### PR TITLE
refactor(FE: traceFilters): remove multiple reducers

### DIFF
--- a/frontend/src/store/actions/traceFilters.ts
+++ b/frontend/src/store/actions/traceFilters.ts
@@ -32,16 +32,4 @@ export const updateTraceFilters = (traceFilters: TraceFilters) => {
 	};
 };
 
-export interface updateInputTagAction {
-	type: ActionTypes.updateInput;
-	payload: string;
-}
-
-export const updateInputTag = (Input: string) => {
-	return {
-		type: ActionTypes.updateInput,
-		payload: Input,
-	};
-};
-
 //named export when you want to export multiple functions from the same file

--- a/frontend/src/store/reducers/index.ts
+++ b/frontend/src/store/reducers/index.ts
@@ -25,13 +25,12 @@ import {
 	externalMetricsReducer,
 	externalAvgDurationMetricsReducer,
 } from "./metrics";
-import { traceFiltersReducer, inputsReducer } from "./traceFilters";
+import TraceFilterReducer from "./traceFilters";
 import { traceItemReducer, tracesReducer } from "./traces";
 import { usageDataReducer } from "./usage";
 import { ServiceMapReducer } from "./serviceMap";
 export interface StoreState {
 	traceFilters: TraceFilters;
-	inputTag: string;
 	traces: traceResponseNew;
 	traceItem: spansWSameTraceIDResponse;
 	servicesList: servicesListItem[];
@@ -48,8 +47,7 @@ export interface StoreState {
 }
 
 const reducers = combineReducers<StoreState>({
-	traceFilters: traceFiltersReducer,
-	inputTag: inputsReducer,
+	traceFilters: TraceFilterReducer,
 	traces: tracesReducer,
 	traceItem: traceItemReducer,
 	servicesList: serviceTableReducer,

--- a/frontend/src/store/reducers/serviceMap.ts
+++ b/frontend/src/store/reducers/serviceMap.ts
@@ -1,12 +1,11 @@
 import { ActionTypes, Action, serviceMapStore } from "../actions";
 
-export const ServiceMapReducer = (
-	state: serviceMapStore = {
-		items: [],
-		services: [],
-	},
-	action: Action,
-) => {
+const initialState: serviceMapStore = {
+	items: [],
+	services: [],
+};
+
+export const ServiceMapReducer = (state = initialState, action: Action) => {
 	switch (action.type) {
 		case ActionTypes.getServiceMapItems:
 			return {

--- a/frontend/src/store/reducers/traceFilters.ts
+++ b/frontend/src/store/reducers/traceFilters.ts
@@ -1,19 +1,17 @@
-import {
-	ActionTypes,
-	TraceFilters,
-	updateInputTagAction,
-	updateTraceFiltersAction,
-} from "../actions";
+import { ActionTypes, TraceFilters } from "../actions";
 
-export const traceFiltersReducer = (
-	state: TraceFilters = {
-		service: "",
-		tags: [],
-		operation: "",
-		latency: { min: "", max: "" },
-	},
-	action: updateTraceFiltersAction,
-) => {
+type ACTION = {
+	type: ActionTypes;
+	payload: TraceFilters;
+};
+const initialState: TraceFilters = {
+	service: "",
+	tags: [],
+	operation: "",
+	latency: { min: "", max: "" },
+};
+
+const TraceFilterReducer = (state = initialState, action: ACTION) => {
 	switch (action.type) {
 		case ActionTypes.updateTraceFilters:
 			return action.payload;
@@ -22,14 +20,4 @@ export const traceFiltersReducer = (
 	}
 };
 
-export const inputsReducer = (
-	state: string = "",
-	action: updateInputTagAction,
-) => {
-	switch (action.type) {
-		case ActionTypes.updateInput:
-			return action.payload;
-		default:
-			return state;
-	}
-};
+export default TraceFilterReducer;


### PR DESCRIPTION
This PR contains some refactoring for TraceFilters and Service Map reducer.
1. Remove `inputsReducer` reducer - not being used 
2. Code cleanup