### PR TITLE
fix(FE: ServiceMap): getZoomPx padding based on screen size

### DIFF
--- a/frontend/src/modules/Servicemap/utils.ts
+++ b/frontend/src/modules/Servicemap/utils.ts
@@ -79,7 +79,7 @@ export const getZoomPx = (): number => {
 	if (width < 1400) {
 		return 190;
 	} else if (width >= 1400 && width < 1700) {
-		return 320;
+		return 352;
 	} else if (width > 1700) {
 		return 485;
 	}

--- a/frontend/src/modules/Servicemap/utils.ts
+++ b/frontend/src/modules/Servicemap/utils.ts
@@ -78,8 +78,8 @@ export const getZoomPx = (): number => {
 	const width = window.screen.width;
 	if (width < 1400) {
 		return 190;
-	} else if (width > 1400 && width < 1700) {
-		return 400;
+	} else if (width >= 1400 && width < 1700) {
+		return 320;
 	} else if (width > 1700) {
 		return 485;
 	}


### PR DESCRIPTION
Issue:

https://user-images.githubusercontent.com/6941627/120882071-0ebe2800-c5f3-11eb-9257-5b17b3d76f83.mov


Fix: 

https://user-images.githubusercontent.com/6941627/120882060-f948fe00-c5f2-11eb-9935-6f7aea202eee.mov

Possible cause: The padding value being passed to `zoomToFit` is too large and occupying all the space around the node. (Hypothesis)

This is a fix for https://github.com/SigNoz/signoz/issues/151

