### PR TITLE
fix: suspense for lazy loaded pages

### DIFF
--- a/frontend/src/modules/AppWrapper.tsx
+++ b/frontend/src/modules/AppWrapper.tsx
@@ -33,34 +33,40 @@ const App = () => {
 					<Switch>
 						<RouteProvider>
 							<BaseLayout>
-								<Route path={ROUTES.SIGN_UP} exact component={Signup} />
-								<Route path={ROUTES.APPLICATION} exact component={ServicesTable} />
-								<Route path={ROUTES.SERVICE_METRICS} exact component={ServiceMetrics} />
-								<Route path={ROUTES.SERVICE_MAP} exact component={ServiceMap} />
-								<Route path={ROUTES.TRACES} exact component={TraceDetail} />
-								<Route path={ROUTES.TRACE_GRAPH} exact component={TraceGraph} />
-								<Route path={ROUTES.SETTINGS} exact component={SettingsPage} />
-								<Route
-									path={ROUTES.INSTRUMENTATION}
-									exact
-									component={IntstrumentationPage}
-								/>
-								<Route
-									path={ROUTES.USAGE_EXPLORER}
-									exactexact
-									component={UsageExplorer}
-								/>
-								<Route
-									path="/"
-									exact
-									render={() => {
-										return localStorage.getItem(IS_LOGGED_IN) === "yes" ? (
-											<Redirect to={ROUTES.APPLICATION} />
-										) : (
-											<Redirect to={ROUTES.SIGN_UP} />
-										);
-									}}
-								/>
+								<Suspense fallback={<Spin size="large" />}>
+									<Route path={ROUTES.SIGN_UP} exact component={Signup} />
+									<Route path={ROUTES.APPLICATION} exact component={ServicesTable} />
+									<Route
+										path={ROUTES.SERVICE_METRICS}
+										exact
+										component={ServiceMetrics}
+									/>
+									<Route path={ROUTES.SERVICE_MAP} exact component={ServiceMap} />
+									<Route path={ROUTES.TRACES} exact component={TraceDetail} />
+									<Route path={ROUTES.TRACE_GRAPH} exact component={TraceGraph} />
+									<Route path={ROUTES.SETTINGS} exact component={SettingsPage} />
+									<Route
+										path={ROUTES.INSTRUMENTATION}
+										exact
+										component={IntstrumentationPage}
+									/>
+									<Route
+										path={ROUTES.USAGE_EXPLORER}
+										exactexact
+										component={UsageExplorer}
+									/>
+									<Route
+										path="/"
+										exact
+										render={() => {
+											return localStorage.getItem(IS_LOGGED_IN) === "yes" ? (
+												<Redirect to={ROUTES.APPLICATION} />
+											) : (
+												<Redirect to={ROUTES.SIGN_UP} />
+											);
+										}}
+									/>
+								</Suspense>
 							</BaseLayout>
 						</RouteProvider>
 					</Switch>


### PR DESCRIPTION
Add suspense to track the route split modules, this will make sure that the sidebar and navbar are not unmounted whenever modules start fetching.

### Current behavior

Whenever new modules are fetching sidebar and navbar gets unmounted to show the loader. 

### New behavior

Only the content loaded dynamically would show the loader