### PR TITLE
feat: Filter spans using regex pattern matching in tags

### DIFF
--- a/frontend/src/modules/Traces/TraceFilter.tsx
+++ b/frontend/src/modules/Traces/TraceFilter.tsx
@@ -481,6 +481,7 @@ const _TraceFilter = (props: TraceFilterProps) => {
 					<Select style={{ width: 120, textAlign: "center" }}>
 						<Option value="equals">EQUAL</Option>
 						<Option value="contains">CONTAINS</Option>
+						<Option value="regex">REGEX</Option>
 					</Select>
 				</FormItem>
 

--- a/frontend/src/store/actions/traceFilters.ts
+++ b/frontend/src/store/actions/traceFilters.ts
@@ -4,7 +4,7 @@ import { ActionTypes } from "./types";
 export interface TagItem {
 	key: string;
 	value: string;
-	operator: "equals" | "contains";
+	operator: "equals" | "contains" | "regex";
 }
 
 export interface LatencyValue {

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -244,11 +244,14 @@ func (r *ClickHouseReader) SearchSpans(ctx context.Context, queryParams *model.S
 		if item.Operator == "equals" {
 			query = query + " AND has(tags, ?)"
 			args = append(args, fmt.Sprintf("%s:%s", item.Key, item.Value))
-
 		} else if item.Operator == "contains" {
 			query = query + " AND tagsValues[indexOf(tagsKeys, ?)] ILIKE ?"
 			args = append(args, item.Key)
 			args = append(args, fmt.Sprintf("%%%s%%", item.Value))
+		} else if item.Operator == "regex" {
+			query = query + " AND match(tagsValues[indexOf(tagsKeys, ?)], ?)"
+			args = append(args, item.Key)
+			args = append(args, item.Value)
 		} else if item.Operator == "isnotnull" {
 			query = query + " AND has(tagsKeys, ?)"
 			args = append(args, item.Key)
@@ -674,11 +677,14 @@ func (r *ClickHouseReader) SearchSpansAggregate(ctx context.Context, queryParams
 		if item.Operator == "equals" {
 			query = query + " AND has(tags, ?)"
 			args = append(args, fmt.Sprintf("%s:%s", item.Key, item.Value))
-
 		} else if item.Operator == "contains" {
 			query = query + " AND tagsValues[indexOf(tagsKeys, ?)] ILIKE ?"
 			args = append(args, item.Key)
 			args = append(args, fmt.Sprintf("%%%s%%", item.Value))
+		} else if item.Operator == "regex" {
+			query = query + " AND match(tagsValues[indexOf(tagsKeys, ?)], ?)"
+			args = append(args, item.Key)
+			args = append(args, item.Value)
 		} else if item.Operator == "isnotnull" {
 			query = query + " AND has(tagsKeys, ?)"
 			args = append(args, item.Key)


### PR DESCRIPTION
https://github.com/SigNoz/signoz/issues/222
This is not the complete solution. Some refactoring, improvements and support in druid setup is pending. I wanted to get an initial feedback for this.

So I think there are 2 ways to do this. 

1. We create one more operator `Pattern` in which we give an option to user to select out of (1xx, 2xx, 3xx, 4xx, 5xx), so that we don't get unexpected patterns. This requires little frontend work. 

2. We implicitly support it from the backend like I have sort of done in this change. If a user passes 4xx, he/she will get response accordingly. 

IMO both are okay, but intuitively would it make more sense to have an explicit operator so that user is sure and know exactly what he/she are searching. 

Let me know your thoughts @ankitnayan 