### PR TITLE
fix: Saving the widget is optimised

### DIFF
--- a/frontend/src/store/actions/dashboard/saveDashboard.ts
+++ b/frontend/src/store/actions/dashboard/saveDashboard.ts
@@ -73,6 +73,15 @@ export const SaveDashboard = ({
 						opacity: updatedopacity,
 						title: updatedTitle,
 						timePreferance: updatedtimePreferance,
+						queryData: {
+							...selectedWidget.queryData,
+							data: [
+								...selectedWidget.queryData.data.map((e) => ({
+									...e,
+									queryData: [],
+								})),
+							],
+						},
 					},
 					...afterWidget,
 				],


### PR DESCRIPTION
while saving the widget, queryData(response of the query) is not sent over the backend as it is always calculated over the frontend