### PR TITLE
Run ESLint and Prettier in CI pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Install dependencies
+        run: cd frontend && yarn install
+      - name: Run Prettier
+        run: cd frontend && npm run prettify
+        continue-on-error: true
+      - name: Run ESLint
+        run: cd frontend && npm run lint
+        continue-on-error: true
       - name: Build frontend docker image
         shell: bash
         run: |


### PR DESCRIPTION
This pull request add ESLint and Prettier to the CI pipeline, according to #280 .
There are some issues in the current code that makes ESLint and Prettier fail, so I've put the `continue-on-error: true` flag, but that should be removed if the issues will be fixed.

