### PR TITLE
Remove duplicate @babel/core package from package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,6 @@
 	"dependencies": {
 		"@ant-design/icons": "^4.6.2",
 		"@auth0/auth0-react": "^1.2.0",
-		"@babel/core": "7.12.3",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.4.2",
 		"@svgr/webpack": "5.4.0",
 		"@testing-library/jest-dom": "^5.11.4",


### PR DESCRIPTION
# Description

Closes #339 

Remove duplicate `@babel/core` package entry from `package.json.

Before (`yarn install`) with dupe warnings for `@babel/core`:

![before-remove-dupe-install](https://user-images.githubusercontent.com/1289472/137588600-0cbe6cb3-e833-42b7-9d92-1c42ba67f5c3.png)

After (`yarn install`) removed dupe warnings for `@babel/core`:

![after-remove-dupe-install](https://user-images.githubusercontent.com/1289472/137588622-f1a37162-5c41-4381-8f6a-0fcde57c1ad0.png)

Before (`yarn dev`) with dupe warnings for `@babel/core`:

![before-remove-dupe-dev](https://user-images.githubusercontent.com/1289472/137588632-b6b9a825-bcd0-4d7d-a59a-a18b6e1fbb15.png)

After (`yarn dev`) removed dupe warnings for `@babel/core`:

![after-remove-dupe-dev](https://user-images.githubusercontent.com/1289472/137588641-c40608f3-95c6-44e7-b546-4b710af4c068.png)

Running app:

![Screen Shot 2021-10-16 at 9 04 33 PM](https://user-images.githubusercontent.com/1289472/137588697-20f07ca6-aa79-4a99-a391-55a9505e8eda.png)

