### PR TITLE
a11y(signup-page): autofocus first input element (email)

### DIFF
--- a/frontend/src/pages/SignUp/index.tsx
+++ b/frontend/src/pages/SignUp/index.tsx
@@ -78,6 +78,7 @@ const Signup = (): JSX.Element => {
 						<Input
 							placeholder="mike@netflix.com"
 							type="email"
+							autoFocus
 							value={formState.email.value}
 							onChange={(e): void => updateForm('email', e.target)}
 							required
@@ -89,7 +90,6 @@ const Signup = (): JSX.Element => {
 						<label htmlFor="signupFirstName">First Name</label>
 						<Input
 							placeholder="Mike"
-							autoFocus
 							value={formState.firstName.value}
 							onChange={(e): void => updateForm('firstName', e.target)}
 							required


### PR DESCRIPTION
Currently signup page focuses the last input