### PR TITLE
Improve ESLint Rules #409

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -41,6 +41,7 @@ module.exports = {
 		'react/prop-types': 'off',
 		'@typescript-eslint/explicit-function-return-type': 'error',
 		'@typescript-eslint/no-var-requires': 0,
+		'react/no-array-index-key': 2,
 		'linebreak-style': ['error', 'unix'],
 
 		// simple sort error

--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -13,7 +13,7 @@ const App = (): JSX.Element => (
 		<AppLayout>
 			<Suspense fallback={<Spinner size="large" tip="Loading..." />}>
 				<Switch>
-					{routes.map(({ path, component, exact }, index) => (
+					{routes.map(({ path, component, exact }) => (
 						<Route key={`${path}`} exact={exact} path={path} component={component} />
 					))}
 					<Redirect from="/" to={ROUTES.APPLICATION} />

--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -14,12 +14,7 @@ const App = (): JSX.Element => (
 			<Suspense fallback={<Spinner size="large" tip="Loading..." />}>
 				<Switch>
 					{routes.map(({ path, component, exact }, index) => (
-						<Route
-							key={`${index.toString()} ${path} ${path?.length}`}
-							exact={exact}
-							path={path}
-							component={component}
-						/>
+						<Route key={`${path}`} exact={exact} path={path} component={component} />
 					))}
 					<Redirect from="/" to={ROUTES.APPLICATION} />
 					<Route component={NotFound} />

--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -14,7 +14,12 @@ const App = (): JSX.Element => (
 			<Suspense fallback={<Spinner size="large" tip="Loading..." />}>
 				<Switch>
 					{routes.map(({ path, component, exact }, index) => (
-						<Route key={index} exact={exact} path={path} component={component} />
+						<Route
+							key={index.toString() + path + path?.length}
+							exact={exact}
+							path={path}
+							component={component}
+						/>
 					))}
 					<Redirect from="/" to={ROUTES.APPLICATION} />
 					<Route component={NotFound} />

--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -15,7 +15,7 @@ const App = (): JSX.Element => (
 				<Switch>
 					{routes.map(({ path, component, exact }, index) => (
 						<Route
-							key={index.toString() + path + path?.length}
+							key={`${index.toString()} ${path} ${path?.length}`}
 							exact={exact}
 							path={path}
 							component={component}

--- a/frontend/src/container/NewWidget/LeftContainer/QuerySection/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/QuerySection/index.tsx
@@ -52,7 +52,7 @@ const QuerySection = ({
 				<Query
 					currentIndex={index}
 					selectedTime={selectedTime}
-					key={e.query + index}
+					key={e.query + e.query.length}
 					preQuery={e.query}
 					preLegend={e.legend || ''}
 				/>

--- a/frontend/src/container/NewWidget/LeftContainer/QuerySection/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/QuerySection/index.tsx
@@ -52,7 +52,7 @@ const QuerySection = ({
 				<Query
 					currentIndex={index}
 					selectedTime={selectedTime}
-					key={e.query + e.query.length}
+					key={`${e.query} ${e.query.length}`}
 					preQuery={e.query}
 					preLegend={e.legend || ''}
 				/>


### PR DESCRIPTION
## fix #409 

- added eslint rule to not to use array index as a key for components.
- fixed the components in frontend that created error because of the new eslint rule.