### PR TITLE
use clickhouse arm64 docker build by altinity for arm64 devices(M1 Macs)

### DIFF
--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "2.4"
 
 services:
   clickhouse:
-      image: yandex/clickhouse-server
+      image: ${clickhouse_image}
       expose:
         - 8123
         - 9000

--- a/deploy/docker/clickhouse-setup/env/arm64.env
+++ b/deploy/docker/clickhouse-setup/env/arm64.env
@@ -1,0 +1,1 @@
+clickhouse_image=altinity/clickhouse-server:21.8.12.1.testingarm

--- a/deploy/docker/clickhouse-setup/env/x86_64.env
+++ b/deploy/docker/clickhouse-setup/env/x86_64.env
@@ -1,0 +1,1 @@
+clickhouse_image=yandex/clickhouse-server

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -496,7 +496,7 @@ else
     echo ""
 
     if [ $setup_type == 'clickhouse' ]; then
-        echo "ℹ️  To bring down SigNoz and clean volumes : sudo docker-compose -f docker/clickhouse-setup/docker-compose.yaml down -v"
+        echo "ℹ️  To bring down SigNoz and clean volumes : sudo docker-compose --env-file ./docker/clickhouse-setup/env/arm64.env -f docker/clickhouse-setup/docker-compose.yaml down -v"
     else
         echo "ℹ️  To bring down SigNoz and clean volumes : sudo docker-compose -f docker/druid-kafka-setup/docker-compose-tiny.yaml down -v"
     fi

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -36,6 +36,10 @@ is_mac() {
     [[ $OSTYPE == darwin* ]]
 }
 
+is_arm64(){
+    [[ `uname -m` == 'arm64' ]]
+}
+
 check_os() {
     if is_mac; then
         package_manager="brew"
@@ -267,7 +271,11 @@ bye() {  # Prints a friendly good bye message and exits the script.
         echo "🔴 The containers didn't seem to start correctly. Please run the following command to check containers that may have errored out:"
         echo ""
         if [ $setup_type == 'clickhouse' ]; then
-            echo -e "sudo docker-compose -f docker/clickhouse-setup/docker-compose.yaml ps -a"
+            if is_arm64; then
+                echo -e "sudo docker-compose --env-file ./docker/clickhouse-setup/env/arm64.env -f docker/clickhouse-setup/docker-compose.yaml ps -a"
+            else
+                echo -e "sudo docker-compose --env-file ./docker/clickhouse-setup/env/x86_64.env -f docker/clickhouse-setup/docker-compose.yaml ps -a"
+            fi
         else   
             echo -e "sudo docker-compose -f docker/druid-kafka-setup/docker-compose-tiny.yaml ps -a"
         fi
@@ -408,7 +416,11 @@ start_docker
 echo ""
 echo -e "\n🟡 Pulling the latest container images for SigNoz. To run as sudo it may ask for system password\n"
 if [ $setup_type == 'clickhouse' ]; then
-    sudo docker-compose -f ./docker/clickhouse-setup/docker-compose.yaml pull
+    if is_arm64; then
+        sudo docker-compose --env-file ./docker/clickhouse-setup/env/arm64.env -f ./docker/clickhouse-setup/docker-compose.yaml pull
+    else
+        sudo docker-compose --env-file ./docker/clickhouse-setup/env/x86_64.env -f ./docker/clickhouse-setup/docker-compose.yaml pull
+    fi
 else
     sudo docker-compose -f ./docker/druid-kafka-setup/docker-compose-tiny.yaml pull
 fi
@@ -420,7 +432,11 @@ echo
 # The docker-compose command does some nasty stuff for the `--detach` functionality. So we add a `|| true` so that the
 # script doesn't exit because this command looks like it failed to do it's thing.
 if [ $setup_type == 'clickhouse' ]; then
-    sudo docker-compose -f ./docker/clickhouse-setup/docker-compose.yaml up --detach --remove-orphans || true
+    if is_arm64; then
+        sudo docker-compose --env-file ./docker/clickhouse-setup/env/arm64.env -f ./docker/clickhouse-setup/docker-compose.yaml up --detach --remove-orphans || true
+    else
+        sudo docker-compose --env-file ./docker/clickhouse-setup/env/x86_64.env -f ./docker/clickhouse-setup/docker-compose.yaml up --detach --remove-orphans || true
+    fi
 else
     sudo docker-compose -f ./docker/druid-kafka-setup/docker-compose-tiny.yaml up --detach --remove-orphans || true
 fi


### PR DESCRIPTION
Fixes https://github.com/SigNoz/signoz/issues/182

The command to bring down SigNoz docker containers is now updated to `sudo docker-compose --env-file ./docker/clickhouse-setup/env/arm64.env -f docker/clickhouse-setup/docker-compose.yaml down -v`