### PR TITLE
[WIP]fix(UI): Allow empty input values in settings retention page.

### DIFF
--- a/frontend/src/container/GeneralSettings/Retention.tsx
+++ b/frontend/src/container/GeneralSettings/Retention.tsx
@@ -56,17 +56,18 @@ const Retention = ({
 
 	const onChangeHandler = (
 		e: React.ChangeEvent<HTMLInputElement>,
-		func: React.Dispatch<React.SetStateAction<number>>,
+		func: React.Dispatch<React.SetStateAction<string>>,
 	): void => {
 		const value = e.target.value;
+		const integerValue = parseInt(value, 10);
 
-		if (value.length > 0) {
-			const parsedValue = Math.abs(parseInt(value, 10));
+		if (value.length > 0 && integerValue.toString() === value) {
+			const parsedValue = Math.abs(integerValue).toString();
 			func(parsedValue);
 		}
 
 		if (value.length === 0) {
-			func(0);
+			func('');
 		}
 	};
 
@@ -96,9 +97,9 @@ interface Option {
 }
 
 interface RetentionProps {
-	retentionValue: number;
+	retentionValue: string;
 	text: string;
-	setRentionValue: React.Dispatch<React.SetStateAction<number>>;
+	setRentionValue: React.Dispatch<React.SetStateAction<string>>;
 	selectedRetentionPeroid: SettingPeroid;
 	setSelectedRetentionPeroid: React.Dispatch<
 		React.SetStateAction<SettingPeroid>

--- a/frontend/src/container/GeneralSettings/index.tsx
+++ b/frontend/src/container/GeneralSettings/index.tsx
@@ -23,8 +23,8 @@ const GeneralSettings = (): JSX.Element => {
 	] = useState<SettingPeroid>('month');
 	const [notifications, Element] = notification.useNotification();
 
-	const [retentionPeroidMetrics, setRetentionPeroidMetrics] = useState<number>(
-		0,
+	const [retentionPeroidMetrics, setRetentionPeroidMetrics] = useState<string>(
+		'',
 	);
 	const [modal, setModal] = useState<boolean>(false);
 	const [postApiLoading, setPostApiLoading] = useState<boolean>(false);
@@ -33,7 +33,7 @@ const GeneralSettings = (): JSX.Element => {
 		'hr',
 	);
 
-	const [retentionPeroidTrace, setRetentionPeroidTrace] = useState<number>(0);
+	const [retentionPeroidTrace, setRetentionPeroidTrace] = useState<string>('');
 	const [isDefaultMetrics, setIsDefaultMetrics] = useState<boolean>(false);
 	const [isDefaultTrace, setIsDefaultTrace] = useState<boolean>(false);
 
@@ -73,10 +73,10 @@ const GeneralSettings = (): JSX.Element => {
 			const traceValue = getSettingsPeroid(traces_ttl_duration_hrs);
 			const metricsValue = getSettingsPeroid(metrics_ttl_duration_hrs);
 
-			setRetentionPeroidTrace(traceValue.value);
+			setRetentionPeroidTrace(traceValue.value.toString());
 			setSelectedTracePeroid(traceValue.peroid);
 
-			setRetentionPeroidMetrics(metricsValue.value);
+			setRetentionPeroidMetrics(metricsValue.value.toString());
 			setSelectedMetricsPeroid(metricsValue.peroid);
 		}
 	}, [setSelectedMetricsPeroid, loading, payload]);
@@ -85,14 +85,15 @@ const GeneralSettings = (): JSX.Element => {
 		try {
 			setPostApiLoading(true);
 			const retentionTraceValue =
-				retentionPeroidTrace === 0 && (payload?.traces_ttl_duration_hrs || 0) < 0
+				retentionPeroidTrace === '0' && (payload?.traces_ttl_duration_hrs || 0) < 0
 					? payload?.traces_ttl_duration_hrs || 0
-					: retentionPeroidTrace;
+					: parseInt(retentionPeroidTrace, 10);
 
 			const retentionMetricsValue =
-				retentionPeroidMetrics === 0 && (payload?.metrics_ttl_duration_hrs || 0) < 0
+				retentionPeroidMetrics === '0' &&
+				(payload?.metrics_ttl_duration_hrs || 0) < 0
 					? payload?.metrics_ttl_duration_hrs || 0
-					: retentionPeroidMetrics;
+					: parseInt(retentionPeroidMetrics, 10);
 
 			const [tracesResponse, metricsResponse] = await Promise.all([
 				setRetentionApi({
@@ -167,6 +168,14 @@ const GeneralSettings = (): JSX.Element => {
 		return `${getValue('Trace , Metrics')}`;
 	};
 
+	const isDisabledHandler = (): boolean => {
+		if (retentionPeroidTrace === '' || retentionPeroidMetrics === '') {
+			return true;
+		}
+
+		return false;
+	};
+
 	const errorText = getErrorText();
 
 	return (
@@ -213,7 +222,11 @@ const GeneralSettings = (): JSX.Element => {
 			</Modal>
 
 			<ButtonContainer>
-				<Button onClick={onClickSaveHandler} type="primary">
+				<Button
+					onClick={onClickSaveHandler}
+					disabled={isDisabledHandler()}
+					type="primary"
+				>
 					Save
 				</Button>
 			</ButtonContainer>


### PR DESCRIPTION
Hey, This pr allows the input field in `Retention` component to have an empty field as well. Earlier, when the user pressed the backspace button, the input field would retain the value as `0` which looked a bit unintuitive from users standpoint.
Now, when the user presses the backspace key, the `Save` button gets disabled.

<strong>Updated screenshot</strong>

https://user-images.githubusercontent.com/53977614/144797142-1e37aefd-cff7-4ce0-9a2c-78891d80b4f7.mov



However, this isn't  a complete pr yet. This is so because, the `setRetention` api converts the value to other time period (`months`/`days`) field which leads to huge decimal number which then cannot be changed by the user (As, the input field only allows whole numbers).

<strong>Issue</strong>

https://user-images.githubusercontent.com/53977614/144797540-e5d94be4-f8f1-4efe-adad-473cb67f0b0c.mov

Do we need this behaviour ? Isn't keeping the values as whole numbers more clean (Unless the user is trying to be more specific)?


References #406.


