### PR TITLE
fix: height for the top nav bar is fixed

### DIFF
--- a/frontend/src/container/Header/styles.ts
+++ b/frontend/src/container/Header/styles.ts
@@ -4,5 +4,6 @@ import styled from 'styled-components';
 export const Container = styled(Row)`
 	&&& {
 		margin-top: 2rem;
+		min-height: 8vh;
 	}
 `;


### PR DESCRIPTION
nav bar now have min height when global date selector is not present

<img width="1089" alt="Screenshot 2021-12-06 at 9 04 47 PM" src="https://user-images.githubusercontent.com/88981777/144874868-d571a421-1fef-47fb-a18d-ca2035f79d8e.png">
