### PR TITLE
fix(UI): Restore theme preference after reloading (#469)

### DIFF
--- a/frontend/src/container/SideNav/index.tsx
+++ b/frontend/src/container/SideNav/index.tsx
@@ -11,6 +11,8 @@ import { ToggleDarkMode } from 'store/actions';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';
 import AppReducer from 'types/reducer/app';
+import getTheme from 'lib/theme/getTheme';
+import setTheme from 'lib/theme/setTheme';
 
 import menus from './menuItems';
 import { Logo, Sider, ThemeSwitcherWrapper } from './styles';
@@ -21,10 +23,10 @@ const SideNav = ({ toggleDarkMode }: Props): JSX.Element => {
 	const { isDarkMode } = useSelector<AppState, AppReducer>((state) => state.app);
 
 	const toggleTheme = useCallback(() => {
-		const preMode: mode = isDarkMode ? 'lightMode' : 'darkMode';
-		const postMode: mode = isDarkMode ? 'darkMode' : 'lightMode';
+		const preMode: appMode = isDarkMode ? 'lightMode' : 'darkMode';
+		setTheme(preMode);
 
-		const id: mode = preMode;
+		const id: appMode = preMode;
 		const head = document.head;
 		const link = document.createElement('link');
 		link.rel = 'stylesheet';
@@ -36,7 +38,7 @@ const SideNav = ({ toggleDarkMode }: Props): JSX.Element => {
 
 		link.onload = (): void => {
 			toggleDarkMode();
-			const prevNode = document.getElementById(postMode);
+			const prevNode = document.getElementById('appMode');
 			prevNode?.remove();
 		};
 	}, [toggleDarkMode, isDarkMode]);
@@ -57,7 +59,7 @@ const SideNav = ({ toggleDarkMode }: Props): JSX.Element => {
 	return (
 		<Sider collapsible collapsed={collapsed} onCollapse={onCollapse} width={200}>
 			<ThemeSwitcherWrapper>
-				<ToggleButton checked={isDarkMode} onChange={toggleTheme} />
+				<ToggleButton checked={getTheme() === 'darkMode'} onChange={toggleTheme} />
 			</ThemeSwitcherWrapper>
 			<NavLink to={ROUTES.APPLICATION}>
 				<Logo src={'/signoz.svg'} alt="SigNoz" collapsed={collapsed} />
@@ -81,7 +83,7 @@ const SideNav = ({ toggleDarkMode }: Props): JSX.Element => {
 	);
 };
 
-type mode = 'darkMode' | 'lightMode';
+type appMode = 'darkMode' | 'lightMode';
 
 interface DispatchProps {
 	toggleDarkMode: () => void;

--- a/frontend/src/index.html.ejs
+++ b/frontend/src/index.html.ejs
@@ -14,11 +14,27 @@
     <meta data-react-helmet="true" name="docusaurus_tag" content="default">
     <link data-react-helmet="true" rel="shortcut icon" href="/favicon.ico">
 
-    <link id='darkMode' rel='stylesheet' type='text/css' href='/css/antd.dark.min.css' />
+    <link id='appMode' rel='stylesheet' type='text/css' href='/css/antd.dark.min.css' />
 </head>
 <body>
 <noscript>You need to enable JavaScript to run this app.</noscript>
 <div id="root"></div>
 
+<script>
+    const themeNode = document.getElementById('appMode');
+    let userTheme;
+
+    try {
+		userTheme = localStorage.getItem('theme');
+	} catch (e) {
+		userTheme = '';
+	}
+
+    if(userTheme === 'lightMode'){
+        themeNode.setAttribute('href','/css/antd.min.css');
+    } else {
+        themeNode.setAttribute('href', '/css/antd.dark.min.css');
+    }
+</script>
 </body>
 </html>

--- a/frontend/src/lib/theme/getTheme.ts
+++ b/frontend/src/lib/theme/getTheme.ts
@@ -1,0 +1,14 @@
+import getLocalStorageKey from 'api/browser/localstorage/get';
+
+const getTheme = (): appMode => {
+	const userTheme = getLocalStorageKey('theme');
+	if (userTheme === null || userTheme === 'darkMode') {
+		return 'darkMode';
+	}
+
+	return 'lightMode';
+};
+
+type appMode = 'darkMode' | 'lightMode';
+
+export default getTheme;

--- a/frontend/src/lib/theme/setTheme.ts
+++ b/frontend/src/lib/theme/setTheme.ts
@@ -1,0 +1,9 @@
+import setLocalStorageKey from 'api/browser/localstorage/set';
+
+const setTheme = (value: appMode): void => {
+	setLocalStorageKey('theme', value);
+};
+
+type appMode = 'darkMode' | 'lightMode';
+
+export default setTheme;

--- a/frontend/src/store/reducers/app.ts
+++ b/frontend/src/store/reducers/app.ts
@@ -5,11 +5,12 @@ import {
 	SWITCH_DARK_MODE,
 	TOGGLE_SETTINGS_TABS,
 } from 'types/actions/app';
+import getTheme from 'lib/theme/getTheme';
 import InitialValueTypes from 'types/reducer/app';
 import getLocalStorageKey from 'api/browser/localstorage/get';
 
 const InitialValue: InitialValueTypes = {
-	isDarkMode: true,
+	isDarkMode: getTheme() === 'darkMode' ? true : false,
 	isLoggedIn: getLocalStorageKey(IS_LOGGED_IN) === 'yes',
 	settingsActiveTab: 'General',
 };


### PR DESCRIPTION
Previously, whenever the user reloads the app, the theme preference is lost and it is set to `Dark` again.
Added a pr to avoid this behaviour.

<strong>Screenshot</strong>


https://user-images.githubusercontent.com/53977614/145181117-a387c9d7-1827-4f81-bdc2-f8ceb61615b9.mov



Would be great if @pal-sig can have a look at it :)

Fixes #469.
