### PR TITLE
fix(UI): Hide sidebar menu for larger widths in Trace panel (#531)

### DIFF
--- a/frontend/src/modules/Traces/SelectedSpanDetails.tsx
+++ b/frontend/src/modules/Traces/SelectedSpanDetails.tsx
@@ -52,6 +52,16 @@ const CardContainer = styled(Card)`
 		max-height: 90vh;
 		overflow-y: auto;
 	}
+
+	.ant-tabs-nav-more {
+		display: none;
+	}
+
+	@media only screen and (max-width: 992px) {
+		.ant-tabs-nav-more {
+			display: block;
+		}
+	}
 `;
 
 const SelectedSpanDetails = (props: SelectedSpanDetailsProps): JSX.Element => {


### PR DESCRIPTION
This pr hides the hamburger menu for devices with larger width within Trace panel page (Occurring in case of Firefox). 

<strong>Screenshot</strong>
https://www.loom.com/share/3b7e094817ed45069eda477c8e60e2b0

As seen in the video, the hamburger menu is then visible for devices when the `Errors` text starts getting cut off i.e `992`px.

Fixes #531