### PR TITLE
fix(BUG): Allow users to enter application if no sample data is provided (#478)

### DIFF
--- a/frontend/src/container/MetricsTable/index.tsx
+++ b/frontend/src/container/MetricsTable/index.tsx
@@ -31,10 +31,7 @@ const Metrics = (): JSX.Element => {
 		history.push(to);
 	};
 
-	if (
-		(services.length === 0 && loading === false && !skipOnboarding) ||
-		(loading == false && error === true)
-	) {
+	if (services.length === 0 && loading === false && !skipOnboarding && error === true) {
 		return <SkipBoardModal onContinueClick={onContinueClick} />;
 	}
 


### PR DESCRIPTION
This pr essentially resolves the unresponsive behavior of `Continue without instrumentation` button in onboarding modal when the user provides no sample app data to monitor upon.

<strong>Logic</strong>

When no sample data is provided, the metric action is set to `GET_SERVICE_LIST_ERROR` which assigns the error variable as `true`. Due to this, the check statement [here](https://github.com/SigNoz/signoz/blob/6f8b78bd97edccac2b81040e7671936e8b388846/frontend/src/container/MetricsTable/index.tsx#L36) gets `true` and even though the user presses the button, the `SkipOnBoardingModal` component is rendered.
Hence, this pr removes the check statement so that even though error variable is `true`, the user can explore the application.

<strong>Screenshot</strong>

https://user-images.githubusercontent.com/53977614/146680144-a5b022f7-98dd-48c7-964f-2c76ee1b216f.mov


(Once the user presses the button, the `skip_onboarding` is set to `true` and the modal closes)


Fixes #478