### PR TITLE
fix(UI): Use SERVER as the default value for span type in Trace panel.

### DIFF
--- a/frontend/src/container/TraceFilter/index.tsx
+++ b/frontend/src/container/TraceFilter/index.tsx
@@ -200,6 +200,7 @@ const TraceList = ({
 			form_basefilter.setFieldsValue({
 				spanKind: selectedKind,
 			});
+			updateSelectedKindHandler(selectedKind);
 		} else {
 			form_basefilter.setFieldsValue({
 				spanKind: '',

--- a/frontend/src/store/reducers/trace.ts
+++ b/frontend/src/store/reducers/trace.ts
@@ -17,13 +17,15 @@ import {
 	UPDATE_TRACE_SELECTED_TAGS,
 } from 'types/actions/trace';
 import { TraceReducer } from 'types/reducer/trace';
+import { spanKindList } from '../../container/TraceFilter/config';
 
 const intitalState: TraceReducer = {
 	error: false,
 	errorMessage: '',
 	loading: true,
 	operationsList: [],
-	selectedKind: '',
+	selectedKind:
+		spanKindList.find((spanKind) => spanKind.label === 'SERVER')?.value || '',
 	selectedLatency: {
 		max: '',
 		min: '',
@@ -71,7 +73,6 @@ export const traceReducer = (
 				selectedService,
 				selectedTags,
 				spansList,
-				selectedKind,
 				selectedLatency,
 				spansAggregate,
 			} = action.payload;
@@ -86,7 +87,6 @@ export const traceReducer = (
 				spanList: spansList,
 				operationsList: operationList,
 				error: false,
-				selectedKind,
 				selectedLatency,
 				spansAggregate,
 				spansLoading: false,


### PR DESCRIPTION
Previously, when the user navigates to `Trace` panel, the `spanKind` dropdown value is empty.
This pr adds a commit to set a default value for `spanKind` dropdown value as `SERVER` as listed within #550.

<strong>Screenshot</strong>

https://user-images.githubusercontent.com/53977614/146970552-42ec9664-b6a2-4d80-ae9c-bd9def91b141.mov


Fixes #550
