### PR TITLE
Swapping images on the "build" GH workflow.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Build  query-service image
         shell: bash
         run: |
-          make build-flattener-amd64
+          make build-query-service-amd64
 
   build-flattener:
     runs-on: ubuntu-latest
@@ -74,4 +74,4 @@ jobs:
       - name: Build flattener docker image
         shell: bash
         run: |
-          make build-query-service-amd64
+          make build-flattener-amd64

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ REPONAME ?= signoz
 DOCKER_TAG ?= latest
 
 FRONTEND_DOCKER_IMAGE ?= frontend
-FLATTERNER_DOCKER_IMAGE ?= query-service
-QUERY_SERVICE_DOCKER_IMAGE ?= flattener-processor
+QUERY_SERVICE_DOCKER_IMAGE ?= query-service
+FLATTERNER_DOCKER_IMAGE ?= flattener-processor
 
 all: build-push-frontend build-push-query-service build-push-flattener
 # Steps to build and push docker image of frontend


### PR DESCRIPTION
query-service job is currently building flattener and flattener job is
currently building query-service.

This PR should fix that mix.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>