### PR TITLE
ci: requiring the 'ok-to-test' label for running some workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,6 +1,18 @@
-To run GitHub workflow, a few environment variables needs to add in GitHub secrets
+# Github actions
 
-####  Environment Variables
+## Testing the UI manually on each PR
+
+First we need to make sure the UI is ready
+* Check the `Start tunnel` step in `e2e-k8s/deploy-on-k3s-cluster` job and make sure you see `your url is: https://pull-<number>-signoz.loca.lt`
+* This job will run until the PR is merged or closed to keep the local tunneling alive
+    - github will cancel this job if the PR wasn't merged after 6h
+    - if the job was cancel, go to the action and press `Re-run all jobs`
+
+Now you can open your browser at https://pull-<number>-signoz.loca.lt and check the UI.
+
+##  Environment Variables
+
+To run GitHub workflow, a few environment variables needs to add in GitHub secrets
 
 <table>
   <tr>

--- a/.github/workflows/e2e-k3s.yaml
+++ b/.github/workflows/e2e-k3s.yaml
@@ -1,7 +1,8 @@
-name: e2e-k8s
+name: e2e-k3s
 
 on:
   pull_request:
+    types: [labeled]
     paths:
       - 'pkg/query-service/**'
       - 'frontend/**'
@@ -10,6 +11,7 @@ jobs:
 
   image-build-and-push-query-service:
     runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'ok-to-test' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -31,6 +33,7 @@ jobs:
 
   image-build-and-push-frontend:
     runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'ok-to-test' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -61,6 +64,7 @@ jobs:
 
   deploy-on-k3s-cluster:
     runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'ok-to-test' }}
     needs:
       - image-build-and-push-query-service
       - image-build-and-push-frontend

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,112 @@
+name: e2e-k8s
+
+on:
+  pull_request:
+    paths:
+      - 'pkg/query-service/**'
+      - 'frontend/**'
+
+jobs:
+
+  image-build-and-push-query-service:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push docker image
+        env:
+          DOCKER_TAG: pull-${{ github.event.number }}
+        run: make build-push-query-service
+
+  image-build-and-push-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        working-directory: frontend
+        run: yarn install
+      - name: Run Prettier
+        working-directory: frontend
+        run: npm run prettify
+        continue-on-error: true
+      - name: Run ESLint
+        working-directory: frontend
+        run: npm run lint
+        continue-on-error: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push docker image
+        env:
+          DOCKER_TAG: pull-${{ github.event.number }}
+        run: make build-push-frontend
+
+  deploy-on-k3s-cluster:
+    runs-on: ubuntu-latest
+    needs:
+      - image-build-and-push-query-service
+      - image-build-and-push-frontend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create a k3s cluster
+        uses: AbsaOSS/k3d-action@v2
+        with:
+          cluster-name: "test-cluster"
+      - name: Deploy the app
+        env:
+          TAG: pull-${{ github.event.number }}
+        run: |
+          helm dependency update deploy/kubernetes/platform
+          helm install signoz deploy/kubernetes/platform/ -n platform --create-namespace \
+            --set cloud=null \
+            --set frontend.service.type=LoadBalancer \
+            --set frontend.image.tag=$TAG \
+            --set query-service.image.tag=$TAG
+          kubectl describe deploy/signoz-frontend -n platform | grep Image
+          kubectl describe statefulset/signoz-query-service -n platform | grep Image
+          # comment the next 3 lines if you open an SSH connection for debugging
+          kubectl -n platform get deploy --output name | xargs -r -n1 -t kubectl -n platform rollout status --timeout=300s
+          kubectl -n platform get statefulset --output name | xargs -r -n1 -t kubectl -n platform rollout status --timeout=300s
+          kubectl -n platform get daemonset --output name | xargs -r -n1 -t kubectl -n platform rollout status --timeout=300s
+          kubectl get pods -n platform
+          kubectl get svc -n platform
+        # Uncomment for debugging using SSH
+      #- name: Setup upterm session
+      #  uses: lhotari/action-upterm@v1
+      - name: Kick off a sample-app workload
+        run: |
+          kubectl create ns sample-application
+          kubectl -n sample-application apply -Rf sample-apps/hotrod/
+          kubectl -n sample-application run strzal --image=djbingham/curl \
+            --restart='OnFailure' -i --rm --command -- curl -X POST -F \
+            'locust_count=6' -F 'hatch_rate=2' http://locust-master:8089/swarm
+          kubectl -n sample-application get deploy --output name | xargs -r -n1 -t kubectl -n sample-application rollout status --timeout=300s
+          kubectl -n sample-application get statefulset --output name | xargs -r -n1 -t kubectl -n sample-application rollout status --timeout=300s
+          kubectl -n sample-application get daemonset --output name | xargs -r -n1 -t kubectl -n sample-application rollout status --timeout=300s
+      - name: Start tunnel
+        env:
+          SUBDOMAIN: pull-${{ github.event.number }}-signoz
+        run: |
+          npm install -g localtunnel
+          host=$(kubectl get svc -n platform | grep signoz-frontend | tr -s ' ' | cut -d" " -f4)
+          port=$(kubectl get svc -n platform | grep signoz-frontend | tr -s ' ' | cut -d" " -f5 | cut -d":" -f1)
+          lt -p $port -l $host -s $SUBDOMAIN

--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -1,0 +1,18 @@
+name: remove-label
+
+on:
+  pull_request:
+    types: [synchronize]
+
+jobs:
+  remove:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name != 'openshift-psap/special-resource-operator'
+    steps:
+      - name: Remove label
+        uses: buildsville/add-remove-label@v1
+        with:
+          label: ok-to-test
+          type: remove
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+

--- a/deploy/kubernetes/platform/signoz-charts/frontend/templates/deployment.yaml
+++ b/deploy/kubernetes/platform/signoz-charts/frontend/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/deploy/kubernetes/platform/signoz-charts/frontend/values.yaml
+++ b/deploy/kubernetes/platform/signoz-charts/frontend/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 
 image:
   repository: signoz/frontend
+  tag: 0.5.4
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/deploy/kubernetes/platform/signoz-charts/query-service/templates/statefulset.yaml
+++ b/deploy/kubernetes/platform/signoz-charts/query-service/templates/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
         {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["-config=/root/config/prometheus.yml"]
           ports:

--- a/deploy/kubernetes/platform/signoz-charts/query-service/values.yaml
+++ b/deploy/kubernetes/platform/signoz-charts/query-service/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 
 image:
   repository: signoz/query-service
+  tag: 0.5.4
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
As of now, the 'e2e' workflow will require the 'ok-to-test' label in
order to get triggered.

In addition to that, on each change to the PR, Github will remove the
label from it and it will be required again.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>
