### PR TITLE
ci: requiring the 'ok-to-test' label for running some workflows

### DIFF
--- a/.github/workflows/e2e-k3s.yaml
+++ b/.github/workflows/e2e-k3s.yaml
@@ -1,7 +1,8 @@
-name: e2e-k8s
+name: e2e-k3s
 
 on:
   pull_request:
+    types: [labeled]
     paths:
       - 'pkg/query-service/**'
       - 'frontend/**'
@@ -10,6 +11,7 @@ jobs:
 
   image-build-and-push-query-service:
     runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'ok-to-test' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -31,6 +33,7 @@ jobs:
 
   image-build-and-push-frontend:
     runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'ok-to-test' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -61,6 +64,7 @@ jobs:
 
   deploy-on-k3s-cluster:
     runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'ok-to-test' }}
     needs:
       - image-build-and-push-query-service
       - image-build-and-push-frontend

--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -1,0 +1,20 @@
+name: remove-label
+
+on:
+  pull_request:
+    types: [synchronize]
+    paths:
+      - 'pkg/query-service/**'
+      - 'frontend/**'
+
+jobs:
+  remove:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove label
+        uses: buildsville/add-remove-label@v1
+        with:
+          label: ok-to-test
+          type: remove
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+


### PR DESCRIPTION
As of now, the 'e2e' workflow will require the 'ok-to-test' label in
order to get triggered.

In addition to that, on each change to the PR, Github will remove the
label from it and it will be required again.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>