### PR TITLE
ci: removing file filtering from some workflows

### DIFF
--- a/.github/workflows/e2e-k3s.yaml
+++ b/.github/workflows/e2e-k3s.yaml
@@ -3,9 +3,6 @@ name: e2e-k3s
 on:
   pull_request:
     types: [labeled]
-    paths:
-      - 'pkg/query-service/**'
-      - 'frontend/**'
 
 jobs:
 

--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -3,9 +3,6 @@ name: remove-label
 on:
   pull_request:
     types: [synchronize]
-    paths:
-      - 'pkg/query-service/**'
-      - 'frontend/**'
 
 jobs:
   remove:


### PR DESCRIPTION
There are other files that can affect the correctness of the code rather
than the src files like the deployment yamls, Makefile etc.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>