### PR TITLE
ci: use pull_request_target for remove label permission

### DIFF
--- a/.github/workflows/remove-label.yaml
+++ b/.github/workflows/remove-label.yaml
@@ -1,7 +1,7 @@
 name: remove-label
 
 on:
-  pull_request:
+  pull_request_target:
     types: [synchronize]
 
 jobs:
@@ -13,5 +13,4 @@ jobs:
         with:
           label: ok-to-test
           type: remove
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
-
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Using `pull_request_target` instead of `pull_request` event, the workflow jobs can use **GITHUB_TOKEN** secret for removing label on any new changes to PR.