### PR TITLE
fix: remove table `default.signoz_spans` from the codebase

### DIFF
--- a/pkg/query-service/app/clickhouseReader/options.go
+++ b/pkg/query-service/app/clickhouseReader/options.go
@@ -20,7 +20,6 @@ const (
 	defaultOperationsTable   string        = "signoz_operations"
 	defaultIndexTable        string        = "signoz_index"
 	defaultErrorTable        string        = "signoz_error_index"
-	defaultArchiveSpansTable string        = "signoz_archive_spans"
 	defaultWriteBatchDelay   time.Duration = 5 * time.Second
 	defaultWriteBatchSize    int           = 10000
 	defaultEncoding          Encoding      = EncodingJSON
@@ -105,7 +104,6 @@ func NewOptions(datasource string, primaryNamespace string, otherNamespaces ...s
 				Datasource:      datasource,
 				OperationsTable: "",
 				IndexTable:      "",
-				SpansTable:      defaultArchiveSpansTable,
 				ErrorTable:      "",
 				WriteBatchDelay: defaultWriteBatchDelay,
 				WriteBatchSize:  defaultWriteBatchSize,

--- a/pkg/query-service/app/clickhouseReader/options.go
+++ b/pkg/query-service/app/clickhouseReader/options.go
@@ -19,7 +19,6 @@ const (
 	defaultDatasource        string        = "tcp://localhost:9000"
 	defaultOperationsTable   string        = "signoz_operations"
 	defaultIndexTable        string        = "signoz_index"
-	defaultSpansTable        string        = "signoz_spans"
 	defaultErrorTable        string        = "signoz_error_index"
 	defaultArchiveSpansTable string        = "signoz_archive_spans"
 	defaultWriteBatchDelay   time.Duration = 5 * time.Second
@@ -90,7 +89,6 @@ func NewOptions(datasource string, primaryNamespace string, otherNamespaces ...s
 			Datasource:      datasource,
 			OperationsTable: defaultOperationsTable,
 			IndexTable:      defaultIndexTable,
-			SpansTable:      defaultSpansTable,
 			ErrorTable:      defaultErrorTable,
 			WriteBatchDelay: defaultWriteBatchDelay,
 			WriteBatchSize:  defaultWriteBatchSize,

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -74,7 +74,6 @@ type ClickHouseReader struct {
 	operationsTable string
 	indexTable      string
 	errorTable      string
-	spansTable      string
 	queryEngine     *promql.Engine
 	remoteStorage   *remote.Storage
 	ruleManager     *rules.Manager
@@ -98,7 +97,6 @@ func NewReader(localDB *sqlx.DB) *ClickHouseReader {
 		localDB:         localDB,
 		operationsTable: options.primary.OperationsTable,
 		indexTable:      options.primary.IndexTable,
-		spansTable:      options.primary.SpansTable,
 		errorTable:      options.primary.ErrorTable,
 	}
 }


### PR DESCRIPTION
Fixes: #486 

**Changes proposed in PR**
- Remove `signoz_spans` from the codebase and its usage since it is not being used anywhere!