### PR TITLE
chore(log-option): set hotrod log options for hotrod app

### DIFF
--- a/deploy/docker/clickhouse-setup/docker-compose.arm.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.arm.yaml
@@ -96,7 +96,11 @@ services:
     image: jaegertracing/example-hotrod:1.30
     container_name: hotrod
     ports:
-    - "9000:8080"
+      - "9000:8080"
+    logging:
+      options:
+        max-size: 50m
+        max-file: 3
     command: ["all"]
     environment:
     - JAEGER_ENDPOINT=http://otel-collector:14268/api/traces

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -98,17 +98,21 @@ services:
     image: jaegertracing/example-hotrod:1.30
     container_name: hotrod
     ports:
-    - "9000:8080"
+      - "9000:8080"
+    logging:
+      options:
+        max-size: 50m
+        max-file: 3
     command: ["all"]
     environment:
-    - JAEGER_ENDPOINT=http://otel-collector:14268/api/traces
+      - JAEGER_ENDPOINT=http://otel-collector:14268/api/traces
 
   load-hotrod:
     image: "grubykarol/locust:1.2.3-python3.9-alpine3.12"
     container_name: load-hotrod
     hostname: load-hotrod
     ports:
-     - "8089:8089"
+      - "8089:8089"
     environment:
       ATTACKED_HOST: http://hotrod:8080
       LOCUST_MODE: standalone


### PR DESCRIPTION
This PR should resolve the issue of hotrod container logs taking all my disk space when run for a long time using docker-compose.

This would set a maximum of three log files with a max size of 50 Mb each. So, at most 150 Mb of logs will be there for the hotrod container. Users can feel free to tune those numbers as they see fit.

Signed-off-by: Prashant Shahi <prashant@signoz.io>