### PR TITLE
Adding support for Openshift.

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-# stage1 as builder
+# builder stage
 FROM node:12.18.0 as builder
 
 # Add Maintainer Info
@@ -13,23 +13,19 @@ WORKDIR /frontend
 COPY package.json ./
 
 # Install the dependencies and make the folder
-RUN yarn install 
+RUN yarn install
 
 COPY . .
 
 # Build the project and copy the files
 RUN yarn build
 
-FROM nginx:1.18-alpine
-
-#!/bin/sh
+# FROM nginx:1.18-alpine
+FROM nginxinc/nginx-unprivileged
 
 COPY conf/default.conf /etc/nginx/conf.d/default.conf
 
-## Remove default nginx index page
-RUN rm -rf /usr/share/nginx/html/*
-
-# Copy from the stahg 1
+# Copy from the builder stage
 COPY --from=builder /frontend/build /usr/share/nginx/html
 
 EXPOSE 3301

--- a/pkg/query-service/Dockerfile
+++ b/pkg/query-service/Dockerfile
@@ -37,13 +37,12 @@ RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 WORKDIR /root
 
 # copy the binary from builder
-COPY --from=builder /go/src/github.com/signoz/signoz/pkg/query-service/bin/query-service .
+COPY --from=builder /go/src/github.com/signoz/signoz/pkg/query-service/bin/query-service /usr/local/bin/
 
 COPY config/prometheus.yml /root/config/prometheus.yml
 
 # run the binary
-ENTRYPOINT ["./query-service"]
-
+ENTRYPOINT ["/usr/local/bin/query-service"]
 CMD ["-config", "/root/config/prometheus.yml"]
 # CMD ["./query-service -config /root/config/prometheus.yml"]
 

--- a/pkg/query-service/app/dashboards/provision.go
+++ b/pkg/query-service/app/dashboards/provision.go
@@ -54,5 +54,5 @@ func readCurrentDir(dir string) error {
 }
 
 func LoadDashboardFiles() error {
-	return readCurrentDir("./config/dashboards")
+	return readCurrentDir("/var/tmp/dashboards")
 }

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -24,7 +24,7 @@ const TraceTTL = "traces"
 const MetricsTTL = "metrics"
 
 const ALERTMANAGER_API_PREFIX = "http://alertmanager:9093/api/"
-const RELATIONAL_DATASOURCE_PATH = "/var/lib/signoz/signoz.db"
+const RELATIONAL_DATASOURCE_PATH = "/var/tmp/signoz/signoz.db"
 
 const (
 	ServiceName      = "serviceName"


### PR DESCRIPTION
Unlike k8s, Openshift is running containers in user mode, therefore,
some adjustments were needed in order to make Signoz run on Openshift.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>