### PR TITLE
fix: Dashboard page does not call API on clicking on apply button

### DIFF
--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -17,6 +17,7 @@ import {
 	SaveDashboard,
 	SaveDashboardProps,
 } from 'store/actions/dashboard/saveDashboard';
+import { UpdateQuery, UpdateQueryProps } from 'store/actions/dashboard/updateQuery';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';
 import { GlobalTime } from 'types/actions/globalTime';
@@ -39,6 +40,7 @@ const NewWidget = ({
 	applySettingsToPanel,
 	saveSettingOfPanel,
 	getQueryResults,
+	updateQuery
 }: Props): JSX.Element => {
 	const { dashboards } = useSelector<AppState, DashboardReducer>(
 		(state) => state.dashboards,
@@ -120,7 +122,16 @@ const NewWidget = ({
 		dashboardId,
 	]);
 
-	const onClickApplyHandler = useCallback(() => {
+	const onClickApplyHandler = () => {
+		selectedWidget?.query.forEach((element, index) => {
+			updateQuery({
+				widgetId: selectedWidget?.id || '',
+				query: element.query || '',
+				legend: element.legend || '', 
+				currentIndex: index
+			});
+		})
+		
 		applySettingsToPanel({
 			description,
 			isStacked: stacked,
@@ -130,16 +141,7 @@ const NewWidget = ({
 			title,
 			widgetId: selectedWidget?.id || '',
 		});
-	}, [
-		applySettingsToPanel,
-		description,
-		opacity,
-		selectedTime,
-		selectedWidget?.id,
-		selectedNullZeroValue,
-		stacked,
-		title,
-	]);
+	}
 
 	const onClickDiscardHandler = useCallback(() => {
 		push(generatePath(ROUTES.DASHBOARD, { dashboardId }));
@@ -220,6 +222,9 @@ interface DispatchProps {
 	getQueryResults: (
 		props: GetQueryResultsProps,
 	) => (dispatch: Dispatch<AppActions>) => void;
+	updateQuery: (
+		props: UpdateQueryProps,
+	) => (dispatch: Dispatch<AppActions>) => void;
 }
 
 const mapDispatchToProps = (
@@ -228,6 +233,7 @@ const mapDispatchToProps = (
 	applySettingsToPanel: bindActionCreators(ApplySettingsToPanel, dispatch),
 	saveSettingOfPanel: bindActionCreators(SaveDashboard, dispatch),
 	getQueryResults: bindActionCreators(GetQueryResults, dispatch),
+	updateQuery: bindActionCreators(UpdateQuery, dispatch)
 });
 
 type Props = DispatchProps & NewWidgetProps;


### PR DESCRIPTION
### Why

Closes #620 

### What is changing

I made some changes on the onClickApplyHandler to update the query when we click on the Apply Button.