### PR TITLE
fix: make it possible to specify alert manager url

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -660,7 +660,7 @@ func (r *ClickHouseReader) LoadChannel(channel *model.ChannelItem) *model.ApiErr
 		return &model.ApiError{Typ: model.ErrorBadData, Err: err}
 	}
 
-	response, err := http.Post(constants.ALERTMANAGER_API_PREFIX+"v1/receivers", "application/json", bytes.NewBuffer([]byte(channel.Data)))
+	response, err := http.Post(constants.GetAlertManagerApiPrefix()+"v1/receivers", "application/json", bytes.NewBuffer([]byte(channel.Data)))
 
 	if err != nil {
 		zap.S().Errorf("Error in getting response of API call to alertmanager/v1/receivers\n", err)
@@ -730,7 +730,7 @@ func (r *ClickHouseReader) DeleteChannel(id string) *model.ApiError {
 	values := map[string]string{"name": channelToDelete.Name}
 	jsonValue, _ := json.Marshal(values)
 
-	req, err := http.NewRequest(http.MethodDelete, constants.ALERTMANAGER_API_PREFIX+"v1/receivers", bytes.NewBuffer(jsonValue))
+	req, err := http.NewRequest(http.MethodDelete, constants.GetAlertManagerApiPrefix()+"v1/receivers", bytes.NewBuffer(jsonValue))
 
 	if err != nil {
 		zap.S().Errorf("Error in creating new delete request to alertmanager/v1/receivers\n", err)
@@ -855,7 +855,7 @@ func (r *ClickHouseReader) EditChannel(receiver *model.Receiver, id string) (*mo
 		}
 	}
 
-	req, err := http.NewRequest(http.MethodPut, constants.ALERTMANAGER_API_PREFIX+"v1/receivers", bytes.NewBuffer(receiverString))
+	req, err := http.NewRequest(http.MethodPut, constants.GetAlertManagerApiPrefix()+"v1/receivers", bytes.NewBuffer(receiverString))
 
 	if err != nil {
 		zap.S().Errorf("Error in creating new update request to alertmanager/v1/receivers\n", err)
@@ -917,7 +917,7 @@ func (r *ClickHouseReader) CreateChannel(receiver *model.Receiver) (*model.Recei
 		}
 	}
 
-	response, err := http.Post(constants.ALERTMANAGER_API_PREFIX+"v1/receivers", "application/json", bytes.NewBuffer(receiverString))
+	response, err := http.Post(constants.GetAlertManagerApiPrefix()+"v1/receivers", "application/json", bytes.NewBuffer(receiverString))
 
 	if err != nil {
 		zap.S().Errorf("Error in getting response of API call to alertmanager/v1/receivers\n", err)

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -23,7 +23,13 @@ func IsTelemetryEnabled() bool {
 const TraceTTL = "traces"
 const MetricsTTL = "metrics"
 
-const ALERTMANAGER_API_PREFIX = "http://alertmanager:9093/api/"
+func GetAlertManagerApiPrefix() string {
+	if os.Getenv("ALERTMANAGER_API_PREFIX") != "" {
+		return os.Getenv("ALERTMANAGER_API_PREFIX")
+	}
+	return "http://alertmanager:9093/api/"
+}
+
 const RELATIONAL_DATASOURCE_PATH = "/var/lib/signoz/signoz.db"
 
 const (

--- a/pkg/query-service/constants/constants_test.go
+++ b/pkg/query-service/constants/constants_test.go
@@ -1,0 +1,21 @@
+package constants
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"os"
+	"testing"
+)
+
+func TestGetAlertManagerApiPrefix(t *testing.T) {
+	Convey("TestGetAlertManagerApiPrefix", t, func() {
+
+		res := GetAlertManagerApiPrefix()
+
+		So(res, ShouldEqual, "http://alertmanager:9093/api/")
+		Convey("WithEnvSet", func() {
+			os.Setenv("ALERTMANAGER_API_PREFIX", "http://test:9093/api/")
+			res = GetAlertManagerApiPrefix()
+			So(res, ShouldEqual, "http://test:9093/api/")
+		})
+	})
+}


### PR DESCRIPTION
Giving it a try to contribute a small fix so it's possible to set alertmanager url via env. 
Cause in the new helm chart the default alertmanager is named `signoz-alertmanager` so with the const it won't work. 

Discussed quickly here in slack https://signoz-community.slack.com/archives/C01HWQ1R0BC/p1644413792082349

Happy to get any feedback on another approach. 

CC: @ankitnayan 