### PR TITLE
chore: 🔧 update default jaeger endpoint in hotrod manifest

### DIFF
--- a/sample-apps/hotrod/hotrod.yaml
+++ b/sample-apps/hotrod/hotrod.yaml
@@ -50,7 +50,7 @@ spec:
             - all
           env:
             - name: JAEGER_ENDPOINT
-              value: http://otel-collector.platform.svc.cluster.local:14268/api/traces
+              value: http://my-release-signoz-otel-collector.platform.svc.cluster.local:14268/api/traces
           image: jaegertracing/example-hotrod:1.30
           imagePullPolicy: IfNotPresent
           name: hotrod


### PR DESCRIPTION
Use the updated otel collector address in hotrod.

Signed-off-by: Prashant Shahi <prashant@signoz.io>