### PR TITLE
bug: clear all now moves with selected filter rather than user selected filter

### DIFF
--- a/frontend/src/container/Trace/Filters/Panel/PanelHeading/index.tsx
+++ b/frontend/src/container/Trace/Filters/Panel/PanelHeading/index.tsx
@@ -164,7 +164,7 @@ const PanelHeading = (props: PanelHeadingProps): JSX.Element => {
 				end: String(global.maxTime),
 				start: String(global.minTime),
 				getFilters: filterToFetchData,
-				other: Object.fromEntries(preUserSelected),
+				other: Object.fromEntries(updatedFilter),
 				isFilterExclude: postIsFilterExclude,
 			});
 


### PR DESCRIPTION
clear all now moves with selected filter rather than user selected filter