### PR TITLE
ci: 💚 fix e2e-k3s workflow as needed with the chart changes

### DIFF
--- a/.github/workflows/e2e-k3s.yaml
+++ b/.github/workflows/e2e-k3s.yaml
@@ -52,14 +52,11 @@ jobs:
           helm install my-release signoz/signoz -n platform \
             --wait \
             --timeout 10m0s \
-            --set cloud=null \
             --set frontend.service.type=LoadBalancer \
-            --set query-service.image.tag=$DOCKER_TAG \
+            --set queryService.image.tag=$DOCKER_TAG \
             --set frontend.image.tag=$DOCKER_TAG
           
           # get pods, services and the container images
-          kubectl describe deploy/my-release-frontend -n platform | grep Image
-          kubectl describe statefulset/my-release-query-service -n platform | grep Image
           kubectl get pods -n platform
           kubectl get svc -n platform
 


### PR DESCRIPTION
Removed `kubectl describe` as we already display the image tags post `helm install`.
Also, removed the `cloud=null` as it is a _no-op_.

Signed-off-by: Prashant Shahi <prashant@signoz.io>