### PR TITLE
fix: top endpoints table overflow

### DIFF
--- a/frontend/src/container/MetricsApplication/Tabs/Application.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Application.tsx
@@ -15,7 +15,7 @@ import MetricReducer from 'types/reducer/metrics';
 
 import { Card, Col, GraphContainer, GraphTitle, Row } from '../styles';
 import TopEndpointsTable from '../TopEndpointsTable';
-import { Button } from './styles';
+import { Button, TableContainerCard } from './styles';
 
 function Application({ getWidget }: DashboardProps): JSX.Element {
 	const { servicename } = useParams<{ servicename?: string }>();
@@ -232,9 +232,9 @@ function Application({ getWidget }: DashboardProps): JSX.Element {
 				</Col>
 
 				<Col span={12}>
-					<Card>
+					<TableContainerCard>
 						<TopEndpointsTable data={topEndPoints} />
-					</Card>
+					</TableContainerCard>
 				</Col>
 			</Row>
 		</>

--- a/frontend/src/container/MetricsApplication/Tabs/styles.ts
+++ b/frontend/src/container/MetricsApplication/Tabs/styles.ts
@@ -1,10 +1,15 @@
 import { Button as ButtonComponent } from 'antd';
 import styled from 'styled-components';
 
+import { Card } from '../styles';
+
 export const Button = styled(ButtonComponent)`
 	&&& {
 		position: absolute;
 		z-index: 999;
 		display: none;
 	}
+`;
+export const TableContainerCard = styled(Card)`
+	overflow-x: scroll;
 `;


### PR DESCRIPTION
Did a quick fix, made the table scrollable horizontally with that made we are not squashing the table contents hence making it more readable.

https://user-images.githubusercontent.com/32242596/159633297-04b33d67-8ea1-4d69-b36d-f4ec88dd1a4b.mov

