### PR TITLE
fix: dashboard table element overflow

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
 	"author": "",
 	"license": "ISC",
 	"dependencies": {
+		"@ant-design/colors": "^6.0.0",
 		"@ant-design/icons": "^4.6.2",
 		"@grafana/data": "^8.4.3",
 		"@monaco-editor/react": "^4.3.1",

--- a/frontend/src/container/ListOfDashboard/TableComponents/DeleteButton.tsx
+++ b/frontend/src/container/ListOfDashboard/TableComponents/DeleteButton.tsx
@@ -1,4 +1,3 @@
-import { Button } from 'antd';
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
@@ -7,6 +6,7 @@ import { DeleteDashboard, DeleteDashboardProps } from 'store/actions';
 import AppActions from 'types/actions';
 
 import { Data } from '../index';
+import { TableLinkText } from './styles';
 
 function DeleteButton({ deleteDashboard, id }: DeleteButtonProps): JSX.Element {
 	const onClickHandler = useCallback(() => {
@@ -15,11 +15,7 @@ function DeleteButton({ deleteDashboard, id }: DeleteButtonProps): JSX.Element {
 		});
 	}, [id, deleteDashboard]);
 
-	return (
-		<Button onClick={onClickHandler} type="link">
-			Delete
-		</Button>
-	);
+	return <TableLinkText onClick={onClickHandler}>Delete</TableLinkText>;
 }
 
 interface DispatchProps {

--- a/frontend/src/container/ListOfDashboard/TableComponents/Name.tsx
+++ b/frontend/src/container/ListOfDashboard/TableComponents/Name.tsx
@@ -1,10 +1,10 @@
-import { Button } from 'antd';
 import ROUTES from 'constants/routes';
 import history from 'lib/history';
 import React from 'react';
 import { generatePath } from 'react-router-dom';
 
 import { Data } from '..';
+import { TableLinkText } from './styles';
 
 function Name(name: Data['name'], data: Data): JSX.Element {
 	const onClickHandler = (): void => {
@@ -17,11 +17,7 @@ function Name(name: Data['name'], data: Data): JSX.Element {
 		);
 	};
 
-	return (
-		<Button onClick={onClickHandler} type="link">
-			{name}
-		</Button>
-	);
+	return <TableLinkText onClick={onClickHandler}>{name}</TableLinkText>;
 }
 
 export default Name;

--- a/frontend/src/container/ListOfDashboard/TableComponents/styles.ts
+++ b/frontend/src/container/ListOfDashboard/TableComponents/styles.ts
@@ -1,0 +1,8 @@
+import { blue } from '@ant-design/colors';
+import { Typography } from 'antd';
+import styled from 'styled-components';
+
+export const TableLinkText = styled(Typography.Text)`
+	color: ${blue.primary} !important;
+	cursor: pointer;
+`;


### PR DESCRIPTION
Closes #925 

Previously we were using button which doesn't allow text wrap. Converted it to a normal text which mimics the styling of links

https://user-images.githubusercontent.com/32242596/160543255-b7f6554a-4b5a-44a2-8e0f-1dbd9abd95b2.mov

