### PR TITLE
(fix): Duplicate alerts in triggered alerts 

### DIFF
--- a/frontend/src/api/alerts/getGroup.ts
+++ b/frontend/src/api/alerts/getGroup.ts
@@ -12,7 +12,7 @@ const getGroups = async (
 		const queryParams = convertObjectIntoParams(props);
 
 		const response = await AxiosAlertManagerInstance.get(
-			`/alerts?${queryParams}`,
+			`/alerts/groups?${queryParams}`,
 		);
 
 		return {

--- a/frontend/src/api/alerts/getTriggered.ts
+++ b/frontend/src/api/alerts/getTriggered.ts
@@ -3,9 +3,9 @@ import { ErrorResponseHandler } from 'api/ErrorResponseHandler';
 import { AxiosError } from 'axios';
 import convertObjectIntoParams from 'lib/query/convertObjectIntoParams';
 import { ErrorResponse, SuccessResponse } from 'types/api';
-import { PayloadProps, Props } from 'types/api/alerts/getGroups';
+import { PayloadProps, Props } from 'types/api/alerts/getTriggered';
 
-const getGroups = async (
+const getTriggered = async (
 	props: Props,
 ): Promise<SuccessResponse<PayloadProps> | ErrorResponse> => {
 	try {
@@ -26,4 +26,4 @@ const getGroups = async (
 	}
 };
 
-export default getGroups;
+export default getTriggered;

--- a/frontend/src/container/TriggeredAlerts/TriggeredAlert.tsx
+++ b/frontend/src/container/TriggeredAlerts/TriggeredAlert.tsx
@@ -1,4 +1,4 @@
-import getGroupApi from 'api/alerts/getGroup';
+import getTriggeredApi from 'api/alerts/getTriggered';
 import useInterval from 'hooks/useInterval';
 import React, { useState } from 'react';
 import { Alerts } from 'types/api/alerts/getAll';
@@ -13,20 +13,20 @@ function TriggeredAlerts({ allAlerts }: TriggeredAlertsProps): JSX.Element {
 
 	useInterval(() => {
 		(async (): Promise<void> => {
-			const response = await getGroupApi({
+			const response = await getTriggeredApi({
 				active: true,
 				inhibited: true,
 				silenced: false,
 			});
 
 			if (response.statusCode === 200 && response.payload !== null) {
-				const initialAlerts: Alerts[] = [];
+				// const initialAlerts: Alerts[] = [];
 
-				const allAlerts: Alerts[] = response.payload.reduce((acc, cur) => {
-					return [...acc, ...cur.alerts];
-				}, initialAlerts);
+				// const allAlerts: Alerts[] = response.payload.reduce((acc, cur) => {
+				//	return [...acc, ...cur.alerts];
+				// }, initialAlerts);
 
-				setInitialAlerts(allAlerts);
+				setInitialAlerts(response.payload);
 			}
 		})();
 	}, 30000);

--- a/frontend/src/container/TriggeredAlerts/TriggeredAlert.tsx
+++ b/frontend/src/container/TriggeredAlerts/TriggeredAlert.tsx
@@ -20,6 +20,8 @@ function TriggeredAlerts({ allAlerts }: TriggeredAlertsProps): JSX.Element {
 			});
 
 			if (response.statusCode === 200 && response.payload !== null) {
+				// commented reduce() call as we no longer use /alerts/groups
+				// from alertmanager which needed re-grouping on client side
 				// const initialAlerts: Alerts[] = [];
 
 				// const allAlerts: Alerts[] = response.payload.reduce((acc, cur) => {

--- a/frontend/src/container/TriggeredAlerts/index.tsx
+++ b/frontend/src/container/TriggeredAlerts/index.tsx
@@ -1,9 +1,9 @@
-import getGroupApi from 'api/alerts/getGroup';
+import getTriggeredApi from 'api/alerts/getTriggered';
 import Spinner from 'components/Spinner';
 import { State } from 'hooks/useFetch';
 import React, { useCallback, useEffect, useState } from 'react';
 import { Alerts } from 'types/api/alerts/getAll';
-import { PayloadProps } from 'types/api/alerts/getGroups';
+import { PayloadProps } from 'types/api/alerts/getTriggered';
 
 import TriggerComponent from './TriggeredAlert';
 
@@ -23,7 +23,7 @@ function TriggeredAlerts(): JSX.Element {
 				loading: true,
 			}));
 
-			const response = await getGroupApi({
+			const response = await getTriggeredApi({
 				active: true,
 				inhibited: true,
 				silenced: false,
@@ -33,7 +33,7 @@ function TriggeredAlerts(): JSX.Element {
 				setGroupState((state) => ({
 					...state,
 					loading: false,
-					payload: response.payload || [],
+					payload: response.payload,
 				}));
 			} else {
 				setGroupState((state) => ({
@@ -65,13 +65,13 @@ function TriggeredAlerts(): JSX.Element {
 		return <Spinner height="75vh" tip="Loading Alerts..." />;
 	}
 
-	const initialAlerts: Alerts[] = [];
+	// const initialAlerts: Alerts[] = [];
 
-	const allAlerts: Alerts[] = groupState.payload.reduce((acc, curr) => {
-		return [...acc, ...curr.alerts];
-	}, initialAlerts);
+	// const allAlerts: Alerts[] = groupState.payload.reduce((acc, curr) => {
+	//	return [...acc, ...curr.alerts];
+	// }, initialAlerts);
 
-	return <TriggerComponent allAlerts={allAlerts} />;
+	return <TriggerComponent allAlerts={groupState.payload} />;
 }
 
 export default TriggeredAlerts;

--- a/frontend/src/container/TriggeredAlerts/index.tsx
+++ b/frontend/src/container/TriggeredAlerts/index.tsx
@@ -33,7 +33,7 @@ function TriggeredAlerts(): JSX.Element {
 				setGroupState((state) => ({
 					...state,
 					loading: false,
-					payload: response.payload,
+					payload: response.payload || [],
 				}));
 			} else {
 				setGroupState((state) => ({
@@ -64,6 +64,9 @@ function TriggeredAlerts(): JSX.Element {
 	if (groupState.loading || groupState.payload === undefined) {
 		return <Spinner height="75vh" tip="Loading Alerts..." />;
 	}
+
+	// commented the reduce() call as we no longer use /alerts/groups
+	// API from alert manager, which returns a group for each receiver
 
 	// const initialAlerts: Alerts[] = [];
 

--- a/frontend/src/types/api/alerts/getTriggered.ts
+++ b/frontend/src/types/api/alerts/getTriggered.ts
@@ -1,0 +1,10 @@
+import { Alerts } from './getAll';
+
+export interface Props {
+	silenced: boolean;
+	inhibited: boolean;
+	active: boolean;
+	[key: string]: string | boolean;
+}
+
+export type PayloadProps = Alerts[] | [];


### PR DESCRIPTION
The use of alert groups API causes duplicate alerts to show up when multiple receivers are setup. 
This change makes use of Alerts API from alert manager instead of group API to fix this issue. 