### PR TITLE
chore: removing version api from being tracked

### DIFF
--- a/pkg/query-service/telemetry/ignoredPaths.go
+++ b/pkg/query-service/telemetry/ignoredPaths.go
@@ -2,7 +2,8 @@ package telemetry
 
 func IgnoredPaths() map[string]struct{} {
 	ignoredPaths := map[string]struct{}{
-		"/api/v1/tags": struct{}{},
+		"/api/v1/tags":    struct{}{},
+		"/api/v1/version": struct{}{},
 	}
 
 	return ignoredPaths


### PR DESCRIPTION
removing version api from being tracked