### PR TITLE
Prashant/deploy changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,11 +115,9 @@ down-arm:
 	@docker-compose -f $(STANDALONE_DIRECTORY)/docker-compose.arm.yaml down -v
 
 clear-standalone-data:
-	@cd $(STANDALONE_DIRECTORY)
-	@docker run --rm -v "data:/pwd" busybox \
+	@docker run --rm -v "$(PWD)/$(STANDALONE_DIRECTORY)/data:/pwd" busybox \
 	sh -c "cd /pwd && rm -rf alertmanager/* clickhouse/* signoz/*"
 
 clear-swarm-data:
-	@cd $(SWARM_DIRECTORY)
-	@docker run --rm -v "data:/pwd" busybox \
+	@docker run --rm -v "$(PWD)/$(SWARM_DIRECTORY)/data:/pwd" busybox \
 	sh -c "cd /pwd && rm -rf alertmanager/* clickhouse/* signoz/*"

--- a/deploy/docker-swarm/clickhouse-setup/clickhouse-config.xml
+++ b/deploy/docker-swarm/clickhouse-setup/clickhouse-config.xml
@@ -2,10 +2,7 @@
 <yandex>
     <logger>
         <level>trace</level>
-        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
-        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
-        <size>1000M</size>
-        <count>10</count>
+        <console>1</console>
     </logger>
 
     <http_port>8123</http_port>
@@ -44,6 +41,34 @@
         </invalidCertificateHandler>
     </client>
 </openSSL>
+
+<!-- Example config for tiered storage -->
+<!-- <storage_configuration>
+	<disks>
+		<default>
+            <keep_free_space_bytes>10485760</keep_free_space_bytes>
+		</default>
+ 	    <s3>
+ 	      <type>s3</type>
+		  <endpoint>https://BUCKET-NAME.s3.amazonaws.com/data/</endpoint>
+ 	      <access_key_id>ACCESS-KEY-ID</access_key_id>
+ 	      <secret_access_key>SECRET-ACCESS-KEY</secret_access_key>
+ 	    </s3>
+	</disks>
+	<policies>
+		<tiered>
+    	<volumes>
+    	  <default>
+    	    <disk>default</disk>
+    	  </default>
+    	  <s3>
+    	    <disk>s3</disk>
+    	  </s3>
+    	</volumes>
+        </tiered>
+	</policies>
+</storage_configuration> -->
+
 
 <!-- Default root page on http[s] server. For example load UI from https://tabix.io/ when opening http://localhost:8123 -->
     <!--

--- a/deploy/docker-swarm/clickhouse-setup/clickhouse-config.xml
+++ b/deploy/docker-swarm/clickhouse-setup/clickhouse-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <yandex>
     <logger>
-        <level>trace</level>
+        <level>information</level>
         <console>1</console>
     </logger>
 

--- a/deploy/docker-swarm/clickhouse-setup/clickhouse-config.xml
+++ b/deploy/docker-swarm/clickhouse-setup/clickhouse-config.xml
@@ -44,29 +44,29 @@
 
 <!-- Example config for tiered storage -->
 <!-- <storage_configuration>
-	<disks>
-		<default>
+    <disks>
+        <default>
             <keep_free_space_bytes>10485760</keep_free_space_bytes>
-		</default>
- 	    <s3>
- 	      <type>s3</type>
-		  <endpoint>https://BUCKET-NAME.s3.amazonaws.com/data/</endpoint>
- 	      <access_key_id>ACCESS-KEY-ID</access_key_id>
- 	      <secret_access_key>SECRET-ACCESS-KEY</secret_access_key>
- 	    </s3>
-	</disks>
-	<policies>
-		<tiered>
-    	<volumes>
-    	  <default>
-    	    <disk>default</disk>
-    	  </default>
-    	  <s3>
-    	    <disk>s3</disk>
-    	  </s3>
-    	</volumes>
+        </default>
+        <s3>
+            <type>s3</type>
+            <endpoint>https://BUCKET-NAME.s3.amazonaws.com/data/</endpoint>
+            <access_key_id>ACCESS-KEY-ID</access_key_id>
+            <secret_access_key>SECRET-ACCESS-KEY</secret_access_key>
+        </s3>
+   </disks>
+   <policies>
+       <tiered>
+           <volumes>
+                <default>
+                    <disk>default</disk>
+                </default>
+                <s3>
+                    <disk>s3</disk>
+                </s3>
+            </volumes>
         </tiered>
-	</policies>
+    </policies>
 </storage_configuration> -->
 
 

--- a/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
@@ -3,6 +3,9 @@ version: "3.9"
 services:
   clickhouse:
     image: yandex/clickhouse-server:21.12.3.32
+    # ports:
+    #   - "9000:9000"
+    #   - "8123:8123"
     volumes:
       - ./clickhouse-config.xml:/etc/clickhouse-server/config.xml
       - ./data/clickhouse/:/var/lib/clickhouse/
@@ -45,6 +48,11 @@ services:
       - TELEMETRY_ENABLED=true
       - DEPLOYMENT_TYPE=docker-swarm
 
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "localhost:8080/api/v1/version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     deploy:
       restart_policy:
         condition: on-failure

--- a/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
@@ -12,6 +12,10 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
+    logging:
+      options:
+        max-size: 50m
+        max-file: "3"
     healthcheck:
       # "clickhouse", "client", "-u ${CLICKHOUSE_USER}", "--password ${CLICKHOUSE_PASSWORD}", "-q 'SELECT 1'"
       test: ["CMD", "wget", "--spider", "-q", "localhost:8123/ping"]

--- a/deploy/docker/clickhouse-setup/clickhouse-config.xml
+++ b/deploy/docker/clickhouse-setup/clickhouse-config.xml
@@ -2,10 +2,7 @@
 <yandex>
     <logger>
         <level>trace</level>
-        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
-        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
-        <size>1000M</size>
-        <count>10</count>
+        <console>1</console>
     </logger>
 
     <http_port>8123</http_port>
@@ -46,30 +43,31 @@
 </openSSL>
 
 <!-- Example config for tiered storage -->
-<!-- <storage_configuration> -->
-<!-- 	<disks> -->
-<!-- 		<default> -->
-<!-- 		</default> -->
-<!--  	    <s3> -->
-<!--  	      <type>s3</type> -->
-<!-- 		  <endpoint>http://172.17.0.1:9100/test/random/</endpoint> -->
-<!--  	      <access_key_id>ash</access_key_id> -->
-<!--  	      <secret_access_key>password</secret_access_key> -->
-<!--  	    </s3> -->
-<!-- 	</disks> -->
-<!-- 	<policies> -->
-<!-- 		<tiered> -->
-<!--     	<volumes> -->
-<!--     	  <default> -->
-<!--     	    <disk>default</disk> -->
-<!--     	  </default> -->
-<!--     	  <s3> -->
-<!--     	    <disk>s3</disk> -->
-<!--     	  </s3> -->
-<!--     	</volumes> -->
-<!--         </tiered> -->
-<!-- 	</policies> -->
-<!-- </storage_configuration> -->
+<!-- <storage_configuration>
+	<disks>
+		<default>
+            <keep_free_space_bytes>10485760</keep_free_space_bytes>
+		</default>
+ 	    <s3>
+ 	      <type>s3</type>
+		  <endpoint>https://BUCKET-NAME.s3.amazonaws.com/data/</endpoint>
+ 	      <access_key_id>ACCESS-KEY-ID</access_key_id>
+ 	      <secret_access_key>SECRET-ACCESS-KEY</secret_access_key>
+ 	    </s3>
+	</disks>
+	<policies>
+		<tiered>
+    	<volumes>
+    	  <default>
+    	    <disk>default</disk>
+    	  </default>
+    	  <s3>
+    	    <disk>s3</disk>
+    	  </s3>
+    	</volumes>
+        </tiered>
+	</policies>
+</storage_configuration> -->
 
 
 <!-- Default root page on http[s] server. For example load UI from https://tabix.io/ when opening http://localhost:8123 -->

--- a/deploy/docker/clickhouse-setup/clickhouse-config.xml
+++ b/deploy/docker/clickhouse-setup/clickhouse-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <yandex>
     <logger>
-        <level>trace</level>
+        <level>information</level>
         <console>1</console>
     </logger>
 

--- a/deploy/docker/clickhouse-setup/clickhouse-config.xml
+++ b/deploy/docker/clickhouse-setup/clickhouse-config.xml
@@ -44,29 +44,29 @@
 
 <!-- Example config for tiered storage -->
 <!-- <storage_configuration>
-	<disks>
-		<default>
+    <disks>
+        <default>
             <keep_free_space_bytes>10485760</keep_free_space_bytes>
-		</default>
- 	    <s3>
- 	      <type>s3</type>
-		  <endpoint>https://BUCKET-NAME.s3.amazonaws.com/data/</endpoint>
- 	      <access_key_id>ACCESS-KEY-ID</access_key_id>
- 	      <secret_access_key>SECRET-ACCESS-KEY</secret_access_key>
- 	    </s3>
-	</disks>
-	<policies>
-		<tiered>
-    	<volumes>
-    	  <default>
-    	    <disk>default</disk>
-    	  </default>
-    	  <s3>
-    	    <disk>s3</disk>
-    	  </s3>
-    	</volumes>
+        </default>
+        <s3>
+            <type>s3</type>
+            <endpoint>https://BUCKET-NAME.s3.amazonaws.com/data/</endpoint>
+            <access_key_id>ACCESS-KEY-ID</access_key_id>
+            <secret_access_key>SECRET-ACCESS-KEY</secret_access_key>
+        </s3>
+   </disks>
+   <policies>
+       <tiered>
+           <volumes>
+                <default>
+                    <disk>default</disk>
+                </default>
+                <s3>
+                    <disk>s3</disk>
+                </s3>
+            </volumes>
         </tiered>
-	</policies>
+    </policies>
 </storage_configuration> -->
 
 

--- a/deploy/docker/clickhouse-setup/docker-compose.arm.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.arm.yaml
@@ -3,6 +3,9 @@ version: "2.4"
 services:
   clickhouse:
     image: altinity/clickhouse-server:21.12.3.32.altinitydev.arm
+    # ports:
+    #   - "9000:9000"
+    #   - "8123:8123"
     volumes:
       - ./clickhouse-config.xml:/etc/clickhouse-server/config.xml
       - ./data/clickhouse/:/var/lib/clickhouse/
@@ -19,7 +22,9 @@ services:
     volumes:
       - ./data/alertmanager:/data
     depends_on:
-      - query-service
+      query-service:
+        condition: service_healthy
+    restart: on-failure
     command:
       - --queryService.url=http://query-service:8080
       - --storage.path=/data
@@ -40,6 +45,11 @@ services:
       - DEPLOYMENT_TYPE=docker-standalone-arm
       
     restart: on-failure
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "localhost:8080/api/v1/version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     depends_on:
       clickhouse:
         condition: service_healthy

--- a/deploy/docker/clickhouse-setup/docker-compose.arm.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.arm.yaml
@@ -10,6 +10,10 @@ services:
       - ./clickhouse-config.xml:/etc/clickhouse-server/config.xml
       - ./data/clickhouse/:/var/lib/clickhouse/
     restart: on-failure
+    logging:
+      options:
+        max-size: 50m
+        max-file: "3"
     healthcheck:
       # "clickhouse", "client", "-u ${CLICKHOUSE_USER}", "--password ${CLICKHOUSE_PASSWORD}", "-q 'SELECT 1'"
       test: ["CMD", "wget", "--spider", "-q", "localhost:8123/ping"]

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -3,6 +3,9 @@ version: "2.4"
 services:
   clickhouse:
     image: yandex/clickhouse-server:21.12.3.32
+    # ports:
+    #   - "9000:9000"
+    #   - "8123:8123"
     volumes:
       - ./clickhouse-config.xml:/etc/clickhouse-server/config.xml
       - ./data/clickhouse/:/var/lib/clickhouse/
@@ -19,7 +22,9 @@ services:
     volumes:
       - ./data/alertmanager:/data
     depends_on:
-      - query-service
+      query-service:
+        condition: service_healthy
+    restart: on-failure
     command:
       - --queryService.url=http://query-service:8080
       - --storage.path=/data
@@ -41,6 +46,11 @@ services:
       - TELEMETRY_ENABLED=true
       - DEPLOYMENT_TYPE=docker-standalone-amd
     restart: on-failure
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "localhost:8080/api/v1/version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     depends_on:
       clickhouse:
         condition: service_healthy

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -10,6 +10,10 @@ services:
       - ./clickhouse-config.xml:/etc/clickhouse-server/config.xml
       - ./data/clickhouse/:/var/lib/clickhouse/
     restart: on-failure
+    logging:
+      options:
+        max-size: 50m
+        max-file: "3"
     healthcheck:
       # "clickhouse", "client", "-u ${CLICKHOUSE_USER}", "--password ${CLICKHOUSE_PASSWORD}", "-q 'SELECT 1'"
       test: ["CMD", "wget", "--spider", "-q", "localhost:8123/ping"]

--- a/pkg/query-service/tests/test-deploy/clickhouse-config.xml
+++ b/pkg/query-service/tests/test-deploy/clickhouse-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <yandex>
     <logger>
-        <level>trace</level>
+        <level>information</level>
         <console>1</console>
     </logger>
 

--- a/pkg/query-service/tests/test-deploy/clickhouse-config.xml
+++ b/pkg/query-service/tests/test-deploy/clickhouse-config.xml
@@ -2,10 +2,7 @@
 <yandex>
     <logger>
         <level>trace</level>
-        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
-        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
-        <size>1000M</size>
-        <count>10</count>
+        <console>1</console>
     </logger>
 
     <http_port>8123</http_port>

--- a/pkg/query-service/tests/test-deploy/docker-compose.arm.yaml
+++ b/pkg/query-service/tests/test-deploy/docker-compose.arm.yaml
@@ -5,6 +5,11 @@ services:
     image: altinity/clickhouse-server:21.12.3.32.altinitydev.arm
     volumes:
       - ./clickhouse-config.xml:/etc/clickhouse-server/config.xml
+    restart: on-failure
+    logging:
+      options:
+        max-size: 50m
+        max-file: "3"
     healthcheck:
       # "clickhouse", "client", "-u ${CLICKHOUSE_USER}", "--password ${CLICKHOUSE_PASSWORD}", "-q 'SELECT 1'"
       test: ["CMD", "wget", "--spider", "-q", "localhost:8123/ping"]

--- a/pkg/query-service/tests/test-deploy/docker-compose.arm.yaml
+++ b/pkg/query-service/tests/test-deploy/docker-compose.arm.yaml
@@ -16,6 +16,7 @@ services:
     image: signoz/alertmanager:0.6.0
     depends_on:
       - query-service
+    restart: on-failure
     command:
       - --queryService.url=http://query-service:8080
       - --storage.path=/data
@@ -35,6 +36,11 @@ services:
       - STORAGE=clickhouse
       - GODEBUG=netdns=go
       - TELEMETRY_ENABLED=true
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "localhost:8080/api/v1/version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     depends_on:
       clickhouse:
         condition: service_healthy

--- a/pkg/query-service/tests/test-deploy/docker-compose.yaml
+++ b/pkg/query-service/tests/test-deploy/docker-compose.yaml
@@ -5,6 +5,11 @@ services:
     image: yandex/clickhouse-server:21.12.3.32
     volumes:
       - ./clickhouse-config.xml:/etc/clickhouse-server/config.xml
+    restart: on-failure
+    logging:
+      options:
+        max-size: 50m
+        max-file: "3"
     healthcheck:
       # "clickhouse", "client", "-u ${CLICKHOUSE_USER}", "--password ${CLICKHOUSE_PASSWORD}", "-q 'SELECT 1'"
       test: ["CMD", "wget", "--spider", "-q", "localhost:8123/ping"]

--- a/pkg/query-service/tests/test-deploy/docker-compose.yaml
+++ b/pkg/query-service/tests/test-deploy/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
     image: signoz/alertmanager:0.6.0
     depends_on:
       - query-service
+    restart: on-failure
     command:
       - --queryService.url=http://query-service:8080
       - --storage.path=/data
@@ -37,6 +38,11 @@ services:
       - STORAGE=clickhouse
       - GODEBUG=netdns=go
       - TELEMETRY_ENABLED=true
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "localhost:8080/api/v1/version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     depends_on:
       clickhouse:
         condition: service_healthy


### PR DESCRIPTION
- using absolute path in docker CLI
- log to console and update storage config
- add query-service healthcheck and related changes
- set logger option to information
- maximum logs size 150m (3 files each of 50m)

Signed-off-by: Prashant Shahi <prashant@signoz.io>