### PR TITLE
chore(eslint): @typescript-eslint/no-unused-vars is made to error

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -101,6 +101,7 @@ module.exports = {
 				},
 			},
 		],
+		'@typescript-eslint/no-unused-vars': 'error',
 
 		// eslint rules need to remove
 		'no-shadow': 'off',


### PR DESCRIPTION
@typescript-eslint/no-unused-vars is made to error to reduce error in CI