### PR TITLE
fix(auth): Return 403 for forbidden requests due to rbac

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1220,7 +1220,7 @@ func (aH *APIHandler) getInvite(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := auth.GetInvite(context.Background(), token)
 	if err != nil {
-		respondError(w, &model.ApiError{Err: err, Typ: model.ErrorInternal}, nil)
+		respondError(w, &model.ApiError{Err: err, Typ: model.ErrorNotFound}, nil)
 		return
 	}
 	aH.writeJSON(w, r, resp)

--- a/pkg/query-service/auth/jwt.go
+++ b/pkg/query-service/auth/jwt.go
@@ -45,7 +45,7 @@ func validateUser(tok string) (*model.UserPayload, error) {
 	}
 	now := time.Now().Unix()
 	if !claims.VerifyExpiresAt(now, true) {
-		return nil, errors.Errorf("Token is expired")
+		return nil, model.ErrorTokenExpired
 	}
 	return &model.UserPayload{
 		User: model.User{

--- a/pkg/query-service/model/auth.go
+++ b/pkg/query-service/model/auth.go
@@ -1,5 +1,11 @@
 package model
 
+import "github.com/pkg/errors"
+
+var (
+	ErrorTokenExpired = errors.New("Token is expired")
+)
+
 type InviteRequest struct {
 	Name  string `json:"name"`
 	Email string `json:"email"`

--- a/pkg/query-service/model/response.go
+++ b/pkg/query-service/model/response.go
@@ -28,6 +28,7 @@ const (
 	ErrorNotFound       ErrorType = "not_found"
 	ErrorNotImplemented ErrorType = "not_implemented"
 	ErrorUnauthorized   ErrorType = "unauthorized"
+	ErrorForbidden      ErrorType = "forbidden"
 )
 
 type QueryDataV2 struct {


### PR DESCRIPTION
All the requests used to return 401 if either the token was invalid, or if the user was forbidden the access due to rbac.
This is not the right behaviour. 403 should be returned for forbidden requests. This PR fixes it.