### PR TITLE
fix: chart y-axis values not showing for values < 1

### DIFF
--- a/frontend/src/components/Graph/index.tsx
+++ b/frontend/src/components/Graph/index.tsx
@@ -160,10 +160,7 @@ function Graph({
 						ticks: {
 							// Include a dollar sign in the ticks
 							callback(value) {
-								return getYAxisFormattedValue(
-									parseInt(value.toString(), 10),
-									yAxisUnit,
-								);
+								return getYAxisFormattedValue(parseFloat(value.toString()), yAxisUnit);
 							},
 						},
 					},

--- a/frontend/src/components/Graph/yAxisConfig.ts
+++ b/frontend/src/components/Graph/yAxisConfig.ts
@@ -6,7 +6,7 @@ export const getYAxisFormattedValue = (
 ): string => {
 	try {
 		return formattedValueToString(
-			getValueFormat(format)(value, undefined, undefined, undefined),
+			getValueFormat(format)(value, 1, undefined, undefined),
 		);
 	} catch (error) {
 		console.error(error);


### PR DESCRIPTION
<img width="624" alt="Screenshot 2022-05-04 at 17 52 28" src="https://user-images.githubusercontent.com/32242596/166680395-2fcaf807-7610-4c50-90d9-57de575766d6.png">
