### PR TITLE
chore: 🔧 improve nginx cache configuration

### DIFF
--- a/deploy/docker-swarm/common/nginx-config.conf
+++ b/deploy/docker-swarm/common/nginx-config.conf
@@ -12,11 +12,16 @@ server {
     gzip_http_version 1.1; 
 
     location / {
-        add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0";
-        add_header Last-Modified $date_gmt;
+        if ( $uri = '/index.html' ) {
+            add_header Cache-Control no-store always;
+        }
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ /index.html;
+    }
+
+    location /api/alertmanager {
+        proxy_pass http://alertmanager:9093/api/v2;
     }
 
     location /api {

--- a/deploy/docker/common/nginx-config.conf
+++ b/deploy/docker/common/nginx-config.conf
@@ -12,14 +12,15 @@ server {
     gzip_http_version 1.1; 
 
     location / {
-        add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0";
-        add_header Last-Modified $date_gmt;
+        if ( $uri = '/index.html' ) {
+            add_header Cache-Control no-store always;
+        }
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ /index.html;
     }
 
-    location /api/alertmanager{
+    location /api/alertmanager {
         proxy_pass http://alertmanager:9093/api/v2;
     }
 


### PR DESCRIPTION
With this PR, all assets except _**index.html**_ will be cached.
Also, added Alertmanager proxy rule for swarm.

Before v0.8.0:
![Screenshot from 2022-05-11 10-53-19](https://user-images.githubusercontent.com/11138844/167780289-b3f4441b-05ba-4064-8ceb-1305a94de52b.png)

Now at v0.8.0:
![Screenshot from 2022-05-11 10-50-59](https://user-images.githubusercontent.com/11138844/167781664-a3eb0274-49ab-46af-a9a7-5bbb2fe0bac6.png)

After this PR:
![Screenshot from 2022-05-11 10-50-40](https://user-images.githubusercontent.com/11138844/167781708-3749be56-b117-4b78-b5b1-bf3652cd85e3.png)

Signed-off-by: Prashant Shahi <prashant@signoz.io>