### PR TITLE
Mandatory FE/BE builds for all PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,40 +1,15 @@
 name: build-pipeline
+
 on:
   pull_request:
     branches:
       - develop
       - main
-      - v*
-    paths:
-      - "pkg/**"
-      - "frontend/**"
+      - release/v*
 
 jobs:
-  get_filters:
-    runs-on: ubuntu-latest
-    # Set job outputs to values from filter step
-    outputs:
-      frontend: ${{ steps.filter.outputs.frontend }}
-      query-service: ${{ steps.filter.outputs.query-service }}
-      flattener: ${{ steps.filter.outputs.flattener }}
-    steps:
-      # For pull requests it's not necessary to checkout the code
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          filters: |
-            frontend:
-              - 'frontend/**'
-            query-service:
-              - 'pkg/query-service/**'
-            flattener:
-              - 'pkg/processors/flattener/**'
-
   build-frontend:
     runs-on: ubuntu-latest
-    needs:
-      - get_filters
-    if: ${{ needs.get_filters.outputs.frontend == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -52,9 +27,6 @@ jobs:
 
   build-query-service:
     runs-on: ubuntu-latest
-    needs:
-      - get_filters
-    if: ${{ needs.get_filters.outputs.query-service == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -62,16 +34,3 @@ jobs:
         shell: bash
         run: |
           make build-query-service-amd64
-
-  build-flattener:
-    runs-on: ubuntu-latest
-    needs:
-      - get_filters
-    if: ${{ needs.get_filters.outputs.flattener == 'true' }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Build flattener docker image
-        shell: bash
-        run: |
-          make build-flattener-amd64


### PR DESCRIPTION
We recently made it mandatory for success checks. Since current workflow skips checks conditionally, it causes PRs to be unmergeable.
We are mandating frontend and backend builds for all PRs.

Refer the URL below to read more regarding the problem with path-based filtering and required status checks:
- https://docs.github.com/en/enterprise-server@3.5/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks

Signed-off-by: Prashant Shahi <prashant@signoz.io>