### PR TITLE
feat: Postgres Support

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -6,7 +6,6 @@ import (
 	"crypto/md5"
 	"database/sql"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -94,11 +93,12 @@ type ClickHouseReader struct {
 	remoteStorage   *remote.Storage
 	ruleManager     *rules.Manager
 	promConfig      *config.Config
+	promConfigPath  string
 	alertManager    am.Manager
 }
 
-// NewTraceReader returns a TraceReader for the database
-func NewReader(localDB *sqlx.DB) *ClickHouseReader {
+// NewReader returns a TraceReader for the database
+func NewReader(localDB *sqlx.DB, promConfigPath string) *ClickHouseReader {
 
 	datasource := os.Getenv("ClickHouseUrl")
 	options := NewOptions(datasource, primaryNamespace, archiveNamespace)
@@ -121,6 +121,7 @@ func NewReader(localDB *sqlx.DB) *ClickHouseReader {
 		errorTable:      options.primary.ErrorTable,
 		durationTable:   options.primary.DurationTable,
 		spansTable:      options.primary.SpansTable,
+		promConfigPath:  promConfigPath,
 	}
 }
 
@@ -174,13 +175,11 @@ func (r *ClickHouseReader) Start() {
 
 		logLevel promlog.AllowedLevel
 	}{
+		configFile: r.promConfigPath,
 		notifier: notifier.Options{
 			Registerer: prometheus.DefaultRegisterer,
 		},
 	}
-
-	flag.StringVar(&cfg.configFile, "config", "./config/prometheus.yml", "(prometheus config to read metrics)")
-	flag.Parse()
 
 	// fanoutStorage := remoteStorage
 	fanoutStorage := storage.NewFanout(logger, remoteStorage)
@@ -356,6 +355,7 @@ func (r *ClickHouseReader) Start() {
 				// }
 				r.promConfig, err = reloadConfig(cfg.configFile, logger, reloaders...)
 				if err != nil {
+					zap.S().Errorf("error loading config from %q: %s", cfg.configFile, err)
 					return fmt.Errorf("error loading config from %q: %s", cfg.configFile, err)
 				}
 
@@ -682,17 +682,17 @@ func (r *ClickHouseReader) LoadChannel(channel *model.ChannelItem) *model.ApiErr
 	if err := json.Unmarshal([]byte(channel.Data), receiver); err != nil { // Parse []byte to go struct pointer
 		return &model.ApiError{Typ: model.ErrorBadData, Err: err}
 	}
-
-	response, err := http.Post(constants.GetAlertManagerApiPrefix()+"v1/receivers", "application/json", bytes.NewBuffer([]byte(channel.Data)))
+	postURL := constants.GetAlertManagerApiPrefix() + "v1/receivers"
+	response, err := http.Post(postURL, "application/json", bytes.NewBuffer([]byte(channel.Data)))
 
 	if err != nil {
-		zap.S().Errorf("Error in getting response of API call to alertmanager/v1/receivers\n", err)
+		zap.S().Errorf(fmt.Sprintf("Error in getting response of API call to %s/v1/receivers\n", constants.GetAlertManagerApiPrefix()), err)
 		return &model.ApiError{Typ: model.ErrorInternal, Err: err}
 	}
 	if response.StatusCode > 299 {
 		responseData, _ := ioutil.ReadAll(response.Body)
 
-		err := fmt.Errorf("Error in getting 2xx response in API call to alertmanager/v1/receivers\n Status: %s \n Data: %s", response.Status, string(responseData))
+		err := fmt.Errorf("Error in getting 2xx response in API call to %s\n Status: %s \n Data: %s", postURL, response.Status, string(responseData))
 		zap.S().Error(err)
 
 		return &model.ApiError{Typ: model.ErrorInternal, Err: err}
@@ -706,7 +706,7 @@ func (r *ClickHouseReader) GetChannel(id string) (*model.ChannelItem, *model.Api
 	idInt, _ := strconv.Atoi(id)
 	channel := model.ChannelItem{}
 
-	query := fmt.Sprintf("SELECT id, created_at, updated_at, name, type, data data FROM notification_channels WHERE id=%d", idInt)
+	query := fmt.Sprintf("SELECT id, created_at, updated_at, name, type, data FROM notification_channels WHERE id=%d", idInt)
 
 	err := r.localDB.Get(&channel, query)
 
@@ -928,7 +928,7 @@ func (r *ClickHouseReader) CreateRule(rule string) *model.ApiError {
 	var lastInsertId int64
 
 	{
-		stmt, err := tx.Prepare(`INSERT into rules (updated_at, data) VALUES($1,$2);`)
+		stmt, err := tx.Prepare(`INSERT into rules (updated_at, data) VALUES($1,$2) RETURNING id;`)
 		if err != nil {
 			zap.S().Errorf("Error in preparing statement for INSERT to rules\n", err)
 			tx.Rollback()
@@ -936,16 +936,16 @@ func (r *ClickHouseReader) CreateRule(rule string) *model.ApiError {
 		}
 		defer stmt.Close()
 
-		result, err := stmt.Exec(time.Now(), rule)
+		err = stmt.QueryRow(time.Now(), rule).Scan(&lastInsertId)
 		if err != nil {
 			zap.S().Errorf("Error in Executing prepared statement for INSERT to rules\n", err)
 			tx.Rollback() // return an error too, we may want to wrap them
 			return &model.ApiError{Typ: model.ErrorInternal, Err: err}
 		}
-		lastInsertId, _ = result.LastInsertId()
+		// LastInsertId() doesnt work for pq. hence using Returning INto above
+		// lastInsertId, _ = result.LastInsertId()
 
 		groupName := fmt.Sprintf("%d-groupname", lastInsertId)
-
 		err = r.ruleManager.AddGroup(time.Duration(r.promConfig.GlobalConfig.EvaluationInterval), rule, groupName)
 
 		if err != nil {

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -772,7 +772,7 @@ func (r *ClickHouseReader) GetChannels() (*[]model.ChannelItem, *model.ApiError)
 
 	channels := []model.ChannelItem{}
 
-	query := fmt.Sprintf("SELECT id, created_at, updated_at, name, type, data data FROM notification_channels")
+	query := fmt.Sprintf("SELECT id, created_at, updated_at, name, type, data FROM notification_channels")
 
 	err := r.localDB.Select(&channels, query)
 

--- a/pkg/query-service/app/dashboards/model.go
+++ b/pkg/query-service/app/dashboards/model.go
@@ -18,55 +18,52 @@ import (
 var db *sqlx.DB
 
 // InitDB sets up setting up the connection pool global variable.
-func InitDB(dataSourceName string) (*sqlx.DB, error) {
+func InitDB(conn *sqlx.DB) error {
 	var err error
 
-	db, err = sqlx.Open("sqlite3", dataSourceName)
-	if err != nil {
-		return nil, err
-	}
+	db = conn
 
 	table_schema := `CREATE TABLE IF NOT EXISTS dashboards (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		id SERIAL PRIMARY KEY,
 		uuid TEXT NOT NULL UNIQUE,
-		created_at datetime NOT NULL,
-		updated_at datetime NOT NULL,
-		data TEXT NOT NULL
+		created_at timestamp NOT NULL,
+		updated_at timestamp NOT NULL,
+		data JSONB NOT NULL
 	);`
 
 	_, err = db.Exec(table_schema)
 	if err != nil {
-		return nil, fmt.Errorf("Error in creating dashboard table: %s", err.Error())
+		return fmt.Errorf("Error in creating dashboard table: %s", err.Error())
 	}
 
 	table_schema = `CREATE TABLE IF NOT EXISTS rules (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		updated_at datetime NOT NULL,
+		id SERIAL PRIMARY KEY,
+		updated_at timestamp NOT NULL,
 		deleted INTEGER DEFAULT 0,
-		data TEXT NOT NULL
+		data JSONB NOT NULL
 	);`
 
 	_, err = db.Exec(table_schema)
 	if err != nil {
-		return nil, fmt.Errorf("Error in creating rules table: %s", err.Error())
+		return fmt.Errorf("Error in creating rules table: %s", err.Error())
 	}
 
 	table_schema = `CREATE TABLE IF NOT EXISTS notification_channels (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		created_at datetime NOT NULL,
-		updated_at datetime NOT NULL,
+		id SERIAL PRIMARY KEY,
+		created_at timestamp NOT NULL,
+		updated_at timestamp NOT NULL,
 		name TEXT NOT NULL UNIQUE,
 		type TEXT NOT NULL,
 		deleted INTEGER DEFAULT 0,
-		data TEXT NOT NULL
+		data JSONB NOT NULL
 	);`
 
 	_, err = db.Exec(table_schema)
 	if err != nil {
-		return nil, fmt.Errorf("Error in creating notification_channles table: %s", err.Error())
+		return fmt.Errorf("Error in creating notification_channles table: %s", err.Error())
 	}
 
-	return db, nil
+	return nil
 }
 
 type Dashboard struct {

--- a/pkg/query-service/config/config.go
+++ b/pkg/query-service/config/config.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"fmt"
+	"go.signoz.io/query-service/constants"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+)
+
+type DBEngine string
+
+const (
+	SQLLITE DBEngine = "sqllite"
+	PG      DBEngine = "postgres"
+)
+
+type QsConfig struct {
+	DB *DBConfig `yaml:"db"`
+}
+
+func GetDefaultConfigPath() string {
+	return constants.GetOrDefaultEnv("SIGNOZ_QS_CONFIG_PATH", "./config/qs.yaml")
+}
+
+func LoadDefaultQsConfig() *QsConfig {
+	return &QsConfig{
+		DB: &DBConfig{
+			Engine: PG,
+			PG: &PGConfig{
+				User:    "apple", //postgress todo
+				DBname:  "postgres",
+				Port:    5432,
+				Host:    "localhost",
+				SSLmode: "disable",
+			},
+		},
+	}
+}
+
+// LoadQsConfigFromFile loads query service config from a given file
+func LoadQsConfigFromFile(filename string) (*QsConfig, error) {
+	cfg := LoadDefaultQsConfig()
+	if filename == "" {
+		return cfg, fmt.Errorf("config file must be set for query service to start")
+	}
+
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return cfg, err
+	}
+
+	err = yaml.UnmarshalStrict(content, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+type DBConfig struct {
+	Engine DBEngine   `yaml:"kind"`
+	SQL    *SQLConfig `yaml:"sql, omitempty"`
+	PG     *PGConfig  `yaml:"pg, omitempty"`
+}
+
+type SQLConfig struct {
+	Path string `yaml:"path"`
+}
+
+type PGConfig struct {
+	User     string `yaml:"user, omitempty"`
+	Password string `yaml:"password, omitempty"`
+	DBname   string `yaml:"db, omitempty"`
+	SSLmode  string `yaml:"ssl, omitempty"`
+	Host     string `yaml:"host, omitempty"`
+	Port     int64  `yaml:"post, omitempty"`
+}

--- a/pkg/query-service/config/config.go
+++ b/pkg/query-service/config/config.go
@@ -2,44 +2,41 @@ package config
 
 import (
 	"fmt"
-	"go.signoz.io/query-service/constants"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
+	"os"
 )
 
 type DBEngine string
 
 const (
-	SQLLITE DBEngine = "sqllite"
+	SQLLITE DBEngine = "sql"
 	PG      DBEngine = "postgres"
 )
 
+// QsConfig contains configuration parameters to get query service
+// up and running. The config can be set through a yaml file or
+// command line parameters
 type QsConfig struct {
+	// primary database used by query service to store configuration items
+	// like alert definitions, dashboard settings, alert rules etc
 	DB *DBConfig `yaml:"db"`
 }
 
-func GetDefaultConfigPath() string {
-	return constants.GetOrDefaultEnv("SIGNOZ_QS_CONFIG_PATH", "./config/qs.yaml")
+// GetDB returns query service db that stores config items
+func (q *QsConfig) GetDB() *DBConfig {
+	return q.DB
 }
 
-func LoadDefaultQsConfig() *QsConfig {
-	return &QsConfig{
-		DB: &DBConfig{
-			Engine: PG,
-			PG: &PGConfig{
-				User:    "apple", //postgress todo
-				DBname:  "postgres",
-				Port:    5432,
-				Host:    "localhost",
-				SSLmode: "disable",
-			},
-		},
-	}
+// GetDBEngine returns the type of database engine that stores
+// config items likes alerts, dashboard etc
+func (q *QsConfig) GetDBEngine() DBEngine {
+	return q.DB.Engine
 }
 
-// LoadQsConfigFromFile loads query service config from a given file
+// LoadQsConfigFromFile imports query service config from a given file
 func LoadQsConfigFromFile(filename string) (*QsConfig, error) {
-	cfg := LoadDefaultQsConfig()
+	cfg := &QsConfig{}
 	if filename == "" {
 		return cfg, fmt.Errorf("config file must be set for query service to start")
 	}
@@ -57,21 +54,43 @@ func LoadQsConfigFromFile(filename string) (*QsConfig, error) {
 	return cfg, nil
 }
 
+// DBConfig contains parameters used for database connection
 type DBConfig struct {
 	Engine DBEngine   `yaml:"kind"`
 	SQL    *SQLConfig `yaml:"sql, omitempty"`
 	PG     *PGConfig  `yaml:"pg, omitempty"`
 }
 
+// SQLConfig contains parameters for SQL Lite connection
 type SQLConfig struct {
 	Path string `yaml:"path"`
 }
 
+// PGConfig contains parameters for postgres connection
 type PGConfig struct {
 	User     string `yaml:"user, omitempty"`
 	Password string `yaml:"password, omitempty"`
+	File     string `yaml:"file, omitempty"`
 	DBname   string `yaml:"db, omitempty"`
 	SSLmode  string `yaml:"ssl, omitempty"`
 	Host     string `yaml:"host, omitempty"`
 	Port     int64  `yaml:"post, omitempty"`
+}
+
+// LoadPassword imports postgres password from a file.
+// This is useful in securing password and would be preferred
+// option in enterprise settings
+func (pg *PGConfig) LoadPassword(path string) error {
+	if path != "" {
+		pg.File = path
+	}
+
+	// load password from file
+	dat, err := os.ReadFile(pg.File)
+	if err != nil {
+		return err
+	}
+
+	pg.Password = string(dat)
+	return nil
 }

--- a/pkg/query-service/config/validate.go
+++ b/pkg/query-service/config/validate.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"fmt"
+)
+
+// ValidateQsConfig validates query service config
+func ValidateQs(q *QsConfig) error {
+	if q == nil {
+		return fmt.Errorf("failed to initialize Query service config")
+	}
+
+	if q.DB == nil {
+		return fmt.Errorf("failed to find config for QS Database")
+	}
+	return nil
+}

--- a/pkg/query-service/dao/factory.go
+++ b/pkg/query-service/dao/factory.go
@@ -12,6 +12,7 @@ import (
 
 var db ModelDao
 
+// InitConn initializes database connection. Supports both sql*lite and postgres
 func InitConn(dbconf *config.DBConfig) (*sqlx.DB, error) {
 	var err error
 	var conn *sqlx.DB
@@ -32,6 +33,8 @@ func InitConn(dbconf *config.DBConfig) (*sqlx.DB, error) {
 	return conn, nil
 }
 
+// InitDao initialize data model and db connection pool
+// to be used by query servie. Supports sql*lite and postgres
 func InitDao(engine config.DBEngine, conn *sqlx.DB) error {
 	var err error
 

--- a/pkg/query-service/dao/postgres/connection.go
+++ b/pkg/query-service/dao/postgres/connection.go
@@ -18,6 +18,7 @@ type modelDao struct {
 	db *sqlx.DB
 }
 
+// InitConn initializes postgres db connection
 func InitConn(pgconf *config.PGConfig) (*sqlx.DB, error) {
 
 	psqlInfo := fmt.Sprintf("dbname=%s user=%s host=%s port=%d ", pgconf.DBname, pgconf.User, pgconf.Host, pgconf.Port)
@@ -38,7 +39,8 @@ func InitConn(pgconf *config.PGConfig) (*sqlx.DB, error) {
 	return db, nil
 }
 
-// InitDB sets up setting up the connection pool global variable.
+// InitDB sets up data model (creates tables if necessary) and
+// the connection pool global variable.
 func InitDB(db *sqlx.DB) (*modelDao, error) {
 
 	table_schema := `
@@ -47,8 +49,8 @@ func InitDB(db *sqlx.DB) (*modelDao, error) {
 			id UUID PRIMARY KEY,
 			name TEXT NOT NULL,
 			created_at INTEGER NOT NULL,
-			is_anonymous INTEGER NOT NULL DEFAULT 0 CHECK(is_anonymous IN (0,1)),
-			has_opted_updates INTEGER NOT NULL DEFAULT 1 CHECK(has_opted_updates IN (0,1))
+			is_anonymous bool DEFAULT false NOT NULL,
+			has_opted_updates bool DEFAULT false NOT NULL
 		);
 
 		CREATE TABLE IF NOT EXISTS invites (

--- a/pkg/query-service/dao/postgres/rbac.go
+++ b/pkg/query-service/dao/postgres/rbac.go
@@ -1,0 +1,520 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"go.signoz.io/query-service/model"
+	"go.signoz.io/query-service/telemetry"
+)
+
+func (mds *modelDao) CreateInviteEntry(ctx context.Context,
+	req *model.InvitationObject) *model.ApiError {
+
+	_, err := mds.db.ExecContext(ctx,
+		`INSERT INTO invites (email, name, token, role, created_at, org_id)
+		VALUES ($1, $2, $3, $4, $5, $6);`,
+		req.Email, req.Name, req.Token, req.Role, req.CreatedAt, req.OrgId)
+	if err != nil {
+		return &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return nil
+}
+
+func (mds *modelDao) DeleteInvitation(ctx context.Context, email string) *model.ApiError {
+	_, err := mds.db.ExecContext(ctx, `DELETE from invites where email=$1;`, email)
+	if err != nil {
+		return &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return nil
+}
+
+func (mds *modelDao) GetInviteFromEmail(ctx context.Context, email string,
+) (*model.InvitationObject, *model.ApiError) {
+
+	invites := []model.InvitationObject{}
+	err := mds.db.Select(&invites,
+		`SELECT * FROM invites WHERE email=$1;`, email)
+
+	if err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	if len(invites) > 1 {
+		return nil, &model.ApiError{
+			Typ: model.ErrorInternal,
+			Err: errors.Errorf("Found multiple invites for the email: %s", email)}
+	}
+
+	if len(invites) == 0 {
+		return nil, nil
+	}
+	return &invites[0], nil
+}
+
+func (mds *modelDao) GetInviteFromToken(ctx context.Context, token string,
+) (*model.InvitationObject, *model.ApiError) {
+
+	invites := []model.InvitationObject{}
+	err := mds.db.Select(&invites,
+		`SELECT * FROM invites WHERE token=$1;`, token)
+
+	if err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	if len(invites) > 1 {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+
+	if len(invites) == 0 {
+		return nil, nil
+	}
+	return &invites[0], nil
+}
+
+func (mds *modelDao) GetInvites(ctx context.Context,
+) ([]model.InvitationObject, *model.ApiError) {
+
+	invites := []model.InvitationObject{}
+	err := mds.db.Select(&invites, "SELECT * FROM invites")
+	if err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return invites, nil
+}
+
+func (mds *modelDao) CreateOrg(ctx context.Context,
+	org *model.Organization) (*model.Organization, *model.ApiError) {
+
+	org.Id = uuid.NewString()
+	org.CreatedAt = time.Now().Unix()
+	_, err := mds.db.ExecContext(ctx,
+		`INSERT INTO organizations (id, name, created_at) VALUES ($1, $2, $3);`,
+		org.Id, org.Name, org.CreatedAt)
+
+	if err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return org, nil
+}
+
+func (mds *modelDao) GetOrg(ctx context.Context,
+	id string) (*model.Organization, *model.ApiError) {
+
+	orgs := []model.Organization{}
+	err := mds.db.Select(&orgs, `SELECT * FROM organizations WHERE id=$1;`, id)
+
+	if err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	if len(orgs) > 1 {
+		return nil, &model.ApiError{
+			Typ: model.ErrorInternal,
+			Err: errors.New("Found multiple org with same ID"),
+		}
+	}
+
+	if len(orgs) == 0 {
+		return nil, nil
+	}
+	return &orgs[0], nil
+}
+
+func (mds *modelDao) GetOrgByName(ctx context.Context,
+	name string) (*model.Organization, *model.ApiError) {
+
+	orgs := []model.Organization{}
+
+	if err := mds.db.Select(&orgs, `SELECT * FROM organizations WHERE name=$1;`, name); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+
+	if len(orgs) > 1 {
+		return nil, &model.ApiError{
+			Typ: model.ErrorInternal,
+			Err: errors.New("Multiple orgs with same ID found"),
+		}
+	}
+	if len(orgs) == 0 {
+		return nil, nil
+	}
+	return &orgs[0], nil
+}
+
+func (mds *modelDao) GetOrgs(ctx context.Context) ([]model.Organization, *model.ApiError) {
+	orgs := []model.Organization{}
+	err := mds.db.Select(&orgs, `SELECT * FROM organizations`)
+
+	if err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return orgs, nil
+}
+
+func (mds *modelDao) EditOrg(ctx context.Context, org *model.Organization) *model.ApiError {
+
+	q := `UPDATE organizations SET name=$1,has_opted_updates=$2,is_anonymous=$3 WHERE id=$4;`
+
+	_, err := mds.db.ExecContext(ctx, q, org.Name, org.HasOptedUpdates, org.IsAnonymous, org.Id)
+	if err != nil {
+		return &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+
+	telemetry.GetInstance().SetTelemetryAnonymous(org.IsAnonymous)
+	return nil
+}
+
+func (mds *modelDao) DeleteOrg(ctx context.Context, id string) *model.ApiError {
+
+	_, err := mds.db.ExecContext(ctx, `DELETE from organizations where id=$1;`, id)
+	if err != nil {
+		return &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return nil
+}
+
+func (mds *modelDao) CreateUser(ctx context.Context,
+	user *model.User) (*model.User, *model.ApiError) {
+
+	_, err := mds.db.ExecContext(ctx,
+		`INSERT INTO users (id, name, email, password, created_at, profile_picture_url, group_id, org_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8);`,
+		user.Id, user.Name, user.Email, user.Password, user.CreatedAt,
+		user.ProfilePirctureURL, user.GroupId, user.OrgId,
+	)
+
+	if err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+
+	data := map[string]interface{}{
+		"name":  user.Name,
+		"email": user.Email,
+	}
+	telemetry.GetInstance().IdentifyUser(user)
+	telemetry.GetInstance().SendEvent(telemetry.TELEMETRY_EVENT_USER, data)
+
+	return user, nil
+}
+
+func (mds *modelDao) EditUser(ctx context.Context,
+	update *model.User) (*model.User, *model.ApiError) {
+
+	_, err := mds.db.ExecContext(ctx,
+		`UPDATE users SET name=$1,org_id=$2,email=$3 WHERE id=$4;`, update.Name,
+		update.OrgId, update.Email, update.Id)
+	if err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return update, nil
+}
+
+func (mds *modelDao) UpdateUserPassword(ctx context.Context, passwordHash,
+	userId string) *model.ApiError {
+
+	q := `UPDATE users SET password=$1 WHERE id=$2;`
+	if _, err := mds.db.ExecContext(ctx, q, passwordHash, userId); err != nil {
+		return &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return nil
+}
+
+func (mds *modelDao) UpdateUserGroup(ctx context.Context, userId, groupId string) *model.ApiError {
+
+	q := `UPDATE users SET group_id=$1 WHERE id=$2;`
+	if _, err := mds.db.ExecContext(ctx, q, groupId, userId); err != nil {
+		return &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return nil
+}
+
+func (mds *modelDao) DeleteUser(ctx context.Context, id string) *model.ApiError {
+
+	result, err := mds.db.ExecContext(ctx, `DELETE from users where id=$1;`, id)
+	if err != nil {
+		return &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+
+	affectedRows, err := result.RowsAffected()
+	if err != nil {
+		return &model.ApiError{Typ: model.ErrorExec, Err: err}
+	}
+	if affectedRows == 0 {
+		return &model.ApiError{
+			Typ: model.ErrorNotFound,
+			Err: fmt.Errorf("no user found with id: %s", id),
+		}
+	}
+
+	return nil
+}
+
+func (mds *modelDao) GetUser(ctx context.Context,
+	id string) (*model.UserPayload, *model.ApiError) {
+
+	users := []model.UserPayload{}
+	query := `select
+				u.id,
+				u.name,
+				u.email,
+				u.password,
+				u.created_at,
+				u.profile_picture_url,
+				u.org_id,
+				u.group_id,
+				g.name as role,
+				o.name as organization
+			from users u, groups g, organizations o
+			where
+				g.id=u.group_id and
+				o.id = u.org_id and
+				u.id=$1;`
+
+	if err := mds.db.Select(&users, query, id); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	if len(users) > 1 {
+		return nil, &model.ApiError{
+			Typ: model.ErrorInternal,
+			Err: errors.New("Found multiple users with same ID"),
+		}
+	}
+
+	if len(users) == 0 {
+		return nil, nil
+	}
+	return &users[0], nil
+}
+
+func (mds *modelDao) GetUserByEmail(ctx context.Context,
+	email string) (*model.UserPayload, *model.ApiError) {
+
+	users := []model.UserPayload{}
+	query := `select
+				u.id,
+				u.name,
+				u.email,
+				u.password,
+				u.created_at,
+				u.profile_picture_url,
+				u.org_id,
+				u.group_id,
+				g.name as role,
+				o.name as organization
+			from users u, groups g, organizations o
+			where
+				g.id=u.group_id and
+				o.id = u.org_id and
+				u.email=$1;`
+
+	if err := mds.db.Select(&users, query, email); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	if len(users) > 1 {
+		return nil, &model.ApiError{
+			Typ: model.ErrorInternal,
+			Err: errors.New("Found multiple users with same ID."),
+		}
+	}
+
+	if len(users) == 0 {
+		return nil, nil
+	}
+	return &users[0], nil
+}
+
+func (mds *modelDao) GetUsers(ctx context.Context) ([]model.UserPayload, *model.ApiError) {
+	users := []model.UserPayload{}
+
+	query := `select
+				u.id,
+				u.name,
+				u.email,
+				u.password,
+				u.created_at,
+				u.profile_picture_url,
+				u.org_id,
+				u.group_id,
+				g.name as role,
+				o.name as organization
+			from users u, groups g, organizations o
+			where
+				g.id = u.group_id and
+				o.id = u.org_id`
+
+	err := mds.db.Select(&users, query)
+
+	if err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return users, nil
+}
+
+func (mds *modelDao) GetUsersByOrg(ctx context.Context,
+	orgId string) ([]model.UserPayload, *model.ApiError) {
+
+	users := []model.UserPayload{}
+	query := `select
+				u.id,
+				u.name,
+				u.email,
+				u.password,
+				u.created_at,
+				u.profile_picture_url,
+				u.org_id,
+				u.group_id,
+				g.name as role,
+				o.name as organization
+			from users u, groups g, organizations o
+			where
+				u.group_id = g.id and
+				u.org_id = o.id and
+				u.org_id=$1;`
+
+	if err := mds.db.Select(&users, query, orgId); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return users, nil
+}
+
+func (mds *modelDao) GetUsersByGroup(ctx context.Context,
+	groupId string) ([]model.UserPayload, *model.ApiError) {
+
+	users := []model.UserPayload{}
+	query := `select
+				u.id,
+				u.name,
+				u.email,
+				u.password,
+				u.created_at,
+				u.profile_picture_url,
+				u.org_id,
+				u.group_id,
+				g.name as role,
+				o.name as organization
+			from users u, groups g, organizations o
+			where
+				u.group_id = g.id and
+				o.id = u.org_id and
+				u.group_id=$1;`
+
+	if err := mds.db.Select(&users, query, groupId); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return users, nil
+}
+
+func (mds *modelDao) CreateGroup(ctx context.Context,
+	group *model.Group) (*model.Group, *model.ApiError) {
+
+	group.Id = uuid.NewString()
+
+	q := `INSERT INTO groups (id, name) VALUES ($1, $2);`
+	if _, err := mds.db.ExecContext(ctx, q, group.Id, group.Name); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+
+	return group, nil
+}
+
+func (mds *modelDao) DeleteGroup(ctx context.Context, id string) *model.ApiError {
+
+	if _, err := mds.db.ExecContext(ctx, `DELETE from groups where id=$1;`, id); err != nil {
+		return &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return nil
+}
+
+func (mds *modelDao) GetGroup(ctx context.Context,
+	id string) (*model.Group, *model.ApiError) {
+
+	groups := []model.Group{}
+	if err := mds.db.Select(&groups, `SELECT id, name FROM groups WHERE id=$1`, id); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+
+	if len(groups) > 1 {
+		return nil, &model.ApiError{
+			Typ: model.ErrorInternal,
+			Err: errors.New("Found multiple groups with same ID."),
+		}
+	}
+
+	if len(groups) == 0 {
+		return nil, nil
+	}
+	return &groups[0], nil
+}
+
+func (mds *modelDao) GetGroupByName(ctx context.Context,
+	name string) (*model.Group, *model.ApiError) {
+
+	groups := []model.Group{}
+	if err := mds.db.Select(&groups, `SELECT id, name FROM groups WHERE name=$1`, name); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+
+	if len(groups) > 1 {
+		return nil, &model.ApiError{
+			Typ: model.ErrorInternal,
+			Err: errors.New("Found multiple groups with same name"),
+		}
+	}
+
+	if len(groups) == 0 {
+		return nil, nil
+	}
+
+	return &groups[0], nil
+}
+
+func (mds *modelDao) GetGroups(ctx context.Context) ([]model.Group, *model.ApiError) {
+
+	groups := []model.Group{}
+	if err := mds.db.Select(&groups, "SELECT * FROM groups"); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+
+	return groups, nil
+}
+
+func (mds *modelDao) CreateResetPasswordEntry(ctx context.Context,
+	req *model.ResetPasswordEntry) *model.ApiError {
+
+	q := `INSERT INTO reset_password_request (user_id, token) VALUES ($1, $2);`
+	if _, err := mds.db.ExecContext(ctx, q, req.UserId, req.Token); err != nil {
+		return &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return nil
+}
+
+func (mds *modelDao) DeleteResetPasswordEntry(ctx context.Context,
+	token string) *model.ApiError {
+	_, err := mds.db.ExecContext(ctx, `DELETE from reset_password_request where token=$1;`, token)
+	if err != nil {
+		return &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	return nil
+}
+
+func (mds *modelDao) GetResetPasswordEntry(ctx context.Context,
+	token string) (*model.ResetPasswordEntry, *model.ApiError) {
+
+	entries := []model.ResetPasswordEntry{}
+
+	q := `SELECT user_id, token FROM reset_password_request WHERE token=$1;`
+	if err := mds.db.Select(&entries, q, token); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	if len(entries) > 1 {
+		return nil, &model.ApiError{Typ: model.ErrorInternal,
+			Err: errors.New("Multiple entries for reset token is found")}
+	}
+
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	return &entries[0], nil
+}

--- a/pkg/query-service/main.go
+++ b/pkg/query-service/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"go.signoz.io/query-service/app"
 	"go.signoz.io/query-service/auth"
+	"go.signoz.io/query-service/config"
 	"go.signoz.io/query-service/constants"
 	"go.signoz.io/query-service/version"
 
@@ -33,12 +35,23 @@ func main() {
 	logger := loggerMgr.Sugar()
 	version.PrintVersion()
 
+	qsConfig, err := config.LoadQsConfigFromFile(config.GetDefaultConfigPath())
+	if err != nil {
+		if qsConfig == nil {
+			logger.Fatal(fmt.Sprintf("could not load QS config from path: %s", config.GetDefaultConfigPath()), zap.Error(err))
+		} else {
+			logger.Warn(fmt.Sprintf("could not load QS config from path: %s, loading default config", config.GetDefaultConfigPath()), zap.Error(err))
+			logger.Info("default config selected")
+		}
+	}
+
 	serverOptions := &app.ServerOptions{
 		// HTTPHostPort:   v.GetString(app.HTTPHostPort),
 		// DruidClientUrl: v.GetString(app.DruidClientUrl),
 
 		HTTPHostPort: constants.HTTPHostPort,
 		// DruidClientUrl: constants.DruidClientUrl,
+		QsConfig: qsConfig,
 	}
 
 	// Read the jwt secret key


### PR DESCRIPTION
This PR introduces postgres support in query service. 

**Background**
Query service needs a database for storing user config items like alerts, rules, dashboard settings etc.  Currently, we use sql*lite, which works well for getting users up and running.  Adding postgres support (in addition to sql*lite) will help users to utilize existing PG setups and also enable scalability of query service.

**Issue ref**
#941 

**Development notes**
- A config object QsConfig has been introduced to enable secured config for query service (mainly to secure passwords in config).  This is still work in progress, at the moment only db connection params are included but in future we can unify all the initialisation params for query service here
- CLI parameters have been added (to query service executable) for overriding or setting up db connection params
- Both SQL*Lite and postgres based initialisation methods are used 
- A migration script will be provided to existing users who want to move to postgres.  It is **not** included in this PR though


