### PR TITLE
chore: changed scrape interval to 60s and batch size to 10000

### DIFF
--- a/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
@@ -23,6 +23,7 @@ receivers:
 processors:
   batch:
     send_batch_size: 10000
+    send_batch_max_size: 11000
     timeout: 10s
   signozspanmetrics/prometheus:
     metrics_exporter: prometheus

--- a/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
@@ -12,7 +12,7 @@ receivers:
       grpc:
       thrift_http:
   hostmetrics:
-    collection_interval: 30s
+    collection_interval: 60s
     scrapers:
       cpu:
       load:
@@ -22,7 +22,7 @@ receivers:
       network:
 processors:
   batch:
-    send_batch_size: 1000
+    send_batch_size: 10000
     timeout: 10s
   signozspanmetrics/prometheus:
     metrics_exporter: prometheus

--- a/deploy/docker-swarm/clickhouse-setup/otel-collector-metrics-config.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/otel-collector-metrics-config.yaml
@@ -9,12 +9,12 @@ receivers:
     config:
       scrape_configs:
         - job_name: "otel-collector"
-          scrape_interval: 30s
+          scrape_interval: 60s
           static_configs:
             - targets: ["otel-collector:8889"]
 processors:
   batch:
-    send_batch_size: 1000
+    send_batch_size: 10000
     timeout: 10s
   # memory_limiter:
   #   # 80% of maximum memory up to 2G

--- a/deploy/docker-swarm/clickhouse-setup/otel-collector-metrics-config.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/otel-collector-metrics-config.yaml
@@ -15,6 +15,7 @@ receivers:
 processors:
   batch:
     send_batch_size: 10000
+    send_batch_max_size: 11000
     timeout: 10s
   # memory_limiter:
   #   # 80% of maximum memory up to 2G

--- a/deploy/docker/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker/clickhouse-setup/otel-collector-config.yaml
@@ -23,6 +23,7 @@ receivers:
 processors:
   batch:
     send_batch_size: 10000
+    send_batch_max_size: 11000
     timeout: 10s
   signozspanmetrics/prometheus:
     metrics_exporter: prometheus

--- a/deploy/docker/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker/clickhouse-setup/otel-collector-config.yaml
@@ -12,7 +12,7 @@ receivers:
       grpc:
       thrift_http:
   hostmetrics:
-    collection_interval: 30s
+    collection_interval: 60s
     scrapers:
       cpu:
       load:
@@ -22,7 +22,7 @@ receivers:
       network:
 processors:
   batch:
-    send_batch_size: 1000
+    send_batch_size: 10000
     timeout: 10s
   signozspanmetrics/prometheus:
     metrics_exporter: prometheus

--- a/deploy/docker/clickhouse-setup/otel-collector-metrics-config.yaml
+++ b/deploy/docker/clickhouse-setup/otel-collector-metrics-config.yaml
@@ -9,12 +9,12 @@ receivers:
     config:
       scrape_configs:
         - job_name: "otel-collector"
-          scrape_interval: 30s
+          scrape_interval: 60s
           static_configs:
             - targets: ["otel-collector:8889"]
 processors:
   batch:
-    send_batch_size: 1000
+    send_batch_size: 10000
     timeout: 10s
   # memory_limiter:
   #   # 80% of maximum memory up to 2G

--- a/deploy/docker/clickhouse-setup/otel-collector-metrics-config.yaml
+++ b/deploy/docker/clickhouse-setup/otel-collector-metrics-config.yaml
@@ -15,6 +15,7 @@ receivers:
 processors:
   batch:
     send_batch_size: 10000
+    send_batch_max_size: 11000
     timeout: 10s
   # memory_limiter:
   #   # 80% of maximum memory up to 2G


### PR DESCRIPTION
* Changed hostmetrics scrape interval from 30s to 60s to reduce samples and improve perf
* Changed apm metrics scrape interval from 30s to 60s to reduce samples and improve perf
* Changed batch size of metrics exporter to 10K from 1K
