### PR TITLE
fix: error rate as a percentage of total requests

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -1222,8 +1222,8 @@ func (r *ClickHouseReader) GetServices(ctx context.Context, queryParams *model.G
 			serviceItems[i].Num4XX = val
 		}
 		serviceItems[i].CallRate = float64(serviceItems[i].NumCalls) / float64(queryParams.Period)
-		serviceItems[i].FourXXRate = float64(serviceItems[i].Num4XX) / float64(queryParams.Period)
-		serviceItems[i].ErrorRate = float64(serviceItems[i].NumErrors) / float64(queryParams.Period)
+		serviceItems[i].FourXXRate = float64(serviceItems[i].Num4XX) / float64(serviceItems[i].NumCalls)
+		serviceItems[i].ErrorRate = float64(serviceItems[i].NumErrors) / float64(serviceItems[i].NumCalls)
 	}
 
 	return &serviceItems, nil


### PR DESCRIPTION
Fixes #1389 and part of https://github.com/SigNoz/engineering-pod/issues/540

The overview API which I believe is no longer used had same as this.

https://github.com/SigNoz/signoz/blob/7aeaecaf1f2e60a12e111d45bf246e4b35b64fd5/pkg/query-service/app/clickhouseReader/reader.go#L1279-L1282