### PR TITLE
fix: resolved issue with promql rule creation

### DIFF
--- a/frontend/src/container/FormAlertRules/index.tsx
+++ b/frontend/src/container/FormAlertRules/index.tsx
@@ -177,25 +177,26 @@ function FormAlertRules({
 			return false;
 		}
 
-		Object.keys(metricQueries).forEach((key) => {
-			if (metricQueries[key].metricName === '') {
-				retval = false;
-				notification.error({
-					message: 'Error',
-					description: t('metricname_missing', { where: metricQueries[key].name }),
-				});
-			}
-		});
-
-		Object.keys(formulaQueries).forEach((key) => {
-			if (formulaQueries[key].expression === '') {
-				retval = false;
-				notification.error({
-					message: 'Error',
-					description: t('expression_missing', formulaQueries[key].name),
-				});
-			}
-		});
+		if (queryCategory === EQueryType.QUERY_BUILDER) {
+			Object.keys(metricQueries).forEach((key) => {
+				if (metricQueries[key].metricName === '') {
+					retval = false;
+					notification.error({
+						message: 'Error',
+						description: t('metricname_missing', { where: metricQueries[key].name }),
+					});
+				}
+			});
+			Object.keys(formulaQueries).forEach((key) => {
+				if (formulaQueries[key].expression === '') {
+					retval = false;
+					notification.error({
+						message: 'Error',
+						description: t('expression_missing', formulaQueries[key].name),
+					});
+				}
+			});
+		}
 
 		return retval;
 	}, [t, alertDef, queryCategory, metricQueries, formulaQueries, promQueries]);
@@ -235,7 +236,7 @@ function FormAlertRules({
 					description:
 						!ruleId || ruleId === 0 ? t('rule_created') : t('rule_edited'),
 				});
-				console.log('invalidting cache');
+
 				// invalidate rule in cache
 				ruleCache.invalidateQueries(['ruleId', ruleId]);
 


### PR DESCRIPTION
This PR solves [issue#575](https://github.com/SigNoz/engineering-pod/issues/575) in v0.10.0 which blocks creation of promql rule, when metric name field is empty. 

The current work around is set select a metric name in query builder tab and then proceed to edit promql tab and save promql rule.

 