### PR TITLE
feat(swarm): 🚀 scraping multiple otel-collector

### DIFF
--- a/deploy/docker-swarm/clickhouse-setup/otel-collector-metrics-config.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/otel-collector-metrics-config.yaml
@@ -5,9 +5,11 @@ receivers:
         # otel-collector internal metrics
         - job_name: "otel-collector"
           scrape_interval: 60s
-          static_configs:
-            - targets:
-              - otel-collector:8888
+          dns_sd_configs:
+            - names:
+                - 'tasks.otel-collector'
+              type: 'A'
+              port: 8888
         # otel-collector-metrics internal metrics
         - job_name: "otel-collector-metrics"
           scrape_interval: 60s
@@ -17,9 +19,11 @@ receivers:
         # SigNoz span metrics
         - job_name: "signozspanmetrics-collector"
           scrape_interval: 60s
-          static_configs:
-            - targets:
-              - otel-collector:8889
+          dns_sd_configs:
+            - names:
+                - 'tasks.otel-collector'
+              type: 'A'
+              port: 8889
 
 processors:
   batch:


### PR DESCRIPTION
Related to #1377

After adding following changes, able to see 3 service instance for `service_instance_id`:

![Screenshot from 2022-07-26 03-01-04](https://user-images.githubusercontent.com/11138844/180931515-7e3e7969-0a17-4cb3-ad9c-ec33db154247.png)

Signed-off-by: Prashant Shahi <prashant@signoz.io>