### PR TITLE
Remove query-service code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@
 * @ankitnayan
 /frontend/ @palashgdev @pranshuchittora
 /deploy/ @prashant-shahi
+/pkg/query-service/ @srikanthccv

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,3 @@
 * @ankitnayan
 /frontend/ @palashgdev @pranshuchittora
 /deploy/ @prashant-shahi
-/pkg/query-service/ @srikanthccv @makeavish @nityanandagohain


### PR DESCRIPTION
Removing query-service code owners temporarily. Code owners will be added by after project structure is restructured for logs, traces and metrics separately.