### PR TITLE
[WIP] fix(query-service): 🚀 embed copy of timezone data

### DIFF
--- a/pkg/query-service/Dockerfile
+++ b/pkg/query-service/Dockerfile
@@ -20,7 +20,7 @@ RUN go mod download -x
 
 # Add the sources and proceed with build
 ADD . .
-RUN go build -a -ldflags "-linkmode external -extldflags '-static' -s -w $LD_FLAGS" -o ./bin/query-service ./main.go
+RUN go build -tags timetzdata -a -ldflags "-linkmode external -extldflags '-static' -s -w $LD_FLAGS" -o ./bin/query-service ./main.go
 RUN chmod +x ./bin/query-service
 
 


### PR DESCRIPTION
Fixes #1460

Another alternative to this would be adding `_ "time/tzdata"` import, however since this issue only affects external ClickHouse with timezone, we can opt for including tzdata at build time.

References:
- https://pkg.go.dev/time/tzdata
- https://wawand.co/blog/posts/timezonedata-go115-7c2a25e7-dbdd-4b6b-8092-51cc2d0241ce/

Signed-off-by: Prashant Shahi <prashant@signoz.io>