### PR TITLE
Alerts/607 test notifications UI

### DIFF
--- a/frontend/public/locales/en-GB/alerts.json
+++ b/frontend/public/locales/en-GB/alerts.json
@@ -1,4 +1,8 @@
 {
+  "target_missing": "Please enter a threshold to proceed",
+  "rule_test_fired": "Test notification sent successfully",
+  "no_alerts_found": "No alerts found during the evaluation. This happens when rule condition is unsatisfied. You may adjust the rule threshold and retry.",
+  "button_testrule": "Test Notification",
   "label_channel_select": "Notification Channels",
   "placeholder_channel_select": "select one or more channels",
   "channel_select_tooltip": "Leave empty to send this alert on all the configured channels",

--- a/frontend/public/locales/en/alerts.json
+++ b/frontend/public/locales/en/alerts.json
@@ -1,4 +1,8 @@
 {
+  "target_missing": "Please enter a threshold to proceed",
+  "rule_test_fired": "Test notification sent successfully",
+  "no_alerts_found": "No alerts found during the evaluation. This happens when rule condition is unsatisfied. You may adjust the rule threshold and retry.",
+  "button_testrule": "Test Notification",
   "label_channel_select": "Notification Channels",
   "placeholder_channel_select": "select one or more channels",
   "channel_select_tooltip": "Leave empty to send this alert on all the configured channels",

--- a/frontend/src/api/alerts/testAlert.ts
+++ b/frontend/src/api/alerts/testAlert.ts
@@ -1,0 +1,26 @@
+import axios from 'api';
+import { ErrorResponseHandler } from 'api/ErrorResponseHandler';
+import { AxiosError } from 'axios';
+import { ErrorResponse, SuccessResponse } from 'types/api';
+import { PayloadProps, Props } from 'types/api/alerts/testAlert';
+
+const testAlert = async (
+	props: Props,
+): Promise<SuccessResponse<PayloadProps> | ErrorResponse> => {
+	try {
+		const response = await axios.post('/testRule', {
+			...props.data,
+		});
+
+		return {
+			statusCode: 200,
+			error: null,
+			message: response.data.status,
+			payload: response.data.data,
+		};
+	} catch (error) {
+		return ErrorResponseHandler(error as AxiosError);
+	}
+};
+
+export default testAlert;

--- a/frontend/src/container/FormAlertRules/ChartPreview/index.tsx
+++ b/frontend/src/container/FormAlertRules/ChartPreview/index.tsx
@@ -21,7 +21,7 @@ export interface ChartPreviewProps {
 	selectedTime?: timePreferenceType;
 	selectedInterval?: Time;
 	headline?: JSX.Element;
-	threshold?: number;
+	threshold?: number | undefined;
 }
 
 function ChartPreview({
@@ -35,7 +35,7 @@ function ChartPreview({
 }: ChartPreviewProps): JSX.Element | null {
 	const { t } = useTranslation('alerts');
 	const staticLine: StaticLineProps | undefined =
-		threshold && threshold > 0
+		threshold !== undefined
 			? {
 					yMin: threshold,
 					yMax: threshold,
@@ -117,7 +117,7 @@ ChartPreview.defaultProps = {
 	selectedTime: 'GLOBAL_TIME',
 	selectedInterval: '5min',
 	headline: undefined,
-	threshold: 0,
+	threshold: undefined,
 };
 
 export default ChartPreview;

--- a/frontend/src/container/FormAlertRules/RuleOptions.tsx
+++ b/frontend/src/container/FormAlertRules/RuleOptions.tsx
@@ -152,6 +152,7 @@ function RuleOptions({
 						addonBefore={t('field_threshold')}
 						value={alertDef?.condition?.target}
 						onChange={(value: number | unknown): void => {
+							console.log('setting target:', value);
 							setAlertDef({
 								...alertDef,
 								condition: {

--- a/frontend/src/container/FormAlertRules/RuleOptions.tsx
+++ b/frontend/src/container/FormAlertRules/RuleOptions.tsx
@@ -152,12 +152,11 @@ function RuleOptions({
 						addonBefore={t('field_threshold')}
 						value={alertDef?.condition?.target}
 						onChange={(value: number | unknown): void => {
-							console.log('setting target:', value);
 							setAlertDef({
 								...alertDef,
 								condition: {
 									...alertDef.condition,
-									target: (value as number) || undefined,
+									target: value as number,
 								},
 							});
 						}}

--- a/frontend/src/types/api/alerts/testAlert.ts
+++ b/frontend/src/types/api/alerts/testAlert.ts
@@ -1,0 +1,10 @@
+import { AlertDef } from 'types/api/alerts/def';
+
+export interface Props {
+	data: AlertDef;
+}
+
+export interface PayloadProps {
+	alertCount: number;
+	message: string;
+}

--- a/pkg/query-service/Dockerfile
+++ b/pkg/query-service/Dockerfile
@@ -20,7 +20,7 @@ RUN go mod download -x
 
 # Add the sources and proceed with build
 ADD . .
-RUN go build -a -ldflags "-linkmode external -extldflags '-static' -s -w $LD_FLAGS" -o ./bin/query-service ./main.go
+RUN go build -tags timetzdata -a -ldflags "-linkmode external -extldflags '-static' -s -w $LD_FLAGS" -o ./bin/query-service ./main.go
 RUN chmod +x ./bin/query-service
 
 


### PR DESCRIPTION
This PR primarily solves [#607 Users should be able to Test Notifications after setting an alert](https://github.com/SigNoz/engineering-pod/issues/607) 

Changes:
- Added testAlert API call
- Added test notification handler in rule create/edit pages
- Improved on validation of api params for query builder and prom queries 
- improved display of threshold line - it wasn't showing up for 0 values 