### PR TITLE
fix: resolves issue for migrated promql

### DIFF
--- a/frontend/src/container/FormAlertRules/RuleOptions.tsx
+++ b/frontend/src/container/FormAlertRules/RuleOptions.tsx
@@ -156,6 +156,8 @@ function RuleOptions({
 								...alertDef,
 								condition: {
 									...alertDef.condition,
+									op: alertDef.condition?.op || defaultCompareOp,
+									matchType: alertDef.condition?.matchType || defaultMatchType,
 									target: value as number,
 								},
 							});


### PR DESCRIPTION
This PR solves issue with migrated PromQL. 
**background**
When a user first time sets threshold for a migrated PromQL rule (i.e. moves the condition like > 100 to rule options "send a notification when metric is Above the alerting threshold of 100 at least once", the test notification does not work. 

This is also likely to cause  issue with rule execution.

The problem is - in the UI, user does not set matchType (at least once) and compare op (e.g. above) explicitly and it is not defaulted as well.  This is not a problem with newly created rules as we default those 2 fields in the data. 

**Solution**
The UI defaults the match type (at least once) and compare op (e.g. above) when the threshold is set for the first time. 

