### PR TITLE
clickhouse logs exporter added to deployment file

### DIFF
--- a/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
@@ -81,14 +81,16 @@ services:
       - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
 
   otel-collector:
-    image: signoz/otelcontribcol:0.45.1-1.3
+    image: signoz-otel-collector:0.55.0-rc.3
     command: ["--config=/etc/otel-collector-config.yaml"]
+    # user: root # required for reading docker container logs
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
     ports:
       # - "1777:1777"     # pprof extension
       - "4317:4317"     # OTLP gRPC receiver
       - "4318:4318"     # OTLP HTTP receiver
+      - "4319:4319"     # OTLP logs receiver
       # - "8888:8888"     # OtelCollector internal metrics
       # - "8889:8889"     # signoz spanmetrics exposed by the agent
       # - "9411:9411"     # Zipkin port
@@ -111,7 +113,7 @@ services:
       - clickhouse
 
   otel-collector-metrics:
-    image: signoz/otelcontribcol:0.45.1-1.3
+    image: signoz-otel-collector:0.55.0-rc.3
     command: ["--config=/etc/otel-collector-metrics-config.yaml"]
     volumes:
       - ./otel-collector-metrics-config.yaml:/etc/otel-collector-metrics-config.yaml

--- a/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
@@ -30,6 +30,10 @@ receivers:
       disk: {}
       filesystem: {}
       network: {}
+  otlp/logs:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4319
 
 processors:
   batch:
@@ -76,6 +80,16 @@ exporters:
   prometheus:
     endpoint: 0.0.0.0:8889
   # logging: {}
+  clickhouselogsexporter:
+    dsn: tcp://clickhouse:9000/
+    timeout: 5s
+    sending_queue:
+      queue_size: 100
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
 
 extensions:
   health_check:
@@ -106,3 +120,7 @@ service:
     metrics/spanmetrics:
       receivers: [otlp/spanmetrics]
       exporters: [prometheus]
+    logs:
+      receivers: [otlp/logs]
+      processors: [batch]
+      exporters: [clickhouselogsexporter]

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -78,7 +78,7 @@ services:
       - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
 
   otel-collector:
-    image: signoz/otelcontribcol:0.45.1-1.3
+    image: signoz/signoz-otel-collector:0.55.0-rc.2
     command: ["--config=/etc/otel-collector-config.yaml"]
     # user: root # required for reading docker container logs
     volumes:
@@ -89,6 +89,7 @@ services:
       # - "1777:1777"     # pprof extension
       - "4317:4317"     # OTLP gRPC receiver
       - "4318:4318"     # OTLP HTTP receiver
+      - "4319:4319"     # OTLP logs receiver
       # - "8888:8888"     # OtelCollector internal metrics
       # - "8889:8889"     # signoz spanmetrics exposed by the agent
       # - "9411:9411"     # Zipkin port

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -80,6 +80,7 @@ services:
   otel-collector:
     image: signoz/otelcontribcol:0.45.1-1.3
     command: ["--config=/etc/otel-collector-config.yaml"]
+    # user: root # required for reading docker container logs
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
     environment:

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -78,7 +78,7 @@ services:
       - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
 
   otel-collector:
-    image: signoz/signoz-otel-collector:0.55.0-rc.2
+    image: signoz/signoz-otel-collector:0.55.0-rc.3
     command: ["--config=/etc/otel-collector-config.yaml"]
     # user: root # required for reading docker container logs
     volumes:
@@ -105,7 +105,7 @@ services:
         condition: service_healthy
 
   otel-collector-metrics:
-    image: signoz/otelcontribcol:0.45.1-1.3
+    image: signoz/signoz-otel-collector:0.55.0-rc.3
     command: ["--config=/etc/otel-collector-metrics-config.yaml"]
     volumes:
       - ./otel-collector-metrics-config.yaml:/etc/otel-collector-metrics-config.yaml

--- a/deploy/docker/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker/clickhouse-setup/otel-collector-config.yaml
@@ -92,8 +92,7 @@ exporters:
 
   # uncomment the exporter below to export logs
   # clickhouselogsexporter:
-  #   dsn: tcp://localhost:9000 
-  #   # ttl_days: 3
+  #   dsn: tcp://clickhouse:9000/
   #   timeout: 5s
   #   sending_queue:
   #     queue_size: 100

--- a/deploy/docker/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker/clickhouse-setup/otel-collector-config.yaml
@@ -31,11 +31,10 @@ receivers:
       filesystem: {}
       network: {}
 
-  # uncomment the reciever below to recieve logs in OLTP
-  # otlp/logs:
-  #   protocols:
-  #     grpc:
-  #       endpoint: 0.0.0.0:4319
+  otlp/logs:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4319
 
 processors:
   batch:
@@ -91,17 +90,16 @@ exporters:
     endpoint: 0.0.0.0:8889
   # logging: {}
 
-  # uncomment the exporter below to export logs
-  # clickhouselogsexporter:
-  #   dsn: tcp://clickhouse:9000/
-  #   timeout: 5s
-  #   sending_queue:
-  #     queue_size: 100
-  #   retry_on_failure:
-  #     enabled: true
-  #     initial_interval: 5s
-  #     max_interval: 30s
-  #     max_elapsed_time: 300s
+  clickhouselogsexporter:
+    dsn: tcp://clickhouse:9000/
+    timeout: 5s
+    sending_queue:
+      queue_size: 100
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
 
 service:
   telemetry:
@@ -127,8 +125,7 @@ service:
     metrics/spanmetrics:
       receivers: [otlp/spanmetrics]
       exporters: [prometheus]
-    # uncomment the pipeline below for logs
-    # logs:
-    #   receivers: [ otlp/logs ]
-    #   processors: [ batch ]
-    #   exporters: [  clickhouselogsexporter ]
+    logs:
+      receivers: [ otlp/logs ]
+      processors: [ batch ]
+      exporters: [  clickhouselogsexporter ]

--- a/deploy/docker/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker/clickhouse-setup/otel-collector-config.yaml
@@ -89,6 +89,7 @@ exporters:
       enabled: true
   prometheus:
     endpoint: 0.0.0.0:8889
+  # logging: {}
 
   # uncomment the exporter below to export logs
   # clickhouselogsexporter:

--- a/deploy/docker/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker/clickhouse-setup/otel-collector-config.yaml
@@ -31,6 +31,12 @@ receivers:
       filesystem: {}
       network: {}
 
+  # uncomment the reciever below to recieve logs in OLTP
+  # otlp/logs:
+  #   protocols:
+  #     grpc:
+  #       endpoint: 0.0.0.0:4319
+
 processors:
   batch:
     send_batch_size: 10000
@@ -83,7 +89,19 @@ exporters:
       enabled: true
   prometheus:
     endpoint: 0.0.0.0:8889
-  # logging: {}
+
+  # uncomment the exporter below to export logs
+  # clickhouselogsexporter:
+  #   dsn: tcp://localhost:9000 
+  #   # ttl_days: 3
+  #   timeout: 5s
+  #   sending_queue:
+  #     queue_size: 100
+  #   retry_on_failure:
+  #     enabled: true
+  #     initial_interval: 5s
+  #     max_interval: 30s
+  #     max_elapsed_time: 300s
 
 service:
   telemetry:
@@ -109,3 +127,8 @@ service:
     metrics/spanmetrics:
       receivers: [otlp/spanmetrics]
       exporters: [prometheus]
+    # uncomment the pipeline below for logs
+    # logs:
+    #   receivers: [ otlp/logs ]
+    #   processors: [ batch ]
+    #   exporters: [  clickhouselogsexporter ]

--- a/deploy/docker/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker/clickhouse-setup/otel-collector-config.yaml
@@ -126,6 +126,6 @@ service:
       receivers: [otlp/spanmetrics]
       exporters: [prometheus]
     logs:
-      receivers: [ otlp/logs ]
-      processors: [ batch ]
-      exporters: [  clickhouselogsexporter ]
+      receivers: [otlp/logs]
+      processors: [batch]
+      exporters: [clickhouselogsexporter]

--- a/pkg/query-service/tests/test-deploy/docker-compose.yaml
+++ b/pkg/query-service/tests/test-deploy/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
         condition: service_healthy
 
   otel-collector:
-    image: signoz/otelcontribcol:0.45.1-1.3
+    image: signoz-otel-collector:0.55.0-rc.3
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
@@ -74,7 +74,7 @@ services:
         condition: service_healthy
 
   otel-collector-metrics:
-    image: signoz/otelcontribcol:0.45.1-1.3
+    image: signoz-otel-collector:0.55.0-rc.3
     command: ["--config=/etc/otel-collector-metrics-config.yaml"]
     volumes:
       - ./otel-collector-metrics-config.yaml:/etc/otel-collector-metrics-config.yaml


### PR DESCRIPTION
The exporter for logs is added but is commented out since it might change based on user requirement.