### PR TITLE
single otlp receiver

### DIFF
--- a/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
@@ -90,7 +90,6 @@ services:
       # - "1777:1777"     # pprof extension
       - "4317:4317"     # OTLP gRPC receiver
       - "4318:4318"     # OTLP HTTP receiver
-      - "4319:4319"     # OTLP logs receiver
       # - "8888:8888"     # OtelCollector internal metrics
       # - "8889:8889"     # signoz spanmetrics exposed by the agent
       # - "9411:9411"     # Zipkin port

--- a/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
@@ -30,10 +30,6 @@ receivers:
       disk: {}
       filesystem: {}
       network: {}
-  otlp/logs:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4319
 
 processors:
   batch:
@@ -121,6 +117,6 @@ service:
       receivers: [otlp/spanmetrics]
       exporters: [prometheus]
     logs:
-      receivers: [otlp/logs]
+      receivers: [otlp]
       processors: [batch]
       exporters: [clickhouselogsexporter]

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -89,7 +89,6 @@ services:
       # - "1777:1777"     # pprof extension
       - "4317:4317"     # OTLP gRPC receiver
       - "4318:4318"     # OTLP HTTP receiver
-      - "4319:4319"     # OTLP logs receiver
       # - "8888:8888"     # OtelCollector internal metrics
       # - "8889:8889"     # signoz spanmetrics exposed by the agent
       # - "9411:9411"     # Zipkin port

--- a/deploy/docker/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker/clickhouse-setup/otel-collector-config.yaml
@@ -31,11 +31,6 @@ receivers:
       filesystem: {}
       network: {}
 
-  otlp/logs:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4319
-
 processors:
   batch:
     send_batch_size: 10000
@@ -126,6 +121,6 @@ service:
       receivers: [otlp/spanmetrics]
       exporters: [prometheus]
     logs:
-      receivers: [otlp/logs]
+      receivers: [otlp]
       processors: [batch]
       exporters: [clickhouselogsexporter]


### PR DESCRIPTION
Instead of using a different OTLP receiver for logs use a single one.