### PR TITLE
docs: Remove `arm64` processors instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,9 +244,10 @@ Please ping us in the [`#contributing`](https://signoz-community.slack.com/archi
     ```
 to set your local environment with the right `RELATIONAL_DATASOURCE_PATH` as mentioned in [`./constants/constants.go#L38`,](https://github.com/SigNoz/signoz/blob/develop/pkg/query-service/constants/constants.go#L38)
 
-- Now, install SigNoz locally **without** the `frontend` and `query-service`,
-  - If you are using `x86_64` processors (All Intel/AMD processors) run `sudo make run-x86`
-  - If you are on `arm64` processors (Apple M1 Macs) run `sudo make run-arm`
+- Now, install SigNoz locally **without** the `frontend` and `query-service`:
+  ```
+  sudo make run-x86
+  ```
 
 #### Run locally,
 ```

--- a/pkg/query-service/README.md
+++ b/pkg/query-service/README.md
@@ -28,12 +28,11 @@ alertmanager:
       - --queryService.url=http://172.17.0.1:8085
       - --storage.path=/data
 ```
-- Run the following:
-```console
-cd signoz/
-If you are using x86_64 processors (All Intel/AMD processors) run sudo make run-x86
-If you are on arm64 processors (Apple M1 Macs) run sudo make run-arm
-```
+- Run following commands:
+    ```bash
+    cd signoz/
+    sudo make run-x86
+    ```
 
 #### Backend Configuration
 


### PR DESCRIPTION
`run-arm` doesn't exists and it will give error when running. PR https://github.com/SigNoz/signoz/pull/1340 removes it so I guess it no longer needed.