### PR TITLE
feat(devbox): splitting docker-compose.yaml into core and prod / local for no-edit local setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,22 +91,15 @@ down-local:
 	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml -f $(STANDALONE_DIRECTORY)/docker-compose-local.yaml \
 	down -v
 
-run-prod:
+run-x86:
 	@docker-compose -f \
 	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml -f $(STANDALONE_DIRECTORY)/docker-compose-prod.yaml \
 	up --build -d
 
-down-prod:
+down-x86:
 	@docker-compose -f \
 	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml -f $(STANDALONE_DIRECTORY)/docker-compose-prod.yaml \
 	down -v
-
-run-x86:
-	@docker-compose -f $(STANDALONE_DIRECTORY)/docker-compose-core.yaml \
-	-f $(STANDALONE_DIRECTORY)/docker-compose-prod.yaml up -d
-
-down-x86:
-	@docker-compose -f $(STANDALONE_DIRECTORY)/docker-compose.yaml down -v
 
 clear-standalone-data:
 	@docker run --rm -v "$(PWD)/$(STANDALONE_DIRECTORY)/data:/pwd" busybox \

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,16 @@ down-local:
 	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml -f $(STANDALONE_DIRECTORY)/docker-compose-local.yaml \
 	down -v
 
+run-prod:
+	@docker-compose -f \
+	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml -f $(STANDALONE_DIRECTORY)/docker-compose-prod.yaml \
+	up --build -d
+
+down-prod:
+	@docker-compose -f \
+	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml -f $(STANDALONE_DIRECTORY)/docker-compose-prod.yaml \
+	down -v
+
 run-x86:
 	@docker-compose -f $(STANDALONE_DIRECTORY)/docker-compose-core.yaml \
 	-f $(STANDALONE_DIRECTORY)/docker-compose-prod.yaml up -d

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ FRONTEND_DIRECTORY ?= frontend
 QUERY_SERVICE_DIRECTORY ?= pkg/query-service
 STANDALONE_DIRECTORY ?= deploy/docker/clickhouse-setup
 SWARM_DIRECTORY ?= deploy/docker-swarm/clickhouse-setup
+LOCAL_GOOS ?= $(shell go env GOOS)
+LOCAL_GOARCH ?= $(shell go env GOARCH)
 
 REPONAME ?= signoz
 DOCKER_TAG ?= latest
@@ -79,8 +81,19 @@ dev-setup:
 	@echo "--> Local Setup completed"
 	@echo "------------------"
 
+run-local:
+	@LOCAL_GOOS=$(LOCAL_GOOS) LOCAL_GOARCH=$(LOCAL_GOARCH) docker-compose -f \
+	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml -f $(STANDALONE_DIRECTORY)/docker-compose-local.yaml \
+	up --build -d
+
+down-local:
+	@docker-compose -f \
+	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml -f $(STANDALONE_DIRECTORY)/docker-compose-local.yaml \
+	down -v
+
 run-x86:
-	@docker-compose -f $(STANDALONE_DIRECTORY)/docker-compose.yaml up -d
+	@docker-compose -f $(STANDALONE_DIRECTORY)/docker-compose-core.yaml \
+	-f $(STANDALONE_DIRECTORY)/docker-compose-prod.yaml up -d
 
 down-x86:
 	@docker-compose -f $(STANDALONE_DIRECTORY)/docker-compose.yaml down -v

--- a/deploy/docker/clickhouse-setup/docker-compose-core.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose-core.yaml
@@ -1,0 +1,109 @@
+version: "2.4"
+
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:22.4.5-alpine
+    container_name: clickhouse
+    # ports:
+    # - "9000:9000"
+    # - "8123:8123"
+    tty: true
+    volumes:
+      - ./clickhouse-config.xml:/etc/clickhouse-server/config.xml
+      - ./clickhouse-users.xml:/etc/clickhouse-server/users.xml
+      # - ./clickhouse-storage.xml:/etc/clickhouse-server/config.d/storage.xml
+      - ./data/clickhouse/:/var/lib/clickhouse/
+    restart: on-failure
+    logging:
+      options:
+        max-size: 50m
+        max-file: "3"
+    healthcheck:
+      # "clickhouse", "client", "-u ${CLICKHOUSE_USER}", "--password ${CLICKHOUSE_PASSWORD}", "-q 'SELECT 1'"
+      test: ["CMD", "wget", "--spider", "-q", "localhost:8123/ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  alertmanager:
+    container_name: alertmanager
+    image: signoz/alertmanager:0.23.0-0.2
+    volumes:
+      - ./data/alertmanager:/data
+    depends_on:
+      query-service:
+        condition: service_healthy
+    restart: on-failure
+    command:
+      - --queryService.url=http://query-service:8085
+      - --storage.path=/data
+
+  # Notes for Maintainers/Contributors who will change Line Numbers of Frontend & Query-Section. Please Update Line Numbers in `./scripts/commentLinesForSetup.sh` & `./CONTRIBUTING.md`
+  otel-collector:
+    container_name: otel-collector
+    image: signoz/signoz-otel-collector:0.55.0-rc.3
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    # user: root # required for reading docker container logs
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    environment:
+      - OTEL_RESOURCE_ATTRIBUTES=host.name=signoz-host,os.type=linux
+    ports:
+      # - "1777:1777"     # pprof extension
+      - "4317:4317"     # OTLP gRPC receiver
+      - "4318:4318"     # OTLP HTTP receiver
+      # - "8888:8888"     # OtelCollector internal metrics
+      # - "8889:8889"     # signoz spanmetrics exposed by the agent
+      # - "9411:9411"     # Zipkin port
+      # - "13133:13133"   # health check extension
+      # - "14250:14250"   # Jaeger gRPC
+      # - "14268:14268"   # Jaeger thrift HTTP
+      # - "55678:55678"   # OpenCensus receiver
+      # - "55679:55679"   # zPages extension
+    mem_limit: 2000m
+    restart: on-failure
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+
+  otel-collector-metrics:
+    container_name: otel-collector-metrics
+    image: signoz/signoz-otel-collector:0.55.0-rc.3
+    command: ["--config=/etc/otel-collector-metrics-config.yaml"]
+    volumes:
+      - ./otel-collector-metrics-config.yaml:/etc/otel-collector-metrics-config.yaml
+    # ports:
+    #   - "1777:1777"     # pprof extension
+    #   - "8888:8888"     # OtelCollector internal metrics
+    #   - "13133:13133"   # Health check extension
+    #   - "55679:55679"   # zPages extension
+    restart: on-failure
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+
+  hotrod:
+    image: jaegertracing/example-hotrod:1.30
+    container_name: hotrod
+    logging:
+      options:
+        max-size: 50m
+        max-file: "3"
+    command: ["all"]
+    environment:
+      - JAEGER_ENDPOINT=http://otel-collector:14268/api/traces
+
+  load-hotrod:
+    image: "grubykarol/locust:1.2.3-python3.9-alpine3.12"
+    container_name: load-hotrod
+    hostname: load-hotrod
+    environment:
+      ATTACKED_HOST: http://hotrod:8080
+      LOCUST_MODE: standalone
+      NO_PROXY: standalone
+      TASK_DELAY_FROM: 5
+      TASK_DELAY_TO: 30
+      QUIET_MODE: "${QUIET_MODE:-false}"
+      LOCUST_OPTS: "--headless -u 10 -r 1"
+    volumes:
+      - ../common/locust-scripts:/locust

--- a/deploy/docker/clickhouse-setup/docker-compose-local.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose-local.yaml
@@ -1,0 +1,51 @@
+version: "2.4"
+
+services:
+  query-service:
+    hostname: query-service
+    build:
+      context: "../../../pkg/query-service"
+      dockerfile: "./Dockerfile"
+      args:
+        LDFLAGS: ""
+        TARGETPLATFORM: "${LOCAL_GOOS}/${LOCAL_GOARCH}"
+    container_name: query-service
+    environment:
+      - ClickHouseUrl=tcp://clickhouse:9000
+      - STORAGE=clickhouse
+      - SIGNOZ_LOCAL_DB_PATH=/root/signoz.db
+    volumes:
+      - ./prometheus.yml:/root/config/prometheus.yml
+      - ../dashboards:/root/config/dashboards
+    command: ["-config=/root/config/prometheus.yml"]
+    ports:
+      - "6060:6060"
+      - "8080:8080"
+    restart: on-failure
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "localhost:8080/api/v1/version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: "../../../frontend"
+      dockerfile: "./Dockerfile"
+      args:
+        TARGETOS: "${LOCAL_GOOS}"
+        TARGETPLATFORM: "${LOCAL_GOARCH}"
+    container_name: frontend
+    environment:
+      - FRONTEND_API_ENDPOINT=http://query-service:8080
+    restart: on-failure
+    depends_on:
+      - alertmanager
+      - query-service
+    ports:
+      - "3301:3301"
+    volumes:
+      - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf

--- a/deploy/docker/clickhouse-setup/docker-compose-prod.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose-prod.yaml
@@ -1,0 +1,41 @@
+version: "2.4"
+
+services:
+  query-service:
+    image: signoz/query-service:0.10.2
+    container_name: query-service
+    command: ["-config=/root/config/prometheus.yml"]
+    # ports:
+    #   - "6060:6060"     # pprof port
+    #   - "8080:8080"     # query-service port
+    volumes:
+      - ./prometheus.yml:/root/config/prometheus.yml
+      - ../dashboards:/root/config/dashboards
+      - ./data/signoz/:/var/lib/signoz/
+    environment:
+      - ClickHouseUrl=tcp://clickhouse:9000/?database=signoz_traces
+      - STORAGE=clickhouse
+      - GODEBUG=netdns=go
+      - TELEMETRY_ENABLED=true
+      - DEPLOYMENT_TYPE=docker-standalone-amd
+    restart: on-failure
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "localhost:8080/api/v1/version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+
+  frontend:
+    image: signoz/frontend:0.10.2
+    container_name: frontend
+    restart: on-failure
+    depends_on:
+      - alertmanager
+      - query-service
+    ports:
+      - "3301:3301"
+    volumes:
+      - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf


### PR DESCRIPTION
**Overview**: This diff breaks the `docker-compose.yaml` file into `docker-compose-core.yaml` and `docker-compose-prod/local.yaml` to allow building and running SigNoz from source (with `make run-local`) without editing anything. Addresses #1529 .
 
**Requirement:** Existing setup instructions in CONTRIBUTING.md needs developers to edit existing `docker-compose.yaml` files in order to setup SigNoz and getting it to work locally. This was painful to me as a first-time contributor, as I faced the following issues:
- Had to edit `docker-compose.yaml`. 
- Had to add multiple `.env` files (each for frontend and query service)
- Had to setup YARN as a non-frontend developer on an M1 machine - which took time as setting up node compiles everything from scratch. 
- `alertmanager` service depends on `query-service` but if according to local instructions, highlighting it away also needed to remove the `depends_on` requirement locally.

Developers should be able to start the service locally and start contributing right away without creating changes which are not supposed to be in the main branch. 

**Changes**: 
Main problem is having a single `docker-compose.yaml` - which is supposed to have a "local" version of frontend and query-service. Editing is required because we need to make to make the rest of services work with our "local" versions. This can be solved by splitting the `docker-compose.yaml` into `core` and env-specific files. 

That way - first-time contributors don't need to do any edits to make SigNoz run / build from source. 