### PR TITLE
fix: reuse the query engine and storage for alerts pqlEngine

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -94,6 +94,7 @@ type ClickHouseReader struct {
 	logsResourceKeys        string
 	queryEngine             *promql.Engine
 	remoteStorage           *remote.Storage
+	fanoutStorage           *storage.Storage
 
 	promConfigFile string
 	promConfig     *config.Config
@@ -311,12 +312,21 @@ func (r *ClickHouseReader) Start() {
 	}
 	r.queryEngine = queryEngine
 	r.remoteStorage = remoteStorage
+	r.fanoutStorage = &fanoutStorage
 
 	if err := g.Run(); err != nil {
 		level.Error(logger).Log("err", err)
 		os.Exit(1)
 	}
 
+}
+
+func (r *ClickHouseReader) GetQueryEngine() *promql.Engine {
+	return r.queryEngine
+}
+
+func (r *ClickHouseReader) GetFanoutStorage() *storage.Storage {
+	return r.fanoutStorage
 }
 
 func reloadConfig(filename string, logger log.Logger, rls ...func(*config.Config) error) (promConfig *config.Config, err error) {

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -144,7 +144,7 @@ func NewReader(localDB *sqlx.DB, configFile string) *ClickHouseReader {
 	}
 }
 
-func (r *ClickHouseReader) Start() {
+func (r *ClickHouseReader) Start(readerReady chan bool) {
 	logLevel := promlog.AllowedLevel{}
 	logLevel.Set("debug")
 	// allowedFormat := promlog.AllowedFormat{}
@@ -313,6 +313,7 @@ func (r *ClickHouseReader) Start() {
 	r.queryEngine = queryEngine
 	r.remoteStorage = remoteStorage
 	r.fanoutStorage = &fanoutStorage
+	readerReady <- true
 
 	if err := g.Run(); err != nil {
 		level.Error(logger).Log("err", err)

--- a/pkg/query-service/app/parser/metrics.go
+++ b/pkg/query-service/app/parser/metrics.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"go.signoz.io/query-service/app/metrics"
 	"go.signoz.io/query-service/model"
@@ -25,29 +24,6 @@ func validateQueryRangeParamsV2(qp *model.QueryRangeParamsV2) error {
 		return fmt.Errorf("one or more errors found : %s", metrics.FormatErrs(errs, ","))
 	}
 	return nil
-}
-
-// FormattedValue formats the value to be used in clickhouse query
-func PromFormattedValue(v interface{}) string {
-	switch x := v.(type) {
-	case int:
-		return fmt.Sprintf("%d", x)
-	case float32, float64:
-		return fmt.Sprintf("%f", x)
-	case string:
-		return fmt.Sprintf("'%s'", x)
-	case bool:
-		return fmt.Sprintf("%v", x)
-	case []interface{}:
-		switch x[0].(type) {
-		case string, int, float32, float64, bool:
-			return strings.Join(strings.Fields(fmt.Sprint(x)), "|")
-		}
-		return ""
-	default:
-		// may be log the warning here?
-		return ""
-	}
 }
 
 func ParseMetricQueryRangeParams(r *http.Request) (*model.QueryRangeParamsV2, *model.ApiError) {

--- a/pkg/query-service/app/parser/metrics.go
+++ b/pkg/query-service/app/parser/metrics.go
@@ -27,6 +27,29 @@ func validateQueryRangeParamsV2(qp *model.QueryRangeParamsV2) error {
 	return nil
 }
 
+// FormattedValue formats the value to be used in clickhouse query
+func PromFormattedValue(v interface{}) string {
+	switch x := v.(type) {
+	case int:
+		return fmt.Sprintf("%d", x)
+	case float32, float64:
+		return fmt.Sprintf("%f", x)
+	case string:
+		return fmt.Sprintf("'%s'", x)
+	case bool:
+		return fmt.Sprintf("%v", x)
+	case []interface{}:
+		switch x[0].(type) {
+		case string, int, float32, float64, bool:
+			return strings.Join(strings.Fields(fmt.Sprint(x)), "|")
+		}
+		return ""
+	default:
+		// may be log the warning here?
+		return ""
+	}
+}
+
 func ParseMetricQueryRangeParams(r *http.Request) (*model.QueryRangeParamsV2, *model.ApiError) {
 
 	var postData *model.QueryRangeParamsV2

--- a/pkg/query-service/app/parser/metrics.go
+++ b/pkg/query-service/app/parser/metrics.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"go.signoz.io/query-service/app/metrics"
 	"go.signoz.io/query-service/model"

--- a/pkg/query-service/app/server.go
+++ b/pkg/query-service/app/server.go
@@ -362,7 +362,7 @@ func makeRulesManager(
 	disableRules bool) (*rules.Manager, error) {
 
 	// create engine
-	pqle, err := pqle.FromConfigPath(promConfigPath)
+	pqle, err := pqle.FromReader(ch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pql engine : %v", err)
 	}

--- a/pkg/query-service/interfaces/interface.go
+++ b/pkg/query-service/interfaces/interface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/stats"
 	am "go.signoz.io/query-service/integrations/alertManager"
 	"go.signoz.io/query-service/model"
@@ -70,6 +71,8 @@ type Reader interface {
 
 	// Connection needed for rules, not ideal but required
 	GetConn() clickhouse.Conn
+	GetQueryEngine() *promql.Engine
+	GetFanoutStorage() *storage.Storage
 
 	QueryDashboardVars(ctx context.Context, query string) (*model.DashboardVar, error)
 }

--- a/pkg/query-service/pqlEngine/engine.go
+++ b/pkg/query-service/pqlEngine/engine.go
@@ -32,9 +32,6 @@ func FromConfigPath(promConfigPath string) (*PqlEngine, error) {
 }
 
 func FromReader(ch interfaces.Reader) (*PqlEngine, error) {
-	for ch.GetFanoutStorage() == nil {
-		time.Sleep(1 * time.Second)
-	}
 	return &PqlEngine{
 		engine:        ch.GetQueryEngine(),
 		fanoutStorage: *ch.GetFanoutStorage(),

--- a/pkg/query-service/pqlEngine/engine.go
+++ b/pkg/query-service/pqlEngine/engine.go
@@ -3,6 +3,8 @@ package promql
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/go-kit/log"
 	pmodel "github.com/prometheus/common/model"
 	plog "github.com/prometheus/common/promlog"
@@ -11,7 +13,7 @@ import (
 	pql "github.com/prometheus/prometheus/promql"
 	pstorage "github.com/prometheus/prometheus/storage"
 	premote "github.com/prometheus/prometheus/storage/remote"
-	"time"
+	"go.signoz.io/query-service/interfaces"
 )
 
 type PqlEngine struct {
@@ -27,6 +29,16 @@ func FromConfigPath(promConfigPath string) (*PqlEngine, error) {
 	}
 
 	return NewPqlEngine(c)
+}
+
+func FromReader(ch interfaces.Reader) (*PqlEngine, error) {
+	for ch.GetFanoutStorage() == nil {
+		time.Sleep(1 * time.Second)
+	}
+	return &PqlEngine{
+		engine:        ch.GetQueryEngine(),
+		fanoutStorage: *ch.GetFanoutStorage(),
+	}, nil
 }
 
 func NewPqlEngine(config *pconfig.Config) (*PqlEngine, error) {


### PR DESCRIPTION
Fixes https://github.com/SigNoz/engineering-pod/issues/737

As described here https://github.com/SigNoz/engineering-pod/issues/728#issuecomment-1240219565 the pqlEngine creates its own client and the same time series data is loaded twice making query service crash in environments that have enough memory resources. This change makes it use the same engine and storage by exposing them from the reader interface. Built one top of https://github.com/SigNoz/signoz/pull/1557 so base is not developed for now.