### PR TITLE
chore: 🔧 414 issue fix for large request URI

### DIFF
--- a/deploy/docker-swarm/common/nginx-config.conf
+++ b/deploy/docker-swarm/common/nginx-config.conf
@@ -13,7 +13,7 @@ server {
 
     # to handle uri issue 414 from nginx
     client_max_body_size 24M;
-    large_client_header_buffers 8 16k;
+    large_client_header_buffers 8 128k;
 
     location / {
         if ( $uri = '/index.html' ) {

--- a/deploy/docker/common/nginx-config.conf
+++ b/deploy/docker/common/nginx-config.conf
@@ -13,7 +13,7 @@ server {
 
     # to handle uri issue 414 from nginx
     client_max_body_size 24M;
-    large_client_header_buffers 8 16k;
+    large_client_header_buffers 8 128k;
 
     location / {
         if ( $uri = '/index.html' ) {

--- a/frontend/conf/default.conf
+++ b/frontend/conf/default.conf
@@ -13,7 +13,7 @@ server {
 
   # to handle uri issue 414 from nginx
   client_max_body_size 24M;
-  large_client_header_buffers 8 16k;
+  large_client_header_buffers 8 128k;
 
   location / {
     root   /usr/share/nginx/html;


### PR DESCRIPTION
@srikanthccv pointed out that the issue still persists for very large request URI.
Hence, we are increasing the size for buffers used for reading large client request header in Nginx.

Signed-off-by: Prashant Shahi <prashant@signoz.io>