### PR TITLE
Fix: move Clickhouse data to docker volume

### DIFF
--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -1,5 +1,8 @@
 version: "2.4"
 
+volumes:
+    clickhouse_data: {}
+
 services:
   clickhouse:
     image: clickhouse/clickhouse-server:22.4.5-alpine
@@ -11,7 +14,7 @@ services:
       - ./clickhouse-config.xml:/etc/clickhouse-server/config.xml
       - ./clickhouse-users.xml:/etc/clickhouse-server/users.xml
       # - ./clickhouse-storage.xml:/etc/clickhouse-server/config.d/storage.xml
-      - ./data/clickhouse/:/var/lib/clickhouse/
+      - clickhouse_data:/var/lib/clickhouse/
     restart: on-failure
     logging:
       options:


### PR DESCRIPTION
Running this docker-compose.yaml on Ubutntu WSL2 without having clickhouse data being in a docker volume causes Clickhouse to not have the required permissions to write data as it tries to write data as a user that does not have permission to write in this directory.

Moving this to a volume resolves the issue.

I believe it should also fix issues reported in #1580