### PR TITLE
fix: [alerts] [ch-query] added aliases in metric query result

### DIFF
--- a/ee/query-service/app/db/metrics.go
+++ b/ee/query-service/app/db/metrics.go
@@ -117,8 +117,7 @@ func (r *ClickhouseReader) GetMetricResultEE(ctx context.Context, query string) 
 					groupAttributes[colName] = fmt.Sprintf("%v", reflect.ValueOf(v).Elem().Int())
 				}
 			default:
-				zap.S().Debugf("unhandled data type found in metric builder results ")
-
+				zap.S().Errorf("invalid var found in metric builder query result", v, colName)
 			}
 		}
 		sort.Strings(groupBy)

--- a/ee/query-service/app/db/metrics.go
+++ b/ee/query-service/app/db/metrics.go
@@ -92,26 +92,33 @@ func (r *ClickhouseReader) GetMetricResultEE(ctx context.Context, query string) 
 				metricPoint.Timestamp = v.UnixMilli()
 			case *float64:
 				metricPoint.Value = *v
-			case *uint64:
-				intv := *v
-				if _, ok := baseconst.ReservedColumnTargetAliases[colName]; ok {
-					metricPoint.Value = float64(intv)
-				} else {
-					groupBy = append(groupBy, fmt.Sprintf("%d", intv))
-					groupAttributes[colName] = fmt.Sprintf("%d", intv)
+			case **float64:
+				// ch seems to return this type when column is derived from
+				// SELECT count(*)/ SELECT count(*)
+				floatVal := *v
+				if floatVal != nil {
+					metricPoint.Value = *floatVal
 				}
-			case *uint8:
-				// note: have to re-write (copy) the logic for uint8 though
-				// they are simiar to uint64 as the type conversion (below)
-				// does not work in multiple cases in switch. means we can't use:
-				// 	case *uint64, uint8
-				intv := *v
+			case *float32:
+				float32Val := float32(*v)
+				metricPoint.Value = float64(float32Val)
+			case *uint8, *uint64, *uint16, *uint32:
 				if _, ok := baseconst.ReservedColumnTargetAliases[colName]; ok {
-					metricPoint.Value = float64(intv)
+					metricPoint.Value = float64(reflect.ValueOf(v).Elem().Uint())
 				} else {
-					groupBy = append(groupBy, fmt.Sprintf("%d", intv))
-					groupAttributes[colName] = fmt.Sprintf("%d", intv)
+					groupBy = append(groupBy, fmt.Sprintf("%v", reflect.ValueOf(v).Elem().Uint()))
+					groupAttributes[colName] = fmt.Sprintf("%v", reflect.ValueOf(v).Elem().Uint())
 				}
+			case *int8, *int16, *int32, *int64:
+				if _, ok := baseconst.ReservedColumnTargetAliases[colName]; ok {
+					metricPoint.Value = float64(reflect.ValueOf(v).Elem().Int())
+				} else {
+					groupBy = append(groupBy, fmt.Sprintf("%v", reflect.ValueOf(v).Elem().Int()))
+					groupAttributes[colName] = fmt.Sprintf("%v", reflect.ValueOf(v).Elem().Int())
+				}
+			default:
+				zap.S().Debugf("unhandled data type found in metric builder results ")
+
 			}
 		}
 		sort.Strings(groupBy)

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -2916,6 +2916,27 @@ func (r *ClickHouseReader) GetMetricResult(ctx context.Context, query string) ([
 				metricPoint.Timestamp = v.UnixMilli()
 			case *float64:
 				metricPoint.Value = *v
+			case *uint64:
+				intv := *v
+				if _, ok := constants.ReservedColumnTargetAliases[colName]; ok {
+					metricPoint.Value = float64(intv)
+				} else {
+					groupBy = append(groupBy, fmt.Sprintf("%d", intv))
+					groupAttributes[colName] = fmt.Sprintf("%d", intv)
+				}
+			case *uint8:
+				// note: have to re-write (copy) the logic for uint8 though
+				// they are simiar to uint64 as the type conversion (below)
+				// does not work in multiple cases in switch. means we can't use:
+				// 	case *uint64, uint8
+				intv := *v
+				if _, ok := constants.ReservedColumnTargetAliases[colName]; ok {
+					metricPoint.Value = float64(intv)
+				} else {
+					groupBy = append(groupBy, fmt.Sprintf("%d", intv))
+					groupAttributes[colName] = fmt.Sprintf("%d", intv)
+				}
+
 			}
 		}
 		sort.Strings(groupBy)

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -2941,7 +2941,7 @@ func (r *ClickHouseReader) GetMetricResult(ctx context.Context, query string) ([
 					groupAttributes[colName] = fmt.Sprintf("%v", reflect.ValueOf(v).Elem().Int())
 				}
 			default:
-				zap.S().Debugf("unhandled data type found in metric builder results ")
+				zap.S().Errorf("invalid var found in metric builder query result", v, colName)
 			}
 		}
 		sort.Strings(groupBy)

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -190,3 +190,8 @@ const (
 		"CAST((attributes_float64_key, attributes_float64_value), 'Map(String, Float64)') as  attributes_float64," +
 		"CAST((resources_string_key, resources_string_value), 'Map(String, String)') as resources_string "
 )
+
+// ReservedColumnTargetAliases identifies result value from a user
+// written clickhouse query. The column alias indcate which value is
+// to be considered as final result (or target)
+var ReservedColumnTargetAliases = map[string]bool{"result": true, "res": true, "value": true}


### PR DESCRIPTION
The issue was reported by Vishal during exception testing. The chart does not work with integer result values in alert form. This PR adds special aliases to support integer type result values which are common in log and exception queries. 