### PR TITLE
fix: [alerts] fixed selected interval for chart preview in ch use case

### DIFF
--- a/frontend/src/container/FormAlertRules/index.tsx
+++ b/frontend/src/container/FormAlertRules/index.tsx
@@ -468,6 +468,7 @@ function FormAlertRules({
 				threshold={alertDef.condition?.target}
 				query={manualStagedQuery}
 				userQueryKey={runQueryId}
+				selectedInterval={toChartInterval(alertDef.evalWindow)}
 			/>
 		);
 	};

--- a/frontend/src/container/FormAlertRules/utils.ts
+++ b/frontend/src/container/FormAlertRules/utils.ts
@@ -135,7 +135,7 @@ export const toChartInterval = (evalWindow: string | undefined): Time => {
 		case '30m0s':
 			return '30min';
 		case '60m0s':
-			return '30min';
+			return '1hr';
 		case '4h0m0s':
 			return '4hr';
 		case '24h0m0s':


### PR DESCRIPTION
The chart preview in alert form does not consider selected intervals for clickhouse queries. This fix resolves the issue. 