### PR TITLE
fix: parser updated to differentiate between params and query string

### DIFF
--- a/pkg/query-service/app/logs/parser.go
+++ b/pkg/query-service/app/logs/parser.go
@@ -309,9 +309,16 @@ func GenerateSQLWhere(allFields *model.GetFieldsResponse, params *model.LogsFilt
 		filterTokens = append(filterTokens, filter)
 	}
 
-	if len(filterTokens) > 0 {
-		if len(tokens) > 0 {
-			tokens[0] = fmt.Sprintf("and %s", tokens[0])
+	lenFilterTokens := len(filterTokens)
+	if lenFilterTokens > 0 {
+		// add parenthesis
+		filterTokens[0] = fmt.Sprintf("( %s", filterTokens[0])
+		filterTokens[lenFilterTokens-1] = fmt.Sprintf("%s) ", filterTokens[lenFilterTokens-1])
+
+		lenTokens := len(tokens)
+		if lenTokens > 0 {
+			tokens[0] = fmt.Sprintf("and ( %s", tokens[0])
+			tokens[lenTokens-1] = fmt.Sprintf("%s) ", tokens[lenTokens-1])
 		}
 		filterTokens = append(filterTokens, tokens...)
 		tokens = filterTokens

--- a/pkg/query-service/app/logs/parser_test.go
+++ b/pkg/query-service/app/logs/parser_test.go
@@ -271,32 +271,65 @@ func TestCheckIfPrevousPaginateAndModifyOrder(t *testing.T) {
 	}
 }
 
-func TestGenerateSQLQuery(t *testing.T) {
-	allFields := model.GetFieldsResponse{
-		Selected: []model.LogField{
-			{
-				Name:     "id",
-				DataType: "int64",
-				Type:     "attributes",
-			},
+var generateSQLQueryFields = model.GetFieldsResponse{
+	Selected: []model.LogField{
+		{
+			Name:     "field1",
+			DataType: "int64",
+			Type:     "attributes",
 		},
-		Interesting: []model.LogField{
-			{
-				Name:     "code",
-				DataType: "int64",
-				Type:     "attributes",
-			},
+		{
+			Name:     "field2",
+			DataType: "double64",
+			Type:     "attributes",
 		},
-	}
+		{
+			Name:     "field2",
+			DataType: "string",
+			Type:     "attributes",
+		},
+	},
+	Interesting: []model.LogField{
+		{
+			Name:     "code",
+			DataType: "int64",
+			Type:     "attributes",
+		},
+	},
+}
 
-	query := "id lt 100 and id gt 50 and code lte 500 and code gte 400"
-	tsStart := uint64(1657689292000)
-	tsEnd := uint64(1657689294000)
-	idStart := "2BsKLKv8cZrLCn6rkOcRGkdjBdM"
-	idEnd := "2BsKG6tRpFWjYMcWsAGKfSxoQdU"
-	sqlWhere := "timestamp >= '1657689292000' and timestamp <= '1657689294000' and id > '2BsKLKv8cZrLCn6rkOcRGkdjBdM' and id < '2BsKG6tRpFWjYMcWsAGKfSxoQdU' and id < 100 and id > 50 and attributes_int64_value[indexOf(attributes_int64_key, 'code')] <= 500 and attributes_int64_value[indexOf(attributes_int64_key, 'code')] >= 400 "
-	Convey("testGenerateSQL", t, func() {
-		res, _ := GenerateSQLWhere(&allFields, &model.LogsFilterParams{Query: query, TimestampStart: tsStart, TimestampEnd: tsEnd, IdGt: idStart, IdLT: idEnd})
-		So(res, ShouldEqual, sqlWhere)
-	})
+var generateSQLQueryTestCases = []struct {
+	Name      string
+	Filter    model.LogsFilterParams
+	SqlFilter string
+}{
+	{
+		Name: "first query with more than 1 compulsory filters",
+		Filter: model.LogsFilterParams{
+			Query:          "field1 lt 100 and field1 gt 50 and code lte 500 and code gte 400",
+			TimestampStart: uint64(1657689292000),
+			TimestampEnd:   uint64(1657689294000),
+			IdGt:           "2BsKLKv8cZrLCn6rkOcRGkdjBdM",
+			IdLT:           "2BsKG6tRpFWjYMcWsAGKfSxoQdU",
+		},
+		SqlFilter: "( timestamp >= '1657689292000' and timestamp <= '1657689294000' and id > '2BsKLKv8cZrLCn6rkOcRGkdjBdM' and id < '2BsKG6tRpFWjYMcWsAGKfSxoQdU' ) and ( field1 < 100 and field1 > 50 and attributes_int64_value[indexOf(attributes_int64_key, 'code')] <= 500 and attributes_int64_value[indexOf(attributes_int64_key, 'code')] >= 400 ) ",
+	},
+	{
+		Name: "second query with only timestamp range",
+		Filter: model.LogsFilterParams{
+			Query:          "field1 lt 100 and field1 gt 50 and code lte 500 and code gte 400",
+			TimestampStart: uint64(1657689292000),
+			TimestampEnd:   uint64(1657689294000),
+		},
+		SqlFilter: "( timestamp >= '1657689292000' and timestamp <= '1657689294000' ) and ( field1 < 100 and field1 > 50 and attributes_int64_value[indexOf(attributes_int64_key, 'code')] <= 500 and attributes_int64_value[indexOf(attributes_int64_key, 'code')] >= 400 ) ",
+	},
+}
+
+func TestGenerateSQLQuery(t *testing.T) {
+	for _, test := range generateSQLQueryTestCases {
+		Convey("testGenerateSQL", t, func() {
+			res, _ := GenerateSQLWhere(&generateSQLQueryFields, &test.Filter)
+			So(res, ShouldEqual, test.SqlFilter)
+		})
+	}
 }


### PR DESCRIPTION
FIXES https://github.com/SigNoz/signoz/issues/1762

This PR fixes the issue where the timestamp range in params is not respected when OR is used in the query string.

It separates the params filtering from the query string by using parenthesis.