### PR TITLE
fix: resolves empty variables issue for imported dashboards

### DIFF
--- a/frontend/src/lib/dashbaordVariables/getDashboardVariables.ts
+++ b/frontend/src/lib/dashbaordVariables/getDashboardVariables.ts
@@ -10,7 +10,7 @@ export const getDashboardVariables = (): Record<string, unknown> => {
 		} = store.getState();
 		const [selectedDashboard] = dashboards;
 		const {
-			data: { variables },
+			data: { variables = {} },
 		} = selectedDashboard;
 
 		const minMax = GetMinMax(globalTime.selectedTime, [


### PR DESCRIPTION
This PR solves an issue with getDashboardVariables.ts

In recent versions, the query builder has started supporting pre-defined variables for click house queries. however, the import files for metric builder do not have or need these variables.  This fix makes the variable parameter in getMetricData optional.
