### PR TITLE
fix: solves issue legend update causing null ch query

### DIFF
--- a/frontend/src/container/FormAlertRules/ChQuerySection/transform.ts
+++ b/frontend/src/container/FormAlertRules/ChQuerySection/transform.ts
@@ -20,8 +20,8 @@ export const rawQueryToIChQuery = (
 	}
 
 	return {
-		rawQuery: rawQuery !== undefined ? rawQuery : src.rawQuery,
-		query: rawQuery !== undefined ? rawQuery : src.rawQuery,
+		rawQuery: rawQuery !== undefined ? rawQuery : src.query,
+		query: rawQuery !== undefined ? rawQuery : src.query,
 		legend: legend !== undefined ? legend : src.legend,
 		name: 'A',
 		disabled: false,


### PR DESCRIPTION
This PR resolves issue with legends in alert form causing NULL click house queries. 

Reproduce Problem:
 1. Update legends field in. alert form
 2. the click house query disappears
 3. when user goes to save the alert form, an error is raised.  