### PR TITLE
Revert "chore: use local table for innery query (#1815)

### DIFF
--- a/pkg/query-service/app/metrics/query_builder.go
+++ b/pkg/query-service/app/metrics/query_builder.go
@@ -142,7 +142,7 @@ func BuildMetricsTimeSeriesFilterQuery(fs *model.FilterSet, groupTags []string, 
 		}
 	}
 
-	filterSubQuery := fmt.Sprintf("SELECT %s fingerprint FROM %s.%s WHERE %s", selectLabels, constants.SIGNOZ_METRIC_DBNAME, constants.SIGNOZ_TIMESERIES_LOCAL_TABLENAME, queryString)
+	filterSubQuery := fmt.Sprintf("SELECT %s fingerprint FROM %s.%s WHERE %s", selectLabels, constants.SIGNOZ_METRIC_DBNAME, constants.SIGNOZ_TIMESERIES_TABLENAME, queryString)
 
 	return filterSubQuery, nil
 }
@@ -166,7 +166,7 @@ func BuildMetricQuery(qp *model.QueryRangeParamsV2, mq *model.MetricQuery, table
 			" toStartOfInterval(toDateTime(intDiv(timestamp_ms, 1000)), INTERVAL %d SECOND) as ts," +
 			" %s as value" +
 			" FROM " + constants.SIGNOZ_METRIC_DBNAME + "." + constants.SIGNOZ_SAMPLES_TABLENAME +
-			" INNER JOIN" +
+			" GLOBAL INNER JOIN" +
 			" (%s) as filtered_time_series" +
 			" USING fingerprint" +
 			" WHERE " + samplesTableTimeFilter +
@@ -228,7 +228,7 @@ func BuildMetricQuery(qp *model.QueryRangeParamsV2, mq *model.MetricQuery, table
 				" toStartOfInterval(toDateTime(intDiv(timestamp_ms, 1000)), INTERVAL %d SECOND) as ts," +
 				" any(value) as value" +
 				" FROM " + constants.SIGNOZ_METRIC_DBNAME + "." + constants.SIGNOZ_SAMPLES_TABLENAME +
-				" INNER JOIN" +
+				" GLOBAL INNER JOIN" +
 				" (%s) as filtered_time_series" +
 				" USING fingerprint" +
 				" WHERE " + samplesTableTimeFilter +
@@ -371,7 +371,7 @@ func expressionToQuery(qp *model.QueryRangeParamsV2, varToQuery map[string]strin
 		joinUsing = strings.Join(groupTags, ",")
 		formulaSubQuery += fmt.Sprintf("(%s) as %s ", query, var_)
 		if idx < len(vars)-1 {
-			formulaSubQuery += "INNER JOIN"
+			formulaSubQuery += "GLOBAL INNER JOIN"
 		} else if len(vars) > 1 {
 			formulaSubQuery += fmt.Sprintf("USING (%s)", joinUsing)
 		}

--- a/pkg/query-service/config/prometheus.yml
+++ b/pkg/query-service/config/prometheus.yml
@@ -22,4 +22,4 @@ rule_files:
 scrape_configs: []
 
 remote_read:
-  - url: tcp://stagingapp.signoz.io:9000/?database=signoz_metrics
+  - url: tcp://localhost:9000/?database=signoz_metrics

--- a/pkg/query-service/config/prometheus.yml
+++ b/pkg/query-service/config/prometheus.yml
@@ -22,4 +22,4 @@ rule_files:
 scrape_configs: []
 
 remote_read:
-  - url: tcp://localhost:9000/?database=signoz_metrics
+  - url: tcp://stagingapp.signoz.io:9000/?database=signoz_metrics

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -110,10 +110,9 @@ const (
 	DefaultLogSkipIndexGranularity = 64
 )
 const (
-	SIGNOZ_METRIC_DBNAME              = "signoz_metrics"
-	SIGNOZ_SAMPLES_TABLENAME          = "distributed_samples_v2"
-	SIGNOZ_TIMESERIES_TABLENAME       = "distributed_time_series_v2"
-	SIGNOZ_TIMESERIES_LOCAL_TABLENAME = "time_series_v2"
+	SIGNOZ_METRIC_DBNAME        = "signoz_metrics"
+	SIGNOZ_SAMPLES_TABLENAME    = "distributed_samples_v2"
+	SIGNOZ_TIMESERIES_TABLENAME = "distributed_time_series_v2"
 )
 
 var TimeoutExcludedRoutes = map[string]bool{


### PR DESCRIPTION
My reasoning for using the local table for the inner query was that if the sample exists in the shard, its corresponding time series entry would also exist in that shard. And the subquery produces the correct results. This is true, but we have some conditional insertion that breaks this. The collector connects to the distributed table to preload the existing fingerprints.

shard-2
```
clickhouse-2 :) SELECT count()
                FROM signoz_metrics.time_series_v2
                WHERE metric_name = 'signoz_calls_total'

SELECT count()
FROM signoz_metrics.time_series_v2
WHERE metric_name = 'signoz_calls_total'

Query id: c922495f-8168-4a60-a2fb-92581d481838

┌─count()─┐
│       0 │
└─────────┘

1 row in set. Elapsed: 0.002 sec.
```

shard-3
```
clickhouse-3 :) SELECT count()
                FROM signoz_metrics.time_series_v2
                WHERE metric_name = 'signoz_calls_total'

SELECT count()
FROM signoz_metrics.time_series_v2
WHERE metric_name = 'signoz_calls_total'

Query id: e8c5bc74-f6f5-47ca-b060-db6180052048

┌─count()─┐
│       0 │
└─────────┘

1 row in set. Elapsed: 0.012 sec.
```

When you go from one shard to multi shard, there is already all-time series filled in the first shard, and we don't `INSERT INTO` table if the fingerprint is already seen all while samples are getting inserted into multiple shards. There are some clear benefits of using a local table and avoiding `GLOBAL`, but before all the edge cases should be addressed. This can come for the next release.