### PR TITLE
fix: do not show result of intermediate sub queries in external calls

### DIFF
--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
@@ -31,7 +31,7 @@ export const externalCallErrorPercent = ({
 
 	const legendFormula = 'External Call Error Percentage';
 	const expression = 'A*100/B';
-	const disabled = false;
+	const disabled = true;
 	return getQueryBuilderQuerieswithAdditionalItems({
 		metricNameA,
 		metricNameB,
@@ -102,7 +102,7 @@ export const externalCallDurationByAddress = ({
 	const metricNameB = 'signoz_external_call_latency_count';
 	const expression = 'A/B';
 	const legendFormula = legend;
-	const disabled = false;
+	const disabled = true;
 	return getQueryBuilderQuerieswithFormula({
 		servicename,
 		legend,


### PR DESCRIPTION
Fixes https://github.com/SigNoz/signoz/issues/1876

There are certain charts (duration/error by address) that only need to display the final result. The result of intermediate sub-query shouldn't be shown in the panel.