### PR TITLE
fix(query_range): invalid memory address or nil pointer dereference

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1159,6 +1159,7 @@ func (aH *APIHandler) queryRangeMetrics(w http.ResponseWriter, r *http.Request) 
 			RespondError(w, &model.ApiError{model.ErrorTimeout, res.Err}, nil)
 		}
 		RespondError(w, &model.ApiError{model.ErrorExec, res.Err}, nil)
+		return
 	}
 
 	response_data := &model.QueryData{


### PR DESCRIPTION
Partially addresses #1685 

There are two helpful pointers from the query service log shared by the issue author.

```
... query was canceled in query queue
... 2022/11/03 19:17:31 http: superfluous response.WriteHeader call from github.com/gorilla/handlers.(*compressResponseWriter).WriteHeader (compress.go:26)
```

This arises from the Prometheus library, relevant issue here https://github.com/prometheus/prometheus/issues/6139

>query was canceled in query queue

This usually happens when the context is cancelled. It's not clear why it's cancelled in the linked issue context.

Either way, we don't want to let the code run beyond this error point and throw a nil pointer exception. I will leave that issue open until we get to the bottom of the issue if we can find a way to reproduce it.