### PR TITLE
fix: allow multiple spaces between a filter expression

### DIFF
--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
@@ -31,7 +31,7 @@ export const externalCallErrorPercent = ({
 
 	const legendFormula = 'External Call Error Percentage';
 	const expression = 'A*100/B';
-	const disabled = false;
+	const disabled = true;
 	return getQueryBuilderQuerieswithAdditionalItems({
 		metricNameA,
 		metricNameB,
@@ -102,7 +102,7 @@ export const externalCallDurationByAddress = ({
 	const metricNameB = 'signoz_external_call_latency_count';
 	const expression = 'A/B';
 	const legendFormula = legend;
-	const disabled = false;
+	const disabled = true;
 	return getQueryBuilderQuerieswithFormula({
 		servicename,
 		legend,

--- a/pkg/query-service/app/logs/parser.go
+++ b/pkg/query-service/app/logs/parser.go
@@ -36,7 +36,7 @@ const (
 	DESC            = "desc"
 )
 
-var tokenRegex, _ = regexp.Compile(`(?i)(and( )*?|or( )*?)?(([\w.-]+ (in|nin) \([^(]+\))|([\w.]+ (gt|lt|gte|lte) (')?[\S]+(')?)|([\w.]+ (contains|ncontains)) [^\\]?'(.*?[^\\])')`)
+var tokenRegex, _ = regexp.Compile(`(?i)(and( )*?|or( )*?)?(([\w.-]+( )+(in|nin)( )+\([^(]+\))|([\w.]+( )+(gt|lt|gte|lte)( )+(')?[\S]+(')?)|([\w.]+( )+(contains|ncontains))( )+[^\\]?'(.*?[^\\])')`)
 var operatorRegex, _ = regexp.Compile(`(?i)(?: )(in|nin|gt|lt|gte|lte|contains|ncontains)(?: )`)
 
 func ParseLogFilterParams(r *http.Request) (*model.LogsFilterParams, error) {
@@ -153,8 +153,8 @@ func ParseLogAggregateParams(r *http.Request) (*model.LogsAggregateParams, error
 func parseLogQuery(query string) ([]string, error) {
 	sqlQueryTokens := []string{}
 
-	// trim multiple spaces to a single one
-	query = strings.Join(strings.Fields(query), " ")
+	// // trim multiple spaces to a single one
+	// query = strings.Join(strings.Fields(query), " ")
 
 	filterTokens := tokenRegex.FindAllString(query, -1)
 
@@ -194,7 +194,13 @@ func parseLogQuery(query string) ([]string, error) {
 			sqlQueryTokens = append(sqlQueryTokens, f)
 		} else {
 			symbol := operatorMapping[strings.ToLower(op)]
-			sqlQueryTokens = append(sqlQueryTokens, strings.Replace(v, " "+op+" ", " "+symbol+" ", 1)+" ")
+			sqlExpr := strings.Replace(v, " "+op+" ", " "+symbol+" ", 1)
+			splittedExpr := strings.Split(sqlExpr, symbol)
+			if len(splittedExpr) != 2 {
+				return nil, fmt.Errorf("error while splitting expression: %s", sqlExpr)
+			}
+			trimmedSqlExpr := fmt.Sprintf("%s %s %s ", strings.Join(strings.Fields(splittedExpr[0]), " "), symbol, strings.TrimSpace(splittedExpr[1]))
+			sqlQueryTokens = append(sqlQueryTokens, trimmedSqlExpr)
 		}
 	}
 

--- a/pkg/query-service/app/logs/parser.go
+++ b/pkg/query-service/app/logs/parser.go
@@ -153,9 +153,6 @@ func ParseLogAggregateParams(r *http.Request) (*model.LogsAggregateParams, error
 func parseLogQuery(query string) ([]string, error) {
 	sqlQueryTokens := []string{}
 
-	// // trim multiple spaces to a single one
-	// query = strings.Join(strings.Fields(query), " ")
-
 	filterTokens := tokenRegex.FindAllString(query, -1)
 
 	if len(filterTokens) == 0 {

--- a/pkg/query-service/app/logs/parser.go
+++ b/pkg/query-service/app/logs/parser.go
@@ -152,6 +152,10 @@ func ParseLogAggregateParams(r *http.Request) (*model.LogsAggregateParams, error
 
 func parseLogQuery(query string) ([]string, error) {
 	sqlQueryTokens := []string{}
+
+	// trim multiple spaces to a single one
+	query = strings.Join(strings.Fields(query), " ")
+
 	filterTokens := tokenRegex.FindAllString(query, -1)
 
 	if len(filterTokens) == 0 {

--- a/pkg/query-service/app/logs/parser_test.go
+++ b/pkg/query-service/app/logs/parser_test.go
@@ -88,6 +88,11 @@ var correctQueriesTest = []struct {
 		[]string{`service IN ('name > 100') `},
 	},
 	{
+		`Extra space between a query filter`,
+		`data  contains  'hello    world    .'`,
+		[]string{`data ILIKE '%hello    world    .%' `},
+	},
+	{
 		`filters with special characters in key name`,
 		`id.userid in (100) and id_userid gt 50`,
 		[]string{`id.userid IN (100) `, `and id_userid > 50 `},

--- a/pkg/query-service/app/logs/parser_test.go
+++ b/pkg/query-service/app/logs/parser_test.go
@@ -80,7 +80,12 @@ var correctQueriesTest = []struct {
 	{
 		`filters with extra spaces`,
 		`service IN ('name > 100')    AND   length gt 100`,
-		[]string{`service IN ('name > 100') `, `AND   length > 100 `},
+		[]string{`service IN ('name > 100') `, `AND length > 100 `},
+	},
+	{
+		`Extra space within a filter expression`,
+		`service  IN  ('name > 100')`,
+		[]string{`service IN ('name > 100') `},
 	},
 	{
 		`filters with special characters in key name`,


### PR DESCRIPTION
Fixes #1740 