### PR TITLE
fix(FE): remove unnecessary complexity from password check

### DIFF
--- a/frontend/src/pages/SignUp/utils.ts
+++ b/frontend/src/pages/SignUp/utils.ts
@@ -6,10 +6,8 @@
  */
 export const isPasswordValid = (value: string): boolean => {
 	// eslint-disable-next-line prefer-regex-literals
-	const pattern = new RegExp(
-		'^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,}$',
-	);
+	const pattern = new RegExp('^.{8,}$');
 	return pattern.test(value);
 };
 
-export const isPasswordNotValidMessage = `Password must a have minimum of 8 characters with at least one lower case, one number ,one upper case and one special character`;
+export const isPasswordNotValidMessage = `Password must a have minimum of 8 characters`;


### PR DESCRIPTION
Signed-off-by: Marius Kimmina <mar.kimmina@gmail.com>

Closes #1606 

Since many studies have shown that length is the primary factor for password strength I'd like to remove the password complexity constraints from the sign up check.
With this, the check is now also aligned with the newest version of NIST Password Guidelines.