### PR TITLE
fix: Added Validations on Log Query builder

### DIFF
--- a/frontend/src/container/LogsSearchFilter/SearchFields/QueryBuilder/utils.ts
+++ b/frontend/src/container/LogsSearchFilter/SearchFields/QueryBuilder/utils.ts
@@ -21,17 +21,3 @@ export const parseQuery = (queries: Query): Query => {
 	}
 	return queries;
 };
-
-export const hashCode = (s: string): string => {
-	if (!s) {
-		return '0';
-	}
-	return `${Math.abs(
-		s.split('').reduce((a, b) => {
-			// eslint-disable-next-line no-bitwise, no-param-reassign
-			a = (a << 5) - a + b.charCodeAt(0);
-			// eslint-disable-next-line no-bitwise
-			return a & a;
-		}, 0),
-	)}`;
-};

--- a/frontend/src/container/LogsSearchFilter/SearchFields/Suggestions.tsx
+++ b/frontend/src/container/LogsSearchFilter/SearchFields/Suggestions.tsx
@@ -2,9 +2,9 @@ import { Button } from 'antd';
 import CategoryHeading from 'components/Logs/CategoryHeading';
 import map from 'lodash-es/map';
 import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { AppState } from 'store/reducers';
-import { ADD_SEARCH_FIELD_QUERY_STRING } from 'types/actions/logs';
+// import { ADD_SEARCH_FIELD_QUERY_STRING } from 'types/actions/logs';
 import { ILogsReducer } from 'types/reducer/logs';
 
 import FieldKey from './FieldKey';
@@ -12,15 +12,15 @@ import FieldKey from './FieldKey';
 interface SuggestedItemProps {
 	name: string;
 	type: string;
+	applySuggestion: (name: string) => void;
 }
-function SuggestedItem({ name, type }: SuggestedItemProps): JSX.Element {
-	const dispatch = useDispatch();
-
+function SuggestedItem({
+	name,
+	type,
+	applySuggestion,
+}: SuggestedItemProps): JSX.Element {
 	const addSuggestedField = (): void => {
-		dispatch({
-			type: ADD_SEARCH_FIELD_QUERY_STRING,
-			payload: name,
-		});
+		applySuggestion(name);
 	};
 	return (
 		<Button
@@ -33,7 +33,11 @@ function SuggestedItem({ name, type }: SuggestedItemProps): JSX.Element {
 	);
 }
 
-function Suggestions(): JSX.Element {
+interface SuggestionsProps {
+	applySuggestion: (name: string) => void;
+}
+
+function Suggestions({ applySuggestion }: SuggestionsProps): JSX.Element {
 	const {
 		fields: { selected },
 	} = useSelector<AppState, ILogsReducer>((store) => store.logs);
@@ -47,6 +51,7 @@ function Suggestions(): JSX.Element {
 						key={JSON.stringify(field)}
 						name={field.name}
 						type={field.type}
+						applySuggestion={applySuggestion}
 					/>
 				))}
 			</div>

--- a/frontend/src/container/LogsSearchFilter/SearchFields/index.tsx
+++ b/frontend/src/container/LogsSearchFilter/SearchFields/index.tsx
@@ -1,8 +1,20 @@
-import React from 'react';
+import { Button, notification, Row } from 'antd';
+import { flatten } from 'lodash-es';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { AppState } from 'store/reducers';
+import { ILogsReducer } from 'types/reducer/logs';
 
 import QueryBuilder from './QueryBuilder/QueryBuilder';
 import Suggestions from './Suggestions';
-import { QueryFields } from './utils';
+import {
+	createParsedQueryStructure,
+	fieldsQueryIsvalid,
+	hashCode,
+	initQueryKOVPair,
+	prepareConditionOperator,
+	QueryFields,
+} from './utils';
 
 export interface SearchFieldsProps {
 	updateParsedQuery: (query: QueryFields[]) => void;
@@ -13,13 +25,76 @@ function SearchFields({
 	updateParsedQuery,
 	onDropDownToggleHandler,
 }: SearchFieldsProps): JSX.Element {
+	const {
+		searchFilter: { parsedQuery },
+	} = useSelector<AppState, ILogsReducer>((store) => store.logs);
+
+	const [fieldsQuery, setFieldsQuery] = useState(
+		createParsedQueryStructure([...parsedQuery] as never[]),
+	);
+
+	const keyPrefixRef = useRef(hashCode(JSON.stringify(fieldsQuery)));
+
+	useEffect(() => {
+		setFieldsQuery(createParsedQueryStructure([...parsedQuery] as never[]));
+	}, [parsedQuery]);
+
+	const addSuggestedField = useCallback(
+		(name: string): void => {
+			if (!name) {
+				return;
+			}
+
+			const query = [...fieldsQuery];
+
+			if (fieldsQuery.length > 0) {
+				query.push([prepareConditionOperator()]);
+			}
+
+			const newField: QueryFields[] = [];
+			initQueryKOVPair(name).forEach((q) => newField.push(q));
+
+			query.push(newField);
+			keyPrefixRef.current = hashCode(JSON.stringify(query));
+			setFieldsQuery(query);
+		},
+		[fieldsQuery, setFieldsQuery],
+	);
+
+	const applyUpdate = useCallback(
+		(e): void => {
+			e.preventDefault();
+			const flatParsedQuery = flatten(fieldsQuery);
+
+			if (!fieldsQueryIsvalid(flatParsedQuery)) {
+				notification.error({
+					message: 'Please enter a valid criteria for each of the selected fields',
+				});
+				return;
+			}
+
+			keyPrefixRef.current = hashCode(JSON.stringify(flatParsedQuery));
+			updateParsedQuery(flatParsedQuery);
+			onDropDownToggleHandler(false)();
+		},
+		[onDropDownToggleHandler, fieldsQuery, updateParsedQuery],
+	);
+
 	return (
 		<>
 			<QueryBuilder
+				key={keyPrefixRef.current}
+				keyPrefix={keyPrefixRef.current}
 				onDropDownToggleHandler={onDropDownToggleHandler}
-				updateParsedQuery={updateParsedQuery}
+				fieldsQuery={fieldsQuery}
+				setFieldsQuery={setFieldsQuery}
 			/>
-			<Suggestions />
+			<Row style={{ justifyContent: 'flex-end', paddingRight: '2.4rem' }}>
+				<Button type="primary" onClick={applyUpdate}>
+					Apply
+				</Button>
+			</Row>
+			<Suggestions applySuggestion={addSuggestedField} />
 		</>
 	);
 }

--- a/frontend/src/container/LogsSearchFilter/SearchFields/utils.ts
+++ b/frontend/src/container/LogsSearchFilter/SearchFields/utils.ts
@@ -2,11 +2,30 @@
 // @ts-ignore
 // @ts-nocheck
 
-import { QueryTypes, QueryOperatorsSingleVal } from 'lib/logql/tokens';
+import { QueryTypes, ConditionalOperators, ValidTypeSequence, ValidTypeValue } from 'lib/logql/tokens';
 
 export interface QueryFields {
 	type: keyof typeof QueryTypes;
-	value: string;
+	value: string | string[];
+}
+
+
+export function fieldsQueryIsvalid(queryFields: QueryFields[]): boolean {
+	let lastOp: string;
+	let result = true;
+	queryFields.forEach((q, idx)=> {
+		
+		if (!q.value || q.value === null || q.value === '') result = false;
+		
+		if (Array.isArray(q.value) && q.value.length === 0 ) result = false;
+
+		const nextOp = idx < queryFields.length  ? queryFields[idx+1]: undefined;
+		if (!ValidTypeSequence(lastOp?.type, q?.type, nextOp?.type)) result = false
+
+		if (!ValidTypeValue(lastOp?.value, q.value)) result = false;
+		lastOp = q;
+	});
+	return result
 }
 
 export const queryKOVPair = (): QueryFields[] => [
@@ -23,6 +42,29 @@ export const queryKOVPair = (): QueryFields[] => [
 		value: null,
 	},
 ];
+
+export const initQueryKOVPair = (name?: string = null, op?: string = null  , value?: string | string[] = null ): QueryFields[] => [
+	{
+		type: QueryTypes.QUERY_KEY,
+		value: name,
+	},
+	{
+		type: QueryTypes.QUERY_OPERATOR,
+		value: op,
+	},
+	{
+		type: QueryTypes.QUERY_VALUE,
+		value: value,
+	},
+];
+
+export const prepareConditionOperator = (op?: string = ConditionalOperators.AND): QueryFields => {
+	return {
+		type: QueryTypes.CONDITIONAL_OPERATOR,
+		value: op,
+	}
+}
+
 export const createParsedQueryStructure = (parsedQuery = []) => {
 	if (!parsedQuery.length) {
 		return parsedQuery;
@@ -63,4 +105,18 @@ export const createParsedQueryStructure = (parsedQuery = []) => {
 		qCtr++;
 	});
 	return structuredArray;
+};
+
+export const hashCode = (s: string): string => {
+	if (!s) {
+		return '0';
+	}
+	return `${Math.abs(
+		s.split('').reduce((a, b) => {
+			// eslint-disable-next-line no-bitwise, no-param-reassign
+			a = (a << 5) - a + b.charCodeAt(0);
+			// eslint-disable-next-line no-bitwise
+			return a & a;
+		}, 0),
+	)}`;
 };

--- a/frontend/src/lib/logql/reverseParser.ts
+++ b/frontend/src/lib/logql/reverseParser.ts
@@ -2,20 +2,34 @@
 // @ts-ignore
 // @ts-nocheck
 
+import { QueryTypes, StringTypeQueryOperators } from "./tokens";
+
 export const reverseParser = (
 	parserQueryArr: { type: string; value: any }[] = [],
 ) => {
 	let queryString = '';
+	let lastToken: { type: string; value: any }; 
 	parserQueryArr.forEach((query) => {
 		if (queryString) {
 			queryString += ' ';
 		}
 
 		if (Array.isArray(query.value) && query.value.length > 0) {
+			// if the values are array type, here we spread them in 
+			// ('a', 'b') format 
 			queryString += `(${query.value.map((val) => `'${val}'`).join(',')})`;
 		} else {
-			queryString += query.value;
+			if (query.type === QueryTypes.QUERY_VALUE 
+				&& lastToken.type === QueryTypes.QUERY_OPERATOR 
+				&& Object.values(StringTypeQueryOperators).includes(lastToken.value) ) {
+					// for operators that need string type value, here we append single 
+					// quotes. if the content has single quote they would be removed 
+					queryString += `'${query.value?.replace(/'/g, '')}'`;
+			} else {
+				queryString += query.value;
+			}
 		}
+		lastToken = query;
 	});
 
 	// console.log(queryString);

--- a/frontend/src/lib/logql/tokens.ts
+++ b/frontend/src/lib/logql/tokens.ts
@@ -7,6 +7,21 @@ export const QueryOperatorsSingleVal = {
 	NCONTAINS: 'NCONTAINS',
 };
 
+// list of operators that support only number values
+export const NumTypeQueryOperators = {
+	GTE: 'GTE',
+	GT: 'GT',
+	LTE: 'LTE',
+	LT: 'LT',
+};
+
+// list of operators that support only string values
+export const StringTypeQueryOperators = {
+	CONTAINS: 'CONTAINS',
+	NCONTAINS: 'NCONTAINS',
+};
+
+// list of operators that support array values
 export const QueryOperatorsMultiVal = {
 	IN: 'IN',
 	NIN: 'NIN',
@@ -22,4 +37,47 @@ export const QueryTypes = {
 	QUERY_OPERATOR: 'QUERY_OPERATOR',
 	QUERY_VALUE: 'QUERY_VALUE',
 	CONDITIONAL_OPERATOR: 'CONDITIONAL_OPERATOR',
+};
+
+export const ValidTypeValue = (
+	op: string,
+	value: string | string[],
+): boolean => {
+	if (!op) return true;
+	if (Object.values(NumTypeQueryOperators).includes(op)) {
+		if (Array.isArray(value)) return false;
+		return !Number.isNaN(Number(value));
+	}
+	return true;
+};
+
+// ValidTypeSequence takes prior, current and next op to confirm
+// the proper sequence. For example, if QUERY_VALUE needs to be
+// in between QUERY_OPERATOR and (empty or CONDITIONAL_OPERATOR).
+export const ValidTypeSequence = (
+	prior: string | undefined,
+	current: string | undefined,
+	next: string | undefined,
+): boolean => {
+	switch (current) {
+		case QueryTypes.QUERY_KEY:
+			// query key can have an empty prior
+			if (!prior) return true;
+			return [QueryTypes.CONDITIONAL_OPERATOR].includes(prior);
+		case QueryTypes.QUERY_OPERATOR:
+			// empty prior is not allowed
+			if (!prior || ![QueryTypes.QUERY_KEY].includes(prior)) return false;
+			if (!next || ![QueryTypes.QUERY_VALUE].includes(next)) return false;
+			return true;
+		case QueryTypes.QUERY_VALUE:
+			// empty prior is not allowed
+			if (!prior) return false;
+			return [QueryTypes.QUERY_OPERATOR].includes(prior);
+		case QueryTypes.CONDITIONAL_OPERATOR:
+			// empty prior is not allowed
+			if (!next) return false;
+			return [QueryTypes.QUERY_KEY].includes(next);
+		default:
+			return false;
+	}
 };


### PR DESCRIPTION
This PR adds following changes:
- Adds `apply` button in log query builder panel (pop-over). This replaces the existing functionality of auto-update of search bar on every change in the panel 
- validations on filter criteria. Raise error for empty values, non-numeric values for numeric types (GT, GTE, LT, LTE). 


Close: https://github.com/SigNoz/signoz/issues/1891