### PR TITLE
fix: resolves issue related ops not flowing from search box to panel

### DIFF
--- a/frontend/src/container/LogsSearchFilter/SearchFields/index.tsx
+++ b/frontend/src/container/LogsSearchFilter/SearchFields/index.tsx
@@ -36,7 +36,14 @@ function SearchFields({
 	const keyPrefixRef = useRef(hashCode(JSON.stringify(fieldsQuery)));
 
 	useEffect(() => {
-		setFieldsQuery(createParsedQueryStructure([...parsedQuery] as never[]));
+		const updatedFieldsQuery = createParsedQueryStructure([
+			...parsedQuery,
+		] as never[]);
+		setFieldsQuery(updatedFieldsQuery);
+		const incomingHashCode = hashCode(JSON.stringify(updatedFieldsQuery));
+		if (incomingHashCode !== keyPrefixRef.current) {
+			keyPrefixRef.current = incomingHashCode;
+		}
 	}, [parsedQuery]);
 
 	const addSuggestedField = useCallback(


### PR DESCRIPTION
This PR solves issue related to logs filter. 


Steps  to reproduce:
- Enter query in search box. keep query panel open while you enter the search query
- The entered query should auto populate search fields in the panel but current operators like "IN" is not set as expected. 

