### PR TITLE
style: use 'no data' for empty graphs

### DIFF
--- a/frontend/src/components/Graph/Plugin/EmptyGraph.ts
+++ b/frontend/src/components/Graph/Plugin/EmptyGraph.ts
@@ -11,7 +11,7 @@ export const emptyGraph = {
 		ctx.textBaseline = 'middle';
 		ctx.font = '1.5rem sans-serif';
 		ctx.fillStyle = `${grey.primary}`;
-		ctx.fillText('No Data', width / 2, height / 2);
+		ctx.fillText('No data', width / 2, height / 2);
 		ctx.restore();
 	},
 };

--- a/frontend/src/components/Graph/Plugin/EmptyGraph.ts
+++ b/frontend/src/components/Graph/Plugin/EmptyGraph.ts
@@ -11,7 +11,7 @@ export const emptyGraph = {
 		ctx.textBaseline = 'middle';
 		ctx.font = '1.5rem sans-serif';
 		ctx.fillStyle = `${grey.primary}`;
-		ctx.fillText('No data to display', width / 2, height / 2);
+		ctx.fillText('No Data', width / 2, height / 2);
 		ctx.restore();
 	},
 };


### PR DESCRIPTION
Related to (but not closing) #1908 

Matching the usual `No data` text of Grafana.

