### PR TITLE
chore: update chartjs to version 3.9.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
 		"babel-plugin-named-asset-import": "^0.3.7",
 		"babel-preset-minify": "^0.5.1",
 		"babel-preset-react-app": "^10.0.0",
-		"chart.js": "^3.4.0",
+		"chart.js": "3.9.1",
 		"chartjs-adapter-date-fns": "^2.0.0",
 		"chartjs-plugin-annotation": "^1.4.0",
 		"color": "^4.2.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4208,7 +4208,7 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-chart.js@^3.4.0:
+chart.js@3.9.1:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.9.1.tgz#3abf2c775169c4c71217a107163ac708515924b8"
   integrity sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w==


### PR DESCRIPTION
This update should not affect project as we were using charjs version 3.9.1 already as the rule in package.json tells us to use the latest version 3. This change is to explicitly show that we are using the latest version 3 and can use all of the extra functionality that was introduced between version 3.4.0 (previous) and 3.9.1 (current latest v3).