### PR TITLE
chore(frontend): 🔧 support ARM and copy yarnrc in Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ build-push-frontend:
 	@echo "--> Building and pushing frontend docker image"
 	@echo "------------------"
 	@cd $(FRONTEND_DIRECTORY) && \
-	docker buildx build --file Dockerfile --progress plane --push --platform linux/amd64 \
+	docker buildx build --file Dockerfile --progress plane --push --platform linux/arm64,linux/amd64 \
 	--tag $(REPONAME)/$(FRONTEND_DOCKER_IMAGE):$(DOCKER_TAG) .
 
 # Steps to build and push docker image of query service

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,8 +9,9 @@ ARG TARGETARCH
 
 WORKDIR /frontend
 
-# Copy the package.json to install dependencies
+# Copy the package.json and .yarnrc files prior to install dependencies
 COPY package.json ./
+COPY .yarnrc ./
 
 # Install the dependencies and make the folder
 RUN CI=1 yarn install


### PR DESCRIPTION
- [X] Support ARM for SigNoz Frontend - this fixes issues with Mac M1/M2 chip
- [X] Copy yarnrc file prior to `yarn install` in Dockerfile - this fixes issues seen in Staging env

Signed-off-by: Prashant Shahi <prashant@signoz.io>