### PR TITLE
fix: log issue remove field in query panel

### DIFF
--- a/frontend/src/container/LogsSearchFilter/SearchFields/index.tsx
+++ b/frontend/src/container/LogsSearchFilter/SearchFields/index.tsx
@@ -47,6 +47,11 @@ function SearchFields({
 		}
 	}, [parsedQuery]);
 
+	const updateFieldsQuery = (updated: QueryFields[][]): void => {
+		setFieldsQuery(updated);
+		keyPrefixRef.current = hashCode(JSON.stringify(updated));
+	};
+
 	const addSuggestedField = useCallback(
 		(name: string): void => {
 			if (!name) {
@@ -97,7 +102,7 @@ function SearchFields({
 				keyPrefix={keyPrefixRef.current}
 				onDropDownToggleHandler={onDropDownToggleHandler}
 				fieldsQuery={fieldsQuery}
-				setFieldsQuery={setFieldsQuery}
+				setFieldsQuery={updateFieldsQuery}
 			/>
 			<SearchFieldsActionBar
 				applyUpdate={applyUpdate}


### PR DESCRIPTION
This PR fixes issue with log query panel. 

Steps to reproduce: 
- In log query search panel, add 3 search fields: id IN 'id', stream IN 's', container_id in 'c'
- remove the second search field (stream IN 's')

Expected: the second field  (stream in 's') goes away, and you should see the remaining two search fields in the query panel. 

Actual: the second search field goes away but condition and values from this field are being stamped on the third field. 
here is what you see in the panel:
- id in 'id'
- container_id in 's'

Notice, how the search value of stream 's' got copied over to container id

