### PR TITLE
fix: refresh issue for custom date selection done by clicking on chart

### DIFF
--- a/frontend/src/container/TopNav/DateTimeSelection/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelection/index.tsx
@@ -60,16 +60,25 @@ function DateTimeSelection({
 		searchStartTime,
 	]);
 
-	const [options, setOptions] = useState(getOptions(location.pathname));
-	const [refreshButtonHidden, setRefreshButtonHidden] = useState<boolean>(false);
-	const [customDateTimeVisible, setCustomDTPickerVisible] = useState<boolean>(
-		false,
-	);
-
 	const { maxTime, minTime, selectedTime } = useSelector<
 		AppState,
 		GlobalReducer
 	>((state) => state.globalTime);
+
+	const [options, setOptions] = useState(getOptions(location.pathname));
+	const [refreshButtonHidden, setRefreshButtonHidden] = useState<boolean>(
+		selectedTime === 'custom',
+	);
+
+	useEffect(() => {
+		if (selectedTime === 'custom') {
+			setRefreshButtonHidden(true);
+		}
+	}, [selectedTime]);
+
+	const [customDateTimeVisible, setCustomDTPickerVisible] = useState<boolean>(
+		false,
+	);
 
 	const getInputLabel = (
 		startTime?: Dayjs,


### PR DESCRIPTION
Close: https://github.com/SigNoz/signoz/issues/2145

This PR solves refresh issue that occurs when you set custom date selection (in global time drop down) by clicking on the chart. 

The solution involves disabling of the refresh option when custom dates are picked.