### PR TITLE
fix: solved re-render issue when input fields were edited

### DIFF
--- a/frontend/src/container/LogsSearchFilter/SearchFields/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/container/LogsSearchFilter/SearchFields/QueryBuilder/QueryBuilder.tsx
@@ -175,6 +175,7 @@ export interface QueryBuilderProps {
 	onDropDownToggleHandler: (value: boolean) => VoidFunction;
 	fieldsQuery: QueryFields[][];
 	setFieldsQuery: (q: QueryFields[][]) => void;
+	syncKeyPrefix: () => void;
 }
 
 function QueryBuilder({
@@ -182,6 +183,7 @@ function QueryBuilder({
 	fieldsQuery,
 	setFieldsQuery,
 	onDropDownToggleHandler,
+	syncKeyPrefix,
 }: QueryBuilderProps): JSX.Element {
 	const handleUpdate = (query: Query, queryIndex: number): void => {
 		const updated = [...fieldsQuery];
@@ -195,6 +197,9 @@ function QueryBuilder({
 		else updated.splice(queryIndex, 2);
 
 		setFieldsQuery(updated);
+
+		// initiate re-render query panel
+		syncKeyPrefix();
 	};
 
 	const QueryUI = (

--- a/frontend/src/container/LogsSearchFilter/SearchFields/index.tsx
+++ b/frontend/src/container/LogsSearchFilter/SearchFields/index.tsx
@@ -47,9 +47,12 @@ function SearchFields({
 		}
 	}, [parsedQuery]);
 
-	const updateFieldsQuery = (updated: QueryFields[][]): void => {
-		setFieldsQuery(updated);
-		keyPrefixRef.current = hashCode(JSON.stringify(updated));
+	// syncKeyPrefix initiates re-render. useful in situations like
+	// delete field (in search panel). this method allows condiitonally
+	// setting keyPrefix as doing it on every update of query initiates
+	// a re-render. this is a problem for text fields where input focus goes away.
+	const syncKeyPrefix = (): void => {
+		keyPrefixRef.current = hashCode(JSON.stringify(fieldsQuery));
 	};
 
 	const addSuggestedField = useCallback(
@@ -102,7 +105,8 @@ function SearchFields({
 				keyPrefix={keyPrefixRef.current}
 				onDropDownToggleHandler={onDropDownToggleHandler}
 				fieldsQuery={fieldsQuery}
-				setFieldsQuery={updateFieldsQuery}
+				setFieldsQuery={setFieldsQuery}
+				syncKeyPrefix={syncKeyPrefix}
 			/>
 			<SearchFieldsActionBar
 				applyUpdate={applyUpdate}


### PR DESCRIPTION
Solves side-effect introduced by https://github.com/SigNoz/signoz/pull/2130

The PR solves exactly the same problem as in original PR but in a slightly different way. Instead of refreshing the query panel every time the query changes, here we limit the refresh (re-render) of query-panel only when delete icon is clicked.


**Original Problem:**

Steps to reproduce:

In log query search panel, add 3 search fields: id IN 'id', stream IN 's', container_id in 'c'
remove the second search field (stream IN 's')
Expected: the second field (stream in 's') goes away, and you should see the remaining two search fields in the query panel.

Actual: the second search field goes away but condition and values from this field are being stamped on the third field.
here is what you see in the panel:

id in 'id'
container_id in 's'
Notice, how the search value of stream 's' got copied over to container id

