### PR TITLE
FIX: The last timestamp label overflows in the flamegraph of trace detail page

### DIFF
--- a/frontend/src/container/Timeline/index.tsx
+++ b/frontend/src/container/Timeline/index.tsx
@@ -76,7 +76,11 @@ function Timeline({
 							},0)`}
 							key={`${interval.label + interval.percentage + index}`}
 						>
-							<text y={13} fill={isDarkMode ? 'white' : 'black'}>
+							<text
+								y={13}
+								x={index === intervals.length - 1 ? -10 : 0}
+								fill={isDarkMode ? 'white' : 'black'}
+							>
 								{interval.label}
 							</text>
 							<line


### PR DESCRIPTION
Fixes #865

## Demo
![image](https://user-images.githubusercontent.com/70234898/218851983-71136a79-a2df-4f5f-bc25-c8469e2798d8.png)