### PR TITLE
chore: run all unit tests on CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Install Dependencies
+        shell: bash
+        run: |
+          sudo apt install -y sqlite3
+          make run-dependencies
       - name: Run tests
         shell: bash
         run: |

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,16 @@ down-local:
 	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml -f $(STANDALONE_DIRECTORY)/docker-compose-local.yaml \
 	down -v
 
+run-dependency:
+	@LOCAL_GOOS=$(LOCAL_GOOS) LOCAL_GOARCH=$(LOCAL_GOARCH) docker-compose -f \
+	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml \
+	up --build -d
+
+down-dependency:
+	@docker-compose -f \
+	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml \
+	down -v
+
 pull-signoz:
 	@docker-compose -f $(STANDALONE_DIRECTORY)/docker-compose.yaml pull
 
@@ -137,4 +147,4 @@ clear-swarm-data:
 	sh -c "cd /pwd && rm -rf alertmanager/* clickhouse*/* signoz/* zookeeper-*/*"
 
 test:
-	go test ./pkg/query-service/app/metrics/...
+	@SIGNOZ_LOCAL_DB_PATH="./signoz.db" go test -cover $(shell go list ./pkg/query-service/... | grep -v tests)

--- a/Makefile
+++ b/Makefile
@@ -119,12 +119,12 @@ down-local:
 	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml -f $(STANDALONE_DIRECTORY)/docker-compose-local.yaml \
 	down -v
 
-run-dependency:
+run-dependencies:
 	@LOCAL_GOOS=$(LOCAL_GOOS) LOCAL_GOARCH=$(LOCAL_GOARCH) docker-compose -f \
 	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml \
 	up --build -d
 
-down-dependency:
+down-dependencies:
 	@docker-compose -f \
 	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml \
 	down -v

--- a/Makefile
+++ b/Makefile
@@ -120,9 +120,7 @@ down-local:
 	down -v
 
 run-dependencies:
-	@LOCAL_GOOS=$(LOCAL_GOOS) LOCAL_GOARCH=$(LOCAL_GOARCH) docker-compose -f \
-	$(STANDALONE_DIRECTORY)/docker-compose-core.yaml \
-	up --build -d
+	@docker-compose -f $(STANDALONE_DIRECTORY)/docker-compose-core.yaml up -d
 
 down-dependencies:
 	@docker-compose -f \

--- a/Makefile
+++ b/Makefile
@@ -147,4 +147,4 @@ clear-swarm-data:
 	sh -c "cd /pwd && rm -rf alertmanager/* clickhouse*/* signoz/* zookeeper-*/*"
 
 test:
-	@SIGNOZ_LOCAL_DB_PATH="./signoz.db" go test -cover $(shell go list ./pkg/query-service/... | grep -v tests)
+	@SIGNOZ_LOCAL_DB_PATH="$(CURDIR)/pkg/query-service/signoz.db" go test -cover $(shell go list ./pkg/query-service/... | grep -v tests)

--- a/deploy/docker/clickhouse-setup/docker-compose-core.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose-core.yaml
@@ -30,9 +30,9 @@ services:
     image: signoz/alertmanager:0.23.0-0.2
     volumes:
       - ./data/alertmanager:/data
-    depends_on:
-      query-service:
-        condition: service_healthy
+    # depends_on:
+    #   query-service:
+    #     condition: service_healthy
     restart: on-failure
     command:
       - --queryService.url=http://query-service:8085

--- a/pkg/query-service/app/http_handler_test.go
+++ b/pkg/query-service/app/http_handler_test.go
@@ -67,7 +67,7 @@ func TestPrepareQuery(t *testing.T) {
 				Query: "ALTER TABLE signoz_table DELETE where true",
 			},
 			expectedErr: true,
-			errMsg:      "query shouldn't alter data",
+			errMsg:      "Operation alter table is not allowed",
 		},
 		{
 			name: "query text produces template exec error",


### PR DESCRIPTION
Part of https://github.com/SigNoz/signoz/issues/236

I found a unit test that was degraded by https://github.com/SigNoz/signoz/pull/2036. 

I think that this occurred because CI did not run all unit tests, so I would like to make sure that they do.
I hope this will prevent the unit tests that we will be adding from now on from being degraded.

I tested gh-actions workflow works on my forked repo's PR
* https://github.com/terakoya76/signoz/pull/2
* https://github.com/terakoya76/signoz/actions/runs/4210018578/jobs/7307402587
