### PR TITLE
fix: operator should be IN for top level operations

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -15,7 +15,7 @@ const config: Config.InitialOptions = {
 			useESM: true,
 		},
 	},
-	testMatch: ['<rootDir>/src/**/?(*.)(test).(ts|js)?(x)'],
+	testMatch: ['<rootDir>/src/**/*?(*.)(test).(ts|js)?(x)'],
 	preset: 'ts-jest/presets/js-with-ts-esm',
 	transform: {
 		'^.+\\.(ts|tsx)?$': 'ts-jest',

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
@@ -26,7 +26,7 @@ export const operationPerSec = ({
 		{
 			id: '',
 			key: 'operation',
-			op: 'In',
+			op: 'IN',
 			value: topLevelOperations,
 		},
 		...tagFilterItems,

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
@@ -26,7 +26,7 @@ export const operationPerSec = ({
 		{
 			id: '',
 			key: 'operation',
-			op: 'MATCH',
+			op: 'In',
 			value: topLevelOperations,
 		},
 		...tagFilterItems,
@@ -56,7 +56,7 @@ export const errorPercentage = ({
 		{
 			id: '',
 			key: 'operation',
-			op: 'MATCH',
+			op: 'IN',
 			value: topLevelOperations,
 		},
 		{
@@ -78,7 +78,7 @@ export const errorPercentage = ({
 		{
 			id: '',
 			key: 'operation',
-			op: 'MATCH',
+			op: 'IN',
 			value: topLevelOperations,
 		},
 		...tagFilterItems,


### PR DESCRIPTION
I initially suspected something about the sharding here, but that was reverted here https://github.com/SigNoz/signoz/pull/1847 already, and indeed that wasn't the issue. 

The `MATCH` operator works on a single value. When migrated from the PromQL to Query builder, the operation used was incorrect. Since the PromQL doesn't support the `IN` we used the `~=a|b|c` which is a regex match and that same meaning is copied over, but the values were not concatenated with re2 syntax like they were for PromQL which behaves randomly based on the first operation received from the `/top_level_operations` API which doesn't guarantee any order. 

Fixes #2305

Partially(or fully) address #2291
