### PR TITLE
chore: update CODEOWNERS for */query-service/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 * @ankitnayan
 /frontend/ @palashgdev @pranshuchittora
 /deploy/ @prashant-shahi
-/pkg/query-service/ @srikanthccv
+**/query-service/ @srikanthccv


### PR DESCRIPTION
The approval from person with repo write access only count towards the requirement only If the author is also part of CODEOWNERS or the reviewer is part of the CODEOWNERS. The `**/query-service` signature matches both OSS and EE parts of query service.