### PR TITLE
fix: get last n versions in getConfigHistory

### DIFF
--- a/pkg/query-service/agentConf/manager.go
+++ b/pkg/query-service/agentConf/manager.go
@@ -51,8 +51,8 @@ func GetConfigVersion(ctx context.Context, elementType ElementTypeDef, version i
 	return m.GetConfigVersion(ctx, elementType, version)
 }
 
-func GetConfigHistory(ctx context.Context, typ ElementTypeDef) ([]ConfigVersion, error) {
-	return m.GetConfigHistory(ctx, typ)
+func GetConfigHistory(ctx context.Context, typ ElementTypeDef, limit int) ([]ConfigVersion, error) {
+	return m.GetConfigHistory(ctx, typ, limit)
 }
 
 // StartNewVersion launches a new config version for given set of elements


### PR DESCRIPTION
As of now, we return the entire history, but we discussed that for now we will be working with return last n number of versions in out API response of history.

we will build pagination support for this later. https://github.com/SigNoz/signoz/issues/2429