### PR TITLE
feat(rate-limit): Add rate limit in the PAT based API calls

### DIFF
--- a/ee/query-service/app/rate_limiter.go
+++ b/ee/query-service/app/rate_limiter.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/time/rate"
+)
+
+// The rate limiter supports the following
+// 1. The limit should be applied on per user-identifier.
+// 2. The type of rate limit used is token bucket, to handle burst requests.
+// 3. The rate-limiter doesn't ensure that the identifer is valid or not. It is the responsibility
+// of the user to ensure it.
+type RateLimiter struct {
+	requestPerSecond int
+	burstSize        int
+	identifierMap    map[string]*rate.Limiter
+}
+
+func NewRateLimiter(requestPerSecond, burstSize int) *RateLimiter {
+	return &RateLimiter{
+		requestPerSecond: requestPerSecond,
+		burstSize:        burstSize,
+	}
+}
+
+func (rl *RateLimiter) LimitsIdentifier(id string) bool {
+	_, found := rl.identifierMap[id]
+	return found
+}
+
+func (rl *RateLimiter) AddIdentifier(id string) {
+	rl.identifierMap[id] = rate.NewLimiter(rate.Limit(rl.requestPerSecond), rl.burstSize)
+}
+
+func (rl *RateLimiter) Limit(id string) error {
+	limiter, found := rl.identifierMap[id]
+	if !found {
+		return nil
+	}
+	if err := limiter.Wait(context.Background()); err != nil {
+		return fmt.Errorf("rate limit exceeded: %v", err)
+	}
+	return nil
+}

--- a/ee/query-service/app/server.go
+++ b/ee/query-service/app/server.go
@@ -180,6 +180,7 @@ func NewServer(serverOptions *ServerOptions) (*Server, error) {
 
 		apiHandler: apiHandler,
 		// Allows 100 requests per second, with maximum burst of 50 at a time.
+		// TODO(ahsanb): Figure out the right rate limit.
 		patRateLimiter: NewRateLimiter(100, 50),
 	}
 


### PR DESCRIPTION
Add rate limit on the PAT based API calls.

Each of the PAT tokens are rate limited by token bucket strategy. It is ensured that no DB call is made in order to rate limit the request so as to make rate limit check cheaper.

TODO: What should be the right rate limit per PAT token.
TODO: Validate that the rate limit is working as intended.