### PR TITLE
fix: update default PagerDuty message

### DIFF
--- a/frontend/src/container/CreateAlertChannels/defaults.ts
+++ b/frontend/src/container/CreateAlertChannels/defaults.ts
@@ -1,15 +1,17 @@
 import { PagerChannel } from './config';
 
 export const PagerInitialConfig: Partial<PagerChannel> = {
-	description: `{{ range .Alerts -}}
-	*Alert:* {{ if .Annotations.title }} {{ .Annotations.title }} {{ else }} {{ .Annotations.summary }} {{end}} {{ if .Labels.severity }} - {{ .Labels.severity }}{{ end }}
-	
-	*Description:* {{ .Annotations.description }}
-
-	*Details:*
-		{{ range .Labels.SortedPairs }} • *{{ .Name }}:* {{ .Value }}
-		{{ end }}
-	{{ end }}`,
+	description: `[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }} for {{ .CommonLabels.job }}
+	{{- if gt (len .CommonLabels) (len .GroupLabels) -}}
+	  {{" "}}(
+	  {{- with .CommonLabels.Remove .GroupLabels.Names }}
+		{{- range $index, $label := .SortedPairs -}}
+		  {{ if $index }}, {{ end }}
+		  {{- $label.Name }}="{{ $label.Value -}}"
+		{{- end }}
+	  {{- end -}}
+	  )
+	{{- end }}`,
 	severity: '{{ (index .Alerts 0).Labels.severity }}',
 	client: 'SigNoz Alert Manager',
 	client_url: 'https://enter-signoz-host-n-port-here/alerts',


### PR DESCRIPTION
Fixes #2614 


The current format dumps all the details making it hard to follow. This commit changes it to sane defaults.
<img width="1094" alt="Screenshot 2023-04-21 at 11 00 50 PM" src="https://user-images.githubusercontent.com/22846633/233754703-742ab0ad-3996-4625-a158-66b1536aedda.png">

With and without this change in that order. This can be updated from Alert channel settings as well.