### PR TITLE
fix: changed versions of zookeeper & alertmanager

### DIFF
--- a/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
@@ -34,7 +34,7 @@ x-clickhouse-depend: &clickhouse-depend
 
 services:
   zookeeper-1:
-    image: bitnami/zookeeper:3.7.0
+    image: bitnami/zookeeper:3.7.1
     hostname: zookeeper-1
     user: root
     ports:
@@ -124,7 +124,7 @@ services:
   #     - ./data/clickhouse-3/:/var/lib/clickhouse/
 
   alertmanager:
-    image: signoz/alertmanager:0.23.0-0.2
+    image: signoz/alertmanager:0.23.1
     volumes:
       - ./data/alertmanager:/data
     command:

--- a/deploy/docker/clickhouse-setup/docker-compose-core.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose-core.yaml
@@ -27,7 +27,7 @@ services:
 
   alertmanager:
     container_name: alertmanager
-    image: signoz/alertmanager:0.23.0-0.2
+    image: signoz/alertmanager:0.23.1
     volumes:
       - ./data/alertmanager:/data
     depends_on:

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -158,7 +158,7 @@ services:
     command: ["-config=/root/config/prometheus.yml"]
     ports:
     #   - "6060:6060"     # pprof port
-      - "8080:8080"     # query-service port
+    #   - "8080:8080"     # query-service port
     volumes:
       - ./prometheus.yml:/root/config/prometheus.yml
       - ../dashboards:/root/config/dashboards
@@ -180,17 +180,17 @@ services:
       retries: 3
     <<: *clickhouse-depend
 
-  # frontend:
-  #   image: signoz/frontend:${DOCKER_TAG:-0.18.1}
-  #   container_name: frontend
-  #   restart: on-failure
-  #   depends_on:
-  #     - alertmanager
-  #     - query-service
-  #   ports:
-  #     - "3301:3301"
-  #   volumes:
-  #     - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
+  frontend:
+    image: signoz/frontend:${DOCKER_TAG:-0.18.1}
+    container_name: frontend
+    restart: on-failure
+    depends_on:
+      - alertmanager
+      - query-service
+    ports:
+      - "3301:3301"
+    volumes:
+      - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
 
   otel-collector:
     image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.66.7}

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -34,9 +34,9 @@ x-clickhouse-depend: &clickhouse-depend
     #   condition: service_healthy
 
 services:
-  
+
   zookeeper-1:
-    image: bitnami/zookeeper:3.7.0
+    image: bitnami/zookeeper:3.7.1
     container_name: zookeeper-1
     hostname: zookeeper-1
     user: root
@@ -120,7 +120,7 @@ services:
   #     - ./data/clickhouse-2/:/var/lib/clickhouse/
   #     - ./user_scripts:/var/lib/clickhouse/user_scripts/
 
-
+  
   # clickhouse-3:
   #   <<: *clickhouse-defaults
   #   container_name: clickhouse-3
@@ -139,7 +139,7 @@ services:
   #     - ./user_scripts:/var/lib/clickhouse/user_scripts/
 
   alertmanager:
-    image: signoz/alertmanager:${ALERTMANAGER_TAG:-0.23.0-0.2}
+    image: signoz/alertmanager:${ALERTMANAGER_TAG:-latest}
     volumes:
       - ./data/alertmanager:/data
     depends_on:
@@ -150,7 +150,7 @@ services:
       - --queryService.url=http://query-service:8085
       - --storage.path=/data
 
-# Notes for Maintainers/Contributors who will change Line Numbers of Frontend & Query-Section. Please Update Line Numbers in `./scripts/commentLinesForSetup.sh` & `./CONTRIBUTING.md`
+  # Notes for Maintainers/Contributors who will change Line Numbers of Frontend & Query-Section. Please Update Line Numbers in `./scripts/commentLinesForSetup.sh` & `./CONTRIBUTING.md`
 
   query-service:
     image: signoz/query-service:${DOCKER_TAG:-0.18.1}

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -139,7 +139,7 @@ services:
   #     - ./user_scripts:/var/lib/clickhouse/user_scripts/
 
   alertmanager:
-    image: signoz/alertmanager:${ALERTMANAGER_TAG:-latest}
+    image: signoz/alertmanager:${ALERTMANAGER_TAG:-0.23.1}
     volumes:
       - ./data/alertmanager:/data
     depends_on:
@@ -156,9 +156,9 @@ services:
     image: signoz/query-service:${DOCKER_TAG:-0.18.1}
     container_name: query-service
     command: ["-config=/root/config/prometheus.yml"]
-    # ports:
+    ports:
     #   - "6060:6060"     # pprof port
-    #   - "8080:8080"     # query-service port
+      - "8080:8080"     # query-service port
     volumes:
       - ./prometheus.yml:/root/config/prometheus.yml
       - ../dashboards:/root/config/dashboards
@@ -180,17 +180,17 @@ services:
       retries: 3
     <<: *clickhouse-depend
 
-  frontend:
-    image: signoz/frontend:${DOCKER_TAG:-0.18.1}
-    container_name: frontend
-    restart: on-failure
-    depends_on:
-      - alertmanager
-      - query-service
-    ports:
-      - "3301:3301"
-    volumes:
-      - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
+  # frontend:
+  #   image: signoz/frontend:${DOCKER_TAG:-0.18.1}
+  #   container_name: frontend
+  #   restart: on-failure
+  #   depends_on:
+  #     - alertmanager
+  #     - query-service
+  #   ports:
+  #     - "3301:3301"
+  #   volumes:
+  #     - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
 
   otel-collector:
     image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.66.7}

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -156,7 +156,7 @@ services:
     image: signoz/query-service:${DOCKER_TAG:-0.18.1}
     container_name: query-service
     command: ["-config=/root/config/prometheus.yml"]
-    ports:
+    # ports:
     #   - "6060:6060"     # pprof port
     #   - "8080:8080"     # query-service port
     volumes:

--- a/pkg/query-service/tests/test-deploy/docker-compose.yaml
+++ b/pkg/query-service/tests/test-deploy/docker-compose.yaml
@@ -35,7 +35,7 @@ x-clickhouse-depends: &clickhouse-depends
 
 services:
   zookeeper-1:
-    image: bitnami/zookeeper:3.7.0
+    image: bitnami/zookeeper:3.7.1
     user: root
     ports:
       - "2181:2181"
@@ -127,7 +127,7 @@ services:
   #     - ./data/clickhouse-3/:/var/lib/clickhouse/
 
   alertmanager:
-    image: signoz/alertmanager:0.23.0-0.2
+    image: signoz/alertmanager:0.23.1
     volumes:
       - ./data/alertmanager:/data
     depends_on:


### PR DESCRIPTION
Fixes a part of #2126 

## Changes

- Updated `signoz/alertmanager` to `latest` version as it was having the support of `linux/arm64`.
- Updated `bitnami/zookeeper` from `3.7.0` to `3.7.1` as it's having the support of `linux/arm64`.

After updating to these versions, it was not giving any warning in Apple M2. Not sure, if it's the correct version update but kept it to minor version update only to prevent any breaking change.