### PR TITLE
fix: query builder filter label is adopted for dark mode

### DIFF
--- a/frontend/src/constants/theme.ts
+++ b/frontend/src/constants/theme.ts
@@ -38,6 +38,8 @@ const themeColors = {
 	whiteCream: '#ffffffd5',
 	black: '#000000',
 	lightgrey: '#ddd',
+	borderLightGrey: '#d9d9d9',
+	borderDarkGrey: '#424242',
 };
 
 export { themeColors };

--- a/frontend/src/container/QueryBuilder/components/FilterLabel/FilterLabel.styled.ts
+++ b/frontend/src/container/QueryBuilder/components/FilterLabel/FilterLabel.styled.ts
@@ -1,6 +1,10 @@
+import { themeColors } from 'constants/theme';
 import styled from 'styled-components';
 
-export const StyledLabel = styled.div`
+interface Props {
+	isDarkMode: boolean;
+}
+export const StyledLabel = styled.div<Props>`
 	padding: 0 0.6875rem;
 	min-height: 2rem;
 	min-width: 5.625rem;
@@ -8,6 +12,8 @@ export const StyledLabel = styled.div`
 	white-space: nowrap;
 	align-items: center;
 	border-radius: 0.125rem;
-	border: 0.0625rem solid #434343;
-	background-color: #141414;
+	border: ${({ isDarkMode }): string =>
+		`1px solid ${
+			isDarkMode ? themeColors.borderDarkGrey : themeColors.borderLightGrey
+		}`};
 `;

--- a/frontend/src/container/QueryBuilder/components/FilterLabel/FilterLabel.tsx
+++ b/frontend/src/container/QueryBuilder/components/FilterLabel/FilterLabel.tsx
@@ -1,3 +1,4 @@
+import { useIsDarkMode } from 'hooks/useDarkMode';
 import React, { memo } from 'react';
 
 // ** Types
@@ -8,5 +9,7 @@ import { StyledLabel } from './FilterLabel.styled';
 export const FilterLabel = memo(function FilterLabel({
 	label,
 }: FilterLabelProps): JSX.Element {
-	return <StyledLabel>{label}</StyledLabel>;
+	const isDarkMode = useIsDarkMode();
+
+	return <StyledLabel isDarkMode={isDarkMode}>{label}</StyledLabel>;
 });


### PR DESCRIPTION
fixed the dark mode and light of the query builder

current: 
<img width="728" alt="Screenshot 2023-05-10 at 11 50 31 PM" src="https://github.com/SigNoz/signoz/assets/88981777/0806043b-6cac-416f-a1f9-51a8615b787e">


fixed: 

https://github.com/SigNoz/signoz/assets/88981777/aa3b9efb-b913-4168-9d70-ef6db29f20e0


