### PR TITLE
feat: api machinery to support enterprise plan channels

### DIFF
--- a/ee/query-service/model/plans.go
+++ b/ee/query-service/model/plans.go
@@ -11,9 +11,13 @@ const Enterprise = "ENTERPRISE_PLAN"
 const DisableUpsell = "DISABLE_UPSELL"
 
 var BasicPlan = basemodel.FeatureSet{
-	Basic:         true,
-	SSO:           false,
-	DisableUpsell: false,
+	Basic:                           true,
+	SSO:                             false,
+	DisableUpsell:                   false,
+	basemodel.AlertChannelSlack:     true,
+	basemodel.AlertChannelWebhook:   true,
+	basemodel.AlertChannelPagerduty: true,
+	basemodel.AlertChannelMsTeams:   false,
 }
 
 var ProPlan = basemodel.FeatureSet{
@@ -21,6 +25,10 @@ var ProPlan = basemodel.FeatureSet{
 	SSO:                             true,
 	basemodel.SmartTraceDetail:      true,
 	basemodel.CustomMetricsFunction: true,
+	basemodel.AlertChannelSlack:     true,
+	basemodel.AlertChannelWebhook:   true,
+	basemodel.AlertChannelPagerduty: true,
+	basemodel.AlertChannelMsTeams:   true,
 }
 
 var EnterprisePlan = basemodel.FeatureSet{
@@ -28,4 +36,8 @@ var EnterprisePlan = basemodel.FeatureSet{
 	SSO:                             true,
 	basemodel.SmartTraceDetail:      true,
 	basemodel.CustomMetricsFunction: true,
+	basemodel.AlertChannelSlack:     true,
+	basemodel.AlertChannelWebhook:   true,
+	basemodel.AlertChannelPagerduty: true,
+	basemodel.AlertChannelMsTeams:   true,
 }

--- a/pkg/query-service/integrations/alertManager/model.go
+++ b/pkg/query-service/integrations/alertManager/model.go
@@ -21,6 +21,7 @@ type Receiver struct {
 	PushoverConfigs  interface{} `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
 	VictorOpsConfigs interface{} `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
 	SNSConfigs       interface{} `yaml:"sns_configs,omitempty" json:"sns_configs,omitempty"`
+	MSTeamsConfigs   interface{} `yaml:"msteams_configs,omitempty" json:"teams_configs,omitempty"`
 }
 
 type ReceiverResponse struct {

--- a/pkg/query-service/model/featureSet.go
+++ b/pkg/query-service/model/featureSet.go
@@ -5,7 +5,15 @@ type FeatureSet map[string]bool
 const Basic = "BASIC_PLAN"
 const SmartTraceDetail = "SMART_TRACE_DETAIL"
 const CustomMetricsFunction = "CUSTOM_METRICS_FUNCTION"
+const AlertChannelSlack = "ALERT_CHANNEL_SLACK"
+const AlertChannelWebhook = "ALERT_CHANNEL_WEBHOOK"
+const AlertChannelPagerduty = "ALERT_CHANNEL_PAGERDUTY"
+const AlertChannelMsTeams = "ALERT_CHANNEL_MSTEAMS"
 
 var BasicPlan = FeatureSet{
-	Basic: true,
+	Basic:                 true,
+	AlertChannelSlack:     true,
+	AlertChannelWebhook:   true,
+	AlertChannelPagerduty: true,
+	AlertChannelMsTeams:   false,
 }


### PR DESCRIPTION
This PR introduces enterprise plan channel - MS Teams in the query service. 