### PR TITLE
fix: add legend property to Queries

### DIFF
--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -325,6 +325,7 @@ type PromQuery struct {
 	Query    string `json:"query"`
 	Stats    string `json:"stats,omitempty"`
 	Disabled bool   `json:"disabled"`
+	Legend   string `json:"legend,omitempty"`
 }
 
 func (p *PromQuery) Validate() error {
@@ -342,6 +343,7 @@ func (p *PromQuery) Validate() error {
 type ClickHouseQuery struct {
 	Query    string `json:"query"`
 	Disabled bool   `json:"disabled"`
+	Legend   string `json:"legend,omitempty"`
 }
 
 func (c *ClickHouseQuery) Validate() error {
@@ -419,6 +421,7 @@ type BuilderQuery struct {
 	Expression         string            `json:"expression"`
 	Disabled           bool              `json:"disabled"`
 	Having             []Having          `json:"having,omitempty"`
+	Legend             string            `json:"legend,omitempty"`
 	Limit              uint64            `json:"limit"`
 	Offset             uint64            `json:"offset"`
 	PageSize           uint64            `json:"pageSize"`


### PR DESCRIPTION
Legend param was not being saved to rules db when saving an alert. It was caused by missing legend property in Query structs.