### PR TITLE
chore: update .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,7 @@
 * @ankitnayan
 /frontend/ @palashgdev
 /deploy/ @prashant-shahi
-**/query-service/ @srikanthccv
+# negate the frontend folder and deploy folder but allow rest
+! /deploy @srikanthccv
+! /frontend @srikanthccv
+* @srikanthccv

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,11 @@
 # Owners are automatically requested for review for PRs that changes code
 # that they own.
 * @ankitnayan
+
 /frontend/ @palashgdev
 /deploy/ @prashant-shahi
-# negate the frontend folder and deploy folder but allow rest
-! /deploy @srikanthccv
-! /frontend @srikanthccv
-* @srikanthccv
+/sample-apps/ @prashant-shahi
+**/query-service/ @srikanthccv
+Makefile @srikanthccv
+go.* @srikanthccv
+.git* @srikanthccv


### PR DESCRIPTION
Change some top-level file ownership that doesn't need to be blocked on for review, such as changes to Makefile etc., while also making sure the other directory owner's behaviour continues to work as it is.