### PR TITLE
fix: create and store label when colon is pressed

### DIFF
--- a/frontend/src/container/FormAlertRules/labels/index.tsx
+++ b/frontend/src/container/FormAlertRules/labels/index.tsx
@@ -5,7 +5,7 @@ import {
 import { useMachine } from '@xstate/react';
 import { Button, Input, message, Modal } from 'antd';
 import { useIsDarkMode } from 'hooks/useDarkMode';
-import { map, replace } from 'lodash-es';
+import { map } from 'lodash-es';
 import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Labels } from 'types/api/alerts/def';
@@ -85,7 +85,7 @@ function LabelSelect({
 	}, [handleBlur]);
 
 	const handleLabelChange = (e: ChangeEvent<HTMLInputElement>): void => {
-		const processedCurrentVal = replace(e.target?.value, ':', '');
+		const processedCurrentVal = e.target?.value.replace(':', '');
 		setCurrentVal(processedCurrentVal);
 	};
 

--- a/frontend/src/container/FormAlertRules/labels/index.tsx
+++ b/frontend/src/container/FormAlertRules/labels/index.tsx
@@ -5,7 +5,7 @@ import {
 import { useMachine } from '@xstate/react';
 import { Button, Input, message, Modal } from 'antd';
 import { useIsDarkMode } from 'hooks/useDarkMode';
-import { map } from 'lodash-es';
+import { map, replace } from 'lodash-es';
 import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Labels } from 'types/api/alerts/def';
@@ -84,8 +84,9 @@ function LabelSelect({
 		handleBlur();
 	}, [handleBlur]);
 
-	const handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
-		setCurrentVal(e.target?.value);
+	const handleLabelChange = (e: ChangeEvent<HTMLInputElement>): void => {
+		const processedCurrentVal = replace(e.target?.value, ':', '');
+		setCurrentVal(processedCurrentVal);
 	};
 
 	const handleClose = (key: string): void => {
@@ -133,9 +134,9 @@ function LabelSelect({
 			<div style={{ display: 'flex', width: '100%' }}>
 				<Input
 					placeholder={renderPlaceholder()}
-					onChange={handleChange}
+					onChange={handleLabelChange}
 					onKeyUp={(e): void => {
-						if (e.key === 'Enter' || e.code === 'Enter') {
+						if (e.key === 'Enter' || e.code === 'Enter' || e.key === ':') {
 							send('NEXT');
 						}
 					}}

--- a/frontend/src/container/FormAlertRules/labels/index.tsx
+++ b/frontend/src/container/FormAlertRules/labels/index.tsx
@@ -84,9 +84,8 @@ function LabelSelect({
 		handleBlur();
 	}, [handleBlur]);
 
-	const handleLabelChange = (e: ChangeEvent<HTMLInputElement>): void => {
-		const processedCurrentVal = e.target?.value.replace(':', '');
-		setCurrentVal(processedCurrentVal);
+	const handleLabelChange = (event: ChangeEvent<HTMLInputElement>): void => {
+		setCurrentVal(event.target?.value.replace(':', ''));
 	};
 
 	const handleClose = (key: string): void => {


### PR DESCRIPTION
Fixes #2692

When creating an Alert, the key value pair (label) field allows the user to include a colon in either key or value. It can cause confusion and lead users to believe the key and value must be included as one string in order to account for a label. This is exactly what caused #2692.

I would recommend that in addition to using `ENTER` as a way to end a key or value string, we also allow `COLON (:)` to do the same. In this way, the user will have a better experience. [This screen recording](https://www.loom.com/share/4eaa4272413d44f1813ad1c98e3be44e) shows how it works. 