### PR TITLE
feat: minor fixes to logs QB

### DIFF
--- a/pkg/query-service/app/logs/v3/enrich_query.go
+++ b/pkg/query-service/app/logs/v3/enrich_query.go
@@ -131,7 +131,7 @@ func enrichFieldWithMetadata(field v3.AttributeKey, fields map[string]v3.Attribu
 	// check if the field is present in the fields map
 	if existingField, ok := fields[field.Key]; ok {
 		if existingField.IsColumn {
-			return field
+			return existingField
 		}
 		field.Type = existingField.Type
 		field.DataType = existingField.DataType

--- a/pkg/query-service/app/logs/v3/query_builder.go
+++ b/pkg/query-service/app/logs/v3/query_builder.go
@@ -321,22 +321,13 @@ func orderByAttributeKeyTags(panelType v3.PanelType, aggregatorOperator v3.Aggre
 	}
 	orderByArray := orderBy(panelType, items, groupTags)
 
-	found := false
-	for i := 0; i < len(orderByArray); i++ {
-		if strings.Compare(orderByArray[i], constants.TIMESTAMP) == 0 {
-			orderByArray[i] = "ts"
-			break
+	if panelType == v3.PanelTypeList {
+		if len(orderByArray) == 0 {
+			orderByArray = append(orderByArray, constants.TIMESTAMP)
 		}
-	}
-	if !found {
-		if aggregatorOperator == v3.AggregateOperatorNoOp {
-			// only add order by timestamp if there is no order by specified for noop
-			if len(orderByArray) == 0 || panelType != v3.PanelTypeList {
-				orderByArray = append(orderByArray, constants.TIMESTAMP)
-			}
-		} else {
-			orderByArray = append(orderByArray, "ts")
-		}
+	} else {
+		// since in other aggregation operator we will have to add ts as it will not be present in group by
+		orderByArray = append(orderByArray, "ts")
 	}
 
 	str := strings.Join(orderByArray, ",")

--- a/pkg/query-service/app/logs/v3/query_builder.go
+++ b/pkg/query-service/app/logs/v3/query_builder.go
@@ -330,7 +330,10 @@ func orderByAttributeKeyTags(panelType v3.PanelType, aggregatorOperator v3.Aggre
 	}
 	if !found {
 		if aggregatorOperator == v3.AggregateOperatorNoOp {
-			orderByArray = append(orderByArray, constants.TIMESTAMP)
+			// only add order by timestamp if there is no order by specified for noop
+			if len(orderByArray) == 0 {
+				orderByArray = append(orderByArray, constants.TIMESTAMP)
+			}
 		} else {
 			orderByArray = append(orderByArray, "ts")
 		}

--- a/pkg/query-service/app/logs/v3/query_builder.go
+++ b/pkg/query-service/app/logs/v3/query_builder.go
@@ -331,7 +331,7 @@ func orderByAttributeKeyTags(panelType v3.PanelType, aggregatorOperator v3.Aggre
 	if !found {
 		if aggregatorOperator == v3.AggregateOperatorNoOp {
 			// only add order by timestamp if there is no order by specified for noop
-			if len(orderByArray) == 0 && panelType != v3.PanelTypeList {
+			if len(orderByArray) == 0 || panelType != v3.PanelTypeList {
 				orderByArray = append(orderByArray, constants.TIMESTAMP)
 			}
 		} else {

--- a/pkg/query-service/app/logs/v3/query_builder.go
+++ b/pkg/query-service/app/logs/v3/query_builder.go
@@ -331,7 +331,7 @@ func orderByAttributeKeyTags(panelType v3.PanelType, aggregatorOperator v3.Aggre
 	if !found {
 		if aggregatorOperator == v3.AggregateOperatorNoOp {
 			// only add order by timestamp if there is no order by specified for noop
-			if len(orderByArray) == 0 {
+			if len(orderByArray) == 0 && panelType != v3.PanelTypeList {
 				orderByArray = append(orderByArray, constants.TIMESTAMP)
 			}
 		} else {

--- a/pkg/query-service/app/logs/v3/query_builder_test.go
+++ b/pkg/query-service/app/logs/v3/query_builder_test.go
@@ -606,6 +606,25 @@ var testBuildLogsQueryData = []struct {
 			"from signoz_logs.distributed_logs where (timestamp >= 1680066360726210000 AND timestamp <= 1680066458000000000) order by timestamp",
 	},
 	{
+		Name:      "Test Noop order by custom",
+		PanelType: v3.PanelTypeList,
+		Start:     1680066360726210000,
+		End:       1680066458000000000,
+		Step:      60,
+		BuilderQuery: &v3.BuilderQuery{
+			SelectColumns:     []v3.AttributeKey{},
+			QueryName:         "A",
+			AggregateOperator: v3.AggregateOperatorNoOp,
+			Expression:        "A",
+			Filters:           &v3.FilterSet{Operator: "AND", Items: []v3.FilterItem{}},
+			OrderBy:           []v3.OrderBy{{ColumnName: "method", Order: "ASC", IsColumn: true}},
+		},
+		ExpectedQuery: "SELECT timestamp, id, trace_id, span_id, trace_flags, severity_text, severity_number, body,CAST((attributes_string_key, attributes_string_value), 'Map(String, String)') as  attributes_string," +
+			"CAST((attributes_int64_key, attributes_int64_value), 'Map(String, Int64)') as  attributes_int64,CAST((attributes_float64_key, attributes_float64_value), 'Map(String, Float64)') as  attributes_float64," +
+			"CAST((resources_string_key, resources_string_value), 'Map(String, String)') as resources_string " +
+			"from signoz_logs.distributed_logs where (timestamp >= 1680066360726210000 AND timestamp <= 1680066458000000000) order by method ASC",
+	},
+	{
 		Name:      "Test aggregate with having clause",
 		PanelType: v3.PanelTypeGraph,
 		Start:     1680066360726210000,

--- a/pkg/query-service/app/logs/v3/query_builder_test.go
+++ b/pkg/query-service/app/logs/v3/query_builder_test.go
@@ -589,7 +589,7 @@ var testBuildLogsQueryData = []struct {
 	},
 	{
 		Name:      "Test Noop",
-		PanelType: v3.PanelTypeGraph,
+		PanelType: v3.PanelTypeList,
 		Start:     1680066360726210000,
 		End:       1680066458000000000,
 		Step:      60,


### PR DESCRIPTION
* Was returning wrong variable in enrich funtion
* Timestamp order by should not be added when a custom order by is selected in list panel 
* Previous logic of order by was added under the impression that timestamp can come in order by for aggregation -> but it won’t come since timestamp won’t be there in group by