### PR TITLE
chore: 🔧 upgrade distributed locust to 1.2.3 and updated related files

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -66,7 +66,7 @@ To generate load:
 ```sh
 kubectl -n sample-application run strzal --image=djbingham/curl \
 --restart='OnFailure' -i --tty --rm --command -- curl -X POST -F \
-'locust_count=6' -F 'hatch_rate=2' http://locust-master:8089/swarm
+'user_count=6' -F 'spawn_rate=2' http://locust-master:8089/swarm
 ```
 
 To stop load:

--- a/sample-apps/hotrod/README.md
+++ b/sample-apps/hotrod/README.md
@@ -5,7 +5,7 @@ Follow the steps in this section to install a sample application named HotR.O.D,
 ```console
 kubectl create ns sample-application
 
-kubectl -n sample-application apply -f https://github.com/SigNoz/signoz/raw/main/sample-apps/hotrod/hotrod.yaml
+kubectl -n sample-application apply -f https://github.com/SigNoz/signoz/raw/develop/sample-apps/hotrod/hotrod.yaml
 ```
 
 In case, you have installed SigNoz in namespace other than `platform` or selected Helm release name other than `my-release`, follow the steps below:
@@ -15,7 +15,7 @@ export HELM_RELEASE=my-release-2
 export SIGNOZ_NAMESPACE=platform-2
 export HOTROD_NAMESPACE=sample-application-2
 
-curl -sL https://github.com/SigNoz/signoz/raw/main/sample-apps/hotrod/hotrod-install.sh | bash
+curl -sL https://github.com/SigNoz/signoz/raw/develop/sample-apps/hotrod/hotrod-install.sh | bash
 ```
 
 To delete sample application:
@@ -23,5 +23,15 @@ To delete sample application:
 ```console
 export HOTROD_NAMESPACE=sample-application-2
 
-curl -sL https://github.com/SigNoz/signoz/raw/main/sample-apps/hotrod/hotrod-delete.sh | bash
+curl -sL https://github.com/SigNoz/signoz/raw/develop/sample-apps/hotrod/hotrod-delete.sh | bash
+```
+
+For testing with local scripts, you can use the following commands:
+
+```console
+# To install hotrod
+cat hotrod-install.sh | bash
+
+# To delete hotrod
+cat hotrod-delete.sh | bash
 ```

--- a/sample-apps/hotrod/hotrod-install.sh
+++ b/sample-apps/hotrod/hotrod-install.sh
@@ -16,7 +16,7 @@ fi
 # Locust's docker image
 if [[ -z $LOCUST_IMAGE ]]; then
     LOCUST_REPO="${LOCUST_REPO:-signoz/locust}"
-    LOCUST_TAG="${LOCUST_TAG:-0.8.1-py3.6}"
+    LOCUST_TAG="${LOCUST_TAG:-1.2.3}"
     LOCUST_IMAGE="${LOCUST_REPO}:${LOCUST_TAG}"
 fi
 

--- a/sample-apps/hotrod/hotrod-template.yaml
+++ b/sample-apps/hotrod/hotrod-template.yaml
@@ -11,8 +11,10 @@ metadata:
   name: scripts-cm
 data:
   locustfile.py: |
-    from locust import HttpLocust, TaskSet, task
-    class UserTasks(TaskSet):
+    from locust import HttpUser, task, between
+    class UserTasks(HttpUser):
+        wait_time = between(5, 15)
+
         @task
         def rachel(self):
             self.client.get("/dispatch?customer=123&nonse=0.6308392664170006")
@@ -25,8 +27,6 @@ data:
         @task
         def coffee(self):
             self.client.get("/dispatch?customer=567&nonse=0.0022220379420636593")
-    class WebsiteUser(HttpLocust):
-        task_set = UserTasks
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -155,13 +155,13 @@ metadata:
   annotations:
     deployment.kubernetes.io/revision: "1"
   labels:
-    role: locust-slave
-  name: locust-slave
+    role: locust-worker
+  name: locust-worker
 spec:
   replicas: 1
   selector:
     matchLabels:
-      role: locust-slave
+      role: locust-worker
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -170,12 +170,12 @@ spec:
   template:
     metadata:
       labels:
-        role: locust-slave
+        role: locust-worker
     spec:
       containers:
       - image: ${LOCUST_IMAGE}
         imagePullPolicy: IfNotPresent
-        name: locust-slave
+        name: locust-worker
         env:
           - name: ATTACKED_HOST
             valueFrom:
@@ -183,8 +183,8 @@ spec:
                 name: locust-cm
                 key: ATTACKED_HOST
           - name: LOCUST_MODE
-            value: SLAVE
-          - name: LOCUST_MASTER
+            value: WORKER
+          - name: LOCUST_MASTER_HOST
             value: locust-master
         volumeMounts:
           - mountPath: /locust

--- a/sample-apps/hotrod/hotrod.yaml
+++ b/sample-apps/hotrod/hotrod.yaml
@@ -11,8 +11,10 @@ metadata:
   name: scripts-cm
 data:
   locustfile.py: |
-    from locust import HttpLocust, TaskSet, task
-    class UserTasks(TaskSet):
+    from locust import HttpUser, task, between
+    class UserTasks(HttpUser):
+        wait_time = between(5, 15)
+
         @task
         def rachel(self):
             self.client.get("/dispatch?customer=123&nonse=0.6308392664170006")
@@ -25,8 +27,6 @@ data:
         @task
         def coffee(self):
             self.client.get("/dispatch?customer=567&nonse=0.0022220379420636593")
-    class WebsiteUser(HttpLocust):
-        task_set = UserTasks
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -155,13 +155,13 @@ metadata:
   annotations:
     deployment.kubernetes.io/revision: "1"
   labels:
-    role: locust-slave
-  name: locust-slave
+    role: locust-worker
+  name: locust-worker
 spec:
   replicas: 1
   selector:
     matchLabels:
-      role: locust-slave
+      role: locust-worker
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -170,12 +170,12 @@ spec:
   template:
     metadata:
       labels:
-        role: locust-slave
+        role: locust-worker
     spec:
       containers:
       - image: signoz/locust:1.2.3
         imagePullPolicy: IfNotPresent
-        name: locust-slave
+        name: locust-worker
         env:
           - name: ATTACKED_HOST
             valueFrom:
@@ -183,8 +183,8 @@ spec:
                 name: locust-cm
                 key: ATTACKED_HOST
           - name: LOCUST_MODE
-            value: SLAVE
-          - name: LOCUST_MASTER
+            value: WORKER
+          - name: LOCUST_MASTER_HOST
             value: locust-master
         volumeMounts:
           - mountPath: /locust


### PR DESCRIPTION
Instructions to start the swarm will be updated as well:

```bash
kubectl -n sample-application run strzal --image=djbingham/curl \
--restart='OnFailure' -i --tty --rm --command -- curl -X POST -F \
'user_count=6' -F 'spawn_rate=2' http://locust-master:8089/swarm
```

Signed-off-by: Prashant Shahi <prashant@signoz.io>
