### PR TITLE
fix: autcomplete top level keys

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -3958,7 +3958,10 @@ func (r *ClickHouseReader) GetLogAttributeValues(ctx context.Context, req *v3.Fi
 
 	// if dataType or tagType is not present return empty response
 	if len(req.FilterAttributeKeyDataType) == 0 || len(req.TagType) == 0 || req.FilterAttributeKey == "body" {
-		return &v3.FilterAttributeValueResponse{}, nil
+		// also check if it is not a top level key
+		if _, ok := constants.StaticFieldsLogsV3[req.FilterAttributeKey]; !ok {
+			return &v3.FilterAttributeValueResponse{}, nil
+		}
 	}
 
 	// if data type is bool, return true and false


### PR DESCRIPTION
We directly query the column for top level keys, but it was not working since there was a wrong codition, have fixed it.

Fixes #3078 