### PR TITLE
Key Operation to Metrics using USE_SPAN_METRIC feature flag

### DIFF
--- a/frontend/src/container/MetricsApplication/MetricsApplication.factory.ts
+++ b/frontend/src/container/MetricsApplication/MetricsApplication.factory.ts
@@ -1,18 +1,24 @@
-import { PANEL_TYPES } from 'constants/queryBuilder';
 import { Widgets } from 'types/api/dashboard/getAll';
 import { v4 } from 'uuid';
 
-export const getWidgetQueryBuilder = (
-	query: Widgets['query'],
+export const getWidgetQueryBuilder = ({
+	query,
 	title = '',
-): Widgets => ({
+	panelTypes,
+}: GetWidgetQueryBuilderProps): Widgets => ({
 	description: '',
 	id: v4(),
 	isStacked: false,
 	nullZeroValues: '',
 	opacity: '0',
-	panelTypes: PANEL_TYPES.TIME_SERIES,
+	panelTypes,
 	query,
 	timePreferance: 'GLOBAL_TIME',
 	title,
 });
+
+export interface GetWidgetQueryBuilderProps {
+	query: Widgets['query'];
+	title?: string;
+	panelTypes: Widgets['panelTypes'];
+}

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/DBCallQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/DBCallQueries.ts
@@ -1,7 +1,11 @@
 import { OPERATORS } from 'constants/queryBuilder';
 import { BaseAutocompleteData } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { TagFilterItem } from 'types/api/queryBuilder/queryBuilderData';
-import { DataSource, QueryBuilderData } from 'types/common/queryBuilder';
+import {
+	DataSource,
+	MetricAggregateOperator,
+	QueryBuilderData,
+} from 'types/common/queryBuilder';
 
 import { DataType, FORMULA, MetricsType, WidgetKeys } from '../constant';
 import { IServiceName } from '../Tabs/types';
@@ -87,15 +91,27 @@ export const databaseCallsAvgDuration = ({
 	];
 	const additionalItemsB = additionalItemsA;
 
-	return getQueryBuilderQuerieswithFormula({
+	const autocompleteData: BaseAutocompleteData[] = [
 		autocompleteDataA,
 		autocompleteDataB,
+	];
+
+	const additionalItems: TagFilterItem[][] = [
 		additionalItemsA,
 		additionalItemsB,
+	];
+
+	return getQueryBuilderQuerieswithFormula({
+		autocompleteData,
+		additionalItems,
 		legend: '',
 		disabled: true,
 		expression: FORMULA.DATABASE_CALLS_AVG_DURATION,
 		legendFormula: 'Average Duration',
+		aggregateOperators: [
+			MetricAggregateOperator.SUM,
+			MetricAggregateOperator.SUM,
+		],
 	});
 };
 

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/DBCallQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/DBCallQueries.ts
@@ -105,7 +105,7 @@ export const databaseCallsAvgDuration = ({
 		autocompleteData,
 		additionalItems,
 		legend: '',
-		disabled: true,
+		disabled: [true, true],
 		expression: FORMULA.DATABASE_CALLS_AVG_DURATION,
 		legendFormula: 'Average Duration',
 		aggregateOperators: [

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/DBCallQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/DBCallQueries.ts
@@ -112,6 +112,7 @@ export const databaseCallsAvgDuration = ({
 			MetricAggregateOperator.SUM,
 			MetricAggregateOperator.SUM,
 		],
+		dataSource: DataSource.METRICS,
 	});
 };
 

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/DBCallQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/DBCallQueries.ts
@@ -104,7 +104,7 @@ export const databaseCallsAvgDuration = ({
 	return getQueryBuilderQuerieswithFormula({
 		autocompleteData,
 		additionalItems,
-		legend: '',
+		legends: ['', ''],
 		disabled: [true, true],
 		expression: FORMULA.DATABASE_CALLS_AVG_DURATION,
 		legendFormula: 'Average Duration',

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
@@ -81,7 +81,7 @@ export const externalCallErrorPercent = ({
 	];
 	const legendFormula = legend;
 	const expression = FORMULA.ERROR_PERCENTAGE;
-	const disabled = true;
+	const disabled = [true, true];
 	const autocompleteData: BaseAutocompleteData[] = [
 		autocompleteDataA,
 		autocompleteDataB,
@@ -127,7 +127,7 @@ export const externalCallDuration = ({
 	const expression = FORMULA.DATABASE_CALLS_AVG_DURATION;
 	const legendFormula = 'Average Duration';
 	const legend = '';
-	const disabled = true;
+	const disabled = [true, true];
 	const additionalItemsA: TagFilterItem[] = [
 		{
 			id: '',
@@ -227,7 +227,7 @@ export const externalCallDurationByAddress = ({
 	};
 	const expression = FORMULA.DATABASE_CALLS_AVG_DURATION;
 	const legendFormula = legend;
-	const disabled = true;
+	const disabled = [true, true];
 	const additionalItemsA: TagFilterItem[] = [
 		{
 			id: '',

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
@@ -104,6 +104,7 @@ export const externalCallErrorPercent = ({
 			MetricAggregateOperator.SUM,
 			MetricAggregateOperator.SUM,
 		],
+		dataSource: DataSource.METRICS,
 	});
 };
 
@@ -163,6 +164,7 @@ export const externalCallDuration = ({
 			MetricAggregateOperator.SUM,
 			MetricAggregateOperator.SUM,
 		],
+		dataSource: DataSource.METRICS,
 	});
 };
 
@@ -263,6 +265,7 @@ export const externalCallDurationByAddress = ({
 			MetricAggregateOperator.SUM_RATE,
 			MetricAggregateOperator.SUM_RATE,
 		],
+		dataSource: DataSource.METRICS,
 	});
 };
 

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
@@ -1,7 +1,11 @@
 import { OPERATORS } from 'constants/queryBuilder';
 import { BaseAutocompleteData } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { TagFilterItem } from 'types/api/queryBuilder/queryBuilderData';
-import { DataSource, QueryBuilderData } from 'types/common/queryBuilder';
+import {
+	DataSource,
+	MetricAggregateOperator,
+	QueryBuilderData,
+} from 'types/common/queryBuilder';
 
 import { DataType, FORMULA, MetricsType, WidgetKeys } from '../constant';
 import { IServiceName } from '../Tabs/types';
@@ -78,16 +82,28 @@ export const externalCallErrorPercent = ({
 	const legendFormula = legend;
 	const expression = FORMULA.ERROR_PERCENTAGE;
 	const disabled = true;
-	return getQueryBuilderQuerieswithFormula({
+	const autocompleteData: BaseAutocompleteData[] = [
 		autocompleteDataA,
 		autocompleteDataB,
+	];
+
+	const additionalItems: TagFilterItem[][] = [
 		additionalItemsA,
 		additionalItemsB,
+	];
+
+	return getQueryBuilderQuerieswithFormula({
+		autocompleteData,
+		additionalItems,
 		legend,
 		groupBy,
 		disabled,
 		expression,
 		legendFormula,
+		aggregateOperators: [
+			MetricAggregateOperator.SUM,
+			MetricAggregateOperator.SUM,
+		],
 	});
 };
 
@@ -125,17 +141,28 @@ export const externalCallDuration = ({
 		},
 		...tagFilterItems,
 	];
-	const additionalItemsB = additionalItemsA;
 
-	return getQueryBuilderQuerieswithFormula({
+	const autocompleteData: BaseAutocompleteData[] = [
 		autocompleteDataA,
 		autocompleteDataB,
+	];
+
+	const additionalItems: TagFilterItem[][] = [
 		additionalItemsA,
-		additionalItemsB,
+		additionalItemsA,
+	];
+
+	return getQueryBuilderQuerieswithFormula({
+		autocompleteData,
+		additionalItems,
 		legend,
 		disabled,
 		expression,
 		legendFormula,
+		aggregateOperators: [
+			MetricAggregateOperator.SUM,
+			MetricAggregateOperator.SUM,
+		],
 	});
 };
 
@@ -213,18 +240,29 @@ export const externalCallDurationByAddress = ({
 		},
 		...tagFilterItems,
 	];
-	const additionalItemsB = additionalItemsA;
 
-	return getQueryBuilderQuerieswithFormula({
+	const autocompleteData: BaseAutocompleteData[] = [
 		autocompleteDataA,
 		autocompleteDataB,
+	];
+
+	const additionalItems: TagFilterItem[][] = [
 		additionalItemsA,
-		additionalItemsB,
+		additionalItemsA,
+	];
+
+	return getQueryBuilderQuerieswithFormula({
+		autocompleteData,
+		additionalItems,
 		legend,
 		groupBy,
 		disabled,
 		expression,
 		legendFormula,
+		aggregateOperators: [
+			MetricAggregateOperator.SUM_RATE,
+			MetricAggregateOperator.SUM_RATE,
+		],
 	});
 };
 

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
@@ -95,7 +95,7 @@ export const externalCallErrorPercent = ({
 	return getQueryBuilderQuerieswithFormula({
 		autocompleteData,
 		additionalItems,
-		legend,
+		legends: [legend, legend],
 		groupBy,
 		disabled,
 		expression,
@@ -156,7 +156,7 @@ export const externalCallDuration = ({
 	return getQueryBuilderQuerieswithFormula({
 		autocompleteData,
 		additionalItems,
-		legend,
+		legends: [legend, legend],
 		disabled,
 		expression,
 		legendFormula,
@@ -256,7 +256,7 @@ export const externalCallDurationByAddress = ({
 	return getQueryBuilderQuerieswithFormula({
 		autocompleteData,
 		additionalItems,
-		legend,
+		legends: [legend, legend],
 		groupBy,
 		disabled,
 		expression,

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/MetricsPageQueriesFactory.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/MetricsPageQueriesFactory.ts
@@ -1,4 +1,5 @@
 import {
+	alphabet,
 	initialFormulaBuilderFormValues,
 	initialQueryBuilderFormValuesMap,
 } from 'constants/queryBuilder';
@@ -61,15 +62,14 @@ export const getQueryBuilderQueries = ({
 });
 
 export const getQueryBuilderQuerieswithFormula = ({
-	autocompleteDataA,
-	autocompleteDataB,
-	additionalItemsA,
-	additionalItemsB,
+	autocompleteData,
+	additionalItems,
 	legend,
 	groupBy = [],
 	disabled,
 	expression,
 	legendFormula,
+	aggregateOperators,
 }: BuilderQuerieswithFormulaProps): QueryBuilderData => ({
 	queryFormulas: [
 		{
@@ -78,46 +78,26 @@ export const getQueryBuilderQuerieswithFormula = ({
 			legend: legendFormula,
 		},
 	],
-	queryData: [
-		{
-			...initialQueryBuilderFormValuesMap.metrics,
-			aggregateOperator: MetricAggregateOperator.SUM_RATE,
-			disabled,
-			groupBy,
-			legend,
-			aggregateAttribute: autocompleteDataA,
-			reduceTo: 'sum',
-			filters: {
-				items: additionalItemsA,
-				op: 'AND',
-			},
-			stepInterval: getStep({
-				end: store.getState().globalTime.maxTime,
-				inputFormat: 'ns',
-				start: store.getState().globalTime.minTime,
-			}),
+	queryData: autocompleteData.map((_, index) => ({
+		...initialQueryBuilderFormValuesMap.metrics,
+		aggregateOperator: aggregateOperators[index],
+		disabled,
+		groupBy,
+		legend,
+		aggregateAttribute: autocompleteData[index],
+		queryName: alphabet[index],
+		expression: alphabet[index],
+		reduceTo: 'sum',
+		filters: {
+			items: additionalItems[index],
+			op: 'AND',
 		},
-		{
-			...initialQueryBuilderFormValuesMap.metrics,
-			aggregateOperator: MetricAggregateOperator.SUM_RATE,
-			disabled,
-			groupBy,
-			legend,
-			aggregateAttribute: autocompleteDataB,
-			queryName: 'B',
-			expression: 'B',
-			reduceTo: 'sum',
-			filters: {
-				items: additionalItemsB,
-				op: 'AND',
-			},
-			stepInterval: getStep({
-				end: store.getState().globalTime.maxTime,
-				inputFormat: 'ns',
-				start: store.getState().globalTime.minTime,
-			}),
-		},
-	],
+		stepInterval: getStep({
+			end: store.getState().globalTime.maxTime,
+			inputFormat: 'ns',
+			start: store.getState().globalTime.minTime,
+		}),
+	})),
 });
 
 interface BuilderQueriesProps {
@@ -131,13 +111,12 @@ interface BuilderQueriesProps {
 }
 
 interface BuilderQuerieswithFormulaProps {
-	autocompleteDataA: BaseAutocompleteData;
-	autocompleteDataB: BaseAutocompleteData;
+	autocompleteData: BaseAutocompleteData[];
 	legend: string;
 	disabled: boolean;
 	groupBy?: BaseAutocompleteData[];
 	expression: string;
 	legendFormula: string;
-	additionalItemsA: TagFilterItem[];
-	additionalItemsB: TagFilterItem[];
+	additionalItems: TagFilterItem[][];
+	aggregateOperators: MetricAggregateOperator[];
 }

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/MetricsPageQueriesFactory.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/MetricsPageQueriesFactory.ts
@@ -64,7 +64,7 @@ export const getQueryBuilderQueries = ({
 export const getQueryBuilderQuerieswithFormula = ({
 	autocompleteData,
 	additionalItems,
-	legend,
+	legends,
 	groupBy = [],
 	disabled,
 	expression,
@@ -84,7 +84,7 @@ export const getQueryBuilderQuerieswithFormula = ({
 		aggregateOperator: aggregateOperators[index],
 		disabled: disabled[index],
 		groupBy,
-		legend,
+		legend: legends[index],
 		aggregateAttribute: autocompleteData[index],
 		queryName: alphabet[index],
 		expression: alphabet[index],
@@ -114,7 +114,7 @@ interface BuilderQueriesProps {
 
 interface BuilderQuerieswithFormulaProps {
 	autocompleteData: BaseAutocompleteData[];
-	legend: string;
+	legends: string[];
 	disabled: boolean[];
 	groupBy?: BaseAutocompleteData[];
 	expression: string;

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/MetricsPageQueriesFactory.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/MetricsPageQueriesFactory.ts
@@ -82,7 +82,7 @@ export const getQueryBuilderQuerieswithFormula = ({
 	queryData: autocompleteData.map((_, index) => ({
 		...initialQueryBuilderFormValuesMap.metrics,
 		aggregateOperator: aggregateOperators[index],
-		disabled,
+		disabled: disabled[index],
 		groupBy,
 		legend,
 		aggregateAttribute: autocompleteData[index],
@@ -115,7 +115,7 @@ interface BuilderQueriesProps {
 interface BuilderQuerieswithFormulaProps {
 	autocompleteData: BaseAutocompleteData[];
 	legend: string;
-	disabled: boolean;
+	disabled: boolean[];
 	groupBy?: BaseAutocompleteData[];
 	expression: string;
 	legendFormula: string;

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/MetricsPageQueriesFactory.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/MetricsPageQueriesFactory.ts
@@ -70,6 +70,7 @@ export const getQueryBuilderQuerieswithFormula = ({
 	expression,
 	legendFormula,
 	aggregateOperators,
+	dataSource,
 }: BuilderQuerieswithFormulaProps): QueryBuilderData => ({
 	queryFormulas: [
 		{
@@ -97,6 +98,7 @@ export const getQueryBuilderQuerieswithFormula = ({
 			inputFormat: 'ns',
 			start: store.getState().globalTime.minTime,
 		}),
+		dataSource,
 	})),
 });
 
@@ -119,4 +121,5 @@ interface BuilderQuerieswithFormulaProps {
 	legendFormula: string;
 	additionalItems: TagFilterItem[][];
 	aggregateOperators: MetricAggregateOperator[];
+	dataSource: DataSource;
 }

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
@@ -224,7 +224,7 @@ export const errorPercentage = ({
 		additionalItemsB,
 	];
 
-	const a = getQueryBuilderQuerieswithFormula({
+	return getQueryBuilderQuerieswithFormula({
 		autocompleteData,
 		additionalItems,
 		legends: [GraphTitle.ERROR_PERCENTAGE],
@@ -237,10 +237,6 @@ export const errorPercentage = ({
 		],
 		dataSource: DataSource.METRICS,
 	});
-
-	console.log('a', a);
-
-	return a;
 };
 
 export interface OperationPerSecProps {

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
@@ -1,7 +1,11 @@
 import { OPERATORS } from 'constants/queryBuilder';
 import { BaseAutocompleteData } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { TagFilterItem } from 'types/api/queryBuilder/queryBuilderData';
-import { DataSource, QueryBuilderData } from 'types/common/queryBuilder';
+import {
+	DataSource,
+	MetricAggregateOperator,
+	QueryBuilderData,
+} from 'types/common/queryBuilder';
 
 import {
 	DataType,
@@ -146,6 +150,12 @@ export const errorPercentage = ({
 		isColumn: true,
 		type: null,
 	};
+
+	const autocompleteData: BaseAutocompleteData[] = [
+		autocompleteDataA,
+		autocompleteDataB,
+	];
+
 	const additionalItemsA: TagFilterItem[] = [
 		{
 			id: '',
@@ -209,16 +219,27 @@ export const errorPercentage = ({
 		...tagFilterItems,
 	];
 
-	return getQueryBuilderQuerieswithFormula({
-		autocompleteDataA,
-		autocompleteDataB,
+	const additionalItems: TagFilterItem[][] = [
 		additionalItemsA,
 		additionalItemsB,
+	];
+
+	const a = getQueryBuilderQuerieswithFormula({
+		autocompleteData,
+		additionalItems,
 		legend: GraphTitle.ERROR_PERCENTAGE,
 		disabled: true,
 		expression: FORMULA.ERROR_PERCENTAGE,
 		legendFormula: GraphTitle.ERROR_PERCENTAGE,
+		aggregateOperators: [
+			MetricAggregateOperator.SUM_RATE,
+			MetricAggregateOperator.SUM_RATE,
+		],
 	});
+
+	console.log('a', a);
+
+	return a;
 };
 
 export interface OperationPerSecProps {

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
@@ -227,7 +227,7 @@ export const errorPercentage = ({
 	const a = getQueryBuilderQuerieswithFormula({
 		autocompleteData,
 		additionalItems,
-		legend: GraphTitle.ERROR_PERCENTAGE,
+		legends: [GraphTitle.ERROR_PERCENTAGE],
 		disabled: [true, true],
 		expression: FORMULA.ERROR_PERCENTAGE,
 		legendFormula: GraphTitle.ERROR_PERCENTAGE,

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
@@ -228,7 +228,7 @@ export const errorPercentage = ({
 		autocompleteData,
 		additionalItems,
 		legend: GraphTitle.ERROR_PERCENTAGE,
-		disabled: true,
+		disabled: [true, true],
 		expression: FORMULA.ERROR_PERCENTAGE,
 		legendFormula: GraphTitle.ERROR_PERCENTAGE,
 		aggregateOperators: [

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
@@ -235,6 +235,7 @@ export const errorPercentage = ({
 			MetricAggregateOperator.SUM_RATE,
 			MetricAggregateOperator.SUM_RATE,
 		],
+		dataSource: DataSource.METRICS,
 	});
 
 	console.log('a', a);

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/TopOperationQueryFactory.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/TopOperationQueryFactory.ts
@@ -1,0 +1,145 @@
+import { OPERATORS } from 'constants/queryBuilder';
+import { BaseAutocompleteData } from 'types/api/queryBuilder/queryAutocompleteResponse';
+import { TagFilterItem } from 'types/api/queryBuilder/queryBuilderData';
+import {
+	DataSource,
+	MetricAggregateOperator,
+	QueryBuilderData,
+} from 'types/common/queryBuilder';
+
+import {
+	DataType,
+	GraphTitle,
+	KeyOperationTableHeader,
+	MetricsType,
+	WidgetKeys,
+} from '../constant';
+import { IServiceName } from '../Tabs/types';
+import { getQueryBuilderQuerieswithFormula } from './MetricsPageQueriesFactory';
+
+export const topOperationQueryFactory = ({
+	servicename,
+}: TopOperationQueryFactoryProps): QueryBuilderData => {
+	const latencyAutoCompleteData: BaseAutocompleteData = {
+		key: WidgetKeys.Signoz_latency_bucket,
+		dataType: DataType.FLOAT64,
+		isColumn: true,
+		type: null,
+	};
+
+	const errorRateAutoCompleteData: BaseAutocompleteData = {
+		key: WidgetKeys.SignozCallsTotal,
+		dataType: DataType.FLOAT64,
+		isColumn: true,
+		type: null,
+	};
+
+	const numOfCountAutoCompleteData: BaseAutocompleteData = {
+		key: WidgetKeys.SignozLatencyCount,
+		dataType: DataType.FLOAT64,
+		isColumn: true,
+		type: null,
+	};
+
+	const latencyAndNumberOfCallAdditionalItems: TagFilterItem[] = [
+		{
+			id: '',
+			key: {
+				key: WidgetKeys.Service_name,
+				dataType: DataType.STRING,
+				isColumn: false,
+				type: MetricsType.Resource,
+			},
+			value: [servicename],
+			op: 'IN',
+		},
+	];
+
+	const errorRateAdditionalItemsA: TagFilterItem[] = [
+		{
+			id: '',
+			key: {
+				dataType: DataType.STRING,
+				isColumn: false,
+				key: WidgetKeys.Service_name,
+				type: MetricsType.Resource,
+			},
+			op: OPERATORS.IN,
+			value: [servicename],
+		},
+		{
+			id: '',
+			key: {
+				dataType: DataType.INT64,
+				isColumn: false,
+				key: WidgetKeys.StatusCode,
+				type: MetricsType.Tag,
+			},
+			op: OPERATORS.IN,
+			value: ['STATUS_CODE_ERROR'],
+		},
+	];
+
+	const errorRateAdditionalItemsB: TagFilterItem[] = latencyAndNumberOfCallAdditionalItems;
+
+	const groupBy: BaseAutocompleteData[] = [
+		{
+			dataType: DataType.STRING,
+			isColumn: false,
+			key: WidgetKeys.Operation,
+			type: MetricsType.Tag,
+		},
+	];
+
+	const autocompleteData = [
+		latencyAutoCompleteData,
+		latencyAutoCompleteData,
+		latencyAutoCompleteData,
+		errorRateAutoCompleteData,
+		errorRateAutoCompleteData,
+		numOfCountAutoCompleteData,
+	];
+	const additionalItems = [
+		latencyAndNumberOfCallAdditionalItems,
+		latencyAndNumberOfCallAdditionalItems,
+		latencyAndNumberOfCallAdditionalItems,
+		errorRateAdditionalItemsA,
+		errorRateAdditionalItemsB,
+		latencyAndNumberOfCallAdditionalItems,
+	];
+	const disabled = [false, false, false, true, true, false];
+	const legends = [
+		KeyOperationTableHeader.P50,
+		KeyOperationTableHeader.P90,
+		KeyOperationTableHeader.P99,
+		KeyOperationTableHeader.ERROR_RATE,
+		KeyOperationTableHeader.ERROR_RATE,
+		KeyOperationTableHeader.NUM_OF_CALLS,
+	];
+	const aggregateOperators = [
+		MetricAggregateOperator.HIST_QUANTILE_50,
+		MetricAggregateOperator.HIST_QUANTILE_90,
+		MetricAggregateOperator.HIST_QUANTILE_99,
+		MetricAggregateOperator.SUM_RATE,
+		MetricAggregateOperator.SUM_RATE,
+		MetricAggregateOperator.SUM_RATE,
+	];
+	const expression = 'D*100/E';
+	const legendFormula = GraphTitle.ERROR_PERCENTAGE;
+
+	return getQueryBuilderQuerieswithFormula({
+		autocompleteData,
+		additionalItems,
+		disabled,
+		legends,
+		aggregateOperators,
+		expression,
+		legendFormula,
+		dataSource: DataSource.METRICS,
+		groupBy,
+	});
+};
+
+interface TopOperationQueryFactoryProps {
+	servicename: IServiceName['servicename'];
+}

--- a/frontend/src/container/MetricsApplication/Tabs/DBCall.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/DBCall.tsx
@@ -1,4 +1,5 @@
 import { Col } from 'antd';
+import { PANEL_TYPES } from 'constants/queryBuilder';
 import Graph from 'container/GridGraphLayout/Graph/';
 import {
 	databaseCallsAvgDuration,
@@ -50,8 +51,8 @@ function DBCall(): JSX.Element {
 
 	const databaseCallsRPSWidget = useMemo(
 		() =>
-			getWidgetQueryBuilder(
-				{
+			getWidgetQueryBuilder({
+				query: {
 					queryType: EQueryType.QUERY_BUILDER,
 					promql: [],
 					builder: databaseCallsRPS({
@@ -62,14 +63,15 @@ function DBCall(): JSX.Element {
 					clickhouse_sql: [],
 					id: uuid(),
 				},
-				GraphTitle.DATABASE_CALLS_RPS,
-			),
+				title: GraphTitle.DATABASE_CALLS_RPS,
+				panelTypes: PANEL_TYPES.TIME_SERIES,
+			}),
 		[servicename, tagFilterItems],
 	);
 	const databaseCallsAverageDurationWidget = useMemo(
 		() =>
-			getWidgetQueryBuilder(
-				{
+			getWidgetQueryBuilder({
+				query: {
 					queryType: EQueryType.QUERY_BUILDER,
 					promql: [],
 					builder: databaseCallsAvgDuration({
@@ -79,8 +81,9 @@ function DBCall(): JSX.Element {
 					clickhouse_sql: [],
 					id: uuid(),
 				},
-				GraphTitle.DATABASE_CALLS_AVG_DURATION,
-			),
+				title: GraphTitle.DATABASE_CALLS_AVG_DURATION,
+				panelTypes: PANEL_TYPES.TIME_SERIES,
+			}),
 		[servicename, tagFilterItems],
 	);
 

--- a/frontend/src/container/MetricsApplication/Tabs/External.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/External.tsx
@@ -1,4 +1,5 @@
 import { Col } from 'antd';
+import { PANEL_TYPES } from 'constants/queryBuilder';
 import Graph from 'container/GridGraphLayout/Graph/';
 import {
 	externalCallDuration,
@@ -41,8 +42,8 @@ function External(): JSX.Element {
 
 	const externalCallErrorWidget = useMemo(
 		() =>
-			getWidgetQueryBuilder(
-				{
+			getWidgetQueryBuilder({
+				query: {
 					queryType: EQueryType.QUERY_BUILDER,
 					promql: [],
 					builder: externalCallErrorPercent({
@@ -53,8 +54,9 @@ function External(): JSX.Element {
 					clickhouse_sql: [],
 					id: uuid(),
 				},
-				GraphTitle.EXTERNAL_CALL_ERROR_PERCENTAGE,
-			),
+				title: GraphTitle.EXTERNAL_CALL_ERROR_PERCENTAGE,
+				panelTypes: PANEL_TYPES.TIME_SERIES,
+			}),
 		[servicename, tagFilterItems],
 	);
 
@@ -65,8 +67,8 @@ function External(): JSX.Element {
 
 	const externalCallDurationWidget = useMemo(
 		() =>
-			getWidgetQueryBuilder(
-				{
+			getWidgetQueryBuilder({
+				query: {
 					queryType: EQueryType.QUERY_BUILDER,
 					promql: [],
 					builder: externalCallDuration({
@@ -76,15 +78,16 @@ function External(): JSX.Element {
 					clickhouse_sql: [],
 					id: uuid(),
 				},
-				GraphTitle.EXTERNAL_CALL_DURATION,
-			),
+				title: GraphTitle.EXTERNAL_CALL_DURATION,
+				panelTypes: PANEL_TYPES.TIME_SERIES,
+			}),
 		[servicename, tagFilterItems],
 	);
 
 	const externalCallRPSWidget = useMemo(
 		() =>
-			getWidgetQueryBuilder(
-				{
+			getWidgetQueryBuilder({
+				query: {
 					queryType: EQueryType.QUERY_BUILDER,
 					promql: [],
 					builder: externalCallRpsByAddress({
@@ -95,15 +98,16 @@ function External(): JSX.Element {
 					clickhouse_sql: [],
 					id: uuid(),
 				},
-				GraphTitle.EXTERNAL_CALL_RPS_BY_ADDRESS,
-			),
+				title: GraphTitle.EXTERNAL_CALL_RPS_BY_ADDRESS,
+				panelTypes: PANEL_TYPES.TIME_SERIES,
+			}),
 		[servicename, tagFilterItems],
 	);
 
 	const externalCallDurationAddressWidget = useMemo(
 		() =>
-			getWidgetQueryBuilder(
-				{
+			getWidgetQueryBuilder({
+				query: {
 					queryType: EQueryType.QUERY_BUILDER,
 					promql: [],
 					builder: externalCallDurationByAddress({
@@ -114,8 +118,9 @@ function External(): JSX.Element {
 					clickhouse_sql: [],
 					id: uuid(),
 				},
-				GraphTitle.EXTERNAL_CALL_DURATION_BY_ADDRESS,
-			),
+				title: GraphTitle.EXTERNAL_CALL_DURATION_BY_ADDRESS,
+				panelTypes: PANEL_TYPES.TIME_SERIES,
+			}),
 		[servicename, tagFilterItems],
 	);
 

--- a/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
@@ -3,6 +3,7 @@ import getTopLevelOperations, {
 } from 'api/metrics/getTopLevelOperations';
 import { ActiveElement, Chart, ChartData, ChartEvent } from 'chart.js';
 import { QueryParams } from 'constants/query';
+import { PANEL_TYPES } from 'constants/queryBuilder';
 import ROUTES from 'constants/routes';
 import { routeConfig } from 'container/SideNav/config';
 import { getQueryString } from 'container/SideNav/helper';
@@ -32,7 +33,8 @@ import {
 import { Col, Row } from '../styles';
 import ServiceOverview from './Overview/ServiceOverview';
 import TopLevelOperation from './Overview/TopLevelOperations';
-import TopOperation from './Overview/TopOperation';
+// import TopOperation from './Overview/TopOperation';
+import TopOperationMetrics from './Overview/TopOperationMetrics';
 import { Button } from './styles';
 import { IServiceName } from './types';
 import {
@@ -104,8 +106,8 @@ function Application(): JSX.Element {
 
 	const operationPerSecWidget = useMemo(
 		() =>
-			getWidgetQueryBuilder(
-				{
+			getWidgetQueryBuilder({
+				query: {
 					queryType: EQueryType.QUERY_BUILDER,
 					promql: [],
 					builder: operationPerSec({
@@ -116,15 +118,16 @@ function Application(): JSX.Element {
 					clickhouse_sql: [],
 					id: uuid(),
 				},
-				GraphTitle.RATE_PER_OPS,
-			),
+				title: GraphTitle.RATE_PER_OPS,
+				panelTypes: PANEL_TYPES.TIME_SERIES,
+			}),
 		[servicename, tagFilterItems, topLevelOperationsRoute],
 	);
 
 	const errorPercentageWidget = useMemo(
 		() =>
-			getWidgetQueryBuilder(
-				{
+			getWidgetQueryBuilder({
+				query: {
 					queryType: EQueryType.QUERY_BUILDER,
 					promql: [],
 					builder: errorPercentage({
@@ -135,8 +138,9 @@ function Application(): JSX.Element {
 					clickhouse_sql: [],
 					id: uuid(),
 				},
-				GraphTitle.ERROR_PERCENTAGE,
-			),
+				title: GraphTitle.ERROR_PERCENTAGE,
+				panelTypes: PANEL_TYPES.TIME_SERIES,
+			}),
 		[servicename, tagFilterItems, topLevelOperationsRoute],
 	);
 
@@ -239,7 +243,8 @@ function Application(): JSX.Element {
 				</Col>
 
 				<Col span={12}>
-					<TopOperation />
+					{/* <TopOperation /> */}
+					<TopOperationMetrics />
 				</Col>
 			</Row>
 		</>

--- a/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
@@ -2,11 +2,13 @@ import getTopLevelOperations, {
 	ServiceDataProps,
 } from 'api/metrics/getTopLevelOperations';
 import { ActiveElement, Chart, ChartData, ChartEvent } from 'chart.js';
+import { FeatureKeys } from 'constants/features';
 import { QueryParams } from 'constants/query';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import ROUTES from 'constants/routes';
 import { routeConfig } from 'container/SideNav/config';
 import { getQueryString } from 'container/SideNav/helper';
+import useFeatureFlag from 'hooks/useFeatureFlag';
 import useResourceAttribute from 'hooks/useResourceAttribute';
 import {
 	convertRawQueriesToTraceSelectedTags,
@@ -30,10 +32,10 @@ import {
 	errorPercentage,
 	operationPerSec,
 } from '../MetricsPageQueries/OverviewQueries';
-import { Col, Row } from '../styles';
+import { Card, Col, Row } from '../styles';
 import ServiceOverview from './Overview/ServiceOverview';
 import TopLevelOperation from './Overview/TopLevelOperations';
-// import TopOperation from './Overview/TopOperation';
+import TopOperation from './Overview/TopOperation';
 import TopOperationMetrics from './Overview/TopOperationMetrics';
 import { Button } from './styles';
 import { IServiceName } from './types';
@@ -55,6 +57,8 @@ function Application(): JSX.Element {
 		() => (convertRawQueriesToTraceSelectedTags(queries) as Tags[]) || [],
 		[queries],
 	);
+	const isSpanMetricEnabled = useFeatureFlag(FeatureKeys.USE_SPAN_METRICS)
+		?.active;
 
 	const handleSetTimeStamp = useCallback((selectTime: number) => {
 		setSelectedTimeStamp(selectTime);
@@ -243,8 +247,9 @@ function Application(): JSX.Element {
 				</Col>
 
 				<Col span={12}>
-					{/* <TopOperation /> */}
-					<TopOperationMetrics />
+					<Card>
+						{isSpanMetricEnabled ? <TopOperationMetrics /> : <TopOperation />}
+					</Card>
 				</Col>
 			</Row>
 		</>

--- a/frontend/src/container/MetricsApplication/Tabs/Overview/ServiceOverview.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview/ServiceOverview.tsx
@@ -1,4 +1,5 @@
 import { FeatureKeys } from 'constants/features';
+import { PANEL_TYPES } from 'constants/queryBuilder';
 import Graph from 'container/GridGraphLayout/Graph/';
 import { GraphTitle } from 'container/MetricsApplication/constant';
 import { getWidgetQueryBuilder } from 'container/MetricsApplication/MetricsApplication.factory';
@@ -31,8 +32,8 @@ function ServiceOverview({
 
 	const latencyWidget = useMemo(
 		() =>
-			getWidgetQueryBuilder(
-				{
+			getWidgetQueryBuilder({
+				query: {
 					queryType: EQueryType.QUERY_BUILDER,
 					promql: [],
 					builder: latency({
@@ -44,8 +45,9 @@ function ServiceOverview({
 					clickhouse_sql: [],
 					id: uuid(),
 				},
-				GraphTitle.LATENCY,
-			),
+				title: GraphTitle.LATENCY,
+				panelTypes: PANEL_TYPES.TIME_SERIES,
+			}),
 		[servicename, tagFilterItems, isSpanMetricEnable, topLevelOperationsRoute],
 	);
 

--- a/frontend/src/container/MetricsApplication/Tabs/Overview/TopOperation.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview/TopOperation.tsx
@@ -1,6 +1,5 @@
 import getTopOperations from 'api/metrics/getTopOperations';
 import Spinner from 'components/Spinner';
-import { Card } from 'container/MetricsApplication/styles';
 import TopOperationsTable from 'container/MetricsApplication/TopOperationsTable';
 import useResourceAttribute from 'hooks/useResourceAttribute';
 import { convertRawQueriesToTraceSelectedTags } from 'hooks/useResourceAttribute/utils';
@@ -36,10 +35,10 @@ function TopOperation(): JSX.Element {
 	});
 
 	return (
-		<Card>
+		<>
 			{isLoading && <Spinner size="large" tip="Loading..." height="40vh" />}
 			{!isLoading && <TopOperationsTable data={data || []} />}
-		</Card>
+		</>
 	);
 }
 

--- a/frontend/src/container/MetricsApplication/Tabs/Overview/TopOperationMetrics.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview/TopOperationMetrics.tsx
@@ -1,0 +1,96 @@
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { getWidgetQueryBuilder } from 'container/MetricsApplication/MetricsApplication.factory';
+import { topOperationQueryFactory } from 'container/MetricsApplication/MetricsPageQueries/TopOperationQueryFactory';
+import { QueryTable } from 'container/QueryTable';
+import { useGetQueryRange } from 'hooks/queryBuilder/useGetQueryRange';
+import { useStepInterval } from 'hooks/queryBuilder/useStepInterval';
+import { getDashboardVariables } from 'lib/dashbaordVariables/getDashboardVariables';
+import { isEmpty } from 'lodash-es';
+import { useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
+import { AppState } from 'store/reducers';
+import { EQueryType } from 'types/common/dashboard';
+import { GlobalReducer } from 'types/reducer/globalTime';
+import { v4 as uuid } from 'uuid';
+
+import { IServiceName } from '../types';
+
+function TopOperationMetrics(): JSX.Element {
+	const { servicename } = useParams<IServiceName>();
+
+	const [errorMessage, setErrorMessage] = useState<string | undefined>('');
+	const { minTime, maxTime, selectedTime: globalSelectedInterval } = useSelector<
+		AppState,
+		GlobalReducer
+	>((state) => state.globalTime);
+
+	const keyOperationWidget = useMemo(
+		() =>
+			getWidgetQueryBuilder({
+				query: {
+					queryType: EQueryType.QUERY_BUILDER,
+					promql: [],
+					builder: topOperationQueryFactory({
+						servicename,
+					}),
+					clickhouse_sql: [],
+					id: uuid(),
+				},
+				panelTypes: PANEL_TYPES.TABLE,
+			}),
+		[servicename],
+	);
+
+	const updatedQuery = useStepInterval(keyOperationWidget.query);
+
+	const isEmptyWidget = useMemo(
+		() => keyOperationWidget.id === 'empty' || isEmpty(keyOperationWidget),
+		[keyOperationWidget],
+	);
+
+	const queryResponse = useGetQueryRange(
+		{
+			selectedTime: keyOperationWidget?.timePreferance,
+			graphType: keyOperationWidget?.panelTypes,
+			query: updatedQuery,
+			globalSelectedInterval,
+			variables: getDashboardVariables(),
+		},
+		{
+			queryKey: [
+				`GetMetricsQueryRange-${keyOperationWidget?.timePreferance}-${globalSelectedInterval}-${keyOperationWidget?.id}`,
+				keyOperationWidget,
+				maxTime,
+				minTime,
+				globalSelectedInterval,
+			],
+			keepPreviousData: true,
+			enabled: !isEmptyWidget,
+			refetchOnMount: false,
+			onError: (error) => {
+				setErrorMessage(error.message);
+			},
+		},
+	);
+
+	console.log('QueryResponse', updatedQuery);
+
+	if (queryResponse.isLoading && queryResponse.data === undefined) {
+		return <div>Loading...</div>;
+	}
+
+	if (errorMessage) {
+		return <div>{errorMessage}</div>;
+	}
+
+	return (
+		<QueryTable
+			query={updatedQuery}
+			queryTableData={queryResponse.data?.payload.data.newResult.data.result || []}
+			loading={queryResponse.isLoading}
+		/>
+	);
+}
+
+export default TopOperationMetrics;

--- a/frontend/src/container/MetricsApplication/Tabs/Overview/TopOperationMetrics.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview/TopOperationMetrics.tsx
@@ -1,3 +1,4 @@
+import Spinner from 'components/Spinner';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import { getWidgetQueryBuilder } from 'container/MetricsApplication/MetricsApplication.factory';
 import { topOperationQueryFactory } from 'container/MetricsApplication/MetricsPageQueries/TopOperationQueryFactory';
@@ -49,7 +50,7 @@ function TopOperationMetrics(): JSX.Element {
 		[keyOperationWidget],
 	);
 
-	const queryResponse = useGetQueryRange(
+	const { data, isLoading } = useGetQueryRange(
 		{
 			selectedTime: keyOperationWidget?.timePreferance,
 			graphType: keyOperationWidget?.panelTypes,
@@ -74,10 +75,10 @@ function TopOperationMetrics(): JSX.Element {
 		},
 	);
 
-	console.log('QueryResponse', updatedQuery);
+	const queryTableData = data?.payload.data.newResult.data.result || [];
 
-	if (queryResponse.isLoading && queryResponse.data === undefined) {
-		return <div>Loading...</div>;
+	if (isLoading) {
+		return <Spinner size="large" tip="Loading..." height="40vh" />;
 	}
 
 	if (errorMessage) {
@@ -87,8 +88,8 @@ function TopOperationMetrics(): JSX.Element {
 	return (
 		<QueryTable
 			query={updatedQuery}
-			queryTableData={queryResponse.data?.payload.data.newResult.data.result || []}
-			loading={queryResponse.isLoading}
+			queryTableData={queryTableData}
+			loading={isLoading}
 		/>
 	);
 }

--- a/frontend/src/container/MetricsApplication/constant.ts
+++ b/frontend/src/container/MetricsApplication/constant.ts
@@ -28,6 +28,14 @@ export enum GraphTitle {
 	EXTERNAL_CALL_DURATION_BY_ADDRESS = 'External Call duration(by Address)',
 }
 
+export enum KeyOperationTableHeader {
+	P50 = 'P50',
+	P90 = 'P90',
+	P99 = 'P99',
+	NUM_OF_CALLS = 'Number of Calls',
+	ERROR_RATE = 'Error Rate',
+}
+
 export enum DataType {
 	STRING = 'string',
 	FLOAT64 = 'float64',


### PR DESCRIPTION
This PR will shift key operation API calls from traces to metrics using the `USE_SPAN_METRIC` feature flag. 