### PR TITLE
fix(FE): rendering order of values on the log details page

### DIFF
--- a/frontend/src/container/LogDetailedView/TableView.tsx
+++ b/frontend/src/container/LogDetailedView/TableView.tsx
@@ -51,10 +51,33 @@ function TableView({
 		return null;
 	}
 
+	const fieldOrder = [
+		'timestamp',
+		'id',
+		'trace_id',
+		'span_id',
+		'trace_flags',
+		'severity_number',
+		'severity_text',
+		'body',
+		'attributes_string.container_id',
+		'attributes_string.log_file_path',
+		'attributes_string.stream',
+	];
+
 	const dataSource =
 		flattenLogData !== null &&
 		Object.keys(flattenLogData)
 			.filter((field) => fieldSearchFilter(field, fieldSearchInput))
+			.sort((a, b) => {
+				const indexA = fieldOrder.indexOf(a);
+				const indexB = fieldOrder.indexOf(b);
+
+				if (indexA === -1) return 1;
+				if (indexB === -1) return -1;
+
+				return indexA - indexB;
+			})
 			.map((key) => ({
 				key,
 				field: key,


### PR DESCRIPTION
fix(FE): Ensure proper order of values on logs detail page

![image](https://github.com/SigNoz/signoz/assets/94978425/c8b431f9-9343-4435-a680-cbb49af09a2a)

closes issue #3158 . The previous version had a specific ordering for timestamp, id, trace_id, span_id, trace_flags, severity_number, severity_text, body, attributes_string.container_id, attributes_string.log_file_path, and attributes_string.stream on the logs detail page. The new detail page was rendering the values in random order. This commit updates the rendering logic to respect the defined fieldOrder array, ensuring the values are displayed in the correct order.
