### PR TITLE
fix: remove unnecessary API call when multiple queries are existing in the traces explorer

### DIFF
--- a/frontend/src/pages/TracesExplorer/index.tsx
+++ b/frontend/src/pages/TracesExplorer/index.tsx
@@ -192,11 +192,18 @@ function TracesExplorer(): JSX.Element {
 
 		if (
 			(currentTab === PANEL_TYPES.LIST || currentTab === PANEL_TYPES.TRACE) &&
-			shouldChangeView
+			shouldChangeView &&
+			panelType
 		) {
 			handleTabChange(PANEL_TYPES.TIME_SERIES);
 		}
-	}, [currentTab, isMultipleQueries, isGroupByExist, handleTabChange]);
+	}, [
+		currentTab,
+		isMultipleQueries,
+		isGroupByExist,
+		panelType,
+		handleTabChange,
+	]);
 
 	return (
 		<>


### PR DESCRIPTION
Close: [#3291](https://github.com/SigNoz/signoz/issues/3291)