### PR TITLE
fix: [FE-3128]: Logs Explorer: Show options based on format type selected

### DIFF
--- a/frontend/src/constants/optionsFormatTypes.ts
+++ b/frontend/src/constants/optionsFormatTypes.ts
@@ -1,0 +1,5 @@
+export enum OptionFormatTypes {
+	RAW = 'raw',
+	LIST = 'list',
+	TABLE = 'table',
+}

--- a/frontend/src/container/ExplorerControlPanel/ExplorerControlPanel.interfaces.ts
+++ b/frontend/src/container/ExplorerControlPanel/ExplorerControlPanel.interfaces.ts
@@ -1,6 +1,7 @@
 import { OptionsMenuConfig } from 'container/OptionsMenu/types';
 
 export type ExplorerControlPanelProps = {
+	selectedOptionFormat: string;
 	isShowPageSize: boolean;
 	isLoading: boolean;
 	optionsMenuConfig?: OptionsMenuConfig;

--- a/frontend/src/container/ExplorerControlPanel/index.tsx
+++ b/frontend/src/container/ExplorerControlPanel/index.tsx
@@ -6,6 +6,7 @@ import { ExplorerControlPanelProps } from './ExplorerControlPanel.interfaces';
 import { ContainerStyled } from './styles';
 
 function ExplorerControlPanel({
+	selectedOptionFormat,
 	isLoading,
 	isShowPageSize,
 	optionsMenuConfig,
@@ -15,7 +16,10 @@ function ExplorerControlPanel({
 			<Row justify="end" gutter={30}>
 				{optionsMenuConfig && (
 					<Col>
-						<OptionsMenu config={optionsMenuConfig} />
+						<OptionsMenu
+							selectedOptionFormat={selectedOptionFormat}
+							config={optionsMenuConfig}
+						/>
 					</Col>
 				)}
 				<Col>

--- a/frontend/src/container/LogsExplorerList/index.tsx
+++ b/frontend/src/container/LogsExplorerList/index.tsx
@@ -141,6 +141,7 @@ function LogsExplorerList({
 	return (
 		<>
 			<ExplorerControlPanel
+				selectedOptionFormat={options.format}
 				isLoading={isLoading}
 				isShowPageSize={false}
 				optionsMenuConfig={config}

--- a/frontend/src/container/OptionsMenu/index.tsx
+++ b/frontend/src/container/OptionsMenu/index.tsx
@@ -1,5 +1,6 @@
 import { SettingFilled, SettingOutlined } from '@ant-design/icons';
 import { Popover, Space } from 'antd';
+import { OptionFormatTypes } from 'constants/optionsFormatTypes';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -12,10 +13,14 @@ import { OptionsMenuConfig } from './types';
 import useOptionsMenu from './useOptionsMenu';
 
 interface OptionsMenuProps {
+	selectedOptionFormat?: string;
 	config: OptionsMenuConfig;
 }
 
-function OptionsMenu({ config }: OptionsMenuProps): JSX.Element {
+function OptionsMenu({
+	selectedOptionFormat,
+	config,
+}: OptionsMenuProps): JSX.Element {
 	const { t } = useTranslation(['trace']);
 	const isDarkMode = useIsDarkMode();
 
@@ -23,11 +28,15 @@ function OptionsMenu({ config }: OptionsMenuProps): JSX.Element {
 		() => (
 			<OptionsContentWrapper direction="vertical">
 				{config?.format && <FormatField config={config.format} />}
-				{config?.maxLines && <MaxLinesField config={config.maxLines} />}
-				{config?.addColumn && <AddColumnField config={config.addColumn} />}
+				{selectedOptionFormat === OptionFormatTypes.RAW && config?.maxLines && (
+					<MaxLinesField config={config.maxLines} />
+				)}
+				{(selectedOptionFormat === OptionFormatTypes.LIST ||
+					selectedOptionFormat === OptionFormatTypes.TABLE) &&
+					config?.addColumn && <AddColumnField config={config.addColumn} />}
 			</OptionsContentWrapper>
 		),
-		[config],
+		[config, selectedOptionFormat],
 	);
 
 	const SettingIcon = isDarkMode ? SettingOutlined : SettingFilled;
@@ -45,5 +54,9 @@ function OptionsMenu({ config }: OptionsMenuProps): JSX.Element {
 }
 
 export default OptionsMenu;
+
+OptionsMenu.defaultProps = {
+	selectedOptionFormat: 'raw',
+};
 
 export { useOptionsMenu };

--- a/frontend/src/container/TracesExplorer/Controls/index.tsx
+++ b/frontend/src/container/TracesExplorer/Controls/index.tsx
@@ -1,9 +1,9 @@
-import { memo } from 'react';
 import { OptionFormatTypes } from 'constants/optionsFormatTypes';
 import Controls, { ControlsProps } from 'container/Controls';
 import OptionsMenu from 'container/OptionsMenu';
 import { OptionsMenuConfig } from 'container/OptionsMenu/types';
 import useQueryPagination from 'hooks/queryPagination/useQueryPagination';
+import { memo } from 'react';
 
 import { Container } from './styles';
 

--- a/frontend/src/container/TracesExplorer/Controls/index.tsx
+++ b/frontend/src/container/TracesExplorer/Controls/index.tsx
@@ -1,8 +1,9 @@
+import { memo } from 'react';
+import { OptionFormatTypes } from 'constants/optionsFormatTypes';
 import Controls, { ControlsProps } from 'container/Controls';
 import OptionsMenu from 'container/OptionsMenu';
 import { OptionsMenuConfig } from 'container/OptionsMenu/types';
 import useQueryPagination from 'hooks/queryPagination/useQueryPagination';
-import { memo } from 'react';
 
 import { Container } from './styles';
 
@@ -21,7 +22,12 @@ function TraceExplorerControls({
 
 	return (
 		<Container>
-			{config && <OptionsMenu config={{ addColumn: config?.addColumn }} />}
+			{config && (
+				<OptionsMenu
+					selectedOptionFormat={OptionFormatTypes.LIST} // Defaulting it to List view as options are shown only in the List view tab
+					config={{ addColumn: config?.addColumn }}
+				/>
+			)}
 
 			<Controls
 				isLoading={isLoading}


### PR DESCRIPTION
Issues Fixed:
https://github.com/SigNoz/signoz/issues/3128



<img width="1680" alt="Screenshot 2023-08-14 at 7 47 33 PM" src="https://github.com/SigNoz/signoz/assets/3520897/a9d24d53-fb5f-4c4b-a6e6-88c4be1b6c10">

<img width="1680" alt="Screenshot 2023-08-14 at 7 47 17 PM" src="https://github.com/SigNoz/signoz/assets/3520897/c87d9b8f-9e40-468d-bd52-d6151cc03398">
<img width="1680" alt="Screenshot 2023-08-14 at 7 46 56 PM" src="https://github.com/SigNoz/signoz/assets/3520897/b94110e8-1baf-4afe-9495-448f30a5e673">




