### PR TITLE
fix: limit the returned number of series for graph panel

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -2976,6 +2976,19 @@ func (aH *APIHandler) queryRangeV3(ctx context.Context, queryRangeParams *v3.Que
 
 	applyMetricLimit(result, queryRangeParams)
 
+	if queryRangeParams.CompositeQuery.PanelType == v3.PanelTypeGraph {
+		// limit the number of series for graph panel
+		for idx := range result {
+			result[idx].TotalSeriesCount = len(result[idx].Series)
+			if len(result[idx].Series) > constants.MaxSeriesForGraphPanel {
+				result[idx].Series = result[idx].Series[:constants.MaxSeriesForGraphPanel]
+				result[idx].Warning = fmt.Sprintf(
+					"series count exceeded the limit of %d, please use filters to reduce the number of series", constants.MaxSeriesForGraphPanel,
+				)
+			}
+		}
+	}
+
 	resp := v3.QueryRangeResponse{
 		Result: result,
 	}

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -313,3 +313,5 @@ const TIMESTAMP = "timestamp"
 
 const FirstQueryGraphLimit = "first_query_graph_limit"
 const SecondQueryGraphLimit = "second_query_graph_limit"
+
+const MaxSeriesForGraphPanel = 64

--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -582,9 +582,11 @@ type QueryRangeResponse struct {
 }
 
 type Result struct {
-	QueryName string    `json:"queryName"`
-	Series    []*Series `json:"series"`
-	List      []*Row    `json:"list"`
+	QueryName        string    `json:"queryName"`
+	Series           []*Series `json:"series"`
+	List             []*Row    `json:"list"`
+	Warning          string    `json:"warning"`
+	TotalSeriesCount int       `json:"totalSeriesCount"`
 }
 
 type LogsLiveTailClient struct {


### PR DESCRIPTION
Preventive measure. Related to https://github.com/SigNoz/signoz/issues/3361