### PR TITLE
fix: escape quote and backslash for ClickHouse value

### DIFF
--- a/pkg/query-service/utils/format.go
+++ b/pkg/query-service/utils/format.go
@@ -141,6 +141,13 @@ func ValidateAndCastValue(v interface{}, dataType v3.AttributeKeyDataType) (inte
 	}
 }
 
+func quoteEscapedString(str string) string {
+	// https://clickhouse.com/docs/en/sql-reference/syntax#string
+	str = strings.ReplaceAll(str, `\`, `\\`)
+	str = strings.ReplaceAll(str, `'`, `\'`)
+	return str
+}
+
 // ClickHouseFormattedValue formats the value to be used in clickhouse query
 func ClickHouseFormattedValue(v interface{}) string {
 	// if it's pointer convert it to a value
@@ -152,7 +159,7 @@ func ClickHouseFormattedValue(v interface{}) string {
 	case float32, float64:
 		return fmt.Sprintf("%f", x)
 	case string:
-		return fmt.Sprintf("'%s'", x)
+		return fmt.Sprintf("'%s'", quoteEscapedString(x))
 	case bool:
 		return fmt.Sprintf("%v", x)
 
@@ -164,7 +171,7 @@ func ClickHouseFormattedValue(v interface{}) string {
 		case string:
 			str := "["
 			for idx, sVal := range x {
-				str += fmt.Sprintf("'%s'", sVal)
+				str += fmt.Sprintf("'%s'", quoteEscapedString(sVal.(string)))
 				if idx != len(x)-1 {
 					str += ","
 				}

--- a/pkg/query-service/utils/format_test.go
+++ b/pkg/query-service/utils/format_test.go
@@ -362,6 +362,19 @@ var testClickHouseFormattedValueData = []struct {
 		value: []interface{}{&one, &one},
 		want:  "[1,1]",
 	},
+	{
+		name:  "string with single quote",
+		value: "test'1",
+		want:  "'test\\'1'",
+	},
+	{
+		name: "[]interface{} with string with single quote",
+		value: []interface{}{
+			"test'1",
+			"test'2",
+		},
+		want: "['test\\'1','test\\'2']",
+	},
 }
 
 func TestClickHouseFormattedValue(t *testing.T) {


### PR DESCRIPTION
>In string literals, you need to escape at least ' and \ using escape codes \' (or: '') and \\.


https://clickhouse.com/docs/en/sql-reference/syntax#string