### PR TITLE
fix: Nav item not selected when nested routes are visited

### DIFF
--- a/frontend/src/constants/nestedRoutesMapping.ts
+++ b/frontend/src/constants/nestedRoutesMapping.ts
@@ -1,0 +1,43 @@
+const NAV_ROUTES = {
+	SERVICE_METRICS: '/services/:servicename',
+	TRACE_DETAIL: '/trace/:id',
+	TRACES_EXPLORER: '/traces-explorer',
+	INSTRUMENTATION: '/get-started',
+	USAGE_EXPLORER: '/usage-explorer',
+	DASHBOARD: '/dashboard/:dashboardId',
+	DASHBOARD_WIDGET: '/dashboard/:dashboardId/:widgetId',
+	EDIT_ALERTS: '/alerts/edit',
+	LIST_ALL_ALERT: '/alerts',
+	ALERTS_NEW: '/alerts/new',
+	ALL_CHANNELS: '/settings/channels',
+	CHANNELS_NEW: '/settings/channels/new',
+	CHANNELS_EDIT: '/settings/channels/:id',
+	ORG_SETTINGS: '/settings/org-settings',
+	LOGS_EXPLORER: '/logs-explorer',
+	LOGS_INDEX_FIELDS: '/logs-explorer/index-fields',
+	LOGS_PIPELINE: '/logs-explorer/pipeline',
+	TRACE_EXPLORER: '/trace-explorer',
+};
+
+const NESTED_ROUTES_MAPPING = {
+	SERVICE_METRICS: '/services',
+	TRACE_DETAIL: '/trace',
+	TRACES_EXPLORER: '/trace',
+	INSTRUMENTATION: '/get-started',
+	USAGE_EXPLORER: '/usage-explorer',
+	DASHBOARD: '/dashboard',
+	DASHBOARD_WIDGET: '/dashboard',
+	EDIT_ALERTS: '/alerts',
+	LIST_ALL_ALERT: '/alerts',
+	ALERTS_NEW: '/alerts',
+	ALL_CHANNELS: '/settings',
+	CHANNELS_NEW: '/settings',
+	CHANNELS_EDIT: '/settings',
+	ORG_SETTINGS: '/settings',
+	LOGS_EXPLORER: '/logs',
+	LOGS_INDEX_FIELDS: '/logs',
+	LOGS_PIPELINE: '/logs',
+	TRACE_EXPLORER: '/trace',
+};
+
+export { NAV_ROUTES, NESTED_ROUTES_MAPPING };

--- a/frontend/src/container/SideNav/index.tsx
+++ b/frontend/src/container/SideNav/index.tsx
@@ -2,6 +2,10 @@ import { CheckCircleTwoTone, WarningOutlined } from '@ant-design/icons';
 import { Menu, MenuProps } from 'antd';
 import getLocalStorageKey from 'api/browser/localstorage/get';
 import { IS_SIDEBAR_COLLAPSED } from 'constants/app';
+import {
+	NAV_ROUTES,
+	NESTED_ROUTES_MAPPING,
+} from 'constants/nestedRoutesMapping';
 import ROUTES from 'constants/routes';
 import history from 'lib/history';
 import {
@@ -116,6 +120,10 @@ function SideNav(): JSX.Element {
 		});
 
 		if (!currentRouteKey) return null;
+
+		if ((NAV_ROUTES as any)[currentRouteKey]) {
+			return (NESTED_ROUTES_MAPPING as any)[currentRouteKey];
+		}
 
 		return ROUTES[currentRouteKey];
 	}, [pathname]);


### PR DESCRIPTION
Fixes Sidenav items not selected when accessing the nested routes like

Trace -> Traces Explorer
Logs -> Logs Explorer
Alerts -> Alerts Edit 

.....

The PR is still in draft mode, will discuss the approach with team and then open for reviews.