### PR TITLE
chore: upgrade to go 1.21

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,10 @@ jobs:
   build-query-service:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run tests
@@ -44,6 +48,10 @@ jobs:
   build-ee-query-service:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Build EE query-service image

--- a/ee/query-service/Dockerfile
+++ b/ee/query-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-buster AS builder
+FROM golang:1.21-bookworm AS builder
 
 # LD_FLAGS is passed as argument from Makefile. It will be empty, if no argument passed
 ARG LD_FLAGS

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module go.signoz.io/signoz
 
-go 1.18
+go 1.21
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.5.1
 	github.com/SigNoz/govaluate v0.0.0-20220522085550-d19c08c206cb
-	github.com/antonmedv/expr v1.12.4
 	github.com/SigNoz/zap_otlp/zap_otlp_encoder v0.0.0-20230523034029-2b7ff773052c
 	github.com/SigNoz/zap_otlp/zap_otlp_sync v0.0.0-20230517094211-cd3f3f0aea85
+	github.com/antonmedv/expr v1.12.4
 	github.com/coreos/go-oidc/v3 v3.4.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/go-co-op/gocron v1.30.1

--- a/pkg/query-service/Dockerfile
+++ b/pkg/query-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-buster AS builder
+FROM golang:1.21-bookworm AS builder
 
 # LD_FLAGS is passed as argument from Makefile. It will be empty, if no argument passed
 ARG LD_FLAGS


### PR DESCRIPTION
The latest trigger for this is the need to use testing.Testing() for disabling code with external dependencies in tests