### PR TITLE
style(FE/layout): Fix app scroll behaviour and sidenav footer section inconsistency

### DIFF
--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -25,7 +25,7 @@ import {
 } from 'types/actions/app';
 import AppReducer from 'types/reducer/app';
 
-import { ChildrenContainer, Layout } from './styles';
+import { ChildrenContainer, Layout, LayoutContent } from './styles';
 import { getRouteKey } from './utils';
 
 function AppLayout(props: AppLayoutProps): JSX.Element {
@@ -240,12 +240,12 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 			{isToDisplayLayout && <Header />}
 			<Layout>
 				{isToDisplayLayout && <SideNav />}
-				<Layout.Content>
+				<LayoutContent>
 					<ChildrenContainer>
 						{isToDisplayLayout && <TopNav />}
 						{children}
 					</ChildrenContainer>
-				</Layout.Content>
+				</LayoutContent>
 			</Layout>
 		</Layout>
 	);

--- a/frontend/src/container/AppLayout/styles.ts
+++ b/frontend/src/container/AppLayout/styles.ts
@@ -7,7 +7,12 @@ export const Layout = styled(LayoutComponent)`
 		position: relative;
 		min-height: calc(100vh - 4rem);
 		overflow: hidden;
+		height: 100%;
 	}
+`;
+
+export const LayoutContent = styled(LayoutComponent.Content)`
+	overflow-y: auto;
 `;
 
 export const ChildrenContainer = styled.div`

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -103,16 +103,10 @@ function SideNav(): JSX.Element {
 		},
 	];
 
-	const currentMenu = useMemo(() => {
-		const routeKeys = Object.keys(ROUTES) as (keyof typeof ROUTES)[];
-		const currentRouteKey = routeKeys.find((key) => {
-			const route = ROUTES[key];
-			return pathname === route;
-		});
-
-		if (!currentRouteKey) return null;
-
-		return ROUTES[currentRouteKey];
+	const activeMenuKey = useMemo(() => {
+		const basePath = pathname?.split('/')?.[1]; // Get the base path, Eg; /dashboard/dc5beb63-589c-46a3-ad4c-1b9ca248ee33 -> /dashboard
+		if (basePath) return `/${basePath}`;
+		return null;
 	}, [pathname]);
 
 	const sidebarItems = (props: SidebarItem, index: number): SidebarItem => ({
@@ -127,7 +121,7 @@ function SideNav(): JSX.Element {
 			<Menu
 				theme="dark"
 				defaultSelectedKeys={[ROUTES.APPLICATION]}
-				selectedKeys={currentMenu ? [currentMenu] : []}
+				selectedKeys={activeMenuKey ? [activeMenuKey] : []}
 				mode="vertical"
 				style={styles}
 				items={menuItems}
@@ -142,7 +136,7 @@ function SideNav(): JSX.Element {
 					<Menu
 						theme="dark"
 						defaultSelectedKeys={[ROUTES.APPLICATION]}
-						selectedKeys={currentMenu ? [currentMenu] : []}
+						selectedKeys={activeMenuKey ? [activeMenuKey] : []}
 						mode="inline"
 						style={styles}
 						items={[sidebarItems(props, index)]}

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -1,5 +1,5 @@
 import { CheckCircleTwoTone, WarningOutlined } from '@ant-design/icons';
-import { Menu, MenuProps } from 'antd';
+import { MenuProps } from 'antd';
 import getLocalStorageKey from 'api/browser/localstorage/get';
 import { IS_SIDEBAR_COLLAPSED } from 'constants/app';
 import ROUTES from 'constants/routes';
@@ -15,14 +15,15 @@ import AppReducer from 'types/reducer/app';
 import { routeConfig, styles } from './config';
 import { getQueryString } from './helper';
 import menuItems from './menuItems';
-import { SidebarItem } from './sideNav.types';
+import { MenuItem, SecondaryMenuItemKey } from './sideNav.types';
 import Slack from './Slack';
 import {
+	MenuLabelContainer,
 	RedDot,
 	Sider,
-	SlackButton,
-	SlackMenuItemContainer,
-	VersionContainer,
+	StyledPrimaryMenu,
+	StyledSecondaryMenu,
+	StyledText,
 } from './styles';
 
 function SideNav(): JSX.Element {
@@ -75,31 +76,29 @@ function SideNav(): JSX.Element {
 
 	const isNotCurrentVersion = currentVersion !== latestVersion;
 
-	const sidebar: SidebarItem[] = [
+	const secondaryMenuItems: MenuItem[] = [
 		{
-			onClick: onClickSlackHandler,
-			icon: <Slack />,
-			text: <SlackButton>Support</SlackButton>,
-			key: 'slack',
-		},
-		{
-			onClick: onClickVersionHandler,
-			key: 'version',
+			key: SecondaryMenuItemKey.Version,
 			icon: isNotCurrentVersion ? (
 				<WarningOutlined style={{ color: '#E87040' }} />
 			) : (
 				<CheckCircleTwoTone twoToneColor={['#D5F2BB', '#1f1f1f']} />
 			),
-			text: (
-				<VersionContainer>
-					{!isCurrentVersionError ? (
-						<SlackButton>{currentVersion}</SlackButton>
-					) : (
-						<SlackButton>{t('n_a')}</SlackButton>
-					)}
+			label: (
+				<MenuLabelContainer>
+					<StyledText ellipsis>
+						{!isCurrentVersionError ? currentVersion : t('n_a')}
+					</StyledText>
 					{isNotCurrentVersion && <RedDot />}
-				</VersionContainer>
+				</MenuLabelContainer>
 			),
+			onClick: onClickVersionHandler,
+		},
+		{
+			key: SecondaryMenuItemKey.Slack,
+			icon: <Slack />,
+			label: <StyledText>Support</StyledText>,
+			onClick: onClickSlackHandler,
 		},
 	];
 
@@ -109,16 +108,9 @@ function SideNav(): JSX.Element {
 		return null;
 	}, [pathname]);
 
-	const sidebarItems = (props: SidebarItem, index: number): SidebarItem => ({
-		key: `${index}`,
-		icon: props.icon,
-		onClick: props.onClick,
-		label: props.text,
-	});
-
 	return (
 		<Sider collapsible collapsed={collapsed} onCollapse={onCollapse} width={200}>
-			<Menu
+			<StyledPrimaryMenu
 				theme="dark"
 				defaultSelectedKeys={[ROUTES.APPLICATION]}
 				selectedKeys={activeMenuKey ? [activeMenuKey] : []}
@@ -127,22 +119,13 @@ function SideNav(): JSX.Element {
 				items={menuItems}
 				onClick={onClickMenuHandler}
 			/>
-			{sidebar.map((props, index) => (
-				<SlackMenuItemContainer
-					index={index + 1}
-					key={`${index + 1}`}
-					collapsed={collapsed}
-				>
-					<Menu
-						theme="dark"
-						defaultSelectedKeys={[ROUTES.APPLICATION]}
-						selectedKeys={activeMenuKey ? [activeMenuKey] : []}
-						mode="inline"
-						style={styles}
-						items={[sidebarItems(props, index)]}
-					/>
-				</SlackMenuItemContainer>
-			))}
+			<StyledSecondaryMenu
+				theme="dark"
+				selectedKeys={activeMenuKey ? [activeMenuKey] : []}
+				mode="vertical"
+				style={styles}
+				items={secondaryMenuItems}
+			/>
 		</Sider>
 	);
 }

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -4,23 +4,18 @@ import getLocalStorageKey from 'api/browser/localstorage/get';
 import { IS_SIDEBAR_COLLAPSED } from 'constants/app';
 import ROUTES from 'constants/routes';
 import history from 'lib/history';
-import {
-	ReactNode,
-	useCallback,
-	useLayoutEffect,
-	useMemo,
-	useState,
-} from 'react';
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-import { SideBarCollapse } from 'store/actions/app';
+import { sideBarCollapse } from 'store/actions/app';
 import { AppState } from 'store/reducers';
 import AppReducer from 'types/reducer/app';
 
 import { routeConfig, styles } from './config';
 import { getQueryString } from './helper';
-import menus from './menuItems';
+import menuItems from './menuItems';
+import { SidebarItem } from './sideNav.types';
 import Slack from './Slack';
 import {
 	RedDot,
@@ -49,7 +44,7 @@ function SideNav(): JSX.Element {
 	}, []);
 
 	useLayoutEffect(() => {
-		dispatch(SideBarCollapse(collapsed));
+		dispatch(sideBarCollapse(collapsed));
 	}, [collapsed, dispatch]);
 
 	const onClickHandler = useCallback(
@@ -135,7 +130,7 @@ function SideNav(): JSX.Element {
 				selectedKeys={currentMenu ? [currentMenu] : []}
 				mode="vertical"
 				style={styles}
-				items={menus}
+				items={menuItems}
 				onClick={onClickMenuHandler}
 			/>
 			{sidebar.map((props, index) => (
@@ -156,14 +151,6 @@ function SideNav(): JSX.Element {
 			))}
 		</Sider>
 	);
-}
-
-interface SidebarItem {
-	onClick: VoidFunction;
-	icon?: ReactNode;
-	text?: ReactNode;
-	key: string;
-	label?: ReactNode;
 }
 
 export default SideNav;

--- a/frontend/src/container/SideNav/Slack.tsx
+++ b/frontend/src/container/SideNav/Slack.tsx
@@ -1,6 +1,6 @@
 interface ISlackProps {
-	width?: number;
-	height?: number;
+	width?: number | string;
+	height?: number | string;
 }
 function Slack({ width, height }: ISlackProps): JSX.Element {
 	return (
@@ -47,8 +47,8 @@ function Slack({ width, height }: ISlackProps): JSX.Element {
 	);
 }
 Slack.defaultProps = {
-	width: 28,
-	height: 28,
+	width: '1em',
+	height: '1em',
 };
 
 export default Slack;

--- a/frontend/src/container/SideNav/index.ts
+++ b/frontend/src/container/SideNav/index.ts
@@ -1,0 +1,3 @@
+import SideNav from './SideNav';
+
+export default SideNav;

--- a/frontend/src/container/SideNav/menuItems.tsx
+++ b/frontend/src/container/SideNav/menuItems.tsx
@@ -10,10 +10,9 @@ import {
 	MenuOutlined,
 	SettingOutlined,
 } from '@ant-design/icons';
-import { MenuProps } from 'antd';
 import ROUTES from 'constants/routes';
 
-type MenuItem = Required<MenuProps>['items'][number];
+import { SidebarMenu } from './sideNav.types';
 
 const menuItems: SidebarMenu[] = [
 	{
@@ -94,9 +93,5 @@ const menuItems: SidebarMenu[] = [
 		icon: <ApiOutlined />,
 	},
 ];
-
-type SidebarMenu = MenuItem & {
-	tags?: string[];
-};
 
 export default menuItems;

--- a/frontend/src/container/SideNav/menuItems.tsx
+++ b/frontend/src/container/SideNav/menuItems.tsx
@@ -10,28 +10,12 @@ import {
 	MenuOutlined,
 	SettingOutlined,
 } from '@ant-design/icons';
-import { MenuProps, Space, Typography } from 'antd';
+import { MenuProps } from 'antd';
 import ROUTES from 'constants/routes';
-
-import { Tags } from './styles';
 
 type MenuItem = Required<MenuProps>['items'][number];
 
-export const createLabelWithTags = (
-	label: string,
-	tags: string[],
-): JSX.Element => (
-	<Space>
-		<div>{label}</div>
-		{tags.map((tag) => (
-			<Tags key={tag}>
-				<Typography.Text>{tag}</Typography.Text>
-			</Tags>
-		))}
-	</Space>
-);
-
-const menus: SidebarMenu[] = [
+const menuItems: SidebarMenu[] = [
 	{
 		key: ROUTES.APPLICATION,
 		label: 'Services',
@@ -115,4 +99,4 @@ type SidebarMenu = MenuItem & {
 	tags?: string[];
 };
 
-export default menus;
+export default menuItems;

--- a/frontend/src/container/SideNav/sideNav.types.ts
+++ b/frontend/src/container/SideNav/sideNav.types.ts
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+export interface SidebarItem {
+	onClick: VoidFunction;
+	icon?: ReactNode;
+	text?: ReactNode;
+	key: string;
+	label?: ReactNode;
+}

--- a/frontend/src/container/SideNav/sideNav.types.ts
+++ b/frontend/src/container/SideNav/sideNav.types.ts
@@ -1,4 +1,11 @@
+import { MenuProps } from 'antd';
 import { ReactNode } from 'react';
+
+export type MenuItem = Required<MenuProps>['items'][number];
+
+export type SidebarMenu = MenuItem & {
+	tags?: string[];
+};
 
 export interface SidebarItem {
 	onClick: VoidFunction;
@@ -6,4 +13,9 @@ export interface SidebarItem {
 	text?: ReactNode;
 	key: string;
 	label?: ReactNode;
+}
+
+export enum SecondaryMenuItemKey {
+	Slack = 'slack',
+	Version = 'version',
 }

--- a/frontend/src/container/SideNav/styles.ts
+++ b/frontend/src/container/SideNav/styles.ts
@@ -1,4 +1,4 @@
-import { Layout, Tag, Typography } from 'antd';
+import { Layout, Typography } from 'antd';
 import { StyledCSS } from 'container/GantChart/Trace/styles';
 import styled, { css } from 'styled-components';
 
@@ -75,13 +75,5 @@ export const RedDot = styled.div`
 export const VersionContainer = styled.div`
 	&&& {
 		display: flex;
-	}
-`;
-
-export const Tags = styled(Tag)`
-	&&& {
-		position: absolute;
-		top: 0;
-		border-radius: 0.5rem;
 	}
 `;

--- a/frontend/src/container/SideNav/styles.ts
+++ b/frontend/src/container/SideNav/styles.ts
@@ -1,17 +1,16 @@
-import { Layout, Typography } from 'antd';
-import { StyledCSS } from 'container/GantChart/Trace/styles';
-import styled, { css } from 'styled-components';
+import { Layout, Menu, Typography } from 'antd';
+import styled from 'styled-components';
 
 const { Sider: SiderComponent } = Layout;
-
-interface LogoProps {
-	collapsed: boolean;
-	index: number;
-}
 
 export const Sider = styled(SiderComponent)`
 	&&& {
 		background: #1f1f1f;
+
+		.ant-layout-sider-children {
+			display: flex;
+			flex-direction: column;
+		}
 
 		.ant-layout-sider-trigger {
 			background: #1f1f1f;
@@ -19,61 +18,51 @@ export const Sider = styled(SiderComponent)`
 	}
 `;
 
-export const SlackButton = styled(Typography)`
-	&&& {
-		margin-left: 1rem;
-		color: white;
-	}
+export const StyledPrimaryMenu = styled(Menu)`
+	flex: 1;
+	overflow-y: auto;
 `;
 
-export const SlackMenuItemContainer = styled.div<LogoProps>`
-	position: fixed;
-	bottom: ${({ index }): string => `${index * 48 + (index + 16)}px`};
-	background: #262626;
-	width: ${({ collapsed }): string => (!collapsed ? '200px' : '80px')};
-	transition: inherit;
-	background: #1f1f1f;
-
+export const StyledSecondaryMenu = styled(Menu)`
 	&&& {
-		li {
-			${({ collapsed }): StyledCSS =>
-				collapsed &&
-				css`
-					padding-left: 24px;
-					padding-top: 6px;
-				`}
+		:not(.ant-menu-inline-collapsed) > .ant-menu-item {
+			padding-inline: 48px;
+
+			display: flex;
+			align-items: center;
+			justify-content: center;
 		}
 
-		svg {
-			margin-left: ${({ collapsed }): string => (collapsed ? '0' : '24px')};
-			width: 28px;
-			height: 28px;
-
-			${({ collapsed }): StyledCSS =>
-				collapsed &&
-				css`
-					height: 100%;
-					margin: 0 auto;
-				`}
-		}
 		.ant-menu-title-content {
-			margin: 0;
+			margin-inline-start: 10px;
+			width: 100%;
+		}
+
+		&.ant-menu-inline-collapsed .ant-menu-title-content {
+			opacity: 0;
 		}
 	}
 `;
 
 export const RedDot = styled.div`
-	width: 12px;
-	height: 12px;
+	width: 10px;
+	height: 10px;
 	background: #d32029;
 	border-radius: 50%;
 
 	margin-left: 0.5rem;
-	margin-top: 0.5rem;
 `;
 
-export const VersionContainer = styled.div`
-	&&& {
-		display: flex;
-	}
+export const MenuLabelContainer = styled.div`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+
+	width: 100%;
+`;
+
+export const StyledText = styled(Typography.Text)`
+	width: 100%;
+
+	color: white;
 `;

--- a/frontend/src/container/TopNav/styles.ts
+++ b/frontend/src/container/TopNav/styles.ts
@@ -4,6 +4,5 @@ import styled from 'styled-components';
 export const Container = styled(Row)`
 	&&& {
 		margin-top: 2rem;
-		min-height: 8vh;
 	}
 `;

--- a/frontend/src/globalStyles.ts
+++ b/frontend/src/globalStyles.ts
@@ -1,0 +1,18 @@
+import { createGlobalStyle } from 'styled-components';
+
+const GlobalStyles = createGlobalStyle`
+#root,
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+}
+
+body {
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+`;
+
+export default GlobalStyles;

--- a/frontend/src/index.html.ejs
+++ b/frontend/src/index.html.ejs
@@ -57,7 +57,7 @@
 			rel="stylesheet"
 		/>
 	</head>
-	<body style="margin: 0; padding: 0; box-sizing: border-box">
+	<body>
 		<noscript>You need to enable JavaScript to run this app.</noscript>
 		<div id="root"></div>
 	</body>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -2,6 +2,7 @@ import './wdyr';
 import './ReactI18';
 
 import AppRoutes from 'AppRoutes';
+import GlobalStyles from 'globalStyles';
 import { ThemeProvider } from 'hooks/useDarkMode';
 import { createRoot } from 'react-dom/client';
 import { HelmetProvider } from 'react-helmet-async';
@@ -33,6 +34,7 @@ if (container) {
 			<ThemeProvider>
 				<QueryClientProvider client={queryClient}>
 					<Provider store={store}>
+						<GlobalStyles />
 						<AppRoutes />
 					</Provider>
 					{process.env.NODE_ENV === 'development' && (

--- a/frontend/src/store/actions/app/sideBarCollapse.ts
+++ b/frontend/src/store/actions/app/sideBarCollapse.ts
@@ -3,7 +3,7 @@ import { IS_SIDEBAR_COLLAPSED } from 'constants/app';
 import { Dispatch } from 'redux';
 import AppActions from 'types/actions';
 
-export const SideBarCollapse = (
+export const sideBarCollapse = (
 	collapseState: boolean,
 ): ((dispatch: Dispatch<AppActions>) => void) => {
 	setLocalStorageKey(IS_SIDEBAR_COLLAPSED, `${collapseState}`);


### PR DESCRIPTION
Fixes #3414 

## Changes overview

- **On navigating to a nested route, the active menu state on the sidebar didn't show up**

_Current Behaviour_

https://github.com/SigNoz/signoz/assets/30779692/0109dbb8-7221-46c7-b8aa-033a57cbc84f


_New Behaviour_

https://github.com/SigNoz/signoz/assets/30779692/efb7ff19-3305-4574-83f6-1b99e4a4c29d

- **The header scrolls along with the body content**

_Current Behaviour_

https://github.com/SigNoz/signoz/assets/30779692/84e4aa14-a3fc-4389-8194-de80deaad1c3

_New Behaviour_

The header will remain fixed and only the body content will be scrollable 

https://github.com/SigNoz/signoz/assets/30779692/386593f6-98a9-4d0c-b1d2-0861a417f812

- **The side nav scrolls along with the body content and the menu items on the footer are inconsistent with the rest of the items, with text overflowing and jittery animation**

_Current Behaviour_

https://github.com/SigNoz/signoz/assets/30779692/64bb927a-123b-4d67-9aee-920cec194723

_New Behaviour_

The sidenav won't scroll only with the body, hence the nav items will always be available for quick navigation irrespective of the scroll height

https://github.com/SigNoz/signoz/assets/30779692/5d4288a1-747f-496a-89cc-40bd16718f97

