### PR TITLE
fix: skip first record only for rate metrics

### DIFF
--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -138,6 +138,24 @@ func (a AggregateOperator) RequireAttribute(dataSource DataSource) bool {
 	}
 }
 
+func (a AggregateOperator) IsRateOperator() bool {
+	switch a {
+	case AggregateOperatorRate,
+		AggregateOperatorSumRate,
+		AggregateOperatorAvgRate,
+		AggregateOperatorMinRate,
+		AggregateOperatorMaxRate,
+		AggregateOperatorRateSum,
+		AggregateOperatorRateAvg,
+		AggregateOperatorRateMin,
+		AggregateOperatorRateMax:
+		return true
+
+	default:
+		return false
+	}
+}
+
 type ReduceToOperator string
 
 const (


### PR DESCRIPTION
Currently, the threshold rule logic skips the first sample of the result regardless of the type of operator and source. The original intention was to skip the rate queries only as the first sample rate is incorrect. This commit updates the logic to skip only when the data source is metric and the operator is rate kind. if the sample shouldn't be skipped `!r.shouldSkipFirstRecord() ` then the first sample is directly added to `resultMap`.