### PR TITLE
refactor(query-service): remove redundant nil check

### DIFF
--- a/pkg/query-service/dao/sqlite/rbac.go
+++ b/pkg/query-service/dao/sqlite/rbac.go
@@ -563,13 +563,11 @@ func (mds *ModelDaoSqlite) UpdateUserFlags(ctx context.Context, userId string, f
 		return nil, apiError
 	}
 
-	if userPayload.Flags != nil {
-		for k, v := range userPayload.Flags {
-			if _, ok := flags[k]; !ok {
-				// insert only missing keys as we want to retain the
-				// flags in the db that are not part of this request
-				flags[k] = v
-			}
+	for k, v := range userPayload.Flags {
+		if _, ok := flags[k]; !ok {
+			// insert only missing keys as we want to retain the
+			// flags in the db that are not part of this request
+			flags[k] = v
 		}
 	}
 

--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -410,27 +410,21 @@ func (c *CompositeQuery) Validate() error {
 		return fmt.Errorf("composite query must contain at least one query")
 	}
 
-	if c.BuilderQueries != nil {
-		for name, query := range c.BuilderQueries {
-			if err := query.Validate(); err != nil {
-				return fmt.Errorf("builder query %s is invalid: %w", name, err)
-			}
+	for name, query := range c.BuilderQueries {
+		if err := query.Validate(); err != nil {
+			return fmt.Errorf("builder query %s is invalid: %w", name, err)
 		}
 	}
 
-	if c.ClickHouseQueries != nil {
-		for name, query := range c.ClickHouseQueries {
-			if err := query.Validate(); err != nil {
-				return fmt.Errorf("clickhouse query %s is invalid: %w", name, err)
-			}
+	for name, query := range c.ClickHouseQueries {
+		if err := query.Validate(); err != nil {
+			return fmt.Errorf("clickhouse query %s is invalid: %w", name, err)
 		}
 	}
 
-	if c.PromQueries != nil {
-		for name, query := range c.PromQueries {
-			if err := query.Validate(); err != nil {
-				return fmt.Errorf("prom query %s is invalid: %w", name, err)
-			}
+	for name, query := range c.PromQueries {
+		if err := query.Validate(); err != nil {
+			return fmt.Errorf("prom query %s is invalid: %w", name, err)
 		}
 	}
 
@@ -515,11 +509,9 @@ func (b *BuilderQuery) Validate() error {
 		}
 	}
 
-	if b.SelectColumns != nil {
-		for _, selectColumn := range b.SelectColumns {
-			if err := selectColumn.Validate(); err != nil {
-				return fmt.Errorf("select column is invalid %w", err)
-			}
+	for _, selectColumn := range b.SelectColumns {
+		if err := selectColumn.Validate(); err != nil {
+			return fmt.Errorf("select column is invalid %w", err)
 		}
 	}
 


### PR DESCRIPTION
From the Go specification (https://go.dev/ref/spec#For_range):

> "1. For a nil slice, the number of iterations is 0."
> "3. If the map is nil, the number of iterations is 0."

Therefore, an additional nil check for slice and map before the loop is unnecessary.