### PR TITLE
chore: refactor copy clipboard hoc

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
 		"classnames": "2.3.2",
 		"color": "^4.2.1",
 		"color-alpha": "1.1.3",
+		"copy-to-clipboard": "3.3.3",
 		"cross-env": "^7.0.3",
 		"css-loader": "4.3.0",
 		"css-minimizer-webpack-plugin": "5.0.1",

--- a/frontend/src/components/Logs/CopyClipboardHOC.tsx
+++ b/frontend/src/components/Logs/CopyClipboardHOC.tsx
@@ -1,28 +1,27 @@
 import { Popover } from 'antd';
+import copy from 'copy-to-clipboard';
 import { useNotifications } from 'hooks/useNotifications';
-import { ReactNode, useCallback, useEffect } from 'react';
-import { useCopyToClipboard } from 'react-use';
+import { ReactNode, useCallback } from 'react';
 
 function CopyClipboardHOC({
 	textToCopy,
 	children,
 }: CopyClipboardHOCProps): JSX.Element {
-	const [value, setCopy] = useCopyToClipboard();
 	const { notifications } = useNotifications();
-	useEffect(() => {
-		if (value.value) {
+
+	const handleCopy = useCallback(() => {
+		try {
+			copy(textToCopy);
 			notifications.success({
 				message: 'Copied to clipboard',
 			});
+		} catch (e) {
+			//
 		}
-	}, [value, notifications]);
-
-	const onClick = useCallback((): void => {
-		setCopy(textToCopy);
-	}, [setCopy, textToCopy]);
+	}, [textToCopy, notifications]);
 
 	return (
-		<span onClick={onClick} role="presentation" tabIndex={-1}>
+		<span onClick={handleCopy} role="presentation" tabIndex={-1}>
 			<Popover
 				placement="top"
 				content={<span style={{ fontSize: '0.9rem' }}>Copy to clipboard</span>}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5628,6 +5628,13 @@ copy-anything@^2.0.1:
   dependencies:
     is-what "^3.14.1"
 
+copy-to-clipboard@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz#55ac43a1db8ae639a4bd99511c148cdd1b83a1b0"
+  integrity sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 copy-to-clipboard@^3.2.0, copy-to-clipboard@^3.3.1:
   version "3.3.3"
   resolved "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz"


### PR DESCRIPTION
Stumbled upon this component while looking into the codebase,

1. I think using useEffect and state just to copy from clipboard is too much ( check library internal ), and also the library (react-use) uses the same package for copying from clipboard. 
2. using this package direclty makes it easy to copy data from API results or anything dynamic which cant be defined upfront.

cc @palashgdev lmk if it makes sense 
