### PR TITLE
fix: promql alert expr formatting for composite queries with join/unless

### DIFF
--- a/pkg/query-service/rules/promRule.go
+++ b/pkg/query-service/rules/promRule.go
@@ -309,7 +309,7 @@ func (r *PromRule) getPqlQuery() (string, error) {
 				if r.ruleCondition.Target != nil && r.ruleCondition.CompareOp != CompareOpNone {
 					unitConverter := converter.FromUnit(converter.Unit(r.ruleCondition.TargetUnit))
 					value := unitConverter.Convert(converter.Value{F: *r.ruleCondition.Target, U: converter.Unit(r.ruleCondition.TargetUnit)}, converter.Unit(r.Unit()))
-					query = fmt.Sprintf("%s %s %f", query, ResolveCompareOp(r.ruleCondition.CompareOp), value.F)
+					query = fmt.Sprintf("(%s) %s %f", query, ResolveCompareOp(r.ruleCondition.CompareOp), value.F)
 					return query, nil
 				} else {
 					return query, nil


### PR DESCRIPTION
For expressions such as 

```
count(process_cpu_time{process_command_line=~"/usr/local/cqonline", host_name=~"cq"} offset 5m) by (host_name) unless count(process_cpu_time{process_command_line=~"/usr/local/cqonline", host_name=~"cq"}) by (host_name)
```

The current comparison isn't done against the whole query result but the right side of it which is incorrect.