### PR TITLE
chore: empty out trace parser fields if field.parseFrom is empty

### DIFF
--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
@@ -72,10 +72,27 @@ func getOperators(ops []PipelineOperator) []PipelineOperator {
 			if len(filteredOp) > 0 {
 				filteredOp[len(filteredOp)-1].Output = operator.ID
 			}
+
+			if operator.Type == "trace_parser" {
+				cleanTraceParser(&operator)
+			}
+
 			filteredOp = append(filteredOp, operator)
 		} else if i == len(ops)-1 && len(filteredOp) != 0 {
 			filteredOp[len(filteredOp)-1].Output = ""
 		}
 	}
 	return filteredOp
+}
+
+func cleanTraceParser(operator *PipelineOperator) {
+	if operator.TraceId != nil && len(operator.TraceId.ParseFrom) < 1 {
+		operator.TraceId = nil
+	}
+	if operator.SpanId != nil && len(operator.SpanId.ParseFrom) < 1 {
+		operator.SpanId = nil
+	}
+	if operator.TraceFlags != nil && len(operator.TraceFlags.ParseFrom) < 1 {
+		operator.TraceFlags = nil
+	}
 }

--- a/pkg/query-service/app/logparsingpipeline/preview_test.go
+++ b/pkg/query-service/app/logparsingpipeline/preview_test.go
@@ -295,6 +295,19 @@ func TestTraceParsingPreview(t *testing.T) {
 	expectedTraceFlags, err := strconv.ParseUint(testTraceFlags, 16, 16)
 	require.Nil(err)
 	require.Equal(uint32(expectedTraceFlags), processed.TraceFlags)
+
+	// trace parser should work even if parse_from value is empty
+	testPipelines[0].Config[0].SpanId.ParseFrom = ""
+	result, err = SimulatePipelinesProcessing(
+		context.Background(),
+		testPipelines,
+		[]model.SignozLog{
+			testLog,
+		},
+	)
+	require.Nil(err)
+	require.Equal(1, len(result))
+	require.Equal("", result[0].SpanID)
 }
 
 func makeTestLogEntry(


### PR DESCRIPTION
Contributes to https://github.com/SigNoz/signoz/issues/3845