### PR TITLE
Fix: log pipelines: only one of the trace parser fields is required

### DIFF
--- a/frontend/public/locales/en/pipeline.json
+++ b/frontend/public/locales/en/pipeline.json
@@ -37,9 +37,9 @@
 	"processor_field_placeholder": "Field",
 	"processor_value_placeholder": "Value",
 	"processor_description_placeholder": "example rule: %{word:first}",
-	"processor_trace_id_placeholder": "Trace Id Parce From",
-	"processor_span_id_placeholder": "Span id Parse From",
-	"processor_trace_flags_placeholder": "Trace flags parse from",
+	"processor_trace_id_placeholder": "Parse Trace ID from",
+	"processor_span_id_placeholder": "Parse Span ID from",
+	"processor_trace_flags_placeholder": "Parse Trace flags from",
 	"processor_from_placeholder": "From",
 	"processor_to_placeholder": "To"
 }

--- a/frontend/src/container/PipelinePage/PipelineListsView/AddNewProcessor/FormFields/NameInput.tsx
+++ b/frontend/src/container/PipelinePage/PipelineListsView/AddNewProcessor/FormFields/NameInput.tsx
@@ -22,6 +22,7 @@ function NameInput({ fieldData }: NameInputProps): JSX.Element {
 					name={fieldData.name}
 					initialValue={fieldData.initialValue}
 					rules={fieldData.rules ? fieldData.rules : formValidationRules}
+					dependencies={fieldData.dependencies || []}
 				>
 					<Input placeholder={t(fieldData.placeholder)} />
 				</Form.Item>

--- a/frontend/src/container/PipelinePage/PipelineListsView/AddNewProcessor/config.ts
+++ b/frontend/src/container/PipelinePage/PipelineListsView/AddNewProcessor/config.ts
@@ -1,3 +1,6 @@
+import { Rule, RuleRender } from 'antd/es/form';
+import { NamePath } from 'antd/es/form/interface';
+
 type ProcessorType = {
 	key: string;
 	value: string;
@@ -8,11 +11,11 @@ type ProcessorType = {
 
 export const processorTypes: Array<ProcessorType> = [
 	{ key: 'grok_parser', value: 'grok_parser', label: 'Grok' },
-	{ key: 'json_parser', value: 'json_parser', label: 'Json Parser' },
 	{ key: 'regex_parser', value: 'regex_parser', label: 'Regex' },
+	{ key: 'json_parser', value: 'json_parser', label: 'Json Parser' },
+	{ key: 'trace_parser', value: 'trace_parser', label: 'Trace Parser' },
 	{ key: 'add', value: 'add', label: 'Add' },
 	{ key: 'remove', value: 'remove', label: 'Remove' },
-	{ key: 'trace_parser', value: 'trace_parser', label: 'Trace Parser' },
 	// { key: 'retain', value: 'retain', label: 'Retain' }, @Chintan - Commented as per Nitya's suggestion
 	{ key: 'move', value: 'move', label: 'Move' },
 	{ key: 'copy', value: 'copy', label: 'Copy' },
@@ -24,10 +27,29 @@ export type ProcessorFormField = {
 	id: number;
 	fieldName: string;
 	placeholder: string;
-	name: string | Array<string>;
-	rules?: Array<{ [key: string]: boolean }>;
+	name: string | NamePath;
+	rules?: Array<Rule>;
 	initialValue?: string;
+	dependencies?: Array<string | NamePath>;
 };
+
+const traceParserFieldValidator: RuleRender = (form) => ({
+	validator: (): Promise<void> => {
+		const parseFromValues = [
+			['trace_id', 'parse_from'],
+			['span_id', 'parse_from'],
+			['trace_flags', 'parse_from'],
+		].map((np) => form.getFieldValue(np));
+
+		if (!parseFromValues.some((v) => v?.length > 0)) {
+			return Promise.reject(
+				new Error('At least one of the trace parser fields must be specified.'),
+			);
+		}
+
+		return Promise.resolve();
+	},
+});
 
 const commonFields = [
 	{
@@ -155,18 +177,33 @@ export const processorFields: { [key: string]: Array<ProcessorFormField> } = {
 			fieldName: 'Parse Trace Id From',
 			placeholder: 'processor_trace_id_placeholder',
 			name: ['trace_id', 'parse_from'],
+			rules: [traceParserFieldValidator],
+			dependencies: [
+				['span_id', 'parse_from'],
+				['trace_flags', 'parse_from'],
+			],
 		},
 		{
 			id: 3,
 			fieldName: 'Parse Span Id From',
 			placeholder: 'processor_span_id_placeholder',
 			name: ['span_id', 'parse_from'],
+			rules: [traceParserFieldValidator],
+			dependencies: [
+				['trace_id', 'parse_from'],
+				['trace_flags', 'parse_from'],
+			],
 		},
 		{
 			id: 4,
 			fieldName: 'Parse Trace flags From',
 			placeholder: 'processor_trace_flags_placeholder',
 			name: ['trace_flags', 'parse_from'],
+			rules: [traceParserFieldValidator],
+			dependencies: [
+				['trace_id', 'parse_from'],
+				['span_id', 'parse_from'],
+			],
 		},
 	],
 	retain: [

--- a/frontend/src/container/PipelinePage/PipelineListsView/AddNewProcessor/utils.tsx
+++ b/frontend/src/container/PipelinePage/PipelineListsView/AddNewProcessor/utils.tsx
@@ -4,6 +4,6 @@ import NameInput from './FormFields/NameInput';
 export const renderProcessorForm = (
 	processorType: string,
 ): Array<JSX.Element> =>
-	processorFields[processorType]?.map((fieldName: ProcessorFormField) => (
-		<NameInput key={fieldName.id} fieldData={fieldName} />
+	processorFields[processorType]?.map((fieldData: ProcessorFormField) => (
+		<NameInput key={fieldData.id} fieldData={fieldData} />
 	));


### PR DESCRIPTION
Fixes https://github.com/SigNoz/signoz/issues/3845

Before:

![279275819-7a2ac7a2-1da6-4567-9190-0816c6f0d79e](https://github.com/SigNoz/signoz/assets/1133322/baf357f5-e4ff-4616-bf82-b2428cd66498)


After:

![trace-parser-require-only-1-field](https://github.com/SigNoz/signoz/assets/1133322/f578b522-56b3-4614-972c-f0715be9b2e6)
