### PR TITLE
fix: ignore reload identity calls

### DIFF
--- a/pkg/query-service/telemetry/telemetry.go
+++ b/pkg/query-service/telemetry/telemetry.go
@@ -267,7 +267,7 @@ func (a *Telemetry) IdentifyUser(user *model.User) {
 	if !a.isTelemetryEnabled() || a.isTelemetryAnonymous() {
 		return
 	}
-	if a.saasOperator != nil {
+	if a.saasOperator != nil && user.Name != "" {
 		a.saasOperator.Enqueue(analytics.Identify{
 			UserId: a.userEmail,
 			Traits: analytics.NewTraits().SetName(user.Name).SetEmail(user.Email),


### PR DESCRIPTION
There are login API calls on every reload.
And if token expires and a page has 10 API calls then 10 login API calls are being made. This was causing duplicates/spamming of telemetry events.
Every refresh token login API call doesn't have user name so ignoring all API calls for identity events without user name.