### PR TITLE
[Fix]: the height issue for resizable tables

### DIFF
--- a/frontend/src/container/QueryTable/QueryTable.styles.scss
+++ b/frontend/src/container/QueryTable/QueryTable.styles.scss
@@ -1,5 +1,6 @@
 .query-table {
     position: relative;
+    height: inherit;
     .query-table--download {
         position: absolute;
         top: 15px;


### PR DESCRIPTION
### Why this issue

The presence of this issue can be attributed to the introduction of an additional <div> element with the class name "query-table" at the top of the "ResizableTable" component. This newly added <div> occupied its own height, which led to the parent container's height not being properly inherited, consequently rendering it non-scrollable. 

### Solution: 
To resolve this issue, we can apply the CSS property `height: inherit` to the `<div>`, which will cause it to assume the height of its parent container, restoring its behavior to its previous state.