### PR TITLE
fix: use correct operator for db and external APM metrics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 * @ankitnayan
 
 /frontend/ @palashgdev @YounixM
+/frontend/src/container/MetricsApplication @srikanthccv
 /deploy/ @prashant-shahi
 /sample-apps/ @prashant-shahi
 **/query-service/ @srikanthccv

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/DBCallQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/DBCallQueries.ts
@@ -114,8 +114,8 @@ export const databaseCallsAvgDuration = ({
 	const legendFormulas = ['Average Duration'];
 	const expressions = [FORMULA.DATABASE_CALLS_AVG_DURATION];
 	const aggregateOperators = [
-		MetricAggregateOperator.SUM,
-		MetricAggregateOperator.SUM,
+		MetricAggregateOperator.SUM_RATE,
+		MetricAggregateOperator.SUM_RATE,
 	];
 	const dataSource = DataSource.METRICS;
 

--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/ExternalQueries.ts
@@ -94,8 +94,8 @@ export const externalCallErrorPercent = ({
 	const additionalItems = [additionalItemsA, additionalItemsB];
 
 	const aggregateOperators = [
-		MetricAggregateOperator.SUM,
-		MetricAggregateOperator.SUM,
+		MetricAggregateOperator.SUM_RATE,
+		MetricAggregateOperator.SUM_RATE,
 	];
 	const legends = [legend, legend];
 	const dataSource = DataSource.METRICS;
@@ -153,8 +153,8 @@ export const externalCallDuration = ({
 	const additionalItems = [additionalItemsA, additionalItemsA];
 	const legends = [legend, legend];
 	const aggregateOperators = [
-		MetricAggregateOperator.SUM,
-		MetricAggregateOperator.SUM,
+		MetricAggregateOperator.SUM_RATE,
+		MetricAggregateOperator.SUM_RATE,
 	];
 	const dataSource = DataSource.METRICS;
 
@@ -251,8 +251,8 @@ export const externalCallDurationByAddress = ({
 	const additionalItems = [additionalItemsA, additionalItemsA];
 	const legends = [legend, legend];
 	const aggregateOperators = [
-		MetricAggregateOperator.SUM,
-		MetricAggregateOperator.SUM,
+		MetricAggregateOperator.SUM_RATE,
+		MetricAggregateOperator.SUM_RATE,
 	];
 	const dataSource = DataSource.METRICS;
 


### PR DESCRIPTION
Some frontend refactoring updateed the operator to the incorrect one. This was supposed to be `SUM_RATE`.

Added myself as codeowner to prevent any such issues in future.