### PR TITLE
fix: add legacy unit types and fix floating point issue

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 
 /frontend/ @palashgdev @YounixM
 /frontend/src/container/MetricsApplication @srikanthccv
+/frontend/src/container/NewWidget/RightContainer/types.ts @srikanthccv
 /deploy/ @prashant-shahi
 /sample-apps/ @prashant-shahi
 **/query-service/ @srikanthccv

--- a/pkg/query-service/converter/converter.go
+++ b/pkg/query-service/converter/converter.go
@@ -43,9 +43,9 @@ var (
 // FromUnit returns a converter for the given unit
 func FromUnit(u Unit) Converter {
 	switch u {
-	case "ns", "us", "ms", "s", "m", "h", "d":
+	case "ns", "us", "µs", "ms", "s", "m", "h", "d":
 		return DurationConverter
-	case "bytes", "decbytes", "bits", "decbits", "kbytes", "decKbytes", "mbytes", "decMbytes", "gbytes", "decGbytes", "tbytes", "decTbytes", "pbytes", "decPbytes":
+	case "bytes", "decbytes", "bits", "decbits", "kbytes", "decKbytes", "deckbytes", "mbytes", "decMbytes", "decmbytes", "gbytes", "decGbytes", "decgbytes", "tbytes", "decTbytes", "dectbytes", "pbytes", "decPbytes", "decpbytes":
 		return DataConverter
 	case "binBps", "Bps", "binbps", "bps", "KiBs", "Kibits", "KBs", "Kbits", "MiBs", "Mibits", "MBs", "Mbits", "GiBs", "Gibits", "GBs", "Gbits", "TiBs", "Tibits", "TBs", "Tbits", "PiBs", "Pibits", "PBs", "Pbits":
 		return DataRateConverter
@@ -64,7 +64,7 @@ func UnitToName(u string) string {
 	switch u {
 	case "ns":
 		return " ns"
-	case "us":
+	case "us", "µs":
 		return " us"
 	case "ms":
 		return " ms"
@@ -86,23 +86,23 @@ func UnitToName(u string) string {
 		return " bits"
 	case "kbytes":
 		return " KiB"
-	case "decKbytes":
+	case "decKbytes", "deckbytes":
 		return " kB"
 	case "mbytes":
 		return " MiB"
-	case "decMbytes":
+	case "decMbytes", "decmbytes":
 		return " MB"
 	case "gbytes":
 		return " GiB"
-	case "decGbytes":
+	case "decGbytes", "decgbytes":
 		return " GB"
 	case "tbytes":
 		return " TiB"
-	case "decTbytes":
+	case "decTbytes", "decybytes":
 		return " TB"
 	case "pbytes":
 		return " PiB"
-	case "decPbytes":
+	case "decPbytes", "decpbytes":
 		return " PB"
 	case "binBps":
 		return " bytes/sec(IEC)"

--- a/pkg/query-service/converter/data.go
+++ b/pkg/query-service/converter/data.go
@@ -70,23 +70,23 @@ func FromDataUnit(u Unit) float64 {
 		return Bit
 	case "kbytes": // base 2
 		return Kibibyte
-	case "deckbytes": // base 10
+	case "decKbytes", "deckbytes": // base 10
 		return Kilobyte
 	case "mbytes": // base 2
 		return Mebibyte
-	case "decmbytes": // base 10
+	case "decMbytes", "decmbytes": // base 10
 		return Megabyte
 	case "gbytes": // base 2
 		return Gibibyte
-	case "decgbytes": // base 10
+	case "decGbytes", "decgbytes": // base 10
 		return Gigabyte
 	case "tbytes": // base 2
 		return Tebibyte
-	case "dectbytes": // base 10
+	case "decTbytes", "dectbytes": // base 10
 		return Terabyte
 	case "pbytes": // base 2
 		return Pebibyte
-	case "decpbytes": // base 10
+	case "decPbytes", "decpbytes": // base 10
 		return Petabyte
 	default:
 		return 1

--- a/pkg/query-service/converter/time.go
+++ b/pkg/query-service/converter/time.go
@@ -31,7 +31,7 @@ func FromTimeUnit(u Unit) Duration {
 	switch u {
 	case "ns":
 		return Nanosecond
-	case "us":
+	case "us", "µs":
 		return Microsecond
 	case "ms":
 		return Millisecond

--- a/pkg/query-service/formatter/data.go
+++ b/pkg/query-service/formatter/data.go
@@ -30,23 +30,23 @@ func (f *dataFormatter) Format(value float64, unit string) string {
 		return humanize.Bytes(uint64(value * converter.Bit))
 	case "kbytes":
 		return humanize.IBytes(uint64(value * converter.Kibibit))
-	case "deckbytes":
+	case "decKbytes", "deckbytes":
 		return humanize.IBytes(uint64(value * converter.Kilobit))
 	case "mbytes":
 		return humanize.IBytes(uint64(value * converter.Mebibit))
-	case "decmbytes":
+	case "decMbytes", "decmbytes":
 		return humanize.Bytes(uint64(value * converter.Megabit))
 	case "gbytes":
 		return humanize.IBytes(uint64(value * converter.Gibibit))
-	case "decgbytes":
+	case "decGbytes", "decgbytes":
 		return humanize.Bytes(uint64(value * converter.Gigabit))
 	case "tbytes":
 		return humanize.IBytes(uint64(value * converter.Tebibit))
-	case "dectbytes":
+	case "decTbytes", "dectbytes":
 		return humanize.Bytes(uint64(value * converter.Terabit))
 	case "pbytes":
 		return humanize.IBytes(uint64(value * converter.Pebibit))
-	case "decpbytes":
+	case "decPbytes", "decpbytes":
 		return humanize.Bytes(uint64(value * converter.Petabit))
 	}
 	// When unit is not matched, return the value as it is.

--- a/pkg/query-service/formatter/formatter.go
+++ b/pkg/query-service/formatter/formatter.go
@@ -18,9 +18,9 @@ var (
 
 func FromUnit(u string) Formatter {
 	switch u {
-	case "ns", "us", "ms", "s", "m", "h", "d":
+	case "ns", "us", "µs", "ms", "s", "m", "h", "d":
 		return DurationFormatter
-	case "bytes", "decbytes", "bits", "decbits", "kbytes", "decKbytes", "mbytes", "decMbytes", "gbytes", "decGbytes", "tbytes", "decTbytes", "pbytes", "decPbytes":
+	case "bytes", "decbytes", "bits", "decbits", "kbytes", "decKbytes", "deckbytes", "mbytes", "decMbytes", "decmbytes", "gbytes", "decGbytes", "decgbytes", "tbytes", "decTbytes", "dectbytes", "pbytes", "decPbytes", "decpbytes":
 		return DataFormatter
 	case "binBps", "Bps", "binbps", "bps", "KiBs", "Kibits", "KBs", "Kbits", "MiBs", "Mibits", "MBs", "Mbits", "GiBs", "Gibits", "GBs", "Gbits", "TiBs", "Tibits", "TBs", "Tbits", "PiBs", "Pibits", "PBs", "Pbits":
 		return DataRateFormatter

--- a/pkg/query-service/formatter/scale.go
+++ b/pkg/query-service/formatter/scale.go
@@ -81,10 +81,9 @@ func toFixed(value float64, decimals DecimalCount) string {
 	precision := 0
 	if decimalPos != -1 {
 		precision = len(formatted) - decimalPos - 1
-	}
-
-	if precision < *decimals {
-		return formatted + strings.Repeat("0", *decimals-precision)
+		if precision < *decimals {
+			return formatted + strings.Repeat("0", *decimals-precision)
+		}
 	}
 
 	return formatted

--- a/pkg/query-service/formatter/scale_test.go
+++ b/pkg/query-service/formatter/scale_test.go
@@ -1,0 +1,15 @@
+package formatter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToFixed(t *testing.T) {
+	twoDecimals := 2
+	require.Equal(t, "0", toFixed(0, nil))
+	require.Equal(t, "61", toFixed(60.99, nil))
+	require.Equal(t, "51.4", toFixed(51.42, nil))
+	require.Equal(t, "51.42", toFixed(51.42, &twoDecimals))
+}

--- a/pkg/query-service/formatter/time.go
+++ b/pkg/query-service/formatter/time.go
@@ -20,7 +20,7 @@ func (f *durationFormatter) Format(value float64, unit string) string {
 	switch unit {
 	case "ns":
 		return toNanoSeconds(value)
-	case "µs":
+	case "µs", "us":
 		return toMicroSeconds(value)
 	case "ms":
 		return toMilliSeconds(value)

--- a/pkg/query-service/rules/thresholdRule.go
+++ b/pkg/query-service/rules/thresholdRule.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"reflect"
 	"sort"
-	"strconv"
 	"sync"
 	"text/template"
 	"time"
@@ -780,7 +779,8 @@ func (r *ThresholdRule) Eval(ctx context.Context, ts time.Time, queriers *Querie
 		}
 
 		value := valueFormatter.Format(smpl.V, r.Unit())
-		threshold := strconv.FormatFloat(r.targetVal(), 'f', 2, 64) + converter.UnitToName(r.ruleCondition.TargetUnit)
+		thresholdFormatter := formatter.FromUnit(r.ruleCondition.TargetUnit)
+		threshold := thresholdFormatter.Format(r.targetVal(), r.ruleCondition.TargetUnit)
 		zap.S().Debugf("Alert template data for rule %s: Formatter=%s, Value=%s, Threshold=%s", r.Name(), valueFormatter.Name(), value, threshold)
 
 		tmplData := AlertTemplateData(l, value, threshold)


### PR DESCRIPTION
This fixes

- Format the threshold value
- Fix the format when the float value is rounded `60.99` -> `61`; this is currently formatted as 610
- Add unit types with mixed use of small and camel case
- I can't simply take `ToLower(unit)` because the casing is important for some units; for Example `binBps` and `binbps` are different but `decKbytes` and `deckbytes` are the same.