### PR TITLE
Fix/2967

### DIFF
--- a/frontend/src/container/TriggeredAlerts/Filter.tsx
+++ b/frontend/src/container/TriggeredAlerts/Filter.tsx
@@ -1,10 +1,34 @@
 /* eslint-disable react/no-unstable-nested-components */
 import type { SelectProps } from 'antd';
-import { Tag } from 'antd';
-import { Dispatch, SetStateAction, useCallback, useMemo } from 'react';
+import { Tag, Tooltip } from 'antd';
+import { BaseOptionType } from 'antd/es/select';
+import { Dispatch, SetStateAction, useCallback, useMemo, useRef } from 'react';
 import { Alerts } from 'types/api/alerts/getTriggered';
 
 import { Container, Select } from './styles';
+
+function TextOverflowTooltip({
+	option,
+}: {
+	option: BaseOptionType;
+}): JSX.Element {
+	const contentRef = useRef<HTMLDivElement | null>(null);
+	const isOverflow = contentRef.current
+		? contentRef.current?.offsetWidth < contentRef.current?.scrollWidth
+		: false;
+	return (
+		<Tooltip
+			placement="left"
+			title={JSON.stringify(option)}
+			// eslint-disable-next-line react/jsx-props-no-spreading
+			{...(!isOverflow ? { open: false } : {})}
+		>
+			<div className="ant-select-item-option-content" ref={contentRef}>
+				{option.value}
+			</div>
+		</Tooltip>
+	);
+}
 
 function Filter({
 	setSelectedFilter,
@@ -51,6 +75,7 @@ function Filter({
 
 	const options = uniqueLabels.map((e) => ({
 		value: e,
+		title: '',
 	}));
 
 	const getTags: SelectProps['tagRender'] = (props): JSX.Element => {
@@ -88,6 +113,9 @@ function Filter({
 				placeholder="Group by any tag"
 				tagRender={(props): JSX.Element => getTags(props)}
 				options={options}
+				optionRender={(option): JSX.Element => (
+					<TextOverflowTooltip option={option} />
+				)}
 			/>
 		</Container>
 	);

--- a/frontend/src/container/TriggeredAlerts/Filter.tsx
+++ b/frontend/src/container/TriggeredAlerts/Filter.tsx
@@ -19,7 +19,7 @@ function TextOverflowTooltip({
 	return (
 		<Tooltip
 			placement="left"
-			title={JSON.stringify(option)}
+			title={option.value}
 			// eslint-disable-next-line react/jsx-props-no-spreading
 			{...(!isOverflow ? { open: false } : {})}
 		>


### PR DESCRIPTION
closes #2967 

- Removes native browser title ( because it was slow and difficult to style )
- Showing users a tooltip only when the attribute name is a really long text.
<img width="670" alt="Screenshot 2023-11-27 at 2 44 03 AM" src="https://github.com/SigNoz/signoz/assets/26812698/0e76a704-d62d-4de6-9fee-4ec8cf8cc833">
