### PR TITLE
fix: [GH-4081]: no whitespace should appear when we remove hidden from body styles

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -37,7 +37,6 @@ if (container) {
 					</QueryClientProvider>
 				</ThemeProvider>
 			</HelmetProvider>
-			,
 		</ErrorBoundary>,
 	);
 }


### PR DESCRIPTION
- The presence of `,` in the app file was rendering it at the end hence causing the scroll 

https://github.com/SigNoz/signoz/assets/54737045/684f8624-e625-44b1-995e-1b606ccf4037


This PR solves #4081 


