### PR TITLE
ci(staging-deployment): ✏️ fix command to fetch schema migrator image

### DIFF
--- a/.github/workflows/staging-deployment.yaml
+++ b/.github/workflows/staging-deployment.yaml
@@ -29,7 +29,7 @@ jobs:
             export PATH="/usr/local/go/bin/:$PATH" # needed for Golang to work
             docker system prune --force
             docker pull signoz/signoz-otel-collector:main
-            docker pull signoz/signoz/signoz-schema-migrator:main
+            docker pull signoz/signoz-schema-migrator:main
             cd ~/signoz
             git status
             git add .


### PR DESCRIPTION
### Summary

Fixes the CI to fetch latest signoz schema-migrator docker image for staging-deployment workflow.

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

NA

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
