### PR TITLE
fix: update logic for handling data for uplot charts

### DIFF
--- a/frontend/src/container/NewWidget/RightContainer/index.tsx
+++ b/frontend/src/container/NewWidget/RightContainer/index.tsx
@@ -107,48 +107,8 @@ function RightContainer({
 				}
 			/>
 
-			{/* <TextContainer>
-				<Typography>Stacked Graphs :</Typography>
-				<Switch
-					checked={stacked}
-					onChange={(): void => {
-						setStacked((value) => !value);
-					}}
-				/>
-			</TextContainer> */}
-
-			{/* <Title light={'true'}>Fill Opacity: </Title> */}
-
-			{/* <Slider
-				value={parseInt(opacity, 10)}
-				marks={{
-					0: '0',
-					33: '33',
-					66: '66',
-					100: '100',
-				}}
-				onChange={(number): void => onChangeHandler(setOpacity, number.toString())}
-				step={1}
-			/> */}
-
-			{/* <Title light={'true'}>Null/Zero values: </Title>
-
-			<NullButtonContainer>
-				{nullValueButtons.map((button) => (
-					<Button
-						type={button.check === selectedNullZeroValue ? 'primary' : 'default'}
-						key={button.name}
-						onClick={(): void =>
-							onChangeHandler(setSelectedNullZeroValue, button.check)
-						}
-					>
-						{button.name}
-					</Button>
-				))}
-			</NullButtonContainer> */}
-
 			<Space style={{ marginTop: 10 }} direction="vertical">
-				<Typography>Fill span gaps</Typography>
+				<Typography>Fill gaps</Typography>
 
 				<Switch
 					checked={isFillSpans}

--- a/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
+++ b/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
@@ -29,6 +29,8 @@ const generateTooltipContent = (
 ): HTMLElement => {
 	const container = document.createElement('div');
 	container.classList.add('tooltip-container');
+	const overlay = document.getElementById('overlay');
+	let tooltipCount = 0;
 
 	let tooltipTitle = '';
 	const formattedData: Record<string, UplotTooltipDataProps> = {};
@@ -52,24 +54,37 @@ const generateTooltipContent = (
 				const value = data[index][idx];
 				const label = getLabelName(metric, queryName || '', legend || '');
 
-				const tooltipValue =
-					value !== null ? getToolTipValue(value, yAxisUnit) : 'NULL';
+				console.log('item', item);
 
-				const dataObj = {
-					show: item.show || false,
-					color: colors[(index - 1) % colors.length],
-					label,
-					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-					// @ts-ignore
-					focus: item?._focus || false,
-					value,
-					tooltipValue,
-					textContent: `${label} : ${tooltipValue}`,
-				};
+				if (value) {
+					const tooltipValue = getToolTipValue(value, yAxisUnit);
 
-				formattedData[label] = dataObj;
+					const dataObj = {
+						show: item.show || false,
+						color: colors[(index - 1) % colors.length],
+						label,
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						focus: item?._focus || false,
+						value,
+						tooltipValue,
+						textContent: `${label} : ${tooltipValue}`,
+					};
+
+					tooltipCount += 1;
+					formattedData[label] = dataObj;
+				}
 			}
 		});
+	}
+
+	// Show tooltip only if atleast only series has a value at the hovered timestamp
+	if (tooltipCount <= 0) {
+		if (overlay && overlay.style.display === 'block') {
+			overlay.style.display = 'none';
+		}
+
+		return container;
 	}
 
 	const sortedData: Record<
@@ -116,8 +131,6 @@ const generateTooltipContent = (
 			}
 		});
 	}
-
-	const overlay = document.getElementById('overlay');
 
 	if (overlay && overlay.style.display === 'none') {
 		overlay.style.display = 'block';

--- a/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
+++ b/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
@@ -54,8 +54,6 @@ const generateTooltipContent = (
 				const value = data[index][idx];
 				const label = getLabelName(metric, queryName || '', legend || '');
 
-				console.log('item', item);
-
 				if (value) {
 					const tooltipValue = getToolTipValue(value, yAxisUnit);
 

--- a/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
+++ b/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
@@ -49,10 +49,11 @@ const generateTooltipContent = (
 				const { metric = {}, queryName = '', legend = '' } =
 					seriesList[index - 1] || {};
 
+				const value = data[index][idx];
 				const label = getLabelName(metric, queryName || '', legend || '');
 
-				const value = data[index][idx] || 0;
-				const tooltipValue = getToolTipValue(value, yAxisUnit);
+				const tooltipValue =
+					value !== null ? getToolTipValue(value, yAxisUnit) : 'NULL';
 
 				const dataObj = {
 					show: item.show || false,

--- a/frontend/src/lib/uPlotLib/utils/getUplotChartData.ts
+++ b/frontend/src/lib/uPlotLib/utils/getUplotChartData.ts
@@ -9,7 +9,7 @@ function getXAxisTimestamps(seriesList: any): any[] {
 		});
 	});
 
-	return Array.from(timestamps).sort((a, b) => a - b);
+	return Array.from(timestamps).sort((a: any, b: any) => a - b);
 }
 
 function fillMissingXAxisTimestamps(
@@ -19,7 +19,6 @@ function fillMissingXAxisTimestamps(
 ): any {
 	// Generate a set of all timestamps in the range
 	const allTimestampsSet = new Set(timestampArr);
-
 	const processedData = JSON.parse(JSON.stringify(data));
 
 	// Fill missing timestamps with null values
@@ -41,7 +40,6 @@ function fillMissingXAxisTimestamps(
 		entry.values.forEach((v) => {
 			if (Number.isNaN(v[1])) {
 				const replaceValue = fillSpans ? 0 : null;
-
 				// eslint-disable-next-line no-param-reassign
 				v[1] = replaceValue;
 			} else if (v[1] !== null) {
@@ -52,7 +50,7 @@ function fillMissingXAxisTimestamps(
 			}
 		});
 
-		entry.values.sort((a: number[], b: number[]) => a[0] - b[0]);
+		entry.values.sort((a: any[], b: any[]) => a[0] - b[0]);
 	});
 
 	return processedData.map((entry: { values: any[][] }) =>

--- a/frontend/src/lib/uPlotLib/utils/getUplotChartData.ts
+++ b/frontend/src/lib/uPlotLib/utils/getUplotChartData.ts
@@ -1,44 +1,63 @@
 import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
 
-// eslint-disable-next-line sonarjs/cognitive-complexity
-function fillMissingTimestamps(
-	sortedTimestamps: number[],
-	subsetArray: any[],
-	fillSpans: boolean | undefined,
-): any[] {
-	const filledArray = [];
+function getXAxisTimestamps(seriesList: any): any[] {
+	const timestamps = new Set();
 
-	let subsetIndex = 0;
-	// eslint-disable-next-line no-restricted-syntax
-	for (const timestamp of sortedTimestamps) {
-		if (
-			subsetIndex < subsetArray.length &&
-			timestamp === subsetArray[subsetIndex][0]
-		) {
-			// Timestamp is present in subsetArray
-			const seriesPointData = subsetArray[subsetIndex];
+	seriesList.forEach((series: { values: any[] }) => {
+		series.values.forEach((value) => {
+			timestamps.add(value[0]);
+		});
+	});
 
-			if (
-				seriesPointData &&
-				Array.isArray(seriesPointData) &&
-				seriesPointData.length > 0 &&
-				seriesPointData[1] !== 'NaN'
-			) {
-				filledArray.push(subsetArray[subsetIndex]);
-			} else {
-				const value = fillSpans ? 0 : null;
-				filledArray.push([seriesPointData[0], value]);
-			}
+	return Array.from(timestamps).sort((a, b) => a - b);
+}
 
-			subsetIndex += 1;
-		} else {
-			// Timestamp is missing in subsetArray, fill with [timestamp, 0]
+function fillMissingXAxisTimestamps(
+	timestampArr: number[],
+	data: any[],
+	fillSpans: boolean,
+): any {
+	// Generate a set of all timestamps in the range
+	const allTimestampsSet = new Set(timestampArr);
+
+	const processedData = JSON.parse(JSON.stringify(data));
+
+	// Fill missing timestamps with null values
+	processedData.forEach((entry: { values: (number | null)[][] }) => {
+		const existingTimestamps = new Set(
+			entry.values.map((value: any[]) => value[0]),
+		);
+
+		const missingTimestamps = Array.from(allTimestampsSet).filter(
+			(timestamp) => !existingTimestamps.has(timestamp),
+		);
+
+		missingTimestamps.forEach((timestamp) => {
 			const value = fillSpans ? 0 : null;
-			filledArray.push([timestamp, value]);
-		}
-	}
 
-	return filledArray;
+			entry.values.push([timestamp, value]);
+		});
+
+		entry.values.forEach((v) => {
+			if (Number.isNaN(v[1])) {
+				const replaceValue = fillSpans ? 0 : null;
+
+				// eslint-disable-next-line no-param-reassign
+				v[1] = replaceValue;
+			} else if (v[1] !== null) {
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				// eslint-disable-next-line no-param-reassign
+				v[1] = parseFloat(v[1]);
+			}
+		});
+
+		entry.values.sort((a: number[], b: number[]) => a[0] - b[0]);
+	});
+
+	return processedData.map((entry: { values: any[][] }) =>
+		entry.values.map((value: any[]) => value[1]),
+	);
 }
 
 export const getUPlotChartData = (
@@ -46,43 +65,12 @@ export const getUPlotChartData = (
 	fillSpans?: boolean,
 ): any[] => {
 	const seriesList = apiResponse?.data?.result || [];
-	const uPlotData = [];
-
-	// this helps us identify the series with the max number of values and helps define the x axis - timestamps
-	const xSeries = seriesList.reduce(
-		(maxObj, currentObj) =>
-			currentObj.values.length > maxObj.values.length ? currentObj : maxObj,
-		seriesList[0],
+	const timestampArr = getXAxisTimestamps(seriesList);
+	const yAxisValuesArr = fillMissingXAxisTimestamps(
+		timestampArr,
+		seriesList,
+		fillSpans || false,
 	);
 
-	// sort seriesList
-	for (let index = 0; index < seriesList.length; index += 1) {
-		seriesList[index]?.values?.sort((a, b) => a[0] - b[0]);
-	}
-
-	const timestampArr = xSeries?.values?.map((v) => v[0]);
-
-	// timestamp
-	uPlotData.push(timestampArr);
-
-	// for each series, push the values
-	seriesList.forEach((series) => {
-		const updatedSeries = fillMissingTimestamps(
-			timestampArr,
-			series?.values || [],
-			fillSpans,
-		);
-
-		const seriesData =
-			updatedSeries?.map((v) => {
-				if (v[1] === null) {
-					return v[1];
-				}
-				return parseFloat(v[1]);
-			}) || [];
-
-		uPlotData.push(seriesData);
-	});
-
-	return uPlotData;
+	return [timestampArr, ...yAxisValuesArr];
 };

--- a/frontend/src/lib/uPlotLib/utils/getUplotChartData.ts
+++ b/frontend/src/lib/uPlotLib/utils/getUplotChartData.ts
@@ -1,15 +1,19 @@
 import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { QueryData } from 'types/api/widgets/getQuery';
 
-function getXAxisTimestamps(seriesList: any): any[] {
+function getXAxisTimestamps(seriesList: QueryData[]): number[] {
 	const timestamps = new Set();
 
-	seriesList.forEach((series: { values: any[] }) => {
+	seriesList.forEach((series: { values: [number, string][] }) => {
 		series.values.forEach((value) => {
 			timestamps.add(value[0]);
 		});
 	});
 
-	return Array.from(timestamps).sort((a: any, b: any) => a - b);
+	const timestampsArr: number[] | unknown[] = Array.from(timestamps) || [];
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	return timestampsArr.sort((a, b) => a - b);
 }
 
 function fillMissingXAxisTimestamps(
@@ -23,9 +27,7 @@ function fillMissingXAxisTimestamps(
 
 	// Fill missing timestamps with null values
 	processedData.forEach((entry: { values: (number | null)[][] }) => {
-		const existingTimestamps = new Set(
-			entry.values.map((value: any[]) => value[0]),
-		);
+		const existingTimestamps = new Set(entry.values.map((value) => value[0]));
 
 		const missingTimestamps = Array.from(allTimestampsSet).filter(
 			(timestamp) => !existingTimestamps.has(timestamp),
@@ -50,11 +52,13 @@ function fillMissingXAxisTimestamps(
 			}
 		});
 
-		entry.values.sort((a: any[], b: any[]) => a[0] - b[0]);
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		entry.values.sort((a, b) => a[0] - b[0]);
 	});
 
-	return processedData.map((entry: { values: any[][] }) =>
-		entry.values.map((value: any[]) => value[1]),
+	return processedData.map((entry: { values: [number, string][] }) =>
+		entry.values.map((value) => value[1]),
 	);
 }
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -42,6 +42,11 @@ body {
 				border-radius: 50%;
 			}
 		}
+
+		&.u-off {
+			text-decoration: line-through;
+			text-decoration-thickness: 3px;
+		}
 	}
 }
 


### PR DESCRIPTION
### Summary

Issues: 
1. Data missing in the plotted graph
2. The tooltip shows 0 values but the graph doesn't plot 0 points in the graph.

Before:
![image (2)](https://github.com/SigNoz/signoz/assets/3520897/befdf138-d2ba-4ad4-9726-dd01a81e04ee)


After:
#### Screenshots
![image](https://github.com/SigNoz/signoz/assets/3520897/91500a01-69b3-4823-87c8-ab95e325a4ac)


RCA: 
The fillMissingTimestamps function was not handling the subsetArray values correctly and introduced null values even when the response had data in few cases. (Mostly in cases when there is deviation amongst the timestamps across different series)

Rewrote the logic to handle data for Uplot as below.

1. Computing values for x-axis points 
    *  Loop through all the series data to create a unique set of timestamps. (previously we were relying on a single series to 
        define our x-axis points)
 2. Filling missing timestamps and corresponding values for all series.
     * Loop through the x-axis timestamps array and series [timestamp, value] array and check if all x-axis timestamps exist in the series timestamps array. If the timestamp doesn't exist in the array, add the timestamp to the series with the value to be `0` or `null` based on the fillSpans value.
3. Maintain a counter for tooltip values and show the tooltip only if a value exists. 

`We need to figure out how to handle 0 values in tooltips as 0 values are not plotted in the graph`


    




