### PR TITLE
fix: custom variables options are not populated

### DIFF
--- a/frontend/src/container/NewDashboard/DashboardVariablesSelection/VariableItem.tsx
+++ b/frontend/src/container/NewDashboard/DashboardVariablesSelection/VariableItem.tsx
@@ -224,6 +224,14 @@ function VariableItem({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [debouncedVariableValue]);
 
+	useEffect(() => {
+		// Fetch options for CUSTOM Type
+		if (variableData.type === 'CUSTOM') {
+			getOptions(null);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
 	return (
 		<VariableContainer>
 			<Typography.Text className="variable-name" ellipsis>


### PR DESCRIPTION
### Summary
Custom variables options are not populated

BEFORE:

<img width="1680" alt="Screenshot 2023-12-05 at 11 17 03 AM" src="https://github.com/SigNoz/signoz/assets/3520897/60640e3b-2614-467a-aa64-3ccabf5a15b6">


AFTER:
<img width="1679" alt="Screenshot 2023-12-05 at 11 16 20 AM" src="https://github.com/SigNoz/signoz/assets/3520897/9351dec7-99da-41d5-881d-13379366cb46">

#### Affected Areas and Manually Tested Areas

Dashboard Variables - Selection Flow
