### PR TITLE
chore: update BuilderQuery struct and add PrepareTimeseriesFilterQuery

### DIFF
--- a/pkg/query-service/app/metrics/v4/query_builder.go
+++ b/pkg/query-service/app/metrics/v4/query_builder.go
@@ -1,0 +1,86 @@
+package v4
+
+import (
+	"fmt"
+	"strings"
+
+	"go.signoz.io/signoz/pkg/query-service/constants"
+	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
+	"go.signoz.io/signoz/pkg/query-service/utils"
+)
+
+// PrepareTimeseriesFilterQuery builds the sub-query to be used for filtering timeseries based on the search criteria
+func PrepareTimeseriesFilterQuery(mq *v3.BuilderQuery) (string, error) {
+	var conditions []string
+	var fs *v3.FilterSet = mq.Filters
+	var groupTags []v3.AttributeKey = mq.GroupBy
+
+	conditions = append(conditions, fmt.Sprintf("metric_name = %s", utils.ClickHouseFormattedValue(mq.AggregateAttribute.Key)))
+	conditions = append(conditions, fmt.Sprintf("temporality = '%s'", mq.Temporality))
+
+	if fs != nil && len(fs.Items) != 0 {
+		for _, item := range fs.Items {
+			toFormat := item.Value
+			op := v3.FilterOperator(strings.ToLower(strings.TrimSpace(string(item.Operator))))
+			if op == v3.FilterOperatorContains || op == v3.FilterOperatorNotContains {
+				toFormat = fmt.Sprintf("%%%s%%", toFormat)
+			}
+			fmtVal := utils.ClickHouseFormattedValue(toFormat)
+			switch op {
+			case v3.FilterOperatorEqual:
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') = %s", item.Key.Key, fmtVal))
+			case v3.FilterOperatorNotEqual:
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') != %s", item.Key.Key, fmtVal))
+			case v3.FilterOperatorIn:
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') IN %s", item.Key.Key, fmtVal))
+			case v3.FilterOperatorNotIn:
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') NOT IN %s", item.Key.Key, fmtVal))
+			case v3.FilterOperatorLike:
+				conditions = append(conditions, fmt.Sprintf("like(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+			case v3.FilterOperatorNotLike:
+				conditions = append(conditions, fmt.Sprintf("notLike(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+			case v3.FilterOperatorRegex:
+				conditions = append(conditions, fmt.Sprintf("match(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+			case v3.FilterOperatorNotRegex:
+				conditions = append(conditions, fmt.Sprintf("not match(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+			case v3.FilterOperatorGreaterThan:
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') > %s", item.Key.Key, fmtVal))
+			case v3.FilterOperatorGreaterThanOrEq:
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') >= %s", item.Key.Key, fmtVal))
+			case v3.FilterOperatorLessThan:
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') < %s", item.Key.Key, fmtVal))
+			case v3.FilterOperatorLessThanOrEq:
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') <= %s", item.Key.Key, fmtVal))
+			case v3.FilterOperatorContains:
+				conditions = append(conditions, fmt.Sprintf("like(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+			case v3.FilterOperatorNotContains:
+				conditions = append(conditions, fmt.Sprintf("notLike(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+			case v3.FilterOperatorExists:
+				conditions = append(conditions, fmt.Sprintf("has(JSONExtractKeys(labels), '%s')", item.Key.Key))
+			case v3.FilterOperatorNotExists:
+				conditions = append(conditions, fmt.Sprintf("not has(JSONExtractKeys(labels), '%s')", item.Key.Key))
+			default:
+				return "", fmt.Errorf("unsupported filter operator")
+			}
+		}
+	}
+	whereClause := strings.Join(conditions, " AND ")
+
+	var selectLabels string
+	for _, tag := range groupTags {
+		selectLabels += fmt.Sprintf("JSONExtractString(labels, '%s') as %s, ", tag.Key, tag.Key)
+	}
+
+	// The table JOIN key always exists
+	selectLabels += "fingerprint"
+
+	filterSubQuery := fmt.Sprintf(
+		"SELECT DISTINCT %s FROM %s.%s WHERE %s",
+		selectLabels,
+		constants.SIGNOZ_METRIC_DBNAME,
+		constants.SIGNOZ_TIMESERIES_LOCAL_TABLENAME,
+		whereClause,
+	)
+
+	return filterSubQuery, nil
+}

--- a/pkg/query-service/app/metrics/v4/query_builder_test.go
+++ b/pkg/query-service/app/metrics/v4/query_builder_test.go
@@ -1,0 +1,150 @@
+package v4
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
+)
+
+func TestPrepareTimeseriesFilterQuery(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		builderQuery          *v3.BuilderQuery
+		expectedQueryContains string
+	}{
+		{
+			name: "test prepare time series with no filters and no group by",
+			builderQuery: &v3.BuilderQuery{
+				QueryName:    "A",
+				StepInterval: 60,
+				DataSource:   v3.DataSourceMetrics,
+				AggregateAttribute: v3.AttributeKey{
+					Key:      "http_requests",
+					DataType: v3.AttributeKeyDataTypeFloat64,
+					Type:     v3.AttributeKeyTypeUnspecified,
+					IsColumn: true,
+					IsJSON:   false,
+				},
+				Temporality: v3.Delta,
+				Expression:  "A",
+				Disabled:    false,
+				// remaining struct fields are not needed here
+			},
+			expectedQueryContains: "SELECT DISTINCT fingerprint FROM signoz_metrics.time_series_v2 WHERE metric_name = 'http_requests' AND temporality = 'Delta'",
+		},
+		{
+			name: "test prepare time series with no filters and group by",
+			builderQuery: &v3.BuilderQuery{
+				QueryName:    "A",
+				StepInterval: 60,
+				DataSource:   v3.DataSourceMetrics,
+				AggregateAttribute: v3.AttributeKey{
+					Key:      "http_requests",
+					DataType: v3.AttributeKeyDataTypeFloat64,
+					Type:     v3.AttributeKeyTypeUnspecified,
+					IsColumn: true,
+					IsJSON:   false,
+				},
+				Temporality: v3.Cumulative,
+				GroupBy: []v3.AttributeKey{{
+					Key:      "service_name",
+					DataType: v3.AttributeKeyDataTypeString,
+					Type:     v3.AttributeKeyTypeTag,
+				}},
+				Expression: "A",
+				Disabled:   false,
+				// remaining struct fields are not needed here
+			},
+			expectedQueryContains: "SELECT DISTINCT JSONExtractString(labels, 'service_name') as service_name, fingerprint FROM signoz_metrics.time_series_v2 WHERE metric_name = 'http_requests' AND temporality = 'Cumulative'",
+		},
+		{
+			name: "test prepare time series with no filters and multiple group by",
+			builderQuery: &v3.BuilderQuery{
+				QueryName:    "A",
+				StepInterval: 60,
+				DataSource:   v3.DataSourceMetrics,
+				AggregateAttribute: v3.AttributeKey{
+					Key:      "http_requests",
+					DataType: v3.AttributeKeyDataTypeFloat64,
+					Type:     v3.AttributeKeyTypeUnspecified,
+					IsColumn: true,
+					IsJSON:   false,
+				},
+				Temporality: v3.Cumulative,
+				GroupBy: []v3.AttributeKey{
+					{
+						Key:      "service_name",
+						DataType: v3.AttributeKeyDataTypeString,
+						Type:     v3.AttributeKeyTypeTag,
+					},
+					{
+						Key:      "endpoint",
+						DataType: v3.AttributeKeyDataTypeString,
+						Type:     v3.AttributeKeyTypeTag,
+					},
+				},
+				Expression: "A",
+				Disabled:   false,
+				// remaining struct fields are not needed here
+			},
+			expectedQueryContains: "SELECT DISTINCT JSONExtractString(labels, 'service_name') as service_name, JSONExtractString(labels, 'endpoint') as endpoint, fingerprint FROM signoz_metrics.time_series_v2 WHERE metric_name = 'http_requests' AND temporality = 'Cumulative'",
+		},
+		{
+			name: "test prepare time series with filters and multiple group by",
+			builderQuery: &v3.BuilderQuery{
+				QueryName:    "A",
+				StepInterval: 60,
+				DataSource:   v3.DataSourceMetrics,
+				AggregateAttribute: v3.AttributeKey{
+					Key:      "http_requests",
+					DataType: v3.AttributeKeyDataTypeFloat64,
+					Type:     v3.AttributeKeyTypeUnspecified,
+					IsColumn: true,
+					IsJSON:   false,
+				},
+				Temporality: v3.Cumulative,
+				Filters: &v3.FilterSet{
+					Operator: "AND",
+					Items: []v3.FilterItem{
+						{
+							Key: v3.AttributeKey{
+								Key:      "service_name",
+								Type:     v3.AttributeKeyTypeTag,
+								DataType: v3.AttributeKeyDataTypeString,
+							},
+							Operator: v3.FilterOperatorNotEqual,
+							Value:    "payment_service",
+						},
+						{
+							Key: v3.AttributeKey{
+								Key:      "endpoint",
+								Type:     v3.AttributeKeyTypeTag,
+								DataType: v3.AttributeKeyDataTypeString,
+							},
+							Operator: v3.FilterOperatorIn,
+							Value:    []interface{}{"/paycallback", "/payme", "/paypal"},
+						},
+					},
+				},
+				GroupBy: []v3.AttributeKey{{
+					Key:      "service_name",
+					DataType: v3.AttributeKeyDataTypeString,
+					Type:     v3.AttributeKeyTypeTag,
+				}},
+				Expression: "A",
+				Disabled:   false,
+				// remaining struct fields are not needed here
+			},
+			expectedQueryContains: "SELECT DISTINCT JSONExtractString(labels, 'service_name') as service_name, fingerprint FROM signoz_metrics.time_series_v2 WHERE metric_name = 'http_requests' AND temporality = 'Cumulative' AND JSONExtractString(labels, 'service_name') != 'payment_service' AND JSONExtractString(labels, 'endpoint') IN ['/paycallback','/payme','/paypal']",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			query, err := PrepareTimeseriesFilterQuery(testCase.builderQuery)
+			assert.Nil(t, err)
+			assert.Contains(t, query, testCase.expectedQueryContains)
+		})
+	}
+}

--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -447,6 +447,38 @@ const (
 	Cumulative  Temporality = "Cumulative"
 )
 
+type TimeAggregation string
+
+const (
+	TimeAggregationUnspecified   TimeAggregation = ""
+	TimeAggregationAnyLast       TimeAggregation = "latest"
+	TimeAggregationSum           TimeAggregation = "sum"
+	TimeAggregationAvg           TimeAggregation = "avg"
+	TimeAggregationMin           TimeAggregation = "min"
+	TimeAggregationMax           TimeAggregation = "max"
+	TimeAggregationCount         TimeAggregation = "count"
+	TimeAggregationCountDistinct TimeAggregation = "count_distinct"
+	TimeAggregationRate          TimeAggregation = "rate"
+	TimeAggregationIncrease      TimeAggregation = "increase"
+)
+
+type SpaceAggregation string
+
+const (
+	SpaceAggregationUnspecified SpaceAggregation = ""
+	SpaceAggregationSum         SpaceAggregation = "sum"
+	SpaceAggregationAvg         SpaceAggregation = "avg"
+	SpaceAggregationMin         SpaceAggregation = "min"
+	SpaceAggregationMax         SpaceAggregation = "max"
+	SpaceAggregationCount       SpaceAggregation = "count"
+)
+
+type Function struct {
+	Category string        `json:"category"`
+	Name     string        `json:"name"`
+	Args     []interface{} `json:"args,omitempty"`
+}
+
 type BuilderQuery struct {
 	QueryName          string            `json:"queryName"`
 	StepInterval       int64             `json:"stepInterval"`
@@ -466,6 +498,9 @@ type BuilderQuery struct {
 	OrderBy            []OrderBy         `json:"orderBy,omitempty"`
 	ReduceTo           ReduceToOperator  `json:"reduceTo,omitempty"`
 	SelectColumns      []AttributeKey    `json:"selectColumns,omitempty"`
+	TimeAggregation    TimeAggregation   `json:"timeAggregation,omitempty"`
+	SpaceAggregation   SpaceAggregation  `json:"spaceAggregation,omitempty"`
+	Functions          []Function        `json:"functions,omitempty"`
 }
 
 func (b *BuilderQuery) Validate() error {


### PR DESCRIPTION
### Summary

Part 1 of #4016 

# Overview

## Metric types

Primary metric types supported are:

- **Counter**: A counter is a (cumulative/delta) metric that represents a single monotonically increasing counter whose value can only increase or be reset to zero on restart. For example, you can use a counter to represent the number of requests served, tasks completed, or errors.

- **Gauge**: A gauge is a metric that represents a single numerical value that can arbitrarily change. It can go up and down. Gauges are typically used for measured values like temperatures or current memory usage, but also "counts" that can go up and down, like the number of concurrent requests.

- **Histogram**: A histogram samples observations (usually things like request durations) and (cumulative/delta) counts them in configurable buckets. This allows for aggregatable calculation of quantiles.

### Temporality

The definition of the word _Temporality_ is _the state of existing within or having some relationship with time_. In the context of metrics, it means how the metric value changes over time. There are two types of temporality:

- **Cumulative**: Cumulative metrics represent a monotonically increasing value. Cumulative metrics are always non-negative floating-point numbers and are only reset when the process restarts.

- **Delta**: Delta metrics are the difference between the current value and the previous value. Delta metrics are always non-negative floating-point numbers.

Both cumulative and delta metrics are supported by the metrics service. We strongly recommend using delta temporality whenever possible.

### Cumulative Counter

A cumulative counter represents a monotonically increasing count over time, reset only on restart.

Example: Total number of requests served.

Time       | Value
-----------|-------
00:00      | 0
00:10      | 5
00:20      | 12
00:30      | 20
00:40      | 28
00:50      | 35
01:00      | 45
01:10      | 55
01:20      | 65
01:30      | 72
01:40      | 80
01:50      | 90
02:00      | 100

In this table, each row after 00:00 shows the cumulative count of requests served since the 00:00 report. For instance, at 00:20, there were 12 requests served since the 00:00 report.

### Delta Counter

A delta counter shows the difference in count since the last report.

Example: Number of new requests served since last report.

Time       | Value
-----------|-------
00:00      | 0
00:10      | 5
00:20      | 7
00:30      | 8
00:40      | 8
00:50      | 7
01:00      | 10
01:10      | 10
01:20      | 10
01:30      | 7
01:40      | 8
01:50      | 10
02:00      | 10

In this table, each row after 00:00 shows the count of new requests served since the last report. For instance, at 00:20, there were 7 new requests served since the 00:10 report.

### Gauge

A gauge represents a value that can increase or decrease over time.

Example: Current number of active sessions.

Time       | Value
-----------|-------
00:00      | 0
00:10      | 3
00:20      | 5
00:30      | 4
00:40      | 6
00:50      | 7
01:00      | 5
01:10      | 6
01:20      | 7
01:30      | 6
01:40      | 8
01:50      | 7
02:00      | 5

In this table, each row after 00:00 shows the current number of active sessions. For instance, at 00:20, there were 5 active sessions.

### Cumulative Histogram

A cumulative histogram represents a monotonically increasing count of observations over time, reset only on restart.

Example: Response times categorized in buckets (e.g., <100ms, 100-200ms, 200-300ms, >300ms).

Time       | <100ms | 100-200ms | 200-300ms | >300ms
-----------|--------|-----------|-----------|-------
00:00      | 0      | 0         | 0         | 0
00:10      | 5      | 0         | 0         | 0
00:20      | 10     | 2         | 0         | 0
00:30      | 15     | 5         | 1         | 0
00:40      | 20     | 8         | 2         | 1
00:50      | 25     | 12        | 3         | 1
01:00      | 30     | 15        | 5         | 2
01:10      | 35     | 18        | 7         | 3
01:20      | 40     | 21        | 10        | 3
01:30      | 45     | 24        | 12        | 4
01:40      | 50     | 28        | 14        | 5
01:50      | 55     | 32        | 15        | 5
02:00      | 60     | 35        | 17        | 6

In this table, each row after 00:00 shows the cumulative count of observations in each response time bucket. For instance, at 00:20, there were 10 observations with response times under 100ms, 2 observations with response times between 100-200ms, and 0 observations with response times between 200-300ms since the 00:00 report.

### Delta Histogram

A delta histogram also counts observations in buckets, but the counts are the difference since the last report.

Example: New response times in the same buckets.

Time       | <100ms | 100-200ms | 200-300ms | >300ms
-----------|--------|-----------|-----------|-------
00:00      | 0      | 0         | 0         | 0
00:10      | 5      | 0         | 0         | 0
00:20      | 5      | 2         | 0         | 0
00:30      | 5      | 3         | 1         | 0
00:40      | 5      | 3         | 1         | 1
00:50      | 5      | 4         | 1         | 0
01:00      | 5      | 3         | 2         | 1
01:10      | 5      | 3         | 2         | 1
01:20      | 5      | 3         | 3         | 0
01:30      | 5      | 3         | 2         | 1
01:40      | 5      | 4         | 2         | 1
01:50      | 5      | 4         | 1         | 0
02:00      | 5      | 3         | 2         | 1

In this table, each row after 00:00 shows the count of new observations in each response time bucket since the last report. For instance, at 00:20, there were 5 new observations with response times under 100ms and 2 new observations with response times between 100-200ms since the 00:10 report.


## Time and Spatial Aggregation Explained for Metrics Data

This document clarifies the concepts of time and spatial aggregation in the context of metrics data analysis.

### Time Aggregation

- Time aggregation is the aggregation of all the measurement values for a time series over a specified aggregation interval. 
- Aggregation interval is dynamically adjusted based on the selected time range.
- Various aggregation operators are available, including `avg`, `sum`, `min`, `max`, `count`, etc. 
- The result is a single value for each aggregation interval. 

### Spatial Aggregation

- Combines data points from multiple time series within a specific spatial dimension(s). The spatial dimension(s) could be a host, a region, a cluster, etc. 
- Various aggregation operators are available, including `avg`, `sum`, `min`, `max`, `count`, etc.
- The result is a single value representing the aggregated data for the chosen spatial dimension(s).

The following table represents the metrics data from five hosts `h1`, `h2`, `h3`, `h4`, and `h5` spread across `r1`, `r2`, and `r3` regions. Assume the reported value is memory usage in MB for each host. The timestamp is mm:ss (minute:second) format and ranges from 10th minute 00 seconds to 12th minute 30 seconds with a collection interval of 10 seconds. The region `r1` has two hosts `h1` and `h2`, region `r2` has one host `h3` and region `r3` has two hosts `h4` and `h5`. The metrics data is collected for 150 sec.

| Time  | (h1, r1) | (h2, r1) | (h3, r2) | (h4, r3) | (h5,r3) |
| ----- | -------- | -------- | -------- | -------- | ------- |
| 10:00 | 45       | 63       | 58       | 32       | 56      |
| 10:10 | 72       | 90       | 87       | 35       | 81      |
| 10:20 | 56       | 85       | 95       | 74       | 72      |
| 10:30 | 73       | 98       | 71       | 63       | 85      |
| 10:40 | 97       | 88       | 56       | 91       | 36      |
| 10:50 | 67       | 48       | 42       | 31       | 76      |
| 11:00 | 65       | 95       | 30       | 35       | 96      |
| 11:10 | 81       | 39       | 68       | 69       | 77      |
| 11:20 | 57       | 75       | 50       | 40       | 43      |
| 11:30 | 54       | 45       | 68       | 48       | 53      |
| 11:40 | 85       | 77       | 39       | 63       | 31      |
| 11:50 | 77       | 52       | 71       | 32       | 88      |
| 12:00 | 30       | 97       | 90       | 51       | 55      |
| 12:10 | 82       | 92       | 83       | 41       | 32      |
| 12:20 | 95       | 37       | 56       | 65       | 91      |
| 12:30 | 53       | 95       | 37       | 94       | 66      |


We can't display the raw data since it is too big. So we first perform the aggregation on the time axis for each unique series. There are 5 time series in the above table. We could use the aggregation operator `avg` to get the representative value for each 30 seconds. The aggregation result is shown in the following table.

| ts    | (h1, r1) | (h2, r1) | (h3, r2) | (h4, r3) | (h5, r3) |
| :---- | -------: | -------: | -------: | -------: | -------: |
| 10:00 |  57.6667 |  79.3333 |       80 |       47 |  69.6667 |
| 10:30 |       79 |       78 |  56.3333 |  61.6667 |  65.6667 |
| 11:00 |  67.6667 |  69.6667 |  49.3333 |       48 |       72 |
| 11:30 |       72 |       58 |  59.3333 |  47.6667 |  57.3333 |
| 12:00 |       69 |  75.3333 |  76.3333 |  52.3333 |  59.3333 |
| 12:30 |       53 |       95 |       37 |       94 |       66 |

Even this table could be too big to display if there were hundreds of hosts. The spatial aggregation is performed on the result of the time aggregation. We could use the aggregation operator `sum` to get the total memory usage. 

### Total Memory Usage for Each Region

| ts    |      r1 |      r2 |      r3 |
| :---- | ------: | ------: | ------: |
| 10:00 |     137 |      80 | 116.667 |
| 10:30 |     157 | 56.3333 | 127.333 |
| 11:00 | 137.333 | 49.3333 |     120 |
| 11:30 |     130 | 59.3333 |     105 |
| 12:00 | 144.333 | 76.3333 | 111.667 |
| 12:30 |     148 |      37 |     160 |


### Total Memory Usage for Each Host

| ts    | (h1, r1) | (h2, r1) | (h3, r2) | (h4, r3) | (h5, r3) |
| :---- | -------: | -------: | -------: | -------: | -------: |
| 10:00 |  57.6667 |  79.3333 |       80 |       47 |  69.6667 |
| 10:30 |       79 |       78 |  56.3333 |  61.6667 |  65.6667 |
| 11:00 |  67.6667 |  69.6667 |  49.3333 |       48 |       72 |
| 11:30 |       72 |       58 |  59.3333 |  47.6667 |  57.3333 |
| 12:00 |       69 |  75.3333 |  76.3333 |  52.3333 |  59.3333 |
| 12:30 |       53 |       95 |       37 |       94 |       66 |

Note: this table is the same as the time aggregation result because each host is unique and there are no sub time series for each host. Other metrics such as DISK usage could have sub time series for each host (usage from each partition). In that case, the spatial aggregation result could be different from the time aggregation result.

### Total Memory Usage from All Hosts

| ts    |     All |
| :---- | ------: |
| 10:00 | 333.667 |
| 10:30 | 340.667 |
| 11:00 | 306.667 |
| 11:30 | 294.333 |
| 12:00 | 332.333 |
| 12:30 |     345 |


### Default aggregation operators

Based on the metric type, the default time and space aggregation operators are chosen. The following table shows the default aggregation operators for each metric type.

| Metric Type | Default Time Aggregation Operator | Default Space Aggregation Operator |
| ----------- | --------------------------------- | ---------------------------------- |
| Counter     | rate                              | sum                                |
| Gauge       | avg                               | sum                                |
| Histogram   | rate                              | sum                                |

Histograms are a special case because the value isn't a single number but a group of numbers. The most common use case is to calculate the quantiles. The current implementation supports the following quantiles: 0.5, 0.9, 0.95, 0.99. The time and space aggregation produces the distribution of observations in each bucket. The quantiles are calculated from the distribution.

## Implementation Details

The schema of the metrics database tables is as follows:

```sql
CREATE TABLE signoz_metrics.time_series_v2
(
    `metric_name` LowCardinality(String),
    `fingerprint` UInt64 CODEC(DoubleDelta, LZ4),
    `timestamp_ms` Int64 CODEC(DoubleDelta, LZ4),
    `labels` String CODEC(ZSTD(5)),
    `temporality` LowCardinality(String) DEFAULT 'Unspecified' CODEC(ZSTD(5)),
    INDEX temporality_index temporality TYPE SET(3) GRANULARITY 1
)
ENGINE = ReplacingMergeTree
PARTITION BY toDate(timestamp_ms / 1000)
ORDER BY (metric_name, fingerprint)
SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
```

- **metric_name**: Name of the metric
- **fingerprint**: Fingerprint of the metric. This is used to identify the metric uniquely. Currently, 
  we are using the hash of the labels to generate the fingerprint.
- **timestamp_ms**: Timestamp of the metric when it was observed for the first time in milliseconds
- **labels**: Labels of the metric; Stored as a JSON string
- **temporality**: Temporality of the metric. This is used to identify the type of the metric. It can 
  be one of the following values:
  - Unspecified: This is the default value. 
  - Cumulative: This is used for monotonic counters.
  - Delta: This is used for non-monotonic counters.


```sql
CREATE TABLE signoz_metrics.samples_v2
(
    `metric_name` LowCardinality(String),
    `fingerprint` UInt64 CODEC(DoubleDelta, LZ4),
    `timestamp_ms` Int64 CODEC(DoubleDelta, LZ4),
    `value` Float64 CODEC(Gorilla, LZ4)
)
ENGINE = MergeTree
PARTITION BY toDate(timestamp_ms / 1000)
ORDER BY (metric_name, fingerprint, timestamp_ms)
TTL toDateTime(timestamp_ms / 1000) + toIntervalSecond(2592000)
SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
```

- **metric_name**: Name of the metric
- **fingerprint**: Fingerprint of the metric. This is used to identify the metric uniquely. Currently, 
  we are using the hash of the labels to generate the fingerprint.
- **timestamp_ms**: Timestamp of the metric in milliseconds
- **value**: Value of the metric

### Query preparation

As there are two tables for metrics, any query on metrics will need to join these two tables. First, we get the fingerprints of the metrics that match the query criteria from the `time_series_v2` table. Then, we join the `samples_v2` table with the `time_series_v2` table to get the actual metric values. The are three to four steps in the query preparation:

1. Get the fingerprints of the metrics that match the query criteria from the `time_series_v2` table.
2. Join the `samples_v2` table with the `time_series_v2` table to get the actual metric values.
3. Apply the time aggregation operator on the metric values.
4. Apply the space aggregation operator on the metric values.

A typical query looks like the following:

```sql
SELECT
    ts,
    sum(per_series_value) AS value
FROM
(
    SELECT
        fingerprint,
        toStartOfInterval(toDateTime(intDiv(timestamp_ms, 1000)), toIntervalSecond(60)) AS ts,
        avg(value) AS per_series_value
    FROM signoz_metrics.distributed_samples_v2
    INNER JOIN
    (
        SELECT DISTINCT fingerprint
        FROM signoz_metrics.time_series_v2
        WHERE (metric_name = 'system_memory_usage') AND (temporality = 'Unspecified') AND (JSONExtractString(labels, 'state') != 'idle')
    ) AS filtered_time_series USING (fingerprint)
    WHERE (metric_name = 'system_memory_usage') AND (timestamp_ms >= 1701794980000) AND (timestamp_ms <= 1701796780000)
    GROUP BY
        fingerprint,
        ts
    ORDER BY
        fingerprint ASC,
        ts ASC
)
WHERE isNaN(per_series_value) = 0
GROUP BY
    GROUPING SETS (
        (ts),
        ())
ORDER BY ts ASC
```

The query can be broken down into the following steps:

1. Get the fingerprints of the metrics that match the query criteria from the `time_series_v2` table.

```sql
SELECT DISTINCT fingerprint
FROM signoz_metrics.time_series_v2
WHERE (metric_name = 'system_memory_usage') AND (temporality = 'Unspecified') AND (JSONExtractString(labels, 'state') != 'idle')
```

2. Join the tables and apply the time aggregation operator on the metric values.

```sql
SELECT
    fingerprint,
    toStartOfInterval(toDateTime(intDiv(timestamp_ms, 1000)), toIntervalSecond(60)) AS ts,
    avg(value) AS per_series_value
FROM signoz_metrics.distributed_samples_v2
INNER JOIN
(
    SELECT DISTINCT fingerprint
    FROM signoz_metrics.time_series_v2
    WHERE (metric_name = 'system_memory_usage') AND (temporality = 'Unspecified') AND (JSONExtractString(labels, 'state') != 'idle')
) AS filtered_time_series USING (fingerprint)
WHERE (metric_name = 'system_memory_usage') AND (timestamp_ms >= 1701794980000) AND (timestamp_ms <= 1701796780000)
GROUP BY
    fingerprint,
    ts
ORDER BY
    fingerprint ASC,
    ts ASC
```

3. Apply the space aggregation operator on the metric values.

```sql
SELECT
    ts,
    sum(per_series_value) AS value
FROM
(
    SELECT
        fingerprint,
        toStartOfInterval(toDateTime(intDiv(timestamp_ms, 1000)), toIntervalSecond(60)) AS ts,
        avg(value) AS per_series_value
    FROM signoz_metrics.distributed_samples_v2
    INNER JOIN
    (
        SELECT DISTINCT fingerprint
        FROM signoz_metrics.time_series_v2
        WHERE (metric_name = 'system_memory_usage') AND (temporality = 'Unspecified') AND (JSONExtractString(labels, 'state') != 'idle')
    ) AS filtered_time_series USING (fingerprint)
    WHERE (metric_name = 'system_memory_usage') AND (timestamp_ms >= 1701794980000) AND (timestamp_ms <= 1701796780000)
    GROUP BY
        fingerprint,
        ts
    ORDER BY
        fingerprint ASC,
        ts ASC
)
WHERE isNaN(per_series_value) = 0
GROUP BY
    GROUPING SETS (
        (ts),
        ())
ORDER BY ts ASC
```

This is a simple example, things gets little complicated when we need to compute rates and percentiles.



------------------------

The major changes in the metrics builder improvements are

1. temporal and spatial aggregation
2. functions support

I will be send a series of PRs to implement these changes. This PR is the first one in the series.

