### PR TITLE
fix(FE): Fixes the background color of the dashboards full screen view as per the mode selected i.e dark or light mode

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCardLayout.tsx
+++ b/frontend/src/container/GridCardLayout/GridCardLayout.tsx
@@ -3,6 +3,7 @@ import './GridCardLayout.styles.scss';
 import { PlusOutlined, SaveFilled } from '@ant-design/icons';
 import { SOMETHING_WENT_WRONG } from 'constants/api';
 import { PANEL_TYPES } from 'constants/queryBuilder';
+import { themeColors } from 'constants/theme';
 import { useUpdateDashboard } from 'hooks/dashboard/useUpdateDashboard';
 import useComponentPermission from 'hooks/useComponentPermission';
 import { useIsDarkMode } from 'hooks/useDarkMode';
@@ -155,7 +156,7 @@ function GraphLayout({ onAddPanelHandler }: GraphLayoutProps): JSX.Element {
 					onLayoutChange={setLayouts}
 					draggableHandle=".drag-handle"
 					layout={layouts}
-					style={{ backgroundColor: isDarkMode ? '' : '#f5f5f5' }}
+					style={{ backgroundColor: isDarkMode ? '' : themeColors.snowWhite }}
 				>
 					{layouts.map((layout) => {
 						const { i: id } = layout;

--- a/frontend/src/container/GridCardLayout/GridCardLayout.tsx
+++ b/frontend/src/container/GridCardLayout/GridCardLayout.tsx
@@ -155,6 +155,7 @@ function GraphLayout({ onAddPanelHandler }: GraphLayoutProps): JSX.Element {
 					onLayoutChange={setLayouts}
 					draggableHandle=".drag-handle"
 					layout={layouts}
+					style={{ backgroundColor: isDarkMode ? '' : '#f5f5f5' }}
 				>
 					{layouts.map((layout) => {
 						const { i: id } = layout;


### PR DESCRIPTION
### Summary

This PR fixes the background color of the dashboard's full screen view as per the mode selected by the user , if dark mode then the backgroud color is black else its `#f5f5f5` matching the color of the dashboard's other screens.

#### Related Issues / PR's

Issue Link: https://github.com/SigNoz/signoz/issues/4138

#### Screenshots

Before: - Even if the mode is light the bg was black. 

<img width="1434" alt="Screenshot 2023-12-06 at 20 21 10" src="https://github.com/SigNoz/signoz/assets/40532869/12e875c1-2dfb-4f04-8fdc-b28fcf4925d1">


After
<img width="1431" alt="Screenshot 2023-12-06 at 20 19 52" src="https://github.com/SigNoz/signoz/assets/40532869/77c988cf-a645-4030-899d-8f934e9e1a5b">
<img width="1438" alt="Screenshot 2023-12-06 at 20 20 03" src="https://github.com/SigNoz/signoz/assets/40532869/388194a4-b5ab-46bd-9a4f-c09e466bd90d">


