### PR TITLE
fix: [GH-3790]: timerange not working for different users

### DIFF
--- a/frontend/src/container/TopNav/DateTimeSelection/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelection/index.tsx
@@ -223,8 +223,6 @@ function DateTimeSelection({
 		}
 	};
 
-	console.log(location.pathname);
-
 	// this is triggred when we change the routes and based on that we are changing the default options
 	useEffect(() => {
 		const metricsTimeDuration = getLocalStorageKey(
@@ -240,8 +238,6 @@ function DateTimeSelection({
 
 		const currentRoute = location.pathname;
 		const time = getDefaultTime(currentRoute);
-
-		console.log(time);
 
 		const currentOptions = getOptions(currentRoute);
 		setOptions(currentOptions);

--- a/frontend/src/container/TopNav/DateTimeSelection/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelection/index.tsx
@@ -223,8 +223,8 @@ function DateTimeSelection({
 				setLocalStorageKey('endTime', endTimeMoment.toString());
 				updateLocalStorageForRoutes('custom');
 				if (!isLogsExplorerPage) {
-					urlQuery.set(QueryParams.startTime, minTime.toString());
-					urlQuery.set(QueryParams.endTime, maxTime.toString());
+					urlQuery.set(QueryParams.startTime, startTimeMoment.toString());
+					urlQuery.set(QueryParams.endTime, endTimeMoment.toString());
 					const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
 					history.replace(generatedUrl);
 				}

--- a/frontend/src/container/TopNav/DateTimeSelection/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelection/index.tsx
@@ -8,6 +8,7 @@ import dayjs, { Dayjs } from 'dayjs';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { updateStepInterval } from 'hooks/queryBuilder/useStepInterval';
 import useUrlQuery from 'hooks/useUrlQuery';
+import createQueryParams from 'lib/createQueryParams';
 import GetMinMax from 'lib/getMinMax';
 import getTimeString from 'lib/getTimeString';
 import history from 'lib/history';
@@ -192,7 +193,10 @@ function DateTimeSelection({
 
 		urlQuery.set(QueryParams.startTime, minTime.toString());
 		urlQuery.set(QueryParams.endTime, maxTime.toString());
-		const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
+		const generatedUrl = `${location.pathname}?${createQueryParams({
+			startTime: minTime.toString(),
+			endTime: maxTime.toString(),
+		})}`;
 		history.replace(generatedUrl);
 
 		initQueryBuilderData(updateStepInterval(stagedQuery, maxTime, minTime));
@@ -215,9 +219,10 @@ function DateTimeSelection({
 				setLocalStorageKey('startTime', startTimeMoment.toString());
 				setLocalStorageKey('endTime', endTimeMoment.toString());
 				updateLocalStorageForRoutes('custom');
-				urlQuery.set(QueryParams.startTime, startTimeMoment.toString());
-				urlQuery.set(QueryParams.endTime, endTimeMoment.toString());
-				const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
+				const generatedUrl = `${location.pathname}?${createQueryParams({
+					startTime: startTimeMoment.toString(),
+					endTime: endTimeMoment.toString(),
+				})}`;
 				history.replace(generatedUrl);
 			}
 		}

--- a/frontend/src/container/TopNav/DateTimeSelection/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelection/index.tsx
@@ -9,7 +9,6 @@ import dayjs, { Dayjs } from 'dayjs';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { updateStepInterval } from 'hooks/queryBuilder/useStepInterval';
 import useUrlQuery from 'hooks/useUrlQuery';
-import createQueryParams from 'lib/createQueryParams';
 import GetMinMax from 'lib/getMinMax';
 import getTimeString from 'lib/getTimeString';
 import history from 'lib/history';
@@ -196,10 +195,7 @@ function DateTimeSelection({
 		if (!isLogsExplorerPage) {
 			urlQuery.set(QueryParams.startTime, minTime.toString());
 			urlQuery.set(QueryParams.endTime, maxTime.toString());
-			const generatedUrl = `${location.pathname}?${createQueryParams({
-				startTime: minTime.toString(),
-				endTime: maxTime.toString(),
-			})}`;
+			const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
 			history.replace(generatedUrl);
 		}
 
@@ -227,10 +223,9 @@ function DateTimeSelection({
 				setLocalStorageKey('endTime', endTimeMoment.toString());
 				updateLocalStorageForRoutes('custom');
 				if (!isLogsExplorerPage) {
-					const generatedUrl = `${location.pathname}?${createQueryParams({
-						startTime: startTimeMoment.toString(),
-						endTime: endTimeMoment.toString(),
-					})}`;
+					urlQuery.set(QueryParams.startTime, minTime.toString());
+					urlQuery.set(QueryParams.endTime, maxTime.toString());
+					const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
 					history.replace(generatedUrl);
 				}
 			}

--- a/frontend/src/hooks/logs/useCopyLogLink.ts
+++ b/frontend/src/hooks/logs/useCopyLogLink.ts
@@ -3,6 +3,7 @@ import ROUTES from 'constants/routes';
 import { useNotifications } from 'hooks/useNotifications';
 import useUrlQuery from 'hooks/useUrlQuery';
 import useUrlQueryData from 'hooks/useUrlQueryData';
+import history from 'lib/history';
 import {
 	MouseEventHandler,
 	useCallback,
@@ -28,14 +29,25 @@ export const useCopyLogLink = (logId?: string): UseCopyLogLink => {
 		(state) => state.globalTime,
 	);
 
-	const {
-		queryData: timeRange,
-		redirectWithQuery: onTimeRangeChange,
-	} = useUrlQueryData<LogTimeRange | null>(QueryParams.timeRange, null);
+	const { queryData: timeRange } = useUrlQueryData<LogTimeRange | null>(
+		QueryParams.timeRange,
+		null,
+	);
 
 	const { queryData: activeLogId } = useUrlQueryData<string | null>(
 		QueryParams.activeLogId,
 		null,
+	);
+
+	const onTimeRangeChange = useCallback(
+		(newTimeRange: LogTimeRange | null): void => {
+			urlQuery.set(QueryParams.timeRange, JSON.stringify(newTimeRange));
+			urlQuery.set(QueryParams.startTime, newTimeRange?.start.toString() || '');
+			urlQuery.set(QueryParams.endTime, newTimeRange?.end.toString() || '');
+			const generatedUrl = `${pathname}?${urlQuery.toString()}`;
+			history.replace(generatedUrl);
+		},
+		[pathname, urlQuery],
 	);
 
 	const isActiveLog = useMemo(() => activeLogId === logId, [activeLogId, logId]);


### PR DESCRIPTION
### Summary

- the startTime and endTime were not getting populated in the URL hence the sharing of timezones were not working for different users
- Now if one user selects some time range and opens it up in different tab OR shares it to a different user , they will see the time range exactly which was being used while sharing the URL

#### Related Issues / PR's

This resolves #3790

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/6064b506-df9b-4023-91dc-5193d03b55f5





#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
