### PR TITLE
fix: centering no data text position

### DIFF
--- a/frontend/src/components/Uplot/uplot.scss
+++ b/frontend/src/components/Uplot/uplot.scss
@@ -3,13 +3,15 @@
 	justify-content: center;
 	align-items: center;
 	z-index: 0;
-	height: 85%;
+	height: 100%;
 	position: absolute;
-	left: 50%;
-	transform: translate(-50%, 0);
-}
+	left: 0;
+	right: 0;
+	margin: auto;
+  }
 
-.uplot-graph-container {
+  .uplot-graph-container {
+	position: relative;
 	height: 100%;
 	width: 100%;
-}
+  }


### PR DESCRIPTION
Hi team, 

Just made a minor change in the css of the Uplot component. I've made the position of the div with "uplot-graph-container" class relative and its child div component with "not-found" class is made absolute. This along with auto margin will ensure the child, which has the "No Data" text, is always centred w.r.t the parent. 

fixing https://github.com/SigNoz/signoz/issues/4194

[Screencast from 09-12-23 11:52:50 AM IST.webm](https://github.com/SigNoz/signoz/assets/64725924/dc258a2b-bbca-4377-a84f-de2cc5e83bce)
