### PR TITLE
fix: retry of query range api is made once only 

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -16,6 +16,18 @@ const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			refetchOnWindowFocus: false,
+			retry(failureCount, error): boolean {
+				// only handling query range api retry
+				// @TODO remove this when all api is transformed into proper error handling
+				if (
+					error instanceof Error &&
+					error.message.includes('API responded with 400')
+				) {
+					return false;
+				}
+
+				return failureCount < 2;
+			},
 		},
 	},
 });


### PR DESCRIPTION
### Summary
part of https://github.com/SigNoz/signoz/issues/3932

<!-- ✍️ A clear and concise description...-->
by default retry count is 3 ... though this pr only account the failure of query range api it will not retry after the failure

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

Dashboard,Service Application,(Logs|Trace)Explorer,Alerts page
