### PR TITLE
fix: use updated query value on test query, restrict direct commit to…

### DIFF
--- a/frontend/.husky/commit-msg
+++ b/frontend/.husky/commit-msg
@@ -2,3 +2,19 @@
 . "$(dirname "$0")/_/husky.sh"
 
 cd frontend && yarn run commitlint --edit $1
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+color_red="$(tput setaf 1)"
+bold="$(tput bold)"
+reset="$(tput sgr0)"
+
+if [ "$branch" = "main" ]; then
+  echo "${color_red}${bold}You can't commit directly to the main branch${reset}"
+  exit 1
+fi
+
+if [ "$branch" = "develop" ]; then
+  echo "${color_red}${bold}You can't commit directly to the develop branch${reset}"
+  exit 1
+fi

--- a/frontend/src/container/NewDashboard/DashboardSettings/Variables/VariableItem/VariableItem.tsx
+++ b/frontend/src/container/NewDashboard/DashboardSettings/Variables/VariableItem/VariableItem.tsx
@@ -140,7 +140,7 @@ function VariableItem({
 			enabled: false,
 			queryFn: () =>
 				dashboardVariablesQuery({
-					query: variableData.queryValue || '',
+					query: variableQueryValue || '',
 					variables: variablePropsToPayloadVariables(existingVariables),
 				}),
 			refetchOnWindowFocus: false,

--- a/frontend/src/container/NewDashboard/DashboardSettings/Variables/VariableItem/VariableItem.tsx
+++ b/frontend/src/container/NewDashboard/DashboardSettings/Variables/VariableItem/VariableItem.tsx
@@ -145,6 +145,7 @@ function VariableItem({
 				}),
 			refetchOnWindowFocus: false,
 			onSuccess: (response) => {
+				setErrorPreview(null);
 				handleQueryResult(response);
 			},
 			onError: (error: {


### PR DESCRIPTION
… develop, main

### Summary
1. [BUG-FIX]: Use updatedQuery when the user clicks on Test query in Variable Edit Flow
2. [CHORE]: Update pre-commit hook to block direct commits to `main` &  `develop` branch

https://www.loom.com/share/424981e1b57542f586006ef684824393?sid=53f463e1-c70d-4e1c-9869-402ee76075c5

![Screenshot 2023-12-12 120204](https://github.com/SigNoz/signoz/assets/3520897/a78bcddd-4840-4de5-9651-9d0fe069be2b)


