### PR TITLE
fix: persistence of live view details modal

### DIFF
--- a/frontend/src/components/Logs/ListLogView/index.tsx
+++ b/frontend/src/components/Logs/ListLogView/index.tsx
@@ -7,7 +7,6 @@ import {
 } from '@ant-design/icons';
 import Convert from 'ansi-to-html';
 import { Button, Divider, Row, Typography } from 'antd';
-import LogDetail from 'components/LogDetail';
 import LogsExplorerContext from 'container/LogsExplorerContext';
 import dayjs from 'dayjs';
 import dompurify from 'dompurify';
@@ -113,16 +112,12 @@ function ListLogView({
 		onSetActiveLog: handleSetActiveContextLog,
 		onClearActiveLog: handleClearActiveContextLog,
 	} = useActiveLog();
-	const {
-		activeLog,
-		onSetActiveLog,
-		onClearActiveLog,
-		onAddToQuery,
-	} = useActiveLog();
+
+	const { onViewLogDetails, onAddToQuery } = useActiveLog();
 
 	const handleDetailedView = useCallback(() => {
-		onSetActiveLog(logData);
-	}, [logData, onSetActiveLog]);
+		onViewLogDetails(logData);
+	}, [logData, onViewLogDetails]);
 
 	const handleShowContext = useCallback(() => {
 		handleSetActiveContextLog(logData);
@@ -223,12 +218,6 @@ function ListLogView({
 						onClose={handleClearActiveContextLog}
 					/>
 				)}
-				<LogDetail
-					log={activeLog}
-					onClose={onClearActiveLog}
-					onAddToQuery={onAddToQuery}
-					onClickActionItem={onAddToQuery}
-				/>
 			</Row>
 		</Container>
 	);

--- a/frontend/src/container/LiveLogs/LiveLogsList/index.tsx
+++ b/frontend/src/container/LiveLogs/LiveLogsList/index.tsx
@@ -1,4 +1,5 @@
 import { Card, Typography } from 'antd';
+import LogDetail from 'components/LogDetail';
 import ListLogView from 'components/Logs/ListLogView';
 import RawLogView from 'components/Logs/RawLogView';
 import Spinner from 'components/Spinner';
@@ -11,6 +12,7 @@ import { convertKeysToColumnFields } from 'container/LogsExplorerList/utils';
 import { Heading } from 'container/LogsTable/styles';
 import { useOptionsMenu } from 'container/OptionsMenu';
 import { useCopyLogLink } from 'hooks/logs/useCopyLogLink';
+import { useDetailedLogView } from 'hooks/logs/useDetailedLogView';
 import useFontFaceObserver from 'hooks/useFontObserver';
 import { useEventSource } from 'providers/EventSource';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
@@ -36,6 +38,8 @@ function LiveLogsList({ logs }: LiveLogsListProps): JSX.Element {
 		dataSource: DataSource.LOGS,
 		aggregateOperator: StringOperators.NOOP,
 	});
+
+	const { activeLog, onClearLogDetails, onAddToQuery } = useDetailedLogView();
 
 	const activeLogIndex = useMemo(
 		() => logs.findIndex(({ id }) => id === activeLogId),
@@ -113,12 +117,20 @@ function LiveLogsList({ logs }: LiveLogsListProps): JSX.Element {
 						/>
 					) : (
 						<Card style={{ width: '100%' }} bodyStyle={CARD_BODY_STYLE}>
-							<Virtuoso
-								ref={ref}
-								data={logs}
-								totalCount={logs.length}
-								itemContent={getItemContent}
-							/>
+							<>
+								<Virtuoso
+									ref={ref}
+									data={logs}
+									totalCount={logs.length}
+									itemContent={getItemContent}
+								/>
+								<LogDetail
+									log={activeLog}
+									onClose={onClearLogDetails}
+									onAddToQuery={onAddToQuery}
+									onClickActionItem={onAddToQuery}
+								/>
+							</>
 						</Card>
 					)}
 				</InfinityWrapperStyled>

--- a/frontend/src/container/LogsExplorerList/index.tsx
+++ b/frontend/src/container/LogsExplorerList/index.tsx
@@ -1,4 +1,5 @@
 import { Card, Typography } from 'antd';
+import LogDetail from 'components/LogDetail';
 // components
 import ListLogView from 'components/Logs/ListLogView';
 import RawLogView from 'components/Logs/RawLogView';
@@ -9,6 +10,7 @@ import ExplorerControlPanel from 'container/ExplorerControlPanel';
 import { Heading } from 'container/LogsTable/styles';
 import { useOptionsMenu } from 'container/OptionsMenu';
 import { useCopyLogLink } from 'hooks/logs/useCopyLogLink';
+import { useDetailedLogView } from 'hooks/logs/useDetailedLogView';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import useFontFaceObserver from 'hooks/useFontObserver';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
@@ -48,6 +50,8 @@ function LogsExplorerList({
 		() => logs.findIndex(({ id }) => id === activeLogId),
 		[logs, activeLogId],
 	);
+
+	const { activeLog, onClearLogDetails, onAddToQuery } = useDetailedLogView();
 
 	useFontFaceObserver(
 		[
@@ -149,6 +153,13 @@ function LogsExplorerList({
 			)}
 
 			<InfinityWrapperStyled>{renderContent}</InfinityWrapperStyled>
+
+			<LogDetail
+				log={activeLog}
+				onClose={onClearLogDetails}
+				onAddToQuery={onAddToQuery}
+				onClickActionItem={onAddToQuery}
+			/>
 		</>
 	);
 }

--- a/frontend/src/container/LogsTable/index.tsx
+++ b/frontend/src/container/LogsTable/index.tsx
@@ -1,6 +1,7 @@
 import './logsTable.styles.scss';
 
 import { Card, Typography } from 'antd';
+import LogDetail from 'components/LogDetail';
 // components
 import ListLogView from 'components/Logs/ListLogView';
 import RawLogView from 'components/Logs/RawLogView';
@@ -8,6 +9,7 @@ import LogsTableView from 'components/Logs/TableView';
 import Spinner from 'components/Spinner';
 import { CARD_BODY_STYLE } from 'constants/card';
 import { useActiveLog } from 'hooks/logs/useActiveLog';
+import { useDetailedLogView } from 'hooks/logs/useDetailedLogView';
 import useFontFaceObserver from 'hooks/useFontObserver';
 import { memo, useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -30,6 +32,8 @@ function LogsTable(props: LogsTableProps): JSX.Element {
 	const { viewMode, linesPerRow } = props;
 
 	const { onSetActiveLog } = useActiveLog();
+
+	const { activeLog, onClearLogDetails, onAddToQuery } = useDetailedLogView();
 
 	useFontFaceObserver(
 		[
@@ -110,6 +114,13 @@ function LogsTable(props: LogsTableProps): JSX.Element {
 			{isNoLogs && <Typography>No logs lines found</Typography>}
 
 			{renderContent}
+
+			<LogDetail
+				log={activeLog}
+				onClose={onClearLogDetails}
+				onAddToQuery={onAddToQuery}
+				onClickActionItem={onAddToQuery}
+			/>
 		</Container>
 	);
 }

--- a/frontend/src/hooks/logs/types.ts
+++ b/frontend/src/hooks/logs/types.ts
@@ -20,7 +20,21 @@ export type UseCopyLogLink = {
 export type UseActiveLog = {
 	activeLog: ILog | null;
 	onSetActiveLog: (log: ILog) => void;
+	onViewLogDetails: (log: ILog) => void;
 	onClearActiveLog: () => void;
+	onClearLogDetails: () => void;
+	onAddToQuery: (
+		fieldKey: string,
+		fieldValue: string,
+		operator: string,
+		isJSON?: boolean,
+		dataType?: DataTypes,
+	) => void;
+};
+
+export type UseDetailedLogView = {
+	activeLog: ILog | null;
+	onClearLogDetails: () => void;
 	onAddToQuery: (
 		fieldKey: string,
 		fieldValue: string,

--- a/frontend/src/hooks/logs/useActiveLog.ts
+++ b/frontend/src/hooks/logs/useActiveLog.ts
@@ -12,7 +12,7 @@ import { useQueryClient } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { AppState } from 'store/reducers';
-import { SET_DETAILED_LOG_DATA } from 'types/actions/logs';
+import { SET_ACTIVE_LOG_DATA, SET_DETAILED_LOG_DATA } from 'types/actions/logs';
 import { ILog } from 'types/api/logs/log';
 import {
 	BaseAutocompleteData,
@@ -49,6 +49,30 @@ export const useActiveLog = (): UseActiveLog => {
 		},
 		[dispatch],
 	);
+
+	const onSetActiveLogData = useCallback(
+		(logData: ILog) => {
+			dispatch({
+				type: SET_ACTIVE_LOG_DATA,
+				payload: logData,
+			});
+		},
+		[dispatch],
+	);
+
+	const onViewLogDetails = useCallback(
+		(nextActiveLog: ILog): void => {
+			onSetActiveLogData(nextActiveLog);
+		},
+		[onSetActiveLogData],
+	);
+
+	const onClearLogDetails = useCallback((): void => {
+		dispatch({
+			type: SET_ACTIVE_LOG_DATA,
+			payload: null,
+		});
+	}, [dispatch]);
 
 	const onSetActiveLog = useCallback(
 		(nextActiveLog: ILog): void => {
@@ -144,6 +168,8 @@ export const useActiveLog = (): UseActiveLog => {
 		activeLog,
 		onSetActiveLog,
 		onClearActiveLog,
+		onViewLogDetails,
+		onClearLogDetails,
 		onAddToQuery: isLogsPage ? onAddToQueryLogs : onAddToQueryExplorer,
 	};
 };

--- a/frontend/src/hooks/logs/useDetailedLogView.ts
+++ b/frontend/src/hooks/logs/useDetailedLogView.ts
@@ -1,0 +1,20 @@
+import { useSelector } from 'react-redux';
+import { AppState } from 'store/reducers';
+import ILogsReducer from 'types/reducer/logs';
+
+import { UseDetailedLogView } from './types';
+import { useActiveLog } from './useActiveLog';
+
+export const useDetailedLogView = (): UseDetailedLogView => {
+	const { onClearLogDetails, onAddToQuery } = useActiveLog();
+
+	const { activeLog } = useSelector<AppState, ILogsReducer>(
+		(state) => state.logs,
+	);
+
+	return {
+		onClearLogDetails,
+		onAddToQuery,
+		activeLog,
+	};
+};

--- a/frontend/src/store/reducers/logs.ts
+++ b/frontend/src/store/reducers/logs.ts
@@ -9,6 +9,7 @@ import {
 	LogsActions,
 	PUSH_LIVE_TAIL_EVENT,
 	RESET_ID_START_AND_END,
+	SET_ACTIVE_LOG_DATA,
 	SET_DETAILED_LOG_DATA,
 	SET_FIELDS,
 	SET_LINES_PER_ROW,
@@ -51,6 +52,7 @@ const initialState: ILogsReducer = {
 	liveTailStartRange: 15,
 	selectedLogId: null,
 	detailedLog: null,
+	activeLog: null,
 	order:
 		(new URLSearchParams(window.location.search).get(
 			'order',
@@ -191,6 +193,13 @@ export const LogsReducer = (
 			return {
 				...state,
 				detailedLog: action.payload,
+			};
+		}
+
+		case SET_ACTIVE_LOG_DATA: {
+			return {
+				...state,
+				activeLog: action.payload,
 			};
 		}
 

--- a/frontend/src/types/actions/logs.ts
+++ b/frontend/src/types/actions/logs.ts
@@ -26,6 +26,7 @@ export const SET_LOADING = 'LOGS_SET_LOADING';
 export const SET_LOADING_AGGREGATE = 'LOGS_SET_LOADING_AGGREGATE';
 export const SET_LOGS_AGGREGATE_SERIES = 'LOGS_SET_LOGS_AGGREGATE_SERIES';
 export const SET_DETAILED_LOG_DATA = 'LOGS_SET_DETAILED_LOG_DATA';
+export const SET_ACTIVE_LOG_DATA = 'LOGS_SET_ACTIVE_LOG_DATA';
 export const TOGGLE_LIVE_TAIL = 'LOGS_TOGGLE_LIVE_TAIL';
 export const PUSH_LIVE_TAIL_EVENT = 'LOGS_PUSH_LIVE_TAIL_EVENT';
 export const STOP_LIVE_TAIL = 'LOGS_STOP_LIVE_TAIL';
@@ -105,6 +106,11 @@ export interface SetDetailedLogData {
 	payload: ILog | null;
 }
 
+export interface SetActiveLogData {
+	type: typeof SET_ACTIVE_LOG_DATA;
+	payload: ILog | null;
+}
+
 export interface ToggleLiveTail {
 	type: typeof TOGGLE_LIVE_TAIL;
 	payload: TLogsLiveTailState;
@@ -164,6 +170,7 @@ export type LogsActions =
 	| SetLoadingAggregate
 	| SetLogsAggregateSeries
 	| SetDetailedLogData
+	| SetActiveLogData
 	| ToggleLiveTail
 	| PushLiveTailEvent
 	| StopLiveTail

--- a/frontend/src/types/reducer/logs.ts
+++ b/frontend/src/types/reducer/logs.ts
@@ -24,6 +24,7 @@ export interface ILogsReducer {
 	logsAggregate: ILogsAggregate[];
 	selectedLogId: string | null;
 	detailedLog: null | ILog;
+	activeLog: null | ILog;
 	liveTail: TLogsLiveTailState;
 	liveTailStartRange: number; // time in minutes
 	order: OrderPreferenceItems;


### PR DESCRIPTION
Hi SigNoz team, 

The reported bug was due to non persistence of activeLog state in the useActiveLog hook when the new logs are rendered. 

Initial Try:
My first implementation to overcome the issue was to store and retrieve the data using redux state management. So I tried implementing redux hooks in the LiveLogList component. The LiveLogList is rendered for each of the log, so when the "View Details" button is clicked the state is retrieved and "LogDetail" for that particular log is rendered without any background as shown in the below picture. I realised this should be due to the targeted re-rendering by redux. 

![Screenshot from 2023-12-13 23-28-38](https://github.com/SigNoz/signoz/assets/64725924/feed6087-2f54-4611-9010-05c10ad94734)

Final Solution: 
From the initial try the evident solution was to move the LogDetail component one level upwards. The LogDetail component was used in the following components:

1. LiveLogsList ----> rendered when "go Live" button is clicked. 
2. LogsExplorereList -----> this is the new logs explorer page. 
3. LogsTable -----> this is part of the old logs explorer. 

I moved the LogDetail component to the above three components and used a custom hook I created to implement the LogDetail Component. You could see in all the above three components only addition would be a hook and the LogDetail component. 

To create the custom hook and apropriate types I've made changes to actions, reducers, and types as required. This solution works flawlessly in live mode be it in the old or new logs explorer. It is shown in the demo video attached below. 
As the new logs come every 10 seconds the ViewDetail modal does not disappear and remains intact. Please take a look. 

[Screencast from 18-12-23 09:31:59 AM IST.webm](https://github.com/SigNoz/signoz/assets/64725924/88fee228-c1a1-4cf8-bced-9cecea06b284)

I hope this helps the team. 

Fix https://github.com/SigNoz/signoz/issues/3821