### PR TITLE
fix(FE): Update the Docker standalone upgrade instructions URL

### DIFF
--- a/frontend/src/container/Version/index.tsx
+++ b/frontend/src/container/Version/index.tsx
@@ -94,7 +94,7 @@ function Version(): JSX.Element {
 
 			{!isError && !isLatestVersion && (
 				<Button
-					href="https://signoz.io/docs/operate/docker-standalone/#upgrade"
+					href="https://signoz.io/docs/operate/docker-standalone/#upgrade-signoz-cluster"
 					target="_blank"
 				>
 					{t('read_how_to_upgrade')}


### PR DESCRIPTION
### Summary

The link to upgrade the standalone Docker does not directly scroll to the linked section as the ID of that section has changed. This PR fixes it by using the correct URL.

#### Related Issues / PR's

N/A

#### Screenshots

![image](https://github.com/SigNoz/signoz/assets/15127115/a9b5dc05-6561-411f-a55f-5e431879085a)

#### Affected Areas and Manually Tested Areas

N/A
