### PR TITLE
fix: [GH-3585]: operator suggestion should work on the substring typed in by the user

### DIFF
--- a/frontend/src/hooks/queryBuilder/useOptions.ts
+++ b/frontend/src/hooks/queryBuilder/useOptions.ts
@@ -82,7 +82,6 @@ export const useOptions = (
 		(key: string) => {
 			const partialOperator = key.split(' ')[1];
 			const partialKey = key.split(' ')[0];
-			console.log(partialOperator);
 			const filteredOperators = operators?.filter((operator) =>
 				operator.startsWith(partialOperator?.toUpperCase()),
 			);

--- a/frontend/src/hooks/queryBuilder/useOptions.ts
+++ b/frontend/src/hooks/queryBuilder/useOptions.ts
@@ -80,8 +80,9 @@ export const useOptions = (
 
 	const getKeyOperatorOptions = useCallback(
 		(key: string) => {
-			const partialOperator = key.split(' ')[1];
-			const partialKey = key.split(' ')[0];
+			const keyOperator = key.split(' ');
+			const partialOperator = keyOperator?.[1];
+			const partialKey = keyOperator?.[0];
 			const filteredOperators = operators?.filter((operator) =>
 				operator.startsWith(partialOperator?.toUpperCase()),
 			);

--- a/frontend/src/hooks/queryBuilder/useOptions.ts
+++ b/frontend/src/hooks/queryBuilder/useOptions.ts
@@ -80,9 +80,15 @@ export const useOptions = (
 
 	const getKeyOperatorOptions = useCallback(
 		(key: string) => {
-			const operatorsOptions = operators?.map((operator) => ({
-				value: `${key} ${operator} `,
-				label: `${key} ${operator} `,
+			const partialOperator = key.split(' ')[1];
+			const partialKey = key.split(' ')[0];
+			console.log(partialOperator);
+			const filteredOperators = operators?.filter((operator) =>
+				operator.startsWith(partialOperator?.toUpperCase()),
+			);
+			const operatorsOptions = filteredOperators?.map((operator) => ({
+				value: `${partialKey} ${operator} `,
+				label: `${partialKey} ${operator} `,
 			}));
 			if (whereClauseConfig) {
 				return [


### PR DESCRIPTION
### Summary

- the operator suggestion should be smart to suggest only operators which have a substring match 

#### Related Issues / PR's

This fixes :- #3585

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/87035282-3281-4355-89c4-6dd43cf4d649



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
