### PR TITLE
FE: Log Detail View: Support for dots in log attributes

### DIFF
--- a/frontend/src/container/LogDetailedView/TableView.tsx
+++ b/frontend/src/container/LogDetailedView/TableView.tsx
@@ -22,8 +22,8 @@ import { ILog } from 'types/api/logs/log';
 import ActionItem, { ActionItemProps } from './ActionItem';
 import FieldRenderer from './FieldRenderer';
 import {
+	filterKeyForField,
 	flattenObject,
-	getFieldAttributes,
 	jsonToDataNodes,
 	recursiveParseJSON,
 	removeEscapeCharacters,
@@ -99,17 +99,12 @@ function TableView({
 			title: 'Action',
 			width: 11,
 			render: (fieldData: Record<string, string>): JSX.Element | null => {
-				// Extract field key to be used. Must work for all 3 types of cases below
-				// timestamp -> timestamp
-				// attributes_string.log.file -> log.file
-				// resources_string.k8s.pod.name -> k8s.pod.name
-				const fieldKey =
-					getFieldAttributes(fieldData.field)?.newField || fieldData.field;
+				const fieldFilterKey = filterKeyForField(fieldData.field);
 
-				if (!RESTRICTED_FIELDS.includes(fieldKey)) {
+				if (!RESTRICTED_FIELDS.includes(fieldFilterKey)) {
 					return (
 						<ActionItem
-							fieldKey={fieldKey}
+							fieldKey={fieldFilterKey}
 							fieldValue={fieldData.value}
 							onClickActionItem={onClickActionItem}
 						/>
@@ -126,7 +121,6 @@ function TableView({
 			align: 'left',
 			ellipsis: true,
 			render: (field: string, record): JSX.Element => {
-				const fieldKey = field.split('.').slice(-1);
 				const renderedField = <FieldRenderer field={field} />;
 
 				if (record.field === 'trace_id') {
@@ -155,10 +149,11 @@ function TableView({
 					);
 				}
 
-				if (!RESTRICTED_FIELDS.includes(fieldKey[0])) {
+				const fieldFilterKey = filterKeyForField(field);
+				if (!RESTRICTED_FIELDS.includes(fieldFilterKey)) {
 					return (
 						<AddToQueryHOC
-							fieldKey={fieldKey[0]}
+							fieldKey={fieldFilterKey}
 							fieldValue={flattenLogData[field]}
 							onAddToQuery={onAddToQuery}
 						>

--- a/frontend/src/container/LogDetailedView/TableView.tsx
+++ b/frontend/src/container/LogDetailedView/TableView.tsx
@@ -23,6 +23,7 @@ import ActionItem, { ActionItemProps } from './ActionItem';
 import FieldRenderer from './FieldRenderer';
 import {
 	flattenObject,
+	getFieldAttributes,
 	jsonToDataNodes,
 	recursiveParseJSON,
 	removeEscapeCharacters,
@@ -98,11 +99,17 @@ function TableView({
 			title: 'Action',
 			width: 11,
 			render: (fieldData: Record<string, string>): JSX.Element | null => {
-				const fieldKey = fieldData.field.split('.').slice(-1);
-				if (!RESTRICTED_FIELDS.includes(fieldKey[0])) {
+				// Extract field key to be used. Must work for all 3 types of cases below
+				// timestamp -> timestamp
+				// attributes_string.log.file -> log.file
+				// resources_string.k8s.pod.name -> k8s.pod.name
+				const fieldKey =
+					getFieldAttributes(fieldData.field)?.newField || fieldData.field;
+
+				if (!RESTRICTED_FIELDS.includes(fieldKey)) {
 					return (
 						<ActionItem
-							fieldKey={fieldKey[0]}
+							fieldKey={fieldKey}
 							fieldValue={fieldData.value}
 							onClickActionItem={onClickActionItem}
 						/>

--- a/frontend/src/container/LogDetailedView/utils.tsx
+++ b/frontend/src/container/LogDetailedView/utils.tsx
@@ -136,6 +136,9 @@ export const removeObjectFromString = (str: string): string =>
 // For example, will return `['a', 'b.c']` when splitting `'a.b.c'` at dots
 const splitOnce = (str: string, delimiter: string): string[] => {
 	const parts = str.split(delimiter);
+	if (parts.length < 2) {
+		return parts;
+	}
 	return [parts[0], parts.slice(1).join(delimiter)];
 };
 

--- a/frontend/src/container/LogDetailedView/utils.tsx
+++ b/frontend/src/container/LogDetailedView/utils.tsx
@@ -162,6 +162,18 @@ export const getFieldAttributes = (field: string): IFieldAttributes => {
 	return { dataType, newField, logType };
 };
 
+// Returns key to be used when filtering for `field` via
+// the query builder. This is useful for powering filtering
+// by field values from log details view.
+export const filterKeyForField = (field: string): string => {
+	// Must work for all 3 of the following types of cases
+	// timestamp -> timestamp
+	// attributes_string.log.file -> log.file
+	// resources_string.k8s.pod.name -> k8s.pod.name
+	const fieldAttribs = getFieldAttributes(field);
+	return fieldAttribs?.newField || field;
+};
+
 export const aggregateAttributesResourcesToString = (logData: ILog): string => {
 	const outputJson: ILogAggregateAttributesResources = {
 		body: logData.body,

--- a/frontend/src/container/LogDetailedView/utils.tsx
+++ b/frontend/src/container/LogDetailedView/utils.tsx
@@ -132,6 +132,13 @@ export const generateFieldKeyForArray = (
 export const removeObjectFromString = (str: string): string =>
 	str.replace(/\[object Object\]./g, '');
 
+// Split `str` on the first occurrence of `delimiter`
+// For example, will return `['a', 'b.c']` when splitting `'a.b.c'` at dots
+const splitOnce = (str: string, delimiter: string): string[] => {
+	const parts = str.split(delimiter);
+	return [parts[0], parts.slice(1).join(delimiter)];
+};
+
 export const getFieldAttributes = (field: string): IFieldAttributes => {
 	let dataType;
 	let newField;
@@ -140,12 +147,12 @@ export const getFieldAttributes = (field: string): IFieldAttributes => {
 	if (field.startsWith('attributes_')) {
 		logType = MetricsType.Tag;
 		const stringWithoutPrefix = field.slice('attributes_'.length);
-		const parts = stringWithoutPrefix.split('.');
+		const parts = splitOnce(stringWithoutPrefix, '.');
 		[dataType, newField] = parts;
 	} else if (field.startsWith('resources_')) {
 		logType = MetricsType.Resource;
 		const stringWithoutPrefix = field.slice('resources_'.length);
-		const parts = stringWithoutPrefix.split('.');
+		const parts = splitOnce(stringWithoutPrefix, '.');
 		[dataType, newField] = parts;
 	}
 


### PR DESCRIPTION
### Summary

The log detail view doesn't display fields containing dot in their name correctly.
It is also not possible to filter by such fields from the log detail view.

#### Related Issues / PR's
Fixes https://github.com/SigNoz/signoz/issues/3681

#### Screenshots
Display of fields containing dot in name
Before:
![Screenshot from 2023-12-19 10-35-31](https://github.com/SigNoz/signoz/assets/1133322/aff808e9-8b94-4a18-ba8a-d662d87d05de)

After:
![Screenshot from 2023-12-19 10-32-30](https://github.com/SigNoz/signoz/assets/1133322/0708f704-4c56-45ba-968f-05af4d509faf)


Filtering by field containing dot by clicking on field name
Before:
![dot-support-in-click-to-filter-log-details-before](https://github.com/SigNoz/signoz/assets/1133322/db46713c-c5d7-4b41-b8ba-56491ab8923a)

After:
![dot-support-in-click-to-filter-log-details-after](https://github.com/SigNoz/signoz/assets/1133322/ba276b33-c5eb-44fa-86f9-091aae85b1e1)



Filtering by field containing dot in name from action menu
Before:
![dot-support-in-filter-from-log-details-before](https://github.com/SigNoz/signoz/assets/1133322/06b62e77-125f-47c5-83bf-a9be1ef1d0a2)

After:
![dot-support-in-filter-from-log-details-after](https://github.com/SigNoz/signoz/assets/1133322/97eefbfa-e7e9-4e5e-9da7-91fbd273e4ac)


#### Affected Areas and Manually Tested Areas

Log detail view. Tested manually