### PR TITLE
feat[i18n]: add ide-extension

### DIFF
--- a/project.inlang/settings.json
+++ b/project.inlang/settings.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://inlang.com/schema/project-settings",
+    "sourceLanguageTag": "en",
+    "languageTags": [
+      "en", "en-GB"
+    ],
+    "modules": [
+      "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-empty-pattern@latest/dist/index.js",
+      "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-identical-pattern@latest/dist/index.js",
+      "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-missing-translation@latest/dist/index.js",
+      "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-without-source@latest/dist/index.js",
+      "https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@4/dist/index.js"
+    ],
+    "plugin.inlang.i18next": {
+      "pathPattern": {
+        "alerts": "./frontend/public/locales/{languageTag}/alerts.json",
+        "channels": "./frontend/public/locales/{languageTag}/channels.json",
+        "common": "./frontend/public/locales/{languageTag}/common.json",
+        "dashboard": "./frontend/public/locales/{languageTag}/dashboard.json",
+        "errorDetails": "./frontend/public/locales/{languageTag}/errorDetails.json",
+        "explorer": "./frontend/public/locales/{languageTag}/explorer.json",
+        "generalSettings": "./frontend/public/locales/{languageTag}/generalSettings.json",
+        "licenses": "./frontend/public/locales/{languageTag}/licenses.json",
+        "login": "./frontend/public/locales/{languageTag}/login.json",
+        "logs": "./frontend/public/locales/{languageTag}/logs.json",
+        "organixationsettings": "./frontend/public/locales/{languageTag}/organixationsettings.json",
+        "pipeline": "./frontend/public/locales/{languageTag}/pipeline.json",
+        "routes": "./frontend/public/locales/{languageTag}/routes.json",
+        "rules": "./frontend/public/locales/{languageTag}/rules.json",
+        "settings": "./frontend/public/locales/{languageTag}/settings.json",
+        "signup": "./frontend/public/locales/{languageTag}/signup.json",
+        "titles": "./frontend/public/locales/{languageTag}/titles.json",
+        "trace": "./frontend/public/locales/{languageTag}/trace.json",
+        "traceDetails": "./frontend/public/locales/{languageTag}/traceDetails.json",
+        "translation": "./frontend/public/locales/{languageTag}/translation.json",
+        "valueGraph": "./frontend/public/locales/{languageTag}/valueGraph.json"
+      }
+    }
+}
+  


### PR DESCRIPTION
> let me know what needs to be changed in order to merge this

# Description: DX upgrade with little i18n tool.
- I added a [ide-extension](https://inlang.com/m/r7kp499g/app-inlang-ideExtension) config to `SigNoz`. This enables developers and contributors to extract, access and update translations in code using the existing json files under the hood. 

- **Opt-in:** With the config in place you can also use the [fink editor](https://inlang.com/m/tdozzpar/app-inlang-editor) to update product copy/translation with a no code UI. Here u see an example from my fork: https://inlang.com/editor/github.com/NilsJacobsen/signoz

# What I added (opt-in)
- A config file -> `settings.json`

## Screenshots:
IDE-Extension:
![image](https://github.com/SigNoz/signoz/assets/58360188/e760919e-e9de-41c8-a8a0-ff1f25fd4328)
![image](https://github.com/SigNoz/signoz/assets/58360188/9ad5c8a5-7701-4729-8f82-9185142a4a9f)

Editor:
<img width="1424" alt="image" src="https://github.com/SigNoz/signoz/assets/58360188/97c64638-e99b-4c31-a98f-4ae527a135ba">