### PR TITLE
feat: gh-4211: show copy and share invite link message next to pendin…

### DIFF
--- a/frontend/public/locales/en-GB/organizationsettings.json
+++ b/frontend/public/locales/en-GB/organizationsettings.json
@@ -14,5 +14,6 @@
 	"delete_domain_message": "Are you sure you want to delete this domain?",
 	"delete_domain": "Delete Domain",
 	"add_domain": "Add Domains",
-	"saml_settings":"Your SAML settings have been saved, please login from incognito window to confirm that it has been set up correctly"
+	"saml_settings": "Your SAML settings have been saved, please login from incognito window to confirm that it has been set up correctly",
+	"invite_link_share_manually": "After inviting members, please copy the invite link and send them the link manually"
 }

--- a/frontend/public/locales/en/organizationsettings.json
+++ b/frontend/public/locales/en/organizationsettings.json
@@ -14,5 +14,6 @@
 	"delete_domain_message": "Are you sure you want to delete this domain?",
 	"delete_domain": "Delete Domain",
 	"add_domain": "Add Domains",
-	"saml_settings":"Your SAML settings have been saved, please login from incognito window to confirm that it has been set up correctly"
+	"saml_settings": "Your SAML settings have been saved, please login from incognito window to confirm that it has been set up correctly",
+	"invite_link_share_manually": "After inviting members, please copy the invite link and send them the link manually"
 }

--- a/frontend/src/container/LogsExplorerViews/index.tsx
+++ b/frontend/src/container/LogsExplorerViews/index.tsx
@@ -147,13 +147,13 @@ function LogsExplorerViews(): JSX.Element {
 		[currentQuery, updateAllQueriesOperators],
 	);
 
-	const listChartData = useGetExplorerQueryRange(
-		listChartQuery,
-		PANEL_TYPES.TIME_SERIES,
-		{
-			enabled: !!listChartQuery && panelType === PANEL_TYPES.LIST,
-		},
-	);
+	const {
+		data: listChartData,
+		isFetching: isFetchingListChartData,
+		isLoading: isLoadingListChartData,
+	} = useGetExplorerQueryRange(listChartQuery, PANEL_TYPES.TIME_SERIES, {
+		enabled: !!listChartQuery && panelType === PANEL_TYPES.LIST,
+	});
 
 	const { data, isFetching, isError } = useGetExplorerQueryRange(
 		requestData,
@@ -445,12 +445,8 @@ function LogsExplorerViews(): JSX.Element {
 		if (!stagedQuery) return [];
 
 		if (panelType === PANEL_TYPES.LIST) {
-			if (
-				listChartData &&
-				listChartData.data &&
-				listChartData.data.payload.data.result.length > 0
-			) {
-				return listChartData.data.payload.data.result;
+			if (listChartData && listChartData.payload.data.result.length > 0) {
+				return listChartData.payload.data.result;
 			}
 			return [];
 		}
@@ -472,7 +468,10 @@ function LogsExplorerViews(): JSX.Element {
 
 	return (
 		<>
-			<LogsExplorerChart isLoading={isFetching} data={chartData} />
+			<LogsExplorerChart
+				isLoading={isFetchingListChartData || isLoadingListChartData}
+				data={chartData}
+			/>
 			{stagedQuery && (
 				<ActionsWrapper>
 					<ExportPanel

--- a/frontend/src/container/OrganizationSettings/PendingInvitesContainer/index.tsx
+++ b/frontend/src/container/OrganizationSettings/PendingInvitesContainer/index.tsx
@@ -271,15 +271,21 @@ function PendingInvitesContainer(): JSX.Element {
 			<Space direction="vertical" size="middle">
 				<TitleWrapper>
 					<Typography.Title level={3}>{t('pending_invites')}</Typography.Title>
-					<Button
-						icon={<PlusOutlined />}
-						type="primary"
-						onClick={(): void => {
-							toggleModal(true);
-						}}
-					>
-						{t('invite_members')}
-					</Button>
+
+					<Space>
+						<Typography.Text type="warning">
+							{t('invite_link_share_manually')}
+						</Typography.Text>
+						<Button
+							icon={<PlusOutlined />}
+							type="primary"
+							onClick={(): void => {
+								toggleModal(true);
+							}}
+						>
+							{t('invite_members')}
+						</Button>
+					</Space>
 				</TitleWrapper>
 				<ResizeTable
 					columns={columns}


### PR DESCRIPTION
…g invites

### Summary

1. show copy and share invite link message next to pending invites
2. Fix Histogram shows no data instead of loader

#### Related Issues / PR's

Closes
#4211 
engineering-pod/issues/1150

#### Screenshots
![Screenshot 2023-12-20 144728](https://github.com/SigNoz/signoz/assets/3520897/3f9f9fb1-b65c-42f0-b9e9-d301351cfb46)


#### Affected Areas and Manually Tested Areas
Invite team members
Logs Explorer

