### PR TITLE
fix: not saving fill-gaps toggle value

### DIFF
--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -178,6 +178,7 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 						yAxisUnit,
 						panelTypes: graphType,
 						thresholds,
+						fillSpans: isFillSpans,
 					},
 					...afterWidgets,
 				],


### PR DESCRIPTION
### Summary

This PR fixes the issue that not saving the `Fill gaps` toggle.

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

#4280
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas
Seems we have not included the flag in API call i.e mutation.
<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
