### PR TITLE
fix: selected logs background to follow theme

### DIFF
--- a/frontend/src/utils/logs.ts
+++ b/frontend/src/utils/logs.ts
@@ -1,4 +1,4 @@
-import { orange } from '@ant-design/colors';
+import { grey } from '@ant-design/colors';
 import { themeColors } from 'constants/theme';
 import getAlphaColor from 'utils/getAlphaColor';
 
@@ -18,5 +18,5 @@ export const getDefaultLogBackground = (
 
 export const getActiveLogBackground = (isActiveLog = true): string => {
 	if (!isActiveLog) return '';
-	return `background-color: ${orange[3]};`;
+	return `background-color: ${grey[5]};`;
 };


### PR DESCRIPTION
Hi, the issue was fixed by changing the colour from orange to a shade of grey. Below is the screencast of the background change, please have a look. 

Fix https://github.com/SigNoz/signoz/issues/3997

 
[Screencast from 03-01-24 11:02:43 AM IST.webm](https://github.com/SigNoz/signoz/assets/64725924/626b6b90-0dd8-4ca1-bf8e-c8122a20b8ce)


