### PR TITLE
feat: preserve the sorting searching and pagination in dashboard page

### DIFF
--- a/frontend/src/components/ResizeTable/DynamicColumnTable.tsx
+++ b/frontend/src/components/ResizeTable/DynamicColumnTable.tsx
@@ -43,7 +43,7 @@ function DynamicColumnTable({
 				: undefined,
 		);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [columns]);
+	}, [columns, dynamicColumns]);
 
 	const onToggleHandler = (index: number) => (
 		checked: boolean,

--- a/frontend/src/container/ListOfDashboard/utils.ts
+++ b/frontend/src/container/ListOfDashboard/utils.ts
@@ -1,14 +1,16 @@
+import { Dashboard } from 'types/api/dashboard/getAll';
+
 export const filterDashboard = (
 	searchValue: string,
-	dashboardList: any,
+	dashboardList: Dashboard[],
 ): any[] => {
 	// Convert the searchValue to lowercase for case-insensitive search
 	const searchValueLowerCase = searchValue.toLowerCase();
 
 	// Use the filter method to find matching objects
-	return dashboardList.filter((item: any) => {
+	return dashboardList.filter((item: Dashboard) => {
 		// Convert each property value to lowercase for case-insensitive search
-		const itemValues = Object.values(item?.data).map((value: any) =>
+		const itemValues = Object.values(item?.data).map((value) =>
 			value.toString().toLowerCase(),
 		);
 

--- a/frontend/src/container/ListOfDashboard/utils.ts
+++ b/frontend/src/container/ListOfDashboard/utils.ts
@@ -1,0 +1,18 @@
+export const filterDashboard = (
+	searchValue: string,
+	dashboardList: any,
+): any[] => {
+	// Convert the searchValue to lowercase for case-insensitive search
+	const searchValueLowerCase = searchValue.toLowerCase();
+
+	// Use the filter method to find matching objects
+	return dashboardList.filter((item: any) => {
+		// Convert each property value to lowercase for case-insensitive search
+		const itemValues = Object.values(item?.data).map((value: any) =>
+			value.toString().toLowerCase(),
+		);
+
+		// Check if any property value contains the searchValue
+		return itemValues.some((value) => value.includes(searchValueLowerCase));
+	});
+};


### PR DESCRIPTION
### Summary
#3938 

before 
https://www.loom.com/share/728ec188880043919e795f03049fc8a8?sid=75cea3c5-4b43-4245-b0c7-79a15410e977

after
https://www.loom.com/share/6cef88de183445ebb4f7ae9fc3b83a6d

#### Affected Areas and Manually Tested Areas
I'm checking the alerts page, service page, and exception page table

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
