### PR TITLE
refactor: updated height for date selector

### DIFF
--- a/frontend/src/container/TopNav/DateTimeSelection/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelection/index.tsx
@@ -295,6 +295,7 @@ function DateTimeSelection({
 						style={{
 							minWidth: 120,
 						}}
+						listHeight={400}
 					>
 						{options.map(({ value, label }) => (
 							<Option key={value + label} value={value}>


### PR DESCRIPTION
Fixes: https://github.com/SigNoz/signoz/issues/4330

After: 

<img width="248" alt="Screenshot 2024-01-04 at 6 35 10 PM" src="https://github.com/SigNoz/signoz/assets/26198062/83003c16-eabb-4a91-934f-5de254b1fa3c">
