### PR TITLE
feat: [SIG-505]: Integrate the new generic toolbar and date time selection according to the new designs

### DIFF
--- a/frontend/src/container/QueryBuilder/components/ToolbarActions/LeftToolbarActions.tsx
+++ b/frontend/src/container/QueryBuilder/components/ToolbarActions/LeftToolbarActions.tsx
@@ -1,0 +1,58 @@
+import './ToolbarActions.styles.scss';
+
+import { Button, Switch, Typography } from 'antd';
+import { Atom, MousePointerSquare, Terminal } from 'lucide-react';
+
+interface LeftToolbarActionsProps {
+	selectedView: string;
+	onToggleHistrogramVisibility: () => void;
+	showHistogram: boolean;
+}
+
+export default function LeftToolbarActions({
+	selectedView,
+	onToggleHistrogramVisibility,
+	showHistogram,
+}: LeftToolbarActionsProps): JSX.Element {
+	return (
+		<div className="left-toolbar">
+			<div className="left-toolbar-query-actions">
+				<Button
+					value="search"
+					// eslint-disable-next-line sonarjs/no-duplicate-string
+					className={
+						// eslint-disable-next-line sonarjs/no-duplicate-string
+						selectedView === 'search' ? 'active-tab action-btn' : 'action-btn'
+					}
+				>
+					<MousePointerSquare size={14} />
+				</Button>
+				<Button
+					value="query-builder"
+					className={
+						selectedView === 'query-builder' ? 'active-tab action-btn' : 'action-btn'
+					}
+				>
+					<Atom size={14} />
+				</Button>
+				<Button
+					value="clickhouse"
+					className={
+						selectedView === 'clickhouse' ? 'active-tab action-btn' : 'action-btn'
+					}
+				>
+					<Terminal size={14} />
+				</Button>
+			</div>
+			<div className="histogram-view-controller">
+				<Typography>Histogram</Typography>
+				<Switch
+					size="small"
+					checked={showHistogram}
+					defaultChecked
+					onChange={onToggleHistrogramVisibility}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/container/QueryBuilder/components/ToolbarActions/RightToolbarActions.tsx
+++ b/frontend/src/container/QueryBuilder/components/ToolbarActions/RightToolbarActions.tsx
@@ -1,0 +1,14 @@
+import './ToolbarActions.styles.scss';
+
+import { Button } from 'antd';
+import { Play } from 'lucide-react';
+
+export default function RightToolbarActions(): JSX.Element {
+	return (
+		<div>
+			<Button type="primary" className="right-toolbar" icon={<Play size={14} />}>
+				Stage & Run Query
+			</Button>
+		</div>
+	);
+}

--- a/frontend/src/container/QueryBuilder/components/ToolbarActions/ToolbarActions.styles.scss
+++ b/frontend/src/container/QueryBuilder/components/ToolbarActions/ToolbarActions.styles.scss
@@ -1,0 +1,40 @@
+.left-toolbar {
+	display: flex;
+	align-items: center;
+
+	.left-toolbar-query-actions {
+		display: flex;
+		border-radius: 2px;
+		border: 1px solid var(--Slate-400, #1d212d);
+		background: var(--Ink-300, #16181d);
+		box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.1);
+		flex-direction: row;
+
+		.ant-btn {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			border: none;
+			padding: 9px;
+
+			&.active-tab {
+				background-color: #1d212d;
+			}
+		}
+		.action-btn + .action-btn {
+			border-left: 1px solid var(--Slate-400, #1d212d);
+		}
+	}
+
+	.histogram-view-controller {
+		display: flex;
+		align-items: center;
+		padding-left: 8px;
+		gap: 8px;
+	}
+}
+
+.right-toolbar {
+	display: flex;
+	align-items: center;
+}

--- a/frontend/src/container/Toolbar/Toolbar.styles.scss
+++ b/frontend/src/container/Toolbar/Toolbar.styles.scss
@@ -1,80 +1,11 @@
 .toolbar {
+	display: grid;
+	grid-template-columns: 3fr auto auto;
 	padding: 8px 16px;
-	display: flex;
-	gap: 8px;
-	justify-content: space-between;
-	align-items: center;
-	border: 1px solid #1d212d;
-	border-left: none;
-	border-right: none;
 
-	.left-options {
+	.timeRange {
 		display: flex;
-		gap: 12px;
-		flex-direction: row;
+		padding-right: 8px;
 		align-items: center;
-
-		.query-builder-view-options {
-			display: flex;
-
-			.views-tabs {
-				display: flex;
-
-				border-radius: 2px;
-				border: 1px solid var(--Slate-400, #1d212d);
-				background: var(--Ink-400, #121317);
-				box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.1);
-
-				.ant-btn {
-					display: flex;
-					align-items: center;
-					justify-content: center;
-					border-radius: 0px;
-					padding: 8px 12px;
-
-					border: 1px solid var(--Slate-400, #1d212d);
-					background: var(--Ink-400, #121317);
-
-					&.active-tab {
-						background-color: #1d212d;
-					}
-				}
-			}
-		}
-
-		.histogram-view-controller {
-			display: flex;
-			align-items: center;
-			gap: 8px;
-		}
-	}
-
-	.right-options {
-		display: flex;
-		gap: 12px;
-		flex-direction: row;
-		align-items: center;
-
-		.date-picker-container {
-			display: flex;
-			align-items: center;
-			gap: 8px;
-		}
-
-		.stage-run-query-container {
-			button {
-				display: flex;
-				align-items: center;
-				padding: 8px;
-
-				color: var(--Vanilla-100, #fff);
-				text-align: center;
-				font-family: Inter;
-				font-size: 12px;
-				font-style: normal;
-				font-weight: 500;
-				line-height: 18px;
-			}
-		}
 	}
 }

--- a/frontend/src/container/Toolbar/Toolbar.tsx
+++ b/frontend/src/container/Toolbar/Toolbar.tsx
@@ -1,112 +1,29 @@
 import './Toolbar.styles.scss';
 
-import { Button, Select, Switch, Typography } from 'antd';
-import { Atom, MousePointerSquare, Play, Terminal } from 'lucide-react';
+import DateTimeSelectionV2 from 'container/TopNav/DateTimeSelectionV2';
 
 interface ToolbarProps {
-	selectedView: string;
-	showHistogram: boolean;
-	onToggleHistrogramVisibility: () => void;
+	leftActions?: JSX.Element;
+	rightActions?: JSX.Element;
 }
 
 export default function Toolbar({
-	selectedView,
-	showHistogram,
-	onToggleHistrogramVisibility,
+	leftActions,
+	rightActions,
 }: ToolbarProps): JSX.Element {
-	const onChange = (value: string): void => {
-		console.log(`selected ${value}`);
-	};
-
-	const onSearch = (value: string): void => {
-		console.log('search:', value);
-	};
-
-	console.log(selectedView, showHistogram);
-
-	// Filter `option.label` match the user type `input`
-	const filterOption = (
-		input: string,
-		option?: { label: string; value: string },
-	): any => (option?.label ?? '').toLowerCase().includes(input.toLowerCase());
-
+	console.log(leftActions, rightActions);
 	return (
 		<div className="toolbar">
-			<div className="left-options">
-				<div className="query-builder-view-options">
-					<div
-						className="views-tabs"
-						// onChange={handleModeChange}
-					>
-						<Button
-							value="search"
-							// eslint-disable-next-line sonarjs/no-duplicate-string
-							className={selectedView === 'search' ? 'active-tab' : ''}
-						>
-							<MousePointerSquare size={14} />
-						</Button>
-						<Button
-							value="query-builder"
-							className={selectedView === 'query-builder' ? 'active-tab' : ''}
-						>
-							<Atom size={14} />
-						</Button>
-						<Button
-							value="clickhouse"
-							className={selectedView === 'clickhouse' ? 'active-tab' : ''}
-						>
-							<Terminal size={14} />
-						</Button>
-					</div>
-				</div>
-
-				<div className="histogram-view-controller">
-					<Typography>Histogram</Typography>
-					<Switch
-						size="small"
-						defaultChecked
-						onChange={onToggleHistrogramVisibility}
-					/>
-				</div>
+			<div className="leftActions">{leftActions}</div>
+			<div className="timeRange">
+				<DateTimeSelectionV2 />
 			</div>
-
-			<div className="right-options">
-				<div className="date-picker-container">
-					<div className="refresh-time">Refreshed 10 min ago</div>
-
-					<Select
-						showSearch
-						style={{
-							width: '160px',
-						}}
-						placeholder="Live"
-						optionFilterProp="children"
-						onChange={onChange}
-						onSearch={onSearch}
-						filterOption={filterOption}
-						options={[
-							{
-								value: 'jack',
-								label: 'Jack',
-							},
-							{
-								value: 'lucy',
-								label: 'Lucy',
-							},
-							{
-								value: 'tom',
-								label: 'Tom',
-							},
-						]}
-					/>
-				</div>
-
-				<div className="stage-run-query-container">
-					<Button type="primary" icon={<Play size={14} />}>
-						Stage & Run Query
-					</Button>
-				</div>
-			</div>
+			<div className="rightActions">{rightActions}</div>
 		</div>
 	);
 }
+
+Toolbar.defaultProps = {
+	leftActions: <div />,
+	rightActions: <div />,
+};

--- a/frontend/src/container/TopNav/AutoRefresh/index.tsx
+++ b/frontend/src/container/TopNav/AutoRefresh/index.tsx
@@ -31,7 +31,10 @@ import { popupContainer } from 'utils/selectPopupContainer';
 import { getMinMax, options } from './config';
 import { ButtonContainer, Container } from './styles';
 
-function AutoRefresh({ disabled = false }: AutoRefreshProps): JSX.Element {
+function AutoRefresh({
+	disabled = false,
+	showAutoRefreshBtnPrimary = true,
+}: AutoRefreshProps): JSX.Element {
 	const globalTime = useSelector<AppState, GlobalReducer>(
 		(state) => state.globalTime,
 	);
@@ -176,7 +179,10 @@ function AutoRefresh({ disabled = false }: AutoRefreshProps): JSX.Element {
 				</Container>
 			}
 		>
-			<ButtonContainer title="Set auto refresh" type="primary">
+			<ButtonContainer
+				title="Set auto refresh"
+				type={showAutoRefreshBtnPrimary ? 'primary' : 'default'}
+			>
 				<CaretDownFilled />
 			</ButtonContainer>
 		</Popover>
@@ -185,10 +191,12 @@ function AutoRefresh({ disabled = false }: AutoRefreshProps): JSX.Element {
 
 interface AutoRefreshProps {
 	disabled?: boolean;
+	showAutoRefreshBtnPrimary?: boolean;
 }
 
 AutoRefresh.defaultProps = {
 	disabled: false,
+	showAutoRefreshBtnPrimary: true,
 };
 
 export default AutoRefresh;

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/DateTimeSelectionV2.styles.scss
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/DateTimeSelectionV2.styles.scss
@@ -1,0 +1,137 @@
+.date-time-root {
+	.ant-popover-inner {
+		width: 532px;
+		min-height: 326px;
+		border-radius: 4px !important;
+		border: 1px solid var(--Slate-400, #1d212d);
+		box-shadow: 4px 10px 16px 2px rgba(0, 0, 0, 0.2) !important;
+		padding: 0px !important;
+		border-radius: 4px;
+		background: linear-gradient(
+			139deg,
+			rgba(18, 19, 23, 0.8) 0%,
+			rgba(18, 19, 23, 0.9) 98.68%
+		) !important;
+		backdrop-filter: blur(20px);
+	}
+}
+
+.date-time-popover {
+	display: flex;
+
+	.date-time-options {
+		display: flex;
+		width: 224px;
+		flex-direction: column;
+		border-right: 1px solid #1d212d;
+
+		.data-time-live {
+			border-bottom: 1px solid #1d212d;
+			text-align: start;
+			padding: 13.5px 14px;
+			height: 44px;
+			color: var(--Vanilla-400, #c0c1c3);
+			font-size: 14px;
+			font-style: normal;
+			font-weight: 400;
+			line-height: normal;
+			letter-spacing: 0.14px;
+			border-bottom: 1px solid var(--Slate-400, #1d212d);
+		}
+
+		.date-time-options-btn {
+			text-align: start;
+			padding: 8px 13px;
+			height: 33px;
+			color: var(--Vanilla-400, #c0c1c3);
+			font-size: 14px;
+			font-style: normal;
+			font-weight: 400;
+			line-height: normal;
+			letter-spacing: 0.14px;
+		}
+	}
+
+	.relative-date-time {
+		width: 307px;
+		display: flex;
+		flex-direction: column;
+		gap: 26px;
+		padding: 13px 14px;
+
+		.relative-date-time-section {
+			display: flex;
+			gap: 6px;
+			flex-flow: wrap;
+		}
+		.time-heading {
+			text-align: left;
+			color: var(--Slate-200, #52575c);
+			font-size: 11px;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 18px;
+			letter-spacing: 0.88px;
+			padding-bottom: 8px;
+		}
+
+		.time-btns {
+			background-color: #23262e;
+			font-size: 14px;
+			line-height: 17px;
+			letter-spacing: 0.04em;
+			text-align: left;
+			border-radius: 2px;
+		}
+	}
+}
+
+.date-time-input-element {
+	border-radius: 2px;
+	border: 1px solid var(--Slate-400, #1d212d);
+	background: var(--Ink-300, #16181d);
+	display: flex;
+	min-width: 192px;
+	height: 32px;
+	padding: 6px 6px 6px 8px;
+	flex-shrink: 0;
+	text-align: start;
+	margin-right: 8px;
+	justify-content: space-between;
+	align-items: center;
+
+	.date-time-input-content {
+		display: flex;
+		align-items: center;
+	}
+	.time-btn {
+		margin-right: 8px;
+	}
+	.down-arrow {
+		margin-left: 6px;
+	}
+}
+
+.refresh-actions {
+	display: flex;
+	flex-direction: row;
+	border-radius: 2px;
+	border: 1px solid var(--Slate-400, #1d212d);
+	background: var(--Ink-300, #16181d);
+	box-shadow: 0px 0px 8px 0px rgba(0, 0, 0, 0.1);
+
+	.refresh-btn {
+		border-right: 1px solid var(--Slate-400, #1d212d);
+	}
+	.ant-btn {
+		display: flex;
+		padding: 4px 8px;
+		justify-content: center;
+		align-items: center;
+		border: none;
+
+		&.active-tab {
+			background-color: #1d212d;
+		}
+	}
+}

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/Refresh.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/Refresh.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+import { RefreshTextContainer, Typography } from './styles';
+
+function RefreshText({
+	onLastRefreshHandler,
+	refreshButtonHidden,
+}: RefreshTextProps): JSX.Element {
+	const [refreshText, setRefreshText] = useState<string>('');
+
+	// this is to update the refresh text
+	useEffect(() => {
+		const interval = setInterval(() => {
+			const text = onLastRefreshHandler();
+			if (refreshText !== text) {
+				setRefreshText(text);
+			}
+		}, 2000);
+		return (): void => {
+			clearInterval(interval);
+		};
+	}, [onLastRefreshHandler, refreshText]);
+
+	return (
+		<RefreshTextContainer refreshButtonHidden={refreshButtonHidden}>
+			<Typography>{refreshText}</Typography>
+		</RefreshTextContainer>
+	);
+}
+
+interface RefreshTextProps {
+	onLastRefreshHandler: () => string;
+	refreshButtonHidden: boolean;
+}
+
+export default RefreshText;

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/config.ts
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/config.ts
@@ -1,0 +1,126 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import ROUTES from 'constants/routes';
+
+type FiveMin = '5min';
+type TenMin = '10min';
+type FifteenMin = '15min';
+type ThirtyMin = '30min';
+type FortyFiveMin = '45min';
+type OneMin = '1min';
+type SixHour = '6hr';
+type OneHour = '1hr';
+type FourHour = '4hr';
+type TwelveHour = '12hr';
+type OneDay = '1day';
+type ThreeDay = '3days';
+type TenDay = '10days';
+type OneWeek = '1week';
+type TwoWeek = '2weeks';
+type TwoMonths = '2months';
+type Custom = 'custom';
+
+export type Time =
+	| FiveMin
+	| TenMin
+	| FifteenMin
+	| ThirtyMin
+	| OneMin
+	| FourHour
+	| SixHour
+	| OneHour
+	| Custom
+	| OneWeek
+	| OneDay
+	| ThreeDay
+	| FortyFiveMin
+	| TwelveHour
+	| TenDay
+	| TwoWeek
+	| TwoMonths;
+
+export const Options: Option[] = [
+	{ value: '5min', label: 'Last 5 minutes' },
+	{ value: '15min', label: 'Last 15 minutes' },
+	{ value: '30min', label: 'Last 30 minutes' },
+	{ value: '1hr', label: 'Last 1 hour' },
+	{ value: '6hr', label: 'Last 6 hours' },
+	{ value: '1day', label: 'Last 1 day' },
+	{ value: '3days', label: 'Last 3 days' },
+	{ value: '1week', label: 'Last 1 week' },
+	{ value: 'custom', label: 'Custom...' },
+];
+
+export interface Option {
+	value: Time;
+	label: string;
+}
+
+export const RelativeDurationOptions: Option[] = [
+	{ value: '5min', label: 'Last 5 minutes' },
+	{ value: '15min', label: 'Last 15 minutes' },
+	{ value: '30min', label: 'Last 30 minutes' },
+	{ value: '1hr', label: 'Last 1 hour' },
+	{ value: '6hr', label: 'Last 6 hour' },
+	{ value: '1day', label: 'Last 1 day' },
+	{ value: '3days', label: 'Last 3 days' },
+	{ value: '1week', label: 'Last 1 week' },
+];
+
+export const RelativeDurationSuggestionOptions: Option[] = [
+	{ value: '45min', label: '45m' },
+	{ value: '12hr', label: '12 hours' },
+	{ value: '10days', label: '10d' },
+	{ value: '2weeks', label: '2 weeks' },
+	{ value: '2months', label: 'Last 2 months' },
+	{ value: '1day', label: 'today' },
+];
+export const FixedDurationSuggestionOptions: Option[] = [
+	{ value: '45min', label: '45m' },
+	{ value: '12hr', label: '12 hours' },
+	{ value: '10days', label: '10d' },
+	{ value: '2weeks', label: '2 weeks' },
+	{ value: '2months', label: 'Last 2 months' },
+	{ value: '1day', label: 'today' },
+];
+
+export const getDefaultOption = (route: string): Time => {
+	if (route === ROUTES.SERVICE_MAP) {
+		return RelativeDurationOptions[2].value;
+	}
+	if (route === ROUTES.APPLICATION) {
+		return Options[2].value;
+	}
+	return Options[2].value;
+};
+
+export const getOptions = (routes: string): Option[] => {
+	if (routes === ROUTES.SERVICE_MAP) {
+		return RelativeDurationOptions;
+	}
+	return Options;
+};
+
+export const routesToHideBreadCrumbs = [ROUTES.SUPPORT, ROUTES.ALL_DASHBOARD];
+
+export const routesToSkip = [
+	ROUTES.SETTINGS,
+	ROUTES.LIST_ALL_ALERT,
+	ROUTES.TRACE_DETAIL,
+	ROUTES.ALL_CHANNELS,
+	ROUTES.USAGE_EXPLORER,
+	ROUTES.GET_STARTED,
+	ROUTES.VERSION,
+	ROUTES.ALL_DASHBOARD,
+	ROUTES.ORG_SETTINGS,
+	ROUTES.INGESTION_SETTINGS,
+	ROUTES.ERROR_DETAIL,
+	ROUTES.LOGS_PIPELINES,
+	ROUTES.BILLING,
+	ROUTES.SUPPORT,
+	ROUTES.WORKSPACE_LOCKED,
+	ROUTES.LOGS,
+	ROUTES.MY_SETTINGS,
+	ROUTES.LIST_LICENSES,
+];
+
+export const routesToDisable = [ROUTES.LOGS_EXPLORER, ROUTES.LIVE_LOGS];

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -1,0 +1,474 @@
+import './DateTimeSelectionV2.styles.scss';
+
+import { SyncOutlined } from '@ant-design/icons';
+import { Button, Popover } from 'antd';
+import getLocalStorageKey from 'api/browser/localstorage/get';
+import setLocalStorageKey from 'api/browser/localstorage/set';
+import { LOCALSTORAGE } from 'constants/localStorage';
+import { QueryParams } from 'constants/query';
+import {
+	initialQueryBuilderFormValuesMap,
+	PANEL_TYPES,
+} from 'constants/queryBuilder';
+import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
+import ROUTES from 'constants/routes';
+import {
+	constructCompositeQuery,
+	defaultLiveQueryDataConfig,
+} from 'container/LiveLogs/constants';
+import { QueryHistoryState } from 'container/LiveLogs/types';
+import dayjs, { Dayjs } from 'dayjs';
+import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
+import { updateStepInterval } from 'hooks/queryBuilder/useStepInterval';
+import useUrlQuery from 'hooks/useUrlQuery';
+import GetMinMax from 'lib/getMinMax';
+import getTimeString from 'lib/getTimeString';
+import history from 'lib/history';
+import { ChevronDown, ChevronUp, Clock4 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQueryClient } from 'react-query';
+import { connect, useSelector } from 'react-redux';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { bindActionCreators, Dispatch } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { GlobalTimeLoading, UpdateTimeInterval } from 'store/actions';
+import { AppState } from 'store/reducers';
+import AppActions from 'types/actions';
+import { ErrorResponse, SuccessResponse } from 'types/api';
+import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { GlobalReducer } from 'types/reducer/globalTime';
+
+import AutoRefresh from '../AutoRefresh';
+import CustomDateTimeModal, { DateTimeRangeType } from '../CustomDateTimeModal';
+import {
+	FixedDurationSuggestionOptions,
+	getDefaultOption,
+	getOptions,
+	Option,
+	RelativeDurationSuggestionOptions,
+	Time,
+} from './config';
+import RefreshText from './Refresh';
+import { Form, FormContainer, FormItem } from './styles';
+
+function DateTimeSelection({
+	location,
+	updateTimeInterval,
+	globalTimeLoading,
+}: Props): JSX.Element {
+	const [formSelector] = Form.useForm();
+
+	const [isOpen, setIsOpen] = useState<boolean>(false);
+	const urlQuery = useUrlQuery();
+	const searchStartTime = urlQuery.get('startTime');
+	const searchEndTime = urlQuery.get('endTime');
+	const queryClient = useQueryClient();
+
+	const localstorageStartTime = getLocalStorageKey('startTime');
+	const localstorageEndTime = getLocalStorageKey('endTime');
+
+	const getTime = useCallback((): [number, number] | undefined => {
+		if (searchEndTime && searchStartTime) {
+			const startDate = dayjs(
+				new Date(parseInt(getTimeString(searchStartTime), 10)),
+			);
+			const endDate = dayjs(new Date(parseInt(getTimeString(searchEndTime), 10)));
+
+			return [startDate.toDate().getTime() || 0, endDate.toDate().getTime() || 0];
+		}
+		if (localstorageStartTime && localstorageEndTime) {
+			const startDate = dayjs(localstorageStartTime);
+			const endDate = dayjs(localstorageEndTime);
+
+			return [startDate.toDate().getTime() || 0, endDate.toDate().getTime() || 0];
+		}
+		return undefined;
+	}, [
+		localstorageEndTime,
+		localstorageStartTime,
+		searchEndTime,
+		searchStartTime,
+	]);
+
+	const [options, setOptions] = useState(getOptions(location.pathname));
+	const [refreshButtonHidden, setRefreshButtonHidden] = useState<boolean>(false);
+	const [customDateTimeVisible, setCustomDTPickerVisible] = useState<boolean>(
+		false,
+	);
+
+	const { stagedQuery, initQueryBuilderData, panelType } = useQueryBuilder();
+
+	const handleGoLive = useCallback(() => {
+		if (!stagedQuery) return;
+
+		let queryHistoryState: QueryHistoryState | null = null;
+
+		const compositeQuery = constructCompositeQuery({
+			query: stagedQuery,
+			initialQueryData: initialQueryBuilderFormValuesMap.logs,
+			customQueryData: defaultLiveQueryDataConfig,
+		});
+
+		const isListView =
+			panelType === PANEL_TYPES.LIST && stagedQuery.builder.queryData[0];
+
+		if (isListView) {
+			const [graphQuery, listQuery] = queryClient.getQueriesData<
+				SuccessResponse<MetricRangePayloadProps> | ErrorResponse
+			>({
+				queryKey: REACT_QUERY_KEY.GET_QUERY_RANGE,
+				active: true,
+			});
+
+			queryHistoryState = {
+				graphQueryPayload:
+					graphQuery && graphQuery[1]
+						? graphQuery[1].payload?.data.result || []
+						: [],
+				listQueryPayload:
+					listQuery && listQuery[1]
+						? listQuery[1].payload?.data.newResult.data.result || []
+						: [],
+			};
+		}
+
+		const JSONCompositeQuery = encodeURIComponent(JSON.stringify(compositeQuery));
+
+		const path = `${ROUTES.LIVE_LOGS}?${QueryParams.compositeQuery}=${JSONCompositeQuery}`;
+
+		history.push(path, queryHistoryState);
+	}, [panelType, queryClient, stagedQuery]);
+
+	const { maxTime, minTime, selectedTime } = useSelector<
+		AppState,
+		GlobalReducer
+	>((state) => state.globalTime);
+
+	const getInputLabel = (
+		startTime?: Dayjs,
+		endTime?: Dayjs,
+		timeInterval: Time = '15min',
+	): string | Time => {
+		if (startTime && endTime && timeInterval === 'custom') {
+			const format = 'YYYY/MM/DD HH:mm';
+
+			const startString = startTime.format(format);
+			const endString = endTime.format(format);
+
+			return `${startString} - ${endString}`;
+		}
+
+		return timeInterval;
+	};
+
+	useEffect(() => {
+		if (selectedTime === 'custom') {
+			setRefreshButtonHidden(true);
+		} else {
+			setRefreshButtonHidden(false);
+		}
+	}, [selectedTime]);
+
+	const getDefaultTime = (pathName: string): Time => {
+		const defaultSelectedOption = getDefaultOption(pathName);
+
+		const routes = getLocalStorageKey(LOCALSTORAGE.METRICS_TIME_IN_DURATION);
+
+		if (routes !== null) {
+			const routesObject = JSON.parse(routes || '{}');
+			const selectedTime = routesObject[pathName];
+
+			if (selectedTime) {
+				return selectedTime;
+			}
+		}
+
+		return defaultSelectedOption;
+	};
+
+	const updateLocalStorageForRoutes = (value: Time): void => {
+		const preRoutes = getLocalStorageKey(LOCALSTORAGE.METRICS_TIME_IN_DURATION);
+		if (preRoutes !== null) {
+			const preRoutesObject = JSON.parse(preRoutes);
+
+			const preRoute = {
+				...preRoutesObject,
+			};
+			preRoute[location.pathname] = value;
+
+			setLocalStorageKey(
+				LOCALSTORAGE.METRICS_TIME_IN_DURATION,
+				JSON.stringify(preRoute),
+			);
+		}
+	};
+
+	const onLastRefreshHandler = useCallback(() => {
+		const currentTime = dayjs();
+
+		const lastRefresh = dayjs(
+			selectedTime === 'custom' ? minTime / 1000000 : maxTime / 1000000,
+		);
+
+		const secondsDiff = currentTime.diff(lastRefresh, 'seconds');
+
+		const minutedDiff = currentTime.diff(lastRefresh, 'minutes');
+		const hoursDiff = currentTime.diff(lastRefresh, 'hours');
+		const daysDiff = currentTime.diff(lastRefresh, 'days');
+		const monthsDiff = currentTime.diff(lastRefresh, 'months');
+
+		if (monthsDiff > 0) {
+			return `Refreshed -${monthsDiff} months ago`;
+		}
+
+		if (daysDiff > 0) {
+			return `Refreshed - ${daysDiff} days ago`;
+		}
+
+		if (hoursDiff > 0) {
+			return `Refreshed - ${hoursDiff} hrs ago`;
+		}
+
+		if (minutedDiff > 0) {
+			return `Refreshed - ${minutedDiff} mins ago`;
+		}
+
+		return `Refreshed - ${secondsDiff} sec ago`;
+	}, [maxTime, minTime, selectedTime]);
+
+	const isLogsExplorerPage = useMemo(
+		() => location.pathname === ROUTES.LOGS_EXPLORER,
+		[location.pathname],
+	);
+
+	const onSelectHandler = (value: Time): void => {
+		if (value !== 'custom') {
+			updateTimeInterval(value);
+			updateLocalStorageForRoutes(value);
+			if (refreshButtonHidden) {
+				setRefreshButtonHidden(false);
+			}
+		} else {
+			setRefreshButtonHidden(true);
+			setCustomDTPickerVisible(true);
+		}
+
+		const { maxTime, minTime } = GetMinMax(value, getTime());
+
+		if (!isLogsExplorerPage) {
+			urlQuery.set(QueryParams.startTime, minTime.toString());
+			urlQuery.set(QueryParams.endTime, maxTime.toString());
+			const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
+			history.replace(generatedUrl);
+		}
+
+		if (!stagedQuery) {
+			return;
+		}
+		initQueryBuilderData(updateStepInterval(stagedQuery, maxTime, minTime));
+	};
+
+	const onRefreshHandler = (): void => {
+		onSelectHandler(selectedTime);
+		onLastRefreshHandler();
+	};
+
+	const onCustomDateHandler = (dateTimeRange: DateTimeRangeType): void => {
+		if (dateTimeRange !== null) {
+			const [startTimeMoment, endTimeMoment] = dateTimeRange;
+			if (startTimeMoment && endTimeMoment) {
+				setCustomDTPickerVisible(false);
+				updateTimeInterval('custom', [
+					startTimeMoment?.toDate().getTime() || 0,
+					endTimeMoment?.toDate().getTime() || 0,
+				]);
+				setLocalStorageKey('startTime', startTimeMoment.toString());
+				setLocalStorageKey('endTime', endTimeMoment.toString());
+				updateLocalStorageForRoutes('custom');
+				if (!isLogsExplorerPage) {
+					urlQuery.set(QueryParams.startTime, startTimeMoment.toString());
+					urlQuery.set(QueryParams.endTime, endTimeMoment.toString());
+					const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
+					history.replace(generatedUrl);
+				}
+			}
+		}
+	};
+
+	// this is triggred when we change the routes and based on that we are changing the default options
+	useEffect(() => {
+		const metricsTimeDuration = getLocalStorageKey(
+			LOCALSTORAGE.METRICS_TIME_IN_DURATION,
+		);
+
+		if (metricsTimeDuration === null) {
+			setLocalStorageKey(
+				LOCALSTORAGE.METRICS_TIME_IN_DURATION,
+				JSON.stringify({}),
+			);
+		}
+
+		const currentRoute = location.pathname;
+		const time = getDefaultTime(currentRoute);
+
+		const currentOptions = getOptions(currentRoute);
+		setOptions(currentOptions);
+
+		const getCustomOrIntervalTime = (time: Time): Time => {
+			if (searchEndTime !== null && searchStartTime !== null) {
+				return 'custom';
+			}
+			if (
+				(localstorageEndTime === null || localstorageStartTime === null) &&
+				time === 'custom'
+			) {
+				return getDefaultOption(currentRoute);
+			}
+
+			return time;
+		};
+
+		const updatedTime = getCustomOrIntervalTime(time);
+
+		const [preStartTime = 0, preEndTime = 0] = getTime() || [];
+
+		setRefreshButtonHidden(updatedTime === 'custom');
+
+		updateTimeInterval(updatedTime, [preStartTime, preEndTime]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [location.pathname, updateTimeInterval, globalTimeLoading]);
+
+	function getTimeChips(options: Option[]): JSX.Element {
+		return (
+			<div className="relative-date-time-section">
+				{options.map((option) => (
+					<Button
+						type="text"
+						className="time-btns"
+						key={option.label + option.value}
+						onClick={(): void => {
+							onSelectHandler(option.value);
+						}}
+					>
+						{option.label}
+					</Button>
+				))}
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<RefreshText
+				{...{
+					onLastRefreshHandler,
+				}}
+				refreshButtonHidden={refreshButtonHidden}
+			/>
+			<Form
+				form={formSelector}
+				layout="inline"
+				initialValues={{ interval: selectedTime }}
+			>
+				<FormContainer>
+					<Popover
+						placement="bottomRight"
+						onOpenChange={setIsOpen}
+						rootClassName="date-time-root"
+						content={
+							<div className="date-time-popover">
+								<div className="date-time-options">
+									<Button className="data-time-live" type="text" onClick={handleGoLive}>
+										Live
+									</Button>
+									{options.map((option) => (
+										<Button
+											type="text"
+											key={option.label + option.value}
+											onClick={(): void => {
+												onSelectHandler(option.value);
+											}}
+											className="date-time-options-btn"
+										>
+											{option.label}
+										</Button>
+									))}
+								</div>
+								<div className="relative-date-time">
+									<div>
+										<div className="time-heading">RELATIVE TIMES</div>
+										<div>{getTimeChips(RelativeDurationSuggestionOptions)}</div>
+									</div>
+									<div>
+										<div className="time-heading">FIXED TIMES</div>
+										<div>{getTimeChips(FixedDurationSuggestionOptions)}</div>
+									</div>
+								</div>
+							</div>
+						}
+						data-testid="dropDown"
+						style={{
+							minWidth: 120,
+						}}
+					>
+						<Button className="date-time-input-element">
+							<div className="date-time-input-content">
+								<Clock4 size={14} className="time-btn" />
+								{getInputLabel(
+									dayjs(minTime / 1000000),
+									dayjs(maxTime / 1000000),
+									selectedTime,
+								)}
+							</div>
+							{isOpen ? (
+								<ChevronUp size={14} className="down-arrow" />
+							) : (
+								<ChevronDown size={14} className="down-arrow" />
+							)}
+						</Button>
+					</Popover>
+
+					<div className="refresh-actions">
+						<FormItem hidden={refreshButtonHidden} className="refresh-btn">
+							<Button icon={<SyncOutlined />} onClick={onRefreshHandler} />
+						</FormItem>
+
+						<FormItem>
+							<AutoRefresh
+								disabled={refreshButtonHidden}
+								showAutoRefreshBtnPrimary={false}
+							/>
+						</FormItem>
+					</div>
+				</FormContainer>
+			</Form>
+
+			<CustomDateTimeModal
+				visible={customDateTimeVisible}
+				onCreate={onCustomDateHandler}
+				onCancel={(): void => {
+					setCustomDTPickerVisible(false);
+				}}
+			/>
+		</>
+	);
+}
+
+interface DispatchProps {
+	updateTimeInterval: (
+		interval: Time,
+		dateTimeRange?: [number, number],
+	) => (dispatch: Dispatch<AppActions>) => void;
+	globalTimeLoading: () => void;
+}
+
+const mapDispatchToProps = (
+	dispatch: ThunkDispatch<unknown, unknown, AppActions>,
+): DispatchProps => ({
+	updateTimeInterval: bindActionCreators(UpdateTimeInterval, dispatch),
+	globalTimeLoading: bindActionCreators(GlobalTimeLoading, dispatch),
+});
+
+type Props = DispatchProps & RouteComponentProps;
+
+export default connect(null, mapDispatchToProps)(withRouter(DateTimeSelection));

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/styles.ts
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/styles.ts
@@ -1,0 +1,34 @@
+import { Form as FormComponent, Typography as TypographyComponent } from 'antd';
+import styled from 'styled-components';
+
+export const Form = styled(FormComponent)`
+	&&& {
+		justify-content: flex-end;
+	}
+`;
+
+export const Typography = styled(TypographyComponent)`
+	&&& {
+		text-align: right;
+	}
+`;
+
+export const FormItem = styled(Form.Item)`
+	&&& {
+		margin: 0;
+	}
+`;
+
+interface Props {
+	refreshButtonHidden: boolean;
+}
+
+export const RefreshTextContainer = styled.div<Props>`
+	padding-right: 8px;
+	visibility: ${({ refreshButtonHidden }): string =>
+		refreshButtonHidden ? 'hidden' : 'visible'};
+`;
+
+export const FormContainer = styled.div`
+	display: flex;
+`;

--- a/frontend/src/lib/getMinMax.ts
+++ b/frontend/src/lib/getMinMax.ts
@@ -1,10 +1,11 @@
 import { Time } from 'container/TopNav/DateTimeSelection/config';
+import { Time as TimeV2 } from 'container/TopNav/DateTimeSelectionV2/config';
 import { GlobalReducer } from 'types/reducer/globalTime';
 
 import getMinAgo from './getStartAndEndTime/getMinAgo';
 
 const GetMinMax = (
-	interval: Time,
+	interval: Time | TimeV2,
 	dateTimeRange?: [number, number],
 	// eslint-disable-next-line sonarjs/cognitive-complexity
 ): GetMinMaxPayload => {
@@ -26,6 +27,9 @@ const GetMinMax = (
 	} else if (interval === '30min') {
 		const minTimeAgo = getMinAgo({ minutes: 30 }).getTime();
 		minTime = minTimeAgo;
+	} else if (interval === '45min') {
+		const minTimeAgo = getMinAgo({ minutes: 45 }).getTime();
+		minTime = minTimeAgo;
 	} else if (interval === '5min') {
 		const minTimeAgo = getMinAgo({ minutes: 5 }).getTime();
 		minTime = minTimeAgo;
@@ -37,11 +41,23 @@ const GetMinMax = (
 		// three day = one day * 3
 		const minTimeAgo = getMinAgo({ minutes: 24 * 60 * 3 }).getTime();
 		minTime = minTimeAgo;
+	} else if (interval === '10days') {
+		// ten day = one day * 10
+		const minTimeAgo = getMinAgo({ minutes: 24 * 60 * 10 }).getTime();
+		minTime = minTimeAgo;
 	} else if (interval === '1week') {
 		// one week = one day * 7
 		const minTimeAgo = getMinAgo({ minutes: 24 * 60 * 7 }).getTime();
 		minTime = minTimeAgo;
-	} else if (['4hr', '6hr'].includes(interval)) {
+	} else if (interval === '2weeks') {
+		// two week = one day * 14
+		const minTimeAgo = getMinAgo({ minutes: 24 * 60 * 14 }).getTime();
+		minTime = minTimeAgo;
+	} else if (interval === '2months') {
+		// two months = one day * 60
+		const minTimeAgo = getMinAgo({ minutes: 24 * 60 * 60 }).getTime();
+		minTime = minTimeAgo;
+	} else if (['4hr', '6hr', '12hr'].includes(interval)) {
 		const h = parseInt(interval.replace('hr', ''), 10);
 		const minTimeAgo = getMinAgo({ minutes: h * 60 }).getTime();
 		minTime = minTimeAgo;

--- a/frontend/src/pages/LogsExplorer/index.tsx
+++ b/frontend/src/pages/LogsExplorer/index.tsx
@@ -2,7 +2,9 @@ import { Col, Row } from 'antd';
 import ExplorerCard from 'components/ExplorerCard/ExplorerCard';
 import LogExplorerQuerySection from 'container/LogExplorerQuerySection';
 import LogsExplorerViews from 'container/LogsExplorerViews';
-import LogsTopNav from 'container/LogsTopNav';
+// import LogsTopNav from 'container/LogsTopNav';
+import LeftToolbarActions from 'container/QueryBuilder/components/ToolbarActions/LeftToolbarActions';
+import RightToolbarActions from 'container/QueryBuilder/components/ToolbarActions/RightToolbarActions';
 import Toolbar from 'container/Toolbar/Toolbar';
 import ErrorBoundaryFallback from 'pages/ErrorBoundaryFallback/ErrorBoundaryFallback';
 import { useState } from 'react';
@@ -13,7 +15,7 @@ import { WrapperStyled } from './styles';
 
 function LogsExplorer(): JSX.Element {
 	const [showHistogram, setShowHistogram] = useState(true);
-	const [selectedView, setSelectedView] = useState('query-builder');
+	const [selectedView] = useState('query-builder');
 
 	const handleToggleShowHistogram = (): void => {
 		setShowHistogram(!showHistogram);
@@ -26,9 +28,14 @@ function LogsExplorer(): JSX.Element {
 			{/* <LogsTopNav /> */}
 
 			<Toolbar
-				showHistogram={showHistogram}
-				selectedView={selectedView}
-				onToggleHistrogramVisibility={handleToggleShowHistogram}
+				leftActions={
+					<LeftToolbarActions
+						selectedView={selectedView}
+						onToggleHistrogramVisibility={handleToggleShowHistogram}
+						showHistogram={showHistogram}
+					/>
+				}
+				rightActions={<RightToolbarActions />}
 			/>
 
 			<WrapperStyled>

--- a/frontend/src/store/actions/global.ts
+++ b/frontend/src/store/actions/global.ts
@@ -1,11 +1,12 @@
 import { Time } from 'container/TopNav/DateTimeSelection/config';
+import { Time as TimeV2 } from 'container/TopNav/DateTimeSelectionV2/config';
 import GetMinMax from 'lib/getMinMax';
 import { Dispatch } from 'redux';
 import AppActions from 'types/actions';
 import { UPDATE_TIME_INTERVAL } from 'types/actions/globalTime';
 
 export const UpdateTimeInterval = (
-	interval: Time,
+	interval: Time | TimeV2,
 	dateTimeRange: [number, number] = [0, 0],
 ): ((dispatch: Dispatch<AppActions>) => void) => (
 	dispatch: Dispatch<AppActions>,

--- a/frontend/src/types/actions/globalTime.ts
+++ b/frontend/src/types/actions/globalTime.ts
@@ -1,4 +1,5 @@
 import { Time } from 'container/TopNav/DateTimeSelection/config';
+import { Time as TimeV2 } from 'container/TopNav/DateTimeSelectionV2/config';
 
 import { ResetIdStartAndEnd, SetSearchQueryString } from './logs';
 
@@ -13,7 +14,7 @@ export type GlobalTime = {
 };
 
 interface UpdateTime extends GlobalTime {
-	selectedTime: Time;
+	selectedTime: Time | TimeV2;
 }
 
 interface UpdateTimeInterval {


### PR DESCRIPTION
### Summary

- Integrate the new generic toolbar according to the new designs
- added the consumption for the new logs explorer page
- Integrates the new `DateTimeSelectionV2` to the system

New Designs Link :- https://www.figma.com/file/L0vX330RkWn7ZpelMpkPHL/Logs?type=design&node-id=2266-7333&mode=design&t=92cnserOghwsv7X2-0

#### Related Issues / PR's

#SIG-505

#### Screenshots



<img width="1792" alt="Screenshot 2024-01-08 at 4 19 29 PM" src="https://github.com/SigNoz/signoz/assets/54737045/05ae844a-69ec-4cab-8834-b62f22375293">





#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
