### PR TITLE
fix: Logs UI: querybuildersearch: avoid emptying out query on sourceKeys update if tags are yet to be populated 

### DIFF
--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
@@ -150,6 +150,16 @@ function QueryBuilderSearch({
 			(item) => item.key as BaseAutocompleteData,
 		);
 
+		// Avoid updating query with onChange at the bottom of this useEffect
+		// if there are no `tags` that need to be normalized after receiving
+		// the latest `sourceKeys`.
+		//
+		// Executing the following logic for empty tags leads to emptying
+		// out of `query` via `onChange`.
+		// `tags` can contain stale empty value while being updated by `useTag`
+		// which maintains it as a state and updates it via useEffect when props change.
+		// This was observed when pipeline filters were becoming empty after
+		// returning from logs explorer.
 		if ((tags?.length || 0) < 1) {
 			return;
 		}

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
@@ -150,6 +150,10 @@ function QueryBuilderSearch({
 			(item) => item.key as BaseAutocompleteData,
 		);
 
+		if ((tags?.length || 0) < 1) {
+			return;
+		}
+
 		initialTagFilters.items = tags.map((tag, index) => {
 			const isJsonTrue = query.filters?.items[index]?.key?.isJSON;
 


### PR DESCRIPTION
### Summary

QueryBuilderSearch component is used for log pipeline filter inputs.

It uses tags generated by `useTags` to display filter tags in the input.

It also has a [useEffect](https://github.com/SigNoz/signoz/blob/develop/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx#L181) that runs when `sourceKeys` (available attributes) are updated.  This useEffect calls onChange with recalculated query filter from tags and latest `sourceKeys`

Changing the `query` prop [doesn't immediately update the tags generated by useTags](https://github.com/SigNoz/signoz/blob/develop/frontend/src/hooks/queryBuilder/useTag.ts#L109). So when the query prop changes from empty to the filter of the pipeline being edited, there is a period in between when tags are yet to be updated and are empty.  

When the pipeline filter input is opened after returning from logs explorer, the query prop gets updated from empty to the pipeline's filter value, but before tags are updated to a non-empty value derived from latest query prop, a `sourceKeys` update triggers the useEffect which calls onChange with an empty query since tags are empty and yet to be updated.
This causes the pipeline filter input to appear empty after returning from logs explorer. 

#### Related Issues / PR's

Fixes https://github.com/SigNoz/signoz/issues/3914

#### Screenshots

Before: 
![empty-pipeline-filter-on-returning-from-logs-explorer-before](https://github.com/SigNoz/signoz/assets/1133322/9e02f055-7f3a-4001-b882-c642106ac44a)

After:
![empty-pipeline-filter-on-returning-from-logs-explorer-after](https://github.com/SigNoz/signoz/assets/1133322/42c79261-30ed-4ba8-99fd-720fa7ccb68c)


#### Affected Areas and Manually Tested Areas

- query builders (explorers)
- live logs
- pipelines
