### PR TITLE
fix(frontend,serviceMap): dynamically truncate service map node label

### DIFF
--- a/frontend/src/modules/Servicemap/Map.tsx
+++ b/frontend/src/modules/Servicemap/Map.tsx
@@ -13,6 +13,8 @@ function ServiceMap({ fgRef, serviceMap }: any): JSX.Element {
 
 	const graphData = { nodes, links };
 
+	let zoomLevel = 1;
+
 	return (
 		<ForceGraph2D
 			ref={fgRef}
@@ -23,8 +25,9 @@ function ServiceMap({ fgRef, serviceMap }: any): JSX.Element {
 			linkDirectionalParticles="value"
 			linkDirectionalParticleSpeed={(d) => d.value}
 			nodeCanvasObject={(node, ctx) => {
-				const label = transformLabel(node.id);
-				const { fontSize } = node;
+				const label = transformLabel(node.id, zoomLevel);
+				let { fontSize } = node;
+				fontSize = (fontSize * 3) / zoomLevel;
 				ctx.font = `${fontSize}px Roboto`;
 				const { width } = node;
 
@@ -42,6 +45,9 @@ function ServiceMap({ fgRef, serviceMap }: any): JSX.Element {
 				if (tooltip && node) {
 					tooltip.innerHTML = getTooltip(node);
 				}
+			}}
+			onZoom={(zoom) => {
+				zoomLevel = zoom.k;
 			}}
 			nodePointerAreaPaint={(node, color, ctx) => {
 				ctx.fillStyle = color;

--- a/frontend/src/modules/Servicemap/utils.ts
+++ b/frontend/src/modules/Servicemap/utils.ts
@@ -59,6 +59,7 @@ export const getGraphData = (serviceMap, isDarkMode): graphDataType => {
 				width: MIN_WIDTH,
 				color,
 				nodeVal: MIN_WIDTH,
+				name: node,
 			};
 		}
 		if (service.errorRate > 0) {
@@ -72,6 +73,7 @@ export const getGraphData = (serviceMap, isDarkMode): graphDataType => {
 			width,
 			color,
 			nodeVal: width,
+			name: node,
 		};
 	});
 	return {
@@ -123,9 +125,9 @@ export const getTooltip = (link: {
 							</div>`;
 };
 
-export const transformLabel = (label: string) => {
-	const MAX_LENGTH = 13;
-	const MAX_SHOW = 10;
+export const transformLabel = (label: string, zoomLevel: number) => {
+	const MAX_LENGTH = 13 * (zoomLevel / 0.9);
+	const MAX_SHOW = MAX_LENGTH - 3;
 	if (label.length > MAX_LENGTH) {
 		return `${label.slice(0, MAX_SHOW)}...`;
 	}


### PR DESCRIPTION
### Summary

- Adjust the node name length dynamically in the service map based on the canvas zoom level.
- Enable displaying the complete node name without any truncation when hovering over a node in the service map. This feature proves beneficial when viewing all nodes on a zoomed-out canvas while needing quick access to full names, displayed in the tooltip.

#### Related Issues / PR's

Fixes #1666
Fixes #4318 (Partial)

#### Screenshots
Default view
![Default View](https://github.com/SigNoz/signoz/assets/8893755/198c4b10-1b61-4b20-8906-c49c111864e3)

Slight zoom in
![Zoomed In](https://github.com/SigNoz/signoz/assets/8893755/d517cd46-f66b-4b45-9d82-3c672de359b0)

Further zoom in
![More Zoomed In](https://github.com/SigNoz/signoz/assets/8893755/d67c9dc9-a7f8-4409-8d5d-aed72a3f2622)

Node hover display
![Hover Display](https://github.com/SigNoz/signoz/assets/8893755/7cb7f061-a961-416a-b8cb-8772333cb88b)

#### Affected Areas and Manually Tested Areas

- `Servicemap` module