### PR TITLE
chore: update onboarding docs to send logs from the end with a note f…

### DIFF
--- a/frontend/src/container/OnboardingContainer/Modules/LogsManagement/ApplicationLogs/applicationLogsFromLogFile.md
+++ b/frontend/src/container/OnboardingContainer/Modules/LogsManagement/ApplicationLogs/applicationLogsFromLogFile.md
@@ -9,11 +9,13 @@
     ...
     filelog/app:
       include: [ /tmp/app.log ]
-      start_at: beginning
+      start_at: end
   ...
   ```
 
-  `start_at: beginning` can be removed once you are done testing.
+  Replace `/tmp/app.log` with the path to your log file.
+
+  Note: change the `start_at` value to `beginning` if you want to read the log file from the beginning. It may be useful if you want to send old logs to SigNoz. The log records older than the standard log retention period (default 15 days) will be discarded.
 
   For parsing logs of different formats you will have to use operators, you can read more about operators [here](https://signoz.io/docs/userguide/logs/#operators-for-parsing-and-manipulating-logs).
 

--- a/frontend/src/container/OnboardingContainer/Modules/LogsManagement/ApplicationLogs/md-docs/LinuxAMD64/appplicationLogs-linuxamd64-configureReceiver.md
+++ b/frontend/src/container/OnboardingContainer/Modules/LogsManagement/ApplicationLogs/md-docs/LinuxAMD64/appplicationLogs-linuxamd64-configureReceiver.md
@@ -7,10 +7,12 @@ receivers:
   ...
   filelog/app:
     include: [ /tmp/app.log ]
-    start_at: beginning
+    start_at: end
 ...
 ```
 Replace `/tmp/app.log` with the path to your log file.
+
+Note: change the `start_at` value to `beginning` if you want to read the log file from the beginning. It may be useful if you want to send old logs to SigNoz. The log records older than the standard log retention period (default 15 days) will be discarded.
 
 For more configurations that are available for syslog receiver please check [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver).
 

--- a/frontend/src/container/OnboardingContainer/Modules/LogsManagement/ApplicationLogs/md-docs/LinuxARM64/appplicationLogs-linuxarm64-configureReceiver.md
+++ b/frontend/src/container/OnboardingContainer/Modules/LogsManagement/ApplicationLogs/md-docs/LinuxARM64/appplicationLogs-linuxarm64-configureReceiver.md
@@ -7,10 +7,12 @@ receivers:
   ...
   filelog/app:
     include: [ /tmp/app.log ]
-    start_at: beginning
+    start_at: end
 ...
 ```
 Replace `/tmp/app.log` with the path to your log file.
+
+Note: change the `start_at` value to `beginning` if you want to read the log file from the beginning. It may be useful if you want to send old logs to SigNoz. The log records older than the standard log retention period (default 15 days) will be discarded.
 
 For more configurations that are available for syslog receiver please check [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver).
 

--- a/frontend/src/container/OnboardingContainer/Modules/LogsManagement/ApplicationLogs/md-docs/MacOsAMD64/appplicationLogs-macosamd64-configureReceiver.md
+++ b/frontend/src/container/OnboardingContainer/Modules/LogsManagement/ApplicationLogs/md-docs/MacOsAMD64/appplicationLogs-macosamd64-configureReceiver.md
@@ -7,10 +7,12 @@ receivers:
   ...
   filelog/app:
     include: [ /tmp/app.log ]
-    start_at: beginning
+    start_at: end
 ...
 ```
 Replace `/tmp/app.log` with the path to your log file.
+
+Note: change the `start_at` value to `beginning` if you want to read the log file from the beginning. It may be useful if you want to send old logs to SigNoz. The log records older than the standard log retention period (default 15 days) will be discarded.
 
 For more configurations that are available for syslog receiver please check [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver).
 

--- a/frontend/src/container/OnboardingContainer/Modules/LogsManagement/ApplicationLogs/md-docs/MacOsARM64/appplicationLogs-macosarm64-configureReceiver.md
+++ b/frontend/src/container/OnboardingContainer/Modules/LogsManagement/ApplicationLogs/md-docs/MacOsARM64/appplicationLogs-macosarm64-configureReceiver.md
@@ -7,10 +7,12 @@ receivers:
   ...
   filelog/app:
     include: [ /tmp/app.log ]
-    start_at: beginning
+    start_at: end
 ...
 ```
 Replace `/tmp/app.log` with the path to your log file.
+
+Note: change the `start_at` value to `beginning` if you want to read the log file from the beginning. It may be useful if you want to send old logs to SigNoz. The log records older than the standard log retention period (default 15 days) will be discarded.
 
 For more configurations that are available for syslog receiver please check [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver).
 


### PR DESCRIPTION
…or about beginning

The start_at: beginning makes reading from the beginning, this leads to reading old logs which will neither be retained nor be ingested because of too many partition errors This commit makes the end as default setting and adds a note about beginning

Was there a strong reason why we chose beginning over end?

