### PR TITLE
fix: [GH-3932]: do not retry API's in case of 4XX status code

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -16,6 +16,15 @@ const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			refetchOnWindowFocus: false,
+			retry(failureCount, error): boolean {
+				if (
+					error instanceof Error &&
+					error.message.includes('API responded with 400')
+				) {
+					return false;
+				}
+				return failureCount < 2;
+			},
 		},
 	},
 });

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,6 +3,7 @@ import 'styles.scss';
 
 import * as Sentry from '@sentry/react';
 import AppRoutes from 'AppRoutes';
+import { AxiosError } from 'axios';
 import { ThemeProvider } from 'hooks/useDarkMode';
 import ErrorBoundaryFallback from 'pages/ErrorBoundaryFallback/ErrorBoundaryFallback';
 import { createRoot } from 'react-dom/client';
@@ -18,8 +19,10 @@ const queryClient = new QueryClient({
 			refetchOnWindowFocus: false,
 			retry(failureCount, error): boolean {
 				if (
-					error instanceof Error &&
-					error.message.includes('API responded with 400')
+					// in case of manually throwing errors please make sure to send error.response.status
+					error instanceof AxiosError &&
+					error.response?.status &&
+					(error.response?.status >= 400 || error.response?.status <= 499)
 				) {
 					return false;
 				}


### PR DESCRIPTION
### Summary

Three scenarios:- 

- The API has a `try` / `catch` block generally with `ErrorResponseHandler`, in that case, the API Error is not propagated to the `QueryClient` so the retries do not trigger, even if we pass `retry: true`, So no change here
- The second case is when we do not catch the error in the API getter, In that case, the error hits the QueryClient and the retry mechanism kicks in.
- The third case where we catch the API error and manually throw a different error which might / might not contain the API response status, so here as well the retry logic won't kick in,So while handling such cases when adding a new API we should add status code to such manually error handling.


#### Related Issues / PR's

#3932 

#### Screenshots



#### Affected Areas and Manually Tested Areas
