### PR TITLE
fix: virtuoso scroll refresh issue

### DIFF
--- a/frontend/src/container/LogsExplorerViews/index.tsx
+++ b/frontend/src/container/LogsExplorerViews/index.tsx
@@ -180,7 +180,7 @@ function LogsExplorerViews({
 		enabled: !!listChartQuery && panelType === PANEL_TYPES.LIST,
 	});
 
-	const { data, isFetching, isError } = useGetExplorerQueryRange(
+	const { data, isLoading, isError } = useGetExplorerQueryRange(
 		requestData,
 		panelType,
 		{
@@ -559,7 +559,7 @@ function LogsExplorerViews({
 				<div className="logs-explorer-views-type-content">
 					{selectedPanelType === PANEL_TYPES.LIST && (
 						<LogsExplorerList
-							isLoading={isFetching}
+							isLoading={isLoading}
 							currentStagedQueryData={listQuery}
 							logs={logs}
 							onEndReached={handleEndReached}
@@ -567,13 +567,13 @@ function LogsExplorerViews({
 					)}
 
 					{selectedPanelType === PANEL_TYPES.TIME_SERIES && (
-						<TimeSeriesView isLoading={isFetching} data={data} isError={isError} />
+						<TimeSeriesView isLoading={isLoading} data={data} isError={isError} />
 					)}
 
 					{selectedPanelType === PANEL_TYPES.TABLE && (
 						<LogsExplorerTable
 							data={data?.payload.data.newResult.data.result || []}
-							isLoading={isFetching}
+							isLoading={isLoading}
 						/>
 					)}
 				</div>


### PR DESCRIPTION
### Summary

- used `isLoading` instead of `isFetching` as it unmounts the component and resets the scroll position 
- Loading state should be present in for first load itself which is taken care by `isLoading` prop

> isLoading returns true when you're fetching data for the first time. On the other hand, isFetching will be true anytime there's an ongoing data fetching process, not just for the first time

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/d6091925-c405-43e3-8b50-3398a79c404a



#### Affected Areas and Manually Tested Areas

All the three views Raw / Default / Column View 
