### PR TITLE
feat: support case insensitive operators

### DIFF
--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/utils.ts
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/utils.ts
@@ -5,7 +5,7 @@ import { parse } from 'papaparse';
 import { orderByValueDelimiter } from '../OrderByFilter/utils';
 
 // eslint-disable-next-line no-useless-escape
-export const tagRegexp = /^\s*(.*?)\s*(IN|NOT_IN|LIKE|NOT_LIKE|REGEX|NOT_REGEX|=|!=|EXISTS|NOT_EXISTS|CONTAINS|NOT_CONTAINS|>=|>|<=|<|HAS|NHAS)\s*(.*)$/g;
+export const tagRegexp = /^\s*(.*?)\s*(\bIN\b|\bNOT_IN\b|\bLIKE\b|\bNOT_LIKE\b|\bREGEX\b|\bNOT_REGEX\b|=|!=|\bEXISTS\b|\bNOT_EXISTS\b|\bCONTAINS\b|\bNOT_CONTAINS\b|>=|>|<=|<|\bHAS\b|\bNHAS\b)\s*(.*)$/gi;
 
 export function isInNInOperator(value: string): boolean {
 	return value === OPERATORS.IN || value === OPERATORS.NIN;
@@ -25,8 +25,8 @@ export function getTagToken(tag: string): ITagToken {
 		const [, matchTagKey, matchTagOperator, matchTagValue] = match;
 		return {
 			tagKey: matchTagKey,
-			tagOperator: matchTagOperator,
-			tagValue: isInNInOperator(matchTagOperator)
+			tagOperator: matchTagOperator.toUpperCase(),
+			tagValue: isInNInOperator(matchTagOperator.toUpperCase())
 				? parse(matchTagValue).data.flat()
 				: matchTagValue,
 		} as ITagToken;


### PR DESCRIPTION
### Summary

- support case insensitive operations for query-builder
- updated the `tag-regex` to support the same 
- the symbolic operators would work without the `Space` delimiters but not the string operators

#### Related Issues / PR's
https://github.com/SigNoz/signoz/issues/3645


#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/4b991256-dcb6-4b47-a29b-f507577d2e0a



#### Affected Areas and Manually Tested Areas

- Across the application where the query builder is being used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved tag parsing in the query builder to ensure operator consistency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->