### PR TITLE
fix: trial banner moving to left screen and breaking trace detail page

### DIFF
--- a/frontend/src/container/AppLayout/styles.ts
+++ b/frontend/src/container/AppLayout/styles.ts
@@ -8,7 +8,7 @@ export const Layout = styled(LayoutComponent)`
 		min-height: calc(100vh - 8rem);
 		overflow: hidden;
 		height: 100%;
-		flex-direction: column;
+		flex-direction: column !important;
 	}
 `;
 

--- a/frontend/src/container/AppLayout/styles.ts
+++ b/frontend/src/container/AppLayout/styles.ts
@@ -8,6 +8,7 @@ export const Layout = styled(LayoutComponent)`
 		min-height: calc(100vh - 8rem);
 		overflow: hidden;
 		height: 100%;
+		flex-direction: column;
 	}
 `;
 


### PR DESCRIPTION
### Summary

- presence of `Sider` component inside the `Layout` component was enforcing `.antd` to add an extra class of `.ant-layout-has-sider` which made `flex-direction: row` hence page breaking, enforced the `flex-direction: column` at all places to avoid such scenarios

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/e5cc4d29-5bb4-4a4c-8aef-aff8e8def143



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
