### PR TITLE
fix: back btn navigation on first load

### DIFF
--- a/frontend/src/container/TopNav/DateTimeSelection/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelection/index.tsx
@@ -289,7 +289,6 @@ function DateTimeSelection({
 			urlQuery.set(QueryParams.endTime, preEndTime.toString());
 		}
 		const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
-		console.log(generatedUrl);
 		history.replace(generatedUrl);
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/container/TopNav/DateTimeSelection/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelection/index.tsx
@@ -279,6 +279,19 @@ function DateTimeSelection({
 		setRefreshButtonHidden(updatedTime === 'custom');
 
 		updateTimeInterval(updatedTime, [preStartTime, preEndTime]);
+
+		if (updatedTime !== 'custom') {
+			const { minTime, maxTime } = GetMinMax(updatedTime);
+			urlQuery.set(QueryParams.startTime, minTime.toString());
+			urlQuery.set(QueryParams.endTime, maxTime.toString());
+		} else {
+			urlQuery.set(QueryParams.startTime, preStartTime.toString());
+			urlQuery.set(QueryParams.endTime, preEndTime.toString());
+		}
+		const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
+		console.log(generatedUrl);
+		history.replace(generatedUrl);
+
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [location.pathname, updateTimeInterval, globalTimeLoading]);
 

--- a/frontend/src/store/actions/trace/getInitialFilter.ts
+++ b/frontend/src/store/actions/trace/getInitialFilter.ts
@@ -114,7 +114,8 @@ export const GetInitialTraceFilter = (
 
 		if (response.payload && !isSelectionSkipped.currentValue) {
 			const diff =
-				query.length === 0
+				query.replace(/(\?|&)startTime=\d+/, '').replace(/&endTime=\d+/, '')
+					.length === 0
 					? traces.filterToFetchData
 					: xor(traces.filterToFetchData, getFilterToFetchData.currentValue);
 

--- a/frontend/src/store/actions/trace/getInitialFilter.ts
+++ b/frontend/src/store/actions/trace/getInitialFilter.ts
@@ -25,6 +25,7 @@ import {
 	parseQueryIntoPageSize,
 	parseQueryIntoSelectedTags,
 	parseSelectedFilter,
+	stripTimestampsFromQuery,
 } from './util';
 
 export const GetInitialTraceFilter = (
@@ -113,9 +114,11 @@ export const GetInitialTraceFilter = (
 		);
 
 		if (response.payload && !isSelectionSkipped.currentValue) {
+			/**  this is required as now we have timestamps updated in date time selection component
+			 * 	 so for initial filters we need to strip timestamps and check for initial load
+			 */
 			const diff =
-				query.replace(/(\?|&)startTime=\d+/, '').replace(/&endTime=\d+/, '')
-					.length === 0
+				stripTimestampsFromQuery(query).length === 0
 					? traces.filterToFetchData
 					: xor(traces.filterToFetchData, getFilterToFetchData.currentValue);
 

--- a/frontend/src/store/actions/trace/util.ts
+++ b/frontend/src/store/actions/trace/util.ts
@@ -86,3 +86,6 @@ export const getFilter = (data: GetFilterPayload): TraceReducer['filter'] => {
 
 	return filter;
 };
+
+export const stripTimestampsFromQuery = (query: string): string =>
+	query.replace(/(\?|&)startTime=\d+/, '').replace(/&endTime=\d+/, '');


### PR DESCRIPTION
### Summary

- setting the URL on the load of the component with the updated time stamps helps in back navigation for all cases.
- for traces we check for query string being empty for initial load state but since now we have timestamps updated first we remove them while checking for initial load condition

#### Related Issues / PR's

#4325 

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/63704d58-fa78-49fd-b234-dea786b71848



#### Affected Areas and Manually Tested Areas

- services / traces page
- services to traces page navigation 
- other pages with time stamps and URL update is present
