### PR TITLE
fix: logs page crash when special chars present in the value of query

### DIFF
--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/utils.ts
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/utils.ts
@@ -122,8 +122,17 @@ export function replaceStringWithMaxLength(
 	if (lastSearchValue === '') {
 		return `${mainString}${replacementString},`;
 	}
+	/**
+	 * We need to escape the special characters in the lastSearchValue else the
+	 * new RegExp fails with error range out of order in char class
+	 */
+	const escapedLastSearchValue = lastSearchValue.replace(
+		/[-/\\^$*+?.()|[\]{}]/g,
+		'\\$&',
+	);
+
 	const updatedString = mainString.replace(
-		new RegExp(`${lastSearchValue}(?=[^${lastSearchValue}]*$)`),
+		new RegExp(`${escapedLastSearchValue}(?=[^${escapedLastSearchValue}]*$)`),
 		replacementString,
 	);
 	return `${updatedString},`;


### PR DESCRIPTION
### Summary

Page crash for logs page on query is happening when there are special characters present in the Value string of the query as we create a `RegExp`  based on the partial value which fails because those char's have different meaning in regEx context.

Solution :- Escape the special chars in the Partial Value

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/e74c8cb4-ef7b-4486-8905-52861cf53951



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
