### PR TITLE
feat: add raw view attributes in the logs list view

### DIFF
--- a/frontend/src/components/Logs/RawLogView/index.tsx
+++ b/frontend/src/components/Logs/RawLogView/index.tsx
@@ -11,6 +11,8 @@ import { useActiveLog } from 'hooks/logs/useActiveLog';
 import { useCopyLogLink } from 'hooks/logs/useCopyLogLink';
 // hooks
 import { useIsDarkMode } from 'hooks/useDarkMode';
+import { FlatLogData } from 'lib/logs/flatLogData';
+import { isUndefined } from 'lodash-es';
 import {
 	KeyboardEvent,
 	MouseEvent,
@@ -36,10 +38,13 @@ function RawLogView({
 	data,
 	linesPerRow,
 	isTextOverflowEllipsisDisabled,
+	selectedFields,
 }: RawLogViewProps): JSX.Element {
 	const { isHighlighted, isLogsExplorerPage, onLogCopy } = useCopyLogLink(
 		data.id,
 	);
+	const flattenLogData = useMemo(() => FlatLogData(data), [data]);
+
 	const {
 		activeLog: activeContextLog,
 		onClearActiveLog: handleClearActiveContextLog,
@@ -61,12 +66,31 @@ function RawLogView({
 
 	const logType = data?.attributes_string?.log_level || LogType.INFO;
 
+	const updatedSelecedFields = useMemo(
+		() => selectedFields.filter((e) => e.name !== 'id'),
+		[selectedFields],
+	);
+
+	const attributesValues = updatedSelecedFields
+		.map((field) => flattenLogData[field.name])
+		.filter((attribute) => !isUndefined(attribute));
+
+	let attributesText = attributesValues.join(' | ');
+
+	if (attributesText.length > 0) {
+		attributesText += ' | ';
+	}
+
 	const text = useMemo(
 		() =>
 			typeof data.timestamp === 'string'
-				? `${dayjs(data.timestamp).format()} | ${severityText} ${data.body}`
-				: `${dayjs(data.timestamp / 1e6).format()} | ${severityText} ${data.body}`,
-		[data.timestamp, data.body, severityText],
+				? `${dayjs(data.timestamp).format()} | ${attributesText} ${severityText} ${
+						data.body
+				  }`
+				: `${dayjs(
+						data.timestamp / 1e6,
+				  ).format()} | ${attributesText} ${severityText} ${data.body}`,
+		[data.timestamp, data.body, severityText, attributesText],
 	);
 
 	const handleClickExpand = useCallback(() => {

--- a/frontend/src/components/Logs/RawLogView/index.tsx
+++ b/frontend/src/components/Logs/RawLogView/index.tsx
@@ -12,7 +12,7 @@ import { useCopyLogLink } from 'hooks/logs/useCopyLogLink';
 // hooks
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { FlatLogData } from 'lib/logs/flatLogData';
-import { isUndefined } from 'lodash-es';
+import { isEmpty, isUndefined } from 'lodash-es';
 import {
 	KeyboardEvent,
 	MouseEvent,
@@ -38,7 +38,7 @@ function RawLogView({
 	data,
 	linesPerRow,
 	isTextOverflowEllipsisDisabled,
-	selectedFields,
+	selectedFields = [],
 }: RawLogViewProps): JSX.Element {
 	const { isHighlighted, isLogsExplorerPage, onLogCopy } = useCopyLogLink(
 		data.id,
@@ -73,7 +73,7 @@ function RawLogView({
 
 	const attributesValues = updatedSelecedFields
 		.map((field) => flattenLogData[field.name])
-		.filter((attribute) => !isUndefined(attribute));
+		.filter((attribute) => !isUndefined(attribute) && !isEmpty(attribute));
 
 	let attributesText = attributesValues.join(' | ');
 

--- a/frontend/src/components/Logs/RawLogView/styles.ts
+++ b/frontend/src/components/Logs/RawLogView/styles.ts
@@ -16,9 +16,13 @@ export const RawLogViewContainer = styled(Row)<{
 	width: 100%;
 
 	display: flex;
-	alignitems: center;
+	align-items: stretch;
 
 	transition: background-color 0.2s ease-in;
+
+	.log-state-indicator {
+		margin: 4px 0;
+	}
 
 	${({ $isActiveLog }): string => getActiveLogBackground($isActiveLog)}
 

--- a/frontend/src/components/Logs/RawLogView/types.ts
+++ b/frontend/src/components/Logs/RawLogView/types.ts
@@ -1,3 +1,4 @@
+import { IField } from 'types/api/logs/fields';
 import { ILog } from 'types/api/logs/log';
 
 export interface RawLogViewProps {
@@ -6,6 +7,7 @@ export interface RawLogViewProps {
 	isTextOverflowEllipsisDisabled?: boolean;
 	data: ILog;
 	linesPerRow: number;
+	selectedFields: IField[];
 }
 
 export interface RawLogContentProps {

--- a/frontend/src/components/Logs/RawLogView/types.ts
+++ b/frontend/src/components/Logs/RawLogView/types.ts
@@ -7,7 +7,7 @@ export interface RawLogViewProps {
 	isTextOverflowEllipsisDisabled?: boolean;
 	data: ILog;
 	linesPerRow: number;
-	selectedFields: IField[];
+	selectedFields?: IField[];
 }
 
 export interface RawLogContentProps {

--- a/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.styles.scss
+++ b/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.styles.scss
@@ -55,6 +55,92 @@
 		}
 	}
 
+	.horizontal-line {
+		height: 1px;
+		background: #1d212d;
+	}
+
+	.max-lines-per-row {
+		padding: 12px;
+
+		.title {
+			color: var(--bg-slate-200, #52575c);
+			font-family: Inter;
+			font-size: 11px;
+			font-style: normal;
+			font-weight: 600;
+			line-height: 18px; /* 163.636% */
+			letter-spacing: 0.88px;
+			text-transform: uppercase;
+
+			margin-bottom: 12px;
+
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+
+			.lucide {
+				color: var(--bg-vanilla-400, #c0c1c3);
+				cursor: pointer;
+			}
+		}
+
+		.max-lines-per-row-input {
+			display: flex;
+
+			border: 1px solid var(--bg-slate-400, #1d212d);
+
+			.ant-input-number-handler-wrap {
+				display: none;
+			}
+
+			.ant-input-number {
+				min-width: 36px;
+				width: auto;
+				border: 0px;
+				text-align: center;
+				height: 26px;
+				border-radius: 0;
+
+				&:active,
+				&:focus {
+					border: none;
+					box-shadow: none;
+				}
+			}
+
+			.ant-input-number-focused {
+				box-shadow: none !important;
+			}
+
+			.ant-input-number-input-wrap {
+				input {
+					text-align: center;
+					font-size: 13px;
+
+					&:active,
+					&:focus {
+						border: none;
+					}
+				}
+
+				&:active,
+				&:focus {
+					border: none;
+				}
+			}
+
+			.periscope-btn {
+				box-shadow: none;
+				padding: 6px 12px;
+				height: 26px;
+
+				border-radius: 0px 1px 1px 0px;
+				background: var(--bg-ink-300, #16181d);
+			}
+		}
+	}
+
 	.selected-item-content-container {
 		.add-new-column-header {
 			padding: 8px;
@@ -93,61 +179,6 @@
 
 		.item-content {
 			padding: 12px;
-
-			.max-lines-per-row-input {
-				display: flex;
-
-				border: 1px solid var(--bg-slate-400, #1d212d);
-
-				.ant-input-number-handler-wrap {
-					display: none;
-				}
-
-				.ant-input-number {
-					min-width: 36px;
-					width: auto;
-					border: 0px;
-					text-align: center;
-					height: 26px;
-					border-radius: 0;
-
-					&:active,
-					&:focus {
-						border: none;
-						box-shadow: none;
-					}
-				}
-
-				.ant-input-number-focused {
-					box-shadow: none !important;
-				}
-
-				.ant-input-number-input-wrap {
-					input {
-						text-align: center;
-						font-size: 13px;
-
-						&:active,
-						&:focus {
-							border: none;
-						}
-					}
-
-					&:active,
-					&:focus {
-						border: none;
-					}
-				}
-
-				.periscope-btn {
-					box-shadow: none;
-					padding: 6px 12px;
-					height: 26px;
-
-					border-radius: 0px 1px 1px 0px;
-					background: var(--bg-ink-300, #16181d);
-				}
-			}
 
 			.column-format,
 			.column-format-new-options {
@@ -265,6 +296,28 @@
 		);
 
 		box-shadow: 4px 10px 16px 2px rgba(255, 255, 255, 0.2);
+
+		.horizontal-line {
+			background: var(--bg-vanilla-300);
+		}
+
+		.max-lines-per-row {
+			.title {
+				color: var(--bg-ink-200);
+
+				.lucide {
+					color: var(--bg-ink-300);
+				}
+			}
+
+			.max-lines-per-row-input {
+				border: 1px solid var(--bg-vanilla-300);
+
+				.periscope-btn {
+					background: var(--bg-vanilla-300);
+				}
+			}
+		}
 
 		.menu-container {
 			.title {

--- a/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
+++ b/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
@@ -92,10 +92,7 @@ export default function LogsFormatOptionsMenu({
 
 	return (
 		<div
-			className={cx(
-				'nested-menu-container',
-				addNewColumn && selectedItem !== 'raw' ? 'active' : '',
-			)}
+			className={cx('nested-menu-container', addNewColumn ? 'active' : '')}
 			onClick={(event): void => {
 				// this is to restrict click events to propogate to parent
 				event.stopPropagation();
@@ -124,11 +121,11 @@ export default function LogsFormatOptionsMenu({
 			</div>
 
 			{selectedItem && (
-				<div className="selected-item-content-container active">
+				<>
 					{selectedItem === 'raw' && (
 						<>
 							<div className="horizontal-line" />
-							<div className="item-content">
+							<div className="max-lines-per-row">
 								<div className="title"> max lines per row </div>
 								<div className="raw-format max-lines-per-row-input">
 									<button
@@ -158,89 +155,93 @@ export default function LogsFormatOptionsMenu({
 						</>
 					)}
 
-					{!addNewColumn && <div className="horizontal-line" />}
-
-					{addNewColumn && (
-						<div className="add-new-column-header">
-							<div className="title">
-								{' '}
-								columns
-								<X size={14} onClick={handleToggleAddNewColumn} />{' '}
-							</div>
-
-							<Input
-								tabIndex={0}
-								type="text"
-								autoFocus
-								onFocus={addColumn?.onFocus}
-								onChange={handleSearchValueChange}
-								placeholder="Search..."
-							/>
-						</div>
-					)}
-
-					<div className="item-content">
-						{!addNewColumn && (
-							<div className="title">
-								columns
-								<Plus size={14} onClick={handleToggleAddNewColumn} />{' '}
-							</div>
-						)}
-
-						<div className="column-format">
-							{addColumn?.value?.map(({ key, id }) => (
-								<div className="column-name" key={id}>
-									<div className="name">
-										<Tooltip placement="left" title={key}>
-											{key}
-										</Tooltip>
-									</div>
-									<X
-										className="delete-btn"
-										size={14}
-										onClick={(): void => addColumn.onRemove(id as string)}
-									/>
-								</div>
-							))}
-						</div>
-
-						{addColumn?.isFetching && (
-							<div className="loading-container"> Loading ... </div>
-						)}
-
-						{addNewColumn &&
-							addColumn &&
-							addColumn.value.length > 0 &&
-							addColumn.options &&
-							addColumn?.options?.length > 0 && <Divider className="column-divider" />}
+					<div className="selected-item-content-container active">
+						{!addNewColumn && <div className="horizontal-line" />}
 
 						{addNewColumn && (
-							<div className="column-format-new-options">
-								{addColumn?.options?.map(({ label, value }) => (
-									<div
-										className="column-name"
-										key={value}
-										onClick={(eve): void => {
-											console.log('coluimn name', label, value);
+							<div className="add-new-column-header">
+								<div className="title">
+									{' '}
+									columns
+									<X size={14} onClick={handleToggleAddNewColumn} />{' '}
+								</div>
 
-											eve.stopPropagation();
+								<Input
+									tabIndex={0}
+									type="text"
+									autoFocus
+									onFocus={addColumn?.onFocus}
+									onChange={handleSearchValueChange}
+									placeholder="Search..."
+								/>
+							</div>
+						)}
 
-											if (addColumn && addColumn?.onSelect) {
-												addColumn?.onSelect(value, { label, disabled: false });
-											}
-										}}
-									>
+						<div className="item-content">
+							{!addNewColumn && (
+								<div className="title">
+									columns
+									<Plus size={14} onClick={handleToggleAddNewColumn} />{' '}
+								</div>
+							)}
+
+							<div className="column-format">
+								{addColumn?.value?.map(({ key, id }) => (
+									<div className="column-name" key={id}>
 										<div className="name">
-											<Tooltip placement="left" title={label}>
-												{label}
+											<Tooltip placement="left" title={key}>
+												{key}
 											</Tooltip>
 										</div>
+										<X
+											className="delete-btn"
+											size={14}
+											onClick={(): void => addColumn.onRemove(id as string)}
+										/>
 									</div>
 								))}
 							</div>
-						)}
+
+							{addColumn?.isFetching && (
+								<div className="loading-container"> Loading ... </div>
+							)}
+
+							{addNewColumn &&
+								addColumn &&
+								addColumn.value.length > 0 &&
+								addColumn.options &&
+								addColumn?.options?.length > 0 && (
+									<Divider className="column-divider" />
+								)}
+
+							{addNewColumn && (
+								<div className="column-format-new-options">
+									{addColumn?.options?.map(({ label, value }) => (
+										<div
+											className="column-name"
+											key={value}
+											onClick={(eve): void => {
+												console.log('coluimn name', label, value);
+
+												eve.stopPropagation();
+
+												if (addColumn && addColumn?.onSelect) {
+													addColumn?.onSelect(value, { label, disabled: false });
+												}
+											}}
+										>
+											<div className="name">
+												<Tooltip placement="left" title={label}>
+													{label}
+												</Tooltip>
+											</div>
+										</div>
+									))}
+								</div>
+							)}
+						</div>
 					</div>
-				</div>
+				</>
 			)}
 		</div>
 	);

--- a/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
+++ b/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
@@ -125,33 +125,11 @@ export default function LogsFormatOptionsMenu({
 
 			{selectedItem && (
 				<div className="selected-item-content-container active">
-					{!addNewColumn && <div className="horizontal-line" />}
-
-					{addNewColumn && selectedItem !== 'raw' && (
-						<div className="add-new-column-header">
-							<div className="title">
-								{' '}
-								columns
-								<X size={14} onClick={handleToggleAddNewColumn} />{' '}
-							</div>
-
-							<Input
-								tabIndex={0}
-								type="text"
-								autoFocus
-								onFocus={addColumn?.onFocus}
-								// onBlur={addColumn?.onBlur}
-								onChange={handleSearchValueChange}
-								placeholder="Search..."
-							/>
-						</div>
-					)}
-
-					<div className="item-content">
-						{selectedItem === 'raw' && (
-							<>
+					{selectedItem === 'raw' && (
+						<>
+							<div className="horizontal-line" />
+							<div className="item-content">
 								<div className="title"> max lines per row </div>
-
 								<div className="raw-format max-lines-per-row-input">
 									<button
 										type="button"
@@ -176,73 +154,90 @@ export default function LogsFormatOptionsMenu({
 										<Plus size={12} />{' '}
 									</button>
 								</div>
-							</>
+							</div>
+						</>
+					)}
+
+					{!addNewColumn && <div className="horizontal-line" />}
+
+					{addNewColumn && (
+						<div className="add-new-column-header">
+							<div className="title">
+								{' '}
+								columns
+								<X size={14} onClick={handleToggleAddNewColumn} />{' '}
+							</div>
+
+							<Input
+								tabIndex={0}
+								type="text"
+								autoFocus
+								onFocus={addColumn?.onFocus}
+								onChange={handleSearchValueChange}
+								placeholder="Search..."
+							/>
+						</div>
+					)}
+
+					<div className="item-content">
+						{!addNewColumn && (
+							<div className="title">
+								columns
+								<Plus size={14} onClick={handleToggleAddNewColumn} />{' '}
+							</div>
 						)}
 
-						{(selectedItem === 'table' || selectedItem === 'list') && (
-							<>
-								{!addNewColumn && (
-									<div className="title">
-										columns
-										<Plus size={14} onClick={handleToggleAddNewColumn} />{' '}
+						<div className="column-format">
+							{addColumn?.value?.map(({ key, id }) => (
+								<div className="column-name" key={id}>
+									<div className="name">
+										<Tooltip placement="left" title={key}>
+											{key}
+										</Tooltip>
 									</div>
-								)}
-
-								<div className="column-format">
-									{addColumn?.value?.map(({ key, id }) => (
-										<div className="column-name" key={id}>
-											<div className="name">
-												<Tooltip placement="left" title={key}>
-													{key}
-												</Tooltip>
-											</div>
-											<X
-												className="delete-btn"
-												size={14}
-												onClick={(): void => addColumn.onRemove(id as string)}
-											/>
-										</div>
-									))}
+									<X
+										className="delete-btn"
+										size={14}
+										onClick={(): void => addColumn.onRemove(id as string)}
+									/>
 								</div>
+							))}
+						</div>
 
-								{addColumn?.isFetching && (
-									<div className="loading-container"> Loading ... </div>
-								)}
+						{addColumn?.isFetching && (
+							<div className="loading-container"> Loading ... </div>
+						)}
 
-								{addNewColumn &&
-									addColumn &&
-									addColumn.value.length > 0 &&
-									addColumn.options &&
-									addColumn?.options?.length > 0 && (
-										<Divider className="column-divider" />
-									)}
+						{addNewColumn &&
+							addColumn &&
+							addColumn.value.length > 0 &&
+							addColumn.options &&
+							addColumn?.options?.length > 0 && <Divider className="column-divider" />}
 
-								{addNewColumn && (
-									<div className="column-format-new-options">
-										{addColumn?.options?.map(({ label, value }) => (
-											<div
-												className="column-name"
-												key={value}
-												onClick={(eve): void => {
-													console.log('coluimn name', label, value);
+						{addNewColumn && (
+							<div className="column-format-new-options">
+								{addColumn?.options?.map(({ label, value }) => (
+									<div
+										className="column-name"
+										key={value}
+										onClick={(eve): void => {
+											console.log('coluimn name', label, value);
 
-													eve.stopPropagation();
+											eve.stopPropagation();
 
-													if (addColumn && addColumn?.onSelect) {
-														addColumn?.onSelect(value, { label, disabled: false });
-													}
-												}}
-											>
-												<div className="name">
-													<Tooltip placement="left" title={label}>
-														{label}
-													</Tooltip>
-												</div>
-											</div>
-										))}
+											if (addColumn && addColumn?.onSelect) {
+												addColumn?.onSelect(value, { label, disabled: false });
+											}
+										}}
+									>
+										<div className="name">
+											<Tooltip placement="left" title={label}>
+												{label}
+											</Tooltip>
+										</div>
 									</div>
-								)}
-							</>
+								))}
+							</div>
 						)}
 					</div>
 				</div>

--- a/frontend/src/container/LiveLogs/LiveLogsList/index.tsx
+++ b/frontend/src/container/LiveLogs/LiveLogsList/index.tsx
@@ -57,7 +57,12 @@ function LiveLogsList({ logs }: LiveLogsListProps): JSX.Element {
 		(_: number, log: ILog): JSX.Element => {
 			if (options.format === 'raw') {
 				return (
-					<RawLogView key={log.id} data={log} linesPerRow={options.maxLines} />
+					<RawLogView
+						key={log.id}
+						data={log}
+						linesPerRow={options.maxLines}
+						selectedFields={selectedFields}
+					/>
 				);
 			}
 

--- a/frontend/src/container/LogsExplorerList/index.tsx
+++ b/frontend/src/container/LogsExplorerList/index.tsx
@@ -68,7 +68,12 @@ function LogsExplorerList({
 		(_: number, log: ILog): JSX.Element => {
 			if (options.format === 'raw') {
 				return (
-					<RawLogView key={log.id} data={log} linesPerRow={options.maxLines} />
+					<RawLogView
+						key={log.id}
+						data={log}
+						linesPerRow={options.maxLines}
+						selectedFields={selectedFields}
+					/>
 				);
 			}
 

--- a/frontend/src/container/LogsTable/index.tsx
+++ b/frontend/src/container/LogsTable/index.tsx
@@ -59,7 +59,14 @@ function LogsTable(props: LogsTableProps): JSX.Element {
 			const log = logs[index];
 
 			if (viewMode === 'raw') {
-				return <RawLogView key={log.id} data={log} linesPerRow={linesPerRow} />;
+				return (
+					<RawLogView
+						key={log.id}
+						data={log}
+						linesPerRow={linesPerRow}
+						selectedFields={selected}
+					/>
+				);
 			}
 
 			return (


### PR DESCRIPTION
### Summary

- Added support to add and visualise the attributes in the `raw` view for logs list
- made the logs indicator stretch to the log length
- currently only support the values in the `raw` view 

Decision Thread - https://signoz-team.slack.com/archives/C02B85R4R0A/p1705666575148639 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots



https://github.com/SigNoz/signoz/assets/54737045/42da3d32-3a3b-49b2-a81b-7543b594964b





#### Affected Areas and Manually Tested Areas

Raw / Default / Column View for logs
