### PR TITLE
fix: center align the dashboard delete modal

### DIFF
--- a/frontend/src/container/ListOfDashboard/TableComponents/DeleteButton.styles.scss
+++ b/frontend/src/container/ListOfDashboard/TableComponents/DeleteButton.styles.scss
@@ -1,0 +1,5 @@
+.delete-modal {
+	.ant-modal-confirm-body {
+		align-items: center;
+	}
+}

--- a/frontend/src/container/ListOfDashboard/TableComponents/DeleteButton.tsx
+++ b/frontend/src/container/ListOfDashboard/TableComponents/DeleteButton.tsx
@@ -1,3 +1,5 @@
+import './DeleteButton.styles.scss';
+
 import { DeleteOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
 import { Modal, Tooltip, Typography } from 'antd';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
@@ -64,6 +66,7 @@ function DeleteButton({
 			okText: 'Delete',
 			okButtonProps: { danger: true },
 			centered: true,
+			className: 'delete-modal',
 		});
 	}, [modal, name, deleteDashboardMutation, notifications, t, queryClient]);
 


### PR DESCRIPTION
### Summary

- center align the icon and the text for dashboard delete modal

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

Before - 
<img width="625" alt="image" src="https://github.com/SigNoz/signoz/assets/54737045/ac3e5cb6-544f-43c6-8349-f5bf84be2285">


After - 
<img width="596" alt="image" src="https://github.com/SigNoz/signoz/assets/54737045/64ab1127-6200-40d7-b00a-f7240df44155">


#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
