### PR TITLE
feat: [GH-4436]: date range enhancements

### DIFF
--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.styles.scss
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.styles.scss
@@ -38,6 +38,12 @@
 	padding: 4px 8px;
 	padding-left: 0px !important;
 
+	&.custom-time {
+		input:not(:focus) {
+			min-width: 240px;
+		}
+	}
+
 	input::placeholder {
 		color: white;
 	}

--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -225,7 +225,10 @@ function CustomTimePicker({
 	return (
 		<div className="custom-time-picker">
 			<Popover
-				className="timeSelection-input-container"
+				className={cx(
+					'timeSelection-input-container',
+					selectedTime === 'custom' && inputValue === '' ? 'custom-time' : '',
+				)}
 				placement="bottomRight"
 				getPopupContainer={popupContainer}
 				rootClassName="date-time-root"
@@ -256,12 +259,7 @@ function CustomTimePicker({
 				<Input
 					className="timeSelection-input"
 					type="text"
-					style={{
-						minWidth: '120px',
-						width: '100%',
-					}}
 					status={inputValue && inputStatus === 'error' ? 'error' : ''}
-					allowClear={!isInputFocused && selectedTime === 'custom'}
 					placeholder={
 						isInputFocused
 							? 'Time Format (1m or 2h or 3d or 4w)'

--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -239,6 +239,7 @@ function CustomTimePicker({
 							onSelectHandler={handleSelect}
 							handleGoLive={defaultTo(handleGoLive, noop)}
 							options={items}
+							selectedTime={selectedTime}
 						/>
 					) : (
 						content

--- a/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
@@ -1,6 +1,7 @@
 import './CustomTimePicker.styles.scss';
 
 import { Button, DatePicker } from 'antd';
+import cx from 'classnames';
 import ROUTES from 'constants/routes';
 import { DateTimeRangeType } from 'container/TopNav/CustomDateTimeModal';
 import {
@@ -9,7 +10,10 @@ import {
 } from 'container/TopNav/DateTimeSelectionV2/config';
 import dayjs, { Dayjs } from 'dayjs';
 import { Dispatch, SetStateAction, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
+import { AppState } from 'store/reducers';
+import { GlobalReducer } from 'types/reducer/globalTime';
 
 interface CustomTimePickerPopoverContentProps {
 	options: any[];
@@ -19,6 +23,7 @@ interface CustomTimePickerPopoverContentProps {
 	onCustomDateHandler: (dateTimeRange: DateTimeRangeType) => void;
 	onSelectHandler: (label: string, value: string) => void;
 	handleGoLive: () => void;
+	selectedTime: string;
 }
 
 function CustomTimePickerPopoverContent({
@@ -29,9 +34,14 @@ function CustomTimePickerPopoverContent({
 	onCustomDateHandler,
 	onSelectHandler,
 	handleGoLive,
+	selectedTime,
 }: CustomTimePickerPopoverContentProps): JSX.Element {
 	const { RangePicker } = DatePicker;
 	const { pathname } = useLocation();
+
+	const { maxTime, minTime } = useSelector<AppState, GlobalReducer>(
+		(state) => state.globalTime,
+	);
 
 	const isLogsExplorerPage = useMemo(() => pathname === ROUTES.LOGS_EXPLORER, [
 		pathname,
@@ -89,18 +99,25 @@ function CustomTimePickerPopoverContent({
 						onClick={(): void => {
 							onSelectHandler(option.label, option.value);
 						}}
-						className="date-time-options-btn"
+						className={cx(
+							'date-time-options-btn',
+							selectedTime === option.value && 'active',
+						)}
 					>
 						{option.label}
 					</Button>
 				))}
 			</div>
 			<div className="relative-date-time">
-				{customDateTimeVisible ? (
+				{selectedTime === 'custom' || customDateTimeVisible ? (
 					<RangePicker
 						disabledDate={disabledDate}
 						allowClear
 						onCalendarChange={onModalOkHandler}
+						// eslint-disable-next-line react/jsx-props-no-spreading
+						{...(selectedTime === 'custom' && {
+							defaultValue: [dayjs(minTime / 1000000), dayjs(maxTime / 1000000)],
+						})}
 					/>
 				) : (
 					<div>

--- a/frontend/src/container/TopNav/DateTimeSelection/DateTimeSelection.styles.scss
+++ b/frontend/src/container/TopNav/DateTimeSelection/DateTimeSelection.styles.scss
@@ -1,0 +1,3 @@
+.date-time-selection-container {
+	margin-bottom: 16px;
+}

--- a/frontend/src/container/TopNav/DateTimeSelection/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelection/index.tsx
@@ -1,3 +1,5 @@
+import './DateTimeSelection.styles.scss';
+
 import { SyncOutlined } from '@ant-design/icons';
 import { Button } from 'antd';
 import getLocalStorageKey from 'api/browser/localstorage/get';
@@ -279,7 +281,7 @@ function DateTimeSelection({
 	}, [location.pathname, updateTimeInterval, globalTimeLoading]);
 
 	return (
-		<>
+		<div className="date-time-selection-container">
 			<Form
 				form={formSelector}
 				layout="inline"
@@ -322,7 +324,7 @@ function DateTimeSelection({
 				</FormContainer>
 			</Form>
 
-			{!hasSelectedTimeError && (
+			{!hasSelectedTimeError && selectedTime !== 'custom' && (
 				<RefreshText
 					{...{
 						onLastRefreshHandler,
@@ -338,7 +340,7 @@ function DateTimeSelection({
 					setCustomDTPickerVisible(false);
 				}}
 			/>
-		</>
+		</div>
 	);
 }
 

--- a/frontend/src/container/TopNav/DateTimeSelection/styles.ts
+++ b/frontend/src/container/TopNav/DateTimeSelection/styles.ts
@@ -24,7 +24,6 @@ interface Props {
 }
 
 export const RefreshTextContainer = styled.div<Props>`
-	min-height: 2rem;
 	visibility: ${({ refreshButtonHidden }): string =>
 		refreshButtonHidden ? 'hidden' : 'visible'};
 `;

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/DateTimeSelectionV2.styles.scss
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/DateTimeSelectionV2.styles.scss
@@ -100,6 +100,16 @@
 			border-bottom: 1px solid var(--bg-slate-400, #1d212d);
 		}
 
+		.active {
+			background-color: rgba(171, 189, 255, 0.04) !important;
+		}
+
+		.data-time-live:hover {
+			&.ant-btn-text {
+				background-color: rgba(171, 189, 255, 0.04) !important;
+			}
+		}
+
 		.date-time-options-btn {
 			text-align: start;
 			padding: 8px 13px;
@@ -110,6 +120,11 @@
 			font-weight: 400;
 			line-height: normal;
 			letter-spacing: 0.14px;
+		}
+		.date-time-options-btn:hover {
+			&.ant-btn-text {
+				background-color: rgba(171, 189, 255, 0.04) !important;
+			}
 		}
 	}
 
@@ -183,6 +198,22 @@
 
 			.date-time-options-btn {
 				color: var(--bg-slate-400);
+			}
+
+			.active {
+				background-color: var(--bg-vanilla-300) !important;
+			}
+
+			.data-time-live:hover {
+				&.ant-btn-text {
+					background-color: var(--bg-vanilla-300) !important;
+				}
+			}
+
+			.date-time-options-btn:hover {
+				&.ant-btn-text {
+					background-color: var(--bg-vanilla-300) !important;
+				}
 			}
 		}
 

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -147,7 +147,7 @@ function DateTimeSelection({
 		timeInterval: Time = '15min',
 	): string | Time => {
 		if (startTime && endTime && timeInterval === 'custom') {
-			const format = 'YYYY/MM/DD HH:mm';
+			const format = 'DD/MM/YYYY HH:mm';
 
 			const startString = startTime.format(format);
 			const endString = endTime.format(format);
@@ -161,8 +161,10 @@ function DateTimeSelection({
 	useEffect(() => {
 		if (selectedTime === 'custom') {
 			setRefreshButtonHidden(true);
+			setCustomDTPickerVisible(true);
 		} else {
 			setRefreshButtonHidden(false);
+			setCustomDTPickerVisible(false);
 		}
 	}, [selectedTime]);
 
@@ -276,9 +278,10 @@ function DateTimeSelection({
 			const [startTimeMoment, endTimeMoment] = dateTimeRange;
 			if (startTimeMoment && endTimeMoment) {
 				setCustomDTPickerVisible(false);
+				startTimeMoment.startOf('day').toString();
 				updateTimeInterval('custom', [
-					startTimeMoment?.toDate().getTime() || 0,
-					endTimeMoment?.toDate().getTime() || 0,
+					startTimeMoment.startOf('day').toDate().getTime(),
+					endTimeMoment.endOf('day').toDate().getTime(),
 				]);
 				setLocalStorageKey('startTime', startTimeMoment.toString());
 				setLocalStorageKey('endTime', endTimeMoment.toString());


### PR DESCRIPTION
### Summary

- when selecting a custom range the time should start from `0:00` of the start date to `23:59` for the end date (Point 3 of the issue)
- pre-fill the custom time values in the custom time calendar  ( Point 4 of the issue ) 
- Query raised for the first two points of the issue in Slack 

#### Related Issues / PR's

#4436 

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/917f8220-f40e-4d8c-a3c9-d8b461fb0695



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
