### PR TITLE
fix: switching between logs display tabs

### DIFF
--- a/frontend/src/container/LogsExplorerViews/index.tsx
+++ b/frontend/src/container/LogsExplorerViews/index.tsx
@@ -172,7 +172,6 @@ function LogsExplorerViews({
 	);
 
 	const handleModeChange = (e: RadioChangeEvent): void => {
-		setSelectedPanelType(e.target.value);
 		setShowFormatMenuItems(false);
 		handleExplorerTabChange(e.target.value);
 	};


### PR DESCRIPTION
### Summary

- the switching between the view tabs of logs explorer rendered the older data for a moment and then switched the tab 
- so rather than manually updating the state we rely on QB state to take care of the same after it triggers the API call

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/b23ba95d-3880-4ee5-9cfc-625f3bddfd45



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
