### PR TITLE
fix: custom range should be unique to pages

### DIFF
--- a/frontend/src/container/TopNav/DateTimeSelection/config.ts
+++ b/frontend/src/container/TopNav/DateTimeSelection/config.ts
@@ -96,3 +96,13 @@ export const routesToSkip = [
 ];
 
 export const routesToDisable = [ROUTES.LOGS_EXPLORER, ROUTES.LIVE_LOGS];
+
+export interface LocalStorageTimeRange {
+	localstorageStartTime: string | null;
+	localstorageEndTime: string | null;
+}
+
+export interface TimeRange {
+	startTime: string;
+	endTime: string;
+}

--- a/frontend/src/container/TopNav/DateTimeSelection/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelection/index.tsx
@@ -15,6 +15,7 @@ import useUrlQuery from 'hooks/useUrlQuery';
 import GetMinMax from 'lib/getMinMax';
 import getTimeString from 'lib/getTimeString';
 import history from 'lib/history';
+import { isObject } from 'lodash-es';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -44,8 +45,32 @@ function DateTimeSelection({
 	const searchStartTime = urlQuery.get('startTime');
 	const searchEndTime = urlQuery.get('endTime');
 
-	const localstorageStartTime = getLocalStorageKey('startTime');
-	const localstorageEndTime = getLocalStorageKey('endTime');
+	const { localstorageStartTime, localstorageEndTime } = ((): any => {
+		const routes = getLocalStorageKey(LOCALSTORAGE.METRICS_TIME_IN_DURATION);
+
+		if (routes !== null) {
+			const routesObject = JSON.parse(routes || '{}');
+			const selectedTime = routesObject[location.pathname];
+
+			if (selectedTime) {
+				let parsedSelectedTime;
+				try {
+					parsedSelectedTime = JSON.parse(selectedTime);
+				} catch {
+					parsedSelectedTime = selectedTime;
+				}
+
+				if (isObject(parsedSelectedTime)) {
+					return {
+						localstorageStartTime: (parsedSelectedTime as any).startTime,
+						localstorageEndTime: (parsedSelectedTime as any).endTime,
+					};
+				}
+				return { localstorageStartTime: null, localstorageEndTime: null };
+			}
+		}
+		return { localstorageStartTime: null, localstorageEndTime: null };
+	})();
 
 	const getTime = useCallback((): [number, number] | undefined => {
 		if (searchEndTime && searchStartTime) {
@@ -118,6 +143,15 @@ function DateTimeSelection({
 			const selectedTime = routesObject[pathName];
 
 			if (selectedTime) {
+				let parsedSelectedTime;
+				try {
+					parsedSelectedTime = JSON.parse(selectedTime);
+				} catch {
+					parsedSelectedTime = selectedTime;
+				}
+				if (isObject(parsedSelectedTime)) {
+					return 'custom';
+				}
 				return selectedTime;
 			}
 		}
@@ -125,7 +159,7 @@ function DateTimeSelection({
 		return defaultSelectedOption;
 	};
 
-	const updateLocalStorageForRoutes = (value: Time): void => {
+	const updateLocalStorageForRoutes = (value: Time | string): void => {
 		const preRoutes = getLocalStorageKey(LOCALSTORAGE.METRICS_TIME_IN_DURATION);
 		if (preRoutes !== null) {
 			const preRoutesObject = JSON.parse(preRoutes);
@@ -220,9 +254,9 @@ function DateTimeSelection({
 					startTimeMoment?.toDate().getTime() || 0,
 					endTimeMoment?.toDate().getTime() || 0,
 				]);
-				setLocalStorageKey('startTime', startTimeMoment.toString());
-				setLocalStorageKey('endTime', endTimeMoment.toString());
-				updateLocalStorageForRoutes('custom');
+				updateLocalStorageForRoutes(
+					JSON.stringify({ startTime: startTimeMoment, endTime: endTimeMoment }),
+				);
 				if (!isLogsExplorerPage) {
 					urlQuery.set(
 						QueryParams.startTime,

--- a/frontend/src/container/TopNav/DateTimeSelection/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelection/index.tsx
@@ -62,7 +62,7 @@ function DateTimeSelection({
 			const selectedTime = routesObject[location.pathname];
 
 			if (selectedTime) {
-				let parsedSelectedTime;
+				let parsedSelectedTime: TimeRange;
 				try {
 					parsedSelectedTime = JSON.parse(selectedTime);
 				} catch {
@@ -71,8 +71,8 @@ function DateTimeSelection({
 
 				if (isObject(parsedSelectedTime)) {
 					return {
-						localstorageStartTime: (parsedSelectedTime as TimeRange).startTime,
-						localstorageEndTime: (parsedSelectedTime as TimeRange).endTime,
+						localstorageStartTime: parsedSelectedTime.startTime,
+						localstorageEndTime: parsedSelectedTime.endTime,
 					};
 				}
 				return { localstorageStartTime: null, localstorageEndTime: null };
@@ -152,7 +152,7 @@ function DateTimeSelection({
 			const selectedTime = routesObject[pathName];
 
 			if (selectedTime) {
-				let parsedSelectedTime;
+				let parsedSelectedTime: TimeRange;
 				try {
 					parsedSelectedTime = JSON.parse(selectedTime);
 				} catch {

--- a/frontend/src/container/TopNav/DateTimeSelection/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelection/index.tsx
@@ -28,7 +28,13 @@ import { GlobalReducer } from 'types/reducer/globalTime';
 
 import AutoRefresh from '../AutoRefresh';
 import CustomDateTimeModal, { DateTimeRangeType } from '../CustomDateTimeModal';
-import { getDefaultOption, getOptions, Time } from './config';
+import {
+	getDefaultOption,
+	getOptions,
+	LocalStorageTimeRange,
+	Time,
+	TimeRange,
+} from './config';
 import RefreshText from './Refresh';
 import { Form, FormContainer, FormItem } from './styles';
 
@@ -45,7 +51,10 @@ function DateTimeSelection({
 	const searchStartTime = urlQuery.get('startTime');
 	const searchEndTime = urlQuery.get('endTime');
 
-	const { localstorageStartTime, localstorageEndTime } = ((): any => {
+	const {
+		localstorageStartTime,
+		localstorageEndTime,
+	} = ((): LocalStorageTimeRange => {
 		const routes = getLocalStorageKey(LOCALSTORAGE.METRICS_TIME_IN_DURATION);
 
 		if (routes !== null) {
@@ -62,8 +71,8 @@ function DateTimeSelection({
 
 				if (isObject(parsedSelectedTime)) {
 					return {
-						localstorageStartTime: (parsedSelectedTime as any).startTime,
-						localstorageEndTime: (parsedSelectedTime as any).endTime,
+						localstorageStartTime: (parsedSelectedTime as TimeRange).startTime,
+						localstorageEndTime: (parsedSelectedTime as TimeRange).endTime,
 					};
 				}
 				return { localstorageStartTime: null, localstorageEndTime: null };


### PR DESCRIPTION
### Summary

- Custom Range should be unique for different pages (based on URL)
- Store the date for custom in the format of `pathname: {startTime: '', endTime: ''}`

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/ffae7f6d-340a-4b50-bc41-252b41b50c69



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
    - Enhanced the `DateTimeSelection` component for more robust handling of local storage data, including better support for various data types.
    - Restructured local storage handling and updated the `updateLocalStorageForRoutes` function.
    - Improved handling of selected time data to accommodate different data types.
- **Documentation**
    - Added two new interfaces `LocalStorageTimeRange` and `TimeRange` in `config.ts` to manage time range data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->