### PR TITLE
fix: set light background for full screen in dashboard

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCardLayout.styles.scss
+++ b/frontend/src/container/GridCardLayout/GridCardLayout.styles.scss
@@ -1,8 +1,10 @@
 .fullscreen-grid-container {
 	overflow: auto;
+	margin-top: 1rem;
 
 	.react-grid-layout {
 		border: none !important;
+		margin-top: 0;
 	}
 }
 
@@ -11,5 +13,11 @@
 
 	&.graph {
 		height: calc(100% - 30px);
+	}
+}
+
+.lightMode {
+	.fullscreen-grid-container {
+		background-color: rgb(250, 250, 250);
 	}
 }

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -74,6 +74,8 @@ function SideNav({
 		isCurrentVersionError,
 	} = useSelector<AppState, AppReducer>((state) => state.app);
 
+	const [licenseTag, setLicenseTag] = useState('');
+
 	const userSettingsMenuItem = {
 		key: ROUTES.MY_SETTINGS,
 		label: user?.name || 'User',
@@ -239,6 +241,18 @@ function SideNav({
 		}
 	};
 
+	useEffect(() => {
+		if (!isFetching) {
+			if (isCloudUserVal) {
+				setLicenseTag('Cloud');
+			} else if (isEnterprise) {
+				setLicenseTag('Enterprise');
+			} else {
+				setLicenseTag('Free');
+			}
+		}
+	}, [isCloudUserVal, isEnterprise, isFetching]);
+
 	return (
 		<div className={cx('sideNav', collapsed ? 'collapsed' : '')}>
 			<div className="brand">
@@ -257,7 +271,7 @@ function SideNav({
 
 				{!collapsed && (
 					<>
-						<div className="license tag">{!isEnterprise ? 'Free' : 'Enterprise'}</div>
+						{!isFetching && <div className="license tag">{licenseTag}</div>}
 
 						<ToggleButton
 							checked={isDarkMode}


### PR DESCRIPTION
1. set a light background for the full screen in the dashboard
2.  show license tag as cloud for cloud users

fixes 
[#1190](https://github.com/SigNoz/engineering-pod/issues/1190)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved the layout and spacing of the grid card layout.
	- Introduced a light mode theme option for better visual comfort.

- **New Features**
	- Added dynamic license tag display in the side navigation, enhancing user awareness and compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->