### PR TITLE
Revert "fix: Logs UI: querybuildersearch: avoid emptying out query on sourceKeys update if tags are yet to be populated "

### DIFF
--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
@@ -150,20 +150,6 @@ function QueryBuilderSearch({
 			(item) => item.key as BaseAutocompleteData,
 		);
 
-		// Avoid updating query with onChange at the bottom of this useEffect
-		// if there are no `tags` that need to be normalized after receiving
-		// the latest `sourceKeys`.
-		//
-		// Executing the following logic for empty tags leads to emptying
-		// out of `query` via `onChange`.
-		// `tags` can contain stale empty value while being updated by `useTag`
-		// which maintains it as a state and updates it via useEffect when props change.
-		// This was observed when pipeline filters were becoming empty after
-		// returning from logs explorer.
-		if ((tags?.length || 0) < 1) {
-			return;
-		}
-
 		initialTagFilters.items = tags.map((tag, index) => {
 			const isJsonTrue = query.filters?.items[index]?.key?.isJSON;
 


### PR DESCRIPTION
Reverts SigNoz/signoz#4355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue where queries were not updating under specific conditions related to tag length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->