### PR TITLE
fix: loading states for list logs view

### DIFF
--- a/frontend/src/container/LogsExplorerList/index.tsx
+++ b/frontend/src/container/LogsExplorerList/index.tsx
@@ -171,7 +171,7 @@ function LogsExplorerList({
 
 			{isError && !isLoading && !isFetching && <LogsError />}
 
-			{!isLoading && !isFetching && !isError && logs.length > 0 && (
+			{!isLoading && !isError && logs.length > 0 && (
 				<>
 					<InfinityWrapperStyled>{renderContent}</InfinityWrapperStyled>
 


### PR DESCRIPTION
### Summary

- gracefully handle loading states for list logs view on tab switch / scroll virtuoso

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
