### PR TITLE
fix: make label compliant with prometheus spec

### DIFF
--- a/pkg/query-service/rules/thresholdRule.go
+++ b/pkg/query-service/rules/thresholdRule.go
@@ -1057,12 +1057,12 @@ func (r *ThresholdRule) Eval(ctx context.Context, ts time.Time, queriers *Querie
 		if r.typ == "TRACES_BASED_ALERT" {
 			link := r.prepareLinksToTraces(ts, smpl.Metric)
 			if link != "" && r.hostFromSource() != "" {
-				lb.Set("See related traces: ", fmt.Sprintf("%s/traces-explorer?%s", r.hostFromSource(), link))
+				lb.Set("RelatedLogs", fmt.Sprintf("%s/traces-explorer?%s", r.hostFromSource(), link))
 			}
 		} else if r.typ == "LOGS_BASED_ALERT" {
 			link := r.prepareLinksToLogs(ts, smpl.Metric)
 			if link != "" && r.hostFromSource() != "" {
-				lb.Set("See related logs: ", fmt.Sprintf("%s/logs/logs-explorer?%s", r.hostFromSource(), link))
+				lb.Set("RelatedTraces", fmt.Sprintf("%s/logs/logs-explorer?%s", r.hostFromSource(), link))
 			}
 		}
 

--- a/pkg/query-service/rules/thresholdRule.go
+++ b/pkg/query-service/rules/thresholdRule.go
@@ -1057,12 +1057,12 @@ func (r *ThresholdRule) Eval(ctx context.Context, ts time.Time, queriers *Querie
 		if r.typ == "TRACES_BASED_ALERT" {
 			link := r.prepareLinksToTraces(ts, smpl.Metric)
 			if link != "" && r.hostFromSource() != "" {
-				lb.Set("RelatedLogs", fmt.Sprintf("%s/traces-explorer?%s", r.hostFromSource(), link))
+				lb.Set("RelatedTraces", fmt.Sprintf("%s/traces-explorer?%s", r.hostFromSource(), link))
 			}
 		} else if r.typ == "LOGS_BASED_ALERT" {
 			link := r.prepareLinksToLogs(ts, smpl.Metric)
 			if link != "" && r.hostFromSource() != "" {
-				lb.Set("RelatedTraces", fmt.Sprintf("%s/logs/logs-explorer?%s", r.hostFromSource(), link))
+				lb.Set("RelatedLogs", fmt.Sprintf("%s/logs/logs-explorer?%s", r.hostFromSource(), link))
 			}
 		}
 


### PR DESCRIPTION
### Summary

Follow up on https://github.com/SigNoz/signoz/pull/4446, the `See related X` is an invalid label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated labels for related traces and logs in alerts to enhance clarity based on the alert type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->