### PR TITLE
feat: setup the context for keyboard hotkeys

### DIFF
--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -8,6 +8,7 @@ import { LOCALSTORAGE } from 'constants/localStorage';
 import ROUTES from 'constants/routes';
 import AppLayout from 'container/AppLayout';
 import useAnalytics from 'hooks/analytics/useAnalytics';
+import { KeyboardHotkeysProvider } from 'hooks/hotkeys/useKeyboardHotkeys';
 import { useThemeConfig } from 'hooks/useDarkMode';
 import useGetFeatureFlag from 'hooks/useGetFeatureFlag';
 import useLicense, { LICENSE_PLAN_KEY } from 'hooks/useLicense';
@@ -177,22 +178,24 @@ function App(): JSX.Element {
 						<ResourceProvider>
 							<QueryBuilderProvider>
 								<DashboardProvider>
-									<AppLayout>
-										<Suspense fallback={<Spinner size="large" tip="Loading..." />}>
-											<Switch>
-												{routes.map(({ path, component, exact }) => (
-													<Route
-														key={`${path}`}
-														exact={exact}
-														path={path}
-														component={component}
-													/>
-												))}
+									<KeyboardHotkeysProvider>
+										<AppLayout>
+											<Suspense fallback={<Spinner size="large" tip="Loading..." />}>
+												<Switch>
+													{routes.map(({ path, component, exact }) => (
+														<Route
+															key={`${path}`}
+															exact={exact}
+															path={path}
+															component={component}
+														/>
+													))}
 
-												<Route path="*" component={NotFound} />
-											</Switch>
-										</Suspense>
-									</AppLayout>
+													<Route path="*" component={NotFound} />
+												</Switch>
+											</Suspense>
+										</AppLayout>
+									</KeyboardHotkeysProvider>
 								</DashboardProvider>
 							</QueryBuilderProvider>
 						</ResourceProvider>

--- a/frontend/src/constants/shortcuts/globalShortcuts.ts
+++ b/frontend/src/constants/shortcuts/globalShortcuts.ts
@@ -1,0 +1,3 @@
+export const GlobalShortcuts = {
+	SidebarCollapse: 'b+meta',
+};

--- a/frontend/src/constants/shortcuts/globalShortcuts.ts
+++ b/frontend/src/constants/shortcuts/globalShortcuts.ts
@@ -1,3 +1,3 @@
 export const GlobalShortcuts = {
-	SidebarCollapse: 'b+meta',
+	SidebarCollapse: '\\+meta',
 };

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -9,6 +9,7 @@ import { IS_SIDEBAR_COLLAPSED } from 'constants/app';
 import { FeatureKeys } from 'constants/features';
 import ROUTES from 'constants/routes';
 import { ToggleButton } from 'container/Header/styles';
+import { useKeyboardHotkeys } from 'hooks/hotkeys/useKeyboardHotkeys';
 import useComponentPermission from 'hooks/useComponentPermission';
 import useThemeMode, { useIsDarkMode } from 'hooks/useDarkMode';
 import { LICENSE_PLAN_KEY, LICENSE_PLAN_STATUS } from 'hooks/useLicense';
@@ -98,6 +99,8 @@ function SideNav({
 
 	const [inviteMembers] = useComponentPermission(['invite_members'], role);
 
+	const { registerShortcut, deregisterShortcut } = useKeyboardHotkeys();
+
 	useEffect(() => {
 		if (inviteMembers) {
 			const updatedUserManagementMenuItems = [
@@ -155,6 +158,15 @@ function SideNav({
 	useLayoutEffect(() => {
 		dispatch(sideBarCollapse(collapsed));
 	}, [collapsed, dispatch]);
+
+	useEffect(() => {
+		registerShortcut('b+meta', onCollapse);
+
+		return (): void => {
+			deregisterShortcut('b+meta');
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	const isLicenseActive =
 		licenseData?.payload?.licenses?.find((e: License) => e.isCurrent)?.status ===

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -8,6 +8,7 @@ import cx from 'classnames';
 import { IS_SIDEBAR_COLLAPSED } from 'constants/app';
 import { FeatureKeys } from 'constants/features';
 import ROUTES from 'constants/routes';
+import { GlobalShortcuts } from 'constants/shortcuts/globalShortcuts';
 import { ToggleButton } from 'container/Header/styles';
 import { useKeyboardHotkeys } from 'hooks/hotkeys/useKeyboardHotkeys';
 import useComponentPermission from 'hooks/useComponentPermission';
@@ -160,10 +161,10 @@ function SideNav({
 	}, [collapsed, dispatch]);
 
 	useEffect(() => {
-		registerShortcut('b+meta', onCollapse);
+		registerShortcut(GlobalShortcuts.SidebarCollapse, onCollapse);
 
 		return (): void => {
-			deregisterShortcut('b+meta');
+			deregisterShortcut(GlobalShortcuts.SidebarCollapse);
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);

--- a/frontend/src/hooks/hotkeys/__tests__/useKeyboardHotkeys.test.tsx
+++ b/frontend/src/hooks/hotkeys/__tests__/useKeyboardHotkeys.test.tsx
@@ -1,0 +1,75 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+	KeyboardHotkeysProvider,
+	useKeyboardHotkeys,
+} from '../useKeyboardHotkeys';
+
+function TestComponentWithRegister({
+	handleShortcut,
+}: {
+	handleShortcut: () => void;
+}): JSX.Element {
+	const { registerShortcut } = useKeyboardHotkeys();
+
+	registerShortcut('a', handleShortcut);
+
+	return (
+		<div>
+			<span>Test Component</span>
+		</div>
+	);
+}
+function TestComponentWithDeRegister({
+	handleShortcut,
+}: {
+	handleShortcut: () => void;
+}): JSX.Element {
+	const { registerShortcut, deregisterShortcut } = useKeyboardHotkeys();
+
+	registerShortcut('b', handleShortcut);
+
+	// Deregister the shortcut before triggering it
+	deregisterShortcut('b');
+
+	return (
+		<div>
+			<span>Test Component</span>
+		</div>
+	);
+}
+
+describe('KeyboardHotkeysProvider', () => {
+	it('registers and triggers shortcuts correctly', async () => {
+		const handleShortcut = jest.fn();
+
+		render(
+			<KeyboardHotkeysProvider>
+				<TestComponentWithRegister handleShortcut={handleShortcut} />
+			</KeyboardHotkeysProvider>,
+		);
+
+		// Trigger the registered shortcut
+		await userEvent.keyboard('a');
+
+		// Assert that the handleShortcut function has been called
+		expect(handleShortcut).toHaveBeenCalled();
+	});
+
+	it('deregisters shortcuts correctly', () => {
+		const handleShortcut = jest.fn();
+
+		render(
+			<KeyboardHotkeysProvider>
+				<TestComponentWithDeRegister handleShortcut={handleShortcut} />
+			</KeyboardHotkeysProvider>,
+		);
+
+		// Try to trigger the deregistered shortcut
+		userEvent.keyboard('b');
+
+		// Assert that the handleShortcut function has NOT been called
+		expect(handleShortcut).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
+++ b/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
@@ -9,6 +9,11 @@ import {
 } from 'react';
 
 interface KeyboardHotkeysContextReturnValue {
+	/**
+	 *
+	 * @param keyCombination provide the string for which the subsequent callback should be triggered. Example 'ctrl+a'
+	 * @param callback the callback that should be triggered when the above key combination is being pressed
+	 */
 	registerShortcut: (keyCombination: string, callback: () => void) => void;
 	deregisterShortcut: (keyCombination: string) => void;
 }
@@ -47,7 +52,7 @@ function KeyboardHotkeysProvider({
 			return;
 		}
 		const modifiers = { ctrlKey, altKey, shiftKey, metaKey };
-		const shortcutKey = `${key}${modifiers.ctrlKey ? '+ctrl' : ''}${
+		const shortcutKey = `${key.toLowerCase()}${modifiers.ctrlKey ? '+ctrl' : ''}${
 			modifiers.altKey ? '+alt' : ''
 		}${modifiers.shiftKey ? '+shift' : ''}${modifiers.metaKey ? '+meta' : ''}`;
 

--- a/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
+++ b/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
@@ -1,4 +1,4 @@
-import { noop } from 'lodash-es';
+import { noop, unset } from 'lodash-es';
 import {
 	createContext,
 	useCallback,
@@ -67,6 +67,8 @@ function KeyboardHotkeysProvider({
 		(keyCombination: string, callback: () => void): void => {
 			if (!shortcuts.current[keyCombination]) {
 				shortcuts.current[keyCombination] = callback;
+			} else {
+				throw new Error('This shortcut is already present in current scope');
 			}
 		},
 		[shortcuts],
@@ -75,7 +77,7 @@ function KeyboardHotkeysProvider({
 	const deregisterShortcut = useCallback(
 		(keyCombination: string): void => {
 			if (shortcuts.current[keyCombination]) {
-				delete shortcuts.current[keyCombination];
+				unset(shortcuts.current, keyCombination);
 			}
 		},
 		[shortcuts],

--- a/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
+++ b/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
@@ -44,17 +44,6 @@ const useKeyboardHotkeys = (): KeyboardHotkeysContextReturnValue => {
 	return context;
 };
 
-function overrideSystemHandling(e: KeyboardEvent): void {
-	if (e) {
-		if (e.preventDefault) e.preventDefault();
-		if (e.stopPropagation) {
-			e.stopPropagation();
-		} else if (window.event) {
-			window.event.cancelBubble = true;
-		}
-	}
-}
-
 function KeyboardHotkeysProvider({
 	children,
 }: {
@@ -63,10 +52,6 @@ function KeyboardHotkeysProvider({
 	const shortcuts = useRef<Record<string, () => void>>({});
 
 	const handleKeyPress = (event: KeyboardEvent): void => {
-		overrideSystemHandling(event);
-		event.preventDefault();
-		event.stopPropagation();
-
 		const { key, ctrlKey, altKey, shiftKey, metaKey, target } = event;
 
 		if (IGNORE_INPUTS.includes((target as HTMLElement).tagName.toLowerCase())) {

--- a/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
+++ b/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
@@ -1,0 +1,99 @@
+import { noop } from 'lodash-es';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+} from 'react';
+
+interface KeyboardHotkeysContextReturnValue {
+	registerShortcut: (keyCombination: string, callback: () => void) => void;
+	deregisterShortcut: (keyCombination: string) => void;
+}
+
+const KeyboardHotkeysContext = createContext<KeyboardHotkeysContextReturnValue>(
+	{
+		registerShortcut: noop,
+		deregisterShortcut: noop,
+	},
+);
+
+const IGNORE_INPUTS = ['input', 'textarea']; // Inputs in which hotkey events will be ignored
+
+const useKeyboardHotkeys = (): KeyboardHotkeysContextReturnValue => {
+	const context = useContext(KeyboardHotkeysContext);
+	if (!context) {
+		throw new Error(
+			'useKeyboardHotkeys must be used within a KeyboardHotkeysProvider',
+		);
+	}
+
+	return context;
+};
+
+function KeyboardHotkeysProvider({
+	children,
+}: {
+	children: JSX.Element;
+}): JSX.Element {
+	const shortcuts = useRef<Record<string, () => void>>({});
+
+	const handleKeyPress = (event: KeyboardEvent): void => {
+		const { key, ctrlKey, altKey, shiftKey, metaKey, target } = event;
+
+		if (IGNORE_INPUTS.includes((target as HTMLElement).tagName.toLowerCase())) {
+			return;
+		}
+		const modifiers = { ctrlKey, altKey, shiftKey, metaKey };
+		const shortcutKey = `${key}${modifiers.ctrlKey ? '+ctrl' : ''}${
+			modifiers.altKey ? '+alt' : ''
+		}${modifiers.shiftKey ? '+shift' : ''}${modifiers.metaKey ? '+meta' : ''}`;
+
+		if (shortcuts.current[shortcutKey]) {
+			shortcuts.current[shortcutKey]();
+		}
+	};
+
+	useEffect(() => {
+		document.addEventListener('keydown', handleKeyPress);
+		return (): void => {
+			document.removeEventListener('keydown', handleKeyPress);
+		};
+	}, []);
+
+	const registerShortcut = useCallback(
+		(keyCombination: string, callback: () => void): void => {
+			if (!shortcuts.current[keyCombination]) {
+				shortcuts.current[keyCombination] = callback;
+			}
+		},
+		[shortcuts],
+	);
+
+	const deregisterShortcut = useCallback(
+		(keyCombination: string): void => {
+			if (shortcuts.current[keyCombination]) {
+				delete shortcuts.current[keyCombination];
+			}
+		},
+		[shortcuts],
+	);
+
+	const contextValue = useMemo(
+		() => ({
+			registerShortcut,
+			deregisterShortcut,
+		}),
+		[registerShortcut, deregisterShortcut],
+	);
+
+	return (
+		<KeyboardHotkeysContext.Provider value={contextValue}>
+			{children}
+		</KeyboardHotkeysContext.Provider>
+	);
+}
+
+export { KeyboardHotkeysProvider, useKeyboardHotkeys };

--- a/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
+++ b/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
@@ -10,11 +10,17 @@ import {
 
 interface KeyboardHotkeysContextReturnValue {
 	/**
-	 *
 	 * @param keyCombination provide the string for which the subsequent callback should be triggered. Example 'ctrl+a'
 	 * @param callback the callback that should be triggered when the above key combination is being pressed
+	 * @returns void
 	 */
 	registerShortcut: (keyCombination: string, callback: () => void) => void;
+
+	/**
+	 *
+	 * @param keyCombination provide the string for which we want to deregister the callback
+	 * @returns void
+	 */
 	deregisterShortcut: (keyCombination: string) => void;
 }
 
@@ -51,10 +57,18 @@ function KeyboardHotkeysProvider({
 		if (IGNORE_INPUTS.includes((target as HTMLElement).tagName.toLowerCase())) {
 			return;
 		}
+
+		// https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey
 		const modifiers = { ctrlKey, altKey, shiftKey, metaKey };
-		const shortcutKey = `${key.toLowerCase()}${modifiers.ctrlKey ? '+ctrl' : ''}${
-			modifiers.altKey ? '+alt' : ''
-		}${modifiers.shiftKey ? '+shift' : ''}${modifiers.metaKey ? '+meta' : ''}`;
+
+		let shortcutKey = `${key.toLowerCase()}`;
+
+		const isCtrlkey = `${modifiers.ctrlKey ? '+ctrl' : ''}`;
+		const isAltKey = `${modifiers.altKey ? '+alt' : ''}`;
+		const isShiftKey = `${modifiers.shiftKey ? '+shift' : ''}`;
+		const isMetaKey = `${modifiers.metaKey ? '+meta' : ''}`;
+
+		shortcutKey = shortcutKey + isCtrlkey + isAltKey + isShiftKey + isMetaKey;
 
 		if (shortcuts.current[shortcutKey]) {
 			shortcuts.current[shortcutKey]();


### PR DESCRIPTION
### Summary

PRD for the below changes :- https://www.notion.so/signoz/Keyboard-Shortcuts-Framework-309c2b67f3c04ddab316c133ef051df3 

- Setup the base context and the hooks for the usage of `keyboard hotkeys`

Usage in components -> 

Case 1 -> Usage of same shortcut `l` in two components (Services Module and Logs Explorer Module)

`Services Trace Component`
```
const { registerShortcut, deregisterShortcut } = useKeyboardHotkeys();

	useEffect(() => {
		registerShortcut('l', () => {
			console.log('Services Traces Table');
		});

		return (): void => {
			deregisterShortcut('l');
		};
		// eslint-disable-next-line react-hooks/exhaustive-deps
	}, []);
```
`Logs Explorer Component` 

```
const { registerShortcut, deregisterShortcut } = useKeyboardHotkeys();

	useEffect(() => {
		registerShortcut('l', () => {
			console.log('LogsExplorerList');
		});

		return (): void => {
			deregisterShortcut('l');
		};
		// eslint-disable-next-line react-hooks/exhaustive-deps
	}, []);
```
**_Since the components are not present on the screen at the same time no error is thrown and  both are supported as expected_**

Video Reference:- 

- the below video shows example of same shortcut `l` across two different modules not firing together and the input boxes not triggering the shortcut callbacks

https://github.com/SigNoz/signoz/assets/54737045/2f48a5ea-e557-428e-bef1-014ba2870dc4



Case 2 -> Usage of same shortcuts in the same component tree when both are rendered on the screen at same time

`Services Root Component` 

```
	const { registerShortcut, deregisterShortcut } = useKeyboardHotkeys();

	useEffect(() => {
		registerShortcut('l', () => {
			console.log('Services');
		});

		return (): void => {
			deregisterShortcut('l');
		};
		// eslint-disable-next-line react-hooks/exhaustive-deps
	}, []);
```

`Services Trace Table Component`

```
const { registerShortcut, deregisterShortcut } = useKeyboardHotkeys();

	useEffect(() => {
		registerShortcut('l', () => {
			console.log('Duplicate Services Traces Table');
		});

		return (): void => {
			deregisterShortcut('l');
		};
		// eslint-disable-next-line react-hooks/exhaustive-deps
	}, []);
```

**_Now since both of them are present in the screen at the same time we throw an exception and crash the UI at development stage itself so as the dev should be aware of the same._**

Video Reference:- 

https://github.com/SigNoz/signoz/assets/54737045/15282a9b-9360-4e81-9f7e-4bd21e17eb9b


**_Added Implementation of `CMD+B` for `SideNav Collapse and Open`_**

https://github.com/SigNoz/signoz/assets/54737045/ddd85907-44ae-4651-9688-1263d1060dde


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced navigation and usability with hotkey functionality, including shortcuts for sidebar collapse.
- **Tests**
	- Ensured reliable operation and integration with added tests for keyboard shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->