### PR TITLE
fix: chart loading when scrolling logs

### DIFF
--- a/frontend/src/components/Logs/LogLinesActionButtons/LogLinesActionButtons.tsx
+++ b/frontend/src/components/Logs/LogLinesActionButtons/LogLinesActionButtons.tsx
@@ -17,7 +17,7 @@ export default function LogLinesActionButtons({
 }: LogLinesActionButtonsProps): JSX.Element {
 	return (
 		<div className={`log-line-action-buttons ${customClassName}`}>
-			<Tooltip title="Show Context">
+			<Tooltip title="Show in Context">
 				<Button
 					size="small"
 					icon={<TextSelect size={14} />}

--- a/frontend/src/container/LogsExplorerViews/index.tsx
+++ b/frontend/src/container/LogsExplorerViews/index.tsx
@@ -507,12 +507,7 @@ function LogsExplorerViews({
 			{showHistogram && (
 				<LogsExplorerChart
 					className="logs-histogram"
-					isLoading={
-						isFetchingListChartData ||
-						isLoadingListChartData ||
-						isLoading ||
-						isFetching
-					}
+					isLoading={isFetchingListChartData || isLoadingListChartData}
 					data={chartData}
 				/>
 			)}

--- a/frontend/src/pages/LogsExplorer/index.tsx
+++ b/frontend/src/pages/LogsExplorer/index.tsx
@@ -16,7 +16,7 @@ import { WrapperStyled } from './styles';
 
 function LogsExplorer(): JSX.Element {
 	const [showHistogram, setShowHistogram] = useState(true);
-	const [selectedView, setSelectedView] = useState('query-builder');
+	const [selectedView, setSelectedView] = useState('search');
 
 	const { handleRunQuery, currentQuery } = useQueryBuilder();
 


### PR DESCRIPTION
### Summary

- fixed the histogram on logs explorer page went into loading state on scrolling the logs
- made the simple search for QB as the default view
- renamed `Show context` to `Show in Context` 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/9d3b43c6-8f79-45ad-b751-fe979c8a552b



#### Affected Areas and Manually Tested Areas

New logs explorer design page
