### PR TITLE
fix: don't throw error while fetching orgname

### DIFF
--- a/ee/query-service/usage/manager.go
+++ b/ee/query-service/usage/manager.go
@@ -139,17 +139,11 @@ func (lm *Manager) UploadUsage() {
 
 	zap.S().Info("uploading usage data")
 
-	// Try to get the org name
 	orgName := ""
-	orgNames, err := lm.modelDao.GetOrgs(ctx)
-	if err != nil {
-		zap.S().Errorf("failed to get org data: %v", zap.Error(err))
-	} else {
-		if len(orgNames) != 1 {
-			zap.S().Errorf("expected one org but got %d orgs", len(orgNames))
-		} else {
-			orgName = orgNames[0].Name
-		}
+	// fetching orgname will result in error only when org is not set, so ignoring it.
+	orgNames, _ := lm.modelDao.GetOrgs(ctx)
+	if len(orgNames) == 1 {
+		orgName = orgNames[0].Name
 	}
 
 	usagesPayload := []model.Usage{}

--- a/ee/query-service/usage/manager.go
+++ b/ee/query-service/usage/manager.go
@@ -140,8 +140,10 @@ func (lm *Manager) UploadUsage() {
 	zap.S().Info("uploading usage data")
 
 	orgName := ""
-	// fetching orgname will result in error only when org is not set, so ignoring it.
-	orgNames, _ := lm.modelDao.GetOrgs(ctx)
+	orgNames, orgError := lm.modelDao.GetOrgs(ctx)
+	if orgError != nil {
+		zap.S().Errorf("failed to get org data: %v", zap.Error(orgError))
+	}
 	if len(orgNames) == 1 {
 		orgName = orgNames[0].Name
 	}


### PR DESCRIPTION
 if there are no rows it doesn't throw an error but since the err variable was initialized in the same block again with orgNames it caused the error. Have fixed and updated the description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Simplified the logic for retrieving organization names in the usage upload process, enhancing efficiency by reducing error handling complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->