### PR TITLE
fix: query range api not triggering on default select first load

### DIFF
--- a/frontend/src/container/LogExplorerQuerySection/index.tsx
+++ b/frontend/src/container/LogExplorerQuerySection/index.tsx
@@ -14,7 +14,10 @@ import { useGetPanelTypesQueryParam } from 'hooks/queryBuilder/useGetPanelTypesQ
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useQueryOperations } from 'hooks/queryBuilder/useQueryBuilderOperations';
 import { useShareBuilderUrl } from 'hooks/queryBuilder/useShareBuilderUrl';
-import { prepareQueryWithDefaultTimestamp } from 'pages/LogsExplorer/utils';
+import {
+	prepareQueryWithDefaultTimestamp,
+	SELECTED_VIEWS,
+} from 'pages/LogsExplorer/utils';
 import { memo, useCallback, useMemo } from 'react';
 import { IBuilderQuery } from 'types/api/queryBuilder/queryBuilderData';
 import { DataSource } from 'types/common/queryBuilder';
@@ -22,7 +25,7 @@ import { DataSource } from 'types/common/queryBuilder';
 function LogExplorerQuerySection({
 	selectedView,
 }: {
-	selectedView: string;
+	selectedView: SELECTED_VIEWS;
 }): JSX.Element {
 	const { currentQuery, updateAllQueriesOperators } = useQueryBuilder();
 
@@ -84,7 +87,7 @@ function LogExplorerQuerySection({
 
 	return (
 		<>
-			{selectedView === 'search' && (
+			{selectedView === SELECTED_VIEWS.SEARCH && (
 				<div className="qb-search-view-container">
 					<QueryBuilderSearch
 						query={query}
@@ -94,7 +97,7 @@ function LogExplorerQuerySection({
 				</div>
 			)}
 
-			{selectedView === 'query-builder' && (
+			{selectedView === SELECTED_VIEWS.QUERY_BUILDER && (
 				<QueryBuilder
 					panelType={panelTypes}
 					config={{ initialDataSource: DataSource.LOGS, queryVariant: 'static' }}

--- a/frontend/src/container/QueryBuilder/components/ToolbarActions/LeftToolbarActions.tsx
+++ b/frontend/src/container/QueryBuilder/components/ToolbarActions/LeftToolbarActions.tsx
@@ -3,18 +3,18 @@ import './ToolbarActions.styles.scss';
 import { Button, Switch, Typography } from 'antd';
 import cx from 'classnames';
 import { Atom, MousePointerSquare, Terminal } from 'lucide-react';
+import { SELECTED_VIEWS } from 'pages/LogsExplorer/utils';
 
 interface LeftToolbarActionsProps {
 	items: any;
 	selectedView: string;
 	onToggleHistrogramVisibility: () => void;
-	onChangeSelectedView: (view: string) => void;
+	onChangeSelectedView: (view: SELECTED_VIEWS) => void;
 	showHistogram: boolean;
 }
 
 const activeTab = 'active-tab';
 const actionBtn = 'action-btn';
-const queryBuilder = 'query-builder';
 
 export default function LeftToolbarActions({
 	items,
@@ -31,22 +31,22 @@ export default function LeftToolbarActions({
 				<Button
 					disabled={search.disabled}
 					className={cx(
-						'search',
+						SELECTED_VIEWS.SEARCH,
 						actionBtn,
 						selectedView === 'search' ? activeTab : '',
 					)}
-					onClick={(): void => onChangeSelectedView('search')}
+					onClick={(): void => onChangeSelectedView(SELECTED_VIEWS.SEARCH)}
 				>
 					<MousePointerSquare size={14} />
 				</Button>
 				<Button
 					disabled={QB.disabled}
 					className={cx(
-						queryBuilder,
+						SELECTED_VIEWS.QUERY_BUILDER,
 						actionBtn,
-						selectedView === queryBuilder ? activeTab : '',
+						selectedView === SELECTED_VIEWS.QUERY_BUILDER ? activeTab : '',
 					)}
-					onClick={(): void => onChangeSelectedView(queryBuilder)}
+					onClick={(): void => onChangeSelectedView(SELECTED_VIEWS.QUERY_BUILDER)}
 				>
 					<Atom size={14} />
 				</Button>
@@ -55,11 +55,11 @@ export default function LeftToolbarActions({
 					<Button
 						disabled={clickhouse.disabled}
 						className={cx(
-							'clickhouse',
+							SELECTED_VIEWS.CLICKHOUSE,
 							actionBtn,
-							selectedView === 'clickhouse' ? activeTab : '',
+							selectedView === SELECTED_VIEWS.CLICKHOUSE ? activeTab : '',
 						)}
-						onClick={(): void => onChangeSelectedView('clickhouse')}
+						onClick={(): void => onChangeSelectedView(SELECTED_VIEWS.CLICKHOUSE)}
 					>
 						<Terminal size={14} />
 					</Button>

--- a/frontend/src/pages/LogsExplorer/index.tsx
+++ b/frontend/src/pages/LogsExplorer/index.tsx
@@ -13,10 +13,13 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { DataSource } from 'types/common/queryBuilder';
 
 import { WrapperStyled } from './styles';
+import { SELECTED_VIEWS } from './utils';
 
 function LogsExplorer(): JSX.Element {
 	const [showHistogram, setShowHistogram] = useState(true);
-	const [selectedView, setSelectedView] = useState('search');
+	const [selectedView, setSelectedView] = useState<SELECTED_VIEWS>(
+		SELECTED_VIEWS.SEARCH,
+	);
 
 	const { handleRunQuery, currentQuery } = useQueryBuilder();
 
@@ -24,7 +27,7 @@ function LogsExplorer(): JSX.Element {
 		setShowHistogram(!showHistogram);
 	};
 
-	const handleChangeSelectedView = (view: string): void => {
+	const handleChangeSelectedView = (view: SELECTED_VIEWS): void => {
 		setSelectedView(view);
 	};
 

--- a/frontend/src/pages/LogsExplorer/utils.ts
+++ b/frontend/src/pages/LogsExplorer/utils.ts
@@ -10,3 +10,10 @@ export const prepareQueryWithDefaultTimestamp = (query: Query): Query => ({
 		})),
 	},
 });
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export enum SELECTED_VIEWS {
+	SEARCH = 'search',
+	QUERY_BUILDER = 'query-builder',
+	CLICKHOUSE = 'clickhouse',
+}


### PR DESCRIPTION
### Summary

- query range api not triggering on default first load

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/ccc9f70a-5474-443e-b924-e6b64eb99c73





#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
