### PR TITLE
fix: update the extend trial from default mailto client to notification panel

### DIFF
--- a/frontend/src/pages/WorkspaceLocked/WorkspaceLocked.tsx
+++ b/frontend/src/pages/WorkspaceLocked/WorkspaceLocked.tsx
@@ -87,21 +87,18 @@ export default function WorkspaceBlocked(): JSX.Element {
 	const handleExtendTrial = (): void => {
 		trackEvent('Workspace Blocked: User Clicked Extend Trial');
 
-		const recipient = 'cloud-support@signoz.io';
-		const subject = 'Extend SigNoz Cloud Trial';
-		const body = `I'd like to request an extension for SigNoz Cloud for my account. Please find my account details below
-		
-		SigNoz URL: 
-		Admin Email:
-		`;
-
-		// Create the mailto link
-		const mailtoLink = `mailto:${recipient}?subject=${encodeURIComponent(
-			subject,
-		)}&body=${encodeURIComponent(body)}`;
-
-		// Open the default email client
-		window.location.href = mailtoLink;
+		notifications.info({
+			message: 'Extend Trial',
+			description: (
+				<Typography>
+					If you have a specific reason why you were not able to finish your PoC in
+					the trial period, please write to us on
+					<a href="mailto:cloud-support@signoz.io"> cloud-support@signoz.io </a>
+					with the reason. Sometimes we can extend trial by a few days on a case by
+					case basis
+				</Typography>
+			),
+		});
 	};
 
 	return (
@@ -152,7 +149,7 @@ export default function WorkspaceBlocked(): JSX.Element {
 						<div className="contact-us">
 							Got Questions?
 							<span>
-								<a href="mailto:support@signoz.io"> Contact Us </a>
+								<a href="mailto:cloud-support@signoz.io"> Contact Us </a>
 							</span>
 						</div>
 					</>


### PR DESCRIPTION
### Summary

- update the extended trial button from default `mailTo` client to notification panel

#### Related Issues / PR's

https://github.com/SigNoz/engineering-pod/issues/1201

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/0555096e-0889-4bf8-aee0-5f24c4671ebe



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the Workspace Locked page to include instructions for requesting a trial period extension via email, enhancing user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->