### PR TITLE
chore: send non monotonic Sum as Gauge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -203,4 +203,4 @@ require (
 	k8s.io/utils v0.0.0-20230711102312-30195339c3c7 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/SigNoz/prometheus v1.9.78
+replace github.com/prometheus/prometheus => github.com/SigNoz/prometheus v1.9.77-update

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/SigNoz/govaluate v0.0.0-20240203125216-988004ccc7fd h1:Bk43AsDYe0fhkbj57eGXx8H3ZJ4zhmQXBnrW523ktj8=
 github.com/SigNoz/govaluate v0.0.0-20240203125216-988004ccc7fd/go.mod h1:nxRcH/OEdM8QxzH37xkGzomr1O0JpYBRS6pwjsWW6Pc=
-github.com/SigNoz/prometheus v1.9.78 h1:bB3yuDrRzi/Mv00kWayR9DZbyjTuGfendSqISyDcXiY=
-github.com/SigNoz/prometheus v1.9.78/go.mod h1:MffmFu2qFILQrOHehx3D0XjYtaZMVfI+Ppeiv98x4Ww=
+github.com/SigNoz/prometheus v1.9.77-update h1:s6oM3tVzLHTYeuPh+ew3T61tbwZWpbSz/ZH0dnSphhY=
+github.com/SigNoz/prometheus v1.9.77-update/go.mod h1:MffmFu2qFILQrOHehx3D0XjYtaZMVfI+Ppeiv98x4Ww=
 github.com/SigNoz/signoz-otel-collector v0.88.9 h1:7bbJSXrSZcQsdEVVLsjsNXm/bWe9MhKu8qfXp8MlXQM=
 github.com/SigNoz/signoz-otel-collector v0.88.9/go.mod h1:7I4FWwraVSnDywsPNbo8TdHDsPxShtYkGU5usr6dTtk=
 github.com/SigNoz/zap_otlp v0.1.0 h1:T7rRcFN87GavY8lDGZj0Z3Xv6OhJA6Pj3I9dNPmqvRc=

--- a/pkg/query-service/common/metrics.go
+++ b/pkg/query-service/common/metrics.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"math"
+	"time"
 
 	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
 )
@@ -16,4 +17,10 @@ func AdjustedMetricTimeRange(start, end, step int64, aggregaOperator v3.TimeAggr
 	adjustStep := int64(math.Min(float64(step), 60))
 	end = end - (end % (adjustStep * 1000))
 	return start, end
+}
+
+func PastDayRoundOff() int64 {
+	now := time.Now().UnixMilli()
+	pastDay := now - (now % (time.Hour.Milliseconds() * 24))
+	return pastDay
 }


### PR DESCRIPTION
### Summary

1. Update version https://github.com/SigNoz/prometheus/pull/24

2. Send non-monotonic sums as gauges, Sum + Monotonic = Counter, Sum + Non-Monotonic = Gauge

3. Return attribute keys and values from the past 1 day for auto-complete. Let's see if users really need old suggestions. If the complain, we will change it.  