### PR TITLE
fix: button border color for tab in log explorer

### DIFF
--- a/frontend/src/pages/LogsModulePage/LogsModulePage.styles.scss
+++ b/frontend/src/pages/LogsModulePage/LogsModulePage.styles.scss
@@ -21,3 +21,13 @@
 		gap: 8px;
 	}
 }
+
+.lightMode {
+	.logs-module-container {
+		.ant-tabs-nav {
+			&::before {
+				border-bottom: 1px solid var(--bg-vanilla-300) !important;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Before
<img width="1680" alt="Screenshot 2024-02-13 at 7 10 52 PM" src="https://github.com/SigNoz/signoz/assets/26198062/f4c9dc07-15f7-42cd-8591-1ee1fe9e5aae">

After: 
<img width="1679" alt="Screenshot 2024-02-13 at 7 11 00 PM" src="https://github.com/SigNoz/signoz/assets/26198062/8e701522-2f02-46df-86c7-6ac975f11b07">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Introduced a new light mode style for the logs module page for enhanced visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->