### PR TITLE
fix: no views leading to frontend crash

### DIFF
--- a/frontend/src/container/ExplorerOptions/ExplorerOptions.tsx
+++ b/frontend/src/container/ExplorerOptions/ExplorerOptions.tsx
@@ -107,7 +107,7 @@ function ExplorerOptions({
 	const viewName = useGetSearchQueryParam(QueryParams.viewName) || '';
 	const viewKey = useGetSearchQueryParam(QueryParams.viewKey) || '';
 
-	const extraData = viewsData?.data.data.find((view) => view.uuid === viewKey)
+	const extraData = viewsData?.data?.data?.find((view) => view.uuid === viewKey)
 		?.extraData;
 
 	const extraDataColor = extraData ? JSON.parse(extraData).color : '';
@@ -134,7 +134,7 @@ function ExplorerOptions({
 	};
 
 	const onUpdateQueryHandler = (): void => {
-		const extraData = viewsData?.data.data.find((view) => view.uuid === viewKey)
+		const extraData = viewsData?.data?.data?.find((view) => view.uuid === viewKey)
 			?.extraData;
 		updateViewAsync(
 			{
@@ -166,7 +166,7 @@ function ExplorerOptions({
 		({ key }: { key: string }): void => {
 			const currentViewDetails = getViewDetailsUsingViewKey(
 				key,
-				viewsData?.data.data,
+				viewsData?.data?.data,
 			);
 			if (!currentViewDetails) return;
 			const {
@@ -296,7 +296,7 @@ function ExplorerOptions({
 						onClear={handleClearSelect}
 						ref={ref}
 					>
-						{viewsData?.data.data.map((view) => {
+						{viewsData?.data?.data?.map((view) => {
 							const extraData =
 								view.extraData !== '' ? JSON.parse(view.extraData) : '';
 							let bgColor = getRandomColor();


### PR DESCRIPTION
If views data is not present, it crashes.

This PR fixes this issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the Explorer Options to prevent crashes due to missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->