### PR TITLE
fix: relative time preferences not respected

### DIFF
--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -220,6 +220,8 @@ function DateTimeSelection({
 			if (isObject(parsedSelectedTime)) {
 				return 'custom';
 			}
+
+			return selectedTime;
 		}
 
 		return defaultSelectedOption;


### PR DESCRIPTION
### Summary

- the selected relative time preferences were not respected in the new designs
- Return statement was removed in some rebase 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/fb1b955e-1b41-47c8-8e9d-703ddfab6b7a



#### Affected Areas and Manually Tested Areas

- Relative times preference working as expected
- Custom times preferences working as expected and is unique for pages
