### PR TITLE
fix: added missing updated time on first load for back navigation

### DIFF
--- a/frontend/src/container/TopNav/DateTimeSelection/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelection/index.tsx
@@ -258,7 +258,6 @@ function DateTimeSelection({
 	};
 
 	const onCustomDateHandler = (dateTimeRange: DateTimeRangeType): void => {
-		console.log('dateTimeRange', dateTimeRange);
 		if (dateTimeRange !== null) {
 			const [startTimeMoment, endTimeMoment] = dateTimeRange;
 			if (startTimeMoment && endTimeMoment) {

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -211,17 +211,19 @@ function DateTimeSelection({
 			const routesObject = JSON.parse(routes || '{}');
 			const selectedTime = routesObject[pathName];
 
-			let parsedSelectedTime: TimeRange;
-			try {
-				parsedSelectedTime = JSON.parse(selectedTime);
-			} catch {
-				parsedSelectedTime = selectedTime;
-			}
-			if (isObject(parsedSelectedTime)) {
-				return 'custom';
-			}
+			if (selectedTime) {
+				let parsedSelectedTime: TimeRange;
+				try {
+					parsedSelectedTime = JSON.parse(selectedTime);
+				} catch {
+					parsedSelectedTime = selectedTime;
+				}
+				if (isObject(parsedSelectedTime)) {
+					return 'custom';
+				}
 
-			return selectedTime;
+				return selectedTime;
+			}
 		}
 
 		return defaultSelectedOption;
@@ -382,6 +384,17 @@ function DateTimeSelection({
 		setRefreshButtonHidden(updatedTime === 'custom');
 
 		updateTimeInterval(updatedTime, [preStartTime, preEndTime]);
+
+		if (updatedTime !== 'custom') {
+			const { minTime, maxTime } = GetMinMax(updatedTime);
+			urlQuery.set(QueryParams.startTime, minTime.toString());
+			urlQuery.set(QueryParams.endTime, maxTime.toString());
+		} else {
+			urlQuery.set(QueryParams.startTime, preStartTime.toString());
+			urlQuery.set(QueryParams.endTime, preEndTime.toString());
+		}
+		const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
+		history.replace(generatedUrl);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [location.pathname, updateTimeInterval, globalTimeLoading]);
 

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -335,8 +335,14 @@ function DateTimeSelection({
 				);
 
 				if (!isLogsExplorerPage) {
-					urlQuery.set(QueryParams.startTime, startTimeMoment.toString());
-					urlQuery.set(QueryParams.endTime, endTimeMoment.toString());
+					urlQuery.set(
+						QueryParams.startTime,
+						startTimeMoment?.toDate().getTime().toString(),
+					);
+					urlQuery.set(
+						QueryParams.endTime,
+						endTimeMoment?.toDate().getTime().toString(),
+					);
 					const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
 					history.replace(generatedUrl);
 				}


### PR DESCRIPTION
### Summary

- the url update of time on first load of component added in the new designs.
- this helps the user navigate through back btns and retrieve the state 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/5dd0a59d-dd2f-41c8-bfac-27a263486dfc



#### Affected Areas and Manually Tested Areas

- Tested the pages where graph is present and the back navigation works as expected.
- Tested the earlier issues of trace filters when back navigation support was added 
