### PR TITLE
fix: qb search not respecting the saved views panel type

### DIFF
--- a/frontend/src/container/LogsExplorerViews/index.tsx
+++ b/frontend/src/container/LogsExplorerViews/index.tsx
@@ -395,7 +395,7 @@ function LogsExplorerViews({
 			handleSetConfig(defaultTo(panelTypes, PANEL_TYPES.LIST), DataSource.LOGS);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [handleSetConfig, panelTypes]);
 
 	useEffect(() => {
 		const currentParams = data?.params as Omit<LogTimeRange, 'pageSize'>;


### PR DESCRIPTION
### Summary

- URL listener for panel type was missing which caused async state between QB panel type / URL panel type / selectedPanelType (local state) 
- only happening with search as the QB advanced had manual setConfig which takes care of sync states

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the responsiveness of the Logs Explorer by updating dependencies in a key component to ensure it reacts to configuration and panel type changes more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->