### PR TITLE
fix: change the order of local and distributed table

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -3665,7 +3665,7 @@ func (r *ClickHouseReader) UpdateLogField(ctx context.Context, field *model.Upda
 			return &model.ApiError{Err: err, Typ: model.ErrorInternal}
 		}
 
-		for _, table := range []string{r.logsLocalTable, r.logsTable} {
+		for _, table := range []string{r.logsTable, r.logsLocalTable} {
 			// drop materialized column from logs table
 			query := "ALTER TABLE %s.%s ON CLUSTER %s DROP COLUMN IF EXISTS %s "
 			err := r.db.Exec(ctx, fmt.Sprintf(query,


### PR DESCRIPTION
### Summary

When we remove the column, the order of the removal should distributed table first and then the local table. Here is how the local first and distributed second could go wrong

1. Column is removed from the local table.
2. The write from the exporter triggers an insert into the distributed table
3. The distributed table creates a `.bin` with the relevant schema to send the data to each shard.
4. Column is removed from the distributed table

As we can see from the above sequence of steps, the `.bin` files are now inconsistent because they were created after local table column removal and before the distributed table.

Part of https://github.com/SigNoz/engineering-pod/issues/1204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the efficiency of log field updates by adjusting the processing order of tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->