### PR TITLE
fix: address gaps in alert to notification link

### DIFF
--- a/frontend/src/container/CreateAlertChannels/index.tsx
+++ b/frontend/src/container/CreateAlertChannels/index.tsx
@@ -50,6 +50,8 @@ function CreateAlertChannels({
 
      *Summary:* {{ .Annotations.summary }}
      *Description:* {{ .Annotations.description }}
+     *RelatedLogs:* {{ .Annotations.related_logs }}
+     *RelatedTraces:* {{ .Annotations.related_traces }}
 
      *Details:*
        {{ range .Labels.SortedPairs }} • *{{ .Name }}:* {{ .Value }}

--- a/pkg/query-service/rules/alerting.go
+++ b/pkg/query-service/rules/alerting.go
@@ -225,7 +225,7 @@ func prepareRuleGeneratorURL(ruleId string, source string) string {
 	}
 
 	// check if source is a valid url
-	_, err := url.Parse(source)
+	parsedSource, err := url.Parse(source)
 	if err != nil {
 		return ""
 	}
@@ -239,5 +239,12 @@ func prepareRuleGeneratorURL(ruleId string, source string) string {
 		return ruleURL
 	}
 
-	return source
+	// The source contains the encoded query, start and end time
+	// and other parameters. We don't want to include them in the generator URL
+	// mainly to keep the URL short and lower the alert body contents
+	// The generator URL with /alerts/edit?ruleId= is enough
+	if parsedSource.Port() != "" {
+		return fmt.Sprintf("%s://%s:%s/alerts/edit?ruleId=%s", parsedSource.Scheme, parsedSource.Hostname(), parsedSource.Port(), ruleId)
+	}
+	return fmt.Sprintf("%s://%s/alerts/edit?ruleId=%s", parsedSource.Scheme, parsedSource.Hostname(), ruleId)
 }

--- a/pkg/query-service/rules/resultTypes.go
+++ b/pkg/query-service/rules/resultTypes.go
@@ -16,6 +16,10 @@ type Sample struct {
 	Point
 
 	Metric labels.Labels
+
+	// Label keys as-is from the result query.
+	// The original labels are used to prepare the related{logs, traces} link in alert notification
+	MetricOrig labels.Labels
 }
 
 func (s Sample) String() string {


### PR DESCRIPTION
### Summary

This PR addresses some gaps found in the alert notification to the explorer link.

- The double encoding is no longer needed (implementation changed with new design changes). @YounixM I hope this remains unchanged going forward.
- Keep the original label format for where clause preparation
- Move the links from labels to annotations. The main difference is labels is used for grouping and we want to group alerts with the same label set, but different timestamps, together
- Fix the source link (messaging tools truncate the lengthy contents).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the "Create Alert Channels" interface to include related logs and traces information.
	- Improved alert notification content by including original metric labels for creating related links.
- **Refactor**
	- Optimized URL construction in alerting rules to exclude unnecessary query parameters, ensuring concise generator URLs.
	- Adjusted handling of labels in alert rules to support both original and normalized labels for enhanced compatibility and link generation in notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->