### PR TITLE
fix: redirect old logs routes to new routes

### DIFF
--- a/frontend/src/AppRoutes/Private.tsx
+++ b/frontend/src/AppRoutes/Private.tsx
@@ -20,11 +20,16 @@ import { UPDATE_USER_IS_FETCH } from 'types/actions/app';
 import AppReducer from 'types/reducer/app';
 import { routePermission } from 'utils/permission';
 
-import routes, { LIST_LICENSES } from './routes';
+import routes, {
+	LIST_LICENSES,
+	oldNewRoutesMapping,
+	oldRoutes,
+} from './routes';
 import afterLogin from './utils';
 
 function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
-	const { pathname } = useLocation();
+	const location = useLocation();
+	const { pathname } = location;
 
 	const mapRoutes = useMemo(
 		() =>
@@ -58,6 +63,8 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 	const { notifications } = useNotifications();
 
 	const currentRoute = mapRoutes.get('current');
+
+	const isOldRoute = oldRoutes.indexOf(pathname) > -1;
 
 	const isLocalStorageLoggedIn =
 		getLocalStorageApi(LOCALSTORAGE.IS_LOGGED_IN) === 'true';
@@ -158,6 +165,16 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 	useEffect(() => {
 		(async (): Promise<void> => {
 			try {
+				if (isOldRoute) {
+					const redirectUrl = oldNewRoutesMapping[pathname];
+
+					const newLocation = {
+						...location,
+						pathname: redirectUrl,
+					};
+					history.replace(newLocation);
+				}
+
 				if (currentRoute) {
 					const { isPrivate, key } = currentRoute;
 

--- a/frontend/src/AppRoutes/routes.ts
+++ b/frontend/src/AppRoutes/routes.ts
@@ -280,6 +280,13 @@ const routes: AppRoutes[] = [
 		isPrivate: true,
 	},
 	{
+		path: ROUTES.LOGS_PIPELINES,
+		exact: true,
+		component: PipelinePage,
+		key: 'LOGS_PIPELINES',
+		isPrivate: true,
+	},
+	{
 		path: ROUTES.LOGIN,
 		exact: true,
 		component: Login,
@@ -306,13 +313,6 @@ const routes: AppRoutes[] = [
 		component: SomethingWentWrong,
 		key: 'SOMETHING_WENT_WRONG',
 		isPrivate: false,
-	},
-	{
-		path: ROUTES.LOGS_PIPELINES,
-		exact: true,
-		component: PipelinePage,
-		key: 'LOGS_PIPELINES',
-		isPrivate: true,
 	},
 	{
 		path: ROUTES.BILLING,
@@ -351,6 +351,20 @@ export const LIST_LICENSES: AppRoutes = {
 	component: LicensePage,
 	isPrivate: true,
 	key: 'LIST_LICENSES',
+};
+
+export const oldRoutes = [
+	'/pipelines',
+	'/logs/old-logs-explorer',
+	'/logs-explorer',
+	'/logs-explorer/live',
+];
+
+export const oldNewRoutesMapping: Record<string, string> = {
+	'/pipelines': '/logs/pipelines',
+	'/logs/old-logs-explorer': '/logs/old-logs-explorer',
+	'/logs-explorer': '/logs/logs-explorer',
+	'/logs-explorer/live': '/logs/logs-explorer/live',
 };
 
 export interface AppRoutes {


### PR DESCRIPTION
redirect old logs routes to new routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new route for pipeline logs, enhancing navigation and access to pipeline-related information.
- **Refactor**
	- Improved route handling to support redirection from old to new routes, ensuring a seamless user experience during navigation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->