### PR TITLE
fix: date time value initialising to start of day in case of typing

### DIFF
--- a/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
@@ -5,6 +5,7 @@ import cx from 'classnames';
 import ROUTES from 'constants/routes';
 import { DateTimeRangeType } from 'container/TopNav/CustomDateTimeModal';
 import {
+	LexicalContext,
 	Option,
 	RelativeDurationSuggestionOptions,
 } from 'container/TopNav/DateTimeSelectionV2/config';
@@ -20,7 +21,10 @@ interface CustomTimePickerPopoverContentProps {
 	setIsOpen: Dispatch<SetStateAction<boolean>>;
 	customDateTimeVisible: boolean;
 	setCustomDTPickerVisible: Dispatch<SetStateAction<boolean>>;
-	onCustomDateHandler: (dateTimeRange: DateTimeRangeType) => void;
+	onCustomDateHandler: (
+		dateTimeRange: DateTimeRangeType,
+		lexicalContext?: LexicalContext,
+	) => void;
 	onSelectHandler: (label: string, value: string) => void;
 	handleGoLive: () => void;
 	selectedTime: string;
@@ -63,7 +67,7 @@ function CustomTimePickerPopoverContent({
 		if (date_time?.[1]) {
 			onPopoverClose(false);
 		}
-		onCustomDateHandler(date_time);
+		onCustomDateHandler(date_time, LexicalContext.CUSTOM_DATE_PICKER);
 	};
 	function getTimeChips(options: Option[]): JSX.Element {
 		return (

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/config.ts
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/config.ts
@@ -148,3 +148,8 @@ export interface TimeRange {
 	startTime: string;
 	endTime: string;
 }
+
+export enum LexicalContext {
+	CUSTOM_DATE_PICKER = 'customDatePicker',
+	CUSTOM_DATE_TIME_INPUT = 'customDateTimeInput',
+}

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -44,6 +44,7 @@ import { DateTimeRangeType } from '../CustomDateTimeModal';
 import {
 	getDefaultOption,
 	getOptions,
+	LexicalContext,
 	LocalStorageTimeRange,
 	Time,
 	TimeRange,
@@ -318,31 +319,37 @@ function DateTimeSelection({
 		onLastRefreshHandler();
 	};
 
-	const onCustomDateHandler = (dateTimeRange: DateTimeRangeType): void => {
+	const onCustomDateHandler = (
+		dateTimeRange: DateTimeRangeType,
+		lexicalContext?: LexicalContext,
+	): void => {
 		if (dateTimeRange !== null) {
 			const [startTimeMoment, endTimeMoment] = dateTimeRange;
 			if (startTimeMoment && endTimeMoment) {
+				let startTime = startTimeMoment;
+				let endTime = endTimeMoment;
+				if (
+					lexicalContext &&
+					lexicalContext === LexicalContext.CUSTOM_DATE_PICKER
+				) {
+					startTime = startTime.startOf('day');
+					endTime = endTime.endOf('day');
+				}
 				setCustomDTPickerVisible(false);
-				startTimeMoment.startOf('day').toString();
 				updateTimeInterval('custom', [
-					startTimeMoment.startOf('day').toDate().getTime(),
-					endTimeMoment.endOf('day').toDate().getTime(),
+					startTime.toDate().getTime(),
+					endTime.toDate().getTime(),
 				]);
-				setLocalStorageKey('startTime', startTimeMoment.toString());
-				setLocalStorageKey('endTime', endTimeMoment.toString());
-				updateLocalStorageForRoutes(
-					JSON.stringify({ startTime: startTimeMoment, endTime: endTimeMoment }),
-				);
+				setLocalStorageKey('startTime', startTime.toString());
+				setLocalStorageKey('endTime', endTime.toString());
+				updateLocalStorageForRoutes(JSON.stringify({ startTime, endTime }));
 
 				if (!isLogsExplorerPage) {
 					urlQuery.set(
 						QueryParams.startTime,
-						startTimeMoment?.toDate().getTime().toString(),
+						startTime?.toDate().getTime().toString(),
 					);
-					urlQuery.set(
-						QueryParams.endTime,
-						endTimeMoment?.toDate().getTime().toString(),
-					);
+					urlQuery.set(QueryParams.endTime, endTime?.toDate().getTime().toString());
 					const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
 					history.replace(generatedUrl);
 				}


### PR DESCRIPTION
### Summary

- Added `lexical context` inside the custom date time handler to handle typing and calendar select dates separately 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PRs where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/84449ef5-fd30-4ea6-af0d-ca7b7e2d9cb4



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the date and time selection feature to adjust start and end times based on user context, improving usability and precision in time selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->