### PR TITLE
fix: traceID link not opening from log details page

### DIFF
--- a/frontend/src/container/LogDetailedView/TableView.tsx
+++ b/frontend/src/container/LogDetailedView/TableView.tsx
@@ -105,7 +105,7 @@ function TableView({
 	const onTraceHandler = (
 		record: DataType,
 		event: React.MouseEvent<HTMLDivElement, MouseEvent>,
-	) => (): void => {
+	): void => {
 		if (flattenLogData === null) return;
 
 		const traceId = flattenLogData[record.field];


### PR DESCRIPTION
### Summary

- Click on Trace ID in the logs details page not opening the traces page
- the onClick event was returning another function instead of running the logic

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PRs where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/aa80f630-0ddf-4109-b914-8461ac9c5e8d



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted the function signature for improved clarity in the log detailed view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->