### PR TITLE
fix: [SIG-528]: precommit typescript check for md files

### DIFF
--- a/frontend/scripts/typecheck-staged.sh
+++ b/frontend/scripts/typecheck-staged.sh
@@ -9,7 +9,7 @@ done
 # create temporary tsconfig which includes only passed files
 str="{
   \"extends\": \"./tsconfig.json\",
-  \"include\": [\"src/types/global.d.ts\",\"src/typings/window.ts\", \"src/typings/chartjs-adapter-date-fns.d.ts\", \"src/typings/environment.ts\" ,$files]
+  \"include\": [\"src/types/global.d.ts\",\"src/typings/window.ts\", \"src/typings/chartjs-adapter-date-fns.d.ts\", \"src/typings/environment.ts\" ,\"src/container/OnboardingContainer/typings.d.ts\",$files]
 }"
 echo $str > tsconfig.tmp
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,11 +11,7 @@
 		"esModuleInterop": true,
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
-		"lib": [
-			"dom",
-			"dom.iterable",
-			"esnext"
-		],
+		"lib": ["dom", "dom.iterable", "esnext"],
 		"allowSyntheticDefaultImports": true,
 		"noFallthroughCasesInSwitch": true,
 		"moduleResolution": "node",
@@ -24,9 +20,7 @@
 		"noEmit": true,
 		"baseUrl": "./src",
 		"paths": {
-			"@constants/*": [
-				"/container/OnboardingContainer/constants/*"
-			]
+			"@constants/*": ["/container/OnboardingContainer/constants/*"]
 		},
 		"downlevelIteration": true,
 		"plugins": [
@@ -34,15 +28,9 @@
 				"name": "typescript-plugin-css-modules"
 			}
 		],
-		"types": [
-			"node",
-			"jest"
-		],
+		"types": ["node", "jest"]
 	},
-	"exclude": [
-		"node_modules",
-		"./src/container/OnboardingContainer/constants/*.ts"
-	],
+	"exclude": ["node_modules"],
 	"include": [
 		"./src",
 		"./src/**/*.ts",


### PR DESCRIPTION
### Summary

- the type declarations of the `**.md` files were not added in the tmp `tsconfig` files, causing it to fail for onboarding containers


#### Related Issues / PR's

[#SIG-528](https://linear.app/signoz-io/issue/SIG-528/fix-the-typescript-issue-in-local-script)



#### Screenshots

**_BEFORE_**

https://github.com/SigNoz/signoz/assets/54737045/ceae52e1-3431-4967-a375-f79c96908801


**_AFTER_**

https://github.com/SigNoz/signoz/assets/54737045/1871f13d-cdb3-4171-8794-0a3716b27134


#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved type checking by including a new definitions file in the temporary TypeScript configuration setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->