### PR TITLE
fix: default version to v4 if version param not present in url params

### DIFF
--- a/frontend/src/container/CreateAlertRule/index.tsx
+++ b/frontend/src/container/CreateAlertRule/index.tsx
@@ -44,7 +44,7 @@ function CreateRules(): JSX.Element {
 			default:
 				setInitValues({
 					...alertDefaults,
-					version: version || 'v3',
+					version: version || 'v4',
 				});
 		}
 	};


### PR DESCRIPTION
fix: default version to v4 if version param not present in url params