### PR TITLE
fix: [SIG-532]: Copy Log Link Functionality for new designs

### DIFF
--- a/frontend/src/components/Logs/ListLogView/index.tsx
+++ b/frontend/src/components/Logs/ListLogView/index.tsx
@@ -9,6 +9,7 @@ import dayjs from 'dayjs';
 import dompurify from 'dompurify';
 import { useActiveLog } from 'hooks/logs/useActiveLog';
 import { useCopyLogLink } from 'hooks/logs/useCopyLogLink';
+import { useIsDarkMode } from 'hooks/useDarkMode';
 // utils
 import { FlatLogData } from 'lib/logs/flatLogData';
 import { useCallback, useMemo, useState } from 'react';
@@ -114,6 +115,8 @@ function ListLogView({
 		onClearActiveLog: handleClearActiveContextLog,
 	} = useActiveLog();
 
+	const isDarkMode = useIsDarkMode();
+
 	const handlerClearActiveContextLog = useCallback(
 		(event: React.MouseEvent | React.KeyboardEvent) => {
 			event.preventDefault();
@@ -163,6 +166,7 @@ function ListLogView({
 		<>
 			<Container
 				$isActiveLog={isHighlighted}
+				$isDarkMode={isDarkMode}
 				onMouseEnter={handleMouseEnter}
 				onMouseLeave={handleMouseLeave}
 				onClick={handleDetailedView}

--- a/frontend/src/components/Logs/ListLogView/styles.ts
+++ b/frontend/src/components/Logs/ListLogView/styles.ts
@@ -15,7 +15,7 @@ export const Container = styled(Card)<{
 		${({ $isActiveLog, $isDarkMode }): string =>
 			$isActiveLog
 				? `background-color: ${
-						$isDarkMode ? Color.BG_SLATE_500 : Color.BG_VANILLA_400
+						$isDarkMode ? Color.BG_SLATE_500 : Color.BG_VANILLA_300
 				  } !important`
 				: ''}
 	}

--- a/frontend/src/components/Logs/ListLogView/styles.ts
+++ b/frontend/src/components/Logs/ListLogView/styles.ts
@@ -1,18 +1,24 @@
+import { Color } from '@signozhq/design-tokens';
 import { Card, Typography } from 'antd';
 import styled from 'styled-components';
-import { getActiveLogBackground } from 'utils/logs';
 
 export const Container = styled(Card)<{
 	$isActiveLog: boolean;
+	$isDarkMode: boolean;
 }>`
 	width: 100% !important;
 	margin-bottom: 0.3rem;
 	cursor: pointer;
 	.ant-card-body {
 		padding: 0.3rem 0.6rem;
-	}
 
-	${({ $isActiveLog }): string => getActiveLogBackground($isActiveLog)}
+		${({ $isActiveLog, $isDarkMode }): string =>
+			$isActiveLog
+				? `background-color: ${
+						$isDarkMode ? Color.BG_SLATE_500 : Color.BG_VANILLA_400
+				  } !important`
+				: ''}
+	}
 `;
 
 export const Text = styled(Typography.Text)`

--- a/frontend/src/components/Logs/RawLogView/styles.ts
+++ b/frontend/src/components/Logs/RawLogView/styles.ts
@@ -30,6 +30,13 @@ export const RawLogViewContainer = styled(Row)<{
 		$isActiveLog
 			? getActiveLogBackground($isActiveLog, $isDarkMode)
 			: getDefaultLogBackground($isReadOnly, $isDarkMode)}
+
+	${({ $isHightlightedLog, $isDarkMode }): string =>
+		$isHightlightedLog
+			? `background-color: ${
+					$isDarkMode ? Color.BG_SLATE_500 : Color.BG_VANILLA_400
+			  }`
+			: ''}
 `;
 
 export const ExpandIconWrapper = styled(Col)`

--- a/frontend/src/components/Logs/RawLogView/styles.ts
+++ b/frontend/src/components/Logs/RawLogView/styles.ts
@@ -34,8 +34,9 @@ export const RawLogViewContainer = styled(Row)<{
 	${({ $isHightlightedLog, $isDarkMode }): string =>
 		$isHightlightedLog
 			? `background-color: ${
-					$isDarkMode ? Color.BG_SLATE_500 : Color.BG_VANILLA_400
-			  }`
+					$isDarkMode ? Color.BG_SLATE_500 : Color.BG_VANILLA_300
+			  };
+			  transition: background-color 2s ease-in;`
 			: ''}
 `;
 

--- a/frontend/src/components/Logs/TableView/types.ts
+++ b/frontend/src/components/Logs/TableView/types.ts
@@ -23,6 +23,7 @@ export type UseTableViewProps = {
 	onOpenLogsContext?: (log: ILog) => void;
 	onClickExpand?: (log: ILog) => void;
 	activeLog?: ILog | null;
+	activeLogIndex?: number;
 	activeContextLog?: ILog | null;
 	isListViewPanel?: boolean;
 } & LogsTableViewProps;

--- a/frontend/src/container/LiveLogs/LiveLogsList/index.tsx
+++ b/frontend/src/container/LiveLogs/LiveLogsList/index.tsx
@@ -122,12 +122,14 @@ function LiveLogsList({ logs }: LiveLogsListProps): JSX.Element {
 								fields: selectedFields,
 								linesPerRow: options.maxLines,
 								appendTo: 'end',
+								activeLogIndex,
 							}}
 						/>
 					) : (
 						<Card style={{ width: '100%' }} bodyStyle={CARD_BODY_STYLE}>
 							<Virtuoso
 								ref={ref}
+								initialTopMostItemIndex={activeLogIndex !== -1 ? activeLogIndex : 0}
 								data={logs}
 								totalCount={logs.length}
 								itemContent={getItemContent}

--- a/frontend/src/container/LogsExplorerList/InfinityTableView/index.tsx
+++ b/frontend/src/container/LogsExplorerList/InfinityTableView/index.tsx
@@ -134,6 +134,9 @@ const InfinityTable = forwardRef<TableVirtuosoHandle, InfinityTableProps>(
 			<>
 				<TableVirtuoso
 					ref={ref}
+					initialTopMostItemIndex={
+						tableViewProps.activeLogIndex !== -1 ? tableViewProps.activeLogIndex : 0
+					}
 					style={infinityDefaultStyles}
 					data={dataSource}
 					components={{

--- a/frontend/src/container/LogsExplorerList/InfinityTableView/styles.ts
+++ b/frontend/src/container/LogsExplorerList/InfinityTableView/styles.ts
@@ -31,7 +31,7 @@ export const TableRowStyled = styled.tr<{
 		${({ $isActiveLog, $isDarkMode }): string =>
 			$isActiveLog
 				? `background-color: ${
-						$isDarkMode ? Color.BG_SLATE_500 : Color.BG_VANILLA_400
+						$isDarkMode ? Color.BG_SLATE_500 : Color.BG_VANILLA_300
 				  } !important`
 				: ''}
 	}

--- a/frontend/src/container/LogsExplorerList/InfinityTableView/styles.ts
+++ b/frontend/src/container/LogsExplorerList/InfinityTableView/styles.ts
@@ -1,3 +1,4 @@
+import { Color } from '@signozhq/design-tokens';
 import { themeColors } from 'constants/theme';
 import styled from 'styled-components';
 import { getActiveLogBackground } from 'utils/logs';
@@ -27,7 +28,12 @@ export const TableRowStyled = styled.tr<{
 	$isDarkMode: boolean;
 }>`
 	td {
-		${({ $isActiveLog }): string => getActiveLogBackground($isActiveLog)}
+		${({ $isActiveLog, $isDarkMode }): string =>
+			$isActiveLog
+				? `background-color: ${
+						$isDarkMode ? Color.BG_SLATE_500 : Color.BG_VANILLA_400
+				  } !important`
+				: ''}
 	}
 
 	cursor: pointer;

--- a/frontend/src/container/LogsExplorerList/index.tsx
+++ b/frontend/src/container/LogsExplorerList/index.tsx
@@ -16,7 +16,7 @@ import { useOptionsMenu } from 'container/OptionsMenu';
 import { useActiveLog } from 'hooks/logs/useActiveLog';
 import { useCopyLogLink } from 'hooks/logs/useCopyLogLink';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
-import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 // interfaces
 import { ILog } from 'types/api/logs/log';
@@ -103,16 +103,6 @@ function LogsExplorerList({
 		],
 	);
 
-	useEffect(() => {
-		if (!activeLogId || activeLogIndex < 0) return;
-
-		ref?.current?.scrollToIndex({
-			index: activeLogIndex,
-			align: 'start',
-			behavior: 'smooth',
-		});
-	}, [activeLogId, activeLogIndex]);
-
 	const renderContent = useMemo(() => {
 		const components = isLoading
 			? {
@@ -130,6 +120,7 @@ function LogsExplorerList({
 						fields: selectedFields,
 						linesPerRow: options.maxLines,
 						appendTo: 'end',
+						activeLogIndex,
 					}}
 					infitiyTableProps={{ onEndReached }}
 				/>
@@ -143,6 +134,7 @@ function LogsExplorerList({
 			>
 				<Virtuoso
 					ref={ref}
+					initialTopMostItemIndex={activeLogIndex !== -1 ? activeLogIndex : 0}
 					data={logs}
 					endReached={onEndReached}
 					totalCount={logs.length}
@@ -151,7 +143,16 @@ function LogsExplorerList({
 				/>
 			</Card>
 		);
-	}, [isLoading, options, logs, onEndReached, getItemContent, selectedFields]);
+	}, [
+		isLoading,
+		options.format,
+		options.maxLines,
+		activeLogIndex,
+		logs,
+		onEndReached,
+		getItemContent,
+		selectedFields,
+	]);
 
 	return (
 		<div className="logs-list-view-container">

--- a/frontend/src/hooks/logs/useCopyLogLink.ts
+++ b/frontend/src/hooks/logs/useCopyLogLink.ts
@@ -11,11 +11,8 @@ import {
 	useMemo,
 	useState,
 } from 'react';
-import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { useCopyToClipboard } from 'react-use';
-import { AppState } from 'store/reducers';
-import { GlobalReducer } from 'types/reducer/globalTime';
 
 import { HIGHLIGHTED_DELAY } from './configs';
 import { LogTimeRange, UseCopyLogLink } from './types';
@@ -25,9 +22,6 @@ export const useCopyLogLink = (logId?: string): UseCopyLogLink => {
 	const { pathname } = useLocation();
 	const [, setCopy] = useCopyToClipboard();
 	const { notifications } = useNotifications();
-	const { maxTime, minTime } = useSelector<AppState, GlobalReducer>(
-		(state) => state.globalTime,
-	);
 
 	const { queryData: timeRange } = useUrlQueryData<LogTimeRange | null>(
 		QueryParams.timeRange,
@@ -70,8 +64,8 @@ export const useCopyLogLink = (logId?: string): UseCopyLogLink => {
 			urlQuery.delete(QueryParams.timeRange);
 			urlQuery.set(QueryParams.activeLogId, `"${logId}"`);
 			urlQuery.set(QueryParams.timeRange, range);
-			urlQuery.set(QueryParams.startTime, minTime.toString());
-			urlQuery.set(QueryParams.endTime, maxTime.toString());
+			urlQuery.set(QueryParams.startTime, timeRange?.start.toString() || '');
+			urlQuery.set(QueryParams.endTime, timeRange?.end.toString() || '');
 
 			const link = `${window.location.origin}${pathname}?${urlQuery.toString()}`;
 
@@ -80,16 +74,7 @@ export const useCopyLogLink = (logId?: string): UseCopyLogLink => {
 				message: 'Copied to clipboard',
 			});
 		},
-		[
-			logId,
-			timeRange,
-			urlQuery,
-			minTime,
-			maxTime,
-			pathname,
-			setCopy,
-			notifications,
-		],
+		[logId, timeRange, urlQuery, pathname, setCopy, notifications],
 	);
 
 	useEffect(() => {


### PR DESCRIPTION
### Summary

- Improved the existing logic of copy-log link to use `initialTopMostItemIndex` rather than useEffect to trigger the scroll which can cause issues as the rendering is async. 
- Improved the color of the highlights according to the new designs
- Next action Item:- to handle the virtuoso scroll logs when shared an extra loaded data link 

#### Related Issues / PR's

https://linear.app/signoz-io/issue/SIG-532/copy-log-link-not-working-in-the-new-designs

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/04b13ec4-9c14-4e94-b354-28001d174583



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
