### PR TITLE
feat: [SIG-543]: add time selection in the custom date selection 

### DIFF
--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -115,6 +115,9 @@ function CustomTimePicker({
 
 	const handleOpenChange = (newOpen: boolean): void => {
 		setOpen(newOpen);
+		if (!newOpen) {
+			setCustomDTPickerVisible?.(false);
+		}
 	};
 
 	const debouncedHandleInputChange = debounce((inputValue): void => {
@@ -260,7 +263,7 @@ function CustomTimePicker({
 					)
 				}
 				arrow={false}
-				trigger="click"
+				trigger="hover"
 				open={open}
 				onOpenChange={handleOpenChange}
 				style={{

--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -260,7 +260,7 @@ function CustomTimePicker({
 					)
 				}
 				arrow={false}
-				trigger="hover"
+				trigger="click"
 				open={open}
 				onOpenChange={handleOpenChange}
 				style={{

--- a/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
@@ -1,6 +1,6 @@
 import './CustomTimePicker.styles.scss';
 
-import { Button, DatePicker } from 'antd';
+import { Button } from 'antd';
 import cx from 'classnames';
 import ROUTES from 'constants/routes';
 import { DateTimeRangeType } from 'container/TopNav/CustomDateTimeModal';
@@ -9,12 +9,10 @@ import {
 	Option,
 	RelativeDurationSuggestionOptions,
 } from 'container/TopNav/DateTimeSelectionV2/config';
-import dayjs, { Dayjs } from 'dayjs';
 import { Dispatch, SetStateAction, useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
-import { AppState } from 'store/reducers';
-import { GlobalReducer } from 'types/reducer/globalTime';
+
+import RangePickerModal from './RangePickerModal';
 
 interface CustomTimePickerPopoverContentProps {
 	options: any[];
@@ -40,35 +38,12 @@ function CustomTimePickerPopoverContent({
 	handleGoLive,
 	selectedTime,
 }: CustomTimePickerPopoverContentProps): JSX.Element {
-	const { RangePicker } = DatePicker;
 	const { pathname } = useLocation();
-
-	const { maxTime, minTime } = useSelector<AppState, GlobalReducer>(
-		(state) => state.globalTime,
-	);
 
 	const isLogsExplorerPage = useMemo(() => pathname === ROUTES.LOGS_EXPLORER, [
 		pathname,
 	]);
 
-	const disabledDate = (current: Dayjs): boolean => {
-		const currentDay = dayjs(current);
-		return currentDay.isAfter(dayjs());
-	};
-
-	const onPopoverClose = (visible: boolean): void => {
-		if (!visible) {
-			setCustomDTPickerVisible(false);
-		}
-		setIsOpen(visible);
-	};
-
-	const onModalOkHandler = (date_time: any): void => {
-		if (date_time?.[1]) {
-			onPopoverClose(false);
-		}
-		onCustomDateHandler(date_time, LexicalContext.CUSTOM_DATE_PICKER);
-	};
 	function getTimeChips(options: Option[]): JSX.Element {
 		return (
 			<div className="relative-date-time-section">
@@ -121,14 +96,11 @@ function CustomTimePickerPopoverContent({
 				)}
 			>
 				{selectedTime === 'custom' || customDateTimeVisible ? (
-					<RangePicker
-						disabledDate={disabledDate}
-						allowClear
-						onCalendarChange={onModalOkHandler}
-						// eslint-disable-next-line react/jsx-props-no-spreading
-						{...(selectedTime === 'custom' && {
-							defaultValue: [dayjs(minTime / 1000000), dayjs(maxTime / 1000000)],
-						})}
+					<RangePickerModal
+						setCustomDTPickerVisible={setCustomDTPickerVisible}
+						setIsOpen={setIsOpen}
+						onCustomDateHandler={onCustomDateHandler}
+						selectedTime={selectedTime}
 					/>
 				) : (
 					<div className="relative-times-container">

--- a/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
@@ -80,7 +80,9 @@ function CustomTimePickerPopoverContent({
 						}}
 						className={cx(
 							'date-time-options-btn',
-							selectedTime === option.value && 'active',
+							customDateTimeVisible
+								? option.value === 'custom' && 'active'
+								: selectedTime === option.value && 'active',
 						)}
 					>
 						{option.label}

--- a/frontend/src/components/CustomTimePicker/RangePickerModal.styles.scss
+++ b/frontend/src/components/CustomTimePicker/RangePickerModal.styles.scss
@@ -1,0 +1,4 @@
+.custom-date-picker {
+	display: flex;
+	flex-direction: column;
+}

--- a/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
+++ b/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
@@ -54,7 +54,8 @@ function RangePickerModal(props: RangePickerModalProps): JSX.Element {
 			<RangePicker
 				disabledDate={disabledDate}
 				allowClear
-				onCalendarChange={onModalOkHandler}
+				showTime
+				onOk={onModalOkHandler}
 				// eslint-disable-next-line react/jsx-props-no-spreading
 				{...(selectedTime === 'custom' && {
 					defaultValue: [dayjs(minTime / 1000000), dayjs(maxTime / 1000000)],

--- a/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
+++ b/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
@@ -1,3 +1,5 @@
+import './RangePickerModal.styles.scss';
+
 import { DatePicker } from 'antd';
 import { DateTimeRangeType } from 'container/TopNav/CustomDateTimeModal';
 import { LexicalContext } from 'container/TopNav/DateTimeSelectionV2/config';
@@ -48,15 +50,17 @@ function RangePickerModal(props: RangePickerModalProps): JSX.Element {
 		onCustomDateHandler(date_time, LexicalContext.CUSTOM_DATE_PICKER);
 	};
 	return (
-		<RangePicker
-			disabledDate={disabledDate}
-			allowClear
-			onCalendarChange={onModalOkHandler}
-			// eslint-disable-next-line react/jsx-props-no-spreading
-			{...(selectedTime === 'custom' && {
-				defaultValue: [dayjs(minTime / 1000000), dayjs(maxTime / 1000000)],
-			})}
-		/>
+		<div className="custom-date-picker">
+			<RangePicker
+				disabledDate={disabledDate}
+				allowClear
+				onCalendarChange={onModalOkHandler}
+				// eslint-disable-next-line react/jsx-props-no-spreading
+				{...(selectedTime === 'custom' && {
+					defaultValue: [dayjs(minTime / 1000000), dayjs(maxTime / 1000000)],
+				})}
+			/>
+		</div>
 	);
 }
 

--- a/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
+++ b/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
@@ -1,0 +1,5 @@
+function RangePickerModal(): JSX.Element {
+	return <div>Range Picker Modal</div>;
+}
+
+export default RangePickerModal;

--- a/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
+++ b/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
@@ -1,5 +1,63 @@
-function RangePickerModal(): JSX.Element {
-	return <div>Range Picker Modal</div>;
+import { DatePicker } from 'antd';
+import { DateTimeRangeType } from 'container/TopNav/CustomDateTimeModal';
+import { LexicalContext } from 'container/TopNav/DateTimeSelectionV2/config';
+import dayjs, { Dayjs } from 'dayjs';
+import { Dispatch, SetStateAction } from 'react';
+import { useSelector } from 'react-redux';
+import { AppState } from 'store/reducers';
+import { GlobalReducer } from 'types/reducer/globalTime';
+
+interface RangePickerModalProps {
+	setCustomDTPickerVisible: Dispatch<SetStateAction<boolean>>;
+	setIsOpen: Dispatch<SetStateAction<boolean>>;
+	onCustomDateHandler: (
+		dateTimeRange: DateTimeRangeType,
+		lexicalContext?: LexicalContext | undefined,
+	) => void;
+	selectedTime: string;
+}
+
+function RangePickerModal(props: RangePickerModalProps): JSX.Element {
+	const {
+		setCustomDTPickerVisible,
+		setIsOpen,
+		onCustomDateHandler,
+		selectedTime,
+	} = props;
+	const { RangePicker } = DatePicker;
+	const { maxTime, minTime } = useSelector<AppState, GlobalReducer>(
+		(state) => state.globalTime,
+	);
+
+	const disabledDate = (current: Dayjs): boolean => {
+		const currentDay = dayjs(current);
+		return currentDay.isAfter(dayjs());
+	};
+
+	const onPopoverClose = (visible: boolean): void => {
+		if (!visible) {
+			setCustomDTPickerVisible(false);
+		}
+		setIsOpen(visible);
+	};
+
+	const onModalOkHandler = (date_time: any): void => {
+		if (date_time?.[1]) {
+			onPopoverClose(false);
+		}
+		onCustomDateHandler(date_time, LexicalContext.CUSTOM_DATE_PICKER);
+	};
+	return (
+		<RangePicker
+			disabledDate={disabledDate}
+			allowClear
+			onCalendarChange={onModalOkHandler}
+			// eslint-disable-next-line react/jsx-props-no-spreading
+			{...(selectedTime === 'custom' && {
+				defaultValue: [dayjs(minTime / 1000000), dayjs(maxTime / 1000000)],
+			})}
+		/>
+	);
 }
 
 export default RangePickerModal;

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/DateTimeSelectionV2.styles.scss
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/DateTimeSelectionV2.styles.scss
@@ -133,8 +133,8 @@
 		padding: 13px 14px;
 
 		&.date-picker {
-			width: 340px;
-			height: 380px;
+			width: 480px;
+			height: 430px;
 		}
 
 		&.relative-times {

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -44,7 +44,6 @@ import { DateTimeRangeType } from '../CustomDateTimeModal';
 import {
 	getDefaultOption,
 	getOptions,
-	LexicalContext,
 	LocalStorageTimeRange,
 	Time,
 	TimeRange,
@@ -319,22 +318,12 @@ function DateTimeSelection({
 		onLastRefreshHandler();
 	};
 
-	const onCustomDateHandler = (
-		dateTimeRange: DateTimeRangeType,
-		lexicalContext?: LexicalContext,
-	): void => {
+	const onCustomDateHandler = (dateTimeRange: DateTimeRangeType): void => {
 		if (dateTimeRange !== null) {
 			const [startTimeMoment, endTimeMoment] = dateTimeRange;
 			if (startTimeMoment && endTimeMoment) {
-				let startTime = startTimeMoment;
-				let endTime = endTimeMoment;
-				if (
-					lexicalContext &&
-					lexicalContext === LexicalContext.CUSTOM_DATE_PICKER
-				) {
-					startTime = startTime.startOf('day');
-					endTime = endTime.endOf('day');
-				}
+				const startTime = startTimeMoment;
+				const endTime = endTimeMoment;
 				setCustomDTPickerVisible(false);
 				updateTimeInterval('custom', [
 					startTime.toDate().getTime(),


### PR DESCRIPTION
### Summary

- bring back the time selection in the date time picker modal in sync with the older designs

#### Related Issues / PR's

https://linear.app/signoz-io/issue/SIG-543/add-back-hours-minutes-seconds-to-the-new-date-time-modal

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/d67f9b06-0430-4117-9e5a-6a8ec3ba8e0b



#### Affected Areas and Manually Tested Areas

- relative date time selection 
- custom date time selection 
- intermediate states 
