### PR TITLE
fix: remove early return for services call in usage explorer

### DIFF
--- a/frontend/src/store/actions/metrics/getService.ts
+++ b/frontend/src/store/actions/metrics/getService.ts
@@ -17,13 +17,6 @@ export const GetService = (
 	try {
 		const { globalTime } = getState();
 
-		if (
-			props.maxTime !== globalTime.maxTime &&
-			props.minTime !== globalTime.minTime
-		) {
-			return;
-		}
-
 		const { maxTime, minTime } = GetMinMax(globalTime.selectedTime, [
 			globalTime.minTime / 1000000,
 			globalTime.maxTime / 1000000,


### PR DESCRIPTION
### Summary

FIxes https://github.com/SigNoz/signoz/issues/4652

The props don't have the `maxTime` and `minTime` and as a result, it returns without fetching any services. I see redux is still used here. This is perhaps not the best way to fix this but for now, I just wanted to fix the missing services list and let users consume data. In future, we can refactor this code.