### PR TITLE
chore: update postgres config instructions to work for both signoz cloud and self-hosted

### DIFF
--- a/pkg/query-service/app/integrations/builtin_integrations/postgres/config/configure-otel-collector.md
+++ b/pkg/query-service/app/integrations/builtin_integrations/postgres/config/configure-otel-collector.md
@@ -2,7 +2,9 @@
 
 #### Create collector config file
 
-Save the following collector config in a file named `postgres-collector-config.yaml`
+Save the collector config for monitoring postgres in a file named `postgres-collector-config.yaml`
+
+Use the following configuration for SigNoz cloud. See further below for configuration for self hosted SigNoz 
 
 ```yaml
 receivers:
@@ -44,10 +46,10 @@ processors:
 
 exporters:
   # export to SigNoz cloud
-  otlp/signoz:
-    endpoint: "ingest.${env:SIGNOZ_REGION}.signoz.cloud:443"
+  otlp/postgres:
+    endpoint: "${env:OTLP_DESTINATION_ENDPOINT}"
     tls:
-      insecure: false
+      insecure: ${env:OTLP_DESTINATION_TLS_INSECURE}
     headers:
       "signoz-access-token": "${env:SIGNOZ_INGESTION_KEY}"
 
@@ -57,7 +59,61 @@ service:
       receivers: [postgresql]
       # note: remove this processor if the collector host is not running on the same host as the postgres instance
       processors: [resourcedetection/system]
-      exporters: [otlp/signoz]
+      exporters: [otlp/postgres]
+```
+
+Use the following config if using self-hosted SigNoz. See the config above if using SigNoz cloud
+```yaml
+receivers:
+  postgresql:
+    # The endpoint of the postgresql server. Whether using TCP or Unix sockets, this value should be host:port. If transport is set to unix, the endpoint will internally be translated from host:port to /host.s.PGSQL.port
+    endpoint: ${env:POSTGRESQL_ENDPOINT}
+    # The frequency at which to collect metrics from the Postgres instance.
+    collection_interval: 60s
+    # The username used to access the postgres instance
+    username: monitoring
+    # The password used to access the postgres instance
+    password: ${env:POSTGRESQL_PASSWORD}
+    # The list of databases for which the receiver will attempt to collect statistics. If an empty list is provided, the receiver will attempt to collect statistics for all non-template databases
+    databases: []
+    # # Defines the network to use for connecting to the server. Valid Values are `tcp` or `unix`
+    # transport: tcp
+    tls:
+      # set to false if SSL is enabled on the server
+      insecure: true
+    #   ca_file: /etc/ssl/certs/ca-certificates.crt
+    #   cert_file: /etc/ssl/certs/postgres.crt
+    #   key_file: /etc/ssl/certs/postgres.key
+    metrics:
+      postgresql.database.locks:
+        enabled: true
+      postgresql.deadlocks:
+        enabled: true
+      postgresql.sequential_scans:
+        enabled: true
+
+processors:
+  # enriches the data with additional host information
+  # see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#resource-detection-processor
+  resourcedetection/system:
+    # add additional detectors if needed
+    detectors: ["system"]
+    system:
+      hostname_sources: ["os"]
+
+exporters:
+  otlp/postgres:
+    endpoint: "${env:OTLP_DESTINATION_ENDPOINT}"
+    tls:
+      insecure: ${env:OTLP_DESTINATION_TLS_INSECURE}
+
+service:
+  pipelines:
+    metrics/postgresql:
+      receivers: [postgresql]
+      # note: remove this processor if the collector host is not running on the same host as the postgres instance
+      processors: [resourcedetection/system]
+      exporters: [otlp/postgres]
 ```
 
 
@@ -73,15 +129,18 @@ export POSTGRESQL_PASSWORD="password"
 # postgres endpoint reachable from the otel collector"
 export POSTGRESQL_ENDPOINT="host:port"
 
-# your signoz ingestion key"
-export SIGNOZ_INGESTION_KEY="key"
+# A reachable OTLP destination for collected metrics. Eg: localhost:4317 or signoz cloud ingestion endpoint
+export OTLP_DESTINATION_ENDPOINT="ingest.us.signoz.cloud:443"
 
-# your signoz region (Eg: us, eu, in ...)
-export SIGNOZ_REGION="us"
+# Set to true if using an endpoint without TLS
+export OTLP_DESTINATION_TLS_INSECURE="false"
+
+# your signoz ingestion key if using SigNoz cloud
+export SIGNOZ_INGESTION_KEY="key"
 
 ```
 
 #### Use collector config file
 
 Make the `postgres-collector-config.yaml` file available to your otel collector and add the flag `--config postgres-collector-config.yaml` to the command for running your otel collector.    
-Note: the collector can use multiple config files, specified by multiple occurances of the --config flag.
+Note: the collector can use multiple config files, specified by multiple occurrences of the --config flag.


### PR DESCRIPTION
### Summary

Updates postgres integration collector config instructions to have 2 separate pastable collector configs for signoz cloud and self-hosted signoz

#### Related Issues / PR's

Contributes to https://github.com/SigNoz/signoz/issues/4462
