### PR TITLE
fix: [SIG-570]: query builder issue when - is present in free text seach 

### DIFF
--- a/frontend/src/hooks/queryBuilder/useTag.ts
+++ b/frontend/src/hooks/queryBuilder/useTag.ts
@@ -74,7 +74,11 @@ export const useTag = (
 	const handleAddTag = useCallback(
 		(value: string): void => {
 			const { tagKey } = getTagToken(value);
-			const [key, id] = tagKey.split('-');
+			const parts = tagKey.split('-');
+
+			// this is done to ensure that `hello-world` also gets converted to `body CONTAINS hello-world`
+			const id = parts[parts.length - 1];
+			const key = parts.slice(0, -1).join('-');
 
 			if (id === 'custom') {
 				const customValue = whereClauseConfig


### PR DESCRIPTION
### Summary

- the keys like `hello-world` were not getting converted to `body CONTAINS hello-world`

#### Related Issues / PR's

Fixes #3593 

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/24f686e1-6604-4896-9dd5-87272baf46db



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
