### PR TITLE
feat: [SIG-571]: added support for has and nhas operator for json filter

### DIFF
--- a/frontend/src/hooks/queryBuilder/useOperators.ts
+++ b/frontend/src/hooks/queryBuilder/useOperators.ts
@@ -1,4 +1,7 @@
-import { QUERY_BUILDER_OPERATORS_BY_TYPES } from 'constants/queryBuilder';
+import {
+	OPERATORS,
+	QUERY_BUILDER_OPERATORS_BY_TYPES,
+} from 'constants/queryBuilder';
 import { getRemovePrefixFromKey } from 'container/QueryBuilder/filters/QueryBuilderSearch/utils';
 import { useMemo } from 'react';
 import { BaseAutocompleteData } from 'types/api/queryBuilder/queryAutocompleteResponse';
@@ -16,9 +19,18 @@ export const useOperators = (
 ): IOperators =>
 	useMemo(() => {
 		const currentKey = keys?.find((el) => el.key === getRemovePrefixFromKey(key));
+		const strippedKey = key.split(' ')[0];
+
+		// eslint-disable-next-line no-nested-ternary
 		return currentKey?.dataType
 			? QUERY_BUILDER_OPERATORS_BY_TYPES[
 					currentKey.dataType as keyof typeof QUERY_BUILDER_OPERATORS_BY_TYPES
+			  ]
+			: strippedKey.endsWith('[*]')
+			? [
+					OPERATORS.HAS,
+					OPERATORS.NHAS,
+					...QUERY_BUILDER_OPERATORS_BY_TYPES.universal,
 			  ]
 			: QUERY_BUILDER_OPERATORS_BY_TYPES.universal;
 	}, [keys, key]);

--- a/frontend/src/hooks/queryBuilder/useOperators.ts
+++ b/frontend/src/hooks/queryBuilder/useOperators.ts
@@ -26,11 +26,7 @@ export const useOperators = (
 			? QUERY_BUILDER_OPERATORS_BY_TYPES[
 					currentKey.dataType as keyof typeof QUERY_BUILDER_OPERATORS_BY_TYPES
 			  ]
-			: strippedKey.endsWith('[*]')
-			? [
-					OPERATORS.HAS,
-					OPERATORS.NHAS,
-					...QUERY_BUILDER_OPERATORS_BY_TYPES.universal,
-			  ]
+			: strippedKey.endsWith('[*]') && strippedKey.startsWith('body.')
+			? [OPERATORS.HAS, OPERATORS.NHAS]
 			: QUERY_BUILDER_OPERATORS_BY_TYPES.universal;
 	}, [keys, key]);


### PR DESCRIPTION
### Summary

- added support for `has` and `nhas` operators when the key ends with `[*]` and starts with `body.`

#### Related Issues / PR's

Fixes #3629 

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/850e2bdf-977f-4038-9929-3b705413b415



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
