### PR TITLE
fix: log chips not forming making filtering not work

### DIFF
--- a/frontend/src/components/Logs/ListLogView/index.tsx
+++ b/frontend/src/components/Logs/ListLogView/index.tsx
@@ -48,7 +48,6 @@ function LogGeneralField({
 	fieldValue,
 	linesPerRow = 1,
 }: LogFieldProps): JSX.Element {
-	console.log('fieldKey:', fieldKey, linesPerRow);
 	const html = useMemo(
 		() => ({
 			__html: convert.toHtml(dompurify.sanitize(fieldValue)),

--- a/frontend/src/hooks/queryBuilder/useTag.ts
+++ b/frontend/src/hooks/queryBuilder/useTag.ts
@@ -83,8 +83,6 @@ export const useTag = (
 				[key] = parts;
 			}
 
-			console.log({ key, id, tagKey });
-
 			if (id === 'custom') {
 				const customValue = whereClauseConfig
 					? `${whereClauseConfig.customKey} ${whereClauseConfig.customOp} ${key}`

--- a/frontend/src/hooks/queryBuilder/useTag.ts
+++ b/frontend/src/hooks/queryBuilder/useTag.ts
@@ -75,10 +75,15 @@ export const useTag = (
 		(value: string): void => {
 			const { tagKey } = getTagToken(value);
 			const parts = tagKey.split('-');
-
 			// this is done to ensure that `hello-world` also gets converted to `body CONTAINS hello-world`
-			const id = parts[parts.length - 1];
-			const key = parts.slice(0, -1).join('-');
+			let id = parts[parts.length - 1];
+			let key = parts.slice(0, -1).join('-');
+			if (parts.length === 1) {
+				id = '';
+				[key] = parts;
+			}
+
+			console.log({ key, id, tagKey });
 
 			if (id === 'custom') {
 				const customValue = whereClauseConfig


### PR DESCRIPTION
### Summary

- The logic to split the parts on the basis of `-` was missing an edge case where it was not taking the key properly when no `-` is present in the query

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/55f3097a-e606-4d26-b4a7-5c9310478b2f




#### Affected Areas and Manually Tested Areas

different filters in the logs explorer page
