### PR TITLE
fix: 404 resource not found issues

### DIFF
--- a/frontend/src/api/SAML/listAllDomain.ts
+++ b/frontend/src/api/SAML/listAllDomain.ts
@@ -8,7 +8,7 @@ const listAllDomain = async (
 	props: Props,
 ): Promise<SuccessResponse<PayloadProps> | ErrorResponse> => {
 	try {
-		const response = await axios.get(`orgs/${props.orgId}/domains`);
+		const response = await axios.get(`/orgs/${props.orgId}/domains`);
 
 		return {
 			statusCode: 200,

--- a/frontend/src/api/queryBuilder/getAggregateAttribute.ts
+++ b/frontend/src/api/queryBuilder/getAggregateAttribute.ts
@@ -24,7 +24,7 @@ export const getAggregateAttribute = async ({
 		const response: AxiosResponse<{
 			data: IQueryAutocompleteResponse;
 		}> = await ApiV3Instance.get(
-			`autocomplete/aggregate_attributes?${createQueryParams({
+			`/autocomplete/aggregate_attributes?${createQueryParams({
 				aggregateOperator,
 				searchText,
 				dataSource,

--- a/frontend/src/api/queryBuilder/getAttributeKeys.ts
+++ b/frontend/src/api/queryBuilder/getAttributeKeys.ts
@@ -25,7 +25,7 @@ export const getAggregateKeys = async ({
 		const response: AxiosResponse<{
 			data: IQueryAutocompleteResponse;
 		}> = await ApiV3Instance.get(
-			`autocomplete/attribute_keys?${createQueryParams({
+			`/autocomplete/attribute_keys?${createQueryParams({
 				aggregateOperator,
 				searchText,
 				dataSource,

--- a/frontend/src/api/saveView/deleteView.ts
+++ b/frontend/src/api/saveView/deleteView.ts
@@ -2,4 +2,4 @@ import axios from 'api';
 import { DeleteViewPayloadProps } from 'types/api/saveViews/types';
 
 export const deleteView = (uuid: string): Promise<DeleteViewPayloadProps> =>
-	axios.delete(`explorer/views/${uuid}`);
+	axios.delete(`/explorer/views/${uuid}`);

--- a/frontend/src/api/saveView/getAllViews.ts
+++ b/frontend/src/api/saveView/getAllViews.ts
@@ -6,4 +6,4 @@ import { DataSource } from 'types/common/queryBuilder';
 export const getAllViews = (
 	sourcepage: DataSource,
 ): Promise<AxiosResponse<AllViewsProps>> =>
-	axios.get(`explorer/views?sourcePage=${sourcepage}`);
+	axios.get(`/explorer/views?sourcePage=${sourcepage}`);

--- a/frontend/src/api/saveView/saveView.ts
+++ b/frontend/src/api/saveView/saveView.ts
@@ -8,7 +8,7 @@ export const saveView = ({
 	viewName,
 	extraData,
 }: SaveViewProps): Promise<AxiosResponse<SaveViewPayloadProps>> =>
-	axios.post('explorer/views', {
+	axios.post('/explorer/views', {
 		name: viewName,
 		sourcePage,
 		compositeQuery,

--- a/frontend/src/api/saveView/updateView.ts
+++ b/frontend/src/api/saveView/updateView.ts
@@ -11,7 +11,7 @@ export const updateView = ({
 	sourcePage,
 	viewKey,
 }: UpdateViewProps): Promise<UpdateViewPayloadProps> =>
-	axios.put(`explorer/views/${viewKey}`, {
+	axios.put(`/explorer/views/${viewKey}`, {
 		name: viewName,
 		compositeQuery,
 		extraData,


### PR DESCRIPTION
### Summary

- the issue arises when let's say the token expires and a call gets stuck inside the 401 un-auth loop.
- the interceptor was making the API call again internally and expected the URL to be `/endpoint` and hence was stripping the `/`.
- but some API's didn't have initial `/` hence removing first letter from endpoint resulting in 404 not found.

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
