### PR TITLE
fix: billing page crashes when all three signal data is not present

### DIFF
--- a/frontend/src/container/BillingContainer/BillingUsageGraph/BillingUsageGraph.tsx
+++ b/frontend/src/container/BillingContainer/BillingUsageGraph/BillingUsageGraph.tsx
@@ -46,7 +46,7 @@ const calculateStartEndTime = (
 ): { startTime: number; endTime: number } => {
 	const timestamps: number[] = [];
 	data?.details?.breakdown?.forEach((breakdown: any) => {
-		breakdown?.dayWiseBreakdown?.breakdown.forEach((entry: any) => {
+		breakdown?.dayWiseBreakdown?.breakdown?.forEach((entry: any) => {
 			timestamps.push(entry?.timestamp);
 		});
 	});


### PR DESCRIPTION
### Summary

- the `calculateStartEndTime` function expected all the `signals` to have `daywisebreakdown` which is not the case. 
- added a null check for the same in case some signal is missing data

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

before 


https://github.com/SigNoz/signoz/assets/54737045/663f697f-cb84-47f6-9886-fc7b715a3d13




After 

https://github.com/SigNoz/signoz/assets/54737045/a8e85a5c-6cad-4459-9559-c648f65d2cdc



#### Affected Areas and Manually Tested Areas

billing graph usage
