### PR TITLE
feat: do not retry query range API's with i/o timeout error

### DIFF
--- a/frontend/src/api/ErrorResponseHandler.ts
+++ b/frontend/src/api/ErrorResponseHandler.ts
@@ -31,7 +31,7 @@ export function ErrorResponseHandler(error: AxiosError): ErrorResponse {
 				payload: null,
 				error: errorMessage,
 				message: (response.data as any)?.status,
-				body: JSON.stringify(response.data),
+				body: JSON.stringify((response.data as any).data),
 			};
 		}
 

--- a/frontend/src/api/ErrorResponseHandler.ts
+++ b/frontend/src/api/ErrorResponseHandler.ts
@@ -30,7 +30,8 @@ export function ErrorResponseHandler(error: AxiosError): ErrorResponse {
 				statusCode,
 				payload: null,
 				error: errorMessage,
-				message: null,
+				message: (response.data as any)?.status,
+				body: JSON.stringify(response.data),
 			};
 		}
 

--- a/frontend/src/container/GridCardLayout/GridCard/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/index.tsx
@@ -148,9 +148,8 @@ function GridCardGraph({
 			],
 			retry(failureCount, error): boolean {
 				if (
-					typeof error.cause === 'string' &&
-					error.cause.includes('status: error') &&
-					error.cause.includes('i/o timeout')
+					String(error).includes('status: error') &&
+					String(error).includes('i/o timeout')
 				) {
 					return false;
 				}

--- a/frontend/src/container/GridCardLayout/GridCard/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/index.tsx
@@ -146,6 +146,17 @@ function GridCardGraph({
 				widget?.panelTypes,
 				widget.timePreferance,
 			],
+			retry(failureCount, error): boolean {
+				if (
+					typeof error.cause === 'string' &&
+					error.cause.includes('status: error') &&
+					error.cause.includes('i/o timeout')
+				) {
+					return false;
+				}
+
+				return failureCount < 2;
+			},
 			keepPreviousData: true,
 			enabled: queryEnabledCondition,
 			refetchOnMount: false,

--- a/frontend/src/lib/dashboard/getQueryResults.ts
+++ b/frontend/src/lib/dashboard/getQueryResults.ts
@@ -32,6 +32,9 @@ export async function GetMetricQueryRange(
 	if (response.statusCode >= 400) {
 		throw new Error(
 			`API responded with ${response.statusCode} -  ${response.error}`,
+			{
+				cause: `status: ${response.message}, errors: ${response?.body}`,
+			},
 		);
 	}
 

--- a/frontend/src/lib/dashboard/getQueryResults.ts
+++ b/frontend/src/lib/dashboard/getQueryResults.ts
@@ -31,10 +31,7 @@ export async function GetMetricQueryRange(
 
 	if (response.statusCode >= 400) {
 		throw new Error(
-			`API responded with ${response.statusCode} -  ${response.error}`,
-			{
-				cause: `status: ${response.message}, errors: ${response?.body}`,
-			},
+			`API responded with ${response.statusCode} -  ${response.error} status: ${response.message}, errors: ${response?.body}`,
 		);
 	}
 

--- a/frontend/src/types/api/index.ts
+++ b/frontend/src/types/api/index.ts
@@ -6,7 +6,8 @@ export interface ErrorResponse {
 	statusCode: ErrorStatusCode;
 	payload: null;
 	error: string;
-	message: null;
+	message: string | null;
+	body?: string | null;
 }
 
 export interface SuccessResponse<T, P = unknown> {


### PR DESCRIPTION
### Summary

- do not retry query range API's with `i/o timeout` error and status `error`

#### Related Issues / PR's

fixes :- #4767

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/5fc9a733-0314-4b30-bb50-beb15fd09b2c



#### Affected Areas and Manually Tested Areas

tested using `mockbin` server
