### PR TITLE
chore: integration instructions: add typical log file locations for macOS

### DIFF
--- a/pkg/query-service/app/integrations/builtin_integrations/mongo/config/collect-logs.md
+++ b/pkg/query-service/app/integrations/builtin_integrations/mongo/config/collect-logs.md
@@ -97,7 +97,9 @@ Set the following environment variables in your otel-collector environment:
 ```bash
 
 # path of MongoDB server log file. must be accessible by the otel collector
-export MONGODB_LOG_FILE=/var/log/mongodb.log
+# typically found in /usr/local/var/log/mongodb on macOS
+# mongod.conf file can also be checked for finding log file location
+export MONGODB_LOG_FILE=/var/log/mongodb/mongodb.log
 
 # region specific SigNoz cloud ingestion endpoint
 export OTLP_DESTINATION_ENDPOINT="ingest.us.signoz.cloud:443"

--- a/pkg/query-service/app/integrations/builtin_integrations/nginx/config/collect-logs.md
+++ b/pkg/query-service/app/integrations/builtin_integrations/nginx/config/collect-logs.md
@@ -117,9 +117,11 @@ Set the following environment variables in your otel-collector environment:
 ```bash
 
 # path of Nginx access log file. must be accessible by the otel collector
-export NGINX_ACCESS_LOG_FILE=/var/log/nginx/access.log;
+# typically found at /usr/local/var/log/nginx/access.log on macOS
+export NGINX_ACCESS_LOG_FILE=/var/log/nginx/access.log
 
 # path of Nginx error log file. must be accessible by the otel collector
+# typically found at /usr/local/var/log/nginx/error.log on macOS
 export NGINX_ERROR_LOG_FILE=/var/log/nginx/error.log
 
 # region specific SigNoz cloud ingestion endpoint

--- a/pkg/query-service/app/integrations/builtin_integrations/postgres/config/collect-logs.md
+++ b/pkg/query-service/app/integrations/builtin_integrations/postgres/config/collect-logs.md
@@ -91,7 +91,9 @@ Set the following environment variables in your otel-collector environment:
 ```bash
 
 # path of Postgres server log file. must be accessible by the otel collector
-export POSTGRESQL_LOG_FILE=/usr/local/var/log/postgres.log
+# typically found in /usr/local/var/log/postgresql on macOS
+# running `SELECT pg_current_logfile();` can also give you the location of postgresql log file
+export POSTGRESQL_LOG_FILE=/var/log/postgresql/postgresql.log
 
 # region specific SigNoz cloud ingestion endpoint
 export OTLP_DESTINATION_ENDPOINT="ingest.us.signoz.cloud:443"

--- a/pkg/query-service/app/integrations/builtin_integrations/redis/config/collect-logs.md
+++ b/pkg/query-service/app/integrations/builtin_integrations/redis/config/collect-logs.md
@@ -82,7 +82,9 @@ Set the following environment variables in your otel-collector environment:
 ```bash
 
 # path of Redis server log file. must be accessible by the otel collector
-export REDIS_LOG_FILE=/var/log/redis.log
+# typically found in /usr/local/var/log/redis on macOS
+# log file location can also be found in the output of `redis-cli CONFIG GET : *`
+export REDIS_LOG_FILE=/var/log/redis/redis-server.log
 
 # region specific SigNoz cloud ingestion endpoint
 export OTLP_DESTINATION_ENDPOINT="ingest.us.signoz.cloud:443"


### PR DESCRIPTION
### Summary

Adds typical log file locations for macOS to integration instructions

#### Related Issues / PR's

contributes to https://github.com/SigNoz/signoz/issues/2760
