### PR TITLE
fix: do not move to next step if env not selected in onboarding

### DIFF
--- a/frontend/src/container/OnboardingContainer/common/ModuleStepsContainer/ModuleStepsContainer.tsx
+++ b/frontend/src/container/OnboardingContainer/common/ModuleStepsContainer/ModuleStepsContainer.tsx
@@ -16,7 +16,7 @@ import { DataSourceType } from 'container/OnboardingContainer/Steps/DataSource/D
 import { hasFrameworks } from 'container/OnboardingContainer/utils/dataSourceUtils';
 import useAnalytics from 'hooks/analytics/useAnalytics';
 import history from 'lib/history';
-import { isEmpty } from 'lodash-es';
+import { isEmpty, isNull } from 'lodash-es';
 import { useState } from 'react';
 
 import { useOnboardingContext } from '../../context/OnboardingContext';
@@ -91,7 +91,10 @@ export default function ModuleStepsContainer({
 			name: selectedDataSourceName = '',
 		} = selectedDataSource as DataSourceType;
 
-		if (step.id === environmentDetailsStep && selectedEnvironment === '') {
+		if (
+			step.id === environmentDetailsStep &&
+			(selectedEnvironment === '' || isNull(selectedEnvironment))
+		) {
 			updateErrorDetails('Please select environment');
 			return false;
 		}


### PR DESCRIPTION
### Summary

- Block the user to move to next step if the environment is not selected
- the `selectedEnvironment` was being sent as `null` but the `isValidForm` expected it to be `''` instead , so added check for the same as well

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/1341ba90-f7a6-4739-a2f9-835473596e38



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
