### PR TITLE
fix: incorrect error rate query

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -879,7 +879,7 @@ func (r *ClickHouseReader) GetServices(ctx context.Context, queryParams *model.G
 				zap.L().Error("Error building query with tag params", zap.Error(errStatus))
 				return
 			}
-			query += subQuery
+			errorQuery += subQuery
 			args = append(args, argsSubQuery...)
 			err = r.db.QueryRow(ctx, errorQuery, args...).Scan(&numErrors)
 			if err != nil {


### PR DESCRIPTION
### Summary

The number of errors retrieval query doesn't use the resource attributes filter because of the incorrect var usage. Many customers also have the `-dev/-prod/-staging` in the service names so it hasn't been a problem for them. For those who use the same service name across the env; the count of errors is much higher as the filter would never be applied.