### PR TITLE
fix: app content overlapping sidenav

### DIFF
--- a/frontend/src/container/AppLayout/AppLayout.styles.scss
+++ b/frontend/src/container/AppLayout/AppLayout.styles.scss
@@ -6,6 +6,7 @@
 	.app-content {
 		width: calc(100% - 64px);
 		overflow: auto;
+		z-index: 0;
 
 		.content-container {
 			position: relative;

--- a/frontend/src/container/SideNav/SideNav.styles.scss
+++ b/frontend/src/container/SideNav/SideNav.styles.scss
@@ -1,6 +1,8 @@
 .sidenav-container {
 	width: 64px;
 	height: 100%;
+	position: relative;
+	z-index: 1;
 
 	&.docked {
 		width: 240px;
@@ -16,8 +18,6 @@
 	border-right: 1px solid var(--bg-slate-400);
 	padding-bottom: 48px;
 	transition: all 0.2s, background 0s, border 0s;
-	position: relative;
-	z-index: 1;
 
 	.brand-company-meta {
 		display: flex;


### PR DESCRIPTION
### Summary

- the sidenav has `z-index`  of 1 but since the `app-content` positioning was not relative so the z-index of child was in the same 3D plane as the root parent hence overlapping the sideNav when z-index above 1

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/367bfcce-557e-4177-a581-d66ca686a23c





#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
