### PR TITLE
fix: alerts tag popup vibrating

### DIFF
--- a/frontend/src/components/TableRenderer/LabelColumn.tsx
+++ b/frontend/src/components/TableRenderer/LabelColumn.tsx
@@ -1,10 +1,10 @@
 import './LabelColumn.styles.scss';
 
 import { Popover, Tag } from 'antd';
-import { popupContainer } from 'utils/selectPopupContainer';
 
 import { LabelColumnProps } from './TableRenderer.types';
 import TagWithToolTip from './TagWithToolTip';
+import { getLabelAndValueContent } from './utils';
 
 function LabelColumn({ labels, value, color }: LabelColumnProps): JSX.Element {
 	const newLabels = labels.length > 3 ? labels.slice(0, 3) : labels;
@@ -19,19 +19,17 @@ function LabelColumn({ labels, value, color }: LabelColumnProps): JSX.Element {
 			)}
 			{remainingLabels.length > 0 && (
 				<Popover
-					getPopupContainer={popupContainer}
 					placement="bottomRight"
 					showArrow={false}
 					content={
 						<div>
 							{labels.map(
 								(label: string): JSX.Element => (
-									<TagWithToolTip
-										key={label}
-										label={label}
-										color={color}
-										value={value}
-									/>
+									<div key={label}>
+										<Tag className="label-column--tag" color={color}>
+											{getLabelAndValueContent(label, value && value[label])}
+										</Tag>
+									</div>
 								),
 							)}
 						</div>

--- a/frontend/src/components/TableRenderer/utils.ts
+++ b/frontend/src/components/TableRenderer/utils.ts
@@ -38,6 +38,16 @@ export const getLabelRenderingValue = (
 	return label;
 };
 
+export const getLabelAndValueContent = (
+	label: string,
+	value?: string,
+): string => {
+	if (value) {
+		return `${label}: ${value}`;
+	}
+	return `${label}`;
+};
+
 interface GeneratorResizeTableColumnsProp<T> {
 	baseColumnOptions: ColumnsType<T>;
 	dynamicColumnOption: { key: string; columnOption: ColumnType<T> }[];


### PR DESCRIPTION
### Summary

- the `getPopupContainer` was not able to calculate the correct placement for the tooltip which is not needed.
- secondly we were `stripping` the values inside the popup as well where user is expected to hover inside the popover as well which is not UX friendly
- hence included the complete values inside the popover.

#### Related Issues / PR's

https://linear.app/signoz-io/issue/SIG-581/flickering-bug-in-alert

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/ddf57666-ee12-4423-b720-b544f73c8499



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
