### PR TITLE
fix: query range API validation

### DIFF
--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -404,7 +404,7 @@ type CompositeQuery struct {
 
 func (c *CompositeQuery) Validate() error {
 	if c == nil {
-		return nil
+		return fmt.Errorf("composite query is required")
 	}
 
 	if c.BuilderQueries == nil && c.ClickHouseQueries == nil && c.PromQueries == nil {


### PR DESCRIPTION
### Summary

Handle edge case when composite query is missing. Return 400