### PR TITLE
feat: revamp integration flow

### DIFF
--- a/frontend/src/pages/Integrations/IntegrationDetailPage/IntegrationDetailContent.tsx
+++ b/frontend/src/pages/Integrations/IntegrationDetailPage/IntegrationDetailContent.tsx
@@ -13,12 +13,18 @@ interface IntegrationDetailContentProps {
 	activeDetailTab: string;
 	integrationData: IntegrationDetailedProps;
 	integrationId: string;
+	setActiveDetailTab: React.Dispatch<React.SetStateAction<string | null>>;
 }
 
 function IntegrationDetailContent(
 	props: IntegrationDetailContentProps,
 ): JSX.Element {
-	const { activeDetailTab, integrationData, integrationId } = props;
+	const {
+		activeDetailTab,
+		integrationData,
+		integrationId,
+		setActiveDetailTab,
+	} = props;
 	const items: TabsProps['items'] = [
 		{
 			key: 'overview',
@@ -78,7 +84,11 @@ function IntegrationDetailContent(
 	];
 	return (
 		<div className="integration-detail-container">
-			<Tabs defaultActiveKey={activeDetailTab} items={items} />
+			<Tabs
+				activeKey={activeDetailTab}
+				items={items}
+				onChange={setActiveDetailTab}
+			/>
 		</div>
 	);
 }

--- a/frontend/src/pages/Integrations/IntegrationDetailPage/IntegrationDetailHeader.tsx
+++ b/frontend/src/pages/Integrations/IntegrationDetailPage/IntegrationDetailHeader.tsx
@@ -129,7 +129,10 @@ function IntegrationDetailHeader(
 					</div>
 				</div>
 				<Button
-					className="configure-btn"
+					className={cx(
+						'configure-btn',
+						!isConnectionStateNotInstalled && 'test-connection',
+					)}
 					icon={<ArrowLeftRight size={14} />}
 					disabled={isInstallLoading}
 					onClick={(): void => {

--- a/frontend/src/pages/Integrations/IntegrationDetailPage/IntegrationDetailPage.styles.scss
+++ b/frontend/src/pages/Integrations/IntegrationDetailPage/IntegrationDetailPage.styles.scss
@@ -380,25 +380,56 @@
 			display: flex;
 			flex-direction: row-reverse;
 
-			.understandBtn {
-				border-radius: 2px;
-				border: 1px solid var(--bg-slate-400);
-				background: var(--bg-ink-300);
-				box-shadow: none;
-				color: var(--bg-vanilla-400);
-				font-family: Inter;
-				font-size: 12px;
-				font-style: normal;
-				font-weight: 400;
-				line-height: 10px; /* 83.333% */
-				letter-spacing: 0.12px;
+			.connection-footer {
 				display: flex;
-				justify-content: center;
-				align-items: center;
-				width: 131px;
-				height: 30px;
-				padding: 6px;
-				flex-shrink: 0;
+				width: 100%;
+				.understandBtn {
+					width: 50%;
+					border-radius: 2px;
+					border: 1px solid var(--bg-slate-400);
+					background: var(--bg-ink-300);
+					box-shadow: none;
+					color: var(--bg-vanilla-400);
+					font-family: Inter;
+					font-size: 12px;
+					font-style: normal;
+					font-weight: 400;
+					line-height: 10px; /* 83.333% */
+					letter-spacing: 0.12px;
+					display: flex;
+					justify-content: center;
+					align-items: center;
+					height: 34px;
+					padding: 6px;
+					flex-shrink: 0;
+				}
+				.configureBtn {
+					width: 50%;
+					color: var(--bg-vanilla-100);
+					font-family: Inter;
+					font-size: 12px;
+					font-style: normal;
+					font-weight: 400;
+					line-height: 10px; /* 83.333% */
+					letter-spacing: 0.12px;
+					border-radius: 2px;
+					background: var(--bg-robin-500);
+					display: flex;
+					height: 34px;
+					padding: 6px;
+					justify-content: center;
+					align-items: center;
+					gap: 6px;
+					flex: 1 0 0;
+				}
+
+				&.not-pending {
+					flex-direction: row-reverse;
+
+					.understandBtn {
+						width: 131px;
+					}
+				}
 			}
 		}
 	}

--- a/frontend/src/pages/Integrations/IntegrationDetailPage/IntegrationDetailPage.styles.scss
+++ b/frontend/src/pages/Integrations/IntegrationDetailPage/IntegrationDetailPage.styles.scss
@@ -160,6 +160,14 @@
 				font-weight: 500;
 				line-height: 10px; /* 83.333% */
 				letter-spacing: 0.12px;
+				box-shadow: none;
+
+				&.test-connection {
+					border-radius: 2px;
+					border: 1px solid var(--bg-slate-400);
+					background: var(--bg-ink-300);
+					color: var(--bg-vanilla-400);
+				}
 			}
 		}
 
@@ -572,6 +580,13 @@
 					}
 
 					.description {
+						color: var(--bg-slate-200);
+					}
+				}
+				.configure-btn {
+					&.test-connection {
+						border: 1px solid rgba(53, 59, 76, 0.2);
+						background: var(--bg-vanilla-200);
 						color: var(--bg-slate-200);
 					}
 				}

--- a/frontend/src/pages/Integrations/IntegrationDetailPage/IntegrationDetailPage.tsx
+++ b/frontend/src/pages/Integrations/IntegrationDetailPage/IntegrationDetailPage.tsx
@@ -22,10 +22,16 @@ interface IntegrationDetailPageProps {
 	selectedIntegration: string;
 	setSelectedIntegration: (id: string | null) => void;
 	activeDetailTab: string;
+	setActiveDetailTab: React.Dispatch<React.SetStateAction<string | null>>;
 }
 
 function IntegrationDetailPage(props: IntegrationDetailPageProps): JSX.Element {
-	const { selectedIntegration, setSelectedIntegration, activeDetailTab } = props;
+	const {
+		selectedIntegration,
+		setSelectedIntegration,
+		activeDetailTab,
+		setActiveDetailTab,
+	} = props;
 
 	const {
 		data,
@@ -119,11 +125,13 @@ function IntegrationDetailPage(props: IntegrationDetailPageProps): JSX.Element {
 								metrics: null,
 							})}
 							refetchIntegrationDetails={refetch}
+							setActiveDetailTab={setActiveDetailTab}
 						/>
 						<IntegrationDetailContent
 							activeDetailTab={activeDetailTab}
 							integrationData={integrationData}
 							integrationId={selectedIntegration}
+							setActiveDetailTab={setActiveDetailTab}
 						/>
 
 						{connectionStatus !== ConnectionStates.NotInstalled && (

--- a/frontend/src/pages/Integrations/Integrations.tsx
+++ b/frontend/src/pages/Integrations/Integrations.tsx
@@ -55,6 +55,7 @@ function Integrations(): JSX.Element {
 						selectedIntegration={selectedIntegration}
 						setSelectedIntegration={setSelectedIntegration}
 						activeDetailTab={activeDetailTab}
+						setActiveDetailTab={setActiveDetailTab}
 					/>
 				) : (
 					<>


### PR DESCRIPTION
### Summary

- Now when the user visits the integrations page first time on click of `connect` button we open up a modal that says you need to configure... and when the user clicks `I have already configured` we make the API call to install the integration, else if he chooses to goto configure tab we do the same 
- Next when in test connection we provide two options to either wait or else go to configuration tab
- renamed the modal headings to `Connect Mongo` and `Test Mongo Connection`
- update the color of the `Test Connection` button to grey

#### Related Issues / PR's

Fixes:- https://github.com/SigNoz/engineering-pod/issues/1242

#### Screenshots

https://github.com/SigNoz/signoz/assets/54737045/af852281-0fa0-4da4-8f2b-0798cd55ace6

https://github.com/SigNoz/signoz/assets/54737045/5c2fcf6a-ff17-4454-b7a8-37237226c0bd



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
