### PR TITLE
chore: make send resolved notifs configurable

### DIFF
--- a/frontend/public/locales/en-GB/channels.json
+++ b/frontend/public/locales/en-GB/channels.json
@@ -15,6 +15,7 @@
   "button_test_channel": "Test",
   "button_return": "Back",
   "field_channel_name": "Name",
+  "field_send_resolved": "Send resolved alerts",
   "field_channel_type": "Type",
   "field_webhook_url": "Webhook URL",
   "field_slack_recipient": "Recipient",

--- a/frontend/public/locales/en/channels.json
+++ b/frontend/public/locales/en/channels.json
@@ -15,6 +15,7 @@
   "button_test_channel": "Test",
   "button_return": "Back",
   "field_channel_name": "Name",
+  "field_send_resolved": "Send resolved alerts",
   "field_channel_type": "Type",
   "field_webhook_url": "Webhook URL",
   "field_slack_recipient": "Recipient",

--- a/frontend/src/api/channels/createEmail.ts
+++ b/frontend/src/api/channels/createEmail.ts
@@ -12,7 +12,7 @@ const create = async (
 			name: props.name,
 			email_configs: [
 				{
-					send_resolved: true,
+					send_resolved: props.send_resolved,
 					to: props.to,
 					html: props.html,
 					headers: props.headers,

--- a/frontend/src/api/channels/createMsTeams.ts
+++ b/frontend/src/api/channels/createMsTeams.ts
@@ -12,7 +12,7 @@ const create = async (
 			name: props.name,
 			msteams_configs: [
 				{
-					send_resolved: true,
+					send_resolved: props.send_resolved,
 					webhook_url: props.webhook_url,
 					title: props.title,
 					text: props.text,

--- a/frontend/src/api/channels/createPager.ts
+++ b/frontend/src/api/channels/createPager.ts
@@ -12,7 +12,7 @@ const create = async (
 			name: props.name,
 			pagerduty_configs: [
 				{
-					send_resolved: true,
+					send_resolved: props.send_resolved,
 					routing_key: props.routing_key,
 					client: props.client,
 					client_url: props.client_url,

--- a/frontend/src/api/channels/createSlack.ts
+++ b/frontend/src/api/channels/createSlack.ts
@@ -12,7 +12,7 @@ const create = async (
 			name: props.name,
 			slack_configs: [
 				{
-					send_resolved: true,
+					send_resolved: props.send_resolved,
 					api_url: props.api_url,
 					channel: props.channel,
 					title: props.title,

--- a/frontend/src/api/channels/createWebhook.ts
+++ b/frontend/src/api/channels/createWebhook.ts
@@ -30,7 +30,7 @@ const create = async (
 			name: props.name,
 			webhook_configs: [
 				{
-					send_resolved: true,
+					send_resolved: props.send_resolved,
 					url: props.api_url,
 					http_config: httpConfig,
 				},

--- a/frontend/src/api/channels/editEmail.ts
+++ b/frontend/src/api/channels/editEmail.ts
@@ -12,7 +12,7 @@ const editEmail = async (
 			name: props.name,
 			email_configs: [
 				{
-					send_resolved: true,
+					send_resolved: props.send_resolved,
 					to: props.to,
 					html: props.html,
 					headers: props.headers,

--- a/frontend/src/api/channels/editMsTeams.ts
+++ b/frontend/src/api/channels/editMsTeams.ts
@@ -12,7 +12,7 @@ const editMsTeams = async (
 			name: props.name,
 			msteams_configs: [
 				{
-					send_resolved: true,
+					send_resolved: props.send_resolved,
 					webhook_url: props.webhook_url,
 					title: props.title,
 					text: props.text,

--- a/frontend/src/api/channels/editOpsgenie.ts
+++ b/frontend/src/api/channels/editOpsgenie.ts
@@ -12,7 +12,7 @@ const editOpsgenie = async (
 			name: props.name,
 			opsgenie_configs: [
 				{
-					send_resolved: true,
+					send_resolved: props.send_resolved,
 					api_key: props.api_key,
 					description: props.description,
 					priority: props.priority,

--- a/frontend/src/api/channels/editPager.ts
+++ b/frontend/src/api/channels/editPager.ts
@@ -12,7 +12,7 @@ const editPager = async (
 			name: props.name,
 			pagerduty_configs: [
 				{
-					send_resolved: true,
+					send_resolved: props.send_resolved,
 					routing_key: props.routing_key,
 					client: props.client,
 					client_url: props.client_url,

--- a/frontend/src/api/channels/editSlack.ts
+++ b/frontend/src/api/channels/editSlack.ts
@@ -12,7 +12,7 @@ const editSlack = async (
 			name: props.name,
 			slack_configs: [
 				{
-					send_resolved: true,
+					send_resolved: props.send_resolved,
 					api_url: props.api_url,
 					channel: props.channel,
 					title: props.title,

--- a/frontend/src/api/channels/editWebhook.ts
+++ b/frontend/src/api/channels/editWebhook.ts
@@ -29,7 +29,7 @@ const editWebhook = async (
 			name: props.name,
 			webhook_configs: [
 				{
-					send_resolved: true,
+					send_resolved: props.send_resolved,
 					url: props.api_url,
 					http_config: httpConfig,
 				},

--- a/frontend/src/container/CreateAlertChannels/index.tsx
+++ b/frontend/src/container/CreateAlertChannels/index.tsx
@@ -53,6 +53,7 @@ function CreateAlertChannels({
 				EmailChannel
 		>
 	>({
+		send_resolved: true,
 		text: `{{ range .Alerts -}}
      *Alert:* {{ .Labels.alertname }}{{ if .Labels.severity }} - {{ .Labels.severity }}{{ end }}
 
@@ -119,7 +120,7 @@ function CreateAlertChannels({
 			api_url: selectedConfig?.api_url || '',
 			channel: selectedConfig?.channel || '',
 			name: selectedConfig?.name || '',
-			send_resolved: true,
+			send_resolved: selectedConfig?.send_resolved || false,
 			text: selectedConfig?.text || '',
 			title: selectedConfig?.title || '',
 		}),
@@ -158,7 +159,7 @@ function CreateAlertChannels({
 		let request: WebhookChannel = {
 			api_url: selectedConfig?.api_url || '',
 			name: selectedConfig?.name || '',
-			send_resolved: true,
+			send_resolved: selectedConfig?.send_resolved || false,
 		};
 
 		if (selectedConfig?.username !== '' || selectedConfig?.password !== '') {
@@ -226,7 +227,7 @@ function CreateAlertChannels({
 
 		return {
 			name: selectedConfig?.name || '',
-			send_resolved: true,
+			send_resolved: selectedConfig?.send_resolved || false,
 			routing_key: selectedConfig?.routing_key || '',
 			client: selectedConfig?.client || '',
 			client_url: selectedConfig?.client_url || '',
@@ -274,7 +275,7 @@ function CreateAlertChannels({
 		() => ({
 			api_key: selectedConfig?.api_key || '',
 			name: selectedConfig?.name || '',
-			send_resolved: true,
+			send_resolved: selectedConfig?.send_resolved || false,
 			description: selectedConfig?.description || '',
 			message: selectedConfig?.message || '',
 			priority: selectedConfig?.priority || '',
@@ -312,7 +313,7 @@ function CreateAlertChannels({
 	const prepareEmailRequest = useCallback(
 		() => ({
 			name: selectedConfig?.name || '',
-			send_resolved: true,
+			send_resolved: selectedConfig?.send_resolved || false,
 			to: selectedConfig?.to || '',
 			html: selectedConfig?.html || '',
 			headers: selectedConfig?.headers || {},
@@ -350,7 +351,7 @@ function CreateAlertChannels({
 		() => ({
 			webhook_url: selectedConfig?.webhook_url || '',
 			name: selectedConfig?.name || '',
-			send_resolved: true,
+			send_resolved: selectedConfig?.send_resolved || false,
 			text: selectedConfig?.text || '',
 			title: selectedConfig?.title || '',
 		}),

--- a/frontend/src/container/EditAlertChannels/index.tsx
+++ b/frontend/src/container/EditAlertChannels/index.tsx
@@ -72,7 +72,7 @@ function EditAlertChannels({
 			api_url: selectedConfig?.api_url || '',
 			channel: selectedConfig?.channel || '',
 			name: selectedConfig?.name || '',
-			send_resolved: true,
+			send_resolved: selectedConfig?.send_resolved || false,
 			text: selectedConfig?.text || '',
 			title: selectedConfig?.title || '',
 			id,
@@ -115,7 +115,7 @@ function EditAlertChannels({
 		return {
 			api_url: selectedConfig?.api_url || '',
 			name: name || '',
-			send_resolved: true,
+			send_resolved: selectedConfig?.send_resolved || false,
 			username,
 			password,
 			id,
@@ -284,7 +284,7 @@ function EditAlertChannels({
 		() => ({
 			webhook_url: selectedConfig?.webhook_url || '',
 			name: selectedConfig?.name || '',
-			send_resolved: true,
+			send_resolved: selectedConfig?.send_resolved || false,
 			text: selectedConfig?.text || '',
 			title: selectedConfig?.title || '',
 			id,

--- a/frontend/src/container/FormAlertChannels/index.tsx
+++ b/frontend/src/container/FormAlertChannels/index.tsx
@@ -1,4 +1,4 @@
-import { Form, FormInstance, Input, Select, Typography } from 'antd';
+import { Form, FormInstance, Input, Select, Switch, Typography } from 'antd';
 import { Store } from 'antd/lib/form/interface';
 import UpgradePrompt from 'components/Upgrade/UpgradePrompt';
 import { FeatureKeys } from 'constants/features';
@@ -90,6 +90,22 @@ function FormAlertChannels({
 							setSelectedConfig((state) => ({
 								...state,
 								name: event.target.value,
+							}));
+						}}
+					/>
+				</Form.Item>
+
+				<Form.Item
+					label={t('field_send_resolved')}
+					labelAlign="left"
+					name="send_resolved"
+				>
+					<Switch
+						defaultChecked={initialValue?.send_resolved}
+						onChange={(value): void => {
+							setSelectedConfig((state) => ({
+								...state,
+								send_resolved: value,
 							}));
 						}}
 					/>


### PR DESCRIPTION
### Summary

Part of https://github.com/SigNoz/signoz/issues/3825

The resolved state of the alert triggers a notification with the original trigger values. This change makes the setting configurable. 

