### PR TITLE
fix: time preference from the panel should be used to fetch data

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCard/FullView/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/FullView/index.tsx
@@ -86,7 +86,7 @@ function FullView({
 		return {
 			query: updatedQuery,
 			graphType: PANEL_TYPES.LIST,
-			selectedTime: 'GLOBAL_TIME',
+			selectedTime: widget?.timePreferance || 'GLOBAL_TIME',
 			globalSelectedInterval: globalSelectedTime,
 			tableParams: {
 				pagination: {

--- a/frontend/src/container/GridCardLayout/GridCard/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/index.tsx
@@ -106,7 +106,7 @@ function GridCardGraph({
 		return {
 			query: updatedQuery,
 			graphType: PANEL_TYPES.LIST,
-			selectedTime: 'GLOBAL_TIME',
+			selectedTime: widget.timePreferance || 'GLOBAL_TIME',
 			globalSelectedInterval,
 			tableParams: {
 				pagination: {
@@ -121,7 +121,7 @@ function GridCardGraph({
 		{
 			...requestData,
 			variables: getDashboardVariables(variables),
-			selectedTime: 'GLOBAL_TIME',
+			selectedTime: widget.timePreferance || 'GLOBAL_TIME',
 			globalSelectedInterval,
 		},
 		version || DEFAULT_ENTITY_VERSION,


### PR DESCRIPTION

Current State: The panel uses GLOBAL_TIME to fetch data for the panel.
FIX: We need to use panel time preference to fetch data for the panel.