### PR TITLE
Feat: generate sync collector config for log pipelines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.8.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/ClickHouse/ch-go v0.61.3 // indirect
+	github.com/alecthomas/participle/v2 v2.1.1 // indirect
 	github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/aws/aws-sdk-go v1.53.16 // indirect
@@ -108,6 +109,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -118,6 +120,7 @@ require (
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
+	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
@@ -142,6 +145,7 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.102.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.102.0 // indirect
 	github.com/paulmach/orb v0.11.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/SigNoz/zap_otlp/zap_otlp_encoder v0.0.0-20230822164844-1b861a431974 h
 github.com/SigNoz/zap_otlp/zap_otlp_encoder v0.0.0-20230822164844-1b861a431974/go.mod h1:fpiHtiboLJpIE5TtkQfiWx6xtnlA+uWmv+N9opETqKY=
 github.com/SigNoz/zap_otlp/zap_otlp_sync v0.0.0-20230822164844-1b861a431974 h1:G2JzCrqdeOTtAn4tDFZEg5gCAEYVRXcddG3ZlrFMumo=
 github.com/SigNoz/zap_otlp/zap_otlp_sync v0.0.0-20230822164844-1b861a431974/go.mod h1:YtDal1xBRQfPRNo7iSU3W37RGT0jMW7Rnzk6EON3a4M=
+github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6icjJvbsmV8=
+github.com/alecthomas/participle/v2 v2.1.1/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -244,6 +246,8 @@ github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 h1:TQcrn6Wq+sKGkpyPvppOz99zsM
 github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/go-zookeeper/zk v1.0.3 h1:7M2kwOsc//9VeeFiPtf+uSJlVpU66x9Ba5+8XK7/TDg=
 github.com/go-zookeeper/zk v1.0.3/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -414,6 +418,8 @@ github.com/hetznercloud/hcloud-go/v2 v2.9.0/go.mod h1:qtW/TuU7Bs16ibXl/ktJarWqU2
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
+github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
@@ -583,6 +589,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.102
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.102.0/go.mod h1:cBbjwd8m4rBVgCQksUbAVQX1EoM5IuCyNQw2mzvibEM=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.102.0 h1:qsM5HhWpAfIMg8LdO4u+CHofu4UuCuJwg/M+ySO9uZA=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.102.0/go.mod h1:wBJlGy9Wx6s7AxIMcSne2sGw73e5ZUy1AQ/duYwpFf8=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.102.0 h1:EPmEtTgrlNzriEYZpkVOVDWlqWTUHoEqmM8oU/EpdkA=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.102.0/go.mod h1:qnLc/+jOVcsL1dF17ztBcf3juQ3f9bt6Wuf+Xxbrd9w=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.102.0 h1:vJL6lDaeI3pVA7ADnWKD3HMpI80BSrZ2UnGc+qkwqoY=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.102.0/go.mod h1:xtE7tds5j8PtI/wMuGb+Em5K9rJH8hm6t28Qe4QrpoU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.102.0 h1:TvJYcU/DLRFCgHr7nT98k5D+qkZ4syKVxc8OJjv+K4c=

--- a/pkg/query-service/app/logparsingpipeline/collector_config.go
+++ b/pkg/query-service/app/logparsingpipeline/collector_config.go
@@ -222,7 +222,7 @@ func GenerateCollectorConfigWithPipelines(
 		return nil, coreModel.BadRequest(err)
 	}
 
-	// fmt.Printf("DEBUG: Config Generated\n%s", updatedConf)
+	fmt.Printf("DEBUG: Config Generated\n%s", updatedConf)
 
 	return updatedConf, nil
 }

--- a/pkg/query-service/app/logparsingpipeline/collector_config.go
+++ b/pkg/query-service/app/logparsingpipeline/collector_config.go
@@ -222,7 +222,5 @@ func GenerateCollectorConfigWithPipelines(
 		return nil, coreModel.BadRequest(err)
 	}
 
-	fmt.Printf("DEBUG: Config Generated\n%s", updatedConf)
-
 	return updatedConf, nil
 }

--- a/pkg/query-service/app/logparsingpipeline/collector_config.go
+++ b/pkg/query-service/app/logparsingpipeline/collector_config.go
@@ -222,7 +222,7 @@ func GenerateCollectorConfigWithPipelines(
 		return nil, coreModel.BadRequest(err)
 	}
 
-	fmt.Printf("DEBUG: Config Generated\n%s", updatedConf)
+	// fmt.Printf("DEBUG: Config Generated\n%s", updatedConf)
 
 	return updatedConf, nil
 }

--- a/pkg/query-service/app/logparsingpipeline/collector_config.go
+++ b/pkg/query-service/app/logparsingpipeline/collector_config.go
@@ -222,5 +222,7 @@ func GenerateCollectorConfigWithPipelines(
 		return nil, coreModel.BadRequest(err)
 	}
 
+	fmt.Printf("DEBUG: Config Generated\n%s", updatedConf)
+
 	return updatedConf, nil
 }

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
@@ -151,6 +151,23 @@ func PreparePipelineProcessor(pipelines []Pipeline) (map[string]interface{}, []s
 							toOttlExpr(parseFromNotNilCheck),
 						)
 
+					} else if operator.Type == "grok_parser" {
+						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+						if err != nil {
+							return nil, nil, fmt.Errorf(
+								"couldn't generate nil check for parseFrom of grok op %s: %w", operator.Name, err,
+							)
+						}
+						appendStatement(
+							fmt.Sprintf(
+								`merge_maps(%s, GrokParse(%s, "%s"), "upsert")`,
+								ottlPath(operator.ParseTo),
+								ottlPath(operator.ParseFrom),
+								escapeDoubleQuotes(operator.Pattern),
+							),
+							toOttlExpr(parseFromNotNilCheck),
+						)
+
 					} else if operator.Type == "json_parser" {
 						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
 						if err != nil {

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
@@ -447,7 +447,7 @@ func PreparePipelineProcessor(pipelines []Pipeline) (map[string]interface{}, []s
 
 	// TODO(Raj): Maybe validate ottl statements
 	if len(ottlStatements) > 0 {
-		pipelinesProcessorName := "transform/logs-pipelines"
+		pipelinesProcessorName := "signoztransform/logs-pipelines"
 		names = append(names, pipelinesProcessorName)
 		processors[pipelinesProcessorName] = map[string]interface{}{
 			"error_mode": "ignore",

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
@@ -429,7 +429,7 @@ func PreparePipelineProcessor(pipelines []Pipeline) (map[string]interface{}, []s
 							}
 							// TODO(Raj): Also check for trace flags hex regex pattern
 							appendStatement(
-								fmt.Sprintf(`set(flags, Hex2Int(%s))`, ottlPath(operator.TraceFlags.ParseFrom)),
+								fmt.Sprintf(`set(flags, HexToInt(%s))`, ottlPath(operator.TraceFlags.ParseFrom)),
 								toOttlExpr(parseFromNotNilCheck),
 							)
 						}

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
@@ -85,7 +85,14 @@ func PreparePipelineProcessor(pipelines []Pipeline) (map[string]interface{}, []s
 
 			appendStatement := func(statement string) {
 				if len(filterExpr) > 0 {
-					statement = fmt.Sprintf("%s where %s", statement, filterExpr)
+					// statement = fmt.Sprintf(`%s where EXPR("%s")`, statement, strings.ReplaceAll(filterExpr, `"`, `\"`))
+					statement = fmt.Sprintf(
+						`%s where EXPR("%s")`,
+						statement,
+						strings.ReplaceAll(
+							strings.ReplaceAll(filterExpr, `\`, `\\`), `"`, `\"`,
+						),
+					)
 				}
 				ottlStatements = append(ottlStatements, statement)
 			}
@@ -96,7 +103,7 @@ func PreparePipelineProcessor(pipelines []Pipeline) (map[string]interface{}, []s
 					if operator.Type == "add" {
 						value := fmt.Sprintf(`"%s"`, operator.Value)
 						if strings.HasPrefix(operator.Value, "EXPR(") {
-							value = operator.Value[5 : len(operator.Value)-1]
+							value = fmt.Sprintf(`EXPR("%s")`, operator.Value[5:len(operator.Value)-1])
 						}
 						appendStatement(fmt.Sprintf(`set(%s, %s)`, ottlPath(operator.Field), value))
 

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
@@ -83,7 +83,11 @@ func PreparePipelineProcessor(pipelines []Pipeline) (map[string]interface{}, []s
 						statement = fmt.Sprintf(`set(%s, "%s")`, ottlPath(operator.Field), operator.Value)
 
 					} else if operator.Type == "remove" {
-						statement = fmt.Sprintf(`set(%s, "%s")`, ottlPath(operator.Field), operator.Value)
+						fieldPath := ottlPath(operator.Field)
+						fieldPathParts := rSplitAfterN(fieldPath, "[", 2)
+						target := fieldPathParts[0]
+						key := fieldPathParts[1][1 : len(fieldPathParts[1])-1]
+						statement = fmt.Sprintf(`delete_key(%s, %s)`, target, key)
 
 					} else {
 						return nil, nil, fmt.Errorf("unsupported pipeline operator type: %s", operator.Type)

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
@@ -2,14 +2,12 @@ package logparsingpipeline
 
 import (
 	"fmt"
-	"regexp"
 	"slices"
 	"strings"
 
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/ast"
 	"github.com/antonmedv/expr/parser"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"go.signoz.io/signoz/pkg/query-service/constants"
 	"go.signoz.io/signoz/pkg/query-service/queryBuilderToExpr"
@@ -23,434 +21,7 @@ func CollectorConfProcessorName(p Pipeline) string {
 	return constants.LogsPPLPfx + p.Alias
 }
 
-// a.b?.c -> ["a", "b", "c"]
-// a.b["c.d"].e -> ["a", "b", "c.d", "e"]
-func pathParts(path string) []string {
-	path = strings.ReplaceAll(path, "?.", ".")
-
-	// Split once from the right to include the rightmost membership op and everything after it.
-	// Eg: `attributes.test["a.b"].value["c.d"].e` would result in `attributes.test["a.b"].value` and `["c.d"].e`
-	memberOpParts := rSplitAfterN(path, "[", 2)
-
-	if len(memberOpParts) < 2 {
-		// there is no [] access in fieldPath
-		return strings.Split(path, ".")
-	}
-
-	// recursively get parts for path prefix before rightmost membership op (`attributes.test["a.b"].value`)
-	parts := pathParts(memberOpParts[0])
-
-	suffixParts := strings.SplitAfter(memberOpParts[1], "]") // ["c.d"].e -> `["c.d"]`, `.e`
-
-	// add key used in membership op ("c.d")
-	parts = append(parts, suffixParts[0][2:len(suffixParts[0])-2])
-
-	// add parts for path after the membership op ("e")
-	if len(suffixParts[1]) > 0 {
-		parts = append(parts, strings.Split(suffixParts[1][1:], ".")...)
-	}
-
-	return parts
-}
-
-// converts a logtransform path to an equivalent ottl path
-// For details, see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottllog#paths
-func logTransformPathToOttlPath(path string) string {
-	if !(strings.HasPrefix(path, "attributes") || strings.HasPrefix(path, "resource")) {
-		return path
-	}
-
-	parts := pathParts(path)
-
-	ottlPathParts := []string{parts[0]}
-
-	if ottlPathParts[0] == "resource" {
-		ottlPathParts[0] = "resource.attributes"
-	}
-
-	for _, p := range parts[1:] {
-		ottlPathParts = append(ottlPathParts, fmt.Sprintf(`["%s"]`, p))
-	}
-
-	return strings.Join(ottlPathParts, "")
-}
-
-func PreparePipelineProcessor(pipelines []Pipeline) (map[string]interface{}, []string, error) {
-	processors := map[string]interface{}{}
-	names := []string{}
-
-	ottlStatements := []string{}
-
-	for _, pipeline := range pipelines {
-		if pipeline.Enabled {
-
-			enabledOperators := []PipelineOperator{}
-			for _, op := range pipeline.Config {
-				if op.Enabled {
-					enabledOperators = append(enabledOperators, op)
-				}
-			}
-			if len(enabledOperators) < 1 {
-				continue
-			}
-
-			filterExpr, err := queryBuilderToExpr.Parse(pipeline.Filter)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to parse pipeline filter: %w", err)
-			}
-
-			escapeDoubleQuotes := func(str string) string {
-				return strings.ReplaceAll(
-					strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`,
-				)
-			}
-
-			toOttlExpr := func(expr string) string {
-				return fmt.Sprintf(`EXPR("%s")`, escapeDoubleQuotes(expr))
-			}
-
-			// We are generating one or more ottl statements per pipeline operator.
-			// ottl statements have individual where conditions per statement
-			// The simplest path is to add where clause for pipeline filter to each statement.
-			// However, this breaks if an early operator statement in the pipeline ends up
-			// modifying the fields referenced in the pipeline filter.
-			// To work around this, we add statements before and after the actual pipeline
-			// operator statements, that add and remove a pipeline specific marker, ensuring
-			// all operators in a pipeline get to act on the log even if an op changes the filter referenced fields.
-			pipelineMarker := fmt.Sprintf("signoz-log-pipeline-%s", pipeline.Alias)
-			addMarkerStatement := fmt.Sprintf(`set(attributes["__signoz_pipeline_marker__"], "%s")`, pipelineMarker)
-			if len(filterExpr) > 0 {
-				addMarkerStatement += fmt.Sprintf(" where %s", toOttlExpr(filterExpr))
-			}
-			ottlStatements = append(ottlStatements, addMarkerStatement)
-			pipelineMarkerWhereClause := fmt.Sprintf(
-				`attributes["__signoz_pipeline_marker__"] == "%s"`, pipelineMarker,
-			)
-
-			// to be called at the end
-			removePipelineMarker := func() {
-				ottlStatements = append(ottlStatements, fmt.Sprintf(
-					`delete_key(attributes, "__signoz_pipeline_marker__") where %s`, pipelineMarkerWhereClause,
-				))
-			}
-
-			appendStatement := func(statement string, additionalFilter string) {
-				whereConditions := []string{pipelineMarkerWhereClause}
-
-				if len(additionalFilter) > 0 {
-					whereConditions = append(whereConditions, additionalFilter)
-				}
-
-				statement = fmt.Sprintf(
-					`%s where %s`, statement, strings.Join(whereConditions, " and "),
-				)
-
-				ottlStatements = append(ottlStatements, statement)
-			}
-
-			appendDeleteStatement := func(path string) {
-				fieldPath := logTransformPathToOttlPath(path)
-				fieldPathParts := rSplitAfterN(fieldPath, "[", 2)
-				target := fieldPathParts[0]
-				key := fieldPathParts[1][1 : len(fieldPathParts[1])-1]
-
-				pathNotNilCheck, err := fieldNotNilCheck(path)
-				if err != nil {
-					panic(err)
-				}
-
-				appendStatement(
-					fmt.Sprintf(`delete_key(%s, %s)`, target, key),
-					toOttlExpr(pathNotNilCheck),
-				)
-			}
-
-			appendMapExtractStatements := func(
-				filterClause string,
-				mapGenerator string,
-				target string,
-			) {
-				cacheKey := uuid.NewString()
-				// Extract parsed map to cache.
-				appendStatement(fmt.Sprintf(
-					`set(cache["%s"], %s)`, cacheKey, mapGenerator,
-				), filterClause)
-
-				// Set target to a map if not already one.
-				appendStatement(fmt.Sprintf(
-					`set(%s, ParseJSON("{}"))`, logTransformPathToOttlPath(target),
-				), strings.Join([]string{
-					fmt.Sprintf(`cache["%s"] != nil`, cacheKey),
-					fmt.Sprintf("not IsMap(%s)", logTransformPathToOttlPath(target)),
-				}, " and "))
-
-				appendStatement(
-					fmt.Sprintf(
-						`merge_maps(%s, cache["%s"], "upsert")`,
-						logTransformPathToOttlPath(target), cacheKey,
-					),
-					fmt.Sprintf(`cache["%s"] != nil`, cacheKey),
-				)
-			}
-
-			for _, operator := range pipeline.Config {
-				if operator.Enabled {
-
-					if operator.Type == "add" {
-						value := fmt.Sprintf(`"%s"`, operator.Value)
-						condition := ""
-						if strings.HasPrefix(operator.Value, "EXPR(") {
-							expression := strings.TrimSuffix(strings.TrimPrefix(operator.Value, "EXPR("), ")")
-							value = toOttlExpr(expression)
-							fieldsNotNilCheck, err := fieldsReferencedInExprNotNilCheck(expression)
-							if err != nil {
-								return nil, nil, fmt.Errorf(
-									"could'nt generate nil check for fields referenced in value expr of add operator %s: %w",
-									operator.Name, err,
-								)
-							}
-							if fieldsNotNilCheck != "" {
-								condition = toOttlExpr(fieldsNotNilCheck)
-							}
-						}
-						appendStatement(
-							fmt.Sprintf(`set(%s, %s)`, logTransformPathToOttlPath(operator.Field), value),
-							condition,
-						)
-
-					} else if operator.Type == "remove" {
-						appendDeleteStatement(operator.Field)
-
-					} else if operator.Type == "copy" {
-						appendStatement(fmt.Sprintf(`set(%s, %s)`, logTransformPathToOttlPath(operator.To), logTransformPathToOttlPath(operator.From)), "")
-
-					} else if operator.Type == "move" {
-						appendStatement(fmt.Sprintf(`set(%s, %s)`, logTransformPathToOttlPath(operator.To), logTransformPathToOttlPath(operator.From)), "")
-						appendDeleteStatement(operator.From)
-
-					} else if operator.Type == "regex_parser" {
-						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
-						if err != nil {
-							return nil, nil, fmt.Errorf(
-								"couldn't generate nil check for parseFrom of regex op %s: %w", operator.Name, err,
-							)
-						}
-						appendStatement(
-							fmt.Sprintf(
-								`merge_maps(%s, ExtractPatterns(%s, "%s"), "upsert")`,
-								logTransformPathToOttlPath(operator.ParseTo),
-								logTransformPathToOttlPath(operator.ParseFrom),
-								escapeDoubleQuotes(operator.Regex),
-							),
-							toOttlExpr(parseFromNotNilCheck),
-						)
-
-					} else if operator.Type == "grok_parser" {
-						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
-						if err != nil {
-							return nil, nil, fmt.Errorf(
-								"couldn't generate nil check for parseFrom of grok op %s: %w", operator.Name, err,
-							)
-						}
-						appendStatement(
-							fmt.Sprintf(
-								`merge_maps(%s, GrokParse(%s, "%s"), "upsert")`,
-								logTransformPathToOttlPath(operator.ParseTo),
-								logTransformPathToOttlPath(operator.ParseFrom),
-								escapeDoubleQuotes(operator.Pattern),
-							),
-							toOttlExpr(parseFromNotNilCheck),
-						)
-
-					} else if operator.Type == "json_parser" {
-						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
-						if err != nil {
-							return nil, nil, fmt.Errorf(
-								"couldn't generate nil check for parseFrom of json parser op %s: %w", operator.Name, err,
-							)
-						}
-						whereClause := strings.Join([]string{
-							toOttlExpr(parseFromNotNilCheck),
-							fmt.Sprintf(`IsMatch(%s, "^\\s*{.*}\\s*$")`, logTransformPathToOttlPath(operator.ParseFrom)),
-						}, " and ")
-
-						appendMapExtractStatements(
-							whereClause,
-							fmt.Sprintf("ParseJSON(%s)", logTransformPathToOttlPath(operator.ParseFrom)),
-							logTransformPathToOttlPath(operator.ParseTo),
-						)
-
-					} else if operator.Type == "time_parser" {
-						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
-						if err != nil {
-							return nil, nil, fmt.Errorf(
-								"couldn't generate nil check for parseFrom of json parser op %s: %w", operator.Name, err,
-							)
-						}
-
-						whereClauseParts := []string{toOttlExpr(parseFromNotNilCheck)}
-
-						if operator.LayoutType == "strptime" {
-							regex, err := RegexForStrptimeLayout(operator.Layout)
-							if err != nil {
-								return nil, nil, fmt.Errorf(
-									"couldn't generate layout regex for time_parser %s: %w", operator.Name, err,
-								)
-							}
-							whereClauseParts = append(whereClauseParts,
-								fmt.Sprintf(`IsMatch(%s, "%s")`, logTransformPathToOttlPath(operator.ParseFrom), regex),
-							)
-
-							appendStatement(
-								fmt.Sprintf(
-									`set(time, Time(%s, "%s"))`,
-									logTransformPathToOttlPath(operator.ParseFrom),
-									operator.Layout,
-								),
-								strings.Join(whereClauseParts, " and "),
-							)
-
-						} else if operator.LayoutType == "epoch" {
-							valueRegex := `^\\s*[0-9]+\\s*$`
-							if strings.Contains(operator.Layout, ".") {
-								valueRegex = `^\\s*[0-9]+\\.[0-9]+\\s*$`
-							}
-
-							whereClauseParts = append(whereClauseParts,
-								toOttlExpr(fmt.Sprintf(
-									`string(%s) matches "%s"`, operator.ParseFrom, valueRegex,
-								)),
-							)
-
-							timeValue := fmt.Sprintf("Double(%s)", logTransformPathToOttlPath(operator.ParseFrom))
-							if strings.HasPrefix(operator.Layout, "seconds") {
-								timeValue = fmt.Sprintf("%s * 1000000000", timeValue)
-							} else if operator.Layout == "milliseconds" {
-								timeValue = fmt.Sprintf("%s * 1000000", timeValue)
-							} else if operator.Layout == "microseconds" {
-								timeValue = fmt.Sprintf("%s * 1000", timeValue)
-							}
-							appendStatement(
-								fmt.Sprintf(`set(time_unix_nano, %s)`, timeValue),
-								strings.Join(whereClauseParts, " and "),
-							)
-						} else {
-							return nil, nil, fmt.Errorf("unsupported time layout %s", operator.LayoutType)
-						}
-
-					} else if operator.Type == "severity_parser" {
-						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
-						if err != nil {
-							return nil, nil, fmt.Errorf(
-								"couldn't generate nil check for parseFrom of severity parser %s: %w", operator.Name, err,
-							)
-						}
-
-						for severity, valuesToMap := range operator.SeverityMapping {
-							for _, value := range valuesToMap {
-								// Special case for 2xx 3xx 4xx and 5xx
-								isSpecialValue, err := regexp.MatchString(`^\s*[2|3|4|5]xx\s*$`, strings.ToLower(value))
-								if err != nil {
-									return nil, nil, fmt.Errorf("couldn't regex match for wildcard severity values: %w", err)
-								}
-								if isSpecialValue {
-									whereClause := strings.Join([]string{
-										toOttlExpr(parseFromNotNilCheck),
-										toOttlExpr(fmt.Sprintf(`type(%s) in ["int", "float"] && %s == float(int(%s))`, operator.ParseFrom, operator.ParseFrom, operator.ParseFrom)),
-										toOttlExpr(fmt.Sprintf(`string(int(%s)) matches "^%s$"`, operator.ParseFrom, fmt.Sprintf("%s[0-9]{2}", value[0:1]))),
-									}, " and ")
-									appendStatement(fmt.Sprintf("set(severity_number, SEVERITY_NUMBER_%s)", strings.ToUpper(severity)), whereClause)
-									appendStatement(fmt.Sprintf(`set(severity_text, "%s")`, strings.ToUpper(severity)), whereClause)
-								} else {
-									whereClause := strings.Join([]string{
-										toOttlExpr(parseFromNotNilCheck),
-										fmt.Sprintf(
-											`IsString(%s)`,
-											logTransformPathToOttlPath(operator.ParseFrom),
-										),
-										fmt.Sprintf(
-											`IsMatch(%s, "^\\s*%s\\s*$")`,
-											logTransformPathToOttlPath(operator.ParseFrom), value,
-										),
-									}, " and ")
-									appendStatement(fmt.Sprintf("set(severity_number, SEVERITY_NUMBER_%s)", strings.ToUpper(severity)), whereClause)
-									appendStatement(fmt.Sprintf(`set(severity_text, "%s")`, strings.ToUpper(severity)), whereClause)
-								}
-							}
-						}
-					} else if operator.Type == "trace_parser" {
-						// panic("TODO(Raj): Implement trace parser translation")
-						if operator.TraceId != nil && len(operator.TraceId.ParseFrom) > 0 {
-							parseFromNotNilCheck, err := fieldNotNilCheck(operator.TraceId.ParseFrom)
-							if err != nil {
-								return nil, nil, fmt.Errorf(
-									"couldn't generate nil check for TraceId.parseFrom %s: %w", operator.Name, err,
-								)
-							}
-							// TODO(Raj): Also check for trace id regex pattern
-							appendStatement(
-								fmt.Sprintf(`set(trace_id.string, %s)`, logTransformPathToOttlPath(operator.TraceId.ParseFrom)),
-								toOttlExpr(parseFromNotNilCheck),
-							)
-						}
-
-						if operator.SpanId != nil && len(operator.SpanId.ParseFrom) > 0 {
-							parseFromNotNilCheck, err := fieldNotNilCheck(operator.SpanId.ParseFrom)
-							if err != nil {
-								return nil, nil, fmt.Errorf(
-									"couldn't generate nil check for TraceId.parseFrom %s: %w", operator.Name, err,
-								)
-							}
-							// TODO(Raj): Also check for span id regex pattern
-							appendStatement(
-								fmt.Sprintf("set(span_id.string, %s)", logTransformPathToOttlPath(operator.SpanId.ParseFrom)),
-								toOttlExpr(parseFromNotNilCheck),
-							)
-
-						}
-
-						if operator.TraceFlags != nil && len(operator.TraceFlags.ParseFrom) > 0 {
-
-							parseFromNotNilCheck, err := fieldNotNilCheck(operator.TraceFlags.ParseFrom)
-							if err != nil {
-								return nil, nil, fmt.Errorf(
-									"couldn't generate nil check for TraceId.parseFrom %s: %w", operator.Name, err,
-								)
-							}
-							// TODO(Raj): Also check for trace flags hex regex pattern
-							appendStatement(
-								fmt.Sprintf(`set(flags, HexToInt(%s))`, logTransformPathToOttlPath(operator.TraceFlags.ParseFrom)),
-								toOttlExpr(parseFromNotNilCheck),
-							)
-						}
-
-					} else {
-						return nil, nil, fmt.Errorf("unsupported pipeline operator type: %s", operator.Type)
-					}
-
-				}
-			}
-
-			removePipelineMarker()
-		}
-	}
-
-	// TODO(Raj): Maybe validate ottl statements
-	if len(ottlStatements) > 0 {
-		pipelinesProcessorName := "signoztransform/logs-pipelines"
-		names = append(names, pipelinesProcessorName)
-		processors[pipelinesProcessorName] = map[string]interface{}{
-			"error_mode": "ignore",
-			"log_statements": []map[string]interface{}{
-				{
-					"context":    "log",
-					"statements": ottlStatements,
-				},
-			},
-		}
-	}
-	return processors, names, nil
-}
+// Old proc generation logic
 
 func PreparePipelineProcessorOld(pipelines []Pipeline) (map[string]interface{}, []string, error) {
 	processors := map[string]interface{}{}
@@ -512,6 +83,156 @@ func PreparePipelineProcessorOld(pipelines []Pipeline) (map[string]interface{}, 
 	}
 	return processors, names, nil
 }
+
+func getOperators(ops []PipelineOperator) ([]PipelineOperator, error) {
+	filteredOp := []PipelineOperator{}
+	for i, operator := range ops {
+		if operator.Enabled {
+			if len(filteredOp) > 0 {
+				filteredOp[len(filteredOp)-1].Output = operator.ID
+			}
+
+			if operator.Type == "regex_parser" {
+				parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"couldn't generate nil check for parseFrom of regex op %s: %w", operator.Name, err,
+					)
+				}
+				operator.If = fmt.Sprintf(
+					`%s && %s matches "%s"`,
+					parseFromNotNilCheck,
+					operator.ParseFrom,
+					strings.ReplaceAll(
+						strings.ReplaceAll(operator.Regex, `\`, `\\`),
+						`"`, `\"`,
+					),
+				)
+
+			} else if operator.Type == "grok_parser" {
+				parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"couldn't generate nil check for parseFrom of grok op %s: %w", operator.Name, err,
+					)
+				}
+				operator.If = parseFromNotNilCheck
+
+			} else if operator.Type == "json_parser" {
+				parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"couldn't generate nil check for parseFrom of json parser op %s: %w", operator.Name, err,
+					)
+				}
+				operator.If = fmt.Sprintf(
+					`%s && %s matches "^\\s*{.*}\\s*$"`, parseFromNotNilCheck, operator.ParseFrom,
+				)
+
+			} else if operator.Type == "add" {
+				if strings.HasPrefix(operator.Value, "EXPR(") && strings.HasSuffix(operator.Value, ")") {
+					expression := strings.TrimSuffix(strings.TrimPrefix(operator.Value, "EXPR("), ")")
+					fieldsNotNilCheck, err := fieldsReferencedInExprNotNilCheck(expression)
+					if err != nil {
+						return nil, fmt.Errorf(
+							"could'nt generate nil check for fields referenced in value expr of add operator %s: %w",
+							operator.Name, err,
+						)
+					}
+					if fieldsNotNilCheck != "" {
+						operator.If = fieldsNotNilCheck
+					}
+				}
+
+			} else if operator.Type == "move" || operator.Type == "copy" {
+				fromNotNilCheck, err := fieldNotNilCheck(operator.From)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"couldn't generate nil check for From field of %s op %s: %w", operator.Type, operator.Name, err,
+					)
+				}
+				operator.If = fromNotNilCheck
+
+			} else if operator.Type == "remove" {
+				fieldNotNilCheck, err := fieldNotNilCheck(operator.Field)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"couldn't generate nil check for field to be removed by op %s: %w", operator.Name, err,
+					)
+				}
+				operator.If = fieldNotNilCheck
+
+			} else if operator.Type == "trace_parser" {
+				cleanTraceParser(&operator)
+
+			} else if operator.Type == "time_parser" {
+				parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"couldn't generate nil check for parseFrom of time parser op %s: %w", operator.Name, err,
+					)
+				}
+				operator.If = parseFromNotNilCheck
+
+				if operator.LayoutType == "strptime" {
+					regex, err := RegexForStrptimeLayout(operator.Layout)
+					if err != nil {
+						return nil, fmt.Errorf(
+							"couldn't generate layout regex for time_parser %s: %w", operator.Name, err,
+						)
+					}
+
+					operator.If = fmt.Sprintf(
+						`%s && %s matches "%s"`, operator.If, operator.ParseFrom, regex,
+					)
+				} else if operator.LayoutType == "epoch" {
+					valueRegex := `^\\s*[0-9]+\\s*$`
+					if strings.Contains(operator.Layout, ".") {
+						valueRegex = `^\\s*[0-9]+\\.[0-9]+\\s*$`
+					}
+
+					operator.If = fmt.Sprintf(
+						`%s && string(%s) matches "%s"`, operator.If, operator.ParseFrom, valueRegex,
+					)
+
+				}
+				// TODO(Raj): Maybe add support for gotime too eventually
+
+			} else if operator.Type == "severity_parser" {
+				parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"couldn't generate nil check for parseFrom of severity parser %s: %w", operator.Name, err,
+					)
+				}
+				operator.If = fmt.Sprintf(
+					`%s && ( type(%s) == "string" || ( type(%s) in ["int", "float"] && %s == float(int(%s)) ) )`,
+					parseFromNotNilCheck, operator.ParseFrom, operator.ParseFrom, operator.ParseFrom, operator.ParseFrom,
+				)
+
+			}
+
+			filteredOp = append(filteredOp, operator)
+		} else if i == len(ops)-1 && len(filteredOp) != 0 {
+			filteredOp[len(filteredOp)-1].Output = ""
+		}
+	}
+	return filteredOp, nil
+}
+
+func cleanTraceParser(operator *PipelineOperator) {
+	if operator.TraceId != nil && len(operator.TraceId.ParseFrom) < 1 {
+		operator.TraceId = nil
+	}
+	if operator.SpanId != nil && len(operator.SpanId.ParseFrom) < 1 {
+		operator.SpanId = nil
+	}
+	if operator.TraceFlags != nil && len(operator.TraceFlags.ParseFrom) < 1 {
+		operator.TraceFlags = nil
+	}
+}
+
+// End of old stuff
 
 // Generates an expression checking that `fieldPath` has a non-nil value in a log record.
 func fieldNotNilCheck(fieldPath string) (string, error) {

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilderV2.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilderV2.go
@@ -12,6 +12,423 @@ import (
 	"go.signoz.io/signoz/pkg/query-service/queryBuilderToExpr"
 )
 
+func PreparePipelineProcessor(pipelines []Pipeline) (map[string]interface{}, []string, error) {
+	processors := map[string]interface{}{}
+	names := []string{}
+
+	ottlStatements := []string{}
+
+	for _, pipeline := range pipelines {
+		if pipeline.Enabled {
+			pipelineOttlStatements, err := ottlStatementsForPipeline(pipeline)
+			if err != nil {
+				return nil, nil, fmt.Errorf("couldn't generate ottl statements for pipeline %s: %w", pipeline.Alias, err)
+			}
+
+			ottlStatements = append(ottlStatements, pipelineOttlStatements...)
+		}
+	}
+
+	// TODO(Raj): Maybe validate ottl statements
+	if len(ottlStatements) > 0 {
+		pipelinesProcessorName := "signoztransform/logs-pipelines"
+		names = append(names, pipelinesProcessorName)
+		processors[pipelinesProcessorName] = map[string]interface{}{
+			"error_mode": "ignore",
+			"log_statements": []map[string]interface{}{
+				{
+					"context":    "log",
+					"statements": ottlStatements,
+				},
+			},
+		}
+	}
+	return processors, names, nil
+}
+
+// representation for ottl statements used for putting
+// together ottl statements for pipelines
+type ottlStatement struct {
+	// All ottl statements have exactly 1 "editor" for transforming log
+	editor string
+	// editor only gets applied if a log matches the condition
+	conditions []string
+}
+
+func (s *ottlStatement) toString() string {
+	if len(s.conditions) < 1 {
+		return s.editor
+	}
+
+	conditions := []string{}
+	for _, c := range s.conditions {
+		if len(c) > 0 {
+			conditions = append(conditions, c)
+		}
+	}
+
+	return fmt.Sprintf(
+		"%s where %s",
+		s.editor,
+		strings.Join(conditions, " and "),
+	)
+}
+
+func ottlStatementsForPipeline(pipeline Pipeline) ([]string, error) {
+
+	ottlStatements := []string{}
+
+	enabledOperators := []PipelineOperator{}
+	for _, op := range pipeline.Config {
+		if op.Enabled {
+			enabledOperators = append(enabledOperators, op)
+		}
+	}
+	if len(enabledOperators) < 1 {
+		return ottlStatements, nil
+	}
+
+	filterExpr, err := queryBuilderToExpr.Parse(pipeline.Filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pipeline filter: %w", err)
+	}
+
+	// We are generating one or more ottl statements per pipeline operator.
+	// ottl statements have individual where conditions per statement
+	// The simplest path is to add where clause for pipeline filter to each statement.
+	// However, this breaks if an early operator statement in the pipeline ends up
+	// modifying the fields referenced in the pipeline filter.
+	// To work around this, we add statements before and after the actual pipeline
+	// operator statements, that add and remove a pipeline specific marker, ensuring
+	// all operators in a pipeline get to act on the log even if an op changes the filter referenced fields.
+	pipelineMarker := fmt.Sprintf("%s-%s", pipeline.Alias, pipeline.Id) // pipeline.Id is guranteed to be unique by DB.
+	addMarkerStatement := fmt.Sprintf(`set(attributes["__matched-log-pipeline__"], "%s")`, pipelineMarker)
+	if len(filterExpr) > 0 {
+		addMarkerStatement += fmt.Sprintf(" where %s", exprForOttl(filterExpr))
+	}
+	ottlStatements = append(ottlStatements, addMarkerStatement)
+	pipelineMarkerWhereClause := fmt.Sprintf(
+		`attributes["__matched-log-pipeline__"] == "%s"`, pipelineMarker,
+	)
+
+	// to be called at the end
+	removePipelineMarker := func() {
+		ottlStatements = append(ottlStatements, fmt.Sprintf(
+			`delete_key(attributes, "__matched-log-pipeline__") where %s`, pipelineMarkerWhereClause,
+		))
+	}
+
+	pipelineStmt := func(editor string, conditions []string) ottlStatement {
+		stmt := ottlStatement{
+			editor:     editor,
+			conditions: []string{pipelineMarkerWhereClause},
+		}
+
+		if len(conditions) > 0 {
+			stmt.conditions = append(stmt.conditions, conditions...)
+		}
+
+		return stmt
+	}
+
+	appendStatement := func(statement string, additionalFilter string) {
+		conditions := []string{}
+		if len(additionalFilter) > 0 {
+			conditions = append(conditions, additionalFilter)
+		}
+		stmt := pipelineStmt(statement, conditions)
+
+		ottlStatements = append(ottlStatements, stmt.toString())
+	}
+
+	appendDeleteStatement := func(path string) {
+		fieldPath := logTransformPathToOttlPath(path)
+		fieldPathParts := rSplitAfterN(fieldPath, "[", 2)
+		target := fieldPathParts[0]
+		key := fieldPathParts[1][1 : len(fieldPathParts[1])-1]
+
+		pathNotNilCheck, err := fieldNotNilCheck(path)
+		if err != nil {
+			panic(err)
+		}
+
+		appendStatement(
+			fmt.Sprintf(`delete_key(%s, %s)`, target, key),
+			exprForOttl(pathNotNilCheck),
+		)
+	}
+
+	appendMapExtractStatements := func(
+		filterClause string,
+		mapGenerator string,
+		target string,
+	) {
+		cacheKey := uuid.NewString()
+		// Extract parsed map to cache.
+		appendStatement(fmt.Sprintf(
+			`set(cache["%s"], %s)`, cacheKey, mapGenerator,
+		), filterClause)
+
+		// Set target to a map if not already one.
+		appendStatement(fmt.Sprintf(
+			`set(%s, ParseJSON("{}"))`, logTransformPathToOttlPath(target),
+		), strings.Join([]string{
+			fmt.Sprintf(`cache["%s"] != nil`, cacheKey),
+			fmt.Sprintf("not IsMap(%s)", logTransformPathToOttlPath(target)),
+		}, " and "))
+
+		appendStatement(
+			fmt.Sprintf(
+				`merge_maps(%s, cache["%s"], "upsert")`,
+				logTransformPathToOttlPath(target), cacheKey,
+			),
+			fmt.Sprintf(`cache["%s"] != nil`, cacheKey),
+		)
+	}
+
+	for _, operator := range pipeline.Config {
+		if operator.Enabled {
+
+			if operator.Type == "add" {
+				value := fmt.Sprintf(`"%s"`, operator.Value)
+				condition := ""
+				if strings.HasPrefix(operator.Value, "EXPR(") {
+					expression := strings.TrimSuffix(strings.TrimPrefix(operator.Value, "EXPR("), ")")
+					value = exprForOttl(expression)
+					fieldsNotNilCheck, err := fieldsReferencedInExprNotNilCheck(expression)
+					if err != nil {
+						return nil, fmt.Errorf(
+							"could'nt generate nil check for fields referenced in value expr of add operator %s: %w",
+							operator.Name, err,
+						)
+					}
+					if fieldsNotNilCheck != "" {
+						condition = exprForOttl(fieldsNotNilCheck)
+					}
+				}
+				appendStatement(
+					fmt.Sprintf(`set(%s, %s)`, logTransformPathToOttlPath(operator.Field), value),
+					condition,
+				)
+
+			} else if operator.Type == "remove" {
+				appendDeleteStatement(operator.Field)
+
+			} else if operator.Type == "copy" {
+				appendStatement(fmt.Sprintf(`set(%s, %s)`, logTransformPathToOttlPath(operator.To), logTransformPathToOttlPath(operator.From)), "")
+
+			} else if operator.Type == "move" {
+				appendStatement(fmt.Sprintf(`set(%s, %s)`, logTransformPathToOttlPath(operator.To), logTransformPathToOttlPath(operator.From)), "")
+				appendDeleteStatement(operator.From)
+
+			} else if operator.Type == "regex_parser" {
+				parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"couldn't generate nil check for parseFrom of regex op %s: %w", operator.Name, err,
+					)
+				}
+				appendStatement(
+					fmt.Sprintf(
+						`merge_maps(%s, ExtractPatterns(%s, "%s"), "upsert")`,
+						logTransformPathToOttlPath(operator.ParseTo),
+						logTransformPathToOttlPath(operator.ParseFrom),
+						escapeDoubleQuotesForOttl(operator.Regex),
+					),
+					exprForOttl(parseFromNotNilCheck),
+				)
+
+			} else if operator.Type == "grok_parser" {
+				parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"couldn't generate nil check for parseFrom of grok op %s: %w", operator.Name, err,
+					)
+				}
+				appendStatement(
+					fmt.Sprintf(
+						`merge_maps(%s, GrokParse(%s, "%s"), "upsert")`,
+						logTransformPathToOttlPath(operator.ParseTo),
+						logTransformPathToOttlPath(operator.ParseFrom),
+						escapeDoubleQuotesForOttl(operator.Pattern),
+					),
+					exprForOttl(parseFromNotNilCheck),
+				)
+
+			} else if operator.Type == "json_parser" {
+				parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"couldn't generate nil check for parseFrom of json parser op %s: %w", operator.Name, err,
+					)
+				}
+				whereClause := strings.Join([]string{
+					exprForOttl(parseFromNotNilCheck),
+					fmt.Sprintf(`IsMatch(%s, "^\\s*{.*}\\s*$")`, logTransformPathToOttlPath(operator.ParseFrom)),
+				}, " and ")
+
+				appendMapExtractStatements(
+					whereClause,
+					fmt.Sprintf("ParseJSON(%s)", logTransformPathToOttlPath(operator.ParseFrom)),
+					logTransformPathToOttlPath(operator.ParseTo),
+				)
+
+			} else if operator.Type == "time_parser" {
+				parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"couldn't generate nil check for parseFrom of json parser op %s: %w", operator.Name, err,
+					)
+				}
+
+				whereClauseParts := []string{exprForOttl(parseFromNotNilCheck)}
+
+				if operator.LayoutType == "strptime" {
+					regex, err := RegexForStrptimeLayout(operator.Layout)
+					if err != nil {
+						return nil, fmt.Errorf(
+							"couldn't generate layout regex for time_parser %s: %w", operator.Name, err,
+						)
+					}
+					whereClauseParts = append(whereClauseParts,
+						fmt.Sprintf(`IsMatch(%s, "%s")`, logTransformPathToOttlPath(operator.ParseFrom), regex),
+					)
+
+					appendStatement(
+						fmt.Sprintf(
+							`set(time, Time(%s, "%s"))`,
+							logTransformPathToOttlPath(operator.ParseFrom),
+							operator.Layout,
+						),
+						strings.Join(whereClauseParts, " and "),
+					)
+
+				} else if operator.LayoutType == "epoch" {
+					valueRegex := `^\\s*[0-9]+\\s*$`
+					if strings.Contains(operator.Layout, ".") {
+						valueRegex = `^\\s*[0-9]+\\.[0-9]+\\s*$`
+					}
+
+					whereClauseParts = append(whereClauseParts,
+						exprForOttl(fmt.Sprintf(
+							`string(%s) matches "%s"`, operator.ParseFrom, valueRegex,
+						)),
+					)
+
+					timeValue := fmt.Sprintf("Double(%s)", logTransformPathToOttlPath(operator.ParseFrom))
+					if strings.HasPrefix(operator.Layout, "seconds") {
+						timeValue = fmt.Sprintf("%s * 1000000000", timeValue)
+					} else if operator.Layout == "milliseconds" {
+						timeValue = fmt.Sprintf("%s * 1000000", timeValue)
+					} else if operator.Layout == "microseconds" {
+						timeValue = fmt.Sprintf("%s * 1000", timeValue)
+					}
+					appendStatement(
+						fmt.Sprintf(`set(time_unix_nano, %s)`, timeValue),
+						strings.Join(whereClauseParts, " and "),
+					)
+				} else {
+					return nil, fmt.Errorf("unsupported time layout %s", operator.LayoutType)
+				}
+
+			} else if operator.Type == "severity_parser" {
+				parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"couldn't generate nil check for parseFrom of severity parser %s: %w", operator.Name, err,
+					)
+				}
+
+				for severity, valuesToMap := range operator.SeverityMapping {
+					for _, value := range valuesToMap {
+						// Special case for 2xx 3xx 4xx and 5xx
+						isSpecialValue, err := regexp.MatchString(`^\s*[2|3|4|5]xx\s*$`, strings.ToLower(value))
+						if err != nil {
+							return nil, fmt.Errorf("couldn't regex match for wildcard severity values: %w", err)
+						}
+						if isSpecialValue {
+							whereClause := strings.Join([]string{
+								exprForOttl(parseFromNotNilCheck),
+								exprForOttl(fmt.Sprintf(`type(%s) in ["int", "float"] && %s == float(int(%s))`, operator.ParseFrom, operator.ParseFrom, operator.ParseFrom)),
+								exprForOttl(fmt.Sprintf(`string(int(%s)) matches "^%s$"`, operator.ParseFrom, fmt.Sprintf("%s[0-9]{2}", value[0:1]))),
+							}, " and ")
+							appendStatement(fmt.Sprintf("set(severity_number, SEVERITY_NUMBER_%s)", strings.ToUpper(severity)), whereClause)
+							appendStatement(fmt.Sprintf(`set(severity_text, "%s")`, strings.ToUpper(severity)), whereClause)
+						} else {
+							whereClause := strings.Join([]string{
+								exprForOttl(parseFromNotNilCheck),
+								fmt.Sprintf(
+									`IsString(%s)`,
+									logTransformPathToOttlPath(operator.ParseFrom),
+								),
+								fmt.Sprintf(
+									`IsMatch(%s, "^\\s*%s\\s*$")`,
+									logTransformPathToOttlPath(operator.ParseFrom), value,
+								),
+							}, " and ")
+							appendStatement(fmt.Sprintf("set(severity_number, SEVERITY_NUMBER_%s)", strings.ToUpper(severity)), whereClause)
+							appendStatement(fmt.Sprintf(`set(severity_text, "%s")`, strings.ToUpper(severity)), whereClause)
+						}
+					}
+				}
+			} else if operator.Type == "trace_parser" {
+				// panic("TODO(Raj): Implement trace parser translation")
+				if operator.TraceId != nil && len(operator.TraceId.ParseFrom) > 0 {
+					parseFromNotNilCheck, err := fieldNotNilCheck(operator.TraceId.ParseFrom)
+					if err != nil {
+						return nil, fmt.Errorf(
+							"couldn't generate nil check for TraceId.parseFrom %s: %w", operator.Name, err,
+						)
+					}
+					// TODO(Raj): Also check for trace id regex pattern
+					appendStatement(
+						fmt.Sprintf(`set(trace_id.string, %s)`, logTransformPathToOttlPath(operator.TraceId.ParseFrom)),
+						exprForOttl(parseFromNotNilCheck),
+					)
+				}
+
+				if operator.SpanId != nil && len(operator.SpanId.ParseFrom) > 0 {
+					parseFromNotNilCheck, err := fieldNotNilCheck(operator.SpanId.ParseFrom)
+					if err != nil {
+						return nil, fmt.Errorf(
+							"couldn't generate nil check for TraceId.parseFrom %s: %w", operator.Name, err,
+						)
+					}
+					// TODO(Raj): Also check for span id regex pattern
+					appendStatement(
+						fmt.Sprintf("set(span_id.string, %s)", logTransformPathToOttlPath(operator.SpanId.ParseFrom)),
+						exprForOttl(parseFromNotNilCheck),
+					)
+
+				}
+
+				if operator.TraceFlags != nil && len(operator.TraceFlags.ParseFrom) > 0 {
+
+					parseFromNotNilCheck, err := fieldNotNilCheck(operator.TraceFlags.ParseFrom)
+					if err != nil {
+						return nil, fmt.Errorf(
+							"couldn't generate nil check for TraceId.parseFrom %s: %w", operator.Name, err,
+						)
+					}
+					// TODO(Raj): Also check for trace flags hex regex pattern
+					appendStatement(
+						fmt.Sprintf(`set(flags, HexToInt(%s))`, logTransformPathToOttlPath(operator.TraceFlags.ParseFrom)),
+						exprForOttl(parseFromNotNilCheck),
+					)
+				}
+
+			} else {
+				return nil, fmt.Errorf("unsupported pipeline operator type: %s", operator.Type)
+			}
+
+		}
+	}
+
+	removePipelineMarker()
+
+	return ottlStatements, nil
+}
+
 // a.b?.c -> ["a", "b", "c"]
 // a.b["c.d"].e -> ["a", "b", "c.d", "e"]
 func pathParts(path string) []string {
@@ -64,379 +481,12 @@ func logTransformPathToOttlPath(path string) string {
 	return strings.Join(ottlPathParts, "")
 }
 
-func PreparePipelineProcessor(pipelines []Pipeline) (map[string]interface{}, []string, error) {
-	processors := map[string]interface{}{}
-	names := []string{}
+func escapeDoubleQuotesForOttl(str string) string {
+	return strings.ReplaceAll(
+		strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`,
+	)
+}
 
-	ottlStatements := []string{}
-
-	for pipelineIdx, pipeline := range pipelines {
-		if pipeline.Enabled {
-
-			enabledOperators := []PipelineOperator{}
-			for _, op := range pipeline.Config {
-				if op.Enabled {
-					enabledOperators = append(enabledOperators, op)
-				}
-			}
-			if len(enabledOperators) < 1 {
-				continue
-			}
-
-			filterExpr, err := queryBuilderToExpr.Parse(pipeline.Filter)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to parse pipeline filter: %w", err)
-			}
-
-			escapeDoubleQuotes := func(str string) string {
-				return strings.ReplaceAll(
-					strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`,
-				)
-			}
-
-			toOttlExpr := func(expr string) string {
-				return fmt.Sprintf(`EXPR("%s")`, escapeDoubleQuotes(expr))
-			}
-
-			// We are generating one or more ottl statements per pipeline operator.
-			// ottl statements have individual where conditions per statement
-			// The simplest path is to add where clause for pipeline filter to each statement.
-			// However, this breaks if an early operator statement in the pipeline ends up
-			// modifying the fields referenced in the pipeline filter.
-			// To work around this, we add statements before and after the actual pipeline
-			// operator statements, that add and remove a pipeline specific marker, ensuring
-			// all operators in a pipeline get to act on the log even if an op changes the filter referenced fields.
-			pipelineMarker := fmt.Sprintf("signoz-log-pipeline-%d-%s", pipelineIdx, pipeline.Alias)
-			addMarkerStatement := fmt.Sprintf(`set(attributes["__signoz_pipeline_marker__"], "%s")`, pipelineMarker)
-			if len(filterExpr) > 0 {
-				addMarkerStatement += fmt.Sprintf(" where %s", toOttlExpr(filterExpr))
-			}
-			ottlStatements = append(ottlStatements, addMarkerStatement)
-			pipelineMarkerWhereClause := fmt.Sprintf(
-				`attributes["__signoz_pipeline_marker__"] == "%s"`, pipelineMarker,
-			)
-
-			// to be called at the end
-			removePipelineMarker := func() {
-				ottlStatements = append(ottlStatements, fmt.Sprintf(
-					`delete_key(attributes, "__signoz_pipeline_marker__") where %s`, pipelineMarkerWhereClause,
-				))
-			}
-
-			appendStatement := func(statement string, additionalFilter string) {
-				whereConditions := []string{pipelineMarkerWhereClause}
-
-				if len(additionalFilter) > 0 {
-					whereConditions = append(whereConditions, additionalFilter)
-				}
-
-				statement = fmt.Sprintf(
-					`%s where %s`, statement, strings.Join(whereConditions, " and "),
-				)
-
-				ottlStatements = append(ottlStatements, statement)
-			}
-
-			appendDeleteStatement := func(path string) {
-				fieldPath := logTransformPathToOttlPath(path)
-				fieldPathParts := rSplitAfterN(fieldPath, "[", 2)
-				target := fieldPathParts[0]
-				key := fieldPathParts[1][1 : len(fieldPathParts[1])-1]
-
-				pathNotNilCheck, err := fieldNotNilCheck(path)
-				if err != nil {
-					panic(err)
-				}
-
-				appendStatement(
-					fmt.Sprintf(`delete_key(%s, %s)`, target, key),
-					toOttlExpr(pathNotNilCheck),
-				)
-			}
-
-			appendMapExtractStatements := func(
-				filterClause string,
-				mapGenerator string,
-				target string,
-			) {
-				cacheKey := uuid.NewString()
-				// Extract parsed map to cache.
-				appendStatement(fmt.Sprintf(
-					`set(cache["%s"], %s)`, cacheKey, mapGenerator,
-				), filterClause)
-
-				// Set target to a map if not already one.
-				appendStatement(fmt.Sprintf(
-					`set(%s, ParseJSON("{}"))`, logTransformPathToOttlPath(target),
-				), strings.Join([]string{
-					fmt.Sprintf(`cache["%s"] != nil`, cacheKey),
-					fmt.Sprintf("not IsMap(%s)", logTransformPathToOttlPath(target)),
-				}, " and "))
-
-				appendStatement(
-					fmt.Sprintf(
-						`merge_maps(%s, cache["%s"], "upsert")`,
-						logTransformPathToOttlPath(target), cacheKey,
-					),
-					fmt.Sprintf(`cache["%s"] != nil`, cacheKey),
-				)
-			}
-
-			for _, operator := range pipeline.Config {
-				if operator.Enabled {
-
-					if operator.Type == "add" {
-						value := fmt.Sprintf(`"%s"`, operator.Value)
-						condition := ""
-						if strings.HasPrefix(operator.Value, "EXPR(") {
-							expression := strings.TrimSuffix(strings.TrimPrefix(operator.Value, "EXPR("), ")")
-							value = toOttlExpr(expression)
-							fieldsNotNilCheck, err := fieldsReferencedInExprNotNilCheck(expression)
-							if err != nil {
-								return nil, nil, fmt.Errorf(
-									"could'nt generate nil check for fields referenced in value expr of add operator %s: %w",
-									operator.Name, err,
-								)
-							}
-							if fieldsNotNilCheck != "" {
-								condition = toOttlExpr(fieldsNotNilCheck)
-							}
-						}
-						appendStatement(
-							fmt.Sprintf(`set(%s, %s)`, logTransformPathToOttlPath(operator.Field), value),
-							condition,
-						)
-
-					} else if operator.Type == "remove" {
-						appendDeleteStatement(operator.Field)
-
-					} else if operator.Type == "copy" {
-						appendStatement(fmt.Sprintf(`set(%s, %s)`, logTransformPathToOttlPath(operator.To), logTransformPathToOttlPath(operator.From)), "")
-
-					} else if operator.Type == "move" {
-						appendStatement(fmt.Sprintf(`set(%s, %s)`, logTransformPathToOttlPath(operator.To), logTransformPathToOttlPath(operator.From)), "")
-						appendDeleteStatement(operator.From)
-
-					} else if operator.Type == "regex_parser" {
-						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
-						if err != nil {
-							return nil, nil, fmt.Errorf(
-								"couldn't generate nil check for parseFrom of regex op %s: %w", operator.Name, err,
-							)
-						}
-						appendStatement(
-							fmt.Sprintf(
-								`merge_maps(%s, ExtractPatterns(%s, "%s"), "upsert")`,
-								logTransformPathToOttlPath(operator.ParseTo),
-								logTransformPathToOttlPath(operator.ParseFrom),
-								escapeDoubleQuotes(operator.Regex),
-							),
-							toOttlExpr(parseFromNotNilCheck),
-						)
-
-					} else if operator.Type == "grok_parser" {
-						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
-						if err != nil {
-							return nil, nil, fmt.Errorf(
-								"couldn't generate nil check for parseFrom of grok op %s: %w", operator.Name, err,
-							)
-						}
-						appendStatement(
-							fmt.Sprintf(
-								`merge_maps(%s, GrokParse(%s, "%s"), "upsert")`,
-								logTransformPathToOttlPath(operator.ParseTo),
-								logTransformPathToOttlPath(operator.ParseFrom),
-								escapeDoubleQuotes(operator.Pattern),
-							),
-							toOttlExpr(parseFromNotNilCheck),
-						)
-
-					} else if operator.Type == "json_parser" {
-						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
-						if err != nil {
-							return nil, nil, fmt.Errorf(
-								"couldn't generate nil check for parseFrom of json parser op %s: %w", operator.Name, err,
-							)
-						}
-						whereClause := strings.Join([]string{
-							toOttlExpr(parseFromNotNilCheck),
-							fmt.Sprintf(`IsMatch(%s, "^\\s*{.*}\\s*$")`, logTransformPathToOttlPath(operator.ParseFrom)),
-						}, " and ")
-
-						appendMapExtractStatements(
-							whereClause,
-							fmt.Sprintf("ParseJSON(%s)", logTransformPathToOttlPath(operator.ParseFrom)),
-							logTransformPathToOttlPath(operator.ParseTo),
-						)
-
-					} else if operator.Type == "time_parser" {
-						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
-						if err != nil {
-							return nil, nil, fmt.Errorf(
-								"couldn't generate nil check for parseFrom of json parser op %s: %w", operator.Name, err,
-							)
-						}
-
-						whereClauseParts := []string{toOttlExpr(parseFromNotNilCheck)}
-
-						if operator.LayoutType == "strptime" {
-							regex, err := RegexForStrptimeLayout(operator.Layout)
-							if err != nil {
-								return nil, nil, fmt.Errorf(
-									"couldn't generate layout regex for time_parser %s: %w", operator.Name, err,
-								)
-							}
-							whereClauseParts = append(whereClauseParts,
-								fmt.Sprintf(`IsMatch(%s, "%s")`, logTransformPathToOttlPath(operator.ParseFrom), regex),
-							)
-
-							appendStatement(
-								fmt.Sprintf(
-									`set(time, Time(%s, "%s"))`,
-									logTransformPathToOttlPath(operator.ParseFrom),
-									operator.Layout,
-								),
-								strings.Join(whereClauseParts, " and "),
-							)
-
-						} else if operator.LayoutType == "epoch" {
-							valueRegex := `^\\s*[0-9]+\\s*$`
-							if strings.Contains(operator.Layout, ".") {
-								valueRegex = `^\\s*[0-9]+\\.[0-9]+\\s*$`
-							}
-
-							whereClauseParts = append(whereClauseParts,
-								toOttlExpr(fmt.Sprintf(
-									`string(%s) matches "%s"`, operator.ParseFrom, valueRegex,
-								)),
-							)
-
-							timeValue := fmt.Sprintf("Double(%s)", logTransformPathToOttlPath(operator.ParseFrom))
-							if strings.HasPrefix(operator.Layout, "seconds") {
-								timeValue = fmt.Sprintf("%s * 1000000000", timeValue)
-							} else if operator.Layout == "milliseconds" {
-								timeValue = fmt.Sprintf("%s * 1000000", timeValue)
-							} else if operator.Layout == "microseconds" {
-								timeValue = fmt.Sprintf("%s * 1000", timeValue)
-							}
-							appendStatement(
-								fmt.Sprintf(`set(time_unix_nano, %s)`, timeValue),
-								strings.Join(whereClauseParts, " and "),
-							)
-						} else {
-							return nil, nil, fmt.Errorf("unsupported time layout %s", operator.LayoutType)
-						}
-
-					} else if operator.Type == "severity_parser" {
-						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
-						if err != nil {
-							return nil, nil, fmt.Errorf(
-								"couldn't generate nil check for parseFrom of severity parser %s: %w", operator.Name, err,
-							)
-						}
-
-						for severity, valuesToMap := range operator.SeverityMapping {
-							for _, value := range valuesToMap {
-								// Special case for 2xx 3xx 4xx and 5xx
-								isSpecialValue, err := regexp.MatchString(`^\s*[2|3|4|5]xx\s*$`, strings.ToLower(value))
-								if err != nil {
-									return nil, nil, fmt.Errorf("couldn't regex match for wildcard severity values: %w", err)
-								}
-								if isSpecialValue {
-									whereClause := strings.Join([]string{
-										toOttlExpr(parseFromNotNilCheck),
-										toOttlExpr(fmt.Sprintf(`type(%s) in ["int", "float"] && %s == float(int(%s))`, operator.ParseFrom, operator.ParseFrom, operator.ParseFrom)),
-										toOttlExpr(fmt.Sprintf(`string(int(%s)) matches "^%s$"`, operator.ParseFrom, fmt.Sprintf("%s[0-9]{2}", value[0:1]))),
-									}, " and ")
-									appendStatement(fmt.Sprintf("set(severity_number, SEVERITY_NUMBER_%s)", strings.ToUpper(severity)), whereClause)
-									appendStatement(fmt.Sprintf(`set(severity_text, "%s")`, strings.ToUpper(severity)), whereClause)
-								} else {
-									whereClause := strings.Join([]string{
-										toOttlExpr(parseFromNotNilCheck),
-										fmt.Sprintf(
-											`IsString(%s)`,
-											logTransformPathToOttlPath(operator.ParseFrom),
-										),
-										fmt.Sprintf(
-											`IsMatch(%s, "^\\s*%s\\s*$")`,
-											logTransformPathToOttlPath(operator.ParseFrom), value,
-										),
-									}, " and ")
-									appendStatement(fmt.Sprintf("set(severity_number, SEVERITY_NUMBER_%s)", strings.ToUpper(severity)), whereClause)
-									appendStatement(fmt.Sprintf(`set(severity_text, "%s")`, strings.ToUpper(severity)), whereClause)
-								}
-							}
-						}
-					} else if operator.Type == "trace_parser" {
-						// panic("TODO(Raj): Implement trace parser translation")
-						if operator.TraceId != nil && len(operator.TraceId.ParseFrom) > 0 {
-							parseFromNotNilCheck, err := fieldNotNilCheck(operator.TraceId.ParseFrom)
-							if err != nil {
-								return nil, nil, fmt.Errorf(
-									"couldn't generate nil check for TraceId.parseFrom %s: %w", operator.Name, err,
-								)
-							}
-							// TODO(Raj): Also check for trace id regex pattern
-							appendStatement(
-								fmt.Sprintf(`set(trace_id.string, %s)`, logTransformPathToOttlPath(operator.TraceId.ParseFrom)),
-								toOttlExpr(parseFromNotNilCheck),
-							)
-						}
-
-						if operator.SpanId != nil && len(operator.SpanId.ParseFrom) > 0 {
-							parseFromNotNilCheck, err := fieldNotNilCheck(operator.SpanId.ParseFrom)
-							if err != nil {
-								return nil, nil, fmt.Errorf(
-									"couldn't generate nil check for TraceId.parseFrom %s: %w", operator.Name, err,
-								)
-							}
-							// TODO(Raj): Also check for span id regex pattern
-							appendStatement(
-								fmt.Sprintf("set(span_id.string, %s)", logTransformPathToOttlPath(operator.SpanId.ParseFrom)),
-								toOttlExpr(parseFromNotNilCheck),
-							)
-
-						}
-
-						if operator.TraceFlags != nil && len(operator.TraceFlags.ParseFrom) > 0 {
-
-							parseFromNotNilCheck, err := fieldNotNilCheck(operator.TraceFlags.ParseFrom)
-							if err != nil {
-								return nil, nil, fmt.Errorf(
-									"couldn't generate nil check for TraceId.parseFrom %s: %w", operator.Name, err,
-								)
-							}
-							// TODO(Raj): Also check for trace flags hex regex pattern
-							appendStatement(
-								fmt.Sprintf(`set(flags, HexToInt(%s))`, logTransformPathToOttlPath(operator.TraceFlags.ParseFrom)),
-								toOttlExpr(parseFromNotNilCheck),
-							)
-						}
-
-					} else {
-						return nil, nil, fmt.Errorf("unsupported pipeline operator type: %s", operator.Type)
-					}
-
-				}
-			}
-
-			removePipelineMarker()
-		}
-	}
-
-	// TODO(Raj): Maybe validate ottl statements
-	if len(ottlStatements) > 0 {
-		pipelinesProcessorName := "signoztransform/logs-pipelines"
-		names = append(names, pipelinesProcessorName)
-		processors[pipelinesProcessorName] = map[string]interface{}{
-			"error_mode": "ignore",
-			"log_statements": []map[string]interface{}{
-				{
-					"context":    "log",
-					"statements": ottlStatements,
-				},
-			},
-		}
-	}
-	return processors, names, nil
+func exprForOttl(expr string) string {
+	return fmt.Sprintf(`EXPR("%s")`, escapeDoubleQuotesForOttl(expr))
 }

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilderV2.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilderV2.go
@@ -1,0 +1,442 @@
+// Generate collector config for log pipelines
+// using ottl targeting signoztransform processor.
+
+package logparsingpipeline
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+	"go.signoz.io/signoz/pkg/query-service/queryBuilderToExpr"
+)
+
+// a.b?.c -> ["a", "b", "c"]
+// a.b["c.d"].e -> ["a", "b", "c.d", "e"]
+func pathParts(path string) []string {
+	path = strings.ReplaceAll(path, "?.", ".")
+
+	// Split once from the right to include the rightmost membership op and everything after it.
+	// Eg: `attributes.test["a.b"].value["c.d"].e` would result in `attributes.test["a.b"].value` and `["c.d"].e`
+	memberOpParts := rSplitAfterN(path, "[", 2)
+
+	if len(memberOpParts) < 2 {
+		// there is no [] access in fieldPath
+		return strings.Split(path, ".")
+	}
+
+	// recursively get parts for path prefix before rightmost membership op (`attributes.test["a.b"].value`)
+	parts := pathParts(memberOpParts[0])
+
+	suffixParts := strings.SplitAfter(memberOpParts[1], "]") // ["c.d"].e -> `["c.d"]`, `.e`
+
+	// add key used in membership op ("c.d")
+	parts = append(parts, suffixParts[0][2:len(suffixParts[0])-2])
+
+	// add parts for path after the membership op ("e")
+	if len(suffixParts[1]) > 0 {
+		parts = append(parts, strings.Split(suffixParts[1][1:], ".")...)
+	}
+
+	return parts
+}
+
+// converts a logtransform path to an equivalent ottl path
+// For details, see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottllog#paths
+func logTransformPathToOttlPath(path string) string {
+	if !(strings.HasPrefix(path, "attributes") || strings.HasPrefix(path, "resource")) {
+		return path
+	}
+
+	parts := pathParts(path)
+
+	ottlPathParts := []string{parts[0]}
+
+	if ottlPathParts[0] == "resource" {
+		ottlPathParts[0] = "resource.attributes"
+	}
+
+	for _, p := range parts[1:] {
+		ottlPathParts = append(ottlPathParts, fmt.Sprintf(`["%s"]`, p))
+	}
+
+	return strings.Join(ottlPathParts, "")
+}
+
+func PreparePipelineProcessor(pipelines []Pipeline) (map[string]interface{}, []string, error) {
+	processors := map[string]interface{}{}
+	names := []string{}
+
+	ottlStatements := []string{}
+
+	for pipelineIdx, pipeline := range pipelines {
+		if pipeline.Enabled {
+
+			enabledOperators := []PipelineOperator{}
+			for _, op := range pipeline.Config {
+				if op.Enabled {
+					enabledOperators = append(enabledOperators, op)
+				}
+			}
+			if len(enabledOperators) < 1 {
+				continue
+			}
+
+			filterExpr, err := queryBuilderToExpr.Parse(pipeline.Filter)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to parse pipeline filter: %w", err)
+			}
+
+			escapeDoubleQuotes := func(str string) string {
+				return strings.ReplaceAll(
+					strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`,
+				)
+			}
+
+			toOttlExpr := func(expr string) string {
+				return fmt.Sprintf(`EXPR("%s")`, escapeDoubleQuotes(expr))
+			}
+
+			// We are generating one or more ottl statements per pipeline operator.
+			// ottl statements have individual where conditions per statement
+			// The simplest path is to add where clause for pipeline filter to each statement.
+			// However, this breaks if an early operator statement in the pipeline ends up
+			// modifying the fields referenced in the pipeline filter.
+			// To work around this, we add statements before and after the actual pipeline
+			// operator statements, that add and remove a pipeline specific marker, ensuring
+			// all operators in a pipeline get to act on the log even if an op changes the filter referenced fields.
+			pipelineMarker := fmt.Sprintf("signoz-log-pipeline-%d-%s", pipelineIdx, pipeline.Alias)
+			addMarkerStatement := fmt.Sprintf(`set(attributes["__signoz_pipeline_marker__"], "%s")`, pipelineMarker)
+			if len(filterExpr) > 0 {
+				addMarkerStatement += fmt.Sprintf(" where %s", toOttlExpr(filterExpr))
+			}
+			ottlStatements = append(ottlStatements, addMarkerStatement)
+			pipelineMarkerWhereClause := fmt.Sprintf(
+				`attributes["__signoz_pipeline_marker__"] == "%s"`, pipelineMarker,
+			)
+
+			// to be called at the end
+			removePipelineMarker := func() {
+				ottlStatements = append(ottlStatements, fmt.Sprintf(
+					`delete_key(attributes, "__signoz_pipeline_marker__") where %s`, pipelineMarkerWhereClause,
+				))
+			}
+
+			appendStatement := func(statement string, additionalFilter string) {
+				whereConditions := []string{pipelineMarkerWhereClause}
+
+				if len(additionalFilter) > 0 {
+					whereConditions = append(whereConditions, additionalFilter)
+				}
+
+				statement = fmt.Sprintf(
+					`%s where %s`, statement, strings.Join(whereConditions, " and "),
+				)
+
+				ottlStatements = append(ottlStatements, statement)
+			}
+
+			appendDeleteStatement := func(path string) {
+				fieldPath := logTransformPathToOttlPath(path)
+				fieldPathParts := rSplitAfterN(fieldPath, "[", 2)
+				target := fieldPathParts[0]
+				key := fieldPathParts[1][1 : len(fieldPathParts[1])-1]
+
+				pathNotNilCheck, err := fieldNotNilCheck(path)
+				if err != nil {
+					panic(err)
+				}
+
+				appendStatement(
+					fmt.Sprintf(`delete_key(%s, %s)`, target, key),
+					toOttlExpr(pathNotNilCheck),
+				)
+			}
+
+			appendMapExtractStatements := func(
+				filterClause string,
+				mapGenerator string,
+				target string,
+			) {
+				cacheKey := uuid.NewString()
+				// Extract parsed map to cache.
+				appendStatement(fmt.Sprintf(
+					`set(cache["%s"], %s)`, cacheKey, mapGenerator,
+				), filterClause)
+
+				// Set target to a map if not already one.
+				appendStatement(fmt.Sprintf(
+					`set(%s, ParseJSON("{}"))`, logTransformPathToOttlPath(target),
+				), strings.Join([]string{
+					fmt.Sprintf(`cache["%s"] != nil`, cacheKey),
+					fmt.Sprintf("not IsMap(%s)", logTransformPathToOttlPath(target)),
+				}, " and "))
+
+				appendStatement(
+					fmt.Sprintf(
+						`merge_maps(%s, cache["%s"], "upsert")`,
+						logTransformPathToOttlPath(target), cacheKey,
+					),
+					fmt.Sprintf(`cache["%s"] != nil`, cacheKey),
+				)
+			}
+
+			for _, operator := range pipeline.Config {
+				if operator.Enabled {
+
+					if operator.Type == "add" {
+						value := fmt.Sprintf(`"%s"`, operator.Value)
+						condition := ""
+						if strings.HasPrefix(operator.Value, "EXPR(") {
+							expression := strings.TrimSuffix(strings.TrimPrefix(operator.Value, "EXPR("), ")")
+							value = toOttlExpr(expression)
+							fieldsNotNilCheck, err := fieldsReferencedInExprNotNilCheck(expression)
+							if err != nil {
+								return nil, nil, fmt.Errorf(
+									"could'nt generate nil check for fields referenced in value expr of add operator %s: %w",
+									operator.Name, err,
+								)
+							}
+							if fieldsNotNilCheck != "" {
+								condition = toOttlExpr(fieldsNotNilCheck)
+							}
+						}
+						appendStatement(
+							fmt.Sprintf(`set(%s, %s)`, logTransformPathToOttlPath(operator.Field), value),
+							condition,
+						)
+
+					} else if operator.Type == "remove" {
+						appendDeleteStatement(operator.Field)
+
+					} else if operator.Type == "copy" {
+						appendStatement(fmt.Sprintf(`set(%s, %s)`, logTransformPathToOttlPath(operator.To), logTransformPathToOttlPath(operator.From)), "")
+
+					} else if operator.Type == "move" {
+						appendStatement(fmt.Sprintf(`set(%s, %s)`, logTransformPathToOttlPath(operator.To), logTransformPathToOttlPath(operator.From)), "")
+						appendDeleteStatement(operator.From)
+
+					} else if operator.Type == "regex_parser" {
+						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+						if err != nil {
+							return nil, nil, fmt.Errorf(
+								"couldn't generate nil check for parseFrom of regex op %s: %w", operator.Name, err,
+							)
+						}
+						appendStatement(
+							fmt.Sprintf(
+								`merge_maps(%s, ExtractPatterns(%s, "%s"), "upsert")`,
+								logTransformPathToOttlPath(operator.ParseTo),
+								logTransformPathToOttlPath(operator.ParseFrom),
+								escapeDoubleQuotes(operator.Regex),
+							),
+							toOttlExpr(parseFromNotNilCheck),
+						)
+
+					} else if operator.Type == "grok_parser" {
+						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+						if err != nil {
+							return nil, nil, fmt.Errorf(
+								"couldn't generate nil check for parseFrom of grok op %s: %w", operator.Name, err,
+							)
+						}
+						appendStatement(
+							fmt.Sprintf(
+								`merge_maps(%s, GrokParse(%s, "%s"), "upsert")`,
+								logTransformPathToOttlPath(operator.ParseTo),
+								logTransformPathToOttlPath(operator.ParseFrom),
+								escapeDoubleQuotes(operator.Pattern),
+							),
+							toOttlExpr(parseFromNotNilCheck),
+						)
+
+					} else if operator.Type == "json_parser" {
+						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+						if err != nil {
+							return nil, nil, fmt.Errorf(
+								"couldn't generate nil check for parseFrom of json parser op %s: %w", operator.Name, err,
+							)
+						}
+						whereClause := strings.Join([]string{
+							toOttlExpr(parseFromNotNilCheck),
+							fmt.Sprintf(`IsMatch(%s, "^\\s*{.*}\\s*$")`, logTransformPathToOttlPath(operator.ParseFrom)),
+						}, " and ")
+
+						appendMapExtractStatements(
+							whereClause,
+							fmt.Sprintf("ParseJSON(%s)", logTransformPathToOttlPath(operator.ParseFrom)),
+							logTransformPathToOttlPath(operator.ParseTo),
+						)
+
+					} else if operator.Type == "time_parser" {
+						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+						if err != nil {
+							return nil, nil, fmt.Errorf(
+								"couldn't generate nil check for parseFrom of json parser op %s: %w", operator.Name, err,
+							)
+						}
+
+						whereClauseParts := []string{toOttlExpr(parseFromNotNilCheck)}
+
+						if operator.LayoutType == "strptime" {
+							regex, err := RegexForStrptimeLayout(operator.Layout)
+							if err != nil {
+								return nil, nil, fmt.Errorf(
+									"couldn't generate layout regex for time_parser %s: %w", operator.Name, err,
+								)
+							}
+							whereClauseParts = append(whereClauseParts,
+								fmt.Sprintf(`IsMatch(%s, "%s")`, logTransformPathToOttlPath(operator.ParseFrom), regex),
+							)
+
+							appendStatement(
+								fmt.Sprintf(
+									`set(time, Time(%s, "%s"))`,
+									logTransformPathToOttlPath(operator.ParseFrom),
+									operator.Layout,
+								),
+								strings.Join(whereClauseParts, " and "),
+							)
+
+						} else if operator.LayoutType == "epoch" {
+							valueRegex := `^\\s*[0-9]+\\s*$`
+							if strings.Contains(operator.Layout, ".") {
+								valueRegex = `^\\s*[0-9]+\\.[0-9]+\\s*$`
+							}
+
+							whereClauseParts = append(whereClauseParts,
+								toOttlExpr(fmt.Sprintf(
+									`string(%s) matches "%s"`, operator.ParseFrom, valueRegex,
+								)),
+							)
+
+							timeValue := fmt.Sprintf("Double(%s)", logTransformPathToOttlPath(operator.ParseFrom))
+							if strings.HasPrefix(operator.Layout, "seconds") {
+								timeValue = fmt.Sprintf("%s * 1000000000", timeValue)
+							} else if operator.Layout == "milliseconds" {
+								timeValue = fmt.Sprintf("%s * 1000000", timeValue)
+							} else if operator.Layout == "microseconds" {
+								timeValue = fmt.Sprintf("%s * 1000", timeValue)
+							}
+							appendStatement(
+								fmt.Sprintf(`set(time_unix_nano, %s)`, timeValue),
+								strings.Join(whereClauseParts, " and "),
+							)
+						} else {
+							return nil, nil, fmt.Errorf("unsupported time layout %s", operator.LayoutType)
+						}
+
+					} else if operator.Type == "severity_parser" {
+						parseFromNotNilCheck, err := fieldNotNilCheck(operator.ParseFrom)
+						if err != nil {
+							return nil, nil, fmt.Errorf(
+								"couldn't generate nil check for parseFrom of severity parser %s: %w", operator.Name, err,
+							)
+						}
+
+						for severity, valuesToMap := range operator.SeverityMapping {
+							for _, value := range valuesToMap {
+								// Special case for 2xx 3xx 4xx and 5xx
+								isSpecialValue, err := regexp.MatchString(`^\s*[2|3|4|5]xx\s*$`, strings.ToLower(value))
+								if err != nil {
+									return nil, nil, fmt.Errorf("couldn't regex match for wildcard severity values: %w", err)
+								}
+								if isSpecialValue {
+									whereClause := strings.Join([]string{
+										toOttlExpr(parseFromNotNilCheck),
+										toOttlExpr(fmt.Sprintf(`type(%s) in ["int", "float"] && %s == float(int(%s))`, operator.ParseFrom, operator.ParseFrom, operator.ParseFrom)),
+										toOttlExpr(fmt.Sprintf(`string(int(%s)) matches "^%s$"`, operator.ParseFrom, fmt.Sprintf("%s[0-9]{2}", value[0:1]))),
+									}, " and ")
+									appendStatement(fmt.Sprintf("set(severity_number, SEVERITY_NUMBER_%s)", strings.ToUpper(severity)), whereClause)
+									appendStatement(fmt.Sprintf(`set(severity_text, "%s")`, strings.ToUpper(severity)), whereClause)
+								} else {
+									whereClause := strings.Join([]string{
+										toOttlExpr(parseFromNotNilCheck),
+										fmt.Sprintf(
+											`IsString(%s)`,
+											logTransformPathToOttlPath(operator.ParseFrom),
+										),
+										fmt.Sprintf(
+											`IsMatch(%s, "^\\s*%s\\s*$")`,
+											logTransformPathToOttlPath(operator.ParseFrom), value,
+										),
+									}, " and ")
+									appendStatement(fmt.Sprintf("set(severity_number, SEVERITY_NUMBER_%s)", strings.ToUpper(severity)), whereClause)
+									appendStatement(fmt.Sprintf(`set(severity_text, "%s")`, strings.ToUpper(severity)), whereClause)
+								}
+							}
+						}
+					} else if operator.Type == "trace_parser" {
+						// panic("TODO(Raj): Implement trace parser translation")
+						if operator.TraceId != nil && len(operator.TraceId.ParseFrom) > 0 {
+							parseFromNotNilCheck, err := fieldNotNilCheck(operator.TraceId.ParseFrom)
+							if err != nil {
+								return nil, nil, fmt.Errorf(
+									"couldn't generate nil check for TraceId.parseFrom %s: %w", operator.Name, err,
+								)
+							}
+							// TODO(Raj): Also check for trace id regex pattern
+							appendStatement(
+								fmt.Sprintf(`set(trace_id.string, %s)`, logTransformPathToOttlPath(operator.TraceId.ParseFrom)),
+								toOttlExpr(parseFromNotNilCheck),
+							)
+						}
+
+						if operator.SpanId != nil && len(operator.SpanId.ParseFrom) > 0 {
+							parseFromNotNilCheck, err := fieldNotNilCheck(operator.SpanId.ParseFrom)
+							if err != nil {
+								return nil, nil, fmt.Errorf(
+									"couldn't generate nil check for TraceId.parseFrom %s: %w", operator.Name, err,
+								)
+							}
+							// TODO(Raj): Also check for span id regex pattern
+							appendStatement(
+								fmt.Sprintf("set(span_id.string, %s)", logTransformPathToOttlPath(operator.SpanId.ParseFrom)),
+								toOttlExpr(parseFromNotNilCheck),
+							)
+
+						}
+
+						if operator.TraceFlags != nil && len(operator.TraceFlags.ParseFrom) > 0 {
+
+							parseFromNotNilCheck, err := fieldNotNilCheck(operator.TraceFlags.ParseFrom)
+							if err != nil {
+								return nil, nil, fmt.Errorf(
+									"couldn't generate nil check for TraceId.parseFrom %s: %w", operator.Name, err,
+								)
+							}
+							// TODO(Raj): Also check for trace flags hex regex pattern
+							appendStatement(
+								fmt.Sprintf(`set(flags, HexToInt(%s))`, logTransformPathToOttlPath(operator.TraceFlags.ParseFrom)),
+								toOttlExpr(parseFromNotNilCheck),
+							)
+						}
+
+					} else {
+						return nil, nil, fmt.Errorf("unsupported pipeline operator type: %s", operator.Type)
+					}
+
+				}
+			}
+
+			removePipelineMarker()
+		}
+	}
+
+	// TODO(Raj): Maybe validate ottl statements
+	if len(ottlStatements) > 0 {
+		pipelinesProcessorName := "signoztransform/logs-pipelines"
+		names = append(names, pipelinesProcessorName)
+		processors[pipelinesProcessorName] = map[string]interface{}{
+			"error_mode": "ignore",
+			"log_statements": []map[string]interface{}{
+				{
+					"context":    "log",
+					"statements": ottlStatements,
+				},
+			},
+		}
+	}
+	return processors, names, nil
+}

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder_test.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/require"
@@ -662,8 +663,16 @@ func TestMembershipOpInProcessorFieldExpressions(t *testing.T) {
 				Enabled:   true,
 				Name:      "json",
 				ParseFrom: `attributes["order.products"]`,
-				ParseTo:   `attributes["order.products"]`,
+				ParseTo:   `attributes["some"].missing.target`,
 			}, {
+				ID:        "json",
+				Type:      "json_parser",
+				Enabled:   true,
+				Name:      "json",
+				ParseFrom: `attributes["order.products"]`,
+				ParseTo:   `attributes["order.products"]`,
+			},
+			{
 				ID:      "move1",
 				Type:    "move",
 				Enabled: true,
@@ -721,6 +730,8 @@ func TestMembershipOpInProcessorFieldExpressions(t *testing.T) {
 	_, methodAttrExists := result[0].Attributes_string["http.method"]
 	require.False(methodAttrExists)
 	require.Equal("GET", result[0].Attributes_string["test.http.method"])
+	spew.Dump(testLogs)
+	spew.Dump(result)
 	require.Equal("pid0", result[0].Attributes_string["order.pids.pid0"])
 }
 

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder_test.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/require"
@@ -740,8 +739,6 @@ func TestMembershipOpInProcessorFieldExpressions(t *testing.T) {
 	_, methodAttrExists := result[0].Attributes_string["http.method"]
 	require.False(methodAttrExists)
 	require.Equal("GET", result[0].Attributes_string["test.http.method"])
-	spew.Dump(testLogs)
-	spew.Dump(result)
 	require.Equal("pid0", result[0].Attributes_string["order.pids.pid0"])
 	require.Equal(`{"new":{"missing_field":"2"}}`, result[0].Attributes_string["another"])
 }

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder_test.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder_test.go
@@ -658,14 +658,14 @@ func TestMembershipOpInProcessorFieldExpressions(t *testing.T) {
 				From:    `attributes["http.method"]`,
 				To:      `attributes["test.http.method"]`,
 			},
-			// {
-			// ID:        "json",
-			// Type:      "json_parser",
-			// Enabled:   true,
-			// Name:      "json",
-			// ParseFrom: `attributes["order.products"]`,
-			// ParseTo:   `attributes["some"].missing.target`,
-			// },
+			{
+				ID:        "json",
+				Type:      "json_parser",
+				Enabled:   true,
+				Name:      "json",
+				ParseFrom: `attributes["order.products"]`,
+				ParseTo:   `attributes["some"].missing.target`,
+			},
 			{
 				ID:        "json",
 				Type:      "json_parser",
@@ -689,6 +689,14 @@ func TestMembershipOpInProcessorFieldExpressions(t *testing.T) {
 				From:    `attributes.test?.doesnt_exist`,
 				To:      `attributes["test.doesnt_exist"]`,
 			}, {
+				ID:      "addToMissingField",
+				Type:    "add",
+				Enabled: true,
+				Name:    "add",
+				Field:   `attributes["another"].new.missing_field`,
+				Value:   `2`,
+			},
+			{
 				ID:      "add",
 				Type:    "add",
 				Enabled: true,
@@ -735,6 +743,7 @@ func TestMembershipOpInProcessorFieldExpressions(t *testing.T) {
 	spew.Dump(testLogs)
 	spew.Dump(result)
 	require.Equal("pid0", result[0].Attributes_string["order.pids.pid0"])
+	require.Equal(`{"new":{"missing_field":"2"}}`, result[0].Attributes_string["another"])
 }
 
 func TestContainsFilterIsCaseInsensitive(t *testing.T) {

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder_test.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder_test.go
@@ -657,14 +657,16 @@ func TestMembershipOpInProcessorFieldExpressions(t *testing.T) {
 				Name:    "move",
 				From:    `attributes["http.method"]`,
 				To:      `attributes["test.http.method"]`,
-			}, {
-				ID:        "json",
-				Type:      "json_parser",
-				Enabled:   true,
-				Name:      "json",
-				ParseFrom: `attributes["order.products"]`,
-				ParseTo:   `attributes["some"].missing.target`,
-			}, {
+			},
+			// {
+			// ID:        "json",
+			// Type:      "json_parser",
+			// Enabled:   true,
+			// Name:      "json",
+			// ParseFrom: `attributes["order.products"]`,
+			// ParseTo:   `attributes["some"].missing.target`,
+			// },
+			{
 				ID:        "json",
 				Type:      "json_parser",
 				Enabled:   true,

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder_test.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder_test.go
@@ -199,9 +199,10 @@ var prepareProcessorTestData = []struct {
 func TestPreparePipelineProcessor(t *testing.T) {
 	for _, test := range prepareProcessorTestData {
 		Convey(test.Name, t, func() {
-			res, err := getOperators(test.Operators)
-			So(err, ShouldBeNil)
-			So(res, ShouldResemble, test.Output)
+			require.NotNil(t, nil, "TODO(Raj): maybe use these tests in new config generation")
+			// res, err := getOperators(test.Operators)
+			// So(err, ShouldBeNil)
+			// So(res, ShouldResemble, test.Output)
 		})
 	}
 }

--- a/pkg/query-service/app/logparsingpipeline/preview.go
+++ b/pkg/query-service/app/logparsingpipeline/preview.go
@@ -8,7 +8,6 @@ import (
 
 	_ "github.com/SigNoz/signoz-otel-collector/pkg/parser/grok"
 	"github.com/SigNoz/signoz-otel-collector/processor/signoztransformprocessor"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -43,7 +42,6 @@ func SimulatePipelinesProcessing(
 	simulatorInputPLogs := SignozLogsToPLogs(logs)
 
 	processorFactories, err := processor.MakeFactoryMap(
-		logstransformprocessor.NewFactory(),
 		signoztransformprocessor.NewFactory(),
 	)
 	if err != nil {

--- a/pkg/query-service/app/logparsingpipeline/preview.go
+++ b/pkg/query-service/app/logparsingpipeline/preview.go
@@ -8,6 +8,7 @@ import (
 
 	_ "github.com/SigNoz/signoz-otel-collector/pkg/parser/grok"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -43,6 +44,7 @@ func SimulatePipelinesProcessing(
 
 	processorFactories, err := processor.MakeFactoryMap(
 		logstransformprocessor.NewFactory(),
+		transformprocessor.NewFactory(),
 	)
 	if err != nil {
 		return nil, nil, model.InternalError(errors.Wrap(

--- a/pkg/query-service/app/logparsingpipeline/preview.go
+++ b/pkg/query-service/app/logparsingpipeline/preview.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	_ "github.com/SigNoz/signoz-otel-collector/pkg/parser/grok"
+	"github.com/SigNoz/signoz-otel-collector/processor/signoztransformprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -44,7 +44,7 @@ func SimulatePipelinesProcessing(
 
 	processorFactories, err := processor.MakeFactoryMap(
 		logstransformprocessor.NewFactory(),
-		transformprocessor.NewFactory(),
+		signoztransformprocessor.NewFactory(),
 	)
 	if err != nil {
 		return nil, nil, model.InternalError(errors.Wrap(

--- a/pkg/query-service/app/logparsingpipeline/processors_test.go
+++ b/pkg/query-service/app/logparsingpipeline/processors_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
 	"go.signoz.io/signoz/pkg/query-service/model"
 	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
@@ -292,9 +293,12 @@ func TestTraceParsingProcessor(t *testing.T) {
 			testLog,
 		},
 	)
+
+	spew.Dump(testLog)
+	spew.Dump(result)
 	require.Nil(err)
 	require.Equal(1, len(result))
-	require.Equal(0, len(collectorWarnAndErrorLogs))
+	require.Equal(0, len(collectorWarnAndErrorLogs), strings.Join(collectorWarnAndErrorLogs, "\n"))
 	processed := result[0]
 
 	require.Equal(testTraceId, processed.TraceID)

--- a/pkg/query-service/app/logparsingpipeline/processors_test.go
+++ b/pkg/query-service/app/logparsingpipeline/processors_test.go
@@ -353,16 +353,16 @@ func TestAddProcessor(t *testing.T) {
 			"type": "add",
 			"name": "Test add parser",
 			"id": "test-add-parser",
-			"field": "attributes.test",
-			"value": "test"
+			"field": "resource.test",
+			"value": "1"
 		}`, `{
 			"orderId": 2,
 			"enabled": true,
 			"type": "add",
 			"name": "Test enabled add resource parser",
 			"id": "test-add-parser",
-			"field": "resource.test",
-			"value": "test"
+			"field": "attributes.test",
+			"value": "EXPR(int(resource.test) + 1)"
 		}`, `{
 			"orderId": 3,
 			"enabled": false,
@@ -397,8 +397,8 @@ func TestAddProcessor(t *testing.T) {
 	require.Equal(1, len(result))
 	require.Equal(0, len(collectorWarnAndErrorLogs), strings.Join(collectorWarnAndErrorLogs, "\n"))
 	processed := result[0]
-	require.Equal("test", processed.Attributes_string["test"])
-	require.Equal("test", processed.Resources_string["test"])
+	require.Equal("1", processed.Resources_string["test"])
+	require.Equal(2, processed.Attributes_int64["test"])
 	require.Equal("", processed.Attributes_string["testMissing"])
 }
 

--- a/pkg/query-service/app/logparsingpipeline/processors_test.go
+++ b/pkg/query-service/app/logparsingpipeline/processors_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
 	"go.signoz.io/signoz/pkg/query-service/model"
 	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
@@ -294,8 +293,6 @@ func TestTraceParsingProcessor(t *testing.T) {
 		},
 	)
 
-	spew.Dump(testLog)
-	spew.Dump(result)
 	require.Nil(err)
 	require.Equal(1, len(result))
 	require.Equal(0, len(collectorWarnAndErrorLogs), strings.Join(collectorWarnAndErrorLogs, "\n"))

--- a/pkg/query-service/app/logparsingpipeline/processors_test.go
+++ b/pkg/query-service/app/logparsingpipeline/processors_test.go
@@ -398,7 +398,7 @@ func TestAddProcessor(t *testing.T) {
 	require.Equal(0, len(collectorWarnAndErrorLogs), strings.Join(collectorWarnAndErrorLogs, "\n"))
 	processed := result[0]
 	require.Equal("1", processed.Resources_string["test"])
-	require.Equal(2, processed.Attributes_int64["test"])
+	require.Equal(int64(2), processed.Attributes_int64["test"])
 	require.Equal("", processed.Attributes_string["testMissing"])
 }
 

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -305,7 +305,7 @@ var ReservedColumnTargetAliases = map[string]struct{}{
 }
 
 // logsPPLPfx is a short constant for logsPipelinePrefix
-const LogsPPLPfx = "logstransform/pipeline_"
+const LogsPPLPfx = "signoztransform/logs-pipeline"
 
 const IntegrationPipelineIdPrefix = "integration"
 


### PR DESCRIPTION
### Summary

Generate sync collector config for log pipelines using signoztransformprocessor.
This allows consumeLogs calls from receivers to by sync - ensuring the data has been written out when the function completes 

Moving to transform processor based config also enables use of top level log fields like severity in pipeline filters - something not supported by logstransform processor

#### Related Issues / PR's

Contributes to https://github.com/SigNoz/signoz/issues/4444

