### PR TITLE
fix: threshold getting cleared on stage and run query and user not able to create alert issue

### DIFF
--- a/frontend/src/container/CreateAlertRule/index.tsx
+++ b/frontend/src/container/CreateAlertRule/index.tsx
@@ -2,6 +2,7 @@ import { Form, Row } from 'antd';
 import { ENTITY_VERSION_V4 } from 'constants/app';
 import FormAlertRules from 'container/FormAlertRules';
 import { useGetCompositeQueryParam } from 'hooks/queryBuilder/useGetCompositeQueryParam';
+import { isEqual } from 'lodash-es';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { AlertTypes } from 'types/api/alerts/alertTypes';
@@ -18,9 +19,7 @@ import SelectAlertType from './SelectAlertType';
 
 function CreateRules(): JSX.Element {
 	const [initValues, setInitValues] = useState<AlertDef | null>(null);
-	const [alertType, setAlertType] = useState<AlertTypes>(
-		AlertTypes.METRICS_BASED_ALERT,
-	);
+	const [alertType, setAlertType] = useState<AlertTypes>();
 
 	const location = useLocation();
 	const queryParams = new URLSearchParams(location.search);
@@ -56,10 +55,10 @@ function CreateRules(): JSX.Element {
 		}
 		const dataSource = compositeQuery?.builder?.queryData[0]?.dataSource;
 
-		const alertType = ALERT_TYPE_VS_SOURCE_MAPPING[dataSource];
+		const alertTypeFromQuery = ALERT_TYPE_VS_SOURCE_MAPPING[dataSource];
 
-		if (alertType) {
-			onSelectType(alertType);
+		if (alertTypeFromQuery && !isEqual(alertType, alertTypeFromQuery)) {
+			onSelectType(alertTypeFromQuery);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [compositeQuery]);

--- a/frontend/src/providers/Dashboard/Dashboard.tsx
+++ b/frontend/src/providers/Dashboard/Dashboard.tsx
@@ -176,8 +176,6 @@ export function DashboardProvider({
 
 		return data;
 	};
-
-	console.log(variablesToGetUpdated);
 	const dashboardResponse = useQuery(
 		[REACT_QUERY_KEY.DASHBOARD_BY_ID, isDashboardPage?.params],
 		{


### PR DESCRIPTION
### Summary

- On stage and run query the parent component was triggering the change of initial value which was causing the reference to change hence the child component regained the base state 
- in the fix we do not retrigger the state update until the value updated 

#### Related Issues / PR's

Fix - https://github.com/SigNoz/signoz/issues/4873

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/03439b1e-0c92-4b91-937e-ae815967f3e6



#### Affected Areas and Manually Tested Areas

- create alerts
- edit alerts
- reload 
- navigation 
