### PR TITLE
fix: handle the case where the functions are undefined in the query response

### DIFF
--- a/frontend/src/container/QueryBuilder/components/QBEntityOptions/QBEntityOptions.tsx
+++ b/frontend/src/container/QueryBuilder/components/QBEntityOptions/QBEntityOptions.tsx
@@ -105,8 +105,8 @@ export default function QBEntityOptions({
 								onQueryFunctionsUpdates && (
 									<QueryFunctions
 										query={query}
-										queryFunctions={query.functions}
-										key={query.functions.toString()}
+										queryFunctions={query.functions || []}
+										key={query.functions?.toString()}
 										onChange={onQueryFunctionsUpdates}
 										maxFunctions={isLogsDataSource ? 1 : 3}
 									/>


### PR DESCRIPTION
### Summary

- the `functions` were not present in the query response and the UI expected it to be `[]` in the default case as well. 
- handled the edge case via adding a default value for UI if not present

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
