### PR TITLE
fix: dashboard variable filters issue with dashboards containing older variable format

### DIFF
--- a/frontend/src/container/NewDashboard/DashboardVariablesSelection/DashboardVariableSelection.tsx
+++ b/frontend/src/container/NewDashboard/DashboardVariablesSelection/DashboardVariableSelection.tsx
@@ -72,6 +72,7 @@ function DashboardVariableSelection(): JSX.Element | null {
 		id: string,
 		value: IDashboardVariable['selectedValue'],
 		allSelected: boolean,
+		// eslint-disable-next-line sonarjs/cognitive-complexity
 	): void => {
 		if (id) {
 			updateLocalStorageDashboardVariables(name, value, allSelected);
@@ -79,17 +80,29 @@ function DashboardVariableSelection(): JSX.Element | null {
 			if (selectedDashboard) {
 				setSelectedDashboard((prev) => {
 					if (prev) {
+						const oldVariables = prev?.data.variables;
+						// this is added to handle case where we have two different
+						// schemas for variable response
+						if (oldVariables[id]) {
+							oldVariables[id] = {
+								...oldVariables[id],
+								selectedValue: value,
+								allSelected,
+							};
+						}
+						if (oldVariables[name]) {
+							oldVariables[name] = {
+								...oldVariables[name],
+								selectedValue: value,
+								allSelected,
+							};
+						}
 						return {
 							...prev,
 							data: {
 								...prev?.data,
 								variables: {
-									...prev?.data.variables,
-									[id]: {
-										...prev.data.variables[id],
-										selectedValue: value,
-										allSelected,
-									},
+									...oldVariables,
 								},
 							},
 						};


### PR DESCRIPTION
### Summary

- when there is the old variable format of `name:{VARIABLE}` the update was happening against ID which was making it require a refresh to work 
- handled both cases of name and id

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PRs where applicable  -->

#### Screenshots

Old Dashboard Variable Data format - 

https://github.com/SigNoz/signoz/assets/54737045/738beb5b-fe3c-482f-8d8f-aaba9518f2bf

New Dashboard Variable Data format - 


https://github.com/SigNoz/signoz/assets/54737045/4af1abb8-629a-42f5-adec-94be92de37ca



#### Affected Areas and Manually Tested Areas

- verified the fix for both older and newer dashboards variables.
