### PR TITLE
fix: billing container scroll issue when trial banner present

### DIFF
--- a/frontend/src/container/BillingContainer/BillingContainer.styles.scss
+++ b/frontend/src/container/BillingContainer/BillingContainer.styles.scss
@@ -1,4 +1,5 @@
 .billing-container {
+	margin-bottom: 40px;
 	padding-top: 36px;
 	width: 65%;
 


### PR DESCRIPTION
### Summary

- when trial banner is present the lower content gets hidden , added margin of 40px to take care of the same. 
- This will make content more readable even when trial banner is not present.

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/39fd7f8b-516f-48aa-9bb6-c5388e2c013d



#### Affected Areas and Manually Tested Areas

- billing container without trial and with trial
