### PR TITLE
fix(clickhouse): update endpoint of the healthcheck in deployment files

### DIFF
--- a/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
@@ -22,7 +22,7 @@ x-clickhouse-defaults: &clickhouse-defaults
         "wget",
         "--spider",
         "-q",
-        "localhost:8123/ping"
+        "0.0.0.0:8123/ping"
       ]
     interval: 30s
     timeout: 5s

--- a/deploy/docker/clickhouse-setup/docker-compose-core.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose-core.yaml
@@ -46,7 +46,7 @@ services:
           "wget",
           "--spider",
           "-q",
-          "localhost:8123/ping"
+          "0.0.0.0:8123/ping"
         ]
       interval: 30s
       timeout: 5s

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -21,7 +21,7 @@ x-clickhouse-defaults: &clickhouse-defaults
         "wget",
         "--spider",
         "-q",
-        "localhost:8123/ping"
+        "0.0.0.0:8123/ping"
       ]
     interval: 30s
     timeout: 5s

--- a/pkg/query-service/tests/test-deploy/docker-compose.yaml
+++ b/pkg/query-service/tests/test-deploy/docker-compose.yaml
@@ -20,7 +20,7 @@ x-clickhouse-defaults: &clickhouse-defaults
         "wget",
         "--spider",
         "-q",
-        "localhost:8123/ping"
+        "0.0.0.0:8123/ping"
       ]
     interval: 30s
     timeout: 5s


### PR DESCRIPTION
### Summary

In latest version of Docker `v26.1.0`, the clickhouse health check endpoint `localhost:8123/ping` does not work as expected.
Updating `localhost` to `0.0.0.0` does the trick.

#### Related Issues / PR's

Resolves #4891

#### Screenshots

NA

#### Affected Areas and Manually Tested Areas

All users with latest version of Docker.
