### PR TITLE
chore: [SIG-583]: Jest coverage collection config

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -4,6 +4,7 @@ const config: Config.InitialOptions = {
 	clearMocks: true,
 	coverageDirectory: 'coverage',
 	coverageReporters: ['text', 'cobertura', 'html', 'json-summary'],
+	collectCoverageFrom: ['src/**/*.{ts,tsx}'],
 	moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
 	modulePathIgnorePatterns: ['dist'],
 	moduleNameMapper: {

--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -410,6 +410,7 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 						panelType: graphType,
 						widgetId: query.get('widgetId'),
 						queryType: currentQuery.queryType,
+						screen: 'Dashboard list page',
 					}}
 					eventName="Dashboard: Facing Issues in dashboard"
 					buttonText="Facing Issues in dashboard"


### PR DESCRIPTION
### Summary

In a few of the recent PRs, I observed that the jest collection for changed files was not done properly, especially for newly added files.
Hence, added `/src` as the Jest coverage collection config

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
