### PR TITLE
fix: dont enrich if non empty keys are not same

### DIFF
--- a/pkg/query-service/app/logs/v3/enrich_query.go
+++ b/pkg/query-service/app/logs/v3/enrich_query.go
@@ -145,12 +145,10 @@ func enrichFieldWithMetadata(field v3.AttributeKey, fields map[string]v3.Attribu
 
 	// check if the field is present in the fields map
 	if existingField, ok := fields[field.Key]; ok {
-		if existingField.IsColumn {
+		// don't update if type is not the same
+		if (field.Type == "" && field.DataType == "") || (field.Type == existingField.Type && field.DataType == existingField.DataType) {
 			return existingField
 		}
-		field.Type = existingField.Type
-		field.DataType = existingField.DataType
-		return field
 	}
 
 	// enrich with default values if metadata is not found

--- a/pkg/query-service/app/logs/v3/enrich_query.go
+++ b/pkg/query-service/app/logs/v3/enrich_query.go
@@ -146,7 +146,10 @@ func enrichFieldWithMetadata(field v3.AttributeKey, fields map[string]v3.Attribu
 	// check if the field is present in the fields map
 	if existingField, ok := fields[field.Key]; ok {
 		// don't update if type is not the same
-		if (field.Type == "" && field.DataType == "") || (field.Type == existingField.Type && field.DataType == existingField.DataType) {
+		if (field.Type == "" && field.DataType == "") ||
+			(field.Type == existingField.Type && field.DataType == existingField.DataType) ||
+			(field.Type == "" && field.DataType == existingField.DataType) ||
+			(field.DataType == "" && field.Type == existingField.Type) {
 			return existingField
 		}
 	}

--- a/pkg/query-service/app/logs/v3/enrich_query_test.go
+++ b/pkg/query-service/app/logs/v3/enrich_query_test.go
@@ -356,7 +356,10 @@ var testEnrichParamsData = []struct {
 							Type:     v3.AttributeKeyTypeResource,
 							DataType: v3.AttributeKeyDataTypeInt64,
 						},
-						Filters: &v3.FilterSet{Operator: "AND", Items: []v3.FilterItem{}},
+						Filters: &v3.FilterSet{Operator: "AND", Items: []v3.FilterItem{
+							{Key: v3.AttributeKey{Key: "test", Type: v3.AttributeKeyTypeTag}, Value: "test", Operator: "="},
+							{Key: v3.AttributeKey{Key: "test", DataType: v3.AttributeKeyDataTypeString}, Value: "test1", Operator: "="},
+						}},
 					},
 				},
 			},
@@ -381,7 +384,10 @@ var testEnrichParamsData = []struct {
 							Type:     v3.AttributeKeyTypeResource,
 							DataType: v3.AttributeKeyDataTypeInt64,
 						},
-						Filters: &v3.FilterSet{Operator: "AND", Items: []v3.FilterItem{}},
+						Filters: &v3.FilterSet{Operator: "AND", Items: []v3.FilterItem{
+							{Key: v3.AttributeKey{Key: "test", Type: v3.AttributeKeyTypeTag, DataType: v3.AttributeKeyDataTypeString, IsColumn: true}, Value: "test", Operator: "="},
+							{Key: v3.AttributeKey{Key: "test", Type: v3.AttributeKeyTypeTag, DataType: v3.AttributeKeyDataTypeString, IsColumn: true}, Value: "test1", Operator: "="},
+						}},
 					},
 				},
 			},

--- a/pkg/query-service/app/logs/v3/enrich_query_test.go
+++ b/pkg/query-service/app/logs/v3/enrich_query_test.go
@@ -342,6 +342,51 @@ var testEnrichParamsData = []struct {
 			},
 		},
 	},
+	{
+		Name: "Don't enrich if other keys are non empty and not same",
+		Params: v3.QueryRangeParamsV3{
+			CompositeQuery: &v3.CompositeQuery{
+				BuilderQueries: map[string]*v3.BuilderQuery{
+					"test": {
+						QueryName:  "test",
+						Expression: "test",
+						DataSource: v3.DataSourceLogs,
+						AggregateAttribute: v3.AttributeKey{
+							Key:      "test",
+							Type:     v3.AttributeKeyTypeResource,
+							DataType: v3.AttributeKeyDataTypeInt64,
+						},
+						Filters: &v3.FilterSet{Operator: "AND", Items: []v3.FilterItem{}},
+					},
+				},
+			},
+		},
+		Fields: map[string]v3.AttributeKey{
+			"test": {
+				Key:      "test",
+				Type:     v3.AttributeKeyTypeTag,
+				DataType: v3.AttributeKeyDataTypeString,
+				IsColumn: true,
+			},
+		},
+		Result: v3.QueryRangeParamsV3{
+			CompositeQuery: &v3.CompositeQuery{
+				BuilderQueries: map[string]*v3.BuilderQuery{
+					"test": {
+						QueryName:  "test",
+						Expression: "test",
+						DataSource: v3.DataSourceLogs,
+						AggregateAttribute: v3.AttributeKey{
+							Key:      "test",
+							Type:     v3.AttributeKeyTypeResource,
+							DataType: v3.AttributeKeyDataTypeInt64,
+						},
+						Filters: &v3.FilterSet{Operator: "AND", Items: []v3.FilterItem{}},
+					},
+				},
+			},
+		},
+	},
 }
 
 func TestEnrichParams(t *testing.T) {


### PR DESCRIPTION
Fixes #4901 

Issue explaination

If there are two fields
* myattr (type=tag, datatype=string)
* myattr (type=resource, datatype=string)

We added a change recently where we forcefully try to enrich all attributes

so if user is searching for `myattr (type=resource, datatype=string)` then it might get replaced with `* myattr (type=tag, datatype=string)`

This PR fixes it.


though there is no solution right now if in the query user enters `myattr` with no metadata, we don't know which one to choose for enriching the tag or the resource attribute. 