### PR TITLE
fix: ch queries sending builder as query type in query range api for exceptions alerts

### DIFF
--- a/frontend/src/constants/query.ts
+++ b/frontend/src/constants/query.ts
@@ -30,4 +30,5 @@ export enum QueryParams {
 	integration = 'integration',
 	pagination = 'pagination',
 	relativeTime = 'relativeTime',
+	alertType = 'alertType',
 }

--- a/frontend/src/container/CreateAlertRule/defaults.ts
+++ b/frontend/src/container/CreateAlertRule/defaults.ts
@@ -130,7 +130,7 @@ export const exceptionAlertDefaults: AlertDef = {
 					disabled: false,
 				},
 			},
-			queryType: EQueryType.QUERY_BUILDER,
+			queryType: EQueryType.CLICKHOUSE,
 			panelType: PANEL_TYPES.TIME_SERIES,
 			unit: undefined,
 		},

--- a/frontend/src/container/CreateAlertRule/defaults.ts
+++ b/frontend/src/container/CreateAlertRule/defaults.ts
@@ -130,7 +130,7 @@ export const exceptionAlertDefaults: AlertDef = {
 					disabled: false,
 				},
 			},
-			queryType: EQueryType.CLICKHOUSE,
+			queryType: EQueryType.QUERY_BUILDER,
 			panelType: PANEL_TYPES.TIME_SERIES,
 			unit: undefined,
 		},

--- a/frontend/src/container/CreateAlertRule/index.tsx
+++ b/frontend/src/container/CreateAlertRule/index.tsx
@@ -27,9 +27,9 @@ function CreateRules(): JSX.Element {
 	const alertTypeFromParams = queryParams.get(QueryParams.alertType);
 
 	const compositeQuery = useGetCompositeQueryParam();
-	function getAlertTypeFromDataSource(): AlertTypes {
+	function getAlertTypeFromDataSource(): AlertTypes | null {
 		if (!compositeQuery) {
-			return AlertTypes.METRICS_BASED_ALERT;
+			return null;
 		}
 		const dataSource = compositeQuery?.builder?.queryData[0]?.dataSource;
 
@@ -66,11 +66,11 @@ function CreateRules(): JSX.Element {
 	};
 
 	useEffect(() => {
-		if (alertTypeFromParams) {
-			onSelectType(alertTypeFromParams as AlertTypes);
+		if (alertType) {
+			onSelectType(alertType);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [alertTypeFromParams]);
+	}, [alertType]);
 
 	if (!initValues) {
 		return (

--- a/frontend/src/container/CreateAlertRule/index.tsx
+++ b/frontend/src/container/CreateAlertRule/index.tsx
@@ -1,8 +1,9 @@
 import { Form, Row } from 'antd';
 import { ENTITY_VERSION_V4 } from 'constants/app';
+import { QueryParams } from 'constants/query';
 import FormAlertRules from 'container/FormAlertRules';
 import { useGetCompositeQueryParam } from 'hooks/queryBuilder/useGetCompositeQueryParam';
-import { isEqual } from 'lodash-es';
+import history from 'lib/history';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { AlertTypes } from 'types/api/alerts/alertTypes';
@@ -19,13 +20,25 @@ import SelectAlertType from './SelectAlertType';
 
 function CreateRules(): JSX.Element {
 	const [initValues, setInitValues] = useState<AlertDef | null>(null);
-	const [alertType, setAlertType] = useState<AlertTypes>();
 
 	const location = useLocation();
 	const queryParams = new URLSearchParams(location.search);
 	const version = queryParams.get('version');
+	const alertTypeFromParams = queryParams.get(QueryParams.alertType);
 
 	const compositeQuery = useGetCompositeQueryParam();
+	function getAlertTypeFromDataSource(): AlertTypes {
+		if (!compositeQuery) {
+			return AlertTypes.METRICS_BASED_ALERT;
+		}
+		const dataSource = compositeQuery?.builder?.queryData[0]?.dataSource;
+
+		return ALERT_TYPE_VS_SOURCE_MAPPING[dataSource];
+	}
+
+	const [alertType, setAlertType] = useState<AlertTypes>(
+		(alertTypeFromParams as AlertTypes) || getAlertTypeFromDataSource(),
+	);
 
 	const [formInstance] = Form.useForm();
 
@@ -47,21 +60,17 @@ function CreateRules(): JSX.Element {
 					version: version || ENTITY_VERSION_V4,
 				});
 		}
+		queryParams.set(QueryParams.alertType, typ);
+		const generatedUrl = `${location.pathname}?${queryParams.toString()}`;
+		history.replace(generatedUrl);
 	};
 
 	useEffect(() => {
-		if (!compositeQuery) {
-			return;
-		}
-		const dataSource = compositeQuery?.builder?.queryData[0]?.dataSource;
-
-		const alertTypeFromQuery = ALERT_TYPE_VS_SOURCE_MAPPING[dataSource];
-
-		if (alertTypeFromQuery && !isEqual(alertType, alertTypeFromQuery)) {
-			onSelectType(alertTypeFromQuery);
+		if (alertTypeFromParams) {
+			onSelectType(alertTypeFromParams as AlertTypes);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [compositeQuery]);
+	}, [alertTypeFromParams]);
 
 	if (!initValues) {
 		return (

--- a/frontend/src/container/FormAlertRules/index.tsx
+++ b/frontend/src/container/FormAlertRules/index.tsx
@@ -523,6 +523,7 @@ function FormAlertRules({
 							runQuery={handleRunQuery}
 							alertDef={alertDef}
 							panelType={panelType || PANEL_TYPES.TIME_SERIES}
+							key={currentQuery.queryType}
 						/>
 
 						<RuleOptions


### PR DESCRIPTION
### Summary

- the logic in the alerts was based on `datasource` from query hence the exceptions alerts were not working as expected as it always routed to trace based alerts.
- refactored the logic to include the `alertType` as query params to maintain the sanity 
- if the query param `alertType` is not present we will extract the same from staged query like we are doing currently to support backwards compatibility 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

Logs -> Alerts 
Dashboard (Traces / Logs / Metrics ) -> Alerts

https://github.com/SigNoz/signoz/assets/54737045/5a16f352-093f-48cd-8f16-516f9ab675b4

Alerts UI navigation 

https://github.com/SigNoz/signoz/assets/54737045/53d61444-98bd-4e81-ad82-ced11aa3c2c0



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
