### PR TITLE
chore: disallow small step intervals for large durations

### DIFF
--- a/pkg/query-service/app/parser.go
+++ b/pkg/query-service/app/parser.go
@@ -20,6 +20,7 @@ import (
 	"go.signoz.io/signoz/pkg/query-service/app/metrics"
 	"go.signoz.io/signoz/pkg/query-service/app/queryBuilder"
 	"go.signoz.io/signoz/pkg/query-service/auth"
+	"go.signoz.io/signoz/pkg/query-service/common"
 	"go.signoz.io/signoz/pkg/query-service/constants"
 	"go.signoz.io/signoz/pkg/query-service/model"
 	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
@@ -1036,6 +1037,10 @@ func ParseQueryRangeParams(r *http.Request) (*v3.QueryRangeParamsV3, *model.ApiE
 				if !can {
 					return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("cannot join the given group keys")}
 				}
+			}
+
+			if minStep := common.MinAllowedStepInterval(queryRangeParams.Start, queryRangeParams.End); query.StepInterval < minStep {
+				query.StepInterval = minStep
 			}
 
 			var timeShiftBy int64

--- a/pkg/query-service/common/metrics.go
+++ b/pkg/query-service/common/metrics.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"time"
 
+	"go.signoz.io/signoz/pkg/query-service/constants"
 	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
 )
 
@@ -22,4 +23,11 @@ func AdjustedMetricTimeRange(start, end, step int64, aggregaOperator v3.TimeAggr
 func PastDayRoundOff() int64 {
 	now := time.Now().UnixMilli()
 	return int64(math.Floor(float64(now)/float64(time.Hour.Milliseconds()*24))) * time.Hour.Milliseconds() * 24
+}
+
+// start and end are in milliseconds
+func MinAllowedStepInterval(start, end int64) int64 {
+	step := (end - start) / constants.MaxAllowedPointsInTimeSeries / 1000
+	// return the nearest lower multiple of 60
+	return step - step%60
 }

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -25,6 +25,8 @@ var ConfigSignozIo = "https://config.signoz.io/api/v1"
 
 var DEFAULT_TELEMETRY_ANONYMOUS = false
 
+const MaxAllowedPointsInTimeSeries = 300
+
 func IsTelemetryEnabled() bool {
 	if testing.Testing() {
 		return false

--- a/pkg/query-service/rules/thresholdRule_test.go
+++ b/pkg/query-service/rules/thresholdRule_test.go
@@ -266,6 +266,19 @@ func TestThresholdRuleCombinations(t *testing.T) {
 			matchType:   "1", // Once
 			target:      0.0,
 		},
+		{
+			values: [][]interface{}{
+				{int32(2), "endpoint"},
+				{int32(3), "endpoint"},
+				{int32(2), "endpoint"},
+				{int32(4), "endpoint"},
+				{int32(2), "endpoint"},
+			},
+			expectAlert: true,
+			compareOp:   "2", // Below
+			matchType:   "3", // On Average
+			target:      3.0,
+		},
 	}
 
 	for idx, c := range cases {

--- a/pkg/query-service/rules/thresholdRule_test.go
+++ b/pkg/query-service/rules/thresholdRule_test.go
@@ -279,6 +279,32 @@ func TestThresholdRuleCombinations(t *testing.T) {
 			matchType:   "3", // On Average
 			target:      3.0,
 		},
+		{
+			values: [][]interface{}{
+				{int32(4), "endpoint"},
+				{int32(7), "endpoint"},
+				{int32(5), "endpoint"},
+				{int32(2), "endpoint"},
+				{int32(9), "endpoint"},
+			},
+			expectAlert: false,
+			compareOp:   "2", // Below
+			matchType:   "3", // On Average
+			target:      3.0,
+		},
+		{
+			values: [][]interface{}{
+				{int32(4), "endpoint"},
+				{int32(7), "endpoint"},
+				{int32(5), "endpoint"},
+				{int32(2), "endpoint"},
+				{int32(9), "endpoint"},
+			},
+			expectAlert: true,
+			compareOp:   "2", // Below
+			matchType:   "3", // On Average
+			target:      6.0,
+		},
 	}
 
 	for idx, c := range cases {


### PR DESCRIPTION
### Summary

Part of https://github.com/SigNoz/signoz/issues/4943

This change makes the query service override the small step interval values with the reasonable step interval based on the selected time range. Even if someone sends a 60s step for one week, we replace it with 1980 i.e. 33 minutes. This prevents memory issues in ClickHouse. Also fixes the average bug in threshold rules.