### PR TITLE
feat: sort tags and events in trace detail

### DIFF
--- a/frontend/src/container/TraceDetail/SelectedSpanDetails/Events/index.tsx
+++ b/frontend/src/container/TraceDetail/SelectedSpanDetails/Events/index.tsx
@@ -13,11 +13,18 @@ function Events({
 		return <Typography>No events data in selected span</Typography>;
 	}
 
+	const sortedTraceEvents = events.sort((a, b) => {
+		// Handle undefined names by treating them as empty strings
+		const nameA = a.name || '';
+		const nameB = b.name || '';
+		return nameA.localeCompare(nameB);
+	});
+
 	return (
 		<ErrorTag
 			onToggleHandler={onToggleHandler}
 			setText={setText}
-			event={events}
+			event={sortedTraceEvents}
 			firstSpanStartTime={firstSpanStartTime}
 		/>
 	);

--- a/frontend/src/container/TraceDetail/SelectedSpanDetails/Tags/index.tsx
+++ b/frontend/src/container/TraceDetail/SelectedSpanDetails/Tags/index.tsx
@@ -41,8 +41,9 @@ function Tags({
 		setSearchText(value);
 	};
 
-	const filteredTags = tags.filter((tag) => tag.key.includes(searchText));
-
+	const filteredTags = tags
+		.filter((tag) => tag.key.includes(searchText))
+		.sort((a, b) => a.key.localeCompare(b.key));
 	if (tags.length === 0) {
 		return <Typography>No tags in selected span</Typography>;
 	}


### PR DESCRIPTION
### Summary

Sort tags by key and events by event name in trace detail