### PR TITLE
fix: prevent page from crashing in case items in filters is null

### DIFF
--- a/frontend/src/lib/newQueryBuilder/getPaginationQueryData.ts
+++ b/frontend/src/lib/newQueryBuilder/getPaginationQueryData.ts
@@ -36,7 +36,7 @@ export const getPaginationQueryData: SetupPaginationQueryData = ({
 
 	const updatedFilters: TagFilter = {
 		...filters,
-		items: filters.items.filter((item) => item.key?.key !== 'id'),
+		items: filters.items?.filter((item) => item.key?.key !== 'id'),
 	};
 
 	const tagFilters: TagFilter = {

--- a/frontend/src/lib/newQueryBuilder/getPaginationQueryData.ts
+++ b/frontend/src/lib/newQueryBuilder/getPaginationQueryData.ts
@@ -36,7 +36,7 @@ export const getPaginationQueryData: SetupPaginationQueryData = ({
 
 	const updatedFilters: TagFilter = {
 		...filters,
-		items: filters.items?.filter((item) => item.key?.key !== 'id'),
+		items: filters?.items?.filter((item) => item.key?.key !== 'id'),
 	};
 
 	const tagFilters: TagFilter = {


### PR DESCRIPTION
### Summary

- fix the page crash when `items` in the filters are null

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


#### Affected Areas and Manually Tested Areas

- logs explorer with null filters
