### PR TITLE
fix: added right padding to the notifications bar to show cancel button

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -242,3 +242,7 @@ body {
 		}
 	}
 }
+
+.ant-notification-notice-message {
+	padding-right: 20px;
+}


### PR DESCRIPTION
### Summary

- added right padding of `20px` to the notifications globally to make the cancel button accessible 

#### Related Issues / PR's

Fixes - https://github.com/SigNoz/signoz/issues/4968

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
