### PR TITLE
fix: handle silent error for dashboard edit mutation

### DIFF
--- a/frontend/src/api/dashboard/update.ts
+++ b/frontend/src/api/dashboard/update.ts
@@ -1,26 +1,20 @@
 import axios from 'api';
-import { ErrorResponseHandler } from 'api/ErrorResponseHandler';
-import { AxiosError } from 'axios';
 import { ErrorResponse, SuccessResponse } from 'types/api';
 import { PayloadProps, Props } from 'types/api/dashboard/update';
 
 const updateDashboard = async (
 	props: Props,
 ): Promise<SuccessResponse<PayloadProps> | ErrorResponse> => {
-	try {
-		const response = await axios.put(`/dashboards/${props.uuid}`, {
-			...props.data,
-		});
+	const response = await axios.put(`/dashboards/${props.uuid}`, {
+		...props.data,
+	});
 
-		return {
-			statusCode: 200,
-			error: null,
-			message: response.data.status,
-			payload: response.data.data,
-		};
-	} catch (error) {
-		return ErrorResponseHandler(error as AxiosError);
-	}
+	return {
+		statusCode: 200,
+		error: null,
+		message: response.data.status,
+		payload: response.data.data,
+	};
 };
 
 export default updateDashboard;

--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -11,6 +11,7 @@ import { DashboardShortcuts } from 'constants/shortcuts/DashboardShortcuts';
 import { useUpdateDashboard } from 'hooks/dashboard/useUpdateDashboard';
 import { useKeyboardHotkeys } from 'hooks/hotkeys/useKeyboardHotkeys';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
+import useAxiosError from 'hooks/useAxiosError';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { MESSAGE, useIsFeatureDisabled } from 'hooks/useFeatureFlag';
 import useUrlQuery from 'hooks/useUrlQuery';
@@ -242,6 +243,8 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 		return { selectedWidget, preWidgets, afterWidgets };
 	}, [selectedDashboard, query]);
 
+	const handleError = useAxiosError();
+
 	const onClickSaveHandler = useCallback(() => {
 		if (!selectedDashboard) {
 			return;
@@ -301,6 +304,7 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 					pathname: generatePath(ROUTES.DASHBOARD, { dashboardId }),
 				});
 			},
+			onError: handleError,
 		});
 	}, [
 		selectedDashboard,
@@ -313,6 +317,7 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 		currentQuery,
 		afterWidgets,
 		updateDashboardMutation,
+		handleError,
 		setSelectedDashboard,
 		setToScrollWidgetId,
 		featureResponse,

--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -3,7 +3,6 @@ import './NewWidget.styles.scss';
 
 import { WarningOutlined } from '@ant-design/icons';
 import { Button, Modal, Space, Tooltip, Typography } from 'antd';
-import { SOMETHING_WENT_WRONG } from 'constants/api';
 import { FeatureKeys } from 'constants/features';
 import { QueryParams } from 'constants/query';
 import { PANEL_TYPES } from 'constants/queryBuilder';
@@ -14,7 +13,6 @@ import { useKeyboardHotkeys } from 'hooks/hotkeys/useKeyboardHotkeys';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { MESSAGE, useIsFeatureDisabled } from 'hooks/useFeatureFlag';
-import { useNotifications } from 'hooks/useNotifications';
 import useUrlQuery from 'hooks/useUrlQuery';
 import history from 'lib/history';
 import { defaultTo, isUndefined } from 'lodash-es';
@@ -244,8 +242,6 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 		return { selectedWidget, preWidgets, afterWidgets };
 	}, [selectedDashboard, query]);
 
-	const { notifications } = useNotifications();
-
 	const onClickSaveHandler = useCallback(() => {
 		if (!selectedDashboard) {
 			return;
@@ -305,11 +301,6 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 					pathname: generatePath(ROUTES.DASHBOARD, { dashboardId }),
 				});
 			},
-			onError: () => {
-				notifications.error({
-					message: SOMETHING_WENT_WRONG,
-				});
-			},
 		});
 	}, [
 		selectedDashboard,
@@ -326,7 +317,6 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 		setToScrollWidgetId,
 		featureResponse,
 		dashboardId,
-		notifications,
 	]);
 
 	const onClickDiscardHandler = useCallback(() => {

--- a/frontend/src/hooks/dashboard/useUpdateDashboard.tsx
+++ b/frontend/src/hooks/dashboard/useUpdateDashboard.tsx
@@ -1,6 +1,5 @@
 import update from 'api/dashboard/update';
 import dayjs from 'dayjs';
-import useAxiosError from 'hooks/useAxiosError';
 import { useDashboard } from 'providers/Dashboard/Dashboard';
 import { useMutation, UseMutationResult } from 'react-query';
 import { ErrorResponse, SuccessResponse } from 'types/api';
@@ -9,14 +8,12 @@ import { Props } from 'types/api/dashboard/update';
 
 export const useUpdateDashboard = (): UseUpdateDashboard => {
 	const { updatedTimeRef } = useDashboard();
-	const handleError = useAxiosError();
 	return useMutation(update, {
 		onSuccess: (data) => {
 			if (data.payload) {
 				updatedTimeRef.current = dayjs(data.payload.updated_at);
 			}
 		},
-		onError: handleError,
 	});
 };
 

--- a/frontend/src/hooks/dashboard/useUpdateDashboard.tsx
+++ b/frontend/src/hooks/dashboard/useUpdateDashboard.tsx
@@ -1,5 +1,6 @@
 import update from 'api/dashboard/update';
 import dayjs from 'dayjs';
+import useAxiosError from 'hooks/useAxiosError';
 import { useDashboard } from 'providers/Dashboard/Dashboard';
 import { useMutation, UseMutationResult } from 'react-query';
 import { ErrorResponse, SuccessResponse } from 'types/api';
@@ -8,12 +9,14 @@ import { Props } from 'types/api/dashboard/update';
 
 export const useUpdateDashboard = (): UseUpdateDashboard => {
 	const { updatedTimeRef } = useDashboard();
+	const handleError = useAxiosError();
 	return useMutation(update, {
 		onSuccess: (data) => {
 			if (data.payload) {
 				updatedTimeRef.current = dayjs(data.payload.updated_at);
 			}
 		},
+		onError: handleError,
 	});
 };
 


### PR DESCRIPTION
### Summary

- handle silent error for dashboard edit mutation failing .
- the code to handle the same was present but was getting catched before itself , hence not triggering the same. 

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/5017

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
