### PR TITLE
fix: metrics order by avg

### DIFF
--- a/pkg/query-service/app/limit.go
+++ b/pkg/query-service/app/limit.go
@@ -40,7 +40,7 @@ func applyMetricLimit(results []*v3.Result, queryRangeParams *v3.QueryRangeParam
 								}
 							}
 
-							ithSum, jthSum, ithCount, jthCount := 0.0, 0.0, 1.0, 1.0
+							ithSum, jthSum, ithCount, jthCount := 0.0, 0.0, 0.0, 0.0
 							for _, point := range result.Series[i].Points {
 								if math.IsNaN(point.Value) || math.IsInf(point.Value, 0) {
 									continue
@@ -56,6 +56,10 @@ func applyMetricLimit(results []*v3.Result, queryRangeParams *v3.QueryRangeParam
 								jthSum += point.Value
 								jthCount++
 							}
+
+							// avoid division by zero
+							ithCount = math.Max(ithCount, 1)
+							jthCount = math.Max(jthCount, 1)
 
 							if orderBy.Order == "asc" {
 								return ithSum/ithCount < jthSum/jthCount


### PR DESCRIPTION
### Summary

The original logic used to decide the order in the table used the sum of values, which is incorrect if there are +Inf or NaNs. Then this commit https://github.com/SigNoz/signoz/pull/5015/commits/351c9b3dbefb18cbf217b54efe3367b6b9b0fc04 added division with count which is also flawed if the number of values is small. Example [5.5], [4.2, 4.2].