### PR TITLE
fix: new dashboards feedback from testing

### DIFF
--- a/frontend/src/container/ListOfDashboard/DashboardsList.tsx
+++ b/frontend/src/container/ListOfDashboard/DashboardsList.tsx
@@ -646,22 +646,28 @@ function DashboardsList(): JSX.Element {
 							</Typography.Text>
 						</section>
 
-						<section className="actions">
-							<Dropdown
-								overlayClassName="new-dashboard-menu"
-								menu={{ items: getCreateDashboardItems }}
-								placement="bottomRight"
-								trigger={['click']}
-							>
-								<Button type="text" className="new-dashboard" icon={<Plus size={14} />}>
-									New Dashboard
+						{createNewDashboard && (
+							<section className="actions">
+								<Dropdown
+									overlayClassName="new-dashboard-menu"
+									menu={{ items: getCreateDashboardItems }}
+									placement="bottomRight"
+									trigger={['click']}
+								>
+									<Button
+										type="text"
+										className="new-dashboard"
+										icon={<Plus size={14} />}
+									>
+										New Dashboard
+									</Button>
+								</Dropdown>
+								<Button type="text" className="learn-more">
+									Learn more
 								</Button>
-							</Dropdown>
-							<Button type="text" className="learn-more">
-								Learn more
-							</Button>
-							<ArrowUpRight size={16} className="learn-more-arrow" />
-						</section>
+								<ArrowUpRight size={16} className="learn-more-arrow" />
+							</section>
+						)}
 					</div>
 				) : (
 					<>
@@ -687,20 +693,22 @@ function DashboardsList(): JSX.Element {
 								onChange={handleSearch}
 							/>
 
-							<Dropdown
-								overlayClassName="new-dashboard-menu"
-								menu={{ items: getCreateDashboardItems }}
-								placement="bottomRight"
-								trigger={['click']}
-							>
-								<Button
-									type="primary"
-									className="periscope-btn primary"
-									icon={<Plus size={14} />}
+							{createNewDashboard && (
+								<Dropdown
+									overlayClassName="new-dashboard-menu"
+									menu={{ items: getCreateDashboardItems }}
+									placement="bottomRight"
+									trigger={['click']}
 								>
-									New dashboard
-								</Button>
-							</Dropdown>
+									<Button
+										type="primary"
+										className="periscope-btn primary"
+										icon={<Plus size={14} />}
+									>
+										New dashboard
+									</Button>
+								</Dropdown>
+							)}
 						</div>
 						<div className="all-dashboards-header">
 							<Typography.Text className="typography">All Dashboards</Typography.Text>

--- a/frontend/src/container/ListOfDashboard/DashboardsList.tsx
+++ b/frontend/src/container/ListOfDashboard/DashboardsList.tsx
@@ -39,7 +39,6 @@ import {
 	CalendarClockIcon,
 	Check,
 	Clock4,
-	Copy,
 	Expand,
 	HdmiPort,
 	LayoutGrid,
@@ -452,15 +451,6 @@ function DashboardsList(): JSX.Element {
 														}}
 													>
 														Copy Link
-													</Button>
-
-													<Button
-														type="text"
-														className="action-btn"
-														icon={<Copy size={14} />}
-														// TODO add duplicate dashboard here
-													>
-														Duplicate
 													</Button>
 												</section>
 												<section className="section-2">

--- a/frontend/src/container/ListOfDashboard/DashboardsList.tsx
+++ b/frontend/src/container/ListOfDashboard/DashboardsList.tsx
@@ -584,7 +584,7 @@ function DashboardsList(): JSX.Element {
 					<div
 						className="create-dashboard-menu-item"
 						onClick={(): void => {
-							setShowNewDashboardTemplatesModal(true);
+							onNewDashboardHandler();
 						}}
 					>
 						<LayoutGrid size={14} /> Create dashboard
@@ -595,7 +595,7 @@ function DashboardsList(): JSX.Element {
 		}
 
 		return menuItems;
-	}, [createNewDashboard]);
+	}, [createNewDashboard, onNewDashboardHandler]);
 
 	return (
 		<div className="dashboards-list-container">

--- a/frontend/src/container/ListOfDashboard/DashboardsList.tsx
+++ b/frontend/src/container/ListOfDashboard/DashboardsList.tsx
@@ -27,6 +27,7 @@ import cx from 'classnames';
 import { ENTITY_VERSION_V4 } from 'constants/app';
 import ROUTES from 'constants/routes';
 import { Base64Icons } from 'container/NewDashboard/DashboardSettings/General/utils';
+import dayjs from 'dayjs';
 import { useGetAllDashboard } from 'hooks/dashboard/useGetAllDashboard';
 import useComponentPermission from 'hooks/useComponentPermission';
 import { useNotifications } from 'hooks/useNotifications';
@@ -354,6 +355,37 @@ function DashboardsList(): JSX.Element {
 		return `${formattedDate} ⎯ ${formattedTime}`;
 	}
 
+	const onLastUpdated = (time: string): string => {
+		const currentTime = dayjs();
+
+		const lastRefresh = dayjs(time);
+
+		const secondsDiff = currentTime.diff(lastRefresh, 'seconds');
+
+		const minutedDiff = currentTime.diff(lastRefresh, 'minutes');
+		const hoursDiff = currentTime.diff(lastRefresh, 'hours');
+		const daysDiff = currentTime.diff(lastRefresh, 'days');
+		const monthsDiff = currentTime.diff(lastRefresh, 'months');
+
+		if (monthsDiff > 0) {
+			return `Last Updated ${monthsDiff} months ago`;
+		}
+
+		if (daysDiff > 0) {
+			return `Last Updated ${daysDiff} days ago`;
+		}
+
+		if (hoursDiff > 0) {
+			return `Last Updated ${hoursDiff} hrs ago`;
+		}
+
+		if (minutedDiff > 0) {
+			return `Last Updated ${minutedDiff} mins ago`;
+		}
+
+		return `Last Updated ${secondsDiff} sec ago`;
+	};
+
 	const columns: TableProps<Data>['columns'] = [
 		{
 			title: 'Dashboards',
@@ -370,10 +402,6 @@ function DashboardsList(): JSX.Element {
 					timeOptions,
 				);
 
-				const lastUpdatedFormattedTime = new Date(
-					dashboard.lastUpdatedTime,
-				).toLocaleTimeString('en-US', timeOptions);
-
 				const dateOptions: Intl.DateTimeFormatOptions = {
 					month: 'short',
 					day: 'numeric',
@@ -385,14 +413,8 @@ function DashboardsList(): JSX.Element {
 					dateOptions,
 				);
 
-				const lastUpdatedFormattedDate = new Date(
-					dashboard.lastUpdatedTime,
-				).toLocaleDateString('en-US', dateOptions);
-
 				// Combine time and date
 				const formattedDateAndTime = `${formattedDate} ⎯ ${formattedTime}`;
-
-				const lastUpdatedFormattedDateTime = `${lastUpdatedFormattedDate} ⎯ ${lastUpdatedFormattedTime}`;
 
 				const getLink = (): string => `${ROUTES.ALL_DASHBOARD}/${dashboard.id}`;
 
@@ -497,7 +519,9 @@ function DashboardsList(): JSX.Element {
 							{visibleColumns.updatedAt && (
 								<div className="dashboard-created-at">
 									<CalendarClock size={14} />
-									<Typography.Text>{lastUpdatedFormattedDateTime}</Typography.Text>
+									<Typography.Text>
+										{onLastUpdated(dashboard.lastUpdatedTime)}
+									</Typography.Text>
 								</div>
 							)}
 
@@ -848,7 +872,7 @@ function DashboardsList(): JSX.Element {
 									{visibleColumns.updatedAt && (
 										<Typography.Text className="formatted-time">
 											<CalendarClock size={14} />
-											{getFormattedTime(dashboards?.[0] as Dashboard, 'updated_at')}
+											{onLastUpdated(dashboards?.[0]?.updated_by || '')}
 										</Typography.Text>
 									)}
 									{visibleColumns.updatedBy && (

--- a/frontend/src/container/ListOfDashboard/TableComponents/DeleteButton.tsx
+++ b/frontend/src/container/ListOfDashboard/TableComponents/DeleteButton.tsx
@@ -46,7 +46,7 @@ export function DeleteButton({
 	const deleteDashboardMutation = useDeleteDashboard(id);
 
 	const openConfirmationDialog = useCallback((): void => {
-		modal.confirm({
+		const { destroy } = modal.confirm({
 			title: (
 				<Typography.Title level={5}>
 					Are you sure you want to delete the
@@ -55,23 +55,28 @@ export function DeleteButton({
 				</Typography.Title>
 			),
 			icon: <ExclamationCircleOutlined style={{ color: '#e42b35' }} />,
-			onOk() {
-				deleteDashboardMutation.mutateAsync(undefined, {
-					onSuccess: () => {
-						notifications.success({
-							message: t('dashboard:delete_dashboard_success', {
-								name,
-							}),
-						});
-						queryClient.invalidateQueries([REACT_QUERY_KEY.GET_ALL_DASHBOARDS]);
-						if (routeToListPage) {
-							history.replace(ROUTES.ALL_DASHBOARD);
-						}
-					},
-				});
-			},
 			okText: 'Delete',
-			okButtonProps: { danger: true },
+			okButtonProps: {
+				danger: true,
+				onClick: (e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					deleteDashboardMutation.mutateAsync(undefined, {
+						onSuccess: () => {
+							notifications.success({
+								message: t('dashboard:delete_dashboard_success', {
+									name,
+								}),
+							});
+							queryClient.invalidateQueries([REACT_QUERY_KEY.GET_ALL_DASHBOARDS]);
+							if (routeToListPage) {
+								history.replace(ROUTES.ALL_DASHBOARD);
+							}
+							destroy();
+						},
+					});
+				},
+			},
 			centered: true,
 			className: 'delete-modal',
 		});

--- a/frontend/src/container/NewDashboard/DashboardDescription/Description.styles.scss
+++ b/frontend/src/container/NewDashboard/DashboardDescription/Description.styles.scss
@@ -128,7 +128,20 @@
 			.icons {
 				display: flex;
 				align-items: center;
-				width: auto;
+				width: 32px;
+				height: 34px;
+				padding: 6px;
+				justify-content: center;
+				border-radius: 2px;
+				border: 1px solid var(--bg-slate-400);
+				background: var(--bg-ink-300);
+				color: var(--bg-vanilla-400);
+				font-family: Inter;
+				font-size: 12px;
+				font-style: normal;
+				font-weight: 500;
+				line-height: 10px; /* 83.333% */
+				letter-spacing: 0.12px;
 			}
 
 			.icons:hover {
@@ -567,6 +580,11 @@
 			}
 
 			.right-section {
+				.icons {
+					border: 1px solid var(--bg-vanilla-300);
+					background: var(--bg-vanilla-100);
+					color: var(--bg-ink-400);
+				}
 				.configure-button {
 					border: 1px solid var(--bg-vanilla-300);
 					background: var(--bg-vanilla-100);

--- a/frontend/src/container/NewDashboard/DashboardDescription/Description.styles.scss
+++ b/frontend/src/container/NewDashboard/DashboardDescription/Description.styles.scss
@@ -231,12 +231,6 @@
 	overflow: hidden;
 }
 
-.dashboard-actions {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-}
-
 .dashboard-settings {
 	width: 191px;
 	height: 302px;

--- a/frontend/src/container/NewDashboard/DashboardDescription/index.tsx
+++ b/frontend/src/container/NewDashboard/DashboardDescription/index.tsx
@@ -1,6 +1,6 @@
 import './Description.styles.scss';
 
-import { PlusOutlined } from '@ant-design/icons';
+import { PlusOutlined, SmallDashOutlined } from '@ant-design/icons';
 import { Button, Card, Input, Modal, Popover, Tag, Typography } from 'antd';
 import { SOMETHING_WENT_WRONG } from 'constants/api';
 import { PANEL_GROUP_TYPES, PANEL_TYPES } from 'constants/queryBuilder';
@@ -14,7 +14,6 @@ import history from 'lib/history';
 import { isEmpty } from 'lodash-es';
 import {
 	Check,
-	CircleEllipsis,
 	ClipboardCopy,
 	FileJson,
 	FolderKanban,
@@ -284,6 +283,7 @@ function DashboardDescription(props: DashboardDescriptionProps): JSX.Element {
 					<Typography.Text className="dashboard-title">{title}</Typography.Text>
 				</div>
 				<div className="right-section">
+					<DateTimeSelectionV2 showAutoRefresh hideShareModal />
 					<Popover
 						open={isDashboardSettingsOpen}
 						arrow={false}
@@ -372,13 +372,8 @@ function DashboardDescription(props: DashboardDescriptionProps): JSX.Element {
 						trigger="click"
 						placement="bottomRight"
 					>
-						<Button
-							icon={<CircleEllipsis size={14} />}
-							type="text"
-							className="icons"
-						/>
+						<Button icon={<SmallDashOutlined />} type="text" className="icons" />
 					</Popover>
-					<DateTimeSelectionV2 showAutoRefresh hideShareModal />
 					{!isDashboardLocked && editDashboard && (
 						<SettingsDrawer drawerTitle="Dashboard Configuration" />
 					)}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -246,3 +246,8 @@ body {
 .ant-notification-notice-message {
 	padding-right: 20px;
 }
+
+.ant-drawer {
+	// do not modify this as this is required to hide intercom in modals
+	z-index: 1000000000000;
+}


### PR DESCRIPTION
### Summary

- hide the add dashboard section / import json from viewer roles.
- move the configuration button to the right of date time picker and convert it into a secondary button with `...` icon
- remove the duplicate dashboard action button for now. will be added incrementally ( not parity item )
- hide the intercom trigger when drawers are open for easy lower right area access
- dashboard list actions popover not closing 
- remove the pre-defined templates modal from the v0 flow
- stop delete button event propagation 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
