### PR TITLE
fix: cursor resetting in dropdown causing wrong query selection

### DIFF
--- a/frontend/src/hooks/queryBuilder/useAutoComplete.ts
+++ b/frontend/src/hooks/queryBuilder/useAutoComplete.ts
@@ -126,6 +126,7 @@ export const useAutoComplete = (
 		isExist,
 		results,
 		result,
+		isFetching,
 		whereClauseConfig,
 	);
 

--- a/frontend/src/hooks/queryBuilder/useOptions.ts
+++ b/frontend/src/hooks/queryBuilder/useOptions.ts
@@ -23,6 +23,7 @@ export const useOptions = (
 	isExist: boolean,
 	results: string[],
 	result: string[],
+	isFetching: boolean,
 	whereClauseConfig?: WhereClauseConfig,
 ): Option[] => {
 	const [options, setOptions] = useState<Option[]>([]);
@@ -138,6 +139,9 @@ export const useOptions = (
 		if (newOptions.length > 0) {
 			setOptions(newOptions);
 		}
+		if (isFetching) {
+			setOptions([]);
+		}
 	}, [
 		whereClauseConfig,
 		getKeyOpValue,
@@ -154,6 +158,7 @@ export const useOptions = (
 		searchValue,
 		getKeyOperatorOptions,
 		getOptionsWithValidOperator,
+		isFetching,
 	]);
 
 	return useMemo(


### PR DESCRIPTION
### Summary

- due to the aggregate keys fetch call the options dropdown was re-rendering hence the cursor reset.
- added the loading state handling

#### Related Issues / PR's

fixes :- https://github.com/SigNoz/signoz/issues/5059

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
