### PR TITLE
fix: clickhouse builder cursor issue

### DIFF
--- a/frontend/src/container/NewWidget/LeftContainer/QuerySection/QueryBuilder/clickHouse/query.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/QuerySection/QueryBuilder/clickHouse/query.tsx
@@ -86,12 +86,9 @@ function ClickHouseQueryBuilder({
 			colors: {
 				'editor.background': Color.BG_INK_300,
 			},
-			// fontFamily: 'SF Mono',
-			fontFamily: 'Space Mono',
-			fontSize: 20,
-			fontWeight: 'normal',
-			lineHeight: 18,
-			letterSpacing: -0.06,
+		});
+		document.fonts.ready.then(() => {
+			monaco.editor.remeasureFonts();
 		});
 	}
 


### PR DESCRIPTION
### Summary

- The Monaco editor was not re-measuring the fonts hence the offset between the same.

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/5052

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/e28f9f3b-07c6-4dbe-9737-374fd91e2b50



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
