### PR TITLE
fix: retain the alerts table sorting when editing or discarding the opened alert

### DIFF
--- a/frontend/src/constants/query.ts
+++ b/frontend/src/constants/query.ts
@@ -31,4 +31,5 @@ export enum QueryParams {
 	pagination = 'pagination',
 	relativeTime = 'relativeTime',
 	alertType = 'alertType',
+	ruleId = 'ruleId',
 }

--- a/frontend/src/container/FormAlertRules/index.tsx
+++ b/frontend/src/container/FormAlertRules/index.tsx
@@ -157,8 +157,12 @@ function FormAlertRules({
 	}, [alertDef, currentQuery?.queryType, queryOptions]);
 
 	const onCancelHandler = useCallback(() => {
-		history.replace(ROUTES.LIST_ALL_ALERT);
-	}, []);
+		urlQuery.delete(QueryParams.compositeQuery);
+		urlQuery.delete(QueryParams.panelTypes);
+		urlQuery.delete(QueryParams.ruleId);
+		urlQuery.delete(QueryParams.relativeTime);
+		history.replace(`${ROUTES.LIST_ALL_ALERT}?${urlQuery.toString()}`);
+	}, [urlQuery]);
 
 	// onQueryCategoryChange handles changes to query category
 	// in state as well as sets additional defaults
@@ -343,8 +347,13 @@ function FormAlertRules({
 				// invalidate rule in cache
 				ruleCache.invalidateQueries(['ruleId', ruleId]);
 
+				// eslint-disable-next-line sonarjs/no-identical-functions
 				setTimeout(() => {
-					history.replace(ROUTES.LIST_ALL_ALERT);
+					urlQuery.delete(QueryParams.compositeQuery);
+					urlQuery.delete(QueryParams.panelTypes);
+					urlQuery.delete(QueryParams.ruleId);
+					urlQuery.delete(QueryParams.relativeTime);
+					history.replace(`${ROUTES.LIST_ALL_ALERT}?${urlQuery.toString()}`);
 				}, 2000);
 			} else {
 				notifications.error({
@@ -360,12 +369,13 @@ function FormAlertRules({
 		}
 		setLoading(false);
 	}, [
-		t,
 		isFormValid,
-		ruleId,
-		ruleCache,
 		memoizedPreparePostData,
+		ruleId,
 		notifications,
+		t,
+		ruleCache,
+		urlQuery,
 	]);
 
 	const onSaveHandler = useCallback(async () => {

--- a/frontend/src/container/ListAlertRules/ListAlert.tsx
+++ b/frontend/src/container/ListAlertRules/ListAlert.tsx
@@ -117,14 +117,19 @@ function ListAlert({ allAlertRules, refetch }: ListAlertProps): JSX.Element {
 			.refetch()
 			.then(() => {
 				const compositeQuery = mapQueryDataFromApi(record.condition.compositeQuery);
-
-				history.push(
-					`${ROUTES.EDIT_ALERTS}?ruleId=${record.id.toString()}&${
-						QueryParams.compositeQuery
-					}=${encodeURIComponent(JSON.stringify(compositeQuery))}&panelTypes=${
-						record.condition.compositeQuery.panelType
-					}`,
+				params.set(
+					QueryParams.compositeQuery,
+					encodeURIComponent(JSON.stringify(compositeQuery)),
 				);
+
+				params.set(
+					QueryParams.panelTypes,
+					record.condition.compositeQuery.panelType,
+				);
+
+				params.set(QueryParams.ruleId, record.id.toString());
+
+				history.push(`${ROUTES.EDIT_ALERTS}?${params.toString()}`);
 			})
 			.catch(handleError);
 	};
@@ -151,7 +156,8 @@ function ListAlert({ allAlertRules, refetch }: ListAlertProps): JSX.Element {
 				setData(refetchData.payload || []);
 				setTimeout(() => {
 					const clonedAlert = refetchData.payload[refetchData.payload.length - 1];
-					history.push(`${ROUTES.EDIT_ALERTS}?ruleId=${clonedAlert.id}`);
+					params.set(QueryParams.ruleId, String(clonedAlert.id));
+					history.push(`${ROUTES.EDIT_ALERTS}?${params.toString()}`);
 				}, 2000);
 			}
 			if (status === 'error') {


### PR DESCRIPTION
### Summary

- retain the alerts table sorting params when navigating  from list to the details page and visiting back the same

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/5055

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/97196b5c-c9bf-44d8-b719-aca763e54171



#### Affected Areas and Manually Tested Areas

- alerts list and details page
