### PR TITLE
feat: added padding bottom to increase the visibility of logs in explorer page

### DIFF
--- a/frontend/src/container/LogsExplorerViews/LogsExplorerViews.styles.scss
+++ b/frontend/src/container/LogsExplorerViews/LogsExplorerViews.styles.scss
@@ -9,6 +9,7 @@
 		display: flex;
 		flex-direction: column;
 		flex: 1;
+		padding-bottom: 60px;
 
 		.views-tabs-container {
 			padding: 8px 16px;


### PR DESCRIPTION
### Summary

- added padding in the bottom of logs explorer to have better readability of logs despite of the toolbar

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/4882

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/cd9437a6-3b2d-4d81-947c-de1a7e208c30



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
