### PR TITLE
fix: do not expose ClickHouse/Zookeeper ports by default

### DIFF
--- a/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
@@ -46,10 +46,10 @@ services:
     image: bitnami/zookeeper:3.7.1
     hostname: zookeeper-1
     user: root
-    ports:
-      - "2181:2181"
-      - "2888:2888"
-      - "3888:3888"
+    # ports:
+    #   - "2181:2181"
+    #   - "2888:2888"
+    #   - "3888:3888"
     volumes:
       - ./data/zookeeper-1:/bitnami/zookeeper
     environment:

--- a/deploy/docker/clickhouse-setup/docker-compose-core.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose-core.yaml
@@ -6,10 +6,10 @@ services:
     container_name: signoz-zookeeper-1
     hostname: zookeeper-1
     user: root
-    ports:
-      - "2181:2181"
-      - "2888:2888"
-      - "3888:3888"
+    # ports:
+    #   - "2181:2181"
+    #   - "2888:2888"
+    #   - "3888:3888"
     volumes:
       - ./data/zookeeper-1:/bitnami/zookeeper
     environment:

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -50,10 +50,10 @@ services:
     container_name: signoz-zookeeper-1
     hostname: zookeeper-1
     user: root
-    ports:
-      - "2181:2181"
-      - "2888:2888"
-      - "3888:3888"
+    # ports:
+    #   - "2181:2181"
+    #   - "2888:2888"
+    #   - "3888:3888"
     volumes:
       - ./data/zookeeper-1:/bitnami/zookeeper
     environment:
@@ -100,10 +100,10 @@ services:
     <<: *clickhouse-defaults
     container_name: signoz-clickhouse
     hostname: clickhouse
-    ports:
-      - "9000:9000"
-      - "8123:8123"
-      - "9181:9181"
+    # ports:
+    #   - "9000:9000"
+    #   - "8123:8123"
+    #   - "9181:9181"
     volumes:
       - ./clickhouse-config.xml:/etc/clickhouse-server/config.xml
       - ./clickhouse-users.xml:/etc/clickhouse-server/users.xml

--- a/pkg/query-service/tests/test-deploy/docker-compose.yaml
+++ b/pkg/query-service/tests/test-deploy/docker-compose.yaml
@@ -47,10 +47,10 @@ services:
     image: bitnami/zookeeper:3.7.1
     container_name: signoz-zookeeper-1
     user: root
-    ports:
-      - "2181:2181"
-      - "2888:2888"
-      - "3888:3888"
+    # ports:
+    #   - "2181:2181"
+    #   - "2888:2888"
+    #   - "3888:3888"
     volumes:
       - ./data/zookeeper-1:/bitnami/zookeeper
     environment:


### PR DESCRIPTION
### Summary

By default, ports of ClickHouse and Zookeeper need not be default in Docker Standalone or Docker Swarm installation.
Users can choose to expose it if they need.
