### PR TITLE
fix: remove series with no points

### DIFF
--- a/pkg/query-service/postprocess/having.go
+++ b/pkg/query-service/postprocess/having.go
@@ -23,6 +23,10 @@ func applyHavingClause(result []*v3.Result, queryRangeParams *v3.QueryRangeParam
 						j--
 					}
 				}
+				if len(result.Series[i].Points) == 0 {
+					result.Series = append(result.Series[:i], result.Series[i+1:]...)
+					i--
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Summary

If the having step removes all the points, we should not return labels with empty points. 