### PR TITLE
fix: page breaking when all queries are hidden

### DIFF
--- a/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/WidgetGraphContainer.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/WidgetGraphContainer.tsx
@@ -50,7 +50,7 @@ function WidgetGraphContainer({
 	}
 	if (
 		selectedGraph === PANEL_TYPES.LIST &&
-		queryResponse.data?.payload.data.newResult.data.result.length === 0
+		queryResponse.data?.payload.data.newResult?.data?.result?.length === 0
 	) {
 		return (
 			<NotFoundContainer>

--- a/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/WidgetGraphContainer.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/WidgetGraphContainer.tsx
@@ -40,7 +40,7 @@ function WidgetGraphContainer({
 
 	if (
 		selectedGraph !== PANEL_TYPES.LIST &&
-		queryResponse.data?.payload.data.result.length === 0
+		queryResponse.data?.payload.data?.result?.length === 0
 	) {
 		return (
 			<NotFoundContainer>


### PR DESCRIPTION
### Summary

- fix the page break when all the queries are hidden as the result in the query range API call is `null`

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/fcba27c0-9998-419c-a763-4dc7208dcf6d



#### Affected Areas and Manually Tested Areas

- verified places where the result null check should have been present 
