### PR TITLE
fix: clone dashboard panel intermittent issue

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.tsx
@@ -160,7 +160,11 @@ function WidgetGraphComponent({
 				},
 			},
 			{
-				onSuccess: () => {
+				onSuccess: (updatedDashboard) => {
+					if (setLayouts) setLayouts(updatedDashboard.payload?.data?.layout || []);
+					if (setSelectedDashboard && updatedDashboard.payload) {
+						setSelectedDashboard(updatedDashboard.payload);
+					}
 					notifications.success({
 						message: 'Panel cloned successfully, redirecting to new copy.',
 					});


### PR DESCRIPTION
### Summary

- `onCloneDashboardHandler` did not update the local state after the `PUT` call hence the editor page didn't receive the data and hence displayed the base state. 
- added state updates on success of the PUT call 
- this was occurring intermittently as there happens a get call in the widget editor which is succeeds before state setting it worked as expected. 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/7b7aad9f-3cde-41ef-8809-8871ea2e9c54



#### Affected Areas and Manually Tested Areas

- clone dashboard handlers 
