### PR TITLE
fix: random sizing issue with alerts query builder

### DIFF
--- a/frontend/src/container/PlannedDowntime/DropdownWithSubMenu/DropdownWithSubMenu.styles.scss
+++ b/frontend/src/container/PlannedDowntime/DropdownWithSubMenu/DropdownWithSubMenu.styles.scss
@@ -1,15 +1,15 @@
 .options {
 	width: 100%;
-}
 
-.option {
-	padding: 8px 10px;
-	cursor: pointer;
-	overflow: auto;
-}
+	.option {
+		padding: 8px 10px;
+		cursor: pointer;
+		overflow: auto;
+	}
 
-.option:hover {
-	background-color: var(--bg-slate-200);
+	.option:hover {
+		background-color: var(--bg-slate-200);
+	}
 }
 
 .submenu-container {
@@ -79,6 +79,15 @@
 .submenu-popover {
 	.ant-popover-inner {
 		padding: 0px;
+	}
+	.option {
+		padding: 8px 10px;
+		cursor: pointer;
+		overflow: auto;
+	}
+
+	.option:hover {
+		background-color: var(--bg-slate-200);
 	}
 }
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -247,28 +247,6 @@ body {
 	padding-right: 20px;
 }
 
-.ant-drawer {
-	// do not modify this as this is required to hide intercom in modals
-	z-index: 1000000000000;
-}
-
-.ant-modal-root {
-	.ant-modal-mask {
-		z-index: 2000000000000 !important;
-	}
-	.ant-modal-wrap {
-		z-index: 2000000000000 !important;
-	}
-}
-
-.ant-select-dropdown {
-	z-index: 3000000000000 !important;
-}
-
-.ant-picker-dropdown {
-	z-index: 3000000000000 !important;
-}
-
-.ant-popover {
-	z-index: 3000000000000 !important;
+.intercom-lightweight-app {
+	z-index: 980 !important;
 }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -247,6 +247,22 @@ body {
 	padding-right: 20px;
 }
 
+// we want the z-index to be less than 1000 (z-index for antd drawers) as we do not want intercom to interfare when drawers are open
 .intercom-lightweight-app {
 	z-index: 980 !important;
 }
+
+/**
+
+z-index chart for components across application
+
+intercom        -  980
+tooltip			-  1070
+popover 		-  1030
+drawer  		-  1000
+time picker 	-  1050
+dropdown 		-  1050
+modal 			-  1000
+toast			-  2050
+
+*/

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -264,3 +264,11 @@ body {
 .ant-select-dropdown {
 	z-index: 3000000000000 !important;
 }
+
+.ant-picker-dropdown {
+	z-index: 3000000000000 !important;
+}
+
+.ant-popover {
+	z-index: 3000000000000 !important;
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -263,6 +263,6 @@ drawer  		-  1000
 time picker 	-  1050
 dropdown 		-  1050
 modal 			-  1000
-toast			-  2050
+notifications	-  2050
 
 */


### PR DESCRIPTION
### Summary

- global styles getting overriden for `options` class 
- make ant-picker component and popover to be displayed in modals and drawers. ( z-index )

#### Related Issues / PR's

fixes https://github.com/SigNoz/engineering-pod/issues/1322

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
