### PR TITLE
fix: page jumping for alerts

### DIFF
--- a/frontend/src/container/FormAlertRules/ChartPreview/index.tsx
+++ b/frontend/src/container/FormAlertRules/ChartPreview/index.tsx
@@ -252,11 +252,11 @@ function ChartPreview({
 					{queryResponse.error.message || t('preview_chart_unexpected_error')}
 				</FailedMessageContainer>
 			)}
-			{queryResponse.isLoading && (
-				<Spinner size="large" tip="Loading..." height="70vh" />
-			)}
 			{chartData && !queryResponse.isError && (
 				<div ref={graphRef} style={{ height: '100%' }}>
+					{queryResponse.isLoading && (
+						<Spinner size="large" tip="Loading..." height="100%" />
+					)}
 					<GridPanelSwitch
 						options={options}
 						panelType={graphType}


### PR DESCRIPTION
### Summary

- the page randomly jumps around when the stage and run is clicked
- this happens because the loader was being rendered and it occupied a fix height of `70vh` and got removed as soon as data comes thus shifting up and down by `70vh` 
- rendered the loader inside the data component so either of the two renders hence no jumping 

#### Related Issues / PR's

fixes https://github.com/SigNoz/engineering-pod/issues/1318

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/0e39b075-c6bd-45d2-8059-9bc526b7a24f



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
