### PR TITLE
fix: dashboard variables should properly load for imported dashboards

### DIFF
--- a/frontend/src/container/NewDashboard/DashboardVariablesSelection/VariableItem.tsx
+++ b/frontend/src/container/NewDashboard/DashboardVariablesSelection/VariableItem.tsx
@@ -7,7 +7,7 @@ import dashboardVariablesQuery from 'api/dashboard/variables/dashboardVariablesQ
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { commaValuesParser } from 'lib/dashbaordVariables/customCommaValuesParser';
 import sortValues from 'lib/dashbaordVariables/sortVariableValues';
-import { debounce } from 'lodash-es';
+import { debounce, isArray, isString } from 'lodash-es';
 import map from 'lodash-es/map';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
@@ -108,10 +108,28 @@ function VariableItem({
 
 					if (!areArraysEqual(newOptionsData, oldOptionsData)) {
 						/* eslint-disable no-useless-escape */
+
+						let valueNotInList = false;
+
+						if (isArray(variableData.selectedValue)) {
+							variableData.selectedValue.forEach((val) => {
+								const isUsed = newOptionsData.includes(val);
+
+								if (!isUsed) {
+									valueNotInList = true;
+								}
+							});
+						} else if (isString(variableData.selectedValue)) {
+							const isUsed = newOptionsData.includes(variableData.selectedValue);
+
+							if (!isUsed) {
+								valueNotInList = true;
+							}
+						}
 						if (
 							variableData.type === 'QUERY' &&
 							variableData.name &&
-							variablesToGetUpdated.includes(variableData.name)
+							(variablesToGetUpdated.includes(variableData.name) || valueNotInList)
 						) {
 							let value = variableData.selectedValue;
 							let allSelected = false;


### PR DESCRIPTION
### Summary

- imported dashboards variables not working and showing empty data
- now since we moved to sequential approach we check for `variablesToBeUpdated` queue and the variable should be present in the queue to get updated. 
- now even if we add the variables on the first load of dashboard it won't work as it will update all the existing values nested structure as well. 
- so we only update if either present in queue or the `selectedValue` is not something that came in the new options.  

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/5121

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/a3221564-1951-40c3-a0f6-77c24058648b



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
