### PR TITLE
fix: use text/template for ClickHouse query templating

### DIFF
--- a/pkg/query-service/rules/thresholdRule.go
+++ b/pkg/query-service/rules/thresholdRule.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"math"
 	"net/url"
 	"regexp"
 	"sort"
 	"sync"
+	"text/template"
 	"time"
 	"unicode"
 


### PR DESCRIPTION
### Summary

The import should be `text/template` instead of `html/template`