### PR TITLE
fix: alerts builder light theme plot tag issue

### DIFF
--- a/frontend/src/container/FormAlertRules/FormAlertRules.styles.scss
+++ b/frontend/src/container/FormAlertRules/FormAlertRules.styles.scss
@@ -22,6 +22,11 @@
 }
 
 .lightMode {
+	.main-container {
+		.plot-tag {
+			background: var(--bg-vanilla-300);
+		}
+	}
 	.ant-modal-content {
 		background-color: var(--bg-vanilla-100);
 		.ant-modal-confirm-title {

--- a/frontend/src/container/FormAlertRules/index.tsx
+++ b/frontend/src/container/FormAlertRules/index.tsx
@@ -512,6 +512,7 @@ function FormAlertRules({
 						initialValues={initialValue}
 						layout="vertical"
 						form={formInstance}
+						className="main-container"
 					>
 						{currentQuery.queryType === EQueryType.QUERY_BUILDER &&
 							renderQBChartPreview()}

--- a/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
+++ b/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
@@ -51,9 +51,7 @@ const generateTooltipContent = (
 	}
 
 	if (Array.isArray(series) && series.length > 0) {
-		console.log(series);
 		series.forEach((item, index) => {
-			console.log(item, index);
 			if (index === 0) {
 				if (isBillingUsageGraphs) {
 					tooltipTitle = dayjs(data[0][idx] * 1000).format('MMM DD YYYY');


### PR DESCRIPTION
### Summary

- fix the plot tag light mode background issue

#### Related Issues / PR's



#### Screenshots

![image](https://github.com/SigNoz/signoz/assets/54737045/2e8fc2fe-e82a-49f4-8d7c-fc7c2f4de893)


#### Affected Areas and Manually Tested Areas

- light mode and dark mode issue for alerts plot tag