### PR TITLE
feat: added option to download billing usage data as csv

### DIFF
--- a/frontend/src/container/BillingContainer/BillingContainer.tsx
+++ b/frontend/src/container/BillingContainer/BillingContainer.tsx
@@ -28,7 +28,7 @@ import useLicense from 'hooks/useLicense';
 import { useNotifications } from 'hooks/useNotifications';
 import { isEmpty, pick } from 'lodash-es';
 import { unparse } from 'papaparse';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMutation, useQuery } from 'react-query';
 import { useSelector } from 'react-redux';
@@ -136,7 +136,7 @@ export default function BillingContainer(): JSX.Element {
 	const [daysRemaining, setDaysRemaining] = useState(0);
 	const [isFreeTrial, setIsFreeTrial] = useState(false);
 	const [data, setData] = useState<any[]>([]);
-	const [csvData, setCsvData] = useState<any[]>([]);
+	const csvData = useRef<QuantityData[]>([]);
 	const [apiResponse, setApiResponse] = useState<
 		Partial<UsageResponsePayloadProps>
 	>({});
@@ -351,17 +351,13 @@ export default function BillingContainer(): JSX.Element {
 		updateCreditCard,
 	]);
 
-	const getCsvData = (quantityData: QuantityData[]): void => {
-		setCsvData(generateCsvData(quantityData));
-	};
-
 	const BillingUsageGraphCallback = useCallback(
 		() =>
 			!isLoading && !isFetchingBillingData ? (
 				<BillingUsageGraph
 					data={apiResponse}
 					billAmount={billAmount}
-					getCsvData={getCsvData}
+					csvData={csvData}
 				/>
 			) : (
 				<Card className="empty-graph-card" bordered={false}>
@@ -385,7 +381,7 @@ export default function BillingContainer(): JSX.Element {
 	);
 
 	const handleCsvDownload = useCallback((): void => {
-		const csv = unparse(csvData);
+		const csv = unparse(generateCsvData(csvData.current));
 		const csvBlob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
 		const csvUrl = URL.createObjectURL(csvBlob);
 		const downloadLink = document.createElement('a');

--- a/frontend/src/container/BillingContainer/BillingContainer.tsx
+++ b/frontend/src/container/BillingContainer/BillingContainer.tsx
@@ -392,6 +392,9 @@ export default function BillingContainer(): JSX.Element {
 			// Clean up
 			downloadLink.remove();
 			URL.revokeObjectURL(csvUrl); // Release the memory associated with the object URL
+			notifications.success({
+				message: 'Download successful',
+			});
 		} catch (error) {
 			console.error('Error downloading the CSV file:', error);
 			notifications.error({

--- a/frontend/src/container/BillingContainer/BillingUsageGraph/BillingUsageGraph.tsx
+++ b/frontend/src/container/BillingContainer/BillingUsageGraph/BillingUsageGraph.tsx
@@ -12,17 +12,20 @@ import getRenderer from 'lib/uPlotLib/utils/getRenderer';
 import { getUPlotChartData } from 'lib/uPlotLib/utils/getUplotChartData';
 import { getXAxisScale } from 'lib/uPlotLib/utils/getXAxisScale';
 import { getYAxisScale } from 'lib/uPlotLib/utils/getYAxisScale';
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import uPlot from 'uplot';
 
+import { QuantityData } from './generateCsvData';
 import {
 	convertDataToMetricRangePayload,
 	fillMissingValuesForQuantities,
+	quantityDataArr,
 } from './utils';
 
 interface BillingUsageGraphProps {
 	data: any;
 	billAmount: number;
+	getCsvData: (quantityData: QuantityData[]) => void;
 }
 const paths = (
 	u: any,
@@ -57,7 +60,7 @@ const calculateStartEndTime = (
 };
 
 export function BillingUsageGraph(props: BillingUsageGraphProps): JSX.Element {
-	const { data, billAmount } = props;
+	const { data, billAmount, getCsvData } = props;
 	const graphCompatibleData = useMemo(
 		() => convertDataToMetricRangePayload(data),
 		[data],
@@ -70,6 +73,16 @@ export function BillingUsageGraph(props: BillingUsageGraphProps): JSX.Element {
 	const { startTime, endTime } = useMemo(() => calculateStartEndTime(data), [
 		data,
 	]);
+
+	const quantityMapArr = useMemo(
+		() => quantityDataArr(graphCompatibleData, chartData[0]),
+		[chartData, graphCompatibleData],
+	);
+
+	useEffect(() => {
+		getCsvData(quantityMapArr);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	const getGraphSeries = (color: string, label: string): any => ({
 		drawStyle: 'bars',

--- a/frontend/src/container/BillingContainer/BillingUsageGraph/BillingUsageGraph.tsx
+++ b/frontend/src/container/BillingContainer/BillingUsageGraph/BillingUsageGraph.tsx
@@ -12,20 +12,17 @@ import getRenderer from 'lib/uPlotLib/utils/getRenderer';
 import { getUPlotChartData } from 'lib/uPlotLib/utils/getUplotChartData';
 import { getXAxisScale } from 'lib/uPlotLib/utils/getXAxisScale';
 import { getYAxisScale } from 'lib/uPlotLib/utils/getYAxisScale';
-import { MutableRefObject, useEffect, useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import uPlot from 'uplot';
 
-import { QuantityData } from './generateCsvData';
 import {
 	convertDataToMetricRangePayload,
 	fillMissingValuesForQuantities,
-	quantityDataArr,
 } from './utils';
 
 interface BillingUsageGraphProps {
 	data: any;
 	billAmount: number;
-	csvData: MutableRefObject<QuantityData[]>;
 }
 const paths = (
 	u: any,
@@ -60,7 +57,7 @@ const calculateStartEndTime = (
 };
 
 export function BillingUsageGraph(props: BillingUsageGraphProps): JSX.Element {
-	const { data, billAmount, csvData } = props;
+	const { data, billAmount } = props;
 	const graphCompatibleData = useMemo(
 		() => convertDataToMetricRangePayload(data),
 		[data],
@@ -73,16 +70,6 @@ export function BillingUsageGraph(props: BillingUsageGraphProps): JSX.Element {
 	const { startTime, endTime } = useMemo(() => calculateStartEndTime(data), [
 		data,
 	]);
-
-	const quantityMapArr = useMemo(
-		() => quantityDataArr(graphCompatibleData, chartData[0]),
-		[chartData, graphCompatibleData],
-	);
-
-	useEffect(() => {
-		csvData.current = quantityMapArr;
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
 
 	const getGraphSeries = (color: string, label: string): any => ({
 		drawStyle: 'bars',

--- a/frontend/src/container/BillingContainer/BillingUsageGraph/BillingUsageGraph.tsx
+++ b/frontend/src/container/BillingContainer/BillingUsageGraph/BillingUsageGraph.tsx
@@ -12,7 +12,7 @@ import getRenderer from 'lib/uPlotLib/utils/getRenderer';
 import { getUPlotChartData } from 'lib/uPlotLib/utils/getUplotChartData';
 import { getXAxisScale } from 'lib/uPlotLib/utils/getXAxisScale';
 import { getYAxisScale } from 'lib/uPlotLib/utils/getYAxisScale';
-import { useEffect, useMemo, useRef } from 'react';
+import { MutableRefObject, useEffect, useMemo, useRef } from 'react';
 import uPlot from 'uplot';
 
 import { QuantityData } from './generateCsvData';
@@ -25,7 +25,7 @@ import {
 interface BillingUsageGraphProps {
 	data: any;
 	billAmount: number;
-	getCsvData: (quantityData: QuantityData[]) => void;
+	csvData: MutableRefObject<QuantityData[]>;
 }
 const paths = (
 	u: any,
@@ -60,7 +60,7 @@ const calculateStartEndTime = (
 };
 
 export function BillingUsageGraph(props: BillingUsageGraphProps): JSX.Element {
-	const { data, billAmount, getCsvData } = props;
+	const { data, billAmount, csvData } = props;
 	const graphCompatibleData = useMemo(
 		() => convertDataToMetricRangePayload(data),
 		[data],
@@ -80,7 +80,7 @@ export function BillingUsageGraph(props: BillingUsageGraphProps): JSX.Element {
 	);
 
 	useEffect(() => {
-		getCsvData(quantityMapArr);
+		csvData.current = quantityMapArr;
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 

--- a/frontend/src/container/BillingContainer/BillingUsageGraph/generateCsvData.ts
+++ b/frontend/src/container/BillingContainer/BillingUsageGraph/generateCsvData.ts
@@ -25,6 +25,16 @@ interface DataPoint {
 	};
 }
 
+interface CsvData {
+	Date: string;
+	'Metrics Vol (Mn samples)': number;
+	'Metrics Cost ($)': number;
+	'Traces Vol (GBs)': number;
+	'Traces Cost ($)': number;
+	'Logs Vol (GBs)': number;
+	'Logs Cost ($)': number;
+}
+
 const formatDate = (timestamp: number): string =>
 	dayjs.unix(timestamp).format('MM/DD/YYYY');
 
@@ -92,25 +102,25 @@ const generateCsvData = (quantityData: QuantityData[]): any[] => {
 		},
 	);
 
-	const csvData = formattedData.map((dataPoint) => ({
+	const csvData: CsvData[] = formattedData.map((dataPoint) => ({
 		Date: dataPoint.date,
-		'Metrics Vol (Mn samples)': dataPoint.metric.total,
-		'Metrics Cost ($)': dataPoint.metric.cost,
-		'Traces Vol (GBs)': dataPoint.trace.total,
-		'Traces Cost ($)': dataPoint.trace.cost,
-		'Logs Vol (GBs)': dataPoint.log.total,
-		'Logs Cost ($)': dataPoint.log.cost,
+		'Metrics Vol (Mn samples)': parseFloat(dataPoint.metric.total.toFixed(2)),
+		'Metrics Cost ($)': parseFloat(dataPoint.metric.cost.toFixed(2)),
+		'Traces Vol (GBs)': parseFloat(dataPoint.trace.total.toFixed(2)),
+		'Traces Cost ($)': parseFloat(dataPoint.trace.cost.toFixed(2)),
+		'Logs Vol (GBs)': parseFloat(dataPoint.log.total.toFixed(2)),
+		'Logs Cost ($)': parseFloat(dataPoint.log.cost.toFixed(2)),
 	}));
 
 	// Add totals row
 	csvData.push({
 		Date: 'Total',
-		'Metrics Vol (Mn samples)': totals.metric.total,
-		'Metrics Cost ($)': totals.metric.cost,
-		'Traces Vol (GBs)': totals.trace.total,
-		'Traces Cost ($)': totals.trace.cost,
-		'Logs Vol (GBs)': totals.log.total,
-		'Logs Cost ($)': totals.log.cost,
+		'Metrics Vol (Mn samples)': parseFloat(totals.metric.total.toFixed(2)),
+		'Metrics Cost ($)': parseFloat(totals.metric.cost.toFixed(2)),
+		'Traces Vol (GBs)': parseFloat(totals.trace.total.toFixed(2)),
+		'Traces Cost ($)': parseFloat(totals.trace.cost.toFixed(2)),
+		'Logs Vol (GBs)': parseFloat(totals.log.total.toFixed(2)),
+		'Logs Cost ($)': parseFloat(totals.log.cost.toFixed(2)),
 	});
 
 	return csvData;

--- a/frontend/src/container/BillingContainer/BillingUsageGraph/generateCsvData.ts
+++ b/frontend/src/container/BillingContainer/BillingUsageGraph/generateCsvData.ts
@@ -1,0 +1,119 @@
+import dayjs from 'dayjs';
+
+export interface QuantityData {
+	metric: string;
+	values: [number, number][];
+	queryName: string;
+	legend: string;
+	quantity: number[];
+	unit: string;
+}
+
+interface DataPoint {
+	date: string;
+	metric: {
+		total: number;
+		cost: number;
+	};
+	trace: {
+		total: number;
+		cost: number;
+	};
+	log: {
+		total: number;
+		cost: number;
+	};
+}
+
+const formatDate = (timestamp: number): string =>
+	dayjs.unix(timestamp).format('MM/DD/YYYY');
+
+const getQuantityData = (
+	data: QuantityData[],
+	metricName: string,
+): QuantityData => {
+	const defaultData: QuantityData = {
+		metric: metricName,
+		values: [],
+		queryName: metricName,
+		legend: metricName,
+		quantity: [],
+		unit: '',
+	};
+	return data.find((d) => d.metric === metricName) || defaultData;
+};
+
+const generateCsvData = (quantityData: QuantityData[]): any[] => {
+	const convertData = (data: QuantityData[]): DataPoint[] => {
+		const metricsData = getQuantityData(data, 'Metrics');
+		const tracesData = getQuantityData(data, 'Traces');
+		const logsData = getQuantityData(data, 'Logs');
+
+		const timestamps = metricsData.values.map((value) => value[0]);
+
+		return timestamps.map((timestamp, index) => {
+			const date = formatDate(timestamp);
+
+			return {
+				date,
+				metric: {
+					total: metricsData.quantity[index] ?? 0,
+					cost: metricsData.values[index]?.[1] ?? 0,
+				},
+				trace: {
+					total: tracesData.quantity[index] ?? 0,
+					cost: tracesData.values[index]?.[1] ?? 0,
+				},
+				log: {
+					total: logsData.quantity[index] ?? 0,
+					cost: logsData.values[index]?.[1] ?? 0,
+				},
+			};
+		});
+	};
+
+	const formattedData = convertData(quantityData);
+
+	// Calculate totals
+	const totals = formattedData.reduce(
+		(acc, dataPoint) => {
+			acc.metric.total += dataPoint.metric.total;
+			acc.metric.cost += dataPoint.metric.cost;
+			acc.trace.total += dataPoint.trace.total;
+			acc.trace.cost += dataPoint.trace.cost;
+			acc.log.total += dataPoint.log.total;
+			acc.log.cost += dataPoint.log.cost;
+			return acc;
+		},
+		{
+			metric: { total: 0, cost: 0 },
+			trace: { total: 0, cost: 0 },
+			log: { total: 0, cost: 0 },
+		},
+	);
+
+	const csvData = formattedData.map((dataPoint) => ({
+		Date: dataPoint.date,
+		'Metrics Vol (Mn samples)': dataPoint.metric.total,
+		'Metrics Cost ($)': dataPoint.metric.cost,
+		'Traces Vol (GBs)': dataPoint.trace.total,
+		'Traces Cost ($)': dataPoint.trace.cost,
+		'Logs Vol (GBs)': dataPoint.log.total,
+		'Logs Cost ($)': dataPoint.log.cost,
+	}));
+
+	// Add totals row
+	csvData.push({
+		Date: 'Total',
+		'Metrics Vol (Mn samples)': totals.metric.total,
+		'Metrics Cost ($)': totals.metric.cost,
+		'Traces Vol (GBs)': totals.trace.total,
+		'Traces Cost ($)': totals.trace.cost,
+		'Logs Vol (GBs)': totals.log.total,
+		'Logs Cost ($)': totals.log.cost,
+	});
+
+	return csvData;
+};
+
+export default generateCsvData;

--- a/frontend/src/container/BillingContainer/BillingUsageGraph/utils.ts
+++ b/frontend/src/container/BillingContainer/BillingUsageGraph/utils.ts
@@ -58,10 +58,7 @@ export const convertDataToMetricRangePayload = (
 	};
 };
 
-export function fillMissingValuesForQuantities(
-	data: any,
-	timestampArray: number[],
-): MetricRangePayloadProps {
+export function quantityDataArr(data: any, timestampArray: number[]): any[] {
 	const { result } = data.data;
 
 	const transformedResultArr: any[] = [];
@@ -76,6 +73,14 @@ export function fillMissingValuesForQuantities(
 		);
 		transformedResultArr.push({ ...item, quantity: quantityArray });
 	});
+	return transformedResultArr;
+}
+
+export function fillMissingValuesForQuantities(
+	data: any,
+	timestampArray: number[],
+): MetricRangePayloadProps {
+	const transformedResultArr = quantityDataArr(data, timestampArray);
 
 	return {
 		data: {

--- a/frontend/src/container/BillingContainer/BillingUsageGraph/utils.ts
+++ b/frontend/src/container/BillingContainer/BillingUsageGraph/utils.ts
@@ -1,5 +1,11 @@
+import { UsageResponsePayloadProps } from 'api/billing/getUsage';
+import dayjs from 'dayjs';
+import { getUPlotChartData } from 'lib/uPlotLib/utils/getUplotChartData';
 import { isEmpty, isNull } from 'lodash-es';
+import { unparse } from 'papaparse';
 import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+
+import generateCsvData, { QuantityData } from './generateCsvData';
 
 export const convertDataToMetricRangePayload = (
 	data: any,
@@ -88,5 +94,38 @@ export function fillMissingValuesForQuantities(
 			result: transformedResultArr,
 			resultType: '',
 		},
+	};
+}
+
+const formatDate = (timestamp: number): string =>
+	dayjs.unix(timestamp).format('MM/DD/YYYY');
+
+export function csvFileName(csvData: QuantityData[]): string {
+	if (!csvData.length) {
+		return `billing-usage.csv`;
+	}
+
+	const { values } = csvData[0];
+
+	const timestamps = values.map((item) => item[0]);
+	const startDate = formatDate(Math.min(...timestamps));
+	const endDate = formatDate(Math.max(...timestamps));
+
+	return `billing_usage_(${startDate}-${endDate}).csv`;
+}
+
+export function prepareCsvData(
+	data: Partial<UsageResponsePayloadProps>,
+): {
+	csvData: string;
+	fileName: string;
+} {
+	const graphCompatibleData = convertDataToMetricRangePayload(data);
+	const chartData = getUPlotChartData(graphCompatibleData);
+	const quantityMapArr = quantityDataArr(graphCompatibleData, chartData[0]);
+
+	return {
+		csvData: unparse(generateCsvData(quantityMapArr)),
+		fileName: csvFileName(quantityMapArr),
 	};
 }


### PR DESCRIPTION
### Summary


Issue: https://github.com/SigNoz/engineering-pod/issues/1325

Fix:  Added option to download billing usage data as csv

#### Related Issues / PR's

https://github.com/SigNoz/engineering-pod/issues/1325

#### Screenshots

Feature:
---------

https://github.com/SigNoz/signoz/assets/162284829/7fcfe3fe-1d6b-44b8-bb22-da027662cecc

<img width="1727" alt="image" src="https://github.com/SigNoz/signoz/assets/162284829/deac0831-220d-4ba0-8443-528db8e27306">

---------

CSV:
----------


<img width="835" alt="image" src="https://github.com/SigNoz/signoz/assets/162284829/5718dd38-76b3-4987-8436-8a61a6472c29">




#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
