### PR TITLE
fix: clone panel randomly jumping around in the middle causing layout issues

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.tsx
@@ -131,15 +131,22 @@ function WidgetGraphComponent({
 
 		const uuid = v4();
 
+		// this is added to make sure the cloned panel is of the same dimensions as the original one
+		const originalPanelLayout = selectedDashboard.data.layout?.find(
+			(l) => l.i === widget.id,
+		);
+
+		// added the cloned panel on the top as it is given most priority when arranging
+		// in the layout. React_grid_layout assigns priority from top, hence no random position for cloned panel
 		const layout = [
-			...(selectedDashboard.data.layout || []),
 			{
 				i: uuid,
-				w: 6,
+				w: originalPanelLayout?.w || 6,
 				x: 0,
-				h: 6,
+				h: originalPanelLayout?.h || 6,
 				y: 0,
 			},
+			...(selectedDashboard.data.layout || []),
 		];
 
 		updateDashboardMutation.mutateAsync(


### PR DESCRIPTION
### Summary

- first issue :- the cloned panel was added in the bottom of the layout which caused the least priority in render. hence it was being randomly placed across the screen. `react-grid-layout` starts layouting from top

- second enhancement added here being that the cloned panel should have similar dimensions to the original panel from which it is cloned.

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/79db3591-2cc5-49dd-9e43-2aa9fe56db8e



#### Affected Areas and Manually Tested Areas

- cloned panels without rows
- cloned panel with rows 
- multiple layout positions.
