### PR TITLE
fix: clickhouse and promQL queries table column headers not handled

### DIFF
--- a/frontend/src/container/NewWidget/RightContainer/ColumnUnitSelector/ColumnUnitSelector.tsx
+++ b/frontend/src/container/NewWidget/RightContainer/ColumnUnitSelector/ColumnUnitSelector.tsx
@@ -4,6 +4,7 @@ import { Typography } from 'antd';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { Dispatch, SetStateAction } from 'react';
 import { ColumnUnit } from 'types/api/dashboard/getAll';
+import { EQueryType } from 'types/common/dashboard';
 
 import YAxisUnitSelector from '../YAxisUnitSelector';
 
@@ -18,7 +19,13 @@ export function ColumnUnitSelector(
 	const { currentQuery } = useQueryBuilder();
 
 	function getAggregateColumnsNamesAndLabels(): string[] {
-		return currentQuery.builder.queryData.map((q) => q.queryName);
+		if (currentQuery.queryType === EQueryType.QUERY_BUILDER) {
+			return currentQuery.builder.queryData.map((q) => q.queryName);
+		}
+		if (currentQuery.queryType === EQueryType.CLICKHOUSE) {
+			return currentQuery.clickhouse_sql.map((q) => q.name);
+		}
+		return currentQuery.promql.map((q) => q.name);
 	}
 
 	const { columnUnits, setColumnUnits } = props;


### PR DESCRIPTION
### Summary

- the handling for adding the correct table columns based on legend or the operators was not present 
- fixes the column units respecting clickhouse and promQL queries as well 

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/5156

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/bdf932f6-5cb0-4b89-ad9f-dde3729f1322



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
