### PR TITLE
fix: unsaved changes popping up for newly created dashboard in settings

### DIFF
--- a/frontend/src/container/NewDashboard/DashboardSettings/General/index.tsx
+++ b/frontend/src/container/NewDashboard/DashboardSettings/General/index.tsx
@@ -71,24 +71,24 @@ function GeneralDashboardSettings(): JSX.Element {
 
 	useEffect(() => {
 		let numberOfUnsavedChanges = 0;
-		if (!isEqual(updatedTitle, selectedData?.title)) {
+		if (!isEqual(updatedTitle, title)) {
 			numberOfUnsavedChanges += 1;
 		}
-		if (!isEqual(updatedDescription, selectedData?.description)) {
+		if (!isEqual(updatedDescription, description)) {
 			numberOfUnsavedChanges += 1;
 		}
-		if (!isEqual(updatedTags, selectedData?.tags)) {
+		if (!isEqual(updatedTags, tags)) {
 			numberOfUnsavedChanges += 1;
 		}
-		if (!isEqual(updatedImage, selectedData?.image)) {
+		if (!isEqual(updatedImage, image)) {
 			numberOfUnsavedChanges += 1;
 		}
 		setNumberOfUnsavedChanges(numberOfUnsavedChanges);
 	}, [
-		selectedData?.description,
-		selectedData?.image,
-		selectedData?.tags,
-		selectedData?.title,
+		description,
+		image,
+		tags,
+		title,
 		updatedDescription,
 		updatedImage,
 		updatedTags,
@@ -168,6 +168,7 @@ function GeneralDashboardSettings(): JSX.Element {
 						<div className="unsaved-dot" />
 						<Typography.Text className="unsaved-changes">
 							{numberOfUnsavedChanges} Unsaved change
+							{numberOfUnsavedChanges > 1 && 's'}
 						</Typography.Text>
 					</div>
 					<div className="footer-action-btns">

--- a/frontend/src/container/NewDashboard/DashboardSettings/General/index.tsx
+++ b/frontend/src/container/NewDashboard/DashboardSettings/General/index.tsx
@@ -71,18 +71,18 @@ function GeneralDashboardSettings(): JSX.Element {
 
 	useEffect(() => {
 		let numberOfUnsavedChanges = 0;
-		if (!isEqual(updatedTitle, title)) {
-			numberOfUnsavedChanges += 1;
-		}
-		if (!isEqual(updatedDescription, description)) {
-			numberOfUnsavedChanges += 1;
-		}
-		if (!isEqual(updatedTags, tags)) {
-			numberOfUnsavedChanges += 1;
-		}
-		if (!isEqual(updatedImage, image)) {
-			numberOfUnsavedChanges += 1;
-		}
+		const initialValues = [title, description, tags, image];
+		const updatedValues = [
+			updatedTitle,
+			updatedDescription,
+			updatedTags,
+			updatedImage,
+		];
+		initialValues.forEach((val, index) => {
+			if (!isEqual(val, updatedValues[index])) {
+				numberOfUnsavedChanges += 1;
+			}
+		});
 		setNumberOfUnsavedChanges(numberOfUnsavedChanges);
 	}, [
 		description,
@@ -167,7 +167,7 @@ function GeneralDashboardSettings(): JSX.Element {
 					<div className="unsaved">
 						<div className="unsaved-dot" />
 						<Typography.Text className="unsaved-changes">
-							{numberOfUnsavedChanges} Unsaved change
+							{numberOfUnsavedChanges} unsaved change
 							{numberOfUnsavedChanges > 1 && 's'}
 						</Typography.Text>
 					</div>

--- a/frontend/src/container/NewWidget/styles.ts
+++ b/frontend/src/container/NewWidget/styles.ts
@@ -10,10 +10,9 @@ export const Container = styled.div`
 
 export const RightContainerWrapper = styled(Col)`
 	&&& {
-		min-width: 330px;
-		overflow-y: auto;
 		max-width: 400px;
 		width: 30%;
+		overflow-y: auto;
 	}
 	&::-webkit-scrollbar {
 		width: 0rem;
@@ -26,7 +25,7 @@ interface LeftContainerWrapperProps {
 
 export const LeftContainerWrapper = styled(Col)<LeftContainerWrapperProps>`
 	&&& {
-		min-width: 70%;
+		width: 100%;
 		overflow-y: auto;
 		border-right: ${({ isDarkMode }): string =>
 			isDarkMode


### PR DESCRIPTION
### Summary

- unsaved changes popping up in the side drawer for new dashboards ( the comparisons didn't take in account for default values )
- updated the text from `change` to `changes` in case of more than 1 change
- fixed the changing width of right and left container 

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/5180

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/a6e0c366-39ff-4d98-8ec1-d3e695fe3e1d


https://github.com/SigNoz/signoz/assets/54737045/baed1838-f918-4054-b327-cc2c0623d56a




#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
