### PR TITLE
chore: open clickhouse builder by default on creating new exception alert

### DIFF
--- a/frontend/src/container/CreateAlertRule/defaults.ts
+++ b/frontend/src/container/CreateAlertRule/defaults.ts
@@ -130,7 +130,7 @@ export const exceptionAlertDefaults: AlertDef = {
 					disabled: false,
 				},
 			},
-			queryType: EQueryType.QUERY_BUILDER,
+			queryType: EQueryType.CLICKHOUSE,
 			panelType: PANEL_TYPES.TIME_SERIES,
 			unit: undefined,
 		},


### PR DESCRIPTION

### Summary

open clickhouse builder by default on creating new exception based alert