### PR TITLE
fix: convert timestamp in new trace explorer to user browser timezone and readable format

### DIFF
--- a/frontend/src/container/TracesExplorer/ListView/utils.tsx
+++ b/frontend/src/container/TracesExplorer/ListView/utils.tsx
@@ -32,7 +32,6 @@ export const getListColumns = (
 			title: 'Timestamp',
 			width: 145,
 			render: (item): JSX.Element => {
-				console.log(item);
 				const date =
 					typeof item === 'string'
 						? dayjs(item).format('YYYY-MM-DD HH:mm:ss.SSS')

--- a/frontend/src/container/TracesExplorer/ListView/utils.tsx
+++ b/frontend/src/container/TracesExplorer/ListView/utils.tsx
@@ -3,6 +3,7 @@ import { ColumnsType } from 'antd/es/table';
 import ROUTES from 'constants/routes';
 import { getMs } from 'container/Trace/Filters/Panel/PanelBody/Duration/util';
 import { formUrlParams } from 'container/TraceDetail/utils';
+import dayjs from 'dayjs';
 import { RowData } from 'lib/query/createTableColumnsFromQuery';
 import { ILog } from 'types/api/logs/log';
 import { BaseAutocompleteData } from 'types/api/queryBuilder/queryAutocompleteResponse';
@@ -30,6 +31,14 @@ export const getListColumns = (
 			key: 'date',
 			title: 'Timestamp',
 			width: 145,
+			render: (item): JSX.Element => {
+				console.log(item);
+				const date =
+					typeof item === 'string'
+						? dayjs(item).format('YYYY-MM-DD HH:mm:ss.SSS')
+						: dayjs(item / 1e6).format('YYYY-MM-DD HH:mm:ss.SSS');
+				return <Typography.Text>{date}</Typography.Text>;
+			},
 		},
 	];
 


### PR DESCRIPTION
### Summary

Converted to `YYYY-MM-DD HH:mm:ss.SSS` format this is similar to what we have in logs

#### Related Issues / PR's

#5220 

#### Screenshots


<img width="1726" alt="image" src="https://github.com/SigNoz/signoz/assets/162284829/d278f600-f4d8-4556-97ea-dd36bc1ad6aa">



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
