### PR TITLE
fix: table row data doesn't align with the response 

### DIFF
--- a/frontend/src/lib/query/createTableColumnsFromQuery.ts
+++ b/frontend/src/lib/query/createTableColumnsFromQuery.ts
@@ -365,6 +365,7 @@ const fillRestAggregationData = (
 	queryTableData: QueryDataV3[],
 	seria: SeriesItem,
 	equalQueriesByLabels: string[],
+	isEqualQuery: boolean,
 ): void => {
 	const nextQueryData =
 		queryTableData.find((q) => q.queryName === column.field) || null;
@@ -374,13 +375,13 @@ const fillRestAggregationData = (
 		nextQueryData,
 	);
 
+	const isEqual = isEqualQueriesByLabel(equalQueriesByLabels, column.field);
 	if (targetSeria) {
-		const isEqual = isEqualQueriesByLabel(equalQueriesByLabels, column.field);
 		if (!isEqual) {
 			// This line is crucial. It ensures that no additional rows are added to the table for similar labels across all formulas here is how this check is applied: signoz/frontend/src/lib/query/createTableColumnsFromQuery.ts line number 370
 			equalQueriesByLabels.push(column.field);
 		}
-	} else {
+	} else if (!isEqualQuery) {
 		column.data.push('N/A');
 	}
 };
@@ -435,6 +436,7 @@ const fillDataFromSeries = (
 					queryTableData,
 					seria,
 					equalQueriesByLabels,
+					isEqualQuery,
 				);
 
 				return;
@@ -573,14 +575,20 @@ export const createTableColumnsFromQuery: CreateTableDataFromQuery = ({
 	// the reason we need this is because the filling of values in rows doesn't account for mismatch enteries
 	// in the response. Example : Series A -> [label1, label2] and Series B -> [label2,label1] this isn't accounted for
 	sortedQueryTableData.forEach((q) => {
+		q.series?.forEach((s) => {
+			s.labelsArray?.sort((a, b) =>
+				Object.keys(a)[0] < Object.keys(b)[0] ? -1 : 1,
+			);
+		});
 		q.series?.sort((a, b) => {
 			let labelA = '';
 			let labelB = '';
-			Object.values(a?.labels).forEach((val) => {
-				labelA += val;
+			a.labelsArray.forEach((lab) => {
+				labelA += Object.values(lab)[0];
 			});
-			Object.values(b?.labels).forEach((val) => {
-				labelB += val;
+
+			b.labelsArray.forEach((lab) => {
+				labelB += Object.values(lab)[0];
 			});
 
 			return labelA < labelB ? -1 : 1;
@@ -589,6 +597,7 @@ export const createTableColumnsFromQuery: CreateTableDataFromQuery = ({
 
 	const dynamicColumns = getDynamicColumns(sortedQueryTableData, query);
 
+	console.log(dynamicColumns);
 	const { filledDynamicColumns, rowsLength } = fillColumnsData(
 		sortedQueryTableData,
 		dynamicColumns,

--- a/frontend/src/lib/query/createTableColumnsFromQuery.ts
+++ b/frontend/src/lib/query/createTableColumnsFromQuery.ts
@@ -597,7 +597,6 @@ export const createTableColumnsFromQuery: CreateTableDataFromQuery = ({
 
 	const dynamicColumns = getDynamicColumns(sortedQueryTableData, query);
 
-	console.log(dynamicColumns);
 	const { filledDynamicColumns, rowsLength } = fillColumnsData(
 		sortedQueryTableData,
 		dynamicColumns,

--- a/frontend/src/lib/query/createTableColumnsFromQuery.ts
+++ b/frontend/src/lib/query/createTableColumnsFromQuery.ts
@@ -570,6 +570,23 @@ export const createTableColumnsFromQuery: CreateTableDataFromQuery = ({
 		a.queryName < b.queryName ? -1 : 1,
 	);
 
+	// the reason we need this is because the filling of values in rows doesn't account for mismatch enteries
+	// in the response. Example : Series A -> [label1, label2] and Series B -> [label2,label1] this isn't accounted for
+	sortedQueryTableData.forEach((q) => {
+		q.series?.sort((a, b) => {
+			let labelA = '';
+			let labelB = '';
+			Object.values(a?.labels).forEach((val) => {
+				labelA += val;
+			});
+			Object.values(b?.labels).forEach((val) => {
+				labelB += val;
+			});
+
+			return labelA < labelB ? -1 : 1;
+		});
+	});
+
 	const dynamicColumns = getDynamicColumns(sortedQueryTableData, query);
 
 	const { filledDynamicColumns, rowsLength } = fillColumnsData(


### PR DESCRIPTION
### Summary

- the calculation for filling of values in the respective columns didn't account for response of the format 
- hence sorting the series order internally based on label columns concatenated on values to maintain the same order across.
- passed the `isEqualQuery` from the parent to the child function as when the series with equal labels is traversed we should not fill `N/A` as it has already been filled by the parent row query

```
series A -> [ label1, label2] 

series B -> [label2, label1]
```

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/5228

#### Screenshots

before 
![image](https://github.com/SigNoz/signoz/assets/54737045/f4221f92-9640-4938-9775-552099dc13fe)


after 
![image](https://github.com/SigNoz/signoz/assets/54737045/d8f9df98-3cd5-4c4c-ad88-7239953bcefd)


#### Affected Areas and Manually Tested Areas

Verified here http://stagingapp.signoz.io/dashboard/a08716a3-5af6-407f-b81f-7d2f89e33d4e?relativeTime=3d&expandedWidgetId=1f3881cb-1ae1-4d13-abba-64af5feffbb0
