### PR TITLE
fix: table sorting when units are present

### DIFF
--- a/frontend/src/container/GridTableComponent/index.tsx
+++ b/frontend/src/container/GridTableComponent/index.tsx
@@ -62,10 +62,11 @@ function GridTableComponent({
 
 			mutateDataSource = mutateDataSource.map(
 				(val): RowData => {
-					const newValue = val;
+					const newValue = { ...val };
 					Object.keys(val).forEach((k) => {
 						if (columnUnits[k]) {
 							newValue[k] = getYAxisFormattedValue(String(val[k]), columnUnits[k]);
+							newValue[`${k}_without_unit`] = val[k];
 						}
 					});
 					return newValue;
@@ -81,7 +82,6 @@ function GridTableComponent({
 		applyColumnUnits,
 		originalDataSource,
 	]);
-
 	useEffect(() => {
 		if (tableProcessedDataRef) {
 			// eslint-disable-next-line no-param-reassign

--- a/frontend/src/lib/query/createTableColumnsFromQuery.ts
+++ b/frontend/src/lib/query/createTableColumnsFromQuery.ts
@@ -537,8 +537,12 @@ const generateTableColumns = (
 			width: QUERY_TABLE_CONFIG.width,
 			render: renderColumnCell && renderColumnCell[item.dataIndex],
 			sorter: (a: RowData, b: RowData): number => {
-				const valueA = Number(a[item.dataIndex]);
-				const valueB = Number(b[item.dataIndex]);
+				const valueA = Number(
+					a[`${item.dataIndex}_without_unit`] ?? a[item.dataIndex],
+				);
+				const valueB = Number(
+					b[`${item.dataIndex}_without_unit`] ?? b[item.dataIndex],
+				);
 
 				if (!isNaN(valueA) && !isNaN(valueB)) {
 					return valueA - valueB;


### PR DESCRIPTION
### Summary

- when adding units to any column add another data column with label `label_without_unit` which helps us in sorting
- and when sorting if there is a column present with `without_unit` use that else use the normal column

#### Related Issues / PR's



#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/9a71831e-81ce-4c71-b31d-934874e6fac1



#### Affected Areas and Manually Tested Areas

- table panel type with and without units
