### PR TITLE
fix: trace explorer not highlighting in sidenav

### DIFF
--- a/frontend/src/container/SideNav/menuItems.tsx
+++ b/frontend/src/container/SideNav/menuItems.tsx
@@ -125,8 +125,8 @@ const menuItems: SidebarItem[] = [
 
 /** Mapping of some newly added routes and their corresponding active sidebar menu key */
 export const NEW_ROUTES_MENU_ITEM_KEY_MAP: Record<string, string> = {
-	[ROUTES.TRACES_EXPLORER]: ROUTES.TRACE,
-	[ROUTES.TRACE_EXPLORER]: ROUTES.TRACE,
+	[ROUTES.TRACE]: ROUTES.TRACES_EXPLORER,
+	[ROUTES.TRACE_EXPLORER]: ROUTES.TRACES_EXPLORER,
 	[ROUTES.LOGS_BASE]: ROUTES.LOGS_EXPLORER,
 };
 


### PR DESCRIPTION
### Summary

- we need to revert the new route map as the route has been changes to new trace explorer from old trace explorer.

#### Related Issues / PR's


https://github.com/SigNoz/signoz/assets/54737045/f689b8e8-5a11-414d-ab43-f1ca887fae77



#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

- new trace explorer 
- old trace explorer 
