### PR TITLE
fix: update companyDomain in before firing every event

### DIFF
--- a/pkg/query-service/telemetry/telemetry.go
+++ b/pkg/query-service/telemetry/telemetry.go
@@ -460,6 +460,7 @@ func (a *Telemetry) SendEvent(event string, data map[string]interface{}, userEma
 
 	if userEmail != "" {
 		a.SetUserEmail(userEmail)
+		a.SetCompanyDomain(userEmail)
 	}
 
 	if !a.isTelemetryEnabled() {


### PR DESCRIPTION
### Summary

When users of multiple domains are present in a tenant then different company domain maybe attached to events as groupId. 
Update companyDomain in before firing every event.