### PR TITLE
fix: update from typography link to react router dom link component t…

### DIFF
--- a/frontend/src/container/TraceDetail/TraceDetails.styles.scss
+++ b/frontend/src/container/TraceDetail/TraceDetails.styles.scss
@@ -1,7 +1,17 @@
 .span-details-sider {
+	padding-top: 16px;
+
+	::-webkit-scrollbar {
+		width: 0.2em;
+	}
+
+	::-webkit-scrollbar-track {
+		box-shadow: inset 0 0 6px rgba(18, 18, 18, 0.3);
+	}
+
 	&.dark {
 		.ant-layout-sider-trigger {
-			background-color: black !important;
+			background-color: #0b0c0e !important;
 		}
 	}
 

--- a/frontend/src/container/TraceDetail/index.tsx
+++ b/frontend/src/container/TraceDetail/index.tsx
@@ -246,13 +246,14 @@ function TraceDetail({ response }: TraceDetailProps): JSX.Element {
 
 			<Sider
 				className={cx('span-details-sider', isDarkMode ? 'dark' : 'light')}
-				style={{ background: isDarkMode ? '#000' : '#fff' }}
+				style={{ background: isDarkMode ? '#0b0c0e' : '#fff' }}
 				theme={isDarkMode ? 'dark' : 'light'}
 				collapsible
 				collapsed={collapsed}
 				reverseArrow
 				width={300}
 				collapsedWidth={40}
+				defaultCollapsed
 				onCollapse={(value): void => setCollapsed(value)}
 			>
 				{!collapsed && (

--- a/frontend/src/container/TracesExplorer/TracesView/configs.tsx
+++ b/frontend/src/container/TracesExplorer/TracesView/configs.tsx
@@ -3,7 +3,7 @@ import { ColumnsType } from 'antd/es/table';
 import ROUTES from 'constants/routes';
 import { getMs } from 'container/Trace/Filters/Panel/PanelBody/Duration/util';
 import { DEFAULT_PER_PAGE_OPTIONS } from 'hooks/queryPagination';
-import { generatePath } from 'react-router-dom';
+import { generatePath, Link } from 'react-router-dom';
 import { ListItem } from 'types/api/widgets/getQuery';
 
 export const PER_PAGE_OPTIONS: number[] = [10, ...DEFAULT_PER_PAGE_OPTIONS];
@@ -38,14 +38,14 @@ export const columns: ColumnsType<ListItem['data']> = [
 		dataIndex: 'traceID',
 		key: 'traceID',
 		render: (traceID: string): JSX.Element => (
-			<Typography.Link
-				href={generatePath(ROUTES.TRACE_DETAIL, {
+			<Link
+				to={generatePath(ROUTES.TRACE_DETAIL, {
 					id: traceID,
 				})}
 				data-testid="trace-id"
 			>
 				{traceID}
-			</Typography.Link>
+			</Link>
 		),
 	},
 ];


### PR DESCRIPTION
…o maintain global state

### Summary

Current Behaviour 

Trace Explorer -> Choose Last 1 Week -> Trace View -> Click on some old trace ID -> Select Span -> Go to related Logs -> Time frame resets to last 15 mins and the results are not return


As we were using AntD Typography Link component to render Link and handle the navigation, the page would re-render and the global state defaults would be set, hence the time frame would reset to last 15 mins when the user clicks on the go to related logs

Using Link from `react-router-dom` handles navigation without render and as a result, the select time frame is maintain across the navigation.



