### PR TITLE
fix: added null checks for stacked bar chart with fallbacks

### DIFF
--- a/frontend/src/lib/uPlotLib/getUplotChartOptions.ts
+++ b/frontend/src/lib/uPlotLib/getUplotChartOptions.ts
@@ -68,7 +68,8 @@ function getStackedSeries(apiResponse: QueryData[]): QueryData[] {
 		const { values } = series[i];
 		for (let j = 0; j < values.length; j++) {
 			values[j][1] = String(
-				parseFloat(values[j]?.[1]) + parseFloat(series[i + 1].values[j]?.[1]),
+				parseFloat(values[j]?.[1] || '0') +
+					parseFloat(series[i + 1].values[j]?.[1] || '0'),
 			);
 		}
 
@@ -88,7 +89,8 @@ function getStackedSeriesQueryFormat(apiResponse: QueryData[]): QueryData[] {
 		const { values } = series[i];
 		for (let j = 0; j < values.length; j++) {
 			values[j].value = String(
-				parseFloat(values[j].value) + parseFloat(series[i + 1].values[j].value),
+				parseFloat(values[j]?.value || '0') +
+					parseFloat(series[i + 1].values[j]?.value || '0'),
 			);
 		}
 


### PR DESCRIPTION
### Summary

- the case where all the series didn't have the value at all timestamps were breaking the page.
- added null checks and fallback values of 0 for such cases.

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/5258

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

stacked bar series 
