### PR TITLE
chore: threshold rule panel type to graph

### DIFF
--- a/pkg/query-service/rules/thresholdRule.go
+++ b/pkg/query-service/rules/thresholdRule.go
@@ -484,6 +484,10 @@ func (r *ThresholdRule) prepareQueryRange(ts time.Time) *v3.QueryRangeParamsV3 {
 		}
 	}
 
+	if r.ruleCondition.CompositeQuery.PanelType != v3.PanelTypeGraph {
+		r.ruleCondition.CompositeQuery.PanelType = v3.PanelTypeGraph
+	}
+
 	// default mode
 	return &v3.QueryRangeParamsV3{
 		Start:          start,


### PR DESCRIPTION
### Summary

We only support line chart panel type in alerts i.e. the result of the query should be n number of points for series and the condition is evaluated against it. The other panel type creates an invalid query for logs/traces as seen in customer env https://signoz-team.slack.com/archives/C02C7P6KE06/p1714633414469399?thread_ts=1714619780.164229&cid=C02C7P6KE06. This ensures alert queries will not produce invalid queries even if they were misconfigured from the API and give additional bandwidth to https://github.com/SigNoz/signoz/pull/5219
 so that it can be fixed properly.