### PR TITLE
fix: dashboard empty state learn more link not working

### DIFF
--- a/frontend/src/container/ListOfDashboard/DashboardsList.tsx
+++ b/frontend/src/container/ListOfDashboard/DashboardsList.tsx
@@ -699,7 +699,16 @@ function DashboardsList(): JSX.Element {
 										New Dashboard
 									</Button>
 								</Dropdown>
-								<Button type="text" className="learn-more">
+								<Button
+									type="text"
+									className="learn-more"
+									onClick={(): void => {
+										window.open(
+											'https://signoz.io/docs/userguide/manage-dashboards?utm_source=product&utm_medium=dashboard-list-empty-state',
+											'_blank',
+										);
+									}}
+								>
 									Learn more
 								</Button>
 								<ArrowUpRight size={16} className="learn-more-arrow" />


### PR DESCRIPTION
### Summary

- learn more link in the dashboard empty state wasn't added 
- added the link for the same 

#### Related Issues / PR's

fixes https://github.com/SigNoz/engineering-pod/issues/1409

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/1bac9248-2f88-400b-a574-93340d35c623



#### Affected Areas and Manually Tested Areas

- empty state of dashboards 
