### PR TITLE
fix: move date time picker to click an option or `ok` for custom time picker rather than hover

### DIFF
--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -287,7 +287,7 @@ function CustomTimePicker({
 					)
 				}
 				arrow={false}
-				trigger="hover"
+				trigger="click"
 				open={open}
 				onOpenChange={handleOpenChange}
 				style={{


### PR DESCRIPTION
### Summary

- move the trigger for date time picker from hover to click for better usability 

#### Related Issues / PR's

fixes https://github.com/SigNoz/engineering-pod/issues/1405

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/7336630f-3401-48eb-a8df-0d12d3a3a473



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
