### PR TITLE
fix: respect orderby for clickhouse queries

### DIFF
--- a/frontend/src/lib/query/createTableColumnsFromQuery.ts
+++ b/frontend/src/lib/query/createTableColumnsFromQuery.ts
@@ -9,7 +9,7 @@ import {
 import { FORMULA_REGEXP } from 'constants/regExp';
 import { QUERY_TABLE_CONFIG } from 'container/QueryTable/config';
 import { QueryTableProps } from 'container/QueryTable/QueryTable.intefaces';
-import { get, isEqual, isNaN, isObject } from 'lodash-es';
+import { cloneDeep, get, isEqual, isNaN, isObject } from 'lodash-es';
 import { ReactNode } from 'react';
 import {
 	IBuilderFormula,
@@ -575,7 +575,9 @@ export const createTableColumnsFromQuery: CreateTableDataFromQuery = ({
 	// the reason we need this is because the filling of values in rows doesn't account for mismatch enteries
 	// in the response. Example : Series A -> [label1, label2] and Series B -> [label2,label1] this isn't accounted for
 	sortedQueryTableData.forEach((q) => {
-		q.series?.forEach((s) => {
+		const updatedSeries = cloneDeep(q);
+
+		updatedSeries.series?.forEach((s) => {
 			s.labelsArray?.sort((a, b) =>
 				Object.keys(a)[0] < Object.keys(b)[0] ? -1 : 1,
 			);
@@ -583,11 +585,13 @@ export const createTableColumnsFromQuery: CreateTableDataFromQuery = ({
 		q.series?.sort((a, b) => {
 			let labelA = '';
 			let labelB = '';
-			a.labelsArray.forEach((lab) => {
+			const updatedSeriesA = updatedSeries.series?.find((s) => isEqual(s, a));
+			const updatedSeriesB = updatedSeries.series?.find((s) => isEqual(s, b));
+			updatedSeriesA?.labelsArray.forEach((lab) => {
 				labelA += Object.values(lab)[0];
 			});
 
-			b.labelsArray.forEach((lab) => {
+			updatedSeriesB?.labelsArray.forEach((lab) => {
 				labelB += Object.values(lab)[0];
 			});
 


### PR DESCRIPTION
### Summary

- orderBy should be respected in clickhouse queries 
- made a copy of the labelsArray to store the sorting type and then sorted the original series without mutating the labels array 

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/5303

#### Screenshots

No difference in staging vs local for previous data misallignment issue

https://github.com/SigNoz/signoz/assets/54737045/0afd3424-de6f-4569-96af-5b8b7bc2ec4b

orderby being respected 

https://github.com/SigNoz/signoz/assets/54737045/90ff4d76-5636-47b1-9101-e11bdbdc478e

#### Affected Areas and Manually Tested Areas

- table panel type orderby clickhouse queries ( single + multiple )
- builder queries for table panel type for misalligned data
- to test the changes :- http://stagingapp.signoz.io/dashboard/a08716a3-5af6-407f-b81f-7d2f89e33d4e?relativeTime=1h
