### PR TITLE
fix: handle overflow for attribute tooltips in trace details page

### DIFF
--- a/frontend/src/container/TraceDetail/SelectedSpanDetails/Tags/Tag.tsx
+++ b/frontend/src/container/TraceDetail/SelectedSpanDetails/Tags/Tag.tsx
@@ -1,3 +1,5 @@
+import './Tags.styles.scss';
+
 import { Tooltip } from 'antd';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { Fragment, useMemo } from 'react';
@@ -26,7 +28,12 @@ function Tag({ tags, onToggleHandler, setText }: TagProps): JSX.Element {
 				<Container>
 					<CustomSubTitle>{tags.key}</CustomSubTitle>
 					<SubTextContainer isDarkMode={isDarkMode}>
-						<Tooltip overlay={(): string => value}>
+						<Tooltip
+							overlayClassName="tagTooltip"
+							placement="left"
+							autoAdjustOverflow
+							title={value}
+						>
 							<CustomSubText
 								ellipsis={{
 									rows: isEllipsed ? 2 : 0,

--- a/frontend/src/container/TraceDetail/SelectedSpanDetails/Tags/Tags.styles.scss
+++ b/frontend/src/container/TraceDetail/SelectedSpanDetails/Tags/Tags.styles.scss
@@ -1,0 +1,37 @@
+.tagTooltip {
+	.ant-tooltip-content {
+		max-height: 300px;
+		overflow-x: hidden;
+		overflow-y: auto;
+		padding: 8px;
+
+		background-color: var(--bg-slate-400);
+		margin-bottom: 8px;
+	}
+
+	.ant-tooltip-inner {
+		box-shadow: none;
+	}
+}
+
+.lightMode {
+	.tagTooltip {
+		.ant-tooltip-content {
+			background-color: var(--bg-vanilla-300);
+		}
+
+		.ant-tooltip-inner {
+			box-shadow: none;
+			background-color: var(--bg-vanilla-300);
+			color: var(--bg-ink-200);
+		}
+
+		.ant-tooltip-arrow {
+			border-top-color: var(--bg-vanilla-300) !important;
+		}
+
+		&.ant-tooltip {
+			--antd-arrow-background-color: var(--bg-vanilla-300) !important;
+		}
+	}
+}


### PR DESCRIPTION
### Summary

handle overflow for attribute tooltips in trace details page

<img width="1913" alt="Screenshot 2024-06-22 at 3 28 05 PM" src="https://github.com/SigNoz/signoz/assets/3520897/4d468c40-f5ae-43fe-a2bf-cc4ea0df0e82">
