### PR TITLE
chore: add start/end millis for trace details response

### DIFF
--- a/pkg/query-service/model/response.go
+++ b/pkg/query-service/model/response.go
@@ -212,9 +212,11 @@ type ServiceOverviewItem struct {
 }
 
 type SearchSpansResult struct {
-	Columns   []string        `json:"columns"`
-	Events    [][]interface{} `json:"events"`
-	IsSubTree bool            `json:"isSubTree"`
+	StartTimestampMillis uint64          `json:"startTimestampMillis"`
+	EndTimestampMillis   uint64          `json:"endTimestampMillis"`
+	Columns              []string        `json:"columns"`
+	Events               [][]interface{} `json:"events"`
+	IsSubTree            bool            `json:"isSubTree"`
 }
 
 type GetFilterSpansResponseItem struct {


### PR DESCRIPTION
### Summary

Part of https://github.com/SigNoz/signoz/issues/5049

Since the `traceID` is part of the path var, I assume it will always be there and the result `searchSpansResult` will contain exactly one item as initialized here https://github.com/SigNoz/signoz/blob/a7a160df76509ee1bd0ccac5fe598a9a7772a9cc/pkg/query-service/app/clickhouseReader/reader.go#L1943 and here https://github.com/SigNoz/signoz/blob/a7a160df76509ee1bd0ccac5fe598a9a7772a9cc/ee/query-service/app/db/trace.go#L120

We go through all the items scanned into `searchScanResponses` and send the `min(timestamp) - durationNano` as start and `max(timestamp) + durationNano` as end. The start and end are not exact but they serve the purpose.