### PR TITLE
ci(push): include POSTHOG_KEY environment in frontend

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -158,6 +158,7 @@ jobs:
           echo 'SENTRY_DSN="${{ secrets.SENTRY_DSN }}"' >> frontend/.env
           echo 'TUNNEL_URL="${{ secrets.TUNNEL_URL }}"' >> frontend/.env
           echo 'TUNNEL_DOMAIN="${{ secrets.TUNNEL_DOMAIN }}"' >> frontend/.env
+          echo 'POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}"' >> frontend/.env
       - name: Install dependencies
         working-directory: frontend
         run: yarn install


### PR DESCRIPTION
### Summary

Adds `POSTHOG_KEY` in frontend environment variable at build time.

Need to add the environment variable value in GitHub secret.

#### Related Issues / PR's

NA

#### Screenshots

NA

#### Affected Areas and Manually Tested Areas

NA

