### PR TITLE
fix: apdex tooltip not visible in service details page

### DIFF
--- a/frontend/src/components/TextToolTip/TextToolTip.tsx
+++ b/frontend/src/components/TextToolTip/TextToolTip.tsx
@@ -9,7 +9,6 @@ import { Tooltip } from 'antd';
 import { themeColors } from 'constants/theme';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { useMemo } from 'react';
-import { popupContainer } from 'utils/selectPopupContainer';
 
 import { style } from './constant';
 
@@ -64,7 +63,7 @@ function TextToolTip({
 	);
 
 	return (
-		<Tooltip getTooltipContainer={popupContainer} overlay={overlay}>
+		<Tooltip overlay={overlay}>
 			{useFilledIcon ? (
 				<QuestionCircleFilled style={iconStyle} />
 			) : (


### PR DESCRIPTION
### Summary

- `apdex` tooltip in service details page is not visible 
- remove the popup container from the component as it isn't needed 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/ceeefd9e-faea-40e0-bc07-fa28917e9314



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
