### PR TITLE
fix: search not working in services table

### DIFF
--- a/frontend/src/container/ServiceApplication/Columns/GetColumnSearchProps.tsx
+++ b/frontend/src/container/ServiceApplication/Columns/GetColumnSearchProps.tsx
@@ -33,10 +33,12 @@ export const getColumnSearchProps = (
 		record: ServicesList,
 	): boolean => {
 		if (record[dataIndex]) {
-			record[dataIndex]
-				?.toString()
-				.toLowerCase()
-				.includes(value.toString().toLowerCase());
+			return (
+				record[dataIndex]
+					?.toString()
+					.toLowerCase()
+					.includes(value.toString().toLowerCase()) || false
+			);
 		}
 
 		return false;


### PR DESCRIPTION
### Summary

- fix the search not working in services table , the return for the `onFilter` method was missing 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
