### PR TITLE
chore: flaky TestTransformToTableForClickHouseQueries

### DIFF
--- a/pkg/query-service/postprocess/table_test.go
+++ b/pkg/query-service/postprocess/table_test.go
@@ -357,7 +357,8 @@ func TestTransformToTableForClickHouseQueries(t *testing.T) {
 					Series: []*v3.Series{
 						{
 							LabelsArray: []map[string]string{
-								{"service": "frontend", "env": "prod"},
+								{"service": "frontend"},
+								{"env": "prod"},
 							},
 							Points: []v3.Point{
 								{Value: 10.0},

--- a/pkg/query-service/postprocess/table_test.go
+++ b/pkg/query-service/postprocess/table_test.go
@@ -366,7 +366,8 @@ func TestTransformToTableForClickHouseQueries(t *testing.T) {
 						},
 						{
 							LabelsArray: []map[string]string{
-								{"service": "backend", "env": "prod"},
+								{"service": "backend"},
+								{"env": "prod"},
 							},
 							Points: []v3.Point{
 								{Value: 20.0},
@@ -379,7 +380,8 @@ func TestTransformToTableForClickHouseQueries(t *testing.T) {
 					Series: []*v3.Series{
 						{
 							LabelsArray: []map[string]string{
-								{"service": "frontend", "env": "prod"},
+								{"service": "frontend"},
+								{"env": "prod"},
 							},
 							Points: []v3.Point{
 								{Value: 15.0},
@@ -387,7 +389,8 @@ func TestTransformToTableForClickHouseQueries(t *testing.T) {
 						},
 						{
 							LabelsArray: []map[string]string{
-								{"service": "backend", "env": "prod"},
+								{"service": "backend"},
+								{"env": "prod"},
 							},
 							Points: []v3.Point{
 								{Value: 25.0},


### PR DESCRIPTION
### Summary

The `LabelsArray` should be array of single `{k: v}` instead of one `{k1: v1, k2: v2, ...}`. Fixes the flakiness introduced in https://github.com/SigNoz/signoz/pull/5349