### PR TITLE
fix: labelsArray being returned null despite of labels being present

### DIFF
--- a/frontend/src/lib/query/createTableColumnsFromQuery.ts
+++ b/frontend/src/lib/query/createTableColumnsFromQuery.ts
@@ -583,11 +583,11 @@ export const createTableColumnsFromQuery: CreateTableDataFromQuery = ({
 		q.series?.sort((a, b) => {
 			let labelA = '';
 			let labelB = '';
-			a.labelsArray.forEach((lab) => {
+			a.labelsArray?.forEach((lab) => {
 				labelA += Object.values(lab)[0];
 			});
 
-			b.labelsArray.forEach((lab) => {
+			b.labelsArray?.forEach((lab) => {
 				labelB += Object.values(lab)[0];
 			});
 


### PR DESCRIPTION
### Summary

- sentry alert :- https://signoz-io.sentry.io/issues/5539843632/?alert_rule_id=15272042&alert_type=issue&notification_uuid=038c8ed6-8b1c-43c8-88da-1e2e23f8bf20&project=4506831143763968&referrer=slack
- the labelsArray is being returned null even when the labels are present. 
- Added the null check for the same 
- this code will be replaced soon with table calculation moving to backend. :- https://github.com/SigNoz/signoz/pull/5351

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
