### PR TITLE
fix: pie chart panels not rendering

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCard/FullView/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/FullView/index.tsx
@@ -81,7 +81,7 @@ function FullView({
 				globalSelectedInterval: globalSelectedTime,
 				variables: getDashboardVariables(selectedDashboard?.data.variables),
 				fillGaps: widget.fillSpans,
-				formatForWeb: getGraphType(widget.panelTypes) === PANEL_TYPES.TABLE,
+				formatForWeb: widget.panelTypes === PANEL_TYPES.TABLE,
 			};
 		}
 		updatedQuery.builder.queryData[0].pageSize = 10;

--- a/frontend/src/container/GridCardLayout/GridCard/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/index.tsx
@@ -109,7 +109,7 @@ function GridCardGraph({
 				globalSelectedInterval,
 				variables: getDashboardVariables(variables),
 				fillGaps: widget.fillSpans,
-				formatForWeb: getGraphType(widget.panelTypes) === PANEL_TYPES.TABLE,
+				formatForWeb: widget.panelTypes === PANEL_TYPES.TABLE,
 			};
 		}
 		updatedQuery.builder.queryData[0].pageSize = 10;

--- a/frontend/src/container/NewWidget/LeftContainer/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/index.tsx
@@ -44,9 +44,7 @@ function LeftContainer({
 				graphType: getGraphType(selectedGraph || selectedWidget.panelTypes),
 				query: stagedQuery || initialQueriesMap.metrics,
 				globalSelectedInterval,
-				formatForWeb:
-					getGraphType(selectedGraph || selectedWidget.panelTypes) ===
-					PANEL_TYPES.TABLE,
+				formatForWeb: selectedWidget.panelTypes === PANEL_TYPES.TABLE,
 				variables: getDashboardVariables(selectedDashboard?.data.variables),
 			};
 		}
@@ -76,9 +74,7 @@ function LeftContainer({
 				graphType: getGraphType(selectedGraph || selectedWidget.panelTypes),
 				query: stagedQuery,
 				fillGaps: selectedWidget.fillSpans || false,
-				formatForWeb:
-					getGraphType(selectedGraph || selectedWidget.panelTypes) ===
-					PANEL_TYPES.TABLE,
+				formatForWeb: selectedWidget.panelTypes === PANEL_TYPES.TABLE,
 			}));
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/container/NewWidget/LeftContainer/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/index.tsx
@@ -12,7 +12,7 @@ import { memo, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { AppState } from 'store/reducers';
 import { GlobalReducer } from 'types/reducer/globalTime';
-import { getGraphType } from 'utils/getGraphType';
+import { getGraphType, getGraphTypeForFormat } from 'utils/getGraphType';
 
 import { WidgetGraphProps } from '../types';
 import ExplorerColumnsRenderer from './ExplorerColumnsRenderer';
@@ -44,7 +44,9 @@ function LeftContainer({
 				graphType: getGraphType(selectedGraph || selectedWidget.panelTypes),
 				query: stagedQuery || initialQueriesMap.metrics,
 				globalSelectedInterval,
-				formatForWeb: selectedWidget.panelTypes === PANEL_TYPES.TABLE,
+				formatForWeb:
+					getGraphTypeForFormat(selectedGraph || selectedWidget.panelTypes) ===
+					PANEL_TYPES.TABLE,
 				variables: getDashboardVariables(selectedDashboard?.data.variables),
 			};
 		}
@@ -74,7 +76,9 @@ function LeftContainer({
 				graphType: getGraphType(selectedGraph || selectedWidget.panelTypes),
 				query: stagedQuery,
 				fillGaps: selectedWidget.fillSpans || false,
-				formatForWeb: selectedWidget.panelTypes === PANEL_TYPES.TABLE,
+				formatForWeb:
+					getGraphTypeForFormat(selectedGraph || selectedWidget.panelTypes) ===
+					PANEL_TYPES.TABLE,
 			}));
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/utils/getGraphType.ts
+++ b/frontend/src/utils/getGraphType.ts
@@ -10,3 +10,6 @@ export const getGraphType = (panelType: PANEL_TYPES): PANEL_TYPES => {
 	}
 	return panelType;
 };
+
+export const getGraphTypeForFormat = (panelType: PANEL_TYPES): PANEL_TYPES =>
+	panelType;


### PR DESCRIPTION
### Summary

- pie chart panels in the `queryRange` API are being treated as table panel types. 
- the new format for table was getting applied to the pie charts as well

Action Items :- 
- https://github.com/SigNoz/engineering-pod/issues/1444#issuecomment-2195898532
- https://github.com/SigNoz/engineering-pod/issues/1445 


#### Related Issues / PR's

fixes https://github.com/SigNoz/engineering-pod/issues/1444

#### Screenshots


https://github.com/SigNoz/signoz/assets/54737045/971ed761-0e13-4463-8d4f-f7e763518e1a



#### Affected Areas and Manually Tested Areas



-- verfied for time series panel type 
    -- create flow 
    -- landing flow
    -- edit flow 
    -- view flow 

-- verified for value panel type 
    -- create flow 
    -- landing flow
    -- edit flow 
    -- view flow 

-- verified for table panel type
    -- create flow 
    -- landing flow
    -- edit flow 
    -- view flow 

-- verified for list panel type
    -- create flow 
    -- landing flow
    -- edit flow 
    -- view flow 

-- verified for bar chart panel type
    -- create flow 
    -- landing flow
    -- edit flow 
    -- view flow 

-- verified for pie chart panel type
    -- create flow 
    -- landing flow
    -- edit flow 
    -- view flow 

-- verified for histogram panel type
    -- create flow 
    -- landing flow
    -- edit flow 
    -- view flow 
