### PR TITLE
fix: use fill gaps only for time series panel types

### DIFF
--- a/pkg/query-service/postprocess/gaps.go
+++ b/pkg/query-service/postprocess/gaps.go
@@ -46,6 +46,9 @@ func fillGap(series *v3.Series, start, end, step int64) *v3.Series {
 
 // TODO(srikanthccv): can WITH FILL be perfect substitute for all cases https://clickhouse.com/docs/en/sql-reference/statements/select/order-by#order-by-expr-with-fill-modifier
 func FillGaps(results []*v3.Result, params *v3.QueryRangeParamsV3) {
+	if params.CompositeQuery.PanelType != v3.PanelTypeGraph {
+		return
+	}
 	for _, result := range results {
 		// A `result` item in `results` contains the query result for individual query.
 		// If there are no series in the result, we add empty series and `fillGap` adds all zeros

--- a/pkg/query-service/postprocess/gaps_test.go
+++ b/pkg/query-service/postprocess/gaps_test.go
@@ -43,6 +43,7 @@ func TestFillGaps(t *testing.T) {
 				Start: 1000,
 				End:   5000,
 				CompositeQuery: &v3.CompositeQuery{
+					PanelType: v3.PanelTypeGraph,
 					BuilderQueries: map[string]*v3.BuilderQuery{
 						"query1": {
 							QueryName:    "query1",
@@ -82,6 +83,7 @@ func TestFillGaps(t *testing.T) {
 				Start: 1000,
 				End:   5000,
 				CompositeQuery: &v3.CompositeQuery{
+					PanelType: v3.PanelTypeGraph,
 					BuilderQueries: map[string]*v3.BuilderQuery{
 						"query1": {
 							QueryName:    "query1",
@@ -121,6 +123,7 @@ func TestFillGaps(t *testing.T) {
 				Start: 1000,
 				End:   5000,
 				CompositeQuery: &v3.CompositeQuery{
+					PanelType: v3.PanelTypeGraph,
 					BuilderQueries: map[string]*v3.BuilderQuery{
 						"query1": {
 							QueryName:    "query1",
@@ -138,6 +141,39 @@ func TestFillGaps(t *testing.T) {
 						{Timestamp: 3000, Value: 0.0},
 						{Timestamp: 4000, Value: 0.0},
 						{Timestamp: 5000, Value: 0.0},
+					}),
+				}),
+			},
+		},
+		{
+			name: "Single series with gaps and panel type is not graph",
+			results: []*v3.Result{
+				createResult("query1", []*v3.Series{
+					createSeries([]v3.Point{
+						{Timestamp: 1000, Value: 1.0},
+						{Timestamp: 3000, Value: 3.0},
+					}),
+				}),
+			},
+			params: &v3.QueryRangeParamsV3{
+				Start: 1000,
+				End:   5000,
+				CompositeQuery: &v3.CompositeQuery{
+					PanelType: v3.PanelTypeList,
+					BuilderQueries: map[string]*v3.BuilderQuery{
+						"query1": {
+							QueryName:    "query1",
+							Expression:   "query1",
+							StepInterval: 1,
+						},
+					},
+				},
+			},
+			expected: []*v3.Result{
+				createResult("query1", []*v3.Series{
+					createSeries([]v3.Point{
+						{Timestamp: 1000, Value: 1.0},
+						{Timestamp: 3000, Value: 3.0},
 					}),
 				}),
 			},


### PR DESCRIPTION
### Summary

Observed during the post fix from https://github.com/SigNoz/signoz/pull/5376