### PR TITLE
fix: use the correct formatter for the description

### DIFF
--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -401,8 +401,11 @@ type CompositeQuery struct {
 	PromQueries       map[string]*PromQuery       `json:"promQueries,omitempty"`
 	PanelType         PanelType                   `json:"panelType"`
 	QueryType         QueryType                   `json:"queryType"`
-	Unit              string                      `json:"unit,omitempty"`
-	FillGaps          bool                        `json:"fillGaps,omitempty"`
+	// Unit for the time series data shown in the graph
+	// This is used in alerts to format the value and threshold
+	Unit string `json:"unit,omitempty"`
+	// FillGaps is used to fill the gaps in the time series data
+	FillGaps bool `json:"fillGaps,omitempty"`
 }
 
 func (c *CompositeQuery) EnabledQueries() int {


### PR DESCRIPTION
### Summary

Here is how the conversion happens in alerts.

1. The y-axis unit is the unit of the underlying data. For example, for durationNano, `ns` is the unit.
2. The user selects the y-axis unit for an alert
3. At the alert condition step, they have a convenient way to define the threshold/target instead of writing it in the same unit as the underlying data. For example, they can say above `1000 ms` rather than above `1000000000`

How do we do the comparison?

1. We send the query without any unit knowledge to ClickHouse.
2. The results are fetched and compared against the threshold/target
3. When comparing, we take the threshold/target value and convert it to the same unit as the underlying data here https://github.com/SigNoz/signoz/blob/b0b69c83dbfa4758cb893f95dfc345308241b011/pkg/query-service/rules/thresholdRule.go#L168-L176

Now that the `targetVal` is already converted to same unit as data, we need to use the same formatter.