### PR TITLE
feat: replace ant design spinner and add color prop for customization

### DIFF
--- a/frontend/src/assets/CustomIcons/RotatingSpinner.tsx
+++ b/frontend/src/assets/CustomIcons/RotatingSpinner.tsx
@@ -1,0 +1,41 @@
+import './rotatingSpinner.scss';
+
+import { CSSProperties } from 'styled-components';
+
+export default function RotatingSpinner({
+	color,
+}: RotatingSpinnerProps): JSX.Element {
+	return (
+		<svg
+			width="auto"
+			height="auto"
+			viewBox="0 0 25 24"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				d="M12.875 22C18.3978 22 22.875 17.5228 22.875 12C22.875 6.47715 18.3978 2 12.875 2C7.35215 2 2.875 6.47715 2.875 12C2.875 17.5228 7.35215 22 12.875 22Z"
+				stroke="white"
+				strokeOpacity="0.3"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			<path
+				className="rotate"
+				d="M22.875 11.999C22.875 6.47618 18.3978 1.99902 12.875 1.99902"
+				stroke={color}
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+}
+
+interface RotatingSpinnerProps {
+	color?: CSSProperties['stroke'];
+}
+RotatingSpinner.defaultProps = {
+	color: '#4566d6',
+};

--- a/frontend/src/assets/CustomIcons/rotatingSpinner.scss
+++ b/frontend/src/assets/CustomIcons/rotatingSpinner.scss
@@ -1,20 +1,15 @@
 .rotate {
-	animation: rotate 0.5s linear infinite;
+	animation: rotate 0.5s linear 1000; /* High iteration count */
+	transform-origin: 50% 50%;
+	animation-fill-mode: forwards; /* Maintains final state after animation */
 }
 
 @keyframes rotate {
 	0% {
-		transform: rotate(0deg);
-		transform-origin: 50% 50%;
-	}
-
-	50% {
-		transform: rotate(180deg);
-		transform-origin: 50% 50%;
+		transform: rotateZ(0deg);
 	}
 
 	100% {
-		transform: rotate(360deg);
-		transform-origin: 50% 50%;
+		transform: rotateZ(360deg);
 	}
 }

--- a/frontend/src/assets/CustomIcons/rotatingSpinner.scss
+++ b/frontend/src/assets/CustomIcons/rotatingSpinner.scss
@@ -1,0 +1,20 @@
+.rotate {
+	animation: rotate 0.5s linear infinite;
+}
+
+@keyframes rotate {
+	0% {
+		transform: rotate(0deg);
+		transform-origin: 50% 50%;
+	}
+
+	50% {
+		transform: rotate(180deg);
+		transform-origin: 50% 50%;
+	}
+
+	100% {
+		transform: rotate(360deg);
+		transform-origin: 50% 50%;
+	}
+}

--- a/frontend/src/components/Spinner/index.tsx
+++ b/frontend/src/components/Spinner/index.tsx
@@ -1,13 +1,41 @@
-import { LoadingOutlined } from '@ant-design/icons';
 import { Spin, SpinProps } from 'antd';
+import SpinnerIcon from 'assets/CustomIcons/RotatingSpinner';
 import { CSSProperties } from 'react';
 
 import { SpinerStyle } from './styles';
 
-function Spinner({ size, tip, height, style }: SpinnerProps): JSX.Element {
+const getStyleForSize = (
+	size: 'small' | 'default' | 'large' | undefined,
+): Record<string, string> => {
+	const STYLES = {
+		small: { height: '20px', width: '20px' },
+		default: { height: '32px', width: '32px' },
+		large: { height: '48px', width: '48px' },
+	};
+
+	if (!size) {
+		return STYLES.small;
+	}
+
+	return STYLES[size];
+};
+
+function Spinner({
+	size,
+	tip,
+	height,
+	style,
+	color,
+}: SpinnerProps): JSX.Element {
 	return (
 		<SpinerStyle height={height} style={style}>
-			<Spin spinning size={size} tip={tip} indicator={<LoadingOutlined spin />} />
+			<Spin
+				spinning
+				size={size}
+				tip={tip}
+				style={{ ...getStyleForSize(size) }}
+				indicator={<SpinnerIcon color={color} />}
+			/>
 		</SpinerStyle>
 	);
 }
@@ -17,12 +45,14 @@ interface SpinnerProps {
 	tip?: SpinProps['tip'];
 	height?: CSSProperties['height'];
 	style?: CSSProperties;
+	color?: CSSProperties['stroke'];
 }
 Spinner.defaultProps = {
-	size: undefined,
+	size: 'small',
 	tip: undefined,
 	height: undefined,
 	style: {},
+	color: '#4566d6',
 };
 
 export default Spinner;

--- a/frontend/src/components/Spinner/styles.ts
+++ b/frontend/src/components/Spinner/styles.ts
@@ -13,4 +13,12 @@ export const SpinerStyle = styled.div<Props>`
 	justify-content: center;
 	align-items: center;
 	height: ${({ height = '100vh' }): number | string => height};
+	${({ color }): string =>
+		color
+			? `
+		svg {
+			fill: ${color}
+		}
+	`
+			: ''}
 `;


### PR DESCRIPTION
### Summary
- Replace ant design spinner
- add support for color prop in <Spinner component
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
close #5281 
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
