### PR TITLE
Prevent overwriting query expression and queryName on switching between panel types

### DIFF
--- a/frontend/src/container/NewWidget/utils.ts
+++ b/frontend/src/container/NewWidget/utils.ts
@@ -372,8 +372,12 @@ export function handleQueryChange(
 		builder: {
 			...supersetQuery.builder,
 			queryData: supersetQuery.builder.queryData.map((query, index) => {
-				const { dataSource } = query;
-				const tempQuery = { ...initialQueryBuilderFormValuesMap[dataSource] };
+				const { dataSource, expression, queryName } = query;
+				const tempQuery = {
+					...initialQueryBuilderFormValuesMap[dataSource],
+					expression,
+					queryName,
+				};
 
 				const fieldsToSelect =
 					panelTypeDataSourceFormValuesMap[newPanelType][dataSource].builder


### PR DESCRIPTION
### Summary
Fix the issue of original query name and expression being overwritten on switching between different panel types in dashboard edit page

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
close #5320
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
the panel in the loom video can be accessed from this [dashboard](https://stagingapp.signoz.io/dashboard/e6efb6c5-5536-41e8-aa85-943e8ee8a3cd/new?widgetId=38b57afa-28e3-493a-aade-c9adffdba518&graphType=histogram&compositeQuery=%257B%2522queryType%2522%253A%2522builder%2522%252C%2522builder%2522%253A%257B%2522queryData%2522%253A%255B%257B%2522dataSource%2522%253A%2522metrics%2522%252C%2522queryName%2522%253A%2522A%2522%252C%2522aggregateOperator%2522%253A%2522avg%2522%252C%2522aggregateAttribute%2522%253A%257B%2522dataType%2522%253A%2522float64%2522%252C%2522id%2522%253A%2522system_memory_usage--float64--Gauge--true%2522%252C%2522isColumn%2522%253Atrue%252C%2522isJSON%2522%253Afalse%252C%2522key%2522%253A%2522system_memory_usage%2522%252C%2522type%2522%253A%2522Gauge%2522%257D%252C%2522timeAggregation%2522%253A%2522rate%2522%252C%2522spaceAggregation%2522%253A%2522avg%2522%252C%2522functions%2522%253A%255B%255D%252C%2522filters%2522%253A%257B%2522items%2522%253A%255B%255D%252C%2522op%2522%253A%2522AND%2522%257D%252C%2522expression%2522%253A%2522A%2522%252C%2522disabled%2522%253Afalse%252C%2522stepInterval%2522%253A60%252C%2522having%2522%253A%255B%255D%252C%2522limit%2522%253Anull%252C%2522orderBy%2522%253A%255B%255D%252C%2522groupBy%2522%253A%255B%255D%252C%2522legend%2522%253A%2522%2522%252C%2522reduceTo%2522%253A%2522avg%2522%257D%252C%257B%2522dataSource%2522%253A%2522metrics%2522%252C%2522queryName%2522%253A%2522A%2522%252C%2522aggregateOperator%2522%253A%2522avg%2522%252C%2522aggregateAttribute%2522%253A%257B%2522dataType%2522%253A%2522float64%2522%252C%2522id%2522%253A%2522otelcol_process_memory_rss--float64--Gauge--true%2522%252C%2522isColumn%2522%253Atrue%252C%2522isJSON%2522%253Afalse%252C%2522key%2522%253A%2522otelcol_process_memory_rss%2522%252C%2522type%2522%253A%2522Gauge%2522%257D%252C%2522timeAggregation%2522%253A%2522rate%2522%252C%2522spaceAggregation%2522%253A%2522avg%2522%252C%2522functions%2522%253A%255B%255D%252C%2522filters%2522%253A%257B%2522items%2522%253A%255B%255D%252C%2522op%2522%253A%2522AND%2522%257D%252C%2522expression%2522%253A%2522A%2522%252C%2522disabled%2522%253Afalse%252C%2522stepInterval%2522%253A60%252C%2522having%2522%253A%255B%255D%252C%2522limit%2522%253Anull%252C%2522orderBy%2522%253A%255B%255D%252C%2522groupBy%2522%253A%255B%255D%252C%2522legend%2522%253A%2522%2522%252C%2522reduceTo%2522%253A%2522avg%2522%257D%255D%252C%2522queryFormulas%2522%253A%255B%255D%257D%252C%2522promql%2522%253A%255B%257B%2522disabled%2522%253Afalse%252C%2522legend%2522%253A%2522%2522%252C%2522name%2522%253A%2522A%2522%252C%2522query%2522%253A%2522%2522%257D%255D%252C%2522clickhouse_sql%2522%253A%255B%257B%2522disabled%2522%253Afalse%252C%2522legend%2522%253A%2522%2522%252C%2522name%2522%253A%2522A%2522%252C%2522query%2522%253A%2522%2522%257D%255D%252C%2522id%2522%253A%2522ed7a18d2-3683-4e6f-83d9-a5cac821e48c%2522%257D&relativeTime=30m) 

Before:
https://www.loom.com/share/d0dad0c9cde1419b8a5244e374bd2923

After:
https://www.loom.com/share/9bbf808c1818433a86100b6ef9c4b877

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
