### PR TITLE
fix: improve the padding of toolbar buttons in explorer pages

### DIFF
--- a/frontend/src/container/ExplorerOptions/ExplorerOptions.styles.scss
+++ b/frontend/src/container/ExplorerOptions/ExplorerOptions.styles.scss
@@ -91,8 +91,7 @@
 			box-shadow: none !important;
 
 			&.ant-btn-round {
-				padding-inline-start: 10px;
-				padding-inline-end: 8px;
+				padding: 8px 12px 8px 10px;
 				font-weight: 500;
 			}
 


### PR DESCRIPTION
### Summary
Improve the padding of toolbar buttons in explorer pages 
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
close #4927 
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
##### Before:
![Screenshot from 2024-07-07 20-56-46](https://github.com/SigNoz/signoz/assets/30066022/8264da42-2d16-4651-820d-e2a0f034a536)


##### After:
![Screenshot from 2024-07-07 20-57-42](https://github.com/SigNoz/signoz/assets/30066022/ea002b6d-5184-45f4-aea4-ba1591e702e9)


<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
