### PR TITLE
Send usage data day wise for last 72 hours.

### DIFF
--- a/ee/query-service/usage/manager.go
+++ b/ee/query-service/usage/manager.go
@@ -121,7 +121,7 @@ func (lm *Manager) UploadUsage() {
 
 	for _, db := range dbs {
 		dbusages := []model.UsageDB{}
-		err := lm.clickhouseConn.Select(ctx, &dbusages, fmt.Sprintf(query, db, db), time.Now().Add(-(48 * time.Hour)))
+		err := lm.clickhouseConn.Select(ctx, &dbusages, fmt.Sprintf(query, db, db), time.Now().Add(-(72 * time.Hour)))
 		if err != nil && !strings.Contains(err.Error(), "doesn't exist") {
 			zap.L().Error("failed to get usage from clickhouse: %v", zap.Error(err))
 			return

--- a/ee/query-service/usage/manager.go
+++ b/ee/query-service/usage/manager.go
@@ -112,7 +112,7 @@ func (lm *Manager) UploadUsage() {
 					tenant, collector_id, exporter_id, MAX(timestamp) as ts 
 					FROM %s.distributed_usage as u2 
 					where timestamp >= $1 
-					GROUP BY tenant, collector_id, exporter_id 
+					GROUP BY tenant, collector_id, exporter_id, date(timestamp) 
 				) as t1
 		ON 
 		u1.tenant = t1.tenant AND u1.collector_id = t1.collector_id AND u1.exporter_id = t1.exporter_id and u1.timestamp = t1.ts 
@@ -121,7 +121,7 @@ func (lm *Manager) UploadUsage() {
 
 	for _, db := range dbs {
 		dbusages := []model.UsageDB{}
-		err := lm.clickhouseConn.Select(ctx, &dbusages, fmt.Sprintf(query, db, db), time.Now().Add(-(24 * time.Hour)))
+		err := lm.clickhouseConn.Select(ctx, &dbusages, fmt.Sprintf(query, db, db), time.Now().Add(-(48 * time.Hour)))
 		if err != nil && !strings.Contains(err.Error(), "doesn't exist") {
 			zap.L().Error("failed to get usage from clickhouse: %v", zap.Error(err))
 			return


### PR DESCRIPTION
Fixes https://github.com/SigNoz/engineering-pod/issues/1472

Previously if usage data of day-1 was not sent then on current day.
* If there are no restarts then yesterdays usage is added to todays usage.

Now if usage data of day-1 was not sent then on current day.
* If there are no restarts then yesterdays usage is sent  along with todays usage.

This is done for the last 72 hours as the TTL of the usage table is 72 hours.

