### PR TITLE
fix: 404 not found when intercepting the ingestion key calls

### DIFF
--- a/frontend/src/api/apiV1.ts
+++ b/frontend/src/api/apiV1.ts
@@ -3,7 +3,7 @@ const apiV1 = '/api/v1/';
 export const apiV2 = '/api/v2/';
 export const apiV3 = '/api/v3/';
 export const apiV4 = '/api/v4/';
-export const gatewayApiV1 = '/api/gateway/v1';
-export const apiAlertManager = '/api/alertmanager';
+export const gatewayApiV1 = '/api/gateway/v1/';
+export const apiAlertManager = '/api/alertmanager/';
 
 export default apiV1;


### PR DESCRIPTION
### Summary

[Issue]: the baseURL for `gatewayAPI` was missing the trailing `/` due to which when the interception happens due to token expiry the new URL formed has a missing `/`. It doesn't cause any issue in the normal flow but only in interception because we do a substring(1) from the URL to remove the leading `/`. Now since both the slashes are missing we form a bad URL and hence we get 404 not found error.

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/5468

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
