### PR TITLE
fix: do not add select columns when the datasource is logs

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCard/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/index.tsx
@@ -125,10 +125,9 @@ function GridCardGraph({
 					offset: 0,
 					limit: updatedQuery.builder.queryData[0].limit || 0,
 				},
+				// we do not need select columns in case of logs
 				selectColumns:
-					initialDataSource === DataSource.LOGS
-						? widget.selectedLogFields
-						: widget.selectedTracesFields,
+					initialDataSource === DataSource.TRACES && widget.selectedTracesFields,
 			},
 			fillGaps: widget.fillSpans,
 		};

--- a/frontend/src/container/NewWidget/LeftContainer/ExplorerColumnsRenderer.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/ExplorerColumnsRenderer.tsx
@@ -309,6 +309,7 @@ function ExplorerColumnsRenderer({
 						>
 							<Button
 								className="action-btn"
+								data-testid="add-columns-button"
 								icon={
 									<PlusCircle
 										size={16}

--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -563,11 +563,11 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 		if (selectedGraph === PANEL_TYPES.LIST) {
 			const initialDataSource = currentQuery.builder.queryData[0].dataSource;
 			if (initialDataSource === DataSource.LOGS) {
+				// we do not need selected log columns in the request data as the entire response contains all the necessary data
 				setRequestData((prev) => ({
 					...prev,
 					tableParams: {
 						...prev.tableParams,
-						selectColumns: selectedLogFields,
 					},
 				}));
 			} else if (initialDataSource === DataSource.TRACES) {


### PR DESCRIPTION
### Summary

- do not add the select columns in the request when the data source is logs as logs request returns all the required data in the first go itself. 

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/5064

test case in this PR https://github.com/SigNoz/signoz-e2e/pull/4

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
