### PR TITLE
fix: handle the super set query reset state when changing widgets

### DIFF
--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -79,6 +79,7 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 		stagedQuery,
 		redirectWithQueryBuilderData,
 		supersetQuery,
+		setSupersetQuery,
 	} = useQueryBuilder();
 
 	const isQueryModified = useMemo(
@@ -547,6 +548,17 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 		selectedWidget?.id,
 		isNewTraceLogsAvailable,
 	]);
+
+	useEffect(() => {
+		/**
+		 * we need this extra handling for superset query because we cannot keep this in sync with current query
+		 * always.we do not sync superset query in the initQueryBuilderData because that function is called on all stage and run
+		 * actions. we do not want that as we loose out on superset functionalities if we do the same. hence initialising the superset query
+		 * on mount here with the currentQuery in the begining itself
+		 */
+		setSupersetQuery(currentQuery);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	useEffect(() => {
 		registerShortcut(DashboardShortcuts.SaveChanges, onSaveDashboard);

--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -829,7 +829,7 @@ export function QueryBuilderProvider({
 				unit,
 			}));
 		},
-		[setCurrentQuery],
+		[setCurrentQuery, setSupersetQuery],
 	);
 
 	const query: Query = useMemo(


### PR DESCRIPTION
### Summary

[Issue]: the state of the superset query was retained even on changing the widgets due to which the values appeared in the other panels from the older accessed panels.

[Solution]: reset the superset query on load of a dashboard panel to the current query at that instant. this helps to clear any old hanging state from the same 

#### Related Issues / PR's

fixes https://github.com/SigNoz/engineering-pod/issues/1557

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
