### PR TITLE
fix: relative time param from the url not respected

### DIFF
--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -23,7 +23,7 @@ import NewExplorerCTA from 'container/NewExplorerCTA';
 import dayjs, { Dayjs } from 'dayjs';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import useUrlQuery from 'hooks/useUrlQuery';
-import GetMinMax from 'lib/getMinMax';
+import GetMinMax, { isValidTimeFormat } from 'lib/getMinMax';
 import getTimeString from 'lib/getTimeString';
 import history from 'lib/history';
 import { isObject } from 'lodash-es';
@@ -406,7 +406,8 @@ function DateTimeSelection({
 		currentRoute: string,
 	): Time | CustomTimeType => {
 		// if the relativeTime param is present in the url give top most preference to the same
-		if (relativeTimeFromUrl != null) {
+		// if the relativeTime param is not valid then move to next preference
+		if (relativeTimeFromUrl != null && isValidTimeFormat(relativeTimeFromUrl)) {
 			return relativeTimeFromUrl as Time;
 		}
 

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -405,13 +405,17 @@ function DateTimeSelection({
 		time: Time,
 		currentRoute: string,
 	): Time | CustomTimeType => {
+		// if the relativeTime param is present in the url give top most preference to the same
+		if (relativeTimeFromUrl != null) {
+			return relativeTimeFromUrl as Time;
+		}
+
+		// if the startTime and endTime params are present in the url give next preference to the them.
 		if (searchEndTime !== null && searchStartTime !== null) {
 			return 'custom';
 		}
 
-		if (relativeTimeFromUrl != null) {
-			return relativeTimeFromUrl as Time;
-		}
+		// if nothing is present in the url for time range then rely on the local storage values
 		if (
 			(localstorageEndTime === null || localstorageStartTime === null) &&
 			time === 'custom'
@@ -419,6 +423,7 @@ function DateTimeSelection({
 			return getDefaultOption(currentRoute);
 		}
 
+		// if not present in the local storage as well then rely on the defaults set for the page
 		if (OLD_RELATIVE_TIME_VALUES.indexOf(time) > -1) {
 			return convertOldTimeToNewValidCustomTimeFormat(time);
 		}

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -73,6 +73,7 @@ function DateTimeSelection({
 	const urlQuery = useUrlQuery();
 	const searchStartTime = urlQuery.get('startTime');
 	const searchEndTime = urlQuery.get('endTime');
+	const relativeTimeFromUrl = urlQuery.get(QueryParams.relativeTime);
 	const queryClient = useQueryClient();
 	const [enableAbsoluteTime, setEnableAbsoluteTime] = useState(false);
 	const [isValidteRelativeTime, setIsValidteRelativeTime] = useState(false);
@@ -407,6 +408,10 @@ function DateTimeSelection({
 		if (searchEndTime !== null && searchStartTime !== null) {
 			return 'custom';
 		}
+
+		if (relativeTimeFromUrl != null) {
+			return relativeTimeFromUrl as Time;
+		}
 		if (
 			(localstorageEndTime === null || localstorageStartTime === null) &&
 			time === 'custom'
@@ -448,7 +453,11 @@ function DateTimeSelection({
 
 		setRefreshButtonHidden(updatedTime === 'custom');
 
-		updateTimeInterval(updatedTime, [preStartTime, preEndTime]);
+		if (updatedTime !== 'custom') {
+			updateTimeInterval(updatedTime);
+		} else {
+			updateTimeInterval(updatedTime, [preStartTime, preEndTime]);
+		}
 
 		if (updatedTime !== 'custom') {
 			urlQuery.delete('startTime');


### PR DESCRIPTION
### Summary

- the `relativeTime` param was not being read and respected in the time range logic, only the search start time and search end time params were being respected. 
- added the preferences correctly to respect the `relativeTime` preference , then `startTime` and `endTime` preference, post that local storage values and then the defaults for the page.

#### Related Issues / PR's

fixes - https://github.com/SigNoz/engineering-pod/issues/1486 

#### Screenshots


https://github.com/user-attachments/assets/9ca92696-bb1a-4cf9-a3bd-39a950bfb4f1



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
