### PR TITLE
fix: do not send query_range api call on every keystroke

### DIFF
--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -27,7 +27,7 @@ import { createIdFromObjectFields } from 'lib/createIdFromObjectFields';
 import { createNewBuilderItemName } from 'lib/newQueryBuilder/createNewBuilderItemName';
 import { getOperatorsBySourceAndPanelType } from 'lib/newQueryBuilder/getOperatorsBySourceAndPanelType';
 import { replaceIncorrectObjectFields } from 'lib/replaceIncorrectObjectFields';
-import { get, merge, set } from 'lodash-es';
+import { cloneDeep, get, merge, set } from 'lodash-es';
 import {
 	createContext,
 	PropsWithChildren,
@@ -532,7 +532,7 @@ export function QueryBuilderProvider({
 					if (!panelType) {
 						return newQueryItem;
 					}
-					const queryItem = item as IBuilderQuery;
+					const queryItem = cloneDeep(item) as IBuilderQuery;
 					const propsRequired =
 						panelTypeDataSourceFormValuesMap[panelType as keyof PartialPanelTypes]?.[
 							queryItem.dataSource


### PR DESCRIPTION
### Summary

- in the update function of handleSetQueryData the prop reference was getting updated hence the stagedQuery got updated and the api calls triggered. 

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/5591

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
