### PR TITLE
chore: nginx integration: add note about adjusting regex if using custom log format

### DIFF
--- a/pkg/query-service/app/integrations/builtin_integrations/nginx/config/collect-logs.md
+++ b/pkg/query-service/app/integrations/builtin_integrations/nginx/config/collect-logs.md
@@ -110,6 +110,13 @@ service:
 
 ```
 
+### If using non-default nginx log format, adjust log parsing regex
+
+If you are using a [custom nginx log format](https://docs.nginx.com/nginx/admin-guide/monitoring/logging/#setting-up-the-access-log),
+please adjust the regex used for parsing logs in the receivers named
+`filelog/nginx-access-logs` and `filelog/nginx-error-logs` in  collector config.
+
+
 #### Set Environment Variables
 
 Set the following environment variables in your otel-collector environment:


### PR DESCRIPTION

### Summary

The collector config recommended in nginx integration today parses the default nginx log format

This PR adds a note reminding users that they need to adjust regex in collector config if they are using a custom log format

#### Screenshots
![Screenshot from 2024-07-31 17-08-06](https://github.com/user-attachments/assets/2861650f-a7fa-4a41-b846-f3fa85a4d005)
