### PR TITLE
chore(telemetry): add telemetry for metrics query type and count prom…

### DIFF
--- a/pkg/query-service/model/response.go
+++ b/pkg/query-service/model/response.go
@@ -634,16 +634,20 @@ type TagsInfo struct {
 }
 
 type AlertsInfo struct {
-	TotalAlerts       int `json:"totalAlerts"`
-	LogsBasedAlerts   int `json:"logsBasedAlerts"`
-	MetricBasedAlerts int `json:"metricBasedAlerts"`
-	TracesBasedAlerts int `json:"tracesBasedAlerts"`
-	SlackChannels     int `json:"slackChannels"`
-	WebHookChannels   int `json:"webHookChannels"`
-	PagerDutyChannels int `json:"pagerDutyChannels"`
-	OpsGenieChannels  int `json:"opsGenieChannels"`
-	EmailChannels     int `json:"emailChannels"`
-	MSTeamsChannels   int `json:"microsoftTeamsChannels"`
+	TotalAlerts                  int `json:"totalAlerts"`
+	LogsBasedAlerts              int `json:"logsBasedAlerts"`
+	MetricBasedAlerts            int `json:"metricBasedAlerts"`
+	TracesBasedAlerts            int `json:"tracesBasedAlerts"`
+	SlackChannels                int `json:"slackChannels"`
+	WebHookChannels              int `json:"webHookChannels"`
+	PagerDutyChannels            int `json:"pagerDutyChannels"`
+	OpsGenieChannels             int `json:"opsGenieChannels"`
+	EmailChannels                int `json:"emailChannels"`
+	MSTeamsChannels              int `json:"microsoftTeamsChannels"`
+	MetricsBuilderQueries        int `json:"metricsBuilderQueries"`
+	MetricsClickHouseQueries     int `json:"metricsClickHouseQueries"`
+	MetricsPrometheusQueries     int `json:"metricsPrometheusQueries"`
+	SpanMetricsPrometheusQueries int `json:"spanMetricsPrometheusQueries"`
 }
 
 type SavedViewsInfo struct {

--- a/pkg/query-service/telemetry/telemetry.go
+++ b/pkg/query-service/telemetry/telemetry.go
@@ -331,6 +331,10 @@ func createTelemetry() {
 							"opsGenieChannels":                alertsInfo.OpsGenieChannels,
 							"emailChannels":                   alertsInfo.EmailChannels,
 							"msteamsChannels":                 alertsInfo.MSTeamsChannels,
+							"metricsBuilderQueries":           alertsInfo.MetricsBuilderQueries,
+							"metricsClickHouseQueries":        alertsInfo.MetricsClickHouseQueries,
+							"metricsPrometheusQueries":        alertsInfo.MetricsPrometheusQueries,
+							"spanMetricsPrometheusQueries":    alertsInfo.SpanMetricsPrometheusQueries,
 						}
 						// send event only if there are dashboards or alerts or channels
 						if (dashboardsInfo.TotalDashboards > 0 || alertsInfo.TotalAlerts > 0 || len(*channels) > 0 || savedViewsInfo.TotalSavedViews > 0) && apiErr == nil {


### PR DESCRIPTION
…e span metrics alerts

We added the `spanmetrics/delta` pipeline because it's efficient at querying and reduces the memory needed for the collector. To remain backward compatible we kept the `spanmetrics/cumulative` pipeline. We have seen delta working well for long enough now. I want to remove the cumulative pipeline for everyone. Before I do that I plan to get an idea of who is using prom alerts based on span metrics, as removing the cumulative pipeline makes alerts not work correctly.

See thread for some more context https://signoz-team.slack.com/archives/C06045Z9163/p1722405396987279?thread_ts=1722354481.521489&cid=C06045Z9163