### PR TITLE
chore: make eval delay configurable

### DIFF
--- a/ee/query-service/app/server.go
+++ b/ee/query-service/app/server.go
@@ -728,6 +728,7 @@ func makeRulesManager(
 		DisableRules: disableRules,
 		FeatureFlags: fm,
 		Reader:       ch,
+		EvalDelay:    baseconst.GetEvalDelay(),
 	}
 
 	// create Manager

--- a/pkg/query-service/app/server.go
+++ b/pkg/query-service/app/server.go
@@ -713,6 +713,7 @@ func makeRulesManager(
 		DisableRules: disableRules,
 		FeatureFlags: fm,
 		Reader:       ch,
+		EvalDelay:    constants.GetEvalDelay(),
 	}
 
 	// create Manager

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -152,6 +152,15 @@ func GetContextTimeoutMaxAllowed() time.Duration {
 	return contextTimeoutDuration
 }
 
+func GetEvalDelay() time.Duration {
+	evalDelayStr := GetOrDefaultEnv("RULES_EVAL_DELAY", "2m")
+	evalDelayDuration, err := time.ParseDuration(evalDelayStr)
+	if err != nil {
+		return 0
+	}
+	return evalDelayDuration
+}
+
 var ContextTimeoutMaxAllowed = GetContextTimeoutMaxAllowed()
 
 const (

--- a/pkg/query-service/rules/manager.go
+++ b/pkg/query-service/rules/manager.go
@@ -63,6 +63,8 @@ type ManagerOptions struct {
 	DisableRules bool
 	FeatureFlags interfaces.FeatureLookup
 	Reader       interfaces.Reader
+
+	EvalDelay time.Duration
 }
 
 // The Manager manages recording and alerting rules.
@@ -524,7 +526,9 @@ func (m *Manager) prepareTask(acquireLock bool, r *PostableRule, taskName string
 		tr, err := NewThresholdRule(
 			ruleId,
 			r,
-			ThresholdRuleOpts{},
+			ThresholdRuleOpts{
+				EvalDelay: m.opts.EvalDelay,
+			},
 			m.featureFlags,
 			m.reader,
 		)

--- a/pkg/query-service/rules/thresholdRule.go
+++ b/pkg/query-service/rules/thresholdRule.go
@@ -441,6 +441,8 @@ func (r *ThresholdRule) Unit() string {
 
 func (r *ThresholdRule) prepareQueryRange(ts time.Time) *v3.QueryRangeParamsV3 {
 
+	zap.L().Info("prepareQueryRange", zap.Int64("ts", ts.UnixMilli()), zap.Int64("evalWindow", r.evalWindow.Milliseconds()), zap.Int64("evalDelay", r.evalDelay.Milliseconds()))
+
 	start := ts.Add(-time.Duration(r.evalWindow)).UnixMilli()
 	end := ts.UnixMilli()
 	if r.evalDelay > 0 {

--- a/pkg/query-service/rules/thresholdRule.go
+++ b/pkg/query-service/rules/thresholdRule.go
@@ -75,6 +75,8 @@ type ThresholdRule struct {
 
 	querier   interfaces.Querier
 	querierV2 interfaces.Querier
+
+	evalDelay time.Duration
 }
 
 type ThresholdRuleOpts struct {
@@ -86,6 +88,12 @@ type ThresholdRuleOpts struct {
 	// sendAlways will send alert irresepective of resendDelay
 	// or other params
 	SendAlways bool
+
+	// EvalDelay is the time to wait for data to be available
+	// before evaluating the rule. This is useful in scenarios
+	// where data might not be available in the system immediately
+	// after the timestamp.
+	EvalDelay time.Duration
 }
 
 func NewThresholdRule(
@@ -95,6 +103,8 @@ func NewThresholdRule(
 	featureFlags interfaces.FeatureLookup,
 	reader interfaces.Reader,
 ) (*ThresholdRule, error) {
+
+	zap.L().Info("creating new ThresholdRule", zap.String("id", id), zap.Any("opts", opts))
 
 	if p.RuleCondition == nil {
 		return nil, fmt.Errorf("no rule condition")
@@ -117,6 +127,7 @@ func NewThresholdRule(
 		typ:               p.AlertType,
 		version:           p.Version,
 		temporalityMap:    make(map[string]map[v3.Temporality]bool),
+		evalDelay:         opts.EvalDelay,
 	}
 
 	if int64(t.evalWindow) == 0 {
@@ -402,7 +413,6 @@ func (r *ThresholdRule) ForEachActiveAlert(f func(*Alert)) {
 }
 
 func (r *ThresholdRule) SendAlerts(ctx context.Context, ts time.Time, resendDelay time.Duration, interval time.Duration, notifyFunc NotifyFunc) {
-	zap.L().Info("sending alerts", zap.String("rule", r.Name()))
 	alerts := []*Alert{}
 	r.ForEachActiveAlert(func(alert *Alert) {
 		if r.opts.SendAlways || alert.needsSending(ts, resendDelay) {
@@ -431,11 +441,12 @@ func (r *ThresholdRule) Unit() string {
 
 func (r *ThresholdRule) prepareQueryRange(ts time.Time) *v3.QueryRangeParamsV3 {
 
-	// todo(srikanthccv): make this configurable
-	// 2 minutes is reasonable time to wait for data to be available
-	// 60 seconds (SDK) + 10 seconds (batch) + rest for n/w + serialization + write to disk etc..
-	start := ts.Add(-time.Duration(r.evalWindow)).UnixMilli() - 2*60*1000
-	end := ts.UnixMilli() - 2*60*1000
+	start := ts.Add(-time.Duration(r.evalWindow)).UnixMilli()
+	end := ts.UnixMilli()
+	if r.evalDelay > 0 {
+		start = start - int64(r.evalDelay.Milliseconds())
+		end = end - int64(r.evalDelay.Milliseconds())
+	}
 	// round to minute otherwise we could potentially miss data
 	start = start - (start % (60 * 1000))
 	end = end - (end % (60 * 1000))


### PR DESCRIPTION
### Summary

Alert evaluation is delayed by 2 minutes to avoid false alerts because the data might be in motion. This is mostly fine but can also mean delayed notification if the data is available without lag. This change makes it configurable so end users can set whatever they desire.