### PR TITLE
chore: handle traceID search 404 performance issue

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -5016,9 +5016,10 @@ func (r *ClickHouseReader) GetMinAndMaxTimestampForTraceID(ctx context.Context, 
 		return 0, 0, err
 	}
 
+	// return current time if traceID not found
 	if minTime.IsZero() || maxTime.IsZero() {
-		zap.L().Debug("minTime or maxTime is zero")
-		return 0, 0, nil
+		zap.L().Debug("minTime or maxTime is zero, traceID not found")
+		return time.Now().UnixNano(), time.Now().UnixNano(), nil
 	}
 
 	zap.L().Debug("GetMinAndMaxTimestampForTraceID", zap.Any("minTime", minTime), zap.Any("maxTime", maxTime))

--- a/pkg/query-service/app/traces/v3/utils.go
+++ b/pkg/query-service/app/traces/v3/utils.go
@@ -127,7 +127,7 @@ func AddTimestampFilters(minTime int64, maxTime int64, params *v3.QueryRangePara
 	if compositeQuery == nil {
 		return
 	}
-	// Build queries for each builder query
+	// Build queries for each builder query and apply timestamp filter only if TraceID is present
 	for queryName, query := range compositeQuery.BuilderQueries {
 		if query.Expression != queryName && query.DataSource != v3.DataSourceTraces {
 			continue


### PR DESCRIPTION

### Summary
Handle traceID search 404 performance issue

By setting max and min timestamp filter same as current timestamp when traceIDs are not found

