### PR TITLE
fix: hide beta icon in sidebar collapsed view

### DIFF
--- a/frontend/src/container/SideNav/SideNav.styles.scss
+++ b/frontend/src/container/SideNav/SideNav.styles.scss
@@ -188,6 +188,10 @@
 		display: none;
 	}
 
+	.nav-item-beta {
+		display: none;
+	}
+
 	&:hover {
 		flex: 0 0 240px;
 		max-width: 240px;
@@ -220,6 +224,10 @@
 		.nav-item-label {
 			display: block;
 		}
+
+		.nav-item-beta {
+			display: block;
+		}
 	}
 
 	&.docked {
@@ -247,6 +255,10 @@
 		}
 
 		.nav-item-label {
+			display: block;
+		}
+
+		.nav-item-beta {
 			display: block;
 		}
 	}


### PR DESCRIPTION
<img width="677" alt="Screenshot 2024-08-14 at 4 00 38 PM" src="https://github.com/user-attachments/assets/9597d21a-5a6b-47b3-a824-71519243abd1">
<img width="512" alt="Screenshot 2024-08-14 at 4 00 32 PM" src="https://github.com/user-attachments/assets/3b786bdc-a200-4857-ae3b-993ac1de9e84">
