### PR TITLE
fix: do not use relative URLs for ws connections

### DIFF
--- a/frontend/src/api/common/getQueryStats.ts
+++ b/frontend/src/api/common/getQueryStats.ts
@@ -18,7 +18,13 @@ function getURL(baseURL: string, queryId: string): URL | string {
 		return `${baseURL}/ws/query_progress?q=${queryId}`;
 	}
 	const url = new URL(`/ws/query_progress?q=${queryId}`, window.location.href);
-	url.protocol = 'wss';
+
+	if (window.location.protocol === 'http:') {
+		url.protocol = 'ws';
+	} else {
+		url.protocol = 'wss';
+	}
+
 	return url;
 }
 

--- a/frontend/src/api/common/getQueryStats.ts
+++ b/frontend/src/api/common/getQueryStats.ts
@@ -16,10 +16,16 @@ export function getQueryStats(props: GetQueryStatsProps): void {
 	const { queryId, setData } = props;
 
 	const token = getLocalStorageApi(LOCALSTORAGE.AUTH_TOKEN) || '';
-	const socket = new WebSocket(
-		`${ENVIRONMENT.wsURL}/api/v3/query_progress?q=${queryId}`,
-		token,
+
+	// https://github.com/whatwg/websockets/issues/20 reason for not using the relative URLs
+	const url = new URL(
+		`/api/v3/query_progress?q=${queryId}`,
+		ENVIRONMENT.wsURL ? ENVIRONMENT.wsURL : window.location.href,
 	);
+
+	url.protocol = 'wss';
+
+	const socket = new WebSocket(url, token);
 
 	socket.addEventListener('message', (event) => {
 		try {

--- a/frontend/src/api/common/getQueryStats.ts
+++ b/frontend/src/api/common/getQueryStats.ts
@@ -15,12 +15,9 @@ interface GetQueryStatsProps {
 
 function getURL(baseURL: string, queryId: string): URL | string {
 	if (baseURL && !isEmpty(baseURL)) {
-		return `${baseURL}/api/v3/query_progress?q=${queryId}`;
+		return `${baseURL}/ws/query_progress?q=${queryId}`;
 	}
-	const url = new URL(
-		`/api/v3/query_progress?q=${queryId}`,
-		window.location.href,
-	);
+	const url = new URL(`/ws/query_progress?q=${queryId}`, window.location.href);
 	url.protocol = 'wss';
 	return url;
 }

--- a/frontend/src/container/LogsExplorerViews/tests/LogsExplorerViews.test.tsx
+++ b/frontend/src/container/LogsExplorerViews/tests/LogsExplorerViews.test.tsx
@@ -46,7 +46,9 @@ jest.mock(
 		},
 );
 
-jest.mock('api/common/getQueryStats', () => jest.fn());
+jest.mock('api/common/getQueryStats', () => ({
+	getQueryStats: jest.fn(),
+}));
 
 jest.mock('constants/panelTypes', () => ({
 	AVAILABLE_EXPORT_PANEL_TYPES: ['graph', 'table'],


### PR DESCRIPTION
### Summary

the websockets api recently started respecting the domain and support for relative URLs so we can't rely on every user being on the updated version hence added the extra handling for the same 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
