### PR TITLE
fix: nan and inf values in formula result

### DIFF
--- a/pkg/query-service/postprocess/formula.go
+++ b/pkg/query-service/postprocess/formula.go
@@ -146,6 +146,10 @@ func joinAndCalculate(
 			return nil, fmt.Errorf("expected float64, got %T", newValue)
 		}
 
+		if math.IsNaN(val) || math.IsInf(val, 0) {
+			continue
+		}
+
 		resultSeries.Points = append(resultSeries.Points, v3.Point{
 			Timestamp: timestamp,
 			Value:     val,

--- a/pkg/query-service/postprocess/formula_test.go
+++ b/pkg/query-service/postprocess/formula_test.go
@@ -204,9 +204,10 @@ func TestFindUniqueLabelSets(t *testing.T) {
 
 func TestProcessResults(t *testing.T) {
 	tests := []struct {
-		name    string
-		results []*v3.Result
-		want    *v3.Result
+		name       string
+		results    []*v3.Result
+		want       *v3.Result
+		expression string
 	}{
 		{
 			name: "test1",
@@ -288,12 +289,68 @@ func TestProcessResults(t *testing.T) {
 					},
 				},
 			},
+			expression: "A + B",
+		},
+		{
+			name: "test2",
+			results: []*v3.Result{
+				{
+					QueryName: "A",
+					Series: []*v3.Series{
+						{
+							Labels: map[string]string{},
+							Points: []v3.Point{
+								{
+									Timestamp: 1,
+									Value:     10,
+								},
+								{
+									Timestamp: 2,
+									Value:     0,
+								},
+							},
+						},
+					},
+				},
+				{
+					QueryName: "B",
+					Series: []*v3.Series{
+						{
+							Labels: map[string]string{},
+							Points: []v3.Point{
+								{
+									Timestamp: 1,
+									Value:     0,
+								},
+								{
+									Timestamp: 3,
+									Value:     10,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &v3.Result{
+				Series: []*v3.Series{
+					{
+						Labels: map[string]string{},
+						Points: []v3.Point{
+							{
+								Timestamp: 3,
+								Value:     0,
+							},
+						},
+					},
+				},
+			},
+			expression: "A/B",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			expression, err := govaluate.NewEvaluableExpression("A + B")
+			expression, err := govaluate.NewEvaluableExpression(tt.expression)
 			if err != nil {
 				t.Errorf("Error parsing expression: %v", err)
 			}

--- a/pkg/query-service/postprocess/formula_test.go
+++ b/pkg/query-service/postprocess/formula_test.go
@@ -1,7 +1,6 @@
 package postprocess
 
 import (
-	"math"
 	"reflect"
 	"testing"
 
@@ -892,10 +891,6 @@ func TestFormula(t *testing.T) {
 								Timestamp: 5,
 								Value:     1,
 							},
-							{
-								Timestamp: 7,
-								Value:     math.Inf(1),
-							},
 						},
 					},
 					{
@@ -911,10 +906,6 @@ func TestFormula(t *testing.T) {
 							{
 								Timestamp: 2,
 								Value:     0.6923076923076923,
-							},
-							{
-								Timestamp: 3,
-								Value:     math.Inf(1),
 							},
 							{
 								Timestamp: 4,
@@ -1054,62 +1045,6 @@ func TestFormula(t *testing.T) {
 			},
 			want: &v3.Result{
 				Series: []*v3.Series{
-					{
-						Labels: map[string]string{
-							"host_name": "ip-10-420-69-1",
-							"state":     "running",
-						},
-						Points: []v3.Point{
-							{
-								Timestamp: 1,
-								Value:     math.Inf(0),
-							},
-							{
-								Timestamp: 2,
-								Value:     math.Inf(0),
-							},
-							{
-								Timestamp: 4,
-								Value:     math.Inf(0),
-							},
-							{
-								Timestamp: 5,
-								Value:     math.Inf(0),
-							},
-							{
-								Timestamp: 7,
-								Value:     math.Inf(0),
-							},
-						},
-					},
-					{
-						Labels: map[string]string{
-							"host_name": "ip-10-420-69-2",
-							"state":     "idle",
-						},
-						Points: []v3.Point{
-							{
-								Timestamp: 1,
-								Value:     math.Inf(0),
-							},
-							{
-								Timestamp: 2,
-								Value:     math.Inf(0),
-							},
-							{
-								Timestamp: 3,
-								Value:     math.Inf(0),
-							},
-							{
-								Timestamp: 4,
-								Value:     math.Inf(0),
-							},
-							{
-								Timestamp: 5,
-								Value:     math.Inf(0),
-							},
-						},
-					},
 					{
 						Labels: map[string]string{
 							"host_name": "ip-10-420-69-1",
@@ -1318,39 +1253,6 @@ func TestFormula(t *testing.T) {
 							{
 								Timestamp: 5,
 								Value:     1,
-							},
-							{
-								Timestamp: 7,
-								Value:     math.Inf(1),
-							},
-						},
-					},
-					{
-						Labels: map[string]string{
-							"host_name": "ip-10-420-69-2",
-							"state":     "idle",
-							"os.type":   "linux",
-						},
-						Points: []v3.Point{
-							{
-								Timestamp: 1,
-								Value:     math.Inf(0),
-							},
-							{
-								Timestamp: 2,
-								Value:     math.Inf(0),
-							},
-							{
-								Timestamp: 3,
-								Value:     math.Inf(0),
-							},
-							{
-								Timestamp: 4,
-								Value:     math.Inf(0),
-							},
-							{
-								Timestamp: 5,
-								Value:     math.Inf(0),
 							},
 						},
 					},
@@ -1594,10 +1496,6 @@ func TestFormula(t *testing.T) {
 								Timestamp: 5,
 								Value:     51,
 							},
-							{
-								Timestamp: 7,
-								Value:     math.Inf(1),
-							},
 						},
 					},
 					{
@@ -1614,10 +1512,6 @@ func TestFormula(t *testing.T) {
 							{
 								Timestamp: 2,
 								Value:     45.6923076923076923,
-							},
-							{
-								Timestamp: 3,
-								Value:     math.Inf(1),
 							},
 							{
 								Timestamp: 4,


### PR DESCRIPTION
### Summary

Fixes https://github.com/SigNoz/engineering-pod/issues/1687

The formula result can be +/-Inf when the denominator value is zero. It can be Nan if one of the values involved in expression is Nan. Even if we send them back to the client, it doesn't know what to do with these values. For example, in time series it incorrectly shows them as random numbers. In tables, it's not desirable for end users to see Nan or +Inf. The same reasons apply to other panel types. The best thing to do for now is to skip them from the result. I will let the real-world use cases come when it's required to include these in the result.