### PR TITLE
fix: dashboard names invisible due to same background color

### DIFF
--- a/frontend/src/container/ListOfDashboard/DashboardList.styles.scss
+++ b/frontend/src/container/ListOfDashboard/DashboardList.styles.scss
@@ -1067,7 +1067,7 @@
 				color: var(--bg-ink-500);
 			}
 			.subtitle {
-				color: var(--bg-vanilla-400);
+				color: var(--bg-ink-300);
 			}
 
 			.ant-table-row {
@@ -1087,6 +1087,10 @@
 
 					.dashboard-title {
 						color: var(--bg-slate-300);
+
+						.title {
+							color: var(--bg-ink-500);
+						}
 					}
 
 					.title-with-action {


### PR DESCRIPTION
### Summary

Issue:
![Screenshot 2024-08-22 at 10 21 50 PM](https://github.com/user-attachments/assets/4f3b853b-a47d-4a7c-b888-cd2823f779e5)


After:
<img width="1919" alt="Screenshot 2024-08-23 at 11 45 54 AM" src="https://github.com/user-attachments/assets/d21961c3-6f49-494f-9cd3-1caf4c332151">

<img width="1919" alt="Screenshot 2024-08-23 at 11 46 07 AM" src="https://github.com/user-attachments/assets/20178362-2270-45a3-9e86-6f7566801dd5">


<img width="1915" alt="Screenshot 2024-08-23 at 11 48 37 AM" src="https://github.com/user-attachments/assets/227c8085-7437-4ca6-a7f4-c838a2fcd7eb">
