### PR TITLE
fix: remove the checks for aggregate operator in case of metrics v3/v4

### DIFF
--- a/frontend/src/container/QueryBuilder/filters/AggregatorFilter/AggregatorFilter.tsx
+++ b/frontend/src/container/QueryBuilder/filters/AggregatorFilter/AggregatorFilter.tsx
@@ -62,7 +62,9 @@ export const AggregatorFilter = memo(function AggregatorFilter({
 				dataSource: query.dataSource,
 			}),
 		{
-			enabled: !!query.aggregateOperator && !!query.dataSource,
+			enabled:
+				query.dataSource === DataSource.METRICS ||
+				(!!query.aggregateOperator && !!query.dataSource),
 			onSuccess: (data) => {
 				const options: ExtendedSelectOption[] =
 					data?.payload?.attributeKeys?.map(({ id: _, ...item }) => ({

--- a/frontend/src/hooks/queryBuilder/useFetchKeysAndValues.ts
+++ b/frontend/src/hooks/queryBuilder/useFetchKeysAndValues.ts
@@ -92,15 +92,9 @@ export const useFetchKeysAndValues = (
 	const isQueryEnabled = useMemo(
 		() =>
 			query.dataSource === DataSource.METRICS
-				? !!query.aggregateOperator &&
-				  !!query.dataSource &&
-				  !!query.aggregateAttribute.dataType
+				? !!query.dataSource && !!query.aggregateAttribute.dataType
 				: true,
-		[
-			query.aggregateAttribute.dataType,
-			query.aggregateOperator,
-			query.dataSource,
-		],
+		[query.aggregateAttribute.dataType, query.dataSource],
 	);
 
 	const { data, isFetching, status } = useGetAggregateKeys(


### PR DESCRIPTION
### Summary

- remove the checks to check the presence / absence of aggregate operator for v3 and v4 metrics data source 

#### Related Issues / PR's

https://github.com/SigNoz/engineering-pod/issues/1704

#### Screenshots



#### Affected Areas and Manually Tested Areas


