### PR TITLE
Fix/alert history UI fixes

### DIFF
--- a/frontend/src/components/AlertDetailsFilters/Filters.tsx
+++ b/frontend/src/components/AlertDetailsFilters/Filters.tsx
@@ -1,30 +1,25 @@
 import './filters.styles.scss';
 
-import { Button } from 'antd';
-import { QueryParams } from 'constants/query';
-import { RelativeTimeMap } from 'container/TopNav/DateTimeSelection/config';
 import DateTimeSelector from 'container/TopNav/DateTimeSelectionV2';
-import useUrlQuery from 'hooks/useUrlQuery';
-import { Undo } from 'lucide-react';
-import { useHistory } from 'react-router-dom';
 
 export function Filters(): JSX.Element {
-	const urlQuery = useUrlQuery();
-	const history = useHistory();
-	const relativeTime = urlQuery.get(QueryParams.relativeTime);
+	// const urlQuery = useUrlQuery();
+	// const history = useHistory();
+	// const relativeTime = urlQuery.get(QueryParams.relativeTime);
 
-	const handleFiltersReset = (): void => {
-		urlQuery.set(QueryParams.relativeTime, RelativeTimeMap['30min']);
-		urlQuery.delete(QueryParams.startTime);
-		urlQuery.delete(QueryParams.endTime);
-		history.replace({
-			pathname: history.location.pathname,
-			search: `?${urlQuery.toString()}`,
-		});
-	};
+	// const handleFiltersReset = (): void => {
+	// 	urlQuery.set(QueryParams.relativeTime, RelativeTimeMap['30min']);
+	// 	urlQuery.delete(QueryParams.startTime);
+	// 	urlQuery.delete(QueryParams.endTime);
+	// 	history.replace({
+	// 		pathname: history.location.pathname,
+	// 		search: `?${urlQuery.toString()}`,
+	// 	});
+	// };
 	return (
 		<div className="filters">
-			{relativeTime !== RelativeTimeMap['30min'] && (
+			{/* TODO(shaheer): re-enable reset button after fixing the issue w.r.t. updated timeInterval not updating in time picker */}
+			{/* {relativeTime !== RelativeTimeMap['30min'] && (
 				<Button
 					type="default"
 					className="reset-button"
@@ -33,7 +28,7 @@ export function Filters(): JSX.Element {
 				>
 					Reset
 				</Button>
-			)}
+			)} */}
 			<DateTimeSelector showAutoRefresh={false} hideShareModal />
 		</div>
 	);

--- a/frontend/src/container/AlertHistory/Timeline/GraphWrapper/GraphWrapper.tsx
+++ b/frontend/src/container/AlertHistory/Timeline/GraphWrapper/GraphWrapper.tsx
@@ -1,8 +1,11 @@
 import '../Graph/graph.styles.scss';
 
+import { BarChartOutlined } from '@ant-design/icons';
+import { QueryParams } from 'constants/query';
 import useUrlQuery from 'hooks/useUrlQuery';
 import { useGetAlertRuleDetailsTimelineGraphData } from 'pages/AlertDetails/hooks';
 import DataStateRenderer from 'periscope/components/DataStateRenderer/DataStateRenderer';
+import { useEffect, useState } from 'react';
 
 import Graph from '../Graph/Graph';
 
@@ -24,20 +27,44 @@ function GraphWrapper({
 		ruleId,
 	} = useGetAlertRuleDetailsTimelineGraphData();
 
+	const startTime = urlQuery.get(QueryParams.startTime);
+
+	const [isPlaceholder, setIsPlaceholder] = useState(false);
+
+	useEffect(() => {
+		if (startTime) {
+			const startTimeDate = new Date(startTime);
+			const now = new Date();
+			const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+			if (startTimeDate < twentyFourHoursAgo) {
+				setIsPlaceholder(true);
+			} else {
+				setIsPlaceholder(false);
+			}
+		}
+	}, [startTime]);
+
 	return (
 		<div className="timeline-graph">
 			<div className="timeline-graph__title">
 				{totalCurrentTriggers} triggers in {relativeTime}
 			</div>
 			<div className="timeline-graph__chart">
-				<DataStateRenderer
-					isLoading={isLoading}
-					isError={isError || !isValidRuleId || !ruleId}
-					isRefetching={isRefetching}
-					data={data?.payload?.data || null}
-				>
-					{(data): JSX.Element => <Graph type="horizontal" data={data} />}
-				</DataStateRenderer>
+				{isPlaceholder ? (
+					<div className="chart-placeholder">
+						<BarChartOutlined className="chart-icon" />
+					</div>
+				) : (
+					<DataStateRenderer
+						isLoading={isLoading}
+						isError={isError || !isValidRuleId || !ruleId}
+						isRefetching={isRefetching}
+						data={data?.payload?.data || null}
+					>
+						{(data): JSX.Element => <Graph type="horizontal" data={data} />}
+					</DataStateRenderer>
+				)}
 			</div>
 		</div>
 	);

--- a/frontend/src/container/AlertHistory/Timeline/Timeline.tsx
+++ b/frontend/src/container/AlertHistory/Timeline/Timeline.tsx
@@ -1,37 +1,11 @@
 import './timeline.styles.scss';
 
-import { useGetAlertRuleDetailsTimelineTable } from 'pages/AlertDetails/hooks';
-import DataStateRenderer from 'periscope/components/DataStateRenderer/DataStateRenderer';
-
 import GraphWrapper from './GraphWrapper/GraphWrapper';
 import TimelineTable from './Table/Table';
 import TabsAndFilters from './TabsAndFilters/TabsAndFilters';
 
 function TimelineTableRenderer(): JSX.Element {
-	const {
-		isLoading,
-		isRefetching,
-		isError,
-		data,
-		isValidRuleId,
-		ruleId,
-	} = useGetAlertRuleDetailsTimelineTable();
-
-	return (
-		<DataStateRenderer
-			isLoading={isLoading}
-			isRefetching={isRefetching}
-			isError={isError || !isValidRuleId || !ruleId}
-			data={data?.payload?.data || null}
-		>
-			{(timelineData): JSX.Element => (
-				<TimelineTable
-					timelineData={timelineData.items}
-					totalItems={timelineData.total}
-				/>
-			)}
-		</DataStateRenderer>
-	);
+	return <TimelineTable />;
 }
 
 function Timeline({

--- a/frontend/src/container/FormAlertRules/QuerySection.styles.scss
+++ b/frontend/src/container/FormAlertRules/QuerySection.styles.scss
@@ -42,6 +42,10 @@
 		display: flex;
 		align-items: center;
 	}
+
+	.ant-tabs-tab-btn {
+		padding: 0 !important;
+	}
 }
 
 .lightMode {
@@ -56,9 +60,6 @@
 			.nav-btns {
 				background: var(--bg-vanilla-300) !important;
 			}
-		}
-		.ant-tabs-tab-btn {
-			padding: 0;
 		}
 	}
 }

--- a/frontend/src/pages/AlertDetails/AlertHeader/AlertHeader.tsx
+++ b/frontend/src/pages/AlertDetails/AlertHeader/AlertHeader.tsx
@@ -1,12 +1,9 @@
 import './alertHeader.styles.scss';
 
-import dayjs from 'dayjs';
-
 import AlertActionButtons from './ActionButtons';
 import AlertLabels from './AlertLabels/AlertLabels';
 import AlertSeverity from './AlertSeverity/AlertSeverity';
 import AlertState from './AlertState/AlertState';
-import AlertStatus from './AlertStatus/AlertStatus';
 
 type AlertHeaderProps = {
 	alertDetails: {
@@ -32,11 +29,11 @@ function AlertHeader({ alertDetails }: AlertHeaderProps): JSX.Element {
 				<div className="bottom-section">
 					<AlertSeverity severity="warning" />
 
-					{/* // TODO(shaheer): Get actual data when we are able to get alert status from API */}
-					<AlertStatus
+					{/* // TODO(shaheer): Get actual data when we are able to get alert firing from state from API */}
+					{/* <AlertStatus
 						status="firing"
 						timestamp={dayjs().subtract(1, 'd').valueOf()}
-					/>
+					/> */}
 					<AlertLabels labels={labels} />
 				</div>
 			</div>

--- a/frontend/src/pages/AlertDetails/alertDetails.styles.scss
+++ b/frontend/src/pages/AlertDetails/alertDetails.styles.scss
@@ -48,16 +48,20 @@
 		margin-top: 10px;
 	}
 	&__breadcrumb {
+		ol {
+			align-items: center;
+		}
 		padding-left: 16px;
-		.ant-breadcrumb-link {
+		.breadcrumb-item {
 			color: var(--text-vanilla-400);
 			font-size: 14px;
 			line-height: 20px;
 			letter-spacing: 0.25px;
+			padding: 0;
 		}
 
 		.ant-breadcrumb-separator,
-		span.ant-breadcrumb-link {
+		.breadcrumb-item--last {
 			color: var(--var-vanilla-500);
 			font-family: 'Geist Mono';
 		}

--- a/frontend/src/pages/AlertDetails/index.tsx
+++ b/frontend/src/pages/AlertDetails/index.tsx
@@ -1,6 +1,6 @@
 import './alertDetails.styles.scss';
 
-import { Breadcrumb, Divider } from 'antd';
+import { Breadcrumb, Button, Divider } from 'antd';
 import { Filters } from 'components/AlertDetailsFilters/Filters';
 import NotFound from 'components/NotFound';
 import RouteTab from 'components/RouteTab';
@@ -38,6 +38,28 @@ function AlertDetailsStatusRenderer({
 
 	return <AlertHeader alertDetails={alertRuleDetails} />;
 }
+
+function BreadCrumbItem({
+	title,
+	isLast = false,
+}: {
+	title: string | null;
+	isLast?: boolean;
+}): JSX.Element {
+	if (isLast) {
+		return <div className="breadcrumb-item breadcrumb-item--last">{title}</div>;
+	}
+	return (
+		<Button type="text" className="breadcrumb-item">
+			{title}
+		</Button>
+	);
+}
+
+BreadCrumbItem.defaultProps = {
+	isLast: false,
+};
+
 function AlertDetails(): JSX.Element {
 	const { pathname } = useLocation();
 	const { routes } = useRouteTabUtils();
@@ -54,17 +76,21 @@ function AlertDetails(): JSX.Element {
 		return <NotFound />;
 	}
 
+	const handleBack = (): void => {
+		history.push(ROUTES.LIST_ALL_ALERT);
+	};
+
 	return (
 		<div className="alert-details">
 			<Breadcrumb
 				className="alert-details__breadcrumb"
 				items={[
 					{
-						title: 'Alert Rules',
-						href: ROUTES.LIST_ALL_ALERT,
+						title: <BreadCrumbItem title="Alert Rules" />,
+						onClick: handleBack,
 					},
 					{
-						title: ruleId,
+						title: <BreadCrumbItem title={ruleId} isLast />,
 					},
 				]}
 			/>

--- a/frontend/src/pages/AlertDetails/index.tsx
+++ b/frontend/src/pages/AlertDetails/index.tsx
@@ -41,16 +41,25 @@ function AlertDetailsStatusRenderer({
 
 function BreadCrumbItem({
 	title,
-	isLast = false,
+	isLast,
+	route,
 }: {
 	title: string | null;
 	isLast?: boolean;
+	route?: string;
 }): JSX.Element {
 	if (isLast) {
 		return <div className="breadcrumb-item breadcrumb-item--last">{title}</div>;
 	}
+	const handleNavigate = (): void => {
+		if (!route) {
+			return;
+		}
+		history.push(ROUTES.LIST_ALL_ALERT);
+	};
+
 	return (
-		<Button type="text" className="breadcrumb-item">
+		<Button type="text" className="breadcrumb-item" onClick={handleNavigate}>
 			{title}
 		</Button>
 	);
@@ -58,6 +67,7 @@ function BreadCrumbItem({
 
 BreadCrumbItem.defaultProps = {
 	isLast: false,
+	route: '',
 };
 
 function AlertDetails(): JSX.Element {
@@ -76,18 +86,15 @@ function AlertDetails(): JSX.Element {
 		return <NotFound />;
 	}
 
-	const handleBack = (): void => {
-		history.push(ROUTES.LIST_ALL_ALERT);
-	};
-
 	return (
 		<div className="alert-details">
 			<Breadcrumb
 				className="alert-details__breadcrumb"
 				items={[
 					{
-						title: <BreadCrumbItem title="Alert Rules" />,
-						onClick: handleBack,
+						title: (
+							<BreadCrumbItem title="Alert Rules" route={ROUTES.LIST_ALL_ALERT} />
+						),
 					},
 					{
 						title: <BreadCrumbItem title={ruleId} isLast />,

--- a/frontend/src/pages/EditRules/EditRules.styles.scss
+++ b/frontend/src/pages/EditRules/EditRules.styles.scss
@@ -1,32 +1,33 @@
 .edit-rules-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin-top: 5rem;
+	padding: 0 16px;
+	&--error {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		margin-top: 5rem;
+	}
 }
 
-
 .edit-rules-card {
-    width: 20rem;
-    padding: 1rem;
+	width: 20rem;
+	padding: 1rem;
 }
 
 .content {
-    font-style: normal;
+	font-style: normal;
 	font-weight: 300;
 	font-size: 18px;
 	line-height: 20px;
 	display: flex;
 	align-items: center;
-    justify-content: center;
-    text-align: center;
+	justify-content: center;
+	text-align: center;
 	margin: 0;
 }
 
 .btn-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin-top: 2rem;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	margin-top: 2rem;
 }
-

--- a/frontend/src/pages/EditRules/index.tsx
+++ b/frontend/src/pages/EditRules/index.tsx
@@ -65,7 +65,7 @@ function EditRules(): JSX.Element {
 		(data?.payload?.data === undefined && !isLoading)
 	) {
 		return (
-			<div className="edit-rules-container">
+			<div className="edit-rules-container edit-rules-container--error">
 				<Card size="small" className="edit-rules-card">
 					<p className="content">
 						{data?.message === errorMessageReceivedFromBackend
@@ -87,10 +87,12 @@ function EditRules(): JSX.Element {
 	}
 
 	return (
-		<EditRulesContainer
-			ruleId={parseInt(ruleId, 10)}
-			initialValue={data.payload.data}
-		/>
+		<div className="edit-rules-container">
+			<EditRulesContainer
+				ruleId={parseInt(ruleId, 10)}
+				initialValue={data.payload.data}
+			/>
+		</div>
 	);
 }
 


### PR DESCRIPTION
### Summary

- [x] remove extra padding from alert overview query section tabs
- [x] add padding to alert overview container
- [x] improve breadcrumb click behavior
- [x] temporarily hide reset button from alert details timepicker
- [x] hide alert firing since
- [x] don't use the data state renderer for timeline table

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
