### PR TITLE
fix: double encode composite query for explorer links

### DIFF
--- a/pkg/query-service/common/query_range.go
+++ b/pkg/query-service/common/query_range.go
@@ -126,7 +126,7 @@ func PrepareLinksToTraces(ts time.Time, filterItems []v3.FilterItem) string {
 	}
 
 	data, _ := json.Marshal(urlData)
-	compositeQuery := url.QueryEscape(string(data))
+	compositeQuery := url.QueryEscape(url.QueryEscape(string(data)))
 
 	optionsData, _ := json.Marshal(options)
 	urlEncodedOptions := url.QueryEscape(string(optionsData))
@@ -185,7 +185,7 @@ func PrepareLinksToLogs(ts time.Time, filterItems []v3.FilterItem) string {
 	}
 
 	data, _ := json.Marshal(urlData)
-	compositeQuery := url.QueryEscape(string(data))
+	compositeQuery := url.QueryEscape(url.QueryEscape(string(data)))
 
 	optionsData, _ := json.Marshal(options)
 	urlEncodedOptions := url.QueryEscape(string(optionsData))

--- a/pkg/query-service/rules/threshold_rule.go
+++ b/pkg/query-service/rules/threshold_rule.go
@@ -671,7 +671,7 @@ func (r *ThresholdRule) prepareLinksToLogs(ts time.Time, lbls labels.Labels) str
 	}
 
 	data, _ := json.Marshal(urlData)
-	compositeQuery := url.QueryEscape(string(data))
+	compositeQuery := url.QueryEscape(url.QueryEscape(string(data)))
 
 	optionsData, _ := json.Marshal(options)
 	urlEncodedOptions := url.QueryEscape(string(optionsData))
@@ -735,7 +735,7 @@ func (r *ThresholdRule) prepareLinksToTraces(ts time.Time, lbls labels.Labels) s
 	}
 
 	data, _ := json.Marshal(urlData)
-	compositeQuery := url.QueryEscape(string(data))
+	compositeQuery := url.QueryEscape(url.QueryEscape(string(data)))
 
 	optionsData, _ := json.Marshal(options)
 	urlEncodedOptions := url.QueryEscape(string(optionsData))


### PR DESCRIPTION
### Summary

In this PR https://github.com/SigNoz/signoz/pull/4573/files#diff-ff903ea33b2803f758b4114f1e70d0e32ac645e679fae55332301bcf80db2b89R767-R830, we removed the double encoding because it seemed like encoding once works. But it fails in some specific cases. Add the double escaping back.