### PR TITLE
fix: dont merge missed series if there is no overlap or has more points

### DIFF
--- a/pkg/query-service/app/querier/querier.go
+++ b/pkg/query-service/app/querier/querier.go
@@ -284,7 +284,7 @@ func mergeSerieses(cachedSeries, missedSeries []*v3.Series) []*v3.Series {
 
 		// add to the series only if the missed series start or end lies in between the cached series
 		if (series.Points[0].Timestamp >= cachedPoints[0].Timestamp && series.Points[0].Timestamp <= cachedPoints[lc-1].Timestamp) ||
-			(series.Points[ls-1].Timestamp >= cachedPoints[0].Timestamp && series.Points[len(series.Points)-1].Timestamp <= cachedPoints[lc-1].Timestamp) {
+			(series.Points[ls-1].Timestamp >= cachedPoints[0].Timestamp && series.Points[ls-1].Timestamp <= cachedPoints[lc-1].Timestamp) {
 
 			seriesesByLabels[labelsToString(series.Labels)].Points = append(seriesesByLabels[labelsToString(series.Labels)].Points, series.Points...)
 		} else if ls > lc {

--- a/pkg/query-service/app/querier/querier.go
+++ b/pkg/query-service/app/querier/querier.go
@@ -282,13 +282,12 @@ func mergeSerieses(cachedSeries, missedSeries []*v3.Series) []*v3.Series {
 		cachedPoints := seriesesByLabels[labelsToString(series.Labels)].Points
 		lc := len(cachedPoints)
 
-		// add to the series only if the missed series start or end lies in between the cached series
-		if (series.Points[0].Timestamp >= cachedPoints[0].Timestamp && series.Points[0].Timestamp <= cachedPoints[lc-1].Timestamp) ||
-			(series.Points[ls-1].Timestamp >= cachedPoints[0].Timestamp && series.Points[ls-1].Timestamp <= cachedPoints[lc-1].Timestamp) {
+		// if cacheSeries Start or End lies in missed series it means it can be merged
+		if (cachedPoints[0].Timestamp >= series.Points[0].Timestamp && cachedPoints[0].Timestamp <= series.Points[ls-1].Timestamp) ||
+			(cachedPoints[lc-1].Timestamp >= series.Points[0].Timestamp && cachedPoints[lc-1].Timestamp <= series.Points[ls-1].Timestamp) {
 
 			seriesesByLabels[labelsToString(series.Labels)].Points = append(seriesesByLabels[labelsToString(series.Labels)].Points, series.Points...)
-		} else if ls > lc {
-			// replace if the new series has more points than the old one
+		} else {
 			seriesesByLabels[labelsToString(series.Labels)] = series
 		}
 	}

--- a/pkg/query-service/app/querier/querier_test.go
+++ b/pkg/query-service/app/querier/querier_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestMergeSerieses(t *testing.T) {
+
 	testCases := []struct {
 		name         string
 		cachedSeries []*v3.Series
@@ -89,9 +90,8 @@ func TestMergeSerieses(t *testing.T) {
 						"__name__": "http_server_requests_seconds_count",
 					},
 					Points: []v3.Point{
-						{Timestamp: 1675115596722, Value: 1},
-						{Timestamp: 1675115596723, Value: 2},
-						{Timestamp: 1675115596724, Value: 3},
+						{Timestamp: 1675115596726, Value: 5},
+						{Timestamp: 1675115596727, Value: 6},
 					},
 				},
 			},
@@ -104,9 +104,9 @@ func TestMergeSerieses(t *testing.T) {
 						"__name__": "http_server_requests_seconds_count",
 					},
 					Points: []v3.Point{
-						{Timestamp: 1675115596722, Value: 1},
-						{Timestamp: 1675115596723, Value: 2},
-						{Timestamp: 1675115596724, Value: 3},
+						{Timestamp: 1675115596722, Value: 8},
+						{Timestamp: 1675115596723, Value: 9},
+						{Timestamp: 1675115596724, Value: 10},
 					},
 				},
 			},
@@ -127,23 +127,23 @@ func TestMergeSerieses(t *testing.T) {
 						"__name__": "http_server_requests_seconds_count",
 					},
 					Points: []v3.Point{
-						{Timestamp: 1675115596722, Value: 1},
-						{Timestamp: 1675115596723, Value: 2},
-						{Timestamp: 1675115596724, Value: 3},
+						{Timestamp: 1675115596720, Value: 5},
+						{Timestamp: 1675115596721, Value: 6},
 					},
 				},
 			},
 		},
 		{
-			name: "replace if new series has more points than the old one",
+			name: "cache is a subset of missed series",
 			cachedSeries: []*v3.Series{
 				{
 					Labels: map[string]string{
 						"__name__": "http_server_requests_seconds_count",
 					},
 					Points: []v3.Point{
-						{Timestamp: 1675115596720, Value: 5},
-						{Timestamp: 1675115596721, Value: 6},
+						{Timestamp: 1675115596723, Value: 3},
+						{Timestamp: 1675115596724, Value: 4},
+						{Timestamp: 1675115596725, Value: 5},
 					},
 				},
 			},
@@ -153,9 +153,11 @@ func TestMergeSerieses(t *testing.T) {
 						"__name__": "http_server_requests_seconds_count",
 					},
 					Points: []v3.Point{
-						{Timestamp: 1675115596722, Value: 1},
-						{Timestamp: 1675115596723, Value: 2},
-						{Timestamp: 1675115596724, Value: 3},
+						{Timestamp: 1675115596721, Value: 1},
+						{Timestamp: 1675115596722, Value: 2},
+						{Timestamp: 1675115596723, Value: 3},
+						{Timestamp: 1675115596725, Value: 5},
+						{Timestamp: 1675115596726, Value: 6},
 					},
 				},
 			},
@@ -165,9 +167,12 @@ func TestMergeSerieses(t *testing.T) {
 						"__name__": "http_server_requests_seconds_count",
 					},
 					Points: []v3.Point{
-						{Timestamp: 1675115596722, Value: 1},
-						{Timestamp: 1675115596723, Value: 2},
-						{Timestamp: 1675115596724, Value: 3},
+						{Timestamp: 1675115596721, Value: 1},
+						{Timestamp: 1675115596722, Value: 2},
+						{Timestamp: 1675115596723, Value: 3},
+						{Timestamp: 1675115596724, Value: 4},
+						{Timestamp: 1675115596725, Value: 5},
+						{Timestamp: 1675115596726, Value: 6},
 					},
 				},
 			},

--- a/pkg/query-service/app/querier/v2/querier.go
+++ b/pkg/query-service/app/querier/v2/querier.go
@@ -295,7 +295,7 @@ func mergeSerieses(cachedSeries, missedSeries []*v3.Series) []*v3.Series {
 
 		// add to the series only if the missed series start or end lies in between the cached series
 		if (series.Points[0].Timestamp >= cachedPoints[0].Timestamp && series.Points[0].Timestamp <= cachedPoints[lc-1].Timestamp) ||
-			(series.Points[ls-1].Timestamp >= cachedPoints[0].Timestamp && series.Points[len(series.Points)-1].Timestamp <= cachedPoints[lc-1].Timestamp) {
+			(series.Points[ls-1].Timestamp >= cachedPoints[0].Timestamp && series.Points[ls-1].Timestamp <= cachedPoints[lc-1].Timestamp) {
 
 			seriesesByLabels[labelsToString(series.Labels)].Points = append(seriesesByLabels[labelsToString(series.Labels)].Points, series.Points...)
 		} else if ls > lc {

--- a/pkg/query-service/app/querier/v2/querier.go
+++ b/pkg/query-service/app/querier/v2/querier.go
@@ -286,7 +286,22 @@ func mergeSerieses(cachedSeries, missedSeries []*v3.Series) []*v3.Series {
 			seriesesByLabels[labelsToString(series.Labels)] = series
 			continue
 		}
-		seriesesByLabels[labelsToString(series.Labels)].Points = append(seriesesByLabels[labelsToString(series.Labels)].Points, series.Points...)
+
+		series.SortPoints()
+		ls := len(series.Points)
+		// existing points are already sorted
+		cachedPoints := seriesesByLabels[labelsToString(series.Labels)].Points
+		lc := len(cachedPoints)
+
+		// add to the series only if the missed series start or end lies in between the cached series
+		if (series.Points[0].Timestamp >= cachedPoints[0].Timestamp && series.Points[0].Timestamp <= cachedPoints[lc-1].Timestamp) ||
+			(series.Points[ls-1].Timestamp >= cachedPoints[0].Timestamp && series.Points[len(series.Points)-1].Timestamp <= cachedPoints[lc-1].Timestamp) {
+
+			seriesesByLabels[labelsToString(series.Labels)].Points = append(seriesesByLabels[labelsToString(series.Labels)].Points, series.Points...)
+		} else if ls > lc {
+			// replace if the new series has more points than the old one
+			seriesesByLabels[labelsToString(series.Labels)] = series
+		}
 	}
 
 	// Sort the points in each series by timestamp

--- a/pkg/query-service/app/querier/v2/querier.go
+++ b/pkg/query-service/app/querier/v2/querier.go
@@ -293,13 +293,12 @@ func mergeSerieses(cachedSeries, missedSeries []*v3.Series) []*v3.Series {
 		cachedPoints := seriesesByLabels[labelsToString(series.Labels)].Points
 		lc := len(cachedPoints)
 
-		// add to the series only if the missed series start or end lies in between the cached series
-		if (series.Points[0].Timestamp >= cachedPoints[0].Timestamp && series.Points[0].Timestamp <= cachedPoints[lc-1].Timestamp) ||
-			(series.Points[ls-1].Timestamp >= cachedPoints[0].Timestamp && series.Points[ls-1].Timestamp <= cachedPoints[lc-1].Timestamp) {
+		// if cacheSeries Start or End lies in missed series it means it can be merged
+		if (cachedPoints[0].Timestamp >= series.Points[0].Timestamp && cachedPoints[0].Timestamp <= series.Points[ls-1].Timestamp) ||
+			(cachedPoints[lc-1].Timestamp >= series.Points[0].Timestamp && cachedPoints[lc-1].Timestamp <= series.Points[ls-1].Timestamp) {
 
 			seriesesByLabels[labelsToString(series.Labels)].Points = append(seriesesByLabels[labelsToString(series.Labels)].Points, series.Points...)
-		} else if ls > lc {
-			// replace if the new series has more points than the old one
+		} else {
 			seriesesByLabels[labelsToString(series.Labels)] = series
 		}
 	}

--- a/pkg/query-service/app/querier/v2/querier_test.go
+++ b/pkg/query-service/app/querier/v2/querier_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestMergeSerieses(t *testing.T) {
+
 	testCases := []struct {
 		name         string
 		cachedSeries []*v3.Series
@@ -89,9 +90,8 @@ func TestMergeSerieses(t *testing.T) {
 						"__name__": "http_server_requests_seconds_count",
 					},
 					Points: []v3.Point{
-						{Timestamp: 1675115596722, Value: 1},
-						{Timestamp: 1675115596723, Value: 2},
-						{Timestamp: 1675115596724, Value: 3},
+						{Timestamp: 1675115596726, Value: 5},
+						{Timestamp: 1675115596727, Value: 6},
 					},
 				},
 			},
@@ -104,9 +104,9 @@ func TestMergeSerieses(t *testing.T) {
 						"__name__": "http_server_requests_seconds_count",
 					},
 					Points: []v3.Point{
-						{Timestamp: 1675115596722, Value: 1},
-						{Timestamp: 1675115596723, Value: 2},
-						{Timestamp: 1675115596724, Value: 3},
+						{Timestamp: 1675115596722, Value: 8},
+						{Timestamp: 1675115596723, Value: 9},
+						{Timestamp: 1675115596724, Value: 10},
 					},
 				},
 			},
@@ -127,23 +127,23 @@ func TestMergeSerieses(t *testing.T) {
 						"__name__": "http_server_requests_seconds_count",
 					},
 					Points: []v3.Point{
-						{Timestamp: 1675115596722, Value: 1},
-						{Timestamp: 1675115596723, Value: 2},
-						{Timestamp: 1675115596724, Value: 3},
+						{Timestamp: 1675115596720, Value: 5},
+						{Timestamp: 1675115596721, Value: 6},
 					},
 				},
 			},
 		},
 		{
-			name: "replace if new series has more points than the old one",
+			name: "cache is a subset of missed series",
 			cachedSeries: []*v3.Series{
 				{
 					Labels: map[string]string{
 						"__name__": "http_server_requests_seconds_count",
 					},
 					Points: []v3.Point{
-						{Timestamp: 1675115596720, Value: 5},
-						{Timestamp: 1675115596721, Value: 6},
+						{Timestamp: 1675115596723, Value: 3},
+						{Timestamp: 1675115596724, Value: 4},
+						{Timestamp: 1675115596725, Value: 5},
 					},
 				},
 			},
@@ -153,9 +153,11 @@ func TestMergeSerieses(t *testing.T) {
 						"__name__": "http_server_requests_seconds_count",
 					},
 					Points: []v3.Point{
-						{Timestamp: 1675115596722, Value: 1},
-						{Timestamp: 1675115596723, Value: 2},
-						{Timestamp: 1675115596724, Value: 3},
+						{Timestamp: 1675115596721, Value: 1},
+						{Timestamp: 1675115596722, Value: 2},
+						{Timestamp: 1675115596723, Value: 3},
+						{Timestamp: 1675115596725, Value: 5},
+						{Timestamp: 1675115596726, Value: 6},
 					},
 				},
 			},
@@ -165,9 +167,12 @@ func TestMergeSerieses(t *testing.T) {
 						"__name__": "http_server_requests_seconds_count",
 					},
 					Points: []v3.Point{
-						{Timestamp: 1675115596722, Value: 1},
-						{Timestamp: 1675115596723, Value: 2},
-						{Timestamp: 1675115596724, Value: 3},
+						{Timestamp: 1675115596721, Value: 1},
+						{Timestamp: 1675115596722, Value: 2},
+						{Timestamp: 1675115596723, Value: 3},
+						{Timestamp: 1675115596724, Value: 4},
+						{Timestamp: 1675115596725, Value: 5},
+						{Timestamp: 1675115596726, Value: 6},
 					},
 				},
 			},

--- a/pkg/query-service/app/querier/v2/querier_test.go
+++ b/pkg/query-service/app/querier/v2/querier_test.go
@@ -12,6 +12,185 @@ import (
 	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
 )
 
+func TestMergeSerieses(t *testing.T) {
+	testCases := []struct {
+		name         string
+		cachedSeries []*v3.Series
+		missedSeries []*v3.Series
+		resultSeries []*v3.Series
+	}{
+		{
+			name: "merge two series",
+			cachedSeries: []*v3.Series{
+				{
+					Labels: map[string]string{
+						"__name__": "http_server_requests_seconds_count",
+					},
+					Points: []v3.Point{
+						{Timestamp: 1675115596722, Value: 1},
+						{Timestamp: 1675115596723, Value: 2},
+						{Timestamp: 1675115596724, Value: 3},
+					},
+				},
+			},
+			missedSeries: []*v3.Series{
+				{
+					Labels: map[string]string{
+						"__name__": "http_server_requests_seconds_count",
+					},
+					Points: []v3.Point{
+						{Timestamp: 1675115596724, Value: 3},
+						{Timestamp: 1675115596725, Value: 4},
+					},
+				},
+			},
+			resultSeries: []*v3.Series{
+				{
+					Labels: map[string]string{
+						"__name__": "http_server_requests_seconds_count",
+					},
+					Points: []v3.Point{
+						{Timestamp: 1675115596722, Value: 1},
+						{Timestamp: 1675115596723, Value: 2},
+						{Timestamp: 1675115596724, Value: 3},
+						{Timestamp: 1675115596725, Value: 4},
+					},
+				},
+			},
+		},
+		{
+			name: "dont merge if start of missed is after end of cached",
+			cachedSeries: []*v3.Series{
+				{
+					Labels: map[string]string{
+						"__name__": "http_server_requests_seconds_count",
+					},
+					Points: []v3.Point{
+						{Timestamp: 1675115596722, Value: 1},
+						{Timestamp: 1675115596723, Value: 2},
+						{Timestamp: 1675115596724, Value: 3},
+					},
+				},
+			},
+			missedSeries: []*v3.Series{
+				{
+					Labels: map[string]string{
+						"__name__": "http_server_requests_seconds_count",
+					},
+					Points: []v3.Point{
+						{Timestamp: 1675115596726, Value: 5},
+						{Timestamp: 1675115596727, Value: 6},
+					},
+				},
+			},
+			resultSeries: []*v3.Series{
+				{
+					Labels: map[string]string{
+						"__name__": "http_server_requests_seconds_count",
+					},
+					Points: []v3.Point{
+						{Timestamp: 1675115596722, Value: 1},
+						{Timestamp: 1675115596723, Value: 2},
+						{Timestamp: 1675115596724, Value: 3},
+					},
+				},
+			},
+		},
+		{
+			name: "dont merge if end of missed is before start of cached",
+			cachedSeries: []*v3.Series{
+				{
+					Labels: map[string]string{
+						"__name__": "http_server_requests_seconds_count",
+					},
+					Points: []v3.Point{
+						{Timestamp: 1675115596722, Value: 1},
+						{Timestamp: 1675115596723, Value: 2},
+						{Timestamp: 1675115596724, Value: 3},
+					},
+				},
+			},
+			missedSeries: []*v3.Series{
+				{
+					Labels: map[string]string{
+						"__name__": "http_server_requests_seconds_count",
+					},
+					Points: []v3.Point{
+						{Timestamp: 1675115596720, Value: 5},
+						{Timestamp: 1675115596721, Value: 6},
+					},
+				},
+			},
+			resultSeries: []*v3.Series{
+				{
+					Labels: map[string]string{
+						"__name__": "http_server_requests_seconds_count",
+					},
+					Points: []v3.Point{
+						{Timestamp: 1675115596722, Value: 1},
+						{Timestamp: 1675115596723, Value: 2},
+						{Timestamp: 1675115596724, Value: 3},
+					},
+				},
+			},
+		},
+		{
+			name: "replace if new series has more points than the old one",
+			cachedSeries: []*v3.Series{
+				{
+					Labels: map[string]string{
+						"__name__": "http_server_requests_seconds_count",
+					},
+					Points: []v3.Point{
+						{Timestamp: 1675115596720, Value: 5},
+						{Timestamp: 1675115596721, Value: 6},
+					},
+				},
+			},
+			missedSeries: []*v3.Series{
+				{
+					Labels: map[string]string{
+						"__name__": "http_server_requests_seconds_count",
+					},
+					Points: []v3.Point{
+						{Timestamp: 1675115596722, Value: 1},
+						{Timestamp: 1675115596723, Value: 2},
+						{Timestamp: 1675115596724, Value: 3},
+					},
+				},
+			},
+			resultSeries: []*v3.Series{
+				{
+					Labels: map[string]string{
+						"__name__": "http_server_requests_seconds_count",
+					},
+					Points: []v3.Point{
+						{Timestamp: 1675115596722, Value: 1},
+						{Timestamp: 1675115596723, Value: 2},
+						{Timestamp: 1675115596724, Value: 3},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := mergeSerieses(tc.cachedSeries, tc.missedSeries)
+			for sIdx, series := range tc.resultSeries {
+				if len(res[sIdx].Points) != len(series.Points) {
+					t.Errorf("expected %d, got %d", len(series.Points), len(res[sIdx].Points))
+				}
+				for pIdx, point := range series.Points {
+					if res[sIdx].Points[pIdx].Timestamp != point.Timestamp {
+						t.Errorf("expected %d, got %d", point.Timestamp, res[sIdx].Points[pIdx].Timestamp)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestV2FindMissingTimeRangesZeroFreshNess(t *testing.T) {
 	// There are five scenarios:
 	// 1. Cached time range is a subset of the requested time range


### PR DESCRIPTION
Fixes #5808 

dont merge missed series if there is no overlap or has more points

Cases
* If the start or end of the cached series lies in the missed series then merge.
* If not then replace it with the missed series.

-----
what happened previously

timerange :- t1 - t5 

time :- t1 - t2 - t3 - t4 - t5

t1 - t2 = cache miss = actual query
t4 - t5 = cache miss = actual query

t2 - t4

cachedSeries = t1, t2, t4, t5

cache_start  = t2
cache_end = t4
here data for t3 is empty.