### PR TITLE
Issue with initial dashboard title value in rename modal fixed

### DIFF
--- a/frontend/src/container/NewDashboard/DashboardDescription/index.tsx
+++ b/frontend/src/container/NewDashboard/DashboardDescription/index.tsx
@@ -182,6 +182,15 @@ function DashboardDescription(props: DashboardDescriptionProps): JSX.Element {
 
 	const { t } = useTranslation(['dashboard', 'common']);
 
+	// used to set the initial value for the updatedTitle
+	// the context value is sometimes not available during the initial render
+	// due to which the updatedTitle is set to some previous value
+	useEffect(() => {
+		if (selectedDashboard) {
+			setUpdatedTitle(selectedDashboard.data.title);
+		}
+	}, [selectedDashboard]);
+
 	useEffect(() => {
 		if (state.error) {
 			notifications.error({


### PR DESCRIPTION
### Summary

When we go back and forth between multiple dashboard views, it was observed that the initial title value in the rename modal was being set to an outdated value, i.e. the title of a previously visited dashboard. This was due to the context not being updated in time before the first render of the dashboard component, which resulted in an incorrect initial value being set.

#### Related Issues / PR's

Fixes #5780 


#### Affected Areas and Manually Tested Areas

Dashboard component affected.
