### PR TITLE
feat: apply resource filters on coming from service details to traces page

### DIFF
--- a/frontend/src/container/MetricsApplication/Tabs/util.ts
+++ b/frontend/src/container/MetricsApplication/Tabs/util.ts
@@ -4,6 +4,8 @@ import ROUTES from 'constants/routes';
 import { routeConfig } from 'container/SideNav/config';
 import { getQueryString } from 'container/SideNav/helper';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
+import useResourceAttribute from 'hooks/useResourceAttribute';
+import { resourceAttributesToTracesFilterItems } from 'hooks/useResourceAttribute/utils';
 import history from 'lib/history';
 import { traceFilterKeys } from 'pages/TracesExplorer/Filter/filterUtils';
 import { Dispatch, SetStateAction, useMemo } from 'react';
@@ -142,7 +144,12 @@ export function useGetAPMToTracesQueries({
 	filters?: TagFilterItem[];
 }): Query {
 	const { updateAllQueriesOperators } = useQueryBuilder();
+	const { queries } = useResourceAttribute();
 
+	const resourceAttributesFilters = useMemo(
+		() => resourceAttributesToTracesFilterItems(queries),
+		[queries],
+	);
 	const finalFilters: TagFilterItem[] = [];
 	let spanKindFilter: TagFilterItem;
 	let dbCallFilter: TagFilterItem;
@@ -183,6 +190,10 @@ export function useGetAPMToTracesQueries({
 
 	if (filters?.length) {
 		finalFilters.push(...filters);
+	}
+
+	if (resourceAttributesFilters?.length) {
+		finalFilters.push(...resourceAttributesFilters);
 	}
 
 	return useMemo(() => {

--- a/frontend/src/container/MetricsApplication/Tabs/util.ts
+++ b/frontend/src/container/MetricsApplication/Tabs/util.ts
@@ -210,5 +210,5 @@ export function useGetAPMToTracesQueries({
 			finalFilters,
 		);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [servicename, updateAllQueriesOperators]);
+	}, [servicename, queries, updateAllQueriesOperators]);
 }

--- a/frontend/src/container/MetricsApplication/Tabs/util.ts
+++ b/frontend/src/container/MetricsApplication/Tabs/util.ts
@@ -90,15 +90,12 @@ export function onGraphClickHandler(
 	};
 }
 
-export const handleNonInQueryRange = (
-	tags: TagFilterItem[],
-	isTrace = false,
-): TagFilterItem[] =>
+export const handleNonInQueryRange = (tags: TagFilterItem[]): TagFilterItem[] =>
 	tags.map((tag) => {
 		if (tag.op === 'Not IN') {
 			return {
 				...tag,
-				op: isTrace ? 'nin' : 'NIN',
+				op: 'NIN',
 			};
 		}
 		return tag;

--- a/frontend/src/container/MetricsApplication/Tabs/util.ts
+++ b/frontend/src/container/MetricsApplication/Tabs/util.ts
@@ -90,12 +90,15 @@ export function onGraphClickHandler(
 	};
 }
 
-export const handleNonInQueryRange = (tags: TagFilterItem[]): TagFilterItem[] =>
+export const handleNonInQueryRange = (
+	tags: TagFilterItem[],
+	isTrace = false,
+): TagFilterItem[] =>
 	tags.map((tag) => {
 		if (tag.op === 'Not IN') {
 			return {
 				...tag,
-				op: 'NIN',
+				op: isTrace ? 'nin' : 'NIN',
 			};
 		}
 		return tag;

--- a/frontend/src/container/MetricsApplication/TopOperationsTable.tsx
+++ b/frontend/src/container/MetricsApplication/TopOperationsTable.tsx
@@ -7,11 +7,8 @@ import { ResizeTable } from 'components/ResizeTable';
 import Download from 'container/Download/Download';
 import { filterDropdown } from 'container/ServiceApplication/Filter/FilterDropdown';
 import useResourceAttribute from 'hooks/useResourceAttribute';
-import {
-	convertRawQueriesToTraceSelectedTags,
-	resourceAttributesToTracesFilterItems,
-} from 'hooks/useResourceAttribute/utils';
-import { useMemo, useRef } from 'react';
+import { convertRawQueriesToTraceSelectedTags } from 'hooks/useResourceAttribute/utils';
+import { useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { AppState } from 'store/reducers';
@@ -48,10 +45,6 @@ function TopOperationsTable({
 	const apmToTraceQuery = useGetAPMToTracesQueries({ servicename });
 
 	const params = useParams<{ servicename: string }>();
-	const tagFilters = useMemo(
-		() => resourceAttributesToTracesFilterItems(queries),
-		[queries],
-	);
 
 	const handleOnClick = (operation: string): void => {
 		const { servicename: encodedServiceName } = params;
@@ -71,7 +64,6 @@ function TopOperationsTable({
 				op: 'in',
 				value: [operation],
 			},
-			...tagFilters,
 		];
 
 		const preparedQuery: Query = {

--- a/frontend/src/container/MetricsApplication/TopOperationsTable.tsx
+++ b/frontend/src/container/MetricsApplication/TopOperationsTable.tsx
@@ -21,7 +21,7 @@ import { GlobalReducer } from 'types/reducer/globalTime';
 import { v4 as uuid } from 'uuid';
 
 import { IServiceName } from './Tabs/types';
-import { handleNonInQueryRange, useGetAPMToTracesQueries } from './Tabs/util';
+import { useGetAPMToTracesQueries } from './Tabs/util';
 import {
 	convertedTracesToDownloadData,
 	getErrorRate,
@@ -49,8 +49,7 @@ function TopOperationsTable({
 
 	const params = useParams<{ servicename: string }>();
 	const tagFilters = useMemo(
-		() =>
-			handleNonInQueryRange(resourceAttributesToTracesFilterItems(queries), true),
+		() => resourceAttributesToTracesFilterItems(queries),
 		[queries],
 	);
 

--- a/frontend/src/hooks/useResourceAttribute/utils.ts
+++ b/frontend/src/hooks/useResourceAttribute/utils.ts
@@ -93,6 +93,22 @@ export const resourceAttributesToTagFilterItems = (
 		value: `${res.tagValue}`.split(','),
 	}));
 };
+/* Convert resource attributes to trace filters items for queryBuilder */
+export const resourceAttributesToTracesFilterItems = (
+	queries: IResourceAttribute[],
+): TagFilterItem[] =>
+	queries.map((res) => ({
+		id: `${res.id}`,
+		key: {
+			key: convertMetricKeyToTrace(res.tagKey),
+			isColumn: false,
+			type: MetricsType.Resource,
+			dataType: DataTypes.String,
+			id: `${convertMetricKeyToTrace(res.tagKey)}--string--resource--true`,
+		},
+		op: `${res.operator}`,
+		value: `${res.tagValue}`.split(','),
+	}));
 
 export const OperatorSchema: IOption[] = OperatorConversions.map(
 	(operator) => ({

--- a/frontend/src/hooks/useResourceAttribute/utils.ts
+++ b/frontend/src/hooks/useResourceAttribute/utils.ts
@@ -107,7 +107,7 @@ export const resourceAttributesToTracesFilterItems = (
 			id: `${convertMetricKeyToTrace(res.tagKey)}--string--resource--true`,
 		},
 		op: `${res.operator}`,
-		value: `${res.tagValue}`.split(','),
+		value: res.tagValue,
 	}));
 
 export const OperatorSchema: IOption[] = OperatorConversions.map(

--- a/frontend/src/hooks/useResourceAttribute/utils.ts
+++ b/frontend/src/hooks/useResourceAttribute/utils.ts
@@ -106,7 +106,7 @@ export const resourceAttributesToTracesFilterItems = (
 			dataType: DataTypes.String,
 			id: `${convertMetricKeyToTrace(res.tagKey)}--string--resource--true`,
 		},
-		op: `${res.operator}`,
+		op: `${res.operator === 'Not IN' ? 'nin' : res.operator}`,
 		value: res.tagValue,
 	}));
 


### PR DESCRIPTION
### Summary
 Actions in the serviceDetail view that take to the trace explorer page should have the resource attributes applied by default. Eg, selected host.name should translate to host.name = 0201ca93c5ae in the trace explorer page

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
close https://github.com/SigNoz/signoz/issues/2865
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
