### PR TITLE
Sidebar collapse state change allows react-grid-layout to be recalculated

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCardLayout.tsx
+++ b/frontend/src/container/GridCardLayout/GridCardLayout.tsx
@@ -69,9 +69,10 @@ function GraphLayout(props: GraphLayoutProps): JSX.Element {
 
 	const { widgets, variables } = data || {};
 
-	const { featureResponse, role, user } = useSelector<AppState, AppReducer>(
-		(state) => state.app,
-	);
+	const { featureResponse, role, user, isSideBarCollapsed } = useSelector<
+		AppState,
+		AppReducer
+	>((state) => state.app);
 
 	const isDarkMode = useIsDarkMode();
 
@@ -268,6 +269,11 @@ function GraphLayout(props: GraphLayoutProps): JSX.Element {
 			},
 		});
 	};
+
+	// trigger a resize event so that the grid layout is recalculated
+	useEffect(() => {
+		window.dispatchEvent(new Event('resize'));
+	}, [isSideBarCollapsed]);
 
 	useEffect(() => {
 		if (!currentSelectRowId) return;


### PR DESCRIPTION
### Summary

When the sidebar docks/undocks, the dashboard's grid layout didn't get adjusted to the remaining/extra width as a result of the operation. This is fixed with this PR by manually dispatching a resize event on sidebar collapse state change.

#### Related Issues / PR's

Fixes #5779 

#### Screenshots

https://github.com/user-attachments/assets/77033f16-3376-490a-a752-04ecf43b295d

