### PR TITLE
fix: populate alert disabled state on switching the toggle

### DIFF
--- a/frontend/src/pages/AlertDetails/AlertHeader/AlertHeader.tsx
+++ b/frontend/src/pages/AlertDetails/AlertHeader/AlertHeader.tsx
@@ -41,7 +41,7 @@ function AlertHeader({ alertDetails }: AlertHeaderProps): JSX.Element {
 			<div className="alert-info__info-wrapper">
 				<div className="top-section">
 					<div className="alert-title-wrapper">
-						<AlertState state={state} />
+						<AlertState state={isAlertRuleDisabled ? 'disabled' : state} />
 						<div className="alert-title">{alert}</div>
 					</div>
 				</div>


### PR DESCRIPTION
### Summary
populate alert disabled state on switching the toggle
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
