### PR TITLE
fix: fix incorrect alert history state

### DIFF
--- a/frontend/src/pages/AlertDetails/AlertHeader/AlertHeader.tsx
+++ b/frontend/src/pages/AlertDetails/AlertHeader/AlertHeader.tsx
@@ -37,6 +37,10 @@ function AlertHeader({ alertDetails }: AlertHeaderProps): JSX.Element {
 		}
 	}, [disabled, setIsAlertRuleDisabled, isAlertRuleDisabled]);
 
+	// on unmount remove the disabeld state
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	useEffect(() => (): void => setIsAlertRuleDisabled(undefined), []);
+
 	return (
 		<div className="alert-info">
 			<div className="alert-info__info-wrapper">

--- a/frontend/src/pages/AlertDetails/AlertHeader/AlertHeader.tsx
+++ b/frontend/src/pages/AlertDetails/AlertHeader/AlertHeader.tsx
@@ -2,7 +2,7 @@ import './AlertHeader.styles.scss';
 
 import LineClampedText from 'periscope/components/LineClampedText/LineClampedText';
 import { useAlertRule } from 'providers/Alert';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import AlertActionButtons from './ActionButtons/ActionButtons';
 import AlertLabels from './AlertLabels/AlertLabels';
@@ -19,7 +19,7 @@ export type AlertHeaderProps = {
 	};
 };
 function AlertHeader({ alertDetails }: AlertHeaderProps): JSX.Element {
-	const { state, alert, labels, disabled } = alertDetails;
+	const { state, alert, labels } = alertDetails;
 
 	const labelsWithoutSeverity = useMemo(
 		() =>
@@ -29,24 +29,14 @@ function AlertHeader({ alertDetails }: AlertHeaderProps): JSX.Element {
 		[labels],
 	);
 
-	const { isAlertRuleDisabled, setIsAlertRuleDisabled } = useAlertRule();
-
-	useEffect(() => {
-		if (isAlertRuleDisabled === undefined) {
-			setIsAlertRuleDisabled(disabled);
-		}
-	}, [disabled, setIsAlertRuleDisabled, isAlertRuleDisabled]);
-
-	// on unmount remove the disabeld state
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	useEffect(() => (): void => setIsAlertRuleDisabled(undefined), []);
+	const { alertRuleState } = useAlertRule();
 
 	return (
 		<div className="alert-info">
 			<div className="alert-info__info-wrapper">
 				<div className="top-section">
 					<div className="alert-title-wrapper">
-						<AlertState state={isAlertRuleDisabled ? 'disabled' : state} />
+						<AlertState state={alertRuleState ?? state} />
 						<div className="alert-title">
 							<LineClampedText text={alert} />
 						</div>

--- a/frontend/src/providers/Alert.tsx
+++ b/frontend/src/providers/Alert.tsx
@@ -1,10 +1,8 @@
 import React, { createContext, useContext, useState } from 'react';
 
 interface AlertRuleContextType {
-	isAlertRuleDisabled: boolean | undefined;
-	setIsAlertRuleDisabled: React.Dispatch<
-		React.SetStateAction<boolean | undefined>
-	>;
+	alertRuleState: string | undefined;
+	setAlertRuleState: React.Dispatch<React.SetStateAction<string | undefined>>;
 }
 
 const AlertRuleContext = createContext<AlertRuleContextType | undefined>(
@@ -16,14 +14,13 @@ function AlertRuleProvider({
 }: {
 	children: React.ReactNode;
 }): JSX.Element {
-	const [isAlertRuleDisabled, setIsAlertRuleDisabled] = useState<
-		boolean | undefined
-	>(undefined);
-
-	const value = React.useMemo(
-		() => ({ isAlertRuleDisabled, setIsAlertRuleDisabled }),
-		[isAlertRuleDisabled],
+	const [alertRuleState, setAlertRuleState] = useState<string | undefined>(
+		undefined,
 	);
+
+	const value = React.useMemo(() => ({ alertRuleState, setAlertRuleState }), [
+		alertRuleState,
+	]);
 
 	return (
 		<AlertRuleContext.Provider value={value}>


### PR DESCRIPTION
### Summary
fixed the incorrect alert state in enable/disable switch. the issue was caused by old disabled state (from another alert). fixed by removing the old state on unmount.
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
Before:
![Screenshot 2024-09-09 at 1 57 37 PM](https://github.com/user-attachments/assets/b8e1405a-b990-44e9-8ce0-2b6f5cfa9adf)

![Screenshot 2024-09-09 at 1 57 47 PM](https://github.com/user-attachments/assets/e90d69ad-605d-4ff5-a27c-9b77c237d841)



After:
https://www.loom.com/share/9b15bc0edbf2439a90b5349e19562e6e

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
