### PR TITLE
fix: use inactive for empty alert state

### DIFF
--- a/pkg/query-service/model/alerting.go
+++ b/pkg/query-service/model/alerting.go
@@ -57,7 +57,7 @@ func (s *AlertState) UnmarshalJSON(b []byte) error {
 		case "disabled":
 			*s = StateDisabled
 		default:
-			return errors.New("invalid alert state")
+			*s = StateInactive
 		}
 		return nil
 	default:


### PR DESCRIPTION
### Summary

In very old instances, the alert state is saved as an empty string in db. This change allows empty to run alert, inactive/normal state is used when the state is an empty string.