### PR TITLE
chore: add note on data refresh in billing

### DIFF
--- a/frontend/src/container/BillingContainer/BillingContainer.styles.scss
+++ b/frontend/src/container/BillingContainer/BillingContainer.styles.scss
@@ -50,6 +50,13 @@
 			align-items: center;
 		}
 	}
+
+	.billing-update-note {
+		text-align: 'left';
+		font-size: '13px';
+		color: '#dcdcdc';
+		margin-top: '16px';
+	}
 }
 
 .ant-skeleton.ant-skeleton-element.ant-skeleton-active {

--- a/frontend/src/container/BillingContainer/BillingContainer.styles.scss
+++ b/frontend/src/container/BillingContainer/BillingContainer.styles.scss
@@ -52,10 +52,10 @@
 	}
 
 	.billing-update-note {
-		text-align: 'left';
-		font-size: '13px';
-		color: '#dcdcdc';
-		margin-top: '16px';
+		text-align: left;
+		font-size: 13px;
+		color: var(--bg-vanilla-200);
+		margin-top: 16px;
 	}
 }
 
@@ -81,6 +81,10 @@
 					border-color: var(--bg-vanilla-200);
 				}
 			}
+		}
+
+		.billing-update-note {
+			color: var(--bg-ink-200);
 		}
 	}
 }

--- a/frontend/src/container/BillingContainer/BillingContainer.tsx
+++ b/frontend/src/container/BillingContainer/BillingContainer.tsx
@@ -348,7 +348,19 @@ export default function BillingContainer(): JSX.Element {
 	const BillingUsageGraphCallback = useCallback(
 		() =>
 			!isLoading && !isFetchingBillingData ? (
-				<BillingUsageGraph data={apiResponse} billAmount={billAmount} />
+				<>
+					<BillingUsageGraph data={apiResponse} billAmount={billAmount} />
+					<div
+						style={{
+							textAlign: 'left',
+							fontSize: '13px',
+							color: '#dcdcdc',
+							marginTop: '16px',
+						}}
+					>
+						Note: Billing metrics are updated once every 24 hours.
+					</div>
+				</>
 			) : (
 				<Card className="empty-graph-card" bordered={false}>
 					<Spinner size="large" tip="Loading..." height="35vh" />

--- a/frontend/src/container/BillingContainer/BillingContainer.tsx
+++ b/frontend/src/container/BillingContainer/BillingContainer.tsx
@@ -350,14 +350,7 @@ export default function BillingContainer(): JSX.Element {
 			!isLoading && !isFetchingBillingData ? (
 				<>
 					<BillingUsageGraph data={apiResponse} billAmount={billAmount} />
-					<div
-						style={{
-							textAlign: 'left',
-							fontSize: '13px',
-							color: '#dcdcdc',
-							marginTop: '16px',
-						}}
-					>
+					<div className="billing-update-note">
 						Note: Billing metrics are updated once every 24 hours.
 					</div>
 				</>


### PR DESCRIPTION
### Summary

Add note on data refresh

### Screenshot

#### Before
<img width="1440" alt="Screenshot 2024-09-12 at 13 44 37" src="https://github.com/user-attachments/assets/9d6aa0eb-3102-4c0c-9a21-7efeeca98ae5">


#### After
<img width="969" alt="Screenshot 2024-09-12 at 15 35 35" src="https://github.com/user-attachments/assets/6e3ec56d-1000-45e9-b827-5667e955b6f6">

Light mode

<img width="1410" alt="Screenshot 2024-09-12 at 16 34 39" src="https://github.com/user-attachments/assets/65007186-5b8d-4f6c-8448-1ca970fcc346">
