### PR TITLE
feat: send last log line time stamp for timestamp order-by desc

### DIFF
--- a/frontend/src/container/LogsExplorerViews/index.tsx
+++ b/frontend/src/container/LogsExplorerViews/index.tsx
@@ -133,6 +133,9 @@ function LogsExplorerViews({
 	// State
 	const [page, setPage] = useState<number>(1);
 	const [logs, setLogs] = useState<ILog[]>([]);
+	const [lastLogLineTimestamp, setLastLogLineTimestamp] = useState<
+		number | string | null
+	>();
 	const [requestData, setRequestData] = useState<Query | null>(null);
 	const [showFormatMenuItems, setShowFormatMenuItems] = useState(false);
 	const [queryId, setQueryId] = useState<string>(v4());
@@ -270,6 +273,14 @@ function LogsExplorerViews({
 					start: minTime,
 					end: maxTime,
 				}),
+			// send the lastLogTimeStamp only when the panel type is list and the orderBy is timestamp and the order is desc
+			lastLogLineTimestamp:
+				panelType === PANEL_TYPES.LIST &&
+				requestData?.builder?.queryData[0]?.orderBy?.[0]?.columnName ===
+					'timestamp' &&
+				requestData?.builder?.queryData[0]?.orderBy?.[0]?.order === 'desc'
+					? lastLogLineTimestamp
+					: undefined,
 		},
 		undefined,
 		listQueryKeyRef,
@@ -346,6 +357,10 @@ function LogsExplorerViews({
 				log: orderByTimestamp ? lastLog : null,
 				pageSize: nextPageSize,
 			});
+
+			// initially then the last log timestamp to null as we don't have the logs.
+			// as soon as we scroll to the end of the logs we set the lastLogLineTimestamp to the last log timestamp.
+			setLastLogLineTimestamp(lastLog.timestamp);
 
 			setPage((prevPage) => prevPage + 1);
 
@@ -537,6 +552,13 @@ function LogsExplorerViews({
 		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [data]);
+
+	console.log(lastLogLineTimestamp);
+
+	useEffect(() => {
+		// clear the lastLogLineTimestamp when the data changes
+		setLastLogLineTimestamp(null);
 	}, [data]);
 
 	useEffect(() => {

--- a/frontend/src/container/LogsExplorerViews/index.tsx
+++ b/frontend/src/container/LogsExplorerViews/index.tsx
@@ -276,9 +276,9 @@ function LogsExplorerViews({
 			// send the lastLogTimeStamp only when the panel type is list and the orderBy is timestamp and the order is desc
 			lastLogLineTimestamp:
 				panelType === PANEL_TYPES.LIST &&
-				requestData?.builder?.queryData[0]?.orderBy?.[0]?.columnName ===
+				requestData?.builder?.queryData?.[0]?.orderBy?.[0]?.columnName ===
 					'timestamp' &&
-				requestData?.builder?.queryData[0]?.orderBy?.[0]?.order === 'desc'
+				requestData?.builder?.queryData?.[0]?.orderBy?.[0]?.order === 'desc'
 					? lastLogLineTimestamp
 					: undefined,
 		},
@@ -358,7 +358,7 @@ function LogsExplorerViews({
 				pageSize: nextPageSize,
 			});
 
-			// initially then the last log timestamp to null as we don't have the logs.
+			// initialise the last log timestamp to null as we don't have the logs.
 			// as soon as we scroll to the end of the logs we set the lastLogLineTimestamp to the last log timestamp.
 			setLastLogLineTimestamp(lastLog.timestamp);
 
@@ -553,8 +553,6 @@ function LogsExplorerViews({
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [data]);
-
-	console.log(lastLogLineTimestamp);
 
 	useEffect(() => {
 		// clear the lastLogLineTimestamp when the data changes

--- a/frontend/src/lib/dashboard/prepareQueryRangePayload.ts
+++ b/frontend/src/lib/dashboard/prepareQueryRangePayload.ts
@@ -1,6 +1,7 @@
 import getStartEndRangeTime from 'lib/getStartEndRangeTime';
 import getStep from 'lib/getStep';
 import { mapQueryDataToApi } from 'lib/newQueryBuilder/queryBuilderMappers/mapQueryDataToApi';
+import { isUndefined } from 'lodash-es';
 import store from 'store';
 import { QueryRangePayload } from 'types/api/metrics/getQueryRange';
 import { EQueryType } from 'types/common/dashboard';
@@ -24,7 +25,11 @@ export const prepareQueryRangePayload = ({
 	fillGaps = false,
 }: GetQueryResultsProps): PrepareQueryRangePayload => {
 	let legendMap: Record<string, string> = {};
-	const { allowSelectedIntervalForStepGen, ...restParams } = params;
+	const {
+		allowSelectedIntervalForStepGen,
+		lastLogLineTimestamp,
+		...restParams
+	} = params;
 
 	const compositeQuery: QueryRangePayload['compositeQuery'] = {
 		queryType: query.queryType,
@@ -90,9 +95,13 @@ export const prepareQueryRangePayload = ({
 		interval: globalSelectedInterval,
 	});
 
+	const endLogTimeStamp = !isUndefined(lastLogLineTimestamp)
+		? new Date(lastLogLineTimestamp as any)?.getTime()
+		: undefined;
+
 	const queryPayload: QueryRangePayload = {
 		start: parseInt(start, 10) * 1e3,
-		end: parseInt(end, 10) * 1e3,
+		end: endLogTimeStamp || parseInt(end, 10) * 1e3,
 		step: getStep({
 			start: allowSelectedIntervalForStepGen
 				? start

--- a/frontend/src/lib/dashboard/prepareQueryRangePayload.ts
+++ b/frontend/src/lib/dashboard/prepareQueryRangePayload.ts
@@ -96,7 +96,7 @@ export const prepareQueryRangePayload = ({
 	});
 
 	const endLogTimeStamp = !isUndefined(lastLogLineTimestamp)
-		? new Date(lastLogLineTimestamp as any)?.getTime()
+		? new Date(lastLogLineTimestamp as string | number)?.getTime() || undefined
 		: undefined;
 
 	const queryPayload: QueryRangePayload = {


### PR DESCRIPTION
### Summary

- send last log line timestamp for list panel type when the orderBy is `timestamp desc` and is on the first position of orderBy 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
