### PR TITLE
chore: improve colors for the log line indicators and group by severity_text

### DIFF
--- a/frontend/src/components/Logs/LogStateIndicator/LogStateIndicator.styles.scss
+++ b/frontend/src/components/Logs/LogStateIndicator/LogStateIndicator.styles.scss
@@ -22,26 +22,21 @@
 		}
 
 		&.INFO {
-			background-color: var(--bg-slate-400);
+			background-color: var(--bg-robin-500);
 		}
-
 		&.WARNING,
 		&.WARN {
 			background-color: var(--bg-amber-500);
 		}
-
 		&.ERROR {
 			background-color: var(--bg-cherry-500);
 		}
-
 		&.TRACE {
-			background-color: var(--bg-robin-300);
+			background-color: var(--bg-forest-400);
 		}
-
 		&.DEBUG {
-			background-color: var(--bg-forest-500);
+			background-color: var(--bg-aqua-500);
 		}
-
 		&.FATAL {
 			background-color: var(--bg-sakura-500);
 		}

--- a/frontend/src/container/LogsExplorerChart/utils.ts
+++ b/frontend/src/container/LogsExplorerChart/utils.ts
@@ -9,15 +9,18 @@ export function getColorsForSeverityLabels(
 	const lowerCaseLabel = label.toLowerCase();
 
 	if (lowerCaseLabel.includes(`{severity_text="trace"}`)) {
-		return Color.BG_ROBIN_300;
+		return Color.BG_FOREST_400;
 	}
 
 	if (lowerCaseLabel.includes(`{severity_text="debug"}`)) {
-		return Color.BG_FOREST_500;
+		return Color.BG_AQUA_500;
 	}
 
-	if (lowerCaseLabel.includes(`{severity_text="info"}`)) {
-		return Color.BG_SLATE_400;
+	if (
+		lowerCaseLabel.includes(`{severity_text="info"}`) ||
+		lowerCaseLabel.includes(`{severity_text=""}`)
+	) {
+		return Color.BG_ROBIN_500;
 	}
 
 	if (lowerCaseLabel.includes(`{severity_text="warn"}`)) {


### PR DESCRIPTION
### Summary

- update the log state indicator colors and group by severity text chart colors 

#### Related Issues / PR's



#### Screenshots


https://github.com/user-attachments/assets/ff870ff2-94f6-45f8-810e-01c7d1ddfddd



https://github.com/user-attachments/assets/7784fcf8-647e-4014-baba-3c27db504016



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
