### PR TITLE
fix: fixed dashboard header and list title alignment

### DIFF
--- a/frontend/src/container/ListOfDashboard/DashboardList.styles.scss
+++ b/frontend/src/container/ListOfDashboard/DashboardList.styles.scss
@@ -64,7 +64,6 @@
 
 						.dashboard-icon {
 							display: inline-block;
-							margin-top: 4px;
 							margin-right: 4px;
 							line-height: 20px;
 						}
@@ -73,6 +72,12 @@
 							min-height: 6px;
 							min-width: 6px;
 							border-radius: 50%;
+						}
+
+						.title-link {
+							display: flex;
+							align-items: center;
+							gap: 4px;
 						}
 
 						.title {

--- a/frontend/src/container/ListOfDashboard/DashboardList.styles.scss
+++ b/frontend/src/container/ListOfDashboard/DashboardList.styles.scss
@@ -64,8 +64,9 @@
 
 						.dashboard-icon {
 							display: inline-block;
-							margin-right: 4px;
 							line-height: 20px;
+							height: 14px;
+							width: 14px;
 						}
 
 						.dot {
@@ -77,7 +78,7 @@
 						.title-link {
 							display: flex;
 							align-items: center;
-							gap: 4px;
+							gap: 8px;
 						}
 
 						.title {

--- a/frontend/src/container/ListOfDashboard/DashboardsList.tsx
+++ b/frontend/src/container/ListOfDashboard/DashboardsList.tsx
@@ -462,7 +462,6 @@ function DashboardsList(): JSX.Element {
 									<Link to={getLink()} className="title-link">
 										<img
 											src={dashboard?.image || Base64Icons[0]}
-											style={{ height: '14px', width: '14px' }}
 											alt="dashboard-image"
 											className="dashboard-icon"
 										/>

--- a/frontend/src/container/ListOfDashboard/DashboardsList.tsx
+++ b/frontend/src/container/ListOfDashboard/DashboardsList.tsx
@@ -459,17 +459,20 @@ function DashboardsList(): JSX.Element {
 									placement="left"
 									overlayClassName="title-toolip"
 								>
-									<Typography.Text data-testid={`dashboard-title-${index}`}>
-										<Link to={getLink()} className="title">
-											<img
-												src={dashboard?.image || Base64Icons[0]}
-												style={{ height: '14px', width: '14px' }}
-												alt="dashboard-image"
-												className="dashboard-icon"
-											/>
+									<Link to={getLink()} className="title-link">
+										<img
+											src={dashboard?.image || Base64Icons[0]}
+											style={{ height: '14px', width: '14px' }}
+											alt="dashboard-image"
+											className="dashboard-icon"
+										/>
+										<Typography.Text
+											data-testid={`dashboard-title-${index}`}
+											className="title"
+										>
 											{dashboard.name}
-										</Link>
-									</Typography.Text>
+										</Typography.Text>
+									</Link>
 								</Tooltip>
 							</div>
 

--- a/frontend/src/container/NewDashboard/DashboardDescription/Description.styles.scss
+++ b/frontend/src/container/NewDashboard/DashboardDescription/Description.styles.scss
@@ -135,6 +135,11 @@
 			gap: 8px;
 			width: 45%;
 
+			.dashboard-img {
+				height: 16px;
+				width: 16px;
+			}
+
 			.dashboard-title {
 				color: #fff;
 				font-family: Inter;

--- a/frontend/src/container/NewDashboard/DashboardDescription/Description.styles.scss
+++ b/frontend/src/container/NewDashboard/DashboardDescription/Description.styles.scss
@@ -130,7 +130,7 @@
 
 		.left-section {
 			display: flex;
-			flex-wrap: wrap;
+			// flex-wrap: wrap;
 
 			align-items: center;
 			gap: 8px;

--- a/frontend/src/container/NewDashboard/DashboardDescription/Description.styles.scss
+++ b/frontend/src/container/NewDashboard/DashboardDescription/Description.styles.scss
@@ -130,7 +130,6 @@
 
 		.left-section {
 			display: flex;
-			// flex-wrap: wrap;
 
 			align-items: center;
 			gap: 8px;

--- a/frontend/src/container/NewDashboard/DashboardDescription/index.tsx
+++ b/frontend/src/container/NewDashboard/DashboardDescription/index.tsx
@@ -306,11 +306,7 @@ function DashboardDescription(props: DashboardDescriptionProps): JSX.Element {
 			</div>
 			<section className="dashboard-details">
 				<div className="left-section">
-					<img
-						src={image}
-						alt="dashboard-img"
-						style={{ width: '16px', height: '16px' }}
-					/>
+					<img src={image} alt="dashboard-img" className="dashboard-img" />
 					<Tooltip title={title.length > 30 ? title : ''}>
 						<Typography.Text
 							className="dashboard-title"

--- a/frontend/src/container/NewDashboard/DashboardDescription/index.tsx
+++ b/frontend/src/container/NewDashboard/DashboardDescription/index.tsx
@@ -306,16 +306,17 @@ function DashboardDescription(props: DashboardDescriptionProps): JSX.Element {
 			</div>
 			<section className="dashboard-details">
 				<div className="left-section">
+					<img
+						src={image}
+						alt="dashboard-img"
+						style={{ width: '16px', height: '16px' }}
+					/>
 					<Tooltip title={title.length > 30 ? title : ''}>
 						<Typography.Text
 							className="dashboard-title"
 							data-testid="dashboard-title"
 						>
-							<img
-								src={image}
-								alt="dashboard-img"
-								style={{ width: '16px', height: '16px' }}
-							/>{' '}
+							{' '}
 							{title}
 						</Typography.Text>
 					</Tooltip>


### PR DESCRIPTION
### Summary

Aligned header title and list page title properly while maintaining the webkit clamping for larger texts

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

**Dashboard Header Title** 
--------------------

| Before | After |
|---|---|
| <img width="1080" alt="image" src="https://github.com/user-attachments/assets/aef30804-3350-4028-b4f5-00bb6e35c239"> | <img width="1083" alt="image" src="https://github.com/user-attachments/assets/53fbfddb-1136-4901-b15a-68167e7e6131"> |
| <img width="397" alt="image" src="https://github.com/user-attachments/assets/a32c6094-b9b4-4722-8756-f00ae6047530"> | <img width="326" alt="image" src="https://github.com/user-attachments/assets/510e8c79-88bd-4c63-beae-bd3cc9e5cf1a"> |


**Dashboard List Page**
-------------------

| Before | After |
|---|---|
| <img width="915" alt="image" src="https://github.com/user-attachments/assets/423e78e9-2598-4ec3-8328-cf2f4b32ac1d"> | <img width="884" alt="image" src="https://github.com/user-attachments/assets/b16c0472-6514-4a4f-9e3c-a6f1b4361e23"> |


#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
