### PR TITLE
fix: alerts links are broken when there is a space in value

### DIFF
--- a/frontend/src/hooks/queryBuilder/useGetCompositeQueryParam.ts
+++ b/frontend/src/hooks/queryBuilder/useGetCompositeQueryParam.ts
@@ -13,6 +13,7 @@ export const useGetCompositeQueryParam = (): Query | null => {
 		try {
 			if (!compositeQuery) return null;
 
+			// MDN reference - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent#decoding_query_parameters_from_a_url
 			parsedCompositeQuery = JSON.parse(
 				decodeURIComponent(compositeQuery.replace(/\+/g, ' ')),
 			);

--- a/frontend/src/hooks/queryBuilder/useGetCompositeQueryParam.ts
+++ b/frontend/src/hooks/queryBuilder/useGetCompositeQueryParam.ts
@@ -14,6 +14,7 @@ export const useGetCompositeQueryParam = (): Query | null => {
 			if (!compositeQuery) return null;
 
 			// MDN reference - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent#decoding_query_parameters_from_a_url
+			// MDN reference to support + characters using encoding - https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#preserving_plus_signs add later
 			parsedCompositeQuery = JSON.parse(
 				decodeURIComponent(compositeQuery.replace(/\+/g, ' ')),
 			);

--- a/frontend/src/hooks/queryBuilder/useGetCompositeQueryParam.ts
+++ b/frontend/src/hooks/queryBuilder/useGetCompositeQueryParam.ts
@@ -13,7 +13,9 @@ export const useGetCompositeQueryParam = (): Query | null => {
 		try {
 			if (!compositeQuery) return null;
 
-			parsedCompositeQuery = JSON.parse(decodeURIComponent(compositeQuery));
+			parsedCompositeQuery = JSON.parse(
+				decodeURIComponent(compositeQuery.replace(/\+/g, ' ')),
+			);
 		} catch (e) {
 			parsedCompositeQuery = null;
 		}


### PR DESCRIPTION
### Summary

- the alerts link generated from query service encoded space as `%2B` instead of `%20` hence the issue started arising. 
- `decodeURIComponent` recommends replacing `+` signs with space before decoding as a standard practice https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent#decoding_query_parameters_from_a_url. 
- also added the link to another MDN doc on how actually the `+` sign should be supported i.e using `%252B` character. https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#preserving_plus_signs
- TLDR :- `%25` is the escape for `%` character. `%2B` is for `+` sign which is also treated as space in browser

#### Related Issues / PR's

fixes - https://github.com/SigNoz/signoz/issues/6006 

#### Screenshots


https://github.com/user-attachments/assets/a859dc9e-fa17-43e2-abbe-b0bf81aa3da9



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
