### PR TITLE
fix: invalidate the cache for the alerts rules post update call

### DIFF
--- a/frontend/src/container/FormAlertRules/index.tsx
+++ b/frontend/src/container/FormAlertRules/index.tsx
@@ -370,7 +370,10 @@ function FormAlertRules({
 				});
 
 				// invalidate rule in cache
-				ruleCache.invalidateQueries([REACT_QUERY_KEY.ALERT_RULE_DETAILS, ruleId]);
+				ruleCache.invalidateQueries([
+					REACT_QUERY_KEY.ALERT_RULE_DETAILS,
+					`${ruleId}`,
+				]);
 
 				// eslint-disable-next-line sonarjs/no-identical-functions
 				setTimeout(() => {


### PR DESCRIPTION
### Summary

- invalidate the cache after making the save call for the alert. 
- the query key was not matching due to which the cache was not getting invalidated 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/user-attachments/assets/c44b74ed-004e-470e-9f1d-29c323f4696b



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
