### PR TITLE
fix: the tag key flickering when moving from traces to logs

### DIFF
--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.styles.scss
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.styles.scss
@@ -235,16 +235,16 @@
 			}
 
 			&.resource {
-				border: 1px solid rgba(242, 71, 105, 0.2);
+				border: 1px solid #4bcff920;
 
 				.ant-typography {
-					color: var(--bg-sakura-400);
-					background: rgba(245, 108, 135, 0.1);
+					color: var(--bg-aqua-400);
+					background: #4bcff910;
 					font-size: 14px;
 				}
 
 				.ant-tag-close-icon {
-					background: rgba(245, 108, 135, 0.1);
+					background: #4bcff910;
 				}
 			}
 			&.tag {
@@ -343,15 +343,15 @@
 				}
 
 				&.resource {
-					border: 1px solid rgba(242, 71, 105, 0.2);
+					border: 1px solid #4bcff920;
 
 					.ant-typography {
-						color: var(--bg-sakura-400);
-						background: rgba(245, 108, 135, 0.1);
+						color: var(--bg-aqua-400);
+						background: #4bcff910;
 					}
 
 					.ant-tag-close-icon {
-						background: rgba(245, 108, 135, 0.1);
+						background: #4bcff910;
 					}
 				}
 				&.tag {

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
@@ -729,7 +729,7 @@ function QueryBuilderSearchV2(
 	}, [tags]);
 
 	useEffect(() => {
-		if (!isEqual(query.filters.items, tags)) {
+		if (!isEqual(getInitTags(query), tags)) {
 			setTags(getInitTags(query));
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -769,7 +769,7 @@ function QueryBuilderSearchV2(
 	);
 
 	const queryTags = useMemo(
-		() => tags.map((tag) => `${tag.key.key} ${tag.op} ${tag.value}`),
+		() => tags.map((tag) => `${tag.key?.key} ${tag.op} ${tag.value}`),
 		[tags],
 	);
 

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
@@ -729,6 +729,7 @@ function QueryBuilderSearchV2(
 	}, [tags]);
 
 	useEffect(() => {
+		// convert the query and tags to same format before comparison
 		if (!isEqual(getInitTags(query), tags)) {
 			setTags(getInitTags(query));
 		}

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/Suggestions.styles.scss
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/Suggestions.styles.scss
@@ -77,14 +77,14 @@
 
 				&.resource {
 					border-radius: 50px;
-					background: rgba(245, 108, 135, 0.1) !important;
-					color: var(--bg-sakura-400) !important;
+					background: #4bcff910 !important;
+					color: var(--bg-aqua-400) !important;
 
 					.dot {
-						background-color: var(--bg-sakura-400);
+						background-color: var(--bg-aqua-400);
 					}
 					.text {
-						color: var(--bg-sakura-400);
+						color: var(--bg-aqua-400);
 						font-family: Inter;
 						font-size: 12px;
 						font-style: normal;


### PR DESCRIPTION
### Summary

- fixed the flicker in the logs explorer where clause when moving between traces and logs 
- changed the color of resource attributes from `sakura` to `aqua`
- takes care of the sentry issue - https://signoz-io.sentry.io/issues/5892584922/?alert_rule_id=15272042&alert_type=issue&notification_uuid=f164c528-8b0d-4204-89f1-d61995bca3a6&project=4506831143763968&referrer=slack 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/user-attachments/assets/9d23554d-2320-4cf9-89ba-83dbec21056b



#### Affected Areas and Manually Tested Areas

- logs explorer filters 
- logs to traces and vice versa
- logs details page filter additions 
