### PR TITLE
feat: enable new logs schema by default

### DIFF
--- a/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
@@ -151,7 +151,6 @@ services:
       [
         "-config=/root/config/prometheus.yml",
         "--use-logs-new-schema=true"
-        # "--prefer-delta=true"
       ]
     # ports:
     #   - "6060:6060"     # pprof port

--- a/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
@@ -150,6 +150,7 @@ services:
     command:
       [
         "-config=/root/config/prometheus.yml",
+        "--use-logs-new-schema=true"
         # "--prefer-delta=true"
       ]
     # ports:

--- a/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
@@ -144,6 +144,7 @@ exporters:
     dsn: tcp://clickhouse:9000/signoz_logs
     docker_multi_node_cluster: ${DOCKER_MULTI_NODE_CLUSTER}
     timeout: 10s
+    use_new_schema: true
 extensions:
   health_check:
     endpoint: 0.0.0.0:13133

--- a/deploy/docker/clickhouse-setup/docker-compose-local.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose-local.yaml
@@ -25,6 +25,7 @@ services:
     command:
       [
         "-config=/root/config/prometheus.yml",
+        "--use-logs-new-schema=true"
         # "--prefer-delta=true"
       ]
     ports:

--- a/deploy/docker/clickhouse-setup/docker-compose-local.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose-local.yaml
@@ -26,7 +26,6 @@ services:
       [
         "-config=/root/config/prometheus.yml",
         "--use-logs-new-schema=true"
-        # "--prefer-delta=true"
       ]
     ports:
       - "6060:6060"

--- a/deploy/docker/clickhouse-setup/docker-compose.testing.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.testing.yaml
@@ -169,7 +169,8 @@ services:
     command:
       [
         "-config=/root/config/prometheus.yml",
-        "-gateway-url=https://api.staging.signoz.cloud"
+        "-gateway-url=https://api.staging.signoz.cloud",
+        "--use-logs-new-schema=true"
         # "--prefer-delta=true"
       ]
     # ports:

--- a/deploy/docker/clickhouse-setup/docker-compose.testing.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.testing.yaml
@@ -171,7 +171,6 @@ services:
         "-config=/root/config/prometheus.yml",
         "-gateway-url=https://api.staging.signoz.cloud",
         "--use-logs-new-schema=true"
-        # "--prefer-delta=true"
       ]
     # ports:
     #   - "6060:6060"     # pprof port

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -168,7 +168,8 @@ services:
     container_name: signoz-query-service
     command:
       [
-        "-config=/root/config/prometheus.yml"
+        "-config=/root/config/prometheus.yml",
+        "--use-logs-new-schema=true"
         # "--prefer-delta=true"
       ]
     # ports:

--- a/deploy/docker/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.yaml
@@ -170,7 +170,6 @@ services:
       [
         "-config=/root/config/prometheus.yml",
         "--use-logs-new-schema=true"
-        # "--prefer-delta=true"
       ]
     # ports:
     #   - "6060:6060"     # pprof port

--- a/deploy/docker/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker/clickhouse-setup/otel-collector-config.yaml
@@ -154,6 +154,7 @@ exporters:
     dsn: tcp://clickhouse:9000/signoz_logs
     docker_multi_node_cluster: ${DOCKER_MULTI_NODE_CLUSTER}
     timeout: 10s
+    use_new_schema: true
   # logging: {}
 
 service:

--- a/pkg/query-service/tests/test-deploy/docker-compose.yaml
+++ b/pkg/query-service/tests/test-deploy/docker-compose.yaml
@@ -158,6 +158,7 @@ services:
     command:
       [
         "-config=/root/config/prometheus.yml",
+        "--use-logs-new-schema=true"
         # "--prefer-delta=true"
       ]
     # ports:

--- a/pkg/query-service/tests/test-deploy/docker-compose.yaml
+++ b/pkg/query-service/tests/test-deploy/docker-compose.yaml
@@ -159,7 +159,6 @@ services:
       [
         "-config=/root/config/prometheus.yml",
         "--use-logs-new-schema=true"
-        # "--prefer-delta=true"
       ]
     # ports:
     #   - "6060:6060"     # pprof port

--- a/pkg/query-service/tests/test-deploy/otel-collector-config.yaml
+++ b/pkg/query-service/tests/test-deploy/otel-collector-config.yaml
@@ -115,6 +115,7 @@ exporters:
     dsn: tcp://clickhouse:9000/signoz_logs
     docker_multi_node_cluster: ${DOCKER_MULTI_NODE_CLUSTER}
     timeout: 10s
+    use_new_schema: true
   # logging: {}
 
 service:


### PR DESCRIPTION
#### Summary

- update all docker compose YAMLs to use new logs schema
- enable `use_new_schema ` flag for clickhouselogsexporter in otel-collector config YAMLs
- remove prefer delta from docker-compose YAMLs