### PR TITLE
fix: add v4 to the new alert payload

### DIFF
--- a/frontend/src/api/alerts/create.ts
+++ b/frontend/src/api/alerts/create.ts
@@ -7,6 +7,7 @@ const create = async (
 ): Promise<SuccessResponse<PayloadProps> | ErrorResponse> => {
 	const response = await axios.post('/rules', {
 		...props.data,
+		version: 'v4',
 	});
 
 	return {


### PR DESCRIPTION
### Summary
send version=v4 with new alert payload
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
Part of https://github.com/SigNoz/engineering-pod/issues/1824#issuecomment-2376986112 of https://github.com/SigNoz/engineering-pod/issues/1824

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
