### PR TITLE
Add onboarding APIs to check the attributes for Messaging Queues feature

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -2600,7 +2600,7 @@ func (aH *APIHandler) onboardConsumers(
 		return
 	}
 
-	chq, err := mq.BuildClickHouseQuery(messagingQueue, mq.KafkaQueue, "onboard_producers")
+	chq, err := mq.BuildClickHouseQuery(messagingQueue, mq.KafkaQueue, "onboard_consumers")
 
 	if err != nil {
 		zap.L().Error(err.Error())
@@ -2650,7 +2650,7 @@ func (aH *APIHandler) onboardConsumers(
 				attribute = "kind"
 				if intValue != 0 {
 					status = "0"
-					message = "check if your producer spans has kind=4 as attribute"
+					message = "check if your consumer spans has kind=5 as attribute"
 				} else {
 					status = "1"
 				}
@@ -2720,6 +2720,10 @@ func (aH *APIHandler) onboardConsumers(
 			entries = append(entries, entry)
 		}
 	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Attribute < entries[j].Attribute
+	})
 
 	aH.Respond(w, entries)
 }
@@ -2800,6 +2804,10 @@ func (aH *APIHandler) onboardKafka(
 			entries = append(entries, entry)
 		}
 	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Attribute < entries[j].Attribute
+	})
 
 	aH.Respond(w, entries)
 }

--- a/pkg/query-service/app/integrations/messagingQueues/kafka/consumerLag.md
+++ b/pkg/query-service/app/integrations/messagingQueues/kafka/consumerLag.md
@@ -230,89 +230,292 @@ Response in query range `table` format
 ### Onboarding APIs
 
 ```
-/api/v1/messaging-queues/kafka/consumer-lag/onboarding-producers
+/api/v1/messaging-queues/kafka/onboarding/producers
 ```
 
+```json
+{
+    "start": 1727620544260611424,
+    "end": 1727620556401481428
+}
 ```
+
+```json
+// everything is present
 {
     "status": "success",
-    "data": {
-        "resultType": "",
-        "result": [
-            {
-                "queryName": "onboard_producers",
-                "series": [
-                    {
-                        "labels": {},
-                        "labelsArray": [
-                            {
-                                "result": "All attributes are present and meet the conditions"
-                            }
-                        ],
-                        "values": []
-                    }
-                ]
-            }
-        ]
-    }
+    "data": [
+        {
+            "attribute": "kind",
+            "error_message": "",
+            "status": "1"
+        },
+        {
+            "attribute": "messaging.destination.name",
+            "error_message": "",
+            "status": "1"
+        },
+        {
+            "attribute": "messaging.destination.partition.id",
+            "error_message": "messaging.destination.partition.id attribute is not present in your spans",
+            "status": "0"
+        },
+        {
+            "attribute": "messaging.system",
+            "error_message": "",
+            "status": "1"
+        },
+        {
+            "attribute": "telemetry ingestion",
+            "error_message": "",
+            "status": "1"
+        }
+    ]
+}
+
+// partial attributes are present
+{
+    "status": "success",
+    "data": [
+        {
+            "attribute": "kind",
+            "error_message": "",
+            "status": "1"
+        },
+        {
+            "attribute": "messaging.destination.name",
+            "error_message": "messaging.destination.name attribute is not present in your spans",
+            "status": "0"
+        },
+        {
+            "attribute": "messaging.destination.partition.id",
+            "error_message": "",
+            "status": "1"
+        },
+        {
+            "attribute": "messaging.system",
+            "error_message": "",
+            "status": "1"
+        },
+        {
+            "attribute": "telemetry ingestion",
+            "error_message": "",
+            "status": "1"
+        }
+    ]
+}
+
+// no data available
+{
+    "status": "success",
+    "data": [
+        {
+            "attribute": "telemetry ingestion",
+            "error_message": "No data available in the given time range",
+            "status": "0"
+        }
+    ]
 }
 ```
 
 
 ```
-/api/v1/messaging-queues/kafka/consumer-lag/onboarding-consumers
+/api/v1/messaging-queues/kafka/onboarding/consumers
 ```
 
-```
+```json
+// everything is present
 {
-    "status": "success",
-    "data": {
-        "resultType": "",
-        "result": [
-            {
-                "queryName": "onboard_consumers",
-                "series": [
-                    {
-                        "labels": {},
-                        "labelsArray": [
-                            {
-                                "result": "All attributes are present and meet the conditions"
-                            }
-                        ],
-                        "values": []
-                    }
-                ]
-            }
-        ]
+  "status": "success",
+  "data": [
+    {
+      "attribute": "kind",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "messaging.client_id",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "messaging.destination.name",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "messaging.destination.partition.id",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "messaging.kafka.consumer.group",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "messaging.message.body.size",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "messaging.system",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "service.instance.id",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "service_name",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "telemetry ingestion",
+      "error_message": "",
+      "status": "1"
     }
+  ]
+}
+
+// partial attributes are present
+{
+  "status": "success",
+  "data": [
+    {
+      "attribute": "kind",
+      "error_message": "check if your consumer spans has kind=5 as attribute",
+      "status": "0"
+    },
+    {
+      "attribute": "messaging.client_id",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "messaging.destination.name",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "messaging.destination.partition.id",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "messaging.kafka.consumer.group",
+      "error_message": "messaging.kafka.consumer.group attribute is not present in your spans",
+      "status": "0"
+    },
+    {
+      "attribute": "messaging.message.body.size",
+      "error_message": "messaging.message.body.size attribute is not present in your spans",
+      "status": "0"
+    },
+    {
+      "attribute": "messaging.system",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "service.instance.id",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "service_name",
+      "error_message": "",
+      "status": "1"
+    },
+    {
+      "attribute": "telemetry ingestion",
+      "error_message": "",
+      "status": "1"
+    }
+  ]
+}
+
+// no data available
+{
+  "status": "success",
+  "data": [
+    {
+      "attribute": "telemetry ingestion",
+      "error_message": "No data available in the given time range",
+      "status": "0"
+    }
+  ]
 }
 ```
 
 ```
-127.0.0.1:8080/api/v1/messaging-queues/kafka/consumer-lag/onboarding-kafka
+/api/v1/messaging-queues/kafka/onboarding/kafka
 ```
 
+```json
+{
+    "start": 1728485200000000000,
+    "end": 1728749800000000000
+}
 ```
+
+```json
+// everything is present
 {
     "status": "success",
-    "data": {
-        "resultType": "",
-        "result": [
-            {
-                "queryName": "onboard_consumers",
-                "series": [
-                    {
-                        "labels": {},
-                        "labelsArray": [
-                            {
-                                "result": "Neither metric (kafka_consumer_fetch_latency_avg nor kafka_consumer_group_lag) is present in the given time range."
-                            }
-                        ],
-                        "values": []
-                    }
-                ]
-            }
-        ]
-    }
+    "data": [
+        {
+            "attribute": "telemetry ingestion",
+            "error_message": "",
+            "status": "1"
+        },
+        {
+            "attribute": "kafka_consumer_fetch_latency_avg",
+            "error_message": "Metric kafka_consumer_fetch_latency_avg is not present in the given time range.",
+            "status": "0"
+        },
+        {
+            "attribute": "kafka_consumer_group_lag",
+            "error_message": "Metric kafka_consumer_group_lag is not present in the given time range.",
+            "status": "0"
+        }
+    ]
+}
+
+// partial attributes are present
+{
+    "status": "success",
+    "data": [
+        {
+            "attribute": "telemetry ingestion",
+            "error_message": "",
+            "status": "1"
+        },
+        {
+            "attribute": "kafka_consumer_fetch_latency_avg",
+            "error_message": "",
+            "status": "1"
+        },
+        {
+            "attribute": "kafka_consumer_group_lag",
+            "error_message": "",
+            "status": "1"
+        }
+    ]
+}
+
+// no data available
+{
+    "status": "success",
+    "data": [
+        {
+            "attribute": "telemetry ingestion",
+            "error_message": "No data available in the given time range",
+            "status": "0"
+        }
+    ]
 }
 ```

--- a/pkg/query-service/app/integrations/messagingQueues/kafka/consumerLag.md
+++ b/pkg/query-service/app/integrations/messagingQueues/kafka/consumerLag.md
@@ -226,3 +226,93 @@ Response in query range `table` format
   }
 }
 ```
+
+### Onboarding APIs
+
+```
+/api/v1/messaging-queues/kafka/consumer-lag/onboarding-producers
+```
+
+```
+{
+    "status": "success",
+    "data": {
+        "resultType": "",
+        "result": [
+            {
+                "queryName": "onboard_producers",
+                "series": [
+                    {
+                        "labels": {},
+                        "labelsArray": [
+                            {
+                                "result": "All attributes are present and meet the conditions"
+                            }
+                        ],
+                        "values": []
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+
+```
+/api/v1/messaging-queues/kafka/consumer-lag/onboarding-consumers
+```
+
+```
+{
+    "status": "success",
+    "data": {
+        "resultType": "",
+        "result": [
+            {
+                "queryName": "onboard_consumers",
+                "series": [
+                    {
+                        "labels": {},
+                        "labelsArray": [
+                            {
+                                "result": "All attributes are present and meet the conditions"
+                            }
+                        ],
+                        "values": []
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+```
+127.0.0.1:8080/api/v1/messaging-queues/kafka/consumer-lag/onboarding-kafka
+```
+
+```
+{
+    "status": "success",
+    "data": {
+        "resultType": "",
+        "result": [
+            {
+                "queryName": "onboard_consumers",
+                "series": [
+                    {
+                        "labels": {},
+                        "labelsArray": [
+                            {
+                                "result": "Neither metric (kafka_consumer_fetch_latency_avg nor kafka_consumer_group_lag) is present in the given time range."
+                            }
+                        ],
+                        "values": []
+                    }
+                ]
+            }
+        ]
+    }
+}
+```

--- a/pkg/query-service/app/integrations/messagingQueues/kafka/model.go
+++ b/pkg/query-service/app/integrations/messagingQueues/kafka/model.go
@@ -1,6 +1,6 @@
 package kafka
 
-const kafkaQueue = "kafka"
+const KafkaQueue = "kafka"
 
 type MessagingQueue struct {
 	Start     int64             `json:"start"`
@@ -13,4 +13,10 @@ type Clients struct {
 	ClientID          []string
 	ServiceInstanceID []string
 	ServiceName       []string
+}
+
+type OnboardingResponse struct {
+	Attribute string `json:"attribute"`
+	Message   string `json:"error_message"`
+	Status    string `json:"status"`
 }

--- a/pkg/query-service/app/integrations/messagingQueues/kafka/sql.go
+++ b/pkg/query-service/app/integrations/messagingQueues/kafka/sql.go
@@ -99,58 +99,50 @@ ORDER BY throughput DESC
 func onboardProducersSQL(start, end int64, queueType string) string {
 	query := fmt.Sprintf(`
 SELECT 
-	CASE 
-		WHEN COUNT(*) = 0 THEN 1
-		WHEN SUM(msgSystem = '%s') = 0 THEN 2
-		WHEN SUM(kind = 4) = 0 THEN 3
-		WHEN SUM(has(stringTagMap, 'messaging.destination.name')) = 0 THEN 4
-		WHEN SUM(has(stringTagMap, 'messaging.destination.partition.id')) = 0 THEN 5
-		ELSE 0
-	END AS result_code
-FROM signoz_traces.distributed_signoz_index_v2
+    COUNT(*) = 0 AS entries,
+    COUNT(IF(msgSystem = '%s', 1, NULL)) = 0 AS queue,
+    COUNT(IF(kind = 4, 1, NULL)) = 0 AS kind,
+    COUNT(IF(has(stringTagMap, 'messaging.destination.name'), 1, NULL)) = 0 AS destination,
+    COUNT(IF(has(stringTagMap, 'messaging.destination.partition.id'), 1, NULL)) = 0 AS partition
+FROM 
+    signoz_traces.distributed_signoz_index_v2
 WHERE 
-	timestamp >= '%d'
-	AND timestamp <= '%d';`, queueType, start, end)
+    timestamp >= '%d'
+    AND timestamp <= '%d';`, queueType, start, end)
 	return query
 }
 
 func onboardConsumerSQL(start, end int64, queueType string) string {
 	query := fmt.Sprintf(`
-SELECT 
-	CASE 
-		WHEN COUNT(*) = 0 THEN 1
-		WHEN SUM(msgSystem = '%s') = 0 THEN 2
-		WHEN SUM(kind = 5) = 0 THEN 3
-		WHEN SUM(serviceName IS NOT NULL) = 0 THEN 4
-		WHEN SUM(has(stringTagMap, 'messaging.destination.name')) = 0 THEN 5
-		WHEN SUM(has(stringTagMap, 'messaging.destination.partition.id')) = 0 THEN 6
-		WHEN SUM(has(stringTagMap, 'messaging.kafka.consumer.group')) = 0 THEN 7
-		WHEN SUM(has(numberTagMap, 'messaging.message.body.size')) = 0 THEN 8
-		WHEN SUM(has(stringTagMap, 'messaging.client_id')) = 0 THEN 9
-		WHEN SUM(has(stringTagMap, 'service.instance.id')) = 0 THEN 10
-		ELSE 0
-	END AS result_code
+SELECT  
+    COUNT(*) = 0 AS entries,
+    COUNT(IF(msgSystem = '%s', 1, NULL)) = 0 AS queue,
+    COUNT(IF(kind = 5, 1, NULL)) = 0 AS kind,
+    COUNT(serviceName) = 0 AS svc,
+    COUNT(IF(has(stringTagMap, 'messaging.destination.name'), 1, NULL)) = 0 AS destination,
+    COUNT(IF(has(stringTagMap, 'messaging.destination.partition.id'), 1, NULL)) = 0 AS partition,
+    COUNT(IF(has(stringTagMap, 'messaging.kafka.consumer.group'), 1, NULL)) = 0 AS cgroup,
+    COUNT(IF(has(numberTagMap, 'messaging.message.body.size'), 1, NULL)) = 0 AS bodysize,
+    COUNT(IF(has(stringTagMap, 'messaging.client_id'), 1, NULL)) = 0 AS clientid,
+    COUNT(IF(has(stringTagMap, 'service.instance.id'), 1, NULL)) = 0 AS instanceid
 FROM signoz_traces.distributed_signoz_index_v2
 WHERE 
-	timestamp >= '%d'
-	AND timestamp <= '%d';`, queueType, start, end)
+    timestamp >= '%d'
+    AND timestamp <= '%d';`, queueType, start, end)
 	return query
 }
 
 func onboardKafkaSQL(start, end int64) string {
 	query := fmt.Sprintf(`
-SELECT
-	CASE
-		WHEN COUNT(CASE WHEN metric_name = 'kafka_consumer_fetch_latency_avg' THEN 1 END) = 0
-            AND COUNT(CASE WHEN metric_name = 'kafka_consumer_group_lag' THEN 1 END) = 0 THEN 1
-		WHEN COUNT(CASE WHEN metric_name = 'kafka_consumer_fetch_latency_avg' THEN 1 END) = 0 THEN 2
-		WHEN COUNT(CASE WHEN metric_name = 'kafka_consumer_group_lag' THEN 1 END) = 0 THEN 3
-		ELSE 0
-	END AS result_code
-FROM signoz_metrics.time_series_v4_1day
+SELECT 
+    COUNT(*) = 0 AS entries,
+    COUNT(IF(metric_name = 'kafka_consumer_fetch_latency_avg', 1, NULL)) = 0 AS fetchlatency,
+    COUNT(IF(metric_name = 'kafka_consumer_group_lag', 1, NULL)) = 0 AS grouplag
+FROM 
+    signoz_metrics.time_series_v4_1day
 WHERE
-	metric_name IN ('kafka_consumer_fetch_latency_avg', 'kafka_consumer_group_lag')
-	AND unix_milli >= '%d'
-	AND unix_milli < '%d';`, start, end)
+    metric_name IN ('kafka_consumer_fetch_latency_avg', 'kafka_consumer_group_lag')
+    AND unix_milli >= '%d'
+    AND unix_milli < '%d';`, start/1000000, end/1000000)
 	return query
 }

--- a/pkg/query-service/app/integrations/messagingQueues/kafka/translator.go
+++ b/pkg/query-service/app/integrations/messagingQueues/kafka/translator.go
@@ -13,15 +13,15 @@ var defaultStepInterval int64 = 60
 func BuildQueryRangeParams(messagingQueue *MessagingQueue, queryContext string) (*v3.QueryRangeParamsV3, error) {
 
 	// ToDo: propagate this through APIs when there are different handlers
-	queueType := kafkaQueue
+	queueType := KafkaQueue
 
-	var cq *v3.CompositeQuery
-
-	chq, err := buildClickHouseQuery(messagingQueue, queueType, queryContext)
+	chq, err := BuildClickHouseQuery(messagingQueue, queueType, queryContext)
 
 	if err != nil {
 		return nil, err
 	}
+
+	var cq *v3.CompositeQuery
 
 	cq, err = buildCompositeQuery(chq, queryContext)
 
@@ -35,6 +35,14 @@ func BuildQueryRangeParams(messagingQueue *MessagingQueue, queryContext string) 
 	}
 
 	return queryRangeParams, nil
+}
+
+func PrepareClikhouseQueries(messagingQueue *MessagingQueue, queryContext string) (*v3.ClickHouseQuery, error) {
+	queueType := KafkaQueue
+
+	chq, err := BuildClickHouseQuery(messagingQueue, queueType, queryContext)
+
+	return chq, err
 }
 
 func buildClickHouseQueryNetwork(messagingQueue *MessagingQueue, queueType string) (*v3.ClickHouseQuery, error) {
@@ -137,7 +145,7 @@ func buildBuilderQueriesNetwork(unixMilliStart, unixMilliEnd int64, attributeCac
 
 func BuildQRParamsNetwork(messagingQueue *MessagingQueue, queryContext string, attributeCache *Clients) (*v3.QueryRangeParamsV3, error) {
 
-	queueType := kafkaQueue
+	queueType := KafkaQueue
 
 	unixMilliStart := messagingQueue.Start / 1000000
 	unixMilliEnd := messagingQueue.End / 1000000
@@ -177,7 +185,7 @@ func BuildQRParamsNetwork(messagingQueue *MessagingQueue, queryContext string, a
 	return queryRangeParams, nil
 }
 
-func buildClickHouseQuery(messagingQueue *MessagingQueue, queueType string, queryContext string) (*v3.ClickHouseQuery, error) {
+func BuildClickHouseQuery(messagingQueue *MessagingQueue, queueType string, queryContext string) (*v3.ClickHouseQuery, error) {
 	start := messagingQueue.Start
 	end := messagingQueue.End
 


### PR DESCRIPTION
Fixes: https://github.com/SigNoz/engineering-pod/issues/1834
Epic: https://github.com/SigNoz/engineering-pod/issues/1584

These APIs would help identify the attributes that need to be there for correlation, it also helps in health checks to verify that the user is sending correct data.

For producers, consumers and kafka, it returns the corresponding checks and returns attributes which are not present.
<img width="738" alt="Screenshot 2024-10-04 at 1 31 25 AM" src="https://github.com/user-attachments/assets/73167e0c-e592-434e-8b4b-4f6acdb47b93">


Example of the UI https://www.notion.so/signoz/Engineering-Design-Doc-for-Kafka-d9db4d601519404c9e93d5f509efd037?pvs=4#d21d7ac0d983455f9ce824c9f6355d0b