### PR TITLE
feat: added info funct for panels in dashaboard layout for showing description

### DIFF
--- a/frontend/src/container/GridCardLayout/WidgetHeader/WidgetHeader.styles.scss
+++ b/frontend/src/container/GridCardLayout/WidgetHeader/WidgetHeader.styles.scss
@@ -20,6 +20,14 @@
 	}
 }
 
+.widget-header-title-container {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 .widget-header-title {
 	max-width: 80%;
 }

--- a/frontend/src/container/GridCardLayout/WidgetHeader/WidgetHeader.styles.scss
+++ b/frontend/src/container/GridCardLayout/WidgetHeader/WidgetHeader.styles.scss
@@ -58,3 +58,17 @@
 		}
 	}
 }
+
+.long-tooltip {
+	.ant-tooltip-content {
+		max-height: 500px;
+		overflow: auto;
+	}
+	&.ant-tooltip {
+		max-width: 500px;
+	}
+}
+
+.info-tooltip {
+	cursor: pointer;
+}

--- a/frontend/src/container/GridCardLayout/WidgetHeader/index.tsx
+++ b/frontend/src/container/GridCardLayout/WidgetHeader/index.tsx
@@ -235,13 +235,25 @@ function WidgetHeader({
 				/>
 			) : (
 				<>
-					<Typography.Text
-						ellipsis
-						data-testid={title}
-						className="widget-header-title"
-					>
-						{title}
-					</Typography.Text>
+					<div className="widget-header-title-container">
+						<Typography.Text
+							ellipsis
+							data-testid={title}
+							className="widget-header-title"
+						>
+							{title}
+						</Typography.Text>
+						{widget.description && (
+							<Tooltip
+								title={widget.description}
+								overlayClassName="long-tooltip"
+								className="info-tooltip"
+								placement="right"
+							>
+								<InfoCircleOutlined />
+							</Tooltip>
+						)}
+					</div>
 					<div className="widget-header-actions">
 						<div className="widget-api-actions">{threshold}</div>
 						{isFetchingResponse && !queryResponse.isError && (
@@ -272,15 +284,6 @@ function WidgetHeader({
 								onClick={(): void => setShowGlobalSearch(true)}
 								data-testid="widget-header-search"
 							/>
-						)}
-						{widget.description && (
-							<Tooltip
-								title={widget.description}
-								overlayClassName="long-tooltip"
-								className="info-tooltip"
-							>
-								<InfoCircleOutlined />
-							</Tooltip>
 						)}
 						<Dropdown menu={menu} trigger={['hover']} placement="bottomRight">
 							<MoreOutlined

--- a/frontend/src/container/GridCardLayout/WidgetHeader/index.tsx
+++ b/frontend/src/container/GridCardLayout/WidgetHeader/index.tsx
@@ -8,6 +8,7 @@ import {
 	EditFilled,
 	ExclamationCircleOutlined,
 	FullscreenOutlined,
+	InfoCircleOutlined,
 	MoreOutlined,
 	SearchOutlined,
 	WarningOutlined,
@@ -271,6 +272,15 @@ function WidgetHeader({
 								onClick={(): void => setShowGlobalSearch(true)}
 								data-testid="widget-header-search"
 							/>
+						)}
+						{widget.description && (
+							<Tooltip
+								title={widget.description}
+								overlayClassName="long-tooltip"
+								className="info-tooltip"
+							>
+								<InfoCircleOutlined />
+							</Tooltip>
 						)}
 						<Dropdown menu={menu} trigger={['hover']} placement="bottomRight">
 							<MoreOutlined

--- a/frontend/src/container/GridCardLayout/WidgetHeader/index.tsx
+++ b/frontend/src/container/GridCardLayout/WidgetHeader/index.tsx
@@ -6,7 +6,6 @@ import {
 	CopyOutlined,
 	DeleteOutlined,
 	EditFilled,
-	ExclamationCircleOutlined,
 	FullscreenOutlined,
 	InfoCircleOutlined,
 	MoreOutlined,
@@ -22,7 +21,7 @@ import useComponentPermission from 'hooks/useComponentPermission';
 import history from 'lib/history';
 import { RowData } from 'lib/query/createTableColumnsFromQuery';
 import { isEmpty } from 'lodash-es';
-import { X } from 'lucide-react';
+import { CircleX, X } from 'lucide-react';
 import { unparse } from 'papaparse';
 import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { UseQueryResult } from 'react-query';
@@ -265,7 +264,7 @@ function WidgetHeader({
 								placement={errorTooltipPosition}
 								className="widget-api-actions"
 							>
-								<ExclamationCircleOutlined />
+								<CircleX size={20} />
 							</Tooltip>
 						)}
 


### PR DESCRIPTION
### Summary

Added icon next to title - which on hover will show the description added under the dashboard

#### Related Issues / PR's

https://github.com/SigNoz/signoz/issues/5788

#### Screenshots


https://github.com/user-attachments/assets/36d68e30-1147-463c-8aba-da72baa8922d



#### Affected Areas and Manually Tested Areas

- tested different dashboard panels
- service page, as these also use widgetHeader component

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds an info icon in `WidgetHeader` to display widget descriptions using a tooltip with new styles for long descriptions.
> 
>   - **Behavior**:
>     - Adds an info icon in `WidgetHeader` to display widget descriptions using a tooltip.
>     - Tooltip is shown only if `widget.description` is present.
>   - **Styles**:
>     - Adds `.long-tooltip` and `.info-tooltip` classes in `WidgetHeader.styles.scss` to style the tooltip for long descriptions.
>     - Updates `.widget-header-title-container` to accommodate the info icon.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for b005e0304442cd48e9a74c8bad66a66b53599aa8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->