### PR TITLE
chore: hide promql from panel type - pie

### DIFF
--- a/frontend/src/container/NewWidget/LeftContainer/QuerySection/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/QuerySection/index.tsx
@@ -214,7 +214,7 @@ function QuerySection({
 	useEffect(() => {
 		// switch to query builder if query type is not supported
 		if (
-			selectedGraph === PANEL_TYPES.TABLE &&
+			(selectedGraph === PANEL_TYPES.TABLE || selectedGraph === PANEL_TYPES.PIE) &&
 			currentQuery.queryType === EQueryType.PROM
 		) {
 			handleQueryCategoryChange(EQueryType.QUERY_BUILDER);

--- a/frontend/src/container/NewWidget/utils.ts
+++ b/frontend/src/container/NewWidget/utils.ts
@@ -517,11 +517,7 @@ export const PANEL_TYPE_TO_QUERY_TYPES: Record<PANEL_TYPES, EQueryType[]> = {
 		EQueryType.CLICKHOUSE,
 		EQueryType.PROM,
 	],
-	[PANEL_TYPES.PIE]: [
-		EQueryType.QUERY_BUILDER,
-		EQueryType.CLICKHOUSE,
-		EQueryType.PROM,
-	],
+	[PANEL_TYPES.PIE]: [EQueryType.QUERY_BUILDER, EQueryType.CLICKHOUSE],
 	[PANEL_TYPES.HISTOGRAM]: [
 		EQueryType.QUERY_BUILDER,
 		EQueryType.CLICKHOUSE,


### PR DESCRIPTION
### Summary

Removed PromQL from Pie Panel type

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/user-attachments/assets/5f94a655-a28c-4349-b5f4-182c6806b8f0



#### Affected Areas and Manually Tested Areas

- tested dashboard edit mode with different panel types
- tested panel type switch and default query-type selection - (like should switch to query-builder type when switching to panel type to pie panel)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove PromQL support for pie panel type by updating query handling logic and mappings.
> 
>   - **Behavior**:
>     - In `index.tsx`, switch to query builder if `PANEL_TYPES.PIE` and `EQueryType.PROM` are selected.
>     - Update `PANEL_TYPE_TO_QUERY_TYPES` in `utils.ts` to exclude `EQueryType.PROM` for `PANEL_TYPES.PIE`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 122f34e4da8c11083c39b5e770017d5a091a0331. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->