### PR TITLE
style: update chart container padding and legend height, closes #1880

### DIFF
--- a/frontend/src/container/FormAlertRules/ChartPreview/styles.ts
+++ b/frontend/src/container/FormAlertRules/ChartPreview/styles.ts
@@ -36,7 +36,7 @@ export const ChartContainer = styled(Card)`
 
 	.ant-card-body {
 		padding: 1.5rem 0;
+		padding-bottom: 80px;
 		height: 57vh;
-		/* padding-bottom: 2rem; */
 	}
 `;

--- a/frontend/src/container/FormAlertRules/FormAlertRules.styles.scss
+++ b/frontend/src/container/FormAlertRules/FormAlertRules.styles.scss
@@ -36,6 +36,20 @@
 		width: 100% !important;
 	}
 }
+.alert-details {
+	&__chart-container {
+		.u-legend {
+			max-height: 84px; // overriding the 30px height of the legend for better interaction
+			min-height: 84px;
+			padding: 16px;
+			text-align: left;
+
+			.darkMode & {
+				background-color: var(--bg-ink-300);
+			}
+		}
+	}
+}
 
 .lightMode {
 	.main-container {

--- a/frontend/src/container/FormAlertRules/index.tsx
+++ b/frontend/src/container/FormAlertRules/index.tsx
@@ -627,7 +627,7 @@ function FormAlertRules({
 						initialValues={initialValue}
 						layout="vertical"
 						form={formInstance}
-						className="main-container"
+						className="main-container alert-details__chart-container"
 					>
 						{currentQuery.queryType === EQueryType.QUERY_BUILDER &&
 							renderQBChartPreview()}


### PR DESCRIPTION
### Summary
The chart legend on the Alert Detail page currently has spacing issues, making it difficult to read and interact with. The goal is to adjust the spacing to improve the visual clarity and overall user experience, ensuring the legend is easily discoverable and clickable.

#### Related Issues / PR's
https://github.com/SigNoz/engineering-pod/issues/1880

#### Screenshots
<img width="1918" alt="image" src="https://github.com/user-attachments/assets/fedbc60b-0298-4f10-a690-21e55ceb60a1">
<img width="1752" alt="image" src="https://github.com/user-attachments/assets/64d5d1fc-2896-4761-9ef7-0eb6657657ae">

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjust chart container padding and legend height for better readability in the Alert Detail page.
> 
>   - **Styles**:
>     - Update `ChartContainer` in `styles.ts` to set `padding-bottom` to `80px`.
>     - Modify `.alert-details__chart-container .u-legend` in `FormAlertRules.styles.scss` to set `max-height` and `min-height` to `84px`, and add `padding` of `16px`.
>   - **Classes**:
>     - Add `alert-details__chart-container` class to `MainFormContainer` in `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for f2fb211907967efc2fae48b45a207614a9d82ea8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->