### PR TITLE
chore: update react router dom to 5.3.4

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -87,6 +87,8 @@
 		"lodash-es": "^4.17.21",
 		"lucide-react": "0.379.0",
 		"mini-css-extract-plugin": "2.4.5",
+		"overlayscrollbars": "^2.8.1",
+		"overlayscrollbars-react": "^0.5.6",
 		"papaparse": "5.4.1",
 		"posthog-js": "1.160.3",
 		"rc-tween-one": "3.0.6",
@@ -106,12 +108,10 @@
 		"react-markdown": "8.0.7",
 		"react-query": "3.39.3",
 		"react-redux": "^7.2.2",
-		"react-router-dom": "^5.2.0",
+		"react-router-dom": "5.3.4",
 		"react-syntax-highlighter": "15.5.0",
 		"react-use": "^17.3.2",
 		"react-virtuoso": "4.0.3",
-		"overlayscrollbars-react": "^0.5.6",
-		"overlayscrollbars": "^2.8.1",
 		"redux": "^4.0.5",
 		"redux-thunk": "^2.3.0",
 		"rehype-raw": "7.0.0",
@@ -239,6 +239,7 @@
 		"debug": "4.3.4",
 		"semver": "7.5.4",
 		"xml2js": "0.5.0",
-		"phin": "^3.7.1"
+		"phin": "^3.7.1",
+		"path-to-regexp": "0.1.10"
 	}
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14258,9 +14258,9 @@ react-resizable@^3.0.4:
     prop-types "15.x"
     react-draggable "^4.0.3"
 
-react-router-dom@^5.2.0:
+react-router-dom@5.3.4:
   version "5.3.4"
-  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.4.tgz#2ed62ffd88cae6db134445f4a0c0ae8b91d2e5e6"
   integrity sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==
   dependencies:
     "@babel/runtime" "^7.12.13"


### PR DESCRIPTION
chore: package updates
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `react-router-dom` to 5.3.4 and add `overlayscrollbars`, `overlayscrollbars-react`, and `path-to-regexp` to `package.json`.
> 
>   - **Dependencies**:
>     - Update `react-router-dom` to version `5.3.4` in `package.json`.
>     - Add `overlayscrollbars` and `overlayscrollbars-react` to `dependencies` in `package.json`.
>   - **Resolutions**:
>     - Add `path-to-regexp` version `0.1.10` to `resolutions` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 82d6d94ee9f5643559b0df354b92920e7662dc48. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->