### PR TITLE
Revert "chore(deps): bump uplot from 1.6.26 to 1.6.31 in /frontend"

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -123,7 +123,7 @@
 		"ts-node": "^10.2.1",
 		"tsconfig-paths-webpack-plugin": "^3.5.1",
 		"typescript": "^4.0.5",
-		"uplot": "1.6.31",
+		"uplot": "1.6.26",
 		"uuid": "^8.3.2",
 		"web-vitals": "^0.2.4",
 		"webpack": "5.88.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16504,10 +16504,10 @@ uplot@1.6.24:
   resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.24.tgz#dfa213fa7da92763261920ea972ed1a5f9f6af12"
   integrity sha512-WpH2BsrFrqxkMu+4XBvc0eCDsRBhzoq9crttYeSI0bfxpzR5YoSVzZXOKFVWcVC7sp/aDXrdDPbDZGCtck2PVg==
 
-uplot@1.6.31:
-  version "1.6.31"
-  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.31.tgz#092a4b586590e9794b679e1df885a15584b03698"
-  integrity sha512-sQZqSwVCbJGnFB4IQjQYopzj5CoTZJ4Br1fG/xdONimqgHmsacvCjNesdGDypNKFbrhLGIeshYhy89FxPF+H+w==
+uplot@1.6.26:
+  version "1.6.26"
+  resolved "https://registry.yarnpkg.com/uplot/-/uplot-1.6.26.tgz#a6012fd141ad4a71741c75af0c71283d0ade45a7"
+  integrity sha512-qN0mveL6UsP40TnHzHAJkUQvpfA3y8zSLXtXKVlJo/sLfj2+vjan/Z3g81MCZjy/hEDUFNtnLftPmETDA4s7Rg==
 
 upper-case-first@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
Reverts SigNoz/signoz#6104
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts `uplot` version from `1.6.31` to `1.6.26` in `frontend/package.json`.
> 
>   - **Dependencies**:
>     - Reverts `uplot` version from `1.6.31` to `1.6.26` in `frontend/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 69bb3ef2bf8ca73b1f54a538bf26298712c77927. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->