### PR TITLE
perf(cache): should delete multiple keys at once to reduce operations in Redis cache

### DIFF
--- a/pkg/query-service/cache/redis/redis_test.go
+++ b/pkg/query-service/cache/redis/redis_test.go
@@ -82,8 +82,7 @@ func TestBulkRemove(t *testing.T) {
 	mock.ExpectSet("key2", []byte("value2"), 10*time.Second).RedisNil()
 	c.Store("key2", []byte("value2"), 10*time.Second)
 
-	mock.ExpectDel("key").RedisNil()
-	mock.ExpectDel("key2").RedisNil()
+	mock.ExpectDel("key", "key2").RedisNil()
 	c.BulkRemove([]string{"key", "key2"})
 
 	if err := mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
### Summary

Currently, it will send multiple commands to Redis if there are more than
one key in BulkRemove. We can improve by sending them at once to reduce operations.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize Redis cache operations by modifying `Remove` and `BulkRemove` to delete multiple keys in a single command, reducing Redis operations.
> 
>   - **Behavior**:
>     - `Remove` in `redis.go` now calls `BulkRemove` to delete a single key, optimizing the operation.
>     - `BulkRemove` in `redis.go` modified to delete multiple keys in a single Redis command.
>   - **Error Handling**:
>     - Uses `errors.Is` for error comparison in `Retrieve` in `redis.go`.
>   - **Tests**:
>     - `TestBulkRemove` in `redis_test.go` updated to expect a single `Del` command for multiple keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for f090886ae158b5d87e03a1b67dc00d655dfb0efe. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->