### PR TITLE
fix: remove trailing slash from http payload example

### DIFF
--- a/frontend/src/container/OnboardingContainer/Modules/LogsManagement/Http/md-docs/httpJsonPayload.md
+++ b/frontend/src/container/OnboardingContainer/Modules/LogsManagement/Http/md-docs/httpJsonPayload.md
@@ -60,7 +60,7 @@ This is a **sample cURL request** which can be used as a template:
 &nbsp;
 
 ```bash
-curl --location 'https://ingest.{{REGION}}.signoz.cloud:443/logs/json/' \
+curl --location 'https://ingest.{{REGION}}.signoz.cloud:443/logs/json' \
 --header 'Content-Type: application/json' \
 --header 'signoz-access-token: {{SIGNOZ_INGESTION_KEY}}' \
 --data '[


### PR DESCRIPTION
### Summary
Removed trailing slash from the `httpJsonPayload` curl command. This change prevents the request from returning a 404 error by correctly using the endpoint without a trailing slash.

#### Related Issues / PR's

NA

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

NA

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

NA

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove trailing slash from URL in `httpJsonPayload.md` cURL command to prevent 404 errors.
> 
>   - **Behavior**:
>     - Removed trailing slash from URL in `httpJsonPayload.md` cURL command example to prevent 404 errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 8657def4028ee922d22d7486765a7d051dbeacea. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->