### PR TITLE
fix(docker): use env prefix for boolean in collector config

### DIFF
--- a/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
@@ -131,8 +131,8 @@ processors:
 exporters:
   clickhousetraces:
     datasource: tcp://clickhouse:9000/signoz_traces
-    docker_multi_node_cluster: ${DOCKER_MULTI_NODE_CLUSTER}
-    low_cardinal_exception_grouping: ${LOW_CARDINAL_EXCEPTION_GROUPING}
+    docker_multi_node_cluster: ${env:DOCKER_MULTI_NODE_CLUSTER}
+    low_cardinal_exception_grouping: ${env:LOW_CARDINAL_EXCEPTION_GROUPING}
   clickhousemetricswrite:
     endpoint: tcp://clickhouse:9000/signoz_metrics
     resource_to_telemetry_conversion:
@@ -142,7 +142,7 @@ exporters:
   # logging: {}
   clickhouselogsexporter:
     dsn: tcp://clickhouse:9000/signoz_logs
-    docker_multi_node_cluster: ${DOCKER_MULTI_NODE_CLUSTER}
+    docker_multi_node_cluster: ${env:DOCKER_MULTI_NODE_CLUSTER}
     timeout: 10s
     use_new_schema: true
 extensions:

--- a/deploy/docker/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker/clickhouse-setup/otel-collector-config.yaml
@@ -142,8 +142,8 @@ extensions:
 exporters:
   clickhousetraces:
     datasource: tcp://clickhouse:9000/signoz_traces
-    docker_multi_node_cluster: ${DOCKER_MULTI_NODE_CLUSTER}
-    low_cardinal_exception_grouping: ${LOW_CARDINAL_EXCEPTION_GROUPING}
+    docker_multi_node_cluster: ${env:DOCKER_MULTI_NODE_CLUSTER}
+    low_cardinal_exception_grouping: ${env:LOW_CARDINAL_EXCEPTION_GROUPING}
   clickhousemetricswrite:
     endpoint: tcp://clickhouse:9000/signoz_metrics
     resource_to_telemetry_conversion:
@@ -152,7 +152,7 @@ exporters:
     endpoint: tcp://clickhouse:9000/signoz_metrics
   clickhouselogsexporter:
     dsn: tcp://clickhouse:9000/signoz_logs
-    docker_multi_node_cluster: ${DOCKER_MULTI_NODE_CLUSTER}
+    docker_multi_node_cluster: ${env:DOCKER_MULTI_NODE_CLUSTER}
     timeout: 10s
     use_new_schema: true
   # logging: {}

--- a/pkg/query-service/tests/test-deploy/otel-collector-config.yaml
+++ b/pkg/query-service/tests/test-deploy/otel-collector-config.yaml
@@ -103,8 +103,8 @@ extensions:
 exporters:
   clickhousetraces:
     datasource: tcp://clickhouse:9000/signoz_traces
-    docker_multi_node_cluster: ${DOCKER_MULTI_NODE_CLUSTER}
-    low_cardinal_exception_grouping: ${LOW_CARDINAL_EXCEPTION_GROUPING}
+    docker_multi_node_cluster: ${env:DOCKER_MULTI_NODE_CLUSTER}
+    low_cardinal_exception_grouping: ${env:LOW_CARDINAL_EXCEPTION_GROUPING}
   clickhousemetricswrite:
     endpoint: tcp://clickhouse:9000/signoz_metrics
     resource_to_telemetry_conversion:
@@ -113,7 +113,7 @@ exporters:
     endpoint: 0.0.0.0:8889
   clickhouselogsexporter:
     dsn: tcp://clickhouse:9000/signoz_logs
-    docker_multi_node_cluster: ${DOCKER_MULTI_NODE_CLUSTER}
+    docker_multi_node_cluster: ${env:DOCKER_MULTI_NODE_CLUSTER}
     timeout: 10s
     use_new_schema: true
   # logging: {}


### PR DESCRIPTION
### Summary

Fixes for `expected type 'bool', got unconvertible type 'string'` errors.

**Sample errors:**

```
error decoding 'exporters': error reading configuration for \"clickhousetraces\": decoding failed due to the following error(s):\n\n'docker_multi_node_cluster' expected type 'bool', got unconvertible type 'string', value: 'false'\n'low_cardinal_exception_grouping' expected type 'bool', got unconvertible type 'string', value: 'false'
```

```
error decoding 'exporters': error reading configuration for \"clickhouselogsexporter\": decoding failed due to the following error(s):\n\n'docker_multi_node_cluster' expected type 'bool', got unconvertible type 'string', value: 'false'
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes boolean type errors in OpenTelemetry collector configuration by prefixing environment variables with `env:`.
> 
>   - **Configuration Fix**:
>     - Prefixes boolean environment variables with `env:` in `otel-collector-config.yaml` files to fix type errors.
>     - Affects `docker_multi_node_cluster` and `low_cardinal_exception_grouping` variables.
>   - **Files Modified**:
>     - `deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml`
>     - `deploy/docker/clickhouse-setup/otel-collector-config.yaml`
>     - `pkg/query-service/tests/test-deploy/otel-collector-config.yaml`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 0221311f6baa6d6c260496b8c42a9534f32409c0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->