### PR TITLE
fix: issue while switching between views

### DIFF
--- a/frontend/src/hooks/useUrlQueryData.ts
+++ b/frontend/src/hooks/useUrlQueryData.ts
@@ -22,14 +22,16 @@ const useUrlQueryData = <T>(
 		(newQueryData: T): void => {
 			const newQuery = JSON.stringify(newQueryData);
 
-			// Create a new URLSearchParams to get the latest URL state
+			// Create a new URLSearchParams object with the current URL's search params
+			// This ensures we're working with the most up-to-date URL state
 			const currentUrlQuery = new URLSearchParams(window.location.search);
 
-			// Update the query parameter
+			// Update or add the specified query parameter with the new serialized data
 			currentUrlQuery.set(queryKey, newQuery);
 
-			// Generate the new URL with updated parameters
+			// Construct the new URL by combining the current pathname with the updated query string
 			const generatedUrl = `${location.pathname}?${currentUrlQuery.toString()}`;
+
 			history.replace(generatedUrl);
 		},
 		[history, location.pathname, queryKey],

--- a/frontend/src/hooks/useUrlQueryData.ts
+++ b/frontend/src/hooks/useUrlQueryData.ts
@@ -1,6 +1,7 @@
-import useUrlQuery from 'hooks/useUrlQuery';
 import { useCallback, useMemo } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
+
+import useUrlQuery from './useUrlQuery';
 
 const useUrlQueryData = <T>(
 	queryKey: string,
@@ -10,7 +11,7 @@ const useUrlQueryData = <T>(
 	const location = useLocation();
 	const urlQuery = useUrlQuery();
 
-	const query = useMemo(() => urlQuery.get(queryKey), [queryKey, urlQuery]);
+	const query = useMemo(() => urlQuery.get(queryKey), [urlQuery, queryKey]);
 
 	const queryData: T = useMemo(() => (query ? JSON.parse(query) : defaultData), [
 		query,
@@ -21,11 +22,17 @@ const useUrlQueryData = <T>(
 		(newQueryData: T): void => {
 			const newQuery = JSON.stringify(newQueryData);
 
-			urlQuery.set(queryKey, newQuery);
-			const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
+			// Create a new URLSearchParams to get the latest URL state
+			const currentUrlQuery = new URLSearchParams(window.location.search);
+
+			// Update the query parameter
+			currentUrlQuery.set(queryKey, newQuery);
+
+			// Generate the new URL with updated parameters
+			const generatedUrl = `${location.pathname}?${currentUrlQuery.toString()}`;
 			history.replace(generatedUrl);
 		},
-		[history, location, urlQuery, queryKey],
+		[history, location.pathname, queryKey],
 	);
 
 	return {


### PR DESCRIPTION
### Summary
the root cause of #6187 was, using `useUrlQuery` to get the current URL's search  params, we used to get the stale `viewName`, therefore, it would update the selectColumns with the old `viewName` being selected. thus it would keep the old view selected.

by creating `URLSearchParams` inside the `redirectWithQuery`, we ensure that we're working with the most up-to-date URL state.

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
close https://github.com/SigNoz/signoz/issues/6187
close https://github.com/SigNoz/engineering-pod/issues/1913
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas
Affecter areas:
- Logs
- Traces

Tested:
- switching between saved views in logs explorer
- switching between saved views in traces explorer
- creating a new view and switching to another view in logs explorer
- creating a new view and switching to another view in traces explorer
<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes URL query handling in `useUrlQueryData` by using `URLSearchParams` for up-to-date query state and corrects import path for `useUrlQuery`.
> 
>   - **Behavior**:
>     - Fixes URL query handling in `useUrlQueryData` by using `URLSearchParams` to ensure up-to-date query state.
>     - Updates `redirectWithQuery` to construct URLs with current pathname and updated query string.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 88c3fa8a64aafb91e1b37d027ca382076d5f7dae. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

