### PR TITLE
fix: all new alerts use v4 version

### DIFF
--- a/frontend/src/api/alerts/create.ts
+++ b/frontend/src/api/alerts/create.ts
@@ -7,7 +7,6 @@ const create = async (
 ): Promise<SuccessResponse<PayloadProps> | ErrorResponse> => {
 	const response = await axios.post('/rules', {
 		...props.data,
-		version: 'v4',
 	});
 
 	return {

--- a/frontend/src/container/CreateAlertRule/defaults.ts
+++ b/frontend/src/container/CreateAlertRule/defaults.ts
@@ -104,6 +104,7 @@ export const anamolyAlertDefaults: AlertDef = {
 
 export const logAlertDefaults: AlertDef = {
 	alertType: AlertTypes.LOGS_BASED_ALERT,
+	version: ENTITY_VERSION_V4,
 	condition: {
 		compositeQuery: {
 			builderQueries: {
@@ -134,6 +135,7 @@ export const logAlertDefaults: AlertDef = {
 
 export const traceAlertDefaults: AlertDef = {
 	alertType: AlertTypes.TRACES_BASED_ALERT,
+	version: ENTITY_VERSION_V4,
 	condition: {
 		compositeQuery: {
 			builderQueries: {
@@ -164,6 +166,7 @@ export const traceAlertDefaults: AlertDef = {
 
 export const exceptionAlertDefaults: AlertDef = {
 	alertType: AlertTypes.EXCEPTIONS_BASED_ALERT,
+	version: ENTITY_VERSION_V4,
 	condition: {
 		compositeQuery: {
 			builderQueries: {

--- a/frontend/src/container/QueryBuilder/components/QueryFunctions/QueryFunctions.tsx
+++ b/frontend/src/container/QueryBuilder/components/QueryFunctions/QueryFunctions.tsx
@@ -13,6 +13,7 @@ import {
 import { DataSource, QueryFunctionsTypes } from 'types/common/queryBuilder';
 
 import Function from './Function';
+import { toFloat64 } from './utils';
 
 const defaultMetricFunctionStruct: QueryFunctionProps = {
 	name: QueryFunctionsTypes.CUTOFF_MIN,
@@ -158,7 +159,13 @@ export default function QueryFunctions({
 		const updateFunctions = cloneDeep(functions);
 
 		if (updateFunctions && updateFunctions.length > 0 && updateFunctions[index]) {
-			updateFunctions[index].args = [value];
+			updateFunctions[index].args = [
+				// timeShift expects a float64 value, so we convert the string to a number
+				// For other functions, we keep the value as a string
+				updateFunctions[index].name === QueryFunctionsTypes.TIME_SHIFT
+					? toFloat64(value)
+					: value,
+			];
 			setFunctions(updateFunctions);
 			onChange(updateFunctions);
 		}

--- a/frontend/src/container/QueryBuilder/components/QueryFunctions/utils.ts
+++ b/frontend/src/container/QueryBuilder/components/QueryFunctions/utils.ts
@@ -1,0 +1,7 @@
+export const toFloat64 = (value: string): number => {
+	const parsed = parseFloat(value);
+	if (!Number.isFinite(parsed)) {
+		console.error(`Invalid value for timeshift. value: ${value}`);
+	}
+	return parsed;
+};

--- a/frontend/src/types/api/queryBuilder/queryBuilderData.ts
+++ b/frontend/src/types/api/queryBuilder/queryBuilderData.ts
@@ -49,7 +49,7 @@ export type OrderByPayload = {
 
 export interface QueryFunctionProps {
 	name: string;
-	args: string[];
+	args: (string | number)[];
 	namedArgs?: Record<string, any>;
 }
 


### PR DESCRIPTION
### Summary
issue: the query builder returns incorrect result when the query has time shift and formula. 
root cause: the query builder uses v3 for query_range API
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
close https://github.com/SigNoz/signoz/issues/6151
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas
Affected areas:
Create alert page

Manually tested areas:
- Create alert page
<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes query builder issue with time shift and formula by updating API version and parsing time shift values as float64.
> 
>   - **Behavior**:
>     - Fixes incorrect query results with time shift and formula in Create alert page by using `ENTITY_VERSION_V4` in `defaults.ts`.
>     - Converts time shift values to `float64` in `QueryFunctions.tsx` using `toFloat64()`.
>   - **API**:
>     - Removes `version: 'v4'` from `create.ts` to use default version.
>   - **Types**:
>     - Updates `args` type in `QueryFunctionProps` to `(string | number)[]` in `queryBuilderData.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for c5a0c507574c21ff0ccbe33810336ac3c3258a49. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->