### PR TITLE
chore: remove the trial expiry banner on logout

### DIFF
--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -211,6 +211,13 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 		}
 	}, [licenseData, isFetching]);
 
+	useEffect(() => {
+		// after logging out hide the trial expiry banner
+		if (!isLoggedIn) {
+			setShowTrialExpiryBanner(false);
+		}
+	}, [isLoggedIn]);
+
 	const handleUpgrade = (): void => {
 		if (role === 'ADMIN') {
 			history.push(ROUTES.BILLING);


### PR DESCRIPTION
### Summary

- remove the trial expiry banner when user is logged out. ( currently it goes away when we reload as the license data call takes care of it. made the change to hide it even without reload ) 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/user-attachments/assets/72919119-fbf8-4377-9205-e2903ac8331f



#### Affected Areas and Manually Tested Areas

- trial banner logged in and logged out state 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `useEffect` in `AppLayout` to hide the trial expiry banner on logout.
> 
>   - **Behavior**:
>     - Adds `useEffect` in `AppLayout` to hide the trial expiry banner when `isLoggedIn` is `false`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for d50fb271c503b0e4ee05be0b289258fa630573f6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->