### PR TITLE
Feature flag kafka scenario in pkg instead of ee

### DIFF
--- a/ee/query-service/constants/constants.go
+++ b/ee/query-service/constants/constants.go
@@ -14,8 +14,6 @@ var SaasSegmentKey = GetOrDefaultEnv("SIGNOZ_SAAS_SEGMENT_KEY", "")
 var FetchFeatures = GetOrDefaultEnv("FETCH_FEATURES", "false")
 var ZeusFeaturesURL = GetOrDefaultEnv("ZEUS_FEATURES_URL", "ZeusFeaturesURL")
 
-var KafkaSpanEval = GetOrDefaultEnv("KAFKA_SPAN_EVAL", "false")
-
 func GetOrDefaultEnv(key string, fallback string) string {
 	v := os.Getenv(key)
 	if len(v) == 0 {

--- a/pkg/query-service/app/integrations/messagingQueues/kafka/translator.go
+++ b/pkg/query-service/app/integrations/messagingQueues/kafka/translator.go
@@ -2,8 +2,8 @@ package kafka
 
 import (
 	"fmt"
-	"go.signoz.io/signoz/ee/query-service/constants"
 	"go.signoz.io/signoz/pkg/query-service/common"
+	"go.signoz.io/signoz/pkg/query-service/constants"
 	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
 )
 

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -80,6 +80,8 @@ var TimestampSortFeature = GetOrDefaultEnv("TIMESTAMP_SORT_FEATURE", "true")
 
 var PreferRPMFeature = GetOrDefaultEnv("PREFER_RPM_FEATURE", "false")
 
+var KafkaSpanEval = GetOrDefaultEnv("KAFKA_SPAN_EVAL", "false")
+
 func IsDurationSortFeatureEnabled() bool {
 	isDurationSortFeatureEnabledStr := DurationSortFeature
 	isDurationSortFeatureEnabledBool, err := strconv.ParseBool(isDurationSortFeatureEnabledStr)


### PR DESCRIPTION
this fixes the broken ci
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Moves `KafkaSpanEval` feature flag from `ee` to `pkg` package to fix CI issues.
> 
>   - **Feature Flag Management**:
>     - Moves `KafkaSpanEval` feature flag from `ee/query-service/constants/constants.go` to `pkg/query-service/constants/constants.go`.
>   - **Imports**:
>     - Updates import path in `pkg/query-service/app/integrations/messagingQueues/kafka/translator.go` to use `pkg/query-service/constants` instead of `ee/query-service/constants`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for dcad3db8f999bebf6977622346e4ae80bfc588f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->