### PR TITLE
chore: make the clear selection view more highlighted

### DIFF
--- a/frontend/src/container/ExplorerOptions/ExplorerOptions.styles.scss
+++ b/frontend/src/container/ExplorerOptions/ExplorerOptions.styles.scss
@@ -18,7 +18,7 @@
 	display: inline-flex;
 	align-items: center;
 	gap: 12px;
-	padding: 10px 12px;
+	padding: 10px 10px;
 	border-radius: 50px;
 	border: 1px solid var(--bg-slate-400);
 	background: rgba(22, 24, 29, 0.6);
@@ -33,6 +33,7 @@
 		border: 1px solid var(--bg-slate-400);
 		background: var(--bg-slate-500);
 		cursor: pointer;
+		box-shadow: none;
 	}
 
 	.hidden {

--- a/frontend/src/container/ExplorerOptions/ExplorerOptions.tsx
+++ b/frontend/src/container/ExplorerOptions/ExplorerOptions.tsx
@@ -45,7 +45,6 @@ import {
 	PanelBottomClose,
 	Plus,
 	X,
-	XCircle,
 } from 'lucide-react';
 import {
 	CSSProperties,
@@ -515,7 +514,11 @@ function ExplorerOptions({
 
 	return (
 		<div className="explorer-options-container">
-			{isQueryUpdated && !isExplorerOptionHidden && (
+			{
+				// if a viewName is selected and the explorer options are not hidden then
+				// always show the clear option
+			}
+			{!isExplorerOptionHidden && viewName && (
 				<div
 					className={cx(
 						isEditDeleteSupported ? '' : 'hide-update',
@@ -529,18 +532,25 @@ function ExplorerOptions({
 							icon={<X size={14} />}
 						/>
 					</Tooltip>
-					<Divider
-						type="vertical"
-						className={isEditDeleteSupported ? '' : 'hidden'}
-					/>
-					<Tooltip title="Update this view" placement="top">
-						<Button
-							className={cx('action-icon', isEditDeleteSupported ? ' ' : 'hidden')}
-							disabled={isViewUpdating}
-							onClick={onUpdateQueryHandler}
-							icon={<Disc3 size={14} />}
-						/>
-					</Tooltip>
+					{
+						// only show the update view option when the query is updated
+					}
+					{isQueryUpdated && (
+						<>
+							<Divider
+								type="vertical"
+								className={isEditDeleteSupported ? '' : 'hidden'}
+							/>
+							<Tooltip title="Update this view" placement="top">
+								<Button
+									className={cx('action-icon', isEditDeleteSupported ? ' ' : 'hidden')}
+									disabled={isViewUpdating}
+									onClick={onUpdateQueryHandler}
+									icon={<Disc3 size={14} />}
+								/>
+							</Tooltip>
+						</>
+					)}
 				</div>
 			)}
 			{!isExplorerOptionHidden && (
@@ -564,10 +574,7 @@ function ExplorerOptions({
 							}}
 							dropdownStyle={dropdownStyle}
 							className="views-dropdown"
-							allowClear={{
-								clearIcon: <XCircle size={16} style={{ marginTop: '-3px' }} />,
-							}}
-							onClear={handleClearSelect}
+							allowClear={false}
 							ref={ref}
 						>
 							{viewsData?.data?.data?.map((view) => {
@@ -662,8 +669,8 @@ function ExplorerOptions({
 					</div>
 				</div>
 			)}
-
 			<ExplorerOptionsHideArea
+				viewName={viewName}
 				isExplorerOptionHidden={isExplorerOptionHidden}
 				setIsExplorerOptionHidden={setIsExplorerOptionHidden}
 				sourcepage={sourcepage}
@@ -672,7 +679,6 @@ function ExplorerOptions({
 				onUpdateQueryHandler={onUpdateQueryHandler}
 				isEditDeleteSupported={isEditDeleteSupported}
 			/>
-
 			<Modal
 				className="save-view-modal"
 				title={<span className="title">Save this view</span>}
@@ -705,7 +711,6 @@ function ExplorerOptions({
 					/>
 				</div>
 			</Modal>
-
 			<Modal
 				footer={null}
 				onOk={onCancel(false)}

--- a/frontend/src/container/ExplorerOptions/ExplorerOptionsHideArea.tsx
+++ b/frontend/src/container/ExplorerOptions/ExplorerOptionsHideArea.tsx
@@ -10,6 +10,7 @@ import { DataSource } from 'types/common/queryBuilder';
 import { setExplorerToolBarVisibility } from './utils';
 
 interface DroppableAreaProps {
+	viewName: string;
 	isQueryUpdated: boolean;
 	isExplorerOptionHidden?: boolean;
 	sourcepage: DataSource;
@@ -20,6 +21,7 @@ interface DroppableAreaProps {
 }
 
 function ExplorerOptionsHideArea({
+	viewName,
 	isQueryUpdated,
 	isExplorerOptionHidden,
 	sourcepage,
@@ -39,7 +41,7 @@ function ExplorerOptionsHideArea({
 		<div className="explorer-option-droppable-container">
 			{isExplorerOptionHidden && (
 				<>
-					{isQueryUpdated && (
+					{viewName && (
 						<div className="explorer-actions-btn">
 							<Tooltip title="Clear this view">
 								<Button
@@ -49,7 +51,7 @@ function ExplorerOptionsHideArea({
 									icon={<X size={14} color={Color.BG_INK_500} />}
 								/>
 							</Tooltip>
-							{isEditDeleteSupported && (
+							{isEditDeleteSupported && isQueryUpdated && (
 								<Tooltip title="Update this View">
 									<Button
 										onClick={onUpdateQueryHandler}


### PR DESCRIPTION
### Summary

Issue - The clear selection view was hidden on hovering over the view name 

Solution - 

- Earlier the left side clear selection view used to appear only when the current selected view has been updated. 
- Now we show that clear selection even if the view is not updated in both collapsed and uncollapsed state.

#### Related Issues / PR's

https://signoz-team.slack.com/archives/C02TJ466H8U/p1729159025041929?thread_ts=1729142743.563519&cid=C02TJ466H8U

#### Screenshots


https://github.com/user-attachments/assets/38dac468-94be-41ce-8857-e973dce6fbbd


https://github.com/user-attachments/assets/e25aea97-0d9e-4cee-9f4d-d14497c53cee



#### Affected Areas and Manually Tested Areas

- Logs Saved views selection and clearing the same in both collapsed and uncollapsed state 

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance visibility of clear selection view in `ExplorerOptions` by adjusting button display conditions and removing unused code.
> 
>   - **Behavior**:
>     - `ExplorerOptions.tsx`: Always show clear option if `viewName` is selected and `isExplorerOptionHidden` is false.
>     - `ExplorerOptions.tsx`: Show update view option only when `isQueryUpdated` is true.
>     - `ExplorerOptionsHideArea.tsx`: Show clear button when `viewName` is present, regardless of `isQueryUpdated`.
>   - **UI Changes**:
>     - Remove `XCircle` icon from `allowClear` in `Select` component in `ExplorerOptions.tsx`.
>     - Add `viewName` prop to `ExplorerOptionsHideArea` in `ExplorerOptions.tsx`.
>   - **Code Cleanup**:
>     - Remove unused import `XCircle` from `ExplorerOptions.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for b1af466d2132ed704bd72183e596c454d9b1263a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->