### PR TITLE
chore: added doc link for kafka on getStarted for non-cloud users

### DIFF
--- a/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
+++ b/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
@@ -10,7 +10,7 @@ import { DataSource } from 'types/common/queryBuilder';
 import { v4 as uuid } from 'uuid';
 
 export const KAFKA_SETUP_DOC_LINK =
-	'https://github.com/shivanshuraj1333/kafka-opentelemetry-instrumentation/tree/master';
+	'https://signoz.io/docs/messaging-queues/kafka/';
 
 export function convertToTitleCase(text: string): string {
 	return text

--- a/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
+++ b/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
@@ -10,7 +10,7 @@ import { DataSource } from 'types/common/queryBuilder';
 import { v4 as uuid } from 'uuid';
 
 export const KAFKA_SETUP_DOC_LINK =
-	'https://signoz.io/docs/messaging-queues/kafka/';
+	'https://signoz.io/docs/messaging-queues/kafka?utm_source=product&utm_medium=kafka-get-started';
 
 export function convertToTitleCase(text: string): string {
 	return text


### PR DESCRIPTION
### Summary

Added non-cloud redirection to newly added doc, instead of GitHub link added earlier

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

https://github.com/user-attachments/assets/d1666c05-1b2c-4152-9dc2-1bc48e38e3bc


#### Affected Areas and Manually Tested Areas

Tested for both cloud and non-cloud user for redirection

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `KAFKA_SETUP_DOC_LINK` in `MessagingQueuesUtils.ts` for non-cloud user redirection.
> 
>   - **Behavior**:
>     - Update `KAFKA_SETUP_DOC_LINK` in `MessagingQueuesUtils.ts` to 'https://signoz.io/docs/messaging-queues/kafka?utm_source=product&utm_medium=kafka-get-started'.
>   - **Testing**:
>     - Verified redirection for both cloud and non-cloud users.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 116406c42de385df5a742063ae8e5943f8cc6943. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->