### PR TITLE
feat: added onboarding setup for Producer for Messaging queues

### DIFF
--- a/frontend/src/api/messagingQueues/onboarding/getOnboardingStatus.ts
+++ b/frontend/src/api/messagingQueues/onboarding/getOnboardingStatus.ts
@@ -1,0 +1,40 @@
+import { ErrorResponseHandler } from 'api/ErrorResponseHandler';
+import axios, { AxiosError } from 'axios';
+import { ErrorResponse, SuccessResponse } from 'types/api';
+
+export interface OnboardingStatusResponse {
+	status: string;
+	data: {
+		attribute?: string;
+		error_message?: string;
+		status?: string;
+	}[];
+}
+
+const getOnboardingStatus = async (
+	start: number,
+	end: number,
+): Promise<SuccessResponse<OnboardingStatusResponse> | ErrorResponse> => {
+	const endpoint = '/messaging-queues/kafka/onboarding/consumers';
+	const payload = {
+		start,
+		end,
+	};
+
+	try {
+		const response = await axios.post<OnboardingStatusResponse>(
+			endpoint,
+			payload,
+		);
+		return {
+			statusCode: 200,
+			error: null,
+			message: response.data.status,
+			payload: response.data,
+		};
+	} catch (error) {
+		return ErrorResponseHandler(error as AxiosError);
+	}
+};
+
+export default getOnboardingStatus;

--- a/frontend/src/api/messagingQueues/onboarding/getOnboardingStatus.ts
+++ b/frontend/src/api/messagingQueues/onboarding/getOnboardingStatus.ts
@@ -1,5 +1,7 @@
+import { ApiBaseInstance } from 'api';
 import { ErrorResponseHandler } from 'api/ErrorResponseHandler';
-import axios, { AxiosError } from 'axios';
+import { AxiosError } from 'axios';
+import { SOMETHING_WENT_WRONG } from 'constants/api';
 import { ErrorResponse, SuccessResponse } from 'types/api';
 
 export interface OnboardingStatusResponse {
@@ -11,21 +13,16 @@ export interface OnboardingStatusResponse {
 	}[];
 }
 
-const getOnboardingStatus = async (
-	start: number,
-	end: number,
-): Promise<SuccessResponse<OnboardingStatusResponse> | ErrorResponse> => {
-	const endpoint = '/messaging-queues/kafka/onboarding/consumers';
-	const payload = {
-		start,
-		end,
-	};
-
+const getOnboardingStatus = async (props: {
+	start: number;
+	end: number;
+}): Promise<SuccessResponse<OnboardingStatusResponse> | ErrorResponse> => {
 	try {
-		const response = await axios.post<OnboardingStatusResponse>(
-			endpoint,
-			payload,
+		const response = await ApiBaseInstance.post(
+			'/messaging-queues/kafka/onboarding/consumers',
+			props,
 		);
+
 		return {
 			statusCode: 200,
 			error: null,
@@ -33,7 +30,7 @@ const getOnboardingStatus = async (
 			payload: response.data,
 		};
 	} catch (error) {
-		return ErrorResponseHandler(error as AxiosError);
+		return ErrorResponseHandler((error as AxiosError) || SOMETHING_WENT_WRONG);
 	}
 };
 

--- a/frontend/src/constants/query.ts
+++ b/frontend/src/constants/query.ts
@@ -38,4 +38,6 @@ export enum QueryParams {
 	selectedTimelineQuery = 'selectedTimelineQuery',
 	ruleType = 'ruleType',
 	configDetail = 'configDetail',
+	getStartedSource = 'getStartedSource',
+	getStartedSourceService = 'getStartedSourceService',
 }

--- a/frontend/src/container/OnboardingContainer/Modules/APM/Java/md-docs/SpringBoot/Kubernetes/springBoot-kubernetes-runApplication-producer.md
+++ b/frontend/src/container/OnboardingContainer/Modules/APM/Java/md-docs/SpringBoot/Kubernetes/springBoot-kubernetes-runApplication-producer.md
@@ -1,0 +1,29 @@
+&nbsp;
+
+Once you are done intrumenting your Java application, you can run it using the below commands
+
+**Note:**
+- Ensure you have Java and Maven installed. Compile your Java producer applications: Ensure your producer and consumer apps are compiled and ready to run.
+
+**Run Producer App with Java Agent:**
+
+```bash
+java -javaagent:/path/to/opentelemetry-javaagent.jar \
+     -Dotel.service.name=producer-svc \
+     -Dotel.traces.exporter=otlp \
+     -Dotel.metrics.exporter=otlp \
+     -Dotel.logs.exporter=otlp \
+     -jar /path/to/your/producer.jar
+```
+
+<path> - update it to the path where you downloaded the Java JAR agent in previous step
+<my-app> - Jar file of your application
+
+&nbsp;
+
+**Note:**
+- In case you're dockerising your application, make sure to dockerise it along with OpenTelemetry instrumentation done in previous step.
+
+&nbsp;
+
+If you encounter any difficulties, please consult the [troubleshooting section](https://signoz.io/docs/instrumentation/springboot/#troubleshooting-your-installation) for assistance.

--- a/frontend/src/container/OnboardingContainer/Steps/ConnectionStatus/ConnectionStatus.tsx
+++ b/frontend/src/container/OnboardingContainer/Steps/ConnectionStatus/ConnectionStatus.tsx
@@ -6,6 +6,7 @@ import {
 	LoadingOutlined,
 } from '@ant-design/icons';
 import logEvent from 'api/common/logEvent';
+import { QueryParams } from 'constants/query';
 import Header from 'container/OnboardingContainer/common/Header/Header';
 import { useOnboardingContext } from 'container/OnboardingContainer/context/OnboardingContext';
 import { useOnboardingStatus } from 'hooks/messagingQueue / onboarding/useOnboardingStatus';
@@ -31,7 +32,7 @@ export default function ConnectionStatus(): JSX.Element {
 	>((state) => state.globalTime);
 
 	const urlQuery = useUrlQuery();
-	const getStartedCaller = urlQuery.get('source');
+	const getStartedSource = urlQuery.get(QueryParams.getStartedSource);
 
 	const {
 		serviceName,
@@ -64,7 +65,7 @@ export default function ConnectionStatus(): JSX.Element {
 		selectedTime,
 		selectedTags,
 		options: {
-			enabled: getStartedCaller !== 'kafka',
+			enabled: getStartedSource !== 'kafka',
 		},
 	});
 
@@ -74,7 +75,7 @@ export default function ConnectionStatus(): JSX.Element {
 		error: onbErr,
 		isFetching: onbFetching,
 	} = useOnboardingStatus({
-		enabled: getStartedCaller === 'kafka',
+		enabled: getStartedSource === 'kafka',
 		refetchInterval: pollInterval,
 	});
 
@@ -84,7 +85,7 @@ export default function ConnectionStatus(): JSX.Element {
 	] = useState<boolean>(false);
 
 	useEffect(() => {
-		if (getStartedCaller === 'kafka') {
+		if (getStartedSource === 'kafka') {
 			if (onbData?.statusCode !== 200) {
 				setShouldRetryOnboardingCall(true);
 			} else if (onbData?.payload?.status === 'success') {
@@ -105,21 +106,21 @@ export default function ConnectionStatus(): JSX.Element {
 		onbData,
 		onbErr,
 		onbFetching,
-		getStartedCaller,
+		getStartedSource,
 	]);
 
 	useEffect(() => {
-		if (retryCount < 0 && getStartedCaller === 'kafka') {
+		if (retryCount < 0 && getStartedSource === 'kafka') {
 			setPollInterval(false);
 			setLoading(false);
 		}
-	}, [retryCount, getStartedCaller]);
+	}, [retryCount, getStartedSource]);
 
 	useEffect(() => {
-		if (getStartedCaller === 'kafka' && !onbFetching) {
+		if (getStartedSource === 'kafka' && !onbFetching) {
 			setRetryCount((prevCount) => prevCount - 1);
 		}
-	}, [getStartedCaller, onbData, onbFetching]);
+	}, [getStartedSource, onbData, onbFetching]);
 
 	const renderDocsReference = (): JSX.Element => {
 		switch (selectedDataSource?.name) {
@@ -254,7 +255,7 @@ export default function ConnectionStatus(): JSX.Element {
 	useEffect(() => {
 		let pollingTimer: string | number | NodeJS.Timer | undefined;
 
-		if (getStartedCaller !== 'kafka') {
+		if (getStartedSource !== 'kafka') {
 			if (loading) {
 				pollingTimer = setInterval(() => {
 					// Trigger a refetch with the updated parameters
@@ -285,14 +286,14 @@ export default function ConnectionStatus(): JSX.Element {
 	}, [refetch, selectedTags, selectedTime, loading]);
 
 	useEffect(() => {
-		if (getStartedCaller !== 'kafka') {
+		if (getStartedSource !== 'kafka') {
 			verifyApplicationData(data);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [isServiceLoading, data, error, isError]);
 
 	useEffect(() => {
-		if (getStartedCaller !== 'kafka') {
+		if (getStartedSource !== 'kafka') {
 			refetch();
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/container/OnboardingContainer/Steps/ConnectionStatus/ConnectionStatus.tsx
+++ b/frontend/src/container/OnboardingContainer/Steps/ConnectionStatus/ConnectionStatus.tsx
@@ -85,6 +85,7 @@ export default function ConnectionStatus(): JSX.Element {
 	] = useState<boolean>(false);
 
 	useEffect(() => {
+		// runs only when the caller is coming from 'kafka' i.e. coming from Messaging Queues - setup helper
 		if (getStartedSource === 'kafka') {
 			if (onbData?.statusCode !== 200) {
 				setShouldRetryOnboardingCall(true);

--- a/frontend/src/container/OnboardingContainer/Steps/DataSource/DataSource.styles.scss
+++ b/frontend/src/container/OnboardingContainer/Steps/DataSource/DataSource.styles.scss
@@ -75,3 +75,10 @@ div[class*='-setup-instructions-container'] {
 		color: var(--bg-slate-500);
 	}
 }
+
+.supported-languages-container {
+	.disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+}

--- a/frontend/src/container/OnboardingContainer/Steps/DataSource/DataSource.tsx
+++ b/frontend/src/container/OnboardingContainer/Steps/DataSource/DataSource.tsx
@@ -6,6 +6,7 @@ import { LoadingOutlined } from '@ant-design/icons';
 import { Button, Card, Form, Input, Select, Space, Typography } from 'antd';
 import logEvent from 'api/common/logEvent';
 import cx from 'classnames';
+import { QueryParams } from 'constants/query';
 import ROUTES from 'constants/routes';
 import { useOnboardingContext } from 'container/OnboardingContainer/context/OnboardingContext';
 import { useCases } from 'container/OnboardingContainer/OnboardingContainer';
@@ -35,9 +36,7 @@ export default function DataSource(): JSX.Element {
 	const { t } = useTranslation(['common']);
 	const history = useHistory();
 
-	const urlQuery = useUrlQuery();
-	const getStartedCaller = urlQuery.get('source');
-	console.log(getStartedCaller);
+	const getStartedSource = useUrlQuery().get(QueryParams.getStartedSource);
 
 	const {
 		serviceName,
@@ -156,15 +155,14 @@ export default function DataSource(): JSX.Element {
 						className={cx(
 							'supported-language',
 							selectedDataSource?.name === dataSource.name ? 'selected' : '',
-							!messagingQueueKakfaSupportedDataSources.includes(dataSource?.id || '')
+							getStartedSource === 'kafka' &&
+								!messagingQueueKakfaSupportedDataSources.includes(dataSource?.id || '')
 								? 'disabled'
 								: '',
 						)}
 						key={dataSource.name}
 						onClick={(): void => {
-							if (
-								messagingQueueKakfaSupportedDataSources.includes(dataSource?.id || '')
-							) {
+							if (getStartedSource !== 'kafka') {
 								updateSelectedFramework(null);
 								updateSelectedEnvironment(null);
 								updateSelectedDataSource(dataSource);

--- a/frontend/src/container/OnboardingContainer/Steps/DataSource/DataSource.tsx
+++ b/frontend/src/container/OnboardingContainer/Steps/DataSource/DataSource.tsx
@@ -13,8 +13,10 @@ import {
 	getDataSources,
 	getSupportedFrameworks,
 	hasFrameworks,
+	messagingQueueKakfaSupportedDataSources,
 } from 'container/OnboardingContainer/utils/dataSourceUtils';
 import { useNotifications } from 'hooks/useNotifications';
+import useUrlQuery from 'hooks/useUrlQuery';
 import { Blocks, Check } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -32,6 +34,10 @@ export default function DataSource(): JSX.Element {
 	const [form] = Form.useForm();
 	const { t } = useTranslation(['common']);
 	const history = useHistory();
+
+	const urlQuery = useUrlQuery();
+	const getStartedCaller = urlQuery.get('source');
+	console.log(getStartedCaller);
 
 	const {
 		serviceName,
@@ -150,13 +156,20 @@ export default function DataSource(): JSX.Element {
 						className={cx(
 							'supported-language',
 							selectedDataSource?.name === dataSource.name ? 'selected' : '',
+							!messagingQueueKakfaSupportedDataSources.includes(dataSource?.id || '')
+								? 'disabled'
+								: '',
 						)}
 						key={dataSource.name}
 						onClick={(): void => {
-							updateSelectedFramework(null);
-							updateSelectedEnvironment(null);
-							updateSelectedDataSource(dataSource);
-							form.setFieldsValue({ selectFramework: null });
+							if (
+								messagingQueueKakfaSupportedDataSources.includes(dataSource?.id || '')
+							) {
+								updateSelectedFramework(null);
+								updateSelectedEnvironment(null);
+								updateSelectedDataSource(dataSource);
+								form.setFieldsValue({ selectFramework: null });
+							}
 						}}
 					>
 						<div>

--- a/frontend/src/container/OnboardingContainer/Steps/LogsConnectionStatus/LogsConnectionStatus.tsx
+++ b/frontend/src/container/OnboardingContainer/Steps/LogsConnectionStatus/LogsConnectionStatus.tsx
@@ -11,6 +11,7 @@ import { PANEL_TYPES } from 'constants/queryBuilder';
 import Header from 'container/OnboardingContainer/common/Header/Header';
 import { useOnboardingContext } from 'container/OnboardingContainer/context/OnboardingContext';
 import { useGetExplorerQueryRange } from 'hooks/queryBuilder/useGetExplorerQueryRange';
+import useUrlQuery from 'hooks/useUrlQuery';
 import { useEffect, useState } from 'react';
 import { SuccessResponse } from 'types/api';
 import { ILog } from 'types/api/logs/log';
@@ -36,6 +37,10 @@ export default function LogsConnectionStatus(): JSX.Element {
 	const [pollingInterval, setPollingInterval] = useState<number | false>(15000); // initial Polling interval of 15 secs , Set to false after 5 mins
 	const [retryCount, setRetryCount] = useState(20); // Retry for 5 mins
 	const logType = selectedDataSource?.id;
+
+	const urlQuery = useUrlQuery();
+	const getStartedCaller = urlQuery.get('source');
+	console.log('logs-connection', getStartedCaller);
 
 	const requestData: Query = {
 		queryType: EQueryType.QUERY_BUILDER,

--- a/frontend/src/container/OnboardingContainer/Steps/LogsConnectionStatus/LogsConnectionStatus.tsx
+++ b/frontend/src/container/OnboardingContainer/Steps/LogsConnectionStatus/LogsConnectionStatus.tsx
@@ -11,7 +11,6 @@ import { PANEL_TYPES } from 'constants/queryBuilder';
 import Header from 'container/OnboardingContainer/common/Header/Header';
 import { useOnboardingContext } from 'container/OnboardingContainer/context/OnboardingContext';
 import { useGetExplorerQueryRange } from 'hooks/queryBuilder/useGetExplorerQueryRange';
-import useUrlQuery from 'hooks/useUrlQuery';
 import { useEffect, useState } from 'react';
 import { SuccessResponse } from 'types/api';
 import { ILog } from 'types/api/logs/log';
@@ -37,10 +36,6 @@ export default function LogsConnectionStatus(): JSX.Element {
 	const [pollingInterval, setPollingInterval] = useState<number | false>(15000); // initial Polling interval of 15 secs , Set to false after 5 mins
 	const [retryCount, setRetryCount] = useState(20); // Retry for 5 mins
 	const logType = selectedDataSource?.id;
-
-	const urlQuery = useUrlQuery();
-	const getStartedCaller = urlQuery.get('source');
-	console.log('logs-connection', getStartedCaller);
 
 	const requestData: Query = {
 		queryType: EQueryType.QUERY_BUILDER,

--- a/frontend/src/container/OnboardingContainer/Steps/MarkdownStep/MarkdownStep.tsx
+++ b/frontend/src/container/OnboardingContainer/Steps/MarkdownStep/MarkdownStep.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { MarkdownRenderer } from 'components/MarkdownRenderer/MarkdownRenderer';
+import { QueryParams } from 'constants/query';
 import { ApmDocFilePaths } from 'container/OnboardingContainer/constants/apmDocFilePaths';
 import { AwsMonitoringDocFilePaths } from 'container/OnboardingContainer/constants/awsMonitoringDocFilePaths';
 import { AzureMonitoringDocFilePaths } from 'container/OnboardingContainer/constants/azureMonitoringDocFilePaths';
@@ -33,8 +34,10 @@ export default function MarkdownStep(): JSX.Element {
 	const [markdownContent, setMarkdownContent] = useState('');
 
 	const urlQuery = useUrlQuery();
-	const getStartedCaller = urlQuery.get('source');
-	console.log('runstep', getStartedCaller);
+	const getStartedSource = urlQuery.get(QueryParams.getStartedSource);
+	const getStartedSourceService = urlQuery.get(
+		QueryParams.getStartedSourceService,
+	);
 
 	const { step } = activeStep;
 
@@ -60,10 +63,10 @@ export default function MarkdownStep(): JSX.Element {
 		path += `_${step?.id}`;
 
 		if (
-			getStartedCaller === 'kafka' &&
-			path === 'APM_java_springBoot_kubernetes_recommendedSteps_runApplication'
+			getStartedSource === 'kafka' &&
+			path === 'APM_java_springBoot_kubernetes_recommendedSteps_runApplication' // todo: Sagar - Make this generic logic in followup PRs
 		) {
-			path += `_producer`;
+			path += `_${getStartedSourceService}`;
 		}
 		return path;
 	};

--- a/frontend/src/container/OnboardingContainer/Steps/MarkdownStep/MarkdownStep.tsx
+++ b/frontend/src/container/OnboardingContainer/Steps/MarkdownStep/MarkdownStep.tsx
@@ -10,6 +10,7 @@ import {
 	useOnboardingContext,
 } from 'container/OnboardingContainer/context/OnboardingContext';
 import { ModulesMap } from 'container/OnboardingContainer/OnboardingContainer';
+import useUrlQuery from 'hooks/useUrlQuery';
 import { useEffect, useState } from 'react';
 
 export interface IngestionInfoProps {
@@ -30,6 +31,10 @@ export default function MarkdownStep(): JSX.Element {
 	} = useOnboardingContext();
 
 	const [markdownContent, setMarkdownContent] = useState('');
+
+	const urlQuery = useUrlQuery();
+	const getStartedCaller = urlQuery.get('source');
+	console.log('runstep', getStartedCaller);
 
 	const { step } = activeStep;
 
@@ -54,6 +59,12 @@ export default function MarkdownStep(): JSX.Element {
 
 		path += `_${step?.id}`;
 
+		if (
+			getStartedCaller === 'kafka' &&
+			path === 'APM_java_springBoot_kubernetes_recommendedSteps_runApplication'
+		) {
+			path += `_producer`;
+		}
 		return path;
 	};
 

--- a/frontend/src/container/OnboardingContainer/constants/apmDocFilePaths.ts
+++ b/frontend/src/container/OnboardingContainer/constants/apmDocFilePaths.ts
@@ -252,6 +252,7 @@ import APM_java_springBoot_docker_recommendedSteps_runApplication from '../Modul
 import APM_java_springBoot_kubernetes_recommendedSteps_setupOtelCollector from '../Modules/APM/Java/md-docs/SpringBoot/Kubernetes/springBoot-kubernetes-installOtelCollector.md';
 import APM_java_springBoot_kubernetes_recommendedSteps_instrumentApplication from '../Modules/APM/Java/md-docs/SpringBoot/Kubernetes/springBoot-kubernetes-instrumentApplication.md';
 import APM_java_springBoot_kubernetes_recommendedSteps_runApplication from '../Modules/APM/Java/md-docs/SpringBoot/Kubernetes/springBoot-kubernetes-runApplication.md';
+import APM_java_springBoot_kubernetes_recommendedSteps_runApplication_producer from '../Modules/APM/Java/md-docs/SpringBoot/Kubernetes/springBoot-kubernetes-runApplication-producer.md';
 // SpringBoot-LinuxAMD64-quickstart
 import APM_java_springBoot_linuxAMD64_quickStart_instrumentApplication from '../Modules/APM/Java/md-docs/SpringBoot/LinuxAMD64/QuickStart/springBoot-linuxamd64-quickStart-instrumentApplication.md';
 import APM_java_springBoot_linuxAMD64_quickStart_runApplication from '../Modules/APM/Java/md-docs/SpringBoot/LinuxAMD64/QuickStart/springBoot-linuxamd64-quickStart-runApplication.md';
@@ -1053,6 +1054,7 @@ export const ApmDocFilePaths = {
 	APM_java_springBoot_kubernetes_recommendedSteps_setupOtelCollector,
 	APM_java_springBoot_kubernetes_recommendedSteps_instrumentApplication,
 	APM_java_springBoot_kubernetes_recommendedSteps_runApplication,
+	APM_java_springBoot_kubernetes_recommendedSteps_runApplication_producer,
 
 	// SpringBoot-LinuxAMD64-recommended
 	APM_java_springBoot_linuxAMD64_recommendedSteps_setupOtelCollector,

--- a/frontend/src/container/OnboardingContainer/utils/dataSourceUtils.ts
+++ b/frontend/src/container/OnboardingContainer/utils/dataSourceUtils.ts
@@ -399,3 +399,5 @@ export const moduleRouteMap = {
 	[ModulesMap.AwsMonitoring]: ROUTES.GET_STARTED_AWS_MONITORING,
 	[ModulesMap.AzureMonitoring]: ROUTES.GET_STARTED_AZURE_MONITORING,
 };
+
+export const messagingQueueKakfaSupportedDataSources = ['java'];

--- a/frontend/src/hooks/messagingQueue / onboarding/useOnboardingStatus.tsx
+++ b/frontend/src/hooks/messagingQueue / onboarding/useOnboardingStatus.tsx
@@ -1,82 +1,18 @@
 import getOnboardingStatus, {
 	OnboardingStatusResponse,
 } from 'api/messagingQueues/onboarding/getOnboardingStatus';
-import { useCallback, useEffect, useState } from 'react';
+import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
+import { ErrorResponse, SuccessResponse } from 'types/api';
 
-interface UseOnboardingStatusProps {
-	start: number;
-	end: number;
-	pollingInterval?: number;
-	retryCount?: number;
-}
+type UseOnboardingStatus = (
+	options?: UseQueryOptions<
+		SuccessResponse<OnboardingStatusResponse> | ErrorResponse
+	>,
+) => UseQueryResult<SuccessResponse<OnboardingStatusResponse> | ErrorResponse>;
 
-interface UseOnboardingStatusReturn {
-	data: OnboardingStatusResponse['data'] | null;
-	loading: boolean;
-	error: string | null;
-	refetch: () => void;
-}
-
-const useOnboardingStatus = ({
-	start,
-	end,
-	pollingInterval,
-	retryCount,
-}: UseOnboardingStatusProps): UseOnboardingStatusReturn => {
-	const [data, setData] = useState<OnboardingStatusResponse['data'] | null>(
-		null,
-	);
-	const [loading, setLoading] = useState<boolean>(true);
-	const [error, setError] = useState<string | null>(null);
-	const [retryAttempts, setRetryAttempts] = useState<number>(0);
-
-	const fetchData = useCallback(async () => {
-		setLoading(true);
-		setError(null);
-
-		try {
-			const response = await getOnboardingStatus(start, end);
-			if (response.statusCode === 200) {
-				setData(response.payload.data);
-			}
-			setLoading(false);
-			setRetryAttempts(0); // Reset retry attempts on success
-		} catch (err) {
-			if (err instanceof Error) {
-				setError(err.message);
-			} else {
-				setError('An unknown error occurred');
-			}
-			setLoading(false);
-			if (retryCount && retryAttempts < retryCount) {
-				setRetryAttempts(retryAttempts + 1);
-			}
-		}
-	}, [start, end, retryAttempts, retryCount]);
-
-	useEffect(() => {
-		fetchData();
-	}, [fetchData]);
-
-	useEffect(() => {
-		let pollingTimer: NodeJS.Timer | undefined;
-		console.log(pollingInterval);
-		if (pollingInterval && loading) {
-			pollingTimer = setInterval(() => {
-				fetchData();
-			}, pollingInterval);
-		} else if (!loading && pollingTimer) {
-			clearInterval(pollingTimer);
-		}
-
-		return (): void => {
-			if (pollingTimer) {
-				clearInterval(pollingTimer);
-			}
-		};
-	}, [loading, pollingInterval, fetchData]);
-
-	return { data, loading, error, refetch: fetchData };
-};
-
-export default useOnboardingStatus;
+export const useOnboardingStatus: UseOnboardingStatus = (options) =>
+	useQuery<SuccessResponse<OnboardingStatusResponse> | ErrorResponse>({
+		queryKey: ['onboardingStatus'],
+		queryFn: () => getOnboardingStatus(Date.now() - 15 * 60 * 1000, Date.now()),
+		...options,
+	});

--- a/frontend/src/hooks/messagingQueue / onboarding/useOnboardingStatus.tsx
+++ b/frontend/src/hooks/messagingQueue / onboarding/useOnboardingStatus.tsx
@@ -13,6 +13,7 @@ type UseOnboardingStatus = (
 export const useOnboardingStatus: UseOnboardingStatus = (options) =>
 	useQuery<SuccessResponse<OnboardingStatusResponse> | ErrorResponse>({
 		queryKey: ['onboardingStatus'],
-		queryFn: () => getOnboardingStatus(Date.now() - 15 * 60 * 1000, Date.now()),
+		queryFn: () =>
+			getOnboardingStatus({ start: Date.now() - 15 * 60 * 1000, end: Date.now() }),
 		...options,
 	});

--- a/frontend/src/hooks/messagingQueue / onboarding/useOnboardingStatus.tsx
+++ b/frontend/src/hooks/messagingQueue / onboarding/useOnboardingStatus.tsx
@@ -14,6 +14,9 @@ export const useOnboardingStatus: UseOnboardingStatus = (options) =>
 	useQuery<SuccessResponse<OnboardingStatusResponse> | ErrorResponse>({
 		queryKey: ['onboardingStatus'],
 		queryFn: () =>
-			getOnboardingStatus({ start: Date.now() - 15 * 60 * 1000, end: Date.now() }),
+			getOnboardingStatus({
+				start: (Date.now() - 15 * 60 * 1000) * 1_000_000,
+				end: Date.now() * 1_000_000,
+			}),
 		...options,
 	});

--- a/frontend/src/hooks/messagingQueue / onboarding/useOnboardingStatus.tsx
+++ b/frontend/src/hooks/messagingQueue / onboarding/useOnboardingStatus.tsx
@@ -1,0 +1,82 @@
+import getOnboardingStatus, {
+	OnboardingStatusResponse,
+} from 'api/messagingQueues/onboarding/getOnboardingStatus';
+import { useCallback, useEffect, useState } from 'react';
+
+interface UseOnboardingStatusProps {
+	start: number;
+	end: number;
+	pollingInterval?: number;
+	retryCount?: number;
+}
+
+interface UseOnboardingStatusReturn {
+	data: OnboardingStatusResponse['data'] | null;
+	loading: boolean;
+	error: string | null;
+	refetch: () => void;
+}
+
+const useOnboardingStatus = ({
+	start,
+	end,
+	pollingInterval,
+	retryCount,
+}: UseOnboardingStatusProps): UseOnboardingStatusReturn => {
+	const [data, setData] = useState<OnboardingStatusResponse['data'] | null>(
+		null,
+	);
+	const [loading, setLoading] = useState<boolean>(true);
+	const [error, setError] = useState<string | null>(null);
+	const [retryAttempts, setRetryAttempts] = useState<number>(0);
+
+	const fetchData = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+
+		try {
+			const response = await getOnboardingStatus(start, end);
+			if (response.statusCode === 200) {
+				setData(response.payload.data);
+			}
+			setLoading(false);
+			setRetryAttempts(0); // Reset retry attempts on success
+		} catch (err) {
+			if (err instanceof Error) {
+				setError(err.message);
+			} else {
+				setError('An unknown error occurred');
+			}
+			setLoading(false);
+			if (retryCount && retryAttempts < retryCount) {
+				setRetryAttempts(retryAttempts + 1);
+			}
+		}
+	}, [start, end, retryAttempts, retryCount]);
+
+	useEffect(() => {
+		fetchData();
+	}, [fetchData]);
+
+	useEffect(() => {
+		let pollingTimer: NodeJS.Timer | undefined;
+		console.log(pollingInterval);
+		if (pollingInterval && loading) {
+			pollingTimer = setInterval(() => {
+				fetchData();
+			}, pollingInterval);
+		} else if (!loading && pollingTimer) {
+			clearInterval(pollingTimer);
+		}
+
+		return (): void => {
+			if (pollingTimer) {
+				clearInterval(pollingTimer);
+			}
+		};
+	}, [loading, pollingInterval, fetchData]);
+
+	return { data, loading, error, refetch: fetchData };
+};
+
+export default useOnboardingStatus;

--- a/frontend/src/pages/MessagingQueues/MessagingQueues.tsx
+++ b/frontend/src/pages/MessagingQueues/MessagingQueues.tsx
@@ -86,7 +86,7 @@ function MessagingQueues(): JSX.Element {
 								type="default"
 								onClick={(): void =>
 									getStartedRedirect(
-										ROUTES.GET_STARTED_APPLICATION_MONITORING,
+										`${ROUTES.GET_STARTED_APPLICATION_MONITORING}?source=kafka`,
 										'Configure Consumer',
 									)
 								}

--- a/frontend/src/pages/MessagingQueues/MessagingQueues.tsx
+++ b/frontend/src/pages/MessagingQueues/MessagingQueues.tsx
@@ -4,6 +4,7 @@ import { ExclamationCircleFilled } from '@ant-design/icons';
 import { Color } from '@signozhq/design-tokens';
 import { Button, Modal } from 'antd';
 import logEvent from 'api/common/logEvent';
+import { QueryParams } from 'constants/query';
 import ROUTES from 'constants/routes';
 import DateTimeSelectionV2 from 'container/TopNav/DateTimeSelectionV2';
 import { Calendar, ListMinus } from 'lucide-react';
@@ -86,7 +87,7 @@ function MessagingQueues(): JSX.Element {
 								type="default"
 								onClick={(): void =>
 									getStartedRedirect(
-										`${ROUTES.GET_STARTED_APPLICATION_MONITORING}?source=kafka`,
+										`${ROUTES.GET_STARTED_APPLICATION_MONITORING}?${QueryParams.getStartedSource}=kafka&${QueryParams.getStartedSourceService}=consumer`,
 										'Configure Consumer',
 									)
 								}
@@ -105,7 +106,7 @@ function MessagingQueues(): JSX.Element {
 								type="default"
 								onClick={(): void =>
 									getStartedRedirect(
-										ROUTES.GET_STARTED_APPLICATION_MONITORING,
+										`${ROUTES.GET_STARTED_APPLICATION_MONITORING}?${QueryParams.getStartedSource}=kafka&${QueryParams.getStartedSourceService}=producer`,
 										'Configure Producer',
 									)
 								}
@@ -124,7 +125,7 @@ function MessagingQueues(): JSX.Element {
 								type="default"
 								onClick={(): void =>
 									getStartedRedirect(
-										ROUTES.GET_STARTED_INFRASTRUCTURE_MONITORING,
+										`${ROUTES.GET_STARTED_INFRASTRUCTURE_MONITORING}?${QueryParams.getStartedSource}=kafka&${QueryParams.getStartedSourceService}=kafka`,
 										'Monitor kafka',
 									)
 								}

--- a/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
+++ b/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
@@ -1,3 +1,4 @@
+import { OnboardingStatusResponse } from 'api/messagingQueues/onboarding/getOnboardingStatus';
 import { QueryParams } from 'constants/query';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import { GetWidgetQueryBuilderProps } from 'container/MetricsApplication/types';
@@ -342,5 +343,41 @@ export const getMetaDataAndAPIPerView = (
 			},
 			tableApi: getTopicThroughputDetails,
 		},
+	};
+};
+
+interface OnboardingStatusAttributeData {
+	overallStatus: string;
+	allAvailableAttributes: string[];
+	attributeDataWithError: { attributeName: string; errorMsg: string }[];
+}
+
+export const getAttributeDataFromOnboardingStatus = (
+	onboardingStatus?: OnboardingStatusResponse | null,
+): OnboardingStatusAttributeData => {
+	const allAvailableAttributes: string[] = [];
+	const attributeDataWithError: {
+		attributeName: string;
+		errorMsg: string;
+	}[] = [];
+
+	if (onboardingStatus?.data && !isEmpty(onboardingStatus?.data)) {
+		onboardingStatus.data.forEach((status) => {
+			if (status.attribute) {
+				allAvailableAttributes.push(status.attribute);
+				if (status.status === '0') {
+					attributeDataWithError.push({
+						attributeName: status.attribute,
+						errorMsg: status.error_message || '',
+					});
+				}
+			}
+		});
+	}
+
+	return {
+		overallStatus: attributeDataWithError.length ? 'error' : 'success',
+		allAvailableAttributes,
+		attributeDataWithError,
 	};
 };


### PR DESCRIPTION
### Summary

In this - 
- Added url changes for get started pages to indentify the caller
- disbaled other datasources when coming from Messaging Queues
- integrated onboarding API status call at the run application step which will retry for 20 times (this was already defined) or until we get the overall_status as success i.e. all "1" in case of onboarding call
- added `.md` changes for - Java - sprinboot - kubernetes - combination, (for Producer) - will add others later 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

Video shows the onboarding api integrated and the onboarding doc changes for - 
- Java-springboot-kubernetes
-------------------

https://github.com/user-attachments/assets/721c2940-ac2d-4683-9f91-4518c41f044e


#### Affected Areas and Manually Tested Areas

Tested - 
- onboarding flow with Messaging queue as source
- tested the existing flow is not affected as we have used url query for source identification

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds onboarding setup for Kafka producers, including API, UI updates, and Java documentation.
> 
>   - **Behavior**:
>     - Adds `getOnboardingStatus` function in `getOnboardingStatus.ts` to fetch onboarding status for Kafka consumers.
>     - Implements `useOnboardingStatus` hook in `useOnboardingStatus.tsx` for querying onboarding status.
>     - Updates `ConnectionStatus.tsx` to handle Kafka onboarding status and polling logic.
>   - **UI Components**:
>     - Adds new query parameters `getStartedSource` and `getStartedSourceService` in `query.ts`.
>     - Updates `DataSource.tsx` and `DataSource.styles.scss` to handle Kafka-specific data source selection.
>     - Modifies `MarkdownStep.tsx` to dynamically load documentation based on Kafka onboarding context.
>   - **Documentation**:
>     - Adds `springBoot-kubernetes-runApplication-producer.md` for Java producer setup in Kubernetes.
>     - Updates `apmDocFilePaths.ts` to include new documentation path.
>   - **Misc**:
>     - Updates `MessagingQueues.tsx` and `MessagingQueuesUtils.ts` to support Kafka onboarding navigation and utilities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 0fe6689d590b88871b978ff5124e0fe1ee64c914. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->