### PR TITLE
chore: add missing shiftby in alert rule

### DIFF
--- a/frontend/src/pages/SignUp/SignUp.tsx
+++ b/frontend/src/pages/SignUp/SignUp.tsx
@@ -303,7 +303,6 @@ function SignUp({ version }: SignUpProps): JSX.Element {
 		return (
 			loading ||
 			!values.email ||
-			!values.organizationName ||
 			(!precheck.sso && (!values.password || !values.confirmPassword)) ||
 			(!isDetailsDisable && !values.firstName) ||
 			confirmPasswordError ||
@@ -354,7 +353,6 @@ function SignUp({ version }: SignUpProps): JSX.Element {
 						<FormContainer.Item noStyle name="organizationName">
 							<Input
 								placeholder={t('placeholder_orgname')}
-								required
 								id="organizationName"
 								disabled={isDetailsDisable}
 							/>

--- a/pkg/query-service/app/parser.go
+++ b/pkg/query-service/app/parser.go
@@ -1145,25 +1145,7 @@ func ParseQueryRangeParams(r *http.Request) (*v3.QueryRangeParamsV3, *model.ApiE
 				}
 			}
 
-			// Remove the time shift function from the list of functions and set the shift by value
-			var timeShiftBy int64
-			if len(query.Functions) > 0 {
-				for idx := range query.Functions {
-					function := &query.Functions[idx]
-					if function.Name == v3.FunctionNameTimeShift {
-						// move the function to the beginning of the list
-						// so any other function can use the shifted time
-						var fns []v3.Function
-						fns = append(fns, *function)
-						fns = append(fns, query.Functions[:idx]...)
-						fns = append(fns, query.Functions[idx+1:]...)
-						query.Functions = fns
-						timeShiftBy = int64(function.Args[0].(float64))
-						break
-					}
-				}
-			}
-			query.ShiftBy = timeShiftBy
+			query.SetShiftByFromFunc()
 
 			if query.Filters == nil || len(query.Filters.Items) == 0 {
 				continue

--- a/pkg/query-service/app/parser_test.go
+++ b/pkg/query-service/app/parser_test.go
@@ -297,6 +297,8 @@ func TestParseQueryRangeParamsCompositeQuery(t *testing.T) {
 		compositeQuery v3.CompositeQuery
 		expectErr      bool
 		errMsg         string
+		hasShiftBy     bool
+		shiftBy        int64
 	}{
 		{
 			desc: "no query in request",
@@ -496,6 +498,31 @@ func TestParseQueryRangeParamsCompositeQuery(t *testing.T) {
 			expectErr: true,
 			errMsg:    "builder query A is invalid: group by is invalid",
 		},
+		{
+			desc: "builder query with shift by",
+			compositeQuery: v3.CompositeQuery{
+				PanelType: v3.PanelTypeGraph,
+				QueryType: v3.QueryTypeBuilder,
+				BuilderQueries: map[string]*v3.BuilderQuery{
+					"A": {
+						QueryName:          "A",
+						DataSource:         "logs",
+						AggregateOperator:  "sum",
+						AggregateAttribute: v3.AttributeKey{Key: "attribute"},
+						GroupBy:            []v3.AttributeKey{{Key: "group_key"}},
+						Expression:         "A",
+						Functions: []v3.Function{
+							{
+								Name: v3.FunctionNameTimeShift,
+								Args: []interface{}{float64(10)},
+							},
+						},
+					},
+				},
+			},
+			hasShiftBy: true,
+			shiftBy:    10,
+		},
 	}
 
 	for _, tc := range reqCases {
@@ -514,12 +541,15 @@ func TestParseQueryRangeParamsCompositeQuery(t *testing.T) {
 			require.NoError(t, err)
 			req := httptest.NewRequest(http.MethodPost, "/api/v3/query_range", body)
 
-			_, apiErr := ParseQueryRangeParams(req)
+			params, apiErr := ParseQueryRangeParams(req)
 			if tc.expectErr {
 				require.Error(t, apiErr)
 				require.Contains(t, apiErr.Error(), tc.errMsg)
 			} else {
 				require.Nil(t, apiErr)
+			}
+			if tc.hasShiftBy {
+				require.Equal(t, tc.shiftBy, params.CompositeQuery.BuilderQueries["A"].ShiftBy)
 			}
 		})
 	}

--- a/pkg/query-service/app/parser_test.go
+++ b/pkg/query-service/app/parser_test.go
@@ -523,6 +523,31 @@ func TestParseQueryRangeParamsCompositeQuery(t *testing.T) {
 			hasShiftBy: true,
 			shiftBy:    10,
 		},
+		{
+			desc: "builder query with shift by as string",
+			compositeQuery: v3.CompositeQuery{
+				PanelType: v3.PanelTypeGraph,
+				QueryType: v3.QueryTypeBuilder,
+				BuilderQueries: map[string]*v3.BuilderQuery{
+					"A": {
+						QueryName:          "A",
+						DataSource:         "logs",
+						AggregateOperator:  "sum",
+						AggregateAttribute: v3.AttributeKey{Key: "attribute"},
+						GroupBy:            []v3.AttributeKey{{Key: "group_key"}},
+						Expression:         "A",
+						Functions: []v3.Function{
+							{
+								Name: v3.FunctionNameTimeShift,
+								Args: []interface{}{"3600"},
+							},
+						},
+					},
+				},
+			},
+			hasShiftBy: true,
+			shiftBy:    3600,
+		},
 	}
 
 	for _, tc := range reqCases {

--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -789,6 +789,29 @@ type BuilderQuery struct {
 	QueriesUsedInFormula []string
 }
 
+func (b *BuilderQuery) SetShiftByFromFunc() {
+	// Remove the time shift function from the list of functions and set the shift by value
+	var timeShiftBy int64
+	if len(b.Functions) > 0 {
+		for idx := range b.Functions {
+			function := &b.Functions[idx]
+			if function.Name == FunctionNameTimeShift {
+				// move the function to the beginning of the list
+				// so any other function can use the shifted time
+				var fns []Function
+				fns = append(fns, *function)
+				fns = append(fns, b.Functions[:idx]...)
+				fns = append(fns, b.Functions[idx+1:]...)
+				b.Functions = fns
+				timeShiftBy = int64(function.Args[0].(float64))
+				fmt.Println("timeShiftBy", timeShiftBy)
+				break
+			}
+		}
+	}
+	b.ShiftBy = timeShiftBy
+}
+
 func (b *BuilderQuery) Clone() *BuilderQuery {
 	if b == nil {
 		return nil

--- a/pkg/query-service/rules/threshold_rule.go
+++ b/pkg/query-service/rules/threshold_rule.go
@@ -152,6 +152,9 @@ func (r *ThresholdRule) prepareQueryRange(ts time.Time) (*v3.QueryRangeParamsV3,
 			if minStep := common.MinAllowedStepInterval(start, end); q.StepInterval < minStep {
 				q.StepInterval = minStep
 			}
+
+			q.SetShiftByFromFunc()
+
 			if q.DataSource == v3.DataSourceMetrics && constants.UseMetricsPreAggregation() {
 				// if the time range is greater than 1 day, and less than 1 week set the step interval to be multiple of 5 minutes
 				// if the time range is greater than 1 week, set the step interval to be multiple of 30 mins


### PR DESCRIPTION
### Summary

Part of https://github.com/SigNoz/signoz/issues/6151

Prior to this change, shift by happened only during the `/query_range`, making the alert created with shift by useless.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `shiftBy` functionality to alert rules by implementing `SetShiftByFromFunc()` in `BuilderQuery` and applying it in query parsing and preparation.
> 
>   - **Behavior**:
>     - Add `SetShiftByFromFunc()` method to `BuilderQuery` in `v3.go` to handle `shiftBy` functionality.
>     - Apply `SetShiftByFromFunc()` in `ParseQueryRangeParams` in `parser.go` and `prepareQueryRange` in `threshold_rule.go` to set `shiftBy` during alert rule creation.
>   - **Tests**:
>     - Add test cases in `parser_test.go` and `threshold_rule_test.go` to verify `shiftBy` functionality for builder queries with `timeShift` function.
>   - **Misc**:
>     - Refactor `ParseQueryRangeParams` in `parser.go` to use `SetShiftByFromFunc()` for cleaner code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for ca5c756ba41be8ce97f8b8dfb169f8313869e8c6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->