### PR TITLE
feat: remove hardcode is darkmode value from get anomaly data func

### DIFF
--- a/frontend/src/container/AnomalyAlertEvaluationView/AnomalyAlertEvaluationView.tsx
+++ b/frontend/src/container/AnomalyAlertEvaluationView/AnomalyAlertEvaluationView.tsx
@@ -74,13 +74,13 @@ function AnomalyAlertEvaluationView({
 	const dimensions = useResizeObserver(graphRef);
 
 	useEffect(() => {
-		const chartData = getUplotChartDataForAnomalyDetection(data);
+		const chartData = getUplotChartDataForAnomalyDetection(data, isDarkMode);
 		setSeriesData(chartData);
 
 		setAllSeries(Object.keys(chartData));
 
 		setFilteredSeriesKeys(Object.keys(chartData));
-	}, [data]);
+	}, [data, isDarkMode]);
 
 	useEffect(() => {
 		const seriesKeys = Object.keys(seriesData);

--- a/frontend/src/lib/uPlotLib/utils/getUplotChartData.ts
+++ b/frontend/src/lib/uPlotLib/utils/getUplotChartData.ts
@@ -153,7 +153,8 @@ const processAnomalyDetectionData = (
 };
 
 export const getUplotChartDataForAnomalyDetection = (
-	apiResponse?: MetricRangePayloadProps,
+	apiResponse: MetricRangePayloadProps,
+	isDarkMode: boolean,
 ): Record<
 	string,
 	{
@@ -163,6 +164,5 @@ export const getUplotChartDataForAnomalyDetection = (
 	}
 > => {
 	const anomalyDetectionData = apiResponse?.data?.newResult?.data?.result;
-	const isDarkMode = true;
 	return processAnomalyDetectionData(anomalyDetectionData, isDarkMode);
 };


### PR DESCRIPTION
Fixes: https://github.com/SigNoz/signoz/pull/6194#discussion_r1812697954
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove hardcoded `isDarkMode` in `getUplotChartDataForAnomalyDetection` to dynamically handle dark mode changes.
> 
>   - **Behavior**:
>     - `getUplotChartDataForAnomalyDetection` in `getUplotChartData.ts` now accepts `isDarkMode` as a parameter instead of using a hardcoded value.
>     - Updates `useEffect` in `AnomalyAlertEvaluationView.tsx` to include `isDarkMode` as a dependency, ensuring chart data updates with dark mode changes.
>   - **Functions**:
>     - Removes hardcoded `isDarkMode` in `processAnomalyDetectionData` in `getUplotChartData.ts`.
>     - Passes `isDarkMode` to `getUplotChartDataForAnomalyDetection` in `AnomalyAlertEvaluationView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for bae443904ebb47b1d989f262b6dd4ef3590c81a5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->