### PR TITLE
fix: name is optional in bulk invite API

### DIFF
--- a/pkg/query-service/app/parser.go
+++ b/pkg/query-service/app/parser.go
@@ -750,9 +750,6 @@ func parseInviteUsersRequest(r *http.Request) (*model.BulkInviteRequest, error) 
 		if req.Users[i].Email == "" {
 			return nil, fmt.Errorf("email is required for each user")
 		}
-		if req.Users[i].Name == "" {
-			return nil, fmt.Errorf("name is required for each user")
-		}
 		if req.Users[i].FrontendBaseUrl == "" {
 			return nil, fmt.Errorf("frontendBaseUrl is required for each user")
 		}


### PR DESCRIPTION
### Summary

name field has be updated to be optional in bulk invite API according to frontend designs
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `Name` field optional in `parseInviteUsersRequest` for bulk invite API in `parser.go`.
> 
>   - **Behavior**:
>     - In `parseInviteUsersRequest` in `parser.go`, the `Name` field is no longer required for each user in the bulk invite API.
>     - If `Name` is missing, no error is returned, aligning with frontend design changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for c2912d93270ca7a08c87d96ca7abbe37f7b5b1f2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->