### PR TITLE
Fix/bulk invite api error response

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1993,7 +1993,7 @@ func (aH *APIHandler) inviteUsers(w http.ResponseWriter, r *http.Request) {
 	}
 	// Check the response status and set the appropriate HTTP status code
 	if response.Status == "failure" {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusBadRequest) // 400 Bad Request for failure
 	} else if response.Status == "partial_success" {
 		w.WriteHeader(http.StatusPartialContent) // 206 Partial Content
 	} else {

--- a/pkg/query-service/app/parser.go
+++ b/pkg/query-service/app/parser.go
@@ -750,9 +750,6 @@ func parseInviteUsersRequest(r *http.Request) (*model.BulkInviteRequest, error) 
 		if req.Users[i].Email == "" {
 			return nil, fmt.Errorf("email is required for each user")
 		}
-		if req.Users[i].Name == "" {
-			return nil, fmt.Errorf("name is required for each user")
-		}
 		if req.Users[i].FrontendBaseUrl == "" {
 			return nil, fmt.Errorf("frontendBaseUrl is required for each user")
 		}


### PR DESCRIPTION
### Summary

Respond with 400 in case of failures. Since it is a bulk API which can have multiple types of failures, so according to discussion with frontend team, we have decided to use 400 as common failure code with failure details in json
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change bulk invite API to return 400 status code for failures.
> 
>   - **Behavior**:
>     - Change HTTP status code from 500 to 400 for failure responses in `inviteUsers()` in `http_handler.go`.
>   - **Misc**:
>     - Update comments to reflect the new status code behavior in `http_handler.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 5a7e597bacf36abe92e65f2c1635b2b79b583f1c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->