### PR TITLE
feat: add org onboarding preference

### DIFF
--- a/pkg/query-service/app/preferences/map.go
+++ b/pkg/query-service/app/preferences/map.go
@@ -1,37 +1,14 @@
 package preferences
 
 var preferenceMap = map[string]Preference{
-	"DASHBOARDS_LIST_VIEW": {
-		Key:              "DASHBOARDS_LIST_VIEW",
-		Name:             "Dashboards List View",
-		Description:      "",
-		ValueType:        "string",
-		DefaultValue:     "grid",
-		AllowedValues:    []interface{}{"grid", "list"},
-		IsDiscreteValues: true,
-		AllowedScopes:    []string{"user", "org"},
-	},
-	"LOGS_TOOLBAR_COLLAPSED": {
-		Key:              "LOGS_TOOLBAR_COLLAPSED",
-		Name:             "Logs toolbar",
-		Description:      "",
+	"ORG_ONBOARDING": {
+		Key:              "ORG_ONBOARDING",
+		Name:             "Organisation Onboarding",
+		Description:      "Organisation Onboarding",
 		ValueType:        "boolean",
 		DefaultValue:     false,
 		AllowedValues:    []interface{}{true, false},
 		IsDiscreteValues: true,
-		AllowedScopes:    []string{"user", "org"},
-	},
-	"MAX_DEPTH_ALLOWED": {
-		Key:              "MAX_DEPTH_ALLOWED",
-		Name:             "Max Depth Allowed",
-		Description:      "",
-		ValueType:        "integer",
-		DefaultValue:     10,
-		IsDiscreteValues: false,
-		Range: Range{
-			Min: 0,
-			Max: 100,
-		},
-		AllowedScopes: []string{"user", "org"},
+		AllowedScopes:    []string{"org"},
 	},
 }


### PR DESCRIPTION
Add ORG_ONBOARDING as org scoped preference.
Remove dummy preferences
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `ORG_ONBOARDING` preference and remove dummy preferences in `map.go`.
> 
>   - **Preferences**:
>     - Add `ORG_ONBOARDING` preference in `map.go` with boolean type, default `false`, and `org` scope.
>     - Remove `DASHBOARDS_LIST_VIEW`, `LOGS_TOOLBAR_COLLAPSED`, and `MAX_DEPTH_ALLOWED` from `map.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 0d1e0880f7ad48652c0345daf249c48a924c2ac9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->