### PR TITLE
fix: redirect to docs on clicking alert setup guide in create alert page

### DIFF
--- a/frontend/src/container/FormAlertRules/index.tsx
+++ b/frontend/src/container/FormAlertRules/index.tsx
@@ -73,6 +73,19 @@ export enum AlertDetectionTypes {
 	ANOMALY_DETECTION_ALERT = 'anomaly_rule',
 }
 
+const ALERT_SETUP_GUIDE_URLS: Record<AlertTypes, string> = {
+	[AlertTypes.METRICS_BASED_ALERT]:
+		'https://signoz.io/docs/alerts-management/metrics-based-alerts/?utm_source=product&utm_medium=alert-creation-page',
+	[AlertTypes.LOGS_BASED_ALERT]:
+		'https://signoz.io/docs/alerts-management/log-based-alerts/?utm_source=product&utm_medium=alert-creation-page',
+	[AlertTypes.TRACES_BASED_ALERT]:
+		'https://signoz.io/docs/alerts-management/trace-based-alerts/?utm_source=product&utm_medium=alert-creation-page',
+	[AlertTypes.EXCEPTIONS_BASED_ALERT]:
+		'https://signoz.io/docs/alerts-management/exceptions-based-alerts/?utm_source=product&utm_medium=alert-creation-page',
+	[AlertTypes.ANOMALY_BASED_ALERT]:
+		'https://signoz.io/docs/alerts-management/anomaly-based-alerts/?utm_source=product&utm_medium=alert-creation-page',
+};
+
 // eslint-disable-next-line sonarjs/cognitive-complexity
 function FormAlertRules({
 	alertType,
@@ -702,6 +715,29 @@ function FormAlertRules({
 
 	const isRuleCreated = !ruleId || ruleId === 0;
 
+	function handleRedirection(option: AlertTypes): void {
+		let url;
+		if (
+			option === AlertTypes.METRICS_BASED_ALERT &&
+			alertTypeFromURL === AlertDetectionTypes.ANOMALY_DETECTION_ALERT
+		) {
+			url = ALERT_SETUP_GUIDE_URLS[AlertTypes.ANOMALY_BASED_ALERT];
+		} else {
+			url = ALERT_SETUP_GUIDE_URLS[option];
+		}
+
+		if (url) {
+			logEvent('Alert: Check example alert clicked', {
+				dataSource: ALERTS_DATA_SOURCE_MAP[alertDef?.alertType as AlertTypes],
+				isNewRule: !ruleId || ruleId === 0,
+				ruleId,
+				queryType: currentQuery.queryType,
+				link: url,
+			});
+			window.open(url, '_blank');
+		}
+	}
+
 	useEffect(() => {
 		if (!isRuleCreated) {
 			logEvent('Alert: Edit page visited', {
@@ -752,7 +788,11 @@ function FormAlertRules({
 						)}
 					</div>
 
-					<Button className="periscope-btn" icon={<ExternalLink size={14} />}>
+					<Button
+						className="periscope-btn"
+						onClick={(): void => handleRedirection(alertDef.alertType as AlertTypes)}
+						icon={<ExternalLink size={14} />}
+					>
 						Alert Setup Guide
 					</Button>
 				</div>


### PR DESCRIPTION
### Summary
On clicking Alert Setup Guide in create alert page, add support for redirecting to alert setup guide based on alert type 
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
![screenshot_2024-10-24_at_13 48 13_480](https://github.com/user-attachments/assets/24150027-a68d-4a31-850a-84b0e48130db)

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds redirection to specific alert setup guides based on alert type in `FormAlertRules` component.
> 
>   - **Behavior**:
>     - Adds `ALERT_SETUP_GUIDE_URLS` mapping in `index.tsx` for different alert types to their respective setup guide URLs.
>     - Implements `handleRedirection()` function in `index.tsx` to open the appropriate URL in a new tab when the 'Alert Setup Guide' button is clicked.
>     - Logs an event with `logEvent()` when the redirection occurs.
>   - **UI**:
>     - Updates the 'Alert Setup Guide' button in `index.tsx` to trigger `handleRedirection()` with the current alert type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 81d1c30a98ce5c3873736ed8bdc5ca395670ce21. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->