### PR TITLE
enable scenario 4 on staging

### DIFF
--- a/.github/workflows/staging-deployment.yaml
+++ b/.github/workflows/staging-deployment.yaml
@@ -31,7 +31,6 @@ jobs:
           GCP_ZONE: ${{ secrets.GCP_ZONE }}
           GCP_INSTANCE: ${{ secrets.GCP_INSTANCE }}
           CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-          KAFKA_SPAN_EVAL: true
         run: |
           read -r -d '' COMMAND <<EOF || true
           echo "GITHUB_BRANCH: ${GITHUB_BRANCH}"
@@ -39,6 +38,7 @@ jobs:
           export DOCKER_TAG="${GITHUB_SHA:0:7}" # needed for child process to access it
           export OTELCOL_TAG="main"
           export PATH="/usr/local/go/bin/:$PATH" # needed for Golang to work
+          export KAFKA_SPAN_EVAL="true"
           docker system prune --force
           docker pull signoz/signoz-otel-collector:main
           docker pull signoz/signoz-schema-migrator:main

--- a/deploy/docker/clickhouse-setup/docker-compose.testing.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.testing.yaml
@@ -191,6 +191,7 @@ services:
       - GODEBUG=netdns=go
       - TELEMETRY_ENABLED=true
       - DEPLOYMENT_TYPE=docker-standalone-amd
+      - KAFKA_SPAN_EVAL=${KAFKA_SPAN_EVAL:-false}
     restart: on-failure
     healthcheck:
       test:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable scenario 4 on staging by setting `KAFKA_SPAN_EVAL` to `true` and adjusting Kafka query parameters.
> 
>   - **Environment**:
>     - Set `KAFKA_SPAN_EVAL` to `true` in `.github/workflows/staging-deployment.yaml` to enable scenario 4 on staging.
>   - **Query Parameters**:
>     - Change query context from `partition_latency` to `producer-topic-throughput` in `getPartitionOverviewLatencyData()` in `http_handler.go`.
>   - **Model Changes**:
>     - Add `omitempty` to `EvalTime` in `MessagingQueue` struct in `model.go` to omit zero values in JSON serialization.
>   - **Query Logic**:
>     - Remove `producer-topic-throughput` from `BuildClickHouseQuery()` in `translator.go` to prevent its use in certain contexts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for d82626a5d1342a28069cdc21092273dfe4aa66a2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->