### PR TITLE
fix: arithmetic operators are removed from Dashboard query builder formulas

### DIFF
--- a/frontend/src/container/GridCardLayout/WidgetHeader/index.tsx
+++ b/frontend/src/container/GridCardLayout/WidgetHeader/index.tsx
@@ -82,7 +82,7 @@ function WidgetHeader({
 			QueryParams.compositeQuery,
 			encodeURIComponent(JSON.stringify(widget.query)),
 		);
-		const generatedUrl = `${window.location.pathname}?${urlQuery}`;
+		const generatedUrl = `${window.location.pathname}/new?${urlQuery}`;
 		history.push(generatedUrl);
 	}, [urlQuery, widget.id, widget.panelTypes, widget.query]);
 

--- a/frontend/src/container/GridCardLayout/WidgetHeader/index.tsx
+++ b/frontend/src/container/GridCardLayout/WidgetHeader/index.tsx
@@ -18,6 +18,7 @@ import { QueryParams } from 'constants/query';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import useCreateAlerts from 'hooks/queryBuilder/useCreateAlerts';
 import useComponentPermission from 'hooks/useComponentPermission';
+import useUrlQuery from 'hooks/useUrlQuery';
 import history from 'lib/history';
 import { RowData } from 'lib/query/createTableColumnsFromQuery';
 import { isEmpty } from 'lodash-es';
@@ -72,16 +73,18 @@ function WidgetHeader({
 	tableProcessedDataRef,
 	setSearchTerm,
 }: IWidgetHeaderProps): JSX.Element | null {
+	const urlQuery = useUrlQuery();
 	const onEditHandler = useCallback((): void => {
 		const widgetId = widget.id;
-		history.push(
-			`${window.location.pathname}/new?widgetId=${widgetId}&graphType=${
-				widget.panelTypes
-			}&${QueryParams.compositeQuery}=${encodeURIComponent(
-				JSON.stringify(widget.query),
-			)}`,
+		urlQuery.set(QueryParams.widgetId, widgetId);
+		urlQuery.set(QueryParams.graphType, widget.panelTypes);
+		urlQuery.set(
+			QueryParams.compositeQuery,
+			encodeURIComponent(JSON.stringify(widget.query)),
 		);
-	}, [widget.id, widget.panelTypes, widget.query]);
+		const generatedUrl = `${window.location.pathname}?${urlQuery}`;
+		history.push(generatedUrl);
+	}, [urlQuery, widget.id, widget.panelTypes, widget.query]);
 
 	const onCreateAlertsHandler = useCreateAlerts(widget, 'dashboardView');
 


### PR DESCRIPTION
### Summary

- the redirection from dashboards page to edit widget page was manually setting query params and not utilising the `URLSearchParams` due to which proper encodings were not in place. 
- the result of this was that decoding was not correct since we have moved to strict standards now. 

#### Related Issues / PR's

fixes https://github.com/SigNoz/signoz/issues/6274 

#### Screenshots


https://github.com/user-attachments/assets/72d3f0b5-b7e6-4389-9cc7-4d163232a946



#### Affected Areas and Manually Tested Areas

- dashboards page to widget edit and back / reload the page

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes URL encoding issue in `WidgetHeader` by using `useUrlQuery` for query parameter management in `onEditHandler`.
> 
>   - **Behavior**:
>     - Fixes URL encoding issue in `onEditHandler` in `WidgetHeader` by using `useUrlQuery` for query parameter management.
>     - Corrects redirection from dashboards to edit widget page, ensuring proper URL encoding.
>   - **Functions**:
>     - Updates `onEditHandler` to use `useUrlQuery` for setting `widgetId`, `graphType`, and `compositeQuery` parameters.
>   - **Misc**:
>     - Addresses issue #6274 related to URL encoding in dashboard widget editing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 7537040be5dff66dc0b24e1fd2c2a5cf76309c4a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->