### PR TITLE
feat: added generic UI for scenario 1,3,4

### DIFF
--- a/frontend/src/constants/query.ts
+++ b/frontend/src/constants/query.ts
@@ -37,4 +37,5 @@ export enum QueryParams {
 	partition = 'partition',
 	selectedTimelineQuery = 'selectedTimelineQuery',
 	ruleType = 'ruleType',
+	configDetail = 'configDetail',
 }

--- a/frontend/src/pages/MessagingQueues/MQDetailPage/MQDetailPage.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetailPage/MQDetailPage.tsx
@@ -8,7 +8,10 @@ import { ListMinus } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
-import { MessagingQueuesViewType } from '../MessagingQueuesUtils';
+import {
+	MessagingQueuesViewType,
+	ProducerLatencyOptions,
+} from '../MessagingQueuesUtils';
 import { SelectLabelWithComingSoon } from '../MQCommon/MQCommon';
 import MessagingQueueOverview from '../MQDetails/MessagingQueueOverview';
 import MessagingQueuesDetails from '../MQDetails/MQDetails';
@@ -20,6 +23,11 @@ function MQDetailPage(): JSX.Element {
 	const [selectedView, setSelectedView] = useState<string>(
 		MessagingQueuesViewType.consumerLag.value,
 	);
+
+	const [
+		producerLatencyOption,
+		setproducerLatencyOption,
+	] = useState<ProducerLatencyOptions>(ProducerLatencyOptions.Producers);
 
 	useEffect(() => {
 		logEvent('Messaging Queues: Detail page visited', {});
@@ -54,13 +62,8 @@ function MQDetailPage(): JSX.Element {
 								value: MessagingQueuesViewType.partitionLatency.value,
 							},
 							{
-								label: (
-									<SelectLabelWithComingSoon
-										label={MessagingQueuesViewType.producerLatency.label}
-									/>
-								),
+								label: MessagingQueuesViewType.producerLatency.label,
 								value: MessagingQueuesViewType.producerLatency.value,
-								disabled: true,
 							},
 							{
 								label: (
@@ -81,11 +84,18 @@ function MQDetailPage(): JSX.Element {
 				{selectedView === MessagingQueuesViewType.consumerLag.value ? (
 					<MessagingQueuesGraph />
 				) : (
-					<MessagingQueueOverview selectedView={selectedView} />
+					<MessagingQueueOverview
+						selectedView={selectedView}
+						option={producerLatencyOption}
+						setOption={setproducerLatencyOption}
+					/>
 				)}
 			</div>
 			<div className="messaging-queue-details">
-				<MessagingQueuesDetails selectedView={selectedView} />
+				<MessagingQueuesDetails
+					selectedView={selectedView}
+					producerLatencyOption={producerLatencyOption}
+				/>
 			</div>
 		</div>
 	);

--- a/frontend/src/pages/MessagingQueues/MQDetailPage/MQDetailPage.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetailPage/MQDetailPage.tsx
@@ -10,6 +10,7 @@ import { useHistory } from 'react-router-dom';
 
 import {
 	MessagingQueuesViewType,
+	MessagingQueuesViewTypeOptions,
 	ProducerLatencyOptions,
 } from '../MessagingQueuesUtils';
 import { SelectLabelWithComingSoon } from '../MQCommon/MQCommon';
@@ -20,7 +21,10 @@ import MessagingQueuesGraph from '../MQGraph/MQGraph';
 
 function MQDetailPage(): JSX.Element {
 	const history = useHistory();
-	const [selectedView, setSelectedView] = useState<string>(
+	const [
+		selectedView,
+		setSelectedView,
+	] = useState<MessagingQueuesViewTypeOptions>(
 		MessagingQueuesViewType.consumerLag.value,
 	);
 

--- a/frontend/src/pages/MessagingQueues/MQDetailPage/MQDetailPage.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetailPage/MQDetailPage.tsx
@@ -5,17 +5,21 @@ import logEvent from 'api/common/logEvent';
 import ROUTES from 'constants/routes';
 import DateTimeSelectionV2 from 'container/TopNav/DateTimeSelectionV2';
 import { ListMinus } from 'lucide-react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { MessagingQueuesViewType } from '../MessagingQueuesUtils';
 import { SelectLabelWithComingSoon } from '../MQCommon/MQCommon';
+import MessagingQueueOverview from '../MQDetails/MessagingQueueOverview';
 import MessagingQueuesDetails from '../MQDetails/MQDetails';
 import MessagingQueuesConfigOptions from '../MQGraph/MQConfigOptions';
 import MessagingQueuesGraph from '../MQGraph/MQGraph';
 
 function MQDetailPage(): JSX.Element {
 	const history = useHistory();
+	const [selectedView, setSelectedView] = useState<string>(
+		MessagingQueuesViewType.consumerLag.value,
+	);
 
 	useEffect(() => {
 		logEvent('Messaging Queues: Detail page visited', {});
@@ -39,19 +43,15 @@ function MQDetailPage(): JSX.Element {
 						className="messaging-queue-options"
 						defaultValue={MessagingQueuesViewType.consumerLag.value}
 						popupClassName="messaging-queue-options-popup"
+						onChange={(value): void => setSelectedView(value)}
 						options={[
 							{
 								label: MessagingQueuesViewType.consumerLag.label,
 								value: MessagingQueuesViewType.consumerLag.value,
 							},
 							{
-								label: (
-									<SelectLabelWithComingSoon
-										label={MessagingQueuesViewType.partitionLatency.label}
-									/>
-								),
+								label: MessagingQueuesViewType.partitionLatency.label,
 								value: MessagingQueuesViewType.partitionLatency.value,
-								disabled: true,
 							},
 							{
 								label: (
@@ -78,10 +78,14 @@ function MQDetailPage(): JSX.Element {
 			</div>
 			<div className="messaging-queue-main-graph">
 				<MessagingQueuesConfigOptions />
-				<MessagingQueuesGraph />
+				{selectedView === MessagingQueuesViewType.consumerLag.value ? (
+					<MessagingQueuesGraph />
+				) : (
+					<MessagingQueueOverview selectedView={selectedView} />
+				)}
 			</div>
 			<div className="messaging-queue-details">
-				<MessagingQueuesDetails />
+				<MessagingQueuesDetails selectedView={selectedView} />
 			</div>
 		</div>
 	);

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQDetails.style.scss
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQDetails.style.scss
@@ -4,3 +4,42 @@
 	flex-direction: column;
 	gap: 24px;
 }
+
+.mq-overview-container {
+	display: flex;
+	padding: 24px;
+	flex-direction: column;
+	align-items: start;
+	gap: 16px;
+
+	border-radius: 6px;
+	border: 1px solid var(--bg-slate-500);
+	background: var(--bg-ink-500);
+
+	.mq-overview-title {
+		color: var(--bg-vanilla-200);
+
+		font-family: Inter;
+		font-size: 18px;
+		font-style: normal;
+		font-weight: 500;
+		line-height: 28px;
+	}
+
+	.mq-details-options {
+		letter-spacing: -0.06px;
+		cursor: pointer;
+
+		.ant-radio-button-wrapper {
+			border-color: var(--bg-slate-400);
+			color: var(--bg-vanilla-400);
+		}
+		.ant-radio-button-wrapper-checked {
+			background: var(--bg-slate-400);
+			color: var(--bg-vanilla-100);
+		}
+		.ant-radio-button-wrapper::before {
+			width: 0px;
+		}
+	}
+}

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQDetails.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQDetails.tsx
@@ -1,71 +1,256 @@
 import './MQDetails.style.scss';
 
 import { Radio } from 'antd';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { QueryParams } from 'constants/query';
+import useUrlQuery from 'hooks/useUrlQuery';
+import { isEmpty } from 'lodash-es';
+import { Dispatch, SetStateAction, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { AppState } from 'store/reducers';
+import { ErrorResponse, SuccessResponse } from 'types/api';
+import { GlobalReducer } from 'types/reducer/globalTime';
 
 import {
 	ConsumerLagDetailTitle,
-	ConsumerLagDetailType,
+	MessagingQueueServiceDetailType,
 	MessagingQueuesViewType,
+	SelectedTimelineQuery,
 } from '../MessagingQueuesUtils';
 import { ComingSoon } from '../MQCommon/MQCommon';
+import {
+	getConsumerLagDetails,
+	MessagingQueueServicePayload,
+	MessagingQueuesPayloadProps,
+} from './MQTables/getConsumerLagDetails';
+import { getPartitionLatencyDetails } from './MQTables/getPartitionLatencyDetails';
 import MessagingQueuesTable from './MQTables/MQTables';
+
+const MQServiceDetailTypePerView = {
+	[MessagingQueuesViewType.consumerLag.value]: [
+		MessagingQueueServiceDetailType.ConsumerDetails,
+		MessagingQueueServiceDetailType.ProducerDetails,
+		MessagingQueueServiceDetailType.NetworkLatency,
+		MessagingQueueServiceDetailType.PartitionHostMetrics,
+	],
+	[MessagingQueuesViewType.partitionLatency.value]: [
+		MessagingQueueServiceDetailType.ConsumerDetails,
+		MessagingQueueServiceDetailType.ProducerDetails,
+	],
+	[MessagingQueuesViewType.producerLatency.value]: [
+		MessagingQueueServiceDetailType.ConsumerDetails,
+		MessagingQueueServiceDetailType.ProducerDetails,
+	],
+};
+
+interface MessagingQueuesOptionsProps {
+	currentTab: MessagingQueueServiceDetailType;
+	setCurrentTab: Dispatch<SetStateAction<MessagingQueueServiceDetailType>>;
+	selectedView: string;
+}
 
 function MessagingQueuesOptions({
 	currentTab,
 	setCurrentTab,
 	selectedView,
-}: {
-	currentTab: ConsumerLagDetailType;
-	setCurrentTab: Dispatch<SetStateAction<ConsumerLagDetailType>>;
-	selectedView: string;
-}): JSX.Element {
-	const [option, setOption] = useState<ConsumerLagDetailType>(currentTab);
+}: MessagingQueuesOptionsProps): JSX.Element {
+	const [option, setOption] = useState<MessagingQueueServiceDetailType>(
+		currentTab,
+	);
+
+	const handleChange = (value: MessagingQueueServiceDetailType): void => {
+		setOption(value);
+		setCurrentTab(value);
+	};
+
+	const renderRadioButtons = (): JSX.Element[] => {
+		const detailTypes = MQServiceDetailTypePerView[selectedView] || [];
+		return detailTypes.map((detailType) => (
+			<Radio.Button
+				key={detailType}
+				value={detailType}
+				disabled={
+					detailType === MessagingQueueServiceDetailType.PartitionHostMetrics
+				}
+				className={
+					detailType === MessagingQueueServiceDetailType.PartitionHostMetrics
+						? 'disabled-option'
+						: ''
+				}
+			>
+				{ConsumerLagDetailTitle[detailType]}
+				{detailType === MessagingQueueServiceDetailType.PartitionHostMetrics && (
+					<ComingSoon />
+				)}
+			</Radio.Button>
+		));
+	};
 
 	return (
 		<Radio.Group
-			onChange={(value): void => {
-				setOption(value.target.value);
-				setCurrentTab(value.target.value);
-			}}
+			onChange={(e): void => handleChange(e.target.value)}
 			value={option}
 			className="mq-details-options"
 		>
-			<Radio.Button value={ConsumerLagDetailType.ConsumerDetails} checked>
-				{ConsumerLagDetailTitle[ConsumerLagDetailType.ConsumerDetails]}
-			</Radio.Button>
-			{selectedView !== MessagingQueuesViewType.partitionLatency.value && (
-				<Radio.Button value={ConsumerLagDetailType.ProducerDetails}>
-					{ConsumerLagDetailTitle[ConsumerLagDetailType.ProducerDetails]}
-				</Radio.Button>
-			)}
-			{selectedView !== MessagingQueuesViewType.partitionLatency.value && (
-				<Radio.Button value={ConsumerLagDetailType.NetworkLatency}>
-					{ConsumerLagDetailTitle[ConsumerLagDetailType.NetworkLatency]}
-				</Radio.Button>
-			)}
-			{selectedView !== MessagingQueuesViewType.partitionLatency.value && (
-				<Radio.Button
-					value={ConsumerLagDetailType.PartitionHostMetrics}
-					disabled
-					className="disabled-option"
-				>
-					{ConsumerLagDetailTitle[ConsumerLagDetailType.PartitionHostMetrics]}
-					<ComingSoon />
-				</Radio.Button>
-			)}
+			{renderRadioButtons()}
 		</Radio.Group>
 	);
 }
+
+interface MetaDataAndAPI {
+	tableApiPayload: MessagingQueueServicePayload;
+	tableApi: (
+		props: MessagingQueueServicePayload,
+	) => Promise<
+		SuccessResponse<MessagingQueuesPayloadProps['payload']> | ErrorResponse
+	>;
+}
+
+interface MetaDataAndAPIPerView {
+	detailType: MessagingQueueServiceDetailType;
+	selectedTimelineQuery: SelectedTimelineQuery;
+	configDetails?: {
+		[key: string]: string;
+	};
+	minTime: number;
+	maxTime: number;
+}
+
+export const getMetaDataAndAPIPerView = (
+	metaDataProps: MetaDataAndAPIPerView,
+): Record<string, MetaDataAndAPI> => {
+	const {
+		detailType,
+		minTime,
+		maxTime,
+		selectedTimelineQuery,
+		// configDetails,
+	} = metaDataProps;
+	return {
+		[MessagingQueuesViewType.consumerLag.value]: {
+			tableApiPayload: {
+				start: (selectedTimelineQuery?.start || 0) * 1e9,
+				end: (selectedTimelineQuery?.end || 0) * 1e9,
+				variables: {
+					partition: selectedTimelineQuery?.partition,
+					topic: selectedTimelineQuery?.topic,
+					consumer_group: selectedTimelineQuery?.group,
+				},
+				detailType,
+			},
+			tableApi: getConsumerLagDetails,
+		},
+		[MessagingQueuesViewType.partitionLatency.value]: {
+			tableApiPayload: {
+				start: minTime,
+				end: maxTime,
+				variables: {
+					// partition: configDetails?.partition,
+					// topic: configDetails?.topic,
+					// consumer_group: configDetails?.group,
+
+					// todo-sagar: look at above props
+					partition: selectedTimelineQuery?.partition,
+					topic: selectedTimelineQuery?.topic,
+					consumer_group: selectedTimelineQuery?.group,
+				},
+				detailType,
+			},
+			tableApi: getPartitionLatencyDetails,
+		},
+		[MessagingQueuesViewType.producerLatency.value]: {
+			tableApiPayload: {
+				start: minTime,
+				end: maxTime,
+				variables: {
+					partition: '',
+					topic: '',
+					consumer_group: '',
+				},
+				detailType,
+			},
+			tableApi: getConsumerLagDetails,
+		},
+	};
+};
+
+const checkValidityOfDetailConfigs = (
+	selectedTimelineQuery: SelectedTimelineQuery,
+	selectedView: string,
+	currentTab: MessagingQueueServiceDetailType,
+	// configDetails?: {
+	// 	[key: string]: string;
+	// },
+): boolean => {
+	if (selectedView === MessagingQueuesViewType.consumerLag.value) {
+		return !(
+			isEmpty(selectedTimelineQuery) ||
+			(!selectedTimelineQuery?.group &&
+				!selectedTimelineQuery?.topic &&
+				!selectedTimelineQuery?.partition)
+		);
+	}
+
+	if (selectedView === MessagingQueuesViewType.partitionLatency.value) {
+		// todo-sagar - change to configdetails
+		if (isEmpty(selectedTimelineQuery)) {
+			return false;
+		}
+
+		if (currentTab === MessagingQueueServiceDetailType.ConsumerDetails) {
+			return Boolean(
+				selectedTimelineQuery?.topic && selectedTimelineQuery?.partition,
+			);
+		}
+		return Boolean(
+			selectedTimelineQuery?.group &&
+				selectedTimelineQuery?.topic &&
+				selectedTimelineQuery?.partition,
+		);
+	}
+
+	return false;
+};
 
 function MessagingQueuesDetails({
 	selectedView,
 }: {
 	selectedView: string;
 }): JSX.Element {
-	const [currentTab, setCurrentTab] = useState<ConsumerLagDetailType>(
-		ConsumerLagDetailType.ConsumerDetails,
+	const [currentTab, setCurrentTab] = useState<MessagingQueueServiceDetailType>(
+		MessagingQueueServiceDetailType.ConsumerDetails,
 	);
+
+	const urlQuery = useUrlQuery();
+	const timelineQuery = decodeURIComponent(
+		urlQuery.get(QueryParams.selectedTimelineQuery) || '',
+	);
+
+	const timelineQueryData: SelectedTimelineQuery = useMemo(
+		() => (timelineQuery ? JSON.parse(timelineQuery) : {}),
+		[timelineQuery],
+	);
+
+	const configDetails = decodeURIComponent(
+		urlQuery.get(QueryParams.configDetail) || '',
+	);
+
+	const configDetailQueryData: {
+		[key: string]: string;
+	} = useMemo(() => (configDetails ? JSON.parse(configDetails) : {}), [
+		configDetails,
+	]);
+
+	const { maxTime, minTime } = useSelector<AppState, GlobalReducer>(
+		(state) => state.globalTime,
+	);
+
+	const serviceConfigDetails = getMetaDataAndAPIPerView({
+		detailType: currentTab,
+		minTime,
+		maxTime,
+		selectedTimelineQuery: timelineQueryData,
+		configDetails: configDetailQueryData,
+	});
 
 	return (
 		<div className="mq-details">
@@ -77,7 +262,14 @@ function MessagingQueuesDetails({
 			<MessagingQueuesTable
 				currentTab={currentTab}
 				selectedView={selectedView}
-				type="Detail"
+				tableApi={serviceConfigDetails[selectedView].tableApi}
+				validConfigPresent={checkValidityOfDetailConfigs(
+					timelineQueryData,
+					selectedView,
+					currentTab,
+					// configDetailQueryData,
+				)}
+				tableApiPayload={serviceConfigDetails[selectedView].tableApiPayload}
 			/>
 		</div>
 	);

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQDetails.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQDetails.tsx
@@ -137,7 +137,7 @@ export const getMetaDataAndAPIPerView = (
 		minTime,
 		maxTime,
 		selectedTimelineQuery,
-		// configDetails,
+		configDetails,
 	} = metaDataProps;
 	return {
 		[MessagingQueuesViewType.consumerLag.value]: {
@@ -158,14 +158,14 @@ export const getMetaDataAndAPIPerView = (
 				start: minTime,
 				end: maxTime,
 				variables: {
-					// partition: configDetails?.partition,
-					// topic: configDetails?.topic,
-					// consumer_group: configDetails?.group,
+					partition: configDetails?.partition,
+					topic: configDetails?.topic,
+					consumer_group: configDetails?.group,
 
 					// todo-sagar: look at above props
-					partition: selectedTimelineQuery?.partition,
-					topic: selectedTimelineQuery?.topic,
-					consumer_group: selectedTimelineQuery?.group,
+					// partition: selectedTimelineQuery?.partition,
+					// topic: selectedTimelineQuery?.topic,
+					// consumer_group: selectedTimelineQuery?.group,
 				},
 				detailType,
 			},
@@ -176,14 +176,14 @@ export const getMetaDataAndAPIPerView = (
 				start: minTime,
 				end: maxTime,
 				variables: {
-					// partition: configDetails?.partition,
-					// topic: configDetails?.topic,
-					// service_name: configDetails?.service_name,
+					partition: configDetails?.partition,
+					topic: configDetails?.topic,
+					service_name: configDetails?.service_name,
 
-					// todo-sagar: look at above props
-					partition: selectedTimelineQuery?.partition,
-					topic: selectedTimelineQuery?.topic,
-					service_name: 'consumer-svc-1', // todo-sagar remove hardcode
+					// // todo-sagar: look at above props
+					// partition: selectedTimelineQuery?.partition,
+					// topic: selectedTimelineQuery?.topic,
+					// service_name: 'consumer-svc-1', // todo-sagar remove hardcode
 				},
 				detailType,
 			},
@@ -196,9 +196,9 @@ const checkValidityOfDetailConfigs = (
 	selectedTimelineQuery: SelectedTimelineQuery,
 	selectedView: string,
 	currentTab: MessagingQueueServiceDetailType,
-	// configDetails?: {
-	// 	[key: string]: string;
-	// },
+	configDetails?: {
+		[key: string]: string;
+	},
 	// eslint-disable-next-line sonarjs/cognitive-complexity
 ): boolean => {
 	if (selectedView === MessagingQueuesViewType.consumerLag.value) {
@@ -211,35 +211,31 @@ const checkValidityOfDetailConfigs = (
 	}
 
 	if (selectedView === MessagingQueuesViewType.partitionLatency.value) {
-		// todo-sagar - change to configdetails
-		if (isEmpty(selectedTimelineQuery)) {
+		if (isEmpty(configDetails)) {
 			return false;
 		}
 
 		if (currentTab === MessagingQueueServiceDetailType.ConsumerDetails) {
-			return Boolean(
-				selectedTimelineQuery?.topic && selectedTimelineQuery?.partition,
-			);
+			return Boolean(configDetails?.topic && configDetails?.partition);
 		}
 		return Boolean(
-			selectedTimelineQuery?.group &&
-				selectedTimelineQuery?.topic &&
-				selectedTimelineQuery?.partition,
+			configDetails?.group && configDetails?.topic && configDetails?.partition,
 		);
 	}
 
 	if (selectedView === MessagingQueuesViewType.producerLatency.value) {
-		// todo-sagar - change to configdetails and add service_name
-		if (isEmpty(selectedTimelineQuery)) {
+		if (isEmpty(configDetails)) {
 			return false;
 		}
 
 		if (currentTab === MessagingQueueServiceDetailType.ProducerDetails) {
 			return Boolean(
-				selectedTimelineQuery?.topic && selectedTimelineQuery?.partition,
+				configDetails?.topic &&
+					configDetails?.partition &&
+					configDetails?.service_name,
 			);
 		}
-		return Boolean(selectedTimelineQuery?.topic);
+		return Boolean(configDetails?.topic && configDetails?.service_name);
 	}
 
 	return false;
@@ -321,7 +317,7 @@ function MessagingQueuesDetails({
 					timelineQueryData,
 					selectedView,
 					currentTab,
-					// configDetailQueryData,
+					configDetailQueryData,
 				)}
 				tableApiPayload={serviceConfigDetails[selectedView].tableApiPayload}
 			/>

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQDetails.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQDetails.tsx
@@ -6,6 +6,7 @@ import { Dispatch, SetStateAction, useState } from 'react';
 import {
 	ConsumerLagDetailTitle,
 	ConsumerLagDetailType,
+	MessagingQueuesViewType,
 } from '../MessagingQueuesUtils';
 import { ComingSoon } from '../MQCommon/MQCommon';
 import MessagingQueuesTable from './MQTables/MQTables';
@@ -13,9 +14,11 @@ import MessagingQueuesTable from './MQTables/MQTables';
 function MessagingQueuesOptions({
 	currentTab,
 	setCurrentTab,
+	selectedView,
 }: {
 	currentTab: ConsumerLagDetailType;
 	setCurrentTab: Dispatch<SetStateAction<ConsumerLagDetailType>>;
+	selectedView: string;
 }): JSX.Element {
 	const [option, setOption] = useState<ConsumerLagDetailType>(currentTab);
 
@@ -31,35 +34,51 @@ function MessagingQueuesOptions({
 			<Radio.Button value={ConsumerLagDetailType.ConsumerDetails} checked>
 				{ConsumerLagDetailTitle[ConsumerLagDetailType.ConsumerDetails]}
 			</Radio.Button>
-			<Radio.Button value={ConsumerLagDetailType.ProducerDetails}>
-				{ConsumerLagDetailTitle[ConsumerLagDetailType.ProducerDetails]}
-			</Radio.Button>
-			<Radio.Button value={ConsumerLagDetailType.NetworkLatency}>
-				{ConsumerLagDetailTitle[ConsumerLagDetailType.NetworkLatency]}
-			</Radio.Button>
-			<Radio.Button
-				value={ConsumerLagDetailType.PartitionHostMetrics}
-				disabled
-				className="disabled-option"
-			>
-				{ConsumerLagDetailTitle[ConsumerLagDetailType.PartitionHostMetrics]}
-				<ComingSoon />
-			</Radio.Button>
+			{selectedView !== MessagingQueuesViewType.partitionLatency.value && (
+				<Radio.Button value={ConsumerLagDetailType.ProducerDetails}>
+					{ConsumerLagDetailTitle[ConsumerLagDetailType.ProducerDetails]}
+				</Radio.Button>
+			)}
+			{selectedView !== MessagingQueuesViewType.partitionLatency.value && (
+				<Radio.Button value={ConsumerLagDetailType.NetworkLatency}>
+					{ConsumerLagDetailTitle[ConsumerLagDetailType.NetworkLatency]}
+				</Radio.Button>
+			)}
+			{selectedView !== MessagingQueuesViewType.partitionLatency.value && (
+				<Radio.Button
+					value={ConsumerLagDetailType.PartitionHostMetrics}
+					disabled
+					className="disabled-option"
+				>
+					{ConsumerLagDetailTitle[ConsumerLagDetailType.PartitionHostMetrics]}
+					<ComingSoon />
+				</Radio.Button>
+			)}
 		</Radio.Group>
 	);
 }
 
-function MessagingQueuesDetails(): JSX.Element {
+function MessagingQueuesDetails({
+	selectedView,
+}: {
+	selectedView: string;
+}): JSX.Element {
 	const [currentTab, setCurrentTab] = useState<ConsumerLagDetailType>(
 		ConsumerLagDetailType.ConsumerDetails,
 	);
+
 	return (
 		<div className="mq-details">
 			<MessagingQueuesOptions
 				currentTab={currentTab}
 				setCurrentTab={setCurrentTab}
+				selectedView={selectedView}
 			/>
-			<MessagingQueuesTable currentTab={currentTab} />
+			<MessagingQueuesTable
+				currentTab={currentTab}
+				selectedView={selectedView}
+				type="Detail"
+			/>
 		</div>
 	);
 }

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.styles.scss
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.styles.scss
@@ -64,14 +64,16 @@
 }
 
 .mq-table {
-	.ant-table-row {
-		background-color: var(--bg-ink-400);
+	&.mq-overview-row-clickable {
+		.ant-table-row {
+			background-color: var(--bg-ink-400);
 
-		&:hover {
-			cursor: pointer;
-			background-color: var(--bg-slate-400) !important;
-			color: var(--bg-vanilla-400);
-			transition: background-color 0.3s ease, color 0.3s ease;
+			&:hover {
+				cursor: pointer;
+				background-color: var(--bg-slate-400) !important;
+				color: var(--bg-vanilla-400);
+				transition: background-color 0.3s ease, color 0.3s ease;
+			}
 		}
 	}
 }

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.styles.scss
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.styles.scss
@@ -31,9 +31,6 @@
 		.ant-table-tbody {
 			.ant-table-cell {
 				max-width: 250px;
-
-				background-color: var(--bg-ink-400);
-
 				border-bottom: none;
 			}
 		}
@@ -59,6 +56,19 @@
 
 		.ant-typography {
 			font-size: 14px;
+		}
+	}
+}
+
+.mq-table {
+	.ant-table-row {
+		background-color: var(--bg-ink-400);
+
+		&:hover {
+			cursor: pointer;
+			background-color: var(--bg-slate-400) !important;
+			color: var(--bg-vanilla-400);
+			transition: background-color 0.3s ease, color 0.3s ease;
 		}
 	}
 }

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.styles.scss
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.styles.scss
@@ -1,4 +1,7 @@
 .mq-tables-container {
+	width: 100%;
+	height: 100%;
+
 	.mq-table-title {
 		display: flex;
 		align-items: center;

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.tsx
@@ -17,6 +17,7 @@ import {
 	convertToTitleCase,
 	MessagingQueueServiceDetailType,
 	MessagingQueuesViewType,
+	MessagingQueuesViewTypeOptions,
 	RowData,
 	SelectedTimelineQuery,
 	setConfigDetail,
@@ -117,7 +118,7 @@ function MessagingQueuesTable({
 	type = 'Detail',
 }: {
 	currentTab?: MessagingQueueServiceDetailType;
-	selectedView: string;
+	selectedView: MessagingQueuesViewTypeOptions;
 	tableApiPayload?: MessagingQueueServicePayload;
 	tableApi: (
 		props: MessagingQueueServicePayload,

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.tsx
@@ -135,8 +135,6 @@ function MessagingQueuesTable({
 		[timelineQuery],
 	);
 
-	console.log(tableApi, tableApiPayload, validConfigPresent);
-
 	const paginationConfig = useMemo(
 		() =>
 			tableData?.length > 20 && {

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getConsumerLagDetails.ts
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getConsumerLagDetails.ts
@@ -12,8 +12,9 @@ export interface MessagingQueueServicePayload {
 		partition?: string;
 		topic?: string;
 		consumer_group?: string;
+		service_name?: string;
 	};
-	detailType?: MessagingQueueServiceDetailType;
+	detailType?: MessagingQueueServiceDetailType | 'producer' | 'consumer';
 }
 
 export interface MessagingQueuesPayloadProps {

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getConsumerLagDetails.ts
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getConsumerLagDetails.ts
@@ -2,10 +2,10 @@ import axios from 'api';
 import { ErrorResponseHandler } from 'api/ErrorResponseHandler';
 import { AxiosError } from 'axios';
 import { SOMETHING_WENT_WRONG } from 'constants/api';
-import { ConsumerLagDetailType } from 'pages/MessagingQueues/MessagingQueuesUtils';
+import { MessagingQueueServiceDetailType } from 'pages/MessagingQueues/MessagingQueuesUtils';
 import { ErrorResponse, SuccessResponse } from 'types/api';
 
-export interface ConsumerLagPayload {
+export interface MessagingQueueServicePayload {
 	start?: number | string;
 	end?: number | string;
 	variables: {
@@ -13,7 +13,7 @@ export interface ConsumerLagPayload {
 		topic?: string;
 		consumer_group?: string;
 	};
-	detailType?: ConsumerLagDetailType;
+	detailType?: MessagingQueueServiceDetailType;
 }
 
 export interface MessagingQueuesPayloadProps {
@@ -36,7 +36,7 @@ export interface MessagingQueuesPayloadProps {
 }
 
 export const getConsumerLagDetails = async (
-	props: ConsumerLagPayload,
+	props: MessagingQueueServicePayload,
 ): Promise<
 	SuccessResponse<MessagingQueuesPayloadProps['payload']> | ErrorResponse
 > => {

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getConsumerLagDetails.ts
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getConsumerLagDetails.ts
@@ -13,7 +13,7 @@ export interface ConsumerLagPayload {
 		topic?: string;
 		consumer_group?: string;
 	};
-	detailType: ConsumerLagDetailType;
+	detailType?: ConsumerLagDetailType;
 }
 
 export interface MessagingQueuesPayloadProps {

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getPartitionLatencyDetails.ts
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getPartitionLatencyDetails.ts
@@ -1,0 +1,34 @@
+import axios from 'api';
+import { ErrorResponseHandler } from 'api/ErrorResponseHandler';
+import { AxiosError } from 'axios';
+import { SOMETHING_WENT_WRONG } from 'constants/api';
+import { ErrorResponse, SuccessResponse } from 'types/api';
+
+import {
+	ConsumerLagPayload,
+	MessagingQueuesPayloadProps,
+} from './getConsumerLagDetails';
+
+export const getPartitionLatencyDetails = async (
+	props: Omit<ConsumerLagPayload, 'detailType'>,
+): Promise<
+	SuccessResponse<MessagingQueuesPayloadProps['payload']> | ErrorResponse
+> => {
+	try {
+		const response = await axios.post(
+			`/messaging-queues/kafka/partition-latency/consumer`,
+			{
+				...props,
+			},
+		);
+
+		return {
+			statusCode: 200,
+			error: null,
+			message: response.data.status,
+			payload: response.data.data,
+		};
+	} catch (error) {
+		return ErrorResponseHandler((error as AxiosError) || SOMETHING_WENT_WRONG);
+	}
+};

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getPartitionLatencyDetails.ts
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getPartitionLatencyDetails.ts
@@ -2,25 +2,30 @@ import axios from 'api';
 import { ErrorResponseHandler } from 'api/ErrorResponseHandler';
 import { AxiosError } from 'axios';
 import { SOMETHING_WENT_WRONG } from 'constants/api';
+import { MessagingQueueServiceDetailType } from 'pages/MessagingQueues/MessagingQueuesUtils';
 import { ErrorResponse, SuccessResponse } from 'types/api';
 
 import {
-	ConsumerLagPayload,
+	MessagingQueueServicePayload,
 	MessagingQueuesPayloadProps,
 } from './getConsumerLagDetails';
 
 export const getPartitionLatencyDetails = async (
-	props: Omit<ConsumerLagPayload, 'detailType'>,
+	props: MessagingQueueServicePayload,
 ): Promise<
 	SuccessResponse<MessagingQueuesPayloadProps['payload']> | ErrorResponse
 > => {
+	const { detailType, ...rest } = props;
+	let endpoint = '';
+	if (detailType === MessagingQueueServiceDetailType.ConsumerDetails) {
+		endpoint = `/messaging-queues/kafka/partition-latency/consumer`;
+	} else {
+		endpoint = `/messaging-queues/kafka/consumer-lag/producer-details`;
+	}
 	try {
-		const response = await axios.post(
-			`/messaging-queues/kafka/partition-latency/consumer`,
-			{
-				...props,
-			},
-		);
+		const response = await axios.post(endpoint, {
+			...rest,
+		});
 
 		return {
 			statusCode: 200,

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getPartitionLatencyOverview.ts
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getPartitionLatencyOverview.ts
@@ -1,0 +1,34 @@
+import axios from 'api';
+import { ErrorResponseHandler } from 'api/ErrorResponseHandler';
+import { AxiosError } from 'axios';
+import { SOMETHING_WENT_WRONG } from 'constants/api';
+import { ErrorResponse, SuccessResponse } from 'types/api';
+
+import {
+	ConsumerLagPayload,
+	MessagingQueuesPayloadProps,
+} from './getConsumerLagDetails';
+
+export const getPartitionLatencyOverview = async (
+	props: Omit<ConsumerLagPayload, 'detailType' | 'variables'>,
+): Promise<
+	SuccessResponse<MessagingQueuesPayloadProps['payload']> | ErrorResponse
+> => {
+	try {
+		const response = await axios.post(
+			`/messaging-queues/kafka/partition-latency/overview`,
+			{
+				...props,
+			},
+		);
+
+		return {
+			statusCode: 200,
+			error: null,
+			message: response.data.status,
+			payload: response.data.data,
+		};
+	} catch (error) {
+		return ErrorResponseHandler((error as AxiosError) || SOMETHING_WENT_WRONG);
+	}
+};

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getPartitionLatencyOverview.ts
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getPartitionLatencyOverview.ts
@@ -5,12 +5,12 @@ import { SOMETHING_WENT_WRONG } from 'constants/api';
 import { ErrorResponse, SuccessResponse } from 'types/api';
 
 import {
-	ConsumerLagPayload,
+	MessagingQueueServicePayload,
 	MessagingQueuesPayloadProps,
 } from './getConsumerLagDetails';
 
 export const getPartitionLatencyOverview = async (
-	props: Omit<ConsumerLagPayload, 'detailType' | 'variables'>,
+	props: Omit<MessagingQueueServicePayload, 'detailType' | 'variables'>,
 ): Promise<
 	SuccessResponse<MessagingQueuesPayloadProps['payload']> | ErrorResponse
 > => {

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getTopicThroughputDetails.ts
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getTopicThroughputDetails.ts
@@ -1,0 +1,33 @@
+import axios from 'api';
+import { ErrorResponseHandler } from 'api/ErrorResponseHandler';
+import { AxiosError } from 'axios';
+import { SOMETHING_WENT_WRONG } from 'constants/api';
+import { ErrorResponse, SuccessResponse } from 'types/api';
+
+import {
+	MessagingQueueServicePayload,
+	MessagingQueuesPayloadProps,
+} from './getConsumerLagDetails';
+
+export const getTopicThroughputDetails = async (
+	props: MessagingQueueServicePayload,
+): Promise<
+	SuccessResponse<MessagingQueuesPayloadProps['payload']> | ErrorResponse
+> => {
+	const { detailType, ...rest } = props;
+	const endpoint = `/messaging-queues/kafka/topic-throughput/${detailType}`;
+	try {
+		const response = await axios.post(endpoint, {
+			...rest,
+		});
+
+		return {
+			statusCode: 200,
+			error: null,
+			message: response.data.status,
+			payload: response.data.data,
+		};
+	} catch (error) {
+		return ErrorResponseHandler((error as AxiosError) || SOMETHING_WENT_WRONG);
+	}
+};

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getTopicThroughputOverview.ts
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getTopicThroughputOverview.ts
@@ -1,0 +1,37 @@
+import axios from 'api';
+import { ErrorResponseHandler } from 'api/ErrorResponseHandler';
+import { AxiosError } from 'axios';
+import { SOMETHING_WENT_WRONG } from 'constants/api';
+import { ErrorResponse, SuccessResponse } from 'types/api';
+
+import {
+	MessagingQueueServicePayload,
+	MessagingQueuesPayloadProps,
+} from './getConsumerLagDetails';
+
+export const getTopicThroughputOverview = async (
+	props: Omit<MessagingQueueServicePayload, 'variables'>,
+): Promise<
+	SuccessResponse<MessagingQueuesPayloadProps['payload']> | ErrorResponse
+> => {
+	const { detailType, start, end } = props;
+	console.log(detailType);
+	try {
+		const response = await axios.post(
+			`messaging-queues/kafka/topic-throughput/${detailType}`,
+			{
+				start,
+				end,
+			},
+		);
+
+		return {
+			statusCode: 200,
+			error: null,
+			message: response.data.status,
+			payload: response.data.data,
+		};
+	} catch (error) {
+		return ErrorResponseHandler((error as AxiosError) || SOMETHING_WENT_WRONG);
+	}
+};

--- a/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
@@ -8,6 +8,7 @@ import { GlobalReducer } from 'types/reducer/globalTime';
 
 import {
 	MessagingQueuesViewType,
+	MessagingQueuesViewTypeOptions,
 	ProducerLatencyOptions,
 } from '../MessagingQueuesUtils';
 import { MessagingQueueServicePayload } from './MQTables/getConsumerLagDetails';
@@ -46,7 +47,7 @@ function PartitionLatencyTabs({
 	);
 }
 
-const getTableApi = (selectedView: string): any => {
+const getTableApi = (selectedView: MessagingQueuesViewTypeOptions): any => {
 	if (selectedView === MessagingQueuesViewType.producerLatency.value) {
 		return getTopicThroughputOverview;
 	}
@@ -58,7 +59,7 @@ function MessagingQueueOverview({
 	option,
 	setOption,
 }: {
-	selectedView: string;
+	selectedView: MessagingQueuesViewTypeOptions;
 	option: ProducerLatencyOptions;
 	setOption: Dispatch<SetStateAction<ProducerLatencyOptions>>;
 }): JSX.Element {

--- a/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
@@ -1,15 +1,66 @@
+import './MQDetails.style.scss';
+
+import { Radio } from 'antd';
+import { Dispatch, SetStateAction } from 'react';
 import { useSelector } from 'react-redux';
 import { AppState } from 'store/reducers';
 import { GlobalReducer } from 'types/reducer/globalTime';
 
+import {
+	MessagingQueuesViewType,
+	ProducerLatencyOptions,
+} from '../MessagingQueuesUtils';
 import { MessagingQueueServicePayload } from './MQTables/getConsumerLagDetails';
 import { getPartitionLatencyOverview } from './MQTables/getPartitionLatencyOverview';
+import { getTopicThroughputOverview } from './MQTables/getTopicThroughputOverview';
 import MessagingQueuesTable from './MQTables/MQTables';
+
+type SelectedViewType = keyof typeof MessagingQueuesViewType;
+
+function PartitionLatencyTabs({
+	option,
+	setOption,
+}: {
+	option: ProducerLatencyOptions;
+	setOption: Dispatch<SetStateAction<ProducerLatencyOptions>>;
+}): JSX.Element {
+	return (
+		<Radio.Group
+			onChange={(e): void => setOption(e.target.value)}
+			value={option}
+			className="mq-details-options"
+		>
+			<Radio.Button
+				value={ProducerLatencyOptions.Producers}
+				key={ProducerLatencyOptions.Producers}
+			>
+				{ProducerLatencyOptions.Producers}
+			</Radio.Button>
+			<Radio.Button
+				value={ProducerLatencyOptions.Consumers}
+				key={ProducerLatencyOptions.Consumers}
+			>
+				{ProducerLatencyOptions.Consumers}
+			</Radio.Button>
+		</Radio.Group>
+	);
+}
+
+const getTableApi = (selectedView: string): any => {
+	if (selectedView === MessagingQueuesViewType.producerLatency.value) {
+		return getTopicThroughputOverview;
+	}
+	return getPartitionLatencyOverview;
+};
 
 function MessagingQueueOverview({
 	selectedView,
+	option,
+	setOption,
 }: {
 	selectedView: string;
+	option: ProducerLatencyOptions;
+	setOption: Dispatch<SetStateAction<ProducerLatencyOptions>>;
 }): JSX.Element {
 	const { maxTime, minTime } = useSelector<AppState, GlobalReducer>(
 		(state) => state.globalTime,
@@ -19,13 +70,28 @@ function MessagingQueueOverview({
 		variables: {},
 		start: minTime,
 		end: maxTime,
+		detailType:
+			// eslint-disable-next-line no-nested-ternary
+			selectedView === MessagingQueuesViewType.producerLatency.value
+				? option === ProducerLatencyOptions.Producers
+					? 'producer'
+					: 'consumer'
+				: undefined,
 	};
+
 	return (
-		<div>
+		<div className="mq-overview-container">
+			{selectedView === MessagingQueuesViewType.producerLatency.value ? (
+				<PartitionLatencyTabs option={option} setOption={setOption} />
+			) : (
+				<div className="mq-overview-title">
+					{MessagingQueuesViewType[selectedView as SelectedViewType].label}
+				</div>
+			)}
 			<MessagingQueuesTable
 				selectedView={selectedView}
 				tableApiPayload={tableApiPayload}
-				tableApi={getPartitionLatencyOverview}
+				tableApi={getTableApi(selectedView)}
 				validConfigPresent
 			/>
 		</div>

--- a/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 import { AppState } from 'store/reducers';
 import { GlobalReducer } from 'types/reducer/globalTime';
 
-import { ConsumerLagPayload } from './MQTables/getConsumerLagDetails';
+import { MessagingQueueServicePayload } from './MQTables/getConsumerLagDetails';
 import { getPartitionLatencyOverview } from './MQTables/getPartitionLatencyOverview';
 import MessagingQueuesTable from './MQTables/MQTables';
 
@@ -15,7 +15,7 @@ function MessagingQueueOverview({
 		(state) => state.globalTime,
 	);
 
-	const tableApiPayload: ConsumerLagPayload = {
+	const tableApiPayload: MessagingQueueServicePayload = {
 		variables: {},
 		start: minTime,
 		end: maxTime,
@@ -26,7 +26,7 @@ function MessagingQueueOverview({
 				selectedView={selectedView}
 				tableApiPayload={tableApiPayload}
 				tableApi={getPartitionLatencyOverview}
-				type="Main"
+				validConfigPresent
 			/>
 		</div>
 	);

--- a/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
@@ -1,0 +1,34 @@
+import { useSelector } from 'react-redux';
+import { AppState } from 'store/reducers';
+import { GlobalReducer } from 'types/reducer/globalTime';
+
+import { ConsumerLagPayload } from './MQTables/getConsumerLagDetails';
+import { getPartitionLatencyOverview } from './MQTables/getPartitionLatencyOverview';
+import MessagingQueuesTable from './MQTables/MQTables';
+
+function MessagingQueueOverview({
+	selectedView,
+}: {
+	selectedView: string;
+}): JSX.Element {
+	const { maxTime, minTime } = useSelector<AppState, GlobalReducer>(
+		(state) => state.globalTime,
+	);
+
+	const tableApiPayload: ConsumerLagPayload = {
+		variables: {},
+		start: minTime,
+		end: maxTime,
+	};
+	return (
+		<div>
+			<MessagingQueuesTable
+				selectedView={selectedView}
+				tableApiPayload={tableApiPayload}
+				tableApi={getPartitionLatencyOverview}
+				type="Main"
+			/>
+		</div>
+	);
+}
+export default MessagingQueueOverview;

--- a/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
@@ -93,6 +93,7 @@ function MessagingQueueOverview({
 				tableApiPayload={tableApiPayload}
 				tableApi={getTableApi(selectedView)}
 				validConfigPresent
+				type="Overview"
 			/>
 		</div>
 	);

--- a/frontend/src/pages/MessagingQueues/MessagingQueues.styles.scss
+++ b/frontend/src/pages/MessagingQueues/MessagingQueues.styles.scss
@@ -106,6 +106,8 @@
 
 		.mq-details-options {
 			letter-spacing: -0.06px;
+			cursor: pointer;
+
 			.ant-radio-button-wrapper {
 				border-color: var(--bg-slate-400);
 				color: var(--bg-vanilla-400);

--- a/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
+++ b/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
@@ -237,7 +237,6 @@ export function setConfigDetail(
 ): void {
 	// remove "key" and its value from the paramsToSet object
 	const { key, ...restParamsToSet } = paramsToSet || {};
-	console.log(restParamsToSet);
 
 	if (!isEmpty(restParamsToSet)) {
 		const configDetail = {
@@ -247,6 +246,8 @@ export function setConfigDetail(
 			QueryParams.configDetail,
 			encodeURIComponent(JSON.stringify(configDetail)),
 		);
+	} else {
+		urlQuery.delete(QueryParams.configDetail);
 	}
 	const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
 	history.replace(generatedUrl);

--- a/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
+++ b/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
@@ -223,3 +223,28 @@ export const MessagingQueuesViewType = {
 		value: 'consumerLatency',
 	},
 };
+
+export function setConfigDetail(
+	urlQuery: URLSearchParams,
+	location: Location<unknown>,
+	history: History<unknown>,
+	paramsToSet?: {
+		[key: string]: string;
+	},
+): void {
+	// remove "key" and its value from the paramsToSet object
+	const { key, ...restParamsToSet } = paramsToSet || {};
+	console.log(restParamsToSet);
+
+	if (!isEmpty(restParamsToSet)) {
+		const configDetail = {
+			...restParamsToSet,
+		};
+		urlQuery.set(
+			QueryParams.configDetail,
+			encodeURIComponent(JSON.stringify(configDetail)),
+		);
+	}
+	const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
+	history.replace(generatedUrl);
+}

--- a/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
+++ b/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
@@ -24,14 +24,17 @@ export type RowData = {
 	[key: string]: string | number;
 };
 
-export enum ConsumerLagDetailType {
+export enum MessagingQueueServiceDetailType {
 	ConsumerDetails = 'consumer-details',
 	ProducerDetails = 'producer-details',
 	NetworkLatency = 'network-latency',
 	PartitionHostMetrics = 'partition-host-metric',
 }
 
-export const ConsumerLagDetailTitle: Record<ConsumerLagDetailType, string> = {
+export const ConsumerLagDetailTitle: Record<
+	MessagingQueueServiceDetailType,
+	string
+> = {
 	'consumer-details': 'Consumer Groups Details',
 	'producer-details': 'Producer Details',
 	'network-latency': 'Network Latency',

--- a/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
+++ b/frontend/src/pages/MessagingQueues/MessagingQueuesUtils.ts
@@ -251,3 +251,8 @@ export function setConfigDetail(
 	const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
 	history.replace(generatedUrl);
 }
+
+export enum ProducerLatencyOptions {
+	Producers = 'Producers',
+	Consumers = 'Consumers',
+}


### PR DESCRIPTION
### Summary

Added - scenario - 1 & 3 screens with details
- added changes and used generic `MQTables` for all the scenarios
- added onRowClick, wherever required

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/user-attachments/assets/d3d27d99-3f74-4e78-bbc4-f9cd24aa6235


#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Added generic UI components and API integrations for messaging queue scenarios with updated styles and configurations.
> 
>   - **Behavior**:
>     - Added `MessagingQueueOverview` and `MessagingQueuesDetails` components in `MQDetailPage.tsx` for different views.
>     - Introduced `ProducerLatencyOptions` and `MessagingQueuesViewType` enums in `MessagingQueuesUtils.ts`.
>     - Added API functions: `getConsumerLagDetails`, `getPartitionLatencyDetails`, `getTopicThroughputDetails`, `getPartitionLatencyOverview`, `getTopicThroughputOverview`.
>   - **Components**:
>     - `MessagingQueuesTable` in `MQTables.tsx` supports dynamic rendering based on view and tab.
>     - `MessagingQueuesOptions` component added for tab selection in `MQDetails.tsx`.
>   - **Styles**:
>     - Updated styles in `MQDetails.style.scss`, `MQTables.styles.scss`, and `MessagingQueues.styles.scss`.
>   - **Misc**:
>     - Added `configDetail` to `QueryParams` in `query.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for c3a86357a2dfb895c50b3f7bbbc73ef7ced6ee8e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->