### PR TITLE
chore: bump signoz-otel-collector version

### DIFF
--- a/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
@@ -199,7 +199,7 @@ services:
       - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
 
   otel-collector:
-    image: signoz/signoz-otel-collector:0.102.12
+    image: signoz/signoz-otel-collector:0.111.5
     command:
       [
         "--config=/etc/otel-collector-config.yaml",
@@ -214,7 +214,6 @@ services:
       - /:/hostfs:ro
     environment:
       - OTEL_RESOURCE_ATTRIBUTES=host.name={{.Node.Hostname}},os.type={{.Node.Platform.OS}},dockerswarm.service.name={{.Service.Name}},dockerswarm.task.name={{.Task.Name}}
-      - DOCKER_MULTI_NODE_CLUSTER=false
       - LOW_CARDINAL_EXCEPTION_GROUPING=false
     ports:
       # - "1777:1777"     # pprof extension
@@ -238,7 +237,7 @@ services:
       - query-service
 
   otel-collector-migrator:
-      image: signoz/signoz-schema-migrator:0.102.10
+      image: signoz/signoz-schema-migrator:0.111.5
       deploy:
         restart_policy:
           condition: on-failure

--- a/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/otel-collector-config.yaml
@@ -131,7 +131,6 @@ processors:
 exporters:
   clickhousetraces:
     datasource: tcp://clickhouse:9000/signoz_traces
-    docker_multi_node_cluster: ${env:DOCKER_MULTI_NODE_CLUSTER}
     low_cardinal_exception_grouping: ${env:LOW_CARDINAL_EXCEPTION_GROUPING}
   clickhousemetricswrite:
     endpoint: tcp://clickhouse:9000/signoz_metrics
@@ -142,7 +141,6 @@ exporters:
   # logging: {}
   clickhouselogsexporter:
     dsn: tcp://clickhouse:9000/signoz_logs
-    docker_multi_node_cluster: ${env:DOCKER_MULTI_NODE_CLUSTER}
     timeout: 10s
     use_new_schema: true
 extensions:

--- a/deploy/docker/clickhouse-setup/docker-compose-core.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose-core.yaml
@@ -69,7 +69,7 @@ services:
       - --storage.path=/data
 
   otel-collector-migrator:
-    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.102.10}
+    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.5}
     container_name: otel-migrator
     command:
       - "--dsn=tcp://clickhouse:9000"
@@ -84,7 +84,7 @@ services:
   # Notes for Maintainers/Contributors who will change Line Numbers of Frontend & Query-Section. Please Update Line Numbers in `./scripts/commentLinesForSetup.sh` & `./CONTRIBUTING.md`
   otel-collector:
     container_name: signoz-otel-collector
-    image: signoz/signoz-otel-collector:0.102.12
+    image: signoz/signoz-otel-collector:0.111.5
     command:
       [
         "--config=/etc/otel-collector-config.yaml",

--- a/deploy/docker/clickhouse-setup/docker-compose-minimal.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose-minimal.yaml
@@ -213,7 +213,7 @@ services:
       - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
 
   otel-collector-migrator-sync:
-    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.102.10}
+    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.5}
     container_name: otel-migrator-sync
     command:
       - "sync"
@@ -228,7 +228,7 @@ services:
       #   condition: service_healthy
 
   otel-collector-migrator-async:
-    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.102.10}
+    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.5}
     container_name: otel-migrator-async
     command:
       - "async"
@@ -245,7 +245,7 @@ services:
       #   condition: service_healthy
 
   otel-collector:
-    image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.102.12}
+    image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.111.5}
     container_name: signoz-otel-collector
     command:
       [
@@ -262,7 +262,6 @@ services:
       - /:/hostfs:ro
     environment:
       - OTEL_RESOURCE_ATTRIBUTES=host.name=signoz-host,os.type=linux
-      - DOCKER_MULTI_NODE_CLUSTER=false
       - LOW_CARDINAL_EXCEPTION_GROUPING=false
     ports:
       # - "1777:1777"     # pprof extension

--- a/deploy/docker/clickhouse-setup/docker-compose.testing.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.testing.yaml
@@ -219,7 +219,7 @@ services:
       - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
 
   otel-collector-migrator:
-    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.102.10}
+    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.5}
     container_name: otel-migrator
     command:
       - "--dsn=tcp://clickhouse:9000"
@@ -233,7 +233,7 @@ services:
 
 
   otel-collector:
-    image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.102.12}
+    image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.111.5}
     container_name: signoz-otel-collector
     command:
       [
@@ -250,7 +250,6 @@ services:
       - /:/hostfs:ro
     environment:
       - OTEL_RESOURCE_ATTRIBUTES=host.name=signoz-host,os.type=linux
-      - DOCKER_MULTI_NODE_CLUSTER=false
       - LOW_CARDINAL_EXCEPTION_GROUPING=false
     ports:
       # - "1777:1777"     # pprof extension

--- a/deploy/docker/clickhouse-setup/otel-collector-config.yaml
+++ b/deploy/docker/clickhouse-setup/otel-collector-config.yaml
@@ -142,7 +142,6 @@ extensions:
 exporters:
   clickhousetraces:
     datasource: tcp://clickhouse:9000/signoz_traces
-    docker_multi_node_cluster: ${env:DOCKER_MULTI_NODE_CLUSTER}
     low_cardinal_exception_grouping: ${env:LOW_CARDINAL_EXCEPTION_GROUPING}
   clickhousemetricswrite:
     endpoint: tcp://clickhouse:9000/signoz_metrics
@@ -152,7 +151,6 @@ exporters:
     endpoint: tcp://clickhouse:9000/signoz_metrics
   clickhouselogsexporter:
     dsn: tcp://clickhouse:9000/signoz_logs
-    docker_multi_node_cluster: ${env:DOCKER_MULTI_NODE_CLUSTER}
     timeout: 10s
     use_new_schema: true
   # logging: {}


### PR DESCRIPTION
### Summary

Fixes https://github.com/SigNoz/signoz/issues/6278
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `signoz-otel-collector` and `signoz-schema-migrator` to version `0.111.5` and remove `DOCKER_MULTI_NODE_CLUSTER` from configurations.
> 
>   - **Version Updates**:
>     - Bump `signoz-otel-collector` to `0.111.5` in `docker-compose.yaml`, `docker-compose-core.yaml`, `docker-compose-minimal.yaml`, and `docker-compose.testing.yaml`.
>     - Bump `signoz-schema-migrator` to `0.111.5` in `docker-compose.yaml`, `docker-compose-core.yaml`, `docker-compose-minimal.yaml`, and `docker-compose.testing.yaml`.
>   - **Configuration Changes**:
>     - Remove `DOCKER_MULTI_NODE_CLUSTER` environment variable from `docker-compose.yaml` and `otel-collector-config.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 69acddd8311a16eee253360d08390079951dd6fa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->