### PR TITLE
chore: upgrade axios from 1.7.4 to 1.7.7

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,7 @@
 		"ansi-to-html": "0.7.2",
 		"antd": "5.11.0",
 		"antd-table-saveas-excel": "2.2.1",
-		"axios": "1.7.4",
+		"axios": "1.7.7",
 		"babel-eslint": "^10.1.0",
 		"babel-jest": "^29.6.4",
 		"babel-loader": "9.1.3",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5590,10 +5590,10 @@ axe-core@^4.6.2:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz"
   integrity sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==
 
-axios@1.7.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.4.tgz#4c8ded1b43683c8dd362973c393f3ede24052aa2"
-  integrity sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==
+axios@1.7.7:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
+  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
### Summary
This PR contains upgrading the axios's patch version. it had been upgraded from `1.6.4` to `1.7.4` in https://github.com/SigNoz/signoz/pull/5734
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
close https://github.com/SigNoz/engineering-pod/issues/1549
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas
Since this is patch upgrade, it won't break anything. I still tested services, traces, logs, alerts, dashboards, ... pages, there doesn't seem to be any regressions.
<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Upgrade `axios` from `1.7.4` to `1.7.7` in `package.json`.
> 
>   - **Dependencies**:
>     - Upgrade `axios` from `1.7.4` to `1.7.7` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for bdf6693b4aa5969212cf21396397db1ac9de46e0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->