### PR TITLE
chore: move hostname to resource attributes for logs qf

### DIFF
--- a/frontend/src/pages/LogsExplorer/utils.tsx
+++ b/frontend/src/pages/LogsExplorer/utils.tsx
@@ -68,7 +68,7 @@ export const LogsQuickFiltersConfig: IQuickFiltersConfig[] = [
 		attributeKey: {
 			key: 'hostname',
 			dataType: DataTypes.String,
-			type: 'tag',
+			type: 'resource',
 			isColumn: false,
 			isJSON: false,
 		},

--- a/frontend/src/pages/LogsExplorer/utils.tsx
+++ b/frontend/src/pages/LogsExplorer/utils.tsx
@@ -66,7 +66,7 @@ export const LogsQuickFiltersConfig: IQuickFiltersConfig[] = [
 		type: FiltersType.CHECKBOX,
 		title: 'Hostname',
 		attributeKey: {
-			key: 'hostname',
+			key: 'host.name',
 			dataType: DataTypes.String,
 			type: 'resource',
 			isColumn: false,


### PR DESCRIPTION
### Summary

- use resource attribute `hostname` for logs quick filters. 
- https://opentelemetry.io/docs/specs/semconv/attributes-registry/host/

#### Related Issues / PR's

fixes - https://signoz-team.slack.com/archives/C02TJ466H8U/p1730132055397139 

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

- logs quick filters 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `hostname` filter key to `host.name` and type to `resource` in `LogsQuickFiltersConfig`.
> 
>   - **Behavior**:
>     - Change `hostname` filter key from `hostname` to `host.name` in `LogsQuickFiltersConfig` in `utils.tsx`.
>     - Update filter type from `tag` to `resource` for `hostname`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 3c1ae9a8bb84a404f30445369a111057e1998f07. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->