### PR TITLE
fix: add safety check to check if anomaly rule in uplot chart options

### DIFF
--- a/frontend/src/lib/uPlotLib/getUplotChartOptions.ts
+++ b/frontend/src/lib/uPlotLib/getUplotChartOptions.ts
@@ -163,7 +163,8 @@ export const getUPlotChartOptions = ({
 
 	const stackBarChart = stackChart && isUndefined(hiddenGraph);
 
-	const isAnomalyRule = apiResponse?.data?.newResult?.data?.result[0].isAnomaly;
+	const isAnomalyRule =
+		apiResponse?.data?.newResult?.data?.result[0]?.isAnomaly || false;
 
 	const series = getStackedSeries(apiResponse?.data?.result || []);
 


### PR DESCRIPTION
https://signoz-io.sentry.io/issues/6034450498/?alert_rule_id=15272042&alert_type=issue&project=4506831143763968
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add safety check for `isAnomaly` property in `getUplotChartOptions` to prevent undefined errors.
> 
>   - **Behavior**:
>     - Add safety check for `isAnomaly` property in `getUplotChartOptions` in `getUplotChartOptions.ts` to default to `false` if undefined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for c9a0d6cee3bc1c72439f3664552322c5048f8c42. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->