### PR TITLE
fix: re add threshold for promql alerts

### DIFF
--- a/frontend/src/container/FormAlertRules/RuleOptions.tsx
+++ b/frontend/src/container/FormAlertRules/RuleOptions.tsx
@@ -386,32 +386,31 @@ function RuleOptions({
 					renderThresholdRuleOpts()}
 
 				<Space direction="vertical" size="large">
-					{queryCategory !== EQueryType.PROM &&
-						ruleType !== AlertDetectionTypes.ANOMALY_DETECTION_ALERT && (
-							<Space direction="horizontal" align="center">
-								<Form.Item noStyle name={['condition', 'target']}>
-									<InputNumber
-										addonBefore={t('field_threshold')}
-										value={alertDef?.condition?.target}
-										onChange={onChange}
-										type="number"
-										onWheel={(e): void => e.currentTarget.blur()}
-									/>
-								</Form.Item>
+					{ruleType !== AlertDetectionTypes.ANOMALY_DETECTION_ALERT && (
+						<Space direction="horizontal" align="center">
+							<Form.Item noStyle name={['condition', 'target']}>
+								<InputNumber
+									addonBefore={t('field_threshold')}
+									value={alertDef?.condition?.target}
+									onChange={onChange}
+									type="number"
+									onWheel={(e): void => e.currentTarget.blur()}
+								/>
+							</Form.Item>
 
-								<Form.Item noStyle>
-									<Select
-										getPopupContainer={popupContainer}
-										allowClear
-										showSearch
-										options={categorySelectOptions}
-										placeholder={t('field_unit')}
-										value={alertDef.condition.targetUnit}
-										onChange={onChangeAlertUnit}
-									/>
-								</Form.Item>
-							</Space>
-						)}
+							<Form.Item noStyle>
+								<Select
+									getPopupContainer={popupContainer}
+									allowClear
+									showSearch
+									options={categorySelectOptions}
+									placeholder={t('field_unit')}
+									value={alertDef.condition.targetUnit}
+									onChange={onChangeAlertUnit}
+								/>
+							</Form.Item>
+						</Space>
+					)}
 
 					<Collapse>
 						<Collapse.Panel header={t('More options')} key="1">


### PR DESCRIPTION
Only certain options were supposed to be removed but the input for add threshold was also removed as part of the anomaly detection change

Fix:

<img width="1920" alt="Screenshot 2024-11-04 at 12 15 25 PM" src="https://github.com/user-attachments/assets/9cff2a87-df46-4fe2-8619-8e5dcb19781d">

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-adds threshold input for PromQL alerts in `RuleOptions.tsx`, excluding only anomaly detection alerts.
> 
>   - **Behavior**:
>     - Re-adds threshold input for PromQL alerts in `RuleOptions.tsx`.
>     - Updates condition to exclude only `ANOMALY_DETECTION_ALERT` from showing threshold input.
>   - **UI**:
>     - Restores `InputNumber` and `Select` for threshold and unit selection in PromQL alerts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 54d385da1168431ebc9783018524d2ff3e3d47b1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->