### PR TITLE
fix: initialize target to 3 in anomaly detection alert

### DIFF
--- a/frontend/src/container/CreateAlertRule/defaults.ts
+++ b/frontend/src/container/CreateAlertRule/defaults.ts
@@ -94,6 +94,7 @@ export const anamolyAlertDefaults: AlertDef = {
 		matchType: defaultMatchType,
 		algorithm: defaultAlgorithm,
 		seasonality: defaultSeasonality,
+		target: 3,
 	},
 	labels: {
 		severity: 'warning',


### PR DESCRIPTION
Issue:  If the user had not updated the target deviation, the save was failing

Fix: initialize target to 3 in anomaly detection alert
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Initialize `target` to 3 in `anamolyAlertDefaults` to prevent save failures when target deviation is not updated.
> 
>   - **Behavior**:
>     - Initialize `target` to 3 in `anamolyAlertDefaults` in `defaults.ts` to prevent save failures when target deviation is not updated by the user.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 96404799f5190df6aa9bdebc55dd09ed3c36a561. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->