### PR TITLE
feat: corrected the handling of relativeTime as null in alertHistory

### DIFF
--- a/frontend/src/pages/AlertDetails/hooks.tsx
+++ b/frontend/src/pages/AlertDetails/hooks.tsx
@@ -57,8 +57,11 @@ export const useAlertHistoryQueryParams = (): {
 
 	const startTime = params.get(QueryParams.startTime);
 	const endTime = params.get(QueryParams.endTime);
+	const relativeTimeParam = params.get(QueryParams.relativeTime);
+
 	const relativeTime =
-		params.get(QueryParams.relativeTime) ?? RelativeTimeMap['6hr'];
+		(relativeTimeParam === 'null' ? null : relativeTimeParam) ??
+		RelativeTimeMap['6hr'];
 
 	const intStartTime = parseInt(startTime || '0', 10);
 	const intEndTime = parseInt(endTime || '0', 10);


### PR DESCRIPTION
### Summary

Earlier logic had `params.get(QueryParams.relativeTime)` returning as null but in string i.e. "null" hence the nullish operator added to handle and assign the defaultRelativeValue was not working as expected.

Corrected that and checked string null separately

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/user-attachments/assets/48a6eeb1-96a9-4d3d-97e3-5574320254b0



#### Affected Areas and Manually Tested Areas

- tested current behaviour with `relativeTime=null` and existing behaviours
