### PR TITLE
feat: added table column and row logic for the new api response structure for producer overview

### DIFF
--- a/frontend/src/api/messagingQueues/getTopicThroughputOverview.ts
+++ b/frontend/src/api/messagingQueues/getTopicThroughputOverview.ts
@@ -1,22 +1,14 @@
 import axios from 'api';
-import { ErrorResponse, SuccessResponse } from 'types/api';
-
 import {
 	MessagingQueueServicePayload,
 	MessagingQueuesPayloadProps,
-} from './getConsumerLagDetails';
-import { TopicThroughputProducerOverviewResponse } from './MQTableUtils';
+} from 'pages/MessagingQueues/MQDetails/MQTables/getConsumerLagDetails';
+import { ErrorResponse, SuccessResponse } from 'types/api';
 
 export const getTopicThroughputOverview = async (
 	props: Omit<MessagingQueueServicePayload, 'variables'>,
 ): Promise<
-	| SuccessResponse<
-			(
-				| MessagingQueuesPayloadProps
-				| TopicThroughputProducerOverviewResponse
-			)['payload']
-	  >
-	| ErrorResponse
+	SuccessResponse<MessagingQueuesPayloadProps['payload']> | ErrorResponse
 > => {
 	const { detailType, start, end } = props;
 	const response = await axios.post(

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQDetails.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQDetails.tsx
@@ -108,13 +108,6 @@ const checkValidityOfDetailConfigs = (
 			return false;
 		}
 
-		if (currentTab === MessagingQueueServiceDetailType.ProducerDetails) {
-			return Boolean(
-				configDetails?.topic &&
-					configDetails?.partition &&
-					configDetails?.service_name,
-			);
-		}
 		return Boolean(configDetails?.topic && configDetails?.service_name);
 	}
 

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTableUtils.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTableUtils.tsx
@@ -1,0 +1,92 @@
+import { Typography } from 'antd';
+import dayjs from 'dayjs';
+import { History } from 'history';
+import {
+	convertToTitleCase,
+	RowData,
+} from 'pages/MessagingQueues/MessagingQueuesUtils';
+
+interface ProducerLatencyOverviewColumn {
+	timestamp: string;
+	data: {
+		[key: string]: number | string;
+	};
+}
+
+export interface TopicThroughputProducerOverviewResponse {
+	status: string;
+	payload: {
+		resultType: string;
+		result: {
+			queryName: string;
+			list: ProducerLatencyOverviewColumn[];
+		}[];
+	};
+}
+
+export const getColumnsForProduderLatencyOverview = (
+	list: ProducerLatencyOverviewColumn[],
+	history: History<unknown>,
+): RowData[] => {
+	if (list?.length === 0) {
+		return [];
+	}
+
+	const columns: {
+		title: string;
+		dataIndex: string;
+		key: string;
+	}[] = Object.keys(list[0].data)?.map((column) => ({
+		title: convertToTitleCase(column),
+		dataIndex: column,
+		key: column,
+		render: (data: string | number): JSX.Element => {
+			if (column === 'service_name') {
+				return (
+					<Typography.Link
+						onClick={(e): void => {
+							e.preventDefault();
+							e.stopPropagation();
+							history.push(`/services/${encodeURIComponent(data as string)}`);
+						}}
+					>
+						{data}
+					</Typography.Link>
+				);
+			}
+
+			if (column === 'ts') {
+				const date =
+					typeof data === 'string'
+						? dayjs(data).format('YYYY-MM-DD HH:mm:ss.SSS')
+						: dayjs(data / 1e6).format('YYYY-MM-DD HH:mm:ss.SSS');
+				return <Typography.Text>{date}</Typography.Text>;
+			}
+
+			if (typeof data === 'number') {
+				return <Typography.Text>{data.toFixed(3)}</Typography.Text>;
+			}
+
+			return <Typography.Text>{data}</Typography.Text>;
+		},
+	}));
+
+	return columns;
+};
+
+export const getTableDataForProducerLatencyOverview = (
+	list: ProducerLatencyOverviewColumn[],
+): RowData[] => {
+	if (list?.length === 0) {
+		return [];
+	}
+
+	const tableData: RowData[] = list?.map(
+		(row, index: number): RowData => ({
+			...row.data,
+			key: index,
+		}),
+	);
+
+	return tableData;
+};

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTableUtils.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTableUtils.tsx
@@ -1,92 +1,35 @@
-import { Typography } from 'antd';
-import dayjs from 'dayjs';
-import { History } from 'history';
-import {
-	convertToTitleCase,
-	RowData,
-} from 'pages/MessagingQueues/MessagingQueuesUtils';
+import { RowData } from 'pages/MessagingQueues/MessagingQueuesUtils';
 
-interface ProducerLatencyOverviewColumn {
-	timestamp: string;
-	data: {
-		[key: string]: number | string;
-	};
-}
+import { MessagingQueuesPayloadProps } from './getConsumerLagDetails';
 
-export interface TopicThroughputProducerOverviewResponse {
-	status: string;
-	payload: {
-		resultType: string;
-		result: {
-			queryName: string;
-			list: ProducerLatencyOverviewColumn[];
-		}[];
-	};
-}
-
-export const getColumnsForProducerLatencyOverview = (
-	list: ProducerLatencyOverviewColumn[],
-	history: History<unknown>,
-): RowData[] => {
-	if (list?.length === 0) {
+export function getTableDataForProducerLatencyOverview(
+	data: MessagingQueuesPayloadProps['payload'],
+): RowData[] {
+	if (data?.result?.length === 0) {
 		return [];
 	}
 
-	const columns: {
-		title: string;
-		dataIndex: string;
-		key: string;
-	}[] = Object.keys(list[0].data)?.map((column) => ({
-		title: convertToTitleCase(column),
-		dataIndex: column,
-		key: column,
-		render: (data: string | number): JSX.Element => {
-			if (column === 'service_name') {
-				return (
-					<Typography.Link
-						onClick={(e): void => {
-							e.preventDefault();
-							e.stopPropagation();
-							history.push(`/services/${encodeURIComponent(data as string)}`);
-						}}
-					>
-						{data}
-					</Typography.Link>
-				);
-			}
+	const firstTableData = data.result[0].table.rows || [];
+	const secondTableData = data.result[1]?.table.rows || [];
 
-			if (column === 'ts') {
-				const date =
-					typeof data === 'string'
-						? dayjs(data).format('YYYY-MM-DD HH:mm:ss.SSS')
-						: dayjs(data / 1e6).format('YYYY-MM-DD HH:mm:ss.SSS');
-				return <Typography.Text>{date}</Typography.Text>;
-			}
-
-			if (typeof data === 'number') {
-				return <Typography.Text>{data.toFixed(3)}</Typography.Text>;
-			}
-
-			return <Typography.Text>{data}</Typography.Text>;
-		},
-	}));
-
-	return columns;
-};
-
-export const getTableDataForProducerLatencyOverview = (
-	list: ProducerLatencyOverviewColumn[],
-): RowData[] => {
-	if (list?.length === 0) {
-		return [];
-	}
-
-	const tableData: RowData[] = list?.map(
-		(row, index: number): RowData => ({
-			...row.data,
-			key: index,
-		}),
+	// Create a map for quick lookup of byte_rate using service_name and topic
+	const byteRateMap = new Map(
+		secondTableData.map((row) => [
+			`${row.data.service_name}--${row.data.topic}`,
+			row.data.byte_rate,
+		]),
 	);
 
-	return tableData;
-};
+	// Merge the data from both tables
+	const mergedTableData: RowData[] =
+		firstTableData.map(
+			(row, index): RowData => ({
+				...row.data,
+				byte_rate:
+					byteRateMap.get(`${row.data.service_name}--${row.data.topic}`) || 0,
+				key: index,
+			}),
+		) || [];
+
+	return mergedTableData;
+}

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTableUtils.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTableUtils.tsx
@@ -24,7 +24,7 @@ export interface TopicThroughputProducerOverviewResponse {
 	};
 }
 
-export const getColumnsForProduderLatencyOverview = (
+export const getColumnsForProducerLatencyOverview = (
 	list: ProducerLatencyOverviewColumn[],
 	history: History<unknown>,
 ): RowData[] => {

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.tsx
@@ -67,6 +67,8 @@ export function getColumns(
 			'throughput',
 			'avg_msg_size',
 			'error_percentage',
+			'ingestion_rate',
+			'byte_rate',
 		].includes(column.name)
 			? (value: number | string): string => {
 					if (!isNumber(value)) return value.toString();

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/MQTables.tsx
@@ -33,7 +33,7 @@ import {
 	MessagingQueuesPayloadProps,
 } from './getConsumerLagDetails';
 import {
-	getColumnsForProduderLatencyOverview,
+	getColumnsForProducerLatencyOverview,
 	getTableDataForProducerLatencyOverview,
 	TopicThroughputProducerOverviewResponse,
 } from './MQTableUtils';
@@ -194,7 +194,7 @@ function MessagingQueuesTable({
 						tableApiPayload?.detailType === 'producer'
 					) {
 						setColumns(
-							getColumnsForProduderLatencyOverview(
+							getColumnsForProducerLatencyOverview(
 								(data?.payload as TopicThroughputProducerOverviewResponse['payload'])
 									.result[0].list,
 								history,

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getTopicThroughputOverview.ts
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQTables/getTopicThroughputOverview.ts
@@ -5,11 +5,18 @@ import {
 	MessagingQueueServicePayload,
 	MessagingQueuesPayloadProps,
 } from './getConsumerLagDetails';
+import { TopicThroughputProducerOverviewResponse } from './MQTableUtils';
 
 export const getTopicThroughputOverview = async (
 	props: Omit<MessagingQueueServicePayload, 'variables'>,
 ): Promise<
-	SuccessResponse<MessagingQueuesPayloadProps['payload']> | ErrorResponse
+	| SuccessResponse<
+			(
+				| MessagingQueuesPayloadProps
+				| TopicThroughputProducerOverviewResponse
+			)['payload']
+	  >
+	| ErrorResponse
 > => {
 	const { detailType, start, end } = props;
 	const response = await axios.post(

--- a/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
@@ -1,8 +1,11 @@
 import './MQDetails.style.scss';
 
 import { Radio } from 'antd';
-import { Dispatch, SetStateAction } from 'react';
+import { getTopicThroughputOverview } from 'api/messagingQueues/getTopicThroughputOverview';
+import useUrlQuery from 'hooks/useUrlQuery';
+import { Dispatch, SetStateAction, useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { useHistory, useLocation } from 'react-router-dom';
 import { AppState } from 'store/reducers';
 import { GlobalReducer } from 'types/reducer/globalTime';
 
@@ -10,25 +13,32 @@ import {
 	MessagingQueuesViewType,
 	MessagingQueuesViewTypeOptions,
 	ProducerLatencyOptions,
+	setConfigDetail,
 } from '../MessagingQueuesUtils';
 import { MessagingQueueServicePayload } from './MQTables/getConsumerLagDetails';
 import { getKafkaSpanEval } from './MQTables/getKafkaSpanEval';
 import { getPartitionLatencyOverview } from './MQTables/getPartitionLatencyOverview';
-import { getTopicThroughputOverview } from './MQTables/getTopicThroughputOverview';
 import MessagingQueuesTable from './MQTables/MQTables';
 
 type SelectedViewType = keyof typeof MessagingQueuesViewType;
 
-function PartitionLatencyTabs({
+function ProducerLatencyTabs({
 	option,
 	setOption,
 }: {
 	option: ProducerLatencyOptions;
 	setOption: Dispatch<SetStateAction<ProducerLatencyOptions>>;
 }): JSX.Element {
+	const urlQuery = useUrlQuery();
+	const location = useLocation();
+	const history = useHistory();
+
 	return (
 		<Radio.Group
-			onChange={(e): void => setOption(e.target.value)}
+			onChange={(e): void => {
+				setConfigDetail(urlQuery, location, history, {});
+				setOption(e.target.value);
+			}}
 			value={option}
 			className="mq-details-options"
 		>
@@ -71,23 +81,26 @@ function MessagingQueueOverview({
 		(state) => state.globalTime,
 	);
 
-	const tableApiPayload: MessagingQueueServicePayload = {
-		variables: {},
-		start: minTime,
-		end: maxTime,
-		detailType:
-			// eslint-disable-next-line no-nested-ternary
-			selectedView === MessagingQueuesViewType.producerLatency.value
-				? option === ProducerLatencyOptions.Producers
-					? 'producer'
-					: 'consumer'
-				: undefined,
-	};
+	const tableApiPayload: MessagingQueueServicePayload = useMemo(
+		() => ({
+			variables: {},
+			start: minTime,
+			end: maxTime,
+			detailType:
+				// eslint-disable-next-line no-nested-ternary
+				selectedView === MessagingQueuesViewType.producerLatency.value
+					? option === ProducerLatencyOptions.Producers
+						? 'producer'
+						: 'consumer'
+					: undefined,
+		}),
+		[minTime, maxTime, selectedView, option],
+	);
 
 	return (
 		<div className="mq-overview-container">
 			{selectedView === MessagingQueuesViewType.producerLatency.value ? (
-				<PartitionLatencyTabs option={option} setOption={setOption} />
+				<ProducerLatencyTabs option={option} setOption={setOption} />
 			) : (
 				<div className="mq-overview-title">
 					{MessagingQueuesViewType[selectedView as SelectedViewType].label}

--- a/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
@@ -82,10 +82,6 @@ function MessagingQueueOverview({
 					? 'producer'
 					: 'consumer'
 				: undefined,
-		evalTime:
-			selectedView === MessagingQueuesViewType.dropRate.value
-				? 2363404
-				: undefined,
 	};
 
 	return (


### PR DESCRIPTION
### Summary

We have a new API response structure, due to which need to change the column and table data handling - 

slack thread for reference - https://signoz-team.slack.com/archives/C070V9S041L/p1731413223737439

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots



https://github.com/user-attachments/assets/72c04608-7a3d-43c5-a84d-82de68444565





#### Affected Areas and Manually Tested Areas

 - Tested producer overview table under Producer Latency View

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add logic for handling new API response structure for producer latency overview in messaging queues.
> 
>   - **New Functionality**:
>     - Add `getColumnsForProducerLatencyOverview` and `getTableDataForProducerLatencyOverview` in `MQTableUtils.tsx` for new API response structure.
>     - Introduce `TopicThroughputProducerOverviewResponse` interface in `MQTableUtils.tsx`.
>   - **Integration**:
>     - Update `MessagingQueuesTable` in `MQTables.tsx` to use new utility functions for producer latency overview.
>     - Modify `getTopicThroughputOverview` in `getTopicThroughputOverview.ts` to return `TopicThroughputProducerOverviewResponse`.
>   - **Misc**:
>     - Remove `evalTime` from `MessagingQueueOverview.tsx`.
>     - Refactor `MQDetails.tsx` to remove redundant code and update imports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for cd2e17f4bc7b3c4c2283a82e979fd122d8df9698. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->