### PR TITLE
fix(FE): fix the timestamp reduction issue when attempting to reduce the timestamp via drag

### DIFF
--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -88,7 +88,7 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 	const { featureResponse } = useSelector<AppState, AppReducer>(
 		(state) => state.app,
 	);
-	const { selectedTime: globalSelectedInterval } = useSelector<
+	const { selectedTime: globalSelectedInterval, maxTime, minTime } = useSelector<
 		AppState,
 		GlobalReducer
 	>((state) => state.globalTime);
@@ -350,6 +350,7 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 				formatForWeb:
 					getGraphTypeForFormat(selectedGraph || selectedWidget.panelTypes) ===
 					PANEL_TYPES.TABLE,
+				timeRange: minTime,
 			}));
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -358,6 +359,8 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 		selectedTime,
 		selectedWidget.fillSpans,
 		globalSelectedInterval,
+		maxTime,
+		minTime,
 	]);
 
 	const onClickSaveHandler = useCallback(() => {


### PR DESCRIPTION
## Fix: Timestamp Update on Zoom for Graph Data Refresh

### Description

This PR resolves an issue with the timestamp update on zoom for graph data in the application. Previously, when attempting to zoom in on the graph by dragging, the `timeRange` was not included in the `requestedData`, causing the `useMemo` hook to recognize the `requestedData` as unchanged. As a result, the post-request function to fetch new data was not triggered, and the graph failed to refresh. The graph data would only update when the timestamp was manually adjusted from the dropdown selection.

### Changes Made
- Added `timeRange` to the `requestedData` when zooming in on the graph.
- Ensured that every time the graph is zoomed, the updated timestamp range is dispatched and triggers a re-fetch of data.

### Issue
> In the attached video, the timestamp reduction on the graph does not refresh correctly upon zoom. The graph only reloads when using the station selection, leading to a poor user experience when trying to zoom. This issue persisted for three days, where initial adjustments worked, but further attempts failed.

### Testing
- Verified that zooming via drag now includes `timeRange` in `requestedData`.
- Confirmed that the graph data refreshes as expected on each zoom action without requiring a dropdown timestamp change.

### Screenshot

https://github.com/user-attachments/assets/5e769a58-ad1d-4ac9-a9e6-a5408ec60965


### Notes
This fix will improve the responsiveness of the graph by ensuring real-time data updates on zoom, providing a more seamless user experience.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes graph data refresh issue on zoom by including `timeRange` in `requestedData` in `NewWidget/index.tsx`.
> 
>   - **Behavior**:
>     - Fixes issue with graph data not refreshing on zoom by including `timeRange` in `requestedData` in `NewWidget/index.tsx`.
>     - Ensures `useEffect` updates `requestData` with `timeRange` to trigger data re-fetch.
>   - **Testing**:
>     - Verified graph refreshes correctly on zoom without needing dropdown timestamp change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 26e805f876104ab0e2b7a93c329e11446a6c2078. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->