### PR TITLE
feat: add feature flag to clickhouse migration

### DIFF
--- a/ee/query-service/app/server.go
+++ b/ee/query-service/app/server.go
@@ -195,8 +195,9 @@ func NewServer(serverOptions *ServerOptions) (*Server, error) {
 		return nil, err
 	}
 
+	migration := baseconst.IsClickhouseMigrationEnable()
 	go func() {
-		err = migrate.ClickHouseMigrate(reader.GetConn(), serverOptions.Cluster)
+		err = migrate.ClickHouseMigrate(reader.GetConn(), serverOptions.Cluster, migration)
 		if err != nil {
 			zap.L().Error("error while running clickhouse migrations", zap.Error(err))
 		}

--- a/pkg/query-service/app/server.go
+++ b/pkg/query-service/app/server.go
@@ -162,8 +162,10 @@ func NewServer(serverOptions *ServerOptions) (*Server, error) {
 		return nil, err
 	}
 
+	migration := constants.IsClickhouseMigrationEnable()
+
 	go func() {
-		err = migrate.ClickHouseMigrate(reader.GetConn(), serverOptions.Cluster)
+		err = migrate.ClickHouseMigrate(reader.GetConn(), serverOptions.Cluster, migration)
 		if err != nil {
 			zap.L().Error("error while running clickhouse migrations", zap.Error(err))
 		}

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -148,6 +148,21 @@ var DEFAULT_FEATURE_SET = model.FeatureSet{
 	},
 }
 
+// Clickhouse migration under the feature-flag
+
+func IsClickhouseMigrationEnable() bool {
+	isEnableMigrationStr := os.Getenv("CLICKHOUSE_MIGRATION_ENABLED")
+	if isEnableMigrationStr == "" {
+		return false
+	}
+	isEnableMigrationBol, err := strconv.ParseBool(isEnableMigrationStr)
+
+	if err != nil {
+		return false
+	}
+	return isEnableMigrationBol
+}
+
 func GetContextTimeout() time.Duration {
 	contextTimeoutStr := GetOrDefaultEnv("CONTEXT_TIMEOUT", "60")
 	contextTimeoutDuration, err := time.ParseDuration(contextTimeoutStr + "s")

--- a/pkg/query-service/migrate/migate.go
+++ b/pkg/query-service/migrate/migate.go
@@ -56,7 +56,10 @@ func Migrate(dsn string) error {
 	return nil
 }
 
-func ClickHouseMigrate(conn driver.Conn, cluster string) error {
+func ClickHouseMigrate(conn driver.Conn, cluster string, config bool) error {
+	if !config {
+		return nil
+	}
 
 	database := "CREATE DATABASE IF NOT EXISTS signoz_analytics ON CLUSTER %s"
 


### PR DESCRIPTION
### Summary

The issue was that ClickHouse migrations were starting automatically when the server launched. To address this, I implemented a flag feature for conditional migrations. An environment variable, `CLICKHOUSE_MIGRATION_ENABLED`, was introduced with a default value of `false`. When set to `false`, migrations do not run; if changed to `true`, migrations will execute. This allows for an optimized, dynamic approach to managing migrations.

#### Related Issues / PR's

resolves #5678

#### Screenshots

NA


#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
