### PR TITLE
fix(FE): prevent saving view with empty label

### DIFF
--- a/frontend/src/container/ExplorerOptions/ExplorerOptions.tsx
+++ b/frontend/src/container/ExplorerOptions/ExplorerOptions.tsx
@@ -418,6 +418,12 @@ function ExplorerOptions({
 	});
 
 	const onSaveHandler = (): void => {
+		if(newViewName.trim() === '' || !newViewName){
+			notifications.error({
+				 message: 'Please enter a valid label name to save this view.'
+			})
+			return
+		}
 		saveNewViewHandler({
 			compositeQuery,
 			handlePopOverClose: hideSaveViewModal,


### PR DESCRIPTION
### PR Title:  
**[FE]: Prevent Saving View with Empty or Whitespace-Only Label**

### PR Description:

**Issue:**  
Currently, the application allows users to save views with an empty or whitespace-only label, leading to confusion and inconsistent naming in the UI.

**Fix:**  
This PR introduces a validation check for the "Label" field in the "Save this view" dialog to ensure that the label contains non-whitespace characters before allowing the view to be saved. If the label is empty or only contains spaces, an error message will prompt the user to enter a valid label.

### Changes:
- Added a validation check for the label field before submission.
- Displayed an error message if the label is empty or contains only whitespace.
- Prevented the form submission if the validation fails.

### Screenshots 
<img width="750" alt="Screenshot 2024-11-15 at 6 41 38 AM" src="https://github.com/user-attachments/assets/849b1e1a-21e9-461b-99ed-a3b4df2bee4a">

<img width="750" alt="Screenshot 2024-11-15 at 6 43 49 AM" src="https://github.com/user-attachments/assets/4a1877f1-0c2a-408b-9fe8-1e86b533f2bd">


### How to test:
1. Open the "Save this view" dialog.
2. Leave the "Label" field empty or enter only spaces.
3. Click the "Save this view" button.
4. Verify that an error message appears prompting the user to enter a valid label.
5. Ensure the view is not saved unless the label is valid (non-empty and non-whitespace).

### Additional Context:
This fix addresses the UX issue where users could save views with invalid labels, making it difficult to manage views later. With the validation in place, users are required to enter a meaningful label before proceeding.

