### PR TITLE
feat: removed dashboard uuid is all cases be it duplicate, empty or somevalid, while import json

### DIFF
--- a/frontend/src/container/ListOfDashboard/ImportJSON/index.tsx
+++ b/frontend/src/container/ListOfDashboard/ImportJSON/index.tsx
@@ -83,7 +83,7 @@ function ImportJSON({
 			const dashboardData = JSON.parse(editorValue) as DashboardData;
 
 			// Add validation for uuid
-			if (dashboardData.uuid !== undefined && dashboardData.uuid.trim() === '') {
+			if (dashboardData.uuid !== undefined) {
 				// silently remove uuid if it is empty
 				delete dashboardData.uuid;
 			}

--- a/frontend/src/container/ListOfDashboard/ImportJSON/index.tsx
+++ b/frontend/src/container/ListOfDashboard/ImportJSON/index.tsx
@@ -82,9 +82,8 @@ function ImportJSON({
 
 			const dashboardData = JSON.parse(editorValue) as DashboardData;
 
-			// Add validation for uuid
+			// Remove uuid from the dashboard data, in all cases - empty, duplicate or any valid not duplicate uuid
 			if (dashboardData.uuid !== undefined) {
-				// silently remove uuid if it is empty
 				delete dashboardData.uuid;
 			}
 


### PR DESCRIPTION
### Summary

Here we want to remove `uuid` for people in case when they are empty string or duplicate, but for identifying a duplicate we would need an api call which is expensive, hence we decided to rather remove `uuid` (exisiting) in all cases, and later once the importing is done, we from behind the scene will provide each dashboard with a unique `uuid`.

With this we wont block user for import json jsut on the uuid parameters

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots


https://github.com/user-attachments/assets/bb9d3ab3-e011-4fc7-b8bf-b1a08eeeaf10



#### Affected Areas and Manually Tested Areas

- Tested import json flows with - 
   - uuid present duplicate or valid
   - uuid empty string
   - uuid not present

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `uuid` from `dashboardData` during JSON import in `ImportJSON` component, regardless of its value.
> 
>   - **Behavior**:
>     - In `ImportJSON` component, `uuid` is removed from `dashboardData` during JSON import, regardless of its value (duplicate, empty, or valid).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 8778934f9a7d401ab415df5c972f1e658f7a41ff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->