### PR TITLE
chore: added an endpoint to support migration of licenses

### DIFF
--- a/ee/query-service/app/api/api.go
+++ b/ee/query-service/app/api/api.go
@@ -193,6 +193,8 @@ func (ah *APIHandler) RegisterRoutes(router *mux.Router, am *baseapp.AuthMiddlew
 		am.AdminAccess(ah.refreshLicensesV3)).
 		Methods(http.MethodPut)
 
+	router.HandleFunc("/api/v3/licenses/insert", am.AdminAccess(ah.insertLicenseV3ForActiveLicenseKey)).Methods(http.MethodPost)
+
 	// v4
 	router.HandleFunc("/api/v4/query_range", am.ViewAccess(ah.queryRangeV4)).Methods(http.MethodPost)
 

--- a/ee/query-service/app/api/license.go
+++ b/ee/query-service/app/api/license.go
@@ -149,6 +149,17 @@ func (ah *APIHandler) refreshLicensesV3(w http.ResponseWriter, r *http.Request) 
 	render.Success(w, http.StatusNoContent, nil)
 }
 
+func (ah *APIHandler) insertLicenseV3ForActiveLicenseKey(w http.ResponseWriter, r *http.Request) {
+	err := ah.LM().InsertLicensesV3(r.Context())
+
+	if err != nil {
+		RespondError(w, err, nil)
+		return
+	}
+
+	render.Success(w, http.StatusAccepted, nil)
+}
+
 func (ah *APIHandler) checkout(w http.ResponseWriter, r *http.Request) {
 
 	type checkoutResponse struct {

--- a/ee/query-service/license/manager.go
+++ b/ee/query-service/license/manager.go
@@ -235,6 +235,25 @@ func (lm *Manager) GetLicensesV3(ctx context.Context) (response []*model.License
 	return response, nil
 }
 
+func (lm *Manager) InsertLicensesV3(ctx context.Context) *model.ApiError {
+	// get the active license from the license manager
+	activeLicenseKey := lm.activeLicense.Key
+
+	// fetch the license from zeus based on the active key
+	licenseV3, err := validate.ValidateLicenseV3(activeLicenseKey)
+	if err != nil {
+		return err
+	}
+
+	// insert the licenseV3 in sqlite db
+	err = lm.repo.InsertLicenseV3(ctx, licenseV3)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Validator validates license after an epoch of time
 func (lm *Manager) Validator(ctx context.Context) {
 	defer close(lm.terminated)


### PR DESCRIPTION
### Summary

- added an endpoint whose role is to pick the active license from license manager and hit the zeus API to get all the details and insert the entry into licenses_v3 table. 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->