### PR TITLE
fix: show org onboarding only to cloud customers

### DIFF
--- a/frontend/src/AppRoutes/Private.tsx
+++ b/frontend/src/AppRoutes/Private.tsx
@@ -22,6 +22,7 @@ import AppActions from 'types/actions';
 import { UPDATE_USER_IS_FETCH } from 'types/actions/app';
 import { Organization } from 'types/api/user/getOrganization';
 import AppReducer from 'types/reducer/app';
+import { isCloudUser } from 'utils/app';
 import { routePermission } from 'utils/permission';
 
 import routes, {
@@ -75,6 +76,8 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 	} = useLicense();
 
 	const { t } = useTranslation(['common']);
+
+	const isCloudUserVal = isCloudUser();
 
 	const localStorageUserAuthToken = getInitialUserTokenRefreshToken();
 
@@ -143,6 +146,7 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 	const handleRedirectForOrgOnboarding = (key: string): void => {
 		if (
 			isLoggedInState &&
+			isCloudUserVal &&
 			!isFetchingOrgPreferences &&
 			!isLoadingOrgUsers &&
 			!isEmpty(orgUsers?.payload) &&
@@ -157,6 +161,10 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 			if (isFirstTimeUser && !isOnboardingComplete) {
 				history.push(ROUTES.ONBOARDING);
 			}
+		}
+
+		if (!isCloudUserVal && key === 'ONBOARDING') {
+			history.push(ROUTES.APPLICATION);
 		}
 	};
 
@@ -250,7 +258,7 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 	const handleRouting = (): void => {
 		const showOrgOnboarding = shouldShowOnboarding();
 
-		if (showOrgOnboarding && !isOnboardingComplete) {
+		if (showOrgOnboarding && !isOnboardingComplete && isCloudUserVal) {
 			history.push(ROUTES.ONBOARDING);
 		} else {
 			history.push(ROUTES.APPLICATION);


### PR DESCRIPTION
fix: show org onboarding only to cloud customers
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `PrivateRoute` in `Private.tsx` to show onboarding only to cloud users using `isCloudUser` check.
> 
>   - **Behavior**:
>     - Modify `handleRedirectForOrgOnboarding` in `Private.tsx` to check `isCloudUserVal` before redirecting to onboarding.
>     - Update `handleRouting` in `Private.tsx` to include `isCloudUserVal` in the condition for showing onboarding.
>   - **Utilities**:
>     - Use `isCloudUser` utility function to determine if the user is a cloud user in `Private.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for b65106f17b538b4ceb68d3b1763366297a7fd14c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->