### PR TITLE
fix: compare op outside bounds for anomaly alert

### DIFF
--- a/ee/query-service/rules/anomaly.go
+++ b/ee/query-service/rules/anomaly.go
@@ -61,6 +61,11 @@ func NewAnomalyRule(
 
 	zap.L().Info("creating new AnomalyRule", zap.String("id", id), zap.Any("opts", opts))
 
+	if p.RuleCondition.CompareOp == baserules.ValueIsBelow {
+		target := -1 * *p.RuleCondition.Target
+		p.RuleCondition.Target = &target
+	}
+
 	baseRule, err := baserules.NewBaseRule(id, p, reader, opts...)
 	if err != nil {
 		return nil, err

--- a/frontend/src/container/FormAlertRules/RuleOptions.tsx
+++ b/frontend/src/container/FormAlertRules/RuleOptions.tsx
@@ -102,9 +102,9 @@ function RuleOptions({
 					<Select.Option value="4">{t('option_notequal')}</Select.Option>
 				</>
 			)}
-
+			{/* the value 5 and 6 are reserved for above or equal and below or equal */}
 			{ruleType === 'anomaly_rule' && (
-				<Select.Option value="5">{t('option_above_below')}</Select.Option>
+				<Select.Option value="7">{t('option_above_below')}</Select.Option>
 			)}
 		</InlineSelect>
 	);

--- a/pkg/query-service/rules/base_rule.go
+++ b/pkg/query-service/rules/base_rule.go
@@ -463,9 +463,9 @@ func (r *BaseRule) ShouldAlert(series v3.Series) (Sample, bool) {
 			}
 		} else if r.compareOp() == ValueOutsideBounds {
 			for _, smpl := range series.Points {
-				if math.Abs(smpl.Value) >= r.targetVal() {
+				if math.Abs(smpl.Value) < r.targetVal() {
 					alertSmpl = Sample{Point: Point{V: smpl.Value}, Metric: lbls}
-					shouldAlert = true
+					shouldAlert = false
 					break
 				}
 			}


### PR DESCRIPTION
### Summary

Some gaps in https://github.com/SigNoz/signoz/issues/5469 implementation
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes anomaly alert condition handling by adjusting target values and correcting comparison logic in backend and updating frontend options.
> 
>   - **Behavior**:
>     - Adjusts target value in `NewAnomalyRule` in `anomaly.go` when `CompareOp` is `ValueIsBelow` by negating the target.
>     - Corrects logic in `ShouldAlert` in `base_rule.go` for `ValueOutsideBounds` to set `shouldAlert` to `false` if value is within bounds.
>   - **Frontend**:
>     - Updates `RuleOptions.tsx` to change `Select.Option` value from `5` to `7` for anomaly rule comparison operator.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 434d3bcfa80d8cf412898bdf0347c4024f5ca4d9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->