### PR TITLE
chore: add missing alert telemetry

### DIFF
--- a/pkg/query-service/telemetry/telemetry.go
+++ b/pkg/query-service/telemetry/telemetry.go
@@ -347,6 +347,7 @@ func createTelemetry() {
 						"alertsWithTSV2":                  alertsInfo.AlertsWithTSV2,
 						"logsBasedAlerts":                 alertsInfo.LogsBasedAlerts,
 						"metricBasedAlerts":               alertsInfo.MetricBasedAlerts,
+						"anomalyBasedAlerts":              alertsInfo.AnomalyBasedAlerts,
 						"tracesBasedAlerts":               alertsInfo.TracesBasedAlerts,
 						"totalChannels":                   alertsInfo.TotalChannels,
 						"totalSavedViews":                 savedViewsInfo.TotalSavedViews,


### PR DESCRIPTION
### Summary

We capture this here. https://github.com/SigNoz/signoz/blob/0acf39a53237f3651dd20c01eb76a1c731d286f5/pkg/query-service/rules/db.go#L602-L604 I forgot it needs to be explicitly added again the `telemetry.go`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `anomalyBasedAlerts` to telemetry data in `createTelemetry()` in `telemetry.go`.
> 
>   - **Telemetry**:
>     - Add `anomalyBasedAlerts` to telemetry data in `createTelemetry()` in `telemetry.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for bbe1919e820a21b15f15a2e117ede109f193b84a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->