### PR TITLE
chore: add user email to log_comment

### DIFF
--- a/pkg/query-service/app/server.go
+++ b/pkg/query-service/app/server.go
@@ -384,6 +384,11 @@ func LogCommentEnricher(next http.Handler) http.Handler {
 			client = "api"
 		}
 
+		email, err := auth.GetEmailFromJwt(r.Context())
+		if err != nil {
+			zap.S().Errorf("error while getting email from jwt: %v", err)
+		}
+
 		kvs := map[string]string{
 			"path":        path,
 			"dashboardID": dashboardID,
@@ -392,6 +397,7 @@ func LogCommentEnricher(next http.Handler) http.Handler {
 			"client":      client,
 			"viewName":    viewName,
 			"servicesTab": tab,
+			"email":       email,
 		}
 
 		r = r.WithContext(context.WithValue(r.Context(), common.LogCommentKey, kvs))


### PR DESCRIPTION
### Summary

Fixes https://github.com/SigNoz/signoz/issues/6439
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds user email to log comments in `LogCommentEnricher` by extracting it from JWT in `server.go`.
> 
>   - **Behavior**:
>     - Adds user email to log comments in `LogCommentEnricher` in `server.go` by extracting email from JWT.
>     - Logs an error if email extraction from JWT fails.
>   - **Misc**:
>     - No changes to existing functionality, only enhancement to logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 441f833cadb5153570de77f82a7535bceea70b3f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->