### PR TITLE
chore: use the license v2 key to fill licenses v3 on startup

### DIFF
--- a/ee/query-service/license/manager.go
+++ b/ee/query-service/license/manager.go
@@ -84,7 +84,8 @@ func StartManager(dbType string, db *sqlx.DB, useLicensesV3 bool, features ...ba
 
 			// insert the licenseV3 in sqlite db
 			apiError = m.repo.InsertLicenseV3(context.Background(), licenseV3)
-			if apiError != nil {
+			// if the license already exists move ahead.
+			if apiError != nil && apiError.Typ != model.ErrorConflict {
 				return m, apiError
 			}
 		}

--- a/ee/query-service/license/manager.go
+++ b/ee/query-service/license/manager.go
@@ -74,16 +74,19 @@ func StartManager(dbType string, db *sqlx.DB, useLicensesV3 bool, features ...ba
 			return m, err
 		}
 
-		// fetch the new license structure from control plane
-		licenseV3, apiError := validate.ValidateLicenseV3(active.Key)
-		if apiError != nil {
-			return m, apiError
-		}
+		// if we have an active license then need to fetch the complete details
+		if active != nil {
+			// fetch the new license structure from control plane
+			licenseV3, apiError := validate.ValidateLicenseV3(active.Key)
+			if apiError != nil {
+				return m, apiError
+			}
 
-		// insert the licenseV3 in sqlite db
-		apiError = m.repo.InsertLicenseV3(context.Background(), licenseV3)
-		if apiError != nil {
-			return m, apiError
+			// insert the licenseV3 in sqlite db
+			apiError = m.repo.InsertLicenseV3(context.Background(), licenseV3)
+			if apiError != nil {
+				return m, apiError
+			}
 		}
 	}
 


### PR DESCRIPTION
### Summary

- make the licenses v3 call on startup to avoid any explicit migration for new structure. 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

