### PR TITLE
Trace static fields and structs for response.

### DIFF
--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	"maps"
 	"os"
 	"strconv"
 	"testing"
@@ -238,8 +239,8 @@ const (
 	SIGNOZ_EXP_HISTOGRAM_TABLENAME             = "distributed_exp_hist"
 	SIGNOZ_TRACE_DBNAME                        = "signoz_traces"
 	SIGNOZ_SPAN_INDEX_TABLENAME                = "distributed_signoz_index_v2"
-	SIGNOZ_SPAN_INDEX_LOCAL_TABLENAME          = "signoz_index_v2"
 	SIGNOZ_SPAN_INDEX_V3                       = "distributed_signoz_index_v3"
+	SIGNOZ_SPAN_INDEX_LOCAL_TABLENAME          = "signoz_index_v2"
 	SIGNOZ_SPAN_INDEX_V3_LOCAL_TABLENAME       = "signoz_index_v3"
 	SIGNOZ_TIMESERIES_v4_LOCAL_TABLENAME       = "time_series_v4"
 	SIGNOZ_TIMESERIES_v4_6HRS_LOCAL_TABLENAME  = "time_series_v4_6hrs"
@@ -447,30 +448,35 @@ const MaxFilterSuggestionsExamplesLimit = 10
 var SpanRenderLimitStr = GetOrDefaultEnv("SPAN_RENDER_LIMIT", "2500")
 var MaxSpansInTraceStr = GetOrDefaultEnv("MAX_SPANS_IN_TRACE", "250000")
 
-var StaticFieldsTraces = map[string]v3.AttributeKey{
+var NewStaticFieldsTraces = map[string]v3.AttributeKey{
 	"timestamp": {},
-	"traceID": {
-		Key:      "traceID",
+	"trace_id": {
+		Key:      "trace_id",
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
-	"spanID": {
-		Key:      "spanID",
+	"span_id": {
+		Key:      "span_id",
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
-	"parentSpanID": {
-		Key:      "parentSpanID",
+	"trace_state": {
+		Key:      "trace_state",
 		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"parent_span_id": {
+		Key:      "parent_span_id",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"flags": {
+		Key:      "flags",
+		DataType: v3.AttributeKeyDataTypeInt64,
 		IsColumn: true,
 	},
 	"name": {
 		Key:      "name",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"serviceName": {
-		Key:      "serviceName",
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
@@ -479,118 +485,33 @@ var StaticFieldsTraces = map[string]v3.AttributeKey{
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
-	"spanKind": {
-		Key:      "spanKind",
+	"kind_string": {
+		Key:      "kind_string",
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
-	"durationNano": {
-		Key:      "durationNano",
+	"duration_nano": {
+		Key:      "duration_nano",
 		DataType: v3.AttributeKeyDataTypeFloat64,
 		IsColumn: true,
 	},
-	"statusCode": {
-		Key:      "statusCode",
+	"status_code": {
+		Key:      "status_code",
 		DataType: v3.AttributeKeyDataTypeFloat64,
 		IsColumn: true,
 	},
-	"hasError": {
-		Key:      "hasError",
-		DataType: v3.AttributeKeyDataTypeBool,
-		IsColumn: true,
-	},
-	"statusMessage": {
-		Key:      "statusMessage",
+	"status_message": {
+		Key:      "status_message",
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
-	"statusCodeString": {
-		Key:      "statusCodeString",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"externalHttpMethod": {
-		Key:      "externalHttpMethod",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"externalHttpUrl": {
-		Key:      "externalHttpUrl",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"dbSystem": {
-		Key:      "dbSystem",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"dbName": {
-		Key:      "dbName",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"dbOperation": {
-		Key:      "dbOperation",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"peerService": {
-		Key:      "peerService",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"httpMethod": {
-		Key:      "httpMethod",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"httpUrl": {
-		Key:      "httpUrl",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"httpRoute": {
-		Key:      "httpRoute",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"httpHost": {
-		Key:      "httpHost",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"msgSystem": {
-		Key:      "msgSystem",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"msgOperation": {
-		Key:      "msgOperation",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"rpcSystem": {
-		Key:      "rpcSystem",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"rpcService": {
-		Key:      "rpcService",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"rpcMethod": {
-		Key:      "rpcMethod",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"responseStatusCode": {
-		Key:      "responseStatusCode",
+	"status_code_string": {
+		Key:      "status_code_string",
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
 
-	// new support
+	// new support for composite attributes
 	"response_status_code": {
 		Key:      "response_status_code",
 		DataType: v3.AttributeKeyDataTypeString,
@@ -643,6 +564,157 @@ var StaticFieldsTraces = map[string]v3.AttributeKey{
 	},
 	// the simple attributes are not present here as
 	// they are taken care by new format <attribute_type>_<attribute_datatype>_'<attribute_key>'
+}
+
+var DeprecatedStaticFieldsTraces = map[string]v3.AttributeKey{
+	"traceID": {
+		Key:      "traceID",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"spanID": {
+		Key:      "spanID",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"parentSpanID": {
+		Key:      "parentSpanID",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"spanKind": {
+		Key:      "spanKind",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"durationNano": {
+		Key:      "durationNano",
+		DataType: v3.AttributeKeyDataTypeFloat64,
+		IsColumn: true,
+	},
+	"statusCode": {
+		Key:      "statusCode",
+		DataType: v3.AttributeKeyDataTypeFloat64,
+		IsColumn: true,
+	},
+	"statusMessage": {
+		Key:      "statusMessage",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"statusCodeString": {
+		Key:      "statusCodeString",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+
+	// old support for composite attributes
+	"responseStatusCode": {
+		Key:      "responseStatusCode",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"externalHttpUrl": {
+		Key:      "externalHttpUrl",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"httpUrl": {
+		Key:      "httpUrl",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"externalHttpMethod": {
+		Key:      "externalHttpMethod",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"httpMethod": {
+		Key:      "httpMethod",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"httpHost": {
+		Key:      "httpHost",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"dbName": {
+		Key:      "dbName",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"dbOperation": {
+		Key:      "dbOperation",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"hasError": {
+		Key:      "hasError",
+		DataType: v3.AttributeKeyDataTypeBool,
+		IsColumn: true,
+	},
+	"isRemote": {
+		Key:      "isRemote",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+
+	// old support for resource attributes
+	"serviceName": {
+		Key:      "serviceName",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+
+	// old support for simple attributes
+	"httpRoute": {
+		Key:      "httpRoute",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"msgSystem": {
+		Key:      "msgSystem",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"msgOperation": {
+		Key:      "msgOperation",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"dbSystem": {
+		Key:      "dbSystem",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"rpcSystem": {
+		Key:      "rpcSystem",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"rpcService": {
+		Key:      "rpcService",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"rpcMethod": {
+		Key:      "rpcMethod",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"peerService": {
+		Key:      "peerService",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+}
+
+var StaticFieldsTraces = map[string]v3.AttributeKey{}
+
+func init() {
+	StaticFieldsTraces = maps.Clone(NewStaticFieldsTraces)
+	maps.Copy(StaticFieldsTraces, DeprecatedStaticFieldsTraces)
 }
 
 const TRACE_V4_MAX_PAGINATION_LIMIT = 10000

--- a/pkg/query-service/model/response.go
+++ b/pkg/query-service/model/response.go
@@ -271,12 +271,12 @@ type SearchSpanResponseItem struct {
 
 type SearchSpanResponseItemV2 struct {
 	TimeUnixNano      time.Time          `json:"timestamp" ch:"timestamp"`
-	DurationNano      uint64             `json:"durationNano" ch:"durationNano"`
+	DurationNano      uint64             `json:"durationNano" ch:"duration_nano"`
 	SpanID            string             `json:"spanId" ch:"span_id"`
 	TraceID           string             `json:"traceId" ch:"trace_id"`
 	HasError          bool               `json:"hasError" ch:"has_error"`
 	Kind              int8               `json:"kind" ch:"kind"`
-	ServiceName       string             `json:"serviceName" ch:"resource_string$$service.name"`
+	ServiceName       string             `json:"serviceName" ch:"resource_string_service$$name"`
 	Name              string             `json:"name" ch:"name"`
 	References        string             `json:"references,omitempty" ch:"references"`
 	Attributes_string map[string]string  `json:"attributes_string" ch:"attributes_string"`

--- a/pkg/query-service/model/response.go
+++ b/pkg/query-service/model/response.go
@@ -269,32 +269,6 @@ type SearchSpanResponseItem struct {
 	SpanKind         string            `json:"spanKind"`
 }
 
-type SearchSpanResponseItemV2 struct {
-	TimeUnixNano      time.Time          `json:"timestamp" ch:"timestamp"`
-	DurationNano      uint64             `json:"durationNano" ch:"duration_nano"`
-	SpanID            string             `json:"spanId" ch:"span_id"`
-	TraceID           string             `json:"traceId" ch:"trace_id"`
-	HasError          bool               `json:"hasError" ch:"has_error"`
-	Kind              int8               `json:"kind" ch:"kind"`
-	ServiceName       string             `json:"serviceName" ch:"resource_string_service$$name"`
-	Name              string             `json:"name" ch:"name"`
-	References        string             `json:"references,omitempty" ch:"references"`
-	Attributes_string map[string]string  `json:"attributes_string" ch:"attributes_string"`
-	Attributes_number map[string]float64 `json:"attributes_number" ch:"attributes_number"`
-	Attributes_bool   map[string]bool    `json:"attributes_bool" ch:"attributes_bool"`
-	Events            []string           `json:"event" ch:"events"`
-	StatusMessage     string             `json:"statusMessage" ch:"status_message"`
-	StatusCodeString  string             `json:"statusCodeString" ch:"status_code_string"`
-	SpanKind          string             `json:"spanKind" ch:"kind_string"`
-}
-
-type TraceSummary struct {
-	TraceID  string    `json:"traceId" ch:"trace_id"`
-	Start    time.Time `json:"start" ch:"start"`
-	End      time.Time `json:"end" ch:"end"`
-	NumSpans uint64    `json:"numSpans" ch:"num_spans"`
-}
-
 type OtelSpanRef struct {
 	TraceId string `json:"traceId,omitempty"`
 	SpanId  string `json:"spanId,omitempty"`

--- a/pkg/query-service/model/response.go
+++ b/pkg/query-service/model/response.go
@@ -269,6 +269,32 @@ type SearchSpanResponseItem struct {
 	SpanKind         string            `json:"spanKind"`
 }
 
+type SearchSpanResponseItemV2 struct {
+	TimeUnixNano      time.Time          `json:"timestamp" ch:"timestamp"`
+	DurationNano      uint64             `json:"durationNano" ch:"durationNano"`
+	SpanID            string             `json:"spanId" ch:"span_id"`
+	TraceID           string             `json:"traceId" ch:"trace_id"`
+	HasError          bool               `json:"hasError" ch:"has_error"`
+	Kind              int8               `json:"kind" ch:"kind"`
+	ServiceName       string             `json:"serviceName" ch:"resource_string$$service.name"`
+	Name              string             `json:"name" ch:"name"`
+	References        string             `json:"references,omitempty" ch:"references"`
+	Attributes_string map[string]string  `json:"attributes_string" ch:"attributes_string"`
+	Attributes_number map[string]float64 `json:"attributes_number" ch:"attributes_number"`
+	Attributes_bool   map[string]bool    `json:"attributes_bool" ch:"attributes_bool"`
+	Events            []string           `json:"event" ch:"events"`
+	StatusMessage     string             `json:"statusMessage" ch:"status_message"`
+	StatusCodeString  string             `json:"statusCodeString" ch:"status_code_string"`
+	SpanKind          string             `json:"spanKind" ch:"kind_string"`
+}
+
+type TraceSummary struct {
+	TraceID  string    `json:"traceId" ch:"trace_id"`
+	Start    time.Time `json:"start" ch:"start"`
+	End      time.Time `json:"end" ch:"end"`
+	NumSpans uint64    `json:"numSpans" ch:"num_spans"`
+}
+
 type OtelSpanRef struct {
 	TraceId string `json:"traceId,omitempty"`
 	SpanId  string `json:"spanId,omitempty"`

--- a/pkg/query-service/model/trace.go
+++ b/pkg/query-service/model/trace.go
@@ -1,0 +1,29 @@
+package model
+
+import "time"
+
+type SpanItemV2 struct {
+	TimeUnixNano      time.Time          `ch:"timestamp"`
+	DurationNano      uint64             `ch:"duration_nano"`
+	SpanID            string             `ch:"span_id"`
+	TraceID           string             `ch:"trace_id"`
+	HasError          bool               `ch:"has_error"`
+	Kind              int8               `ch:"kind"`
+	ServiceName       string             `ch:"resource_string_service$$name"`
+	Name              string             `ch:"name"`
+	References        string             `ch:"references"`
+	Attributes_string map[string]string  `ch:"attributes_string"`
+	Attributes_number map[string]float64 `ch:"attributes_number"`
+	Attributes_bool   map[string]bool    `ch:"attributes_bool"`
+	Events            []string           `ch:"events"`
+	StatusMessage     string             `ch:"status_message"`
+	StatusCodeString  string             `ch:"status_code_string"`
+	SpanKind          string             `ch:"kind_string"`
+}
+
+type TraceSummary struct {
+	TraceID  string    `ch:"trace_id"`
+	Start    time.Time `ch:"start"`
+	End      time.Time `ch:"end"`
+	NumSpans uint64    `ch:"num_spans"`
+}


### PR DESCRIPTION
* Has new static fields of traces  (used for suggestions)
* Has deprecated static fields of traces ( use to support old names)
* Static field traces is a union of the above
* The response structs will be used in trace detail page.

ref for static fields https://github.com/SigNoz/signoz-otel-collector/blob/main/cmd/signozschemamigrator/schema_migrator/traces_migrations.go

FOR https://github.com/SigNoz/signoz/issues/5713
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds new static fields for traces, deprecates old ones, and introduces new response structs for trace details.
> 
>   - **Static Fields**:
>     - Introduces `NewStaticFieldsTraces` and `DeprecatedStaticFieldsTraces` in `constants.go`.
>     - Combines both into `StaticFieldsTraces` using `init()` function.
>   - **Response Structs**:
>     - Adds `SpanItemV2` and `TraceSummary` structs in `trace.go` for trace detail responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for ce7b509ddbd9fb8ba39dbca434cb0c103f58a368. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->