### PR TITLE
fix: update TestListTsRange to return all range

### DIFF
--- a/pkg/query-service/utils/logs.go
+++ b/pkg/query-service/utils/logs.go
@@ -35,6 +35,8 @@ func GetListTsRanges(start, end int64) []LogsListTsRange {
 				tStartNano = startNano
 			}
 		}
+	} else {
+		result = append(result, LogsListTsRange{Start: start, End: end})
 	}
 	return result
 }

--- a/pkg/query-service/utils/logs_test.go
+++ b/pkg/query-service/utils/logs_test.go
@@ -18,7 +18,7 @@ func TestListTsRange(t *testing.T) {
 			name:  "testing for less then one hour",
 			start: 1722262800000000000, // July 29, 2024 7:50:00 PM
 			end:   1722263800000000000, // July 29, 2024 8:06:40 PM
-			res:   []LogsListTsRange{},
+			res:   []LogsListTsRange{{1722262800000000000, 1722263800000000000}},
 		},
 		{
 			name:  "testing for more than one hour",


### PR DESCRIPTION
Previously we had an if clause that if the `startEndArr` array is empty don't run the new pagination and fallback, which was missed so. Queries for <= hour interval were returning empty results.

Update the function to return a signle item which contains the actual start and end if the interval is < hour
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `GetListTsRanges` to return a single range for intervals less than 1 hour, updating the test case accordingly.
> 
>   - **Behavior**:
>     - Fixes `GetListTsRanges` in `logs.go` to return a single range for intervals < 1 hour.
>     - Previously, intervals <= 1 hour returned empty results.
>   - **Tests**:
>     - Updates `TestListTsRange` in `logs_test.go` to expect a single range for intervals < 1 hour.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 2ed2bd617537e2d8d0ff252412afb07683a11c39. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->