### PR TITLE
chore: set `ZEUS_URL` via build time variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ BUILD_HASH      ?= $(shell git rev-parse --short HEAD)
 BUILD_TIME      ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILD_BRANCH    ?= $(shell git rev-parse --abbrev-ref HEAD)
 DEV_LICENSE_SIGNOZ_IO ?= https://staging-license.signoz.io/api/v1
+ZEUS_URL ?= https://api.signoz.cloud
 DEV_BUILD ?= "" # set to any non-empty value to enable dev build
 
 # Internal variables or constants.
@@ -33,8 +34,9 @@ buildHash=${PACKAGE}/pkg/query-service/version.buildHash
 buildTime=${PACKAGE}/pkg/query-service/version.buildTime
 gitBranch=${PACKAGE}/pkg/query-service/version.gitBranch
 licenseSignozIo=${PACKAGE}/ee/query-service/constants.LicenseSignozIo
+zeusURL=${PACKAGE}/ee/query-service/constants.ZeusURL
 
-LD_FLAGS=-X ${buildHash}=${BUILD_HASH} -X ${buildTime}=${BUILD_TIME} -X ${buildVersion}=${BUILD_VERSION} -X ${gitBranch}=${BUILD_BRANCH}
+LD_FLAGS=-X ${buildHash}=${BUILD_HASH} -X ${buildTime}=${BUILD_TIME} -X ${buildVersion}=${BUILD_VERSION} -X ${gitBranch}=${BUILD_BRANCH} -X ${zeusURL}=${ZEUS_URL}
 DEV_LD_FLAGS=-X ${licenseSignozIo}=${DEV_LICENSE_SIGNOZ_IO}
 
 all: build-push-frontend build-push-query-service

--- a/ee/query-service/constants/constants.go
+++ b/ee/query-service/constants/constants.go
@@ -13,7 +13,9 @@ var LicenseAPIKey = GetOrDefaultEnv("SIGNOZ_LICENSE_API_KEY", "")
 var SaasSegmentKey = GetOrDefaultEnv("SIGNOZ_SAAS_SEGMENT_KEY", "")
 var FetchFeatures = GetOrDefaultEnv("FETCH_FEATURES", "false")
 var ZeusFeaturesURL = GetOrDefaultEnv("ZEUS_FEATURES_URL", "ZeusFeaturesURL")
-var ZeusURL = GetOrDefaultEnv("ZEUS_URL", "ZeusURL")
+
+// this is set via build time variable
+var ZeusURL = "https://api.signoz.cloud"
 
 func GetOrDefaultEnv(key string, fallback string) string {
 	v := os.Getenv(key)


### PR DESCRIPTION
### Summary

- make `zeus_url` a build time variable rather than env variable. 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
