### PR TITLE
chore: exactly match the list licenses v2 structure with FF on

### DIFF
--- a/ee/query-service/app/api/license.go
+++ b/ee/query-service/app/api/license.go
@@ -218,6 +218,10 @@ func (ah *APIHandler) getBilling(w http.ResponseWriter, r *http.Request) {
 func convertLicenseV3ToLicenseV2(licenses []*model.LicenseV3) []model.License {
 	licensesV2 := []model.License{}
 	for _, l := range licenses {
+		planKeyFromPlanName, ok := model.MapOldPlanKeyToNewPlanName[l.PlanName]
+		if !ok {
+			planKeyFromPlanName = model.Basic
+		}
 		licenseV2 := model.License{
 			Key:               l.Key,
 			ActivationId:      "",
@@ -226,7 +230,7 @@ func convertLicenseV3ToLicenseV2(licenses []*model.LicenseV3) []model.License {
 			ValidationMessage: "",
 			IsCurrent:         l.IsCurrent,
 			LicensePlan: model.LicensePlan{
-				PlanKey:    l.PlanName,
+				PlanKey:    planKeyFromPlanName,
 				ValidFrom:  l.ValidFrom,
 				ValidUntil: l.ValidUntil,
 				Status:     l.Status},

--- a/ee/query-service/license/manager.go
+++ b/ee/query-service/license/manager.go
@@ -253,6 +253,11 @@ func (lm *Manager) GetLicensesV3(ctx context.Context) (response []*model.License
 		if lm.activeLicenseV3 != nil && l.Key == lm.activeLicenseV3.Key {
 			l.IsCurrent = true
 		}
+		if l.ValidUntil == -1 {
+			// for subscriptions, there is no end-date as such
+			// but for showing user some validity we default one year timespan
+			l.ValidUntil = l.ValidFrom + 31556926
+		}
 		response = append(response, l)
 	}
 

--- a/ee/query-service/model/plans.go
+++ b/ee/query-service/model/plans.go
@@ -17,6 +17,10 @@ var (
 )
 
 var (
+	MapOldPlanKeyToNewPlanName map[string]string = map[string]string{PlanNameBasic: Basic, PlanNameTeams: Pro, PlanNameEnterprise: Enterprise}
+)
+
+var (
 	LicenseStatusInactive = "INACTIVE"
 )
 


### PR DESCRIPTION
### Summary

- the plan key in the new structure was missing `PLAN` in the string end
- added the valid until of 1 year similar to previous flow 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Align license structure with feature flag by mapping old plan keys to new names and setting default validity in `license.go` and `manager.go`.
> 
>   - **Behavior**:
>     - In `convertLicenseV3ToLicenseV2` in `license.go`, map old plan keys to new plan names using `MapOldPlanKeyToNewPlanName`.
>     - In `GetLicensesV3` in `manager.go`, set `ValidUntil` to one year from `ValidFrom` if `ValidUntil` is -1.
>   - **Models**:
>     - Add `MapOldPlanKeyToNewPlanName` in `plans.go` to map old plan keys to new plan names.
>   - **Misc**:
>     - Ensure `PlanKey` in `LicensePlan` is correctly set in `convertLicenseV3ToLicenseV2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for ba2e84bf0d840834dbc1863580a709b79ab2da5f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->