### PR TITLE
Release/v0.59.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ BUILD_HASH      ?= $(shell git rev-parse --short HEAD)
 BUILD_TIME      ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILD_BRANCH    ?= $(shell git rev-parse --abbrev-ref HEAD)
 DEV_LICENSE_SIGNOZ_IO ?= https://staging-license.signoz.io/api/v1
+ZEUS_URL ?= https://api.signoz.cloud
 DEV_BUILD ?= "" # set to any non-empty value to enable dev build
 
 # Internal variables or constants.
@@ -33,8 +34,9 @@ buildHash=${PACKAGE}/pkg/query-service/version.buildHash
 buildTime=${PACKAGE}/pkg/query-service/version.buildTime
 gitBranch=${PACKAGE}/pkg/query-service/version.gitBranch
 licenseSignozIo=${PACKAGE}/ee/query-service/constants.LicenseSignozIo
+zeusURL=${PACKAGE}/ee/query-service/constants.ZeusURL
 
-LD_FLAGS=-X ${buildHash}=${BUILD_HASH} -X ${buildTime}=${BUILD_TIME} -X ${buildVersion}=${BUILD_VERSION} -X ${gitBranch}=${BUILD_BRANCH}
+LD_FLAGS=-X ${buildHash}=${BUILD_HASH} -X ${buildTime}=${BUILD_TIME} -X ${buildVersion}=${BUILD_VERSION} -X ${gitBranch}=${BUILD_BRANCH} -X ${zeusURL}=${ZEUS_URL}
 DEV_LD_FLAGS=-X ${licenseSignozIo}=${DEV_LICENSE_SIGNOZ_IO}
 
 all: build-push-frontend build-push-query-service

--- a/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
+++ b/deploy/docker-swarm/clickhouse-setup/docker-compose.yaml
@@ -146,7 +146,7 @@ services:
         condition: on-failure
 
   query-service:
-    image: signoz/query-service:0.58.2
+    image: signoz/query-service:0.59.0
     command:
       [
         "-config=/root/config/prometheus.yml",
@@ -186,7 +186,7 @@ services:
     <<: *db-depend
 
   frontend:
-    image: signoz/frontend:0.58.2
+    image: signoz/frontend:0.59.0
     deploy:
       restart_policy:
         condition: on-failure
@@ -199,7 +199,7 @@ services:
       - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
 
   otel-collector:
-    image: signoz/signoz-otel-collector:0.111.8
+    image: signoz/signoz-otel-collector:0.111.9
     command:
       [
         "--config=/etc/otel-collector-config.yaml",
@@ -237,7 +237,7 @@ services:
       - query-service
 
   otel-collector-migrator:
-      image: signoz/signoz-schema-migrator:0.111.8
+      image: signoz/signoz-schema-migrator:0.111.9
       deploy:
         restart_policy:
           condition: on-failure

--- a/deploy/docker/clickhouse-setup/docker-compose-core.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose-core.yaml
@@ -69,7 +69,7 @@ services:
       - --storage.path=/data
 
   otel-collector-migrator:
-    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.8}
+    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.9}
     container_name: otel-migrator
     command:
       - "--dsn=tcp://clickhouse:9000"
@@ -84,7 +84,7 @@ services:
   # Notes for Maintainers/Contributors who will change Line Numbers of Frontend & Query-Section. Please Update Line Numbers in `./scripts/commentLinesForSetup.sh` & `./CONTRIBUTING.md`
   otel-collector:
     container_name: signoz-otel-collector
-    image: signoz/signoz-otel-collector:0.111.8
+    image: signoz/signoz-otel-collector:0.111.9
     command:
       [
         "--config=/etc/otel-collector-config.yaml",

--- a/deploy/docker/clickhouse-setup/docker-compose-minimal.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose-minimal.yaml
@@ -162,7 +162,7 @@ services:
   # Notes for Maintainers/Contributors who will change Line Numbers of Frontend & Query-Section. Please Update Line Numbers in `./scripts/commentLinesForSetup.sh` & `./CONTRIBUTING.md`
 
   query-service:
-    image: signoz/query-service:${DOCKER_TAG:-0.58.2}
+    image: signoz/query-service:${DOCKER_TAG:-0.59.0}
     container_name: signoz-query-service
     command:
       [
@@ -201,7 +201,7 @@ services:
     <<: *db-depend
 
   frontend:
-    image: signoz/frontend:${DOCKER_TAG:-0.58.2}
+    image: signoz/frontend:${DOCKER_TAG:-0.59.0}
     container_name: signoz-frontend
     restart: on-failure
     depends_on:
@@ -213,7 +213,7 @@ services:
       - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
 
   otel-collector-migrator-sync:
-    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.8}
+    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.9}
     container_name: otel-migrator-sync
     command:
       - "sync"
@@ -228,7 +228,7 @@ services:
       #   condition: service_healthy
 
   otel-collector-migrator-async:
-    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.8}
+    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.9}
     container_name: otel-migrator-async
     command:
       - "async"
@@ -245,7 +245,7 @@ services:
       #   condition: service_healthy
 
   otel-collector:
-    image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.111.8}
+    image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.111.9}
     container_name: signoz-otel-collector
     command:
       [

--- a/deploy/docker/clickhouse-setup/docker-compose.testing.yaml
+++ b/deploy/docker/clickhouse-setup/docker-compose.testing.yaml
@@ -167,7 +167,7 @@ services:
   # Notes for Maintainers/Contributors who will change Line Numbers of Frontend & Query-Section. Please Update Line Numbers in `./scripts/commentLinesForSetup.sh` & `./CONTRIBUTING.md`
 
   query-service:
-    image: signoz/query-service:${DOCKER_TAG:-0.58.2}
+    image: signoz/query-service:${DOCKER_TAG:-0.59.0}
     container_name: signoz-query-service
     command:
       [
@@ -208,7 +208,7 @@ services:
     <<: *db-depend
 
   frontend:
-    image: signoz/frontend:${DOCKER_TAG:-0.58.2}
+    image: signoz/frontend:${DOCKER_TAG:-0.59.0}
     container_name: signoz-frontend
     restart: on-failure
     depends_on:
@@ -220,7 +220,7 @@ services:
       - ../common/nginx-config.conf:/etc/nginx/conf.d/default.conf
 
   otel-collector-migrator:
-    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.8}
+    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.9}
     container_name: otel-migrator
     command:
       - "--dsn=tcp://clickhouse:9000"
@@ -234,7 +234,7 @@ services:
 
 
   otel-collector:
-    image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.111.8}
+    image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.111.9}
     container_name: signoz-otel-collector
     command:
       [

--- a/ee/query-service/app/api/api.go
+++ b/ee/query-service/app/api/api.go
@@ -197,7 +197,7 @@ func (ah *APIHandler) RegisterRoutes(router *mux.Router, am *baseapp.AuthMiddlew
 	router.HandleFunc("/api/v4/query_range", am.ViewAccess(ah.queryRangeV4)).Methods(http.MethodPost)
 
 	// Gateway
-	router.PathPrefix(gateway.RoutePrefix).HandlerFunc(am.AdminAccess(ah.ServeGatewayHTTP))
+	router.PathPrefix(gateway.RoutePrefix).HandlerFunc(am.EditAccess(ah.ServeGatewayHTTP))
 
 	ah.APIHandler.RegisterRoutes(router, am)
 

--- a/ee/query-service/app/api/license.go
+++ b/ee/query-service/app/api/license.go
@@ -218,6 +218,10 @@ func (ah *APIHandler) getBilling(w http.ResponseWriter, r *http.Request) {
 func convertLicenseV3ToLicenseV2(licenses []*model.LicenseV3) []model.License {
 	licensesV2 := []model.License{}
 	for _, l := range licenses {
+		planKeyFromPlanName, ok := model.MapOldPlanKeyToNewPlanName[l.PlanName]
+		if !ok {
+			planKeyFromPlanName = model.Basic
+		}
 		licenseV2 := model.License{
 			Key:               l.Key,
 			ActivationId:      "",
@@ -226,7 +230,7 @@ func convertLicenseV3ToLicenseV2(licenses []*model.LicenseV3) []model.License {
 			ValidationMessage: "",
 			IsCurrent:         l.IsCurrent,
 			LicensePlan: model.LicensePlan{
-				PlanKey:    l.PlanName,
+				PlanKey:    planKeyFromPlanName,
 				ValidFrom:  l.ValidFrom,
 				ValidUntil: l.ValidUntil,
 				Status:     l.Status},

--- a/ee/query-service/constants/constants.go
+++ b/ee/query-service/constants/constants.go
@@ -13,7 +13,9 @@ var LicenseAPIKey = GetOrDefaultEnv("SIGNOZ_LICENSE_API_KEY", "")
 var SaasSegmentKey = GetOrDefaultEnv("SIGNOZ_SAAS_SEGMENT_KEY", "")
 var FetchFeatures = GetOrDefaultEnv("FETCH_FEATURES", "false")
 var ZeusFeaturesURL = GetOrDefaultEnv("ZEUS_FEATURES_URL", "ZeusFeaturesURL")
-var ZeusURL = GetOrDefaultEnv("ZEUS_URL", "ZeusURL")
+
+// this is set via build time variable
+var ZeusURL = "https://api.signoz.cloud"
 
 func GetOrDefaultEnv(key string, fallback string) string {
 	v := os.Getenv(key)

--- a/ee/query-service/license/manager.go
+++ b/ee/query-service/license/manager.go
@@ -253,6 +253,11 @@ func (lm *Manager) GetLicensesV3(ctx context.Context) (response []*model.License
 		if lm.activeLicenseV3 != nil && l.Key == lm.activeLicenseV3.Key {
 			l.IsCurrent = true
 		}
+		if l.ValidUntil == -1 {
+			// for subscriptions, there is no end-date as such
+			// but for showing user some validity we default one year timespan
+			l.ValidUntil = l.ValidFrom + 31556926
+		}
 		response = append(response, l)
 	}
 

--- a/ee/query-service/model/plans.go
+++ b/ee/query-service/model/plans.go
@@ -17,6 +17,10 @@ var (
 )
 
 var (
+	MapOldPlanKeyToNewPlanName map[string]string = map[string]string{PlanNameBasic: Basic, PlanNameTeams: Pro, PlanNameEnterprise: Enterprise}
+)
+
+var (
 	LicenseStatusInactive = "INACTIVE"
 )
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,7 +76,7 @@
 		"fontfaceobserver": "2.3.0",
 		"history": "4.10.1",
 		"html-webpack-plugin": "5.5.0",
-		"http-proxy-middleware": "2.0.7",
+		"http-proxy-middleware": "3.0.3",
 		"i18next": "^21.6.12",
 		"i18next-browser-languagedetector": "^6.1.3",
 		"i18next-http-backend": "^1.3.2",

--- a/frontend/src/components/RouteTab/index.tsx
+++ b/frontend/src/components/RouteTab/index.tsx
@@ -11,7 +11,7 @@ function RouteTab({
 }: RouteTabProps & TabsProps): JSX.Element {
 	const onChange = (activeRoute: string): void => {
 		if (onChangeHandler) {
-			onChangeHandler();
+			onChangeHandler(activeRoute);
 		}
 
 		const selectedRoute = routes.find((e) => e.key === activeRoute);

--- a/frontend/src/components/RouteTab/types.ts
+++ b/frontend/src/components/RouteTab/types.ts
@@ -11,6 +11,6 @@ export type TabRoutes = {
 export interface RouteTabProps {
 	routes: TabRoutes[];
 	activeKey: TabsProps['activeKey'];
-	onChangeHandler?: VoidFunction;
+	onChangeHandler?: (key: string) => void;
 	history: History<unknown>;
 }

--- a/frontend/src/container/AlertHistory/Statistics/TopContributorsCard/TopContributorsRows.tsx
+++ b/frontend/src/container/AlertHistory/Statistics/TopContributorsCard/TopContributorsRows.tsx
@@ -1,10 +1,16 @@
 import { Color } from '@signozhq/design-tokens';
 import { Progress, Table } from 'antd';
 import { ColumnsType } from 'antd/es/table';
+import logEvent from 'api/common/logEvent';
 import { ConditionalAlertPopover } from 'container/AlertHistory/AlertPopover/AlertPopover';
 import AlertLabels from 'pages/AlertDetails/AlertHeader/AlertLabels/AlertLabels';
 import PaginationInfoText from 'periscope/components/PaginationInfoText/PaginationInfoText';
-import { AlertRuleStats, AlertRuleTopContributors } from 'types/api/alerts/def';
+import { HTMLAttributes } from 'react';
+import {
+	AlertRuleStats,
+	AlertRuleTimelineTableResponse,
+	AlertRuleTopContributors,
+} from 'types/api/alerts/def';
 
 function TopContributorsRows({
 	topContributors,
@@ -70,10 +76,21 @@ function TopContributorsRows({
 		},
 	];
 
+	const handleRowClick = (
+		record: AlertRuleTopContributors,
+	): HTMLAttributes<AlertRuleTimelineTableResponse> => ({
+		onClick: (): void => {
+			logEvent('Alert history: Top contributors row: Clicked', {
+				labels: record.labels,
+			});
+		},
+	});
+
 	return (
 		<Table
 			rowClassName="contributors-row"
 			rowKey={(row): string => `top-contributor-${row.fingerprint}`}
+			onRow={handleRowClick}
 			columns={columns}
 			showHeader={false}
 			dataSource={topContributors}

--- a/frontend/src/container/AlertHistory/Timeline/Table/Table.tsx
+++ b/frontend/src/container/AlertHistory/Timeline/Table/Table.tsx
@@ -1,13 +1,15 @@
 import './Table.styles.scss';
 
 import { Table } from 'antd';
+import logEvent from 'api/common/logEvent';
 import { initialFilters } from 'constants/queryBuilder';
 import {
 	useGetAlertRuleDetailsTimelineTable,
 	useTimelineTable,
 } from 'pages/AlertDetails/hooks';
-import { useMemo, useState } from 'react';
+import { HTMLAttributes, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { AlertRuleTimelineTableResponse } from 'types/api/alerts/def';
 import { TagFilter } from 'types/api/queryBuilder/queryBuilderData';
 
 import { timelineTableColumns } from './useTimelineTable';
@@ -43,6 +45,17 @@ function TimelineTable(): JSX.Element {
 		return <div>{t('something_went_wrong')}</div>;
 	}
 
+	const handleRowClick = (
+		record: AlertRuleTimelineTableResponse,
+	): HTMLAttributes<AlertRuleTimelineTableResponse> => ({
+		onClick: (): void => {
+			logEvent('Alert history: Timeline table row: Clicked', {
+				ruleId: record.ruleID,
+				labels: record.labels,
+			});
+		},
+	});
+
 	return (
 		<div className="timeline-table">
 			<Table
@@ -52,6 +65,7 @@ function TimelineTable(): JSX.Element {
 					labels: labels ?? {},
 					setFilters,
 				})}
+				onRow={handleRowClick}
 				dataSource={timelineData}
 				pagination={paginationConfig}
 				size="middle"

--- a/frontend/src/pages/AlertDetails/AlertDetails.tsx
+++ b/frontend/src/pages/AlertDetails/AlertDetails.tsx
@@ -1,6 +1,7 @@
 import './AlertDetails.styles.scss';
 
 import { Breadcrumb, Button, Divider } from 'antd';
+import logEvent from 'api/common/logEvent';
 import { Filters } from 'components/AlertDetailsFilters/Filters';
 import NotFound from 'components/NotFound';
 import RouteTab from 'components/RouteTab';
@@ -87,6 +88,12 @@ function AlertDetails(): JSX.Element {
 		return <NotFound />;
 	}
 
+	const handleTabChange = (route: string): void => {
+		if (route === ROUTES.ALERT_HISTORY) {
+			logEvent('Alert History tab: Visited', { ruleId });
+		}
+	};
+
 	return (
 		<div className="alert-details">
 			<Breadcrumb
@@ -113,6 +120,7 @@ function AlertDetails(): JSX.Element {
 					routes={routes}
 					activeKey={pathname}
 					history={history}
+					onChangeHandler={handleTabChange}
 					tabBarExtraContent={<Filters />}
 				/>
 			</div>

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -1,13 +1,13 @@
 /* eslint-disable  */
 // @ts-ignore
 // @ts-nocheck
-import { createProxyMiddleware } from 'http-proxy-middleware';
+import { legacyCreateProxyMiddleware } from 'http-proxy-middleware';
 
 export default function (app) {
 	app.use(
 		'/tunnel',
-		createProxyMiddleware({
-			target: process.env.TUNNEL_DOMAIN,
+		legacyCreateProxyMiddleware({
+			target: `${process.env.TUNNEL_DOMAIN}/tunnel`,
 			changeOrigin: true,
 		}),
 	);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4074,6 +4074,13 @@
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#4fc33a00c1d0c16987b1a20cf92d20614c55ac35"
   integrity sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==
 
+"@types/http-proxy@^1.17.15":
+  version "1.17.15"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.15.tgz#12118141ce9775a6499ecb4c01d02f90fc839d36"
+  integrity sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/http-proxy@^1.17.8":
   version "1.17.11"
   resolved "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.11.tgz"
@@ -7224,7 +7231,7 @@ debounce@^1.2.1:
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
-debug@2.6.9, debug@4, debug@4.3.4, debug@^3.2.6, debug@^3.2.7, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@ngokevin/debug#noTimestamp:
+debug@2.6.9, debug@4, debug@4.3.4, debug@^3.2.6, debug@^3.2.7, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@^4.3.6, debug@ngokevin/debug#noTimestamp:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -9352,16 +9359,17 @@ http-proxy-agent@^4.0.1:
     agent-base "6"
     debug "4"
 
-http-proxy-middleware@2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz#915f236d92ae98ef48278a95dedf17e991936ec6"
-  integrity sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==
+http-proxy-middleware@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-3.0.3.tgz#dc1313c75bd00d81e103823802551ee30130ebd1"
+  integrity sha512-usY0HG5nyDUwtqpiZdETNbmKtw3QQ1jwYFZ9wi5iHzX2BcILwQKtYDJPo7XHTsu5Z0B2Hj3W9NNnbd+AjFWjqg==
   dependencies:
-    "@types/http-proxy" "^1.17.8"
+    "@types/http-proxy" "^1.17.15"
+    debug "^4.3.6"
     http-proxy "^1.18.1"
-    is-glob "^4.0.1"
-    is-plain-obj "^3.0.0"
-    micromatch "^4.0.2"
+    is-glob "^4.0.3"
+    is-plain-object "^5.0.0"
+    micromatch "^4.0.8"
 
 http-proxy-middleware@^2.0.3:
   version "2.0.6"
@@ -9852,6 +9860,11 @@ is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
@@ -11838,7 +11851,7 @@ micromark@^3.0.0:
     micromark-util-types "^1.0.1"
     uvu "^0.5.0"
 
-micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.25.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/SigNoz/govaluate v0.0.0-20240203125216-988004ccc7fd
-	github.com/SigNoz/signoz-otel-collector v0.111.8
+	github.com/SigNoz/signoz-otel-collector v0.111.9
 	github.com/SigNoz/zap_otlp/zap_otlp_encoder v0.0.0-20230822164844-1b861a431974
 	github.com/SigNoz/zap_otlp/zap_otlp_sync v0.0.0-20230822164844-1b861a431974
 	github.com/antonmedv/expr v1.15.3

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/SigNoz/govaluate v0.0.0-20240203125216-988004ccc7fd h1:Bk43AsDYe0fhkb
 github.com/SigNoz/govaluate v0.0.0-20240203125216-988004ccc7fd/go.mod h1:nxRcH/OEdM8QxzH37xkGzomr1O0JpYBRS6pwjsWW6Pc=
 github.com/SigNoz/prometheus v1.12.0 h1:+BXeIHyMOOWWa+xjhJ+x80JFva7r1WzWIfIhQ5PUmIE=
 github.com/SigNoz/prometheus v1.12.0/go.mod h1:EqNM27OwmPfqMUk+E+XG1L9rfDFcyXnzzDrg0EPOfxA=
-github.com/SigNoz/signoz-otel-collector v0.111.8 h1:t3V3Ahue2ucryRdHvqz33zRCPGQ86xkAsx9J23ZNPk0=
-github.com/SigNoz/signoz-otel-collector v0.111.8/go.mod h1:/nyVFDiEz/QBfyqekB3zRwstZ/KSIB85qgV9NnzAtig=
+github.com/SigNoz/signoz-otel-collector v0.111.9 h1:U4q7o0H9C842zQFsM5wGHgt9ba92KU6LxnKmmYQ91ew=
+github.com/SigNoz/signoz-otel-collector v0.111.9/go.mod h1:vRDT10om89DHybN7SRMlt8IN9+/pgh1D57pNHPr2LM4=
 github.com/SigNoz/zap_otlp v0.1.0 h1:T7rRcFN87GavY8lDGZj0Z3Xv6OhJA6Pj3I9dNPmqvRc=
 github.com/SigNoz/zap_otlp v0.1.0/go.mod h1:lcHvbDbRgvDnPxo9lDlaL1JK2PyOyouP/C3ynnYIvyo=
 github.com/SigNoz/zap_otlp/zap_otlp_encoder v0.0.0-20230822164844-1b861a431974 h1:PKVgdf83Yw+lZJbFtNGBgqXiXNf3+kOXW2qZ7Ms7OaY=

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	"maps"
 	"os"
 	"strconv"
 	"testing"
@@ -238,8 +239,8 @@ const (
 	SIGNOZ_EXP_HISTOGRAM_TABLENAME             = "distributed_exp_hist"
 	SIGNOZ_TRACE_DBNAME                        = "signoz_traces"
 	SIGNOZ_SPAN_INDEX_TABLENAME                = "distributed_signoz_index_v2"
-	SIGNOZ_SPAN_INDEX_LOCAL_TABLENAME          = "signoz_index_v2"
 	SIGNOZ_SPAN_INDEX_V3                       = "distributed_signoz_index_v3"
+	SIGNOZ_SPAN_INDEX_LOCAL_TABLENAME          = "signoz_index_v2"
 	SIGNOZ_SPAN_INDEX_V3_LOCAL_TABLENAME       = "signoz_index_v3"
 	SIGNOZ_TIMESERIES_v4_LOCAL_TABLENAME       = "time_series_v4"
 	SIGNOZ_TIMESERIES_v4_6HRS_LOCAL_TABLENAME  = "time_series_v4_6hrs"
@@ -447,30 +448,35 @@ const MaxFilterSuggestionsExamplesLimit = 10
 var SpanRenderLimitStr = GetOrDefaultEnv("SPAN_RENDER_LIMIT", "2500")
 var MaxSpansInTraceStr = GetOrDefaultEnv("MAX_SPANS_IN_TRACE", "250000")
 
-var StaticFieldsTraces = map[string]v3.AttributeKey{
+var NewStaticFieldsTraces = map[string]v3.AttributeKey{
 	"timestamp": {},
-	"traceID": {
-		Key:      "traceID",
+	"trace_id": {
+		Key:      "trace_id",
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
-	"spanID": {
-		Key:      "spanID",
+	"span_id": {
+		Key:      "span_id",
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
-	"parentSpanID": {
-		Key:      "parentSpanID",
+	"trace_state": {
+		Key:      "trace_state",
 		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"parent_span_id": {
+		Key:      "parent_span_id",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"flags": {
+		Key:      "flags",
+		DataType: v3.AttributeKeyDataTypeInt64,
 		IsColumn: true,
 	},
 	"name": {
 		Key:      "name",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"serviceName": {
-		Key:      "serviceName",
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
@@ -479,118 +485,33 @@ var StaticFieldsTraces = map[string]v3.AttributeKey{
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
-	"spanKind": {
-		Key:      "spanKind",
+	"kind_string": {
+		Key:      "kind_string",
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
-	"durationNano": {
-		Key:      "durationNano",
+	"duration_nano": {
+		Key:      "duration_nano",
 		DataType: v3.AttributeKeyDataTypeFloat64,
 		IsColumn: true,
 	},
-	"statusCode": {
-		Key:      "statusCode",
+	"status_code": {
+		Key:      "status_code",
 		DataType: v3.AttributeKeyDataTypeFloat64,
 		IsColumn: true,
 	},
-	"hasError": {
-		Key:      "hasError",
-		DataType: v3.AttributeKeyDataTypeBool,
-		IsColumn: true,
-	},
-	"statusMessage": {
-		Key:      "statusMessage",
+	"status_message": {
+		Key:      "status_message",
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
-	"statusCodeString": {
-		Key:      "statusCodeString",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"externalHttpMethod": {
-		Key:      "externalHttpMethod",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"externalHttpUrl": {
-		Key:      "externalHttpUrl",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"dbSystem": {
-		Key:      "dbSystem",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"dbName": {
-		Key:      "dbName",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"dbOperation": {
-		Key:      "dbOperation",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"peerService": {
-		Key:      "peerService",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"httpMethod": {
-		Key:      "httpMethod",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"httpUrl": {
-		Key:      "httpUrl",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"httpRoute": {
-		Key:      "httpRoute",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"httpHost": {
-		Key:      "httpHost",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"msgSystem": {
-		Key:      "msgSystem",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"msgOperation": {
-		Key:      "msgOperation",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"rpcSystem": {
-		Key:      "rpcSystem",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"rpcService": {
-		Key:      "rpcService",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"rpcMethod": {
-		Key:      "rpcMethod",
-		DataType: v3.AttributeKeyDataTypeString,
-		IsColumn: true,
-	},
-	"responseStatusCode": {
-		Key:      "responseStatusCode",
+	"status_code_string": {
+		Key:      "status_code_string",
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
 
-	// new support
+	// new support for composite attributes
 	"response_status_code": {
 		Key:      "response_status_code",
 		DataType: v3.AttributeKeyDataTypeString,
@@ -643,6 +564,157 @@ var StaticFieldsTraces = map[string]v3.AttributeKey{
 	},
 	// the simple attributes are not present here as
 	// they are taken care by new format <attribute_type>_<attribute_datatype>_'<attribute_key>'
+}
+
+var DeprecatedStaticFieldsTraces = map[string]v3.AttributeKey{
+	"traceID": {
+		Key:      "traceID",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"spanID": {
+		Key:      "spanID",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"parentSpanID": {
+		Key:      "parentSpanID",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"spanKind": {
+		Key:      "spanKind",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"durationNano": {
+		Key:      "durationNano",
+		DataType: v3.AttributeKeyDataTypeFloat64,
+		IsColumn: true,
+	},
+	"statusCode": {
+		Key:      "statusCode",
+		DataType: v3.AttributeKeyDataTypeFloat64,
+		IsColumn: true,
+	},
+	"statusMessage": {
+		Key:      "statusMessage",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"statusCodeString": {
+		Key:      "statusCodeString",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+
+	// old support for composite attributes
+	"responseStatusCode": {
+		Key:      "responseStatusCode",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"externalHttpUrl": {
+		Key:      "externalHttpUrl",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"httpUrl": {
+		Key:      "httpUrl",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"externalHttpMethod": {
+		Key:      "externalHttpMethod",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"httpMethod": {
+		Key:      "httpMethod",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"httpHost": {
+		Key:      "httpHost",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"dbName": {
+		Key:      "dbName",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"dbOperation": {
+		Key:      "dbOperation",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"hasError": {
+		Key:      "hasError",
+		DataType: v3.AttributeKeyDataTypeBool,
+		IsColumn: true,
+	},
+	"isRemote": {
+		Key:      "isRemote",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+
+	// old support for resource attributes
+	"serviceName": {
+		Key:      "serviceName",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+
+	// old support for simple attributes
+	"httpRoute": {
+		Key:      "httpRoute",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"msgSystem": {
+		Key:      "msgSystem",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"msgOperation": {
+		Key:      "msgOperation",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"dbSystem": {
+		Key:      "dbSystem",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"rpcSystem": {
+		Key:      "rpcSystem",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"rpcService": {
+		Key:      "rpcService",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"rpcMethod": {
+		Key:      "rpcMethod",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"peerService": {
+		Key:      "peerService",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+}
+
+var StaticFieldsTraces = map[string]v3.AttributeKey{}
+
+func init() {
+	StaticFieldsTraces = maps.Clone(NewStaticFieldsTraces)
+	maps.Copy(StaticFieldsTraces, DeprecatedStaticFieldsTraces)
 }
 
 const TRACE_V4_MAX_PAGINATION_LIMIT = 10000

--- a/pkg/query-service/model/trace.go
+++ b/pkg/query-service/model/trace.go
@@ -1,0 +1,29 @@
+package model
+
+import "time"
+
+type SpanItemV2 struct {
+	TimeUnixNano      time.Time          `ch:"timestamp"`
+	DurationNano      uint64             `ch:"duration_nano"`
+	SpanID            string             `ch:"span_id"`
+	TraceID           string             `ch:"trace_id"`
+	HasError          bool               `ch:"has_error"`
+	Kind              int8               `ch:"kind"`
+	ServiceName       string             `ch:"resource_string_service$$name"`
+	Name              string             `ch:"name"`
+	References        string             `ch:"references"`
+	Attributes_string map[string]string  `ch:"attributes_string"`
+	Attributes_number map[string]float64 `ch:"attributes_number"`
+	Attributes_bool   map[string]bool    `ch:"attributes_bool"`
+	Events            []string           `ch:"events"`
+	StatusMessage     string             `ch:"status_message"`
+	StatusCodeString  string             `ch:"status_code_string"`
+	SpanKind          string             `ch:"kind_string"`
+}
+
+type TraceSummary struct {
+	TraceID  string    `ch:"trace_id"`
+	Start    time.Time `ch:"start"`
+	End      time.Time `ch:"end"`
+	NumSpans uint64    `ch:"num_spans"`
+}


### PR DESCRIPTION
### Summary

- release SigNoz v0.59.0
- bump up SigNoz OtelCollector v0.111.9
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update SigNoz to v0.59.0 and OtelCollector to v0.111.9, with changes in API routes, logging, and constants.
> 
>   - **Version Updates**:
>     - Update SigNoz to v0.59.0 in `docker-compose.yaml`, `docker-compose-core.yaml`, `docker-compose-minimal.yaml`, and `docker-compose.testing.yaml`.
>     - Update SigNoz OtelCollector to v0.111.9 in `docker-compose.yaml`, `docker-compose-core.yaml`, `docker-compose-minimal.yaml`, and `docker-compose.testing.yaml`.
>   - **API and Constants**:
>     - Change API route access from `AdminAccess` to `EditAccess` in `api.go`.
>     - Add `ZeusURL` constant in `constants.go` and set via build time variable.
>   - **Logging and Event Tracking**:
>     - Add logging for row clicks in `TopContributorsRows.tsx` and `Table.tsx`.
>     - Add tab change logging in `AlertDetails.tsx`.
>   - **Frontend Changes**:
>     - Update `http-proxy-middleware` to v3.0.3 in `package.json`.
>     - Change `createProxyMiddleware` to `legacyCreateProxyMiddleware` in `setupProxy.js`.
>     - Modify `onChangeHandler` signature in `RouteTab` component.
>   - **Go Modifications**:
>     - Update `signoz-otel-collector` dependency to v0.111.9 in `go.mod` and `go.sum`.
>     - Add `SpanItemV2` and `TraceSummary` structs in `trace.go`.
>     - Refactor `StaticFieldsTraces` in `constants.go` to include new and deprecated fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 5a70123b0669aa23ed9314a1be2d09a1eeacf407. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->