### PR TITLE
fix: decrease the pad angle and remove the empty legend entries

### DIFF
--- a/frontend/src/container/PanelWrapper/PiePanelWrapper.tsx
+++ b/frontend/src/container/PanelWrapper/PiePanelWrapper.tsx
@@ -108,7 +108,6 @@ function PiePanelWrapper({
 										if (!active) return half - 3;
 										return data.label === active.label ? half : half - 3;
 									}}
-									padAngle={0.02}
 									cornerRadius={3}
 									width={size}
 									height={size}

--- a/frontend/src/container/PanelWrapper/PiePanelWrapper.tsx
+++ b/frontend/src/container/PanelWrapper/PiePanelWrapper.tsx
@@ -8,6 +8,7 @@ import { getYAxisFormattedValue } from 'components/Graph/yAxisConfig';
 import { themeColors } from 'constants/theme';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { generateColor } from 'lib/uPlotLib/utils/generateColor';
+import { isNaN } from 'lodash-es';
 import { useRef, useState } from 'react';
 import { Query } from 'types/api/queryBuilder/queryBuilderData';
 
@@ -44,7 +45,7 @@ function PiePanelWrapper({
 
 	const isDarkMode = useIsDarkMode();
 
-	const pieChartData: {
+	let pieChartData: {
 		label: string;
 		value: string;
 		color: string;
@@ -66,6 +67,10 @@ function PiePanelWrapper({
 				})),
 			)
 			.filter((d) => d !== undefined) as never[]),
+	);
+	pieChartData = pieChartData.filter(
+		(arc) =>
+			arc.value && !isNaN(parseFloat(arc.value)) && parseFloat(arc.value) > 0,
 	);
 
 	let size = 0;
@@ -108,6 +113,7 @@ function PiePanelWrapper({
 										if (!active) return half - 3;
 										return data.label === active.label ? half : half - 3;
 									}}
+									padAngle={0.01}
 									cornerRadius={3}
 									width={size}
 									height={size}


### PR DESCRIPTION
### Summary

- the presence of `padAngle` adds a padding between adjacent values which appears as a chunk on pie chart.
- since there were `0` entries also present they were consuming the padding still. removed the 0 entries. 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
