### PR TITLE
fix: add settings to allow distributed_product_mode for trace panel

### DIFF
--- a/pkg/query-service/app/traces/v3/query_builder_test.go
+++ b/pkg/query-service/app/traces/v3/query_builder_test.go
@@ -1169,7 +1169,7 @@ var testBuildTracesQueryData = []struct {
 			"AND stringTagMap['method'] = 'GET' ORDER BY durationNano DESC LIMIT 1 BY traceID  LIMIT 100)" +
 			" AS inner_subquery ) AS subQuery " +
 			"ON signoz_traces.distributed_signoz_index_v2.traceID = subQuery.traceID WHERE (timestamp >= '1680066360726210000' AND timestamp <= '1680066458000000000') " +
-			"GROUP BY subQuery.traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY subQuery.durationNano desc LIMIT 1 BY subQuery.traceID;",
+			"GROUP BY subQuery.traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY subQuery.durationNano desc LIMIT 1 BY subQuery.traceID",
 		PanelType: v3.PanelTypeTrace,
 	},
 }

--- a/pkg/query-service/app/traces/v4/query_builder.go
+++ b/pkg/query-service/app/traces/v4/query_builder.go
@@ -255,6 +255,8 @@ func buildTracesQuery(start, end, step int64, mq *v3.BuilderQuery, panelType v3.
 				withSubQuery = tracesV3.AddOffsetToQuery(withSubQuery, mq.Offset)
 			}
 			query = fmt.Sprintf(constants.TracesExplorerViewSQLSelectBeforeSubQuery, constants.SIGNOZ_TRACE_DBNAME, constants.SIGNOZ_SPAN_INDEX_V3) + withSubQuery + ") " + fmt.Sprintf(constants.TracesExplorerViewSQLSelectAfterSubQuery, constants.SIGNOZ_TRACE_DBNAME, constants.SIGNOZ_SPAN_INDEX_V3, timeFilter)
+			// adding this to avoid the distributed product mode error which doesn't allow global in
+			query += " settings distributed_product_mode='allow'"
 		} else if panelType == v3.PanelTypeList {
 			if len(mq.SelectColumns) == 0 {
 				return "", fmt.Errorf("select columns cannot be empty for panelType %s", panelType)

--- a/pkg/query-service/app/traces/v4/query_builder.go
+++ b/pkg/query-service/app/traces/v4/query_builder.go
@@ -256,7 +256,7 @@ func buildTracesQuery(start, end, step int64, mq *v3.BuilderQuery, panelType v3.
 			}
 			query = fmt.Sprintf(constants.TracesExplorerViewSQLSelectBeforeSubQuery, constants.SIGNOZ_TRACE_DBNAME, constants.SIGNOZ_SPAN_INDEX_V3) + withSubQuery + ") " + fmt.Sprintf(constants.TracesExplorerViewSQLSelectAfterSubQuery, constants.SIGNOZ_TRACE_DBNAME, constants.SIGNOZ_SPAN_INDEX_V3, timeFilter)
 			// adding this to avoid the distributed product mode error which doesn't allow global in
-			query += " settings distributed_product_mode='allow'"
+			query += " settings distributed_product_mode='allow', max_memory_usage=10000000000"
 		} else if panelType == v3.PanelTypeList {
 			if len(mq.SelectColumns) == 0 {
 				return "", fmt.Errorf("select columns cannot be empty for panelType %s", panelType)

--- a/pkg/query-service/app/traces/v4/query_builder_test.go
+++ b/pkg/query-service/app/traces/v4/query_builder_test.go
@@ -531,7 +531,7 @@ func Test_buildTracesQuery(t *testing.T) {
 				"WHERE (seen_at_ts_bucket_start >= 1680064560) AND (seen_at_ts_bucket_start <= 1680066458) AND simpleJSONExtractString(labels, 'service.name') = 'myService' AND labels like '%service.name%myService%')) " +
 				"ORDER BY durationNano DESC LIMIT 1 BY traceID  LIMIT 100) AS inner_subquery ) AS subQuery ON signoz_traces.distributed_signoz_index_v3.traceID = subQuery.traceID WHERE (timestamp >= '1680066360726210000' AND " +
 				"timestamp <= '1680066458000000000') AND (ts_bucket_start >= 1680064560 AND ts_bucket_start <= 1680066458) GROUP BY subQuery.traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY " +
-				"subQuery.durationNano desc LIMIT 1 BY subQuery.traceID;",
+				"subQuery.durationNano desc LIMIT 1 BY subQuery.traceID settings distributed_product_mode='allow'",
 		},
 		{
 			name: "Test order by value with having",

--- a/pkg/query-service/app/traces/v4/query_builder_test.go
+++ b/pkg/query-service/app/traces/v4/query_builder_test.go
@@ -531,7 +531,7 @@ func Test_buildTracesQuery(t *testing.T) {
 				"WHERE (seen_at_ts_bucket_start >= 1680064560) AND (seen_at_ts_bucket_start <= 1680066458) AND simpleJSONExtractString(labels, 'service.name') = 'myService' AND labels like '%service.name%myService%')) " +
 				"ORDER BY durationNano DESC LIMIT 1 BY traceID  LIMIT 100) AS inner_subquery ) AS subQuery ON signoz_traces.distributed_signoz_index_v3.traceID = subQuery.traceID WHERE (timestamp >= '1680066360726210000' AND " +
 				"timestamp <= '1680066458000000000') AND (ts_bucket_start >= 1680064560 AND ts_bucket_start <= 1680066458) GROUP BY subQuery.traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY " +
-				"subQuery.durationNano desc LIMIT 1 BY subQuery.traceID settings distributed_product_mode='allow'",
+				"subQuery.durationNano desc LIMIT 1 BY subQuery.traceID settings distributed_product_mode='allow', max_memory_usage=10000000000",
 		},
 		{
 			name: "Test order by value with having",

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -348,7 +348,7 @@ const (
 	TracesExplorerViewSQLSelectBeforeSubQuery = "SELECT subQuery.serviceName, subQuery.name, count() AS " +
 		"span_count, subQuery.durationNano, subQuery.traceID AS traceID FROM %s.%s INNER JOIN ( SELECT * FROM "
 	TracesExplorerViewSQLSelectAfterSubQuery = "AS inner_subquery ) AS subQuery ON %s.%s.traceID = subQuery.traceID WHERE %s " +
-		"GROUP BY subQuery.traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY subQuery.durationNano desc LIMIT 1 BY subQuery.traceID;"
+		"GROUP BY subQuery.traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY subQuery.durationNano desc LIMIT 1 BY subQuery.traceID"
 	TracesExplorerViewSQLSelectQuery = "SELECT subQuery.serviceName, subQuery.name, count() AS " +
 		"span_count, subQuery.durationNano, traceID FROM %s.%s GLOBAL INNER JOIN subQuery ON %s.traceID = subQuery.traceID GROUP " +
 		"BY traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY subQuery.durationNano desc;"


### PR DESCRIPTION
Temporary fix for https://github.com/SigNoz/signoz/issues/6515
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `settings distributed_product_mode='allow'` to SQL queries in `buildTracesQuery()` to handle distributed product mode errors and updates tests accordingly.
> 
>   - **Behavior**:
>     - Adds `settings distributed_product_mode='allow'` to SQL query in `buildTracesQuery()` in `query_builder.go` to prevent distributed product mode errors.
>   - **Tests**:
>     - Updates expected SQL query strings in `Test_buildTracesQuery` in `query_builder_test.go` to include `settings distributed_product_mode='allow'`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 60d663e32a993c29df287986d278bd61a82900fa. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->