### PR TITLE
feat: display timezone adjusted time range in time picker

### DIFF
--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -156,6 +156,7 @@ function CustomTimePicker({
 		setOpen(newOpen);
 		if (!newOpen) {
 			setCustomDTPickerVisible?.(false);
+			setActiveView('datetime');
 		}
 	};
 

--- a/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
+++ b/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
@@ -4,6 +4,7 @@ import { DatePicker } from 'antd';
 import { DateTimeRangeType } from 'container/TopNav/CustomDateTimeModal';
 import { LexicalContext } from 'container/TopNav/DateTimeSelectionV2/config';
 import dayjs, { Dayjs } from 'dayjs';
+import { useTimezone } from 'providers/Timezone';
 import { Dispatch, SetStateAction } from 'react';
 import { useSelector } from 'react-redux';
 import { AppState } from 'store/reducers';
@@ -49,6 +50,8 @@ function RangePickerModal(props: RangePickerModalProps): JSX.Element {
 		}
 		onCustomDateHandler(date_time, LexicalContext.CUSTOM_DATE_PICKER);
 	};
+
+	const { timezone } = useTimezone();
 	return (
 		<div className="custom-date-picker">
 			<RangePicker
@@ -58,7 +61,10 @@ function RangePickerModal(props: RangePickerModalProps): JSX.Element {
 				onOk={onModalOkHandler}
 				// eslint-disable-next-line react/jsx-props-no-spreading
 				{...(selectedTime === 'custom' && {
-					defaultValue: [dayjs(minTime / 1000000), dayjs(maxTime / 1000000)],
+					defaultValue: [
+						dayjs(minTime / 1000000).tz(timezone.value),
+						dayjs(maxTime / 1000000).tz(timezone.value),
+					],
 				})}
 			/>
 		</div>

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -28,6 +28,7 @@ import getTimeString from 'lib/getTimeString';
 import history from 'lib/history';
 import { isObject } from 'lodash-es';
 import { Check, Copy, Info, Send, Undo } from 'lucide-react';
+import { useTimezone } from 'providers/Timezone';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from 'react-query';
 import { connect, useSelector } from 'react-redux';
@@ -613,6 +614,8 @@ function DateTimeSelection({
 		);
 	};
 
+	const { timezone } = useTimezone();
+
 	return (
 		<div className="date-time-selector">
 			{showResetButton && selectedTime !== defaultRelativeTime && (
@@ -664,8 +667,8 @@ function DateTimeSelection({
 							setIsValidteRelativeTime(isValid);
 						}}
 						selectedValue={getInputLabel(
-							dayjs(minTime / 1000000),
-							dayjs(maxTime / 1000000),
+							dayjs(minTime / 1000000).tz(timezone.value),
+							dayjs(maxTime / 1000000).tz(timezone.value),
 							selectedTime,
 						)}
 						data-testid="dropDown"


### PR DESCRIPTION
### Summary
- [x] When a time range is selected from any graph, display the timezone adjusted selected range in time picker placeholder
- [x] Display the timezone adjusted time range in custom time range selected of time picker

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
Part of https://github.com/SigNoz/engineering-pod/issues/2005
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
Before:

https://github.com/user-attachments/assets/e30f45be-3b74-4e9b-a54f-7e9f2cebf91b


After:

https://github.com/user-attachments/assets/fdd4c6a3-9993-4348-bfe6-5809ff095f41





<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas
- time picker placeholder
- custom range picker of time picker
<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
