### PR TITLE
fix: open the timepicker on clicking the time picker input after closing the timezone picker by clicking outside it

### DIFF
--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -156,6 +156,7 @@ function CustomTimePicker({
 		setOpen(newOpen);
 		if (!newOpen) {
 			setCustomDTPickerVisible?.(false);
+			setActiveView('datetime');
 		}
 	};
 


### PR DESCRIPTION
### Summary
- [x] fix the issue of clicking on time range input after closing the timezone picker not showing time picker

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
Part of https://github.com/SigNoz/engineering-pod/issues/2005
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
Before:

https://github.com/user-attachments/assets/1a008983-d6de-45cc-9e31-3833cee812e5


After:

https://github.com/user-attachments/assets/2aacb304-02f7-4c69-873e-82bac54dc96b


<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas
- time range picker
<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue in `CustomTimePicker.tsx` where time picker did not open after closing timezone picker by resetting `activeView` in `handleOpenChange()`.
> 
>   - **Behavior**:
>     - Fixes issue in `CustomTimePicker.tsx` where clicking on time range input after closing timezone picker did not show time picker.
>     - Resets `activeView` to 'datetime' in `handleOpenChange()` when popover is closed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for d37e5f5f7435cf84f8e5e36678b556af3c6b489b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->