### PR TITLE
fix: make x axis and tooltip time format consistent in uPlot graphs

### DIFF
--- a/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
+++ b/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
@@ -76,7 +76,7 @@ const generateTooltipContent = (
 				} else {
 					tooltipTitle = dayjs(data[0][idx] * 1000)
 						.tz(timezone)
-						.format('MMM DD YYYY HH:mm:ss');
+						.format('MMM DD YYYY h:mm:ss A');
 				}
 			} else if (item.show) {
 				const {


### PR DESCRIPTION
### Summary
- [x] make x axis and tooltip time format consistent in uPlot graphs

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
Part of https://github.com/SigNoz/engineering-pod/issues/2005

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
Before:
![Screenshot from 2024-11-25 12-30-13](https://github.com/user-attachments/assets/08896e44-64fc-4d11-ac5d-6f7f6544233b)

After:
![Screenshot from 2024-11-25 12-29-44](https://github.com/user-attachments/assets/c2f86ef5-331f-47d1-99cd-77d7326307f9)

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas
- uPlot graphs that have tooltip
<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change tooltip time format in `tooltipPlugin.ts` for uPlot graphs to match x-axis format.
> 
>   - **Behavior**:
>     - Change tooltip time format in `generateTooltipContent` in `tooltipPlugin.ts` from `MMM DD YYYY HH:mm:ss` to `MMM DD YYYY h:mm:ss A` for consistency with x-axis.
>   - **Affected Areas**:
>     - uPlot graphs with tooltips.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for fb78018be563bc021097d5e8b2e65876f93f6999. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->