### PR TITLE
fix: update api's to repect the new changes in attributes table

### DIFF
--- a/pkg/query-service/app/logs/v3/enrich_query.go
+++ b/pkg/query-service/app/logs/v3/enrich_query.go
@@ -18,7 +18,7 @@ func EnrichmentRequired(params *v3.QueryRangeParamsV3) bool {
 
 	// Build queries for each builder query
 	for queryName, query := range compositeQuery.BuilderQueries {
-		if query.Expression != queryName && query.DataSource != v3.DataSourceLogs {
+		if query.Expression != queryName || query.DataSource != v3.DataSourceLogs {
 			continue
 		}
 

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -582,6 +582,21 @@ var DeprecatedStaticFieldsTraces = map[string]v3.AttributeKey{
 		DataType: v3.AttributeKeyDataTypeString,
 		IsColumn: true,
 	},
+	"flags": {
+		Key:      "flags",
+		DataType: v3.AttributeKeyDataTypeInt64,
+		IsColumn: true,
+	},
+	"name": {
+		Key:      "name",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
+	"kind": {
+		Key:      "kind",
+		DataType: v3.AttributeKeyDataTypeString,
+		IsColumn: true,
+	},
 	"spanKind": {
 		Key:      "spanKind",
 		DataType: v3.AttributeKeyDataTypeString,


### PR DESCRIPTION
Fixes https://github.com/SigNoz/engineering-pod/issues/2032

Part of https://github.com/SigNoz/signoz/issues/5713

* In the new schema changes for the traces exporter we removed the old logic of writing span_attributes. Where we wrote the hardcoded keys and their values to the span_attributes tables.
* So even for the old query builder we are using the new function for suggestions of values where 
  * For keys we use the fields from contants.
  * For values we get it from the respective columns.

* had to update the depricated constants as they were are being used individually above.

* Also added a fix where logs enrichment function was running for traces. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated trace attribute handling to align with new schema and fixed logs enrichment bug.
> 
>   - **Behavior**:
>     - `GetTraceAggregateAttributes`, `GetTraceAttributeKeys`, and `GetTraceAttributeValues` in `reader.go` now use new schema logic for trace attributes, removing old logic.
>     - `EnrichmentRequired` in `enrich_query.go` fixed to correctly handle traces, not just logs.
>   - **Constants**:
>     - Added `flags`, `name`, and `kind` to `DeprecatedStaticFieldsTraces` in `constants.go`.
>   - **Misc**:
>     - Renamed `GetTraceAggregateAttributesV2`, `GetTraceAttributeKeysV2`, and `GetTraceAttributeValuesV2` to remove `V2` suffix in `reader.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 6fadf9b63cd6f75aed541da28c18aa103f91751a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->