### PR TITLE
chore: move away from parallel usages of licenses v2 and v3

### DIFF
--- a/ee/query-service/app/api/license.go
+++ b/ee/query-service/app/api/license.go
@@ -87,6 +87,7 @@ func (ah *APIHandler) applyLicense(w http.ResponseWriter, r *http.Request) {
 	if ah.UseLicensesV3 {
 		// if the licenses v3 is toggled on then do not apply license in v2 and run the validator!
 		// TODO: remove after migration to v3 and deprecation from zeus
+		zap.L().Info("early return from apply license v2 call")
 		render.Success(w, http.StatusOK, nil)
 		return
 	}

--- a/ee/query-service/app/api/license.go
+++ b/ee/query-service/app/api/license.go
@@ -84,6 +84,12 @@ func (ah *APIHandler) listLicenses(w http.ResponseWriter, r *http.Request) {
 }
 
 func (ah *APIHandler) applyLicense(w http.ResponseWriter, r *http.Request) {
+	if ah.UseLicensesV3 {
+		// if the licenses v3 is toggled on then do not apply license in v2 and run the validator!
+		// TODO: remove after migration to v3 and deprecation from zeus
+		render.Success(w, http.StatusOK, nil)
+		return
+	}
 	var l model.License
 
 	if err := json.NewDecoder(r.Body).Decode(&l); err != nil {

--- a/ee/query-service/license/db.go
+++ b/ee/query-service/license/db.go
@@ -18,13 +18,15 @@ import (
 
 // Repo is license repo. stores license keys in a secured DB
 type Repo struct {
-	db *sqlx.DB
+	db            *sqlx.DB
+	useLicensesV3 bool
 }
 
 // NewLicenseRepo initiates a new license repo
-func NewLicenseRepo(db *sqlx.DB) Repo {
+func NewLicenseRepo(db *sqlx.DB, useLicensesV3 bool) Repo {
 	return Repo{
-		db: db,
+		db:            db,
+		useLicensesV3: useLicensesV3,
 	}
 }
 
@@ -81,6 +83,16 @@ func (r *Repo) GetLicensesV3(ctx context.Context) ([]*model.LicenseV3, error) {
 // GetActiveLicense fetches the latest active license from DB.
 // If the license is not present, expect a nil license and a nil error in the output.
 func (r *Repo) GetActiveLicense(ctx context.Context) (*model.License, *basemodel.ApiError) {
+	if r.useLicensesV3 {
+		activeLicenseV3, err := r.GetActiveLicenseV3(ctx)
+		if err != nil {
+			return nil, basemodel.InternalError(fmt.Errorf("failed to get active licenses from db: %v", err))
+		}
+
+		activeLicenseV2 := model.ConvertLicenseV3ToLicenseV2(activeLicenseV3)
+		return activeLicenseV2, nil
+
+	}
 	var err error
 	licenses := []model.License{}
 

--- a/ee/query-service/license/manager.go
+++ b/ee/query-service/license/manager.go
@@ -56,7 +56,7 @@ func StartManager(dbType string, db *sqlx.DB, useLicensesV3 bool, features ...ba
 		return LM, nil
 	}
 
-	repo := NewLicenseRepo(db)
+	repo := NewLicenseRepo(db, useLicensesV3)
 	err := repo.InitDB(dbType)
 
 	if err != nil {

--- a/ee/query-service/license/manager.go
+++ b/ee/query-service/license/manager.go
@@ -69,7 +69,7 @@ func StartManager(dbType string, db *sqlx.DB, useLicensesV3 bool, features ...ba
 
 	if useLicensesV3 {
 		// get active license from the db
-		active, err := m.repo.GetActiveLicense(context.Background())
+		active, err := m.repo.GetActiveLicenseV2(context.Background())
 		if err != nil {
 			return m, err
 		}
@@ -88,6 +88,7 @@ func StartManager(dbType string, db *sqlx.DB, useLicensesV3 bool, features ...ba
 			if apiError != nil && apiError.Typ != model.ErrorConflict {
 				return m, apiError
 			}
+			zap.L().Info("Successfully inserted license from v2 to v3 table")
 		}
 	}
 
@@ -266,6 +267,7 @@ func (lm *Manager) GetLicensesV3(ctx context.Context) (response []*model.License
 
 // Validator validates license after an epoch of time
 func (lm *Manager) Validator(ctx context.Context) {
+	zap.L().Info("Validator started!")
 	defer close(lm.terminated)
 	tick := time.NewTicker(validationFrequency)
 	defer tick.Stop()
@@ -290,6 +292,7 @@ func (lm *Manager) Validator(ctx context.Context) {
 
 // Validator validates license after an epoch of time
 func (lm *Manager) ValidatorV3(ctx context.Context) {
+	zap.L().Info("ValidatorV3 started!")
 	defer close(lm.terminated)
 	tick := time.NewTicker(validationFrequency)
 	defer tick.Stop()
@@ -379,7 +382,6 @@ func (lm *Manager) Validate(ctx context.Context) (reterr error) {
 	return nil
 }
 
-// todo[vikrantgupta25]: check the comparison here between old and new license!
 func (lm *Manager) RefreshLicense(ctx context.Context) *model.ApiError {
 
 	license, apiError := validate.ValidateLicenseV3(lm.activeLicenseV3.Key)

--- a/ee/query-service/model/license.go
+++ b/ee/query-service/model/license.go
@@ -247,3 +247,24 @@ func NewLicenseV3WithIDAndKey(id string, key string, data map[string]interface{}
 	licenseDataWithIdAndKey["key"] = key
 	return NewLicenseV3(licenseDataWithIdAndKey)
 }
+
+func ConvertLicenseV3ToLicenseV2(l *LicenseV3) *License {
+	planKeyFromPlanName, ok := MapOldPlanKeyToNewPlanName[l.PlanName]
+	if !ok {
+		planKeyFromPlanName = Basic
+	}
+	return &License{
+		Key:               l.Key,
+		ActivationId:      "",
+		PlanDetails:       "",
+		FeatureSet:        l.Features,
+		ValidationMessage: "",
+		IsCurrent:         l.IsCurrent,
+		LicensePlan: LicensePlan{
+			PlanKey:    planKeyFromPlanName,
+			ValidFrom:  l.ValidFrom,
+			ValidUntil: l.ValidUntil,
+			Status:     l.Status},
+	}
+
+}


### PR DESCRIPTION
### Summary

- in the current approach we were running both licenses v2 and license v3 in parallel which can cause stale keys to be applied to usage and gateway. 
- moving away from all the usages of licenses v2 when we toggle the flag. 
- added logging at places necessary for debugging if something goes crazy!

#### Related Issues / PR's

contributes to - https://github.com/SigNoz/platform-pod/issues/304 

