### PR TITLE
fix: add telemetry for trace migration

### DIFF
--- a/pkg/query-service/model/response.go
+++ b/pkg/query-service/model/response.go
@@ -636,6 +636,7 @@ type AlertsInfo struct {
 	AlertNames                   []string `json:"alertNames"`
 	AlertsWithTSV2               int      `json:"alertsWithTSv2"`
 	AlertsWithLogsChQuery        int      `json:"alertsWithLogsChQuery"`
+	AlertsWithTraceChQuery       int      `json:"alertsWithTraceChQuery"`
 	AlertsWithLogsContainsOp     int      `json:"alertsWithLogsContainsOp"`
 }
 
@@ -656,6 +657,7 @@ type DashboardsInfo struct {
 	DashboardNames                  []string `json:"dashboardNames"`
 	QueriesWithTSV2                 int      `json:"queriesWithTSV2"`
 	DashboardsWithLogsChQuery       int      `json:"dashboardsWithLogsChQuery"`
+	DashboardsWithTraceChQuery      int      `json:"dashboardsWithTraceChQuery"`
 	LogsPanelsWithAttrContainsOp    int      `json:"logsPanelsWithAttrContainsOp"`
 }
 

--- a/pkg/query-service/rules/db.go
+++ b/pkg/query-service/rules/db.go
@@ -604,6 +604,16 @@ func (r *ruleDB) GetAlertsInfo(ctx context.Context) (*model.AlertsInfo, error) {
 			}
 		} else if rule.AlertType == AlertTypeTraces {
 			alertsInfo.TracesBasedAlerts = alertsInfo.TracesBasedAlerts + 1
+
+			if rule.RuleCondition != nil && rule.RuleCondition.CompositeQuery != nil {
+				if rule.RuleCondition.CompositeQuery.QueryType == v3.QueryTypeClickHouseSQL {
+					if strings.Contains(alert, "signoz_traces.distributed_signoz_index_v2") ||
+						strings.Contains(alert, "signoz_traces.distributed_signoz_spans") ||
+						strings.Contains(alert, "signoz_traces.distributed_signoz_error_index_v2") {
+						alertsInfo.AlertsWithTraceChQuery = alertsInfo.AlertsWithTraceChQuery + 1
+					}
+				}
+			}
 		}
 		alertsInfo.TotalAlerts = alertsInfo.TotalAlerts + 1
 	}

--- a/pkg/query-service/telemetry/telemetry.go
+++ b/pkg/query-service/telemetry/telemetry.go
@@ -307,8 +307,11 @@ func createTelemetry() {
 			"getLogsInfoInLastHeartBeatInterval":    getLogsInfoInLastHeartBeatInterval,
 			"countUsers":                            userCount,
 			"metricsTTLStatus":                      metricsTTL.Status,
+			"metricsTTLValue":                       metricsTTL.MetricsMoveTime,
 			"tracesTTLStatus":                       traceTTL.Status,
+			"traceTTLValue":                         traceTTL.TracesTime,
 			"logsTTLStatus":                         logsTTL.Status,
+			"logsTTLValue":                          logsTTL.LogsTime,
 			"patUser":                               telemetry.patTokenUser,
 		}
 		telemetry.patTokenUser = false
@@ -343,6 +346,7 @@ func createTelemetry() {
 						"tracesBasedPanels":               dashboardsInfo.TracesBasedPanels,
 						"dashboardsWithTSV2":              dashboardsInfo.QueriesWithTSV2,
 						"dashboardWithLogsChQuery":        dashboardsInfo.DashboardsWithLogsChQuery,
+						"dashboardWithTraceChQuery":       dashboardsInfo.DashboardsWithTraceChQuery,
 						"totalAlerts":                     alertsInfo.TotalAlerts,
 						"alertsWithTSV2":                  alertsInfo.AlertsWithTSV2,
 						"logsBasedAlerts":                 alertsInfo.LogsBasedAlerts,
@@ -366,6 +370,7 @@ func createTelemetry() {
 						"spanMetricsPrometheusQueries":    alertsInfo.SpanMetricsPrometheusQueries,
 						"alertsWithLogsChQuery":           alertsInfo.AlertsWithLogsChQuery,
 						"alertsWithLogsContainsOp":        alertsInfo.AlertsWithLogsContainsOp,
+						"alertsWithTraceChQuery":          alertsInfo.AlertsWithTraceChQuery,
 					}
 					// send event only if there are dashboards or alerts or channels
 					if (dashboardsInfo.TotalDashboards > 0 || alertsInfo.TotalAlerts > 0 || alertsInfo.TotalChannels > 0 || savedViewsInfo.TotalSavedViews > 0) && apiErr == nil {


### PR DESCRIPTION
Part of https://github.com/SigNoz/engineering-pod/issues/2036

* Collect the TTL for metrics, traces, logs
* Collect number of dashboards and alerts having trace clickhouse query