### PR TITLE
fix: explicit mouse move event user action

### DIFF
--- a/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
+++ b/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
@@ -82,6 +82,7 @@ export default function LogsFormatOptionsMenu({
 	}, 300);
 
 	const handleToggleAddNewColumn = (): void => {
+		addColumn?.onSearch?.('');
 		setShowAddNewColumnContainer(!showAddNewColumnContainer);
 	};
 

--- a/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
+++ b/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
@@ -4,6 +4,7 @@
 import './LogsFormatOptionsMenu.styles.scss';
 
 import { Button, Input, InputNumber, Tooltip, Typography } from 'antd';
+import { DefaultOptionType } from 'antd/es/select';
 import cx from 'classnames';
 import { LogViewMode } from 'container/LogsTable';
 import { FontSize, OptionsMenuConfig } from 'container/OptionsMenu/types';
@@ -106,6 +107,39 @@ export default function LogsFormatOptionsMenu({
 		}
 	}, [fontSizeValue]);
 
+	function handleColumnSelection(
+		currentIndex: number,
+		optionsData: DefaultOptionType[],
+	): void {
+		const currentItem = optionsData[currentIndex];
+		const itemLength = optionsData.length;
+		if (addColumn && addColumn?.onSelect) {
+			addColumn?.onSelect(selectedValue, {
+				label: currentItem.label,
+				disabled: false,
+			});
+
+			// if the last element is selected then select the previous one
+			if (currentIndex === itemLength - 1) {
+				// there should be more than 1 element in the list
+				if (currentIndex - 1 > 0) {
+					const prevValue = optionsData[currentIndex - 1]?.value || null;
+					setSelectedValue(prevValue as string | null);
+				} else {
+					// if there is only one element then just select and do nothing
+					setSelectedValue(null);
+				}
+			} else {
+				// selecting any random element from the list except the last one
+				const nextIndex = currentIndex + 1;
+
+				const nextValue = optionsData[nextIndex]?.value || null;
+
+				setSelectedValue(nextValue as string | null);
+			}
+		}
+	}
+
 	const handleKeyDown = (e: KeyboardEvent): void => {
 		if (!selectedValue) return;
 
@@ -114,8 +148,6 @@ export default function LogsFormatOptionsMenu({
 		const currentIndex = optionsData.findIndex(
 			(item) => item?.value === selectedValue,
 		);
-
-		const currentItem = optionsData[currentIndex];
 
 		const itemLength = optionsData.length;
 
@@ -137,24 +169,7 @@ export default function LogsFormatOptionsMenu({
 			}
 			case 'Enter':
 				e.preventDefault();
-				if (addColumn && addColumn?.onSelect) {
-					addColumn?.onSelect(selectedValue, {
-						label: currentItem.label,
-						disabled: false,
-					});
-
-					if (currentIndex === itemLength - 1) {
-						setSelectedValue(null);
-						break;
-					} else {
-						const nextIndex = currentIndex + 1;
-
-						const nextValue = optionsData[nextIndex]?.value || null;
-
-						setSelectedValue(nextValue as string | null);
-					}
-				}
-
+				handleColumnSelection(currentIndex, optionsData);
 				break;
 			default:
 				break;
@@ -279,7 +294,7 @@ export default function LogsFormatOptionsMenu({
 						)}
 
 						<div className="column-format-new-options" ref={listRef}>
-							{addColumn?.options?.map(({ label, value }) => (
+							{addColumn?.options?.map(({ label, value }, index) => (
 								<div
 									className={cx('column-name', value === selectedValue && 'selected')}
 									key={value}
@@ -296,12 +311,7 @@ export default function LogsFormatOptionsMenu({
 									}}
 									onClick={(eve): void => {
 										eve.stopPropagation();
-
-										if (addColumn && addColumn?.onSelect) {
-											addColumn?.onSelect(value, { label, disabled: false });
-										}
-
-										setSelectedValue(null);
+										handleColumnSelection(index, addColumn?.options || []);
 									}}
 								>
 									<div className="name">

--- a/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
+++ b/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
@@ -290,6 +290,10 @@ export default function LogsFormatOptionsMenu({
 
 										initialMouseEnterRef.current = true;
 									}}
+									onMouseMove={(): void => {
+										// this is added to handle the mouse move explicit event and not the re-rendered on mouse enter event
+										setSelectedValue(value as string | null);
+									}}
 									onClick={(eve): void => {
 										eve.stopPropagation();
 

--- a/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
+++ b/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
@@ -122,7 +122,7 @@ export default function LogsFormatOptionsMenu({
 			// if the last element is selected then select the previous one
 			if (currentIndex === itemLength - 1) {
 				// there should be more than 1 element in the list
-				if (currentIndex - 1 > 0) {
+				if (currentIndex - 1 >= 0) {
 					const prevValue = optionsData[currentIndex - 1]?.value || null;
 					setSelectedValue(prevValue as string | null);
 				} else {


### PR DESCRIPTION
### Summary

- when the user enters the dropdown then post the first time we block the mouse enter event to handle the re-render keyboard scrolling better.
- but this caused issue for later explicit mouse enter events where user actually does some action
- so we capture these explicit events from mouse move. 

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Capture explicit mouse move events and centralize column selection logic in `LogsFormatOptionsMenu.tsx`.
> 
>   - **Behavior**:
>     - Capture explicit mouse move events in `LogsFormatOptionsMenu.tsx` to handle user actions better.
>     - Use `onMouseMove` to update `selectedValue` for explicit mouse actions.
>   - **Functions**:
>     - Introduce `handleColumnSelection()` to centralize column selection logic.
>     - Replace inline selection logic in `handleKeyDown()` and `onClick` with `handleColumnSelection()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 02af14186e77a10af5ecc836a1988c8d00100a6c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->