### PR TITLE
fix: add dashbard names and update logs count in telemetry

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -2540,7 +2540,7 @@ func (r *ClickHouseReader) GetTotalLogs(ctx context.Context) (uint64, error) {
 
 	var totalLogs uint64
 
-	queryStr := fmt.Sprintf("SELECT count() from %s.%s;", r.logsDB, r.logsTable)
+	queryStr := fmt.Sprintf("SELECT count() from %s.%s;", r.logsDB, r.logsTableName)
 	r.db.QueryRow(ctx, queryStr).Scan(&totalLogs)
 
 	return totalLogs, nil

--- a/pkg/query-service/app/dashboards/model.go
+++ b/pkg/query-service/app/dashboards/model.go
@@ -472,6 +472,11 @@ func GetDashboardsInfo(ctx context.Context) (*model.DashboardsInfo, error) {
 		if isDashboardWithTSV2(dashboard.Data) {
 			count = count + 1
 		}
+
+		if dashboardInfo.DashboardsWithTraceChQuery > 0 {
+			dashboardsInfo.DashboardNamesWithTraceChQuery = append(dashboardsInfo.DashboardNamesWithTraceChQuery, dashboardName)
+		}
+
 		// check if dashboard is a has a log operator with contains
 	}
 
@@ -505,6 +510,8 @@ func isDashboardWithTracesClickhouseQuery(data map[string]interface{}) bool {
 	if err != nil {
 		return false
 	}
+
+	// also check if the query is actually active
 	str := string(jsonData)
 	result := strings.Contains(str, "signoz_traces.distributed_signoz_index_v2") ||
 		strings.Contains(str, "signoz_traces.distributed_signoz_spans") ||

--- a/pkg/query-service/model/response.go
+++ b/pkg/query-service/model/response.go
@@ -658,6 +658,7 @@ type DashboardsInfo struct {
 	QueriesWithTSV2                 int      `json:"queriesWithTSV2"`
 	DashboardsWithLogsChQuery       int      `json:"dashboardsWithLogsChQuery"`
 	DashboardsWithTraceChQuery      int      `json:"dashboardsWithTraceChQuery"`
+	DashboardNamesWithTraceChQuery  []string `json:"dashboardNamesWithTraceChQuery"`
 	LogsPanelsWithAttrContainsOp    int      `json:"logsPanelsWithAttrContainsOp"`
 }
 

--- a/pkg/query-service/telemetry/telemetry.go
+++ b/pkg/query-service/telemetry/telemetry.go
@@ -347,6 +347,7 @@ func createTelemetry() {
 						"dashboardsWithTSV2":              dashboardsInfo.QueriesWithTSV2,
 						"dashboardWithLogsChQuery":        dashboardsInfo.DashboardsWithLogsChQuery,
 						"dashboardWithTraceChQuery":       dashboardsInfo.DashboardsWithTraceChQuery,
+						"dashboardNamesWithTraceChQuery":  dashboardsInfo.DashboardNamesWithTraceChQuery,
 						"totalAlerts":                     alertsInfo.TotalAlerts,
 						"alertsWithTSV2":                  alertsInfo.AlertsWithTSV2,
 						"logsBasedAlerts":                 alertsInfo.LogsBasedAlerts,


### PR DESCRIPTION


FOR https://github.com/SigNoz/signoz/issues/5713
https://github.com/SigNoz/engineering-pod/issues/2036

* send the name of dashboards with trace ch query.
* update the log count function to get correct logs sent
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR updates telemetry to include dashboard names with trace queries and corrects log count retrieval in telemetry.
> 
>   - **Telemetry Updates**:
>     - `createTelemetry` in `telemetry.go` now sends `DashboardNamesWithTraceChQuery`.
>   - **Dashboard Names**:
>     - `GetDashboardsInfo` in `model.go` appends `DashboardNamesWithTraceChQuery` if trace query is present.
>     - `DashboardsInfo` in `response.go` includes `DashboardNamesWithTraceChQuery`.
>   - **Log Count Correction**:
>     - `GetTotalLogs` in `reader.go` now uses `logsTableName` instead of `logsTable`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e26adc8747a1aaaeadb46e67bdd2faf01f59a00c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->