### PR TITLE
feat: apply timezone to the date/time in tabular data throughout the app

### DIFF
--- a/frontend/src/components/Graph/index.tsx
+++ b/frontend/src/components/Graph/index.tsx
@@ -1,4 +1,5 @@
 import {
+	_adapters,
 	BarController,
 	BarElement,
 	CategoryScale,
@@ -18,8 +19,10 @@ import {
 } from 'chart.js';
 import annotationPlugin from 'chartjs-plugin-annotation';
 import { generateGridTitle } from 'container/GridPanelSwitch/utils';
+import dayjs from 'dayjs';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import isEqual from 'lodash-es/isEqual';
+import { useTimezone } from 'providers/Timezone';
 import {
 	forwardRef,
 	memo,
@@ -62,6 +65,17 @@ Chart.register(
 
 Tooltip.positioners.custom = TooltipPositionHandler;
 
+// Map of Chart.js time formats to dayjs format strings
+const formatMap = {
+	'HH:mm:ss': 'HH:mm:ss',
+	'HH:mm': 'HH:mm',
+	'MM/DD HH:mm': 'MM/DD HH:mm',
+	'MM/dd HH:mm': 'MM/DD HH:mm',
+	'MM/DD': 'MM/DD',
+	'YY-MM': 'YY-MM',
+	YY: 'YY',
+};
+
 const Graph = forwardRef<ToggleGraphProps | undefined, GraphProps>(
 	(
 		{
@@ -80,11 +94,13 @@ const Graph = forwardRef<ToggleGraphProps | undefined, GraphProps>(
 			dragSelectColor,
 		},
 		ref,
+		// eslint-disable-next-line sonarjs/cognitive-complexity
 	): JSX.Element => {
 		const nearestDatasetIndex = useRef<null | number>(null);
 		const chartRef = useRef<HTMLCanvasElement>(null);
 		const isDarkMode = useIsDarkMode();
 		const gridTitle = useMemo(() => generateGridTitle(title), [title]);
+		const { timezone } = useTimezone();
 
 		const currentTheme = isDarkMode ? 'dark' : 'light';
 		const xAxisTimeUnit = useXAxisTimeUnit(data); // Computes the relevant time unit for x axis by analyzing the time stamp data
@@ -112,6 +128,22 @@ const Graph = forwardRef<ToggleGraphProps | undefined, GraphProps>(
 			return 'rgba(231,233,237,0.8)';
 		}, [currentTheme]);
 
+		// Override Chart.js date adapter to use dayjs with timezone support
+		useEffect(() => {
+			_adapters._date.override({
+				format(time: number | Date, fmt: string) {
+					const dayjsTime = dayjs(time).tz(timezone?.value);
+					const format = formatMap[fmt as keyof typeof formatMap];
+					if (!format) {
+						console.warn(`Missing datetime format for ${fmt}`);
+						return dayjsTime.format('YYYY-MM-DD HH:mm:ss'); // fallback format
+					}
+
+					return dayjsTime.format(format);
+				},
+			});
+		}, [timezone]);
+
 		const buildChart = useCallback(() => {
 			if (lineChartRef.current !== undefined) {
 				lineChartRef.current.destroy();
@@ -132,6 +164,7 @@ const Graph = forwardRef<ToggleGraphProps | undefined, GraphProps>(
 					isStacked,
 					onClickHandler,
 					data,
+					timezone,
 				);
 
 				const chartHasData = hasData(data);
@@ -166,6 +199,7 @@ const Graph = forwardRef<ToggleGraphProps | undefined, GraphProps>(
 			isStacked,
 			onClickHandler,
 			data,
+			timezone,
 			name,
 			type,
 		]);

--- a/frontend/src/components/Graph/utils.ts
+++ b/frontend/src/components/Graph/utils.ts
@@ -1,5 +1,6 @@
 import { Chart, ChartConfiguration, ChartData, Color } from 'chart.js';
 import * as chartjsAdapter from 'chartjs-adapter-date-fns';
+import { Timezone } from 'components/CustomTimePicker/timezoneUtils';
 import dayjs from 'dayjs';
 import { MutableRefObject } from 'react';
 
@@ -50,6 +51,7 @@ export const getGraphOptions = (
 	isStacked: boolean | undefined,
 	onClickHandler: GraphOnClickHandler | undefined,
 	data: ChartData,
+	timezone: Timezone,
 	// eslint-disable-next-line sonarjs/cognitive-complexity
 ): CustomChartOptions => ({
 	animation: {
@@ -97,7 +99,7 @@ export const getGraphOptions = (
 			callbacks: {
 				title(context): string | string[] {
 					const date = dayjs(context[0].parsed.x);
-					return date.format('MMM DD, YYYY, HH:mm:ss');
+					return date.tz(timezone?.value).format('MMM DD, YYYY, HH:mm:ss');
 				},
 				label(context): string | string[] {
 					let label = context.dataset.label || '';

--- a/frontend/src/components/Logs/ListLogView/index.tsx
+++ b/frontend/src/components/Logs/ListLogView/index.tsx
@@ -174,17 +174,20 @@ function ListLogView({
 		[selectedFields],
 	);
 
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	const timestampValue = useMemo(
 		() =>
 			typeof flattenLogData.timestamp === 'string'
-				? formatTimestamp(flattenLogData.timestamp, 'YYYY-MM-DD HH:mm:ss.SSS')
-				: formatTimestamp(
+				? formatTimezoneAdjustedTimestamp(
+						flattenLogData.timestamp,
+						'YYYY-MM-DD HH:mm:ss.SSS',
+				  )
+				: formatTimezoneAdjustedTimestamp(
 						flattenLogData.timestamp / 1e6,
 						'YYYY-MM-DD HH:mm:ss.SSS',
 				  ),
-		[flattenLogData.timestamp, formatTimestamp],
+		[flattenLogData.timestamp, formatTimezoneAdjustedTimestamp],
 	);
 
 	const logType = getLogIndicatorType(logData);

--- a/frontend/src/components/Logs/ListLogView/index.tsx
+++ b/frontend/src/components/Logs/ListLogView/index.tsx
@@ -8,13 +8,13 @@ import LogDetail from 'components/LogDetail';
 import { VIEW_TYPES } from 'components/LogDetail/constants';
 import { unescapeString } from 'container/LogDetailedView/utils';
 import { FontSize } from 'container/OptionsMenu/types';
-import dayjs from 'dayjs';
 import dompurify from 'dompurify';
 import { useActiveLog } from 'hooks/logs/useActiveLog';
 import { useCopyLogLink } from 'hooks/logs/useCopyLogLink';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 // utils
 import { FlatLogData } from 'lib/logs/flatLogData';
+import { useTimezone } from 'providers/Timezone';
 import { useCallback, useMemo, useState } from 'react';
 // interfaces
 import { IField } from 'types/api/logs/fields';
@@ -174,12 +174,17 @@ function ListLogView({
 		[selectedFields],
 	);
 
+	const { formatTimestamp } = useTimezone();
+
 	const timestampValue = useMemo(
 		() =>
 			typeof flattenLogData.timestamp === 'string'
-				? dayjs(flattenLogData.timestamp).format('YYYY-MM-DD HH:mm:ss.SSS')
-				: dayjs(flattenLogData.timestamp / 1e6).format('YYYY-MM-DD HH:mm:ss.SSS'),
-		[flattenLogData.timestamp],
+				? formatTimestamp(flattenLogData.timestamp, 'YYYY-MM-DD HH:mm:ss.SSS')
+				: formatTimestamp(
+						flattenLogData.timestamp / 1e6,
+						'YYYY-MM-DD HH:mm:ss.SSS',
+				  ),
+		[flattenLogData.timestamp, formatTimestamp],
 	);
 
 	const logType = getLogIndicatorType(logData);

--- a/frontend/src/components/Logs/RawLogView/index.tsx
+++ b/frontend/src/components/Logs/RawLogView/index.tsx
@@ -89,16 +89,24 @@ function RawLogView({
 		attributesText += ' | ';
 	}
 
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	const text = useMemo(() => {
 		const date =
 			typeof data.timestamp === 'string'
-				? formatTimestamp(data.timestamp, 'YYYY-MM-DD HH:mm:ss.SSS')
-				: formatTimestamp(data.timestamp / 1e6, 'YYYY-MM-DD HH:mm:ss.SSS');
+				? formatTimezoneAdjustedTimestamp(data.timestamp, 'YYYY-MM-DD HH:mm:ss.SSS')
+				: formatTimezoneAdjustedTimestamp(
+						data.timestamp / 1e6,
+						'YYYY-MM-DD HH:mm:ss.SSS',
+				  );
 
 		return `${date} | ${attributesText} ${data.body}`;
-	}, [data.timestamp, data.body, attributesText, formatTimestamp]);
+	}, [
+		data.timestamp,
+		data.body,
+		attributesText,
+		formatTimezoneAdjustedTimestamp,
+	]);
 
 	const handleClickExpand = useCallback(() => {
 		if (activeContextLog || isReadOnly) return;

--- a/frontend/src/components/Logs/RawLogView/index.tsx
+++ b/frontend/src/components/Logs/RawLogView/index.tsx
@@ -6,7 +6,6 @@ import LogDetail from 'components/LogDetail';
 import { VIEW_TYPES, VIEWS } from 'components/LogDetail/constants';
 import { unescapeString } from 'container/LogDetailedView/utils';
 import LogsExplorerContext from 'container/LogsExplorerContext';
-import dayjs from 'dayjs';
 import dompurify from 'dompurify';
 import { useActiveLog } from 'hooks/logs/useActiveLog';
 import { useCopyLogLink } from 'hooks/logs/useCopyLogLink';
@@ -14,6 +13,7 @@ import { useCopyLogLink } from 'hooks/logs/useCopyLogLink';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { FlatLogData } from 'lib/logs/flatLogData';
 import { isEmpty, isNumber, isUndefined } from 'lodash-es';
+import { useTimezone } from 'providers/Timezone';
 import {
 	KeyboardEvent,
 	MouseEvent,
@@ -89,16 +89,16 @@ function RawLogView({
 		attributesText += ' | ';
 	}
 
+	const { formatTimestamp } = useTimezone();
+
 	const text = useMemo(() => {
 		const date =
 			typeof data.timestamp === 'string'
-				? dayjs(data.timestamp)
-				: dayjs(data.timestamp / 1e6);
+				? formatTimestamp(data.timestamp, 'YYYY-MM-DD HH:mm:ss.SSS')
+				: formatTimestamp(data.timestamp / 1e6, 'YYYY-MM-DD HH:mm:ss.SSS');
 
-		return `${date.format('YYYY-MM-DD HH:mm:ss.SSS')} | ${attributesText} ${
-			data.body
-		}`;
-	}, [data.timestamp, data.body, attributesText]);
+		return `${date} | ${attributesText} ${data.body}`;
+	}, [data.timestamp, data.body, attributesText, formatTimestamp]);
 
 	const handleClickExpand = useCallback(() => {
 		if (activeContextLog || isReadOnly) return;

--- a/frontend/src/components/Logs/TableView/useTableView.tsx
+++ b/frontend/src/components/Logs/TableView/useTableView.tsx
@@ -5,10 +5,10 @@ import { Typography } from 'antd';
 import { ColumnsType } from 'antd/es/table';
 import cx from 'classnames';
 import { unescapeString } from 'container/LogDetailedView/utils';
-import dayjs from 'dayjs';
 import dompurify from 'dompurify';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { FlatLogData } from 'lib/logs/flatLogData';
+import { useTimezone } from 'providers/Timezone';
 import { useMemo } from 'react';
 import { FORBID_DOM_PURIFY_TAGS } from 'utils/app';
 
@@ -43,6 +43,8 @@ export const useTableView = (props: UseTableViewProps): UseTableViewResult => {
 	const flattenLogData = useMemo(() => logs.map((log) => FlatLogData(log)), [
 		logs,
 	]);
+
+	const { formatTimestamp } = useTimezone();
 
 	const columns: ColumnsType<Record<string, unknown>> = useMemo(() => {
 		const fieldColumns: ColumnsType<Record<string, unknown>> = fields
@@ -81,8 +83,8 @@ export const useTableView = (props: UseTableViewProps): UseTableViewResult => {
 				render: (field, item): ColumnTypeRender<Record<string, unknown>> => {
 					const date =
 						typeof field === 'string'
-							? dayjs(field).format('YYYY-MM-DD HH:mm:ss.SSS')
-							: dayjs(field / 1e6).format('YYYY-MM-DD HH:mm:ss.SSS');
+							? formatTimestamp(field, 'YYYY-MM-DD HH:mm:ss.SSS')
+							: formatTimestamp(field / 1e6, 'YYYY-MM-DD HH:mm:ss.SSS');
 					return {
 						children: (
 							<div className="table-timestamp">
@@ -125,7 +127,15 @@ export const useTableView = (props: UseTableViewProps): UseTableViewResult => {
 			},
 			...(appendTo === 'end' ? fieldColumns : []),
 		];
-	}, [fields, isListViewPanel, appendTo, isDarkMode, linesPerRow, fontSize]);
+	}, [
+		fields,
+		isListViewPanel,
+		appendTo,
+		isDarkMode,
+		linesPerRow,
+		fontSize,
+		formatTimestamp,
+	]);
 
 	return { columns, dataSource: flattenLogData };
 };

--- a/frontend/src/components/Logs/TableView/useTableView.tsx
+++ b/frontend/src/components/Logs/TableView/useTableView.tsx
@@ -44,7 +44,7 @@ export const useTableView = (props: UseTableViewProps): UseTableViewResult => {
 		logs,
 	]);
 
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	const columns: ColumnsType<Record<string, unknown>> = useMemo(() => {
 		const fieldColumns: ColumnsType<Record<string, unknown>> = fields
@@ -83,8 +83,11 @@ export const useTableView = (props: UseTableViewProps): UseTableViewResult => {
 				render: (field, item): ColumnTypeRender<Record<string, unknown>> => {
 					const date =
 						typeof field === 'string'
-							? formatTimestamp(field, 'YYYY-MM-DD HH:mm:ss.SSS')
-							: formatTimestamp(field / 1e6, 'YYYY-MM-DD HH:mm:ss.SSS');
+							? formatTimezoneAdjustedTimestamp(field, 'YYYY-MM-DD HH:mm:ss.SSS')
+							: formatTimezoneAdjustedTimestamp(
+									field / 1e6,
+									'YYYY-MM-DD HH:mm:ss.SSS',
+							  );
 					return {
 						children: (
 							<div className="table-timestamp">
@@ -134,7 +137,7 @@ export const useTableView = (props: UseTableViewProps): UseTableViewResult => {
 		isDarkMode,
 		linesPerRow,
 		fontSize,
-		formatTimestamp,
+		formatTimezoneAdjustedTimestamp,
 	]);
 
 	return { columns, dataSource: flattenLogData };

--- a/frontend/src/components/ResizeTable/TableComponent/Time.tsx
+++ b/frontend/src/components/ResizeTable/TableComponent/Time.tsx
@@ -2,9 +2,12 @@ import { Typography } from 'antd';
 import { useTimezone } from 'providers/Timezone';
 
 function Time({ CreatedOrUpdateTime }: DateProps): JSX.Element {
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 	const time = new Date(CreatedOrUpdateTime);
-	const timeString = formatTimestamp(time, 'MM/DD/YYYY hh:mm:ss A (UTC Z)');
+	const timeString = formatTimezoneAdjustedTimestamp(
+		time,
+		'MM/DD/YYYY hh:mm:ss A (UTC Z)',
+	);
 	return <Typography>{timeString}</Typography>;
 }
 

--- a/frontend/src/components/ResizeTable/TableComponent/Time.tsx
+++ b/frontend/src/components/ResizeTable/TableComponent/Time.tsx
@@ -1,11 +1,10 @@
 import { Typography } from 'antd';
-import convertDateToAmAndPm from 'lib/convertDateToAmAndPm';
-import getFormattedDate from 'lib/getFormatedDate';
+import { useTimezone } from 'providers/Timezone';
 
 function Time({ CreatedOrUpdateTime }: DateProps): JSX.Element {
+	const { formatTimestamp } = useTimezone();
 	const time = new Date(CreatedOrUpdateTime);
-	const date = getFormattedDate(time);
-	const timeString = `${date} ${convertDateToAmAndPm(time)}`;
+	const timeString = formatTimestamp(time, 'MM/DD/YYYY hh:mm:ss A (UTC Z)');
 	return <Typography>{timeString}</Typography>;
 }
 

--- a/frontend/src/container/AlertHistory/Timeline/Table/Table.tsx
+++ b/frontend/src/container/AlertHistory/Timeline/Table/Table.tsx
@@ -40,7 +40,7 @@ function TimelineTable(): JSX.Element {
 
 	const { t } = useTranslation('common');
 
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	if (isError || !isValidRuleId || !ruleId) {
 		return <div>{t('something_went_wrong')}</div>;
@@ -54,7 +54,7 @@ function TimelineTable(): JSX.Element {
 					filters,
 					labels: labels ?? {},
 					setFilters,
-					formatTimestamp,
+					formatTimezoneAdjustedTimestamp,
 				})}
 				dataSource={timelineData}
 				pagination={paginationConfig}

--- a/frontend/src/container/AlertHistory/Timeline/Table/Table.tsx
+++ b/frontend/src/container/AlertHistory/Timeline/Table/Table.tsx
@@ -6,6 +6,7 @@ import {
 	useGetAlertRuleDetailsTimelineTable,
 	useTimelineTable,
 } from 'pages/AlertDetails/hooks';
+import { useTimezone } from 'providers/Timezone';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TagFilter } from 'types/api/queryBuilder/queryBuilderData';
@@ -39,6 +40,8 @@ function TimelineTable(): JSX.Element {
 
 	const { t } = useTranslation('common');
 
+	const { formatTimestamp } = useTimezone();
+
 	if (isError || !isValidRuleId || !ruleId) {
 		return <div>{t('something_went_wrong')}</div>;
 	}
@@ -51,6 +54,7 @@ function TimelineTable(): JSX.Element {
 					filters,
 					labels: labels ?? {},
 					setFilters,
+					formatTimestamp,
 				})}
 				dataSource={timelineData}
 				pagination={paginationConfig}

--- a/frontend/src/container/AlertHistory/Timeline/Table/useTimelineTable.tsx
+++ b/frontend/src/container/AlertHistory/Timeline/Table/useTimelineTable.tsx
@@ -74,12 +74,15 @@ export const timelineTableColumns = ({
 	filters,
 	labels,
 	setFilters,
-	formatTimestamp,
+	formatTimezoneAdjustedTimestamp,
 }: {
 	filters: TagFilter;
 	labels: AlertLabelsProps['labels'];
 	setFilters: (filters: TagFilter) => void;
-	formatTimestamp: (input: TimestampInput, format?: string) => string;
+	formatTimezoneAdjustedTimestamp: (
+		input: TimestampInput,
+		format?: string,
+	) => string;
 }): ColumnsType<AlertRuleTimelineTableResponse> => [
 	{
 		title: 'STATE',
@@ -109,7 +112,7 @@ export const timelineTableColumns = ({
 		width: 200,
 		render: (value): JSX.Element => (
 			<div className="alert-rule__created-at">
-				{formatTimestamp(value, 'MMM D, YYYY ⎯ HH:mm:ss')}
+				{formatTimezoneAdjustedTimestamp(value, 'MMM D, YYYY ⎯ HH:mm:ss')}
 			</div>
 		),
 	},

--- a/frontend/src/container/AlertHistory/Timeline/Table/useTimelineTable.tsx
+++ b/frontend/src/container/AlertHistory/Timeline/Table/useTimelineTable.tsx
@@ -8,6 +8,7 @@ import ClientSideQBSearch, {
 import { ConditionalAlertPopover } from 'container/AlertHistory/AlertPopover/AlertPopover';
 import { transformKeyValuesToAttributeValuesMap } from 'container/QueryBuilder/filters/utils';
 import { useIsDarkMode } from 'hooks/useDarkMode';
+import { TimestampInput } from 'hooks/useTimezoneFormatter/useTimezoneFormatter';
 import { Search } from 'lucide-react';
 import AlertLabels, {
 	AlertLabelsProps,
@@ -16,7 +17,6 @@ import AlertState from 'pages/AlertDetails/AlertHeader/AlertState/AlertState';
 import { useMemo } from 'react';
 import { AlertRuleTimelineTableResponse } from 'types/api/alerts/def';
 import { TagFilter } from 'types/api/queryBuilder/queryBuilderData';
-import { formatEpochTimestamp } from 'utils/timeUtils';
 
 const transformLabelsToQbKeys = (
 	labels: AlertRuleTimelineTableResponse['labels'],
@@ -74,10 +74,12 @@ export const timelineTableColumns = ({
 	filters,
 	labels,
 	setFilters,
+	formatTimestamp,
 }: {
 	filters: TagFilter;
 	labels: AlertLabelsProps['labels'];
 	setFilters: (filters: TagFilter) => void;
+	formatTimestamp: (input: TimestampInput, format?: string) => string;
 }): ColumnsType<AlertRuleTimelineTableResponse> => [
 	{
 		title: 'STATE',
@@ -106,7 +108,9 @@ export const timelineTableColumns = ({
 		dataIndex: 'unixMilli',
 		width: 200,
 		render: (value): JSX.Element => (
-			<div className="alert-rule__created-at">{formatEpochTimestamp(value)}</div>
+			<div className="alert-rule__created-at">
+				{formatTimestamp(value, 'MMM D, YYYY ⎯ HH:mm:ss')}
+			</div>
 		),
 	},
 	{

--- a/frontend/src/container/AllError/index.tsx
+++ b/frontend/src/container/AllError/index.tsx
@@ -158,9 +158,14 @@ function AllErrors(): JSX.Element {
 
 	const getDateValue = (
 		value: string,
-		formatTimestamp: (input: TimestampInput, format?: string) => string,
+		formatTimezoneAdjustedTimestamp: (
+			input: TimestampInput,
+			format?: string,
+		) => string,
 	): JSX.Element => (
-		<Typography>{formatTimestamp(value, 'DD/MM/YYYY hh:mm:ss A')}</Typography>
+		<Typography>
+			{formatTimezoneAdjustedTimestamp(value, 'DD/MM/YYYY hh:mm:ss A')}
+		</Typography>
 	);
 
 	const filterIcon = useCallback(() => <SearchOutlined />, []);
@@ -287,7 +292,7 @@ function AllErrors(): JSX.Element {
 		[filterIcon, filterDropdownWrapper],
 	);
 
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	const columns: ColumnsType<Exception> = [
 		{
@@ -348,7 +353,8 @@ function AllErrors(): JSX.Element {
 			dataIndex: 'lastSeen',
 			width: 80,
 			key: 'lastSeen',
-			render: (value): JSX.Element => getDateValue(value, formatTimestamp),
+			render: (value): JSX.Element =>
+				getDateValue(value, formatTimezoneAdjustedTimestamp),
 			sorter: true,
 			defaultSortOrder: getDefaultOrder(
 				getUpdatedParams,
@@ -361,7 +367,8 @@ function AllErrors(): JSX.Element {
 			dataIndex: 'firstSeen',
 			width: 80,
 			key: 'firstSeen',
-			render: (value): JSX.Element => getDateValue(value, formatTimestamp),
+			render: (value): JSX.Element =>
+				getDateValue(value, formatTimezoneAdjustedTimestamp),
 			sorter: true,
 			defaultSortOrder: getDefaultOrder(
 				getUpdatedParams,

--- a/frontend/src/container/AllError/index.tsx
+++ b/frontend/src/container/AllError/index.tsx
@@ -17,14 +17,15 @@ import getAll from 'api/errors/getAll';
 import getErrorCounts from 'api/errors/getErrorCounts';
 import { ResizeTable } from 'components/ResizeTable';
 import ROUTES from 'constants/routes';
-import dayjs from 'dayjs';
 import { useNotifications } from 'hooks/useNotifications';
 import useResourceAttribute from 'hooks/useResourceAttribute';
 import { convertRawQueriesToTraceSelectedTags } from 'hooks/useResourceAttribute/utils';
+import { TimestampInput } from 'hooks/useTimezoneFormatter/useTimezoneFormatter';
 import useUrlQuery from 'hooks/useUrlQuery';
 import createQueryParams from 'lib/createQueryParams';
 import history from 'lib/history';
 import { isUndefined } from 'lodash-es';
+import { useTimezone } from 'providers/Timezone';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueries } from 'react-query';
@@ -155,8 +156,11 @@ function AllErrors(): JSX.Element {
 		}
 	}, [data?.error, data?.payload, t, notifications]);
 
-	const getDateValue = (value: string): JSX.Element => (
-		<Typography>{dayjs(value).format('DD/MM/YYYY HH:mm:ss A')}</Typography>
+	const getDateValue = (
+		value: string,
+		formatTimestamp: (input: TimestampInput, format?: string) => string,
+	): JSX.Element => (
+		<Typography>{formatTimestamp(value, 'DD/MM/YYYY hh:mm:ss A')}</Typography>
 	);
 
 	const filterIcon = useCallback(() => <SearchOutlined />, []);
@@ -283,6 +287,8 @@ function AllErrors(): JSX.Element {
 		[filterIcon, filterDropdownWrapper],
 	);
 
+	const { formatTimestamp } = useTimezone();
+
 	const columns: ColumnsType<Exception> = [
 		{
 			title: 'Exception Type',
@@ -342,7 +348,7 @@ function AllErrors(): JSX.Element {
 			dataIndex: 'lastSeen',
 			width: 80,
 			key: 'lastSeen',
-			render: getDateValue,
+			render: (value): JSX.Element => getDateValue(value, formatTimestamp),
 			sorter: true,
 			defaultSortOrder: getDefaultOrder(
 				getUpdatedParams,
@@ -355,7 +361,7 @@ function AllErrors(): JSX.Element {
 			dataIndex: 'firstSeen',
 			width: 80,
 			key: 'firstSeen',
-			render: getDateValue,
+			render: (value): JSX.Element => getDateValue(value, formatTimestamp),
 			sorter: true,
 			defaultSortOrder: getDefaultOrder(
 				getUpdatedParams,

--- a/frontend/src/container/ErrorDetails/index.tsx
+++ b/frontend/src/container/ErrorDetails/index.tsx
@@ -6,12 +6,12 @@ import getNextPrevId from 'api/errors/getNextPrevId';
 import Editor from 'components/Editor';
 import { ResizeTable } from 'components/ResizeTable';
 import { getNanoSeconds } from 'container/AllError/utils';
-import dayjs from 'dayjs';
 import { useNotifications } from 'hooks/useNotifications';
 import createQueryParams from 'lib/createQueryParams';
 import history from 'lib/history';
 import { isUndefined } from 'lodash-es';
 import { urlKey } from 'pages/ErrorDetails/utils';
+import { useTimezone } from 'providers/Timezone';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from 'react-query';
@@ -103,8 +103,6 @@ function ErrorDetails(props: ErrorDetailsProps): JSX.Element {
 		}
 	};
 
-	const timeStamp = dayjs(errorDetail.timestamp);
-
 	const data: { key: string; value: string }[] = Object.keys(errorDetail)
 		.filter((e) => !keyToExclude.includes(e))
 		.map((key) => ({
@@ -136,6 +134,8 @@ function ErrorDetails(props: ErrorDetailsProps): JSX.Element {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [data]);
 
+	const { formatTimestamp } = useTimezone();
+
 	return (
 		<>
 			<Typography>{errorDetail.exceptionType}</Typography>
@@ -145,7 +145,9 @@ function ErrorDetails(props: ErrorDetailsProps): JSX.Element {
 			<EventContainer>
 				<div>
 					<Typography>Event {errorDetail.errorId}</Typography>
-					<Typography>{timeStamp.format('MMM DD YYYY hh:mm:ss A')}</Typography>
+					<Typography>
+						{formatTimestamp(errorDetail.timestamp, 'DD/MM/YYYY hh:mm:ss A (UTC Z)')}
+					</Typography>
 				</div>
 				<div>
 					<Space align="end" direction="horizontal">

--- a/frontend/src/container/ErrorDetails/index.tsx
+++ b/frontend/src/container/ErrorDetails/index.tsx
@@ -134,7 +134,7 @@ function ErrorDetails(props: ErrorDetailsProps): JSX.Element {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [data]);
 
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	return (
 		<>
@@ -146,7 +146,10 @@ function ErrorDetails(props: ErrorDetailsProps): JSX.Element {
 				<div>
 					<Typography>Event {errorDetail.errorId}</Typography>
 					<Typography>
-						{formatTimestamp(errorDetail.timestamp, 'DD/MM/YYYY hh:mm:ss A (UTC Z)')}
+						{formatTimezoneAdjustedTimestamp(
+							errorDetail.timestamp,
+							'DD/MM/YYYY hh:mm:ss A (UTC Z)',
+						)}
 					</Typography>
 				</div>
 				<div>

--- a/frontend/src/container/Licenses/ListLicenses.tsx
+++ b/frontend/src/container/Licenses/ListLicenses.tsx
@@ -6,11 +6,11 @@ import { useTranslation } from 'react-i18next';
 import { License } from 'types/api/licenses/def';
 
 function ValidityColumn({ value }: { value: string }): JSX.Element {
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	return (
 		<Typography>
-			{formatTimestamp(value, 'YYYY-MM-DD HH:mm:ss (UTC Z)')}
+			{formatTimezoneAdjustedTimestamp(value, 'YYYY-MM-DD HH:mm:ss (UTC Z)')}
 		</Typography>
 	);
 }

--- a/frontend/src/container/Licenses/ListLicenses.tsx
+++ b/frontend/src/container/Licenses/ListLicenses.tsx
@@ -1,7 +1,19 @@
+import { Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { ResizeTable } from 'components/ResizeTable';
+import { useTimezone } from 'providers/Timezone';
 import { useTranslation } from 'react-i18next';
 import { License } from 'types/api/licenses/def';
+
+function ValidityColumn({ value }: { value: string }): JSX.Element {
+	const { formatTimestamp } = useTimezone();
+
+	return (
+		<Typography>
+			{formatTimestamp(value, 'YYYY-MM-DD HH:mm:ss (UTC Z)')}
+		</Typography>
+	);
+}
 
 function ListLicenses({ licenses }: ListLicensesProps): JSX.Element {
 	const { t } = useTranslation(['licenses']);
@@ -23,12 +35,14 @@ function ListLicenses({ licenses }: ListLicensesProps): JSX.Element {
 			title: t('column_valid_from'),
 			dataIndex: 'ValidFrom',
 			key: 'valid from',
+			render: (value: string): JSX.Element => ValidityColumn({ value }),
 			width: 80,
 		},
 		{
 			title: t('column_valid_until'),
 			dataIndex: 'ValidUntil',
 			key: 'valid until',
+			render: (value: string): JSX.Element => ValidityColumn({ value }),
 			width: 80,
 		},
 	];

--- a/frontend/src/container/ListOfDashboard/DashboardsList.tsx
+++ b/frontend/src/container/ListOfDashboard/DashboardsList.tsx
@@ -344,10 +344,13 @@ function DashboardsList(): JSX.Element {
 		}
 	}, [state.error, state.value, t, notifications]);
 
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	function getFormattedTime(dashboard: Dashboard, option: string): string {
-		return formatTimestamp(get(dashboard, option, ''), 'MMM D, YYYY ⎯ HH:mm:ss');
+		return formatTimezoneAdjustedTimestamp(
+			get(dashboard, option, ''),
+			'MMM D, YYYY ⎯ HH:mm:ss',
+		);
 	}
 
 	const onLastUpdated = (time: string): string => {
@@ -390,7 +393,7 @@ function DashboardsList(): JSX.Element {
 			title: 'Dashboards',
 			key: 'dashboard',
 			render: (dashboard: Data, _, index): JSX.Element => {
-				const formattedDateAndTime = formatTimestamp(
+				const formattedDateAndTime = formatTimezoneAdjustedTimestamp(
 					dashboard.createdAt,
 					'MMM D, YYYY ⎯ HH:mm:ss',
 				);

--- a/frontend/src/container/ListOfDashboard/DashboardsList.tsx
+++ b/frontend/src/container/ListOfDashboard/DashboardsList.tsx
@@ -57,6 +57,7 @@ import {
 // see more: https://github.com/lucide-icons/lucide/issues/94
 import { handleContactSupport } from 'pages/Integrations/utils';
 import { useDashboard } from 'providers/Dashboard/Dashboard';
+import { useTimezone } from 'providers/Timezone';
 import {
 	ChangeEvent,
 	Key,
@@ -343,31 +344,10 @@ function DashboardsList(): JSX.Element {
 		}
 	}, [state.error, state.value, t, notifications]);
 
+	const { formatTimestamp } = useTimezone();
+
 	function getFormattedTime(dashboard: Dashboard, option: string): string {
-		const timeOptions: Intl.DateTimeFormatOptions = {
-			hour: '2-digit',
-			minute: '2-digit',
-			second: '2-digit',
-			hour12: false,
-		};
-		const formattedTime = new Date(get(dashboard, option, '')).toLocaleTimeString(
-			'en-US',
-			timeOptions,
-		);
-
-		const dateOptions: Intl.DateTimeFormatOptions = {
-			month: 'short',
-			day: 'numeric',
-			year: 'numeric',
-		};
-
-		const formattedDate = new Date(get(dashboard, option, '')).toLocaleDateString(
-			'en-US',
-			dateOptions,
-		);
-
-		// Combine time and date
-		return `${formattedDate} ⎯ ${formattedTime}`;
+		return formatTimestamp(get(dashboard, option, ''), 'MMM D, YYYY ⎯ HH:mm:ss');
 	}
 
 	const onLastUpdated = (time: string): string => {
@@ -410,30 +390,10 @@ function DashboardsList(): JSX.Element {
 			title: 'Dashboards',
 			key: 'dashboard',
 			render: (dashboard: Data, _, index): JSX.Element => {
-				const timeOptions: Intl.DateTimeFormatOptions = {
-					hour: '2-digit',
-					minute: '2-digit',
-					second: '2-digit',
-					hour12: false,
-				};
-				const formattedTime = new Date(dashboard.createdAt).toLocaleTimeString(
-					'en-US',
-					timeOptions,
+				const formattedDateAndTime = formatTimestamp(
+					dashboard.createdAt,
+					'MMM D, YYYY ⎯ HH:mm:ss',
 				);
-
-				const dateOptions: Intl.DateTimeFormatOptions = {
-					month: 'short',
-					day: 'numeric',
-					year: 'numeric',
-				};
-
-				const formattedDate = new Date(dashboard.createdAt).toLocaleDateString(
-					'en-US',
-					dateOptions,
-				);
-
-				// Combine time and date
-				const formattedDateAndTime = `${formattedDate} ⎯ ${formattedTime}`;
 
 				const getLink = (): string => `${ROUTES.ALL_DASHBOARD}/${dashboard.id}`;
 

--- a/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
+++ b/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
@@ -11,7 +11,8 @@ import ROUTES from 'constants/routes';
 import dompurify from 'dompurify';
 import { isEmpty } from 'lodash-es';
 import { ArrowDownToDot, ArrowUpFromDot, Ellipsis } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useTimezone } from 'providers/Timezone';
+import React, { useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { FORBID_DOM_PURIFY_TAGS } from 'utils/app';
@@ -68,6 +69,8 @@ export function TableViewActions(
 
 	const [isOpen, setIsOpen] = useState<boolean>(false);
 
+	const { formatTimestamp } = useTimezone();
+
 	if (record.field === 'body') {
 		const parsedBody = recursiveParseJSON(fieldData.value);
 		if (!isEmpty(parsedBody)) {
@@ -100,33 +103,41 @@ export function TableViewActions(
 		);
 	}
 
+	let cleanTimestamp: string;
+	if (record.field === 'timestamp') {
+		cleanTimestamp = fieldData.value.replace(/^["']|["']$/g, '');
+	}
+
+	const renderFieldContent = (): JSX.Element => {
+		const commonStyles: React.CSSProperties = {
+			color: Color.BG_SIENNA_400,
+			whiteSpace: 'pre-wrap',
+			tabSize: 4,
+		};
+
+		switch (record.field) {
+			case 'body':
+				return <span style={commonStyles} dangerouslySetInnerHTML={bodyHtml} />;
+
+			case 'timestamp':
+				return (
+					<span style={commonStyles}>
+						{formatTimestamp(cleanTimestamp, 'MM/DD/YYYY, HH:mm:ss.SSS (UTC Z)')}
+					</span>
+				);
+
+			default:
+				return (
+					<span style={commonStyles}>{removeEscapeCharacters(fieldData.value)}</span>
+				);
+		}
+	};
+
 	return (
 		<div className={cx('value-field', isOpen ? 'open-popover' : '')}>
-			{record.field === 'body' ? (
-				<CopyClipboardHOC entityKey={fieldFilterKey} textToCopy={textToCopy}>
-					<span
-						style={{
-							color: Color.BG_SIENNA_400,
-							whiteSpace: 'pre-wrap',
-							tabSize: 4,
-						}}
-						dangerouslySetInnerHTML={bodyHtml}
-					/>
-				</CopyClipboardHOC>
-			) : (
-				<CopyClipboardHOC entityKey={fieldFilterKey} textToCopy={textToCopy}>
-					<span
-						style={{
-							color: Color.BG_SIENNA_400,
-							whiteSpace: 'pre-wrap',
-							tabSize: 4,
-						}}
-					>
-						{removeEscapeCharacters(fieldData.value)}
-					</span>
-				</CopyClipboardHOC>
-			)}
-
+			<CopyClipboardHOC entityKey={fieldFilterKey} textToCopy={textToCopy}>
+				{renderFieldContent()}
+			</CopyClipboardHOC>
 			{!isListViewPanel && (
 				<span className="action-btn">
 					<Tooltip title="Filter for value">

--- a/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
+++ b/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
@@ -69,7 +69,7 @@ export function TableViewActions(
 
 	const [isOpen, setIsOpen] = useState<boolean>(false);
 
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	if (record.field === 'body') {
 		const parsedBody = recursiveParseJSON(fieldData.value);
@@ -122,7 +122,10 @@ export function TableViewActions(
 			case 'timestamp':
 				return (
 					<span style={commonStyles}>
-						{formatTimestamp(cleanTimestamp, 'MM/DD/YYYY, HH:mm:ss.SSS (UTC Z)')}
+						{formatTimezoneAdjustedTimestamp(
+							cleanTimestamp,
+							'MM/DD/YYYY, HH:mm:ss.SSS (UTC Z)',
+						)}
 					</span>
 				);
 

--- a/frontend/src/container/LogsPanelTable/LogsPanelComponent.tsx
+++ b/frontend/src/container/LogsPanelTable/LogsPanelComponent.tsx
@@ -77,11 +77,11 @@ function LogsPanelComponent({
 		});
 	};
 
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	const columns = getLogPanelColumnsList(
 		widget.selectedLogFields,
-		formatTimestamp,
+		formatTimezoneAdjustedTimestamp,
 	);
 
 	const dataLength =

--- a/frontend/src/container/LogsPanelTable/LogsPanelComponent.tsx
+++ b/frontend/src/container/LogsPanelTable/LogsPanelComponent.tsx
@@ -15,6 +15,7 @@ import { useLogsData } from 'hooks/useLogsData';
 import { GetQueryResultsProps } from 'lib/dashboard/getQueryResults';
 import { FlatLogData } from 'lib/logs/flatLogData';
 import { RowData } from 'lib/query/createTableColumnsFromQuery';
+import { useTimezone } from 'providers/Timezone';
 import {
 	Dispatch,
 	HTMLAttributes,
@@ -76,7 +77,12 @@ function LogsPanelComponent({
 		});
 	};
 
-	const columns = getLogPanelColumnsList(widget.selectedLogFields);
+	const { formatTimestamp } = useTimezone();
+
+	const columns = getLogPanelColumnsList(
+		widget.selectedLogFields,
+		formatTimestamp,
+	);
 
 	const dataLength =
 		queryResponse.data?.payload?.data?.newResult?.data?.result[0]?.list?.length;

--- a/frontend/src/container/LogsPanelTable/utils.tsx
+++ b/frontend/src/container/LogsPanelTable/utils.tsx
@@ -14,7 +14,10 @@ import { v4 as uuid } from 'uuid';
 
 export const getLogPanelColumnsList = (
 	selectedLogFields: Widgets['selectedLogFields'],
-	formatTimestamp: (input: TimestampInput, format?: string) => string,
+	formatTimezoneAdjustedTimestamp: (
+		input: TimestampInput,
+		format?: string,
+	) => string,
 ): ColumnsType<RowData> => {
 	const initialColumns: ColumnsType<RowData> = [];
 
@@ -30,7 +33,9 @@ export const getLogPanelColumnsList = (
 				render: (value: ReactNode): JSX.Element => {
 					if (name === 'timestamp') {
 						return (
-							<Typography.Text>{formatTimestamp(value as string)}</Typography.Text>
+							<Typography.Text>
+								{formatTimezoneAdjustedTimestamp(value as string)}
+							</Typography.Text>
 						);
 					}
 

--- a/frontend/src/container/LogsPanelTable/utils.tsx
+++ b/frontend/src/container/LogsPanelTable/utils.tsx
@@ -1,6 +1,7 @@
 import { ColumnsType } from 'antd/es/table';
 import { Typography } from 'antd/lib';
 import { OPERATORS } from 'constants/queryBuilder';
+import { TimestampInput } from 'hooks/useTimezoneFormatter/useTimezoneFormatter';
 // import Typography from 'antd/es/typography/Typography';
 import { RowData } from 'lib/query/createTableColumnsFromQuery';
 import { ReactNode } from 'react';
@@ -13,18 +14,26 @@ import { v4 as uuid } from 'uuid';
 
 export const getLogPanelColumnsList = (
 	selectedLogFields: Widgets['selectedLogFields'],
+	formatTimestamp: (input: TimestampInput, format?: string) => string,
 ): ColumnsType<RowData> => {
 	const initialColumns: ColumnsType<RowData> = [];
 
 	const columns: ColumnsType<RowData> =
 		selectedLogFields?.map((field: IField) => {
 			const { name } = field;
+
 			return {
 				title: name,
 				dataIndex: name,
 				key: name,
 				width: name === 'body' ? 350 : 100,
 				render: (value: ReactNode): JSX.Element => {
+					if (name === 'timestamp') {
+						return (
+							<Typography.Text>{formatTimestamp(value as string)}</Typography.Text>
+						);
+					}
+
 					if (name === 'body') {
 						return (
 							<Typography.Paragraph ellipsis={{ rows: 1 }} data-testid={name}>

--- a/frontend/src/container/PipelinePage/Layouts/ChangeHistory/DeploymentTime.tsx
+++ b/frontend/src/container/PipelinePage/Layouts/ChangeHistory/DeploymentTime.tsx
@@ -1,9 +1,14 @@
 import { useTimezone } from 'providers/Timezone';
 
 function DeploymentTime(deployTime: string): JSX.Element {
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 	return (
-		<span>{formatTimestamp(deployTime, 'MMMM DD, YYYY hh:mm A (UTC Z)')} </span>
+		<span>
+			{formatTimezoneAdjustedTimestamp(
+				deployTime,
+				'MMMM DD, YYYY hh:mm A (UTC Z)',
+			)}{' '}
+		</span>
 	);
 }
 

--- a/frontend/src/container/PipelinePage/Layouts/ChangeHistory/DeploymentTime.tsx
+++ b/frontend/src/container/PipelinePage/Layouts/ChangeHistory/DeploymentTime.tsx
@@ -1,8 +1,9 @@
-import dayjs from 'dayjs';
+import { useTimezone } from 'providers/Timezone';
 
 function DeploymentTime(deployTime: string): JSX.Element {
+	const { formatTimestamp } = useTimezone();
 	return (
-		<span>{dayjs(deployTime).locale('en').format('MMMM DD, YYYY hh:mm A')}</span>
+		<span>{formatTimestamp(deployTime, 'MMMM DD, YYYY hh:mm A (UTC Z)')} </span>
 	);
 }
 

--- a/frontend/src/container/PipelinePage/PipelineListsView/Preview/components/LogsList/index.tsx
+++ b/frontend/src/container/PipelinePage/PipelineListsView/Preview/components/LogsList/index.tsx
@@ -3,8 +3,8 @@ import './styles.scss';
 import { ExpandAltOutlined } from '@ant-design/icons';
 import LogDetail from 'components/LogDetail';
 import { VIEW_TYPES } from 'components/LogDetail/constants';
-import dayjs from 'dayjs';
 import { useActiveLog } from 'hooks/logs/useActiveLog';
+import { useTimezone } from 'providers/Timezone';
 import { ILog } from 'types/api/logs/log';
 
 function LogsList({ logs }: LogsListProps): JSX.Element {
@@ -18,12 +18,14 @@ function LogsList({ logs }: LogsListProps): JSX.Element {
 
 	const makeLogDetailsHandler = (log: ILog) => (): void => onSetActiveLog(log);
 
+	const { formatTimestamp } = useTimezone();
+
 	return (
 		<div className="logs-preview-list-container">
 			{logs.map((log) => (
 				<div key={log.id} className="logs-preview-list-item">
 					<div className="logs-preview-list-item-timestamp">
-						{dayjs(log.timestamp).format('MMM DD HH:mm:ss.SSS')}
+						{formatTimestamp(log.timestamp, 'MMM DD HH:mm:ss.SSS (UTC Z)')}
 					</div>
 					<div className="logs-preview-list-item-body">{log.body}</div>
 					<div

--- a/frontend/src/container/PipelinePage/PipelineListsView/Preview/components/LogsList/index.tsx
+++ b/frontend/src/container/PipelinePage/PipelineListsView/Preview/components/LogsList/index.tsx
@@ -18,14 +18,17 @@ function LogsList({ logs }: LogsListProps): JSX.Element {
 
 	const makeLogDetailsHandler = (log: ILog) => (): void => onSetActiveLog(log);
 
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	return (
 		<div className="logs-preview-list-container">
 			{logs.map((log) => (
 				<div key={log.id} className="logs-preview-list-item">
 					<div className="logs-preview-list-item-timestamp">
-						{formatTimestamp(log.timestamp, 'MMM DD HH:mm:ss.SSS (UTC Z)')}
+						{formatTimezoneAdjustedTimestamp(
+							log.timestamp,
+							'MMM DD HH:mm:ss.SSS (UTC Z)',
+						)}
 					</div>
 					<div className="logs-preview-list-item-body">{log.body}</div>
 					<div

--- a/frontend/src/container/PipelinePage/PipelineListsView/TableComponents/index.tsx
+++ b/frontend/src/container/PipelinePage/PipelineListsView/TableComponents/index.tsx
@@ -1,4 +1,4 @@
-import dayjs from 'dayjs';
+import { useTimezone } from 'providers/Timezone';
 import React from 'react';
 import { PipelineData, ProcessorData } from 'types/api/pipeline/def';
 
@@ -6,13 +6,18 @@ import { PipelineIndexIcon } from '../AddNewProcessor/styles';
 import { ColumnDataStyle, ListDataStyle, ProcessorIndexIcon } from '../styles';
 import PipelineFilterSummary from './PipelineFilterSummary';
 
+function CreatedAtComponent({ record }: { record: Record }): JSX.Element {
+	const { formatTimestamp } = useTimezone();
+	return (
+		<ColumnDataStyle>
+			{formatTimestamp(record, 'MMMM DD, YYYY hh:mm A (UTC Z)')}
+		</ColumnDataStyle>
+	);
+}
+
 const componentMap: ComponentMap = {
 	orderId: ({ record }) => <PipelineIndexIcon>{record}</PipelineIndexIcon>,
-	createdAt: ({ record }) => (
-		<ColumnDataStyle>
-			{dayjs(record).locale('en').format('MMMM DD, YYYY hh:mm A')}
-		</ColumnDataStyle>
-	),
+	createdAt: ({ record }) => <CreatedAtComponent record={record} />,
 	id: ({ record }) => <ProcessorIndexIcon>{record}</ProcessorIndexIcon>,
 	name: ({ record }) => <ListDataStyle>{record}</ListDataStyle>,
 	filter: ({ record }) => <PipelineFilterSummary filter={record} />,

--- a/frontend/src/container/PipelinePage/PipelineListsView/TableComponents/index.tsx
+++ b/frontend/src/container/PipelinePage/PipelineListsView/TableComponents/index.tsx
@@ -7,10 +7,10 @@ import { ColumnDataStyle, ListDataStyle, ProcessorIndexIcon } from '../styles';
 import PipelineFilterSummary from './PipelineFilterSummary';
 
 function CreatedAtComponent({ record }: { record: Record }): JSX.Element {
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 	return (
 		<ColumnDataStyle>
-			{formatTimestamp(record, 'MMMM DD, YYYY hh:mm A (UTC Z)')}
+			{formatTimezoneAdjustedTimestamp(record, 'MMMM DD, YYYY hh:mm A (UTC Z)')}
 		</ColumnDataStyle>
 	);
 }

--- a/frontend/src/container/TracesExplorer/ListView/index.tsx
+++ b/frontend/src/container/TracesExplorer/ListView/index.tsx
@@ -15,6 +15,7 @@ import useDragColumns from 'hooks/useDragColumns';
 import { getDraggedColumns } from 'hooks/useDragColumns/utils';
 import useUrlQueryData from 'hooks/useUrlQueryData';
 import { RowData } from 'lib/query/createTableColumnsFromQuery';
+import { useTimezone } from 'providers/Timezone';
 import { memo, useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { AppState } from 'store/reducers';
@@ -97,10 +98,15 @@ function ListView({ isFilterApplied }: ListViewProps): JSX.Element {
 		queryTableDataResult,
 	]);
 
+	const { formatTimestamp } = useTimezone();
+
 	const columns = useMemo(() => {
-		const updatedColumns = getListColumns(options?.selectColumns || []);
+		const updatedColumns = getListColumns(
+			options?.selectColumns || [],
+			formatTimestamp,
+		);
 		return getDraggedColumns(updatedColumns, draggedColumns);
-	}, [options?.selectColumns, draggedColumns]);
+	}, [options?.selectColumns, formatTimestamp, draggedColumns]);
 
 	const transformedQueryTableData = useMemo(
 		() => transformDataWithDate(queryTableData) || [],

--- a/frontend/src/container/TracesExplorer/ListView/index.tsx
+++ b/frontend/src/container/TracesExplorer/ListView/index.tsx
@@ -98,15 +98,15 @@ function ListView({ isFilterApplied }: ListViewProps): JSX.Element {
 		queryTableDataResult,
 	]);
 
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	const columns = useMemo(() => {
 		const updatedColumns = getListColumns(
 			options?.selectColumns || [],
-			formatTimestamp,
+			formatTimezoneAdjustedTimestamp,
 		);
 		return getDraggedColumns(updatedColumns, draggedColumns);
-	}, [options?.selectColumns, formatTimestamp, draggedColumns]);
+	}, [options?.selectColumns, formatTimezoneAdjustedTimestamp, draggedColumns]);
 
 	const transformedQueryTableData = useMemo(
 		() => transformDataWithDate(queryTableData) || [],

--- a/frontend/src/container/TracesExplorer/ListView/utils.tsx
+++ b/frontend/src/container/TracesExplorer/ListView/utils.tsx
@@ -3,7 +3,7 @@ import { ColumnsType } from 'antd/es/table';
 import ROUTES from 'constants/routes';
 import { getMs } from 'container/Trace/Filters/Panel/PanelBody/Duration/util';
 import { formUrlParams } from 'container/TraceDetail/utils';
-import dayjs from 'dayjs';
+import { TimestampInput } from 'hooks/useTimezoneFormatter/useTimezoneFormatter';
 import { RowData } from 'lib/query/createTableColumnsFromQuery';
 import { Link } from 'react-router-dom';
 import { ILog } from 'types/api/logs/log';
@@ -40,6 +40,7 @@ export const getTraceLink = (record: RowData): string =>
 
 export const getListColumns = (
 	selectedColumns: BaseAutocompleteData[],
+	formatTimestamp: (input: TimestampInput, format?: string) => string | number,
 ): ColumnsType<RowData> => {
 	const initialColumns: ColumnsType<RowData> = [
 		{
@@ -50,8 +51,8 @@ export const getListColumns = (
 			render: (value, item): JSX.Element => {
 				const date =
 					typeof value === 'string'
-						? dayjs(value).format('YYYY-MM-DD HH:mm:ss.SSS')
-						: dayjs(value / 1e6).format('YYYY-MM-DD HH:mm:ss.SSS');
+						? formatTimestamp(value, 'YYYY-MM-DD HH:mm:ss.SSS')
+						: formatTimestamp(value / 1e6, 'YYYY-MM-DD HH:mm:ss.SSS');
 				return (
 					<BlockLink to={getTraceLink(item)}>
 						<Typography.Text>{date}</Typography.Text>

--- a/frontend/src/container/TracesExplorer/ListView/utils.tsx
+++ b/frontend/src/container/TracesExplorer/ListView/utils.tsx
@@ -40,7 +40,10 @@ export const getTraceLink = (record: RowData): string =>
 
 export const getListColumns = (
 	selectedColumns: BaseAutocompleteData[],
-	formatTimestamp: (input: TimestampInput, format?: string) => string | number,
+	formatTimezoneAdjustedTimestamp: (
+		input: TimestampInput,
+		format?: string,
+	) => string | number,
 ): ColumnsType<RowData> => {
 	const initialColumns: ColumnsType<RowData> = [
 		{
@@ -51,8 +54,8 @@ export const getListColumns = (
 			render: (value, item): JSX.Element => {
 				const date =
 					typeof value === 'string'
-						? formatTimestamp(value, 'YYYY-MM-DD HH:mm:ss.SSS')
-						: formatTimestamp(value / 1e6, 'YYYY-MM-DD HH:mm:ss.SSS');
+						? formatTimezoneAdjustedTimestamp(value, 'YYYY-MM-DD HH:mm:ss.SSS')
+						: formatTimezoneAdjustedTimestamp(value / 1e6, 'YYYY-MM-DD HH:mm:ss.SSS');
 				return (
 					<BlockLink to={getTraceLink(item)}>
 						<Typography.Text>{date}</Typography.Text>

--- a/frontend/src/container/TracesTableComponent/TracesTableComponent.tsx
+++ b/frontend/src/container/TracesTableComponent/TracesTableComponent.tsx
@@ -15,6 +15,7 @@ import { Pagination } from 'hooks/queryPagination';
 import { GetQueryResultsProps } from 'lib/dashboard/getQueryResults';
 import history from 'lib/history';
 import { RowData } from 'lib/query/createTableColumnsFromQuery';
+import { useTimezone } from 'providers/Timezone';
 import {
 	Dispatch,
 	HTMLAttributes,
@@ -49,7 +50,12 @@ function TracesTableComponent({
 		}));
 	}, [pagination, setRequestData]);
 
-	const columns = getListColumns(widget.selectedTracesFields || []);
+	const { formatTimestamp } = useTimezone();
+
+	const columns = getListColumns(
+		widget.selectedTracesFields || [],
+		formatTimestamp,
+	);
 
 	const dataLength =
 		queryResponse.data?.payload?.data?.newResult?.data?.result[0]?.list?.length;

--- a/frontend/src/container/TracesTableComponent/TracesTableComponent.tsx
+++ b/frontend/src/container/TracesTableComponent/TracesTableComponent.tsx
@@ -50,11 +50,11 @@ function TracesTableComponent({
 		}));
 	}, [pagination, setRequestData]);
 
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	const columns = getListColumns(
 		widget.selectedTracesFields || [],
-		formatTimestamp,
+		formatTimezoneAdjustedTimestamp,
 	);
 
 	const dataLength =

--- a/frontend/src/container/TriggeredAlerts/FilteredTable/ExapandableRow.tsx
+++ b/frontend/src/container/TriggeredAlerts/FilteredTable/ExapandableRow.tsx
@@ -1,12 +1,12 @@
 import { Tag, Typography } from 'antd';
-import convertDateToAmAndPm from 'lib/convertDateToAmAndPm';
-import getFormattedDate from 'lib/getFormatedDate';
+import { useTimezone } from 'providers/Timezone';
 import { Alerts } from 'types/api/alerts/getTriggered';
 
 import Status from '../TableComponents/AlertStatus';
 import { TableCell, TableRow } from './styles';
 
 function ExapandableRow({ allAlerts }: ExapandableRowProps): JSX.Element {
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 	return (
 		<>
 			{allAlerts.map((alert) => {
@@ -40,8 +40,9 @@ function ExapandableRow({ allAlerts }: ExapandableRowProps): JSX.Element {
 						</TableCell>
 
 						<TableCell>
-							<Typography>{`${getFormattedDate(formatedDate)} ${convertDateToAmAndPm(
+							<Typography>{`${formatTimezoneAdjustedTimestamp(
 								formatedDate,
+								'MM/DD/YYYY hh:mm:ss A (UTC Z)',
 							)}`}</Typography>
 						</TableCell>
 

--- a/frontend/src/container/TriggeredAlerts/NoFilterTable.tsx
+++ b/frontend/src/container/TriggeredAlerts/NoFilterTable.tsx
@@ -4,8 +4,7 @@ import { ColumnsType } from 'antd/lib/table';
 import { ResizeTable } from 'components/ResizeTable';
 import LabelColumn from 'components/TableRenderer/LabelColumn';
 import AlertStatus from 'container/TriggeredAlerts/TableComponents/AlertStatus';
-import convertDateToAmAndPm from 'lib/convertDateToAmAndPm';
-import getFormattedDate from 'lib/getFormatedDate';
+import { useTimezone } from 'providers/Timezone';
 import { Alerts } from 'types/api/alerts/getTriggered';
 
 import { Value } from './Filter';
@@ -16,6 +15,7 @@ function NoFilterTable({
 	selectedFilter,
 }: NoFilterTableProps): JSX.Element {
 	const filteredAlerts = FilterAlerts(allAlerts, selectedFilter);
+	const { formatTimestamp } = useTimezone();
 
 	// need to add the filter
 	const columns: ColumnsType<Alerts> = [
@@ -83,15 +83,12 @@ function NoFilterTable({
 			width: 100,
 			sorter: (a, b): number =>
 				new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime(),
-			render: (date): JSX.Element => {
-				const formatedDate = new Date(date);
-
-				return (
-					<Typography>{`${getFormattedDate(formatedDate)} ${convertDateToAmAndPm(
-						formatedDate,
-					)}`}</Typography>
-				);
-			},
+			render: (date): JSX.Element => (
+				<Typography>{`${formatTimestamp(
+					date,
+					'MM/DD/YYYY hh:mm:ss A (UTC Z)',
+				)}`}</Typography>
+			),
 		},
 	];
 

--- a/frontend/src/container/TriggeredAlerts/NoFilterTable.tsx
+++ b/frontend/src/container/TriggeredAlerts/NoFilterTable.tsx
@@ -15,7 +15,7 @@ function NoFilterTable({
 	selectedFilter,
 }: NoFilterTableProps): JSX.Element {
 	const filteredAlerts = FilterAlerts(allAlerts, selectedFilter);
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	// need to add the filter
 	const columns: ColumnsType<Alerts> = [
@@ -84,7 +84,7 @@ function NoFilterTable({
 			sorter: (a, b): number =>
 				new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime(),
 			render: (date): JSX.Element => (
-				<Typography>{`${formatTimestamp(
+				<Typography>{`${formatTimezoneAdjustedTimestamp(
 					date,
 					'MM/DD/YYYY hh:mm:ss A (UTC Z)',
 				)}`}</Typography>

--- a/frontend/src/hooks/useTimezoneFormatter/useTimezoneFormatter.ts
+++ b/frontend/src/hooks/useTimezoneFormatter/useTimezoneFormatter.ts
@@ -26,7 +26,10 @@ function useTimezoneFormatter({
 }: {
 	userTimezone: Timezone;
 }): {
-	formatTimestamp: (input: TimestampInput, format?: string) => string;
+	formatTimezoneAdjustedTimestamp: (
+		input: TimestampInput,
+		format?: string,
+	) => string;
 } {
 	// Initialize cache using useMemo to persist between renders
 	const cache = useMemo(() => new Map<string, CacheEntry>(), []);
@@ -51,7 +54,7 @@ function useTimezoneFormatter({
 		sortedEntries.slice(0, entriesToRemove).forEach(([key]) => cache.delete(key));
 	}, [cache]);
 
-	const formatTimestamp = useCallback(
+	const formatTimezoneAdjustedTimestamp = useCallback(
 		(input: TimestampInput, format = 'YYYY-MM-DD HH:mm:ss'): string => {
 			const cacheKey = `${input}_${format}_${userTimezone?.value}`;
 
@@ -89,7 +92,7 @@ function useTimezoneFormatter({
 		[cache, clearExpiredEntries, userTimezone],
 	);
 
-	return { formatTimestamp };
+	return { formatTimezoneAdjustedTimestamp };
 }
 
 export default useTimezoneFormatter;

--- a/frontend/src/hooks/useTimezoneFormatter/useTimezoneFormatter.ts
+++ b/frontend/src/hooks/useTimezoneFormatter/useTimezoneFormatter.ts
@@ -1,0 +1,95 @@
+import { Timezone } from 'components/CustomTimePicker/timezoneUtils';
+import dayjs from 'dayjs';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+import { useCallback, useEffect, useMemo } from 'react';
+
+// Initialize dayjs plugins
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+// Types
+export type TimestampInput = string | number | Date;
+interface CacheEntry {
+	value: string;
+	timestamp: number;
+}
+
+//
+
+// Constants
+const CACHE_SIZE_LIMIT = 1000;
+const CACHE_CLEANUP_PERCENTAGE = 0.5; // Remove 50% when limit is reached
+
+function useTimezoneFormatter({
+	userTimezone,
+}: {
+	userTimezone: Timezone;
+}): {
+	formatTimestamp: (input: TimestampInput, format?: string) => string | number;
+} {
+	// Initialize cache using useMemo to persist between renders
+	const cache = useMemo(() => new Map<string, CacheEntry>(), []);
+
+	// Clear cache when timezone changes
+	useEffect(() => {
+		cache.clear();
+	}, [cache, userTimezone]);
+
+	const clearExpiredEntries = useCallback(() => {
+		if (cache.size <= CACHE_SIZE_LIMIT) return;
+
+		// Sort entries by timestamp (oldest first)
+		const sortedEntries = Array.from(cache.entries()).sort(
+			(a, b) => a[1].timestamp - b[1].timestamp,
+		);
+
+		// Calculate how many entries to remove
+		const entriesToRemove = Math.floor(cache.size * CACHE_CLEANUP_PERCENTAGE);
+
+		// Remove oldest entries
+		sortedEntries.slice(0, entriesToRemove).forEach(([key]) => cache.delete(key));
+	}, [cache]);
+
+	const formatTimestamp = useCallback(
+		(input: TimestampInput, format = 'YYYY-MM-DD HH:mm:ss'): string | number => {
+			const cacheKey = `${input}_${format}_${userTimezone?.value}`;
+
+			// Check cache first
+			const cachedValue = cache.get(cacheKey);
+			if (cachedValue) {
+				return cachedValue.value;
+			}
+			// Format timestamp
+			const formattedValue = dayjs(input).tz(userTimezone?.value).format(format);
+
+			// Update cache
+			cache.set(cacheKey, {
+				value: formattedValue,
+				timestamp: Date.now(),
+			});
+
+			// Clear expired entries and enforce size limit
+			if (cache.size > CACHE_SIZE_LIMIT) {
+				clearExpiredEntries();
+
+				// If still over limit, remove oldest entries
+				const entriesToDelete = cache.size - CACHE_SIZE_LIMIT;
+				if (entriesToDelete > 0) {
+					const entries = Array.from(cache.entries());
+					entries
+						.sort((a, b) => a[1].timestamp - b[1].timestamp)
+						.slice(0, entriesToDelete)
+						.forEach(([key]) => cache.delete(key));
+				}
+			}
+
+			return formattedValue;
+		},
+		[cache, clearExpiredEntries, userTimezone],
+	);
+
+	return { formatTimestamp };
+}
+
+export default useTimezoneFormatter;

--- a/frontend/src/hooks/useTimezoneFormatter/useTimezoneFormatter.ts
+++ b/frontend/src/hooks/useTimezoneFormatter/useTimezoneFormatter.ts
@@ -26,7 +26,7 @@ function useTimezoneFormatter({
 }: {
 	userTimezone: Timezone;
 }): {
-	formatTimestamp: (input: TimestampInput, format?: string) => string | number;
+	formatTimestamp: (input: TimestampInput, format?: string) => string;
 } {
 	// Initialize cache using useMemo to persist between renders
 	const cache = useMemo(() => new Map<string, CacheEntry>(), []);
@@ -52,7 +52,7 @@ function useTimezoneFormatter({
 	}, [cache]);
 
 	const formatTimestamp = useCallback(
-		(input: TimestampInput, format = 'YYYY-MM-DD HH:mm:ss'): string | number => {
+		(input: TimestampInput, format = 'YYYY-MM-DD HH:mm:ss'): string => {
 			const cacheKey = `${input}_${format}_${userTimezone?.value}`;
 
 			// Check cache first

--- a/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
+++ b/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
@@ -76,7 +76,7 @@ const generateTooltipContent = (
 				} else {
 					tooltipTitle = dayjs(data[0][idx] * 1000)
 						.tz(timezone)
-						.format('MMM DD YYYY HH:mm:ss');
+						.format('MMM DD YYYY h:mm:ss A');
 				}
 			} else if (item.show) {
 				const {

--- a/frontend/src/pages/SaveView/index.tsx
+++ b/frontend/src/pages/SaveView/index.tsx
@@ -208,7 +208,7 @@ function SaveView(): JSX.Element {
 		}
 	};
 
-	const { formatTimestamp } = useTimezone();
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	const columns: TableProps<ViewProps>['columns'] = [
 		{
@@ -221,7 +221,7 @@ function SaveView(): JSX.Element {
 					bgColor = extraData.color;
 				}
 
-				const formattedDateAndTime = formatTimestamp(
+				const formattedDateAndTime = formatTimezoneAdjustedTimestamp(
 					view.createdAt,
 					'HH:mm:ss ⎯ MMM D, YYYY (UTC Z)',
 				);

--- a/frontend/src/pages/SaveView/index.tsx
+++ b/frontend/src/pages/SaveView/index.tsx
@@ -31,6 +31,7 @@ import {
 	Trash2,
 	X,
 } from 'lucide-react';
+import { useTimezone } from 'providers/Timezone';
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -207,6 +208,8 @@ function SaveView(): JSX.Element {
 		}
 	};
 
+	const { formatTimestamp } = useTimezone();
+
 	const columns: TableProps<ViewProps>['columns'] = [
 		{
 			title: 'Save View',
@@ -218,31 +221,10 @@ function SaveView(): JSX.Element {
 					bgColor = extraData.color;
 				}
 
-				const timeOptions: Intl.DateTimeFormatOptions = {
-					hour: '2-digit',
-					minute: '2-digit',
-					second: '2-digit',
-					hour12: false,
-				};
-				const formattedTime = new Date(view.createdAt).toLocaleTimeString(
-					'en-US',
-					timeOptions,
+				const formattedDateAndTime = formatTimestamp(
+					view.createdAt,
+					'HH:mm:ss ⎯ MMM D, YYYY (UTC Z)',
 				);
-
-				const dateOptions: Intl.DateTimeFormatOptions = {
-					month: 'short',
-					day: 'numeric',
-					year: 'numeric',
-				};
-
-				const formattedDate = new Date(view.createdAt).toLocaleDateString(
-					'en-US',
-					dateOptions,
-				);
-
-				// Combine time and date
-				const formattedDateAndTime = `${formattedTime} ⎯ ${formattedDate}`;
-
 				const isEditDeleteSupported = allowedRoles.includes(role as string);
 
 				return (

--- a/frontend/src/providers/Timezone.tsx
+++ b/frontend/src/providers/Timezone.tsx
@@ -19,7 +19,7 @@ interface TimezoneContextType {
 	timezone: Timezone;
 	browserTimezone: Timezone;
 	updateTimezone: (timezone: Timezone) => void;
-	formatTimestamp: (input: TimestampInput, format?: string) => string | number;
+	formatTimestamp: (input: TimestampInput, format?: string) => string;
 }
 
 const TimezoneContext = createContext<TimezoneContextType | undefined>(

--- a/frontend/src/providers/Timezone.tsx
+++ b/frontend/src/providers/Timezone.tsx
@@ -19,7 +19,10 @@ interface TimezoneContextType {
 	timezone: Timezone;
 	browserTimezone: Timezone;
 	updateTimezone: (timezone: Timezone) => void;
-	formatTimestamp: (input: TimestampInput, format?: string) => string;
+	formatTimezoneAdjustedTimestamp: (
+		input: TimestampInput,
+		format?: string,
+	) => string;
 }
 
 const TimezoneContext = createContext<TimezoneContextType | undefined>(
@@ -63,16 +66,18 @@ function TimezoneProvider({
 		setTimezone(timezone);
 	}, []);
 
-	const { formatTimestamp } = useTimezoneFormatter({ userTimezone: timezone });
+	const { formatTimezoneAdjustedTimestamp } = useTimezoneFormatter({
+		userTimezone: timezone,
+	});
 
 	const value = React.useMemo(
 		() => ({
 			timezone,
 			browserTimezone,
 			updateTimezone,
-			formatTimestamp,
+			formatTimezoneAdjustedTimestamp,
 		}),
-		[timezone, browserTimezone, updateTimezone, formatTimestamp],
+		[timezone, browserTimezone, updateTimezone, formatTimezoneAdjustedTimestamp],
 	);
 
 	return (

--- a/frontend/src/providers/Timezone.tsx
+++ b/frontend/src/providers/Timezone.tsx
@@ -4,6 +4,9 @@ import {
 	Timezone,
 } from 'components/CustomTimePicker/timezoneUtils';
 import { LOCALSTORAGE } from 'constants/localStorage';
+import useTimezoneFormatter, {
+	TimestampInput,
+} from 'hooks/useTimezoneFormatter/useTimezoneFormatter';
 import React, {
 	createContext,
 	useCallback,
@@ -16,6 +19,7 @@ interface TimezoneContextType {
 	timezone: Timezone;
 	browserTimezone: Timezone;
 	updateTimezone: (timezone: Timezone) => void;
+	formatTimestamp: (input: TimestampInput, format?: string) => string | number;
 }
 
 const TimezoneContext = createContext<TimezoneContextType | undefined>(
@@ -59,13 +63,16 @@ function TimezoneProvider({
 		setTimezone(timezone);
 	}, []);
 
+	const { formatTimestamp } = useTimezoneFormatter({ userTimezone: timezone });
+
 	const value = React.useMemo(
 		() => ({
 			timezone,
 			browserTimezone,
 			updateTimezone,
+			formatTimestamp,
 		}),
-		[timezone, browserTimezone, updateTimezone],
+		[timezone, browserTimezone, updateTimezone, formatTimestamp],
 	);
 
 	return (


### PR DESCRIPTION
### Summary

## Apply timezone support to Tabular Data
### Traces explorer

- Explorer
  - List view
    - [x] timestamp
- Views
  - List
    - [x] created at

### Logs explorer

- List View
  - [x] Raw -> timestamp
  - Columns
    - [x] for each column, check the data type (i.e. if it's timestamp, display the timestamp based on the specified timezone) (inside `useTableView`) [note: I checked all the columns, it seems that we don't get timestamp for any other column, added timezone support to the timestamp column]
  - Default
    - [x] display the timestamp based on the specified timezone (inside `ListLogView`)
    -  Log field (similar to Raw, timestamp is inside the text) [note: for displaying the timezone adjusted timestamp we need to parse the timestamp, skipping this for now]
- Pipelines
  - Pipelines Tab
    - List
      - [x] Last Edited
    - Details
      - [x] Timestamp
      - [x] Processed Output
  - Change History
    - [x] Last Deployed Time
- Views
  - List
    - [x] time
- Log details
  - [x] check if we can apply timezone dynamically to the date/time values [note: Applied timezone adjustment to timestamp field]

### Dashboard

- Listing Page
  - [x] Dashboard date
  - [x] Edit metadata modal
- Panel types (Details page ) :
  - Table [note: I couldn't find a case where we get timestamp for any columns]
- Panel types (New Panel) :
  - Table [note: I couldn't find a case where we get timestamp for any columns]
- Panel types (Edit Panel) :
  - Table [note: I couldn't find a case where we get timestamp for any columns]

### Alerts

- Triggered Alerts List
  - [x] Firing Since
- Alert Rules List
  - [x] Created At
  - [x] Updated At
- Alert Details
  - Alert History Tab
    - [x] Timeline Table
      - [x] Created At

### Exceptions

- List

  - [x] First seen
  - [x] Last seen

- Details page
  - [x] Date

### Licenses

- History
  - [x] Valid from
  - [x] Valid Until
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
Part of https://github.com/SigNoz/engineering-pod/issues/2005
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces timezone-based formatting for date/time displays across the app using a new `formatTimestamp` function.
> 
>   - **Behavior**:
>     - Introduces `formatTimestamp` function in `useTimezone` hook for timezone-based timestamp formatting.
>     - Replaces `dayjs` formatting with `formatTimestamp` in components like `ListLogView`, `RawLogView`, `TableView`, and others.
>     - Updates timestamp rendering in tables, logs, and alerts to use `formatTimestamp`.
>   - **Components**:
>     - `CustomTimePicker`, `LogsPanelComponent`, `TracesTableComponent`, `SaveView`, and others now use `formatTimestamp` for date/time display.
>     - `useTimezoneFormatter` hook added to handle timezone-based formatting with caching.
>   - **Misc**:
>     - Removes direct `dayjs` usage for timestamp formatting in favor of `formatTimestamp`.
>     - Updates `TimezoneProvider` to include `formatTimestamp` in its context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for a7da3f349c1b580a9ae61fdf266fb9df25339af7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->