### PR TITLE
feat: add timezone support to ingestion settings list page and alerts page when groupe filter is applied

### DIFF
--- a/frontend/src/container/TriggeredAlerts/FilteredTable/ExapandableRow.tsx
+++ b/frontend/src/container/TriggeredAlerts/FilteredTable/ExapandableRow.tsx
@@ -1,12 +1,12 @@
 import { Tag, Typography } from 'antd';
-import convertDateToAmAndPm from 'lib/convertDateToAmAndPm';
-import getFormattedDate from 'lib/getFormatedDate';
+import { useTimezone } from 'providers/Timezone';
 import { Alerts } from 'types/api/alerts/getTriggered';
 
 import Status from '../TableComponents/AlertStatus';
 import { TableCell, TableRow } from './styles';
 
 function ExapandableRow({ allAlerts }: ExapandableRowProps): JSX.Element {
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 	return (
 		<>
 			{allAlerts.map((alert) => {
@@ -40,8 +40,9 @@ function ExapandableRow({ allAlerts }: ExapandableRowProps): JSX.Element {
 						</TableCell>
 
 						<TableCell>
-							<Typography>{`${getFormattedDate(formatedDate)} ${convertDateToAmAndPm(
+							<Typography>{`${formatTimezoneAdjustedTimestamp(
 								formatedDate,
+								'MM/DD/YYYY hh:mm:ss A (UTC Z)',
 							)}`}</Typography>
 						</TableCell>
 


### PR DESCRIPTION
### Summary
- [x] Add timezone support to ingestion settings list page
- [x] Add timezone support to triggered alerts page when groupe filter is applied
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
Part of https://github.com/SigNoz/engineering-pod/issues/2005
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
##### Ingestion settings
- Before
![Screenshot from 2024-12-02 14-11-37](https://github.com/user-attachments/assets/746da60a-b9cb-4f8c-a43d-0ccdb080b9a6)

- After
![Screenshot from 2024-12-02 14-11-08](https://github.com/user-attachments/assets/286540e3-1208-4b79-ba94-39048e17be29)

##### Triggered alerts
- Before
![Screenshot from 2024-12-02 14-12-31](https://github.com/user-attachments/assets/54c872c5-5c36-41c5-b5a7-2dafac89ce55)

- After
![Screenshot from 2024-12-02 14-12-41](https://github.com/user-attachments/assets/a7cecdab-ec02-4972-803f-e664540c11f8)


<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
