### PR TITLE
chore: make the entire row clickable in logs quick filters

### DIFF
--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.styles.scss
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.styles.scss
@@ -8,6 +8,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
+		cursor: pointer;
 
 		.left-action {
 			display: flex;

--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.tsx
@@ -396,23 +396,22 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 
 	return (
 		<div className="checkbox-filter">
-			<section className="filter-header-checkbox">
+			<section
+				className="filter-header-checkbox"
+				onClick={(): void => {
+					if (isOpen) {
+						setIsOpen(false);
+						setVisibleItemsCount(10);
+					} else {
+						setIsOpen(true);
+					}
+				}}
+			>
 				<section className="left-action">
 					{isOpen ? (
-						<ChevronDown
-							size={13}
-							cursor="pointer"
-							onClick={(): void => {
-								setIsOpen(false);
-								setVisibleItemsCount(10);
-							}}
-						/>
+						<ChevronDown size={13} cursor="pointer" />
 					) : (
-						<ChevronRight
-							size={13}
-							onClick={(): void => setIsOpen(true)}
-							cursor="pointer"
-						/>
+						<ChevronRight size={13} cursor="pointer" />
 					)}
 					<Typography.Text className="title">{filter.title}</Typography.Text>
 				</section>
@@ -420,7 +419,11 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 					{isOpen && (
 						<Typography.Text
 							className="clear-all"
-							onClick={handleClearFilterAttribute}
+							onClick={(e): void => {
+								e.stopPropagation();
+								e.preventDefault();
+								handleClearFilterAttribute();
+							}}
 						>
 							Clear All
 						</Typography.Text>


### PR DESCRIPTION
### Summary

- currently only the chevron icon was clickable to expand and collpase the quick filters in logs. 
- made the entire row clickable for expand and collapse for better experience 

#### Related Issues / PR's

contributes to - https://github.com/SigNoz/signoz/issues/6572

#### Screenshots


https://github.com/user-attachments/assets/886913fa-dc5a-4d05-bc21-16aeb8f58c7b



#### Affected Areas and Manually Tested Areas

- quick filters in logs 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make entire row clickable for expand/collapse in logs quick filters, enhancing user experience.
> 
>   - **Behavior**:
>     - Entire row in `filter-header-checkbox` is now clickable for expand/collapse in `Checkbox.tsx`.
>     - `Clear All` button click event now stops propagation to prevent row toggle.
>   - **Styles**:
>     - Added `cursor: pointer` to `.filter-header-checkbox` in `Checkbox.styles.scss` to indicate clickable area.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 2de8dacb37d19afdfca1d8c3bdab81ee1baf4994. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->