### PR TITLE
chore: replace the 'Get started' CTA with 'New source'

### DIFF
--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -16,7 +16,7 @@ import history from 'lib/history';
 import {
 	AlertTriangle,
 	CheckSquare,
-	RocketIcon,
+	PackagePlus,
 	UserCircle,
 } from 'lucide-react';
 import { MouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
@@ -395,9 +395,9 @@ function SideNav({
 								onClickGetStarted(event);
 							}}
 						>
-							<RocketIcon size={16} />
+							<PackagePlus size={16} />
 
-							<div className="license tag nav-item-label"> Get Started </div>
+							<div className="license tag nav-item-label"> New source </div>
 						</Button>
 					</div>
 				)}


### PR DESCRIPTION
### Summary

Replaced the "Get started" CTA with "New source" in the onboarding flow.

#### Related Issues / PR's

#6535 

#### Screenshots

<img width="335" alt="Screenshot 2024-12-05 at 12 44 31 PM" src="https://github.com/user-attachments/assets/2e0ffa52-bd2f-4b0e-9121-42fd29cdd332">

#### Affected Areas and Manually Tested Areas

Only modified at a single place (button) in the onboarding flow.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaces 'Get started' with 'New source' in `SideNav.tsx`, updating button text, icon, localization, styles, and tests.
> 
>   - **Behavior**:
>     - Replaces "Get started" button text with "New source" in `SideNav.tsx`.
>     - Updates button icon to `PackagePlus` in `SideNav.tsx`.
>   - **Localization**:
>     - Adds `"new_source": "New source"` to `onboarding.json`.
>   - **Styles**:
>     - Adjusts button alignment in `.continue-to-next-step` in `Onboarding.styles.scss`.
>   - **Tests**:
>     - Updates `InviteUserFlow.test.tsx` to check for "new_source" button text.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 8c6225185daadf0f5f24d0dc6319619264760ee7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->