### PR TITLE
fix: enable smart trace detail

### DIFF
--- a/ee/query-service/app/api/traces.go
+++ b/ee/query-service/app/api/traces.go
@@ -2,31 +2,32 @@ package api
 
 import (
 	"net/http"
+
+	"go.signoz.io/signoz/ee/query-service/app/db"
+	"go.signoz.io/signoz/ee/query-service/model"
+	baseapp "go.signoz.io/signoz/pkg/query-service/app"
+	basemodel "go.signoz.io/signoz/pkg/query-service/model"
+	"go.uber.org/zap"
 )
 
 func (ah *APIHandler) searchTraces(w http.ResponseWriter, r *http.Request) {
 
-	ah.APIHandler.SearchTraces(w, r)
-	return
+	if !ah.CheckFeature(basemodel.SmartTraceDetail) {
+		zap.L().Info("SmartTraceDetail feature is not enabled in this plan")
+		ah.APIHandler.SearchTraces(w, r)
+		return
+	}
+	searchTracesParams, err := baseapp.ParseSearchTracesParams(r)
+	if err != nil {
+		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, "Error reading params")
+		return
+	}
 
-	// This is commented since this will be taken care by new trace API
+	result, err := ah.opts.DataConnector.SearchTraces(r.Context(), searchTracesParams, db.SmartTraceAlgorithm)
+	if ah.HandleError(w, err, http.StatusBadRequest) {
+		return
+	}
 
-	// if !ah.CheckFeature(basemodel.SmartTraceDetail) {
-	// 	zap.L().Info("SmartTraceDetail feature is not enabled in this plan")
-	// 	ah.APIHandler.SearchTraces(w, r)
-	// 	return
-	// }
-	// searchTracesParams, err := baseapp.ParseSearchTracesParams(r)
-	// if err != nil {
-	// 	RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, "Error reading params")
-	// 	return
-	// }
-
-	// result, err := ah.opts.DataConnector.SearchTraces(r.Context(), searchTracesParams, db.SmartTraceAlgorithm)
-	// if ah.HandleError(w, err, http.StatusBadRequest) {
-	// 	return
-	// }
-
-	// ah.WriteJSON(w, r, result)
+	ah.WriteJSON(w, r, result)
 
 }


### PR DESCRIPTION
I disabled the smart trace detail thinking that it won't be used and we were working on a different version of trace detail, but seems like it's controlled thorugh a feature flag.

since the new detail is not being worked upon enabling it back.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-enables smart trace detail in `searchTraces()` in `traces.go`, controlled by a feature flag, with error handling improvements.
> 
>   - **Behavior**:
>     - Re-enables smart trace detail in `searchTraces()` in `traces.go`.
>     - Checks `SmartTraceDetail` feature flag; if disabled, logs info and defaults to standard trace search.
>     - If enabled, parses search parameters and uses `SmartTraceAlgorithm` for trace search.
>   - **Error Handling**:
>     - Logs error and returns bad request if parameter parsing fails.
>     - Handles errors from `SearchTraces` and returns appropriate HTTP status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 475db3df5700f4849d02cc42f49272cad1aaf604. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->