### PR TITLE
fix: resolve unnecessary refetching of graphs on service details page

### DIFF
--- a/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
@@ -145,41 +145,49 @@ function Application(): JSX.Element {
 		[servicename, topLevelOperations],
 	);
 
-	const operationPerSecWidget = getWidgetQueryBuilder({
-		query: {
-			queryType: EQueryType.QUERY_BUILDER,
-			promql: [],
-			builder: operationPerSec({
-				servicename,
-				tagFilterItems,
-				topLevelOperations: topLevelOperationsRoute,
+	const operationPerSecWidget = useMemo(
+		() =>
+			getWidgetQueryBuilder({
+				query: {
+					queryType: EQueryType.QUERY_BUILDER,
+					promql: [],
+					builder: operationPerSec({
+						servicename,
+						tagFilterItems,
+						topLevelOperations: topLevelOperationsRoute,
+					}),
+					clickhouse_sql: [],
+					id: uuid(),
+				},
+				title: GraphTitle.RATE_PER_OPS,
+				panelTypes: PANEL_TYPES.TIME_SERIES,
+				yAxisUnit: 'ops',
+				id: SERVICE_CHART_ID.rps,
 			}),
-			clickhouse_sql: [],
-			id: uuid(),
-		},
-		title: GraphTitle.RATE_PER_OPS,
-		panelTypes: PANEL_TYPES.TIME_SERIES,
-		yAxisUnit: 'ops',
-		id: SERVICE_CHART_ID.rps,
-	});
+		[servicename, tagFilterItems, topLevelOperationsRoute],
+	);
 
-	const errorPercentageWidget = getWidgetQueryBuilder({
-		query: {
-			queryType: EQueryType.QUERY_BUILDER,
-			promql: [],
-			builder: errorPercentage({
-				servicename,
-				tagFilterItems,
-				topLevelOperations: topLevelOperationsRoute,
+	const errorPercentageWidget = useMemo(
+		() =>
+			getWidgetQueryBuilder({
+				query: {
+					queryType: EQueryType.QUERY_BUILDER,
+					promql: [],
+					builder: errorPercentage({
+						servicename,
+						tagFilterItems,
+						topLevelOperations: topLevelOperationsRoute,
+					}),
+					clickhouse_sql: [],
+					id: uuid(),
+				},
+				title: GraphTitle.ERROR_PERCENTAGE,
+				panelTypes: PANEL_TYPES.TIME_SERIES,
+				yAxisUnit: '%',
+				id: SERVICE_CHART_ID.errorPercentage,
 			}),
-			clickhouse_sql: [],
-			id: uuid(),
-		},
-		title: GraphTitle.ERROR_PERCENTAGE,
-		panelTypes: PANEL_TYPES.TIME_SERIES,
-		yAxisUnit: '%',
-		id: SERVICE_CHART_ID.errorPercentage,
-	});
+		[servicename, tagFilterItems, topLevelOperationsRoute],
+	);
 
 	const stepInterval = useMemo(
 		() =>

--- a/frontend/src/container/MetricsApplication/Tabs/Overview/ServiceOverview.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview/ServiceOverview.tsx
@@ -53,24 +53,28 @@ function ServiceOverview({
 		[isSpanMetricEnable, queries],
 	);
 
-	const latencyWidget = getWidgetQueryBuilder({
-		query: {
-			queryType: EQueryType.QUERY_BUILDER,
-			promql: [],
-			builder: latency({
-				servicename,
-				tagFilterItems,
-				isSpanMetricEnable,
-				topLevelOperationsRoute,
+	const latencyWidget = useMemo(
+		() =>
+			getWidgetQueryBuilder({
+				query: {
+					queryType: EQueryType.QUERY_BUILDER,
+					promql: [],
+					builder: latency({
+						servicename,
+						tagFilterItems,
+						isSpanMetricEnable,
+						topLevelOperationsRoute,
+					}),
+					clickhouse_sql: [],
+					id: uuid(),
+				},
+				title: GraphTitle.LATENCY,
+				panelTypes: PANEL_TYPES.TIME_SERIES,
+				yAxisUnit: 'ns',
+				id: SERVICE_CHART_ID.latency,
 			}),
-			clickhouse_sql: [],
-			id: uuid(),
-		},
-		title: GraphTitle.LATENCY,
-		panelTypes: PANEL_TYPES.TIME_SERIES,
-		yAxisUnit: 'ns',
-		id: SERVICE_CHART_ID.latency,
-	});
+		[isSpanMetricEnable, servicename, tagFilterItems, topLevelOperationsRoute],
+	);
 
 	const isQueryEnabled =
 		!topLevelOperationsIsLoading && topLevelOperationsRoute.length > 0;


### PR DESCRIPTION
### Summary

If we were clicking on 1 graph, it was causing rerenders of the other graphs as well. That was happening because of `operationPerSecWidget`, `errorPercentageWidget` and `latencyWidget` widgets. Inside their functions, a new `uuid()` call was being made every time, due to which the props being passed to the child components were changing everytime, hence causing rerenders.
Fixed that by wrapping these functions with `useMemo`.

#### Related Issues / PR's

#6111 

#### Screenshots

https://github.com/user-attachments/assets/420e4437-13ea-430e-b249-d879e1950b74

#### Affected Areas and Manually Tested Areas

Service Details page
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize widget rendering on service details page using `useMemo` to prevent unnecessary re-renders.
> 
>   - **Optimization**:
>     - Use `useMemo` for `operationPerSecWidget`, `errorPercentageWidget` in `Overview.tsx` to prevent unnecessary re-renders.
>     - Use `useMemo` for `latencyWidget` in `ServiceOverview.tsx` to prevent unnecessary re-renders.
>   - **Behavior**:
>     - Prevents all graphs from re-rendering when one is clicked by stabilizing widget props.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for d0d6eb98078284259de0692a6d0de58970f67f04. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->