### PR TITLE
fix: fix count aggregate attribute column name

### DIFF
--- a/pkg/query-service/app/traces/v4/query_builder.go
+++ b/pkg/query-service/app/traces/v4/query_builder.go
@@ -355,8 +355,9 @@ func buildTracesQuery(start, end, step int64, mq *v3.BuilderQuery, panelType v3.
 					filterSubQuery = fmt.Sprintf("%s AND %s", filterSubQuery, subQuery)
 				}
 			} else {
-				column := getColumnName(mq.AggregateAttribute)
-				filterSubQuery = fmt.Sprintf("%s AND has(%s, '%s')", filterSubQuery, column, mq.AggregateAttribute.Key)
+				cType := getClickHouseTracesColumnType(mq.AggregateAttribute.Type)
+				cDataType := getClickHouseTracesColumnDataType(mq.AggregateAttribute.DataType)
+				filterSubQuery = fmt.Sprintf("%s AND mapContains(%s_%s, '%s')", filterSubQuery, cType, cDataType, mq.AggregateAttribute.Key)
 			}
 		}
 		op := "toFloat64(count())"

--- a/pkg/query-service/app/traces/v4/query_builder_test.go
+++ b/pkg/query-service/app/traces/v4/query_builder_test.go
@@ -480,6 +480,34 @@ func Test_buildTracesQuery(t *testing.T) {
 				"group by `http.method` order by `http.method` ASC",
 		},
 		{
+			name: "Test buildTracesQuery - count with mat attr",
+			args: args{
+				panelType: v3.PanelTypeTable,
+				start:     1680066360726210000,
+				end:       1680066458000000000,
+				step:      1000,
+				mq: &v3.BuilderQuery{
+					AggregateOperator:  v3.AggregateOperatorCount,
+					AggregateAttribute: v3.AttributeKey{Key: "name", DataType: v3.AttributeKeyDataTypeString, Type: v3.AttributeKeyTypeTag, IsColumn: true},
+					Filters: &v3.FilterSet{
+						Items: []v3.FilterItem{
+							{
+								Key:      v3.AttributeKey{Key: "http.method", DataType: v3.AttributeKeyDataTypeString, Type: v3.AttributeKeyTypeTag},
+								Value:    100,
+								Operator: v3.FilterOperatorEqual,
+							},
+						},
+					},
+					GroupBy: []v3.AttributeKey{{Key: "http.method", DataType: v3.AttributeKeyDataTypeString, Type: v3.AttributeKeyTypeTag}},
+					OrderBy: []v3.OrderBy{
+						{ColumnName: "http.method", Order: "ASC"}},
+				},
+			},
+			want: "SELECT  attributes_string['http.method'] as `http.method`, toFloat64(count()) as value from signoz_traces.distributed_signoz_index_v3 where (timestamp >= '1680066360726210000' AND timestamp <= '1680066458000000000') " +
+				"AND (ts_bucket_start >= 1680064560 AND ts_bucket_start <= 1680066458) AND attributes_string['http.method'] = '100' AND mapContains(attributes_string, 'http.method') AND name != '' " +
+				"group by `http.method` order by `http.method` ASC",
+		},
+		{
 			name: "Test buildTracesQuery",
 			args: args{
 				panelType: v3.PanelTypeTable,

--- a/pkg/query-service/app/traces/v4/query_builder_test.go
+++ b/pkg/query-service/app/traces/v4/query_builder_test.go
@@ -452,6 +452,34 @@ func Test_buildTracesQuery(t *testing.T) {
 				"group by `http.method` order by `http.method` ASC",
 		},
 		{
+			name: "Test buildTracesQuery - count with attr",
+			args: args{
+				panelType: v3.PanelTypeTable,
+				start:     1680066360726210000,
+				end:       1680066458000000000,
+				step:      1000,
+				mq: &v3.BuilderQuery{
+					AggregateOperator:  v3.AggregateOperatorCount,
+					AggregateAttribute: v3.AttributeKey{Key: "name", DataType: v3.AttributeKeyDataTypeString, Type: v3.AttributeKeyTypeTag},
+					Filters: &v3.FilterSet{
+						Items: []v3.FilterItem{
+							{
+								Key:      v3.AttributeKey{Key: "http.method", DataType: v3.AttributeKeyDataTypeString, Type: v3.AttributeKeyTypeTag},
+								Value:    100,
+								Operator: v3.FilterOperatorEqual,
+							},
+						},
+					},
+					GroupBy: []v3.AttributeKey{{Key: "http.method", DataType: v3.AttributeKeyDataTypeString, Type: v3.AttributeKeyTypeTag}},
+					OrderBy: []v3.OrderBy{
+						{ColumnName: "http.method", Order: "ASC"}},
+				},
+			},
+			want: "SELECT  attributes_string['http.method'] as `http.method`, toFloat64(count()) as value from signoz_traces.distributed_signoz_index_v3 where (timestamp >= '1680066360726210000' AND timestamp <= '1680066458000000000') " +
+				"AND (ts_bucket_start >= 1680064560 AND ts_bucket_start <= 1680066458) AND attributes_string['http.method'] = '100' AND mapContains(attributes_string, 'http.method') AND mapContains(attributes_string, 'name') " +
+				"group by `http.method` order by `http.method` ASC",
+		},
+		{
 			name: "Test buildTracesQuery",
 			args: args{
 				panelType: v3.PanelTypeTable,

--- a/pkg/query-service/rules/threshold_rule.go
+++ b/pkg/query-service/rules/threshold_rule.go
@@ -73,8 +73,9 @@ func NewThresholdRule(
 	}
 
 	t := ThresholdRule{
-		BaseRule: baseRule,
-		version:  p.Version,
+		BaseRule:          baseRule,
+		version:           p.Version,
+		useTraceNewSchema: useTraceNewSchema,
 	}
 
 	querierOption := querier.QuerierOptions{


### PR DESCRIPTION
* previous thqe query becomes `has(attributes_string['attr'], 'attr')` . Fixed it to `mapContains(attributes_string, 'attr')`
* encrich v4 was not called for threshold rule, fixed it

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes query logic in `buildTracesQuery` to use `mapContains()` for attribute existence checks, with updated tests.
> 
>   - **Behavior**:
>     - Fixes query logic in `buildTracesQuery` in `query_builder.go` to use `mapContains()` instead of `has()` for checking attribute existence.
>     - Ensures correct handling of `AggregateAttribute` in trace queries.
>   - **Tests**:
>     - Adds test case in `query_builder_test.go` to verify `mapContains()` usage for attribute existence checks in `buildTracesQuery`.
>   - **Misc**:
>     - Adds `useTraceNewSchema` field to `ThresholdRule` in `threshold_rule.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for fe1ba76374761bb3b8f7f1d9404145df0afa7873. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->