### PR TITLE
fix(Traces Explorer): prevent duplicate API calls to query_range in traces explorer

### DIFF
--- a/frontend/src/container/TracesExplorer/ListView/index.tsx
+++ b/frontend/src/container/TracesExplorer/ListView/index.tsx
@@ -7,10 +7,12 @@ import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import EmptyLogsSearch from 'container/EmptyLogsSearch/EmptyLogsSearch';
 import NoLogs from 'container/NoLogs/NoLogs';
 import { useOptionsMenu } from 'container/OptionsMenu';
+import { CustomTimeType } from 'container/TopNav/DateTimeSelectionV2/config';
 import TraceExplorerControls from 'container/TracesExplorer/Controls';
 import { useGetQueryRange } from 'hooks/queryBuilder/useGetQueryRange';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { Pagination } from 'hooks/queryPagination';
+import { getDefaultPaginationConfig } from 'hooks/queryPagination/utils';
 import useDragColumns from 'hooks/useDragColumns';
 import { getDraggedColumns } from 'hooks/useDragColumns/utils';
 import useUrlQueryData from 'hooks/useUrlQueryData';
@@ -31,12 +33,19 @@ interface ListViewProps {
 }
 
 function ListView({ isFilterApplied }: ListViewProps): JSX.Element {
-	const { stagedQuery, panelType } = useQueryBuilder();
+	const {
+		stagedQuery,
+		panelType: panelTypeFromQueryBuilder,
+	} = useQueryBuilder();
 
-	const { selectedTime: globalSelectedTime, maxTime, minTime } = useSelector<
-		AppState,
-		GlobalReducer
-	>((state) => state.globalTime);
+	const panelType = panelTypeFromQueryBuilder || PANEL_TYPES.LIST;
+
+	const {
+		selectedTime: globalSelectedTime,
+		maxTime,
+		minTime,
+		loading: timeRangeUpdateLoading,
+	} = useSelector<AppState, GlobalReducer>((state) => state.globalTime);
 
 	const { options, config } = useOptionsMenu({
 		storageKey: LOCALSTORAGE.TRACES_LIST_OPTIONS,
@@ -54,34 +63,51 @@ function ListView({ isFilterApplied }: ListViewProps): JSX.Element {
 	const { queryData: paginationQueryData } = useUrlQueryData<Pagination>(
 		QueryParams.pagination,
 	);
+	const paginationConfig =
+		paginationQueryData ?? getDefaultPaginationConfig(PER_PAGE_OPTIONS);
+
+	const queryKey = useMemo(
+		() => [
+			REACT_QUERY_KEY.GET_QUERY_RANGE,
+			globalSelectedTime,
+			maxTime,
+			minTime,
+			stagedQuery,
+			panelType,
+			paginationConfig,
+			options?.selectColumns,
+		],
+		[
+			stagedQuery,
+			panelType,
+			globalSelectedTime,
+			paginationConfig,
+			options?.selectColumns,
+			maxTime,
+			minTime,
+		],
+	);
 
 	const { data, isFetching, isLoading, isError } = useGetQueryRange(
 		{
 			query: stagedQuery || initialQueriesMap.traces,
-			graphType: panelType || PANEL_TYPES.LIST,
-			selectedTime: 'GLOBAL_TIME',
-			globalSelectedInterval: globalSelectedTime,
+			graphType: panelType,
+			selectedTime: 'GLOBAL_TIME' as const,
+			globalSelectedInterval: globalSelectedTime as CustomTimeType,
 			params: {
 				dataSource: 'traces',
 			},
 			tableParams: {
-				pagination: paginationQueryData,
+				pagination: paginationConfig,
 				selectColumns: options?.selectColumns,
 			},
 		},
 		DEFAULT_ENTITY_VERSION,
 		{
-			queryKey: [
-				REACT_QUERY_KEY.GET_QUERY_RANGE,
-				globalSelectedTime,
-				maxTime,
-				minTime,
-				stagedQuery,
-				panelType,
-				paginationQueryData,
-				options?.selectColumns,
-			],
+			queryKey,
 			enabled:
+				// don't make api call while the time range state in redux is loading
+				!timeRangeUpdateLoading &&
 				!!stagedQuery &&
 				panelType === PANEL_TYPES.LIST &&
 				!!options?.selectColumns?.length,

--- a/frontend/src/pages/TracesExplorer/Filter/Filter.tsx
+++ b/frontend/src/pages/TracesExplorer/Filter/Filter.tsx
@@ -203,6 +203,10 @@ export function Filter(props: FilterProps): JSX.Element {
 					selectedFilters,
 				});
 			}
+
+			if (isEqual(currentQuery, preparedQuery)) {
+				return;
+			}
 			redirectWithQueryBuilderData(preparedQuery);
 		},
 		[currentQuery, redirectWithQueryBuilderData, selectedFilters],

--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -95,7 +95,17 @@ export function QueryBuilderProvider({
 	const urlQuery = useUrlQuery();
 	const history = useHistory();
 	const location = useLocation();
-	const currentPathnameRef = useRef<string | null>(null);
+	/**
+	 // set location.pathname as the initial value for currentPathnameRef, absense of this causes `stagedQuery && location.pathname !== currentPathnameRef.current` to be truthy (since currentPathnameRef.current is null), and therefore causes duplicate triggering of initQueryBuilderData(compositeQueryParam); in the useEffect of line ~784
+		
+		if (!isValid) {
+			redirectWithQueryBuilderData(validData);
+		} else {
+			initQueryBuilderData(compositeQueryParam);
+		}
+		* 
+		*/
+	const currentPathnameRef = useRef<string | null>(location.pathname);
 
 	const { maxTime, minTime } = useSelector<AppState, GlobalReducer>(
 		(state) => state.globalTime,
@@ -233,6 +243,7 @@ export function QueryBuilderProvider({
 				timeUpdated ? merge(currentQuery, newQueryState) : newQueryState,
 			);
 			setQueryType(type);
+			// debugger;
 		},
 		[prepareQueryBuilderData, currentQuery],
 	);
@@ -792,6 +803,7 @@ export function QueryBuilderProvider({
 			initialQueriesMap.metrics,
 		);
 
+		// debugger;
 		if (!isValid) {
 			redirectWithQueryBuilderData(validData);
 		} else {
@@ -814,14 +826,14 @@ export function QueryBuilderProvider({
 	};
 
 	useEffect(() => {
-		if (stagedQuery && location.pathname !== currentPathnameRef.current) {
+		if (location.pathname !== currentPathnameRef.current) {
 			currentPathnameRef.current = location.pathname;
 
 			setStagedQuery(null);
 			// reset the last used query to 0 when navigating away from the page
 			setLastUsedQuery(0);
 		}
-	}, [location, stagedQuery, currentQuery]);
+	}, [location.pathname]);
 
 	const handleOnUnitsChange = useCallback(
 		(unit: string) => {


### PR DESCRIPTION
### Summary

- Memoize the query key to ensure that we don't have multiple query keys.
- Make API call only when the time range state is not loading (while the time range state is being updated).
- Added a check in the Filter component to avoid redundant redirection when the current query matches the prepared query.


<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
close #6308 
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

Before:

https://github.com/user-attachments/assets/7ec3b450-0fe3-43e9-843a-6d633f19d442


After:

https://github.com/user-attachments/assets/d88e5729-fa46-40ab-80cc-308e4cd07b1e


<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prevent duplicate API calls in Traces Explorer by memoizing query keys and optimizing conditions for API execution and redirection.
> 
>   - **Behavior**:
>     - Memoize `queryKey` in `ListView` to prevent duplicate API calls.
>     - API call in `ListView` only when `timeRangeUpdateLoading` is false.
>     - In `Filter`, prevent redirection if `currentQuery` equals `preparedQuery`.
>   - **Code Improvements**:
>     - Initialize `currentPathnameRef` in `QueryBuilderProvider` to prevent duplicate query initialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 9e1aa028c76ae0ac0c3858d98b2eb9e59703dd66. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->