### PR TITLE
fix: unable to remove query tags from the beginning when similar tags present 

### DIFF
--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
@@ -841,10 +841,10 @@ function QueryBuilderSearchV2(
 	useEffect(() => {
 		// this is required because on change of query tags the Select component re-renders which looses focus.
 		// this was added because Select component was acting inconsistently for similar tags
-		if (selectRef.current && queryTags.length > 0) {
+		if (selectRef.current && queryTags.length > 0 && isOpen) {
 			selectRef.current?.focus();
 		}
-	}, [queryTags]);
+	}, [queryTags, isOpen]);
 
 	const onTagRender = ({
 		value,

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
@@ -838,6 +838,14 @@ function QueryBuilderSearchV2(
 		[tags],
 	);
 
+	useEffect(() => {
+		// this is required because on change of query tags the Select component re-renders which looses focus.
+		// this was added because Select component was acting inconsistently for similar tags
+		if (selectRef.current && queryTags.length > 0) {
+			selectRef.current?.focus();
+		}
+	}, [queryTags]);
+
 	const onTagRender = ({
 		value,
 		closable,
@@ -897,6 +905,7 @@ function QueryBuilderSearchV2(
 			<Select
 				ref={selectRef}
 				getPopupContainer={popupContainer}
+				key={queryTags.join('.')}
 				virtual={false}
 				showSearch
 				tagRender={onTagRender}

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
@@ -838,14 +838,6 @@ function QueryBuilderSearchV2(
 		[tags],
 	);
 
-	useEffect(() => {
-		// this is required because on change of query tags the Select component re-renders which looses focus.
-		// this was added because Select component was acting inconsistently for similar tags
-		if (selectRef.current && queryTags.length > 0 && isOpen) {
-			selectRef.current?.focus();
-		}
-	}, [queryTags, isOpen]);
-
 	const onTagRender = ({
 		value,
 		closable,
@@ -912,6 +904,7 @@ function QueryBuilderSearchV2(
 				transitionName=""
 				choiceTransitionName=""
 				filterOption={false}
+				autoFocus={isOpen}
 				open={isOpen}
 				suffixIcon={
 					// eslint-disable-next-line no-nested-ternary


### PR DESCRIPTION
### Summary

- when there were duplicate filters present the `Select` component behaves inconsistently, while the state updates well but the component doesn't update. 
- added `queryTags` as the key for the `Select` component but since the component re-renders the focus state is lost used auto focus prop for the same 