### PR TITLE
fix: added handling for new key - duration_nano in traces

### DIFF
--- a/frontend/src/container/TimeSeriesView/index.tsx
+++ b/frontend/src/container/TimeSeriesView/index.tsx
@@ -29,7 +29,8 @@ function TimeSeriesViewContainer({
 		currentQuery.builder.queryData.forEach(
 			({ aggregateAttribute, aggregateOperator }) => {
 				const isExistDurationNanoAttribute =
-					aggregateAttribute.key === 'durationNano';
+					aggregateAttribute.key === 'durationNano' ||
+					aggregateAttribute.key === 'duration_nano';
 
 				const isCountOperator =
 					aggregateOperator === 'count' || aggregateOperator === 'count_distinct';

--- a/frontend/src/container/Trace/TraceTable/util.ts
+++ b/frontend/src/container/Trace/TraceTable/util.ts
@@ -1,5 +1,5 @@
 export const getSpanOrderParam = (key: string): string => {
-	if (key === 'durationNano') {
+	if (key === 'durationNano' || key === 'duration_nano') {
 		return 'duration';
 	}
 	if (key === 'timestamp') {

--- a/frontend/src/container/TracesExplorer/ListView/utils.tsx
+++ b/frontend/src/container/TracesExplorer/ListView/utils.tsx
@@ -96,7 +96,7 @@ export const getListColumns = (
 					);
 				}
 
-				if (key === 'durationNano') {
+				if (key === 'durationNano' || key === 'duration_nano') {
 					return (
 						<BlockLink to={getTraceLink(item)} openInNewTab={false}>
 							<Typography data-testid={key}>{getMs(value)}ms</Typography>


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

https://github.com/SigNoz/engineering-pod/issues/2095

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add handling for `duration_nano` key alongside `durationNano` in various components and utilities.
> 
>   - **Behavior**:
>     - Add handling for `duration_nano` key in addition to `durationNano` in `TimeSeriesViewContainer` in `index.tsx`.
>     - Update `getSpanOrderParam` in `util.ts` to handle `duration_nano`.
>     - Modify `getListColumns` in `utils.tsx` to support `duration_nano` key for rendering duration in milliseconds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for b6159a7b0cc089ae8fbbdb8b651038cd64932706. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->