### PR TITLE
enable kafka_span_eval, enabling the feature to avoid 404 in the messaging queue tab

### DIFF
--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -90,7 +90,7 @@ func EnableHostsInfraMonitoring() bool {
 	return GetOrDefaultEnv("ENABLE_INFRA_METRICS", "true") == "true"
 }
 
-var KafkaSpanEval = GetOrDefaultEnv("KAFKA_SPAN_EVAL", "false")
+var KafkaSpanEval = GetOrDefaultEnv("KAFKA_SPAN_EVAL", "true")
 
 func IsDurationSortFeatureEnabled() bool {
 	isDurationSortFeatureEnabledStr := DurationSortFeature


### PR DESCRIPTION
Enables the feature by default to avoid 404
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enables `KafkaSpanEval` by default in `constants.go` to prevent 404 errors in the messaging queue tab.
> 
>   - **Behavior**:
>     - Enables `KafkaSpanEval` by default in `constants.go` to prevent 404 errors in the messaging queue tab.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for cb87806835e5bbe2301ea4df20027fe48ea96a45. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->