### PR TITLE
Add support for trace_v3 schema in messaging queues

### DIFF
--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -90,7 +90,7 @@ func EnableHostsInfraMonitoring() bool {
 	return GetOrDefaultEnv("ENABLE_INFRA_METRICS", "true") == "true"
 }
 
-var KafkaSpanEval = GetOrDefaultEnv("KAFKA_SPAN_EVAL", "false")
+var KafkaSpanEval = GetOrDefaultEnv("KAFKA_SPAN_EVAL", "true")
 
 func IsDurationSortFeatureEnabled() bool {
 	isDurationSortFeatureEnabledStr := DurationSortFeature


### PR DESCRIPTION
Supports trace_v3 now
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update SQL queries to support `trace_v3` schema and enable Kafka span evaluation by default.
> 
>   - **Behavior**:
>     - Update SQL queries in `sql.go` to use `signoz_traces.distributed_signoz_index_v3` instead of `v2`.
>     - Replace `serviceName` with `resource_string_service$$name` and `msgSystem` with `attribute_string_messaging$$system` in SQL queries.
>   - **Constants**:
>     - Change `KafkaSpanEval` default value to `true` in `constants.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 7460888db2f5d4b8722681cd67afdf9766a5107d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->