### PR TITLE
feat: added span_count using the MV and index v3 traces table [Design needs to be finalised]

### DIFF
--- a/pkg/query-service/app/queryBuilder/query_builder.go
+++ b/pkg/query-service/app/queryBuilder/query_builder.go
@@ -41,7 +41,7 @@ var SupportedFunctions = []string{
 
 var EvalFuncs = map[string]govaluate.ExpressionFunction{}
 
-type prepareTracesQueryFunc func(start, end int64, panelType v3.PanelType, bq *v3.BuilderQuery, options v3.QBOptions) (string, error)
+type prepareTracesQueryFunc func(start, end int64, panelType v3.PanelType, bq *v3.BuilderQuery, options v3.QBOptions, sortBy string) (string, error)
 type prepareLogsQueryFunc func(start, end int64, queryType v3.QueryType, panelType v3.PanelType, bq *v3.BuilderQuery, options v3.QBOptions) (string, error)
 type prepareMetricQueryFunc func(start, end int64, queryType v3.QueryType, panelType v3.PanelType, bq *v3.BuilderQuery, options metricsV3.Options) (string, error)
 
@@ -196,12 +196,12 @@ func (qb *QueryBuilder) PrepareQueries(params *v3.QueryRangeParamsV3) (map[strin
 					// for ts query with group by and limit form two queries
 					if compositeQuery.PanelType == v3.PanelTypeGraph && query.Limit > 0 && len(query.GroupBy) > 0 {
 						limitQuery, err := qb.options.BuildTraceQuery(start, end, compositeQuery.PanelType, query,
-							v3.QBOptions{GraphLimitQtype: constants.FirstQueryGraphLimit, PreferRPM: PreferRPMFeatureEnabled})
+							v3.QBOptions{GraphLimitQtype: constants.FirstQueryGraphLimit, PreferRPM: PreferRPMFeatureEnabled}, params.SortBy)
 						if err != nil {
 							return nil, err
 						}
 						placeholderQuery, err := qb.options.BuildTraceQuery(start, end, compositeQuery.PanelType,
-							query, v3.QBOptions{GraphLimitQtype: constants.SecondQueryGraphLimit, PreferRPM: PreferRPMFeatureEnabled})
+							query, v3.QBOptions{GraphLimitQtype: constants.SecondQueryGraphLimit, PreferRPM: PreferRPMFeatureEnabled}, params.SortBy)
 						if err != nil {
 							return nil, err
 						}
@@ -209,7 +209,7 @@ func (qb *QueryBuilder) PrepareQueries(params *v3.QueryRangeParamsV3) (map[strin
 						queries[queryName] = query
 					} else {
 						queryString, err := qb.options.BuildTraceQuery(start, end, compositeQuery.PanelType,
-							query, v3.QBOptions{PreferRPM: PreferRPMFeatureEnabled, GraphLimitQtype: ""})
+							query, v3.QBOptions{PreferRPM: PreferRPMFeatureEnabled, GraphLimitQtype: ""}, params.SortBy)
 						if err != nil {
 							return nil, err
 						}

--- a/pkg/query-service/app/traces/v3/query_builder.go
+++ b/pkg/query-service/app/traces/v3/query_builder.go
@@ -499,7 +499,7 @@ func AddOffsetToQuery(query string, offset uint64) string {
 // PrepareTracesQuery returns the query string for traces
 // start and end are in epoch millisecond
 // step is in seconds
-func PrepareTracesQuery(start, end int64, panelType v3.PanelType, mq *v3.BuilderQuery, options v3.QBOptions) (string, error) {
+func PrepareTracesQuery(start, end int64, panelType v3.PanelType, mq *v3.BuilderQuery, options v3.QBOptions, sortBy string) (string, error) {
 	// adjust the start and end time to the step interval
 	if panelType == v3.PanelTypeGraph {
 		// adjust the start and end time to the step interval for graph panel types

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -53,6 +53,8 @@ const LogsTTL = "logs"
 const DurationSort = "DurationSort"
 const TimestampSort = "TimestampSort"
 const PreferRPM = "PreferRPM"
+const TraceSortBySpanCount = "span_count"
+const TraceSortByTraceDuration = "trace_duration"
 
 func GetAlertManagerApiPrefix() string {
 	if os.Getenv("ALERTMANAGER_API_PREFIX") != "" {
@@ -248,6 +250,7 @@ const (
 	SIGNOZ_TIMESERIES_v4_1DAY_LOCAL_TABLENAME  = "time_series_v4_1day"
 	SIGNOZ_TIMESERIES_v4_1WEEK_LOCAL_TABLENAME = "time_series_v4_1week"
 	SIGNOZ_TIMESERIES_v4_1DAY_TABLENAME        = "distributed_time_series_v4_1day"
+	SIGNOZ_TRACE_SPAN_COUNT_MV                 = "trace_summary_mv"
 )
 
 var TimeoutExcludedRoutes = map[string]bool{
@@ -353,6 +356,8 @@ const (
 	TracesExplorerViewSQLSelectQuery = "SELECT subQuery.serviceName, subQuery.name, count() AS " +
 		"span_count, subQuery.durationNano, traceID FROM %s.%s GLOBAL INNER JOIN subQuery ON %s.traceID = subQuery.traceID GROUP " +
 		"BY traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY subQuery.durationNano desc;"
+	TraceExplorerSpanCountSubQuery    = "SELECT t.trace_id, t.num_spans FROM %s.%s as t GLOBAL INNER JOIN (SELECT * FROM (SELECT trace_id FROM %s.%s WHERE %s %s LIMIT 1 BY trace_id) AS inner_filtered ) AS filtered_traces ON t.trace_id = filtered_traces.trace_id ORDER BY t.num_spans DESC "
+	TraceExplorerEnrichSpanCountQuery = "SELECT name, serviceName, duration_nano FROM %s.%s WHERE trace_id = %s"
 )
 
 // ReservedColumnTargetAliases identifies result value from a user

--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -379,6 +379,7 @@ type QueryRangeParamsV3 struct {
 	NoCache        bool                   `json:"noCache"`
 	Version        string                 `json:"-"`
 	FormatForWeb   bool                   `json:"formatForWeb,omitempty"`
+	SortBy         string                 `json:"sortBy,omitempty"`
 }
 
 func (q *QueryRangeParamsV3) Clone() *QueryRangeParamsV3 {


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added support for sorting trace queries by span count using a new `sortBy` parameter in query functions.
> 
>   - **Behavior**:
>     - Added `sortBy` parameter to `prepareTracesQueryFunc` in `query_builder.go` to support sorting by span count.
>     - Updated `PrepareTracesQuery` in `query_builder.go`, `v3/query_builder.go`, and `v4/query_builder.go` to handle `sortBy` parameter.
>     - Introduced `TraceSortBySpanCount` and `TraceSortByTraceDuration` constants in `constants.go`.
>   - **Query Building**:
>     - Modified `buildTracesQuery` in `v3/query_builder.go` and `v4/query_builder.go` to include logic for sorting by span count using `TraceExplorerSpanCountSubQuery`.
>     - Adjusted query logic to use `SIGNOZ_TRACE_SPAN_COUNT_MV` for span count sorting.
>   - **Models**:
>     - Added `SortBy` field to `QueryRangeParamsV3` in `v3.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for cdeb0af23d9d81ae38a5dd4761f5f4f9d0b2fb6d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->