### PR TITLE
 chore: add log events for timezone interactions in date/time picker and timezone adaptation

### DIFF
--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -3,6 +3,7 @@
 import './CustomTimePicker.styles.scss';
 
 import { Input, Popover, Tooltip, Typography } from 'antd';
+import logEvent from 'api/common/logEvent';
 import cx from 'classnames';
 import { DateTimeRangeType } from 'container/TopNav/CustomDateTimeModal';
 import {
@@ -297,6 +298,16 @@ function CustomTimePicker({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [location.pathname]);
 
+	const handleTimezoneHintClick = (e: React.MouseEvent): void => {
+		e.stopPropagation();
+		handleViewChange('timezone');
+		setIsOpenedFromFooter(false);
+		logEvent('Timezone picker opened', {
+			source: `current timezone badge in date/time picker input`,
+			page: location.pathname,
+		});
+	};
+
 	return (
 		<div className="custom-time-picker">
 			<Popover
@@ -360,14 +371,7 @@ function CustomTimePicker({
 					suffix={
 						<>
 							{!!isTimezoneOverridden && activeTimezoneOffset && (
-								<div
-									className="timezone-badge"
-									onClick={(e): void => {
-										e.stopPropagation();
-										handleViewChange('timezone');
-										setIsOpenedFromFooter(false);
-									}}
-								>
+								<div className="timezone-badge" onClick={handleTimezoneHintClick}>
 									<span>{activeTimezoneOffset}</span>
 								</div>
 							)}

--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -303,7 +303,7 @@ function CustomTimePicker({
 		handleViewChange('timezone');
 		setIsOpenedFromFooter(false);
 		logEvent(
-			'DateTimePicker: Timezone picker opened from Current timezone badge in date/time picker input',
+			'DateTimePicker: Timezone picker opened from time range input badge',
 			{
 				page: location.pathname,
 			},

--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -302,10 +302,12 @@ function CustomTimePicker({
 		e.stopPropagation();
 		handleViewChange('timezone');
 		setIsOpenedFromFooter(false);
-		logEvent('Timezone picker opened', {
-			source: `current timezone badge in date/time picker input`,
-			page: location.pathname,
-		});
+		logEvent(
+			'DateTimePicker: Timezone picker opened from Current timezone badge in date/time picker input',
+			{
+				page: location.pathname,
+			},
+		);
 	};
 
 	return (

--- a/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
@@ -2,6 +2,7 @@ import './CustomTimePicker.styles.scss';
 
 import { Color } from '@signozhq/design-tokens';
 import { Button } from 'antd';
+import logEvent from 'api/common/logEvent';
 import cx from 'classnames';
 import ROUTES from 'constants/routes';
 import { DateTimeRangeType } from 'container/TopNav/CustomDateTimeModal';
@@ -81,6 +82,10 @@ function CustomTimePickerPopoverContent({
 	const handleTimezoneHintClick = (): void => {
 		setActiveView('timezone');
 		setIsOpenedFromFooter(true);
+		logEvent('Timezone picker opened', {
+			source: `"Current Timezone" hint inside date time picker popover`,
+			page: pathname,
+		});
 	};
 
 	if (activeView === 'timezone') {

--- a/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
@@ -83,7 +83,7 @@ function CustomTimePickerPopoverContent({
 		setActiveView('timezone');
 		setIsOpenedFromFooter(true);
 		logEvent(
-			'DateTimePicker: Timezone picker opened from "Current Timezone" hint inside date time picker popover',
+			'DateTimePicker: Timezone picker opened from time range picker footer',
 			{
 				page: pathname,
 			},

--- a/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
@@ -82,10 +82,12 @@ function CustomTimePickerPopoverContent({
 	const handleTimezoneHintClick = (): void => {
 		setActiveView('timezone');
 		setIsOpenedFromFooter(true);
-		logEvent('Timezone picker opened', {
-			source: `"Current Timezone" hint inside date time picker popover`,
-			page: pathname,
-		});
+		logEvent(
+			'DateTimePicker: Timezone picker opened from "Current Timezone" hint inside date time picker popover',
+			{
+				page: pathname,
+			},
+		);
 	};
 
 	if (activeView === 'timezone') {

--- a/frontend/src/components/CustomTimePicker/TimezonePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/TimezonePicker.tsx
@@ -2,6 +2,7 @@ import './TimezonePicker.styles.scss';
 
 import { Color } from '@signozhq/design-tokens';
 import { Input } from 'antd';
+import logEvent from 'api/common/logEvent';
 import cx from 'classnames';
 import { TimezonePickerShortcuts } from 'constants/shortcuts/TimezonePickerShortcuts';
 import { useKeyboardHotkeys } from 'hooks/hotkeys/useKeyboardHotkeys';
@@ -157,6 +158,12 @@ function TimezonePicker({
 			updateTimezone(timezone);
 			handleCloseTimezonePicker();
 			setIsOpen(false);
+			logEvent('Timezone selected', {
+				timezone: {
+					name: timezone.name,
+					offset: timezone.offset,
+				},
+			});
 		},
 		[handleCloseTimezonePicker, setIsOpen, updateTimezone],
 	);

--- a/frontend/src/components/CustomTimePicker/TimezonePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/TimezonePicker.tsx
@@ -158,7 +158,7 @@ function TimezonePicker({
 			updateTimezone(timezone);
 			handleCloseTimezonePicker();
 			setIsOpen(false);
-			logEvent('Timezone selected', {
+			logEvent('DateTimePicker: New Timezone Selected', {
 				timezone: {
 					name: timezone.name,
 					offset: timezone.offset,

--- a/frontend/src/container/MySettings/TimezoneAdaptation/TimezoneAdaptation.tsx
+++ b/frontend/src/container/MySettings/TimezoneAdaptation/TimezoneAdaptation.tsx
@@ -2,6 +2,7 @@ import './TimezoneAdaptation.styles.scss';
 
 import { Color } from '@signozhq/design-tokens';
 import { Switch } from 'antd';
+import logEvent from 'api/common/logEvent';
 import { Delete } from 'lucide-react';
 import { useTimezone } from 'providers/Timezone';
 import { useMemo } from 'react';
@@ -27,6 +28,15 @@ function TimezoneAdaptation(): JSX.Element {
 
 	const handleOverrideClear = (): void => {
 		updateTimezone(browserTimezone);
+		logEvent('Timezone override cleared', {});
+	};
+
+	const handleSwitchChange = (): void => {
+		setIsAdaptationEnabled((prev) => {
+			const isEnabled = !prev;
+			logEvent(`Timezone adaptation ${isEnabled ? 'enabled' : 'disabled'}`, {});
+			return isEnabled;
+		});
 	};
 
 	return (
@@ -35,7 +45,7 @@ function TimezoneAdaptation(): JSX.Element {
 				<h2 className="timezone-adaption__title">Adapt to my timezone</h2>
 				<Switch
 					checked={isAdaptationEnabled}
-					onChange={setIsAdaptationEnabled}
+					onChange={handleSwitchChange}
 					style={getSwitchStyles()}
 				/>
 			</div>

--- a/frontend/src/container/MySettings/TimezoneAdaptation/TimezoneAdaptation.tsx
+++ b/frontend/src/container/MySettings/TimezoneAdaptation/TimezoneAdaptation.tsx
@@ -28,13 +28,16 @@ function TimezoneAdaptation(): JSX.Element {
 
 	const handleOverrideClear = (): void => {
 		updateTimezone(browserTimezone);
-		logEvent('Timezone override cleared', {});
+		logEvent('Settings: Timezone override cleared', {});
 	};
 
 	const handleSwitchChange = (): void => {
 		setIsAdaptationEnabled((prev) => {
 			const isEnabled = !prev;
-			logEvent(`Timezone adaptation ${isEnabled ? 'enabled' : 'disabled'}`, {});
+			logEvent(
+				`Settings: Timezone adaptation ${isEnabled ? 'enabled' : 'disabled'}`,
+				{},
+			);
 			return isEnabled;
 		});
 	};


### PR DESCRIPTION
### Summary

- Clicking on the Current Timezone inside date/time picker popover
- Clicking on the timezone badge in date/time picker input
- Clicking on a timezone inside the timezone picker
- Clicking on Clear override in timezone adaptation settings

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
#6644
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add logging for timezone interactions in date/time picker and adaptation settings.
> 
>   - **Logging**:
>     - Add `logEvent` for opening timezone picker from time range input badge in `CustomTimePicker.tsx`.
>     - Add `logEvent` for opening timezone picker from time range picker footer in `CustomTimePickerPopoverContent.tsx`.
>     - Add `logEvent` for selecting a new timezone in `TimezonePicker.tsx`.
>     - Add `logEvent` for clearing timezone override and toggling adaptation in `TimezoneAdaptation.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 33e12add6e84b23c008f06f7b4fcda97135b2599. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->