### PR TITLE
fix: fix the issue of saved view overriding query for logs and traces

### DIFF
--- a/frontend/src/container/ExplorerOptions/ExplorerOptions.tsx
+++ b/frontend/src/container/ExplorerOptions/ExplorerOptions.tsx
@@ -112,6 +112,7 @@ function ExplorerOptions({
 		panelType,
 		isStagedQueryUpdated,
 		redirectWithQueryBuilderData,
+		isDefaultQuery,
 	} = useQueryBuilder();
 
 	const handleSaveViewModalToggle = (): void => {
@@ -478,6 +479,11 @@ function ExplorerOptions({
 	] = useState(false);
 
 	useEffect(() => {
+		// If the query is not the default query, don't set the recently used saved view
+		if (!isDefaultQuery({ currentQuery, sourcePage: sourcepage })) {
+			return;
+		}
+
 		const parsedPreservedView = JSON.parse(
 			localStorage.getItem(PRESERVED_VIEW_LOCAL_STORAGE_KEY) || '{}',
 		);
@@ -499,12 +505,18 @@ function ExplorerOptions({
 			setIsRecentlyUsedSavedViewSelected(false);
 		}
 
-		return (): void => clearTimeout(timeoutId);
+		// eslint-disable-next-line consistent-return
+		return (): void => {
+			clearTimeout(timeoutId);
+		};
 	}, [
 		PRESERVED_VIEW_LOCAL_STORAGE_KEY,
 		PRESERVED_VIEW_TYPE,
+		currentQuery,
+		isDefaultQuery,
 		isRecentlyUsedSavedViewSelected,
 		onMenuItemSelectHandler,
+		sourcepage,
 		viewKey,
 		viewName,
 		viewsData?.data?.data,

--- a/frontend/src/pages/LogsExplorer/__tests__/LogsExplorer.test.tsx
+++ b/frontend/src/pages/LogsExplorer/__tests__/LogsExplorer.test.tsx
@@ -155,6 +155,7 @@ describe('Logs Explorer Tests', () => {
 		const { queryAllByText } = render(
 			<QueryBuilderContext.Provider
 				value={{
+					isDefaultQuery: (): boolean => false,
 					currentQuery: {
 						...initialQueriesMap.metrics,
 						builder: {

--- a/frontend/src/pages/TracesExplorer/__test__/testUtils.ts
+++ b/frontend/src/pages/TracesExplorer/__test__/testUtils.ts
@@ -195,6 +195,7 @@ export const compositeQuery: Query = {
 export const redirectWithQueryBuilderData = jest.fn();
 
 export const qbProviderValue = {
+	isDefaultQuery: jest.fn(() => false),
 	currentQuery: {
 		...initialQueriesMap.traces,
 		builder: {

--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -251,6 +251,53 @@ export function QueryBuilderProvider({
 		[getElementWithActualOperator],
 	);
 
+	const extractRelevantKeys = useCallback(
+		(queryData: IBuilderQuery): IBuilderQuery => {
+			const {
+				dataSource,
+				queryName,
+				aggregateOperator,
+				aggregateAttribute,
+				timeAggregation,
+				spaceAggregation,
+				functions,
+				filters,
+				expression,
+				disabled,
+				stepInterval,
+				having,
+				groupBy,
+				legend,
+			} = queryData;
+
+			return {
+				dataSource,
+				queryName,
+				aggregateOperator,
+				// remove id from aggregateAttribute
+				aggregateAttribute: {
+					...aggregateAttribute,
+					id: '',
+				},
+				timeAggregation,
+				spaceAggregation,
+				functions,
+				filters,
+				expression,
+				disabled,
+				stepInterval,
+				having,
+				groupBy,
+				legend,
+				// set to default values
+				orderBy: [],
+				limit: null,
+				reduceTo: 'avg',
+			};
+		},
+		[],
+	);
+
 	const isDefaultQuery = useCallback(
 		({ currentQuery, sourcePage }: IsDefaultQueryProps): boolean => {
 			// Get default query with updated operators
@@ -271,53 +318,9 @@ export function QueryBuilderProvider({
 			}
 
 			// If there is more than one query, then it is not a default query
-			if (currentQuery.builder.queryData.length !== 1) {
+			if (currentQuery.builder.queryData.length > 1) {
 				return false;
 			}
-
-			const extractRelevantKeys = (queryData: IBuilderQuery): IBuilderQuery => {
-				const {
-					dataSource,
-					queryName,
-					aggregateOperator,
-					aggregateAttribute,
-					timeAggregation,
-					spaceAggregation,
-					functions,
-					filters,
-					expression,
-					disabled,
-					stepInterval,
-					having,
-					groupBy,
-					legend,
-				} = queryData;
-
-				return {
-					dataSource,
-					queryName,
-					aggregateOperator,
-					// remove id from aggregateAttribute
-					aggregateAttribute: {
-						...aggregateAttribute,
-						id: '',
-					},
-					timeAggregation,
-					spaceAggregation,
-					functions,
-					filters,
-					expression,
-					disabled,
-					stepInterval,
-					having,
-					groupBy,
-					legend,
-					// set to default values
-					orderBy: [],
-					limit: null,
-					reduceTo: 'avg',
-				};
-			};
 
 			const currentBuilderData = extractRelevantKeys(
 				currentQuery.builder.queryData[0],
@@ -328,7 +331,7 @@ export function QueryBuilderProvider({
 
 			return isEqual(currentBuilderData, defaultBuilderData);
 		},
-		[updateAllQueriesOperators],
+		[updateAllQueriesOperators, extractRelevantKeys],
 	);
 	const updateQueriesData = useCallback(
 		<T extends keyof QueryBuilderData>(

--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -270,6 +270,11 @@ export function QueryBuilderProvider({
 				return false;
 			}
 
+			// If there is more than one query, then it is not a default query
+			if (currentQuery.builder.queryData.length !== 1) {
+				return false;
+			}
+
 			const extractRelevantKeys = (queryData: IBuilderQuery): IBuilderQuery => {
 				const {
 					dataSource,

--- a/frontend/src/types/common/queryBuilder.ts
+++ b/frontend/src/types/common/queryBuilder.ts
@@ -247,9 +247,15 @@ export type QueryBuilderContextType = {
 		viewData: ViewProps[] | undefined,
 		viewKey: string,
 	) => boolean;
+	isDefaultQuery: (props: IsDefaultQueryProps) => boolean;
 };
 
 export type QueryAdditionalFilter = {
 	field: keyof IBuilderQuery;
 	text: string;
+};
+
+export type IsDefaultQueryProps = {
+	currentQuery: Query;
+	sourcePage: DataSource;
 };


### PR DESCRIPTION
### Summary
- Added isDefaultQuery function to determine if the current query matches the default query.
- Integrated isDefaultQuery into ExplorerOptions to conditionally handle applying the recently used saved view based on the query type.
- Updated types to include IsDefaultQueryProps for better type safety.

This enhancement improves the query handling logic, ensuring that only default queries are processed for recently used saved view.
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
close https://signoz-team.slack.com/archives/C02TJ466H8U/p1734874203586999
close https://github.com/SigNoz/engineering-pod/issues/2067

Previous PR: https://github.com/SigNoz/signoz/pull/6612
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
Before:

https://github.com/user-attachments/assets/fae0972d-7baa-4f68-aa48-020e9866bca0




After:

https://github.com/user-attachments/assets/02c1cabc-6134-492e-9254-4edbc363d40f


<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas 
- Logs explorer
- Traces explorer

#### Manually Tested Areas
- Visiting logs explorer from service details page (View logs) -> should respect the query and avoid applying the recently used saved view
- Visiting traces explorer from service details page (View traces) -> should respect the query and avoid applying the recently used saved view
- Visiting logs explorer from timeline table of alert history page (View logs) -> should respect the query and avoid applying the recently used saved view
- Visiting logs explorer from other pages -> should apply the recently used saved view
- Visiting traces explorer from other pages -> should apply the recently used saved view

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `isDefaultQuery` function to conditionally apply saved views in `ExplorerOptions` based on query type, with updated types for safety.
> 
>   - **Behavior**:
>     - Added `isDefaultQuery` function in `QueryBuilder.tsx` to check if a query is default.
>     - Integrated `isDefaultQuery` in `ExplorerOptions.tsx` to conditionally apply saved views based on query type.
>   - **Types**:
>     - Updated types in `queryBuilder.ts` to include `IsDefaultQueryProps` for type safety.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 7670b936b17b5aa751cc3dce487fd08bb87c5221. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->