### PR TITLE
fix: add support route to the base route for private routes

### DIFF
--- a/frontend/src/AppRoutes/Private.tsx
+++ b/frontend/src/AppRoutes/Private.tsx
@@ -161,6 +161,7 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 				pathname: redirectUrl,
 			};
 			history.replace(newLocation);
+			return;
 		}
 		// if the current route
 		if (currentRoute) {

--- a/frontend/src/AppRoutes/Private.tsx
+++ b/frontend/src/AppRoutes/Private.tsx
@@ -18,6 +18,7 @@ import routes, {
 	LIST_LICENSES,
 	oldNewRoutesMapping,
 	oldRoutes,
+	SUPPORT_ROUTE,
 } from './routes';
 
 function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
@@ -37,7 +38,7 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 	const mapRoutes = useMemo(
 		() =>
 			new Map(
-				[...routes, LIST_LICENSES].map((e) => {
+				[...routes, LIST_LICENSES, SUPPORT_ROUTE].map((e) => {
 					const currentPath = matchPath(pathname, {
 						path: e.path,
 					});

--- a/frontend/src/AppRoutes/routes.ts
+++ b/frontend/src/AppRoutes/routes.ts
@@ -427,7 +427,6 @@ export const LIST_LICENSES: AppRoutes = {
 
 export const oldRoutes = [
 	'/pipelines',
-	'/logs/old-logs-explorer',
 	'/logs-explorer',
 	'/logs-explorer/live',
 	'/logs-save-views',
@@ -437,7 +436,6 @@ export const oldRoutes = [
 
 export const oldNewRoutesMapping: Record<string, string> = {
 	'/pipelines': '/logs/pipelines',
-	'/logs/old-logs-explorer': '/logs/old-logs-explorer',
 	'/logs-explorer': '/logs/logs-explorer',
 	'/logs-explorer/live': '/logs/logs-explorer/live',
 	'/logs-save-views': '/logs/saved-views',


### PR DESCRIPTION
### Summary

- support route needs to be added to the base routes in the `Private.tsx` to let users navigate to that route conditionally 
- early return from `useEffect` if it's an old route as we never removed the oldRoutes from the baseAppRoutes which define the currentRoute check. 
- the `old-explorer-route` was same in the oldRouteMapping causing the browser to throttle navigation 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->