### PR TITLE
fix: do not try to route to org onboarding when workspace locked or suspended

### DIFF
--- a/frontend/src/AppRoutes/Private.tsx
+++ b/frontend/src/AppRoutes/Private.tsx
@@ -18,6 +18,7 @@ import routes, {
 	LIST_LICENSES,
 	oldNewRoutesMapping,
 	oldRoutes,
+	ROUTES_NOT_TO_BE_OVERRIDEN,
 	SUPPORT_ROUTE,
 } from './routes';
 
@@ -90,7 +91,12 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 			)?.value;
 
 			const isFirstUser = checkFirstTimeUser();
-			if (isFirstUser && !isOnboardingComplete) {
+			if (
+				isFirstUser &&
+				!isOnboardingComplete &&
+				// if the current route is allowed to be overriden by org onboarding then only do the same
+				!ROUTES_NOT_TO_BE_OVERRIDEN.includes(pathname)
+			) {
 				history.push(ROUTES.ONBOARDING);
 			}
 		}

--- a/frontend/src/AppRoutes/routes.ts
+++ b/frontend/src/AppRoutes/routes.ts
@@ -443,6 +443,11 @@ export const oldNewRoutesMapping: Record<string, string> = {
 	'/settings/access-tokens': '/settings/api-keys',
 };
 
+export const ROUTES_NOT_TO_BE_OVERRIDEN: string[] = [
+	ROUTES.WORKSPACE_LOCKED,
+	ROUTES.WORKSPACE_SUSPENDED,
+];
+
 export interface AppRoutes {
 	component: RouteProps['component'];
 	path: RouteProps['path'];

--- a/frontend/src/providers/App/App.tsx
+++ b/frontend/src/providers/App/App.tsx
@@ -144,7 +144,7 @@ export function AppProvider({ children }: PropsWithChildren): JSX.Element {
 		error: orgPreferencesFetchError,
 	} = useQuery({
 		queryFn: () => getAllOrgPreferences(),
-		queryKey: ['getOrgPreferences'],
+		queryKey: ['getOrgPreferences', 'app-context'],
 		enabled: !!isLoggedIn && !!user.email && user.role === USER_ROLES.ADMIN,
 	});
 


### PR DESCRIPTION
### Summary

- do not try to route to org onboarding when the workspace is locked or suspended 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevents routing to onboarding when workspace is locked or suspended by checking new `ROUTES_NOT_TO_BE_OVERRIDEN` constant.
> 
>   - **Behavior**:
>     - Prevents routing to organization onboarding when workspace is locked or suspended by checking `ROUTES_NOT_TO_BE_OVERRIDEN` in `PrivateRoute` in `Private.tsx`.
>   - **Routes**:
>     - Adds `ROUTES_NOT_TO_BE_OVERRIDEN` in `routes.ts` with `ROUTES.WORKSPACE_LOCKED` and `ROUTES.WORKSPACE_SUSPENDED`.
>   - **Misc**:
>     - Updates query key in `App.tsx` for `getOrgPreferences` to include `'app-context'`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 073a77a803f0882f3372f6234e508baa91259a32. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->