### PR TITLE
chore: changed droprate view options values

### DIFF
--- a/frontend/src/pages/MessagingQueues/MQDetails/DropRateView/EvaluationTimeSelector.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/DropRateView/EvaluationTimeSelector.tsx
@@ -41,7 +41,9 @@ function EvaluationTimeSelector({
 	setInterval: Dispatch<SetStateAction<string>>;
 }): JSX.Element {
 	const [inputValue, setInputValue] = useState<string>('');
-	const [selectedInterval, setSelectedInterval] = useState<string | null>('5ms');
+	const [selectedInterval, setSelectedInterval] = useState<string | null>(
+		'10ms',
+	);
 	const [dropdownOpen, setDropdownOpen] = useState<boolean>(false);
 
 	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
@@ -98,11 +100,13 @@ function EvaluationTimeSelector({
 				onDropdownVisibleChange={setDropdownOpen}
 				dropdownRender={renderDropdown}
 			>
-				<Option value="1ms">1ms</Option>
-				<Option value="2ms">2ms</Option>
-				<Option value="5ms">5ms</Option>
 				<Option value="10ms">10ms</Option>
-				<Option value="15ms">15ms</Option>
+				<Option value="20ms">20ms</Option>
+				<Option value="50ms">50ms</Option>
+				<Option value="100ms">100ms</Option>
+				<Option value="150ms">150ms</Option>
+				<Option value="200ms">200ms</Option>
+				<Option value="500ms">500ms</Option>
 			</Select>
 		</div>
 	);


### PR DESCRIPTION
### Summary

Changed drop rate options from - `1ms`, `2ms`, `5ms`, `10ms`, `15ms` to `10ms`, `20ms`, `50ms`, `100ms`, `150ms`, `200ms`, `500ms`

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

**Before -**
-------------

<img width="406" alt="image" src="https://github.com/user-attachments/assets/b7e2c07a-05c3-46bb-8759-7b9016724054" />

**After:**
 -----------
 
<img width="396" alt="image" src="https://github.com/user-attachments/assets/dff7b3c9-a3bf-456e-9d69-048163dd1138" />


https://github.com/user-attachments/assets/c213961c-479b-4ef2-8244-4b49f8a5aa34



#### Affected Areas and Manually Tested Areas

Tested droprate view dropdown selection and respective API payload and responses

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated drop rate options and default selection in `EvaluationTimeSelector.tsx`.
> 
>   - **Behavior**:
>     - Updated drop rate options in `EvaluationTimeSelector.tsx` from `1ms`, `2ms`, `5ms`, `10ms`, `15ms` to `10ms`, `20ms`, `50ms`, `100ms`, `150ms`, `200ms`, `500ms`.
>     - Changed default selected interval from `5ms` to `10ms` in `EvaluationTimeSelector.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 806d9449e919024750e6595d46ae80faf9cf2087. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->