### PR TITLE
feat: add k8s pod name as quick filter for logs

### DIFF
--- a/frontend/src/pages/LogsExplorer/utils.tsx
+++ b/frontend/src/pages/LogsExplorer/utils.tsx
@@ -110,4 +110,16 @@ export const LogsQuickFiltersConfig: IQuickFiltersConfig[] = [
 		},
 		defaultOpen: false,
 	},
+	{
+		type: FiltersType.CHECKBOX,
+		title: 'K8s Pod Name',
+		attributeKey: {
+			key: 'k8s.pod.name',
+			dataType: DataTypes.String,
+			type: 'resource',
+			isColumn: false,
+			isJSON: false,
+		},
+		defaultOpen: false,
+	},
 ];


### PR DESCRIPTION
### Summary

- add k8s pod name as quick filter attribute for logs 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `K8s Pod Name` as a quick filter in `LogsQuickFiltersConfig` in `utils.tsx`.
> 
>   - **Feature**:
>     - Add `K8s Pod Name` as a quick filter in `LogsQuickFiltersConfig` in `utils.tsx`.
>     - Uses `k8s.pod.name` as the attribute key with `DataTypes.String` and `resource` type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 826508fa7e8cbc01ca7d9baf04a000eda3d37953. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->