### PR TITLE
fix: update API key expiration display logic in MultiIngestionSettings component

### DIFF
--- a/frontend/src/container/IngestionSettings/MultiIngestionSettings.tsx
+++ b/frontend/src/container/IngestionSettings/MultiIngestionSettings.tsx
@@ -561,10 +561,11 @@ function MultiIngestionSettings(): JSX.Element {
 					APIKey.created_at,
 					formatTimezoneAdjustedTimestamp,
 				);
-				const formattedDateAndTime =
-					APIKey &&
-					APIKey?.expires_at &&
-					getFormattedTime(APIKey?.expires_at, formatTimezoneAdjustedTimestamp);
+
+				const expiresOn =
+					!APIKey?.expires_at || APIKey?.expires_at === '0001-01-01T00:00:00Z'
+						? 'No Expiry'
+						: getFormattedTime(APIKey?.expires_at, formatTimezoneAdjustedTimestamp);
 
 				const updatedOn = getFormattedTime(
 					APIKey?.updated_at,
@@ -987,7 +988,7 @@ function MultiIngestionSettings(): JSX.Element {
 							<div className="ingestion-key-last-used-at">
 								<CalendarClock size={14} />
 								Expires on <Minus size={12} />
-								<Typography.Text>{formattedDateAndTime}</Typography.Text>
+								<Typography.Text>{expiresOn}</Typography.Text>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
### Summary
- display 'No Expiry' for invalid or zero date expiration dates.
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
Before:
![Screenshot from 2024-12-26 13-14-28](https://github.com/user-attachments/assets/a8114fed-eda9-4c2c-bf15-19657fdc6895)

After:
![Screenshot from 2024-12-26 13-13-25](https://github.com/user-attachments/assets/0a16c785-1e76-43a4-b07b-0e92af425d13)

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas
- Ingestion Settings
<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `MultiIngestionSettings` to display 'No Expiry' for API keys with invalid or zero expiration dates.
> 
>   - **Behavior**:
>     - In `MultiIngestionSettings`, display 'No Expiry' for API keys with `expires_at` as `null` or `0001-01-01T00:00:00Z`.
>     - Updates the `expiresOn` logic to handle invalid or zero date expiration dates.
>   - **UI**:
>     - Updates the expiration display in the `ingestion-key-details` section to use the new `expiresOn` logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for f80c58e5afaa4e6191021487d6140135a734cc65. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->