### PR TITLE
ci(releaser): github workflow for signoz releases

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -1,0 +1,16 @@
+name: releaser
+
+on:
+  # schedule every wednesday 9:30 AM UTC (3pm IST)
+  schedule:
+    - cron: '30 9 * * 3'
+
+  # allow manual triggering of the workflow by a maintainer with no inputs
+  workflow_dispatch: {}
+
+jobs:
+  releaser:
+    uses: signoz/primus.workflows/.github/workflows/releaser-signoz.yaml@feat/releaser-signoz
+    secrets: inherit
+    with:
+      PRIMUS_REF: feat/signoz-releaser


### PR DESCRIPTION
### Summary

- github workflow for automated SigNoz releases
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds GitHub workflow `releaser.yaml` for automated SigNoz releases, scheduled weekly and supporting manual triggers.
> 
>   - **GitHub Workflow**:
>     - Adds `releaser.yaml` for automated SigNoz releases.
>     - Scheduled to run every Wednesday at 9:30 AM UTC.
>     - Supports manual triggering via `workflow_dispatch`.
>   - **Jobs**:
>     - Uses `signoz/primus.workflows/.github/workflows/releaser-signoz.yaml@feat/releaser-signoz` for the release process.
>     - Inherits secrets and sets `PRIMUS_REF` to `feat/signoz-releaser`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e4084598b46f398514f001d01d27188e71dfe600. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->