### PR TITLE
add host ports as config flags

### DIFF
--- a/pkg/query-service/app/server.go
+++ b/pkg/query-service/app/server.go
@@ -56,6 +56,8 @@ type ServerOptions struct {
 	SkipTopLvlOpsPath string
 	HTTPHostPort      string
 	PrivateHostPort   string
+	DebugHostPort     string
+	OpAmpWsEndpoint   string
 	// alert specific params
 	DisableRules      bool
 	RuleRepoURL       string
@@ -656,9 +658,9 @@ func (s *Server) Start() error {
 	}()
 
 	go func() {
-		zap.L().Info("Starting pprof server", zap.String("addr", constants.DebugHttpPort))
+		zap.L().Info("Starting pprof server", zap.String("addr", s.serverOptions.DebugHostPort))
 
-		err = http.ListenAndServe(constants.DebugHttpPort, nil)
+		err = http.ListenAndServe(s.serverOptions.DebugHostPort, nil)
 		if err != nil {
 			zap.L().Error("Could not start pprof server", zap.Error(err))
 		}
@@ -685,8 +687,8 @@ func (s *Server) Start() error {
 	}()
 
 	go func() {
-		zap.L().Info("Starting OpAmp Websocket server", zap.String("addr", constants.OpAmpWsEndpoint))
-		err := s.opampServer.Start(constants.OpAmpWsEndpoint)
+		zap.L().Info("Starting OpAmp Websocket server", zap.String("addr", s.serverOptions.OpAmpWsEndpoint))
+		err := s.opampServer.Start(s.serverOptions.OpAmpWsEndpoint)
 		if err != nil {
 			zap.L().Info("opamp ws server failed to start", zap.Error(err))
 			s.unavailableChannel <- healthcheck.Unavailable

--- a/pkg/query-service/main.go
+++ b/pkg/query-service/main.go
@@ -50,6 +50,11 @@ func main() {
 	var maxOpenConns int
 	var dialTimeout time.Duration
 
+	var httpHostPort string
+	var privateHostPort string
+	var debugHostPort string
+	var opAmpWsEndpoint string
+
 	flag.BoolVar(&useLogsNewSchema, "use-logs-new-schema", false, "use logs_v2 schema for logs")
 	flag.BoolVar(&useTraceNewSchema, "use-trace-new-schema", false, "use new schema for traces")
 	flag.StringVar(&promConfigPath, "config", "./config/prometheus.yml", "(prometheus config to read metrics)")
@@ -65,6 +70,11 @@ func main() {
 	flag.IntVar(&maxIdleConns, "max-idle-conns", 50, "(number of connections to maintain in the pool, only used with clickhouse if not set in ClickHouseUrl env var DSN.)")
 	flag.IntVar(&maxOpenConns, "max-open-conns", 100, "(max connections for use at any time, only used with clickhouse if not set in ClickHouseUrl env var DSN.)")
 	flag.DurationVar(&dialTimeout, "dial-timeout", 5*time.Second, "(the maximum time to establish a connection, only used with clickhouse if not set in ClickHouseUrl env var DSN.)")
+	// Host ports
+	flag.StringVar(&httpHostPort, "http-host-port", constants.HTTPHostPort, "Address to listen on for HTTP requests")
+	flag.StringVar(&privateHostPort, "private-host-port", constants.PrivateHostPort, "Address to listen on for private HTTP requests")
+	flag.StringVar(&debugHostPort, "debug-host-port", constants.DebugHttpPort, "Address to listen on for debug HTTP requests")
+	flag.StringVar(&opAmpWsEndpoint, "opamp-ws-endpoint", constants.OpAmpWsEndpoint, "Address to listen on for OpAmp WS requests")
 	flag.Parse()
 
 	loggerMgr := initZapLog()
@@ -75,11 +85,13 @@ func main() {
 	version.PrintVersion()
 
 	serverOptions := &app.ServerOptions{
-		HTTPHostPort:      constants.HTTPHostPort,
+		HTTPHostPort:      httpHostPort,
+		PrivateHostPort:   privateHostPort,
+		DebugHostPort:     debugHostPort,
+		OpAmpWsEndpoint:   opAmpWsEndpoint,
 		PromConfigPath:    promConfigPath,
 		SkipTopLvlOpsPath: skipTopLvlOpsPath,
 		PreferSpanMetrics: preferSpanMetrics,
-		PrivateHostPort:   constants.PrivateHostPort,
 		DisableRules:      disableRules,
 		RuleRepoURL:       ruleRepoURL,
 		MaxIdleConns:      maxIdleConns,


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->
Adding host port config flags for http, private http, debug http, and opamp servers to allow using ipv6.
Defaults are set to previous constant values.

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add configuration flags for host ports in `main.go` and update `server.go` to use these flags for server initialization.
> 
>   - **Behavior**:
>     - Adds configuration flags for `http-host-port`, `private-host-port`, `debug-host-port`, and `opamp-ws-endpoint` in `main.go`.
>     - Updates `ServerOptions` in `server.go` to use these flags instead of constants.
>   - **Server Initialization**:
>     - `NewServer` in `server.go` now initializes ports using the new flags.
>     - `Start` function in `server.go` uses `serverOptions` for port configuration.
>   - **Misc**:
>     - Defaults for new flags are set to previous constant values in `constants`.
>     - Minor logging updates in `server.go` to reflect new port configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for d4036006b2e85e308e9a19c58af500e336ae2cf5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->