### PR TITLE
ci(releaser): trigger charts releaser workflow on new release

### DIFF
--- a/.github/workflows/prereleaser.yaml
+++ b/.github/workflows/prereleaser.yaml
@@ -1,11 +1,11 @@
-name: releaser-signoz
+name: prereleaser
 
 on:
   # schedule every wednesday 9:30 AM UTC (3pm IST)
   schedule:
     - cron: '30 9 * * 3'
 
-  # allow manual triggering of the workflow by a maintainer with no inputs
+  # allow manual triggering of the workflow by a maintainer
   workflow_dispatch:
     inputs:
       release_type:

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -1,0 +1,39 @@
+name: releaser
+
+on:
+  # trigger on new latest release
+  release:
+    types: [published]
+
+jobs:
+  charts:
+    runs-on: ubuntu-latest
+    steps:
+      - id: token
+        name: github-token-gen
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PRIMUS_APP_ID }}
+          private-key: ${{ secrets.PRIMUS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: trigger-charts-prereleaser
+        run: |
+          # Variables
+          repo_owner="signoz"
+          repo_name="charts"
+          event_type="prereleaser"
+
+          # identify the release type
+          release_tag=${{ github.event.release.tag_name }}
+          patch_number=$(echo $release_tag | awk -F. '{print $3}')
+          release_type="minor"
+          if [[ $patch_number -ne 0 ]]; then
+            release_type="patch"
+          fi
+
+          # trigger the releaser workflow in signoz/charts repo
+          curl -L -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ steps.token.outputs.token }}" \
+            "https://api.github.com/repos/${repo_owner}/${repo_name}/dispatches" \
+            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"release_type\": \"$release_type\"}}"


### PR DESCRIPTION
### Summary

- GH workflow to trigger releaser workflow in charts repository on new SigNoz release
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a GitHub workflow to trigger the charts releaser on new SigNoz releases, renaming and creating workflows for this purpose.
> 
>   - **Workflows**:
>     - Renames `releaser-signoz.yaml` to `prereleaser.yaml`.
>     - Adds new `releaser.yaml` to trigger charts releaser workflow on new SigNoz release.
>   - **Triggering**:
>     - `releaser.yaml` triggers on new release publication.
>     - Uses `actions/create-github-app-token@v1` to generate GitHub token.
>     - Sends POST request to `signoz/charts` repo to trigger `prereleaser` event.
>   - **Release Type Detection**:
>     - Determines release type (`minor` or `patch`) based on release tag in `releaser.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 35320bbc844f2ea31c09099eb404df2592541528. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->