### PR TITLE
fix(ci): fix jest coverage since github workflow

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
 		"husky:configure": "cd .. && husky install frontend/.husky && cd frontend && chmod ug+x .husky/*",
 		"commitlint": "commitlint --edit $1",
 		"test": "jest --coverage",
-		"test:changedsince": "jest --changedSince=develop --coverage --silent"
+		"test:changedsince": "jest --changedSince=main --coverage --silent"
 	},
 	"engines": {
 		"node": ">=16.15.0"


### PR DESCRIPTION
### Summary

- update the base branch for jest coverage to be `main` rather than `develop` 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
