### PR TITLE
feat: enable billing and org-settings in workspace blocked state

### DIFF
--- a/frontend/src/AppRoutes/Private.tsx
+++ b/frontend/src/AppRoutes/Private.tsx
@@ -11,6 +11,7 @@ import { useQuery } from 'react-query';
 import { matchPath, useLocation } from 'react-router-dom';
 import { LicenseState, LicenseStatus } from 'types/api/licensesV3/getActive';
 import { Organization } from 'types/api/user/getOrganization';
+import { USER_ROLES } from 'types/roles';
 import { isCloudUser } from 'utils/app';
 import { routePermission } from 'utils/permission';
 
@@ -36,6 +37,8 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 		activeLicenseV3,
 		isFetchingActiveLicenseV3,
 	} = useAppContext();
+
+	const isAdmin = user.role === USER_ROLES.ADMIN;
 	const mapRoutes = useMemo(
 		() =>
 			new Map(
@@ -113,11 +116,16 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 	const navigateToWorkSpaceBlocked = (route: any): void => {
 		const { path } = route;
 
+		const isRouteEnabledForWorkspaceBlockedState =
+			isAdmin &&
+			(path === ROUTES.ORG_SETTINGS ||
+				path === ROUTES.BILLING ||
+				path === ROUTES.MY_SETTINGS);
+
 		if (
 			path &&
 			path !== ROUTES.WORKSPACE_LOCKED &&
-			path !== ROUTES.ORG_SETTINGS &&
-			path !== ROUTES.BILLING
+			!isRouteEnabledForWorkspaceBlockedState
 		) {
 			history.push(ROUTES.WORKSPACE_LOCKED);
 		}
@@ -132,6 +140,7 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 				navigateToWorkSpaceBlocked(currentRoute);
 			}
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [isFetchingLicenses, licenses?.workSpaceBlock, mapRoutes, pathname]);
 
 	const navigateToWorkSpaceSuspended = (route: any): void => {

--- a/frontend/src/AppRoutes/Private.tsx
+++ b/frontend/src/AppRoutes/Private.tsx
@@ -113,7 +113,12 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 	const navigateToWorkSpaceBlocked = (route: any): void => {
 		const { path } = route;
 
-		if (path && path !== ROUTES.WORKSPACE_LOCKED) {
+		if (
+			path &&
+			path !== ROUTES.WORKSPACE_LOCKED &&
+			path !== ROUTES.ORG_SETTINGS &&
+			path !== ROUTES.BILLING
+		) {
 			history.push(ROUTES.WORKSPACE_LOCKED);
 		}
 	};

--- a/frontend/src/container/SideNav/NavItem/NavItem.styles.scss
+++ b/frontend/src/container/SideNav/NavItem/NavItem.styles.scss
@@ -15,6 +15,13 @@
 		}
 	}
 
+	&.disabled {
+		.nav-item-data {
+			opacity: 0.5;
+			cursor: not-allowed;
+		}
+	}
+
 	&:hover {
 		cursor: pointer;
 

--- a/frontend/src/container/SideNav/NavItem/NavItem.tsx
+++ b/frontend/src/container/SideNav/NavItem/NavItem.tsx
@@ -11,17 +11,28 @@ export default function NavItem({
 	item,
 	isActive,
 	onClick,
+	isDisabled,
 }: {
 	item: SidebarItem;
 	isActive: boolean;
 	onClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+	isDisabled: boolean;
 }): JSX.Element {
 	const { label, icon, isBeta, isNew } = item;
 
 	return (
 		<div
-			className={cx('nav-item', isActive ? 'active' : '')}
-			onClick={(event): void => onClick(event)}
+			className={cx(
+				'nav-item',
+				isActive ? 'active' : '',
+				isDisabled ? 'disabled' : '',
+			)}
+			onClick={(event): void => {
+				if (isDisabled) {
+					return;
+				}
+				onClick(event);
+			}}
 		>
 			<div className="nav-item-active-marker" />
 			<div className={cx('nav-item-data', isBeta ? 'beta-tag' : '')}>

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -89,6 +89,8 @@ function SideNav(): JSX.Element {
 	const licenseStatus: string =
 		licenses?.licenses?.find((e: License) => e.isCurrent)?.status || '';
 
+	const isWorkspaceBlocked = licenses?.workSpaceBlock || false;
+
 	const isLicenseActive =
 		licenseStatus?.toLocaleLowerCase() ===
 		LICENSE_PLAN_STATUS.VALID.toLocaleLowerCase();
@@ -351,7 +353,11 @@ function SideNav(): JSX.Element {
 					<div className="get-started-nav-items">
 						<Button
 							className="get-started-btn"
+							disabled={isWorkspaceBlocked}
 							onClick={(event: MouseEvent): void => {
+								if (isWorkspaceBlocked) {
+									return;
+								}
 								onClickGetStarted(event);
 							}}
 						>
@@ -369,6 +375,11 @@ function SideNav(): JSX.Element {
 								key={item.key || index}
 								item={item}
 								isActive={activeMenuKey === item.key}
+								isDisabled={
+									isWorkspaceBlocked &&
+									item.key !== ROUTES.BILLING &&
+									item.key !== ROUTES.SETTINGS
+								}
 								onClick={(event): void => {
 									handleMenuItemClick(event, item);
 								}}
@@ -380,6 +391,7 @@ function SideNav(): JSX.Element {
 						<NavItem
 							key="keyboardShortcuts"
 							item={shortcutMenuItem}
+							isDisabled={isWorkspaceBlocked}
 							isActive={false}
 							onClick={onClickShortcuts}
 						/>
@@ -389,6 +401,7 @@ function SideNav(): JSX.Element {
 								key="trySignozCloud"
 								item={trySignozCloudMenuItem}
 								isActive={false}
+								isDisabled={isWorkspaceBlocked}
 								onClick={onClickSignozCloud}
 							/>
 						)}
@@ -399,6 +412,7 @@ function SideNav(): JSX.Element {
 									key={item?.key || index}
 									item={item}
 									isActive={activeMenuKey === item?.key}
+									isDisabled={isWorkspaceBlocked}
 									onClick={(event: MouseEvent): void => {
 										handleUserManagentMenuItemClick(item?.key as string, event);
 										logEvent('Sidebar: Menu clicked', {
@@ -415,6 +429,7 @@ function SideNav(): JSX.Element {
 								key={inviteMemberMenuItem.key}
 								item={inviteMemberMenuItem}
 								isActive={activeMenuKey === inviteMemberMenuItem?.key}
+								isDisabled={false}
 								onClick={(event: React.MouseEvent): void => {
 									if (isCtrlMetaKey(event)) {
 										openInNewTab(`${inviteMemberMenuItem.key}`);
@@ -434,6 +449,7 @@ function SideNav(): JSX.Element {
 								key={ROUTES.MY_SETTINGS}
 								item={userSettingsMenuItem}
 								isActive={activeMenuKey === userSettingsMenuItem?.key}
+								isDisabled={false}
 								onClick={(event: MouseEvent): void => {
 									handleUserManagentMenuItemClick(
 										userSettingsMenuItem?.key as string,

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -11,7 +11,9 @@ import { getRoutes } from './utils';
 
 function SettingsPage(): JSX.Element {
 	const { pathname } = useLocation();
-	const { user, featureFlags } = useAppContext();
+	const { user, featureFlags, licenses } = useAppContext();
+
+	const isWorkspaceBlocked = licenses?.workSpaceBlock || false;
 
 	const [isCurrentOrgSettings] = useComponentPermission(
 		['current_org_settings'],
@@ -24,8 +26,15 @@ function SettingsPage(): JSX.Element {
 			?.active || false;
 
 	const routes = useMemo(
-		() => getRoutes(user.role, isCurrentOrgSettings, isGatewayEnabled, t),
-		[user.role, isCurrentOrgSettings, isGatewayEnabled, t],
+		() =>
+			getRoutes(
+				user.role,
+				isCurrentOrgSettings,
+				isGatewayEnabled,
+				isWorkspaceBlocked,
+				t,
+			),
+		[user.role, isCurrentOrgSettings, isGatewayEnabled, isWorkspaceBlocked, t],
 	);
 
 	return <RouteTab routes={routes} activeKey={pathname} history={history} />;

--- a/frontend/src/pages/Settings/utils.ts
+++ b/frontend/src/pages/Settings/utils.ts
@@ -17,6 +17,7 @@ export const getRoutes = (
 	userRole: ROLES | null,
 	isCurrentOrgSettings: boolean,
 	isGatewayEnabled: boolean,
+	isWorkspaceBlocked: boolean,
 	t: TFunction,
 ): RouteTabProps['routes'] => {
 	const settings = [];
@@ -26,6 +27,12 @@ export const getRoutes = (
 
 	const isAdmin = userRole === USER_ROLES.ADMIN;
 	const isEditor = userRole === USER_ROLES.EDITOR;
+
+	if (isWorkspaceBlocked && isAdmin) {
+		settings.push(...organizationSettings(t));
+
+		return settings;
+	}
 
 	settings.push(...generalSettings(t));
 

--- a/frontend/src/pages/WorkspaceLocked/WorkspaceLocked.styles.scss
+++ b/frontend/src/pages/WorkspaceLocked/WorkspaceLocked.styles.scss
@@ -49,6 +49,14 @@ $dark-theme: 'darkMode';
 				display: flex;
 				align-items: center;
 				gap: 16px;
+
+				.ant-btn-link {
+					color: var(--text-vanilla-400);
+
+					.#{$light-theme} & {
+						color: var(--text-ink-200);
+					}
+				}
 			}
 		}
 		.ant-modal-content {

--- a/frontend/src/pages/WorkspaceLocked/WorkspaceLocked.tsx
+++ b/frontend/src/pages/WorkspaceLocked/WorkspaceLocked.tsx
@@ -126,6 +126,12 @@ export default function WorkspaceBlocked(): JSX.Element {
 		});
 	};
 
+	const handleViewBilling = (): void => {
+		logEvent('Workspace Blocked: User Clicked View Billing', {});
+
+		history.push(ROUTES.BILLING);
+	};
+
 	const renderCustomerStories = (
 		filterCondition: (index: number) => boolean,
 	): JSX.Element[] =>
@@ -276,6 +282,18 @@ export default function WorkspaceBlocked(): JSX.Element {
 							{t('trialPlanExpired')}
 						</span>
 						<span className="workspace-locked__modal__header__actions">
+							{isAdmin && (
+								<Button
+									className="workspace-locked__modal__header__actions__billing"
+									type="link"
+									size="small"
+									role="button"
+									onClick={handleViewBilling}
+								>
+									View Billing
+								</Button>
+							)}
+
 							<Typography.Text className="workspace-locked__modal__title">
 								Got Questions?
 							</Typography.Text>


### PR DESCRIPTION
Fixes - https://github.com/SigNoz/engineering-pod/issues/1991
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable billing and organization settings access for admins in workspace blocked state, with UI updates for disabled elements.
> 
>   - **Behavior**:
>     - Allow admins to access `ORG_SETTINGS`, `BILLING`, and `MY_SETTINGS` routes in workspace blocked state in `Private.tsx`.
>     - Update `navigateToWorkSpaceBlocked` to check for admin role and specific routes.
>   - **UI Components**:
>     - Add `isDisabled` prop to `NavItem` in `NavItem.tsx` to handle disabled state.
>     - Update `SideNav.tsx` to disable menu items when workspace is blocked, except for billing and settings for admins.
>     - Add `View Billing` button for admins in `WorkspaceLocked.tsx`.
>   - **Styles**:
>     - Add `.disabled` class styling in `NavItem.styles.scss` to indicate disabled state visually.
>     - Update `WorkspaceLocked.styles.scss` for button styling in blocked state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for dc89503f9a562e9f88e850754b655c6f0f608aa0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->