### PR TITLE
fix: fixed tables view not honouring order by in traces explorer

### DIFF
--- a/frontend/src/lib/query/createTableColumnsFromQuery.ts
+++ b/frontend/src/lib/query/createTableColumnsFromQuery.ts
@@ -572,6 +572,7 @@ export const createTableColumnsFromQuery: CreateTableDataFromQuery = ({
 		a.queryName < b.queryName ? -1 : 1,
 	);
 
+	console.log('here', queryTableData, query);
 	// the reason we need this is because the filling of values in rows doesn't account for mismatch enteries
 	// in the response. Example : Series A -> [label1, label2] and Series B -> [label2,label1] this isn't accounted for
 	sortedQueryTableData.forEach((q) => {

--- a/frontend/src/lib/query/createTableColumnsFromQuery.ts
+++ b/frontend/src/lib/query/createTableColumnsFromQuery.ts
@@ -572,30 +572,6 @@ export const createTableColumnsFromQuery: CreateTableDataFromQuery = ({
 		a.queryName < b.queryName ? -1 : 1,
 	);
 
-	console.log('here', queryTableData, query);
-	// the reason we need this is because the filling of values in rows doesn't account for mismatch enteries
-	// in the response. Example : Series A -> [label1, label2] and Series B -> [label2,label1] this isn't accounted for
-	sortedQueryTableData.forEach((q) => {
-		q.series?.forEach((s) => {
-			s.labelsArray?.sort((a, b) =>
-				Object.keys(a)[0] < Object.keys(b)[0] ? -1 : 1,
-			);
-		});
-		q.series?.sort((a, b) => {
-			let labelA = '';
-			let labelB = '';
-			a.labelsArray?.forEach((lab) => {
-				labelA += Object.values(lab)[0];
-			});
-
-			b.labelsArray?.forEach((lab) => {
-				labelB += Object.values(lab)[0];
-			});
-
-			return labelA < labelB ? -1 : 1;
-		});
-	});
-
 	const dynamicColumns = getDynamicColumns(sortedQueryTableData, query);
 
 	const { filledDynamicColumns, rowsLength } = fillColumnsData(


### PR DESCRIPTION
### Summary

Here the sorting via orderBy query was not being honoured due a manually sorting added in between, that was added due to some other issue - here - https://github.com/SigNoz/signoz/pull/5248/

But we dont need that anymore as the logic has shifted to BE, hence reverted it, with this the orderBy query sorting is getting correctly rendered. (check video below)

#### Related Issues / PR's

https://github.com/SigNoz/engineering-pod/issues/2130

#### Screenshots


https://github.com/user-attachments/assets/76468b32-ad6f-4a3f-8d39-7be5113dd5e0



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes manual sorting in `createTableColumnsFromQuery.ts` to restore `orderBy` query sorting in traces explorer.
> 
>   - **Behavior**:
>     - Removes manual sorting logic in `createTableColumnsFromQuery.ts` that was overriding `orderBy` query sorting.
>     - Restores correct sorting behavior based on `orderBy` query in traces explorer.
>   - **Misc**:
>     - Reverts changes from a previous PR that added the manual sorting logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for daf98c3c1016d54e7fd867b37d6bec0145f3f339. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->