### PR TITLE
fix(portal): use window.location.origin instead of the window.location.href

### DIFF
--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -272,7 +272,7 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 	const handleFailedPayment = (): void => {
 		manageCreditCard({
 			licenseKey: activeLicenseV3?.key || '',
-			successURL: window.location.href,
+			successURL: window.location.origin,
 			cancelURL: window.location.href,
 		});
 	};

--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -273,7 +273,7 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 		manageCreditCard({
 			licenseKey: activeLicenseV3?.key || '',
 			successURL: window.location.origin,
-			cancelURL: window.location.href,
+			cancelURL: window.location.origin,
 		});
 	};
 


### PR DESCRIPTION
### Summary

- the portal session fails when the `return_url` is too large, instead use the origin only

#### Related Issues / PR's

contributes to - https://github.com/SigNoz/engineering-pod/issues/2129 

