### PR TITLE
fix: resolve k8s pods list local storage issue

### DIFF
--- a/frontend/src/container/InfraMonitoringK8s/Pods/K8sPodLists.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Pods/K8sPodLists.tsx
@@ -105,7 +105,7 @@ function K8sPodsList({
 	);
 
 	useEffect(() => {
-		const addedColumns = JSON.parse(get('k8sPodsAddedColumns') ?? '');
+		const addedColumns = JSON.parse(get('k8sPodsAddedColumns') ?? '[]');
 
 		if (addedColumns && addedColumns.length > 0) {
 			const availableColumns = defaultAvailableColumns.filter(


### PR DESCRIPTION
### Summary

Pods List UI was breaking when opened for the 1st time as it couldn't find the column config key in local storage.
Updated the logic to handle it.

#### Related Issues / PR's


#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

Infra Monitoring section

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes UI breakage in `K8sPodsList` by defaulting missing local storage key to an empty array.
> 
>   - **Behavior**:
>     - Fixes issue in `K8sPodsList` where the UI breaks if `k8sPodsAddedColumns` key is missing in local storage by defaulting to an empty array.
>   - **Code**:
>     - Updates `useEffect` in `K8sPodsList.tsx` to use `JSON.parse(get('k8sPodsAddedColumns') ?? '[]')` instead of `JSON.parse(get('k8sPodsAddedColumns') ?? '')`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for efbd637611cd69705654c0d121129ea33b827aa5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->