### PR TITLE
fix: avoid loading Segment analytics when SEGMENT_ID is not set

### DIFF
--- a/frontend/src/index.html.ejs
+++ b/frontend/src/index.html.ejs
@@ -100,76 +100,79 @@
 		</script>
 
 		<script>
-			//Set your SEGMENT_ID
-			const SEGMENT_ID = '<%= htmlWebpackPlugin.options.SEGMENT_ID %>';
+            // Set your SEGMENT_ID
+            const SEGMENT_ID = '<%= htmlWebpackPlugin.options.SEGMENT_ID %>';
 
-			!(function () {
-				var analytics = (window.analytics = window.analytics || []);
-				if (!analytics.initialize)
-					if (analytics.invoked)
-						window.console &&
-							console.error &&
-							console.error('Segment snippet included twice.');
-					else {
-						analytics.invoked = !0;
-						analytics.methods = [
-							'trackSubmit',
-							'trackClick',
-							'trackLink',
-							'trackForm',
-							'pageview',
-							'identify',
-							'reset',
-							'group',
-							'track',
-							'ready',
-							'alias',
-							'debug',
-							'page',
-							'once',
-							'off',
-							'on',
-							'addSourceMiddleware',
-							'addIntegrationMiddleware',
-							'setAnonymousId',
-							'addDestinationMiddleware',
-						];
-						analytics.factory = function (e) {
-							return function () {
-								if (window.analytics.initialized)
-									return window.analytics[e].apply(window.analytics, arguments);
-								var i = Array.prototype.slice.call(arguments);
-								i.unshift(e);
-								analytics.push(i);
-								return analytics;
-							};
-						};
-						for (var i = 0; i < analytics.methods.length; i++) {
-							var key = analytics.methods[i];
-							analytics[key] = analytics.factory(key);
-						}
-						analytics.load = function (key, i) {
-							var t = document.createElement('script');
-							t.type = 'text/javascript';
-							t.async = !0;
-							t.src =
-								'https://analytics-cdn.signoz.io/analytics.js/v1/' +
-								key +
-								'/analytics.min.js';
-							var n = document.getElementsByTagName('script')[0];
-							n.parentNode.insertBefore(t, n);
-							analytics._loadOptions = i;
-						};
-						analytics._writeKey = SEGMENT_ID;
-						analytics.SNIPPET_VERSION = '4.16.1';
-						analytics.load(SEGMENT_ID, {
-							integrations: {
-								'Segment.io': { apiHost: 'analytics-api.signoz.io/v1' },
-							},
-						});
-						analytics.page();
-					}
-			})();
-		</script>
+            // Check if SEGMENT_ID is set
+            if (SEGMENT_ID) {
+                !(function () {
+                    var analytics = (window.analytics = window.analytics || []);
+                    if (!analytics.initialize)
+                        if (analytics.invoked)
+                            window.console &&
+                                console.error &&
+                                console.error('Segment snippet included twice.');
+                        else {
+                            analytics.invoked = !0;
+                            analytics.methods = [
+                                'trackSubmit',
+                                'trackClick',
+                                'trackLink',
+                                'trackForm',
+                                'pageview',
+                                'identify',
+                                'reset',
+                                'group',
+                                'track',
+                                'ready',
+                                'alias',
+                                'debug',
+                                'page',
+                                'once',
+                                'off',
+                                'on',
+                                'addSourceMiddleware',
+                                'addIntegrationMiddleware',
+                                'setAnonymousId',
+                                'addDestinationMiddleware',
+                            ];
+                            analytics.factory = function (e) {
+                                return function () {
+                                    if (window.analytics.initialized)
+                                        return window.analytics[e].apply(window.analytics, arguments);
+                                    var i = Array.prototype.slice.call(arguments);
+                                    i.unshift(e);
+                                    analytics.push(i);
+                                    return analytics;
+                                };
+                            };
+                            for (var i = 0; i < analytics.methods.length; i++) {
+                                var key = analytics.methods[i];
+                                analytics[key] = analytics.factory(key);
+                            }
+                            analytics.load = function (key, i) {
+                                var t = document.createElement('script');
+                                t.type = 'text/javascript';
+                                t.async = !0;
+                                t.src =
+                                    'https://analytics-cdn.signoz.io/analytics.js/v1/' +
+                                    key +
+                                    '/analytics.min.js';
+                                var n = document.getElementsByTagName('script')[0];
+                                n.parentNode.insertBefore(t, n);
+                                analytics._loadOptions = i;
+                            };
+                            analytics._writeKey = SEGMENT_ID;
+                            analytics.SNIPPET_VERSION = '4.16.1';
+                            analytics.load(SEGMENT_ID, {
+                                integrations: {
+                                    'Segment.io': { apiHost: 'analytics-api.signoz.io/v1' },
+                                },
+                            });
+                            analytics.page();
+                        }
+                })();
+            }
+        </script>
 	</body>
 </html>


### PR DESCRIPTION
Added a check to prevent loading the Segment analytics script when SEGMENT_ID is not set. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a check in `index.html.ejs` to load Segment analytics only if `SEGMENT_ID` is set.
> 
>   - **Behavior**:
>     - Adds a check in `index.html.ejs` to load Segment analytics script only if `SEGMENT_ID` is set.
>     - Prevents loading and execution of Segment analytics when `SEGMENT_ID` is not configured.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for ad973390376811c19367e2ced4c820f92fc8f2c0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->