### PR TITLE
fix: conditionally render Intercom script in EJS based on APP_ID

### DIFF
--- a/frontend/src/index.html.ejs
+++ b/frontend/src/index.html.ejs
@@ -54,50 +54,51 @@
 
 		<link rel="stylesheet" href="/css/uPlot.min.css" />
 
-
 	</head>
 	<body>
 		<noscript>You need to enable JavaScript to run this app.</noscript>
 		<div id="root"></div>
 
-		<script>
-			//Set your APP_ID
-			const APP_ID = '<%= htmlWebpackPlugin.options.INTERCOM_APP_ID %>';
+		<% if (htmlWebpackPlugin.options.INTERCOM_APP_ID) { %>
+            <script>
+                // Set your APP_ID
+                const APP_ID = '<%= htmlWebpackPlugin.options.INTERCOM_APP_ID %>';
 
-			(function () {
-				var w = window;
-				var ic = w.Intercom;
-				if (typeof ic === 'function') {
-					ic('reattach_activator');
-					ic('update', w.intercomSettings);
-				} else {
-					var d = document;
-					var i = function () {
-						i.c(arguments);
-					};
-					i.q = [];
-					i.c = function (args) {
-						i.q.push(args);
-					};
-					w.Intercom = i;
-					var l = function () {
-						var s = d.createElement('script');
-						s.type = 'text/javascript';
-						s.async = true;
-						s.src = 'https://widget.intercom.io/widget/' + APP_ID;
-						var x = d.getElementsByTagName('script')[0];
-						x.parentNode.insertBefore(s, x);
-					};
-					if (document.readyState === 'complete') {
-						l();
-					} else if (w.attachEvent) {
-						w.attachEvent('onload', l);
-					} else {
-						w.addEventListener('load', l, false);
-					}
-				}
-			})();
-		</script>
+                (function () {
+                    var w = window;
+                    var ic = w.Intercom;
+                    if (typeof ic === 'function') {
+                        ic('reattach_activator');
+                        ic('update', w.intercomSettings);
+                    } else {
+                        var d = document;
+                        var i = function () {
+                            i.c(arguments);
+                        };
+                        i.q = [];
+                        i.c = function (args) {
+                            i.q.push(args);
+                        };
+                        w.Intercom = i;
+                        var l = function () {
+                            var s = d.createElement('script');
+                            s.type = 'text/javascript';
+                            s.async = true;
+                            s.src = 'https://widget.intercom.io/widget/' + APP_ID;
+                            var x = d.getElementsByTagName('script')[0];
+                            x.parentNode.insertBefore(s, x);
+                        };
+                        if (document.readyState === 'complete') {
+                            l();
+                        } else if (w.attachEvent) {
+                            w.attachEvent('onload', l);
+                        } else {
+                            w.addEventListener('load', l, false);
+                        }
+                    }
+                })();
+            </script>
+        <% } %>
 
 		<script>
 			//Set your SEGMENT_ID


### PR DESCRIPTION
Added EJS conditional logic to render the Intercom script tag only if INTERCOM_APP_ID is defined
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Conditionally renders Intercom script in `index.html.ejs` based on `INTERCOM_APP_ID`.
> 
>   - **Behavior**:
>     - Conditionally renders Intercom script in `index.html.ejs` only if `INTERCOM_APP_ID` is defined.
>     - Prevents loading Intercom script when `INTERCOM_APP_ID` is not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 4fdaaf2c8253167bbaeadb1ad53a5ceb9b09e252. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->