### PR TITLE
chore: add dummy jwt secret

### DIFF
--- a/ee/query-service/main.go
+++ b/ee/query-service/main.go
@@ -179,6 +179,9 @@ func main() {
 
 	if len(auth.JwtSecret) == 0 {
 		zap.L().Warn("No JWT secret key is specified.")
+		zap.L().Warn("Please specify a secret if running in production")
+		zap.L().Warn("Adding a dummy JWT token")
+		auth.JwtSecret = baseconst.SIGNOZ_JWT_SECRET
 	} else {
 		zap.L().Info("JWT secret key set successfully.")
 	}

--- a/pkg/query-service/constants/auth.go
+++ b/pkg/query-service/constants/auth.go
@@ -1,7 +1,8 @@
 package constants
 
 const (
-	AdminGroup  = "ADMIN"
-	EditorGroup = "EDITOR"
-	ViewerGroup = "VIEWER"
+	AdminGroup        = "ADMIN"
+	EditorGroup       = "EDITOR"
+	ViewerGroup       = "VIEWER"
+	SIGNOZ_JWT_SECRET = "dummy token"
 )

--- a/pkg/query-service/main.go
+++ b/pkg/query-service/main.go
@@ -97,6 +97,9 @@ func main() {
 
 	if len(auth.JwtSecret) == 0 {
 		zap.L().Warn("No JWT secret key is specified.")
+		zap.L().Warn("Please specify a secret if running in production")
+		zap.L().Warn("Adding a dummy JWT token")
+		auth.JwtSecret = constants.SIGNOZ_JWT_SECRET
 	} else {
 		zap.L().Info("JWT secret key set successfully.")
 	}


### PR DESCRIPTION
fixes: https://github.com/SigNoz/signoz/issues/6763

Currently if JWT_SECRET is not setup through env variable, it breaks the frontend.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a dummy JWT secret to be used if no JWT secret is specified, with warnings logged for production environments.
> 
>   - **Behavior**:
>     - Adds a dummy JWT secret `SIGNOZ_JWT_SECRET` in `auth.go` to be used if no JWT secret is specified.
>     - Updates `main.go` in both `ee/query-service` and `pkg/query-service` to set `auth.JwtSecret` to `SIGNOZ_JWT_SECRET` if the environment variable `SIGNOZ_JWT_SECRET` is not set.
>     - Logs a warning if the dummy JWT secret is used, advising to specify a secret in production.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 9f4af9fdc7aed93eb898a81756d012f8bf7f0852. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->