### PR TITLE
feat: toggle off infra monitoring

### DIFF
--- a/frontend/src/pages/InfrastructureMonitoring/InfrastructureMonitoringPage.tsx
+++ b/frontend/src/pages/InfrastructureMonitoring/InfrastructureMonitoringPage.tsx
@@ -5,12 +5,12 @@ import { TabRoutes } from 'components/RouteTab/types';
 import history from 'lib/history';
 import { useLocation } from 'react-use';
 
-import { Hosts, Kubernetes } from './constants';
+import { Hosts } from './constants';
 
 export default function InfrastructureMonitoringPage(): JSX.Element {
 	const { pathname } = useLocation();
 
-	const routes: TabRoutes[] = [Hosts, Kubernetes];
+	const routes: TabRoutes[] = [Hosts];
 
 	return (
 		<div className="infra-monitoring-module-container">


### PR DESCRIPTION
### Summary

Toggle off infra monitoring feature

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

<img width="1720" alt="Screenshot 2025-01-09 at 7 29 09 PM" src="https://github.com/user-attachments/assets/dc9b0504-378d-4854-bb42-df5106d7464b" />

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

Infra Monitoring section
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `Kubernetes` from `routes` in `InfrastructureMonitoringPage.tsx` to disable Kubernetes infra monitoring.
> 
>   - **Behavior**:
>     - Removed `Kubernetes` from `routes` array in `InfrastructureMonitoringPage.tsx`, disabling Kubernetes infra monitoring.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 9c01cec57f76db40d46c729ae7b0549772a2bfc4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->