### PR TITLE
feat: header auth

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -31,3 +31,6 @@ indent_size = 2
 [{package.json,.travis.yml}]
 indent_style = space
 indent_size = 2
+
+[*.{ts,tsx}]
+indent_style = tab

--- a/ee/query-service/app/api/auth.go
+++ b/ee/query-service/app/api/auth.go
@@ -50,7 +50,7 @@ func (ah *APIHandler) loginUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// if all looks good, call auth
-	resp, err := baseauth.Login(ctx, &req)
+	resp, err := baseauth.Login(ctx, &req, nil)
 	if ah.HandleError(w, err, http.StatusUnauthorized) {
 		return
 	}

--- a/frontend/src/container/Login/index.tsx
+++ b/frontend/src/container/Login/index.tsx
@@ -49,6 +49,7 @@ function Login({
 
 	const [precheckInProcess, setPrecheckInProcess] = useState(false);
 	const [precheckComplete, setPrecheckComplete] = useState(false);
+	const [headerAuthEmail, setHeaderAuthEmail] = useState<string | null>(null);
 
 	const { notifications } = useNotifications();
 
@@ -64,10 +65,13 @@ function Login({
 			getUserVersionResponse.data &&
 			getUserVersionResponse.data.payload
 		) {
-			const { setupCompleted } = getUserVersionResponse.data.payload;
+			const { setupCompleted, headerEmail } = getUserVersionResponse.data.payload;
 			if (!setupCompleted) {
 				// no org account registered yet, re-route user to sign up first
 				history.push(ROUTES.SIGN_UP);
+			}
+			if (headerEmail) {
+				setHeaderAuthEmail(headerEmail);
 			}
 		}
 	}, [getUserVersionResponse]);
@@ -185,6 +189,12 @@ function Login({
 			});
 		}
 	};
+
+	useEffect(() => {
+		form.setFieldValue('email', headerAuthEmail);
+		setPrecheckComplete(true);
+		form.submit();
+	}, [headerAuthEmail, form]);
 
 	const renderSAMLAction = (): JSX.Element => (
 		<Button

--- a/frontend/src/types/api/user/getVersion.ts
+++ b/frontend/src/types/api/user/getVersion.ts
@@ -2,4 +2,5 @@ export interface PayloadProps {
 	version: string;
 	ee: 'Y' | 'N';
 	setupCompleted: boolean;
+	headerEmail: string;
 }

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1897,10 +1897,15 @@ func (aH *APIHandler) getDisks(w http.ResponseWriter, r *http.Request) {
 
 func (aH *APIHandler) getVersion(w http.ResponseWriter, r *http.Request) {
 	version := version.GetVersion()
+	var headerEmail string
+	if user := auth.GetUserFromHeader(r); user != nil {
+		headerEmail = user.Email
+	}
 	versionResponse := model.GetVersionResponse{
 		Version:        version,
 		EE:             "Y",
 		SetupCompleted: aH.SetupCompleted,
+		HeaderEmail:    headerEmail,
 	}
 
 	aH.WriteJSON(w, r, versionResponse)
@@ -2112,7 +2117,7 @@ func (aH *APIHandler) loginUser(w http.ResponseWriter, r *http.Request) {
 	// 	req.RefreshToken = c.Value
 	// }
 
-	resp, err := auth.Login(context.Background(), req)
+	resp, err := auth.Login(context.Background(), req, auth.GetUserFromHeader(r))
 	if aH.HandleError(w, err, http.StatusUnauthorized) {
 		return
 	}

--- a/pkg/query-service/auth/rbac.go
+++ b/pkg/query-service/auth/rbac.go
@@ -61,6 +61,22 @@ func GetUserFromRequest(r *http.Request) (*model.UserPayload, error) {
 	return user, nil
 }
 
+func GetUserFromHeader(r *http.Request) *model.UserPayload {
+	email := r.Header.Get(HeaderAuthEmail)
+	if email == "" {
+		return nil
+	}
+	role := r.Header.Get(HeaderAuthRole)
+	org := r.Header.Get(HeaderAuthOrg)
+	return &model.UserPayload{
+		User: model.User{
+			Email: email,
+		},
+		Role:         role,
+		Organization: org,
+	}
+}
+
 func IsSelfAccessRequest(user *model.UserPayload, id string) bool { return user.Id == id }
 
 func IsViewer(user *model.UserPayload) bool { return user.GroupId == AuthCacheObj.ViewerGroupId }

--- a/pkg/query-service/dao/sqlite/connection.go
+++ b/pkg/query-service/dao/sqlite/connection.go
@@ -130,9 +130,10 @@ func (mds *ModelDaoSqlite) initializeOrgPreferences(ctx context.Context) error {
 		return apiError.Err
 	}
 
-	if len(orgs) > 1 {
-		return errors.Errorf("Found %d organizations, expected one or none.", len(orgs))
-	}
+	// TODO(mlg): reconsider how to handle this
+	//if len(orgs) > 1 {
+	//	return errors.Errorf("Found %d organizations, expected one or none.", len(orgs))
+	//}
 
 	var org model.Organization
 	if len(orgs) == 1 {

--- a/pkg/query-service/main.go
+++ b/pkg/query-service/main.go
@@ -50,6 +50,8 @@ func main() {
 	var maxOpenConns int
 	var dialTimeout time.Duration
 
+	var useHeaderAuth bool
+
 	flag.BoolVar(&useLogsNewSchema, "use-logs-new-schema", false, "use logs_v2 schema for logs")
 	flag.BoolVar(&useTraceNewSchema, "use-trace-new-schema", false, "use new schema for traces")
 	flag.StringVar(&promConfigPath, "config", "./config/prometheus.yml", "(prometheus config to read metrics)")
@@ -65,6 +67,7 @@ func main() {
 	flag.IntVar(&maxIdleConns, "max-idle-conns", 50, "(number of connections to maintain in the pool, only used with clickhouse if not set in ClickHouseUrl env var DSN.)")
 	flag.IntVar(&maxOpenConns, "max-open-conns", 100, "(max connections for use at any time, only used with clickhouse if not set in ClickHouseUrl env var DSN.)")
 	flag.DurationVar(&dialTimeout, "dial-timeout", 5*time.Second, "(the maximum time to establish a connection, only used with clickhouse if not set in ClickHouseUrl env var DSN.)")
+	flag.BoolVar(&useHeaderAuth, "use-header-auth", false, "use HTTP header from a trusted proxy for authentication")
 	flag.Parse()
 
 	loggerMgr := initZapLog()
@@ -119,6 +122,8 @@ func main() {
 	if err := auth.InitAuthCache(context.Background()); err != nil {
 		logger.Fatal("Failed to initialize auth cache", zap.Error(err))
 	}
+
+	auth.UseHeaderAuth = useHeaderAuth
 
 	signalsChannel := make(chan os.Signal, 1)
 	signal.Notify(signalsChannel, os.Interrupt, syscall.SIGTERM)

--- a/pkg/query-service/model/response.go
+++ b/pkg/query-service/model/response.go
@@ -690,4 +690,5 @@ type GetVersionResponse struct {
 	Version        string `json:"version"`
 	EE             string `json:"ee"`
 	SetupCompleted bool   `json:"setupCompleted"`
+	HeaderEmail    string `json:"headerEmail"`
 }


### PR DESCRIPTION
### Summary

This is a first cut of supporting "trusted header authentication", as referenced in [this issue](https://github.com/SigNoz/signoz/issues/6197), and also inspired by Kubernetes' support for [authenticating proxies](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#authenticating-proxy) and [impersonation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation). It is working in my cluster, but I expect will need more polish before merge. I wanted to open the PR to provide a concrete basis for discussion and alignment on the approach and design.

The feature is an alternative means of authenticating users, in addition to the existing email+password login and the ee-only SAML login. In this scenario:
- The SigNoz API is deployed behind a reverse proxy.
- The reverse proxy authenticates the user via some outside mechanism, e.g.
  - external JWT
  - mutual TLS
  - Kubernetes token
  - HTTP Basic
  - etc.
- The reverse proxy forwards the authenticated user identity to the SigNoz API via HTTP headers.
- The SigNoz API is secured such that it only responds to requests from the reverse proxy (or at least, only trusts the custom HTTP headers iff they only come from the reverse proxy).

The implementation in this PR expects that the query service is locked down at the network level to only permit access through the reverse proxy. This can be achieved via running the proxy as a container in the same pod and only listening on localhost, via network policy, or other means. Future enhancements could include:
- having the query service authenticate the reverse proxy via mutual TLS or JWT (like the Kubernetes service account token)
- an optional allowlist of IPs that are permitted to call the query service

#### Related Issues / PR's

- https://github.com/SigNoz/signoz/issues/6197

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

The feature is behind a feature flag command-line arg that preserves the prior logic when it is not enabled. When it is enabled, the front-end will call the login API with only the email specified, and the query service will use the header injected by the proxy to authenticate the user, instead of password.

This implementation will create the specified user and org in the sqllite DB, if they do not already exist. This may merit discussion to ensure it aligns with the long-term intentions for SigNoz multi-tenancy. It doesn't appear that the current persisted user and org data are used for much, but I'm sure there are plans to build on them. Happy to discuss this on Slack or elsewhere.

Manually tested login, logout, email+password login when auth headers are absent.
