### PR TITLE
fix: don't expect /licenses to work for oss query service (#6763)

### DIFF
--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -227,6 +227,10 @@ function App(): JSX.Element {
 		}
 	}, [user, isFetchingUser, isCloudUserVal, enableAnalytics]);
 
+	const isOss = featureFlags?.some(
+		(flag) => flag.name === FeatureKeys.OSS && flag.active,
+	);
+
 	// if the user is in logged in state
 	if (isLoggedInState) {
 		if (pathname === ROUTES.HOME_PAGE) {
@@ -241,7 +245,7 @@ function App(): JSX.Element {
 		// this needs to be on top of data missing error because if there is an error, data will never be loaded and it will
 		// move to indefinitive loading
 		if (
-			(userFetchError || licensesFetchError) &&
+			(userFetchError || (licensesFetchError && featureFlags && !isOss)) && // oss query service does not have licenses API
 			pathname !== ROUTES.SOMETHING_WENT_WRONG
 		) {
 			history.replace(ROUTES.SOMETHING_WENT_WRONG);


### PR DESCRIPTION
### Summary

fixes: https://github.com/SigNoz/signoz/issues/6763

The current code expects the `/api/v2/licenses` call to work, and will display an error message if it doesn't. But `/api/v2/licenses` is not a defined route in the OSS build, so the OSS build will always experience the error upon logging in.

This fix checks to see if we're running the OSS version, and if we are, ignores the error fetching licenses.

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes error handling in OSS version by ignoring missing `/licenses` API error in `AppRoutes/index.tsx`.
> 
>   - **Behavior**:
>     - In `AppRoutes/index.tsx`, added `isOss` check to determine if the application is running in OSS mode.
>     - Modified error handling logic to ignore `licensesFetchError` if `isOss` is true, preventing unnecessary error display for missing `/licenses` API in OSS.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 87dc3e08373e0b6e63dc293ecbef176031ea416f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->