### PR TITLE
chore: cloud integrations: include cloud account id in account status response

### DIFF
--- a/pkg/query-service/app/cloudintegrations/controller.go
+++ b/pkg/query-service/app/cloudintegrations/controller.go
@@ -127,8 +127,9 @@ func (c *Controller) GenerateConnectionUrl(
 }
 
 type AccountStatusResponse struct {
-	Id     string        `json:"id"`
-	Status AccountStatus `json:"status"`
+	Id             string        `json:"id"`
+	CloudAccountId *string       `json:"cloud_account_id,omitempty"`
+	Status         AccountStatus `json:"status"`
 }
 
 func (c *Controller) GetAccountStatus(
@@ -146,8 +147,9 @@ func (c *Controller) GetAccountStatus(
 	}
 
 	resp := AccountStatusResponse{
-		Id:     account.Id,
-		Status: account.status(),
+		Id:             account.Id,
+		CloudAccountId: account.CloudAccountId,
+		Status:         account.status(),
 	}
 
 	return &resp, nil

--- a/pkg/query-service/tests/integration/signoz_cloud_integrations_test.go
+++ b/pkg/query-service/tests/integration/signoz_cloud_integrations_test.go
@@ -52,6 +52,7 @@ func TestAWSIntegrationAccountLifecycle(t *testing.T) {
 	accountStatusResp := testbed.GetAccountStatusFromQS("aws", testAccountId)
 	require.Equal(testAccountId, accountStatusResp.Id)
 	require.Nil(accountStatusResp.Status.Integration.LastHeartbeatTsMillis)
+	require.Nil(accountStatusResp.CloudAccountId)
 
 	// The unconnected account should not show up in connected accounts list yet
 	accountsListResp1 := testbed.GetConnectedAccountsListFromQS("aws")
@@ -75,6 +76,8 @@ func TestAWSIntegrationAccountLifecycle(t *testing.T) {
 	// Polling for connection status from UI should now return latest status
 	accountStatusResp1 := testbed.GetAccountStatusFromQS("aws", testAccountId)
 	require.Equal(testAccountId, accountStatusResp1.Id)
+	require.NotNil(accountStatusResp1.CloudAccountId)
+	require.Equal(testAWSAccountId, *accountStatusResp1.CloudAccountId)
 	require.NotNil(accountStatusResp1.Status.Integration.LastHeartbeatTsMillis)
 	require.LessOrEqual(
 		tsMillisBeforeAgentCheckIn,


### PR DESCRIPTION
### Summary

Adds cloud_account_id in cloud integrations account status response

#### Related Issues / PR's

Contributes to https://github.com/SigNoz/signoz/issues/6544
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `CloudAccountId` to `AccountStatusResponse` and update tests to verify its presence.
> 
>   - **Behavior**:
>     - Add `CloudAccountId` field to `AccountStatusResponse` in `controller.go`.
>     - Update `GetAccountStatus` in `controller.go` to include `CloudAccountId` in response.
>   - **Tests**:
>     - Update `TestAWSIntegrationAccountLifecycle` in `signoz_cloud_integrations_test.go` to check for `CloudAccountId` in account status response.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for bd63d708287d315999c9a720cb469c5787d003a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->