### PR TITLE
fix(infra-monitoring): use proper axios instance for retrying the 401 req

### DIFF
--- a/frontend/src/api/infraMonitoring/getHostLists.ts
+++ b/frontend/src/api/infraMonitoring/getHostLists.ts
@@ -1,4 +1,4 @@
-import { ApiBaseInstance } from 'api';
+import axios from 'api';
 import { ErrorResponseHandler } from 'api/ErrorResponseHandler';
 import { AxiosError } from 'axios';
 import { ErrorResponse, SuccessResponse } from 'types/api';
@@ -59,7 +59,7 @@ export const getHostLists = async (
 	headers?: Record<string, string>,
 ): Promise<SuccessResponse<HostListResponse> | ErrorResponse> => {
 	try {
-		const response = await ApiBaseInstance.post('/hosts/list', props, {
+		const response = await axios.post('/hosts/list', props, {
 			signal,
 			headers,
 		});


### PR DESCRIPTION
### Summary

- the axios instance used was incorrect which didn't have the interceptor rejected added to the same
- that instance is only for specific scenarios

#### Related Issues / PR's

fixes - https://github.com/SigNoz/engineering-pod/issues/2139 

#### Screenshots


https://github.com/user-attachments/assets/6e248da7-2478-4dfd-b9b5-fb25d2de251f



#### Affected Areas and Manually Tested Areas

- infra monitoring listing 
