### PR TITLE
fix: remove analytics schema migrations

### DIFF
--- a/ee/query-service/app/server.go
+++ b/ee/query-service/app/server.go
@@ -30,7 +30,6 @@ import (
 	"go.signoz.io/signoz/ee/query-service/interfaces"
 	"go.signoz.io/signoz/ee/query-service/rules"
 	baseauth "go.signoz.io/signoz/pkg/query-service/auth"
-	"go.signoz.io/signoz/pkg/query-service/migrate"
 	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
 	"go.signoz.io/signoz/pkg/signoz"
 	"go.signoz.io/signoz/pkg/web"
@@ -201,13 +200,6 @@ func NewServer(serverOptions *ServerOptions) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	go func() {
-		err = migrate.ClickHouseMigrate(reader.GetConn(), serverOptions.Cluster)
-		if err != nil {
-			zap.L().Error("error while running clickhouse migrations", zap.Error(err))
-		}
-	}()
 
 	// initiate opamp
 	_, err = opAmpModel.InitDB(localDB)

--- a/pkg/query-service/app/server.go
+++ b/pkg/query-service/app/server.go
@@ -33,7 +33,6 @@ import (
 	opAmpModel "go.signoz.io/signoz/pkg/query-service/app/opamp/model"
 	"go.signoz.io/signoz/pkg/query-service/app/preferences"
 	"go.signoz.io/signoz/pkg/query-service/common"
-	"go.signoz.io/signoz/pkg/query-service/migrate"
 	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
 
 	"go.signoz.io/signoz/pkg/query-service/app/explorer"
@@ -165,13 +164,6 @@ func NewServer(serverOptions *ServerOptions) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	go func() {
-		err = migrate.ClickHouseMigrate(reader.GetConn(), serverOptions.Cluster)
-		if err != nil {
-			zap.L().Error("error while running clickhouse migrations", zap.Error(err))
-		}
-	}()
 
 	fluxInterval, err := time.ParseDuration(serverOptions.FluxInterval)
 	if err != nil {

--- a/pkg/query-service/migrate/migate.go
+++ b/pkg/query-service/migrate/migate.go
@@ -1,11 +1,8 @@
 package migrate
 
 import (
-	"context"
 	"database/sql"
-	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -51,93 +48,6 @@ func Migrate(dsn string) error {
 	}
 	if err := initSchema(conn); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func ClickHouseMigrate(conn driver.Conn, cluster string) error {
-
-	database := "CREATE DATABASE IF NOT EXISTS signoz_analytics ON CLUSTER %s"
-
-	localTable := `CREATE TABLE IF NOT EXISTS signoz_analytics.rule_state_history_v0 ON CLUSTER %s
-(
-	_retention_days UInt32 DEFAULT 180,
-    rule_id LowCardinality(String),
-    rule_name LowCardinality(String),
-    overall_state LowCardinality(String),
-    overall_state_changed Bool,
-    state LowCardinality(String),
-    state_changed Bool,
-    unix_milli Int64 CODEC(Delta(8), ZSTD(1)),
-    fingerprint UInt64 CODEC(ZSTD(1)),
-    value Float64 CODEC(Gorilla, ZSTD(1)),
-    labels String CODEC(ZSTD(5)),
-)
-ENGINE = MergeTree
-PARTITION BY toDate(unix_milli / 1000)
-ORDER BY (rule_id, unix_milli)
-TTL toDateTime(unix_milli / 1000) + toIntervalDay(_retention_days)
-SETTINGS ttl_only_drop_parts = 1, index_granularity = 8192`
-
-	distributedTable := `CREATE TABLE IF NOT EXISTS signoz_analytics.distributed_rule_state_history_v0 ON CLUSTER %s
-(
-    rule_id LowCardinality(String),
-    rule_name LowCardinality(String),
-    overall_state LowCardinality(String),
-    overall_state_changed Bool,
-    state LowCardinality(String),
-    state_changed Bool,
-    unix_milli Int64 CODEC(Delta(8), ZSTD(1)),
-    fingerprint UInt64 CODEC(ZSTD(1)),
-    value Float64 CODEC(Gorilla, ZSTD(1)),
-    labels String CODEC(ZSTD(5)),
-)
-ENGINE = Distributed(%s, signoz_analytics, rule_state_history_v0, cityHash64(rule_id, rule_name, fingerprint))`
-
-	// check if db exists
-	dbExists := `SELECT count(*) FROM system.databases WHERE name = 'signoz_analytics'`
-	var count uint64
-	err := conn.QueryRow(context.Background(), dbExists).Scan(&count)
-	if err != nil {
-		return err
-	}
-
-	if count == 0 {
-		err = conn.Exec(context.Background(), fmt.Sprintf(database, cluster))
-		if err != nil {
-			return err
-		}
-	}
-
-	// check if table exists
-	tableExists := `SELECT count(*) FROM system.tables WHERE name = 'rule_state_history_v0' AND database = 'signoz_analytics'`
-	var tableCount uint64
-	err = conn.QueryRow(context.Background(), tableExists).Scan(&tableCount)
-	if err != nil {
-		return err
-	}
-
-	if tableCount == 0 {
-		err = conn.Exec(context.Background(), fmt.Sprintf(localTable, cluster))
-		if err != nil {
-			return err
-		}
-	}
-
-	// check if distributed table exists
-	distributedTableExists := `SELECT count(*) FROM system.tables WHERE name = 'distributed_rule_state_history_v0' AND database = 'signoz_analytics'`
-	var distributedTableCount uint64
-	err = conn.QueryRow(context.Background(), distributedTableExists).Scan(&distributedTableCount)
-	if err != nil {
-		return err
-	}
-
-	if distributedTableCount == 0 {
-		err = conn.Exec(context.Background(), fmt.Sprintf(distributedTable, cluster, cluster))
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil


### PR DESCRIPTION
Fixes https://github.com/SigNoz/platform-pod/issues/402

The clickhouse migrations are moved to otel collector schema migrator https://github.com/SigNoz/signoz-otel-collector/pull/525

There was no strict reason for keeping this in QS https://github.com/SigNoz/signoz/pull/5255#issuecomment-2256189871

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes ClickHouse migration logic from query service, delegating it to otel collector, and deletes related code.
> 
>   - **Behavior**:
>     - Removes ClickHouse migration logic from `NewServer()` in `server.go` in both `ee/query-service/app` and `pkg/query-service/app`.
>     - Migration responsibility moved to otel collector.
>   - **Code Removal**:
>     - Deletes `ClickHouseMigrate` function from `migrate/migate.go`.
>     - Removes `migrate` package import and usage in `server.go` in both `ee/query-service/app` and `pkg/query-service/app`.
>     - Deletes `migrate/migate.go` file entirely.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 305f27061d730eb58eecc4956f0353537465530d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->