### PR TITLE
fix: remove depricated message from ingestion dashboard

### DIFF
--- a/pkg/query-service/app/dashboards/model.go
+++ b/pkg/query-service/app/dashboards/model.go
@@ -288,11 +288,7 @@ func GetDashboard(ctx context.Context, uuid string) (*Dashboard, *model.ApiError
 	if err != nil {
 		return nil, &model.ApiError{Typ: model.ErrorNotFound, Err: fmt.Errorf("no dashboard found with uuid: %s", uuid)}
 	}
-
-	if dashboard.Data["title"] == "Ingestion" && dashboard.Data["description"] != nil {
-		dashboard.Data["description"] = "This dashboard is deprecated. Please use the new Ingestion V2 dashboard. " + dashboard.Data["description"].(string)
-	}
-
+	
 	return &dashboard, nil
 }
 


### PR DESCRIPTION
Removing the custom message we added, the old users will already have ingestion v2.

For new users they can name it ingestion or anything
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes deprecated message from 'Ingestion' dashboard descriptions in `GetDashboard()` in `model.go`.
> 
>   - **Behavior**:
>     - Removes deprecated message from dashboard descriptions in `GetDashboard()` in `model.go`.
>     - Affects dashboards with the title 'Ingestion'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 6c6f7f35bb646970eb2365c3fb92f5e4a533f5f7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->