### PR TITLE
Revert "feat: show/hide timestamp and body fields in logs explorer (raw, default, column views)"

### DIFF
--- a/frontend/src/components/Logs/ListLogView/index.tsx
+++ b/frontend/src/components/Logs/ListLogView/index.tsx
@@ -219,14 +219,12 @@ function ListLogView({
 					<LogStateIndicator type={logType} fontSize={fontSize} />
 					<div>
 						<LogContainer fontSize={fontSize}>
-							{updatedSelecedFields.some((field) => field.name === 'body') && (
-								<LogGeneralField
-									fieldKey="Log"
-									fieldValue={flattenLogData.body}
-									linesPerRow={linesPerRow}
-									fontSize={fontSize}
-								/>
-							)}
+							<LogGeneralField
+								fieldKey="Log"
+								fieldValue={flattenLogData.body}
+								linesPerRow={linesPerRow}
+								fontSize={fontSize}
+							/>
 							{flattenLogData.stream && (
 								<LogGeneralField
 									fieldKey="Stream"
@@ -234,27 +232,23 @@ function ListLogView({
 									fontSize={fontSize}
 								/>
 							)}
-							{updatedSelecedFields.some((field) => field.name === 'timestamp') && (
-								<LogGeneralField
-									fieldKey="Timestamp"
-									fieldValue={timestampValue}
-									fontSize={fontSize}
-								/>
-							)}
+							<LogGeneralField
+								fieldKey="Timestamp"
+								fieldValue={timestampValue}
+								fontSize={fontSize}
+							/>
 
-							{updatedSelecedFields
-								.filter((field) => !['timestamp', 'body'].includes(field.name))
-								.map((field) =>
-									isValidLogField(flattenLogData[field.name] as never) ? (
-										<LogSelectedField
-											key={field.name}
-											fieldKey={field.name}
-											fieldValue={flattenLogData[field.name] as never}
-											onAddToQuery={onAddToQuery}
-											fontSize={fontSize}
-										/>
-									) : null,
-								)}
+							{updatedSelecedFields.map((field) =>
+								isValidLogField(flattenLogData[field.name] as never) ? (
+									<LogSelectedField
+										key={field.name}
+										fieldKey={field.name}
+										fieldValue={flattenLogData[field.name] as never}
+										onAddToQuery={onAddToQuery}
+										fontSize={fontSize}
+									/>
+								) : null,
+							)}
 						</LogContainer>
 					</div>
 				</div>

--- a/frontend/src/components/Logs/RawLogView/index.tsx
+++ b/frontend/src/components/Logs/RawLogView/index.tsx
@@ -73,7 +73,6 @@ function RawLogView({
 	);
 
 	const attributesValues = updatedSelecedFields
-		.filter((field) => !['timestamp', 'body'].includes(field.name))
 		.map((field) => flattenLogData[field.name])
 		.filter((attribute) => {
 			// loadash isEmpty doesnot work with numbers
@@ -93,40 +92,19 @@ function RawLogView({
 	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	const text = useMemo(() => {
-		const parts = [];
+		const date =
+			typeof data.timestamp === 'string'
+				? formatTimezoneAdjustedTimestamp(data.timestamp, 'YYYY-MM-DD HH:mm:ss.SSS')
+				: formatTimezoneAdjustedTimestamp(
+						data.timestamp / 1e6,
+						'YYYY-MM-DD HH:mm:ss.SSS',
+				  );
 
-		// Check if timestamp is selected
-		const showTimestamp = selectedFields.some(
-			(field) => field.name === 'timestamp',
-		);
-		if (showTimestamp) {
-			const date =
-				typeof data.timestamp === 'string'
-					? formatTimezoneAdjustedTimestamp(
-							data.timestamp,
-							'YYYY-MM-DD HH:mm:ss.SSS',
-					  )
-					: formatTimezoneAdjustedTimestamp(
-							data.timestamp / 1e6,
-							'YYYY-MM-DD HH:mm:ss.SSS',
-					  );
-			parts.push(date);
-		}
-
-		// Check if body is selected
-		const showBody = selectedFields.some((field) => field.name === 'body');
-		if (showBody) {
-			parts.push(`${attributesText} ${data.body}`);
-		} else {
-			parts.push(attributesText);
-		}
-
-		return parts.join(' | ');
+		return `${date} | ${attributesText} ${data.body}`;
 	}, [
-		selectedFields,
-		attributesText,
 		data.timestamp,
 		data.body,
+		attributesText,
 		formatTimezoneAdjustedTimestamp,
 	]);
 

--- a/frontend/src/components/Logs/TableView/useTableView.tsx
+++ b/frontend/src/components/Logs/TableView/useTableView.tsx
@@ -48,7 +48,7 @@ export const useTableView = (props: UseTableViewProps): UseTableViewResult => {
 
 	const columns: ColumnsType<Record<string, unknown>> = useMemo(() => {
 		const fieldColumns: ColumnsType<Record<string, unknown>> = fields
-			.filter((e) => !['id', 'body', 'timestamp'].includes(e.name))
+			.filter((e) => e.name !== 'id')
 			.map(({ name }) => ({
 				title: name,
 				dataIndex: name,
@@ -91,67 +91,55 @@ export const useTableView = (props: UseTableViewProps): UseTableViewResult => {
 					),
 				}),
 			},
-			...(fields.some((field) => field.name === 'timestamp')
-				? [
-						{
-							title: 'timestamp',
-							dataIndex: 'timestamp',
-							key: 'timestamp',
-							// https://github.com/ant-design/ant-design/discussions/36886
-							render: (
-								field: string | number,
-							): ColumnTypeRender<Record<string, unknown>> => {
-								const date =
-									typeof field === 'string'
-										? formatTimezoneAdjustedTimestamp(field, 'YYYY-MM-DD HH:mm:ss.SSS')
-										: formatTimezoneAdjustedTimestamp(
-												field / 1e6,
-												'YYYY-MM-DD HH:mm:ss.SSS',
-										  );
-								return {
-									children: (
-										<div className="table-timestamp">
-											<Typography.Paragraph ellipsis className={cx('text', fontSize)}>
-												{date}
-											</Typography.Paragraph>
-										</div>
-									),
-								};
-							},
-						},
-				  ]
-				: []),
+			{
+				title: 'timestamp',
+				dataIndex: 'timestamp',
+				key: 'timestamp',
+				// https://github.com/ant-design/ant-design/discussions/36886
+				render: (field): ColumnTypeRender<Record<string, unknown>> => {
+					const date =
+						typeof field === 'string'
+							? formatTimezoneAdjustedTimestamp(field, 'YYYY-MM-DD HH:mm:ss.SSS')
+							: formatTimezoneAdjustedTimestamp(
+									field / 1e6,
+									'YYYY-MM-DD HH:mm:ss.SSS',
+							  );
+					return {
+						children: (
+							<div className="table-timestamp">
+								<Typography.Paragraph ellipsis className={cx('text', fontSize)}>
+									{date}
+								</Typography.Paragraph>
+							</div>
+						),
+					};
+				},
+			},
 			...(appendTo === 'center' ? fieldColumns : []),
-			...(fields.some((field) => field.name === 'body')
-				? [
-						{
-							title: 'body',
-							dataIndex: 'body',
-							key: 'body',
-							render: (
-								field: string | number,
-							): ColumnTypeRender<Record<string, unknown>> => ({
-								props: {
-									style: defaultTableStyle,
-								},
-								children: (
-									<TableBodyContent
-										dangerouslySetInnerHTML={{
-											__html: convert.toHtml(
-												dompurify.sanitize(unescapeString(field as string), {
-													FORBID_TAGS: [...FORBID_DOM_PURIFY_TAGS],
-												}),
-											),
-										}}
-										fontSize={fontSize}
-										linesPerRow={linesPerRow}
-										isDarkMode={isDarkMode}
-									/>
+			{
+				title: 'body',
+				dataIndex: 'body',
+				key: 'body',
+				render: (field): ColumnTypeRender<Record<string, unknown>> => ({
+					props: {
+						style: defaultTableStyle,
+					},
+					children: (
+						<TableBodyContent
+							dangerouslySetInnerHTML={{
+								__html: convert.toHtml(
+									dompurify.sanitize(unescapeString(field), {
+										FORBID_TAGS: [...FORBID_DOM_PURIFY_TAGS],
+									}),
 								),
-							}),
-						},
-				  ]
-				: []),
+							}}
+							fontSize={fontSize}
+							linesPerRow={linesPerRow}
+							isDarkMode={isDarkMode}
+						/>
+					),
+				}),
+			},
 			...(appendTo === 'end' ? fieldColumns : []),
 		];
 	}, [

--- a/frontend/src/container/LogsExplorerList/InfinityTableView/index.tsx
+++ b/frontend/src/container/LogsExplorerList/InfinityTableView/index.tsx
@@ -121,25 +121,23 @@ const InfinityTable = forwardRef<TableVirtuosoHandle, InfinityTableProps>(
 		const tableHeader = useCallback(
 			() => (
 				<tr>
-					{tableColumns
-						.filter((column) => column.key)
-						.map((column) => {
-							const isDragColumn = column.key !== 'expand';
+					{tableColumns.map((column) => {
+						const isDragColumn = column.key !== 'expand';
 
-							return (
-								<TableHeaderCellStyled
-									$isLogIndicator={column.key === 'state-indicator'}
-									$isDarkMode={isDarkMode}
-									$isDragColumn={isDragColumn}
-									key={column.key}
-									fontSize={tableViewProps?.fontSize}
-									// eslint-disable-next-line react/jsx-props-no-spreading
-									{...(isDragColumn && { className: 'dragHandler' })}
-								>
-									{(column.title as string).replace(/^\w/, (c) => c.toUpperCase())}
-								</TableHeaderCellStyled>
-							);
-						})}
+						return (
+							<TableHeaderCellStyled
+								$isLogIndicator={column.key === 'state-indicator'}
+								$isDarkMode={isDarkMode}
+								$isDragColumn={isDragColumn}
+								key={column.key}
+								fontSize={tableViewProps?.fontSize}
+								// eslint-disable-next-line react/jsx-props-no-spreading
+								{...(isDragColumn && { className: 'dragHandler' })}
+							>
+								{(column.title as string).replace(/^\w/, (c) => c.toUpperCase())}
+							</TableHeaderCellStyled>
+						);
+					})}
 				</tr>
 			),
 			[tableColumns, isDarkMode, tableViewProps?.fontSize],

--- a/frontend/src/container/LogsExplorerList/InfinityTableView/styles.ts
+++ b/frontend/src/container/LogsExplorerList/InfinityTableView/styles.ts
@@ -29,7 +29,7 @@ export const TableCellStyled = styled.td<TableHeaderCellStyledProps>`
 		props.$isDarkMode ? 'inherit' : themeColors.whiteCream};
 
 	${({ $isLogIndicator }): string =>
-		$isLogIndicator ? 'padding: 0 0 0 8px;width: 15px;' : ''}
+		$isLogIndicator ? 'padding: 0 0 0 8px;' : ''}
 	color: ${(props): string =>
 		props.$isDarkMode ? themeColors.white : themeColors.bckgGrey};
 `;

--- a/frontend/src/container/OptionsMenu/constants.ts
+++ b/frontend/src/container/OptionsMenu/constants.ts
@@ -5,26 +5,7 @@ import { FontSize, OptionsQuery } from './types';
 export const URL_OPTIONS = 'options';
 
 export const defaultOptionsQuery: OptionsQuery = {
-	selectColumns: [
-		{
-			key: 'timestamp',
-			dataType: DataTypes.String,
-			type: 'tag',
-			isColumn: true,
-			isJSON: false,
-			id: 'timestamp--string--tag--true',
-			isIndexed: false,
-		},
-		{
-			key: 'body',
-			dataType: DataTypes.String,
-			type: 'tag',
-			isColumn: true,
-			isJSON: false,
-			id: 'body--string--tag--true',
-			isIndexed: false,
-		},
-	],
+	selectColumns: [],
 	maxLines: 2,
 	format: 'raw',
 	fontSize: FontSize.SMALL,

--- a/frontend/src/container/OptionsMenu/useOptionsMenu.ts
+++ b/frontend/src/container/OptionsMenu/useOptionsMenu.ts
@@ -169,15 +169,6 @@ const useOptionsMenu = ({
 
 	const searchedAttributeKeys = useMemo(() => {
 		if (searchedAttributesData?.payload?.attributeKeys?.length) {
-			if (dataSource === DataSource.LOGS) {
-				// add timestamp and body to the list of attributes
-				return [
-					...defaultOptionsQuery.selectColumns,
-					...searchedAttributesData.payload.attributeKeys.filter(
-						(attribute) => attribute.key !== 'body',
-					),
-				];
-			}
 			return searchedAttributesData.payload.attributeKeys;
 		}
 		if (dataSource === DataSource.TRACES) {
@@ -207,17 +198,12 @@ const useOptionsMenu = ({
 	);
 
 	const optionsFromAttributeKeys = useMemo(() => {
-		const filteredAttributeKeys = searchedAttributeKeys.filter((item) => {
-			// For other data sources, only filter out 'body' if it exists
-			if (dataSource !== DataSource.LOGS) {
-				return item.key !== 'body';
-			}
-			// For LOGS, keep all keys
-			return true;
-		});
+		const filteredAttributeKeys = searchedAttributeKeys.filter(
+			(item) => item.key !== 'body',
+		);
 
 		return getOptionsFromKeys(filteredAttributeKeys, selectedColumnKeys);
-	}, [dataSource, searchedAttributeKeys, selectedColumnKeys]);
+	}, [searchedAttributeKeys, selectedColumnKeys]);
 
 	const handleRedirectWithOptionsData = useCallback(
 		(newQueryData: OptionsQuery) => {


### PR DESCRIPTION
Reverts SigNoz/signoz#6831
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts feature to conditionally show/hide timestamp and body fields in logs explorer views, affecting log display and options menu configuration.
> 
>   - **Behavior**:
>     - Reverts feature to show/hide timestamp and body fields in logs explorer views.
>     - `ListLogView`, `RawLogView`, and `useTableView` now always display `timestamp` and `body` fields.
>   - **Components**:
>     - `ListLogView` and `RawLogView` no longer filter out `timestamp` and `body` fields.
>     - `useTableView` includes `timestamp` and `body` in columns unconditionally.
>   - **Options Menu**:
>     - `defaultOptionsQuery` in `constants.ts` no longer includes `timestamp` and `body` in `selectColumns`.
>     - `useOptionsMenu` no longer filters out `timestamp` and `body` from attribute keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for ec24014af962121451aa1cf06eaea5145151ec99. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->