### PR TITLE
chore: address some gaps in infra

### DIFF
--- a/frontend/src/container/InfraMonitoringK8s/Clusters/K8sClustersList.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Clusters/K8sClustersList.tsx
@@ -164,7 +164,8 @@ function K8sClustersList({
 	} = useGetAggregateKeys(
 		{
 			dataSource: currentQuery.builder.queryData[0].dataSource,
-			aggregateAttribute: K8sEntityToAggregateAttributeMapping[K8sCategory.NODES],
+			aggregateAttribute:
+				K8sEntityToAggregateAttributeMapping[K8sCategory.CLUSTERS],
 			aggregateOperator: 'noop',
 			searchText: '',
 			tagType: '',

--- a/frontend/src/container/InfraMonitoringK8s/Deployments/K8sDeploymentsList.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Deployments/K8sDeploymentsList.tsx
@@ -165,7 +165,8 @@ function K8sDeploymentsList({
 	} = useGetAggregateKeys(
 		{
 			dataSource: currentQuery.builder.queryData[0].dataSource,
-			aggregateAttribute: K8sEntityToAggregateAttributeMapping[K8sCategory.NODES],
+			aggregateAttribute:
+				K8sEntityToAggregateAttributeMapping[K8sCategory.DEPLOYMENTS],
 			aggregateOperator: 'noop',
 			searchText: '',
 			tagType: '',

--- a/frontend/src/container/InfraMonitoringK8s/Namespaces/K8sNamespacesList.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Namespaces/K8sNamespacesList.tsx
@@ -164,7 +164,8 @@ function K8sNamespacesList({
 	} = useGetAggregateKeys(
 		{
 			dataSource: currentQuery.builder.queryData[0].dataSource,
-			aggregateAttribute: K8sEntityToAggregateAttributeMapping[K8sCategory.NODES],
+			aggregateAttribute:
+				K8sEntityToAggregateAttributeMapping[K8sCategory.NAMESPACES],
 			aggregateOperator: 'noop',
 			searchText: '',
 			tagType: '',

--- a/pkg/query-service/app/inframetrics/clusters.go
+++ b/pkg/query-service/app/inframetrics/clusters.go
@@ -19,7 +19,8 @@ var (
 
 	clusterAttrsToEnrich = []string{"k8s_cluster_name"}
 
-	k8sClusterUIDAttrKey = "k8s_cluster_uid"
+	// TODO(srikanthccv): change this to k8s_cluster_uid after showing the missing data banner
+	k8sClusterUIDAttrKey = "k8s_cluster_name"
 
 	queryNamesForClusters = map[string][]string{
 		"cpu":                {"A"},
@@ -319,7 +320,7 @@ func (p *ClustersRepo) GetClusterList(ctx context.Context, req model.ClusterList
 			}
 
 			record.Meta = map[string]string{}
-			if _, ok := clusterAttrs[record.ClusterUID]; ok {
+			if _, ok := clusterAttrs[record.ClusterUID]; ok && record.ClusterUID != "" {
 				record.Meta = clusterAttrs[record.ClusterUID]
 			}
 

--- a/pkg/query-service/app/inframetrics/daemonsets.go
+++ b/pkg/query-service/app/inframetrics/daemonsets.go
@@ -421,7 +421,7 @@ func (d *DaemonSetsRepo) GetDaemonSetList(ctx context.Context, req model.DaemonS
 			}
 
 			record.Meta = map[string]string{}
-			if _, ok := daemonSetAttrs[record.DaemonSetName]; ok {
+			if _, ok := daemonSetAttrs[record.DaemonSetName]; ok && record.DaemonSetName != "" {
 				record.Meta = daemonSetAttrs[record.DaemonSetName]
 			}
 

--- a/pkg/query-service/app/inframetrics/deployments.go
+++ b/pkg/query-service/app/inframetrics/deployments.go
@@ -421,7 +421,7 @@ func (d *DeploymentsRepo) GetDeploymentList(ctx context.Context, req model.Deplo
 			}
 
 			record.Meta = map[string]string{}
-			if _, ok := deploymentAttrs[record.DeploymentName]; ok {
+			if _, ok := deploymentAttrs[record.DeploymentName]; ok && record.DeploymentName != "" {
 				record.Meta = deploymentAttrs[record.DeploymentName]
 			}
 

--- a/pkg/query-service/app/inframetrics/jobs.go
+++ b/pkg/query-service/app/inframetrics/jobs.go
@@ -475,7 +475,7 @@ func (d *JobsRepo) GetJobList(ctx context.Context, req model.JobListRequest) (mo
 			}
 
 			record.Meta = map[string]string{}
-			if _, ok := jobAttrs[record.JobName]; ok {
+			if _, ok := jobAttrs[record.JobName]; ok && record.JobName != "" {
 				record.Meta = jobAttrs[record.JobName]
 			}
 

--- a/pkg/query-service/app/inframetrics/namespaces.go
+++ b/pkg/query-service/app/inframetrics/namespaces.go
@@ -322,7 +322,7 @@ func (p *NamespacesRepo) GetNamespaceList(ctx context.Context, req model.Namespa
 			}
 
 			record.Meta = map[string]string{}
-			if _, ok := namespaceAttrs[record.NamespaceName]; ok {
+			if _, ok := namespaceAttrs[record.NamespaceName]; ok && record.NamespaceName != "" {
 				record.Meta = namespaceAttrs[record.NamespaceName]
 			}
 

--- a/pkg/query-service/app/inframetrics/nodes.go
+++ b/pkg/query-service/app/inframetrics/nodes.go
@@ -335,7 +335,7 @@ func (p *NodesRepo) GetNodeList(ctx context.Context, req model.NodeListRequest) 
 			}
 
 			record.Meta = map[string]string{}
-			if _, ok := nodeAttrs[record.NodeUID]; ok {
+			if _, ok := nodeAttrs[record.NodeUID]; ok && record.NodeUID != "" {
 				record.Meta = nodeAttrs[record.NodeUID]
 			}
 

--- a/pkg/query-service/app/inframetrics/pods.go
+++ b/pkg/query-service/app/inframetrics/pods.go
@@ -385,7 +385,7 @@ func (p *PodsRepo) GetPodList(ctx context.Context, req model.PodListRequest) (mo
 			}
 
 			record.Meta = map[string]string{}
-			if _, ok := podAttrs[record.PodUID]; ok {
+			if _, ok := podAttrs[record.PodUID]; ok && record.PodUID != "" {
 				record.Meta = podAttrs[record.PodUID]
 			}
 

--- a/pkg/query-service/app/inframetrics/pvcs.go
+++ b/pkg/query-service/app/inframetrics/pvcs.go
@@ -355,7 +355,7 @@ func (p *PvcsRepo) GetPvcList(ctx context.Context, req model.VolumeListRequest) 
 			record.VolumeUsage = record.VolumeCapacity - record.VolumeAvailable
 
 			record.Meta = map[string]string{}
-			if _, ok := volumeAttrs[record.PersistentVolumeClaimName]; ok {
+			if _, ok := volumeAttrs[record.PersistentVolumeClaimName]; ok && record.PersistentVolumeClaimName != "" {
 				record.Meta = volumeAttrs[record.PersistentVolumeClaimName]
 			}
 

--- a/pkg/query-service/app/inframetrics/statefulsets.go
+++ b/pkg/query-service/app/inframetrics/statefulsets.go
@@ -421,7 +421,7 @@ func (d *StatefulSetsRepo) GetStatefulSetList(ctx context.Context, req model.Sta
 			}
 
 			record.Meta = map[string]string{}
-			if _, ok := statefulSetAttrs[record.StatefulSetName]; ok {
+			if _, ok := statefulSetAttrs[record.StatefulSetName]; ok && record.StatefulSetName != "" {
 				record.Meta = statefulSetAttrs[record.StatefulSetName]
 			}
 


### PR DESCRIPTION
### Summary

follow up to https://github.com/SigNoz/signoz/pull/6786

1. use the right aggregate attribute for fetching attribute key/values
2. handle empty names in backend
3. change the attribute from uid to name to support old users.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update aggregate attributes, handle empty names, and switch from UID to name for Kubernetes entities in infrastructure monitoring.
> 
>   - **Behavior**:
>     - Update `aggregateAttribute` in `K8sClustersList.tsx`, `K8sDeploymentsList.tsx`, and `K8sNamespacesList.tsx` to use correct mapping for `CLUSTERS`, `DEPLOYMENTS`, and `NAMESPACES` respectively.
>     - Handle empty names in `GetClusterList()` in `clusters.go`, `GetDaemonSetList()` in `daemonsets.go`, `GetDeploymentList()` in `deployments.go`, `GetJobList()` in `jobs.go`, `GetNamespaceList()` in `namespaces.go`, `GetNodeList()` in `nodes.go`, `GetPodList()` in `pods.go`, `GetPvcList()` in `pvcs.go`, and `GetStatefulSetList()` in `statefulsets.go`.
>   - **Attributes**:
>     - Change attribute from `uid` to `name` in `clusters.go` for `k8sClusterUIDAttrKey`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 558541f34e75cac5f7449e0bc29a97e30061a5f8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->