### PR TITLE
fix: prevent today's date disabling in range picker by setting default time values

### DIFF
--- a/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
+++ b/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
@@ -71,6 +71,7 @@ function RangePickerModal(props: RangePickerModalProps): JSX.Element {
 				showTime={{
 					use12Hours: true,
 					format: 'hh:mm A',
+					defaultValue: [dayjs().tz(timezone.value), dayjs().tz(timezone.value)],
 				}}
 				format={(date: Dayjs): string =>
 					date.tz(timezone.value).format('YYYY-MM-DD hh:mm A')


### PR DESCRIPTION
### Summary
This PR fixes the issue of today's date being disabled intermittently in the custom time range
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
Before:

https://github.com/user-attachments/assets/b0df76c8-fe21-46ea-a1ce-2e789ac5de85


After:

https://github.com/user-attachments/assets/40992682-76aa-4e9d-b5cd-0e4a3063345f




<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas
Custom time range selector
<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets default time values in `RangePicker` to prevent disabling today's date in `RangePickerModal.tsx`.
> 
>   - **Behavior**:
>     - Sets `defaultValue` for `showTime` in `RangePicker` in `RangePickerModal.tsx` to prevent disabling today's date.
>     - Uses `dayjs().tz(timezone.value)` for both start and end default times.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 8c7ae68f35d041053eae0c61411c1cc0b9222e5d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->