### PR TITLE
feat: show/hide timestamp and body fields in logs explorer (raw, default, column views)

### DIFF
--- a/frontend/src/components/Logs/ListLogView/index.tsx
+++ b/frontend/src/components/Logs/ListLogView/index.tsx
@@ -220,12 +220,14 @@ function ListLogView({
 					<LogStateIndicator type={logType} fontSize={fontSize} />
 					<div>
 						<LogContainer fontSize={fontSize}>
-							<LogGeneralField
-								fieldKey="Log"
-								fieldValue={flattenLogData.body}
-								linesPerRow={linesPerRow}
-								fontSize={fontSize}
-							/>
+							{updatedSelecedFields.some((field) => field.name === 'body') && (
+								<LogGeneralField
+									fieldKey="Log"
+									fieldValue={flattenLogData.body}
+									linesPerRow={linesPerRow}
+									fontSize={fontSize}
+								/>
+							)}
 							{flattenLogData.stream && (
 								<LogGeneralField
 									fieldKey="Stream"
@@ -233,23 +235,27 @@ function ListLogView({
 									fontSize={fontSize}
 								/>
 							)}
-							<LogGeneralField
-								fieldKey="Timestamp"
-								fieldValue={timestampValue}
-								fontSize={fontSize}
-							/>
-
-							{updatedSelecedFields.map((field) =>
-								isValidLogField(flattenLogData[field.name] as never) ? (
-									<LogSelectedField
-										key={field.name}
-										fieldKey={field.name}
-										fieldValue={flattenLogData[field.name] as never}
-										onAddToQuery={onAddToQuery}
-										fontSize={fontSize}
-									/>
-								) : null,
+							{updatedSelecedFields.some((field) => field.name === 'timestamp') && (
+								<LogGeneralField
+									fieldKey="Timestamp"
+									fieldValue={timestampValue}
+									fontSize={fontSize}
+								/>
 							)}
+
+							{updatedSelecedFields
+								.filter((field) => !['timestamp', 'body'].includes(field.name))
+								.map((field) =>
+									isValidLogField(flattenLogData[field.name] as never) ? (
+										<LogSelectedField
+											key={field.name}
+											fieldKey={field.name}
+											fieldValue={flattenLogData[field.name] as never}
+											onAddToQuery={onAddToQuery}
+											fontSize={fontSize}
+										/>
+									) : null,
+								)}
 						</LogContainer>
 					</div>
 				</div>

--- a/frontend/src/components/Logs/RawLogView/index.tsx
+++ b/frontend/src/components/Logs/RawLogView/index.tsx
@@ -74,6 +74,7 @@ function RawLogView({
 	);
 
 	const attributesValues = updatedSelecedFields
+		.filter((field) => !['timestamp', 'body'].includes(field.name))
 		.map((field) => flattenLogData[field.name])
 		.filter((attribute) => {
 			// loadash isEmpty doesnot work with numbers
@@ -93,22 +94,40 @@ function RawLogView({
 	const { formatTimezoneAdjustedTimestamp } = useTimezone();
 
 	const text = useMemo(() => {
-		const date =
-			typeof data.timestamp === 'string'
-				? formatTimezoneAdjustedTimestamp(
-						data.timestamp,
-						DATE_TIME_FORMATS.ISO_DATETIME_MS,
-				  )
-				: formatTimezoneAdjustedTimestamp(
-						data.timestamp / 1e6,
-						DATE_TIME_FORMATS.ISO_DATETIME_MS,
-				  );
+		const parts = [];
 
-		return `${date} | ${attributesText} ${data.body}`;
+		// Check if timestamp is selected
+		const showTimestamp = selectedFields.some(
+			(field) => field.name === 'timestamp',
+		);
+		if (showTimestamp) {
+			const date =
+				typeof data.timestamp === 'string'
+					? formatTimezoneAdjustedTimestamp(
+							data.timestamp,
+							DATE_TIME_FORMATS.ISO_DATETIME_MS,
+					  )
+					: formatTimezoneAdjustedTimestamp(
+							data.timestamp / 1e6,
+							DATE_TIME_FORMATS.ISO_DATETIME_MS,
+					  );
+			parts.push(date);
+		}
+
+		// Check if body is selected
+		const showBody = selectedFields.some((field) => field.name === 'body');
+		if (showBody) {
+			parts.push(`${attributesText} ${data.body}`);
+		} else {
+			parts.push(attributesText);
+		}
+
+		return parts.join(' | ');
 	}, [
+		selectedFields,
+		attributesText,
 		data.timestamp,
 		data.body,
-		attributesText,
 		formatTimezoneAdjustedTimestamp,
 	]);
 

--- a/frontend/src/components/Logs/TableView/useTableView.tsx
+++ b/frontend/src/components/Logs/TableView/useTableView.tsx
@@ -49,7 +49,7 @@ export const useTableView = (props: UseTableViewProps): UseTableViewResult => {
 
 	const columns: ColumnsType<Record<string, unknown>> = useMemo(() => {
 		const fieldColumns: ColumnsType<Record<string, unknown>> = fields
-			.filter((e) => e.name !== 'id')
+			.filter((e) => !['id', 'body', 'timestamp'].includes(e.name))
 			.map(({ name }) => ({
 				title: name,
 				dataIndex: name,
@@ -92,58 +92,70 @@ export const useTableView = (props: UseTableViewProps): UseTableViewResult => {
 					),
 				}),
 			},
-			{
-				title: 'timestamp',
-				dataIndex: 'timestamp',
-				key: 'timestamp',
-				// https://github.com/ant-design/ant-design/discussions/36886
-				render: (field): ColumnTypeRender<Record<string, unknown>> => {
-					const date =
-						typeof field === 'string'
-							? formatTimezoneAdjustedTimestamp(
-									field,
-									DATE_TIME_FORMATS.ISO_DATETIME_MS,
-							  )
-							: formatTimezoneAdjustedTimestamp(
-									field / 1e6,
-									DATE_TIME_FORMATS.ISO_DATETIME_MS,
-							  );
-					return {
-						children: (
-							<div className="table-timestamp">
-								<Typography.Paragraph ellipsis className={cx('text', fontSize)}>
-									{date}
-								</Typography.Paragraph>
-							</div>
-						),
-					};
-				},
-			},
+			...(fields.some((field) => field.name === 'timestamp')
+				? [
+						{
+							title: 'timestamp',
+							dataIndex: 'timestamp',
+							key: 'timestamp',
+							// https://github.com/ant-design/ant-design/discussions/36886
+							render: (
+								field: string | number,
+							): ColumnTypeRender<Record<string, unknown>> => {
+								const date =
+									typeof field === 'string'
+										? formatTimezoneAdjustedTimestamp(
+												field,
+												DATE_TIME_FORMATS.ISO_DATETIME_MS,
+										  )
+										: formatTimezoneAdjustedTimestamp(
+												field / 1e6,
+												DATE_TIME_FORMATS.ISO_DATETIME_MS,
+										  );
+								return {
+									children: (
+										<div className="table-timestamp">
+											<Typography.Paragraph ellipsis className={cx('text', fontSize)}>
+												{date}
+											</Typography.Paragraph>
+										</div>
+									),
+								};
+							},
+						},
+				  ]
+				: []),
 			...(appendTo === 'center' ? fieldColumns : []),
-			{
-				title: 'body',
-				dataIndex: 'body',
-				key: 'body',
-				render: (field): ColumnTypeRender<Record<string, unknown>> => ({
-					props: {
-						style: defaultTableStyle,
-					},
-					children: (
-						<TableBodyContent
-							dangerouslySetInnerHTML={{
-								__html: convert.toHtml(
-									dompurify.sanitize(unescapeString(field), {
-										FORBID_TAGS: [...FORBID_DOM_PURIFY_TAGS],
-									}),
+			...(fields.some((field) => field.name === 'body')
+				? [
+						{
+							title: 'body',
+							dataIndex: 'body',
+							key: 'body',
+							render: (
+								field: string | number,
+							): ColumnTypeRender<Record<string, unknown>> => ({
+								props: {
+									style: defaultTableStyle,
+								},
+								children: (
+									<TableBodyContent
+										dangerouslySetInnerHTML={{
+											__html: convert.toHtml(
+												dompurify.sanitize(unescapeString(field as string), {
+													FORBID_TAGS: [...FORBID_DOM_PURIFY_TAGS],
+												}),
+											),
+										}}
+										fontSize={fontSize}
+										linesPerRow={linesPerRow}
+										isDarkMode={isDarkMode}
+									/>
 								),
-							}}
-							fontSize={fontSize}
-							linesPerRow={linesPerRow}
-							isDarkMode={isDarkMode}
-						/>
-					),
-				}),
-			},
+							}),
+						},
+				  ]
+				: []),
 			...(appendTo === 'end' ? fieldColumns : []),
 		];
 	}, [

--- a/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
+++ b/frontend/src/components/LogsFormatOptionsMenu/LogsFormatOptionsMenu.tsx
@@ -417,11 +417,13 @@ export default function LogsFormatOptionsMenu({
 														{key}
 													</Tooltip>
 												</div>
-												<X
-													className="delete-btn"
-													size={14}
-													onClick={(): void => addColumn.onRemove(id as string)}
-												/>
+												{addColumn?.value?.length > 1 && (
+													<X
+														className="delete-btn"
+														size={14}
+														onClick={(): void => addColumn.onRemove(id as string)}
+													/>
+												)}
 											</div>
 										))}
 										{addColumn && addColumn?.value?.length === 0 && (

--- a/frontend/src/container/LogsExplorerList/InfinityTableView/index.tsx
+++ b/frontend/src/container/LogsExplorerList/InfinityTableView/index.tsx
@@ -121,23 +121,25 @@ const InfinityTable = forwardRef<TableVirtuosoHandle, InfinityTableProps>(
 		const tableHeader = useCallback(
 			() => (
 				<tr>
-					{tableColumns.map((column) => {
-						const isDragColumn = column.key !== 'expand';
+					{tableColumns
+						.filter((column) => column.key)
+						.map((column) => {
+							const isDragColumn = column.key !== 'expand';
 
-						return (
-							<TableHeaderCellStyled
-								$isLogIndicator={column.key === 'state-indicator'}
-								$isDarkMode={isDarkMode}
-								$isDragColumn={isDragColumn}
-								key={column.key}
-								fontSize={tableViewProps?.fontSize}
-								// eslint-disable-next-line react/jsx-props-no-spreading
-								{...(isDragColumn && { className: 'dragHandler' })}
-							>
-								{(column.title as string).replace(/^\w/, (c) => c.toUpperCase())}
-							</TableHeaderCellStyled>
-						);
-					})}
+							return (
+								<TableHeaderCellStyled
+									$isLogIndicator={column.key === 'state-indicator'}
+									$isDarkMode={isDarkMode}
+									$isDragColumn={isDragColumn}
+									key={column.key}
+									fontSize={tableViewProps?.fontSize}
+									// eslint-disable-next-line react/jsx-props-no-spreading
+									{...(isDragColumn && { className: 'dragHandler' })}
+								>
+									{(column.title as string).replace(/^\w/, (c) => c.toUpperCase())}
+								</TableHeaderCellStyled>
+							);
+						})}
 				</tr>
 			),
 			[tableColumns, isDarkMode, tableViewProps?.fontSize],

--- a/frontend/src/container/LogsExplorerList/InfinityTableView/styles.ts
+++ b/frontend/src/container/LogsExplorerList/InfinityTableView/styles.ts
@@ -29,7 +29,7 @@ export const TableCellStyled = styled.td<TableHeaderCellStyledProps>`
 		props.$isDarkMode ? 'inherit' : themeColors.whiteCream};
 
 	${({ $isLogIndicator }): string =>
-		$isLogIndicator ? 'padding: 0 0 0 8px;' : ''}
+		$isLogIndicator ? 'padding: 0 0 0 8px;width: 15px;' : ''}
 	color: ${(props): string =>
 		props.$isDarkMode ? themeColors.white : themeColors.bckgGrey};
 `;

--- a/frontend/src/container/OptionsMenu/constants.ts
+++ b/frontend/src/container/OptionsMenu/constants.ts
@@ -5,30 +5,32 @@ import { FontSize, OptionsQuery } from './types';
 export const URL_OPTIONS = 'options';
 
 export const defaultOptionsQuery: OptionsQuery = {
-	selectColumns: [
-		{
-			key: 'timestamp',
-			dataType: DataTypes.String,
-			type: 'tag',
-			isColumn: true,
-			isJSON: false,
-			id: 'timestamp--string--tag--true',
-			isIndexed: false,
-		},
-		{
-			key: 'body',
-			dataType: DataTypes.String,
-			type: 'tag',
-			isColumn: true,
-			isJSON: false,
-			id: 'body--string--tag--true',
-			isIndexed: false,
-		},
-	],
+	selectColumns: [],
 	maxLines: 2,
 	format: 'raw',
 	fontSize: FontSize.SMALL,
 };
+
+export const defaultLogsSelectedColumns = [
+	{
+		key: 'timestamp',
+		dataType: DataTypes.String,
+		type: 'tag',
+		isColumn: true,
+		isJSON: false,
+		id: 'timestamp--string--tag--true',
+		isIndexed: false,
+	},
+	{
+		key: 'body',
+		dataType: DataTypes.String,
+		type: 'tag',
+		isColumn: true,
+		isJSON: false,
+		id: 'body--string--tag--true',
+		isIndexed: false,
+	},
+];
 
 export const defaultTraceSelectedColumns = [
 	{

--- a/frontend/src/container/OptionsMenu/constants.ts
+++ b/frontend/src/container/OptionsMenu/constants.ts
@@ -5,7 +5,26 @@ import { FontSize, OptionsQuery } from './types';
 export const URL_OPTIONS = 'options';
 
 export const defaultOptionsQuery: OptionsQuery = {
-	selectColumns: [],
+	selectColumns: [
+		{
+			key: 'timestamp',
+			dataType: DataTypes.String,
+			type: 'tag',
+			isColumn: true,
+			isJSON: false,
+			id: 'timestamp--string--tag--true',
+			isIndexed: false,
+		},
+		{
+			key: 'body',
+			dataType: DataTypes.String,
+			type: 'tag',
+			isColumn: true,
+			isJSON: false,
+			id: 'body--string--tag--true',
+			isIndexed: false,
+		},
+	],
 	maxLines: 2,
 	format: 'raw',
 	fontSize: FontSize.SMALL,

--- a/frontend/src/container/OptionsMenu/types.ts
+++ b/frontend/src/container/OptionsMenu/types.ts
@@ -17,6 +17,7 @@ export interface OptionsQuery {
 	maxLines: number;
 	format: LogViewMode;
 	fontSize: FontSize;
+	version?: number;
 }
 
 export interface InitialOptions

--- a/frontend/src/container/OptionsMenu/useOptionsMenu.ts
+++ b/frontend/src/container/OptionsMenu/useOptionsMenu.ts
@@ -21,6 +21,7 @@ import {
 import { DataSource } from 'types/common/queryBuilder';
 
 import {
+	defaultLogsSelectedColumns,
 	defaultOptionsQuery,
 	defaultTraceSelectedColumns,
 	URL_OPTIONS,
@@ -172,7 +173,7 @@ const useOptionsMenu = ({
 			if (dataSource === DataSource.LOGS) {
 				// add timestamp and body to the list of attributes
 				return [
-					...defaultOptionsQuery.selectColumns,
+					...defaultLogsSelectedColumns,
 					...searchedAttributesData.payload.attributeKeys.filter(
 						(attribute) => attribute.key !== 'body',
 					),

--- a/frontend/src/container/OptionsMenu/useOptionsMenu.ts
+++ b/frontend/src/container/OptionsMenu/useOptionsMenu.ts
@@ -169,6 +169,15 @@ const useOptionsMenu = ({
 
 	const searchedAttributeKeys = useMemo(() => {
 		if (searchedAttributesData?.payload?.attributeKeys?.length) {
+			if (dataSource === DataSource.LOGS) {
+				// add timestamp and body to the list of attributes
+				return [
+					...defaultOptionsQuery.selectColumns,
+					...searchedAttributesData.payload.attributeKeys.filter(
+						(attribute) => attribute.key !== 'body',
+					),
+				];
+			}
 			return searchedAttributesData.payload.attributeKeys;
 		}
 		if (dataSource === DataSource.TRACES) {
@@ -198,12 +207,17 @@ const useOptionsMenu = ({
 	);
 
 	const optionsFromAttributeKeys = useMemo(() => {
-		const filteredAttributeKeys = searchedAttributeKeys.filter(
-			(item) => item.key !== 'body',
-		);
+		const filteredAttributeKeys = searchedAttributeKeys.filter((item) => {
+			// For other data sources, only filter out 'body' if it exists
+			if (dataSource !== DataSource.LOGS) {
+				return item.key !== 'body';
+			}
+			// For LOGS, keep all keys
+			return true;
+		});
 
 		return getOptionsFromKeys(filteredAttributeKeys, selectedColumnKeys);
-	}, [searchedAttributeKeys, selectedColumnKeys]);
+	}, [dataSource, searchedAttributeKeys, selectedColumnKeys]);
 
 	const handleRedirectWithOptionsData = useCallback(
 		(newQueryData: OptionsQuery) => {


### PR DESCRIPTION
### Summary
#### Overview
Adds flexibility to control the visibility of timestamp and body fields across all logs explorer views (raw, default, column) while maintaining backward compatibility.

#### Key Changes
- Makes timestamp and body fields optional in logs display
- Adds default visibility for timestamp and body columns on new logs explorer visits
- Implements user preference persistence for column visibility

#### Backward Compatibility
- Automatically migrates old logs explorer URLs that lack timestamp/body in selectColumns
- Preserves functionality of existing saved views by adding default columns

#### User Experience
- Respects user preferences when timestamp/body columns are intentionally hidden
- Preserves column visibility choices in newly saved views
- Ensures at least one column is always visible to prevent empty logs
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
close https://github.com/SigNoz/signoz/issues/4999
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

https://github.com/user-attachments/assets/e8f3d7ba-18e5-41a4-a5b2-91f8e4df8c2b





<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

- Visit the logs explorer page from any other page, it should display the timestamp and body columns
- Visit a logs explorer link that doesn't have timestamp and body in the selectColumns query param, it should display the timestamp and body columns
- Visit the logs explorer page, and remove the timestamp / body columns from the options menu, it should be hidden
- Select an old saved view that doesn't have timestamp and body in the selectColumns, it should display the timestamp and body columns
- Remove the timestamp / body columns from the options menu, save the view, upon setting the view, it should respect the preference of removed columns
- While remove the columns from the options menu, don't allow removing the last column that can cause empty log line
<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds optional visibility for timestamp and body fields in logs explorer views with user preference persistence and backward compatibility.
> 
>   - **Behavior**:
>     - Timestamp and body fields are now optional in logs explorer views (`ListLogView`, `RawLogView`, `useTableView`).
>     - Default visibility for timestamp and body columns on new visits.
>     - User preferences for column visibility are persisted.
>   - **Backward Compatibility**:
>     - Migrates old logs explorer URLs missing timestamp/body in `selectColumns`.
>     - Preserves existing saved views by adding default columns.
>   - **User Experience**:
>     - Respects user preferences when timestamp/body columns are hidden.
>     - Ensures at least one column is visible to prevent empty logs.
>   - **Misc**:
>     - Adds `defaultLogsSelectedColumns` in `constants.ts` for default column settings.
>     - Updates `useOptionsMenu` to handle new default columns and versioning.
>     - Modifies `LogsFormatOptionsMenu` to prevent removing the last visible column.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 37d1f62b0f46e1d618780511dcf78330e59a527b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->