### PR TITLE
fix: show upgrade plan option in grace period if not converted to trial

### DIFF
--- a/frontend/src/container/BillingContainer/BillingContainer.test.tsx
+++ b/frontend/src/container/BillingContainer/BillingContainer.test.tsx
@@ -51,14 +51,12 @@ describe('BillingContainer', () => {
 		expect(cost).toBeInTheDocument();
 
 		const dayRemainingInBillingPeriod = await screen.findByText(
-			/11 days_remaining/i,
+			/Please upgrade plan now to retain your data./i,
 		);
 		expect(dayRemainingInBillingPeriod).toBeInTheDocument();
 
-		const manageBilling = screen.getByRole('button', {
-			name: 'manage_billing',
-		});
-		expect(manageBilling).toBeInTheDocument();
+		const upgradePlanButton = screen.getByTestId('upgrade-plan-button');
+		expect(upgradePlanButton).toBeInTheDocument();
 
 		const dollar = screen.getByText(/\$1,278.3/i);
 		await waitFor(() => expect(dollar).toBeInTheDocument());

--- a/frontend/src/container/BillingContainer/BillingContainer.tsx
+++ b/frontend/src/container/BillingContainer/BillingContainer.tsx
@@ -202,15 +202,16 @@ export default function BillingContainer(): JSX.Element {
 	const isSubscriptionPastDue =
 		apiResponse.subscriptionStatus === SubscriptionStatus.PastDue;
 
-	const { isLoading, isFetching: isFetchingBillingData } = useQuery(
-		[REACT_QUERY_KEY.GET_BILLING_USAGE, user?.id],
-		{
-			queryFn: () => getUsage(activeLicense?.key || ''),
-			onError: handleError,
-			enabled: activeLicense !== null,
-			onSuccess: processUsageData,
-		},
-	);
+	const {
+		isLoading,
+		isFetching: isFetchingBillingData,
+		data: billingData,
+	} = useQuery([REACT_QUERY_KEY.GET_BILLING_USAGE, user?.id], {
+		queryFn: () => getUsage(activeLicense?.key || ''),
+		onError: handleError,
+		enabled: activeLicense !== null,
+		onSuccess: processUsageData,
+	});
 
 	useEffect(() => {
 		const activeValidLicense =
@@ -318,7 +319,7 @@ export default function BillingContainer(): JSX.Element {
 	});
 
 	const handleBilling = useCallback(async () => {
-		if (isFreeTrial && !licenses?.trialConvertedToSubscription) {
+		if (!licenses?.trialConvertedToSubscription) {
 			logEvent('Billing : Upgrade Plan', {
 				user: pick(user, ['email', 'userId', 'name']),
 				org,
@@ -411,6 +412,12 @@ export default function BillingContainer(): JSX.Element {
 		}
 	}, [apiResponse, notifications]);
 
+	const showGracePeriodMessage =
+		!isLoading &&
+		!licenses?.trialConvertedToSubscription &&
+		!licenses?.onTrial &&
+		licenses?.gracePeriodEnd;
+
 	return (
 		<div className="billing-container">
 			<Flex vertical style={{ marginBottom: 16 }}>
@@ -433,7 +440,8 @@ export default function BillingContainer(): JSX.Element {
 							{isCloudUserVal ? t('teams_cloud') : t('teams')}{' '}
 							{isFreeTrial ? <Tag color="success"> Free Trial </Tag> : ''}
 						</Typography.Title>
-						{!isLoading && !isFetchingBillingData ? (
+
+						{!isLoading && !isFetchingBillingData && !showGracePeriodMessage ? (
 							<Typography.Text style={{ fontSize: 12, color: Color.BG_VANILLA_400 }}>
 								{daysRemaining} {daysRemainingStr}
 							</Typography.Text>
@@ -457,9 +465,9 @@ export default function BillingContainer(): JSX.Element {
 							disabled={isLoading}
 							onClick={handleBilling}
 						>
-							{isFreeTrial && !licenses?.trialConvertedToSubscription
-								? t('upgrade_plan')
-								: t('manage_billing')}
+							{licenses?.trialConvertedToSubscription
+								? t('manage_billing')
+								: t('upgrade_plan')}
 						</Button>
 					</Flex>
 				</Flex>
@@ -473,18 +481,35 @@ export default function BillingContainer(): JSX.Element {
 					</Typography.Text>
 				)}
 
-				{!isLoading && !isFetchingBillingData ? (
-					headerText && (
-						<Alert
-							message={headerText}
-							type="info"
-							showIcon
-							style={{ marginTop: 12 }}
-						/>
-					)
-				) : (
+				{!isLoading && !isFetchingBillingData && !showGracePeriodMessage
+					? headerText && (
+							<Alert
+								message={headerText}
+								type="info"
+								showIcon
+								style={{ marginTop: 12 }}
+							/>
+					  )
+					: null}
+
+				{isLoading || isFetchingBillingData ? (
 					<Skeleton.Input active style={{ height: 20, marginTop: 20 }} />
-				)}
+				) : null}
+
+				{!isLoading &&
+				!isFetchingBillingData &&
+				billingData &&
+				licenses?.gracePeriodEnd &&
+				showGracePeriodMessage ? (
+					<Alert
+						message={`Your data is safe with us until ${getFormattedDate(
+							licenses?.gracePeriodEnd || Date.now(),
+						)}. Please upgrade plan now to retain your data.`}
+						type="info"
+						showIcon
+						style={{ marginTop: 12 }}
+					/>
+				) : null}
 
 				{isSubscriptionPastDue &&
 					(!isLoading && !isFetchingBillingData ? (
@@ -514,7 +539,7 @@ export default function BillingContainer(): JSX.Element {
 				{(isLoading || isFetchingBillingData) && renderTableSkeleton()}
 			</div>
 
-			{isFreeTrial && !licenses?.trialConvertedToSubscription && (
+			{!licenses?.trialConvertedToSubscription && (
 				<div className="upgrade-plan-benefits">
 					<Row
 						justify="space-between"

--- a/frontend/src/container/BillingContainer/BillingContainer.tsx
+++ b/frontend/src/container/BillingContainer/BillingContainer.tsx
@@ -459,6 +459,7 @@ export default function BillingContainer(): JSX.Element {
 							Download CSV
 						</Button>
 						<Button
+							data-testid="header-billing-button"
 							type="primary"
 							size="middle"
 							loading={isLoadingBilling || isLoadingManageBilling}
@@ -577,6 +578,7 @@ export default function BillingContainer(): JSX.Element {
 						</Col>
 						<Col span={4} style={{ display: 'flex', justifyContent: 'flex-end' }}>
 							<Button
+								data-testid="upgrade-plan-button"
 								type="primary"
 								size="middle"
 								loading={isLoadingBilling || isLoadingManageBilling}


### PR DESCRIPTION

<img width="1920" alt="Screenshot 2025-01-23 at 15 29 03" src="https://github.com/user-attachments/assets/a5437098-482f-417f-a438-7cdbe6cfaea9" />



<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Show upgrade plan option during grace period if trial not converted to subscription in `BillingContainer`.
> 
>   - **Behavior**:
>     - Show upgrade plan option during grace period if trial not converted to subscription in `BillingContainer.tsx`.
>     - Update alert message to inform users about data safety until grace period end.
>   - **Tests**:
>     - Update `BillingContainer.test.tsx` to check for upgrade plan button visibility and new alert message.
>   - **Misc**:
>     - Add `showGracePeriodMessage` logic to determine when to display the upgrade plan option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 029204533f6ee565c4d1f298267e1990d1c68f09. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->