### PR TITLE
Feat/6175

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -2571,6 +2571,58 @@ func (r *ClickHouseReader) FetchTemporality(ctx context.Context, metricNames []s
 	return metricNameToTemporality, nil
 }
 
+func (r *ClickHouseReader) GetTemporalitySwitchPoints(ctx context.Context, metricName string, startTime int64, endTime int64) ([]v3.TemporalityChangePoint, error) {
+	// Initialize slice to store temporality switch points
+	var temporalitySwitches []v3.TemporalityChangePoint
+
+	query := fmt.Sprintf(`
+		SELECT
+			temporality,
+			unix_milli,
+			lag_temporality
+		FROM (
+			SELECT
+				metric_name,
+				temporality,
+				unix_milli,
+				lagInFrame(temporality, 1, '') OVER (
+					PARTITION BY metric_name ORDER BY unix_milli
+				) AS lag_temporality
+			FROM %s.%s
+			WHERE unix_milli >= %d
+			AND unix_milli <= %d
+			AND metric_name = '%s'
+		) AS subquery
+		WHERE lag_temporality != temporality
+		AND lag_temporality != ''
+		ORDER BY unix_milli ASC;
+		`, signozMetricDBName, signozTSLocalTableNameV4, startTime, endTime, metricName)
+
+	rows, err := r.db.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var temporality string
+		var timestamp int64
+		var lagTemporality string
+		err := rows.Scan(&temporality, &timestamp, &lagTemporality)
+		if err != nil {
+			return nil, err
+		}
+		// Store each temporality switch point with both temporalities
+		temporalitySwitches = append(temporalitySwitches, v3.TemporalityChangePoint{
+			Timestamp:       timestamp,
+			FromTemporality: v3.Temporality(lagTemporality),
+			ToTemporality:   v3.Temporality(temporality),
+		})
+	}
+
+	return temporalitySwitches, nil
+}
+
 func (r *ClickHouseReader) GetTimeSeriesInfo(ctx context.Context) (map[string]interface{}, error) {
 
 	queryStr := fmt.Sprintf("SELECT countDistinct(fingerprint) as count from %s.%s where metric_name not like 'signoz_%%' group by metric_name order by count desc;", signozMetricDBName, signozTSTableNameV41Day)

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -645,6 +645,9 @@ func (aH *APIHandler) PopulateTemporality(ctx context.Context, qp *v3.QueryRange
 				} else {
 					query.Temporality = v3.Unspecified
 				}
+				if len(aH.temporalityMap[query.AggregateAttribute.Key]) > 1 {
+					query.MultipleTemporalities = true
+				}
 			}
 			// we don't have temporality for this metric
 			if query.DataSource == v3.DataSourceMetrics && query.Temporality == "" {
@@ -671,6 +674,9 @@ func (aH *APIHandler) PopulateTemporality(ctx context.Context, qp *v3.QueryRange
 					query.Temporality = v3.Cumulative
 				} else {
 					query.Temporality = v3.Unspecified
+				}
+				if len(nameToTemporality[query.AggregateAttribute.Key]) > 1 {
+					query.MultipleTemporalities = true
 				}
 				aH.temporalityMap[query.AggregateAttribute.Key] = nameToTemporality[query.AggregateAttribute.Key]
 			}

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -734,3 +734,10 @@ func init() {
 }
 
 const TRACE_V4_MAX_PAGINATION_LIMIT = 10000
+
+// ClickHouse context settings
+const (
+	ResultOverflowMode = "result_overflow_mode"
+	MaxRowsToGroupBy   = "max_rows_to_group_by"
+	MaxResultRows      = "max_result_rows"
+)

--- a/pkg/query-service/interfaces/interface.go
+++ b/pkg/query-service/interfaces/interface.go
@@ -113,6 +113,8 @@ type Reader interface {
 	//trace
 	GetTraceFields(ctx context.Context) (*model.GetFieldsResponse, *model.ApiError)
 	UpdateTraceField(ctx context.Context, field *model.UpdateField) *model.ApiError
+
+	GetTemporalitySwitchPoints(ctx context.Context, metricName string, startTime int64, endTime int64) ([]v3.TemporalityChangePoint, error)
 }
 
 type Querier interface {

--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -786,32 +786,33 @@ func (m *MetricValueFilter) Clone() *MetricValueFilter {
 }
 
 type BuilderQuery struct {
-	QueryName            string            `json:"queryName"`
-	StepInterval         int64             `json:"stepInterval"`
-	DataSource           DataSource        `json:"dataSource"`
-	AggregateOperator    AggregateOperator `json:"aggregateOperator"`
-	AggregateAttribute   AttributeKey      `json:"aggregateAttribute,omitempty"`
-	Temporality          Temporality       `json:"temporality,omitempty"`
-	Filters              *FilterSet        `json:"filters,omitempty"`
-	GroupBy              []AttributeKey    `json:"groupBy,omitempty"`
-	Expression           string            `json:"expression"`
-	Disabled             bool              `json:"disabled"`
-	Having               []Having          `json:"having,omitempty"`
-	Legend               string            `json:"legend,omitempty"`
-	Limit                uint64            `json:"limit"`
-	Offset               uint64            `json:"offset"`
-	PageSize             uint64            `json:"pageSize"`
-	OrderBy              []OrderBy         `json:"orderBy,omitempty"`
-	ReduceTo             ReduceToOperator  `json:"reduceTo,omitempty"`
-	SelectColumns        []AttributeKey    `json:"selectColumns,omitempty"`
-	TimeAggregation      TimeAggregation   `json:"timeAggregation,omitempty"`
-	SpaceAggregation     SpaceAggregation  `json:"spaceAggregation,omitempty"`
-	Functions            []Function        `json:"functions,omitempty"`
-	ShiftBy              int64
-	IsAnomaly            bool
-	QueriesUsedInFormula []string
-	MetricTableHints     *MetricTableHints  `json:"-"`
-	MetricValueFilter    *MetricValueFilter `json:"-"`
+	QueryName             string            `json:"queryName"`
+	StepInterval          int64             `json:"stepInterval"`
+	DataSource            DataSource        `json:"dataSource"`
+	AggregateOperator     AggregateOperator `json:"aggregateOperator"`
+	AggregateAttribute    AttributeKey      `json:"aggregateAttribute,omitempty"`
+	Temporality           Temporality       `json:"temporality,omitempty"`
+	Filters               *FilterSet        `json:"filters,omitempty"`
+	GroupBy               []AttributeKey    `json:"groupBy,omitempty"`
+	Expression            string            `json:"expression"`
+	Disabled              bool              `json:"disabled"`
+	Having                []Having          `json:"having,omitempty"`
+	Legend                string            `json:"legend,omitempty"`
+	Limit                 uint64            `json:"limit"`
+	Offset                uint64            `json:"offset"`
+	PageSize              uint64            `json:"pageSize"`
+	OrderBy               []OrderBy         `json:"orderBy,omitempty"`
+	ReduceTo              ReduceToOperator  `json:"reduceTo,omitempty"`
+	SelectColumns         []AttributeKey    `json:"selectColumns,omitempty"`
+	TimeAggregation       TimeAggregation   `json:"timeAggregation,omitempty"`
+	SpaceAggregation      SpaceAggregation  `json:"spaceAggregation,omitempty"`
+	Functions             []Function        `json:"functions,omitempty"`
+	ShiftBy               int64
+	IsAnomaly             bool
+	QueriesUsedInFormula  []string
+	MetricTableHints      *MetricTableHints  `json:"-"`
+	MetricValueFilter     *MetricValueFilter `json:"-"`
+	MultipleTemporalities bool
 }
 
 func (b *BuilderQuery) SetShiftByFromFunc() {
@@ -1377,4 +1378,10 @@ type QBOptions struct {
 	GraphLimitQtype string
 	IsLivetailQuery bool
 	PreferRPM       bool
+}
+
+type TemporalityChangePoint struct {
+	Timestamp       int64       `json:"timestamp"`
+	FromTemporality Temporality `json:"from_temporality"`
+	ToTemporality   Temporality `json:"to_temporality"`
 }

--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -398,10 +398,12 @@ func (q *QueryRangeParamsV3) Clone() *QueryRangeParamsV3 {
 }
 
 type PromQuery struct {
-	Query    string `json:"query"`
-	Stats    string `json:"stats,omitempty"`
-	Disabled bool   `json:"disabled"`
-	Legend   string `json:"legend,omitempty"`
+	Query         string `json:"query"`
+	Stats         string `json:"stats,omitempty"`
+	Disabled      bool   `json:"disabled"`
+	Legend        string `json:"legend,omitempty"`
+	MaxTimeSeries int    `json:"maxTimeSeries,omitempty"`
+	MaxSamples    int    `json:"maxSamples,omitempty"`
 }
 
 func (p *PromQuery) Clone() *PromQuery {


### PR DESCRIPTION
### Summary

added support for cumulative and delta metrics counter, for metrics in which user switched the temporality in between

#### Related Issues / PR's

https://github.com/SigNoz/signoz/issues/6175#event-15899165728


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for handling temporality switches in metrics queries, enhancing data accuracy when temporality changes occur.
> 
>   - **Behavior**:
>     - Adds `GetTemporalitySwitchPoints()` in `reader.go` to detect temporality changes in metrics.
>     - Updates `runBuilderQueries()` in `querier.go` to handle queries with multiple temporalities using `handleTemporalitySwitches()`.
>     - Modifies `PopulateTemporality()` in `http_handler.go` to set `MultipleTemporalities` flag for metrics with temporality changes.
>   - **Models**:
>     - Adds `TemporalityChangePoint` struct in `v3.go` to represent temporality switch points.
>   - **Constants**:
>     - Adds constants for ClickHouse context settings in `constants.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 762e61b44262a0633a17a479a41b473076bb2891. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->