### PR TITLE
feat: added simultaneous temporality changes | 6175

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -655,6 +655,9 @@ func (aH *APIHandler) PopulateTemporality(ctx context.Context, qp *v3.QueryRange
 				} else {
 					query.Temporality = v3.Unspecified
 				}
+				if len(aH.temporalityMap[query.AggregateAttribute.Key]) > 1 {
+					query.MultipleTemporalities = true
+				}
 			}
 			// we don't have temporality for this metric
 			if query.DataSource == v3.DataSourceMetrics && query.Temporality == "" {
@@ -681,6 +684,9 @@ func (aH *APIHandler) PopulateTemporality(ctx context.Context, qp *v3.QueryRange
 					query.Temporality = v3.Cumulative
 				} else {
 					query.Temporality = v3.Unspecified
+				}
+				if len(nameToTemporality[query.AggregateAttribute.Key]) > 1 {
+					query.MultipleTemporalities = true
 				}
 				aH.temporalityMap[query.AggregateAttribute.Key] = nameToTemporality[query.AggregateAttribute.Key]
 			}

--- a/pkg/query-service/interfaces/interface.go
+++ b/pkg/query-service/interfaces/interface.go
@@ -115,6 +115,8 @@ type Reader interface {
 	//trace
 	GetTraceFields(ctx context.Context) (*model.GetFieldsResponse, *model.ApiError)
 	UpdateTraceField(ctx context.Context, field *model.UpdateField) *model.ApiError
+
+	GetTemporalitySwitchPoints(ctx context.Context, metricName string, startTime int64, endTime int64) ([]v3.TemporalityChangePoint, error)
 }
 
 type Querier interface {

--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -807,6 +807,7 @@ func (m *MetricValueFilter) Clone() *MetricValueFilter {
 }
 
 type BuilderQuery struct {
+<<<<<<< HEAD
 	QueryName            string               `json:"queryName"`
 	StepInterval         int64                `json:"stepInterval"`
 	DataSource           DataSource           `json:"dataSource"`
@@ -834,6 +835,35 @@ type BuilderQuery struct {
 	QueriesUsedInFormula []string
 	MetricTableHints     *MetricTableHints  `json:"-"`
 	MetricValueFilter    *MetricValueFilter `json:"-"`
+=======
+	QueryName             string            `json:"queryName"`
+	StepInterval          int64             `json:"stepInterval"`
+	DataSource            DataSource        `json:"dataSource"`
+	AggregateOperator     AggregateOperator `json:"aggregateOperator"`
+	AggregateAttribute    AttributeKey      `json:"aggregateAttribute,omitempty"`
+	Temporality           Temporality       `json:"temporality,omitempty"`
+	Filters               *FilterSet        `json:"filters,omitempty"`
+	GroupBy               []AttributeKey    `json:"groupBy,omitempty"`
+	Expression            string            `json:"expression"`
+	Disabled              bool              `json:"disabled"`
+	Having                []Having          `json:"having,omitempty"`
+	Legend                string            `json:"legend,omitempty"`
+	Limit                 uint64            `json:"limit"`
+	Offset                uint64            `json:"offset"`
+	PageSize              uint64            `json:"pageSize"`
+	OrderBy               []OrderBy         `json:"orderBy,omitempty"`
+	ReduceTo              ReduceToOperator  `json:"reduceTo,omitempty"`
+	SelectColumns         []AttributeKey    `json:"selectColumns,omitempty"`
+	TimeAggregation       TimeAggregation   `json:"timeAggregation,omitempty"`
+	SpaceAggregation      SpaceAggregation  `json:"spaceAggregation,omitempty"`
+	Functions             []Function        `json:"functions,omitempty"`
+	ShiftBy               int64
+	IsAnomaly             bool
+	QueriesUsedInFormula  []string
+	MetricTableHints      *MetricTableHints  `json:"-"`
+	MetricValueFilter     *MetricValueFilter `json:"-"`
+	MultipleTemporalities bool
+>>>>>>> b581657bb (feat: added simultaneous temporality changes | 6175)
 }
 
 func (b *BuilderQuery) SetShiftByFromFunc() {
@@ -1405,4 +1435,10 @@ type QBOptions struct {
 	GraphLimitQtype string
 	IsLivetailQuery bool
 	PreferRPM       bool
+}
+
+type TemporalityChangePoint struct {
+	Timestamp       int64       `json:"timestamp"`
+	FromTemporality Temporality `json:"from_temporality"`
+	ToTemporality   Temporality `json:"to_temporality"`
 }


### PR DESCRIPTION
Summary
Added support for cumulative and delta metrics counter, for metrics in which user switched the temporality in between

Related Issues / PR's
https://github.com/SigNoz/signoz/issues/6175
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for handling metrics with changing temporalities by detecting switch points and adjusting queries accordingly.
> 
>   - **Behavior**:
>     - Added `GetTemporalitySwitchPoints()` in `reader.go` to fetch points where temporality changes for a metric.
>     - Updated `runBuilderQueries()` in `querier.go` to handle metrics with multiple temporalities by splitting queries at switch points.
>     - Modified `PopulateTemporality()` in `http_handler.go` to set `MultipleTemporalities` flag in `BuilderQuery` if temporality changes are detected.
>   - **Models**:
>     - Added `TemporalityChangePoint` struct in `v3.go` to represent temporality switch points.
>     - Updated `BuilderQuery` struct in `v3.go` to include `MultipleTemporalities` flag.
>   - **Interfaces**:
>     - Added `GetTemporalitySwitchPoints()` to `Reader` interface in `interface.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for bdd3b5d5b7c07ac53a2a72871429e675dc0114c7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->