### PR TITLE
fix: logging middleware add excluded routes

### DIFF
--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -78,3 +78,6 @@ apiserver:
     excluded_routes:
       - /api/v1/logs/tail
       - /api/v3/logs/livetail
+  logging:
+    excluded_routes:
+      - /api/v1/health

--- a/ee/query-service/app/server.go
+++ b/ee/query-service/app/server.go
@@ -330,7 +330,7 @@ func (s *Server) createPrivateServer(apiHandler *api.APIHandler) (*http.Server, 
 		s.serverOptions.Config.APIServer.Timeout.Max,
 	).Wrap)
 	r.Use(middleware.NewAnalytics(zap.L()).Wrap)
-	r.Use(middleware.NewLogging(zap.L(), s.serverOptions.Config.APIServer.Logging.ExcludedApiRoutes).Wrap)
+	r.Use(middleware.NewLogging(zap.L(), s.serverOptions.Config.APIServer.Logging.ExcludedRoutes).Wrap)
 
 	apiHandler.RegisterPrivateRoutes(r)
 
@@ -376,7 +376,7 @@ func (s *Server) createPublicServer(apiHandler *api.APIHandler, web web.Web) (*h
 		s.serverOptions.Config.APIServer.Timeout.Max,
 	).Wrap)
 	r.Use(middleware.NewAnalytics(zap.L()).Wrap)
-	r.Use(middleware.NewLogging(zap.L(), s.serverOptions.Config.APIServer.Logging.ExcludedApiRoutes).Wrap)
+	r.Use(middleware.NewLogging(zap.L(), s.serverOptions.Config.APIServer.Logging.ExcludedRoutes).Wrap)
 
 	apiHandler.RegisterRoutes(r, am)
 	apiHandler.RegisterLogsRoutes(r, am)

--- a/ee/query-service/app/server.go
+++ b/ee/query-service/app/server.go
@@ -330,7 +330,7 @@ func (s *Server) createPrivateServer(apiHandler *api.APIHandler) (*http.Server, 
 		s.serverOptions.Config.APIServer.Timeout.Max,
 	).Wrap)
 	r.Use(middleware.NewAnalytics(zap.L()).Wrap)
-	r.Use(middleware.NewLogging(zap.L()).Wrap)
+	r.Use(middleware.NewLogging(zap.L(), s.serverOptions.Config.APIServer.Logging.ExcludedApiRoutes).Wrap)
 
 	apiHandler.RegisterPrivateRoutes(r)
 
@@ -376,7 +376,7 @@ func (s *Server) createPublicServer(apiHandler *api.APIHandler, web web.Web) (*h
 		s.serverOptions.Config.APIServer.Timeout.Max,
 	).Wrap)
 	r.Use(middleware.NewAnalytics(zap.L()).Wrap)
-	r.Use(middleware.NewLogging(zap.L()).Wrap)
+	r.Use(middleware.NewLogging(zap.L(), s.serverOptions.Config.APIServer.Logging.ExcludedApiRoutes).Wrap)
 
 	apiHandler.RegisterRoutes(r, am)
 	apiHandler.RegisterLogsRoutes(r, am)

--- a/pkg/apiserver/config.go
+++ b/pkg/apiserver/config.go
@@ -23,7 +23,7 @@ type Timeout struct {
 
 type Logging struct {
 	// The list of routes that are excluded from the logging
-	ExcludedApiRoutes []string `mapstructure:"excluded_api_routes"`
+	ExcludedRoutes []string `mapstructure:"excluded_api_routes"`
 }
 
 func NewConfigFactory() factory.ConfigFactory {
@@ -41,7 +41,7 @@ func newConfig() factory.Config {
 			},
 		},
 		Logging: Logging{
-			ExcludedApiRoutes: []string{
+			ExcludedRoutes: []string{
 				"/api/v1/health",
 			},
 		},

--- a/pkg/apiserver/config.go
+++ b/pkg/apiserver/config.go
@@ -9,6 +9,7 @@ import (
 // Config holds the configuration for config.
 type Config struct {
 	Timeout Timeout `mapstructure:"timeout"`
+	Logging Logging `mapstructure:"logging"`
 }
 
 type Timeout struct {
@@ -18,6 +19,11 @@ type Timeout struct {
 	Max time.Duration `mapstructure:"max"`
 	// The list of routes that are excluded from the timeout
 	ExcludedRoutes []string `mapstructure:"excluded_routes"`
+}
+
+type Logging struct {
+	// The list of routes that are excluded from the logging
+	ExcludedApiRoutes []string `mapstructure:"excluded_api_routes"`
 }
 
 func NewConfigFactory() factory.ConfigFactory {
@@ -32,6 +38,11 @@ func newConfig() factory.Config {
 			ExcludedRoutes: []string{
 				"/api/v1/logs/tail",
 				"/api/v3/logs/livetail",
+			},
+		},
+		Logging: Logging{
+			ExcludedApiRoutes: []string{
+				"/api/v1/health",
 			},
 		},
 	}

--- a/pkg/apiserver/config.go
+++ b/pkg/apiserver/config.go
@@ -23,7 +23,7 @@ type Timeout struct {
 
 type Logging struct {
 	// The list of routes that are excluded from the logging
-	ExcludedRoutes []string `mapstructure:"excluded_api_routes"`
+	ExcludedRoutes []string `mapstructure:"excluded_routes"`
 }
 
 func NewConfigFactory() factory.ConfigFactory {

--- a/pkg/apiserver/config_test.go
+++ b/pkg/apiserver/config_test.go
@@ -16,7 +16,7 @@ func TestNewWithEnvProvider(t *testing.T) {
 	t.Setenv("SIGNOZ_APISERVER_TIMEOUT_DEFAULT", "70s")
 	t.Setenv("SIGNOZ_APISERVER_TIMEOUT_MAX", "700s")
 	t.Setenv("SIGNOZ_APISERVER_TIMEOUT_EXCLUDED__ROUTES", "/excluded1,/excluded2")
-	t.Setenv("SIGNOZ_APISERVER_LOGGING_EXCLUDED__API__ROUTES", "/api/v1/health1")
+	t.Setenv("SIGNOZ_APISERVER_LOGGING_EXCLUDED__ROUTES", "/api/v1/health1")
 
 	conf, err := config.New(
 		context.Background(),
@@ -47,7 +47,7 @@ func TestNewWithEnvProvider(t *testing.T) {
 			},
 		},
 		Logging: Logging{
-			ExcludedApiRoutes: []string{
+			ExcludedRoutes: []string{
 				"/api/v1/health1",
 			},
 		},

--- a/pkg/apiserver/config_test.go
+++ b/pkg/apiserver/config_test.go
@@ -16,6 +16,7 @@ func TestNewWithEnvProvider(t *testing.T) {
 	t.Setenv("SIGNOZ_APISERVER_TIMEOUT_DEFAULT", "70s")
 	t.Setenv("SIGNOZ_APISERVER_TIMEOUT_MAX", "700s")
 	t.Setenv("SIGNOZ_APISERVER_TIMEOUT_EXCLUDED__ROUTES", "/excluded1,/excluded2")
+	t.Setenv("SIGNOZ_APISERVER_LOGGING_EXCLUDED__API__ROUTES", "/api/v1/health1")
 
 	conf, err := config.New(
 		context.Background(),
@@ -43,6 +44,11 @@ func TestNewWithEnvProvider(t *testing.T) {
 			ExcludedRoutes: []string{
 				"/excluded1",
 				"/excluded2",
+			},
+		},
+		Logging: Logging{
+			ExcludedApiRoutes: []string{
+				"/api/v1/health1",
 			},
 		},
 	}

--- a/pkg/http/middleware/logging.go
+++ b/pkg/http/middleware/logging.go
@@ -21,16 +21,23 @@ const (
 )
 
 type Logging struct {
-	logger *zap.Logger
+	logger            *zap.Logger
+	excludedApiRoutes map[string]struct{}
 }
 
-func NewLogging(logger *zap.Logger) *Logging {
+func NewLogging(logger *zap.Logger, excludedApiRoutes []string) *Logging {
 	if logger == nil {
 		panic("cannot build logging, logger is empty")
 	}
 
+	excludedApiRoutesMap := make(map[string]struct{})
+	for _, route := range excludedApiRoutes {
+		excludedApiRoutesMap[route] = struct{}{}
+	}
+
 	return &Logging{
-		logger: logger.Named(pkgname),
+		logger:            logger.Named(pkgname),
+		excludedApiRoutes: excludedApiRoutesMap,
 	}
 }
 
@@ -58,6 +65,11 @@ func (middleware *Logging) Wrap(next http.Handler) http.Handler {
 		badResponseBuffer := new(bytes.Buffer)
 		writer := newBadResponseLoggingWriter(rw, badResponseBuffer)
 		next.ServeHTTP(writer, req)
+
+		// if the path is in the excludedApiRoutes map, don't log
+		if _, ok := middleware.excludedApiRoutes[path]; ok {
+			return
+		}
 
 		statusCode, err := writer.StatusCode(), writer.WriteError()
 		fields = append(fields,

--- a/pkg/http/middleware/logging.go
+++ b/pkg/http/middleware/logging.go
@@ -21,23 +21,23 @@ const (
 )
 
 type Logging struct {
-	logger            *zap.Logger
-	excludedApiRoutes map[string]struct{}
+	logger         *zap.Logger
+	excludedRoutes map[string]struct{}
 }
 
-func NewLogging(logger *zap.Logger, excludedApiRoutes []string) *Logging {
+func NewLogging(logger *zap.Logger, excludedRoutes []string) *Logging {
 	if logger == nil {
 		panic("cannot build logging, logger is empty")
 	}
 
-	excludedApiRoutesMap := make(map[string]struct{})
-	for _, route := range excludedApiRoutes {
-		excludedApiRoutesMap[route] = struct{}{}
+	excludedRoutesMap := make(map[string]struct{})
+	for _, route := range excludedRoutes {
+		excludedRoutesMap[route] = struct{}{}
 	}
 
 	return &Logging{
-		logger:            logger.Named(pkgname),
-		excludedApiRoutes: excludedApiRoutesMap,
+		logger:         logger.Named(pkgname),
+		excludedRoutes: excludedRoutesMap,
 	}
 }
 
@@ -66,8 +66,8 @@ func (middleware *Logging) Wrap(next http.Handler) http.Handler {
 		writer := newBadResponseLoggingWriter(rw, badResponseBuffer)
 		next.ServeHTTP(writer, req)
 
-		// if the path is in the excludedApiRoutes map, don't log
-		if _, ok := middleware.excludedApiRoutes[path]; ok {
+		// if the path is in the excludedRoutes map, don't log
+		if _, ok := middleware.excludedRoutes[path]; ok {
 			return
 		}
 

--- a/pkg/query-service/app/server.go
+++ b/pkg/query-service/app/server.go
@@ -275,7 +275,7 @@ func (s *Server) createPrivateServer(api *APIHandler) (*http.Server, error) {
 		s.serverOptions.Config.APIServer.Timeout.Max,
 	).Wrap)
 	r.Use(middleware.NewAnalytics(zap.L()).Wrap)
-	r.Use(middleware.NewLogging(zap.L()).Wrap)
+	r.Use(middleware.NewLogging(zap.L(), s.serverOptions.Config.APIServer.Logging.ExcludedApiRoutes).Wrap)
 
 	api.RegisterPrivateRoutes(r)
 
@@ -305,7 +305,7 @@ func (s *Server) createPublicServer(api *APIHandler, web web.Web) (*http.Server,
 		s.serverOptions.Config.APIServer.Timeout.Max,
 	).Wrap)
 	r.Use(middleware.NewAnalytics(zap.L()).Wrap)
-	r.Use(middleware.NewLogging(zap.L()).Wrap)
+	r.Use(middleware.NewLogging(zap.L(), s.serverOptions.Config.APIServer.Logging.ExcludedApiRoutes).Wrap)
 
 	// add auth middleware
 	getUserFromRequest := func(r *http.Request) (*model.UserPayload, error) {

--- a/pkg/query-service/app/server.go
+++ b/pkg/query-service/app/server.go
@@ -275,7 +275,7 @@ func (s *Server) createPrivateServer(api *APIHandler) (*http.Server, error) {
 		s.serverOptions.Config.APIServer.Timeout.Max,
 	).Wrap)
 	r.Use(middleware.NewAnalytics(zap.L()).Wrap)
-	r.Use(middleware.NewLogging(zap.L(), s.serverOptions.Config.APIServer.Logging.ExcludedApiRoutes).Wrap)
+	r.Use(middleware.NewLogging(zap.L(), s.serverOptions.Config.APIServer.Logging.ExcludedRoutes).Wrap)
 
 	api.RegisterPrivateRoutes(r)
 
@@ -305,7 +305,7 @@ func (s *Server) createPublicServer(api *APIHandler, web web.Web) (*http.Server,
 		s.serverOptions.Config.APIServer.Timeout.Max,
 	).Wrap)
 	r.Use(middleware.NewAnalytics(zap.L()).Wrap)
-	r.Use(middleware.NewLogging(zap.L(), s.serverOptions.Config.APIServer.Logging.ExcludedApiRoutes).Wrap)
+	r.Use(middleware.NewLogging(zap.L(), s.serverOptions.Config.APIServer.Logging.ExcludedRoutes).Wrap)
 
 	// add auth middleware
 	getUserFromRequest := func(r *http.Request) (*model.UserPayload, error) {


### PR DESCRIPTION
Part of https://github.com/SigNoz/platform-pod/issues/406

Logging middleware not takes an array of routes to exclude, and apiserver configs excepts a logging config.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for excluding specific routes from logging in middleware by updating configuration and server setup.
> 
>   - **Behavior**:
>     - `NewLogging` in `logging.go` now accepts `excludedRoutes` to skip logging for specified paths.
>     - Updated `createPrivateServer` and `createPublicServer` in `server.go` to use the new logging configuration.
>   - **Configuration**:
>     - Added `Logging` struct in `config.go` with `ExcludedRoutes`.
>     - Updated `example.yaml` to include `logging.excluded_routes`.
>   - **Tests**:
>     - Updated `TestNewWithEnvProvider` in `config_test.go` to test `SIGNOZ_APISERVER_LOGGING_EXCLUDED__ROUTES`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 4aa3ffc11aced89c93edcb8ab741b3e683d9bbfb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->