### PR TITLE
fix: adjust the buffer time for start and end time in trace to logs

### DIFF
--- a/frontend/src/container/TraceDetail/SelectedSpanDetails/index.tsx
+++ b/frontend/src/container/TraceDetail/SelectedSpanDetails/index.tsx
@@ -19,6 +19,8 @@ import Events from './Events';
 import { CardContainer, CustomSubText, styles } from './styles';
 import Tags from './Tags';
 
+const FIVE_MINUTES_IN_MS = 5 * 60 * 1000;
+
 function SelectedSpanDetails(props: SelectedSpanDetailsProps): JSX.Element {
 	const { maxTime, minTime } = useSelector<AppState, GlobalReducer>(
 		(state) => state.globalTime,
@@ -86,10 +88,10 @@ function SelectedSpanDetails(props: SelectedSpanDetailsProps): JSX.Element {
 		history.push(
 			`${ROUTES.LOGS_EXPLORER}?${createQueryParams({
 				[QueryParams.compositeQuery]: JSON.stringify(query),
-				// we subtract 1000 milliseconds from the start time to handle the cases when the trace duration is in nanoseconds
-				[QueryParams.startTime]: traceStartTime - 1000,
-				// we add 1000 milliseconds to the end time for nano second duration traces
-				[QueryParams.endTime]: traceEndTime + 1000,
+				// we subtract 5 minutes from the start time to handle the cases when the trace duration is in nanoseconds
+				[QueryParams.startTime]: traceStartTime - FIVE_MINUTES_IN_MS,
+				// we add 5 minutes to the end time for nano second duration traces
+				[QueryParams.endTime]: traceEndTime + FIVE_MINUTES_IN_MS,
 			})}`,
 		);
 	};


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's
close https://github.com/SigNoz/signoz/issues/6927
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
Before:

https://github.com/user-attachments/assets/3bda0965-fbd0-4dbe-a519-ab669695722e


After:

https://github.com/user-attachments/assets/1db9c93d-701a-4e25-ae66-49f47db1f28b



<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas
- Trace to log in trace details pge
<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjusts buffer time for trace start and end times in `SelectedSpanDetails` to 5 minutes for log queries.
> 
>   - **Behavior**:
>     - Adjusts buffer time for `traceStartTime` and `traceEndTime` in `SelectedSpanDetails` from 1000ms to 5 minutes.
>     - Affects log queries in `onLogsHandler()` by modifying start and end times to handle nanosecond duration traces.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 5b475337bbfade2fdf1d66960962fa9379bf2c8f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->