### PR TITLE
fix: apply x axis date/time formatting only to panel types that have date/time in x axis

### DIFF
--- a/frontend/src/container/AnomalyAlertEvaluationView/AnomalyAlertEvaluationView.tsx
+++ b/frontend/src/container/AnomalyAlertEvaluationView/AnomalyAlertEvaluationView.tsx
@@ -259,7 +259,7 @@ function AnomalyAlertEvaluationView({
 		grid: {
 			show: true,
 		},
-		axes: getAxes(isDarkMode, yAxisUnit),
+		axes: getAxes({ isDarkMode, yAxisUnit }),
 		tzDate: (timestamp: number): Date =>
 			uPlot.tzDate(new Date(timestamp * 1e3), timezone.value),
 	};

--- a/frontend/src/container/BillingContainer/BillingUsageGraph/BillingUsageGraph.tsx
+++ b/frontend/src/container/BillingContainer/BillingUsageGraph/BillingUsageGraph.tsx
@@ -122,7 +122,7 @@ export function BillingUsageGraph(props: BillingUsageGraphProps): JSX.Element {
 		[graphCompatibleData.data.result],
 	);
 
-	const axesOptions = getAxes(isDarkMode, '');
+	const axesOptions = getAxes({ isDarkMode, yAxisUnit: '' });
 
 	const optionsForChart: uPlot.Options = useMemo(
 		() => ({

--- a/frontend/src/lib/uPlotLib/getUplotChartOptions.ts
+++ b/frontend/src/lib/uPlotLib/getUplotChartOptions.ts
@@ -387,6 +387,6 @@ export const getUPlotChartOptions = ({
 					hiddenGraph,
 					isDarkMode,
 			  }),
-		axes: getAxes(isDarkMode, yAxisUnit),
+		axes: getAxes({ isDarkMode, yAxisUnit, panelType }),
 	};
 };

--- a/frontend/src/lib/uPlotLib/getUplotHistogramChartOptions.ts
+++ b/frontend/src/lib/uPlotLib/getUplotHistogramChartOptions.ts
@@ -123,6 +123,7 @@ export const getUplotHistogramChartOptions = ({
 	setGraphsVisibilityStates,
 	mergeAllQueries,
 	onClickHandler = _noop,
+	panelType,
 }: GetUplotHistogramChartOptionsProps): uPlot.Options =>
 	({
 		id,
@@ -210,5 +211,5 @@ export const getUplotHistogramChartOptions = ({
 				},
 			],
 		},
-		axes: getAxes(isDarkMode),
+		axes: getAxes({ isDarkMode, panelType }),
 	} as uPlot.Options);

--- a/frontend/src/lib/uPlotLib/utils/getAxes.ts
+++ b/frontend/src/lib/uPlotLib/utils/getAxes.ts
@@ -1,12 +1,27 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 import { getToolTipValue } from 'components/Graph/yAxisConfig';
+import { PANEL_TYPES } from 'constants/queryBuilder';
 
 import { uPlotXAxisValuesFormat } from './constants';
 import getGridColor from './getGridColor';
 
+const PANEL_TYPES_WITH_X_AXIS_DATETIME_FORMAT = [
+	PANEL_TYPES.TIME_SERIES,
+	PANEL_TYPES.BAR,
+	PANEL_TYPES.PIE,
+];
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getAxes = (isDarkMode: boolean, yAxisUnit?: string): any => [
+const getAxes = ({
+	isDarkMode,
+	yAxisUnit,
+	panelType,
+}: {
+	isDarkMode: boolean;
+	yAxisUnit?: string;
+	panelType?: PANEL_TYPES;
+}): any => [
 	{
 		stroke: isDarkMode ? 'white' : 'black', // Color of the axis line
 		grid: {
@@ -19,7 +34,11 @@ const getAxes = (isDarkMode: boolean, yAxisUnit?: string): any => [
 			width: 0.3, // Width of the tick lines,
 			show: true,
 		},
-		values: uPlotXAxisValuesFormat,
+		...(PANEL_TYPES_WITH_X_AXIS_DATETIME_FORMAT.includes(panelType)
+			? {
+					values: uPlotXAxisValuesFormat,
+			  }
+			: {}),
 		gap: 5,
 	},
 	{


### PR DESCRIPTION
### Summary
- previously the uPlotXAxisValuesFormat was being applied to all panel types, which caused some graphs to break, e.g. in the before recording
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
Before:

https://github.com/user-attachments/assets/80d31604-f3f6-418a-997b-747f3a27dc02


After:

https://github.com/user-attachments/assets/11432e42-bd28-45de-87a9-ada12498ec55



<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Apply `uPlotXAxisValuesFormat` only to panel types with date/time x-axis by updating `getAxes` function and its usage across multiple files.
> 
>   - **Behavior**:
>     - Apply `uPlotXAxisValuesFormat` only to panel types with date/time x-axis in `getAxes`.
>     - Affects `PANEL_TYPES.TIME_SERIES`, `PANEL_TYPES.BAR`, `PANEL_TYPES.PIE`.
>   - **Functions**:
>     - Update `getAxes` to accept `panelType` and conditionally apply `uPlotXAxisValuesFormat`.
>   - **Files**:
>     - Modify `AnomalyAlertEvaluationView.tsx`, `BillingUsageGraph.tsx`, `getUplotChartOptions.ts`, and `getUplotHistogramChartOptions.ts` to pass `panelType` to `getAxes`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 905d469951f4c92d3b6f754889ee794bb65bd0f1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->