### PR TITLE
fix: properly get the alert severity 

### DIFF
--- a/frontend/src/pages/AlertDetails/AlertHeader/AlertHeader.tsx
+++ b/frontend/src/pages/AlertDetails/AlertHeader/AlertHeader.tsx
@@ -43,7 +43,7 @@ function AlertHeader({ alertDetails }: AlertHeaderProps): JSX.Element {
 					</div>
 				</div>
 				<div className="bottom-section">
-					<AlertSeverity severity="warning" />
+					{labels.severity && <AlertSeverity severity={labels.severity} />}
 
 					{/* // TODO(shaheer): Get actual data when we are able to get alert firing from state from API */}
 					{/* <AlertStatus


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Conditionally render `AlertSeverity` in `AlertHeader.tsx` based on `labels.severity`.
> 
>   - **Behavior**:
>     - In `AlertHeader.tsx`, `AlertSeverity` is now conditionally rendered based on the presence of `labels.severity`.
>     - This change ensures that the alert severity is only displayed when the `severity` label is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e17962e8aa83a8cd2c344aec47d80591a582d4fd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->