### PR TITLE
chore: fix visibility toggle in host filters

### DIFF
--- a/frontend/src/container/InfraMonitoringHosts/HostsList.tsx
+++ b/frontend/src/container/InfraMonitoringHosts/HostsList.tsx
@@ -1,7 +1,7 @@
 import './InfraMonitoring.styles.scss';
 
 import { VerticalAlignTopOutlined } from '@ant-design/icons';
-import { Tooltip, Typography } from 'antd';
+import { Button, Tooltip, Typography } from 'antd';
 import logEvent from 'api/common/logEvent';
 import { HostListPayload } from 'api/infraMonitoring/getHostLists';
 import HostMetricDetail from 'components/HostMetricsDetail';
@@ -11,6 +11,7 @@ import { usePageSize } from 'container/InfraMonitoringK8s/utils';
 import { useGetHostList } from 'hooks/infraMonitoring/useGetHostList';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useQueryOperations } from 'hooks/queryBuilder/useQueryBuilderOperations';
+import { Filter } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { AppState } from 'store/reducers';
@@ -140,7 +141,21 @@ function HostsList(): JSX.Element {
 					</div>
 				)}
 				<div className="hosts-list-table-container">
-					<HostsListControls handleFiltersChange={handleFiltersChange} />
+					<div className="hosts-list-table-header">
+						{!showFilters && (
+							<div className="quick-filters-toggle-container">
+								<Button
+									className="periscope-btn ghost"
+									type="text"
+									size="small"
+									onClick={handleFilterVisibilityChange}
+								>
+									<Filter size={14} />
+								</Button>
+							</div>
+						)}
+						<HostsListControls handleFiltersChange={handleFiltersChange} />
+					</div>
 					<HostsListTable
 						isLoading={isLoading}
 						isFetching={isFetching}

--- a/frontend/src/container/InfraMonitoringHosts/InfraMonitoring.styles.scss
+++ b/frontend/src/container/InfraMonitoringHosts/InfraMonitoring.styles.scss
@@ -11,6 +11,7 @@
 	}
 
 	.hosts-list-controls {
+		flex: 1;
 		padding: 8px;
 
 		display: flex;
@@ -73,6 +74,16 @@
 
 	.hosts-list-table-container {
 		flex: 1;
+
+		.hosts-list-table-header {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+
+			.quick-filters-toggle-container {
+				padding: 0 8px;
+			}
+		}
 	}
 
 	.hosts-list-table {

--- a/frontend/src/container/InfraMonitoringK8s/K8sFiltersSidePanel/K8sFiltersSidePanel.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/K8sFiltersSidePanel/K8sFiltersSidePanel.tsx
@@ -37,6 +37,25 @@ function K8sFiltersSidePanel({
 		}
 	}, [searchValue]);
 
+	// Close side panel when clicking outside of it
+	useEffect(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			if (
+				sidePanelRef.current &&
+				!sidePanelRef.current.contains(event.target as Node)
+			) {
+				onClose();
+			}
+		};
+
+		document.addEventListener('mousedown', handleClickOutside);
+
+		return () => {
+			document.removeEventListener('mousedown', handleClickOutside);
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
 	return (
 		<div className="k8s-filters-side-panel-container">
 			<div className="k8s-filters-side-panel" ref={sidePanelRef}>


### PR DESCRIPTION
### Summary

Fix the toggle filters visibility button in hosts list

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

<img width="1728" alt="Screenshot 2025-01-29 at 11 35 44 PM" src="https://github.com/user-attachments/assets/7c871e3a-3b1f-4bac-8b52-fb37c74aece7" />

<img width="1728" alt="Screenshot 2025-01-29 at 11 35 51 PM" src="https://github.com/user-attachments/assets/a525fb17-ebd8-4348-b3e3-32a7db3ce255" />


<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

Infra Monitoring

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes filter visibility toggle in `HostsList.tsx` and adds click outside handler in `K8sFiltersSidePanel.tsx`.
> 
>   - **Behavior**:
>     - Fixes visibility toggle for filters in `HostsList.tsx` by adding a button to toggle `showFilters` state.
>     - Adds click outside handler in `K8sFiltersSidePanel.tsx` to close the panel when clicking outside.
>   - **UI Components**:
>     - Adds `Button` component for filter toggle in `HostsList.tsx`.
>     - Updates styles in `InfraMonitoring.styles.scss` to support new toggle button layout.
>   - **Misc**:
>     - Imports `Filter` icon from `lucide-react` in `HostsList.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for d87b73ff11162cba9b1dab19bc4d8aaa48f52457. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->