### PR TITLE
Fix/check the flows of toggling logs timestamp and body columns

### DIFF
--- a/frontend/src/container/ExplorerOptions/ExplorerOptions.tsx
+++ b/frontend/src/container/ExplorerOptions/ExplorerOptions.tsx
@@ -25,7 +25,10 @@ import { PANEL_TYPES } from 'constants/queryBuilder';
 import ROUTES from 'constants/routes';
 import ExportPanelContainer from 'container/ExportPanel/ExportPanelContainer';
 import { useOptionsMenu } from 'container/OptionsMenu';
-import { defaultTraceSelectedColumns } from 'container/OptionsMenu/constants';
+import {
+	defaultLogsSelectedColumns,
+	defaultTraceSelectedColumns,
+} from 'container/OptionsMenu/constants';
 import { OptionsQuery } from 'container/OptionsMenu/types';
 import { useGetSearchQueryParam } from 'hooks/queryBuilder/useGetSearchQueryParam';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
@@ -407,6 +410,14 @@ function ExplorerOptions({
 
 	const handleClearSelect = (): void => {
 		removeCurrentViewFromLocalStorage();
+
+		handleOptionsChange({
+			...options,
+			selectColumns:
+				sourcepage === DataSource.TRACES
+					? defaultTraceSelectedColumns
+					: defaultLogsSelectedColumns,
+		});
 
 		history.replace(DATASOURCE_VS_ROUTES[sourcepage]);
 	};

--- a/frontend/src/container/LiveLogs/LiveLogsList/index.tsx
+++ b/frontend/src/container/LiveLogs/LiveLogsList/index.tsx
@@ -13,6 +13,7 @@ import { InfinityWrapperStyled } from 'container/LogsExplorerList/styles';
 import { convertKeysToColumnFields } from 'container/LogsExplorerList/utils';
 import { Heading } from 'container/LogsTable/styles';
 import { useOptionsMenu } from 'container/OptionsMenu';
+import { defaultLogsSelectedColumns } from 'container/OptionsMenu/constants';
 import { useActiveLog } from 'hooks/logs/useActiveLog';
 import { useCopyLogLink } from 'hooks/logs/useCopyLogLink';
 import { useEventSource } from 'providers/EventSource';
@@ -53,7 +54,10 @@ function LiveLogsList({ logs }: LiveLogsListProps): JSX.Element {
 		[logs, activeLogId],
 	);
 
-	const selectedFields = convertKeysToColumnFields(options.selectColumns);
+	const selectedFields = convertKeysToColumnFields([
+		...defaultLogsSelectedColumns,
+		...options.selectColumns,
+	]);
 
 	const getItemContent = useCallback(
 		(_: number, log: ILog): JSX.Element => {

--- a/frontend/src/container/LogDetailedView/ContextView/ContextLogRenderer.tsx
+++ b/frontend/src/container/LogDetailedView/ContextView/ContextLogRenderer.tsx
@@ -5,6 +5,7 @@ import RawLogView from 'components/Logs/RawLogView';
 import OverlayScrollbar from 'components/OverlayScrollbar/OverlayScrollbar';
 import { LOCALSTORAGE } from 'constants/localStorage';
 import ShowButton from 'container/LogsContextList/ShowButton';
+import { convertKeysToColumnFields } from 'container/LogsExplorerList/utils';
 import { useOptionsMenu } from 'container/OptionsMenu';
 import { defaultLogsSelectedColumns } from 'container/OptionsMenu/constants';
 import { FontSize } from 'container/OptionsMenu/types';
@@ -12,20 +13,11 @@ import { ORDERBY_FILTERS } from 'container/QueryBuilder/filters/OrderByFilter/co
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
-import { IField } from 'types/api/logs/fields';
 import { ILog } from 'types/api/logs/log';
 import { Query, TagFilter } from 'types/api/queryBuilder/queryBuilderData';
 import { DataSource, StringOperators } from 'types/common/queryBuilder';
 
 import { useContextLogData } from './useContextLogData';
-
-const defaultLogsSelectedFields: IField[] = defaultLogsSelectedColumns.map(
-	(item) => ({
-		name: item.key,
-		type: item.type,
-		dataType: item.dataType,
-	}),
-);
 
 function ContextLogRenderer({
 	isEdit,
@@ -119,7 +111,7 @@ function ContextLogRenderer({
 				data={logTorender}
 				linesPerRow={1}
 				fontSize={options.fontSize}
-				selectedFields={defaultLogsSelectedFields}
+				selectedFields={convertKeysToColumnFields(defaultLogsSelectedColumns)}
 			/>
 		),
 		[log.id, options.fontSize],


### PR DESCRIPTION
### Summary
- [x] fix the issue of body/timestamp not visible in live logs
- [x] fix the issue of selected columns lost when we visit any other page and then visit logs explorer
- [x] remove the selected columns when we clear a view 

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix and enhance logs explorer by ensuring default columns are visible and preserved across sessions and views.
> 
>   - **Behavior**:
>     - Fix visibility of `body` and `timestamp` in live logs by ensuring `defaultLogsSelectedColumns` are always included in `LiveLogsList` and `ContextLogRenderer`.
>     - Preserve selected columns across page visits in `LogsExplorer` by migrating options query to include `defaultLogsSelectedColumns` if missing.
>     - Clear selected columns when clearing a view in `ExplorerOptions` by resetting to `defaultLogsSelectedColumns` or `defaultTraceSelectedColumns`.
>   - **Functions**:
>     - `migrateOptionsQuery` in `LogsExplorer` ensures required columns are present in the query.
>     - `handleClearSelect` in `ExplorerOptions` resets columns to defaults based on `sourcepage`.
>   - **Misc**:
>     - Add utility functions `hasRequiredColumns` and `mergeWithRequiredColumns` in `LogsExplorer` to manage column defaults.
>     - Minor refactoring in `ContextLogRenderer` to use `defaultLogsSelectedColumns` for selected fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for ba5c27f30cb123eca2326b5c3d74c8e7a0a4d856. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->