### PR TITLE
fix(trace-detail): trace details improvements 

### DIFF
--- a/frontend/src/container/SpanDetailsDrawer/Events/Events.tsx
+++ b/frontend/src/container/SpanDetailsDrawer/Events/Events.tsx
@@ -45,7 +45,7 @@ function EventsTable(props: IEventsTableProps): JSX.Element {
 				)}
 				{events
 					.filter((eve) =>
-						eve.name.toLowerCase().includes(fieldSearchInput.toLowerCase()),
+						eve.name?.toLowerCase().includes(fieldSearchInput.toLowerCase()),
 					)
 					.map((event) => (
 						<div
@@ -76,7 +76,7 @@ function EventsTable(props: IEventsTableProps): JSX.Element {
 													<div className="timestamp-container">
 														<Typography.Text className="attribute-value">
 															{getYAxisFormattedValue(
-																`${event.timeUnixNano / 1e6 - startTime}`,
+																`${(event.timeUnixNano || 0) / 1e6 - startTime}`,
 																'ms',
 															)}
 														</Typography.Text>

--- a/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/Success.styles.scss
+++ b/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/Success.styles.scss
@@ -241,18 +241,19 @@
 				height: 54px;
 				position: relative;
 				width: 100%;
+				padding-left: 15px;
 				cursor: pointer;
 
 				.span-line {
-					position: absolute;
+					position: relative;
 					height: 12px;
 					top: 35%;
 					border-radius: 6px;
 				}
 
 				.span-line-text {
-					position: absolute;
-					top: 65%;
+					position: relative;
+					top: 40%;
 					font-variant-numeric: lining-nums tabular-nums stacked-fractions
 						slashed-zero;
 					font-feature-settings: 'case' on, 'cpsp' on, 'dlig' on, 'salt' on;

--- a/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
+++ b/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
@@ -188,14 +188,13 @@ function SpanDuration({
 					left: `${leftOffset}%`,
 					width: `${width}%`,
 					backgroundColor: color,
-					marginLeft: '15px',
 				}}
 			/>
 			<Tooltip title={`${toFixed(time, 2)} ${timeUnitName}`}>
 				<Typography.Text
 					className="span-line-text"
 					ellipsis
-					style={{ left: `${leftOffset}%`, color, marginLeft: '15px' }}
+					style={{ left: `${leftOffset}%`, color }}
 				>{`${toFixed(time, 2)} ${timeUnitName}`}</Typography.Text>
 			</Tooltip>
 		</div>

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -1454,6 +1454,7 @@ func (r *ClickHouseReader) GetWaterfallSpansForTraceWithMetadata(ctx context.Con
 	var serviceNameIntervalMap = map[string][]tracedetail.Interval{}
 	var hasMissingSpans bool
 
+	userEmail , emailErr := auth.GetEmailFromJwt(ctx)
 	cachedTraceData, err := r.GetWaterfallSpansForTraceWithMetadataCache(ctx, traceID)
 	if err == nil {
 		startTime = cachedTraceData.StartTime
@@ -1465,6 +1466,10 @@ func (r *ClickHouseReader) GetWaterfallSpansForTraceWithMetadata(ctx context.Con
 		totalSpans = cachedTraceData.TotalSpans
 		totalErrorSpans = cachedTraceData.TotalErrorSpans
 		hasMissingSpans = cachedTraceData.HasMissingSpans
+
+		if emailErr == nil {
+			telemetry.GetInstance().SendEvent(telemetry.TELEMETRY_EVENT_TRACE_DETAIL_API, map[string]interface{}{"traceSize": totalSpans}, userEmail, true, false)
+		}
 	}
 
 	if err != nil {
@@ -1478,6 +1483,10 @@ func (r *ClickHouseReader) GetWaterfallSpansForTraceWithMetadata(ctx context.Con
 			return response, nil
 		}
 		totalSpans = uint64(len(searchScanResponses))
+
+		if emailErr == nil {
+			telemetry.GetInstance().SendEvent(telemetry.TELEMETRY_EVENT_TRACE_DETAIL_API, map[string]interface{}{"traceSize": totalSpans}, userEmail, true, false)
+		}
 
 		processingBeforeCache := time.Now()
 		for _, item := range searchScanResponses {

--- a/pkg/query-service/app/traces/tracedetail/flamegraph.go
+++ b/pkg/query-service/app/traces/tracedetail/flamegraph.go
@@ -149,7 +149,7 @@ func getLatencyAndTimestampBucketedSpans(spans []*model.FlamegraphSpan, selected
 }
 
 func GetSelectedSpansForFlamegraphForRequest(selectedSpanID string, selectedSpans [][]*model.FlamegraphSpan, startTime uint64, endTime uint64) [][]*model.FlamegraphSpan {
-	var selectedSpansForRequest [][]*model.FlamegraphSpan
+	var selectedSpansForRequest = make([][]*model.FlamegraphSpan, 0)
 	var selectedIndex = 0
 
 	if selectedSpanID != "" {

--- a/pkg/query-service/app/traces/tracedetail/waterfall.go
+++ b/pkg/query-service/app/traces/tracedetail/waterfall.go
@@ -158,7 +158,7 @@ func CalculateServiceTime(serviceIntervals map[string][]Interval) map[string]uin
 
 func GetSelectedSpans(uncollapsedSpans []string, selectedSpanID string, traceRoots []*model.Span, spanIdToSpanNodeMap map[string]*model.Span, isSelectedSpanIDUnCollapsed bool) ([]*model.Span, []string, string, string) {
 
-	var preOrderTraversal = []*model.Span{}
+	var preOrderTraversal = make([]*model.Span, 0)
 	var rootServiceName, rootServiceEntryPoint string
 	updatedUncollapsedSpans := uncollapsedSpans
 

--- a/pkg/query-service/model/cacheable.go
+++ b/pkg/query-service/model/cacheable.go
@@ -11,6 +11,7 @@ type GetWaterfallSpansForTraceWithMetadataCache struct {
 	ServiceNameToTotalDurationMap map[string]uint64 `json:"serviceNameToTotalDurationMap"`
 	SpanIdToSpanNodeMap           map[string]*Span  `json:"spanIdToSpanNodeMap"`
 	TraceRoots                    []*Span           `json:"traceRoots"`
+	HasMissingSpans               bool              `json:"hasMissingSpans"`
 }
 
 func (c *GetWaterfallSpansForTraceWithMetadataCache) MarshalBinary() (data []byte, err error) {


### PR DESCRIPTION
### Summary

- handle the smaller timestamps better for `ns` precision in timeline 
- null check for the missing `name` in the events 
- telemetry events for trace details API hit for query service 
- better handling for waterfall span duration 
