### PR TITLE
fix the gap between text and button in logs quick filters

### DIFF
--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.styles.scss
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.styles.scss
@@ -133,7 +133,7 @@
 	.go-to-docs {
 		display: flex;
 		flex-direction: column;
-		gap: 64px;
+		gap: 44px;
 		&__container {
 			display: flex;
 			flex-direction: column;


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
Before:
![Screenshot 2025-02-03 at 09 35 39](https://github.com/user-attachments/assets/f0f23afb-1c78-4757-8b8a-066d99cadf32)

After:
![image](https://github.com/user-attachments/assets/e3770e86-3511-4cb9-ad9c-73fe89904c8a)



<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reduces gap between text and button in `.go-to-docs` class in `Checkbox.styles.scss`.
> 
>   - **Styles**:
>     - Adjusts `gap` from `64px` to `44px` in `.go-to-docs` class in `Checkbox.styles.scss` to reduce space between text and button.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for ae1916581407b7cea5f3bbb2f1b4d89e3382c637. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->