### PR TITLE
feat: fix incorrect suggestions while moving between explorers

### DIFF
--- a/frontend/src/container/InfraMonitoringHosts/HostsListControls.tsx
+++ b/frontend/src/container/InfraMonitoringHosts/HostsListControls.tsx
@@ -1,18 +1,19 @@
 import './InfraMonitoring.styles.scss';
 
+import { initialQueriesMap } from 'constants/queryBuilder';
 import { K8sCategory } from 'container/InfraMonitoringK8s/constants';
 import QueryBuilderSearch from 'container/QueryBuilder/filters/QueryBuilderSearch';
 import DateTimeSelectionV2 from 'container/TopNav/DateTimeSelectionV2';
-import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useCallback, useMemo } from 'react';
 import { IBuilderQuery } from 'types/api/queryBuilder/queryBuilderData';
+import { DataSource } from 'types/common/queryBuilder';
 
 function HostsListControls({
 	handleFiltersChange,
 }: {
 	handleFiltersChange: (value: IBuilderQuery['filters']) => void;
 }): JSX.Element {
-	const { currentQuery } = useQueryBuilder();
+	const currentQuery = initialQueriesMap[DataSource.METRICS];
 	const updatedCurrentQuery = useMemo(
 		() => ({
 			...currentQuery,

--- a/frontend/src/container/InfraMonitoringK8s/K8sHeader.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/K8sHeader.tsx
@@ -2,13 +2,14 @@
 import './InfraMonitoringK8s.styles.scss';
 
 import { Button, Select } from 'antd';
+import { initialQueriesMap } from 'constants/queryBuilder';
 import QueryBuilderSearch from 'container/QueryBuilder/filters/QueryBuilderSearch';
 import DateTimeSelectionV2 from 'container/TopNav/DateTimeSelectionV2';
-import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { Filter, SlidersHorizontal } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { BaseAutocompleteData } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { IBuilderQuery } from 'types/api/queryBuilder/queryBuilderData';
+import { DataSource } from 'types/common/queryBuilder';
 
 import { K8sCategory } from './constants';
 import K8sFiltersSidePanel from './K8sFiltersSidePanel/K8sFiltersSidePanel';
@@ -47,7 +48,7 @@ function K8sHeader({
 }: K8sHeaderProps): JSX.Element {
 	const [isFiltersSidePanelOpen, setIsFiltersSidePanelOpen] = useState(false);
 
-	const { currentQuery } = useQueryBuilder();
+	const currentQuery = initialQueriesMap[DataSource.METRICS];
 
 	const updatedCurrentQuery = useMemo(
 		() => ({

--- a/frontend/src/hooks/queryBuilder/useFetchKeysAndValues.ts
+++ b/frontend/src/hooks/queryBuilder/useFetchKeysAndValues.ts
@@ -243,13 +243,15 @@ export const useFetchKeysAndValues = (
 			fetchingSuggestionsStatus === 'success' &&
 			suggestionsData?.payload?.attributes
 		) {
-			setKeys(suggestionsData.payload.attributes);
-			setSourceKeys((prevState) =>
-				uniqWith(
-					[...(suggestionsData.payload.attributes ?? []), ...prevState],
-					isEqual,
-				),
-			);
+			if (!isInfraMonitoring) {
+				setKeys(suggestionsData.payload.attributes);
+				setSourceKeys((prevState) =>
+					uniqWith(
+						[...(suggestionsData.payload.attributes ?? []), ...prevState],
+						isEqual,
+					),
+				);
+			}
 		} else {
 			setKeys([]);
 		}
@@ -265,6 +267,7 @@ export const useFetchKeysAndValues = (
 		suggestionsData?.payload?.attributes,
 		fetchingSuggestionsStatus,
 		suggestionsData?.payload?.example_queries,
+		isInfraMonitoring,
 	]);
 
 	return {


### PR DESCRIPTION
### Summary

When switching from another explorer (e.g. logs) to infra monitoring, the search bar auto suggestions were coming with outdated data. Fixed it.

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

Fixes #7001 

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

Infra Monitoring

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix outdated search bar suggestions by using `initialQueriesMap` and adjusting key setting logic for infra monitoring.
> 
>   - **Behavior**:
>     - Fix outdated auto-suggestions in search bar when switching explorers by using `initialQueriesMap` instead of `useQueryBuilder` in `HostsListControls.tsx` and `K8sHeader.tsx`.
>     - Prevent setting keys and source keys for infra monitoring in `useFetchKeysAndValues`.
>   - **Files**:
>     - `HostsListControls.tsx`: Replace `useQueryBuilder` with `initialQueriesMap` for `currentQuery`.
>     - `K8sHeader.tsx`: Replace `useQueryBuilder` with `initialQueriesMap` for `currentQuery`.
>     - `useFetchKeysAndValues.ts`: Add condition to skip setting keys for infra monitoring.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for f95de4d56e1c83281f7c0787217523c62e1c44e6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->