### PR TITLE
feat: bug fix for the issue in span filtering feature. No spans returned in traces tab

### DIFF
--- a/pkg/query-service/app/traces/v3/query_builder_test.go
+++ b/pkg/query-service/app/traces/v3/query_builder_test.go
@@ -1166,10 +1166,10 @@ var testBuildTracesQueryData = []struct {
 			" AS traceID FROM signoz_traces.distributed_signoz_index_v2 INNER JOIN" +
 			" ( SELECT * FROM (SELECT traceID, durationNano, serviceName, name " +
 			"FROM signoz_traces.signoz_index_v2 WHERE parentSpanID = '' AND (timestamp >= '1680066360726210000' AND timestamp <= '1680066458000000000') " +
-			"ORDER BY durationNano DESC LIMIT 1 BY traceID  LIMIT 100)" +
+			"ORDER BY durationNano DESC LIMIT 1 BY traceID LIMIT 100)" +
 			" AS inner_subquery ) AS subQuery " +
 			"ON signoz_traces.distributed_signoz_index_v2.traceID = subQuery.traceID WHERE (timestamp >= '1680066360726210000' AND timestamp <= '1680066458000000000') " +
-			" AND stringTagMap['method'] = 'GET' GROUP BY subQuery.traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY subQuery.durationNano desc LIMIT 1 BY subQuery.traceID",
+			" AND stringTagMap['method'] = 'GET' GROUP BY subQuery.traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY subQuery.durationNano desc LIMIT 1 BY subQuery.traceID ",
 		PanelType: v3.PanelTypeTrace,
 	},
 }

--- a/pkg/query-service/app/traces/v4/query_builder_test.go
+++ b/pkg/query-service/app/traces/v4/query_builder_test.go
@@ -566,7 +566,7 @@ func Test_buildTracesQuery(t *testing.T) {
 				},
 			},
 			want: "SELECT timestamp as timestamp_datetime, spanID, traceID, name as `name` from signoz_traces.distributed_signoz_index_v3 where (timestamp >= '1680066360726210000' AND timestamp <= '1680066458000000000') " +
-				"AND (ts_bucket_start >= 1680064560 AND ts_bucket_start <= 1680066458)  AND ((name, `resource_string_service$$name`) IN ( SELECT DISTINCT name, serviceName from signoz_traces.distributed_top_level_operations ))  order by timestamp ASC",
+				"AND (ts_bucket_start >= 1680064560 AND ts_bucket_start <= 1680066458)  AND ((name, `resource_string_service$$name`) GLOBAL IN ( SELECT DISTINCT name, serviceName from signoz_traces.distributed_top_level_operations ))  order by timestamp ASC",
 		},
 		{
 			name: "test noop list view with root_spans",
@@ -650,10 +650,10 @@ func Test_buildTracesQuery(t *testing.T) {
 			want: "SELECT subQuery.serviceName, subQuery.name, count() AS span_count, subQuery.durationNano, subQuery.traceID AS traceID FROM signoz_traces.distributed_signoz_index_v3 INNER JOIN " +
 				"( SELECT * FROM (SELECT traceID, durationNano, serviceName, name FROM signoz_traces.signoz_index_v3 WHERE parentSpanID = '' AND (timestamp >= '1680066360726210000' AND timestamp <= '1680066458000000000') AND " +
 				"(ts_bucket_start >= 1680064560 AND ts_bucket_start <= 1680066458) " +
-				"ORDER BY durationNano DESC LIMIT 1 BY traceID  LIMIT 100) AS inner_subquery ) AS subQuery ON signoz_traces.distributed_signoz_index_v3.traceID = subQuery.traceID WHERE (timestamp >= '1680066360726210000' AND " +
+				"ORDER BY durationNano DESC LIMIT 1 BY traceID) AS inner_subquery ) AS subQuery ON signoz_traces.distributed_signoz_index_v3.traceID = subQuery.traceID WHERE (timestamp >= '1680066360726210000' AND " +
 				"timestamp <= '1680066458000000000') AND (ts_bucket_start >= 1680064560 AND ts_bucket_start <= 1680066458)  AND attributes_string['method'] = 'GET' AND (resource_fingerprint GLOBAL IN (SELECT fingerprint FROM signoz_traces.distributed_traces_v3_resource WHERE " +
 				"(seen_at_ts_bucket_start >= 1680064560) AND (seen_at_ts_bucket_start <= 1680066458) AND simpleJSONExtractString(labels, 'service.name') = 'myService' AND labels like '%service.name%myService%')) GROUP BY subQuery.traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY " +
-				"subQuery.durationNano desc LIMIT 1 BY subQuery.traceID settings distributed_product_mode='allow', max_memory_usage=10000000000",
+				"subQuery.durationNano desc LIMIT 1 BY subQuery.traceID  LIMIT 100 settings distributed_product_mode='allow', max_memory_usage=10000000000",
 		},
 		{
 			name: "Test order by value with having",

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -323,11 +323,11 @@ const (
 		"resources_string, " +
 		"scope_string "
 	TracesExplorerViewSQLSelectWithSubQuery = "(SELECT traceID, durationNano, " +
-		"serviceName, name FROM %s.%s WHERE parentSpanID = '' AND %s ORDER BY durationNano DESC LIMIT 1 BY traceID "
+		"serviceName, name FROM %s.%s WHERE parentSpanID = '' AND %s ORDER BY durationNano DESC LIMIT 1 BY traceID"
 	TracesExplorerViewSQLSelectBeforeSubQuery = "SELECT subQuery.serviceName, subQuery.name, count() AS " +
 		"span_count, subQuery.durationNano, subQuery.traceID AS traceID FROM %s.%s INNER JOIN ( SELECT * FROM "
 	TracesExplorerViewSQLSelectAfterSubQuery = "AS inner_subquery ) AS subQuery ON %s.%s.traceID = subQuery.traceID WHERE %s %s " +
-		"GROUP BY subQuery.traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY subQuery.durationNano desc LIMIT 1 BY subQuery.traceID"
+		"GROUP BY subQuery.traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY subQuery.durationNano desc LIMIT 1 BY subQuery.traceID "
 	TracesExplorerViewSQLSelectQuery = "SELECT subQuery.serviceName, subQuery.name, count() AS " +
 		"span_count, subQuery.durationNano, traceID FROM %s.%s GLOBAL INNER JOIN subQuery ON %s.traceID = subQuery.traceID GROUP " +
 		"BY traceID, subQuery.durationNano, subQuery.name, subQuery.serviceName ORDER BY subQuery.durationNano desc;"


### PR DESCRIPTION
### Summary

Fixed a bug where no traces are returned in the traces tab. 
Refer : https://signoz-team.slack.com/archives/C089D1B5516/p1738552174171329
<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes span filtering bug in traces tab by adjusting SQL query construction and handling of `GLOBAL IN` clauses.
> 
>   - **Behavior**:
>     - Fixes span filtering bug in traces tab by adjusting SQL query construction in `query_builder.go`.
>     - Ensures correct handling of `GLOBAL IN` clause for span search scope attributes.
>     - Adjusts limit and offset handling in `buildTracesQuery()`.
>   - **SQL Queries**:
>     - Modifies `TracesExplorerViewSQLSelectWithSubQuery` and `TracesExplorerViewSQLSelectAfterSubQuery` in `constants.go` to correct query limits.
>     - Updates `buildSpanScopeQuery()` to use `GLOBAL IN` for entry point spans.
>   - **Tests**:
>     - Updates test cases in `query_builder_test.go` and `query_builder_test.go` to reflect query changes and ensure correct behavior.
>     - Adds tests for handling of `GLOBAL IN` and query limits.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 0a240e6f1d022fb6e151a4cb1d96482139a08b50. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->