### PR TITLE
fix(add_pats): fix type of column

### DIFF
--- a/pkg/sqlmigration/009_add_pats.go
+++ b/pkg/sqlmigration/009_add_pats.go
@@ -56,11 +56,10 @@ func (migration *addPats) Up(ctx context.Context, db *bun.DB) error {
 		return err
 	}
 
-	// table:rules op:add column created_at
 	if _, err := db.
 		NewAddColumn().
 		Table("personal_access_tokens").
-		ColumnExpr("role test not null default 'ADMIN'").
+		ColumnExpr("role TEXT NOT NULL DEFAULT 'ADMIN'").
 		Apply(WrapIfNotExists(ctx, db, "personal_access_tokens", "role")).
 		Exec(ctx); err != nil && err != ErrNoExecute {
 		return err


### PR DESCRIPTION
### Summary

Fix type of column in ALTER query. We missed this because CREATE TABLE creates the column and then the ALTER query is a no-op. Raising this PR for our future effort of integrating other sql databases.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes column type in `009_add_pats.go` for `role` in `personal_access_tokens` from `test` to `TEXT`.
> 
>   - **SQL Migration**:
>     - Fixes column type in `009_add_pats.go` for `role` in `personal_access_tokens` from `test` to `TEXT`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 67723c99d42887c6258a540b0c65865de23a9074. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->