### PR TITLE
feat: change grid to flex - flower metrics section

### DIFF
--- a/frontend/src/components/CeleryTask/CeleryTaskGraph/CeleryTaskGraph.style.scss
+++ b/frontend/src/components/CeleryTask/CeleryTaskGraph/CeleryTaskGraph.style.scss
@@ -116,9 +116,8 @@
 		gap: 10px;
 
 		.metric-page-grid {
-			display: grid;
-			grid-template-columns: 30% 19%;
-			align-items: flex-start;
+			display: flex;
+			flex-direction: row;
 			gap: 10px;
 			width: 100%;
 


### PR DESCRIPTION
Before:
![Screenshot 2025-02-05 at 10 14 59 AM](https://github.com/user-attachments/assets/abed80ab-6e17-44f0-8bab-68f900c3e23b)


After:
<img width="1919" alt="Screenshot 2025-02-05 at 11 37 35" src="https://github.com/user-attachments/assets/d174a194-5536-4de7-b39d-01e6e7dcf155" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `metric-page-grid` layout from grid to flex in `CeleryTaskGraph.style.scss`.
> 
>   - **Layout Change**:
>     - Change `metric-page-grid` from `grid` to `flex` layout in `CeleryTaskGraph.style.scss`.
>     - Set `flex-direction: row` for `metric-page-grid` to align items horizontally.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 66a120fd1f9b19cd63f8c89acfc25bb51d8978fd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->