### PR TITLE
revert(licenses): update the license events and the state names

### DIFF
--- a/ee/query-service/model/license.go
+++ b/ee/query-service/model/license.go
@@ -140,7 +140,7 @@ func NewLicenseV3(data map[string]interface{}) (*LicenseV3, error) {
 		return nil, err
 	}
 	// if license status is inactive then default it to basic
-	if status == LicenseStatusInvalid {
+	if status == LicenseStatusInactive {
 		planName = PlanNameBasic
 	}
 

--- a/ee/query-service/model/plans.go
+++ b/ee/query-service/model/plans.go
@@ -21,7 +21,7 @@ var (
 )
 
 var (
-	LicenseStatusInvalid = "INVALID"
+	LicenseStatusInactive = "INACTIVE"
 )
 
 const DisableUpsell = "DISABLE_UPSELL"

--- a/frontend/src/AppRoutes/Private.tsx
+++ b/frontend/src/AppRoutes/Private.tsx
@@ -156,7 +156,7 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 			const currentRoute = mapRoutes.get('current');
 			const shouldSuspendWorkspace =
 				activeLicenseV3.status === LicenseStatus.SUSPENDED &&
-				activeLicenseV3.state === LicenseState.DEFAULTED;
+				activeLicenseV3.state === LicenseState.PAYMENT_FAILED;
 
 			if (shouldSuspendWorkspace && currentRoute) {
 				navigateToWorkSpaceSuspended(currentRoute);

--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -250,7 +250,7 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 		if (
 			!isFetchingActiveLicenseV3 &&
 			!isNull(activeLicenseV3) &&
-			activeLicenseV3?.event_queue?.event === LicenseEvent.DEFAULT
+			activeLicenseV3?.event_queue?.event === LicenseEvent.FAILED_PAYMENT
 		) {
 			setShowPaymentFailedWarning(true);
 		}

--- a/frontend/src/pages/WorkspaceSuspended/WorkspaceSuspended.tsx
+++ b/frontend/src/pages/WorkspaceSuspended/WorkspaceSuspended.tsx
@@ -61,7 +61,7 @@ function WorkspaceSuspended(): JSX.Element {
 		if (!isFetchingActiveLicenseV3 && activeLicenseV3) {
 			const shouldSuspendWorkspace =
 				activeLicenseV3.status === LicenseStatus.SUSPENDED &&
-				activeLicenseV3.state === LicenseState.DEFAULTED;
+				activeLicenseV3.state === LicenseState.PAYMENT_FAILED;
 
 			if (!shouldSuspendWorkspace) {
 				history.push(ROUTES.APPLICATION);

--- a/frontend/src/types/api/licensesV3/getActive.ts
+++ b/frontend/src/types/api/licensesV3/getActive.ts
@@ -1,6 +1,6 @@
 export enum LicenseEvent {
 	NO_EVENT = '',
-	DEFAULT = 'DEFAULT',
+	FAILED_PAYMENT = 'FAILED_PAYMENT',
 }
 
 export enum LicenseStatus {
@@ -9,7 +9,7 @@ export enum LicenseStatus {
 }
 
 export enum LicenseState {
-	DEFAULTED = 'DEFAULTED',
+	PAYMENT_FAILED = 'PAYMENT_FAILED',
 	ACTIVE = 'ACTIVE',
 }
 


### PR DESCRIPTION
Reverts SigNoz/signoz#7021
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts changes to license status and state names in both backend and frontend code, restoring previous naming and logic.
> 
>   - **Backend**:
>     - Revert `LicenseStatusInvalid` to `LicenseStatusInactive` in `plans.go` and `license.go`.
>   - **Frontend**:
>     - Revert `LicenseState.DEFAULTED` to `LicenseState.PAYMENT_FAILED` in `Private.tsx` and `WorkspaceSuspended.tsx`.
>     - Revert `LicenseEvent.DEFAULT` to `LicenseEvent.FAILED_PAYMENT` in `AppLayout/index.tsx`.
>   - **Types**:
>     - Revert `LicenseState` and `LicenseEvent` enums in `getActive.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 42986195de5596b203ce7fafe2b637c932c8bd1d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->