### PR TITLE
fix: handle all null autocomplete aggregateValues

### DIFF
--- a/frontend/src/pages/TracesExplorer/Filter/filterUtils.ts
+++ b/frontend/src/pages/TracesExplorer/Filter/filterUtils.ts
@@ -305,6 +305,19 @@ type IuseGetAggregateValue = {
 	isFetching: boolean;
 };
 
+const hasNonNullValues = (obj: any): boolean => {
+	if (Array.isArray(obj) && obj.length > 0) {
+		return true;
+	}
+	if (obj && typeof obj === 'object') {
+		console.log(obj);
+		return Object.values(obj).some((value) =>
+			value === null ? false : hasNonNullValues(value),
+		);
+	}
+	return obj !== null;
+};
+
 export function useGetAggregateValues(
 	props: AggregateValuesProps,
 ): IuseGetAggregateValue {
@@ -327,7 +340,7 @@ export function useGetAggregateValues(
 			});
 
 			if (payload) {
-				const values = Object.values(payload).find((el) => !!el) || [];
+				const values = Object.values(payload).find(hasNonNullValues) || [];
 				setResults(values);
 			}
 		} catch (e) {

--- a/frontend/src/pages/TracesExplorer/Filter/filterUtils.ts
+++ b/frontend/src/pages/TracesExplorer/Filter/filterUtils.ts
@@ -310,7 +310,6 @@ const hasNonNullValues = (obj: any): boolean => {
 		return true;
 	}
 	if (obj && typeof obj === 'object') {
-		console.log(obj);
 		return Object.values(obj).some((value) =>
 			value === null ? false : hasNonNullValues(value),
 		);


### PR DESCRIPTION
### Summary
The Traces Explorer page  breaks when the autocomplete/attribute_values response contains only null values. This happens because the relatedValues key is an object where keys can be of any type, and the transformation logic fails when all values are null.

Example problematic response:

```json
{
  "stringAttributeValues": null,
  "numberAttributeValues": null,
  "boolAttributeValues": null,
  "relatedValues": {
    "stringAttributeValues": null,
    "numberAttributeValues": null,
    "boolAttributeValues": null,
    "relatedValues": null
  }
}
```

this PR handles nested such cases

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

https://signoz-team.slack.com/archives/C089D1B5516/p1738858580435309

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Traces Explorer crash by handling null autocomplete responses using `hasNonNullValues` in `filterUtils.ts`.
> 
>   - **Behavior**:
>     - Fixes issue in `useGetAggregateValues` in `filterUtils.ts` where Traces Explorer breaks if autocomplete response contains only null values.
>     - Introduces `hasNonNullValues` function to check for non-null values in nested objects.
>   - **Functions**:
>     - Updates `useGetAggregateValues` to use `hasNonNullValues` for determining valid payload values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for fd765f864622c7730450e1b079c73e2687eaef90. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->