### PR TITLE
Multi-Tenancy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -231,4 +231,5 @@ require (
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/SigNoz/prometheus v1.12.0
+//replace github.com/prometheus/prometheus => github.com/SigNoz/prometheus v1.12.0
+replace github.com/prometheus/prometheus => ../prometheus

--- a/pkg/query-service/app/auth.go
+++ b/pkg/query-service/app/auth.go
@@ -46,6 +46,7 @@ func (am *AuthMiddleware) ViewAccess(f func(http.ResponseWriter, *http.Request))
 			return
 		}
 		ctx := context.WithValue(r.Context(), constants.ContextUserKey, user)
+		ctx = context.WithValue(ctx, constants.ContextTenantKey, user.Organization)
 		r = r.WithContext(ctx)
 		f(w, r)
 	}
@@ -69,6 +70,7 @@ func (am *AuthMiddleware) EditAccess(f func(http.ResponseWriter, *http.Request))
 			return
 		}
 		ctx := context.WithValue(r.Context(), constants.ContextUserKey, user)
+		ctx = context.WithValue(ctx, constants.ContextTenantKey, user.Organization)
 		r = r.WithContext(ctx)
 		f(w, r)
 	}
@@ -93,6 +95,7 @@ func (am *AuthMiddleware) SelfAccess(f func(http.ResponseWriter, *http.Request))
 			return
 		}
 		ctx := context.WithValue(r.Context(), constants.ContextUserKey, user)
+		ctx = context.WithValue(ctx, constants.ContextTenantKey, user.Organization)
 		r = r.WithContext(ctx)
 		f(w, r)
 	}
@@ -116,6 +119,7 @@ func (am *AuthMiddleware) AdminAccess(f func(http.ResponseWriter, *http.Request)
 			return
 		}
 		ctx := context.WithValue(r.Context(), constants.ContextUserKey, user)
+		ctx = context.WithValue(ctx, constants.ContextTenantKey, user.Organization)
 		r = r.WithContext(ctx)
 		f(w, r)
 	}

--- a/pkg/query-service/app/clickhouseReader/filter_suggestions.go
+++ b/pkg/query-service/app/clickhouseReader/filter_suggestions.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"go.signoz.io/signoz/pkg/query-service/constants"
 	"slices"
 	"strings"
 
@@ -158,6 +159,8 @@ func (r *ClickHouseReader) getValuesForLogAttributes(
 		is being used to ensure the `limit` clause minimizes the amount of data scanned.
 	*/
 
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+
 	if len(attributes) > 10 {
 		zap.L().Error(
 			"log attribute values requested for too many attributes. This can lead to slow and costly queries",
@@ -176,7 +179,7 @@ func (r *ClickHouseReader) getValuesForLogAttributes(
 				string_value != '' or number_value is not null
 			)
 			limit %d
-		)`, r.logsDB, r.logsTagAttributeTableV2, idx+1, limit))
+		)`, r.logsDB, attributeTagView(tenant), idx+1, limit))
 
 		tagKeyQueryArgs = append(tagKeyQueryArgs, attrib.Key)
 	}

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	chprom "github.com/prometheus/prometheus/storage/clickhouse"
 	"math"
 	"math/rand"
 	"os"
@@ -112,6 +113,7 @@ var (
 // SpanWriter for reading spans from ClickHouse
 type ClickHouseReader struct {
 	db                      clickhouse.Conn
+	tenantDb                clickhouse.Conn
 	localDB                 *sqlx.DB
 	TraceDB                 string
 	operationsTable         string
@@ -167,6 +169,7 @@ type ClickHouseReader struct {
 func NewReader(
 	localDB *sqlx.DB,
 	db driver.Conn,
+	tenantDb driver.Conn,
 	configFile string,
 	featureFlag interfaces.FeatureLookup,
 	cluster string,
@@ -176,11 +179,12 @@ func NewReader(
 	cache cache.Cache,
 ) *ClickHouseReader {
 	options := NewOptions(primaryNamespace, archiveNamespace)
-	return NewReaderFromClickhouseConnection(db, options, localDB, configFile, featureFlag, cluster, useLogsNewSchema, useTraceNewSchema, fluxIntervalForTraceDetail, cache)
+	return NewReaderFromClickhouseConnection(db, tenantDb, options, localDB, configFile, featureFlag, cluster, useLogsNewSchema, useTraceNewSchema, fluxIntervalForTraceDetail, cache)
 }
 
 func NewReaderFromClickhouseConnection(
 	db driver.Conn,
+	tenantDb driver.Conn,
 	options *Options,
 	localDB *sqlx.DB,
 	configFile string,
@@ -444,12 +448,13 @@ func (r *ClickHouseReader) GetQueryRangeResult(ctx context.Context, query *model
 }
 
 func (r *ClickHouseReader) GetServicesList(ctx context.Context) (*[]string, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	services := []string{}
-	query := fmt.Sprintf(`SELECT DISTINCT serviceName FROM %s.%s WHERE toDate(timestamp) > now() - INTERVAL 1 DAY`, r.TraceDB, r.traceTableName)
+	query := fmt.Sprintf(`SELECT DISTINCT serviceName FROM %s.%s WHERE toDate(timestamp) > now() - INTERVAL 1 DAY`, r.TraceDB, traceIndexView(tenant))
 
 	if r.useTraceNewSchema {
-		query = fmt.Sprintf(`SELECT DISTINCT serviceName FROM %s.%s WHERE ts_bucket_start > (toUnixTimestamp(now() - INTERVAL 1 DAY) - 1800) AND toDate(timestamp) > now() - INTERVAL 1 DAY`, r.TraceDB, r.traceTableName)
+		query = fmt.Sprintf(`SELECT DISTINCT serviceName FROM %s.%s WHERE ts_bucket_start > (toUnixTimestamp(now() - INTERVAL 1 DAY) - 1800) AND toDate(timestamp) > now() - INTERVAL 1 DAY`, r.TraceDB, traceIndexView(tenant))
 	}
 
 	rows, err := r.db.Query(ctx, query)
@@ -473,6 +478,7 @@ func (r *ClickHouseReader) GetServicesList(ctx context.Context) (*[]string, erro
 }
 
 func (r *ClickHouseReader) GetTopLevelOperations(ctx context.Context, skipConfig *model.SkipConfig, start, end time.Time, services []string) (*map[string][]string, *model.ApiError) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	start = start.In(time.UTC)
 
@@ -480,7 +486,7 @@ func (r *ClickHouseReader) GetTopLevelOperations(ctx context.Context, skipConfig
 	operations := map[string][]string{}
 	// We can't use the `end` because the `top_level_operations` table has the most recent instances of the operations
 	// We can only use the `start` time to filter the operations
-	query := fmt.Sprintf(`SELECT name, serviceName, max(time) as ts FROM %s.%s WHERE time >= @start`, r.TraceDB, r.topLevelOperationsTable)
+	query := fmt.Sprintf(`SELECT name, serviceName, max(time) as ts FROM %s.%s WHERE time >= @start`, r.TraceDB, fmt.Sprintf("%s (tenant='%s')", constants.TENANT_TRACES_TL_OPS_VIEW, tenant))
 	if len(services) > 0 {
 		query += ` AND serviceName IN @services`
 	}
@@ -571,6 +577,7 @@ func (r *ClickHouseReader) buildResourceSubQuery(tags []model.TagQueryParam, svc
 }
 
 func (r *ClickHouseReader) GetServicesV2(ctx context.Context, queryParams *model.GetServicesParams, skipConfig *model.SkipConfig) (*[]model.ServiceItem, *model.ApiError) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	if r.indexTable == "" {
 		return nil, &model.ApiError{Typ: model.ErrorExec, Err: ErrNoIndexTable}
@@ -618,14 +625,14 @@ func (r *ClickHouseReader) GetServicesV2(ctx context.Context, queryParams *model
 					count(*) as numCalls
 				FROM %s.%s
 				WHERE serviceName = @serviceName AND name In @names AND timestamp>= @start AND timestamp<= @end`,
-				r.TraceDB, r.traceTableName,
+				r.TraceDB, traceIndexView(tenant),
 			)
 			errorQuery := fmt.Sprintf(
 				`SELECT
 					count(*) as numErrors
 				FROM %s.%s
 				WHERE serviceName = @serviceName AND name In @names AND timestamp>= @start AND timestamp<= @end AND statusCode=2`,
-				r.TraceDB, r.traceTableName,
+				r.TraceDB, traceIndexView(tenant),
 			)
 
 			args := []interface{}{}
@@ -646,6 +653,7 @@ func (r *ClickHouseReader) GetServicesV2(ctx context.Context, queryParams *model
 						resource_fingerprint GLOBAL IN ` +
 				resourceSubQuery +
 				`) AND ts_bucket_start >= @start_bucket AND ts_bucket_start <= @end_bucket`
+			query += constants.UseAliasesInViewSettings
 
 			args = append(args,
 				clickhouse.Named("start_bucket", strconv.FormatInt(queryParams.Start.Unix()-1800, 10)),
@@ -672,6 +680,7 @@ func (r *ClickHouseReader) GetServicesV2(ctx context.Context, queryParams *model
 						resource_fingerprint GLOBAL IN ` +
 				resourceSubQuery +
 				`) AND ts_bucket_start >= @start_bucket AND ts_bucket_start <= @end_bucket`
+			errorQuery += constants.UseAliasesInViewSettings
 
 			err = r.db.QueryRow(ctx, errorQuery, args...).Scan(&numErrors)
 			if err != nil {
@@ -994,6 +1003,7 @@ func addExistsOperator(item model.TagQuery, tagMapType string, not bool) (string
 }
 
 func (r *ClickHouseReader) GetTopOperationsV2(ctx context.Context, queryParams *model.GetTopOperationsParams) (*[]model.TopOperationsItem, *model.ApiError) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	namedArgs := []interface{}{
 		clickhouse.Named("start", strconv.FormatInt(queryParams.Start.UnixNano(), 10)),
@@ -1015,7 +1025,7 @@ func (r *ClickHouseReader) GetTopOperationsV2(ctx context.Context, queryParams *
 			name
 		FROM %s.%s
 		WHERE serviceName = @serviceName AND timestamp>= @start AND timestamp<= @end`,
-		r.TraceDB, r.traceTableName,
+		r.TraceDB, traceIndexView(tenant),
 	)
 
 	resourceSubQuery, err := r.buildResourceSubQuery(queryParams.Tags, queryParams.ServiceName, *queryParams.Start, *queryParams.End)
@@ -1034,6 +1044,7 @@ func (r *ClickHouseReader) GetTopOperationsV2(ctx context.Context, queryParams *
 		query += " LIMIT @limit"
 		namedArgs = append(namedArgs, clickhouse.Named("limit", queryParams.Limit))
 	}
+	query += constants.UseAliasesInViewSettings
 	err = r.db.Select(ctx, &topOperationsItems, query, namedArgs...)
 
 	if err != nil {
@@ -1140,7 +1151,9 @@ func (r *ClickHouseReader) GetUsage(ctx context.Context, queryParams *model.GetU
 
 func (r *ClickHouseReader) SearchTracesV2(ctx context.Context, params *model.SearchTracesParams,
 	smartTraceAlgorithm func(payload []model.SearchSpanResponseItem, targetSpanId string,
-		levelUp int, levelDown int, spanLimit int) ([]model.SearchSpansResult, error)) (*[]model.SearchSpansResult, error) {
+	levelUp int, levelDown int, spanLimit int) ([]model.SearchSpansResult, error)) (*[]model.SearchSpansResult, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+
 	searchSpansResult := []model.SearchSpansResult{
 		{
 			Columns:   []string{"__time", "SpanId", "TraceId", "ServiceName", "Name", "Kind", "DurationNano", "TagsKeys", "TagsValues", "References", "Events", "HasError", "StatusMessage", "StatusCodeString", "SpanKind"},
@@ -1185,7 +1198,8 @@ func (r *ClickHouseReader) SearchTracesV2(ctx context.Context, params *model.Sea
 	var startTime, endTime, durationNano uint64
 	var searchScanResponses []model.SpanItemV2
 
-	query := fmt.Sprintf("SELECT timestamp, duration_nano, span_id, trace_id, has_error, kind, resource_string_service$$name, name, references, attributes_string, attributes_number, attributes_bool, resources_string, events, status_message, status_code_string, kind_string FROM %s.%s WHERE trace_id=$1 and ts_bucket_start>=$2 and ts_bucket_start<=$3", r.TraceDB, r.traceTableName)
+	query := fmt.Sprintf("SELECT timestamp, duration_nano, span_id, trace_id, has_error, kind, resource_string_service$$name, name, references, attributes_string, attributes_number, attributes_bool, resources_string, events, status_message, status_code_string, kind_string FROM %s.%s WHERE trace_id=$1 and ts_bucket_start>=$2 and ts_bucket_start<=$3", r.TraceDB, traceIndexView(tenant))
+	query += constants.UseAliasesInViewSettings
 
 	start := time.Now()
 
@@ -1288,7 +1302,7 @@ func (r *ClickHouseReader) SearchTracesV2(ctx context.Context, params *model.Sea
 
 func (r *ClickHouseReader) SearchTraces(ctx context.Context, params *model.SearchTracesParams,
 	smartTraceAlgorithm func(payload []model.SearchSpanResponseItem, targetSpanId string,
-		levelUp int, levelDown int, spanLimit int) ([]model.SearchSpansResult, error)) (*[]model.SearchSpansResult, error) {
+	levelUp int, levelDown int, spanLimit int) ([]model.SearchSpansResult, error)) (*[]model.SearchSpansResult, error) {
 
 	if r.useTraceNewSchema {
 		return r.SearchTracesV2(ctx, params, smartTraceAlgorithm)
@@ -1454,7 +1468,7 @@ func (r *ClickHouseReader) GetWaterfallSpansForTraceWithMetadata(ctx context.Con
 	var serviceNameIntervalMap = map[string][]tracedetail.Interval{}
 	var hasMissingSpans bool
 
-	userEmail , emailErr := auth.GetEmailFromJwt(ctx)
+	userEmail, emailErr := auth.GetEmailFromJwt(ctx)
 	cachedTraceData, err := r.GetWaterfallSpansForTraceWithMetadataCache(ctx, traceID)
 	if err == nil {
 		startTime = cachedTraceData.StartTime
@@ -1530,8 +1544,8 @@ func (r *ClickHouseReader) GetWaterfallSpansForTraceWithMetadata(ctx context.Con
 			if startTime == 0 || startTimeUnixNano < startTime {
 				startTime = startTimeUnixNano
 			}
-			if endTime == 0 ||  (startTimeUnixNano + jsonItem.DurationNano )  > endTime {
-				endTime =  (startTimeUnixNano + jsonItem.DurationNano )
+			if endTime == 0 || (startTimeUnixNano+jsonItem.DurationNano) > endTime {
+				endTime = (startTimeUnixNano + jsonItem.DurationNano)
 			}
 			if durationNano == 0 || jsonItem.DurationNano > durationNano {
 				durationNano = jsonItem.DurationNano
@@ -1708,12 +1722,12 @@ func (r *ClickHouseReader) GetFlamegraphSpansForTrace(ctx context.Context, trace
 			}
 
 			// metadata calculation
-			startTimeUnixNano := uint64(item.TimeUnixNano.UnixNano())	
+			startTimeUnixNano := uint64(item.TimeUnixNano.UnixNano())
 			if startTime == 0 || startTimeUnixNano < startTime {
 				startTime = startTimeUnixNano
 			}
-			if endTime == 0 || ( startTimeUnixNano + jsonItem.DurationNano )  > endTime {
-				endTime =  (startTimeUnixNano + jsonItem.DurationNano )
+			if endTime == 0 || (startTimeUnixNano+jsonItem.DurationNano) > endTime {
+				endTime = (startTimeUnixNano + jsonItem.DurationNano)
 			}
 			if durationNano == 0 || jsonItem.DurationNano > durationNano {
 				durationNano = jsonItem.DurationNano
@@ -1777,7 +1791,7 @@ func (r *ClickHouseReader) GetFlamegraphSpansForTrace(ctx context.Context, trace
 
 	trace.Spans = selectedSpansForRequest
 	trace.StartTimestampMillis = startTime / 1000000
-	trace.EndTimestampMillis = endTime / 1000000	
+	trace.EndTimestampMillis = endTime / 1000000
 	return trace, nil
 }
 
@@ -2530,7 +2544,16 @@ func (r *ClickHouseReader) GetTTL(ctx context.Context, ttlParams *model.GetTTLPa
 
 }
 
+func traceIndexView(tenant string) string {
+	return fmt.Sprintf("%s (tenant='%s')", constants.TENANT_TRACES_INDEX_VIEW, tenant)
+}
+
+func errorsView(tenant string) string {
+	return fmt.Sprintf("%s (tenant='%s', window_start='%d', window_end='%d')", constants.TENANT_TRACES_ERROR_INDEX_VIEW, tenant)
+}
+
 func (r *ClickHouseReader) ListErrors(ctx context.Context, queryParams *model.ListErrorsParams) (*[]model.Error, *model.ApiError) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	var getErrorResponses []model.Error
 
@@ -2545,7 +2568,7 @@ func (r *ClickHouseReader) ListErrors(ctx context.Context, queryParams *model.Li
 	} else {
 		query = query + ", any(exceptionType) as exceptionType"
 	}
-	query += fmt.Sprintf(" FROM %s.%s WHERE timestamp >= @timestampL AND timestamp <= @timestampU", r.TraceDB, r.errorTable)
+	query += fmt.Sprintf(" FROM %s.%s WHERE timestamp >= @timestampL AND timestamp <= @timestampU", r.TraceDB, errorsView(tenant))
 	args := []interface{}{clickhouse.Named("timestampL", strconv.FormatInt(queryParams.Start.UnixNano(), 10)), clickhouse.Named("timestampU", strconv.FormatInt(queryParams.End.UnixNano(), 10))}
 
 	if len(queryParams.ServiceName) != 0 {
@@ -2603,10 +2626,11 @@ func (r *ClickHouseReader) ListErrors(ctx context.Context, queryParams *model.Li
 }
 
 func (r *ClickHouseReader) CountErrors(ctx context.Context, queryParams *model.CountErrorsParams) (uint64, *model.ApiError) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	var errorCount uint64
 
-	query := fmt.Sprintf("SELECT count(distinct(groupID)) FROM %s.%s WHERE timestamp >= @timestampL AND timestamp <= @timestampU", r.TraceDB, r.errorTable)
+	query := fmt.Sprintf("SELECT count(distinct(groupID)) FROM %s.%s WHERE timestamp >= @timestampL AND timestamp <= @timestampU", r.TraceDB, errorsView(tenant))
 	args := []interface{}{clickhouse.Named("timestampL", strconv.FormatInt(queryParams.Start.UnixNano(), 10)), clickhouse.Named("timestampU", strconv.FormatInt(queryParams.End.UnixNano(), 10))}
 	if len(queryParams.ServiceName) != 0 {
 		query = query + " AND serviceName ilike @serviceName"
@@ -2640,6 +2664,7 @@ func (r *ClickHouseReader) CountErrors(ctx context.Context, queryParams *model.C
 }
 
 func (r *ClickHouseReader) GetErrorFromErrorID(ctx context.Context, queryParams *model.GetErrorParams) (*model.ErrorWithSpan, *model.ApiError) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	if queryParams.ErrorID == "" {
 		zap.L().Error("errorId missing from params")
@@ -2647,7 +2672,7 @@ func (r *ClickHouseReader) GetErrorFromErrorID(ctx context.Context, queryParams 
 	}
 	var getErrorWithSpanReponse []model.ErrorWithSpan
 
-	query := fmt.Sprintf("SELECT errorID, exceptionType, exceptionStacktrace, exceptionEscaped, exceptionMessage, timestamp, spanID, traceID, serviceName, groupID FROM %s.%s WHERE timestamp = @timestamp AND groupID = @groupID AND errorID = @errorID LIMIT 1", r.TraceDB, r.errorTable)
+	query := fmt.Sprintf("SELECT errorID, exceptionType, exceptionStacktrace, exceptionEscaped, exceptionMessage, timestamp, spanID, traceID, serviceName, groupID FROM %s.%s WHERE timestamp = @timestamp AND groupID = @groupID AND errorID = @errorID LIMIT 1", r.TraceDB, errorsView(tenant))
 	args := []interface{}{clickhouse.Named("errorID", queryParams.ErrorID), clickhouse.Named("groupID", queryParams.GroupID), clickhouse.Named("timestamp", strconv.FormatInt(queryParams.Timestamp.UnixNano(), 10))}
 
 	err := r.db.Select(ctx, &getErrorWithSpanReponse, query, args...)
@@ -2667,10 +2692,11 @@ func (r *ClickHouseReader) GetErrorFromErrorID(ctx context.Context, queryParams 
 }
 
 func (r *ClickHouseReader) GetErrorFromGroupID(ctx context.Context, queryParams *model.GetErrorParams) (*model.ErrorWithSpan, *model.ApiError) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	var getErrorWithSpanReponse []model.ErrorWithSpan
 
-	query := fmt.Sprintf("SELECT errorID, exceptionType, exceptionStacktrace, exceptionEscaped, exceptionMessage, timestamp, spanID, traceID, serviceName, groupID FROM %s.%s WHERE timestamp = @timestamp AND groupID = @groupID LIMIT 1", r.TraceDB, r.errorTable)
+	query := fmt.Sprintf("SELECT errorID, exceptionType, exceptionStacktrace, exceptionEscaped, exceptionMessage, timestamp, spanID, traceID, serviceName, groupID FROM %s.%s WHERE timestamp = @timestamp AND groupID = @groupID LIMIT 1", r.TraceDB, errorsView(tenant))
 	args := []interface{}{clickhouse.Named("groupID", queryParams.GroupID), clickhouse.Named("timestamp", strconv.FormatInt(queryParams.Timestamp.UnixNano(), 10))}
 
 	err := r.db.Select(ctx, &getErrorWithSpanReponse, query, args...)
@@ -2715,10 +2741,11 @@ func (r *ClickHouseReader) GetNextPrevErrorIDs(ctx context.Context, queryParams 
 }
 
 func (r *ClickHouseReader) getNextErrorID(ctx context.Context, queryParams *model.GetErrorParams) (string, time.Time, *model.ApiError) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	var getNextErrorIDReponse []model.NextPrevErrorIDsDBResponse
 
-	query := fmt.Sprintf("SELECT errorID as nextErrorID, timestamp as nextTimestamp FROM %s.%s WHERE groupID = @groupID AND timestamp >= @timestamp AND errorID != @errorID ORDER BY timestamp ASC LIMIT 2", r.TraceDB, r.errorTable)
+	query := fmt.Sprintf("SELECT errorID as nextErrorID, timestamp as nextTimestamp FROM %s.%s WHERE groupID = @groupID AND timestamp >= @timestamp AND errorID != @errorID ORDER BY timestamp ASC LIMIT 2", r.TraceDB, errorsView(tenant))
 	args := []interface{}{clickhouse.Named("errorID", queryParams.ErrorID), clickhouse.Named("groupID", queryParams.GroupID), clickhouse.Named("timestamp", strconv.FormatInt(queryParams.Timestamp.UnixNano(), 10))}
 
 	err := r.db.Select(ctx, &getNextErrorIDReponse, query, args...)
@@ -2739,7 +2766,7 @@ func (r *ClickHouseReader) getNextErrorID(ctx context.Context, queryParams *mode
 		if getNextErrorIDReponse[0].Timestamp.UnixNano() == getNextErrorIDReponse[1].Timestamp.UnixNano() {
 			var getNextErrorIDReponse []model.NextPrevErrorIDsDBResponse
 
-			query := fmt.Sprintf("SELECT errorID as nextErrorID, timestamp as nextTimestamp FROM %s.%s WHERE groupID = @groupID AND timestamp = @timestamp AND errorID > @errorID ORDER BY errorID ASC LIMIT 1", r.TraceDB, r.errorTable)
+			query := fmt.Sprintf("SELECT errorID as nextErrorID, timestamp as nextTimestamp FROM %s.%s WHERE groupID = @groupID AND timestamp = @timestamp AND errorID > @errorID ORDER BY errorID ASC LIMIT 1", r.TraceDB, errorsView(tenant))
 			args := []interface{}{clickhouse.Named("errorID", queryParams.ErrorID), clickhouse.Named("groupID", queryParams.GroupID), clickhouse.Named("timestamp", strconv.FormatInt(queryParams.Timestamp.UnixNano(), 10))}
 
 			err := r.db.Select(ctx, &getNextErrorIDReponse, query, args...)
@@ -2753,7 +2780,7 @@ func (r *ClickHouseReader) getNextErrorID(ctx context.Context, queryParams *mode
 			if len(getNextErrorIDReponse) == 0 {
 				var getNextErrorIDReponse []model.NextPrevErrorIDsDBResponse
 
-				query := fmt.Sprintf("SELECT errorID as nextErrorID, timestamp as nextTimestamp FROM %s.%s WHERE groupID = @groupID AND timestamp > @timestamp ORDER BY timestamp ASC LIMIT 1", r.TraceDB, r.errorTable)
+				query := fmt.Sprintf("SELECT errorID as nextErrorID, timestamp as nextTimestamp FROM %s.%s WHERE groupID = @groupID AND timestamp > @timestamp ORDER BY timestamp ASC LIMIT 1", r.TraceDB, errorsView(tenant))
 				args := []interface{}{clickhouse.Named("errorID", queryParams.ErrorID), clickhouse.Named("groupID", queryParams.GroupID), clickhouse.Named("timestamp", strconv.FormatInt(queryParams.Timestamp.UnixNano(), 10))}
 
 				err := r.db.Select(ctx, &getNextErrorIDReponse, query, args...)
@@ -2784,10 +2811,11 @@ func (r *ClickHouseReader) getNextErrorID(ctx context.Context, queryParams *mode
 }
 
 func (r *ClickHouseReader) getPrevErrorID(ctx context.Context, queryParams *model.GetErrorParams) (string, time.Time, *model.ApiError) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	var getPrevErrorIDReponse []model.NextPrevErrorIDsDBResponse
 
-	query := fmt.Sprintf("SELECT errorID as prevErrorID, timestamp as prevTimestamp FROM %s.%s WHERE groupID = @groupID AND timestamp <= @timestamp AND errorID != @errorID ORDER BY timestamp DESC LIMIT 2", r.TraceDB, r.errorTable)
+	query := fmt.Sprintf("SELECT errorID as prevErrorID, timestamp as prevTimestamp FROM %s.%s WHERE groupID = @groupID AND timestamp <= @timestamp AND errorID != @errorID ORDER BY timestamp DESC LIMIT 2", r.TraceDB, errorsView(tenant))
 	args := []interface{}{clickhouse.Named("errorID", queryParams.ErrorID), clickhouse.Named("groupID", queryParams.GroupID), clickhouse.Named("timestamp", strconv.FormatInt(queryParams.Timestamp.UnixNano(), 10))}
 
 	err := r.db.Select(ctx, &getPrevErrorIDReponse, query, args...)
@@ -2808,7 +2836,7 @@ func (r *ClickHouseReader) getPrevErrorID(ctx context.Context, queryParams *mode
 		if getPrevErrorIDReponse[0].Timestamp.UnixNano() == getPrevErrorIDReponse[1].Timestamp.UnixNano() {
 			var getPrevErrorIDReponse []model.NextPrevErrorIDsDBResponse
 
-			query := fmt.Sprintf("SELECT errorID as prevErrorID, timestamp as prevTimestamp FROM %s.%s WHERE groupID = @groupID AND timestamp = @timestamp AND errorID < @errorID ORDER BY errorID DESC LIMIT 1", r.TraceDB, r.errorTable)
+			query := fmt.Sprintf("SELECT errorID as prevErrorID, timestamp as prevTimestamp FROM %s.%s WHERE groupID = @groupID AND timestamp = @timestamp AND errorID < @errorID ORDER BY errorID DESC LIMIT 1", r.TraceDB, errorsView(tenant))
 			args := []interface{}{clickhouse.Named("errorID", queryParams.ErrorID), clickhouse.Named("groupID", queryParams.GroupID), clickhouse.Named("timestamp", strconv.FormatInt(queryParams.Timestamp.UnixNano(), 10))}
 
 			err := r.db.Select(ctx, &getPrevErrorIDReponse, query, args...)
@@ -2822,7 +2850,7 @@ func (r *ClickHouseReader) getPrevErrorID(ctx context.Context, queryParams *mode
 			if len(getPrevErrorIDReponse) == 0 {
 				var getPrevErrorIDReponse []model.NextPrevErrorIDsDBResponse
 
-				query := fmt.Sprintf("SELECT errorID as prevErrorID, timestamp as prevTimestamp FROM %s.%s WHERE groupID = @groupID AND timestamp < @timestamp ORDER BY timestamp DESC LIMIT 1", r.TraceDB, r.errorTable)
+				query := fmt.Sprintf("SELECT errorID as prevErrorID, timestamp as prevTimestamp FROM %s.%s WHERE groupID = @groupID AND timestamp < @timestamp ORDER BY timestamp DESC LIMIT 1", r.TraceDB, errorsView(tenant))
 				args := []interface{}{clickhouse.Named("errorID", queryParams.ErrorID), clickhouse.Named("groupID", queryParams.GroupID), clickhouse.Named("timestamp", strconv.FormatInt(queryParams.Timestamp.UnixNano(), 10))}
 
 				err := r.db.Select(ctx, &getPrevErrorIDReponse, query, args...)
@@ -2988,16 +3016,18 @@ func (r *ClickHouseReader) GetLogsInfoInLastHeartBeatInterval(ctx context.Contex
 }
 
 func (r *ClickHouseReader) GetTagsInfoInLastHeartBeatInterval(ctx context.Context, interval time.Duration) (*model.TagsInfo, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+
 	queryStr := fmt.Sprintf(`select serviceName, stringTagMap['deployment.environment'] as env, 
 	stringTagMap['telemetry.sdk.language'] as language from %s.%s 
 	where timestamp > toUnixTimestamp(now()-toIntervalMinute(%d))
-	group by serviceName, env, language;`, r.TraceDB, r.traceTableName, int(interval.Minutes()))
+	group by serviceName, env, language;`, r.TraceDB, traceIndexView(tenant), int(interval.Minutes()))
 
 	if r.useTraceNewSchema {
 		queryStr = fmt.Sprintf(`select serviceName, resources_string['deployment.environment'] as env, 
 	resources_string['telemetry.sdk.language'] as language from %s.%s 
 	where timestamp > toUnixTimestamp(now()-toIntervalMinute(%d))
-	group by serviceName, env, language;`, r.TraceDB, r.traceTableName, int(interval.Minutes()))
+	group by serviceName, env, language;`, r.TraceDB, traceIndexView(tenant), int(interval.Minutes()))
 	}
 
 	tagTelemetryDataList := []model.TagTelemetryData{}
@@ -3287,7 +3317,17 @@ func (r *ClickHouseReader) UpdateLogField(ctx context.Context, field *model.Upda
 	return nil
 }
 
+func attributeKeysView(tenant string) string {
+	return fmt.Sprintf("%s (tenant='%s')", constants.TENANT_TRACES_ATTR_KEYS_VIEW, tenant)
+}
+
+func attributeTagView(tenant string) string {
+	return fmt.Sprintf("%s (tenant='%s')", constants.TENANT_TRACES_TAG_ATTR_VEIW, tenant)
+}
+
 func (r *ClickHouseReader) GetTraceFields(ctx context.Context) (*model.GetFieldsResponse, *model.ApiError) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+
 	// response will contain top level fields from the otel trace model
 	response := model.GetFieldsResponse{
 		Selected:    []model.Field{},
@@ -3308,7 +3348,7 @@ func (r *ClickHouseReader) GetTraceFields(ctx context.Context) (*model.GetFields
 
 	// get attribute keys
 	attributes := []model.Field{}
-	query := fmt.Sprintf("SELECT tagKey, tagType, dataType from %s.%s group by tagKey, tagType, dataType", r.TraceDB, r.spanAttributesKeysTable)
+	query := fmt.Sprintf("SELECT tagKey, tagType, dataType from %s.%s group by tagKey, tagType, dataType", r.TraceDB, attributeKeysView(tenant))
 	rows, err := r.db.Query(ctx, query)
 	if err != nil {
 		return nil, &model.ApiError{Err: err, Typ: model.ErrorInternal}
@@ -3699,13 +3739,14 @@ func (r *ClickHouseReader) GetMetricAggregateAttributes(
 	req *v3.AggregateAttributeRequest,
 	skipDotNames bool,
 ) (*v3.AggregateAttributeResponse, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	var query string
 	var err error
 	var rows driver.Rows
 	var response v3.AggregateAttributeResponse
 
-	query = fmt.Sprintf("SELECT metric_name, type, is_monotonic, temporality FROM %s.%s WHERE metric_name ILIKE $1 GROUP BY metric_name, type, is_monotonic, temporality", signozMetricDBName, signozTSTableNameV41Day)
+	query = fmt.Sprintf("SELECT metric_name, type, is_monotonic, temporality FROM %s.%s WHERE metric_name ILIKE $1 GROUP BY metric_name, type, is_monotonic, temporality", signozMetricDBName, chprom.MetricsViewForTenant(chprom.DistributedTimeSeriesV41dayView, tenant, 0, math.MaxInt64))
 	if req.Limit != 0 {
 		query = query + fmt.Sprintf(" LIMIT %d;", req.Limit)
 	}
@@ -3752,6 +3793,7 @@ func (r *ClickHouseReader) GetMetricAggregateAttributes(
 }
 
 func (r *ClickHouseReader) GetMetricAttributeKeys(ctx context.Context, req *v3.FilterAttributeKeyRequest) (*v3.FilterAttributeKeyResponse, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	var query string
 	var err error
@@ -3759,7 +3801,7 @@ func (r *ClickHouseReader) GetMetricAttributeKeys(ctx context.Context, req *v3.F
 	var response v3.FilterAttributeKeyResponse
 
 	// skips the internal attributes i.e attributes starting with __
-	query = fmt.Sprintf("SELECT arrayJoin(tagKeys) AS distinctTagKey FROM (SELECT JSONExtractKeys(labels) AS tagKeys FROM %s.%s WHERE metric_name=$1 AND unix_milli >= $2 GROUP BY tagKeys) WHERE distinctTagKey ILIKE $3 AND distinctTagKey NOT LIKE '\\_\\_%%' GROUP BY distinctTagKey", signozMetricDBName, signozTSTableNameV41Day)
+	query = fmt.Sprintf("SELECT arrayJoin(tagKeys) AS distinctTagKey FROM (SELECT JSONExtractKeys(labels) AS tagKeys FROM %s.%s WHERE metric_name=$1 AND unix_milli >= $2 GROUP BY tagKeys) WHERE distinctTagKey ILIKE $3 AND distinctTagKey NOT LIKE '\\_\\_%%' GROUP BY distinctTagKey", signozMetricDBName, chprom.MetricsViewForTenant(chprom.DistributedTimeSeriesV41dayView, tenant, common.PastDayRoundOff(), math.MaxInt64))
 	if req.Limit != 0 {
 		query = query + fmt.Sprintf(" LIMIT %d;", req.Limit)
 	}
@@ -3788,13 +3830,14 @@ func (r *ClickHouseReader) GetMetricAttributeKeys(ctx context.Context, req *v3.F
 }
 
 func (r *ClickHouseReader) GetMetricAttributeValues(ctx context.Context, req *v3.FilterAttributeValueRequest) (*v3.FilterAttributeValueResponse, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	var query string
 	var err error
 	var rows driver.Rows
 	var attributeValues v3.FilterAttributeValueResponse
 
-	query = fmt.Sprintf("SELECT JSONExtractString(labels, $1) AS tagValue FROM %s.%s WHERE metric_name=$2 AND JSONExtractString(labels, $3) ILIKE $4 AND unix_milli >= $5 GROUP BY tagValue", signozMetricDBName, signozTSTableNameV41Day)
+	query = fmt.Sprintf("SELECT JSONExtractString(labels, $1) AS tagValue FROM %s.%s WHERE metric_name=$2 AND JSONExtractString(labels, $3) ILIKE $4 AND unix_milli >= $5 GROUP BY tagValue", signozMetricDBName, chprom.MetricsViewForTenant(chprom.DistributedTimeSeriesV41dayView, tenant, common.PastDayRoundOff(), math.MaxInt64))
 	if req.Limit != 0 {
 		query = query + fmt.Sprintf(" LIMIT %d;", req.Limit)
 	}
@@ -3820,13 +3863,14 @@ func (r *ClickHouseReader) GetMetricAttributeValues(ctx context.Context, req *v3
 }
 
 func (r *ClickHouseReader) GetMetricMetadata(ctx context.Context, metricName, serviceName string) (*v3.MetricMetadataResponse, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	unixMilli := common.PastDayRoundOff()
 
 	// Note: metric metadata should be accessible regardless of the time range selection
 	// our standard retention period is 30 days, so we are querying the table v4_1_day to reduce the
 	// amount of data scanned
-	query := fmt.Sprintf("SELECT temporality, description, type, unit, is_monotonic from %s.%s WHERE metric_name=$1 AND unix_milli >= $2 GROUP BY temporality, description, type, unit, is_monotonic", signozMetricDBName, signozTSTableNameV41Day)
+	query := fmt.Sprintf("SELECT temporality, description, type, unit, is_monotonic from %s.%s WHERE metric_name=$1 AND unix_milli >= $2 GROUP BY temporality, description, type, unit, is_monotonic", signozMetricDBName, chprom.MetricsViewForTenant(chprom.DistributedTimeSeriesV41dayView, tenant, unixMilli, math.MaxInt64))
 	rows, err := r.db.Query(ctx, query, metricName, unixMilli)
 	if err != nil {
 		zap.L().Error("Error while fetching metric metadata", zap.Error(err))
@@ -3845,7 +3889,7 @@ func (r *ClickHouseReader) GetMetricMetadata(ctx context.Context, metricName, se
 		}
 	}
 
-	query = fmt.Sprintf("SELECT JSONExtractString(labels, 'le') as le from %s.%s WHERE metric_name=$1 AND unix_milli >= $2 AND type = 'Histogram' AND JSONExtractString(labels, 'service_name') = $3 GROUP BY le ORDER BY le", signozMetricDBName, signozTSTableNameV41Day)
+	query = fmt.Sprintf("SELECT JSONExtractString(labels, 'le') as le from %s.%s WHERE metric_name=$1 AND unix_milli >= $2 AND type = 'Histogram' AND JSONExtractString(labels, 'service_name') = $3 GROUP BY le ORDER BY le", signozMetricDBName, chprom.MetricsViewForTenant(chprom.DistributedTimeSeriesV41dayView, tenant, unixMilli, math.MaxInt64))
 	rows, err = r.db.Query(ctx, query, metricName, unixMilli, serviceName)
 	if err != nil {
 		zap.L().Error("Error while executing query", zap.Error(err))
@@ -3969,6 +4013,7 @@ func isColumn(useLogsNewSchema bool, tableStatement, attrType, field, datType st
 }
 
 func (r *ClickHouseReader) GetLogAggregateAttributes(ctx context.Context, req *v3.AggregateAttributeRequest) (*v3.AggregateAttributeResponse, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	var query string
 	var err error
@@ -4011,7 +4056,7 @@ func (r *ClickHouseReader) GetLogAggregateAttributes(ctx context.Context, req *v
 		return nil, fmt.Errorf("unsupported aggregate operator")
 	}
 
-	query = fmt.Sprintf("SELECT DISTINCT(tag_key), tag_type, tag_data_type from %s.%s WHERE %s limit $2", r.logsDB, r.logsTagAttributeTableV2, where)
+	query = fmt.Sprintf("SELECT DISTINCT(tag_key), tag_type, tag_data_type from %s.%s WHERE %s limit $2", r.logsDB, attributeTagView(tenant), where)
 	rows, err = r.db.Query(ctx, query, fmt.Sprintf("%%%s%%", req.SearchText), req.Limit)
 	if err != nil {
 		zap.L().Error("Error while executing query", zap.Error(err))
@@ -4054,16 +4099,18 @@ func (r *ClickHouseReader) GetLogAggregateAttributes(ctx context.Context, req *v
 }
 
 func (r *ClickHouseReader) GetLogAttributeKeys(ctx context.Context, req *v3.FilterAttributeKeyRequest) (*v3.FilterAttributeKeyResponse, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+
 	var query string
 	var err error
 	var rows driver.Rows
 	var response v3.FilterAttributeKeyResponse
 
 	if len(req.SearchText) != 0 {
-		query = fmt.Sprintf("select distinct tag_key, tag_type, tag_data_type from  %s.%s where tag_key ILIKE $1 limit $2", r.logsDB, r.logsTagAttributeTableV2)
+		query = fmt.Sprintf("select distinct tag_key, tag_type, tag_data_type from  %s.%s where tag_key ILIKE $1 limit $2", r.logsDB, attributeTagView(tenant))
 		rows, err = r.db.Query(ctx, query, fmt.Sprintf("%%%s%%", req.SearchText), req.Limit)
 	} else {
-		query = fmt.Sprintf("select distinct tag_key, tag_type, tag_data_type from  %s.%s limit $1", r.logsDB, r.logsTagAttributeTableV2)
+		query = fmt.Sprintf("select distinct tag_key, tag_type, tag_data_type from  %s.%s limit $1", r.logsDB, attributeTagView(tenant))
 		rows, err = r.db.Query(ctx, query, req.Limit)
 	}
 
@@ -4112,6 +4159,8 @@ func (r *ClickHouseReader) GetLogAttributeKeys(ctx context.Context, req *v3.Filt
 }
 
 func (r *ClickHouseReader) GetLogAttributeValues(ctx context.Context, req *v3.FilterAttributeValueRequest) (*v3.FilterAttributeValueResponse, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+
 	var err error
 	var filterValueColumn string
 	var rows driver.Rows
@@ -4172,10 +4221,10 @@ func (r *ClickHouseReader) GetLogAttributeValues(ctx context.Context, req *v3.Fi
 		if req.FilterAttributeKeyDataType != v3.AttributeKeyDataTypeString {
 			filterValueColumnWhere = fmt.Sprintf("toString(%s)", filterValueColumn)
 		}
-		query = fmt.Sprintf("SELECT DISTINCT %s FROM %s.%s WHERE tag_key=$1 AND %s ILIKE $2 AND tag_type=$3 LIMIT $4", filterValueColumn, r.logsDB, r.logsTagAttributeTableV2, filterValueColumnWhere)
+		query = fmt.Sprintf("SELECT DISTINCT %s FROM %s.%s WHERE tag_key=$1 AND %s ILIKE $2 AND tag_type=$3 LIMIT $4", filterValueColumn, r.logsDB, attributeTagView(tenant), filterValueColumnWhere)
 		rows, err = r.db.Query(ctx, query, req.FilterAttributeKey, searchText, req.TagType, req.Limit)
 	} else {
-		query = fmt.Sprintf("SELECT DISTINCT %s FROM %s.%s WHERE tag_key=$1 AND tag_type=$2 LIMIT $3", filterValueColumn, r.logsDB, r.logsTagAttributeTableV2)
+		query = fmt.Sprintf("SELECT DISTINCT %s FROM %s.%s WHERE tag_key=$1 AND tag_type=$2 LIMIT $3", filterValueColumn, r.logsDB, attributeTagView(tenant))
 		rows, err = r.db.Query(ctx, query, req.FilterAttributeKey, req.TagType, req.Limit)
 	}
 
@@ -4430,8 +4479,51 @@ func logCommentKVs(ctx context.Context) map[string]string {
 	return logCommentKVs
 }
 
+var tenantRe = regexp.MustCompile(`^tenant\s*=`)
+
+func imputeTenant(query string, tenant string, tenantIdx int) string {
+	// query = "SELECT whatever FROM my_tenant_view (tenant = 'mytenant') WHERE ..."
+	start := query[tenantIdx:] // 	tenant = 'mytenant') WHERE ...
+
+	if !tenantRe.MatchString(start) {
+		// defeat comment hacking
+		equalsIdx := strings.IndexRune(start, '=')
+		if equalsIdx > -1 {
+			sub := start[:equalsIdx]
+			if strings.Contains(sub, "/*") || strings.Contains(sub, "--") {
+				return query[:tenantIdx] + "invalid"
+			}
+		}
+		// string "tenant" not being used to designate a view parameter in this case
+		return query
+	}
+
+	firstQuoteStartIdx := strings.IndexRune(start, '\'')
+	firstQuoteStart := start[firstQuoteStartIdx:]                                // 	'mytenant') WHERE ...
+	suffix := firstQuoteStart[1:][strings.IndexRune(firstQuoteStart[1:], '\''):] //  ') WHERE ...
+	return query[:tenantIdx] + "tenant='" + tenant + suffix
+}
+
+func imputeTenantInQuery(query string, tenant string) string {
+	// this parsing is not very general and could be improved upon...
+	lastTenantIdx := -1
+	tenantIdx := strings.Index(query, "tenant")
+	for lastTenantIdx != tenantIdx {
+		query = imputeTenant(query, tenant, tenantIdx)
+		lastTenantIdx = tenantIdx
+		tenantIdx = tenantIdx + 1 + strings.Index(query[tenantIdx+1:], "tenant") // finds the next occurrence of "tenant"
+	}
+	return query
+}
+
 // GetTimeSeriesResultV3 runs the query and returns list of time series
 func (r *ClickHouseReader) GetTimeSeriesResultV3(ctx context.Context, query string) ([]*v3.Series, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+	query = imputeTenantInQuery(query, tenant)
+	db := r.db
+	if r.tenantDb != nil {
+		db = r.tenantDb
+	}
 
 	ctxArgs := map[string]interface{}{"query": query}
 	for k, v := range logCommentKVs(ctx) {
@@ -4464,7 +4556,7 @@ func (r *ClickHouseReader) GetTimeSeriesResultV3(ctx context.Context, query stri
 		}
 	}
 
-	rows, err := r.db.Query(ctx, query)
+	rows, err := db.Query(ctx, query)
 
 	if err != nil {
 		zap.L().Error("error while reading time series result", zap.Error(err))
@@ -4646,6 +4738,8 @@ func (r *ClickHouseReader) CheckClickHouse(ctx context.Context) error {
 }
 
 func (r *ClickHouseReader) GetTraceAggregateAttributes(ctx context.Context, req *v3.AggregateAttributeRequest) (*v3.AggregateAttributeResponse, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+
 	var query string
 	var err error
 	var rows driver.Rows
@@ -4686,7 +4780,7 @@ func (r *ClickHouseReader) GetTraceAggregateAttributes(ctx context.Context, req 
 	default:
 		return nil, fmt.Errorf("unsupported aggregate operator")
 	}
-	query = fmt.Sprintf("SELECT DISTINCT(tag_key), tag_type, tag_data_type FROM %s.%s WHERE %s", r.TraceDB, r.spanAttributeTableV2, where)
+	query = fmt.Sprintf("SELECT DISTINCT(tag_key), tag_type, tag_data_type FROM %s.%s WHERE %s", r.TraceDB, attributeTagView(tenant), where)
 	if req.Limit != 0 {
 		query = query + fmt.Sprintf(" LIMIT %d;", req.Limit)
 	}
@@ -4742,13 +4836,14 @@ func (r *ClickHouseReader) GetTraceAggregateAttributes(ctx context.Context, req 
 }
 
 func (r *ClickHouseReader) GetTraceAttributeKeys(ctx context.Context, req *v3.FilterAttributeKeyRequest) (*v3.FilterAttributeKeyResponse, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	var query string
 	var err error
 	var rows driver.Rows
 	var response v3.FilterAttributeKeyResponse
 
-	query = fmt.Sprintf("SELECT DISTINCT(tag_key), tag_type, tag_data_type FROM %s.%s WHERE tag_key ILIKE $1 LIMIT $2", r.TraceDB, r.spanAttributeTableV2)
+	query = fmt.Sprintf("SELECT DISTINCT(tag_key), tag_type, tag_data_type FROM %s.%s WHERE tag_key ILIKE $1 LIMIT $2", r.TraceDB, attributeTagView(tenant))
 
 	rows, err = r.db.Query(ctx, query, fmt.Sprintf("%%%s%%", req.SearchText), req.Limit)
 
@@ -4807,6 +4902,8 @@ func (r *ClickHouseReader) GetTraceAttributeKeys(ctx context.Context, req *v3.Fi
 }
 
 func (r *ClickHouseReader) GetTraceAttributeValues(ctx context.Context, req *v3.FilterAttributeValueRequest) (*v3.FilterAttributeValueResponse, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+
 	var query string
 	var filterValueColumn string
 	var err error
@@ -4856,14 +4953,14 @@ func (r *ClickHouseReader) GetTraceAttributeValues(ctx context.Context, req *v3.
 		if r.useTraceNewSchema {
 			where += " AND ts_bucket_start >= toUInt64(toUnixTimestamp(now() - INTERVAL 48 HOUR))"
 		}
-		query = fmt.Sprintf("SELECT DISTINCT %s FROM %s.%s WHERE %s AND %s ILIKE $1 LIMIT $2", selectKey, r.TraceDB, r.traceTableName, where, filterValueColumnWhere)
+		query = fmt.Sprintf("SELECT DISTINCT %s FROM %s.%s WHERE %s AND %s ILIKE $1 LIMIT $2", selectKey, r.TraceDB, traceIndexView(tenant), where, filterValueColumnWhere)
 		rows, err = r.db.Query(ctx, query, searchText, req.Limit)
 	} else {
 		filterValueColumnWhere := filterValueColumn
 		if req.FilterAttributeKeyDataType != v3.AttributeKeyDataTypeString {
 			filterValueColumnWhere = fmt.Sprintf("toString(%s)", filterValueColumn)
 		}
-		query = fmt.Sprintf("SELECT DISTINCT %s FROM %s.%s WHERE tag_key=$1 AND %s ILIKE $2 AND tag_type=$3 LIMIT $4", filterValueColumn, r.TraceDB, r.spanAttributeTableV2, filterValueColumnWhere)
+		query = fmt.Sprintf("SELECT DISTINCT %s FROM %s.%s WHERE tag_key=$1 AND %s ILIKE $2 AND tag_type=$3 LIMIT $4", filterValueColumn, r.TraceDB, attributeTagView(tenant), filterValueColumnWhere)
 		rows, err = r.db.Query(ctx, query, req.FilterAttributeKey, searchText, req.TagType, req.Limit)
 	}
 
@@ -4896,12 +4993,14 @@ func (r *ClickHouseReader) GetTraceAttributeValues(ctx context.Context, req *v3.
 }
 
 func (r *ClickHouseReader) GetSpanAttributeKeysV2(ctx context.Context) (map[string]v3.AttributeKey, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+
 	var query string
 	var err error
 	var rows driver.Rows
 	response := map[string]v3.AttributeKey{}
 
-	query = fmt.Sprintf("SELECT DISTINCT(tagKey), tagType, dataType FROM %s.%s", r.TraceDB, r.spanAttributesKeysTable)
+	query = fmt.Sprintf("SELECT DISTINCT(tagKey), tagType, dataType FROM %s.%s", r.TraceDB, attributeKeysView(tenant))
 
 	rows, err = r.db.Query(ctx, query)
 	if err != nil {
@@ -4944,6 +5043,8 @@ func (r *ClickHouseReader) GetSpanAttributeKeysV2(ctx context.Context) (map[stri
 }
 
 func (r *ClickHouseReader) GetSpanAttributeKeys(ctx context.Context) (map[string]v3.AttributeKey, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+
 	if r.useTraceNewSchema {
 		return r.GetSpanAttributeKeysV2(ctx)
 	}
@@ -4952,7 +5053,7 @@ func (r *ClickHouseReader) GetSpanAttributeKeys(ctx context.Context) (map[string
 	var rows driver.Rows
 	response := map[string]v3.AttributeKey{}
 
-	query = fmt.Sprintf("SELECT DISTINCT(tagKey), tagType, dataType, isColumn FROM %s.%s", r.TraceDB, r.spanAttributesKeysTable)
+	query = fmt.Sprintf("SELECT DISTINCT(tagKey), tagType, dataType, isColumn FROM %s.%s", r.TraceDB, attributeKeysView(tenant))
 
 	rows, err = r.db.Query(ctx, query)
 

--- a/pkg/query-service/app/dashboards/model.go
+++ b/pkg/query-service/app/dashboards/model.go
@@ -120,9 +120,8 @@ func CreateDashboard(ctx context.Context, data map[string]interface{}, fm interf
 }
 
 func GetDashboards(ctx context.Context) ([]Dashboard, *model.ApiError) {
-
 	dashboards := []Dashboard{}
-	query := `SELECT * FROM dashboards`
+	query := `SELECT * FROM dashboards WHERE ` + common.TenantSqlPredicate(ctx)
 
 	err := db.Select(&dashboards, query)
 	if err != nil {
@@ -146,7 +145,7 @@ func DeleteDashboard(ctx context.Context, uuid string, fm interfaces.FeatureLook
 		}
 	}
 
-	query := `DELETE FROM dashboards WHERE uuid=?`
+	query := `DELETE FROM dashboards WHERE uuid=? AND ` + common.TenantSqlPredicate(ctx)
 
 	result, err := db.Exec(query, uuid)
 	if err != nil {
@@ -167,7 +166,7 @@ func DeleteDashboard(ctx context.Context, uuid string, fm interfaces.FeatureLook
 func GetDashboard(ctx context.Context, uuid string) (*Dashboard, *model.ApiError) {
 
 	dashboard := Dashboard{}
-	query := `SELECT * FROM dashboards WHERE uuid=?`
+	query := `SELECT * FROM dashboards WHERE uuid=? AND ` + common.TenantSqlPredicate(ctx)
 
 	err := db.Get(&dashboard, query, uuid)
 	if err != nil {
@@ -213,7 +212,7 @@ func UpdateDashboard(ctx context.Context, uuid string, data map[string]interface
 	dashboard.UpdateBy = &userEmail
 	dashboard.Data = data
 
-	_, err = db.Exec("UPDATE dashboards SET updated_at=$1, updated_by=$2, data=$3 WHERE uuid=$4;",
+	_, err = db.Exec("UPDATE dashboards SET updated_at=$1, updated_by=$2, data=$3 WHERE uuid=$4 AND "+common.TenantSqlPredicate(ctx),
 		dashboard.UpdatedAt, userEmail, mapData, dashboard.Uuid)
 
 	if err != nil {
@@ -226,9 +225,9 @@ func UpdateDashboard(ctx context.Context, uuid string, data map[string]interface
 func LockUnlockDashboard(ctx context.Context, uuid string, lock bool) *model.ApiError {
 	var query string
 	if lock {
-		query = `UPDATE dashboards SET locked=1 WHERE uuid=?;`
+		query = `UPDATE dashboards SET locked=1 WHERE uuid=? AND ` + common.TenantSqlPredicate(ctx)
 	} else {
-		query = `UPDATE dashboards SET locked=0 WHERE uuid=?;`
+		query = `UPDATE dashboards SET locked=0 WHERE uuid=? AND ` + common.TenantSqlPredicate(ctx)
 	}
 
 	_, err := db.Exec(query, uuid)

--- a/pkg/query-service/app/inframetrics/clusters.go
+++ b/pkg/query-service/app/inframetrics/clusters.go
@@ -96,7 +96,7 @@ func (p *ClustersRepo) getMetadataAttributes(ctx context.Context, req model.Clus
 		GroupBy:     req.GroupBy,
 	}
 
-	query, err := helpers.PrepareTimeseriesFilterQuery(req.Start, req.End, &mq)
+	query, err := helpers.PrepareTimeseriesFilterQuery("TODO", req.Start, req.End, &mq)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query-service/app/inframetrics/daemonsets.go
+++ b/pkg/query-service/app/inframetrics/daemonsets.go
@@ -163,7 +163,7 @@ func (d *DaemonSetsRepo) getMetadataAttributes(ctx context.Context, req model.Da
 		GroupBy:     req.GroupBy,
 	}
 
-	query, err := helpers.PrepareTimeseriesFilterQuery(req.Start, req.End, &mq)
+	query, err := helpers.PrepareTimeseriesFilterQuery("TODO", req.Start, req.End, &mq)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query-service/app/inframetrics/deployments.go
+++ b/pkg/query-service/app/inframetrics/deployments.go
@@ -163,7 +163,7 @@ func (d *DeploymentsRepo) getMetadataAttributes(ctx context.Context, req model.D
 		GroupBy:     req.GroupBy,
 	}
 
-	query, err := helpers.PrepareTimeseriesFilterQuery(req.Start, req.End, &mq)
+	query, err := helpers.PrepareTimeseriesFilterQuery("TODO", req.Start, req.End, &mq)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query-service/app/inframetrics/hosts.go
+++ b/pkg/query-service/app/inframetrics/hosts.go
@@ -211,7 +211,7 @@ func (h *HostsRepo) getMetadataAttributes(ctx context.Context, req model.HostLis
 		GroupBy:     req.GroupBy,
 	}
 
-	query, err := helpers.PrepareTimeseriesFilterQuery(req.Start, req.End, &mq)
+	query, err := helpers.PrepareTimeseriesFilterQuery("TODO", req.Start, req.End, &mq)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query-service/app/inframetrics/jobs.go
+++ b/pkg/query-service/app/inframetrics/jobs.go
@@ -207,7 +207,7 @@ func (d *JobsRepo) getMetadataAttributes(ctx context.Context, req model.JobListR
 		GroupBy:     req.GroupBy,
 	}
 
-	query, err := helpers.PrepareTimeseriesFilterQuery(req.Start, req.End, &mq)
+	query, err := helpers.PrepareTimeseriesFilterQuery("TODO", req.Start, req.End, &mq)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query-service/app/inframetrics/namespaces.go
+++ b/pkg/query-service/app/inframetrics/namespaces.go
@@ -90,7 +90,7 @@ func (p *NamespacesRepo) getMetadataAttributes(ctx context.Context, req model.Na
 		GroupBy:     req.GroupBy,
 	}
 
-	query, err := helpers.PrepareTimeseriesFilterQuery(req.Start, req.End, &mq)
+	query, err := helpers.PrepareTimeseriesFilterQuery("TODO", req.Start, req.End, &mq)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query-service/app/inframetrics/nodes.go
+++ b/pkg/query-service/app/inframetrics/nodes.go
@@ -120,7 +120,7 @@ func (p *NodesRepo) getMetadataAttributes(ctx context.Context, req model.NodeLis
 		GroupBy:     req.GroupBy,
 	}
 
-	query, err := helpers.PrepareTimeseriesFilterQuery(req.Start, req.End, &mq)
+	query, err := helpers.PrepareTimeseriesFilterQuery("TODO", req.Start, req.End, &mq)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query-service/app/inframetrics/pods.go
+++ b/pkg/query-service/app/inframetrics/pods.go
@@ -265,7 +265,7 @@ func (p *PodsRepo) getMetadataAttributes(ctx context.Context, req model.PodListR
 		GroupBy:     req.GroupBy,
 	}
 
-	query, err := helpers.PrepareTimeseriesFilterQuery(req.Start, req.End, &mq)
+	query, err := helpers.PrepareTimeseriesFilterQuery("TODO", req.Start, req.End, &mq)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query-service/app/inframetrics/processes.go
+++ b/pkg/query-service/app/inframetrics/processes.go
@@ -107,7 +107,7 @@ func (p *ProcessesRepo) getMetadataAttributes(ctx context.Context,
 		GroupBy:     req.GroupBy,
 	}
 
-	query, err := helpers.PrepareTimeseriesFilterQuery(req.Start, req.End, &mq)
+	query, err := helpers.PrepareTimeseriesFilterQuery("TODO", req.Start, req.End, &mq)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query-service/app/inframetrics/pvcs.go
+++ b/pkg/query-service/app/inframetrics/pvcs.go
@@ -123,7 +123,7 @@ func (p *PvcsRepo) getMetadataAttributes(ctx context.Context, req model.VolumeLi
 		GroupBy:     req.GroupBy,
 	}
 
-	query, err := helpers.PrepareTimeseriesFilterQuery(req.Start, req.End, &mq)
+	query, err := helpers.PrepareTimeseriesFilterQuery("TODO", req.Start, req.End, &mq)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query-service/app/inframetrics/statefulsets.go
+++ b/pkg/query-service/app/inframetrics/statefulsets.go
@@ -163,7 +163,7 @@ func (d *StatefulSetsRepo) getMetadataAttributes(ctx context.Context, req model.
 		GroupBy:     req.GroupBy,
 	}
 
-	query, err := helpers.PrepareTimeseriesFilterQuery(req.Start, req.End, &mq)
+	query, err := helpers.PrepareTimeseriesFilterQuery("TODO", req.Start, req.End, &mq)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query-service/app/logs/v3/query_builder.go
+++ b/pkg/query-service/app/logs/v3/query_builder.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -496,7 +497,7 @@ func IsOrderByTs(orderBy []v3.OrderBy) bool {
 // PrepareLogsQuery prepares the query for logs
 // start and end are in epoch millisecond
 // step is in seconds
-func PrepareLogsQuery(start, end int64, queryType v3.QueryType, panelType v3.PanelType, mq *v3.BuilderQuery, options v3.QBOptions) (string, error) {
+func PrepareLogsQuery(_ context.Context, start, end int64, queryType v3.QueryType, panelType v3.PanelType, mq *v3.BuilderQuery, options v3.QBOptions) (string, error) {
 
 	// adjust the start and end time to the step interval
 	// NOTE: Disabling this as it's creating confusion between charts and actual data

--- a/pkg/query-service/app/logs/v4/query_builder_test.go
+++ b/pkg/query-service/app/logs/v4/query_builder_test.go
@@ -789,7 +789,7 @@ func Test_buildLogsQuery(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildLogsQuery(tt.args.panelType, tt.args.start, tt.args.end, tt.args.step, tt.args.mq, tt.args.graphLimitQtype, tt.args.preferRPM)
+			got, err := buildLogsQuery(nil, tt.args.panelType, tt.args.start, tt.args.end, tt.args.step, tt.args.mq, tt.args.graphLimitQtype, tt.args.preferRPM)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("buildLogsQuery() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/query-service/app/metrics/v3/query_builder.go
+++ b/pkg/query-service/app/metrics/v3/query_builder.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -337,7 +338,7 @@ func reduceQuery(query string, reduceTo v3.ReduceToOperator, aggregateOperator v
 // from the database
 // start and end are in milliseconds
 // step is in seconds
-func PrepareMetricQuery(start, end int64, queryType v3.QueryType, panelType v3.PanelType, mq *v3.BuilderQuery, options Options) (string, error) {
+func PrepareMetricQuery(ctx context.Context, start, end int64, queryType v3.QueryType, panelType v3.PanelType, mq *v3.BuilderQuery, options Options) (string, error) {
 
 	start, end = common.AdjustedMetricTimeRange(start, end, mq.StepInterval, *mq)
 

--- a/pkg/query-service/app/metrics/v4/cumulative/table.go
+++ b/pkg/query-service/app/metrics/v4/cumulative/table.go
@@ -8,10 +8,10 @@ import (
 )
 
 // PrepareMetricQueryCumulativeTable prepares the query to be used for fetching metrics
-func PrepareMetricQueryCumulativeTable(start, end, step int64, mq *v3.BuilderQuery) (string, error) {
+func PrepareMetricQueryCumulativeTable(tenant string, start, end, step int64, mq *v3.BuilderQuery) (string, error) {
 	var query string
 
-	temporalAggSubQuery, err := prepareTimeAggregationSubQuery(start, end, step, mq)
+	temporalAggSubQuery, err := prepareTimeAggregationSubQuery(tenant, start, end, step, mq)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/query-service/app/metrics/v4/cumulative/timeseries.go
+++ b/pkg/query-service/app/metrics/v4/cumulative/timeseries.go
@@ -108,10 +108,10 @@ const (
 // value to be reset to 0. This will produce an inaccurate result. The max is the best approximation we can get.
 // We don't expect the process to restart very often, so this should be a good approximation.
 
-func prepareTimeAggregationSubQuery(start, end, step int64, mq *v3.BuilderQuery) (string, error) {
+func prepareTimeAggregationSubQuery(tenant string, start, end, step int64, mq *v3.BuilderQuery) (string, error) {
 	var subQuery string
 
-	timeSeriesSubQuery, err := helpers.PrepareTimeseriesFilterQuery(start, end, mq)
+	timeSeriesSubQuery, err := helpers.PrepareTimeseriesFilterQuery(tenant, start, end, mq)
 	if err != nil {
 		return "", err
 	}
@@ -178,10 +178,10 @@ func prepareTimeAggregationSubQuery(start, end, step int64, mq *v3.BuilderQuery)
 }
 
 // PrepareMetricQueryCumulativeTimeSeries prepares the query to be used for fetching metrics
-func PrepareMetricQueryCumulativeTimeSeries(start, end, step int64, mq *v3.BuilderQuery) (string, error) {
+func PrepareMetricQueryCumulativeTimeSeries(tenant string, start, end, step int64, mq *v3.BuilderQuery) (string, error) {
 	var query string
 
-	temporalAggSubQuery, err := prepareTimeAggregationSubQuery(start, end, step, mq)
+	temporalAggSubQuery, err := prepareTimeAggregationSubQuery(tenant, start, end, step, mq)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/query-service/app/metrics/v4/delta/table.go
+++ b/pkg/query-service/app/metrics/v4/delta/table.go
@@ -8,15 +8,15 @@ import (
 )
 
 // PrepareMetricQueryDeltaTable builds the query to be used for fetching metrics
-func PrepareMetricQueryDeltaTable(start, end, step int64, mq *v3.BuilderQuery) (string, error) {
+func PrepareMetricQueryDeltaTable(tenant string, start, end, step int64, mq *v3.BuilderQuery) (string, error) {
 
 	if canShortCircuit(mq) {
-		return prepareQueryOptimized(start, end, step, mq)
+		return prepareQueryOptimized(tenant, start, end, step, mq)
 	}
 
 	var query string
 
-	temporalAggSubQuery, err := prepareTimeAggregationSubQuery(start, end, step, mq)
+	temporalAggSubQuery, err := prepareTimeAggregationSubQuery(tenant, start, end, step, mq)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/query-service/app/metrics/v4/delta/timeseries.go
+++ b/pkg/query-service/app/metrics/v4/delta/timeseries.go
@@ -15,11 +15,11 @@ var (
 )
 
 // prepareTimeAggregationSubQuery builds the sub-query to be used for temporal aggregation
-func prepareTimeAggregationSubQuery(start, end, step int64, mq *v3.BuilderQuery) (string, error) {
+func prepareTimeAggregationSubQuery(tenant string, start, end, step int64, mq *v3.BuilderQuery) (string, error) {
 
 	var subQuery string
 
-	timeSeriesSubQuery, err := helpers.PrepareTimeseriesFilterQuery(start, end, mq)
+	timeSeriesSubQuery, err := helpers.PrepareTimeseriesFilterQuery(tenant, start, end, mq)
 	if err != nil {
 		return "", err
 	}
@@ -70,7 +70,7 @@ func prepareTimeAggregationSubQuery(start, end, step int64, mq *v3.BuilderQuery)
 }
 
 // See `canShortCircuit` below for details
-func prepareQueryOptimized(start, end, step int64, mq *v3.BuilderQuery) (string, error) {
+func prepareQueryOptimized(tenant string, start, end, step int64, mq *v3.BuilderQuery) (string, error) {
 
 	groupBy := helpers.GroupingSetsByAttributeKeyTags(mq.GroupBy...)
 	orderBy := helpers.OrderByAttributeKeyTags(mq.OrderBy, mq.GroupBy)
@@ -78,7 +78,7 @@ func prepareQueryOptimized(start, end, step int64, mq *v3.BuilderQuery) (string,
 
 	var query string
 
-	timeSeriesSubQuery, err := helpers.PrepareTimeseriesFilterQuery(start, end, mq)
+	timeSeriesSubQuery, err := helpers.PrepareTimeseriesFilterQuery(tenant, start, end, mq)
 	if err != nil {
 		return "", err
 	}
@@ -125,15 +125,15 @@ func prepareQueryOptimized(start, end, step int64, mq *v3.BuilderQuery) (string,
 }
 
 // PrepareMetricQueryDeltaTimeSeries builds the query to be used for fetching metrics
-func PrepareMetricQueryDeltaTimeSeries(start, end, step int64, mq *v3.BuilderQuery) (string, error) {
+func PrepareMetricQueryDeltaTimeSeries(tenant string, start, end, step int64, mq *v3.BuilderQuery) (string, error) {
 
 	if canShortCircuit(mq) {
-		return prepareQueryOptimized(start, end, step, mq)
+		return prepareQueryOptimized(tenant, start, end, step, mq)
 	}
 
 	var query string
 
-	temporalAggSubQuery, err := prepareTimeAggregationSubQuery(start, end, step, mq)
+	temporalAggSubQuery, err := prepareTimeAggregationSubQuery(tenant, start, end, step, mq)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/query-service/app/metrics/v4/query_builder.go
+++ b/pkg/query-service/app/metrics/v4/query_builder.go
@@ -1,7 +1,9 @@
 package v4
 
 import (
+	"context"
 	"fmt"
+	"go.signoz.io/signoz/pkg/query-service/constants"
 	"time"
 
 	"go.signoz.io/signoz/pkg/query-service/app/metrics"
@@ -18,7 +20,8 @@ import (
 // from the database
 // start and end are in milliseconds
 // step is in seconds
-func PrepareMetricQuery(start, end int64, queryType v3.QueryType, panelType v3.PanelType, mq *v3.BuilderQuery, options metricsV3.Options) (string, error) {
+func PrepareMetricQuery(ctx context.Context, start, end int64, queryType v3.QueryType, panelType v3.PanelType, mq *v3.BuilderQuery, options metricsV3.Options) (string, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
 
 	if valFilter := metrics.AddMetricValueFilter(mq); valFilter != nil {
 		mq.MetricValueFilter = valFilter
@@ -58,15 +61,15 @@ func PrepareMetricQuery(start, end int64, queryType v3.QueryType, panelType v3.P
 	var err error
 	if mq.Temporality == v3.Delta {
 		if panelType == v3.PanelTypeTable {
-			query, err = delta.PrepareMetricQueryDeltaTable(start, end, mq.StepInterval, mq)
+			query, err = delta.PrepareMetricQueryDeltaTable(tenant, start, end, mq.StepInterval, mq)
 		} else {
-			query, err = delta.PrepareMetricQueryDeltaTimeSeries(start, end, mq.StepInterval, mq)
+			query, err = delta.PrepareMetricQueryDeltaTimeSeries(tenant, start, end, mq.StepInterval, mq)
 		}
 	} else {
 		if panelType == v3.PanelTypeTable {
-			query, err = cumulative.PrepareMetricQueryCumulativeTable(start, end, mq.StepInterval, mq)
+			query, err = cumulative.PrepareMetricQueryCumulativeTable(tenant, start, end, mq.StepInterval, mq)
 		} else {
-			query, err = cumulative.PrepareMetricQueryCumulativeTimeSeries(start, end, mq.StepInterval, mq)
+			query, err = cumulative.PrepareMetricQueryCumulativeTimeSeries(tenant, start, end, mq.StepInterval, mq)
 		}
 	}
 

--- a/pkg/query-service/app/querier/v2/helper.go
+++ b/pkg/query-service/app/querier/v2/helper.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func prepareLogsQuery(_ context.Context,
+func prepareLogsQuery(ctx context.Context,
 	useLogsNewSchema bool,
 	start,
 	end int64,
@@ -40,6 +40,7 @@ func prepareLogsQuery(_ context.Context,
 	// for ts query with limit replace it as it is already formed
 	if params.CompositeQuery.PanelType == v3.PanelTypeGraph && builderQuery.Limit > 0 && len(builderQuery.GroupBy) > 0 {
 		limitQuery, err := logsQueryBuilder(
+			ctx,
 			start,
 			end,
 			params.CompositeQuery.QueryType,
@@ -51,6 +52,7 @@ func prepareLogsQuery(_ context.Context,
 			return query, err
 		}
 		placeholderQuery, err := logsQueryBuilder(
+			ctx,
 			start,
 			end,
 			params.CompositeQuery.QueryType,
@@ -66,6 +68,7 @@ func prepareLogsQuery(_ context.Context,
 	}
 
 	query, err := logsQueryBuilder(
+		ctx,
 		start,
 		end,
 		params.CompositeQuery.QueryType,
@@ -169,6 +172,7 @@ func (q *querier) runBuilderQuery(
 		// for ts query with group by and limit form two queries
 		if params.CompositeQuery.PanelType == v3.PanelTypeGraph && builderQuery.Limit > 0 && len(builderQuery.GroupBy) > 0 {
 			limitQuery, err := tracesQueryBuilder(
+				ctx,
 				start,
 				end,
 				params.CompositeQuery.PanelType,
@@ -180,6 +184,7 @@ func (q *querier) runBuilderQuery(
 				return
 			}
 			placeholderQuery, err := tracesQueryBuilder(
+				ctx,
 				start,
 				end,
 				params.CompositeQuery.PanelType,
@@ -193,6 +198,7 @@ func (q *querier) runBuilderQuery(
 			query = strings.Replace(placeholderQuery, "#LIMIT_PLACEHOLDER", limitQuery, 1)
 		} else {
 			query, err = tracesQueryBuilder(
+				ctx,
 				start,
 				end,
 				params.CompositeQuery.PanelType,
@@ -215,7 +221,7 @@ func (q *querier) runBuilderQuery(
 	// If the query is not cached, we execute the query and return the result without caching it.
 	if _, ok := cacheKeys[queryName]; !ok || params.NoCache {
 		zap.L().Info("skipping cache for metrics query", zap.String("queryName", queryName), zap.Int64("start", params.Start), zap.Int64("end", params.End), zap.Int64("step", params.Step), zap.Bool("noCache", params.NoCache), zap.String("cacheKey", cacheKeys[queryName]))
-		query, err := metricsV4.PrepareMetricQuery(start, end, params.CompositeQuery.QueryType, params.CompositeQuery.PanelType, builderQuery, metricsV3.Options{PreferRPM: preferRPM})
+		query, err := metricsV4.PrepareMetricQuery(ctx, start, end, params.CompositeQuery.QueryType, params.CompositeQuery.PanelType, builderQuery, metricsV3.Options{PreferRPM: preferRPM})
 		if err != nil {
 			ch <- channelResult{Err: err, Name: queryName, Query: query, Series: nil}
 			return
@@ -230,6 +236,7 @@ func (q *querier) runBuilderQuery(
 	missedSeries := make([]querycache.CachedSeriesData, 0)
 	for _, miss := range misses {
 		query, err := metricsV4.PrepareMetricQuery(
+			ctx,
 			miss.Start,
 			miss.End,
 			params.CompositeQuery.QueryType,

--- a/pkg/query-service/app/querier/v2/querier.go
+++ b/pkg/query-service/app/querier/v2/querier.go
@@ -169,6 +169,11 @@ func (q *querier) runBuilderQueries(ctx context.Context, params *v3.QueryRangePa
 
 	cacheKeys := q.keyGenerator.GenerateKeys(params)
 
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+	for queryName, key := range cacheKeys {
+		cacheKeys[queryName] = fmt.Sprintf("tenant=%s&%s", tenant, key)
+	}
+
 	now := time.Now()
 
 	ch := make(chan channelResult, len(params.CompositeQuery.BuilderQueries))
@@ -213,6 +218,11 @@ func (q *querier) runPromQueries(ctx context.Context, params *v3.QueryRangeParam
 	channelResults := make(chan channelResult, len(params.CompositeQuery.PromQueries))
 	var wg sync.WaitGroup
 	cacheKeys := q.keyGenerator.GenerateKeys(params)
+
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+	for queryName, key := range cacheKeys {
+		cacheKeys[queryName] = fmt.Sprintf("tenant=%s&%s", tenant, key)
+	}
 
 	for queryName, promQuery := range params.CompositeQuery.PromQueries {
 		if promQuery.Disabled {
@@ -348,7 +358,7 @@ func (q *querier) runWindowBasedListQuery(ctx context.Context, params *v3.QueryR
 		// appending the filter to get the next set of data
 		if params.CompositeQuery.BuilderQueries[qName].DataSource == v3.DataSourceLogs {
 			params.CompositeQuery.BuilderQueries[qName].PageSize = pageSize - uint64(len(data))
-			queries, err := q.builder.PrepareQueries(params)
+			queries, err := q.builder.PrepareQueries(ctx, params)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -404,7 +414,7 @@ func (q *querier) runWindowBasedListQuery(ctx context.Context, params *v3.QueryR
 
 			params.CompositeQuery.BuilderQueries[qName].Offset = 0
 			params.CompositeQuery.BuilderQueries[qName].Limit = tracesLimit
-			queries, err := q.builder.PrepareQueries(params)
+			queries, err := q.builder.PrepareQueries(ctx, params)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -469,7 +479,7 @@ func (q *querier) runBuilderListQueries(ctx context.Context, params *v3.QueryRan
 	queries := make(map[string]string)
 	var err error
 	if params.CompositeQuery.QueryType == v3.QueryTypeBuilder {
-		queries, err = q.builder.PrepareQueries(params)
+		queries, err = q.builder.PrepareQueries(ctx, params)
 	} else if params.CompositeQuery.QueryType == v3.QueryTypeClickHouseSQL {
 		for name, chQuery := range params.CompositeQuery.ClickHouseQueries {
 			queries[name] = chQuery.Query

--- a/pkg/query-service/app/queryBuilder/query_builder_test.go
+++ b/pkg/query-service/app/queryBuilder/query_builder_test.go
@@ -54,7 +54,7 @@ func TestBuildQueryWithMultipleQueriesAndFormula(t *testing.T) {
 		fm := featureManager.StartManager()
 		qb := NewQueryBuilder(qbOptions, fm)
 
-		queries, err := qb.PrepareQueries(q)
+		queries, err := qb.PrepareQueries(nil, q)
 
 		require.NoError(t, err)
 
@@ -96,7 +96,7 @@ func TestBuildQueryWithIncorrectQueryRef(t *testing.T) {
 		fm := featureManager.StartManager()
 		qb := NewQueryBuilder(qbOptions, fm)
 
-		_, err := qb.PrepareQueries(q)
+		_, err := qb.PrepareQueries(nil, q)
 
 		require.NoError(t, err)
 	})
@@ -171,7 +171,7 @@ func TestBuildQueryWithThreeOrMoreQueriesRefAndFormula(t *testing.T) {
 		fm := featureManager.StartManager()
 		qb := NewQueryBuilder(qbOptions, fm)
 
-		queries, err := qb.PrepareQueries(q)
+		queries, err := qb.PrepareQueries(nil, q)
 
 		require.NoError(t, err)
 
@@ -341,7 +341,7 @@ func TestBuildQueryWithThreeOrMoreQueriesRefAndFormula(t *testing.T) {
 		fm := featureManager.StartManager()
 		qb := NewQueryBuilder(qbOptions, fm)
 
-		queries, err := qb.PrepareQueries(q)
+		queries, err := qb.PrepareQueries(nil, q)
 		require.Contains(t, queries["F1"], "SELECT A.`os.type` as `os.type`, A.`ts` as `ts`, A.value + B.value as value FROM (SELECT `os.type`,  toStartOfInterval(toDateTime(intDiv(unix_milli, 1000)), INTERVAL 60 SECOND) as ts, avg(value) as value FROM signoz_metrics.distributed_samples_v4 INNER JOIN (SELECT DISTINCT JSONExtractString(labels, 'os.type') as `os.type`, fingerprint FROM signoz_metrics.time_series_v4_1day WHERE metric_name = 'system.memory.usage' AND temporality = '' AND unix_milli >= 1734998400000 AND unix_milli < 1735637880000 AND JSONExtractString(labels, 'os.type') = 'linux') as filtered_time_series USING fingerprint WHERE metric_name = 'system.memory.usage' AND unix_milli >= 1735036080000 AND unix_milli < 1735637880000 GROUP BY `os.type`, ts ORDER BY `os.type` ASC, ts) as A  INNER JOIN (SELECT * FROM (SELECT `os.type`,  toStartOfInterval(toDateTime(intDiv(unix_milli, 1000)), INTERVAL 60 SECOND) as ts, sum(value) as value FROM signoz_metrics.distributed_samples_v4 INNER JOIN (SELECT DISTINCT JSONExtractString(labels, 'os.type') as `os.type`, fingerprint FROM signoz_metrics.time_series_v4_1day WHERE metric_name = 'system.network.io' AND temporality = '' AND unix_milli >= 1734998400000 AND unix_milli < 1735637880000) as filtered_time_series USING fingerprint WHERE metric_name = 'system.network.io' AND unix_milli >= 1735036020000 AND unix_milli < 1735637880000 GROUP BY `os.type`, ts ORDER BY `os.type` ASC, ts) HAVING value > 4) as B  ON A.`os.type` = B.`os.type` AND A.`ts` = B.`ts`")
 		require.NoError(t, err)
 
@@ -500,7 +500,7 @@ func TestDeltaQueryBuilder(t *testing.T) {
 			}
 			fm := featureManager.StartManager()
 			qb := NewQueryBuilder(qbOptions, fm)
-			queries, err := qb.PrepareQueries(c.query)
+			queries, err := qb.PrepareQueries(nil, c.query)
 
 			require.NoError(t, err)
 			require.Equal(t, c.expected, queries[c.queryToTest])
@@ -708,7 +708,7 @@ func TestLogsQueryWithFormula(t *testing.T) {
 
 	for _, test := range testLogsWithFormula {
 		t.Run(test.Name, func(t *testing.T) {
-			queries, err := qb.PrepareQueries(test.Query)
+			queries, err := qb.PrepareQueries(nil, test.Query)
 			require.NoError(t, err)
 			require.Equal(t, test.ExpectedQuery, queries["C"])
 		})
@@ -919,7 +919,7 @@ func TestLogsQueryWithFormulaV2(t *testing.T) {
 
 	for _, test := range testLogsWithFormulaV2 {
 		t.Run(test.Name, func(t *testing.T) {
-			queries, err := qb.PrepareQueries(test.Query)
+			queries, err := qb.PrepareQueries(nil, test.Query)
 			require.NoError(t, err)
 			require.Equal(t, test.ExpectedQuery, queries["C"])
 		})

--- a/pkg/query-service/app/traces/v3/query_builder.go
+++ b/pkg/query-service/app/traces/v3/query_builder.go
@@ -1,6 +1,7 @@
 package v3
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strings"
@@ -499,7 +500,7 @@ func AddOffsetToQuery(query string, offset uint64) string {
 // PrepareTracesQuery returns the query string for traces
 // start and end are in epoch millisecond
 // step is in seconds
-func PrepareTracesQuery(start, end int64, panelType v3.PanelType, mq *v3.BuilderQuery, options v3.QBOptions) (string, error) {
+func PrepareTracesQuery(_ context.Context, start, end int64, panelType v3.PanelType, mq *v3.BuilderQuery, options v3.QBOptions) (string, error) {
 	// adjust the start and end time to the step interval
 	if panelType == v3.PanelTypeGraph {
 		// adjust the start and end time to the step interval for graph panel types

--- a/pkg/query-service/app/traces/v4/query_builder.go
+++ b/pkg/query-service/app/traces/v4/query_builder.go
@@ -1,6 +1,7 @@
 package v4
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -213,6 +214,10 @@ func orderByAttributeKeyTags(panelType v3.PanelType, items []v3.OrderBy, tags []
 	return str
 }
 
+func tracesView(tenant string, bucketStartSeconds, bucketEndSeconds int64) string {
+	return fmt.Sprintf("%s (tenant='%s', window_start='%d', window_end='%d')", constants.TENANT_TRACES_INDEX_RES_VIEW, tenant, bucketStartSeconds, bucketEndSeconds)
+}
+
 func buildSpanScopeQuery(fs *v3.FilterSet) (string, error) {
 	var query string
 	if fs == nil || len(fs.Items) == 0 {
@@ -238,7 +243,9 @@ func buildSpanScopeQuery(fs *v3.FilterSet) (string, error) {
 	return "", nil
 }
 
-func buildTracesQuery(start, end, step int64, mq *v3.BuilderQuery, panelType v3.PanelType, options v3.QBOptions) (string, error) {
+func buildTracesQuery(ctx context.Context, start, end, step int64, mq *v3.BuilderQuery, panelType v3.PanelType, options v3.QBOptions) (string, error) {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+
 	tracesStart := utils.GetEpochNanoSecs(start)
 	tracesEnd := utils.GetEpochNanoSecs(end)
 
@@ -292,12 +299,12 @@ func buildTracesQuery(start, end, step int64, mq *v3.BuilderQuery, panelType v3.
 	if mq.AggregateOperator == v3.AggregateOperatorNoOp {
 		var query string
 		if panelType == v3.PanelTypeTrace {
-			withSubQuery := fmt.Sprintf(constants.TracesExplorerViewSQLSelectWithSubQuery, constants.SIGNOZ_TRACE_DBNAME, constants.SIGNOZ_SPAN_INDEX_V3_LOCAL_TABLENAME, timeFilter)
-			afterSubQuery := tracesV3.AddLimitToQuery(constants.TracesExplorerViewSQLSelectAfterSubQuery, mq.Limit)
+			withSubQuery := fmt.Sprintf(constants.TracesExplorerViewSQLSelectWithSubQuery, constants.SIGNOZ_TRACE_DBNAME, tracesView(tenant, bucketStart, bucketEnd), timeFilter, filterSubQuery)
+			afterSubQuery := tracesV3.AddLimitToQuery(withSubQuery, mq.Limit)
 			if mq.Offset != 0 {
 				afterSubQuery = tracesV3.AddOffsetToQuery(afterSubQuery, mq.Offset)
 			}
-			query = fmt.Sprintf(constants.TracesExplorerViewSQLSelectBeforeSubQuery, constants.SIGNOZ_TRACE_DBNAME, constants.SIGNOZ_SPAN_INDEX_V3) + withSubQuery + ") " + fmt.Sprintf(afterSubQuery, constants.SIGNOZ_TRACE_DBNAME, constants.SIGNOZ_SPAN_INDEX_V3, timeFilter, filterSubQuery)
+			query = fmt.Sprintf(constants.TracesExplorerViewSQLSelectBeforeSubQuery, constants.SIGNOZ_TRACE_DBNAME, tracesView(tenant, bucketStart, bucketEnd)) + withSubQuery + ") " + fmt.Sprintf(afterSubQuery, constants.SIGNOZ_TRACE_DBNAME, constants.SIGNOZ_SPAN_INDEX_V3, timeFilter)
 			// adding this to avoid the distributed product mode error which doesn't allow global in
 			query += " settings distributed_product_mode='allow', max_memory_usage=10000000000"
 		} else if panelType == v3.PanelTypeList {
@@ -306,7 +313,8 @@ func buildTracesQuery(start, end, step int64, mq *v3.BuilderQuery, panelType v3.
 			}
 			selectLabels = getSelectLabels(mq.SelectColumns)
 			// add it to the select labels
-			queryNoOpTmpl := fmt.Sprintf("SELECT timestamp as timestamp_datetime, spanID, traceID,%s ", selectLabels) + "from " + constants.SIGNOZ_TRACE_DBNAME + "." + constants.SIGNOZ_SPAN_INDEX_V3 + " where %s %s" + "%s"
+			selectLabels = getSelectLabels(mq.SelectColumns)
+			queryNoOpTmpl := fmt.Sprintf("SELECT timestamp as timestamp_datetime, spanID, traceID,%s ", selectLabels) + "from " + constants.SIGNOZ_TRACE_DBNAME + "." + tracesView(tenant, bucketStart, bucketEnd) + " where %s %s" + "%s"
 			query = fmt.Sprintf(queryNoOpTmpl, timeFilter, filterSubQuery, orderBy)
 		} else {
 			return "", fmt.Errorf("unsupported aggregate operator %s for panelType %s", mq.AggregateOperator, panelType)
@@ -344,7 +352,7 @@ func buildTracesQuery(start, end, step int64, mq *v3.BuilderQuery, panelType v3.
 
 	queryTmpl = queryTmpl + selectLabels +
 		" %s as value " +
-		"from " + constants.SIGNOZ_TRACE_DBNAME + "." + constants.SIGNOZ_SPAN_INDEX_V3 +
+		"from " + constants.SIGNOZ_TRACE_DBNAME + "." + tracesView(tenant, bucketStart, bucketEnd) +
 		" where " + timeFilter + "%s" +
 		"%s%s" +
 		"%s"
@@ -418,7 +426,8 @@ func buildTracesQuery(start, end, step int64, mq *v3.BuilderQuery, panelType v3.
 // PrepareTracesQuery returns the query string for traces
 // start and end are in epoch millisecond
 // step is in seconds
-func PrepareTracesQuery(start, end int64, panelType v3.PanelType, mq *v3.BuilderQuery, options v3.QBOptions) (string, error) {
+func PrepareTracesQuery(ctx context.Context, start, end int64, panelType v3.PanelType, mq *v3.BuilderQuery, options v3.QBOptions) (string, error) {
+
 	// adjust the start and end time to the step interval
 	if panelType == v3.PanelTypeGraph {
 		// adjust the start and end time to the step interval for graph panel types
@@ -427,22 +436,22 @@ func PrepareTracesQuery(start, end int64, panelType v3.PanelType, mq *v3.Builder
 	}
 	if options.GraphLimitQtype == constants.FirstQueryGraphLimit {
 		// give me just the group by names
-		query, err := buildTracesQuery(start, end, mq.StepInterval, mq, panelType, options)
+		query, err := buildTracesQuery(ctx, start, end, mq.StepInterval, mq, panelType, options)
 		if err != nil {
 			return "", err
 		}
 		query = tracesV3.AddLimitToQuery(query, mq.Limit)
 
-		return query, nil
+		return query + constants.UseAliasesInViewSettings, nil
 	} else if options.GraphLimitQtype == constants.SecondQueryGraphLimit {
-		query, err := buildTracesQuery(start, end, mq.StepInterval, mq, panelType, options)
+		query, err := buildTracesQuery(ctx, start, end, mq.StepInterval, mq, panelType, options)
 		if err != nil {
 			return "", err
 		}
-		return query, nil
+		return query + constants.UseAliasesInViewSettings, nil
 	}
 
-	query, err := buildTracesQuery(start, end, mq.StepInterval, mq, panelType, options)
+	query, err := buildTracesQuery(ctx, start, end, mq.StepInterval, mq, panelType, options)
 	if err != nil {
 		return "", err
 	}
@@ -456,5 +465,5 @@ func PrepareTracesQuery(start, end int64, panelType v3.PanelType, mq *v3.Builder
 			query = tracesV3.AddOffsetToQuery(query, mq.Offset)
 		}
 	}
-	return query, err
+	return query + constants.UseAliasesInViewSettings, err
 }

--- a/pkg/query-service/common/user.go
+++ b/pkg/query-service/common/user.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 
 	"go.signoz.io/signoz/pkg/query-service/constants"
 	"go.signoz.io/signoz/pkg/query-service/model"
@@ -13,4 +14,10 @@ func GetUserFromContext(ctx context.Context) *model.UserPayload {
 		return nil
 	}
 	return user
+}
+
+func TenantSqlPredicate(ctx context.Context) string {
+	tenant := ctx.Value(constants.ContextTenantKey).(string)
+	return fmt.Sprintf(` created_by IN (SELECT u.email FROM users u INNER JOIN organizations o ON u.org_id = o.id WHERE o.name = '%s')`,
+		tenant)
 }

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	chprom "github.com/prometheus/prometheus/storage/clickhouse"
 	"maps"
 	"os"
 	"strconv"
@@ -21,6 +22,8 @@ const (
 type ContextKey string
 
 const ContextUserKey ContextKey = "user"
+
+const ContextTenantKey = chprom.ContextTenantKey
 
 var ConfigSignozIo = "https://config.signoz.io/api/v1"
 
@@ -151,6 +154,13 @@ var DEFAULT_FEATURE_SET = model.FeatureSet{
 		UsageLimit: -1,
 		Route:      "",
 	},
+	model.Feature{
+		Name:       model.AlertChannelWebhook,
+		Active:     true,
+		Usage:      0,
+		UsageLimit: -1,
+		Route:      "",
+	},
 }
 
 func GetEvalDelay() time.Duration {
@@ -232,6 +242,26 @@ const (
 	SIGNOZ_TIMESERIES_v4_1DAY_TABLENAME        = "distributed_time_series_v4_1day"
 	SIGNOZ_TOP_LEVEL_OPERATIONS_TABLENAME      = "distributed_top_level_operations"
 )
+
+const (
+	TENANT_LOGS_VIEW          = "logs_view"
+	TENANT_LOGS_RESOURCE_VIEW = "logs_resource_view"
+	TENANT_LOGS_TAG_ATTR_VIEW = "tag_attributes_tenant_view"
+
+	TENANT_TRACES_INDEX_VIEW       = "signoz_index_view"
+	TENANT_TRACES_INDEX_RES_VIEW   = "signoz_index_resource_view"
+	TENANT_TRACES_ERROR_INDEX_VIEW = "signoz_error_index_view"
+	TENANT_TRACES_TL_OPS_VIEW      = "top_level_operations_view"
+	TENANT_TRACES_ATTR_KEYS_VIEW   = "span_attributes_keys_tenant_view"
+	TENANT_TRACES_TAG_ATTR_VEIW    = "tag_attributes_tenant_view"
+
+	UseAliasesInViewSettings = " SETTINGS asterisk_include_alias_columns=1"
+)
+
+var TimeoutExcludedRoutes = map[string]bool{
+	"/api/v1/logs/tail":     true,
+	"/api/v3/logs/livetail": true,
+}
 
 // alert related constants
 const (

--- a/pkg/query-service/rules/test_notification.go
+++ b/pkg/query-service/rules/test_notification.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"context"
 	"fmt"
+	"go.signoz.io/signoz/pkg/query-service/constants"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,6 +17,7 @@ import (
 func defaultTestNotification(opts PrepareTestRuleOptions) (int, *model.ApiError) {
 
 	ctx := context.Background()
+	ctx = context.WithValue(ctx, constants.ContextTenantKey, opts.Tenant)
 
 	if opts.Rule == nil {
 		return 0, model.BadRequest(fmt.Errorf("rule is required"))

--- a/pkg/signoz/config.go
+++ b/pkg/signoz/config.go
@@ -137,6 +137,11 @@ func mergeAndEnsureBackwardCompatibility(config *Config, deprecatedFlags Depreca
 		config.TelemetryStore.ClickHouse.DSN = os.Getenv("ClickHouseUrl")
 	}
 
+	if os.Getenv("TenantClickHouseUrl") != "" {
+		fmt.Println("[Deprecated] env TenantClickHouseUrl is deprecated and scheduled for removal...")
+		config.TelemetryStore.ClickHouse.TenantDSN = os.Getenv("TenantClickHouseUrl")
+	}
+
 	if deprecatedFlags.MaxIdleConns != 50 {
 		fmt.Println("[Deprecated] flag --max-idle-conns is deprecated and scheduled for removal. Please use SIGNOZ_TELEMETRYSTORE_MAX__IDLE__CONNS env variable instead.")
 		config.TelemetryStore.Connection.MaxIdleConns = deprecatedFlags.MaxIdleConns

--- a/pkg/sqlmigration/003_add_dashboards.go
+++ b/pkg/sqlmigration/003_add_dashboards.go
@@ -2,7 +2,6 @@ package sqlmigration
 
 import (
 	"context"
-
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/migrate"
 	"go.signoz.io/signoz/pkg/factory"
@@ -56,11 +55,13 @@ func (migration *addDashboards) Up(ctx context.Context, db *bun.DB) error {
 		name TEXT NOT NULL UNIQUE,
 		type TEXT NOT NULL,
 		deleted INTEGER DEFAULT 0,
-		data TEXT NOT NULL
+		data TEXT NOT NULL,
+		created_by TEXT
 	);`); err != nil {
 		return err
 	}
-
+	// TODO: de-uniqueify 'name' column for full multi-tenant, and move created_by column addition to migration
+	
 	// table:planned_maintenance
 	if _, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS planned_maintenance (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/pkg/telemetrystore/config.go
+++ b/pkg/telemetrystore/config.go
@@ -32,7 +32,8 @@ type ClickHouseQuerySettings struct {
 }
 
 type ClickHouseConfig struct {
-	DSN string `mapstructure:"dsn"`
+	DSN       string `mapstructure:"dsn"`
+	TenantDSN string
 
 	QuerySettings ClickHouseQuerySettings `mapstructure:"settings"`
 }

--- a/pkg/telemetrystore/telemetrystore.go
+++ b/pkg/telemetrystore/telemetrystore.go
@@ -9,6 +9,7 @@ import (
 
 type TelemetryStore interface {
 	ClickHouseDB() clickhouse.Conn
+	TenantClickHouseDB() clickhouse.Conn
 }
 
 type TelemetryStoreHook interface {


### PR DESCRIPTION
### Summary

This PR offers shared-instance multi-tenancy for SigNoz. It is not ready to be merged in its current form, but it is functional, and it meets my company's needs for multi-tenancy in our environment.

I am opening the PR to get feedback from owners and see if this is a direction the project wants to go, and hopefully find alignment before doing more preparation for merging. I'm not picky about or attached to the design. If there are aspects of design you'd like to see changed, I can spend some amount of time to make changes. I'm on #contributing in Slack.

#### Related Issues / PR's

- https://github.com/SigNoz/signoz/discussions/1471
- Multi-Tenancy has also been listed on the product roadmap on the website.

#### Design Sketch

The scope of changes include:
- identifying the tenant associated with a request
- authorizing and isolating access to telemetry data in ClickHouse for the tenant
- authorizing and isolating access to user data in sqlite by tenant

##### Tenant identity
- We assume there is exactly one tenant associated with a given request for a given user. The tenant is identified by a string.
- This current implementation assumes the tenant is the Organization.
- The tenant is plumbed through the system where needed, in some places as a direct function parameter, and in others as a Context value.
- The tenant is sent through Context to the custom Prometheus ClickHouse metrics reader and applied in the SQL there as well.
- Tenant is also applied as a key to the query cache lookups.

##### Telemetry data
- We define ClickHouse parameterized views to "protect" the base tables. The views take the tenant as a parameter.
  - The views are used as drop-in replacements for the base tables in many places in the query service.
  - Some of the views also take the time window as parameters for performance reasons. In theory this might not be necessary as the ClickHouse query optimizer could push the predicates down, but when I checked for that I was not seeing reassuring query plans.
  - As an alternative to parameterized views, we could include the tenant filter in the dynamic SQL built inside the query service. There are pros and cons to both approaches we could discuss further (security, coupling, flexibility, performance, etc.)
- The views can be defined differently on the back end to implement tenancy in different ways. This may or may not be an advantage depending on the direction the project wants to take.
  - This gist contains "noop" views I used for local testing: https://gist.github.com/mgilham/55c4c746eb2d9b6320b77bca3b39bf90
  - In my company's full environment, we take the tenant to be either the Kubernetes namespace from the resource tags, or a prefix of the otel `service.name`.
- In some cases we add columns in or on top of the existing base tables to materialize the tenant identifier.
- As an alternative, we could simplify the design and view logic by establishing a common standard column for all relevant tables. This would require more table changes, but the simplicity could be worthwhile. For the telemetry intake, I would recommend considering the otel `service.namespace`, which would help in de-duplicating `service.name` across tenants.

##### User data in sqllite
- Filters are added to restrict all CRUD operations to the organization of the user making the request.

#### Open Items
- Custom user ClickHouse queries are not yet isolated.
  - This is mostly implemented in this PR, but the version of ClickHouse would need to upgrade to support SQL security settings to allow users to query the views without access to the base tables.
  - Custom queries are parsed to ensure the `tenant` parameter to the views match the authenticated tenant for the request. This parsing could be improved upon for generality, or discarded in favor of an alternate solution, e.g. custom per-tenant views.
- Tests still need to be updated
- Infra metrics
- SigNoz internal telemetry for multiple orgs?
- New Role for a meta-admin that can access data for all tenants?