### PR TITLE
chore: also use signoz_api_key from connection params

### DIFF
--- a/frontend/src/container/CloudIntegrationPage/HeroSection/components/RenderConnectionParams.tsx
+++ b/frontend/src/container/CloudIntegrationPage/HeroSection/components/RenderConnectionParams.tsx
@@ -14,7 +14,8 @@ function RenderConnectionFields({
 		isConnectionParamsLoading ||
 		(!!connectionParams?.ingestion_url &&
 			!!connectionParams?.ingestion_key &&
-			!!connectionParams?.signoz_api_url)
+			!!connectionParams?.signoz_api_url &&
+			!!connectionParams?.signoz_api_key)
 	) {
 		return null;
 	}
@@ -46,6 +47,15 @@ function RenderConnectionFields({
 					rules={[{ required: true, message: 'Please enter SigNoz API URL' }]}
 				>
 					<Input placeholder="Enter SigNoz API URL" disabled={isFormDisabled} />
+				</Form.Item>
+			)}
+			{!connectionParams?.signoz_api_key && (
+				<Form.Item
+					name="signoz_api_key"
+					label="SigNoz API KEY"
+					rules={[{ required: true, message: 'Please enter SigNoz API Key' }]}
+				>
+					<Input placeholder="Enter SigNoz API Key" disabled={isFormDisabled} />
 				</Form.Item>
 			)}
 		</Form.Item>

--- a/frontend/src/hooks/integrations/aws/useIntegrationModal.ts
+++ b/frontend/src/hooks/integrations/aws/useIntegrationModal.ts
@@ -140,6 +140,7 @@ export function useIntegrationModal({
 					ingestion_url: connectionParams?.ingestion_url || values.ingestion_url,
 					ingestion_key: connectionParams?.ingestion_key || values.ingestion_key,
 					signoz_api_url: connectionParams?.signoz_api_url || values.signoz_api_url,
+					signoz_api_key: connectionParams?.signoz_api_key || values.signoz_api_key,
 				},
 				account_config: {
 					regions: includeAllRegions ? ['all'] : selectedRegions,

--- a/frontend/src/types/api/integrations/aws.ts
+++ b/frontend/src/types/api/integrations/aws.ts
@@ -4,6 +4,7 @@ export interface ConnectionParams {
 	ingestion_url?: string;
 	ingestion_key?: string;
 	signoz_api_url?: string;
+	signoz_api_key?: string;
 }
 
 export interface GenerateConnectionUrlPayload {


### PR DESCRIPTION
### Summary

Includes SigNoz API key connection param when generating AWS account connection url

#### Related Issues / PR's

contributes to https://github.com/SigNoz/engineering-pod/issues/2023


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `signoz_api_key` in AWS connection parameters, updating UI and logic to handle the new field.
> 
>   - **Behavior**:
>     - Include `signoz_api_key` in connection parameters check in `RenderConnectionFields`.
>     - Add input field for `signoz_api_key` in `RenderConnectionFields` if not present.
>     - Update `useIntegrationModal` to include `signoz_api_key` in `agent_config` when generating connection URL.
>   - **Types**:
>     - Add `signoz_api_key` to `ConnectionParams` in `aws.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 067f41cc7fbf1989f4ce191747f615c8c342d1e1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->