### PR TITLE
fix(otelcol): rename clickhousemetricswritev2 to signozclickhousemetrics

### DIFF
--- a/deploy/docker-swarm/otel-collector-config.yaml
+++ b/deploy/docker-swarm/otel-collector-config.yaml
@@ -66,7 +66,7 @@ exporters:
       enabled: true
   clickhousemetricswrite/prometheus:
     endpoint: tcp://clickhouse:9000/signoz_metrics
-  clickhousemetricswritev2:
+  signozclickhousemetrics:
     dsn: tcp://clickhouse:9000/signoz_metrics
   clickhouselogsexporter:
     dsn: tcp://clickhouse:9000/signoz_logs
@@ -90,11 +90,11 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [clickhousemetricswrite, clickhousemetricswritev2]
+      exporters: [clickhousemetricswrite, signozclickhousemetrics]
     metrics/prometheus:
       receivers: [prometheus]
       processors: [batch]
-      exporters: [clickhousemetricswrite/prometheus, clickhousemetricswritev2]
+      exporters: [clickhousemetricswrite/prometheus, signozclickhousemetrics]
     logs:
       receivers: [otlp]
       processors: [batch]

--- a/deploy/docker/otel-collector-config.yaml
+++ b/deploy/docker/otel-collector-config.yaml
@@ -66,7 +66,7 @@ exporters:
       enabled: true
   clickhousemetricswrite/prometheus:
     endpoint: tcp://clickhouse:9000/signoz_metrics
-  clickhousemetricswritev2:
+  signozclickhousemetrics:
     dsn: tcp://clickhouse:9000/signoz_metrics
   clickhouselogsexporter:
     dsn: tcp://clickhouse:9000/signoz_logs
@@ -90,11 +90,11 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [clickhousemetricswrite, clickhousemetricswritev2]
+      exporters: [clickhousemetricswrite, signozclickhousemetrics]
     metrics/prometheus:
       receivers: [prometheus]
       processors: [batch]
-      exporters: [clickhousemetricswrite/prometheus, clickhousemetricswritev2]
+      exporters: [clickhousemetricswrite/prometheus, signozclickhousemetrics]
     logs:
       receivers: [otlp]
       processors: [batch]


### PR DESCRIPTION
### Summary

- rename exporter `clickhousemetricswritev2` to `signozclickhousemetrics` in collector config
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename `clickhousemetricswritev2` exporter to `signozclickhousemetrics` in `otel-collector-config.yaml` files.
> 
>   - **Rename Exporter**:
>     - Rename `clickhousemetricswritev2` to `signozclickhousemetrics` in `otel-collector-config.yaml` in both `deploy/docker-swarm` and `deploy/docker` directories.
>     - Update exporter references in metrics pipelines to use `signozclickhousemetrics`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 43ff7582ea10aef4f3a96d45357496bda026539f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->