### PR TITLE
fix(otelcol): remove the v2 metrics exporter configuration

### DIFF
--- a/deploy/docker-swarm/otel-collector-config.yaml
+++ b/deploy/docker-swarm/otel-collector-config.yaml
@@ -66,8 +66,6 @@ exporters:
       enabled: true
   clickhousemetricswrite/prometheus:
     endpoint: tcp://clickhouse:9000/signoz_metrics
-  signozclickhousemetrics:
-    dsn: tcp://clickhouse:9000/signoz_metrics
   clickhouselogsexporter:
     dsn: tcp://clickhouse:9000/signoz_logs
     timeout: 10s
@@ -90,11 +88,11 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [clickhousemetricswrite, signozclickhousemetrics]
+      exporters: [clickhousemetricswrite]
     metrics/prometheus:
       receivers: [prometheus]
       processors: [batch]
-      exporters: [clickhousemetricswrite/prometheus, signozclickhousemetrics]
+      exporters: [clickhousemetricswrite/prometheus]
     logs:
       receivers: [otlp]
       processors: [batch]

--- a/deploy/docker/otel-collector-config.yaml
+++ b/deploy/docker/otel-collector-config.yaml
@@ -66,8 +66,6 @@ exporters:
       enabled: true
   clickhousemetricswrite/prometheus:
     endpoint: tcp://clickhouse:9000/signoz_metrics
-  signozclickhousemetrics:
-    dsn: tcp://clickhouse:9000/signoz_metrics
   clickhouselogsexporter:
     dsn: tcp://clickhouse:9000/signoz_logs
     timeout: 10s
@@ -90,11 +88,11 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [clickhousemetricswrite, signozclickhousemetrics]
+      exporters: [clickhousemetricswrite]
     metrics/prometheus:
       receivers: [prometheus]
       processors: [batch]
-      exporters: [clickhousemetricswrite/prometheus, signozclickhousemetrics]
+      exporters: [clickhousemetricswrite/prometheus]
     logs:
       receivers: [otlp]
       processors: [batch]


### PR DESCRIPTION
### Summary

- remove the unused metrics exporter `signozclickhousemetrics` (previously `clickhousemetricswritev2`)  in otel-collector configuration.

#### Related Issues / PR's

- #7099
- #7102

#### Screenshots

NA

#### Affected Areas and Manually Tested Areas

NA
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused `signozclickhousemetrics` exporter from `otel-collector-config.yaml` in `deploy/docker-swarm` and `deploy/docker`.
> 
>   - **Configuration Changes**:
>     - Remove `signozclickhousemetrics` exporter from `otel-collector-config.yaml` in `deploy/docker-swarm` and `deploy/docker`.
>     - Update `metrics` and `metrics/prometheus` pipelines to exclude `signozclickhousemetrics` exporter in both files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for cdca47b3dac01e3513f3c332ebaaf9d10182cf52. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->