### PR TITLE
fix: fixed widgets not visible after saving in the dashboard detail

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCardLayout.tsx
+++ b/frontend/src/container/GridCardLayout/GridCardLayout.tsx
@@ -66,6 +66,7 @@ function GraphLayout(props: GraphLayoutProps): JSX.Element {
 		dashboardQueryRangeCalled,
 		setDashboardQueryRangeCalled,
 		setSelectedRowWidgetId,
+		isDashboardFetching,
 	} = useDashboard();
 	const { data } = selectedDashboard || {};
 	const { pathname } = useLocation();
@@ -231,7 +232,8 @@ function GraphLayout(props: GraphLayoutProps): JSX.Element {
 			!isEqual(layouts, dashboardLayout) &&
 			!isDashboardLocked &&
 			saveLayoutPermission &&
-			!updateDashboardMutation.isLoading
+			!updateDashboardMutation.isLoading &&
+			!isDashboardFetching
 		) {
 			onSaveHandler();
 		}

--- a/frontend/src/providers/Dashboard/Dashboard.tsx
+++ b/frontend/src/providers/Dashboard/Dashboard.tsx
@@ -73,6 +73,7 @@ const DashboardContext = createContext<IDashboardContext>({
 	setDashboardQueryRangeCalled: () => {},
 	selectedRowWidgetId: '',
 	setSelectedRowWidgetId: () => {},
+	isDashboardFetching: false,
 });
 
 interface Props {
@@ -192,6 +193,8 @@ export function DashboardProvider({
 	const { t } = useTranslation(['dashboard']);
 	const dashboardRef = useRef<Dashboard>();
 
+	const [isDashboardFetching, setIsDashboardFetching] = useState<boolean>(false);
+
 	const mergeDBWithLocalStorage = (
 		data: Dashboard,
 		localStorageVariables: any,
@@ -256,10 +259,16 @@ export function DashboardProvider({
 		[REACT_QUERY_KEY.DASHBOARD_BY_ID, isDashboardPage?.params],
 		{
 			enabled: (!!isDashboardPage || !!isDashboardWidgetPage) && isLoggedIn,
-			queryFn: () =>
-				getDashboard({
-					uuid: dashboardId,
-				}),
+			queryFn: async () => {
+				setIsDashboardFetching(true);
+				try {
+					return await getDashboard({
+						uuid: dashboardId,
+					});
+				} finally {
+					setIsDashboardFetching(false);
+				}
+			},
 			refetchOnWindowFocus: false,
 			onSuccess: (data) => {
 				const updatedDashboardData = transformDashboardVariables(data);
@@ -424,6 +433,7 @@ export function DashboardProvider({
 			setDashboardQueryRangeCalled,
 			selectedRowWidgetId,
 			setSelectedRowWidgetId,
+			isDashboardFetching,
 		}),
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[
@@ -445,6 +455,7 @@ export function DashboardProvider({
 			setDashboardQueryRangeCalled,
 			selectedRowWidgetId,
 			setSelectedRowWidgetId,
+			isDashboardFetching,
 		],
 	);
 

--- a/frontend/src/providers/Dashboard/types.ts
+++ b/frontend/src/providers/Dashboard/types.ts
@@ -47,4 +47,5 @@ export interface IDashboardContext {
 	setDashboardQueryRangeCalled: (value: boolean) => void;
 	selectedRowWidgetId: string | null;
 	setSelectedRowWidgetId: React.Dispatch<React.SetStateAction<string | null>>;
+	isDashboardFetching: boolean;
 }


### PR DESCRIPTION
### Summary

Here we had a race condition in maintaining 2 interdependent variables `dashboardLayout` and `layouts` caused by the parallel execution of the get and put calls triggered from different sources.

> The get API gets called with the updated values and returns the correct result. Meanwhile, the put call doesn't wait for the get call to finish and update the variables; rather, it continues with the older value. In those cases when the put call finishes after the get call, it overrides the updated value. Hence, we see the widget coming and then going away.

#### Related Issues / PR's

- https://github.com/SigNoz/signoz/issues/6947

Solves following customer issues:
- https://signoz-team.slack.com/archives/C02C7P6KE06/p1728319342518089
- https://signoz-team.slack.com/archives/C02B85R4R0A/p1728367047032009


#### Screenshots

Before:
--------------
https://github.com/user-attachments/assets/c6deee0e-3651-4985-82fd-0d7264bfad30


After: 
--------------
https://github.com/user-attachments/assets/b9eb7c39-692e-4254-8855-7655bf9d4464



#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix widgets visibility issue by adding `isDashboardFetching` check in `GridCardLayout.tsx` and updating dashboard context in `Dashboard.tsx`.
> 
>   - **Behavior**:
>     - Add `isDashboardFetching` check in `GraphLayout` in `GridCardLayout.tsx` to prevent saving layout during fetch.
>     - Modify `useDashboard` in `Dashboard.tsx` to set `isDashboardFetching` state during dashboard data fetch.
>   - **Context**:
>     - Add `isDashboardFetching` to `IDashboardContext` in `types.ts` and `Dashboard.tsx`.
>   - **Misc**:
>     - Update `DashboardProvider` in `Dashboard.tsx` to manage `isDashboardFetching` state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 98ec6168e3e06008b538fdc0e5949f18dd77294c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->