### PR TITLE
Revert "fix(otelcol): remove the v2 metrics exporter configuration (#…   …7105)"

### DIFF
--- a/deploy/docker-swarm/docker-compose.ha.yaml
+++ b/deploy/docker-swarm/docker-compose.ha.yaml
@@ -224,7 +224,7 @@ services:
       - ../common/signoz/nginx-config.conf:/etc/nginx/conf.d/default.conf
   otel-collector:
     !!merge <<: *db-depend
-    image: signoz/signoz-otel-collector:0.111.27
+    image: signoz/signoz-otel-collector:0.111.28
     command:
       - --config=/etc/otel-collector-config.yaml
       - --manager-config=/etc/manager-config.yaml
@@ -248,7 +248,7 @@ services:
       - query-service
   schema-migrator:
     !!merge <<: *common
-    image: signoz/signoz-schema-migrator:0.111.24
+    image: signoz/signoz-schema-migrator:0.111.28
     deploy:
       restart_policy:
         condition: on-failure

--- a/deploy/docker-swarm/docker-compose.yaml
+++ b/deploy/docker-swarm/docker-compose.yaml
@@ -160,7 +160,7 @@ services:
       - ../common/signoz/nginx-config.conf:/etc/nginx/conf.d/default.conf
   otel-collector:
     !!merge <<: *db-depend
-    image: signoz/signoz-otel-collector:0.111.27
+    image: signoz/signoz-otel-collector:0.111.28
     command:
       - --config=/etc/otel-collector-config.yaml
       - --manager-config=/etc/manager-config.yaml
@@ -184,7 +184,7 @@ services:
       - query-service
   schema-migrator:
     !!merge <<: *common
-    image: signoz/signoz-schema-migrator:0.111.24
+    image: signoz/signoz-schema-migrator:0.111.28
     deploy:
       restart_policy:
         condition: on-failure

--- a/deploy/docker-swarm/otel-collector-config.yaml
+++ b/deploy/docker-swarm/otel-collector-config.yaml
@@ -66,6 +66,8 @@ exporters:
       enabled: true
   clickhousemetricswrite/prometheus:
     endpoint: tcp://clickhouse:9000/signoz_metrics
+  signozclickhousemetrics:
+    dsn: tcp://clickhouse:9000/signoz_metrics
   clickhouselogsexporter:
     dsn: tcp://clickhouse:9000/signoz_logs
     timeout: 10s
@@ -88,11 +90,11 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [clickhousemetricswrite]
+      exporters: [clickhousemetricswrite, signozclickhousemetrics]
     metrics/prometheus:
       receivers: [prometheus]
       processors: [batch]
-      exporters: [clickhousemetricswrite/prometheus]
+      exporters: [clickhousemetricswrite/prometheus, signozclickhousemetrics]
     logs:
       receivers: [otlp]
       processors: [batch]

--- a/deploy/docker/docker-compose.ha.yaml
+++ b/deploy/docker/docker-compose.ha.yaml
@@ -234,7 +234,7 @@ services:
   # TODO: support otel-collector multiple replicas. Nginx/Traefik for loadbalancing?
   otel-collector:
     !!merge <<: *db-depend
-    image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.111.27}
+    image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.111.28}
     container_name: signoz-otel-collector
     command:
       - --config=/etc/otel-collector-config.yaml
@@ -260,7 +260,7 @@ services:
         condition: service_healthy
   schema-migrator-sync:
     !!merge <<: *common
-    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.24}
+    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.28}
     container_name: schema-migrator-sync
     command:
       - sync
@@ -271,7 +271,7 @@ services:
         condition: service_healthy
   schema-migrator-async:
     !!merge <<: *db-depend
-    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.24}
+    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.28}
     container_name: schema-migrator-async
     command:
       - async

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -166,7 +166,7 @@ services:
       - ../common/signoz/nginx-config.conf:/etc/nginx/conf.d/default.conf
   otel-collector:
     !!merge <<: *db-depend
-    image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.111.27}
+    image: signoz/signoz-otel-collector:${OTELCOL_TAG:-0.111.28}
     container_name: signoz-otel-collector
     command:
       - --config=/etc/otel-collector-config.yaml
@@ -188,7 +188,7 @@ services:
         condition: service_healthy
   schema-migrator-sync:
     !!merge <<: *common
-    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.24}
+    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.28}
     container_name: schema-migrator-sync
     command:
       - sync
@@ -199,7 +199,7 @@ services:
         condition: service_healthy
   schema-migrator-async:
     !!merge <<: *db-depend
-    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.24}
+    image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.28}
     container_name: schema-migrator-async
     command:
       - async

--- a/deploy/docker/otel-collector-config.yaml
+++ b/deploy/docker/otel-collector-config.yaml
@@ -66,6 +66,8 @@ exporters:
       enabled: true
   clickhousemetricswrite/prometheus:
     endpoint: tcp://clickhouse:9000/signoz_metrics
+  signozclickhousemetrics:
+    dsn: tcp://clickhouse:9000/signoz_metrics
   clickhouselogsexporter:
     dsn: tcp://clickhouse:9000/signoz_logs
     timeout: 10s
@@ -88,11 +90,11 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [clickhousemetricswrite]
+      exporters: [clickhousemetricswrite, signozclickhousemetrics]
     metrics/prometheus:
       receivers: [prometheus]
       processors: [batch]
-      exporters: [clickhousemetricswrite/prometheus]
+      exporters: [clickhousemetricswrite/prometheus, signozclickhousemetrics]
     logs:
       receivers: [otlp]
       processors: [batch]


### PR DESCRIPTION
### Summary

This reverts commit 846b6a9 and updates the collector version.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts a previous commit, updates OpenTelemetry Collector and schema migrator versions, and adds a new metrics exporter configuration.
> 
>   - **Revert**:
>     - Reverts commit `846b6a9` which removed the v2 metrics exporter configuration.
>   - **Version Updates**:
>     - Updates `otel-collector` image to `signoz/signoz-otel-collector:0.111.28` in `docker-compose.ha.yaml` and `docker-compose.yaml`.
>     - Updates `schema-migrator` image to `signoz/signoz-schema-migrator:0.111.28` in `docker-compose.ha.yaml` and `docker-compose.yaml`.
>   - **Configuration Changes**:
>     - Adds `signozclickhousemetrics` exporter in `otel-collector-config.yaml`.
>     - Updates metrics exporters to include `signozclickhousemetrics` in `otel-collector-config.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 2a5c9deee976cd6477aa7b601d299de044a2909a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->