### PR TITLE
fix(alertmanager): fix a flaky test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-co-op/gocron v1.30.1
 	github.com/go-kit/log v0.2.1
 	github.com/go-openapi/runtime v0.28.0
+	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-redis/redismock/v8 v8.11.5
 	github.com/go-viper/mapstructure/v2 v2.1.0
@@ -126,7 +127,6 @@ require (
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/loads v0.22.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect
-	github.com/go-openapi/strfmt v0.23.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect

--- a/pkg/types/alertmanagertypes/channel_test.go
+++ b/pkg/types/alertmanagertypes/channel_test.go
@@ -180,11 +180,11 @@ func TestNewConfigFromChannels(t *testing.T) {
 
 			routes, err := json.Marshal(c.alertmanagerConfig.Route.Routes)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedRoutes, string(routes))
+			assert.JSONEq(t, tc.expectedRoutes, string(routes))
 
 			receivers, err := json.Marshal(c.alertmanagerConfig.Receivers)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedReceivers, string(receivers))
+			assert.JSONEq(t, tc.expectedReceivers, string(receivers))
 		})
 	}
 }


### PR DESCRIPTION
### Summary

 fix a flaky test in alertmanager
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix flaky test in `channel_test.go` by using `assert.JSONEq` for JSON string comparison.
> 
>   - **Test Fix**:
>     - In `channel_test.go`, replace `assert.Equal` with `assert.JSONEq` for comparing JSON strings in `TestNewConfigFromChannels`.
>   - **Dependencies**:
>     - Add `github.com/go-openapi/strfmt v0.23.0` as a direct dependency in `go.mod`.
>     - Remove `github.com/go-openapi/strfmt v0.23.0` from indirect dependencies in `go.mod`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 0635ee6b4b97cb13f119cac1d5333ace1a7a7a10. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->