### PR TITLE
fix: handle invalid invitation token gracefully in signup page

### DIFF
--- a/frontend/src/pages/SignUp/SignUp.tsx
+++ b/frontend/src/pages/SignUp/SignUp.tsx
@@ -150,7 +150,7 @@ function SignUp({ version }: SignUpProps): JSX.Element {
 				notifications.error({
 					message: response.error || t('unexpected_error'),
 				});
-				if (response.message === ErrorType.Unavailable) {
+				if (response.statusCode === 403) {
 					history.push(ROUTES.LOGIN);
 				}
 			}

--- a/frontend/src/pages/SignUp/SignUp.tsx
+++ b/frontend/src/pages/SignUp/SignUp.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { useQuery } from 'react-query';
 import { useLocation } from 'react-router-dom';
 import { PayloadProps as LoginPrecheckPayloadProps } from 'types/api/user/loginPrecheck';
+import { ErrorType } from 'types/common';
 
 import {
 	ButtonContainer,
@@ -149,7 +150,9 @@ function SignUp({ version }: SignUpProps): JSX.Element {
 				notifications.error({
 					message: response.error || t('unexpected_error'),
 				});
-				history.push(ROUTES.LOGIN);
+				if (response.message === ErrorType.Unavailable) {
+					history.push(ROUTES.LOGIN);
+				}
 			}
 		} catch (error) {
 			notifications.error({

--- a/frontend/src/pages/SignUp/SignUp.tsx
+++ b/frontend/src/pages/SignUp/SignUp.tsx
@@ -149,6 +149,7 @@ function SignUp({ version }: SignUpProps): JSX.Element {
 				notifications.error({
 					message: response.error || t('unexpected_error'),
 				});
+				history.push(ROUTES.LOGIN);
 			}
 		} catch (error) {
 			notifications.error({

--- a/frontend/src/types/common/index.ts
+++ b/frontend/src/types/common/index.ts
@@ -27,6 +27,7 @@ export type ErrorStatusCode =
 
 export enum ErrorType {
 	NotFound = 'not_found',
+	Unavailable = 'unavailable',
 }
 
 export type StatusCode = SuccessStatusCode | ErrorStatusCode;

--- a/pkg/query-service/auth/auth.go
+++ b/pkg/query-service/auth/auth.go
@@ -452,7 +452,7 @@ func RegisterInvitedUser(ctx context.Context, req *RegisterRequest, nopassword b
 	invite, err := ValidateInvite(ctx, req)
 	if err != nil {
 		zap.L().Error("failed to validate invite token", zap.Error(err))
-		return nil, model.UnavailableError(fmt.Errorf("invalid/used/expired invitation token, please contact your admin"))
+		return nil, model.ForbiddenError(fmt.Errorf("invalid/used/expired invitation token, please contact your admin"))
 	}
 
 	// checking if user email already exists, this is defensive but

--- a/pkg/query-service/auth/auth.go
+++ b/pkg/query-service/auth/auth.go
@@ -452,7 +452,7 @@ func RegisterInvitedUser(ctx context.Context, req *RegisterRequest, nopassword b
 	invite, err := ValidateInvite(ctx, req)
 	if err != nil {
 		zap.L().Error("failed to validate invite token", zap.Error(err))
-		return nil, model.BadRequest(model.ErrSignupFailed{})
+		return nil, model.BadRequest(fmt.Errorf("invalid/used/expired invitation token, please contact your admin"))
 	}
 
 	// checking if user email already exists, this is defensive but

--- a/pkg/query-service/auth/auth.go
+++ b/pkg/query-service/auth/auth.go
@@ -452,7 +452,7 @@ func RegisterInvitedUser(ctx context.Context, req *RegisterRequest, nopassword b
 	invite, err := ValidateInvite(ctx, req)
 	if err != nil {
 		zap.L().Error("failed to validate invite token", zap.Error(err))
-		return nil, model.BadRequest(fmt.Errorf("invalid/used/expired invitation token, please contact your admin"))
+		return nil, model.UnavailableError(fmt.Errorf("invalid/used/expired invitation token, please contact your admin"))
 	}
 
 	// checking if user email already exists, this is defensive but


### PR DESCRIPTION
### Summary

If the sign up fails, we redirect the users to the Login Page where we should display the error message: "invalid/used/expired invitation token. Please contact your admin."

#### Related Issues / PR's

#7011 

#### Screenshots
https://github.com/user-attachments/assets/0e3fd09d-c500-40f8-9ad3-0e6870f739c1

#### Affected Areas and Manually Tested Areas
`frontend/src/pages/SignUp/SignUp.tsx`
`pkg/query-service/auth/auth.go`
