### PR TITLE
chore: added kakfa analytics

### DIFF
--- a/frontend/src/pages/MessagingQueues/MQDetails/DropRateView/DropRateView.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/DropRateView/DropRateView.tsx
@@ -2,6 +2,7 @@
 import '../MQDetails.style.scss';
 
 import { Table, Typography } from 'antd';
+import logEvent from 'api/common/logEvent';
 import { MessagingQueueServicePayload } from 'api/messagingQueues/getConsumerLagDetails';
 import { getKafkaSpanEval } from 'api/messagingQueues/getKafkaSpanEval';
 import axios from 'axios';
@@ -15,7 +16,7 @@ import {
 	MessagingQueuesViewType,
 	RowData,
 } from 'pages/MessagingQueues/MessagingQueuesUtils';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation } from 'react-query';
 import { useSelector } from 'react-redux';
 import { AppState } from 'store/reducers';
@@ -93,6 +94,9 @@ export function getColumns(
 											className="traceid-text"
 											onClick={(): void => {
 												window.open(`${ROUTES.TRACE}/${item}`, '_blank');
+												logEvent(`MQ Kafka: Drop Rate - traceid navigation`, {
+													item,
+												});
 											}}
 										>
 											{item}
@@ -226,6 +230,22 @@ function DropRateView(): JSX.Element {
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [minTime, maxTime, evaluationTime]);
+
+	const prevTableDataRef = useRef<string>();
+
+	useEffect(() => {
+		if (tableData.length > 0) {
+			const currentTableData = JSON.stringify(tableData);
+
+			if (currentTableData !== prevTableDataRef.current) {
+				logEvent(`MQ Kafka: Drop Rate View`, {
+					dataRender: tableData.length,
+				});
+				prevTableDataRef.current = currentTableData;
+			}
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [JSON.stringify(tableData)]);
 
 	return (
 		<div className={cx('mq-overview-container', 'droprate-view')}>

--- a/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
@@ -112,6 +112,7 @@ function MessagingQueueOverview({
 				tableApi={getTableApi(selectedView)}
 				validConfigPresent
 				type="Overview"
+				option={option}
 			/>
 		</div>
 	);

--- a/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricColumnGraphs.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricColumnGraphs.tsx
@@ -26,12 +26,14 @@ interface MetricSectionProps {
 	title: string;
 	description: string;
 	graphCount: Widgets[];
+	checkIfDataExists?: (isDataAvailable: boolean) => void;
 }
 
 function MetricSection({
 	title,
 	description,
 	graphCount,
+	checkIfDataExists,
 }: MetricSectionProps): JSX.Element {
 	const isDarkMode = useIsDarkMode();
 
@@ -50,6 +52,7 @@ function MetricSection({
 					<MetricPageGridGraph
 						key={`graph-${widgetData.id}`}
 						widgetData={widgetData}
+						checkIfDataExists={checkIfDataExists}
 					/>
 				))}
 			</div>
@@ -57,7 +60,15 @@ function MetricSection({
 	);
 }
 
-function MetricColumnGraphs(): JSX.Element {
+MetricSection.defaultProps = {
+	checkIfDataExists: (): void => {},
+};
+
+function MetricColumnGraphs({
+	checkIfDataExists,
+}: {
+	checkIfDataExists: (isDataAvailable: boolean) => void;
+}): JSX.Element {
 	const { t } = useTranslation('messagingQueues');
 
 	const metricsData = [
@@ -106,6 +117,7 @@ function MetricColumnGraphs(): JSX.Element {
 					title={metric.title}
 					description={metric.description}
 					graphCount={metric?.graphCount || []}
+					checkIfDataExists={checkIfDataExists}
 				/>
 			))}
 		</div>

--- a/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricPageGraph.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricPageGraph.tsx
@@ -15,8 +15,10 @@ import { Widgets } from 'types/api/dashboard/getAll';
 
 function MetricPageGridGraph({
 	widgetData,
+	checkIfDataExists,
 }: {
 	widgetData: Widgets;
+	checkIfDataExists?: (isDataAvailable: boolean) => void;
 }): JSX.Element {
 	const history = useHistory();
 	const { pathname } = useLocation();
@@ -51,9 +53,14 @@ function MetricPageGridGraph({
 				widget={widgetData}
 				headerMenuList={[...ViewMenuAction]}
 				onDragSelect={onDragSelect}
+				dataAvailable={checkIfDataExists}
 			/>
 		</Card>
 	);
 }
+
+MetricPageGridGraph.defaultProps = {
+	checkIfDataExists: (): void => {},
+};
 
 export default MetricPageGridGraph;


### PR DESCRIPTION
### Summary


MQ Kafka: Partition Latency view | opened and if data rendered
-- | --
MQ Kafka: Partition Latency - details | active tab(producer or consumer ), data rendered, config (topic and partition)
MQ Kafka: Producer Latency view | opened and if data rendered, active tab (producer or consumer)
MQ Kafka: Producer Latency - details | source- (producer or consumer parent table), active tab(producer or consumer ), data rendered, config (topic and service)
MQ Kafka: Drop Rate view | opened and if data rendered
MQ Kafka: Drop Rate - traceid navigation | traceid, filters used to navigate
MQ Kafka: Metric view | visited and graphs rendered



#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Kafka analytics logging for data rendering and navigation in messaging queue details and metric pages.
> 
>   - **Logging**:
>     - Add `logEvent` calls in `DropRateView.tsx` for trace ID navigation and data rendering.
>     - Add `logEvent` calls in `MQTables.tsx` for data rendering in both overview and detail views.
>     - Add `logEvent` in `MetricPage.tsx` to log when the first graph is rendered.
>   - **Components**:
>     - Update `MetricPageGridGraph` to accept `checkIfDataExists` prop for logging data availability.
>     - Update `MetricColumnGraphs` and `CollapsibleMetricSection` to pass `checkIfDataExists` to child components.
>   - **Misc**:
>     - Add `option` prop to `MessagingQueueOverview.tsx` and `MQTables.tsx` for producer latency options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 92eaa590393e5680724464dddb7436ec41d19fee. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->