### PR TITLE
fix: add form validation to alert channel form

### DIFF
--- a/frontend/src/container/FormAlertChannels/Settings/MsTeams.tsx
+++ b/frontend/src/container/FormAlertChannels/Settings/MsTeams.tsx
@@ -9,7 +9,7 @@ function MsTeams({ setSelectedConfig }: MsTeamsProps): JSX.Element {
 
 	return (
 		<>
-			<Form.Item name="webhook_url" label={t('field_webhook_url')}>
+			<Form.Item required name="webhook_url" label={t('field_webhook_url')}>
 				<Input
 					onChange={(event): void => {
 						setSelectedConfig((value) => ({

--- a/frontend/src/container/FormAlertChannels/Settings/Slack.tsx
+++ b/frontend/src/container/FormAlertChannels/Settings/Slack.tsx
@@ -11,7 +11,7 @@ function Slack({ setSelectedConfig }: SlackProps): JSX.Element {
 
 	return (
 		<>
-			<Form.Item name="api_url" label={t('field_webhook_url')}>
+			<Form.Item required name="api_url" label={t('field_webhook_url')}>
 				<Input
 					onChange={(event): void => {
 						setSelectedConfig((value) => ({
@@ -27,6 +27,7 @@ function Slack({ setSelectedConfig }: SlackProps): JSX.Element {
 				name="channel"
 				help={t('slack_channel_help')}
 				label={t('field_slack_recipient')}
+				required
 			>
 				<Input
 					onChange={(event): void =>

--- a/frontend/src/container/FormAlertChannels/Settings/Webhook.tsx
+++ b/frontend/src/container/FormAlertChannels/Settings/Webhook.tsx
@@ -9,7 +9,7 @@ function WebhookSettings({ setSelectedConfig }: WebhookProps): JSX.Element {
 
 	return (
 		<>
-			<Form.Item name="api_url" label={t('field_webhook_url')}>
+			<Form.Item required name="api_url" label={t('field_webhook_url')}>
 				<Input
 					onChange={(event): void => {
 						setSelectedConfig((value) => ({


### PR DESCRIPTION
### Summary

When adding an alarm channel, the alarm channel name, web address, and email are not verified in the form, resulting in an interface error.

#### Related Issues / PR's

#6614 - bug 1

#### Screenshots

https://github.com/user-attachments/assets/121ee27b-32ad-4af7-8aae-95e01671bed3

#### Affected Areas and Manually Tested Areas

`frontend/src/container/FormAlertChannels/index.tsx`
