### PR TITLE
feat(sqlstorehook): add sqlstore logging hook

### DIFF
--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -8,6 +8,7 @@ import (
 	"go.signoz.io/signoz/pkg/sqlmigration"
 	"go.signoz.io/signoz/pkg/sqlstore"
 	"go.signoz.io/signoz/pkg/sqlstore/sqlitesqlstore"
+	"go.signoz.io/signoz/pkg/sqlstore/sqlstorehook"
 	"go.signoz.io/signoz/pkg/telemetrystore"
 	"go.signoz.io/signoz/pkg/telemetrystore/clickhousetelemetrystore"
 	"go.signoz.io/signoz/pkg/telemetrystore/telemetrystorehook"
@@ -34,7 +35,6 @@ type ProviderConfig struct {
 }
 
 func NewProviderConfig() ProviderConfig {
-	hook := telemetrystorehook.NewFactory()
 	return ProviderConfig{
 		CacheProviderFactories: factory.MustNewNamedMap(
 			memorycache.NewFactory(),
@@ -45,7 +45,7 @@ func NewProviderConfig() ProviderConfig {
 			noopweb.NewFactory(),
 		),
 		SQLStoreProviderFactories: factory.MustNewNamedMap(
-			sqlitesqlstore.NewFactory(),
+			sqlitesqlstore.NewFactory(sqlstorehook.NewLoggingFactory()),
 			// postgressqlstore.NewFactory(),
 		),
 		SQLMigrationProviderFactories: factory.MustNewNamedMap(
@@ -62,7 +62,7 @@ func NewProviderConfig() ProviderConfig {
 			sqlmigration.NewModifyDatetimeFactory(),
 		),
 		TelemetryStoreProviderFactories: factory.MustNewNamedMap(
-			clickhousetelemetrystore.NewFactory(hook),
+			clickhousetelemetrystore.NewFactory(telemetrystorehook.NewFactory()),
 		),
 	}
 }

--- a/pkg/sqlstore/bun.go
+++ b/pkg/sqlstore/bun.go
@@ -1,0 +1,18 @@
+package sqlstore
+
+import (
+	"database/sql"
+
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/schema"
+)
+
+func NewBunDB(sqldb *sql.DB, dialect schema.Dialect, hooks []SQLStoreHook, opts ...bun.DBOption) *bun.DB {
+	bunDB := bun.NewDB(sqldb, dialect, opts...)
+
+	for _, hook := range hooks {
+		bunDB.AddQueryHook(hook)
+	}
+
+	return bunDB
+}

--- a/pkg/sqlstore/sqlstore.go
+++ b/pkg/sqlstore/sqlstore.go
@@ -16,3 +16,7 @@ type SQLStore interface {
 	// SQLxDB returns an instance of sqlx.DB.
 	SQLxDB() *sqlx.DB
 }
+
+type SQLStoreHook interface {
+	bun.QueryHook
+}

--- a/pkg/sqlstore/sqlstorehook/logging.go
+++ b/pkg/sqlstore/sqlstorehook/logging.go
@@ -1,0 +1,43 @@
+package sqlstorehook
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/uptrace/bun"
+	"go.signoz.io/signoz/pkg/factory"
+	"go.signoz.io/signoz/pkg/sqlstore"
+)
+
+type logging struct {
+	bun.QueryHook
+	logger *slog.Logger
+	level  slog.Level
+}
+
+func NewFactory() factory.ProviderFactory[sqlstore.SQLStoreHook, sqlstore.Config] {
+	return factory.NewProviderFactory(factory.MustNewName("logging"), NewLogging)
+}
+
+func NewLogging(ctx context.Context, providerSettings factory.ProviderSettings, config sqlstore.Config) (sqlstore.SQLStoreHook, error) {
+	return &logging{
+		logger: factory.NewScopedProviderSettings(providerSettings, "go.signoz.io/signoz/pkg/sqlstore/sqlstorehook").Logger(),
+		level:  slog.LevelDebug,
+	}, nil
+}
+
+func (logging) BeforeQuery(ctx context.Context, event *bun.QueryEvent) context.Context {
+	return ctx
+}
+
+func (hook logging) AfterQuery(ctx context.Context, event *bun.QueryEvent) {
+	hook.logger.Log(
+		ctx,
+		hook.level,
+		"::SQLSTORE-QUERY::",
+		"db.query.operation", event.Operation(),
+		"db.query.text", event.Query,
+		"db.duration", time.Since(event.StartTime).String(),
+	)
+}

--- a/pkg/sqlstore/sqlstorehook/logging.go
+++ b/pkg/sqlstore/sqlstorehook/logging.go
@@ -16,7 +16,7 @@ type logging struct {
 	level  slog.Level
 }
 
-func NewFactory() factory.ProviderFactory[sqlstore.SQLStoreHook, sqlstore.Config] {
+func NewLoggingFactory() factory.ProviderFactory[sqlstore.SQLStoreHook, sqlstore.Config] {
 	return factory.NewProviderFactory(factory.MustNewName("logging"), NewLogging)
 }
 

--- a/pkg/types/alertmanagertypes/channel_test.go
+++ b/pkg/types/alertmanagertypes/channel_test.go
@@ -2,6 +2,7 @@ package alertmanagertypes
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -180,11 +181,17 @@ func TestNewConfigFromChannels(t *testing.T) {
 
 			routes, err := json.Marshal(c.alertmanagerConfig.Route.Routes)
 			assert.NoError(t, err)
-			assert.ElementsMatch(t, tc.expectedRoutes, routes)
+			var actualRoutes []map[string]any
+			err = json.Unmarshal(routes, &actualRoutes)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tc.expectedRoutes, actualRoutes)
 
 			receivers, err := json.Marshal(c.alertmanagerConfig.Receivers)
 			assert.NoError(t, err)
-			assert.ElementsMatch(t, tc.expectedReceivers, receivers)
+			var actualReceivers []map[string]any
+			err = json.Unmarshal(receivers, &actualReceivers)
+			assert.NoError(t, err)
+			assert.True(t, reflect.DeepEqual(tc.expectedReceivers, actualReceivers))
 		})
 	}
 }

--- a/pkg/types/alertmanagertypes/channel_test.go
+++ b/pkg/types/alertmanagertypes/channel_test.go
@@ -99,8 +99,8 @@ func TestNewConfigFromChannels(t *testing.T) {
 	testCases := []struct {
 		name              string
 		channels          Channels
-		expectedRoutes    string
-		expectedReceivers string
+		expectedRoutes    []map[string]any
+		expectedReceivers []map[string]any
 	}{
 		{
 			name: "OneEmailChannel",
@@ -111,8 +111,8 @@ func TestNewConfigFromChannels(t *testing.T) {
 					Data: `{"name":"email-receiver","email_configs":[{"to":"test@example.com"}]}`,
 				},
 			},
-			expectedRoutes:    `[{"receiver":"email-receiver","continue":true}]`,
-			expectedReceivers: `[{"name":"default-receiver"},{"name":"email-receiver","email_configs":[{"send_resolved":false,"to":"test@example.com","from":"alerts@example.com","hello":"localhost","smarthost":"smtp.example.com:587","require_tls":true,"tls_config":{"insecure_skip_verify":false}}]}]`,
+			expectedRoutes:    []map[string]any{{"receiver": "email-receiver", "continue": true}},
+			expectedReceivers: []map[string]any{{"name": "default-receiver"}, {"name": "email-receiver", "email_configs": []map[string]any{{"send_resolved": false, "to": "test@example.com", "from": "alerts@example.com", "hello": "localhost", "smarthost": "smtp.example.com:587", "require_tls": true, "tls_config": map[string]any{"insecure_skip_verify": false}}}}},
 		},
 		{
 			name: "OneSlackChannel",
@@ -123,8 +123,8 @@ func TestNewConfigFromChannels(t *testing.T) {
 					Data: `{"name":"slack-receiver","slack_configs":[{"channel":"#alerts","api_url":"https://slack.com/api/test","send_resolved":true}]}`,
 				},
 			},
-			expectedRoutes:    `[{"receiver":"slack-receiver","continue":true}]`,
-			expectedReceivers: `[{"name":"default-receiver"},{"name":"slack-receiver","slack_configs":[{"send_resolved":true,"http_config":{"tls_config":{"insecure_skip_verify":false},"follow_redirects":true,"enable_http2":true,"proxy_url":null},"api_url":"https://slack.com/api/test","channel":"#alerts"}]}]`,
+			expectedRoutes:    []map[string]any{{"receiver": "slack-receiver", "continue": true}},
+			expectedReceivers: []map[string]any{{"name": "default-receiver"}, {"name": "slack-receiver", "slack_configs": []map[string]any{{"send_resolved": true, "http_config": map[string]any{"tls_config": map[string]any{"insecure_skip_verify": false}, "follow_redirects": true, "enable_http2": true, "proxy_url": nil}, "api_url": "https://slack.com/api/test", "channel": "#alerts"}}}},
 		},
 		{
 			name: "OnePagerdutyChannel",
@@ -135,8 +135,8 @@ func TestNewConfigFromChannels(t *testing.T) {
 					Data: `{"name":"pagerduty-receiver","pagerduty_configs":[{"service_key":"test"}]}`,
 				},
 			},
-			expectedRoutes:    `[{"receiver":"pagerduty-receiver","continue":true}]`,
-			expectedReceivers: `[{"name":"default-receiver"},{"name":"pagerduty-receiver","pagerduty_configs":[{"send_resolved":false,"http_config":{"tls_config":{"insecure_skip_verify":false},"follow_redirects":true,"enable_http2":true,"proxy_url":null},"service_key":"test","url":"https://events.pagerduty.com/v2/enqueue"}]}]`,
+			expectedRoutes:    []map[string]any{{"receiver": "pagerduty-receiver", "continue": true}},
+			expectedReceivers: []map[string]any{{"name": "default-receiver"}, {"name": "pagerduty-receiver", "pagerduty_configs": []map[string]any{{"send_resolved": false, "http_config": map[string]any{"tls_config": map[string]any{"insecure_skip_verify": false}, "follow_redirects": true, "enable_http2": true, "proxy_url": nil}, "service_key": "test", "url": "https://events.pagerduty.com/v2/enqueue"}}}},
 		},
 		{
 			name: "OnePagerdutyAndOneSlackChannel",
@@ -152,8 +152,8 @@ func TestNewConfigFromChannels(t *testing.T) {
 					Data: `{"name":"slack-receiver","slack_configs":[{"channel":"#alerts","api_url":"https://slack.com/api/test","send_resolved":true}]}`,
 				},
 			},
-			expectedRoutes:    `[{"receiver":"pagerduty-receiver","continue":true},{"receiver":"slack-receiver","continue":true}]`,
-			expectedReceivers: `[{"name":"default-receiver"},{"name":"pagerduty-receiver","pagerduty_configs":[{"send_resolved":false,"http_config":{"tls_config":{"insecure_skip_verify":false},"follow_redirects":true,"enable_http2":true,"proxy_url":null},"service_key":"test","url":"https://events.pagerduty.com/v2/enqueue"}]},{"name":"slack-receiver","slack_configs":[{"send_resolved":true,"http_config":{"tls_config":{"insecure_skip_verify":false},"follow_redirects":true,"enable_http2":true,"proxy_url":null},"api_url":"https://slack.com/api/test","channel":"#alerts"}]}]`,
+			expectedRoutes:    []map[string]any{{"receiver": "pagerduty-receiver", "continue": true}, {"receiver": "slack-receiver", "continue": true}},
+			expectedReceivers: []map[string]any{{"name": "default-receiver"}, {"name": "pagerduty-receiver", "pagerduty_configs": []map[string]any{{"send_resolved": false, "http_config": map[string]any{"tls_config": map[string]any{"insecure_skip_verify": false}, "follow_redirects": true, "enable_http2": true, "proxy_url": nil}, "service_key": "test", "url": "https://events.pagerduty.com/v2/enqueue"}}}, {"name": "slack-receiver", "slack_configs": []map[string]any{{"send_resolved": true, "http_config": map[string]any{"tls_config": map[string]any{"insecure_skip_verify": false}, "follow_redirects": true, "enable_http2": true, "proxy_url": nil}, "api_url": "https://slack.com/api/test", "channel": "#alerts"}}}},
 		},
 	}
 
@@ -180,11 +180,11 @@ func TestNewConfigFromChannels(t *testing.T) {
 
 			routes, err := json.Marshal(c.alertmanagerConfig.Route.Routes)
 			assert.NoError(t, err)
-			assert.JSONEq(t, tc.expectedRoutes, string(routes))
+			assert.ElementsMatch(t, tc.expectedRoutes, routes)
 
 			receivers, err := json.Marshal(c.alertmanagerConfig.Receivers)
 			assert.NoError(t, err)
-			assert.JSONEq(t, tc.expectedReceivers, string(receivers))
+			assert.ElementsMatch(t, tc.expectedReceivers, receivers)
 		})
 	}
 }

--- a/pkg/types/alertmanagertypes/channel_test.go
+++ b/pkg/types/alertmanagertypes/channel_test.go
@@ -2,7 +2,6 @@ package alertmanagertypes
 
 import (
 	"encoding/json"
-	"reflect"
 	"testing"
 	"time"
 
@@ -113,7 +112,7 @@ func TestNewConfigFromChannels(t *testing.T) {
 				},
 			},
 			expectedRoutes:    []map[string]any{{"receiver": "email-receiver", "continue": true}},
-			expectedReceivers: []map[string]any{{"name": "default-receiver"}, {"name": "email-receiver", "email_configs": []map[string]any{{"send_resolved": false, "to": "test@example.com", "from": "alerts@example.com", "hello": "localhost", "smarthost": "smtp.example.com:587", "require_tls": true, "tls_config": map[string]any{"insecure_skip_verify": false}}}}},
+			expectedReceivers: []map[string]any{{"name": "default-receiver"}, {"name": "email-receiver", "email_configs": []any{map[string]any{"send_resolved": false, "to": "test@example.com", "from": "alerts@example.com", "hello": "localhost", "smarthost": "smtp.example.com:587", "require_tls": true, "tls_config": map[string]any{"insecure_skip_verify": false}}}}},
 		},
 		{
 			name: "OneSlackChannel",
@@ -125,7 +124,7 @@ func TestNewConfigFromChannels(t *testing.T) {
 				},
 			},
 			expectedRoutes:    []map[string]any{{"receiver": "slack-receiver", "continue": true}},
-			expectedReceivers: []map[string]any{{"name": "default-receiver"}, {"name": "slack-receiver", "slack_configs": []map[string]any{{"send_resolved": true, "http_config": map[string]any{"tls_config": map[string]any{"insecure_skip_verify": false}, "follow_redirects": true, "enable_http2": true, "proxy_url": nil}, "api_url": "https://slack.com/api/test", "channel": "#alerts"}}}},
+			expectedReceivers: []map[string]any{{"name": "default-receiver"}, {"name": "slack-receiver", "slack_configs": []any{map[string]any{"send_resolved": true, "http_config": map[string]any{"tls_config": map[string]any{"insecure_skip_verify": false}, "follow_redirects": true, "enable_http2": true, "proxy_url": nil}, "api_url": "https://slack.com/api/test", "channel": "#alerts"}}}},
 		},
 		{
 			name: "OnePagerdutyChannel",
@@ -137,7 +136,7 @@ func TestNewConfigFromChannels(t *testing.T) {
 				},
 			},
 			expectedRoutes:    []map[string]any{{"receiver": "pagerduty-receiver", "continue": true}},
-			expectedReceivers: []map[string]any{{"name": "default-receiver"}, {"name": "pagerduty-receiver", "pagerduty_configs": []map[string]any{{"send_resolved": false, "http_config": map[string]any{"tls_config": map[string]any{"insecure_skip_verify": false}, "follow_redirects": true, "enable_http2": true, "proxy_url": nil}, "service_key": "test", "url": "https://events.pagerduty.com/v2/enqueue"}}}},
+			expectedReceivers: []map[string]any{{"name": "default-receiver"}, {"name": "pagerduty-receiver", "pagerduty_configs": []any{map[string]any{"send_resolved": false, "http_config": map[string]any{"tls_config": map[string]any{"insecure_skip_verify": false}, "follow_redirects": true, "enable_http2": true, "proxy_url": nil}, "service_key": "test", "url": "https://events.pagerduty.com/v2/enqueue"}}}},
 		},
 		{
 			name: "OnePagerdutyAndOneSlackChannel",
@@ -154,7 +153,7 @@ func TestNewConfigFromChannels(t *testing.T) {
 				},
 			},
 			expectedRoutes:    []map[string]any{{"receiver": "pagerduty-receiver", "continue": true}, {"receiver": "slack-receiver", "continue": true}},
-			expectedReceivers: []map[string]any{{"name": "default-receiver"}, {"name": "pagerduty-receiver", "pagerduty_configs": []map[string]any{{"send_resolved": false, "http_config": map[string]any{"tls_config": map[string]any{"insecure_skip_verify": false}, "follow_redirects": true, "enable_http2": true, "proxy_url": nil}, "service_key": "test", "url": "https://events.pagerduty.com/v2/enqueue"}}}, {"name": "slack-receiver", "slack_configs": []map[string]any{{"send_resolved": true, "http_config": map[string]any{"tls_config": map[string]any{"insecure_skip_verify": false}, "follow_redirects": true, "enable_http2": true, "proxy_url": nil}, "api_url": "https://slack.com/api/test", "channel": "#alerts"}}}},
+			expectedReceivers: []map[string]any{{"name": "default-receiver"}, {"name": "pagerduty-receiver", "pagerduty_configs": []any{map[string]any{"send_resolved": false, "http_config": map[string]any{"tls_config": map[string]any{"insecure_skip_verify": false}, "follow_redirects": true, "enable_http2": true, "proxy_url": nil}, "service_key": "test", "url": "https://events.pagerduty.com/v2/enqueue"}}}, {"name": "slack-receiver", "slack_configs": []any{map[string]any{"send_resolved": true, "http_config": map[string]any{"tls_config": map[string]any{"insecure_skip_verify": false}, "follow_redirects": true, "enable_http2": true, "proxy_url": nil}, "api_url": "https://slack.com/api/test", "channel": "#alerts"}}}},
 		},
 	}
 
@@ -191,7 +190,7 @@ func TestNewConfigFromChannels(t *testing.T) {
 			var actualReceivers []map[string]any
 			err = json.Unmarshal(receivers, &actualReceivers)
 			assert.NoError(t, err)
-			assert.True(t, reflect.DeepEqual(tc.expectedReceivers, actualReceivers))
+			assert.ElementsMatch(t, tc.expectedReceivers, actualReceivers)
 		})
 	}
 }


### PR DESCRIPTION
### Summary

add sqlstore logging hook
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds SQLStore logging hook and updates provider configurations and tests to support query logging.
> 
>   - **Behavior**:
>     - Adds `NewLoggingFactory` in `sqlstorehook/logging.go` to create logging hooks for SQLStore.
>     - Modifies `NewFactory` in `postgressqlstore/provider.go` and `sqlitesqlstore/provider.go` to accept hook factories.
>     - Updates `NewBunDB` in `bun.go` to add hooks to `bun.DB`.
>   - **Interfaces**:
>     - Adds `SQLStoreHook` interface in `sqlstore.go` extending `bun.QueryHook`.
>   - **Tests**:
>     - Updates `TestNewConfigFromChannels` in `channel_test.go` to use `[]map[string]any` for `expectedRoutes` and `expectedReceivers`.
>     - Ensures test assertions use `ElementsMatch` for unordered comparison.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 55777d4c4ffdf81becf2a99216827ab0dbbb3b35. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->