### PR TITLE
fix: signoz shouldn't panic with postgres provider

### DIFF
--- a/ee/query-service/app/api/cloudIntegrations.go
+++ b/ee/query-service/app/api/cloudIntegrations.go
@@ -183,7 +183,7 @@ func (ah *APIHandler) getOrCreateCloudIntegrationUser(
 	if apiErr != nil {
 		return nil, basemodel.WrapApiError(apiErr, "couldn't get viewer group for creating integration user")
 	}
-	newUser.GroupId = viewerGroup.Id
+	newUser.GroupId = viewerGroup.ID
 
 	passwordHash, err := auth.PasswordHash(uuid.NewString())
 	if err != nil {

--- a/ee/query-service/app/server.go
+++ b/ee/query-service/app/server.go
@@ -105,7 +105,7 @@ func (s Server) HealthCheckStatus() chan healthcheck.Status {
 
 // NewServer creates and initializes Server
 func NewServer(serverOptions *ServerOptions) (*Server, error) {
-	modelDao, err := dao.InitDao(serverOptions.SigNoz.SQLStore.SQLxDB(), serverOptions.SigNoz.SQLStore.BunDB())
+	modelDao, err := dao.InitDao(serverOptions.SigNoz.SQLStore)
 	if err != nil {
 		return nil, err
 	}
@@ -197,14 +197,14 @@ func NewServer(serverOptions *ServerOptions) (*Server, error) {
 		return nil, err
 	}
 
-	integrationsController, err := integrations.NewController(serverOptions.SigNoz.SQLStore.SQLxDB())
+	integrationsController, err := integrations.NewController(serverOptions.SigNoz.SQLStore)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"couldn't create integrations controller: %w", err,
 		)
 	}
 
-	cloudIntegrationsController, err := cloudintegrations.NewController(serverOptions.SigNoz.SQLStore.SQLxDB())
+	cloudIntegrationsController, err := cloudintegrations.NewController(serverOptions.SigNoz.SQLStore)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"couldn't create cloud provider integrations controller: %w", err,

--- a/ee/query-service/app/server.go
+++ b/ee/query-service/app/server.go
@@ -105,7 +105,7 @@ func (s Server) HealthCheckStatus() chan healthcheck.Status {
 
 // NewServer creates and initializes Server
 func NewServer(serverOptions *ServerOptions) (*Server, error) {
-	modelDao, err := dao.InitDao(serverOptions.SigNoz.SQLStore.SQLxDB())
+	modelDao, err := dao.InitDao(serverOptions.SigNoz.SQLStore.SQLxDB(), serverOptions.SigNoz.SQLStore.BunDB())
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func NewServer(serverOptions *ServerOptions) (*Server, error) {
 	}
 
 	// initiate license manager
-	lm, err := licensepkg.StartManager(serverOptions.SigNoz.SQLStore.SQLxDB())
+	lm, err := licensepkg.StartManager(serverOptions.SigNoz.SQLStore.SQLxDB(), serverOptions.SigNoz.SQLStore.BunDB())
 	if err != nil {
 		return nil, err
 	}

--- a/ee/query-service/auth/auth.go
+++ b/ee/query-service/auth/auth.go
@@ -40,7 +40,7 @@ func GetUserFromRequestContext(ctx context.Context, apiHandler *api.APIHandler) 
 			}
 			telemetry.GetInstance().SetPatTokenUser()
 			dao.UpdatePATLastUsed(ctx, patToken, time.Now().Unix())
-			user.User.GroupId = group.Id
+			user.User.GroupId = group.ID
 			user.User.Id = pat.Id
 			return &basemodel.UserPayload{
 				User: user.User,

--- a/ee/query-service/dao/factory.go
+++ b/ee/query-service/dao/factory.go
@@ -2,9 +2,10 @@ package dao
 
 import (
 	"github.com/jmoiron/sqlx"
+	"github.com/uptrace/bun"
 	"go.signoz.io/signoz/ee/query-service/dao/sqlite"
 )
 
-func InitDao(inputDB *sqlx.DB) (ModelDao, error) {
-	return sqlite.InitDB(inputDB)
+func InitDao(inputDB *sqlx.DB, bundb *bun.DB) (ModelDao, error) {
+	return sqlite.InitDB(inputDB, bundb)
 }

--- a/ee/query-service/dao/factory.go
+++ b/ee/query-service/dao/factory.go
@@ -1,11 +1,10 @@
 package dao
 
 import (
-	"github.com/jmoiron/sqlx"
-	"github.com/uptrace/bun"
 	"go.signoz.io/signoz/ee/query-service/dao/sqlite"
+	"go.signoz.io/signoz/pkg/sqlstore"
 )
 
-func InitDao(inputDB *sqlx.DB, bundb *bun.DB) (ModelDao, error) {
-	return sqlite.InitDB(inputDB, bundb)
+func InitDao(sqlStore sqlstore.SQLStore) (ModelDao, error) {
+	return sqlite.InitDB(sqlStore)
 }

--- a/ee/query-service/dao/sqlite/auth.go
+++ b/ee/query-service/dao/sqlite/auth.go
@@ -49,7 +49,7 @@ func (m *modelDao) createUserForSAMLRequest(ctx context.Context, email string) (
 		Password:          hash,
 		CreatedAt:         time.Now().Unix(),
 		ProfilePictureURL: "", // Currently unused
-		GroupId:           group.Id,
+		GroupId:           group.ID,
 		OrgId:             domain.OrgId,
 	}
 

--- a/ee/query-service/dao/sqlite/modelDao.go
+++ b/ee/query-service/dao/sqlite/modelDao.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/uptrace/bun"
 	basedao "go.signoz.io/signoz/pkg/query-service/dao"
 	basedsql "go.signoz.io/signoz/pkg/query-service/dao/sqlite"
 	baseint "go.signoz.io/signoz/pkg/query-service/interfaces"
+	"go.signoz.io/signoz/pkg/sqlstore"
 )
 
 type modelDao struct {
@@ -30,8 +30,8 @@ func (m *modelDao) checkFeature(key string) error {
 }
 
 // InitDB creates and extends base model DB repository
-func InitDB(inputDB *sqlx.DB, bundb *bun.DB) (*modelDao, error) {
-	dao, err := basedsql.InitDB(inputDB, bundb)
+func InitDB(sqlStore sqlstore.SQLStore) (*modelDao, error) {
+	dao, err := basedsql.InitDB(sqlStore)
 	if err != nil {
 		return nil, err
 	}

--- a/ee/query-service/dao/sqlite/modelDao.go
+++ b/ee/query-service/dao/sqlite/modelDao.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/uptrace/bun"
 	basedao "go.signoz.io/signoz/pkg/query-service/dao"
 	basedsql "go.signoz.io/signoz/pkg/query-service/dao/sqlite"
 	baseint "go.signoz.io/signoz/pkg/query-service/interfaces"
@@ -29,8 +30,8 @@ func (m *modelDao) checkFeature(key string) error {
 }
 
 // InitDB creates and extends base model DB repository
-func InitDB(inputDB *sqlx.DB) (*modelDao, error) {
-	dao, err := basedsql.InitDB(inputDB)
+func InitDB(inputDB *sqlx.DB, bundb *bun.DB) (*modelDao, error) {
+	dao, err := basedsql.InitDB(inputDB, bundb)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query-service/app/cloudintegrations/controller.go
+++ b/pkg/query-service/app/cloudintegrations/controller.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"go.signoz.io/signoz/pkg/query-service/app/dashboards"
 	"go.signoz.io/signoz/pkg/query-service/model"
+	"go.signoz.io/signoz/pkg/sqlstore"
 	"golang.org/x/exp/maps"
 )
 
@@ -30,15 +30,15 @@ type Controller struct {
 	serviceConfigRepo serviceConfigRepository
 }
 
-func NewController(db *sqlx.DB) (
+func NewController(sqlStore sqlstore.SQLStore) (
 	*Controller, error,
 ) {
-	accountsRepo, err := newCloudProviderAccountsRepository(db)
+	accountsRepo, err := newCloudProviderAccountsRepository(sqlStore.SQLxDB())
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create cloud provider accounts repo: %w", err)
 	}
 
-	serviceConfigRepo, err := newServiceConfigRepository(db)
+	serviceConfigRepo, err := newServiceConfigRepository(sqlStore.SQLxDB())
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create cloud provider service config repo: %w", err)
 	}

--- a/pkg/query-service/app/cloudintegrations/controller_test.go
+++ b/pkg/query-service/app/cloudintegrations/controller_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestRegenerateConnectionUrlWithUpdatedConfig(t *testing.T) {
 	require := require.New(t)
-	testDB, _, _ := utils.NewTestSqliteDB(t)
-	controller, err := NewController(testDB)
+	sqlStore, _ := utils.NewTestSqliteDB(t)
+	controller, err := NewController(sqlStore)
 	require.NoError(err)
 
 	// should be able to generate connection url for
@@ -56,8 +56,8 @@ func TestRegenerateConnectionUrlWithUpdatedConfig(t *testing.T) {
 
 func TestAgentCheckIns(t *testing.T) {
 	require := require.New(t)
-	testDB, _, _ := utils.NewTestSqliteDB(t)
-	controller, err := NewController(testDB)
+	sqlStore, _ := utils.NewTestSqliteDB(t)
+	controller, err := NewController(sqlStore)
 	require.NoError(err)
 
 	// An agent should be able to check in from a cloud account even
@@ -139,8 +139,8 @@ func TestAgentCheckIns(t *testing.T) {
 
 func TestCantDisconnectNonExistentAccount(t *testing.T) {
 	require := require.New(t)
-	testDB, _, _ := utils.NewTestSqliteDB(t)
-	controller, err := NewController(testDB)
+	sqlStore, _ := utils.NewTestSqliteDB(t)
+	controller, err := NewController(sqlStore)
 	require.NoError(err)
 
 	// Attempting to disconnect a non-existent account should return error
@@ -154,8 +154,8 @@ func TestCantDisconnectNonExistentAccount(t *testing.T) {
 
 func TestConfigureService(t *testing.T) {
 	require := require.New(t)
-	testDB, _, _ := utils.NewTestSqliteDB(t)
-	controller, err := NewController(testDB)
+	sqlStore, _ := utils.NewTestSqliteDB(t)
+	controller, err := NewController(sqlStore)
 	require.NoError(err)
 
 	testCloudAccountId := "546311234"

--- a/pkg/query-service/app/cloudintegrations/controller_test.go
+++ b/pkg/query-service/app/cloudintegrations/controller_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRegenerateConnectionUrlWithUpdatedConfig(t *testing.T) {
 	require := require.New(t)
-	testDB, _ := utils.NewTestSqliteDB(t)
+	testDB, _, _ := utils.NewTestSqliteDB(t)
 	controller, err := NewController(testDB)
 	require.NoError(err)
 
@@ -56,7 +56,7 @@ func TestRegenerateConnectionUrlWithUpdatedConfig(t *testing.T) {
 
 func TestAgentCheckIns(t *testing.T) {
 	require := require.New(t)
-	testDB, _ := utils.NewTestSqliteDB(t)
+	testDB, _, _ := utils.NewTestSqliteDB(t)
 	controller, err := NewController(testDB)
 	require.NoError(err)
 
@@ -139,7 +139,7 @@ func TestAgentCheckIns(t *testing.T) {
 
 func TestCantDisconnectNonExistentAccount(t *testing.T) {
 	require := require.New(t)
-	testDB, _ := utils.NewTestSqliteDB(t)
+	testDB, _, _ := utils.NewTestSqliteDB(t)
 	controller, err := NewController(testDB)
 	require.NoError(err)
 
@@ -154,7 +154,7 @@ func TestCantDisconnectNonExistentAccount(t *testing.T) {
 
 func TestConfigureService(t *testing.T) {
 	require := require.New(t)
-	testDB, _ := utils.NewTestSqliteDB(t)
+	testDB, _, _ := utils.NewTestSqliteDB(t)
 	controller, err := NewController(testDB)
 	require.NoError(err)
 

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -2285,13 +2285,13 @@ func (aH *APIHandler) deleteUser(w http.ResponseWriter, r *http.Request) {
 		RespondError(w, apiErr, "Failed to get admin group")
 		return
 	}
-	adminUsers, apiErr := dao.DB().GetUsersByGroup(ctx, adminGroup.Id)
+	adminUsers, apiErr := dao.DB().GetUsersByGroup(ctx, adminGroup.ID)
 	if apiErr != nil {
 		RespondError(w, apiErr, "Failed to get admin group users")
 		return
 	}
 
-	if user.GroupId == adminGroup.Id && len(adminUsers) == 1 {
+	if user.GroupId == adminGroup.ID && len(adminUsers) == 1 {
 		RespondError(w, &model.ApiError{
 			Typ: model.ErrorInternal,
 			Err: errors.New("cannot delete the last admin user")}, nil)
@@ -2403,7 +2403,7 @@ func (aH *APIHandler) editRole(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	apiErr = dao.DB().UpdateUserGroup(context.Background(), user.Id, newGroup.Id)
+	apiErr = dao.DB().UpdateUserGroup(context.Background(), user.Id, newGroup.ID)
 	if apiErr != nil {
 		RespondError(w, apiErr, "Failed to add user to group")
 		return

--- a/pkg/query-service/app/integrations/controller.go
+++ b/pkg/query-service/app/integrations/controller.go
@@ -4,21 +4,21 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/jmoiron/sqlx"
 	"go.signoz.io/signoz/pkg/query-service/agentConf"
 	"go.signoz.io/signoz/pkg/query-service/app/dashboards"
 	"go.signoz.io/signoz/pkg/query-service/app/logparsingpipeline"
 	"go.signoz.io/signoz/pkg/query-service/model"
+	"go.signoz.io/signoz/pkg/sqlstore"
 )
 
 type Controller struct {
 	mgr *Manager
 }
 
-func NewController(db *sqlx.DB) (
+func NewController(sqlStore sqlstore.SQLStore) (
 	*Controller, error,
 ) {
-	mgr, err := NewManager(db)
+	mgr, err := NewManager(sqlStore.SQLxDB())
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create integrations manager: %w", err)
 	}

--- a/pkg/query-service/app/integrations/test_utils.go
+++ b/pkg/query-service/app/integrations/test_utils.go
@@ -16,7 +16,7 @@ import (
 func NewTestIntegrationsManager(t *testing.T) *Manager {
 	testDB := utils.NewQueryServiceDBForTests(t)
 
-	installedIntegrationsRepo, err := NewInstalledIntegrationsSqliteRepo(testDB)
+	installedIntegrationsRepo, err := NewInstalledIntegrationsSqliteRepo(testDB.SQLxDB())
 	if err != nil {
 		t.Fatalf("could not init sqlite DB for installed integrations: %v", err)
 	}

--- a/pkg/query-service/app/opamp/config_provider_test.go
+++ b/pkg/query-service/app/opamp/config_provider_test.go
@@ -166,7 +166,7 @@ type testbed struct {
 
 func newTestbed(t *testing.T) *testbed {
 	testDB := utils.NewQueryServiceDBForTests(t)
-	_, err := model.InitDB(testDB)
+	_, err := model.InitDB(testDB.SQLxDB())
 	if err != nil {
 		t.Fatalf("could not init opamp model: %v", err)
 	}

--- a/pkg/query-service/app/server.go
+++ b/pkg/query-service/app/server.go
@@ -91,7 +91,7 @@ func (s Server) HealthCheckStatus() chan healthcheck.Status {
 // NewServer creates and initializes Server
 func NewServer(serverOptions *ServerOptions) (*Server, error) {
 	var err error
-	if err := dao.InitDao(serverOptions.SigNoz.SQLStore.SQLxDB(), serverOptions.SigNoz.SQLStore.BunDB()); err != nil {
+	if err := dao.InitDao(serverOptions.SigNoz.SQLStore); err != nil {
 		return nil, err
 	}
 
@@ -163,12 +163,12 @@ func NewServer(serverOptions *ServerOptions) (*Server, error) {
 		return nil, err
 	}
 
-	integrationsController, err := integrations.NewController(serverOptions.SigNoz.SQLStore.SQLxDB())
+	integrationsController, err := integrations.NewController(serverOptions.SigNoz.SQLStore)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create integrations controller: %w", err)
 	}
 
-	cloudIntegrationsController, err := cloudintegrations.NewController(serverOptions.SigNoz.SQLStore.SQLxDB())
+	cloudIntegrationsController, err := cloudintegrations.NewController(serverOptions.SigNoz.SQLStore)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create cloud provider integrations controller: %w", err)
 	}

--- a/pkg/query-service/app/server.go
+++ b/pkg/query-service/app/server.go
@@ -91,7 +91,7 @@ func (s Server) HealthCheckStatus() chan healthcheck.Status {
 // NewServer creates and initializes Server
 func NewServer(serverOptions *ServerOptions) (*Server, error) {
 	var err error
-	if err := dao.InitDao(serverOptions.SigNoz.SQLStore.SQLxDB()); err != nil {
+	if err := dao.InitDao(serverOptions.SigNoz.SQLStore.SQLxDB(), serverOptions.SigNoz.SQLStore.BunDB()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/query-service/auth/auth.go
+++ b/pkg/query-service/auth/auth.go
@@ -421,7 +421,7 @@ func RegisterFirstUser(ctx context.Context, req *RegisterRequest) (*model.User, 
 		Password:          hash,
 		CreatedAt:         time.Now().Unix(),
 		ProfilePictureURL: "", // Currently unused
-		GroupId:           group.Id,
+		GroupId:           group.ID,
 		OrgId:             org.Id,
 	}
 
@@ -499,7 +499,7 @@ func RegisterInvitedUser(ctx context.Context, req *RegisterRequest, nopassword b
 		Password:          hash,
 		CreatedAt:         time.Now().Unix(),
 		ProfilePictureURL: "", // Currently unused
-		GroupId:           group.Id,
+		GroupId:           group.ID,
 		OrgId:             invite.OrgId,
 	}
 

--- a/pkg/query-service/auth/rbac.go
+++ b/pkg/query-service/auth/rbac.go
@@ -31,7 +31,7 @@ func InitAuthCache(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrapf(err.Err, "failed to get group %s", groupName)
 		}
-		*dest = group.Id
+		*dest = group.ID
 		return nil
 	}
 

--- a/pkg/query-service/dao/factory.go
+++ b/pkg/query-service/dao/factory.go
@@ -2,14 +2,15 @@ package dao
 
 import (
 	"github.com/jmoiron/sqlx"
+	"github.com/uptrace/bun"
 	"go.signoz.io/signoz/pkg/query-service/dao/sqlite"
 )
 
 var db ModelDao
 
-func InitDao(inputDB *sqlx.DB) error {
+func InitDao(inputDB *sqlx.DB, bundb *bun.DB) error {
 	var err error
-	db, err = sqlite.InitDB(inputDB)
+	db, err = sqlite.InitDB(inputDB, bundb)
 	if err != nil {
 		return err
 	}

--- a/pkg/query-service/dao/factory.go
+++ b/pkg/query-service/dao/factory.go
@@ -1,16 +1,15 @@
 package dao
 
 import (
-	"github.com/jmoiron/sqlx"
-	"github.com/uptrace/bun"
 	"go.signoz.io/signoz/pkg/query-service/dao/sqlite"
+	"go.signoz.io/signoz/pkg/sqlstore"
 )
 
 var db ModelDao
 
-func InitDao(inputDB *sqlx.DB, bundb *bun.DB) error {
+func InitDao(sqlStore sqlstore.SQLStore) error {
 	var err error
-	db, err = sqlite.InitDB(inputDB, bundb)
+	db, err = sqlite.InitDB(sqlStore)
 	if err != nil {
 		return err
 	}

--- a/pkg/query-service/dao/interface.go
+++ b/pkg/query-service/dao/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.signoz.io/signoz/pkg/query-service/model"
+	"go.signoz.io/signoz/pkg/types"
 )
 
 type ModelDao interface {
@@ -22,7 +23,7 @@ type Queries interface {
 	GetUsersWithOpts(ctx context.Context, limit int) ([]model.UserPayload, *model.ApiError)
 
 	GetGroup(ctx context.Context, id string) (*model.Group, *model.ApiError)
-	GetGroupByName(ctx context.Context, name string) (*model.Group, *model.ApiError)
+	GetGroupByName(ctx context.Context, name string) (*types.Group, *model.ApiError)
 	GetGroups(ctx context.Context) ([]model.Group, *model.ApiError)
 
 	GetOrgs(ctx context.Context) ([]model.Organization, *model.ApiError)
@@ -50,7 +51,7 @@ type Mutations interface {
 
 	UpdateUserFlags(ctx context.Context, userId string, flags map[string]string) (model.UserFlag, *model.ApiError)
 
-	CreateGroup(ctx context.Context, group *model.Group) (*model.Group, *model.ApiError)
+	CreateGroup(ctx context.Context, group *types.Group) (*types.Group, *model.ApiError)
 	DeleteGroup(ctx context.Context, id string) *model.ApiError
 
 	CreateOrg(ctx context.Context, org *model.Organization) (*model.Organization, *model.ApiError)

--- a/pkg/query-service/dao/sqlite/connection.go
+++ b/pkg/query-service/dao/sqlite/connection.go
@@ -5,19 +5,22 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
 	"go.signoz.io/signoz/pkg/query-service/constants"
 	"go.signoz.io/signoz/pkg/query-service/model"
 	"go.signoz.io/signoz/pkg/query-service/telemetry"
+	"go.signoz.io/signoz/pkg/types"
 	"go.uber.org/zap"
 )
 
 type ModelDaoSqlite struct {
-	db *sqlx.DB
+	db    *sqlx.DB
+	bundb *bun.DB
 }
 
 // InitDB sets up setting up the connection pool global variable.
-func InitDB(db *sqlx.DB) (*ModelDaoSqlite, error) {
-	mds := &ModelDaoSqlite{db: db}
+func InitDB(db *sqlx.DB, bundb *bun.DB) (*ModelDaoSqlite, error) {
+	mds := &ModelDaoSqlite{db: db, bundb: bundb}
 
 	ctx := context.Background()
 	if err := mds.initializeOrgPreferences(ctx); err != nil {
@@ -97,7 +100,7 @@ func (mds *ModelDaoSqlite) initializeRBAC(ctx context.Context) error {
 }
 
 func (mds *ModelDaoSqlite) createGroupIfNotPresent(ctx context.Context,
-	name string) (*model.Group, error) {
+	name string) (*types.Group, error) {
 
 	group, err := mds.GetGroupByName(ctx, name)
 	if err != nil {
@@ -108,7 +111,7 @@ func (mds *ModelDaoSqlite) createGroupIfNotPresent(ctx context.Context,
 	}
 
 	zap.L().Debug("group is not found, creating it", zap.String("group_name", name))
-	group, cErr := mds.CreateGroup(ctx, &model.Group{Name: name})
+	group, cErr := mds.CreateGroup(ctx, &types.Group{Name: name})
 	if cErr != nil {
 		return nil, cErr.Err
 	}

--- a/pkg/query-service/dao/sqlite/connection.go
+++ b/pkg/query-service/dao/sqlite/connection.go
@@ -9,6 +9,7 @@ import (
 	"go.signoz.io/signoz/pkg/query-service/constants"
 	"go.signoz.io/signoz/pkg/query-service/model"
 	"go.signoz.io/signoz/pkg/query-service/telemetry"
+	"go.signoz.io/signoz/pkg/sqlstore"
 	"go.signoz.io/signoz/pkg/types"
 	"go.uber.org/zap"
 )
@@ -19,8 +20,8 @@ type ModelDaoSqlite struct {
 }
 
 // InitDB sets up setting up the connection pool global variable.
-func InitDB(db *sqlx.DB, bundb *bun.DB) (*ModelDaoSqlite, error) {
-	mds := &ModelDaoSqlite{db: db, bundb: bundb}
+func InitDB(sqlStore sqlstore.SQLStore) (*ModelDaoSqlite, error) {
+	mds := &ModelDaoSqlite{db: sqlStore.SQLxDB(), bundb: sqlStore.BunDB()}
 
 	ctx := context.Background()
 	if err := mds.initializeOrgPreferences(ctx); err != nil {

--- a/pkg/query-service/dao/sqlite/rbac.go
+++ b/pkg/query-service/dao/sqlite/rbac.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"go.signoz.io/signoz/pkg/query-service/model"
 	"go.signoz.io/signoz/pkg/query-service/telemetry"
+	"go.signoz.io/signoz/pkg/types"
 )
 
 func (mds *ModelDaoSqlite) CreateInviteEntry(ctx context.Context,
@@ -436,12 +437,13 @@ func (mds *ModelDaoSqlite) GetUsersByGroup(ctx context.Context,
 }
 
 func (mds *ModelDaoSqlite) CreateGroup(ctx context.Context,
-	group *model.Group) (*model.Group, *model.ApiError) {
+	group *types.Group) (*types.Group, *model.ApiError) {
 
-	group.Id = uuid.NewString()
+	group.ID = uuid.NewString()
 
-	q := `INSERT INTO groups (id, name) VALUES (?, ?);`
-	if _, err := mds.db.ExecContext(ctx, q, group.Id, group.Name); err != nil {
+	if _, err := mds.bundb.NewInsert().
+		Model(group).
+		Exec(ctx); err != nil {
 		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
 	}
 
@@ -478,10 +480,14 @@ func (mds *ModelDaoSqlite) GetGroup(ctx context.Context,
 }
 
 func (mds *ModelDaoSqlite) GetGroupByName(ctx context.Context,
-	name string) (*model.Group, *model.ApiError) {
+	name string) (*types.Group, *model.ApiError) {
 
-	groups := []model.Group{}
-	if err := mds.db.Select(&groups, `SELECT id, name FROM groups WHERE name=?`, name); err != nil {
+	groups := []types.Group{}
+	err := mds.bundb.NewSelect().
+		Model(&groups).
+		Where("name = ?", name).
+		Scan(ctx)
+	if err != nil {
 		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
 	}
 

--- a/pkg/query-service/tests/integration/filter_suggestions_test.go
+++ b/pkg/query-service/tests/integration/filter_suggestions_test.go
@@ -293,7 +293,7 @@ func NewFilterSuggestionsTestBed(t *testing.T) *FilterSuggestionsTestBed {
 	testDB := utils.NewQueryServiceDBForTests(t)
 
 	fm := featureManager.StartManager()
-	reader, mockClickhouse := NewMockClickhouseReader(t, testDB, fm)
+	reader, mockClickhouse := NewMockClickhouseReader(t, testDB.SQLxDB(), fm)
 	mockClickhouse.MatchExpectationsInOrder(false)
 
 	apiHandler, err := app.NewAPIHandler(app.APIHandlerOpts{

--- a/pkg/query-service/tests/integration/logparsingpipeline_test.go
+++ b/pkg/query-service/tests/integration/logparsingpipeline_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/jmoiron/sqlx"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/pkg/errors"
@@ -28,6 +27,7 @@ import (
 	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
 	"go.signoz.io/signoz/pkg/query-service/queryBuilderToExpr"
 	"go.signoz.io/signoz/pkg/query-service/utils"
+	"go.signoz.io/signoz/pkg/sqlstore"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 )
@@ -449,18 +449,18 @@ type LogPipelinesTestBed struct {
 }
 
 // testDB can be injected for sharing a DB across multiple integration testbeds.
-func NewTestbedWithoutOpamp(t *testing.T, testDB *sqlx.DB) *LogPipelinesTestBed {
-	if testDB == nil {
-		testDB = utils.NewQueryServiceDBForTests(t)
+func NewTestbedWithoutOpamp(t *testing.T, sqlStore sqlstore.SQLStore) *LogPipelinesTestBed {
+	if sqlStore == nil {
+		sqlStore = utils.NewQueryServiceDBForTests(t)
 	}
 
-	ic, err := integrations.NewController(testDB)
+	ic, err := integrations.NewController(sqlStore)
 	if err != nil {
 		t.Fatalf("could not create integrations controller: %v", err)
 	}
 
 	controller, err := logparsingpipeline.NewLogParsingPipelinesController(
-		testDB, ic.GetPipelinesForInstalledIntegrations,
+		sqlStore.SQLxDB(), ic.GetPipelinesForInstalledIntegrations,
 	)
 	if err != nil {
 		t.Fatalf("could not create a logparsingpipelines controller: %v", err)
@@ -481,7 +481,7 @@ func NewTestbedWithoutOpamp(t *testing.T, testDB *sqlx.DB) *LogPipelinesTestBed 
 	}
 
 	// Mock an available opamp agent
-	testDB, err = opampModel.InitDB(testDB)
+	testDB, err := opampModel.InitDB(sqlStore.SQLxDB())
 	require.Nil(t, err, "failed to init opamp model")
 
 	agentConfMgr, err := agentConf.Initiate(&agentConf.ManagerOptions{
@@ -499,7 +499,7 @@ func NewTestbedWithoutOpamp(t *testing.T, testDB *sqlx.DB) *LogPipelinesTestBed 
 	}
 }
 
-func NewLogPipelinesTestBed(t *testing.T, testDB *sqlx.DB) *LogPipelinesTestBed {
+func NewLogPipelinesTestBed(t *testing.T, testDB sqlstore.SQLStore) *LogPipelinesTestBed {
 	testbed := NewTestbedWithoutOpamp(t, testDB)
 
 	opampServer := opamp.InitializeServer(nil, testbed.agentConfMgr)

--- a/pkg/query-service/tests/integration/signoz_cloud_integrations_test.go
+++ b/pkg/query-service/tests/integration/signoz_cloud_integrations_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jmoiron/sqlx"
 	mockhouse "github.com/srikanthccv/ClickHouse-go-mock"
 	"github.com/stretchr/testify/require"
 	"go.signoz.io/signoz/pkg/http/middleware"
@@ -20,6 +19,7 @@ import (
 	"go.signoz.io/signoz/pkg/query-service/featureManager"
 	"go.signoz.io/signoz/pkg/query-service/model"
 	"go.signoz.io/signoz/pkg/query-service/utils"
+	"go.signoz.io/signoz/pkg/sqlstore"
 	"go.uber.org/zap"
 )
 
@@ -344,7 +344,7 @@ type CloudIntegrationsTestBed struct {
 }
 
 // testDB can be injected for sharing a DB across multiple integration testbeds.
-func NewCloudIntegrationsTestBed(t *testing.T, testDB *sqlx.DB) *CloudIntegrationsTestBed {
+func NewCloudIntegrationsTestBed(t *testing.T, testDB sqlstore.SQLStore) *CloudIntegrationsTestBed {
 	if testDB == nil {
 		testDB = utils.NewQueryServiceDBForTests(t)
 	}
@@ -355,7 +355,7 @@ func NewCloudIntegrationsTestBed(t *testing.T, testDB *sqlx.DB) *CloudIntegratio
 	}
 
 	fm := featureManager.StartManager()
-	reader, mockClickhouse := NewMockClickhouseReader(t, testDB, fm)
+	reader, mockClickhouse := NewMockClickhouseReader(t, testDB.SQLxDB(), fm)
 	mockClickhouse.MatchExpectationsInOrder(false)
 
 	apiHandler, err := app.NewAPIHandler(app.APIHandlerOpts{

--- a/pkg/query-service/tests/integration/signoz_integrations_test.go
+++ b/pkg/query-service/tests/integration/signoz_integrations_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	mockhouse "github.com/srikanthccv/ClickHouse-go-mock"
 	"github.com/stretchr/testify/require"
 	"go.signoz.io/signoz/pkg/http/middleware"
@@ -23,6 +22,7 @@ import (
 	"go.signoz.io/signoz/pkg/query-service/model"
 	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
 	"go.signoz.io/signoz/pkg/query-service/utils"
+	"go.signoz.io/signoz/pkg/sqlstore"
 	"go.uber.org/zap"
 )
 
@@ -546,7 +546,7 @@ func (tb *IntegrationsTestBed) mockMetricStatusQueryResponse(expectation *model.
 }
 
 // testDB can be injected for sharing a DB across multiple integration testbeds.
-func NewIntegrationsTestBed(t *testing.T, testDB *sqlx.DB) *IntegrationsTestBed {
+func NewIntegrationsTestBed(t *testing.T, testDB sqlstore.SQLStore) *IntegrationsTestBed {
 	if testDB == nil {
 		testDB = utils.NewQueryServiceDBForTests(t)
 	}
@@ -557,7 +557,7 @@ func NewIntegrationsTestBed(t *testing.T, testDB *sqlx.DB) *IntegrationsTestBed 
 	}
 
 	fm := featureManager.StartManager()
-	reader, mockClickhouse := NewMockClickhouseReader(t, testDB, fm)
+	reader, mockClickhouse := NewMockClickhouseReader(t, testDB.SQLxDB(), fm)
 	mockClickhouse.MatchExpectationsInOrder(false)
 
 	cloudIntegrationsController, err := cloudintegrations.NewController(testDB)

--- a/pkg/query-service/tests/integration/test_utils.go
+++ b/pkg/query-service/tests/integration/test_utils.go
@@ -176,7 +176,7 @@ func createTestUser() (*model.User, *model.ApiError) {
 			Email:    userId[:8] + "test@test.com",
 			Password: "test",
 			OrgId:    org.Id,
-			GroupId:  group.Id,
+			GroupId:  group.ID,
 		},
 		true,
 	)

--- a/pkg/query-service/utils/testutils.go
+++ b/pkg/query-service/utils/testutils.go
@@ -63,7 +63,7 @@ func NewQueryServiceDBForTests(t *testing.T) sqlstore.SQLStore {
 	sqlStore, _ := NewTestSqliteDB(t)
 
 	dao.InitDao(sqlStore)
-	dashboards.InitDB((sqlStore).SQLxDB())
+	dashboards.InitDB(sqlStore.SQLxDB())
 
 	return sqlStore
 }

--- a/pkg/query-service/utils/testutils.go
+++ b/pkg/query-service/utils/testutils.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/uptrace/bun"
 	"go.signoz.io/signoz/pkg/factory"
 	"go.signoz.io/signoz/pkg/factory/providertest"
 	"go.signoz.io/signoz/pkg/query-service/app/dashboards"
@@ -17,7 +18,7 @@ import (
 	"go.signoz.io/signoz/pkg/sqlstore/sqlitesqlstore"
 )
 
-func NewTestSqliteDB(t *testing.T) (testDB *sqlx.DB, testDBFilePath string) {
+func NewTestSqliteDB(t *testing.T) (testDB *sqlx.DB, testDBFilePath string, bundb *bun.DB) {
 	testDBFile, err := os.CreateTemp("", "test-signoz-db-*")
 	if err != nil {
 		t.Fatalf("could not create temp file for test db: %v", err)
@@ -59,14 +60,14 @@ func NewTestSqliteDB(t *testing.T) (testDB *sqlx.DB, testDBFilePath string) {
 
 	testDB = sqlstore.SQLxDB()
 
-	return testDB, testDBFilePath
+	return testDB, testDBFilePath, sqlstore.BunDB()
 }
 
 func NewQueryServiceDBForTests(t *testing.T) *sqlx.DB {
-	testDB, _ := NewTestSqliteDB(t)
+	testDB, _, bundb := NewTestSqliteDB(t)
 
 	// TODO(Raj): This should not require passing in the DB file path
-	dao.InitDao(testDB)
+	dao.InitDao(testDB, bundb)
 	dashboards.InitDB(testDB)
 
 	return testDB

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -7,6 +7,7 @@ import (
 	"go.signoz.io/signoz/pkg/factory"
 	"go.signoz.io/signoz/pkg/sqlmigration"
 	"go.signoz.io/signoz/pkg/sqlstore"
+	"go.signoz.io/signoz/pkg/sqlstore/postgressqlstore"
 	"go.signoz.io/signoz/pkg/sqlstore/sqlitesqlstore"
 	"go.signoz.io/signoz/pkg/telemetrystore"
 	"go.signoz.io/signoz/pkg/telemetrystore/clickhousetelemetrystore"
@@ -46,7 +47,7 @@ func NewProviderConfig() ProviderConfig {
 		),
 		SQLStoreProviderFactories: factory.MustNewNamedMap(
 			sqlitesqlstore.NewFactory(),
-			// postgressqlstore.NewFactory(),
+			postgressqlstore.NewFactory(),
 		),
 		SQLMigrationProviderFactories: factory.MustNewNamedMap(
 			sqlmigration.NewAddDataMigrationsFactory(),

--- a/pkg/types/license.go
+++ b/pkg/types/license.go
@@ -30,11 +30,11 @@ type Site struct {
 type FeatureStatus struct {
 	bun.BaseModel `bun:"table:feature_status"`
 
-	Name       string `bun:"name,pk,type:text"`
-	Active     bool   `bun:"active"`
-	Usage      int    `bun:"usage,default:0"`
-	UsageLimit int    `bun:"usage_limit,default:0"`
-	Route      string `bun:"route,type:text"`
+	Name       string `bun:"name,pk,type:text" json:"name"`
+	Active     bool   `bun:"active" json:"active"`
+	Usage      int    `bun:"usage,default:0" json:"usage"`
+	UsageLimit int    `bun:"usage_limit,default:0" json:"usage_limit"`
+	Route      string `bun:"route,type:text" json:"route"`
 }
 
 type LicenseV3 struct {

--- a/pkg/types/organization.go
+++ b/pkg/types/organization.go
@@ -31,8 +31,8 @@ type Invite struct {
 
 type Group struct {
 	bun.BaseModel `bun:"table:groups"`
-	ID            string `bun:"id,pk,type:text"`
-	Name          string `bun:"name,type:text,notnull,unique"`
+	ID            string `bun:"id,pk,type:text" json:"id"`
+	Name          string `bun:"name,type:text,notnull,unique" json:"name"`
 }
 
 type User struct {


### PR DESCRIPTION
Fixes https://github.com/SigNoz/platform-pod/issues/457

All necessary changes so that whatever initalize SQL commans run, they are moved to bun so that it works with both sqlite and postgres.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor SigNoz to support both SQLite and Postgres by abstracting database initialization and updating tests.
> 
>   - **Database Initialization**:
>     - Replace `SQLx.DB` with `SQLStore` in `dao/factory.go`, `dao/sqlite/connection.go`, and `app/server.go` for database initialization.
>     - Update `NewController` functions in `cloudintegrations/controller.go` and `integrations/controller.go` to use `SQLStore`.
>   - **Field Renaming**:
>     - Rename `Id` to `ID` in multiple files for consistency, including `auth.go`, `rbac.go`, and `http_handler.go`.
>   - **Test Updates**:
>     - Update test cases in `controller_test.go`, `logparsingpipeline_test.go`, and `signoz_integrations_test.go` to use `SQLStore`.
>     - Modify test utilities in `test_utils.go` and `utils/testutils.go` to support `SQLStore`.
>   - **Miscellaneous**:
>     - Add Postgres support in `provider.go` by including `postgressqlstore.NewFactory()`.
>     - Update `FeatureStatus` model in `license.go` to use `bun` ORM for compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e8bc4779623049bfa6a6b49a097f22b09076460c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->