### PR TITLE
fix(AutoRefresh): reflect default value selection when auto refresh i…

### DIFF
--- a/frontend/src/container/TopNav/AutoRefreshV2/index.tsx
+++ b/frontend/src/container/TopNav/AutoRefreshV2/index.tsx
@@ -127,6 +127,10 @@ function AutoRefresh({
 					DASHBOARD_TIME_IN_DURATION,
 					JSON.stringify(_omit(localStorageData, pathname)),
 				);
+				setSelectedOption('off'); // Ensure selectedOption reflects the removal
+			} else {
+				// Ensure default option reflects
+				setSelectedOption('30s');
 			}
 			setIsAutoRefreshfreshEnabled(checked);
 		},


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->
Ensure the default value of auto-refresh (30s) is reflected when the user selects it  

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->
#7048

#### Screenshots

[screen-capture (12).webm](https://github.com/user-attachments/assets/c8db2354-1204-4d3c-bfd3-c81b52ee22e2)

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
frontend/src/container/TopNav/AutoRefreshV2/index.tsx

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix default value selection for auto-refresh in `AutoRefresh` component to reflect '30s' when enabled.
> 
>   - **Behavior**:
>     - In `AutoRefresh` component, `onChangeAutoRefreshHandler` now sets `selectedOption` to '30s' when auto-refresh is enabled.
>     - Ensures default value is reflected when user selects auto-refresh.
>   - **Affected Areas**:
>     - `frontend/src/container/TopNav/AutoRefreshV2/index.tsx`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for ff5fb499256d3568d5bb4bf2d3fe265d493a7799. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->