### PR TITLE
fix: typo in pod filesystem usage legend

### DIFF
--- a/frontend/src/container/InfraMonitoringK8s/Pods/PodDetails/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8s/Pods/PodDetails/constants.ts
@@ -2633,7 +2633,7 @@ export const getPodMetricsQueryPayload = (
 						functions: [],
 						groupBy: [],
 						having: [],
-						legend: 'Uage',
+						legend: 'Usage',
 						limit: null,
 						orderBy: [],
 						queryName: 'C',


### PR DESCRIPTION
### Summary
Noticed a small typo when looking into pod filesystem usage.
Fixed `Uage` --> `Usage`
#### Related Issues / PR's
NA
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
<img width="403" alt="CleanShot 2025-02-17 at 20 22 56@2x" src="https://github.com/user-attachments/assets/6356dac3-900b-4d49-8f90-a9a5bd3425fb" />
<!-- ✍️ Add screenshots of before and after changes where applicable-->


<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes typo in `legend` from `Uage` to `Usage` in `getPodMetricsQueryPayload` function in `constants.ts`.
> 
>   - **Fixes**:
>     - Corrects typo in `legend` from `Uage` to `Usage` in `getPodMetricsQueryPayload` function in `constants.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e38cfb29e346da27e91a0a54845a674cd3145e9d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->