### PR TITLE
fix: org domain

### DIFF
--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -61,6 +61,7 @@ func NewProviderConfig() ProviderConfig {
 			sqlmigration.NewAddLicensesFactory(),
 			sqlmigration.NewAddPatsFactory(),
 			sqlmigration.NewModifyDatetimeFactory(),
+			sqlmigration.NewModifyOrgDomainFactory(),
 		),
 		TelemetryStoreProviderFactories: factory.MustNewNamedMap(
 			clickhousetelemetrystore.NewFactory(telemetrystorehook.NewFactory()),

--- a/pkg/sqlmigration/012_modify_org_domain.go
+++ b/pkg/sqlmigration/012_modify_org_domain.go
@@ -27,11 +27,6 @@ func (migration *modifyOrgDomain) Register(migrations *migrate.Migrations) error
 }
 
 func (migration *modifyOrgDomain) Up(ctx context.Context, db *bun.DB) error {
-	// only run this for old sqlite db
-	if db.Dialect().Name().String() != "sqlite" {
-		return nil
-	}
-
 	// begin transaction
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
@@ -44,12 +39,10 @@ func (migration *modifyOrgDomain) Up(ctx context.Context, db *bun.DB) error {
 		return err
 	}
 
-	// cannot add not null constraint to the column
 	if _, err := tx.ExecContext(ctx, `ALTER TABLE org_domains ADD COLUMN updated_at INTEGER`); err != nil {
 		return err
 	}
 
-	// update the new column with the value of the old column
 	if _, err := tx.ExecContext(ctx, `UPDATE org_domains SET updated_at = CAST(updated_at_old AS INTEGER)`); err != nil {
 		return err
 	}

--- a/pkg/sqlmigration/012_modify_org_domain.go
+++ b/pkg/sqlmigration/012_modify_org_domain.go
@@ -1,0 +1,71 @@
+package sqlmigration
+
+import (
+	"context"
+
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/migrate"
+	"go.signoz.io/signoz/pkg/factory"
+)
+
+type modifyOrgDomain struct{}
+
+func NewModifyOrgDomainFactory() factory.ProviderFactory[SQLMigration, Config] {
+	return factory.NewProviderFactory(factory.MustNewName("modify_org_domain"), newModifyOrgDomain)
+}
+
+func newModifyOrgDomain(_ context.Context, _ factory.ProviderSettings, _ Config) (SQLMigration, error) {
+	return &modifyOrgDomain{}, nil
+}
+
+func (migration *modifyOrgDomain) Register(migrations *migrate.Migrations) error {
+	if err := migrations.Register(migration.Up, migration.Down); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (migration *modifyOrgDomain) Up(ctx context.Context, db *bun.DB) error {
+	// only run this for old sqlite db
+	if db.Dialect().Name().String() != "sqlite" {
+		return nil
+	}
+
+	// begin transaction
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// rename old column
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE org_domains RENAME COLUMN updated_at TO updated_at_old`); err != nil {
+		return err
+	}
+
+	// cannot add not null constraint to the column
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE org_domains ADD COLUMN updated_at INTEGER`); err != nil {
+		return err
+	}
+
+	// update the new column with the value of the old column
+	if _, err := tx.ExecContext(ctx, `UPDATE org_domains SET updated_at = CAST(updated_at_old AS INTEGER)`); err != nil {
+		return err
+	}
+
+	// drop the old column
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE org_domains DROP COLUMN updated_at_old`); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (migration *modifyOrgDomain) Down(ctx context.Context, db *bun.DB) error {
+	return nil
+}


### PR DESCRIPTION
Fixes the updated_at type of org domain
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds SQL migration to modify `updated_at` column in `org_domains` table and updates provider configuration.
> 
>   - **SQL Migration**:
>     - Adds `012_modify_org_domain.go` to modify `updated_at` column in `org_domains` table.
>     - Renames `updated_at` to `updated_at_old`, adds new `updated_at` as `INTEGER`, and updates values.
>     - Drops `updated_at_old` column after migration.
>   - **Provider Configuration**:
>     - Adds `NewModifyOrgDomainFactory()` to `SQLMigrationProviderFactories` in `provider.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for cf6c5494bbfac41ec445ce4095301c35783b8deb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->