### PR TITLE
chore: reset filters while going from hosts list to host details

### DIFF
--- a/frontend/src/components/HostMetricsDetail/HostMetricTraces/HostMetricTraces.tsx
+++ b/frontend/src/components/HostMetricsDetail/HostMetricTraces/HostMetricTraces.tsx
@@ -67,6 +67,10 @@ function HostMetricTraces({
 						aggregateAttribute: {
 							...currentQuery.builder.queryData[0].aggregateAttribute,
 						},
+						filters: {
+							items: [],
+							op: 'AND',
+						},
 					},
 				],
 			},

--- a/frontend/src/components/HostMetricsDetail/HostMetricsLogs/HostMetricLogsDetailedView.tsx
+++ b/frontend/src/components/HostMetricsDetail/HostMetricsLogs/HostMetricLogsDetailedView.tsx
@@ -50,6 +50,10 @@ function HostMetricLogsDetailedView({
 						aggregateAttribute: {
 							...currentQuery.builder.queryData[0].aggregateAttribute,
 						},
+						filters: {
+							items: [],
+							op: 'AND',
+						},
 					},
 				],
 			},

--- a/frontend/src/container/InfraMonitoringHosts/InfraMonitoring.styles.scss
+++ b/frontend/src/container/InfraMonitoringHosts/InfraMonitoring.styles.scss
@@ -55,11 +55,14 @@
 	.hosts-list-content {
 		display: flex;
 		flex-direction: row;
+		align-items: stretch;
+		height: calc(100vh - 110px);
 
 		.hosts-quick-filters-container {
 			width: 280px;
 			min-width: 280px;
 			border-right: 1px solid var(--bg-slate-400);
+			height: 100%;
 
 			.hosts-quick-filters-container-header {
 				padding: 8px;
@@ -193,7 +196,7 @@
 		.ant-pagination {
 			position: fixed;
 			bottom: 0;
-			width: calc(100% - 64px);
+			width: calc(100% - 364px);
 			background: var(--bg-ink-500);
 			padding: 16px;
 			margin: 0;


### PR DESCRIPTION
### Summary

- Reset the quick filters applied on hosts list while going to host details page
- Minor CSS fix to make the filters side panel take full height

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

Infra Monitoring Hosts
