### PR TITLE
feat(inspect): added inspect metric api | 7076

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -6328,3 +6328,94 @@ LIMIT 30
 
 	return result, nil
 }
+
+func (r *ClickHouseReader) GetInspectMetrics(ctx context.Context, req *metrics_explorer.InspectMetricsRequest) (*metrics_explorer.InspectMetricsResponse, *model.ApiError) {
+	query := fmt.Sprintf(`SELECT
+                fingerprint,
+                labels,
+                unix_milli,
+                value as per_series_value
+        FROM
+                signoz_metrics.distributed_samples_v4
+        INNER JOIN (
+                SELECT DISTINCT
+                        fingerprint,
+                        labels
+                FROM
+                        %s.%s
+                WHERE
+                        metric_name = ?
+                        AND unix_milli >= ?
+                        AND unix_milli < ? LIMIT 20) as filtered_time_series
+                USING fingerprint
+        WHERE
+                metric_name  = ?
+                AND unix_milli >= ?
+                AND unix_milli < ?
+                ORDER BY fingerprint DESC, unix_milli DESC`, signozMetricDBName, signozTSLocalTableNameV4)
+
+	rows, err := r.db.Query(ctx, query, req.MetricName, req.Start, req.End, req.MetricName, req.Start, req.End)
+	if err != nil {
+		return nil, &model.ApiError{Typ: "ClickHouseError", Err: err}
+	}
+	defer rows.Close()
+
+	// Create a map to group points by fingerprint.
+	seriesMap := make(map[uint64]*v3.Series)
+
+	for rows.Next() {
+		var fingerprint uint64
+		var labelsJSON string
+		var unixMilli int64
+		var perSeriesValue float64
+
+		if err := rows.Scan(&fingerprint, &labelsJSON, &unixMilli, &perSeriesValue); err != nil {
+			return nil, &model.ApiError{Typ: "ClickHouseError", Err: err}
+		}
+
+		// Unmarshal the JSON labels into a map.
+		var labelsMap map[string]string
+		if err := json.Unmarshal([]byte(labelsJSON), &labelsMap); err != nil {
+			return nil, &model.ApiError{Typ: "JsonUnmarshalError", Err: err}
+		}
+
+		// Convert labelsMap into a slice of single-key maps.
+		var labelsArray []map[string]string
+		for k, v := range labelsMap {
+			labelsArray = append(labelsArray, map[string]string{k: v})
+		}
+
+		// Check if we already have a Series for this fingerprint.
+		series, exists := seriesMap[fingerprint]
+		if !exists {
+			// Initialize a new Series with the parsed labels and labelsArray.
+			series = &v3.Series{
+				Labels:      labelsMap,
+				LabelsArray: labelsArray,
+				Points:      []v3.Point{},
+			}
+			seriesMap[fingerprint] = series
+		}
+
+		// Append the current point to the Series.
+		series.Points = append(series.Points, v3.Point{
+			Timestamp: unixMilli,
+			Value:     perSeriesValue,
+		})
+	}
+
+	// Check for any error encountered during iteration.
+	if err = rows.Err(); err != nil {
+		return nil, &model.ApiError{Typ: "ClickHouseError", Err: err}
+	}
+
+	// Convert the map to a slice to build the response.
+	var seriesList []v3.Series
+	for _, s := range seriesMap {
+		seriesList = append(seriesList, *s)
+	}
+
+	return &metrics_explorer.InspectMetricsResponse{
+		Series: &seriesList,
+	}, nil
+}

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -1143,7 +1143,7 @@ func (r *ClickHouseReader) GetUsage(ctx context.Context, queryParams *model.GetU
 
 func (r *ClickHouseReader) SearchTracesV2(ctx context.Context, params *model.SearchTracesParams,
 	smartTraceAlgorithm func(payload []model.SearchSpanResponseItem, targetSpanId string,
-		levelUp int, levelDown int, spanLimit int) ([]model.SearchSpansResult, error)) (*[]model.SearchSpansResult, error) {
+	levelUp int, levelDown int, spanLimit int) ([]model.SearchSpansResult, error)) (*[]model.SearchSpansResult, error) {
 	searchSpansResult := []model.SearchSpansResult{
 		{
 			Columns:   []string{"__time", "SpanId", "TraceId", "ServiceName", "Name", "Kind", "DurationNano", "TagsKeys", "TagsValues", "References", "Events", "HasError", "StatusMessage", "StatusCodeString", "SpanKind"},
@@ -1291,7 +1291,7 @@ func (r *ClickHouseReader) SearchTracesV2(ctx context.Context, params *model.Sea
 
 func (r *ClickHouseReader) SearchTraces(ctx context.Context, params *model.SearchTracesParams,
 	smartTraceAlgorithm func(payload []model.SearchSpanResponseItem, targetSpanId string,
-		levelUp int, levelDown int, spanLimit int) ([]model.SearchSpansResult, error)) (*[]model.SearchSpansResult, error) {
+	levelUp int, levelDown int, spanLimit int) ([]model.SearchSpansResult, error)) (*[]model.SearchSpansResult, error) {
 
 	if r.useTraceNewSchema {
 		return r.SearchTracesV2(ctx, params, smartTraceAlgorithm)
@@ -6330,6 +6330,7 @@ LIMIT 30
 }
 
 func (r *ClickHouseReader) GetInspectMetrics(ctx context.Context, req *metrics_explorer.InspectMetricsRequest) (*metrics_explorer.InspectMetricsResponse, *model.ApiError) {
+	start, end, _, localTsTable := utils.WhichTSTableToUse(req.Start, req.End)
 	query := fmt.Sprintf(`SELECT
                 fingerprint,
                 labels,
@@ -6352,15 +6353,14 @@ func (r *ClickHouseReader) GetInspectMetrics(ctx context.Context, req *metrics_e
                 metric_name  = ?
                 AND unix_milli >= ?
                 AND unix_milli < ?
-                ORDER BY fingerprint DESC, unix_milli DESC`, signozMetricDBName, signozTSLocalTableNameV4)
+                ORDER BY fingerprint DESC, unix_milli DESC`, signozMetricDBName, localTsTable)
 
-	rows, err := r.db.Query(ctx, query, req.MetricName, req.Start, req.End, req.MetricName, req.Start, req.End)
+	rows, err := r.db.Query(ctx, query, req.MetricName, start, end, req.MetricName, start, end)
 	if err != nil {
 		return nil, &model.ApiError{Typ: "ClickHouseError", Err: err}
 	}
 	defer rows.Close()
 
-	// Create a map to group points by fingerprint.
 	seriesMap := make(map[uint64]*v3.Series)
 
 	for rows.Next() {
@@ -6373,43 +6373,45 @@ func (r *ClickHouseReader) GetInspectMetrics(ctx context.Context, req *metrics_e
 			return nil, &model.ApiError{Typ: "ClickHouseError", Err: err}
 		}
 
-		// Unmarshal the JSON labels into a map.
 		var labelsMap map[string]string
 		if err := json.Unmarshal([]byte(labelsJSON), &labelsMap); err != nil {
 			return nil, &model.ApiError{Typ: "JsonUnmarshalError", Err: err}
 		}
 
-		// Convert labelsMap into a slice of single-key maps.
-		var labelsArray []map[string]string
+		// Filter out keys starting with "__"
+		filteredLabelsMap := make(map[string]string)
 		for k, v := range labelsMap {
+			if !strings.HasPrefix(k, "__") {
+				filteredLabelsMap[k] = v
+			}
+		}
+
+		var labelsArray []map[string]string
+		for k, v := range filteredLabelsMap {
 			labelsArray = append(labelsArray, map[string]string{k: v})
 		}
 
 		// Check if we already have a Series for this fingerprint.
 		series, exists := seriesMap[fingerprint]
 		if !exists {
-			// Initialize a new Series with the parsed labels and labelsArray.
 			series = &v3.Series{
-				Labels:      labelsMap,
+				Labels:      filteredLabelsMap,
 				LabelsArray: labelsArray,
 				Points:      []v3.Point{},
 			}
 			seriesMap[fingerprint] = series
 		}
 
-		// Append the current point to the Series.
 		series.Points = append(series.Points, v3.Point{
 			Timestamp: unixMilli,
 			Value:     perSeriesValue,
 		})
 	}
 
-	// Check for any error encountered during iteration.
 	if err = rows.Err(); err != nil {
 		return nil, &model.ApiError{Typ: "ClickHouseError", Err: err}
 	}
 
-	// Convert the map to a slice to build the response.
 	var seriesList []v3.Series
 	for _, s := range seriesMap {
 		seriesList = append(seriesList, *s)

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -630,6 +630,9 @@ func (ah *APIHandler) MetricExplorerRoutes(router *mux.Router, am *AuthMiddlewar
 	router.HandleFunc("/api/v1/metrics/related",
 		am.ViewAccess(ah.GetRelatedMetrics)).
 		Methods(http.MethodPost)
+	router.HandleFunc("/api/v1/metrics/inspect",
+		am.ViewAccess(ah.GetInspectMetricsData)).
+		Methods(http.MethodPost)
 }
 
 func Intersection(a, b []int) (c []int) {

--- a/pkg/query-service/app/metricsexplorer/parser.go
+++ b/pkg/query-service/app/metricsexplorer/parser.go
@@ -82,7 +82,7 @@ func ParseInspectMetricsParams(r *http.Request) (*metrics_explorer.InspectMetric
 	if err := json.NewDecoder(r.Body).Decode(&inspectMetricParams); err != nil {
 		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("cannot parse the request body: %v", err)}
 	}
-	if inspectMetricParams.End-inspectMetricParams.Start > 180000 { // half hour only
+	if inspectMetricParams.End-inspectMetricParams.Start > 1800000 { // half hour only
 		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("time duration shouldn't be more than 30 mins")}
 	}
 	return &inspectMetricParams, nil

--- a/pkg/query-service/app/metricsexplorer/parser.go
+++ b/pkg/query-service/app/metricsexplorer/parser.go
@@ -82,8 +82,8 @@ func ParseInspectMetricsParams(r *http.Request) (*metrics_explorer.InspectMetric
 	if err := json.NewDecoder(r.Body).Decode(&inspectMetricParams); err != nil {
 		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("cannot parse the request body: %v", err)}
 	}
-	//if inspectMetricParams.End-inspectMetricParams.Start > 180000 {
-	//	return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("time duration shouldn't be more than 15 mins")}
-	//}
+	if inspectMetricParams.End-inspectMetricParams.Start > 180000 { // half hour only
+		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("time duration shouldn't be more than 15 mins")}
+	}
 	return &inspectMetricParams, nil
 }

--- a/pkg/query-service/app/metricsexplorer/parser.go
+++ b/pkg/query-service/app/metricsexplorer/parser.go
@@ -83,7 +83,7 @@ func ParseInspectMetricsParams(r *http.Request) (*metrics_explorer.InspectMetric
 		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("cannot parse the request body: %v", err)}
 	}
 	if inspectMetricParams.End-inspectMetricParams.Start > 180000 { // half hour only
-		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("time duration shouldn't be more than 15 mins")}
+		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("time duration shouldn't be more than 30 mins")}
 	}
 	return &inspectMetricParams, nil
 }

--- a/pkg/query-service/app/metricsexplorer/parser.go
+++ b/pkg/query-service/app/metricsexplorer/parser.go
@@ -76,3 +76,14 @@ func ParseRelatedMetricsParams(r *http.Request) (*metrics_explorer.RelatedMetric
 	}
 	return &relatedMetricParams, nil
 }
+
+func ParseInspectMetricsParams(r *http.Request) (*metrics_explorer.InspectMetricsRequest, *model.ApiError) {
+	var inspectMetricParams metrics_explorer.InspectMetricsRequest
+	if err := json.NewDecoder(r.Body).Decode(&inspectMetricParams); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("cannot parse the request body: %v", err)}
+	}
+	//if inspectMetricParams.End-inspectMetricParams.Start > 180000 {
+	//	return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("time duration shouldn't be more than 15 mins")}
+	//}
+	return &inspectMetricParams, nil
+}

--- a/pkg/query-service/app/metricsexplorer/summary.go
+++ b/pkg/query-service/app/metricsexplorer/summary.go
@@ -329,3 +329,7 @@ func GetQueryRangeForRelateMetricsList(metricName string, scores metrics_explore
 
 	return &query
 }
+
+func (receiver *SummaryService) GetInspectMetrics(ctx context.Context, params *metrics_explorer.InspectMetricsRequest) (*metrics_explorer.InspectMetricsResponse, *model.ApiError) {
+	return receiver.reader.GetInspectMetrics(ctx, params)
+}

--- a/pkg/query-service/app/summary.go
+++ b/pkg/query-service/app/summary.go
@@ -122,3 +122,23 @@ func (aH *APIHandler) GetRelatedMetrics(w http.ResponseWriter, r *http.Request) 
 	aH.Respond(w, result)
 
 }
+
+func (aH *APIHandler) GetInspectMetricsData(w http.ResponseWriter, r *http.Request) {
+	bodyBytes, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	ctx := r.Context()
+	params, apiError := explorer.ParseInspectMetricsParams(r)
+	if apiError != nil {
+		zap.L().Error("error parsing metric query range params", zap.Error(apiError.Err))
+		RespondError(w, apiError, nil)
+		return
+	}
+	result, apiError := aH.SummaryService.GetInspectMetrics(ctx, params)
+	if apiError != nil {
+		zap.L().Error("error getting heatmap data", zap.Error(apiError.Err))
+		RespondError(w, apiError, nil)
+		return
+	}
+	aH.Respond(w, result)
+
+}

--- a/pkg/query-service/app/summary.go
+++ b/pkg/query-service/app/summary.go
@@ -135,7 +135,7 @@ func (aH *APIHandler) GetInspectMetricsData(w http.ResponseWriter, r *http.Reque
 	}
 	result, apiError := aH.SummaryService.GetInspectMetrics(ctx, params)
 	if apiError != nil {
-		zap.L().Error("error getting heatmap data", zap.Error(apiError.Err))
+		zap.L().Error("error getting inspect metrics data", zap.Error(apiError.Err))
 		RespondError(w, apiError, nil)
 		return
 	}

--- a/pkg/query-service/interfaces/interface.go
+++ b/pkg/query-service/interfaces/interface.go
@@ -133,6 +133,7 @@ type Reader interface {
 	GetMetricsTimeSeriesPercentage(ctx context.Context, request *metrics_explorer.TreeMapMetricsRequest) (*[]metrics_explorer.TreeMapResponseItem, *model.ApiError)
 	GetMetricsSamplesPercentage(ctx context.Context, req *metrics_explorer.TreeMapMetricsRequest) (*[]metrics_explorer.TreeMapResponseItem, *model.ApiError)
 	GetRelatedMetrics(ctx context.Context, req *metrics_explorer.RelatedMetricsRequest) (map[string]metrics_explorer.RelatedMetricsScore, *model.ApiError)
+	GetInspectMetrics(ctx context.Context, req *metrics_explorer.InspectMetricsRequest) (*metrics_explorer.InspectMetricsResponse, *model.ApiError)
 }
 
 type Querier interface {

--- a/pkg/query-service/model/metrics_explorer/summary.go
+++ b/pkg/query-service/model/metrics_explorer/summary.go
@@ -147,3 +147,14 @@ type RelatedMetrics struct {
 	Alerts     []Alert          `json:"alerts"`
 	Query      *v3.BuilderQuery `json:"query"`
 }
+
+type InspectMetricsRequest struct {
+	MetricName string       `json:"metricName"`
+	Filters    v3.FilterSet `json:"filters"`
+	Start      int64        `json:"start"`
+	End        int64        `json:"end"`
+}
+
+type InspectMetricsResponse struct {
+	Series *[]v3.Series `json:"series,omitempty"`
+}


### PR DESCRIPTION
### Summary

Added Inspect metric apis for metric explorer

#### Related Issues / PR's
(https://github.com/SigNoz/signoz/issues/7076)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a new API for inspecting metrics, including database querying, request parsing, and route handling.
> 
>   - **Behavior**:
>     - Adds `GetInspectMetrics` function in `reader.go` to query metrics data from ClickHouse.
>     - Introduces `/api/v1/metrics/inspect` route in `http_handler.go` for inspecting metrics.
>     - Implements `ParseInspectMetricsParams` in `parser.go` to parse request parameters.
>   - **Service and Interface**:
>     - Adds `GetInspectMetrics` method to `SummaryService` in `summary.go`.
>     - Updates `Reader` interface in `interface.go` to include `GetInspectMetrics` method.
>   - **Models**:
>     - Adds `InspectMetricsRequest` and `InspectMetricsResponse` structs in `metrics_explorer/summary.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for a431b53af429bf8ebb5206ff544435a51ea1cd74. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->