### PR TITLE
feat(summary view): added summary view endpoints

### DIFF
--- a/ee/query-service/app/server.go
+++ b/ee/query-service/app/server.go
@@ -375,6 +375,7 @@ func (s *Server) createPublicServer(apiHandler *api.APIHandler, web web.Web) (*h
 	apiHandler.RegisterWebSocketPaths(r, am)
 	apiHandler.RegisterMessagingQueuesRoutes(r, am)
 	apiHandler.RegisterThirdPartyApiRoutes(r, am)
+	apiHandler.MetricExplorerRoutes(r, am)
 
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},

--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 	golang.org/x/net v0.33.0
 	golang.org/x/oauth2 v0.24.0
+	golang.org/x/sync v0.10.0
 	golang.org/x/text v0.21.0
 	google.golang.org/grpc v1.67.1
 	google.golang.org/protobuf v1.35.2
@@ -263,7 +264,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/mod v0.22.0 // indirect
-	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/time v0.6.0 // indirect
 	golang.org/x/tools v0.28.0 // indirect

--- a/pkg/query-service/app/dashboards/model.go
+++ b/pkg/query-service/app/dashboards/model.go
@@ -537,3 +537,87 @@ func countPanelsInDashboard(inputData map[string]interface{}) model.DashboardsIn
 		LogsPanelsWithAttrContainsOp: logsPanelsWithAttrContains,
 	}
 }
+
+func GetDashboardsWithMetricName(ctx context.Context, metricName string) ([]map[string]string, *model.ApiError) {
+	// Get all dashboards first
+	query := `SELECT uuid, data FROM dashboards`
+
+	type dashboardRow struct {
+		Uuid string          `db:"uuid"`
+		Data json.RawMessage `db:"data"`
+	}
+
+	var dashboards []dashboardRow
+	err := db.Select(&dashboards, query)
+	if err != nil {
+		zap.L().Error("Error in getting dashboards", zap.Error(err))
+		return nil, &model.ApiError{Typ: model.ErrorExec, Err: err}
+	}
+
+	// Process the JSON data in Go
+	var result []map[string]string
+	for _, dashboard := range dashboards {
+		var dashData map[string]interface{}
+		if err := json.Unmarshal(dashboard.Data, &dashData); err != nil {
+			continue
+		}
+
+		dashTitle, _ := dashData["title"].(string)
+		widgets, ok := dashData["widgets"].([]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, w := range widgets {
+			widget, ok := w.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			widgetTitle, _ := widget["title"].(string)
+			widgetID, _ := widget["id"].(string)
+
+			query, ok := widget["query"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			builder, ok := query["builder"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			queryData, ok := builder["queryData"].([]interface{})
+			if !ok {
+				continue
+			}
+
+			for _, qd := range queryData {
+				data, ok := qd.(map[string]interface{})
+				if !ok {
+					continue
+				}
+
+				if dataSource, ok := data["dataSource"].(string); !ok || dataSource != "metrics" {
+					continue
+				}
+
+				aggregateAttr, ok := data["aggregateAttribute"].(map[string]interface{})
+				if !ok {
+					continue
+				}
+
+				if key, ok := aggregateAttr["key"].(string); ok && strings.TrimSpace(key) == metricName {
+					result = append(result, map[string]string{
+						"dashboard_id":    dashboard.Uuid,
+						"widget_title":    widgetTitle,
+						"widget_id":       widgetID,
+						"dashboard_title": dashTitle,
+					})
+				}
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/query-service/app/metricsexplorer/parser.go
+++ b/pkg/query-service/app/metricsexplorer/parser.go
@@ -1,0 +1,70 @@
+package metricsexplorer
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
+
+	"go.signoz.io/signoz/pkg/query-service/model"
+	"go.signoz.io/signoz/pkg/query-service/model/metrics_explorer"
+)
+
+func ParseFilterKeySuggestions(r *http.Request) (*metrics_explorer.FilterKeyRequest, *model.ApiError) {
+
+	searchText := r.URL.Query().Get("searchText")
+	limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+	if err != nil {
+		limit = 50
+	}
+
+	return &metrics_explorer.FilterKeyRequest{Limit: limit, SearchText: searchText}, nil
+}
+
+func ParseFilterValueSuggestions(r *http.Request) (*metrics_explorer.FilterValueRequest, *model.ApiError) {
+	var filterValueRequest metrics_explorer.FilterValueRequest
+
+	// parse the request body
+	if err := json.NewDecoder(r.Body).Decode(&filterValueRequest); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("cannot parse the request body: %v", err)}
+	}
+
+	return &filterValueRequest, nil
+}
+
+func ParseSummaryListMetricsParams(r *http.Request) (*metrics_explorer.SummaryListMetricsRequest, *model.ApiError) {
+	var listMetricsParams *metrics_explorer.SummaryListMetricsRequest
+
+	// parse the request body
+	if err := json.NewDecoder(r.Body).Decode(&listMetricsParams); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("cannot parse the request body: %v", err)}
+	}
+
+	if listMetricsParams.OrderBy.ColumnName == "" || listMetricsParams.OrderBy.Order == "" {
+		listMetricsParams.OrderBy.ColumnName = "timeseries" // DEFAULT ORDER BY
+		listMetricsParams.OrderBy.Order = v3.DirectionDesc
+	}
+
+	if listMetricsParams.Limit == 0 {
+		listMetricsParams.Limit = 10 // DEFAULT LIMIT
+	}
+
+	return listMetricsParams, nil
+}
+
+func ParseTreeMapMetricsParams(r *http.Request) (*metrics_explorer.TreeMapMetricsRequest, *model.ApiError) {
+	var treeMapMetricParams *metrics_explorer.TreeMapMetricsRequest
+
+	// parse the request body
+	if err := json.NewDecoder(r.Body).Decode(&treeMapMetricParams); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("cannot parse the request body: %v", err)}
+	}
+
+	if treeMapMetricParams.Limit == 0 {
+		treeMapMetricParams.Limit = 10
+	}
+
+	return treeMapMetricParams, nil
+}

--- a/pkg/query-service/app/metricsexplorer/summary.go
+++ b/pkg/query-service/app/metricsexplorer/summary.go
@@ -1,0 +1,209 @@
+package metricsexplorer
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"go.uber.org/zap"
+
+	"go.signoz.io/signoz/pkg/query-service/app/dashboards"
+	"go.signoz.io/signoz/pkg/query-service/interfaces"
+	"go.signoz.io/signoz/pkg/query-service/model"
+	"go.signoz.io/signoz/pkg/query-service/model/metrics_explorer"
+	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
+	"golang.org/x/sync/errgroup"
+)
+
+type SummaryService struct {
+	reader    interfaces.Reader
+	querierV2 interfaces.Querier
+}
+
+func NewSummaryService(reader interfaces.Reader, querierV2 interfaces.Querier) *SummaryService {
+	return &SummaryService{reader: reader, querierV2: querierV2}
+}
+
+func (receiver *SummaryService) FilterKeys(ctx context.Context, params *metrics_explorer.FilterKeyRequest) (*metrics_explorer.FilterKeyResponse, *model.ApiError) {
+	var response metrics_explorer.FilterKeyResponse
+	keys, apiError := receiver.reader.GetAllMetricFilterAttributeKeys(
+		ctx,
+		params,
+		true,
+	)
+	if apiError != nil {
+		return nil, apiError
+	}
+	response.AttributeKeys = *keys
+	var availableColumnFilter []string
+	for key := range metrics_explorer.AvailableColumnFilterMap {
+		availableColumnFilter = append(availableColumnFilter, key)
+	}
+	response.MetricColumns = availableColumnFilter
+	return &response, nil
+}
+
+func (receiver *SummaryService) FilterValues(ctx context.Context, params *metrics_explorer.FilterValueRequest) (*metrics_explorer.FilterValueResponse, *model.ApiError) {
+	var response metrics_explorer.FilterValueResponse
+	switch params.FilterKey {
+	case "metric_name":
+		var filterValues []string
+		request := v3.AggregateAttributeRequest{DataSource: v3.DataSourceMetrics, SearchText: params.SearchText, Limit: params.Limit}
+		attributes, err := receiver.reader.GetMetricAggregateAttributes(ctx, &request, true)
+		if err != nil {
+			return nil, model.InternalError(err)
+		}
+		for _, item := range attributes.AttributeKeys {
+			filterValues = append(filterValues, item.Key)
+		}
+		response.FilterValues = filterValues
+		return &response, nil
+	case "metric_unit":
+		attributes, err := receiver.reader.GetAllMetricFilterUnits(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+		response.FilterValues = attributes
+		return &response, nil
+	case "metric_type":
+		attributes, err := receiver.reader.GetAllMetricFilterTypes(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+		response.FilterValues = attributes
+		return &response, nil
+	default:
+		attributes, err := receiver.reader.GetAllMetricFilterAttributeValues(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+		response.FilterValues = attributes
+		return &response, nil
+	}
+}
+
+func (receiver *SummaryService) GetMetricsSummary(ctx context.Context, metricName string) (metrics_explorer.MetricDetailsDTO, *model.ApiError) {
+	var metricDetailsDTO metrics_explorer.MetricDetailsDTO
+	g, ctx := errgroup.WithContext(ctx)
+
+	// Call 1: GetMetricMetadata
+	g.Go(func() error {
+		metadata, err := receiver.reader.GetMetricMetadata(ctx, metricName, metricName)
+		if err != nil {
+			return &model.ApiError{Typ: "ClickHouseError", Err: err}
+		}
+		metricDetailsDTO.Name = metricName
+		metricDetailsDTO.Unit = metadata.Unit
+		metricDetailsDTO.Description = metadata.Description
+		metricDetailsDTO.Type = metadata.Type
+		metricDetailsDTO.Metadata.MetricType = metadata.Type
+		metricDetailsDTO.Metadata.Description = metadata.Description
+		metricDetailsDTO.Metadata.Unit = metadata.Unit
+		return nil
+	})
+
+	// Call 2: GetMetricsDataPointsAndLastReceived
+	g.Go(func() error {
+		dataPoints, lastReceived, err := receiver.reader.GetMetricsDataPointsAndLastReceived(ctx, metricName)
+		if err != nil {
+			return err
+		}
+		metricDetailsDTO.Samples = dataPoints
+		metricDetailsDTO.LastReceived = lastReceived
+		return nil
+	})
+
+	// Call 3: GetTotalTimeSeriesForMetricName
+	g.Go(func() error {
+		totalSeries, err := receiver.reader.GetTotalTimeSeriesForMetricName(ctx, metricName)
+		if err != nil {
+			return err
+		}
+		metricDetailsDTO.TimeSeriesTotal = totalSeries
+		return nil
+	})
+
+	// Call 4: GetActiveTimeSeriesForMetricName
+	g.Go(func() error {
+		activeSeries, err := receiver.reader.GetActiveTimeSeriesForMetricName(ctx, metricName, 120*time.Minute)
+		if err != nil {
+			return err
+		}
+		metricDetailsDTO.TimeSeriesActive = activeSeries
+		return nil
+	})
+
+	// Call 5: GetAttributesForMetricName
+	g.Go(func() error {
+		attributes, err := receiver.reader.GetAttributesForMetricName(ctx, metricName)
+		if err != nil {
+			return err
+		}
+		if attributes != nil {
+			metricDetailsDTO.Attributes = *attributes
+		}
+		return nil
+	})
+
+	// Call 6: GetDashboardsWithMetricName
+	g.Go(func() error {
+		data, err := dashboards.GetDashboardsWithMetricName(ctx, metricName)
+		if err != nil {
+			return err
+		}
+		if data != nil {
+			jsonData, err := json.Marshal(data)
+			if err != nil {
+				zap.L().Error("Error marshalling data:", zap.Error(err))
+				return &model.ApiError{Typ: "MarshallingErr", Err: err}
+			}
+
+			var dashboards []metrics_explorer.Dashboard
+			err = json.Unmarshal(jsonData, &dashboards)
+			if err != nil {
+				zap.L().Error("Error unmarshalling data:", zap.Error(err))
+				return &model.ApiError{Typ: "UnMarshallingErr", Err: err}
+			}
+			metricDetailsDTO.Dashboards = dashboards
+		}
+		return nil
+	})
+
+	// Wait for all goroutines and handle any errors
+	if err := g.Wait(); err != nil {
+		// Type assert to check if it's already an ApiError
+		if apiErr, ok := err.(*model.ApiError); ok {
+			return metrics_explorer.MetricDetailsDTO{}, apiErr
+		}
+		// If it's not an ApiError, wrap it in one
+		return metrics_explorer.MetricDetailsDTO{}, &model.ApiError{Typ: "InternalError", Err: err}
+	}
+
+	return metricDetailsDTO, nil
+}
+
+func (receiver *SummaryService) ListMetricsWithSummary(ctx context.Context, params *metrics_explorer.SummaryListMetricsRequest) (*metrics_explorer.SummaryListMetricsResponse, *model.ApiError) {
+	return receiver.reader.ListSummaryMetrics(ctx, params)
+}
+
+func (receiver *SummaryService) GetMetricsTreemap(ctx context.Context, params *metrics_explorer.TreeMapMetricsRequest) (*metrics_explorer.TreeMap, *model.ApiError) {
+	var response metrics_explorer.TreeMap
+	switch params.Treemap {
+	case metrics_explorer.TimeSeriesTeeMap:
+		cardinality, apiError := receiver.reader.GetMetricsTimeSeriesPercentage(ctx, params)
+		if apiError != nil {
+			return nil, apiError
+		}
+		response.TimeSeries = *cardinality
+		return &response, nil
+	case metrics_explorer.SamplesTreeMap:
+		dataPoints, apiError := receiver.reader.GetMetricsSamplesPercentage(ctx, params)
+		if apiError != nil {
+			return nil, apiError
+		}
+		response.Samples = *dataPoints
+		return &response, nil
+	default:
+		return nil, nil
+	}
+}

--- a/pkg/query-service/app/server.go
+++ b/pkg/query-service/app/server.go
@@ -316,6 +316,7 @@ func (s *Server) createPublicServer(api *APIHandler, web web.Web) (*http.Server,
 	api.RegisterQueryRangeV4Routes(r, am)
 	api.RegisterMessagingQueuesRoutes(r, am)
 	api.RegisterThirdPartyApiRoutes(r, am)
+	api.MetricExplorerRoutes(r, am)
 
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},

--- a/pkg/query-service/app/summary.go
+++ b/pkg/query-service/app/summary.go
@@ -1,0 +1,104 @@
+package app
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"go.signoz.io/signoz/pkg/query-service/model"
+
+	explorer "go.signoz.io/signoz/pkg/query-service/app/metricsexplorer"
+	"go.uber.org/zap"
+)
+
+func (aH *APIHandler) FilterKeysSuggestion(w http.ResponseWriter, r *http.Request) {
+	bodyBytes, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	ctx := r.Context()
+	params, apiError := explorer.ParseFilterKeySuggestions(r)
+	if apiError != nil {
+		zap.L().Error("error parsing summary filter keys request", zap.Error(apiError.Err))
+		RespondError(w, apiError, nil)
+		return
+	}
+	keys, apiError := aH.SummaryService.FilterKeys(ctx, params)
+	if apiError != nil {
+		zap.L().Error("error getting filter keys", zap.Error(apiError.Err))
+		RespondError(w, apiError, nil)
+		return
+	}
+	aH.Respond(w, keys)
+}
+
+func (aH *APIHandler) FilterValuesSuggestion(w http.ResponseWriter, r *http.Request) {
+	bodyBytes, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	ctx := r.Context()
+	params, apiError := explorer.ParseFilterValueSuggestions(r)
+	if apiError != nil {
+		zap.L().Error("error parsing summary filter values request", zap.Error(apiError.Err))
+		RespondError(w, apiError, nil)
+		return
+	}
+
+	values, apiError := aH.SummaryService.FilterValues(ctx, params)
+	if apiError != nil {
+		zap.L().Error("error getting filter values", zap.Error(apiError.Err))
+		RespondError(w, apiError, nil)
+		return
+	}
+	aH.Respond(w, values)
+}
+
+func (aH *APIHandler) GetMetricsDetails(w http.ResponseWriter, r *http.Request) {
+	metricName := mux.Vars(r)["metric_name"]
+	ctx := r.Context()
+	metricsDetail, apiError := aH.SummaryService.GetMetricsSummary(ctx, metricName)
+	if apiError != nil {
+		zap.L().Error("error parsing metric query range params", zap.Error(apiError.Err))
+		RespondError(w, apiError, nil)
+		return
+	}
+	aH.Respond(w, metricsDetail)
+}
+
+func (aH *APIHandler) ListMetrics(w http.ResponseWriter, r *http.Request) {
+	bodyBytes, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	ctx := r.Context()
+	params, apiError := explorer.ParseSummaryListMetricsParams(r)
+	if apiError != nil {
+		zap.L().Error("error parsing metric list metric summary api request", zap.Error(apiError.Err))
+		RespondError(w, model.BadRequest(apiError), nil)
+		return
+	}
+
+	slmr, apiErr := aH.SummaryService.ListMetricsWithSummary(ctx, params)
+	if apiErr != nil {
+		zap.L().Error("error parsing metric query range params", zap.Error(apiErr.Err))
+		RespondError(w, apiError, nil)
+		return
+	}
+	aH.Respond(w, slmr)
+}
+
+func (aH *APIHandler) GetTreeMap(w http.ResponseWriter, r *http.Request) {
+	bodyBytes, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+	ctx := r.Context()
+	params, apiError := explorer.ParseTreeMapMetricsParams(r)
+	if apiError != nil {
+		zap.L().Error("error parsing metric query range params", zap.Error(apiError.Err))
+		RespondError(w, apiError, nil)
+		return
+	}
+	result, apiError := aH.SummaryService.GetMetricsTreemap(ctx, params)
+	if apiError != nil {
+		zap.L().Error("error getting heatmap data", zap.Error(apiError.Err))
+		RespondError(w, apiError, nil)
+		return
+	}
+	aH.Respond(w, result)
+
+}

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -85,6 +85,8 @@ var TimestampSortFeature = GetOrDefaultEnv("TIMESTAMP_SORT_FEATURE", "true")
 
 var PreferRPMFeature = GetOrDefaultEnv("PREFER_RPM_FEATURE", "false")
 
+var MetricsExplorerClickhouseThreads = GetOrDefaultEnvInt("METRICS_EXPLORER_CLICKHOUSE_THREADS", 8)
+
 // TODO(srikanthccv): remove after backfilling is done
 func UseMetricsPreAggregation() bool {
 	return GetOrDefaultEnv("USE_METRICS_PRE_AGGREGATION", "true") == "true"
@@ -231,6 +233,9 @@ const (
 	SIGNOZ_TIMESERIES_v4_1WEEK_LOCAL_TABLENAME = "time_series_v4_1week"
 	SIGNOZ_TIMESERIES_v4_1DAY_TABLENAME        = "distributed_time_series_v4_1day"
 	SIGNOZ_TOP_LEVEL_OPERATIONS_TABLENAME      = "distributed_top_level_operations"
+	SIGNOZ_TIMESERIES_v4_TABLENAME             = "distributed_time_series_v4"
+	SIGNOZ_TIMESERIES_v4_1WEEK_TABLENAME       = "distributed_time_series_v4_1week"
+	SIGNOZ_TIMESERIES_v4_6HRS_TABLENAME        = "distributed_time_series_v4_6hrs"
 )
 
 // alert related constants

--- a/pkg/query-service/interfaces/interface.go
+++ b/pkg/query-service/interfaces/interface.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/stats"
 	"go.signoz.io/signoz/pkg/query-service/model"
+	"go.signoz.io/signoz/pkg/query-service/model/metrics_explorer"
 	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
 	"go.signoz.io/signoz/pkg/query-service/querycache"
 )
@@ -115,6 +116,21 @@ type Reader interface {
 	//trace
 	GetTraceFields(ctx context.Context) (*model.GetFieldsResponse, *model.ApiError)
 	UpdateTraceField(ctx context.Context, field *model.UpdateField) *model.ApiError
+
+	GetAllMetricFilterAttributeValues(ctx context.Context, req *metrics_explorer.FilterValueRequest) ([]string, *model.ApiError)
+	GetAllMetricFilterUnits(ctx context.Context, req *metrics_explorer.FilterValueRequest) ([]string, *model.ApiError)
+	GetAllMetricFilterTypes(ctx context.Context, req *metrics_explorer.FilterValueRequest) ([]string, *model.ApiError)
+	GetAllMetricFilterAttributeKeys(ctx context.Context, req *metrics_explorer.FilterKeyRequest, skipDotNames bool) (*[]v3.AttributeKey, *model.ApiError)
+
+	GetMetricsDataPointsAndLastReceived(ctx context.Context, metricName string) (uint64, uint64, *model.ApiError)
+	GetTotalTimeSeriesForMetricName(ctx context.Context, metricName string) (uint64, *model.ApiError)
+	GetActiveTimeSeriesForMetricName(ctx context.Context, metricName string, duration time.Duration) (uint64, *model.ApiError)
+	GetAttributesForMetricName(ctx context.Context, metricName string) (*[]metrics_explorer.Attribute, *model.ApiError)
+
+	ListSummaryMetrics(ctx context.Context, req *metrics_explorer.SummaryListMetricsRequest) (*metrics_explorer.SummaryListMetricsResponse, *model.ApiError)
+
+	GetMetricsTimeSeriesPercentage(ctx context.Context, request *metrics_explorer.TreeMapMetricsRequest) (*[]metrics_explorer.TreeMapResponseItem, *model.ApiError)
+	GetMetricsSamplesPercentage(ctx context.Context, req *metrics_explorer.TreeMapMetricsRequest) (*[]metrics_explorer.TreeMapResponseItem, *model.ApiError)
 }
 
 type Querier interface {

--- a/pkg/query-service/model/metrics_explorer/summary.go
+++ b/pkg/query-service/model/metrics_explorer/summary.go
@@ -1,0 +1,124 @@
+package metrics_explorer
+
+import (
+	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
+)
+
+type SummaryListMetricsRequest struct {
+	Offset  int          `json:"offset"`
+	Limit   int          `json:"limit"`
+	OrderBy v3.OrderBy   `json:"orderBy"`
+	Start   int64        `json:"start"`
+	EndD    int64        `json:"end"`
+	Filters v3.FilterSet `json:"filters"`
+}
+
+type TreeMapType string
+
+const (
+	TimeSeriesTeeMap TreeMapType = "timeseries"
+	SamplesTreeMap   TreeMapType = "samples"
+)
+
+type TreeMapMetricsRequest struct {
+	Limit   int          `json:"limit"`
+	Treemap TreeMapType  `json:"treemap"`
+	Start   int64        `json:"start"`
+	EndD    int64        `json:"end"`
+	Filters v3.FilterSet `json:"filters"`
+}
+
+type MetricDetail struct {
+	MetricName   string `json:"metric_name"`
+	Description  string `json:"description"`
+	Type         string `json:"type"`
+	Unit         string `json:"unit"`
+	TimeSeries   uint64 `json:"timeseries"`
+	Samples      uint64 `json:"samples"`
+	LastReceived int64  `json:"lastReceived"`
+}
+
+type TreeMapResponseItem struct {
+	Percentage float64 `json:"percentage"`
+	TotalValue uint64  `json:"total_value"`
+	MetricName string  `json:"metric_name"`
+}
+
+type TreeMap struct {
+	TimeSeries []TreeMapResponseItem `json:"timeseries"`
+	Samples    []TreeMapResponseItem `json:"samples"`
+}
+
+type SummaryListMetricsResponse struct {
+	Metrics []MetricDetail `json:"metrics"`
+	Total   uint64         `json:"total"`
+}
+
+type Attribute struct {
+	Key        string   `json:"key" db:"key"`
+	Value      []string `json:"value" db:"value"`
+	ValueCount uint64   `json:"valueCount" db:"valueCount"`
+}
+
+// Metadata holds additional information about the metric.
+type Metadata struct {
+	MetricType  string `json:"metric_type"`
+	Description string `json:"description"`
+	Unit        string `json:"unit"`
+}
+
+// Alert represents individual alerts associated with the metric.
+type Alert struct {
+	AlertName string `json:"alert_name"`
+	AlertID   string `json:"alert_id"`
+}
+
+// Dashboard represents individual dashboards associated with the metric.
+type Dashboard struct {
+	DashboardName string `json:"dashboard_name"`
+	DashboardID   string `json:"dashboard_id"`
+	WidgetID      string `json:"widget_id"`
+	WidgetName    string `json:"widget_name"`
+}
+
+type MetricDetailsDTO struct {
+	Name             string      `json:"name"`
+	Description      string      `json:"description"`
+	Type             string      `json:"type"`
+	Unit             string      `json:"unit"`
+	Samples          uint64      `json:"samples"`
+	TimeSeriesTotal  uint64      `json:"timeSeriesTotal"`
+	TimeSeriesActive uint64      `json:"timeSeriesActive"`
+	LastReceived     uint64      `json:"lastReceived"`
+	Attributes       []Attribute `json:"attributes"`
+	Metadata         Metadata    `json:"metadata"`
+	Alerts           []Alert     `json:"alerts"`
+	Dashboards       []Dashboard `json:"dashboards"`
+}
+
+type FilterKeyRequest struct {
+	SearchText string `json:"searchText"`
+	Limit      int    `json:"limit"`
+}
+
+type FilterValueRequest struct {
+	FilterKey                  string                  `json:"filterKey"`
+	FilterAttributeKeyDataType v3.AttributeKeyDataType `json:"filterAttributeKeyDataType"`
+	SearchText                 string                  `json:"searchText"`
+	Limit                      int                     `json:"limit"`
+}
+
+type FilterValueResponse struct {
+	FilterValues []string `json:"filterValues"`
+}
+
+type FilterKeyResponse struct {
+	MetricColumns []string          `json:"metricColumns"`
+	AttributeKeys []v3.AttributeKey `json:"attributeKeys"`
+}
+
+var AvailableColumnFilterMap = map[string]bool{
+	"metric_name": true,
+	"metric_unit": true,
+	"metric_type": true,
+}

--- a/pkg/query-service/utils/filter_conditions.go
+++ b/pkg/query-service/utils/filter_conditions.go
@@ -1,0 +1,153 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"go.signoz.io/signoz/pkg/query-service/constants"
+	"go.signoz.io/signoz/pkg/query-service/model/metrics_explorer"
+	v3 "go.signoz.io/signoz/pkg/query-service/model/v3"
+)
+
+// skipKey is an optional parameter to skip processing of a specific key
+func BuildFilterConditions(fs *v3.FilterSet, skipKey string) ([]string, error) {
+	if fs == nil || len(fs.Items) == 0 {
+		return nil, nil
+	}
+
+	var conditions []string
+
+	for _, item := range fs.Items {
+		if skipKey != "" && item.Key.Key == skipKey {
+			continue
+		}
+
+		toFormat := item.Value
+		op := v3.FilterOperator(strings.ToLower(strings.TrimSpace(string(item.Operator))))
+		if op == v3.FilterOperatorContains || op == v3.FilterOperatorNotContains {
+			toFormat = fmt.Sprintf("%%%s%%", toFormat)
+		}
+		fmtVal := ClickHouseFormattedValue(toFormat)
+
+		// Determine if the key is a JSON key or a normal column
+		isJSONKey := false
+		if _, exists := metrics_explorer.AvailableColumnFilterMap[item.Key.Key]; exists {
+			isJSONKey = false
+		} else {
+			isJSONKey = true
+		}
+
+		condition, err := buildSingleFilterCondition(item.Key.Key, op, fmtVal, isJSONKey)
+		if err != nil {
+			return nil, err
+		}
+		conditions = append(conditions, condition)
+	}
+
+	return conditions, nil
+}
+
+func buildSingleFilterCondition(key string, op v3.FilterOperator, fmtVal string, isJSONKey bool) (string, error) {
+	var keyCondition string
+	if isJSONKey {
+		keyCondition = fmt.Sprintf("JSONExtractString(labels, '%s')", key)
+	} else { // Assuming normal column access
+		if key == "metric_unit" {
+			key = "unit"
+		}
+		if key == "metric_type" {
+			key = "type"
+		}
+		keyCondition = key
+	}
+
+	switch op {
+	case v3.FilterOperatorEqual:
+		return fmt.Sprintf("%s = %s", keyCondition, fmtVal), nil
+	case v3.FilterOperatorNotEqual:
+		return fmt.Sprintf("%s != %s", keyCondition, fmtVal), nil
+	case v3.FilterOperatorIn:
+		return fmt.Sprintf("%s IN %s", keyCondition, fmtVal), nil
+	case v3.FilterOperatorNotIn:
+		return fmt.Sprintf("%s NOT IN %s", keyCondition, fmtVal), nil
+	case v3.FilterOperatorLike:
+		return fmt.Sprintf("like(%s, %s)", keyCondition, fmtVal), nil
+	case v3.FilterOperatorNotLike:
+		return fmt.Sprintf("notLike(%s, %s)", keyCondition, fmtVal), nil
+	case v3.FilterOperatorRegex:
+		return fmt.Sprintf("match(%s, %s)", keyCondition, fmtVal), nil
+	case v3.FilterOperatorNotRegex:
+		return fmt.Sprintf("not match(%s, %s)", keyCondition, fmtVal), nil
+	case v3.FilterOperatorGreaterThan:
+		return fmt.Sprintf("%s > %s", keyCondition, fmtVal), nil
+	case v3.FilterOperatorGreaterThanOrEq:
+		return fmt.Sprintf("%s >= %s", keyCondition, fmtVal), nil
+	case v3.FilterOperatorLessThan:
+		return fmt.Sprintf("%s < %s", keyCondition, fmtVal), nil
+	case v3.FilterOperatorLessThanOrEq:
+		return fmt.Sprintf("%s <= %s", keyCondition, fmtVal), nil
+	case v3.FilterOperatorContains:
+		return fmt.Sprintf("like(%s, %s)", keyCondition, fmtVal), nil
+	case v3.FilterOperatorNotContains:
+		return fmt.Sprintf("notLike(%s, %s)", keyCondition, fmtVal), nil
+	case v3.FilterOperatorExists:
+		return fmt.Sprintf("has(JSONExtractKeys(labels), '%s')", key), nil
+	case v3.FilterOperatorNotExists:
+		return fmt.Sprintf("not has(JSONExtractKeys(labels), '%s')", key), nil
+	default:
+		return "", fmt.Errorf("unsupported filter operator: %s", op)
+	}
+}
+
+var (
+	sixHoursInMilliseconds = time.Hour.Milliseconds() * 6
+	oneDayInMilliseconds   = time.Hour.Milliseconds() * 24
+	oneWeekInMilliseconds  = oneDayInMilliseconds * 7
+)
+
+func WhichTSTableToUse(start, end int64) (int64, int64, string, string) {
+
+	var tableName string
+	var localTableName string
+	if end-start < sixHoursInMilliseconds {
+		// adjust the start time to nearest 1 hour
+		start = start - (start % (time.Hour.Milliseconds() * 1))
+		tableName = constants.SIGNOZ_TIMESERIES_v4_TABLENAME
+		localTableName = constants.SIGNOZ_TIMESERIES_v4_LOCAL_TABLENAME
+	} else if end-start < oneDayInMilliseconds {
+		// adjust the start time to nearest 6 hours
+		start = start - (start % (time.Hour.Milliseconds() * 6))
+		tableName = constants.SIGNOZ_TIMESERIES_v4_6HRS_TABLENAME
+		localTableName = constants.SIGNOZ_TIMESERIES_v4_6HRS_LOCAL_TABLENAME
+	} else if end-start < oneWeekInMilliseconds {
+		// adjust the start time to nearest 1 day
+		start = start - (start % (time.Hour.Milliseconds() * 24))
+		tableName = constants.SIGNOZ_TIMESERIES_v4_1DAY_TABLENAME
+		localTableName = constants.SIGNOZ_TIMESERIES_v4_1DAY_LOCAL_TABLENAME
+	} else {
+		if constants.UseMetricsPreAggregation() {
+			// adjust the start time to nearest 1 week
+			start = start - (start % (time.Hour.Milliseconds() * 24 * 7))
+			tableName = constants.SIGNOZ_TIMESERIES_v4_1WEEK_TABLENAME
+			localTableName = constants.SIGNOZ_TIMESERIES_v4_1WEEK_LOCAL_TABLENAME
+		} else {
+			// continue to use the 1 day table
+			start = start - (start % (time.Hour.Milliseconds() * 24))
+			tableName = constants.SIGNOZ_TIMESERIES_v4_1DAY_TABLENAME
+			localTableName = constants.SIGNOZ_TIMESERIES_v4_1DAY_LOCAL_TABLENAME
+		}
+	}
+
+	return start, end, tableName, localTableName
+}
+
+func WhichSampleTableToUse(start, end int64) (string, string) {
+	if end-start < oneDayInMilliseconds {
+		return constants.SIGNOZ_SAMPLES_V4_TABLENAME, "count(*)"
+	} else if end-start < oneWeekInMilliseconds {
+		return constants.SIGNOZ_SAMPLES_V4_AGG_5M_TABLENAME, "sum(count)"
+	} else {
+		return constants.SIGNOZ_SAMPLES_V4_AGG_30M_TABLENAME, "sum(count)"
+	}
+}

--- a/pkg/telemetrystore/telemetrystorehook/settings.go
+++ b/pkg/telemetrystore/telemetrystorehook/settings.go
@@ -63,6 +63,10 @@ func (h *provider) clickHouseSettings(ctx context.Context, query string, args ..
 		settings["timeout_before_checking_execution_speed"] = h.settings.TimeoutBeforeCheckingExecutionSpeed
 	}
 
+	if ctx.Value("clickhouse_max_threads") != nil {
+		if maxThreads, ok := ctx.Value("clickhouse_max_threads").(int); ok { settings["max_threads"] = maxThreads }
+	}
+
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(settings))
 	return ctx, query, args
 }


### PR DESCRIPTION
### Summary

https://www.notion.so/signoz/API-Documentation-Metrics-Explorer-18afcc6bcd19808ea646ce51b1c7ac69?showMoveTo=true&saveParent=true)

#### Related Issues / PR's

(https://github.com/SigNoz/signoz/issues/7078)



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added new APIs and services for metric filtering and summarization in the summary view, including new routes, handlers, and models.
> 
>   - **APIs and Routes**:
>     - Added `MetricExplorerRoutes` in `server.go` to register new metric explorer routes.
>     - New routes for filter keys, filter values, metric details, list metrics, and treemap in `http_handler.go`.
>   - **Services and Handlers**:
>     - Introduced `SummaryService` in `metricsexplorer/summary.go` for handling metric summary operations.
>     - Added handlers in `summary.go` for filter keys, filter values, metric details, list metrics, and treemap.
>   - **Models and Interfaces**:
>     - Added new request and response models in `metrics_explorer/summary.go`.
>     - Updated `Reader` interface in `interfaces/interface.go` with new methods for metric filtering and summarization.
>   - **Utilities and Constants**:
>     - Added utility functions in `utils/filter_conditions.go` for building filter conditions.
>     - Updated constants in `constants.go` for new table names and configurations.
>   - **Miscellaneous**:
>     - Updated `telemetrystorehook/settings.go` to include `clickhouse_max_threads` setting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for a6ea09d6b489a31378c1f56ca26a7f97138f40a7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->