### PR TITLE
feat(summary): added alerts and basic query updates

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -219,7 +219,7 @@ func NewAPIHandler(opts APIHandlerOpts) (*APIHandler, error) {
 	jobsRepo := inframetrics.NewJobsRepo(opts.Reader, querierv2)
 	pvcsRepo := inframetrics.NewPvcsRepo(opts.Reader, querierv2)
 	//explorerCache := metricsexplorer.NewExplorerCache(metricsexplorer.WithCache(opts.Cache))
-	summaryService := metricsexplorer.NewSummaryService(opts.Reader, querierv2)
+	summaryService := metricsexplorer.NewSummaryService(opts.Reader, opts.RuleManager)
 
 	aH := &APIHandler{
 		reader:                        opts.Reader,

--- a/pkg/query-service/app/metricsexplorer/summary.go
+++ b/pkg/query-service/app/metricsexplorer/summary.go
@@ -19,11 +19,11 @@ import (
 
 type SummaryService struct {
 	reader       interfaces.Reader
-	alertManager *rules.Manager
+	rulesManager *rules.Manager
 }
 
 func NewSummaryService(reader interfaces.Reader, alertManager *rules.Manager) *SummaryService {
-	return &SummaryService{reader: reader, alertManager: alertManager}
+	return &SummaryService{reader: reader, rulesManager: alertManager}
 }
 
 func (receiver *SummaryService) FilterKeys(ctx context.Context, params *metrics_explorer.FilterKeyRequest) (*metrics_explorer.FilterKeyResponse, *model.ApiError) {
@@ -178,7 +178,7 @@ func (receiver *SummaryService) GetMetricsSummary(ctx context.Context, metricNam
 		var metrics []string
 		var metricsAlerts []metrics_explorer.Alert
 		metrics = append(metrics, metricName)
-		data, err := receiver.alertManager.GetAlertDetailsForMetricNames(ctx, metrics)
+		data, err := receiver.rulesManager.GetAlertDetailsForMetricNames(ctx, metrics)
 		if err != nil {
 			return err
 		}
@@ -216,14 +216,18 @@ func (receiver *SummaryService) GetMetricsTreemap(ctx context.Context, params *m
 		if apiError != nil {
 			return nil, apiError
 		}
-		response.TimeSeries = *cardinality
+		if cardinality != nil {
+			response.TimeSeries = *cardinality
+		}
 		return &response, nil
 	case metrics_explorer.SamplesTreeMap:
 		dataPoints, apiError := receiver.reader.GetMetricsSamplesPercentage(ctx, params)
 		if apiError != nil {
 			return nil, apiError
 		}
-		response.Samples = *dataPoints
+		if dataPoints != nil {
+			response.Samples = *dataPoints
+		}
 		return &response, nil
 	default:
 		return nil, nil

--- a/pkg/query-service/interfaces/interface.go
+++ b/pkg/query-service/interfaces/interface.go
@@ -122,7 +122,8 @@ type Reader interface {
 	GetAllMetricFilterTypes(ctx context.Context, req *metrics_explorer.FilterValueRequest) ([]string, *model.ApiError)
 	GetAllMetricFilterAttributeKeys(ctx context.Context, req *metrics_explorer.FilterKeyRequest, skipDotNames bool) (*[]v3.AttributeKey, *model.ApiError)
 
-	GetMetricsDataPointsAndLastReceived(ctx context.Context, metricName string) (uint64, uint64, *model.ApiError)
+	GetMetricsDataPoints(ctx context.Context, metricName string) (uint64, *model.ApiError)
+	GetMetricsLastReceived(ctx context.Context, metricName string) (int64, *model.ApiError)
 	GetTotalTimeSeriesForMetricName(ctx context.Context, metricName string) (uint64, *model.ApiError)
 	GetActiveTimeSeriesForMetricName(ctx context.Context, metricName string, duration time.Duration) (uint64, *model.ApiError)
 	GetAttributesForMetricName(ctx context.Context, metricName string) (*[]metrics_explorer.Attribute, *model.ApiError)

--- a/pkg/query-service/model/metrics_explorer/summary.go
+++ b/pkg/query-service/model/metrics_explorer/summary.go
@@ -89,7 +89,7 @@ type MetricDetailsDTO struct {
 	Samples          uint64      `json:"samples"`
 	TimeSeriesTotal  uint64      `json:"timeSeriesTotal"`
 	TimeSeriesActive uint64      `json:"timeSeriesActive"`
-	LastReceived     uint64      `json:"lastReceived"`
+	LastReceived     int64       `json:"lastReceived"`
 	Attributes       []Attribute `json:"attributes"`
 	Metadata         Metadata    `json:"metadata"`
 	Alerts           []Alert     `json:"alerts"`


### PR DESCRIPTION
### Summary

Added alerts, segregated last received and data points function for summary view, break the query into optional subquery for list metrics without where clause.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Added alerts to metrics summary, separated data points and last received queries, and optimized query building in metrics handling.
> 
>   - **Behavior**:
>     - Added alerts to `MetricDetailsDTO` in `summary.go` by fetching alert details for metric names using `GetAlertDetailsForMetricNames()` in `manager.go`.
>     - Separated `GetMetricsDataPointsAndLastReceived()` into `GetMetricsDataPoints()` and `GetMetricsLastReceived()` in `reader.go`.
>     - Optimized query building in `ListSummaryMetrics()` and `GetMetricsSamplesPercentage()` in `reader.go` by using `strings.Builder`.
>   - **Interfaces**:
>     - Updated `Reader` interface in `interface.go` to include `GetMetricsDataPoints()` and `GetMetricsLastReceived()`.
>   - **Misc**:
>     - Changed `LastReceived` type from `uint64` to `int64` in `MetricDetailsDTO` in `summary.go`.
>     - Updated `NewSummaryService()` in `summary.go` to use `RuleManager` instead of `QuerierV2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 28a94423685dedc960e8becad975f299c714e1d0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->