### PR TITLE
fix: fix the issue of service to logs/traces explorer caused by similar start and end timestamps

### DIFF
--- a/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
@@ -221,6 +221,13 @@ function Application(): JSX.Element {
 		[dispatch, pathname, urlQuery],
 	);
 
+	/**
+	 *
+	 * @param timestamp - The timestamp in seconds
+	 * @param apmToTraceQuery - query object
+	 * @param isViewLogsClicked - Whether this is for viewing logs vs traces
+	 * @returns A callback function that handles the navigation when executed
+	 */
 	const onErrorTrackHandler = useCallback(
 		(
 			timestamp: number,

--- a/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
@@ -30,6 +30,7 @@ import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { Query } from 'types/api/queryBuilder/queryBuilderData';
 import { EQueryType } from 'types/common/dashboard';
 import { GlobalReducer } from 'types/reducer/globalTime';
+import { secondsToMilliseconds } from 'utils/timeUtils';
 import { v4 as uuid } from 'uuid';
 
 import { GraphTitle, SERVICE_CHART_ID } from '../constant';
@@ -226,8 +227,8 @@ function Application(): JSX.Element {
 			apmToTraceQuery: Query,
 			isViewLogsClicked?: boolean,
 		): (() => void) => (): void => {
-			const endTime = timestamp;
-			const startTime = timestamp - stepInterval;
+			const endTime = secondsToMilliseconds(timestamp);
+			const startTime = secondsToMilliseconds(timestamp - stepInterval);
 
 			const urlParams = new URLSearchParams(search);
 			urlParams.set(QueryParams.startTime, startTime.toString());

--- a/frontend/src/container/MetricsApplication/Tabs/util.ts
+++ b/frontend/src/container/MetricsApplication/Tabs/util.ts
@@ -66,8 +66,8 @@ export function onViewTracePopupClick({
 	safeNavigate,
 }: OnViewTracePopupClickProps): VoidFunction {
 	return (): void => {
-		const endTime = timestamp;
-		const startTime = timestamp - (stepInterval || 60);
+		const endTime = timestamp * 1_000;
+		const startTime = (timestamp - (stepInterval || 60)) * 1_000;
 
 		const urlParams = new URLSearchParams(window.location.search);
 		urlParams.set(QueryParams.startTime, startTime.toString());
@@ -112,7 +112,7 @@ export function onGraphClickHandler(
 				buttonElement.style.display = 'block';
 				buttonElement.style.left = `${mouseX}px`;
 				buttonElement.style.top = `${mouseY}px`;
-				setSelectedTimeStamp(Math.floor(xValue * 1_000));
+				setSelectedTimeStamp(Math.floor(xValue));
 			}
 		} else if (buttonElement && buttonElement.style.display === 'block') {
 			buttonElement.style.display = 'none';

--- a/frontend/src/container/MetricsApplication/Tabs/util.ts
+++ b/frontend/src/container/MetricsApplication/Tabs/util.ts
@@ -57,6 +57,18 @@ export function generateExplorerPath(
 }
 
 // TODO(@rahul-signoz): update the name of this function once we have view logs button in every panel
+
+/**
+ * Handles click events for viewing trace/logs popup
+ * @param selectedTraceTags - Selected trace tags
+ * @param servicename - Name of the service
+ * @param timestamp - Timestamp in seconds
+ * @param apmToTraceQuery - Query object
+ * @param isViewLogsClicked - Whether this is for viewing logs vs traces
+ * @param stepInterval - Time interval in seconds
+ * @param safeNavigate - Navigation function
+ 
+ */
 export function onViewTracePopupClick({
 	selectedTraceTags,
 	servicename,

--- a/frontend/src/container/MetricsApplication/Tabs/util.ts
+++ b/frontend/src/container/MetricsApplication/Tabs/util.ts
@@ -16,6 +16,7 @@ import {
 import { Query, TagFilterItem } from 'types/api/queryBuilder/queryBuilderData';
 import { DataSource } from 'types/common/queryBuilder';
 import { Tags } from 'types/reducer/trace';
+import { secondsToMilliseconds } from 'utils/timeUtils';
 import { v4 as uuid } from 'uuid';
 
 export const dbSystemTags: Tags[] = [
@@ -66,8 +67,8 @@ export function onViewTracePopupClick({
 	safeNavigate,
 }: OnViewTracePopupClickProps): VoidFunction {
 	return (): void => {
-		const endTime = timestamp * 1_000;
-		const startTime = (timestamp - (stepInterval || 60)) * 1_000;
+		const endTime = secondsToMilliseconds(timestamp);
+		const startTime = secondsToMilliseconds(timestamp - (stepInterval || 60));
 
 		const urlParams = new URLSearchParams(window.location.search);
 		urlParams.set(QueryParams.startTime, startTime.toString());

--- a/frontend/src/utils/timeUtils.ts
+++ b/frontend/src/utils/timeUtils.ts
@@ -124,6 +124,9 @@ export function formatTime(seconds: number): string {
 export const nanoToMilli = (nanoseconds: number): number =>
 	nanoseconds / 1_000_000;
 
+export const secondsToMilliseconds = (seconds: number): number =>
+	seconds * 1_000;
+
 export const epochToTimeString = (epochMs: number): string => {
 	console.log({ epochMs });
 	const date = new Date(epochMs);


### PR DESCRIPTION
### Summary
The issue was happening because I had made this change to convert the timestamp to milliseconds:

```tsx
setSelectedTimeStamp(Math.floor(xValue * 1_000));
```

this was meant to fix a back navigation issue (in services -> logs/traces) since timestamps were originally set in seconds but later converted to milliseconds in getTime of DateTimeSelectionV2, causing duplicate history entries.


however, this was causing the issue because instead of subtracting 60 seconds from the timestamp, it was subtracting 60 milliseconds, leading to similar timestamps.


<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots
Before:
![Screenshot from 2025-02-25 11-36-35](https://github.com/user-attachments/assets/b1eec1af-b4f3-4fc9-9a74-b0c1dd2f5fca)

After:
![Screenshot from 2025-02-25 11-37-02](https://github.com/user-attachments/assets/290b4f2b-bc08-48e2-8a3d-352bf314d8d9)


<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes timestamp conversion issue in navigation between services and logs/traces by ensuring consistent conversion to milliseconds.
> 
>   - **Behavior**:
>     - Fixes timestamp conversion issue in `Overview.tsx` and `util.ts` by ensuring timestamps are consistently converted to milliseconds using `secondsToMilliseconds()`.
>     - Corrects navigation issue between services and logs/traces by adjusting timestamp subtraction logic.
>   - **Functions**:
>     - Adds `secondsToMilliseconds()` in `timeUtils.ts` to convert seconds to milliseconds.
>     - Updates `onErrorTrackHandler` and `onViewTracePopupClick` to use `secondsToMilliseconds()` for timestamp conversion.
>   - **Misc**:
>     - Removes unnecessary multiplication by 1,000 in `setSelectedTimeStamp()` in `util.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 751aabd7570c7aed64d4a4316ce44feefbea4e91. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->