### PR TITLE
fix: disabled same url check for redirect in logs explorer

### DIFF
--- a/frontend/src/hooks/useSafeNavigate.ts
+++ b/frontend/src/hooks/useSafeNavigate.ts
@@ -13,7 +13,7 @@ interface SafeNavigateParams {
 }
 
 interface UseSafeNavigateProps {
-	enableSameURLCheck?: boolean;
+	preventSameUrlNavigation?: boolean;
 }
 
 const areUrlsEffectivelySame = (url1: URL, url2: URL): boolean => {
@@ -83,7 +83,9 @@ const isDefaultNavigation = (currentUrl: URL, targetUrl: URL): boolean => {
 	return newKeys.length > 0;
 };
 export const useSafeNavigate = (
-	{ enableSameURLCheck }: UseSafeNavigateProps = { enableSameURLCheck: true },
+	{ preventSameUrlNavigation }: UseSafeNavigateProps = {
+		preventSameUrlNavigation: true,
+	},
 ): {
 	safeNavigate: (
 		to: string | SafeNavigateParams,
@@ -114,7 +116,7 @@ export const useSafeNavigate = (
 			const urlsAreSame = areUrlsEffectivelySame(currentUrl, targetUrl);
 			const isDefaultParamsNavigation = isDefaultNavigation(currentUrl, targetUrl);
 
-			if (enableSameURLCheck && urlsAreSame) {
+			if (preventSameUrlNavigation && urlsAreSame) {
 				return;
 			}
 
@@ -135,7 +137,7 @@ export const useSafeNavigate = (
 				);
 			}
 		},
-		[navigate, location.pathname, location.search, enableSameURLCheck],
+		[navigate, location.pathname, location.search, preventSameUrlNavigation],
 	);
 
 	return { safeNavigate };

--- a/frontend/src/hooks/useSafeNavigate.ts
+++ b/frontend/src/hooks/useSafeNavigate.ts
@@ -12,6 +12,10 @@ interface SafeNavigateParams {
 	search?: string;
 }
 
+interface UseSafeNavigateProps {
+	enableSameURLCheck?: boolean;
+}
+
 const areUrlsEffectivelySame = (url1: URL, url2: URL): boolean => {
 	if (url1.pathname !== url2.pathname) return false;
 
@@ -78,7 +82,9 @@ const isDefaultNavigation = (currentUrl: URL, targetUrl: URL): boolean => {
 
 	return newKeys.length > 0;
 };
-export const useSafeNavigate = (): {
+export const useSafeNavigate = (
+	{ enableSameURLCheck }: UseSafeNavigateProps = { enableSameURLCheck: true },
+): {
 	safeNavigate: (
 		to: string | SafeNavigateParams,
 		options?: NavigateOptions,
@@ -108,7 +114,7 @@ export const useSafeNavigate = (): {
 			const urlsAreSame = areUrlsEffectivelySame(currentUrl, targetUrl);
 			const isDefaultParamsNavigation = isDefaultNavigation(currentUrl, targetUrl);
 
-			if (urlsAreSame) {
+			if (enableSameURLCheck && urlsAreSame) {
 				return;
 			}
 
@@ -129,7 +135,7 @@ export const useSafeNavigate = (): {
 				);
 			}
 		},
-		[navigate, location.pathname, location.search],
+		[navigate, location.pathname, location.search, enableSameURLCheck],
 	);
 
 	return { safeNavigate };

--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -764,7 +764,10 @@ export function QueryBuilderProvider({
 	);
 
 	const { safeNavigate } = useSafeNavigate({
-		enableSameURLCheck: !(initialDataSource === DataSource.LOGS),
+		preventSameUrlNavigation: !(
+			initialDataSource === DataSource.LOGS ||
+			initialDataSource === DataSource.TRACES
+		),
 	});
 
 	const redirectWithQueryBuilderData = useCallback(

--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -763,7 +763,9 @@ export function QueryBuilderProvider({
 		[panelType, stagedQuery],
 	);
 
-	const { safeNavigate } = useSafeNavigate();
+	const { safeNavigate } = useSafeNavigate({
+		enableSameURLCheck: !(initialDataSource === DataSource.LOGS),
+	});
 
 	const redirectWithQueryBuilderData = useCallback(
 		(


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->
Resolves : https://github.com/SigNoz/signoz/issues/7164

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `preventSameUrlNavigation` option to `useSafeNavigate` and applies it in `QueryBuilderProvider` to allow same URL navigation for specific data sources.
> 
>   - **Behavior**:
>     - Adds `preventSameUrlNavigation` option to `useSafeNavigate` in `useSafeNavigate.ts`.
>     - Default is `true`, preventing navigation to the same URL.
>     - In `QueryBuilder.tsx`, disables same URL navigation prevention for `DataSource.LOGS` and `DataSource.TRACES`.
>   - **Functions**:
>     - Modifies `useSafeNavigate` to accept `UseSafeNavigateProps` with `preventSameUrlNavigation`.
>     - Updates `safeNavigate` logic to respect `preventSameUrlNavigation` flag.
>   - **Misc**:
>     - Updates `QueryBuilderProvider` to use the new `useSafeNavigate` option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 7739a44f88d226e95a24a0117f763b4666cfcd11. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->