### PR TITLE
chore: update restart policy of Docker containers

### DIFF
--- a/deploy/docker-swarm/docker-compose.ha.yaml
+++ b/deploy/docker-swarm/docker-compose.ha.yaml
@@ -77,7 +77,7 @@ services:
         tar -xvzf histogram-quantile.tar.gz
         mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
     deploy:
-      restart:
+      restart_policy:
         condition: on-failure
     volumes:
       - ../common/clickhouse/user_scripts:/var/lib/clickhouse/user_scripts/

--- a/deploy/docker-swarm/docker-compose.ha.yaml
+++ b/deploy/docker-swarm/docker-compose.ha.yaml
@@ -76,6 +76,8 @@ services:
         wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2F$${version}/histogram-quantile_$${node_os}_$${node_arch}.tar.gz"
         tar -xvzf histogram-quantile.tar.gz
         mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
+    deploy:
+      restart: on-failure
     volumes:
       - ../common/clickhouse/user_scripts:/var/lib/clickhouse/user_scripts/
   zookeeper-1:

--- a/deploy/docker-swarm/docker-compose.ha.yaml
+++ b/deploy/docker-swarm/docker-compose.ha.yaml
@@ -77,7 +77,8 @@ services:
         tar -xvzf histogram-quantile.tar.gz
         mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
     deploy:
-      restart: on-failure
+      restart:
+        condition: on-failure
     volumes:
       - ../common/clickhouse/user_scripts:/var/lib/clickhouse/user_scripts/
   zookeeper-1:

--- a/deploy/docker-swarm/docker-compose.yaml
+++ b/deploy/docker-swarm/docker-compose.yaml
@@ -74,7 +74,8 @@ services:
         tar -xvzf histogram-quantile.tar.gz
         mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
     deploy:
-      restart: on-failure
+      restart:
+        condition: on-failure
     volumes:
       - ../common/clickhouse/user_scripts:/var/lib/clickhouse/user_scripts/
   zookeeper-1:

--- a/deploy/docker-swarm/docker-compose.yaml
+++ b/deploy/docker-swarm/docker-compose.yaml
@@ -73,6 +73,8 @@ services:
         wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2F$${version}/histogram-quantile_$${node_os}_$${node_arch}.tar.gz"
         tar -xvzf histogram-quantile.tar.gz
         mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
+    deploy:
+      restart: on-failure
     volumes:
       - ../common/clickhouse/user_scripts:/var/lib/clickhouse/user_scripts/
   zookeeper-1:

--- a/deploy/docker-swarm/docker-compose.yaml
+++ b/deploy/docker-swarm/docker-compose.yaml
@@ -74,7 +74,7 @@ services:
         tar -xvzf histogram-quantile.tar.gz
         mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
     deploy:
-      restart:
+      restart_policy:
         condition: on-failure
     volumes:
       - ../common/clickhouse/user_scripts:/var/lib/clickhouse/user_scripts/

--- a/deploy/docker/docker-compose.ha.yaml
+++ b/deploy/docker/docker-compose.ha.yaml
@@ -2,7 +2,7 @@ version: "3"
 x-common: &common
   networks:
     - signoz-net
-  restart: on-failure
+  restart: unless-stopped
   logging:
     options:
       max-size: 50m
@@ -79,6 +79,7 @@ services:
         wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2F$${version}/histogram-quantile_$${node_os}_$${node_arch}.tar.gz"
         tar -xvzf histogram-quantile.tar.gz
         mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
+    restart: on-failure
     volumes:
       - ../common/clickhouse/user_scripts:/var/lib/clickhouse/user_scripts/
   zookeeper-1:
@@ -277,6 +278,7 @@ services:
       - async
       - --dsn=tcp://clickhouse:9000
       - --up=
+    restart: on-failure
 networks:
   signoz-net:
     name: signoz-net

--- a/deploy/docker/docker-compose.testing.yaml
+++ b/deploy/docker/docker-compose.testing.yaml
@@ -2,7 +2,7 @@ version: "3"
 x-common: &common
   networks:
     - signoz-net
-  restart: on-failure
+  restart: unless-stopped
   logging:
     options:
       max-size: 50m
@@ -75,6 +75,7 @@ services:
         wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2F$${version}/histogram-quantile_$${node_os}_$${node_arch}.tar.gz"
         tar -xvzf histogram-quantile.tar.gz
         mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
+    restart: on-failure
     volumes:
       - ../common/clickhouse/user_scripts:/var/lib/clickhouse/user_scripts/
   zookeeper-1:
@@ -199,6 +200,7 @@ services:
     depends_on:
       clickhouse:
         condition: service_healthy
+    restart: on-failure
   schema-migrator-async:
     !!merge <<: *db-depend
     image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.29}
@@ -207,6 +209,7 @@ services:
       - async
       - --dsn=tcp://clickhouse:9000
       - --up=
+    restart: on-failure
 networks:
   signoz-net:
     name: signoz-net

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 x-common: &common
   networks:
     - signoz-net
-  restart: on-failure
+  restart: unless-stopped
   logging:
     options:
       max-size: 50m
@@ -75,6 +75,7 @@ services:
         wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2F$${version}/histogram-quantile_$${node_os}_$${node_arch}.tar.gz"
         tar -xvzf histogram-quantile.tar.gz
         mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
+    restart: on-failure
     volumes:
       - ../common/clickhouse/user_scripts:/var/lib/clickhouse/user_scripts/
   zookeeper-1:
@@ -197,6 +198,7 @@ services:
     depends_on:
       clickhouse:
         condition: service_healthy
+    restart: on-failure
   schema-migrator-async:
     !!merge <<: *db-depend
     image: signoz/signoz-schema-migrator:${OTELCOL_TAG:-0.111.29}
@@ -205,6 +207,7 @@ services:
       - async
       - --dsn=tcp://clickhouse:9000
       - --up=
+    restart: on-failure
 networks:
   signoz-net:
     name: signoz-net

--- a/deploy/docker/generator/hotrod/docker-compose.yaml
+++ b/deploy/docker/generator/hotrod/docker-compose.yaml
@@ -8,7 +8,7 @@ x-common: &common
     options:
       max-size: 50m
       max-file: "3"
-  restart: on-failure
+  restart: unless-stopped
 services:
   hotrod:
     <<: *common

--- a/deploy/docker/generator/infra/docker-compose.yaml
+++ b/deploy/docker/generator/infra/docker-compose.yaml
@@ -8,7 +8,7 @@ x-common: &common
     options:
       max-size: 50m
       max-file: "3"
-  restart: on-failure
+  restart: unless-stopped
 services:
   otel-agent:
     <<: *common

--- a/pkg/query-service/README.md
+++ b/pkg/query-service/README.md
@@ -23,7 +23,7 @@ alertmanager:
     # depends_on:
     #   query-service:
     #     condition: service_healthy
-    restart: on-failure
+    restart: unless-stopped
     command:
       - --queryService.url=http://172.17.0.1:8085
       - --storage.path=/data


### PR DESCRIPTION
### Summary

- update the restart policy of Docker containers

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update Docker container restart policies to `unless-stopped` and `on-failure` for specific services across multiple `docker-compose` files.
> 
>   - **Behavior**:
>     - Update restart policy to `unless-stopped` in `docker-compose.ha.yaml`, `docker-compose.testing.yaml`, `docker-compose.yaml`, `docker-compose.hotrod.yaml`, and `docker-compose.infra.yaml`.
>     - Set specific services like `init-clickhouse` and `schema-migrator-async` to restart `on-failure` in `docker-compose.ha.yaml`, `docker-compose.testing.yaml`, and `docker-compose.yaml`.
>   - **Misc**:
>     - Update `README.md` to reflect the new restart policy for `alertmanager` in `docker-compose.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 7e02c2915622f29f1481fd1e2a47f69fe802d380. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->