### PR TITLE
fix: added safety checks for buildgraph functions and revert upgrades

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -250,10 +250,6 @@
 		"body-parser": "1.20.3",
 		"http-proxy-middleware": "3.0.3",
 		"cross-spawn": "7.0.5",
-		"cookie": "^0.7.1",
-		"react-router/path-to-regexp": "^1.7.0",
-		"webpack-dev-server/path-to-regexp": "^1.7.0",
-		"express/path-to-regexp": "^1.7.0",
-		"@types/webpack-dev-server/path-to-regexp": "^1.7.0"
+		"cookie": "^0.7.1"
 	}
 }

--- a/frontend/src/container/NewDashboard/DashboardVariablesSelection/util.ts
+++ b/frontend/src/container/NewDashboard/DashboardVariablesSelection/util.ts
@@ -106,7 +106,7 @@ export const buildDependencyGraph = (
 	Object.keys(dependencies).forEach((node) => {
 		if (!inDegree[node]) inDegree[node] = 0;
 		if (!adjList[node]) adjList[node] = [];
-		dependencies[node].forEach((child) => {
+		dependencies[node]?.forEach((child) => {
 			if (!inDegree[child]) inDegree[child] = 0;
 			inDegree[child]++;
 			adjList[node].push(child);
@@ -126,13 +126,13 @@ export const buildDependencyGraph = (
 		}
 		topologicalOrder.push(current);
 
-		adjList[current].forEach((neighbor) => {
+		adjList[current]?.forEach((neighbor) => {
 			inDegree[neighbor]--;
 			if (inDegree[neighbor] === 0) queue.push(neighbor);
 		});
 	}
 
-	if (topologicalOrder.length !== Object.keys(dependencies).length) {
+	if (topologicalOrder.length !== Object.keys(dependencies)?.length) {
 		console.error('Cycle detected in the dependency graph!');
 	}
 


### PR DESCRIPTION
### Summary

- Revert upgrades along with adding safety check as it didn't fixed the vanta vulnerability.

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add safety checks to `buildDependencyGraph` in `util.ts` and revert certain package upgrades in `package.json`.
> 
>   - **Safety Checks**:
>     - Added optional chaining in `buildDependencyGraph` in `util.ts` to handle undefined `dependencies` and `adjList`.
>   - **Dependency Reverts**:
>     - Reverted upgrades for `react-router/path-to-regexp`, `webpack-dev-server/path-to-regexp`, and `express/path-to-regexp` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for fe4452adbd3f914c19e428c165acf312829ce17c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->