### PR TITLE
feat(sqlstore): add transaction support for sqlstore

### DIFF
--- a/pkg/alertmanager/alertmanagerserver/server.go
+++ b/pkg/alertmanager/alertmanagerserver/server.go
@@ -314,7 +314,7 @@ func (server *Server) SetConfig(ctx context.Context, alertmanagerConfig *alertma
 }
 
 func (server *Server) TestReceiver(ctx context.Context, receiver alertmanagertypes.Receiver) error {
-	return alertmanagertypes.TestReceiver(ctx, receiver, server.tmpl, server.logger, alertmanagertypes.NewTestAlert(receiver, time.Now(), time.Now()))
+	return alertmanagertypes.TestReceiver(ctx, receiver, server.alertmanagerConfig, server.tmpl, server.logger, alertmanagertypes.NewTestAlert(receiver, time.Now(), time.Now()))
 }
 
 func (server *Server) TestAlert(ctx context.Context, postableAlert *alertmanagertypes.PostableAlert, receivers []string) error {
@@ -335,7 +335,7 @@ func (server *Server) TestAlert(ctx context.Context, postableAlert *alertmanager
 				ch <- err
 				return
 			}
-			ch <- alertmanagertypes.TestReceiver(ctx, receiver, server.tmpl, server.logger, alerts[0])
+			ch <- alertmanagertypes.TestReceiver(ctx, receiver, server.alertmanagerConfig, server.tmpl, server.logger, alerts[0])
 		}(receiverName)
 	}
 

--- a/pkg/alertmanager/signozalertmanager/provider.go
+++ b/pkg/alertmanager/signozalertmanager/provider.go
@@ -109,6 +109,10 @@ func (provider *provider) UpdateChannelByReceiverAndID(ctx context.Context, orgI
 		return err
 	}
 
+	if err := channel.Update(receiver); err != nil {
+		return err
+	}
+
 	config, err := provider.configStore.Get(ctx, orgID)
 	if err != nil {
 		return err
@@ -118,15 +122,9 @@ func (provider *provider) UpdateChannelByReceiverAndID(ctx context.Context, orgI
 		return err
 	}
 
-	if err := provider.configStore.Set(ctx, config); err != nil {
-		return err
-	}
-
-	if err := channel.Update(receiver); err != nil {
-		return err
-	}
-
-	return provider.configStore.UpdateChannel(ctx, orgID, channel, alertmanagertypes.ConfigStoreNoopCallback)
+	return provider.configStore.UpdateChannel(ctx, orgID, channel, alertmanagertypes.WithCb(func(ctx context.Context) error {
+		return provider.configStore.Set(ctx, config)
+	}))
 }
 
 func (provider *provider) DeleteChannelByID(ctx context.Context, orgID string, channelID int) error {
@@ -144,11 +142,9 @@ func (provider *provider) DeleteChannelByID(ctx context.Context, orgID string, c
 		return err
 	}
 
-	if err := provider.configStore.Set(ctx, config); err != nil {
-		return err
-	}
-
-	return provider.configStore.DeleteChannelByID(ctx, orgID, channelID, alertmanagertypes.ConfigStoreNoopCallback)
+	return provider.configStore.DeleteChannelByID(ctx, orgID, channelID, alertmanagertypes.WithCb(func(ctx context.Context) error {
+		return provider.configStore.Set(ctx, config)
+	}))
 }
 
 func (provider *provider) CreateChannel(ctx context.Context, orgID string, receiver alertmanagertypes.Receiver) error {
@@ -161,12 +157,10 @@ func (provider *provider) CreateChannel(ctx context.Context, orgID string, recei
 		return err
 	}
 
-	if err := provider.configStore.Set(ctx, config); err != nil {
-		return err
-	}
-
 	channel := alertmanagertypes.NewChannelFromReceiver(receiver, orgID)
-	return provider.configStore.CreateChannel(ctx, channel, alertmanagertypes.ConfigStoreNoopCallback)
+	return provider.configStore.CreateChannel(ctx, channel, alertmanagertypes.WithCb(func(ctx context.Context) error {
+		return provider.configStore.Set(ctx, config)
+	}))
 }
 
 func (provider *provider) SetConfig(ctx context.Context, config *alertmanagertypes.Config) error {

--- a/pkg/sqlstore/bun.go
+++ b/pkg/sqlstore/bun.go
@@ -1,18 +1,67 @@
 package sqlstore
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/schema"
+	"go.signoz.io/signoz/pkg/errors"
+	"go.signoz.io/signoz/pkg/factory"
 )
 
-func NewBunDB(sqldb *sql.DB, dialect schema.Dialect, hooks []SQLStoreHook, opts ...bun.DBOption) *bun.DB {
-	bunDB := bun.NewDB(sqldb, dialect, opts...)
+type transactorKey struct{}
+
+type BunDB struct {
+	*bun.DB
+	settings factory.ScopedProviderSettings
+}
+
+func NewBunDB(settings factory.ScopedProviderSettings, sqldb *sql.DB, dialect schema.Dialect, hooks []SQLStoreHook, opts ...bun.DBOption) *BunDB {
+	db := bun.NewDB(sqldb, dialect, opts...)
 
 	for _, hook := range hooks {
-		bunDB.AddQueryHook(hook)
+		db.AddQueryHook(hook)
 	}
 
-	return bunDB
+	return &BunDB{db, settings}
+}
+
+func (db *BunDB) RunInTxCtx(ctx context.Context, opts *sql.TxOptions, cb func(ctx context.Context) error) error {
+	// begin transaction
+	tx, err := db.BeginTx(ctx, opts)
+	if err != nil {
+		return errors.Wrapf(err, errors.TypeInternal, errors.CodeInternal, "cannot begin transaction")
+	}
+
+	defer func() {
+		if err := tx.Rollback(); err != nil {
+			if err != sql.ErrTxDone {
+				db.settings.Logger().ErrorContext(ctx, "cannot rollback transaction", "error", err)
+			}
+		}
+	}()
+
+	if err := cb(newContextWithTx(ctx, tx)); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (db *BunDB) BunDBCtx(ctx context.Context) bun.IDB {
+	tx, ok := txFromContext(ctx)
+	if !ok {
+		return db.DB
+	}
+	return tx
+}
+
+func newContextWithTx(ctx context.Context, tx bun.Tx) context.Context {
+	return context.WithValue(ctx, transactorKey{}, tx)
+}
+
+func txFromContext(ctx context.Context) (bun.Tx, bool) {
+	tx, ok := ctx.Value(transactorKey{}).(bun.Tx)
+	return tx, ok
 }

--- a/pkg/sqlstore/bun.go
+++ b/pkg/sqlstore/bun.go
@@ -28,6 +28,11 @@ func NewBunDB(settings factory.ScopedProviderSettings, sqldb *sql.DB, dialect sc
 }
 
 func (db *BunDB) RunInTxCtx(ctx context.Context, opts *sql.TxOptions, cb func(ctx context.Context) error) error {
+	tx, ok := txFromContext(ctx)
+	if ok {
+		return cb(ctx)
+	}
+
 	// begin transaction
 	tx, err := db.BeginTx(ctx, opts)
 	if err != nil {

--- a/pkg/sqlstore/postgressqlstore/provider.go
+++ b/pkg/sqlstore/postgressqlstore/provider.go
@@ -16,7 +16,7 @@ import (
 type provider struct {
 	settings factory.ScopedProviderSettings
 	sqldb    *sql.DB
-	bundb    *bun.DB
+	bundb    *sqlstore.BunDB
 	sqlxdb   *sqlx.DB
 }
 
@@ -57,13 +57,13 @@ func New(ctx context.Context, providerSettings factory.ProviderSettings, config 
 	return &provider{
 		settings: settings,
 		sqldb:    sqldb,
-		bundb:    sqlstore.NewBunDB(sqldb, pgdialect.New(), hooks),
+		bundb:    sqlstore.NewBunDB(settings, sqldb, pgdialect.New(), hooks),
 		sqlxdb:   sqlx.NewDb(sqldb, "postgres"),
 	}, nil
 }
 
 func (provider *provider) BunDB() *bun.DB {
-	return provider.bundb
+	return provider.bundb.DB
 }
 
 func (provider *provider) SQLDB() *sql.DB {
@@ -72,4 +72,12 @@ func (provider *provider) SQLDB() *sql.DB {
 
 func (provider *provider) SQLxDB() *sqlx.DB {
 	return provider.sqlxdb
+}
+
+func (provider *provider) BunDBCtx(ctx context.Context) bun.IDB {
+	return provider.bundb.BunDBCtx(ctx)
+}
+
+func (provider *provider) RunInTxCtx(ctx context.Context, opts *sql.TxOptions, cb func(ctx context.Context) error) error {
+	return provider.bundb.RunInTxCtx(ctx, opts, cb)
 }

--- a/pkg/sqlstore/sqlstore.go
+++ b/pkg/sqlstore/sqlstore.go
@@ -17,13 +17,13 @@ type SQLStore interface {
 	// BunDB returns an instance of bun.DB. This is the recommended way to interact with the database.
 	BunDB() *bun.DB
 
-	// SQLxDB returns an instance of sqlx.DB.
+	// SQLxDB returns an instance of sqlx.DB. This is the legacy ORM used.
 	SQLxDB() *sqlx.DB
 
 	// RunInTxCtx runs the given callback in a transaction. It creates and injects a new context with the transaction.
 	RunInTxCtx(ctx context.Context, opts *SQLStoreTxOptions, cb func(ctx context.Context) error) error
 
-	// BunDBCtx returns an instance of bun.IDB for the given context. It is recommended to use this method to interact with the database.
+	// BunDBCtx returns an instance of bun.IDB for the given context.
 	// If a transaction is present in the context, it will be used. Otherwise, the default will be used.
 	BunDBCtx(ctx context.Context) bun.IDB
 }

--- a/pkg/sqlstore/sqlstore.go
+++ b/pkg/sqlstore/sqlstore.go
@@ -21,6 +21,7 @@ type SQLStore interface {
 	SQLxDB() *sqlx.DB
 
 	// RunInTxCtx runs the given callback in a transaction. It creates and injects a new context with the transaction.
+	// If a transaction is present in the context, it will be used.
 	RunInTxCtx(ctx context.Context, opts *SQLStoreTxOptions, cb func(ctx context.Context) error) error
 
 	// BunDBCtx returns an instance of bun.IDB for the given context.

--- a/pkg/sqlstore/sqlstore.go
+++ b/pkg/sqlstore/sqlstore.go
@@ -1,20 +1,31 @@
 package sqlstore
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/uptrace/bun"
 )
 
-// SQLStore is the interface for the SQLStore.
+type SQLStoreTxOptions = sql.TxOptions
+
 type SQLStore interface {
 	// SQLDB returns the underlying sql.DB.
 	SQLDB() *sql.DB
+
 	// BunDB returns an instance of bun.DB. This is the recommended way to interact with the database.
 	BunDB() *bun.DB
+
 	// SQLxDB returns an instance of sqlx.DB.
 	SQLxDB() *sqlx.DB
+
+	// RunInTxCtx runs the given callback in a transaction. It creates and injects a new context with the transaction.
+	RunInTxCtx(ctx context.Context, opts *SQLStoreTxOptions, cb func(ctx context.Context) error) error
+
+	// BunDBCtx returns an instance of bun.IDB for the given context. It is recommended to use this method to interact with the database.
+	// If a transaction is present in the context, it will be used. Otherwise, the default will be used.
+	BunDBCtx(ctx context.Context) bun.IDB
 }
 
 type SQLStoreHook interface {

--- a/pkg/sqlstore/sqlstoretest/provider.go
+++ b/pkg/sqlstore/sqlstoretest/provider.go
@@ -1,6 +1,7 @@
 package sqlstoretest
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -58,4 +59,12 @@ func (provider *Provider) SQLxDB() *sqlx.DB {
 
 func (provider *Provider) Mock() sqlmock.Sqlmock {
 	return provider.mock
+}
+
+func (provider *Provider) BunDBCtx(ctx context.Context) bun.IDB {
+	return provider.bunDB
+}
+
+func (provider *Provider) RunInTxCtx(ctx context.Context, opts *sql.TxOptions, cb func(ctx context.Context) error) error {
+	return cb(ctx)
 }

--- a/pkg/types/alertmanagertypes/config.go
+++ b/pkg/types/alertmanagertypes/config.go
@@ -316,9 +316,33 @@ func (c *Config) ReceiverNamesFromRuleID(ruleID string) ([]string, error) {
 	return receiverNames, nil
 }
 
+type storeOptions struct {
+	Cb func(context.Context) error
+}
+
+type StoreOption func(*storeOptions)
+
+func WithCb(cb func(context.Context) error) StoreOption {
+	return func(o *storeOptions) {
+		o.Cb = cb
+	}
+}
+
+func NewStoreOptions(opts ...StoreOption) *storeOptions {
+	o := &storeOptions{
+		Cb: nil,
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o
+}
+
 type ConfigStore interface {
 	// Set creates or updates a config.
-	Set(context.Context, *Config) error
+	Set(context.Context, *Config, ...StoreOption) error
 
 	// Get returns the config for the given orgID
 	Get(context.Context, string) (*Config, error)
@@ -327,16 +351,16 @@ type ConfigStore interface {
 	ListOrgs(context.Context) ([]string, error)
 
 	// CreateChannel creates a new channel.
-	CreateChannel(context.Context, *Channel, func(context.Context) error) error
+	CreateChannel(context.Context, *Channel, ...StoreOption) error
 
 	// GetChannelByID returns the channel for the given id.
 	GetChannelByID(context.Context, string, int) (*Channel, error)
 
 	// UpdateChannel updates a channel.
-	UpdateChannel(context.Context, string, *Channel, func(context.Context) error) error
+	UpdateChannel(context.Context, string, *Channel, ...StoreOption) error
 
 	// DeleteChannelByID deletes a channel.
-	DeleteChannelByID(context.Context, string, int, func(context.Context) error) error
+	DeleteChannelByID(context.Context, string, int, ...StoreOption) error
 
 	// ListChannels returns the list of channels.
 	ListChannels(context.Context, string) ([]*Channel, error)
@@ -348,8 +372,6 @@ type ConfigStore interface {
 	// Matchers is an array of ruleId to receiver names.
 	GetMatchers(context.Context, string) (map[string][]string, error)
 }
-
-var ConfigStoreNoopCallback = func(ctx context.Context) error { return nil }
 
 // MarshalSecretValue if set to true will expose Secret type
 // through the marshal interfaces. We need to store the actual value of the secret

--- a/pkg/types/alertmanagertypes/receiver.go
+++ b/pkg/types/alertmanagertypes/receiver.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
+	"go.signoz.io/signoz/pkg/errors"
 
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/config/receiver"
@@ -37,14 +38,27 @@ func NewReceiverIntegrations(nc Receiver, tmpl *template.Template, logger *slog.
 	return receiver.BuildReceiverIntegrations(nc, tmpl, logger)
 }
 
-func TestReceiver(ctx context.Context, receiver Receiver, tmpl *template.Template, logger *slog.Logger, alert *Alert) error {
+func TestReceiver(ctx context.Context, receiver Receiver, config *Config, tmpl *template.Template, logger *slog.Logger, alert *Alert) error {
 	ctx = notify.WithGroupKey(ctx, fmt.Sprintf("%s-%s-%d", receiver.Name, alert.Labels.Fingerprint(), time.Now().Unix()))
 	ctx = notify.WithGroupLabels(ctx, alert.Labels)
 	ctx = notify.WithReceiverName(ctx, receiver.Name)
 
+	testConfig, err := config.CopyWithReset()
+	if err != nil {
+		return err
+	}
+
+	if err := testConfig.CreateReceiver(receiver); err != nil {
+		return err
+	}
+
 	integrations, err := NewReceiverIntegrations(receiver, tmpl, logger)
 	if err != nil {
 		return err
+	}
+
+	if len(integrations) == 0 {
+		return errors.Newf(errors.TypeNotFound, errors.CodeNotFound, "no integrations found for receiver %s", receiver.Name)
 	}
 
 	if _, err = integrations[0].Notify(ctx, alert); err != nil {

--- a/pkg/types/alertmanagertypes/receiver.go
+++ b/pkg/types/alertmanagertypes/receiver.go
@@ -43,6 +43,9 @@ func TestReceiver(ctx context.Context, receiver Receiver, config *Config, tmpl *
 	ctx = notify.WithGroupLabels(ctx, alert.Labels)
 	ctx = notify.WithReceiverName(ctx, receiver.Name)
 
+	// We need to create a new config with the same global and route config but empty receivers and routes
+	// This is so that we can call CreateReceiver without worrying about the existing receivers and routes.
+	// CreateReceiver will ensure that any defaults (such as http config in the case of slack) are set. Otherwise the integration will panic.
 	testConfig, err := config.CopyWithReset()
 	if err != nil {
 		return err


### PR DESCRIPTION
### Summary

- add transaction support for sqlstore
- use transactions in alertmanager

#### Related Issues / PR's

https://github.com/SigNoz/platform-pod/issues/404

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds transaction support to SQL store operations and updates alert manager components to utilize transactions for consistency.
> 
>   - **Transaction Support**:
>     - Adds transaction support to `sqlstore` with `RunInTxCtx()` and `BunDBCtx()` in `bun.go`.
>     - Implements `wrap()` function in `config.go` to handle transactions for `Set`, `CreateChannel`, `UpdateChannel`, and `DeleteChannelByID`.
>   - **Alert Manager Changes**:
>     - Updates `TestReceiver()` in `server.go` to use `alertmanagerConfig` for testing receivers.
>     - Modifies `UpdateChannelByReceiverAndID()`, `CreateChannel()`, and `DeleteChannelByID()` in `provider.go` to use transactions.
>   - **Miscellaneous**:
>     - Adds `CopyWithReset()` in `config.go` to create a new config with default settings.
>     - Introduces `StoreOption` and `WithCb()` in `config.go` for transaction callbacks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 81945dd73b587795ff9e5f16726ffa604a24b261. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->