### PR TITLE
fix: update bearer to capital case and handle undefined

### DIFF
--- a/frontend/src/api/channels/createWebhook.ts
+++ b/frontend/src/api/channels/createWebhook.ts
@@ -9,19 +9,21 @@ const create = async (
 ): Promise<SuccessResponse<PayloadProps> | ErrorResponse> => {
 	try {
 		let httpConfig = {};
+		const username = props.username ? props.username.trim() : '';
+		const password = props.password ? props.password.trim() : '';
 
-		if (props.username !== '' && props.password !== '') {
+		if (username !== '' && password !== '') {
 			httpConfig = {
 				basic_auth: {
-					username: props.username,
-					password: props.password,
+					username,
+					password,
 				},
 			};
-		} else if (props.username === '' && props.password !== '') {
+		} else if (username === '' && password !== '') {
 			httpConfig = {
 				authorization: {
-					type: 'bearer',
-					credentials: props.password,
+					type: 'Bearer',
+					credentials: password,
 				},
 			};
 		}

--- a/frontend/src/api/channels/editWebhook.ts
+++ b/frontend/src/api/channels/editWebhook.ts
@@ -9,18 +9,21 @@ const editWebhook = async (
 ): Promise<SuccessResponse<PayloadProps> | ErrorResponse> => {
 	try {
 		let httpConfig = {};
-		if (props.username !== '' && props.password !== '') {
+		const username = props.username ? props.username.trim() : '';
+		const password = props.password ? props.password.trim() : '';
+
+		if (username !== '' && password !== '') {
 			httpConfig = {
 				basic_auth: {
-					username: props.username,
-					password: props.password,
+					username,
+					password,
 				},
 			};
-		} else if (props.username === '' && props.password !== '') {
+		} else if (username === '' && password !== '') {
 			httpConfig = {
 				authorization: {
-					type: 'bearer',
-					credentials: props.password,
+					type: 'Bearer',
+					credentials: password,
 				},
 			};
 		}

--- a/frontend/src/api/channels/testWebhook.ts
+++ b/frontend/src/api/channels/testWebhook.ts
@@ -9,19 +9,21 @@ const testWebhook = async (
 ): Promise<SuccessResponse<PayloadProps> | ErrorResponse> => {
 	try {
 		let httpConfig = {};
+		const username = props.username ? props.username.trim() : '';
+		const password = props.password ? props.password.trim() : '';
 
-		if (props.username !== '' && props.password !== '') {
+		if (username !== '' && password !== '') {
 			httpConfig = {
 				basic_auth: {
-					username: props.username,
-					password: props.password,
+					username,
+					password,
 				},
 			};
-		} else if (props.username === '' && props.password !== '') {
+		} else if (username === '' && password !== '') {
 			httpConfig = {
 				authorization: {
-					type: 'bearer',
-					credentials: props.password,
+					type: 'Bearer',
+					credentials: password,
 				},
 			};
 		}


### PR DESCRIPTION
### Summary

Part of https://github.com/SigNoz/signoz/issues/7216

When creating webhook-based alert channel, the user can either provide a username and password or just a secret in the password field. When just the secret is provided, we use bearer authorization config. The type currently sent as `bearer` which doesn't work with the incident.io. It would have been nice to have them support lowercase as well. But to address the issue, we change it to Bearer. 


https://auth0.com/blog/the-bearer-token-case/


Other than the case, the props were undefined, the user didn't use the input box and went into incorrect case. This change also fixes it.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Trim whitespace from `username` and `password` and capitalize 'Bearer' in authorization type in webhook functions.
> 
>   - **Behavior**:
>     - Trim whitespace from `username` and `password` in `createWebhook.ts`, `editWebhook.ts`, and `testWebhook.ts`.
>     - Update authorization type to 'Bearer' (capitalized) when `username` is empty and `password` is provided.
>   - **Functions**:
>     - Modify `create()` in `createWebhook.ts` to handle trimmed inputs and correct authorization type.
>     - Modify `editWebhook()` in `editWebhook.ts` to handle trimmed inputs and correct authorization type.
>     - Modify `testWebhook()` in `testWebhook.ts` to handle trimmed inputs and correct authorization type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 1159b55afbaeb65fc886cc938b7fe6f837612bd1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->