### PR TITLE
fix: add missing send_resolved for email/pager/opsgenie edit payload

### DIFF
--- a/frontend/src/container/EditAlertChannels/index.tsx
+++ b/frontend/src/container/EditAlertChannels/index.tsx
@@ -173,6 +173,7 @@ function EditAlertChannels({
 	const prepareEmailRequest = useCallback(
 		() => ({
 			name: selectedConfig?.name || '',
+			send_resolved: selectedConfig?.send_resolved || false,
 			to: selectedConfig.to || '',
 			html: selectedConfig.html || '',
 			headers: selectedConfig.headers || {},
@@ -208,6 +209,7 @@ function EditAlertChannels({
 	const preparePagerRequest = useCallback(
 		() => ({
 			name: selectedConfig.name || '',
+			send_resolved: selectedConfig?.send_resolved || false,
 			routing_key: selectedConfig.routing_key,
 			client: selectedConfig.client,
 			client_url: selectedConfig.client_url,
@@ -261,6 +263,7 @@ function EditAlertChannels({
 	const prepareOpsgenieRequest = useCallback(
 		() => ({
 			name: selectedConfig.name || '',
+			send_resolved: selectedConfig?.send_resolved || false,
 			api_key: selectedConfig.api_key || '',
 			message: selectedConfig.message || '',
 			description: selectedConfig.description || '',


### PR DESCRIPTION
### Summary

Fixes #7233

Fixes https://github.com/SigNoz/signoz/issues/7131

The `send_resolved` prop is not sent in the edit request payload for email/pagerduty/opsgenie alert channels. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `send_resolved` to email, pagerduty, and opsgenie edit payloads in `index.tsx`.
> 
>   - **Behavior**:
>     - Adds `send_resolved` property to the payload in `prepareEmailRequest`, `preparePagerRequest`, and `prepareOpsgenieRequest` in `index.tsx`.
>     - Ensures `send_resolved` is sent with edit requests for email, pagerduty, and opsgenie channels.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 00f9ba1a10b43bb80575f474e58943a5ead3acd1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->