### PR TITLE
fix: ignore identity for default user

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1545,9 +1545,9 @@ func (aH *APIHandler) registerEvent(w http.ResponseWriter, r *http.Request) {
 		case model.TrackEvent:
 			telemetry.GetInstance().SendEvent(request.EventName, request.Attributes, claims.Email, request.RateLimited, true)
 		case model.GroupEvent:
-			telemetry.GetInstance().SendGroupEvent(request.Attributes)
+			telemetry.GetInstance().SendGroupEvent(request.Attributes, claims.Email)
 		case model.IdentifyEvent:
-			telemetry.GetInstance().SendIdentifyEvent(request.Attributes)
+			telemetry.GetInstance().SendIdentifyEvent(request.Attributes, claims.Email)
 		}
 		aH.WriteJSON(w, r, map[string]string{"data": "Event Processed Successfully"})
 	} else {

--- a/pkg/query-service/telemetry/telemetry.go
+++ b/pkg/query-service/telemetry/telemetry.go
@@ -425,7 +425,7 @@ func createTelemetry() {
 						"total_metrics_based_panels":  dashboardsInfo.MetricBasedPanels,
 						"total_logs_based_panels":     dashboardsInfo.LogsBasedPanels,
 						"total_traces_based_panels":   dashboardsInfo.TracesBasedPanels,
-					})
+					}, "")
 					telemetry.SendGroupEvent(map[string]interface{}{
 						"total_logs":                  totalLogs,
 						"total_traces":                totalSpans,
@@ -442,7 +442,7 @@ func createTelemetry() {
 						"total_metrics_based_panels":  dashboardsInfo.MetricBasedPanels,
 						"total_logs_based_panels":     dashboardsInfo.LogsBasedPanels,
 						"total_traces_based_panels":   dashboardsInfo.TracesBasedPanels,
-					})
+					}, "")
 				}
 			}
 		}
@@ -451,16 +451,16 @@ func createTelemetry() {
 		}
 
 		if totalLogs > 0 {
-			telemetry.SendIdentifyEvent(map[string]interface{}{"sent_logs": true})
-			telemetry.SendGroupEvent(map[string]interface{}{"sent_logs": true})
+			telemetry.SendIdentifyEvent(map[string]interface{}{"sent_logs": true}, "")
+			telemetry.SendGroupEvent(map[string]interface{}{"sent_logs": true}, "")
 		}
 		if totalSpans > 0 {
-			telemetry.SendIdentifyEvent(map[string]interface{}{"sent_traces": true})
-			telemetry.SendGroupEvent(map[string]interface{}{"sent_traces": true})
+			telemetry.SendIdentifyEvent(map[string]interface{}{"sent_traces": true}, "")
+			telemetry.SendGroupEvent(map[string]interface{}{"sent_traces": true}, "")
 		}
 		if totalSamples > 0 {
-			telemetry.SendIdentifyEvent(map[string]interface{}{"sent_metrics": true})
-			telemetry.SendGroupEvent(map[string]interface{}{"sent_metrics": true})
+			telemetry.SendIdentifyEvent(map[string]interface{}{"sent_metrics": true}, "")
+			telemetry.SendGroupEvent(map[string]interface{}{"sent_metrics": true}, "")
 		}
 
 		getDistributedInfoInLastHeartBeatInterval, _ := telemetry.reader.GetDistributedInfoInLastHeartBeatInterval(ctx)
@@ -591,10 +591,19 @@ func (a *Telemetry) IdentifyUser(user *types.User) {
 	}
 }
 
-func (a *Telemetry) SendIdentifyEvent(data map[string]interface{}) {
+func (a *Telemetry) SendIdentifyEvent(data map[string]interface{}, userEmail string) {
 
 	if !a.isTelemetryEnabled() || a.isTelemetryAnonymous() {
 		return
+	}
+	// ignore telemetry for default user
+	if userEmail == DEFAULT_CLOUD_EMAIL || a.GetUserEmail() == DEFAULT_CLOUD_EMAIL {
+		return
+	}
+
+	if userEmail != "" {
+		a.SetUserEmail(userEmail)
+		a.SetCompanyDomain(userEmail)
 	}
 	traits := analytics.NewTraits()
 
@@ -615,10 +624,19 @@ func (a *Telemetry) SendIdentifyEvent(data map[string]interface{}) {
 	}
 }
 
-func (a *Telemetry) SendGroupEvent(data map[string]interface{}) {
+func (a *Telemetry) SendGroupEvent(data map[string]interface{}, userEmail string) {
 
 	if !a.isTelemetryEnabled() || a.isTelemetryAnonymous() {
 		return
+	}
+	// ignore telemetry for default user
+	if userEmail == DEFAULT_CLOUD_EMAIL || a.GetUserEmail() == DEFAULT_CLOUD_EMAIL {
+		return
+	}
+
+	if userEmail != "" {
+		a.SetUserEmail(userEmail)
+		a.SetCompanyDomain(userEmail)
 	}
 	traits := analytics.NewTraits()
 


### PR DESCRIPTION
### Summary

Ignore default user for SendGroupEvent and SendIdentifyEvent 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `SendGroupEvent` and `SendIdentifyEvent` now ignore events for the default user, identified by `DEFAULT_CLOUD_EMAIL`, in `telemetry.go` and `http_handler.go`.
> 
>   - **Behavior**:
>     - `SendGroupEvent` and `SendIdentifyEvent` in `telemetry.go` now ignore events for `DEFAULT_CLOUD_EMAIL`.
>     - `registerEvent` in `http_handler.go` passes `claims.Email` to `SendGroupEvent` and `SendIdentifyEvent`.
>   - **Functions**:
>     - Updated `SendGroupEvent` and `SendIdentifyEvent` to check `userEmail` against `DEFAULT_CLOUD_EMAIL`.
>     - `registerEvent` updated to include `claims.Email` when calling telemetry functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 9ebfef38b61593fd0120bed34c7691fa4fa8c9c2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->