### PR TITLE
fix: use correct createdAt and updatedAt for dashboards

### DIFF
--- a/frontend/src/container/AlertHistory/Statistics/TopContributorsCard/TopContributorsCard.tsx
+++ b/frontend/src/container/AlertHistory/Statistics/TopContributorsCard/TopContributorsCard.tsx
@@ -22,7 +22,7 @@ function TopContributorsCard({
 	const viewAllTopContributorsParam = searchParams.get('viewAllTopContributors');
 
 	const [isViewAllVisible, setIsViewAllVisible] = useState(
-		!!viewAllTopContributorsParam ?? false,
+		!!viewAllTopContributorsParam,
 	);
 
 	const isDarkMode = useIsDarkMode();

--- a/frontend/src/container/GridCardLayout/DashboardEmptyState/DashboardEmptyState.tsx
+++ b/frontend/src/container/GridCardLayout/DashboardEmptyState/DashboardEmptyState.tsx
@@ -28,7 +28,7 @@ export default function DashboardEmptyState(): JSX.Element {
 	}
 
 	const userRole: ROLES | null =
-		selectedDashboard?.created_by === user?.email
+		selectedDashboard?.createdBy === user?.email
 			? (USER_ROLES.AUTHOR as ROLES)
 			: user.role;
 

--- a/frontend/src/container/GridCardLayout/GridCardLayout.tsx
+++ b/frontend/src/container/GridCardLayout/GridCardLayout.tsx
@@ -113,7 +113,7 @@ function GraphLayout(props: GraphLayoutProps): JSX.Element {
 	}
 
 	const userRole: ROLES | null =
-		selectedDashboard?.created_by === user?.email
+		selectedDashboard?.createdBy === user?.email
 			? (USER_ROLES.AUTHOR as ROLES)
 			: user.role;
 

--- a/frontend/src/container/GridCardLayout/WidgetRow.tsx
+++ b/frontend/src/container/GridCardLayout/WidgetRow.tsx
@@ -44,7 +44,7 @@ export function WidgetRowHeader(props: WidgetRowHeaderProps): JSX.Element {
 	const { user } = useAppContext();
 
 	const userRole: ROLES | null =
-		selectedDashboard?.created_by === user?.email
+		selectedDashboard?.createdBy === user?.email
 			? (USER_ROLES.AUTHOR as ROLES)
 			: user.role;
 	const [addPanelPermission] = useComponentPermission(permissions, userRole);

--- a/frontend/src/container/ListOfDashboard/SearchFilter/__tests__/utils.test.ts
+++ b/frontend/src/container/ListOfDashboard/SearchFilter/__tests__/utils.test.ts
@@ -8,10 +8,10 @@ describe('executeSearchQueries', () => {
 	const firstDashboard: Dashboard = {
 		id: 11111,
 		uuid: uuid(),
-		created_at: '',
-		updated_at: '',
-		created_by: '',
-		updated_by: '',
+		createdAt: '',
+		updatedAt: '',
+		createdBy: '',
+		updatedBy: '',
 		data: {
 			title: 'first dashboard',
 			variables: {},
@@ -20,10 +20,10 @@ describe('executeSearchQueries', () => {
 	const secondDashboard: Dashboard = {
 		id: 22222,
 		uuid: uuid(),
-		created_at: '',
-		updated_at: '',
-		created_by: '',
-		updated_by: '',
+		createdAt: '',
+		updatedAt: '',
+		createdBy: '',
+		updatedBy: '',
 		data: {
 			title: 'second dashboard',
 			variables: {},
@@ -32,10 +32,10 @@ describe('executeSearchQueries', () => {
 	const thirdDashboard: Dashboard = {
 		id: 333333,
 		uuid: uuid(),
-		created_at: '',
-		updated_at: '',
-		created_by: '',
-		updated_by: '',
+		createdAt: '',
+		updatedAt: '',
+		createdBy: '',
+		updatedBy: '',
 		data: {
 			title: 'third dashboard (with special characters +?\\)',
 			variables: {},

--- a/frontend/src/pages/DashboardsListPage/__tests__/DashboardListPage.test.tsx
+++ b/frontend/src/pages/DashboardsListPage/__tests__/DashboardListPage.test.tsx
@@ -236,7 +236,7 @@ describe('dashboard list page', () => {
 			expect.objectContaining({
 				id: firstDashboardData.uuid,
 				title: firstDashboardData.data.title,
-				createdAt: firstDashboardData.created_at,
+				createdAt: firstDashboardData.createdAt,
 			}),
 		);
 	});


### PR DESCRIPTION
Uses correct createdAt and updatedAt for dashboard
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renames dashboard metadata properties to camelCase in multiple files for consistency.
> 
>   - **Renames**:
>     - `created_at` to `createdAt`, `updated_at` to `updatedAt`, `created_by` to `createdBy`, and `updated_by` to `updatedBy` in `GridCardLayout.tsx`, `DashboardEmptyState.tsx`, and `WidgetRow.tsx`.
>   - **Tests**:
>     - Update `utils.test.ts` and `DashboardListPage.test.tsx` to use `createdAt` and `updatedAt` instead of `created_at` and `updated_at`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 889b1d9d1ee2273a662c173ca755393d302e4707. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->