### PR TITLE
fix(alertmanager): send empty array instead of nil

### DIFF
--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -97,6 +97,11 @@ func (api *API) ListChannels(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// This ensures that the UI receives an empty array instead of null
+	if len(channels) == 0 {
+		channels = make([]*alertmanagertypes.Channel, 0)
+	}
+
 	render.Success(rw, http.StatusOK, channels)
 }
 


### PR DESCRIPTION
### Summary

- send empty array instead of nil for /channels endpoint

#### Related Issues / PR's

Reported by community
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Return an empty array instead of `nil` in `ListChannels()` in `api.go` when no channels are present.
> 
>   - **Behavior**:
>     - In `ListChannels()` in `api.go`, return an empty array instead of `nil` when no channels are present.
>     - This change ensures UI consistency by preventing `null` responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 95d1f404eb0034346d023a9e4b32269e6df75748. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->