### PR TITLE
fix(usage): set default tenant for exporting usage

### DIFF
--- a/ee/query-service/usage/manager.go
+++ b/ee/query-service/usage/manager.go
@@ -165,7 +165,7 @@ func (lm *Manager) UploadUsage() {
 		usageData.CollectorID = usage.CollectorID
 		usageData.ExporterID = usage.ExporterID
 		usageData.Type = usage.Type
-		usageData.Tenant = usage.Tenant
+		usageData.Tenant = "default"
 		usageData.OrgName = orgName
 		usageData.TenantId = lm.tenantID
 		usagesPayload = append(usagesPayload, usageData)


### PR DESCRIPTION
### Summary

- set the tenant as `default` for usage reporting as there is some long running issue with otel exporter 

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `usageData.Tenant` to `"default"` in `UploadUsage()` in `manager.go` to address an otel exporter issue.
> 
>   - **Behavior**:
>     - In `UploadUsage()` in `manager.go`, set `usageData.Tenant` to `"default"` instead of using `usage.Tenant`.
>   - **Purpose**:
>     - Addresses a long-running issue with the otel exporter by ensuring a consistent tenant value for usage reporting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e609448649352c19e1cfe0e4f13385bf6e52e301. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->