### PR TITLE
ci(codeowners): add codeowners for core pkg packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,8 @@
 /frontend/src/container/MetricsApplication @srikanthccv
 /frontend/src/container/NewWidget/RightContainer/types.ts @srikanthccv
 /deploy/ @SigNoz/devops
-/sample-apps/ @SigNoz/devops
 .github @SigNoz/devops
+/pkg/config/ @grandwizard28
+/pkg/errors/ @grandwizard28
+/pkg/factory/ @grandwizard28
+/pkg/types/ @grandwizard28


### PR DESCRIPTION
### Summary

Add codeowners for
/pkg/config/ @grandwizard28
/pkg/errors/ @grandwizard28
/pkg/factory/ @grandwizard28
/pkg/types/ @grandwizard28
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `@grandwizard28` as codeowner for `/pkg/config/`, `/pkg/errors/`, `/pkg/factory/`, and `/pkg/types/`.
> 
>   - **Codeowners**:
>     - Add `@grandwizard28` as codeowner for `/pkg/config/`, `/pkg/errors/`, `/pkg/factory/`, and `/pkg/types/` in `.github/CODEOWNERS`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 550c40888791c20b76beac28b93eea5669a8a7f2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->