### PR TITLE
fix: css style override in planned downtime table

### DIFF
--- a/frontend/src/container/PlannedDowntime/PlannedDowntime.styles.scss
+++ b/frontend/src/container/PlannedDowntime/PlannedDowntime.styles.scss
@@ -274,7 +274,9 @@
 	.ant-table-cell {
 		padding: 0 !important;
 		border: 0 !important;
-		width: 736px;
+		min-width: 736px !important;
+                max-width: 736px !important;
+                width: 736px !important;
 	}
 
 	.ant-table-tbody {


### PR DESCRIPTION
## Description
This PR fixes the CSS style override issue in the Planned Downtime page where gloabl scoped table cell styles from InfraMonitoringK8s.styles.scss were overriding component-specific styles, causing layout issues.

## Changes
- Added specific CSS rules with !important flags to ensure the planned downtime table cells maintain their correct width
- Fixed the table cell width to 736px as intended by the component design

## Related Issue
Fixes #7214

## Testing
- Verified that the table cells maintain the correct width
- Confirmed that the layout no longer breaks after navigation

## Screenshots 
<img width="995" alt="Screenshot 2025-03-17 at 8 56 36 AM" src="https://github.com/user-attachments/assets/b048432e-9798-41c1-b3c0-9cde9407cfab" />

