### PR TITLE
fix: enable 8080 ports for testing standalone and swarm

### DIFF
--- a/deploy/docker-swarm/docker-compose.ha.yaml
+++ b/deploy/docker-swarm/docker-compose.ha.yaml
@@ -179,8 +179,8 @@ services:
       - --config=/root/config/prometheus.yml
       - --use-logs-new-schema=true
       - --use-trace-new-schema=true
-    # ports:
-    #   - "8080:8080"     # signoz port
+    ports:
+      - "8080:8080"     # signoz port
     #   - "6060:6060"     # pprof port
     volumes:
       - ../common/signoz/prometheus.yml:/root/config/prometheus.yml

--- a/deploy/docker-swarm/docker-compose.yaml
+++ b/deploy/docker-swarm/docker-compose.yaml
@@ -115,8 +115,8 @@ services:
       - --config=/root/config/prometheus.yml
       - --use-logs-new-schema=true
       - --use-trace-new-schema=true
-    # ports:
-    #   - "8080:8080"     # signoz port
+    ports:
+      - "8080:8080"     # signoz port
     #   - "6060:6060"     # pprof port
     volumes:
       - ../common/signoz/prometheus.yml:/root/config/prometheus.yml

--- a/deploy/docker/docker-compose.testing.yaml
+++ b/deploy/docker/docker-compose.testing.yaml
@@ -117,8 +117,8 @@ services:
       - --gateway-url=https://api.staging.signoz.cloud
       - --use-logs-new-schema=true
       - --use-trace-new-schema=true
-    # ports:
-    #   - "8080:8080"     # signoz port
+    ports:
+      - "8080:8080"     # signoz port
     #   - "6060:6060"     # pprof port
     volumes:
       - ../common/signoz/prometheus.yml:/root/config/prometheus.yml


### PR DESCRIPTION
### Summary

- expose SigNoz port 8080 for testing standalone and swarm

#### Related Issues / PR's

NA

#### Screenshots

NA

#### Affected Areas and Manually Tested Areas

NA
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expose port 8080 for the SigNoz service in Docker Compose files for testing standalone and swarm modes.
> 
>   - **Behavior**:
>     - Expose port `8080` for the `signoz` service in `docker-compose.ha.yaml`, `docker-compose.yaml`, and `docker-compose.testing.yaml` for testing purposes.
>   - **Files**:
>     - `docker-compose.ha.yaml`: Uncommented `8080:8080` under `signoz` service.
>     - `docker-compose.yaml`: Uncommented `8080:8080` under `signoz` service.
>     - `docker-compose.testing.yaml`: Uncommented `8080:8080` under `signoz` service.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for d19d1ce91e74de2dbb9325720c2fabeab053ec33. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->