### PR TITLE
feat: handle navigations in case of oss in homepage

### DIFF
--- a/frontend/src/container/Home/DataSourceInfo/DataSourceInfo.tsx
+++ b/frontend/src/container/Home/DataSourceInfo/DataSourceInfo.tsx
@@ -6,7 +6,11 @@ import { useGetDeploymentsData } from 'hooks/CustomDomain/useGetDeploymentsData'
 import history from 'lib/history';
 import { Globe, Link2 } from 'lucide-react';
 import Card from 'periscope/components/Card/Card';
+import { useAppContext } from 'providers/App/App';
 import { useEffect, useState } from 'react';
+import { LicensePlatform } from 'types/api/licensesV3/getActive';
+
+import { DOCS_LINKS } from '../constants';
 
 function DataSourceInfo({
 	dataSentToSigNoz,
@@ -15,6 +19,8 @@ function DataSourceInfo({
 	dataSentToSigNoz: boolean;
 	isLoading: boolean;
 }): JSX.Element {
+	const { activeLicenseV3 } = useAppContext();
+
 	const notSendingData = !dataSentToSigNoz;
 
 	const {
@@ -77,12 +83,36 @@ function DataSourceInfo({
 								tabIndex={0}
 								onClick={(): void => {
 									logEvent('Homepage: Connect dataSource clicked', {});
-									history.push(ROUTES.GET_STARTED);
+
+									if (
+										activeLicenseV3 &&
+										activeLicenseV3.platform === LicensePlatform.CLOUD
+									) {
+										history.push(ROUTES.GET_STARTED_WITH_CLOUD);
+									} else {
+										window?.open(
+											DOCS_LINKS.ADD_DATA_SOURCE,
+											'_blank',
+											'noopener noreferrer',
+										);
+									}
 								}}
 								onKeyDown={(e): void => {
 									if (e.key === 'Enter') {
 										logEvent('Homepage: Connect dataSource clicked', {});
-										history.push(ROUTES.GET_STARTED);
+
+										if (
+											activeLicenseV3 &&
+											activeLicenseV3.platform === LicensePlatform.CLOUD
+										) {
+											history.push(ROUTES.GET_STARTED_WITH_CLOUD);
+										} else {
+											window?.open(
+												DOCS_LINKS.ADD_DATA_SOURCE,
+												'_blank',
+												'noopener noreferrer',
+											);
+										}
 									}
 								}}
 							>

--- a/frontend/src/container/Home/HomeChecklist/HomeChecklist.tsx
+++ b/frontend/src/container/Home/HomeChecklist/HomeChecklist.tsx
@@ -127,7 +127,7 @@ function HomeChecklist({
 												)}
 											</div>
 
-											{!item.isSkipped && !item.isSkippable && (
+											{!item.isSkipped && item.isSkippable && (
 												<div className="whats-next-checklist-item-action-buttons-container">
 													<Button
 														type="link"

--- a/frontend/src/container/Home/HomeChecklist/HomeChecklist.tsx
+++ b/frontend/src/container/Home/HomeChecklist/HomeChecklist.tsx
@@ -1,11 +1,14 @@
+/* eslint-disable sonarjs/cognitive-complexity */
 import './HomeChecklist.styles.scss';
 
 import { Button } from 'antd';
 import logEvent from 'api/common/logEvent';
+import ROUTES from 'constants/routes';
+import history from 'lib/history';
 import { ArrowRight, ArrowRightToLine, BookOpenText } from 'lucide-react';
 import { useAppContext } from 'providers/App/App';
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { LicensePlatform } from 'types/api/licensesV3/getActive';
 import { USER_ROLES } from 'types/roles';
 
 export type ChecklistItem = {
@@ -14,6 +17,7 @@ export type ChecklistItem = {
 	description: string;
 	completed: boolean;
 	isSkipped: boolean;
+	isSkippable?: boolean;
 	skippedPreferenceKey?: string;
 	toRoute?: string;
 	docsLink?: string;
@@ -28,7 +32,7 @@ function HomeChecklist({
 	onSkip: (item: ChecklistItem) => void;
 	isLoading: boolean;
 }): JSX.Element {
-	const { user } = useAppContext();
+	const { user, activeLicenseV3 } = useAppContext();
 
 	const [completedChecklistItems, setCompletedChecklistItems] = useState<
 		ChecklistItem[]
@@ -79,19 +83,32 @@ function HomeChecklist({
 									{user?.role !== USER_ROLES.VIEWER && (
 										<div className="whats-next-checklist-item-action-buttons">
 											<div className="whats-next-checklist-item-action-buttons-container">
-												<Link to={item.toRoute || ''}>
-													<Button
-														type="default"
-														className="periscope-btn secondary"
-														onClick={(): void => {
-															logEvent('Welcome Checklist: Get started clicked', {
-																step: item.id,
-															});
-														}}
-													>
-														Get Started &nbsp; <ArrowRight size={16} />
-													</Button>
-												</Link>
+												<Button
+													type="default"
+													className="periscope-btn secondary"
+													onClick={(): void => {
+														logEvent('Welcome Checklist: Get started clicked', {
+															step: item.id,
+														});
+
+														if (item.toRoute !== ROUTES.GET_STARTED_WITH_CLOUD) {
+															history.push(item.toRoute || '');
+														} else if (
+															activeLicenseV3 &&
+															activeLicenseV3.platform === LicensePlatform.CLOUD
+														) {
+															history.push(item.toRoute || '');
+														} else {
+															window?.open(
+																item.docsLink || '',
+																'_blank',
+																'noopener noreferrer',
+															);
+														}
+													}}
+												>
+													Get Started &nbsp; <ArrowRight size={16} />
+												</Button>
 
 												{item.docsLink && (
 													<Button
@@ -102,7 +119,7 @@ function HomeChecklist({
 																step: item.id,
 															});
 
-															window?.open(item.docsLink, '_blank');
+															window?.open(item.docsLink, '_blank', 'noopener noreferrer');
 														}}
 													>
 														<BookOpenText size={16} />
@@ -110,7 +127,7 @@ function HomeChecklist({
 												)}
 											</div>
 
-											{!item.isSkipped && (
+											{!item.isSkipped && !item.isSkippable && (
 												<div className="whats-next-checklist-item-action-buttons-container">
 													<Button
 														type="link"

--- a/frontend/src/container/Home/Services/ServiceTraces.tsx
+++ b/frontend/src/container/Home/Services/ServiceTraces.tsx
@@ -115,32 +115,30 @@ export default function ServiceTraces({
 
 					{user?.role !== USER_ROLES.VIEWER && (
 						<div className="empty-actions-container">
-							<Link to={ROUTES.GET_STARTED}>
-								<Button
-									type="default"
-									className="periscope-btn secondary"
-									onClick={(): void => {
-										logEvent('Homepage: Get Started clicked', {
-											source: 'Service Traces',
-										});
+							<Button
+								type="default"
+								className="periscope-btn secondary"
+								onClick={(): void => {
+									logEvent('Homepage: Get Started clicked', {
+										source: 'Service Traces',
+									});
 
-										if (
-											activeLicenseV3 &&
-											activeLicenseV3.platform === LicensePlatform.CLOUD
-										) {
-											history.push(ROUTES.GET_STARTED_WITH_CLOUD);
-										} else {
-											window?.open(
-												DOCS_LINKS.ADD_DATA_SOURCE,
-												'_blank',
-												'noopener noreferrer',
-											);
-										}
-									}}
-								>
-									Get Started &nbsp; <ArrowRight size={16} />
-								</Button>
-							</Link>
+									if (
+										activeLicenseV3 &&
+										activeLicenseV3.platform === LicensePlatform.CLOUD
+									) {
+										history.push(ROUTES.GET_STARTED_WITH_CLOUD);
+									} else {
+										window?.open(
+											DOCS_LINKS.ADD_DATA_SOURCE,
+											'_blank',
+											'noopener noreferrer',
+										);
+									}
+								}}
+							>
+								Get Started &nbsp; <ArrowRight size={16} />
+							</Button>
 
 							<Button
 								type="link"

--- a/frontend/src/container/Home/Services/ServiceTraces.tsx
+++ b/frontend/src/container/Home/Services/ServiceTraces.tsx
@@ -3,6 +3,7 @@ import logEvent from 'api/common/logEvent';
 import ROUTES from 'constants/routes';
 import { useQueryService } from 'hooks/useQueryService';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
+import history from 'lib/history';
 import { ArrowRight, ArrowUpRight } from 'lucide-react';
 import Card from 'periscope/components/Card/Card';
 import { useAppContext } from 'providers/App/App';
@@ -10,10 +11,12 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { AppState } from 'store/reducers';
+import { LicensePlatform } from 'types/api/licensesV3/getActive';
 import { ServicesList } from 'types/api/metrics/getService';
 import { GlobalReducer } from 'types/reducer/globalTime';
 import { USER_ROLES } from 'types/roles';
 
+import { DOCS_LINKS } from '../constants';
 import { columns, TIME_PICKER_OPTIONS } from './constants';
 
 const homeInterval = 30 * 60 * 1000;
@@ -29,7 +32,7 @@ export default function ServiceTraces({
 		(state) => state.globalTime,
 	);
 
-	const { user } = useAppContext();
+	const { user, activeLicenseV3 } = useAppContext();
 
 	const now = new Date().getTime();
 	const [timeRange, setTimeRange] = useState({
@@ -120,6 +123,19 @@ export default function ServiceTraces({
 										logEvent('Homepage: Get Started clicked', {
 											source: 'Service Traces',
 										});
+
+										if (
+											activeLicenseV3 &&
+											activeLicenseV3.platform === LicensePlatform.CLOUD
+										) {
+											history.push(ROUTES.GET_STARTED_WITH_CLOUD);
+										} else {
+											window?.open(
+												DOCS_LINKS.ADD_DATA_SOURCE,
+												'_blank',
+												'noopener noreferrer',
+											);
+										}
 									}}
 								>
 									Get Started &nbsp; <ArrowRight size={16} />
@@ -146,7 +162,7 @@ export default function ServiceTraces({
 				</div>
 			</div>
 		),
-		[user?.role],
+		[user?.role, activeLicenseV3],
 	);
 
 	const renderDashboardsList = useCallback(

--- a/frontend/src/container/Home/constants.ts
+++ b/frontend/src/container/Home/constants.ts
@@ -15,6 +15,7 @@ export const checkListStepToPreferenceKeyMap = {
 };
 
 export const DOCS_LINKS = {
+	ADD_DATA_SOURCE: 'https://signoz.io/docs/instrumentation/overview/',
 	SEND_LOGS: 'https://signoz.io/docs/userguide/logs/',
 	SEND_TRACES: 'https://signoz.io/docs/userguide/traces/',
 	SEND_INFRA_METRICS:
@@ -32,6 +33,7 @@ export const defaultChecklistItemsState: ChecklistItem[] = [
 		description: '',
 		completed: true,
 		isSkipped: false,
+		isSkippable: false,
 		skippedPreferenceKey: checkListStepToPreferenceKeyMap.SETUP_WORKSPACE,
 	},
 	{
@@ -41,7 +43,9 @@ export const defaultChecklistItemsState: ChecklistItem[] = [
 		completed: false,
 		isSkipped: false,
 		skippedPreferenceKey: checkListStepToPreferenceKeyMap.ADD_DATA_SOURCE,
-		toRoute: ROUTES.GET_STARTED,
+		toRoute: ROUTES.GET_STARTED_WITH_CLOUD,
+		docsLink: DOCS_LINKS.ADD_DATA_SOURCE,
+		isSkippable: true,
 	},
 	{
 		id: 'SEND_LOGS',
@@ -50,8 +54,9 @@ export const defaultChecklistItemsState: ChecklistItem[] = [
 			'Send your logs to SigNoz to get more visibility into how your resources interact.',
 		completed: false,
 		isSkipped: false,
+		isSkippable: true,
 		skippedPreferenceKey: checkListStepToPreferenceKeyMap.SEND_LOGS,
-		toRoute: ROUTES.GET_STARTED,
+		toRoute: ROUTES.GET_STARTED_WITH_CLOUD,
 		docsLink: DOCS_LINKS.SEND_LOGS,
 	},
 	{
@@ -61,8 +66,9 @@ export const defaultChecklistItemsState: ChecklistItem[] = [
 			'Send your traces to SigNoz to get more visibility into how your resources interact.',
 		completed: false,
 		isSkipped: false,
+		isSkippable: true,
 		skippedPreferenceKey: checkListStepToPreferenceKeyMap.SEND_TRACES,
-		toRoute: ROUTES.GET_STARTED,
+		toRoute: ROUTES.GET_STARTED_WITH_CLOUD,
 		docsLink: DOCS_LINKS.SEND_TRACES,
 	},
 	{
@@ -72,8 +78,9 @@ export const defaultChecklistItemsState: ChecklistItem[] = [
 			'Send your infra metrics to SigNoz to get more visibility into your infrastructure.',
 		completed: false,
 		isSkipped: false,
+		isSkippable: true,
 		skippedPreferenceKey: checkListStepToPreferenceKeyMap.SEND_INFRA_METRICS,
-		toRoute: ROUTES.GET_STARTED,
+		toRoute: ROUTES.GET_STARTED_WITH_CLOUD,
 		docsLink: DOCS_LINKS.SEND_INFRA_METRICS,
 	},
 	{
@@ -83,6 +90,7 @@ export const defaultChecklistItemsState: ChecklistItem[] = [
 			'Setup alerts to get notified when your resources are not performing as expected.',
 		completed: false,
 		isSkipped: false,
+		isSkippable: true,
 		skippedPreferenceKey: checkListStepToPreferenceKeyMap.SETUP_ALERTS,
 		toRoute: ROUTES.ALERTS_NEW,
 		docsLink: DOCS_LINKS.SETUP_ALERTS,
@@ -94,6 +102,7 @@ export const defaultChecklistItemsState: ChecklistItem[] = [
 			'Save your views to get a quick overview of your data and share it with your team.',
 		completed: false,
 		isSkipped: false,
+		isSkippable: true,
 		skippedPreferenceKey: checkListStepToPreferenceKeyMap.SETUP_SAVED_VIEWS,
 		toRoute: ROUTES.LOGS_EXPLORER,
 		docsLink: DOCS_LINKS.SETUP_SAVED_VIEWS,
@@ -105,6 +114,7 @@ export const defaultChecklistItemsState: ChecklistItem[] = [
 			'Create dashboards to visualize your data and share it with your team.',
 		completed: false,
 		isSkipped: false,
+		isSkippable: true,
 		skippedPreferenceKey: checkListStepToPreferenceKeyMap.SETUP_DASHBOARDS,
 		toRoute: ROUTES.ALL_DASHBOARD,
 		docsLink: DOCS_LINKS.SETUP_DASHBOARDS,

--- a/frontend/src/container/Home/constants.ts
+++ b/frontend/src/container/Home/constants.ts
@@ -45,7 +45,7 @@ export const defaultChecklistItemsState: ChecklistItem[] = [
 		skippedPreferenceKey: checkListStepToPreferenceKeyMap.ADD_DATA_SOURCE,
 		toRoute: ROUTES.GET_STARTED_WITH_CLOUD,
 		docsLink: DOCS_LINKS.ADD_DATA_SOURCE,
-		isSkippable: true,
+		isSkippable: false,
 	},
 	{
 		id: 'SEND_LOGS',


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update navigation in homepage components to handle cloud and non-cloud users differently based on license platform.
> 
>   - **Behavior**:
>     - Update navigation in `DataSourceInfo.tsx`, `HomeChecklist.tsx`, `ServiceMetrics.tsx`, and `ServiceTraces.tsx` to handle cloud and non-cloud users differently.
>     - For cloud users, navigate to `ROUTES.GET_STARTED_WITH_CLOUD`; for others, open `DOCS_LINKS.ADD_DATA_SOURCE` in a new tab.
>   - **Components**:
>     - Add `activeLicenseV3` check in `DataSourceInfo`, `HomeChecklist`, `ServiceMetrics`, and `ServiceTraces` to determine navigation behavior.
>     - Modify button click handlers to conditionally navigate or open documentation based on `activeLicenseV3.platform`.
>   - **Constants**:
>     - Add `ADD_DATA_SOURCE` link to `DOCS_LINKS` in `constants.ts` for non-cloud user navigation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 9cf3f0c21e61636cb0bdd52d033b60889c0cd2e8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->