### PR TITLE
fix: min step interval to 60

### DIFF
--- a/pkg/query-service/common/query_range.go
+++ b/pkg/query-service/common/query_range.go
@@ -47,7 +47,7 @@ func PastDayRoundOff() int64 {
 func MinAllowedStepInterval(start, end int64) int64 {
 	step := (end - start) / constants.MaxAllowedPointsInTimeSeries / 1000
 	if step < 60 {
-		return step
+		return 60
 	}
 	// return the nearest lower multiple of 60
 	return step - step%60


### PR DESCRIPTION
Min step interval to be 60
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `MinAllowedStepInterval()` in `query_range.go` returns a minimum step interval of 60.
> 
>   - **Behavior**:
>     - In `query_range.go`, `MinAllowedStepInterval()` now returns a minimum step interval of 60 if calculated step is less than 60.
>     - Ensures step intervals are not less than 60, affecting time series data processing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 151860bc578bf8a2a8aaf521b64e70d20422a827. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->