### PR TITLE
chore: update metric metadata response payload

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -5971,8 +5971,6 @@ func (r *ClickHouseReader) ListSummaryMetrics(ctx context.Context, req *metrics_
 		if req.Limit < 50 {
 			firstQueryLimit = 50
 		}
-	} else if req.OrderBy.ColumnName == "metric_type" {
-		orderByClauseFirstQuery = fmt.Sprintf("ORDER BY type %s", req.OrderBy.Order)
 	} else {
 		orderByClauseFirstQuery = fmt.Sprintf("ORDER BY %s %s", req.OrderBy.ColumnName, req.OrderBy.Order)
 	}
@@ -5985,8 +5983,8 @@ func (r *ClickHouseReader) ListSummaryMetrics(ctx context.Context, req *metrics_
 		`SELECT 
 		    t.metric_name AS metric_name,
 		    ANY_VALUE(t.description) AS description,
-		    ANY_VALUE(t.type) AS type,
-		    ANY_VALUE(t.unit),
+		    ANY_VALUE(t.type) AS metric_type,
+		    ANY_VALUE(t.unit) AS metric_unit,
 		    uniq(t.fingerprint) AS timeseries,
 			uniq(metric_name) OVER() AS total
 		FROM %s.%s AS t
@@ -6013,7 +6011,7 @@ func (r *ClickHouseReader) ListSummaryMetrics(ctx context.Context, req *metrics_
 
 	for rows.Next() {
 		var metric metrics_explorer.MetricDetail
-		if err := rows.Scan(&metric.MetricName, &metric.Description, &metric.Type, &metric.Unit, &metric.TimeSeries, &response.Total); err != nil {
+		if err := rows.Scan(&metric.MetricName, &metric.Description, &metric.MetricType, &metric.MetricUnit, &metric.TimeSeries, &response.Total); err != nil {
 			zap.L().Error("Error scanning metric row", zap.Error(err))
 			return &response, &model.ApiError{Typ: "ClickHouseError", Err: err}
 		}

--- a/pkg/query-service/model/metrics_explorer/summary.go
+++ b/pkg/query-service/model/metrics_explorer/summary.go
@@ -31,8 +31,8 @@ type TreeMapMetricsRequest struct {
 type MetricDetail struct {
 	MetricName   string `json:"metric_name"`
 	Description  string `json:"description"`
-	Type         string `json:"type"`
-	Unit         string `json:"unit"`
+	MetricType   string `json:"metric_type"`
+	MetricUnit   string `json:"metric_unit"`
 	TimeSeries   uint64 `json:"timeseries"`
 	Samples      uint64 `json:"samples"`
 	LastReceived int64  `json:"lastReceived"`

--- a/pkg/query-service/model/metrics_explorer/summary.go
+++ b/pkg/query-service/model/metrics_explorer/summary.go
@@ -31,8 +31,8 @@ type TreeMapMetricsRequest struct {
 type MetricDetail struct {
 	MetricName   string `json:"metric_name"`
 	Description  string `json:"description"`
-	MetricType   string `json:"metric_type"`
-	MetricUnit   string `json:"metric_unit"`
+	MetricType   string `json:"type"`
+	MetricUnit   string `json:"unit"`
 	TimeSeries   uint64 `json:"timeseries"`
 	Samples      uint64 `json:"samples"`
 	LastReceived int64  `json:"lastReceived"`


### PR DESCRIPTION
### Summary
Renamed metrics explorer json keys, from metric_type to type, and metric_unit to unit

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renamed JSON keys in metrics explorer from `type` to `metric_type` and `unit` to `metric_unit`.
> 
>   - **Renames**:
>     - In `reader.go`, rename JSON keys `type` to `metric_type` and `unit` to `metric_unit` in `ListSummaryMetrics()`.
>     - In `summary.go`, rename struct fields `Type` to `MetricType` and `Unit` to `MetricUnit` in `MetricDetail`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 9d44adfa34052a913d699eb06a7090e898e16256. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->