### PR TITLE
chore: ignore license error and render oss edition on failure

### DIFF
--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -45,7 +45,6 @@ function App(): JSX.Element {
 		activeLicenseV3,
 		isFetchingActiveLicenseV3,
 		userFetchError,
-		licensesFetchError,
 		featureFlagsFetchError,
 		isLoggedIn: isLoggedInState,
 		featureFlags,
@@ -270,19 +269,12 @@ function App(): JSX.Element {
 		// if the required calls fails then return a something went wrong error
 		// this needs to be on top of data missing error because if there is an error, data will never be loaded and it will
 		// move to indefinitive loading
-		if (
-			(userFetchError || licensesFetchError) &&
-			pathname !== ROUTES.SOMETHING_WENT_WRONG
-		) {
+		if (userFetchError && pathname !== ROUTES.SOMETHING_WENT_WRONG) {
 			history.replace(ROUTES.SOMETHING_WENT_WRONG);
 		}
 
 		// if all of the data is not set then return a spinner, this is required because there is some gap between loading states and data setting
-		if (
-			(!licenses || !user.email || !featureFlags) &&
-			!userFetchError &&
-			!licensesFetchError
-		) {
+		if ((!user.email || !featureFlags) && !userFetchError) {
 			return <Spinner tip="Loading..." />;
 		}
 	}

--- a/pkg/http/render/render.go
+++ b/pkg/http/render/render.go
@@ -56,6 +56,8 @@ func Error(rw http.ResponseWriter, cause error) {
 		httpCode = http.StatusConflict
 	case errors.TypeUnauthenticated:
 		httpCode = http.StatusUnauthorized
+	case errors.TypeUnsupported:
+		httpCode = http.StatusNotImplemented
 	}
 
 	rea := make([]responseerroradditional, len(a))

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -614,6 +614,13 @@ func (aH *APIHandler) RegisterRoutes(router *mux.Router, am *AuthMiddleware) {
 	router.HandleFunc("/api/v1/getResetPasswordToken/{id}", am.AdminAccess(aH.getResetPasswordToken)).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/resetPassword", am.OpenAccess(aH.resetPassword)).Methods(http.MethodPost)
 	router.HandleFunc("/api/v1/changePassword/{id}", am.SelfAccess(aH.changePassword)).Methods(http.MethodPost)
+
+	router.HandleFunc("/api/v3/licenses", am.ViewAccess(func(rw http.ResponseWriter, req *http.Request) {
+		render.Error(rw, errorsV2.New(errorsV2.TypeUnsupported, errorsV2.CodeUnsupported, "not implemented"))
+	})).Methods(http.MethodGet)
+	router.HandleFunc("/api/v3/licenses/active", am.ViewAccess(func(rw http.ResponseWriter, req *http.Request) {
+		render.Error(rw, errorsV2.New(errorsV2.TypeUnsupported, errorsV2.CodeUnsupported, "not implemented"))
+	})).Methods(http.MethodGet)
 }
 
 func (ah *APIHandler) MetricExplorerRoutes(router *mux.Router, am *AuthMiddleware) {
@@ -1900,7 +1907,7 @@ func (aH *APIHandler) getVersion(w http.ResponseWriter, r *http.Request) {
 	version := version.GetVersion()
 	versionResponse := model.GetVersionResponse{
 		Version:        version,
-		EE:             "Y",
+		EE:             "N",
 		SetupCompleted: aH.SetupCompleted,
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR updates error handling for licenses, adds new API routes for license endpoints, and modifies the version response to indicate OSS edition.
> 
>   - **Frontend**:
>     - Removed `licensesFetchError` handling in `App()` in `index.tsx`.
>     - Updated logic to render spinner and error page based on `userFetchError` and data availability.
>   - **Backend**:
>     - Added new error type `errors.TypeUnsupported` mapped to `http.StatusNotImplemented` in `render.go`.
>     - Added `/api/v3/licenses` and `/api/v3/licenses/active` routes in `http_handler.go` to return "not implemented" error.
>   - **Misc**:
>     - Changed `EE` field to "N" in `getVersion()` in `http_handler.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 04fb7738b485439e9af2d938de9003e6d8b2b804. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->