### PR TITLE
chore: fix query builder datasource issue in metrics explorer

### DIFF
--- a/frontend/src/container/MetricsExplorer/Summary/Summary.tsx
+++ b/frontend/src/container/MetricsExplorer/Summary/Summary.tsx
@@ -1,16 +1,17 @@
 import './Summary.styles.scss';
 
 import * as Sentry from '@sentry/react';
+import { initialQueriesMap } from 'constants/queryBuilder';
 import { usePageSize } from 'container/InfraMonitoringK8s/utils';
 import { useGetMetricsList } from 'hooks/metricsExplorer/useGetMetricsList';
 import { useGetMetricsTreeMap } from 'hooks/metricsExplorer/useGetMetricsTreeMap';
-import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useQueryOperations } from 'hooks/queryBuilder/useQueryBuilderOperations';
 import ErrorBoundaryFallback from 'pages/ErrorBoundaryFallback/ErrorBoundaryFallback';
 import { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { AppState } from 'store/reducers';
 import { TagFilter } from 'types/api/queryBuilder/queryBuilderData';
+import { DataSource } from 'types/common/queryBuilder';
 import { GlobalReducer } from 'types/reducer/globalTime';
 
 import MetricDetails from '../MetricDetails';
@@ -43,7 +44,7 @@ function Summary(): JSX.Element {
 		(state) => state.globalTime,
 	);
 
-	const { currentQuery } = useQueryBuilder();
+	const currentQuery = initialQueriesMap[DataSource.METRICS];
 	const queryFilters = useMemo(
 		() =>
 			currentQuery?.builder?.queryData[0]?.filters || {


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

We were not building the current query properly in Metrics Explorer due to which it was capturing the left-over query from other pages (such as Logs, Traces explorer) hence leading to incorrect behavior in QB search and QB.

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

Metrics Explorer

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes query builder issue in `Summary.tsx` by setting `currentQuery` to `initialQueriesMap[DataSource.METRICS]`, preventing leftover queries from affecting Metrics Explorer.
> 
>   - **Behavior**:
>     - Fixes query builder issue in `Summary.tsx` by setting `currentQuery` to `initialQueriesMap[DataSource.METRICS]`.
>     - Prevents leftover queries from other pages (e.g., Logs, Traces) from affecting Metrics Explorer.
>   - **Imports**:
>     - Adds import for `initialQueriesMap` from `constants/queryBuilder`.
>     - Adds import for `DataSource` from `types/common/queryBuilder`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for d14cb6f6c7b4326ed15cb8d00ef8132111538e69. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->