### PR TITLE
fix(apiserver): remove redundant logs by default

### DIFF
--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -82,6 +82,8 @@ apiserver:
     # List of routes to exclude from request responselogging.
     excluded_routes:
       - /api/v1/health
+      - /api/v1/version
+      - /
 
 
 ##################### TelemetryStore #####################

--- a/pkg/apiserver/config.go
+++ b/pkg/apiserver/config.go
@@ -43,6 +43,8 @@ func newConfig() factory.Config {
 		Logging: Logging{
 			ExcludedRoutes: []string{
 				"/api/v1/health",
+				"/api/v1/version",
+				"/",
 			},
 		},
 	}


### PR DESCRIPTION
### Summary

remove redundant logs by default
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Exclude `/api/v1/version` and `/` from logging in API server configuration to reduce redundant logs.
> 
>   - **Behavior**:
>     - Exclude `/api/v1/version` and `/` from logging in `example.yaml` and `config.go`.
>   - **Configuration**:
>     - Update `excluded_routes` in `apiserver` section of `example.yaml`.
>     - Update `ExcludedRoutes` in `Logging` struct in `config.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 7ca23b8b8ecd47fff2557dcca76299e3bb1ead29. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->