### PR TITLE
fix(portal): url limit reached for stripe customer portal

### DIFF
--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -325,7 +325,7 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 
 	const handleFailedPayment = useCallback((): void => {
 		manageCreditCard({
-			url: window.location.href,
+			url: window.location.origin,
 		});
 	}, [manageCreditCard]);
 


### PR DESCRIPTION
### Summary

- the upper limit for the url is being reached for stripe customer portal session
- use origin instead of href to ignore the query parameters 

