### PR TITLE
chore: correct isMonotonic field name in metric details

### DIFF
--- a/frontend/src/container/MetricsExplorer/MetricDetails/Metadata.tsx
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/Metadata.tsx
@@ -50,8 +50,8 @@ function Metadata({
 						...metadata,
 						temporality: metadata?.temporality,
 				  })
-						// Filter out isMonotonic as user input is not required
-						.filter((key) => key !== 'isMonotonic')
+						// Filter out monotonic as user input is not required
+						.filter((key) => key !== 'monotonic')
 						.map((key) => ({
 							key,
 							value: {
@@ -74,7 +74,9 @@ function Metadata({
 				className: 'metric-metadata-key',
 				render: (field: string): JSX.Element => (
 					<FieldRenderer
-						field={METRIC_METADATA_KEYS[field as keyof typeof METRIC_METADATA_KEYS]}
+						field={
+							METRIC_METADATA_KEYS[field as keyof typeof METRIC_METADATA_KEYS] || ''
+						}
 					/>
 				),
 			},


### PR DESCRIPTION
### Summary

Read isMonotonic from the correct API field

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects field name from `isMonotonic` to `monotonic` in `Metadata` component, updating filter and rendering logic.
> 
>   - **Behavior**:
>     - Corrects field name from `isMonotonic` to `monotonic` in `Metadata` component.
>     - Updates filter function to exclude `monotonic` from user input in `Metadata`.
>   - **Rendering**:
>     - Adds fallback empty string for `field` in `FieldRenderer` in `Metadata` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for bf5a51ab4268c6010b451e7d9a170d47bcae59eb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->