### PR TITLE
fix: fix the pat middleware

### DIFF
--- a/ee/http/middleware/pat.go
+++ b/ee/http/middleware/pat.go
@@ -29,47 +29,46 @@ func (p *Pat) Wrap(next http.Handler) http.Handler {
 
 		for _, header := range p.headers {
 			values = append(values, r.Header.Get(header))
-
-			if header == "SIGNOZ-API-KEY" {
-				patToken = values[0]
-				err := p.db.NewSelect().Model(&pat).Where("token = ?", patToken).Scan(r.Context())
-				if err != nil {
-					next.ServeHTTP(w, r)
-					return
-				}
-
-				if pat.ExpiresAt < time.Now().Unix() && pat.ExpiresAt != 0 {
-					next.ServeHTTP(w, r)
-					return
-				}
-
-				// get user from db
-				user := types.User{}
-				err = p.db.NewSelect().Model(&user).Where("id = ?", pat.UserID).Scan(r.Context())
-				if err != nil {
-					next.ServeHTTP(w, r)
-					return
-				}
-
-				jwt := authtypes.Claims{
-					UserID:  user.ID,
-					GroupID: user.GroupID,
-					Email:   user.Email,
-					OrgID:   user.OrgID,
-				}
-
-				ctx := authtypes.NewContextWithClaims(r.Context(), jwt)
-				r = r.WithContext(ctx)
-
-				// Mark to update last used since SIGNOZ-API-KEY is present and successful
-				updateLastUsed = true
-			}
 		}
+
 		ctx, err := p.uuid.ContextFromRequest(r.Context(), values...)
 		if err != nil {
 			next.ServeHTTP(w, r)
 			return
 		}
+		patToken, ok := authtypes.UUIDFromContext(ctx)
+		if !ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		err = p.db.NewSelect().Model(&pat).Where("token = ?", patToken).Scan(r.Context())
+		if err != nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if pat.ExpiresAt < time.Now().Unix() && pat.ExpiresAt != 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// get user from db
+		user := types.User{}
+		err = p.db.NewSelect().Model(&user).Where("id = ?", pat.UserID).Scan(r.Context())
+		if err != nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		jwt := authtypes.Claims{
+			UserID:  user.ID,
+			GroupID: user.GroupID,
+			Email:   user.Email,
+			OrgID:   user.OrgID,
+		}
+
+		ctx = authtypes.NewContextWithClaims(ctx, jwt)
 
 		r = r.WithContext(ctx)
 


### PR DESCRIPTION
This makes sure that we use the functions from authtypes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `Wrap` in `pat.go` to use `authtypes` functions for token extraction and context handling, removing redundant code.
> 
>   - **Behavior**:
>     - Refactor `Wrap` in `pat.go` to use `authtypes.UUIDFromContext` for token extraction and `authtypes.NewContextWithClaims` for context creation.
>     - Removes redundant code for handling `SIGNOZ-API-KEY` header and token validation.
>   - **Error Handling**:
>     - Ensures early return on errors during token extraction and user retrieval.
>   - **Misc**:
>     - Removes unnecessary loop logic for headers in `Wrap`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e9de1ec251c9f1b22b0c70e98462efef2be23018. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->