### PR TITLE
ci: append amd64 suffix for staging/testing deployment versions

### DIFF
--- a/.github/workflows/staging-deployment.yaml
+++ b/.github/workflows/staging-deployment.yaml
@@ -50,7 +50,7 @@ jobs:
           git checkout ${GITHUB_BRANCH}
           git pull
           make docker-build-enterprise-amd64
-          export VERSION="${VERSION}-amd64"
+          export VERSION="${GITHUB_SHA:0:7}-amd64"
           docker-compose -f deploy/docker/docker-compose.testing.yaml up --build -d
           EOF
           gcloud beta compute ssh ${GCP_INSTANCE} --zone ${GCP_ZONE} --ssh-key-expire-after=15m --tunnel-through-iap --project ${GCP_PROJECT} --command "${COMMAND}"

--- a/.github/workflows/staging-deployment.yaml
+++ b/.github/workflows/staging-deployment.yaml
@@ -50,6 +50,7 @@ jobs:
           git checkout ${GITHUB_BRANCH}
           git pull
           make docker-build-enterprise-amd64
+          export VERSION="${VERSION}-amd64"
           docker-compose -f deploy/docker/docker-compose.testing.yaml up --build -d
           EOF
           gcloud beta compute ssh ${GCP_INSTANCE} --zone ${GCP_ZONE} --ssh-key-expire-after=15m --tunnel-through-iap --project ${GCP_PROJECT} --command "${COMMAND}"

--- a/.github/workflows/testing-deployment.yaml
+++ b/.github/workflows/testing-deployment.yaml
@@ -50,6 +50,7 @@ jobs:
           git branch -D ${GITHUB_BRANCH}
           git checkout --track origin/${GITHUB_BRANCH}
           make docker-build-enterprise-amd64
+          export VERSION="${VERSION}-amd64"
           docker-compose -f deploy/docker/docker-compose.testing.yaml up --build -d
           EOF
           gcloud beta compute ssh ${GCP_INSTANCE} --zone ${GCP_ZONE} --ssh-key-expire-after=15m --tunnel-through-iap --project ${GCP_PROJECT} --command "${COMMAND}"

--- a/.github/workflows/testing-deployment.yaml
+++ b/.github/workflows/testing-deployment.yaml
@@ -50,7 +50,7 @@ jobs:
           git branch -D ${GITHUB_BRANCH}
           git checkout --track origin/${GITHUB_BRANCH}
           make docker-build-enterprise-amd64
-          export VERSION="${VERSION}-amd64"
+          export VERSION="${GITHUB_SHA:0:7}-amd64"
           docker-compose -f deploy/docker/docker-compose.testing.yaml up --build -d
           EOF
           gcloud beta compute ssh ${GCP_INSTANCE} --zone ${GCP_ZONE} --ssh-key-expire-after=15m --tunnel-through-iap --project ${GCP_PROJECT} --command "${COMMAND}"


### PR DESCRIPTION
### Summary

- update CI workflows to append amd64 suffix for staging/testing deployment versions

#### Related Issues / PR's

NA

#### Screenshots

NA

#### Affected Areas and Manually Tested Areas

NA
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Append `-amd64` suffix to version strings in CI workflows for staging and testing deployments.
> 
>   - **CI Workflows**:
>     - Append `-amd64` suffix to `VERSION` in `staging-deployment.yaml` and `testing-deployment.yaml`.
>     - Ensures version strings reflect architecture for staging and testing deployments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for d9a82e2f7e4324d2c5dc4b0236a5cbb02c648fc4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->