### PR TITLE
fix(logger): remove color encoding with json logs

### DIFF
--- a/ee/query-service/main.go
+++ b/ee/query-service/main.go
@@ -24,7 +24,6 @@ import (
 
 func initZapLog() *zap.Logger {
 	config := zap.NewProductionConfig()
-	config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 	config.EncoderConfig.TimeKey = "timestamp"
 	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	logger, _ := config.Build()

--- a/pkg/query-service/main.go
+++ b/pkg/query-service/main.go
@@ -23,7 +23,6 @@ import (
 
 func initZapLog() *zap.Logger {
 	config := zap.NewProductionConfig()
-	config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 	config.EncoderConfig.TimeKey = "timestamp"
 	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	logger, _ := config.Build()


### PR DESCRIPTION
### Summary

remove color encoding with json logs. Fixes the irritating: 
```
{"level":"\u001b[34mINFO\u001b[0m","timestamp":"2025-03-24T13:03:58.889Z",
```

in both enterprise and community