### PR TITLE
fix: telemetry version function call

### DIFF
--- a/pkg/query-service/telemetry/telemetry.go
+++ b/pkg/query-service/telemetry/telemetry.go
@@ -740,7 +740,7 @@ func (a *Telemetry) SendEvent(event string, data map[string]interface{}, userEma
 
 	// zap.L().Info(data)
 	properties := analytics.NewProperties()
-	properties.Set("version", version.Info.Version)
+	properties.Set("version", version.Info.Version())
 	properties.Set("deploymentType", getDeploymentType())
 	properties.Set("companyDomain", a.getCompanyDomain())
 


### PR DESCRIPTION
### Summary

Fix telemetry version function call 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes version retrieval in `SendEvent()` in `telemetry.go` by using `version.Info.Version()` instead of `version.Info.Version`.
> 
>   - **Behavior**:
>     - Fixes version retrieval in `SendEvent()` in `telemetry.go` by changing `version.Info.Version` to `version.Info.Version()`.
>   - **Misc**:
>     - No other changes or additions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 74f009324a1f8069b817f7bcc503f943fe5d5177. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->