### PR TITLE
chore: add third party feature flag

### DIFF
--- a/ee/query-service/model/plans.go
+++ b/ee/query-service/model/plans.go
@@ -157,6 +157,13 @@ var BasicPlan = basemodel.FeatureSet{
 		UsageLimit: -1,
 		Route:      "",
 	},
+	basemodel.Feature{
+		Name:       basemodel.ThirdPartyApi,
+		Active:     false,
+		Usage:      0,
+		UsageLimit: -1,
+		Route:      "",
+	},
 }
 
 var ProPlan = basemodel.FeatureSet{
@@ -275,6 +282,13 @@ var ProPlan = basemodel.FeatureSet{
 	basemodel.Feature{
 		Name:       basemodel.HostsInfraMonitoring,
 		Active:     constants.EnableHostsInfraMonitoring(),
+		Usage:      0,
+		UsageLimit: -1,
+		Route:      "",
+	},
+	basemodel.Feature{
+		Name:       basemodel.ThirdPartyApi,
+		Active:     false,
 		Usage:      0,
 		UsageLimit: -1,
 		Route:      "",
@@ -411,6 +425,13 @@ var EnterprisePlan = basemodel.FeatureSet{
 	basemodel.Feature{
 		Name:       basemodel.HostsInfraMonitoring,
 		Active:     constants.EnableHostsInfraMonitoring(),
+		Usage:      0,
+		UsageLimit: -1,
+		Route:      "",
+	},
+	basemodel.Feature{
+		Name:       basemodel.ThirdPartyApi,
+		Active:     false,
 		Usage:      0,
 		UsageLimit: -1,
 		Route:      "",

--- a/pkg/query-service/model/featureSet.go
+++ b/pkg/query-service/model/featureSet.go
@@ -24,6 +24,7 @@ const AlertChannelOpsgenie = "ALERT_CHANNEL_OPSGENIE"
 const AlertChannelEmail = "ALERT_CHANNEL_EMAIL"
 const AnomalyDetection = "ANOMALY_DETECTION"
 const HostsInfraMonitoring = "HOSTS_INFRA_MONITORING"
+const ThirdPartyApi = "THIRD_PARTY_API"
 
 var BasicPlan = FeatureSet{
 	Feature{
@@ -119,6 +120,13 @@ var BasicPlan = FeatureSet{
 	},
 	Feature{
 		Name:       AnomalyDetection,
+		Active:     false,
+		Usage:      0,
+		UsageLimit: -1,
+		Route:      "",
+	},
+	Feature{
+		Name:       ThirdPartyApi,
 		Active:     false,
 		Usage:      0,
 		UsageLimit: -1,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `ThirdPartyApi` feature flag to various plans, initially inactive, in `plans.go` and `featureSet.go`.
> 
>   - **Feature Addition**:
>     - Add `ThirdPartyApi` feature to `BasicPlan`, `ProPlan`, and `EnterprisePlan` in `plans.go`.
>     - Add `ThirdPartyApi` feature to `BasicPlan` in `featureSet.go`.
>   - **Constants**:
>     - Define `ThirdPartyApi` constant in `featureSet.go`.
>   - **Behavior**:
>     - `ThirdPartyApi` is initially inactive (`Active: false`) across all plans.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 735076096bfa832e08e3cf9e3aa61c3717bb06b4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->