### PR TITLE
fix(nil-pointer): wrong error passed | 2262

### DIFF
--- a/conf/prometheus.yml
+++ b/conf/prometheus.yml
@@ -22,4 +22,4 @@ rule_files:
 scrape_configs: []
 
 remote_read:
-  - url: tcp://localhost:9000/signoz_metrics
+  - url: tcp://localhost:9001/signoz_metrics

--- a/frontend/src/constants/env.ts
+++ b/frontend/src/constants/env.ts
@@ -1,7 +1,3 @@
 export const ENVIRONMENT = {
-	baseURL:
-		process?.env?.FRONTEND_API_ENDPOINT ||
-		process?.env?.GITPOD_WORKSPACE_URL?.replace('://', '://8080-') ||
-		'',
-	wsURL: process?.env?.WEBSOCKET_API_ENDPOINT || '',
+	baseURL: 'http://localhost:8080',
 };

--- a/pkg/query-service/app/summary.go
+++ b/pkg/query-service/app/summary.go
@@ -67,17 +67,17 @@ func (aH *APIHandler) ListMetrics(w http.ResponseWriter, r *http.Request) {
 	bodyBytes, _ := io.ReadAll(r.Body)
 	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	ctx := r.Context()
-	params, apiError := explorer.ParseSummaryListMetricsParams(r)
-	if apiError != nil {
-		zap.L().Error("error parsing metric list metric summary api request", zap.Error(apiError.Err))
-		RespondError(w, model.BadRequest(apiError), nil)
+	params, apiErr := explorer.ParseSummaryListMetricsParams(r)
+	if apiErr != nil {
+		zap.L().Error("error parsing metric list metric summary api request", zap.Error(apiErr.Err))
+		RespondError(w, model.BadRequest(apiErr), nil)
 		return
 	}
 
 	slmr, apiErr := aH.SummaryService.ListMetricsWithSummary(ctx, params)
 	if apiErr != nil {
-		zap.L().Error("error parsing metric query range params", zap.Error(apiErr.Err))
-		RespondError(w, apiError, nil)
+		zap.L().Error("error in getting list metrics summary", zap.Error(apiErr.Err))
+		RespondError(w, apiErr, nil)
 		return
 	}
 	aH.Respond(w, slmr)


### PR DESCRIPTION
### Summary

Wrong error was passed to the handler function so when RespondError calls err.type() it causes the nil pointer dereference.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes error handling in `ListMetrics` in `summary.go` and updates configuration in `prometheus.yml` and `env.ts`.
> 
>   - **Error Handling**:
>     - Fixes error handling in `ListMetrics` in `summary.go` by using `apiErr` instead of `apiError` to prevent nil pointer dereference.
>   - **Configuration Changes**:
>     - Updates `remote_read` URL in `prometheus.yml` from port 9000 to 9001.
>     - Sets `baseURL` in `env.ts` to `http://localhost:8080` and removes environment variable fallbacks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 648ba8bce20652912c9e880dd751a05950d54f2a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->