### PR TITLE
fix: collector connection to opamp without orgID

### DIFF
--- a/pkg/query-service/app/logparsingpipeline/controller.go
+++ b/pkg/query-service/app/logparsingpipeline/controller.go
@@ -145,10 +145,11 @@ func (ic *LogParsingPipelineController) getEffectivePipelinesByVersion(
 	// todo(nitya): remove this once we fix agents in multitenancy
 	defaultOrgID, err := ic.GetDefaultOrgID(ctx)
 	if err != nil {
-		return nil, model.WrapApiError(err, "failed to get default org ID")
+		// we don't want to fail the request if we can't get the default org ID
+		// we will just return an empty list of pipelines
+		zap.L().Warn("failed to get default org ID", zap.Error(err))
+		return result, nil
 	}
-
-	fmt.Println("defaultOrgID", defaultOrgID)
 
 	if version >= 0 {
 		savedPipelines, errors := ic.getPipelinesByVersion(ctx, defaultOrgID, version)


### PR DESCRIPTION
Fixes https://github.com/SigNoz/platform-pod/issues/464#issuecomment-2758375439

When there is no orgID, it just returnss empty pipelines, instead of crashing.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes handling of missing `orgID` in `getEffectivePipelinesByVersion` by returning an empty pipeline list instead of crashing.
> 
>   - **Behavior**:
>     - In `getEffectivePipelinesByVersion` in `controller.go`, if `GetDefaultOrgID` fails, return an empty list of pipelines instead of crashing.
>     - Logs a warning with `zap.L().Warn` when `GetDefaultOrgID` fails.
>   - **Misc**:
>     - Removes unused `fmt.Println` statement for `defaultOrgID`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 4c9c7da7e158fa69dbb726590eb972c67849a635. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->