### PR TITLE
chore: remove new banner from infra monitoring tab in side nav

### DIFF
--- a/frontend/src/container/SideNav/menuItems.tsx
+++ b/frontend/src/container/SideNav/menuItems.tsx
@@ -112,7 +112,6 @@ const menuItems: SidebarItem[] = [
 		key: ROUTES.INFRASTRUCTURE_MONITORING_HOSTS,
 		label: 'Infra Monitoring',
 		icon: <Boxes size={16} />,
-		isNew: true,
 	},
 	{
 		key: ROUTES.ALL_DASHBOARD,


### PR DESCRIPTION
### Summary

Remove the new banner from infra monitoring tab in side nav

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

<img width="300" alt="Screenshot 2025-03-30 at 4 15 59 PM" src="https://github.com/user-attachments/assets/1783eaee-057d-4ee2-80bd-c10700aee5c0" />

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

Side Navigation
