### PR TITLE
chore: use new uuid in pipelines

### DIFF
--- a/pkg/query-service/app/integrations/manager.go
+++ b/pkg/query-service/app/integrations/manager.go
@@ -12,7 +12,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/query-service/utils"
 	"github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/types/pipelinetypes"
-	"github.com/google/uuid"
+	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -271,8 +271,10 @@ func (m *Manager) GetPipelinesForInstalledIntegrations(
 				// since versioning while saving pipelines requires a new id for each version
 				// to avoid altering history when pipelines are edited/reordered etc
 				StoreablePipeline: pipelinetypes.StoreablePipeline{
-					Alias:       AliasForIntegrationPipeline(ii.Id, p.Alias),
-					ID:          uuid.NewString(),
+					Alias: AliasForIntegrationPipeline(ii.Id, p.Alias),
+					Identifiable: types.Identifiable{
+						ID: valuer.GenerateUUID(),
+					},
 					OrderID:     p.OrderID,
 					Enabled:     p.Enabled,
 					Name:        p.Name,

--- a/pkg/query-service/app/logparsingpipeline/controller.go
+++ b/pkg/query-service/app/logparsingpipeline/controller.go
@@ -12,8 +12,10 @@ import (
 	"github.com/SigNoz/signoz/pkg/query-service/model"
 	"github.com/SigNoz/signoz/pkg/query-service/utils"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
 	"github.com/SigNoz/signoz/pkg/types/pipelinetypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -82,7 +84,7 @@ func (ic *LogParsingPipelineController) ApplyPipelines(
 	// prepare config elements
 	elements := make([]string, len(pipelines))
 	for i, p := range pipelines {
-		elements[i] = p.ID
+		elements[i] = p.ID.StringValue()
 	}
 
 	// prepare config by calling gen func
@@ -110,7 +112,9 @@ func (ic *LogParsingPipelineController) ValidatePipelines(
 	for _, pp := range postedPipelines {
 		gettablePipelines = append(gettablePipelines, pipelinetypes.GettablePipeline{
 			StoreablePipeline: pipelinetypes.StoreablePipeline{
-				ID:          uuid.New().String(),
+				Identifiable: types.Identifiable{
+					ID: valuer.GenerateUUID(),
+				},
 				OrderID:     pp.OrderID,
 				Enabled:     pp.Enabled,
 				Name:        pp.Name,

--- a/pkg/query-service/app/logparsingpipeline/db.go
+++ b/pkg/query-service/app/logparsingpipeline/db.go
@@ -11,7 +11,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
 	"github.com/SigNoz/signoz/pkg/types/pipelinetypes"
-	"github.com/google/uuid"
+	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -60,8 +60,10 @@ func (r *Repo) insertPipeline(
 
 	insertRow := &pipelinetypes.GettablePipeline{
 		StoreablePipeline: pipelinetypes.StoreablePipeline{
-			OrgID:        orgID,
-			ID:           uuid.New().String(),
+			OrgID: orgID,
+			Identifiable: types.Identifiable{
+				ID: valuer.GenerateUUID(),
+			},
 			OrderID:      postable.OrderID,
 			Enabled:      postable.Enabled,
 			Name:         postable.Name,

--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder_test.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/SigNoz/signoz/pkg/query-service/model"
 	v3 "github.com/SigNoz/signoz/pkg/query-service/model/v3"
 	"github.com/SigNoz/signoz/pkg/query-service/utils"
+	"github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/types/pipelinetypes"
-	"github.com/google/uuid"
+	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/require"
@@ -228,7 +229,9 @@ func TestNoCollectorErrorsFromProcessorsForMismatchedLogs(t *testing.T) {
 	makeTestPipeline := func(config []pipelinetypes.PipelineOperator) pipelinetypes.GettablePipeline {
 		return pipelinetypes.GettablePipeline{
 			StoreablePipeline: pipelinetypes.StoreablePipeline{
-				ID:      uuid.New().String(),
+				Identifiable: types.Identifiable{
+					ID: valuer.GenerateUUID(),
+				},
 				OrderID: 1,
 				Name:    "pipeline1",
 				Alias:   "pipeline1",
@@ -457,7 +460,9 @@ func TestResourceFiltersWork(t *testing.T) {
 
 	testPipeline := pipelinetypes.GettablePipeline{
 		StoreablePipeline: pipelinetypes.StoreablePipeline{
-			ID:      uuid.New().String(),
+			Identifiable: types.Identifiable{
+				ID: valuer.GenerateUUID(),
+			},
 			OrderID: 1,
 			Name:    "pipeline1",
 			Alias:   "pipeline1",
@@ -525,7 +530,9 @@ func TestPipelineFilterWithStringOpsShouldNotSpamWarningsIfAttributeIsMissing(t 
 	} {
 		testPipeline := pipelinetypes.GettablePipeline{
 			StoreablePipeline: pipelinetypes.StoreablePipeline{
-				ID:      uuid.New().String(),
+				Identifiable: types.Identifiable{
+					ID: valuer.GenerateUUID(),
+				},
 				OrderID: 1,
 				Name:    "pipeline1",
 				Alias:   "pipeline1",
@@ -584,7 +591,9 @@ func TestAttributePathsContainingDollarDoNotBreakCollector(t *testing.T) {
 
 	testPipeline := pipelinetypes.GettablePipeline{
 		StoreablePipeline: pipelinetypes.StoreablePipeline{
-			ID:      uuid.New().String(),
+			Identifiable: types.Identifiable{
+				ID: valuer.GenerateUUID(),
+			},
 			OrderID: 1,
 			Name:    "pipeline1",
 			Alias:   "pipeline1",
@@ -645,7 +654,9 @@ func TestMembershipOpInProcessorFieldExpressions(t *testing.T) {
 
 	testPipeline := pipelinetypes.GettablePipeline{
 		StoreablePipeline: pipelinetypes.StoreablePipeline{
-			ID:      uuid.New().String(),
+			Identifiable: types.Identifiable{
+				ID: valuer.GenerateUUID(),
+			},
 			OrderID: 1,
 			Name:    "pipeline1",
 			Alias:   "pipeline1",
@@ -752,7 +763,9 @@ func TestContainsFilterIsCaseInsensitive(t *testing.T) {
 
 	testPipelines := []pipelinetypes.GettablePipeline{{
 		StoreablePipeline: pipelinetypes.StoreablePipeline{
-			ID:      uuid.New().String(),
+			Identifiable: types.Identifiable{
+				ID: valuer.GenerateUUID(),
+			},
 			OrderID: 1,
 			Name:    "pipeline1",
 			Alias:   "pipeline1",
@@ -783,7 +796,9 @@ func TestContainsFilterIsCaseInsensitive(t *testing.T) {
 		},
 	}, {
 		StoreablePipeline: pipelinetypes.StoreablePipeline{
-			ID:      uuid.New().String(),
+			Identifiable: types.Identifiable{
+				ID: valuer.GenerateUUID(),
+			},
 			OrderID: 2,
 			Name:    "pipeline2",
 			Alias:   "pipeline2",

--- a/pkg/query-service/tests/integration/signoz_integrations_test.go
+++ b/pkg/query-service/tests/integration/signoz_integrations_test.go
@@ -601,7 +601,7 @@ func postableFromPipelines(gettablePipelines []pipelinetypes.GettablePipeline) p
 
 	for _, p := range gettablePipelines {
 		postable := pipelinetypes.PostablePipeline{
-			ID:      p.ID,
+			ID:      p.ID.StringValue(),
 			OrderID: p.OrderID,
 			Name:    p.Name,
 			Alias:   p.Alias,

--- a/pkg/types/pipelinetypes/pipeline.go
+++ b/pkg/types/pipelinetypes/pipeline.go
@@ -19,8 +19,8 @@ type StoreablePipeline struct {
 
 	types.UserAuditable
 	types.TimeAuditable
+	types.Identifiable
 	OrgID        string `json:"-" bun:"org_id,notnull"`
-	ID           string `json:"id" bun:"id,pk,type:text"`
 	OrderID      int    `json:"orderId" bun:"order_id"`
 	Enabled      bool   `json:"enabled" bun:"enabled"`
 	Name         string `json:"name" bun:"name,type:varchar(400),notnull"`


### PR DESCRIPTION
Use new Identifiable for pipelines.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update pipeline ID generation to use `valuer.GenerateUUID()` and `Identifiable` struct for consistency across the codebase.
> 
>   - **Behavior**:
>     - Replace `uuid.NewString()` with `valuer.GenerateUUID()` for pipeline ID generation in `manager.go`, `controller.go`, and `db.go`.
>     - Use `Identifiable` struct for ID encapsulation in `StoreablePipeline`.
>   - **Tests**:
>     - Update test cases in `pipelineBuilder_test.go` to use `valuer.GenerateUUID()` for ID generation.
>     - Modify `signoz_integrations_test.go` to reflect new ID handling.
>   - **Misc**:
>     - Remove direct `ID` field usage in favor of `Identifiable` struct in `pipeline.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 1ceb393e4351239d41d5f184be28d173cd6313f1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->