### PR TITLE
fix: don't panic in GetClickhouseColumnName

### DIFF
--- a/pkg/query-service/utils/format.go
+++ b/pkg/query-service/utils/format.go
@@ -303,7 +303,7 @@ func GetClickhouseColumnName(typeName string, dataType, field string) string {
 		typeName = constants.Attributes
 	}
 
-	if typeName != string(v3.AttributeKeyTypeResource) {
+	if typeName != string(v3.AttributeKeyTypeResource) && len(typeName) > 0 {
 		typeName = typeName[:len(typeName)-1]
 	}
 
@@ -319,7 +319,7 @@ func GetClickhouseColumnNameV2(typeName string, dataType, field string) string {
 		typeName = constants.Attributes
 	}
 
-	if typeName != string(v3.AttributeKeyTypeResource) {
+	if typeName != string(v3.AttributeKeyTypeResource) && len(typeName) > 0 {
 		typeName = typeName[:len(typeName)-1]
 	}
 


### PR DESCRIPTION
don't panic in GetClickhouseColumnName, a wrong result in UI is still fine.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent panic in `GetClickhouseColumnName` and `GetClickhouseColumnNameV2` by checking `typeName` length before slicing.
> 
>   - **Behavior**:
>     - Prevents panic in `GetClickhouseColumnName` and `GetClickhouseColumnNameV2` by checking `len(typeName) > 0` before slicing.
>     - Ensures stability when `typeName` is empty, avoiding runtime errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 071477bf1ffa189e8a7d9d06a91e9d5ae51c8963. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->