### PR TITLE
feat: added span filtering to queryBuildersearchv2

### DIFF
--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
@@ -358,7 +358,6 @@ function QueryBuilderSearch({
 		</Select.Option>
 	));
 
-	console.log('isTracesExplorerPage', isTracesExplorerPage);
 	return (
 		<div className="query-builder-search-container">
 			<Select

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
@@ -358,6 +358,7 @@ function QueryBuilderSearch({
 		</Select.Option>
 	));
 
+	console.log('isTracesExplorerPage', isTracesExplorerPage);
 	return (
 		<div className="query-builder-search-container">
 			<Select

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
@@ -10,6 +10,7 @@ import {
 	QUERY_BUILDER_SEARCH_VALUES,
 } from 'constants/queryBuilder';
 import { DEBOUNCE_DELAY } from 'constants/queryBuilderFilterConfig';
+import ROUTES from 'constants/routes';
 import { LogsExplorerShortcuts } from 'constants/shortcuts/logsExplorerShortcuts';
 import { useKeyboardHotkeys } from 'hooks/hotkeys/useKeyboardHotkeys';
 import { WhereClauseConfig } from 'hooks/queryBuilder/useAutoComplete';
@@ -40,6 +41,7 @@ import {
 	useRef,
 	useState,
 } from 'react';
+import { useLocation } from 'react-router-dom';
 import {
 	BaseAutocompleteData,
 	DataTypes,
@@ -54,6 +56,7 @@ import { v4 as uuid } from 'uuid';
 
 import { selectStyle } from '../QueryBuilderSearch/config';
 import { PLACEHOLDER } from '../QueryBuilderSearch/constant';
+import SpanScopeSelector from '../QueryBuilderSearch/SpanScopeSelector';
 import { TypographyText } from '../QueryBuilderSearch/style';
 import {
 	checkCommaInValue,
@@ -122,6 +125,8 @@ function QueryBuilderSearchV2(
 		whereClauseConfig,
 		hardcodedAttributeKeys,
 	} = props;
+
+	const { pathname } = useLocation();
 
 	const { registerShortcut, deregisterShortcut } = useKeyboardHotkeys();
 
@@ -924,6 +929,11 @@ function QueryBuilderSearchV2(
 		);
 	};
 
+	const isTracesExplorerPage = useMemo(
+		() => pathname === ROUTES.TRACES_EXPLORER,
+		[pathname],
+	);
+
 	return (
 		<div className="query-builder-search-v2">
 			<Select
@@ -1008,6 +1018,7 @@ function QueryBuilderSearchV2(
 					);
 				})}
 			</Select>
+			{isTracesExplorerPage && <SpanScopeSelector queryName={query.queryName} />}
 		</div>
 	);
 }


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a2f11747-b2aa-4aae-8bd4-1832b9bd1349" />


#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds span filtering to `QueryBuilderSearchV2` for Traces Explorer page by rendering `SpanScopeSelector`.
> 
>   - **Behavior**:
>     - Adds span filtering to `QueryBuilderSearchV2` by rendering `SpanScopeSelector` when on Traces Explorer page.
>     - Uses `useLocation` to determine if the current path is `ROUTES.TRACES_EXPLORER`.
>   - **Imports**:
>     - Adds `useLocation` from `react-router-dom`.
>     - Imports `SpanScopeSelector` from `QueryBuilderSearch/SpanScopeSelector`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 1ad8043936467cab3973f97c6ba88e95b364bc07. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->