### PR TITLE
fix: disable sidenav items for cloud users whose license has expired

### DIFF
--- a/frontend/src/providers/App/App.tsx
+++ b/frontend/src/providers/App/App.tsx
@@ -21,6 +21,7 @@ import { useQuery } from 'react-query';
 import { FeatureFlagProps as FeatureFlags } from 'types/api/features/getFeaturesFlags';
 import { PayloadProps as LicensesResModel } from 'types/api/licenses/getAll';
 import {
+	LicensePlatform,
 	LicenseState,
 	LicenseV3ResModel,
 	TrialInfo,
@@ -145,7 +146,8 @@ export function AppProvider({ children }: PropsWithChildren): JSX.Element {
 				).unix(),
 				onTrial: isOnTrial,
 				workSpaceBlock:
-					activeLicenseV3Data.payload.state === LicenseState.EVALUATION_EXPIRED,
+					activeLicenseV3Data.payload.state === LicenseState.EVALUATION_EXPIRED &&
+					activeLicenseV3Data.payload.platform === LicensePlatform.CLOUD,
 				trialConvertedToSubscription:
 					activeLicenseV3Data.payload.state !== LicenseState.ISSUED &&
 					activeLicenseV3Data.payload.state !== LicenseState.EVALUATING &&


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disable side navigation items for cloud users with expired licenses in `App.tsx`.
> 
>   - **Behavior**:
>     - In `App.tsx`, disables side navigation items for cloud users with expired licenses by checking `LicenseState.EVALUATION_EXPIRED` and `LicensePlatform.CLOUD`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for a33260493b8616b15df1f0b4c35dddc0c55f27d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->