### PR TITLE
feat: added copy span link support alongside span click expand in waterfall graph

### DIFF
--- a/frontend/src/container/TraceWaterfall/SpanLineActionButtons/SpanLineActionButtons.styles.scss
+++ b/frontend/src/container/TraceWaterfall/SpanLineActionButtons/SpanLineActionButtons.styles.scss
@@ -32,9 +32,6 @@
 		border: 1px solid var(--bg-vanilla-400);
 		background: var(--bg-vanilla-400);
 
-		.ant-btn-default {
-		}
-
 		.copy-span-btn {
 			border-color: var(--bg-vanilla-400) !important;
 		}

--- a/frontend/src/container/TraceWaterfall/SpanLineActionButtons/SpanLineActionButtons.styles.scss
+++ b/frontend/src/container/TraceWaterfall/SpanLineActionButtons/SpanLineActionButtons.styles.scss
@@ -1,0 +1,42 @@
+.span-line-action-buttons {
+	display: flex;
+	position: absolute;
+	transform: translate(-50%, -50%);
+	top: 50%;
+	right: 0;
+	cursor: pointer;
+	border-radius: 2px;
+	border: 1px solid var(--bg-slate-400);
+	background: var(--bg-ink-400);
+
+	.ant-btn-default {
+		border: none;
+		box-shadow: none;
+		padding: 9px;
+		justify-content: center;
+		align-items: center;
+		display: flex;
+
+		&.active-tab {
+			background-color: var(--bg-slate-400);
+		}
+	}
+
+	.copy-span-btn {
+		border-color: var(--bg-slate-400) !important;
+	}
+}
+
+.lightMode {
+	.span-line-action-buttons {
+		border: 1px solid var(--bg-vanilla-400);
+		background: var(--bg-vanilla-400);
+
+		.ant-btn-default {
+		}
+
+		.copy-span-btn {
+			border-color: var(--bg-vanilla-400) !important;
+		}
+	}
+}

--- a/frontend/src/container/TraceWaterfall/SpanLineActionButtons/__tests__/SpanLineActionButtons.test.tsx
+++ b/frontend/src/container/TraceWaterfall/SpanLineActionButtons/__tests__/SpanLineActionButtons.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { useCopySpanLink } from 'hooks/trace/useCopySpanLink';
+import { render } from 'tests/test-utils';
+import { Span } from 'types/api/trace/getTraceV2';
+
+import SpanLineActionButtons from '../index';
+
+// Mock the useCopySpanLink hook
+jest.mock('hooks/trace/useCopySpanLink');
+
+const mockSpan: Span = {
+	spanId: 'test-span-id',
+	name: 'test-span',
+	serviceName: 'test-service',
+	durationNano: 1000,
+	timestamp: 1234567890,
+	rootSpanId: 'test-root-span-id',
+	parentSpanId: 'test-parent-span-id',
+	traceId: 'test-trace-id',
+	hasError: false,
+	kind: 0,
+	references: [],
+	tagMap: {},
+	event: [],
+	rootName: 'test-root-name',
+	statusMessage: 'test-status-message',
+	statusCodeString: 'test-status-code-string',
+	spanKind: 'test-span-kind',
+	hasChildren: false,
+	hasSibling: false,
+	subTreeNodeCount: 0,
+	level: 0,
+};
+
+describe('SpanLineActionButtons', () => {
+	beforeEach(() => {
+		// Clear mock before each test
+		jest.clearAllMocks();
+	});
+
+	it('renders copy link button with correct icon', () => {
+		(useCopySpanLink as jest.Mock).mockReturnValue({
+			onSpanCopy: jest.fn(),
+		});
+
+		render(<SpanLineActionButtons span={mockSpan} />);
+
+		// Check if the button is rendered
+		const copyButton = screen.getByRole('button');
+		expect(copyButton).toBeInTheDocument();
+
+		// Check if the link icon is rendered
+		const linkIcon = screen.getByRole('img', { hidden: true });
+		expect(linkIcon).toHaveClass('anticon anticon-link');
+	});
+
+	it('calls onSpanCopy when copy button is clicked', () => {
+		const mockOnSpanCopy = jest.fn();
+		(useCopySpanLink as jest.Mock).mockReturnValue({
+			onSpanCopy: mockOnSpanCopy,
+		});
+
+		render(<SpanLineActionButtons span={mockSpan} />);
+
+		// Click the copy button
+		const copyButton = screen.getByRole('button');
+		fireEvent.click(copyButton);
+
+		// Verify the copy function was called
+		expect(mockOnSpanCopy).toHaveBeenCalledTimes(1);
+	});
+
+	it('applies correct styling classes', () => {
+		(useCopySpanLink as jest.Mock).mockReturnValue({
+			onSpanCopy: jest.fn(),
+		});
+
+		render(<SpanLineActionButtons span={mockSpan} />);
+
+		// Check if the main container has the correct class
+		const container = screen
+			.getByRole('button')
+			.closest('.span-line-action-buttons');
+		expect(container).toHaveClass('span-line-action-buttons');
+
+		// Check if the button has the correct class
+		const copyButton = screen.getByRole('button');
+		expect(copyButton).toHaveClass('copy-span-btn');
+	});
+});

--- a/frontend/src/container/TraceWaterfall/SpanLineActionButtons/index.tsx
+++ b/frontend/src/container/TraceWaterfall/SpanLineActionButtons/index.tsx
@@ -7,16 +7,14 @@ import { Span } from 'types/api/trace/getTraceV2';
 
 export interface SpanLineActionButtonsProps {
 	span: Span;
-	customClassName?: string;
 }
 export default function SpanLineActionButtons({
 	span,
-	customClassName = '',
 }: SpanLineActionButtonsProps): JSX.Element {
 	const { onSpanCopy } = useCopySpanLink(span);
 
 	return (
-		<div className={`span-line-action-buttons ${customClassName}`}>
+		<div className="span-line-action-buttons">
 			<Tooltip title="Copy Span Link">
 				<Button
 					size="small"
@@ -28,7 +26,3 @@ export default function SpanLineActionButtons({
 		</div>
 	);
 }
-
-SpanLineActionButtons.defaultProps = {
-	customClassName: '',
-};

--- a/frontend/src/container/TraceWaterfall/SpanLineActionButtons/index.tsx
+++ b/frontend/src/container/TraceWaterfall/SpanLineActionButtons/index.tsx
@@ -1,0 +1,34 @@
+import './SpanLineActionButtons.styles.scss';
+
+import { LinkOutlined } from '@ant-design/icons';
+import { Button, Tooltip } from 'antd';
+import { useCopySpanLink } from 'hooks/trace/useCopySpanLink';
+import { Span } from 'types/api/trace/getTraceV2';
+
+export interface SpanLineActionButtonsProps {
+	span: Span;
+	customClassName?: string;
+}
+export default function SpanLineActionButtons({
+	span,
+	customClassName = '',
+}: SpanLineActionButtonsProps): JSX.Element {
+	const { onSpanCopy } = useCopySpanLink(span);
+
+	return (
+		<div className={`span-line-action-buttons ${customClassName}`}>
+			<Tooltip title="Copy Span Link">
+				<Button
+					size="small"
+					icon={<LinkOutlined size={14} />}
+					onClick={onSpanCopy}
+					className="copy-span-btn"
+				/>
+			</Tooltip>
+		</div>
+	);
+}
+
+SpanLineActionButtons.defaultProps = {
+	customClassName: '',
+};

--- a/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
+++ b/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
@@ -9,6 +9,7 @@ import cx from 'classnames';
 import { TableV3 } from 'components/TableV3/TableV3';
 import { themeColors } from 'constants/theme';
 import { convertTimeToRelevantUnit } from 'container/TraceDetail/utils';
+import SpanLineActionButtons from 'container/TraceWaterfall/SpanLineActionButtons';
 import { IInterestedSpan } from 'container/TraceWaterfall/TraceWaterfall';
 import { generateColor } from 'lib/uPlotLib/utils/generateColor';
 import {
@@ -25,7 +26,9 @@ import {
 	useEffect,
 	useMemo,
 	useRef,
+	useState,
 } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import { Span } from 'types/api/trace/getTraceV2';
 import { toFixed } from 'utils/toFixed';
 
@@ -166,11 +169,25 @@ function SpanDuration({
 	const leftOffset = ((span.timestamp - traceMetadata.startTime) * 1e2) / spread;
 	const width = (span.durationNano * 1e2) / (spread * 1e6);
 
+	const { search } = useLocation();
+	const history = useHistory();
+	const searchParams = new URLSearchParams(search);
+
 	let color = generateColor(span.serviceName, themeColors.traceDetailColors);
 
 	if (span.hasError) {
 		color = `var(--bg-cherry-500)`;
 	}
+
+	const [hasActionButtons, setHasActionButtons] = useState(false);
+
+	const handleMouseEnter = (): void => {
+		setHasActionButtons(true);
+	};
+
+	const handleMouseLeave = (): void => {
+		setHasActionButtons(false);
+	};
 
 	return (
 		<div
@@ -178,8 +195,12 @@ function SpanDuration({
 				'span-duration',
 				selectedSpan?.spanId === span.spanId ? 'interested-span' : '',
 			)}
+			onMouseEnter={handleMouseEnter}
+			onMouseLeave={handleMouseLeave}
 			onClick={(): void => {
 				setSelectedSpan(span);
+				searchParams.set('spanId', span.spanId);
+				history.replace({ search: searchParams.toString() });
 			}}
 		>
 			<div
@@ -190,6 +211,7 @@ function SpanDuration({
 					backgroundColor: color,
 				}}
 			/>
+			{hasActionButtons && <SpanLineActionButtons span={span} />}
 			<Tooltip title={`${toFixed(time, 2)} ${timeUnitName}`}>
 				<Typography.Text
 					className="span-line-text"

--- a/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
+++ b/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
@@ -151,7 +151,7 @@ function SpanOverview({
 	);
 }
 
-function SpanDuration({
+export function SpanDuration({
 	span,
 	traceMetadata,
 	setSelectedSpan,

--- a/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
+++ b/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
@@ -11,6 +11,8 @@ import { themeColors } from 'constants/theme';
 import { convertTimeToRelevantUnit } from 'container/TraceDetail/utils';
 import SpanLineActionButtons from 'container/TraceWaterfall/SpanLineActionButtons';
 import { IInterestedSpan } from 'container/TraceWaterfall/TraceWaterfall';
+import { useSafeNavigate } from 'hooks/useSafeNavigate';
+import useUrlQuery from 'hooks/useUrlQuery';
 import { generateColor } from 'lib/uPlotLib/utils/generateColor';
 import {
 	AlertCircle,
@@ -28,7 +30,6 @@ import {
 	useRef,
 	useState,
 } from 'react';
-import { useHistory, useLocation } from 'react-router-dom';
 import { Span } from 'types/api/trace/getTraceV2';
 import { toFixed } from 'utils/toFixed';
 
@@ -169,9 +170,8 @@ function SpanDuration({
 	const leftOffset = ((span.timestamp - traceMetadata.startTime) * 1e2) / spread;
 	const width = (span.durationNano * 1e2) / (spread * 1e6);
 
-	const { search } = useLocation();
-	const history = useHistory();
-	const searchParams = new URLSearchParams(search);
+	const urlQuery = useUrlQuery();
+	const { safeNavigate } = useSafeNavigate();
 
 	let color = generateColor(span.serviceName, themeColors.traceDetailColors);
 
@@ -199,8 +199,11 @@ function SpanDuration({
 			onMouseLeave={handleMouseLeave}
 			onClick={(): void => {
 				setSelectedSpan(span);
-				searchParams.set('spanId', span.spanId);
-				history.replace({ search: searchParams.toString() });
+				if (span?.spanId) {
+					urlQuery.set('spanId', span?.spanId);
+				}
+
+				safeNavigate({ search: urlQuery.toString() });
 			}}
 		>
 			<div

--- a/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/__tests__/SpanDuration.test.tsx
+++ b/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/__tests__/SpanDuration.test.tsx
@@ -1,0 +1,131 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { useSafeNavigate } from 'hooks/useSafeNavigate';
+import useUrlQuery from 'hooks/useUrlQuery';
+import { render } from 'tests/test-utils';
+import { Span } from 'types/api/trace/getTraceV2';
+
+import { SpanDuration } from '../Success';
+
+// Mock the hooks
+jest.mock('hooks/useSafeNavigate');
+jest.mock('hooks/useUrlQuery');
+
+const mockSpan: Span = {
+	spanId: 'test-span-id',
+	name: 'test-span',
+	serviceName: 'test-service',
+	durationNano: 1160000, // 1ms in nano
+	timestamp: 1234567890,
+	rootSpanId: 'test-root-span-id',
+	parentSpanId: 'test-parent-span-id',
+	traceId: 'test-trace-id',
+	hasError: false,
+	kind: 0,
+	references: [],
+	tagMap: {},
+	event: [],
+	rootName: 'test-root-name',
+	statusMessage: 'test-status-message',
+	statusCodeString: 'test-status-code-string',
+	spanKind: 'test-span-kind',
+	hasChildren: false,
+	hasSibling: false,
+	subTreeNodeCount: 0,
+	level: 0,
+};
+
+const mockTraceMetadata = {
+	traceId: 'test-trace-id',
+	startTime: 1234567000,
+	endTime: 1234569000,
+	hasMissingSpans: false,
+};
+
+describe('SpanDuration', () => {
+	const mockSetSelectedSpan = jest.fn();
+	const mockUrlQuerySet = jest.fn();
+	const mockSafeNavigate = jest.fn();
+	const mockUrlQueryGet = jest.fn();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		// Mock URL query hook
+		(useUrlQuery as jest.Mock).mockReturnValue({
+			set: mockUrlQuerySet,
+			get: mockUrlQueryGet,
+			toString: () => 'spanId=test-span-id',
+		});
+
+		// Mock safe navigate hook
+		(useSafeNavigate as jest.Mock).mockReturnValue({
+			safeNavigate: mockSafeNavigate,
+		});
+	});
+
+	it('updates URL and selected span when clicked', () => {
+		render(
+			<SpanDuration
+				span={mockSpan}
+				traceMetadata={mockTraceMetadata}
+				selectedSpan={undefined}
+				setSelectedSpan={mockSetSelectedSpan}
+			/>,
+		);
+
+		// Find and click the span duration element
+		const spanElement = screen.getByText('1.16 ms');
+		fireEvent.click(spanElement);
+
+		// Verify setSelectedSpan was called with the correct span
+		expect(mockSetSelectedSpan).toHaveBeenCalledWith(mockSpan);
+
+		// Verify URL query was updated
+		expect(mockUrlQuerySet).toHaveBeenCalledWith('spanId', 'test-span-id');
+
+		// Verify navigation was triggered
+		expect(mockSafeNavigate).toHaveBeenCalledWith({
+			search: 'spanId=test-span-id',
+		});
+	});
+
+	it('shows action buttons on hover', () => {
+		render(
+			<SpanDuration
+				span={mockSpan}
+				traceMetadata={mockTraceMetadata}
+				selectedSpan={undefined}
+				setSelectedSpan={mockSetSelectedSpan}
+			/>,
+		);
+
+		const spanElement = screen.getByText('1.16 ms');
+
+		// Initially, action buttons should not be visible
+		expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+		// Hover over the span
+		fireEvent.mouseEnter(spanElement);
+
+		// Action buttons should now be visible
+		expect(screen.getByRole('button')).toBeInTheDocument();
+
+		// Mouse leave should hide the buttons
+		fireEvent.mouseLeave(spanElement);
+		expect(screen.queryByRole('button')).not.toBeInTheDocument();
+	});
+
+	it('applies interested-span class when span is selected', () => {
+		render(
+			<SpanDuration
+				span={mockSpan}
+				traceMetadata={mockTraceMetadata}
+				selectedSpan={mockSpan}
+				setSelectedSpan={mockSetSelectedSpan}
+			/>,
+		);
+
+		const spanElement = screen.getByText('1.16 ms').closest('.span-duration');
+		expect(spanElement).toHaveClass('interested-span');
+	});
+});

--- a/frontend/src/hooks/trace/useCopySpanLink.ts
+++ b/frontend/src/hooks/trace/useCopySpanLink.ts
@@ -1,0 +1,42 @@
+import { useNotifications } from 'hooks/useNotifications';
+import useUrlQuery from 'hooks/useUrlQuery';
+import { MouseEventHandler, useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useCopyToClipboard } from 'react-use';
+import { Span } from 'types/api/trace/getTraceV2';
+
+export const useCopySpanLink = (
+	span?: Span,
+): { onSpanCopy: MouseEventHandler<HTMLElement> } => {
+	const urlQuery = useUrlQuery();
+	const { pathname } = useLocation();
+	const [, setCopy] = useCopyToClipboard();
+	const { notifications } = useNotifications();
+
+	const onSpanCopy: MouseEventHandler<HTMLElement> = useCallback(
+		(event) => {
+			if (!span) return;
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			urlQuery.delete('spanId');
+
+			if (span.spanId) {
+				urlQuery.set('spanId', span?.spanId);
+			}
+
+			const link = `${window.location.origin}${pathname}?${urlQuery.toString()}`;
+
+			setCopy(link);
+			notifications.success({
+				message: 'Copied to clipboard',
+			});
+		},
+		[span, urlQuery, pathname, setCopy, notifications],
+	);
+
+	return {
+		onSpanCopy,
+	};
+};


### PR DESCRIPTION
### Summary
Fixes an issue where clicking on spans in the waterfall graph wasn't expanding the span details or updating the URL query parameters.

#### Related Issues / PR's
- Resolves #7344

#### Screenshots
**Previous Behavior:**
- Clicking multiple times on a span in the waterfall graph did not:
  - Expand the span details
  - Update the spanId in URL query parameters
  
![Previous Behavior](https://github.com/user-attachments/assets/9f800660-ea20-49e4-9f5d-1551d83aafd6)

**New Behavior:**
- Clicking on spans now properly:
  - Expands the span details
  - Updates the URL query parameters with the selected spanId
  - We now have a copy span link button on hover which copies the link to that specific span.

![New Behavior](https://github.com/user-attachments/assets/0c0551c9-2096-45c9-9c54-b52df9762839)


<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds span expansion, URL update, and copy link functionality to waterfall graph spans.
> 
>   - **Behavior**:
>     - Clicking spans in the waterfall graph now expands details and updates URL with `spanId` in `Success.tsx`.
>     - Adds a copy span link button on hover in `SpanDuration` component.
>   - **Components**:
>     - New `SpanLineActionButtons` component for copy link functionality.
>     - Uses `useCopySpanLink` hook to handle link copying.
>   - **Tests**:
>     - Adds tests for `SpanLineActionButtons` in `SpanLineActionButtons.test.tsx`.
>     - Adds tests for `SpanDuration` in `SpanDuration.test.tsx`.
>   - **Styles**:
>     - Adds styles for action buttons in `SpanLineActionButtons.styles.scss`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 52ae3ef4b1e90289a11fe635aef58e49de5c2b54. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->