### PR TITLE
fix: removed timestamp and id from being passed to query from log details drawer

### DIFF
--- a/frontend/src/container/LogDetailedView/TableView.tsx
+++ b/frontend/src/container/LogDetailedView/TableView.tsx
@@ -30,12 +30,10 @@ import { ILog } from 'types/api/logs/log';
 import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
 
 import { ActionItemProps } from './ActionItem';
+import { RESTRICTED_FIELDS } from './constant';
 import FieldRenderer from './FieldRenderer';
 import { TableViewActions } from './TableView/TableViewActions';
 import { filterKeyForField, findKeyPath, flattenObject } from './utils';
-
-// Fields which should be restricted from adding it to query
-const RESTRICTED_FIELDS = ['timestamp'];
 
 interface TableViewProps {
 	logData: ILog;

--- a/frontend/src/container/LogDetailedView/TableView.tsx
+++ b/frontend/src/container/LogDetailedView/TableView.tsx
@@ -13,6 +13,7 @@ import AddToQueryHOC, {
 import { ResizeTable } from 'components/ResizeTable';
 import { OPERATORS } from 'constants/queryBuilder';
 import ROUTES from 'constants/routes';
+import { RESTRICTED_SELECTED_FIELDS } from 'container/LogsFilters/config';
 import { FontSize, OptionsQuery } from 'container/OptionsMenu/types';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import history from 'lib/history';
@@ -30,7 +31,6 @@ import { ILog } from 'types/api/logs/log';
 import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
 
 import { ActionItemProps } from './ActionItem';
-import { RESTRICTED_FIELDS } from './constant';
 import FieldRenderer from './FieldRenderer';
 import { TableViewActions } from './TableView/TableViewActions';
 import { filterKeyForField, findKeyPath, flattenObject } from './utils';
@@ -247,7 +247,7 @@ function TableView({
 				}
 
 				const fieldFilterKey = filterKeyForField(field);
-				if (!RESTRICTED_FIELDS.includes(fieldFilterKey)) {
+				if (!RESTRICTED_SELECTED_FIELDS.includes(fieldFilterKey)) {
 					return (
 						<AddToQueryHOC
 							fieldKey={fieldFilterKey}

--- a/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
+++ b/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
@@ -18,6 +18,7 @@ import { useLocation } from 'react-router-dom';
 import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { FORBID_DOM_PURIFY_TAGS } from 'utils/app';
 
+import { RESTRICTED_FIELDS } from '../constant';
 import { DataType } from '../TableView';
 import {
 	filterKeyForField,
@@ -142,7 +143,7 @@ export function TableViewActions(
 			<CopyClipboardHOC entityKey={fieldFilterKey} textToCopy={textToCopy}>
 				{renderFieldContent()}
 			</CopyClipboardHOC>
-			{!isListViewPanel && (
+			{!isListViewPanel && !RESTRICTED_FIELDS.includes(fieldFilterKey) && (
 				<span className="action-btn">
 					<Tooltip title="Filter for value">
 						<Button

--- a/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
+++ b/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
@@ -9,6 +9,7 @@ import CopyClipboardHOC from 'components/Logs/CopyClipboardHOC';
 import { DATE_TIME_FORMATS } from 'constants/dateTimeFormats';
 import { OPERATORS } from 'constants/queryBuilder';
 import ROUTES from 'constants/routes';
+import { RESTRICTED_SELECTED_FIELDS } from 'container/LogsFilters/config';
 import dompurify from 'dompurify';
 import { isEmpty } from 'lodash-es';
 import { ArrowDownToDot, ArrowUpFromDot, Ellipsis } from 'lucide-react';
@@ -18,7 +19,6 @@ import { useLocation } from 'react-router-dom';
 import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { FORBID_DOM_PURIFY_TAGS } from 'utils/app';
 
-import { RESTRICTED_FIELDS } from '../constant';
 import { DataType } from '../TableView';
 import {
 	filterKeyForField,
@@ -143,7 +143,7 @@ export function TableViewActions(
 			<CopyClipboardHOC entityKey={fieldFilterKey} textToCopy={textToCopy}>
 				{renderFieldContent()}
 			</CopyClipboardHOC>
-			{!isListViewPanel && !RESTRICTED_FIELDS.includes(fieldFilterKey) && (
+			{!isListViewPanel && !RESTRICTED_SELECTED_FIELDS.includes(fieldFilterKey) && (
 				<span className="action-btn">
 					<Tooltip title="Filter for value">
 						<Button

--- a/frontend/src/container/LogDetailedView/TableView/__test__/TableViewActions.test.tsx
+++ b/frontend/src/container/LogDetailedView/TableView/__test__/TableViewActions.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react';
+import { RESTRICTED_SELECTED_FIELDS } from 'container/LogsFilters/config';
+
+import { TableViewActions } from '../TableViewActions';
+
+// Mock the components and hooks
+jest.mock('components/Logs/CopyClipboardHOC', () => ({
+	__esModule: true,
+	default: ({ children }: { children: React.ReactNode }): JSX.Element => (
+		<div className="CopyClipboardHOC">{children}</div>
+	),
+}));
+
+jest.mock('providers/Timezone', () => ({
+	useTimezone: (): {
+		formatTimezoneAdjustedTimestamp: (timestamp: string) => string;
+	} => ({
+		formatTimezoneAdjustedTimestamp: (timestamp: string): string => timestamp,
+	}),
+}));
+
+jest.mock('react-router-dom', () => ({
+	useLocation: (): {
+		pathname: string;
+		search: string;
+		hash: string;
+		state: null;
+	} => ({
+		pathname: '/test',
+		search: '',
+		hash: '',
+		state: null,
+	}),
+}));
+
+describe('TableViewActions', () => {
+	const TEST_VALUE = 'test value';
+	const ACTION_BUTTON_TEST_ID = '.action-btn';
+	const defaultProps = {
+		fieldData: {
+			field: 'test-field',
+			value: TEST_VALUE,
+		},
+		record: {
+			key: 'test-key',
+			field: 'test-field',
+			value: TEST_VALUE,
+		},
+		isListViewPanel: false,
+		isfilterInLoading: false,
+		isfilterOutLoading: false,
+		onClickHandler: jest.fn(),
+		onGroupByAttribute: jest.fn(),
+	};
+
+	it('should render without crashing', () => {
+		render(
+			<TableViewActions
+				fieldData={defaultProps.fieldData}
+				record={defaultProps.record}
+				isListViewPanel={defaultProps.isListViewPanel}
+				isfilterInLoading={defaultProps.isfilterInLoading}
+				isfilterOutLoading={defaultProps.isfilterOutLoading}
+				onClickHandler={defaultProps.onClickHandler}
+				onGroupByAttribute={defaultProps.onGroupByAttribute}
+			/>,
+		);
+		expect(screen.getByText(TEST_VALUE)).toBeInTheDocument();
+	});
+
+	it('should not render action buttons for restricted fields', () => {
+		RESTRICTED_SELECTED_FIELDS.forEach((field) => {
+			const { container } = render(
+				<TableViewActions
+					fieldData={{
+						...defaultProps.fieldData,
+						field,
+					}}
+					record={{
+						...defaultProps.record,
+						field,
+					}}
+					isListViewPanel={defaultProps.isListViewPanel}
+					isfilterInLoading={defaultProps.isfilterInLoading}
+					isfilterOutLoading={defaultProps.isfilterOutLoading}
+					onClickHandler={defaultProps.onClickHandler}
+					onGroupByAttribute={defaultProps.onGroupByAttribute}
+				/>,
+			);
+			// Verify that action buttons are not rendered for restricted fields
+			expect(
+				container.querySelector(ACTION_BUTTON_TEST_ID),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	it('should render action buttons for non-restricted fields', () => {
+		const { container } = render(
+			<TableViewActions
+				fieldData={defaultProps.fieldData}
+				record={defaultProps.record}
+				isListViewPanel={defaultProps.isListViewPanel}
+				isfilterInLoading={defaultProps.isfilterInLoading}
+				isfilterOutLoading={defaultProps.isfilterOutLoading}
+				onClickHandler={defaultProps.onClickHandler}
+				onGroupByAttribute={defaultProps.onGroupByAttribute}
+			/>,
+		);
+		// Verify that action buttons are not rendered in list view panel
+		expect(container.querySelector(ACTION_BUTTON_TEST_ID)).toBeInTheDocument();
+	});
+
+	it('should not render action buttons in list view panel', () => {
+		const { container } = render(
+			<TableViewActions
+				fieldData={defaultProps.fieldData}
+				record={defaultProps.record}
+				isListViewPanel
+				isfilterInLoading={defaultProps.isfilterInLoading}
+				isfilterOutLoading={defaultProps.isfilterOutLoading}
+				onClickHandler={defaultProps.onClickHandler}
+				onGroupByAttribute={defaultProps.onGroupByAttribute}
+			/>,
+		);
+		// Verify that action buttons are not rendered in list view panel
+		expect(
+			container.querySelector(ACTION_BUTTON_TEST_ID),
+		).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/container/LogDetailedView/TableView/__test__/TableViewActions.test.tsx
+++ b/frontend/src/container/LogDetailedView/TableView/__test__/TableViewActions.test.tsx
@@ -106,7 +106,7 @@ describe('TableViewActions', () => {
 				onGroupByAttribute={defaultProps.onGroupByAttribute}
 			/>,
 		);
-		// Verify that action buttons are not rendered in list view panel
+		// Verify that action buttons are rendered for non-restricted fields
 		expect(container.querySelector(ACTION_BUTTON_TEST_ID)).toBeInTheDocument();
 	});
 

--- a/frontend/src/container/LogDetailedView/constant.ts
+++ b/frontend/src/container/LogDetailedView/constant.ts
@@ -2,6 +2,3 @@ export const DROPDOWN_KEY = {
 	FILTER_IN: 'filterIn',
 	FILTER_OUT: 'filterOut',
 };
-
-// Fields which should be restricted from adding it to query
-export const RESTRICTED_FIELDS = ['timestamp', 'id'];

--- a/frontend/src/container/LogDetailedView/constant.ts
+++ b/frontend/src/container/LogDetailedView/constant.ts
@@ -2,3 +2,6 @@ export const DROPDOWN_KEY = {
 	FILTER_IN: 'filterIn',
 	FILTER_OUT: 'filterOut',
 };
+
+// Fields which should be restricted from adding it to query
+export const RESTRICTED_FIELDS = ['timestamp', 'id'];


### PR DESCRIPTION

### Summary

<!-- ✍️ A clear and concise description...-->

#### Related Issues / PR's


Fixes : https://github.com/SigNoz/signoz/issues/7521
<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prevents restricted fields (e.g., `timestamp`, `id`) from being passed to queries or showing filter actions in the log details drawer, with tests to verify behavior.
> 
>   - **Restrict query/filter actions for certain fields**:
>     - Use `RESTRICTED_SELECTED_FIELDS` (from `LogsFilters/config`) in `TableView.tsx` and `TableViewActions.tsx` to prevent `timestamp`, `id`, and other restricted fields from being added to queries or showing filter actions in the log details drawer.
>     - Removes local `RESTRICTED_FIELDS` constant in favor of the shared config.
>   - **Testing**:
>     - Adds `TableViewActions.test.tsx` to verify that action buttons are not rendered for restricted fields and are rendered for allowed fields.
>   - **Misc**:
>     - Minor refactor to use shared config for restricted fields in relevant components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 8b662304a5e21b9e7018282b1dbac18edb05b1a4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->