### PR TITLE
chore: error log on query error

### DIFF
--- a/pkg/telemetrystore/telemetrystorehook/logging.go
+++ b/pkg/telemetrystore/telemetrystorehook/logging.go
@@ -2,6 +2,8 @@ package telemetrystorehook
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -36,7 +38,7 @@ func (hook *logging) AfterQuery(ctx context.Context, event *telemetrystore.Query
 		"db.query.args", event.QueryArgs,
 		"db.duration", time.Since(event.StartTime).String(),
 	}
-	if event.Err != nil {
+	if event.Err != nil && !errors.Is(event.Err, sql.ErrNoRows) && !errors.Is(event.Err, context.Canceled) {
 		level = slog.LevelError
 		args = append(args, "db.query.error", event.Err)
 	}

--- a/pkg/telemetrystore/telemetrystorehook/logging.go
+++ b/pkg/telemetrystore/telemetrystorehook/logging.go
@@ -30,12 +30,21 @@ func (logging) BeforeQuery(ctx context.Context, event *telemetrystore.QueryEvent
 }
 
 func (hook *logging) AfterQuery(ctx context.Context, event *telemetrystore.QueryEvent) {
-	hook.logger.Log(
-		ctx,
-		hook.level,
-		"::TELEMETRYSTORE-QUERY::",
+	level := hook.level
+	args := []any{
 		"db.query.text", event.Query,
 		"db.query.args", event.QueryArgs,
 		"db.duration", time.Since(event.StartTime).String(),
+	}
+	if event.Err != nil {
+		level = slog.LevelError
+		args = append(args, "db.query.error", event.Err)
+	}
+
+	hook.logger.Log(
+		ctx,
+		level,
+		"::TELEMETRYSTORE-QUERY::",
+		args...,
 	)
 }


### PR DESCRIPTION
### Summary

Emit error log with query error on non-nil event error. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Log query errors in `AfterQuery` function of `logging` struct when `event.Err` is non-nil and not `sql.ErrNoRows` or `context.Canceled`.
> 
>   - **Behavior**:
>     - In `AfterQuery` function of `logging` struct, log level set to error if `event.Err` is non-nil and not `sql.ErrNoRows` or `context.Canceled`.
>     - Append `db.query.error` to log arguments if error conditions are met.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 156868b456391f4c37c15eb0fbb77e2425a9cb5f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->