### PR TITLE
chore: enable third party api feature by default

### DIFF
--- a/ee/query-service/model/plans.go
+++ b/ee/query-service/model/plans.go
@@ -69,6 +69,13 @@ var BasicPlan = basemodel.FeatureSet{
 		UsageLimit: -1,
 		Route:      "",
 	},
+	basemodel.Feature{
+		Name:       basemodel.ThirdPartyApi,
+		Active:     true,
+		Usage:      0,
+		UsageLimit: -1,
+		Route:      "",
+	},
 }
 
 var EnterprisePlan = basemodel.FeatureSet{
@@ -124,6 +131,13 @@ var EnterprisePlan = basemodel.FeatureSet{
 	basemodel.Feature{
 		Name:       basemodel.TraceFunnels,
 		Active:     false,
+		Usage:      0,
+		UsageLimit: -1,
+		Route:      "",
+	},
+	basemodel.Feature{
+		Name:       basemodel.ThirdPartyApi,
+		Active:     true,
 		Usage:      0,
 		UsageLimit: -1,
 		Route:      "",

--- a/ee/query-service/model/plans.go
+++ b/ee/query-service/model/plans.go
@@ -70,7 +70,7 @@ var BasicPlan = basemodel.FeatureSet{
 		Route:      "",
 	},
 	basemodel.Feature{
-		Name:       basemodel.ThirdPartyApi,
+		Name:       basemodel.ThirdPartyAPI,
 		Active:     true,
 		Usage:      0,
 		UsageLimit: -1,
@@ -136,7 +136,7 @@ var EnterprisePlan = basemodel.FeatureSet{
 		Route:      "",
 	},
 	basemodel.Feature{
-		Name:       basemodel.ThirdPartyApi,
+		Name:       basemodel.ThirdPartyAPI,
 		Active:     true,
 		Usage:      0,
 		UsageLimit: -1,

--- a/pkg/query-service/model/featureSet.go
+++ b/pkg/query-service/model/featureSet.go
@@ -12,6 +12,7 @@ type Feature struct {
 const UseSpanMetrics = "USE_SPAN_METRICS"
 const AnomalyDetection = "ANOMALY_DETECTION"
 const TraceFunnels = "TRACE_FUNNELS"
+const ThirdPartyApi = "THIRD_PARTY_API"
 
 var BasicPlan = FeatureSet{
 	Feature{
@@ -31,6 +32,13 @@ var BasicPlan = FeatureSet{
 	Feature{
 		Name:       TraceFunnels,
 		Active:     false,
+		Usage:      0,
+		UsageLimit: -1,
+		Route:      "",
+	},
+	Feature{
+		Name:       ThirdPartyApi,
+		Active:     true,
 		Usage:      0,
 		UsageLimit: -1,
 		Route:      "",

--- a/pkg/query-service/model/featureSet.go
+++ b/pkg/query-service/model/featureSet.go
@@ -12,7 +12,7 @@ type Feature struct {
 const UseSpanMetrics = "USE_SPAN_METRICS"
 const AnomalyDetection = "ANOMALY_DETECTION"
 const TraceFunnels = "TRACE_FUNNELS"
-const ThirdPartyApi = "THIRD_PARTY_API"
+const ThirdPartyAPI = "THIRD_PARTY_API"
 
 var BasicPlan = FeatureSet{
 	Feature{
@@ -37,7 +37,7 @@ var BasicPlan = FeatureSet{
 		Route:      "",
 	},
 	Feature{
-		Name:       ThirdPartyApi,
+		Name:       ThirdPartyAPI,
 		Active:     true,
 		Usage:      0,
 		UsageLimit: -1,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable `ThirdPartyApi` feature by default in `BasicPlan` and `EnterprisePlan`.
> 
>   - **Feature Addition**:
>     - Add `ThirdPartyApi` feature to `BasicPlan` and `EnterprisePlan` in `plans.go` and `featureSet.go`.
>     - Set `ThirdPartyApi` feature `Active` to `true` in both plans.
>   - **Constants**:
>     - Add `ThirdPartyApi` constant in `featureSet.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 5431853b53b44d4b9d3872562d106b72c2594692. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->