### PR TITLE
Revert "fix: reevaluated newdashboard bool to ensure that widget doesn't exist, incase of a prior PUT call"

### DIFF
--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -111,8 +111,9 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 		const widgetId = query.get('widgetId');
 		const selectedWidget = widgets?.find((e) => e.id === widgetId);
 		const isWidgetNotPresent = isUndefined(selectedWidget);
-
-		setIsNewDashboard(isWidgetNotPresent);
+		if (isWidgetNotPresent) {
+			setIsNewDashboard(true);
+		}
 
 		if (!logEventCalledRef.current) {
 			logEvent('Panel Edit: Page visited', {
@@ -126,7 +127,7 @@ function NewWidget({ selectedGraph }: NewWidgetProps): JSX.Element {
 			logEventCalledRef.current = true;
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [widgets]);
+	}, []);
 
 	const getWidget = useCallback(() => {
 		const widgetId = query.get('widgetId');


### PR DESCRIPTION
Reverts SigNoz/signoz#7525
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts logic in `NewWidget/index.tsx` to conditionally set `isNewDashboard` and modifies `useEffect` to run once on mount.
> 
>   - **Revert Changes**:
>     - Reverts logic in `NewWidget/index.tsx` to set `isNewDashboard` using a conditional statement instead of directly assigning `isWidgetNotPresent`.
>     - Modifies `useEffect` dependency array to `[]`, ensuring it runs only once on mount.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for d6379eae5163e3923a911f4a2c104914d5f8c795. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->