### PR TITLE
chore(build): include missing LDFLAGS in the community/enterprise builds

### DIFF
--- a/.github/workflows/build-community.yaml
+++ b/.github/workflows/build-community.yaml
@@ -7,6 +7,10 @@ on:
     tags:
       - v*
 
+defaults:
+  run:
+    shell: bash
+
 env:
   PRIMUS_HOME: .primus
   MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
@@ -39,10 +43,10 @@ jobs:
           token: ${{ steps.token.outputs.token }}
       - name: build-info
         run: |
-          echo "version=$(eval $MAKE info-version)" >> $GITHUB_OUTPUT
-          echo "hash=$(eval $MAKE info-commit-short)" >> $GITHUB_OUTPUT
-          echo "time=$(eval $MAKE info-timestamp)" >> $GITHUB_OUTPUT
-          echo "branch=$(eval $MAKE info-branch)" >> $GITHUB_OUTPUT
+          echo "version=$($MAKE info-version)" >> $GITHUB_OUTPUT
+          echo "hash=$($MAKE info-commit-short)" >> $GITHUB_OUTPUT
+          echo "time=$($MAKE info-timestamp)" >> $GITHUB_OUTPUT
+          echo "branch=$($MAKE info-branch)" >> $GITHUB_OUTPUT
       - name: set-docker-providers
         id: set-docker-providers
         run: |

--- a/.github/workflows/build-community.yaml
+++ b/.github/workflows/build-community.yaml
@@ -75,7 +75,7 @@ jobs:
       GO_BUILD_FLAGS: >-
         -tags timetzdata
         -ldflags='-linkmode external -extldflags \"-static\" -s -w
-        -X github.com/SigNoz/signoz/pkg/version.Version=${{ needs.prepare.outputs.version }}
+        -X github.com/SigNoz/signoz/pkg/version.version=${{ needs.prepare.outputs.version }}
         -X github.com/SigNoz/signoz/pkg/version.variant=community
         -X github.com/SigNoz/signoz/pkg/version.hash=${{ needs.prepare.outputs.hash }}
         -X github.com/SigNoz/signoz/pkg/version.time=${{ needs.prepare.outputs.time }}

--- a/.github/workflows/build-community.yaml
+++ b/.github/workflows/build-community.yaml
@@ -39,10 +39,10 @@ jobs:
           token: ${{ steps.token.outputs.token }}
       - name: build-info
         run: |
-          echo "version=$($MAKE info-version)" >> $GITHUB_OUTPUT
-          echo "hash=$($MAKE info-commit-short)" >> $GITHUB_OUTPUT
-          echo "time=$($MAKE info-timestamp)" >> $GITHUB_OUTPUT
-          echo "branch=$($MAKE info-branch)" >> $GITHUB_OUTPUT
+          echo "version=$(eval $MAKE info-version)" >> $GITHUB_OUTPUT
+          echo "hash=$(eval $MAKE info-commit-short)" >> $GITHUB_OUTPUT
+          echo "time=$(eval $MAKE info-timestamp)" >> $GITHUB_OUTPUT
+          echo "branch=$(eval $MAKE info-branch)" >> $GITHUB_OUTPUT
       - name: set-docker-providers
         id: set-docker-providers
         run: |
@@ -75,11 +75,11 @@ jobs:
       GO_BUILD_FLAGS: >-
         -tags timetzdata
         -ldflags='-linkmode external -extldflags \"-static\" -s -w
-        -X github.com/signoz/zeus/pkg/version.Version=${{ needs.prepare.outputs.version }}
-        -X github.com/signoz/zeus/pkg/version.variant=community
-        -X github.com/signoz/zeus/pkg/version.hash=${{ needs.prepare.outputs.hash }}
-        -X github.com/signoz/zeus/pkg/version.time=${{ needs.prepare.outputs.time }}
-        -X github.com/signoz/zeus/pkg/version.branch=${{ needs.prepare.outputs.branch }}'
+        -X github.com/SigNoz/signoz/pkg/version.Version=${{ needs.prepare.outputs.version }}
+        -X github.com/SigNoz/signoz/pkg/version.variant=community
+        -X github.com/SigNoz/signoz/pkg/version.hash=${{ needs.prepare.outputs.hash }}
+        -X github.com/SigNoz/signoz/pkg/version.time=${{ needs.prepare.outputs.time }}
+        -X github.com/SigNoz/signoz/pkg/version.branch=${{ needs.prepare.outputs.branch }}'
       GO_CGO_ENABLED: 1
       DOCKER_BASE_IMAGES: '{"alpine": "alpine:3.20.3"}'
       DOCKER_DOCKERFILE_PATH: ./pkg/query-service/Dockerfile.multi-arch

--- a/.github/workflows/build-community.yaml
+++ b/.github/workflows/build-community.yaml
@@ -7,12 +7,42 @@ on:
     tags:
       - v*
 
+env:
+  PRIMUS_HOME: .primus
+  MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
       docker_providers: ${{ steps.set-docker-providers.outputs.providers }}
+      version: ${{ steps.build-info.outputs.version }}
+      hash: ${{ steps.build-info.outputs.hash }}
+      time: ${{ steps.build-info.outputs.time }}
+      branch: ${{ steps.build-info.outputs.branch }}
     steps:
+      - name: self-checkout
+        uses: actions/checkout@v4
+      - id: token
+        name: github-token-gen
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PRIMUS_APP_ID }}
+          private-key: ${{ secrets.PRIMUS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: primus-checkout
+        uses: actions/checkout@v4
+        with:
+          repository: signoz/primus
+          ref: ${{ inputs.PRIMUS_REF }}
+          path: .primus
+          token: ${{ steps.token.outputs.token }}
+      - name: build-info
+        run: |
+          echo "version=$($MAKE info-version)" >> $GITHUB_OUTPUT
+          echo "hash=$($MAKE info-commit-short)" >> $GITHUB_OUTPUT
+          echo "time=$($MAKE info-timestamp)" >> $GITHUB_OUTPUT
+          echo "branch=$($MAKE info-branch)" >> $GITHUB_OUTPUT
       - name: set-docker-providers
         id: set-docker-providers
         run: |
@@ -45,11 +75,11 @@ jobs:
       GO_BUILD_FLAGS: >-
         -tags timetzdata
         -ldflags='-linkmode external -extldflags \"-static\" -s -w
-        -X github.com/signoz/zeus/pkg/version.Version=\$($MAKE info-version)
+        -X github.com/signoz/zeus/pkg/version.Version=${{ needs.prepare.outputs.version }}
         -X github.com/signoz/zeus/pkg/version.variant=community
-        -X github.com/signoz/zeus/pkg/version.hash=\$($MAKE info-commit-short)
-        -X github.com/signoz/zeus/pkg/version.time=\$($MAKE info-timestamp)
-        -X github.com/signoz/zeus/pkg/version.branch=\$($MAKE info-branch)'
+        -X github.com/signoz/zeus/pkg/version.hash=${{ needs.prepare.outputs.hash }}
+        -X github.com/signoz/zeus/pkg/version.time=${{ needs.prepare.outputs.time }}
+        -X github.com/signoz/zeus/pkg/version.branch=${{ needs.prepare.outputs.branch }}'
       GO_CGO_ENABLED: 1
       DOCKER_BASE_IMAGES: '{"alpine": "alpine:3.20.3"}'
       DOCKER_DOCKERFILE_PATH: ./pkg/query-service/Dockerfile.multi-arch

--- a/.github/workflows/build-enterprise.yaml
+++ b/.github/workflows/build-enterprise.yaml
@@ -7,12 +7,42 @@ on:
     tags:
       - v*
 
+env:
+  PRIMUS_HOME: .primus
+  MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
       docker_providers: ${{ steps.set-docker-providers.outputs.providers }}
+      version: ${{ steps.build-info.outputs.version }}
+      hash: ${{ steps.build-info.outputs.hash }}
+      time: ${{ steps.build-info.outputs.time }}
+      branch: ${{ steps.build-info.outputs.branch }}
     steps:
+      - name: self-checkout
+        uses: actions/checkout@v4
+      - id: token
+        name: github-token-gen
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PRIMUS_APP_ID }}
+          private-key: ${{ secrets.PRIMUS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: primus-checkout
+        uses: actions/checkout@v4
+        with:
+          repository: signoz/primus
+          ref: ${{ inputs.PRIMUS_REF }}
+          path: .primus
+          token: ${{ steps.token.outputs.token }}
+      - name: build-info
+        run: |
+          echo "version=$($MAKE info-version)" >> $GITHUB_OUTPUT
+          echo "hash=$($MAKE info-commit-short)" >> $GITHUB_OUTPUT
+          echo "time=$($MAKE info-timestamp)" >> $GITHUB_OUTPUT
+          echo "branch=$($MAKE info-branch)" >> $GITHUB_OUTPUT
       - name: set-docker-providers
         id: set-docker-providers
         run: |
@@ -66,11 +96,11 @@ jobs:
       GO_BUILD_FLAGS: >-
         -tags timetzdata
         -ldflags='-linkmode external -extldflags \"-static\" -s -w
-        -X github.com/signoz/zeus/pkg/version.Version=\$($MAKE info-version)
+        -X github.com/signoz/zeus/pkg/version.Version=${{ needs.prepare.outputs.version }}
         -X github.com/signoz/zeus/pkg/version.variant=enterprise
-        -X github.com/signoz/zeus/pkg/version.hash=\$($MAKE info-commit-short)
-        -X github.com/signoz/zeus/pkg/version.time=\$($MAKE info-timestamp)
-        -X github.com/signoz/zeus/pkg/version.branch=\$($MAKE info-branch)
+        -X github.com/signoz/zeus/pkg/version.hash=${{ needs.prepare.outputs.hash }}
+        -X github.com/signoz/zeus/pkg/version.time=${{ needs.prepare.outputs.time }}
+        -X github.com/signoz/zeus/pkg/version.branch=${{ needs.prepare.outputs.branch }}
         -X github.com/signoz/zeus/ee/query-service/constants.ZeusURL=https://api.signoz.cloud
         -X github.com/signoz/zeus/ee/query-service/constants.LicenseSignozIo=https://license.signoz.io/api/v1'
       GO_CGO_ENABLED: 1

--- a/.github/workflows/build-enterprise.yaml
+++ b/.github/workflows/build-enterprise.yaml
@@ -39,10 +39,10 @@ jobs:
           token: ${{ steps.token.outputs.token }}
       - name: build-info
         run: |
-          echo "version=$($MAKE info-version)" >> $GITHUB_OUTPUT
-          echo "hash=$($MAKE info-commit-short)" >> $GITHUB_OUTPUT
-          echo "time=$($MAKE info-timestamp)" >> $GITHUB_OUTPUT
-          echo "branch=$($MAKE info-branch)" >> $GITHUB_OUTPUT
+          echo "version=$(eval $MAKE info-version)" >> $GITHUB_OUTPUT
+          echo "hash=$(eval $MAKE info-commit-short)" >> $GITHUB_OUTPUT
+          echo "time=$(eval $MAKE info-timestamp)" >> $GITHUB_OUTPUT
+          echo "branch=$(eval $MAKE info-branch)" >> $GITHUB_OUTPUT
       - name: set-docker-providers
         id: set-docker-providers
         run: |
@@ -96,13 +96,13 @@ jobs:
       GO_BUILD_FLAGS: >-
         -tags timetzdata
         -ldflags='-linkmode external -extldflags \"-static\" -s -w
-        -X github.com/signoz/zeus/pkg/version.Version=${{ needs.prepare.outputs.version }}
-        -X github.com/signoz/zeus/pkg/version.variant=enterprise
-        -X github.com/signoz/zeus/pkg/version.hash=${{ needs.prepare.outputs.hash }}
-        -X github.com/signoz/zeus/pkg/version.time=${{ needs.prepare.outputs.time }}
-        -X github.com/signoz/zeus/pkg/version.branch=${{ needs.prepare.outputs.branch }}
-        -X github.com/signoz/zeus/ee/query-service/constants.ZeusURL=https://api.signoz.cloud
-        -X github.com/signoz/zeus/ee/query-service/constants.LicenseSignozIo=https://license.signoz.io/api/v1'
+        -X github.com/SigNoz/signoz/pkg/version.Version=${{ needs.prepare.outputs.version }}
+        -X github.com/SigNoz/signoz/pkg/version.variant=enterprise
+        -X github.com/SigNoz/signoz/pkg/version.hash=${{ needs.prepare.outputs.hash }}
+        -X github.com/SigNoz/signoz/pkg/version.time=${{ needs.prepare.outputs.time }}
+        -X github.com/SigNoz/signoz/pkg/version.branch=${{ needs.prepare.outputs.branch }}
+        -X github.com/SigNoz/signoz/ee/query-service/constants.ZeusURL=https://api.signoz.cloud
+        -X github.com/SigNoz/signoz/ee/query-service/constants.LicenseSignozIo=https://license.signoz.io/api/v1'
       GO_CGO_ENABLED: 1
       DOCKER_BASE_IMAGES: '{"alpine": "alpine:3.20.3"}'
       DOCKER_DOCKERFILE_PATH: ./ee/query-service/Dockerfile.multi-arch

--- a/.github/workflows/build-enterprise.yaml
+++ b/.github/workflows/build-enterprise.yaml
@@ -96,7 +96,7 @@ jobs:
       GO_BUILD_FLAGS: >-
         -tags timetzdata
         -ldflags='-linkmode external -extldflags \"-static\" -s -w
-        -X github.com/SigNoz/signoz/pkg/version.Version=${{ needs.prepare.outputs.version }}
+        -X github.com/SigNoz/signoz/pkg/version.version=${{ needs.prepare.outputs.version }}
         -X github.com/SigNoz/signoz/pkg/version.variant=enterprise
         -X github.com/SigNoz/signoz/pkg/version.hash=${{ needs.prepare.outputs.hash }}
         -X github.com/SigNoz/signoz/pkg/version.time=${{ needs.prepare.outputs.time }}

--- a/.github/workflows/build-enterprise.yaml
+++ b/.github/workflows/build-enterprise.yaml
@@ -7,6 +7,10 @@ on:
     tags:
       - v*
 
+defaults:
+  run:
+    shell: bash
+
 env:
   PRIMUS_HOME: .primus
   MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
@@ -38,11 +42,12 @@ jobs:
           path: .primus
           token: ${{ steps.token.outputs.token }}
       - name: build-info
+        id: build-info
         run: |
-          echo "version=$(eval $MAKE info-version)" >> $GITHUB_OUTPUT
-          echo "hash=$(eval $MAKE info-commit-short)" >> $GITHUB_OUTPUT
-          echo "time=$(eval $MAKE info-timestamp)" >> $GITHUB_OUTPUT
-          echo "branch=$(eval $MAKE info-branch)" >> $GITHUB_OUTPUT
+          echo "version=$($MAKE info-version)" >> $GITHUB_OUTPUT
+          echo "hash=$($MAKE info-commit-short)" >> $GITHUB_OUTPUT
+          echo "time=$($MAKE info-timestamp)" >> $GITHUB_OUTPUT
+          echo "branch=$($MAKE info-branch)" >> $GITHUB_OUTPUT
       - name: set-docker-providers
         id: set-docker-providers
         run: |


### PR DESCRIPTION
### Summary

- include missing LDFLAGS in the community/enterprise builds

#### Related Issues / PR's

NA

#### Screenshots

NA

#### Affected Areas and Manually Tested Areas

NA

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Include missing LDFLAGS in community and enterprise build workflows, and update enterprise workflow to handle `.env` file creation and caching.
> 
>   - **Build Workflow Updates**:
>     - Include missing LDFLAGS in `build-community.yaml` and `build-enterprise.yaml`.
>     - Use `needs.prepare.outputs` for version, hash, time, and branch in Go build flags.
>   - **Enterprise Specific**:
>     - Add steps to create and cache `.env` file with secrets in `build-enterprise.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 431d46d0a55a86e5cac894349685277004e5bb8e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->