### PR TITLE
chore: add virtual fields table

### DIFF
--- a/pkg/query-service/utils/testutils.go
+++ b/pkg/query-service/utils/testutils.go
@@ -51,6 +51,7 @@ func NewTestSqliteDB(t *testing.T) (sqlStore sqlstore.SQLStore, testDBFilePath s
 			sqlmigration.NewUpdateDashboardAndSavedViewsFactory(sqlStore),
 			sqlmigration.NewUpdatePatAndOrgDomainsFactory(sqlStore),
 			sqlmigration.NewUpdatePipelines(sqlStore),
+			sqlmigration.NewAddVirtualFieldsFactory(),
 		),
 	)
 	if err != nil {

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -69,6 +69,7 @@ func NewSQLMigrationProviderFactories(sqlstore sqlstore.SQLStore) factory.NamedM
 		sqlmigration.NewUpdatePreferencesFactory(sqlstore),
 		sqlmigration.NewUpdateApdexTtlFactory(sqlstore),
 		sqlmigration.NewUpdateResetPasswordFactory(sqlstore),
+		sqlmigration.NewAddVirtualFieldsFactory(),
 	)
 }
 

--- a/pkg/sqlmigration/025_add_virtual_fields.go
+++ b/pkg/sqlmigration/025_add_virtual_fields.go
@@ -2,9 +2,9 @@ package sqlmigration
 
 import (
 	"context"
-	"time"
 
 	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/migrate"
@@ -29,20 +29,20 @@ func (migration *addVirtualFields) Register(migrations *migrate.Migrations) erro
 }
 
 func (migration *addVirtualFields) Up(ctx context.Context, db *bun.DB) error {
-	// table:virtual_fields op:create
+	// table:virtual_field op:create
 	if _, err := db.NewCreateTable().
 		Model(&struct {
-			bun.BaseModel `bun:"table:virtual_fields"`
-			UUID          string                `bun:"uuid,pk,type:text"`
-			CreatedAt     time.Time             `bun:"created_at,notnull"`
-			CreatedBy     string                `bun:"created_by,type:text"`
-			UpdatedAt     time.Time             `bun:"updated_at,notnull"`
-			UpdatedBy     string                `bun:"updated_by,type:text"`
-			Name          string                `bun:"name,type:text,notnull"`
-			Expression    string                `bun:"expression,type:text,notnull"`
-			Description   string                `bun:"description,type:text"`
-			Signal        telemetrytypes.Signal `bun:"signal,type:text,notnull"`
-			OrgID         string                `bun:"org_id,type:text,notnull"`
+			bun.BaseModel `bun:"table:virtual_field"`
+
+			types.Identifiable
+			types.TimeAuditable
+			types.UserAuditable
+
+			Name        string                `bun:"name,type:text,notnull"`
+			Expression  string                `bun:"expression,type:text,notnull"`
+			Description string                `bun:"description,type:text"`
+			Signal      telemetrytypes.Signal `bun:"signal,type:text,notnull"`
+			OrgID       string                `bun:"org_id,type:text,notnull"`
 		}{}).
 		ForeignKey(`("org_id") REFERENCES "organizations" ("id") ON DELETE CASCADE`).
 		IfNotExists().

--- a/pkg/sqlmigration/025_add_virtual_fields.go
+++ b/pkg/sqlmigration/025_add_virtual_fields.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/migrate"
 )
@@ -32,15 +33,18 @@ func (migration *addVirtualFields) Up(ctx context.Context, db *bun.DB) error {
 	if _, err := db.NewCreateTable().
 		Model(&struct {
 			bun.BaseModel `bun:"table:virtual_fields"`
-			UUID          string    `bun:"uuid,pk,type:text"`
-			CreatedAt     time.Time `bun:"created_at,notnull"`
-			CreatedBy     string    `bun:"created_by,type:text"`
-			UpdatedAt     time.Time `bun:"updated_at,notnull"`
-			UpdatedBy     string    `bun:"updated_by,type:text"`
-			Name          string    `bun:"name,type:text,notnull"`
-			Expression    string    `bun:"expression,type:text,notnull"`
-			Description   string    `bun:"description,type:text"`
+			UUID          string                `bun:"uuid,pk,type:text"`
+			CreatedAt     time.Time             `bun:"created_at,notnull"`
+			CreatedBy     string                `bun:"created_by,type:text"`
+			UpdatedAt     time.Time             `bun:"updated_at,notnull"`
+			UpdatedBy     string                `bun:"updated_by,type:text"`
+			Name          string                `bun:"name,type:text,notnull"`
+			Expression    string                `bun:"expression,type:text,notnull"`
+			Description   string                `bun:"description,type:text"`
+			Signal        telemetrytypes.Signal `bun:"signal,type:text,notnull"`
+			OrgID         string                `bun:"org_id,type:text,notnull"`
 		}{}).
+		ForeignKey(`("org_id") REFERENCES "organizations" ("id") ON DELETE CASCADE`).
 		IfNotExists().
 		Exec(ctx); err != nil {
 		return err

--- a/pkg/sqlmigration/025_add_virtual_fields.go
+++ b/pkg/sqlmigration/025_add_virtual_fields.go
@@ -39,7 +39,7 @@ func (migration *addVirtualFields) Up(ctx context.Context, db *bun.DB) error {
 			UpdatedBy     string    `bun:"updated_by,type:text"`
 			Name          string    `bun:"name,type:text,notnull"`
 			Expression    string    `bun:"expression,type:text,notnull"`
-			Description   string    `bun:"description,type:text,notnull"`
+			Description   string    `bun:"description,type:text"`
 		}{}).
 		IfNotExists().
 		Exec(ctx); err != nil {

--- a/pkg/sqlmigration/025_add_virtual_fields.go
+++ b/pkg/sqlmigration/025_add_virtual_fields.go
@@ -1,0 +1,54 @@
+package sqlmigration
+
+import (
+	"context"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/migrate"
+)
+
+type addVirtualFields struct{}
+
+func NewAddVirtualFieldsFactory() factory.ProviderFactory[SQLMigration, Config] {
+	return factory.NewProviderFactory(factory.MustNewName("add_virtual_fields"), newAddVirtualFields)
+}
+
+func newAddVirtualFields(_ context.Context, _ factory.ProviderSettings, _ Config) (SQLMigration, error) {
+	return &addVirtualFields{}, nil
+}
+
+func (migration *addVirtualFields) Register(migrations *migrate.Migrations) error {
+	if err := migrations.Register(migration.Up, migration.Down); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (migration *addVirtualFields) Up(ctx context.Context, db *bun.DB) error {
+	// table:virtual_fields op:create
+	if _, err := db.NewCreateTable().
+		Model(&struct {
+			bun.BaseModel `bun:"table:virtual_fields"`
+			UUID          string    `bun:"uuid,pk,type:text"`
+			CreatedAt     time.Time `bun:"created_at,notnull"`
+			CreatedBy     string    `bun:"created_by,type:text"`
+			UpdatedAt     time.Time `bun:"updated_at,notnull"`
+			UpdatedBy     string    `bun:"updated_by,type:text"`
+			Name          string    `bun:"name,type:text,notnull"`
+			Expression    string    `bun:"expression,type:text,notnull"`
+			Description   string    `bun:"description,type:text,notnull"`
+		}{}).
+		IfNotExists().
+		Exec(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (migration *addVirtualFields) Down(ctx context.Context, db *bun.DB) error {
+	return nil
+}

--- a/pkg/types/telemetrytypes/virtualfield.go
+++ b/pkg/types/telemetrytypes/virtualfield.go
@@ -2,19 +2,20 @@ package telemetrytypes
 
 import (
 	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/uptrace/bun"
 )
 
 type VirtualField struct {
-	bun.BaseModel `bun:"table:virtual_fields"`
+	bun.BaseModel `bun:"table:virtual_field"`
 
 	types.Identifiable
 	types.TimeAuditable
 	types.UserAuditable
 
-	OrgID       string `bun:"org_id,type:text,notnull" json:"orgId"`
-	Name        string `bun:"name,type:text,notnull" json:"name"`
-	Expression  string `bun:"expression,type:text,notnull" json:"expression"`
-	Signal      Signal `bun:"signal,type:text,notnull" json:"signal"`
-	Description string `bun:"description,type:text" json:"description"`
+	Name        string      `bun:"name,type:text,notnull" json:"name"`
+	Expression  string      `bun:"expression,type:text,notnull" json:"expression"`
+	Description string      `bun:"description,type:text" json:"description"`
+	Signal      Signal      `bun:"signal,type:text,notnull" json:"signal"`
+	OrgID       valuer.UUID `bun:"org_id,type:text,notnull" json:"orgId"`
 }

--- a/pkg/types/telemetrytypes/virtualfield.go
+++ b/pkg/types/telemetrytypes/virtualfield.go
@@ -1,0 +1,20 @@
+package telemetrytypes
+
+import (
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/uptrace/bun"
+)
+
+type VirtualField struct {
+	bun.BaseModel `bun:"table:virtual_fields"`
+
+	types.Identifiable
+	types.TimeAuditable
+	types.UserAuditable
+
+	OrgID       string `bun:"org_id,type:text,notnull" json:"orgId"`
+	Name        string `bun:"name,type:text,notnull" json:"name"`
+	Expression  string `bun:"expression,type:text,notnull" json:"expression"`
+	Signal      Signal `bun:"signal,type:text,notnull" json:"signal"`
+	Description string `bun:"description,type:text,notnull" json:"description"`
+}

--- a/pkg/types/telemetrytypes/virtualfield.go
+++ b/pkg/types/telemetrytypes/virtualfield.go
@@ -16,5 +16,5 @@ type VirtualField struct {
 	Name        string `bun:"name,type:text,notnull" json:"name"`
 	Expression  string `bun:"expression,type:text,notnull" json:"expression"`
 	Signal      Signal `bun:"signal,type:text,notnull" json:"signal"`
-	Description string `bun:"description,type:text,notnull" json:"description"`
+	Description string `bun:"description,type:text" json:"description"`
 }


### PR DESCRIPTION
### Summary

Adds a new table to store the expressions used for virtual fields. The virtual field enables users to write an expression to create a new value of existing data, for example: `topLevelDomain(http.url)` named/aliased as a domain. 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add SQL migration and model for virtual fields to support user-defined data expressions.
> 
>   - **SQL Migration**:
>     - Adds `025_add_virtual_fields.go` to create `virtual_field` table with fields `Name`, `Expression`, `Description`, `Signal`, and `OrgID`.
>     - Registers `Up` and `Down` methods for migration in `addVirtualFields`.
>   - **Provider Factories**:
>     - Updates `NewSQLMigrationProviderFactories` in `provider.go` to include `NewAddVirtualFieldsFactory()`.
>     - Updates `NewTestSqliteDB` in `testutils.go` to include `NewAddVirtualFieldsFactory()`.
>   - **Models**:
>     - Adds `VirtualField` struct in `virtualfield.go` with fields `Name`, `Expression`, `Description`, `Signal`, and `OrgID`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 46584e015dd7c56ad829b4d912890df252aac736. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->