### PR TITLE
fix(status): normalize version strings to prevent false upgrade alert

### DIFF
--- a/frontend/src/utils/app.ts
+++ b/frontend/src/utils/app.ts
@@ -28,8 +28,14 @@ export const checkVersionState = (
 	currentVersion: string,
 	latestVersion: string,
 ): boolean => {
-	const versionCore = currentVersion?.split('-')[0];
-	return versionCore === latestVersion;
+	// Normalize versions by removing 'v' prefix if present
+	const normalizeVersion = (version: string): string => 
+		version?.startsWith('v') ? version.slice(1) : version;
+	
+	const currentNormalized = normalizeVersion(currentVersion?.split('-')[0]);
+	const latestNormalized = normalizeVersion(latestVersion);
+	
+	return currentNormalized === latestNormalized;
 };
 
 // list of forbidden tags to remove in dompurify


### PR DESCRIPTION
### Summary

The status page showed a false upgrade alert due to one version having a 'v' prefix (e.g., v0.76.2) and the other not (0.76.2), causing a mismatch

#### Related Issues / PR's
https://github.com/SigNoz/signoz/issues/7484

## Fix
Normalize both version strings before comparison by stripping the leading 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes false upgrade alert by normalizing version strings in `checkVersionState` in `app.ts`.
> 
>   - **Behavior**:
>     - Fixes false upgrade alert by normalizing version strings in `checkVersionState` in `app.ts`.
>     - Strips 'v' prefix from version strings before comparison.
>   - **Functions**:
>     - Adds `normalizeVersion` function within `checkVersionState` to handle version string normalization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 3efd25ed84ae3815ee8aa8c1cf12e8f18c4dff80. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->