### PR TITLE
fix(signup): redirect on invalid invitation token

### DIFF
--- a/frontend/src/pages/SignUp/SignUp.tsx
+++ b/frontend/src/pages/SignUp/SignUp.tsx
@@ -75,6 +75,16 @@ function SignUp({ version }: SignUpProps): JSX.Element {
 	const { notifications } = useNotifications();
 	const [form] = Form.useForm<FormValues>();
 
+	// Early check for invalid token
+	useEffect(() => {
+		if (token && getInviteDetailsResponse.isError) {
+			notifications.error({
+				message: 'Invalid invitation token. Please contact your admin.',
+			});
+			history.push(ROUTES.LOGIN);
+		}
+	}, [token, getInviteDetailsResponse.isError, notifications]);
+
 	useEffect(() => {
 		if (
 			getInviteDetailsResponse.status === 'success' &&
@@ -108,8 +118,10 @@ function SignUp({ version }: SignUpProps): JSX.Element {
 		) {
 			const { error } = getInviteDetailsResponse.data;
 			notifications.error({
-				message: error,
+				message: error || 'Invalid invitation token. Please contact your admin.',
 			});
+			// Redirect to login page after showing error
+			history.push(ROUTES.LOGIN);
 		}
 	}, [
 		getInviteDetailsResponse.data,


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description of what this PR does -->
Redirects users to the login page with an appropriate error message when an invalid, used, or expired invitation token is detected on the signup page. This improves the user experience by preventing interaction with an invalid signup form.

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->
Fixes #7011

#### Screenshots

NA

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->
- Affected: Signup page logic for invitation-based registration
- Manually tested:
  - Accessed signup page with invalid/expired/used token
  - Confirmed redirect to login page with error message

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Redirects users with invalid invitation tokens to the login page with an error message in `SignUp.tsx`.
> 
>   - **Behavior**:
>     - Redirects users to login page with error message for invalid/used/expired invitation tokens in `SignUp.tsx`.
>     - Uses `useEffect` to check `getInviteDetailsResponse.isError` and `getInviteDetailsResponse.data.error` for token validity.
>   - **Notifications**:
>     - Displays error message using `notifications.error()` for invalid tokens.
>   - **Routing**:
>     - Utilizes `history.push(ROUTES.LOGIN)` to redirect users.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 43f21bc26de07e7f211f9c08e08d2cb1b3715d28. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->