### PR TITLE
fix: missing receivers in json payload for legacy postableAlert

### DIFF
--- a/pkg/alertmanager/legacyalertmanager/provider.go
+++ b/pkg/alertmanager/legacyalertmanager/provider.go
@@ -25,6 +25,25 @@ type postableAlert struct {
 	Receivers []string `json:"receivers"`
 }
 
+func (pa *postableAlert) MarshalJSON() ([]byte, error) {
+	// Marshal the embedded PostableAlert to get its JSON representation.
+	alertJSON, err := json.Marshal(pa.PostableAlert)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal that JSON into a map so we can add extra fields.
+	var m map[string]interface{}
+	if err := json.Unmarshal(alertJSON, &m); err != nil {
+		return nil, err
+	}
+
+	// Add the Receivers field.
+	m["receivers"] = pa.Receivers
+
+	return json.Marshal(m)
+}
+
 const (
 	alertsPath       string = "/v1/alerts"
 	routesPath       string = "/v1/routes"

--- a/pkg/alertmanager/legacyalertmanager/provider_test.go
+++ b/pkg/alertmanager/legacyalertmanager/provider_test.go
@@ -1,0 +1,35 @@
+package legacyalertmanager
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
+	"github.com/prometheus/alertmanager/api/v2/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProvider_TestAlert(t *testing.T) {
+	pa := &postableAlert{
+		PostableAlert: &alertmanagertypes.PostableAlert{
+			Alert: models.Alert{
+				Labels: models.LabelSet{
+					"alertname": "test",
+				},
+				GeneratorURL: "http://localhost:9090/graph?g0.expr=up&g0.tab=1",
+			},
+			Annotations: models.LabelSet{
+				"summary": "test",
+			},
+		},
+		Receivers: []string{"receiver1", "receiver2"},
+	}
+
+	body, err := json.Marshal(pa)
+	if err != nil {
+		t.Fatalf("failed to marshal postable alert: %v", err)
+	}
+
+	assert.Contains(t, string(body), "receiver1")
+	assert.Contains(t, string(body), "receiver2")
+}


### PR DESCRIPTION
### Summary

```go
type postableAlert struct {
	*alertmanagertypes.PostableAlert
	Receivers []string `json:"receivers"`
}
```


We embed a pointer to a `alertmanagertypes.PostableAlert` type from the types package. If that embedded type implements a custom MarshalJSON method (which it does), then the JSON encoder will call that method to produce its output. When that happens, the resulting JSON is taken as is—and it won’t merge in any additional top‐level fields (like the Receivers field) from the outer struct.

That effectively never sent the Recivers in the payload, resulting in notifications sent to channels that are not configured.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes missing `Receivers` in JSON payload for `postableAlert` by implementing custom `MarshalJSON` method.
> 
>   - **Behavior**:
>     - Implements `MarshalJSON()` for `postableAlert` in `provider.go` to include `Receivers` in JSON payload.
>     - Fixes issue where `Receivers` were not sent, causing alerts to be sent to incorrect channels.
>   - **Testing**:
>     - Adds `TestProvider_TestAlert` in `provider_test.go` to verify `Receivers` are included in JSON payload.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 8b740aa80ad339c6b123d5c129b6814b93904b8e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->