### PR TITLE
chore(prereleaser): update cron schedule - 6:30AM UTC

### DIFF
--- a/.github/workflows/prereleaser.yaml
+++ b/.github/workflows/prereleaser.yaml
@@ -1,9 +1,9 @@
 name: prereleaser
 
 on:
-  # schedule every wednesday 9:30 AM UTC (3pm IST)
+  # schedule every wednesday 6:30 AM UTC (12:00 PM IST)
   schedule:
-    - cron: '30 9 * * 3'
+    - cron: '30 6 * * 3'
 
   # allow manual triggering of the workflow by a maintainer
   workflow_dispatch:


### PR DESCRIPTION
### Summary

- update preleaser cron schedule to 6:30AM UTC

#### Related Issues / PR's

NA

#### Screenshots

NA

#### Affected Areas and Manually Tested Areas

NA
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update cron schedule in `prereleaser.yaml` to 6:30 AM UTC every Wednesday.
> 
>   - **Schedule Update**:
>     - Update cron schedule in `prereleaser.yaml` from 9:30 AM UTC to 6:30 AM UTC every Wednesday.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 0c912e3cd75ac0f8174506799aed64ab30275f9f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->