### PR TITLE
chore: log original query failed to transform

### DIFF
--- a/pkg/query-service/app/parser.go
+++ b/pkg/query-service/app/parser.go
@@ -877,7 +877,7 @@ func chTransformQuery(query string, variables map[string]interface{}) {
 	transformer := chVariables.NewQueryTransformer(query, varsForTransform)
 	transformedQuery, err := transformer.Transform()
 	if err != nil {
-		zap.L().Warn("failed to transform clickhouse query", zap.Error(err))
+		zap.L().Warn("failed to transform clickhouse query", zap.String("query", query), zap.Error(err))
 	}
 	zap.L().Info("transformed clickhouse query", zap.String("transformedQuery", transformedQuery), zap.String("originalQuery", query))
 }


### PR DESCRIPTION
### Summary

Helps in understand the kind of the queries we need to address with parser.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Log original query in `chTransformQuery` when transformation fails in `parser.go`.
> 
>   - **Logging**:
>     - In `chTransformQuery` function in `parser.go`, log the original query string when transformation fails, aiding in debugging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 9ea711493cc52ad5b9cf03b7eb2c183033a8af28. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->