### PR TITLE
fix: boolean values are not shown in the list panel's column

### DIFF
--- a/frontend/src/container/TracesExplorer/ListView/utils.tsx
+++ b/frontend/src/container/TracesExplorer/ListView/utils.tsx
@@ -6,7 +6,6 @@ import { getMs } from 'container/Trace/Filters/Panel/PanelBody/Duration/util';
 import { formUrlParams } from 'container/TraceDetail/utils';
 import { TimestampInput } from 'hooks/useTimezoneFormatter/useTimezoneFormatter';
 import { RowData } from 'lib/query/createTableColumnsFromQuery';
-import { isBoolean } from 'lodash-es';
 import LineClampedText from 'periscope/components/LineClampedText/LineClampedText';
 import { Link } from 'react-router-dom';
 import { ILog } from 'types/api/logs/log';
@@ -116,10 +115,7 @@ export const getListColumns = (
 				return (
 					<BlockLink to={getTraceLink(item)} openInNewTab={false}>
 						<Typography data-testid={key}>
-							<LineClampedText
-								text={isBoolean(value) ? String(value) : value}
-								lines={3}
-							/>
+							<LineClampedText text={value} lines={3} />
 						</Typography>
 					</BlockLink>
 				);

--- a/frontend/src/container/TracesExplorer/ListView/utils.tsx
+++ b/frontend/src/container/TracesExplorer/ListView/utils.tsx
@@ -6,6 +6,7 @@ import { getMs } from 'container/Trace/Filters/Panel/PanelBody/Duration/util';
 import { formUrlParams } from 'container/TraceDetail/utils';
 import { TimestampInput } from 'hooks/useTimezoneFormatter/useTimezoneFormatter';
 import { RowData } from 'lib/query/createTableColumnsFromQuery';
+import { isBoolean } from 'lodash-es';
 import LineClampedText from 'periscope/components/LineClampedText/LineClampedText';
 import { Link } from 'react-router-dom';
 import { ILog } from 'types/api/logs/log';
@@ -115,7 +116,10 @@ export const getListColumns = (
 				return (
 					<BlockLink to={getTraceLink(item)} openInNewTab={false}>
 						<Typography data-testid={key}>
-							<LineClampedText text={value} lines={3} />
+							<LineClampedText
+								text={isBoolean(value) ? String(value) : value}
+								lines={3}
+							/>
 						</Typography>
 					</BlockLink>
 				);

--- a/frontend/src/periscope/components/LineClampedText/LineClampedText.tsx
+++ b/frontend/src/periscope/components/LineClampedText/LineClampedText.tsx
@@ -1,6 +1,7 @@
 import './LineClampedText.styles.scss';
 
 import { Tooltip, TooltipProps } from 'antd';
+import { isBoolean } from 'lodash-es';
 import { useEffect, useRef, useState } from 'react';
 
 function LineClampedText({
@@ -40,7 +41,7 @@ function LineClampedText({
 				WebkitLineClamp: lines,
 			}}
 		>
-			{text}
+			{isBoolean(text) ? String(text) : text}
 		</div>
 	);
 

--- a/frontend/src/periscope/components/LineClampedText/LineClampedText.tsx
+++ b/frontend/src/periscope/components/LineClampedText/LineClampedText.tsx
@@ -9,7 +9,7 @@ function LineClampedText({
 	lines,
 	tooltipProps,
 }: {
-	text: string;
+	text: string | boolean;
 	lines?: number;
 	tooltipProps?: TooltipProps;
 }): JSX.Element {

--- a/frontend/src/periscope/components/LineClampedText/__test__/LineClampedText.test.tsx
+++ b/frontend/src/periscope/components/LineClampedText/__test__/LineClampedText.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+
+import LineClampedText from '../LineClampedText';
+
+// Mock the useRef and useState hooks for overflow testing
+jest.mock('react', () => {
+	const originalReact = jest.requireActual('react');
+	return {
+		...originalReact,
+		useRef: jest.fn(() => ({
+			current: {
+				scrollHeight: 100,
+				clientHeight: 50, // This will simulate overflow
+			},
+		})),
+		useState: jest.fn((initialValue) => [initialValue, jest.fn()]),
+		useEffect: jest.fn((cb) => cb()),
+	};
+});
+
+describe('LineClampedText', () => {
+	// Reset all mocks after each test
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('renders string text correctly', () => {
+		const text = 'Test text';
+		render(<LineClampedText text={text} />);
+
+		expect(screen.getByText(text)).toBeInTheDocument();
+	});
+
+	it('renders empty string correctly', () => {
+		const { container } = render(<LineClampedText text="" />);
+
+		// For empty strings, we need to check that a div exists
+		// but it's harder to check for empty text directly with queries
+		expect(container.textContent).toBe('');
+	});
+
+	it('renders boolean text correctly - true', () => {
+		render(<LineClampedText text />);
+
+		expect(screen.getByText('true')).toBeInTheDocument();
+	});
+
+	it('renders boolean text correctly - false', () => {
+		render(<LineClampedText text={false} />);
+
+		expect(screen.getByText('false')).toBeInTheDocument();
+	});
+
+	it('applies line clamping with provided lines prop', () => {
+		const text = 'Test text with multiple lines';
+		const lines = 2;
+
+		render(<LineClampedText text={text} lines={lines} />);
+
+		// Verify the text is rendered correctly
+		expect(screen.getByText(text)).toBeInTheDocument();
+
+		// Verify the component received the correct props
+		expect(LineClampedText.defaultProps?.lines).toBe(1);
+	});
+
+	it('uses default line count of 1 when lines prop is not provided', () => {
+		const text = 'Test text';
+
+		render(<LineClampedText text={text} />);
+
+		// Verify the text is rendered correctly
+		expect(screen.getByText(text)).toBeInTheDocument();
+
+		// Verify the default props
+		expect(LineClampedText.defaultProps?.lines).toBe(1);
+	});
+});

--- a/frontend/src/periscope/components/LineClampedText/__test__/LineClampedText.test.tsx
+++ b/frontend/src/periscope/components/LineClampedText/__test__/LineClampedText.test.tsx
@@ -2,22 +2,6 @@ import { render, screen } from '@testing-library/react';
 
 import LineClampedText from '../LineClampedText';
 
-// Mock the useRef and useState hooks for overflow testing
-jest.mock('react', () => {
-	const originalReact = jest.requireActual('react');
-	return {
-		...originalReact,
-		useRef: jest.fn(() => ({
-			current: {
-				scrollHeight: 100,
-				clientHeight: 50, // This will simulate overflow
-			},
-		})),
-		useState: jest.fn((initialValue) => [initialValue, jest.fn()]),
-		useEffect: jest.fn((cb) => cb()),
-	};
-});
-
 describe('LineClampedText', () => {
 	// Reset all mocks after each test
 	afterEach(() => {
@@ -61,7 +45,9 @@ describe('LineClampedText', () => {
 		expect(screen.getByText(text)).toBeInTheDocument();
 
 		// Verify the component received the correct props
-		expect(LineClampedText.defaultProps?.lines).toBe(1);
+		expect((screen.getByText(text).style as any).WebkitLineClamp).toBe(
+			String(lines),
+		);
 	});
 
 	it('uses default line count of 1 when lines prop is not provided', () => {


### PR DESCRIPTION
### Summary

Added test cases - 
<img width="711" alt="image" src="https://github.com/user-attachments/assets/e6c9eb22-95fd-4fa1-9b2b-ce1971c3a97e" />

#### Related Issues / PR's

 - Pylon - https://signoz-team.slack.com/archives/C075R3X4S04/p1744841450070519

#### Screenshots

After:
-------
<img width="1720" alt="Screenshot 2025-04-18 at 6 59 41 AM" src="https://github.com/user-attachments/assets/c09368da-332d-4123-94f7-cbfba7dc6071" />

Before:
-------
<img width="1728" alt="Screenshot 2025-04-18 at 6 40 26 AM" src="https://github.com/user-attachments/assets/35761861-4690-4ccb-91c0-a0e5d56022e8" />


#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes boolean display issue in `LineClampedText` by supporting boolean `text` prop and adds tests for various text types.
> 
>   - **Behavior**:
>     - `LineClampedText` component now supports `boolean` type for `text` prop, converting booleans to strings for display.
>     - Fixes issue where boolean values were not shown in the list panel's column.
>   - **Testing**:
>     - Adds `LineClampedText.test.tsx` to test rendering of string, empty string, and boolean values.
>     - Verifies line clamping functionality and default line count behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 0d764e182825cd0ec843b2bf76836548cf176e43. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->