### PR TITLE
Fix error rate for Third Party API

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -5600,7 +5600,7 @@ func (aH *APIHandler) getDomainList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result = postprocess.TransformToTableForBuilderQueries(result, queryRangeParams)
+	result, err = postprocess.PostProcessResult(result, queryRangeParams)
 
 	if !thirdPartyQueryRequest.ShowIp {
 		result = thirdPartyApi.FilterResponse(result)

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -5601,6 +5601,11 @@ func (aH *APIHandler) getDomainList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result, err = postprocess.PostProcessResult(result, queryRangeParams)
+	if err != nil {
+		apiErrObj := &model.ApiError{Typ: model.ErrorBadData, Err: err}
+		RespondError(w, apiErrObj, errQuriesByName)
+		return
+	}
 
 	if !thirdPartyQueryRequest.ShowIp {
 		result = thirdPartyApi.FilterResponse(result)

--- a/pkg/query-service/app/integrations/thirdPartyApi/translator.go
+++ b/pkg/query-service/app/integrations/thirdPartyApi/translator.go
@@ -58,6 +58,7 @@ func BuildDomainList(thirdPartyApis *ThirdPartyApis) (*v3.QueryRangeParamsV3, er
 
 	builderQueries["endpoints"] = &v3.BuilderQuery{
 		QueryName:         "endpoints",
+		Legend:            "endpoints",
 		DataSource:        v3.DataSourceTraces,
 		StepInterval:      defaultStepInterval,
 		AggregateOperator: v3.AggregateOperatorCountDistinct,
@@ -91,11 +92,14 @@ func BuildDomainList(thirdPartyApis *ThirdPartyApis) (*v3.QueryRangeParamsV3, er
 				Type:     v3.AttributeKeyTypeTag,
 			},
 		}, thirdPartyApis.GroupBy),
-		ReduceTo: v3.ReduceToOperatorAvg,
+		ReduceTo:  v3.ReduceToOperatorAvg,
+		ShiftBy:   0,
+		IsAnomaly: false,
 	}
 
 	builderQueries["lastseen"] = &v3.BuilderQuery{
 		QueryName:         "lastseen",
+		Legend:            "lastseen",
 		DataSource:        v3.DataSourceTraces,
 		StepInterval:      defaultStepInterval,
 		AggregateOperator: v3.AggregateOperatorMax,
@@ -127,11 +131,14 @@ func BuildDomainList(thirdPartyApis *ThirdPartyApis) (*v3.QueryRangeParamsV3, er
 				Type:     v3.AttributeKeyTypeTag,
 			},
 		}, thirdPartyApis.GroupBy),
-		ReduceTo: v3.ReduceToOperatorAvg,
+		ReduceTo:  v3.ReduceToOperatorAvg,
+		ShiftBy:   0,
+		IsAnomaly: false,
 	}
 
 	builderQueries["rps"] = &v3.BuilderQuery{
 		QueryName:         "rps",
+		Legend:            "rps",
 		DataSource:        v3.DataSourceTraces,
 		StepInterval:      defaultStepInterval,
 		AggregateOperator: v3.AggregateOperatorRate,
@@ -163,18 +170,22 @@ func BuildDomainList(thirdPartyApis *ThirdPartyApis) (*v3.QueryRangeParamsV3, er
 				Type:     v3.AttributeKeyTypeTag,
 			},
 		}, thirdPartyApis.GroupBy),
-		ReduceTo: v3.ReduceToOperatorAvg,
+		ReduceTo:  v3.ReduceToOperatorAvg,
+		ShiftBy:   0,
+		IsAnomaly: false,
 	}
 
-	builderQueries["error_rate"] = &v3.BuilderQuery{
-		QueryName:         "error_rate",
+	builderQueries["error"] = &v3.BuilderQuery{
+		QueryName:         "error",
 		DataSource:        v3.DataSourceTraces,
 		StepInterval:      defaultStepInterval,
-		AggregateOperator: v3.AggregateOperatorRate,
+		AggregateOperator: v3.AggregateOperatorCountDistinct,
 		AggregateAttribute: v3.AttributeKey{
-			Key: "",
+			Key:      "span_id",
+			DataType: v3.AttributeKeyDataTypeString,
+			IsColumn: true,
 		},
-		TimeAggregation:  v3.TimeAggregationRate,
+		TimeAggregation:  v3.TimeAggregationCountDistinct,
 		SpaceAggregation: v3.SpaceAggregationSum,
 		Filters: &v3.FilterSet{
 			Operator: "AND",
@@ -200,7 +211,7 @@ func BuildDomainList(thirdPartyApis *ThirdPartyApis) (*v3.QueryRangeParamsV3, er
 				},
 			}, thirdPartyApis.Filters),
 		},
-		Expression: "error_rate",
+		Expression: "error",
 		GroupBy: getGroupBy([]v3.AttributeKey{
 			{
 				Key:      "net.peer.name",
@@ -208,11 +219,56 @@ func BuildDomainList(thirdPartyApis *ThirdPartyApis) (*v3.QueryRangeParamsV3, er
 				Type:     v3.AttributeKeyTypeTag,
 			},
 		}, thirdPartyApis.GroupBy),
-		ReduceTo: v3.ReduceToOperatorAvg,
+		ReduceTo:  v3.ReduceToOperatorAvg,
+		Disabled:  true,
+		ShiftBy:   0,
+		IsAnomaly: false,
+	}
+
+	builderQueries["total_span"] = &v3.BuilderQuery{
+		QueryName:         "total_span",
+		DataSource:        v3.DataSourceTraces,
+		StepInterval:      defaultStepInterval,
+		AggregateOperator: v3.AggregateOperatorCountDistinct,
+		AggregateAttribute: v3.AttributeKey{
+			Key:      "span_id",
+			DataType: v3.AttributeKeyDataTypeString,
+			IsColumn: true,
+		},
+		TimeAggregation:  v3.TimeAggregationCountDistinct,
+		SpaceAggregation: v3.SpaceAggregationSum,
+		Filters: &v3.FilterSet{
+			Operator: "AND",
+			Items: getFilterSet([]v3.FilterItem{
+				{
+					Key: v3.AttributeKey{
+						Key:      "http.url",
+						DataType: v3.AttributeKeyDataTypeString,
+						IsColumn: false,
+						Type:     v3.AttributeKeyTypeTag,
+					},
+					Operator: v3.FilterOperatorExists,
+					Value:    "",
+				},
+			}, thirdPartyApis.Filters),
+		},
+		Expression: "total_span",
+		GroupBy: getGroupBy([]v3.AttributeKey{
+			{
+				Key:      "net.peer.name",
+				DataType: v3.AttributeKeyDataTypeString,
+				Type:     v3.AttributeKeyTypeTag,
+			},
+		}, thirdPartyApis.GroupBy),
+		ReduceTo:  v3.ReduceToOperatorAvg,
+		Disabled:  true,
+		ShiftBy:   0,
+		IsAnomaly: false,
 	}
 
 	builderQueries["p99"] = &v3.BuilderQuery{
 		QueryName:         "p99",
+		Legend:            "p99",
 		DataSource:        v3.DataSourceTraces,
 		StepInterval:      defaultStepInterval,
 		AggregateOperator: v3.AggregateOperatorP99,
@@ -246,7 +302,18 @@ func BuildDomainList(thirdPartyApis *ThirdPartyApis) (*v3.QueryRangeParamsV3, er
 				Type:     v3.AttributeKeyTypeTag,
 			},
 		}, thirdPartyApis.GroupBy),
-		ReduceTo: v3.ReduceToOperatorAvg,
+		ReduceTo:  v3.ReduceToOperatorAvg,
+		ShiftBy:   0,
+		IsAnomaly: false,
+	}
+
+	builderQueries["error_rate"] = &v3.BuilderQuery{
+		QueryName:  "error_rate",
+		Expression: "(error/total_span)*100",
+		Legend:     "error_rate",
+		Disabled:   false,
+		ShiftBy:    0,
+		IsAnomaly:  false,
 	}
 
 	compositeQuery := &v3.CompositeQuery{


### PR DESCRIPTION
Related to https://github.com/SigNoz/signoz/issues/6815

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor error rate calculation in `translator.go` by introducing separate `errors` and `total_spans` queries and a new `error_rate` query.
> 
>   - **Behavior**:
>     - Replaces `error_rate` query with separate `errors` and `total_spans` queries in `BuildDomainList()`.
>     - New `error_rate` query calculates as `(errors/total_spans)*100`.
>     - `errors` and `total_spans` queries are disabled by default.
>   - **Queries**:
>     - `errors` query uses `AggregateOperatorCountDistinct` on `span_id` with `has_error` filter.
>     - `total_spans` query uses `AggregateOperatorCountDistinct` on `span_id`.
>     - `error_rate` query is enabled and uses the expression `(errors/total_spans)*100`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for c58f2974d9e0ff21350022c1db1c77d6af5c23a1. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->