### PR TITLE
feat: adds a part of trace funnel feature (APIs, module, handler, store, migrations) implementation 

### DIFF
--- a/ee/query-service/app/server.go
+++ b/ee/query-service/app/server.go
@@ -327,6 +327,7 @@ func (s *Server) createPublicServer(apiHandler *api.APIHandler, web web.Web) (*h
 	apiHandler.RegisterMessagingQueuesRoutes(r, am)
 	apiHandler.RegisterThirdPartyApiRoutes(r, am)
 	apiHandler.MetricExplorerRoutes(r, am)
+	apiHandler.RegisterTraceFunnelsRoutes(r, am)
 
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},

--- a/pkg/modules/tracefunnel/impltracefunnel/handler.go
+++ b/pkg/modules/tracefunnel/impltracefunnel/handler.go
@@ -1,0 +1,453 @@
+package impltracefunnel
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/http/render"
+	"github.com/SigNoz/signoz/pkg/modules/tracefunnel"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	tf "github.com/SigNoz/signoz/pkg/types/tracefunnel"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/gorilla/mux"
+)
+
+type handler struct {
+	module tracefunnel.Module
+}
+
+func NewHandler(module tracefunnel.Module) tracefunnel.Handler {
+	return &handler{module: module}
+}
+
+func (handler *handler) New(rw http.ResponseWriter, r *http.Request) {
+	var req tf.FunnelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	claims, err := authtypes.ClaimsFromContext(r.Context())
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+	userID := claims.UserID
+	orgID := claims.OrgID
+
+	funnels, err := handler.module.List(r.Context(), orgID)
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	for _, f := range funnels {
+		if f.Name == req.Name {
+			render.Error(rw,
+				errors.Newf(errors.TypeInvalidInput,
+					errors.CodeInvalidInput,
+					"a funnel with name '%s' already exists in this organization",
+					req.Name))
+			return
+		}
+	}
+
+	funnel, err := handler.module.Create(r.Context(), req.Timestamp, req.Name, userID, orgID)
+	if err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"failed to create funnel"))
+		return
+	}
+
+	response := tf.FunnelResponse{
+		FunnelID:   funnel.ID.String(),
+		FunnelName: funnel.Name,
+		CreatedAt:  req.Timestamp,
+		UserEmail:  claims.Email,
+		OrgID:      orgID,
+	}
+
+	render.Success(rw, http.StatusOK, response)
+}
+
+func (handler *handler) UpdateSteps(rw http.ResponseWriter, r *http.Request) {
+	var req tf.FunnelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	claims, err := authtypes.ClaimsFromContext(r.Context())
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+	userID := claims.UserID
+	orgID := claims.OrgID
+
+	if err := tracefunnel.ValidateTimestamp(req.Timestamp, "timestamp"); err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"timestamp is invalid: %v", err))
+		return
+	}
+
+	funnel, err := handler.module.Get(r.Context(), req.FunnelID.String())
+	if err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"funnel not found: %v", err))
+		return
+	}
+
+	// Check if name is being updated and if it already exists
+	if req.Name != "" && req.Name != funnel.Name {
+		funnels, err := handler.module.List(r.Context(), orgID)
+		if err != nil {
+			render.Error(rw,
+				errors.Newf(errors.TypeInvalidInput,
+					errors.CodeInvalidInput,
+					"failed to list funnels: %v", err))
+			return
+		}
+
+		for _, f := range funnels {
+			if f.Name == req.Name {
+				render.Error(rw,
+					errors.Newf(errors.TypeInvalidInput,
+						errors.CodeInvalidInput,
+						"a funnel with name '%s' already exists in this organization", req.Name))
+				return
+			}
+		}
+	}
+
+	// Process each step in the request
+	for i := range req.Steps {
+		if req.Steps[i].Order < 1 {
+			req.Steps[i].Order = int64(i + 1) // Default to sequential ordering if not specified
+		}
+		// Generate a new UUID for the step if it doesn't have one
+		if req.Steps[i].Id.IsZero() {
+			newUUID := valuer.GenerateUUID()
+			req.Steps[i].Id = newUUID
+		}
+	}
+
+	if err := tracefunnel.ValidateFunnelSteps(req.Steps); err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"invalid funnel steps: %v", err))
+		return
+	}
+
+	// Normalize step orders
+	req.Steps = tracefunnel.NormalizeFunnelSteps(req.Steps)
+
+	// Update the funnel with new steps
+	funnel.Steps = req.Steps
+	funnel.UpdatedAt = time.Unix(0, req.Timestamp*1000000) // Convert to nanoseconds
+	funnel.UpdatedBy = userID
+
+	if req.Name != "" {
+		funnel.Name = req.Name
+	}
+	if req.Description != "" {
+		funnel.Description = req.Description
+	}
+
+	// Update funnel in database
+	err = handler.module.Update(r.Context(), funnel, userID)
+	if err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"failed to update funnel in database: %v", err))
+		return
+	}
+
+	// Get the updated funnel to return in response
+	updatedFunnel, err := handler.module.Get(r.Context(), funnel.ID.String())
+	if err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"failed to get updated funnel: %v", err))
+		return
+	}
+
+	response := tf.FunnelResponse{
+		FunnelName:  updatedFunnel.Name,
+		FunnelID:    updatedFunnel.ID.String(),
+		Steps:       updatedFunnel.Steps,
+		CreatedAt:   updatedFunnel.CreatedAt.UnixNano() / 1000000,
+		CreatedBy:   updatedFunnel.CreatedBy,
+		OrgID:       updatedFunnel.OrgID.String(),
+		UpdatedBy:   userID,
+		UpdatedAt:   updatedFunnel.UpdatedAt.UnixNano() / 1000000,
+		Description: updatedFunnel.Description,
+		UserEmail:   claims.Email,
+	}
+
+	render.Success(rw, http.StatusOK, response)
+}
+
+func (handler *handler) UpdateFunnel(rw http.ResponseWriter, r *http.Request) {
+	var req tf.FunnelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	claims, err := authtypes.ClaimsFromContext(r.Context())
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+	userID := claims.UserID
+	orgID := claims.OrgID
+
+	if err := tracefunnel.ValidateTimestamp(req.Timestamp, "timestamp"); err != nil {
+		render.Error(rw, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "timestamp is invalid: %v", err))
+		return
+	}
+	vars := mux.Vars(r)
+	funnelID := vars["funnel_id"]
+
+	funnel, err := handler.module.Get(r.Context(), funnelID)
+	if err != nil {
+		render.Error(rw, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "funnel not found: %v", err))
+		return
+	}
+
+	// Check if name is being updated and if it already exists
+	if req.Name != "" && req.Name != funnel.Name {
+		funnels, err := handler.module.List(r.Context(), orgID)
+		if err != nil {
+			render.Error(rw, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "failed to list funnels: %v", err))
+			return
+		}
+
+		for _, f := range funnels {
+			if f.Name == req.Name {
+				render.Error(rw, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "a funnel with name '%s' already exists in this organization", req.Name))
+				return
+			}
+		}
+	}
+
+	funnel.UpdatedAt = time.Unix(0, req.Timestamp*1000000) // Convert to nanoseconds
+	funnel.UpdatedBy = userID
+
+	if req.Name != "" {
+		funnel.Name = req.Name
+	}
+	if req.Description != "" {
+		funnel.Description = req.Description
+	}
+
+	err = handler.module.Update(r.Context(), funnel, userID)
+	if err != nil {
+		render.Error(rw, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "failed to update funnel in database: %v", err))
+		return
+	}
+
+	// Get the updated funnel to return in response
+	updatedFunnel, err := handler.module.Get(r.Context(), funnel.ID.String())
+	if err != nil {
+		render.Error(rw, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "failed to get updated funnel: %v", err))
+		return
+	}
+
+	response := tf.FunnelResponse{
+		FunnelName:  updatedFunnel.Name,
+		FunnelID:    updatedFunnel.ID.String(),
+		Steps:       updatedFunnel.Steps,
+		CreatedAt:   updatedFunnel.CreatedAt.UnixNano() / 1000000,
+		CreatedBy:   updatedFunnel.CreatedBy,
+		OrgID:       updatedFunnel.OrgID.String(),
+		UpdatedBy:   userID,
+		UpdatedAt:   updatedFunnel.UpdatedAt.UnixNano() / 1000000,
+		Description: updatedFunnel.Description,
+		UserEmail:   claims.Email,
+	}
+
+	render.Success(rw, http.StatusOK, response)
+}
+
+func (handler *handler) List(rw http.ResponseWriter, r *http.Request) {
+	claims, err := authtypes.ClaimsFromContext(r.Context())
+	if err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"unauthenticated"))
+		return
+	}
+
+	orgID := claims.OrgID
+	funnels, err := handler.module.List(r.Context(), orgID)
+	if err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"failed to list funnels: %v", err))
+		return
+	}
+
+	var response []tf.FunnelResponse
+	for _, f := range funnels {
+		funnelResp := tf.FunnelResponse{
+			FunnelName:  f.Name,
+			FunnelID:    f.ID.String(),
+			CreatedAt:   f.CreatedAt.UnixNano() / 1000000,
+			CreatedBy:   f.CreatedBy,
+			OrgID:       f.OrgID.String(),
+			UpdatedAt:   f.UpdatedAt.UnixNano() / 1000000,
+			UpdatedBy:   f.UpdatedBy,
+			Description: f.Description,
+		}
+
+		// Get user email if available
+		if f.CreatedByUser != nil {
+			funnelResp.UserEmail = f.CreatedByUser.Email
+		}
+
+		response = append(response, funnelResp)
+	}
+
+	render.Success(rw, http.StatusOK, response)
+}
+
+func (handler *handler) Get(rw http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	funnelID := vars["funnel_id"]
+
+	funnel, err := handler.module.Get(r.Context(), funnelID)
+	if err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"funnel not found: %v", err))
+		return
+	}
+
+	response := tf.FunnelResponse{
+		FunnelID:    funnel.ID.String(),
+		FunnelName:  funnel.Name,
+		Description: funnel.Description,
+		CreatedAt:   funnel.CreatedAt.UnixNano() / 1000000,
+		UpdatedAt:   funnel.UpdatedAt.UnixNano() / 1000000,
+		CreatedBy:   funnel.CreatedBy,
+		UpdatedBy:   funnel.UpdatedBy,
+		OrgID:       funnel.OrgID.String(),
+		Steps:       funnel.Steps,
+	}
+
+	if funnel.CreatedByUser != nil {
+		response.UserEmail = funnel.CreatedByUser.Email
+	}
+
+	render.Success(rw, http.StatusOK, response)
+}
+
+func (handler *handler) Delete(rw http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	funnelID := vars["funnel_id"]
+
+	err := handler.module.Delete(r.Context(), funnelID)
+	if err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"failed to delete funnel: %v", err))
+		return
+	}
+
+	render.Success(rw, http.StatusOK, nil)
+}
+
+func (handler *handler) Save(rw http.ResponseWriter, r *http.Request) {
+	var req tf.FunnelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"invalid request: %v", err))
+		return
+	}
+
+	claims, err := authtypes.ClaimsFromContext(r.Context())
+	if err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"unauthenticated"))
+		return
+	}
+	orgID := claims.OrgID
+	usrID := claims.UserID
+
+	funnel, err := handler.module.Get(r.Context(), req.FunnelID.String())
+	if err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"funnel not found: %v", err))
+		return
+	}
+
+	updateTimestamp := req.Timestamp
+	if updateTimestamp == 0 {
+		updateTimestamp = time.Now().UnixMilli()
+	} else if !tracefunnel.ValidateTimestampIsMilliseconds(updateTimestamp) {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"timestamp must be in milliseconds format (13 digits)"))
+		return
+	}
+	funnel.UpdatedAt = time.Unix(0, updateTimestamp*1000000) // Convert to nanoseconds
+
+	if req.UserID != "" {
+		funnel.UpdatedBy = usrID
+	}
+
+	funnel.Description = req.Description
+
+	if err := handler.module.Save(r.Context(), funnel, funnel.UpdatedBy, orgID); err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"failed to save funnel: %v", err))
+		return
+	}
+
+	createdAt, updatedAt, extraDataFromDB, err := handler.module.GetFunnelMetadata(r.Context(), funnel.ID.String())
+	if err != nil {
+		render.Error(rw,
+			errors.Newf(errors.TypeInvalidInput,
+				errors.CodeInvalidInput,
+				"failed to get funnel metadata: %v", err))
+		return
+	}
+
+	resp := tf.FunnelResponse{
+		FunnelName:  funnel.Name,
+		CreatedAt:   createdAt,
+		UpdatedAt:   updatedAt,
+		CreatedBy:   funnel.CreatedBy,
+		UpdatedBy:   funnel.UpdatedBy,
+		OrgID:       funnel.OrgID.String(),
+		Description: extraDataFromDB,
+	}
+
+	render.Success(rw, http.StatusOK, resp)
+}

--- a/pkg/modules/tracefunnel/impltracefunnel/handler_test.go
+++ b/pkg/modules/tracefunnel/impltracefunnel/handler_test.go
@@ -1,0 +1,415 @@
+package impltracefunnel
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	traceFunnels "github.com/SigNoz/signoz/pkg/types/tracefunnel"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockModule struct {
+	mock.Mock
+}
+
+func (m *MockModule) Create(ctx context.Context, timestamp int64, name string, userID string, orgID string) (*traceFunnels.Funnel, error) {
+	args := m.Called(ctx, timestamp, name, userID, orgID)
+	return args.Get(0).(*traceFunnels.Funnel), args.Error(1)
+}
+
+func (m *MockModule) Get(ctx context.Context, funnelID string) (*traceFunnels.Funnel, error) {
+	args := m.Called(ctx, funnelID)
+	return args.Get(0).(*traceFunnels.Funnel), args.Error(1)
+}
+
+func (m *MockModule) Update(ctx context.Context, funnel *traceFunnels.Funnel, userID string) error {
+	args := m.Called(ctx, funnel, userID)
+	return args.Error(0)
+}
+
+func (m *MockModule) List(ctx context.Context, orgID string) ([]*traceFunnels.Funnel, error) {
+	args := m.Called(ctx, orgID)
+	return args.Get(0).([]*traceFunnels.Funnel), args.Error(1)
+}
+
+func (m *MockModule) Delete(ctx context.Context, funnelID string) error {
+	args := m.Called(ctx, funnelID)
+	return args.Error(0)
+}
+
+func (m *MockModule) Save(ctx context.Context, funnel *traceFunnels.Funnel, userID string, orgID string) error {
+	args := m.Called(ctx, funnel, userID, orgID)
+	return args.Error(0)
+}
+
+func (m *MockModule) GetFunnelMetadata(ctx context.Context, funnelID string) (int64, int64, string, error) {
+	args := m.Called(ctx, funnelID)
+	return args.Get(0).(int64), args.Get(1).(int64), args.String(2), args.Error(3)
+}
+
+func TestHandler_New(t *testing.T) {
+	mockModule := new(MockModule)
+	handler := NewHandler(mockModule)
+
+	reqBody := traceFunnels.FunnelRequest{
+		Name:      "test-funnel",
+		Timestamp: time.Now().UnixMilli(),
+	}
+
+	jsonBody, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/trace-funnels/new", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	orgID := valuer.GenerateUUID().String()
+	claims := authtypes.Claims{
+		UserID: "user-123",
+		OrgID:  orgID,
+		Email:  "test@example.com",
+	}
+	req = req.WithContext(authtypes.NewContextWithClaims(req.Context(), claims))
+
+	rr := httptest.NewRecorder()
+
+	funnelID := valuer.GenerateUUID()
+	expectedFunnel := &traceFunnels.Funnel{
+		BaseMetadata: traceFunnels.BaseMetadata{
+			Identifiable: types.Identifiable{
+				ID: funnelID,
+			},
+			Name:  reqBody.Name,
+			OrgID: valuer.MustNewUUID(orgID),
+		},
+	}
+
+	mockModule.On("List", req.Context(), orgID).Return([]*traceFunnels.Funnel{}, nil)
+	mockModule.On("Create", req.Context(), reqBody.Timestamp, reqBody.Name, "user-123", orgID).Return(expectedFunnel, nil)
+
+	handler.New(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var response struct {
+		Status string                      `json:"status"`
+		Data   traceFunnels.FunnelResponse `json:"data"`
+	}
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "success", response.Status)
+	assert.Equal(t, reqBody.Name, response.Data.FunnelName)
+	assert.Equal(t, orgID, response.Data.OrgID)
+	assert.Equal(t, "test@example.com", response.Data.UserEmail)
+
+	mockModule.AssertExpectations(t)
+}
+
+func TestHandler_Update(t *testing.T) {
+	mockModule := new(MockModule)
+	handler := NewHandler(mockModule)
+
+	// Create a valid UUID for the funnel ID
+	funnelID := valuer.GenerateUUID()
+	orgID := valuer.GenerateUUID().String()
+
+	reqBody := traceFunnels.FunnelRequest{
+		FunnelID: funnelID,
+		Name:     "updated-funnel",
+		Steps: []traceFunnels.FunnelStep{
+			{
+				Id:          valuer.GenerateUUID(),
+				Name:        "Step 1",
+				ServiceName: "test-service",
+				SpanName:    "test-span",
+				Order:       1,
+			},
+			{
+				Id:          valuer.GenerateUUID(),
+				Name:        "Step 2",
+				ServiceName: "test-service",
+				SpanName:    "test-span-2",
+				Order:       2,
+			},
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
+
+	body, err := json.Marshal(reqBody)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPut, "/api/v1/trace-funnels/steps/update", bytes.NewBuffer(body))
+	assert.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Set up context with claims
+	claims := authtypes.Claims{
+		UserID: "user-123",
+		OrgID:  orgID,
+		Email:  "test@example.com",
+	}
+	ctx := authtypes.NewContextWithClaims(req.Context(), claims)
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+
+	// Set up mock expectations
+	existingFunnel := &traceFunnels.Funnel{
+		BaseMetadata: traceFunnels.BaseMetadata{
+			Identifiable: types.Identifiable{
+				ID: funnelID,
+			},
+			Name:  "test-funnel",
+			OrgID: valuer.MustNewUUID(orgID),
+			TimeAuditable: types.TimeAuditable{
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			UserAuditable: types.UserAuditable{
+				CreatedBy: "user-123",
+				UpdatedBy: "user-123",
+			},
+		},
+		CreatedByUser: &types.User{
+			ID:    "user-123",
+			Email: "test@example.com",
+		},
+	}
+
+	updatedFunnel := &traceFunnels.Funnel{
+		BaseMetadata: traceFunnels.BaseMetadata{
+			Identifiable: types.Identifiable{
+				ID: funnelID,
+			},
+			Name:  reqBody.Name,
+			OrgID: valuer.MustNewUUID(orgID),
+			TimeAuditable: types.TimeAuditable{
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Unix(0, reqBody.Timestamp*1000000),
+			},
+			UserAuditable: types.UserAuditable{
+				CreatedBy: "user-123",
+				UpdatedBy: "user-123",
+			},
+		},
+		Steps: reqBody.Steps,
+		CreatedByUser: &types.User{
+			ID:    "user-123",
+			Email: "test@example.com",
+		},
+	}
+
+	// First Get call to validate the funnel exists
+	mockModule.On("Get", req.Context(), funnelID.String()).Return(existingFunnel, nil).Once()
+	// List call to check for name conflicts
+	mockModule.On("List", req.Context(), orgID).Return([]*traceFunnels.Funnel{}, nil).Once()
+	// Update call to save the changes
+	mockModule.On("Update", req.Context(), mock.MatchedBy(func(f *traceFunnels.Funnel) bool {
+		return f.Name == reqBody.Name &&
+			f.ID.String() == funnelID.String() &&
+			len(f.Steps) == len(reqBody.Steps) &&
+			f.Steps[0].Name == reqBody.Steps[0].Name &&
+			f.Steps[0].ServiceName == reqBody.Steps[0].ServiceName &&
+			f.Steps[0].SpanName == reqBody.Steps[0].SpanName &&
+			f.Steps[1].Name == reqBody.Steps[1].Name &&
+			f.Steps[1].ServiceName == reqBody.Steps[1].ServiceName &&
+			f.Steps[1].SpanName == reqBody.Steps[1].SpanName &&
+			f.UpdatedAt.UnixNano()/1000000 == reqBody.Timestamp &&
+			f.UpdatedBy == "user-123"
+	}), "user-123").Return(nil).Once()
+	// Second Get call to get the updated funnel for the response
+	mockModule.On("Get", req.Context(), funnelID.String()).Return(updatedFunnel, nil).Once()
+
+	handler.UpdateSteps(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var response struct {
+		Status string                      `json:"status"`
+		Data   traceFunnels.FunnelResponse `json:"data"`
+	}
+	err = json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "success", response.Status)
+	assert.Equal(t, "updated-funnel", response.Data.FunnelName)
+	assert.Equal(t, funnelID.String(), response.Data.FunnelID)
+	assert.Equal(t, "test@example.com", response.Data.UserEmail)
+
+	mockModule.AssertExpectations(t)
+}
+
+func TestHandler_List(t *testing.T) {
+	mockModule := new(MockModule)
+	handler := NewHandler(mockModule)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/trace-funnels/list", nil)
+
+	orgID := valuer.GenerateUUID().String()
+	claims := authtypes.Claims{
+		OrgID: orgID,
+	}
+	req = req.WithContext(authtypes.NewContextWithClaims(req.Context(), claims))
+
+	rr := httptest.NewRecorder()
+
+	funnel1ID := valuer.GenerateUUID()
+	funnel2ID := valuer.GenerateUUID()
+	expectedFunnels := []*traceFunnels.Funnel{
+		{
+			BaseMetadata: traceFunnels.BaseMetadata{
+				Identifiable: types.Identifiable{
+					ID: funnel1ID,
+				},
+				Name:  "funnel-1",
+				OrgID: valuer.MustNewUUID(orgID),
+			},
+		},
+		{
+			BaseMetadata: traceFunnels.BaseMetadata{
+				Identifiable: types.Identifiable{
+					ID: funnel2ID,
+				},
+				Name:  "funnel-2",
+				OrgID: valuer.MustNewUUID(orgID),
+			},
+		},
+	}
+
+	mockModule.On("List", req.Context(), orgID).Return(expectedFunnels, nil)
+
+	handler.List(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var response struct {
+		Status string                        `json:"status"`
+		Data   []traceFunnels.FunnelResponse `json:"data"`
+	}
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "success", response.Status)
+	assert.Len(t, response.Data, 2)
+	assert.Equal(t, "funnel-1", response.Data[0].FunnelName)
+	assert.Equal(t, "funnel-2", response.Data[1].FunnelName)
+
+	mockModule.AssertExpectations(t)
+}
+
+func TestHandler_Get(t *testing.T) {
+	mockModule := new(MockModule)
+	handler := NewHandler(mockModule)
+
+	funnelID := valuer.GenerateUUID()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/trace-funnels/"+funnelID.String(), nil)
+	req = mux.SetURLVars(req, map[string]string{"funnel_id": funnelID.String()})
+
+	rr := httptest.NewRecorder()
+
+	expectedFunnel := &traceFunnels.Funnel{
+		BaseMetadata: traceFunnels.BaseMetadata{
+			Identifiable: types.Identifiable{
+				ID: funnelID,
+			},
+			Name:  "test-funnel",
+			OrgID: valuer.GenerateUUID(),
+		},
+	}
+
+	mockModule.On("Get", req.Context(), funnelID.String()).Return(expectedFunnel, nil)
+
+	handler.Get(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var response struct {
+		Status string                      `json:"status"`
+		Data   traceFunnels.FunnelResponse `json:"data"`
+	}
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "success", response.Status)
+	assert.Equal(t, "test-funnel", response.Data.FunnelName)
+	assert.Equal(t, expectedFunnel.OrgID.String(), response.Data.OrgID)
+
+	mockModule.AssertExpectations(t)
+}
+
+func TestHandler_Delete(t *testing.T) {
+	mockModule := new(MockModule)
+	handler := NewHandler(mockModule)
+
+	funnelID := valuer.GenerateUUID()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/trace-funnels/"+funnelID.String(), nil)
+	req = mux.SetURLVars(req, map[string]string{"funnel_id": funnelID.String()})
+
+	rr := httptest.NewRecorder()
+
+	mockModule.On("Delete", req.Context(), funnelID.String()).Return(nil)
+
+	handler.Delete(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	mockModule.AssertExpectations(t)
+}
+
+func TestHandler_Save(t *testing.T) {
+	mockModule := new(MockModule)
+	handler := NewHandler(mockModule)
+
+	reqBody := traceFunnels.FunnelRequest{
+		FunnelID:    valuer.GenerateUUID(),
+		Description: "updated description",
+		Timestamp:   time.Now().UnixMilli(),
+		UserID:      "user-123",
+	}
+
+	jsonBody, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/trace-funnels/save", bytes.NewBuffer(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	orgID := valuer.GenerateUUID().String()
+	claims := authtypes.Claims{
+		UserID: "user-123",
+		OrgID:  orgID,
+	}
+	req = req.WithContext(authtypes.NewContextWithClaims(req.Context(), claims))
+
+	rr := httptest.NewRecorder()
+
+	existingFunnel := &traceFunnels.Funnel{
+		BaseMetadata: traceFunnels.BaseMetadata{
+			Identifiable: types.Identifiable{
+				ID: reqBody.FunnelID,
+			},
+			Name:  "test-funnel",
+			OrgID: valuer.MustNewUUID(orgID),
+		},
+	}
+
+	mockModule.On("Get", req.Context(), reqBody.FunnelID.String()).Return(existingFunnel, nil)
+	mockModule.On("Save", req.Context(), mock.AnythingOfType("*tracefunnels.Funnel"), "user-123", orgID).Return(nil)
+	mockModule.On("GetFunnelMetadata", req.Context(), reqBody.FunnelID.String()).Return(int64(0), int64(0), reqBody.Description, nil)
+
+	handler.Save(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var response struct {
+		Status string                      `json:"status"`
+		Data   traceFunnels.FunnelResponse `json:"data"`
+	}
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "success", response.Status)
+	assert.Equal(t, reqBody.Description, response.Data.Description)
+
+	mockModule.AssertExpectations(t)
+}

--- a/pkg/modules/tracefunnel/impltracefunnel/module.go
+++ b/pkg/modules/tracefunnel/impltracefunnel/module.go
@@ -1,0 +1,123 @@
+package impltracefunnel
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/modules/tracefunnel"
+	"github.com/SigNoz/signoz/pkg/types"
+	traceFunnels "github.com/SigNoz/signoz/pkg/types/tracefunnel"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+type module struct {
+	store traceFunnels.TraceFunnelStore
+}
+
+func NewModule(store traceFunnels.TraceFunnelStore) tracefunnel.Module {
+	return &module{
+		store: store,
+	}
+}
+
+func (module *module) Create(ctx context.Context, timestamp int64, name string, userID string, orgID string) (*traceFunnels.Funnel, error) {
+	orgUUID, err := valuer.NewUUID(orgID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid org ID: %v", err)
+	}
+
+	funnel := &traceFunnels.Funnel{
+		BaseMetadata: traceFunnels.BaseMetadata{
+			Name:  name,
+			OrgID: orgUUID,
+		},
+	}
+	funnel.CreatedAt = time.Unix(0, timestamp*1000000) // Convert to nanoseconds
+	funnel.CreatedBy = userID
+
+	// Set up the user relationship
+	funnel.CreatedByUser = &types.User{
+		ID: userID,
+	}
+
+	if err := module.store.Create(ctx, funnel); err != nil {
+		return nil, fmt.Errorf("failed to create funnel: %v", err)
+	}
+
+	return funnel, nil
+}
+
+// Get gets a funnel by ID
+func (module *module) Get(ctx context.Context, funnelID string) (*traceFunnels.Funnel, error) {
+	uuid, err := valuer.NewUUID(funnelID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid funnel ID: %v", err)
+	}
+	return module.store.Get(ctx, uuid)
+}
+
+// Update updates a funnel
+func (module *module) Update(ctx context.Context, funnel *traceFunnels.Funnel, userID string) error {
+	funnel.UpdatedBy = userID
+	return module.store.Update(ctx, funnel)
+}
+
+// List lists all funnels for an organization
+func (module *module) List(ctx context.Context, orgID string) ([]*traceFunnels.Funnel, error) {
+	orgUUID, err := valuer.NewUUID(orgID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid org ID: %v", err)
+	}
+
+	funnels, err := module.store.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter by orgID
+	var orgFunnels []*traceFunnels.Funnel
+	for _, f := range funnels {
+		if f.OrgID == orgUUID {
+			orgFunnels = append(orgFunnels, f)
+		}
+	}
+
+	return orgFunnels, nil
+}
+
+// Delete deletes a funnel
+func (module *module) Delete(ctx context.Context, funnelID string) error {
+	uuid, err := valuer.NewUUID(funnelID)
+	if err != nil {
+		return fmt.Errorf("invalid funnel ID: %v", err)
+	}
+	return module.store.Delete(ctx, uuid)
+}
+
+// Save saves a funnel
+func (module *module) Save(ctx context.Context, funnel *traceFunnels.Funnel, userID string, orgID string) error {
+	orgUUID, err := valuer.NewUUID(orgID)
+	if err != nil {
+		return fmt.Errorf("invalid org ID: %v", err)
+	}
+
+	funnel.UpdatedBy = userID
+	funnel.OrgID = orgUUID
+	return module.store.Update(ctx, funnel)
+}
+
+// GetFunnelMetadata gets metadata for a funnel
+func (module *module) GetFunnelMetadata(ctx context.Context, funnelID string) (int64, int64, string, error) {
+	uuid, err := valuer.NewUUID(funnelID)
+	if err != nil {
+		return 0, 0, "", fmt.Errorf("invalid funnel ID: %v", err)
+	}
+
+	funnel, err := module.store.Get(ctx, uuid)
+	if err != nil {
+		return 0, 0, "", err
+	}
+
+	return funnel.CreatedAt.UnixNano() / 1000000, funnel.UpdatedAt.UnixNano() / 1000000, funnel.Description, nil
+}

--- a/pkg/modules/tracefunnel/impltracefunnel/module_test.go
+++ b/pkg/modules/tracefunnel/impltracefunnel/module_test.go
@@ -1,0 +1,203 @@
+package impltracefunnel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/types"
+	traceFunnels "github.com/SigNoz/signoz/pkg/types/tracefunnel"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockStore struct {
+	mock.Mock
+}
+
+func (m *MockStore) Create(ctx context.Context, funnel *traceFunnels.Funnel) error {
+	args := m.Called(ctx, funnel)
+	return args.Error(0)
+}
+
+func (m *MockStore) Get(ctx context.Context, uuid valuer.UUID) (*traceFunnels.Funnel, error) {
+	args := m.Called(ctx, uuid)
+	return args.Get(0).(*traceFunnels.Funnel), args.Error(1)
+}
+
+func (m *MockStore) List(ctx context.Context) ([]*traceFunnels.Funnel, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*traceFunnels.Funnel), args.Error(1)
+}
+
+func (m *MockStore) Update(ctx context.Context, funnel *traceFunnels.Funnel) error {
+	args := m.Called(ctx, funnel)
+	return args.Error(0)
+}
+
+func (m *MockStore) Delete(ctx context.Context, uuid valuer.UUID) error {
+	args := m.Called(ctx, uuid)
+	return args.Error(0)
+}
+
+func TestModule_Create(t *testing.T) {
+	mockStore := new(MockStore)
+	module := NewModule(mockStore)
+
+	ctx := context.Background()
+	timestamp := time.Now().UnixMilli()
+	name := "test-funnel"
+	userID := "user-123"
+	orgID := valuer.GenerateUUID().String()
+
+	mockStore.On("Create", ctx, mock.AnythingOfType("*tracefunnels.Funnel")).Return(nil)
+
+	funnel, err := module.Create(ctx, timestamp, name, userID, orgID)
+	assert.NoError(t, err)
+	assert.NotNil(t, funnel)
+	assert.Equal(t, name, funnel.Name)
+	assert.Equal(t, userID, funnel.CreatedBy)
+	assert.Equal(t, orgID, funnel.OrgID.String())
+
+	mockStore.AssertExpectations(t)
+}
+
+func TestModule_Get(t *testing.T) {
+	mockStore := new(MockStore)
+	module := NewModule(mockStore)
+
+	ctx := context.Background()
+	funnelID := valuer.GenerateUUID().String()
+	expectedFunnel := &traceFunnels.Funnel{
+		BaseMetadata: traceFunnels.BaseMetadata{
+			Name: "test-funnel",
+		},
+	}
+
+	mockStore.On("Get", ctx, mock.AnythingOfType("valuer.UUID")).Return(expectedFunnel, nil)
+
+	funnel, err := module.Get(ctx, funnelID)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedFunnel, funnel)
+
+	mockStore.AssertExpectations(t)
+}
+
+func TestModule_Update(t *testing.T) {
+	mockStore := new(MockStore)
+	module := NewModule(mockStore)
+
+	ctx := context.Background()
+	userID := "user-123"
+	funnel := &traceFunnels.Funnel{
+		BaseMetadata: traceFunnels.BaseMetadata{
+			Name: "test-funnel",
+		},
+	}
+
+	mockStore.On("Update", ctx, funnel).Return(nil)
+
+	err := module.Update(ctx, funnel, userID)
+	assert.NoError(t, err)
+	assert.Equal(t, userID, funnel.UpdatedBy)
+
+	mockStore.AssertExpectations(t)
+}
+
+func TestModule_List(t *testing.T) {
+	mockStore := new(MockStore)
+	module := NewModule(mockStore)
+
+	ctx := context.Background()
+	orgID := valuer.GenerateUUID().String()
+	expectedFunnels := []*traceFunnels.Funnel{
+		{
+			BaseMetadata: traceFunnels.BaseMetadata{
+				Name:  "funnel-1",
+				OrgID: valuer.MustNewUUID(orgID),
+			},
+		},
+		{
+			BaseMetadata: traceFunnels.BaseMetadata{
+				Name:  "funnel-2",
+				OrgID: valuer.MustNewUUID(orgID),
+			},
+		},
+	}
+
+	mockStore.On("List", ctx).Return(expectedFunnels, nil)
+
+	funnels, err := module.List(ctx, orgID)
+	assert.NoError(t, err)
+	assert.Len(t, funnels, 2)
+	assert.Equal(t, expectedFunnels, funnels)
+
+	mockStore.AssertExpectations(t)
+}
+
+func TestModule_Delete(t *testing.T) {
+	mockStore := new(MockStore)
+	module := NewModule(mockStore)
+
+	ctx := context.Background()
+	funnelID := valuer.GenerateUUID().String()
+
+	mockStore.On("Delete", ctx, mock.AnythingOfType("valuer.UUID")).Return(nil)
+
+	err := module.Delete(ctx, funnelID)
+	assert.NoError(t, err)
+
+	mockStore.AssertExpectations(t)
+}
+
+func TestModule_Save(t *testing.T) {
+	mockStore := new(MockStore)
+	module := NewModule(mockStore)
+
+	ctx := context.Background()
+	userID := "user-123"
+	orgID := valuer.GenerateUUID().String()
+	funnel := &traceFunnels.Funnel{
+		BaseMetadata: traceFunnels.BaseMetadata{
+			Name: "test-funnel",
+		},
+	}
+
+	mockStore.On("Update", ctx, funnel).Return(nil)
+
+	err := module.Save(ctx, funnel, userID, orgID)
+	assert.NoError(t, err)
+	assert.Equal(t, userID, funnel.UpdatedBy)
+	assert.Equal(t, orgID, funnel.OrgID.String())
+
+	mockStore.AssertExpectations(t)
+}
+
+func TestModule_GetFunnelMetadata(t *testing.T) {
+	mockStore := new(MockStore)
+	module := NewModule(mockStore)
+
+	ctx := context.Background()
+	funnelID := valuer.GenerateUUID().String()
+	now := time.Now()
+	expectedFunnel := &traceFunnels.Funnel{
+		BaseMetadata: traceFunnels.BaseMetadata{
+			Description: "test description",
+			TimeAuditable: types.TimeAuditable{
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+		},
+	}
+
+	mockStore.On("Get", ctx, mock.AnythingOfType("valuer.UUID")).Return(expectedFunnel, nil)
+
+	createdAt, updatedAt, description, err := module.GetFunnelMetadata(ctx, funnelID)
+	assert.NoError(t, err)
+	assert.Equal(t, now.UnixNano()/1000000, createdAt)
+	assert.Equal(t, now.UnixNano()/1000000, updatedAt)
+	assert.Equal(t, "test description", description)
+
+	mockStore.AssertExpectations(t)
+}

--- a/pkg/modules/tracefunnel/impltracefunnel/store.go
+++ b/pkg/modules/tracefunnel/impltracefunnel/store.go
@@ -1,0 +1,119 @@
+package impltracefunnel
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	traceFunnels "github.com/SigNoz/signoz/pkg/types/tracefunnel"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+type store struct {
+	sqlstore sqlstore.SQLStore
+}
+
+func NewStore(sqlstore sqlstore.SQLStore) traceFunnels.TraceFunnelStore {
+	return &store{sqlstore: sqlstore}
+}
+
+func (store *store) Create(ctx context.Context, funnel *traceFunnels.Funnel) error {
+	if funnel.ID.IsZero() {
+		funnel.ID = valuer.GenerateUUID()
+	}
+
+	if funnel.CreatedAt.IsZero() {
+		funnel.CreatedAt = time.Now()
+	}
+	if funnel.UpdatedAt.IsZero() {
+		funnel.UpdatedAt = time.Now()
+	}
+
+	_, err := store.
+		sqlstore.
+		BunDB().
+		NewInsert().
+		Model(funnel).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create funnel: %v", err)
+	}
+
+	if funnel.CreatedByUser != nil {
+		_, err = store.sqlstore.BunDB().NewUpdate().
+			Model(funnel).
+			Set("created_by = ?", funnel.CreatedByUser.ID).
+			Where("id = ?", funnel.ID).
+			Exec(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to update funnel user relationship: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// Get retrieves a funnel by ID
+func (store *store) Get(ctx context.Context, uuid valuer.UUID) (*traceFunnels.Funnel, error) {
+	funnel := &traceFunnels.Funnel{}
+	err := store.
+		sqlstore.
+		BunDB().
+		NewSelect().
+		Model(funnel).
+		Relation("CreatedByUser").
+		Where("?TableAlias.id = ?", uuid).
+		Scan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get funnel: %v", err)
+	}
+	return funnel, nil
+}
+
+// Update updates an existing funnel
+func (store *store) Update(ctx context.Context, funnel *traceFunnels.Funnel) error {
+	funnel.UpdatedAt = time.Now()
+
+	_, err := store.
+		sqlstore.
+		BunDB().
+		NewUpdate().
+		Model(funnel).
+		WherePK().
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to update funnel: %v", err)
+	}
+	return nil
+}
+
+// List retrieves all funnels
+func (store *store) List(ctx context.Context) ([]*traceFunnels.Funnel, error) {
+	var funnels []*traceFunnels.Funnel
+	err := store.
+		sqlstore.
+		BunDB().
+		NewSelect().
+		Model(&funnels).
+		Relation("CreatedByUser").
+		Scan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list funnels: %v", err)
+	}
+	return funnels, nil
+}
+
+// Delete removes a funnel by ID
+func (store *store) Delete(ctx context.Context, uuid valuer.UUID) error {
+	_, err := store.
+		sqlstore.
+		BunDB().
+		NewDelete().
+		Model((*traceFunnels.Funnel)(nil)).
+		Where("id = ?", uuid).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to delete funnel: %v", err)
+	}
+	return nil
+}

--- a/pkg/modules/tracefunnel/tracefunnel.go
+++ b/pkg/modules/tracefunnel/tracefunnel.go
@@ -1,0 +1,41 @@
+package tracefunnel
+
+import (
+	"context"
+	"net/http"
+
+	traceFunnels "github.com/SigNoz/signoz/pkg/types/tracefunnel"
+)
+
+// Module defines the interface for trace funnel operations
+type Module interface {
+	Create(ctx context.Context, timestamp int64, name string, userID string, orgID string) (*traceFunnels.Funnel, error)
+
+	Get(ctx context.Context, funnelID string) (*traceFunnels.Funnel, error)
+
+	Update(ctx context.Context, funnel *traceFunnels.Funnel, userID string) error
+
+	List(ctx context.Context, orgID string) ([]*traceFunnels.Funnel, error)
+
+	Delete(ctx context.Context, funnelID string) error
+
+	Save(ctx context.Context, funnel *traceFunnels.Funnel, userID string, orgID string) error
+
+	GetFunnelMetadata(ctx context.Context, funnelID string) (int64, int64, string, error)
+}
+
+type Handler interface {
+	New(http.ResponseWriter, *http.Request)
+
+	UpdateSteps(http.ResponseWriter, *http.Request)
+
+	UpdateFunnel(http.ResponseWriter, *http.Request)
+
+	List(http.ResponseWriter, *http.Request)
+
+	Get(http.ResponseWriter, *http.Request)
+
+	Delete(http.ResponseWriter, *http.Request)
+
+	Save(http.ResponseWriter, *http.Request)
+}

--- a/pkg/modules/tracefunnel/utils.go
+++ b/pkg/modules/tracefunnel/utils.go
@@ -1,0 +1,56 @@
+package tracefunnel
+
+import (
+	"fmt"
+	tracefunnel "github.com/SigNoz/signoz/pkg/types/tracefunnel"
+	"sort"
+)
+
+// ValidateTimestamp validates a timestamp
+func ValidateTimestamp(timestamp int64, fieldName string) error {
+	if timestamp == 0 {
+		return fmt.Errorf("%s is required", fieldName)
+	}
+	if timestamp < 0 {
+		return fmt.Errorf("%s must be positive", fieldName)
+	}
+	return nil
+}
+
+// ValidateTimestampIsMilliseconds validates that a timestamp is in milliseconds
+func ValidateTimestampIsMilliseconds(timestamp int64) bool {
+	return timestamp >= 1000000000000 && timestamp <= 9999999999999
+}
+
+func ValidateFunnelSteps(steps []tracefunnel.FunnelStep) error {
+	if len(steps) < 2 {
+		return fmt.Errorf("funnel must have at least 2 steps")
+	}
+
+	for i, step := range steps {
+		if step.ServiceName == "" {
+			return fmt.Errorf("step %d: service name is required", i+1)
+		}
+		if step.SpanName == "" {
+			return fmt.Errorf("step %d: span name is required", i+1)
+		}
+		if step.Order < 0 {
+			return fmt.Errorf("step %d: order must be non-negative", i+1)
+		}
+	}
+
+	return nil
+}
+
+// NormalizeFunnelSteps normalizes step orders to be sequential
+func NormalizeFunnelSteps(steps []tracefunnel.FunnelStep) []tracefunnel.FunnelStep {
+	sort.Slice(steps, func(i, j int) bool {
+		return steps[i].Order < steps[j].Order
+	})
+
+	for i := range steps {
+		steps[i].Order = int64(i + 1)
+	}
+
+	return steps
+}

--- a/pkg/modules/tracefunnel/utils_test.go
+++ b/pkg/modules/tracefunnel/utils_test.go
@@ -1,0 +1,335 @@
+package tracefunnel
+
+import (
+	"testing"
+	"time"
+
+	tracefunnel "github.com/SigNoz/signoz/pkg/types/tracefunnel"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTimestamp(t *testing.T) {
+	tests := []struct {
+		name        string
+		timestamp   int64
+		fieldName   string
+		expectError bool
+	}{
+		{
+			name:        "valid timestamp",
+			timestamp:   time.Now().UnixMilli(),
+			fieldName:   "timestamp",
+			expectError: false,
+		},
+		{
+			name:        "zero timestamp",
+			timestamp:   0,
+			fieldName:   "timestamp",
+			expectError: true,
+		},
+		{
+			name:        "negative timestamp",
+			timestamp:   -1,
+			fieldName:   "timestamp",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTimestamp(tt.timestamp, tt.fieldName)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateTimestampIsMilliseconds(t *testing.T) {
+	tests := []struct {
+		name      string
+		timestamp int64
+		expected  bool
+	}{
+		{
+			name:      "valid millisecond timestamp",
+			timestamp: 1700000000000, // 2023-11-14 12:00:00 UTC
+			expected:  true,
+		},
+		{
+			name:      "too small timestamp",
+			timestamp: 999999999999,
+			expected:  false,
+		},
+		{
+			name:      "too large timestamp",
+			timestamp: 10000000000000,
+			expected:  false,
+		},
+		{
+			name:      "second precision timestamp",
+			timestamp: 1700000000,
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ValidateTimestampIsMilliseconds(tt.timestamp)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestValidateFunnelSteps(t *testing.T) {
+	tests := []struct {
+		name        string
+		steps       []tracefunnel.FunnelStep
+		expectError bool
+	}{
+		{
+			name: "valid steps",
+			steps: []tracefunnel.FunnelStep{
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 1",
+					ServiceName: "test-service",
+					SpanName:    "test-span",
+					Order:       1,
+				},
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 2",
+					ServiceName: "test-service",
+					SpanName:    "test-span-2",
+					Order:       2,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "too few steps",
+			steps: []tracefunnel.FunnelStep{
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 1",
+					ServiceName: "test-service",
+					SpanName:    "test-span",
+					Order:       1,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "missing service name",
+			steps: []tracefunnel.FunnelStep{
+				{
+					Id:       valuer.GenerateUUID(),
+					Name:     "Step 1",
+					SpanName: "test-span",
+					Order:    1,
+				},
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 2",
+					ServiceName: "test-service",
+					SpanName:    "test-span-2",
+					Order:       2,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "missing span name",
+			steps: []tracefunnel.FunnelStep{
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 1",
+					ServiceName: "test-service",
+					Order:       1,
+				},
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 2",
+					ServiceName: "test-service",
+					SpanName:    "test-span-2",
+					Order:       2,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "negative order",
+			steps: []tracefunnel.FunnelStep{
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 1",
+					ServiceName: "test-service",
+					SpanName:    "test-span",
+					Order:       -1,
+				},
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 2",
+					ServiceName: "test-service",
+					SpanName:    "test-span-2",
+					Order:       2,
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFunnelSteps(tt.steps)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNormalizeFunnelSteps(t *testing.T) {
+	tests := []struct {
+		name     string
+		steps    []tracefunnel.FunnelStep
+		expected []tracefunnel.FunnelStep
+	}{
+		{
+			name: "already normalized steps",
+			steps: []tracefunnel.FunnelStep{
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 1",
+					ServiceName: "test-service",
+					SpanName:    "test-span",
+					Order:       1,
+				},
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 2",
+					ServiceName: "test-service",
+					SpanName:    "test-span-2",
+					Order:       2,
+				},
+			},
+			expected: []tracefunnel.FunnelStep{
+				{
+					Name:        "Step 1",
+					ServiceName: "test-service",
+					SpanName:    "test-span",
+					Order:       1,
+				},
+				{
+					Name:        "Step 2",
+					ServiceName: "test-service",
+					SpanName:    "test-span-2",
+					Order:       2,
+				},
+			},
+		},
+		{
+			name: "unordered steps",
+			steps: []tracefunnel.FunnelStep{
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 2",
+					ServiceName: "test-service",
+					SpanName:    "test-span-2",
+					Order:       2,
+				},
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 1",
+					ServiceName: "test-service",
+					SpanName:    "test-span",
+					Order:       1,
+				},
+			},
+			expected: []tracefunnel.FunnelStep{
+				{
+					Name:        "Step 1",
+					ServiceName: "test-service",
+					SpanName:    "test-span",
+					Order:       1,
+				},
+				{
+					Name:        "Step 2",
+					ServiceName: "test-service",
+					SpanName:    "test-span-2",
+					Order:       2,
+				},
+			},
+		},
+		{
+			name: "steps with gaps in order",
+			steps: []tracefunnel.FunnelStep{
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 1",
+					ServiceName: "test-service",
+					SpanName:    "test-span",
+					Order:       1,
+				},
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 3",
+					ServiceName: "test-service",
+					SpanName:    "test-span-3",
+					Order:       3,
+				},
+				{
+					Id:          valuer.GenerateUUID(),
+					Name:        "Step 2",
+					ServiceName: "test-service",
+					SpanName:    "test-span-2",
+					Order:       2,
+				},
+			},
+			expected: []tracefunnel.FunnelStep{
+				{
+					Name:        "Step 1",
+					ServiceName: "test-service",
+					SpanName:    "test-span",
+					Order:       1,
+				},
+				{
+					Name:        "Step 2",
+					ServiceName: "test-service",
+					SpanName:    "test-span-2",
+					Order:       2,
+				},
+				{
+					Name:        "Step 3",
+					ServiceName: "test-service",
+					SpanName:    "test-span-3",
+					Order:       3,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a copy of the steps to avoid modifying the original
+			steps := make([]tracefunnel.FunnelStep, len(tt.steps))
+			copy(steps, tt.steps)
+
+			result := NormalizeFunnelSteps(steps)
+
+			// Compare only the relevant fields
+			for i := range result {
+				assert.Equal(t, tt.expected[i].Name, result[i].Name)
+				assert.Equal(t, tt.expected[i].ServiceName, result[i].ServiceName)
+				assert.Equal(t, tt.expected[i].SpanName, result[i].SpanName)
+				assert.Equal(t, tt.expected[i].Order, result[i].Order)
+			}
+		})
+	}
+}

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -5425,3 +5425,33 @@ func (aH *APIHandler) getDomainInfo(w http.ResponseWriter, r *http.Request) {
 	}
 	aH.Respond(w, resp)
 }
+
+// RegisterTraceFunnelsRoutes adds trace funnels routes
+func (aH *APIHandler) RegisterTraceFunnelsRoutes(router *mux.Router, am *middleware.AuthZ) {
+	// Main trace funnels router
+	traceFunnelsRouter := router.PathPrefix("/api/v1/trace-funnels").Subrouter()
+
+	// API endpoints
+	traceFunnelsRouter.HandleFunc("/new",
+		am.ViewAccess(aH.Signoz.Handlers.TraceFunnel.New)).
+		Methods(http.MethodPost)
+	traceFunnelsRouter.HandleFunc("/list",
+		am.ViewAccess(aH.Signoz.Handlers.TraceFunnel.List)).
+		Methods(http.MethodGet)
+	traceFunnelsRouter.HandleFunc("/steps/update",
+		am.ViewAccess(aH.Signoz.Handlers.TraceFunnel.UpdateSteps)).
+		Methods(http.MethodPut)
+
+	traceFunnelsRouter.HandleFunc("/{funnel_id}",
+		am.ViewAccess(aH.Signoz.Handlers.TraceFunnel.Get)).
+		Methods(http.MethodGet)
+	traceFunnelsRouter.HandleFunc("/{funnel_id}",
+		am.ViewAccess(aH.Signoz.Handlers.TraceFunnel.Delete)).
+		Methods(http.MethodDelete)
+	traceFunnelsRouter.HandleFunc("/{funnel_id}",
+		am.ViewAccess(aH.Signoz.Handlers.TraceFunnel.UpdateFunnel)).
+		Methods(http.MethodPut)
+	traceFunnelsRouter.HandleFunc("/save",
+		am.ViewAccess(aH.Signoz.Handlers.TraceFunnel.Save)).
+		Methods(http.MethodPost)
+}

--- a/pkg/query-service/app/server.go
+++ b/pkg/query-service/app/server.go
@@ -281,6 +281,7 @@ func (s *Server) createPublicServer(api *APIHandler, web web.Web) (*http.Server,
 	api.RegisterMessagingQueuesRoutes(r, am)
 	api.RegisterThirdPartyApiRoutes(r, am)
 	api.MetricExplorerRoutes(r, am)
+	api.RegisterTraceFunnelsRoutes(r, am)
 
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},

--- a/pkg/signoz/handler.go
+++ b/pkg/signoz/handler.go
@@ -5,16 +5,20 @@ import (
 	"github.com/SigNoz/signoz/pkg/modules/organization/implorganization"
 	"github.com/SigNoz/signoz/pkg/modules/preference"
 	"github.com/SigNoz/signoz/pkg/modules/preference/implpreference"
+	"github.com/SigNoz/signoz/pkg/modules/tracefunnel"
+	"github.com/SigNoz/signoz/pkg/modules/tracefunnel/impltracefunnel"
 )
 
 type Handlers struct {
 	Organization organization.Handler
 	Preference   preference.Handler
+	TraceFunnel  tracefunnel.Handler
 }
 
 func NewHandlers(modules Modules) Handlers {
 	return Handlers{
 		Organization: implorganization.NewHandler(modules.Organization),
 		Preference:   implpreference.NewHandler(modules.Preference),
+		TraceFunnel:  impltracefunnel.NewHandler(modules.TraceFunnel),
 	}
 }

--- a/pkg/signoz/module.go
+++ b/pkg/signoz/module.go
@@ -5,6 +5,8 @@ import (
 	"github.com/SigNoz/signoz/pkg/modules/organization/implorganization"
 	"github.com/SigNoz/signoz/pkg/modules/preference"
 	"github.com/SigNoz/signoz/pkg/modules/preference/implpreference"
+	"github.com/SigNoz/signoz/pkg/modules/tracefunnel"
+	"github.com/SigNoz/signoz/pkg/modules/tracefunnel/impltracefunnel"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
 	"github.com/SigNoz/signoz/pkg/types/preferencetypes"
 )
@@ -12,11 +14,13 @@ import (
 type Modules struct {
 	Organization organization.Module
 	Preference   preference.Module
+	TraceFunnel  tracefunnel.Module
 }
 
 func NewModules(sqlstore sqlstore.SQLStore) Modules {
 	return Modules{
 		Organization: implorganization.NewModule(implorganization.NewStore(sqlstore)),
 		Preference:   implpreference.NewModule(implpreference.NewStore(sqlstore), preferencetypes.NewDefaultPreferenceMap()),
+		TraceFunnel:  impltracefunnel.NewModule(impltracefunnel.NewStore(sqlstore)),
 	}
 }

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -74,6 +74,7 @@ func NewSQLMigrationProviderFactories(sqlstore sqlstore.SQLStore) factory.NamedM
 		sqlmigration.NewUpdateIntegrationsFactory(sqlstore),
 		sqlmigration.NewUpdateOrganizationsFactory(sqlstore),
 		sqlmigration.NewDropGroupsFactory(sqlstore),
+		sqlmigration.NewAddTraceFunnelsFactory(sqlstore),
 	)
 }
 

--- a/pkg/sqlmigration/030_add_trace_funnels.go
+++ b/pkg/sqlmigration/030_add_trace_funnels.go
@@ -1,0 +1,111 @@
+package sqlmigration
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	traceFunnels "github.com/SigNoz/signoz/pkg/types/tracefunnel"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/migrate"
+)
+
+type addTraceFunnels struct {
+	sqlstore sqlstore.SQLStore
+}
+
+func NewAddTraceFunnelsFactory(sqlstore sqlstore.SQLStore) factory.ProviderFactory[SQLMigration, Config] {
+	return factory.
+		NewProviderFactory(factory.
+			MustNewName("add_trace_funnels"),
+			func(ctx context.Context, providerSettings factory.ProviderSettings, config Config) (SQLMigration, error) {
+				return newAddTraceFunnels(ctx, providerSettings, config, sqlstore)
+			})
+}
+
+func newAddTraceFunnels(_ context.Context, _ factory.ProviderSettings, _ Config, sqlstore sqlstore.SQLStore) (SQLMigration, error) {
+	return &addTraceFunnels{sqlstore: sqlstore}, nil
+}
+
+func (migration *addTraceFunnels) Register(migrations *migrate.Migrations) error {
+	if err := migrations.
+		Register(migration.Up, migration.Down); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (migration *addTraceFunnels) Up(ctx context.Context, db *bun.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// Create trace_funnel table with foreign key constraint inline
+	_, err = tx.NewCreateTable().
+		Model((*traceFunnels.Funnel)(nil)).
+		ForeignKey(`("org_id") REFERENCES "organizations" ("id") ON DELETE CASCADE`).
+		IfNotExists().
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create trace_funnel table: %v", err)
+	}
+
+	// Add unique constraint for org_id and name
+	_, err = tx.NewRaw(`
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_trace_funnel_org_id_name 
+		ON trace_funnel (org_id, name)
+	`).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create unique constraint: %v", err)
+	}
+
+	// Create indexes
+	_, err = tx.NewCreateIndex().
+		Model((*traceFunnels.Funnel)(nil)).
+		Index("idx_trace_funnel_org_id").
+		Column("org_id").
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create org_id index: %v", err)
+	}
+
+	_, err = tx.NewCreateIndex().
+		Model((*traceFunnels.Funnel)(nil)).
+		Index("idx_trace_funnel_created_at").
+		Column("created_at").Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create created_at index: %v", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (migration *addTraceFunnels) Down(ctx context.Context, db *bun.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// Drop trace_funnel table
+	_, err = tx.NewDropTable().
+		Model((*traceFunnels.Funnel)(nil)).
+		IfExists().
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to drop trace_funnel table: %v", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/types/tracefunnel/store.go
+++ b/pkg/types/tracefunnel/store.go
@@ -1,0 +1,15 @@
+package tracefunnels
+
+import (
+	"context"
+
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+type TraceFunnelStore interface {
+	Create(context.Context, *Funnel) error
+	Get(context.Context, valuer.UUID) (*Funnel, error)
+	List(context.Context) ([]*Funnel, error)
+	Update(context.Context, *Funnel) error
+	Delete(context.Context, valuer.UUID) error
+}

--- a/pkg/types/tracefunnel/tracefunnel.go
+++ b/pkg/types/tracefunnel/tracefunnel.go
@@ -1,0 +1,98 @@
+package tracefunnels
+
+import (
+	v3 "github.com/SigNoz/signoz/pkg/query-service/model/v3"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/uptrace/bun"
+)
+
+// BaseMetadata metadata for funnels
+type BaseMetadata struct {
+	types.Identifiable // funnel id
+	types.TimeAuditable
+	types.UserAuditable
+	Name        string      `json:"funnel_name" bun:"name,type:text,notnull"` // funnel name
+	Description string      `json:"description" bun:"description,type:text"`  // funnel description
+	OrgID       valuer.UUID `json:"org_id" bun:"org_id,type:varchar,notnull"`
+}
+
+// Funnel Core Data Structure (Funnel and FunnelStep)
+type Funnel struct {
+	bun.BaseModel `bun:"table:trace_funnel"`
+	BaseMetadata
+	Steps         []FunnelStep `json:"steps" bun:"steps,type:text,notnull"`
+	Tags          string       `json:"tags" bun:"tags,type:text"`
+	CreatedByUser *types.User  `json:"user" bun:"rel:belongs-to,join:created_by=id"`
+}
+
+type FunnelStep struct {
+	Id             valuer.UUID   `json:"id,omitempty"`
+	Name           string        `json:"name,omitempty"`        // step name
+	Description    string        `json:"description,omitempty"` // step description
+	Order          int64         `json:"step_order"`
+	ServiceName    string        `json:"service_name"`
+	SpanName       string        `json:"span_name"`
+	Filters        *v3.FilterSet `json:"filters,omitempty"`
+	LatencyPointer string        `json:"latency_pointer,omitempty"`
+	LatencyType    string        `json:"latency_type,omitempty"`
+	HasErrors      bool          `json:"has_errors"`
+}
+
+// FunnelRequest represents all possible funnel-related requests
+type FunnelRequest struct {
+	FunnelID    valuer.UUID  `json:"funnel_id,omitempty"`
+	Name        string       `json:"funnel_name,omitempty"`
+	Timestamp   int64        `json:"timestamp,omitempty"`
+	Description string       `json:"description,omitempty"`
+	Steps       []FunnelStep `json:"steps,omitempty"`
+	UserID      string       `json:"user_id,omitempty"`
+
+	// Analytics specific fields
+	StartTime  int64 `json:"start_time,omitempty"`
+	EndTime    int64 `json:"end_time,omitempty"`
+	StepAOrder int64 `json:"step_a_order,omitempty"`
+	StepBOrder int64 `json:"step_b_order,omitempty"`
+}
+
+// FunnelResponse represents all possible funnel-related responses
+type FunnelResponse struct {
+	FunnelID    string       `json:"funnel_id,omitempty"`
+	FunnelName  string       `json:"funnel_name,omitempty"`
+	Description string       `json:"description,omitempty"`
+	CreatedAt   int64        `json:"created_at,omitempty"`
+	CreatedBy   string       `json:"created_by,omitempty"`
+	UpdatedAt   int64        `json:"updated_at,omitempty"`
+	UpdatedBy   string       `json:"updated_by,omitempty"`
+	OrgID       string       `json:"org_id,omitempty"`
+	UserEmail   string       `json:"user_email,omitempty"`
+	Funnel      *Funnel      `json:"funnel,omitempty"`
+	Steps       []FunnelStep `json:"steps,omitempty"`
+}
+
+// TimeRange represents a time range for analytics
+type TimeRange struct {
+	StartTime int64 `json:"start_time"`
+	EndTime   int64 `json:"end_time"`
+}
+
+// StepTransitionRequest represents a request for step transition analytics
+type StepTransitionRequest struct {
+	TimeRange
+	StepAOrder int64 `json:"step_a_order"`
+	StepBOrder int64 `json:"step_b_order"`
+}
+
+// UserInfo represents basic user information
+type UserInfo struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}
+
+type FunnelStepFilter struct {
+	StepNumber     int
+	ServiceName    string
+	SpanName       string
+	LatencyPointer string // "start" or "end"
+	CustomFilters  *v3.FilterSet
+}


### PR DESCRIPTION
part of: https://github.com/SigNoz/signoz/issues/7210

Adds trace funnel feature implementation:

- [ ] APIs
- [ ] module
- [ ] handler
- [ ] store
- [ ] migrations
- [ ] types
- [ ] tests

Postman collection: [link](https://signoz.postman.co/workspace/Team-Workspace~cfa5c7b5-124f-4bbc-88d9-2351af8dd95b/collection/35983931-f2f252b4-92a1-47ba-b392-32a84c83334c?action=share&creator=35983931)
<!-- ELLIPSIS_HIDDEN -->

Followup would include the unit tests, to keep this PR size in control (already big in size)

Functional testing done via postman https://signoz.postman.co/workspace/Team-Workspace~cfa5c7b5-124f-4bbc-88d9-2351af8dd95b/collection/35983931-7b154621-135f-4cec-8c18-121ac51cba9f?action=share&creator=35983931

and also via https://demo-internal.in.signoz.cloud/traces/funnels