### PR TITLE
docs(contributing): add sql docs

### DIFF
--- a/docs/contributing/go/sql.md
+++ b/docs/contributing/go/sql.md
@@ -88,6 +88,7 @@ For schema migrations, use the [SQLMigration](/pkg/sqlmigration/sqlmigration.go)
 
 ## What should I remember?
 
+- Use `BunDBCtx` and `RunInTxCtx` to access the database instance and execute transactions respectively.
 - While designing new tables, ensure the consistency of `id`, `created_at`, `updated_at` and an `org_id` column with a foreign key constraint to the `organizations` table (unless the table serves as a transitive entity not directly associated with an organization but indirectly associated with one).
 - Implement deletion logic in the application rather than relying on cascading deletes in the database.
 - While writing migrations, adhere to the guidelines mentioned above.

--- a/docs/contributing/go/sql.md
+++ b/docs/contributing/go/sql.md
@@ -36,7 +36,8 @@ func CreateThing(ctx context.Context, thing *Thing) error {
 }
 ```
 
-> 💡 **Note**: Always use line breaks while working with SQL queries to enhance code readability. 
+> 💡 **Note**: Always use line breaks while working with SQL queries to enhance code readability.
+
 > 💡 **Note**: Always use the `new` function to create new instances of structs.
 
 ## What are hooks?
@@ -45,7 +46,7 @@ Hooks are user-defined functions that execute before and/or after specific datab
 
 ## How is the schema designed?
 
-SigNoz implements a star schema design with the organizations table as the central entity. All other tables link to the organizations table via foreign key constraints on the org_id column. This design ensures that every entity within the system is either directly or indirectly associated with an organization.
+SigNoz implements a star schema design with the organizations table as the central entity. All other tables link to the organizations table via foreign key constraints on the `org_id` column. This design ensures that every entity within the system is either directly or indirectly associated with an organization.
 
 ```mermaid
 erDiagram

--- a/docs/contributing/go/sql.md
+++ b/docs/contributing/go/sql.md
@@ -1,0 +1,90 @@
+# SQL
+SigNoz utilizes a relational database to store metadata including organization information, user data and other settings.
+
+## How to use it?
+
+The database interface is defined in [SQLStore](/pkg/sqlstore/sqlstore.go). SigNoz leverages the Bun ORM to interact with the underlying database. To access the database instance, use the `BunDBCtx` function. For operations that require transactions across multiple database operations, use the `RunInTxCtx` function. This function embeds a transaction in the context, which propagates through various functions in the callback.
+
+```go
+type Thing struct {
+	bun.BaseModel
+
+	ID            types.Identifiable  `bun:",embed"`
+	SomeColumn    string              `bun:"some_column"`
+	TimeAuditable types.TimeAuditable `bun:",embed"`
+	OrgID         string              `bun:"org_id"`
+}
+
+func GetThing(ctx context.Context, id string) (*Thing, error) {
+	thing := new(Thing)
+	err := sqlstore.
+        BunDBCtx(ctx).
+        NewSelect().
+        Model(thing).
+        Where("id = ?", id).
+        Scan(ctx)
+
+    return thing, err
+}
+
+func CreateThing(ctx context.Context, thing *Thing) error {
+	return sqlstore.
+        BunDBCtx(ctx).
+        NewInsert().
+        Model(thing).
+        Exec(ctx)
+}
+```
+
+> 💡 **Note**: Always use consistent formatting with appropriate line breaks to enhance code readability. Always use the `new` function to create new instances of structs.
+
+
+## How to use hooks?
+
+Hooks are user-defined functions that execute before and/or after specific database operations. These hooks are particularly useful for generating telemetry data such as logs, traces, and metrics, providing visibility into database interactions. Hooks are defined in the [SQLStoreHook](/pkg/sqlstore/sqlstore.go) interface.
+
+
+## How is the schema designed?
+
+SigNoz implements a star schema design with the organizations table as the central entity. All other tables link to the organizations table via foreign key constraints on the org_id column. This design ensures that every entity within the system is either directly or indirectly associated with an organization.
+
+```mermaid
+erDiagram
+    ORGANIZATIONS {
+        string id PK
+        timestamp created_at
+        timestamp updated_at
+    }
+    TABLE_A {
+        string id PK
+        timestamp created_at
+        timestamp updated_at
+        string org_id FK
+    }
+    TABLE_B {
+        string id PK
+        timestamp created_at
+        timestamp updated_at
+        string org_id FK
+    }
+    
+    ORGANIZATIONS ||--o{ TABLE_A : contains
+    ORGANIZATIONS ||--o{ TABLE_B : contains
+```
+
+
+All tables follow a consistent primary key pattern using a `id` column (referenced by the `types.Identifiable` struct) and include `created_at` and `updated_at` columns (referenced by the `types.TimeAuditable` struct) for audit purposes.
+
+## How to write migrations?
+
+For schema migrations, use the `sqlmigration` package. When creating migrations, adhere to these guidelines:
+
+- Do not implement ON CASCADE foreign key constraints. Deletion operations should be handled explicitly in application logic rather than delegated to the database.
+- Do not import types from the types package in the sqlmigration package. Instead, define the required types within the migration package itself. This practice ensures migration stability as the core types evolve over time.
+- We currently do not implement Down migrations. As the codebase matures, we may introduce this capability, but for now, the Down function should remain empty.
+
+## What should I remember?
+
+- Always pass `context.Context` to all functions that interact with the database.
+- Implement deletion logic in the application rather than relying on cascading deletes in the database.
+- Ensure all new tables include an `org_id` column with a foreign key constraint to the `organizations` table, unless the table serves as a transitive entity not directly associated with an organization.


### PR DESCRIPTION
### Summary

add sql docs

#### Related Issues / PR's

Part of https://github.com/SigNoz/platform-pod/issues/760
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `sql.md` documentation for SQL usage, schema design, hooks, and migration guidelines in SigNoz.
> 
>   - **Documentation**:
>     - Adds `sql.md` to `docs/contributing/go/`.
>     - Describes database usage with Bun ORM, including `BunDBCtx` and `RunInTxCtx` functions.
>     - Explains hooks for telemetry data in `SQLStoreHook`.
>     - Details star schema design with `organizations` table as central entity.
>     - Provides guidelines for writing migrations using `SQLMigration` interface.
>   - **Guidelines**:
>     - Avoid `ON CASCADE` constraints; handle deletions in application logic.
>     - Do not import types from `types` package in migrations.
>     - Write idempotent migrations; avoid `Down` migrations.
>     - Ensure table consistency with `id`, `created_at`, `updated_at`, and `org_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for f5ed9d9565f8afb10bcec45763db4e1484c9d81f. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->