### PR TITLE
fix: correctly populate response_status

### DIFF
--- a/frontend/src/container/ApiMonitoring/APIMonitoringUtils.test.tsx
+++ b/frontend/src/container/ApiMonitoring/APIMonitoringUtils.test.tsx
@@ -411,7 +411,7 @@ describe('API Monitoring Utils', () => {
 			const statusFilter = result.items.find(
 				(item) =>
 					item.key &&
-					item.key.key === SPAN_ATTRIBUTES.STATUS_CODE &&
+					item.key.key === SPAN_ATTRIBUTES.RESPONSE_STATUS_CODE &&
 					item.value === statusCode,
 			);
 			expect(statusFilter).toBeDefined();

--- a/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/constants.ts
+++ b/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/constants.ts
@@ -13,7 +13,6 @@ export const VIEW_TYPES = {
 // Span attribute keys - these are the source of truth for all attribute keys
 export const SPAN_ATTRIBUTES = {
 	URL_PATH: 'http.url',
-	STATUS_CODE: 'status_code',
 	RESPONSE_STATUS_CODE: 'response_status_code',
 	SERVER_NAME: 'net.peer.name',
 	SERVER_PORT: 'net.peer.port',

--- a/frontend/src/container/ApiMonitoring/utils.tsx
+++ b/frontend/src/container/ApiMonitoring/utils.tsx
@@ -1438,12 +1438,12 @@ export const getTopErrorsCoRelationQueryFilters = (
 		{
 			id: 'f6891e27',
 			key: {
-				key: 'status_code',
-				dataType: DataTypes.Float64,
+				key: 'response_status_code',
+				dataType: DataTypes.String,
 				type: '',
 				isColumn: true,
 				isJSON: false,
-				id: 'status_code--float64----true',
+				id: 'response_status_code--string----true',
 			},
 			op: '=',
 			value: statusCode,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update key from `status_code` to `response_status_code` across API monitoring utilities and tests for consistency.
> 
>   - **Behavior**:
>     - Update key from `status_code` to `response_status_code` in `APIMonitoringUtils.test.tsx` and `utils.tsx`.
>     - Ensure filters and queries use `response_status_code` for consistency.
>   - **Constants**:
>     - Remove `STATUS_CODE` from `SPAN_ATTRIBUTES` in `constants.ts`.
>   - **Functions**:
>     - Update `getTopErrorsCoRelationQueryFilters` and `getTopErrorsQueryPayload` to use `response_status_code`.
>     - Modify `getFormattedEndPointStatusCodeData` to handle `response_status_code`.
>   - **Tests**:
>     - Adjust tests in `APIMonitoringUtils.test.tsx` to reflect key change to `response_status_code`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for f2a0d2e9eb51bd5cf16e4f58c85df0c1cfcd094b. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->