### PR TITLE
chore(signoz): remove deprecated signoz arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,7 @@ go-run-enterprise: ## Runs the enterprise go backend server
 	go run -race \
 		$(GO_BUILD_CONTEXT_ENTERPRISE)/main.go \
 		--config ./conf/prometheus.yml \
-		--cluster cluster \
-		--use-logs-new-schema true \
-		--use-trace-new-schema true
+		--cluster cluster
 
 .PHONY: go-test
 go-test: ## Runs go unit tests

--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,7 @@ go-run-community: ## Runs the community go backend server
 	go run -race \
 		$(GO_BUILD_CONTEXT_COMMUNITY)/main.go \
 		--config ./conf/prometheus.yml \
-		--cluster cluster \
-		--use-logs-new-schema true \
-		--use-trace-new-schema true
+		--cluster cluster
 
 .PHONY: go-build-community $(GO_BUILD_ARCHS_COMMUNITY)
 go-build-community: ## Builds the go backend server for community

--- a/deploy/docker-swarm/docker-compose.ha.yaml
+++ b/deploy/docker-swarm/docker-compose.ha.yaml
@@ -177,8 +177,6 @@ services:
     image: signoz/signoz:v0.82.0
     command:
       - --config=/root/config/prometheus.yml
-      - --use-logs-new-schema=true
-      - --use-trace-new-schema=true
     ports:
       - "8080:8080" # signoz port
     #   - "6060:6060"     # pprof port

--- a/deploy/docker-swarm/docker-compose.yaml
+++ b/deploy/docker-swarm/docker-compose.yaml
@@ -113,8 +113,6 @@ services:
     image: signoz/signoz:v0.82.0
     command:
       - --config=/root/config/prometheus.yml
-      - --use-logs-new-schema=true
-      - --use-trace-new-schema=true
     ports:
       - "8080:8080" # signoz port
     #   - "6060:6060"     # pprof port

--- a/deploy/docker/docker-compose.ha.yaml
+++ b/deploy/docker/docker-compose.ha.yaml
@@ -181,8 +181,6 @@ services:
     container_name: signoz
     command:
       - --config=/root/config/prometheus.yml
-      - --use-logs-new-schema=true
-      - --use-trace-new-schema=true
     ports:
       - "8080:8080" # signoz port
     #   - "6060:6060"     # pprof port

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -114,8 +114,6 @@ services:
     container_name: signoz
     command:
       - --config=/root/config/prometheus.yml
-      - --use-logs-new-schema=true
-      - --use-trace-new-schema=true
     ports:
       - "8080:8080" # signoz port
     #   - "6060:6060"     # pprof port


### PR DESCRIPTION
### Summary

- remove deprecated signoz arguments

#### Related Issues / PR's

NA

#### Screenshots

NA

#### Affected Areas and Manually Tested Areas

NA
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove deprecated Signoz arguments from `Makefile` and Docker Compose files.
> 
>   - **Makefile**:
>     - Removed `--use-logs-new-schema` and `--use-trace-new-schema` from `go-run-enterprise` and `go-run-community` targets.
>   - **Docker Compose**:
>     - Removed `--use-logs-new-schema` and `--use-trace-new-schema` from `docker-compose.ha.yaml`, `docker-compose.yaml`, `docker-compose.ha.yaml`, and `docker-compose.yaml` under `deploy/docker-swarm` and `deploy/docker` directories.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 5801fc6d427dc06efcb446ab1079e58baa2668e4. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->