### PR TITLE
Revert "chore(signoz): remove deprecated signoz arguments"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,9 @@ go-run-enterprise: ## Runs the enterprise go backend server
 	go run -race \
 		$(GO_BUILD_CONTEXT_ENTERPRISE)/main.go \
 		--config ./conf/prometheus.yml \
-		--cluster cluster
+		--cluster cluster \
+		--use-logs-new-schema true \
+		--use-trace-new-schema true
 
 .PHONY: go-test
 go-test: ## Runs go unit tests
@@ -94,7 +96,9 @@ go-run-community: ## Runs the community go backend server
 	go run -race \
 		$(GO_BUILD_CONTEXT_COMMUNITY)/main.go \
 		--config ./conf/prometheus.yml \
-		--cluster cluster
+		--cluster cluster \
+		--use-logs-new-schema true \
+		--use-trace-new-schema true
 
 .PHONY: go-build-community $(GO_BUILD_ARCHS_COMMUNITY)
 go-build-community: ## Builds the go backend server for community

--- a/deploy/docker-swarm/docker-compose.ha.yaml
+++ b/deploy/docker-swarm/docker-compose.ha.yaml
@@ -177,6 +177,8 @@ services:
     image: signoz/signoz:v0.82.0
     command:
       - --config=/root/config/prometheus.yml
+      - --use-logs-new-schema=true
+      - --use-trace-new-schema=true
     ports:
       - "8080:8080" # signoz port
     #   - "6060:6060"     # pprof port

--- a/deploy/docker-swarm/docker-compose.yaml
+++ b/deploy/docker-swarm/docker-compose.yaml
@@ -113,6 +113,8 @@ services:
     image: signoz/signoz:v0.82.0
     command:
       - --config=/root/config/prometheus.yml
+      - --use-logs-new-schema=true
+      - --use-trace-new-schema=true
     ports:
       - "8080:8080" # signoz port
     #   - "6060:6060"     # pprof port

--- a/deploy/docker/docker-compose.ha.yaml
+++ b/deploy/docker/docker-compose.ha.yaml
@@ -181,6 +181,8 @@ services:
     container_name: signoz
     command:
       - --config=/root/config/prometheus.yml
+      - --use-logs-new-schema=true
+      - --use-trace-new-schema=true
     ports:
       - "8080:8080" # signoz port
     #   - "6060:6060"     # pprof port

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -114,6 +114,8 @@ services:
     container_name: signoz
     command:
       - --config=/root/config/prometheus.yml
+      - --use-logs-new-schema=true
+      - --use-trace-new-schema=true
     ports:
       - "8080:8080" # signoz port
     #   - "6060:6060"     # pprof port


### PR DESCRIPTION
Reverts SigNoz/signoz#7849
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts removal of deprecated SigNoz arguments, reintroducing `--use-logs-new-schema` and `--use-trace-new-schema` in `Makefile` and Docker Compose files.
> 
>   - **Reversion**:
>     - Reverts removal of deprecated SigNoz arguments `--use-logs-new-schema` and `--use-trace-new-schema`.
>   - **Makefile**:
>     - Re-adds `--use-logs-new-schema true` and `--use-trace-new-schema true` to `go-run-enterprise` and `go-run-community` targets.
>   - **Docker Compose**:
>     - Re-adds `--use-logs-new-schema=true` and `--use-trace-new-schema=true` in `docker-compose.ha.yaml`, `docker-compose.yaml`, and `docker-compose.ha.yaml` for `signoz` service.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for a63fe3b85cbf4da2b9777e14c44ab168b30668b7. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->