### PR TITLE
fix: fix 'open in explorer' functionality in metrics explorer

### DIFF
--- a/frontend/src/container/MetricsExplorer/MetricDetails/AllAttributes.tsx
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/AllAttributes.tsx
@@ -3,28 +3,40 @@ import { ColumnsType } from 'antd/es/table';
 import { ResizeTable } from 'components/ResizeTable';
 import { DataType } from 'container/LogDetailedView/TableView';
 import { Search } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { AllAttributesProps } from './types';
+import { useHandleExplorerTabChange } from '../../../hooks/useHandleExplorerTabChange';
+import { getMetricDetailsQuery } from './utils';
+import ROUTES from '../../../constants/routes';
+import { PANEL_TYPES } from '../../../constants/queryBuilder';
 
-function AllAttributes({ attributes }: AllAttributesProps): JSX.Element {
+function AllAttributes({
+	metricName,
+	attributes,
+}: AllAttributesProps): JSX.Element {
 	const [searchString, setSearchString] = useState('');
 	const [activeKey, setActiveKey] = useState<string | string[]>(
 		'all-attributes',
 	);
 
-	// const { safeNavigate } = useSafeNavigate();
+	const { handleExplorerTabChange } = useHandleExplorerTabChange();
 
-	// const goToMetricsExploreWithAppliedAttribute = useCallback(
-	// 	(key: string, value: string) => {
-	// 		const compositeQuery = getMetricDetailsQuery(metricName, { key, value });
-	// 		const encodedCompositeQuery = JSON.stringify(compositeQuery);
-	// 		safeNavigate(
-	// 			`${ROUTES.METRICS_EXPLORER_EXPLORER}?compositeQuery=${encodedCompositeQuery}`,
-	// 		);
-	// 	},
-	// 	[metricName, safeNavigate],
-	// );
+	const goToMetricsExploreWithAppliedAttribute = useCallback(
+		(key: string, value: string) => {
+			const compositeQuery = getMetricDetailsQuery(metricName, { key, value });
+			handleExplorerTabChange(
+				PANEL_TYPES.TIME_SERIES,
+				{
+					query: compositeQuery,
+					name: metricName,
+					id: metricName,
+				},
+				ROUTES.METRICS_EXPLORER_EXPLORER,
+			);
+		},
+		[metricName, handleExplorerTabChange],
+	);
 
 	const filteredAttributes = useMemo(
 		() =>
@@ -81,10 +93,9 @@ function AllAttributes({ attributes }: AllAttributesProps): JSX.Element {
 							<Button
 								key={attribute}
 								type="text"
-								// TODO: Enable this once we have fixed the redirect issue
-								// onClick={(): void => {
-								// 	goToMetricsExploreWithAppliedAttribute(field.key, attribute);
-								// }}
+								onClick={(): void => {
+									goToMetricsExploreWithAppliedAttribute(field.key, attribute);
+								}}
 							>
 								<Typography.Text>{attribute}</Typography.Text>
 							</Button>
@@ -93,7 +104,7 @@ function AllAttributes({ attributes }: AllAttributesProps): JSX.Element {
 				),
 			},
 		],
-		[],
+		[goToMetricsExploreWithAppliedAttribute],
 	);
 
 	const items = useMemo(

--- a/frontend/src/container/MetricsExplorer/MetricDetails/MetricDetails.styles.scss
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/MetricDetails.styles.scss
@@ -14,6 +14,11 @@
 			}
 		}
 
+		.metric-details-header-buttons {
+			display: flex;
+			gap: 8px;
+		}
+
 		.ant-btn {
 			display: flex;
 			align-items: center;

--- a/frontend/src/container/MetricsExplorer/MetricDetails/MetricDetails.tsx
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/MetricDetails.tsx
@@ -111,8 +111,6 @@ function MetricDetails({
 							onClick={goToMetricsExplorerwithSelectedMetric}
 							icon={<Compass size={16} />}
 							disabled={!metricName}
-							target="_blank"
-							rel="noopener noreferrer"
 							data-testid="open-in-explorer-button"
 						>
 							Open in Explorer

--- a/frontend/src/container/MetricsExplorer/MetricDetails/MetricDetails.tsx
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/MetricDetails.tsx
@@ -113,6 +113,7 @@ function MetricDetails({
 							disabled={!metricName}
 							target="_blank"
 							rel="noopener noreferrer"
+							data-testid="open-in-explorer-button"
 						>
 							Open in Explorer
 						</Button>
@@ -127,6 +128,7 @@ function MetricDetails({
 										openInspectModal(metric.name);
 									}
 								}}
+								data-testid="inspect-metric-button"
 							/>
 						)}
 					</div>

--- a/frontend/src/container/MetricsExplorer/MetricDetails/MetricDetails.tsx
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/MetricDetails.tsx
@@ -13,8 +13,8 @@ import {
 } from 'antd';
 import { useGetMetricDetails } from 'hooks/metricsExplorer/useGetMetricDetails';
 import { useIsDarkMode } from 'hooks/useDarkMode';
-import { Compass, X } from 'lucide-react';
-import { useMemo } from 'react';
+import { Compass, Crosshair, X } from 'lucide-react';
+import { useCallback, useMemo } from 'react';
 
 import { isInspectEnabled } from '../Inspect/utils';
 import { formatNumberIntoHumanReadableFormat } from '../Summary/utils';
@@ -25,7 +25,11 @@ import { MetricDetailsProps } from './types';
 import {
 	formatNumberToCompactFormat,
 	formatTimestampToReadableDate,
+	getMetricDetailsQuery,
 } from './utils';
+import { PANEL_TYPES } from '../../../constants/queryBuilder';
+import ROUTES from '../../../constants/routes';
+import { useHandleExplorerTabChange } from '../../../hooks/useHandleExplorerTabChange';
 
 function MetricDetails({
 	onClose,
@@ -34,7 +38,7 @@ function MetricDetails({
 	openInspectModal,
 }: MetricDetailsProps): JSX.Element {
 	const isDarkMode = useIsDarkMode();
-	// const { safeNavigate } = useSafeNavigate();
+	const { handleExplorerTabChange } = useHandleExplorerTabChange();
 
 	const {
 		data,
@@ -76,15 +80,20 @@ function MetricDetails({
 		);
 	}, [metric]);
 
-	// const goToMetricsExplorerwithSelectedMetric = useCallback(() => {
-	// 	if (metricName) {
-	// 		const compositeQuery = getMetricDetailsQuery(metricName);
-	// 		const encodedCompositeQuery = JSON.stringify(compositeQuery);
-	// 		safeNavigate(
-	// 			`${ROUTES.METRICS_EXPLORER_EXPLORER}?compositeQuery=${encodedCompositeQuery}`,
-	// 		);
-	// 	}
-	// }, [metricName, safeNavigate]);
+	const goToMetricsExplorerwithSelectedMetric = useCallback(() => {
+		if (metricName) {
+			const compositeQuery = getMetricDetailsQuery(metricName);
+			handleExplorerTabChange(
+				PANEL_TYPES.TIME_SERIES,
+				{
+					query: compositeQuery,
+					name: metricName,
+					id: metricName,
+				},
+				ROUTES.METRICS_EXPLORER_EXPLORER,
+			);
+		}
+	}, [metricName, handleExplorerTabChange]);
 
 	const isMetricDetailsError = metricDetailsError || !metric;
 
@@ -97,29 +106,30 @@ function MetricDetails({
 						<Divider type="vertical" />
 						<Typography.Text>{metric?.name}</Typography.Text>
 					</div>
-					{/* TODO: Enable this once we have fixed the redirect issue */}
-					{/* <Button
-						onClick={goToMetricsExplorerwithSelectedMetric}
-						icon={<Compass size={16} />}
-						disabled={!metricName}
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Open in Explorer
-					</Button> */}
-					{/* Show the based on the feature flag. Will remove before releasing the feature */}
-					{showInspectFeature && (
+					<div className="metric-details-header-buttons">
 						<Button
-							className="inspect-metrics-button"
-							aria-label="Inspect Metric"
-							icon={<Compass size={18} />}
-							onClick={(): void => {
-								if (metric?.name) {
-									openInspectModal(metric.name);
-								}
-							}}
-						/>
-					)}
+							onClick={goToMetricsExplorerwithSelectedMetric}
+							icon={<Compass size={16} />}
+							disabled={!metricName}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Open in Explorer
+						</Button>
+						{/* Show the based on the feature flag. Will remove before releasing the feature */}
+						{showInspectFeature && (
+							<Button
+								className="inspect-metrics-button"
+								aria-label="Inspect Metric"
+								icon={<Crosshair size={18} />}
+								onClick={(): void => {
+									if (metric?.name) {
+										openInspectModal(metric.name);
+									}
+								}}
+							/>
+						)}
+					</div>
 				</div>
 			}
 			placement="right"

--- a/frontend/src/container/MetricsExplorer/MetricDetails/__tests__/AllAttributes.test.tsx
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/__tests__/AllAttributes.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import AllAttributes from '../AllAttributes';
+import { MetricDetailsAttribute } from '../../../../api/metricsExplorer/getMetricDetails';
+import ROUTES from '../../../../constants/routes';
+import * as useHandleExplorerTabChange from 'hooks/useHandleExplorerTabChange';
+
+jest.mock('react-router-dom', () => ({
+	...jest.requireActual('react-router-dom'),
+	useLocation: (): { pathname: string } => ({
+		pathname: `${ROUTES.METRICS_EXPLORER}`,
+	}),
+}));
+const mockHandleExplorerTabChange = jest.fn();
+jest
+	.spyOn(useHandleExplorerTabChange, 'useHandleExplorerTabChange')
+	.mockReturnValue({
+		handleExplorerTabChange: mockHandleExplorerTabChange,
+	});
+
+const mockMetricName = 'test-metric';
+const mockAttributes: MetricDetailsAttribute[] = [
+	{
+		key: 'attribute1',
+		value: ['value1', 'value2'],
+		valueCount: 2,
+	},
+	{
+		key: 'attribute2',
+		value: ['value3'],
+		valueCount: 1,
+	},
+];
+
+describe('AllAttributes', () => {
+	it('renders attributes section with title', () => {
+		render(
+			<AllAttributes metricName={mockMetricName} attributes={mockAttributes} />,
+		);
+
+		expect(screen.getByText('All Attributes')).toBeInTheDocument();
+	});
+
+	it('renders all attribute keys and values', () => {
+		render(
+			<AllAttributes metricName={mockMetricName} attributes={mockAttributes} />,
+		);
+
+		// Check attribute keys are rendered
+		expect(screen.getByText('attribute1')).toBeInTheDocument();
+		expect(screen.getByText('attribute2')).toBeInTheDocument();
+
+		// Check attribute values are rendered
+		expect(screen.getByText('value1')).toBeInTheDocument();
+		expect(screen.getByText('value2')).toBeInTheDocument();
+		expect(screen.getByText('value3')).toBeInTheDocument();
+	});
+
+	it('renders value counts correctly', () => {
+		render(
+			<AllAttributes metricName={mockMetricName} attributes={mockAttributes} />,
+		);
+
+		expect(screen.getByText('2')).toBeInTheDocument(); // For attribute1
+		expect(screen.getByText('1')).toBeInTheDocument(); // For attribute2
+	});
+
+	it('handles empty attributes array', () => {
+		render(<AllAttributes metricName={mockMetricName} attributes={[]} />);
+
+		expect(screen.getByText('All Attributes')).toBeInTheDocument();
+		expect(screen.queryByText('No data')).toBeInTheDocument();
+	});
+
+	it('clicking on an attribute value opens the explorer with the attribute filter applied', () => {
+		render(
+			<AllAttributes metricName={mockMetricName} attributes={mockAttributes} />,
+		);
+		fireEvent.click(screen.getByText('value1'));
+		expect(mockHandleExplorerTabChange).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

- Fix the functionality of opening a metric in the explorer section from the metric details drawer
- Also fixed the flow where we can click on a attribute from a metric which will redirect to the explorer page with the metric name and filter applied
- Also updated the inspect button icon so that it's not the same as that of 'Open in Explorer'
- Added unit tests

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

Fixes #7366

#### Screenshots

https://github.com/user-attachments/assets/06e32963-40b6-4590-a741-feb4fad0ae9d

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

Metrics Explorer

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix 'Open in Explorer' functionality in Metrics Explorer and update inspect button icon.
> 
>   - **Functionality Fixes**:
>     - Fix 'Open in Explorer' functionality in `MetricDetails.tsx` and `AllAttributes.tsx` to correctly redirect with metric name and filters applied.
>     - Update inspect button icon in `MetricDetails.tsx` to differentiate from 'Open in Explorer'.
>   - **Testing**:
>     - Add tests in `AllAttributes.test.tsx` to verify explorer redirection with attribute filters.
>     - Add tests in `MetricDetails.test.tsx` to verify button rendering and functionality.
>   - **Styles**:
>     - Update styles in `MetricDetails.styles.scss` for button layout and appearance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 70b38b70d1acaa21180ed56d5354218b47dc7258. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->