### PR TITLE
chore: persist one chart per query toggle across refreshes and exports

### DIFF
--- a/frontend/src/container/MetricsExplorer/Explorer/Explorer.tsx
+++ b/frontend/src/container/MetricsExplorer/Explorer/Explorer.tsx
@@ -56,7 +56,7 @@ function Explorer(): JSX.Element {
 
 	const handleToggleShowOneChartPerQuery = (): void => {
 		toggleShowOneChartPerQuery(!showOneChartPerQuery);
-		setSearchParams({
+		setSearchParams({ ...Object.fromEntries(searchParams),
 			[ONE_CHART_PER_QUERY_ENABLED_KEY]: (!showOneChartPerQuery).toString(),
 		});
 	};

--- a/frontend/src/container/MetricsExplorer/Explorer/Explorer.tsx
+++ b/frontend/src/container/MetricsExplorer/Explorer/Explorer.tsx
@@ -17,6 +17,7 @@ import { useNotifications } from 'hooks/useNotifications';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import ErrorBoundaryFallback from 'pages/ErrorBoundaryFallback/ErrorBoundaryFallback';
 import { useCallback, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom-v5-compat';
 import { Dashboard } from 'types/api/dashboard/getAll';
 import { DataSource } from 'types/common/queryBuilder';
 import { generateExportToDashboardLink } from 'utils/dashboard/generateExportToDashboardLink';
@@ -25,6 +26,8 @@ import { v4 as uuid } from 'uuid';
 import QuerySection from './QuerySection';
 import TimeSeries from './TimeSeries';
 import { ExplorerTabs } from './types';
+
+const ONE_CHART_PER_QUERY_ENABLED_KEY = 'isOneChartPerQueryEnabled';
 
 function Explorer(): JSX.Element {
 	const {
@@ -42,11 +45,21 @@ function Explorer(): JSX.Element {
 		aggregateOperator: 'noop',
 	});
 
-	const [showOneChartPerQuery, toggleShowOneChartPerQuery] = useState(false);
+	const [searchParams, setSearchParams] = useSearchParams();
+	const isOneChartPerQueryEnabled =
+		searchParams.get(ONE_CHART_PER_QUERY_ENABLED_KEY) === 'true';
+
+	const [showOneChartPerQuery, toggleShowOneChartPerQuery] = useState(
+		isOneChartPerQueryEnabled,
+	);
 	const [selectedTab] = useState<ExplorerTabs>(ExplorerTabs.TIME_SERIES);
 
-	const handleToggleShowOneChartPerQuery = (): void =>
+	const handleToggleShowOneChartPerQuery = (): void => {
 		toggleShowOneChartPerQuery(!showOneChartPerQuery);
+		setSearchParams({
+			[ONE_CHART_PER_QUERY_ENABLED_KEY]: (!showOneChartPerQuery).toString(),
+		});
+	};
 
 	const exportDefaultQuery = useMemo(
 		() =>

--- a/frontend/src/container/MetricsExplorer/Explorer/Explorer.tsx
+++ b/frontend/src/container/MetricsExplorer/Explorer/Explorer.tsx
@@ -56,7 +56,8 @@ function Explorer(): JSX.Element {
 
 	const handleToggleShowOneChartPerQuery = (): void => {
 		toggleShowOneChartPerQuery(!showOneChartPerQuery);
-		setSearchParams({ ...Object.fromEntries(searchParams),
+		setSearchParams({
+			...Object.fromEntries(searchParams),
 			[ONE_CHART_PER_QUERY_ENABLED_KEY]: (!showOneChartPerQuery).toString(),
 		});
 	};

--- a/frontend/src/container/MetricsExplorer/Explorer/__tests__/Explorer.test.tsx
+++ b/frontend/src/container/MetricsExplorer/Explorer/__tests__/Explorer.test.tsx
@@ -1,20 +1,58 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
-import ROUTES from 'constants/routes';
 import * as useOptionsMenuHooks from 'container/OptionsMenu';
 import * as useUpdateDashboardHooks from 'hooks/dashboard/useUpdateDashboard';
 import * as useQueryBuilderHooks from 'hooks/queryBuilder/useQueryBuilder';
+import * as appContextHooks from 'providers/App/App';
+import * as timezoneHooks from 'providers/Timezone';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom-v5-compat';
 import store from 'store';
+import { LicenseEvent } from 'types/api/licensesV3/getActive';
 import { DataSource } from 'types/common/queryBuilder';
 
 import Explorer from '../Explorer';
 
-jest.mock('react-router-dom', () => ({
-	...jest.requireActual('react-router-dom'),
-	useLocation: (): { pathname: string } => ({
-		pathname: `${ROUTES.METRICS_EXPLORER_EXPLORER}`,
+const mockSetSearchParams = jest.fn();
+const queryClient = new QueryClient();
+const mockUpdateAllQueriesOperators = jest.fn();
+const mockUseQueryBuilderData = {
+	handleRunQuery: jest.fn(),
+	stagedQuery: initialQueriesMap[DataSource.METRICS],
+	updateAllQueriesOperators: mockUpdateAllQueriesOperators,
+	currentQuery: initialQueriesMap[DataSource.METRICS],
+	resetQuery: jest.fn(),
+	redirectWithQueryBuilderData: jest.fn(),
+	isStagedQueryUpdated: jest.fn(),
+	handleSetQueryData: jest.fn(),
+	handleSetFormulaData: jest.fn(),
+	handleSetQueryItemData: jest.fn(),
+	handleSetConfig: jest.fn(),
+	removeQueryBuilderEntityByIndex: jest.fn(),
+	removeQueryTypeItemByIndex: jest.fn(),
+	isDefaultQuery: jest.fn(),
+};
+
+jest.mock('react-router-dom-v5-compat', () => {
+	const actual = jest.requireActual('react-router-dom-v5-compat');
+	return {
+		...actual,
+		useSearchParams: jest.fn(),
+		useNavigationType: (): any => 'PUSH',
+	};
+});
+jest.mock('hooks/useDimensions', () => ({
+	useResizeObserver: (): { width: number; height: number } => ({
+		width: 800,
+		height: 400,
+	}),
+}));
+jest.mock('react-query', () => ({
+	...jest.requireActual('react-query'),
+	useQueryClient: jest.fn().mockReturnValue({
+		getQueriesData: jest.fn(),
 	}),
 }));
 jest.mock('hooks/useSafeNavigate', () => ({
@@ -60,42 +98,116 @@ jest.spyOn(useUpdateDashboardHooks, 'useUpdateDashboard').mockReturnValue({
 	mutate: jest.fn(),
 	isLoading: false,
 } as any);
-
 jest.spyOn(useOptionsMenuHooks, 'useOptionsMenu').mockReturnValue({
-	selectColumns: [],
+	options: {
+		selectColumns: [],
+	},
 } as any);
-
-const mockUpdateAllQueriesOperators = jest.fn();
-const mockUseQueryBuilderData = {
-	handleRunQuery: jest.fn(),
-	stagedQuery: initialQueriesMap[DataSource.METRICS],
-	updateAllQueriesOperators: mockUpdateAllQueriesOperators,
-	currentQuery: initialQueriesMap[DataSource.METRICS],
-	resetQuery: jest.fn(),
-	redirectWithQueryBuilderData: jest.fn(),
-};
+jest.spyOn(timezoneHooks, 'useTimezone').mockReturnValue({
+	timezone: {
+		offset: 0,
+	},
+	browserTimezone: {
+		offset: 0,
+	},
+} as any);
+jest.spyOn(appContextHooks, 'useAppContext').mockReturnValue({
+	user: {
+		role: 'admin',
+	},
+	activeLicenseV3: {
+		event_queue: {
+			created_at: '0',
+			event: LicenseEvent.NO_EVENT,
+			scheduled_at: '0',
+			status: '',
+			updated_at: '0',
+		},
+		license: {
+			license_key: 'test-license-key',
+			license_type: 'trial',
+			org_id: 'test-org-id',
+			plan_id: 'test-plan-id',
+			plan_name: 'test-plan-name',
+			plan_type: 'trial',
+			plan_version: 'test-plan-version',
+		},
+	},
+} as any);
 jest.spyOn(useQueryBuilderHooks, 'useQueryBuilder').mockReturnValue({
-	mockUseQueryBuilderData,
+	...mockUseQueryBuilderData,
 } as any);
 
 describe('Explorer', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
 	it('should render Explorer query builder with metrics datasource selected', () => {
 		jest.spyOn(useQueryBuilderHooks, 'useQueryBuilder').mockReturnValue({
 			...mockUseQueryBuilderData,
-			// Initially have a different datasource
 			stagedQuery: initialQueriesMap[DataSource.TRACES],
 		} as any);
+
+		(useSearchParams as jest.Mock).mockReturnValue([
+			new URLSearchParams({ isOneChartPerQueryEnabled: 'false' }),
+			mockSetSearchParams,
+		]);
+
 		render(
-			<MemoryRouter>
-				<Provider store={store}>
-					<Explorer />
-				</Provider>
-			</MemoryRouter>,
+			<QueryClientProvider client={queryClient}>
+				<MemoryRouter>
+					<Provider store={store}>
+						<Explorer />
+					</Provider>
+				</MemoryRouter>
+			</QueryClientProvider>,
 		);
+
 		expect(mockUpdateAllQueriesOperators).toHaveBeenCalledWith(
 			initialQueriesMap[DataSource.METRICS],
 			PANEL_TYPES.TIME_SERIES,
 			DataSource.METRICS,
 		);
+	});
+
+	it('should enable one chart per query toggle when oneChartPerQuery=true in URL', () => {
+		(useSearchParams as jest.Mock).mockReturnValue([
+			new URLSearchParams({ isOneChartPerQueryEnabled: 'true' }),
+			mockSetSearchParams,
+		]);
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<MemoryRouter>
+					<Provider store={store}>
+						<Explorer />
+					</Provider>
+				</MemoryRouter>
+			</QueryClientProvider>,
+		);
+
+		const toggle = screen.getByRole('switch');
+		expect(toggle).toBeChecked();
+	});
+
+	it('should disable one chart per query toggle when oneChartPerQuery=false in URL', () => {
+		(useSearchParams as jest.Mock).mockReturnValue([
+			new URLSearchParams({ isOneChartPerQueryEnabled: 'false' }),
+			mockSetSearchParams,
+		]);
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<MemoryRouter>
+					<Provider store={store}>
+						<Explorer />
+					</Provider>
+				</MemoryRouter>
+			</QueryClientProvider>,
+		);
+
+		const toggle = screen.getByRole('switch');
+		expect(toggle).not.toBeChecked();
 	});
 });


### PR DESCRIPTION
### Summary

<!-- ✍️ A clear and concise description...-->

In the explorer section, persist one chart per query toggle across refreshes and exports (sharing links)

#### Related Issues / PR's

<!-- ✍️ Add the issues being resolved here and related PR's where applicable  -->

Closes #7720 

#### Screenshots

https://github.com/user-attachments/assets/0f97bc28-8e49-47ea-a156-80ff9ec12bae

<!-- ✍️ Add screenshots of before and after changes where applicable-->

#### Affected Areas and Manually Tested Areas

<!-- ✍️ Add details of blast radius and dev testing areas where applicable-->

Metrics Explorer

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Persist 'one chart per query' toggle state in Metrics Explorer using URL parameters, with tests for state persistence.
> 
>   - **Behavior**:
>     - Persist 'one chart per query' toggle state using URL search parameters in `Explorer.tsx`.
>     - Toggle state is maintained across page refreshes and exports.
>   - **Tests**:
>     - Add tests in `Explorer.test.tsx` to verify toggle state persistence based on URL parameters.
>     - Ensure toggle is checked when `isOneChartPerQueryEnabled=true` and unchecked when `false`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e8b7c853ac2f2b18d7f0dafbb6eb6f38105780e3. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->