### PR TITLE
Fix: Update query_range api from v3 to v4 (Logs and Traces)

### DIFF
--- a/frontend/src/container/LogsExplorerViews/index.tsx
+++ b/frontend/src/container/LogsExplorerViews/index.tsx
@@ -6,7 +6,7 @@ import { getQueryStats, WsDataEvent } from 'api/common/getQueryStats';
 import logEvent from 'api/common/logEvent';
 import { getYAxisFormattedValue } from 'components/Graph/yAxisConfig';
 import LogsFormatOptionsMenu from 'components/LogsFormatOptionsMenu/LogsFormatOptionsMenu';
-import { DEFAULT_ENTITY_VERSION } from 'constants/app';
+import { ENTITY_VERSION_V4 } from 'constants/app';
 import { DATE_TIME_FORMATS } from 'constants/dateTimeFormats';
 import { LOCALSTORAGE } from 'constants/localStorage';
 import { AVAILABLE_EXPORT_PANEL_TYPES } from 'constants/panelTypes';
@@ -247,7 +247,7 @@ function LogsExplorerViews({
 	} = useGetExplorerQueryRange(
 		listChartQuery,
 		PANEL_TYPES.TIME_SERIES,
-		DEFAULT_ENTITY_VERSION,
+		ENTITY_VERSION_V4,
 		{
 			enabled: !!listChartQuery && panelType === PANEL_TYPES.LIST,
 		},
@@ -265,7 +265,7 @@ function LogsExplorerViews({
 	} = useGetExplorerQueryRange(
 		requestData,
 		panelType,
-		DEFAULT_ENTITY_VERSION,
+		ENTITY_VERSION_V4,
 		{
 			keepPreviousData: true,
 			enabled: !isLimit && !!requestData,

--- a/frontend/src/container/TimeSeriesView/index.tsx
+++ b/frontend/src/container/TimeSeriesView/index.tsx
@@ -1,4 +1,4 @@
-import { DEFAULT_ENTITY_VERSION } from 'constants/app';
+import { ENTITY_VERSION_V4 } from 'constants/app';
 import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { useGetQueryRange } from 'hooks/queryBuilder/useGetQueryRange';
@@ -52,7 +52,7 @@ function TimeSeriesViewContainer({
 				dataSource,
 			},
 		},
-		DEFAULT_ENTITY_VERSION,
+		ENTITY_VERSION_V4,
 		{
 			queryKey: [
 				REACT_QUERY_KEY.GET_QUERY_RANGE,

--- a/frontend/src/container/TracesExplorer/ListView/index.tsx
+++ b/frontend/src/container/TracesExplorer/ListView/index.tsx
@@ -1,6 +1,6 @@
 import logEvent from 'api/common/logEvent';
 import { ResizeTable } from 'components/ResizeTable';
-import { DEFAULT_ENTITY_VERSION } from 'constants/app';
+import { ENTITY_VERSION_V4 } from 'constants/app';
 import { LOCALSTORAGE } from 'constants/localStorage';
 import { QueryParams } from 'constants/query';
 import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
@@ -104,7 +104,7 @@ function ListView({ isFilterApplied }: ListViewProps): JSX.Element {
 				selectColumns: options?.selectColumns,
 			},
 		},
-		DEFAULT_ENTITY_VERSION,
+		ENTITY_VERSION_V4,
 		{
 			queryKey,
 			enabled:

--- a/frontend/src/container/TracesExplorer/TableView/index.tsx
+++ b/frontend/src/container/TracesExplorer/TableView/index.tsx
@@ -1,5 +1,5 @@
 import { Space } from 'antd';
-import { DEFAULT_ENTITY_VERSION } from 'constants/app';
+import { ENTITY_VERSION_V4 } from 'constants/app';
 import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { QueryTable } from 'container/QueryTable';
@@ -28,7 +28,7 @@ function TableView(): JSX.Element {
 				dataSource: 'traces',
 			},
 		},
-		DEFAULT_ENTITY_VERSION,
+		ENTITY_VERSION_V4,
 		{
 			queryKey: [
 				REACT_QUERY_KEY.GET_QUERY_RANGE,

--- a/frontend/src/container/TracesExplorer/TracesView/index.tsx
+++ b/frontend/src/container/TracesExplorer/TracesView/index.tsx
@@ -1,7 +1,7 @@
 import { Typography } from 'antd';
 import logEvent from 'api/common/logEvent';
 import { ResizeTable } from 'components/ResizeTable';
-import { DEFAULT_ENTITY_VERSION } from 'constants/app';
+import { ENTITY_VERSION_V4 } from 'constants/app';
 import { QueryParams } from 'constants/query';
 import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
@@ -52,7 +52,7 @@ function TracesView({ isFilterApplied }: TracesViewProps): JSX.Element {
 				pagination: paginationQueryData,
 			},
 		},
-		DEFAULT_ENTITY_VERSION,
+		ENTITY_VERSION_V4,
 		{
 			queryKey: [
 				REACT_QUERY_KEY.GET_QUERY_RANGE,

--- a/frontend/src/pages/TracesExplorer/__test__/TracesExplorer.test.tsx
+++ b/frontend/src/pages/TracesExplorer/__test__/TracesExplorer.test.tsx
@@ -465,7 +465,7 @@ jest.mock('hooks/useHandleExplorerTabChange', () => ({
 describe('TracesExplorer - ', () => {
 	it('should render the traces explorer page', async () => {
 		server.use(
-			rest.post('http://localhost/api/v3/query_range', (req, res, ctx) =>
+			rest.post('http://localhost/api/v4/query_range', (req, res, ctx) =>
 				res(ctx.status(200), ctx.json(queryRangeForTimeSeries)),
 			),
 		);
@@ -513,7 +513,7 @@ describe('TracesExplorer - ', () => {
 
 	it('trace explorer - list view', async () => {
 		server.use(
-			rest.post('http://localhost/api/v3/query_range', (req, res, ctx) =>
+			rest.post('http://localhost/api/v4/query_range', (req, res, ctx) =>
 				res(ctx.status(200), ctx.json(queryRangeForListView)),
 			),
 		);
@@ -536,7 +536,7 @@ describe('TracesExplorer - ', () => {
 
 	it('trace explorer - table view', async () => {
 		server.use(
-			rest.post('http://localhost/api/v3/query_range', (req, res, ctx) =>
+			rest.post('http://localhost/api/v4/query_range', (req, res, ctx) =>
 				res(ctx.status(200), ctx.json(queryRangeForTableView)),
 			),
 		);
@@ -554,7 +554,7 @@ describe('TracesExplorer - ', () => {
 
 	it('trace explorer - trace view', async () => {
 		server.use(
-			rest.post('http://localhost/api/v3/query_range', (req, res, ctx) =>
+			rest.post('http://localhost/api/v4/query_range', (req, res, ctx) =>
 				res(ctx.status(200), ctx.json(queryRangeForTraceView)),
 			),
 		);


### PR DESCRIPTION
### Summary
Update query range api from v3 to v4 in Logs and Traces (Timeseries/List/Table view)

#### Related Issues / PR's
https://github.com/SigNoz/signoz/issues/7899

#### Affected Areas and Manually Tested Areas

Logs
* List View 
* Time series
* Table

Traces
* List View
* Traces
* Time series
* Table view

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update query_range API from v3 to v4 in Logs and Traces components and tests.
> 
>   - **API Version Update**:
>     - Update `query_range` API from v3 to v4 in `LogsExplorerViews/index.tsx`, `TimeSeriesView/index.tsx`, and `TracesExplorer/ListView/index.tsx`.
>     - Update test cases in `TracesExplorer.test.tsx` to use v4 API endpoint.
>   - **Constants**:
>     - Replace `DEFAULT_ENTITY_VERSION` with `ENTITY_VERSION_V4` in affected components.
>   - **Testing**:
>     - Update mock server responses in `TracesExplorer.test.tsx` to use v4 API.
>     - Ensure all test cases reflect the new API version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 3832b33bf6236c0fedb660cb5435240498c56d95. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->