### PR TITLE
fix: OSS telemetry for the number of services

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1771,7 +1771,7 @@ func (aH *APIHandler) GetWaterfallSpansForTraceWithMetadata(w http.ResponseWrite
 		return
 	}
 	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err != nil {
+	if err == nil {
 		render.Error(w, err)
 		return
 	}

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1711,7 +1711,7 @@ func (aH *APIHandler) getServices(w http.ResponseWriter, r *http.Request) {
 		"number": len(*result),
 	}
 	claims, errv2 := authtypes.ClaimsFromContext(r.Context())
-	if errv2 != nil {
+	if errv2 == nil {
 		telemetry.GetInstance().SendEvent(telemetry.TELEMETRY_EVENT_NUMBER_OF_SERVICES, data, claims.Email, true, false)
 	}
 
@@ -1771,7 +1771,7 @@ func (aH *APIHandler) GetWaterfallSpansForTraceWithMetadata(w http.ResponseWrite
 		return
 	}
 	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err == nil {
+	if err != nil {
 		render.Error(w, err)
 		return
 	}


### PR DESCRIPTION
## 📄 Summary


Fixes the OSS telemetry for sending the `Number of services` events.

---

## ✅ Changes

- [ ] Feature: Brief description
- [x] Bug fix: Brief description




## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes error handling in `GetWaterfallSpansForTraceWithMetadata` in `http_handler.go` by correcting the UUID conversion error check.
> 
>   - **Bug Fix**:
>     - Corrects error handling in `GetWaterfallSpansForTraceWithMetadata` in `http_handler.go` by changing `if err != nil` to `if err == nil` to properly handle UUID conversion errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for a145148c72ab8b29a8a52a241081beb279da827b. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->