### PR TITLE
fix: cover the title as reactNode case for useGetResolvedText

### DIFF
--- a/frontend/src/hooks/dashboard/__test__/useGetResolvedText.test.tsx
+++ b/frontend/src/hooks/dashboard/__test__/useGetResolvedText.test.tsx
@@ -147,4 +147,36 @@ describe('useGetResolvedText', () => {
 		expect(result.current.fullText).toBe(reactNodeText);
 		expect(result.current.truncatedText).toBe(reactNodeText);
 	});
+
+	it('should handle number input', () => {
+		const text = 123;
+		const variables = {
+			'service.name': SERVICE_VAR,
+		};
+
+		const { result } = renderHookWithProps({
+			text,
+			variables,
+		});
+
+		// Should return the number unchanged
+		expect(result.current.fullText).toBe(text);
+		expect(result.current.truncatedText).toBe(text);
+	});
+
+	it('should handle boolean input', () => {
+		const text = true;
+		const variables = {
+			'service.name': SERVICE_VAR,
+		};
+
+		const { result } = renderHookWithProps({
+			text,
+			variables,
+		});
+
+		// Should return the boolean unchanged
+		expect(result.current.fullText).toBe(text);
+		expect(result.current.truncatedText).toBe(text);
+	});
 });

--- a/frontend/src/hooks/dashboard/__test__/useGetResolvedText.test.tsx
+++ b/frontend/src/hooks/dashboard/__test__/useGetResolvedText.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react';
+import React from 'react';
 
 import useGetResolvedText from '../useGetResolvedText';
 
@@ -20,7 +21,7 @@ describe('useGetResolvedText', () => {
 	const TEXT_TEMPLATE = 'Logs count in $service.name in $severity';
 
 	const renderHookWithProps = (props: {
-		text: string;
+		text: string | React.ReactNode;
 		variables?: Record<string, string | number | boolean>;
 		dashboardVariables?: Record<string, any>;
 		maxLength?: number;
@@ -129,5 +130,21 @@ describe('useGetResolvedText', () => {
 		expect(result.current.fullText).toBe(
 			'Logs count in test, app, frontend, env in $unknown',
 		);
+	});
+
+	it('should handle non-string text input (ReactNode)', () => {
+		const reactNodeText = <div>Test ReactNode</div>;
+		const variables = {
+			'service.name': SERVICE_VAR,
+		};
+
+		const { result } = renderHookWithProps({
+			text: reactNodeText,
+			variables,
+		});
+
+		// Should return the ReactNode unchanged
+		expect(result.current.fullText).toBe(reactNodeText);
+		expect(result.current.truncatedText).toBe(reactNodeText);
 	});
 });


### PR DESCRIPTION
## 📄 Summary

- Added edge case handling to the useGetResolvedText hook - like - ReactNode, undefined etc.

---

## ✅ Changes

- [ ] Feature: Brief description
- [x] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- [x] @SigNoz/frontend
- [ ] @SigNoz/backend
- [ ] @SigNoz/devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. Have a added a test specifying this usecase only
2. Open any services dashboard, as the Apdex have a reactnode title

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [x] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `useGetResolvedText` to handle `ReactNode`, `number`, and `boolean` inputs, with tests for these cases.
> 
>   - **Behavior**:
>     - `useGetResolvedText` now handles `ReactNode`, `number`, and `boolean` inputs, returning them unchanged if not a string.
>     - Adds edge case handling for undefined variables, keeping the original text.
>   - **Tests**:
>     - Adds tests in `useGetResolvedText.test.tsx` for `ReactNode`, `number`, and `boolean` inputs.
>     - Tests ensure non-string inputs are returned unchanged.
>   - **Misc**:
>     - Updates `useGetResolvedText` to check if `text` is a string before processing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 160e65db1bdcd6cbf621e7ad346aa83481b99044. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->