### PR TITLE
feat(7274): added dot metrics migration for messaging queue

### DIFF
--- a/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricColumnGraphs.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricColumnGraphs.tsx
@@ -4,22 +4,24 @@ import { useIsDarkMode } from 'hooks/useDarkMode';
 import { useTranslation } from 'react-i18next';
 import { Widgets } from 'types/api/dashboard/getAll';
 
+import { FeatureKeys } from '../../../../constants/features';
+import { useAppContext } from '../../../../providers/App/App';
 import MetricPageGridGraph from './MetricPageGraph';
 import {
-	averageRequestLatencyWidgetData,
-	brokerCountWidgetData,
-	brokerNetworkThroughputWidgetData,
-	bytesConsumedWidgetData,
-	consumerFetchRateWidgetData,
-	consumerGroupMemberWidgetData,
-	consumerLagByGroupWidgetData,
-	consumerOffsetWidgetData,
-	ioWaitTimeWidgetData,
-	kafkaProducerByteRateWidgetData,
-	messagesConsumedWidgetData,
-	producerFetchRequestPurgatoryWidgetData,
-	requestResponseWidgetData,
-	requestTimesWidgetData,
+	getAverageRequestLatencyWidgetData,
+	getBrokerCountWidgetData,
+	getBrokerNetworkThroughputWidgetData,
+	getBytesConsumedWidgetData,
+	getConsumerFetchRateWidgetData,
+	getConsumerGroupMemberWidgetData,
+	getConsumerLagByGroupWidgetData,
+	getConsumerOffsetWidgetData,
+	getIoWaitTimeWidgetData,
+	getKafkaProducerByteRateWidgetData,
+	getMessagesConsumedWidgetData,
+	getProducerFetchRequestPurgatoryWidgetData,
+	getRequestResponseWidgetData,
+	getRequestTimesWidgetData,
 } from './MetricPageUtil';
 
 interface MetricSectionProps {
@@ -71,15 +73,20 @@ function MetricColumnGraphs({
 }): JSX.Element {
 	const { t } = useTranslation('messagingQueues');
 
+	const { featureFlags } = useAppContext();
+	const dotMetricsEnabled =
+		featureFlags?.find((flag) => flag.name === FeatureKeys.DOT_METRICS_ENABLED)
+			?.active || false;
+
 	const metricsData = [
 		{
 			title: t('metricGraphCategory.brokerMetrics.title'),
 			description: t('metricGraphCategory.brokerMetrics.description'),
 			graphCount: [
-				brokerCountWidgetData,
-				requestTimesWidgetData,
-				producerFetchRequestPurgatoryWidgetData,
-				brokerNetworkThroughputWidgetData,
+				getBrokerCountWidgetData(dotMetricsEnabled),
+				getRequestTimesWidgetData(dotMetricsEnabled),
+				getProducerFetchRequestPurgatoryWidgetData(dotMetricsEnabled),
+				getBrokerNetworkThroughputWidgetData(dotMetricsEnabled),
 			],
 			id: 'broker-metrics',
 		},
@@ -87,11 +94,11 @@ function MetricColumnGraphs({
 			title: t('metricGraphCategory.producerMetrics.title'),
 			description: t('metricGraphCategory.producerMetrics.description'),
 			graphCount: [
-				ioWaitTimeWidgetData,
-				requestResponseWidgetData,
-				averageRequestLatencyWidgetData,
-				kafkaProducerByteRateWidgetData,
-				bytesConsumedWidgetData,
+				getIoWaitTimeWidgetData(dotMetricsEnabled),
+				getRequestResponseWidgetData(dotMetricsEnabled),
+				getAverageRequestLatencyWidgetData(dotMetricsEnabled),
+				getKafkaProducerByteRateWidgetData(dotMetricsEnabled),
+				getBytesConsumedWidgetData(dotMetricsEnabled),
 			],
 			id: 'producer-metrics',
 		},
@@ -99,11 +106,11 @@ function MetricColumnGraphs({
 			title: t('metricGraphCategory.consumerMetrics.title'),
 			description: t('metricGraphCategory.consumerMetrics.description'),
 			graphCount: [
-				consumerOffsetWidgetData,
-				consumerGroupMemberWidgetData,
-				consumerLagByGroupWidgetData,
-				consumerFetchRateWidgetData,
-				messagesConsumedWidgetData,
+				getConsumerOffsetWidgetData(dotMetricsEnabled),
+				getConsumerGroupMemberWidgetData(dotMetricsEnabled),
+				getConsumerLagByGroupWidgetData(dotMetricsEnabled),
+				getConsumerFetchRateWidgetData(dotMetricsEnabled),
+				getMessagesConsumedWidgetData(dotMetricsEnabled),
 			],
 			id: 'consumer-metrics',
 		},

--- a/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricPage.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricPage.tsx
@@ -10,17 +10,19 @@ import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Widgets } from 'types/api/dashboard/getAll';
 
+import { FeatureKeys } from '../../../../constants/features';
+import { useAppContext } from '../../../../providers/App/App';
 import MetricColumnGraphs from './MetricColumnGraphs';
 import MetricPageGridGraph from './MetricPageGraph';
 import {
-	cpuRecentUtilizationWidgetData,
-	currentOffsetPartitionWidgetData,
-	insyncReplicasWidgetData,
-	jvmGcCollectionsElapsedWidgetData,
-	jvmGCCountWidgetData,
-	jvmMemoryHeapWidgetData,
-	oldestOffsetWidgetData,
-	partitionCountPerTopicWidgetData,
+	getCpuRecentUtilizationWidgetData,
+	getCurrentOffsetPartitionWidgetData,
+	getInsyncReplicasWidgetData,
+	getJvmGcCollectionsElapsedWidgetData,
+	getJvmGCCountWidgetData,
+	getJvmMemoryHeapWidgetData,
+	getOldestOffsetWidgetData,
+	getPartitionCountPerTopicWidgetData,
 } from './MetricPageUtil';
 
 interface CollapsibleMetricSectionProps {
@@ -95,6 +97,11 @@ function MetricPage(): JSX.Element {
 		}));
 	};
 
+	const { featureFlags } = useAppContext();
+	const dotMetricsEnabled =
+		featureFlags?.find((flag) => flag.name === FeatureKeys.DOT_METRICS_ENABLED)
+			?.active || false;
+
 	const { t } = useTranslation('messagingQueues');
 
 	const metricSections = [
@@ -103,10 +110,10 @@ function MetricPage(): JSX.Element {
 			title: t('metricGraphCategory.brokerJVMMetrics.title'),
 			description: t('metricGraphCategory.brokerJVMMetrics.description'),
 			graphCount: [
-				jvmGCCountWidgetData,
-				jvmGcCollectionsElapsedWidgetData,
-				cpuRecentUtilizationWidgetData,
-				jvmMemoryHeapWidgetData,
+				getJvmGCCountWidgetData(dotMetricsEnabled),
+				getJvmGcCollectionsElapsedWidgetData(dotMetricsEnabled),
+				getCpuRecentUtilizationWidgetData(dotMetricsEnabled),
+				getJvmMemoryHeapWidgetData(dotMetricsEnabled),
 			],
 		},
 		{
@@ -114,10 +121,10 @@ function MetricPage(): JSX.Element {
 			title: t('metricGraphCategory.partitionMetrics.title'),
 			description: t('metricGraphCategory.partitionMetrics.description'),
 			graphCount: [
-				partitionCountPerTopicWidgetData,
-				currentOffsetPartitionWidgetData,
-				oldestOffsetWidgetData,
-				insyncReplicasWidgetData,
+				getPartitionCountPerTopicWidgetData(dotMetricsEnabled),
+				getCurrentOffsetPartitionWidgetData(dotMetricsEnabled),
+				getOldestOffsetWidgetData(dotMetricsEnabled),
+				getInsyncReplicasWidgetData(dotMetricsEnabled),
 			],
 		},
 	];

--- a/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricPageUtil.ts
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricPageUtil.ts
@@ -79,1023 +79,1143 @@ export function getWidgetQuery(
 	};
 }
 
-export const requestTimesWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_request_time_avg--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_request_time_avg',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'Request Times',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'Request Times',
-		description:
-			'This metric is used to measure the average latency experienced by requests across the Kafka broker.',
-	}),
-);
-
-export const brokerCountWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_brokers--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_brokers',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'sum',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'Broker count',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'sum',
-			},
-		],
-		title: 'Broker Count',
-		description: 'Total number of active brokers in the Kafka cluster.\n',
-	}),
-);
-
-export const producerFetchRequestPurgatoryWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_purgatory_size--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_purgatory_size',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'Producer and Fetch Request Purgatory',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'Producer and Fetch Request Purgatory',
-		description:
-			'Measures the number of requests that Kafka brokers have received but cannot immediately fulfill',
-	}),
-);
-
-export const brokerNetworkThroughputWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id:
-						'kafka_server_brokertopicmetrics_bytesoutpersec_oneminuterate--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_server_brokertopicmetrics_bytesoutpersec_oneminuterate',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'Broker Network Throughput',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'Broker Network Throughput',
-		description:
-			'Helps gauge the data throughput from the Kafka broker to consumer clients, focusing on the network usage associated with serving messages to consumers.',
-	}),
-);
-
-export const ioWaitTimeWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_producer_io_waittime_total--float64--Sum--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_producer_io_waittime_total',
-					type: 'Sum',
-				},
-				aggregateOperator: 'rate',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'I/O Wait Time',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'sum',
-				stepInterval: 60,
-				timeAggregation: 'rate',
-			},
-		],
-		title: 'I/O Wait Time',
-		description:
-			'This metric measures the total time that producers are in an I/O wait state, indicating potential bottlenecks in data transmission from producers to Kafka brokers.',
-	}),
-);
-
-export const requestResponseWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_producer_request_rate--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_producer_request_rate',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'Request Rate',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_producer_response_rate--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_producer_response_rate',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'B',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'Response Rate',
-				limit: null,
-				orderBy: [],
-				queryName: 'B',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'Request and Response Rate',
-		description:
-			"Indicates how many requests the producer is sending per second, reflecting the intensity of the producer's interaction with the Kafka cluster. Also, helps Kafka administrators gauge the responsiveness of brokers to producer requests.",
-	}),
-);
-
-export const averageRequestLatencyWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_producer_request_latency_avg--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_producer_request_latency_avg',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'Average Request Latency',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'Average Request Latency',
-		description:
-			'Helps Kafka administrators and developers understand the average latency experienced by producer requests.',
-	}),
-);
-
-export const kafkaProducerByteRateWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_producer_byte_rate--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_producer_byte_rate',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [
-					{
-						dataType: DataTypes.String,
-						id: 'topic--string--tag--false',
-						isColumn: false,
+export const getRequestTimesWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						// choose key based on flag
+						key: dotMetricsEnabled
+							? 'kafka.request.time.avg'
+							: 'kafka_request_time_avg',
+						// mirror into the id as well
+						id: 'kafka_request_time_avg--float64--Gauge--true',
+						isColumn: true,
 						isJSON: false,
-						key: 'topic',
-						type: 'tag',
+						type: 'Gauge',
 					},
-				],
-				having: [],
-				legend: '',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'kafka_producer_byte_rate',
-		description:
-			'Helps measure the data output rate from the producer, indicating the load a producer is placing on Kafka brokers.',
-	}),
-);
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: {
+						items: [],
+						op: 'AND',
+					},
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'Request Times',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: 'Request Times',
+			description:
+				'This metric is used to measure the average latency experienced by requests across the Kafka broker.',
+		}),
+	);
 
-export const bytesConsumedWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_consumer_bytes_consumed_rate--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_consumer_bytes_consumed_rate',
-					type: 'Gauge',
+export const getBrokerCountWidgetData = (dotMetricsEnabled: boolean): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled ? 'kafka.brokers' : 'kafka_brokers',
+						id: 'kafka_brokers--float64--Gauge--true',
+						isColumn: true,
+						isJSON: false,
+						type: 'Gauge',
+					},
+					aggregateOperator: 'sum',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'Broker count',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'sum',
 				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'Bytes Consumed',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'Bytes Consumed',
-		description:
-			'Helps Kafka administrators monitor the data consumption rate of a consumer group, showing how much data (in bytes) is being read from the Kafka cluster over time.',
-	}),
-);
+			],
+			title: 'Broker Count',
+			description: 'Total number of active brokers in the Kafka cluster.',
+		}),
+	);
 
-export const consumerOffsetWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_consumer_group_offset--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_consumer_group_offset',
-					type: 'Gauge',
+export const getProducerFetchRequestPurgatoryWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						// inline ternary based on dotMetricsEnabled
+						key: dotMetricsEnabled ? 'kafka.purgatory.size' : 'kafka_purgatory_size',
+						id: `${
+							dotMetricsEnabled ? 'kafka.purgatory.size' : 'kafka_purgatory_size'
+						}--float64--Gauge--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Gauge',
+					},
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'Producer and Fetch Request Purgatory',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
 				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [
-					{
-						dataType: DataTypes.String,
-						id: 'group--string--tag--false',
-						isColumn: false,
-						isJSON: false,
-						key: 'group',
-						type: 'tag',
-					},
-					{
-						dataType: DataTypes.String,
-						id: 'topic--string--tag--false',
-						isColumn: false,
-						isJSON: false,
-						key: 'topic',
-						type: 'tag',
-					},
-					{
-						dataType: DataTypes.String,
-						id: 'partition--string--tag--false',
-						isColumn: false,
-						isJSON: false,
-						key: 'partition',
-						type: 'tag',
-					},
-				],
-				having: [],
-				legend: '',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'Consumer Offset',
-		description: 'Current offset of each consumer group for each topic partition',
-	}),
-);
+			],
+			title: 'Producer and Fetch Request Purgatory',
+			description:
+				'Measures the number of requests that Kafka brokers have received but cannot immediately fulfill',
+		}),
+	);
 
-export const consumerGroupMemberWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_consumer_group_members--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_consumer_group_members',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'sum',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [
-					{
-						dataType: DataTypes.String,
-						id: 'group--string--tag--false',
-						isColumn: false,
+export const getBrokerNetworkThroughputWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						// inline ternary based on dotMetricsEnabled
+						key: dotMetricsEnabled
+							? 'kafka.server.brokertopicmetrics.bytesoutpersec.oneminuterate'
+							: 'kafka_server_brokertopicmetrics_bytesoutpersec_oneminuterate',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.server.brokertopicmetrics.bytesoutpersec.oneminuterate'
+								: 'kafka_server_brokertopicmetrics_bytesoutpersec_oneminuterate'
+						}--float64--Gauge--true`,
+						isColumn: true,
 						isJSON: false,
-						key: 'group',
-						type: 'tag',
+						type: 'Gauge',
 					},
-				],
-				having: [],
-				legend: '',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'sum',
-				stepInterval: 60,
-				timeAggregation: 'sum',
-			},
-		],
-		title: 'Consumer Group Members',
-		description: 'Number of active users in each group',
-	}),
-);
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'Broker Network Throughput',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: 'Broker Network Throughput',
+			description:
+				'Helps gauge the data throughput from the Kafka broker to consumer clients, focusing on the network usage associated with serving messages to consumers.',
+		}),
+	);
 
-export const consumerLagByGroupWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_consumer_group_lag--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_consumer_group_lag',
-					type: 'Gauge',
+export const getIoWaitTimeWidgetData = (dotMetricsEnabled: boolean): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						// inline ternary based on dotMetricsEnabled
+						key: dotMetricsEnabled
+							? 'kafka.producer.io_waittime_total'
+							: 'kafka_producer_io_waittime_total',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.producer.io_waittime_total'
+								: 'kafka_producer_io_waittime_total'
+						}--float64--Sum--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Sum',
+					},
+					aggregateOperator: 'rate',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'I/O Wait Time',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'sum',
+					stepInterval: 60,
+					timeAggregation: 'rate',
 				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [
-					{
-						dataType: DataTypes.String,
-						id: 'group--string--tag--false',
-						isColumn: false,
-						isJSON: false,
-						key: 'group',
-						type: 'tag',
-					},
-					{
-						dataType: DataTypes.String,
-						id: 'topic--string--tag--false',
-						isColumn: false,
-						isJSON: false,
-						key: 'topic',
-						type: 'tag',
-					},
-					{
-						dataType: DataTypes.String,
-						id: 'partition--string--tag--false',
-						isColumn: false,
-						isJSON: false,
-						key: 'partition',
-						type: 'tag',
-					},
-				],
-				having: [],
-				legend: '',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'Consumer Lag by Group',
-		description:
-			'Helps Kafka administrators assess whether consumer groups are keeping up with the incoming data stream or falling behind',
-	}),
-);
+			],
+			title: 'I/O Wait Time',
+			description:
+				'This metric measures the total time that producers are in an I/O wait state, indicating potential bottlenecks in data transmission from producers to Kafka brokers.',
+		}),
+	);
 
-export const consumerFetchRateWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_consumer_fetch_rate--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_consumer_fetch_rate',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [
-					{
-						dataType: DataTypes.String,
-						id: 'service_name--string--tag--false',
-						isColumn: false,
+export const getRequestResponseWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.producer.request-rate'
+							: 'kafka_producer_request_rate',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.producer.request-rate'
+								: 'kafka_producer_request_rate'
+						}--float64--Gauge--true`,
+						isColumn: true,
 						isJSON: false,
-						key: 'service_name',
-						type: 'tag',
+						type: 'Gauge',
 					},
-				],
-				having: [],
-				legend: '',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'Consumer Fetch Rate',
-		description:
-			'Metric measures the rate at which fetch requests are made by a Kafka consumer to the broker, typically in requests per second.',
-	}),
-);
-
-export const messagesConsumedWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_consumer_records_consumed_rate--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_consumer_records_consumed_rate',
-					type: 'Gauge',
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'Request Rate',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
 				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'Messages Consumed',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'Messages Consumed',
-		description:
-			'Measures the rate at which a Kafka consumer is consuming records (messages) per second from Kafka brokers.',
-	}),
-);
-
-export const jvmGCCountWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'jvm_gc_collections_count--float64--Sum--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'jvm_gc_collections_count',
-					type: 'Sum',
-				},
-				aggregateOperator: 'rate',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'JVM GC Count',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'sum',
-				stepInterval: 60,
-				timeAggregation: 'rate',
-			},
-		],
-		title: 'JVM GC Count',
-		description:
-			'Tracks the total number of garbage collection (GC) events that have occurred in the Java Virtual Machine (JVM).',
-	}),
-);
-
-export const jvmGcCollectionsElapsedWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'jvm_gc_collections_elapsed--float64--Sum--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'jvm_gc_collections_elapsed',
-					type: 'Sum',
-				},
-				aggregateOperator: 'rate',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'garbagecollector',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'sum',
-				stepInterval: 60,
-				timeAggregation: 'rate',
-			},
-		],
-		title: 'jvm_gc_collections_elapsed',
-		description:
-			'Measures the total time (usually in milliseconds) spent on garbage collection (GC) events in the Java Virtual Machine (JVM).',
-	}),
-);
-
-export const cpuRecentUtilizationWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'jvm_cpu_recent_utilization--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'jvm_cpu_recent_utilization',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'CPU utilization',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'CPU Recent Utilization',
-		description:
-			'This metric measures the recent CPU usage by the Java Virtual Machine (JVM), typically expressed as a percentage.',
-	}),
-);
-
-export const jvmMemoryHeapWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'jvm_memory_heap_max--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'jvm_memory_heap_max',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [],
-				having: [],
-				legend: 'JVM memory heap',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'JVM memory heap',
-		description:
-			'The metric represents the maximum amount of heap memory available to the Java Virtual Machine (JVM)',
-	}),
-);
-
-export const partitionCountPerTopicWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_topic_partitions--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_topic_partitions',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'sum',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [
-					{
-						dataType: DataTypes.String,
-						id: 'topic--string--tag--false',
-						isColumn: false,
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.producer.response-rate'
+							: 'kafka_producer_response_rate',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.producer.response-rate'
+								: 'kafka_producer_response_rate'
+						}--float64--Gauge--true`,
+						isColumn: true,
 						isJSON: false,
-						key: 'topic',
-						type: 'tag',
+						type: 'Gauge',
 					},
-				],
-				having: [],
-				legend: '',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'sum',
-				stepInterval: 60,
-				timeAggregation: 'sum',
-			},
-		],
-		title: 'Partition Count per Topic',
-		description: 'Number of partitions for each topic',
-	}),
-);
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'B',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'Response Rate',
+					limit: null,
+					orderBy: [],
+					queryName: 'B',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: 'Request and Response Rate',
+			description:
+				"Indicates how many requests the producer is sending per second, reflecting the intensity of the producer's interaction with the Kafka cluster. Also, helps Kafka administrators gauge the responsiveness of brokers to producer requests.",
+		}),
+	);
 
-export const currentOffsetPartitionWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_partition_current_offset--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_partition_current_offset',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [
-					{
-						dataType: DataTypes.String,
-						id: 'topic--string--tag--false',
-						isColumn: false,
+export const getAverageRequestLatencyWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.producer.request-latency-avg'
+							: 'kafka_producer_request_latency_avg',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.producer.request-latency-avg'
+								: 'kafka_producer_request_latency_avg'
+						}--float64--Gauge--true`,
+						isColumn: true,
 						isJSON: false,
-						key: 'topic',
-						type: 'tag',
+						type: 'Gauge',
 					},
-					{
-						dataType: DataTypes.String,
-						id: 'partition--string--tag--false',
-						isColumn: false,
-						isJSON: false,
-						key: 'partition',
-						type: 'tag',
-					},
-				],
-				having: [],
-				legend: '',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'Current Offset ( Partition )',
-		description:
-			'Current offset of each partition, showing the latest position in each partition',
-	}),
-);
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'Average Request Latency',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: 'Average Request Latency',
+			description:
+				'Helps Kafka administrators and developers understand the average latency experienced by producer requests.',
+		}),
+	);
 
-export const oldestOffsetWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_partition_oldest_offset--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_partition_oldest_offset',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [
-					{
-						dataType: DataTypes.String,
-						id: 'topic--string--tag--false',
-						isColumn: false,
+export const getKafkaProducerByteRateWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.producer.byte-rate'
+							: 'kafka_producer_byte_rate',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.producer.byte-rate'
+								: 'kafka_producer_byte_rate'
+						}--float64--Gauge--true`,
+						isColumn: true,
 						isJSON: false,
-						key: 'topic',
-						type: 'tag',
+						type: 'Gauge',
 					},
-					{
-						dataType: DataTypes.String,
-						id: 'partition--string--tag--false',
-						isColumn: false,
-						isJSON: false,
-						key: 'partition',
-						type: 'tag',
-					},
-				],
-				having: [],
-				legend: '',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'Oldest Offset (Partition)',
-		description:
-			'Oldest offset of each partition to identify log retention and offset range.',
-	}),
-);
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [
+						{
+							dataType: DataTypes.String,
+							id: 'topic--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'topic',
+							type: 'tag',
+						},
+					],
+					having: [],
+					legend: '',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: dotMetricsEnabled
+				? 'kafka.producer.byte-rate'
+				: 'kafka_producer_byte_rate',
+			description:
+				'Helps measure the data output rate from the producer, indicating the load a producer is placing on Kafka brokers.',
+		}),
+	);
 
-export const insyncReplicasWidgetData = getWidgetQueryBuilder(
-	getWidgetQuery({
-		queryData: [
-			{
-				aggregateAttribute: {
-					dataType: DataTypes.Float64,
-					id: 'kafka_partition_replicas_in_sync--float64--Gauge--true',
-					isColumn: true,
-					isJSON: false,
-					key: 'kafka_partition_replicas_in_sync',
-					type: 'Gauge',
-				},
-				aggregateOperator: 'avg',
-				dataSource: DataSource.METRICS,
-				disabled: false,
-				expression: 'A',
-				filters: {
-					items: [],
-					op: 'AND',
-				},
-				functions: [],
-				groupBy: [
-					{
-						dataType: DataTypes.String,
-						id: 'topic--string--tag--false',
-						isColumn: false,
+export const getBytesConsumedWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.consumer.bytes-consumed-rate'
+							: 'kafka_consumer_bytes_consumed_rate',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.consumer.bytes-consumed-rate'
+								: 'kafka_consumer_bytes_consumed_rate'
+						}--float64--Gauge--true`,
+						isColumn: true,
 						isJSON: false,
-						key: 'topic',
-						type: 'tag',
+						type: 'Gauge',
 					},
-					{
-						dataType: DataTypes.String,
-						id: 'partition--string--tag--false',
-						isColumn: false,
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'Bytes Consumed',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			// Use kebab-case title as requested
+			title: 'Bytes Consumed',
+			description:
+				'Helps Kafka administrators monitor the data consumption rate of a consumer group, showing how much data (in bytes) is being read from the Kafka cluster over time.',
+		}),
+	);
+
+export const getConsumerOffsetWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.consumer_group.offset'
+							: 'kafka_consumer_group_offset',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.consumer_group.offset'
+								: 'kafka_consumer_group_offset'
+						}--float64--Gauge--true`,
+						isColumn: true,
 						isJSON: false,
-						key: 'partition',
-						type: 'tag',
+						type: 'Gauge',
 					},
-				],
-				having: [],
-				legend: '',
-				limit: null,
-				orderBy: [],
-				queryName: 'A',
-				reduceTo: 'avg',
-				spaceAggregation: 'avg',
-				stepInterval: 60,
-				timeAggregation: 'avg',
-			},
-		],
-		title: 'In-Sync Replicas (ISR)',
-		description:
-			'Count of in-sync replicas for each partition to ensure data availability.',
-	}),
-);
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [
+						{
+							dataType: DataTypes.String,
+							id: 'group--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'group',
+							type: 'tag',
+						},
+						{
+							dataType: DataTypes.String,
+							id: 'topic--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'topic',
+							type: 'tag',
+						},
+						{
+							dataType: DataTypes.String,
+							id: 'partition--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'partition',
+							type: 'tag',
+						},
+					],
+					having: [],
+					legend: '',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: 'Consumer Offset',
+			description:
+				'Current offset of each consumer group for each topic partition',
+		}),
+	);
+
+export const getConsumerGroupMemberWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.consumer_group.members'
+							: 'kafka_consumer_group_members',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.consumer_group.members'
+								: 'kafka_consumer_group_members'
+						}--float64--Gauge--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Gauge',
+					},
+					aggregateOperator: 'sum',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [
+						{
+							dataType: DataTypes.String,
+							id: 'group--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'group',
+							type: 'tag',
+						},
+					],
+					having: [],
+					legend: '',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'sum',
+					stepInterval: 60,
+					timeAggregation: 'sum',
+				},
+			],
+			title: 'Consumer Group Members',
+			description: 'Number of active users in each group',
+		}),
+	);
+
+export const getConsumerLagByGroupWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.consumer_group.lag'
+							: 'kafka_consumer_group_lag',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.consumer_group.lag'
+								: 'kafka_consumer_group_lag'
+						}--float64--Gauge--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Gauge',
+					},
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [
+						{
+							dataType: DataTypes.String,
+							id: 'group--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'group',
+							type: 'tag',
+						},
+						{
+							dataType: DataTypes.String,
+							id: 'topic--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'topic',
+							type: 'tag',
+						},
+						{
+							dataType: DataTypes.String,
+							id: 'partition--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'partition',
+							type: 'tag',
+						},
+					],
+					having: [],
+					legend: '',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: 'Consumer Lag by Group',
+			description:
+				'Helps Kafka administrators assess whether consumer groups are keeping up with the incoming data stream or falling behind',
+		}),
+	);
+
+export const getConsumerFetchRateWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.consumer.fetch-rate'
+							: 'kafka_consumer_fetch_rate',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.consumer.fetch-rate'
+								: 'kafka_consumer_fetch_rate'
+						}--float64--Gauge--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Gauge',
+					},
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [
+						{
+							dataType: DataTypes.String,
+							id: 'service_name--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'service_name',
+							type: 'tag',
+						},
+					],
+					having: [],
+					legend: '',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: 'Consumer Fetch Rate',
+			description:
+				'Metric measures the rate at which fetch requests are made by a Kafka consumer to the broker, typically in requests per second.',
+		}),
+	);
+
+export const getMessagesConsumedWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.consumer.records-consumed-rate'
+							: 'kafka_consumer_records_consumed_rate',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.consumer.records-consumed-rate'
+								: 'kafka_consumer_records_consumed_rate'
+						}--float64--Gauge--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Gauge',
+					},
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'Messages Consumed',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: 'Messages Consumed',
+			description:
+				'Measures the rate at which a Kafka consumer is consuming records (messages) per second from Kafka brokers.',
+		}),
+	);
+
+export const getJvmGCCountWidgetData = (dotMetricsEnabled: boolean): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'jvm.gc.collections.count'
+							: 'jvm_gc_collections_count',
+						id: `${
+							dotMetricsEnabled
+								? 'jvm.gc.collections.count'
+								: 'jvm_gc_collections_count'
+						}--float64--Sum--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Sum',
+					},
+					aggregateOperator: 'rate',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'JVM GC Count',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'sum',
+					stepInterval: 60,
+					timeAggregation: 'rate',
+				},
+			],
+			title: 'JVM GC Count',
+			description:
+				'Tracks the total number of garbage collection (GC) events that have occurred in the Java Virtual Machine (JVM).',
+		}),
+	);
+
+export const getJvmGcCollectionsElapsedWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'jvm.gc.collections.elapsed'
+							: 'jvm_gc_collections_elapsed',
+						id: `${
+							dotMetricsEnabled
+								? 'jvm.gc.collections.elapsed'
+								: 'jvm_gc_collections_elapsed'
+						}--float64--Sum--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Sum',
+					},
+					aggregateOperator: 'rate',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'garbagecollector',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'sum',
+					stepInterval: 60,
+					timeAggregation: 'rate',
+				},
+			],
+			title: 'jvm_gc_collections_elapsed',
+			description:
+				'Measures the total time (usually in milliseconds) spent on garbage collection (GC) events in the Java Virtual Machine (JVM).',
+		}),
+	);
+
+export const getCpuRecentUtilizationWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'jvm.cpu.recent_utilization'
+							: 'jvm_cpu_recent_utilization',
+						id: `${
+							dotMetricsEnabled
+								? 'jvm.cpu.recent_utilization'
+								: 'jvm_cpu_recent_utilization'
+						}--float64--Gauge--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Gauge',
+					},
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'CPU utilization',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: 'CPU Recent Utilization',
+			description:
+				'This metric measures the recent CPU usage by the Java Virtual Machine (JVM), typically expressed as a percentage.',
+		}),
+	);
+
+export const getJvmMemoryHeapWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled ? 'jvm.memory.heap.max' : 'jvm_memory_heap_max',
+						id: `${
+							dotMetricsEnabled ? 'jvm.memory.heap.max' : 'jvm_memory_heap_max'
+						}--float64--Gauge--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Gauge',
+					},
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [],
+					having: [],
+					legend: 'JVM memory heap',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: 'JVM memory heap',
+			description:
+				'The metric represents the maximum amount of heap memory available to the Java Virtual Machine (JVM)',
+		}),
+	);
+
+export const getPartitionCountPerTopicWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.topic.partitions'
+							: 'kafka_topic_partitions',
+						id: `${
+							dotMetricsEnabled ? 'kafka.topic.partitions' : 'kafka_topic_partitions'
+						}--float64--Gauge--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Gauge',
+					},
+					aggregateOperator: 'sum',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [
+						{
+							dataType: DataTypes.String,
+							id: 'topic--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'topic',
+							type: 'tag',
+						},
+					],
+					having: [],
+					legend: '',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'sum',
+					stepInterval: 60,
+					timeAggregation: 'sum',
+				},
+			],
+			title: 'Partition Count per Topic',
+			description: 'Number of partitions for each topic',
+		}),
+	);
+
+export const getCurrentOffsetPartitionWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.partition.current_offset'
+							: 'kafka_partition_current_offset',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.partition.current_offset'
+								: 'kafka_partition_current_offset'
+						}--float64--Gauge--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Gauge',
+					},
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [
+						{
+							dataType: DataTypes.String,
+							id: 'topic--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'topic',
+							type: 'tag',
+						},
+						{
+							dataType: DataTypes.String,
+							id: 'partition--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'partition',
+							type: 'tag',
+						},
+					],
+					having: [],
+					legend: '',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: 'Current Offset ( Partition )',
+			description:
+				'Current offset of each partition, showing the latest position in each partition',
+		}),
+	);
+
+export const getOldestOffsetWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.partition.oldest_offset'
+							: 'kafka_partition_oldest_offset',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.partition.oldest_offset'
+								: 'kafka_partition_oldest_offset'
+						}--float64--Gauge--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Gauge',
+					},
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [
+						{
+							dataType: DataTypes.String,
+							id: 'topic--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'topic',
+							type: 'tag',
+						},
+						{
+							dataType: DataTypes.String,
+							id: 'partition--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'partition',
+							type: 'tag',
+						},
+					],
+					having: [],
+					legend: '',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: 'Oldest Offset (Partition)',
+			description:
+				'Oldest offset of each partition to identify log retention and offset range.',
+		}),
+	);
+
+export const getInsyncReplicasWidgetData = (
+	dotMetricsEnabled: boolean,
+): Widgets =>
+	getWidgetQueryBuilder(
+		getWidgetQuery({
+			queryData: [
+				{
+					aggregateAttribute: {
+						dataType: DataTypes.Float64,
+						key: dotMetricsEnabled
+							? 'kafka.partition.replicas_in_sync'
+							: 'kafka_partition_replicas_in_sync',
+						id: `${
+							dotMetricsEnabled
+								? 'kafka.partition.replicas_in_sync'
+								: 'kafka_partition_replicas_in_sync'
+						}--float64--Gauge--true`,
+						isColumn: true,
+						isJSON: false,
+						type: 'Gauge',
+					},
+					aggregateOperator: 'avg',
+					dataSource: DataSource.METRICS,
+					disabled: false,
+					expression: 'A',
+					filters: { items: [], op: 'AND' },
+					functions: [],
+					groupBy: [
+						{
+							dataType: DataTypes.String,
+							id: 'topic--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'topic',
+							type: 'tag',
+						},
+						{
+							dataType: DataTypes.String,
+							id: 'partition--string--tag--false',
+							isColumn: false,
+							isJSON: false,
+							key: 'partition',
+							type: 'tag',
+						},
+					],
+					having: [],
+					legend: '',
+					limit: null,
+					orderBy: [],
+					queryName: 'A',
+					reduceTo: 'avg',
+					spaceAggregation: 'avg',
+					stepInterval: 60,
+					timeAggregation: 'avg',
+				},
+			],
+			title: 'In-Sync Replicas (ISR)',
+			description:
+				'Count of in-sync replicas for each partition to ensure data availability.',
+		}),
+	);

--- a/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricPageUtil.ts
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricPageUtil.ts
@@ -214,11 +214,11 @@ export const getBrokerNetworkThroughputWidgetData = (
 						dataType: DataTypes.Float64,
 						// inline ternary based on dotMetricsEnabled
 						key: dotMetricsEnabled
-							? 'kafka.server.brokertopicmetrics.bytesoutpersec.oneminuterate'
+							? 'kafka_server_brokertopicmetrics_total_replicationbytesinpersec_oneminuterate'
 							: 'kafka_server_brokertopicmetrics_bytesoutpersec_oneminuterate',
 						id: `${
 							dotMetricsEnabled
-								? 'kafka.server.brokertopicmetrics.bytesoutpersec.oneminuterate'
+								? 'kafka_server_brokertopicmetrics_total_replicationbytesinpersec_oneminuterate'
 								: 'kafka_server_brokertopicmetrics_bytesoutpersec_oneminuterate'
 						}--float64--Gauge--true`,
 						isColumn: true,
@@ -303,11 +303,11 @@ export const getRequestResponseWidgetData = (
 					aggregateAttribute: {
 						dataType: DataTypes.Float64,
 						key: dotMetricsEnabled
-							? 'kafka.producer.request-rate'
+							? 'kafka.producer.request_rate'
 							: 'kafka_producer_request_rate',
 						id: `${
 							dotMetricsEnabled
-								? 'kafka.producer.request-rate'
+								? 'kafka.producer.request_rate'
 								: 'kafka_producer_request_rate'
 						}--float64--Gauge--true`,
 						isColumn: true,
@@ -335,11 +335,11 @@ export const getRequestResponseWidgetData = (
 					aggregateAttribute: {
 						dataType: DataTypes.Float64,
 						key: dotMetricsEnabled
-							? 'kafka.producer.response-rate'
+							? 'kafka.producer.response_rate'
 							: 'kafka_producer_response_rate',
 						id: `${
 							dotMetricsEnabled
-								? 'kafka.producer.response-rate'
+								? 'kafka.producer.response_rate'
 								: 'kafka_producer_response_rate'
 						}--float64--Gauge--true`,
 						isColumn: true,
@@ -380,11 +380,11 @@ export const getAverageRequestLatencyWidgetData = (
 					aggregateAttribute: {
 						dataType: DataTypes.Float64,
 						key: dotMetricsEnabled
-							? 'kafka.producer.request-latency-avg'
+							? 'kafka.producer.request_latency_avg'
 							: 'kafka_producer_request_latency_avg',
 						id: `${
 							dotMetricsEnabled
-								? 'kafka.producer.request-latency-avg'
+								? 'kafka.producer.request_latency_avg'
 								: 'kafka_producer_request_latency_avg'
 						}--float64--Gauge--true`,
 						isColumn: true,
@@ -425,11 +425,11 @@ export const getKafkaProducerByteRateWidgetData = (
 					aggregateAttribute: {
 						dataType: DataTypes.Float64,
 						key: dotMetricsEnabled
-							? 'kafka.producer.byte-rate'
+							? 'kafka.producer.byte_rate'
 							: 'kafka_producer_byte_rate',
 						id: `${
 							dotMetricsEnabled
-								? 'kafka.producer.byte-rate'
+								? 'kafka.producer.byte_rate'
 								: 'kafka_producer_byte_rate'
 						}--float64--Gauge--true`,
 						isColumn: true,
@@ -464,7 +464,7 @@ export const getKafkaProducerByteRateWidgetData = (
 				},
 			],
 			title: dotMetricsEnabled
-				? 'kafka.producer.byte-rate'
+				? 'kafka.producer.byte_rate'
 				: 'kafka_producer_byte_rate',
 			description:
 				'Helps measure the data output rate from the producer, indicating the load a producer is placing on Kafka brokers.',
@@ -481,11 +481,11 @@ export const getBytesConsumedWidgetData = (
 					aggregateAttribute: {
 						dataType: DataTypes.Float64,
 						key: dotMetricsEnabled
-							? 'kafka.consumer.bytes-consumed-rate'
+							? 'kafka.consumer.bytes_consumed_rate'
 							: 'kafka_consumer_bytes_consumed_rate',
 						id: `${
 							dotMetricsEnabled
-								? 'kafka.consumer.bytes-consumed-rate'
+								? 'kafka.consumer.bytes_consumed_rate'
 								: 'kafka_consumer_bytes_consumed_rate'
 						}--float64--Gauge--true`,
 						isColumn: true,
@@ -720,11 +720,11 @@ export const getConsumerFetchRateWidgetData = (
 					aggregateAttribute: {
 						dataType: DataTypes.Float64,
 						key: dotMetricsEnabled
-							? 'kafka.consumer.fetch-rate'
+							? 'kafka.consumer.fetch_rate'
 							: 'kafka_consumer_fetch_rate',
 						id: `${
 							dotMetricsEnabled
-								? 'kafka.consumer.fetch-rate'
+								? 'kafka.consumer.fetch_rate'
 								: 'kafka_consumer_fetch_rate'
 						}--float64--Gauge--true`,
 						isColumn: true,
@@ -743,7 +743,7 @@ export const getConsumerFetchRateWidgetData = (
 							id: 'service_name--string--tag--false',
 							isColumn: false,
 							isJSON: false,
-							key: 'service_name',
+							key: dotMetricsEnabled ? 'service.name' : 'service_name',
 							type: 'tag',
 						},
 					],
@@ -774,11 +774,11 @@ export const getMessagesConsumedWidgetData = (
 					aggregateAttribute: {
 						dataType: DataTypes.Float64,
 						key: dotMetricsEnabled
-							? 'kafka.consumer.records-consumed-rate'
+							? 'kafka.consumer.records_consumed_rate'
 							: 'kafka_consumer_records_consumed_rate',
 						id: `${
 							dotMetricsEnabled
-								? 'kafka.consumer.records-consumed-rate'
+								? 'kafka.consumer.records_consumed_rate'
 								: 'kafka_consumer_records_consumed_rate'
 						}--float64--Gauge--true`,
 						isColumn: true,
@@ -891,7 +891,9 @@ export const getJvmGcCollectionsElapsedWidgetData = (
 					timeAggregation: 'rate',
 				},
 			],
-			title: 'jvm_gc_collections_elapsed',
+			title: dotMetricsEnabled
+				? 'jvm.gc.collections.elapsed'
+				: 'jvm_gc_collections_elapsed',
 			description:
 				'Measures the total time (usually in milliseconds) spent on garbage collection (GC) events in the Java Virtual Machine (JVM).',
 		}),

--- a/frontend/src/pages/MessagingQueues/MQGraph/MQConfigOptions.tsx
+++ b/frontend/src/pages/MessagingQueues/MQGraph/MQConfigOptions.tsx
@@ -13,6 +13,8 @@ import { useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useCopyToClipboard } from 'react-use';
 
+import { FeatureKeys } from '../../../constants/features';
+import { useAppContext } from '../../../providers/App/App';
 import { useGetAllConfigOptions } from './useGetAllConfigOptions';
 
 type ConfigOptionType = 'group' | 'topic' | 'partition';
@@ -38,11 +40,19 @@ const useConfigOptions = (
 	isFetching: boolean;
 	options: DefaultOptionType[];
 } => {
+	const { featureFlags } = useAppContext();
+	const dotMetricsEnabled =
+		featureFlags?.find((flag) => flag.name === FeatureKeys.DOT_METRICS_ENABLED)
+			?.active || false;
+
 	const [searchText, setSearchText] = useState<string>('');
-	const { isFetching, options } = useGetAllConfigOptions({
-		attributeKey: type,
-		searchText,
-	});
+	const { isFetching, options } = useGetAllConfigOptions(
+		{
+			attributeKey: type,
+			searchText,
+		},
+		dotMetricsEnabled,
+	);
 	const handleDebouncedSearch = useDebouncedFn((searchText): void => {
 		setSearchText(searchText as string);
 	}, 500);

--- a/frontend/src/pages/MessagingQueues/MQGraph/useGetAllConfigOptions.ts
+++ b/frontend/src/pages/MessagingQueues/MQGraph/useGetAllConfigOptions.ts
@@ -17,16 +17,19 @@ export interface GetAllConfigOptionsResponse {
 
 export function useGetAllConfigOptions(
 	props: ConfigOptions,
+	dotMetricsEnabled: boolean,
 ): GetAllConfigOptionsResponse {
 	const { attributeKey, searchText } = props;
 
 	const { data, isLoading } = useQuery(
 		['attributesValues', attributeKey, searchText],
-		async () => {
+		async (): Promise<DefaultOptionType[]> => {
 			const { payload } = await getAttributesValues({
 				aggregateOperator: 'avg',
 				dataSource: DataSource.METRICS,
-				aggregateAttribute: 'kafka_consumer_group_lag',
+				aggregateAttribute: dotMetricsEnabled
+					? 'kafka.consumer_group.lag'
+					: 'kafka_consumer_group_lag',
 				attributeKey,
 				searchText: searchText ?? '',
 				filterAttributeKeyDataType: DataTypes.String,

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/SigNoz/signoz/pkg/query-service/constants"
 	"io"
 	"math"
 	"net/http"
@@ -2850,6 +2851,12 @@ func (aH *APIHandler) onboardKafka(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	var kafkaConsumerFetchLatencyAvg string = "kafka_consumer_fetch_latency_avg"
+	var kafkaConsumerLag string = "kafka_consumer_group_lag"
+	if constants.GetOrDefaultEnv(constants.DotMetricsEnabled, "false") == "true" {
+		kafkaConsumerLag = "kafka.consumer_group.lag"
+		kafkaConsumerFetchLatencyAvg = "kafka.consumer.fetch_latency_avg"
+	}
 
 	if !fetchLatencyState && !consumerLagState {
 		entries = append(entries, kafka.OnboardingResponse{
@@ -2860,27 +2867,28 @@ func (aH *APIHandler) onboardKafka(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !fetchLatencyState {
+
 		entries = append(entries, kafka.OnboardingResponse{
-			Attribute: "kafka_consumer_fetch_latency_avg",
+			Attribute: kafkaConsumerFetchLatencyAvg,
 			Message:   "Metric kafka_consumer_fetch_latency_avg is not present in the given time range.",
 			Status:    "0",
 		})
 	} else {
 		entries = append(entries, kafka.OnboardingResponse{
-			Attribute: "kafka_consumer_fetch_latency_avg",
+			Attribute: kafkaConsumerFetchLatencyAvg,
 			Status:    "1",
 		})
 	}
 
 	if !consumerLagState {
 		entries = append(entries, kafka.OnboardingResponse{
-			Attribute: "kafka_consumer_group_lag",
+			Attribute: kafkaConsumerLag,
 			Message:   "Metric kafka_consumer_group_lag is not present in the given time range.",
 			Status:    "0",
 		})
 	} else {
 		entries = append(entries, kafka.OnboardingResponse{
-			Attribute: "kafka_consumer_group_lag",
+			Attribute: kafkaConsumerLag,
 			Status:    "1",
 		})
 	}

--- a/pkg/query-service/app/integrations/messagingQueues/kafka/translator.go
+++ b/pkg/query-service/app/integrations/messagingQueues/kafka/translator.go
@@ -66,6 +66,11 @@ func buildBuilderQueriesProducerBytes(
 	attributeCache *Clients,
 ) (map[string]*v3.BuilderQuery, error) {
 
+	normalized := true
+	if constants.GetOrDefaultEnv(constants.DotMetricsEnabled, "false") == "true" {
+		normalized = false
+	}
+
 	bq := make(map[string]*v3.BuilderQuery)
 	queryName := "byte_rate"
 
@@ -74,7 +79,7 @@ func buildBuilderQueriesProducerBytes(
 		StepInterval: common.MinAllowedStepInterval(unixMilliStart, unixMilliEnd),
 		DataSource:   v3.DataSourceMetrics,
 		AggregateAttribute: v3.AttributeKey{
-			Key:      "kafka_producer_byte_rate",
+			Key:      getDotMetrics("kafka_producer_byte_rate", normalized),
 			DataType: v3.AttributeKeyDataTypeFloat64,
 			Type:     v3.AttributeKeyType("Gauge"),
 			IsColumn: true,
@@ -88,7 +93,7 @@ func buildBuilderQueriesProducerBytes(
 			Items: []v3.FilterItem{
 				{
 					Key: v3.AttributeKey{
-						Key:      "service_name",
+						Key:      getDotMetrics("service_name", normalized),
 						Type:     v3.AttributeKeyTypeTag,
 						DataType: v3.AttributeKeyDataTypeString,
 					},
@@ -110,7 +115,7 @@ func buildBuilderQueriesProducerBytes(
 		ReduceTo:   v3.ReduceToOperatorAvg,
 		GroupBy: []v3.AttributeKey{
 			{
-				Key:      "service_name",
+				Key:      getDotMetrics("service_name", normalized),
 				DataType: v3.AttributeKeyDataTypeString,
 				Type:     v3.AttributeKeyTypeTag,
 			},
@@ -133,12 +138,17 @@ func buildBuilderQueriesNetwork(
 	bq := make(map[string]*v3.BuilderQuery)
 	queryName := "latency"
 
+	normalized := true
+	if constants.GetOrDefaultEnv(constants.DotMetricsEnabled, "false") == "true" {
+		normalized = false
+	}
+
 	chq := &v3.BuilderQuery{
 		QueryName:    queryName,
 		StepInterval: common.MinAllowedStepInterval(unixMilliStart, unixMilliEnd),
 		DataSource:   v3.DataSourceMetrics,
 		AggregateAttribute: v3.AttributeKey{
-			Key: "kafka_consumer_fetch_latency_avg",
+			Key: getDotMetrics("kafka_consumer_fetch_latency_avg", normalized),
 		},
 		AggregateOperator: v3.AggregateOperatorAvg,
 		Temporality:       v3.Unspecified,
@@ -149,7 +159,7 @@ func buildBuilderQueriesNetwork(
 			Items: []v3.FilterItem{
 				{
 					Key: v3.AttributeKey{
-						Key:      "service_name",
+						Key:      getDotMetrics("service_name", normalized),
 						Type:     v3.AttributeKeyTypeTag,
 						DataType: v3.AttributeKeyDataTypeString,
 					},
@@ -158,7 +168,7 @@ func buildBuilderQueriesNetwork(
 				},
 				{
 					Key: v3.AttributeKey{
-						Key:      "client_id",
+						Key:      getDotMetrics("client_id", normalized),
 						Type:     v3.AttributeKeyTypeTag,
 						DataType: v3.AttributeKeyDataTypeString,
 					},
@@ -167,7 +177,7 @@ func buildBuilderQueriesNetwork(
 				},
 				{
 					Key: v3.AttributeKey{
-						Key:      "service_instance_id",
+						Key:      getDotMetrics("service_instance_id", normalized),
 						Type:     v3.AttributeKeyTypeTag,
 						DataType: v3.AttributeKeyDataTypeString,
 					},
@@ -180,17 +190,17 @@ func buildBuilderQueriesNetwork(
 		ReduceTo:   v3.ReduceToOperatorAvg,
 		GroupBy: []v3.AttributeKey{
 			{
-				Key:      "service_name",
+				Key:      getDotMetrics("service_name", normalized),
 				DataType: v3.AttributeKeyDataTypeString,
 				Type:     v3.AttributeKeyTypeTag,
 			},
 			{
-				Key:      "client_id",
+				Key:      getDotMetrics("client_id", normalized),
 				DataType: v3.AttributeKeyDataTypeString,
 				Type:     v3.AttributeKeyTypeTag,
 			},
 			{
-				Key:      "service_instance_id",
+				Key:      getDotMetrics("service_instance_id", normalized),
 				DataType: v3.AttributeKeyDataTypeString,
 				Type:     v3.AttributeKeyTypeTag,
 			},
@@ -207,12 +217,17 @@ func BuildBuilderQueriesKafkaOnboarding(messagingQueue *MessagingQueue) (*v3.Que
 	unixMilliStart := messagingQueue.Start / 1000000
 	unixMilliEnd := messagingQueue.End / 1000000
 
+	normalized := true
+	if constants.GetOrDefaultEnv(constants.DotMetricsEnabled, "false") == "true" {
+		normalized = false
+	}
+
 	buiderQuery := &v3.BuilderQuery{
 		QueryName:    "fetch_latency",
 		StepInterval: common.MinAllowedStepInterval(unixMilliStart, unixMilliEnd),
 		DataSource:   v3.DataSourceMetrics,
 		AggregateAttribute: v3.AttributeKey{
-			Key: "kafka_consumer_fetch_latency_avg",
+			Key: getDotMetrics("kafka_consumer_fetch_latency_avg", normalized),
 		},
 		AggregateOperator: v3.AggregateOperatorCount,
 		Temporality:       v3.Unspecified,
@@ -227,7 +242,7 @@ func BuildBuilderQueriesKafkaOnboarding(messagingQueue *MessagingQueue) (*v3.Que
 		StepInterval: common.MinAllowedStepInterval(unixMilliStart, unixMilliEnd),
 		DataSource:   v3.DataSourceMetrics,
 		AggregateAttribute: v3.AttributeKey{
-			Key: "kafka_consumer_group_lag",
+			Key: getDotMetrics("kafka_consumer_group_lag", normalized),
 		},
 		AggregateOperator: v3.AggregateOperatorCount,
 		Temporality:       v3.Unspecified,
@@ -410,4 +425,20 @@ func buildCompositeQuery(chq *v3.ClickHouseQuery, queryContext string) (*v3.Comp
 		ClickHouseQueries: map[string]*v3.ClickHouseQuery{queryContext: chq},
 		PanelType:         v3.PanelTypeTable,
 	}, nil
+}
+
+func getDotMetrics(metricName string, normalized bool) string {
+	dotMetricsMap := map[string]string{
+		"kafka_producer_byte_rate":         "kafka.producer.byte-rate",
+		"service_name":                     "service.name",
+		"kafka_consumer_fetch_latency_avg": "kafka.consumer.fetch_latency_avg",
+		"service_instance_id":              "service.instance.id",
+		"client_id":                        "client-id",
+		"kafka_consumer_group_lag":         "kafka.consumer_group.lag",
+	}
+	if _, ok := dotMetricsMap[metricName]; ok && !normalized {
+		return dotMetricsMap[metricName]
+	} else {
+		return metricName
+	}
 }


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- [ ] @SigNoz/frontend
- [ ] @SigNoz/backend
- [ ] @SigNoz/devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds support for dot metrics in Kafka messaging queues with a feature flag to toggle between dot and non-dot metrics.
> 
>   - **Feature Flag**:
>     - Introduces `DOT_METRICS_ENABLED` feature flag in `constants` to toggle between dot and non-dot metrics.
>   - **Frontend**:
>     - Updates `MetricColumnGraphs.tsx` and `MetricPage.tsx` to use dot metrics based on feature flag.
>     - Modifies `useGetAllConfigOptions` to accept `dotMetricsEnabled` parameter.
>   - **Backend**:
>     - Updates `http_handler.go` to handle dot metrics in Kafka onboarding.
>     - Modifies `translator.go` to use `getDotMetrics()` for metric keys based on feature flag.
>   - **Query Modifications**:
>     - Replaces static metric keys with `getDotMetrics()` in `MetricPageUtil.ts` and `translator.go`.
>     - Adjusts queries in `BuildBuilderQueriesKafkaOnboarding` and `BuildQueryRangeParams` to support dot metrics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 20f1b722908ad1374b61ef186fdc15e1d1ee4997. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->