### PR TITLE
fix: changed the get request access from admin to view

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -574,8 +574,8 @@ func (aH *APIHandler) RegisterRoutes(router *mux.Router, am *middleware.AuthZ) {
 	router.HandleFunc("/api/v1/org/preferences/{preferenceId}", am.AdminAccess(aH.Signoz.Handlers.Preference.UpdateOrg)).Methods(http.MethodPut)
 
 	// Quick Filters
-	router.HandleFunc("/api/v1/orgs/me/filters", am.AdminAccess(aH.QuickFilters.GetQuickFilters)).Methods(http.MethodGet)
-	router.HandleFunc("/api/v1/orgs/me/filters/{signal}", am.AdminAccess(aH.QuickFilters.GetSignalFilters)).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/orgs/me/filters", am.ViewAccess(aH.QuickFilters.GetQuickFilters)).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/orgs/me/filters/{signal}", am.ViewAccess(aH.QuickFilters.GetSignalFilters)).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/orgs/me/filters", am.AdminAccess(aH.QuickFilters.UpdateQuickFilters)).Methods(http.MethodPut)
 
 	// === Authentication APIs ===


### PR DESCRIPTION
## 📄 Summary

Changed Admin Access to ViewAccess for Quick Filters API Get request

---

## ✅ Changes

- [x] Bug fix: Brief description


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Changed access level from `AdminAccess` to `ViewAccess` for quick filter GET requests in `http_handler.go`.
> 
>   - **Access Level Change**:
>     - Changed access level from `AdminAccess` to `ViewAccess` for `GetQuickFilters` and `GetSignalFilters` in `http_handler.go`.
>     - Affects endpoints `/api/v1/orgs/me/filters` and `/api/v1/orgs/me/filters/{signal}`.
>   - **Purpose**:
>     - Allows non-admin users to access quick filters via GET requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 20fa17a954c0a2d6b6df43e0e1513fec94cbd33d. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->