### PR TITLE
fix(license): return the active license even in case of suspended status

### DIFF
--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -105,8 +105,7 @@ function SideNav(): JSX.Element {
 
 	const isWorkspaceBlocked = trialInfo?.workSpaceBlock || false;
 
-	const isLicenseActive =
-		licenseStatus === 'VALID' || licenseStatus === 'SUSPENDED';
+	const isLicenseActive = licenseStatus !== 'INVALID';
 
 	const onClickSignozCloud = (): void => {
 		window.open(

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -105,7 +105,7 @@ function SideNav(): JSX.Element {
 
 	const isWorkspaceBlocked = trialInfo?.workSpaceBlock || false;
 
-	const isLicenseActive = licenseStatus !== 'INVALID';
+	const isLicenseActive = licenseStatus !== '' && licenseStatus !== 'INVALID';
 
 	const onClickSignozCloud = (): void => {
 		window.open(

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -105,7 +105,8 @@ function SideNav(): JSX.Element {
 
 	const isWorkspaceBlocked = trialInfo?.workSpaceBlock || false;
 
-	const isLicenseActive = licenseStatus === 'VALID';
+	const isLicenseActive =
+		licenseStatus === 'VALID' || licenseStatus === 'SUSPENDED';
 
 	const onClickSignozCloud = (): void => {
 		window.open(

--- a/pkg/types/licensetypes/license.go
+++ b/pkg/types/licensetypes/license.go
@@ -87,7 +87,7 @@ func GetActiveLicenseFromStorableLicenses(storableLicenses []*StorableLicense, o
 			return nil, err
 		}
 
-		if license.Status != "VALID" {
+		if license.Status != "VALID" && license.Status != "SUSPENDED" {
 			continue
 		}
 		if activeLicense == nil &&

--- a/pkg/types/licensetypes/license.go
+++ b/pkg/types/licensetypes/license.go
@@ -87,7 +87,7 @@ func GetActiveLicenseFromStorableLicenses(storableLicenses []*StorableLicense, o
 			return nil, err
 		}
 
-		if license.Status != "VALID" && license.Status != "SUSPENDED" {
+		if license.Status == "INVALID" {
 			continue
 		}
 		if activeLicense == nil &&


### PR DESCRIPTION
- the active license API returns 404 status for suspended licenses
- we need to return the license even in this case to allow users to access features
