### PR TITLE
fix(promql): add missing flag columns in query

### DIFF
--- a/pkg/prometheus/clickhouseprometheus/client.go
+++ b/pkg/prometheus/clickhouseprometheus/client.go
@@ -170,7 +170,7 @@ func (client *client) querySamples(ctx context.Context, start int64, end int64, 
 	argCount := len(args)
 
 	query := fmt.Sprintf(`
-		SELECT metric_name, fingerprint, unix_milli, value
+		SELECT metric_name, fingerprint, unix_milli, value, flags
 			FROM %s.%s
 			WHERE metric_name = $1 AND fingerprint GLOBAL IN (%s) AND unix_milli >= $%s AND unix_milli <= $%s ORDER BY fingerprint, unix_milli;`,
 		databaseName, distributedSamplesV4, subQuery, strconv.Itoa(argCount+2), strconv.Itoa(argCount+3))


### PR DESCRIPTION
## 📄 Summary
Added flags column in query while getting samples in promql

Testing Ss - 
<img width="894" alt="Screenshot 2025-06-04 at 8 02 08 PM" src="https://github.com/user-attachments/assets/52e625a0-00b7-4ba8-ab59-4bf3ef0d8543" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `flags` column to SQL query in `querySamples()` in `client.go` to handle staleness in Prometheus samples.
> 
>   - **Behavior**:
>     - Adds `flags` column to SQL query in `querySamples()` in `client.go` to retrieve additional data.
>     - Handles `flags` in `querySamples()` to set `value` to `StaleNaN` if `flags` indicate staleness.
>   - **Misc**:
>     - Updates SQL query format string in `querySamples()` to include `flags`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 7e4fbb9f84168ca1278dc07e8a08b99e8a29afd6. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->