### PR TITLE
feat(statsreporter): build a statsreporter service

### DIFF
--- a/.github/workflows/build-community.yaml
+++ b/.github/workflows/build-community.yaml
@@ -74,7 +74,8 @@ jobs:
         -X github.com/SigNoz/signoz/pkg/version.variant=community
         -X github.com/SigNoz/signoz/pkg/version.hash=${{ needs.prepare.outputs.hash }}
         -X github.com/SigNoz/signoz/pkg/version.time=${{ needs.prepare.outputs.time }}
-        -X github.com/SigNoz/signoz/pkg/version.branch=${{ needs.prepare.outputs.branch }}'
+        -X github.com/SigNoz/signoz/pkg/version.branch=${{ needs.prepare.outputs.branch }}
+        -X github.com/SigNoz/signoz/pkg/analytics.key=9kRrJ7oPCGPEJLF6QjMPLt5bljFhRQBr'
       GO_CGO_ENABLED: 1
       DOCKER_BASE_IMAGES: '{"alpine": "alpine:3.20.3"}'
       DOCKER_DOCKERFILE_PATH: ./pkg/query-service/Dockerfile.multi-arch

--- a/.github/workflows/build-enterprise.yaml
+++ b/.github/workflows/build-enterprise.yaml
@@ -108,7 +108,8 @@ jobs:
         -X github.com/SigNoz/signoz/ee/zeus.url=https://api.signoz.cloud
         -X github.com/SigNoz/signoz/ee/zeus.deprecatedURL=https://license.signoz.io
         -X github.com/SigNoz/signoz/ee/query-service/constants.ZeusURL=https://api.signoz.cloud
-        -X github.com/SigNoz/signoz/ee/query-service/constants.LicenseSignozIo=https://license.signoz.io/api/v1'
+        -X github.com/SigNoz/signoz/ee/query-service/constants.LicenseSignozIo=https://license.signoz.io/api/v1
+        -X github.com/SigNoz/signoz/pkg/analytics.key=9kRrJ7oPCGPEJLF6QjMPLt5bljFhRQBr'
       GO_CGO_ENABLED: 1
       DOCKER_BASE_IMAGES: '{"alpine": "alpine:3.20.3"}'
       DOCKER_DOCKERFILE_PATH: ./ee/query-service/Dockerfile.multi-arch

--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -107,7 +107,8 @@ jobs:
         -X github.com/SigNoz/signoz/ee/zeus.url=https://api.staging.signoz.cloud
         -X github.com/SigNoz/signoz/ee/zeus.deprecatedURL=https://license.staging.signoz.cloud
         -X github.com/SigNoz/signoz/ee/query-service/constants.ZeusURL=https://api.staging.signoz.cloud
-        -X github.com/SigNoz/signoz/ee/query-service/constants.LicenseSignozIo=https://license.staging.signoz.cloud/api/v1'
+        -X github.com/SigNoz/signoz/ee/query-service/constants.LicenseSignozIo=https://license.staging.signoz.cloud/api/v1
+        -X github.com/SigNoz/signoz/pkg/analytics.key=9kRrJ7oPCGPEJLF6QjMPLt5bljFhRQBr'
       GO_CGO_ENABLED: 1
       DOCKER_BASE_IMAGES: '{"alpine": "alpine:3.20.3"}'
       DOCKER_DOCKERFILE_PATH: ./ee/query-service/Dockerfile.multi-arch

--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -165,12 +165,6 @@ alertmanager:
       # Retention of the notification logs.
       retention: 120h
 
-
-##################### Analytics #####################
-analytics:
-  # Whether to enable analytics.
-  enabled: false
-
 ##################### Emailing #####################
 emailing:
   # Whether to enable emailing.
@@ -215,3 +209,18 @@ sharder:
   single:
     # The org id to which this instance belongs to.
     org_id: org_id
+
+##################### Analytics #####################
+analytics:
+  # Whether to enable analytics.
+  enabled: false
+  segment:
+    # The key to use for segment.
+    key: ""
+
+##################### StatsReporter #####################
+statsreporter:
+  # Whether to enable stats reporter. This is used to provide valuable insights to the SigNoz team. It does not collect any sensitive/PII data.
+  enabled: true
+  # The interval at which the stats are collected.
+  interval: 6h

--- a/ee/licensing/httplicensing/provider.go
+++ b/ee/licensing/httplicensing/provider.go
@@ -211,3 +211,16 @@ func (provider *provider) GetFeatureFlags(ctx context.Context, organizationID va
 
 	return license.Features, nil
 }
+
+func (provider *provider) Collect(ctx context.Context, orgID valuer.UUID) (map[string]any, error) {
+	activeLicense, err := provider.GetActive(ctx, orgID)
+	if err != nil {
+		if errors.Ast(err, errors.TypeNotFound) {
+			return map[string]any{}, nil
+		}
+
+		return nil, err
+	}
+
+	return licensetypes.NewStatsFromLicense(activeLicense), nil
+}

--- a/ee/query-service/.goreleaser.yaml
+++ b/ee/query-service/.goreleaser.yaml
@@ -39,6 +39,7 @@ builds:
       - -X github.com/SigNoz/signoz/ee/zeus.deprecatedURL=https://license.signoz.io
       - -X github.com/SigNoz/signoz/ee/query-service/constants.ZeusURL=https://api.signoz.cloud
       - -X github.com/SigNoz/signoz/ee/query-service/constants.LicenseSignozIo=https://license.signoz.io/api/v1
+      - -X github.com/SigNoz/signoz/pkg/analytics.key=9kRrJ7oPCGPEJLF6QjMPLt5bljFhRQBr
       - >-
         {{- if eq .Os "linux" }}-linkmode external -extldflags '-static'{{- end }}
     mod_timestamp: "{{ .CommitTimestamp }}"

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/statsreporter"
 	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
@@ -53,4 +54,7 @@ type Alertmanager interface {
 
 	// SetDefaultConfig sets the default config for the organization.
 	SetDefaultConfig(context.Context, string) error
+
+	// Collects stats for the organization.
+	statsreporter.StatsCollector
 }

--- a/pkg/alertmanager/legacyalertmanager/provider.go
+++ b/pkg/alertmanager/legacyalertmanager/provider.go
@@ -471,3 +471,12 @@ func (provider *provider) SetDefaultConfig(ctx context.Context, orgID string) er
 
 	return provider.configStore.Set(ctx, config)
 }
+
+func (provider *provider) Collect(ctx context.Context, orgID valuer.UUID) (map[string]any, error) {
+	channels, err := provider.configStore.ListChannels(ctx, orgID.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return alertmanagertypes.NewStatsFromChannels(channels), nil
+}

--- a/pkg/alertmanager/signozalertmanager/provider.go
+++ b/pkg/alertmanager/signozalertmanager/provider.go
@@ -182,3 +182,12 @@ func (provider *provider) SetDefaultConfig(ctx context.Context, orgID string) er
 
 	return provider.configStore.Set(ctx, config)
 }
+
+func (provider *provider) Collect(ctx context.Context, orgID valuer.UUID) (map[string]any, error) {
+	channels, err := provider.configStore.ListChannels(ctx, orgID.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return alertmanagertypes.NewStatsFromChannels(channels), nil
+}

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -13,3 +13,26 @@ type Analytics interface {
 	// Sends analytics messages to an analytics backend.
 	Send(context.Context, ...analyticstypes.Message)
 }
+
+type API interface {
+	// func (aH *APIHandler) registerEvent(w http.ResponseWriter, r *http.Request) {
+	// 	request, err := parseRegisterEventRequest(r)
+	// 	if aH.HandleError(w, err, http.StatusBadRequest) {
+	// 		return
+	// 	}
+	// 	claims, errv2 := authtypes.ClaimsFromContext(r.Context())
+	// 	if errv2 == nil {
+	// 		switch request.EventType {
+	// 		case model.TrackEvent:
+	// 			telemetry.GetInstance().SendEvent(request.EventName, request.Attributes, claims.Email, request.RateLimited, true)
+	// 		case model.GroupEvent:
+	// 			telemetry.GetInstance().SendGroupEvent(request.Attributes, claims.Email)
+	// 		case model.IdentifyEvent:
+	// 			telemetry.GetInstance().SendIdentifyEvent(request.Attributes, claims.Email)
+	// 		}
+	// 		aH.WriteJSON(w, r, map[string]string{"data": "Event Processed Successfully"})
+	// 	} else {
+	// 		RespondError(w, &model.ApiError{Typ: model.ErrorInternal, Err: err}, nil)
+	// 	}
+	// }
+}

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -13,26 +13,3 @@ type Analytics interface {
 	// Sends analytics messages to an analytics backend.
 	Send(context.Context, ...analyticstypes.Message)
 }
-
-type API interface {
-	// func (aH *APIHandler) registerEvent(w http.ResponseWriter, r *http.Request) {
-	// 	request, err := parseRegisterEventRequest(r)
-	// 	if aH.HandleError(w, err, http.StatusBadRequest) {
-	// 		return
-	// 	}
-	// 	claims, errv2 := authtypes.ClaimsFromContext(r.Context())
-	// 	if errv2 == nil {
-	// 		switch request.EventType {
-	// 		case model.TrackEvent:
-	// 			telemetry.GetInstance().SendEvent(request.EventName, request.Attributes, claims.Email, request.RateLimited, true)
-	// 		case model.GroupEvent:
-	// 			telemetry.GetInstance().SendGroupEvent(request.Attributes, claims.Email)
-	// 		case model.IdentifyEvent:
-	// 			telemetry.GetInstance().SendIdentifyEvent(request.Attributes, claims.Email)
-	// 		}
-	// 		aH.WriteJSON(w, r, map[string]string{"data": "Event Processed Successfully"})
-	// 	} else {
-	// 		RespondError(w, &model.ApiError{Typ: model.ErrorInternal, Err: err}, nil)
-	// 	}
-	// }
-}

--- a/pkg/analytics/analyticstest/provider.go
+++ b/pkg/analytics/analyticstest/provider.go
@@ -1,0 +1,30 @@
+package analyticstest
+
+import (
+	"context"
+
+	"github.com/SigNoz/signoz/pkg/analytics"
+	"github.com/SigNoz/signoz/pkg/types/analyticstypes"
+)
+
+var _ analytics.Analytics = (*Provider)(nil)
+
+type Provider struct {
+	stopC chan struct{}
+}
+
+func New() *Provider {
+	return &Provider{stopC: make(chan struct{})}
+}
+
+func (provider *Provider) Start(_ context.Context) error {
+	<-provider.stopC
+	return nil
+}
+
+func (provider *Provider) Send(ctx context.Context, messages ...analyticstypes.Message) {}
+
+func (provider *Provider) Stop(_ context.Context) error {
+	close(provider.stopC)
+	return nil
+}

--- a/pkg/analytics/config.go
+++ b/pkg/analytics/config.go
@@ -1,8 +1,6 @@
 package analytics
 
 import (
-	"fmt"
-
 	"github.com/SigNoz/signoz/pkg/factory"
 )
 
@@ -12,8 +10,12 @@ var (
 )
 
 type Config struct {
-	Enabled bool   `mapstructure:"enabled"`
-	Key     string `mapstructure:"key"`
+	Enabled bool    `mapstructure:"enabled"`
+	Segment Segment `mapstructure:"segment"`
+}
+
+type Segment struct {
+	Key string `mapstructure:"key"`
 }
 
 func NewConfigFactory() factory.ConfigFactory {
@@ -23,14 +25,20 @@ func NewConfigFactory() factory.ConfigFactory {
 func newConfig() factory.Config {
 	return Config{
 		Enabled: false,
-		Key:     key,
+		Segment: Segment{
+			Key: key,
+		},
 	}
 }
 
 func (c Config) Validate() error {
-	if c.Key != key {
-		return fmt.Errorf("cannot override key set at build time with key: %s", c.Key)
+	return nil
+}
+
+func (c Config) Provider() string {
+	if c.Enabled {
+		return "segment"
 	}
 
-	return nil
+	return "noop"
 }

--- a/pkg/analytics/segmentanalytics/logger.go
+++ b/pkg/analytics/segmentanalytics/logger.go
@@ -18,9 +18,9 @@ func newSegmentLogger(settings factory.ScopedProviderSettings) segment.Logger {
 }
 
 func (logger *logger) Logf(format string, args ...interface{}) {
-	logger.settings.Logger().InfoContext(context.TODO(), format, args...)
+	logger.settings.Logger().InfoContext(context.TODO(), format, args...) //nolint:sloglint
 }
 
 func (logger *logger) Errorf(format string, args ...interface{}) {
-	logger.settings.Logger().ErrorContext(context.TODO(), format, args...)
+	logger.settings.Logger().ErrorContext(context.TODO(), format, args...) //nolint:sloglint
 }

--- a/pkg/analytics/segmentanalytics/logger.go
+++ b/pkg/analytics/segmentanalytics/logger.go
@@ -1,0 +1,24 @@
+package segmentanalytics
+
+import (
+	"github.com/SigNoz/signoz/pkg/factory"
+	segment "github.com/segmentio/analytics-go/v3"
+)
+
+type logger struct {
+	settings factory.ScopedProviderSettings
+}
+
+func newSegmentLogger(settings factory.ScopedProviderSettings) segment.Logger {
+	return &logger{
+		settings: settings,
+	}
+}
+
+func (logger *logger) Logf(format string, args ...interface{}) {
+	logger.settings.Logger().Info(format, args...)
+}
+
+func (logger *logger) Errorf(format string, args ...interface{}) {
+	logger.settings.Logger().Error(format, args...)
+}

--- a/pkg/analytics/segmentanalytics/logger.go
+++ b/pkg/analytics/segmentanalytics/logger.go
@@ -1,6 +1,8 @@
 package segmentanalytics
 
 import (
+	"context"
+
 	"github.com/SigNoz/signoz/pkg/factory"
 	segment "github.com/segmentio/analytics-go/v3"
 )
@@ -16,9 +18,9 @@ func newSegmentLogger(settings factory.ScopedProviderSettings) segment.Logger {
 }
 
 func (logger *logger) Logf(format string, args ...interface{}) {
-	logger.settings.Logger().Info(format, args...)
+	logger.settings.Logger().InfoContext(context.TODO(), format, args...)
 }
 
 func (logger *logger) Errorf(format string, args ...interface{}) {
-	logger.settings.Logger().Error(format, args...)
+	logger.settings.Logger().ErrorContext(context.TODO(), format, args...)
 }

--- a/pkg/analytics/segmentanalytics/logger.go
+++ b/pkg/analytics/segmentanalytics/logger.go
@@ -18,9 +18,11 @@ func newSegmentLogger(settings factory.ScopedProviderSettings) segment.Logger {
 }
 
 func (logger *logger) Logf(format string, args ...interface{}) {
+	// the no lint directive is needed because the segmentlogger is not a slog.Logger
 	logger.settings.Logger().InfoContext(context.TODO(), format, args...) //nolint:sloglint
 }
 
 func (logger *logger) Errorf(format string, args ...interface{}) {
+	// the no lint directive is needed because the segment logger is not a slog.Logger
 	logger.settings.Logger().ErrorContext(context.TODO(), format, args...) //nolint:sloglint
 }

--- a/pkg/analytics/segmentanalytics/provider.go
+++ b/pkg/analytics/segmentanalytics/provider.go
@@ -22,6 +22,10 @@ func NewFactory() factory.ProviderFactory[analytics.Analytics, analytics.Config]
 func New(ctx context.Context, providerSettings factory.ProviderSettings, config analytics.Config) (analytics.Analytics, error) {
 	settings := factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/analytics/segmentanalytics")
 
+	segment.NewWithConfig(config.Segment.Key, segment.Config{
+		Logger: newSegmentLogger(settings),
+	})
+
 	return &provider{
 		settings: settings,
 		client:   segment.New(config.Segment.Key),

--- a/pkg/analytics/segmentanalytics/provider.go
+++ b/pkg/analytics/segmentanalytics/provider.go
@@ -22,13 +22,16 @@ func NewFactory() factory.ProviderFactory[analytics.Analytics, analytics.Config]
 func New(ctx context.Context, providerSettings factory.ProviderSettings, config analytics.Config) (analytics.Analytics, error) {
 	settings := factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/analytics/segmentanalytics")
 
-	segment.NewWithConfig(config.Segment.Key, segment.Config{
+	client, err := segment.NewWithConfig(config.Segment.Key, segment.Config{
 		Logger: newSegmentLogger(settings),
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	return &provider{
 		settings: settings,
-		client:   segment.New(config.Segment.Key),
+		client:   client,
 		stopC:    make(chan struct{}),
 	}, nil
 }

--- a/pkg/licensing/licensing.go
+++ b/pkg/licensing/licensing.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/statsreporter"
 	"github.com/SigNoz/signoz/pkg/types/licensetypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
@@ -32,6 +33,8 @@ type Licensing interface {
 	Portal(ctx context.Context, organizationID valuer.UUID, postableSubscription *licensetypes.PostableSubscription) (*licensetypes.GettableSubscription, error)
 	// GetFeatureFlags fetches all the defined feature flags
 	GetFeatureFlags(ctx context.Context, organizationID valuer.UUID) ([]*licensetypes.Feature, error)
+
+	statsreporter.StatsCollector
 }
 
 type API interface {

--- a/pkg/licensing/nooplicensing/provider.go
+++ b/pkg/licensing/nooplicensing/provider.go
@@ -62,3 +62,7 @@ func (provider *noopLicensing) GetActive(ctx context.Context, organizationID val
 func (provider *noopLicensing) GetFeatureFlags(_ context.Context, _ valuer.UUID) ([]*licensetypes.Feature, error) {
 	return licensetypes.DefaultFeatureSet, nil
 }
+
+func (provider *noopLicensing) Collect(ctx context.Context, orgID valuer.UUID) (map[string]any, error) {
+	return map[string]any{}, nil
+}

--- a/pkg/modules/dashboard/dashboard.go
+++ b/pkg/modules/dashboard/dashboard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/SigNoz/signoz/pkg/statsreporter"
 	"github.com/SigNoz/signoz/pkg/types/dashboardtypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
@@ -22,6 +23,8 @@ type Module interface {
 	Delete(ctx context.Context, orgID valuer.UUID, id valuer.UUID) error
 
 	GetByMetricNames(ctx context.Context, orgID valuer.UUID, metricNames []string) (map[string][]map[string]string, error)
+
+	statsreporter.StatsCollector
 }
 
 type Handler interface {

--- a/pkg/modules/dashboard/dashboard.go
+++ b/pkg/modules/dashboard/dashboard.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Module interface {
-	Create(ctx context.Context, orgID valuer.UUID, createdBy string, data dashboardtypes.PostableDashboard) (*dashboardtypes.Dashboard, error)
+	Create(ctx context.Context, orgID valuer.UUID, createdBy string, creator valuer.UUID, data dashboardtypes.PostableDashboard) (*dashboardtypes.Dashboard, error)
 
 	Get(ctx context.Context, orgID valuer.UUID, id valuer.UUID) (*dashboardtypes.Dashboard, error)
 

--- a/pkg/modules/dashboard/impldashboard/handler.go
+++ b/pkg/modules/dashboard/impldashboard/handler.go
@@ -46,7 +46,7 @@ func (handler *handler) Create(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dashboard, err := handler.module.Create(ctx, orgID, claims.Email, req)
+	dashboard, err := handler.module.Create(ctx, orgID, claims.Email, valuer.MustNewUUID(claims.ID), req)
 	if err != nil {
 		render.Error(rw, err)
 		return

--- a/pkg/modules/dashboard/impldashboard/module.go
+++ b/pkg/modules/dashboard/impldashboard/module.go
@@ -4,28 +4,32 @@ import (
 	"context"
 	"strings"
 
+	"github.com/SigNoz/signoz/pkg/analytics"
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/modules/dashboard"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/types/analyticstypes"
 	"github.com/SigNoz/signoz/pkg/types/dashboardtypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
 
 type module struct {
-	store    dashboardtypes.Store
-	settings factory.ScopedProviderSettings
+	store     dashboardtypes.Store
+	settings  factory.ScopedProviderSettings
+	analytics analytics.Analytics
 }
 
-func NewModule(sqlstore sqlstore.SQLStore, settings factory.ProviderSettings) dashboard.Module {
+func NewModule(sqlstore sqlstore.SQLStore, settings factory.ProviderSettings, analytics analytics.Analytics) dashboard.Module {
 	scopedProviderSettings := factory.NewScopedProviderSettings(settings, "github.com/SigNoz/signoz/pkg/modules/impldashboard")
 	return &module{
-		store:    NewStore(sqlstore),
-		settings: scopedProviderSettings,
+		store:     NewStore(sqlstore),
+		settings:  scopedProviderSettings,
+		analytics: analytics,
 	}
 }
 
-func (module *module) Create(ctx context.Context, orgID valuer.UUID, createdBy string, postableDashboard dashboardtypes.PostableDashboard) (*dashboardtypes.Dashboard, error) {
+func (module *module) Create(ctx context.Context, orgID valuer.UUID, createdBy string, creator valuer.UUID, postableDashboard dashboardtypes.PostableDashboard) (*dashboardtypes.Dashboard, error) {
 	dashboard, err := dashboardtypes.NewDashboard(orgID, createdBy, postableDashboard)
 	if err != nil {
 		return nil, err
@@ -35,10 +39,24 @@ func (module *module) Create(ctx context.Context, orgID valuer.UUID, createdBy s
 	if err != nil {
 		return nil, err
 	}
+
 	err = module.store.Create(ctx, storableDashboard)
 	if err != nil {
 		return nil, err
 	}
+
+	module.analytics.Send(ctx,
+		analyticstypes.Track{
+			UserId:     creator.String(),
+			Event:      "Dashboard Created",
+			Properties: analyticstypes.NewPropertiesFromMap(dashboardtypes.NewStatsFromStorableDashboards([]*dashboardtypes.StorableDashboard{storableDashboard})),
+			Context: &analyticstypes.Context{
+				Extra: map[string]interface{}{
+					analyticstypes.KeyGroupID: orgID,
+				},
+			},
+		},
+	)
 
 	return dashboard, nil
 }

--- a/pkg/modules/dashboard/impldashboard/module.go
+++ b/pkg/modules/dashboard/impldashboard/module.go
@@ -207,3 +207,12 @@ func (module *module) GetByMetricNames(ctx context.Context, orgID valuer.UUID, m
 
 	return result, nil
 }
+
+func (module *module) Collect(ctx context.Context, orgID valuer.UUID) (map[string]any, error) {
+	dashboards, err := module.store.List(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	return dashboardtypes.NewStatsFromStorableDashboards(dashboards), nil
+}

--- a/pkg/modules/organization/implorganization/getter.go
+++ b/pkg/modules/organization/implorganization/getter.go
@@ -22,10 +22,6 @@ func (module *getter) Get(ctx context.Context, id valuer.UUID) (*types.Organizat
 	return module.store.Get(ctx, id)
 }
 
-func (module *getter) List(ctx context.Context) ([]*types.Organization, error) {
-	return module.store.GetAll(ctx)
-}
-
 func (module *getter) ListByOwnedKeyRange(ctx context.Context) ([]*types.Organization, error) {
 	start, end, err := module.sharder.GetMyOwnedKeyRange(ctx)
 	if err != nil {

--- a/pkg/modules/organization/organization.go
+++ b/pkg/modules/organization/organization.go
@@ -12,9 +12,6 @@ type Getter interface {
 	// Get gets the organization based on the given id
 	Get(context.Context, valuer.UUID) (*types.Organization, error)
 
-	// Lists all the organizations
-	List(context.Context) ([]*types.Organization, error)
-
 	// ListByOwnedKeyRange gets all the organizations owned by the instance
 	ListByOwnedKeyRange(context.Context) ([]*types.Organization, error)
 }

--- a/pkg/modules/savedview/implsavedview/module.go
+++ b/pkg/modules/savedview/implsavedview/module.go
@@ -169,3 +169,20 @@ func (module *module) DeleteView(ctx context.Context, orgID string, uuid valuer.
 	}
 	return nil
 }
+
+func (module *module) Collect(ctx context.Context, orgID valuer.UUID) (map[string]any, error) {
+	savedViews := []*types.SavedView{}
+
+	err := module.
+		sqlstore.
+		BunDB().
+		NewSelect().
+		Model(&savedViews).
+		Where("org_id = ?", orgID).
+		Scan(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return types.NewStatsFromSavedViews(savedViews), nil
+}

--- a/pkg/modules/savedview/savedview.go
+++ b/pkg/modules/savedview/savedview.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	v3 "github.com/SigNoz/signoz/pkg/query-service/model/v3"
+	"github.com/SigNoz/signoz/pkg/statsreporter"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
 
@@ -18,6 +19,8 @@ type Module interface {
 	UpdateView(ctx context.Context, orgID string, uuid valuer.UUID, view v3.SavedView) error
 
 	DeleteView(ctx context.Context, orgID string, uuid valuer.UUID) error
+
+	statsreporter.StatsCollector
 }
 
 type Handler interface {

--- a/pkg/modules/user/impluser/module.go
+++ b/pkg/modules/user/impluser/module.go
@@ -139,8 +139,11 @@ func (m *Module) CreateUserWithPassword(ctx context.Context, user *types.User, p
 		analyticstypes.Identify{
 			UserId: user.ID.String(),
 			Traits: analyticstypes.
-				NewTraitsFromMap(map[string]any{analyticstypes.KeyDisplayName: user.DisplayName}).
-				SetEmail(user.Email),
+				NewTraits().
+				SetName(user.DisplayName).
+				SetEmail(user.Email).
+				Set("role", user.Role).
+				SetCreatedAt(user.CreatedAt),
 		},
 		analyticstypes.Group{
 			UserId:  user.ID.String(),
@@ -149,6 +152,11 @@ func (m *Module) CreateUserWithPassword(ctx context.Context, user *types.User, p
 		analyticstypes.Track{
 			UserId: user.ID.String(),
 			Event:  "User Created",
+			Properties: analyticstypes.NewPropertiesFromMap(map[string]any{
+				"role":  user.Role,
+				"email": user.Email,
+				"name":  user.DisplayName,
+			}),
 			Context: &analyticstypes.Context{
 				Extra: map[string]interface{}{
 					analyticstypes.KeyGroupID: user.OrgID,
@@ -169,8 +177,11 @@ func (m *Module) CreateUser(ctx context.Context, user *types.User) error {
 		analyticstypes.Identify{
 			UserId: user.ID.String(),
 			Traits: analyticstypes.
-				NewTraitsFromMap(map[string]any{analyticstypes.KeyDisplayName: user.DisplayName}).
-				SetEmail(user.Email),
+				NewTraits().
+				SetName(user.DisplayName).
+				SetEmail(user.Email).
+				Set("role", user.Role).
+				SetCreatedAt(user.CreatedAt),
 		},
 		analyticstypes.Group{
 			UserId:  user.ID.String(),
@@ -179,6 +190,11 @@ func (m *Module) CreateUser(ctx context.Context, user *types.User) error {
 		analyticstypes.Track{
 			UserId: user.ID.String(),
 			Event:  "User Created",
+			Properties: analyticstypes.NewPropertiesFromMap(map[string]any{
+				"role":  user.Role,
+				"email": user.Email,
+				"name":  user.DisplayName,
+			}),
 			Context: &analyticstypes.Context{
 				Extra: map[string]interface{}{
 					analyticstypes.KeyGroupID: user.OrgID,

--- a/pkg/modules/user/impluser/module.go
+++ b/pkg/modules/user/impluser/module.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/SigNoz/signoz/pkg/analytics"
 	"github.com/SigNoz/signoz/pkg/emailing"
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
@@ -17,6 +18,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/query-service/model"
 	"github.com/SigNoz/signoz/pkg/query-service/telemetry"
 	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/analyticstypes"
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
 	"github.com/SigNoz/signoz/pkg/types/emailtypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
@@ -29,10 +31,11 @@ type Module struct {
 	emailing  emailing.Emailing
 	settings  factory.ScopedProviderSettings
 	orgSetter organization.Setter
+	analytics analytics.Analytics
 }
 
 // This module is a WIP, don't take inspiration from this.
-func NewModule(store types.UserStore, jwt *authtypes.JWT, emailing emailing.Emailing, providerSettings factory.ProviderSettings, orgSetter organization.Setter) user.Module {
+func NewModule(store types.UserStore, jwt *authtypes.JWT, emailing emailing.Emailing, providerSettings factory.ProviderSettings, orgSetter organization.Setter, analytics analytics.Analytics) user.Module {
 	settings := factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/modules/user/impluser")
 	return &Module{
 		store:     store,
@@ -40,6 +43,7 @@ func NewModule(store types.UserStore, jwt *authtypes.JWT, emailing emailing.Emai
 		emailing:  emailing,
 		settings:  settings,
 		orgSetter: orgSetter,
+		analytics: analytics,
 	}
 }
 
@@ -126,17 +130,64 @@ func (m *Module) GetInviteByEmailInOrg(ctx context.Context, orgID string, email 
 }
 
 func (m *Module) CreateUserWithPassword(ctx context.Context, user *types.User, password *types.FactorPassword) (*types.User, error) {
-
 	user, err := m.store.CreateUserWithPassword(ctx, user, password)
 	if err != nil {
 		return nil, err
 	}
 
+	m.analytics.Send(ctx,
+		analyticstypes.Identify{
+			UserId: user.ID.String(),
+			Traits: analyticstypes.
+				NewTraitsFromMap(map[string]any{analyticstypes.KeyDisplayName: user.DisplayName}).
+				SetEmail(user.Email),
+		},
+		analyticstypes.Group{
+			UserId:  user.ID.String(),
+			GroupId: user.OrgID,
+		},
+		analyticstypes.Track{
+			UserId: user.ID.String(),
+			Event:  "User Created",
+			Context: &analyticstypes.Context{
+				Extra: map[string]interface{}{
+					analyticstypes.KeyGroupID: user.OrgID,
+				},
+			},
+		},
+	)
+
 	return user, nil
 }
 
 func (m *Module) CreateUser(ctx context.Context, user *types.User) error {
-	return m.store.CreateUser(ctx, user)
+	if err := m.store.CreateUser(ctx, user); err != nil {
+		return err
+	}
+
+	m.analytics.Send(ctx,
+		analyticstypes.Identify{
+			UserId: user.ID.String(),
+			Traits: analyticstypes.
+				NewTraitsFromMap(map[string]any{analyticstypes.KeyDisplayName: user.DisplayName}).
+				SetEmail(user.Email),
+		},
+		analyticstypes.Group{
+			UserId:  user.ID.String(),
+			GroupId: user.OrgID,
+		},
+		analyticstypes.Track{
+			UserId: user.ID.String(),
+			Event:  "User Created",
+			Context: &analyticstypes.Context{
+				Extra: map[string]interface{}{
+					analyticstypes.KeyGroupID: user.OrgID,
+				},
+			},
+		},
+	)
+
+	return nil
 }
 
 func (m *Module) GetUserByID(ctx context.Context, orgID string, id string) (*types.GettableUser, error) {

--- a/pkg/modules/user/impluser/module.go
+++ b/pkg/modules/user/impluser/module.go
@@ -575,3 +575,12 @@ func (m *Module) Register(ctx context.Context, req *types.PostableRegisterOrgAnd
 
 	return user, nil
 }
+
+func (m *Module) Collect(ctx context.Context, orgID valuer.UUID) (map[string]any, error) {
+	count, err := m.store.CountByOrgID(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{"user.count": count}, nil
+}

--- a/pkg/modules/user/impluser/store.go
+++ b/pkg/modules/user/impluser/store.go
@@ -809,3 +809,20 @@ func (store *store) DeleteDomain(ctx context.Context, id uuid.UUID) error {
 
 	return nil
 }
+
+func (store *store) CountByOrgID(ctx context.Context, orgID valuer.UUID) (int64, error) {
+	user := new(types.User)
+
+	count, err := store.
+		sqlstore.
+		BunDB().
+		NewSelect().
+		Model(user).
+		Where("org_id = ?", orgID).
+		Count(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return int64(count), nil
+}

--- a/pkg/modules/user/user.go
+++ b/pkg/modules/user/user.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/SigNoz/signoz/pkg/statsreporter"
 	"github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
@@ -65,6 +66,8 @@ type Module interface {
 
 	// Register
 	Register(ctx context.Context, req *types.PostableRegisterOrgAndAdmin) (*types.User, error)
+
+	statsreporter.StatsCollector
 }
 
 type Handler interface {

--- a/pkg/query-service/.goreleaser.yaml
+++ b/pkg/query-service/.goreleaser.yaml
@@ -35,6 +35,7 @@ builds:
       - -X github.com/SigNoz/signoz/pkg/version.hash={{ .ShortCommit }}
       - -X github.com/SigNoz/signoz/pkg/version.time={{ .CommitTimestamp }}
       - -X github.com/SigNoz/signoz/pkg/version.branch={{ .Branch }}
+      - -X github.com/SigNoz/signoz/pkg/analytics.key=9kRrJ7oPCGPEJLF6QjMPLt5bljFhRQBr
       - >-
         {{- if eq .Os "linux" }}-linkmode external -extldflags '-static'{{- end }}
     mod_timestamp: "{{ .CommitTimestamp }}"

--- a/pkg/query-service/app/cloudintegrations/controller_test.go
+++ b/pkg/query-service/app/cloudintegrations/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/alertmanager"
 	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagerserver"
 	"github.com/SigNoz/signoz/pkg/alertmanager/signozalertmanager"
+	"github.com/SigNoz/signoz/pkg/analytics/analyticstest"
 	"github.com/SigNoz/signoz/pkg/emailing/emailingtest"
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/modules/organization"
@@ -38,7 +39,8 @@ func TestRegenerateConnectionUrlWithUpdatedConfig(t *testing.T) {
 	require.NoError(err)
 	jwt := authtypes.NewJWT("", 1*time.Hour, 1*time.Hour)
 	emailing := emailingtest.New()
-	modules := signoz.NewModules(sqlStore, jwt, emailing, providerSettings, orgGetter, alertmanager)
+	analytics := analyticstest.New()
+	modules := signoz.NewModules(sqlStore, jwt, emailing, providerSettings, orgGetter, alertmanager, analytics)
 	user, apiErr := createTestUser(modules.OrgSetter, modules.User)
 	require.Nil(apiErr)
 
@@ -94,7 +96,8 @@ func TestAgentCheckIns(t *testing.T) {
 	require.NoError(err)
 	jwt := authtypes.NewJWT("", 1*time.Hour, 1*time.Hour)
 	emailing := emailingtest.New()
-	modules := signoz.NewModules(sqlStore, jwt, emailing, providerSettings, orgGetter, alertmanager)
+	analytics := analyticstest.New()
+	modules := signoz.NewModules(sqlStore, jwt, emailing, providerSettings, orgGetter, alertmanager, analytics)
 	user, apiErr := createTestUser(modules.OrgSetter, modules.User)
 	require.Nil(apiErr)
 
@@ -189,7 +192,8 @@ func TestCantDisconnectNonExistentAccount(t *testing.T) {
 	require.NoError(err)
 	jwt := authtypes.NewJWT("", 1*time.Hour, 1*time.Hour)
 	emailing := emailingtest.New()
-	modules := signoz.NewModules(sqlStore, jwt, emailing, providerSettings, orgGetter, alertmanager)
+	analytics := analyticstest.New()
+	modules := signoz.NewModules(sqlStore, jwt, emailing, providerSettings, orgGetter, alertmanager, analytics)
 	user, apiErr := createTestUser(modules.OrgSetter, modules.User)
 	require.Nil(apiErr)
 
@@ -216,7 +220,8 @@ func TestConfigureService(t *testing.T) {
 	require.NoError(err)
 	jwt := authtypes.NewJWT("", 1*time.Hour, 1*time.Hour)
 	emailing := emailingtest.New()
-	modules := signoz.NewModules(sqlStore, jwt, emailing, providerSettings, orgGetter, alertmanager)
+	analytics := analyticstest.New()
+	modules := signoz.NewModules(sqlStore, jwt, emailing, providerSettings, orgGetter, alertmanager, analytics)
 	user, apiErr := createTestUser(modules.OrgSetter, modules.User)
 	require.Nil(apiErr)
 

--- a/pkg/query-service/app/integrations/manager_test.go
+++ b/pkg/query-service/app/integrations/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/alertmanager"
 	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagerserver"
 	"github.com/SigNoz/signoz/pkg/alertmanager/signozalertmanager"
+	"github.com/SigNoz/signoz/pkg/analytics/analyticstest"
 	"github.com/SigNoz/signoz/pkg/emailing/emailingtest"
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/modules/organization/implorganization"
@@ -31,7 +32,8 @@ func TestIntegrationLifecycle(t *testing.T) {
 	alertmanager, _ := signozalertmanager.New(context.TODO(), providerSettings, alertmanager.Config{Provider: "signoz", Signoz: alertmanager.Signoz{PollInterval: 10 * time.Second, Config: alertmanagerserver.NewConfig()}}, store, orgGetter)
 	jwt := authtypes.NewJWT("", 1*time.Hour, 1*time.Hour)
 	emailing := emailingtest.New()
-	modules := signoz.NewModules(store, jwt, emailing, providerSettings, orgGetter, alertmanager)
+	analytics := analyticstest.New()
+	modules := signoz.NewModules(store, jwt, emailing, providerSettings, orgGetter, alertmanager, analytics)
 	user, apiErr := createTestUser(modules.OrgSetter, modules.User)
 	if apiErr != nil {
 		t.Fatalf("could not create test user: %v", apiErr)

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -18,8 +18,10 @@ const (
 	OpAmpWsEndpoint = "0.0.0.0:4320" // address for opamp websocket
 )
 
+// Deprecated: Use the new analytics service instead
 var DEFAULT_TELEMETRY_ANONYMOUS = false
 
+// Deprecated: Use the new analytics service instead
 func IsOSSTelemetryEnabled() bool {
 	ossSegmentKey := GetOrDefaultEnv("OSS_TELEMETRY_ENABLED", "true")
 	return ossSegmentKey == "true"
@@ -27,6 +29,7 @@ func IsOSSTelemetryEnabled() bool {
 
 const MaxAllowedPointsInTimeSeries = 300
 
+// Deprecated: Use the new analytics service instead
 func IsTelemetryEnabled() bool {
 	if testing.Testing() {
 		return false
@@ -48,8 +51,10 @@ const SpanSearchScopeRoot = "isroot"
 const SpanSearchScopeEntryPoint = "isentrypoint"
 const OrderBySpanCount = "span_count"
 
+// Deprecated: Use the new statsreporter service instead
 var TELEMETRY_HEART_BEAT_DURATION_MINUTES = GetOrDefaultEnvInt("TELEMETRY_HEART_BEAT_DURATION_MINUTES", 720)
 
+// Deprecated: Use the new statsreporter service instead
 var TELEMETRY_ACTIVE_USER_DURATION_MINUTES = GetOrDefaultEnvInt("TELEMETRY_ACTIVE_USER_DURATION_MINUTES", 360)
 
 // Deprecated: Use the new emailing service instead

--- a/pkg/query-service/rules/manager.go
+++ b/pkg/query-service/rules/manager.go
@@ -195,7 +195,7 @@ func defaultPrepareTaskFunc(opts PrepareTaskOptions) (Task, error) {
 // by calling the Run method.
 func NewManager(o *ManagerOptions) (*Manager, error) {
 	o = defaultOptions(o)
-	ruleStore := sqlrulestore.NewRuleStore(o.DBConn, o.SQLStore)
+	ruleStore := sqlrulestore.NewRuleStore(o.SQLStore)
 	maintenanceStore := sqlrulestore.NewMaintenanceStore(o.SQLStore)
 
 	m := &Manager{

--- a/pkg/query-service/telemetry/ignored.go
+++ b/pkg/query-service/telemetry/ignored.go
@@ -1,13 +1,5 @@
 package telemetry
 
-func EnabledPaths() map[string]struct{} {
-	enabledPaths := map[string]struct{}{
-		"/api/v1/channels": {},
-	}
-
-	return enabledPaths
-}
-
 func ignoreEvents(event string, attributes map[string]interface{}) bool {
 
 	if event == TELEMETRY_EVENT_ACTIVE_USER {

--- a/pkg/query-service/telemetry/telemetry.go
+++ b/pkg/query-service/telemetry/telemetry.go
@@ -613,7 +613,6 @@ func (a *Telemetry) SendIdentifyEvent(data map[string]interface{}, userEmail str
 }
 
 func (a *Telemetry) SendGroupEvent(data map[string]interface{}, userEmail string) {
-
 	if !a.isTelemetryEnabled() || a.isTelemetryAnonymous() {
 		return
 	}

--- a/pkg/query-service/tests/integration/filter_suggestions_test.go
+++ b/pkg/query-service/tests/integration/filter_suggestions_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/alertmanager"
 	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagerserver"
 	"github.com/SigNoz/signoz/pkg/alertmanager/signozalertmanager"
+	"github.com/SigNoz/signoz/pkg/analytics/analyticstest"
 	"github.com/SigNoz/signoz/pkg/emailing/emailingtest"
 	"github.com/SigNoz/signoz/pkg/sharder"
 	"github.com/SigNoz/signoz/pkg/sharder/noopsharder"
@@ -315,7 +316,8 @@ func NewFilterSuggestionsTestBed(t *testing.T) *FilterSuggestionsTestBed {
 	require.NoError(t, err)
 	jwt := authtypes.NewJWT("", 1*time.Hour, 1*time.Hour)
 	emailing := emailingtest.New()
-	modules := signoz.NewModules(testDB, jwt, emailing, providerSettings, orgGetter, alertmanager)
+	analytics := analyticstest.New()
+	modules := signoz.NewModules(testDB, jwt, emailing, providerSettings, orgGetter, alertmanager, analytics)
 	handlers := signoz.NewHandlers(modules)
 
 	apiHandler, err := app.NewAPIHandler(app.APIHandlerOpts{

--- a/pkg/query-service/tests/integration/logparsingpipeline_test.go
+++ b/pkg/query-service/tests/integration/logparsingpipeline_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/alertmanager"
 	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagerserver"
 	"github.com/SigNoz/signoz/pkg/alertmanager/signozalertmanager"
+	"github.com/SigNoz/signoz/pkg/analytics/analyticstest"
 	"github.com/SigNoz/signoz/pkg/emailing/emailingtest"
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/modules/organization/implorganization"
@@ -491,7 +492,8 @@ func NewTestbedWithoutOpamp(t *testing.T, sqlStore sqlstore.SQLStore) *LogPipeli
 	require.NoError(t, err)
 	jwt := authtypes.NewJWT("", 1*time.Hour, 1*time.Hour)
 	emailing := emailingtest.New()
-	modules := signoz.NewModules(sqlStore, jwt, emailing, providerSettings, orgGetter, alertmanager)
+	analytics := analyticstest.New()
+	modules := signoz.NewModules(sqlStore, jwt, emailing, providerSettings, orgGetter, alertmanager, analytics)
 	handlers := signoz.NewHandlers(modules)
 
 	apiHandler, err := app.NewAPIHandler(app.APIHandlerOpts{

--- a/pkg/query-service/tests/integration/signoz_cloud_integrations_test.go
+++ b/pkg/query-service/tests/integration/signoz_cloud_integrations_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/alertmanager"
 	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagerserver"
 	"github.com/SigNoz/signoz/pkg/alertmanager/signozalertmanager"
+	"github.com/SigNoz/signoz/pkg/analytics/analyticstest"
 	"github.com/SigNoz/signoz/pkg/emailing/emailingtest"
 	"github.com/SigNoz/signoz/pkg/sharder"
 	"github.com/SigNoz/signoz/pkg/sharder/noopsharder"
@@ -376,7 +377,8 @@ func NewCloudIntegrationsTestBed(t *testing.T, testDB sqlstore.SQLStore) *CloudI
 	require.NoError(t, err)
 	jwt := authtypes.NewJWT("", 1*time.Hour, 1*time.Hour)
 	emailing := emailingtest.New()
-	modules := signoz.NewModules(testDB, jwt, emailing, providerSettings, orgGetter, alertmanager)
+	analytics := analyticstest.New()
+	modules := signoz.NewModules(testDB, jwt, emailing, providerSettings, orgGetter, alertmanager, analytics)
 	handlers := signoz.NewHandlers(modules)
 
 	apiHandler, err := app.NewAPIHandler(app.APIHandlerOpts{

--- a/pkg/query-service/tests/integration/signoz_integrations_test.go
+++ b/pkg/query-service/tests/integration/signoz_integrations_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/alertmanager"
 	"github.com/SigNoz/signoz/pkg/alertmanager/alertmanagerserver"
 	"github.com/SigNoz/signoz/pkg/alertmanager/signozalertmanager"
+	"github.com/SigNoz/signoz/pkg/analytics/analyticstest"
 	"github.com/SigNoz/signoz/pkg/emailing/emailingtest"
 	"github.com/SigNoz/signoz/pkg/http/middleware"
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
@@ -582,7 +583,8 @@ func NewIntegrationsTestBed(t *testing.T, testDB sqlstore.SQLStore) *Integration
 	require.NoError(t, err)
 	jwt := authtypes.NewJWT("", 1*time.Hour, 1*time.Hour)
 	emailing := emailingtest.New()
-	modules := signoz.NewModules(testDB, jwt, emailing, providerSettings, orgGetter, alertmanager)
+	analytics := analyticstest.New()
+	modules := signoz.NewModules(testDB, jwt, emailing, providerSettings, orgGetter, alertmanager, analytics)
 	handlers := signoz.NewHandlers(modules)
 
 	apiHandler, err := app.NewAPIHandler(app.APIHandlerOpts{

--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -1,0 +1,20 @@
+package ruler
+
+import (
+	"github.com/SigNoz/signoz/pkg/factory"
+)
+
+type Config struct {
+}
+
+func NewConfigFactory() factory.ConfigFactory {
+	return factory.NewConfigFactory(factory.MustNewName("ruler"), newConfig)
+}
+
+func newConfig() factory.Config {
+	return Config{}
+}
+
+func (c Config) Validate() error {
+	return nil
+}

--- a/pkg/ruler/ruler.go
+++ b/pkg/ruler/ruler.go
@@ -1,0 +1,7 @@
+package ruler
+
+import "github.com/SigNoz/signoz/pkg/statsreporter"
+
+type Ruler interface {
+	statsreporter.StatsCollector
+}

--- a/pkg/ruler/rulestore/sqlrulestore/rule.go
+++ b/pkg/ruler/rulestore/sqlrulestore/rule.go
@@ -6,16 +6,14 @@ import (
 	"github.com/SigNoz/signoz/pkg/sqlstore"
 	ruletypes "github.com/SigNoz/signoz/pkg/types/ruletypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
-	"github.com/jmoiron/sqlx"
 )
 
 type rule struct {
-	*sqlx.DB
 	sqlstore sqlstore.SQLStore
 }
 
-func NewRuleStore(db *sqlx.DB, store sqlstore.SQLStore) ruletypes.RuleStore {
-	return &rule{sqlstore: store, DB: db}
+func NewRuleStore(store sqlstore.SQLStore) ruletypes.RuleStore {
+	return &rule{sqlstore: store}
 }
 
 func (r *rule) CreateRule(ctx context.Context, storedRule *ruletypes.Rule, cb func(context.Context, valuer.UUID) error) (valuer.UUID, error) {

--- a/pkg/ruler/signozruler/provider.go
+++ b/pkg/ruler/signozruler/provider.go
@@ -1,0 +1,35 @@
+package signozruler
+
+import (
+	"context"
+
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/ruler"
+	"github.com/SigNoz/signoz/pkg/ruler/rulestore/sqlrulestore"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/types/ruletypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+type provider struct {
+	ruleStore ruletypes.RuleStore
+}
+
+func NewFactory(sqlstore sqlstore.SQLStore) factory.ProviderFactory[ruler.Ruler, ruler.Config] {
+	return factory.NewProviderFactory(factory.MustNewName("signoz"), func(ctx context.Context, settings factory.ProviderSettings, config ruler.Config) (ruler.Ruler, error) {
+		return New(ctx, settings, config, sqlstore)
+	})
+}
+
+func New(ctx context.Context, settings factory.ProviderSettings, config ruler.Config, sqlstore sqlstore.SQLStore) (ruler.Ruler, error) {
+	return &provider{ruleStore: sqlrulestore.NewRuleStore(sqlstore)}, nil
+}
+
+func (provider *provider) Collect(ctx context.Context, orgID valuer.UUID) (map[string]any, error) {
+	rules, err := provider.ruleStore.GetStoredRules(ctx, orgID.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return ruletypes.NewStatsFromRules(rules), nil
+}

--- a/pkg/signoz/handler_test.go
+++ b/pkg/signoz/handler_test.go
@@ -33,7 +33,7 @@ func TestNewHandlers(t *testing.T) {
 	require.NoError(t, err)
 	jwt := authtypes.NewJWT("", 1*time.Hour, 1*time.Hour)
 	emailing := emailingtest.New()
-	modules := NewModules(sqlstore, jwt, emailing, providerSettings, orgGetter, alertmanager)
+	modules := NewModules(sqlstore, jwt, emailing, providerSettings, orgGetter, alertmanager, nil)
 
 	handlers := NewHandlers(modules)
 

--- a/pkg/signoz/module.go
+++ b/pkg/signoz/module.go
@@ -2,6 +2,7 @@ package signoz
 
 import (
 	"github.com/SigNoz/signoz/pkg/alertmanager"
+	"github.com/SigNoz/signoz/pkg/analytics"
 	"github.com/SigNoz/signoz/pkg/emailing"
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/modules/apdex"
@@ -44,10 +45,11 @@ func NewModules(
 	providerSettings factory.ProviderSettings,
 	orgGetter organization.Getter,
 	alertmanager alertmanager.Alertmanager,
+	analytics analytics.Analytics,
 ) Modules {
 	quickfilter := implquickfilter.NewModule(implquickfilter.NewStore(sqlstore))
 	orgSetter := implorganization.NewSetter(implorganization.NewStore(sqlstore), alertmanager, quickfilter)
-	user := impluser.NewModule(impluser.NewStore(sqlstore, providerSettings), jwt, emailing, providerSettings, orgSetter)
+	user := impluser.NewModule(impluser.NewStore(sqlstore, providerSettings), jwt, emailing, providerSettings, orgSetter, analytics)
 	return Modules{
 		OrgGetter:   orgGetter,
 		OrgSetter:   orgSetter,

--- a/pkg/signoz/module.go
+++ b/pkg/signoz/module.go
@@ -56,7 +56,7 @@ func NewModules(
 		Preference:  implpreference.NewModule(implpreference.NewStore(sqlstore), preferencetypes.NewAvailablePreference()),
 		SavedView:   implsavedview.NewModule(sqlstore),
 		Apdex:       implapdex.NewModule(sqlstore),
-		Dashboard:   impldashboard.NewModule(sqlstore, providerSettings),
+		Dashboard:   impldashboard.NewModule(sqlstore, providerSettings, analytics),
 		User:        user,
 		QuickFilter: quickfilter,
 		TraceFunnel: impltracefunnel.NewModule(impltracefunnel.NewStore(sqlstore)),

--- a/pkg/signoz/module_test.go
+++ b/pkg/signoz/module_test.go
@@ -33,7 +33,7 @@ func TestNewModules(t *testing.T) {
 	require.NoError(t, err)
 	jwt := authtypes.NewJWT("", 1*time.Hour, 1*time.Hour)
 	emailing := emailingtest.New()
-	modules := NewModules(sqlstore, jwt, emailing, providerSettings, orgGetter, alertmanager)
+	modules := NewModules(sqlstore, jwt, emailing, providerSettings, orgGetter, alertmanager, nil)
 
 	reflectVal := reflect.ValueOf(modules)
 	for i := 0; i < reflectVal.NumField(); i++ {

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -150,9 +150,9 @@ func NewSharderProviderFactories() factory.NamedMap[factory.ProviderFactory[shar
 	)
 }
 
-func NewStatsReporterProviderFactories(collectors []statsreporter.StatsCollector, orgGetter organization.Getter, analytics analytics.Analytics, build version.Build) factory.NamedMap[factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config]] {
+func NewStatsReporterProviderFactories(telemetryStore telemetrystore.TelemetryStore, collectors []statsreporter.StatsCollector, orgGetter organization.Getter, analytics analytics.Analytics, build version.Build) factory.NamedMap[factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config]] {
 	return factory.MustNewNamedMap(
-		analyticsstatsreporter.NewFactory(collectors, orgGetter, analytics, build),
+		analyticsstatsreporter.NewFactory(telemetryStore, collectors, orgGetter, analytics, build),
 		noopstatsreporter.NewFactory(),
 	)
 }

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -4,6 +4,9 @@ import (
 	"github.com/SigNoz/signoz/pkg/alertmanager"
 	"github.com/SigNoz/signoz/pkg/alertmanager/legacyalertmanager"
 	"github.com/SigNoz/signoz/pkg/alertmanager/signozalertmanager"
+	"github.com/SigNoz/signoz/pkg/analytics"
+	"github.com/SigNoz/signoz/pkg/analytics/noopanalytics"
+	"github.com/SigNoz/signoz/pkg/analytics/segmentanalytics"
 	"github.com/SigNoz/signoz/pkg/cache"
 	"github.com/SigNoz/signoz/pkg/cache/memorycache"
 	"github.com/SigNoz/signoz/pkg/cache/rediscache"
@@ -14,6 +17,8 @@ import (
 	"github.com/SigNoz/signoz/pkg/modules/organization"
 	"github.com/SigNoz/signoz/pkg/prometheus"
 	"github.com/SigNoz/signoz/pkg/prometheus/clickhouseprometheus"
+	"github.com/SigNoz/signoz/pkg/ruler"
+	"github.com/SigNoz/signoz/pkg/ruler/signozruler"
 	"github.com/SigNoz/signoz/pkg/sharder"
 	"github.com/SigNoz/signoz/pkg/sharder/noopsharder"
 	"github.com/SigNoz/signoz/pkg/sharder/singlesharder"
@@ -21,13 +26,24 @@ import (
 	"github.com/SigNoz/signoz/pkg/sqlstore"
 	"github.com/SigNoz/signoz/pkg/sqlstore/sqlitesqlstore"
 	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstorehook"
+	"github.com/SigNoz/signoz/pkg/statsreporter"
+	"github.com/SigNoz/signoz/pkg/statsreporter/analyticsstatsreporter"
+	"github.com/SigNoz/signoz/pkg/statsreporter/noopstatsreporter"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/clickhousetelemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystorehook"
+	"github.com/SigNoz/signoz/pkg/version"
 	"github.com/SigNoz/signoz/pkg/web"
 	"github.com/SigNoz/signoz/pkg/web/noopweb"
 	"github.com/SigNoz/signoz/pkg/web/routerweb"
 )
+
+func NewAnalyticsProviderFactories() factory.NamedMap[factory.ProviderFactory[analytics.Analytics, analytics.Config]] {
+	return factory.MustNewNamedMap(
+		noopanalytics.NewFactory(),
+		segmentanalytics.NewFactory(),
+	)
+}
 
 func NewCacheProviderFactories() factory.NamedMap[factory.ProviderFactory[cache.Cache, cache.Config]] {
 	return factory.MustNewNamedMap(
@@ -114,6 +130,12 @@ func NewAlertmanagerProviderFactories(sqlstore sqlstore.SQLStore, orgGetter orga
 	)
 }
 
+func NewRulerProviderFactories(sqlstore sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[ruler.Ruler, ruler.Config]] {
+	return factory.MustNewNamedMap(
+		signozruler.NewFactory(sqlstore),
+	)
+}
+
 func NewEmailingProviderFactories() factory.NamedMap[factory.ProviderFactory[emailing.Emailing, emailing.Config]] {
 	return factory.MustNewNamedMap(
 		noopemailing.NewFactory(),
@@ -125,5 +147,12 @@ func NewSharderProviderFactories() factory.NamedMap[factory.ProviderFactory[shar
 	return factory.MustNewNamedMap(
 		singlesharder.NewFactory(),
 		noopsharder.NewFactory(),
+	)
+}
+
+func NewStatsReporterProviderFactories(collectors []statsreporter.StatsCollector, orgGetter organization.Getter, analytics analytics.Analytics, build version.Build) factory.NamedMap[factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config]] {
+	return factory.MustNewNamedMap(
+		analyticsstatsreporter.NewFactory(collectors, orgGetter, analytics, build),
+		noopstatsreporter.NewFactory(),
 	)
 }

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -150,9 +150,9 @@ func NewSharderProviderFactories() factory.NamedMap[factory.ProviderFactory[shar
 	)
 }
 
-func NewStatsReporterProviderFactories(telemetryStore telemetrystore.TelemetryStore, collectors []statsreporter.StatsCollector, orgGetter organization.Getter, build version.Build) factory.NamedMap[factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config]] {
+func NewStatsReporterProviderFactories(telemetryStore telemetrystore.TelemetryStore, collectors []statsreporter.StatsCollector, orgGetter organization.Getter, build version.Build, analyticsConfig analytics.Config) factory.NamedMap[factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config]] {
 	return factory.MustNewNamedMap(
-		analyticsstatsreporter.NewFactory(telemetryStore, collectors, orgGetter, build),
+		analyticsstatsreporter.NewFactory(telemetryStore, collectors, orgGetter, build, analyticsConfig),
 		noopstatsreporter.NewFactory(),
 	)
 }

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -150,9 +150,9 @@ func NewSharderProviderFactories() factory.NamedMap[factory.ProviderFactory[shar
 	)
 }
 
-func NewStatsReporterProviderFactories(telemetryStore telemetrystore.TelemetryStore, collectors []statsreporter.StatsCollector, orgGetter organization.Getter, analytics analytics.Analytics, build version.Build) factory.NamedMap[factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config]] {
+func NewStatsReporterProviderFactories(telemetryStore telemetrystore.TelemetryStore, collectors []statsreporter.StatsCollector, orgGetter organization.Getter, build version.Build) factory.NamedMap[factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config]] {
 	return factory.MustNewNamedMap(
-		analyticsstatsreporter.NewFactory(telemetryStore, collectors, orgGetter, analytics, build),
+		analyticsstatsreporter.NewFactory(telemetryStore, collectors, orgGetter, build),
 		noopstatsreporter.NewFactory(),
 	)
 }

--- a/pkg/signoz/provider_test.go
+++ b/pkg/signoz/provider_test.go
@@ -62,6 +62,6 @@ func TestNewProviderFactories(t *testing.T) {
 	assert.NotPanics(t, func() {
 		orgGetter := implorganization.NewGetter(implorganization.NewStore(sqlstoretest.New(sqlstore.Config{Provider: "sqlite"}, sqlmock.QueryMatcherEqual)), nil)
 		telemetryStore := telemetrystoretest.New(telemetrystore.Config{Provider: "clickhouse"}, sqlmock.QueryMatcherEqual)
-		NewStatsReporterProviderFactories(telemetryStore, []statsreporter.StatsCollector{}, orgGetter, nil, version.Build{})
+		NewStatsReporterProviderFactories(telemetryStore, []statsreporter.StatsCollector{}, orgGetter, version.Build{})
 	})
 }

--- a/pkg/signoz/provider_test.go
+++ b/pkg/signoz/provider_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/SigNoz/signoz/pkg/modules/organization/implorganization"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
 	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstoretest"
+	"github.com/SigNoz/signoz/pkg/statsreporter"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
+	"github.com/SigNoz/signoz/pkg/version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,10 +48,19 @@ func TestNewProviderFactories(t *testing.T) {
 	})
 
 	assert.NotPanics(t, func() {
+		NewRulerProviderFactories(sqlstoretest.New(sqlstore.Config{Provider: "sqlite"}, sqlmock.QueryMatcherEqual))
+	})
+
+	assert.NotPanics(t, func() {
 		NewEmailingProviderFactories()
 	})
 
 	assert.NotPanics(t, func() {
 		NewSharderProviderFactories()
+	})
+
+	assert.NotPanics(t, func() {
+		orgGetter := implorganization.NewGetter(implorganization.NewStore(sqlstoretest.New(sqlstore.Config{Provider: "sqlite"}, sqlmock.QueryMatcherEqual)), nil)
+		NewStatsReporterProviderFactories([]statsreporter.StatsCollector{}, orgGetter, nil, version.Build{})
 	})
 }

--- a/pkg/signoz/provider_test.go
+++ b/pkg/signoz/provider_test.go
@@ -61,6 +61,7 @@ func TestNewProviderFactories(t *testing.T) {
 
 	assert.NotPanics(t, func() {
 		orgGetter := implorganization.NewGetter(implorganization.NewStore(sqlstoretest.New(sqlstore.Config{Provider: "sqlite"}, sqlmock.QueryMatcherEqual)), nil)
-		NewStatsReporterProviderFactories([]statsreporter.StatsCollector{}, orgGetter, nil, version.Build{})
+		telemetryStore := telemetrystoretest.New(telemetrystore.Config{Provider: "clickhouse"}, sqlmock.QueryMatcherEqual)
+		NewStatsReporterProviderFactories(telemetryStore, []statsreporter.StatsCollector{}, orgGetter, nil, version.Build{})
 	})
 }

--- a/pkg/signoz/provider_test.go
+++ b/pkg/signoz/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/SigNoz/signoz/pkg/analytics"
 	"github.com/SigNoz/signoz/pkg/modules/organization/implorganization"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
 	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstoretest"
@@ -62,6 +63,6 @@ func TestNewProviderFactories(t *testing.T) {
 	assert.NotPanics(t, func() {
 		orgGetter := implorganization.NewGetter(implorganization.NewStore(sqlstoretest.New(sqlstore.Config{Provider: "sqlite"}, sqlmock.QueryMatcherEqual)), nil)
 		telemetryStore := telemetrystoretest.New(telemetrystore.Config{Provider: "clickhouse"}, sqlmock.QueryMatcherEqual)
-		NewStatsReporterProviderFactories(telemetryStore, []statsreporter.StatsCollector{}, orgGetter, version.Build{})
+		NewStatsReporterProviderFactories(telemetryStore, []statsreporter.StatsCollector{}, orgGetter, version.Build{}, analytics.Config{Enabled: true})
 	})
 }

--- a/pkg/signoz/signoz.go
+++ b/pkg/signoz/signoz.go
@@ -252,7 +252,7 @@ func New(
 		ctx,
 		providerSettings,
 		config.StatsReporter,
-		NewStatsReporterProviderFactories(telemetrystore, statsCollectors, orgGetter, version.Info),
+		NewStatsReporterProviderFactories(telemetrystore, statsCollectors, orgGetter, version.Info, config.Analytics),
 		config.StatsReporter.Provider(),
 	)
 	if err != nil {

--- a/pkg/signoz/signoz.go
+++ b/pkg/signoz/signoz.go
@@ -232,7 +232,7 @@ func New(
 	}
 
 	// Initialize all modules
-	modules := NewModules(sqlstore, jwt, emailing, providerSettings, orgGetter, alertmanager)
+	modules := NewModules(sqlstore, jwt, emailing, providerSettings, orgGetter, alertmanager, analytics)
 
 	// Initialize all handlers for the modules
 	handlers := NewHandlers(modules)

--- a/pkg/signoz/signoz.go
+++ b/pkg/signoz/signoz.go
@@ -251,7 +251,7 @@ func New(
 		ctx,
 		providerSettings,
 		config.StatsReporter,
-		NewStatsReporterProviderFactories(statsCollectors, orgGetter, analytics, version.Info),
+		NewStatsReporterProviderFactories(telemetrystore, statsCollectors, orgGetter, analytics, version.Info),
 		config.StatsReporter.Provider(),
 	)
 	if err != nil {

--- a/pkg/signoz/signoz.go
+++ b/pkg/signoz/signoz.go
@@ -244,6 +244,7 @@ func New(
 		modules.Dashboard,
 		modules.SavedView,
 		modules.User,
+		licensing,
 	}
 
 	// Initialize stats reporter from the available stats reporter provider factories
@@ -251,7 +252,7 @@ func New(
 		ctx,
 		providerSettings,
 		config.StatsReporter,
-		NewStatsReporterProviderFactories(telemetrystore, statsCollectors, orgGetter, analytics, version.Info),
+		NewStatsReporterProviderFactories(telemetrystore, statsCollectors, orgGetter, version.Info),
 		config.StatsReporter.Provider(),
 	)
 	if err != nil {
@@ -261,6 +262,7 @@ func New(
 	registry, err := factory.NewRegistry(
 		instrumentation.Logger(),
 		factory.NewNamedService(factory.MustNewName("instrumentation"), instrumentation),
+		factory.NewNamedService(factory.MustNewName("analytics"), analytics),
 		factory.NewNamedService(factory.MustNewName("alertmanager"), alertmanager),
 		factory.NewNamedService(factory.MustNewName("licensing"), licensing),
 		factory.NewNamedService(factory.MustNewName("statsreporter"), statsReporter),

--- a/pkg/signoz/signoz.go
+++ b/pkg/signoz/signoz.go
@@ -12,10 +12,12 @@ import (
 	"github.com/SigNoz/signoz/pkg/modules/organization"
 	"github.com/SigNoz/signoz/pkg/modules/organization/implorganization"
 	"github.com/SigNoz/signoz/pkg/prometheus"
+	"github.com/SigNoz/signoz/pkg/ruler"
 	"github.com/SigNoz/signoz/pkg/sharder"
 	"github.com/SigNoz/signoz/pkg/sqlmigration"
 	"github.com/SigNoz/signoz/pkg/sqlmigrator"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/statsreporter"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
 	"github.com/SigNoz/signoz/pkg/version"
@@ -33,10 +35,12 @@ type SigNoz struct {
 	TelemetryStore  telemetrystore.TelemetryStore
 	Prometheus      prometheus.Prometheus
 	Alertmanager    alertmanager.Alertmanager
+	Rules           ruler.Ruler
 	Zeus            zeus.Zeus
 	Licensing       licensing.Licensing
 	Emailing        emailing.Emailing
 	Sharder         sharder.Sharder
+	StatsReporter   statsreporter.StatsReporter
 	Modules         Modules
 	Handlers        Handlers
 }
@@ -48,7 +52,7 @@ func New(
 	zeusConfig zeus.Config,
 	zeusProviderFactory factory.ProviderFactory[zeus.Zeus, zeus.Config],
 	licenseConfig licensing.Config,
-	licenseProviderFactoryCb func(sqlstore.SQLStore, zeus.Zeus, organization.Getter) factory.ProviderFactory[licensing.Licensing, licensing.Config],
+	licenseProviderFactory func(sqlstore.SQLStore, zeus.Zeus, organization.Getter) factory.ProviderFactory[licensing.Licensing, licensing.Config],
 	emailingProviderFactories factory.NamedMap[factory.ProviderFactory[emailing.Emailing, emailing.Config]],
 	cacheProviderFactories factory.NamedMap[factory.ProviderFactory[cache.Cache, cache.Config]],
 	webProviderFactories factory.NamedMap[factory.ProviderFactory[web.Web, web.Config]],
@@ -66,6 +70,18 @@ func New(
 
 	// Get the provider settings from instrumentation
 	providerSettings := instrumentation.ToProviderSettings()
+
+	// Initialize analytics just after instrumentation, as providers might require it
+	analytics, err := factory.NewProviderFromNamedMap(
+		ctx,
+		providerSettings,
+		config.Analytics,
+		NewAnalyticsProviderFactories(),
+		config.Analytics.Provider(),
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	// Initialize zeus from the available zeus provider factory. This is not config controlled
 	// and depends on the variant of the build.
@@ -193,7 +209,19 @@ func New(
 		return nil, err
 	}
 
-	licensingProviderFactory := licenseProviderFactoryCb(sqlstore, zeus, orgGetter)
+	// Initialize ruler from the available ruler provider factories
+	ruler, err := factory.NewProviderFromNamedMap(
+		ctx,
+		providerSettings,
+		config.Ruler,
+		NewRulerProviderFactories(sqlstore),
+		"signoz",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	licensingProviderFactory := licenseProviderFactory(sqlstore, zeus, orgGetter)
 	licensing, err := licensingProviderFactory.New(
 		ctx,
 		providerSettings,
@@ -209,11 +237,33 @@ func New(
 	// Initialize all handlers for the modules
 	handlers := NewHandlers(modules)
 
+	// Create a list of all stats collectors
+	statsCollectors := []statsreporter.StatsCollector{
+		alertmanager,
+		ruler,
+		modules.Dashboard,
+		modules.SavedView,
+		modules.User,
+	}
+
+	// Initialize stats reporter from the available stats reporter provider factories
+	statsReporter, err := factory.NewProviderFromNamedMap(
+		ctx,
+		providerSettings,
+		config.StatsReporter,
+		NewStatsReporterProviderFactories(statsCollectors, orgGetter, analytics, version.Info),
+		config.StatsReporter.Provider(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	registry, err := factory.NewRegistry(
 		instrumentation.Logger(),
 		factory.NewNamedService(factory.MustNewName("instrumentation"), instrumentation),
 		factory.NewNamedService(factory.MustNewName("alertmanager"), alertmanager),
 		factory.NewNamedService(factory.MustNewName("licensing"), licensing),
+		factory.NewNamedService(factory.MustNewName("statsreporter"), statsReporter),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -81,7 +81,11 @@ func New(
 }
 
 func (provider *provider) Start(ctx context.Context) error {
-	go provider.analytics.Start(ctx)
+	go func() {
+		if err := provider.analytics.Start(ctx); err != nil {
+			provider.settings.Logger().ErrorContext(ctx, "failed to start analytics", "error", err)
+		}
+	}()
 
 	ticker := time.NewTicker(provider.config.Interval)
 	defer ticker.Stop()

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -1,0 +1,164 @@
+package analyticsstatsreporter
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/analytics"
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/modules/organization"
+	"github.com/SigNoz/signoz/pkg/statsreporter"
+	"github.com/SigNoz/signoz/pkg/types/analyticstypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/SigNoz/signoz/pkg/version"
+)
+
+type provider struct {
+	// settings
+	settings factory.ScopedProviderSettings
+
+	// config
+	config statsreporter.Config
+
+	// a list of collectors, used to collect stats from across the codebase
+	collectors []statsreporter.StatsCollector
+
+	// used to get organizations
+	orgGetter organization.Getter
+
+	// used to send stats to an analytics backend
+	analytics analytics.Analytics
+
+	// used to get build information
+	build version.Build
+
+	// used to get deployment information
+	deployment version.Deployment
+
+	// used to stop the provider
+	stopC chan struct{}
+}
+
+func NewFactory(collectors []statsreporter.StatsCollector, orgGetter organization.Getter, analytics analytics.Analytics, build version.Build) factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config] {
+	return factory.NewProviderFactory(factory.MustNewName("analytics"), func(ctx context.Context, settings factory.ProviderSettings, config statsreporter.Config) (statsreporter.StatsReporter, error) {
+		return New(ctx, settings, config, collectors, orgGetter, analytics, build)
+	})
+}
+
+func New(
+	ctx context.Context,
+	providerSettings factory.ProviderSettings,
+	config statsreporter.Config,
+	collectors []statsreporter.StatsCollector,
+	orgGetter organization.Getter,
+	analytics analytics.Analytics,
+	build version.Build,
+) (statsreporter.StatsReporter, error) {
+	settings := factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/statsreporter/analyticsstatsreporter")
+	deployment := version.NewDeployment()
+
+	return &provider{
+		settings:   settings,
+		config:     config,
+		collectors: collectors,
+		orgGetter:  orgGetter,
+		analytics:  analytics,
+		build:      build,
+		deployment: deployment,
+		stopC:      make(chan struct{}),
+	}, nil
+}
+
+func (provider *provider) Start(ctx context.Context) error {
+	ticker := time.NewTicker(provider.config.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-provider.stopC:
+			return nil
+		case <-ticker.C:
+			err := provider.Report(ctx)
+			if err != nil {
+				provider.settings.Logger().ErrorContext(ctx, "failed to report stats", "error", err)
+			}
+		}
+	}
+}
+
+func (provider *provider) Report(ctx context.Context) error {
+	orgs, err := provider.orgGetter.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, org := range orgs {
+		stats := provider.collectOrg(ctx, org.ID)
+		if len(stats) == 0 {
+			provider.settings.Logger().WarnContext(ctx, "no stats collected", "org_id", org.ID)
+			continue
+		}
+
+		stats["build.version"] = provider.build.Version()
+		stats["build.branch"] = provider.build.Branch()
+		stats["build.hash"] = provider.build.Hash()
+		stats["build.variant"] = provider.build.Variant()
+		stats["deployment.mode"] = provider.deployment.Mode()
+		stats["deployment.platform"] = provider.deployment.Platform()
+		stats["deployment.os"] = provider.deployment.OS()
+		stats["deployment.arch"] = provider.deployment.Arch()
+
+		provider.settings.Logger().DebugContext(ctx, "reporting stats", "stats", stats)
+		provider.analytics.Send(
+			ctx,
+			analyticstypes.Track{
+				UserId:     org.ID.String(),
+				Event:      "Stats Reported",
+				Properties: analyticstypes.NewPropertiesFromMap(stats),
+				Context: &analyticstypes.Context{
+					Extra: map[string]interface{}{
+						analyticstypes.ContextKeyGroupID: org.ID.String(),
+					},
+					Traits: analyticstypes.NewTraitsFromMap(stats),
+				},
+			},
+		)
+	}
+
+	return nil
+}
+
+func (provider *provider) Stop(ctx context.Context) error {
+	close(provider.stopC)
+	return nil
+}
+
+func (provider *provider) collectOrg(ctx context.Context, orgID valuer.UUID) map[string]any {
+	var wg sync.WaitGroup
+	wg.Add(len(provider.collectors))
+
+	stats := make(map[string]any, 0)
+	mtx := sync.Mutex{}
+
+	for _, collector := range provider.collectors {
+		go func(collector statsreporter.StatsCollector) {
+			defer wg.Done()
+
+			collectorStats, err := collector.Collect(ctx, orgID)
+			if err != nil {
+				provider.settings.Logger().ErrorContext(ctx, "failed to collect stats", "error", err)
+				return
+			}
+
+			mtx.Lock()
+			for k, v := range collectorStats {
+				stats[k] = v
+			}
+			mtx.Unlock()
+		}(collector)
+	}
+	wg.Wait()
+
+	return stats
+}

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -45,9 +45,9 @@ type provider struct {
 	stopC chan struct{}
 }
 
-func NewFactory(telemetryStore telemetrystore.TelemetryStore, collectors []statsreporter.StatsCollector, orgGetter organization.Getter, build version.Build) factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config] {
+func NewFactory(telemetryStore telemetrystore.TelemetryStore, collectors []statsreporter.StatsCollector, orgGetter organization.Getter, build version.Build, analyticsConfig analytics.Config) factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config] {
 	return factory.NewProviderFactory(factory.MustNewName("analytics"), func(ctx context.Context, settings factory.ProviderSettings, config statsreporter.Config) (statsreporter.StatsReporter, error) {
-		return New(ctx, settings, config, telemetryStore, collectors, orgGetter, build)
+		return New(ctx, settings, config, telemetryStore, collectors, orgGetter, build, analyticsConfig)
 	})
 }
 
@@ -59,10 +59,11 @@ func New(
 	collectors []statsreporter.StatsCollector,
 	orgGetter organization.Getter,
 	build version.Build,
+	analyticsConfig analytics.Config,
 ) (statsreporter.StatsReporter, error) {
 	settings := factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/statsreporter/analyticsstatsreporter")
 	deployment := version.NewDeployment()
-	analytics, err := segmentanalytics.New(ctx, providerSettings, analytics.Config{Enabled: true})
+	analytics, err := segmentanalytics.New(ctx, providerSettings, analyticsConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -118,14 +118,24 @@ func (provider *provider) Report(ctx context.Context) error {
 				Properties: analyticstypes.NewPropertiesFromMap(stats),
 				Context: &analyticstypes.Context{
 					Extra: map[string]interface{}{
-						analyticstypes.ContextKeyGroupID: org.ID.String(),
+						analyticstypes.KeyGroupID: org.ID.String(),
 					},
 				},
 			},
 			analyticstypes.Group{
 				UserId:  org.ID.String(),
 				GroupId: org.ID.String(),
-				Traits:  analyticstypes.NewTraitsFromMap(stats),
+				Traits: analyticstypes.
+					NewTraitsFromMap(stats).
+					SetName(org.Name).
+					Set(analyticstypes.KeyDisplayName, org.DisplayName),
+			},
+			analyticstypes.Identify{
+				UserId: org.ID.String(),
+				Traits: analyticstypes.
+					NewTraits().
+					SetName(org.Name).
+					Set(analyticstypes.KeyDisplayName, org.DisplayName),
 			},
 		)
 	}

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -123,6 +123,11 @@ func (provider *provider) Report(ctx context.Context) error {
 					Traits: analyticstypes.NewTraitsFromMap(stats),
 				},
 			},
+			analyticstypes.Group{
+				UserId:  org.ID.String(),
+				GroupId: org.ID.String(),
+				Traits:  analyticstypes.NewTraitsFromMap(stats),
+			},
 		)
 	}
 

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -120,7 +120,6 @@ func (provider *provider) Report(ctx context.Context) error {
 					Extra: map[string]interface{}{
 						analyticstypes.ContextKeyGroupID: org.ID.String(),
 					},
-					Traits: analyticstypes.NewTraitsFromMap(stats),
 				},
 			},
 			analyticstypes.Group{

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -133,15 +133,17 @@ func (provider *provider) Report(ctx context.Context) error {
 				GroupId: org.ID.String(),
 				Traits: analyticstypes.
 					NewTraitsFromMap(stats).
-					SetName(org.Name).
-					Set(analyticstypes.KeyDisplayName, org.DisplayName),
+					SetName(org.DisplayName).
+					SetUsername(org.Name).
+					SetCreatedAt(org.CreatedAt),
 			},
 			analyticstypes.Identify{
 				UserId: org.ID.String(),
 				Traits: analyticstypes.
 					NewTraits().
-					SetName(org.Name).
-					Set(analyticstypes.KeyDisplayName, org.DisplayName),
+					SetName(org.DisplayName).
+					SetUsername(org.Name).
+					SetCreatedAt(org.CreatedAt),
 			},
 		)
 	}

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -105,7 +105,7 @@ func (provider *provider) Start(ctx context.Context) error {
 }
 
 func (provider *provider) Report(ctx context.Context) error {
-	orgs, err := provider.orgGetter.List(ctx)
+	orgs, err := provider.orgGetter.ListByOwnedKeyRange(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/statsreporter/config.go
+++ b/pkg/statsreporter/config.go
@@ -1,0 +1,38 @@
+package statsreporter
+
+import (
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/factory"
+)
+
+type Config struct {
+	// Enabled is a flag to enable or disable the stats reporter.
+	Enabled bool `mapstructure:"enabled"`
+
+	// Interval is the interval at which the stats are collected.
+	Interval time.Duration `mapstructure:"interval"`
+}
+
+func NewConfigFactory() factory.ConfigFactory {
+	return factory.NewConfigFactory(factory.MustNewName("statsreporter"), newConfig)
+}
+
+func newConfig() factory.Config {
+	return Config{
+		Enabled:  true,
+		Interval: 6 * time.Hour,
+	}
+}
+
+func (c Config) Validate() error {
+	return nil
+}
+
+func (c Config) Provider() string {
+	if c.Enabled {
+		return "analytics"
+	}
+
+	return "noop"
+}

--- a/pkg/statsreporter/noopstatsreporter/provider.go
+++ b/pkg/statsreporter/noopstatsreporter/provider.go
@@ -1,0 +1,36 @@
+package noopstatsreporter
+
+import (
+	"context"
+
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/statsreporter"
+)
+
+type provider struct {
+	stopC chan struct{}
+}
+
+func NewFactory() factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config] {
+	return factory.NewProviderFactory(factory.MustNewName("noop"), New)
+}
+
+func New(ctx context.Context, providerSettings factory.ProviderSettings, config statsreporter.Config) (statsreporter.StatsReporter, error) {
+	return &provider{
+		stopC: make(chan struct{}),
+	}, nil
+}
+
+func (provider *provider) Start(ctx context.Context) error {
+	<-provider.stopC
+	return nil
+}
+
+func (provider *provider) Report(ctx context.Context) error {
+	return nil
+}
+
+func (provider *provider) Stop(ctx context.Context) error {
+	close(provider.stopC)
+	return nil
+}

--- a/pkg/statsreporter/statsreporter.go
+++ b/pkg/statsreporter/statsreporter.go
@@ -1,0 +1,18 @@
+package statsreporter
+
+import (
+	"context"
+
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+type StatsReporter interface {
+	factory.Service
+
+	Report(context.Context) error
+}
+
+type StatsCollector interface {
+	Collect(context.Context, valuer.UUID) (map[string]any, error)
+}

--- a/pkg/types/alertmanagertypes/channel.go
+++ b/pkg/types/alertmanagertypes/channel.go
@@ -146,6 +146,22 @@ func GetChannelByName(channels Channels, name string) (int, *Channel, error) {
 	return 0, nil, errors.Newf(errors.TypeNotFound, ErrCodeAlertmanagerChannelNotFound, "cannot find channel with name %s", name)
 }
 
+func NewStatsFromChannels(channels Channels) map[string]any {
+	stats := make(map[string]any)
+	for _, channel := range channels {
+		key := "alertmanager.channel.type." + channel.Type
+
+		if _, ok := stats[key]; !ok {
+			stats[key] = int64(1)
+		} else {
+			stats[key] = stats[key].(int64) + 1
+		}
+	}
+
+	stats["alertmanager.channel.count"] = int64(len(channels))
+	return stats
+}
+
 func (c *Channel) Update(receiver Receiver) error {
 	channel := NewChannelFromReceiver(receiver, c.OrgID)
 	if channel == nil {

--- a/pkg/types/analyticstypes/message.go
+++ b/pkg/types/analyticstypes/message.go
@@ -5,9 +5,7 @@ import (
 )
 
 const (
-	KeyGroupID     string = "groupId"
-	KeyName        string = "name"
-	KeyDisplayName string = "displayName"
+	KeyGroupID string = "groupId"
 )
 
 type Message = segment.Message

--- a/pkg/types/analyticstypes/message.go
+++ b/pkg/types/analyticstypes/message.go
@@ -5,7 +5,9 @@ import (
 )
 
 const (
-	ContextKeyGroupID string = "groupId"
+	KeyGroupID     string = "groupId"
+	KeyName        string = "name"
+	KeyDisplayName string = "displayName"
 )
 
 type Message = segment.Message

--- a/pkg/types/analyticstypes/message.go
+++ b/pkg/types/analyticstypes/message.go
@@ -1,6 +1,8 @@
 package analyticstypes
 
 import (
+	"strings"
+
 	segment "github.com/segmentio/analytics-go/v3"
 )
 
@@ -27,7 +29,7 @@ func NewProperties() Properties {
 func NewPropertiesFromMap(m map[string]any) Properties {
 	properties := NewProperties()
 	for k, v := range m {
-		properties.Set(k, v)
+		properties.Set(strings.ReplaceAll(k, ".", "_"), v)
 	}
 
 	return properties
@@ -36,7 +38,7 @@ func NewPropertiesFromMap(m map[string]any) Properties {
 func NewTraitsFromMap(m map[string]any) Traits {
 	traits := NewTraits()
 	for k, v := range m {
-		traits.Set(k, v)
+		traits.Set(strings.ReplaceAll(k, ".", "_"), v)
 	}
 
 	return traits

--- a/pkg/types/analyticstypes/message.go
+++ b/pkg/types/analyticstypes/message.go
@@ -4,6 +4,10 @@ import (
 	segment "github.com/segmentio/analytics-go/v3"
 )
 
+const (
+	ContextKeyGroupID string = "groupId"
+)
+
 type Message = segment.Message
 type Group = segment.Group
 type Identify = segment.Identify
@@ -18,4 +22,22 @@ func NewTraits() Traits {
 
 func NewProperties() Properties {
 	return segment.NewProperties()
+}
+
+func NewPropertiesFromMap(m map[string]any) Properties {
+	properties := NewProperties()
+	for k, v := range m {
+		properties.Set(k, v)
+	}
+
+	return properties
+}
+
+func NewTraitsFromMap(m map[string]any) Traits {
+	traits := NewTraits()
+	for k, v := range m {
+		traits.Set(k, v)
+	}
+
+	return traits
 }

--- a/pkg/types/licensetypes/license.go
+++ b/pkg/types/licensetypes/license.go
@@ -323,6 +323,13 @@ func NewLicenseFromStorableLicense(storableLicense *StorableLicense) (*License, 
 
 }
 
+func NewStatsFromLicense(license *License) map[string]any {
+	return map[string]any{
+		"license.plan": license.PlanName.StringValue(),
+		"license.id":   license.ID.StringValue(),
+	}
+}
+
 func (license *License) UpdateFeatures(features []*Feature) {
 	license.Features = features
 }

--- a/pkg/types/ruletypes/rule.go
+++ b/pkg/types/ruletypes/rule.go
@@ -2,6 +2,8 @@ package ruletypes
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 
 	"github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/valuer"
@@ -16,6 +18,26 @@ type Rule struct {
 	Deleted int    `bun:"deleted,notnull,default:0"`
 	Data    string `bun:"data,type:text,notnull"`
 	OrgID   string `bun:"org_id,type:text"`
+}
+
+func NewStatsFromRules(rules []*Rule) map[string]any {
+	stats := make(map[string]any)
+	for _, rule := range rules {
+		gettableRule := &GettableRule{}
+		if err := json.Unmarshal([]byte(rule.Data), gettableRule); err != nil {
+			continue
+		}
+
+		key := "rule.type." + strings.ToLower(string(gettableRule.RuleType))
+		if _, ok := stats[key]; !ok {
+			stats[key] = int64(1)
+		} else {
+			stats[key] = stats[key].(int64) + 1
+		}
+	}
+
+	stats["rule.count"] = int64(len(rules))
+	return stats
 }
 
 type RuleStore interface {

--- a/pkg/types/ruletypes/rule.go
+++ b/pkg/types/ruletypes/rule.go
@@ -28,7 +28,14 @@ func NewStatsFromRules(rules []*Rule) map[string]any {
 			continue
 		}
 
-		key := "rule.type." + strings.ToLower(string(gettableRule.RuleType))
+		key := "rule.type." + strings.TrimSuffix(strings.ToLower(string(gettableRule.RuleType)), "_rule") + ".count"
+		if _, ok := stats[key]; !ok {
+			stats[key] = int64(1)
+		} else {
+			stats[key] = stats[key].(int64) + 1
+		}
+
+		key = "alert.type." + strings.TrimSuffix(strings.ToLower(string(gettableRule.AlertType)), "_BASED_ALERT") + ".count"
 		if _, ok := stats[key]; !ok {
 			stats[key] = int64(1)
 		} else {

--- a/pkg/types/ruletypes/rule.go
+++ b/pkg/types/ruletypes/rule.go
@@ -35,7 +35,7 @@ func NewStatsFromRules(rules []*Rule) map[string]any {
 			stats[key] = stats[key].(int64) + 1
 		}
 
-		key = "alert.type." + strings.TrimSuffix(strings.ToLower(string(gettableRule.AlertType)), "_BASED_ALERT") + ".count"
+		key = "alert.type." + strings.TrimSuffix(strings.ToLower(string(gettableRule.AlertType)), "_based_alert") + ".count"
 		if _, ok := stats[key]; !ok {
 			stats[key] = int64(1)
 		} else {

--- a/pkg/types/savedview.go
+++ b/pkg/types/savedview.go
@@ -24,7 +24,7 @@ type SavedView struct {
 func NewStatsFromSavedViews(savedViews []*SavedView) map[string]any {
 	stats := make(map[string]any)
 	for _, savedView := range savedViews {
-		key := "savedview.source." + strings.ToLower(string(savedView.SourcePage))
+		key := "savedview.source." + strings.ToLower(string(savedView.SourcePage)) + ".count"
 		if _, ok := stats[key]; !ok {
 			stats[key] = int64(1)
 		} else {

--- a/pkg/types/savedview.go
+++ b/pkg/types/savedview.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"strings"
+
 	"github.com/uptrace/bun"
 )
 
@@ -17,4 +19,19 @@ type SavedView struct {
 	Tags       string `json:"tags" bun:"tags,type:text"`
 	Data       string `json:"data" bun:"data,type:text,notnull"`
 	ExtraData  string `json:"extraData" bun:"extra_data,type:text"`
+}
+
+func NewStatsFromSavedViews(savedViews []*SavedView) map[string]any {
+	stats := make(map[string]any)
+	for _, savedView := range savedViews {
+		key := "savedview.category." + strings.ToLower(string(savedView.Category))
+		if _, ok := stats[key]; !ok {
+			stats[key] = int64(1)
+		} else {
+			stats[key] = stats[key].(int64) + 1
+		}
+	}
+
+	stats["savedview.count"] = int64(len(savedViews))
+	return stats
 }

--- a/pkg/types/savedview.go
+++ b/pkg/types/savedview.go
@@ -24,7 +24,7 @@ type SavedView struct {
 func NewStatsFromSavedViews(savedViews []*SavedView) map[string]any {
 	stats := make(map[string]any)
 	for _, savedView := range savedViews {
-		key := "savedview.category." + strings.ToLower(string(savedView.Category))
+		key := "savedview.source." + strings.ToLower(string(savedView.SourcePage))
 		if _, ok := stats[key]; !ok {
 			stats[key] = int64(1)
 		} else {

--- a/pkg/types/user.go
+++ b/pkg/types/user.go
@@ -72,6 +72,8 @@ type UserStore interface {
 	ListAPIKeys(ctx context.Context, orgID valuer.UUID) ([]*StorableAPIKeyUser, error)
 	RevokeAPIKey(ctx context.Context, id valuer.UUID, revokedByUserID valuer.UUID) error
 	GetAPIKey(ctx context.Context, orgID, id valuer.UUID) (*StorableAPIKeyUser, error)
+
+	CountByOrgID(ctx context.Context, orgID valuer.UUID) (int64, error)
 }
 
 type GettableUser struct {

--- a/pkg/version/deployment.go
+++ b/pkg/version/deployment.go
@@ -1,0 +1,155 @@
+package version
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	gotime "time"
+)
+
+var (
+	current = Deployment{mode: "unknown", platform: "unknown", os: "unknown", arch: "unknown"}
+	once    = sync.Once{}
+)
+
+type Deployment struct {
+	// mode of deployment, e.g. kubernetes, binary, etc.
+	mode string
+
+	// platform of deployment, e.g. heroku, render, aws, gcp, azure, digitalocean, etc.
+	platform string
+
+	// os of deployment, e.g. linux, darwin, etc.
+	os string
+
+	// arch of deployment, e.g. amd64, arm64, etc.
+	arch string
+}
+
+func NewDeployment() Deployment {
+	once.Do(func() {
+		current.mode = detectMode()
+		current.platform = detectPlatform()
+		current.os = runtime.GOOS
+		current.arch = runtime.GOARCH
+	})
+
+	return current
+}
+
+func (d Deployment) Mode() string {
+	return d.mode
+}
+
+func (d Deployment) Platform() string {
+	return d.platform
+}
+
+func (d Deployment) OS() string {
+	return d.os
+}
+
+func (d Deployment) Arch() string {
+	return d.arch
+}
+
+func detectMode() string {
+	// Check if running in Kubernetes
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		return "kubernetes"
+	}
+
+	// Check if running in a container and identify the runtime
+	if data, err := os.ReadFile("/proc/self/cgroup"); err == nil {
+		cgroupData := string(data)
+		switch {
+		case strings.Contains(cgroupData, "docker"):
+			return "docker"
+		case strings.Contains(cgroupData, "containerd"):
+			return "containerd"
+		case strings.Contains(cgroupData, "libpod") || strings.Contains(cgroupData, "podman"):
+			return "podman"
+		case strings.Contains(cgroupData, "crio"):
+			return "cri-o"
+		}
+	}
+
+	// Check if running as a binary
+	if exe, err := os.Executable(); err == nil {
+		// Check if the executable is in a standard binary location
+		exePath := filepath.Clean(exe)
+		if strings.HasPrefix(exePath, "/usr/local/bin/") ||
+			strings.HasPrefix(exePath, "/usr/bin/") ||
+			strings.HasPrefix(exePath, "/bin/") ||
+			strings.HasPrefix(exePath, "/opt/") {
+			return "binary"
+		}
+
+		// Check if the executable is in the current directory
+		if filepath.Dir(exePath) == "." || filepath.Dir(exePath) == filepath.Clean(os.Getenv("PWD")) {
+			return "binary"
+		}
+	}
+
+	return "unknown"
+}
+
+func detectPlatform() string {
+	// Check for PaaS platforms first as they use environment variables
+	switch {
+	case os.Getenv("DYNO") != "" || os.Getenv("HEROKU_APP_ID") != "":
+		return "heroku"
+	case os.Getenv("RENDER") != "" || os.Getenv("RENDER_SERVICE_ID") != "":
+		return "render"
+	}
+
+	// Try to detect cloud provider through metadata endpoints
+	client := &http.Client{Timeout: 1 * gotime.Second}
+
+	// AWS metadata
+	if req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data/", nil); err == nil {
+		if resp, err := client.Do(req); err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == 200 {
+				return "aws"
+			}
+		}
+	}
+
+	// GCP metadata
+	if req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/computeMetadata/v1/", nil); err == nil {
+		req.Header.Add("Metadata-Flavor", "Google")
+		if resp, err := client.Do(req); err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == 200 {
+				return "gcp"
+			}
+		}
+	}
+
+	// Azure metadata
+	if req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/metadata/instance", nil); err == nil {
+		req.Header.Add("Metadata", "true")
+		if resp, err := client.Do(req); err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == 200 {
+				return "azure"
+			}
+		}
+	}
+
+	// Digitalocean metadata
+	if req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/metadata/v1/", nil); err == nil {
+		if resp, err := client.Do(req); err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == 200 {
+				return "digitalocean"
+			}
+		}
+	}
+
+	return "unknown"
+}


### PR DESCRIPTION
## 📄 Summary

- build a new statsreporter service
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce `statsreporter` service for collecting and reporting statistics, integrating it with existing modules and configurations.
> 
>   - **StatsReporter Service**:
>     - Introduces `statsreporter` service for collecting and reporting statistics.
>     - Adds `StatsReporter` and `StatsCollector` interfaces in `statsreporter.go`.
>     - Implements `analyticsstatsreporter` and `noopstatsreporter` providers.
>     - Adds `NewFactory` functions for both providers.
>     - Configurable via `statsreporter/config.go` with `enabled` and `interval` options.
>   - **Integration**:
>     - Integrates `statsreporter` with existing modules like `alertmanager`, `ruler`, `dashboard`, `savedview`, `user`, and `licensing`.
>     - Updates `signoz.go` to initialize and start `statsreporter`.
>     - Modifies `module.go` and `provider.go` to include `statsreporter` in the module and provider initialization.
>   - **Configuration**:
>     - Updates `config.go` to include `StatsReporter` configuration.
>     - Adds `NewStatsReporterProviderFactories` in `provider.go`.
>   - **Miscellaneous**:
>     - Adds `NewStatsFrom*` functions in various types to support stats collection.
>     - Updates tests to accommodate `statsreporter` integration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for ac431254785c4f8499e4e5b7be8119506a524e94. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->