### PR TITLE
feat(statsreporter): report stats on stop

### DIFF
--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -130,7 +130,7 @@ func (provider *provider) Report(ctx context.Context) error {
 		provider.analytics.Send(
 			ctx,
 			analyticstypes.Track{
-				UserId:     org.ID.String(),
+				UserId:     "stats_" + org.ID.String(),
 				Event:      "Stats Reported",
 				Properties: analyticstypes.NewPropertiesFromMap(stats),
 				Context: &analyticstypes.Context{
@@ -140,7 +140,7 @@ func (provider *provider) Report(ctx context.Context) error {
 				},
 			},
 			analyticstypes.Group{
-				UserId:  org.ID.String(),
+				UserId:  "stats_" + org.ID.String(),
 				GroupId: org.ID.String(),
 				Traits: analyticstypes.
 					NewTraitsFromMap(stats).
@@ -149,7 +149,7 @@ func (provider *provider) Report(ctx context.Context) error {
 					SetCreatedAt(org.CreatedAt),
 			},
 			analyticstypes.Identify{
-				UserId: org.ID.String(),
+				UserId: "stats_" + org.ID.String(),
 				Traits: analyticstypes.
 					NewTraits().
 					SetName(org.DisplayName).
@@ -164,6 +164,12 @@ func (provider *provider) Report(ctx context.Context) error {
 
 func (provider *provider) Stop(ctx context.Context) error {
 	close(provider.stopC)
+	// report stats on stop
+	err := provider.Report(ctx)
+	if err != nil {
+		provider.settings.Logger().ErrorContext(ctx, "failed to report stats", "error", err)
+	}
+
 	if err := provider.analytics.Stop(ctx); err != nil {
 		provider.settings.Logger().ErrorContext(ctx, "failed to stop analytics", "error", err)
 	}

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -96,9 +96,8 @@ func (provider *provider) Start(ctx context.Context) error {
 		case <-provider.stopC:
 			return nil
 		case <-ticker.C:
-			err := provider.Report(ctx)
-			if err != nil {
-				provider.settings.Logger().ErrorContext(ctx, "failed to report stats", "error", err)
+			if err := provider.Report(ctx); err != nil {
+				provider.settings.Logger().WarnContext(ctx, "failed to report stats", "error", err)
 			}
 		}
 	}
@@ -165,9 +164,8 @@ func (provider *provider) Report(ctx context.Context) error {
 func (provider *provider) Stop(ctx context.Context) error {
 	close(provider.stopC)
 	// report stats on stop
-	err := provider.Report(ctx)
-	if err != nil {
-		provider.settings.Logger().ErrorContext(ctx, "failed to report stats", "error", err)
+	if err := provider.Report(ctx); err != nil {
+		provider.settings.Logger().WarnContext(ctx, "failed to report stats", "error", err)
 	}
 
 	if err := provider.analytics.Stop(ctx); err != nil {


### PR DESCRIPTION
## 📄 Summary

report stats on stop. Prefix user with "stats_" to make it distinguishable from org id. I have a hunch that mixpanel isn't playing well with the same org_id and user_id

Part of https://github.com/SigNoz/platform-pod/issues/500
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Report stats on stop and prefix `UserId` with "stats_" in `provider.go`.
> 
>   - **Behavior**:
>     - `Stop()` in `provider.go` now calls `Report()` to report stats on stop.
>     - `UserId` in `Report()` prefixed with "stats_" to distinguish from org ID.
>   - **Logging**:
>     - Changed error log level to warning in `Start()` and `Stop()` for failed stats reporting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 6ea3e4ab2d56e2fccd4a4b7b5669f43fe423a75a. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->