### PR TITLE
Revert "fix: remove whitespace from sso cert"

### DIFF
--- a/pkg/types/domain.go
+++ b/pkg/types/domain.go
@@ -102,9 +102,7 @@ func (od *GettableOrgDomain) GetSAMLIdpURL() string {
 
 func (od *GettableOrgDomain) GetSAMLCert() string {
 	if od.SamlConfig != nil {
-		// remove any whitespaces from the cert
-		cert := strings.ReplaceAll(od.SamlConfig.SamlCert, " ", "")
-		return cert
+		return od.SamlConfig.SamlCert
 	}
 	return ""
 }


### PR DESCRIPTION
Reverts SigNoz/signoz#8141
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts change in `GetSAMLCert()` to return SAML certificate with original whitespace.
> 
>   - **Behavior**:
>     - Reverts change in `GetSAMLCert()` in `domain.go` to return SAML certificate with original whitespace.
>   - **Misc**:
>     - Reverts SigNoz/signoz#8141.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 102a7125c61782ac41e42215e4ae583899040db3. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->