### PR TITLE
chore: allow url as label value in alerts

### DIFF
--- a/frontend/src/container/FormAlertRules/labels/index.tsx
+++ b/frontend/src/container/FormAlertRules/labels/index.tsx
@@ -85,7 +85,13 @@ function LabelSelect({
 	}, [handleBlur]);
 
 	const handleLabelChange = (event: ChangeEvent<HTMLInputElement>): void => {
-		setCurrentVal(event.target?.value.replace(':', ''));
+		// Remove the colon if it's the last character.
+		// As the colon is used to separate the key and value in the query.
+		setCurrentVal(
+			event.target?.value.endsWith(':')
+				? event.target?.value.slice(0, -1)
+				: event.target?.value,
+		);
 	};
 
 	const handleClose = (key: string): void => {


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

Allow entering urls as label value in alerts creation.
Earlier, the colon would get removed

---

## ✅ Changes

- [ ] Feature: Brief description
- [x] Bug fix: allow url as label value in alerts

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #4702 

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

https://github.com/user-attachments/assets/4e0c4857-ebf7-4331-8b7a-42eba651ac70

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `handleLabelChange` in `LabelSelect` to allow URLs as label values by handling colons correctly.
> 
>   - **Bug Fix**:
>     - In `LabelSelect` component in `index.tsx`, `handleLabelChange` function now allows URLs as label values by removing colons only if they are the last character.
>     - This change ensures colons used in URLs are preserved unless they are at the end, fixing the previous issue where colons were removed indiscriminately.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e22db3343c997a4ab39753e69a7832b215f90978. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->