### PR TITLE
fix(dashboard): enable Cmd/Ctrl+Click to open dashboards in new tab

### DIFF
--- a/frontend/src/container/ListOfDashboard/DashboardsList.tsx
+++ b/frontend/src/container/ListOfDashboard/DashboardsList.tsx
@@ -440,13 +440,7 @@ function DashboardsList(): JSX.Element {
 									placement="left"
 									overlayClassName="title-toolip"
 								>
-									<div
-										className="title-link"
-										onClick={(e): void => {
-											e.stopPropagation();
-											safeNavigate(getLink());
-										}}
-									>
+									<div className="title-link">
 										<img
 											src={dashboard?.image || Base64Icons[0]}
 											alt="dashboard-image"


### PR DESCRIPTION
## 📄 Summary

This PR fixes the issue where Command+Click on a dashboard name didn’t open it in a new tab. The issue was caused by the dashboard title's click handler, which blocked the list item from receiving the event and handling the tab-opening logic. Removing the handler from the title allows the item's logic to execute correctly.

---

## ✅ Changes

Bug fix: Removed redundant click listener from dashboard title to allow Command+Click behavior to propagate and work as expected.

---

## 🏷️ Required: Add Relevant Labels

- `frontend`
- `bug`
- `ui`
---

## 👥 Reviewers

- frontend 
@YounixM 

---

## 🧪 How to Test

1. Navigate to the dashboard list view.
2. Hold Command (Mac) or Ctrl (Windows/Linux) and click on any dashboard name.
3. It should now open the dashboard in a new tab instead of navigating in the current tab.

---

## 🔍 Related Issues

Closes #3939

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<img width="1470" alt="Screenshot 2025-06-14 at 12 31 10 PM" src="https://github.com/user-attachments/assets/0e56c9d8-8bc8-4aa2-85ed-b66b3fd0f38a" />


---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [X] Manually tested the changes


---

## 👀 Notes for Reviewers

This is a small UI behavior fix. The removed handler was unnecessary and was blocking expected browser behavior for Cmd/Ctrl+Click. The parent handler continues to handle regular clicks and Cmd+Click correctly.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Cmd/Ctrl+Click on dashboard names to open in a new tab by removing redundant click handler in `DashboardsList.tsx`.
> 
>   - **Behavior**:
>     - Fixes Cmd/Ctrl+Click on dashboard names to open in a new tab by removing redundant click handler from `title-link` div in `DashboardsList.tsx`.
>   - **Testing**:
>     - Manually tested to ensure dashboards open in a new tab with Cmd/Ctrl+Click.
>   - **Misc**:
>     - Closes issue #3939.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for da890db86ca0c80b9c8a2d0a7ec7c92086103f6f. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->