### PR TITLE
feat(statsreporter): add stats for telemetry.*.last_observed.time

### DIFF
--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -217,18 +217,18 @@ func (provider *provider) collectOrg(ctx context.Context, orgID valuer.UUID) map
 	}
 
 	var tracesLastSeenAt time.Time
-	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT toDateTime(max(timestamp)) FROM signoz_traces.distributed_signoz_index_v3").Scan(&tracesLastSeenAt); err == nil {
-		stats["telemetry.traces.last_seen_at"] = tracesLastSeenAt
+	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT max(timestamp) FROM signoz_traces.distributed_signoz_index_v3").Scan(&tracesLastSeenAt); err == nil {
+		stats["telemetry.traces.last_seen_at"] = tracesLastSeenAt.UTC()
 	}
 
 	var logsLastSeenAt time.Time
 	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT fromUnixTimestamp64Nano(max(timestamp)) FROM signoz_logs.distributed_logs_v2").Scan(&logsLastSeenAt); err == nil {
-		stats["telemetry.logs.last_seen_at"] = logsLastSeenAt
+		stats["telemetry.logs.last_seen_at"] = logsLastSeenAt.UTC()
 	}
 
 	var metricsLastSeenAt time.Time
 	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT toDateTime(max(unix_milli) / 1000) FROM signoz_metrics.distributed_samples_v4").Scan(&metricsLastSeenAt); err == nil {
-		stats["telemetry.metrics.last_seen_at"] = metricsLastSeenAt
+		stats["telemetry.metrics.last_seen_at"] = metricsLastSeenAt.UTC()
 	}
 
 	return stats

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -216,5 +216,20 @@ func (provider *provider) collectOrg(ctx context.Context, orgID valuer.UUID) map
 		stats["telemetry.metrics.count"] = metrics
 	}
 
+	var tracesLastSeenAt time.Time
+	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT toDateTime(max(timestamp)) FROM signoz_traces.distributed_signoz_index_v3").Scan(&tracesLastSeenAt); err == nil {
+		stats["telemetry.traces.last_seen_at"] = tracesLastSeenAt
+	}
+
+	var logsLastSeenAt time.Time
+	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT fromUnixTimestamp64Nano(max(timestamp)) FROM signoz_logs.distributed_logs_v2").Scan(&logsLastSeenAt); err == nil {
+		stats["telemetry.logs.last_seen_at"] = logsLastSeenAt
+	}
+
+	var metricsLastSeenAt time.Time
+	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT toDateTime(max(unix_milli) / 1000) FROM signoz_metrics.distributed_samples_v4").Scan(&metricsLastSeenAt); err == nil {
+		stats["telemetry.metrics.last_seen_at"] = metricsLastSeenAt
+	}
+
 	return stats
 }

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -218,17 +218,17 @@ func (provider *provider) collectOrg(ctx context.Context, orgID valuer.UUID) map
 
 	var tracesLastSeenAt time.Time
 	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT max(timestamp) FROM signoz_traces.distributed_signoz_index_v3").Scan(&tracesLastSeenAt); err == nil {
-		stats["telemetry.traces.last_seen_at"] = tracesLastSeenAt.UTC()
+		stats["telemetry.traces.last_observed.time"] = tracesLastSeenAt.UTC()
 	}
 
 	var logsLastSeenAt time.Time
 	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT fromUnixTimestamp64Nano(max(timestamp)) FROM signoz_logs.distributed_logs_v2").Scan(&logsLastSeenAt); err == nil {
-		stats["telemetry.logs.last_seen_at"] = logsLastSeenAt.UTC()
+		stats["telemetry.logs.last_observed.time"] = logsLastSeenAt.UTC()
 	}
 
 	var metricsLastSeenAt time.Time
 	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT toDateTime(max(unix_milli) / 1000) FROM signoz_metrics.distributed_samples_v4").Scan(&metricsLastSeenAt); err == nil {
-		stats["telemetry.metrics.last_seen_at"] = metricsLastSeenAt.UTC()
+		stats["telemetry.metrics.last_observed.time"] = metricsLastSeenAt.UTC()
 	}
 
 	return stats


### PR DESCRIPTION
## 📄 Summary

- add stats for telemetry.*.last_observed.time
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds tracking for `last_seen_at` timestamps for traces, logs, and metrics in `collectOrg()` in `provider.go`.
> 
>   - **Behavior**:
>     - Adds tracking for `last_seen_at` timestamps for traces, logs, and metrics in `collectOrg()` in `provider.go`.
>     - Queries maximum timestamp from `signoz_traces.distributed_signoz_index_v3`, `signoz_logs.distributed_logs_v2`, and `signoz_metrics.distributed_samples_v4`.
>     - Updates stats map with `telemetry.traces.last_observed.time`, `telemetry.logs.last_observed.time`, and `telemetry.metrics.last_observed.time`.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for a44a3c7df9a39f6eaf396adf45be7e613b553ef2. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->