### PR TITLE
feat: adds more analytics endpoints for trace funnel feature (analytics APIs, and analytics queries) for autosave flow

### DIFF
--- a/pkg/types/tracefunneltypes/tracefunnel.go
+++ b/pkg/types/tracefunneltypes/tracefunnel.go
@@ -49,10 +49,10 @@ type PostableFunnel struct {
 	UserID      string        `json:"user_id,omitempty"`
 
 	// Analytics specific fields
-	StartTime  int64 `json:"start_time,omitempty"`
-	EndTime    int64 `json:"end_time,omitempty"`
-	StepAOrder int64 `json:"step_a_order,omitempty"`
-	StepBOrder int64 `json:"step_b_order,omitempty"`
+	StartTime int64 `json:"start_time,omitempty"`
+	EndTime   int64 `json:"end_time,omitempty"`
+	StepStart int64 `json:"step_start,omitempty"`
+	StepEnd   int64 `json:"step_end,omitempty"`
 }
 
 // GettableFunnel represents all possible funnel-related responses


### PR DESCRIPTION
part of: https://github.com/SigNoz/signoz/issues/7210

fixes: https://github.com/SigNoz/signoz/issues/7802, https://github.com/SigNoz/signoz/issues/7382

Add new trace funnel analytics endpoints with payload-based funnel definition

Changes
- Added new endpoints for trace funnel analytics that accept funnel definition in the request payload instead of requiring a funnel ID
- Removed dependency on stored funnels for analytics operations
- Endpoints added:
  - `/validate` - Validate traces against a funnel definition
  - `/analytics` - Get funnel analytics
  - `/analytics/steps` - Get step analytics
  - `/analytics/steps/overview` - Get funnel step analytics
  - `/analytics/slow-traces` - Get slow traces
  - `/analytics/error-traces` - Get error traces

Postman collection: [link](https://signoz.postman.co/workspace/Team-Workspace~cfa5c7b5-124f-4bbc-88d9-2351af8dd95b/collection/35983931-f2f252b4-92a1-47ba-b392-32a84c83334c?action=share&creator=35983931)

Functional testing done via postman and also via staging environment https://awake-eft.us.staging.signoz.cloud/home and via https://github.com/SigNoz/signoz/pull/8098 and https://github.com/SigNoz/signoz/pull/8119


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add new trace funnel analytics endpoints with payload-based funnel definitions, removing dependency on stored funnels.
> 
>   - **Endpoints**:
>     - Added new endpoints in `http_handler.go` for trace funnel analytics using payload-based funnel definitions.
>     - Endpoints include `/analytics/validate`, `/analytics/overview`, `/analytics/steps`, `/analytics/steps/overview`, `/analytics/slow-traces`, `/analytics/error-traces`.
>   - **Functions**:
>     - Added `handleValidateTracesWithPayload`, `handleFunnelAnalyticsWithPayload`, `handleStepAnalyticsWithPayload`, `handleFunnelStepAnalyticsWithPayload`, `handleFunnelSlowTracesWithPayload`, `handleFunnelErrorTracesWithPayload` in `http_handler.go`.
>   - **Models**:
>     - Updated `PostableFunnel` in `tracefunnel.go` to include `StepStart` and `StepEnd` fields for analytics.
>   - **Behavior**:
>     - Removed dependency on stored funnels for analytics operations, allowing dynamic funnel definitions via request payloads.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 67f02c6609e728fc822b26d7f4630888663f074b. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->