### PR TITLE
fix(prom-aggr): Added fix for prom aggregation

### DIFF
--- a/pkg/prometheus/clickhouseprometheus/json.go
+++ b/pkg/prometheus/clickhouseprometheus/json.go
@@ -2,6 +2,7 @@ package clickhouseprometheus
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/prometheus/prometheus/prompb"
 )
@@ -17,7 +18,12 @@ func unmarshalLabels(s string) ([]prompb.Label, string, error) {
 	for n, v := range m {
 		if n == "__name__" {
 			metricName = v
+		} else {
+			if strings.Contains(n, ".") {
+				n = `"` + n + `"`
+			}
 		}
+
 		res = append(res, prompb.Label{
 			Name:  n,
 			Value: v,


### PR DESCRIPTION
## 📄 Summary

PromQL aggregation was not working as expected due to the presence of extra quotes in label names. When generating grouping keys, these quotes were being included in the hash, causing mismatches during aggregation. As a temporary solution, we now explicitly quote label names that contain dots (.) when generating Prometheus-style timeseries labels to ensure consistent hashing and matching.

Test Cases -> 
https://www.notion.so/signoz/Prom-ql-Agg-Labels-Test-214fcc6bcd198036ae56f3c127a41ecd?showMoveTo=true&saveParent=true