### PR TITLE
fix(8232): added fix for error graph in services tab

### DIFF
--- a/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
+++ b/frontend/src/container/MetricsApplication/MetricsPageQueries/OverviewQueries.ts
@@ -611,9 +611,7 @@ export const errorPercentage = ({
 		{
 			id: '',
 			key: {
-				key: dotMetricsEnabled
-					? WidgetKeys.Service_name
-					: WidgetKeys.StatusCodeNorm,
+				key: dotMetricsEnabled ? WidgetKeys.StatusCode : WidgetKeys.StatusCodeNorm,
 				dataType: DataTypes.Int64,
 				isColumn: false,
 				type: MetricsType.Tag,


### PR DESCRIPTION
## 📄 Summary
Added Fix for error graph it was earlier using service_name instead of status code.

Tested ss - > 

![Screenshot 2025-06-16 at 7 50 07 PM](https://github.com/user-attachments/assets/5c52bb96-1cb1-486d-a1c1-156ce5480189)
