### PR TITLE
feat(analytics): move frontend event to group_id

### DIFF
--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -224,3 +224,6 @@ statsreporter:
   enabled: true
   # The interval at which the stats are collected.
   interval: 6h
+  collect:
+    # Whether to collect identities and traits (emails).
+    identities: true

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -12,4 +12,16 @@ type Analytics interface {
 
 	// Sends analytics messages to an analytics backend.
 	Send(context.Context, ...analyticstypes.Message)
+
+	// Tracks an event on a group level. Input is group, event name, and attributes. The user is "stats_<org_id>".
+	TrackGroup(context.Context, string, string, map[string]any)
+
+	// Tracks an event on a user level and attributes it with the group. Input is group, user, event name, and attributes.
+	TrackUser(context.Context, string, string, string, map[string]any)
+
+	// Identifies a group. Input is group, traits.
+	IdentifyGroup(context.Context, string, map[string]any)
+
+	// Identifies a user. Input is group, user, traits.
+	IdentifyUser(context.Context, string, string, map[string]any)
 }

--- a/pkg/analytics/analyticstest/provider.go
+++ b/pkg/analytics/analyticstest/provider.go
@@ -24,6 +24,18 @@ func (provider *Provider) Start(_ context.Context) error {
 
 func (provider *Provider) Send(ctx context.Context, messages ...analyticstypes.Message) {}
 
+func (provider *Provider) TrackGroup(ctx context.Context, group, event string, attributes map[string]any) {
+}
+
+func (provider *Provider) TrackUser(ctx context.Context, group, user, event string, attributes map[string]any) {
+}
+
+func (provider *Provider) IdentifyGroup(ctx context.Context, group string, traits map[string]any) {
+}
+
+func (provider *Provider) IdentifyUser(ctx context.Context, group, user string, traits map[string]any) {
+}
+
 func (provider *Provider) Stop(_ context.Context) error {
 	close(provider.stopC)
 	return nil

--- a/pkg/analytics/noopanalytics/provider.go
+++ b/pkg/analytics/noopanalytics/provider.go
@@ -27,7 +27,25 @@ func (provider *provider) Start(_ context.Context) error {
 	return nil
 }
 
-func (provider *provider) Send(ctx context.Context, messages ...analyticstypes.Message) {}
+func (provider *provider) Send(ctx context.Context, messages ...analyticstypes.Message) {
+	// do nothing
+}
+
+func (provider *provider) TrackGroup(ctx context.Context, group, event string, attributes map[string]any) {
+	// do nothing
+}
+
+func (provider *provider) TrackUser(ctx context.Context, group, user, event string, attributes map[string]any) {
+	// do nothing
+}
+
+func (provider *provider) IdentifyGroup(ctx context.Context, group string, traits map[string]any) {
+	// do nothing
+}
+
+func (provider *provider) IdentifyUser(ctx context.Context, group, user string, traits map[string]any) {
+	// do nothing
+}
 
 func (provider *provider) Stop(_ context.Context) error {
 	close(provider.stopC)

--- a/pkg/analytics/segmentanalytics/provider.go
+++ b/pkg/analytics/segmentanalytics/provider.go
@@ -50,6 +50,99 @@ func (provider *provider) Send(ctx context.Context, messages ...analyticstypes.M
 	}
 }
 
+func (provider *provider) TrackGroup(ctx context.Context, group, event string, properties map[string]any) {
+	if properties == nil {
+		provider.settings.Logger().WarnContext(ctx, "empty attributes received, skipping event", "group", group, "event", event)
+		return
+	}
+
+	err := provider.client.Enqueue(analyticstypes.Track{
+		UserId:     "stats_" + group,
+		Event:      event,
+		Properties: analyticstypes.NewPropertiesFromMap(properties),
+		Context: &analyticstypes.Context{
+			Extra: map[string]interface{}{
+				analyticstypes.KeyGroupID: group,
+			},
+		},
+	})
+	if err != nil {
+		provider.settings.Logger().WarnContext(ctx, "unable to send message to segment", "err", err)
+	}
+}
+
+func (provider *provider) TrackUser(ctx context.Context, group, user, event string, properties map[string]any) {
+	if properties == nil {
+		provider.settings.Logger().WarnContext(ctx, "empty attributes received, skipping event", "user", user, "group", group, "event", event)
+		return
+	}
+
+	err := provider.client.Enqueue(analyticstypes.Track{
+		UserId:     user,
+		Event:      event,
+		Properties: analyticstypes.NewPropertiesFromMap(properties),
+		Context: &analyticstypes.Context{
+			Extra: map[string]interface{}{
+				analyticstypes.KeyGroupID: group,
+			},
+		},
+	})
+	if err != nil {
+		provider.settings.Logger().WarnContext(ctx, "unable to send message to segment", "err", err)
+	}
+}
+
+func (provider *provider) IdentifyGroup(ctx context.Context, group string, traits map[string]any) {
+	if traits == nil {
+		provider.settings.Logger().WarnContext(ctx, "empty attributes received, skipping identify", "group", group)
+		return
+	}
+
+	// identify the user
+	err := provider.client.Enqueue(analyticstypes.Identify{
+		UserId: "stats_" + group,
+		Traits: analyticstypes.NewTraitsFromMap(traits),
+	})
+	if err != nil {
+		provider.settings.Logger().WarnContext(ctx, "unable to send message to segment", "err", err)
+	}
+
+	// identify the group using the stats user
+	err = provider.client.Enqueue(analyticstypes.Group{
+		UserId:  "stats_" + group,
+		GroupId: group,
+		Traits:  analyticstypes.NewTraitsFromMap(traits),
+	})
+	if err != nil {
+		provider.settings.Logger().WarnContext(ctx, "unable to send message to segment", "err", err)
+	}
+}
+
+func (provider *provider) IdentifyUser(ctx context.Context, group, user string, traits map[string]any) {
+	if traits == nil {
+		provider.settings.Logger().WarnContext(ctx, "empty attributes received, skipping identify", "user", user, "group", group)
+		return
+	}
+
+	// identify the user
+	err := provider.client.Enqueue(analyticstypes.Identify{
+		UserId: user,
+		Traits: analyticstypes.NewTraitsFromMap(traits),
+	})
+	if err != nil {
+		provider.settings.Logger().WarnContext(ctx, "unable to send message to segment", "err", err)
+	}
+
+	// associate the user with the group
+	err = provider.client.Enqueue(analyticstypes.Group{
+		UserId:  user,
+		GroupId: group,
+	})
+	if err != nil {
+		provider.settings.Logger().WarnContext(ctx, "unable to send message to segment", "err", err)
+	}
+}
+
 func (provider *provider) Stop(ctx context.Context) error {
 	if err := provider.client.Close(); err != nil {
 		provider.settings.Logger().WarnContext(ctx, "unable to close segment client", "err", err)

--- a/pkg/analytics/segmentanalytics/provider.go
+++ b/pkg/analytics/segmentanalytics/provider.go
@@ -137,7 +137,7 @@ func (provider *provider) IdentifyUser(ctx context.Context, group, user string, 
 	err = provider.client.Enqueue(analyticstypes.Group{
 		UserId:  user,
 		GroupId: group,
-		Traits:  analyticstypes.NewTraits(),
+		Traits:  analyticstypes.NewTraits().Set("id", group),
 	})
 	if err != nil {
 		provider.settings.Logger().WarnContext(ctx, "unable to send message to segment", "err", err)

--- a/pkg/analytics/segmentanalytics/provider.go
+++ b/pkg/analytics/segmentanalytics/provider.go
@@ -137,7 +137,7 @@ func (provider *provider) IdentifyUser(ctx context.Context, group, user string, 
 	err = provider.client.Enqueue(analyticstypes.Group{
 		UserId:  user,
 		GroupId: group,
-		Traits:  analyticstypes.NewTraits().Set("id", group),
+		Traits:  analyticstypes.NewTraits().Set("id", group), // A trait is required
 	})
 	if err != nil {
 		provider.settings.Logger().WarnContext(ctx, "unable to send message to segment", "err", err)

--- a/pkg/analytics/segmentanalytics/provider.go
+++ b/pkg/analytics/segmentanalytics/provider.go
@@ -137,6 +137,7 @@ func (provider *provider) IdentifyUser(ctx context.Context, group, user string, 
 	err = provider.client.Enqueue(analyticstypes.Group{
 		UserId:  user,
 		GroupId: group,
+		Traits:  analyticstypes.NewTraits(),
 	})
 	if err != nil {
 		provider.settings.Logger().WarnContext(ctx, "unable to send message to segment", "err", err)

--- a/pkg/modules/dashboard/impldashboard/module.go
+++ b/pkg/modules/dashboard/impldashboard/module.go
@@ -9,7 +9,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/modules/dashboard"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
-	"github.com/SigNoz/signoz/pkg/types/analyticstypes"
 	"github.com/SigNoz/signoz/pkg/types/dashboardtypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
@@ -45,19 +44,7 @@ func (module *module) Create(ctx context.Context, orgID valuer.UUID, createdBy s
 		return nil, err
 	}
 
-	module.analytics.Send(ctx,
-		analyticstypes.Track{
-			UserId:     creator.String(),
-			Event:      "Dashboard Created",
-			Properties: analyticstypes.NewPropertiesFromMap(dashboardtypes.NewStatsFromStorableDashboards([]*dashboardtypes.StorableDashboard{storableDashboard})),
-			Context: &analyticstypes.Context{
-				Extra: map[string]interface{}{
-					analyticstypes.KeyGroupID: orgID,
-				},
-			},
-		},
-	)
-
+	module.analytics.TrackUser(ctx, orgID.String(), creator.String(), "Dashboard Created", dashboardtypes.NewStatsFromStorableDashboards([]*dashboardtypes.StorableDashboard{storableDashboard}))
 	return dashboard, nil
 }
 

--- a/pkg/modules/user/impluser/getter.go
+++ b/pkg/modules/user/impluser/getter.go
@@ -1,0 +1,31 @@
+package impluser
+
+import (
+	"context"
+
+	"github.com/SigNoz/signoz/pkg/modules/user"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+type getter struct {
+	store types.UserStore
+}
+
+func NewGetter(store types.UserStore) user.Getter {
+	return &getter{store: store}
+}
+
+func (module *getter) ListByOrgID(ctx context.Context, orgID valuer.UUID) ([]*types.User, error) {
+	gettableUsers, err := module.store.ListUsers(ctx, orgID.StringValue())
+	if err != nil {
+		return nil, err
+	}
+
+	users := make([]*types.User, len(gettableUsers))
+	for i, user := range gettableUsers {
+		users[i] = &user.User
+	}
+
+	return users, nil
+}

--- a/pkg/modules/user/impluser/handler.go
+++ b/pkg/modules/user/impluser/handler.go
@@ -326,7 +326,7 @@ func (h *handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 
 	user.UpdatedAt = time.Now()
 
-	updatedUser, err := h.module.UpdateUser(ctx, claims.OrgID, id, &user)
+	updatedUser, err := h.module.UpdateUser(ctx, claims.OrgID, id, &user, claims.UserID)
 	if err != nil {
 		render.Error(w, err)
 		return
@@ -347,7 +347,7 @@ func (h *handler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.module.DeleteUser(ctx, claims.OrgID, id); err != nil {
+	if err := h.module.DeleteUser(ctx, claims.OrgID, id, claims.UserID); err != nil {
 		render.Error(w, err)
 		return
 	}

--- a/pkg/modules/user/impluser/module.go
+++ b/pkg/modules/user/impluser/module.go
@@ -644,10 +644,16 @@ func (m *Module) Register(ctx context.Context, req *types.PostableRegisterOrgAnd
 }
 
 func (m *Module) Collect(ctx context.Context, orgID valuer.UUID) (map[string]any, error) {
+	stats := make(map[string]any)
 	count, err := m.store.CountByOrgID(ctx, orgID)
-	if err != nil {
-		return nil, err
+	if err == nil {
+		stats["user.count"] = count
 	}
 
-	return map[string]any{"user.count": count}, nil
+	count, err = m.store.CountAPIKeyByOrgID(ctx, orgID)
+	if err == nil {
+		stats["factor.api_key.count"] = count
+	}
+
+	return stats, nil
 }

--- a/pkg/modules/user/impluser/module.go
+++ b/pkg/modules/user/impluser/module.go
@@ -18,7 +18,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/query-service/model"
 	"github.com/SigNoz/signoz/pkg/query-service/telemetry"
 	"github.com/SigNoz/signoz/pkg/types"
-	"github.com/SigNoz/signoz/pkg/types/analyticstypes"
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
 	"github.com/SigNoz/signoz/pkg/types/emailtypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
@@ -135,35 +134,14 @@ func (m *Module) CreateUserWithPassword(ctx context.Context, user *types.User, p
 		return nil, err
 	}
 
-	m.analytics.Send(ctx,
-		analyticstypes.Identify{
-			UserId: user.ID.String(),
-			Traits: analyticstypes.
-				NewTraits().
-				SetName(user.DisplayName).
-				SetEmail(user.Email).
-				Set("role", user.Role).
-				SetCreatedAt(user.CreatedAt),
-		},
-		analyticstypes.Group{
-			UserId:  user.ID.String(),
-			GroupId: user.OrgID,
-		},
-		analyticstypes.Track{
-			UserId: user.ID.String(),
-			Event:  "User Created",
-			Properties: analyticstypes.NewPropertiesFromMap(map[string]any{
-				"role":  user.Role,
-				"email": user.Email,
-				"name":  user.DisplayName,
-			}),
-			Context: &analyticstypes.Context{
-				Extra: map[string]interface{}{
-					analyticstypes.KeyGroupID: user.OrgID,
-				},
-			},
-		},
-	)
+	traitsOrProperties := map[string]any{
+		"role":         user.Role,
+		"email":        user.Email,
+		"display_name": user.DisplayName,
+		"created_at":   user.CreatedAt,
+	}
+	m.analytics.IdentifyUser(ctx, user.OrgID, user.ID.String(), traitsOrProperties)
+	m.analytics.TrackUser(ctx, user.OrgID, user.ID.String(), "User Created", traitsOrProperties)
 
 	return user, nil
 }
@@ -173,35 +151,14 @@ func (m *Module) CreateUser(ctx context.Context, user *types.User) error {
 		return err
 	}
 
-	m.analytics.Send(ctx,
-		analyticstypes.Identify{
-			UserId: user.ID.String(),
-			Traits: analyticstypes.
-				NewTraits().
-				SetName(user.DisplayName).
-				SetEmail(user.Email).
-				Set("role", user.Role).
-				SetCreatedAt(user.CreatedAt),
-		},
-		analyticstypes.Group{
-			UserId:  user.ID.String(),
-			GroupId: user.OrgID,
-		},
-		analyticstypes.Track{
-			UserId: user.ID.String(),
-			Event:  "User Created",
-			Properties: analyticstypes.NewPropertiesFromMap(map[string]any{
-				"role":  user.Role,
-				"email": user.Email,
-				"name":  user.DisplayName,
-			}),
-			Context: &analyticstypes.Context{
-				Extra: map[string]interface{}{
-					analyticstypes.KeyGroupID: user.OrgID,
-				},
-			},
-		},
-	)
+	traitsOrProperties := map[string]any{
+		"role":         user.Role,
+		"email":        user.Email,
+		"display_name": user.DisplayName,
+		"created_at":   user.CreatedAt,
+	}
+	m.analytics.IdentifyUser(ctx, user.OrgID, user.ID.String(), traitsOrProperties)
+	m.analytics.TrackUser(ctx, user.OrgID, user.ID.String(), "User Created", traitsOrProperties)
 
 	return nil
 }

--- a/pkg/modules/user/impluser/store.go
+++ b/pkg/modules/user/impluser/store.go
@@ -826,3 +826,21 @@ func (store *store) CountByOrgID(ctx context.Context, orgID valuer.UUID) (int64,
 
 	return int64(count), nil
 }
+
+func (store *store) CountAPIKeyByOrgID(ctx context.Context, orgID valuer.UUID) (int64, error) {
+	apiKey := new(types.StorableAPIKey)
+
+	count, err := store.
+		sqlstore.
+		BunDB().
+		NewSelect().
+		Model(apiKey).
+		Join("JOIN users ON users.id = factor_api_key.user_id").
+		Where("org_id = ?", orgID).
+		Count(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return int64(count), nil
+}

--- a/pkg/modules/user/impluser/store.go
+++ b/pkg/modules/user/impluser/store.go
@@ -835,7 +835,7 @@ func (store *store) CountAPIKeyByOrgID(ctx context.Context, orgID valuer.UUID) (
 		BunDB().
 		NewSelect().
 		Model(apiKey).
-		Join("JOIN users ON users.id = factor_api_key.user_id").
+		Join("JOIN users ON users.id = storable_api_key.user_id").
 		Where("org_id = ?", orgID).
 		Count(ctx)
 	if err != nil {

--- a/pkg/modules/user/user.go
+++ b/pkg/modules/user/user.go
@@ -28,8 +28,8 @@ type Module interface {
 	GetUserByEmailInOrg(ctx context.Context, orgID string, email string) (*types.GettableUser, error)
 	GetUsersByRoleInOrg(ctx context.Context, orgID string, role types.Role) ([]*types.GettableUser, error)
 	ListUsers(ctx context.Context, orgID string) ([]*types.GettableUser, error)
-	UpdateUser(ctx context.Context, orgID string, id string, user *types.User) (*types.User, error)
-	DeleteUser(ctx context.Context, orgID string, id string) error
+	UpdateUser(ctx context.Context, orgID string, id string, user *types.User, updatedBy string) (*types.User, error)
+	DeleteUser(ctx context.Context, orgID string, id string, deletedBy string) error
 
 	// login
 	GetAuthenticatedUser(ctx context.Context, orgID, email, password, refreshToken string) (*types.User, error)
@@ -68,6 +68,11 @@ type Module interface {
 	Register(ctx context.Context, req *types.PostableRegisterOrgAndAdmin) (*types.User, error)
 
 	statsreporter.StatsCollector
+}
+
+type Getter interface {
+	// Get gets the users based on the given id
+	ListByOrgID(context.Context, valuer.UUID) ([]*types.User, error)
 }
 
 type Handler interface {

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1584,6 +1584,7 @@ func (aH *APIHandler) registerEvent(w http.ResponseWriter, r *http.Request) {
 		switch request.EventType {
 		case model.TrackEvent:
 			telemetry.GetInstance().SendEvent(request.EventName, request.Attributes, claims.Email, request.RateLimited, true)
+			aH.Signoz.Analytics.TrackUser(r.Context(), claims.OrgID, claims.UserID, request.EventName, request.Attributes)
 		case model.GroupEvent:
 			telemetry.GetInstance().SendGroupEvent(request.Attributes, claims.Email)
 		case model.IdentifyEvent:

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/emailing/smtpemailing"
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/modules/organization"
+	"github.com/SigNoz/signoz/pkg/modules/user"
 	"github.com/SigNoz/signoz/pkg/prometheus"
 	"github.com/SigNoz/signoz/pkg/prometheus/clickhouseprometheus"
 	"github.com/SigNoz/signoz/pkg/querier"
@@ -153,9 +154,9 @@ func NewSharderProviderFactories() factory.NamedMap[factory.ProviderFactory[shar
 	)
 }
 
-func NewStatsReporterProviderFactories(telemetryStore telemetrystore.TelemetryStore, collectors []statsreporter.StatsCollector, orgGetter organization.Getter, build version.Build, analyticsConfig analytics.Config) factory.NamedMap[factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config]] {
+func NewStatsReporterProviderFactories(telemetryStore telemetrystore.TelemetryStore, collectors []statsreporter.StatsCollector, orgGetter organization.Getter, userGetter user.Getter, build version.Build, analyticsConfig analytics.Config) factory.NamedMap[factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config]] {
 	return factory.MustNewNamedMap(
-		analyticsstatsreporter.NewFactory(telemetryStore, collectors, orgGetter, build, analyticsConfig),
+		analyticsstatsreporter.NewFactory(telemetryStore, collectors, orgGetter, userGetter, build, analyticsConfig),
 		noopstatsreporter.NewFactory(),
 	)
 }

--- a/pkg/signoz/provider_test.go
+++ b/pkg/signoz/provider_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/SigNoz/signoz/pkg/analytics"
+	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/modules/organization/implorganization"
+	"github.com/SigNoz/signoz/pkg/modules/user/impluser"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
 	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstoretest"
 	"github.com/SigNoz/signoz/pkg/statsreporter"
@@ -61,8 +63,9 @@ func TestNewProviderFactories(t *testing.T) {
 	})
 
 	assert.NotPanics(t, func() {
+		userGetter := impluser.NewGetter(impluser.NewStore(sqlstoretest.New(sqlstore.Config{Provider: "sqlite"}, sqlmock.QueryMatcherEqual), instrumentationtest.New().ToProviderSettings()))
 		orgGetter := implorganization.NewGetter(implorganization.NewStore(sqlstoretest.New(sqlstore.Config{Provider: "sqlite"}, sqlmock.QueryMatcherEqual)), nil)
 		telemetryStore := telemetrystoretest.New(telemetrystore.Config{Provider: "clickhouse"}, sqlmock.QueryMatcherEqual)
-		NewStatsReporterProviderFactories(telemetryStore, []statsreporter.StatsCollector{}, orgGetter, version.Build{}, analytics.Config{Enabled: true})
+		NewStatsReporterProviderFactories(telemetryStore, []statsreporter.StatsCollector{}, orgGetter, userGetter, version.Build{}, analytics.Config{Enabled: true})
 	})
 }

--- a/pkg/signoz/signoz.go
+++ b/pkg/signoz/signoz.go
@@ -31,6 +31,7 @@ import (
 type SigNoz struct {
 	*factory.Registry
 	Instrumentation instrumentation.Instrumentation
+	Analytics       analytics.Analytics
 	Cache           cache.Cache
 	Web             web.Web
 	SQLStore        sqlstore.SQLStore
@@ -288,6 +289,7 @@ func New(
 
 	return &SigNoz{
 		Registry:        registry,
+		Analytics:       analytics,
 		Instrumentation: instrumentation,
 		Cache:           cache,
 		Web:             web,

--- a/pkg/signoz/signoz.go
+++ b/pkg/signoz/signoz.go
@@ -12,6 +12,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/licensing"
 	"github.com/SigNoz/signoz/pkg/modules/organization"
 	"github.com/SigNoz/signoz/pkg/modules/organization/implorganization"
+	"github.com/SigNoz/signoz/pkg/modules/user/impluser"
 	"github.com/SigNoz/signoz/pkg/prometheus"
 	"github.com/SigNoz/signoz/pkg/querier"
 	"github.com/SigNoz/signoz/pkg/ruler"
@@ -213,6 +214,9 @@ func New(
 	// Initialize organization getter
 	orgGetter := implorganization.NewGetter(implorganization.NewStore(sqlstore), sharder)
 
+	// Initialize user getter
+	userGetter := impluser.NewGetter(impluser.NewStore(sqlstore, providerSettings))
+
 	// Initialize alertmanager from the available alertmanager provider factories
 	alertmanager, err := factory.NewProviderFromNamedMap(
 		ctx,
@@ -268,7 +272,7 @@ func New(
 		ctx,
 		providerSettings,
 		config.StatsReporter,
-		NewStatsReporterProviderFactories(telemetrystore, statsCollectors, orgGetter, version.Info, config.Analytics),
+		NewStatsReporterProviderFactories(telemetrystore, statsCollectors, orgGetter, userGetter, version.Info, config.Analytics),
 		config.StatsReporter.Provider(),
 	)
 	if err != nil {

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -141,6 +141,10 @@ func (provider *provider) Report(ctx context.Context) error {
 		provider.analytics.IdentifyGroup(ctx, org.ID.String(), traits)
 		provider.analytics.TrackGroup(ctx, org.ID.String(), "Stats Reported", stats)
 
+		if !provider.config.Collect.Identities {
+			continue
+		}
+
 		users, err := provider.userGetter.ListByOrgID(ctx, org.ID)
 		if err != nil {
 			provider.settings.Logger().WarnContext(ctx, "failed to list users", "error", err, "org_id", org.ID)

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -122,6 +122,7 @@ func (provider *provider) Report(ctx context.Context) error {
 			continue
 		}
 
+		// Add build and deployment stats
 		stats["build.version"] = provider.build.Version()
 		stats["build.branch"] = provider.build.Branch()
 		stats["build.hash"] = provider.build.Hash()
@@ -131,15 +132,15 @@ func (provider *provider) Report(ctx context.Context) error {
 		stats["deployment.os"] = provider.deployment.OS()
 		stats["deployment.arch"] = provider.deployment.Arch()
 
-		provider.settings.Logger().DebugContext(ctx, "reporting stats", "stats", stats)
-		traits := map[string]any{
-			"display_name": org.DisplayName,
-			"name":         org.Name,
-			"created_at":   org.CreatedAt,
-			"alias":        org.Alias,
-		}
+		// Add org stats
+		stats["display_name"] = org.DisplayName
+		stats["name"] = org.Name
+		stats["created_at"] = org.CreatedAt
+		stats["alias"] = org.Alias
 
-		provider.analytics.IdentifyGroup(ctx, org.ID.String(), traits)
+		provider.settings.Logger().DebugContext(ctx, "reporting stats", "stats", stats)
+
+		provider.analytics.IdentifyGroup(ctx, org.ID.String(), stats)
 		provider.analytics.TrackGroup(ctx, org.ID.String(), "Stats Reported", stats)
 
 		if !provider.config.Collect.Identities {

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/modules/user"
 	"github.com/SigNoz/signoz/pkg/statsreporter"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
+	"github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/SigNoz/signoz/pkg/version"
 )
@@ -152,7 +153,7 @@ func (provider *provider) Report(ctx context.Context) error {
 		}
 
 		for _, user := range users {
-			provider.analytics.IdentifyUser(ctx, org.ID.String(), user.ID.String(), traits)
+			provider.analytics.IdentifyUser(ctx, org.ID.String(), user.ID.String(), types.NewTraitsFromUser(user))
 		}
 	}
 

--- a/pkg/statsreporter/config.go
+++ b/pkg/statsreporter/config.go
@@ -12,6 +12,13 @@ type Config struct {
 
 	// Interval is the interval at which the stats are collected.
 	Interval time.Duration `mapstructure:"interval"`
+
+	// Collect is the collection configuration.
+	Collect Collect `mapstructure:"collect"`
+}
+
+type Collect struct {
+	Identities bool `mapstructure:"identities"`
 }
 
 func NewConfigFactory() factory.ConfigFactory {
@@ -22,6 +29,9 @@ func newConfig() factory.Config {
 	return Config{
 		Enabled:  true,
 		Interval: 6 * time.Hour,
+		Collect: Collect{
+			Identities: true,
+		},
 	}
 }
 

--- a/pkg/types/organization.go
+++ b/pkg/types/organization.go
@@ -49,6 +49,15 @@ func NewOrganizationKey(orgID valuer.UUID) uint32 {
 	return hasher.Sum32()
 }
 
+func NewTraitsFromOrganization(org *Organization) map[string]any {
+	return map[string]any{
+		"display_name": org.DisplayName,
+		"name":         org.Name,
+		"created_at":   org.CreatedAt,
+		"alias":        org.Alias,
+	}
+}
+
 type TTLSetting struct {
 	bun.BaseModel `bun:"table:ttl_setting"`
 	Identifiable

--- a/pkg/types/user.go
+++ b/pkg/types/user.go
@@ -255,3 +255,12 @@ type GettableLoginPrecheck struct {
 	SelectOrg       bool     `json:"selectOrg"`
 	Orgs            []string `json:"orgs"`
 }
+
+func NewTraitsFromUser(user *User) map[string]any {
+	return map[string]any{
+		"role":         user.Role,
+		"email":        user.Email,
+		"display_name": user.DisplayName,
+		"created_at":   user.CreatedAt,
+	}
+}

--- a/pkg/types/user.go
+++ b/pkg/types/user.go
@@ -72,6 +72,7 @@ type UserStore interface {
 	ListAPIKeys(ctx context.Context, orgID valuer.UUID) ([]*StorableAPIKeyUser, error)
 	RevokeAPIKey(ctx context.Context, id valuer.UUID, revokedByUserID valuer.UUID) error
 	GetAPIKey(ctx context.Context, orgID, id valuer.UUID) (*StorableAPIKeyUser, error)
+	CountAPIKeyByOrgID(ctx context.Context, orgID valuer.UUID) (int64, error)
 
 	CountByOrgID(ctx context.Context, orgID valuer.UUID) (int64, error)
 }

--- a/pkg/types/user.go
+++ b/pkg/types/user.go
@@ -258,6 +258,7 @@ type GettableLoginPrecheck struct {
 
 func NewTraitsFromUser(user *User) map[string]any {
 	return map[string]any{
+		"name":         user.DisplayName,
 		"role":         user.Role,
 		"email":        user.Email,
 		"display_name": user.DisplayName,


### PR DESCRIPTION
## 📄 Summary

- Only accept track events from frontend
- Add api_key count in cummulative stats
- Identify users in statsreporter (a configurable option to disable this)