### PR TITLE
fix: JSON Query parse string int value

### DIFF
--- a/pkg/query-service/app/logs/v3/enrich_query.go
+++ b/pkg/query-service/app/logs/v3/enrich_query.go
@@ -229,12 +229,12 @@ func parseStrValue(valueStr string, operator v3.FilterOperator) (string, interfa
 
 	var err error
 	var parsedValue interface{}
-	if parsedValue, err = strconv.ParseBool(valueStr); err == nil {
-		valueType = "bool"
-	} else if parsedValue, err = strconv.ParseInt(valueStr, 10, 64); err == nil {
+	if parsedValue, err = strconv.ParseInt(valueStr, 10, 64); err == nil {
 		valueType = "int64"
 	} else if parsedValue, err = strconv.ParseFloat(valueStr, 64); err == nil {
 		valueType = "float64"
+	} else if parsedValue, err = strconv.ParseBool(valueStr); err == nil {
+		valueType = "bool"
 	} else {
 		parsedValue = valueStr
 		valueType = "string"

--- a/pkg/query-service/app/logs/v3/enrich_query_test.go
+++ b/pkg/query-service/app/logs/v3/enrich_query_test.go
@@ -520,6 +520,28 @@ var testJSONFilterEnrichData = []struct {
 		},
 	},
 	{
+		Name: "int64 string",
+		Filter: v3.FilterItem{
+			Key: v3.AttributeKey{
+				Key:      "body.intx",
+				DataType: v3.AttributeKeyDataTypeUnspecified,
+				Type:     v3.AttributeKeyTypeUnspecified,
+			},
+			Operator: "=",
+			Value:    "0",
+		},
+		Result: v3.FilterItem{
+			Key: v3.AttributeKey{
+				Key:      "body.intx",
+				DataType: v3.AttributeKeyDataTypeInt64,
+				Type:     v3.AttributeKeyTypeUnspecified,
+				IsJSON:   true,
+			},
+			Operator: "=",
+			Value:    int64(0),
+		},
+	},
+	{
 		Name: "float64",
 		Filter: v3.FilterItem{
 			Key: v3.AttributeKey{
@@ -613,7 +635,7 @@ func TestJsonEnrich(t *testing.T) {
 	for _, tt := range testJSONFilterEnrichData {
 		Convey(tt.Name, t, func() {
 			res := jsonFilterEnrich(tt.Filter)
-			So(res, ShouldResemble, tt.Result)
+			So(res, ShouldEqual, tt.Result)
 		})
 	}
 }


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

`parseStrValue` function parsed Boolean first hence string value such as `"1", "0"` hence turning int comparison into boolean ending up in wrong Query formation.

---

## ✅ Changes

- [ ] Bug fix: `parseStrValue` function fix 


---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📋 Checklist

- [ ] Dev Review
- [x] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->
