### PR TITLE
fix: use pathname to get channel id

### DIFF
--- a/frontend/src/AppRoutes/pageComponents.ts
+++ b/frontend/src/AppRoutes/pageComponents.ts
@@ -131,10 +131,6 @@ export const CreateAlertChannelAlerts = Loadable(
 	() => import(/* webpackChunkName: "Create Channels" */ 'pages/Settings'),
 );
 
-export const EditAlertChannelsAlerts = Loadable(
-	() => import(/* webpackChunkName: "Edit Channels" */ 'pages/Settings'),
-);
-
 export const AllAlertChannels = Loadable(
 	() => import(/* webpackChunkName: "All Channels" */ 'pages/Settings'),
 );

--- a/frontend/src/AppRoutes/routes.ts
+++ b/frontend/src/AppRoutes/routes.ts
@@ -12,7 +12,6 @@ import {
 	CreateNewAlerts,
 	DashboardPage,
 	DashboardWidget,
-	EditAlertChannelsAlerts,
 	EditRulesPage,
 	ErrorDetails,
 	Home,
@@ -252,13 +251,6 @@ const routes: AppRoutes[] = [
 		component: CreateAlertChannelAlerts,
 		isPrivate: true,
 		key: 'CHANNELS_NEW',
-	},
-	{
-		path: ROUTES.CHANNELS_EDIT,
-		exact: true,
-		component: EditAlertChannelsAlerts,
-		isPrivate: true,
-		key: 'CHANNELS_EDIT',
 	},
 	{
 		path: ROUTES.ALL_CHANNELS,

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -29,7 +29,7 @@ const ROUTES = {
 	ALERT_OVERVIEW: '/alerts/overview',
 	ALL_CHANNELS: '/settings/channels',
 	CHANNELS_NEW: '/settings/channels/new',
-	CHANNELS_EDIT: '/settings/channels/edit/:id',
+	CHANNELS_EDIT: '/settings/channels/edit/:channelId',
 	ALL_ERROR: '/exceptions',
 	ERROR_DETAIL: '/error-detail',
 	VERSION: '/status',

--- a/frontend/src/container/AllAlertChannels/AlertChannels.tsx
+++ b/frontend/src/container/AllAlertChannels/AlertChannels.tsx
@@ -23,7 +23,7 @@ function AlertChannels({ allChannels }: AlertChannelsProps): JSX.Element {
 	const onClickEditHandler = useCallback((id: string) => {
 		history.push(
 			generatePath(ROUTES.CHANNELS_EDIT, {
-				id,
+				channelId: id,
 			}),
 		);
 	}, []);

--- a/frontend/src/container/FormAlertChannels/index.tsx
+++ b/frontend/src/container/FormAlertChannels/index.tsx
@@ -149,7 +149,7 @@ function FormAlertChannels({
 					</Button>
 					<Button
 						onClick={(): void => {
-							history.replace(ROUTES.SETTINGS);
+							history.replace(ROUTES.ALL_CHANNELS);
 						}}
 					>
 						{t('button_return')}

--- a/frontend/src/pages/AlertList/AlertList.styles.scss
+++ b/frontend/src/pages/AlertList/AlertList.styles.scss
@@ -4,7 +4,6 @@
 	}
 
 	.ant-tabs-content-holder {
-		padding-left: 16px;
-		padding-right: 16px;
+		padding: 8px;
 	}
 }

--- a/frontend/src/pages/ChannelsEdit/ChannelsEdit.styles.scss
+++ b/frontend/src/pages/ChannelsEdit/ChannelsEdit.styles.scss
@@ -1,6 +1,5 @@
 .edit-alert-channels-container {
-	width: 90%;
-	margin: 12px auto;
+	margin: 12px;
 
 	border: 1px solid var(--Slate-500, #161922);
 	background: var(--Ink-400, #121317);

--- a/frontend/src/pages/ChannelsEdit/index.tsx
+++ b/frontend/src/pages/ChannelsEdit/index.tsx
@@ -15,23 +15,27 @@ import {
 import EditAlertChannels from 'container/EditAlertChannels';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from 'react-query';
-import { useParams } from 'react-router-dom';
 import { SuccessResponseV2 } from 'types/api';
 import { Channels } from 'types/api/channels/getAll';
 import APIError from 'types/api/error';
 
 function ChannelsEdit(): JSX.Element {
-	const { id } = useParams<Params>();
 	const { t } = useTranslation();
+
+	// Extract channelId from URL pathname since useParams doesn't work in nested routing
+	const { pathname } = window.location;
+	const channelIdMatch = pathname.match(/\/settings\/channels\/edit\/([^/]+)/);
+	const channelId = channelIdMatch ? channelIdMatch[1] : undefined;
 
 	const { isFetching, isError, data, error } = useQuery<
 		SuccessResponseV2<Channels>,
 		APIError
-	>(['getChannel', id], {
+	>(['getChannel', channelId], {
 		queryFn: () =>
 			get({
-				id,
+				id: channelId || '',
 			}),
+		enabled: !!channelId,
 	});
 
 	if (isError) {
@@ -143,9 +147,6 @@ function ChannelsEdit(): JSX.Element {
 			/>
 		</div>
 	);
-}
-interface Params {
-	id: string;
 }
 
 export default ChannelsEdit;

--- a/frontend/src/pages/Settings/Settings.tsx
+++ b/frontend/src/pages/Settings/Settings.tsx
@@ -217,6 +217,13 @@ function SettingsPage(): JSX.Element {
 			return true;
 		}
 
+		if (
+			pathname.startsWith(ROUTES.CHANNELS_EDIT) &&
+			key === ROUTES.ALL_CHANNELS
+		) {
+			return true;
+		}
+
 		return pathname === key;
 	};
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Extract `channelId` from URL pathname for alert channels and update related routes and styles.
> 
>   - **Behavior**:
>     - Extract `channelId` from URL pathname in `ChannelsEdit` instead of using `useParams`.
>     - Update `onClickEditHandler` in `AlertChannels.tsx` to use `channelId`.
>     - Change `history.replace` in `FormAlertChannels` to navigate to `ROUTES.ALL_CHANNELS`.
>   - **Routes**:
>     - Remove `EditAlertChannelsAlerts` route from `routes.ts`.
>     - Update `ROUTES.CHANNELS_EDIT` to use `:channelId` in `routes.ts`.
>   - **Styles**:
>     - Adjust padding in `.ant-tabs-content-holder` in `AlertList.styles.scss`.
>     - Modify margin and padding in `.edit-alert-channels-container` in `ChannelsEdit.styles.scss`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 00ec4d7839347eb4ec6d04dc28111b637024f3b7. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->