### PR TITLE
fix: update app layout height based on banners visible

### DIFF
--- a/frontend/src/container/AppLayout/AppLayout.styles.scss
+++ b/frontend/src/container/AppLayout/AppLayout.styles.scss
@@ -1,7 +1,33 @@
+.app-banner-container {
+	position: relative;
+	width: 100%;
+}
+
 .app-layout {
 	position: relative;
 	height: 100%;
 	width: 100%;
+
+	&.isWorkspaceRestricted {
+		height: calc(100% - 32px);
+
+		// same styles as its either trial expired or payment failed
+		&.isTrialExpired {
+			height: calc(100% - 64px);
+		}
+
+		&.isPaymentFailed {
+			height: calc(100% - 64px);
+		}
+	}
+
+	&.isTrialExpired {
+		height: calc(100% - 32px);
+	}
+
+	&.isPaymentFailed {
+		height: calc(100% - 32px);
+	}
 
 	.app-content {
 		width: calc(100% - 64px); // width of the sidebar
@@ -162,4 +188,10 @@
 		text-decoration-thickness: 2px;
 		text-underline-offset: 2px;
 	}
+}
+
+.workspace-restricted-banner,
+.trial-expiry-banner,
+.payment-failed-banner {
+	height: 32px;
 }

--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -563,52 +563,54 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 				<title>{pageTitle}</title>
 			</Helmet>
 
-			<div className={cx('app-banner-container')}>
-				{SHOW_TRIAL_EXPIRY_BANNER && (
-					<div className="trial-expiry-banner">
-						You are in free trial period. Your free trial will end on{' '}
-						<span>{getFormattedDate(trialInfo?.trialEnd || Date.now())}.</span>
-						{user.role === USER_ROLES.ADMIN ? (
-							<span>
-								{' '}
-								Please{' '}
-								<a className="upgrade-link" onClick={handleUpgrade}>
-									upgrade
-								</a>
-								to continue using SigNoz features.
-							</span>
-						) : (
-							'Please contact your administrator for upgrading to a paid plan.'
-						)}
-					</div>
-				)}
-
-				{SHOW_WORKSPACE_RESTRICTED_BANNER && renderWorkspaceRestrictedBanner()}
-
-				{SHOW_PAYMENT_FAILED_BANNER && (
-					<div className="payment-failed-banner">
-						Your bill payment has failed. Your workspace will get suspended on{' '}
-						<span>
-							{getFormattedDateWithMinutes(
-								dayjs(activeLicense?.event_queue?.scheduled_at).unix() || Date.now(),
+			{isLoggedIn && (
+				<div className={cx('app-banner-container')}>
+					{SHOW_TRIAL_EXPIRY_BANNER && (
+						<div className="trial-expiry-banner">
+							You are in free trial period. Your free trial will end on{' '}
+							<span>{getFormattedDate(trialInfo?.trialEnd || Date.now())}.</span>
+							{user.role === USER_ROLES.ADMIN ? (
+								<span>
+									{' '}
+									Please{' '}
+									<a className="upgrade-link" onClick={handleUpgrade}>
+										upgrade
+									</a>
+									to continue using SigNoz features.
+								</span>
+							) : (
+								'Please contact your administrator for upgrading to a paid plan.'
 							)}
-							.
-						</span>
-						{user.role === USER_ROLES.ADMIN ? (
+						</div>
+					)}
+
+					{SHOW_WORKSPACE_RESTRICTED_BANNER && renderWorkspaceRestrictedBanner()}
+
+					{SHOW_PAYMENT_FAILED_BANNER && (
+						<div className="payment-failed-banner">
+							Your bill payment has failed. Your workspace will get suspended on{' '}
 							<span>
-								{' '}
-								Please{' '}
-								<a className="upgrade-link" onClick={handleFailedPayment}>
-									pay the bill
-								</a>
-								to continue using SigNoz features.
+								{getFormattedDateWithMinutes(
+									dayjs(activeLicense?.event_queue?.scheduled_at).unix() || Date.now(),
+								)}
+								.
 							</span>
-						) : (
-							' Please contact your administrator to pay the bill.'
-						)}
-					</div>
-				)}
-			</div>
+							{user.role === USER_ROLES.ADMIN ? (
+								<span>
+									{' '}
+									Please{' '}
+									<a className="upgrade-link" onClick={handleFailedPayment}>
+										pay the bill
+									</a>
+									to continue using SigNoz features.
+								</span>
+							) : (
+								' Please contact your administrator to pay the bill.'
+							)}
+						</div>
+					)}
+				</div>
+			)}
 
 			<Flex
 				className={cx(

--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -551,62 +551,73 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 		(preference) => preference.name === USER_PREFERENCES.SIDENAV_PINNED,
 	)?.value as boolean;
 
+	const SHOW_TRIAL_EXPIRY_BANNER =
+		showTrialExpiryBanner && !showPaymentFailedWarning;
+	const SHOW_WORKSPACE_RESTRICTED_BANNER = showWorkspaceRestricted;
+	const SHOW_PAYMENT_FAILED_BANNER =
+		!showTrialExpiryBanner && showPaymentFailedWarning;
+
 	return (
 		<Layout className={cx(isDarkMode ? 'darkMode dark' : 'lightMode')}>
 			<Helmet>
 				<title>{pageTitle}</title>
 			</Helmet>
 
-			{showTrialExpiryBanner && !showPaymentFailedWarning && (
-				<div className="trial-expiry-banner">
-					You are in free trial period. Your free trial will end on{' '}
-					<span>{getFormattedDate(trialInfo?.trialEnd || Date.now())}.</span>
-					{user.role === USER_ROLES.ADMIN ? (
-						<span>
-							{' '}
-							Please{' '}
-							<a className="upgrade-link" onClick={handleUpgrade}>
-								upgrade
-							</a>
-							to continue using SigNoz features.
-						</span>
-					) : (
-						'Please contact your administrator for upgrading to a paid plan.'
-					)}
-				</div>
-			)}
-
-			{showWorkspaceRestricted && renderWorkspaceRestrictedBanner()}
-
-			{!showTrialExpiryBanner && showPaymentFailedWarning && (
-				<div className="payment-failed-banner">
-					Your bill payment has failed. Your workspace will get suspended on{' '}
-					<span>
-						{getFormattedDateWithMinutes(
-							dayjs(activeLicense?.event_queue?.scheduled_at).unix() || Date.now(),
+			<div className={cx('app-banner-container')}>
+				{SHOW_TRIAL_EXPIRY_BANNER && (
+					<div className="trial-expiry-banner">
+						You are in free trial period. Your free trial will end on{' '}
+						<span>{getFormattedDate(trialInfo?.trialEnd || Date.now())}.</span>
+						{user.role === USER_ROLES.ADMIN ? (
+							<span>
+								{' '}
+								Please{' '}
+								<a className="upgrade-link" onClick={handleUpgrade}>
+									upgrade
+								</a>
+								to continue using SigNoz features.
+							</span>
+						) : (
+							'Please contact your administrator for upgrading to a paid plan.'
 						)}
-						.
-					</span>
-					{user.role === USER_ROLES.ADMIN ? (
+					</div>
+				)}
+
+				{SHOW_WORKSPACE_RESTRICTED_BANNER && renderWorkspaceRestrictedBanner()}
+
+				{SHOW_PAYMENT_FAILED_BANNER && (
+					<div className="payment-failed-banner">
+						Your bill payment has failed. Your workspace will get suspended on{' '}
 						<span>
-							{' '}
-							Please{' '}
-							<a className="upgrade-link" onClick={handleFailedPayment}>
-								pay the bill
-							</a>
-							to continue using SigNoz features.
+							{getFormattedDateWithMinutes(
+								dayjs(activeLicense?.event_queue?.scheduled_at).unix() || Date.now(),
+							)}
+							.
 						</span>
-					) : (
-						' Please contact your administrator to pay the bill.'
-					)}
-				</div>
-			)}
+						{user.role === USER_ROLES.ADMIN ? (
+							<span>
+								{' '}
+								Please{' '}
+								<a className="upgrade-link" onClick={handleFailedPayment}>
+									pay the bill
+								</a>
+								to continue using SigNoz features.
+							</span>
+						) : (
+							' Please contact your administrator to pay the bill.'
+						)}
+					</div>
+				)}
+			</div>
 
 			<Flex
 				className={cx(
 					'app-layout',
 					isDarkMode ? 'darkMode dark' : 'lightMode',
 					sideNavPinned ? 'side-nav-pinned' : '',
+					SHOW_WORKSPACE_RESTRICTED_BANNER ? 'isWorkspaceRestricted' : '',
+					SHOW_TRIAL_EXPIRY_BANNER ? 'isTrialExpired' : '',
+					SHOW_PAYMENT_FAILED_BANNER ? 'isPaymentFailed' : '',
 				)}
 			>
 				{isToDisplayLayout && !renderFullScreen && (


### PR DESCRIPTION
<img width="1920" alt="Screenshot 2025-06-20 at 01 12 49" src="https://github.com/user-attachments/assets/9eacf1b3-bf1c-4fa8-9a01-69b68cd51d92" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjusts `AppLayout` height based on visibility of workspace, trial expiry, and payment failed banners, updating both styles and logic.
> 
>   - **Behavior**:
>     - Adjusts `app-layout` height in `AppLayout.styles.scss` based on banner visibility: `isWorkspaceRestricted`, `isTrialExpired`, `isPaymentFailed`.
>     - Adds `.app-banner-container` to wrap banners.
>     - Sets banner height to 32px for `workspace-restricted-banner`, `trial-expiry-banner`, `payment-failed-banner`.
>   - **Logic**:
>     - In `index.tsx`, defines constants `SHOW_TRIAL_EXPIRY_BANNER`, `SHOW_WORKSPACE_RESTRICTED_BANNER`, `SHOW_PAYMENT_FAILED_BANNER` to control banner visibility.
>     - Updates `AppLayout` component to conditionally render banners and adjust layout classes accordingly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 3f4be2f5767e85bd2147721bc0719dc45e1faff9. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->