### PR TITLE
fix: remove deprecated telemetry::metrics::address from config

### DIFF
--- a/deploy/docker-swarm/otel-collector-config.yaml
+++ b/deploy/docker-swarm/otel-collector-config.yaml
@@ -80,7 +80,6 @@ service:
     logs:
       encoding: json
     metrics:
-      address: 0.0.0.0:8888
   extensions:
     - health_check
     - pprof

--- a/deploy/docker-swarm/otel-collector-config.yaml
+++ b/deploy/docker-swarm/otel-collector-config.yaml
@@ -74,12 +74,10 @@ exporters:
     dsn: tcp://clickhouse:9000/signoz_logs
     timeout: 10s
     use_new_schema: true
-  # debug: {}
 service:
   telemetry:
     logs:
       encoding: json
-    metrics:
   extensions:
     - health_check
     - pprof

--- a/deploy/docker/otel-collector-config.yaml
+++ b/deploy/docker/otel-collector-config.yaml
@@ -80,7 +80,6 @@ service:
     logs:
       encoding: json
     metrics:
-      address: 0.0.0.0:8888
   extensions:
     - health_check
     - pprof

--- a/deploy/docker/otel-collector-config.yaml
+++ b/deploy/docker/otel-collector-config.yaml
@@ -74,12 +74,10 @@ exporters:
     dsn: tcp://clickhouse:9000/signoz_logs
     timeout: 10s
     use_new_schema: true
-  # debug: {}
 service:
   telemetry:
     logs:
       encoding: json
-    metrics:
   extensions:
     - health_check
     - pprof


### PR DESCRIPTION
## 📄 Summary

Leaving the config to default so it won't change the metric names. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove deprecated `address` field from `metrics` configuration in `otel-collector-config.yaml` to use default settings.
> 
>   - **Configuration Changes**:
>     - Remove deprecated `address` field from `metrics` in `otel-collector-config.yaml` in `deploy/docker-swarm` and `deploy/docker`.
>     - Defaults are now used for `metrics` configuration to avoid changing metric names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 237de61a9e93a04cdfbfd7c21db8e6586b4f7001. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->