### PR TITLE
fix: fixed the route match dropping the query search param after ?

### DIFF
--- a/frontend/src/components/RouteTab/index.tsx
+++ b/frontend/src/components/RouteTab/index.tsx
@@ -29,13 +29,23 @@ function RouteTab({
 
 	// Find the matching route for the current pathname
 	const currentRoute = routesWithParams.find((route) => {
-		const pathnameOnly = route.route.split('?')[0];
-		const routePattern = escapeRegExp(pathnameOnly).replace(
+		const [routePathname, routeQueryString = ''] = route.route.split('?');
+
+		const routePattern = escapeRegExp(routePathname).replace(
 			/\\:([a-zA-Z0-9_]+)/g,
 			'([^/]+)',
 		);
 		const regex = new RegExp(`^${routePattern}$`);
-		return regex.test(location.pathname);
+
+		const routeParams = new URLSearchParams(routeQueryString);
+		const locationParams = new URLSearchParams(location.search);
+
+		return (
+			regex.test(location.pathname) &&
+			Array.from(routeParams.entries()).every(
+				([key, value]) => locationParams.get(key) === value,
+			)
+		);
 	});
 
 	const onChange = (activeRoute: string): void => {


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes query parameter handling in `RouteTab` component by comparing both pathname and query string with current location.
> 
>   - **Bug Fix**:
>     - Fixes query parameter handling in `RouteTab` component in `index.tsx`.
>     - Splits route into pathname and query string, compares both with current location.
>     - Uses `URLSearchParams` to ensure query parameters match between route and location.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e69d054c4109e1fbd292483168e8bd2326390a0f. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->