### PR TITLE
chore: fix the route tab regex error

### DIFF
--- a/frontend/src/components/RouteTab/index.tsx
+++ b/frontend/src/components/RouteTab/index.tsx
@@ -29,13 +29,19 @@ function RouteTab({
 
 	// Find the matching route for the current pathname
 	const currentRoute = routesWithParams.find((route) => {
-		const pathnameOnly = route.route.split('?')[0];
-		const routePattern = escapeRegExp(pathnameOnly).replace(
-			/\\:([a-zA-Z0-9_]+)/g,
-			'([^/]+)',
-		);
-		const regex = new RegExp(`^${routePattern}$`);
-		return regex.test(location.pathname);
+		try {
+			const routePattern = route.route.replace(/:(\w+)/g, '([^/]+)');
+			const regex = new RegExp(`^${routePattern}$`);
+			return regex.test(location.pathname);
+		} catch (error) {
+			const pathnameOnly = route.route.split('?')[0];
+			const routePattern = escapeRegExp(pathnameOnly).replace(
+				/\\:([a-zA-Z0-9_]+)/g,
+				'([^/]+)',
+			);
+			const regex = new RegExp(`^${routePattern}$`);
+			return regex.test(location.pathname);
+		}
 	});
 
 	const onChange = (activeRoute: string): void => {


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

- Caused as an regression by https://github.com/SigNoz/signoz/pull/8393
- The original fix was made to fix errors caused by large query strings in alerts, but that fix didn't work with nested route tabs
- So I reverted back to the original routing logic. Whenever that fails for large query strings by throwing a regex error, we catch that and use the updated logic.
- That should cover all our cases

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes route tab regex error by reverting to original logic with a fallback for large query strings in `RouteTab`.
> 
>   - **Behavior**:
>     - Reverts to original routing logic in `RouteTab` component for handling route tabs.
>     - Adds a try-catch block to handle regex errors for large query strings by using updated logic as a fallback.
>   - **Files**:
>     - Modifies `index.tsx` in `RouteTab` to implement the above changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for aaaad8e0a2b92edc08491a8c150ce59521e098b8. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->