### PR TITLE
Revert "fix: fix the regex matching logic in RouteTab"

### DIFF
--- a/frontend/src/components/RouteTab/index.tsx
+++ b/frontend/src/components/RouteTab/index.tsx
@@ -1,5 +1,4 @@
 import { Tabs, TabsProps } from 'antd';
-import { escapeRegExp } from 'lodash-es';
 import { useLocation, useParams } from 'react-router-dom';
 
 import { RouteTabProps } from './types';
@@ -29,11 +28,7 @@ function RouteTab({
 
 	// Find the matching route for the current pathname
 	const currentRoute = routesWithParams.find((route) => {
-		const pathnameOnly = route.route.split('?')[0];
-		const routePattern = escapeRegExp(pathnameOnly).replace(
-			/\\:([a-zA-Z0-9_]+)/g,
-			'([^/]+)',
-		);
+		const routePattern = route.route.replace(/:(\w+)/g, '([^/]+)');
 		const regex = new RegExp(`^${routePattern}$`);
 		return regex.test(location.pathname);
 	});


### PR DESCRIPTION
Reverts SigNoz/signoz#8393

Relevant slack thread - https://signoz-team.slack.com/archives/C02TJ466H8U/p1751485996607799
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts regex logic in `RouteTab` to previous implementation, removing `escapeRegExp` usage.
> 
>   - **Revert Changes**:
>     - Reverts regex logic in `RouteTab` in `index.tsx` to previous implementation.
>     - Removes `escapeRegExp` usage and restores original regex pattern `/:(\w+)/g` for route matching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 397462879a795fb3e0bb17992bfa837785eef775. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->