### PR TITLE
fix: no logs in list view issue - added logs datasource for formatting and column options in the useoptionsmenu consumption

### DIFF
--- a/frontend/src/components/LogDetail/index.tsx
+++ b/frontend/src/components/LogDetail/index.tsx
@@ -71,7 +71,7 @@ function LogDetail({
 	const [contextQuery, setContextQuery] = useState<Query | undefined>();
 	const [filters, setFilters] = useState<TagFilter | null>(null);
 	const [isEdit, setIsEdit] = useState<boolean>(false);
-	const { initialDataSource, stagedQuery } = useQueryBuilder();
+	const { stagedQuery } = useQueryBuilder();
 
 	const listQuery = useMemo(() => {
 		if (!stagedQuery || stagedQuery.builder.queryData.length < 1) return null;
@@ -81,7 +81,7 @@ function LogDetail({
 
 	const { options } = useOptionsMenu({
 		storageKey: LOCALSTORAGE.LOGS_LIST_OPTIONS,
-		dataSource: initialDataSource || DataSource.LOGS,
+		dataSource: DataSource.LOGS,
 		aggregateOperator: listQuery?.aggregateOperator || StringOperators.NOOP,
 	});
 

--- a/frontend/src/container/LogDetailedView/ContextView/ContextLogRenderer.tsx
+++ b/frontend/src/container/LogDetailedView/ContextView/ContextLogRenderer.tsx
@@ -42,7 +42,7 @@ function ContextLogRenderer({
 
 	const { options } = useOptionsMenu({
 		storageKey: LOCALSTORAGE.LOGS_LIST_OPTIONS,
-		dataSource: DataSource.METRICS,
+		dataSource: DataSource.LOGS,
 		aggregateOperator: listQuery?.aggregateOperator || StringOperators.NOOP,
 	});
 

--- a/frontend/src/container/LogDetailedView/ContextView/ContextLogRenderer.tsx
+++ b/frontend/src/container/LogDetailedView/ContextView/ContextLogRenderer.tsx
@@ -32,7 +32,7 @@ function ContextLogRenderer({
 	const [afterLogPage, setAfterLogPage] = useState<number>(1);
 	const [logs, setLogs] = useState<ILog[]>([log]);
 
-	const { initialDataSource, stagedQuery } = useQueryBuilder();
+	const { stagedQuery } = useQueryBuilder();
 
 	const listQuery = useMemo(() => {
 		if (!stagedQuery || stagedQuery.builder.queryData.length < 1) return null;
@@ -42,7 +42,7 @@ function ContextLogRenderer({
 
 	const { options } = useOptionsMenu({
 		storageKey: LOCALSTORAGE.LOGS_LIST_OPTIONS,
-		dataSource: initialDataSource || DataSource.METRICS,
+		dataSource: DataSource.METRICS,
 		aggregateOperator: listQuery?.aggregateOperator || StringOperators.NOOP,
 	});
 

--- a/frontend/src/container/LogsExplorerList/index.tsx
+++ b/frontend/src/container/LogsExplorerList/index.tsx
@@ -48,7 +48,6 @@ function LogsExplorerList({
 	isFilterApplied,
 }: LogsExplorerListProps): JSX.Element {
 	const ref = useRef<VirtuosoHandle>(null);
-	const { initialDataSource } = useQueryBuilder();
 
 	const { activeLogId } = useCopyLogLink();
 
@@ -62,7 +61,7 @@ function LogsExplorerList({
 
 	const { options } = useOptionsMenu({
 		storageKey: LOCALSTORAGE.LOGS_LIST_OPTIONS,
-		dataSource: initialDataSource || DataSource.METRICS,
+		dataSource: DataSource.LOGS,
 		aggregateOperator:
 			currentStagedQueryData?.aggregateOperator || StringOperators.NOOP,
 	});


### PR DESCRIPTION
**Issue: Inconsistent Trace Column Display in Logs Due to Query Builder Data Source Flickering**

**Description:**
A race condition occurs when the data source within the query builder flickers, leading to the options menu incorrectly populating trace-related columns in the logs view. The existing preferences framework, which relies on `LOGS_LIST_OPTIONS` in local storage or query parameters, prevents recalculation and re-fetching of column definitions once they are initially present. This behaviour results in a persistent display of trace columns in the logs, even when not intended, causing an inconsistent user experience.

**Root Cause:**
The `LOGS_LIST_OPTIONS` key, once populated in local storage or URL query parameters with trace columns, prevents subsequent re-calculation of log columns. This interaction creates a race condition where an intermittently flickering data source can "trickle down" incorrect column configurations into the persistent preferences, leading to the erroneous display of trace columns.

**Resolution:**
To mitigate this race condition, the data source consumption within the `useOptionsMenu` hook has been temporarily defaulted to `DataSource.LOGS`. This prevents the flickering data source from influencing the preferences framework and ensures that log columns are calculated based on the correct data source context.

**Monitoring Plan:**
We will continue to monitor the bug's behaviour to determine if it manifests in other areas of the application.

**Quick Resolution (If Persistence Observed):**
Should the issue persist for end-users, the following steps can be taken as a quick workaround:
1.  Clear all query parameters from the URL.
2.  Delete the local storage key named `LOGS_LIST_OPTIONS`.
3.  Perform a hard refresh of the page.
4. Alternatively user can manually add the missing (time and body) columns from the options menu and delete any non related columns.


## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Standardize `dataSource` to `DataSource.LOGS` in `useOptionsMenu` across multiple components.
> 
>   - **Data Source Changes**:
>     - Remove `initialDataSource` and set `dataSource` to `DataSource.LOGS` in `useOptionsMenu` in `LogDetail/index.tsx`, `ContextLogRenderer.tsx`, and `LogsExplorerList/index.tsx`.
>   - **Misc**:
>     - Remove unused `initialDataSource` variable in `LogsExplorerList/index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 30dd4e588fa80f5a3e5be316b71fe17d3e4a60f9. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->