### PR TITLE
fix: update media styling for changelog renderer and adjust video class

### DIFF
--- a/frontend/src/components/ChangelogModal/components/ChangelogRenderer.styles.scss
+++ b/frontend/src/components/ChangelogModal/components/ChangelogRenderer.styles.scss
@@ -101,12 +101,17 @@
 		line-height: 28px;
 	}
 
-	.changelog-media-image {
+	.changelog-media-image,
+	.changelog-media-video {
 		height: auto;
 		width: 100%;
 		overflow: hidden;
 		border-radius: 4px;
 		border: 1px solid var(--bg-slate-400, #1d212d);
+	}
+
+	.changelog-media-video {
+		margin: 12px 0;
 	}
 }
 

--- a/frontend/src/components/ChangelogModal/components/ChangelogRenderer.tsx
+++ b/frontend/src/components/ChangelogModal/components/ChangelogRenderer.tsx
@@ -32,7 +32,7 @@ function renderMedia(media: Media): JSX.Element | null {
 				controls
 				controlsList="nodownload noplaybackrate"
 				loop
-				className="my-3 h-auto w-full rounded"
+				className="changelog-media-video"
 			>
 				<source src={media.url} type={media.mime} />
 				<track kind="captions" src="" label="No captions available" default />
@@ -56,7 +56,7 @@ function ChangelogRenderer({ changelog }: Props): JSX.Element {
 			</div>
 			<span className="changelog-release-date">{formattedReleaseDate}</span>
 			{changelog.features && changelog.features.length > 0 && (
-				<div className="changelog-renderer-list flex flex-col gap-7">
+				<div className="changelog-renderer-list">
 					{changelog.features.map((feature) => (
 						<div key={feature.id}>
 							<h2>{feature.title}</h2>


### PR DESCRIPTION
## 📄 Summary

fix: video component is overflowing, added a style fix for that
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix video overflow in changelog renderer by updating `.changelog-media-video` styling and usage.
> 
>   - **Styling**:
>     - Add `.changelog-media-video` class to `ChangelogRenderer.styles.scss` for consistent video styling.
>     - Set `margin: 12px 0` for `.changelog-media-video` to prevent overflow.
>   - **Component Update**:
>     - Update `renderMedia()` in `ChangelogRenderer.tsx` to use `changelog-media-video` class for video elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 9be0b82202f3c0dd76ae7450f4f474790da52f51. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->