### PR TITLE
fix(statsreporter): add unix timestamps for last observed time

### DIFF
--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -220,6 +220,7 @@ func (provider *provider) collectOrg(ctx context.Context, orgID valuer.UUID) map
 	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT max(timestamp) FROM signoz_traces.distributed_signoz_index_v3").Scan(&tracesLastSeenAt); err == nil {
 		if tracesLastSeenAt.Unix() != 0 {
 			stats["telemetry.traces.last_observed.time"] = tracesLastSeenAt.UTC()
+			stats["telemetry.traces.last_observed.time_unix"] = tracesLastSeenAt.Unix()
 		}
 	}
 
@@ -227,6 +228,7 @@ func (provider *provider) collectOrg(ctx context.Context, orgID valuer.UUID) map
 	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT fromUnixTimestamp64Nano(max(timestamp)) FROM signoz_logs.distributed_logs_v2").Scan(&logsLastSeenAt); err == nil {
 		if logsLastSeenAt.Unix() != 0 {
 			stats["telemetry.logs.last_observed.time"] = logsLastSeenAt.UTC()
+			stats["telemetry.logs.last_observed.time_unix"] = logsLastSeenAt.Unix()
 		}
 	}
 
@@ -234,6 +236,7 @@ func (provider *provider) collectOrg(ctx context.Context, orgID valuer.UUID) map
 	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT toDateTime(max(unix_milli) / 1000) FROM signoz_metrics.distributed_samples_v4").Scan(&metricsLastSeenAt); err == nil {
 		if metricsLastSeenAt.Unix() != 0 {
 			stats["telemetry.metrics.last_observed.time"] = metricsLastSeenAt.UTC()
+			stats["telemetry.metrics.last_observed.time_unix"] = metricsLastSeenAt.Unix()
 		}
 	}
 


### PR DESCRIPTION
## 📄 Summary

add unix timestamps for last observed time
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Unix timestamps for last observed time of traces, logs, and metrics in `collectOrg()` in `provider.go`.
> 
>   - **Behavior**:
>     - Adds Unix timestamps for last observed time of traces, logs, and metrics in `collectOrg()` in `provider.go`.
>     - Updates `stats` map with `telemetry.traces.last_observed.time_unix`, `telemetry.logs.last_observed.time_unix`, and `telemetry.metrics.last_observed.time_unix` keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for d39e656418ffd921141611f1a49f2b6db70f13d7. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->