### PR TITLE
fix: simplify changelog fetching logic and enhance version display interactivity

### DIFF
--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -63,7 +63,6 @@ import {
 } from 'types/api/licensesV3/getActive';
 import AppReducer from 'types/reducer/app';
 import { USER_ROLES } from 'types/roles';
-import { checkVersionState } from 'utils/app';
 import { eventEmitter } from 'utils/getEventEmitter';
 import {
 	getFormattedDate,
@@ -98,15 +97,10 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 
 	const [showSlowApiWarning, setShowSlowApiWarning] = useState(false);
 	const [slowApiWarningShown, setSlowApiWarningShown] = useState(false);
-	const [shouldFetchChangelog, setShouldFetchChangelog] = useState<boolean>(
-		false,
-	);
 
-	const { currentVersion, latestVersion } = useSelector<AppState, AppReducer>(
+	const { latestVersion } = useSelector<AppState, AppReducer>(
 		(state) => state.app,
 	);
-
-	const isLatestVersion = checkVersionState(currentVersion, latestVersion);
 
 	const handleBillingOnSuccess = (
 		data: SuccessResponseV2<CheckoutSuccessPayloadProps>,
@@ -163,7 +157,7 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 			queryFn: (): Promise<SuccessResponse<ChangelogSchema> | ErrorResponse> =>
 				getChangelogByVersion(latestVersion),
 			queryKey: ['getChangelogByVersion', latestVersion],
-			enabled: isLoggedIn && !isCloudUserVal && shouldFetchChangelog,
+			enabled: isLoggedIn && !isCloudUserVal && Boolean(latestVersion),
 		},
 	]);
 
@@ -223,7 +217,7 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 
 		if (
 			getUserVersionResponse.isFetched &&
-			getUserLatestVersionResponse.isSuccess &&
+			getUserVersionResponse.isSuccess &&
 			getUserVersionResponse.data &&
 			getUserVersionResponse.data.payload
 		) {
@@ -261,17 +255,12 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 		getUserVersionResponse.isLoading,
 		getUserVersionResponse.isError,
 		getUserVersionResponse.data,
+		getUserVersionResponse.isSuccess,
 		getUserLatestVersionResponse.isFetched,
 		getUserVersionResponse.isFetched,
 		getUserLatestVersionResponse.isSuccess,
 		notifications,
 	]);
-
-	useEffect(() => {
-		if (!isLatestVersion) {
-			setShouldFetchChangelog(true);
-		}
-	}, [isLatestVersion]);
 
 	useEffect(() => {
 		if (

--- a/frontend/src/container/SideNav/SideNav.styles.scss
+++ b/frontend/src/container/SideNav/SideNav.styles.scss
@@ -112,14 +112,15 @@
 				font-weight: 500;
 				line-height: 14px; /* 140% */
 				letter-spacing: 0.4px;
-
-				cursor: pointer;
-
 				max-width: 60px;
 
 				overflow: hidden;
 				text-overflow: ellipsis;
 				white-space: nowrap;
+			}
+
+			.version-clickable {
+				cursor: pointer;
 			}
 
 			.version-update-notification-dot-icon {

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -741,12 +741,12 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 	}, [isCloudUser, isEnterpriseSelfHostedUser]);
 
 	const onClickVersionHandler = useCallback((): void => {
-		if (isCloudUser) {
+		if (isCloudUser || !changelog) {
 			return;
 		}
 
 		setShowChangelogModal(true);
-	}, [isCloudUser]);
+	}, [isCloudUser, changelog]);
 
 	useEffect(() => {
 		if (!isLatestVersion && !isCloudUser) {
@@ -814,7 +814,10 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 											}
 										>
 											<div className="version-container">
-												<span className="version" onClick={onClickVersionHandler}>
+												<span
+													className={cx('version', changelog && 'version-clickable')}
+													onClick={onClickVersionHandler}
+												>
 													{currentVersion}
 												</span>
 


### PR DESCRIPTION
## 📄 Summary

- Fetching changelog even if the user is on the lastest version also
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplify changelog fetching logic and enhance version display interactivity by removing `checkVersionState` and adding `version-clickable` class.
> 
>   - **Behavior**:
>     - Fetch changelog even if user is on latest version by enabling query based on `latestVersion` in `AppLayout/index.tsx`.
>     - Remove `checkVersionState` logic and `shouldFetchChangelog` state in `AppLayout/index.tsx` and `SideNav.tsx`.
>   - **Interactivity**:
>     - Add `version-clickable` class to version span in `SideNav.tsx` for interactive version display.
>     - Update CSS in `SideNav.styles.scss` to support `version-clickable` class.
>   - **Misc**:
>     - Remove unused import of `checkVersionState` in `AppLayout/index.tsx` and `SideNav.tsx`.
>     - Adjust `onClickVersionHandler` in `SideNav.tsx` to check for `changelog` presence.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for bae4cbf0bd6026a15a2794ebcb26c2ab7860c5d5. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->