### PR TITLE
Hide integration tab for Community users

### DIFF
--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -193,6 +193,9 @@ function App(): JSX.Element {
 					updatedRoutes = updatedRoutes.filter(
 						(route) => route?.path !== ROUTES.BILLING,
 					);
+					updatedRoutes = updatedRoutes.filter(
+						(route) => route?.path !== ROUTES.INTEGRATIONS,
+					);
 				}
 
 				if (isEnterpriseSelfHostedUser) {
@@ -205,6 +208,9 @@ function App(): JSX.Element {
 				// if not a cloud user then remove billing and add list licenses route
 				updatedRoutes = updatedRoutes.filter(
 					(route) => route?.path !== ROUTES.BILLING,
+				);
+				updatedRoutes = updatedRoutes.filter(
+					(route) => route?.path !== ROUTES.INTEGRATIONS,
 				);
 				updatedRoutes = [...updatedRoutes, LIST_LICENSES];
 			}

--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -191,10 +191,8 @@ function App(): JSX.Element {
 				// if the user is on basic plan then remove billing
 				if (isOnBasicPlan) {
 					updatedRoutes = updatedRoutes.filter(
-						(route) => route?.path !== ROUTES.BILLING,
-					);
-					updatedRoutes = updatedRoutes.filter(
-						(route) => route?.path !== ROUTES.INTEGRATIONS,
+						(route) =>
+							route?.path !== ROUTES.BILLING && route?.path !== ROUTES.INTEGRATIONS,
 					);
 				}
 
@@ -207,10 +205,8 @@ function App(): JSX.Element {
 			} else {
 				// if not a cloud user then remove billing and add list licenses route
 				updatedRoutes = updatedRoutes.filter(
-					(route) => route?.path !== ROUTES.BILLING,
-				);
-				updatedRoutes = updatedRoutes.filter(
-					(route) => route?.path !== ROUTES.INTEGRATIONS,
+					(route) =>
+						route?.path !== ROUTES.BILLING && route?.path !== ROUTES.INTEGRATIONS,
 				);
 				updatedRoutes = [...updatedRoutes, LIST_LICENSES];
 			}

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -195,10 +195,24 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 		};
 	}, [checkScroll]);
 
+	const {
+		isCloudUser,
+		isEnterpriseSelfHostedUser,
+		isCommunityUser,
+		isCommunityEnterpriseUser,
+	} = useGetTenantLicense();
+
+	const [licenseTag, setLicenseTag] = useState('');
+	const isAdmin = user.role === USER_ROLES.ADMIN;
+	const isEditor = user.role === USER_ROLES.EDITOR;
+
 	useEffect(() => {
 		const navShortcuts = (userPreferences?.find(
 			(preference) => preference.name === USER_PREFERENCES.NAV_SHORTCUTS,
 		)?.value as unknown) as string[];
+
+		const shouldShowIntegrations =
+			(isCloudUser || isEnterpriseSelfHostedUser) && (isAdmin || isEditor);
 
 		if (navShortcuts && isArray(navShortcuts) && navShortcuts.length > 0) {
 			// nav shortcuts is array of strings
@@ -211,11 +225,14 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 			// Set pinned items in the order they were stored
 			setPinnedMenuItems(pinnedItems);
 
-			// Set secondary items with proper isPinned state
 			setSecondaryMenuItems(
 				defaultMoreMenuItems.map((item) => ({
 					...item,
 					isPinned: pinnedItems.some((pinned) => pinned.itemKey === item.itemKey),
+					isEnabled:
+						item.key === ROUTES.INTEGRATIONS
+							? shouldShowIntegrations
+							: item.isEnabled,
 				})),
 			);
 		} else {
@@ -225,17 +242,26 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 			);
 			setPinnedMenuItems(defaultPinnedItems);
 
-			// Set secondary items with proper isPinned state
 			setSecondaryMenuItems(
 				defaultMoreMenuItems.map((item) => ({
 					...item,
 					isPinned: defaultPinnedItems.some(
 						(pinned) => pinned.itemKey === item.itemKey,
 					),
+					isEnabled:
+						item.key === ROUTES.INTEGRATIONS
+							? shouldShowIntegrations
+							: item.isEnabled,
 				})),
 			);
 		}
-	}, [userPreferences]);
+	}, [
+		userPreferences,
+		isCloudUser,
+		isEnterpriseSelfHostedUser,
+		isAdmin,
+		isEditor,
+	]);
 
 	const isOnboardingV3Enabled = featureFlags?.find(
 		(flag) => flag.name === FeatureKeys.ONBOARDING_V3,
@@ -248,10 +274,6 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 	const isPremiumSupportEnabled = featureFlags?.find(
 		(flag) => flag.name === FeatureKeys.PREMIUM_SUPPORT,
 	)?.active;
-
-	const [licenseTag, setLicenseTag] = useState('');
-	const isAdmin = user.role === USER_ROLES.ADMIN;
-	const isEditor = user.role === USER_ROLES.EDITOR;
 
 	const userSettingsMenuItem = {
 		key: ROUTES.SETTINGS,
@@ -374,13 +396,6 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 	}, [isReorderShortcutNavItemsModalOpen, pinnedMenuItems]);
 
 	const { registerShortcut, deregisterShortcut } = useKeyboardHotkeys();
-
-	const {
-		isCloudUser,
-		isEnterpriseSelfHostedUser,
-		isCommunityUser,
-		isCommunityEnterpriseUser,
-	} = useGetTenantLicense();
 
 	const isWorkspaceBlocked = trialInfo?.workSpaceBlock || false;
 
@@ -717,28 +732,6 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 			default:
 		}
 	};
-
-	useEffect(() => {
-		if ((isCloudUser || isEnterpriseSelfHostedUser) && (isAdmin || isEditor)) {
-			// enable integrations for cloud users
-			setSecondaryMenuItems((prevItems) =>
-				prevItems.map((item) => ({
-					...item,
-					isEnabled: item.key === ROUTES.INTEGRATIONS ? true : item.isEnabled,
-				})),
-			);
-
-			// enable integrations for pinned menu items
-			// eslint-disable-next-line sonarjs/no-identical-functions
-			setPinnedMenuItems((prevItems) =>
-				prevItems.map((item) => ({
-					...item,
-					isEnabled: item.key === ROUTES.INTEGRATIONS ? true : item.isEnabled,
-				})),
-			);
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isCloudUser, isEnterpriseSelfHostedUser]);
 
 	const onClickVersionHandler = useCallback((): void => {
 		if (isCloudUser) {

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -220,6 +220,7 @@ func (provider *provider) collectOrg(ctx context.Context, orgID valuer.UUID) map
 	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT max(timestamp) FROM signoz_traces.distributed_signoz_index_v3").Scan(&tracesLastSeenAt); err == nil {
 		if tracesLastSeenAt.Unix() != 0 {
 			stats["telemetry.traces.last_observed.time"] = tracesLastSeenAt.UTC()
+			stats["telemetry.traces.last_observed.time_unix"] = tracesLastSeenAt.Unix()
 		}
 	}
 
@@ -227,6 +228,7 @@ func (provider *provider) collectOrg(ctx context.Context, orgID valuer.UUID) map
 	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT fromUnixTimestamp64Nano(max(timestamp)) FROM signoz_logs.distributed_logs_v2").Scan(&logsLastSeenAt); err == nil {
 		if logsLastSeenAt.Unix() != 0 {
 			stats["telemetry.logs.last_observed.time"] = logsLastSeenAt.UTC()
+			stats["telemetry.logs.last_observed.time_unix"] = logsLastSeenAt.Unix()
 		}
 	}
 
@@ -234,6 +236,7 @@ func (provider *provider) collectOrg(ctx context.Context, orgID valuer.UUID) map
 	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT toDateTime(max(unix_milli) / 1000) FROM signoz_metrics.distributed_samples_v4").Scan(&metricsLastSeenAt); err == nil {
 		if metricsLastSeenAt.Unix() != 0 {
 			stats["telemetry.metrics.last_observed.time"] = metricsLastSeenAt.UTC()
+			stats["telemetry.metrics.last_observed.time_unix"] = metricsLastSeenAt.Unix()
 		}
 	}
 


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

Moved setting secondaryItems and pinnedItems into single useEffect to prevent race condition and conflicting setting logic .

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Hide integration tab for non-cloud and non-enterprise users and consolidate menu item setting logic.
> 
>   - **Behavior**:
>     - Hide `INTEGRATIONS` route in `App()` in `index.tsx` for non-cloud and non-enterprise users.
>     - Hide `INTEGRATIONS` menu item in `SideNav()` in `SideNav.tsx` for non-cloud and non-enterprise users who are not admins or editors.
>   - **Logic**:
>     - Consolidate setting of `secondaryMenuItems` and `pinnedMenuItems` in a single `useEffect` in `SideNav.tsx` to prevent race conditions.
>   - **Misc**:
>     - Remove redundant `useEffect` for enabling integrations in `SideNav.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 39bf153fd38e9f703b31db1d377cf45c965e3a5f. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->