### PR TITLE
chore: disabled logs histogram for table view

### DIFF
--- a/frontend/src/container/QueryBuilder/components/ToolbarActions/LeftToolbarActions.tsx
+++ b/frontend/src/container/QueryBuilder/components/ToolbarActions/LeftToolbarActions.tsx
@@ -3,6 +3,8 @@ import './ToolbarActions.styles.scss';
 import { FilterOutlined } from '@ant-design/icons';
 import { Button, Switch, Tooltip, Typography } from 'antd';
 import cx from 'classnames';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { Atom, SquareMousePointer, Terminal } from 'lucide-react';
 import { SELECTED_VIEWS } from 'pages/LogsExplorer/utils';
 
@@ -30,6 +32,7 @@ export default function LeftToolbarActions({
 	handleFilterVisibilityChange,
 }: LeftToolbarActionsProps): JSX.Element {
 	const { clickhouse, search, queryBuilder: QB } = items;
+	const { panelType } = useQueryBuilder();
 
 	return (
 		<div className="left-toolbar">
@@ -85,12 +88,27 @@ export default function LeftToolbarActions({
 
 			<div className="frequency-chart-view-controller">
 				<Typography>Frequency chart</Typography>
-				<Switch
-					size="small"
-					checked={showFrequencyChart}
-					defaultChecked
-					onChange={onToggleHistrogramVisibility}
-				/>
+				{panelType === PANEL_TYPES.TABLE ? (
+					<Tooltip title="Frequency chart is not available in table view">
+						<span>
+							<Switch
+								size="small"
+								checked={false}
+								disabled
+								defaultChecked
+								onChange={onToggleHistrogramVisibility}
+							/>
+						</span>
+					</Tooltip>
+				) : (
+					<Switch
+						size="small"
+						checked={showFrequencyChart}
+						disabled={false}
+						defaultChecked
+						onChange={onToggleHistrogramVisibility}
+					/>
+				)}
 			</div>
 		</div>
 	);

--- a/frontend/src/pages/LogsExplorer/index.tsx
+++ b/frontend/src/pages/LogsExplorer/index.tsx
@@ -8,6 +8,7 @@ import ExplorerCard from 'components/ExplorerCard/ExplorerCard';
 import QuickFilters from 'components/QuickFilters/QuickFilters';
 import { QuickFiltersSource, SignalType } from 'components/QuickFilters/types';
 import { LOCALSTORAGE } from 'constants/localStorage';
+import { PANEL_TYPES } from 'constants/queryBuilder';
 import LogExplorerQuerySection from 'container/LogExplorerQuerySection';
 import LogsExplorerViews from 'container/LogsExplorerViews';
 import {
@@ -33,6 +34,8 @@ import { SELECTED_VIEWS } from './utils';
 
 function LogsExplorer(): JSX.Element {
 	const [showFrequencyChart, setShowFrequencyChart] = useState(true);
+	const showFrequencyChartRef = useRef<boolean>(true);
+	const prevPanelTypeRef = useRef<string | null>(null);
 	const [selectedView, setSelectedView] = useState<SELECTED_VIEWS>(
 		SELECTED_VIEWS.SEARCH,
 	);
@@ -48,7 +51,7 @@ function LogsExplorer(): JSX.Element {
 		return true;
 	});
 
-	const { handleRunQuery, currentQuery } = useQueryBuilder();
+	const { handleRunQuery, currentQuery, panelType } = useQueryBuilder();
 
 	const listQueryKeyRef = useRef<any>();
 
@@ -164,6 +167,18 @@ function LogsExplorer(): JSX.Element {
 		},
 		[mergeWithRequiredColumns, logListOptionsFromLocalStorage],
 	);
+
+	useEffect(() => {
+		if (prevPanelTypeRef.current !== panelType) {
+			if (panelType === PANEL_TYPES.TABLE) {
+				showFrequencyChartRef.current = showFrequencyChart;
+				setShowFrequencyChart(false);
+			} else if (prevPanelTypeRef.current === PANEL_TYPES.TABLE) {
+				setShowFrequencyChart(showFrequencyChartRef.current);
+			}
+			prevPanelTypeRef.current = panelType;
+		}
+	}, [panelType, showFrequencyChart]);
 
 	useEffect(() => {
 		if (!preferences || preferencesLoading) {


### PR DESCRIPTION
Issue : https://github.com/SigNoz/signoz/issues/8356
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disable frequency chart in table view and manage state transitions in `LeftToolbarActions.tsx` and `LogsExplorer/index.tsx`.
> 
>   - **Behavior**:
>     - Disable frequency chart switch in `LeftToolbarActions.tsx` when `panelType` is `PANEL_TYPES.TABLE`.
>     - In `index.tsx`, store and restore `showFrequencyChart` state when switching `panelType` to/from `PANEL_TYPES.TABLE`.
>   - **Components**:
>     - Update `LeftToolbarActions` to conditionally render a disabled `Switch` with a tooltip when in table view.
>     - Modify `LogsExplorer` to manage `showFrequencyChart` state with `useRef` and `useEffect` for `panelType` changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 1c007cde9ca893a1f7474319036bda14cdde672f. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->