### PR TITLE
feat: run query on mod-enter

### DIFF
--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
@@ -42,6 +42,7 @@ import {
 } from 'utils/queryContextUtils';
 
 import { queryExamples } from './constants';
+import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 
 const { Panel } = Collapse;
 
@@ -133,6 +134,8 @@ function QuerySearch({
 	const lastKeyRef = useRef<string>('');
 	const lastValueRef = useRef<string>('');
 	const isMountedRef = useRef<boolean>(true);
+
+	const { handleRunQuery } = useQueryBuilder();
 
 	// const {
 	// 	data: queryKeySuggestions,
@@ -1162,6 +1165,7 @@ function QuerySearch({
 									// and instead run a custom action
 									// Mod-Enter is usually Ctrl-Enter or Cmd-Enter based on OS
 									run: (): boolean => {
+										handleRunQuery(true, true);
 										return true;
 									},
 								},


### PR DESCRIPTION
## 📄 Summary

- Stage & Run query with mod+enter shortcut 
- mod+enter = command+enter (In mac) & ctrl+enter (In windows)

---

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `Mod-Enter` shortcut to run queries in `QuerySearch.tsx`, using `handleRunQuery` from `useQueryBuilder`.
> 
>   - **Behavior**:
>     - Adds `Mod-Enter` shortcut to run queries in `QuerySearch.tsx`.
>     - `Mod-Enter` maps to `Cmd-Enter` on Mac and `Ctrl-Enter` on Windows.
>   - **Functions**:
>     - Uses `handleRunQuery` from `useQueryBuilder` hook to execute queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 6f99fb59b2884d8a7550db6529b3f6425441dd91. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->