### PR TITLE
fix(users): skip sending email if frontend base url is not set

### DIFF
--- a/pkg/modules/user/impluser/module.go
+++ b/pkg/modules/user/impluser/module.go
@@ -91,7 +91,6 @@ func (m *Module) CreateBulkInvite(ctx context.Context, orgID, userID string, bul
 		return nil, err
 	}
 
-	// send telemetry event
 	for i := 0; i < len(invites); i++ {
 		m.analytics.TrackUser(ctx, orgID, creator.ID.String(), "Invite Sent", map[string]any{"invitee_email": invites[i].Email, "invitee_role": invites[i].Role})
 

--- a/pkg/modules/user/impluser/module.go
+++ b/pkg/modules/user/impluser/module.go
@@ -95,6 +95,12 @@ func (m *Module) CreateBulkInvite(ctx context.Context, orgID, userID string, bul
 	for i := 0; i < len(invites); i++ {
 		m.analytics.TrackUser(ctx, orgID, creator.ID.String(), "Invite Sent", map[string]any{"invitee_email": invites[i].Email, "invitee_role": invites[i].Role})
 
+		// if the frontend base url is not provided, we don't send the email
+		if bulkInvites.Invites[i].FrontendBaseUrl == "" {
+			m.settings.Logger().InfoContext(ctx, "frontend base url is not provided, skipping email", "invitee_email", invites[i].Email)
+			continue
+		}
+
 		if err := m.emailing.SendHTML(ctx, invites[i].Email, "You are invited to join a team in SigNoz", emailtypes.TemplateNameInvitationEmail, map[string]any{
 			"CustomerName": invites[i].Name,
 			"InviterName":  creator.DisplayName,


### PR DESCRIPTION
## 📄 Summary

skip sending email if frontend base url is not set
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Skip sending invitation email in `CreateBulkInvite` if `FrontendBaseUrl` is not set, logging an info message instead.
> 
>   - **Behavior**:
>     - In `CreateBulkInvite` in `module.go`, skip sending invitation email if `FrontendBaseUrl` is empty.
>     - Log info message when skipping email due to missing `FrontendBaseUrl`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 11f3e929e50b757d86e3bd76336b629e787c8c3c. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->