### PR TITLE
fix(apdex): use right metric name for metadata

### DIFF
--- a/frontend/src/container/MetricsApplication/Tabs/Overview/ApDex/ApDexMetricsApplication.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview/ApDex/ApDexMetricsApplication.tsx
@@ -3,9 +3,11 @@ import { useGetMetricMeta } from 'hooks/apDex/useGetMetricMeta';
 import useErrorNotification from 'hooks/useErrorNotification';
 import { useParams } from 'react-router-dom';
 
+import { FeatureKeys } from '../../../../../constants/features';
+import { useAppContext } from '../../../../../providers/App/App';
+import { WidgetKeys } from '../../../constant';
 import { IServiceName } from '../../types';
 import ApDexMetrics from './ApDexMetrics';
-import { metricMeta } from './constants';
 import { ApDexDataSwitcherProps } from './types';
 
 function ApDexMetricsApplication({
@@ -18,7 +20,19 @@ function ApDexMetricsApplication({
 	const { servicename: encodedServiceName } = useParams<IServiceName>();
 	const servicename = decodeURIComponent(encodedServiceName);
 
-	const { data, isLoading, error } = useGetMetricMeta(metricMeta, servicename);
+	const { featureFlags } = useAppContext();
+	const dotMetricsEnabled =
+		featureFlags?.find((flag) => flag.name === FeatureKeys.DOT_METRICS_ENABLED)
+			?.active || false;
+
+	const signozLatencyBucketMetrics = dotMetricsEnabled
+		? WidgetKeys.Signoz_latency_bucket
+		: WidgetKeys.Signoz_latency_bucket_norm;
+
+	const { data, isLoading, error } = useGetMetricMeta(
+		signozLatencyBucketMetrics,
+		servicename,
+	);
 	useErrorNotification(error);
 
 	if (isLoading) {

--- a/frontend/src/container/MetricsApplication/Tabs/Overview/ApDex/constants.ts
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview/ApDex/constants.ts
@@ -1,1 +1,0 @@
-export const metricMeta = 'signoz_latency_bucket';

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -2858,11 +2858,11 @@ func (r *ClickHouseReader) GetMetricMetadata(ctx context.Context, orgID valuer.U
 			WHERE metric_name = $1
 				AND unix_milli >= $2
 				AND type = 'Histogram'
-				AND JSONExtractString(labels, 'service_name') = $3
+				AND (JSONExtractString(labels, 'service_name') = $3 OR JSONExtractString(labels, 'service.name') = $4)
 			GROUP BY le
 			ORDER BY le`, signozMetricDBName, signozTSTableNameV41Day)
 
-		rows, err := r.db.Query(ctx, query, metricName, unixMilli, serviceName)
+		rows, err := r.db.Query(ctx, query, metricName, unixMilli, serviceName, serviceName)
 		if err != nil {
 			zap.L().Error("Error while querying histogram buckets", zap.Error(err))
 			return nil, fmt.Errorf("error while querying histogram buckets: %s", err.Error())


### PR DESCRIPTION
## 📄 Summary

Fixes https://github.com/SigNoz/engineering-pod/issues/2611
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix ApDex metric name handling by using feature flag and updating service name query in `ApDexMetricsApplication.tsx` and `reader.go`.
> 
>   - **Frontend**:
>     - In `ApDexMetricsApplication.tsx`, replace `metricMeta` with `signozLatencyBucketMetrics` based on `DOT_METRICS_ENABLED` feature flag.
>     - Remove `metricMeta` import and usage.
>   - **Backend**:
>     - In `reader.go`, update `GetMetricMetadata` to query with both `service_name` and `service.name` labels for histograms.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 960e628f5f7532f29238617e048e7e16e4de28a0. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->