### PR TITLE
chore: only log telemetry query for explorer, rule and dashboard pages

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -4556,6 +4556,28 @@ func (aH *APIHandler) sendQueryResultEvents(r *http.Request, result []*v3.Result
 		return
 	}
 
+	if dashboardMatched {
+		if dashboardIDRegex, err := regexp.Compile(`/dashboard/([a-f0-9\-]+)/`); err == nil {
+			if matches := dashboardIDRegex.FindStringSubmatch(referrer); len(matches) > 1 {
+				properties["dashboard_id"] = matches[1]
+			}
+		}
+
+		if widgetIDRegex, err := regexp.Compile(`widgetId=([a-f0-9\-]+)`); err == nil {
+			if matches := widgetIDRegex.FindStringSubmatch(referrer); len(matches) > 1 {
+				properties["widget_id"] = matches[1]
+			}
+		}
+	}
+
+	if alertMatched {
+		if alertIDRegex, err := regexp.Compile(`ruleId=(\d+)`); err == nil {
+			if matches := alertIDRegex.FindStringSubmatch(referrer); len(matches) > 1 {
+				properties["rule_id"] = matches[1]
+			}
+		}
+	}
+
 	// Check if result is empty or has no data
 	if len(result) == 0 {
 		aH.Signoz.Analytics.TrackUser(r.Context(), claims.OrgID, claims.UserID, "Telemetry Query Returned Empty", properties)
@@ -4577,36 +4599,6 @@ func (aH *APIHandler) sendQueryResultEvents(r *http.Request, result []*v3.Result
 				return
 			}
 		}
-	}
-
-	if dashboardMatched {
-
-		if dashboardIDRegex, err := regexp.Compile(`/dashboard/([a-f0-9\-]+)/`); err == nil {
-			if matches := dashboardIDRegex.FindStringSubmatch(referrer); len(matches) > 1 {
-				properties["dashboard_id"] = matches[1]
-			}
-		}
-
-		if widgetIDRegex, err := regexp.Compile(`widgetId=([a-f0-9\-]+)`); err == nil {
-			if matches := widgetIDRegex.FindStringSubmatch(referrer); len(matches) > 1 {
-				properties["widget_id"] = matches[1]
-			}
-		}
-
-		aH.Signoz.Analytics.TrackUser(r.Context(), claims.OrgID, claims.UserID, "Telemetry Query Returned Results", properties)
-		return
-	}
-
-	if alertMatched {
-
-		if alertIDRegex, err := regexp.Compile(`ruleId=(\d+)`); err == nil {
-			if matches := alertIDRegex.FindStringSubmatch(referrer); len(matches) > 1 {
-				properties["alert_id"] = matches[1]
-			}
-		}
-
-		aH.Signoz.Analytics.TrackUser(r.Context(), claims.OrgID, claims.UserID, "Telemetry Query Returned Results", properties)
-		return
 	}
 
 	aH.Signoz.Analytics.TrackUser(r.Context(), claims.OrgID, claims.UserID, "Telemetry Query Returned Results", properties)


### PR DESCRIPTION
## 📄 Summary

Only log telemetry query for explorer, rule and dashboard pages

---

## 👥 Reviewers

> Tag the relevant teams for review:

- @grandwizard28 

---


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Restrict telemetry logging in `sendQueryResultEvents()` to specific pages based on referrer URL in `http_handler.go`.
> 
>   - **Behavior**:
>     - Restrict telemetry logging in `sendQueryResultEvents()` in `http_handler.go` to only log for explorer, rule, and dashboard pages based on referrer URL.
>     - Referrer URL patterns checked: `/logs/logs-explorer`, `/traces-explorer`, `/metrics-explorer/explorer`, `/dashboard/[a-zA-Z0-9\-]+/(new|edit)`, `/alerts/(new|edit)`.
>     - Telemetry logging for empty results moved to the end of `sendQueryResultEvents()` to ensure it only logs for specified pages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 0a560a9194aa2917884e934bdf9fca2a296519b2. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->