### PR TITLE
fix(aws-elastic-cache): corrected variable query for elastic cache

### DIFF
--- a/pkg/query-service/app/cloudintegrations/services/definitions/aws/elasticache/assets/dashboards/redis_overview_dot.json
+++ b/pkg/query-service/app/cloudintegrations/services/definitions/aws/elasticache/assets/dashboards/redis_overview_dot.json
@@ -175,7 +175,7 @@
       "multiSelect": false,
       "name": "Account",
       "order": 0,
-      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'cloud.account.id') AS cloud.account.id FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'aws_ElastiCache_CPUUtilization_max' GROUP BY cloud.account.id",
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'cloud.account.id') AS cloud.account.id FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'aws_ElastiCache_CPUUtilization_max' GROUP BY `cloud.account.id`",
       "showALLOption": false,
       "sort": "DISABLED",
       "textboxValue": "",

--- a/pkg/query-service/app/cloudintegrations/services/definitions/aws/elasticache/assets/dashboards/redis_overview_dot.json
+++ b/pkg/query-service/app/cloudintegrations/services/definitions/aws/elasticache/assets/dashboards/redis_overview_dot.json
@@ -175,7 +175,7 @@
       "multiSelect": false,
       "name": "Account",
       "order": 0,
-      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'cloud.account.id') AS cloud.account.id FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'aws_ElastiCache_CPUUtilization_max' GROUP BY `cloud.account.id`",
+      "queryValue": "SELECT DISTINCT JSONExtractString(labels, 'cloud.account.id') AS `cloud.account.id` FROM signoz_metrics.distributed_time_series_v4_1day WHERE metric_name = 'aws_ElastiCache_CPUUtilization_max' GROUP BY `cloud.account.id`",
       "showALLOption": false,
       "sort": "DISABLED",
       "textboxValue": "",


### PR DESCRIPTION
## 📄 Summary

Corrected elastic cache query for overview.json for aws cloud integrations

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrected SQL query aliasing in `redis_overview_dot.json` for AWS ElastiCache dashboard.
> 
>   - **Query Fix**:
>     - Corrected `queryValue` in `redis_overview_dot.json` to use backticks for `cloud.account.id` alias in SQL query.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 9addafe121519b96a904f939d842dd590f37b552. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->