### PR TITLE
chore: send email on role update

### DIFF
--- a/pkg/modules/user/impluser/handler.go
+++ b/pkg/modules/user/impluser/handler.go
@@ -289,43 +289,6 @@ func (h *handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	existingUser, err := h.module.GetUserByID(ctx, claims.OrgID, id)
-	if err != nil {
-		render.Error(w, err)
-		return
-	}
-
-	// only displayName, role can be updated
-	if user.DisplayName == "" {
-		user.DisplayName = existingUser.DisplayName
-	}
-
-	if user.Role == "" {
-		user.Role = existingUser.Role
-	}
-
-	if user.Role != existingUser.Role && claims.Role != types.RoleAdmin {
-		render.Error(w, errors.New(errors.TypeForbidden, errors.CodeForbidden, "only admins can change roles"))
-		return
-	}
-
-	// Make sure that the request is not demoting the last admin user.
-	// also an admin user can only change role of their own or other user
-	if user.Role != existingUser.Role && existingUser.Role == types.RoleAdmin.String() {
-		adminUsers, err := h.module.GetUsersByRoleInOrg(ctx, claims.OrgID, types.RoleAdmin)
-		if err != nil {
-			render.Error(w, err)
-			return
-		}
-
-		if len(adminUsers) == 1 {
-			render.Error(w, errors.New(errors.TypeForbidden, errors.CodeForbidden, "cannot demote the last admin"))
-			return
-		}
-	}
-
-	user.UpdatedAt = time.Now()
-
 	updatedUser, err := h.module.UpdateUser(ctx, claims.OrgID, id, &user, claims.UserID)
 	if err != nil {
 		render.Error(w, err)

--- a/pkg/modules/user/impluser/module.go
+++ b/pkg/modules/user/impluser/module.go
@@ -224,7 +224,7 @@ func (m *Module) UpdateUser(ctx context.Context, orgID string, id string, user *
 	m.analytics.IdentifyUser(ctx, user.OrgID, user.ID.String(), traits)
 
 	traits["updated_by"] = updatedBy
-	m.analytics.TrackUser(ctx, updatedUser.OrgID, updatedUser.ID.String(), "User Updated", traits)
+	m.analytics.TrackUser(ctx, user.OrgID, user.ID.String(), "User Updated", traits)
 
 	// if the role is updated then send an email
 	if existingUser.Role != updatedUser.Role {

--- a/pkg/modules/user/impluser/module.go
+++ b/pkg/modules/user/impluser/module.go
@@ -238,7 +238,7 @@ func (m *Module) UpdateUser(ctx context.Context, orgID string, id string, user *
 		}
 	}
 
-	return user, nil
+	return updatedUser, nil
 }
 
 func (m *Module) DeleteUser(ctx context.Context, orgID string, id string, deletedBy string) error {

--- a/pkg/types/emailtypes/template.go
+++ b/pkg/types/emailtypes/template.go
@@ -17,6 +17,7 @@ var (
 
 var (
 	TemplateNameInvitationEmail = TemplateName{valuer.NewString("invitation_email")}
+	TemplateNameUpdateRole      = TemplateName{valuer.NewString("update_role")}
 )
 
 type TemplateName struct{ valuer.String }
@@ -25,6 +26,8 @@ func NewTemplateName(name string) (TemplateName, error) {
 	switch name {
 	case TemplateNameInvitationEmail.StringValue():
 		return TemplateNameInvitationEmail, nil
+	case TemplateNameUpdateRole.StringValue():
+		return TemplateNameUpdateRole, nil
 	default:
 		return TemplateName{}, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "invalid template name: %s", name)
 	}

--- a/pkg/types/emailtypes/template.go
+++ b/pkg/types/emailtypes/template.go
@@ -12,7 +12,7 @@ import (
 var (
 	// Templates is a list of all the templates that are supported by the emailing service.
 	// This list should be updated whenever a new template is added.
-	Templates = []TemplateName{TemplateNameInvitationEmail}
+	Templates = []TemplateName{TemplateNameInvitationEmail, TemplateNameUpdateRole}
 )
 
 var (

--- a/templates/email/update_role.gotmpl
+++ b/templates/email/update_role.gotmpl
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <p>Hi {{.CustomerName}},</p>
+    <p>We wanted to inform you that your role in the SigNoz project has been updated by {{.UpdatedByEmail}}.</p>
+    <p>**Previous Role:** {{.OldRole}}</p>
+    <p>**New Role:** {{.NewRole}}</p>
+    <p>If you were not expecting this change or have any questions, please reach out to your project administrator or contact us at support@signoz.io</p>
+    <p>Thanks,</p>
+    <p>SigNoz Team</p>
+</body>
+</html>

--- a/templates/email/update_role.gotmpl
+++ b/templates/email/update_role.gotmpl
@@ -2,11 +2,22 @@
 <html>
 <body>
     <p>Hi {{.CustomerName}},</p>
-    <p>We wanted to inform you that your role in the SigNoz project has been updated by {{.UpdatedByEmail}}.</p>
-    <p>**Previous Role:** {{.OldRole}}</p>
-    <p>**New Role:** {{.NewRole}}</p>
-    <p>If you were not expecting this change or have any questions, please reach out to your project administrator or contact us at support@signoz.io</p>
-    <p>Thanks,</p>
-    <p>SigNoz Team</p>
+
+    <p>We wanted to inform you that your role in the <strong>SigNoz</strong> project has been updated by <strong>{{.UpdatedByEmail}}</strong>.</p>
+
+    <p>
+        <strong>Previous Role:</strong> {{.OldRole}}<br>
+        <strong>New Role:</strong> {{.NewRole}}
+    </p>
+
+    <p>
+        Please note that you will need to <strong>log out and log back in</strong> for the changes to take full effect.
+    </p>
+
+    <p>
+        If you were not expecting this change or have any questions, please reach out to your project administrator or contact us at <a href="mailto:support@signoz.io">support@signoz.io</a>.
+    </p>
+
+    <p>Thanks,<br/>The SigNoz Team</p>
 </body>
 </html>

--- a/templates/email/update_role.gotmpl
+++ b/templates/email/update_role.gotmpl
@@ -11,7 +11,7 @@
     </p>
 
     <p>
-        Please note that you will need to <strong>log out and log back in</strong> for the changes to take full effect.
+        Please note that you will need to <strong>log out and log back in</strong> for the changes to take effect.
     </p>
 
     <p>


### PR DESCRIPTION
For https://github.com/SigNoz/signoz/issues/6578

send an email if the role is updated 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Send email notification on user role update using a new email template.
> 
>   - **Behavior**:
>     - Send email notification when user role is updated in `UpdateUser()` in `module.go`.
>     - Email sent only if role changes and includes old and new roles, and the email of the person who made the change.
>   - **Templates**:
>     - Add `update_role.gotmpl` for role update email.
>     - Add `TemplateNameUpdateRole` to `Templates` in `template.go`.
>   - **Misc**:
>     - Remove role update logic from `UpdateUser()` in `handler.go` and move to `module.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for f87f5eb6939e4b28b508ec46115ab1bb2cbaf628. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->