### PR TITLE
fix: fixed context for query in parenthesis

### DIFF
--- a/frontend/src/utils/queryContextUtils.ts
+++ b/frontend/src/utils/queryContextUtils.ts
@@ -1521,7 +1521,6 @@ export function getCurrentQueryPair(
 				const pairStart =
 					position.keyStart ?? (position.operatorStart || position.valueStart || 0);
 
-				const ll = getIndexTillSpace(pair, query);
 				// If this pair ends at or before the cursor, and it's further right than our previous best match
 				if (
 					((pairEnd >= cursorIndex && pairStart <= cursorIndex) ||

--- a/frontend/src/utils/queryContextUtils.ts
+++ b/frontend/src/utils/queryContextUtils.ts
@@ -967,6 +967,30 @@ export function getQueryContextAtCursor(
 					currentPair: currentPair,
 				};
 			}
+
+			if (
+				lastTokenContext.isInParenthesis &&
+				lastTokenBeforeCursor.type === FilterQueryLexer.RPAREN
+			) {
+				// If we are after a parenthesis we should enter the conjunction context.
+				return {
+					tokenType: lastTokenBeforeCursor.type,
+					text: lastTokenBeforeCursor.text,
+					start: adjustedCursorIndex,
+					stop: adjustedCursorIndex,
+					currentToken: lastTokenBeforeCursor.text,
+					isInKey: false,
+					isInNegation: false,
+					isInOperator: false,
+					isInValue: false,
+					isInFunction: false,
+					isInConjunction: true, // After RPARAN + space, should be conjunction context
+					isInParenthesis: false,
+					isInBracketList: false,
+					queryPairs: queryPairs,
+					currentPair: currentPair,
+				};
+			}
 		}
 
 		// FIXED: Consider the case where the cursor is at the end of a token


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- Fixed query context when cursor is in between parantheses
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes query context handling in `getQueryContextAtCursor()` for cursor between parentheses, ensuring correct transition to conjunction context.
> 
>   - **Behavior**:
>     - Fixes query context handling in `getQueryContextAtCursor()` when cursor is between parentheses.
>     - Ensures transition to conjunction context after closing parenthesis.
>   - **Functions**:
>     - Adds `getIndexTillSpace()` to determine end of query pair.
>     - Removes `isInParenthesisBoundary` check in `getQueryContextAtCursor()`.
>   - **Misc**:
>     - Adjusts logic for context progression after parentheses in `getQueryContextAtCursor()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 4120b53c2794b8f4ed2cdee791a63251046cf4c3. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->