### PR TITLE
fix: use new error in pipelines handler

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -4041,7 +4041,7 @@ func (aH *APIHandler) PreviewLogsPipelinesHandler(w http.ResponseWriter, r *http
 	req := logparsingpipeline.PipelinesPreviewRequest{}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		RespondError(w, model.BadRequest(err), nil)
+		render.Error(w, err)
 		return
 	}
 
@@ -4050,7 +4050,7 @@ func (aH *APIHandler) PreviewLogsPipelinesHandler(w http.ResponseWriter, r *http
 	)
 
 	if apiErr != nil {
-		RespondError(w, apiErr, nil)
+		render.Error(w, apiErr)
 		return
 	}
 
@@ -4072,7 +4072,7 @@ func (aH *APIHandler) ListLogsPipelinesHandler(w http.ResponseWriter, r *http.Re
 
 	version, err := parseAgentConfigVersion(r)
 	if err != nil {
-		RespondError(w, model.WrapApiError(err, "Failed to parse agent config version"), nil)
+		render.Error(w, err)
 		return
 	}
 
@@ -4086,7 +4086,7 @@ func (aH *APIHandler) ListLogsPipelinesHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	if apierr != nil {
-		RespondError(w, apierr, payload)
+		render.Error(w, apierr)
 		return
 	}
 	aH.Respond(w, payload)
@@ -4164,7 +4164,7 @@ func (aH *APIHandler) CreateLogsPipeline(w http.ResponseWriter, r *http.Request)
 	req := pipelinetypes.PostablePipelines{}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		RespondError(w, model.BadRequest(err), nil)
+		render.Error(w, err)
 		return
 	}
 
@@ -4186,7 +4186,7 @@ func (aH *APIHandler) CreateLogsPipeline(w http.ResponseWriter, r *http.Request)
 
 	res, err := createPipeline(r.Context(), req.Pipelines)
 	if err != nil {
-		RespondError(w, err, nil)
+		render.Error(w, err)
 		return
 	}
 


### PR DESCRIPTION
Hot fix to use new error
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `RespondError` with `render.Error` for error handling in `PreviewLogsPipelinesHandler`, `ListLogsPipelinesHandler`, and `CreateLogsPipeline` in `http_handler.go`.
> 
>   - **Error Handling**:
>     - Replaces `RespondError` with `render.Error` in `PreviewLogsPipelinesHandler`, `ListLogsPipelinesHandler`, and `CreateLogsPipeline` in `http_handler.go`.
>     - Affects JSON decoding errors and API errors in these handlers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 99edf9691025a975fbd60965ed3e4b45d9f817ca. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->