### PR TITLE
Feat: changes for showing changelog to cloud users

### DIFF
--- a/frontend/src/components/ChangelogModal/ChangelogModal.tsx
+++ b/frontend/src/components/ChangelogModal/ChangelogModal.tsx
@@ -2,11 +2,16 @@ import './ChangelogModal.styles.scss';
 
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
 import { Button, Modal } from 'antd';
+import updateUserPreference from 'api/v1/user/preferences/name/update';
 import cx from 'classnames';
+import { USER_PREFERENCES } from 'constants/userPreferences';
 import dayjs from 'dayjs';
 import { ChevronsDown, ScrollText } from 'lucide-react';
+import { useAppContext } from 'providers/App/App';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useMutation } from 'react-query';
 import { ChangelogSchema } from 'types/api/changelog/getChangelogByVersion';
+import { UserPreference } from 'types/api/preferences/preference';
 
 import ChangelogRenderer from './components/ChangelogRenderer';
 
@@ -18,10 +23,41 @@ interface Props {
 function ChangelogModal({ changelog, onClose }: Props): JSX.Element {
 	const [hasScroll, setHasScroll] = useState(false);
 	const changelogContentSectionRef = useRef<HTMLDivElement>(null);
+	const { userPreferences, updateUserPreferenceInContext } = useAppContext();
 
 	const formattedReleaseDate = dayjs(changelog?.release_date).format(
 		'MMMM D, YYYY',
 	);
+
+	const seenChangelogVersion = userPreferences?.find(
+		(preference) =>
+			preference.name === USER_PREFERENCES.LAST_SEEN_CHANGELOG_VERSION,
+	)?.value as string;
+
+	const { mutate: updateUserPreferenceMutation } = useMutation(
+		updateUserPreference,
+		{
+			onSuccess: () => {},
+			onError: () => {},
+		},
+	);
+
+	useEffect(() => {
+		// Update the seen version
+		if (seenChangelogVersion !== changelog.version) {
+			const version = {
+				name: USER_PREFERENCES.LAST_SEEN_CHANGELOG_VERSION,
+				value: changelog.version,
+			};
+			updateUserPreferenceInContext(version as UserPreference);
+			updateUserPreferenceMutation(version);
+		}
+	}, [
+		seenChangelogVersion,
+		changelog.version,
+		updateUserPreferenceMutation,
+		updateUserPreferenceInContext,
+	]);
 
 	const checkScroll = useCallback((): void => {
 		if (changelogContentSectionRef.current) {

--- a/frontend/src/constants/userPreferences.ts
+++ b/frontend/src/constants/userPreferences.ts
@@ -1,4 +1,5 @@
 export const USER_PREFERENCES = {
 	SIDENAV_PINNED: 'sidenav_pinned',
 	NAV_SHORTCUTS: 'nav_shortcuts',
+	LAST_SEEN_CHANGELOG_VERSION: 'last_seen_changelog_version',
 };

--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -93,8 +93,6 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 		toggleChangelogModal,
 		showChangelogModal,
 		changelog,
-		// currentChangelog,
-		// latestChangelog,
 	} = useAppContext();
 
 	const { notifications } = useNotifications();
@@ -151,6 +149,11 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 		? DeploymentType.CLOUD_ONLY
 		: DeploymentType.OSS_ONLY;
 
+	const seenChangelogVersion = userPreferences?.find(
+		(preference) =>
+			preference.name === USER_PREFERENCES.LAST_SEEN_CHANGELOG_VERSION,
+	)?.value as string;
+
 	const [
 		getUserVersionResponse,
 		getUserLatestVersionResponse,
@@ -170,8 +173,26 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 			queryFn: (): Promise<SuccessResponse<ChangelogSchema> | ErrorResponse> =>
 				getChangelogByVersion(latestVersion, changelogForTenant),
 			queryKey: ['getChangelogByVersion', latestVersion, changelogForTenant],
-			enabled: isLoggedIn && !isCloudUserVal && Boolean(latestVersion),
+			enabled: isLoggedIn && Boolean(latestVersion),
 		},
+	]);
+
+	useEffect(() => {
+		if (
+			isCloudUserVal &&
+			Boolean(latestVersion) &&
+			latestVersion !== seenChangelogVersion
+		) {
+			// Automatically open the changelog modal for cloud users after 1s, if they've not seen this version before.
+			setTimeout(() => {
+				toggleChangelogModal();
+			}, 1000);
+		}
+	}, [
+		isCloudUserVal,
+		latestVersion,
+		seenChangelogVersion,
+		toggleChangelogModal,
 	]);
 
 	useEffect(() => {

--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -178,16 +178,21 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 	]);
 
 	useEffect(() => {
+		let timer: ReturnType<typeof setTimeout>;
 		if (
 			isCloudUserVal &&
 			Boolean(latestVersion) &&
 			latestVersion !== seenChangelogVersion
 		) {
 			// Automatically open the changelog modal for cloud users after 1s, if they've not seen this version before.
-			setTimeout(() => {
+			timer = setTimeout(() => {
 				toggleChangelogModal();
 			}, 1000);
 		}
+
+		return (): void => {
+			clearInterval(timer);
+		};
 	}, [
 		isCloudUserVal,
 		latestVersion,

--- a/pkg/types/preferencetypes/name.go
+++ b/pkg/types/preferencetypes/name.go
@@ -18,6 +18,7 @@ var (
 	NameWelcomeChecklistSetupSavedViewSkipped   = Name{valuer.NewString("welcome_checklist_setup_saved_view_skipped")}
 	NameSidenavPinned                           = Name{valuer.NewString("sidenav_pinned")}
 	NameNavShortcuts                            = Name{valuer.NewString("nav_shortcuts")}
+	NameLastSeenChangelogVersion                = Name{valuer.NewString("last_seen_changelog_version")}
 )
 
 type Name struct{ valuer.String }
@@ -35,6 +36,7 @@ func NewName(name string) (Name, error) {
 			NameWelcomeChecklistSetupSavedViewSkipped.StringValue(),
 			NameSidenavPinned.StringValue(),
 			NameNavShortcuts.StringValue(),
+			NameLastSeenChangelogVersion.StringValue(),
 		},
 		name,
 	)

--- a/pkg/types/preferencetypes/preference.go
+++ b/pkg/types/preferencetypes/preference.go
@@ -145,6 +145,15 @@ func NewAvailablePreference() map[Name]Preference {
 			AllowedValues: []string{},
 			Value:         MustNewValue([]any{}, ValueTypeArray),
 		},
+		NameLastSeenChangelogVersion: {
+			Name:          NameLastSeenChangelogVersion,
+			Description:   "Changelog version seen by the user.",
+			ValueType:     ValueTypeString,
+			DefaultValue:  MustNewValue("", ValueTypeString),
+			AllowedScopes: []Scope{ScopeUser},
+			AllowedValues: []string{},
+			Value:         MustNewValue("", ValueTypeString),
+		},
 	}
 }
 


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes
 
- Changes related to showing changelog to cloud users
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add feature to show changelog to cloud users and track last seen version in user preferences.
> 
>   - **Behavior**:
>     - `ChangelogModal.tsx`: Updates user preference for `LAST_SEEN_CHANGELOG_VERSION` when a new changelog is viewed.
>     - `AppLayout/index.tsx`: Automatically opens changelog modal for cloud users if the latest version is unseen.
>   - **Constants**:
>     - Adds `LAST_SEEN_CHANGELOG_VERSION` to `USER_PREFERENCES` in `userPreferences.ts`.
>   - **Types**:
>     - Adds `NameLastSeenChangelogVersion` to `name.go` and `preference.go` to handle new preference type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 3d59b3b1e82b55ad8135fff351e6d78fd4fb4ff7. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->