### PR TITLE
fix: check if it's castable to string

### DIFF
--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -1140,6 +1140,9 @@ func (b *BuilderQuery) Validate(panelType PanelType) error {
 				_, ok := function.Args[0].(float64)
 				if !ok {
 					// if string, attempt to convert to float
+					if _, ok := function.Args[0].(string); !ok {
+						return fmt.Errorf("threshold param should be a float")
+					}
 					threshold, err := strconv.ParseFloat(function.Args[0].(string), 64)
 					if err != nil {
 						return fmt.Errorf("threshold param should be a float")


### PR DESCRIPTION
We were trying to convert it to a string directly without checking if it's possible or not.