### PR TITLE
fix: preserve query context inside parentheses + removed normalizespaces

### DIFF
--- a/frontend/src/utils/queryContextUtils.ts
+++ b/frontend/src/utils/queryContextUtils.ts
@@ -545,8 +545,6 @@ export function getQueryContextAtCursor(
 			(isAtSpace && isAfterToken) ||
 			(cursorIndex === query.length && isAfterToken);
 
-		cursorIndex = cursorIndex;
-
 		// Create input stream and lexer with query
 		const input = query || '';
 		const chars = CharStreams.fromString(input);

--- a/frontend/src/utils/queryContextUtils.ts
+++ b/frontend/src/utils/queryContextUtils.ts
@@ -1521,7 +1521,6 @@ export function getCurrentQueryPair(
 				const pairStart =
 					position.keyStart ?? (position.operatorStart || position.valueStart || 0);
 
-				const ll = getIndexTillSpace(pair, query);
 				// If this pair ends at or before the cursor, and it's further right than our previous best match
 				if (
 					((pairEnd >= cursorIndex && pairStart <= cursorIndex) ||

--- a/frontend/src/utils/queryContextUtils.ts
+++ b/frontend/src/utils/queryContextUtils.ts
@@ -1411,7 +1411,7 @@ export function extractQueryPairs(query: string): IQueryPair[] {
 	}
 }
 
-function getIndexTillSpace(pair: IQueryPair, query: string): number {
+function getEndIndexAfterSpaces(pair: IQueryPair, query: string): number {
 	const { position } = pair;
 	let pairEnd = position.valueEnd || position.operatorEnd || position.keyEnd;
 
@@ -1460,7 +1460,7 @@ export function getCurrentQueryPair(
 					((pairEnd >= cursorIndex && pairStart <= cursorIndex) ||
 						(!pair.isComplete &&
 							pairStart <= cursorIndex &&
-							getIndexTillSpace(pair, query) >= cursorIndex)) &&
+							getEndIndexAfterSpaces(pair, query) >= cursorIndex)) &&
 					(!bestMatch ||
 						pairEnd >
 							(bestMatch.position.valueEnd ||

--- a/frontend/src/utils/queryContextUtils.ts
+++ b/frontend/src/utils/queryContextUtils.ts
@@ -967,6 +967,30 @@ export function getQueryContextAtCursor(
 					currentPair: currentPair,
 				};
 			}
+
+			if (
+				lastTokenContext.isInParenthesis &&
+				lastTokenBeforeCursor.type === FilterQueryLexer.RPAREN
+			) {
+				// If we are after a parenthesis we should enter the conjunction context.
+				return {
+					tokenType: lastTokenBeforeCursor.type,
+					text: lastTokenBeforeCursor.text,
+					start: adjustedCursorIndex,
+					stop: adjustedCursorIndex,
+					currentToken: lastTokenBeforeCursor.text,
+					isInKey: false,
+					isInNegation: false,
+					isInOperator: false,
+					isInValue: false,
+					isInFunction: false,
+					isInConjunction: true, // After RPARAN + space, should be conjunction context
+					isInParenthesis: false,
+					isInBracketList: false,
+					queryPairs: queryPairs,
+					currentPair: currentPair,
+				};
+			}
 		}
 
 		// FIXED: Consider the case where the cursor is at the end of a token


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- Fix for preserving context inside parenthesis
- Removed normalizespaces function
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes query context handling within parentheses by removing space normalization and adjusting cursor index logic in `queryContextUtils.ts`.
> 
>   - **Behavior**:
>     - Fixes query context handling within parentheses in `getQueryContextAtCursor()` in `queryContextUtils.ts`.
>     - Removes `normalizeSpaces()` function, eliminating space normalization logic.
>     - Adjusts cursor index handling to ensure accurate context detection, especially after parentheses.
>   - **Functions**:
>     - Modifies `getQueryContextAtCursor()` to handle context transitions after parentheses and conjunctions.
>     - Updates `determineContextBoundaries()` to correctly identify context boundaries without space normalization.
>     - Adds `getEndIndexAfterSpaces()` to calculate end index after spaces for query pairs.
>   - **Misc**:
>     - Removes adjusted cursor index logic throughout `queryContextUtils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for f8ec9e17796e45da35a839fb81b31b6473d4a6ff. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->