### PR TITLE
fix: query search showing redundant error icon

### DIFF
--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
@@ -105,8 +105,22 @@ function QuerySearch({
 		errors: [],
 	});
 
+	const handleQueryValidation = (newQuery: string): void => {
+		try {
+			const validationResponse = validateQuery(newQuery);
+			setValidation(validationResponse);
+		} catch (error) {
+			setValidation({
+				isValid: false,
+				message: 'Failed to process query',
+				errors: [error as IDetailedError],
+			});
+		}
+	};
+
 	useEffect(() => {
 		setQuery(queryData.filter?.expression || '');
+		handleQueryValidation(queryData.filter?.expression || '');
 	}, [queryData.filter?.expression]);
 
 	const [keySuggestions, setKeySuggestions] = useState<
@@ -457,19 +471,6 @@ function QuerySearch({
 		setQuery(value);
 		handleQueryChange(value);
 		onChange(value);
-	};
-
-	const handleQueryValidation = (newQuery: string): void => {
-		try {
-			const validationResponse = validateQuery(newQuery);
-			setValidation(validationResponse);
-		} catch (error) {
-			setValidation({
-				isValid: false,
-				message: 'Failed to process query',
-				errors: [error as IDetailedError],
-			});
-		}
 	};
 
 	const handleBlur = (): void => {

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
@@ -70,18 +70,6 @@ const stopEventsExtension = EditorView.domEventHandlers({
 	},
 });
 
-// const disallowMultipleSpaces: Extension = EditorView.inputHandler.of(
-// 	(view, from, to, text) => {
-// 		const currentLine = view.state.doc.lineAt(from);
-// 		const before = currentLine.text.slice(0, from - currentLine.from);
-// 		const after = currentLine.text.slice(to - currentLine.from);
-
-// 		const newText = before + text + after;
-
-// 		return /\s{2,}/.test(newText);
-// 	},
-// );
-
 function QuerySearch({
 	onChange,
 	queryData,


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- Added fix for query search showing redundant error icon, even if there's no error when the query is being changes from outside (like from quick filter or dropdown)