### PR TITLE
fix: reset query in quick filters

### DIFF
--- a/frontend/src/components/QueryBuilderV2/utils.ts
+++ b/frontend/src/components/QueryBuilderV2/utils.ts
@@ -398,7 +398,7 @@ export const removeKeysFromExpression = (
 						currentQueryPair.position.operatorEnd ??
 						currentQueryPair.position.keyEnd;
 					// Get the part of the expression that comes after the current query pair
-					const expressionAfterPair = `${expression.slice(queryPairEnd + 1)}`;
+					const expressionAfterPair = `${updatedExpression.slice(queryPairEnd + 1)}`;
 					// Match optional spaces and an optional conjunction (AND/OR), case-insensitive
 					const conjunctionOrSpacesRegex = /^(\s*((AND|OR)\s+)?)/i;
 					const match = expressionAfterPair.match(conjunctionOrSpacesRegex);
@@ -407,10 +407,10 @@ export const removeKeysFromExpression = (
 						queryPairEnd += match[0].length;
 					}
 					// Remove the full query pair (including any conjunction/whitespace) from the expression
-					updatedExpression = `${expression.slice(
+					updatedExpression = `${updatedExpression.slice(
 						0,
 						queryPairStart,
-					)}${expression.slice(queryPairEnd + 1)}`.trim();
+					)}${updatedExpression.slice(queryPairEnd + 1)}`.trim();
 				}
 			}
 		});

--- a/frontend/src/components/QuickFilters/QuickFilters.tsx
+++ b/frontend/src/components/QuickFilters/QuickFilters.tsx
@@ -90,6 +90,10 @@ export default function QuickFilters(props: IQuickFiltersProps): JSX.Element {
 				...currentQuery.builder,
 				queryData: currentQuery.builder.queryData.map((item, idx) => ({
 					...item,
+					filter: {
+						...item.filter,
+						expression: '',
+					},
 					filters: {
 						...item.filters,
 						items: idx === lastUsedQuery ? [] : [...item.filters.items],

--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -864,6 +864,13 @@ export function QueryBuilderProvider({
 						...currentQueryData.builder,
 						queryData: currentQueryData.builder.queryData.map((item) => ({
 							...item,
+							filter: {
+								...item.filter,
+								expression:
+									item.filter?.expression.trim() === ''
+										? ''
+										: item.filter?.expression ?? '',
+							},
 							filters: {
 								items: [],
 								op: 'AND',


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- Added fix for reset query in quick filters
- Fixed breaking UI when running a empty query with space