### PR TITLE
fix: revalidate changelog on tab visibility change

### DIFF
--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -183,17 +183,7 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 	useEffect(() => {
 		// refetch the changelog only when the current tab becomes active + there isn't an active request + no changelog already available
 		if (!changelog && !getChangelogByVersionResponse.isLoading && isVisible) {
-			const FOUR_HOURS_MS = 4 * 60 * 60 * 1000; // 4 hours in ms
-
-			const now = Date.now();
-			const lastUpdated = getChangelogByVersionResponse.dataUpdatedAt || 0;
-
-			const timeSinceLastUpdate = now - lastUpdated;
-
-			// only refetch when there's a difference of 4 hours from the last refetch time.
-			if (timeSinceLastUpdate >= FOUR_HOURS_MS) {
-				getChangelogByVersionResponse.refetch();
-			}
+			getChangelogByVersionResponse.refetch();
 		}
 	}, [isVisible, changelog, getChangelogByVersionResponse]);
 


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- Added fix for Revalidation changelog when tab visibility change
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Revalidates changelog in `AppLayout` on tab visibility change using `useTabVisibility` hook.
> 
>   - **Behavior**:
>     - Revalidates changelog on tab visibility change in `AppLayout`.
>     - Uses `useTabVisibility` hook to detect tab visibility.
>     - Refetches changelog if tab is visible, no active request, and changelog is unavailable.
>   - **Hooks**:
>     - Imports `useTabVisibility` from `hooks/useTabFocus` in `index.tsx`.
>   - **Effects**:
>     - Adds `useEffect` in `AppLayout` to handle changelog refetching logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 2d6bef8e68121f90f4400e8659c97228bf457de3. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->