### PR TITLE
Fix/alert-all-channel: Alert all channel fix, restarting the server

### DIFF
--- a/pkg/query-service/rules/manager.go
+++ b/pkg/query-service/rules/manager.go
@@ -330,7 +330,7 @@ func (m *Manager) EditRule(ctx context.Context, ruleStr string, id valuer.UUID) 
 	if err != nil {
 		return err
 	}
-	if len(parsedRule.PreferredChannels) == 0 {
+	if parsedRule.BroadcastToAll {
 		channels, err := m.alertmanager.ListChannels(ctx, claims.OrgID)
 		if err != nil {
 			return err
@@ -509,7 +509,7 @@ func (m *Manager) CreateRule(ctx context.Context, ruleStr string) (*ruletypes.Ge
 		return nil, err
 	}
 
-	if len(parsedRule.PreferredChannels) == 0 {
+	if len(parsedRule.PreferredChannels) == 0 && parsedRule.BroadcastToAll {
 		channels, err := m.alertmanager.ListChannels(ctx, claims.OrgID)
 		if err != nil {
 			return nil, err

--- a/pkg/types/ruletypes/api_params.go
+++ b/pkg/types/ruletypes/api_params.go
@@ -60,6 +60,7 @@ type PostableRule struct {
 	// Source captures the source url where rule has been created
 	Source string `json:"source,omitempty"`
 
+	BroadcastToAll    bool     `json:"broadcastToAll,omitempty"`
 	PreferredChannels []string `json:"preferredChannels,omitempty"`
 
 	Version string `json:"version,omitempty"`


### PR DESCRIPTION
## 📄 Summary

1.) Current Scenario.
1.1) We consider preferred to channel array empty as broadcastToAll.
1.2) So when server restarts in get matchers, there is no handling for empty array, we only consider preferred channels array.
1.3) we cant add that handling there, because any time new channel is created , for older rules in which broadcastToAll is on, and whenever server get restarted, those new channel will become part of the older rules.

New Implementation.
1.) Create Rule ->
 Whenever user creates a rule and select broadcast to all , we will fill the preferred channels array with current channels.
2.) Edit Rule ->
Now if the users go and edit that channel, we will not show them the option broadcastToAll is on we will only show them, channels which this alerts get notified in, 
2.1) if now they select broadcast to all again, then we will fetch all the channels that are present currently which will include new channels also.
---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->
