### PR TITLE
chore(release): bump SigNoz to v0.90.0, OTel Collector to v0.128.1

### DIFF
--- a/.devenv/docker/clickhouse/compose.yaml
+++ b/.devenv/docker/clickhouse/compose.yaml
@@ -40,7 +40,7 @@ services:
       timeout: 5s
       retries: 3
   schema-migrator-sync:
-    image: signoz/signoz-schema-migrator:v0.128.0
+    image: signoz/signoz-schema-migrator:v0.128.1
     container_name: schema-migrator-sync
     command:
       - sync
@@ -53,7 +53,7 @@ services:
         condition: service_healthy
     restart: on-failure
   schema-migrator-async:
-    image: signoz/signoz-schema-migrator:v0.128.0
+    image: signoz/signoz-schema-migrator:v0.128.1
     container_name: schema-migrator-async
     command:
       - async

--- a/.github/workflows/integrationci.yaml
+++ b/.github/workflows/integrationci.yaml
@@ -22,7 +22,7 @@ jobs:
           - 24.1.2-alpine
           - 24.12-alpine
         schema-migrator-version:
-          - v0.128.0
+          - v0.128.1
         postgres-version:
           - 15
     if: |

--- a/deploy/docker-swarm/docker-compose.ha.yaml
+++ b/deploy/docker-swarm/docker-compose.ha.yaml
@@ -174,7 +174,7 @@ services:
       # - ../common/clickhouse/storage.xml:/etc/clickhouse-server/config.d/storage.xml
   signoz:
     !!merge <<: *db-depend
-    image: signoz/signoz:v0.89.0
+    image: signoz/signoz:v0.90.0
     command:
       - --config=/root/config/prometheus.yml
     ports:
@@ -231,7 +231,7 @@ services:
       - signoz
   schema-migrator:
     !!merge <<: *common
-    image: signoz/signoz-schema-migrator:v0.128.0
+    image: signoz/signoz-schema-migrator:v0.128.1
     deploy:
       restart_policy:
         condition: on-failure

--- a/deploy/docker-swarm/docker-compose.yaml
+++ b/deploy/docker-swarm/docker-compose.yaml
@@ -115,7 +115,7 @@ services:
       # - ../common/clickhouse/storage.xml:/etc/clickhouse-server/config.d/storage.xml
   signoz:
     !!merge <<: *db-depend
-    image: signoz/signoz:v0.89.0
+    image: signoz/signoz:v0.90.0
     command:
       - --config=/root/config/prometheus.yml
     ports:
@@ -174,7 +174,7 @@ services:
       - signoz
   schema-migrator:
     !!merge <<: *common
-    image: signoz/signoz-schema-migrator:v0.128.0
+    image: signoz/signoz-schema-migrator:v0.128.1
     deploy:
       restart_policy:
         condition: on-failure

--- a/deploy/docker/docker-compose.ha.yaml
+++ b/deploy/docker/docker-compose.ha.yaml
@@ -177,7 +177,7 @@ services:
       # - ../common/clickhouse/storage.xml:/etc/clickhouse-server/config.d/storage.xml
   signoz:
     !!merge <<: *db-depend
-    image: signoz/signoz:${VERSION:-v0.89.0}
+    image: signoz/signoz:${VERSION:-v0.90.0}
     container_name: signoz
     command:
       - --config=/root/config/prometheus.yml

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -110,7 +110,7 @@ services:
       # - ../common/clickhouse/storage.xml:/etc/clickhouse-server/config.d/storage.xml
   signoz:
     !!merge <<: *db-depend
-    image: signoz/signoz:${VERSION:-v0.89.0}
+    image: signoz/signoz:${VERSION:-v0.90.0}
     container_name: signoz
     command:
       - --config=/root/config/prometheus.yml


### PR DESCRIPTION
Summary
Release SigNoz v0.88.1 & Otel-Col v0.128.1
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump SigNoz to v0.90.0 and schema migrator to v0.128.1 across multiple Docker Compose files.
> 
>   - **Version Updates**:
>     - Bump `signoz` image to `v0.90.0` in `docker-compose.ha.yaml`, `docker-compose.yaml`, and `docker-compose.ha.yaml`.
>     - Bump `signoz-schema-migrator` image to `v0.128.1` in `compose.yaml`, `integrationci.yaml`, `docker-compose.ha.yaml`, and `docker-compose.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for f9b841ab2ca1d38b572191915c5089884c1bf125. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->