### PR TITLE
feat: add copy button for span attributes (#8550)

### DIFF
--- a/frontend/src/container/SpanDetailsDrawer/Attributes/Attributes.tsx
+++ b/frontend/src/container/SpanDetailsDrawer/Attributes/Attributes.tsx
@@ -1,9 +1,11 @@
 import './Attributes.styles.scss';
 
-import { Input, Tooltip, Typography } from 'antd';
+import { CopyOutlined } from '@ant-design/icons';
+import { Button, Input, message, Tooltip, Typography } from 'antd';
 import cx from 'classnames';
 import { flattenObject } from 'container/LogDetailedView/utils';
 import { useMemo, useState } from 'react';
+import { useCopyToClipboard } from 'react-use';
 import { Span } from 'types/api/trace/getTraceV2';
 
 import NoData from '../NoData/NoData';
@@ -21,6 +23,8 @@ function Attributes(props: IAttributesProps): JSX.Element {
 		() => (span.tagMap ? flattenObject(span.tagMap) : {}),
 		[span],
 	);
+
+	const [, copy] = useCopyToClipboard();
 
 	const datasource = Object.keys(flattenSpanData)
 		.filter((attribute) =>
@@ -57,6 +61,14 @@ function Attributes(props: IAttributesProps): JSX.Element {
 									{item.value}
 								</Typography.Text>
 							</Tooltip>
+							<Button
+								type="text"
+								icon={<CopyOutlined />}
+								onClick={(): void => {
+									copy(item.value);
+									message.success(`${item.field} copied to clipboard`);
+								}}
+							/>
 						</div>
 					</div>
 				))}


### PR DESCRIPTION
##  Summary

This PR adds a **Copy button** on attribute values in the `Attributes.tsx` file of the **Span Details** section. It allows users to quickly copy attribute values to the clipboard and displays a success message upon successful copy.

---

##  Changes

- **Feature**: Added a `Copy` button next to each attribute in the `Attributes.tsx` component.
- Displays a **success toast message** after copying the value.

---

##  Required: Add Relevant Labels

> **Manually add appropriate labels in the PR sidebar**

Suggested labels:

- `frontend`
- `ui`
- `enhancement`

---

##  Reviewers

- `@signoz/frontend`

---

##  How to Test

1. Navigate to the **Trace Details** page.
2. In the **Span Attributes** section, locate the attributes listed.
3. Hover over any attribute and click the **Copy button** (icon).
4. Verify that:
   - The attribute value is copied to the clipboard.
   - A success toast message appears confirming the copy.

---

##  Related Issues

Closes #8550

---

## 📸 Screenshots / Screen Recording (if applicable)

| Before            | After                                               |
|-------------------|-----------------------------------------------------|
| No copy button    | Copy button visible with tooltip and click action   |

---

## 📋 Checklist

- [x] Dev Review  
- [x] Manually tested the changes  

---

## 👀 Notes for Reviewers

Minor UI improvement for better UX. Easy to verify.  

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add copy button for span attributes in `Attributes.tsx`, enabling easy copying with success feedback.
> 
>   - **Feature**:
>     - Add `Copy` button next to each attribute in `Attributes.tsx`.
>     - Use `useCopyToClipboard` for copying attribute values.
>     - Display success message using `message.success` after copying.
>   - **Imports**:
>     - Add `CopyOutlined` from `@ant-design/icons`.
>     - Add `Button`, `message` from `antd`.
>     - Add `useCopyToClipboard` from `react-use`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 28cc821a3e808dffbe9559a2c69eb45a4751864b. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->