### PR TITLE
fix: add safeguard for large log body entries

### DIFF
--- a/frontend/src/components/LogDetail/index.tsx
+++ b/frontend/src/components/LogDetail/index.tsx
@@ -2,7 +2,6 @@
 import './LogDetails.styles.scss';
 
 import { Color, Spacing } from '@signozhq/design-tokens';
-import Convert from 'ansi-to-html';
 import { Button, Divider, Drawer, Radio, Tooltip, Typography } from 'antd';
 import { RadioChangeEvent } from 'antd/lib';
 import cx from 'classnames';
@@ -16,12 +15,10 @@ import JSONView from 'container/LogDetailedView/JsonView';
 import Overview from 'container/LogDetailedView/Overview';
 import {
 	aggregateAttributesResourcesToString,
-	escapeHtml,
+	getSanitizedLogBody,
 	removeEscapeCharacters,
-	unescapeString,
 } from 'container/LogDetailedView/utils';
 import { useOptionsMenu } from 'container/OptionsMenu';
-import dompurify from 'dompurify';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { useNotifications } from 'hooks/useNotifications';
@@ -45,13 +42,10 @@ import { AppState } from 'store/reducers';
 import { Query, TagFilter } from 'types/api/queryBuilder/queryBuilderData';
 import { DataSource, StringOperators } from 'types/common/queryBuilder';
 import { GlobalReducer } from 'types/reducer/globalTime';
-import { FORBID_DOM_PURIFY_TAGS } from 'utils/app';
 
 import { RESOURCE_KEYS, VIEW_TYPES, VIEWS } from './constants';
 import { LogDetailProps } from './LogDetail.interfaces';
 import QueryBuilderSearchWrapper from './QueryBuilderSearchWrapper';
-
-const convert = new Convert();
 
 function LogDetail({
 	log,
@@ -118,11 +112,7 @@ function LogDetail({
 
 	const htmlBody = useMemo(
 		() => ({
-			__html: convert.toHtml(
-				dompurify.sanitize(unescapeString(escapeHtml(log?.body || '')), {
-					FORBID_TAGS: [...FORBID_DOM_PURIFY_TAGS],
-				}),
-			),
+			__html: getSanitizedLogBody(log?.body || '', { shouldEscapeHtml: true }),
 		}),
 		[log?.body],
 	);

--- a/frontend/src/components/Logs/ListLogView/index.tsx
+++ b/frontend/src/components/Logs/ListLogView/index.tsx
@@ -1,15 +1,13 @@
 import './ListLogView.styles.scss';
 
 import { blue } from '@ant-design/colors';
-import Convert from 'ansi-to-html';
 import { Typography } from 'antd';
 import cx from 'classnames';
 import LogDetail from 'components/LogDetail';
 import { VIEW_TYPES } from 'components/LogDetail/constants';
 import { DATE_TIME_FORMATS } from 'constants/dateTimeFormats';
-import { escapeHtml, unescapeString } from 'container/LogDetailedView/utils';
+import { getSanitizedLogBody } from 'container/LogDetailedView/utils';
 import { FontSize } from 'container/OptionsMenu/types';
-import dompurify from 'dompurify';
 import { useActiveLog } from 'hooks/logs/useActiveLog';
 import { useCopyLogLink } from 'hooks/logs/useCopyLogLink';
 import { useIsDarkMode } from 'hooks/useDarkMode';
@@ -20,7 +18,6 @@ import { useCallback, useMemo, useState } from 'react';
 // interfaces
 import { IField } from 'types/api/logs/fields';
 import { ILog } from 'types/api/logs/log';
-import { FORBID_DOM_PURIFY_TAGS } from 'utils/app';
 
 // components
 import AddToQueryHOC, { AddToQueryHOCProps } from '../AddToQueryHOC';
@@ -36,8 +33,6 @@ import {
 	TextContainer,
 } from './styles';
 import { isValidLogField } from './util';
-
-const convert = new Convert();
 
 interface LogFieldProps {
 	fieldKey: string;
@@ -57,11 +52,7 @@ function LogGeneralField({
 }: LogFieldProps): JSX.Element {
 	const html = useMemo(
 		() => ({
-			__html: convert.toHtml(
-				dompurify.sanitize(unescapeString(escapeHtml(fieldValue)), {
-					FORBID_TAGS: [...FORBID_DOM_PURIFY_TAGS],
-				}),
-			),
+			__html: getSanitizedLogBody(fieldValue, { shouldEscapeHtml: true }),
 		}),
 		[fieldValue],
 	);

--- a/frontend/src/components/Logs/RawLogView/index.tsx
+++ b/frontend/src/components/Logs/RawLogView/index.tsx
@@ -1,13 +1,11 @@
 import './RawLogView.styles.scss';
 
-import Convert from 'ansi-to-html';
 import { DrawerProps } from 'antd';
 import LogDetail from 'components/LogDetail';
 import { VIEW_TYPES, VIEWS } from 'components/LogDetail/constants';
 import { DATE_TIME_FORMATS } from 'constants/dateTimeFormats';
-import { escapeHtml, unescapeString } from 'container/LogDetailedView/utils';
+import { getSanitizedLogBody } from 'container/LogDetailedView/utils';
 import LogsExplorerContext from 'container/LogsExplorerContext';
-import dompurify from 'dompurify';
 import { useActiveLog } from 'hooks/logs/useActiveLog';
 import { useCopyLogLink } from 'hooks/logs/useCopyLogLink';
 // hooks
@@ -23,7 +21,6 @@ import {
 	useMemo,
 	useState,
 } from 'react';
-import { FORBID_DOM_PURIFY_TAGS } from 'utils/app';
 
 import LogLinesActionButtons from '../LogLinesActionButtons/LogLinesActionButtons';
 import LogStateIndicator from '../LogStateIndicator/LogStateIndicator';
@@ -31,8 +28,6 @@ import { getLogIndicatorType } from '../LogStateIndicator/utils';
 // styles
 import { RawLogContent, RawLogViewContainer } from './styles';
 import { RawLogViewProps } from './types';
-
-const convert = new Convert();
 
 function RawLogView({
 	isActiveLog,
@@ -176,11 +171,7 @@ function RawLogView({
 
 	const html = useMemo(
 		() => ({
-			__html: convert.toHtml(
-				dompurify.sanitize(unescapeString(escapeHtml(text)), {
-					FORBID_TAGS: [...FORBID_DOM_PURIFY_TAGS],
-				}),
-			),
+			__html: getSanitizedLogBody(text, { shouldEscapeHtml: true }),
 		}),
 		[text],
 	);

--- a/frontend/src/components/Logs/TableView/useTableView.tsx
+++ b/frontend/src/components/Logs/TableView/useTableView.tsx
@@ -1,17 +1,14 @@
 import './useTableView.styles.scss';
 
-import Convert from 'ansi-to-html';
 import { Typography } from 'antd';
 import { ColumnsType } from 'antd/es/table';
 import cx from 'classnames';
 import { DATE_TIME_FORMATS } from 'constants/dateTimeFormats';
-import { unescapeString } from 'container/LogDetailedView/utils';
-import dompurify from 'dompurify';
+import { getSanitizedLogBody } from 'container/LogDetailedView/utils';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { FlatLogData } from 'lib/logs/flatLogData';
 import { useTimezone } from 'providers/Timezone';
 import { useMemo } from 'react';
-import { FORBID_DOM_PURIFY_TAGS } from 'utils/app';
 
 import LogStateIndicator from '../LogStateIndicator/LogStateIndicator';
 import { getLogIndicatorTypeForTable } from '../LogStateIndicator/utils';
@@ -26,8 +23,6 @@ import {
 	UseTableViewProps,
 	UseTableViewResult,
 } from './types';
-
-const convert = new Convert();
 
 export const useTableView = (props: UseTableViewProps): UseTableViewResult => {
 	const {
@@ -149,11 +144,7 @@ export const useTableView = (props: UseTableViewProps): UseTableViewResult => {
 								children: (
 									<TableBodyContent
 										dangerouslySetInnerHTML={{
-											__html: convert.toHtml(
-												dompurify.sanitize(unescapeString(field as string), {
-													FORBID_TAGS: [...FORBID_DOM_PURIFY_TAGS],
-												}),
-											),
+											__html: getSanitizedLogBody(field as string),
 										}}
 										fontSize={fontSize}
 										linesPerRow={linesPerRow}

--- a/frontend/src/container/LogDetailedView/TableView/useAsyncJSONProcessing.ts
+++ b/frontend/src/container/LogDetailedView/TableView/useAsyncJSONProcessing.ts
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState } from 'react';
 
 import { jsonToDataNodes, recursiveParseJSON } from '../utils';
 
+const MAX_BODY_BYTES = 100 * 1024; // 100 KB
+
 // Hook for async JSON processing
 const useAsyncJSONProcessing = (
 	value: string,
@@ -27,68 +29,84 @@ const useAsyncJSONProcessing = (
 
 	// eslint-disable-next-line sonarjs/cognitive-complexity
 	useEffect((): (() => void) => {
-		if (!shouldProcess || processingRef.current) {
-			return (): void => {};
-		}
-
-		processingRef.current = true;
-		setJsonState({ isLoading: true, treeData: null, error: null });
-
-		// Option 1: Using setTimeout for non-blocking processing
-		const processAsync = (): void => {
-			setTimeout(() => {
-				try {
-					const parsedBody = recursiveParseJSON(value);
-					if (!isEmpty(parsedBody)) {
-						const treeData = jsonToDataNodes(parsedBody);
-						setJsonState({ isLoading: false, treeData, error: null });
-					} else {
-						setJsonState({ isLoading: false, treeData: null, error: null });
-					}
-				} catch (error) {
-					setJsonState({
-						isLoading: false,
-						treeData: null,
-						error: error instanceof Error ? error.message : 'Parsing failed',
-					});
-				} finally {
-					processingRef.current = false;
-				}
-			}, 0);
-		};
-
-		// Option 2: Using requestIdleCallback for better performance
-		const processWithIdleCallback = (): void => {
-			if ('requestIdleCallback' in window) {
-				requestIdleCallback(
-					// eslint-disable-next-line sonarjs/no-identical-functions
-					(): void => {
-						try {
-							const parsedBody = recursiveParseJSON(value);
-							if (!isEmpty(parsedBody)) {
-								const treeData = jsonToDataNodes(parsedBody);
-								setJsonState({ isLoading: false, treeData, error: null });
-							} else {
-								setJsonState({ isLoading: false, treeData: null, error: null });
-							}
-						} catch (error) {
-							setJsonState({
-								isLoading: false,
-								treeData: null,
-								error: error instanceof Error ? error.message : 'Parsing failed',
-							});
-						} finally {
-							processingRef.current = false;
-						}
-					},
-					{ timeout: 1000 },
-				);
-			} else {
-				processAsync();
+		try {
+			if (!shouldProcess || processingRef.current) {
+				return (): void => {};
 			}
-		};
 
-		processWithIdleCallback();
+			// Check if the JSON is too large
+			const json = JSON.stringify(value);
+			const byteSize = new Blob([json]).size;
+
+			if (byteSize > MAX_BODY_BYTES) {
+				setJsonState({ isLoading: false, treeData: null, error: null });
+				return (): void => {};
+			}
+
+			processingRef.current = true;
+			setJsonState({ isLoading: true, treeData: null, error: null });
+
+			// Option 1: Using setTimeout for non-blocking processing
+			const processAsync = (): void => {
+				setTimeout(() => {
+					try {
+						const parsedBody = recursiveParseJSON(value);
+						if (!isEmpty(parsedBody)) {
+							const treeData = jsonToDataNodes(parsedBody);
+							setJsonState({ isLoading: false, treeData, error: null });
+						} else {
+							setJsonState({ isLoading: false, treeData: null, error: null });
+						}
+					} catch (error) {
+						setJsonState({
+							isLoading: false,
+							treeData: null,
+							error: error instanceof Error ? error.message : 'Parsing failed',
+						});
+					} finally {
+						processingRef.current = false;
+					}
+				}, 0);
+			};
+
+			// Option 2: Using requestIdleCallback for better performance
+			const processWithIdleCallback = (): void => {
+				if ('requestIdleCallback' in window) {
+					requestIdleCallback(
+						// eslint-disable-next-line sonarjs/no-identical-functions
+						(): void => {
+							try {
+								const parsedBody = recursiveParseJSON(value);
+								if (!isEmpty(parsedBody)) {
+									const treeData = jsonToDataNodes(parsedBody);
+									setJsonState({ isLoading: false, treeData, error: null });
+								} else {
+									setJsonState({ isLoading: false, treeData: null, error: null });
+								}
+							} catch (error) {
+								setJsonState({
+									isLoading: false,
+									treeData: null,
+									error: error instanceof Error ? error.message : 'Parsing failed',
+								});
+							} finally {
+								processingRef.current = false;
+							}
+						},
+						{ timeout: 1000 },
+					);
+				} else {
+					processAsync();
+				}
+			};
+
+			processWithIdleCallback();
+		} catch (error) {
+			console.error('Error processing JSON', error);
+			setJsonState({ isLoading: false, treeData: null, error: 'Parsing failed' });
+		} finally {
+			processingRef.current = false;
+		}
 
 		// Cleanup function
 		return (): void => {

--- a/frontend/src/container/LogDetailedView/utils.tsx
+++ b/frontend/src/container/LogDetailedView/utils.tsx
@@ -1,8 +1,11 @@
+import Convert from 'ansi-to-html';
 import { DataNode } from 'antd/es/tree';
 import { MetricsType } from 'container/MetricsApplication/constant';
+import dompurify from 'dompurify';
 import { uniqueId } from 'lodash-es';
 import { ILog, ILogAggregateAttributesResources } from 'types/api/logs/log';
 import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
+import { FORBID_DOM_PURIFY_TAGS } from 'utils/app';
 
 import BodyTitleRenderer from './BodyTitleRenderer';
 import { typeToArrayTypeMapper } from './config';
@@ -336,3 +339,22 @@ export function findKeyPath(
 	});
 	return finalPath;
 }
+
+export const getSanitizedLogBody = (
+	text: string,
+	options: { shouldEscapeHtml?: boolean } = {},
+): string => {
+	const convert = new Convert();
+	const { shouldEscapeHtml = false } = options;
+	const escapedText = shouldEscapeHtml ? escapeHtml(text) : text;
+	try {
+		return convert.toHtml(
+			dompurify.sanitize(unescapeString(escapedText), {
+				FORBID_TAGS: [...FORBID_DOM_PURIFY_TAGS],
+			}),
+		);
+	} catch (error) {
+		console.error('Error sanitizing text', error, text);
+		return '{}';
+	}
+};


### PR DESCRIPTION
## 📄 Summary

Log entries have size more than a certain threshold breaking UI. Added safeguards to prevent same.

---

## ✅ Changes

- [ ] Feature: Brief description
- [x] Bug fix: Brief description

---


## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #
https://github.com/SigNoz/engineering-pod/issues/2656
---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

Before:
Large Log breaking UI

https://github.com/user-attachments/assets/f5e91b38-7d4f-4aba-9119-fddd977afe96

After:
On error processing data displaying : {} (similar to datadog, can change later if req)

https://github.com/user-attachments/assets/e83f7f2e-02c9-4297-93f3-8bd133f45e2b



---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->
