### PR TITLE
fix: use only needed resource attributes in context filter

### DIFF
--- a/frontend/src/container/LogsExplorerContext/useInitialQuery.ts
+++ b/frontend/src/container/LogsExplorerContext/useInitialQuery.ts
@@ -6,6 +6,9 @@ import { DataSource } from 'types/common/queryBuilder';
 
 import { getFiltersFromResources } from './utils';
 
+const RESOURCE_STARTS_WITH_REGEX = /^(k8s|cloud|host|deployment)/; // regex to filter out resources that start with the specified keywords
+const RESOURCE_CONTAINS_REGEX = /(env|service|file|container|tenant)/; // regex to filter out resources that contains the spefied keywords
+
 const useInitialQuery = (log: ILog): Query => {
 	const { updateAllQueriesOperators } = useQueryBuilder();
 	const resourcesFilters = getFiltersFromResources(log.resources_string);
@@ -16,20 +19,15 @@ const useInitialQuery = (log: ILog): Query => {
 		DataSource.LOGS,
 	);
 
-	const updateFilters = (filters: TagFilter): TagFilter => {
-		const startsWithRegex = /^(k8s|cloud|host|deployment)/;
-		const containsRegex = /(env|service|file|container|tenant)/;
-
-		return {
-			...filters,
-			items: filters.items.filter(
-				(filterItem) =>
-					filterItem.key?.key &&
-					(startsWithRegex.test(filterItem.key.key) ||
-						containsRegex.test(filterItem.key.key)),
-			),
-		};
-	};
+	const updateFilters = (filters: TagFilter): TagFilter => ({
+		...filters,
+		items: filters.items.filter(
+			(filterItem) =>
+				filterItem.key?.key &&
+				(RESOURCE_STARTS_WITH_REGEX.test(filterItem.key.key) ||
+					RESOURCE_CONTAINS_REGEX.test(filterItem.key.key)),
+		),
+	});
 
 	const data: Query = {
 		...updatedAllQueriesOperator,


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- Fix: https://github.com/SigNoz/signoz/issues/8504#issuecomment-3061153364
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `useInitialQuery` now filters resource attributes using regex patterns to include only necessary resources.
> 
>   - **Behavior**:
>     - `useInitialQuery` in `useInitialQuery.ts` now filters resource attributes using regex patterns `RESOURCE_STARTS_WITH_REGEX` and `RESOURCE_CONTAINS_REGEX`.
>     - Filters only include resources starting with `k8s`, `cloud`, `host`, `deployment` or containing `env`, `service`, `file`, `container`, `tenant`.
>   - **Functions**:
>     - Adds `updateFilters` function to filter `TagFilter` items based on regex patterns.
>     - Applies `updateFilters` to `queryData` items in `useInitialQuery`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for cefcb7c91a5526d20b6f7ccff3da44627a5f1b07. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->