### PR TITLE
ci(prereleaser): remove cron scheduler

### DIFF
--- a/.github/workflows/prereleaser.yaml
+++ b/.github/workflows/prereleaser.yaml
@@ -1,10 +1,6 @@
 name: prereleaser
 
 on:
-  # schedule every wednesday 6:30 AM UTC (12:00 PM IST)
-  schedule:
-    - cron: '30 6 * * 3'
-
   # allow manual triggering of the workflow by a maintainer
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## 📄 Summary

remove cron scheduler
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove cron schedule from `prereleaser.yaml`, leaving only manual triggers for the workflow.
> 
>   - **Behavior**:
>     - Removed cron schedule from `prereleaser.yaml`, eliminating automatic weekly triggers.
>     - Workflow can now only be triggered manually by a maintainer via `workflow_dispatch`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 8033c976570d01cffa79712492811bc29b0bfa90. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->