### PR TITLE
fix: added fix for key suggestions in metrics

### DIFF
--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
@@ -753,9 +753,6 @@ function QuerySearch({
 				options = options.map((option) => ({
 					...option,
 					boost: usedKeys.includes(option.label) ? -10 : 10,
-					// info: usedKeys.includes(option.label)
-					// 	? `${option.info || ''} (already used in query)`
-					// 	: option.info,
 				}));
 			}
 
@@ -840,12 +837,6 @@ function QuerySearch({
 							}));
 					}
 				}
-
-				// Add key info to all operators
-				// options = options.map((op) => ({
-				// 	...op,
-				// 	info: `${op.info || ''} (for ${keyName})`,
-				// }));
 			}
 
 			// Add space after selection for operators

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
@@ -161,6 +161,10 @@ function QuerySearch({
 		);
 
 	const fetchKeySuggestions = async (searchText?: string): Promise<void> => {
+		if (dataSource === DataSource.METRICS && !queryData.aggregateAttribute?.key) {
+			setKeySuggestions([]);
+			return;
+		}
 		const response = await getKeySuggestions({
 			signal: dataSource,
 			searchText: searchText || '',
@@ -173,9 +177,11 @@ function QuerySearch({
 			// Use a Map to deduplicate by label and preserve order: new options take precedence
 			const merged = new Map<string, QueryKeyDataSuggestionsProps>();
 			options.forEach((opt) => merged.set(opt.label, opt));
-			(keySuggestions || []).forEach((opt) => {
-				if (!merged.has(opt.label)) merged.set(opt.label, opt);
-			});
+			if (searchText && lastKeyRef.current !== searchText) {
+				(keySuggestions || []).forEach((opt) => {
+					if (!merged.has(opt.label)) merged.set(opt.label, opt);
+				});
+			}
 			setKeySuggestions(Array.from(merged.values()));
 			setIsCompleteKeysList(complete);
 		}
@@ -747,9 +753,9 @@ function QuerySearch({
 				options = options.map((option) => ({
 					...option,
 					boost: usedKeys.includes(option.label) ? -10 : 10,
-					info: usedKeys.includes(option.label)
-						? `${option.info || ''} (already used in query)`
-						: option.info,
+					// info: usedKeys.includes(option.label)
+					// 	? `${option.info || ''} (already used in query)`
+					// 	: option.info,
 				}));
 			}
 
@@ -836,10 +842,10 @@ function QuerySearch({
 				}
 
 				// Add key info to all operators
-				options = options.map((op) => ({
-					...op,
-					info: `${op.info || ''} (for ${keyName})`,
-				}));
+				// options = options.map((op) => ({
+				// 	...op,
+				// 	info: `${op.info || ''} (for ${keyName})`,
+				// }));
 			}
 
 			// Add space after selection for operators


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- Fix: added fix for key suggestions in metrics
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes key suggestion logic in `QuerySearch.tsx` for `METRICS` data source by adding early return and refining suggestion merging.
> 
>   - **Behavior**:
>     - In `QuerySearch.tsx`, `fetchKeySuggestions` now clears suggestions and returns early if `dataSource` is `METRICS` and `queryData.aggregateAttribute?.key` is not set.
>     - Prevents merging of `keySuggestions` if `searchText` is unchanged, ensuring deduplication only when necessary.
>   - **Misc**:
>     - Removes redundant `info` field updates in options mapping logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 8627382409194d2b8490305efe011e19c2fc9452. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->