### PR TITLE
fix: open log details on clicking on empty column cell too

### DIFF
--- a/frontend/src/container/LogsExplorerList/InfinityTableView/TableRow.tsx
+++ b/frontend/src/container/LogsExplorerList/InfinityTableView/TableRow.tsx
@@ -23,6 +23,7 @@ interface TableRowProps {
 	index: number;
 	log: Record<string, unknown>;
 	handleSetActiveContextLog: (log: ILog) => void;
+	onShowLogDetails: (log: ILog) => void;
 	logs: ILog[];
 	hasActions: boolean;
 	fontSize: FontSize;
@@ -33,6 +34,7 @@ export default function TableRow({
 	index,
 	log,
 	handleSetActiveContextLog,
+	onShowLogDetails,
 	logs,
 	hasActions,
 	fontSize,
@@ -56,6 +58,11 @@ export default function TableRow({
 		},
 		[currentLog, handleSetActiveContextLog],
 	);
+
+	const handleShowLogDetails = useCallback(() => {
+		if (!onShowLogDetails || !currentLog) return;
+		onShowLogDetails(currentLog);
+	}, [currentLog, onShowLogDetails]);
 
 	const hasSingleColumn =
 		tableColumns.filter((column) => column.key !== 'state-indicator').length ===
@@ -89,6 +96,7 @@ export default function TableRow({
 						key={column.key}
 						fontSize={fontSize}
 						columnKey={column.key as string}
+						onClick={handleShowLogDetails}
 					>
 						{cloneElement(children, props)}
 					</TableCellStyled>

--- a/frontend/src/container/LogsExplorerList/InfinityTableView/index.tsx
+++ b/frontend/src/container/LogsExplorerList/InfinityTableView/index.tsx
@@ -108,6 +108,7 @@ const InfinityTable = forwardRef<TableVirtuosoHandle, InfinityTableProps>(
 					logs={tableViewProps.logs}
 					hasActions
 					fontSize={tableViewProps.fontSize}
+					onShowLogDetails={onSetActiveLog}
 				/>
 			),
 			[
@@ -115,6 +116,7 @@ const InfinityTable = forwardRef<TableVirtuosoHandle, InfinityTableProps>(
 				tableColumns,
 				tableViewProps.fontSize,
 				tableViewProps.logs,
+				onSetActiveLog,
 			],
 		);
 
@@ -145,12 +147,6 @@ const InfinityTable = forwardRef<TableVirtuosoHandle, InfinityTableProps>(
 			),
 			[tableColumns, isDarkMode, tableViewProps?.fontSize],
 		);
-
-		const handleClickExpand = (index: number): void => {
-			if (!onSetActiveLog) return;
-
-			onSetActiveLog(tableViewProps.logs[index]);
-		};
 
 		return (
 			<>
@@ -183,9 +179,6 @@ const InfinityTable = forwardRef<TableVirtuosoHandle, InfinityTableProps>(
 					{...(infitiyTableProps?.onEndReached
 						? { endReached: infitiyTableProps.onEndReached }
 						: {})}
-					onClick={(event: any): void => {
-						handleClickExpand(event.target.parentElement.parentElement.dataset.index);
-					}}
 				/>
 
 				{activeContextLog && (


### PR DESCRIPTION
## 📄 Summary

Fixes #8593 
---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: open log details on clicking on empty column cell too


## 🧪 How to Test

Go to logs list view
Select column format and add random column.
Click on a row where column data is empty, the detail page should open now

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #8593

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)


https://github.com/user-attachments/assets/fe7b8cce-2fac-48b8-8118-99c1a34d0ecf




<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug to open log details on clicking empty column cells in `TableRow.tsx`.
> 
>   - **Behavior**:
>     - Clicking on empty column cells now opens log details in `TableRow.tsx`.
>     - `onShowLogDetails` prop added to `TableRow` to handle log detail display.
>   - **Functions**:
>     - `handleShowLogDetails` in `TableRow.tsx` triggers `onShowLogDetails` when a cell is clicked.
>     - `itemContent` in `index.tsx` passes `onShowLogDetails` to `TableRow`.
>   - **Misc**:
>     - Removed unused `handleClickExpand` function in `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for c79c4836a70b6c8d0b2f4c14b9eaae60833024ee. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->