### PR TITLE
feat: add duration calculation for latency_pointer='end' in funnel qu…

### DIFF
--- a/pkg/modules/tracefunnel/clickhouse_queries_latency_test.go
+++ b/pkg/modules/tracefunnel/clickhouse_queries_latency_test.go
@@ -1,0 +1,258 @@
+package tracefunnel
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildFunnelOverviewQuery_WithLatencyPointer(t *testing.T) {
+	tests := []struct {
+		name  string
+		steps []struct {
+			ServiceName    string
+			SpanName       string
+			ContainsError  int
+			LatencyPointer string
+			Clause         string
+		}
+		startTs      int64
+		endTs        int64
+		wantContains []string
+		wantNotContains []string
+	}{
+		{
+			name: "latency pointer end for first step only",
+			steps: []struct {
+				ServiceName    string
+				SpanName       string
+				ContainsError  int
+				LatencyPointer string
+				Clause         string
+			}{
+				{ServiceName: "service1", SpanName: "span1", ContainsError: 0, LatencyPointer: "end", Clause: ""},
+				{ServiceName: "service2", SpanName: "span2", ContainsError: 0, LatencyPointer: "start", Clause: ""},
+			},
+			startTs: 1000000000,
+			endTs:   2000000000,
+			wantContains: []string{
+				"minIf(timestamp, serviceName = step1.1 AND name = step1.2) + toIntervalNanosecond(minIf(durationNano, serviceName = step1.1 AND name = step1.2)) AS t1_time",
+				"minIf(timestamp, serviceName = step2.1 AND name = step2.2) AS t2_time",
+			},
+		},
+		{
+			name: "latency pointer end for all steps",
+			steps: []struct {
+				ServiceName    string
+				SpanName       string
+				ContainsError  int
+				LatencyPointer string
+				Clause         string
+			}{
+				{ServiceName: "service1", SpanName: "span1", ContainsError: 0, LatencyPointer: "end", Clause: ""},
+				{ServiceName: "service2", SpanName: "span2", ContainsError: 0, LatencyPointer: "end", Clause: ""},
+				{ServiceName: "service3", SpanName: "span3", ContainsError: 0, LatencyPointer: "end", Clause: ""},
+			},
+			startTs: 1000000000,
+			endTs:   2000000000,
+			wantContains: []string{
+				"minIf(timestamp, serviceName = step1.1 AND name = step1.2) + toIntervalNanosecond(minIf(durationNano, serviceName = step1.1 AND name = step1.2)) AS t1_time",
+				"minIf(timestamp, serviceName = step2.1 AND name = step2.2) + toIntervalNanosecond(minIf(durationNano, serviceName = step2.1 AND name = step2.2)) AS t2_time",
+				"minIf(timestamp, serviceName = step3.1 AND name = step3.2) + toIntervalNanosecond(minIf(durationNano, serviceName = step3.1 AND name = step3.2)) AS t3_time",
+			},
+		},
+		{
+			name: "mixed latency pointers",
+			steps: []struct {
+				ServiceName    string
+				SpanName       string
+				ContainsError  int
+				LatencyPointer string
+				Clause         string
+			}{
+				{ServiceName: "service1", SpanName: "span1", ContainsError: 0, LatencyPointer: "start", Clause: ""},
+				{ServiceName: "service2", SpanName: "span2", ContainsError: 0, LatencyPointer: "end", Clause: ""},
+				{ServiceName: "service3", SpanName: "span3", ContainsError: 0, LatencyPointer: "start", Clause: ""},
+			},
+			startTs: 1000000000,
+			endTs:   2000000000,
+			wantContains: []string{
+				"minIf(timestamp, serviceName = step1.1 AND name = step1.2) AS t1_time",
+				"minIf(timestamp, serviceName = step2.1 AND name = step2.2) + toIntervalNanosecond(minIf(durationNano, serviceName = step2.1 AND name = step2.2)) AS t2_time",
+				"minIf(timestamp, serviceName = step3.1 AND name = step3.2) AS t3_time",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := BuildFunnelOverviewQuery(tt.steps, tt.startTs, tt.endTs)
+			
+			for _, want := range tt.wantContains {
+				if !strings.Contains(query, want) {
+					t.Errorf("Query missing expected content: %s", want)
+				}
+			}
+			
+			for _, notWant := range tt.wantNotContains {
+				if strings.Contains(query, notWant) {
+					t.Errorf("Query contains unexpected content: %s", notWant)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildFunnelStepOverviewQuery_WithLatencyPointer(t *testing.T) {
+	tests := []struct {
+		name  string
+		steps []struct {
+			ServiceName    string
+			SpanName       string
+			ContainsError  int
+			LatencyPointer string
+			LatencyType    string
+			Clause         string
+		}
+		stepStart    int64
+		stepEnd      int64
+		wantContains []string
+	}{
+		{
+			name: "step 1 to 2 with end latency pointers",
+			steps: []struct {
+				ServiceName    string
+				SpanName       string
+				ContainsError  int
+				LatencyPointer string
+				LatencyType    string
+				Clause         string
+			}{
+				{ServiceName: "service1", SpanName: "span1", ContainsError: 0, LatencyPointer: "end", LatencyType: "p99", Clause: ""},
+				{ServiceName: "service2", SpanName: "span2", ContainsError: 0, LatencyPointer: "end", LatencyType: "p99", Clause: ""},
+			},
+			stepStart: 1,
+			stepEnd:   2,
+			wantContains: []string{
+				"minIf(timestamp, serviceName = step1.1 AND name = step1.2) + toIntervalNanosecond(minIf(durationNano, serviceName = step1.1 AND name = step1.2)) AS t1_time",
+				"minIf(timestamp, serviceName = step2.1 AND name = step2.2) + toIntervalNanosecond(minIf(durationNano, serviceName = step2.1 AND name = step2.2)) AS t2_time",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := BuildFunnelStepOverviewQuery(tt.steps, 1000000000, 2000000000, tt.stepStart, tt.stepEnd)
+			
+			for _, want := range tt.wantContains {
+				if !strings.Contains(query, want) {
+					t.Errorf("Query missing expected content: %s", want)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildFunnelTopSlowTracesQuery_WithLatencyPointer(t *testing.T) {
+	tests := []struct {
+		name              string
+		latencyPointerT1  string
+		latencyPointerT2  string
+		wantContains      []string
+	}{
+		{
+			name:             "both steps with end latency",
+			latencyPointerT1: "end",
+			latencyPointerT2: "end",
+			wantContains: []string{
+				"minIf(timestamp, serviceName = step1.1 AND name = step1.2) + toIntervalNanosecond(minIf(durationNano, serviceName = step1.1 AND name = step1.2)) AS t1_time",
+				"minIf(timestamp, serviceName = step2.1 AND name = step2.2) + toIntervalNanosecond(minIf(durationNano, serviceName = step2.1 AND name = step2.2)) AS t2_time",
+			},
+		},
+		{
+			name:             "first step end, second step start",
+			latencyPointerT1: "end",
+			latencyPointerT2: "start",
+			wantContains: []string{
+				"minIf(timestamp, serviceName = step1.1 AND name = step1.2) + toIntervalNanosecond(minIf(durationNano, serviceName = step1.1 AND name = step1.2)) AS t1_time",
+				"minIf(timestamp, serviceName = step2.1 AND name = step2.2) AS t2_time",
+			},
+		},
+		{
+			name:             "both steps with start latency",
+			latencyPointerT1: "start",
+			latencyPointerT2: "start",
+			wantContains: []string{
+				"minIf(timestamp, serviceName = step1.1 AND name = step1.2) AS t1_time",
+				"minIf(timestamp, serviceName = step2.1 AND name = step2.2) AS t2_time",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := BuildFunnelTopSlowTracesQuery(
+				0, 0,
+				1000000000, 2000000000,
+				"service1", "span1",
+				"service2", "span2",
+				"", "",
+				tt.latencyPointerT1,
+				tt.latencyPointerT2,
+			)
+			
+			for _, want := range tt.wantContains {
+				if !strings.Contains(query, want) {
+					t.Errorf("Query missing expected content: %s", want)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildFunnelTopSlowErrorTracesQuery_WithLatencyPointer(t *testing.T) {
+	tests := []struct {
+		name              string
+		latencyPointerT1  string
+		latencyPointerT2  string
+		wantContains      []string
+	}{
+		{
+			name:             "both steps with end latency",
+			latencyPointerT1: "end",
+			latencyPointerT2: "end",
+			wantContains: []string{
+				"minIf(timestamp, serviceName = step1.1 AND name = step1.2) + toIntervalNanosecond(minIf(durationNano, serviceName = step1.1 AND name = step1.2)) AS t1_time",
+				"minIf(timestamp, serviceName = step2.1 AND name = step2.2) + toIntervalNanosecond(minIf(durationNano, serviceName = step2.1 AND name = step2.2)) AS t2_time",
+			},
+		},
+		{
+			name:             "mixed latency pointers",
+			latencyPointerT1: "start",
+			latencyPointerT2: "end",
+			wantContains: []string{
+				"minIf(timestamp, serviceName = step1.1 AND name = step1.2) AS t1_time",
+				"minIf(timestamp, serviceName = step2.1 AND name = step2.2) + toIntervalNanosecond(minIf(durationNano, serviceName = step2.1 AND name = step2.2)) AS t2_time",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := BuildFunnelTopSlowErrorTracesQuery(
+				0, 0,
+				1000000000, 2000000000,
+				"service1", "span1",
+				"service2", "span2",
+				"", "",
+				tt.latencyPointerT1,
+				tt.latencyPointerT2,
+			)
+			
+			for _, want := range tt.wantContains {
+				if !strings.Contains(query, want) {
+					t.Errorf("Query missing expected content: %s", want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/modules/tracefunnel/query.go
+++ b/pkg/modules/tracefunnel/query.go
@@ -240,6 +240,16 @@ func GetSlowestTraces(funnel *tracefunneltypes.StorableFunnel, timeRange tracefu
 	clauseStep1 = sanitizeClause(clauseStep1)
 	clauseStep2 = sanitizeClause(clauseStep2)
 
+	// Get latency pointers with defaults
+	latencyPointerT1 := funnelSteps[stepStartOrder].LatencyPointer
+	if latencyPointerT1 == "" {
+		latencyPointerT1 = "start"
+	}
+	latencyPointerT2 := funnelSteps[stepEndOrder].LatencyPointer
+	if latencyPointerT2 == "" {
+		latencyPointerT2 = "start"
+	}
+
 	query := BuildFunnelTopSlowTracesQuery(
 		containsErrorT1,
 		containsErrorT2,
@@ -251,6 +261,8 @@ func GetSlowestTraces(funnel *tracefunneltypes.StorableFunnel, timeRange tracefu
 		funnelSteps[stepEndOrder].SpanName,
 		clauseStep1,
 		clauseStep2,
+		latencyPointerT1,
+		latencyPointerT2,
 	)
 	return &v3.ClickHouseQuery{Query: query}, nil
 }
@@ -287,6 +299,16 @@ func GetErroredTraces(funnel *tracefunneltypes.StorableFunnel, timeRange tracefu
 	clauseStep1 = sanitizeClause(clauseStep1)
 	clauseStep2 = sanitizeClause(clauseStep2)
 
+	// Get latency pointers with defaults
+	latencyPointerT1 := funnelSteps[stepStartOrder].LatencyPointer
+	if latencyPointerT1 == "" {
+		latencyPointerT1 = "start"
+	}
+	latencyPointerT2 := funnelSteps[stepEndOrder].LatencyPointer
+	if latencyPointerT2 == "" {
+		latencyPointerT2 = "start"
+	}
+
 	query := BuildFunnelTopSlowErrorTracesQuery(
 		containsErrorT1,
 		containsErrorT2,
@@ -298,6 +320,8 @@ func GetErroredTraces(funnel *tracefunneltypes.StorableFunnel, timeRange tracefu
 		funnelSteps[stepEndOrder].SpanName,
 		clauseStep1,
 		clauseStep2,
+		latencyPointerT1,
+		latencyPointerT2,
 	)
 	return &v3.ClickHouseQuery{Query: query}, nil
 }


### PR DESCRIPTION
…eries

- Updated BuildFunnelOverviewQuery and BuildFunnelStepOverviewQuery to calculate end time when latency_pointer is 'end'
- Modified BuildFunnelTopSlowTracesQuery and BuildFunnelTopSlowErrorTracesQuery to support latency pointer parameters
- Added comprehensive tests for latency pointer functionality in clickhouse_queries_latency_test.go
- When latency_pointer is 'end', the query now adds span duration to timestamp for accurate latency calculations

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->
