### PR TITLE
fix: disabling alert from overview page doesn't work

### DIFF
--- a/frontend/src/pages/AlertDetails/AlertHeader/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/pages/AlertDetails/AlertHeader/ActionButtons/ActionButtons.tsx
@@ -111,7 +111,7 @@ function AlertActionButtons({
 	return (
 		<>
 			<div className="alert-action-buttons">
-				<Tooltip title={alertRuleState ? 'Enable alert' : 'Disable alert'}>
+				<Tooltip title={isAlertRuleDisabled ? 'Enable alert' : 'Disable alert'}>
 					{isAlertRuleDisabled !== undefined && (
 						<Switch
 							size="small"

--- a/frontend/src/pages/AlertDetails/hooks.tsx
+++ b/frontend/src/pages/AlertDetails/hooks.tsx
@@ -394,7 +394,7 @@ export const useAlertRuleStatusToggle = ({
 		{
 			onSuccess: (data) => {
 				setAlertRuleState(data?.payload?.state);
-
+				queryClient.refetchQueries([REACT_QUERY_KEY.ALERT_RULE_DETAILS, ruleId]);
 				notifications.success({
 					message: `Alert has been ${
 						data?.payload?.state === 'disabled' ? 'disabled' : 'enabled'


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

2 issues resolved here:
- If the user disables/enables the alert, and then clicks on Save Rule. The save actions calls the API with the outdated payload as the query key is not invalidated after the enable/disable happens.
- The condition for the tooltip message for showing Enable/Disable was wrong. Fixed that

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

https://github.com/user-attachments/assets/0ed7de43-afc7-4aaf-8374-fdf3eb20a150

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix outdated payload and incorrect tooltip logic for enabling/disabling alerts in `ActionButtons.tsx` and `hooks.tsx`.
> 
>   - **Behavior**:
>     - Fix outdated payload issue when saving alert rules after enabling/disabling in `hooks.tsx` by refetching queries.
>     - Correct tooltip message logic for enabling/disabling alerts in `ActionButtons.tsx`.
>   - **Functions**:
>     - Update `useAlertRuleStatusToggle` in `hooks.tsx` to refetch `ALERT_RULE_DETAILS` query on success and error.
>     - Change tooltip title condition in `AlertActionButtons` in `ActionButtons.tsx` to use `isAlertRuleDisabled`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 8b6c355486fb7faf753a29a685dda819a4a3fbed. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->