### PR TITLE
fix(added-backticks): added backticks for hyphen also

### DIFF
--- a/pkg/query-service/utils/format.go
+++ b/pkg/query-service/utils/format.go
@@ -245,7 +245,7 @@ func ClickHouseFormattedMetricNames(v interface{}) string {
 }
 
 func AddBackTickToFormatTag(str string) string {
-	if strings.Contains(str, ".") {
+	if strings.Contains(str, ".") || strings.Contains(str, "-") {
 		return "`" + str + "`"
 	} else {
 		return str


### PR DESCRIPTION
## 📄 Summary

Added backtick so that clickhouse queries can work in metrics, so when use as alias we can surrond the variable with backtick

---

