### PR TITLE
test(integration): add or filter with resource attributes

### DIFF
--- a/tests/integration/fixtures/logs.py
+++ b/tests/integration/fixtures/logs.py
@@ -22,7 +22,7 @@ class LogsResource(ABC):
         fingerprint: str,
         seen_at_ts_bucket_start: np.int64,
     ) -> None:
-        self.labels = json.dumps(labels)
+        self.labels = json.dumps(labels, separators=(',', ':')) # clickhouse treats {"a": "b"} differently from {"a":"b"}. In the first case it is not able to run json functions
         self.fingerprint = fingerprint
         self.seen_at_ts_bucket_start = seen_at_ts_bucket_start
 


### PR DESCRIPTION
## 📄 Summary

- add or filter with resource attributes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds test for OR filter with resource attributes in logs query and updates JSON serialization in `logs.py`.
> 
>   - **Tests**:
>     - Adds test case in `a_logs.py` for counting logs where `service.name = "erlang" OR cloud.account.id = "000"` for the last 5 minutes.
>     - Updates `test_logs_time_series_count()` in `a_logs.py` to include the new OR filter test.
>   - **Serialization**:
>     - Modifies JSON serialization in `LogsResource.__init__()` in `logs.py` to use compact separators for ClickHouse compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for ffaa351d89aad2b176a434ea6bff15d348bf1840. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->