### PR TITLE
fix: adding missing flags to run go-run-community

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ go-run-community: ## Runs the community go backend server
 	SIGNOZ_TELEMETRYSTORE_PROVIDER=clickhouse \
 	SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_DSN=tcp://127.0.0.1:9000 \
 	go run -race \
-		$(GO_BUILD_CONTEXT_COMMUNITY)/*.go \
+		$(GO_BUILD_CONTEXT_COMMUNITY)/*.go server \
 		--config ./conf/prometheus.yml \
 		--cluster cluster
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,15 +18,6 @@ var RootCmd = &cobra.Command{
 	CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 }
 
-// Add config flag
-var configPath string
-var clusterName string
-
-func init() {
-	RootCmd.Flags().StringVarP(&configPath, "config", "c", "./conf/prometheus.yml", "Path to the configuration file")
-	RootCmd.Flags().StringVarP(&clusterName, "cluster", "l", "cluster", "Name of the cluster")
-}
-
 func Execute(logger *slog.Logger) {
 	zapLogger := newZapLogger()
 	zap.ReplaceGlobals(zapLogger)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,15 @@ var RootCmd = &cobra.Command{
 	CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 }
 
+// Add config flag
+var configPath string
+var clusterName string
+
+func init() {
+	RootCmd.Flags().StringVarP(&configPath, "config", "c", "./conf/prometheus.yml", "Path to the configuration file")
+	RootCmd.Flags().StringVarP(&clusterName, "cluster", "l", "cluster", "Name of the cluster")
+}
+
 func Execute(logger *slog.Logger) {
 	zapLogger := newZapLogger()
 	zap.ReplaceGlobals(zapLogger)


### PR DESCRIPTION
## 📄 Summary

The change adds missing flags required during execution of `make go-run-community`. Currently, running the command cause the error "unknown flag: --config", mentioned in the issue #8623 

---

## ✅ Changes

* Adds missing flags for config and cluster referenced in Makerfile required by root command.
* Adds server subcommand to Makerfile
---

## 👥 Reviewers

> Tag the relevant teams for review:

- backend
- @srikanthccv 
- @YounixM 

---

## 🧪 How to Test

1. make go-run-community
2. curl http://localhost:8080/api/v1/health

---

## Screenshot

<img width="811" height="345" alt="Screenshot 2025-07-29 175332" src="https://github.com/user-attachments/assets/18a070af-4e18-4312-9db6-bb4b27569202" />


---

## 🔍 Related Issues

Closes #8623

---

## 👀 Notes for Reviewers

* Current state on running `make go-run-community`
```bash
{"timestamp":"2025-07-29T11:50:13.306971609Z","level":"ERROR","code":{"function":"github.com/SigNoz/signoz/cmd.Execute","file":"/home/rajsinha/signoz/cmd/root.go","line":39},"msg":"error running command","error":"unknown flag: --config"}
exit status 1
make: *** [Makefile:87: go-run-community] Error 1
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes missing flags in `Makefile` and `cmd/root.go` for `go-run-community` command execution.
> 
>   - **Makefile**:
>     - Adds `server` subcommand to `go-run-community` target to fix execution error.
>   - **cmd/root.go**:
>     - Adds `config` and `cluster` flags to `RootCmd` to support configuration and cluster name specification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e18093e4d6e9bfce43ff0e77f440ce1e2f034877. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->