### PR TITLE
fix: fix the issue of stale pipeline processor state while switching between different processors after updating json flattening config in any processor

### DIFF
--- a/frontend/src/container/PipelinePage/PipelineListsView/AddNewProcessor/index.tsx
+++ b/frontend/src/container/PipelinePage/PipelineListsView/AddNewProcessor/index.tsx
@@ -33,6 +33,10 @@ function AddNewProcessor({
 	const isAdd = isActionType === 'add-processor';
 
 	useEffect(() => {
+		if (isEdit || isAdd) {
+			// Reset form first to clear any stale fields from previous processors
+			form.resetFields();
+		}
 		if (isEdit && selectedProcessorData && expandedPipelineData?.config) {
 			const findRecordIndex = getRecordIndex(
 				expandedPipelineData?.config,
@@ -45,9 +49,6 @@ function AddNewProcessor({
 			};
 			setProcessorType(updatedProcessorData.type);
 			form.setFieldsValue(updatedProcessorData);
-		}
-		if (isAdd) {
-			form.resetFields();
 		}
 	}, [form, isEdit, isAdd, selectedProcessorData, expandedPipelineData?.config]);
 


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes https://github.com/SigNoz/engineering-pod/issues/2721

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)
Before:

https://github.com/user-attachments/assets/0f69cd88-e171-4a36-8d4c-08caaca1c650



After:

https://github.com/user-attachments/assets/5a0165db-b1c3-4353-ad45-69c543031265



<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix stale form data issue in `AddNewProcessor` by resetting form fields when switching processors.
> 
>   - **Bug Fix**:
>     - In `AddNewProcessor` component, reset form fields when `isEdit` or `isAdd` is true to clear stale data from previous processors.
>     - Removed redundant `form.resetFields()` call when `isAdd` is true, as it is now covered by the combined condition `isEdit || isAdd`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for d59e9c59dafecc98b8908df0f3c8368bc26c69ed. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->