### PR TITLE
fix: added fix for persisting currentquery even without stage+run and…

### DIFF
--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -386,8 +386,29 @@ function DateTimeSelection({
 			// Remove Hidden Filters from URL query parameters on time change
 			urlQuery.delete(QueryParams.activeLogId);
 
-			const updatedCompositeQuery = cloneDeep(currentQuery);
+			let updatedCompositeQuery = cloneDeep(currentQuery);
 			updatedCompositeQuery.id = uuid();
+			// Remove the filters
+			updatedCompositeQuery = {
+				...updatedCompositeQuery,
+				builder: {
+					...updatedCompositeQuery.builder,
+					queryData: updatedCompositeQuery.builder.queryData.map((item) => ({
+						...item,
+						filter: {
+							...item.filter,
+							expression:
+								item.filter?.expression.trim() === ''
+									? ''
+									: item.filter?.expression ?? '',
+						},
+						filters: {
+							items: [],
+							op: 'AND',
+						},
+					})),
+				},
+			};
 			urlQuery.set(
 				QueryParams.compositeQuery,
 				JSON.stringify(updatedCompositeQuery),
@@ -396,7 +417,7 @@ function DateTimeSelection({
 			const generatedUrl = `${location.pathname}?${urlQuery.toString()}`;
 			safeNavigate(generatedUrl);
 
-			// For logs explorer - time range handling is managed in useCopyLogLink.ts:52
+			// // For logs explorer - time range handling is managed in useCopyLogLink.ts:52
 		},
 		[
 			isModalTimeSelection,

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -363,10 +363,7 @@ function DateTimeSelection({
 					...item,
 					filter: {
 						...item.filter,
-						expression:
-							item.filter?.expression.trim() === ''
-								? ''
-								: item.filter?.expression ?? '',
+						expression: item.filter?.expression?.trim() || '',
 					},
 					filters: {
 						items: [],

--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -29,7 +29,7 @@ import { createIdFromObjectFields } from 'lib/createIdFromObjectFields';
 import { createNewBuilderItemName } from 'lib/newQueryBuilder/createNewBuilderItemName';
 import { getOperatorsBySourceAndPanelType } from 'lib/newQueryBuilder/getOperatorsBySourceAndPanelType';
 import { replaceIncorrectObjectFields } from 'lib/replaceIncorrectObjectFields';
-import { cloneDeep, get, isEqual, merge, set } from 'lodash-es';
+import { cloneDeep, get, isEqual, set } from 'lodash-es';
 import {
 	createContext,
 	PropsWithChildren,
@@ -219,7 +219,7 @@ export function QueryBuilderProvider({
 	);
 
 	const initQueryBuilderData = useCallback(
-		(query: Query, timeUpdated?: boolean): void => {
+		(query: Query): void => {
 			const { queryType: newQueryType, ...queryState } = prepareQueryBuilderData(
 				query,
 			);
@@ -234,12 +234,10 @@ export function QueryBuilderProvider({
 			const nextQuery: Query = { ...newQueryState, queryType: type };
 
 			setStagedQuery(nextQuery);
-			setCurrentQuery(
-				timeUpdated ? merge(currentQuery, newQueryState) : newQueryState,
-			);
+			setCurrentQuery(newQueryState);
 			setQueryType(type);
 		},
-		[prepareQueryBuilderData, currentQuery],
+		[prepareQueryBuilderData],
 	);
 
 	const updateAllQueriesOperators = useCallback(


### PR DESCRIPTION
… with changing time

## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes
 - Fix for persisting current query even if user doesn't run the query and changes time 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes query persistence issue in `DateTimeSelection` when changing time without running the query, updating URL with `compositeQuery`.
> 
>   - **Behavior**:
>     - Fixes issue where current query was not persisted when time was changed without running the query in `DateTimeSelection`.
>     - Updates URL with `compositeQuery` parameter using `getUpdatedCompositeQuery()` in `DateTimeSelection`.
>   - **Functions**:
>     - Adds `getUpdatedCompositeQuery()` in `DateTimeSelection` to clone and update query ID, clear filters.
>     - Modifies `initQueryBuilderData()` in `QueryBuilderProvider` to remove `timeUpdated` parameter and always set `currentQuery` to `newQueryState`.
>   - **Imports**:
>     - Adds `cloneDeep` and `uuid` imports in `DateTimeSelection` for deep cloning and unique ID generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for bf898102c49e35ea05a7aecaab7c5cf743e0bae9. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->