### PR TITLE
fix: cloned panel query shows previous query

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.tsx
@@ -198,9 +198,6 @@ function WidgetGraphComponent({
 								JSON.stringify(clonedWidget.query),
 							),
 						}),
-						// [QueryParams.compositeQuery]: encodeURIComponent(
-						// 	JSON.stringify(clonedWidget?.query),
-						// ),
 					};
 					safeNavigate(`${pathname}/new?${createQueryParams(queryParams)}`);
 				},

--- a/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.tsx
@@ -30,6 +30,7 @@ import {
 	useState,
 } from 'react';
 import { useLocation } from 'react-router-dom';
+import { Widgets } from 'types/api/dashboard/getAll';
 import { Props } from 'types/api/dashboard/update';
 import { DataSource } from 'types/common/queryBuilder';
 import { v4 } from 'uuid';
@@ -184,9 +185,22 @@ function WidgetGraphComponent({
 					notifications.success({
 						message: 'Panel cloned successfully, redirecting to new copy.',
 					});
+
+					const clonedWidget = updatedDashboard.data?.data?.widgets?.find(
+						(w) => w.id === uuid,
+					) as Widgets;
+
 					const queryParams = {
-						graphType: widget?.panelTypes,
-						widgetId: uuid,
+						[QueryParams.graphType]: clonedWidget?.panelTypes,
+						[QueryParams.widgetId]: uuid,
+						...(clonedWidget.query && {
+							[QueryParams.compositeQuery]: encodeURIComponent(
+								JSON.stringify(clonedWidget.query),
+							),
+						}),
+						// [QueryParams.compositeQuery]: encodeURIComponent(
+						// 	JSON.stringify(clonedWidget?.query),
+						// ),
 					};
 					safeNavigate(`${pathname}/new?${createQueryParams(queryParams)}`);
 				},

--- a/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.tsx
@@ -193,7 +193,7 @@ function WidgetGraphComponent({
 					const queryParams = {
 						[QueryParams.graphType]: clonedWidget?.panelTypes,
 						[QueryParams.widgetId]: uuid,
-						...(clonedWidget.query && {
+						...(clonedWidget?.query && {
 							[QueryParams.compositeQuery]: encodeURIComponent(
 								JSON.stringify(clonedWidget.query),
 							),

--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -900,27 +900,42 @@ export function QueryBuilderProvider({
 	);
 
 	useEffect(() => {
+		if (location.pathname !== currentPathnameRef.current) {
+			currentPathnameRef.current = location.pathname;
+
+			setStagedQuery(null);
+			// reset the last used query to 0 when navigating away from the page
+			setLastUsedQuery(0);
+		}
+	}, [location.pathname]);
+
+	// Separate useEffect to handle initQueryBuilderData after pathname changes
+	useEffect(() => {
 		if (!compositeQueryParam) return;
 
-		if (stagedQuery && stagedQuery.id === compositeQueryParam.id) {
-			return;
-		}
+		// Only run initQueryBuilderData if we're not in the middle of a pathname change
+		if (location.pathname === currentPathnameRef.current) {
+			if (stagedQuery && stagedQuery.id === compositeQueryParam.id) {
+				return;
+			}
 
-		const { isValid, validData } = replaceIncorrectObjectFields(
-			compositeQueryParam,
-			initialQueriesMap.metrics,
-		);
+			const { isValid, validData } = replaceIncorrectObjectFields(
+				compositeQueryParam,
+				initialQueriesMap.metrics,
+			);
 
-		if (!isValid) {
-			redirectWithQueryBuilderData(validData);
-		} else {
-			initQueryBuilderData(compositeQueryParam);
+			if (!isValid) {
+				redirectWithQueryBuilderData(validData);
+			} else {
+				initQueryBuilderData(compositeQueryParam);
+			}
 		}
 	}, [
 		initQueryBuilderData,
 		redirectWithQueryBuilderData,
 		compositeQueryParam,
 		stagedQuery,
+		location.pathname,
 	]);
 
 	const resetQuery = (newCurrentQuery?: QueryState): void => {
@@ -931,16 +946,6 @@ export function QueryBuilderProvider({
 			setSupersetQuery(newCurrentQuery);
 		}
 	};
-
-	useEffect(() => {
-		if (location.pathname !== currentPathnameRef.current) {
-			currentPathnameRef.current = location.pathname;
-
-			setStagedQuery(null);
-			// reset the last used query to 0 when navigating away from the page
-			setLastUsedQuery(0);
-		}
-	}, [location.pathname]);
 
 	const handleOnUnitsChange = useCallback(
 		(unit: string) => {


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- Fix for cloned panel query showing previous query
- Fix for query not running when opening dashboard panel
- Fix for trace explorer api not triggering when coming back from span details
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix cloned panel query issue by updating query parameters and ensuring correct query initialization after pathname changes.
> 
>   - **Behavior**:
>     - Fix cloned panel query showing previous query in `WidgetGraphComponent.tsx` by updating query parameters with `clonedWidget.query`.
>     - Ensure `initQueryBuilderData` runs correctly after pathname changes in `QueryBuilder.tsx`.
>   - **Functions**:
>     - Update `onCloneHandler` in `WidgetGraphComponent.tsx` to include `compositeQuery` in query parameters.
>     - Modify `useEffect` in `QueryBuilder.tsx` to handle pathname changes and initialize query builder data correctly.
>   - **Misc**:
>     - Add import for `Widgets` in `WidgetGraphComponent.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for c3805c3f32c9fc97f85aefb4541a44f3907f3c73. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->