### PR TITLE
chore: improve metrics explorer empty state

### DIFF
--- a/frontend/src/container/MetricsExplorer/Summary/Summary.tsx
+++ b/frontend/src/container/MetricsExplorer/Summary/Summary.tsx
@@ -1,9 +1,11 @@
+/* eslint-disable no-nested-ternary */
 import './Summary.styles.scss';
 
 import * as Sentry from '@sentry/react';
 import logEvent from 'api/common/logEvent';
 import { initialQueriesMap } from 'constants/queryBuilder';
 import { usePageSize } from 'container/InfraMonitoringK8s/utils';
+import NoLogs from 'container/NoLogs/NoLogs';
 import { useGetMetricsList } from 'hooks/metricsExplorer/useGetMetricsList';
 import { useGetMetricsTreeMap } from 'hooks/metricsExplorer/useGetMetricsTreeMap';
 import ErrorBoundaryFallback from 'pages/ErrorBoundaryFallback/ErrorBoundaryFallback';
@@ -12,11 +14,13 @@ import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { AppState } from 'store/reducers';
 import { TagFilter } from 'types/api/queryBuilder/queryBuilderData';
+import { DataSource } from 'types/common/queryBuilder';
 import { GlobalReducer } from 'types/reducer/globalTime';
 
 import { MetricsExplorerEventKeys, MetricsExplorerEvents } from '../events';
 import InspectModal from '../Inspect';
 import MetricDetails from '../MetricDetails';
+import { MetricsLoading } from '../MetricsLoading/MetricsLoading';
 import {
 	IS_INSPECT_MODAL_OPEN_KEY,
 	IS_METRIC_DETAILS_OPEN_KEY,
@@ -267,30 +271,64 @@ function Summary(): JSX.Element {
 		});
 	};
 
+	const isMetricsListDataEmpty = useMemo(
+		() =>
+			formattedMetricsData.length === 0 && !isMetricsLoading && !isMetricsFetching,
+		[formattedMetricsData, isMetricsLoading, isMetricsFetching],
+	);
+
+	const isMetricsTreeMapDataEmpty = useMemo(
+		() =>
+			!treeMapData?.payload?.data[heatmapView]?.length &&
+			!isTreeMapLoading &&
+			!isTreeMapFetching,
+		[
+			treeMapData?.payload?.data,
+			heatmapView,
+			isTreeMapLoading,
+			isTreeMapFetching,
+		],
+	);
+
+	console.log({
+		isMetricsListDataEmpty,
+		isMetricsTreeMapDataEmpty,
+		treeMapData,
+		sec: treeMapData?.payload?.data[heatmapView],
+	});
+
 	return (
 		<Sentry.ErrorBoundary fallback={<ErrorBoundaryFallback />}>
 			<div className="metrics-explorer-summary-tab">
 				<MetricsSearch query={searchQuery} onChange={handleFilterChange} />
-				<MetricsTreemap
-					data={treeMapData?.payload}
-					isLoading={isTreeMapLoading || isTreeMapFetching}
-					isError={isProportionViewError}
-					viewType={heatmapView}
-					openMetricDetails={openMetricDetails}
-					setHeatmapView={handleSetHeatmapView}
-				/>
-				<MetricsTable
-					isLoading={isMetricsLoading || isMetricsFetching}
-					isError={isListViewError}
-					data={formattedMetricsData}
-					pageSize={pageSize}
-					currentPage={currentPage}
-					onPaginationChange={onPaginationChange}
-					setOrderBy={handleSetOrderBy}
-					totalCount={metricsData?.payload?.data?.total || 0}
-					openMetricDetails={openMetricDetails}
-					queryFilters={queryFilters}
-				/>
+				{isMetricsLoading || isTreeMapLoading ? (
+					<MetricsLoading />
+				) : isMetricsListDataEmpty && isMetricsTreeMapDataEmpty ? (
+					<NoLogs dataSource={DataSource.METRICS} />
+				) : (
+					<>
+						<MetricsTreemap
+							data={treeMapData?.payload}
+							isLoading={isTreeMapLoading || isTreeMapFetching}
+							isError={isProportionViewError}
+							viewType={heatmapView}
+							openMetricDetails={openMetricDetails}
+							setHeatmapView={handleSetHeatmapView}
+						/>
+						<MetricsTable
+							isLoading={isMetricsLoading || isMetricsFetching}
+							isError={isListViewError}
+							data={formattedMetricsData}
+							pageSize={pageSize}
+							currentPage={currentPage}
+							onPaginationChange={onPaginationChange}
+							setOrderBy={handleSetOrderBy}
+							totalCount={metricsData?.payload?.data?.total || 0}
+							openMetricDetails={openMetricDetails}
+							queryFilters={queryFilters}
+						/>
+					</>
+				)}
 			</div>
 			{isMetricDetailsOpen && (
 				<MetricDetails

--- a/frontend/src/container/NoLogs/NoLogs.tsx
+++ b/frontend/src/container/NoLogs/NoLogs.tsx
@@ -27,14 +27,22 @@ export default function NoLogs({
 				logEvent('Traces Explorer: Navigate to onboarding', {});
 			} else if (dataSource === DataSource.LOGS) {
 				logEvent('Logs Explorer: Navigate to onboarding', {});
+			} else if (dataSource === DataSource.METRICS) {
+				logEvent('Metrics Explorer: Navigate to onboarding', {});
 			}
-			history.push(
-				dataSource === 'traces'
-					? ROUTES.GET_STARTED_APPLICATION_MONITORING
-					: ROUTES.GET_STARTED_LOGS_MANAGEMENT,
-			);
+			let link;
+			if (dataSource === DataSource.TRACES) {
+				link = ROUTES.GET_STARTED_APPLICATION_MONITORING;
+			} else if (dataSource === DataSource.METRICS) {
+				link = ROUTES.GET_STARTED_WITH_CLOUD;
+			} else {
+				link = ROUTES.GET_STARTED_LOGS_MANAGEMENT;
+			}
+			history.push(link);
 		} else if (dataSource === 'traces') {
 			window.open(DOCLINKS.TRACES_EXPLORER_EMPTY_STATE, '_blank');
+		} else if (dataSource === DataSource.METRICS) {
+			window.open(DOCLINKS.METRICS_EXPLORER_EMPTY_STATE, '_blank');
 		} else {
 			window.open(`${DOCLINKS.USER_GUIDE}${dataSource}/`, '_blank');
 		}

--- a/frontend/src/utils/docLinks.ts
+++ b/frontend/src/utils/docLinks.ts
@@ -4,6 +4,8 @@ const DOCLINKS = {
 	USER_GUIDE: 'https://signoz.io/docs/userguide/',
 	TRACES_DETAILS_LINK:
 		'https://signoz.io/docs/product-features/trace-explorer/?utm_source=product&utm_medium=traces-explorer-trace-tab#traces-view',
+	METRICS_EXPLORER_EMPTY_STATE:
+		'https://signoz.io/docs/userguide/send-metrics-cloud/',
 };
 
 export default DOCLINKS;


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

improve metrics explorer empty state

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

https://github.com/user-attachments/assets/b6bb7d37-93cd-45d3-abe6-537dcabda93b

https://github.com/user-attachments/assets/4dec5eae-b9f6-450e-b710-7bc3728de09d

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves Metrics Explorer empty state handling with new component and updated navigation logic.
> 
>   - **Behavior**:
>     - Adds `NoLogs` component to `Summary.tsx` for empty state handling in Metrics Explorer.
>     - Updates navigation logic in `NoLogs.tsx` to handle `DataSource.METRICS`.
>     - Displays `MetricsLoading` component when metrics or treemap data is loading.
>   - **Documentation**:
>     - Adds `METRICS_EXPLORER_EMPTY_STATE` link to `docLinks.ts` for metrics documentation.
>   - **Misc**:
>     - Minor logging changes in `Summary.tsx` and `NoLogs.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 7754e49a4fbfbb920afda5a2fad5461c795bbf9e. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->