### PR TITLE
fix: added fix for query addon lightmode ui

### DIFF
--- a/frontend/src/components/QueryBuilderV2/QueryV2/QueryAddOns/QueryAddOns.styles.scss
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QueryAddOns/QueryAddOns.styles.scss
@@ -127,6 +127,7 @@
 					box-sizing: border-box;
 					box-shadow: 0 4px 8px rgba(0, 0, 0, 0.6);
 					font-family: 'Space Mono', monospace !important;
+					color: var(--bg-vanilla-100) !important;
 
 					ul {
 						width: 100% !important;

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QueryAddOns/QueryAddOns.styles.scss
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QueryAddOns/QueryAddOns.styles.scss
@@ -162,7 +162,6 @@
 							overflow: hidden;
 
 							font-family: 'Space Mono', monospace !important;
-							color: var(--bg-vanilla-100) !important;
 
 							.cm-completionIcon {
 								display: none !important;
@@ -331,13 +330,14 @@
 
 						ul {
 							li {
+								color: var(--bg-ink-300) !important;
 								&:hover {
 									background: var(--bg-vanilla-300) !important;
 								}
 
 								&[aria-selected='true'] {
-									color: var(--bg-ink-500) !important;
 									background: var(--bg-vanilla-300) !important;
+									font-weight: 600 !important;
 								}
 							}
 						}

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QueryAggregation/QueryAggregation.styles.scss
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QueryAggregation/QueryAggregation.styles.scss
@@ -271,16 +271,13 @@
 
 							ul {
 								li {
-									&:hover {
-										background-color: var(--bg-vanilla-300) !important;
-										color: var(--bg-ink-500) !important;
-										font-weight: 600;
-									}
+									color: var(--bg-ink-300) !important;
 
+									&:hover,
 									&[aria-selected='true'] {
 										background: var(--bg-vanilla-300) !important;
 										color: var(--bg-ink-500) !important;
-										font-weight: 600;
+										font-weight: 600 !important;
 									}
 								}
 							}

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.styles.scss
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.styles.scss
@@ -585,7 +585,7 @@
 						&:hover,
 						&[aria-selected='true'] {
 							background-color: var(--bg-vanilla-300) !important;
-							font-weight: 600;
+							font-weight: 600 !important;
 						}
 					}
 				}


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- Added fix for query addon lightmode ui

Before:
<img width="1928" height="325" alt="image" src="https://github.com/user-attachments/assets/91076487-7eb5-477d-ab5f-b68514874067" />

After: 
<img width="1979" height="312" alt="image" src="https://github.com/user-attachments/assets/be85035b-cc6c-49d7-a202-e2d3e752c939" />



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes light mode UI styling for query addon components by adjusting colors and font weights for better visibility.
> 
>   - **Styles**:
>     - In `QueryAddOns.styles.scss`, removed `color: var(--bg-vanilla-100)` and added `color: var(--bg-ink-300)` for list items. Adjusted font weight to 600 for selected items.
>     - In `QueryAggregation.styles.scss`, removed hover color change for list items and added `color: var(--bg-ink-300)`. Adjusted font weight to 600 for selected items.
>     - In `QuerySearch.styles.scss`, added `font-weight: 600` for selected list items and adjusted hover background color to `var(--bg-vanilla-300)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for eb6ca6042d42368755d030d6d058212b69b7841a. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->