### PR TITLE
fix: limit keys for empty search key

### DIFF
--- a/pkg/telemetrymetadata/metadata.go
+++ b/pkg/telemetrymetadata/metadata.go
@@ -179,6 +179,9 @@ func (t *telemetryMetaStore) getTracesKeys(ctx context.Context, fieldKeySelector
 
 		conds = append(conds, sb.And(fieldKeyConds...))
 		limit += fieldKeySelector.Limit
+		if strings.TrimSpace(fieldKeySelector.Name) == "" {
+			sb.Limit(200)
+		}
 	}
 	sb.Where(sb.Or(conds...))
 	sb.GroupBy("tag_key", "tag_type", "tag_data_type")
@@ -387,6 +390,9 @@ func (t *telemetryMetaStore) getLogsKeys(ctx context.Context, fieldKeySelectors 
 
 		conds = append(conds, sb.And(fieldKeyConds...))
 		limit += fieldKeySelector.Limit
+		if strings.TrimSpace(fieldKeySelector.Name) == "" {
+			sb.Limit(200)
+		}
 	}
 	sb.Where(sb.Or(conds...))
 	sb.GroupBy("tag_key", "tag_type", "tag_data_type")


### PR DESCRIPTION
## 📄 Summary


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add a limit of 200 to SQL queries in `getTracesKeys` and `getLogsKeys` when `fieldKeySelector.Name` is empty in `metadata.go`.
> 
>   - **Behavior**:
>     - In `getTracesKeys` and `getLogsKeys` in `metadata.go`, add a limit of 200 to SQL queries when `fieldKeySelector.Name` is empty.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 751802f2116fde4e2e2be8963b347cbe48b716b4. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->