### PR TITLE
fix: added fix for extractquerypararms when value is string in multivalue operators

### DIFF
--- a/frontend/src/utils/queryContextUtils.ts
+++ b/frontend/src/utils/queryContextUtils.ts
@@ -1279,6 +1279,15 @@ export function extractQueryPairs(query: string): IQueryPair[] {
 						if (allTokens[iterator].type === closingToken) {
 							multiValueEnd = allTokens[iterator].stop;
 						}
+					} else if (isValueToken(allTokens[iterator].type)) {
+						valueList.push(allTokens[iterator].text);
+						valuesPosition.push({
+							start: allTokens[iterator].start,
+							end: allTokens[iterator].stop,
+						});
+						multiValueStart = allTokens[iterator].start;
+						multiValueEnd = allTokens[iterator].stop;
+						iterator += 1;
 					}
 
 					currentPair.valuesPosition = valuesPosition;


### PR DESCRIPTION
…alue operator

## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- Added fix for extractQueryPararms when value is string in multivalue operators.
