### PR TITLE
chore: add option to ignore data skipping indices

### DIFF
--- a/pkg/telemetrystore/config.go
+++ b/pkg/telemetrystore/config.go
@@ -40,11 +40,12 @@ type ClickhouseConfig struct {
 }
 
 type QuerySettings struct {
-	MaxExecutionTime                    int `mapstructure:"max_execution_time"`
-	MaxExecutionTimeLeaf                int `mapstructure:"max_execution_time_leaf"`
-	TimeoutBeforeCheckingExecutionSpeed int `mapstructure:"timeout_before_checking_execution_speed"`
-	MaxBytesToRead                      int `mapstructure:"max_bytes_to_read"`
-	MaxResultRows                       int `mapstructure:"max_result_rows"`
+	MaxExecutionTime                    int    `mapstructure:"max_execution_time"`
+	MaxExecutionTimeLeaf                int    `mapstructure:"max_execution_time_leaf"`
+	TimeoutBeforeCheckingExecutionSpeed int    `mapstructure:"timeout_before_checking_execution_speed"`
+	MaxBytesToRead                      int    `mapstructure:"max_bytes_to_read"`
+	MaxResultRows                       int    `mapstructure:"max_result_rows"`
+	IgnoreDataSkippingIndices           string `mapstructure:"ignore_data_skipping_indices"`
 }
 
 func NewConfigFactory() factory.ConfigFactory {

--- a/pkg/telemetrystore/telemetrystorehook/settings.go
+++ b/pkg/telemetrystore/telemetrystorehook/settings.go
@@ -53,6 +53,10 @@ func (h *provider) BeforeQuery(ctx context.Context, _ *telemetrystore.QueryEvent
 		settings["timeout_before_checking_execution_speed"] = h.settings.TimeoutBeforeCheckingExecutionSpeed
 	}
 
+	if h.settings.IgnoreDataSkippingIndices != "" {
+		settings["ignore_data_skipping_indices"] = h.settings.IgnoreDataSkippingIndices
+	}
+
 	if ctx.Value("clickhouse_max_threads") != nil {
 		if maxThreads, ok := ctx.Value("clickhouse_max_threads").(int); ok {
 			settings["max_threads"] = maxThreads


### PR DESCRIPTION
```
"SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_SETTINGS_IGNORE__DATA__SKIPPING__INDICES": "body_idx"
```