### PR TITLE
test(integration): bump requests to 2.32.4

### DIFF
--- a/tests/integration/poetry.lock
+++ b/tests/integration/poetry.lock
@@ -869,19 +869,19 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.32.3"
+version = "2.32.4"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
-    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
+    {file = "requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c"},
+    {file = "requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<4"
+charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<3"
 
@@ -1223,4 +1223,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "e55e2d0af184876ca7c3a42d700c085abd3516430120c04cb984f254a052ac00"
+content-hash = "200a3892f48467b2639abfae99b94b6de6b75fe09f9669ea115eb2b55a2f46ea"

--- a/tests/integration/pyproject.toml
+++ b/tests/integration/pyproject.toml
@@ -10,11 +10,11 @@ python = "^3.13"
 pytest = "^8.3.5"
 psycopg2 = "^2.9.10"
 testcontainers = "^4.10.0"
-requests = "^2.32.3"
 wiremock = "^2.6.1"
 numpy = "^2.3.2"
 clickhouse-connect = "^0.8.18"
 svix-ksuid = "^0.6.2"
+requests = "^2.32.4"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## 📄 Summary

- bump requests to 2.32.4

Closes a vulnerability
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `requests` version to `2.32.4` in `tests/integration/pyproject.toml` to address a security vulnerability.
> 
>   - **Dependencies**:
>     - Bump `requests` version from `2.32.3` to `2.32.4` in `tests/integration/pyproject.toml` to address a security vulnerability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 868aa2619f4788fdba3c0b2f7952e1e52bdca4ad. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->