### PR TITLE
fix: use localstorage value to avoid waiting for pref api to set the toggle state, add shortcut

### DIFF
--- a/frontend/src/constants/shortcuts/globalShortcuts.ts
+++ b/frontend/src/constants/shortcuts/globalShortcuts.ts
@@ -6,6 +6,7 @@ export const GlobalShortcuts = {
 	NavigateToAlerts: 'a+shift',
 	NavigateToExceptions: 'e+shift',
 	NavigateToMessagingQueues: 'm+shift',
+	ToggleSidebar: 'b+shift',
 };
 
 export const GlobalShortcutsName = {
@@ -16,6 +17,7 @@ export const GlobalShortcutsName = {
 	NavigateToAlerts: 'shift+a',
 	NavigateToExceptions: 'shift+e',
 	NavigateToMessagingQueues: 'shift+m',
+	ToggleSidebar: 'shift+b',
 };
 
 export const GlobalShortcutsDescription = {
@@ -26,4 +28,5 @@ export const GlobalShortcutsDescription = {
 	NavigateToAlerts: 'Navigate to alerts page',
 	NavigateToExceptions: 'Navigate to Exceptions page',
 	NavigateToMessagingQueues: 'Navigate to Messaging Queues page',
+	ToggleSidebar: 'Toggle sidebar visibility',
 };

--- a/frontend/src/container/AppLayout/__tests__/sidebar-toggle-shortcut.test.tsx
+++ b/frontend/src/container/AppLayout/__tests__/sidebar-toggle-shortcut.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import logEvent from 'api/common/logEvent';
+import { GlobalShortcuts } from 'constants/shortcuts/globalShortcuts';
+import { USER_PREFERENCES } from 'constants/userPreferences';
+import {
+	KeyboardHotkeysProvider,
+	useKeyboardHotkeys,
+} from 'hooks/hotkeys/useKeyboardHotkeys';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+// Mock dependencies
+jest.mock('api/common/logEvent', () => jest.fn());
+
+// Mock the AppContext
+const mockUpdateUserPreferenceInContext = jest.fn();
+
+const SHIFT_B_KEYBOARD_SHORTCUT = '{Shift>}b{/Shift}';
+
+jest.mock('providers/App/App', () => ({
+	useAppContext: jest.fn(() => ({
+		userPreferences: [
+			{
+				name: USER_PREFERENCES.SIDENAV_PINNED,
+				value: false,
+			},
+		],
+		updateUserPreferenceInContext: mockUpdateUserPreferenceInContext,
+	})),
+}));
+
+function TestComponent({
+	mockHandleShortcut,
+}: {
+	mockHandleShortcut: () => void;
+}): JSX.Element {
+	const { registerShortcut } = useKeyboardHotkeys();
+	registerShortcut(GlobalShortcuts.ToggleSidebar, mockHandleShortcut);
+	return <div data-testid="test">Test</div>;
+}
+
+describe('Sidebar Toggle Shortcut', () => {
+	let queryClient: QueryClient;
+
+	beforeEach(() => {
+		queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+				mutations: {
+					retry: false,
+				},
+			},
+		});
+
+		jest.clearAllMocks();
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('Global Shortcuts Constants', () => {
+		it('should have the correct shortcut key combination', () => {
+			expect(GlobalShortcuts.ToggleSidebar).toBe('b+shift');
+		});
+	});
+
+	describe('Keyboard Shortcut Registration', () => {
+		it('should register the sidebar toggle shortcut correctly', async () => {
+			const user = userEvent.setup();
+			const mockHandleShortcut = jest.fn();
+
+			render(
+				<QueryClientProvider client={queryClient}>
+					<KeyboardHotkeysProvider>
+						<TestComponent mockHandleShortcut={mockHandleShortcut} />
+					</KeyboardHotkeysProvider>
+				</QueryClientProvider>,
+			);
+
+			// Trigger the shortcut
+			await user.keyboard(SHIFT_B_KEYBOARD_SHORTCUT);
+
+			expect(mockHandleShortcut).toHaveBeenCalled();
+		});
+
+		it('should not trigger shortcut in input fields', async () => {
+			const user = userEvent.setup();
+			const mockHandleShortcut = jest.fn();
+
+			function TestComponent(): JSX.Element {
+				const { registerShortcut } = useKeyboardHotkeys();
+				registerShortcut(GlobalShortcuts.ToggleSidebar, mockHandleShortcut);
+				return (
+					<div>
+						<input data-testid="input-field" />
+						<div data-testid="test">Test</div>
+					</div>
+				);
+			}
+
+			render(
+				<QueryClientProvider client={queryClient}>
+					<KeyboardHotkeysProvider>
+						<TestComponent />
+					</KeyboardHotkeysProvider>
+				</QueryClientProvider>,
+			);
+
+			// Focus on input field
+			const inputField = screen.getByTestId('input-field');
+			await user.click(inputField);
+
+			// Try to trigger shortcut while focused on input
+			await user.keyboard('{Shift>}b{/Shift}');
+
+			// Should not trigger the shortcut
+			expect(mockHandleShortcut).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Sidebar Toggle Functionality', () => {
+		it('should log the toggle event with correct parameters', async () => {
+			const user = userEvent.setup();
+			const mockHandleShortcut = jest.fn(() => {
+				logEvent('Global Shortcut: Sidebar Toggle', {
+					previousState: false,
+					newState: true,
+				});
+			});
+
+			render(
+				<QueryClientProvider client={queryClient}>
+					<KeyboardHotkeysProvider>
+						<TestComponent mockHandleShortcut={mockHandleShortcut} />
+					</KeyboardHotkeysProvider>
+				</QueryClientProvider>,
+			);
+
+			await user.keyboard(SHIFT_B_KEYBOARD_SHORTCUT);
+
+			expect(logEvent).toHaveBeenCalledWith('Global Shortcut: Sidebar Toggle', {
+				previousState: false,
+				newState: true,
+			});
+		});
+
+		it('should update user preference in context', async () => {
+			const user = userEvent.setup();
+			const mockHandleShortcut = jest.fn(() => {
+				const save = {
+					name: USER_PREFERENCES.SIDENAV_PINNED,
+					value: true,
+				};
+				mockUpdateUserPreferenceInContext(save);
+			});
+
+			render(
+				<QueryClientProvider client={queryClient}>
+					<KeyboardHotkeysProvider>
+						<TestComponent mockHandleShortcut={mockHandleShortcut} />
+					</KeyboardHotkeysProvider>
+				</QueryClientProvider>,
+			);
+
+			await user.keyboard(SHIFT_B_KEYBOARD_SHORTCUT);
+
+			expect(mockUpdateUserPreferenceInContext).toHaveBeenCalledWith({
+				name: USER_PREFERENCES.SIDENAV_PINNED,
+				value: true,
+			});
+		});
+	});
+});

--- a/frontend/src/container/MySettings/index.tsx
+++ b/frontend/src/container/MySettings/index.tsx
@@ -1,6 +1,7 @@
 import './MySettings.styles.scss';
 
 import { Radio, RadioChangeEvent, Switch, Tag } from 'antd';
+import setLocalStorageApi from 'api/browser/localstorage/set';
 import logEvent from 'api/common/logEvent';
 import updateUserPreference from 'api/v1/user/preferences/name/update';
 import { AxiosError } from 'axios';
@@ -109,6 +110,9 @@ function MySettings(): JSX.Element {
 		// Optimistically update the UI
 		setSideNavPinned(checked);
 
+		// Save to localStorage immediately for instant feedback
+		setLocalStorageApi(USER_PREFERENCES.SIDENAV_PINNED, checked.toString());
+
 		// Update the context immediately
 		const save = {
 			name: USER_PREFERENCES.SIDENAV_PINNED,
@@ -130,6 +134,8 @@ function MySettings(): JSX.Element {
 						name: USER_PREFERENCES.SIDENAV_PINNED,
 						value: !checked,
 					} as UserPreference);
+					// Also revert localStorage
+					setLocalStorageApi(USER_PREFERENCES.SIDENAV_PINNED, (!checked).toString());
 					showErrorNotification(notifications, error as AxiosError);
 				},
 			},


### PR DESCRIPTION

## 📄 Summary

fix: use localstorage value to avoid waiting for pref api to set the toggle state, add shortcut

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `ToggleSidebar` shortcut and optimizes sidebar state management using localStorage for immediate feedback.
> 
>   - **Behavior**:
>     - Adds `ToggleSidebar` shortcut (`b+shift`) to `globalShortcuts.ts`.
>     - Uses localStorage for `SIDENAV_PINNED` to provide immediate feedback on sidebar toggle in `AppLayout/index.tsx` and `MySettings/index.tsx`.
>     - Updates user preference context and makes API call in the background for sidebar state changes.
>   - **Tests**:
>     - Adds `sidebar-toggle-shortcut.test.tsx` to test `ToggleSidebar` shortcut registration and functionality.
>     - Verifies shortcut does not trigger in input fields and logs events correctly.
>   - **Misc**:
>     - Registers and deregisters `ToggleSidebar` shortcut in `AppLayout/index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e38bf3a46fcfcf82421daaaaebf0bb441fa62b13. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->