### PR TITLE
chore: add unit tests for k8s entity details

### DIFF
--- a/frontend/src/container/InfraMonitoringK8s/Clusters/ClusterDetails/ClusterDetails.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Clusters/ClusterDetails/ClusterDetails.tsx
@@ -520,21 +520,12 @@ function ClusterDetails({
 								>
 									Cluster Name
 								</Typography.Text>
-								<Typography.Text
-									type="secondary"
-									className="entity-details-metadata-label"
-								>
-									Cluster Name
-								</Typography.Text>
 							</div>
 							<div className="values-row">
 								<Typography.Text className="entity-details-metadata-value">
 									<Tooltip title={cluster.meta.k8s_cluster_name}>
 										{cluster.meta.k8s_cluster_name}
 									</Tooltip>
-								</Typography.Text>
-								<Typography.Text className="entity-details-metadata-value">
-									<Tooltip title="Cluster name">{cluster.meta.k8s_cluster_name}</Tooltip>
 								</Typography.Text>
 							</div>
 						</div>

--- a/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityEvents/__tests__/EntityEvents.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityEvents/__tests__/EntityEvents.test.tsx
@@ -1,0 +1,345 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable sonarjs/no-duplicate-string */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { initialQueriesMap } from 'constants/queryBuilder';
+import ROUTES from 'constants/routes';
+import { K8sCategory } from 'container/InfraMonitoringK8s/constants';
+import { Time } from 'container/TopNav/DateTimeSelectionV2/config';
+import * as useQueryBuilderHooks from 'hooks/queryBuilder/useQueryBuilder';
+import * as appContextHooks from 'providers/App/App';
+import { LicenseEvent } from 'types/api/licensesV3/getActive';
+import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
+import { IBuilderQuery } from 'types/api/queryBuilder/queryBuilderData';
+import { DataSource } from 'types/common/queryBuilder';
+
+import EntityEvents from '../EntityEvents';
+
+jest.mock('container/TopNav/DateTimeSelectionV2', () => ({
+	__esModule: true,
+	default: (): JSX.Element => (
+		<div data-testid="date-time-selection">Date Time</div>
+	),
+}));
+
+const mockUseQuery = jest.fn();
+jest.mock('react-query', () => ({
+	useQuery: (queryKey: any, queryFn: any, options: any): any =>
+		mockUseQuery(queryKey, queryFn, options),
+}));
+
+jest.mock('react-router-dom', () => ({
+	...jest.requireActual('react-router-dom'),
+	useLocation: (): { pathname: string } => ({
+		pathname: `${process.env.FRONTEND_API_ENDPOINT}/${ROUTES.INFRASTRUCTURE_MONITORING_KUBERNETES}/`,
+	}),
+}));
+
+jest.spyOn(appContextHooks, 'useAppContext').mockReturnValue({
+	user: {
+		role: 'admin',
+	},
+	activeLicenseV3: {
+		event_queue: {
+			created_at: '0',
+			event: LicenseEvent.NO_EVENT,
+			scheduled_at: '0',
+			status: '',
+			updated_at: '0',
+		},
+		license: {
+			license_key: 'test-license-key',
+			license_type: 'trial',
+			org_id: 'test-org-id',
+			plan_id: 'test-plan-id',
+			plan_name: 'test-plan-name',
+			plan_type: 'trial',
+			plan_version: 'test-plan-version',
+		},
+	},
+} as any);
+
+const mockUseQueryBuilderData = {
+	handleRunQuery: jest.fn(),
+	stagedQuery: initialQueriesMap[DataSource.METRICS],
+	updateAllQueriesOperators: jest.fn(),
+	currentQuery: initialQueriesMap[DataSource.METRICS],
+	resetQuery: jest.fn(),
+	redirectWithQueryBuilderData: jest.fn(),
+	isStagedQueryUpdated: jest.fn(),
+	handleSetQueryData: jest.fn(),
+	handleSetFormulaData: jest.fn(),
+	handleSetQueryItemData: jest.fn(),
+	handleSetConfig: jest.fn(),
+	removeQueryBuilderEntityByIndex: jest.fn(),
+	removeQueryTypeItemByIndex: jest.fn(),
+	isDefaultQuery: jest.fn(),
+};
+
+jest.spyOn(useQueryBuilderHooks, 'useQueryBuilder').mockReturnValue({
+	...mockUseQueryBuilderData,
+} as any);
+
+const timeRange = {
+	startTime: 1718236800,
+	endTime: 1718236800,
+};
+
+const mockHandleChangeEventFilters = jest.fn();
+
+const mockFilters: IBuilderQuery['filters'] = {
+	items: [
+		{
+			id: 'pod-name',
+			key: {
+				id: 'pod-name',
+				dataType: DataTypes.String,
+				isColumn: true,
+				key: 'pod-name',
+				type: 'tag',
+				isJSON: false,
+				isIndexed: false,
+			},
+			op: '=',
+			value: 'pod-1',
+		},
+	],
+	op: 'and',
+};
+
+const isModalTimeSelection = false;
+const mockHandleTimeChange = jest.fn();
+const selectedInterval: Time = '1m';
+const category = K8sCategory.PODS;
+const queryKey = 'pod-events';
+
+const mockEventsData = {
+	payload: {
+		data: {
+			newResult: {
+				data: {
+					result: [
+						{
+							list: [
+								{
+									timestamp: '2024-01-15T10:00:00Z',
+									data: {
+										id: 'event-1',
+										severity_text: 'INFO',
+										body: 'Test event 1',
+										resources_string: { 'pod.name': 'test-pod-1' },
+										attributes_string: { service: 'test-service' },
+									},
+								},
+								{
+									timestamp: '2024-01-15T10:01:00Z',
+									data: {
+										id: 'event-2',
+										severity_text: 'WARN',
+										body: 'Test event 2',
+										resources_string: { 'pod.name': 'test-pod-2' },
+										attributes_string: { service: 'test-service' },
+									},
+								},
+							],
+						},
+					],
+				},
+			},
+		},
+	},
+};
+
+const mockEmptyEventsData = {
+	payload: {
+		data: {
+			newResult: {
+				data: {
+					result: [
+						{
+							list: [],
+						},
+					],
+				},
+			},
+		},
+	},
+};
+
+const createMockEvent = (
+	id: string,
+	severity: string,
+	body: string,
+	podName: string,
+): any => ({
+	timestamp: `2024-01-15T10:${id.padStart(2, '0')}:00Z`,
+	data: {
+		id: `event-${id}`,
+		severity_text: severity,
+		body,
+		resources_string: { 'pod.name': podName },
+		attributes_string: { service: 'test-service' },
+	},
+});
+
+const createMockMoreEventsData = (): any => ({
+	payload: {
+		data: {
+			newResult: {
+				data: {
+					result: [
+						{
+							list: Array.from({ length: 11 }, (_, i) =>
+								createMockEvent(
+									String(i + 1),
+									['INFO', 'WARN', 'ERROR', 'DEBUG'][i % 4],
+									`Test event ${i + 1}`,
+									`test-pod-${i + 1}`,
+								),
+							),
+						},
+					],
+				},
+			},
+		},
+	},
+});
+
+const renderEntityEvents = (overrides = {}): any => {
+	const defaultProps = {
+		timeRange,
+		handleChangeEventFilters: mockHandleChangeEventFilters,
+		filters: mockFilters,
+		isModalTimeSelection,
+		handleTimeChange: mockHandleTimeChange,
+		selectedInterval,
+		category,
+		queryKey,
+		...overrides,
+	};
+
+	return render(
+		<EntityEvents
+			timeRange={defaultProps.timeRange}
+			handleChangeEventFilters={defaultProps.handleChangeEventFilters}
+			filters={defaultProps.filters}
+			isModalTimeSelection={defaultProps.isModalTimeSelection}
+			handleTimeChange={defaultProps.handleTimeChange}
+			selectedInterval={defaultProps.selectedInterval}
+			category={defaultProps.category}
+			queryKey={defaultProps.queryKey}
+		/>,
+	);
+};
+
+describe('EntityEvents', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockUseQuery.mockReturnValue({
+			data: mockEventsData,
+			isLoading: false,
+			isError: false,
+			isFetching: false,
+		});
+	});
+
+	it('should render events list', () => {
+		renderEntityEvents();
+	});
+
+	it('renders empty state when no events are found', () => {
+		mockUseQuery.mockReturnValue({
+			data: mockEmptyEventsData,
+			isLoading: false,
+			isError: false,
+			isFetching: false,
+		});
+
+		renderEntityEvents();
+		expect(screen.getByText(/No events found for this pods/)).toBeInTheDocument();
+	});
+
+	it('renders loader when fetching events', () => {
+		mockUseQuery.mockReturnValue({
+			data: undefined,
+			isLoading: true,
+			isError: false,
+			isFetching: true,
+		});
+
+		renderEntityEvents();
+		expect(screen.getByTestId('loader')).toBeInTheDocument();
+	});
+
+	it('shows pagination controls when events are present', () => {
+		renderEntityEvents();
+		expect(screen.getByText('Prev')).toBeInTheDocument();
+		expect(screen.getByText('Next')).toBeInTheDocument();
+	});
+
+	it('disables Prev button on first page', () => {
+		renderEntityEvents();
+		const prevButton = screen.getByText('Prev').closest('button');
+		expect(prevButton).toBeDisabled();
+	});
+
+	it('enables Next button when more events are available', () => {
+		mockUseQuery.mockReturnValue({
+			data: createMockMoreEventsData(),
+			isLoading: false,
+			isError: false,
+			isFetching: false,
+		});
+
+		renderEntityEvents();
+		const nextButton = screen.getByText('Next').closest('button');
+		expect(nextButton).not.toBeDisabled();
+	});
+
+	it('navigates to next page when Next button is clicked', () => {
+		mockUseQuery.mockReturnValue({
+			data: createMockMoreEventsData(),
+			isLoading: false,
+			isError: false,
+			isFetching: false,
+		});
+
+		renderEntityEvents();
+
+		const nextButton = screen.getByText('Next').closest('button');
+		expect(nextButton).not.toBeNull();
+		fireEvent.click(nextButton as Element);
+
+		const { calls } = mockUseQuery.mock;
+		const hasPage2Call = calls.some((call) => {
+			const { queryKey: callQueryKey } = call[0] || {};
+			return Array.isArray(callQueryKey) && callQueryKey.includes(2);
+		});
+		expect(hasPage2Call).toBe(true);
+	});
+
+	it('navigates to previous page when Prev button is clicked', () => {
+		mockUseQuery.mockReturnValue({
+			data: createMockMoreEventsData(),
+			isLoading: false,
+			isError: false,
+			isFetching: false,
+		});
+
+		renderEntityEvents();
+
+		const nextButton = screen.getByText('Next').closest('button');
+		expect(nextButton).not.toBeNull();
+		fireEvent.click(nextButton as Element);
+
+		const prevButton = screen.getByText('Prev').closest('button');
+		expect(prevButton).not.toBeNull();
+		fireEvent.click(prevButton as Element);
+
+		const { calls } = mockUseQuery.mock;
+		const hasPage1Call = calls.some((call) => {
+			const { queryKey: callQueryKey } = call[0] || {};
+			return Array.isArray(callQueryKey) && callQueryKey.includes(1);
+		});
+		expect(hasPage1Call).toBe(true);
+	});
+});

--- a/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityEvents/__tests__/EntityEvents.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityEvents/__tests__/EntityEvents.test.tsx
@@ -242,8 +242,14 @@ describe('EntityEvents', () => {
 		});
 	});
 
-	it('should render events list', () => {
+	it('should render events list with data', () => {
 		renderEntityEvents();
+		expect(screen.getByText('Prev')).toBeInTheDocument();
+		expect(screen.getByText('Next')).toBeInTheDocument();
+		expect(screen.getByText('Test event 1')).toBeInTheDocument();
+		expect(screen.getByText('Test event 2')).toBeInTheDocument();
+		expect(screen.getByText('INFO')).toBeInTheDocument();
+		expect(screen.getByText('WARN')).toBeInTheDocument();
 	});
 
 	it('renders empty state when no events are found', () => {

--- a/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityMetrics/__tests__/EntityMetrics.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityMetrics/__tests__/EntityMetrics.test.tsx
@@ -1,0 +1,374 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable sonarjs/no-duplicate-string */
+import { render, screen } from '@testing-library/react';
+import { K8sCategory } from 'container/InfraMonitoringK8s/constants';
+import { Time } from 'container/TopNav/DateTimeSelectionV2/config';
+import * as appContextHooks from 'providers/App/App';
+import { LicenseEvent } from 'types/api/licensesV3/getActive';
+
+import EntityMetrics from '../EntityMetrics';
+
+jest.mock('lib/uPlotLib/getUplotChartOptions', () => ({
+	getUPlotChartOptions: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('lib/uPlotLib/utils/getUplotChartData', () => ({
+	getUPlotChartData: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('container/TopNav/DateTimeSelectionV2', () => ({
+	__esModule: true,
+	default: (): JSX.Element => (
+		<div data-testid="date-time-selection">Date Time</div>
+	),
+}));
+
+jest.mock('components/Uplot', () => ({
+	__esModule: true,
+	default: (): JSX.Element => <div data-testid="uplot-chart">Uplot Chart</div>,
+}));
+
+jest.mock('container/InfraMonitoringK8s/commonUtils', () => ({
+	__esModule: true,
+	getMetricsTableData: jest.fn().mockReturnValue([
+		{
+			rows: [
+				{ data: { timestamp: '2024-01-15T10:00:00Z', value: '42.5' } },
+				{ data: { timestamp: '2024-01-15T10:01:00Z', value: '43.2' } },
+			],
+			columns: [
+				{ key: 'timestamp', label: 'Timestamp', isValueColumn: false },
+				{ key: 'value', label: 'Value', isValueColumn: true },
+			],
+		},
+	]),
+	MetricsTable: jest
+		.fn()
+		.mockImplementation(
+			(): JSX.Element => <div data-testid="metrics-table">Metrics Table</div>,
+		),
+}));
+
+const mockUseQueries = jest.fn();
+jest.mock('react-query', () => ({
+	useQueries: (queryConfigs: any[]): any[] => mockUseQueries(queryConfigs),
+}));
+
+jest.mock('hooks/useDarkMode', () => ({
+	useIsDarkMode: (): boolean => false,
+}));
+
+jest.mock('hooks/useDimensions', () => ({
+	useResizeObserver: (): { width: number; height: number } => ({
+		width: 800,
+		height: 600,
+	}),
+}));
+
+jest.mock('hooks/useMultiIntersectionObserver', () => ({
+	useMultiIntersectionObserver: (count: number): any => ({
+		visibilities: new Array(count).fill(true),
+		setElement: jest.fn(),
+	}),
+}));
+
+jest.spyOn(appContextHooks, 'useAppContext').mockReturnValue({
+	user: {
+		role: 'admin',
+	},
+	activeLicenseV3: {
+		event_queue: {
+			created_at: '0',
+			event: LicenseEvent.NO_EVENT,
+			scheduled_at: '0',
+			status: '',
+			updated_at: '0',
+		},
+		license: {
+			license_key: 'test-license-key',
+			license_type: 'trial',
+			org_id: 'test-org-id',
+			plan_id: 'test-plan-id',
+			plan_name: 'test-plan-name',
+			plan_type: 'trial',
+			plan_version: 'test-plan-version',
+		},
+	},
+	featureFlags: [
+		{
+			name: 'DOT_METRICS_ENABLED',
+			active: false,
+		},
+	],
+} as any);
+
+const mockEntity = {
+	id: 'test-entity-1',
+	name: 'test-entity',
+	type: 'pod',
+};
+
+const mockEntityWidgetInfo = [
+	{
+		title: 'CPU Usage',
+		yAxisUnit: 'percentage',
+	},
+	{
+		title: 'Memory Usage',
+		yAxisUnit: 'bytes',
+	},
+];
+
+const mockGetEntityQueryPayload = jest.fn().mockReturnValue([
+	{
+		query: 'cpu_usage',
+		start: 1705315200,
+		end: 1705318800,
+	},
+	{
+		query: 'memory_usage',
+		start: 1705315200,
+		end: 1705318800,
+	},
+]);
+
+const mockTimeRange = {
+	startTime: 1705315200,
+	endTime: 1705318800,
+};
+
+const mockHandleTimeChange = jest.fn();
+
+const mockQueries = [
+	{
+		data: {
+			payload: {
+				data: {
+					result: [
+						{
+							table: {
+								rows: [
+									{ data: { timestamp: '2024-01-15T10:00:00Z', value: '42.5' } },
+									{ data: { timestamp: '2024-01-15T10:01:00Z', value: '43.2' } },
+								],
+								columns: [
+									{ key: 'timestamp', label: 'Timestamp', isValueColumn: false },
+									{ key: 'value', label: 'Value', isValueColumn: true },
+								],
+							},
+						},
+					],
+				},
+			},
+			params: {
+				compositeQuery: {
+					panelType: 'time_series',
+				},
+			},
+		},
+		isLoading: false,
+		isError: false,
+		error: null,
+	},
+	{
+		data: {
+			payload: {
+				data: {
+					result: [
+						{
+							table: {
+								rows: [
+									{ data: { timestamp: '2024-01-15T10:00:00Z', value: '1024' } },
+									{ data: { timestamp: '2024-01-15T10:01:00Z', value: '1028' } },
+								],
+								columns: [
+									{ key: 'timestamp', label: 'Timestamp', isValueColumn: false },
+									{ key: 'value', label: 'Value', isValueColumn: true },
+								],
+							},
+						},
+					],
+				},
+			},
+			params: {
+				compositeQuery: {
+					panelType: 'table',
+				},
+			},
+		},
+		isLoading: false,
+		isError: false,
+		error: null,
+	},
+];
+
+const mockLoadingQueries = [
+	{
+		data: undefined,
+		isLoading: true,
+		isError: false,
+		error: null,
+	},
+	{
+		data: undefined,
+		isLoading: true,
+		isError: false,
+		error: null,
+	},
+];
+
+const mockErrorQueries = [
+	{
+		data: undefined,
+		isLoading: false,
+		isError: true,
+		error: new Error('API Error'),
+	},
+	{
+		data: undefined,
+		isLoading: false,
+		isError: true,
+		error: new Error('Network Error'),
+	},
+];
+
+const mockEmptyQueries = [
+	{
+		data: {
+			payload: {
+				data: {
+					result: [],
+				},
+			},
+			params: {
+				compositeQuery: {
+					panelType: 'time_series',
+				},
+			},
+		},
+		isLoading: false,
+		isError: false,
+		error: null,
+	},
+	{
+		data: {
+			payload: {
+				data: {
+					result: [],
+				},
+			},
+			params: {
+				compositeQuery: {
+					panelType: 'table',
+				},
+			},
+		},
+		isLoading: false,
+		isError: false,
+		error: null,
+	},
+];
+
+const renderEntityMetrics = (overrides = {}): any => {
+	const defaultProps = {
+		timeRange: mockTimeRange,
+		isModalTimeSelection: false,
+		handleTimeChange: mockHandleTimeChange,
+		selectedInterval: '5m' as Time,
+		entity: mockEntity,
+		entityWidgetInfo: mockEntityWidgetInfo,
+		getEntityQueryPayload: mockGetEntityQueryPayload,
+		queryKey: 'test-query-key',
+		category: K8sCategory.PODS,
+		...overrides,
+	};
+
+	return render(
+		<EntityMetrics
+			timeRange={defaultProps.timeRange}
+			isModalTimeSelection={defaultProps.isModalTimeSelection}
+			handleTimeChange={defaultProps.handleTimeChange}
+			selectedInterval={defaultProps.selectedInterval}
+			entity={defaultProps.entity}
+			entityWidgetInfo={defaultProps.entityWidgetInfo}
+			getEntityQueryPayload={defaultProps.getEntityQueryPayload}
+			queryKey={defaultProps.queryKey}
+			category={defaultProps.category}
+		/>,
+	);
+};
+
+describe('EntityMetrics', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockUseQueries.mockReturnValue(mockQueries);
+	});
+
+	it('should render metrics with data', () => {
+		renderEntityMetrics();
+		expect(screen.getByText('CPU Usage')).toBeInTheDocument();
+		expect(screen.getByText('Memory Usage')).toBeInTheDocument();
+		expect(screen.getByTestId('date-time-selection')).toBeInTheDocument();
+		expect(screen.getByTestId('uplot-chart')).toBeInTheDocument();
+		expect(screen.getByTestId('metrics-table')).toBeInTheDocument();
+	});
+
+	it('renders loading state when fetching metrics', () => {
+		mockUseQueries.mockReturnValue(mockLoadingQueries);
+		renderEntityMetrics();
+		expect(screen.getAllByText('CPU Usage')).toHaveLength(1);
+		expect(screen.getAllByText('Memory Usage')).toHaveLength(1);
+	});
+
+	it('renders error state when query fails', () => {
+		mockUseQueries.mockReturnValue(mockErrorQueries);
+		renderEntityMetrics();
+		expect(screen.getByText('API Error')).toBeInTheDocument();
+		expect(screen.getByText('Network Error')).toBeInTheDocument();
+	});
+
+	it('renders empty state when no metrics data', () => {
+		mockUseQueries.mockReturnValue(mockEmptyQueries);
+		renderEntityMetrics();
+		expect(screen.getByTestId('uplot-chart')).toBeInTheDocument();
+		expect(screen.getByTestId('metrics-table')).toBeInTheDocument();
+	});
+
+	it('calls handleTimeChange when datetime selection changes', () => {
+		renderEntityMetrics();
+		expect(screen.getByTestId('date-time-selection')).toBeInTheDocument();
+	});
+
+	it('renders multiple metric widgets', () => {
+		renderEntityMetrics();
+		expect(screen.getByText('CPU Usage')).toBeInTheDocument();
+		expect(screen.getByText('Memory Usage')).toBeInTheDocument();
+	});
+
+	it('handles different panel types correctly', () => {
+		renderEntityMetrics();
+		expect(screen.getByTestId('uplot-chart')).toBeInTheDocument();
+		expect(screen.getByTestId('metrics-table')).toBeInTheDocument();
+	});
+
+	it('applies intersection observer for visibility', () => {
+		renderEntityMetrics();
+		expect(mockUseQueries).toHaveBeenCalledWith(
+			expect.arrayContaining([
+				expect.objectContaining({
+					enabled: true,
+				}),
+			]),
+		);
+	});
+
+	it('generates correct query payloads', () => {
+		renderEntityMetrics();
+		expect(mockGetEntityQueryPayload).toHaveBeenCalledWith(
+			mockEntity,
+			mockTimeRange.startTime,
+			mockTimeRange.endTime,
+			false,
+		);
+	});
+});

--- a/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityTraces/__tests__/EntityTraces.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityTraces/__tests__/EntityTraces.test.tsx
@@ -1,0 +1,288 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable sonarjs/no-duplicate-string */
+import { render, screen } from '@testing-library/react';
+import { initialQueriesMap } from 'constants/queryBuilder';
+import { K8sCategory } from 'container/InfraMonitoringK8s/constants';
+import { Time } from 'container/TopNav/DateTimeSelectionV2/config';
+import * as useQueryBuilderHooks from 'hooks/queryBuilder/useQueryBuilder';
+import * as appContextHooks from 'providers/App/App';
+import { LicenseEvent } from 'types/api/licensesV3/getActive';
+import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
+import { IBuilderQuery } from 'types/api/queryBuilder/queryBuilderData';
+import { DataSource } from 'types/common/queryBuilder';
+
+import EntityTraces from '../EntityTraces';
+
+jest.mock('container/TopNav/DateTimeSelectionV2', () => ({
+	__esModule: true,
+	default: (): JSX.Element => (
+		<div data-testid="date-time-selection">Date Time</div>
+	),
+}));
+
+const mockUseQuery = jest.fn();
+jest.mock('react-query', () => ({
+	useQuery: (queryKey: any, queryFn: any, options: any): any =>
+		mockUseQuery(queryKey, queryFn, options),
+}));
+
+jest.mock('react-router-dom', () => ({
+	...jest.requireActual('react-router-dom'),
+	useLocation: (): { pathname: string } => ({
+		pathname: '/test-path',
+	}),
+	useNavigate: (): jest.Mock => jest.fn(),
+}));
+
+jest.mock('hooks/useSafeNavigate', () => ({
+	useSafeNavigate: (): { safeNavigate: jest.Mock } => ({
+		safeNavigate: jest.fn(),
+	}),
+}));
+
+jest.spyOn(appContextHooks, 'useAppContext').mockReturnValue({
+	user: {
+		role: 'admin',
+	},
+	activeLicenseV3: {
+		event_queue: {
+			created_at: '0',
+			event: LicenseEvent.NO_EVENT,
+			scheduled_at: '0',
+			status: '',
+			updated_at: '0',
+		},
+		license: {
+			license_key: 'test-license-key',
+			license_type: 'trial',
+			org_id: 'test-org-id',
+			plan_id: 'test-plan-id',
+			plan_name: 'test-plan-name',
+			plan_type: 'trial',
+			plan_version: 'test-plan-version',
+		},
+	},
+} as any);
+
+const mockUseQueryBuilderData = {
+	handleRunQuery: jest.fn(),
+	stagedQuery: initialQueriesMap[DataSource.METRICS],
+	updateAllQueriesOperators: jest.fn(),
+	currentQuery: initialQueriesMap[DataSource.METRICS],
+	resetQuery: jest.fn(),
+	redirectWithQueryBuilderData: jest.fn(),
+	isStagedQueryUpdated: jest.fn(),
+	handleSetQueryData: jest.fn(),
+	handleSetFormulaData: jest.fn(),
+	handleSetQueryItemData: jest.fn(),
+	handleSetConfig: jest.fn(),
+	removeQueryBuilderEntityByIndex: jest.fn(),
+	removeQueryTypeItemByIndex: jest.fn(),
+	isDefaultQuery: jest.fn(),
+};
+
+jest.spyOn(useQueryBuilderHooks, 'useQueryBuilder').mockReturnValue({
+	...mockUseQueryBuilderData,
+} as any);
+
+const timeRange = {
+	startTime: 1718236800,
+	endTime: 1718236800,
+};
+
+const mockHandleChangeTracesFilters = jest.fn();
+
+const mockTracesFilters: IBuilderQuery['filters'] = {
+	items: [
+		{
+			id: 'service-name',
+			key: {
+				id: 'service-name',
+				dataType: DataTypes.String,
+				isColumn: true,
+				key: 'service.name',
+				type: 'tag',
+				isJSON: false,
+				isIndexed: false,
+			},
+			op: '=',
+			value: 'test-service',
+		},
+	],
+	op: 'and',
+};
+
+const isModalTimeSelection = false;
+const mockHandleTimeChange = jest.fn();
+const selectedInterval: Time = '5m';
+const category = K8sCategory.PODS;
+const queryKey = 'pod-traces';
+const queryKeyFilters = ['service.name'];
+
+const mockTracesData = {
+	payload: {
+		data: {
+			newResult: {
+				data: {
+					result: [
+						{
+							list: [
+								{
+									timestamp: '2024-01-15T10:00:00Z',
+									data: {
+										trace_id: 'trace-1',
+										span_id: 'span-1',
+										service_name: 'test-service-1',
+										operation_name: 'test-operation-1',
+										duration: 100,
+										status_code: 200,
+									},
+								},
+								{
+									timestamp: '2024-01-15T10:01:00Z',
+									data: {
+										trace_id: 'trace-2',
+										span_id: 'span-2',
+										service_name: 'test-service-2',
+										operation_name: 'test-operation-2',
+										duration: 150,
+										status_code: 500,
+									},
+								},
+							],
+						},
+					],
+				},
+			},
+		},
+	},
+};
+
+const mockEmptyTracesData = {
+	payload: {
+		data: {
+			newResult: {
+				data: {
+					result: [
+						{
+							list: [],
+						},
+					],
+				},
+			},
+		},
+	},
+};
+
+const renderEntityTraces = (overrides = {}): any => {
+	const defaultProps = {
+		timeRange,
+		isModalTimeSelection,
+		handleTimeChange: mockHandleTimeChange,
+		handleChangeTracesFilters: mockHandleChangeTracesFilters,
+		tracesFilters: mockTracesFilters,
+		selectedInterval,
+		queryKey,
+		category,
+		queryKeyFilters,
+		...overrides,
+	};
+
+	return render(
+		<EntityTraces
+			timeRange={defaultProps.timeRange}
+			isModalTimeSelection={defaultProps.isModalTimeSelection}
+			handleTimeChange={defaultProps.handleTimeChange}
+			handleChangeTracesFilters={defaultProps.handleChangeTracesFilters}
+			tracesFilters={defaultProps.tracesFilters}
+			selectedInterval={defaultProps.selectedInterval}
+			queryKey={defaultProps.queryKey}
+			category={defaultProps.category}
+			queryKeyFilters={defaultProps.queryKeyFilters}
+		/>,
+	);
+};
+
+describe('EntityTraces', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockUseQuery.mockReturnValue({
+			data: mockTracesData,
+			isLoading: false,
+			isError: false,
+			isFetching: false,
+		});
+	});
+
+	it('should render traces list with data', () => {
+		renderEntityTraces();
+		expect(screen.getByText('Previous')).toBeInTheDocument();
+		expect(screen.getByText('Next')).toBeInTheDocument();
+		expect(
+			screen.getByText(/Search Filter : select options from suggested values/),
+		).toBeInTheDocument();
+		expect(screen.getByTestId('date-time-selection')).toBeInTheDocument();
+	});
+
+	it('renders empty state when no traces are found', () => {
+		mockUseQuery.mockReturnValue({
+			data: mockEmptyTracesData,
+			isLoading: false,
+			isError: false,
+			isFetching: false,
+		});
+
+		renderEntityTraces();
+		expect(screen.getByText(/No traces yet./)).toBeInTheDocument();
+	});
+
+	it('renders loader when fetching traces', () => {
+		mockUseQuery.mockReturnValue({
+			data: undefined,
+			isLoading: true,
+			isError: false,
+			isFetching: true,
+		});
+
+		renderEntityTraces();
+		expect(screen.getByText('pending_data_placeholder')).toBeInTheDocument();
+	});
+
+	it('shows error state when query fails', () => {
+		mockUseQuery.mockReturnValue({
+			data: { error: 'API Error' },
+			isLoading: false,
+			isError: true,
+			isFetching: false,
+		});
+
+		renderEntityTraces();
+		expect(screen.getByText('API Error')).toBeInTheDocument();
+	});
+
+	it('calls handleChangeTracesFilters when query builder search changes', () => {
+		renderEntityTraces();
+		expect(
+			screen.getByText(/Search Filter : select options from suggested values/),
+		).toBeInTheDocument();
+	});
+
+	it('calls handleTimeChange when datetime selection changes', () => {
+		renderEntityTraces();
+		expect(screen.getByTestId('date-time-selection')).toBeInTheDocument();
+	});
+
+	it('shows pagination controls when traces are present', () => {
+		renderEntityTraces();
+		expect(screen.getByText('Previous')).toBeInTheDocument();
+		expect(screen.getByText('Next')).toBeInTheDocument();
+	});
+
+	it('disables pagination buttons when no more data', () => {
+		renderEntityTraces();
+		const prevButton = screen.getByText('Previous').closest('button');
+		const nextButton = screen.getByText('Next').closest('button');
+		expect(prevButton).toBeDisabled();
+		expect(nextButton).toBeDisabled();
+	});
+});

--- a/frontend/src/container/InfraMonitoringK8s/LoadingContainer.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/LoadingContainer.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from 'antd';
 
 function LoadingContainer(): JSX.Element {
 	return (
-		<div className="k8s-list-loading-state">
+		<div className="k8s-list-loading-state" data-testid="loader">
 			<Skeleton.Input
 				className="k8s-list-loading-state-item"
 				size="large"

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Clusters/ClusterDetails/ClusterDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Clusters/ClusterDetails/ClusterDetails.test.tsx
@@ -1,0 +1,131 @@
+/* eslint-disable import/first */
+// eslint-disable-next-line import/order
+import setupCommonMocks from '../../commonMocks';
+
+setupCommonMocks();
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import ClusterDetails from 'container/InfraMonitoringK8s/Clusters/ClusterDetails/ClusterDetails';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import store from 'store';
+
+const queryClient = new QueryClient();
+
+describe('ClusterDetails', () => {
+	const mockCluster = {
+		meta: {
+			k8s_cluster_name: 'test-cluster',
+		},
+	} as any;
+	const mockOnClose = jest.fn();
+
+	it('should render modal with relevant metadata', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<ClusterDetails
+							cluster={mockCluster}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const clusterNameElements = screen.getAllByText('test-cluster');
+		expect(clusterNameElements.length).toBeGreaterThan(0);
+		expect(clusterNameElements[0]).toBeInTheDocument();
+	});
+
+	it('should render modal with 4 tabs', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<ClusterDetails
+							cluster={mockCluster}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByText('Metrics');
+		expect(metricsTab).toBeInTheDocument();
+
+		const eventsTab = screen.getByText('Events');
+		expect(eventsTab).toBeInTheDocument();
+
+		const logsTab = screen.getByText('Logs');
+		expect(logsTab).toBeInTheDocument();
+
+		const tracesTab = screen.getByText('Traces');
+		expect(tracesTab).toBeInTheDocument();
+	});
+
+	it('default tab should be metrics', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<ClusterDetails
+							cluster={mockCluster}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByRole('radio', { name: 'Metrics' });
+		expect(metricsTab).toBeChecked();
+	});
+
+	it('should switch to events tab when events tab is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<ClusterDetails
+							cluster={mockCluster}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const eventsTab = screen.getByRole('radio', { name: 'Events' });
+		expect(eventsTab).not.toBeChecked();
+		fireEvent.click(eventsTab);
+		expect(eventsTab).toBeChecked();
+	});
+
+	it('should close modal when close button is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<ClusterDetails
+							cluster={mockCluster}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const closeButton = screen.getByRole('button', { name: 'Close' });
+		fireEvent.click(closeButton);
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/DaemonSets/DaemonSetDetails/DaemonSetDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/DaemonSets/DaemonSetDetails/DaemonSetDetails.test.tsx
@@ -1,0 +1,141 @@
+/* eslint-disable import/first */
+// eslint-disable-next-line import/order
+import setupCommonMocks from '../../commonMocks';
+
+setupCommonMocks();
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import DaemonSetDetails from 'container/InfraMonitoringK8s/DaemonSets/DaemonSetDetails/DaemonSetDetails';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import store from 'store';
+
+const queryClient = new QueryClient();
+
+describe('DaemonSetDetails', () => {
+	const mockDaemonSet = {
+		meta: {
+			k8s_daemonset_name: 'test-daemon-set',
+			k8s_cluster_name: 'test-cluster',
+			k8s_namespace_name: 'test-namespace',
+		},
+	} as any;
+	const mockOnClose = jest.fn();
+
+	it('should render modal with relevant metadata', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<DaemonSetDetails
+							daemonSet={mockDaemonSet}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const daemonSetNameElements = screen.getAllByText('test-daemon-set');
+		expect(daemonSetNameElements.length).toBeGreaterThan(0);
+		expect(daemonSetNameElements[0]).toBeInTheDocument();
+
+		const clusterNameElements = screen.getAllByText('test-cluster');
+		expect(clusterNameElements.length).toBeGreaterThan(0);
+		expect(clusterNameElements[0]).toBeInTheDocument();
+
+		const namespaceNameElements = screen.getAllByText('test-namespace');
+		expect(namespaceNameElements.length).toBeGreaterThan(0);
+		expect(namespaceNameElements[0]).toBeInTheDocument();
+	});
+
+	it('should render modal with 4 tabs', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<DaemonSetDetails
+							daemonSet={mockDaemonSet}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByText('Metrics');
+		expect(metricsTab).toBeInTheDocument();
+
+		const eventsTab = screen.getByText('Events');
+		expect(eventsTab).toBeInTheDocument();
+
+		const logsTab = screen.getByText('Logs');
+		expect(logsTab).toBeInTheDocument();
+
+		const tracesTab = screen.getByText('Traces');
+		expect(tracesTab).toBeInTheDocument();
+	});
+
+	it('default tab should be metrics', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<DaemonSetDetails
+							daemonSet={mockDaemonSet}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByRole('radio', { name: 'Metrics' });
+		expect(metricsTab).toBeChecked();
+	});
+
+	it('should switch to events tab when events tab is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<DaemonSetDetails
+							daemonSet={mockDaemonSet}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const eventsTab = screen.getByRole('radio', { name: 'Events' });
+		expect(eventsTab).not.toBeChecked();
+		fireEvent.click(eventsTab);
+		expect(eventsTab).toBeChecked();
+	});
+
+	it('should close modal when close button is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<DaemonSetDetails
+							daemonSet={mockDaemonSet}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const closeButton = screen.getByRole('button', { name: 'Close' });
+		fireEvent.click(closeButton);
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Deployments/DeploymentDetails/DeploymentDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Deployments/DeploymentDetails/DeploymentDetails.test.tsx
@@ -1,0 +1,141 @@
+/* eslint-disable import/first */
+// eslint-disable-next-line import/order
+import setupCommonMocks from '../../commonMocks';
+
+setupCommonMocks();
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import DeploymentDetails from 'container/InfraMonitoringK8s/Deployments/DeploymentDetails/DeploymentDetails';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import store from 'store';
+
+const queryClient = new QueryClient();
+
+describe('DeploymentDetails', () => {
+	const mockDeployment = {
+		meta: {
+			k8s_deployment_name: 'test-deployment',
+			k8s_cluster_name: 'test-cluster',
+			k8s_namespace_name: 'test-namespace',
+		},
+	} as any;
+	const mockOnClose = jest.fn();
+
+	it('should render modal with relevant metadata', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<DeploymentDetails
+							deployment={mockDeployment}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const deploymentNameElements = screen.getAllByText('test-deployment');
+		expect(deploymentNameElements.length).toBeGreaterThan(0);
+		expect(deploymentNameElements[0]).toBeInTheDocument();
+
+		const clusterNameElements = screen.getAllByText('test-cluster');
+		expect(clusterNameElements.length).toBeGreaterThan(0);
+		expect(clusterNameElements[0]).toBeInTheDocument();
+
+		const namespaceNameElements = screen.getAllByText('test-namespace');
+		expect(namespaceNameElements.length).toBeGreaterThan(0);
+		expect(namespaceNameElements[0]).toBeInTheDocument();
+	});
+
+	it('should render modal with 4 tabs', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<DeploymentDetails
+							deployment={mockDeployment}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByText('Metrics');
+		expect(metricsTab).toBeInTheDocument();
+
+		const eventsTab = screen.getByText('Events');
+		expect(eventsTab).toBeInTheDocument();
+
+		const logsTab = screen.getByText('Logs');
+		expect(logsTab).toBeInTheDocument();
+
+		const tracesTab = screen.getByText('Traces');
+		expect(tracesTab).toBeInTheDocument();
+	});
+
+	it('default tab should be metrics', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<DeploymentDetails
+							deployment={mockDeployment}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByRole('radio', { name: 'Metrics' });
+		expect(metricsTab).toBeChecked();
+	});
+
+	it('should switch to events tab when events tab is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<DeploymentDetails
+							deployment={mockDeployment}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const eventsTab = screen.getByRole('radio', { name: 'Events' });
+		expect(eventsTab).not.toBeChecked();
+		fireEvent.click(eventsTab);
+		expect(eventsTab).toBeChecked();
+	});
+
+	it('should close modal when close button is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<DeploymentDetails
+							deployment={mockDeployment}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const closeButton = screen.getByRole('button', { name: 'Close' });
+		fireEvent.click(closeButton);
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Jobs/JobDetails/JobDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Jobs/JobDetails/JobDetails.test.tsx
@@ -1,0 +1,116 @@
+/* eslint-disable import/first */
+// eslint-disable-next-line import/order
+import setupCommonMocks from '../../commonMocks';
+
+setupCommonMocks();
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import JobDetails from 'container/InfraMonitoringK8s/Jobs/JobDetails/JobDetails';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import store from 'store';
+
+const queryClient = new QueryClient();
+
+describe('JobDetails', () => {
+	const mockJob = {
+		meta: {
+			k8s_job_name: 'test-job',
+			k8s_namespace_name: 'test-namespace',
+		},
+	} as any;
+	const mockOnClose = jest.fn();
+
+	it('should render modal with relevant metadata', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<JobDetails job={mockJob} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const jobNameElements = screen.getAllByText('test-job');
+		expect(jobNameElements.length).toBeGreaterThan(0);
+		expect(jobNameElements[0]).toBeInTheDocument();
+
+		const namespaceNameElements = screen.getAllByText('test-namespace');
+		expect(namespaceNameElements.length).toBeGreaterThan(0);
+		expect(namespaceNameElements[0]).toBeInTheDocument();
+	});
+
+	it('should render modal with 4 tabs', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<JobDetails job={mockJob} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByText('Metrics');
+		expect(metricsTab).toBeInTheDocument();
+
+		const eventsTab = screen.getByText('Events');
+		expect(eventsTab).toBeInTheDocument();
+
+		const logsTab = screen.getByText('Logs');
+		expect(logsTab).toBeInTheDocument();
+
+		const tracesTab = screen.getByText('Traces');
+		expect(tracesTab).toBeInTheDocument();
+	});
+
+	it('default tab should be metrics', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<JobDetails job={mockJob} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByRole('radio', { name: 'Metrics' });
+		expect(metricsTab).toBeChecked();
+	});
+
+	it('should switch to events tab when events tab is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<JobDetails job={mockJob} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const eventsTab = screen.getByRole('radio', { name: 'Events' });
+		expect(eventsTab).not.toBeChecked();
+		fireEvent.click(eventsTab);
+		expect(eventsTab).toBeChecked();
+	});
+
+	it('should close modal when close button is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<JobDetails job={mockJob} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const closeButton = screen.getByRole('button', { name: 'Close' });
+		fireEvent.click(closeButton);
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Namespaces/NamespaceDetails/NamespaceDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Namespaces/NamespaceDetails/NamespaceDetails.test.tsx
@@ -1,0 +1,136 @@
+/* eslint-disable import/first */
+// eslint-disable-next-line import/order
+import setupCommonMocks from '../../commonMocks';
+
+setupCommonMocks();
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import NamespaceDetails from 'container/InfraMonitoringK8s/Namespaces/NamespaceDetails/NamespaceDetails';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import store from 'store';
+
+const queryClient = new QueryClient();
+
+describe('NamespaceDetails', () => {
+	const mockNamespace = {
+		namespaceName: 'test-namespace',
+		meta: {
+			k8s_cluster_name: 'test-cluster',
+		},
+	} as any;
+	const mockOnClose = jest.fn();
+
+	it('should render modal with relevant metadata', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<NamespaceDetails
+							namespace={mockNamespace}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const namespaceNameElements = screen.getAllByText('test-namespace');
+		expect(namespaceNameElements.length).toBeGreaterThan(0);
+		expect(namespaceNameElements[0]).toBeInTheDocument();
+
+		const clusterNameElements = screen.getAllByText('test-cluster');
+		expect(clusterNameElements.length).toBeGreaterThan(0);
+		expect(clusterNameElements[0]).toBeInTheDocument();
+	});
+
+	it('should render modal with 4 tabs', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<NamespaceDetails
+							namespace={mockNamespace}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByText('Metrics');
+		expect(metricsTab).toBeInTheDocument();
+
+		const eventsTab = screen.getByText('Events');
+		expect(eventsTab).toBeInTheDocument();
+
+		const logsTab = screen.getByText('Logs');
+		expect(logsTab).toBeInTheDocument();
+
+		const tracesTab = screen.getByText('Traces');
+		expect(tracesTab).toBeInTheDocument();
+	});
+
+	it('default tab should be metrics', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<NamespaceDetails
+							namespace={mockNamespace}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByRole('radio', { name: 'Metrics' });
+		expect(metricsTab).toBeChecked();
+	});
+
+	it('should switch to events tab when events tab is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<NamespaceDetails
+							namespace={mockNamespace}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const eventsTab = screen.getByRole('radio', { name: 'Events' });
+		expect(eventsTab).not.toBeChecked();
+		fireEvent.click(eventsTab);
+		expect(eventsTab).toBeChecked();
+	});
+
+	it('should close modal when close button is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<NamespaceDetails
+							namespace={mockNamespace}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const closeButton = screen.getByRole('button', { name: 'Close' });
+		fireEvent.click(closeButton);
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Nodes/NodeDetails/NodeDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Nodes/NodeDetails/NodeDetails.test.tsx
@@ -1,0 +1,116 @@
+/* eslint-disable import/first */
+// eslint-disable-next-line import/order
+import setupCommonMocks from '../../commonMocks';
+
+setupCommonMocks();
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import NodeDetails from 'container/InfraMonitoringK8s/Nodes/NodeDetails/NodeDetails';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import store from 'store';
+
+const queryClient = new QueryClient();
+
+describe('NodeDetails', () => {
+	const mockNode = {
+		meta: {
+			k8s_node_name: 'test-node',
+			k8s_cluster_name: 'test-cluster',
+		},
+	} as any;
+	const mockOnClose = jest.fn();
+
+	it('should render modal with relevant metadata', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<NodeDetails node={mockNode} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const nodeNameElements = screen.getAllByText('test-node');
+		expect(nodeNameElements.length).toBeGreaterThan(0);
+		expect(nodeNameElements[0]).toBeInTheDocument();
+
+		const clusterNameElements = screen.getAllByText('test-cluster');
+		expect(clusterNameElements.length).toBeGreaterThan(0);
+		expect(clusterNameElements[0]).toBeInTheDocument();
+	});
+
+	it('should render modal with 4 tabs', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<NodeDetails node={mockNode} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByText('Metrics');
+		expect(metricsTab).toBeInTheDocument();
+
+		const eventsTab = screen.getByText('Events');
+		expect(eventsTab).toBeInTheDocument();
+
+		const logsTab = screen.getByText('Logs');
+		expect(logsTab).toBeInTheDocument();
+
+		const tracesTab = screen.getByText('Traces');
+		expect(tracesTab).toBeInTheDocument();
+	});
+
+	it('default tab should be metrics', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<NodeDetails node={mockNode} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByRole('radio', { name: 'Metrics' });
+		expect(metricsTab).toBeChecked();
+	});
+
+	it('should switch to events tab when events tab is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<NodeDetails node={mockNode} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const eventsTab = screen.getByRole('radio', { name: 'Events' });
+		expect(eventsTab).not.toBeChecked();
+		fireEvent.click(eventsTab);
+		expect(eventsTab).toBeChecked();
+	});
+
+	it('should close modal when close button is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<NodeDetails node={mockNode} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const closeButton = screen.getByRole('button', { name: 'Close' });
+		fireEvent.click(closeButton);
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Pods/PodDetails/PodDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Pods/PodDetails/PodDetails.test.tsx
@@ -1,0 +1,122 @@
+/* eslint-disable import/first */
+// eslint-disable-next-line import/order
+import setupCommonMocks from '../../commonMocks';
+
+setupCommonMocks();
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import PodDetails from 'container/InfraMonitoringK8s/Pods/PodDetails/PodDetails';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import store from 'store';
+
+const queryClient = new QueryClient();
+
+describe('PodDetails', () => {
+	const mockPod = {
+		podName: 'test-pod',
+		meta: {
+			k8s_cluster_name: 'test-cluster',
+			k8s_namespace_name: 'test-namespace',
+			k8s_node_name: 'test-node',
+		},
+	} as any;
+	const mockOnClose = jest.fn();
+
+	it('should render modal with relevant metadata', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<PodDetails pod={mockPod} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const clusterNameElements = screen.getAllByText('test-cluster');
+		expect(clusterNameElements.length).toBeGreaterThan(0);
+		expect(clusterNameElements[0]).toBeInTheDocument();
+
+		const namespaceNameElements = screen.getAllByText('test-namespace');
+		expect(namespaceNameElements.length).toBeGreaterThan(0);
+		expect(namespaceNameElements[0]).toBeInTheDocument();
+
+		const nodeNameElements = screen.getAllByText('test-node');
+		expect(nodeNameElements.length).toBeGreaterThan(0);
+		expect(nodeNameElements[0]).toBeInTheDocument();
+	});
+
+	it('should render modal with 4 tabs', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<PodDetails pod={mockPod} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByText('Metrics');
+		expect(metricsTab).toBeInTheDocument();
+
+		const eventsTab = screen.getByText('Events');
+		expect(eventsTab).toBeInTheDocument();
+
+		const logsTab = screen.getByText('Logs');
+		expect(logsTab).toBeInTheDocument();
+
+		const tracesTab = screen.getByText('Traces');
+		expect(tracesTab).toBeInTheDocument();
+	});
+
+	it('default tab should be metrics', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<PodDetails pod={mockPod} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByRole('radio', { name: 'Metrics' });
+		expect(metricsTab).toBeChecked();
+	});
+
+	it('should switch to events tab when events tab is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<PodDetails pod={mockPod} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const eventsTab = screen.getByRole('radio', { name: 'Events' });
+		expect(eventsTab).not.toBeChecked();
+		fireEvent.click(eventsTab);
+		expect(eventsTab).toBeChecked();
+	});
+
+	it('should close modal when close button is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<PodDetails pod={mockPod} isModalTimeSelection onClose={mockOnClose} />
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const closeButton = screen.getByRole('button', { name: 'Close' });
+		fireEvent.click(closeButton);
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/StatefulSets/StatefulSetDetails/StatefulSetDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/StatefulSets/StatefulSetDetails/StatefulSetDetails.test.tsx
@@ -1,0 +1,136 @@
+/* eslint-disable import/first */
+// eslint-disable-next-line import/order
+import setupCommonMocks from '../../commonMocks';
+
+setupCommonMocks();
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import StatefulSetDetails from 'container/InfraMonitoringK8s/StatefulSets/StatefulSetDetails/StatefulSetDetails';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import store from 'store';
+
+const queryClient = new QueryClient();
+
+describe('StatefulSetDetails', () => {
+	const mockStatefulSet = {
+		meta: {
+			k8s_namespace_name: 'test-namespace',
+			k8s_statefulset_name: 'test-stateful-set',
+		},
+	} as any;
+	const mockOnClose = jest.fn();
+
+	it('should render modal with relevant metadata', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<StatefulSetDetails
+							statefulSet={mockStatefulSet}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const statefulSetNameElements = screen.getAllByText('test-stateful-set');
+		expect(statefulSetNameElements.length).toBeGreaterThan(0);
+		expect(statefulSetNameElements[0]).toBeInTheDocument();
+
+		const namespaceNameElements = screen.getAllByText('test-namespace');
+		expect(namespaceNameElements.length).toBeGreaterThan(0);
+		expect(namespaceNameElements[0]).toBeInTheDocument();
+	});
+
+	it('should render modal with 4 tabs', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<StatefulSetDetails
+							statefulSet={mockStatefulSet}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByText('Metrics');
+		expect(metricsTab).toBeInTheDocument();
+
+		const eventsTab = screen.getByText('Events');
+		expect(eventsTab).toBeInTheDocument();
+
+		const logsTab = screen.getByText('Logs');
+		expect(logsTab).toBeInTheDocument();
+
+		const tracesTab = screen.getByText('Traces');
+		expect(tracesTab).toBeInTheDocument();
+	});
+
+	it('default tab should be metrics', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<StatefulSetDetails
+							statefulSet={mockStatefulSet}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const metricsTab = screen.getByRole('radio', { name: 'Metrics' });
+		expect(metricsTab).toBeChecked();
+	});
+
+	it('should switch to events tab when events tab is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<StatefulSetDetails
+							statefulSet={mockStatefulSet}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const eventsTab = screen.getByRole('radio', { name: 'Events' });
+		expect(eventsTab).not.toBeChecked();
+		fireEvent.click(eventsTab);
+		expect(eventsTab).toBeChecked();
+	});
+
+	it('should close modal when close button is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<StatefulSetDetails
+							statefulSet={mockStatefulSet}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const closeButton = screen.getByRole('button', { name: 'Close' });
+		fireEvent.click(closeButton);
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Volumes/VolumeDetails/VolumeDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Volumes/VolumeDetails/VolumeDetails.test.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable import/first */
+// eslint-disable-next-line import/order
+import setupCommonMocks from '../../commonMocks';
+
+setupCommonMocks();
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import VolumeDetails from 'container/InfraMonitoringK8s/Volumes/VolumeDetails/VolumeDetails';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import store from 'store';
+
+const queryClient = new QueryClient();
+
+describe('VolumeDetails', () => {
+	const mockVolume = {
+		persistentVolumeClaimName: 'test-volume',
+		meta: {
+			k8s_cluster_name: 'test-cluster',
+			k8s_namespace_name: 'test-namespace',
+		},
+	} as any;
+	const mockOnClose = jest.fn();
+
+	it('should render modal with relevant metadata', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<VolumeDetails
+							volume={mockVolume}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const volumeNameElements = screen.getAllByText('test-volume');
+		expect(volumeNameElements.length).toBeGreaterThan(0);
+		expect(volumeNameElements[0]).toBeInTheDocument();
+
+		const clusterNameElements = screen.getAllByText('test-cluster');
+		expect(clusterNameElements.length).toBeGreaterThan(0);
+		expect(clusterNameElements[0]).toBeInTheDocument();
+
+		const namespaceNameElements = screen.getAllByText('test-namespace');
+		expect(namespaceNameElements.length).toBeGreaterThan(0);
+		expect(namespaceNameElements[0]).toBeInTheDocument();
+	});
+
+	it('should close modal when close button is clicked', () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<VolumeDetails
+							volume={mockVolume}
+							isModalTimeSelection
+							onClose={mockOnClose}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		const closeButton = screen.getByRole('button', { name: 'Close' });
+		fireEvent.click(closeButton);
+		expect(mockOnClose).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/commonMocks.ts
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/commonMocks.ts
@@ -1,0 +1,121 @@
+import * as appContextHooks from 'providers/App/App';
+import * as timezoneHooks from 'providers/Timezone';
+import { LicenseEvent } from 'types/api/licensesV3/getActive';
+
+const setupCommonMocks = (): void => {
+	const createMockObserver = (): {
+		observe: jest.Mock;
+		unobserve: jest.Mock;
+		disconnect: jest.Mock;
+	} => ({
+		observe: jest.fn(),
+		unobserve: jest.fn(),
+		disconnect: jest.fn(),
+	});
+
+	global.IntersectionObserver = jest.fn().mockImplementation(createMockObserver);
+	global.ResizeObserver = jest.fn().mockImplementation(createMockObserver);
+
+	jest.mock('react-redux', () => ({
+		...jest.requireActual('react-redux'),
+		useSelector: jest.fn(() => ({
+			globalTime: {
+				selectedTime: {
+					startTime: 1713734400000,
+					endTime: 1713738000000,
+				},
+				maxTime: 1713738000000,
+				minTime: 1713734400000,
+			},
+		})),
+	}));
+
+	jest.mock('uplot', () => ({
+		paths: {
+			spline: jest.fn(),
+			bars: jest.fn(),
+		},
+		default: jest.fn(() => ({
+			paths: {
+				spline: jest.fn(),
+				bars: jest.fn(),
+			},
+		})),
+	}));
+
+	jest.mock('react-router-dom-v5-compat', () => ({
+		...jest.requireActual('react-router-dom-v5-compat'),
+		useSearchParams: jest.fn().mockReturnValue([
+			{
+				get: jest.fn(),
+				entries: jest.fn(() => []),
+				set: jest.fn(),
+			},
+			jest.fn(),
+		]),
+		useNavigationType: (): any => 'PUSH',
+	}));
+
+	jest.mock('hooks/useUrlQuery', () => ({
+		__esModule: true,
+		default: jest.fn(() => ({
+			set: jest.fn(),
+			delete: jest.fn(),
+			get: jest.fn(),
+			has: jest.fn(),
+			entries: jest.fn(() => []),
+			append: jest.fn(),
+			toString: jest.fn(() => ''),
+		})),
+	}));
+
+	jest.mock('lib/getMinMax', () => ({
+		__esModule: true,
+		default: jest.fn().mockImplementation(() => ({
+			minTime: 1713734400000,
+			maxTime: 1713738000000,
+		})),
+		isValidTimeFormat: jest.fn().mockReturnValue(true),
+	}));
+
+	jest.spyOn(appContextHooks, 'useAppContext').mockReturnValue({
+		user: {
+			role: 'admin',
+		},
+		activeLicenseV3: {
+			event_queue: {
+				created_at: '0',
+				event: LicenseEvent.NO_EVENT,
+				scheduled_at: '0',
+				status: '',
+				updated_at: '0',
+			},
+			license: {
+				license_key: 'test-license-key',
+				license_type: 'trial',
+				org_id: 'test-org-id',
+				plan_id: 'test-plan-id',
+				plan_name: 'test-plan-name',
+				plan_type: 'trial',
+				plan_version: 'test-plan-version',
+			},
+		},
+	} as any);
+
+	jest.spyOn(timezoneHooks, 'useTimezone').mockReturnValue({
+		timezone: {
+			offset: 0,
+		},
+		browserTimezone: {
+			offset: 0,
+		},
+	} as any);
+
+	jest.mock('hooks/useSafeNavigate', () => ({
+		useSafeNavigate: (): any => ({
+			safeNavigate: jest.fn(),
+		}),
+	}));
+};
+
+export default setupCommonMocks;


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

Add unit tests for k8s entity details 

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add unit tests for Kubernetes entity details and update `LoadingContainer` for testing.
> 
>   - **Unit Tests**:
>     - Add tests for `ClusterDetails`, `DaemonSetDetails`, `DeploymentDetails`, `JobDetails`, `NamespaceDetails`, `NodeDetails`, `PodDetails`, `StatefulSetDetails`, and `VolumeDetails` to check rendering of metadata, tab switching, and modal closing.
>     - Add tests for `EntityEvents`, `EntityMetrics`, and `EntityTraces` to verify data rendering, loading states, and error handling.
>   - **Components**:
>     - Update `LoadingContainer` to include `data-testid="loader"` for testing purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 263f2ba9e621b424482ecaef544f5801f6fdca97. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->