### PR TITLE
fix: check ch version

### DIFF
--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -136,7 +136,14 @@ func NewSQLMigrationProviderFactories(
 
 func NewTelemetryStoreProviderFactories() factory.NamedMap[factory.ProviderFactory[telemetrystore.TelemetryStore, telemetrystore.Config]] {
 	return factory.MustNewNamedMap(
-		clickhousetelemetrystore.NewFactory(telemetrystorehook.NewSettingsFactory(), telemetrystorehook.NewLoggingFactory()),
+		clickhousetelemetrystore.NewFactory(
+			telemetrystore.TelemetryStoreHookFactoryFunc(func(s string) factory.ProviderFactory[telemetrystore.TelemetryStoreHook, telemetrystore.Config] {
+				return telemetrystorehook.NewSettingsFactory(s)
+			}),
+			telemetrystore.TelemetryStoreHookFactoryFunc(func(s string) factory.ProviderFactory[telemetrystore.TelemetryStoreHook, telemetrystore.Config] {
+				return telemetrystorehook.NewLoggingFactory()
+			}),
+		),
 	)
 }
 

--- a/pkg/telemetrystore/clickhousetelemetrystore/provider.go
+++ b/pkg/telemetrystore/clickhousetelemetrystore/provider.go
@@ -16,22 +16,13 @@ type provider struct {
 	hooks          []telemetrystore.TelemetryStoreHook
 }
 
-func NewFactory(hookFactories ...factory.ProviderFactory[telemetrystore.TelemetryStoreHook, telemetrystore.Config]) factory.ProviderFactory[telemetrystore.TelemetryStore, telemetrystore.Config] {
+func NewFactory(hookFactories ...telemetrystore.TelemetryStoreHookFactoryFunc) factory.ProviderFactory[telemetrystore.TelemetryStore, telemetrystore.Config] {
 	return factory.NewProviderFactory(factory.MustNewName("clickhouse"), func(ctx context.Context, providerSettings factory.ProviderSettings, config telemetrystore.Config) (telemetrystore.TelemetryStore, error) {
-		// we want to fail fast so we have hook registration errors before creating the telemetry store
-		hooks := make([]telemetrystore.TelemetryStoreHook, len(hookFactories))
-		for i, hookFactory := range hookFactories {
-			hook, err := hookFactory.New(ctx, providerSettings, config)
-			if err != nil {
-				return nil, err
-			}
-			hooks[i] = hook
-		}
-		return New(ctx, providerSettings, config, hooks...)
+		return New(ctx, providerSettings, config, hookFactories...)
 	})
 }
 
-func New(ctx context.Context, providerSettings factory.ProviderSettings, config telemetrystore.Config, hooks ...telemetrystore.TelemetryStoreHook) (telemetrystore.TelemetryStore, error) {
+func New(ctx context.Context, providerSettings factory.ProviderSettings, config telemetrystore.Config, hookFactories ...telemetrystore.TelemetryStoreHookFactoryFunc) (telemetrystore.TelemetryStore, error) {
 	settings := factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/telemetrystore/clickhousetelemetrystore")
 
 	options, err := clickhouse.ParseDSN(config.Clickhouse.DSN)
@@ -45,6 +36,20 @@ func New(ctx context.Context, providerSettings factory.ProviderSettings, config 
 	chConn, err := clickhouse.Open(options)
 	if err != nil {
 		return nil, err
+	}
+
+	var version string
+	if err := chConn.QueryRow(ctx, "SELECT version()").Scan(&version); err != nil {
+		return nil, err
+	}
+
+	hooks := make([]telemetrystore.TelemetryStoreHook, len(hookFactories))
+	for i, hookFactory := range hookFactories {
+		hook, err := hookFactory(version).New(ctx, providerSettings, config)
+		if err != nil {
+			return nil, err
+		}
+		hooks[i] = hook
 	}
 
 	return &provider{

--- a/pkg/telemetrystore/telemetrystore.go
+++ b/pkg/telemetrystore/telemetrystore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/SigNoz/signoz/pkg/factory"
 )
 
 type TelemetryStore interface {
@@ -18,6 +19,8 @@ type TelemetryStoreHook interface {
 	BeforeQuery(ctx context.Context, event *QueryEvent) context.Context
 	AfterQuery(ctx context.Context, event *QueryEvent)
 }
+
+type TelemetryStoreHookFactoryFunc func(string) factory.ProviderFactory[TelemetryStoreHook, Config]
 
 func WrapBeforeQuery(hooks []TelemetryStoreHook, ctx context.Context, event *QueryEvent) context.Context {
 	for _, hook := range hooks {

--- a/pkg/telemetrystore/telemetrystorehook/settings.go
+++ b/pkg/telemetrystore/telemetrystorehook/settings.go
@@ -81,7 +81,7 @@ func (h *provider) BeforeQuery(ctx context.Context, _ *telemetrystore.QueryEvent
 	}
 
 	// ClickHouse version check is added since this setting is not support on version below 25.5
-	if strings.Contains(h.clickHouseVersion, "25") && !h.settings.SecondaryIndicesEnableBulkFiltering {
+	if strings.HasPrefix(h.clickHouseVersion, "25") && !h.settings.SecondaryIndicesEnableBulkFiltering {
 		// TODO(srikanthccv): enable it when the "Cannot read all data" issue is fixed
 		// https://github.com/ClickHouse/ClickHouse/issues/82283
 		settings["secondary_indices_enable_bulk_filtering"] = false


### PR DESCRIPTION
Check the clickhouse version, before the setting `secondary_indices_enable_bulk_filtering` is used.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add ClickHouse version check to ensure compatibility with `secondary_indices_enable_bulk_filtering` setting in telemetry store hooks.
> 
>   - **Behavior**:
>     - Add ClickHouse version check in `New()` in `provider.go` to ensure compatibility with `secondary_indices_enable_bulk_filtering` setting.
>     - Modify `BeforeQuery()` in `settings.go` to conditionally apply `secondary_indices_enable_bulk_filtering` based on ClickHouse version.
>   - **Factories**:
>     - Update `NewFactory()` in `provider.go` to pass ClickHouse version to hook factories.
>     - Introduce `TelemetryStoreHookFactoryFunc` in `telemetrystore.go` to handle version-specific factory creation.
>   - **Misc**:
>     - Refactor `NewSettingsFactory()` in `settings.go` to accept ClickHouse version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e1c8c64e78b41832534cc0c6e7589b4e7bfc4190. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->