### PR TITLE
fix: fix the issue of group by queries not switching to timeseries view in logs and traces explorer

### DIFF
--- a/frontend/src/container/LogsExplorerViews/index.tsx
+++ b/frontend/src/container/LogsExplorerViews/index.tsx
@@ -482,8 +482,7 @@ function LogsExplorerViewsContainer({
 	);
 
 	useEffect(() => {
-		const shouldChangeView =
-			(isMultipleQueries || isGroupByExist) && selectedView !== ExplorerViews.LIST;
+		const shouldChangeView = isMultipleQueries || isGroupByExist;
 
 		if (selectedPanelType === PANEL_TYPES.LIST && shouldChangeView) {
 			handleExplorerTabChange(PANEL_TYPES.TIME_SERIES);

--- a/frontend/src/pages/TracesExplorer/index.tsx
+++ b/frontend/src/pages/TracesExplorer/index.tsx
@@ -219,6 +219,39 @@ function TracesExplorer(): JSX.Element {
 
 	useShareBuilderUrl({ defaultValue: defaultQuery, forceReset: shouldReset });
 
+	const isMultipleQueries = useMemo(
+		() =>
+			currentQuery.builder.queryData.length > 1 ||
+			currentQuery.builder.queryFormulas.length > 0,
+		[currentQuery],
+	);
+
+	const isGroupByExist = useMemo(() => {
+		const groupByCount: number = currentQuery.builder.queryData.reduce<number>(
+			(acc, query) => acc + (query?.groupBy?.length || 0),
+			0,
+		);
+		return groupByCount > 0;
+	}, [currentQuery]);
+
+	useEffect(() => {
+		const shouldChangeView = isMultipleQueries || isGroupByExist;
+
+		if (
+			(selectedView === ExplorerViews.LIST ||
+				selectedView === ExplorerViews.TRACE) &&
+			shouldChangeView
+		) {
+			// Switch to timeseries view automatically
+			handleChangeSelectedView(ExplorerViews.TIMESERIES);
+		}
+	}, [
+		selectedView,
+		isMultipleQueries,
+		isGroupByExist,
+		handleChangeSelectedView,
+	]);
+
 	useEffect(() => {
 		if (shouldReset) {
 			setShouldReset(false);


### PR DESCRIPTION
## 📄 Summary
This PR fixes the issue of group queries not redirecting to the time series view in the logs and traces explorer.  The issue was introduced while working on the new query builder changes. 


<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
Traces Explorer:
  1. Go to trace details page
  2. Click on any span in the trace
  3. Hover over any attribute in the right sidebar
  4. Click on the "Group by attribute" option
  5. Verify it redirects to Traces Explorer and automatically shows Time Series view
  
  
Logs explorer:
  1. Go to Logs Explorer
  2. Click on any log line to open details
  3. Hover over any attribute in the right drawer
  4. Click on "Group by attribute" option
  5. Verify that it redirects to Logs Explorer and automatically shows Time Series view
---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes https://github.com/SigNoz/engineering-pod/issues/2843

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->
