### PR TITLE
fix: resolve sentry issues in alert list

### DIFF
--- a/frontend/src/container/FormAlertRules/labels/utils.ts
+++ b/frontend/src/container/FormAlertRules/labels/utils.ts
@@ -23,7 +23,7 @@ export const flattenLabels = (labels: Labels): ILabelRecord[] => {
 		if (!hiddenLabels.includes(key)) {
 			recs.push({
 				key,
-				value: labels[key],
+				value: labels[key] || '',
 			});
 		}
 	});

--- a/frontend/src/container/ListAlertRules/ListAlert.tsx
+++ b/frontend/src/container/ListAlertRules/ListAlert.tsx
@@ -272,12 +272,11 @@ function ListAlert({ allAlertRules, refetch }: ListAlertProps): JSX.Element {
 			width: 80,
 			key: 'severity',
 			sorter: (a, b): number =>
-				(a.labels ? a.labels.severity.length : 0) -
-				(b.labels ? b.labels.severity.length : 0),
+				(a?.labels?.severity?.length || 0) - (b?.labels?.severity?.length || 0),
 			render: (value): JSX.Element => {
-				const objectKeys = Object.keys(value);
+				const objectKeys = value ? Object.keys(value) : [];
 				const withSeverityKey = objectKeys.find((e) => e === 'severity') || '';
-				const severityValue = value[withSeverityKey];
+				const severityValue = withSeverityKey ? value[withSeverityKey] : '-';
 
 				return <Typography>{severityValue}</Typography>;
 			},
@@ -290,7 +289,7 @@ function ListAlert({ allAlertRules, refetch }: ListAlertProps): JSX.Element {
 			align: 'center',
 			width: 100,
 			render: (value): JSX.Element => {
-				const objectKeys = Object.keys(value);
+				const objectKeys = value ? Object.keys(value) : [];
 				const withOutSeverityKeys = objectKeys.filter((e) => e !== 'severity');
 
 				if (withOutSeverityKeys.length === 0) {

--- a/frontend/src/pages/AlertDetails/AlertHeader/AlertHeader.tsx
+++ b/frontend/src/pages/AlertDetails/AlertHeader/AlertHeader.tsx
@@ -14,7 +14,7 @@ export type AlertHeaderProps = {
 		state: string;
 		alert: string;
 		id: string;
-		labels: Record<string, string>;
+		labels: Record<string, string | undefined> | undefined;
 		disabled: boolean;
 	};
 };
@@ -23,13 +23,14 @@ function AlertHeader({ alertDetails }: AlertHeaderProps): JSX.Element {
 	const { alertRuleState } = useAlertRule();
 	const [updatedName, setUpdatedName] = useState(alertName);
 
-	const labelsWithoutSeverity = useMemo(
-		() =>
-			Object.fromEntries(
+	const labelsWithoutSeverity = useMemo(() => {
+		if (labels) {
+			return Object.fromEntries(
 				Object.entries(labels).filter(([key]) => key !== 'severity'),
-			),
-		[labels],
-	);
+			);
+		}
+		return {};
+	}, [labels]);
 
 	return (
 		<div className="alert-info">
@@ -43,7 +44,7 @@ function AlertHeader({ alertDetails }: AlertHeaderProps): JSX.Element {
 					</div>
 				</div>
 				<div className="bottom-section">
-					{labels.severity && <AlertSeverity severity={labels.severity} />}
+					{labels?.severity && <AlertSeverity severity={labels.severity} />}
 
 					{/* // TODO(shaheer): Get actual data when we are able to get alert firing from state from API */}
 					{/* <AlertStatus

--- a/frontend/src/types/api/alerts/def.ts
+++ b/frontend/src/types/api/alerts/def.ts
@@ -48,7 +48,7 @@ export interface RuleCondition {
 	seasonality?: string;
 }
 export interface Labels {
-	[key: string]: string;
+	[key: string]: string | undefined;
 }
 
 export interface AlertRuleStats {

--- a/pkg/transition/migrate_common.go
+++ b/pkg/transition/migrate_common.go
@@ -366,7 +366,7 @@ func (mc *migrateCommon) createAggregations(ctx context.Context, queryData map[s
 			aggregation = map[string]any{
 				"metricName":       aggregateAttr["key"],
 				"temporality":      queryData["temporality"],
-				"timeAggregation":  aggregateOp,
+				"timeAggregation":  queryData["timeAggregation"],
 				"spaceAggregation": queryData["spaceAggregation"],
 			}
 			if reduceTo, ok := queryData["reduceTo"].(string); ok {


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

When creating alerts via API, the labels field can be omitted. UI doesn't handle that case due to which Alert List was breaking.

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix UI breakage by handling undefined `labels` in alert list and header components.
> 
>   - **Bug Fixes**:
>     - In `ListAlert.tsx`, handle undefined `labels` by using optional chaining and default values.
>     - In `AlertHeader.tsx`, update `labels` type to `Record<string, string | undefined> | undefined` and handle undefined `labels` in `useMemo`.
>     - In `utils.ts`, ensure `flattenLabels` function assigns an empty string if `labels[key]` is undefined.
>   - **Type Changes**:
>     - Update `Labels` interface in `def.ts` to `Record<string, string | undefined>`.
>   - **Misc**:
>     - In `migrate_common.go`, fix `createAggregations` to use `queryData["timeAggregation"]` instead of `aggregateOp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for e1afef0a4b1ac700b4c770913d8d49ef58fbc211. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->