### PR TITLE
fix: related links for rule history page

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -64,6 +64,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/licensetypes"
 	"github.com/SigNoz/signoz/pkg/types/opamptypes"
 	"github.com/SigNoz/signoz/pkg/types/pipelinetypes"
+	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	ruletypes "github.com/SigNoz/signoz/pkg/types/ruletypes"
 	traceFunnels "github.com/SigNoz/signoz/pkg/types/tracefunneltypes"
 
@@ -1035,9 +1036,54 @@ func (aH *APIHandler) getRuleStateHistory(w http.ResponseWriter, r *http.Request
 			// to get the correct query range
 			start := end.Add(-time.Duration(rule.EvalWindow)).Add(-3 * time.Minute)
 			if rule.AlertType == ruletypes.AlertTypeLogs {
-				res.Items[idx].RelatedLogsLink = contextlinks.PrepareLinksToLogs(start, end, newFilters)
+				if rule.Version != "v5" {
+					res.Items[idx].RelatedLogsLink = contextlinks.PrepareLinksToLogs(start, end, newFilters)
+				} else {
+					// TODO(srikanthccv): re-visit this and support multiple queries
+					var q qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]
+
+					for _, query := range rule.RuleCondition.CompositeQuery.Queries {
+						if query.Type == qbtypes.QueryTypeBuilder {
+							switch spec := query.Spec.(type) {
+							case qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]:
+								q = spec
+							}
+						}
+					}
+
+					filterExpr := ""
+					if q.Filter != nil && q.Filter.Expression != "" {
+						filterExpr = q.Filter.Expression
+					}
+
+					whereClause := contextlinks.PrepareFilterExpression(lbls, filterExpr, q.GroupBy)
+
+					res.Items[idx].RelatedLogsLink = contextlinks.PrepareLinksToLogsV5(start, end, whereClause)
+				}
 			} else if rule.AlertType == ruletypes.AlertTypeTraces {
-				res.Items[idx].RelatedTracesLink = contextlinks.PrepareLinksToTraces(start, end, newFilters)
+				if rule.Version != "v5" {
+					res.Items[idx].RelatedTracesLink = contextlinks.PrepareLinksToTraces(start, end, newFilters)
+				} else {
+					// TODO(srikanthccv): re-visit this and support multiple queries
+					var q qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]
+
+					for _, query := range rule.RuleCondition.CompositeQuery.Queries {
+						if query.Type == qbtypes.QueryTypeBuilder {
+							switch spec := query.Spec.(type) {
+							case qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]:
+								q = spec
+							}
+						}
+					}
+
+					filterExpr := ""
+					if q.Filter != nil && q.Filter.Expression != "" {
+						filterExpr = q.Filter.Expression
+					}
+
+					whereClause := contextlinks.PrepareFilterExpression(lbls, filterExpr, q.GroupBy)
+					res.Items[idx].RelatedTracesLink = contextlinks.PrepareLinksToTracesV5(start, end, whereClause)
+				}
 			}
 		}
 	}

--- a/pkg/query-service/rules/threshold_rule.go
+++ b/pkg/query-service/rules/threshold_rule.go
@@ -478,6 +478,11 @@ func (r *ThresholdRule) buildAndRunQuery(ctx context.Context, orgID valuer.UUID,
 		return resultVector, nil
 	}
 
+	if queryResult == nil {
+		r.logger.WarnContext(ctx, "query result is nil", "rule_name", r.Name(), "query_name", selectedQuery)
+		return resultVector, nil
+	}
+
 	for _, series := range queryResult.Series {
 		smpl, shouldAlert := r.ShouldAlert(*series)
 		if shouldAlert {

--- a/pkg/transition/migrate_alert.go
+++ b/pkg/transition/migrate_alert.go
@@ -73,7 +73,7 @@ func (m *alertMigrateV5) Migrate(ctx context.Context, ruleData map[string]any) b
 						panelType = pt
 					}
 
-					if m.updateQueryData(ctx, queryMap, "v4", panelType) {
+					if m.updateQueryData(ctx, queryMap, version, panelType) {
 						updated = true
 					}
 					m.logger.InfoContext(ctx, "migrated querymap")

--- a/pkg/types/ruletypes/alerting.go
+++ b/pkg/types/ruletypes/alerting.go
@@ -11,6 +11,8 @@ import (
 	"github.com/SigNoz/signoz/pkg/query-service/model"
 	v3 "github.com/SigNoz/signoz/pkg/query-service/model/v3"
 	"github.com/SigNoz/signoz/pkg/query-service/utils/labels"
+
+	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 )
 
 // this file contains common structs and methods used by
@@ -131,9 +133,27 @@ func (rc *RuleCondition) GetSelectedQueryName() string {
 				for name := range rc.CompositeQuery.BuilderQueries {
 					queryNames[name] = struct{}{}
 				}
+
+				for _, query := range rc.CompositeQuery.Queries {
+					switch spec := query.Spec.(type) {
+					case qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]:
+						queryNames[spec.Name] = struct{}{}
+					case qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]:
+						queryNames[spec.Name] = struct{}{}
+					case qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]:
+						queryNames[spec.Name] = struct{}{}
+					}
+				}
 			} else if rc.QueryType() == v3.QueryTypeClickHouseSQL {
 				for name := range rc.CompositeQuery.ClickHouseQueries {
 					queryNames[name] = struct{}{}
+				}
+
+				for _, query := range rc.CompositeQuery.Queries {
+					switch spec := query.Spec.(type) {
+					case qbtypes.ClickHouseQuery:
+						queryNames[spec.Name] = struct{}{}
+					}
 				}
 			}
 		}

--- a/pkg/types/ruletypes/alerting.go
+++ b/pkg/types/ruletypes/alerting.go
@@ -142,6 +142,8 @@ func (rc *RuleCondition) GetSelectedQueryName() string {
 						queryNames[spec.Name] = struct{}{}
 					case qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]:
 						queryNames[spec.Name] = struct{}{}
+					case qbtypes.QueryBuilderFormula:
+						queryNames[spec.Name] = struct{}{}
 					}
 				}
 			} else if rc.QueryType() == v3.QueryTypeClickHouseSQL {


### PR DESCRIPTION
## 📄 Summary

- the links generated for rule history page are broken
- fall back query name when `selectedQueryName` is not present in JSON
- remove hard coded version in alerts (they were migrated, but weren't migrated for some early adopters, which created a bit of chaos for handful of alerts)
- nil panic in v4 runner, we still allow to v4 for graceful backward compatibility till we sort out everyones migration.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken links in rule history page, add fallback for `selectedQueryName`, handle nil panic in v4 runner, and update alert migration process.
> 
>   - **Behavior**:
>     - Fix broken links in rule history page by using `PrepareLinksToLogsV5` and `PrepareLinksToTracesV5` for version `v5` in `getRuleStateHistory()` in `http_handler.go`.
>     - Add fallback to `selectedQueryName` in `GetSelectedQueryName()` in `alerting.go` when not present in JSON.
>     - Handle nil panic in `buildAndRunQuery()` in `threshold_rule.go` by checking if `queryResult` is nil.
>   - **Migration**:
>     - Remove hardcoded version in `Migrate()` in `migrate_alert.go` to support alert migration for early adopters.
>   - **Misc**:
>     - Import `qbtypes` in `http_handler.go` and `alerting.go` for query builder types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for c15b4872340a1a9e4de9513f192338749a613e6a. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->