### PR TITLE
Allow deletion of multiple panels for dashboard updates made with API key

### DIFF
--- a/pkg/modules/dashboard/impldashboard/module.go
+++ b/pkg/modules/dashboard/impldashboard/module.go
@@ -81,7 +81,7 @@ func (module *module) Update(ctx context.Context, orgID valuer.UUID, id valuer.U
 		return nil, err
 	}
 
-	err = dashboard.Update(updatableDashboard, updatedBy)
+	err = dashboard.Update(ctx, updatableDashboard, updatedBy)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->
The check is originally intended to prevent accidental updates to lots of dashboard panels. We still want that for edits made from the web. Remove the restriction for API key users.

---

## ✅ Changes

- [ ] Feature: Brief description
- [x] fix: Allow deletion of multiple panels for dashboard updates made with API key

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

- `backend`


---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #8901 

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->
