### PR TITLE
fix(meter): meter regex for comment middleware

### DIFF
--- a/pkg/types/ctxtypes/comment.go
+++ b/pkg/types/ctxtypes/comment.go
@@ -13,7 +13,7 @@ var (
 	logsExplorerRegex    = regexp.MustCompile(`/logs/logs-explorer(?:\?.*)?$`)
 	traceExplorerRegex   = regexp.MustCompile(`/traces-explorer(?:\?.*)?$`)
 	metricsExplorerRegex = regexp.MustCompile(`/metrics-explorer/explorer(?:\?.*)?$`)
-	meterRegex           = regexp.MustCompile(`/meter/(?:\?.*)?$`)
+	meterRegex           = regexp.MustCompile(`/meter(?:/.*)?(?:\?.*)?$`)
 	dashboardRegex       = regexp.MustCompile(`/dashboard/[a-zA-Z0-9\-]+/(new|edit)(?:\?.*)?$`)
 	dashboardIDRegex     = regexp.MustCompile(`/dashboard/([a-f0-9\-]+)/`)
 	widgetIDRegex        = regexp.MustCompile(`widgetId=([a-f0-9\-]+)`)


### PR DESCRIPTION
- the previous regex had `/` in the end which didn't let it match with `/meter?relativeTime=1h` and also not for `/meter/explorer` since it expected `?` post the last `/`


contributes to - https://github.com/SigNoz/platform-pod/issues/859