### PR TITLE
fix(alert-query-v5): Added fillgaps format options in alerts qbv5

### DIFF
--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -514,7 +514,8 @@ type CompositeQuery struct {
 	ClickHouseQueries map[string]*ClickHouseQuery `json:"chQueries,omitempty"`
 	PromQueries       map[string]*PromQuery       `json:"promQueries,omitempty"`
 
-	Queries []qbtypes.QueryEnvelope `json:"queries,omitempty"`
+	Queries       []qbtypes.QueryEnvelope `json:"queries,omitempty"`
+	FormatOptions *qbtypes.FormatOptions  `json:"formatOptions,omitempty"`
 
 	PanelType PanelType `json:"panelType"`
 	QueryType QueryType `json:"queryType"`

--- a/pkg/query-service/rules/threshold_rule.go
+++ b/pkg/query-service/rules/threshold_rule.go
@@ -293,6 +293,9 @@ func (r *ThresholdRule) prepareQueryRangeV5(ctx context.Context, ts time.Time) (
 	}
 	req.CompositeQuery.Queries = make([]qbtypes.QueryEnvelope, len(r.Condition().CompositeQuery.Queries))
 	copy(req.CompositeQuery.Queries, r.Condition().CompositeQuery.Queries)
+	if r.Condition().CompositeQuery.FormatOptions != nil {
+		req.FormatOptions = r.Condition().CompositeQuery.FormatOptions
+	}
 	return req, nil
 }
 


### PR DESCRIPTION
## 📄 Summary



Added Format Options In alerts qbv5 so that we can use fillgaps in the alerts also
---
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `FormatOptions` to `CompositeQuery` for alert queries in version 5, enabling `fillgaps` support.
> 
>   - **Behavior**:
>     - Adds `FormatOptions` to `CompositeQuery` in `v3.go` to support `fillgaps` in alerts.
>     - Updates `prepareQueryRangeV5()` in `threshold_rule.go` to include `FormatOptions` if present.
>   - **Misc**:
>     - Minor formatting change in `CompositeQuery` declaration in `v3.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 5d1253d2b6213f3742dfdaf41dbf2dae32625c04. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->