### PR TITLE
fix: trace explorer and home page keyboard shortcut

### DIFF
--- a/frontend/src/constants/shortcuts/globalShortcuts.ts
+++ b/frontend/src/constants/shortcuts/globalShortcuts.ts
@@ -25,11 +25,11 @@ export const GlobalShortcutsName = {
 export const GlobalShortcutsDescription = {
 	NavigateToHome: 'Navigate to Home',
 	NavigateToServices: 'Navigate to Services page',
-	NavigateToTraces: 'Navigate to Traces page',
-	NavigateToLogs: 'Navigate to logs page',
-	NavigateToDashboards: 'Navigate to dashboards page',
-	NavigateToAlerts: 'Navigate to alerts page',
-	NavigateToExceptions: 'Navigate to Exceptions page',
-	NavigateToMessagingQueues: 'Navigate to Messaging Queues page',
+	NavigateToTraces: 'Navigate to Traces Explorer',
+	NavigateToLogs: 'Navigate to Logs Explorer',
+	NavigateToDashboards: 'Navigate to Dashboards List',
+	NavigateToAlerts: 'Navigate to Alerts List',
+	NavigateToExceptions: 'Navigate to Exceptions List',
+	NavigateToMessagingQueues: 'Navigate to Messaging Queues',
 	ToggleSidebar: 'Toggle sidebar visibility',
 };

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -647,11 +647,14 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 	};
 
 	useEffect(() => {
+		registerShortcut(GlobalShortcuts.NavigateToHome, () =>
+			onClickHandler(ROUTES.HOME, null),
+		);
 		registerShortcut(GlobalShortcuts.NavigateToServices, () =>
 			onClickHandler(ROUTES.APPLICATION, null),
 		);
 		registerShortcut(GlobalShortcuts.NavigateToTraces, () =>
-			onClickHandler(ROUTES.TRACE, null),
+			onClickHandler(ROUTES.TRACES_EXPLORER, null),
 		);
 
 		registerShortcut(GlobalShortcuts.NavigateToLogs, () =>
@@ -674,6 +677,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 		);
 
 		return (): void => {
+			deregisterShortcut(GlobalShortcuts.NavigateToHome);
 			deregisterShortcut(GlobalShortcuts.NavigateToServices);
 			deregisterShortcut(GlobalShortcuts.NavigateToTraces);
 			deregisterShortcut(GlobalShortcuts.NavigateToLogs);


### PR DESCRIPTION
## 📄 Summary

Fixed trace explorer and home page keyboard shortcut navigation

Also found that 2 logs explorer shortcuts are invalid, keeping them for now and created issue - https://github.com/SigNoz/engineering-pod/issues/2890
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes keyboard shortcuts for trace explorer and home page navigation, updating descriptions in `globalShortcuts.ts` and handling in `SideNav.tsx`.
> 
>   - **Behavior**:
>     - Fixes keyboard shortcuts for navigating to the trace explorer and home page in `SideNav.tsx`.
>     - Updates shortcut descriptions in `globalShortcuts.ts` to reflect correct navigation targets (e.g., "Traces Explorer" instead of "Traces page").
>   - **Misc**:
>     - Registers and deregisters the `NavigateToHome` shortcut in `SideNav.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 85664abaa66f97f8fb76b7bf20ad76bb4a40b092. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->