### PR TITLE
fix: support canDefaultZero for logs and traces

### DIFF
--- a/pkg/querier/postprocess.go
+++ b/pkg/querier/postprocess.go
@@ -1012,8 +1012,7 @@ func canDefaultZeroAgg(expr string) bool {
 	// while statistical/analytical operations should show gaps when there's no data to analyze.
 	if strings.HasPrefix(expr, "count(") ||
 		strings.HasPrefix(expr, "count_distinct(") ||
-		strings.HasPrefix(expr, "sum(") ||
-		strings.HasPrefix(expr, "increase(") {
+		strings.HasPrefix(expr, "sum(") {
 		return true
 	}
 	return false

--- a/pkg/types/querybuildertypes/querybuildertypesv5/req.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/req.go
@@ -409,6 +409,7 @@ func (r *QueryRangeRequest) GetQueriesSupportingZeroDefault() map[string]bool {
 		expr = strings.ToLower(expr)
 		// only pure additive/counting operations should default to zero,
 		// while statistical/analytical operations should show gaps when there's no data to analyze.
+		// TODO: use newExprVisitor for getting the function used in the expression
 		if strings.HasPrefix(expr, "count(") ||
 			strings.HasPrefix(expr, "count_distinct(") ||
 			strings.HasPrefix(expr, "sum(") ||

--- a/pkg/types/querybuildertypes/querybuildertypesv5/req.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/req.go
@@ -403,3 +403,36 @@ type FormatOptions struct {
 	FillGaps               bool `json:"fillGaps,omitempty"`
 	FormatTableResultForUI bool `json:"formatTableResultForUI,omitempty"`
 }
+
+func (r *QueryRangeRequest) GetQueriesSupportingZeroDefault() map[string]bool {
+	canDefaultZeroAgg := func(expr string) bool {
+		expr = strings.ToLower(expr)
+		// only pure additive/counting operations should default to zero,
+		// while statistical/analytical operations should show gaps when there's no data to analyze.
+		if strings.HasPrefix(expr, "count(") ||
+			strings.HasPrefix(expr, "count_distinct(") ||
+			strings.HasPrefix(expr, "sum(") ||
+			strings.HasPrefix(expr, "rate(") {
+			return true
+		}
+		return false
+
+	}
+
+	canDefaultZero := make(map[string]bool)
+	for _, q := range r.CompositeQuery.Queries {
+		if q.Type == QueryTypeBuilder {
+			if query, ok := q.Spec.(QueryBuilderQuery[TraceAggregation]); ok {
+				if len(query.Aggregations) == 1 && canDefaultZeroAgg(query.Aggregations[0].Expression) {
+					canDefaultZero[query.Name] = true
+				}
+			} else if query, ok := q.Spec.(QueryBuilderQuery[LogAggregation]); ok {
+				if len(query.Aggregations) == 1 && canDefaultZeroAgg(query.Aggregations[0].Expression) {
+					canDefaultZero[query.Name] = true
+				}
+			}
+		}
+	}
+
+	return canDefaultZero
+}

--- a/pkg/types/querybuildertypes/querybuildertypesv5/req_test.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/req_test.go
@@ -1587,13 +1587,13 @@ func TestQueryRangeRequest_GetQueriesSupportingZeroDefault(t *testing.T) {
 				Queries: []QueryEnvelope{
 					{
 						Type: QueryTypeBuilder,
-						Spec: QueryBuilderQuery[TraceAggregation]{
+						Spec: QueryBuilderQuery[LogAggregation]{
 							Name:   "A",
 							Signal: telemetrytypes.SignalTraces,
 							Filter: &Filter{
 								Expression: "service.name = demo",
 							},
-							Aggregations: []TraceAggregation{
+							Aggregations: []LogAggregation{
 								{
 									Expression: "rate()",
 								},
@@ -1612,13 +1612,13 @@ func TestQueryRangeRequest_GetQueriesSupportingZeroDefault(t *testing.T) {
 				Queries: []QueryEnvelope{
 					{
 						Type: QueryTypeBuilder,
-						Spec: QueryBuilderQuery[TraceAggregation]{
+						Spec: QueryBuilderQuery[LogAggregation]{
 							Name:   "A",
 							Signal: telemetrytypes.SignalTraces,
 							Filter: &Filter{
 								Expression: "service.name = demo",
 							},
-							Aggregations: []TraceAggregation{
+							Aggregations: []LogAggregation{
 								{
 									Expression: "min(duration)",
 								},


### PR DESCRIPTION
Fixes https://github.com/SigNoz/signoz/issues/8914
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for defaulting to zero in logs and traces by implementing `GetQueriesSupportingZeroDefault` in `QueryRangeRequest`.
> 
>   - **Behavior**:
>     - Implement `GetQueriesSupportingZeroDefault()` in `QueryRangeRequest` to identify queries that can default to zero.
>     - Modify `processTimeSeriesFormula()` and `processScalarFormula()` in `postprocess.go` to use `GetQueriesSupportingZeroDefault()`.
>   - **Tests**:
>     - Add `TestQueryRangeRequest_GetQueriesSupportingZeroDefault` in `req_test.go` to verify correct identification of queries supporting zero default.
>   - **Misc**:
>     - Remove TODO comment about conditional default zero in `postprocess.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 8a525afc7e60a46032fe66fae1db00138ad75f81. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->