### PR TITLE
fix(binding): better error messages

### DIFF
--- a/pkg/http/binding/binding.go
+++ b/pkg/http/binding/binding.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	ErrCodeInvalidRequestBody = errors.MustNewCode("invalid_request_body")
+	ErrCodeInvalidRequestBody  = errors.MustNewCode("invalid_request_body")
+	ErrCodeInvalidRequestField = errors.MustNewCode("invalid_request_field")
 )
 
 var (

--- a/pkg/http/binding/json.go
+++ b/pkg/http/binding/json.go
@@ -7,6 +7,11 @@ import (
 	"github.com/SigNoz/signoz/pkg/errors"
 )
 
+const (
+	ErrMessageInvalidJSON  string = "request body contains invalid JSON, please verify the format and try again."
+	ErrMessageInvalidField string = "request body contains invalid field value"
+)
+
 var _ Binding = (*jsonBinding)(nil)
 
 type jsonBinding struct{}
@@ -32,9 +37,29 @@ func (b *jsonBinding) BindBody(body io.Reader, obj any, opts ...BindBodyOption) 
 	}
 
 	if err := decoder.Decode(obj); err != nil {
-		return errors.
-			New(errors.TypeInvalidInput, ErrCodeInvalidRequestBody, "request body is invalid").
-			WithAdditional(err.Error())
+		var syntaxError *json.SyntaxError
+		var unmarshalError *json.InvalidUnmarshalError
+		var unmarshalTypeError *json.UnmarshalTypeError
+
+		if errors.As(err, &syntaxError) || errors.As(err, &unmarshalError) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return errors.
+				New(errors.TypeInvalidInput, ErrCodeInvalidRequestBody, ErrMessageInvalidJSON).
+				WithAdditional(err.Error())
+		}
+
+		if errors.As(err, &unmarshalTypeError) {
+			if unmarshalTypeError.Field != "" {
+				return errors.
+					New(errors.TypeInvalidInput, ErrCodeInvalidRequestField, ErrMessageInvalidField).
+					WithAdditional("value of type '" + unmarshalTypeError.Value + "' was received for field '" + unmarshalTypeError.Field + "', try sending '" + unmarshalTypeError.Type.String() + "' instead?")
+			}
+
+			return errors.
+				New(errors.TypeInvalidInput, ErrCodeInvalidRequestField, ErrMessageInvalidField).
+				WithAdditional("value of type '" + unmarshalTypeError.Value + "' was received, try sending '" + unmarshalTypeError.Type.String() + "' instead?")
+		}
+
+		return err
 	}
 
 	return nil

--- a/pkg/http/binding/json_test.go
+++ b/pkg/http/binding/json_test.go
@@ -1,0 +1,68 @@
+package binding
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+type s struct {
+	A int `json:"a"`
+}
+
+func (req *s) UnmarshalJSON(b []byte) error {
+	type Alias s
+
+	var temp Alias
+	if err := json.Unmarshal(b, &temp); err != nil {
+		return err
+	}
+
+	if temp.A <= 10 {
+		return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "a must be greater than 10")
+	}
+
+	*req = s(temp)
+	return nil
+}
+
+type n struct {
+	S s `json:"s"`
+}
+
+func TestJSONBinding_BindBodyErrors(t *testing.T) {
+	testCases := []struct {
+		name    string
+		body    string
+		obj     any
+		opts    []BindBodyOption
+		code    errors.Code
+		message string
+		a       []string
+	}{
+		{name: "Empty", body: "", opts: nil, obj: &struct{}{}, code: ErrCodeInvalidRequestBody, message: ErrMessageInvalidJSON, a: []string{io.EOF.Error()}},
+		{name: "String", body: "invalid json", opts: nil, obj: &struct{}{}, code: ErrCodeInvalidRequestBody, message: ErrMessageInvalidJSON, a: []string{"invalid character 'i' looking for beginning of value"}},
+		{name: "Invalid", body: `{"a":"b}`, opts: nil, obj: &struct{}{}, code: ErrCodeInvalidRequestBody, message: ErrMessageInvalidJSON, a: []string{io.ErrUnexpectedEOF.Error()}},
+		{name: "CustomValid", body: `{"a":9}`, opts: nil, obj: new(s), code: errors.CodeInvalidInput, message: "a must be greater than 10", a: []string{}},
+		{name: "CustomInvalidJSON", body: `{"a:9}`, opts: nil, obj: new(s), code: ErrCodeInvalidRequestBody, message: ErrMessageInvalidJSON, a: []string{io.ErrUnexpectedEOF.Error()}},
+		{name: "CustomMismatchedType", body: `{"a":"b"}`, opts: nil, obj: new(s), code: ErrCodeInvalidRequestField, message: ErrMessageInvalidField, a: []string{`value of type 'string' was received for field 'a', try sending 'int' instead?`}},
+		{name: "CustomNestedMismatchedType", body: `{"s":{"a":"b"}}`, opts: nil, obj: new(n), code: ErrCodeInvalidRequestField, message: ErrMessageInvalidField, a: []string{`value of type 'string' was received for field 's.a', try sending 'int' instead?`}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := JSON.BindBody(strings.NewReader(testCase.body), testCase.obj, testCase.opts...)
+			assert.Error(t, err)
+
+			typ, c, m, _, _, a := errors.Unwrapb(err)
+			assert.Equal(t, errors.TypeInvalidInput, typ)
+			assert.Equal(t, testCase.code, c)
+			assert.Equal(t, testCase.message, m)
+			assert.ElementsMatch(t, testCase.a, a)
+		})
+	}
+}


### PR DESCRIPTION
## 📄 Summary

better error messages from binding package

part of https://github.com/SigNoz/platform-pod/issues/1133
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves JSON binding error messages and handling in `binding` package, adding specific error codes and tests.
> 
>   - **Error Handling**:
>     - Adds `ErrCodeInvalidRequestField` in `binding.go` for invalid field values.
>     - Adds `ErrMessageInvalidJSON` and `ErrMessageInvalidField` in `json.go` for detailed error messages.
>     - Updates `BindBody` in `json.go` to handle `json.SyntaxError`, `json.InvalidUnmarshalError`, and `json.UnmarshalTypeError` with specific messages.
>   - **Testing**:
>     - Adds `json_test.go` to test various error scenarios in `BindBody`, including empty body, invalid JSON, and type mismatches.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 16c9879a220ce5631364ba4bbf7fdd762d918c68. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->