### PR TITLE
chore: enable forbidigo and noerrors in depguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,10 @@ linters-settings:
         deny:
           - pkg: "go.uber.org/zap"
             desc: "Do not use zap logger. Use slog instead."
+      noerrors:
+        deny:
+          - pkg: "errors"
+            desc: "Do not use errors package. Use github.com/SigNoz/signoz/pkg/errors instead."
   iface:
     enable:
       - identical

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - depguard
     - iface
     - unparam
+    - forbidigo
 
 linters-settings:
   sloglint:

--- a/cmd/community/server.go
+++ b/cmd/community/server.go
@@ -32,7 +32,7 @@ func registerServer(parentCmd *cobra.Command, logger *slog.Logger) {
 		Short:              "Run the SigNoz server",
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		RunE: func(currCmd *cobra.Command, args []string) error {
-			config, err := cmd.NewSigNozConfig(currCmd.Context(), flags)
+			config, err := cmd.NewSigNozConfig(currCmd.Context(), logger, flags)
 			if err != nil {
 				return err
 			}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 
@@ -12,9 +11,10 @@ import (
 	"github.com/SigNoz/signoz/pkg/signoz"
 )
 
-func NewSigNozConfig(ctx context.Context, flags signoz.DeprecatedFlags) (signoz.Config, error) {
+func NewSigNozConfig(ctx context.Context, logger *slog.Logger, flags signoz.DeprecatedFlags) (signoz.Config, error) {
 	config, err := signoz.NewConfig(
 		ctx,
+		logger,
 		config.ResolverConfig{
 			Uris: []string{"env:"},
 			ProviderFactories: []config.ProviderFactory{
@@ -31,14 +31,10 @@ func NewSigNozConfig(ctx context.Context, flags signoz.DeprecatedFlags) (signoz.
 	return config, nil
 }
 
-func NewJWTSecret(_ context.Context, _ *slog.Logger) string {
+func NewJWTSecret(ctx context.Context, logger *slog.Logger) string {
 	jwtSecret := os.Getenv("SIGNOZ_JWT_SECRET")
 	if len(jwtSecret) == 0 {
-		fmt.Println("🚨 CRITICAL SECURITY ISSUE: No JWT secret key specified!")
-		fmt.Println("SIGNOZ_JWT_SECRET environment variable is not set. This has dire consequences for the security of the application.")
-		fmt.Println("Without a JWT secret, user sessions are vulnerable to tampering and unauthorized access.")
-		fmt.Println("Please set the SIGNOZ_JWT_SECRET environment variable immediately.")
-		fmt.Println("For more information, please refer to https://github.com/SigNoz/signoz/issues/8400.")
+		logger.ErrorContext(ctx, "🚨 CRITICAL SECURITY ISSUE: No JWT secret key specified!", "error", "SIGNOZ_JWT_SECRET environment variable is not set. This has dire consequences for the security of the application. Without a JWT secret, user sessions are vulnerable to tampering and unauthorized access. Please set the SIGNOZ_JWT_SECRET environment variable immediately. For more information, please refer to https://github.com/SigNoz/signoz/issues/8400.")
 	}
 
 	return jwtSecret

--- a/cmd/enterprise/server.go
+++ b/cmd/enterprise/server.go
@@ -35,7 +35,7 @@ func registerServer(parentCmd *cobra.Command, logger *slog.Logger) {
 		Short:              "Run the SigNoz server",
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		RunE: func(currCmd *cobra.Command, args []string) error {
-			config, err := cmd.NewSigNozConfig(currCmd.Context(), flags)
+			config, err := cmd.NewSigNozConfig(currCmd.Context(), logger, flags)
 			if err != nil {
 				return err
 			}

--- a/pkg/errors/code.go
+++ b/pkg/errors/code.go
@@ -16,7 +16,7 @@ var (
 	CodeForbidden             = Code{"forbidden"}
 	CodeCanceled              = Code{"canceled"}
 	CodeTimeout               = Code{"timeout"}
-	codeUnknown               = Code{"unknown"}
+	CodeUnknown               = Code{"unknown"}
 )
 
 var (

--- a/pkg/errors/code.go
+++ b/pkg/errors/code.go
@@ -16,6 +16,7 @@ var (
 	CodeForbidden             = Code{"forbidden"}
 	CodeCanceled              = Code{"canceled"}
 	CodeTimeout               = Code{"timeout"}
+	codeUnknown               = Code{"unknown"}
 )
 
 var (

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,7 +1,7 @@
 package errors
 
 import (
-	"errors"
+	"errors" //nolint:depguard
 	"fmt"
 	"log/slog"
 )
@@ -138,7 +138,7 @@ func Unwrapb(cause error) (typ, Code, string, error, string, []string) {
 		return base.t, base.c, base.m, base.e, base.u, base.a
 	}
 
-	return TypeInternal, codeUnknown, cause.Error(), cause, "", []string{}
+	return TypeInternal, CodeUnknown, cause.Error(), cause, "", []string{}
 }
 
 // Ast checks if the provided error matches the specified custom error type.

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -6,10 +6,6 @@ import (
 	"log/slog"
 )
 
-var (
-	codeUnknown Code = MustNewCode("unknown")
-)
-
 // base is the fundamental struct that implements the error interface.
 // The order of the struct is 'TCMEUA'.
 type base struct {
@@ -59,7 +55,7 @@ func New(t typ, code Code, message string) *base {
 }
 
 // Newf returns a new base by formatting the error message with the supplied format specifier.
-func Newf(t typ, code Code, format string, args ...interface{}) *base {
+func Newf(t typ, code Code, format string, args ...any) *base {
 	return &base{
 		t: t,
 		c: code,
@@ -70,7 +66,7 @@ func Newf(t typ, code Code, format string, args ...interface{}) *base {
 
 // Wrapf returns a new error by formatting the error message with the supplied format specifier
 // and wrapping another error with base.
-func Wrapf(cause error, t typ, code Code, format string, args ...interface{}) *base {
+func Wrapf(cause error, t typ, code Code, format string, args ...any) *base {
 	return &base{
 		t: t,
 		c: code,
@@ -91,7 +87,7 @@ func Wrap(cause error, t typ, code Code, message string) *base {
 
 // WithAdditional wraps an existing base error with a new formatted message.
 // It is used when the original error already contains type and code.
-func WithAdditional(cause error, format string, args ...interface{}) *base {
+func WithAdditional(cause error, format string, args ...any) *base {
 	t, c, m, e, u, a := Unwrapb(cause)
 	b := &base{
 		t: t,
@@ -164,42 +160,52 @@ func Join(errs ...error) error {
 	return errors.Join(errs...)
 }
 
+// As is a wrapper around errors.As.
 func As(err error, target any) bool {
 	return errors.As(err, target)
 }
 
+// Is is a wrapper around errors.Is.
 func Is(err error, target error) bool {
 	return errors.Is(err, target)
 }
 
-func WrapNotFoundf(cause error, code Code, format string, args ...interface{}) *base {
+// WrapNotFoundf is a wrapper around Wrapf with TypeNotFound.
+func WrapNotFoundf(cause error, code Code, format string, args ...any) *base {
 	return Wrapf(cause, TypeNotFound, code, format, args...)
 }
 
-func NewNotFoundf(code Code, format string, args ...interface{}) *base {
+// NewNotFoundf is a wrapper around Newf with TypeNotFound.
+func NewNotFoundf(code Code, format string, args ...any) *base {
 	return Newf(TypeNotFound, code, format, args...)
 }
 
-func WrapInternalf(cause error, code Code, format string, args ...interface{}) *base {
+// WrapInternalf is a wrapper around Wrapf with TypeInternal.
+func WrapInternalf(cause error, code Code, format string, args ...any) *base {
 	return Wrapf(cause, TypeInternal, code, format, args...)
 }
 
-func NewInternalf(code Code, format string, args ...interface{}) *base {
+// NewInternalf is a wrapper around Newf with TypeInternal.
+func NewInternalf(code Code, format string, args ...any) *base {
 	return Newf(TypeInternal, code, format, args...)
 }
 
-func WrapInvalidInputf(cause error, code Code, format string, args ...interface{}) *base {
+// WrapInvalidInputf is a wrapper around Wrapf with TypeInvalidInput.
+func WrapInvalidInputf(cause error, code Code, format string, args ...any) *base {
 	return Wrapf(cause, TypeInvalidInput, code, format, args...)
 }
 
-func NewInvalidInputf(code Code, format string, args ...interface{}) *base {
+// NewInvalidInputf is a wrapper around Newf with TypeInvalidInput.
+func NewInvalidInputf(code Code, format string, args ...any) *base {
 	return Newf(TypeInvalidInput, code, format, args...)
 }
 
-func WrapUnexpectedf(cause error, code Code, format string, args ...interface{}) *base {
+// WrapUnexpectedf is a wrapper around Wrapf with TypeUnexpected.
+func WrapUnexpectedf(cause error, code Code, format string, args ...any) *base {
 	return Wrapf(cause, TypeInvalidInput, code, format, args...)
 }
 
-func NewUnexpectedf(code Code, format string, args ...interface{}) *base {
+// NewUnexpectedf is a wrapper around Newf with TypeUnexpected.
+func NewUnexpectedf(code Code, format string, args ...any) *base {
 	return Newf(TypeInvalidInput, code, format, args...)
 }

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,7 +1,7 @@
 package errors
 
 import (
-	"errors"
+	"errors" //nolint:depguard
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/factory/registry.go
+++ b/pkg/factory/registry.go
@@ -2,12 +2,16 @@ package factory
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+)
+
+var (
+	ErrCodeInvalidRegistry = errors.MustNewCode("invalid_registry")
 )
 
 type Registry struct {
@@ -20,11 +24,11 @@ type Registry struct {
 // New creates a new registry of services. It needs at least one service in the input.
 func NewRegistry(logger *slog.Logger, services ...NamedService) (*Registry, error) {
 	if logger == nil {
-		return nil, fmt.Errorf("cannot build registry, logger is required")
+		return nil, errors.Newf(errors.TypeInvalidInput, ErrCodeInvalidRegistry, "cannot build registry, logger is required")
 	}
 
 	if len(services) == 0 {
-		return nil, fmt.Errorf("cannot build registry, at least one service is required")
+		return nil, errors.Newf(errors.TypeInvalidInput, ErrCodeInvalidRegistry, "cannot build registry, at least one service is required")
 	}
 
 	m, err := NewNamedMap(services...)

--- a/pkg/gateway/config.go
+++ b/pkg/gateway/config.go
@@ -1,10 +1,15 @@
 package gateway
 
 import (
-	"errors"
 	"net/url"
 
+	"github.com/SigNoz/signoz/pkg/errors"
+
 	"github.com/SigNoz/signoz/pkg/factory"
+)
+
+var (
+	ErrCodeInvalidGatewayConfig = errors.MustNewCode("invalid_gateway_config")
 )
 
 type Config struct {
@@ -27,7 +32,8 @@ func newConfig() factory.Config {
 
 func (c Config) Validate() error {
 	if c.URL == nil {
-		return errors.New("url is required")
+		return errors.New(errors.TypeInvalidInput, ErrCodeInvalidGatewayConfig, "url is required")
 	}
+
 	return nil
 }

--- a/pkg/signoz/config_test.go
+++ b/pkg/signoz/config_test.go
@@ -2,6 +2,8 @@ package signoz
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/SigNoz/signoz/pkg/config/configtest"
@@ -11,6 +13,7 @@ import (
 // This is a test to ensure that all fields of config implement the factory.Config interface and are valid with
 // their default values.
 func TestValidateConfig(t *testing.T) {
-	_, err := NewConfig(context.Background(), configtest.NewResolverConfig(), DeprecatedFlags{})
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	_, err := NewConfig(context.Background(), logger, configtest.NewResolverConfig(), DeprecatedFlags{})
 	assert.NoError(t, err)
 }

--- a/pkg/smtp/client/auth.go
+++ b/pkg/smtp/client/auth.go
@@ -1,9 +1,10 @@
 package client
 
 import (
-	"errors"
 	"net/smtp"
 	"strings"
+
+	"github.com/SigNoz/signoz/pkg/errors"
 )
 
 type loginAuth struct {
@@ -27,7 +28,7 @@ func (auth *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 		case "password:":
 			return []byte(auth.password), nil
 		default:
-			return nil, errors.New("unexpected server challenge")
+			return nil, errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "unexpected server challenge")
 		}
 	}
 	return nil, nil

--- a/pkg/sqlmigration/013_update_organization.go
+++ b/pkg/sqlmigration/013_update_organization.go
@@ -3,7 +3,8 @@ package sqlmigration
 import (
 	"context"
 	"database/sql"
-	"errors"
+
+	"github.com/SigNoz/signoz/pkg/errors"
 
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/sqlstore"

--- a/pkg/sqlmigration/014_add_alertmanager.go
+++ b/pkg/sqlmigration/014_add_alertmanager.go
@@ -70,7 +70,7 @@ func (migration *addAlertmanager) Up(ctx context.Context, db *bun.DB) error {
 			NewAddColumn().
 			Table("notification_channels").
 			ColumnExpr("org_id TEXT REFERENCES organizations(id) ON DELETE CASCADE").
-			Exec(ctx); err != nil && err != ErrNoExecute {
+			Exec(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/sqlmigration/046_update_dashboard_alert_and_saved_view_v5.go
+++ b/pkg/sqlmigration/046_update_dashboard_alert_and_saved_view_v5.go
@@ -279,7 +279,6 @@ func (migration *queryBuilderV5Migration) migrateRules(
 		updated := alertsMigrator.Migrate(ctx, rule.Data)
 
 		if updated {
-			fmt.Println("updated rule", rule.ID)
 			dataJSON, err := json.Marshal(rule.Data)
 			if err != nil {
 				return err

--- a/pkg/sqlmigration/sqlmigration.go
+++ b/pkg/sqlmigration/sqlmigration.go
@@ -2,7 +2,6 @@ package sqlmigration
 
 import (
 	"context"
-	"errors"
 
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/uptrace/bun"
@@ -21,10 +20,6 @@ type SQLMigration interface {
 	// Down rolls back the migration.
 	Down(context.Context, *bun.DB) error
 }
-
-var (
-	ErrNoExecute = errors.New("no execute")
-)
 
 var (
 	OrgReference                = "org"

--- a/pkg/sqlmigrator/config.go
+++ b/pkg/sqlmigrator/config.go
@@ -1,10 +1,15 @@
 package sqlmigrator
 
 import (
-	"errors"
 	"time"
 
+	"github.com/SigNoz/signoz/pkg/errors"
+
 	"github.com/SigNoz/signoz/pkg/factory"
+)
+
+var (
+	ErrCodeInvalidSQLMigratorConfig = errors.MustNewCode("invalid_sqlmigrator_config")
 )
 
 type Config struct {
@@ -34,7 +39,7 @@ func newConfig() factory.Config {
 
 func (c Config) Validate() error {
 	if c.Lock.Timeout <= c.Lock.Interval {
-		return errors.New("lock::timeout must be greater than lock::interval")
+		return errors.New(errors.TypeInvalidInput, ErrCodeInvalidSQLMigratorConfig, "lock::timeout must be greater than lock::interval")
 	}
 
 	return nil

--- a/pkg/sqlmigrator/migrator.go
+++ b/pkg/sqlmigrator/migrator.go
@@ -2,8 +2,9 @@ package sqlmigrator
 
 import (
 	"context"
-	"errors"
 	"time"
+
+	"github.com/SigNoz/signoz/pkg/errors"
 
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
@@ -100,7 +101,7 @@ func (migrator *migrator) Lock(ctx context.Context) error {
 	for {
 		select {
 		case <-timer.C:
-			err := errors.New("timed out waiting for lock")
+			err := errors.New(errors.TypeTimeout, errors.CodeTimeout, "timed out waiting for lock")
 			migrator.settings.Logger().ErrorContext(ctx, "cannot acquire lock", "error", err, "lock_timeout", migrator.config.Lock.Timeout.String(), "dialect", migrator.dialect)
 			return err
 		case <-ticker.C:

--- a/pkg/sqlschema/sqlitesqlschema/ddl.go
+++ b/pkg/sqlschema/sqlitesqlschema/ddl.go
@@ -1,10 +1,11 @@
 package sqlitesqlschema
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/SigNoz/signoz/pkg/errors"
 
 	"github.com/SigNoz/signoz/pkg/sqlschema"
 )
@@ -12,6 +13,7 @@ import (
 // Inspired by https://github.com/go-gorm/sqlite
 
 var (
+	ErrCodeInvalidDDL  = errors.MustNewCode("invalid_ddl")
 	sqliteSeparator    = "`|\"|'|\t"
 	sqliteIdentQuote   = "`|\"|'"
 	uniqueRegexp       = regexp.MustCompile(fmt.Sprintf(`^(?:CONSTRAINT [%v]?[\w-]+[%v]? )?UNIQUE (.*)$`, sqliteSeparator, sqliteSeparator))
@@ -40,12 +42,12 @@ const (
 func parseCreateTable(str string, fmter sqlschema.SQLFormatter) (*sqlschema.Table, []*sqlschema.UniqueConstraint, error) {
 	sections := tableRegexp.FindStringSubmatch(str)
 	if len(sections) == 0 {
-		return nil, nil, errors.New("invalid DDL")
+		return nil, nil, errors.New(errors.TypeInternal, ErrCodeInvalidDDL, "invalid DDL")
 	}
 
 	tableNameSections := tableNameRegexp.FindStringSubmatch(str)
 	if len(tableNameSections) == 0 {
-		return nil, nil, errors.New("invalid DDL")
+		return nil, nil, errors.New(errors.TypeInternal, ErrCodeInvalidDDL, "invalid DDL")
 	}
 
 	tableName := sqlschema.TableName(tableNameSections[1])
@@ -97,14 +99,14 @@ func parseCreateTable(str string, fmter sqlschema.SQLFormatter) (*sqlschema.Tabl
 		}
 
 		if bracketLevel < 0 {
-			return nil, nil, errors.New("invalid DDL, unbalanced brackets")
+			return nil, nil, errors.New(errors.TypeInternal, ErrCodeInvalidDDL, "invalid DDL, unbalanced brackets")
 		}
 
 		buf += string(c)
 	}
 
 	if bracketLevel != 0 {
-		return nil, nil, errors.New("invalid DDL, unbalanced brackets")
+		return nil, nil, errors.New(errors.TypeInternal, ErrCodeInvalidDDL, "invalid DDL, unbalanced brackets")
 	}
 
 	if buf != "" {
@@ -300,14 +302,14 @@ func parseAllColumns(in string) ([]sqlschema.ColumnName, error) {
 				state = parseAllColumnsState_State_End
 				continue
 			}
-			return nil, fmt.Errorf("unexpected token: %s", string(s[i]))
+			return nil, errors.Newf(errors.TypeInternal, ErrCodeInvalidDDL, "unexpected token: %s", string(s[i]))
 		case parseAllColumnsState_State_End:
 			// break is automatic in Go switch statements
 		}
 	}
 
 	if state != parseAllColumnsState_State_End {
-		return nil, errors.New("unexpected end")
+		return nil, errors.New(errors.TypeInternal, ErrCodeInvalidDDL, "unexpected end")
 	}
 
 	return columns, nil

--- a/pkg/telemetrystore/telemetrystorehook/logging.go
+++ b/pkg/telemetrystore/telemetrystorehook/logging.go
@@ -3,9 +3,10 @@ package telemetrystorehook
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"log/slog"
 	"time"
+
+	"github.com/SigNoz/signoz/pkg/errors"
 
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"

--- a/pkg/types/authtypes/uuid.go
+++ b/pkg/types/authtypes/uuid.go
@@ -2,7 +2,8 @@ package authtypes
 
 import (
 	"context"
-	"errors"
+
+	"github.com/SigNoz/signoz/pkg/errors"
 )
 
 type uuidKey struct{}
@@ -24,7 +25,7 @@ func (u *UUID) ContextFromRequest(ctx context.Context, values ...string) (contex
 	}
 
 	if value == "" {
-		return ctx, errors.New("missing Authorization header")
+		return ctx, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "missing Authorization header")
 	}
 
 	return NewContextWithUUID(ctx, value), nil

--- a/pkg/types/pipelinetypes/time_parser.go
+++ b/pkg/types/pipelinetypes/time_parser.go
@@ -1,10 +1,11 @@
 package pipelinetypes
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/SigNoz/signoz/pkg/errors"
 )
 
 // Regex for strptime format placeholders supported by the time parser.
@@ -106,7 +107,7 @@ func RegexForStrptimeLayout(layout string) (string, error) {
 		if regex, ok := ctimeRegex[directive]; ok {
 			return regex
 		}
-		errs = append(errs, errors.New("unsupported ctimefmt directive: "+directive))
+		errs = append(errs, errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "unsupported ctimefmt directive: "+directive))
 		return ""
 	}
 

--- a/pkg/types/ruletypes/recurrence.go
+++ b/pkg/types/ruletypes/recurrence.go
@@ -3,8 +3,9 @@ package ruletypes
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"errors"
 	"time"
+
+	"github.com/SigNoz/signoz/pkg/errors"
 )
 
 type RepeatType string
@@ -61,7 +62,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 
 		return nil
 	default:
-		return errors.New("invalid duration")
+		return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "invalid duration")
 	}
 }
 

--- a/pkg/types/ruletypes/templates.go
+++ b/pkg/types/ruletypes/templates.go
@@ -3,13 +3,14 @@ package ruletypes
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"net/url"
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/SigNoz/signoz/pkg/errors"
 
 	html_template "html/template"
 	text_template "text/template"
@@ -73,7 +74,7 @@ func NewTemplateExpander(
 				if len(v) > 0 {
 					return v[0], nil
 				}
-				return nil, errors.New("first() called on vector with no elements")
+				return nil, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "first() called on vector with no elements")
 			},
 			"label": func(label string, s *tmplQueryRecord) string {
 				return s.Labels[label]

--- a/pkg/valuer/string.go
+++ b/pkg/valuer/string.go
@@ -3,9 +3,10 @@ package valuer
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"strings"
+
+	"github.com/SigNoz/signoz/pkg/errors"
 )
 
 var _ Valuer = (*String)(nil)
@@ -50,7 +51,7 @@ func (enum String) Value() (driver.Value, error) {
 
 func (enum *String) Scan(val interface{}) error {
 	if enum == nil {
-		return fmt.Errorf("string: (nil \"%s\")", reflect.TypeOf(enum).String())
+		return errors.Newf(errors.TypeInternal, ErrCodeUnknownValuerScan, "string: (nil \"%s\")", reflect.TypeOf(enum).String())
 	}
 
 	if val == nil {
@@ -61,7 +62,7 @@ func (enum *String) Scan(val interface{}) error {
 
 	str, ok := val.(string)
 	if !ok {
-		return fmt.Errorf("string: (non-string \"%s\")", reflect.TypeOf(val).String())
+		return errors.Newf(errors.TypeInternal, ErrCodeUnknownValuerScan, "string: (non-string \"%s\")", reflect.TypeOf(val).String())
 	}
 
 	*enum = NewString(str)

--- a/pkg/valuer/uuid.go
+++ b/pkg/valuer/uuid.go
@@ -3,9 +3,9 @@ package valuer
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"fmt"
 	"reflect"
 
+	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/google/uuid"
 )
 
@@ -98,11 +98,11 @@ func (enum UUID) Value() (driver.Value, error) {
 
 func (enum *UUID) Scan(val interface{}) error {
 	if enum == nil {
-		return fmt.Errorf("uuid: (nil \"%s\")", reflect.TypeOf(enum).String())
+		return errors.Newf(errors.TypeInternal, ErrCodeUnknownValuerScan, "uuid: (nil \"%s\")", reflect.TypeOf(enum).String())
 	}
 
 	if val == nil {
-		return fmt.Errorf("uuid: (nil \"%s\")", reflect.TypeOf(val).String())
+		return errors.Newf(errors.TypeInternal, ErrCodeUnknownValuerScan, "uuid: (nil \"%s\")", reflect.TypeOf(val).String())
 	}
 
 	var enumVal UUID
@@ -110,17 +110,17 @@ func (enum *UUID) Scan(val interface{}) error {
 	case string:
 		_enumVal, err := NewUUID(val)
 		if err != nil {
-			return fmt.Errorf("uuid: (invalid-uuid \"%s\")", err.Error())
+			return errors.Newf(errors.TypeInternal, ErrCodeUnknownValuerScan, "uuid: (invalid-uuid \"%s\")", err.Error())
 		}
 		enumVal = _enumVal
 	case []byte:
 		_enumVal, err := NewUUIDFromBytes(val)
 		if err != nil {
-			return fmt.Errorf("uuid: (invalid-uuid \"%s\")", err.Error())
+			return errors.Newf(errors.TypeInternal, ErrCodeUnknownValuerScan, "uuid: (invalid-uuid \"%s\")", err.Error())
 		}
 		enumVal = _enumVal
 	default:
-		return fmt.Errorf("uuid: (non-uuid \"%s\")", reflect.TypeOf(val).String())
+		return errors.Newf(errors.TypeInternal, ErrCodeUnknownValuerScan, "uuid: (non-uuid \"%s\")", reflect.TypeOf(val).String())
 	}
 
 	*enum = enumVal

--- a/pkg/valuer/valuer.go
+++ b/pkg/valuer/valuer.go
@@ -6,6 +6,12 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+)
+
+var (
+	ErrCodeUnknownValuerScan = errors.MustNewCode("unknown_valuer_scan")
 )
 
 type Valuer interface {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -102,10 +102,10 @@ func (b Build) PrettyPrint(cfg Config) {
 		"                       :**********=                        ",
 	}
 
-	fmt.Println()
+	fmt.Println() //nolint:forbidigo
 	for _, line := range ascii {
-		fmt.Print(line)
-		fmt.Println()
+		fmt.Print(line) //nolint:forbidigo
+		fmt.Println()   //nolint:forbidigo
 	}
-	fmt.Println()
+	fmt.Println() //nolint:forbidigo
 }


### PR DESCRIPTION
## 📄 Summary

Enable basic forbidigo in ci
Enable noerrors in depguard
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable `forbidigo` linter in CI and refactor codebase to use custom error handling and logging with `slog`.
> 
>   - **CI Configuration**:
>     - Enable `forbidigo` linter in `.golangci.yml`.
>     - Add `noerrors` rule to `depguard` to enforce using `github.com/SigNoz/signoz/pkg/errors` instead of the standard `errors` package.
>   - **Error Handling**:
>     - Replace `errors` package with `github.com/SigNoz/signoz/pkg/errors` in `resolver.go`, `auth.go`, `smtp.go`, `metric.go`, `config.go`, `uuid.go`, `time_parser.go`, `recurrence.go`, `templates.go`, `google.go`, `string.go`, `uuid.go`, `valuer.go`, `ddl.go`, `logging.go`, `013_update_organization.go`, `014_add_alertmanager.go`, `046_update_dashboard_alert_and_saved_view_v5.go`.
>     - Use `errors.Newf` and `errors.Wrapf` for formatted error messages.
>   - **Logging**:
>     - Replace `fmt` with `slog` for logging in `server.go`, `config.go`, `resolver.go`, `registry.go`, `metric.go`, `config.go`, `auth.go`, `smtp.go`, `logging.go`, `version.go`.
>     - Use `logger.ErrorContext` and `logger.WarnContext` for error and warning logs.
>   - **Function Signatures**:
>     - Update function signatures to include `logger *slog.Logger` in `NewSigNozConfig` and `NewJWTSecret` in `config.go`.
>   - **Miscellaneous**:
>     - Remove unused imports and variables in several files.
>     - Update test cases in `errors_test.go` to reflect changes in error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 046a69b29a7968e846d937df4cdf6097132c3a3a. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->