### PR TITLE
Fix: changelog modal spacing issue

### DIFF
--- a/frontend/src/components/ChangelogModal/components/ChangelogRenderer.styles.scss
+++ b/frontend/src/components/ChangelogModal/components/ChangelogRenderer.styles.scss
@@ -2,7 +2,7 @@
 	position: relative;
 	padding-left: 20px;
 
-	& :is(h1, h2, h3, h4, h5, h6, p) {
+	& :is(h1, h2, h3, h4, h5, h6, p, &-section-title) {
 		margin-bottom: 12px;
 	}
 
@@ -10,6 +10,12 @@
 		display: flex;
 		flex-direction: column;
 		gap: 32px;
+	}
+
+	&-section-title {
+		font-size: 14px;
+		line-height: 20px;
+		color: var(--text-vanilla-400, #c0c1c3);
 	}
 
 	.changelog-release-date {
@@ -93,22 +99,20 @@
 		}
 	}
 
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6 {
+	& :is(h1, h2, h3, h4, h5, h6, p, &-section-title) {
 		font-weight: 600;
 		color: var(--text-vanilla-100, #fff);
 	}
+
+
 
 	h1 {
 		font-size: 24px;
 		line-height: 32px;
 	}
 
-	h2 {
+	h2,
+	&-section-title {
 		font-size: 20px;
 		line-height: 28px;
 	}
@@ -138,7 +142,7 @@
 			background-color: var(--bg-vanilla-300);
 		}
 
-		& :is(h1, h2, h3, h4, h5, h6, p, li) {
+		& :is(h1, h2, h3, h4, h5, h6, p, li, &-section-title) {
 			color: var(--text-ink-500);
 		}
 

--- a/frontend/src/components/ChangelogModal/components/ChangelogRenderer.styles.scss
+++ b/frontend/src/components/ChangelogModal/components/ChangelogRenderer.styles.scss
@@ -104,8 +104,6 @@
 		color: var(--text-vanilla-100, #fff);
 	}
 
-
-
 	h1 {
 		font-size: 24px;
 		line-height: 32px;

--- a/frontend/src/components/ChangelogModal/components/ChangelogRenderer.styles.scss
+++ b/frontend/src/components/ChangelogModal/components/ChangelogRenderer.styles.scss
@@ -2,10 +2,22 @@
 	position: relative;
 	padding-left: 20px;
 
+	& :is(h1, h2, h3, h4, h5, h6, p) {
+		margin-bottom: 12px;
+	}
+
+	&-content {
+		display: flex;
+		flex-direction: column;
+		gap: 32px;
+	}
+
 	.changelog-release-date {
 		font-size: 14px;
 		line-height: 20px;
 		color: var(--text-vanilla-400, #c0c1c3);
+		display: block;
+		margin-bottom: 12px;
 	}
 
 	&-list {
@@ -108,6 +120,7 @@
 		overflow: hidden;
 		border-radius: 4px;
 		border: 1px solid var(--bg-slate-400, #1d212d);
+		margin-bottom: 28px;
 	}
 
 	.changelog-media-video {

--- a/frontend/src/components/ChangelogModal/components/ChangelogRenderer.styles.scss
+++ b/frontend/src/components/ChangelogModal/components/ChangelogRenderer.styles.scss
@@ -137,17 +137,8 @@
 		&-line {
 			background-color: var(--bg-vanilla-300);
 		}
-		li,
-		p {
-			color: var(--text-ink-500);
-		}
 
-		h1,
-		h2,
-		h3,
-		h4,
-		h5,
-		h6 {
+		& :is(h1, h2, h3, h4, h5, h6, p, li) {
 			color: var(--text-ink-500);
 		}
 

--- a/frontend/src/components/ChangelogModal/components/ChangelogRenderer.tsx
+++ b/frontend/src/components/ChangelogModal/components/ChangelogRenderer.tsx
@@ -60,7 +60,7 @@ function ChangelogRenderer({ changelog }: Props): JSX.Element {
 					<div className="changelog-renderer-list">
 						{changelog.features.map((feature) => (
 							<div key={feature.id}>
-								<h2>{feature.title}</h2>
+								<div className="changelog-renderer-section-title">{feature.title}</div>
 								{feature.media && renderMedia(feature.media)}
 								<ReactMarkdown>{feature.description}</ReactMarkdown>
 							</div>
@@ -68,16 +68,16 @@ function ChangelogRenderer({ changelog }: Props): JSX.Element {
 					</div>
 				)}
 				{changelog.bug_fixes && changelog.bug_fixes.length > 0 && (
-					<div>
-						<h2>Bug Fixes</h2>
+					<div className="changelog-renderer-bug-fixes">
+						<div className="changelog-renderer-section-title">Bug Fixes</div>
 						{changelog.bug_fixes && (
 							<ReactMarkdown>{changelog.bug_fixes}</ReactMarkdown>
 						)}
 					</div>
 				)}
 				{changelog.maintenance && changelog.maintenance.length > 0 && (
-					<div>
-						<h2>Maintenance</h2>
+					<div className="changelog-renderer-maintenance">
+						<div className="changelog-renderer-section-title">Maintenance</div>
 						{changelog.maintenance && (
 							<ReactMarkdown>{changelog.maintenance}</ReactMarkdown>
 						)}

--- a/frontend/src/components/ChangelogModal/components/ChangelogRenderer.tsx
+++ b/frontend/src/components/ChangelogModal/components/ChangelogRenderer.tsx
@@ -55,33 +55,35 @@ function ChangelogRenderer({ changelog }: Props): JSX.Element {
 				<div className="inner-ball" />
 			</div>
 			<span className="changelog-release-date">{formattedReleaseDate}</span>
-			{changelog.features && changelog.features.length > 0 && (
-				<div className="changelog-renderer-list">
-					{changelog.features.map((feature) => (
-						<div key={feature.id}>
-							<h2>{feature.title}</h2>
-							{feature.media && renderMedia(feature.media)}
-							<ReactMarkdown>{feature.description}</ReactMarkdown>
-						</div>
-					))}
-				</div>
-			)}
-			{changelog.bug_fixes && changelog.bug_fixes.length > 0 && (
-				<div>
-					<h2>Bug Fixes</h2>
-					{changelog.bug_fixes && (
-						<ReactMarkdown>{changelog.bug_fixes}</ReactMarkdown>
-					)}
-				</div>
-			)}
-			{changelog.maintenance && changelog.maintenance.length > 0 && (
-				<div>
-					<h2>Maintenance</h2>
-					{changelog.maintenance && (
-						<ReactMarkdown>{changelog.maintenance}</ReactMarkdown>
-					)}
-				</div>
-			)}
+			<div className="changelog-renderer-content">
+				{changelog.features && changelog.features.length > 0 && (
+					<div className="changelog-renderer-list">
+						{changelog.features.map((feature) => (
+							<div key={feature.id}>
+								<h2>{feature.title}</h2>
+								{feature.media && renderMedia(feature.media)}
+								<ReactMarkdown>{feature.description}</ReactMarkdown>
+							</div>
+						))}
+					</div>
+				)}
+				{changelog.bug_fixes && changelog.bug_fixes.length > 0 && (
+					<div>
+						<h2>Bug Fixes</h2>
+						{changelog.bug_fixes && (
+							<ReactMarkdown>{changelog.bug_fixes}</ReactMarkdown>
+						)}
+					</div>
+				)}
+				{changelog.maintenance && changelog.maintenance.length > 0 && (
+					<div>
+						<h2>Maintenance</h2>
+						{changelog.maintenance && (
+							<ReactMarkdown>{changelog.maintenance}</ReactMarkdown>
+						)}
+					</div>
+				)}
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## ✅ Changes

Before: 
<img width="829" height="1070" alt="image" src="https://github.com/user-attachments/assets/cd0d329e-788f-47b2-912f-e4bc54606949" />

After:
<img width="831" height="1032" alt="image" src="https://github.com/user-attachments/assets/4069a54d-ea52-4f08-856f-7d89ac6f8877" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes spacing issues in changelog modal by updating styles and restructuring JSX layout in `ChangelogRenderer.styles.scss` and `ChangelogRenderer.tsx`.
> 
>   - **Styles**:
>     - Updated `ChangelogRenderer.styles.scss` to add spacing between headings, paragraphs, and sections using `margin-bottom` and `gap` properties.
>     - Introduced `.changelog-renderer-content` and `.changelog-renderer-section-title` classes for better layout structure.
>     - Adjusted styles for `.changelog-release-date` and media elements to ensure consistent spacing.
>   - **JSX Structure**:
>     - Modified `ChangelogRenderer.tsx` to wrap content in `.changelog-renderer-content` for improved layout.
>     - Added `.changelog-renderer-section-title` for section headings to enhance readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for f7dbc3f5f536a5f37b4f3006565a48f04afc01c0. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->