### PR TITLE
fix: enable dot metrics by default

### DIFF
--- a/ee/query-service/constants/constants.go
+++ b/ee/query-service/constants/constants.go
@@ -40,7 +40,7 @@ var IsDotMetricsEnabled = false
 var IsPreferSpanMetrics = false
 
 func init() {
-	if GetOrDefaultEnv(DotMetricsEnabled, "false") == "true" {
+	if GetOrDefaultEnv(DotMetricsEnabled, "true") == "true" {
 		IsDotMetricsEnabled = true
 	}
 

--- a/pkg/query-service/constants/constants.go
+++ b/pkg/query-service/constants/constants.go
@@ -696,7 +696,7 @@ var MaxJSONFlatteningDepth = 1
 func init() {
 	StaticFieldsTraces = maps.Clone(NewStaticFieldsTraces)
 	maps.Copy(StaticFieldsTraces, DeprecatedStaticFieldsTraces)
-	if GetOrDefaultEnv(DotMetricsEnabled, "false") == "true" {
+	if GetOrDefaultEnv(DotMetricsEnabled, "true") == "true" {
 		IsDotMetricsEnabled = true
 	}
 	if GetOrDefaultEnv("USE_SPAN_METRICS", "false") == "true" {


### PR DESCRIPTION
## 📄 Summary

- enable dot metrics by default.
- starting v0.88.0, we have asked the community to upgrade their collectors to the dot metrics one. Still requiring this feature flag seems redundant