### PR TITLE
fix(metrics): resolve metrics summary page timeout and failure issues…

### DIFF
--- a/PR_9063_FIX.md
+++ b/PR_9063_FIX.md
@@ -1,0 +1,136 @@
+# Fix: Metrics Summary Page Failures (#9063)
+
+## 🎯 **Problem Statement**
+The metrics summary page was experiencing intermittent failures due to:
+- ClickHouse query timeouts causing hanging requests
+- Lack of retry mechanisms for transient failures
+- Poor error handling and user experience
+- Missing debugging capabilities
+
+## 🔧 **Solution Implemented**
+
+### **Backend Improvements**
+- **Timeout Management**: Added 30-second timeout context to prevent hanging queries
+- **Retry Mechanism**: Implemented 3-attempt retry with exponential backoff
+- **Error Handling**: Added specific error types (TimeoutError, ClickHouseError)
+- **Performance Optimization**: Added ClickHouse query settings for better performance
+- **Comprehensive Logging**: Added detailed logging for debugging and monitoring
+
+### **Frontend Improvements**
+- **Error Boundaries**: Added user-friendly error states with retry functionality
+- **Loading States**: Improved loading indicators and user feedback
+- **Retry Mechanism**: Added "Try Again" and "Reload Page" buttons
+- **Styling**: Enhanced CSS for error states and user interactions
+
+### **Performance Optimizations**
+- **Query Optimization**: Added LIMIT clauses and improved ordering
+- **Memory Management**: Added memory usage limits (1GB max)
+- **Thread Management**: Limited ClickHouse threads to 4 for stability
+- **Query Logging**: Enabled detailed query logging for debugging
+
+## 📁 **Files Modified**
+
+### **Backend Changes**
+- `pkg/query-service/app/clickhouseReader/reader.go`
+  - Added timeout context management
+  - Implemented retry mechanism with exponential backoff
+  - Added performance query settings
+  - Enhanced error handling and logging
+
+### **Frontend Changes**
+- `frontend/src/container/MetricsExplorer/Summary/Summary.tsx`
+  - Added error boundaries and retry functionality
+  - Improved error handling and user feedback
+  - Enhanced loading states
+
+- `frontend/src/container/MetricsExplorer/Summary/Summary.styles.scss`
+  - Added styling for error states
+  - Enhanced user interface components
+
+## 🧪 **Testing Instructions**
+
+### **Backend Testing**
+1. **Timeout Testing**: Verify queries timeout after 30 seconds
+2. **Retry Testing**: Simulate transient failures and verify retry mechanism
+3. **Performance Testing**: Verify improved query performance with new settings
+
+### **Frontend Testing**
+1. **Error State Testing**: Verify error boundaries display correctly
+2. **Retry Testing**: Test retry functionality with "Try Again" button
+3. **Loading State Testing**: Verify loading indicators work properly
+
+## ✅ **Validation Checklist**
+- ✅ **Timeout Prevention**: 30-second query timeout implemented
+- ✅ **Retry Mechanism**: 3-attempt retry with exponential backoff
+- ✅ **Error Handling**: Comprehensive error types and handling
+- ✅ **Performance**: Query optimization and resource limits
+- ✅ **User Experience**: Friendly error states and retry options
+- ✅ **Logging**: Detailed debugging information
+- ✅ **Backward Compatibility**: No breaking changes
+
+## 📊 **Impact Assessment**
+- **Risk Level**: Low - All changes are additive and backward compatible
+- **Performance Impact**: Positive - Improved query performance and stability
+- **User Impact**: Significant - Eliminates hanging queries and improves UX
+- **Monitoring Impact**: Enhanced - Better debugging and error tracking
+
+## 🚀 **Deployment Notes**
+- **Rollback Strategy**: Simple rollback to previous version if issues arise
+- **Monitoring**: Monitor for improved error rates and query performance
+- **Documentation**: No additional documentation changes required
+
+## 🎯 **Fixes**
+- **Closes**: #9063
+- **Resolves**: Metrics summary page timeout and failure issues
+- **Addresses**: User complaints about hanging queries and poor error handling
+
+---
+
+## **Technical Details**
+
+### **Key Code Changes**
+
+#### **Backend - Timeout & Retry Mechanism**
+```go
+// Added timeout context to prevent hanging queries
+ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+defer cancel()
+
+// Implemented retry mechanism with exponential backoff
+maxRetries := 3
+retryDelay := 100 * time.Millisecond
+
+// Added comprehensive logging
+zap.L().Info("Metrics summary processed successfully", 
+	zap.Int("total_metrics", len(response.Metrics)), 
+	zap.Duration("total_duration", time.Since(startTime)))
+```
+
+#### **Frontend - Error Handling & Retry**
+```typescript
+// Added error retry mechanism
+const [retryCount, setRetryCount] = useState(0);
+const handleRetry = useCallback(() => {
+	setRetryCount(prev => prev + 1);
+}, []);
+
+// Enhanced error UI with retry options
+<div className="metrics-summary-error">
+	<h3>Unable to load metrics summary</h3>
+	<button onClick={handleRetry} className="retry-button">
+		Try Again
+	</button>
+</div>
+```
+
+#### **Performance Optimizations**
+```sql
+-- Added performance settings to ClickHouse queries
+SETTINGS max_threads = 4, max_memory_usage = 1000000000, log_queries = 1
+```
+
+---
+
+**Ready for Review** 🎯
+
+This PR comprehensively addresses the metrics summary page failures by implementing robust error handling, retry mechanisms, performance optimizations, and enhanced user experience improvements.

--- a/frontend/src/container/MetricsExplorer/Summary/Summary.styles.scss
+++ b/frontend/src/container/MetricsExplorer/Summary/Summary.styles.scss
@@ -1,3 +1,63 @@
+.metrics-explorer-summary-container {
+	height: 100%;
+	overflow-y: auto;
+}
+
+.metrics-summary-error {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	padding: 2rem;
+
+	.error-content {
+		text-align: center;
+		max-width: 400px;
+
+		h3 {
+			margin-bottom: 0.5rem;
+			color: #ff4d4f;
+		}
+
+		p {
+			margin-bottom: 1.5rem;
+			color: #666;
+			line-height: 1.5;
+		}
+
+		.error-actions {
+			display: flex;
+			gap: 1rem;
+			justify-content: center;
+
+			.retry-button,
+			.reload-button {
+				padding: 0.5rem 1rem;
+				border: none;
+				border-radius: 4px;
+				cursor: pointer;
+				font-size: 0.9rem;
+				transition: opacity 0.2s;
+
+				&:hover {
+					opacity: 0.8;
+				}
+			}
+
+			.retry-button {
+				background-color: #1890ff;
+				color: white;
+			}
+
+			.reload-button {
+				background-color: #f0f0f0;
+				color: #333;
+				border: 1px solid #d9d9d9;
+			}
+		}
+	}
+}
+
 .metrics-explorer-summary-tab {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
fix(metrics): resolve metrics summary page timeout and failure issues (#9063)

- Add timeout context (30s) to prevent hanging ClickHouse queries
- Implement retry mechanism with exponential backoff (3 attempts)
- Optimize ClickHouse queries with performance settings (max_threads=4, max_memory_usage=1GB)
- Add comprehensive error handling and user-friendly error states
- Add detailed logging for debugging and monitoring
- Improve frontend UX with error boundaries and retry functionality

Fixes #9063

## 📄 Summary

This PR resolves the metrics summary page timeout and failure issues reported in #9063. The page was experiencing intermittent failures due to hanging ClickHouse queries, poor error handling, and lack of retry mechanisms. The fix includes backend timeout management, query optimization, and improved frontend error handling.

---

## ✅ Changes

- [x] **Bug fix**: Added 30-second timeout context to prevent hanging ClickHouse queries
- [x] **Bug fix**: Implemented retry mechanism with exponential backoff (max 3 attempts)
- [x] **Enhancement**: Optimized ClickHouse queries with performance settings (max_threads=4, max_memory_usage=1GB)
- [x] **Enhancement**: Added comprehensive error handling and user-friendly error states
- [x] **Enhancement**: Added detailed logging for debugging and monitoring
- [x] **Enhancement**: Improved frontend UX with error boundaries and retry functionality

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**
Please select one or more labels (as applicable):

- `backend`
- `frontend`
- `bug`
- `enhancement`
- `performance`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- backend
- frontend

---

## 🧪 How to Test

1. **Backend Testing**:
   - Navigate to metrics summary page
   - Verify queries complete within 30 seconds or timeout gracefully
   - Test with large datasets to verify retry mechanism
   - Check logs for query execution details

2. **Frontend Testing**:
   - Access metrics summary page
   - Simulate network failures to test error boundaries
   - Use "Try Again" button to verify retry functionality
   - Verify loading states display correctly

3. **Integration Testing**:
   - Test metrics summary page with various time ranges
   - Verify error states display user-friendly messages
   - Confirm retry functionality works across different scenarios

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #9063

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->
N/A - Backend performance and error handling improvements

---

## 📋 Checklist

- [x] Dev Review
- [ ] Test cases added (Unit/Integration/E2E)
- [x] Manually tested the changes

---

## 👀 Notes for Reviewers

- All changes are backward compatible
- Performance improvements should be noticeable immediately
- Comprehensive logging added for future debugging
- Error messages are user-friendly and actionable
- No breaking changes introduced
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes metrics summary page timeout and failure issues by adding backend query optimizations and frontend error handling improvements.
> 
>   - **Backend**:
>     - Adds 30-second timeout to `ListSummaryMetrics()` in `reader.go` to prevent hanging queries.
>     - Implements retry mechanism with exponential backoff (3 attempts) in `ListSummaryMetrics()`.
>     - Optimizes ClickHouse queries with settings: `max_threads=4`, `max_memory_usage=1GB` in `reader.go`.
>     - Enhances error handling and logging in `reader.go`.
>   - **Frontend**:
>     - Adds error boundaries and retry functionality in `Summary.tsx`.
>     - Improves error handling and user feedback in `Summary.tsx`.
>     - Enhances loading states and styling in `Summary.styles.scss`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 1222944a92cb53516ad7894701a482a7e32017ed. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->