### PR TITLE
fix: add trace perf improvement only when there is any filter

### DIFF
--- a/pkg/telemetrytraces/statement_builder.go
+++ b/pkg/telemetrytraces/statement_builder.go
@@ -390,7 +390,11 @@ func (b *traceQueryStatementBuilder) buildTraceQuery(
 	innerSB.Select("trace_id", "duration_nano", sqlbuilder.Escape("resource_string_service$$name as `service.name`"), "name")
 	innerSB.From(fmt.Sprintf("%s.%s", DBName, SpanIndexV3TableName))
 	innerSB.Where("parent_span_id = ''")
-	innerSB.Where("trace_id GLOBAL IN __toe")
+
+	// this only helps when there is a filter
+	if query.Filter != nil && query.Filter.Expression != "" {
+		innerSB.Where("trace_id GLOBAL IN __toe")
+	}
 
 	// Add time filter to inner query
 	innerSB.Where(


### PR DESCRIPTION
We added a fix to read only the required traces, but it doesn't help in cases where the filter is empty and results in more memory usage.