### PR TITLE
chore: populate default zero queries for metrics

### DIFF
--- a/pkg/types/querybuildertypes/querybuildertypesv5/req_test.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/req_test.go
@@ -1684,6 +1684,86 @@ func TestQueryRangeRequest_GetQueriesSupportingZeroDefault(t *testing.T) {
 			},
 		},
 		{
+			name: "test metrics",
+			CompositeQuery: CompositeQuery{
+				Queries: []QueryEnvelope{
+					{
+						Type: QueryTypeBuilder,
+						Spec: QueryBuilderQuery[MetricAggregation]{
+							Name:   "A",
+							Signal: telemetrytypes.SignalTraces,
+							Filter: &Filter{
+								Expression: "service.name = demo",
+							},
+							Aggregations: []MetricAggregation{
+								{
+									MetricName:       "calls",
+									TimeAggregation:  metrictypes.TimeAggregationRate,
+									SpaceAggregation: metrictypes.SpaceAggregationSum,
+								},
+							},
+						},
+					},
+					{
+						Type: QueryTypeBuilder,
+						Spec: QueryBuilderQuery[MetricAggregation]{
+							Name:   "B",
+							Signal: telemetrytypes.SignalTraces,
+							Filter: &Filter{
+								Expression: "service.name = demo",
+							},
+							Aggregations: []MetricAggregation{
+								{
+									MetricName:       "memory.usage",
+									TimeAggregation:  metrictypes.TimeAggregationAvg,
+									SpaceAggregation: metrictypes.SpaceAggregationSum,
+								},
+							},
+						},
+					},
+					{
+						Type: QueryTypeBuilder,
+						Spec: QueryBuilderQuery[MetricAggregation]{
+							Name:   "C",
+							Signal: telemetrytypes.SignalTraces,
+							Filter: &Filter{
+								Expression: "service.name = demo",
+							},
+							Aggregations: []MetricAggregation{
+								{
+									MetricName:       "calls",
+									TimeAggregation:  metrictypes.TimeAggregationIncrease,
+									SpaceAggregation: metrictypes.SpaceAggregationSum,
+								},
+							},
+						},
+					},
+					{
+						Type: QueryTypeBuilder,
+						Spec: QueryBuilderQuery[MetricAggregation]{
+							Name:   "D",
+							Signal: telemetrytypes.SignalTraces,
+							Filter: &Filter{
+								Expression: "service.name = demo",
+							},
+							Aggregations: []MetricAggregation{
+								{
+									MetricName:       "calls",
+									TimeAggregation:  metrictypes.TimeAggregationCount,
+									SpaceAggregation: metrictypes.SpaceAggregationSum,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]bool{
+				"A": true,
+				"C": true,
+				"D": true,
+			},
+		},
+		{
 			name: "test min on logs - doesn't support zeroDefault",
 			CompositeQuery: CompositeQuery{
 				Queries: []QueryEnvelope{


### PR DESCRIPTION
## 📄 Summary

Metrics part of https://github.com/SigNoz/signoz/issues/8914
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `GetQueriesSupportingZeroDefault` to support default zero for specific metric time aggregations and updates tests accordingly.
> 
>   - **Behavior**:
>     - Updates `GetQueriesSupportingZeroDefault` in `req.go` to support default zero for `MetricAggregation` with `TimeAggregationCount`, `TimeAggregationCountDistinct`, `TimeAggregationRate`, and `TimeAggregationIncrease`.
>   - **Tests**:
>     - Adds test cases in `req_test.go` for `MetricAggregation` to verify default zero behavior for supported time aggregations.
>     - Ensures existing tests cover new logic without errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 3439e5ecf3103c7c7b4969662288f1f8f59d047e. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->