### PR TITLE
chore: use wss usage for workloads listing

### DIFF
--- a/frontend/src/container/InfraMonitoringK8s/Clusters/utils.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Clusters/utils.tsx
@@ -31,7 +31,7 @@ export const defaultAddedColumns: IEntityColumn[] = [
 		canRemove: false,
 	},
 	{
-		label: 'Mem Usage',
+		label: 'Mem Usage (WSS)',
 		value: 'memory',
 		id: 'memory',
 		canRemove: false,
@@ -105,7 +105,7 @@ const columnsConfig = [
 		align: 'left',
 	},
 	{
-		title: <div className="column-header-left">Memory Utilization (bytes)</div>,
+		title: <div className="column-header-left">Memory Utilization (WSS)</div>,
 		dataIndex: 'memory',
 		key: 'memory',
 		width: 80,
@@ -113,7 +113,7 @@ const columnsConfig = [
 		align: 'left',
 	},
 	{
-		title: <div className="column-header-left">Memory Allocatable (bytes)</div>,
+		title: <div className="column-header-left">Memory Allocatable</div>,
 		dataIndex: 'memory_allocatable',
 		key: 'memory_allocatable',
 		width: 80,

--- a/frontend/src/container/InfraMonitoringK8s/DaemonSets/utils.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/DaemonSets/utils.tsx
@@ -72,7 +72,7 @@ export const defaultAddedColumns: IEntityColumn[] = [
 		canRemove: false,
 	},
 	{
-		label: 'Mem Usage',
+		label: 'Mem Usage (WSS)',
 		value: 'memory',
 		id: 'memory',
 		canRemove: false,
@@ -211,10 +211,10 @@ const columnsConfig = [
 		className: `column ${columnProgressBarClassName}`,
 	},
 	{
-		title: <div className="column-header small-col">Mem Usage</div>,
+		title: <div className="column-header med-col">Mem Usage (WSS)</div>,
 		dataIndex: 'memory',
 		key: 'memory',
-		width: 80,
+		width: 120,
 		ellipsis: true,
 		sorter: true,
 		align: 'left',

--- a/frontend/src/container/InfraMonitoringK8s/Deployments/utils.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Deployments/utils.tsx
@@ -203,10 +203,10 @@ const columnsConfig = [
 		align: 'left',
 	},
 	{
-		title: <div className="column-header-left small-col">Mem Usage</div>,
+		title: <div className="column-header-left small-col">Mem Usage (WSS)</div>,
 		dataIndex: 'memory',
 		key: 'memory',
-		width: 80,
+		width: 120,
 		sorter: true,
 		align: 'left',
 	},

--- a/frontend/src/container/InfraMonitoringK8s/Jobs/utils.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Jobs/utils.tsx
@@ -238,7 +238,7 @@ const columnsConfig = [
 		className: `column ${columnProgressBarClassName}`,
 	},
 	{
-		title: <div className="column-header small-col">Mem Usage(WSS)</div>,
+		title: <div className="column-header small-col">Mem Usage (WSS)</div>,
 		dataIndex: 'memory',
 		key: 'memory',
 		width: 120,

--- a/frontend/src/container/InfraMonitoringK8s/Jobs/utils.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Jobs/utils.tsx
@@ -84,7 +84,7 @@ export const defaultAddedColumns: IEntityColumn[] = [
 		canRemove: false,
 	},
 	{
-		label: 'Mem Usage',
+		label: 'Mem Usage (WSS)',
 		value: 'memory',
 		id: 'memory',
 		canRemove: false,
@@ -238,10 +238,10 @@ const columnsConfig = [
 		className: `column ${columnProgressBarClassName}`,
 	},
 	{
-		title: <div className="column-header small-col">Mem Usage</div>,
+		title: <div className="column-header small-col">Mem Usage(WSS)</div>,
 		dataIndex: 'memory',
 		key: 'memory',
-		width: 80,
+		width: 120,
 		ellipsis: true,
 		sorter: true,
 		align: 'left',

--- a/frontend/src/container/InfraMonitoringK8s/Namespaces/utils.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Namespaces/utils.tsx
@@ -99,10 +99,10 @@ const columnsConfig = [
 		align: 'left',
 	},
 	{
-		title: <div className="column-header-left">Mem Usage</div>,
+		title: <div className="column-header-left">Mem Usage (WSS)</div>,
 		dataIndex: 'memory',
 		key: 'memory',
-		width: 80,
+		width: 120,
 		sorter: true,
 		align: 'left',
 	},

--- a/frontend/src/container/InfraMonitoringK8s/Nodes/utils.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Nodes/utils.tsx
@@ -37,7 +37,7 @@ export const defaultAddedColumns: IEntityColumn[] = [
 		canRemove: false,
 	},
 	{
-		label: 'Memory Usage (bytes)',
+		label: 'Memory Usage (WSS)',
 		value: 'memory',
 		id: 'memory',
 		canRemove: false,
@@ -121,7 +121,7 @@ const columnsConfig = [
 		align: 'left',
 	},
 	{
-		title: <div className="column-header-left">Memory Usage (bytes)</div>,
+		title: <div className="column-header-left">Memory Usage (WSS)</div>,
 		dataIndex: 'memory',
 		key: 'memory',
 		width: 80,
@@ -129,7 +129,7 @@ const columnsConfig = [
 		align: 'left',
 	},
 	{
-		title: <div className="column-header-left">Memory Alloc (bytes)</div>,
+		title: <div className="column-header-left">Memory Allocatable</div>,
 		dataIndex: 'memory_allocatable',
 		key: 'memory_allocatable',
 		width: 80,

--- a/frontend/src/container/InfraMonitoringK8s/StatefulSets/utils.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/StatefulSets/utils.tsx
@@ -72,7 +72,7 @@ export const defaultAddedColumns: IEntityColumn[] = [
 		canRemove: false,
 	},
 	{
-		label: 'Mem Usage',
+		label: 'Mem Usage (WSS)',
 		value: 'memory',
 		id: 'memory',
 		canRemove: false,
@@ -211,10 +211,10 @@ const columnsConfig = [
 		className: `column ${columnProgressBarClassName}`,
 	},
 	{
-		title: <div className="column-header small-col">Mem Usage</div>,
+		title: <div className="column-header med-col">Mem Usage (WSS)</div>,
 		dataIndex: 'memory',
 		key: 'memory',
-		width: 80,
+		width: 120,
 		ellipsis: true,
 		sorter: true,
 		align: 'left',

--- a/frontend/src/container/InfraMonitoringK8s/utils.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/utils.tsx
@@ -69,7 +69,7 @@ export const defaultAddedColumns: IEntityColumn[] = [
 		canRemove: false,
 	},
 	{
-		label: 'Mem Usage',
+		label: 'Mem Usage (WSS)',
 		value: 'memory',
 		id: 'memory',
 		canRemove: false,
@@ -207,10 +207,10 @@ const columnsConfig = [
 		className: `column ${columnProgressBarClassName}`,
 	},
 	{
-		title: <div className="column-header">Mem Usage</div>,
+		title: <div className="column-header med-col">Mem Usage (WSS)</div>,
 		dataIndex: 'memory',
 		key: 'memory',
-		width: 80,
+		width: 120,
 		ellipsis: true,
 		sorter: true,
 		align: 'left',

--- a/pkg/query-service/app/inframetrics/common.go
+++ b/pkg/query-service/app/inframetrics/common.go
@@ -207,7 +207,7 @@ var (
 	// TODO(srikanthccv): import metadata yaml from receivers and use generated files to check the metrics
 	podMetricNamesToCheck = []string{
 		GetDotMetrics("k8s_pod_cpu_usage"),
-		GetDotMetrics("k8s_pod_memory_usage"),
+		GetDotMetrics("k8s_pod_memory_working_set"),
 		GetDotMetrics("k8s_pod_cpu_request_utilization"),
 		GetDotMetrics("k8s_pod_memory_request_utilization"),
 		GetDotMetrics("k8s_pod_cpu_limit_utilization"),
@@ -218,7 +218,7 @@ var (
 	nodeMetricNamesToCheck = []string{
 		GetDotMetrics("k8s_node_cpu_usage"),
 		GetDotMetrics("k8s_node_allocatable_cpu"),
-		GetDotMetrics("k8s_node_memory_usage"),
+		GetDotMetrics("k8s_node_memory_working_set"),
 		GetDotMetrics("k8s_node_allocatable_memory"),
 		GetDotMetrics("k8s_node_condition_ready"),
 	}

--- a/pkg/query-service/app/inframetrics/nodes.go
+++ b/pkg/query-service/app/inframetrics/nodes.go
@@ -36,7 +36,7 @@ var (
 	metricNamesForNodes = map[string]string{
 		"cpu":                GetDotMetrics("k8s_node_cpu_usage"),
 		"cpu_allocatable":    GetDotMetrics("k8s_node_allocatable_cpu"),
-		"memory":             GetDotMetrics("k8s_node_memory_usage"),
+		"memory":             GetDotMetrics("k8s_node_memory_working_set"),
 		"memory_allocatable": GetDotMetrics("k8s_node_allocatable_memory"),
 		"node_condition":     GetDotMetrics("k8s_node_condition_ready"),
 	}

--- a/pkg/query-service/app/inframetrics/pods.go
+++ b/pkg/query-service/app/inframetrics/pods.go
@@ -52,7 +52,7 @@ var (
 		"cpu":            GetDotMetrics("k8s_pod_cpu_usage"),
 		"cpu_request":    GetDotMetrics("k8s_pod_cpu_request_utilization"),
 		"cpu_limit":      GetDotMetrics("k8s_pod_cpu_limit_utilization"),
-		"memory":         GetDotMetrics("k8s_pod_memory_usage"),
+		"memory":         GetDotMetrics("k8s_pod_memory_working_set"),
 		"memory_request": GetDotMetrics("k8s_pod_memory_request_utilization"),
 		"memory_limit":   GetDotMetrics("k8s_pod_memory_limit_utilization"),
 		"restarts":       GetDotMetrics("k8s_container_restarts"),

--- a/pkg/query-service/app/inframetrics/workload_query.go
+++ b/pkg/query-service/app/inframetrics/workload_query.go
@@ -7,7 +7,7 @@ var (
 		"cpu":            GetDotMetrics("k8s_pod_cpu_usage"),
 		"cpu_request":    GetDotMetrics("k8s_pod_cpu_request_utilization"),
 		"cpu_limit":      GetDotMetrics("k8s_pod_cpu_limit_utilization"),
-		"memory":         GetDotMetrics("k8s_pod_memory_usage"),
+		"memory":         GetDotMetrics("k8s_pod_memory_working_set"),
 		"memory_request": GetDotMetrics("k8s_pod_memory_request_utilization"),
 		"memory_limit":   GetDotMetrics("k8s_pod_memory_limit_utilization"),
 		"restarts":       GetDotMetrics("k8s_container_restarts"),


### PR DESCRIPTION
## 📄 Summary

Use working set memory for list as it is closest to actual memory used by the resource
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch memory usage metric to working set size (WSS) across frontend and backend components.
> 
>   - **Behavior**:
>     - Change memory usage metric to working set size (WSS) in `Clusters/utils.tsx`, `DaemonSets/utils.tsx`, and `Deployments/utils.tsx`.
>     - Update column labels to reflect WSS in `Jobs/utils.tsx`, `Namespaces/utils.tsx`, and `Nodes/utils.tsx`.
>     - Adjust column widths for memory usage in `StatefulSets/utils.tsx` and `utils.tsx`.
>   - **Backend**:
>     - Update metric names to use `k8s_pod_memory_working_set` and `k8s_node_memory_working_set` in `common.go`, `nodes.go`, and `pods.go`.
>     - Modify `workload_query.go` to use WSS for memory metrics.
>   - **Misc**:
>     - Rename `k8s_pod_memory_usage` to `k8s_pod_memory_working_set` and `k8s_node_memory_usage` to `k8s_node_memory_working_set` in `common.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for c91261668a1e3a25dd6e611f3618c5c954d98ab7. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->