### PR TITLE
fix: revert queryKey update to re-enable cancel run

### DIFF
--- a/frontend/src/hooks/queryBuilder/useGetExplorerQueryRange.ts
+++ b/frontend/src/hooks/queryBuilder/useGetExplorerQueryRange.ts
@@ -66,13 +66,7 @@ export const useGetExplorerQueryRange = (
 		ENTITY_VERSION_V5,
 		{
 			...options,
-			queryKey: [
-				key,
-				selectedTimeInterval ?? globalSelectedInterval,
-				requestData,
-				minTime,
-				maxTime,
-			],
+			queryKey: [key, globalSelectedInterval, requestData, minTime, maxTime],
 			enabled: isEnabled,
 		},
 		headers,


### PR DESCRIPTION
## 📄 Summary

Cancel Run flow was broken as the key ref and query key were different. For the cancel run to work as expected, we need to maintain same key while query execution and cancel.