### PR TITLE
fix: removed staleTime and cacheTime from query client level 

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -16,8 +16,6 @@ const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			refetchOnWindowFocus: false,
-			staleTime: 2 * 60 * 1000, // 2 minutes - data becomes stale after 2 minutes
-			cacheTime: 5 * 60 * 1000, // 5 minutes - cache entries are garbage collected after 5 minutes
 			retry(failureCount, error): boolean {
 				if (
 					// in case of manually throwing errors please make sure to send error.response.status

--- a/frontend/src/providers/Dashboard/Dashboard.tsx
+++ b/frontend/src/providers/Dashboard/Dashboard.tsx
@@ -269,7 +269,7 @@ export function DashboardProvider({
 		return data;
 	};
 	const dashboardResponse = useQuery(
-		[REACT_QUERY_KEY.DASHBOARD_BY_ID, isDashboardPage?.params],
+		[REACT_QUERY_KEY.DASHBOARD_BY_ID, isDashboardPage?.params, dashboardId],
 		{
 			enabled: (!!isDashboardPage || !!isDashboardWidgetPage) && isLoggedIn,
 			queryFn: async () => {

--- a/frontend/src/providers/Dashboard/Dashboard.tsx
+++ b/frontend/src/providers/Dashboard/Dashboard.tsx
@@ -285,7 +285,6 @@ export function DashboardProvider({
 					setIsDashboardFetching(false);
 				}
 			},
-			staleTime: 0, // Always consider dashboard data stale
 			refetchOnWindowFocus: false,
 			onError: (error) => {
 				showErrorModal(error as APIError);

--- a/frontend/src/providers/Dashboard/Dashboard.tsx
+++ b/frontend/src/providers/Dashboard/Dashboard.tsx
@@ -285,6 +285,7 @@ export function DashboardProvider({
 					setIsDashboardFetching(false);
 				}
 			},
+			staleTime: 0, // Always consider dashboard data stale
 			refetchOnWindowFocus: false,
 			onError: (error) => {
 				showErrorModal(error as APIError);

--- a/frontend/src/providers/Dashboard/Dashboard.tsx
+++ b/frontend/src/providers/Dashboard/Dashboard.tsx
@@ -269,7 +269,7 @@ export function DashboardProvider({
 		return data;
 	};
 	const dashboardResponse = useQuery(
-		[REACT_QUERY_KEY.DASHBOARD_BY_ID, isDashboardPage?.params, dashboardId],
+		[REACT_QUERY_KEY.DASHBOARD_BY_ID, dashboardId],
 		{
 			enabled: (!!isDashboardPage || !!isDashboardWidgetPage) && isLoggedIn,
 			queryFn: async () => {


### PR DESCRIPTION
## 📄 Summary

Recently, we added a global staleTime of 2 minutes to our queryClient config. This makes React Query treat fetched data as fresh for 2 minutes, avoiding re-fetching during that period. (PR: https://github.com/SigNoz/signoz/pull/8815)

However, this breaks behavior in some cases:

Our dashboard detail API didn’t include dashboardId in its queryKey. Without the ID, React Query can’t distinguish between dashboards, so switching between them ends up using stale cached data.

Even if dashboardId is added, toggling dashboards (e.g., Dashboard 1 → Dashboard 2 → Dashboard 1) still returns stale data when returning to Dashboard 1, because it remains cached under that key within the staleTime.

Decision: Remove the global staleTime setting from queryClient. We need to refactor relevant queries to use properly scoped queryKeys before re-introducing staleness.

---

## ✅ Changes

- [ ] Feature: Brief description
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

- https://github.com/SigNoz/engineering-pod/issues/2991
- https://github.com/SigNoz/engineering-pod/issues/2988

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removes global `staleTime` and `cacheTime` from query client and updates dashboard query key to include `dashboardId`.
> 
>   - **Behavior**:
>     - Removes `staleTime` and `cacheTime` from `QueryClient` in `index.tsx` to prevent stale data issues.
>     - Updates query key in `useQuery` in `DashboardProvider` to include `dashboardId` for correct data scoping.
>   - **Misc**:
>     - Removes global staleTime setting to address stale data issues when toggling dashboards.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for de8f603091e518a7f56d351650eade4c98175dc2. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->