### PR TITLE
fix: dont accept materialized key from payload

### DIFF
--- a/pkg/types/telemetrytypes/field.go
+++ b/pkg/types/telemetrytypes/field.go
@@ -24,7 +24,7 @@ type TelemetryFieldKey struct {
 	Signal        Signal        `json:"signal,omitempty"`
 	FieldContext  FieldContext  `json:"fieldContext,omitempty"`
 	FieldDataType FieldDataType `json:"fieldDataType,omitempty"`
-	Materialized  bool          `json:"materialized,omitempty"`
+	Materialized  bool          `json:"_"`
 }
 
 func (f TelemetryFieldKey) String() string {

--- a/pkg/types/telemetrytypes/field.go
+++ b/pkg/types/telemetrytypes/field.go
@@ -24,7 +24,7 @@ type TelemetryFieldKey struct {
 	Signal        Signal        `json:"signal,omitempty"`
 	FieldContext  FieldContext  `json:"fieldContext,omitempty"`
 	FieldDataType FieldDataType `json:"fieldDataType,omitempty"`
-	Materialized  bool          `json:"_"`
+	Materialized  bool          `json:"-"`
 }
 
 func (f TelemetryFieldKey) String() string {


### PR DESCRIPTION
Fixes :- https://github.com/SigNoz/signoz/issues/9015

Test added for group by.

For order by a test named `list query with mat col order by` already exists
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prevents serialization of `Materialized` field in `TelemetryFieldKey` and adds test for grouping by materialized column.
> 
>   - **Behavior**:
>     - Prevents `Materialized` field in `TelemetryFieldKey` from being serialized to JSON in `field.go`.
>     - Adds test case for grouping by materialized column in `stmt_builder_test.go`.
>   - **Tests**:
>     - Adds test "Time series with group by on materialized column" in `stmt_builder_test.go`.
>     - Confirms existing test "list query with mat col order by" covers ordering by materialized column.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for ecab43e2ec1a74c2f65d80831c291a5d0b6cf156. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->