### PR TITLE
fix: test rule multiple threhsold

### DIFF
--- a/ee/query-service/rules/manager.go
+++ b/ee/query-service/rules/manager.go
@@ -126,7 +126,7 @@ func TestNotification(opts baserules.PrepareTestRuleOptions) (int, *basemodel.Ap
 	if parsedRule.RuleType == ruletypes.RuleTypeThreshold {
 
 		// add special labels for test alerts
-		parsedRule.Annotations[labels.AlertSummaryLabel] = fmt.Sprintf("The rule threshold is set to %.4f, and the observed metric value is {{$value}}.", *parsedRule.RuleCondition.Target)
+		//parsedRule.Annotations[labels.AlertSummaryLabel] = fmt.Sprintf("The rule threshold is set to %.4f, and the observed metric value is {{$value}}.", *parsedRule.RuleCondition.Target)
 		parsedRule.Labels[labels.RuleSourceLabel] = ""
 		parsedRule.Labels[labels.AlertRuleIdLabel] = ""
 

--- a/ee/query-service/rules/manager.go
+++ b/ee/query-service/rules/manager.go
@@ -123,12 +123,6 @@ func TestNotification(opts baserules.PrepareTestRuleOptions) (int, *basemodel.Ap
 	var rule baserules.Rule
 	var err error
 
-	//need to add this label only for test
-	//otherwise we won't know whether to use policy or not
-	if parsedRule.NotificationSettings.UsePolicy {
-		parsedRule.Labels[labels.TestNotificationPolicyRule] = "true"
-	}
-
 	if parsedRule.RuleType == ruletypes.RuleTypeThreshold {
 
 		// add special labels for test alerts

--- a/ee/query-service/rules/manager.go
+++ b/ee/query-service/rules/manager.go
@@ -123,6 +123,12 @@ func TestNotification(opts baserules.PrepareTestRuleOptions) (int, *basemodel.Ap
 	var rule baserules.Rule
 	var err error
 
+	//need to add this label only for test
+	//otherwise we won't know whether to use policy or not
+	if parsedRule.NotificationSettings.UsePolicy {
+		parsedRule.Labels[labels.TestNotificationPolicyRule] = "true"
+	}
+
 	if parsedRule.RuleType == ruletypes.RuleTypeThreshold {
 
 		// add special labels for test alerts

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -28,7 +28,7 @@ type Alertmanager interface {
 	TestReceiver(context.Context, string, alertmanagertypes.Receiver) error
 
 	// TestAlert sends an alert to a list of receivers.
-	TestAlert(ctx context.Context, orgID string, alert *alertmanagertypes.PostableAlert, receivers []string) error
+	TestAlert(ctx context.Context, orgID string, alert *alertmanagertypes.PostableAlert, receivers []string, usePolicy bool) error
 
 	// ListChannels lists all channels for the organization.
 	ListChannels(context.Context, string) ([]*alertmanagertypes.Channel, error)

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -28,7 +28,7 @@ type Alertmanager interface {
 	TestReceiver(context.Context, string, alertmanagertypes.Receiver) error
 
 	// TestAlert sends an alert to a list of receivers.
-	TestAlert(ctx context.Context, orgID string, alert *alertmanagertypes.PostableAlert, receivers []string, usePolicy bool) error
+	TestAlert(ctx context.Context, orgID string, ruleID string, receiversMap map[*alertmanagertypes.PostableAlert][]string) error
 
 	// ListChannels lists all channels for the organization.
 	ListChannels(context.Context, string) ([]*alertmanagertypes.Channel, error)

--- a/pkg/alertmanager/alertmanagerserver/server.go
+++ b/pkg/alertmanager/alertmanagerserver/server.go
@@ -2,6 +2,9 @@ package alertmanagerserver
 
 import (
 	"context"
+	"fmt"
+	"github.com/prometheus/alertmanager/types"
+	"golang.org/x/sync/errgroup"
 	"log/slog"
 	"strings"
 	"sync"
@@ -321,39 +324,104 @@ func (server *Server) SetConfig(ctx context.Context, alertmanagerConfig *alertma
 }
 
 func (server *Server) TestReceiver(ctx context.Context, receiver alertmanagertypes.Receiver) error {
-	return alertmanagertypes.TestReceiver(ctx, receiver, alertmanagernotify.NewReceiverIntegrations, server.alertmanagerConfig, server.tmpl, server.logger, alertmanagertypes.NewTestAlert(receiver, time.Now(), time.Now()))
+	testAlert := alertmanagertypes.NewTestAlert(receiver, time.Now(), time.Now())
+	return alertmanagertypes.TestReceiver(ctx, receiver, alertmanagernotify.NewReceiverIntegrations, server.alertmanagerConfig, server.tmpl, server.logger, testAlert.Labels, testAlert)
 }
 
-func (server *Server) TestAlert(ctx context.Context, postableAlert *alertmanagertypes.PostableAlert, receivers []string) error {
-	alerts, err := alertmanagertypes.NewAlertsFromPostableAlerts(alertmanagertypes.PostableAlerts{postableAlert}, time.Duration(server.srvConfig.Global.ResolveTimeout), time.Now())
+func (server *Server) TestAlert(ctx context.Context, receiversMap map[*alertmanagertypes.PostableAlert][]string, config *alertmanagertypes.NotificationConfig) error {
+	if len(receiversMap) == 0 {
+		return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput,
+			"expected at least 1 alert, got 0")
+	}
+
+	postableAlerts := make(alertmanagertypes.PostableAlerts, 0, len(receiversMap))
+	for alert := range receiversMap {
+		postableAlerts = append(postableAlerts, alert)
+	}
+
+	alerts, err := alertmanagertypes.NewAlertsFromPostableAlerts(
+		postableAlerts,
+		time.Duration(server.srvConfig.Global.ResolveTimeout),
+		time.Now(),
+	)
 	if err != nil {
-		return errors.Join(err...)
+		return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput,
+			"failed to construct alerts from postable alerts: %v", err)
 	}
 
-	if len(alerts) == 0 {
-		return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "expected atleast 1 alert, got %d", len(alerts))
+	type alertGroup struct {
+		groupLabels model.LabelSet
+		alerts      []*types.Alert
+		receivers   map[string]struct{}
 	}
 
-	ch := make(chan error, len(receivers))
-	for _, receiverName := range receivers {
-		go func(receiverName string) {
-			receiver, err := server.alertmanagerConfig.GetReceiver(receiverName)
-			if err != nil {
-				ch <- err
-				return
+	groupMap := make(map[model.Fingerprint]*alertGroup)
+
+	for i, alert := range alerts {
+		labels := getGroupLabels(alert, config.NotificationGroup, config.GroupByAll)
+		fp := labels.Fingerprint()
+
+		postableAlert := postableAlerts[i]
+		alertReceivers := receiversMap[postableAlert]
+
+		if group, exists := groupMap[fp]; exists {
+			group.alerts = append(group.alerts, alert)
+			for _, r := range alertReceivers {
+				group.receivers[r] = struct{}{}
 			}
-			ch <- alertmanagertypes.TestReceiver(ctx, receiver, alertmanagernotify.NewReceiverIntegrations, server.alertmanagerConfig, server.tmpl, server.logger, alerts[0])
-		}(receiverName)
-	}
-
-	var errs []error
-	for i := 0; i < len(receivers); i++ {
-		if err := <-ch; err != nil {
-			errs = append(errs, err)
+		} else {
+			receiverSet := make(map[string]struct{})
+			for _, r := range alertReceivers {
+				receiverSet[r] = struct{}{}
+			}
+			groupMap[fp] = &alertGroup{
+				groupLabels: labels,
+				alerts:      []*types.Alert{alert},
+				receivers:   receiverSet,
+			}
 		}
 	}
 
-	if errs != nil {
+	var mu sync.Mutex
+	var errs []error
+
+	g, gCtx := errgroup.WithContext(ctx)
+	for _, group := range groupMap {
+		for receiverName := range group.receivers {
+			group := group
+			receiverName := receiverName
+
+			g.Go(func() error {
+				receiver, err := server.alertmanagerConfig.GetReceiver(receiverName)
+				if err != nil {
+					mu.Lock()
+					errs = append(errs, fmt.Errorf("failed to get receiver %q: %w", receiverName, err))
+					mu.Unlock()
+					return nil // Return nil to continue processing other goroutines
+				}
+
+				err = alertmanagertypes.TestReceiver(
+					gCtx,
+					receiver,
+					alertmanagernotify.NewReceiverIntegrations,
+					server.alertmanagerConfig,
+					server.tmpl,
+					server.logger,
+					group.groupLabels,
+					group.alerts...,
+				)
+				if err != nil {
+					mu.Lock()
+					errs = append(errs, fmt.Errorf("receiver %q test failed: %w", receiverName, err))
+					mu.Unlock()
+				}
+				return nil // Return nil to continue processing other goroutines
+			})
+		}
+	}
+	_ = g.Wait()
+
+	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
 

--- a/pkg/alertmanager/alertmanagerserver/server.go
+++ b/pkg/alertmanager/alertmanagerserver/server.go
@@ -330,8 +330,8 @@ func (server *Server) TestAlert(ctx context.Context, postableAlert *alertmanager
 		return errors.Join(err...)
 	}
 
-	if len(alerts) != 1 {
-		return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "expected 1 alert, got %d", len(alerts))
+	if len(alerts) == 0 {
+		return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "expected atleast 1 alert, got %d", len(alerts))
 	}
 
 	ch := make(chan error, len(receivers))

--- a/pkg/alertmanager/alertmanagerserver/server_test.go
+++ b/pkg/alertmanager/alertmanagerserver/server_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/client_golang/prometheus"
 	commoncfg "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -126,4 +127,190 @@ func TestServerPutAlerts(t *testing.T) {
 	assert.Equal(t, 1, len(gettableAlerts))
 	assert.Equal(t, gettableAlerts[0].Alert.Labels["alertname"], "test-alert")
 	assert.NoError(t, server.Stop(context.Background()))
+}
+
+func TestServerTestAlert(t *testing.T) {
+	stateStore := alertmanagertypestest.NewStateStore()
+	srvCfg := NewConfig()
+	srvCfg.Route.GroupInterval = 1 * time.Second
+	notificationManager := nfmanagertest.NewMock()
+	server, err := New(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), prometheus.NewRegistry(), srvCfg, "1", stateStore, notificationManager)
+	require.NoError(t, err)
+
+	amConfig, err := alertmanagertypes.NewDefaultConfig(srvCfg.Global, srvCfg.Route, "1")
+	require.NoError(t, err)
+
+	webhook1Listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	webhook2Listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	requestCount1 := 0
+	requestCount2 := 0
+	webhook1Server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount1++
+			w.WriteHeader(http.StatusOK)
+		}),
+	}
+	webhook2Server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount2++
+			w.WriteHeader(http.StatusOK)
+		}),
+	}
+
+	go func() {
+		_ = webhook1Server.Serve(webhook1Listener)
+	}()
+	go func() {
+		_ = webhook2Server.Serve(webhook2Listener)
+	}()
+
+	webhook1URL, err := url.Parse("http://" + webhook1Listener.Addr().String() + "/webhook")
+	require.NoError(t, err)
+	webhook2URL, err := url.Parse("http://" + webhook2Listener.Addr().String() + "/webhook")
+	require.NoError(t, err)
+
+	require.NoError(t, amConfig.CreateReceiver(alertmanagertypes.Receiver{
+		Name: "receiver-1",
+		WebhookConfigs: []*config.WebhookConfig{
+			{
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				URL:        &config.SecretURL{URL: webhook1URL},
+			},
+		},
+	}))
+
+	require.NoError(t, amConfig.CreateReceiver(alertmanagertypes.Receiver{
+		Name: "receiver-2",
+		WebhookConfigs: []*config.WebhookConfig{
+			{
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				URL:        &config.SecretURL{URL: webhook2URL},
+			},
+		},
+	}))
+
+	require.NoError(t, server.SetConfig(context.Background(), amConfig))
+	defer func() {
+		_ = server.Stop(context.Background())
+		_ = webhook1Server.Close()
+		_ = webhook2Server.Close()
+	}()
+
+	// Test with multiple alerts going to different receivers
+	alert1 := &alertmanagertypes.PostableAlert{
+		Annotations: models.LabelSet{"alertname": "test-alert-1"},
+		StartsAt:    strfmt.DateTime(time.Now()),
+		Alert: models.Alert{
+			Labels: models.LabelSet{"alertname": "test-alert-1", "severity": "critical"},
+		},
+	}
+	alert2 := &alertmanagertypes.PostableAlert{
+		Annotations: models.LabelSet{"alertname": "test-alert-2"},
+		StartsAt:    strfmt.DateTime(time.Now()),
+		Alert: models.Alert{
+			Labels: models.LabelSet{"alertname": "test-alert-2", "severity": "warning"},
+		},
+	}
+
+	receiversMap := map[*alertmanagertypes.PostableAlert][]string{
+		alert1: {"receiver-1", "receiver-2"},
+		alert2: {"receiver-2"},
+	}
+
+	config := &alertmanagertypes.NotificationConfig{
+		NotificationGroup: make(map[model.LabelName]struct{}),
+		GroupByAll:        false,
+	}
+
+	err = server.TestAlert(context.Background(), receiversMap, config)
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Greater(t, requestCount1, 0, "receiver-1 should have received at least one request")
+	assert.Greater(t, requestCount2, 0, "receiver-2 should have received at least one request")
+}
+
+func TestServerTestAlertContinuesOnFailure(t *testing.T) {
+	stateStore := alertmanagertypestest.NewStateStore()
+	srvCfg := NewConfig()
+	srvCfg.Route.GroupInterval = 1 * time.Second
+	notificationManager := nfmanagertest.NewMock()
+	server, err := New(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), prometheus.NewRegistry(), srvCfg, "1", stateStore, notificationManager)
+	require.NoError(t, err)
+
+	amConfig, err := alertmanagertypes.NewDefaultConfig(srvCfg.Global, srvCfg.Route, "1")
+	require.NoError(t, err)
+
+	// Create one working webhook and one failing receiver (non-existent)
+	webhookListener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	requestCount := 0
+	webhookServer := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			w.WriteHeader(http.StatusOK)
+		}),
+	}
+
+	go func() {
+		_ = webhookServer.Serve(webhookListener)
+	}()
+
+	webhookURL, err := url.Parse("http://" + webhookListener.Addr().String() + "/webhook")
+	require.NoError(t, err)
+
+	require.NoError(t, amConfig.CreateReceiver(alertmanagertypes.Receiver{
+		Name: "working-receiver",
+		WebhookConfigs: []*config.WebhookConfig{
+			{
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				URL:        &config.SecretURL{URL: webhookURL},
+			},
+		},
+	}))
+
+	require.NoError(t, amConfig.CreateReceiver(alertmanagertypes.Receiver{
+		Name: "failing-receiver",
+		WebhookConfigs: []*config.WebhookConfig{
+			{
+				HTTPConfig: &commoncfg.HTTPClientConfig{},
+				URL:        &config.SecretURL{URL: &url.URL{Scheme: "http", Host: "localhost:1", Path: "/webhook"}},
+			},
+		},
+	}))
+
+	require.NoError(t, server.SetConfig(context.Background(), amConfig))
+	defer func() {
+		_ = server.Stop(context.Background())
+		_ = webhookServer.Close()
+	}()
+
+	alert := &alertmanagertypes.PostableAlert{
+		Annotations: models.LabelSet{"alertname": "test-alert"},
+		StartsAt:    strfmt.DateTime(time.Now()),
+		Alert: models.Alert{
+			Labels: models.LabelSet{"alertname": "test-alert"},
+		},
+	}
+
+	receiversMap := map[*alertmanagertypes.PostableAlert][]string{
+		alert: {"working-receiver", "failing-receiver"},
+	}
+
+	config := &alertmanagertypes.NotificationConfig{
+		NotificationGroup: make(map[model.LabelName]struct{}),
+		GroupByAll:        false,
+	}
+
+	err = server.TestAlert(context.Background(), receiversMap, config)
+	assert.Error(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Greater(t, requestCount, 0, "working-receiver should have received at least one request even though failing-receiver failed")
 }

--- a/pkg/alertmanager/service.go
+++ b/pkg/alertmanager/service.go
@@ -146,7 +146,7 @@ func (service *Service) TestReceiver(ctx context.Context, orgID string, receiver
 	return server.TestReceiver(ctx, receiver)
 }
 
-func (service *Service) TestAlert(ctx context.Context, orgID string, alert *alertmanagertypes.PostableAlert, receivers []string) error {
+func (service *Service) TestAlert(ctx context.Context, orgID string, receiversMap map[*alertmanagertypes.PostableAlert][]string, config *alertmanagertypes.NotificationConfig) error {
 	service.serversMtx.RLock()
 	defer service.serversMtx.RUnlock()
 
@@ -155,7 +155,7 @@ func (service *Service) TestAlert(ctx context.Context, orgID string, alert *aler
 		return err
 	}
 
-	return server.TestAlert(ctx, alert, receivers)
+	return server.TestAlert(ctx, receiversMap, config)
 }
 
 func (service *Service) Stop(ctx context.Context) error {

--- a/pkg/alertmanager/signozalertmanager/provider.go
+++ b/pkg/alertmanager/signozalertmanager/provider.go
@@ -100,19 +100,29 @@ func (provider *provider) TestReceiver(ctx context.Context, orgID string, receiv
 	return provider.service.TestReceiver(ctx, orgID, receiver)
 }
 
-func (provider *provider) TestAlert(ctx context.Context, orgID string, alert *alertmanagertypes.PostableAlert, receivers []string, usePolicy bool) error {
-	set := model.LabelSet{}
-	for k, v := range alert.Labels {
-		set[model.LabelName(k)] = model.LabelValue(v)
+func (provider *provider) TestAlert(ctx context.Context, orgID string, ruleID string, receiversMap map[*alertmanagertypes.PostableAlert][]string) error {
+	config, err := provider.notificationManager.GetNotificationConfig(orgID, ruleID)
+	if err != nil {
+		return err
 	}
-	if usePolicy {
-		match, err := provider.notificationManager.Match(ctx, orgID, alert.Labels[labels.AlertRuleIdLabel], set)
-		if err != nil {
-			return err
+	if config.UsePolicy {
+		for alert, _ := range receiversMap {
+			set := make(model.LabelSet)
+			for k, v := range alert.Labels {
+				set[model.LabelName(k)] = model.LabelValue(v)
+			}
+			match, err := provider.notificationManager.Match(ctx, orgID, alert.Labels[labels.AlertRuleIdLabel], set)
+			if err != nil {
+				return err
+			}
+			if match == nil || len(match) == 0 {
+				delete(receiversMap, alert)
+			} else {
+				receiversMap[alert] = match
+			}
 		}
-		return provider.service.TestAlert(ctx, orgID, alert, match)
 	}
-	return provider.service.TestAlert(ctx, orgID, alert, receivers)
+	return provider.service.TestAlert(ctx, orgID, receiversMap, config)
 }
 
 func (provider *provider) ListChannels(ctx context.Context, orgID string) ([]*alertmanagertypes.Channel, error) {

--- a/pkg/query-service/rules/prom_rule.go
+++ b/pkg/query-service/rules/prom_rule.go
@@ -147,6 +147,12 @@ func (r *PromRule) Eval(ctx context.Context, ts time.Time) (interface{}, error) 
 
 	var alerts = make(map[uint64]*ruletypes.Alert, len(res))
 
+	ruleReceivers := r.Threshold.GetRuleReceivers()
+	ruleReceiverMap := make(map[string][]string)
+	for _, value := range ruleReceivers {
+		ruleReceiverMap[value.Name] = value.Channels
+	}
+
 	for _, series := range res {
 
 		if len(series.Floats) == 0 {
@@ -218,7 +224,6 @@ func (r *PromRule) Eval(ctx context.Context, ts time.Time) (interface{}, error) 
 				r.lastError = err
 				return nil, err
 			}
-
 			alerts[h] = &ruletypes.Alert{
 				Labels:            lbs,
 				QueryResultLables: resultLabels,
@@ -227,18 +232,12 @@ func (r *PromRule) Eval(ctx context.Context, ts time.Time) (interface{}, error) 
 				State:             model.StatePending,
 				Value:             result.V,
 				GeneratorURL:      r.GeneratorURL(),
-				Receivers:         r.preferredChannels,
+				Receivers:         ruleReceiverMap[lbs.Map()[ruletypes.LabelThresholdName]],
 			}
 		}
 	}
 
 	r.logger.InfoContext(ctx, "number of alerts found", "rule_name", r.Name(), "alerts_count", len(alerts))
-
-	ruleReceivers := r.Threshold.GetRuleReceivers()
-	ruleReceiverMap := make(map[string][]string)
-	for _, value := range ruleReceivers {
-		ruleReceiverMap[value.Name] = value.Channels
-	}
 	// alerts[h] is ready, add or update active list now
 	for h, a := range alerts {
 		// Check whether we already have alerting state for the identifying label set.

--- a/pkg/query-service/rules/test_notification.go
+++ b/pkg/query-service/rules/test_notification.go
@@ -38,7 +38,8 @@ func defaultTestNotification(opts PrepareTestRuleOptions) (int, *model.ApiError)
 	if parsedRule.RuleType == ruletypes.RuleTypeThreshold {
 
 		// add special labels for test alerts
-		parsedRule.Annotations[labels.AlertSummaryLabel] = fmt.Sprintf("The rule threshold is set to %.4f, and the observed metric value is {{$value}}.", *parsedRule.RuleCondition.Target)
+		//we dont need this label as of now
+		//parsedRule.Annotations[labels.AlertSummaryLabel] = fmt.Sprintf("The rule threshold is set to %.4f, and the observed metric value is {{$value}}.", 0)
 		parsedRule.Labels[labels.RuleSourceLabel] = ""
 		parsedRule.Labels[labels.AlertRuleIdLabel] = ""
 

--- a/pkg/query-service/rules/test_notification.go
+++ b/pkg/query-service/rules/test_notification.go
@@ -43,6 +43,10 @@ func defaultTestNotification(opts PrepareTestRuleOptions) (int, *model.ApiError)
 		parsedRule.Labels[labels.RuleSourceLabel] = ""
 		parsedRule.Labels[labels.AlertRuleIdLabel] = ""
 
+		if parsedRule.NotificationSettings.UsePolicy {
+			parsedRule.Labels[labels.TestNotificationPolicyRule] = "true"
+		}
+
 		// create a threshold rule
 		rule, err = NewThresholdRule(
 			alertname,

--- a/pkg/query-service/utils/labels/labels.go
+++ b/pkg/query-service/utils/labels/labels.go
@@ -28,6 +28,8 @@ const (
 	RuleThresholdLabel    = "threshold"
 	AlertSummaryLabel     = "summary"
 	AlertDescriptionLabel = "description"
+
+	TestNotificationPolicyRule = "test_notification_policy"
 )
 
 // Label is a key/value pair of strings.


### PR DESCRIPTION
Added cases for multiple threshold routing test notificaiton

1.) it will send one alert each to every registered receiver for a specific threshold,

Let say if you have 2 thresholds each having 2 channels, it will send 4 test notifications.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance alert notification system to support multiple thresholds and channels, ensuring alerts are sent to designated receivers.
> 
>   - **Behavior**:
>     - Updated `Eval()` in `anomaly.go`, `prom_rule.go`, and `threshold_rule.go` to send alerts to specific receivers based on threshold names.
>     - Modified `TestAlert()` in `server.go` to handle multiple alerts and receivers, ensuring each alert is sent to its designated receivers.
>   - **Functions**:
>     - Changed `TestAlert()` signature in `alertmanager.go` and `service.go` to accept a map of alerts to receivers.
>     - Updated `TestNotification()` in `manager.go` to support multiple thresholds and channels.
>   - **Tests**:
>     - Added `TestServerTestAlert()` and `TestServerTestAlertContinuesOnFailure()` in `server_test.go` to verify alert sending to multiple receivers and handling of failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 2e8a73aecab3afcc58285ff698b91161e267f8c6. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->