### PR TITLE
feat: Add dashboard pinning functionality (#8210)

### DIFF
--- a/frontend/src/container/ListOfDashboard/DashboardsList.tsx
+++ b/frontend/src/container/ListOfDashboard/DashboardsList.tsx
@@ -58,6 +58,7 @@ import {
 	RotateCw,
 	Search,
 	SquareArrowOutUpRight,
+	Star,     // added star icon for pinning
 } from 'lucide-react';
 // #TODO: lucide will be removing brand icons like Github in future, in that case we can use simple icons
 // see more: https://github.com/lucide-icons/lucide/issues/94
@@ -141,7 +142,19 @@ function DashboardsList(): JSX.Element {
 	const [isConfigureMetadataOpen, setIsConfigureMetadata] = useState<boolean>(
 		false,
 	);
+	
+	// Add pinned dashboards state here (NEW CODE)
+	const [pinnedDashboardIds, setPinnedDashboardIds] = useState<string[]>(() => {
+    		const stored = localStorage.getItem('pinnedDashboards');
+    		return stored ? JSON.parse(stored) : [];
+	});
 
+	// Add useEffect to persist to localStorage (NEW CODE)
+	useEffect(() => {
+    		localStorage.setItem('pinnedDashboards', JSON.stringify(pinnedDashboardIds));
+	}, [pinnedDashboardIds]);
+
+	
 	const getLocalStorageDynamicColumns = (): DashboardDynamicColumns => {
 		const dashboardDynamicColumnsString = localStorage.getItem('dashboard');
 		let dashboardDynamicColumns: DashboardDynamicColumns = {
@@ -186,6 +199,15 @@ function DashboardsList(): JSX.Element {
 	}
 
 	const [dashboards, setDashboards] = useState<Dashboard[]>();
+
+	// new togglePinDashboard function
+	const togglePinDashboard = (dashboardId: string): void => {
+	setPinnedDashboardIds(prev =>
+		prev.includes(dashboardId)
+			? prev.filter(id => id !== dashboardId)
+			: [...prev, dashboardId]
+	);
+	};
 
 	const sortDashboardsByCreatedAt = (dashboards: Dashboard[]): void => {
 		const sortedDashboards = dashboards.sort(
@@ -262,7 +284,16 @@ function DashboardsList(): JSX.Element {
 	const { showErrorModal } = useErrorModal();
 
 	const data: Data[] =
-		dashboards?.map((e) => ({
+	dashboards
+		?.sort((a, b) => {
+			const aIsPinned = pinnedDashboardIds.includes(a.id);
+			const bIsPinned = pinnedDashboardIds.includes(b.id);
+			
+			if (aIsPinned && !bIsPinned) return -1;
+			if (!aIsPinned && bIsPinned) return 1;
+			return 0;
+		})
+		?.map((e) => ({
 			createdAt: e.createdAt,
 			description: e.data.description || '',
 			id: e.id,
@@ -280,6 +311,7 @@ function DashboardsList(): JSX.Element {
 			panelMap: e.data.panelMap,
 			version: e.data.version,
 			refetchDashboardList,
+			isPinned: pinnedDashboardIds.includes(e.id),  // <-- This is the new line
 		})) || [];
 
 	const onNewDashboardHandler = useCallback(async () => {
@@ -436,6 +468,21 @@ function DashboardsList(): JSX.Element {
 					<div className="dashboard-list-item" onClick={onClickHandler}>
 						<div className="title-with-action">
 							<div className="dashboard-title">
+								<Button
+									type="text"
+									size="small"
+									className="pin-button"
+									icon={
+										pinnedDashboardIds.includes(dashboard.id)
+											? <Star size={16} style={{ fill: '#FFD700', color: '#FFD700' }} />
+											: <Star size={16} />
+									}
+									onClick={(e): void => {
+										e.stopPropagation();
+										togglePinDashboard(dashboard.id);
+									}}
+									title={pinnedDashboardIds.includes(dashboard.id) ? "Unpin dashboard" : "Pin dashboard"}
+								/>
 								<Tooltip
 									title={dashboard?.name?.length > 50 ? dashboard?.name : ''}
 									placement="left"
@@ -1109,6 +1156,7 @@ export interface Data {
 	panelMap?: Record<string, { widgets: Layout[]; collapsed: boolean }>;
 	variables: Record<string, IDashboardVariable>;
 	version?: string;
+	isPinned?: boolean;
 }
 
 export default DashboardsList;


### PR DESCRIPTION

Fixes #8210

## 📄 Summary

Implements dashboard pinning/favoriting functionality as requested in #8210. Users can pin frequently used dashboards for quick access, with pinned dashboards appearing at the top of the list.

---

## ✅ Changes

- [x] Feature: Added dashboard pinning with star icons
- [x] Feature: Pinned dashboards automatically sort to the top of the list
- [x] Feature: Pin state persists using localStorage across sessions
- [x] Feature: Visual feedback with gold filled star for pinned dashboards 

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

- `frontend`
- `enhancement`
- `ui`
- `good first issue`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend

---

## 🧪 How to Test

1. Navigate to Dashboards list page
2. Click the star icon next to any dashboard to pin
3. Observe that the dashboard moves to the top of the list and the star turns gold
4. Pin multiple dashboards - they should all appear at the top.
5. Refresh the page - pinned state should persist
6. Unpin a dashboard by clicking the gold star - it should return to its original position

---

## 🔍 Related Issues

Fixes #8210 

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

Demo: https://www.youtube.com/watch?v=hF6jLd8-0uA

---

## 📋 Checklist

- [x] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes


---

## 👀 Notes for Reviewers

- Implementation uses localStorage for persistence (client-side only)
- No backend changes required
- Pinned dashboards maintain their relative sort order within the pinned group
- The feature follows existing UI patterns in the application

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds dashboard pinning feature to `DashboardsList`, allowing users to pin dashboards with star icons, sort them to the top, and persist their state using localStorage.
> 
>   - **Behavior**:
>     - Adds dashboard pinning functionality with star icons in `DashboardsList`.
>     - Pinned dashboards sort to the top and persist using `localStorage`.
>     - Gold filled star indicates pinned dashboards.
>   - **State Management**:
>     - Introduces `pinnedDashboardIds` state in `DashboardsList` to track pinned dashboards.
>     - Adds `togglePinDashboard` function to update pin state.
>     - Uses `useEffect` to persist pin state to `localStorage`.
>   - **UI Changes**:
>     - Adds star icon button to each dashboard item for pinning/unpinning.
>     - Updates dashboard sorting logic to prioritize pinned dashboards.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 64b561cef04d0fa878801375867246be168a93d7. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->