### PR TITLE
feat: remove Hours and Months from Logs TTL dropdown for s3 cold storage

### DIFF
--- a/frontend/src/container/GeneralSettings/Retention.tsx
+++ b/frontend/src/container/GeneralSettings/Retention.tsx
@@ -32,6 +32,7 @@ function Retention({
 	setRetentionValue,
 	text,
 	hide,
+	isS3ColdStorage = false,
 }: RetentionProps): JSX.Element | null {
 	const {
 		value: initialValue,
@@ -54,7 +55,8 @@ function Retention({
 	}, [initialTimeUnitValue]);
 
 	const menuItems = TimeUnits.filter((option) =>
-		type === 'logs' ? option.value !== TimeUnitsValues.hr : true,
+		type === 'logs' && isS3ColdStorage ? option.value !== TimeUnitsValues.hr && option.value !== TimeUnitsValues.month: true,
+
 	).map((option) => (
 		<Option key={option.value} value={option.value}>
 			{option.key}
@@ -134,6 +136,7 @@ interface RetentionProps {
 	text: string;
 	setRetentionValue: Dispatch<SetStateAction<number | null>>;
 	hide: boolean;
+	isS3ColdStorage: boolean;
 }
 
 export default Retention;


### PR DESCRIPTION
## 📄 Summary

Removes Hours and Months options from Logs TTL dropdown when configuring s3 cold storage, leaving only Days as an available option. This standardizes the TTL schema for s3 cold storage as requested in the issue.

---

## ✅ Changes

- [ ✓] Feature: Add isS3ColdStorage prop to Retention component
- [ ✓] Bug fix: Modify filter logic to exclude Hours and Months when type === 'logs' and isS3ColdStorage === true
- [ ✓]  Enhancement: Standardize TTL schema by removing Hours option for s3 cold storage

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `bug`
- `enhancement`
- `ui`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend 

---

## 🔍 Related Issues

Fixes #9190

---

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `Hours` and `Months` from Logs TTL dropdown in `Retention` component for S3 cold storage, leaving only `Days`.
> 
>   - **Behavior**:
>     - Removes `Hours` and `Months` options from Logs TTL dropdown in `Retention` component when `isS3ColdStorage` is `true`.
>     - Only `Days` option remains for S3 cold storage.
>   - **Props**:
>     - Adds `isS3ColdStorage` prop to `Retention` component.
>   - **Logic**:
>     - Modifies filter logic in `Retention` to exclude `Hours` and `Months` when `type === 'logs'` and `isS3ColdStorage === true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for b7040e2144464e55a66ab1a7aff36d5b642262c8. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->