### PR TITLE
fix: highlight log copy link

### DIFF
--- a/frontend/src/container/LogsExplorerList/index.tsx
+++ b/frontend/src/container/LogsExplorerList/index.tsx
@@ -83,12 +83,19 @@ function LogsExplorerList({
 		[options],
 	);
 	useEffect(() => {
-		if (!isLoading && !isFetching && !isError && logs.length !== 0) {
-			logEvent('Logs Explorer: Data present', {
-				panelType: 'LIST',
-			});
-		}
-	}, [isLoading, isFetching, isError, logs.length]);
+        if (!isLoading && !isFetching && !isError && logs.length !== 0) {
+            logEvent('Logs Explorer: Data present', {
+                panelType: 'LIST',
+            });
+
+            if(activeLogIndex !== -1 && ref.current){
+                ref.current.scrollToIndex({
+                    index: activeLogIndex,
+                    align: 'center',
+                })
+            }
+        }
+    }, [isLoading, isFetching, isError, logs.length, activeLogIndex]);
 
 	const getItemContent = useCallback(
 		(_: number, log: ILog): JSX.Element => {


### PR DESCRIPTION
## 📄 Summary
This PR fixes the issue where logs are not highlighted when accessed via a shared copy link. The fix adds auto-scroll functionality to the useEffect hook, ensuring that when a user opens a shared log link, the specific log entry is automatically scrolled into view and highlighted in the center of the viewport.

---

## ✅ Changes
- [x] Bug fix: Added activeLogIndex to useEffect dependencies to trigger scroll on log selection
- [x] Bug fix: Implemented scrollToIndex functionality with center alignment for better UX
- [x] Bug fix: Logs now properly highlight when accessed via shared URLs

---

## 🏷️ Required: Add Relevant Labels
> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

- `frontend`
- `bug`
- `ui`
- `logs`

---

## 👥 Reviewers
> Tag the relevant teams for review:
- frontend

---

## 🔍 Related Issues
<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Fix#8952

---
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes log highlighting issue in `LogsExplorerList` by updating `useEffect` to include `activeLogIndex` and implementing `scrollToIndex` for centering logs.
> 
>   - **Behavior**:
>     - Fixes log highlighting issue when accessed via shared link by updating `useEffect` in `LogsExplorerList`.
>     - Adds `activeLogIndex` to `useEffect` dependencies to trigger scroll.
>     - Implements `scrollToIndex` with center alignment for better UX.
>   - **Files**:
>     - Changes in `index.tsx` in `LogsExplorerList` to handle log highlighting and scrolling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for b371a8c4d34e52e489c6ba1215b4b35d4c12eff9. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->