### PR TITLE
chore(statsreporter): fix azure IMDS endpoint in statsreporter

### DIFF
--- a/pkg/version/deployment.go
+++ b/pkg/version/deployment.go
@@ -141,7 +141,7 @@ func detectPlatform() string {
 	}
 
 	// Azure metadata
-	if req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/metadata/instance", nil); err == nil {
+	if req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254/metadata/instance?api-version=2017-03-01", nil); err == nil {
 		req.Header.Add("Metadata", "true")
 		if resp, err := client.Do(req); err == nil {
 			resp.Body.Close()


### PR DESCRIPTION
## 📄 Summary

The Azure stats reporter is returning deployment_platform: "unknown" because the Azure IMDS endpoint requires an api-version parameter to be specified in the request. The fix is to update the endpoint URL from http://169.254.169.254/metadata/instance to http://169.254.169.254/metadata/instance?api-version=2017-03-01.



## ✅ Changes

- [ ] Feature: Brief description
- [x] Bug fix: Brief description

---
Related: https://github.com/SigNoz/platform-pod/issues/1182
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Azure IMDS endpoint in `detectPlatform()` to include API version, resolving `deployment_platform: "unknown"` issue.
> 
>   - **Bug Fix**:
>     - Update Azure IMDS endpoint URL in `detectPlatform()` in `deployment.go` to include `api-version=2017-03-01`.
>     - Fixes issue where Azure stats reporter returned `deployment_platform: "unknown"` due to missing API version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for f2e1036018acac24a3fad215efc5492196599ff3. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->