### PR TITLE
fix: anomaly with below operator negates the target

### DIFF
--- a/ee/query-service/rules/anomaly.go
+++ b/ee/query-service/rules/anomaly.go
@@ -78,11 +78,6 @@ func NewAnomalyRule(
 
 	opts = append(opts, baserules.WithLogger(logger))
 
-	if p.RuleCondition.CompareOp == ruletypes.ValueIsBelow {
-		target := -1 * *p.RuleCondition.Target
-		p.RuleCondition.Target = &target
-	}
-
 	baseRule, err := baserules.NewBaseRule(id, orgID, p, reader, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/types/ruletypes/api_params.go
+++ b/pkg/types/ruletypes/api_params.go
@@ -207,6 +207,7 @@ func (r *PostableRule) processRuleDefaults() error {
 				q.Expression = qLabel
 			}
 		}
+
 		//added alerts v2 fields
 		if r.SchemaVersion == DefaultSchemaVersion {
 			thresholdName := CriticalThresholdName
@@ -215,12 +216,20 @@ func (r *PostableRule) processRuleDefaults() error {
 					thresholdName = severity
 				}
 			}
+
+			// For anomaly detection with ValueIsBelow, negate the target
+			targetValue := r.RuleCondition.Target
+			if r.RuleType == RuleTypeAnomaly && r.RuleCondition.CompareOp == ValueIsBelow && targetValue != nil {
+				negated := -1 * *targetValue
+				targetValue = &negated
+			}
+
 			thresholdData := RuleThresholdData{
 				Kind: BasicThresholdKind,
 				Spec: BasicRuleThresholds{{
 					Name:        thresholdName,
 					TargetUnit:  r.RuleCondition.TargetUnit,
-					TargetValue: r.RuleCondition.Target,
+					TargetValue: targetValue,
 					MatchType:   r.RuleCondition.MatchType,
 					CompareOp:   r.RuleCondition.CompareOp,
 					Channels:    r.PreferredChannels,

--- a/pkg/types/ruletypes/api_params_test.go
+++ b/pkg/types/ruletypes/api_params_test.go
@@ -888,7 +888,7 @@ func TestAnomalyNegationShouldAlert(t *testing.T) {
 			series: v3.Series{
 				Labels: map[string]string{"host": "server1"},
 				Points: []v3.Point{
-					{Timestamp: 1000, Value: -2.1}, // all below -50
+					{Timestamp: 1000, Value: -2.1}, // all below -2
 					{Timestamp: 2000, Value: -2.2},
 					{Timestamp: 3000, Value: -2.5},
 				},
@@ -999,7 +999,7 @@ func TestAnomalyNegationShouldAlert(t *testing.T) {
 			expectedValue: 80.0,
 		},
 		{
-			name: "non-anomaly rule with ValueIsBelow - should alert",
+			name: "non-anomaly rule with ValueIsBelow - should not alert",
 			ruleJSON: []byte(`{
 				"alert": "ThresholdTest",
 				"ruleType": "threshold_rule",


### PR DESCRIPTION
## 📄 Summary

With the recent enhancements, the comparison is moved to the `ShouldAlert` of the `Threshold` object from the rule. The thresholds are populated for the existing alerts during the Unmarshal. This works every time except for the anomaly alert +  operator is below. When the operator is below, we need to negate the target value, i.e if the expected value is 2 deviations below means the z-score threshold is -2. This negation is taking place in the `NewAnomalyRule`, which makes it of no use as the threshold has been created. 

While fixing the issue, also notice that the stdDev is not using the current season series. Fixed it.

Unit tests don't catch these subtle bugs, so I didn't add any here.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes anomaly detection bug with `ValueIsBelow` operator by moving target negation logic and correcting standard deviation calculation.
> 
>   - **Behavior**:
>     - Fixes anomaly detection with `ValueIsBelow` operator by negating target value in `processRuleDefaults()` in `api_params.go`.
>     - Corrects standard deviation calculation to use `currentSeasonSeries` in `getBounds()` and `getAnomalies()` in `seasonal.go`.
>   - **Tests**:
>     - Adds `TestAnomalyNegationShouldAlert` in `api_params_test.go` to verify anomaly rule behavior with `ValueIsBelow` and other operators.
>   - **Misc**:
>     - Removes redundant negation logic from `NewAnomalyRule()` in `anomaly.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SigNoz%2Fsignoz&utm_source=github&utm_medium=referral)<sup> for 2193bc826ae0224136f44eee70a22241f57651ce. You can [customize](https://app.ellipsis.dev/SigNoz/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->