### PR TITLE
feat: implement case-insensitive query name handling in formula evaluation

### DIFF
--- a/pkg/types/querybuildertypes/querybuildertypesv5/formula.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/formula.go
@@ -153,10 +153,28 @@ func NewFormulaEvaluator(expressionStr string, canDefaultZero map[string]bool) (
 		return nil, errors.NewInvalidInputf(errors.CodeInvalidInput, "failed to parse expression")
 	}
 
+	// Normalize canDefaultZero keys to match variable casing from expression
+	normalizedCanDefaultZero := make(map[string]bool)
+	vars := expression.Vars()
+	for _, variable := range vars {
+		// If exact match exists, use it
+		if val, ok := canDefaultZero[variable]; ok {
+			normalizedCanDefaultZero[variable] = val
+			continue
+		}
+		// Otherwise try case-insensitive lookup
+		for k, v := range canDefaultZero {
+			if strings.EqualFold(k, variable) {
+				normalizedCanDefaultZero[variable] = v
+				break
+			}
+		}
+	}
+
 	evaluator := &FormulaEvaluator{
 		expression:     expression,
-		variables:      expression.Vars(),
-		canDefaultZero: canDefaultZero,
+		variables:      vars,
+		canDefaultZero: normalizedCanDefaultZero,
 		aggRefs:        make(map[string]aggregationRef),
 	}
 


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

Modified the formula evaluation logic in formula.go to normalize query names to uppercase during parsing and use case-insensitive matching when looking up time series data, allowing formulas like A/B, a/b, A/b, and a/B to produce same results

---

## ✅ Changes

- [x] Feature: Brief description
- [x] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `backend`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. go to Dashboards
2. add time series panel
3. create matrices & formula
4. test with different case queries

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #9216

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)


https://github.com/user-attachments/assets/47b02980-a836-42a4-bd0a-0b6836192826


<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [x] Dev Review
- [x] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds case-insensitive handling of query names and variables in formula evaluation.
> 
> - Normalize `canDefaultZero` keys to match expression variable casing; fall back to case-insensitive lookup
> - Case-insensitive query name matching when retrieving `timeSeriesData` in `buildSeriesLookup`
> - Use cached `expression.Vars()` for `variables`
> - Add `TestCaseInsensitiveQueryNames` with mixed-case scenarios ensuring consistent results
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f724bc658a0a4ab0f9048b1b2d3d164c03f48538. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->