### PR TITLE
chore(release): bump SigNoz to v0.97.1

### DIFF
--- a/deploy/docker-swarm/docker-compose.ha.yaml
+++ b/deploy/docker-swarm/docker-compose.ha.yaml
@@ -176,7 +176,7 @@ services:
       # - ../common/clickhouse/storage.xml:/etc/clickhouse-server/config.d/storage.xml
   signoz:
     !!merge <<: *db-depend
-    image: signoz/signoz:v0.97.0
+    image: signoz/signoz:v0.97.1
     command:
       - --config=/root/config/prometheus.yml
     ports:

--- a/deploy/docker-swarm/docker-compose.yaml
+++ b/deploy/docker-swarm/docker-compose.yaml
@@ -117,7 +117,7 @@ services:
       # - ../common/clickhouse/storage.xml:/etc/clickhouse-server/config.d/storage.xml
   signoz:
     !!merge <<: *db-depend
-    image: signoz/signoz:v0.97.0
+    image: signoz/signoz:v0.97.1
     command:
       - --config=/root/config/prometheus.yml
     ports:

--- a/deploy/docker/docker-compose.ha.yaml
+++ b/deploy/docker/docker-compose.ha.yaml
@@ -179,7 +179,7 @@ services:
       # - ../common/clickhouse/storage.xml:/etc/clickhouse-server/config.d/storage.xml
   signoz:
     !!merge <<: *db-depend
-    image: signoz/signoz:${VERSION:-v0.97.0}
+    image: signoz/signoz:${VERSION:-v0.97.1}
     container_name: signoz
     command:
       - --config=/root/config/prometheus.yml

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -111,7 +111,7 @@ services:
       # - ../common/clickhouse/storage.xml:/etc/clickhouse-server/config.d/storage.xml
   signoz:
     !!merge <<: *db-depend
-    image: signoz/signoz:${VERSION:-v0.97.0}
+    image: signoz/signoz:${VERSION:-v0.97.1}
     container_name: signoz
     command:
       - --config=/root/config/prometheus.yml


### PR DESCRIPTION
## 📄 Summary

Bumps the signoz version to v0.97.1 in Docker Compose 

Related: https://github.com/SigNoz/signoz/issues/9367
