### PR TITLE
fix: correct toolbar border color hierarchy in light mode for Externa…

### DIFF
--- a/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
+++ b/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
@@ -184,6 +184,12 @@
 }
 
 .lightMode {
+	.api-module-right-section {
+		.toolbar {
+			border-bottom: 1px solid var(--bg-vanilla-300);
+		}
+	}
+
 	.api-monitoring-domain-list-table {
 		.ant-table {
 			.ant-table-thead > tr > th {


### PR DESCRIPTION
fix: correct toolbar border color hierarchy in light mode for External APIs

- Wrapped .toolbar inside .api-module-right-section in .lightMode block
- Ensures proper CSS specificity to apply light mode border colors
- Maintains consistency with dark mode structure hierarchy

Fixes #9402

## 📄 Summary

This PR fixes the border color inconsistency in the External APIs section when using light mode. The `.toolbar` element was not applying the correct light mode border color (`var(--bg-vanilla-300)`) due to incorrect CSS selector specificity. By wrapping `.toolbar` inside `.api-module-right-section` in the `.lightMode` block, the CSS hierarchy now matches the dark mode structure, ensuring the light mode styles are properly applied.

---

## ✅ Changes

- [x] Bug fix: Fixed border color for toolbar in External APIs light mode to match design system

---

## 🏷️ Required: Add Relevant Labels

- `frontend`
- `bug`
- `ui`

---

## 👥 Reviewers

- frontend
@YounixM  @vikrantgupta25 @SagarRajput-7  @ahmadshaheer @amlannandy @sawhil @aks07 @ahrefabhi 


---

## 🧪 How to Test

1. Check out this branch locally
2. Run `cd frontend && yarn dev`
3. Navigate to External APIs section in the application
4. Toggle to **Light Mode** in the UI
5. Verify that the toolbar border color matches other borders (light gray - `var(--bg-vanilla-300)`)
6. Toggle back to **Dark Mode** and verify no visual regression
7. Check that all borders are consistent across the page in both modes

---

## 🔍 Related Issues

Closes #9402

---

## 📸 Screenshots

### Before
<!-- Border color was inconsistent - darker than other borders in light mode -->
<img width="1846" height="77" alt="504651513-f9f11f30-7baf-45fe-a9f1-d67908d3f0ce" src="https://github.com/user-attachments/assets/68d3d758-dc38-42da-bda7-16e0be669a20" />

### After
<!-- All borders now use consistent var(--bg-vanilla-300) in light mode -->
![WhatsApp Image 2025-10-24 at 15 54 40](https://github.com/user-attachments/assets/8e066960-21ca-4eea-a657-d12facf1ba64)


---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E) - N/A for CSS-only change
- [x] Manually tested the changes

---

## 👀 Notes for Reviewers

- This is a **CSS-only change** - no functional logic modified
- The fix maintains the exact same structure as the dark mode CSS hierarchy
- Only one line added: wrapping `.toolbar` inside `.api-module-right-section`
- No breaking changes or side effects expected
- The change ensures CSS specificity matches between light and dark mode selectors