### PR TITLE
Feat/external api dependent service different color

### DIFF
--- a/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/DomainDetails.styles.scss
+++ b/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/DomainDetails.styles.scss
@@ -793,7 +793,6 @@
 
 			.ant-table-cell:has(.top-services-item-latency) {
 				text-align: center;
-
 			}
 
 			.ant-table-cell:has(.top-services-item-latency-title) {
@@ -890,7 +889,7 @@
 				}
 
 				.top-services-item-progress-bar {
-					background-color: transparent;
+					background-color: var(--bg-slate-400);
 					border-radius: 2px;
 					height: 100%;
 					position: absolute;
@@ -1221,7 +1220,7 @@
 				}
 
 				.top-services-item-progress-bar {
-					background-color: transparent;
+					background-color: var(--bg-vanilla-200);
 					border: 1px solid var(--bg-vanilla-300);
 				}
 			}


### PR DESCRIPTION
Fixes #9400 

## 📄 Summary

All the columns in the External API right drawer now have same background color.
Column background modified:
- Dependent Services
- Avg. Latency
---

## ✅ Changes

Now all the columns have same background color.

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `ui`

---
Default view:

<img width="1777" height="187" alt="Image" src="https://github.com/user-attachments/assets/2bbb8a38-0a67-4823-a154-11e1655e67f7" />


On hover:

<img width="1784" height="186" alt="Image" src="https://github.com/user-attachments/assets/88359205-ccfa-4e60-8021-15ef047ecf60" />