### PR TITLE
fix(api-monitoring): border being hidden on hover

### DIFF
--- a/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/DomainDetails.styles.scss
+++ b/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/DomainDetails.styles.scss
@@ -700,11 +700,17 @@
 
 		.ant-btn {
 			box-shadow: none;
+			position: relative;
 		}
 
 		.tab {
 			border: 1px solid var(--bg-slate-400);
 			width: 114px;
+			z-index: 1;
+		}
+
+		.tab:hover {
+			z-index: 3;
 		}
 
 		.tab::before {
@@ -715,6 +721,7 @@
 			background: var(--bg-slate-400);
 			color: var(--text-vanilla-100);
 			border: 1px solid var(--bg-slate-400);
+			z-index: 2;
 		}
 
 		.selected_view::before {


### PR DESCRIPTION
Fixes #9399 

## 📄 Summary

This PR ensures the hovered tab's border is always fully visible on top of all other tabs, regardless of which tab is selected.

---

## ✅ Changes

This ensures the hovered tab's border is always fully visible on top of all other tabs, regardless of which tab is selected.

---

- <img width="249" height="50" alt="image" src="https://github.com/user-attachments/assets/e4687657-4318-451b-807a-6808de0a377d" />