### PR TITLE
fix: prevent janky login screen flash after successful authentication

### DIFF
--- a/frontend/src/container/Login/index.tsx
+++ b/frontend/src/container/Login/index.tsx
@@ -7,10 +7,12 @@ import get from 'api/v2/sessions/context/get';
 import post from 'api/v2/sessions/email_password/post';
 import afterLogin from 'AppRoutes/utils';
 import AuthError from 'components/AuthError/AuthError';
+import Spinner from 'components/Spinner';
 import ROUTES from 'constants/routes';
 import useUrlQuery from 'hooks/useUrlQuery';
 import history from 'lib/history';
 import { ArrowRight } from 'lucide-react';
+import { useAppContext } from 'providers/App/App';
 import { ErrorV2 } from 'types/api';
 import APIError from 'types/api/error';
 import { SessionsContext } from 'types/api/v2/sessions/context/get';
@@ -69,6 +71,7 @@ function Login(): JSX.Element {
 	const email = Form.useWatch('email', form);
 	const password = Form.useWatch('password', form);
 	const orgId = Form.useWatch('orgId', form);
+	const { isLoggedIn } = useAppContext();
 
 	// setupCompleted information to route to signup page in case setup is incomplete
 	const {
@@ -299,6 +302,11 @@ function Login(): JSX.Element {
 		isPasswordAuthN,
 		password,
 	]);
+
+	if (isLoggedIn) {
+		// Route to home immediately via PrivateRoute, but show loading to prevent UI flashing
+		return <Spinner tip="Loading..." />;
+	}
 
 	return (
 		<div className="login-form-container">


### PR DESCRIPTION
## 📄 Summary

This PR fixes a janky user experience on the Sign In screen where, after submitting credentials, the login screen briefly flashes again before redirecting to the dashboard. The change ensures a smooth transition from loading to dashboard after successful authentication.

---

## ✅ Changes

- [x] Bug fix: Prevents login screen from flashing after successful sign-in by showing a loading spinner when the user is already authenticated.
- [x] UI: Improves login flow for a seamless user experience.

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

- `frontend`
- `bug`
- `ui`
- `enhancement`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend

---

## 🧪 How to Test

1. Start the frontend dev server.
2. Go to the login screen and sign in with valid credentials.
3. Observe the flow: after clicking "Sign In," you should see a loading spinner and then be redirected directly to the dashboard, without the login screen flashing again.
4. Try reloading `/login` while already authenticated; you should see a spinner and be redirected to the dashboard.

---

## 🔍 Related Issues

Closes #9417
Closes https://github.com/SigNoz/engineering-pod/issues/4191

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

https://github.com/user-attachments/assets/ae9d4a54-0f03-4584-830b-9a5e9c7c8468

> Email was hidden for privacy reasons.

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes