### PR TITLE
feat: allow passing ports as env vars

### DIFF
--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -116,7 +116,7 @@ services:
     command:
       - --config=/root/config/prometheus.yml
     ports:
-      - "8080:8080" # signoz port
+      - "${SIGNOZ_PORT:-8080}:8080" # signoz port
     #   - "6060:6060"     # pprof port
     volumes:
       - ../common/signoz/prometheus.yml:/root/config/prometheus.yml
@@ -159,8 +159,8 @@ services:
       - LOW_CARDINAL_EXCEPTION_GROUPING=false
     ports:
       # - "1777:1777"     # pprof extension
-      - "4317:4317" # OTLP gRPC receiver
-      - "4318:4318" # OTLP HTTP receiver
+      - "${OTEL_GRPC_PORT:-4317}:4317" # OTLP gRPC receiver
+      - "${OTEL_HTTP_PORT:-4318}:4318" # OTLP HTTP receiver
     depends_on:
       signoz:
         condition: service_healthy


### PR DESCRIPTION
## 📄 Summary

Add: Allow passing ports as env vars for standalone docker deployment. Uses default ports (8080, 4317 and 4318) if none provided. This is useful where users might have other crucial services running on ports 8080, 4317 and 4318

---

## ✅ Changes

- [x] Feature: Allow passing custom ports as env variables. Uses default ports if none provided. This is useful where users might have other crucial services running on ports 8080, 4317 and 4318
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- devops

---

## 🧪 How to Test

1. Make sure you cannot deploy SigNoz using the default ports 8080 / 4317 / 4318 because at least one of them is already in use
2. Now try deploying using `SIGNOZ_PORT=9090 OTEL_GRPC_PORT=5000 OTEL_HTTP_PORT=5001 docker-compose up -d --remove-orphans`
3. SigNoz should be up and running on port 9090

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #636 

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

- I'm not sure if this affects the install script, but I think this would be a good addition to the install script as well, so that users can specify their desired ports before running the install script
