### PR TITLE
feat: Allow users to use custom ports using env vars

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -28,6 +28,32 @@ docker compose up -d
 
 Open http://localhost:8080 in your favourite browser.
 
+### Custom Port Configuration
+
+You can customize the ports used by SigNoz by setting the following environment variables:
+
+- `SIGNOZ_PORT` - Port for the SigNoz UI and API (default: 8080)
+- `OTEL_GRPC_PORT` - Port for OTLP gRPC receiver (default: 4317)
+- `OTEL_HTTP_PORT` - Port for OTLP HTTP receiver (default: 4318)
+
+**Example using Docker Compose:**
+
+```sh
+cd deploy/docker
+SIGNOZ_PORT=9090 OTEL_GRPC_PORT=5317 OTEL_HTTP_PORT=5318 docker compose up -d
+```
+
+**Example using Install Script:**
+
+```sh
+export SIGNOZ_PORT=9090
+export OTEL_GRPC_PORT=5317
+export OTEL_HTTP_PORT=5318
+./install.sh
+```
+
+After setting custom ports, access SigNoz UI at `http://localhost:<SIGNOZ_PORT>`.
+
 To start collecting logs and metrics from your infrastructure, run the following command:
 
 ```sh
@@ -78,4 +104,3 @@ For more details, please refer to the [SigNoz documentation](https://signoz.io/d
 ## Uninstall/Troubleshoot?
 
 Go to our official documentation site [signoz.io/docs](https://signoz.io/docs) for more.
-

--- a/deploy/docker/docker-compose.ha.yaml
+++ b/deploy/docker/docker-compose.ha.yaml
@@ -184,7 +184,7 @@ services:
     command:
       - --config=/root/config/prometheus.yml
     ports:
-      - "8080:8080" # signoz port
+      - "${SIGNOZ_PORT:-8080}:8080" # signoz port
     #   - "6060:6060"     # pprof port
     volumes:
       - ../common/signoz/prometheus.yml:/root/config/prometheus.yml
@@ -228,8 +228,8 @@ services:
       - LOW_CARDINAL_EXCEPTION_GROUPING=false
     ports:
       # - "1777:1777"     # pprof extension
-      - "4317:4317" # OTLP gRPC receiver
-      - "4318:4318" # OTLP HTTP receiver
+      - "${OTEL_GRPC_PORT:-4317}:4317" # OTLP gRPC receiver
+      - "${OTEL_HTTP_PORT:-4318}:4318" # OTLP HTTP receiver
     depends_on:
       clickhouse:
         condition: service_healthy

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -116,7 +116,7 @@ services:
     command:
       - --config=/root/config/prometheus.yml
     ports:
-      - "8080:8080" # signoz port
+      - "${SIGNOZ_PORT:-8080}:8080" # signoz port
     #   - "6060:6060"     # pprof port
     volumes:
       - ../common/signoz/prometheus.yml:/root/config/prometheus.yml
@@ -159,8 +159,8 @@ services:
       - LOW_CARDINAL_EXCEPTION_GROUPING=false
     ports:
       # - "1777:1777"     # pprof extension
-      - "4317:4317" # OTLP gRPC receiver
-      - "4318:4318" # OTLP HTTP receiver
+      - "${OTEL_GRPC_PORT:-4317}:4317" # OTLP gRPC receiver
+      - "${OTEL_HTTP_PORT:-4318}:4318" # OTLP HTTP receiver
     depends_on:
       signoz:
         condition: service_healthy


### PR DESCRIPTION
## 📄 Summary

`devops` Allows the user to use custom ports by passing them as environment variables, so that they can run Signoz on a port other than 8080 if they already have another service running on port 8080.

---

## ✅ Changes

- [x] Feature: Allows the user to use custom ports by passing them as environment variables
- [ ] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

- `devops`
- `enhancement`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- devops @prashant-shahi @therealpandey 

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. Running the install script or using docker compose with default ports throws an error saying any one of the port is already in use
2. Try running the service using `SIGNOZ_PORT=9090 docker compose up -d` or `SIGNOZ_PORT=9090 ./install.sh`
3. Service starts successfully

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #636 

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes


---

## 👀 Notes for Reviewers

- I haven't added these changes for docker-swarm, as I have never worked with it. Please let me know if I should leave it as is, or update the files for docker-swarm as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds env-var-based custom port configuration for SigNoz UI and OTLP (gRPC/HTTP) receivers, updating docker-compose files, install script, and docs.
> 
> - **Deploy configs**:
>   - `deploy/docker/docker-compose.yaml`, `deploy/docker/docker-compose.ha.yaml`:
>     - Make ports configurable via env vars: `SIGNOZ_PORT` for UI/API, `OTEL_GRPC_PORT` for OTLP gRPC, `OTEL_HTTP_PORT` for OTLP HTTP.
> - **Install script** (`deploy/install.sh`):
>   - Port checks now honor `SIGNOZ_PORT`, `OTEL_GRPC_PORT`, `OTEL_HTTP_PORT` with defaults; updated error messaging.
>   - Health check and success URL dynamically use `SIGNOZ_PORT`.
> - **Docs** (`deploy/README.md`):
>   - Add “Custom Port Configuration” section with examples for Docker Compose and install script; note accessing UI at custom port.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f87785b7342f305ee62ca4de2f1974201e5998ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->