### PR TITLE
chore: bump golangci-lint to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,43 +1,63 @@
+version: "2"
 linters:
-  default: standard
+  default: none
   enable:
     - bodyclose
+    - depguard
+    - errcheck
+    - forbidigo
+    - govet
+    - iface
+    - ineffassign
     - misspell
     - nilnil
     - sloglint
-    - depguard
-    - iface
     - unparam
-    - forbidigo
-
-linters-settings:
-  sloglint:
-    no-mixed-args: true
-    kv-only: true
-    no-global: all
-    context: all
-    static-msg: true
-    msg-style: lowercased
-    key-naming-case: snake
-  depguard:
-    rules:
-      nozap:
-        deny:
-          - pkg: "go.uber.org/zap"
-            desc: "Do not use zap logger. Use slog instead."
-      noerrors:
-        deny:
-          - pkg: "errors"
-            desc: "Do not use errors package. Use github.com/SigNoz/signoz/pkg/errors instead."
-  iface:
-    enable:
-      - identical
-  forbidigo:
-    forbid:
-      - fmt.Errorf
-      - ^(fmt\.Print.*|print|println)$
-issues:
-  exclude-dirs:
-    - "pkg/query-service"
-    - "ee/query-service"
-    - "scripts/"
+    - unused
+  settings:
+    depguard:
+      rules:
+        noerrors:
+          deny:
+            - pkg: errors
+              desc: Do not use errors package. Use github.com/SigNoz/signoz/pkg/errors instead.
+        nozap:
+          deny:
+            - pkg: go.uber.org/zap
+              desc: Do not use zap logger. Use slog instead.
+    forbidigo:
+      forbid:
+        - pattern: fmt.Errorf
+        - pattern: ^(fmt\.Print.*|print|println)$
+    iface:
+      enable:
+        - identical
+    sloglint:
+      no-mixed-args: true
+      kv-only: true
+      no-global: all
+      context: all
+      static-msg: true
+      key-naming-case: snake
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - pkg/query-service
+      - ee/query-service
+      - scripts/
+      - tmp/
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/pkg/alertmanager/alertmanagerbatcher/batcher_test.go
+++ b/pkg/alertmanager/alertmanagerbatcher/batcher_test.go
@@ -2,7 +2,6 @@ package alertmanagerbatcher
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"testing"
 
@@ -11,7 +10,7 @@ import (
 )
 
 func TestBatcherWithOneAlertAndDefaultConfigs(t *testing.T) {
-	batcher := New(slog.New(slog.NewTextHandler(io.Discard, nil)), NewConfig())
+	batcher := New(slog.New(slog.DiscardHandler), NewConfig())
 	_ = batcher.Start(context.Background())
 
 	batcher.Add(context.Background(), &alertmanagertypes.PostableAlert{Alert: alertmanagertypes.AlertModel{
@@ -25,7 +24,7 @@ func TestBatcherWithOneAlertAndDefaultConfigs(t *testing.T) {
 }
 
 func TestBatcherWithBatchSize(t *testing.T) {
-	batcher := New(slog.New(slog.NewTextHandler(io.Discard, nil)), Config{Size: 2, Capacity: 4})
+	batcher := New(slog.New(slog.DiscardHandler), Config{Size: 2, Capacity: 4})
 	_ = batcher.Start(context.Background())
 
 	var alerts alertmanagertypes.PostableAlerts
@@ -45,7 +44,7 @@ func TestBatcherWithBatchSize(t *testing.T) {
 }
 
 func TestBatcherWithCClosed(t *testing.T) {
-	batcher := New(slog.New(slog.NewTextHandler(io.Discard, nil)), Config{Size: 2, Capacity: 4})
+	batcher := New(slog.New(slog.DiscardHandler), Config{Size: 2, Capacity: 4})
 	_ = batcher.Start(context.Background())
 
 	var alerts alertmanagertypes.PostableAlerts

--- a/pkg/alertmanager/alertmanagerserver/server_e2e_test.go
+++ b/pkg/alertmanager/alertmanagerserver/server_e2e_test.go
@@ -2,13 +2,13 @@ package alertmanagerserver
 
 import (
 	"context"
-	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes/alertmanagertypestest"
-	"github.com/prometheus/alertmanager/dispatch"
-	"io"
 	"log/slog"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes/alertmanagertypestest"
+	"github.com/prometheus/alertmanager/dispatch"
 
 	"github.com/SigNoz/signoz/pkg/alertmanager/nfmanager"
 	"github.com/SigNoz/signoz/pkg/alertmanager/nfmanager/nfroutingstore/nfroutingstoretest"
@@ -89,7 +89,7 @@ func TestEndToEndAlertManagerFlow(t *testing.T) {
 	srvCfg := NewConfig()
 	stateStore := alertmanagertypestest.NewStateStore()
 	registry := prometheus.NewRegistry()
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	server, err := New(context.Background(), logger, registry, srvCfg, orgID, stateStore, notificationManager)
 	require.NoError(t, err)
 	amConfig, err := alertmanagertypes.NewDefaultConfig(srvCfg.Global, srvCfg.Route, orgID)

--- a/pkg/alertmanager/alertmanagerserver/server_test.go
+++ b/pkg/alertmanager/alertmanagerserver/server_test.go
@@ -3,7 +3,6 @@ package alertmanagerserver
 import (
 	"bytes"
 	"context"
-	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -26,7 +25,7 @@ import (
 
 func TestServerSetConfigAndStop(t *testing.T) {
 	notificationManager := nfmanagertest.NewMock()
-	server, err := New(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), prometheus.NewRegistry(), NewConfig(), "1", alertmanagertypestest.NewStateStore(), notificationManager)
+	server, err := New(context.Background(), slog.New(slog.DiscardHandler), prometheus.NewRegistry(), NewConfig(), "1", alertmanagertypestest.NewStateStore(), notificationManager)
 	require.NoError(t, err)
 
 	amConfig, err := alertmanagertypes.NewDefaultConfig(alertmanagertypes.GlobalConfig{}, alertmanagertypes.RouteConfig{GroupInterval: 1 * time.Minute, RepeatInterval: 1 * time.Minute, GroupWait: 1 * time.Minute}, "1")
@@ -38,7 +37,7 @@ func TestServerSetConfigAndStop(t *testing.T) {
 
 func TestServerTestReceiverTypeWebhook(t *testing.T) {
 	notificationManager := nfmanagertest.NewMock()
-	server, err := New(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), prometheus.NewRegistry(), NewConfig(), "1", alertmanagertypestest.NewStateStore(), notificationManager)
+	server, err := New(context.Background(), slog.New(slog.DiscardHandler), prometheus.NewRegistry(), NewConfig(), "1", alertmanagertypestest.NewStateStore(), notificationManager)
 	require.NoError(t, err)
 
 	amConfig, err := alertmanagertypes.NewDefaultConfig(alertmanagertypes.GlobalConfig{}, alertmanagertypes.RouteConfig{GroupInterval: 1 * time.Minute, RepeatInterval: 1 * time.Minute, GroupWait: 1 * time.Minute}, "1")
@@ -86,7 +85,7 @@ func TestServerPutAlerts(t *testing.T) {
 	srvCfg := NewConfig()
 	srvCfg.Route.GroupInterval = 1 * time.Second
 	notificationManager := nfmanagertest.NewMock()
-	server, err := New(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), prometheus.NewRegistry(), srvCfg, "1", stateStore, notificationManager)
+	server, err := New(context.Background(), slog.New(slog.DiscardHandler), prometheus.NewRegistry(), srvCfg, "1", stateStore, notificationManager)
 	require.NoError(t, err)
 
 	amConfig, err := alertmanagertypes.NewDefaultConfig(srvCfg.Global, srvCfg.Route, "1")
@@ -134,7 +133,7 @@ func TestServerTestAlert(t *testing.T) {
 	srvCfg := NewConfig()
 	srvCfg.Route.GroupInterval = 1 * time.Second
 	notificationManager := nfmanagertest.NewMock()
-	server, err := New(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), prometheus.NewRegistry(), srvCfg, "1", stateStore, notificationManager)
+	server, err := New(context.Background(), slog.New(slog.DiscardHandler), prometheus.NewRegistry(), srvCfg, "1", stateStore, notificationManager)
 	require.NoError(t, err)
 
 	amConfig, err := alertmanagertypes.NewDefaultConfig(srvCfg.Global, srvCfg.Route, "1")
@@ -239,7 +238,7 @@ func TestServerTestAlertContinuesOnFailure(t *testing.T) {
 	srvCfg := NewConfig()
 	srvCfg.Route.GroupInterval = 1 * time.Second
 	notificationManager := nfmanagertest.NewMock()
-	server, err := New(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), prometheus.NewRegistry(), srvCfg, "1", stateStore, notificationManager)
+	server, err := New(context.Background(), slog.New(slog.DiscardHandler), prometheus.NewRegistry(), srvCfg, "1", stateStore, notificationManager)
 	require.NoError(t, err)
 
 	amConfig, err := alertmanagertypes.NewDefaultConfig(srvCfg.Global, srvCfg.Route, "1")

--- a/pkg/factory/registry_test.go
+++ b/pkg/factory/registry_test.go
@@ -2,7 +2,6 @@ package factory
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"sync"
 	"testing"
@@ -33,7 +32,7 @@ func TestRegistryWith2Services(t *testing.T) {
 	s1 := newTestService(t)
 	s2 := newTestService(t)
 
-	registry, err := NewRegistry(slog.New(slog.NewTextHandler(io.Discard, nil)), NewNamedService(MustNewName("s1"), s1), NewNamedService(MustNewName("s2"), s2))
+	registry, err := NewRegistry(slog.New(slog.DiscardHandler), NewNamedService(MustNewName("s1"), s1), NewNamedService(MustNewName("s2"), s2))
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -54,7 +53,7 @@ func TestRegistryWith2ServicesWithoutWait(t *testing.T) {
 	s1 := newTestService(t)
 	s2 := newTestService(t)
 
-	registry, err := NewRegistry(slog.New(slog.NewTextHandler(io.Discard, nil)), NewNamedService(MustNewName("s1"), s1), NewNamedService(MustNewName("s2"), s2))
+	registry, err := NewRegistry(slog.New(slog.DiscardHandler), NewNamedService(MustNewName("s1"), s1), NewNamedService(MustNewName("s2"), s2))
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/pkg/http/middleware/timeout_test.go
+++ b/pkg/http/middleware/timeout_test.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -17,7 +16,7 @@ func TestTimeout(t *testing.T) {
 	writeTimeout := 6 * time.Second
 	defaultTimeout := 2 * time.Second
 	maxTimeout := 4 * time.Second
-	m := NewTimeout(slog.New(slog.NewTextHandler(io.Discard, nil)), []string{"/excluded"}, defaultTimeout, maxTimeout)
+	m := NewTimeout(slog.New(slog.DiscardHandler), []string{"/excluded"}, defaultTimeout, maxTimeout)
 
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)

--- a/pkg/instrumentation/instrumentationtest/instrumentation.go
+++ b/pkg/instrumentation/instrumentationtest/instrumentation.go
@@ -1,7 +1,6 @@
 package instrumentationtest
 
 import (
-	"io"
 	"log/slog"
 
 	"github.com/SigNoz/signoz/pkg/factory"
@@ -21,7 +20,7 @@ type noopInstrumentation struct {
 
 func New() instrumentation.Instrumentation {
 	return &noopInstrumentation{
-		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		logger:         slog.New(slog.DiscardHandler),
 		meterProvider:  noopmetric.NewMeterProvider(),
 		tracerProvider: nooptrace.NewTracerProvider(),
 	}

--- a/pkg/signoz/config_test.go
+++ b/pkg/signoz/config_test.go
@@ -2,7 +2,6 @@ package signoz
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"testing"
 
@@ -13,7 +12,7 @@ import (
 // This is a test to ensure that all fields of config implement the factory.Config interface and are valid with
 // their default values.
 func TestValidateConfig(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger := slog.New(slog.DiscardHandler)
 	_, err := NewConfig(context.Background(), logger, configtest.NewResolverConfig(), DeprecatedFlags{})
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## 📄 Summary

bump golangci-lint to v2