### PR TITLE
feat: enable staticcheck and godot linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,8 @@ linters:
     - sloglint
     - unparam
     - unused
+    - staticcheck
+    - godot
   settings:
     depguard:
       rules:


### PR DESCRIPTION
This PR enables two additional linters
1.staticcheck & godot
it address issue #9446 
The changes i made is updated the existing code with two additional linkers.
No code functionally was modified. And verified the configuration by running golangci-lint run
This lint run successfully.
53 issues were reported i.e,50 from staticcheck 3 from godot 
This will be handled by further PR
