### PR TITLE
fix: return coldstorage -1 if not set for logs

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -1860,6 +1860,7 @@ func (r *ClickHouseReader) GetCustomRetentionTTL(ctx context.Context, orgID stri
 			response.DefaultTTLDays = 15
 			response.TTLConditions = []model.CustomRetentionRule{}
 			response.Status = constants.StatusFailed
+			response.ColdStorageTTLDays = -1
 			return response, nil
 		}
 
@@ -1894,6 +1895,7 @@ func (r *ClickHouseReader) GetCustomRetentionTTL(ctx context.Context, orgID stri
 		response.ExpectedLogsTime = ttlResult.ExpectedLogsTime
 		response.ExpectedLogsMoveTime = ttlResult.ExpectedLogsMoveTime
 		response.Status = ttlResult.Status
+		response.ColdStorageTTLDays = -1
 		if ttlResult.LogsTime > 0 {
 			response.DefaultTTLDays = ttlResult.LogsTime / 24
 		}


### PR DESCRIPTION
We return coldstorage days = -1, in all cases except the base where there is no change, this PR fixes that so that the button display logic on the frontend works as expected.

ref:- https://github.com/SigNoz/signoz/pull/9458