### PR TITLE
feat: changed descirption of span percentile calculation

### DIFF
--- a/pkg/modules/spanpercentile/implspanpercentile/module.go
+++ b/pkg/modules/spanpercentile/implspanpercentile/module.go
@@ -99,9 +99,9 @@ func transformToSpanPercentileResponse(queryResult *qbtypes.QueryRangeResponse) 
 		return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "no spans found matching the specified criteria")
 	}
 
-	description := fmt.Sprintf("faster than %.1f%% of spans", position)
+	description := fmt.Sprintf("slower than %.1f%% of spans", position)
 	if position < 50 {
-		description = fmt.Sprintf("slower than %.1f%% of spans", 100-position)
+		description = fmt.Sprintf("faster than %.1f%% of spans", 100-position)
 	}
 
 	return &spanpercentiletypes.SpanPercentileResponse{


### PR DESCRIPTION
## 📄 Summary

changed description of span percentile calculation

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts span percentile description to default to "slower than X%" and use "faster than (100−X)%" when position < 50.
> 
> - **Span percentile**: Update `transformToSpanPercentileResponse` to set description as "slower than %.1f%% of spans" by default, and "faster than %.1f%% of spans" when `position < 50` (using `100 - position`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1f6c503340c520a70784d87226ce0858f5c81d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->