### PR TITLE
Update Zookeeper image version to 3.9.3

### DIFF
--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -39,7 +39,7 @@ x-clickhouse-defaults: &clickhouse-defaults
     - CLICKHOUSE_SKIP_USER_SETUP=1
 x-zookeeper-defaults: &zookeeper-defaults
   !!merge <<: *common
-  image: signoz/zookeeper:3.7.1
+  image: signoz/zookeeper:3.9.3
   user: root
   labels:
     signoz.io/scrape: "true"


### PR DESCRIPTION
3.7.1 no longer available

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps Zookeeper Docker image in `deploy/docker/docker-compose.yaml` from `signoz/zookeeper:3.7.1` to `3.9.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b7a66c68f2ac4092efffb25cd8d43cb30b0c7a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->