### PR TITLE
feat: pass email if username is not set - pylon

### DIFF
--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -274,7 +274,7 @@ function App(): JSX.Element {
 					chat_settings: {
 						app_id: process.env.PYLON_APP_ID,
 						email: user.email,
-						name: user.displayName,
+						name: user.displayName || user.email,
 					},
 				};
 			}


### PR DESCRIPTION
RCA - Pylon chat window was not initializing if the user did not have the username.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use email as a fallback for Pylon chat `name` when `displayName` is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1bdb7a523b95611570ae274564066c0558aaf32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->