### PR TITLE
feat: reset error boundary on pathname change

### DIFF
--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -112,6 +112,8 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 		setShowPaymentFailedWarning,
 	] = useState<boolean>(false);
 
+	const errorBoundaryRef = useRef<Sentry.ErrorBoundary>(null);
+
 	const [showSlowApiWarning, setShowSlowApiWarning] = useState(false);
 	const [slowApiWarningShown, setSlowApiWarningShown] = useState(false);
 
@@ -377,6 +379,13 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 		getChangelogByVersionResponse.data,
 		getChangelogByVersionResponse.isSuccess,
 	]);
+
+	// reset error boundary on route change
+	useEffect(() => {
+		if (errorBoundaryRef.current) {
+			errorBoundaryRef.current.resetErrorBoundary();
+		}
+	}, [pathname]);
 
 	const isToDisplayLayout = isLoggedIn;
 
@@ -836,7 +845,10 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 					})}
 					data-overlayscrollbars-initialize
 				>
-					<Sentry.ErrorBoundary fallback={<ErrorBoundaryFallback />} key={pathname}>
+					<Sentry.ErrorBoundary
+						fallback={<ErrorBoundaryFallback />}
+						ref={errorBoundaryRef}
+					>
 						<LayoutContent data-overlayscrollbars-initialize>
 							<OverlayScrollbar>
 								<ChildrenContainer>


### PR DESCRIPTION
feat: reset error boundary on pathname change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reset `Sentry.ErrorBoundary` on `pathname` changes using a ref-driven `useEffect`, removing reliance on `key={pathname}`.
> 
> - **Frontend**
>   - **Layout (`frontend/src/container/AppLayout/index.tsx`)**:
>     - Add `errorBoundaryRef` and attach it to `Sentry.ErrorBoundary`.
>     - On `pathname` change, call `errorBoundaryRef.current.resetErrorBoundary()` via `useEffect`.
>     - Remove `key={pathname}` from `Sentry.ErrorBoundary` wrapper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc9e52cda552d167957563ccab8e79e207059170. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->