### PR TITLE
fix: improve span percentile UI text and update tests

### DIFF
--- a/frontend/src/container/SpanDetailsDrawer/SpanDetailsDrawer.tsx
+++ b/frontend/src/container/SpanDetailsDrawer/SpanDetailsDrawer.tsx
@@ -291,27 +291,21 @@ function SpanDetailsDrawer(props: ISpanDetailsDrawerProps): JSX.Element {
 		},
 		eventType: 'mousedown',
 	});
-
-	const spanPercentileTooltipText = useMemo(
-		() => (
-			<div className="span-percentile-tooltip-text">
-				<Typography.Text>
-					This span duration is{' '}
-					<span className="span-percentile-tooltip-text-percentile">
-						p{Math.floor(spanPercentileData?.percentile || 0)}
-					</span>{' '}
-					out of the distribution for this resource evaluated for {selectedTimeRange}{' '}
-					hour(s) since the span start time.
-				</Typography.Text>
-				<br />
-				<br />
-				<Typography.Text className="span-percentile-tooltip-text-link">
-					Click to learn more
-				</Typography.Text>
-			</div>
-		),
-		[spanPercentileData?.percentile, selectedTimeRange],
-	);
+const spanPercentileTooltipText = useMemo(
+  () => (
+    <div className="span-percentile-tooltip-text">
+      <Typography.Text>
+        p{Math.floor(spanPercentileData?.percentile || 0)} ({selectedSpan?.duration || 'N/A'}) — slower than {Math.floor(spanPercentileData?.percentile || 0)}% of recent spans for this operation in the last {selectedTimeRange}h.
+      </Typography.Text>
+      <br />
+      <br />
+      <Typography.Text className="span-percentile-tooltip-text-link">
+        Click to learn more
+      </Typography.Text>
+    </div>
+  ),
+  [spanPercentileData?.percentile, selectedTimeRange, selectedSpan?.duration],
+);
 
 	const endTime = useMemo(
 		() => Math.floor(Number(selectedSpan?.timestamp) / 1000) * 1000,
@@ -709,23 +703,22 @@ function SpanDetailsDrawer(props: ISpanDetailsDrawerProps): JSX.Element {
 											)}
 
 											<div className="span-percentile-content">
-												<Typography.Text className="span-percentile-content-title">
-													This span duration is{' '}
+													<Typography.Text className="span-percentile-content-title">
 													{!isLoadingSpanPercentilesData &&
 													!isFetchingSpanPercentilesData &&
 													spanPercentileData ? (
+														<>
 														<span className="span-percentile-value">
 															p{Math.floor(spanPercentileData?.percentile || 0)}
-														</span>
+														</span>{' '}
+														({selectedSpan?.duration ? `${(selectedSpan.duration / 1000000).toFixed(2)} ms` : 'N/A'}) — slower than {Math.floor(spanPercentileData?.percentile || 0)}% of recent spans for this operation in the last {selectedTimeRange}h.
+														</>
 													) : (
 														<span className="span-percentile-value-loader">
-															<Loader2 size={12} className="animate-spin" />
+														<Loader2 size={12} className="animate-spin" />
 														</span>
-													)}{' '}
-													out of the distribution for this resource evaluated for{' '}
-													{selectedTimeRange} hour(s) since the span start time.
-												</Typography.Text>
-
+													)}
+													</Typography.Text>
 												<div className="span-percentile-timerange">
 													<Select
 														labelInValue

--- a/frontend/src/container/SpanDetailsDrawer/__tests__/SpanDetailsDrawer.test.tsx
+++ b/frontend/src/container/SpanDetailsDrawer/__tests__/SpanDetailsDrawer.test.tsx
@@ -680,17 +680,15 @@ describe('SpanDetailsDrawer', () => {
 			// Click on the percentile value to expand details
 			const percentileValue = screen.getByText(P75_TEXT);
 			fireEvent.click(percentileValue);
-
 			// Verify percentile details are expanded
 			await waitFor(() => {
 				expect(screen.getByText(SPAN_PERCENTILE_TEXT)).toBeInTheDocument();
 				// Look for the text that's actually rendered
-				expect(screen.getByText(/This span duration is/)).toBeInTheDocument();
-				expect(
-					screen.getByText(/out of the distribution for this resource/),
-				).toBeInTheDocument();
+				expect(screen.getByText(/p\d+.*slower than/)).toBeInTheDocument();
+				expect(screen.getByText(/recent spans for this operation/)).toBeInTheDocument();
 			});
 		});
+
 
 		it('should display percentile table with correct values', async () => {
 			renderSpanDetailsDrawer();


### PR DESCRIPTION
## 📄 Summary
Updated the span percentile UI text to be more concise and user-friendly as per issue #9583. Changed from verbose description to a clearer format showing percentile with duration.

---

## ✅ Changes
- [x] UI improvement: Updated span percentile description text
- [x] Bug fix: Updated corresponding test cases to match new text format

---

## 🏷️ Required: Add Relevant Labels
> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):
- `frontend`
- `ui`
- `enhancement`
- `traces`

---

## 👥 Reviewers
> Tag the relevant teams for review:
- @nityanandagohain (issue creator)
- frontend team

---

## 🧪 How to Test
1. Navigate to Traces section
2. Open any trace detail view
3. Look for the span percentile information
4. Verify the text now shows: "p77 (X.XX ms) — slower than 77% of recent spans for this operation in the last Xh"
5. Run the test suite to ensure tests pass

---

## 🔍 Related Issues
Fixes #9583

---

## 📋 Checklist
- [ ] Dev Review
- [x] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes (unable to run full stack locally)

---

## 👀 Notes for Reviewers
- Changed both the main display text and tooltip text
- Updated test expectations to match new format
- Duration formatting assumes nanoseconds to milliseconds conversion
- May need adjustment if duration format differs from assumption

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies span percentile tooltip and expanded text to a concise "pXX (X.XX ms) — slower than XX%..." format and updates tests to match.
> 
> - **Frontend (SpanDetailsDrawer)**
>   - Update span percentile tooltip and expanded content to concise format: `pXX (X.XX ms) — slower than XX% of recent spans ... in the last Xh`.
>   - Include duration display (ms) and reflect selected time range; adjust memo deps accordingly.
> - **Tests**
>   - Update assertions to match new text format (regex for `p\d+.*slower than`, etc.).
>   - Remove checks for old verbose strings; keep percentile table and interactions intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9118d5c9c7184deffbff076a7ec60f3c51003fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->