### PR TITLE
fix: make Quick filter and header sticky during scroll in traces/logs…

### DIFF
--- a/frontend/src/container/Toolbar/Toolbar.styles.scss
+++ b/frontend/src/container/Toolbar/Toolbar.styles.scss
@@ -2,6 +2,10 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: flex-end;
+	position: sticky;
+	top: 0;
+	z-index: 10;
+	background: var(--bg-ink-500);
 
 	border-top: 1px solid var(--bg-slate-400);
 	border-bottom: 1px solid var(--bg-slate-400);
@@ -23,7 +27,7 @@
 	}
 }
 
-@media screen and (width <= 1300px) {
+@media screen and (width <=1300px) {
 	.toolbar {
 		grid-template-columns: repeat(1, 1fr);
 
@@ -41,6 +45,7 @@
 
 .lightMode {
 	.toolbar {
+		background: var(--bg-vanilla-100);
 		border-top: 1px solid var(--bg-vanilla-300);
 		border-bottom: 1px solid var(--bg-vanilla-300);
 	}

--- a/frontend/src/pages/LogsExplorer/LogsExplorer.styles.scss
+++ b/frontend/src/pages/LogsExplorer/LogsExplorer.styles.scss
@@ -1,15 +1,21 @@
 .logs-module-page {
 	display: flex;
 	height: 100%;
+
 	.log-quick-filter-left-section {
 		width: 0%;
 		flex-shrink: 0;
+		position: sticky;
+		top: 0;
+		height: 100vh;
+		overflow-y: auto;
 	}
 
 	.log-module-right-section {
 		display: flex;
 		flex-direction: column;
 		width: 100%;
+
 		.log-explorer-query-container {
 			display: flex;
 			flex-direction: column;

--- a/frontend/src/pages/TracesExplorer/TracesExplorer.styles.scss
+++ b/frontend/src/pages/TracesExplorer/TracesExplorer.styles.scss
@@ -1,4 +1,9 @@
 .trace-explorer-header {
+	position: sticky;
+	top: 0;
+	z-index: 10;
+	background: var(--bg-ink-500);
+
 	.trace-explorer-run-query {
 		display: flex;
 		flex-direction: row-reverse;
@@ -69,14 +74,16 @@
 
 	.filter {
 		width: 260px;
-		height: 100%;
-		min-height: 100vh;
+		height: 100vh;
+		position: sticky;
+		top: 0;
+		overflow-y: auto;
 
 		border-right: 0px;
 		border: 1px solid var(--bg-slate-400);
 		background-color: var(--bg-ink-500);
 
-		> .ant-card-body {
+		>.ant-card-body {
 			padding: 0;
 			width: 258px;
 		}
@@ -86,12 +93,13 @@
 		width: 100%;
 		background: var(--bg-ink-500);
 
-		> .ant-card-body {
+		>.ant-card-body {
 			padding: 0;
 		}
 
 		border-color: var(--bg-slate-400);
 	}
+
 	.trace-explorer.filters-expanded {
 		width: calc(100% - 260px);
 	}
@@ -109,7 +117,7 @@
 			border-left: 1px solid var(--bg-vanilla-200);
 			background: var(--bg-vanilla-200);
 
-			> .ant-card-body {
+			>.ant-card-body {
 				padding: 8px 8px;
 			}
 
@@ -118,6 +126,8 @@
 	}
 
 	.trace-explorer-header {
+		background: var(--bg-vanilla-100);
+
 		.filter-outlined-btn {
 			border-radius: 0px 2px 2px 0px;
 			border-top: 1px solid var(--bg-vanilla-200);


### PR DESCRIPTION
fix: make Quick filter and header sticky during scroll in traces/logs explorer

- Added sticky positioning to Quick filter sidebar in both traces and logs explorer
- Made Toolbar header sticky with proper z-index and background colors
- Added overflow-y: auto to Quick filter for scrollable content
- Ensured proper background colors for both dark and light modes
- Fixes #9368

## 📄 Summary

This PR addresses issue #9368 where the Quick filter and header sections would scroll out of view in the Traces and Logs explorer pages. It implements sticky positioning for these elements to ensure they remain visible and accessible while scrolling through long lists of data, significantly improving the navigation experience.

---

## ✅ Changes

- [ ] Feature: Brief description
- [x] Bug fix: Made Quick filter sidebar and Header sticky in Traces and Logs explorer pages

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

- `frontend`
- `ui`
- `bug`
- `enhancement`

---

## 👥 Reviewers

@YounixM and @aks07 

- frontend

---

## 🧪 How to Test

1. Open the Traces Explorer page in the SigNoz UI.
2. Scroll vertically down the page.
3. Observe that the Quick Filter sidebar (on the left) and the Header/Toolbar (at the top) remain fixed and visible.
4. Navigate to the Logs Explorer page and repeat the scrolling test.
5. Switch between Light and Dark modes to ensure the background colors of the sticky elements are correct and underlying content does not show through.

---

## 🔍 Related Issues

Closes #9368


## 📋 Checklist

- [x] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes


---

## 👀 Notes for Reviewers

- Added `z-index: 10` to the header/toolbar to ensure it stays on top of the scrolling content.
- Added `overflow-y: auto` to the Quick Filter sidebar to ensure that if the filter list is longer than the viewport, it can still be scrolled independently.