### PR TITLE
fix: decimal precision 0 not saving

### DIFF
--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -504,7 +504,7 @@ function NewWidget({
 								stackedBarChart: selectedWidget?.stackedBarChart || false,
 								yAxisUnit: selectedWidget?.yAxisUnit,
 								decimalPrecision:
-									selectedWidget?.decimalPrecision || PrecisionOptionsEnum.TWO,
+									selectedWidget?.decimalPrecision ?? PrecisionOptionsEnum.TWO,
 								panelTypes: graphType,
 								query: adjustedQueryForV5,
 								thresholds: selectedWidget?.thresholds,
@@ -535,7 +535,7 @@ function NewWidget({
 								stackedBarChart: selectedWidget?.stackedBarChart || false,
 								yAxisUnit: selectedWidget?.yAxisUnit,
 								decimalPrecision:
-									selectedWidget?.decimalPrecision || PrecisionOptionsEnum.TWO,
+									selectedWidget?.decimalPrecision ?? PrecisionOptionsEnum.TWO,
 								panelTypes: graphType,
 								query: adjustedQueryForV5,
 								thresholds: selectedWidget?.thresholds,


### PR DESCRIPTION
## 📄 Summary

This PR fixes a bug where setting the decimal precision to `0` in a dashboard panel would not be saved, causing it to revert to the default value of `2`. The issue was caused by the value `0` being treated as falsy in a logical OR operation.

---

## ✅ Changes

- [ ] Feature: Brief description
- [x] Bug fix: Fix decimal precision not persisting when set to 0

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

- `frontend`
- `bug`
- `ui`

---

## 👥 Reviewers

> Tag the relevant teams for review:
- @YounixM 
- @aks07


---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. Create a new Dashboard or edit an existing one.
2. Add or edit a **Time Series** panel.
3. In the right-side configuration panel, locate the **Decimal Precision** setting.
4. Change the value to **0 decimals**.
5. Save the panel and save the dashboard.
6. Refresh the page or re-open the panel configuration.
7. **Verify:** The Decimal Precision should remain set to **0 decimals** (previously it would revert to 2).

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #9542

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->
_N/A - Logic fix for state persistence_

---

## 📋 Checklist

- [x] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->
The fix involves replacing the logical OR operator (`||`) with the nullish coalescing operator (`??`) for the `decimalPrecision` field. This ensures that `0` is treated as a valid value and not falsy, while still providing a fallback for `null` or `undefined`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 0d5a4d72a7a041dce8f767df6536fe6f454f46a1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->