### PR TITLE
chore: fix error in http_handler for get ttl

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -2000,9 +2000,8 @@ func (aH *APIHandler) getTTL(w http.ResponseWriter, r *http.Request) {
 		render.Error(w, err)
 		return
 	}
-	result, err := aH.reader.GetTTL(r.Context(), claims.OrgID, ttlParams)
-	if err != nil {
-		render.Error(w, err)
+	result, apiErr := aH.reader.GetTTL(r.Context(), claims.OrgID, ttlParams)
+	if apiErr != nil && aH.HandleError(w, apiErr.Err, http.StatusInternalServerError) {
 		return
 	}
 	aH.WriteJSON(w, r, result)


### PR DESCRIPTION
Since the errors are different go back to using different variables.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes error handling in `getTTL` to use `apiErr` and `HandleError` with 500, aligning with existing patterns.
> 
> - **Backend (query-service)**:
>   - Standardizes error handling in `getTTL` by using `apiErr` from `reader.GetTTL` and routing via `aH.HandleError(..., http.StatusInternalServerError)` instead of direct `render.Error`.
>   - Minor variable renaming to avoid conflict and align with existing `getDisks` pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1eda5c212d7768a7e416f39314ff29de4f057a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->