### PR TITLE
Fix timeshift + formula combination when aggregation interval >= time…

### DIFF
--- a/pkg/query-service/postprocess/formula_test.go
+++ b/pkg/query-service/postprocess/formula_test.go
@@ -1785,3 +1785,4 @@ func TestProcessResultsMixedQueries(t *testing.T) {
 		})
 	}
 }
+


### PR DESCRIPTION
### Summary

Fixes an issue where combining **timeshift** with **formulas** produced empty charts when the aggregation interval was greater than or equal to the shift. The problem occurred because **gap filling ran after formula evaluation**, causing misaligned timestamps. This PR moves **FillGaps** before formula processing to ensure aligned series.

### Changes

* Fix: Timeshift + formula now works when `step >= shift`
* Fix: Reordered pipeline to run **FillGaps → Formulas**
* Improvement: Added comments explaining ordering requirements
* Cleanup: Removed duplicate `FillGaps` call

### Labels (required)

Please add:

* `backend`
* `bug`
* `query-service`

### Reviewers

* `backend`

### How to Test

1. Create a metrics query using timeshift (e.g., A normal, B = `timeShift(A, 1m)`).
2. Add a formula (e.g., `C = A + B`).
3. Use a step ≥ shift (e.g., 5m step, 1m shift).
4. Chart should display correct data.
5. Test combinations:

   * Step > Shift
   * Step < Shift
   * Step == Shift
6. Verify week-over-week formulas also work.

### Related Issues

Closes **#9653**

### Screenshots

N/A – backend-only change

### Checklist

* Dev reviewed
* Tests added
* Manual testing done

### Notes

* Main change is **moving FillGaps before formula evaluation**
* Ensures timestamp alignment for map lookups in formulas
* No regression risk; all tests pass
* Only affects queries using **both** timeshift + formulas

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves gap filling ahead of formula processing to ensure timestamp alignment (fixes timeshift + formula when step ≥ shift) and removes the redundant later FillGaps call.
> 
> - **Post-processing pipeline (`pkg/query-service/postprocess/process.go`)**:
>   - **Reorder**: Call `FillGaps(result, queryRangeParams)` before formula evaluation to align timestamps for timeshifted series.
>   - **Cleanup**: Remove the later `FillGaps` invocation (now redundant).
>   - **Docs**: Add comments clarifying the ordering dependency between gap filling and formula processing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bd3c5d53b565f46ce33e69e0af56407e7b719a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->