### PR TITLE
style: updated subdomain already exists UI error on 409

### DIFF
--- a/frontend/src/container/CustomDomainSettings/CustomDomainSettings.tsx
+++ b/frontend/src/container/CustomDomainSettings/CustomDomainSettings.tsx
@@ -143,8 +143,6 @@ export default function CustomDomainSettings(): JSX.Element {
 		});
 	};
 
-	console.log('updateDomainError', updateDomainError);
-
 	return (
 		<div className="custom-domain-settings-container">
 			<div className="custom-domain-settings-content">
@@ -270,7 +268,7 @@ export default function CustomDomainSettings(): JSX.Element {
 								<Alert
 									message={
 										(updateDomainError?.response?.data as { error?: string })?.error ||
-										'Team’s URL: composed-tarpon subdomain name is taken, please try another one.'
+										'You’ve already updated the custom domain once today. To make further changes, please contact our support team for assistance.'
 									}
 									type="warning"
 									className="update-limit-reached-error"


### PR DESCRIPTION
## 📄 Summary

<!-- 
When a user tries to update to a subdomain that is already taken, the UI incorrectly displays the message "You've already updated the custom domain..." instead of showing the actual error returned by the backend.
We need to update the frontend logic to display the backend-provided error message correctly.
-->

---

## ✅ Changes

- [x] Feature: When a user tries to update to a subdomain that is already taken, the UI incorrectly displays the message "You've already updated the custom domain..." instead of showing the actual error returned by the backend.
- [x] Bug fix: In the fix, we now correctly read and display the error message returned from the backend’s response.

---


## 👥 Reviewers

> Tag the relevant teams for review:

- frontend 

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. Open the custom domain settings page: https://app.us.staging.signoz.cloud/settings/custom-domain-settings
2. In the left panel, go to Custom Domain.
3. Click Customize Team URL.
4. Enter a subdomain name that already exists (same as the current tenant’s subdomain).
  Before the fix: The UI incorrectly showed the static message: "You’ve already updated the custom domain once today. To make further changes, please contact our support team for assistance."
  After the fix: You should now see the actual error returned from the backend

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes # https://github.com/SigNoz/engineering-pod/issues/3288

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

Before : 

<img width="1728" height="1080" alt="Screenshot 2025-11-24 at 10 07 27 AM" src="https://github.com/user-attachments/assets/8b90d66d-142d-4e21-9d3e-468502d0992c" />



After

<img width="1728" height="1117" alt="Screenshot 2025-11-24 at 12 29 42 PM" src="https://github.com/user-attachments/assets/6ece2a8d-2aa7-4f1a-ab5b-2bc6acc60701" />

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Display backend-provided error for 409 conflicts when updating custom domain, with fallback to the previous static message.
> 
> - **Frontend**
>   - **Error handling in `frontend/src/container/CustomDomainSettings/CustomDomainSettings.tsx`**:
>     - For `409` responses, the `Alert` now displays `response.data.error` when available, falling back to the prior static message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb803411b246326761b6ffaa057e257537da4859. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->