### PR TITLE
fix: Correct aggregation payload for Services view panel click (#9676)

### DIFF
--- a/frontend/src/api/v5/queryRange/prepareQueryRangePayloadV5.ts
+++ b/frontend/src/api/v5/queryRange/prepareQueryRangePayloadV5.ts
@@ -297,6 +297,21 @@ export function createAggregation(
 		);
 	}
 
+	// For TRACES/LOGS queries, if aggregations array is not present but aggregateAttribute and aggregateOperator/spaceAggregation exist,
+	// construct the aggregation expression from these fields
+	if (queryData.aggregateAttribute?.key) {
+		const aggregateOperator =
+			queryData.aggregateOperator || queryData.spaceAggregation;
+		if (aggregateOperator) {
+			// Convert aggregateOperator to lowercase for the expression (e.g., P50 -> p50)
+			const operator = aggregateOperator.toLowerCase();
+			const fieldKey = queryData.aggregateAttribute.key;
+			// Construct expression like "p50(duration_nano)"
+			const expression = `${operator}(${fieldKey})`;
+			return [{ expression }];
+		}
+	}
+
 	return [{ expression: 'count()' }];
 }
 


### PR DESCRIPTION
## Description

Fixes the incorrect payload sent to the v5 `/query_range` API when clicking the "view panel" button in the Services section. The view panel was sending `count()` as the aggregation expression instead of the correct percentile aggregations like `p50(duration_nano)`, `p90(duration_nano)`, and `p99(duration_nano)`.

## Problem

When viewing the Services section:
- The overview page correctly uses `/v4/query_range` API with proper aggregations: `p50(durationNano)`, `p90(durationNano)`, `p99(durationNano)`
- However, clicking the "view panel" button calls `/v5/query_range` API with incorrect payload containing `count()` instead of the proper aggregation expressions

**Incorrect Payload (Before Fix):**
{
  "legend": "p50",
  "aggregations": [
    {
      "expression": "count()"
    }
  ]
}**Expected Payload (After Fix):**
{
  "legend": "p50",
  "aggregations": [
    {
      "expression": "p50(duration_nano)"
    }
  ]
}## Root Cause

The `createAggregation` function in `prepareQueryRangePayloadV5.ts` only handled:
1. METRICS data source queries (which have different structure)
2. TRACES/LOGS queries with an existing `aggregations` array

It did not handle TRACES/LOGS queries that have:
- `aggregateAttribute` (e.g., `duration_nano`)
- `aggregateOperator` or `spaceAggregation` (e.g., `p50`, `p90`, `p99`)
- But no `aggregations` array

In such cases, it defaulted to `count()`, causing the bug.

## Solution

Added logic in `createAggregation` to construct aggregation expressions from `aggregateAttribute` and `aggregateOperator`/`spaceAggregation` when the `aggregations` array is not present:
cript
// For TRACES/LOGS queries, if aggregations array is not present but aggregateAttribute and aggregateOperator/spaceAggregation exist,
// construct the aggregation expression from these fields
if (queryData.aggregateAttribute?.key) {
  const aggregateOperator = queryData.aggregateOperator || queryData.spaceAggregation;
  if (aggregateOperator) {
    const operator = aggregateOperator.toLowerCase();
    const fieldKey = queryData.aggregateAttribute.key;
    const expression = `${operator}(${fieldKey})`;
    return [{ expression }];
  }
}## Changes Made

- Modified `frontend/src/api/v5/queryRange/prepareQueryRangePayloadV5.ts`
  - Enhanced `createAggregation` function to handle TRACES/LOGS queries with `aggregateAttribute` and `aggregateOperator`/`spaceAggregation`
  - Constructs proper aggregation expressions like `p50(duration_nano)` instead of defaulting to `count()`

## Testing

### How to Reproduce
1. Navigate to Services section
2. Click on a service to view its details
3. Check the payload for calls to `/v4/query_range` - note the correct aggregations
4. Click on "view" button for a latency panel
5. Check the payload for calls to `/v5/query_range` - should now have correct aggregations

### Expected Behavior
- View panel click should send correct aggregation expressions matching the overview page
- Aggregations should be `p50(duration_nano)`, `p90(duration_nano)`, `p99(duration_nano)` instead of `count()`

## Related Issue

Fixes #9676

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Build aggregation expression for traces/logs from operator and attribute when `aggregations` is missing, fixing incorrect default to `count()` in V5 payloads.
> 
> - **API (V5 query_range)**:
>   - In `frontend/src/api/v5/queryRange/prepareQueryRangePayloadV5.ts` → `createAggregation` now constructs trace/log aggregation expressions (e.g., `p50(duration_nano)`) from `aggregateOperator|spaceAggregation` and `aggregateAttribute.key` when `aggregations` is absent, instead of defaulting to `count()`.
>   - Existing metrics handling and parsed `aggregations` logic retained; falls back to `count()` only if no operator/attribute found.
> 
