### PR TITLE
fix: prevent quick filters skeleton from rendering outside container

### DIFF
--- a/frontend/src/components/QuickFilters/QuickFilters.styles.scss
+++ b/frontend/src/components/QuickFilters/QuickFilters.styles.scss
@@ -99,8 +99,11 @@
 	}
 
 	.quick-filters-skeleton {
+		overflow: hidden;
+
 		.ant-skeleton-input {
 			width: 236px;
+			max-width: calc(100% - 24px);
 			margin: 8px 12px;
 		}
 	}


### PR DESCRIPTION
## Summary
Fixed the loading skeleton in External APIs Quick Filters that was rendering outside its container.

## Changes
- Added `overflow: hidden` to `.quick-filters-skeleton` container
- Added `max-width: calc(100% - 24px)` to skeleton inputs to respect container boundaries

## Screenshot
Before: Skeleton inputs overflow the quick filters container
After: Skeleton inputs stay within container bounds

Fixes #9401

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Constrain Quick Filters loading skeleton to its container by hiding overflow and limiting skeleton input width.
> 
> - **UI — Quick Filters**:
>   - `.quick-filters-skeleton`: add `overflow: hidden` to prevent visual overflow.
>   - `.ant-skeleton-input`: add `max-width: calc(100% - 24px)` to keep inputs within container while retaining margins.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2602801bf263872021600154498cc771193872a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->