### PR TITLE
fix: add cursor pointer on domain rows hover in External APIs

### DIFF
--- a/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
+++ b/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
@@ -147,6 +147,10 @@
 			.error-rate {
 				width: 120px;
 			}
+
+			.expanded-clickable-row {
+				cursor: pointer;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
Added cursor: pointer style to domain rows in External APIs table to indicate they are clickable.

## Changes
- Added `.expanded-clickable-row { cursor: pointer; }` to Explorer.styles.scss

Fixes #9403

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `cursor: pointer` to `.expanded-clickable-row` in `Explorer.styles.scss` to indicate clickable domain rows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8586c89f1cc4a8ceca4634e7c618b2555ef965d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->