### PR TITLE
fix: normalize version strings for proper comparison on status page

### DIFF
--- a/frontend/src/utils/app.ts
+++ b/frontend/src/utils/app.ts
@@ -18,8 +18,9 @@ export const checkVersionState = (
 	currentVersion: string,
 	latestVersion: string,
 ): boolean => {
-	const versionCore = currentVersion?.split('-')[0];
-	return versionCore === latestVersion;
+	const normalizeVersion = (v: string): string =>
+		v?.replace(/^v/, '').split('-')[0];
+	return normalizeVersion(currentVersion) === normalizeVersion(latestVersion);
 };
 
 // list of forbidden tags to remove in dompurify


### PR DESCRIPTION
## Summary
Fixed the /status page incorrectly showing upgrade available when versions match but have different 'v' prefix formatting.

## Problem
When current version is `v0.76.2` and latest version is `0.76.2` (or vice versa), the comparison fails due to the 'v' prefix difference.

## Solution
Normalize version strings by removing 'v' prefix before comparison.

## Changes
- Updated `checkVersionState` function in `utils/app.ts` to strip 'v' prefix from both versions

Fixes #7484

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize version comparison by stripping leading "v" and prerelease suffix from both versions to prevent false upgrade prompts.
> 
> - **Utils**:
>   - **Version Check**: Update `checkVersionState` in `frontend/src/utils/app.ts` to normalize versions (strip leading `v`, ignore `-` suffix) before comparison.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2000234a5a2a3523b1cc2e3596ab8c62a193fd8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->