### PR TITLE
feat: make URLs in dashboard description clickable

### DIFF
--- a/frontend/src/container/NewDashboard/DashboardDescription/Description.styles.scss
+++ b/frontend/src/container/NewDashboard/DashboardDescription/Description.styles.scss
@@ -260,6 +260,15 @@
 		line-height: 22px; /* 157.143% */
 		letter-spacing: -0.07px;
 		padding: 20px 16px 0px 16px;
+
+		.dashboard-description-link {
+			color: var(--bg-robin-400);
+			text-decoration: underline;
+
+			&:hover {
+				color: var(--bg-robin-300);
+			}
+		}
 	}
 
 	.dashboard-variables {
@@ -637,6 +646,14 @@
 
 		.dashboard-description-section {
 			color: var(--bg-ink-400);
+
+			.dashboard-description-link {
+				color: var(--bg-robin-500);
+
+				&:hover {
+					color: var(--bg-robin-400);
+				}
+			}
 		}
 	}
 	.dashboard-settings {

--- a/frontend/src/container/NewDashboard/DashboardDescription/index.tsx
+++ b/frontend/src/container/NewDashboard/DashboardDescription/index.tsx
@@ -37,7 +37,7 @@ import {
 import { useAppContext } from 'providers/App/App';
 import { useDashboard } from 'providers/Dashboard/Dashboard';
 import { sortLayout } from 'providers/Dashboard/util';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { FullScreenHandle } from 'react-full-screen';
 import { Layout } from 'react-grid-layout';
 import { useTranslation } from 'react-i18next';
@@ -49,6 +49,7 @@ import { ComponentTypes } from 'utils/permission';
 import { v4 as uuid } from 'uuid';
 
 import DashboardGraphSlider from '../ComponentsSlider';
+import { linkifyText } from './utils';
 import { Base64Icons } from '../DashboardSettings/General/utils';
 import DashboardVariableSelection from '../DashboardVariablesSelection';
 import SettingsDrawer from './SettingsDrawer';
@@ -476,7 +477,9 @@ function DashboardDescription(props: DashboardDescriptionProps): JSX.Element {
 				</div>
 			)}
 			{!isEmpty(description) && (
-				<section className="dashboard-description-section">{description}</section>
+				<section className="dashboard-description-section">
+					{linkifyText(description)}
+				</section>
 			)}
 
 			{!isEmpty(selectedData.variables) && (

--- a/frontend/src/container/NewDashboard/DashboardDescription/utils.tsx
+++ b/frontend/src/container/NewDashboard/DashboardDescription/utils.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 export function downloadObjectAsJson(
 	exportObj: unknown,
 	exportName: string,
@@ -14,3 +16,25 @@ export function downloadObjectAsJson(
 }
 
 export const DEFAULT_ROW_NAME = 'Sample Row';
+
+export function linkifyText(text: string): ReactNode[] {
+	const urlRegex = /(https?:\/\/[^\s]+)/g;
+	const parts = text.split(urlRegex);
+
+	return parts.map((part, index) => {
+		if (part.match(urlRegex)) {
+			return (
+				<a
+					key={`link-${index}`}
+					href={part}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="dashboard-description-link"
+				>
+					{part}
+				</a>
+			);
+		}
+		return part;
+	});
+}


### PR DESCRIPTION
## Summary
URLs pasted in dashboard description are now clickable links.

## Problem
When users paste URLs in dashboard description, they appear as plain text and are not usable.

## Solution
Added a `linkifyText` utility function that:
- Detects URLs (http/https) in the description text
- Converts them to clickable `<a>` tags
- Opens links in new tab with `target="_blank"`
- Adds proper security attributes (`rel="noopener noreferrer"`)

## Changes
- Renamed `utils.ts` to `utils.tsx` to support JSX
- Added `linkifyText` function
- Updated description rendering to use linkifyText
- Added link styling for both dark and light modes

Fixes #5256

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Convert URLs in dashboard descriptions to clickable links with theme-aware styling.
> 
> - **Dashboard Description**:
>   - Render `description` using `linkifyText(description)` in `frontend/src/container/NewDashboard/DashboardDescription/index.tsx` to convert URLs to clickable links (opens in new tab with safe attrs).
> - **Utilities**:
>   - Add `linkifyText` in `frontend/src/container/NewDashboard/DashboardDescription/utils.tsx` to detect `http/https` URLs and return linkified parts.
> - **Styles**:
>   - Add `.dashboard-description-link` styles (hover states) under `.dashboard-description-section` for dark and light modes in `frontend/src/container/NewDashboard/DashboardDescription/Description.styles.scss`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6069d0246d0d79d3131ce114804087e3da993178. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->