### PR TITLE
ci: enable staticcheck and godot linters in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,12 +6,14 @@ linters:
     - depguard
     - errcheck
     - forbidigo
+    - godot
     - govet
     - iface
     - ineffassign
     - misspell
     - nilnil
     - sloglint
+    - staticcheck
     - unparam
     - unused
   settings:


### PR DESCRIPTION
## Summary
Enabled `staticcheck` and `godot` linters in golangci-lint configuration as requested.

## Changes
- Added `staticcheck` for advanced static analysis
- Added `godot` for comment period checking

## Notes
- Using golangci-lint v2.6.0 config format
- Excluded paths remain unchanged as specified in the issue

Fixes #9446

---
**Note:** If CI fails due to new lint errors, I can help fix them in follow-up commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `staticcheck` and `godot` linters in `.golangci.yml`.
> 
> - **CI/Lint**:
>   - **golangci-lint config** (`.golangci.yml`):
>     - Add `godot` and `staticcheck` to `linters.enable`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f8d3610a43cb8790f188b559c5dd87d724f7847. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->