### PR TITLE
fix: filter expression not being sent on reconnect

### DIFF
--- a/frontend/src/container/LiveLogs/LiveLogsContainer/index.tsx
+++ b/frontend/src/container/LiveLogs/LiveLogsContainer/index.tsx
@@ -175,7 +175,18 @@ function LiveLogsContainer(): JSX.Element {
 		if (isConnectionError && reconnectDueToError) {
 			// Small delay to prevent immediate reconnection attempts
 			const reconnectTimer = setTimeout(() => {
-				handleStartNewConnection();
+				const fallbackFilterExpression =
+					prevFilterExpressionRef.current ||
+					currentQuery?.builder.queryData[0]?.filter?.expression?.trim() ||
+					null;
+
+				const validationResult = validateQuery(fallbackFilterExpression || '');
+
+				if (validationResult.isValid) {
+					handleStartNewConnection(fallbackFilterExpression);
+				} else {
+					handleStartNewConnection(null);
+				}
 			}, 1000);
 
 			return (): void => clearTimeout(reconnectTimer);
@@ -186,6 +197,7 @@ function LiveLogsContainer(): JSX.Element {
 		reconnectDueToError,
 		compositeQuery,
 		handleStartNewConnection,
+		currentQuery,
 	]);
 
 	// clean up the connection when the component unmounts


### PR DESCRIPTION
Issue: Live logs reconnects were calling handleStartNewConnection() without arguments, so the SSE fallback URL always opened with an empty filter query when a connection error triggered a retry. 

Fix: The reconnect effect now reuses the latest validated filter (falling back to the current query expression if the ref is empty) before restarting the stream, ensuring the filter survives token-refresh reconnects.