### PR TITLE
fix: populate metric Type for exponential histogram queries

### DIFF
--- a/pkg/types/telemetrytypes/store.go
+++ b/pkg/types/telemetrytypes/store.go
@@ -30,4 +30,7 @@ type MetadataStore interface {
 
 	// FetchTemporalityMulti fetches the temporality for multiple metrics
 	FetchTemporalityMulti(ctx context.Context, metricNames ...string) (map[string]metrictypes.Temporality, error)
+
+	// FetchTypeMulti fetches the type for multiple metrics (e.g., Gauge, Sum, Histogram, ExponentialHistogram)
+	FetchTypeMulti(ctx context.Context, metricNames ...string) (map[string]metrictypes.Type, error)
 }

--- a/pkg/types/telemetrytypes/telemetrytypestest/metadata_store.go
+++ b/pkg/types/telemetrytypes/telemetrytypestest/metadata_store.go
@@ -15,6 +15,7 @@ type MockMetadataStore struct {
 	RelatedValuesMap map[string][]string
 	AllValuesMap     map[string]*telemetrytypes.TelemetryFieldValues
 	TemporalityMap   map[string]metrictypes.Temporality
+	TypeMap          map[string]metrictypes.Type
 }
 
 // NewMockMetadataStore creates a new instance of MockMetadataStore with initialized maps
@@ -24,6 +25,7 @@ func NewMockMetadataStore() *MockMetadataStore {
 		RelatedValuesMap: make(map[string][]string),
 		AllValuesMap:     make(map[string]*telemetrytypes.TelemetryFieldValues),
 		TemporalityMap:   make(map[string]metrictypes.Temporality),
+		TypeMap:          make(map[string]metrictypes.Type),
 	}
 }
 
@@ -283,4 +285,24 @@ func (m *MockMetadataStore) FetchTemporalityMulti(ctx context.Context, metricNam
 // SetTemporality sets the temporality for a metric in the mock store
 func (m *MockMetadataStore) SetTemporality(metricName string, temporality metrictypes.Temporality) {
 	m.TemporalityMap[metricName] = temporality
+}
+
+// FetchTypeMulti fetches the type for multiple metrics
+func (m *MockMetadataStore) FetchTypeMulti(ctx context.Context, metricNames ...string) (map[string]metrictypes.Type, error) {
+	result := make(map[string]metrictypes.Type)
+
+	for _, metricName := range metricNames {
+		if mtype, exists := m.TypeMap[metricName]; exists {
+			result[metricName] = mtype
+		} else {
+			result[metricName] = metrictypes.UnspecifiedType
+		}
+	}
+
+	return result, nil
+}
+
+// SetType sets the type for a metric in the mock store
+func (m *MockMetadataStore) SetType(metricName string, mtype metrictypes.Type) {
+	m.TypeMap[metricName] = mtype
 }


### PR DESCRIPTION
Summary

Fixes Query Builder UI returning empty results for ExponentialHistogram metrics. The MetricAggregation.Type field was never being populated from metadata, causing exponential histogram queries to route to the wrong table (samples instead of exp_hist).

---
Changes

- Bug fix: Add FetchTypeMulti method to MetadataStore interface to fetch metric types
- Bug fix: Implement type fetching from metrics metadata table in telemetrymetadata
- Bug fix: Populate Type field in querier alongside existing Temporality enrichment
- Bug fix: Update mock store for testing

---
Required: Add Relevant Labels

- backend
- bug

---
Reviewers

- backend

---
How to Test

1. Ingest ExponentialHistogram metrics (e.g., via OTEL collector with enable_exp_hist: true)
2. Open Query Builder in SigNoz UI
3. Select an ExponentialHistogram metric from the dropdown
4. Choose an aggregation (P50, P95, P99)
5. Run query - should now return data (previously returned empty results)
6. Verify regular histogram/gauge/sum metrics still work correctly

---
🔍 Related Issues

N/A

---
Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

Would previously return empty results for ExponentialHistogram.
<img width="1185" height="940" alt="image" src="https://github.com/user-attachments/assets/3131129d-f76e-479a-8e65-941ae4224d98" />

---
Checklist

- Dev Review
- Test cases added (Unit/ Integration / E2E)
- Manually tested the changes

---
Notes for Reviewers

Root Cause

1. MetricAggregation.Type has json:"-" tag in builder_elements.go:25, so it cannot be deserialized from frontend JSON requests
2. The querier (pkg/querier/querier.go) enriches Temporality from metadata but never fetches or populates Type
3. The routing logic in sub_query.go:98 that checks if mq.AggregateAttribute.Type == v3.AttributeKeyType(v3.MetricTypeExponentialHistogram) never triggers
4. Queries go to the regular samples table instead of exp_hist, returning no data

Solution

Follow the same pattern already used for Temporality enrichment - fetch Type from metadata and populate it before query execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fetches metric `Type` for all referenced metrics and injects it into builder aggregations; adds `FetchTypeMulti` to metadata store with ClickHouse implementation and test mock support.
> 
> - **Querier (`pkg/querier/querier.go`)**:
>   - Fetches metric `Type` for all referenced metrics via `metadataStore.FetchTypeMulti`.
>   - Populates missing `MetricAggregation.Type` from fetched metadata alongside existing temporality enrichment.
> - **Telemetry Metadata (`pkg/telemetrymetadata/metadata.go`)**:
>   - Adds `FetchTypeMulti` and underlying `fetchMetricsType` querying `metrics_fields` (uses `argMax(type, last_reported_unix_milli)`).
>   - Maps string types to `metrictypes.Type` (e.g., gauge, sum, histogram, exponentialhistogram).
> - **Types/Interfaces (`pkg/types/telemetrytypes/store.go`)**:
>   - Extends `MetadataStore` with `FetchTypeMulti`.
> - **Tests/Mocks (`pkg/types/telemetrytypes/telemetrytypestest/metadata_store.go`)**:
>   - Adds `TypeMap`, `FetchTypeMulti`, and `SetType` to mock store.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abbd6a5867dbf6b697c3a333e26461759e28aa70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->