### PR TITLE
fix: setup the acs url while creating saml client

### DIFF
--- a/tests/integration/fixtures/idputils.py
+++ b/tests/integration/fixtures/idputils.py
@@ -71,6 +71,7 @@ def create_saml_client(
                     "saml_signature_canonicalization_method": "http://www.w3.org/2001/10/xml-exc-c14n#",
                     "saml.onetimeuse.condition": "false",
                     "saml.server.signature.keyinfo.xmlSigKeyInfoKeyNameTransformer": "NONE",
+                    "saml_assertion_consumer_url_post": urljoin(f"{signoz.self.host_configs['8080'].base()}", callback_path)
                 },
                 "authenticationFlowBindingOverrides": {},
                 "fullScopeAllowed": True,

--- a/tests/integration/src/callbackauthn/b_saml.py
+++ b/tests/integration/src/callbackauthn/b_saml.py
@@ -93,8 +93,7 @@ def test_create_auth_domain(
         f"{signoz.self.host_configs['8080'].address}:{signoz.self.host_configs['8080'].port}",
         {
             "saml_idp_initiated_sso_url_name": "idp-initiated-saml-test",
-            "saml_idp_initiated_sso_relay_state": relay_state_url,
-            "saml_assertion_consumer_url_post": signoz.self.host_configs["8080"].get("/api/v1/complete/saml")
+            "saml_idp_initiated_sso_relay_state": relay_state_url
         }
     )
 


### PR DESCRIPTION
## 📄 Summary

Set the ACS URL while creating SAML Client in integration tests.

---

## ✅ Changes

- [x] Fix: Set the SAML ACS URL while creating SAML Client in Test Keycloak instead of setting it while updating the client for IdP setup

---

## 🏷️ Required: Add Relevant Labels

> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

ex:

- `frontend`
- `backend`
- `devops`
- `bug`
- `enhancement`
- `ui`
- `test`

---

## 👥 Reviewers

> Tag the relevant teams for review:

- frontend / backend / devops

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. ...
2. ...
3. ...

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->
