### PR TITLE
chore: update tests

### DIFF
--- a/pkg/prometheus/prometheustest/provider.go
+++ b/pkg/prometheus/prometheustest/provider.go
@@ -1,55 +1,42 @@
 package prometheustest
 
 import (
-	"log/slog"
-	"os"
-	"time"
+	"context"
 
+	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/prometheus"
+	"github.com/SigNoz/signoz/pkg/prometheus/clickhouseprometheus"
+	"github.com/SigNoz/signoz/pkg/telemetrystore"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/storage/remote"
 )
 
 var _ prometheus.Prometheus = (*Provider)(nil)
 
 type Provider struct {
-	db     *tsdb.DB
-	dir    string
-	engine *prometheus.Engine
+	queryable storage.SampleAndChunkQueryable
+	engine    *prometheus.Engine
 }
 
-func New(logger *slog.Logger, cfg prometheus.Config, outOfOrderTimeWindow ...int64) *Provider {
-	dir, err := os.MkdirTemp("", "test_storage")
-	if err != nil {
-		panic(err)
-	}
+var stCallback = func() (int64, error) {
+	return int64(model.Latest), nil
+}
 
-	// Tests just load data for a series sequentially. Thus we
-	// need a long appendable window.
-	opts := tsdb.DefaultOptions()
-	opts.MinBlockDuration = int64(24 * time.Hour / time.Millisecond)
-	opts.MaxBlockDuration = int64(24 * time.Hour / time.Millisecond)
-	opts.RetentionDuration = 0
-	opts.EnableNativeHistograms = true
+func New(ctx context.Context, providerSettings factory.ProviderSettings, config prometheus.Config, telemetryStore telemetrystore.TelemetryStore) *Provider {
 
-	// Set OutOfOrderTimeWindow if provided, otherwise use default (0)
-	if len(outOfOrderTimeWindow) > 0 {
-		opts.OutOfOrderTimeWindow = outOfOrderTimeWindow[0]
-	} else {
-		opts.OutOfOrderTimeWindow = 0 // Default value is zero
-	}
+	settings := factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/prometheus/prometheustest")
 
-	db, err := tsdb.Open(dir, nil, nil, opts, tsdb.NewDBStats())
-	if err != nil {
-		panic(err)
-	}
+	engine := prometheus.NewEngine(settings.Logger(), config)
 
-	engine := prometheus.NewEngine(logger, cfg)
+	readClient := clickhouseprometheus.NewReadClient(settings, telemetryStore)
+
+	queryable := remote.NewSampleAndChunkQueryableClient(readClient, labels.EmptyLabels(), []*labels.Matcher{}, false, stCallback)
 
 	return &Provider{
-		db:     db,
-		dir:    dir,
-		engine: engine,
+		engine:    engine,
+		queryable: queryable,
 	}
 }
 
@@ -58,17 +45,9 @@ func (provider *Provider) Engine() *prometheus.Engine {
 }
 
 func (provider *Provider) Storage() storage.Queryable {
-	return provider.db
-}
-
-// DB returns the underlying TSDB instance for testing purposes
-func (provider *Provider) DB() *tsdb.DB {
-	return provider.db
+	return provider.queryable
 }
 
 func (provider *Provider) Close() error {
-	if err := provider.db.Close(); err != nil {
-		return err
-	}
-	return os.RemoveAll(provider.dir)
+	return nil
 }

--- a/pkg/query-service/rules/threshold_rule_test.go
+++ b/pkg/query-service/rules/threshold_rule_test.go
@@ -488,7 +488,7 @@ func TestThresholdRuleEvalDelay(t *testing.T) {
 		AlertName: "Test Eval Delay",
 		AlertType: ruletypes.AlertTypeMetric,
 		RuleType:  ruletypes.RuleTypeThreshold,
-		Evaluation: &ruletypes.EvaluationEnvelope{ruletypes.RollingEvaluation, ruletypes.RollingWindow{
+		Evaluation: &ruletypes.EvaluationEnvelope{Kind: ruletypes.RollingEvaluation, Spec: ruletypes.RollingWindow{
 			EvalWindow: ruletypes.Duration(5 * time.Minute),
 			Frequency:  ruletypes.Duration(1 * time.Minute),
 		}},
@@ -551,7 +551,7 @@ func TestThresholdRuleClickHouseTmpl(t *testing.T) {
 		AlertName: "Tricky Condition Tests",
 		AlertType: ruletypes.AlertTypeMetric,
 		RuleType:  ruletypes.RuleTypeThreshold,
-		Evaluation: &ruletypes.EvaluationEnvelope{ruletypes.RollingEvaluation, ruletypes.RollingWindow{
+		Evaluation: &ruletypes.EvaluationEnvelope{Kind: ruletypes.RollingEvaluation, Spec: ruletypes.RollingWindow{
 			EvalWindow: ruletypes.Duration(5 * time.Minute),
 			Frequency:  ruletypes.Duration(1 * time.Minute),
 		}},
@@ -620,7 +620,7 @@ func TestThresholdRuleUnitCombinations(t *testing.T) {
 		AlertName: "Units test",
 		AlertType: ruletypes.AlertTypeMetric,
 		RuleType:  ruletypes.RuleTypeThreshold,
-		Evaluation: &ruletypes.EvaluationEnvelope{ruletypes.RollingEvaluation, ruletypes.RollingWindow{
+		Evaluation: &ruletypes.EvaluationEnvelope{Kind: ruletypes.RollingEvaluation, Spec: ruletypes.RollingWindow{
 			EvalWindow: ruletypes.Duration(5 * time.Minute),
 			Frequency:  ruletypes.Duration(1 * time.Minute),
 		}},
@@ -784,7 +784,7 @@ func TestThresholdRuleUnitCombinations(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		reader := clickhouseReader.NewReader(nil, telemetryStore, prometheustest.New(instrumentationtest.New().Logger(), prometheus.Config{}), "", time.Duration(time.Second), nil, readerCache, options)
+		reader := clickhouseReader.NewReader(nil, telemetryStore, prometheustest.New(context.Background(), instrumentationtest.New().ToProviderSettings(), prometheus.Config{}, telemetryStore), "", time.Duration(time.Second), nil, readerCache, options)
 		rule, err := NewThresholdRule("69", valuer.GenerateUUID(), &postableRule, reader, nil, logger)
 		rule.TemporalityMap = map[string]map[v3.Temporality]bool{
 			"signoz_calls_total": {
@@ -821,7 +821,7 @@ func TestThresholdRuleNoData(t *testing.T) {
 		AlertName: "No data test",
 		AlertType: ruletypes.AlertTypeMetric,
 		RuleType:  ruletypes.RuleTypeThreshold,
-		Evaluation: &ruletypes.EvaluationEnvelope{ruletypes.RollingEvaluation, ruletypes.RollingWindow{
+		Evaluation: &ruletypes.EvaluationEnvelope{Kind: ruletypes.RollingEvaluation, Spec: ruletypes.RollingWindow{
 			EvalWindow: ruletypes.Duration(5 * time.Minute),
 			Frequency:  ruletypes.Duration(1 * time.Minute),
 		}},
@@ -899,7 +899,7 @@ func TestThresholdRuleNoData(t *testing.T) {
 		)
 		assert.NoError(t, err)
 		options := clickhouseReader.NewOptions("", "", "archiveNamespace")
-		reader := clickhouseReader.NewReader(nil, telemetryStore, prometheustest.New(instrumentationtest.New().Logger(), prometheus.Config{}), "", time.Duration(time.Second), nil, readerCache, options)
+		reader := clickhouseReader.NewReader(nil, telemetryStore, prometheustest.New(context.Background(), instrumentationtest.New().ToProviderSettings(), prometheus.Config{}, telemetryStore), "", time.Duration(time.Second), nil, readerCache, options)
 
 		rule, err := NewThresholdRule("69", valuer.GenerateUUID(), &postableRule, reader, nil, logger)
 		rule.TemporalityMap = map[string]map[v3.Temporality]bool{
@@ -932,7 +932,7 @@ func TestThresholdRuleTracesLink(t *testing.T) {
 		AlertName: "Traces link test",
 		AlertType: ruletypes.AlertTypeTraces,
 		RuleType:  ruletypes.RuleTypeThreshold,
-		Evaluation: &ruletypes.EvaluationEnvelope{ruletypes.RollingEvaluation, ruletypes.RollingWindow{
+		Evaluation: &ruletypes.EvaluationEnvelope{Kind: ruletypes.RollingEvaluation, Spec: ruletypes.RollingWindow{
 			EvalWindow: ruletypes.Duration(5 * time.Minute),
 			Frequency:  ruletypes.Duration(1 * time.Minute),
 		}},
@@ -1019,7 +1019,7 @@ func TestThresholdRuleTracesLink(t *testing.T) {
 		}
 
 		options := clickhouseReader.NewOptions("", "", "archiveNamespace")
-		reader := clickhouseReader.NewReader(nil, telemetryStore, prometheustest.New(instrumentationtest.New().Logger(), prometheus.Config{}), "", time.Duration(time.Second), nil, nil, options)
+		reader := clickhouseReader.NewReader(nil, telemetryStore, prometheustest.New(context.Background(), instrumentationtest.New().ToProviderSettings(), prometheus.Config{}, telemetryStore), "", time.Duration(time.Second), nil, nil, options)
 
 		rule, err := NewThresholdRule("69", valuer.GenerateUUID(), &postableRule, reader, nil, logger)
 		rule.TemporalityMap = map[string]map[v3.Temporality]bool{
@@ -1057,7 +1057,7 @@ func TestThresholdRuleLogsLink(t *testing.T) {
 		AlertName: "Logs link test",
 		AlertType: ruletypes.AlertTypeLogs,
 		RuleType:  ruletypes.RuleTypeThreshold,
-		Evaluation: &ruletypes.EvaluationEnvelope{ruletypes.RollingEvaluation, ruletypes.RollingWindow{
+		Evaluation: &ruletypes.EvaluationEnvelope{Kind: ruletypes.RollingEvaluation, Spec: ruletypes.RollingWindow{
 			EvalWindow: ruletypes.Duration(5 * time.Minute),
 			Frequency:  ruletypes.Duration(1 * time.Minute),
 		}},
@@ -1156,7 +1156,7 @@ func TestThresholdRuleLogsLink(t *testing.T) {
 		}
 
 		options := clickhouseReader.NewOptions("", "", "archiveNamespace")
-		reader := clickhouseReader.NewReader(nil, telemetryStore, prometheustest.New(instrumentationtest.New().Logger(), prometheus.Config{}), "", time.Duration(time.Second), nil, nil, options)
+		reader := clickhouseReader.NewReader(nil, telemetryStore, prometheustest.New(context.Background(), instrumentationtest.New().ToProviderSettings(), prometheus.Config{}, telemetryStore), "", time.Duration(time.Second), nil, nil, options)
 
 		rule, err := NewThresholdRule("69", valuer.GenerateUUID(), &postableRule, reader, nil, logger)
 		rule.TemporalityMap = map[string]map[v3.Temporality]bool{
@@ -1195,7 +1195,7 @@ func TestThresholdRuleShiftBy(t *testing.T) {
 		AlertName: "Logs link test",
 		AlertType: ruletypes.AlertTypeLogs,
 		RuleType:  ruletypes.RuleTypeThreshold,
-		Evaluation: &ruletypes.EvaluationEnvelope{ruletypes.RollingEvaluation, ruletypes.RollingWindow{
+		Evaluation: &ruletypes.EvaluationEnvelope{Kind: ruletypes.RollingEvaluation, Spec: ruletypes.RollingWindow{
 			EvalWindow: ruletypes.Duration(5 * time.Minute),
 			Frequency:  ruletypes.Duration(1 * time.Minute),
 		}},
@@ -1269,7 +1269,7 @@ func TestMultipleThresholdRule(t *testing.T) {
 		AlertName: "Mulitple threshold test",
 		AlertType: ruletypes.AlertTypeMetric,
 		RuleType:  ruletypes.RuleTypeThreshold,
-		Evaluation: &ruletypes.EvaluationEnvelope{ruletypes.RollingEvaluation, ruletypes.RollingWindow{
+		Evaluation: &ruletypes.EvaluationEnvelope{Kind: ruletypes.RollingEvaluation, Spec: ruletypes.RollingWindow{
 			EvalWindow: ruletypes.Duration(5 * time.Minute),
 			Frequency:  ruletypes.Duration(1 * time.Minute),
 		}},
@@ -1423,7 +1423,7 @@ func TestMultipleThresholdRule(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		reader := clickhouseReader.NewReader(nil, telemetryStore, prometheustest.New(instrumentationtest.New().Logger(), prometheus.Config{}), "", time.Duration(time.Second), nil, readerCache, options)
+		reader := clickhouseReader.NewReader(nil, telemetryStore, prometheustest.New(context.Background(), instrumentationtest.New().ToProviderSettings(), prometheus.Config{}, telemetryStore), "", time.Duration(time.Second), nil, readerCache, options)
 		rule, err := NewThresholdRule("69", valuer.GenerateUUID(), &postableRule, reader, nil, logger)
 		rule.TemporalityMap = map[string]map[v3.Temporality]bool{
 			"signoz_calls_total": {


### PR DESCRIPTION
## 📄 Summary

Fix the prom test provider and add tests that use the telemetry store mock for prom rule Eval. We don't want to use tsdb (because we don't use tsdb).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch prometheus test provider to ClickHouse remote read client and refactor Prom/Threshold rule tests to use telemetry store mocks with deterministic timing, removing TSDB dependencies.
> 
> - **Prometheus test provider (`pkg/prometheus/prometheustest/provider.go`)**:
>   - Replace TSDB-backed storage with ClickHouse remote read via `clickhouseprometheus.NewReadClient` and `remote.NewSampleAndChunkQueryableClient`.
>   - Update `Provider` to use `queryable` instead of `tsdb.DB`; `Close` is a no-op.
>   - Change `New` signature to accept `context`, `factory.ProviderSettings`, and `telemetrystore.TelemetryStore`.
> - **Rule tests**:
>   - **Prom rules (`pkg/query-service/rules/promrule_test.go`)**:
>     - Use `telemetrystoretest` with `ClickHouse-go-mock` to mock fingerprints/samples; remove TSDB population helpers and TSDB-based query tests.
>     - Introduce fixed base/eval times and computed query ranges; adjust expected alert counts; add a disabled no-data test placeholder.
>     - Create readers with the new prometheus test provider.
>   - **Threshold rules (`pkg/query-service/rules/threshold_rule_test.go`)**:
>     - Initialize `EvaluationEnvelope` with named fields; update readers to use new provider.
>     - Use telemetry store mocks for metrics/logs/traces metadata and data; keep cache where needed.
>     - Minor expectation/summary string tweaks and deterministic timing where applicable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fa72241c3188d4c8f64b843a675fdb127562008. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->