### PR TITLE
fix: third party api filtering

### DIFF
--- a/pkg/types/thirdpartyapitypes/thirdpartyapi.go
+++ b/pkg/types/thirdpartyapitypes/thirdpartyapi.go
@@ -11,7 +11,7 @@ type ThirdPartyApiRequest struct {
 	ShowIp   bool                 `json:"show_ip,omitempty"`
 	Domain   string               `json:"domain,omitempty"`
 	Endpoint string               `json:"endpoint,omitempty"`
-	Filter   *qbtypes.Filter      `json:"filters,omitempty"`
+	Filter   *qbtypes.Filter      `json:"filter,omitempty"`
 	GroupBy  []qbtypes.GroupByKey `json:"groupBy,omitempty"`
 }
 


### PR DESCRIPTION
Fixes https://github.com/SigNoz/signoz/issues/9480

This makes sure that the request is parsed properly and then correct filter is generated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies filter application across queries, rebuilds the error query to prepend `has_error = true`, and renames the request JSON field to `filter` with validation.
> 
> - **Third-party API translator (`pkg/modules/thirdpartyapi/translator.go`)**:
>   - Simplifies filtering by removing `containsKindStringOverride` and `buildErrorFilter`; `buildBaseFilter` now always ANDs user-provided `filter`.
>   - Reworks `buildErrorQuery` to use base filter and prepend `has_error = true AND (...)`.
> - **Types (`pkg/types/thirdpartyapitypes/thirdpartyapi.go`)**:
>   - Renames `ThirdPartyApiRequest.Filter` JSON tag from `filters` to `filter`.
>   - Adds validation to reject empty `filter.Expression` when `filter` is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d2a2d68596aa4f86e27f4c91bb595be3148cd56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->