### PR TITLE
fix: handle middle mouse button on click menu item

### DIFF
--- a/frontend/src/container/SideNav/NavItem/NavItem.tsx
+++ b/frontend/src/container/SideNav/NavItem/NavItem.tsx
@@ -44,6 +44,15 @@ export default function NavItem({
 				isActive ? 'active' : '',
 				isDisabled ? 'disabled' : '',
 			)}
+			onMouseDown={(event): void => {
+				if (
+					event.button === 1 &&
+					!isDisabled &&
+					!(event.target as Element).closest?.('.nav-item-pin-icon')
+				) {
+					onClick(event);
+				}
+			}}
 			onClick={(event): void => {
 				if (isDisabled) {
 					return;

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -306,7 +306,11 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 		icon: <Cog size={16} />,
 	};
 
-	const isCtrlMetaKey = (e: MouseEvent): boolean => e.ctrlKey || e.metaKey;
+	const shouldMouseEventOpenInNewTab = useCallback(
+		(e: MouseEvent | null): boolean =>
+			e !== null && (e.ctrlKey || e.metaKey || e.button === 1),
+		[],
+	);
 
 	const isLatestVersion = checkVersionState(currentVersion, latestVersion);
 
@@ -450,7 +454,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 			? ROUTES.GET_STARTED_WITH_CLOUD
 			: ROUTES.GET_STARTED;
 
-		if (isCtrlMetaKey(event)) {
+		if (shouldMouseEventOpenInNewTab(event)) {
 			openInNewTab(onboaringRoute);
 		} else {
 			history.push(onboaringRoute);
@@ -465,7 +469,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 			const queryString = getQueryString(availableParams || [], params);
 
 			if (pathname !== key) {
-				if (event && isCtrlMetaKey(event)) {
+				if (shouldMouseEventOpenInNewTab(event)) {
 					openInNewTab(`${key}?${queryString.join('&')}`);
 				} else {
 					history.push(`${key}?${queryString.join('&')}`, {
@@ -474,7 +478,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 				}
 			}
 		},
-		[pathname, search],
+		[pathname, search, shouldMouseEventOpenInNewTab],
 	);
 
 	const activeMenuKey = useMemo(() => getActiveMenuKeyFromPath(pathname), [
@@ -664,7 +668,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 
 	const handleMenuItemClick = (event: MouseEvent, item: SidebarItem): void => {
 		if (item.key === ROUTES.SETTINGS) {
-			if (isCtrlMetaKey(event)) {
+			if (shouldMouseEventOpenInNewTab(event)) {
 				openInNewTab(settingsRoute);
 			} else {
 				history.push(settingsRoute);


### PR DESCRIPTION
## 📄 Summary

Add support to open the new tab not only via CTRL but also via middle click of the button, like URL link.

---

## ✅ Changes

- [ ] Feature: Brief description
- [x] Bug fix: Brief description

---

## 🧪 How to Test

1. Open the initial page
2. Middle click in any menu item

---

## 🔍 Related Issues

I found no related issue.

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

No screenshots since this change via click.

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes


---

## 👀 Notes for Reviewers

Inspired by https://www.linkedin.com/feed/update/urn:li:activity:7400183369948520448?commentUrn=urn%3Ali%3Acomment%3A%28activity%3A7400183369948520448%2C7400648742405554176%29&dashCommentUrn=urn%3Ali%3Afsd_comment%3A%287400648742405554176%2Curn%3Ali%3Aactivity%3A7400183369948520448%29

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI navigation change that broadens “open in new tab” behavior to include middle-click; potential risk is minor regressions in sidebar click handling (e.g., pin icon interactions).
> 
> **Overview**
> Sidebar navigation now treats *middle-click* the same as Ctrl/Meta-click when deciding to `openInNewTab`, via a shared `shouldMouseEventOpenInNewTab` helper used across menu handlers.
> 
> `NavItem` also triggers navigation on `onMouseDown` for middle clicks (while still respecting disabled items and ignoring clicks on the pin icon) so middle-click works consistently on sidebar entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be22ce7938aabafeb9d4cb00735e7dac0d705f8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->