### PR TITLE
perf: remove typography.text to improve scroll performance

### DIFF
--- a/frontend/src/components/Logs/ListLogView/ListLogView.styles.scss
+++ b/frontend/src/components/Logs/ListLogView/ListLogView.styles.scss
@@ -1,11 +1,15 @@
-.log-field-key {
-	padding-right: 5px;
+.log-field-container {
+	display: flex;
+	overflow: hidden;
+	width: 100%;
+	align-items: baseline;
+}
+.log-field-key,
+.log-field-key-colon {
 	color: var(--text-vanilla-400, #c0c1c3);
 	font-size: 14px;
 	font-style: normal;
 	font-weight: 400;
-	line-height: 18px; /* 128.571% */
-	letter-spacing: -0.07px;
 
 	&.small {
 		font-size: 11px;
@@ -21,6 +25,20 @@
 		font-size: 14px;
 		line-height: 24px;
 	}
+}
+.log-field-key {
+	line-height: 18px; /* 128.571% */
+	letter-spacing: -0.07px;
+	white-space: nowrap;
+	display: inline-block;
+	max-width: 20vw;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	margin: 0;
+}
+.log-field-key-colon {
+	min-width: 0.8rem;
+	flex-shrink: 0;
 }
 .log-value {
 	color: var(--text-vanilla-400, #c0c1c3);
@@ -158,7 +176,8 @@
 }
 
 .lightMode {
-	.log-field-key {
+	.log-field-key,
+	.log-field-key-colon {
 		color: var(--text-slate-400);
 	}
 	.log-value {
@@ -168,5 +187,12 @@
 		&:hover {
 			background-color: var(--text-vanilla-200) !important;
 		}
+	}
+}
+
+.dark {
+	.log-field-key,
+	.log-field-key-colon {
+		color: rgba(255, 255, 255, 0.45);
 	}
 }

--- a/frontend/src/components/Logs/ListLogView/index.tsx
+++ b/frontend/src/components/Logs/ListLogView/index.tsx
@@ -25,13 +25,7 @@ import LogLinesActionButtons from '../LogLinesActionButtons/LogLinesActionButton
 import LogStateIndicator from '../LogStateIndicator/LogStateIndicator';
 import { getLogIndicatorType } from '../LogStateIndicator/utils';
 // styles
-import {
-	Container,
-	LogContainer,
-	LogText,
-	Text,
-	TextContainer,
-} from './styles';
+import { Container, LogContainer, LogText } from './styles';
 import { isValidLogField } from './util';
 
 interface LogFieldProps {
@@ -58,16 +52,18 @@ function LogGeneralField({
 	);
 
 	return (
-		<TextContainer>
-			<Text ellipsis type="secondary" className={cx('log-field-key', fontSize)}>
-				{`${fieldKey} : `}
-			</Text>
+		<div className="log-field-container">
+			<p className={cx('log-field-key', fontSize)} title={fieldKey}>
+				{fieldKey}
+			</p>
+			<span className={cx('log-field-key-colon', fontSize)}>&nbsp;:&nbsp;</span>
 			<LogText
 				dangerouslySetInnerHTML={html}
 				className={cx('log-value', fontSize)}
+				title={fieldValue}
 				linesPerRow={linesPerRow > 1 ? linesPerRow : undefined}
 			/>
-		</TextContainer>
+		</div>
 	);
 }
 

--- a/frontend/src/components/Logs/ListLogView/styles.ts
+++ b/frontend/src/components/Logs/ListLogView/styles.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-nested-ternary */
-import { Card, Typography } from 'antd';
+import { Card } from 'antd';
 import { FontSize } from 'container/OptionsMenu/types';
 import styled from 'styled-components';
 import { getActiveLogBackground } from 'utils/logs';
@@ -44,19 +44,6 @@ export const Container = styled(Card)<{
 
 		${({ $isActiveLog, $isDarkMode, $logType }): string =>
 			getActiveLogBackground($isActiveLog, $isDarkMode, $logType)}
-`;
-
-export const Text = styled(Typography.Text)`
-	&&& {
-		min-width: 2.5rem;
-		white-space: nowrap;
-	}
-`;
-
-export const TextContainer = styled.div`
-	display: flex;
-	overflow: hidden;
-	width: 100%;
 `;
 
 export const LogContainer = styled.div<LogContainerProps>`


### PR DESCRIPTION
## 📄 Summary

Remove the usage of typography.text to improve performance by reducing the amount of DOM changes.

---

## ✅ Changes

- [ ] Feature: Brief description
- [x] Bug fix: Brief description

---

## 🏷️ Required: Add Relevant Labels

- `frontend`

---

## 👥 Reviewers

- frontend
---

## 🧪 How to Test

1. Open log tab
2. Press f12, start recording performance
3. Scroll up and down very fast

---

## 🔍 Related Issues

Reference #9784

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

Before:
<img width="485" height="612" alt="image" src="https://github.com/user-attachments/assets/35ebae2c-d309-4db2-888b-65d828d04532" />

After:
<img width="558" height="688" alt="image" src="https://github.com/user-attachments/assets/d852fb0c-8490-4c3a-bf80-53fea31e03bf" />

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes log list rendering by reducing DOM/AntD overhead and moving styling to CSS.
> 
> - Replaces `Typography.Text`/`TextContainer` around general log fields with plain elements and `ListLogView.styles.scss` classes (`.log-field-container`, `.log-field-key`, `.log-field-key-colon`); colon rendered separately and non-shrinking
> - Removes styled `Text` and `TextContainer` from `styles.ts`; `LogText` remains with ellipsis/line-clamp behavior
> - Adds truncation/ellipsis and `title` tooltips for keys/values; sets max width for keys to prevent overflow
> - Updates light/dark theme colors for keys/colon and hover background
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0dcb5d9868c2aaf1405ac5ec5622247ad65920b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->