### PR TITLE
fix(apiserver): preference routes registeration before user routes

### DIFF
--- a/pkg/apiserver/signozapiserver/provider.go
+++ b/pkg/apiserver/signozapiserver/provider.go
@@ -96,11 +96,11 @@ func (provider *provider) AddToRouter(router *mux.Router) error {
 		return err
 	}
 
-	if err := provider.addUserRoutes(router); err != nil {
+	if err := provider.addPreferenceRoutes(router); err != nil {
 		return err
 	}
 
-	if err := provider.addPreferenceRoutes(router); err != nil {
+	if err := provider.addUserRoutes(router); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

- preference routes were being registered post user routes hence all the preference apis were being hit at user routes. 

contributes to - https://github.com/SigNoz/platform-pod/issues/1422

