### PR TITLE
chore: update codeowners for frontend repo from individuals to frontend-maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Owners are automatically requested for review for PRs that changes code
 # that they own.
 
-/frontend/ @YounixM @aks07
+/frontend/ @SigNoz/frontend-maintainers
 
 # Onboarding
 /frontend/src/container/OnboardingV2Container/onboarding-configs/onboarding-config-with-links.json @makeavish


### PR DESCRIPTION
Update codeowners for frontend repo from individuals to frontend-maintainers team


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace individual owners for ` /frontend/` with `@SigNoz/frontend-maintainers` in `.github/CODEOWNERS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37a2566d78bc82c20b066700b35f1dfc73526dab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->