### PR TITLE
fix(apikey): batch last seen sql update for api-key middleware

### DIFF
--- a/pkg/http/middleware/api_key.go
+++ b/pkg/http/middleware/api_key.go
@@ -132,7 +132,7 @@ func (a *APIKey) Wrap(next http.Handler) http.Handler {
 				Where("revoked = false").
 				Exec(lastUsedCtx)
 			if err != nil {
-				a.logger.ErrorContext(r.Context(), "failed to update last used of api key", "error", err)
+				a.logger.ErrorContext(lastUsedCtx, "failed to update last used of api key", "error", err)
 			}
 
 			return true, nil


### PR DESCRIPTION
## Summary

- currently on each read/write call the last seen for api key was getting updated which essentially meant every read request requires an exclusive lock on sqlite 
- batched the api key last seen updates. 


contributes to - https://github.com/SigNoz/platform-pod/issues/1386
