### PR TITLE
perf(logs): reduce amount of re-renders

### DIFF
--- a/frontend/src/components/Logs/ListLogView/index.tsx
+++ b/frontend/src/components/Logs/ListLogView/index.tsx
@@ -14,7 +14,7 @@ import { useIsDarkMode } from 'hooks/useDarkMode';
 // utils
 import { FlatLogData } from 'lib/logs/flatLogData';
 import { useTimezone } from 'providers/Timezone';
-import { useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 // interfaces
 import { IField } from 'types/api/logs/fields';
 import { ILog } from 'types/api/logs/log';
@@ -121,10 +121,11 @@ function ListLogView({
 }: ListLogViewProps): JSX.Element {
 	const flattenLogData = useMemo(() => FlatLogData(logData), [logData]);
 
-	const [hasActionButtons, setHasActionButtons] = useState<boolean>(false);
 	const { isHighlighted, isLogsExplorerPage, onLogCopy } = useCopyLogLink(
 		logData.id,
 	);
+	const isReadOnlyLog = !isLogsExplorerPage;
+
 	const {
 		activeLog: activeContextLog,
 		onAddToQuery: handleAddToQuery,
@@ -180,14 +181,6 @@ function ListLogView({
 
 	const logType = getLogIndicatorType(logData);
 
-	const handleMouseEnter = (): void => {
-		setHasActionButtons(true);
-	};
-
-	const handleMouseLeave = (): void => {
-		setHasActionButtons(false);
-	};
-
 	return (
 		<>
 			<Container
@@ -198,8 +191,6 @@ function ListLogView({
 				}
 				$isDarkMode={isDarkMode}
 				$logType={logType}
-				onMouseEnter={handleMouseEnter}
-				onMouseLeave={handleMouseLeave}
 				onClick={handleDetailedView}
 				fontSize={fontSize}
 			>
@@ -251,7 +242,7 @@ function ListLogView({
 					</div>
 				</div>
 
-				{hasActionButtons && isLogsExplorerPage && (
+				{!isReadOnlyLog && (
 					<LogLinesActionButtons
 						handleShowContext={handleShowContext}
 						onLogCopy={onLogCopy}
@@ -279,4 +270,4 @@ LogGeneralField.defaultProps = {
 	linesPerRow: 1,
 };
 
-export default ListLogView;
+export default memo(ListLogView);

--- a/frontend/src/components/Logs/ListLogView/styles.ts
+++ b/frontend/src/components/Logs/ListLogView/styles.ts
@@ -30,6 +30,11 @@ export const Container = styled(Card)<{
 			? `margin-bottom:0.3rem;`
 			: ``}
 	cursor: pointer;
+
+	&:not(:hover) .log-line-action-buttons {
+		display: none;
+	}
+
 	.ant-card-body {
 		padding: 0.3rem 0.6rem;
 

--- a/frontend/src/components/Logs/LogLinesActionButtons/LogLinesActionButtons.tsx
+++ b/frontend/src/components/Logs/LogLinesActionButtons/LogLinesActionButtons.tsx
@@ -3,14 +3,15 @@ import './LogLinesActionButtons.styles.scss';
 import { LinkOutlined } from '@ant-design/icons';
 import { Button, Tooltip } from 'antd';
 import { TextSelect } from 'lucide-react';
-import { MouseEventHandler } from 'react';
+import { memo, MouseEventHandler } from 'react';
 
 export interface LogLinesActionButtonsProps {
 	handleShowContext: MouseEventHandler<HTMLElement>;
 	onLogCopy: MouseEventHandler<HTMLElement>;
 	customClassName?: string;
 }
-export default function LogLinesActionButtons({
+
+function LogLinesActionButtons({
 	handleShowContext,
 	onLogCopy,
 	customClassName = '',
@@ -40,3 +41,5 @@ export default function LogLinesActionButtons({
 LogLinesActionButtons.defaultProps = {
 	customClassName: '',
 };
+
+export default memo(LogLinesActionButtons);

--- a/frontend/src/components/Logs/RawLogView/styles.ts
+++ b/frontend/src/components/Logs/RawLogView/styles.ts
@@ -30,6 +30,10 @@ export const RawLogViewContainer = styled(Row)<{
 
 	transition: background-color 0.2s ease-in;
 
+	&:not(:hover) .log-line-action-buttons {
+		display: none;
+	}
+
 	.log-state-indicator {
 		margin: 4px 0;
 


### PR DESCRIPTION
## 📄 Summary

Reduce the absurd amount of re-renders on logs page that causes slowdown and drop of fps.

Relates to #9784

---

## ✅ Changes

Basically changes the causes of re-renders due to mouse listeners and add couple memos around the main components.

---

## 🏷️ Required: Add Relevant Labels

- `frontend`

---

## 👥 Reviewers

- frontend

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. Open the Logs UI, and then start scroll
2. To visualize the re-renders, use the React Devtools

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

Before:


[signoz-log-re-rendering-before-optimization.webm](https://github.com/user-attachments/assets/ad19510e-af8f-4c96-b3e9-7c54aceb235e)

[signoz-log-re-rendering-before-optimization-raw.webm](https://github.com/user-attachments/assets/f48cede2-7500-4704-9301-f91a5ea5252d)

After:

[signoz-log-re-rendering-after-optimization.webm](https://github.com/user-attachments/assets/96d89f8f-13e4-4a24-905d-33ea8f37bfea)

[signoz-log-re-rendering-after-optimization-raw.webm](https://github.com/user-attachments/assets/edfeaf15-8e08-435d-b3ca-9abfd19694dc)

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes
