### PR TITLE
fix: show loading spinner in SpanLogs until trace-only logs query completes

### DIFF
--- a/frontend/src/container/SpanDetailsDrawer/SpanLogs/SpanLogs.tsx
+++ b/frontend/src/container/SpanDetailsDrawer/SpanLogs/SpanLogs.tsx
@@ -46,6 +46,7 @@ interface SpanLogsProps {
 	isLogSpanRelated: (logId: string) => boolean;
 	handleExplorerPageRedirect: () => void;
 	emptyStateConfig?: EmptyLogsListConfig;
+	isTraceOnlyLoading: boolean;
 }
 
 function SpanLogs({
@@ -59,6 +60,7 @@ function SpanLogs({
 	isLogSpanRelated,
 	handleExplorerPageRedirect,
 	emptyStateConfig,
+	isTraceOnlyLoading,
 }: SpanLogsProps): JSX.Element {
 	const { updateAllQueriesOperators } = useQueryBuilder();
 
@@ -254,7 +256,7 @@ function SpanLogs({
 	);
 
 	const renderSpanLogsContent = (): JSX.Element | null => {
-		if (isLoading || isFetching) {
+		if (isLoading || isFetching || isTraceOnlyLoading) {
 			return <LogsLoading />;
 		}
 
@@ -263,7 +265,8 @@ function SpanLogs({
 		}
 
 		if (logs.length === 0) {
-			if (emptyStateConfig) {
+			// Only show enhanced empty state if not loading trace-only logs
+			if (emptyStateConfig && !isTraceOnlyLoading) {
 				return (
 					<EmptyLogsSearch
 						dataSource={DataSource.LOGS}

--- a/frontend/src/container/SpanDetailsDrawer/SpanLogs/__tests__/SpanLogs.test.tsx
+++ b/frontend/src/container/SpanDetailsDrawer/SpanLogs/__tests__/SpanLogs.test.tsx
@@ -117,6 +117,7 @@ const defaultProps = {
 		startTime: 1640995200000,
 		endTime: 1640995260000,
 	},
+	isTraceOnlyLoading: false,
 	logs: [],
 	isLoading: false,
 	isError: false,
@@ -141,6 +142,7 @@ describe('SpanLogs', () => {
 
 		// Should show simple empty state (no emptyStateConfig provided)
 		expect(
+			// eslint-disable-next-line sonarjs/no-duplicate-string
 			screen.getByText('No logs found for selected span.'),
 		).toBeInTheDocument();
 		expect(
@@ -210,5 +212,28 @@ describe('SpanLogs', () => {
 		await user.click(logExplorerButton);
 
 		expect(mockHandleExplorerPageRedirect).toHaveBeenCalledTimes(1);
+	});
+
+	it('should show loading state when isTraceOnlyLoading is true', () => {
+		// Render with isTraceOnlyLoading true and emptyStateConfig present
+		render(
+			<SpanLogs
+				// eslint-disable-next-line react/jsx-props-no-spreading
+				{...defaultProps}
+				isTraceOnlyLoading
+				emptyStateConfig={getEmptyLogsListConfig(jest.fn())}
+			/>,
+		);
+
+		// Should show loading spinner
+		expect(screen.getByTestId('logs-loading')).toBeInTheDocument();
+
+		// Should NOT show enhanced empty state
+		expect(screen.queryByTestId('empty-logs-search')).not.toBeInTheDocument();
+
+		// Should NOT show simple empty state
+		expect(
+			screen.queryByText('No logs found for selected span.'),
+		).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/container/SpanDetailsDrawer/SpanLogs/useSpanContextLogs.ts
+++ b/frontend/src/container/SpanDetailsDrawer/SpanLogs/useSpanContextLogs.ts
@@ -31,6 +31,7 @@ interface UseSpanContextLogsReturn {
 	spanLogIds: Set<string>;
 	isLogSpanRelated: (logId: string) => boolean;
 	hasTraceIdLogs: boolean;
+	isTraceOnlyLoading: boolean;
 }
 
 const traceIdKey = {
@@ -284,7 +285,7 @@ export const useSpanContextLogs = ({
 		);
 	}, [timeRange.startTime, timeRange.endTime, traceOnlyFilter]);
 
-	const { data: traceOnlyData } = useQuery({
+	const { data: traceOnlyData, isLoading: isTraceOnlyLoading } = useQuery({
 		queryKey: [
 			REACT_QUERY_KEY.TRACE_ONLY_LOGS,
 			traceId,
@@ -318,5 +319,6 @@ export const useSpanContextLogs = ({
 		spanLogIds,
 		isLogSpanRelated,
 		hasTraceIdLogs,
+		isTraceOnlyLoading,
 	};
 };

--- a/frontend/src/container/SpanDetailsDrawer/SpanRelatedSignals/SpanRelatedSignals.tsx
+++ b/frontend/src/container/SpanDetailsDrawer/SpanRelatedSignals/SpanRelatedSignals.tsx
@@ -72,6 +72,7 @@ function SpanRelatedSignals({
 		isFetching,
 		isLogSpanRelated,
 		hasTraceIdLogs,
+		isTraceOnlyLoading,
 	} = useSpanContextLogs({
 		traceId: selectedSpan.traceId,
 		spanId: selectedSpan.spanId,
@@ -233,6 +234,7 @@ function SpanRelatedSignals({
 							isLogSpanRelated={isLogSpanRelated}
 							handleExplorerPageRedirect={handleExplorerPageRedirect}
 							emptyStateConfig={!hasTraceIdLogs ? emptyStateConfig : undefined}
+							isTraceOnlyLoading={isTraceOnlyLoading}
 						/>
 					)}
 


### PR DESCRIPTION
## 📄 Summary
Prevents the empty state from rendering while the trace-only logs query is still loading in the SpanLogs component. This eliminates UI flicker and ensures users only see the empty state after all relevant log queries have finished
<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes https://github.com/SigNoz/engineering-pod/issues/3490

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)
Before:

https://github.com/user-attachments/assets/228fa541-2cb2-4d15-9439-97eab84148b7



After:

https://github.com/user-attachments/assets/e8c9f5ce-2f19-4d97-b5b1-ae6c947be39b



<!-- Add screenshots or GIFs to help visualize changes -->

---

## 📋 Checklist

- [x] Dev Review
- [x] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes
