### PR TITLE
feat: handled case for checkbox query reload

### DIFF
--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.tsx
@@ -421,11 +421,16 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 										...currentFilter,
 										value: currentFilter.value.filter((val) => val !== value),
 									};
-
 									if (newFilter.value.length === 0) {
 										query.filters.items = query.filters.items.filter(
 											(item) => !isEqual(item.key?.key, filter.attributeKey.key),
 										);
+										if (query.filter?.expression) {
+											query.filter.expression = removeKeysFromExpression(
+												query.filter.expression,
+												[filter.attributeKey.key],
+											);
+										}
 									} else {
 										query.filters.items = query.filters.items.map((item) => {
 											if (isEqual(item.key?.key, filter.attributeKey.key)) {
@@ -435,6 +440,16 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 										});
 									}
 								} else {
+									const newFilter = {
+										...currentFilter,
+										value: currentFilter.value === value ? null : currentFilter.value,
+									};
+									if (newFilter.value === null && query.filter?.expression) {
+										query.filter.expression = removeKeysFromExpression(
+											query.filter.expression,
+											[filter.attributeKey.key],
+										);
+									}
 									query.filters.items = query.filters.items.filter(
 										(item) => !isEqual(item.key?.key, filter.attributeKey.key),
 									);


### PR DESCRIPTION
## 📄 Summary

<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->
When a filter checkbox is toggled off, the filter expression is now updated by removing the corresponding attribute key from the existing expression.
---

## ✅ Changes

- [x] Feature: Brief description
While applying filters, selecting a checkbox correctly updates the filter expression to exclude the selected value. However, clicking the same checkbox again does not update the filter expression, even though it still triggers a data refresh. This results in an unnecessary refresh with no corresponding change in the applied filters.
- [x] Bug fix: Brief description
We are checking if new filter applied items length is 0 then we are removing the whole filter key from filter expression as well
---

---

## 🧪 How to Test
1. Open https://app.us.staging.signoz.cloud/logs/logs-explorer
2. On the left pane , select any filter item (example user selected severity_text -> warn), it should filter the logs with query severity_text not in ['WARN']
3. Deselect the same filter again to add it in the query, you should see the filter getting applied back again

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes [#3355](https://github.com/SigNoz/engineering-pod/issues/3355)

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

Before 

https://github.com/user-attachments/assets/ea7ea354-4c39-4c44-9266-526eae1f843c

After

https://github.com/user-attachments/assets/3d0beb52-5b22-4031-98c2-635100a09231



---

## 📋 Checklist

- [x] Dev Review
- [x] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->
