### PR TITLE
chore: add integration tests owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,5 +47,7 @@
 /pkg/telemetrytraces/ @srikanthccv
 
 # AuthN / AuthZ Owners 
-
 /pkg/authz/ @vikrantgupta25 @therealpandey
+
+# Integration tests
+/tests/integration/ @therealpandey


### PR DESCRIPTION
## 📄 Summary

add integration tests owner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates repository ownership configuration.
> 
> - Adds CODEOWNERS entry for `/tests/integration/` assigning reviews to `@therealpandey`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2364673b584954ac65c12d7cdfefeb262bd12b19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->