### PR TITLE
fix(dashboards): apply custom legend colors to histogram panels

### DIFF
--- a/frontend/src/lib/uPlotLib/getUplotHistogramChartOptions.ts
+++ b/frontend/src/lib/uPlotLib/getUplotHistogramChartOptions.ts
@@ -93,12 +93,14 @@ const getHistogramSeries = ({
 			? ''
 			: getLabelName(metric, queryName || '', legend);
 
-        const color =
-	      colorMapping?.[label || ''] ||  
-	      generateColor(
-		    label || '',
-		    isDarkMode ? themeColors.chartcolors : themeColors.lightModeColor,
-	      );
+		const labelForColorMapping = legend || label;
+
+		const color =
+			colorMapping?.[labelForColorMapping || ''] ||
+			generateColor(
+				label || '',
+				isDarkMode ? themeColors.chartcolors : themeColors.lightModeColor,
+			);
 
 		const pointSize = seriesList[i].values.length > 1 ? 5 : 10;
 		const showPoints = !(seriesList[i].values.length > 1);

--- a/frontend/src/lib/uPlotLib/getUplotHistogramChartOptions.ts
+++ b/frontend/src/lib/uPlotLib/getUplotHistogramChartOptions.ts
@@ -93,10 +93,8 @@ const getHistogramSeries = ({
 			? ''
 			: getLabelName(metric, queryName || '', legend);
 
-		const labelForColorMapping = legend || label;
-
 		const color =
-			colorMapping?.[labelForColorMapping || ''] ||
+			colorMapping?.[label || ''] ||
 			generateColor(
 				label || '',
 				isDarkMode ? themeColors.chartcolors : themeColors.lightModeColor,

--- a/frontend/src/lib/uPlotLib/getUplotHistogramChartOptions.ts
+++ b/frontend/src/lib/uPlotLib/getUplotHistogramChartOptions.ts
@@ -37,6 +37,7 @@ type GetUplotHistogramChartOptionsProps = {
 	onClickHandler?: OnClickPluginOpts['onClick'];
 	legendScrollPosition?: number;
 	setLegendScrollPosition?: (position: number) => void;
+	colorMapping?: Record<string, string>;
 };
 
 type GetHistogramSeriesProps = {
@@ -46,6 +47,7 @@ type GetHistogramSeriesProps = {
 	graphsVisibilityStates?: boolean[];
 	isMergedSeries?: boolean;
 	isDarkMode: boolean;
+	colorMapping?: Record<string, string>;
 };
 
 const { bars } = uPlot.paths;
@@ -68,6 +70,7 @@ const getHistogramSeries = ({
 	graphsVisibilityStates,
 	isMergedSeries,
 	isDarkMode,
+	colorMapping,
 }: GetHistogramSeriesProps): uPlot.Options['series'] => {
 	const configurations: uPlot.Series[] = [
 		{ label: 'Timestamp', stroke: 'purple' },
@@ -90,10 +93,12 @@ const getHistogramSeries = ({
 			? ''
 			: getLabelName(metric, queryName || '', legend);
 
-		const color = generateColor(
-			label,
-			isDarkMode ? themeColors.chartcolors : themeColors.lightModeColor,
-		);
+        const color =
+	      colorMapping?.[label || ''] ||  
+	      generateColor(
+		    label || '',
+		    isDarkMode ? themeColors.chartcolors : themeColors.lightModeColor,
+	      );
 
 		const pointSize = seriesList[i].values.length > 1 ? 5 : 10;
 		const showPoints = !(seriesList[i].values.length > 1);
@@ -133,6 +138,7 @@ export const getUplotHistogramChartOptions = ({
 	panelType,
 	legendScrollPosition,
 	setLegendScrollPosition,
+	colorMapping,
 }: GetUplotHistogramChartOptionsProps): uPlot.Options =>
 	({
 		id,
@@ -182,6 +188,7 @@ export const getUplotHistogramChartOptions = ({
 			graphsVisibilityStates,
 			isMergedSeries: mergeAllQueries,
 			isDarkMode,
+			colorMapping,
 		}),
 		hooks: {
 			ready: [

--- a/frontend/src/lib/uPlotLib/getUplotHistogramChartOptions.ts
+++ b/frontend/src/lib/uPlotLib/getUplotHistogramChartOptions.ts
@@ -161,6 +161,7 @@ export const getUplotHistogramChartOptions = ({
 				isHistogramGraphs: true,
 				isMergedSeries: mergeAllQueries,
 				isDarkMode,
+				colorMapping,
 			}),
 			onClickPlugin({
 				onClick: onClickHandler,


### PR DESCRIPTION
Added support for custom legend colors in histogram panels by passing colorMapping through the chart options pipeline. Previously, histogram panels ignored user-configured legend colors and always used auto-generated colors based on hash function.
The histogram panel now respects custom legend colors configuration, matching the behavior of Time Series and Bar chart panels.
Fixes #9804

## 📄 Summary
<!-- Describe the purpose of the PR in a few sentences. What does it fix/add/update? -->

This PR fixes a bug where histogram panels were ignoring custom legend color configurations set by users. The issue was that the `colorMapping` parameter wasn't being passed through the chart options pipeline, causing histograms to always use auto-generated hash-based colors instead of respecting user preferences.

The fix ensures histogram panels now behave consistently with Time Series and Bar chart panels by checking for custom colors first before falling back to auto-generated colors.

---

## ✅ Changes
- [x] Bug fix: Added colorMapping parameter support to histogram chart options
- [x] Bug fix: Updated color generation logic to respect custom legend colors
- [x] Bug fix: Aligned histogram color behavior with Time Series and Bar charts

---

## 🏷️ Required: Add Relevant Labels
> ⚠️ **Manually add appropriate labels in the PR sidebar**  
Please select one or more labels (as applicable):

- `frontend`
- `bug`
- `dashboards`
- `ui`

---

## 👥 Reviewers
> Tag the relevant teams for review:
- @ frontendteam 

---

## 🧪 How to Test
<!-- Describe how reviewers can test this PR -->

1. **Create a new dashboard panel**
   - Navigate to any dashboard
   - Click "Add Panel" or create a new panel

2. **Configure histogram with multiple series**
   - Select "Histogram" as the panel type
   - Add a query that returns multiple series (e.g., metrics with different labels)
   - Ensure you have at least 2-3 different series showing

3. **Set custom legend colors**
   - In the right panel, scroll down to "Panel Details"
   - Expand the "LEGEND COLORS" section
   - Click on a series color swatch
   - Change the color to something distinctly different (e.g., bright red, lime green)
   - Repeat for one or two more series with different colors

4. **Verify the fix**
   - ✅ The histogram bars should now display in your custom colors
   - ✅ Colors should persist when you save and reload the dashboard
   - ✅ Colors should remain when switching between view/edit modes

5. **Test edge cases**
   - Change a color, then change it back - should update correctly
   - Reset colors to default - should work as expected
   - Compare with Time Series panel - behavior should be identical

---

## 🔍 Related Issues
<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->

Closes #9804

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

**Before fix:**
- Histogram ignores custom legend colors (shows auto-generated colors only)

**After fix:**
- Histogram respects custom legend colors set by user
- Custom colors are applied to histogram bars and legend markers

*Note: Please add before/after screenshots showing:*
1. *Custom colors being set in the LEGEND COLORS section*
2. *Histogram displaying those custom colors correctly*

---

## 📋 Checklist
- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes

---

## 👀 Notes for Reviewers
<!-- Anything reviewers should keep in mind while reviewing -->

**Key Changes:**
- Added `colorMapping?: Record<string, string>` parameter to both `GetUplotHistogramChartOptionsProps` and `GetHistogramSeriesProps` type definitions
- Updated color generation logic in `getHistogramSeries` function (line 93-96) to check `colorMapping` before falling back to `generateColor()`
- Ensured `colorMapping` is passed through the entire options pipeline

**Implementation Pattern:**
This fix follows the same pattern already implemented in Time Series charts (see `frontend/src/lib/uPlotLib/utils/getSeriesData.ts:62-67`), ensuring consistency across all chart types.

**Testing Focus:**
- Verify custom colors are applied correctly
- Check that default behavior (no custom colors) still works
- Ensure color persistence across dashboard saves/reloads
- Confirm no regression in other histogram functionality


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures histogram panels respect user-configured legend colors.
> 
> - Adds optional `colorMapping` to `getUplotHistogramChartOptions` and `getHistogramSeries` props
> - Uses `colorMapping[label]` for series `stroke/fill` before falling back to `generateColor`
> - Passes `colorMapping` through to `tooltipPlugin` and series construction for consistent coloring
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f324eb23a6e63b7fe91fa4aa000fcb2310c51b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->