### PR TITLE
perf(app-routes): lazy load message queues and meter components

### DIFF
--- a/frontend/src/AppRoutes/pageComponents.ts
+++ b/frontend/src/AppRoutes/pageComponents.ts
@@ -256,7 +256,7 @@ export const InstalledIntegrations = Loadable(
 		),
 );
 
-export const MessagingQueuesMainPage = Loadable(
+export const MessagingQueues = Loadable(
 	() =>
 		import(/* webpackChunkName: "MessagingQueues" */ 'pages/MessagingQueues'),
 );
@@ -302,5 +302,16 @@ export const PublicDashboardPage = Loadable(
 	() =>
 		import(
 			/* webpackChunkName: "Public Dashboard Page" */ 'pages/PublicDashboard'
+		),
+);
+
+export const MeterExplorer = Loadable(
+	() => import(/* webpackChunkName: "MeterExplorer" */ 'pages/MeterExplorer'),
+);
+
+export const AlertTypeSelectionPage = Loadable(
+	() =>
+		import(
+			/* webpackChunkName: "AlertTypeSelection" */ 'pages/AlertTypeSelection'
 		),
 );

--- a/frontend/src/AppRoutes/routes.ts
+++ b/frontend/src/AppRoutes/routes.ts
@@ -1,12 +1,10 @@
 import ROUTES from 'constants/routes';
-import AlertTypeSelectionPage from 'pages/AlertTypeSelection';
-import MessagingQueues from 'pages/MessagingQueues';
-import MeterExplorer from 'pages/MeterExplorer';
 import { RouteProps } from 'react-router-dom';
 
 import {
 	AlertHistory,
 	AlertOverview,
+	AlertTypeSelectionPage,
 	AllAlertChannels,
 	AllErrors,
 	ApiMonitoring,
@@ -28,6 +26,8 @@ import {
 	LogsExplorer,
 	LogsIndexToFields,
 	LogsSaveViews,
+	MessagingQueues,
+	MeterExplorer,
 	MetricsExplorer,
 	OldLogsExplorer,
 	Onboarding,


### PR DESCRIPTION
## 📄 Summary

These two components probably were forgot to be included in the lazy load components.

---

## ✅ Changes

Before:

<img width="1442" height="838" alt="image" src="https://github.com/user-attachments/assets/a18bf3b9-034e-4feb-86d3-989dfeefe97b" />

After:

<img width="1447" height="835" alt="image" src="https://github.com/user-attachments/assets/e024a713-f8c2-43c4-a582-b95476223e7d" />

---

## 🧪 How to Test

1. Press F12
2. Go to performance tab
3. Press record and reload (CTRL + SHIFT + E)
4. Wait for 5s and then stop.

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves route-level code-splitting by lazy-loading previously eagerly-loaded pages.
> 
> - Adds `Loadable` exports for `MessagingQueues`, `MeterExplorer`, and `AlertTypeSelectionPage` in `pageComponents.ts`
> - Updates `routes.ts` to import these components from `pageComponents` (instead of direct imports) and use them for existing routes
> - Renames `MessagingQueuesMainPage` export to `MessagingQueues` for consistency
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 752e3841a0a251f6184a531d1e9432865d05977d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->