### PR TITLE
feat: updated tooltip - mouse delay to 0 from 100ms

### DIFF
--- a/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
+++ b/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
@@ -219,7 +219,7 @@ export default function TableViewActions(
 				/>
 				{!isListViewPanel && !RESTRICTED_SELECTED_FIELDS.includes(fieldFilterKey) && (
 					<span className="action-btn">
-						<Tooltip title="Filter for value">
+						<Tooltip title="Filter for value" mouseLeaveDelay={0}>
 							<Button
 								className="filter-btn periscope-btn"
 								icon={
@@ -238,7 +238,7 @@ export default function TableViewActions(
 								)}
 							/>
 						</Tooltip>
-						<Tooltip title="Filter out value">
+						<Tooltip title="Filter out value" mouseLeaveDelay={0}>
 							<Button
 								className="filter-btn periscope-btn"
 								icon={
@@ -299,7 +299,7 @@ export default function TableViewActions(
 			</CopyClipboardHOC>
 			{!isListViewPanel && !RESTRICTED_SELECTED_FIELDS.includes(fieldFilterKey) && (
 				<span className="action-btn">
-					<Tooltip title="Filter for value">
+					<Tooltip title="Filter for value" mouseLeaveDelay={0}>
 						<Button
 							className="filter-btn periscope-btn"
 							icon={
@@ -318,7 +318,7 @@ export default function TableViewActions(
 							)}
 						/>
 					</Tooltip>
-					<Tooltip title="Filter out value">
+					<Tooltip title="Filter out value" mouseLeaveDelay={0}>
 						<Button
 							className="filter-btn periscope-btn"
 							icon={


### PR DESCRIPTION
## 📄 Summary

Improved log details tooltip behaviour to prevent scroll blocking during interaction.
Tooltips no longer interrupt natural scrolling, ensuring a smooth and uninterrupted log exploration experience.

## ✅ Changes

- [x] Feature: 
While viewing log details, there are tooltips for Filter for value, Filter out  value and Group by attribute. If the mouse lands on this tooltip while naturally scrolling, or deliberately, scrolling gets disabled. The mouse has to be moved elsewhere to resume scrolling.

- [x] Bug fix: Brief description
Enhanced tooltip interaction in log details by updating the AntD Tooltip configuration to avoid scroll blocking.
Tooltips now dismiss immediately on mouse leave, ensuring smooth scrolling even during rapid mouse movements.
Default was 100ms , we made it 0ms to avoid this issue


## 🧪 How to Test

1. Open app.us.staging and navigate to Logs Explorer (List View).
2. Click on any log entry to open the Log Details Overview.
3. Hover over any column that shows Filter / Filter out options.
4. Move the mouse from the button toward the tooltip and verify that the tooltip disappears immediately once the cursor leaves the button, and scrolling remains unaffected.

---

## 🔍 Related Issues

Closes #[3341](https://github.com/SigNoz/engineering-pod/issues/3441)

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

Before: 

https://github.com/user-attachments/assets/b92ca880-2510-4ec3-bf9a-3c026a582b5b


After: 

https://github.com/user-attachments/assets/c29c8837-6f81-4169-a83b-7e8f2c8b94b3



## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves log details interaction by ensuring tooltips dismiss immediately and don’t block scrolling.
> 
> - In `TableViewActions.tsx`, sets `mouseLeaveDelay={0}` on AntD `Tooltip` for `"Filter for value"` and `"Filter out value"` buttons (both body and non-body render paths) to eliminate hover delay
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c55c305491d445293eb15afeb3beea44d4fc601. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->