### PR TITLE
fix: exclude 'A' filter from endpoint stats while navigating from all…

### DIFF
--- a/frontend/src/container/ApiMonitoring/utils.tsx
+++ b/frontend/src/container/ApiMonitoring/utils.tsx
@@ -3123,7 +3123,7 @@ export const getAllEndpointsWidgetData = (
 	return widget;
 };
 
-const keysToRemove = ['http.url', 'url.full', 'B', 'C', 'F1'];
+const keysToRemove = ['http.url', 'url.full', 'A', 'B', 'C', 'F1'];
 
 export const getGroupByFiltersFromGroupByValues = (
 	rowData: any,


### PR DESCRIPTION
… endpoints

## 📄 Summary

Queries break when A = numOfCalls is present in the filter in endpoint stats page. It was a bug introduced when we updated from query_range v3 to query_range v5

Before:
https://github.com/user-attachments/assets/1e4a88a0-a3b3-449c-9afc-b70b9eed974e



After:
https://github.com/user-attachments/assets/fa2a9c0c-c9c3-4a3c-8530-9d1fc20ff403



