### PR TITLE
perf(tooltip-value): cache intl number object

### DIFF
--- a/frontend/src/components/Graph/utils.ts
+++ b/frontend/src/components/Graph/utils.ts
@@ -248,6 +248,11 @@ declare module 'chart.js' {
 	}
 }
 
+const intlNumberFormatter = new Intl.NumberFormat('en-US', {
+	useGrouping: false,
+	maximumFractionDigits: 20,
+});
+
 /**
  * Formats a number for display, preserving leading zeros after the decimal point
  * and showing up to DEFAULT_SIGNIFICANT_DIGITS digits after the first non-zero decimal digit.
@@ -270,10 +275,7 @@ export const formatDecimalWithLeadingZeros = (
 	}
 
 	// Use toLocaleString to get a full decimal representation without scientific notation.
-	const numStr = value.toLocaleString('en-US', {
-		useGrouping: false,
-		maximumFractionDigits: 20,
-	});
+	const numStr = intlNumberFormatter.format(value);
 
 	const [integerPart, decimalPart = ''] = numStr.split('.');
 


### PR DESCRIPTION
Before:

<img width="1262" height="861" alt="image" src="https://github.com/user-attachments/assets/4e9d7ea3-8df5-4bd3-9459-1f3f772933f5" />

After:

<img width="942" height="776" alt="image" src="https://github.com/user-attachments/assets/1919f8dc-a09f-4b33-99ce-402d025343f0" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes number formatting in graph utilities.
> 
> - Introduces a module-level `intlNumberFormatter` and replaces `toLocaleString` with `intlNumberFormatter.format` in `formatDecimalWithLeadingZeros` to reduce allocations and improve tooltip/y-axis number formatting performance
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce801bde79e8a97288d3ce0eca1ed178bc01d007. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->