### PR TITLE
perf(tooltip-plugin): limit amount of items when hover with mouse

### DIFF
--- a/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
+++ b/frontend/src/lib/uPlotLib/plugins/tooltipPlugin.ts
@@ -64,6 +64,8 @@ function sortTooltipContentBasedOnValue(
 	return Object.fromEntries(focusedEntries.concat(nonFocusedEntries));
 }
 
+const MAX_TOOLTIP_ITEMS = 20;
+
 const generateTooltipContent = (
 	seriesList: any[],
 	data: any[],
@@ -221,7 +223,7 @@ const generateTooltipContent = (
 
 	const sortedValues = Object.values(sortedData);
 
-	for (let i = 0; i < sortedValues.length; i++) {
+	for (let i = 0; i < Math.min(sortedValues.length, MAX_TOOLTIP_ITEMS); i++) {
 		const { textContent, color, focus } = sortedValues[i];
 
 		const div = document.createElement('div');


### PR DESCRIPTION
## 📄 Summary

Opened just to discuss a little bit, there's any need to render all the legends when you can only see the first one's since you can't scroll in that dialog?

Related #9784

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caps tooltip content to the first 20 entries.
> 
> - Adds `MAX_TOOLTIP_ITEMS = 20` and limits the render loop to `Math.min(sortedValues.length, MAX_TOOLTIP_ITEMS)` in `tooltipPlugin.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c60e8bff90bbf6d159a0ddd0c5e8f2a2b60f671. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->