### PR TITLE
perf: getLabelName & store legends graph efficiently

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCard/FullView/types.ts
+++ b/frontend/src/container/GridCardLayout/GridCard/FullView/types.ts
@@ -22,7 +22,21 @@ export interface DataSetProps {
 
 export interface LegendEntryProps {
 	label: string;
-	show: boolean;
+	show?: boolean;
+}
+
+export interface SavedLegendGraph {
+	name: string;
+	inverted: boolean;
+	dataIndex: SavedLegendEntry[];
+}
+
+export interface SavedLegendEntry {
+	label: string;
+	/**
+	 * @deprecated Only available for backward compatibility
+	 */
+	show?: boolean;
 }
 
 export type ExtendedChartDataset = uPlot.Series & {

--- a/frontend/src/container/GridCardLayout/GridCard/FullView/utils.ts
+++ b/frontend/src/container/GridCardLayout/GridCard/FullView/utils.ts
@@ -6,6 +6,7 @@ import uPlot from 'uplot';
 import {
 	ExtendedChartDataset,
 	LegendEntryProps,
+	SavedLegendGraph,
 	SaveLegendEntriesToLocalStoreProps,
 } from './types';
 
@@ -86,17 +87,26 @@ export const saveLegendEntriesToLocalStorage = ({
 	graphVisibilityState,
 	name,
 }: SaveLegendEntriesToLocalStoreProps): void => {
-	const newLegendEntry = {
+	let amountOfFalse = 0;
+	graphVisibilityState.forEach((state) => {
+		if (!state) {
+			amountOfFalse++;
+		}
+	});
+	const storeInverted = amountOfFalse > options.series.length / 2;
+	const newLegendEntry: SavedLegendGraph = {
 		name,
-		dataIndex: options.series.map(
-			(item, index): LegendEntryProps => ({
+		inverted: storeInverted,
+		dataIndex: options.series
+			.filter((_, index) =>
+				storeInverted ? graphVisibilityState[index] : !graphVisibilityState[index],
+			)
+			.map((item) => ({
 				label: item.label || '',
-				show: graphVisibilityState[index],
-			}),
-		),
+			})),
 	};
 
-	let existingEntries: { name: string; dataIndex: LegendEntryProps[] }[] = [];
+	let existingEntries: SavedLegendGraph[] = [];
 
 	try {
 		existingEntries = JSON.parse(
@@ -111,7 +121,7 @@ export const saveLegendEntriesToLocalStorage = ({
 	if (entryIndex >= 0) {
 		existingEntries[entryIndex] = newLegendEntry;
 	} else {
-		existingEntries = [...existingEntries, newLegendEntry];
+		existingEntries.push(newLegendEntry);
 	}
 
 	try {

--- a/frontend/src/lib/getLabelName.ts
+++ b/frontend/src/lib/getLabelName.ts
@@ -1,47 +1,42 @@
 import { SeriesItem } from 'types/api/widgets/getQuery';
 
-const getLabelName = (
+// eslint-disable-next-line sonarjs/cognitive-complexity
+function getLabelNameFromMetric(
 	metric: SeriesItem['labels'],
 	query: string,
-	legends: string,
-): string => {
-	if (metric === undefined) {
-		return '';
+): string {
+	let metricName = '';
+	let pre = '';
+	let post = '';
+	let foundName = false;
+	let hasPreLabels = false;
+	let hasPostLabels = false;
+
+	// eslint-disable-next-line no-restricted-syntax
+	for (const [key, value] of Object.entries(metric)) {
+		if (key === '__name__') {
+			metricName = value || '';
+			foundName = true;
+		} else if (foundName) {
+			if (hasPostLabels) {
+				post += ',';
+			}
+			post += `${key}="${value}"`;
+			hasPostLabels = true;
+		} else {
+			if (hasPreLabels) {
+				pre += ',';
+			}
+			pre += `${key}="${value}"`;
+			hasPreLabels = true;
+		}
 	}
 
-	const keysArray = Object.keys(metric);
-	if (legends.length !== 0) {
-		const variables = legends
-			.split('{{')
-			.filter((e) => e)
-			.map((e) => e.split('}}')[0]);
+	const result = metricName;
 
-		const results = variables.map((variable) => metric[variable]);
-
-		let endResult = legends;
-
-		variables.forEach((e, index) => {
-			endResult = endResult.replace(`{{${e}}}`, results[index]);
-		});
-
-		return endResult;
-	}
-
-	const index = keysArray.findIndex((e) => e === '__name__');
-
-	const preArray = index !== -1 ? keysArray.slice(0, index) : [];
-	const postArray = keysArray.slice(index + 1, keysArray.length);
-
-	if (index === undefined && preArray.length === 0 && postArray.length) {
+	if (!foundName && !hasPreLabels && hasPostLabels) {
 		return query;
 	}
-
-	const post = postArray.map((e) => `${e}="${metric[e]}"`).join(',');
-	const pre = preArray.map((e) => `${e}="${metric[e]}"`).join(',');
-
-	const value = metric[keysArray[index]];
-
-	const result = `${value === undefined ? '' : value}`;
 
 	if (post.length === 0 && pre.length === 0) {
 		if (result) {
@@ -53,6 +48,38 @@ const getLabelName = (
 		return result;
 	}
 	return `${result}{${pre}${post}}`;
+}
+
+const getLabelName = (
+	metric: SeriesItem['labels'],
+	query: string,
+	legends: string,
+): string => {
+	if (metric === undefined) {
+		return '';
+	}
+
+	if (legends.length !== 0) {
+		let endResult = legends;
+
+		const startingVariables = legends.split('{{');
+
+		// eslint-disable-next-line no-restricted-syntax
+		for (const variable of startingVariables) {
+			if (variable) {
+				const variableName = variable.split('}}')[0];
+				const variableValue = metric[variableName] || '';
+
+				if (variableValue) {
+					endResult = endResult.replace(`{{${variableName}}}`, variableValue);
+				}
+			}
+		}
+
+		return endResult;
+	}
+
+	return getLabelNameFromMetric(metric, query);
 };
 
 export default getLabelName;


### PR DESCRIPTION
## 📄 Summary

First, reduce the amount of array copies and loops inside the getLabelName since is called heavily.

Secondly, instead of storing the whole legends in the localStorage, storage only what is needed, this greatly improves the UI perf when you click a legend and then refresh the page.

---

## ✅ Changes

- [x] Performance

---

## 🧪 How to Test

<!-- Describe how reviewers can test this PR -->
1. Go to logs
2. Select time series
3. Load any data that could contain more than 10 legends/labels
4. Click in the legend
5. Press F12, see the Application -> Localstorage -> localhost -> GRAPH_VISIBILITY_STATES
6. Should only store the selected value instead of all the possible values.

---

## 🔍 Related Issues

Related #9784

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<img width="1358" height="1066" alt="image" src="https://github.com/user-attachments/assets/eb8d3126-461f-4a02-b939-ed68e861e8e0" />

---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes

---

About the eslint ignores, I was not able to make it pass without them, so let me know what you want to do for that case.

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: this changes the persisted `GRAPH_VISIBILITY_STATES` schema (now storing an `inverted` flag plus a subset of labels), so any other reader of that key could break or misapply visibility. The `getLabelName` refactor is performance-focused but could subtly change series label output in edge cases.
> 
> **Overview**
> Improves UI performance by refactoring `getLabelName` to avoid extra array allocations/copies and by building metric-based labels in a single pass.
> 
> Changes legend visibility persistence (`saveLegendEntriesToLocalStorage`) to store a compact `SavedLegendGraph` payload: an `inverted` flag plus only the smaller set of *shown* or *hidden* series labels, instead of storing every legend entry.
> 
> Updates `getLocalStorageGraphVisibilityState` to reconstruct visibility from the new format and to read the previous `show` boolean format for backward compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fb17da44e790f818ac216bfd8c3d3aa930e7102. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->