### PR TITLE
feat: Pin log detail -> trace correlation button to top or more discoverable

### DIFF
--- a/frontend/src/container/LogDetailedView/TableView.tsx
+++ b/frontend/src/container/LogDetailedView/TableView.tsx
@@ -92,6 +92,10 @@ function TableView({
 				}
 			});
 		}
+		// pin trace_id by default when present
+		if (logData?.trace_id) {
+			pinnedAttributes.trace_id = true;
+		}
 
 		setPinnedAttributes(pinnedAttributes);
 	}, [

--- a/frontend/src/lib/query/createTableColumnsFromQuery.ts
+++ b/frontend/src/lib/query/createTableColumnsFromQuery.ts
@@ -491,16 +491,18 @@ const fillDataFromList = (
 	listItem: ListItem,
 	columns: DynamicColumns,
 ): void => {
+	const listData = listItem.data || {};
 	columns.forEach((column) => {
 		if (isFormula(column.field)) return;
 
-		Object.keys(listItem.data).forEach((label) => {
+		Object.keys(listData).forEach((label) => {
 			if (column.dataIndex === label) {
-				if (listItem.data[label as ListItemKey] !== '') {
-					if (isObject(listItem.data[label as ListItemKey])) {
-						column.data.push(JSON.stringify(listItem.data[label as ListItemKey]));
+				const listValue = listData[label as ListItemKey];
+				if (listValue !== '') {
+					if (isObject(listValue)) {
+						column.data.push(JSON.stringify(listValue));
 					} else {
-						column.data.push(listItem.data[label as ListItemKey].toString());
+						column.data.push(listValue?.toString() ?? '');
 					}
 				} else {
 					column.data.push('N/A');
@@ -538,7 +540,7 @@ const fillDataFromTable = (
 		);
 
 		columns.forEach((column) => {
-			const rowData = row.data;
+			const rowData = row.data || {};
 			const columnField = column.id || column.title || column.field;
 
 			if (Object.prototype.hasOwnProperty.call(rowData, columnField)) {

--- a/frontend/src/types/api/logs/log.ts
+++ b/frontend/src/types/api/logs/log.ts
@@ -17,6 +17,7 @@ export interface ILog {
 	attributesFloat: Record<string, never>;
 	severity_text: string;
 	severity_number: number;
+	trace_id?: string;
 }
 
 type OmitAttributesResources = Pick<


### PR DESCRIPTION
## 📄 Summary

Users were unable to easily discover the Logs → Traces action since it was located at the bottom of the view. To improve discoverability and accessibility, we have moved (pinned) this action to the top of the interface.

## ✅ Changes

We now conditionally pin the trace_id attribute only when it is present in the log data. This ensures that trace-related context is highlighted for logs that are associated with traces, while avoiding unnecessary or empty pinned attributes for logs without a trace reference.

---

## 🧪 How to Test

1. Open app.us.staging.signoz.cloud and navigate to Logs Explorer https://app.us.staging.signoz.cloud/logs/logs-explorer
2. Open any log detail view 
3. If traceId is present, it should be pinned and onClick should redirect as expected

---

## 🔍 Related Issues

<!-- Reference any related issues (e.g. Fixes #123, Closes #456) -->
Closes #https://github.com/SigNoz/engineering-pod/issues/3356

---

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

Before: 

https://github.com/user-attachments/assets/95cfa3d1-0320-4a4e-8935-d05dd0484935



After: 
https://github.com/user-attachments/assets/252cc3b2-7694-4a21-9891-da89a3b624a2


## 📋 Checklist

- [x] Dev Review
- [x] Test cases added (Unit/ Integration / E2E)
- [x] Manually tested the changes