### PR TITLE
fix: added layout fix for changelog modal

### DIFF
--- a/frontend/src/components/ChangelogModal/components/ChangelogRenderer.styles.scss
+++ b/frontend/src/components/ChangelogModal/components/ChangelogRenderer.styles.scss
@@ -58,6 +58,7 @@
 		flex-direction: column;
 		gap: 16px;
 		padding-left: 30px;
+		margin-bottom: 1rem;
 
 		li {
 			position: relative;


### PR DESCRIPTION
## 📄 Summary
- Spacing fix for changelog modal

## 📸 Screenshots / Screen Recording (if applicable / mandatory for UI related changes)

<!-- Add screenshots or GIFs to help visualize changes -->
### Before
<img width="824" height="1028" alt="image" src="https://github.com/user-attachments/assets/ccef6b10-af70-418a-8228-d7eed974bfa1" />

--- 
### After
<img width="823" height="1037" alt="image" src="https://github.com/user-attachments/assets/811b89be-fbd4-4539-af5c-8d0615425fa4" />


---

## 📋 Checklist

- [ ] Dev Review
- [ ] Test cases added (Unit/ Integration / E2E)
- [ ] Manually tested the changes


---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves spacing in the changelog modal lists.
> 
> - Adds `margin-bottom: 1rem` to `ul, ol` in `ChangelogRenderer.styles.scss` to create clearer separation after lists
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b63451530217c9b1bef264759a63662ad046b5fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->