### PR TITLE
fix(kafka): fix nil pointer error in evaluation api

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -3135,7 +3135,10 @@ func (aH *APIHandler) getProducerConsumerEval(w http.ResponseWriter, r *http.Req
 	queryRangeParams, err := kafka.BuildQueryRangeParams(messagingQueue, "producer-consumer-eval", kafkaSpanEval)
 	if err != nil {
 		zap.L().Error(err.Error())
-		RespondError(w, apiErr, nil)
+		RespondError(w, &model.ApiError{
+			Typ: model.ErrorBadData,
+			Err: err,
+		}, nil)
 		return
 	}
 


### PR DESCRIPTION
## 📄 Summary

- fix nil pointer error in evaluation api

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves error handling in Kafka span evaluation API.
> 
> - In `getProducerConsumerEval` (http_handler.go), replace `RespondError(w, apiErr, nil)` on `BuildQueryRangeParams` failure with `RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)` to surface the real error and prevent nil dereference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92e9f992747918aed72824e5ce4291f5cb7295e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->