### PR TITLE
Add context7.json with URL and public key

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/signoz/signoz",
+  "public_key": "pk_6g9GfjdkuPEIDuTGAxnol"
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  

To verify ownership of context7 library

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `context7.json` to the repo to expose Context7 verification data.
> 
> - New `context7.json` with `url` and `public_key` used for ownership verification
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41ba67dc45be3e953a588bc8488794c415799bfe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->