### PR TITLE
chore: update metrics explorer v2 generated APIs

### DIFF
--- a/frontend/src/api/generated/services/authdomains/index.ts
+++ b/frontend/src/api/generated/services/authdomains/index.ts
@@ -4,6 +4,7 @@
  * * regenerate with 'yarn generate:api'
  * SigNoz
  */
+import { useMutation, useQuery } from 'react-query';
 import type {
 	InvalidateOptions,
 	MutationFunction,
@@ -15,9 +16,7 @@ import type {
 	UseQueryOptions,
 	UseQueryResult,
 } from 'react-query';
-import { useMutation, useQuery } from 'react-query';
 
-import { GeneratedAPIInstance } from '../../../index';
 import type {
 	AuthtypesPostableAuthDomainDTO,
 	AuthtypesUpdateableAuthDomainDTO,
@@ -28,6 +27,8 @@ import type {
 	UpdateAuthDomainPathParameters,
 } from '../sigNoz.schemas';
 
+import { GeneratedAPIInstance } from '../../../index';
+
 type AwaitedInput<T> = PromiseLike<T> | T;
 
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
@@ -36,14 +37,17 @@ type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
  * This endpoint lists all auth domains
  * @summary List all auth domains
  */
-export const listAuthDomains = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<ListAuthDomains200>({
+export const listAuthDomains = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<ListAuthDomains200>({
 		url: `/api/v1/domains`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getListAuthDomainsQueryKey = () => ['listAuthDomains'] as const;
+export const getListAuthDomainsQueryKey = () => {
+	return ['listAuthDomains'] as const;
+};
 
 export const getListAuthDomainsQueryOptions = <
 	TData = Awaited<ReturnType<typeof listAuthDomains>>,
@@ -122,14 +126,15 @@ export const invalidateListAuthDomains = async (
 export const createAuthDomain = (
 	authtypesPostableAuthDomainDTO: AuthtypesPostableAuthDomainDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<CreateAuthDomain200>({
+) => {
+	return GeneratedAPIInstance<CreateAuthDomain200>({
 		url: `/api/v1/domains`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: authtypesPostableAuthDomainDTO,
 		signal,
 	});
+};
 
 export const getCreateAuthDomainMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -201,11 +206,12 @@ export const useCreateAuthDomain = <
  * This endpoint deletes an auth domain
  * @summary Delete auth domain
  */
-export const deleteAuthDomain = ({ id }: DeleteAuthDomainPathParameters) =>
-	GeneratedAPIInstance<void>({
+export const deleteAuthDomain = ({ id }: DeleteAuthDomainPathParameters) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v1/domains/${id}`,
 		method: 'DELETE',
 	});
+};
 
 export const getDeleteAuthDomainMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -280,13 +286,14 @@ export const useDeleteAuthDomain = <
 export const updateAuthDomain = (
 	{ id }: UpdateAuthDomainPathParameters,
 	authtypesUpdateableAuthDomainDTO: AuthtypesUpdateableAuthDomainDTO,
-) =>
-	GeneratedAPIInstance<void>({
+) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v1/domains/${id}`,
 		method: 'PUT',
 		headers: { 'Content-Type': 'application/json' },
 		data: authtypesUpdateableAuthDomainDTO,
 	});
+};
 
 export const getUpdateAuthDomainMutationOptions = <
 	TError = RenderErrorResponseDTO,

--- a/frontend/src/api/generated/services/dashboard/index.ts
+++ b/frontend/src/api/generated/services/dashboard/index.ts
@@ -4,6 +4,7 @@
  * * regenerate with 'yarn generate:api'
  * SigNoz
  */
+import { useMutation, useQuery } from 'react-query';
 import type {
 	InvalidateOptions,
 	MutationFunction,
@@ -15,9 +16,7 @@ import type {
 	UseQueryOptions,
 	UseQueryResult,
 } from 'react-query';
-import { useMutation, useQuery } from 'react-query';
 
-import { GeneratedAPIInstance } from '../../../index';
 import type {
 	CreatePublicDashboard201,
 	CreatePublicDashboardPathParameters,
@@ -34,6 +33,8 @@ import type {
 	UpdatePublicDashboardPathParameters,
 } from '../sigNoz.schemas';
 
+import { GeneratedAPIInstance } from '../../../index';
+
 type AwaitedInput<T> = PromiseLike<T> | T;
 
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
@@ -44,11 +45,12 @@ type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
  */
 export const deletePublicDashboard = ({
 	id,
-}: DeletePublicDashboardPathParameters) =>
-	GeneratedAPIInstance<string>({
+}: DeletePublicDashboardPathParameters) => {
+	return GeneratedAPIInstance<string>({
 		url: `/api/v1/dashboards/${id}/public`,
 		method: 'DELETE',
 	});
+};
 
 export const getDeletePublicDashboardMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -123,16 +125,19 @@ export const useDeletePublicDashboard = <
 export const getPublicDashboard = (
 	{ id }: GetPublicDashboardPathParameters,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<GetPublicDashboard200>({
+) => {
+	return GeneratedAPIInstance<GetPublicDashboard200>({
 		url: `/api/v1/dashboards/${id}/public`,
 		method: 'GET',
 		signal,
 	});
+};
 
 export const getGetPublicDashboardQueryKey = ({
 	id,
-}: GetPublicDashboardPathParameters) => ['getPublicDashboard'] as const;
+}: GetPublicDashboardPathParameters) => {
+	return ['getPublicDashboard'] as const;
+};
 
 export const getGetPublicDashboardQueryOptions = <
 	TData = Awaited<ReturnType<typeof getPublicDashboard>>,
@@ -225,14 +230,15 @@ export const createPublicDashboard = (
 	{ id }: CreatePublicDashboardPathParameters,
 	dashboardtypesPostablePublicDashboardDTO: DashboardtypesPostablePublicDashboardDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<CreatePublicDashboard201>({
+) => {
+	return GeneratedAPIInstance<CreatePublicDashboard201>({
 		url: `/api/v1/dashboards/${id}/public`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: dashboardtypesPostablePublicDashboardDTO,
 		signal,
 	});
+};
 
 export const getCreatePublicDashboardMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -322,13 +328,14 @@ export const useCreatePublicDashboard = <
 export const updatePublicDashboard = (
 	{ id }: UpdatePublicDashboardPathParameters,
 	dashboardtypesUpdatablePublicDashboardDTO: DashboardtypesUpdatablePublicDashboardDTO,
-) =>
-	GeneratedAPIInstance<string>({
+) => {
+	return GeneratedAPIInstance<string>({
 		url: `/api/v1/dashboards/${id}/public`,
 		method: 'PUT',
 		headers: { 'Content-Type': 'application/json' },
 		data: dashboardtypesUpdatablePublicDashboardDTO,
 	});
+};
 
 export const getUpdatePublicDashboardMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -418,16 +425,19 @@ export const useUpdatePublicDashboard = <
 export const getPublicDashboardData = (
 	{ id }: GetPublicDashboardDataPathParameters,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<GetPublicDashboardData200>({
+) => {
+	return GeneratedAPIInstance<GetPublicDashboardData200>({
 		url: `/api/v1/public/dashboards/${id}`,
 		method: 'GET',
 		signal,
 	});
+};
 
 export const getGetPublicDashboardDataQueryKey = ({
 	id,
-}: GetPublicDashboardDataPathParameters) => ['getPublicDashboardData'] as const;
+}: GetPublicDashboardDataPathParameters) => {
+	return ['getPublicDashboardData'] as const;
+};
 
 export const getGetPublicDashboardDataQueryOptions = <
 	TData = Awaited<ReturnType<typeof getPublicDashboardData>>,
@@ -519,18 +529,20 @@ export const invalidateGetPublicDashboardData = async (
 export const getPublicDashboardWidgetQueryRange = (
 	{ id, idx }: GetPublicDashboardWidgetQueryRangePathParameters,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<GetPublicDashboardWidgetQueryRange200>({
+) => {
+	return GeneratedAPIInstance<GetPublicDashboardWidgetQueryRange200>({
 		url: `/api/v1/public/dashboards/${id}/widgets/${idx}/query_range`,
 		method: 'GET',
 		signal,
 	});
+};
 
 export const getGetPublicDashboardWidgetQueryRangeQueryKey = ({
 	id,
 	idx,
-}: GetPublicDashboardWidgetQueryRangePathParameters) =>
-	['getPublicDashboardWidgetQueryRange'] as const;
+}: GetPublicDashboardWidgetQueryRangePathParameters) => {
+	return ['getPublicDashboardWidgetQueryRange'] as const;
+};
 
 export const getGetPublicDashboardWidgetQueryRangeQueryOptions = <
 	TData = Awaited<ReturnType<typeof getPublicDashboardWidgetQueryRange>>,

--- a/frontend/src/api/generated/services/features/index.ts
+++ b/frontend/src/api/generated/services/features/index.ts
@@ -4,6 +4,7 @@
  * * regenerate with 'yarn generate:api'
  * SigNoz
  */
+import { useQuery } from 'react-query';
 import type {
 	InvalidateOptions,
 	QueryClient,
@@ -12,10 +13,10 @@ import type {
 	UseQueryOptions,
 	UseQueryResult,
 } from 'react-query';
-import { useQuery } from 'react-query';
+
+import type { GetFeatures200, RenderErrorResponseDTO } from '../sigNoz.schemas';
 
 import { GeneratedAPIInstance } from '../../../index';
-import type { GetFeatures200, RenderErrorResponseDTO } from '../sigNoz.schemas';
 
 type AwaitedInput<T> = PromiseLike<T> | T;
 
@@ -25,14 +26,17 @@ type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
  * This endpoint returns the supported features and their details
  * @summary Get features
  */
-export const getFeatures = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<GetFeatures200>({
+export const getFeatures = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<GetFeatures200>({
 		url: `/api/v2/features`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getGetFeaturesQueryKey = () => ['getFeatures'] as const;
+export const getGetFeaturesQueryKey = () => {
+	return ['getFeatures'] as const;
+};
 
 export const getGetFeaturesQueryOptions = <
 	TData = Awaited<ReturnType<typeof getFeatures>>,

--- a/frontend/src/api/generated/services/gateway/index.ts
+++ b/frontend/src/api/generated/services/gateway/index.ts
@@ -4,6 +4,7 @@
  * * regenerate with 'yarn generate:api'
  * SigNoz
  */
+import { useMutation, useQuery } from 'react-query';
 import type {
 	InvalidateOptions,
 	MutationFunction,
@@ -15,9 +16,7 @@ import type {
 	UseQueryOptions,
 	UseQueryResult,
 } from 'react-query';
-import { useMutation, useQuery } from 'react-query';
 
-import { GeneratedAPIInstance } from '../../../index';
 import type {
 	CreateIngestionKey200,
 	CreateIngestionKeyLimit201,
@@ -34,6 +33,8 @@ import type {
 	UpdateIngestionKeyPathParameters,
 } from '../sigNoz.schemas';
 
+import { GeneratedAPIInstance } from '../../../index';
+
 type AwaitedInput<T> = PromiseLike<T> | T;
 
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
@@ -42,14 +43,17 @@ type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
  * This endpoint returns the ingestion keys for a workspace
  * @summary Get ingestion keys for workspace
  */
-export const getIngestionKeys = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<GetIngestionKeys200>({
+export const getIngestionKeys = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<GetIngestionKeys200>({
 		url: `/api/v2/gateway/ingestion_keys`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getGetIngestionKeysQueryKey = () => ['getIngestionKeys'] as const;
+export const getGetIngestionKeysQueryKey = () => {
+	return ['getIngestionKeys'] as const;
+};
 
 export const getGetIngestionKeysQueryOptions = <
 	TData = Awaited<ReturnType<typeof getIngestionKeys>>,
@@ -128,14 +132,15 @@ export const invalidateGetIngestionKeys = async (
 export const createIngestionKey = (
 	gatewaytypesPostableIngestionKeyDTO: GatewaytypesPostableIngestionKeyDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<CreateIngestionKey200>({
+) => {
+	return GeneratedAPIInstance<CreateIngestionKey200>({
 		url: `/api/v2/gateway/ingestion_keys`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: gatewaytypesPostableIngestionKeyDTO,
 		signal,
 	});
+};
 
 export const getCreateIngestionKeyMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -209,11 +214,12 @@ export const useCreateIngestionKey = <
  */
 export const deleteIngestionKey = ({
 	keyId,
-}: DeleteIngestionKeyPathParameters) =>
-	GeneratedAPIInstance<void>({
+}: DeleteIngestionKeyPathParameters) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v2/gateway/ingestion_keys/${keyId}`,
 		method: 'DELETE',
 	});
+};
 
 export const getDeleteIngestionKeyMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -288,13 +294,14 @@ export const useDeleteIngestionKey = <
 export const updateIngestionKey = (
 	{ keyId }: UpdateIngestionKeyPathParameters,
 	gatewaytypesPostableIngestionKeyDTO: GatewaytypesPostableIngestionKeyDTO,
-) =>
-	GeneratedAPIInstance<void>({
+) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v2/gateway/ingestion_keys/${keyId}`,
 		method: 'PATCH',
 		headers: { 'Content-Type': 'application/json' },
 		data: gatewaytypesPostableIngestionKeyDTO,
 	});
+};
 
 export const getUpdateIngestionKeyMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -385,14 +392,15 @@ export const createIngestionKeyLimit = (
 	{ keyId }: CreateIngestionKeyLimitPathParameters,
 	gatewaytypesPostableIngestionKeyLimitDTO: GatewaytypesPostableIngestionKeyLimitDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<CreateIngestionKeyLimit201>({
+) => {
+	return GeneratedAPIInstance<CreateIngestionKeyLimit201>({
 		url: `/api/v2/gateway/ingestion_keys/${keyId}/limits`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: gatewaytypesPostableIngestionKeyLimitDTO,
 		signal,
 	});
+};
 
 export const getCreateIngestionKeyLimitMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -481,11 +489,12 @@ export const useCreateIngestionKeyLimit = <
  */
 export const deleteIngestionKeyLimit = ({
 	limitId,
-}: DeleteIngestionKeyLimitPathParameters) =>
-	GeneratedAPIInstance<void>({
+}: DeleteIngestionKeyLimitPathParameters) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v2/gateway/ingestion_keys/limits/${limitId}`,
 		method: 'DELETE',
 	});
+};
 
 export const getDeleteIngestionKeyLimitMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -560,13 +569,14 @@ export const useDeleteIngestionKeyLimit = <
 export const updateIngestionKeyLimit = (
 	{ limitId }: UpdateIngestionKeyLimitPathParameters,
 	gatewaytypesUpdatableIngestionKeyLimitDTO: GatewaytypesUpdatableIngestionKeyLimitDTO,
-) =>
-	GeneratedAPIInstance<void>({
+) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v2/gateway/ingestion_keys/limits/${limitId}`,
 		method: 'PATCH',
 		headers: { 'Content-Type': 'application/json' },
 		data: gatewaytypesUpdatableIngestionKeyLimitDTO,
 	});
+};
 
 export const getUpdateIngestionKeyLimitMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -653,15 +663,17 @@ export const useUpdateIngestionKeyLimit = <
  * This endpoint returns the ingestion keys for a workspace
  * @summary Search ingestion keys for workspace
  */
-export const searchIngestionKeys = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<SearchIngestionKeys200>({
+export const searchIngestionKeys = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<SearchIngestionKeys200>({
 		url: `/api/v2/gateway/ingestion_keys/search`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getSearchIngestionKeysQueryKey = () =>
-	['searchIngestionKeys'] as const;
+export const getSearchIngestionKeysQueryKey = () => {
+	return ['searchIngestionKeys'] as const;
+};
 
 export const getSearchIngestionKeysQueryOptions = <
 	TData = Awaited<ReturnType<typeof searchIngestionKeys>>,

--- a/frontend/src/api/generated/services/global/index.ts
+++ b/frontend/src/api/generated/services/global/index.ts
@@ -4,6 +4,7 @@
  * * regenerate with 'yarn generate:api'
  * SigNoz
  */
+import { useQuery } from 'react-query';
 import type {
 	InvalidateOptions,
 	QueryClient,
@@ -12,13 +13,13 @@ import type {
 	UseQueryOptions,
 	UseQueryResult,
 } from 'react-query';
-import { useQuery } from 'react-query';
 
-import { GeneratedAPIInstance } from '../../../index';
 import type {
 	GetGlobalConfig200,
 	RenderErrorResponseDTO,
 } from '../sigNoz.schemas';
+
+import { GeneratedAPIInstance } from '../../../index';
 
 type AwaitedInput<T> = PromiseLike<T> | T;
 
@@ -28,14 +29,17 @@ type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
  * This endpoints returns global config
  * @summary Get global config
  */
-export const getGlobalConfig = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<GetGlobalConfig200>({
+export const getGlobalConfig = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<GetGlobalConfig200>({
 		url: `/api/v1/global/config`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getGetGlobalConfigQueryKey = () => ['getGlobalConfig'] as const;
+export const getGetGlobalConfigQueryKey = () => {
+	return ['getGlobalConfig'] as const;
+};
 
 export const getGetGlobalConfigQueryOptions = <
 	TData = Awaited<ReturnType<typeof getGlobalConfig>>,

--- a/frontend/src/api/generated/services/logs/index.ts
+++ b/frontend/src/api/generated/services/logs/index.ts
@@ -4,6 +4,7 @@
  * * regenerate with 'yarn generate:api'
  * SigNoz
  */
+import { useMutation, useQuery } from 'react-query';
 import type {
 	InvalidateOptions,
 	MutationFunction,
@@ -15,14 +16,14 @@ import type {
 	UseQueryOptions,
 	UseQueryResult,
 } from 'react-query';
-import { useMutation, useQuery } from 'react-query';
 
-import { GeneratedAPIInstance } from '../../../index';
 import type {
 	ListPromotedAndIndexedPaths200,
 	PromotetypesPromotePathDTO,
 	RenderErrorResponseDTO,
 } from '../sigNoz.schemas';
+
+import { GeneratedAPIInstance } from '../../../index';
 
 type AwaitedInput<T> = PromiseLike<T> | T;
 
@@ -32,15 +33,17 @@ type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
  * This endpoints promotes and indexes paths
  * @summary Promote and index paths
  */
-export const listPromotedAndIndexedPaths = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<ListPromotedAndIndexedPaths200>({
+export const listPromotedAndIndexedPaths = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<ListPromotedAndIndexedPaths200>({
 		url: `/api/v1/logs/promote_paths`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getListPromotedAndIndexedPathsQueryKey = () =>
-	['listPromotedAndIndexedPaths'] as const;
+export const getListPromotedAndIndexedPathsQueryKey = () => {
+	return ['listPromotedAndIndexedPaths'] as const;
+};
 
 export const getListPromotedAndIndexedPathsQueryOptions = <
 	TData = Awaited<ReturnType<typeof listPromotedAndIndexedPaths>>,
@@ -120,14 +123,15 @@ export const invalidateListPromotedAndIndexedPaths = async (
 export const handlePromoteAndIndexPaths = (
 	promotetypesPromotePathDTONull: PromotetypesPromotePathDTO[] | null,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<void>({
+) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v1/logs/promote_paths`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: promotetypesPromotePathDTONull,
 		signal,
 	});
+};
 
 export const getHandlePromoteAndIndexPathsMutationOptions = <
 	TError = RenderErrorResponseDTO,

--- a/frontend/src/api/generated/services/metrics/index.ts
+++ b/frontend/src/api/generated/services/metrics/index.ts
@@ -4,6 +4,7 @@
  * * regenerate with 'yarn generate:api'
  * SigNoz
  */
+import { useMutation, useQuery } from 'react-query';
 import type {
 	InvalidateOptions,
 	MutationFunction,
@@ -15,15 +16,17 @@ import type {
 	UseQueryOptions,
 	UseQueryResult,
 } from 'react-query';
-import { useMutation, useQuery } from 'react-query';
 
-import { GeneratedAPIInstance } from '../../../index';
 import type {
 	GetMetricAlerts200,
+	GetMetricAlertsParams,
 	GetMetricAttributes200,
 	GetMetricDashboards200,
+	GetMetricDashboardsParams,
 	GetMetricHighlights200,
+	GetMetricHighlightsParams,
 	GetMetricMetadata200,
+	GetMetricMetadataParams,
 	GetMetricsStats200,
 	GetMetricsTreemap200,
 	MetricsexplorertypesMetricAttributesRequestDTO,
@@ -34,6 +37,8 @@ import type {
 	UpdateMetricMetadataPathParameters,
 } from '../sigNoz.schemas';
 
+import { GeneratedAPIInstance } from '../../../index';
+
 type AwaitedInput<T> = PromiseLike<T> | T;
 
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
@@ -42,32 +47,42 @@ type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
  * This endpoint returns associated alerts for a specified metric
  * @summary Get metric alerts
  */
-export const getMetricAlerts = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<GetMetricAlerts200>({
+export const getMetricAlerts = (
+	params?: GetMetricAlertsParams,
+	signal?: AbortSignal,
+) => {
+	return GeneratedAPIInstance<GetMetricAlerts200>({
 		url: `/api/v2/metric/alerts`,
 		method: 'GET',
+		params,
 		signal,
 	});
+};
 
-export const getGetMetricAlertsQueryKey = () => ['getMetricAlerts'] as const;
+export const getGetMetricAlertsQueryKey = (params?: GetMetricAlertsParams) => {
+	return ['getMetricAlerts', ...(params ? [params] : [])] as const;
+};
 
 export const getGetMetricAlertsQueryOptions = <
 	TData = Awaited<ReturnType<typeof getMetricAlerts>>,
 	TError = RenderErrorResponseDTO
->(options?: {
-	query?: UseQueryOptions<
-		Awaited<ReturnType<typeof getMetricAlerts>>,
-		TError,
-		TData
-	>;
-}) => {
+>(
+	params?: GetMetricAlertsParams,
+	options?: {
+		query?: UseQueryOptions<
+			Awaited<ReturnType<typeof getMetricAlerts>>,
+			TError,
+			TData
+		>;
+	},
+) => {
 	const { query: queryOptions } = options ?? {};
 
-	const queryKey = queryOptions?.queryKey ?? getGetMetricAlertsQueryKey();
+	const queryKey = queryOptions?.queryKey ?? getGetMetricAlertsQueryKey(params);
 
 	const queryFn: QueryFunction<Awaited<ReturnType<typeof getMetricAlerts>>> = ({
 		signal,
-	}) => getMetricAlerts(signal);
+	}) => getMetricAlerts(params, signal);
 
 	return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
 		Awaited<ReturnType<typeof getMetricAlerts>>,
@@ -88,14 +103,17 @@ export type GetMetricAlertsQueryError = RenderErrorResponseDTO;
 export function useGetMetricAlerts<
 	TData = Awaited<ReturnType<typeof getMetricAlerts>>,
 	TError = RenderErrorResponseDTO
->(options?: {
-	query?: UseQueryOptions<
-		Awaited<ReturnType<typeof getMetricAlerts>>,
-		TError,
-		TData
-	>;
-}): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
-	const queryOptions = getGetMetricAlertsQueryOptions(options);
+>(
+	params?: GetMetricAlertsParams,
+	options?: {
+		query?: UseQueryOptions<
+			Awaited<ReturnType<typeof getMetricAlerts>>,
+			TError,
+			TData
+		>;
+	},
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
+	const queryOptions = getGetMetricAlertsQueryOptions(params, options);
 
 	const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
 		queryKey: QueryKey;
@@ -111,10 +129,11 @@ export function useGetMetricAlerts<
  */
 export const invalidateGetMetricAlerts = async (
 	queryClient: QueryClient,
+	params?: GetMetricAlertsParams,
 	options?: InvalidateOptions,
 ): Promise<QueryClient> => {
 	await queryClient.invalidateQueries(
-		{ queryKey: getGetMetricAlertsQueryKey() },
+		{ queryKey: getGetMetricAlertsQueryKey(params) },
 		options,
 	);
 
@@ -125,33 +144,45 @@ export const invalidateGetMetricAlerts = async (
  * This endpoint returns associated dashboards for a specified metric
  * @summary Get metric dashboards
  */
-export const getMetricDashboards = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<GetMetricDashboards200>({
+export const getMetricDashboards = (
+	params?: GetMetricDashboardsParams,
+	signal?: AbortSignal,
+) => {
+	return GeneratedAPIInstance<GetMetricDashboards200>({
 		url: `/api/v2/metric/dashboards`,
 		method: 'GET',
+		params,
 		signal,
 	});
+};
 
-export const getGetMetricDashboardsQueryKey = () =>
-	['getMetricDashboards'] as const;
+export const getGetMetricDashboardsQueryKey = (
+	params?: GetMetricDashboardsParams,
+) => {
+	return ['getMetricDashboards', ...(params ? [params] : [])] as const;
+};
 
 export const getGetMetricDashboardsQueryOptions = <
 	TData = Awaited<ReturnType<typeof getMetricDashboards>>,
 	TError = RenderErrorResponseDTO
->(options?: {
-	query?: UseQueryOptions<
-		Awaited<ReturnType<typeof getMetricDashboards>>,
-		TError,
-		TData
-	>;
-}) => {
+>(
+	params?: GetMetricDashboardsParams,
+	options?: {
+		query?: UseQueryOptions<
+			Awaited<ReturnType<typeof getMetricDashboards>>,
+			TError,
+			TData
+		>;
+	},
+) => {
 	const { query: queryOptions } = options ?? {};
 
-	const queryKey = queryOptions?.queryKey ?? getGetMetricDashboardsQueryKey();
+	const queryKey =
+		queryOptions?.queryKey ?? getGetMetricDashboardsQueryKey(params);
 
 	const queryFn: QueryFunction<
 		Awaited<ReturnType<typeof getMetricDashboards>>
-	> = ({ signal }) => getMetricDashboards(signal);
+	> = ({ signal }) => getMetricDashboards(params, signal);
 
 	return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
 		Awaited<ReturnType<typeof getMetricDashboards>>,
@@ -172,14 +203,17 @@ export type GetMetricDashboardsQueryError = RenderErrorResponseDTO;
 export function useGetMetricDashboards<
 	TData = Awaited<ReturnType<typeof getMetricDashboards>>,
 	TError = RenderErrorResponseDTO
->(options?: {
-	query?: UseQueryOptions<
-		Awaited<ReturnType<typeof getMetricDashboards>>,
-		TError,
-		TData
-	>;
-}): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
-	const queryOptions = getGetMetricDashboardsQueryOptions(options);
+>(
+	params?: GetMetricDashboardsParams,
+	options?: {
+		query?: UseQueryOptions<
+			Awaited<ReturnType<typeof getMetricDashboards>>,
+			TError,
+			TData
+		>;
+	},
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
+	const queryOptions = getGetMetricDashboardsQueryOptions(params, options);
 
 	const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
 		queryKey: QueryKey;
@@ -195,10 +229,11 @@ export function useGetMetricDashboards<
  */
 export const invalidateGetMetricDashboards = async (
 	queryClient: QueryClient,
+	params?: GetMetricDashboardsParams,
 	options?: InvalidateOptions,
 ): Promise<QueryClient> => {
 	await queryClient.invalidateQueries(
-		{ queryKey: getGetMetricDashboardsQueryKey() },
+		{ queryKey: getGetMetricDashboardsQueryKey(params) },
 		options,
 	);
 
@@ -209,33 +244,45 @@ export const invalidateGetMetricDashboards = async (
  * This endpoint returns highlights like number of datapoints, totaltimeseries, active time series, last received time for a specified metric
  * @summary Get metric highlights
  */
-export const getMetricHighlights = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<GetMetricHighlights200>({
+export const getMetricHighlights = (
+	params?: GetMetricHighlightsParams,
+	signal?: AbortSignal,
+) => {
+	return GeneratedAPIInstance<GetMetricHighlights200>({
 		url: `/api/v2/metric/highlights`,
 		method: 'GET',
+		params,
 		signal,
 	});
+};
 
-export const getGetMetricHighlightsQueryKey = () =>
-	['getMetricHighlights'] as const;
+export const getGetMetricHighlightsQueryKey = (
+	params?: GetMetricHighlightsParams,
+) => {
+	return ['getMetricHighlights', ...(params ? [params] : [])] as const;
+};
 
 export const getGetMetricHighlightsQueryOptions = <
 	TData = Awaited<ReturnType<typeof getMetricHighlights>>,
 	TError = RenderErrorResponseDTO
->(options?: {
-	query?: UseQueryOptions<
-		Awaited<ReturnType<typeof getMetricHighlights>>,
-		TError,
-		TData
-	>;
-}) => {
+>(
+	params?: GetMetricHighlightsParams,
+	options?: {
+		query?: UseQueryOptions<
+			Awaited<ReturnType<typeof getMetricHighlights>>,
+			TError,
+			TData
+		>;
+	},
+) => {
 	const { query: queryOptions } = options ?? {};
 
-	const queryKey = queryOptions?.queryKey ?? getGetMetricHighlightsQueryKey();
+	const queryKey =
+		queryOptions?.queryKey ?? getGetMetricHighlightsQueryKey(params);
 
 	const queryFn: QueryFunction<
 		Awaited<ReturnType<typeof getMetricHighlights>>
-	> = ({ signal }) => getMetricHighlights(signal);
+	> = ({ signal }) => getMetricHighlights(params, signal);
 
 	return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
 		Awaited<ReturnType<typeof getMetricHighlights>>,
@@ -256,14 +303,17 @@ export type GetMetricHighlightsQueryError = RenderErrorResponseDTO;
 export function useGetMetricHighlights<
 	TData = Awaited<ReturnType<typeof getMetricHighlights>>,
 	TError = RenderErrorResponseDTO
->(options?: {
-	query?: UseQueryOptions<
-		Awaited<ReturnType<typeof getMetricHighlights>>,
-		TError,
-		TData
-	>;
-}): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
-	const queryOptions = getGetMetricHighlightsQueryOptions(options);
+>(
+	params?: GetMetricHighlightsParams,
+	options?: {
+		query?: UseQueryOptions<
+			Awaited<ReturnType<typeof getMetricHighlights>>,
+			TError,
+			TData
+		>;
+	},
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
+	const queryOptions = getGetMetricHighlightsQueryOptions(params, options);
 
 	const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
 		queryKey: QueryKey;
@@ -279,10 +329,11 @@ export function useGetMetricHighlights<
  */
 export const invalidateGetMetricHighlights = async (
 	queryClient: QueryClient,
+	params?: GetMetricHighlightsParams,
 	options?: InvalidateOptions,
 ): Promise<QueryClient> => {
 	await queryClient.invalidateQueries(
-		{ queryKey: getGetMetricHighlightsQueryKey() },
+		{ queryKey: getGetMetricHighlightsQueryKey(params) },
 		options,
 	);
 
@@ -297,14 +348,15 @@ export const updateMetricMetadata = (
 	{ metricName }: UpdateMetricMetadataPathParameters,
 	metricsexplorertypesUpdateMetricMetadataRequestDTO: MetricsexplorertypesUpdateMetricMetadataRequestDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<string>({
+) => {
+	return GeneratedAPIInstance<string>({
 		url: `/api/v2/metrics/${metricName}/metadata`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: metricsexplorertypesUpdateMetricMetadataRequestDTO,
 		signal,
 	});
+};
 
 export const getUpdateMetricMetadataMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -394,14 +446,15 @@ export const useUpdateMetricMetadata = <
 export const getMetricAttributes = (
 	metricsexplorertypesMetricAttributesRequestDTO: MetricsexplorertypesMetricAttributesRequestDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<GetMetricAttributes200>({
+) => {
+	return GeneratedAPIInstance<GetMetricAttributes200>({
 		url: `/api/v2/metrics/attributes`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: metricsexplorertypesMetricAttributesRequestDTO,
 		signal,
 	});
+};
 
 export const getGetMetricAttributesMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -473,33 +526,45 @@ export const useGetMetricAttributes = <
  * This endpoint returns metadata information like metric description, unit, type, temporality, monotonicity for a specified metric
  * @summary Get metric metadata
  */
-export const getMetricMetadata = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<GetMetricMetadata200>({
+export const getMetricMetadata = (
+	params?: GetMetricMetadataParams,
+	signal?: AbortSignal,
+) => {
+	return GeneratedAPIInstance<GetMetricMetadata200>({
 		url: `/api/v2/metrics/metadata`,
 		method: 'GET',
+		params,
 		signal,
 	});
+};
 
-export const getGetMetricMetadataQueryKey = () =>
-	['getMetricMetadata'] as const;
+export const getGetMetricMetadataQueryKey = (
+	params?: GetMetricMetadataParams,
+) => {
+	return ['getMetricMetadata', ...(params ? [params] : [])] as const;
+};
 
 export const getGetMetricMetadataQueryOptions = <
 	TData = Awaited<ReturnType<typeof getMetricMetadata>>,
 	TError = RenderErrorResponseDTO
->(options?: {
-	query?: UseQueryOptions<
-		Awaited<ReturnType<typeof getMetricMetadata>>,
-		TError,
-		TData
-	>;
-}) => {
+>(
+	params?: GetMetricMetadataParams,
+	options?: {
+		query?: UseQueryOptions<
+			Awaited<ReturnType<typeof getMetricMetadata>>,
+			TError,
+			TData
+		>;
+	},
+) => {
 	const { query: queryOptions } = options ?? {};
 
-	const queryKey = queryOptions?.queryKey ?? getGetMetricMetadataQueryKey();
+	const queryKey =
+		queryOptions?.queryKey ?? getGetMetricMetadataQueryKey(params);
 
 	const queryFn: QueryFunction<
 		Awaited<ReturnType<typeof getMetricMetadata>>
-	> = ({ signal }) => getMetricMetadata(signal);
+	> = ({ signal }) => getMetricMetadata(params, signal);
 
 	return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
 		Awaited<ReturnType<typeof getMetricMetadata>>,
@@ -520,14 +585,17 @@ export type GetMetricMetadataQueryError = RenderErrorResponseDTO;
 export function useGetMetricMetadata<
 	TData = Awaited<ReturnType<typeof getMetricMetadata>>,
 	TError = RenderErrorResponseDTO
->(options?: {
-	query?: UseQueryOptions<
-		Awaited<ReturnType<typeof getMetricMetadata>>,
-		TError,
-		TData
-	>;
-}): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
-	const queryOptions = getGetMetricMetadataQueryOptions(options);
+>(
+	params?: GetMetricMetadataParams,
+	options?: {
+		query?: UseQueryOptions<
+			Awaited<ReturnType<typeof getMetricMetadata>>,
+			TError,
+			TData
+		>;
+	},
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
+	const queryOptions = getGetMetricMetadataQueryOptions(params, options);
 
 	const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
 		queryKey: QueryKey;
@@ -543,10 +611,11 @@ export function useGetMetricMetadata<
  */
 export const invalidateGetMetricMetadata = async (
 	queryClient: QueryClient,
+	params?: GetMetricMetadataParams,
 	options?: InvalidateOptions,
 ): Promise<QueryClient> => {
 	await queryClient.invalidateQueries(
-		{ queryKey: getGetMetricMetadataQueryKey() },
+		{ queryKey: getGetMetricMetadataQueryKey(params) },
 		options,
 	);
 
@@ -560,14 +629,15 @@ export const invalidateGetMetricMetadata = async (
 export const getMetricsStats = (
 	metricsexplorertypesStatsRequestDTO: MetricsexplorertypesStatsRequestDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<GetMetricsStats200>({
+) => {
+	return GeneratedAPIInstance<GetMetricsStats200>({
 		url: `/api/v2/metrics/stats`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: metricsexplorertypesStatsRequestDTO,
 		signal,
 	});
+};
 
 export const getGetMetricsStatsMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -642,14 +712,15 @@ export const useGetMetricsStats = <
 export const getMetricsTreemap = (
 	metricsexplorertypesTreemapRequestDTO: MetricsexplorertypesTreemapRequestDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<GetMetricsTreemap200>({
+) => {
+	return GeneratedAPIInstance<GetMetricsTreemap200>({
 		url: `/api/v2/metrics/treemap`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: metricsexplorertypesTreemapRequestDTO,
 		signal,
 	});
+};
 
 export const getGetMetricsTreemapMutationOptions = <
 	TError = RenderErrorResponseDTO,

--- a/frontend/src/api/generated/services/orgs/index.ts
+++ b/frontend/src/api/generated/services/orgs/index.ts
@@ -4,6 +4,7 @@
  * * regenerate with 'yarn generate:api'
  * SigNoz
  */
+import { useMutation, useQuery } from 'react-query';
 import type {
 	InvalidateOptions,
 	MutationFunction,
@@ -15,14 +16,14 @@ import type {
 	UseQueryOptions,
 	UseQueryResult,
 } from 'react-query';
-import { useMutation, useQuery } from 'react-query';
 
-import { GeneratedAPIInstance } from '../../../index';
 import type {
 	GetMyOrganization200,
 	RenderErrorResponseDTO,
 	TypesOrganizationDTO,
 } from '../sigNoz.schemas';
+
+import { GeneratedAPIInstance } from '../../../index';
 
 type AwaitedInput<T> = PromiseLike<T> | T;
 
@@ -32,15 +33,17 @@ type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
  * This endpoint returns the organization I belong to
  * @summary Get my organization
  */
-export const getMyOrganization = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<GetMyOrganization200>({
+export const getMyOrganization = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<GetMyOrganization200>({
 		url: `/api/v2/orgs/me`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getGetMyOrganizationQueryKey = () =>
-	['getMyOrganization'] as const;
+export const getGetMyOrganizationQueryKey = () => {
+	return ['getMyOrganization'] as const;
+};
 
 export const getGetMyOrganizationQueryOptions = <
 	TData = Awaited<ReturnType<typeof getMyOrganization>>,
@@ -118,13 +121,14 @@ export const invalidateGetMyOrganization = async (
  */
 export const updateMyOrganization = (
 	typesOrganizationDTO: TypesOrganizationDTO,
-) =>
-	GeneratedAPIInstance<void>({
+) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v2/orgs/me`,
 		method: 'PUT',
 		headers: { 'Content-Type': 'application/json' },
 		data: typesOrganizationDTO,
 	});
+};
 
 export const getUpdateMyOrganizationMutationOptions = <
 	TError = RenderErrorResponseDTO,

--- a/frontend/src/api/generated/services/preferences/index.ts
+++ b/frontend/src/api/generated/services/preferences/index.ts
@@ -4,6 +4,7 @@
  * * regenerate with 'yarn generate:api'
  * SigNoz
  */
+import { useMutation, useQuery } from 'react-query';
 import type {
 	InvalidateOptions,
 	MutationFunction,
@@ -15,9 +16,7 @@ import type {
 	UseQueryOptions,
 	UseQueryResult,
 } from 'react-query';
-import { useMutation, useQuery } from 'react-query';
 
-import { GeneratedAPIInstance } from '../../../index';
 import type {
 	GetOrgPreference200,
 	GetOrgPreferencePathParameters,
@@ -31,6 +30,8 @@ import type {
 	UpdateUserPreferencePathParameters,
 } from '../sigNoz.schemas';
 
+import { GeneratedAPIInstance } from '../../../index';
+
 type AwaitedInput<T> = PromiseLike<T> | T;
 
 type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
@@ -39,15 +40,17 @@ type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
  * This endpoint lists all org preferences
  * @summary List org preferences
  */
-export const listOrgPreferences = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<ListOrgPreferences200>({
+export const listOrgPreferences = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<ListOrgPreferences200>({
 		url: `/api/v1/org/preferences`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getListOrgPreferencesQueryKey = () =>
-	['listOrgPreferences'] as const;
+export const getListOrgPreferencesQueryKey = () => {
+	return ['listOrgPreferences'] as const;
+};
 
 export const getListOrgPreferencesQueryOptions = <
 	TData = Awaited<ReturnType<typeof listOrgPreferences>>,
@@ -126,16 +129,19 @@ export const invalidateListOrgPreferences = async (
 export const getOrgPreference = (
 	{ name }: GetOrgPreferencePathParameters,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<GetOrgPreference200>({
+) => {
+	return GeneratedAPIInstance<GetOrgPreference200>({
 		url: `/api/v1/org/preferences/${name}`,
 		method: 'GET',
 		signal,
 	});
+};
 
 export const getGetOrgPreferenceQueryKey = ({
 	name,
-}: GetOrgPreferencePathParameters) => ['getOrgPreference'] as const;
+}: GetOrgPreferencePathParameters) => {
+	return ['getOrgPreference'] as const;
+};
 
 export const getGetOrgPreferenceQueryOptions = <
 	TData = Awaited<ReturnType<typeof getOrgPreference>>,
@@ -227,13 +233,14 @@ export const invalidateGetOrgPreference = async (
 export const updateOrgPreference = (
 	{ name }: UpdateOrgPreferencePathParameters,
 	preferencetypesUpdatablePreferenceDTO: PreferencetypesUpdatablePreferenceDTO,
-) =>
-	GeneratedAPIInstance<void>({
+) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v1/org/preferences/${name}`,
 		method: 'PUT',
 		headers: { 'Content-Type': 'application/json' },
 		data: preferencetypesUpdatablePreferenceDTO,
 	});
+};
 
 export const getUpdateOrgPreferenceMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -320,15 +327,17 @@ export const useUpdateOrgPreference = <
  * This endpoint lists all user preferences
  * @summary List user preferences
  */
-export const listUserPreferences = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<ListUserPreferences200>({
+export const listUserPreferences = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<ListUserPreferences200>({
 		url: `/api/v1/user/preferences`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getListUserPreferencesQueryKey = () =>
-	['listUserPreferences'] as const;
+export const getListUserPreferencesQueryKey = () => {
+	return ['listUserPreferences'] as const;
+};
 
 export const getListUserPreferencesQueryOptions = <
 	TData = Awaited<ReturnType<typeof listUserPreferences>>,
@@ -407,16 +416,19 @@ export const invalidateListUserPreferences = async (
 export const getUserPreference = (
 	{ name }: GetUserPreferencePathParameters,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<GetUserPreference200>({
+) => {
+	return GeneratedAPIInstance<GetUserPreference200>({
 		url: `/api/v1/user/preferences/${name}`,
 		method: 'GET',
 		signal,
 	});
+};
 
 export const getGetUserPreferenceQueryKey = ({
 	name,
-}: GetUserPreferencePathParameters) => ['getUserPreference'] as const;
+}: GetUserPreferencePathParameters) => {
+	return ['getUserPreference'] as const;
+};
 
 export const getGetUserPreferenceQueryOptions = <
 	TData = Awaited<ReturnType<typeof getUserPreference>>,
@@ -508,13 +520,14 @@ export const invalidateGetUserPreference = async (
 export const updateUserPreference = (
 	{ name }: UpdateUserPreferencePathParameters,
 	preferencetypesUpdatablePreferenceDTO: PreferencetypesUpdatablePreferenceDTO,
-) =>
-	GeneratedAPIInstance<void>({
+) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v1/user/preferences/${name}`,
 		method: 'PUT',
 		headers: { 'Content-Type': 'application/json' },
 		data: preferencetypesUpdatablePreferenceDTO,
 	});
+};
 
 export const getUpdateUserPreferenceMutationOptions = <
 	TError = RenderErrorResponseDTO,

--- a/frontend/src/api/generated/services/sessions/index.ts
+++ b/frontend/src/api/generated/services/sessions/index.ts
@@ -4,6 +4,7 @@
  * * regenerate with 'yarn generate:api'
  * SigNoz
  */
+import { useMutation, useQuery } from 'react-query';
 import type {
 	InvalidateOptions,
 	MutationFunction,
@@ -15,11 +16,8 @@ import type {
 	UseQueryOptions,
 	UseQueryResult,
 } from 'react-query';
-import { useMutation, useQuery } from 'react-query';
 
-import { GeneratedAPIInstance } from '../../../index';
 import type {
-	AuthtypesDeprecatedPostableLoginDTO,
 	AuthtypesPostableEmailPasswordSessionDTO,
 	AuthtypesPostableRotateTokenDTO,
 	CreateSessionByEmailPassword200,
@@ -28,11 +26,12 @@ import type {
 	CreateSessionBySAMLCallback303,
 	CreateSessionBySAMLCallbackBody,
 	CreateSessionBySAMLCallbackParams,
-	DeprecatedCreateSessionByEmailPassword200,
 	GetSessionContext200,
 	RenderErrorResponseDTO,
 	RotateSession200,
 } from '../sigNoz.schemas';
+
+import { GeneratedAPIInstance } from '../../../index';
 
 type AwaitedInput<T> = PromiseLike<T> | T;
 
@@ -42,15 +41,17 @@ type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
  * This endpoint creates a session for a user using google callback
  * @summary Create session by google callback
  */
-export const createSessionByGoogleCallback = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<unknown>({
+export const createSessionByGoogleCallback = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<unknown>({
 		url: `/api/v1/complete/google`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getCreateSessionByGoogleCallbackQueryKey = () =>
-	['createSessionByGoogleCallback'] as const;
+export const getCreateSessionByGoogleCallbackQueryKey = () => {
+	return ['createSessionByGoogleCallback'] as const;
+};
 
 export const getCreateSessionByGoogleCallbackQueryOptions = <
 	TData = Awaited<ReturnType<typeof createSessionByGoogleCallback>>,
@@ -129,15 +130,17 @@ export const invalidateCreateSessionByGoogleCallback = async (
  * This endpoint creates a session for a user using oidc callback
  * @summary Create session by oidc callback
  */
-export const createSessionByOIDCCallback = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<unknown>({
+export const createSessionByOIDCCallback = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<unknown>({
 		url: `/api/v1/complete/oidc`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getCreateSessionByOIDCCallbackQueryKey = () =>
-	['createSessionByOIDCCallback'] as const;
+export const getCreateSessionByOIDCCallbackQueryKey = () => {
+	return ['createSessionByOIDCCallback'] as const;
+};
 
 export const getCreateSessionByOIDCCallbackQueryOptions = <
 	TData = Awaited<ReturnType<typeof createSessionByOIDCCallback>>,
@@ -329,100 +332,15 @@ export const useCreateSessionBySAMLCallback = <
 	return useMutation(mutationOptions);
 };
 /**
- * This endpoint is deprecated and will be removed in the future
- * @deprecated
- * @summary Deprecated create session by email password
- */
-export const deprecatedCreateSessionByEmailPassword = (
-	authtypesDeprecatedPostableLoginDTO: AuthtypesDeprecatedPostableLoginDTO,
-	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<DeprecatedCreateSessionByEmailPassword200>({
-		url: `/api/v1/login`,
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		data: authtypesDeprecatedPostableLoginDTO,
-		signal,
-	});
-
-export const getDeprecatedCreateSessionByEmailPasswordMutationOptions = <
-	TError = RenderErrorResponseDTO,
-	TContext = unknown
->(options?: {
-	mutation?: UseMutationOptions<
-		Awaited<ReturnType<typeof deprecatedCreateSessionByEmailPassword>>,
-		TError,
-		{ data: AuthtypesDeprecatedPostableLoginDTO },
-		TContext
-	>;
-}): UseMutationOptions<
-	Awaited<ReturnType<typeof deprecatedCreateSessionByEmailPassword>>,
-	TError,
-	{ data: AuthtypesDeprecatedPostableLoginDTO },
-	TContext
-> => {
-	const mutationKey = ['deprecatedCreateSessionByEmailPassword'];
-	const { mutation: mutationOptions } = options
-		? options.mutation &&
-		  'mutationKey' in options.mutation &&
-		  options.mutation.mutationKey
-			? options
-			: { ...options, mutation: { ...options.mutation, mutationKey } }
-		: { mutation: { mutationKey } };
-
-	const mutationFn: MutationFunction<
-		Awaited<ReturnType<typeof deprecatedCreateSessionByEmailPassword>>,
-		{ data: AuthtypesDeprecatedPostableLoginDTO }
-	> = (props) => {
-		const { data } = props ?? {};
-
-		return deprecatedCreateSessionByEmailPassword(data);
-	};
-
-	return { mutationFn, ...mutationOptions };
-};
-
-export type DeprecatedCreateSessionByEmailPasswordMutationResult = NonNullable<
-	Awaited<ReturnType<typeof deprecatedCreateSessionByEmailPassword>>
->;
-export type DeprecatedCreateSessionByEmailPasswordMutationBody = AuthtypesDeprecatedPostableLoginDTO;
-export type DeprecatedCreateSessionByEmailPasswordMutationError = RenderErrorResponseDTO;
-
-/**
- * @deprecated
- * @summary Deprecated create session by email password
- */
-export const useDeprecatedCreateSessionByEmailPassword = <
-	TError = RenderErrorResponseDTO,
-	TContext = unknown
->(options?: {
-	mutation?: UseMutationOptions<
-		Awaited<ReturnType<typeof deprecatedCreateSessionByEmailPassword>>,
-		TError,
-		{ data: AuthtypesDeprecatedPostableLoginDTO },
-		TContext
-	>;
-}): UseMutationResult<
-	Awaited<ReturnType<typeof deprecatedCreateSessionByEmailPassword>>,
-	TError,
-	{ data: AuthtypesDeprecatedPostableLoginDTO },
-	TContext
-> => {
-	const mutationOptions = getDeprecatedCreateSessionByEmailPasswordMutationOptions(
-		options,
-	);
-
-	return useMutation(mutationOptions);
-};
-/**
  * This endpoint deletes the session
  * @summary Delete session
  */
-export const deleteSession = () =>
-	GeneratedAPIInstance<void>({
+export const deleteSession = () => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v2/sessions`,
 		method: 'DELETE',
 	});
+};
 
 export const getDeleteSessionMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -452,7 +370,9 @@ export const getDeleteSessionMutationOptions = <
 	const mutationFn: MutationFunction<
 		Awaited<ReturnType<typeof deleteSession>>,
 		void
-	> = () => deleteSession();
+	> = () => {
+		return deleteSession();
+	};
 
 	return { mutationFn, ...mutationOptions };
 };
@@ -490,15 +410,17 @@ export const useDeleteSession = <
  * This endpoint returns the context for the session
  * @summary Get session context
  */
-export const getSessionContext = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<GetSessionContext200>({
+export const getSessionContext = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<GetSessionContext200>({
 		url: `/api/v2/sessions/context`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getGetSessionContextQueryKey = () =>
-	['getSessionContext'] as const;
+export const getGetSessionContextQueryKey = () => {
+	return ['getSessionContext'] as const;
+};
 
 export const getGetSessionContextQueryOptions = <
 	TData = Awaited<ReturnType<typeof getSessionContext>>,
@@ -577,14 +499,15 @@ export const invalidateGetSessionContext = async (
 export const createSessionByEmailPassword = (
 	authtypesPostableEmailPasswordSessionDTO: AuthtypesPostableEmailPasswordSessionDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<CreateSessionByEmailPassword200>({
+) => {
+	return GeneratedAPIInstance<CreateSessionByEmailPassword200>({
 		url: `/api/v2/sessions/email_password`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: authtypesPostableEmailPasswordSessionDTO,
 		signal,
 	});
+};
 
 export const getCreateSessionByEmailPasswordMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -661,14 +584,15 @@ export const useCreateSessionByEmailPassword = <
 export const rotateSession = (
 	authtypesPostableRotateTokenDTO: AuthtypesPostableRotateTokenDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<RotateSession200>({
+) => {
+	return GeneratedAPIInstance<RotateSession200>({
 		url: `/api/v2/sessions/rotate`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: authtypesPostableRotateTokenDTO,
 		signal,
 	});
+};
 
 export const getRotateSessionMutationOptions = <
 	TError = RenderErrorResponseDTO,

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -70,28 +70,6 @@ export interface AuthtypesCallbackAuthNSupportDTO {
 	url?: string;
 }
 
-export interface AuthtypesDeprecatedGettableLoginDTO {
-	/**
-	 * @type string
-	 */
-	accessJwt?: string;
-	/**
-	 * @type string
-	 */
-	userId?: string;
-}
-
-export interface AuthtypesDeprecatedPostableLoginDTO {
-	/**
-	 * @type string
-	 */
-	email?: string;
-	/**
-	 * @type string
-	 */
-	password?: string;
-}
-
 export interface AuthtypesGettableAuthDomainDTO {
 	authNProviderInfo?: AuthtypesAuthNProviderInfoDTO;
 	/**
@@ -1619,14 +1597,6 @@ export type AcceptInvite201 = {
 	status?: string;
 };
 
-export type DeprecatedCreateSessionByEmailPassword200 = {
-	data?: AuthtypesDeprecatedGettableLoginDTO;
-	/**
-	 * @type string
-	 */
-	status?: string;
-};
-
 export type ListPromotedAndIndexedPaths200 = {
 	/**
 	 * @type array
@@ -1839,6 +1809,14 @@ export type SearchIngestionKeys200 = {
 	status?: string;
 };
 
+export type GetMetricAlertsParams = {
+	/**
+	 * @type string
+	 * @description undefined
+	 */
+	metricName?: string;
+};
+
 export type GetMetricAlerts200 = {
 	data?: MetricsexplorertypesMetricAlertsResponseDTO;
 	/**
@@ -1847,12 +1825,28 @@ export type GetMetricAlerts200 = {
 	status?: string;
 };
 
+export type GetMetricDashboardsParams = {
+	/**
+	 * @type string
+	 * @description undefined
+	 */
+	metricName?: string;
+};
+
 export type GetMetricDashboards200 = {
 	data?: MetricsexplorertypesMetricDashboardsResponseDTO;
 	/**
 	 * @type string
 	 */
 	status?: string;
+};
+
+export type GetMetricHighlightsParams = {
+	/**
+	 * @type string
+	 * @description undefined
+	 */
+	metricName?: string;
 };
 
 export type GetMetricHighlights200 = {
@@ -1872,6 +1866,14 @@ export type GetMetricAttributes200 = {
 	 * @type string
 	 */
 	status?: string;
+};
+
+export type GetMetricMetadataParams = {
+	/**
+	 * @type string
+	 * @description undefined
+	 */
+	metricName?: string;
 };
 
 export type GetMetricMetadata200 = {

--- a/frontend/src/api/generated/services/users/index.ts
+++ b/frontend/src/api/generated/services/users/index.ts
@@ -4,6 +4,7 @@
  * * regenerate with 'yarn generate:api'
  * SigNoz
  */
+import { useMutation, useQuery } from 'react-query';
 import type {
 	InvalidateOptions,
 	MutationFunction,
@@ -15,9 +16,7 @@ import type {
 	UseQueryOptions,
 	UseQueryResult,
 } from 'react-query';
-import { useMutation, useQuery } from 'react-query';
 
-import { GeneratedAPIInstance } from '../../../index';
 import type {
 	AcceptInvite201,
 	ChangePasswordPathParameters,
@@ -38,8 +37,8 @@ import type {
 	RenderErrorResponseDTO,
 	RevokeAPIKeyPathParameters,
 	TypesChangePasswordRequestDTO,
-	TypesPostableAcceptInviteDTO,
 	TypesPostableAPIKeyDTO,
+	TypesPostableAcceptInviteDTO,
 	TypesPostableInviteDTO,
 	TypesPostableResetPasswordDTO,
 	TypesStorableAPIKeyDTO,
@@ -48,6 +47,8 @@ import type {
 	UpdateUser200,
 	UpdateUserPathParameters,
 } from '../sigNoz.schemas';
+
+import { GeneratedAPIInstance } from '../../../index';
 
 type AwaitedInput<T> = PromiseLike<T> | T;
 
@@ -61,14 +62,15 @@ export const changePassword = (
 	{ id }: ChangePasswordPathParameters,
 	typesChangePasswordRequestDTO: TypesChangePasswordRequestDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<void>({
+) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v1/changePassword/${id}`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: typesChangePasswordRequestDTO,
 		signal,
 	});
+};
 
 export const getChangePasswordMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -158,16 +160,19 @@ export const useChangePassword = <
 export const getResetPasswordToken = (
 	{ id }: GetResetPasswordTokenPathParameters,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<GetResetPasswordToken200>({
+) => {
+	return GeneratedAPIInstance<GetResetPasswordToken200>({
 		url: `/api/v1/getResetPasswordToken/${id}`,
 		method: 'GET',
 		signal,
 	});
+};
 
 export const getGetResetPasswordTokenQueryKey = ({
 	id,
-}: GetResetPasswordTokenPathParameters) => ['getResetPasswordToken'] as const;
+}: GetResetPasswordTokenPathParameters) => {
+	return ['getResetPasswordToken'] as const;
+};
 
 export const getGetResetPasswordTokenQueryOptions = <
 	TData = Awaited<ReturnType<typeof getResetPasswordToken>>,
@@ -256,14 +261,17 @@ export const invalidateGetResetPasswordToken = async (
  * This endpoint lists all invites
  * @summary List invites
  */
-export const listInvite = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<ListInvite200>({
+export const listInvite = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<ListInvite200>({
 		url: `/api/v1/invite`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getListInviteQueryKey = () => ['listInvite'] as const;
+export const getListInviteQueryKey = () => {
+	return ['listInvite'] as const;
+};
 
 export const getListInviteQueryOptions = <
 	TData = Awaited<ReturnType<typeof listInvite>>,
@@ -334,14 +342,15 @@ export const invalidateListInvite = async (
 export const createInvite = (
 	typesPostableInviteDTO: TypesPostableInviteDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<CreateInvite201>({
+) => {
+	return GeneratedAPIInstance<CreateInvite201>({
 		url: `/api/v1/invite`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: typesPostableInviteDTO,
 		signal,
 	});
+};
 
 export const getCreateInviteMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -413,11 +422,12 @@ export const useCreateInvite = <
  * This endpoint deletes an invite by id
  * @summary Delete invite
  */
-export const deleteInvite = ({ id }: DeleteInvitePathParameters) =>
-	GeneratedAPIInstance<void>({
+export const deleteInvite = ({ id }: DeleteInvitePathParameters) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v1/invite/${id}`,
 		method: 'DELETE',
 	});
+};
 
 export const getDeleteInviteMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -492,15 +502,17 @@ export const useDeleteInvite = <
 export const getInvite = (
 	{ token }: GetInvitePathParameters,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<GetInvite200>({
+) => {
+	return GeneratedAPIInstance<GetInvite200>({
 		url: `/api/v1/invite/${token}`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getGetInviteQueryKey = ({ token }: GetInvitePathParameters) =>
-	['getInvite'] as const;
+export const getGetInviteQueryKey = ({ token }: GetInvitePathParameters) => {
+	return ['getInvite'] as const;
+};
 
 export const getGetInviteQueryOptions = <
 	TData = Awaited<ReturnType<typeof getInvite>>,
@@ -581,14 +593,15 @@ export const invalidateGetInvite = async (
 export const acceptInvite = (
 	typesPostableAcceptInviteDTO: TypesPostableAcceptInviteDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<AcceptInvite201>({
+) => {
+	return GeneratedAPIInstance<AcceptInvite201>({
 		url: `/api/v1/invite/accept`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: typesPostableAcceptInviteDTO,
 		signal,
 	});
+};
 
 export const getAcceptInviteMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -663,14 +676,15 @@ export const useAcceptInvite = <
 export const createBulkInvite = (
 	typesPostableInviteDTO: TypesPostableInviteDTO[],
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<void>({
+) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v1/invite/bulk`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: typesPostableInviteDTO,
 		signal,
 	});
+};
 
 export const getCreateBulkInviteMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -742,14 +756,17 @@ export const useCreateBulkInvite = <
  * This endpoint lists all api keys
  * @summary List api keys
  */
-export const listAPIKeys = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<ListAPIKeys200>({
+export const listAPIKeys = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<ListAPIKeys200>({
 		url: `/api/v1/pats`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getListAPIKeysQueryKey = () => ['listAPIKeys'] as const;
+export const getListAPIKeysQueryKey = () => {
+	return ['listAPIKeys'] as const;
+};
 
 export const getListAPIKeysQueryOptions = <
 	TData = Awaited<ReturnType<typeof listAPIKeys>>,
@@ -828,14 +845,15 @@ export const invalidateListAPIKeys = async (
 export const createAPIKey = (
 	typesPostableAPIKeyDTO: TypesPostableAPIKeyDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<CreateAPIKey201>({
+) => {
+	return GeneratedAPIInstance<CreateAPIKey201>({
 		url: `/api/v1/pats`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: typesPostableAPIKeyDTO,
 		signal,
 	});
+};
 
 export const getCreateAPIKeyMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -907,11 +925,12 @@ export const useCreateAPIKey = <
  * This endpoint revokes an api key
  * @summary Revoke api key
  */
-export const revokeAPIKey = ({ id }: RevokeAPIKeyPathParameters) =>
-	GeneratedAPIInstance<void>({
+export const revokeAPIKey = ({ id }: RevokeAPIKeyPathParameters) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v1/pats/${id}`,
 		method: 'DELETE',
 	});
+};
 
 export const getRevokeAPIKeyMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -986,13 +1005,14 @@ export const useRevokeAPIKey = <
 export const updateAPIKey = (
 	{ id }: UpdateAPIKeyPathParameters,
 	typesStorableAPIKeyDTO: TypesStorableAPIKeyDTO,
-) =>
-	GeneratedAPIInstance<string>({
+) => {
+	return GeneratedAPIInstance<string>({
 		url: `/api/v1/pats/${id}`,
 		method: 'PUT',
 		headers: { 'Content-Type': 'application/json' },
 		data: typesStorableAPIKeyDTO,
 	});
+};
 
 export const getUpdateAPIKeyMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -1067,14 +1087,15 @@ export const useUpdateAPIKey = <
 export const resetPassword = (
 	typesPostableResetPasswordDTO: TypesPostableResetPasswordDTO,
 	signal?: AbortSignal,
-) =>
-	GeneratedAPIInstance<void>({
+) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v1/resetPassword`,
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		data: typesPostableResetPasswordDTO,
 		signal,
 	});
+};
 
 export const getResetPasswordMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -1146,14 +1167,17 @@ export const useResetPassword = <
  * This endpoint lists all users
  * @summary List users
  */
-export const listUsers = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<ListUsers200>({
+export const listUsers = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<ListUsers200>({
 		url: `/api/v1/user`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getListUsersQueryKey = () => ['listUsers'] as const;
+export const getListUsersQueryKey = () => {
+	return ['listUsers'] as const;
+};
 
 export const getListUsersQueryOptions = <
 	TData = Awaited<ReturnType<typeof listUsers>>,
@@ -1221,11 +1245,12 @@ export const invalidateListUsers = async (
  * This endpoint deletes the user by id
  * @summary Delete user
  */
-export const deleteUser = ({ id }: DeleteUserPathParameters) =>
-	GeneratedAPIInstance<void>({
+export const deleteUser = ({ id }: DeleteUserPathParameters) => {
+	return GeneratedAPIInstance<void>({
 		url: `/api/v1/user/${id}`,
 		method: 'DELETE',
 	});
+};
 
 export const getDeleteUserMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -1297,15 +1322,20 @@ export const useDeleteUser = <
  * This endpoint returns the user by id
  * @summary Get user
  */
-export const getUser = ({ id }: GetUserPathParameters, signal?: AbortSignal) =>
-	GeneratedAPIInstance<GetUser200>({
+export const getUser = (
+	{ id }: GetUserPathParameters,
+	signal?: AbortSignal,
+) => {
+	return GeneratedAPIInstance<GetUser200>({
 		url: `/api/v1/user/${id}`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getGetUserQueryKey = ({ id }: GetUserPathParameters) =>
-	['getUser'] as const;
+export const getGetUserQueryKey = ({ id }: GetUserPathParameters) => {
+	return ['getUser'] as const;
+};
 
 export const getGetUserQueryOptions = <
 	TData = Awaited<ReturnType<typeof getUser>>,
@@ -1386,13 +1416,14 @@ export const invalidateGetUser = async (
 export const updateUser = (
 	{ id }: UpdateUserPathParameters,
 	typesUserDTO: TypesUserDTO,
-) =>
-	GeneratedAPIInstance<UpdateUser200>({
+) => {
+	return GeneratedAPIInstance<UpdateUser200>({
 		url: `/api/v1/user/${id}`,
 		method: 'PUT',
 		headers: { 'Content-Type': 'application/json' },
 		data: typesUserDTO,
 	});
+};
 
 export const getUpdateUserMutationOptions = <
 	TError = RenderErrorResponseDTO,
@@ -1464,14 +1495,17 @@ export const useUpdateUser = <
  * This endpoint returns the user I belong to
  * @summary Get my user
  */
-export const getMyUser = (signal?: AbortSignal) =>
-	GeneratedAPIInstance<GetMyUser200>({
+export const getMyUser = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<GetMyUser200>({
 		url: `/api/v1/user/me`,
 		method: 'GET',
 		signal,
 	});
+};
 
-export const getGetMyUserQueryKey = () => ['getMyUser'] as const;
+export const getGetMyUserQueryKey = () => {
+	return ['getMyUser'] as const;
+};
 
 export const getGetMyUserQueryOptions = <
 	TData = Awaited<ReturnType<typeof getMyUser>>,


### PR DESCRIPTION
### 📄 Summary

Backend team has updated the types for Metrics Explorer V2 APIs with https://github.com/SigNoz/signoz/pull/10091

This PR contains the updated APIs for frontend generated after running the relevant command

