### PR TITLE
docs: add Code of Conduct section to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,18 @@ Need assistance? Join our Slack community:
 - [`#contributing`](https://signoz-community.slack.com/archives/C01LWQ8KS7M)
 - [`#contributing-frontend`](https://signoz-community.slack.com/archives/C027134DM8B)
 
+## Code of Conduct
+
+SigNoz is committed to providing a welcoming, inclusive, and harassment-free experience for everyone in the community, regardless of background or identity.
+
+All contributors, maintainers, and community members are expected to follow our Code of Conduct in all project spaces, including GitHub issues, pull requests, discussions, and community channels.
+
+Please take a moment to review our Code of Conduct before contributing:
+
+👉 https://github.com/SigNoz/signoz/blob/main/CODE_OF_CONDUCT.md
+
+If you experience or witness unacceptable behavior, please report it according to the guidelines outlined in the Code of Conduct.
+
 ## Where do I go from here?
 
 - Set up your [development environment](docs/contributing/development.md)


### PR DESCRIPTION
## Summary

This PR adds a **Code of Conduct** section to `CONTRIBUTING.md` to clearly communicate community expectations and ensure a welcoming and inclusive contribution environment.

## Changes Made
- Added a new **Code of Conduct** section under the “How can I get help?” section
- Included a link to the project’s Code of Conduct for easy reference

## Why This Change
Having a visible Code of Conduct in the contributing guidelines aligns with GitHub best practices and helps set clear expectations for all contributors interacting through issues, pull requests, and discussions.

## Checklist
- [x] Documentation-only change
- [x] Follows existing contributing guidelines
- [x] No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a clear Code of Conduct reference to contributor docs to set expectations for community interactions.
> 
> - Introduces a new **Code of Conduct** section in `CONTRIBUTING.md`
> - Links to `CODE_OF_CONDUCT.md` for full policy details
> - States expectations for conduct across project spaces and provides reporting guidance
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aee042dfda990fd0666cf4e2812e2f6a90a7962b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->