### PR TITLE
refactor(dashboards): improve error message when identifier is missing or invalid

### DIFF
--- a/frontend/src/components/NewSelect/styles.scss
+++ b/frontend/src/components/NewSelect/styles.scss
@@ -322,6 +322,7 @@ $custom-border-color: #2c3044;
 	.navigation-text {
 		color: var(--bg-vanilla-400);
 		font-size: 12px;
+        white-space: pre-wrap;
 	}
 
 	.navigation-text-incomplete {

--- a/frontend/src/container/DashboardContainer/DashboardVariablesSelection/QueryVariableInput.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardVariablesSelection/QueryVariableInput.tsx
@@ -201,6 +201,24 @@ function QueryVariableInput({
 						message =
 							'Please make sure query is valid and dependent variables are selected';
 					}
+					if (
+						(details.error ?? '')
+							.toString()
+							.includes('Unknown expression or function identifier')
+					) {
+						const missingIdentifier = details.error
+							?.toString()
+							?.match(/`([^`]+)`/)?.[1];
+
+						if (
+							missingIdentifier?.startsWith('$') &&
+							!existingVariables[missingIdentifier?.slice(1)]
+						) {
+							message = `Failed to run the query, please make sure the variable "${missingIdentifier}" have any value selected to be used in the query.`;
+						} else if (!missingIdentifier?.startsWith('$')) {
+							message = `Please make sure query is valid. The identifier "${missingIdentifier}" supposed to be a variable? If so, rewrite it to be "$${missingIdentifier}".\nMore details: ${details.error}`;
+						}
+					}
 					setErrorMessage(message);
 				}
 				settleVariableFetch(variableData.name, 'failure');

--- a/frontend/src/container/DashboardContainer/DashboardVariablesSelection/SelectVariableInput.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardVariablesSelection/SelectVariableInput.tsx
@@ -137,7 +137,14 @@ function SelectVariableInput({
 
 			{errorMessage && (
 				<span style={errorIconStyle}>
-					<Popover placement="top" content={<Typography>{errorMessage}</Typography>}>
+					<Popover
+						placement="top"
+						content={
+							<Typography style={{ whiteSpace: 'pre-wrap' }}>
+								{errorMessage}
+							</Typography>
+						}
+					>
 						<WarningOutlined style={{ color: orange[5] }} />
 					</Popover>
 				</span>


### PR DESCRIPTION
## Pull Request

Give a better feedback when the query fails due to missing variable value or identifier that should look like a variable.

---

### 📄 Summary

I run into this error and I thought it was a bug in the dashboard I imported from the samples.

#### Screenshots / Screen Recordings (if applicable)

<img width="614" height="273" alt="signoz-invalid-query-identifier-missing-value" src="https://github.com/user-attachments/assets/432dc9a3-3d06-4f86-b0a1-0ec366807194" />

<img width="549" height="364" alt="image" src="https://github.com/user-attachments/assets/ab1ac9e3-9aa7-4c17-aad6-07e6036fe111" />

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

#### Fix Strategy

I just followed the same pattern that existed previously but I think we should provide a better error message in the backend itself.

---

### 🧪 Testing Strategy

- Manual verification: Since there's no test, I did it manually.

---


### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
