### PR TITLE
perf(grid-card): set cache time zero when auto-refresh is enabled

### DIFF
--- a/frontend/src/constants/queryCacheTime.ts
+++ b/frontend/src/constants/queryCacheTime.ts
@@ -1,0 +1,3 @@
+export const DASHBOARD_CACHE_TIME = 30_000;
+// keep it low or zero, otherwise, when enabled auto-refresh, this causes OOM due to accumulated queries in cache
+export const DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED = 0;

--- a/frontend/src/constants/reactQueryKeys.ts
+++ b/frontend/src/constants/reactQueryKeys.ts
@@ -97,4 +97,7 @@ export const REACT_QUERY_KEY = {
 
 	// Span Percentiles Query Keys
 	GET_SPAN_PERCENTILES: 'GET_SPAN_PERCENTILES',
+
+	// Dashboard Grid Card Query Keys
+	DASHBOARD_GRID_CARD_QUERY_RANGE: 'DASHBOARD_GRID_CARD_QUERY_RANGE',
 } as const;

--- a/frontend/src/container/DashboardContainer/DashboardVariablesSelection/DynamicVariableInput.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardVariablesSelection/DynamicVariableInput.tsx
@@ -13,6 +13,10 @@ import { FieldValueResponse } from 'types/api/dynamicVariables/getFieldValues';
 import { GlobalReducer } from 'types/reducer/globalTime';
 import { isRetryableError as checkIfRetryableError } from 'utils/errorUtils';
 
+import {
+	DASHBOARD_CACHE_TIME,
+	DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
+} from '../../../constants/queryCacheTime';
 import SelectVariableInput from './SelectVariableInput';
 import { useDashboardVariableSelectHelper } from './useDashboardVariableSelectHelper';
 import {
@@ -101,9 +105,10 @@ function DynamicVariableInput({
 		return dynamicVars || 'no_dynamic_variables';
 	}, [existingVariables]);
 
-	const { maxTime, minTime } = useSelector<AppState, GlobalReducer>(
-		(state) => state.globalTime,
-	);
+	const { maxTime, minTime, isAutoRefreshDisabled } = useSelector<
+		AppState,
+		GlobalReducer
+	>((state) => state.globalTime);
 
 	const {
 		variableFetchCycleId,
@@ -232,6 +237,9 @@ function DynamicVariableInput({
 				!!variableData.dynamicVariablesSource &&
 				!!variableData.dynamicVariablesAttribute &&
 				(isVariableFetching || (isVariableSettled && hasVariableFetchedOnce)),
+			cacheTime: isAutoRefreshDisabled
+				? DASHBOARD_CACHE_TIME
+				: DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
 			queryFn: ({ signal }) =>
 				getFieldValues(
 					variableData.dynamicVariablesSource?.toLowerCase() === 'all telemetry'

--- a/frontend/src/container/DashboardContainer/DashboardVariablesSelection/QueryVariableInput.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardVariablesSelection/QueryVariableInput.tsx
@@ -11,6 +11,10 @@ import { AppState } from 'store/reducers';
 import { VariableResponseProps } from 'types/api/dashboard/variables/query';
 import { GlobalReducer } from 'types/reducer/globalTime';
 
+import {
+	DASHBOARD_CACHE_TIME,
+	DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
+} from '../../../constants/queryCacheTime';
 import { variablePropsToPayloadVariables } from '../utils';
 import SelectVariableInput from './SelectVariableInput';
 import { useDashboardVariableSelectHelper } from './useDashboardVariableSelectHelper';
@@ -33,9 +37,10 @@ function QueryVariableInput({
 	);
 	const [errorMessage, setErrorMessage] = useState<null | string>(null);
 
-	const { maxTime, minTime } = useSelector<AppState, GlobalReducer>(
-		(state) => state.globalTime,
-	);
+	const { maxTime, minTime, isAutoRefreshDisabled } = useSelector<
+		AppState,
+		GlobalReducer
+	>((state) => state.globalTime);
 
 	const {
 		variableFetchCycleId,
@@ -197,6 +202,9 @@ function QueryVariableInput({
 					signal,
 				),
 			refetchOnWindowFocus: false,
+			cacheTime: isAutoRefreshDisabled
+				? DASHBOARD_CACHE_TIME
+				: DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
 			onSuccess: (response) => {
 				getOptions(response.payload);
 				settleVariableFetch(variableData.name, 'complete');

--- a/frontend/src/container/GridCardLayout/GridCard/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/index.tsx
@@ -25,6 +25,11 @@ import { GlobalReducer } from 'types/reducer/globalTime';
 import { getGraphType } from 'utils/getGraphType';
 import { getSortedSeriesData } from 'utils/getSortedSeriesData';
 
+import {
+	DASHBOARD_CACHE_TIME,
+	DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
+} from '../../../constants/queryCacheTime';
+import { REACT_QUERY_KEY } from '../../../constants/reactQueryKeys';
 import EmptyWidget from '../EmptyWidget';
 import { MenuItemKeys } from '../WidgetHeader/contants';
 import { GridCardGraphProps } from './types';
@@ -68,10 +73,12 @@ function GridCardGraph({
 		setDashboardQueryRangeCalled,
 	} = useDashboard();
 
-	const { minTime, maxTime, selectedTime: globalSelectedInterval } = useSelector<
-		AppState,
-		GlobalReducer
-	>((state) => state.globalTime);
+	const {
+		minTime,
+		maxTime,
+		selectedTime: globalSelectedInterval,
+		isAutoRefreshDisabled,
+	} = useSelector<AppState, GlobalReducer>((state) => state.globalTime);
 
 	const handleBackNavigation = (): void => {
 		const searchParams = new URLSearchParams(window.location.search);
@@ -210,8 +217,10 @@ function GridCardGraph({
 		version || DEFAULT_ENTITY_VERSION,
 		{
 			queryKey: [
+				REACT_QUERY_KEY.DASHBOARD_GRID_CARD_QUERY_RANGE,
 				maxTime,
 				minTime,
+				isAutoRefreshDisabled,
 				globalSelectedInterval,
 				widget?.query,
 				widget?.panelTypes,
@@ -241,6 +250,9 @@ function GridCardGraph({
 				return failureCount < 2;
 			},
 			keepPreviousData: true,
+			cacheTime: isAutoRefreshDisabled
+				? DASHBOARD_CACHE_TIME
+				: DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
 			enabled: queryEnabledCondition,
 			refetchOnMount: false,
 			onError: (error) => {

--- a/frontend/src/providers/Dashboard/Dashboard.tsx
+++ b/frontend/src/providers/Dashboard/Dashboard.tsx
@@ -46,6 +46,10 @@ import APIError from 'types/api/error';
 import { GlobalReducer } from 'types/reducer/globalTime';
 import { v4 as generateUUID } from 'uuid';
 
+import {
+	DASHBOARD_CACHE_TIME,
+	DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
+} from '../../constants/queryCacheTime';
 import { useDashboardVariablesSelector } from '../../hooks/dashboard/useDashboardVariables';
 import {
 	setDashboardVariablesStore,
@@ -272,7 +276,12 @@ export function DashboardProvider({
 		return data;
 	};
 	const dashboardResponse = useQuery(
-		[REACT_QUERY_KEY.DASHBOARD_BY_ID, isDashboardPage?.params, dashboardId],
+		[
+			REACT_QUERY_KEY.DASHBOARD_BY_ID,
+			isDashboardPage?.params,
+			dashboardId,
+			globalTime.isAutoRefreshDisabled,
+		],
 		{
 			enabled: (!!isDashboardPage || !!isDashboardWidgetPage) && isLoggedIn,
 			queryFn: async () => {
@@ -289,6 +298,9 @@ export function DashboardProvider({
 				}
 			},
 			refetchOnWindowFocus: false,
+			cacheTime: globalTime.isAutoRefreshDisabled
+				? DASHBOARD_CACHE_TIME
+				: DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
 			onError: (error) => {
 				showErrorModal(error as APIError);
 			},

--- a/frontend/src/providers/Dashboard/__tests__/Dashboard.test.tsx
+++ b/frontend/src/providers/Dashboard/__tests__/Dashboard.test.tsx
@@ -1,7 +1,10 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
+import { useSelector } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import getDashboard from 'api/v1/dashboards/id/get';
+import { DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED } from 'constants/queryCacheTime';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import ROUTES from 'constants/routes';
 import { DashboardProvider, useDashboard } from 'providers/Dashboard/Dashboard';
@@ -47,6 +50,7 @@ jest.mock('react-redux', () => ({
 		selectedTime: 'GLOBAL_TIME',
 		minTime: '2023-01-01T00:00:00Z',
 		maxTime: '2023-01-01T01:00:00Z',
+		isAutoRefreshDisabled: true,
 	})),
 	useDispatch: jest.fn(() => jest.fn()),
 }));
@@ -322,12 +326,67 @@ describe('Dashboard Provider - Query Key with Route Params', () => {
 				REACT_QUERY_KEY.DASHBOARD_BY_ID,
 				{ dashboardId: dashboardId1 },
 				dashboardId1,
+				true, // globalTime.isAutoRefreshDisabled
 			]);
 			expect(cacheKeys[1]).toEqual([
 				REACT_QUERY_KEY.DASHBOARD_BY_ID,
 				{ dashboardId: dashboardId2 },
 				dashboardId2,
+				true, // globalTime.isAutoRefreshDisabled
 			]);
+		});
+
+		it('should not store dashboard in cache when autoRefresh is enabled (isAutoRefreshDisabled=false)', async () => {
+			jest.mocked(useSelector).mockImplementation(() => ({
+				selectedTime: 'GLOBAL_TIME',
+				minTime: '2023-01-01T00:00:00Z',
+				maxTime: '2023-01-01T01:00:00Z',
+				isAutoRefreshDisabled: false,
+			}));
+
+			const queryClient = createTestQueryClient();
+			const dashboardId = 'auto-refresh-dashboard';
+
+			mockUseRouteMatch.mockReturnValue({
+				path: ROUTES.DASHBOARD,
+				url: `/dashboard/${dashboardId}`,
+				isExact: true,
+				params: { dashboardId },
+			});
+
+			render(
+				<QueryClientProvider client={queryClient}>
+					<MemoryRouter initialEntries={[`/dashboard/${dashboardId}`]}>
+						<DashboardProvider>
+							<TestComponent />
+						</DashboardProvider>
+					</MemoryRouter>
+				</QueryClientProvider>,
+			);
+
+			await waitFor(() => {
+				expect(mockGetDashboard).toHaveBeenCalledWith({ id: dashboardId });
+			});
+
+			const dashboardQuery = queryClient
+				.getQueryCache()
+				.getAll()
+				.find(
+					(query) =>
+						query.queryKey[0] === REACT_QUERY_KEY.DASHBOARD_BY_ID &&
+						query.queryKey[3] === false,
+				);
+			expect(dashboardQuery).toBeDefined();
+			expect((dashboardQuery as { cacheTime: number }).cacheTime).toBe(
+				DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
+			);
+
+			jest.mocked(useSelector).mockImplementation(() => ({
+				selectedTime: 'GLOBAL_TIME',
+				minTime: '2023-01-01T00:00:00Z',
+				maxTime: '2023-01-01T01:00:00Z',
+				isAutoRefreshDisabled: true,
+			}));
 		});
 	});
 });


### PR DESCRIPTION
## Pull Request

This issue is caused by the react-query storing all the queries without releasing it fast enough.

This version of react-query is old, in the newer versions, we could use other kind of persistent implementations to allow have the cache without too much risk of overflow the memory.

Before:

<img width="1327" height="786" alt="image" src="https://github.com/user-attachments/assets/073e44ea-8dda-448b-8ebd-e1ab010c4506" />

After:

<img width="1342" height="701" alt="image" src="https://github.com/user-attachments/assets/30504478-153b-4a19-8a49-53d5d9b3f817" />

---


#### Issues closed by this PR

Fixes #2169

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

To be able to test this issue:

- Open any dashboard
- Have actual data in the dashboard (more panels, faster you see the issue)
- Enable auto-refresh of 5s
- Press F12, go to Memory tab and get a Heap Snapshot
- Wait 1~2minutes
- Get another snapshot
- Select the second and compare with the first
- Search for query
- You should see a lot of queries stored (if the fix is not applied)

#### Root Cause

React query

#### Fix Strategy

Disable cache time that leads to react query to remove the query as soon it adds the item to the cache.

But we should also have another task just to update the version of react-query and then replace/improve the caching strategy.

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---
