### PR TITLE
perf(bundle-size): be explicit when including new languages for react-syntax-highlighter

### DIFF
--- a/.github/workflows/jsci.yaml
+++ b/.github/workflows/jsci.yaml
@@ -61,3 +61,13 @@ jobs:
     with:
       PRIMUS_REF: main
       JS_SRC: frontend
+  md-languages:
+    if: |
+      (github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork && github.event.pull_request.user.login != 'dependabot[bot]' && ! contains(github.event.pull_request.labels.*.name, 'safe-to-test')) ||
+      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: validate md languages
+        run: bash frontend/scripts/validate-md-languages.sh

--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -19,6 +19,8 @@ const config: Config.InitialOptions = {
 		'^.*/useSafeNavigate$': USE_SAFE_NAVIGATE_MOCK_PATH,
 		'^@signozhq/icons$':
 			'<rootDir>/node_modules/@signozhq/icons/dist/index.esm.js',
+		'^react-syntax-highlighter/dist/esm/(.*)$':
+			'<rootDir>/node_modules/react-syntax-highlighter/dist/cjs/$1',
 	},
 	globals: {
 		extensionsToTreatAsEsm: ['.ts'],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -214,7 +214,7 @@
 		"@types/react-redux": "^7.1.11",
 		"@types/react-resizable": "3.0.3",
 		"@types/react-router-dom": "^5.1.6",
-		"@types/react-syntax-highlighter": "15.5.7",
+		"@types/react-syntax-highlighter": "15.5.13",
 		"@types/redux-mock-store": "1.0.4",
 		"@types/styled-components": "^5.1.4",
 		"@types/uuid": "^8.3.1",

--- a/frontend/scripts/extract-md-languages.sh
+++ b/frontend/scripts/extract-md-languages.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Extracts unique fenced code block language identifiers from all .md files under frontend/src/
+# Usage: bash frontend/scripts/extract-md-languages.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="$SCRIPT_DIR/../src"
+
+grep -roh '```[a-zA-Z0-9_+-]*' "$SRC_DIR" --include='*.md' \
+  | sed 's/^```//' \
+  | grep -v '^$' \
+  | sort -u

--- a/frontend/scripts/validate-md-languages.sh
+++ b/frontend/scripts/validate-md-languages.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Validates that all fenced code block languages used in .md files are registered
+# in the syntax highlighter.
+# Usage: bash frontend/scripts/validate-md-languages.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYNTAX_HIGHLIGHTER="$SCRIPT_DIR/../src/components/MarkdownRenderer/syntaxHighlighter.ts"
+
+# Get all languages used in .md files
+md_languages=$("$SCRIPT_DIR/extract-md-languages.sh")
+
+# Get all registered languages from syntaxHighlighter.ts
+registered_languages=$(grep -oP "registerLanguage\('\K[^']+" "$SYNTAX_HIGHLIGHTER" | sort -u)
+
+missing_languages=()
+
+for lang in $md_languages; do
+  if ! echo "$registered_languages" | grep -qx "$lang"; then
+    missing_languages+=("$lang")
+  fi
+done
+
+if [ ${#missing_languages[@]} -gt 0 ]; then
+  echo "Error: The following languages are used in .md files but not registered in syntaxHighlighter.ts:"
+  for lang in "${missing_languages[@]}"; do
+    echo "  - $lang"
+  done
+  echo ""
+  echo "Please add them to: frontend/src/components/MarkdownRenderer/syntaxHighlighter.ts"
+  exit 1
+fi
+
+echo "All markdown code block languages are registered in syntaxHighlighter.ts"

--- a/frontend/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -2,13 +2,12 @@
 
 import ReactMarkdown from 'react-markdown';
 import { CodeProps } from 'react-markdown/lib/ast-to-react';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { a11yDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import logEvent from 'api/common/logEvent';
 import { isEmpty } from 'lodash-es';
 import rehypeRaw from 'rehype-raw';
 
 import CodeCopyBtn from './CodeCopyBtn/CodeCopyBtn';
+import SyntaxHighlighter, { a11yDark } from './syntaxHighlighter';
 
 interface LinkProps {
 	href: string;

--- a/frontend/src/components/MarkdownRenderer/syntaxHighlighter.ts
+++ b/frontend/src/components/MarkdownRenderer/syntaxHighlighter.ts
@@ -1,0 +1,34 @@
+import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
+import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
+import docker from 'react-syntax-highlighter/dist/esm/languages/prism/docker';
+import elixir from 'react-syntax-highlighter/dist/esm/languages/prism/elixir';
+import go from 'react-syntax-highlighter/dist/esm/languages/prism/go';
+import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript';
+import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
+import jsx from 'react-syntax-highlighter/dist/esm/languages/prism/jsx';
+import rust from 'react-syntax-highlighter/dist/esm/languages/prism/rust';
+import swift from 'react-syntax-highlighter/dist/esm/languages/prism/swift';
+import tsx from 'react-syntax-highlighter/dist/esm/languages/prism/tsx';
+import typescript from 'react-syntax-highlighter/dist/esm/languages/prism/typescript';
+import yaml from 'react-syntax-highlighter/dist/esm/languages/prism/yaml';
+import a11yDark from 'react-syntax-highlighter/dist/esm/styles/prism/a11y-dark';
+
+SyntaxHighlighter.registerLanguage('bash', bash);
+SyntaxHighlighter.registerLanguage('docker', docker);
+SyntaxHighlighter.registerLanguage('dockerfile', docker);
+SyntaxHighlighter.registerLanguage('elixir', elixir);
+SyntaxHighlighter.registerLanguage('go', go);
+SyntaxHighlighter.registerLanguage('javascript', javascript);
+SyntaxHighlighter.registerLanguage('js', javascript);
+SyntaxHighlighter.registerLanguage('json', json);
+SyntaxHighlighter.registerLanguage('jsx', jsx);
+SyntaxHighlighter.registerLanguage('rust', rust);
+SyntaxHighlighter.registerLanguage('swift', swift);
+SyntaxHighlighter.registerLanguage('ts', typescript);
+SyntaxHighlighter.registerLanguage('tsx', tsx);
+SyntaxHighlighter.registerLanguage('typescript', typescript);
+SyntaxHighlighter.registerLanguage('yaml', yaml);
+SyntaxHighlighter.registerLanguage('yml', yaml);
+
+export default SyntaxHighlighter;
+export { a11yDark };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6205,10 +6205,10 @@
     "@types/history" "^4.7.11"
     "@types/react" "*"
 
-"@types/react-syntax-highlighter@15.5.7":
-  version "15.5.7"
-  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.7.tgz#bd29020ccb118543d88779848f99059b64b02d0f"
-  integrity sha512-bo5fEO5toQeyCp0zVHBeggclqf5SQ/Z5blfFmjwO5dkMVGPgmiwZsJh9nu/Bo5L7IHTuGWrja6LxJVE2uB5ZrQ==
+"@types/react-syntax-highlighter@15.5.13":
+  version "15.5.13"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz#c5baf62a3219b3bf28d39cfea55d0a49a263d1f2"
+  integrity sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
## Pull Request

This PR improves the bundle size for react-syntax-highlighter by including only the used languages (and themes).

I also added a little CI step to run to ensure the languages are tracked when new one is added inside any markdown of the codebase to ensure we have syntax highlight for these new languages.

This change saves about 670Kb.

---

### 📄 Summary

Before:

<img width="1925" height="963" alt="image" src="https://github.com/user-attachments/assets/ee1987f9-63b1-4699-b002-57568d26b251" />

After:

<img width="1921" height="961" alt="image" src="https://github.com/user-attachments/assets/d3ff219d-cc04-4212-ac03-52c26f00f6c6" />

#### Issues closed by this PR

Related: #10192

---

### ✅ Change Type

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered
