### PR TITLE
perf(bundle-size): move antd-table-saveas-excel out of main bundle

### DIFF
--- a/frontend/src/container/DownloadV2/DownloadV2.tsx
+++ b/frontend/src/container/DownloadV2/DownloadV2.tsx
@@ -1,5 +1,5 @@
+import { useState } from 'react';
 import { Button, Popover, Typography } from 'antd';
-import { Excel } from 'antd-table-saveas-excel';
 import { FileDigit, FileDown, Sheet } from 'lucide-react';
 import { unparse } from 'papaparse';
 
@@ -8,25 +8,34 @@ import { DownloadProps } from './DownloadV2.types';
 import './DownloadV2.styles.scss';
 
 function Download({ data, isLoading, fileName }: DownloadProps): JSX.Element {
-	const downloadExcelFile = (): void => {
-		const headers = Object.keys(Object.assign({}, ...data)).map((item) => {
-			const updatedTitle = item
-				.split('_')
-				.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-				.join(' ');
-			return {
-				title: updatedTitle,
-				dataIndex: item,
-			};
-		});
-		const excel = new Excel();
-		excel
-			.addSheet(fileName)
-			.addColumns(headers)
-			.addDataSource(data, {
-				str2Percent: true,
-			})
-			.saveAs(`${fileName}.xlsx`);
+	const [isDownloading, setIsDownloading] = useState(false);
+
+	const downloadExcelFile = async (): Promise<void> => {
+		setIsDownloading(true);
+
+		try {
+			const headers = Object.keys(Object.assign({}, ...data)).map((item) => {
+				const updatedTitle = item
+					.split('_')
+					.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+					.join(' ');
+				return {
+					title: updatedTitle,
+					dataIndex: item,
+				};
+			});
+			const excelLib = await import('antd-table-saveas-excel');
+			const excel = new excelLib.Excel();
+			excel
+				.addSheet(fileName)
+				.addColumns(headers)
+				.addDataSource(data, {
+					str2Percent: true,
+				})
+				.saveAs(`${fileName}.xlsx`);
+		} finally {
+			setIsDownloading(false);
+		}
 	};
 
 	const downloadCsvFile = (): void => {
@@ -54,6 +63,7 @@ function Download({ data, isLoading, fileName }: DownloadProps): JSX.Element {
 						type="text"
 						onClick={downloadExcelFile}
 						className="action-btns"
+						loading={isDownloading}
 					>
 						Excel (.xlsx)
 					</Button>


### PR DESCRIPTION
## Pull Request

This PRs move the jszip/better-xlsx out of main bundle, saving 220kb from main bundle.

---

### 📄 Summary

Before:

<img width="1920" height="961" alt="image" src="https://github.com/user-attachments/assets/e1e57749-a893-44cb-8f54-4aec4e8ed5c8" />


After:

<img width="1917" height="961" alt="image" src="https://github.com/user-attachments/assets/bedf6e7d-c402-492e-8c4f-67192f25f465" />

#### Issues closed by this PR

Related: #10192

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---


### 🧪 Testing Strategy

To test this change:
- Open services
- Select any service
- Inside overview, you will see the panel "Key Operations"
- Click to download as Excel.

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered
