### PR TITLE
feat: Faster way to view associated logs for a trace in logs explorer

### DIFF
--- a/frontend/src/container/LogDetailedView/TableView/TableViewActions.styles.scss
+++ b/frontend/src/container/LogDetailedView/TableView/TableViewActions.styles.scss
@@ -35,7 +35,7 @@
 		box-shadow: 4px 10px 16px 2px rgba(0, 0, 0, 0.2);
 		backdrop-filter: blur(20px);
 		padding: 0px;
-		.ellipses-attribute {
+		.more-filter-actions {
 			display: flex;
 			align-items: center;
 			gap: 8px;
@@ -53,7 +53,7 @@
 			}
 		}
 
-		.ellipses-attribute:hover {
+		.more-filter-actions:hover {
 			background-color: unset !important;
 		}
 	}
@@ -65,7 +65,7 @@
 			border: 1px solid var(--bg-vanilla-400);
 			background: var(--bg-vanilla-100) !important;
 
-			.ellipses-attribute {
+			.more-filter-actions {
 				color: var(--bg-ink-400);
 			}
 		}

--- a/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
+++ b/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
@@ -397,33 +397,21 @@ export default function TableViewActions(
 								content={
 									<div>
 										<Button
-											className="ellipses-attribute"
+											className="more-filter-actions"
 											type="text"
 											icon={<GroupByIcon />}
 											onClick={handleGroupByAttribute}
 										>
 											Group By Attribute
 										</Button>
-										<Tooltip
-											title={`Replace filters with ${fieldFilterKey}:${fieldData.value}`}
-											mouseEnterDelay={0}
-											mouseLeaveDelay={0}
+										<Button
+											className="more-filter-actions"
+											type="text"
+											icon={<RefreshCw size={14} />}
+											onClick={handleReplaceFilter}
 										>
-											<Button
-												className="ellipses-attribute"
-												type="text"
-												icon={<RefreshCw size={14} />}
-												onClick={handleReplaceFilter}
-											>
-												Replace filters with {fieldFilterKey}:
-												{fieldData.value.length > 12
-													? `${fieldData.value.substring(
-															0,
-															5,
-													  )}...${fieldData.value.substring(fieldData.value.length - 4)}`
-													: fieldData.value}
-											</Button>
-										</Tooltip>
+											Replace filters with this value
+										</Button>
 									</div>
 								}
 								rootClassName="table-view-actions-content"
@@ -495,32 +483,21 @@ export default function TableViewActions(
 							content={
 								<div>
 									<Button
-										className="ellipses-attribute"
+										className="more-filter-actions"
 										type="text"
 										icon={<GroupByIcon />}
 										onClick={handleGroupByAttribute}
 									>
 										Group By Attribute
 									</Button>
-									<Tooltip
-										title={`Replace filters with ${fieldFilterKey}:${fieldData.value}`}
-										mouseEnterDelay={0}
-										mouseLeaveDelay={0}
+									<Button
+										className="more-filter-actions"
+										type="text"
+										icon={<RefreshCw size={14} />}
+										onClick={handleReplaceFilter}
 									>
-										<Button
-											className="ellipses-attribute"
-											type="text"
-											icon={<RefreshCw size={14} />}
-											onClick={handleReplaceFilter}
-										>
-											Replace filters with {fieldFilterKey}:
-											{fieldData.value.length > 12
-												? `${fieldData.value.substring(0, 5)}...${fieldData.value.substring(
-														fieldData.value.length - 4,
-												  )}`
-												: fieldData.value}
-										</Button>
-									</Tooltip>
+										Replace filters with this value
+									</Button>
 								</div>
 							}
 							rootClassName="table-view-actions-content"


### PR DESCRIPTION
## Pull Request

### 📄 Summary
> Why does this change exist?  
New feature to give user power to replace all existing filters with selected filter value
> What problem does it solve, and why is this the right approach?
Currently, when a user applies multiple filters and then opens the log details, replacing all those filters with a single specific value is a manual and time-consuming process. The user has to copy the desired value, reset all existing filters, and then manually paste or type the copied value again.
With this feature, users can now replace all existing filters with a selected filter value in a single action, eliminating unnecessary steps and significantly improving efficiency and usability.



#### Screenshots / Screen Recordings (if applicable)


https://github.com/user-attachments/assets/82a94d01-f6d7-4806-9765-18d5ba4a503b




#### Issues closed by this PR
> Closes #3402

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only


### 🧪 Testing Strategy
> How was this change validated?
Steps : 


### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Query search might break if not handled properly
- Potential regressions:
- Rollback plan: Code revert as it is not behind any feature flag

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches query mutation/navigation logic by overwriting filters and clearing the query expression for the primary query, which could change search behavior if the query shape/assumptions differ across views.
> 
> **Overview**
> Adds a new “Replace filters with this value” option to the per-field actions popover in log details, allowing users to reset the current query’s filters to a single `IN` filter for the selected field/value and navigate back to `ExplorerViews.LIST`.
> 
> Updates popover button styling by renaming `.group-by-clause` to `.more-filter-actions`, adjusting spacing, and applying the new class in both dark/light modes; also adds the `RefreshCw` icon and suppresses a Sonar cognitive complexity warning for the component.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07e26f034347d92240152179eadf1aea61267f1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->