### PR TITLE
feat: The open Icon in the quick filters is not correct

### DIFF
--- a/frontend/src/container/QueryBuilder/components/ToolbarActions/LeftToolbarActions.tsx
+++ b/frontend/src/container/QueryBuilder/components/ToolbarActions/LeftToolbarActions.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import { FilterOutlined } from '@ant-design/icons';
+import { FilterOutlined, VerticalAlignTopOutlined } from '@ant-design/icons';
 import { Button, Tooltip } from 'antd';
 import cx from 'classnames';
 import { Atom, Binoculars, SquareMousePointer, Terminal } from 'lucide-react';
@@ -32,6 +32,7 @@ export default function LeftToolbarActions({
 				<Tooltip title="Show Filters">
 					<Button onClick={handleFilterVisibilityChange} className="filter-btn">
 						<FilterOutlined />
+						<VerticalAlignTopOutlined rotate={90} />
 					</Button>
 				</Tooltip>
 			)}

--- a/frontend/src/container/QueryBuilder/components/ToolbarActions/ToolbarActions.styles.scss
+++ b/frontend/src/container/QueryBuilder/components/ToolbarActions/ToolbarActions.styles.scss
@@ -7,7 +7,7 @@
 		align-items: center;
 		justify-content: center;
 		box-shadow: none;
-		width: 32px;
+		width: 40px;
 		height: 32px;
 		margin-right: 12px;
 		border: 1px solid var(--bg-slate-400);


### PR DESCRIPTION
## Pull Request

### 📄 Summary
> Why does this change exist? 
Currently when filters are collapsed, we show a generic filter which is not intuitive
> What problem does it solve, and why is this the right approach?
We have added right arrow along with filter icon when filters are collapsed



#### Screenshots / Screen Recordings (if applicable)
Before : 
<img width="1728" height="963" alt="Screenshot 2026-02-09 at 11 24 57 AM" src="https://github.com/user-attachments/assets/6a1a0369-ea7a-4d7f-8b40-76f7a14a2d11" />


After : 

<img width="1728" height="963" alt="Screenshot 2026-02-09 at 11 24 45 AM" src="https://github.com/user-attachments/assets/fa40631e-c330-46d1-ba39-ec51a35d7e00" />


#### Issues closed by this PR
> Closes #3788

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

