### PR TITLE
fix(frontend): add cursor pointer to external api domain rows (fixes #9403)

### DIFF
--- a/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
+++ b/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
@@ -159,6 +159,10 @@
 			width: calc(100% - 260px);
 		}
 	}
+
+	.expanded-clickable-row {
+		cursor: pointer;
+	}
 }
 
 .no-filtered-domains-message-container {


### PR DESCRIPTION
## Description
This PR addresses issue #9403 by adding `cursor: pointer` style to the domain table rows in the "External APIs" section. This provides better visual feedback to users that these rows are interactive and expandable.

## Changes
- Modified [frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss](cci:7://file:///Users/sudipkumarprasad/Desktop/signoz/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss:0:0-0:0) to include `.expanded-clickable-row { cursor: pointer; }`.

## Fixes
- Fixes #9403

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Verified locally by hovering over the domain rows in the External APIs page; the cursor now changes to a pointer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only change limited to cursor styling on rows already marked clickable; minimal chance of functional regressions.
> 
> **Overview**
> Improves UX in API Monitoring’s External APIs tables by styling expandable/clickable rows with `cursor: pointer` via the `.expanded-clickable-row` class in `Explorer.styles.scss`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3da795af0522a541b3ff298bc261c2a3e3053ea1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->