### PR TITLE
test: change PRIMUS_REF from 'main' to 'provenance'

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -93,7 +93,7 @@ jobs:
     needs: [prepare, js-build]
     secrets: inherit
     with:
-      PRIMUS_REF: main
+      PRIMUS_REF: provenance
       GO_VERSION: 1.24
       GO_INPUT_ARTIFACT_CACHE_KEY: staging-jsbuild-${{ github.sha }}
       GO_INPUT_ARTIFACT_PATH: frontend/build


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single CI config change that only alters which reusable workflow ref is used for staging builds; low risk but could affect build reproducibility if the ref differs unexpectedly.
> 
> **Overview**
> Updates the staging GitHub Actions pipeline so the `go-build` reusable workflow is invoked with `PRIMUS_REF: provenance` instead of `main`, changing which Primus workflow ref is used for staging Go builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8eff96dbe1f9b9059cfdf5e5d261055c059d3c39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->