### PR TITLE
fix(ui): show service.name next to Settings in service metrics page

### DIFF
--- a/frontend/src/pages/MetricsApplication/ApDex/ApDexApplication.styles.scss
+++ b/frontend/src/pages/MetricsApplication/ApDex/ApDexApplication.styles.scss
@@ -1,0 +1,19 @@
+.ap-dex-settings-popover-content {
+	display: flex;
+	width: 100%;
+	justify-content: space-between;
+	align-items: center;
+	gap: 12px;
+}
+
+.service-name-inline {
+	flex: 1;
+	min-width: 0;
+	font-size: 16px;
+	font-weight: 500;
+	color: var(--text-vanilla-400);
+	line-height: 1.3;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}

--- a/frontend/src/pages/MetricsApplication/ApDex/ApDexApplication.tsx
+++ b/frontend/src/pages/MetricsApplication/ApDex/ApDexApplication.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { SettingOutlined } from '@ant-design/icons';
-import { Popover } from 'antd';
+import { Popover, Typography } from 'antd';
 import { IServiceName } from 'container/MetricsApplication/Tabs/types';
 import { useGetApDexSettings } from 'hooks/apDex/useGetApDexSettings';
 import { useNotifications } from 'hooks/useNotifications';
@@ -11,7 +11,14 @@ import ApDexSettings from './ApDexSettings';
 
 function ApDexApplication(): JSX.Element {
 	const { servicename: encodedServiceName } = useParams<IServiceName>();
-	const servicename = decodeURIComponent(encodedServiceName);
+	const servicename = ((): string => {
+		try {
+			return decodeURIComponent(encodedServiceName || '');
+		} catch {
+			return encodedServiceName || '';
+		}
+	})();
+	const serviceDisplayName = servicename || 'unknown';
 
 	const {
 		data,
@@ -59,6 +66,12 @@ function ApDexApplication(): JSX.Element {
 			}
 		>
 			<div className="ap-dex-settings-popover-content">
+				<Typography.Text
+					className="service-name-inline"
+					title={`service.name = ${serviceDisplayName}`}
+				>
+					{`service.name = ${serviceDisplayName}`}
+				</Typography.Text>
 				<Button size="middle" icon={<SettingOutlined />}>
 					Settings
 				</Button>

--- a/frontend/src/pages/MetricsApplication/ApDex/ApDexApplication.tsx
+++ b/frontend/src/pages/MetricsApplication/ApDex/ApDexApplication.tsx
@@ -9,6 +9,8 @@ import { useNotifications } from 'hooks/useNotifications';
 import { Button } from '../styles';
 import ApDexSettings from './ApDexSettings';
 
+import './ApDexApplication.styles.scss';
+
 function ApDexApplication(): JSX.Element {
 	const { servicename: encodedServiceName } = useParams<IServiceName>();
 	const servicename = ((): string => {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -745,7 +745,21 @@ notifications	-  2050
 .ap-dex-settings-popover-content {
 	display: flex;
 	width: 100%;
-	justify-content: flex-end;
+	justify-content: space-between;
+	align-items: center;
+	gap: 12px;
+}
+
+.service-name-inline {
+	flex: 1;
+	min-width: 0;
+	font-size: 16px;
+	font-weight: 500;
+	color: var(--text-vanilla-400);
+	line-height: 1.3;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .service-map-container {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -742,26 +742,6 @@ notifications	-  2050
 	padding: 0px 8px;
 }
 
-.ap-dex-settings-popover-content {
-	display: flex;
-	width: 100%;
-	justify-content: space-between;
-	align-items: center;
-	gap: 12px;
-}
-
-.service-name-inline {
-	flex: 1;
-	min-width: 0;
-	font-size: 16px;
-	font-weight: 500;
-	color: var(--text-vanilla-400);
-	line-height: 1.3;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
 .service-map-container {
 	padding: 0px 8px;
 }


### PR DESCRIPTION
## Pull Request

Disclosure: created using codex with react best practices skill

### 📄 Summary

> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

On the service metrics page (`/services/:servicename`), the selected service identifier was not clearly associated with the metrics tabs and settings controls. This made it harder to confirm which service context the user was viewing.

This PR surfaces `service.name = <value>` inline with the Settings row (left-aligned) so context is visible exactly where users interact with service-level controls, while keeping tab hierarchy (`Overview`, `DB Call Metrics`, `External Metrics`) intact.

It also scopes the new styles to the ApDex page stylesheet to avoid global style bleed.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

- Before:
<img width="3024" height="1720" alt="CleanShot 2026-02-15 at 22 53 43@2x" src="https://github.com/user-attachments/assets/b18b2649-9757-441f-b3cb-44331c36676f" />

- After:
<img width="3024" height="1730" alt="CleanShot 2026-02-16 at 13 12 44@2x" src="https://github.com/user-attachments/assets/cc419417-9a8f-4175-8a0f-26bbd42a3fcd" />




#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes #9212

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

Service context (`service.name`) was either not visible enough or visually detached from the controls/tabs on the service details page, causing ambiguity in UX.

#### Fix Strategy
> How does this PR address the root cause?

- Render `service.name = ...` in the same row as Settings, left side.
- Keep tabs directly below as children of that context.
- Handle malformed URL encoding and empty service names (`unknown` fallback).
- Truncate overly long names with ellipsis and preserve full value in `title` tooltip.
- Move related styles from global stylesheet into `ApDexApplication.styles.scss`.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No automated tests added (UI-only placement/styling change).
- Manual verification:
  - Verified `service.name` appears on the same line as Settings in `/services/catalog-node?relativeTime=30m`.
  - Verified tab area still renders and behaves correctly.
  - Verified long-name truncation and hover title behavior.
- Edge cases covered:
  - malformed `servicename` URL segment
  - empty/missing `servicename` (`unknown` fallback)

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Service metrics page UI only.
- Potential regressions: Minor layout shifts in the service header row.
- Rollback plan: Revert this PR; changes are isolated to 3 frontend files.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | OSS / Cloud / Enterprise |
| Change Type | Bug Fix |
| Description | Service context label (`service.name`) is shown inline with Settings on service metrics page for clearer context. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Style scoping was intentionally moved from `frontend/src/styles.scss` to `frontend/src/pages/MetricsApplication/ApDex/ApDexApplication.styles.scss` to align with local styling patterns and reduce global side-effects.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only rendering/styling changes with minor risk of small layout shifts in the ApDex settings header row.
> 
> **Overview**
> Adds an inline `service.name = …` label next to the ApDex **Settings** button in `ApDexApplication`, with safe decoding of the route param and an `unknown` fallback plus tooltip+ellipsis for long names.
> 
> Moves the popover row styling out of global `styles.scss` into a new local `ApDexApplication.styles.scss` and updates the layout to `space-between`/aligned row to accommodate the new label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cef6f6793858d7ea13d31d930d11bdb21c007478. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->