### PR TITLE
feat: enabled new bar panel

### DIFF
--- a/frontend/src/container/PanelWrapper/constants.ts
+++ b/frontend/src/container/PanelWrapper/constants.ts
@@ -1,11 +1,11 @@
 import { PANEL_TYPES } from 'constants/queryBuilder';
+import BarPanel from 'container/DashboardContainer/visualization/panels/BarPanel/BarPanel';
 
 import TimeSeriesPanel from '../DashboardContainer/visualization/panels/TimeSeriesPanel/TimeSeriesPanel';
 import HistogramPanelWrapper from './HistogramPanelWrapper';
 import ListPanelWrapper from './ListPanelWrapper';
 import PiePanelWrapper from './PiePanelWrapper';
 import TablePanelWrapper from './TablePanelWrapper';
-import UplotPanelWrapper from './UplotPanelWrapper';
 import ValuePanelWrapper from './ValuePanelWrapper';
 
 export const PanelTypeVsPanelWrapper = {
@@ -16,7 +16,7 @@ export const PanelTypeVsPanelWrapper = {
 	[PANEL_TYPES.TRACE]: null,
 	[PANEL_TYPES.EMPTY_WIDGET]: null,
 	[PANEL_TYPES.PIE]: PiePanelWrapper,
-	[PANEL_TYPES.BAR]: UplotPanelWrapper,
+	[PANEL_TYPES.BAR]: BarPanel,
 	[PANEL_TYPES.HISTOGRAM]: HistogramPanelWrapper,
 };
 


### PR DESCRIPTION
## feat: enabled new bar panel

### Summary

This PR enables the **new Bar panel** for dashboards by switching the Bar panel type from `UplotPanelWrapper` to the dedicated `BarPanel` component.

**Why this change exists:**  
The new Bar panel provides a dedicated bar chart implementation. This change makes it the default for `PANEL_TYPES.BAR` so users get the new implementation when they add or view bar panels.

**What changed:**  
- In `PanelWrapper/constants.ts`, `PANEL_TYPES.BAR` now maps to `BarPanel` instead of `UplotPanelWrapper`.
- Added import for `BarPanel` and removed the `UplotPanelWrapper` import (only used for bar type).

**Additional feature:**  
With this PR, we also add support for **selecting multiple legends** in stacked bar charts in view mode, which was previously not supported.


### Screenshots

- Before
<img width="2056" height="1295" alt="image" src="https://github.com/user-attachments/assets/fe620b81-7766-4bf3-8fca-5335ba115711" />

- After
<img width="2056" height="1251" alt="image" src="https://github.com/user-attachments/assets/5011af58-3fb3-4621-948b-907fc1812327" />



### Change type

- ✨ Feature

### Files changed

- `frontend/src/container/PanelWrapper/constants.ts` — Bar panel type mapping and imports updated.

### Testing

- Manually verify bar panels in dashboards render and behave as expected (data, stacking, legends, etc.).
- Confirm no impact on other panel types (Time Series, Table, Pie, Value, Histogram, List).

### Risk & impact

- **Blast radius:** Bar panels only; other panel types unchanged.
- **Rollback:** Revert this PR to restore `UplotPanelWrapper` for bar panels.

### Changelog

| Field | Value |
|-------|--------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Bar chart panels in dashboards now use the new Bar panel implementation. Selecting multiple legends is now supported for stacked bar charts in view mode. |
