### PR TITLE
chore: dynamic variables first load

### DIFF
--- a/frontend/src/providers/Dashboard/store/dashboardVariables/__tests__/dashboardVariablesStore.test.ts
+++ b/frontend/src/providers/Dashboard/store/dashboardVariables/__tests__/dashboardVariablesStore.test.ts
@@ -204,6 +204,78 @@ describe('dashboardVariablesStore', () => {
 			expect(doAllVariablesHaveValuesSelected).toBe(true);
 		});
 
+		it('should treat DYNAMIC variable with allSelected=true and selectedValue=undefined as having a value', () => {
+			setDashboardVariablesStore({
+				dashboardId: 'dash-1',
+				variables: {
+					dyn1: createVariable({
+						name: 'dyn1',
+						type: 'DYNAMIC',
+						order: 0,
+						selectedValue: undefined,
+						allSelected: true,
+					}),
+					env: createVariable({
+						name: 'env',
+						type: 'QUERY',
+						order: 1,
+						selectedValue: 'prod',
+					}),
+				},
+			});
+
+			const { doAllVariablesHaveValuesSelected } = getVariableDependencyContext();
+			expect(doAllVariablesHaveValuesSelected).toBe(true);
+		});
+
+		it('should treat DYNAMIC variable with allSelected=true and empty string selectedValue as having a value', () => {
+			setDashboardVariablesStore({
+				dashboardId: 'dash-1',
+				variables: {
+					dyn1: createVariable({
+						name: 'dyn1',
+						type: 'DYNAMIC',
+						order: 0,
+						selectedValue: '',
+						allSelected: true,
+					}),
+					env: createVariable({
+						name: 'env',
+						type: 'QUERY',
+						order: 1,
+						selectedValue: 'prod',
+					}),
+				},
+			});
+
+			const { doAllVariablesHaveValuesSelected } = getVariableDependencyContext();
+			expect(doAllVariablesHaveValuesSelected).toBe(true);
+		});
+
+		it('should treat DYNAMIC variable with allSelected=true and empty array selectedValue as having a value', () => {
+			setDashboardVariablesStore({
+				dashboardId: 'dash-1',
+				variables: {
+					dyn1: createVariable({
+						name: 'dyn1',
+						type: 'DYNAMIC',
+						order: 0,
+						selectedValue: [] as any,
+						allSelected: true,
+					}),
+					env: createVariable({
+						name: 'env',
+						type: 'QUERY',
+						order: 1,
+						selectedValue: 'prod',
+					}),
+				},
+			});
+
+			const { doAllVariablesHaveValuesSelected } = getVariableDependencyContext();
+			expect(doAllVariablesHaveValuesSelected).toBe(true);
+		});
+
 		it('should report false when a DYNAMIC variable has empty selectedValue and allSelected is not true', () => {
 			setDashboardVariablesStore({
 				dashboardId: 'dash-1',

--- a/frontend/src/providers/Dashboard/store/dashboardVariables/dashboardVariablesStore.ts
+++ b/frontend/src/providers/Dashboard/store/dashboardVariables/dashboardVariablesStore.ts
@@ -76,7 +76,7 @@ export function getVariableDependencyContext(): VariableFetchContext {
 		(variable) => {
 			if (
 				variable.type === 'DYNAMIC' &&
-				variable.selectedValue === null &&
+				(variable.selectedValue === null || isEmpty(variable.selectedValue)) &&
 				variable.allSelected === true
 			) {
 				return true;


### PR DESCRIPTION
### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Dynamic variables standalone with 'ALL' selected was in waiting state when no query variables existed

---

#### Screenshots / Screen Recordings (if applicable)

Before:


https://github.com/user-attachments/assets/7767832c-4be8-46e1-9f77-a35cfec4001b



After:


https://github.com/user-attachments/assets/92d95973-8ac3-44ed-a305-86b0a3ab00d6



---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [x] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.
Missed Edge case

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Yes
- Manual verification: Yes
- Edge cases covered: Yes
