### PR TITLE
fix: prevent users from deleting themselves

### DIFF
--- a/pkg/modules/user/impluser/handler.go
+++ b/pkg/modules/user/impluser/handler.go
@@ -259,6 +259,11 @@ func (h *handler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if claims.UserID == id {
+		render.Error(w, errors.Newf(errors.TypeForbidden, errors.CodeForbidden, "users cannot delete themselves"))
+		return
+	}
+
 	if err := h.module.DeleteUser(ctx, valuer.MustNewUUID(claims.OrgID), id, claims.UserID); err != nil {
 		render.Error(w, err)
 		return


### PR DESCRIPTION
### 📄 Summary

Adds a check in the DeleteUser API to return a 403 Forbidden error when a user attempts to delete their own account.

This is part of the fix for [https://github.com/SigNoz/platform-pod/issues/1076]. The complete solution is a combination of:
1. The root user PR (which ensures there's always an admin who can't be removed)
2. This PR -> a small safeguard that prevents a user from deleting themselves via the API


Closes: https://github.com/SigNoz/platform-pod/issues/528