### PR TITLE
chore: add tests for unique index on email and org_id in users table

### DIFF
--- a/tests/integration/src/passwordauthn/06_duplicate_invite.py
+++ b/tests/integration/src/passwordauthn/06_duplicate_invite.py
@@ -28,7 +28,7 @@ def test_duplicate_user_invite_rejected(
         timeout=2,
     )
     assert initial_invite_response.status_code == HTTPStatus.CREATED
-    initial_invite_token = invite_response.json()["data"]["token"]
+    initial_invite_token = initial_invite_response.json()["data"]["token"]
 
     # Step 2: Accept the invite to create the user.
     initial_accept_response = requests.post(


### PR DESCRIPTION
### 📄 Summary
- Adds an integration test to verify the unique index on (email, org_id) in the users table introduced in migration 065
- The test invites a user, accepts the invite, then attempts to invite and accept the same email again — asserting the duplicate is rejected