### PR TITLE
fix: hide scrollbar in variable selector as we expand the container h…

### DIFF
--- a/frontend/src/container/DashboardContainer/DashboardVariablesSelection/DashboardVariableSelection.styles.scss
+++ b/frontend/src/container/DashboardContainer/DashboardVariablesSelection/DashboardVariableSelection.styles.scss
@@ -50,6 +50,10 @@
 	}
 
 	.variable-select {
+		.ant-select-selector {
+			overflow-y: hidden !important;
+		}
+
 		.ant-select-item {
 			display: flex;
 			align-items: center;


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

On the Dashboard details page, the variables select (e.g. `$k8s.pod.name` showing "ALL") showed a vertical scrollbar on the closed selector even when the content fit. This was a visual bug only; the fix hides the selector’s vertical overflow so the scrollbar no longer appears as we expand the selector horizontally.

---

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

- **Before:** 
<img width="1917" height="495" alt="Screenshot 2026-02-19 at 13 12 43" src="https://github.com/user-attachments/assets/30af5df7-6586-41f6-b8b1-c8771e45ad58" />



- **After:** 
<img width="1915" height="470" alt="Screenshot 2026-02-19 at 13 12 35" src="https://github.com/user-attachments/assets/6b1f4a30-e6ba-4cd5-8a1b-d0806116c7cb" />



---

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

N/A (or add issue number if applicable)

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
Ant Design’s Select (rc-select) sets `overflow-y: auto` on the selector so multiple selected tags can scroll. 

#### Fix Strategy
Scope the dashboard variables select in `DashboardVariableSelection.styles.scss` and set `overflow-y: hidden` on `.variable-select .ant-select-selector` so the selector doesn’t show a vertical scrollbar when content fits. Multi-select still only shows up to 2 tags in the trigger, so hiding overflow does not clip meaningful content.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: None (CSS-only visual fix).
- Manual verification: Open a dashboard with variables (e.g. `$k8s.pod.name`), confirm the variables select no longer shows a scrollbar when showing "ALL" or a small number of tags.
- Edge cases covered: Multi-select with 1–2 tags and single select both fit in one line; no change to dropdown behavior.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Limited to the dashboard variables selection UI (`.variable-select` inside dashboard variable items).
- Potential regressions: If a variable had many tags visible in the trigger (beyond the existing maxTagCount=2), overflow would be clipped; current behavior only shows 2 tags + “+n”, so no regression expected.
- Rollback plan: Revert the SCSS change; no data or API changes.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed unnecessary vertical scrollbar on dashboard variable select when value (e.g. "ALL") fits in one line. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required (CSS-only; manual verification sufficient)
- [x] Manually tested
- [x] Breaking changes documented (N/A – no breaking changes)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Change is in `src/container/DashboardContainer/DashboardVariablesSelection/DashboardVariableSelection.styles.scss`: one rule on `.variable-select .ant-select-selector` with `overflow-y: hidden !important` to override Ant Design’s default.
- Only the closed selector (trigger) is affected; the dropdown list is unchanged.