### PR TITLE
chore: ui bug fix - last row in overview gets hidden

### DIFF
--- a/frontend/src/components/LogDetail/LogDetails.styles.scss
+++ b/frontend/src/components/LogDetail/LogDetails.styles.scss
@@ -42,6 +42,7 @@
 		display: flex;
 		flex-direction: column;
 		padding: 16px;
+		padding-bottom: 0;
 	}
 
 	.title {
@@ -190,7 +191,7 @@
 		padding: 0px;
 	}
 	.log-detail-drawer__footer-hint {
-		position: absolute;
+		position: sticky;
 		bottom: 0;
 		left: 0;
 		right: 0;
@@ -366,7 +367,7 @@
 	}
 
 	.log-detail-drawer__footer-hint {
-		position: absolute;
+		position: sticky;
 		bottom: 0;
 		left: 0;
 		right: 0;


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
As we introduced logs keyboard navigation, text "Use arrow to move to next./previous log" was introduced at the bottom of the view , but it blocked last table row of overview



#### Screenshots / Screen Recordings (if applicable)



https://github.com/user-attachments/assets/0f3cde4a-4d2d-4aa0-84ba-55871a0c55ce






### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

#### Root Cause
> What caused the issue?  
CSS issue

#### Fix Strategy
We identified and resolved the issue: the Ant Design Drawer was applying an unnecessary extra 16px bottom padding. Additionally, we made the bottom bar sticky to ensure consistent visibility and improve the user experience.
