### PR TITLE
chore: bump clickhouse to 25.10.5

### DIFF
--- a/.github/workflows/integrationci.yaml
+++ b/.github/workflows/integrationci.yaml
@@ -53,9 +53,9 @@ jobs:
           - sqlite
         clickhouse-version:
           - 25.5.6
-          - 25.10.1
+          - 25.10.5
         schema-migrator-version:
-          - v0.129.7
+          - v0.142.0
         postgres-version:
           - 15
     if: |


### PR DESCRIPTION
## Pull Request

- bumping clickhouse to 25.10.5 instead of 25.10.1 due to https://github.com/ClickHouse/ClickHouse/issues/89693
- upgrading schema migrator to the latest