### PR TITLE
feat: color fallback and red checks

### DIFF
--- a/frontend/src/container/LogsExplorerChart/__tests__/frequencyGraphColor.test.ts
+++ b/frontend/src/container/LogsExplorerChart/__tests__/frequencyGraphColor.test.ts
@@ -1,0 +1,34 @@
+import { Color } from '@signozhq/design-tokens';
+
+import { getColorsForSeverityLabels, isRedLike } from '../utils';
+
+describe('getColorsForSeverityLabels', () => {
+	it('should return slate for blank labels', () => {
+		expect(getColorsForSeverityLabels('', 0)).toBe(Color.BG_SLATE_300);
+		expect(getColorsForSeverityLabels('   ', 0)).toBe(Color.BG_SLATE_300);
+	});
+
+	it('should return correct colors for known severity variants', () => {
+		expect(getColorsForSeverityLabels('INFO', 0)).toBe(Color.BG_ROBIN_600);
+		expect(getColorsForSeverityLabels('ERROR', 0)).toBe(Color.BG_CHERRY_600);
+		expect(getColorsForSeverityLabels('WARN', 0)).toBe(Color.BG_AMBER_600);
+		expect(getColorsForSeverityLabels('DEBUG', 0)).toBe(Color.BG_AQUA_600);
+		expect(getColorsForSeverityLabels('TRACE', 0)).toBe(Color.BG_FOREST_600);
+		expect(getColorsForSeverityLabels('FATAL', 0)).toBe(Color.BG_SAKURA_600);
+	});
+
+	it('should return non-red colors for unrecognized labels at any index', () => {
+		for (let i = 0; i < 30; i++) {
+			const color = getColorsForSeverityLabels('4', i);
+			expect(isRedLike(color)).toBe(false);
+		}
+	});
+
+	it('should return non-red colors for numeric severity text', () => {
+		const numericLabels = ['1', '2', '4', '9', '13', '17', '21'];
+		numericLabels.forEach((label) => {
+			const color = getColorsForSeverityLabels(label, 0);
+			expect(isRedLike(color)).toBe(false);
+		});
+	});
+});

--- a/frontend/src/container/LogsExplorerChart/utils.ts
+++ b/frontend/src/container/LogsExplorerChart/utils.ts
@@ -1,8 +1,8 @@
 import { Color } from '@signozhq/design-tokens';
 import { colors } from 'lib/getRandomColor';
 
-// Check if a color is red-like
-function isRedLike(hex: string): boolean {
+// Function to determine if a color is "red-like" based on its RGB values
+export function isRedLike(hex: string): boolean {
 	const r = parseInt(hex.slice(1, 3), 16);
 	const g = parseInt(hex.slice(3, 5), 16);
 	const b = parseInt(hex.slice(5, 7), 16);


### PR DESCRIPTION
## Pull Request
RED color is reserved exclusively for severity_text = ERROR or when severity_number > X (where X denotes the error threshold). Currently, the frequency graph incorrectly renders blank values in RED by default, which misrepresents non-error states as errors.

---

### 📄 Summary
> What problem does it solve, and why is this the right approach?
Previously, the frequency graph could render RED for blank or unmapped values because the fallback palette sometimes included red-like shades. This created false error signals and violated the visual contract that RED is reserved strictly for real error states (severity_text = ERROR or severity_number > X). The fix ensures that:
Blank or unknown severities never appear as errors.
Only genuine error data is highlighted in RED.
The graph remains trustworthy and semantically correct.



#### Screenshots / Screen Recordings (if applicable)
Before: 
<img width="1728" height="963" alt="Screenshot 2026-02-23 at 1 53 10 PM" src="https://github.com/user-attachments/assets/61baa8c6-02e6-463b-bdb5-12c07458fe14" />



After:
<img width="1728" height="963" alt="Screenshot 2026-02-23 at 3 29 01 PM" src="https://github.com/user-attachments/assets/430d8880-b5e4-4a6e-87d3-6d967440d60d" />

#### Issues closed by this PR
[#3889](https://github.com/SigNoz/engineering-pod/issues/3889)

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
> What caused the issue?  
Edge case
Fallback color selection did not explicitly exclude red-like shades. As a result, when severity was blank or not mapped, the default palette could still assign a RED tone.

#### Fix Strategy
> How does this PR address the root cause?
Sanitizing the fallback palette
It introduces an isRedLike heuristic to detect red-dominant hex colors and removes them from the fallback pool (SAFE_FALLBACK_COLORS). This ensures non-error states can never accidentally render as RED.

Adding explicit blank handling
When the label is empty after trimming, the code now returns a neutral slate color instead of entering fallback logic. This removes ambiguity for missing severity values.

Preserving deterministic fallback behavior
Non-error values still receive consistent colors via indexed selection, but only from the safe palette.

### 🧪 Testing Strategy
> How was this change validated?
Manual verification:
---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Minimal , frequency graph in logs-explorer might show right color for non standard severity labels
- Rollback plan: Revert this PR to restore the original fallback color behavior.

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered