### PR TITLE
chore(frontend): add state governance lint rules

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -146,6 +146,49 @@ module.exports = {
 
 		// SonarJS - code quality and complexity
 		'sonarjs/no-duplicate-string': 'off', // Disabled - can be noisy (enable periodically to check)
+
+		// State management governance
+		// Approved patterns: Zustand, nuqs (URL state), react-query (server state), useState/useRef/useReducer, localStorage/sessionStorage for simple cases
+		'no-restricted-imports': [
+			'error',
+			{
+				paths: [
+					{
+						name: 'redux',
+						message:
+							'[State mgmt] redux is deprecated. Migrate to Zustand, nuqs, or react-query.',
+					},
+					{
+						name: 'react-redux',
+						message:
+							'[State mgmt] react-redux is deprecated. Migrate to Zustand, nuqs, or react-query.',
+					},
+					{
+						name: 'xstate',
+						message:
+							'[State mgmt] xstate is deprecated. Migrate to Zustand or react-query.',
+					},
+					{
+						name: '@xstate/react',
+						message:
+							'[State mgmt] @xstate/react is deprecated. Migrate to Zustand or react-query.',
+					},
+					{
+						// Restrict React Context — useState/useRef/useReducer remain allowed
+						name: 'react',
+						importNames: ['createContext', 'useContext'],
+						message:
+							'[State mgmt] React Context is deprecated. Migrate shared state to Zustand.',
+					},
+					{
+						// immer used standalone as a store pattern is deprecated; Zustand bundles it internally
+						name: 'immer',
+						message:
+							'[State mgmt] Direct immer usage is deprecated. Use Zustand (which integrates immer via the immer middleware) instead.',
+					},
+				],
+			},
+		],
 	},
 	overrides: [
 		{

--- a/frontend/src/components/CeleryOverview/CeleryOverviewTable/CeleryOverviewTable.tsx
+++ b/frontend/src/components/CeleryOverview/CeleryOverviewTable/CeleryOverviewTable.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { LoadingOutlined, SearchOutlined } from '@ant-design/icons';
 import { Color } from '@signozhq/design-tokens';

--- a/frontend/src/components/CeleryTask/CeleryTaskConfigOptions/useGetCeleryFilters.ts
+++ b/frontend/src/components/CeleryTask/CeleryTaskConfigOptions/useGetCeleryFilters.ts
@@ -1,4 +1,5 @@
 import { useQuery } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { DefaultOptionType } from 'antd/es/select';
 import { getAttributesValues } from 'api/queryBuilder/getAttributesValues';

--- a/frontend/src/components/CeleryTask/CeleryTaskGraph/CeleryTaskBar.tsx
+++ b/frontend/src/components/CeleryTask/CeleryTaskGraph/CeleryTaskBar.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Color } from '@signozhq/design-tokens';

--- a/frontend/src/components/CeleryTask/CeleryTaskGraph/CeleryTaskGraph.tsx
+++ b/frontend/src/components/CeleryTask/CeleryTaskGraph/CeleryTaskGraph.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { ENTITY_VERSION_V4 } from 'constants/app';

--- a/frontend/src/components/CeleryTask/CeleryTaskGraph/CeleryTaskGraphGrid.tsx
+++ b/frontend/src/components/CeleryTask/CeleryTaskGraph/CeleryTaskGraphGrid.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Card, Typography } from 'antd';
 import logEvent from 'api/common/logEvent';

--- a/frontend/src/components/CeleryTask/CeleryTaskGraph/CeleryTaskLatencyGraph.tsx
+++ b/frontend/src/components/CeleryTask/CeleryTaskGraph/CeleryTaskLatencyGraph.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Col, Row } from 'antd';

--- a/frontend/src/components/CeleryTask/CeleryTaskGraph/useGetValueFromWidget.ts
+++ b/frontend/src/components/CeleryTask/CeleryTaskGraph/useGetValueFromWidget.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useQueries } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { ENTITY_VERSION_V4 } from 'constants/app';
 import { PANEL_TYPES } from 'constants/queryBuilder';

--- a/frontend/src/components/CeleryTask/useNavigateToExplorer.ts
+++ b/frontend/src/components/CeleryTask/useNavigateToExplorer.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { QueryParams } from 'constants/query';
 import { PANEL_TYPES } from 'constants/queryBuilder';

--- a/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
+++ b/frontend/src/components/CustomTimePicker/RangePickerModal.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction, useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { DatePicker } from 'antd';
 import { DATE_TIME_FORMATS } from 'constants/dateTimeFormats';

--- a/frontend/src/components/Graph/xAxisConfig.ts
+++ b/frontend/src/components/Graph/xAxisConfig.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Chart, TimeUnit } from 'chart.js';
 import { AppState } from 'store/reducers';

--- a/frontend/src/components/HeaderRightSection/ShareURLModal.tsx
+++ b/frontend/src/components/HeaderRightSection/ShareURLModal.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { matchPath, useLocation } from 'react-router-dom';
 import { useCopyToClipboard } from 'react-use';

--- a/frontend/src/components/HeaderRightSection/__tests__/ShareURLModal.test.tsx
+++ b/frontend/src/components/HeaderRightSection/__tests__/ShareURLModal.test.tsx
@@ -1,4 +1,5 @@
 // Mock dependencies before imports
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { matchPath, useLocation } from 'react-router-dom';
 import { useCopyToClipboard } from 'react-use';

--- a/frontend/src/components/HostMetricsDetail/HostMetricsDetails.tsx
+++ b/frontend/src/components/HostMetricsDetail/HostMetricsDetails.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { Color, Spacing } from '@signozhq/design-tokens';

--- a/frontend/src/components/LogDetail/index.tsx
+++ b/frontend/src/components/LogDetail/index.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable sonarjs/cognitive-complexity */
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useCopyToClipboard, useLocation } from 'react-use';
 import { Color, Spacing } from '@signozhq/design-tokens';
@@ -55,6 +55,7 @@ import { LogDetailInnerProps, LogDetailProps } from './LogDetail.interfaces';
 
 import './LogDetails.styles.scss';
 
+/* eslint-disable-next-line sonarjs/cognitive-complexity */
 function LogDetailInner({
 	log,
 	onClose,
@@ -109,6 +110,7 @@ function LogDetailInner({
 
 	// Keyboard navigation - handle up/down arrow keys
 	// Only listen when in OVERVIEW tab
+	// eslint-disable-next-line sonarjs/cognitive-complexity
 	useEffect(() => {
 		if (
 			!logs ||

--- a/frontend/src/components/NewSelect/__test__/VariableItem.integration.test.tsx
+++ b/frontend/src/components/NewSelect/__test__/VariableItem.integration.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { VirtuosoMockContext } from 'react-virtuoso';
 import { render, screen, waitFor } from '@testing-library/react';

--- a/frontend/src/components/NotFound/NotFound.test.tsx
+++ b/frontend/src/components/NotFound/NotFound.test.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';

--- a/frontend/src/components/QueryBuilderV2/QueryBuilderV2Context.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryBuilderV2Context.tsx
@@ -1,7 +1,9 @@
 import {
+	// eslint-disable-next-line no-restricted-imports
 	createContext,
 	ReactNode,
 	useCallback,
+	// eslint-disable-next-line no-restricted-imports
 	useContext,
 	useMemo,
 	useState,

--- a/frontend/src/container/AlertHistory/Timeline/Graph/Graph.tsx
+++ b/frontend/src/container/AlertHistory/Timeline/Graph/Graph.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch } from 'react-redux';
 import { Color } from '@signozhq/design-tokens';
 import Uplot from 'components/Uplot';

--- a/frontend/src/container/AllError/index.tsx
+++ b/frontend/src/container/AllError/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueries } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Link, useLocation } from 'react-router-dom';
 import { SearchOutlined } from '@ant-design/icons';

--- a/frontend/src/container/AllError/tests/AllError.test.tsx
+++ b/frontend/src/container/AllError/tests/AllError.test.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Provider, useSelector } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';

--- a/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/DomainDetails.tsx
+++ b/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/DomainDetails.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Color, Spacing } from '@signozhq/design-tokens';
 import { Button, Divider, Drawer, Radio, Typography } from 'antd';

--- a/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/components/ExpandedRow.tsx
+++ b/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/components/ExpandedRow.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useQueries } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { LoadingOutlined } from '@ant-design/icons';
 import { Spin, Table } from 'antd';

--- a/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainList.tsx
+++ b/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { LoadingOutlined } from '@ant-design/icons';
 import { Spin, Table } from 'antd';

--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -9,6 +9,7 @@ import {
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useMutation, useQueries } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
@@ -47,6 +48,7 @@ import history from 'lib/history';
 import { isNull } from 'lodash-es';
 import ErrorBoundaryFallback from 'pages/ErrorBoundaryFallback/ErrorBoundaryFallback';
 import { useAppContext } from 'providers/App/App';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';

--- a/frontend/src/container/ConfigDropdown/index.tsx
+++ b/frontend/src/container/ConfigDropdown/index.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import {
 	CaretDownFilled,

--- a/frontend/src/container/CreateAlertV2/QuerySection/ChartPreview/ChartPreview.tsx
+++ b/frontend/src/container/CreateAlertV2/QuerySection/ChartPreview/ChartPreview.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import YAxisUnitSelector from 'components/YAxisUnitSelector';
 import { YAxisSource } from 'components/YAxisUnitSelector/types';

--- a/frontend/src/container/CreateAlertV2/QuerySection/__tests__/ChartPreview.test.tsx
+++ b/frontend/src/container/CreateAlertV2/QuerySection/__tests__/ChartPreview.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';

--- a/frontend/src/container/CreateAlertV2/QuerySection/__tests__/QuerySection.test.tsx
+++ b/frontend/src/container/CreateAlertV2/QuerySection/__tests__/QuerySection.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';

--- a/frontend/src/container/CreateAlertV2/context/index.tsx
+++ b/frontend/src/container/CreateAlertV2/context/index.tsx
@@ -1,6 +1,8 @@
 import {
+	// eslint-disable-next-line no-restricted-imports
 	createContext,
 	useCallback,
+	// eslint-disable-next-line no-restricted-imports
 	useContext,
 	useEffect,
 	useMemo,

--- a/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/VariableItem.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/VariableItem.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { orange } from '@ant-design/colors';
 import { Color } from '@signozhq/design-tokens';

--- a/frontend/src/container/DashboardContainer/DashboardVariablesSelection/DashboardVariableSelection.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardVariablesSelection/DashboardVariableSelection.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Row } from 'antd';
 import { ALL_SELECTED_VALUE } from 'components/NewSelect/utils';

--- a/frontend/src/container/DashboardContainer/DashboardVariablesSelection/DynamicVariableInput.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardVariablesSelection/DynamicVariableInput.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { getFieldValues } from 'api/dynamicVariables/getFieldValues';
 import { DEBOUNCE_DELAY } from 'constants/queryBuilderFilterConfig';

--- a/frontend/src/container/DashboardContainer/DashboardVariablesSelection/QueryVariableInput.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardVariablesSelection/QueryVariableInput.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import dashboardVariablesQuery from 'api/dashboard/variables/dashboardVariablesQuery';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';

--- a/frontend/src/container/DashboardContainer/DashboardVariablesSelection/__test__/DynamicVariableInput.test.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardVariablesSelection/__test__/DynamicVariableInput.test.tsx
@@ -1,4 +1,5 @@
 import * as ReactQuery from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import * as ReactRedux from 'react-redux';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { IDashboardVariable } from 'types/api/dashboard/getAll';

--- a/frontend/src/container/DashboardContainer/__test__/DynamicVariableDefaultBehavior.test.tsx
+++ b/frontend/src/container/DashboardContainer/__test__/DynamicVariableDefaultBehavior.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import * as ReactRedux from 'react-redux';
 import {
 	act,

--- a/frontend/src/container/DashboardContainer/__test__/IntegrationTests.test.tsx
+++ b/frontend/src/container/DashboardContainer/__test__/IntegrationTests.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 

--- a/frontend/src/container/DashboardContainer/__test__/VariableItem.test.tsx
+++ b/frontend/src/container/DashboardContainer/__test__/VariableItem.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import configureStore from 'redux-mock-store';

--- a/frontend/src/container/FormAlertRules/ChartPreview/index.tsx
+++ b/frontend/src/container/FormAlertRules/ChartPreview/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import ErrorInPlace from 'components/ErrorInPlace/ErrorInPlace';

--- a/frontend/src/container/FormAlertRules/index.tsx
+++ b/frontend/src/container/FormAlertRules/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { ExclamationCircleOutlined, SaveOutlined } from '@ant-design/icons';

--- a/frontend/src/container/FormAlertRules/labels/Labels.machine.ts
+++ b/frontend/src/container/FormAlertRules/labels/Labels.machine.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { createMachine } from 'xstate';
 
 export const ResourceAttributesFilterMachine =

--- a/frontend/src/container/FormAlertRules/labels/index.tsx
+++ b/frontend/src/container/FormAlertRules/labels/index.tsx
@@ -4,6 +4,7 @@ import {
 	CloseCircleFilled,
 	ExclamationCircleOutlined,
 } from '@ant-design/icons';
+// eslint-disable-next-line no-restricted-imports
 import { useMachine } from '@xstate/react';
 import { Button, Input, message, Modal } from 'antd';
 import { useIsDarkMode } from 'hooks/useDarkMode';

--- a/frontend/src/container/GridCardLayout/GridCard/FullView/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/FullView/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import {
 	LoadingOutlined,

--- a/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.test.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.test.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { PANEL_TYPES } from 'constants/queryBuilder';

--- a/frontend/src/container/GridCardLayout/GridCard/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/index.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import logEvent from 'api/common/logEvent';
 import { DEFAULT_ENTITY_VERSION, ENTITY_VERSION_V5 } from 'constants/app';

--- a/frontend/src/container/GridCardLayout/GridCardLayout.tsx
+++ b/frontend/src/container/GridCardLayout/GridCardLayout.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FullScreen, FullScreenHandle } from 'react-full-screen';
 import { ItemCallback, Layout } from 'react-grid-layout';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import * as Sentry from '@sentry/react';

--- a/frontend/src/container/GridCardLayout/WidgetHeader/__tests__/WidgetHeader.test.tsx
+++ b/frontend/src/container/GridCardLayout/WidgetHeader/__tests__/WidgetHeader.test.tsx
@@ -1,5 +1,6 @@
 import React, { MutableRefObject } from 'react';
 import { QueryClient, QueryClientProvider, UseQueryResult } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render as rtlRender, screen } from '@testing-library/react';

--- a/frontend/src/container/GridCardLayout/useResolveQuery.ts
+++ b/frontend/src/container/GridCardLayout/useResolveQuery.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useMutation } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { getSubstituteVars } from 'api/dashboard/substitute_vars';
 import { prepareQueryRangePayloadV5 } from 'api/v5/v5';

--- a/frontend/src/container/Home/Services/ServiceMetrics.tsx
+++ b/frontend/src/container/Home/Services/ServiceMetrics.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { QueryKey } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Button, Select, Skeleton, Table } from 'antd';

--- a/frontend/src/container/Home/Services/ServiceTraces.tsx
+++ b/frontend/src/container/Home/Services/ServiceTraces.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Button, Select, Skeleton, Table } from 'antd';

--- a/frontend/src/container/InfraMonitoringHosts/HostsList.tsx
+++ b/frontend/src/container/InfraMonitoringHosts/HostsList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { VerticalAlignTopOutlined } from '@ant-design/icons';

--- a/frontend/src/container/InfraMonitoringHosts/__tests__/HostsList.test.tsx
+++ b/frontend/src/container/InfraMonitoringHosts/__tests__/HostsList.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';

--- a/frontend/src/container/InfraMonitoringK8s/Clusters/ClusterDetails/ClusterDetails.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Clusters/ClusterDetails/ClusterDetails.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { Color, Spacing } from '@signozhq/design-tokens';

--- a/frontend/src/container/InfraMonitoringK8s/Clusters/K8sClustersList.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Clusters/K8sClustersList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { LoadingOutlined } from '@ant-design/icons';

--- a/frontend/src/container/InfraMonitoringK8s/DaemonSets/DaemonSetDetails/DaemonSetDetails.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/DaemonSets/DaemonSetDetails/DaemonSetDetails.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { Color, Spacing } from '@signozhq/design-tokens';

--- a/frontend/src/container/InfraMonitoringK8s/DaemonSets/K8sDaemonSetsList.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/DaemonSets/K8sDaemonSetsList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { LoadingOutlined } from '@ant-design/icons';

--- a/frontend/src/container/InfraMonitoringK8s/Deployments/DeploymentDetails/DeploymentDetails.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Deployments/DeploymentDetails/DeploymentDetails.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { Color, Spacing } from '@signozhq/design-tokens';

--- a/frontend/src/container/InfraMonitoringK8s/Deployments/K8sDeploymentsList.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Deployments/K8sDeploymentsList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { LoadingOutlined } from '@ant-design/icons';

--- a/frontend/src/container/InfraMonitoringK8s/Jobs/JobDetails/JobDetails.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Jobs/JobDetails/JobDetails.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { Color, Spacing } from '@signozhq/design-tokens';

--- a/frontend/src/container/InfraMonitoringK8s/Jobs/K8sJobsList.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Jobs/K8sJobsList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { LoadingOutlined } from '@ant-design/icons';

--- a/frontend/src/container/InfraMonitoringK8s/Namespaces/K8sNamespacesList.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Namespaces/K8sNamespacesList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { LoadingOutlined } from '@ant-design/icons';

--- a/frontend/src/container/InfraMonitoringK8s/Namespaces/NamespaceDetails/NamespaceDetails.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Namespaces/NamespaceDetails/NamespaceDetails.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { Color, Spacing } from '@signozhq/design-tokens';

--- a/frontend/src/container/InfraMonitoringK8s/Nodes/K8sNodesList.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Nodes/K8sNodesList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { LoadingOutlined } from '@ant-design/icons';

--- a/frontend/src/container/InfraMonitoringK8s/Nodes/NodeDetails/NodeDetails.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Nodes/NodeDetails/NodeDetails.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { Color, Spacing } from '@signozhq/design-tokens';

--- a/frontend/src/container/InfraMonitoringK8s/Pods/K8sPodLists.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Pods/K8sPodLists.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { LoadingOutlined } from '@ant-design/icons';

--- a/frontend/src/container/InfraMonitoringK8s/Pods/PodDetails/PodDetails.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Pods/PodDetails/PodDetails.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { Color, Spacing } from '@signozhq/design-tokens';

--- a/frontend/src/container/InfraMonitoringK8s/StatefulSets/K8sStatefulSetsList.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/StatefulSets/K8sStatefulSetsList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { LoadingOutlined } from '@ant-design/icons';

--- a/frontend/src/container/InfraMonitoringK8s/StatefulSets/StatefulSetDetails/StatefulSetDetails.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/StatefulSets/StatefulSetDetails/StatefulSetDetails.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { Color, Spacing } from '@signozhq/design-tokens';

--- a/frontend/src/container/InfraMonitoringK8s/Volumes/K8sVolumesList.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Volumes/K8sVolumesList.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { LoadingOutlined } from '@ant-design/icons';

--- a/frontend/src/container/InfraMonitoringK8s/Volumes/VolumeDetails/VolumeDetails.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Volumes/VolumeDetails/VolumeDetails.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Color, Spacing } from '@signozhq/design-tokens';
 import { Divider, Drawer, Tooltip, Typography } from 'antd';

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Clusters/ClusterDetails/ClusterDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Clusters/ClusterDetails/ClusterDetails.test.tsx
@@ -3,6 +3,7 @@ import setupCommonMocks from '../../commonMocks';
 setupCommonMocks();
 
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/DaemonSets/DaemonSetDetails/DaemonSetDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/DaemonSets/DaemonSetDetails/DaemonSetDetails.test.tsx
@@ -3,6 +3,7 @@ import setupCommonMocks from '../../commonMocks';
 setupCommonMocks();
 
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Deployments/DeploymentDetails/DeploymentDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Deployments/DeploymentDetails/DeploymentDetails.test.tsx
@@ -3,6 +3,7 @@ import setupCommonMocks from '../../commonMocks';
 setupCommonMocks();
 
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Namespaces/NamespaceDetails/NamespaceDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Namespaces/NamespaceDetails/NamespaceDetails.test.tsx
@@ -3,6 +3,7 @@ import setupCommonMocks from '../../commonMocks';
 setupCommonMocks();
 
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Nodes/NodeDetails/NodeDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Nodes/NodeDetails/NodeDetails.test.tsx
@@ -3,6 +3,7 @@ import setupCommonMocks from '../../commonMocks';
 setupCommonMocks();
 
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Pods/PodDetails/PodDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Pods/PodDetails/PodDetails.test.tsx
@@ -3,6 +3,7 @@ import setupCommonMocks from '../../commonMocks';
 setupCommonMocks();
 
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/StatefulSets/StatefulSetDetails/StatefulSetDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/StatefulSets/StatefulSetDetails/StatefulSetDetails.test.tsx
@@ -3,6 +3,7 @@ import setupCommonMocks from '../../commonMocks';
 setupCommonMocks();
 
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Volumes/VolumeDetails/VolumeDetails.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Volumes/VolumeDetails/VolumeDetails.test.tsx
@@ -3,6 +3,7 @@ import setupCommonMocks from '../../commonMocks';
 setupCommonMocks();
 
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/frontend/src/container/ListOfDashboard/SearchFilter/Dashboard.machine.tsx
+++ b/frontend/src/container/ListOfDashboard/SearchFilter/Dashboard.machine.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { createMachine } from 'xstate';
 
 export const DashboardSearchAndFilter = createMachine({

--- a/frontend/src/container/ListOfDashboard/SearchFilter/index.tsx
+++ b/frontend/src/container/ListOfDashboard/SearchFilter/index.tsx
@@ -6,6 +6,7 @@ import {
 	useState,
 } from 'react';
 import { CloseCircleFilled } from '@ant-design/icons';
+// eslint-disable-next-line no-restricted-imports
 import { useMachine } from '@xstate/react';
 import { Button, Select } from 'antd';
 import { RefSelectProps } from 'antd/lib/select';

--- a/frontend/src/container/LogControls/index.tsx
+++ b/frontend/src/container/LogControls/index.tsx
@@ -1,4 +1,5 @@
 import { memo, useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { FastBackwardOutlined } from '@ant-design/icons';
 import { Button, Divider } from 'antd';
@@ -11,6 +12,7 @@ import { Pagination } from 'hooks/queryPagination';
 import { getMinMaxForSelectedTime } from 'lib/getMinMax';
 import { FlatLogData } from 'lib/logs/flatLogData';
 import { OrderPreferenceItems } from 'pages/Logs/config';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';

--- a/frontend/src/container/LogDetailedView/ContextView/__tests__/ContextLogRenderer.test.tsx
+++ b/frontend/src/container/LogDetailedView/ContextView/__tests__/ContextLogRenderer.test.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { VirtuosoMockContext } from 'react-virtuoso';

--- a/frontend/src/container/LogDetailedView/TableView.tsx
+++ b/frontend/src/container/LogDetailedView/TableView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch } from 'react-redux';
 import { generatePath } from 'react-router-dom';
 import { LinkOutlined } from '@ant-design/icons';
@@ -21,6 +22,7 @@ import history from 'lib/history';
 import { fieldSearchFilter } from 'lib/logs/fieldSearch';
 import { removeJSONStringifyQuotes } from 'lib/removeJSONStringifyQuotes';
 import { Pin } from 'lucide-react';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import AppActions from 'types/actions';
 import { SET_DETAILED_LOG_DATA } from 'types/actions/logs';

--- a/frontend/src/container/LogDetailedView/index.tsx
+++ b/frontend/src/container/LogDetailedView/index.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import LogDetail from 'components/LogDetail';
@@ -8,6 +9,7 @@ import { getOldLogsOperatorFromNew } from 'hooks/logs/useActiveLog';
 import { getGeneratedFilterQueryString } from 'lib/getGeneratedFilterQueryString';
 import getStep from 'lib/getStep';
 import { getIdConditions } from 'pages/Logs/utils';
+// eslint-disable-next-line no-restricted-imports
 import { bindActionCreators, Dispatch } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { getLogs } from 'store/actions/logs/getLogs';

--- a/frontend/src/container/LogLiveTail/index.tsx
+++ b/frontend/src/container/LogLiveTail/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { green } from '@ant-design/colors';
 import {
@@ -13,6 +14,7 @@ import { useIsDarkMode } from 'hooks/useDarkMode';
 import { useNotifications } from 'hooks/useNotifications';
 import getStep from 'lib/getStep';
 import { throttle } from 'lodash-es';
+// eslint-disable-next-line no-restricted-imports
 import { bindActionCreators, Dispatch } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { getLogsAggregate } from 'store/actions/logs/getLogsAggregate';

--- a/frontend/src/container/LogsAggregate/index.tsx
+++ b/frontend/src/container/LogsAggregate/index.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { connect, useSelector } from 'react-redux';
 import { blue } from '@ant-design/colors';
 import Graph from 'components/Graph';
@@ -6,6 +7,7 @@ import Spinner from 'components/Spinner';
 import dayjs from 'dayjs';
 import useInterval from 'hooks/useInterval';
 import getStep from 'lib/getStep';
+// eslint-disable-next-line no-restricted-imports
 import { bindActionCreators } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { getLogsAggregate } from 'store/actions/logs/getLogsAggregate';

--- a/frontend/src/container/LogsExplorerChart/index.tsx
+++ b/frontend/src/container/LogsExplorerChart/index.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import Graph from 'components/Graph';

--- a/frontend/src/container/LogsExplorerViews/index.tsx
+++ b/frontend/src/container/LogsExplorerViews/index.tsx
@@ -9,6 +9,7 @@ import {
 	useRef,
 	useState,
 } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import getFromLocalstorage from 'api/browser/localstorage/get';
 import setToLocalstorage from 'api/browser/localstorage/set';

--- a/frontend/src/container/LogsFilters/index.tsx
+++ b/frontend/src/container/LogsFilters/index.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, useCallback, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { CloseOutlined, PlusCircleFilled } from '@ant-design/icons';
 import { Col, Input } from 'antd';

--- a/frontend/src/container/LogsSearchFilter/SearchFields/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/container/LogsSearchFilter/SearchFields/QueryBuilder/QueryBuilder.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { CloseOutlined, CloseSquareOutlined } from '@ant-design/icons';
 import { Button, Input, Select } from 'antd';

--- a/frontend/src/container/LogsSearchFilter/SearchFields/Suggestions.tsx
+++ b/frontend/src/container/LogsSearchFilter/SearchFields/Suggestions.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Button } from 'antd';
 import CategoryHeading from 'components/Logs/CategoryHeading';

--- a/frontend/src/container/LogsSearchFilter/SearchFields/index.tsx
+++ b/frontend/src/container/LogsSearchFilter/SearchFields/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useNotifications } from 'hooks/useNotifications';
 import { reverseParser } from 'lib/logql';

--- a/frontend/src/container/LogsSearchFilter/index.tsx
+++ b/frontend/src/container/LogsSearchFilter/index.tsx
@@ -1,10 +1,12 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { Input, InputRef, Popover } from 'antd';
 import useUrlQuery from 'hooks/useUrlQuery';
 import getStep from 'lib/getStep';
 import debounce from 'lodash-es/debounce';
 import { getIdConditions } from 'pages/Logs/utils';
+// eslint-disable-next-line no-restricted-imports
 import { bindActionCreators, Dispatch } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { GetLogsFields } from 'store/actions/logs/getFields';

--- a/frontend/src/container/LogsSearchFilter/useSearchParser.ts
+++ b/frontend/src/container/LogsSearchFilter/useSearchParser.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { QueryParams } from 'constants/query';
 import useUrlQuery from 'hooks/useUrlQuery';
@@ -6,6 +7,7 @@ import { getMinMaxForSelectedTime } from 'lib/getMinMax';
 import history from 'lib/history';
 import { parseQuery } from 'lib/logql';
 import isEqual from 'lodash-es/isEqual';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';

--- a/frontend/src/container/LogsTable/index.tsx
+++ b/frontend/src/container/LogsTable/index.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Virtuoso } from 'react-virtuoso';
 import { Card, Typography } from 'antd';

--- a/frontend/src/container/MeterExplorer/Breakdown/BreakDown.tsx
+++ b/frontend/src/container/MeterExplorer/Breakdown/BreakDown.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Alert, Typography } from 'antd';

--- a/frontend/src/container/MeterExplorer/Explorer/TimeSeries.tsx
+++ b/frontend/src/container/MeterExplorer/Explorer/TimeSeries.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useQueries } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { isAxiosError } from 'axios';
 import { ENTITY_VERSION_V5 } from 'constants/app';

--- a/frontend/src/container/MetricsApplication/Tabs/DBCall.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/DBCall.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
 import { Col } from 'antd';

--- a/frontend/src/container/MetricsApplication/Tabs/External.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/External.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
 import { Col } from 'antd';

--- a/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
 import logEvent from 'api/common/logEvent';

--- a/frontend/src/container/MetricsApplication/Tabs/Overview/TopOperation.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview/TopOperation.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import getTopOperations from 'api/metrics/getTopOperations';

--- a/frontend/src/container/MetricsApplication/Tabs/Overview/TopOperationMetrics.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview/TopOperationMetrics.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { ENTITY_VERSION_V4 } from 'constants/app';

--- a/frontend/src/container/MetricsApplication/TopOperationsTable.tsx
+++ b/frontend/src/container/MetricsApplication/TopOperationsTable.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { SearchOutlined } from '@ant-design/icons';

--- a/frontend/src/container/MetricsApplication/__tests__/TopOperationsTable.test.tsx
+++ b/frontend/src/container/MetricsApplication/__tests__/TopOperationsTable.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import {
 	act,

--- a/frontend/src/container/MetricsExplorer/Explorer/RelatedMetrics.tsx
+++ b/frontend/src/container/MetricsExplorer/Explorer/RelatedMetrics.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Color } from '@signozhq/design-tokens';
 import { Card, Col, Empty, Input, Row, Select, Skeleton } from 'antd';

--- a/frontend/src/container/MetricsExplorer/Explorer/TimeSeries.tsx
+++ b/frontend/src/container/MetricsExplorer/Explorer/TimeSeries.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useQueries, useQueryClient } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Color } from '@signozhq/design-tokens';
 import { toast } from '@signozhq/sonner';

--- a/frontend/src/container/MetricsExplorer/Explorer/__tests__/Explorer.test.tsx
+++ b/frontend/src/container/MetricsExplorer/Explorer/__tests__/Explorer.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { useSearchParams } from 'react-router-dom-v5-compat';

--- a/frontend/src/container/MetricsExplorer/Explorer/useGetRelatedMetricsGraphs.ts
+++ b/frontend/src/container/MetricsExplorer/Explorer/useGetRelatedMetricsGraphs.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useQueries } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { ENTITY_VERSION_V4 } from 'constants/app';
 import { PANEL_TYPES } from 'constants/queryBuilder';

--- a/frontend/src/container/MetricsExplorer/Inspect/GraphView.tsx
+++ b/frontend/src/container/MetricsExplorer/Inspect/GraphView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Color } from '@signozhq/design-tokens';
 import { Button, Skeleton, Switch, Typography } from 'antd';

--- a/frontend/src/container/MetricsExplorer/Inspect/__tests__/GraphView.test.tsx
+++ b/frontend/src/container/MetricsExplorer/Inspect/__tests__/GraphView.test.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/frontend/src/container/MetricsExplorer/Inspect/__tests__/Inspect.test.tsx
+++ b/frontend/src/container/MetricsExplorer/Inspect/__tests__/Inspect.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { render, screen } from '@testing-library/react';
 import { InspectMetricsSeries } from 'api/metricsExplorer/getInspectMetricsDetails';

--- a/frontend/src/container/MetricsExplorer/Inspect/__tests__/QueryBuilder.test.tsx
+++ b/frontend/src/container/MetricsExplorer/Inspect/__tests__/QueryBuilder.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/frontend/src/container/MetricsExplorer/Summary/Summary.tsx
+++ b/frontend/src/container/MetricsExplorer/Summary/Summary.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import * as Sentry from '@sentry/react';

--- a/frontend/src/container/MetricsExplorer/Summary/__tests__/MetricsTable.test.tsx
+++ b/frontend/src/container/MetricsExplorer/Summary/__tests__/MetricsTable.test.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/frontend/src/container/MetricsExplorer/Summary/__tests__/MetricsTreemap.test.tsx
+++ b/frontend/src/container/MetricsExplorer/Summary/__tests__/MetricsTreemap.test.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';

--- a/frontend/src/container/MetricsExplorer/Summary/__tests__/Summary.test.tsx
+++ b/frontend/src/container/MetricsExplorer/Summary/__tests__/Summary.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { MetricType } from 'api/metricsExplorer/getMetricsList';

--- a/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/WidgetGraphs.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/WidgetGraphs.tsx
@@ -7,6 +7,7 @@ import {
 	useState,
 } from 'react';
 import { UseQueryResult } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { useNavigateToExplorer } from 'components/CeleryTask/useNavigateToExplorer';

--- a/frontend/src/container/NewWidget/LeftContainer/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/index.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect } from 'react';
 import { useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { PANEL_TYPES } from 'constants/queryBuilder';

--- a/frontend/src/container/NewWidget/RightContainer/ContextLinks/__test__/ContextLinks.test.tsx
+++ b/frontend/src/container/NewWidget/RightContainer/ContextLinks/__test__/ContextLinks.test.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';

--- a/frontend/src/container/NewWidget/RightContainer/__tests__/RightContainer.test.tsx
+++ b/frontend/src/container/NewWidget/RightContainer/__tests__/RightContainer.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render as rtlRender, screen } from '@testing-library/react';

--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { UseQueryResult } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { generatePath, useParams } from 'react-router-dom';
 import { WarningOutlined } from '@ant-design/icons';

--- a/frontend/src/container/OnboardingContainer/Steps/ConnectionStatus/ConnectionStatus.tsx
+++ b/frontend/src/container/OnboardingContainer/Steps/ConnectionStatus/ConnectionStatus.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import {
 	CheckCircleTwoTone,

--- a/frontend/src/container/OnboardingContainer/context/OnboardingContext.tsx
+++ b/frontend/src/container/OnboardingContainer/context/OnboardingContext.tsx
@@ -1,4 +1,11 @@
-import { createContext, ReactNode, useContext, useState } from 'react';
+import {
+	// eslint-disable-next-line no-restricted-imports
+	createContext,
+	ReactNode,
+	// eslint-disable-next-line no-restricted-imports
+	useContext,
+	useState,
+} from 'react';
 
 import { ModuleProps, useCases } from '../OnboardingContainer';
 import { DataSourceType } from '../Steps/DataSource/DataSource';

--- a/frontend/src/container/PipelinePage/Layouts/ChangeHistory/tests/ChangeHistory.test.tsx
+++ b/frontend/src/container/PipelinePage/Layouts/ChangeHistory/tests/ChangeHistory.test.tsx
@@ -1,5 +1,6 @@
 import { I18nextProvider } from 'react-i18next';
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';

--- a/frontend/src/container/PipelinePage/tests/CreatePipelineButton.test.tsx
+++ b/frontend/src/container/PipelinePage/tests/CreatePipelineButton.test.tsx
@@ -1,4 +1,5 @@
 import { I18nextProvider } from 'react-i18next';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';

--- a/frontend/src/container/PipelinePage/tests/DeleteAction.test.tsx
+++ b/frontend/src/container/PipelinePage/tests/DeleteAction.test.tsx
@@ -1,4 +1,5 @@
 import { I18nextProvider } from 'react-i18next';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';

--- a/frontend/src/container/PipelinePage/tests/DragAction.test.tsx
+++ b/frontend/src/container/PipelinePage/tests/DragAction.test.tsx
@@ -1,4 +1,5 @@
 import { I18nextProvider } from 'react-i18next';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';

--- a/frontend/src/container/PipelinePage/tests/EditAction.test.tsx
+++ b/frontend/src/container/PipelinePage/tests/EditAction.test.tsx
@@ -1,4 +1,5 @@
 import { I18nextProvider } from 'react-i18next';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';

--- a/frontend/src/container/PipelinePage/tests/PipelineActions.test.tsx
+++ b/frontend/src/container/PipelinePage/tests/PipelineActions.test.tsx
@@ -1,4 +1,5 @@
 import { I18nextProvider } from 'react-i18next';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';

--- a/frontend/src/container/PipelinePage/tests/PipelinesSearchSection.test.tsx
+++ b/frontend/src/container/PipelinePage/tests/PipelinesSearchSection.test.tsx
@@ -1,4 +1,5 @@
 import { I18nextProvider } from 'react-i18next';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, waitFor } from '@testing-library/react';

--- a/frontend/src/container/PipelinePage/tests/TableExpandIcon.test.tsx
+++ b/frontend/src/container/PipelinePage/tests/TableExpandIcon.test.tsx
@@ -1,4 +1,5 @@
 import { I18nextProvider } from 'react-i18next';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';

--- a/frontend/src/container/PipelinePage/tests/TagInput.test.tsx
+++ b/frontend/src/container/PipelinePage/tests/TagInput.test.tsx
@@ -1,4 +1,5 @@
 import { I18nextProvider } from 'react-i18next';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';

--- a/frontend/src/container/QueryTable/Drilldown/__tests__/Breakout.test.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/__tests__/Breakout.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/frontend/src/container/QueryTable/Drilldown/__tests__/TableDrilldown.test.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/__tests__/TableDrilldown.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, render, screen } from '@testing-library/react';

--- a/frontend/src/container/ServiceApplication/ServiceMetrics/ServiceMetricTable.tsx
+++ b/frontend/src/container/ServiceApplication/ServiceMetrics/ServiceMetricTable.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { WarningFilled } from '@ant-design/icons';

--- a/frontend/src/container/ServiceApplication/ServiceMetrics/ServiceMetricsApplication.tsx
+++ b/frontend/src/container/ServiceApplication/ServiceMetrics/ServiceMetricsApplication.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { AppState } from 'store/reducers';
 import { GlobalReducer } from 'types/reducer/globalTime';

--- a/frontend/src/container/ServiceApplication/ServiceMetrics/index.tsx
+++ b/frontend/src/container/ServiceApplication/ServiceMetrics/index.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { QueryKey } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import localStorageGet from 'api/browser/localstorage/get';
 import localStorageSet from 'api/browser/localstorage/set';

--- a/frontend/src/container/ServiceApplication/ServiceTraces/index.tsx
+++ b/frontend/src/container/ServiceApplication/ServiceTraces/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import localStorageGet from 'api/browser/localstorage/get';
 import localStorageSet from 'api/browser/localstorage/set';

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -7,6 +7,7 @@ import {
 	useState,
 } from 'react';
 import { useMutation } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import {

--- a/frontend/src/container/TimeSeriesView/TimeSeriesView.tsx
+++ b/frontend/src/container/TimeSeriesView/TimeSeriesView.tsx
@@ -7,6 +7,7 @@ import {
 	useRef,
 	useState,
 } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import logEvent from 'api/common/logEvent';

--- a/frontend/src/container/TopNav/AutoRefreshV2/index.tsx
+++ b/frontend/src/container/TopNav/AutoRefreshV2/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { useInterval } from 'react-use';
@@ -12,6 +13,7 @@ import useUrlQuery from 'hooks/useUrlQuery';
 import { getMinMaxForSelectedTime } from 'lib/getMinMax';
 import _omit from 'lodash-es/omit';
 import { Check } from 'lucide-react';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';

--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { useNavigationType, useSearchParams } from 'react-router-dom-v5-compat';
@@ -21,6 +22,7 @@ import getTimeString from 'lib/getTimeString';
 import { cloneDeep, isObject } from 'lodash-es';
 import { Undo } from 'lucide-react';
 import { useTimezone } from 'providers/Timezone';
+// eslint-disable-next-line no-restricted-imports
 import { bindActionCreators, Dispatch } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { GlobalTimeLoading, UpdateTimeInterval } from 'store/actions';

--- a/frontend/src/container/Trace/Filters/Panel/PanelBody/Common/Checkbox.tsx
+++ b/frontend/src/container/Trace/Filters/Panel/PanelBody/Common/Checkbox.tsx
@@ -1,9 +1,11 @@
 import { useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { Checkbox, Tooltip, Typography } from 'antd';
 import getFilters from 'api/trace/getFilters';
 import { AxiosError } from 'axios';
 import { useNotifications } from 'hooks/useNotifications';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { getFilter, updateURL } from 'store/actions/trace/util';
 import { AppState } from 'store/reducers';

--- a/frontend/src/container/Trace/Filters/Panel/PanelBody/CommonCheckBox/index.tsx
+++ b/frontend/src/container/Trace/Filters/Panel/PanelBody/CommonCheckBox/index.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, Input } from 'antd';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { AppState } from 'store/reducers';
 import { INITIAL_FILTER_VALUE } from 'store/reducers/trace';

--- a/frontend/src/container/Trace/Filters/Panel/PanelBody/Duration/index.tsx
+++ b/frontend/src/container/Trace/Filters/Panel/PanelBody/Duration/index.tsx
@@ -6,11 +6,13 @@ import {
 	useRef,
 	useState,
 } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { Slider } from 'antd';
 import { SliderRangeProps } from 'antd/lib/slider';
 import getFilters from 'api/trace/getFilters';
 import useDebouncedFn from 'hooks/useDebouncedFunction';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { getFilter, updateURL } from 'store/actions/trace/util';
 import { AppState } from 'store/reducers';

--- a/frontend/src/container/Trace/Filters/Panel/PanelBody/SearchTraceID/index.tsx
+++ b/frontend/src/container/Trace/Filters/Panel/PanelBody/SearchTraceID/index.tsx
@@ -1,9 +1,11 @@
 import { ChangeEvent, useEffect, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { Input } from 'antd';
 import getFilters from 'api/trace/getFilters';
 import { AxiosError } from 'axios';
 import { useNotifications } from 'hooks/useNotifications';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { getFilter, updateURL } from 'store/actions/trace/util';
 import { AppState } from 'store/reducers';

--- a/frontend/src/container/Trace/Filters/Panel/PanelBody/index.tsx
+++ b/frontend/src/container/Trace/Filters/Panel/PanelBody/index.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Card } from 'antd';
 import Spinner from 'components/Spinner';

--- a/frontend/src/container/Trace/Filters/Panel/PanelHeading/index.tsx
+++ b/frontend/src/container/Trace/Filters/Panel/PanelHeading/index.tsx
@@ -1,10 +1,12 @@
 import { MouseEventHandler, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { DownOutlined, RightOutlined } from '@ant-design/icons';
 import { Card, Divider, Typography } from 'antd';
 import getFilters from 'api/trace/getFilters';
 import { AxiosError } from 'axios';
 import { useNotifications } from 'hooks/useNotifications';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { getFilter, updateURL } from 'store/actions/trace/util';
 import { AppState } from 'store/reducers';

--- a/frontend/src/container/Trace/Filters/Panel/index.tsx
+++ b/frontend/src/container/Trace/Filters/Panel/index.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { AppState } from 'store/reducers';
 import { TraceFilterEnum, TraceReducer } from 'types/reducer/trace';

--- a/frontend/src/container/Trace/Graph/index.tsx
+++ b/frontend/src/container/Trace/Graph/index.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useMeasure } from 'react-use';
 import { Typography } from 'antd';

--- a/frontend/src/container/Trace/Search/AllTags/Tag/TagKey.tsx
+++ b/frontend/src/container/Trace/Search/AllTags/Tag/TagKey.tsx
@@ -6,6 +6,7 @@ import {
 	useState,
 } from 'react';
 import { useQuery } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { AutoComplete, Input } from 'antd';
 import getTagFilters from 'api/trace/getTagFilter';

--- a/frontend/src/container/Trace/Search/AllTags/Tag/TagValue.tsx
+++ b/frontend/src/container/Trace/Search/AllTags/Tag/TagValue.tsx
@@ -7,6 +7,7 @@ import {
 	useState,
 } from 'react';
 import { useQuery } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Select } from 'antd';
 import { BaseOptionType } from 'antd/es/select';

--- a/frontend/src/container/Trace/Search/AllTags/index.tsx
+++ b/frontend/src/container/Trace/Search/AllTags/index.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { connect, useSelector } from 'react-redux';
 import { CaretRightFilled, PlusOutlined } from '@ant-design/icons';
 import { Button, Space, Typography } from 'antd';
+// eslint-disable-next-line no-restricted-imports
 import { bindActionCreators } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { UpdateTagIsError } from 'store/actions/trace/updateIsTagsError';

--- a/frontend/src/container/Trace/Search/index.tsx
+++ b/frontend/src/container/Trace/Search/index.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { CaretRightFilled } from '@ant-design/icons';
 import { Popover } from 'antd';
+// eslint-disable-next-line no-restricted-imports
 import { bindActionCreators, Dispatch } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { UpdateTagIsError } from 'store/actions/trace/updateIsTagsError';

--- a/frontend/src/container/Trace/TraceGraphFilter/index.tsx
+++ b/frontend/src/container/Trace/TraceGraphFilter/index.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { AutoComplete, Input, Space } from 'antd';
 import getTagFilters from 'api/trace/getTagFilter';

--- a/frontend/src/container/Trace/TraceTable/index.tsx
+++ b/frontend/src/container/Trace/TraceTable/index.tsx
@@ -1,4 +1,5 @@
 import { HTMLAttributes } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { TableProps, Tag, Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
@@ -14,6 +15,7 @@ import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import history from 'lib/history';
 import omit from 'lodash-es/omit';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { updateURL } from 'store/actions/trace/util';
 import { AppState } from 'store/reducers';

--- a/frontend/src/container/TraceDetail/SelectedSpanDetails/index.tsx
+++ b/frontend/src/container/TraceDetail/SelectedSpanDetails/index.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { Button, Modal, Row, Tabs, Tooltip, Typography } from 'antd';

--- a/frontend/src/container/TraceFlameGraph/__tests__/TraceFlameGraph.test.tsx
+++ b/frontend/src/container/TraceFlameGraph/__tests__/TraceFlameGraph.test.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { render, renderHook } from '@testing-library/react';
 import TraceFlameGraph from 'container/TraceFlameGraph';

--- a/frontend/src/container/TracesExplorer/ListView/index.tsx
+++ b/frontend/src/container/TracesExplorer/ListView/index.tsx
@@ -8,6 +8,7 @@ import {
 	useMemo,
 	useState,
 } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import logEvent from 'api/common/logEvent';
 import ErrorInPlace from 'components/ErrorInPlace/ErrorInPlace';

--- a/frontend/src/container/TracesExplorer/TableView/index.tsx
+++ b/frontend/src/container/TracesExplorer/TableView/index.tsx
@@ -6,6 +6,7 @@ import {
 	useEffect,
 	useMemo,
 } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Space } from 'antd';
 import ErrorInPlace from 'components/ErrorInPlace/ErrorInPlace';

--- a/frontend/src/container/TracesExplorer/TracesView/index.tsx
+++ b/frontend/src/container/TracesExplorer/TracesView/index.tsx
@@ -7,6 +7,7 @@ import {
 	useEffect,
 	useMemo,
 } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Typography } from 'antd';
 import logEvent from 'api/common/logEvent';

--- a/frontend/src/container/Version/index.tsx
+++ b/frontend/src/container/Version/index.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Button, Form } from 'antd';
 import { CheckCircle, CloudUpload, InfoIcon, Wrench } from 'lucide-react';

--- a/frontend/src/hooks/dashboard/useContextVariables.tsx
+++ b/frontend/src/hooks/dashboard/useContextVariables.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useDashboardVariables } from 'hooks/dashboard/useDashboardVariables';
 import { AppState } from 'store/reducers';

--- a/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
+++ b/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
@@ -1,6 +1,8 @@
 import {
+	// eslint-disable-next-line no-restricted-imports
 	createContext,
 	useCallback,
+	// eslint-disable-next-line no-restricted-imports
 	useContext,
 	useEffect,
 	useMemo,

--- a/frontend/src/hooks/logs/useActiveLog.ts
+++ b/frontend/src/hooks/logs/useActiveLog.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { getAggregateKeys } from 'api/queryBuilder/getAttributeKeys';

--- a/frontend/src/hooks/logs/useCopyLogLink.ts
+++ b/frontend/src/hooks/logs/useCopyLogLink.ts
@@ -5,6 +5,7 @@ import {
 	useMemo,
 	useState,
 } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { useCopyToClipboard } from 'react-use';

--- a/frontend/src/hooks/queryBuilder/useCreateAlerts.tsx
+++ b/frontend/src/hooks/queryBuilder/useCreateAlerts.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useMutation } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import logEvent from 'api/common/logEvent';
 import { getSubstituteVars } from 'api/dashboard/substitute_vars';

--- a/frontend/src/hooks/queryBuilder/useGetExplorerQueryRange.ts
+++ b/frontend/src/hooks/queryBuilder/useGetExplorerQueryRange.ts
@@ -1,5 +1,6 @@
 import { MutableRefObject, useMemo } from 'react';
 import { UseQueryOptions, UseQueryResult } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';

--- a/frontend/src/hooks/queryBuilder/useGetWidgetQueryRange.ts
+++ b/frontend/src/hooks/queryBuilder/useGetWidgetQueryRange.ts
@@ -1,4 +1,5 @@
 import { UseQueryOptions, UseQueryResult } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { initialQueriesMap } from 'constants/queryBuilder';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';

--- a/frontend/src/hooks/queryBuilder/useQueryBuilder.ts
+++ b/frontend/src/hooks/queryBuilder/useQueryBuilder.ts
@@ -1,4 +1,7 @@
-import { useContext } from 'react';
+import {
+	// eslint-disable-next-line no-restricted-imports
+	useContext,
+} from 'react';
 import { QueryBuilderContext } from 'providers/QueryBuilder';
 import { QueryBuilderContextType } from 'types/common/queryBuilder';
 

--- a/frontend/src/hooks/useDarkMode/index.tsx
+++ b/frontend/src/hooks/useDarkMode/index.tsx
@@ -1,9 +1,11 @@
 import {
+	// eslint-disable-next-line no-restricted-imports
 	createContext,
 	Dispatch,
 	ReactNode,
 	SetStateAction,
 	useCallback,
+	// eslint-disable-next-line no-restricted-imports
 	useContext,
 	useEffect,
 	useMemo,

--- a/frontend/src/hooks/useLogsData.ts
+++ b/frontend/src/hooks/useLogsData.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { DEFAULT_ENTITY_VERSION } from 'constants/app';
 import { QueryParams } from 'constants/query';

--- a/frontend/src/hooks/useNotifications.tsx
+++ b/frontend/src/hooks/useNotifications.tsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, useMemo } from 'react';
+import {
+	// eslint-disable-next-line no-restricted-imports
+	createContext,
+	// eslint-disable-next-line no-restricted-imports
+	useContext,
+	useMemo,
+} from 'react';
 import { notification } from 'antd';
 import { NotificationInstance } from 'antd/es/notification/interface';
 

--- a/frontend/src/hooks/useResourceAttribute/ResourceProvider.tsx
+++ b/frontend/src/hooks/useResourceAttribute/ResourceProvider.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+// eslint-disable-next-line no-restricted-imports
 import { useMachine } from '@xstate/react';
 import { QueryParams } from 'constants/query';
 import ROUTES from 'constants/routes';

--- a/frontend/src/hooks/useResourceAttribute/context.ts
+++ b/frontend/src/hooks/useResourceAttribute/context.ts
@@ -1,4 +1,7 @@
-import { createContext } from 'react';
+import {
+	// eslint-disable-next-line no-restricted-imports
+	createContext,
+} from 'react';
 
 import { IResourceAttributeProps } from './types';
 

--- a/frontend/src/hooks/useResourceAttribute/machine.ts
+++ b/frontend/src/hooks/useResourceAttribute/machine.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { createMachine } from 'xstate';
 
 export const ResourceAttributesFilterMachine =

--- a/frontend/src/hooks/useResourceAttribute/useResourceAttribute.tsx
+++ b/frontend/src/hooks/useResourceAttribute/useResourceAttribute.tsx
@@ -1,4 +1,7 @@
-import { useContext } from 'react';
+import {
+	// eslint-disable-next-line no-restricted-imports
+	useContext,
+} from 'react';
 
 import { ResourceContext } from './context';
 import { IResourceAttributeProps } from './types';

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import { HelmetProvider } from 'react-helmet-async';
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import AppRoutes from 'AppRoutes';
 import { AxiosError } from 'axios';

--- a/frontend/src/lib/uPlotV2/context/PlotContext.tsx
+++ b/frontend/src/lib/uPlotV2/context/PlotContext.tsx
@@ -1,7 +1,9 @@
 import {
+	// eslint-disable-next-line no-restricted-imports
 	createContext,
 	PropsWithChildren,
 	useCallback,
+	// eslint-disable-next-line no-restricted-imports
 	useContext,
 	useMemo,
 	useRef,

--- a/frontend/src/modules/Servicemap/ServiceMap.tsx
+++ b/frontend/src/modules/Servicemap/ServiceMap.tsx
@@ -1,6 +1,7 @@
 //@ts-nocheck
 
 import { useEffect, useRef } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { Card } from 'antd';

--- a/frontend/src/modules/Usage/UsageExplorer.tsx
+++ b/frontend/src/modules/Usage/UsageExplorer.tsx
@@ -1,6 +1,7 @@
 //@ts-nocheck
 
 import { useEffect, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { connect, useSelector } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { Select, Space, Typography } from 'antd';

--- a/frontend/src/pages/Celery/CeleryOverview/CeleryOverviewDetail/OverviewRightPanelGraph.tsx
+++ b/frontend/src/pages/Celery/CeleryOverview/CeleryOverviewDetail/OverviewRightPanelGraph.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Color } from '@signozhq/design-tokens';

--- a/frontend/src/pages/Celery/CeleryOverview/CeleryOverviewDetail/ValueInfo.tsx
+++ b/frontend/src/pages/Celery/CeleryOverview/CeleryOverviewDetail/ValueInfo.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useQueries } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { FileSearchOutlined } from '@ant-design/icons';
 import { Button, Card, Col, Row } from 'antd';

--- a/frontend/src/pages/ErrorDetails/index.tsx
+++ b/frontend/src/pages/ErrorDetails/index.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Redirect, useLocation } from 'react-router-dom';
 import { Typography } from 'antd';

--- a/frontend/src/pages/Logs/hooks.ts
+++ b/frontend/src/pages/Logs/hooks.ts
@@ -1,5 +1,6 @@
 // utils
 import { useCallback, useLayoutEffect, useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import get from 'api/browser/localstorage/get';
 import { LOCALSTORAGE } from 'constants/localStorage';

--- a/frontend/src/pages/Logs/index.tsx
+++ b/frontend/src/pages/Logs/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { Button, Col, Divider, Popover, Row, Select, Space } from 'antd';
@@ -11,6 +12,7 @@ import LogsFilters from 'container/LogsFilters';
 import LogsSearchFilter from 'container/LogsSearchFilter';
 import LogsTable from 'container/LogsTable';
 import history from 'lib/history';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';

--- a/frontend/src/pages/MessagingQueues/MQDetails/DropRateView/DropRateView.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/DropRateView/DropRateView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Table, Typography } from 'antd';
 import logEvent from 'api/common/logEvent';

--- a/frontend/src/pages/MessagingQueues/MQDetails/MQDetails.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MQDetails.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Radio } from 'antd';
 import { QueryParams } from 'constants/query';

--- a/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MessagingQueueOverview.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction, useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Radio } from 'antd';

--- a/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricPageGraph.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/MetricPage/MetricPageGraph.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { QueryParams } from 'constants/query';

--- a/frontend/src/pages/MessagingQueues/MQGraph/MQGraph.tsx
+++ b/frontend/src/pages/MessagingQueues/MQGraph/MQGraph.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useRef } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import logEvent from 'api/common/logEvent';

--- a/frontend/src/pages/ServiceTopLevelOperations/index.tsx
+++ b/frontend/src/pages/ServiceTopLevelOperations/index.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useEffect, useMemo, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { Link, useParams } from 'react-router-dom';
 import { SyncOutlined } from '@ant-design/icons';

--- a/frontend/src/pages/Trace/index.tsx
+++ b/frontend/src/pages/Trace/index.tsx
@@ -1,4 +1,5 @@
 import { MouseEventHandler, useCallback, useEffect, useState } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { connect, useDispatch, useSelector } from 'react-redux';
 import * as Sentry from '@sentry/react';
 import { Card } from 'antd';
@@ -13,6 +14,7 @@ import { useNotifications } from 'hooks/useNotifications';
 import getStep from 'lib/getStep';
 import history from 'lib/history';
 import ErrorBoundaryFallback from 'pages/ErrorBoundaryFallback/ErrorBoundaryFallback';
+// eslint-disable-next-line no-restricted-imports
 import { bindActionCreators, Dispatch } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { GetInitialTraceFilter } from 'store/actions/trace/getInitialFilter';

--- a/frontend/src/pages/TracesExplorer/TimeSeriesView/index.tsx
+++ b/frontend/src/pages/TracesExplorer/TimeSeriesView/index.tsx
@@ -6,6 +6,7 @@ import {
 	useMemo,
 	useState,
 } from 'react';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';

--- a/frontend/src/pages/TracesFunnels/FunnelContext.tsx
+++ b/frontend/src/pages/TracesFunnels/FunnelContext.tsx
@@ -1,13 +1,16 @@
 import {
+	// eslint-disable-next-line no-restricted-imports
 	createContext,
 	Dispatch,
 	SetStateAction,
 	useCallback,
+	// eslint-disable-next-line no-restricted-imports
 	useContext,
 	useMemo,
 	useState,
 } from 'react';
 import { useQueryClient } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import logEvent from 'api/common/logEvent';
 import { ValidateFunnelResponse } from 'api/traceFunnels';

--- a/frontend/src/providers/Alert.tsx
+++ b/frontend/src/providers/Alert.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, {
+	// eslint-disable-next-line no-restricted-imports
+	createContext,
+	// eslint-disable-next-line no-restricted-imports
+	useContext,
+	useState,
+} from 'react';
 
 interface AlertRuleContextType {
 	alertRuleState: string | undefined;

--- a/frontend/src/providers/App/App.tsx
+++ b/frontend/src/providers/App/App.tsx
@@ -1,7 +1,9 @@
 import {
+	// eslint-disable-next-line no-restricted-imports
 	createContext,
 	PropsWithChildren,
 	useCallback,
+	// eslint-disable-next-line no-restricted-imports
 	useContext,
 	useEffect,
 	useMemo,

--- a/frontend/src/providers/Dashboard/Dashboard.tsx
+++ b/frontend/src/providers/Dashboard/Dashboard.tsx
@@ -1,6 +1,8 @@
 import {
+	// eslint-disable-next-line no-restricted-imports
 	createContext,
 	PropsWithChildren,
+	// eslint-disable-next-line no-restricted-imports
 	useContext,
 	useEffect,
 	useMemo,
@@ -10,6 +12,7 @@ import {
 import { Layout } from 'react-grid-layout';
 import { useTranslation } from 'react-i18next';
 import { useMutation, useQuery, UseQueryResult } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
 import { useRouteMatch } from 'react-router-dom';
 import { Modal } from 'antd';
@@ -32,6 +35,7 @@ import { useAppContext } from 'providers/App/App';
 import { initializeDefaultVariables } from 'providers/Dashboard/initializeDefaultVariables';
 import { normalizeUrlValueForVariable } from 'providers/Dashboard/normalizeUrlValue';
 import { useErrorModal } from 'providers/ErrorModalProvider';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';

--- a/frontend/src/providers/Dashboard/store/store.ts
+++ b/frontend/src/providers/Dashboard/store/store.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { produce } from 'immer';
 type ListenerFn = () => void;
 

--- a/frontend/src/providers/ErrorModalProvider.tsx
+++ b/frontend/src/providers/ErrorModalProvider.tsx
@@ -1,7 +1,9 @@
 import {
+	// eslint-disable-next-line no-restricted-imports
 	createContext,
 	ReactNode,
 	useCallback,
+	// eslint-disable-next-line no-restricted-imports
 	useContext,
 	useMemo,
 	useState,

--- a/frontend/src/providers/EventSource.tsx
+++ b/frontend/src/providers/EventSource.tsx
@@ -1,7 +1,9 @@
 import {
+	// eslint-disable-next-line no-restricted-imports
 	createContext,
 	PropsWithChildren,
 	useCallback,
+	// eslint-disable-next-line no-restricted-imports
 	useContext,
 	useEffect,
 	useMemo,

--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -1,4 +1,5 @@
 import {
+	// eslint-disable-next-line no-restricted-imports
 	createContext,
 	PropsWithChildren,
 	useCallback,

--- a/frontend/src/providers/Timezone.tsx
+++ b/frontend/src/providers/Timezone.tsx
@@ -1,8 +1,10 @@
 import React, {
+	// eslint-disable-next-line no-restricted-imports
 	createContext,
 	Dispatch,
 	SetStateAction,
 	useCallback,
+	// eslint-disable-next-line no-restricted-imports
 	useContext,
 	useMemo,
 	useState,

--- a/frontend/src/providers/cmdKProvider.tsx
+++ b/frontend/src/providers/cmdKProvider.tsx
@@ -1,6 +1,8 @@
 import React, {
+	// eslint-disable-next-line no-restricted-imports
 	createContext,
 	ReactNode,
+	// eslint-disable-next-line no-restricted-imports
 	useContext,
 	useMemo,
 	useState,

--- a/frontend/src/providers/preferences/context/PreferenceContextProvider.tsx
+++ b/frontend/src/providers/preferences/context/PreferenceContextProvider.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useMemo } from 'react';
+import React, {
+	// eslint-disable-next-line no-restricted-imports
+	createContext,
+	// eslint-disable-next-line no-restricted-imports
+	useContext,
+	useMemo,
+} from 'react';
 import useUrlQuery from 'hooks/useUrlQuery';
 import {
 	PreferenceContextValue,

--- a/frontend/src/store/actions/global.ts
+++ b/frontend/src/store/actions/global.ts
@@ -3,6 +3,7 @@ import {
 	Time,
 } from 'container/TopNav/DateTimeSelectionV2/types';
 import GetMinMax from 'lib/getMinMax';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import AppActions from 'types/actions';
 import { UPDATE_TIME_INTERVAL } from 'types/actions/globalTime';

--- a/frontend/src/store/actions/logs/addToSelectedField.ts
+++ b/frontend/src/store/actions/logs/addToSelectedField.ts
@@ -1,4 +1,5 @@
 import GetSearchFields from 'api/logs/GetSearchFields';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import AppActions from 'types/actions';
 import { SET_FIELDS } from 'types/actions/logs';

--- a/frontend/src/store/actions/logs/getFields.ts
+++ b/frontend/src/store/actions/logs/getFields.ts
@@ -1,4 +1,5 @@
 import GetSearchFields from 'api/logs/GetSearchFields';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import AppActions from 'types/actions';
 import { SET_FIELDS } from 'types/actions/logs';

--- a/frontend/src/store/actions/logs/getLogs.ts
+++ b/frontend/src/store/actions/logs/getLogs.ts
@@ -1,4 +1,5 @@
 import GetLogs from 'api/logs/GetLogs';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import AppActions from 'types/actions';
 import { SET_LOADING, SET_LOGS } from 'types/actions/logs';

--- a/frontend/src/store/actions/logs/getLogsAggregate.ts
+++ b/frontend/src/store/actions/logs/getLogsAggregate.ts
@@ -1,4 +1,5 @@
 import GetLogsAggregate from 'api/logs/GetLogsAggregate';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import AppActions from 'types/actions';
 import {

--- a/frontend/src/store/actions/metrics/getService.ts
+++ b/frontend/src/store/actions/metrics/getService.ts
@@ -2,6 +2,7 @@ import getService from 'api/metrics/getService';
 import { AxiosError } from 'axios';
 import { SOMETHING_WENT_WRONG } from 'constants/api';
 import GetMinMax from 'lib/getMinMax';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';

--- a/frontend/src/store/actions/metrics/resetInitialData.ts
+++ b/frontend/src/store/actions/metrics/resetInitialData.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';

--- a/frontend/src/store/actions/serviceMap.ts
+++ b/frontend/src/store/actions/serviceMap.ts
@@ -1,6 +1,7 @@
 import api from 'api';
 import { IResourceAttribute } from 'hooks/useResourceAttribute/types';
 import { convertRawQueriesToTraceSelectedTags } from 'hooks/useResourceAttribute/utils';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { GlobalTime } from 'types/actions/globalTime';
 

--- a/frontend/src/store/actions/trace/getInitialFilter.ts
+++ b/frontend/src/store/actions/trace/getInitialFilter.ts
@@ -1,6 +1,7 @@
 import { NotificationInstance } from 'antd/es/notification/interface';
 import getFiltersApi from 'api/trace/getFilters';
 import xor from 'lodash-es/xor';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch, Store } from 'redux';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';

--- a/frontend/src/store/actions/trace/getInitialSpansAggregate.ts
+++ b/frontend/src/store/actions/trace/getInitialSpansAggregate.ts
@@ -1,5 +1,6 @@
 import { NotificationInstance } from 'antd/es/notification/interface';
 import getSpansAggregate from 'api/trace/getSpansAggregate';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch, Store } from 'redux';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';

--- a/frontend/src/store/actions/trace/getSpans.ts
+++ b/frontend/src/store/actions/trace/getSpans.ts
@@ -1,5 +1,6 @@
 import { NotificationInstance } from 'antd/es/notification/interface';
 import getSpans from 'api/trace/getSpans';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch, Store } from 'redux';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';

--- a/frontend/src/store/actions/trace/selectTraceFilter.ts
+++ b/frontend/src/store/actions/trace/selectTraceFilter.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch, Store } from 'redux';
 import { AppState } from 'store/reducers';
 import AppActions from 'types/actions';

--- a/frontend/src/store/actions/trace/updateIsTagsError.ts
+++ b/frontend/src/store/actions/trace/updateIsTagsError.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import AppActions from 'types/actions';
 import { UPDATE_IS_TAG_ERROR } from 'types/actions/trace';

--- a/frontend/src/store/actions/trace/updateTagPanelVisiblity.ts
+++ b/frontend/src/store/actions/trace/updateTagPanelVisiblity.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import AppActions from 'types/actions';
 import { UPDATE_TAG_MODAL_VISIBILITY } from 'types/actions/trace';

--- a/frontend/src/store/actions/trace/updateTagsSelected.ts
+++ b/frontend/src/store/actions/trace/updateTagsSelected.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import AppActions from 'types/actions';
 import { UPDATE_SELECTED_TAGS } from 'types/actions/trace';

--- a/frontend/src/store/actions/usage.ts
+++ b/frontend/src/store/actions/usage.ts
@@ -1,4 +1,5 @@
 import api from 'api';
+// eslint-disable-next-line no-restricted-imports
 import { Dispatch } from 'redux';
 import { toUTCEpoch } from 'utils/timeUtils';
 

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import {
 	applyMiddleware,
 	compose,

--- a/frontend/src/store/reducers/index.ts
+++ b/frontend/src/store/reducers/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { combineReducers } from 'redux';
 
 import appReducer from './app';

--- a/frontend/src/tests/test-utils.tsx
+++ b/frontend/src/tests/test-utils.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render, RenderOptions, RenderResult } from '@testing-library/react';

--- a/frontend/src/typings/window.ts
+++ b/frontend/src/typings/window.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { compose, Store } from 'redux';
 
 declare global {


### PR DESCRIPTION
### 📄 Summary

This PR enforces a standardised state management strategy for the SigNoz frontend by adding an ESLint `no-restricted-imports` rule that flags deprecated state management patterns at import time.

**Approved patterns going forward:**
- `zustand` — client state
- `nuqs` — URL / query-string state
- `react-query` — server / async state
- `useState`, `useRef`, `useReducer` — local component state

**Deprecated (flagged by the rule):**
- `redux` / `react-redux` — global store
- `xstate` / `@xstate/react` — state machines
- `react` `createContext` / `useContext` — React Context API
- `immer` — standalone immer stores

All ~225 existing files that already use a deprecated pattern have been given a targeted `// eslint-disable-next-line no-restricted-imports`. New code written after this PR will receive a hard ESLint **error** if it reaches for a deprecated pattern, with a message pointing to the approved alternative.

See: https://signoz.notion.site/State-Management-in-SigNoz-Frontend-30bfcc6bcd1980f69523debbd70a89b5

#### Issues closed by this PR
Closes [#4092](https://github.com/SigNoz/engineering-pod/issues/4092)

---

### ✅ Change Type

- [x] 🛠️ Infra / Tooling
- [x] ♻️ Refactor

---

### 🧪 Testing Strategy

- Manual verification: ran `eslint src` after the change — 0 `no-restricted-imports` violations
- No new tests needed (rule is validated by ESLint itself)
- Edge cases: NA

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** ESLint / CI only — zero runtime impact
- **Potential regressions:** None; all existing violations are suppressed with inline disable comments
- **Rollback plan:** Revert `.eslintrc.js` change; all disable comments are inert without the rule

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | N/A |
| Change Type | Maintenance |
| Description | N/A — internal tooling change only |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The only file with logic changes is `.eslintrc.js` — all other file changes are mechanical `// eslint-disable-next-line` insertions.
- To migrate a file off the legacy pattern, remove its disable comment and replace the import with the approved equivalent; the rule will enforce it from that point forward.
