### PR TITLE
Rule state history issues

### DIFF
--- a/pkg/modules/rulestatehistory/implrulestatehistory/condition_builder.go
+++ b/pkg/modules/rulestatehistory/implrulestatehistory/condition_builder.go
@@ -97,9 +97,9 @@ func (c *conditionBuilder) ConditionFor(
 			return "true", nil
 		}
 		if operator == qbtypes.FilterOperatorExists {
-			return fmt.Sprintf("has(JSONExtractKeys(labels), '%s')", key.Name), nil
+			return fmt.Sprintf("has(JSONExtractKeys(labels), %s)", sb.Var(key.Name)), nil
 		}
-		return fmt.Sprintf("not has(JSONExtractKeys(labels), '%s')", key.Name), nil
+		return fmt.Sprintf("not has(JSONExtractKeys(labels), %s)", sb.Var(key.Name)), nil
 	}
 
 	return "", errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported operator: %v", operator)

--- a/pkg/modules/rulestatehistory/implrulestatehistory/handler.go
+++ b/pkg/modules/rulestatehistory/implrulestatehistory/handler.go
@@ -82,6 +82,9 @@ func (h *handler) GetRuleHistoryTimeline(w http.ResponseWriter, r *http.Request)
 			req.Query.Limit = token.Limit
 		}
 	}
+	if req.Query.Limit == 0 {
+		req.Query.Limit = 50
+	}
 
 	timelineItems, timelineTotal, err := h.module.GetHistoryTimeline(r.Context(), ruleID, req.Query)
 	if err != nil {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
This PR addresses two identified issues:
1.  **Timeline API returns zero results when limit omitted**: The API previously returned an empty result set when the `limit` query parameter was omitted, as `limit=0` was passed to ClickHouse. This change sets a default limit of 50 when no limit is specified.
2.  **Unescaped key name enables SQL injection risk**: A potential SQL injection vulnerability existed in the `Exists`/`NotExists` operator handling where `key.Name` was directly interpolated into the SQL query. This change updates the implementation to use parameterized queries for `key.Name` to prevent injection.

#### Screenshots / Screen Recordings (if applicable)
N/A

#### Issues closed by this PR
Closes c9298c3c-854c-4f13-b874-5c0447670246
Closes 79156efc-fb04-4909-a102-a89ebd55c580

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
#### Root Cause
1.  **Timeline API returns zero results when limit omitted**: The `V2HistoryTimelineQueryParams.Limit` defaulted to `0` when omitted, which `Query.Validate()` allowed. This `0` limit was then passed to ClickHouse, resulting in `LIMIT 0` and an empty result set.
2.  **Unescaped key name enables SQL injection risk**: The `key.Name` in `Exists`/`NotExists` operators was directly interpolated into the SQL string via `fmt.Sprintf` without proper escaping, creating a SQL injection vector.

#### Fix Strategy
1.  **Timeline API returns zero results when limit omitted**: In `parseV2TimelineQueryFromURL`, if `req.Query.Limit` is `0` (meaning no limit was provided), it is now explicitly set to a default of `50`.
2.  **Unescaped key name enables SQL injection risk**: The `key.Name` for `Exists`/`NotExists` operators is now passed as a parameter to `sb.Var()` instead of being directly interpolated, ensuring it is properly escaped by the SQL builder.

---

### 🧪 Testing Strategy
- Tests added/updated: None
- Manual verification: Verified that the timeline API returns results when limit is omitted and that the SQL injection vector is closed by using parameterized queries.
- Edge cases covered: Default limit for omitted parameter, safe handling of user-provided key names.

---

### ⚠️ Risk & Impact Assessment
- Blast radius: Low. Changes are localized to specific API handling and SQL query construction.
- Potential regressions: Low. The changes fix specific edge cases an