### PR TITLE
fix(planned-downtime): notification breaking the page due to invalid description

### DIFF
--- a/frontend/src/container/PlannedDowntime/PlannedDowntimeForm.tsx
+++ b/frontend/src/container/PlannedDowntime/PlannedDowntimeForm.tsx
@@ -33,6 +33,8 @@ import { ALL_TIME_ZONES } from 'utils/timeZoneUtil';
 
 import 'dayjs/locale/en';
 
+import { SOMETHING_WENT_WRONG } from '../../constants/api';
+import { showErrorNotification } from '../../utils/error';
 import { AlertRuleTags } from './PlannedDowntimeList';
 import {
 	createEditDowntimeSchedule,
@@ -175,14 +177,14 @@ export function PlannedDowntimeForm(
 				} else {
 					notifications.error({
 						message: 'Error',
-						description: response.error || 'unexpected_error',
+						description:
+							typeof response.error === 'string'
+								? response.error
+								: response.error?.message || SOMETHING_WENT_WRONG,
 					});
 				}
-			} catch (e) {
-				notifications.error({
-					message: 'Error',
-					description: 'unexpected_error',
-				});
+			} catch (e: unknown) {
+				showErrorNotification(notifications, e as Error);
 			}
 			setSaveLoading(false);
 		},

--- a/frontend/src/container/PlannedDowntime/PlannedDowntimeList.tsx
+++ b/frontend/src/container/PlannedDowntime/PlannedDowntimeList.tsx
@@ -25,6 +25,7 @@ import { CalendarClock, PenLine, Trash2 } from 'lucide-react';
 import { useAppContext } from 'providers/App/App';
 import { USER_ROLES } from 'types/roles';
 
+import { showErrorNotification } from '../../utils/error';
 import {
 	formatDateTime,
 	getAlertOptionsFromIds,
@@ -359,7 +360,7 @@ export function PlannedDowntimeList({
 
 	useEffect(() => {
 		if (downtimeSchedules.isError) {
-			notifications.error(downtimeSchedules.error);
+			showErrorNotification(notifications, downtimeSchedules.error);
 		}
 	}, [downtimeSchedules.error, downtimeSchedules.isError, notifications]);
 

--- a/frontend/src/container/PlannedDowntime/PlannedDowntimeutils.ts
+++ b/frontend/src/container/PlannedDowntime/PlannedDowntimeutils.ts
@@ -137,7 +137,10 @@ export const deleteDowntimeHandler = ({
 
 export const createEditDowntimeSchedule = async (
 	props: DowntimeScheduleUpdatePayload,
-): Promise<SuccessResponse<PayloadProps> | ErrorResponse> => {
+): Promise<
+	| SuccessResponse<PayloadProps>
+	| ErrorResponse<{ code: string; message: string } | string>
+> => {
 	if (props.id) {
 		return updateDowntimeSchedule({ ...props });
 	}

--- a/frontend/src/types/api/index.ts
+++ b/frontend/src/types/api/index.ts
@@ -3,10 +3,10 @@ import { ErrorStatusCode, SuccessStatusCode } from 'types/common';
 
 export type ApiResponse<T> = { data: T };
 
-export interface ErrorResponse {
+export interface ErrorResponse<ErrorObject = string> {
 	statusCode: ErrorStatusCode;
 	payload: null;
-	error: string;
+	error: ErrorObject;
 	message: string | null;
 	body?: string | null;
 }


### PR DESCRIPTION
## Pull Request

This PR fixes the issue on Planned Downtime, any misconfiguration in the screen breaks the entire page.

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The issue was caused by the ErrorResponse expecting `string` but got `{code:string, message: string}` instead.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

https://github.com/user-attachments/assets/6e5ebc9a-4164-468a-8be3-5daff9600b37

After:

https://github.com/user-attachments/assets/b53cd60f-aa09-4dda-9ed9-d4b57e774d14

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

The issue was passing bad data to useNotification.

#### Fix Strategy
> How does this PR address the root cause?

Updated types to pass the correct data to useNotification.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Added tests for notification & Alerts test manually.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed the Planned Downtime Page breaking when the information was invalid |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered