### PR TITLE
feat: operators LIKE/ILIKE support in logs pipelines

### DIFF
--- a/pkg/query-service/queryBuilderToExpr/queryBuilderToExpr.go
+++ b/pkg/query-service/queryBuilderToExpr/queryBuilderToExpr.go
@@ -427,13 +427,13 @@ func buildFilterExpr(key *telemetrytypes.TelemetryFieldKey, op qbtypes.FilterOpe
 		// contains / not contains must be case-insensitive to match query-time behaviour.
 		filter = fmt.Sprintf("lower(%s) %s lower(%s)", keyName, logOperatorsToExpr[op], fmtValue)
 	case qbtypes.FilterOperatorLike:
-		filter = fmt.Sprintf("like(string(%s), %s)", keyName, fmtValue)
+		filter = fmt.Sprintf(`type(%s) != "map" && like(string(%s), %s)`, keyName, keyName, fmtValue)
 	case qbtypes.FilterOperatorNotLike:
-		filter = fmt.Sprintf("not like(string(%s), %s)", keyName, fmtValue)
+		filter = fmt.Sprintf(`type(%s) != "map" && not like(string(%s), %s)`, keyName, keyName, fmtValue)
 	case qbtypes.FilterOperatorILike:
-		filter = fmt.Sprintf("ilike(string(%s), %s)", keyName, fmtValue)
+		filter = fmt.Sprintf(`type(%s) != "map" && ilike(string(%s), %s)`, keyName, keyName, fmtValue)
 	case qbtypes.FilterOperatorNotILike:
-		filter = fmt.Sprintf("not ilike(string(%s), %s)", keyName, fmtValue)
+		filter = fmt.Sprintf(`type(%s) != "map" && not ilike(string(%s), %s)`, keyName, keyName, fmtValue)
 	default:
 		filter = fmt.Sprintf("%s %s %s", keyName, logOperatorsToExpr[op], fmtValue)
 	}

--- a/pkg/query-service/queryBuilderToExpr/queryBuilderToExpr_test.go
+++ b/pkg/query-service/queryBuilderToExpr/queryBuilderToExpr_test.go
@@ -205,42 +205,42 @@ func TestParseExpression(t *testing.T) {
 			Query: &qbtypes.Filter{
 				Expression: "attribute.key LIKE 'foo%'",
 			},
-			Expr: `attributes["key"] != nil && like(string(attributes["key"]), "foo%")`,
+			Expr: `attributes["key"] != nil && type(attributes["key"]) != "map" && like(string(attributes["key"]), "foo%")`,
 		},
 		{
 			Name: "NOT LIKE",
 			Query: &qbtypes.Filter{
 				Expression: "attribute.key NOT LIKE 'foo%'",
 			},
-			Expr: `attributes["key"] != nil && not like(string(attributes["key"]), "foo%")`,
+			Expr: `attributes["key"] != nil && type(attributes["key"]) != "map" && not like(string(attributes["key"]), "foo%")`,
 		},
 		{
 			Name: "ILIKE",
 			Query: &qbtypes.Filter{
 				Expression: "attribute.key ILIKE 'FOO%'",
 			},
-			Expr: `attributes["key"] != nil && ilike(string(attributes["key"]), "FOO%")`,
+			Expr: `attributes["key"] != nil && type(attributes["key"]) != "map" && ilike(string(attributes["key"]), "FOO%")`,
 		},
 		{
 			Name: "NOT ILIKE",
 			Query: &qbtypes.Filter{
 				Expression: "attribute.key NOT ILIKE 'FOO%'",
 			},
-			Expr: `attributes["key"] != nil && not ilike(string(attributes["key"]), "FOO%")`,
+			Expr: `attributes["key"] != nil && type(attributes["key"]) != "map" && not ilike(string(attributes["key"]), "FOO%")`,
 		},
 		{
 			Name: "body LIKE",
 			Query: &qbtypes.Filter{
 				Expression: "body LIKE 'Server%'",
 			},
-			Expr: `body != nil && like(string(body), "Server%")`,
+			Expr: `body != nil && type(body) != "map" && like(string(body), "Server%")`,
 		},
 		{
 			Name: "body ILIKE",
 			Query: &qbtypes.Filter{
 				Expression: "body ILIKE 'server%'",
 			},
-			Expr: `body != nil && ilike(string(body), "server%")`,
+			Expr: `body != nil && type(body) != "map" && ilike(string(body), "server%")`,
 		},
 	}
 
@@ -581,8 +581,8 @@ func TestExpressionVSEntry(t *testing.T) {
 			Query: &qbtypes.Filter{
 				Expression: "body LIKE '%checkbody%'",
 			},
-			// string(map) yields "map[msg:checkbody substring level:info]" so entry 18 matches
-			ExpectedMatches: []int{2, 9, 16, 18},
+			// map bodies excluded by type check; entries 18-20 have map body → no match
+			ExpectedMatches: []int{2, 9, 16},
 		},
 		{
 			Name: "LIKE single-char wildcard (attribute)",
@@ -639,7 +639,8 @@ func TestExpressionVSEntry(t *testing.T) {
 			Query: &qbtypes.Filter{
 				Expression: "body ILIKE '%checkbody%'",
 			},
-			ExpectedMatches: []int{2, 9, 10, 16, 18},
+			// map bodies excluded by type check
+			ExpectedMatches: []int{2, 9, 10, 16},
 		},
 		{
 			Name: "NOT ILIKE case-insensitive exact (attribute)",


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Support for LIKE/NOT LIKE/ ILIKE/ NOT ILIKE operators in logs pipelines filter UI
This PR is succession to FILTERS UI being updated to v5



#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes #5878 

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification:
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix / Maintenance |
| Description | User-facing summary |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
