### PR TITLE
Revert "Sig 8931 : Migrate quick filters to use /fields/keys and /fields/values"

### DIFF
--- a/frontend/src/api/querySuggestions/getKeySuggestions.ts
+++ b/frontend/src/api/querySuggestions/getKeySuggestions.ts
@@ -1,6 +1,5 @@
 import axios from 'api';
 import { AxiosResponse } from 'axios';
-import store from 'store';
 import {
 	QueryKeyRequestProps,
 	QueryKeySuggestionsResponseProps,
@@ -18,12 +17,6 @@ export const getKeySuggestions = (
 		signalSource = '',
 	} = props;
 
-	const { globalTime } = store.getState();
-	const resolvedTimeRange = {
-		startUnixMilli: Math.floor(globalTime.minTime / 1000000),
-		endUnixMilli: Math.floor(globalTime.maxTime / 1000000),
-	};
-
 	const encodedSignal = encodeURIComponent(signal);
 	const encodedSearchText = encodeURIComponent(searchText);
 	const encodedMetricName = encodeURIComponent(metricName);
@@ -31,14 +24,7 @@ export const getKeySuggestions = (
 	const encodedFieldDataType = encodeURIComponent(fieldDataType);
 	const encodedSource = encodeURIComponent(signalSource);
 
-	let url = `/fields/keys?signal=${encodedSignal}&searchText=${encodedSearchText}&metricName=${encodedMetricName}&fieldContext=${encodedFieldContext}&fieldDataType=${encodedFieldDataType}&source=${encodedSource}`;
-
-	if (resolvedTimeRange.startUnixMilli !== undefined) {
-		url += `&startUnixMilli=${resolvedTimeRange.startUnixMilli}`;
-	}
-	if (resolvedTimeRange.endUnixMilli !== undefined) {
-		url += `&endUnixMilli=${resolvedTimeRange.endUnixMilli}`;
-	}
-
-	return axios.get(url);
+	return axios.get(
+		`/fields/keys?signal=${encodedSignal}&searchText=${encodedSearchText}&metricName=${encodedMetricName}&fieldContext=${encodedFieldContext}&fieldDataType=${encodedFieldDataType}&source=${encodedSource}`,
+	);
 };

--- a/frontend/src/api/querySuggestions/getValueSuggestion.ts
+++ b/frontend/src/api/querySuggestions/getValueSuggestion.ts
@@ -1,6 +1,5 @@
 import axios from 'api';
 import { AxiosResponse } from 'axios';
-import store from 'store';
 import {
 	QueryKeyValueRequestProps,
 	QueryKeyValueSuggestionsResponseProps,
@@ -9,20 +8,7 @@ import {
 export const getValueSuggestions = (
 	props: QueryKeyValueRequestProps,
 ): Promise<AxiosResponse<QueryKeyValueSuggestionsResponseProps>> => {
-	const {
-		signal,
-		key,
-		searchText,
-		signalSource,
-		metricName,
-		existingQuery,
-	} = props;
-
-	const { globalTime } = store.getState();
-	const resolvedTimeRange = {
-		startUnixMilli: Math.floor(globalTime.minTime / 1000000),
-		endUnixMilli: Math.floor(globalTime.maxTime / 1000000),
-	};
+	const { signal, key, searchText, signalSource, metricName } = props;
 
 	const encodedSignal = encodeURIComponent(signal);
 	const encodedKey = encodeURIComponent(key);
@@ -30,17 +16,7 @@ export const getValueSuggestions = (
 	const encodedSearchText = encodeURIComponent(searchText);
 	const encodedSource = encodeURIComponent(signalSource || '');
 
-	let url = `/fields/values?signal=${encodedSignal}&name=${encodedKey}&searchText=${encodedSearchText}&metricName=${encodedMetricName}&source=${encodedSource}`;
-
-	if (resolvedTimeRange.startUnixMilli !== undefined) {
-		url += `&startUnixMilli=${resolvedTimeRange.startUnixMilli}`;
-	}
-	if (resolvedTimeRange.endUnixMilli !== undefined) {
-		url += `&endUnixMilli=${resolvedTimeRange.endUnixMilli}`;
-	}
-	if (existingQuery) {
-		url += `&existingQuery=${encodeURIComponent(existingQuery)}`;
-	}
-
-	return axios.get(url);
+	return axios.get(
+		`/fields/values?signal=${encodedSignal}&name=${encodedKey}&searchText=${encodedSearchText}&metricName=${encodedMetricName}&source=${encodedSource}`,
+	);
 };

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.tsx
@@ -272,6 +272,7 @@ function QuerySearch({
 				metricName: debouncedMetricName ?? undefined,
 				signalSource: signalSource as 'meter' | '',
 			});
+
 			if (response.data.data) {
 				const { keys } = response.data.data;
 				const options = generateOptions(keys);
@@ -431,7 +432,6 @@ function QuerySearch({
 			}
 
 			const sanitizedSearchText = searchText ? searchText?.trim() : '';
-			const existingQuery = queryData.filter?.expression || '';
 
 			try {
 				const response = await getValueSuggestions({
@@ -440,9 +440,9 @@ function QuerySearch({
 					signal: dataSource,
 					signalSource: signalSource as 'meter' | '',
 					metricName: debouncedMetricName ?? undefined,
-					existingQuery,
-				}); // Skip updates if component unmounted or key changed
+				});
 
+				// Skip updates if component unmounted or key changed
 				if (
 					!isMountedRef.current ||
 					lastKeyRef.current !== key ||
@@ -454,9 +454,7 @@ function QuerySearch({
 				// Process the response data
 				const responseData = response.data as any;
 				const values = responseData.data?.values || {};
-				const relatedValues = values.relatedValues || [];
-				const stringValues =
-					relatedValues.length > 0 ? relatedValues : values.stringValues || [];
+				const stringValues = values.stringValues || [];
 				const numberValues = values.numberValues || [];
 
 				// Generate options from string values - explicitly handle empty strings
@@ -531,12 +529,11 @@ function QuerySearch({
 		},
 		[
 			activeKey,
-			isLoadingSuggestions,
-			queryData.filter?.expression,
-			toggleSuggestions,
 			dataSource,
-			signalSource,
+			isLoadingSuggestions,
 			debouncedMetricName,
+			signalSource,
+			toggleSuggestions,
 		],
 	);
 
@@ -1243,17 +1240,19 @@ function QuerySearch({
 		if (!queryContext) {
 			return;
 		}
-		// Only trigger suggestions and fetch if editor is focused (i.e., user is interacting)
-		if (isFocused && editorRef.current) {
+		// Trigger suggestions based on context
+		if (editorRef.current) {
 			toggleSuggestions(10);
-			// Handle value suggestions for value context
-			if (queryContext.isInValue) {
-				const { keyToken, currentToken } = queryContext;
-				const key = keyToken || currentToken;
-				// Only fetch if needed and if we have a valid key
-				if (key && key !== activeKey && !isLoadingSuggestions) {
-					fetchValueSuggestions({ key });
-				}
+		}
+
+		// Handle value suggestions for value context
+		if (queryContext.isInValue) {
+			const { keyToken, currentToken } = queryContext;
+			const key = keyToken || currentToken;
+
+			// Only fetch if needed and if we have a valid key
+			if (key && key !== activeKey && !isLoadingSuggestions) {
+				fetchValueSuggestions({ key });
 			}
 		}
 	}, [
@@ -1262,7 +1261,6 @@ function QuerySearch({
 		isLoadingSuggestions,
 		activeKey,
 		fetchValueSuggestions,
-		isFocused,
 	]);
 
 	const getTooltipContent = (): JSX.Element => (

--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.styles.scss
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.styles.scss
@@ -48,12 +48,7 @@
 		.filter-separator {
 			height: 1px;
 			background-color: var(--bg-slate-400);
-			margin: 7px 0;
-
-			&.related-separator {
-				opacity: 0.5;
-				margin: 0.5px 0;
-			}
+			margin: 4px 0;
 		}
 
 		.value {
@@ -141,93 +136,6 @@
 		.show-more-text {
 			color: var(--bg-robin-500);
 			cursor: pointer;
-		}
-	}
-
-	.search-prompt {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 8px;
-		padding: 10px 12px;
-		margin-top: 4px;
-		border: 1px dashed var(--bg-amber-500);
-		border-radius: 10px;
-		color: var(--bg-amber-200);
-		background: linear-gradient(
-			90deg,
-			var(--bg-ink-500) 0%,
-			var(--bg-ink-400) 100%
-		);
-		cursor: pointer;
-		transition: all 0.16s ease, transform 0.12s ease;
-		text-align: left;
-		box-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
-
-		&:hover {
-			background: linear-gradient(
-				90deg,
-				var(--bg-ink-400) 0%,
-				var(--bg-ink-300) 100%
-			);
-			box-shadow: 0 4px 18px rgba(0, 0, 0, 0.45);
-		}
-
-		&:active {
-			transform: translateY(1px);
-		}
-
-		&__icon {
-			color: var(--bg-amber-400);
-			flex-shrink: 0;
-		}
-
-		&__text {
-			display: flex;
-			flex-direction: column;
-			gap: 2px;
-		}
-
-		&__title {
-			color: var(--bg-amber-200);
-		}
-
-		&__subtitle {
-			color: var(--bg-amber-300);
-			font-size: 12px;
-		}
-	}
-	.lightMode & {
-		.search-prompt {
-			border: 1px dashed var(--bg-amber-500);
-			color: var(--bg-amber-800);
-			background: linear-gradient(
-				90deg,
-				var(--bg-vanilla-200) 0%,
-				var(--bg-vanilla-100) 100%
-			);
-			box-shadow: 0 2px 12px rgba(184, 107, 0, 0.08);
-
-			&:hover {
-				background: linear-gradient(
-					90deg,
-					var(--bg-vanilla-100) 0%,
-					var(--bg-vanilla-50) 100%
-				);
-				box-shadow: 0 4px 16px rgba(184, 107, 0, 0.15);
-			}
-
-			&__icon {
-				color: var(--bg-amber-600);
-			}
-
-			&__title {
-				color: var(--bg-amber-800);
-			}
-
-			&__subtitle {
-				color: var(--bg-amber-800);
-			}
 		}
 	}
 	.go-to-docs {

--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.test.tsx
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.test.tsx
@@ -150,8 +150,7 @@ describe('CheckboxFilter - User Flows', () => {
 		// User should see the filter is automatically opened (not collapsed)
 		expect(screen.getByText('Service Name')).toBeInTheDocument();
 		await waitFor(() => {
-			// eslint-disable-next-line sonarjs/no-duplicate-string
-			expect(screen.getByPlaceholderText('Search values')).toBeInTheDocument();
+			expect(screen.getByPlaceholderText('Filter values')).toBeInTheDocument();
 		});
 
 		// User should see visual separator between checked and unchecked items
@@ -185,7 +184,7 @@ describe('CheckboxFilter - User Flows', () => {
 
 		// Initially auto-opened due to active filters
 		await waitFor(() => {
-			expect(screen.getByPlaceholderText('Search values')).toBeInTheDocument();
+			expect(screen.getByPlaceholderText('Filter values')).toBeInTheDocument();
 		});
 
 		// User manually closes the filter
@@ -193,7 +192,7 @@ describe('CheckboxFilter - User Flows', () => {
 
 		// User should see filter is now closed (respecting user preference)
 		expect(
-			screen.queryByPlaceholderText('Search values'),
+			screen.queryByPlaceholderText('Filter values'),
 		).not.toBeInTheDocument();
 
 		// User manually opens the filter again
@@ -201,7 +200,7 @@ describe('CheckboxFilter - User Flows', () => {
 
 		// User should see filter is now open (respecting user preference)
 		await waitFor(() => {
-			expect(screen.getByPlaceholderText('Search values')).toBeInTheDocument();
+			expect(screen.getByPlaceholderText('Filter values')).toBeInTheDocument();
 		});
 	});
 

--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.tsx
@@ -1,15 +1,6 @@
 /* eslint-disable sonarjs/no-identical-functions */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-import {
-	Fragment,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from 'react';
-import { Button, Checkbox, Input, InputRef, Skeleton, Typography } from 'antd';
+import { Fragment, useMemo, useState } from 'react';
+import { Button, Checkbox, Input, Skeleton, Typography } from 'antd';
 import cx from 'classnames';
 import { removeKeysFromExpression } from 'components/QueryBuilderV2/utils';
 import {
@@ -17,14 +8,19 @@ import {
 	QuickFiltersSource,
 } from 'components/QuickFilters/types';
 import { OPERATORS } from 'constants/antlrQueryConstants';
-import { PANEL_TYPES } from 'constants/queryBuilder';
+import {
+	DATA_TYPE_VS_ATTRIBUTE_VALUES_KEY,
+	PANEL_TYPES,
+} from 'constants/queryBuilder';
 import { DEBOUNCE_DELAY } from 'constants/queryBuilderFilterConfig';
 import { getOperatorValue } from 'container/QueryBuilder/filters/QueryBuilderSearch/utils';
+import { useGetAggregateValues } from 'hooks/queryBuilder/useGetAggregateValues';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useGetQueryKeyValueSuggestions } from 'hooks/querySuggestions/useGetQueryKeyValueSuggestions';
 import useDebouncedFn from 'hooks/useDebouncedFunction';
 import { cloneDeep, isArray, isEqual, isFunction } from 'lodash-es';
-import { AlertTriangle, ChevronDown, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { Query, TagFilterItem } from 'types/api/queryBuilder/queryBuilderData';
 import { DataSource } from 'types/common/queryBuilder';
 import { v4 as uuid } from 'uuid';
@@ -61,7 +57,6 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 	// null = no user action, true = user opened, false = user closed
 	const [userToggleState, setUserToggleState] = useState<boolean | null>(null);
 	const [visibleItemsCount, setVisibleItemsCount] = useState<number>(10);
-	const [visibleUncheckedCount, setVisibleUncheckedCount] = useState<number>(5);
 
 	const {
 		lastUsedQuery,
@@ -82,12 +77,6 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 		}
 		return lastUsedQuery || 0;
 	}, [isListView, source, lastUsedQuery]);
-
-	// Extract current filter expression for the active query
-	const currentFilterExpression = useMemo(() => {
-		const queryData = currentQuery.builder.queryData?.[activeQueryIndex];
-		return queryData?.filter?.expression || '';
-	}, [currentQuery.builder.queryData, activeQueryIndex]);
 
 	// Check if this filter has active filters in the query
 	const isSomeFilterPresentForCurrentAttribute = useMemo(
@@ -120,125 +109,54 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 		filter.defaultOpen,
 	]);
 
+	const { data, isLoading } = useGetAggregateValues(
+		{
+			aggregateOperator: filter.aggregateOperator || 'noop',
+			dataSource: filter.dataSource || DataSource.LOGS,
+			aggregateAttribute: filter.aggregateAttribute || '',
+			attributeKey: filter.attributeKey.key,
+			filterAttributeKeyDataType: filter.attributeKey.dataType || DataTypes.EMPTY,
+			tagType: filter.attributeKey.type || '',
+			searchText: searchText ?? '',
+		},
+		{
+			enabled: isOpen && source !== QuickFiltersSource.METER_EXPLORER,
+			keepPreviousData: true,
+		},
+	);
+
 	const {
 		data: keyValueSuggestions,
 		isLoading: isLoadingKeyValueSuggestions,
-		refetch: refetchKeyValueSuggestions,
 	} = useGetQueryKeyValueSuggestions({
 		key: filter.attributeKey.key,
 		signal: filter.dataSource || DataSource.LOGS,
 		signalSource: 'meter',
-		searchText: searchText || '',
-		existingQuery: currentFilterExpression,
 		options: {
-			enabled: isOpen,
+			enabled: isOpen && source === QuickFiltersSource.METER_EXPLORER,
 			keepPreviousData: true,
 		},
 	});
 
-	const searchInputRef = useRef<InputRef | null>(null);
-	const searchContainerRef = useRef<HTMLDivElement | null>(null);
-	const previousFiltersItemsRef = useRef(
-		currentQuery.builder.queryData?.[activeQueryIndex]?.filters?.items,
-	);
+	const attributeValues: string[] = useMemo(() => {
+		const dataType = filter.attributeKey.dataType || DataTypes.String;
 
-	// Refetch when other filters change (not this filter)
-	// Watch for when filters.items is different from previous value, indicating other filters changed
-	useEffect(() => {
-		const currentFiltersItems =
-			currentQuery.builder.queryData?.[activeQueryIndex]?.filters?.items;
-
-		const previousFiltersItems = previousFiltersItemsRef.current;
-
-		// Check if filters items have changed (not the same)
-		const filtersChanged = !isEqual(previousFiltersItems, currentFiltersItems);
-
-		if (isOpen && filtersChanged) {
-			// Check if OTHER filters (not this filter) have changed
-			const currentOtherFilters = currentFiltersItems?.filter(
-				(item) => !isEqual(item.key?.key, filter.attributeKey.key),
-			);
-			const previousOtherFilters = previousFiltersItems?.filter(
-				(item) => !isEqual(item.key?.key, filter.attributeKey.key),
-			);
-
-			// Refetch if other filters changed (not just this filter's values)
-			const otherFiltersChanged = !isEqual(
-				currentOtherFilters,
-				previousOtherFilters,
-			);
-
-			// Only update ref if we have valid API data or if filters actually changed
-			// Don't update if search returned 0 results to preserve unchecked values
-			const hasValidData = keyValueSuggestions && !isLoadingKeyValueSuggestions;
-			if (otherFiltersChanged || hasValidData) {
-				previousFiltersItemsRef.current = currentFiltersItems;
-			}
-
-			if (otherFiltersChanged) {
-				refetchKeyValueSuggestions();
-			}
-		} else {
-			previousFiltersItemsRef.current = currentFiltersItems;
-		}
-	}, [
-		activeQueryIndex,
-		isOpen,
-		refetchKeyValueSuggestions,
-		filter.attributeKey.key,
-		currentQuery.builder.queryData,
-		keyValueSuggestions,
-		isLoadingKeyValueSuggestions,
-	]);
-
-	const handleSearchPromptClick = useCallback((): void => {
-		if (searchContainerRef.current) {
-			searchContainerRef.current.scrollIntoView({
-				behavior: 'smooth',
-				block: 'center',
-			});
-		}
-		if (searchInputRef.current) {
-			setTimeout(() => searchInputRef.current?.focus({ cursor: 'end' }), 120);
-		}
-	}, []);
-
-	const isDataComplete = useMemo(() => {
-		if (keyValueSuggestions) {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const responseData = keyValueSuggestions?.data as any;
-			return responseData.data?.complete || false;
-		}
-		return false;
-	}, [keyValueSuggestions]);
-
-	const previousUncheckedValuesRef = useRef<string[]>([]);
-
-	const { attributeValues, relatedValuesSet } = useMemo(() => {
-		if (keyValueSuggestions) {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		if (source === QuickFiltersSource.METER_EXPLORER && keyValueSuggestions) {
+			// Process the response data
 			const responseData = keyValueSuggestions?.data as any;
 			const values = responseData.data?.values || {};
-			const relatedValues: string[] = values.relatedValues || [];
-			const stringValues: string[] = values.stringValues || [];
-			const numberValues: number[] = values.numberValues || [];
+			const stringValues = values.stringValues || [];
+			const numberValues = values.numberValues || [];
 
-			const valuesToUse = [
-				...relatedValues,
-				...stringValues.filter(
-					(value: string | null | undefined) =>
-						value !== null &&
-						value !== undefined &&
-						value !== '' &&
-						!relatedValues.includes(value),
-				),
-			];
+			// Generate options from string values - explicitly handle empty strings
+			const stringOptions = stringValues
+				// Strict filtering for empty string - we'll handle it as a special case if needed
+				.filter(
+					(value: string | null | undefined): value is string =>
+						value !== null && value !== undefined && value !== '',
+				);
 
-			const stringOptions = valuesToUse.filter(
-				(value: string | null | undefined): value is string =>
-					value !== null && value !== undefined && value !== '',
-			);
-
+			// Generate options from number values
 			const numberOptions = numberValues
 				.filter(
 					(value: number | null | undefined): value is number =>
@@ -246,27 +164,15 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 				)
 				.map((value: number) => value.toString());
 
-			const filteredRelated = new Set(
-				relatedValues.filter(
-					(v): v is string => v !== null && v !== undefined && v !== '',
-				),
-			);
-
-			const baseValues = [...stringOptions, ...numberOptions];
-			const previousUnchecked = previousUncheckedValuesRef.current || [];
-			const preservedUnchecked = previousUnchecked.filter(
-				(value) => !baseValues.includes(value),
-			);
-			return {
-				attributeValues: [...baseValues, ...preservedUnchecked],
-				relatedValuesSet: filteredRelated,
-			};
+			// Combine all options and make sure we don't have duplicate labels
+			return [...stringOptions, ...numberOptions];
 		}
-		return {
-			attributeValues: [] as string[],
-			relatedValuesSet: new Set<string>(),
-		};
-	}, [keyValueSuggestions]);
+
+		const key = DATA_TYPE_VS_ATTRIBUTE_VALUES_KEY[dataType];
+		return (data?.payload?.[key] || []).filter(
+			(val) => val !== undefined && val !== null,
+		);
+	}, [data?.payload, filter.attributeKey.dataType, keyValueSuggestions, source]);
 
 	const setSearchTextDebounced = useDebouncedFn((...args) => {
 		setSearchText(args[0] as string);
@@ -340,51 +246,22 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 	const isMultipleValuesTrueForTheKey =
 		Object.values(currentFilterState).filter((val) => val).length > 1;
 
-	// Sort checked items to the top; always show unchecked items beneath, regardless of pagination
-	const {
-		visibleCheckedValues,
-		uncheckedValues,
-		visibleUncheckedValues,
-		visibleCheckedCount,
-		hasMoreChecked,
-		hasMoreUnchecked,
-		checkedSeparatorIndex,
-	} = useMemo(() => {
+	// Sort checked items to the top, then unchecked items
+	const currentAttributeKeys = useMemo(() => {
 		const checkedValues = attributeValues.filter(
 			(val) => currentFilterState[val],
 		);
-		const unchecked = attributeValues.filter((val) => !currentFilterState[val]);
-		const visibleChecked = checkedValues.slice(0, visibleItemsCount);
-		const visibleUnchecked = unchecked.slice(0, visibleUncheckedCount);
+		const uncheckedValues = attributeValues.filter(
+			(val) => !currentFilterState[val],
+		);
+		return [...checkedValues, ...uncheckedValues].slice(0, visibleItemsCount);
+	}, [attributeValues, currentFilterState, visibleItemsCount]);
 
-		const findSeparatorIndex = (list: string[]): number => {
-			if (relatedValuesSet.size === 0) {
-				return -1;
-			}
-			const firstNonRelated = list.findIndex((v) => !relatedValuesSet.has(v));
-			return firstNonRelated > 0 ? firstNonRelated : -1;
-		};
-
-		return {
-			visibleCheckedValues: visibleChecked,
-			uncheckedValues: unchecked,
-			visibleUncheckedValues: visibleUnchecked,
-			visibleCheckedCount: visibleChecked.length,
-			hasMoreChecked: checkedValues.length > visibleChecked.length,
-			hasMoreUnchecked: unchecked.length > visibleUnchecked.length,
-			checkedSeparatorIndex: findSeparatorIndex(visibleChecked),
-		};
-	}, [
-		attributeValues,
-		currentFilterState,
-		visibleItemsCount,
-		visibleUncheckedCount,
-		relatedValuesSet,
-	]);
-
-	useEffect(() => {
-		previousUncheckedValuesRef.current = uncheckedValues;
-	}, [uncheckedValues]);
+	// Count of checked values in the currently visible items
+	const checkedValuesCount = useMemo(
+		() => currentAttributeKeys.filter((val) => currentFilterState[val]).length,
+		[currentAttributeKeys, currentFilterState],
+	);
 
 	const handleClearFilterAttribute = (): void => {
 		const preparedQuery: Query = {
@@ -425,7 +302,6 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 		isOnlyOrAllClicked: boolean,
 		// eslint-disable-next-line sonarjs/cognitive-complexity
 	): void => {
-		setVisibleUncheckedCount(5);
 		const query = cloneDeep(currentQuery.builder.queryData?.[activeQueryIndex]);
 
 		// if only or all are clicked we do not need to worry about anything just override whatever we have
@@ -686,7 +562,6 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 					if (isOpen) {
 						setUserToggleState(false);
 						setVisibleItemsCount(10);
-						setVisibleUncheckedCount(5);
 					} else {
 						setUserToggleState(true);
 					}
@@ -715,93 +590,35 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 					)}
 				</section>
 			</section>
-			{isOpen && isLoadingKeyValueSuggestions && !attributeValues.length && (
-				<section className="loading">
-					<Skeleton paragraph={{ rows: 4 }} />
-				</section>
-			)}
-			{isOpen && !isLoadingKeyValueSuggestions && (
+			{isOpen &&
+				(isLoading || isLoadingKeyValueSuggestions) &&
+				!attributeValues.length && (
+					<section className="loading">
+						<Skeleton paragraph={{ rows: 4 }} />
+					</section>
+				)}
+			{isOpen && !isLoading && !isLoadingKeyValueSuggestions && (
 				<>
 					{!isEmptyStateWithDocsEnabled && (
-						<section className="search" ref={searchContainerRef}>
+						<section className="search">
 							<Input
-								placeholder="Search values"
+								placeholder="Filter values"
 								onChange={(e): void => setSearchTextDebounced(e.target.value)}
 								disabled={isFilterDisabled}
-								ref={searchInputRef}
 							/>
 						</section>
 					)}
 					{attributeValues.length > 0 ? (
 						<section className="values">
-							{visibleCheckedValues.map((value: string, index: number) => (
+							{currentAttributeKeys.map((value: string, index: number) => (
 								<Fragment key={value}>
-									{index === checkedSeparatorIndex && (
-										<div className="filter-separator related-separator" />
-									)}
-									<div className="value">
-										<Checkbox
-											onChange={(e): void => onChange(value, e.target.checked, false)}
-											checked={currentFilterState[value]}
-											disabled={isFilterDisabled}
-											rootClassName="check-box"
-										/>
-
+									{index === checkedValuesCount && checkedValuesCount > 0 && (
 										<div
-											className={cx(
-												'checkbox-value-section',
-												isFilterDisabled ? 'filter-disabled' : '',
-											)}
-											onClick={(): void => {
-												if (isFilterDisabled) {
-													return;
-												}
-												onChange(value, currentFilterState[value], true);
-											}}
-										>
-											<div className={`${filter.title} label-${value}`} />
-											{filter.customRendererForValue ? (
-												filter.customRendererForValue(value)
-											) : (
-												<Typography.Text
-													className="value-string"
-													ellipsis={{ tooltip: { placement: 'top' } }}
-												>
-													{String(value)}
-												</Typography.Text>
-											)}
-											<Button type="text" className="only-btn">
-												{isSomeFilterPresentForCurrentAttribute
-													? currentFilterState[value] && !isMultipleValuesTrueForTheKey
-														? 'All'
-														: 'Only'
-													: 'Only'}
-											</Button>
-											<Button type="text" className="toggle-btn">
-												Toggle
-											</Button>
-										</div>
-									</div>
-								</Fragment>
-							))}
-
-							{hasMoreChecked && (
-								<section className="show-more">
-									<Typography.Text
-										className="show-more-text"
-										onClick={(): void => setVisibleItemsCount((prev) => prev + 10)}
-									>
-										Show More...
-									</Typography.Text>
-								</section>
-							)}
-
-							{visibleCheckedCount > 0 && uncheckedValues.length > 0 && (
-								<div className="filter-separator" data-testid="filter-separator" />
-							)}
-
-							{visibleUncheckedValues.map((value: string) => (
-								<Fragment key={value}>
+											key="separator"
+											className="filter-separator"
+											data-testid="filter-separator"
+										/>
+									)}
 									<div className="value">
 										<Checkbox
 											onChange={(e): void => onChange(value, e.target.checked, false)}
@@ -853,17 +670,6 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 									</div>
 								</Fragment>
 							))}
-
-							{hasMoreUnchecked && (
-								<section className="show-more">
-									<Typography.Text
-										className="show-more-text"
-										onClick={(): void => setVisibleUncheckedCount((prev) => prev + 5)}
-									>
-										Show More...
-									</Typography.Text>
-								</section>
-							)}
 						</section>
 					) : isEmptyStateWithDocsEnabled ? (
 						<LogsQuickFilterEmptyState attributeKey={filter.attributeKey.key} />
@@ -872,18 +678,16 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 							<Typography.Text>No values found</Typography.Text>{' '}
 						</section>
 					)}
-					{visibleItemsCount >= attributeValues?.length &&
-						attributeValues?.length > 0 &&
-						!isDataComplete && (
-							<section className="search-prompt" onClick={handleSearchPromptClick}>
-								<AlertTriangle size={16} className="search-prompt__icon" />
-								<span className="search-prompt__text">
-									<Typography.Text className="search-prompt__subtitle">
-										Tap to search and load more suggestions.
-									</Typography.Text>
-								</span>
-							</section>
-						)}
+					{visibleItemsCount < attributeValues?.length && (
+						<section className="show-more">
+							<Typography.Text
+								className="show-more-text"
+								onClick={(): void => setVisibleItemsCount((prev) => prev + 10)}
+							>
+								Show More...
+							</Typography.Text>
+						</section>
+					)}
 				</>
 			)}
 		</div>

--- a/frontend/src/components/QuickFilters/QuickFilters.styles.scss
+++ b/frontend/src/components/QuickFilters/QuickFilters.styles.scss
@@ -127,34 +127,6 @@
 		align-items: center;
 		padding: 8px;
 	}
-
-	.filters-info {
-		display: flex;
-		align-items: center;
-		padding: 6px 10px 0 10px;
-		color: var(--bg-vanilla-400);
-		gap: 6px;
-		flex-wrap: wrap;
-
-		.filters-info-toggle {
-			display: inline-flex;
-			align-items: center;
-			gap: 6px;
-			padding: 0;
-			height: auto;
-			color: var(--bg-vanilla-400);
-
-			&:hover {
-				color: var(--bg-robin-500);
-			}
-		}
-
-		.filters-info-text {
-			color: var(--bg-vanilla-400);
-			font-size: 13px;
-			line-height: 16px;
-		}
-	}
 }
 
 .perilin-bg {
@@ -208,30 +180,5 @@
 				}
 			}
 		}
-
-		.filters-info {
-			color: var(--bg-ink-400);
-
-			.filters-info-toggle {
-				color: var(--bg-ink-400);
-
-				&:hover {
-					color: var(--bg-ink-300);
-				}
-			}
-
-			.filters-info-text {
-				color: var(--bg-ink-400);
-			}
-		}
 	}
-}
-
-.filters-info-tooltip-title {
-	font-weight: var(--font-weight-bold);
-	margin-bottom: 4px;
-}
-
-.filters-info-tooltip-detail {
-	margin-top: 4px;
 }

--- a/frontend/src/components/QuickFilters/QuickFilters.tsx
+++ b/frontend/src/components/QuickFilters/QuickFilters.tsx
@@ -23,7 +23,7 @@ import { PANEL_TYPES } from 'constants/queryBuilder';
 import { useApiMonitoringParams } from 'container/ApiMonitoring/queryParams';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { isFunction, isNull } from 'lodash-es';
-import { Frown, Lightbulb, Settings2 as SettingsIcon } from 'lucide-react';
+import { Frown, Settings2 as SettingsIcon } from 'lucide-react';
 import { useAppContext } from 'providers/App/App';
 import { Query } from 'types/api/queryBuilder/queryBuilderData';
 import { USER_ROLES } from 'types/roles';
@@ -291,27 +291,6 @@ export default function QuickFilters(props: IQuickFiltersProps): JSX.Element {
 					/>
 				</div>
 			)}
-			<section className="filters-info">
-				<Tooltip
-					title={
-						<div className="filters-info-tooltip">
-							<div className="filters-info-tooltip-title">Adaptive Filters</div>
-							<div>Values update automatically as you apply filters.</div>
-							<div className="filters-info-tooltip-detail">
-								The most relevant values are shown first, followed by all other
-								available options.
-							</div>
-						</div>
-					}
-					placement="right"
-					mouseEnterDelay={0.3}
-				>
-					<Typography.Text className="filters-info-toggle">
-						<Lightbulb size={15} />
-						Adaptive filters
-					</Typography.Text>
-				</Tooltip>
-			</section>
 			<section className="filters">
 				{filterConfig.map((filter) => {
 					switch (filter.type) {

--- a/frontend/src/components/QuickFilters/tests/QuickFilters.test.tsx
+++ b/frontend/src/components/QuickFilters/tests/QuickFilters.test.tsx
@@ -4,7 +4,6 @@ import {
 	useApiMonitoringParams,
 } from 'container/ApiMonitoring/queryParams';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
-import { useGetQueryKeyValueSuggestions } from 'hooks/querySuggestions/useGetQueryKeyValueSuggestions';
 import {
 	otherFiltersResponse,
 	quickFiltersAttributeValuesResponse,
@@ -25,8 +24,6 @@ jest.mock('hooks/queryBuilder/useQueryBuilder', () => ({
 }));
 jest.mock('container/ApiMonitoring/queryParams');
 
-jest.mock('hooks/querySuggestions/useGetQueryKeyValueSuggestions');
-
 const handleFilterVisibilityChange = jest.fn();
 const redirectWithQueryBuilderData = jest.fn();
 const putHandler = jest.fn();
@@ -35,15 +32,13 @@ const mockSetApiMonitoringParams = jest.fn() as jest.MockedFunction<
 >;
 const mockUseApiMonitoringParams = jest.mocked(useApiMonitoringParams);
 
-const mockUseGetQueryKeyValueSuggestions = jest.mocked(
-	useGetQueryKeyValueSuggestions,
-);
-
 const BASE_URL = ENVIRONMENT.baseURL;
 const SIGNAL = SignalType.LOGS;
 const quickFiltersListURL = `${BASE_URL}/api/v1/orgs/me/filters/${SIGNAL}`;
 const saveQuickFiltersURL = `${BASE_URL}/api/v1/orgs/me/filters`;
 const quickFiltersSuggestionsURL = `${BASE_URL}/api/v3/filter_suggestions`;
+const quickFiltersAttributeValuesURL = `${BASE_URL}/api/v3/autocomplete/attribute_values`;
+const fieldsValuesURL = `${BASE_URL}/api/v1/fields/values`;
 
 const FILTER_OS_DESCRIPTION = 'os.description';
 const FILTER_K8S_DEPLOYMENT_NAME = 'k8s.deployment.name';
@@ -67,7 +62,10 @@ const setupServer = (): void => {
 			putHandler(await req.json());
 			return res(ctx.status(200), ctx.json({}));
 		}),
-		rest.get('*/api/v1/fields/values*', (_req, res, ctx) =>
+		rest.get(quickFiltersAttributeValuesURL, (_req, res, ctx) =>
+			res(ctx.status(200), ctx.json(quickFiltersAttributeValuesResponse)),
+		),
+		rest.get(fieldsValuesURL, (_req, res, ctx) =>
 			res(ctx.status(200), ctx.json(quickFiltersAttributeValuesResponse)),
 		),
 	);
@@ -137,28 +135,18 @@ beforeEach(() => {
 				queryData: [
 					{
 						queryName: QUERY_NAME,
-						filters: { items: [], op: 'AND' },
-						filter: { expression: '' },
+						filters: { items: [{ key: 'test', value: 'value' }] },
 					},
 				],
 			},
 		},
 		lastUsedQuery: 0,
-		panelType: 'logs',
 		redirectWithQueryBuilderData,
 	});
 	mockUseApiMonitoringParams.mockReturnValue([
 		{ showIP: true } as ApiMonitoringParams,
 		mockSetApiMonitoringParams,
 	]);
-
-	// Mock the hook to return data with mq-kafka
-	mockUseGetQueryKeyValueSuggestions.mockReturnValue({
-		data: quickFiltersAttributeValuesResponse,
-		isLoading: false,
-		refetch: jest.fn(),
-	} as any);
-
 	setupServer();
 });
 
@@ -271,9 +259,8 @@ describe('Quick Filters', () => {
 
 		render(<TestQuickFilters />);
 
-		// Wait for the filter to load with data
-		const target = await screen.findByText('mq-kafka', {}, { timeout: 5000 });
-
+		// Prefer role if possible; if label text isn’t wired to input, clicking the label text is OK
+		const target = await screen.findByText('mq-kafka');
 		await user.click(target);
 
 		await waitFor(() => {

--- a/frontend/src/hooks/querySuggestions/useGetQueryKeyValueSuggestions.ts
+++ b/frontend/src/hooks/querySuggestions/useGetQueryKeyValueSuggestions.ts
@@ -1,11 +1,7 @@
-/* eslint-disable no-restricted-imports */
 import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
-import { useSelector } from 'react-redux';
 import { getValueSuggestions } from 'api/querySuggestions/getValueSuggestion';
 import { AxiosError, AxiosResponse } from 'axios';
-import { AppState } from 'store/reducers';
 import { QueryKeyValueSuggestionsResponseProps } from 'types/api/querySuggestions/types';
-import { GlobalReducer } from 'types/reducer/globalTime';
 
 export const useGetQueryKeyValueSuggestions = ({
 	key,
@@ -13,7 +9,6 @@ export const useGetQueryKeyValueSuggestions = ({
 	searchText,
 	signalSource,
 	metricName,
-	existingQuery,
 	options,
 }: {
 	key: string;
@@ -25,24 +20,11 @@ export const useGetQueryKeyValueSuggestions = ({
 		AxiosError
 	>;
 	metricName?: string;
-	existingQuery?: string;
 }): UseQueryResult<
 	AxiosResponse<QueryKeyValueSuggestionsResponseProps>,
 	AxiosError
-> => {
-	const { minTime, maxTime } = useSelector<AppState, GlobalReducer>(
-		(state) => state.globalTime,
-	);
-
-	const timeRangeKey =
-		minTime != null && maxTime != null
-			? `${Math.floor(minTime / 1e9)}-${Math.floor(maxTime / 1e9)}`
-			: null;
-
-	return useQuery<
-		AxiosResponse<QueryKeyValueSuggestionsResponseProps>,
-		AxiosError
-	>({
+> =>
+	useQuery<AxiosResponse<QueryKeyValueSuggestionsResponseProps>, AxiosError>({
 		queryKey: [
 			'queryKeyValueSuggestions',
 			key,
@@ -50,7 +32,6 @@ export const useGetQueryKeyValueSuggestions = ({
 			searchText,
 			signalSource,
 			metricName,
-			timeRangeKey,
 		],
 		queryFn: () =>
 			getValueSuggestions({
@@ -59,8 +40,6 @@ export const useGetQueryKeyValueSuggestions = ({
 				searchText: searchText || '',
 				signalSource: signalSource as 'meter' | '',
 				metricName: metricName || '',
-				existingQuery,
 			}),
 		...options,
 	});
-};

--- a/frontend/src/mocks-server/__mockdata__/customQuickFilters.ts
+++ b/frontend/src/mocks-server/__mockdata__/customQuickFilters.ts
@@ -118,13 +118,13 @@ export const otherFiltersResponse = {
 export const quickFiltersAttributeValuesResponse = {
 	status: 'success',
 	data: {
-		data: {
-			values: {
-				relatedValues: ['mq-kafka', 'otel-demo', 'otlp-python', 'sample-flask'],
-				stringValues: ['mq-kafka', 'otel-demo', 'otlp-python', 'sample-flask'],
-				numberValues: [],
-			},
-			complete: true,
-		},
+		stringAttributeValues: [
+			'mq-kafka',
+			'otel-demo',
+			'otlp-python',
+			'sample-flask',
+		],
+		numberAttributeValues: null,
+		boolAttributeValues: null,
 	},
 };

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -592,39 +592,6 @@ body {
 		}
 	}
 
-	.ant-btn-text:hover,
-	.ant-btn-text:focus-visible {
-		background-color: var(--bg-vanilla-200) !important;
-	}
-
-	.ant-btn-link:hover,
-	.ant-btn-link:focus-visible {
-		background-color: transparent !important;
-	}
-
-	.ant-btn-default:hover,
-	.ant-btn-default:focus-visible,
-	.ant-btn-text:not(.ant-btn-primary):hover,
-	.ant-btn-text:not(.ant-btn-primary):focus-visible,
-	.ant-btn:not(.ant-btn-primary):not(.ant-btn-dangerous):hover,
-	.ant-btn:not(.ant-btn-primary):not(.ant-btn-dangerous):focus-visible {
-		background-color: var(--bg-vanilla-200) !important;
-	}
-
-	.ant-typography:hover,
-	.ant-typography:focus-visible {
-		background-color: transparent !important;
-	}
-
-	.ant-tooltip {
-		--antd-arrow-background-color: var(--bg-vanilla-300);
-
-		.ant-tooltip-inner {
-			background-color: var(--bg-vanilla-200);
-			color: var(--bg-ink-500);
-		}
-	}
-
 	// Enhanced legend light mode styles
 	.u-legend-enhanced {
 		// Light mode scrollbar styling

--- a/frontend/src/types/api/querySuggestions/types.ts
+++ b/frontend/src/types/api/querySuggestions/types.ts
@@ -47,7 +47,6 @@ export interface QueryKeyValueRequestProps {
 	searchText: string;
 	signalSource?: 'meter' | '';
 	metricName?: string;
-	existingQuery?: string;
 }
 
 export type SignalType = 'traces' | 'logs' | 'metrics';


### PR DESCRIPTION
Reverts SigNoz/signoz#10110


Issue: Blank/empty values appearing in quick filters on Traces pages after PR https://github.com/SigNoz/signoz/pull/10110 was merged.
https://github.com/SigNoz/signoz/pull/10110 - PR
https://github.com/SigNoz/signoz/issues/8931 - Ticket

Root Cause:
PR https://github.com/SigNoz/signoz/pull/10110 migrated all quick filters across the application to use the new /fields/keys and /fields/values API endpoints (adaptive filters experience). However, this migration was implemented for all pages simultaneously (Logs, Traces, Metrics, Infrastructure Monitoring, etc.), when the backend's new API was only fully ready and tested for Logs.
The new API returned incomplete or empty data for Traces signals, causing blank filter values to appear in the UI.

Why Full Revert Instead of Targeted Fix:
The implementation in PR https://github.com/SigNoz/signoz/pull/10110 was tightly coupled across components:
Checkbox.tsx (filter renderer) was modified to use useGetQueryKeyValueSuggestions hook
QuerySearch.tsx (autocomplete) shared the same new API integration
Mock data and tests were updated to the new response format
Due to this coupling, isolating the fix for Traces while keeping the new behaviour for Logs would have required significant refactoring. A full revert was the fastest path to restore functionality.

Note: In the original ticket it was mentioned to migrate quick filters for all respective pages.