### PR TITLE
feat: add Kong dashboard #6028

### DIFF
--- a/kong-gateway.json
+++ b/kong-gateway.json
@@ -439,15 +439,15 @@
       "query": {
         "promql": [
           {
-            "query": "histogram_quantile(0.50, sum(rate(kong_latency_bucket{type=\"request\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le)) * 1000",
+            "query": "histogram_quantile(0.50, sum(rate(kong_latency_bucket{type=\"request\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le))",
             "legend": "p50"
           },
           {
-            "query": "histogram_quantile(0.90, sum(rate(kong_latency_bucket{type=\"request\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le)) * 1000",
+            "query": "histogram_quantile(0.90, sum(rate(kong_latency_bucket{type=\"request\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le))",
             "legend": "p90"
           },
           {
-            "query": "histogram_quantile(0.99, sum(rate(kong_latency_bucket{type=\"request\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le)) * 1000",
+            "query": "histogram_quantile(0.99, sum(rate(kong_latency_bucket{type=\"request\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le))",
             "legend": "p99"
           }
         ],
@@ -463,11 +463,11 @@
       "query": {
         "promql": [
           {
-            "query": "histogram_quantile(0.50, sum(rate(kong_latency_bucket{type=\"upstream\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le, service)) * 1000",
+            "query": "histogram_quantile(0.50, sum(rate(kong_latency_bucket{type=\"upstream\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le, service))",
             "legend": "p50 - {{service}}"
           },
           {
-            "query": "histogram_quantile(0.99, sum(rate(kong_latency_bucket{type=\"upstream\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le, service)) * 1000",
+            "query": "histogram_quantile(0.99, sum(rate(kong_latency_bucket{type=\"upstream\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le, service))",
             "legend": "p99 - {{service}}"
           }
         ],
@@ -483,11 +483,11 @@
       "query": {
         "promql": [
           {
-            "query": "histogram_quantile(0.50, sum(rate(kong_latency_bucket{type=\"kong\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le)) * 1000",
+            "query": "histogram_quantile(0.50, sum(rate(kong_latency_bucket{type=\"kong\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le))",
             "legend": "p50"
           },
           {
-            "query": "histogram_quantile(0.99, sum(rate(kong_latency_bucket{type=\"kong\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le)) * 1000",
+            "query": "histogram_quantile(0.99, sum(rate(kong_latency_bucket{type=\"kong\", namespace=~\"$namespace\", service=~\"$service\", environment=~\"$environment\", cluster=~\"$cluster\"}[5m])) by (le))",
             "legend": "p99"
           }
         ],
@@ -681,3 +681,4 @@
   },
   "version": "v3"
 }
+


### PR DESCRIPTION
Closes [#6028](tg://search_hashtag?hashtag=6028).
This PR adds a comprehensive Kong Gateway dashboard for monitoring requests, latency, and resource usage.
/claim [#6028](tg://search_hashtag?hashtag=6028)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only adds a static dashboard JSON with PromQL queries; the main risk is mismatched metric/label expectations in a given Prometheus setup.
> 
> **Overview**
> Adds a new `kong-gateway.json` dashboard definition for Kong Gateway, including Prometheus template variables (`namespace`, `service`, `environment`, `cluster`) and a 23-panel layout covering request/connection rates, latency percentiles (request/upstream/kong), response codes and error breakdowns, traffic volume, CPU/memory usage, and pod restarts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8edcff499c0c5d91ce39dd666ea81c7acb2264a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->