### PR TITLE
fix: return error for unsupported metric aggregation instead of generating malformed SQL

### DIFF
--- a/pkg/query-service/app/metrics/v4/cumulative/timeseries.go
+++ b/pkg/query-service/app/metrics/v4/cumulative/timeseries.go
@@ -137,7 +137,10 @@ func prepareTimeAggregationSubQuery(start, end, step int64, mq *v3.BuilderQuery)
 	selectLabelsAny := helpers.SelectLabelsAny(mq.GroupBy)
 	selectLabels := helpers.SelectLabels(mq.GroupBy)
 
-	op := helpers.AggregationColumnForSamplesTable(start, end, mq)
+	op, err := helpers.AggregationColumnForSamplesTable(start, end, mq)
+	if err != nil {
+		return "", err
+	}
 
 	switch mq.TimeAggregation {
 	case v3.TimeAggregationAvg:

--- a/pkg/query-service/app/metrics/v4/delta/timeseries.go
+++ b/pkg/query-service/app/metrics/v4/delta/timeseries.go
@@ -44,7 +44,10 @@ func prepareTimeAggregationSubQuery(start, end, step int64, mq *v3.BuilderQuery)
 
 	selectLabelsAny := helpers.SelectLabelsAny(mq.GroupBy)
 
-	op := helpers.AggregationColumnForSamplesTable(start, end, mq)
+	op, err := helpers.AggregationColumnForSamplesTable(start, end, mq)
+	if err != nil {
+		return "", err
+	}
 
 	switch mq.TimeAggregation {
 	case v3.TimeAggregationAvg:
@@ -104,16 +107,25 @@ func prepareQueryOptimized(start, end, step int64, mq *v3.BuilderQuery) (string,
 
 	switch mq.SpaceAggregation {
 	case v3.SpaceAggregationSum:
-		op := helpers.AggregationColumnForSamplesTable(start, end, mq)
+		op, err := helpers.AggregationColumnForSamplesTable(start, end, mq)
+		if err != nil {
+			return "", err
+		}
 		if mq.TimeAggregation == v3.TimeAggregationRate {
 			op = fmt.Sprintf("%s/%d", op, step)
 		}
 		query = fmt.Sprintf(queryTmpl, selectLabels, step, op, timeSeriesSubQuery, groupBy, orderBy)
 	case v3.SpaceAggregationMin:
-		op := helpers.AggregationColumnForSamplesTable(start, end, mq)
+		op, err := helpers.AggregationColumnForSamplesTable(start, end, mq)
+		if err != nil {
+			return "", err
+		}
 		query = fmt.Sprintf(queryTmpl, selectLabels, step, op, timeSeriesSubQuery, groupBy, orderBy)
 	case v3.SpaceAggregationMax:
-		op := helpers.AggregationColumnForSamplesTable(start, end, mq)
+		op, err := helpers.AggregationColumnForSamplesTable(start, end, mq)
+		if err != nil {
+			return "", err
+		}
 		query = fmt.Sprintf(queryTmpl, selectLabels, step, op, timeSeriesSubQuery, groupBy, orderBy)
 	case v3.SpaceAggregationPercentile50,
 		v3.SpaceAggregationPercentile75,

--- a/pkg/query-service/app/metrics/v4/helpers/sub_query.go
+++ b/pkg/query-service/app/metrics/v4/helpers/sub_query.go
@@ -117,7 +117,7 @@ func WhichSamplesTableToUse(start, end int64, mq *v3.BuilderQuery) string {
 	}
 }
 
-func AggregationColumnForSamplesTable(start, end int64, mq *v3.BuilderQuery) string {
+func AggregationColumnForSamplesTable(start, end int64, mq *v3.BuilderQuery) (string, error) {
 	tableName := WhichSamplesTableToUse(start, end, mq)
 	var aggregationColumn string
 	switch mq.Temporality {
@@ -247,7 +247,10 @@ func AggregationColumnForSamplesTable(start, end int64, mq *v3.BuilderQuery) str
 			}
 		}
 	}
-	return aggregationColumn
+	if aggregationColumn == "" {
+		return "", fmt.Errorf("unsupported combination of temporality (%s), time aggregation (%s), and table (%s)", mq.Temporality, mq.TimeAggregation, tableName)
+	}
+	return aggregationColumn, nil
 }
 
 // PrepareTimeseriesFilterQuery builds the sub-query to be used for filtering timeseries based on the search criteria


### PR DESCRIPTION
## Summary

Fixes #8912

`AggregationColumnForSamplesTable` in the v4 metrics query builder (`pkg/query-service/app/metrics/v4/helpers/sub_query.go`) silently returned an empty string when given an unsupported combination of temporality, time aggregation, and samples table. This empty string was then interpolated into the SQL template (`%s as per_series_value`), producing malformed ClickHouse queries containing `AS AS per_series_value` that fail at execution time with:

```
Unknown expression identifier `AS` in scope __temporal_aggregation_cte AS (
  SELECT fingerprint,
         toStartOfInterval(toDateTime(intDiv(unix_milli, 1000)), toIntervalSecond(60)) AS ts,
         AS AS per_series_value
  ...
```

### Changes

- **`pkg/query-service/app/metrics/v4/helpers/sub_query.go`**: Changed `AggregationColumnForSamplesTable` return type from `string` to `(string, error)`. When the resolved aggregation column is empty (unsupported input combination), it now returns a descriptive error instead of an empty string.

- **`pkg/query-service/app/metrics/v4/delta/timeseries.go`**: Updated all 4 call sites to handle the new error return, propagating it up to the caller.

- **`pkg/query-service/app/metrics/v4/cumulative/timeseries.go`**: Updated the call site to handle the new error return.

This aligns the older v4 query builder with the pattern already used in the newer `pkg/telemetrymetrics` package, which already returns `(string, error)` and checks for empty aggregation columns.

## Test plan

- [ ] Existing unit tests in `delta/time_series_test.go`, `cumulative/timeseries_test.go`, and `query_builder_test.go` continue to pass (all use valid temporality/timeAggregation combinations)
- [ ] Queries with unsupported combinations now return a clear error message instead of producing a malformed ClickHouse query

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only alters behavior for previously unsupported query combinations by returning an error instead of generating invalid SQL.
> 
> **Overview**
> Prevents malformed v4 metric time series SQL by changing `helpers.AggregationColumnForSamplesTable` to return `(string, error)` and emitting a descriptive error when no valid aggregation column can be resolved.
> 
> Updates cumulative and delta time series query builders to handle and propagate this error at all call sites (including the delta optimized path), so unsupported query combinations fail fast instead of generating invalid `AS AS per_series_value` SQL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5f51dc62e7b81772e0dfec73524f05fc9d21577. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->