### PR TITLE
chore: remove tsc2 check from jsci

### DIFF
--- a/.github/workflows/jsci.yaml
+++ b/.github/workflows/jsci.yaml
@@ -17,23 +17,6 @@ jobs:
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork && github.event.pull_request.user.login != 'dependabot[bot]' && ! contains(github.event.pull_request.labels.*.name, 'safe-to-test')) ||
       (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: setup node
-        uses: actions/setup-node@v5
-        with:
-          node-version: "22"
-      - name: install
-        run: cd frontend && yarn install
-      - name: tsc
-        run: cd frontend && yarn tsc
-  tsc2:
-    if: |
-      github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork && github.event.pull_request.user.login != 'dependabot[bot]' && ! contains(github.event.pull_request.labels.*.name, 'safe-to-test')) ||
-      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
     uses: signoz/primus.workflows/.github/workflows/js-tsc.yaml@main
     secrets: inherit
     with:


### PR DESCRIPTION
### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Removed the tsc2 check from jsci. This is a clean up that was pending.

https://github.com/SigNoz/signoz/pull/10011#issuecomment-3783510846