### PR TITLE
fix(frontend): refresh generated api on 401 errors

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -94,19 +94,13 @@ export const interceptorRejected = async (
 					afterLogin(response.data.accessToken, response.data.refreshToken, true);
 
 					try {
-						const reResponse = await axios(
-							`${value.config.baseURL}${value.config.url?.substring(1)}`,
-							{
-								method: value.config.method,
-								headers: {
-									...value.config.headers,
-									Authorization: `Bearer ${response.data.accessToken}`,
-								},
-								data: {
-									...JSON.parse(value.config.data || '{}'),
-								},
+						const reResponse = await axios({
+							...value.config,
+							headers: {
+								...value.config.headers,
+								Authorization: `Bearer ${response.data.accessToken}`,
 							},
-						);
+						});
 
 						return await Promise.resolve(reResponse);
 					} catch (error) {


### PR DESCRIPTION
### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

When the auth token expires and calls are made to any API, the expectation is that it first fails and then a new call is made with the rotated token. This was not happening for APIs generated from openAPI. This PR fixes that

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

##### Before

https://github.com/user-attachments/assets/73706bd1-93e9-447c-a338-86608a8eb65c

##### After (Page using generated API)

https://github.com/user-attachments/assets/4b8007a2-d8cf-4217-9f8d-277343d1ea3b

##### After (Page not using generated API)

https://github.com/user-attachments/assets/58fec8e1-7c58-4d3d-beda-6fc9a6f9eef9

##### After (Page not using generated API but with POST)

https://github.com/user-attachments/assets/fd79ea75-ae5b-4b9b-ae4a-cbde22152770

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/signoz/issues/10531

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only