### PR TITLE
Fix list height in trace details page for filters dropdown

### DIFF
--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
@@ -100,6 +100,17 @@ interface QueryBuilderSearchV2Props {
 	// Determines whether to call onChange when a tag is closed
 	triggerOnChangeOnClose?: boolean;
 	skipQueryBuilderRedirect?: boolean;
+	/** Additional props passed through to the underlying Ant Design Select (e.g. listHeight, listItemHeight) */
+	selectProps?: Partial<
+		Pick<
+			React.ComponentProps<typeof Select>,
+			| 'listHeight'
+			| 'listItemHeight'
+			| 'popupClassName'
+			| 'dropdownMatchSelectWidth'
+			| 'popupMatchSelectWidth'
+		>
+	>;
 }
 
 export interface Option {
@@ -142,6 +153,7 @@ function QueryBuilderSearchV2(
 		hideSpanScopeSelector,
 		triggerOnChangeOnClose,
 		skipQueryBuilderRedirect,
+		selectProps,
 	} = props;
 
 	const { registerShortcut, deregisterShortcut } = useKeyboardHotkeys();
@@ -972,6 +984,7 @@ function QueryBuilderSearchV2(
 	return (
 		<div className="query-builder-search-v2">
 			<Select
+				{...selectProps}
 				data-testid={'qb-search-select'}
 				ref={selectRef}
 				{...(hasPopupContainer ? { getPopupContainer: popupContainer } : {})}
@@ -1077,6 +1090,7 @@ QueryBuilderSearchV2.defaultProps = {
 	hideSpanScopeSelector: true,
 	triggerOnChangeOnClose: false,
 	skipQueryBuilderRedirect: false,
+	selectProps: undefined,
 };
 
 export default QueryBuilderSearchV2;

--- a/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/Filters/Filters.tsx
+++ b/frontend/src/container/TraceWaterfall/TraceWaterfallStates/Success/Filters/Filters.tsx
@@ -160,6 +160,7 @@ function Filters({
 				onChange={handleFilterChange}
 				hideSpanScopeSelector={false}
 				skipQueryBuilderRedirect
+				selectProps={{ listHeight: 125 }}
 			/>
 			{filteredSpanIds.length > 0 && (
 				<div className="pre-next-toggle">


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The filter dropdown (QueryBuilderSearchV2) on the Trace details page was overlapping the search bar when zoomed because there wasn’t enough space below for the full dropdown.
Changes made:

- selectProps prop on QueryBuilderSearchV2 – Added a selectProps prop so callers can pass Ant Design Select props (e.g. listHeight) through to the underlying Select.
- Trace Waterfall Filters – Pass selectProps={{ listHeight: 125 }} to cap the dropdown height at 100px so it fits in the zoomed view and no longer hides the search bar.


#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

https://github.com/user-attachments/assets/3de369dd-49c5-4741-b332-eb82fd3b7d89

After:


https://github.com/user-attachments/assets/e2b67547-0f8f-4d24-bad0-336b53860f84



#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.
https://github.com/SigNoz/engineering-pod/issues/4047
---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification:
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix / Maintenance |
| Description | User-facing summary |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->



