### PR TITLE
fix: match light mode border color in External APIs page

### DIFF
--- a/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
+++ b/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
@@ -25,7 +25,7 @@
 		width: 100%;
 
 		.toolbar {
-            border-top: 0px;
+			border-top: 0px;
 			border-bottom: 1px solid var(--bg-slate-400);
 		}
 


### PR DESCRIPTION
Found this while testing the API Monitoring page in light mode — the border color under the quick filters and toolbar looked different from the rest of the app.

Fixed by:
- Added border color override in Explorer.styles.scss for .lightMode
- Changed .api-quick-filters-header to use var(--bg-vanilla-300)
- Changed .toolbar to use var(--bg-vanilla-300)

Tested locally by switching to light mode and comparing with other pages. The borders now match the header and other components.

Wondering if there's a better way to centralize these light mode overrides so they don't get out of sync in the future?

Fixes #9402

Before:
<img width="1714" height="479" alt="image" src="https://github.com/user-attachments/assets/09ae339f-b97b-47ae-bb9f-4e609523131b" />

After:

<img width="1714" height="382" alt="image" src="https://github.com/user-attachments/assets/5ecf38ca-2133-4cd1-a15f-adad272284b6" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that tweaks border colors in light mode; no logic or data flow is affected.
> 
> **Overview**
> Adjusts `ApiMonitoring` Explorer styling so **light mode** borders match the rest of the app.
> 
> Adds `.lightMode` overrides to use `var(--bg-vanilla-300)` for the bottom borders under the quick filters header and the right-side toolbar, and removes an unused right border from the quick filters header while explicitly zeroing the toolbar top border.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f1fe3c4fd52792e78b012bd786aed592534e9b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->