### PR TITLE
fix(app-routes): do not render old route, redirect instead

### DIFF
--- a/frontend/src/AppRoutes/Private.tsx
+++ b/frontend/src/AppRoutes/Private.tsx
@@ -1,6 +1,6 @@
 import { ReactChild, useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
-import { matchPath, useLocation } from 'react-router-dom';
+import { matchPath, Redirect, useLocation } from 'react-router-dom';
 import getLocalStorageApi from 'api/browser/localstorage/get';
 import setLocalStorageApi from 'api/browser/localstorage/set';
 import getAll from 'api/v1/user/get';
@@ -236,13 +236,7 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 	useEffect(() => {
 		// if it is an old route navigate to the new route
 		if (isOldRoute) {
-			const redirectUrl = oldNewRoutesMapping[pathname];
-
-			const newLocation = {
-				...location,
-				pathname: redirectUrl,
-			};
-			history.replace(newLocation);
+			// this will be handled by the redirect component below
 			return;
 		}
 
@@ -295,6 +289,19 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 			history.push(ROUTES.LOGIN);
 		}
 	}, [isLoggedInState, pathname, user, isOldRoute, currentRoute, location]);
+
+	if (isOldRoute) {
+		const redirectUrl = oldNewRoutesMapping[pathname];
+		return (
+			<Redirect
+				to={{
+					pathname: redirectUrl,
+					search: location.search,
+					hash: location.hash,
+				}}
+			/>
+		);
+	}
 
 	// NOTE: disabling this rule as there is no need to have div
 	return <>{children}</>;


### PR DESCRIPTION
## Pull Request

There's a really rare race condition that could cause the old page to render first and then it redirects to the new URL.

It's very likely the user that had this issue saw the redirect after the error page, so it's not a huge bug but a more annoying one.

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

This can cause an issue like [this](https://signoz-io.sentry.io/issues/7324889549/?alert_rule_id=15272042&alert_type=issue&notification_uuid=44078c62-07cf-4fee-9638-d8e25833c462&project=4506831143763968&referrer=slack#contexts).

The bug was caused because the EditRules was rendered before it redirects, and the EditRules has the component `EditAlertV2` that requires the `CreateAlertProvider`, which is only defined on `AlertDetails`.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

I was not able to reproduce the bug locally.

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

[Sentry Link](https://signoz-io.sentry.io/issues/7324889549/?alert_rule_id=15272042&alert_type=issue&notification_uuid=44078c62-07cf-4fee-9638-d8e25833c462&project=4506831143763968&referrer=slack#contexts)

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

It was caused by a race condition on EditRules being rendered before the PrivateRoute could redirect to the new route, the bug was the missing provider of `CreateAlertProvider`

#### Fix Strategy
> How does this PR address the root cause?

Instead of try render the component, just return an `Redirect` route component.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification: I was not able to test locally.
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Little
- Potential regressions: This should now cause any regression since this only affects old routes.
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | In rare cases, the old routes could cause an error in the app due to redirect to new page being a little bit slow to run. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
