### PR TITLE
chore: add slack notification on dequeue from merge queue

### DIFF
--- a/.github/workflows/mergequeueci.yaml
+++ b/.github/workflows/mergequeueci.yaml
@@ -1,4 +1,4 @@
-name: Notify on Dequeue from Merge Queue
+name: mergequeueci
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Send Slack alert
+      - name: alert
         uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ secrets.SLACK_MERGE_QUEUE_WEBHOOK }}
@@ -46,7 +46,7 @@ jobs:
                 }
               ]
             }
-      - name: Post PR comment
+      - name: comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

- If any PR is dequeued from the merge queue for any reason, a slack notification needs to be sent across notifying the  owners of it. 
- Currently not able to link slack id with github id. 

- Devs could also subscribe to PR workflows with the Github app on slack as an alternative