### PR TITLE
refactor(Test PR): rename body JSON constants

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/SigNoz/signoz-otel-collector v0.144.2
 	github.com/antlr4-go/antlr/v4 v4.13.1
 	github.com/antonmedv/expr v1.15.3
-	github.com/bytedance/sonic v1.14.1
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dgraph-io/ristretto/v2 v2.3.0
@@ -106,6 +105,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 // indirect
 	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
+	github.com/bytedance/sonic v1.14.1 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect

--- a/pkg/modules/promote/implpromote/module.go
+++ b/pkg/modules/promote/implpromote/module.go
@@ -78,7 +78,7 @@ func (m *module) ListPromotedAndIndexedPaths(ctx context.Context) ([]promotetype
 
 	// add the paths that are not promoted but have indexes
 	for path, indexes := range aggr {
-		path := strings.TrimPrefix(path, telemetrylogs.BodyJSONColumnPrefix)
+		path := strings.TrimPrefix(path, telemetrylogs.BodyV2ColumnPrefix)
 		path = telemetrytypes.BodyJSONStringSearchPrefix + path
 		response = append(response, promotetypes.PromotePath{
 			Path:    path,
@@ -163,7 +163,7 @@ func (m *module) PromoteAndIndexPaths(
 			}
 		}
 		if len(it.Indexes) > 0 {
-			parentColumn := telemetrylogs.LogsV2BodyJSONColumn
+			parentColumn := telemetrylogs.LogsV2BodyV2Column
 			// if the path is already promoted or is being promoted, add it to the promoted column
 			if _, promoted := existingPromotedPaths[it.Path]; promoted || it.Promote {
 				parentColumn = telemetrylogs.LogsV2BodyPromotedColumn

--- a/pkg/querier/builder_query.go
+++ b/pkg/querier/builder_query.go
@@ -10,13 +10,11 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/SigNoz/signoz/pkg/errors"
-	"github.com/SigNoz/signoz/pkg/telemetrylogs"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/types/ctxtypes"
 	"github.com/SigNoz/signoz/pkg/types/instrumentationtypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
-	"github.com/bytedance/sonic"
 )
 
 type builderQuery[T any] struct {
@@ -262,40 +260,6 @@ func (q *builderQuery[T]) executeWithContext(ctx context.Context, query string, 
 		return nil, err
 	}
 
-	// merge body_json and promoted into body
-	if q.spec.Signal == telemetrytypes.SignalLogs {
-		switch typedPayload := payload.(type) {
-		case *qbtypes.RawData:
-			for _, rr := range typedPayload.Rows {
-				seeder := func() error {
-					body, ok := rr.Data[telemetrylogs.LogsV2BodyJSONColumn].(map[string]any)
-					if !ok {
-						return nil
-					}
-					promoted, ok := rr.Data[telemetrylogs.LogsV2BodyPromotedColumn].(map[string]any)
-					if !ok {
-						return nil
-					}
-					seed(promoted, body)
-					str, err := sonic.MarshalString(body)
-					if err != nil {
-						return errors.Wrapf(err, errors.TypeInternal, errors.CodeInternal, "failed to marshal body")
-					}
-					rr.Data["body"] = str
-					return nil
-				}
-				err := seeder()
-				if err != nil {
-					return nil, err
-				}
-
-				delete(rr.Data, telemetrylogs.LogsV2BodyJSONColumn)
-				delete(rr.Data, telemetrylogs.LogsV2BodyPromotedColumn)
-			}
-			payload = typedPayload
-		}
-	}
-
 	return &qbtypes.Result{
 		Type:  q.kind,
 		Value: payload,
@@ -422,19 +386,4 @@ func decodeCursor(cur string) (int64, error) {
 		return 0, err
 	}
 	return strconv.ParseInt(string(b), 10, 64)
-}
-
-func seed(promoted map[string]any, body map[string]any) {
-	for key, fromValue := range promoted {
-		if toValue, ok := body[key]; !ok {
-			body[key] = fromValue
-		} else {
-			if fromValue, ok := fromValue.(map[string]any); ok {
-				if toValue, ok := toValue.(map[string]any); ok {
-					seed(fromValue, toValue)
-					body[key] = toValue
-				}
-			}
-		}
-	}
 }

--- a/pkg/querier/consume.go
+++ b/pkg/querier/consume.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
-	"github.com/bytedance/sonic"
 )
 
 var (
@@ -394,17 +393,11 @@ func readAsRaw(rows driver.Rows, queryName string) (*qbtypes.RawData, error) {
 
 			// de-reference the typed pointer to any
 			val := reflect.ValueOf(cellPtr).Elem().Interface()
-
-			// Post-process JSON columns: normalize into structured values
+			// Post-process JSON columns: normalize into String value
 			if strings.HasPrefix(strings.ToUpper(colTypes[i].DatabaseTypeName()), "JSON") {
 				switch x := val.(type) {
 				case []byte:
-					if len(x) > 0 {
-						var v any
-						if err := sonic.Unmarshal(x, &v); err == nil {
-							val = v
-						}
-					}
+					val = string(x)
 				default:
 					// already a structured type (map[string]any, []any, etc.)
 				}

--- a/pkg/telemetrylogs/const.go
+++ b/pkg/telemetrylogs/const.go
@@ -1,7 +1,11 @@
 package telemetrylogs
 
 import (
+	"fmt"
+
+	schema "github.com/SigNoz/signoz-otel-collector/cmd/signozschemamigrator/schema_migrator"
 	"github.com/SigNoz/signoz-otel-collector/constants"
+	"github.com/SigNoz/signoz/pkg/querybuilder"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 )
@@ -17,7 +21,7 @@ const (
 	LogsV2TimestampColumn         = "timestamp"
 	LogsV2ObservedTimestampColumn = "observed_timestamp"
 	LogsV2BodyColumn              = "body"
-	LogsV2BodyJSONColumn          = constants.BodyV2Column
+	LogsV2BodyV2Column            = constants.BodyV2Column
 	LogsV2BodyPromotedColumn      = constants.BodyPromotedColumn
 	LogsV2TraceIDColumn           = "trace_id"
 	LogsV2SpanIDColumn            = "span_id"
@@ -34,11 +38,23 @@ const (
 	LogsV2ResourcesStringColumn  = "resources_string"
 	LogsV2ScopeStringColumn      = "scope_string"
 
-	BodyJSONColumnPrefix     = constants.BodyV2ColumnPrefix
+	BodyV2ColumnPrefix       = constants.BodyV2ColumnPrefix
 	BodyPromotedColumnPrefix = constants.BodyPromotedColumnPrefix
+	MessageBodyField         = "message"
+	MessageSubColumn         = "body_v2.message"
+	bodySearchDefaultWarning = "body searches default to `body.message:string`. Use `body.<key>` to search a different field inside body"
 )
 
 var (
+	// Mapping to access it as a direct sub-column (body_v2.message) rather than via
+	// dynamicElement() lambda expressions.
+	BodyFieldMessageMapping = &telemetrytypes.TelemetryFieldKey{
+		Name:          MessageBodyField,
+		Signal:        telemetrytypes.SignalLogs,
+		FieldContext:  telemetrytypes.FieldContextBody,
+		FieldDataType: telemetrytypes.FieldDataTypeString,
+		Materialized:  true,
+	}
 	DefaultFullTextColumn = &telemetrytypes.TelemetryFieldKey{
 		Name:          "body",
 		Signal:        telemetrytypes.SignalLogs,
@@ -118,3 +134,31 @@ var (
 		},
 	}
 )
+
+func bodyAliasExpression() string {
+	if !querybuilder.BodyJSONQueryEnabled {
+		return LogsV2BodyColumn
+	}
+
+	return fmt.Sprintf("%s as body", LogsV2BodyV2Column)
+}
+
+func enrichMapsForJSONBodyEnabled() {
+	if querybuilder.BodyJSONQueryEnabled {
+		DefaultFullTextColumn = BodyFieldMessageMapping
+		IntrinsicFields["body"] = *BodyFieldMessageMapping
+
+		// Register all key names that should resolve to the message type-hint column so
+		// QB can look them up directly: bare "message" and qualified "body_v2.message".
+		IntrinsicFields[MessageSubColumn] = *BodyFieldMessageMapping
+		IntrinsicFields[MessageBodyField] = *BodyFieldMessageMapping
+		logsV2Columns[MessageSubColumn] = &schema.Column{
+			Name: MessageSubColumn,
+			Type: schema.ColumnTypeString,
+		}
+	}
+}
+
+func init() {
+	enrichMapsForJSONBodyEnabled()
+}

--- a/pkg/telemetrylogs/field_mapper.go
+++ b/pkg/telemetrylogs/field_mapper.go
@@ -30,7 +30,7 @@ var (
 		"severity_text":      {Name: "severity_text", Type: schema.LowCardinalityColumnType{ElementType: schema.ColumnTypeString}},
 		"severity_number":    {Name: "severity_number", Type: schema.ColumnTypeUInt8},
 		"body":               {Name: "body", Type: schema.ColumnTypeString},
-		LogsV2BodyJSONColumn: {Name: LogsV2BodyJSONColumn, Type: schema.JSONColumnType{
+		LogsV2BodyV2Column: {Name: LogsV2BodyV2Column, Type: schema.JSONColumnType{
 			MaxDynamicTypes: utils.ToPointer(uint(32)),
 			MaxDynamicPaths: utils.ToPointer(uint(0)),
 		}},
@@ -88,10 +88,16 @@ func (m *fieldMapper) getColumn(_ context.Context, key *telemetrytypes.Telemetry
 			return logsV2Columns["attributes_bool"], nil
 		}
 	case telemetrytypes.FieldContextBody:
-		// Body context is for JSON body fields
-		// Use body_json if feature flag is enabled
+		// Body context is for JSON body fields. Use body_v2 if feature flag is enabled.
 		if querybuilder.BodyJSONQueryEnabled {
-			return logsV2Columns[LogsV2BodyJSONColumn], nil
+			// (Materialized=true) have a direct physical sub-column in body_v2.
+			// No lambda expressions (which expects a JSONPlan).
+			if key.Materialized {
+				// return direct physical sub-column in body_v2 (e.g. body_v2.message).
+				return logsV2Columns[fmt.Sprintf("%s.%s", LogsV2BodyV2Column, key.Name)], nil
+			}
+
+			return logsV2Columns[LogsV2BodyV2Column], nil
 		}
 		// Fall back to legacy body column
 		return logsV2Columns["body"], nil
@@ -100,9 +106,9 @@ func (m *fieldMapper) getColumn(_ context.Context, key *telemetrytypes.Telemetry
 		if !ok {
 			// check if the key has body JSON search
 			if strings.HasPrefix(key.Name, telemetrytypes.BodyJSONStringSearchPrefix) {
-				// Use body_json if feature flag is enabled and we have a body condition builder
+				// Use body_v2 if feature flag is enabled and we have a body condition builder
 				if querybuilder.BodyJSONQueryEnabled {
-					return logsV2Columns[LogsV2BodyJSONColumn], nil
+					return logsV2Columns[LogsV2BodyV2Column], nil
 				}
 				// Fall back to legacy body column
 				return logsV2Columns["body"], nil
@@ -246,34 +252,37 @@ func (m *fieldMapper) buildFieldForJSON(key *telemetrytypes.TelemetryFieldKey) (
 		node := plan[0]
 
 		expr := fmt.Sprintf("dynamicElement(%s, '%s')", node.FieldPath(), node.TerminalConfig.ElemType.StringValue())
-		if key.Materialized {
-			if len(plan) < 2 {
-				return "", errors.Newf(errors.TypeUnexpected, CodePromotedPlanMissing,
-					"plan length is less than 2 for promoted path: %s", key.Name)
-			}
+		// TODO(Piyush): Promoted path logic commented out. Materialized now means type hint
+		// promotion will be extracted from key field evolution
+		// (direct sub-column access), not a promoted body_promoted.* column.
+		// if key.Materialized {
+		// 	if len(plan) < 2 {
+		// 		return "", errors.Newf(errors.TypeUnexpected, CodePromotedPlanMissing,
+		// 			"plan length is less than 2 for promoted path: %s", key.Name)
+		// 	}
 
-			node := plan[1]
-			promotedExpr := fmt.Sprintf(
-				"dynamicElement(%s, '%s')",
-				node.FieldPath(),
-				node.TerminalConfig.ElemType.StringValue(),
-			)
+		// 	node := plan[1]
+		// 	promotedExpr := fmt.Sprintf(
+		// 		"dynamicElement(%s, '%s')",
+		// 		node.FieldPath(),
+		// 		node.TerminalConfig.ElemType.StringValue(),
+		// 	)
 
-			// dynamicElement returns NULL for scalar types or an empty array for array types.
-			if node.TerminalConfig.ElemType.IsArray {
-				expr = fmt.Sprintf(
-					"if(length(%s) > 0, %s, %s)",
-					promotedExpr,
-					promotedExpr,
-					expr,
-				)
-			} else {
-				// promoted column first then body_json column
-				// TODO(Piyush): Change this in future for better performance
-				expr = fmt.Sprintf("coalesce(%s, %s)", promotedExpr, expr)
-			}
+		// 	// dynamicElement returns NULL for scalar types or an empty array for array types.
+		// 	if node.TerminalConfig.ElemType.IsArray {
+		// 		expr = fmt.Sprintf(
+		// 			"if(length(%s) > 0, %s, %s)",
+		// 			promotedExpr,
+		// 			promotedExpr,
+		// 			expr,
+		// 		)
+		// 	} else {
+		// 		// promoted column first then body_json column
+		// 		// TODO(Piyush): Change this in future for better performance
+		// 		expr = fmt.Sprintf("coalesce(%s, %s)", promotedExpr, expr)
+		// 	}
 
-		}
+		// }
 
 		return expr, nil
 	}

--- a/pkg/telemetrylogs/statement_builder.go
+++ b/pkg/telemetrylogs/statement_builder.go
@@ -65,7 +65,7 @@ func (b *logQueryStatementBuilder) Build(
 	start = querybuilder.ToNanoSecs(start)
 	end = querybuilder.ToNanoSecs(end)
 
-	keySelectors := getKeySelectors(query)
+	keySelectors, warnings := getKeySelectors(query)
 	keys, _, err := b.metadataStore.GetKeysMulti(ctx, keySelectors)
 	if err != nil {
 		return nil, err
@@ -76,20 +76,29 @@ func (b *logQueryStatementBuilder) Build(
 	// Create SQL builder
 	q := sqlbuilder.NewSelectBuilder()
 
+	var stmt *qbtypes.Statement
 	switch requestType {
 	case qbtypes.RequestTypeRaw, qbtypes.RequestTypeRawStream:
-		return b.buildListQuery(ctx, q, query, start, end, keys, variables)
+		stmt, err = b.buildListQuery(ctx, q, query, start, end, keys, variables)
 	case qbtypes.RequestTypeTimeSeries:
-		return b.buildTimeSeriesQuery(ctx, q, query, start, end, keys, variables)
+		stmt, err = b.buildTimeSeriesQuery(ctx, q, query, start, end, keys, variables)
 	case qbtypes.RequestTypeScalar:
-		return b.buildScalarQuery(ctx, q, query, start, end, keys, false, variables)
+		stmt, err = b.buildScalarQuery(ctx, q, query, start, end, keys, false, variables)
+	default:
+		return nil, errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported request type: %s", requestType)
 	}
 
-	return nil, errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported request type: %s", requestType)
+	if err != nil {
+		return nil, err
+	}
+
+	stmt.Warnings = append(stmt.Warnings, warnings...)
+	return stmt, nil
 }
 
-func getKeySelectors(query qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]) []*telemetrytypes.FieldKeySelector {
+func getKeySelectors(query qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]) ([]*telemetrytypes.FieldKeySelector, []string) {
 	var keySelectors []*telemetrytypes.FieldKeySelector
+	var warnings []string
 
 	for idx := range query.Aggregations {
 		aggExpr := query.Aggregations[idx]
@@ -136,7 +145,19 @@ func getKeySelectors(query qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]) []
 		keySelectors[idx].SelectorMatchType = telemetrytypes.FieldSelectorMatchTypeExact
 	}
 
-	return keySelectors
+	// When the new JSON body experience is enabled, warn the user if they use the bare
+	// "body" key in the filter — queries on plain "body" default to body.message:string.
+	// TODO(Piyush): Setup better for coming FTS support.
+	if querybuilder.BodyJSONQueryEnabled {
+		for _, sel := range keySelectors {
+			if sel.Name == LogsV2BodyColumn {
+				warnings = append(warnings, bodySearchDefaultWarning)
+				break
+			}
+		}
+	}
+
+	return keySelectors, warnings
 }
 
 func (b *logQueryStatementBuilder) adjustKeys(ctx context.Context, keys map[string][]*telemetrytypes.TelemetryFieldKey, query qbtypes.QueryBuilderQuery[qbtypes.LogAggregation], requestType qbtypes.RequestType) qbtypes.QueryBuilderQuery[qbtypes.LogAggregation] {
@@ -203,7 +224,6 @@ func (b *logQueryStatementBuilder) adjustKeys(ctx context.Context, keys map[stri
 }
 
 func (b *logQueryStatementBuilder) adjustKey(key *telemetrytypes.TelemetryFieldKey, keys map[string][]*telemetrytypes.TelemetryFieldKey) []string {
-
 	// First check if it matches with any intrinsic fields
 	var intrinsicOrCalculatedField telemetrytypes.TelemetryFieldKey
 	if _, ok := IntrinsicFields[key.Name]; ok {
@@ -212,7 +232,6 @@ func (b *logQueryStatementBuilder) adjustKey(key *telemetrytypes.TelemetryFieldK
 	}
 
 	return querybuilder.AdjustKey(key, keys, nil)
-
 }
 
 // buildListQuery builds a query for list panel type
@@ -249,11 +268,7 @@ func (b *logQueryStatementBuilder) buildListQuery(
 		sb.SelectMore(LogsV2SeverityNumberColumn)
 		sb.SelectMore(LogsV2ScopeNameColumn)
 		sb.SelectMore(LogsV2ScopeVersionColumn)
-		sb.SelectMore(LogsV2BodyColumn)
-		if querybuilder.BodyJSONQueryEnabled {
-			sb.SelectMore(LogsV2BodyJSONColumn)
-			sb.SelectMore(LogsV2BodyPromotedColumn)
-		}
+		sb.SelectMore(bodyAliasExpression())
 		sb.SelectMore(LogsV2AttributesStringColumn)
 		sb.SelectMore(LogsV2AttributesNumberColumn)
 		sb.SelectMore(LogsV2AttributesBoolColumn)

--- a/pkg/telemetrymetadata/body_json_metadata.go
+++ b/pkg/telemetrymetadata/body_json_metadata.go
@@ -54,6 +54,7 @@ func (t *telemetryMetaStore) fetchBodyJSONPaths(ctx context.Context,
 		instrumentationtypes.CodeNamespace:    "metadata",
 		instrumentationtypes.CodeFunctionName: "fetchBodyJSONPaths",
 	})
+
 	query, args, limit := buildGetBodyJSONPathsQuery(fieldKeySelectors)
 	rows, err := t.telemetrystore.ClickhouseDB().Query(ctx, query, args...)
 	if err != nil {
@@ -184,7 +185,6 @@ func buildGetBodyJSONPathsQuery(fieldKeySelectors []*telemetrytypes.FieldKeySele
 		limit += fieldKeySelector.Limit
 	}
 	sb.Where(sb.Or(orClauses...))
-
 	// Group by path to get unique paths with aggregated types
 	sb.GroupBy("path")
 
@@ -319,7 +319,7 @@ func (t *telemetryMetaStore) ListJSONValues(ctx context.Context, path string, li
 	if promoted {
 		path = telemetrylogs.BodyPromotedColumnPrefix + path
 	} else {
-		path = telemetrylogs.BodyJSONColumnPrefix + path
+		path = telemetrylogs.BodyV2ColumnPrefix + path
 	}
 
 	from := fmt.Sprintf("%s.%s", telemetrylogs.DBName, telemetrylogs.LogsV2TableName)
@@ -522,7 +522,7 @@ func (t *telemetryMetaStore) GetPromotedPaths(ctx context.Context, paths ...stri
 // TODO(Piyush): Remove this function
 func CleanPathPrefixes(path string) string {
 	path = strings.TrimPrefix(path, telemetrytypes.BodyJSONStringSearchPrefix)
-	path = strings.TrimPrefix(path, telemetrylogs.BodyJSONColumnPrefix)
+	path = strings.TrimPrefix(path, telemetrylogs.BodyV2ColumnPrefix)
 	path = strings.TrimPrefix(path, telemetrylogs.BodyPromotedColumnPrefix)
 	return path
 }

--- a/pkg/telemetrymetadata/metadata.go
+++ b/pkg/telemetrymetadata/metadata.go
@@ -102,7 +102,7 @@ func NewTelemetryMetaStore(
 		jsonColumnMetadata: map[telemetrytypes.Signal]map[telemetrytypes.FieldContext]telemetrytypes.JSONColumnMetadata{
 			telemetrytypes.SignalLogs: {
 				telemetrytypes.FieldContextBody: telemetrytypes.JSONColumnMetadata{
-					BaseColumn:     telemetrylogs.LogsV2BodyJSONColumn,
+					BaseColumn:     telemetrylogs.LogsV2BodyV2Column,
 					PromotedColumn: telemetrylogs.LogsV2BodyPromotedColumn,
 				},
 			},
@@ -351,7 +351,7 @@ func (t *telemetryMetaStore) logsTblStatementToFieldKeys(ctx context.Context) ([
 }
 
 // getLogsKeys returns the keys from the spans that match the field selection criteria
-func (t *telemetryMetaStore) getLogsKeys(ctx context.Context, fieldKeySelectors []*telemetrytypes.FieldKeySelector) ([]*telemetrytypes.TelemetryFieldKey, bool, error) {
+func (t *telemetryMetaStore) getLogsKeys(ctx context.Context, fieldKeySelectors []*telemetrytypes.FieldKeySelector) (map[string][]*telemetrytypes.TelemetryFieldKey, bool, error) {
 	ctx = ctxtypes.NewContextWithCommentVals(ctx, map[string]string{
 		instrumentationtypes.TelemetrySignal:  telemetrytypes.SignalLogs.StringValue(),
 		instrumentationtypes.CodeNamespace:    "metadata",
@@ -367,9 +367,10 @@ func (t *telemetryMetaStore) getLogsKeys(ctx context.Context, fieldKeySelectors 
 	if err != nil {
 		return nil, false, err
 	}
-	mapOfKeys := make(map[string]*telemetrytypes.TelemetryFieldKey)
+	// setOfKeys to reuse the same key object for qualified names
+	setOfKeys := make(map[string]*telemetrytypes.TelemetryFieldKey)
 	for _, key := range matKeys {
-		mapOfKeys[key.Name+";"+key.FieldContext.StringValue()+";"+key.FieldDataType.StringValue()] = key
+		setOfKeys[key.Text()] = key
 	}
 
 	// queries for both attribute and resource keys tables
@@ -470,7 +471,7 @@ func (t *telemetryMetaStore) getLogsKeys(ctx context.Context, fieldKeySelectors 
 
 	if len(queries) == 0 {
 		// No matching contexts, return empty result
-		return []*telemetrytypes.TelemetryFieldKey{}, true, nil
+		return nil, true, nil
 	}
 
 	// Combine queries with UNION ALL
@@ -498,7 +499,7 @@ func (t *telemetryMetaStore) getLogsKeys(ctx context.Context, fieldKeySelectors 
 	}
 	defer rows.Close()
 
-	keys := []*telemetrytypes.TelemetryFieldKey{}
+	mapOfKeys := make(map[string][]*telemetrytypes.TelemetryFieldKey)
 	rowCount := 0
 	searchTexts := []string{}
 	dataTypes := []telemetrytypes.FieldDataType{}
@@ -526,7 +527,7 @@ func (t *telemetryMetaStore) getLogsKeys(ctx context.Context, fieldKeySelectors 
 		if err != nil {
 			return nil, false, errors.Wrap(err, errors.TypeInternal, errors.CodeInternal, ErrFailedToGetLogsKeys.Error())
 		}
-		key, ok := mapOfKeys[name+";"+fieldContext.StringValue()+";"+fieldDataType.StringValue()]
+		key, ok := setOfKeys[fieldContext.StringValue()+"."+name+":"+fieldDataType.StringValue()]
 
 		// if there is no materialised column, create a key with the field context and data type
 		if !ok {
@@ -538,8 +539,8 @@ func (t *telemetryMetaStore) getLogsKeys(ctx context.Context, fieldKeySelectors 
 			}
 		}
 
-		keys = append(keys, key)
-		mapOfKeys[name+";"+fieldContext.StringValue()+";"+fieldDataType.StringValue()] = key
+		mapOfKeys[key.Name] = append(mapOfKeys[key.Name], key)
+		setOfKeys[key.Text()] = key
 	}
 
 	if rows.Err() != nil {
@@ -565,17 +566,15 @@ func (t *telemetryMetaStore) getLogsKeys(ctx context.Context, fieldKeySelectors 
 
 		if found {
 			if field, exists := telemetrylogs.IntrinsicFields[key]; exists {
-				if _, added := mapOfKeys[field.Name+";"+field.FieldContext.StringValue()+";"+field.FieldDataType.StringValue()]; !added {
-					keys = append(keys, &field)
+				// Register by field name once if it doesn't exists from before
+				if _, added := setOfKeys[field.Text()]; !added {
+					mapOfKeys[field.Name] = append(mapOfKeys[field.Name], &field)
 				}
-				continue
+				// Register the field key for alias as well; IntrinsicFields has alias of "body" to "message" field
+				if key != field.Name {
+					mapOfKeys[key] = append(mapOfKeys[key], &field)
+				}
 			}
-
-			keys = append(keys, &telemetrytypes.TelemetryFieldKey{
-				Name:         key,
-				FieldContext: telemetrytypes.FieldContextLog,
-				Signal:       telemetrytypes.SignalLogs,
-			})
 		}
 	}
 
@@ -584,10 +583,13 @@ func (t *telemetryMetaStore) getLogsKeys(ctx context.Context, fieldKeySelectors 
 		if err != nil {
 			t.logger.ErrorContext(ctx, "failed to extract body JSON paths", "error", err)
 		}
-		keys = append(keys, bodyJSONPaths...)
+		for _, key := range bodyJSONPaths {
+			mapOfKeys[key.Name] = append(mapOfKeys[key.Name], key)
+		}
 		complete = complete && finished
 	}
-	return keys, complete, nil
+
+	return mapOfKeys, complete, nil
 }
 
 func getPriorityForContext(ctx telemetrytypes.FieldContext) int {
@@ -882,12 +884,20 @@ func (t *telemetryMetaStore) GetKeys(ctx context.Context, fieldKeySelector *tele
 	if fieldKeySelector != nil {
 		selectors = []*telemetrytypes.FieldKeySelector{fieldKeySelector}
 	}
+	mapOfKeys := make(map[string][]*telemetrytypes.TelemetryFieldKey)
 
 	switch fieldKeySelector.Signal {
 	case telemetrytypes.SignalTraces:
 		keys, complete, err = t.getTracesKeys(ctx, selectors)
 	case telemetrytypes.SignalLogs:
-		keys, complete, err = t.getLogsKeys(ctx, selectors)
+		mapOfLogKeys, logsComplete, err := t.getLogsKeys(ctx, selectors)
+		if err != nil {
+			return nil, false, err
+		}
+		for keyName, keys := range mapOfLogKeys {
+			mapOfKeys[keyName] = append(mapOfKeys[keyName], keys...)
+		}
+		complete = complete && logsComplete
 	case telemetrytypes.SignalMetrics:
 		if fieldKeySelector.Source == telemetrytypes.SourceMeter {
 			keys, complete, err = t.getMeterSourceMetricKeys(ctx, selectors)
@@ -903,12 +913,13 @@ func (t *telemetryMetaStore) GetKeys(ctx context.Context, fieldKeySelector *tele
 		keys = append(keys, tracesKeys...)
 
 		// get logs keys
-		logsKeys, logsComplete, err := t.getLogsKeys(ctx, selectors)
+		mapOfLogKeys, logsComplete, err := t.getLogsKeys(ctx, selectors)
 		if err != nil {
 			return nil, false, err
 		}
-		keys = append(keys, logsKeys...)
-
+		for keyName, keys := range mapOfLogKeys {
+			mapOfKeys[keyName] = append(mapOfKeys[keyName], keys...)
+		}
 		// get metrics keys
 		metricsKeys, metricsComplete, err := t.getMetricsKeys(ctx, selectors)
 		if err != nil {
@@ -922,7 +933,6 @@ func (t *telemetryMetaStore) GetKeys(ctx context.Context, fieldKeySelector *tele
 		return nil, false, err
 	}
 
-	mapOfKeys := make(map[string][]*telemetrytypes.TelemetryFieldKey)
 	for _, key := range keys {
 		mapOfKeys[key.Name] = append(mapOfKeys[key.Name], key)
 	}
@@ -959,7 +969,7 @@ func (t *telemetryMetaStore) GetKeysMulti(ctx context.Context, fieldKeySelectors
 		}
 	}
 
-	logsKeys, logsComplete, err := t.getLogsKeys(ctx, logsSelectors)
+	mapOfLogKeys, logsComplete, err := t.getLogsKeys(ctx, logsSelectors)
 	if err != nil {
 		return nil, false, err
 	}
@@ -980,8 +990,8 @@ func (t *telemetryMetaStore) GetKeysMulti(ctx context.Context, fieldKeySelectors
 	complete := logsComplete && tracesComplete && metricsComplete
 
 	mapOfKeys := make(map[string][]*telemetrytypes.TelemetryFieldKey)
-	for _, key := range logsKeys {
-		mapOfKeys[key.Name] = append(mapOfKeys[key.Name], key)
+	for keyName, keys := range mapOfLogKeys {
+		mapOfKeys[keyName] = append(mapOfKeys[keyName], keys...)
 	}
 	for _, key := range tracesKeys {
 		mapOfKeys[key.Name] = append(mapOfKeys[key.Name], key)

--- a/pkg/types/telemetrytypes/field.go
+++ b/pkg/types/telemetrytypes/field.go
@@ -40,7 +40,7 @@ type TelemetryFieldKey struct {
 	JSONDataType *JSONDataType       `json:"-"`
 	JSONPlan     JSONAccessPlan      `json:"-"`
 	Indexes      []JSONDataTypeIndex `json:"-"`
-	Materialized bool                `json:"-"` // refers to promoted in case of body.... fields
+	Materialized bool                `json:"-"` // refers to type hint in case of JSON column fields
 }
 
 func (f *TelemetryFieldKey) KeyNameContainsArray() bool {

--- a/pkg/types/telemetrytypes/field_datatype.go
+++ b/pkg/types/telemetrytypes/field_datatype.go
@@ -21,6 +21,7 @@ var (
 	// int64 and number are synonyms for float64
 	FieldDataTypeInt64       = FieldDataType{valuer.NewString("int64")}
 	FieldDataTypeNumber      = FieldDataType{valuer.NewString("number")}
+	FieldDataTypeJSON        = FieldDataType{valuer.NewString("json")}
 	FieldDataTypeUnspecified = FieldDataType{valuer.NewString("")}
 
 	FieldDataTypeArrayString  = FieldDataType{valuer.NewString("[]string")}

--- a/pkg/types/telemetrytypes/json_access_plan.go
+++ b/pkg/types/telemetrytypes/json_access_plan.go
@@ -40,7 +40,7 @@ type JSONAccessNode struct {
 	// Node information
 	Name       string
 	IsTerminal bool
-	isRoot     bool // marked true for only body_json and body_json_promoted
+	isRoot     bool // marked true for only body_v2 and body_promoted
 
 	// Precomputed type information (single source of truth)
 	AvailableTypes []JSONDataType

--- a/pkg/types/telemetrytypes/telemetrytypestest/metadata_store.go
+++ b/pkg/types/telemetrytypes/telemetrytypestest/metadata_store.go
@@ -2,6 +2,7 @@ package telemetrytypestest
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	schemamigrator "github.com/SigNoz/signoz-otel-collector/cmd/signozschemamigrator/schema_migrator"
@@ -20,9 +21,11 @@ type MockMetadataStore struct {
 	PromotedPathsMap   map[string]bool
 	LogsJSONIndexesMap map[string][]schemamigrator.Index
 	LookupKeysMap      map[telemetrytypes.MetricMetadataLookupKey]int64
+	// StaticFields holds signal-specific intrinsic field definitions (e.g. telemetrylogs.IntrinsicFields).
+	StaticFields map[string]telemetrytypes.TelemetryFieldKey
 }
 
-// NewMockMetadataStore creates a new instance of MockMetadataStore with initialized maps
+// NewMockMetadataStore creates a new instance of MockMetadataStore with initialized maps.
 func NewMockMetadataStore() *MockMetadataStore {
 	return &MockMetadataStore{
 		KeysMap:            make(map[string][]*telemetrytypes.TelemetryFieldKey),
@@ -33,12 +36,20 @@ func NewMockMetadataStore() *MockMetadataStore {
 		PromotedPathsMap:   make(map[string]bool),
 		LogsJSONIndexesMap: make(map[string][]schemamigrator.Index),
 		LookupKeysMap:      make(map[telemetrytypes.MetricMetadataLookupKey]int64),
+		StaticFields:       make(map[string]telemetrytypes.TelemetryFieldKey),
 	}
+}
+
+// SetStaticFields sets the static fields for the mock metadata store.
+// Pass the signal-specific intrinsic fields (e.g. telemetrylogs.IntrinsicFields) so the mock
+// mirrors what the real metadata store does when injecting those definitions into key results.
+func (m *MockMetadataStore) SetStaticFields(intrinsicFields map[string]telemetrytypes.TelemetryFieldKey) {
+	m.StaticFields = intrinsicFields
 }
 
 // GetKeys returns a map of field keys types.TelemetryFieldKey by name
 func (m *MockMetadataStore) GetKeys(ctx context.Context, fieldKeySelector *telemetrytypes.FieldKeySelector) (map[string][]*telemetrytypes.TelemetryFieldKey, bool, error) {
-
+	setOfKeys := make(map[string]*telemetrytypes.TelemetryFieldKey)
 	result := make(map[string][]*telemetrytypes.TelemetryFieldKey)
 
 	// If selector is nil, return all keys
@@ -46,19 +57,35 @@ func (m *MockMetadataStore) GetKeys(ctx context.Context, fieldKeySelector *telem
 		return m.KeysMap, true, nil
 	}
 
-	// Apply selector logic
+	// Apply selector logic from KeysMap
 	for name, keys := range m.KeysMap {
-		// Check if name matches
 		if matchesName(fieldKeySelector, name) {
-			filteredKeys := []*telemetrytypes.TelemetryFieldKey{}
 			for _, key := range keys {
 				if matchesKey(fieldKeySelector, key) {
-					filteredKeys = append(filteredKeys, key)
+					if _, exists := setOfKeys[key.Text()]; !exists {
+						result[name] = append(result[name], key)
+						setOfKeys[key.Text()] = key
+					}
 				}
 			}
-			if len(filteredKeys) > 0 {
-				result[name] = filteredKeys
-			}
+		}
+	}
+
+	// StaticFields (e.g. IntrinsicFields), mirroring the real metadata store.
+	for key, field := range m.StaticFields {
+		if !matchesName(fieldKeySelector, key) {
+			continue
+		}
+
+		// Register by field name once if it doesn't exists from before
+		if _, exists := setOfKeys[field.Text()]; !exists {
+			result[field.Name] = append(result[field.Name], &field)
+			setOfKeys[field.Text()] = &field
+		}
+
+		// Register the field key for alias as well; IntrinsicFields has alias of "body" to "message" field
+		if key != field.Name {
+			result[key] = append(result[key], &field)
 		}
 	}
 
@@ -108,7 +135,7 @@ func (m *MockMetadataStore) GetKey(ctx context.Context, fieldKeySelector *teleme
 
 	result := []*telemetrytypes.TelemetryFieldKey{}
 
-	// Find keys matching the selector
+	// Find keys matching the selector from KeysMap
 	for name, keys := range m.KeysMap {
 		if matchesName(fieldKeySelector, name) {
 			for _, key := range keys {
@@ -116,6 +143,14 @@ func (m *MockMetadataStore) GetKey(ctx context.Context, fieldKeySelector *teleme
 					result = append(result, key)
 				}
 			}
+		}
+	}
+
+	// Add matching StaticFields (e.g. IntrinsicFields), same as the real metadata store does
+	for key, field := range m.StaticFields {
+		if fieldKeySelector.Name == "" || strings.Contains(key, fieldKeySelector.Name) {
+			fieldCopy := field
+			result = append(result, &fieldCopy)
 		}
 	}
 
@@ -178,8 +213,9 @@ func matchesKey(selector *telemetrytypes.FieldKeySelector, key *telemetrytypes.T
 		return true
 	}
 
+	matchNameExceptions := []string{"body"}
 	// Check name (already checked in matchesName, but double-check here)
-	if selector.Name != "" && !matchesName(selector, key.Name) {
+	if selector.Name != "" && !matchesName(selector, key.Name) && slices.Contains(matchNameExceptions, key.Name) {
 		return false
 	}
 
@@ -289,7 +325,7 @@ func (m *MockMetadataStore) FetchTemporalityMulti(ctx context.Context, queryTime
 	return result, nil
 }
 
-// FetchTemporalityMulti fetches the temporality for multiple metrics
+// FetchTemporalityAndTypeMulti fetches the temporality and type for multiple metrics
 func (m *MockMetadataStore) FetchTemporalityAndTypeMulti(ctx context.Context, queryTimeRangeStartTs, queryTimeRangeEndTs uint64, metricNames ...string) (map[string]metrictypes.Temporality, map[string]metrictypes.Type, error) {
 	temporalities := make(map[string]metrictypes.Temporality)
 	types := make(map[string]metrictypes.Type)

--- a/pkg/types/telemetrytypes/test_data.go
+++ b/pkg/types/telemetrytypes/test_data.go
@@ -64,8 +64,7 @@ func TestJSONTypeSet() (map[string][]JSONDataType, MetadataStore) {
 		"interests[].entities[].reviews[].entries[].metadata[].positions[].duration": {Int64, Float64},
 		"interests[].entities[].reviews[].entries[].metadata[].positions[].unit":     {String},
 		"interests[].entities[].reviews[].entries[].metadata[].positions[].ratings":  {ArrayInt64, ArrayString},
-		"message": {String},
-		"tags":    {ArrayString},
+		"tags": {ArrayString},
 	}
 
 	return types, nil


### PR DESCRIPTION
## Summary
- Rename `LogsV2BodyJSONColumn` → `LogsV2BodyV2Column` and `BodyJSONColumnPrefix` → `BodyV2ColumnPrefix` across the codebase
- Add `FieldDataTypeJSON` to `FieldDataType` for JSON column fields
- Add `BodyFieldMessageMapping` and `enrichMapsForJSONBodyEnabled()` to prepare `IntrinsicFields` for the JSON body feature
- Change `getLogsKeys()` return type from `[]*TelemetryFieldKey` to `map[string][]*TelemetryFieldKey` for deduplication
- Update `MockMetadataStore` to support `StaticFields` injection (mirrors real store's IntrinsicFields behaviour)
- Remove Go-level `body_json` + `body_promoted` merge; SELECT now uses `bodyAliasExpression()` at SQL level
- Move `bytedance/sonic` to indirect dependency (no longer used directly)

## Why
Renames align constant names with the actual ClickHouse column (`body_v2`). The `getLogsKeys` map return enables callers to look up keys by alias (e.g. `body` → `message` field). The body merge removal simplifies the data path now that aliasing is done in SQL.

## Part of series
This is PR 1 of 2 split from a larger change.
- [ ] PR 1 (this PR): Foundation — constant renames, new types, metadata refactoring
- [ ] PR 2: Feature — condition builder, statement builder, querybuilder, and tests

**Merge order: PR 1 must merge before PR 2.**

## Build verification
- Build: `go build ./...` ✅

## Test plan
- [ ] Existing unit tests pass: `go test -race ./pkg/types/telemetrytypes/...`
- [ ] Existing logs metadata tests pass: `go test -race ./pkg/telemetrymetadata/...`