### PR TITLE
fix(ui): add cursor pointer on domain rows in External APIs table

### DIFF
--- a/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
+++ b/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
@@ -138,10 +138,12 @@
 
 			.table-row-light {
 				background: none;
+				cursor: pointer;
 			}
 
 			.table-row-dark {
 				background: var(--bg-ink-300);
+				cursor: pointer;
 			}
 
 			.error-rate {
@@ -259,10 +261,12 @@
 
 			.table-row-light {
 				background: none;
+				cursor: pointer;
 			}
 
 			.table-row-dark {
 				background: none;
+				cursor: pointer;
 			}
 
 			.round-metric-tag {


### PR DESCRIPTION
### 📄 Summary

Closes #9403.

Domain rows in the External APIs table are clickable (they navigate to domain details) but the cursor does not change to a pointer on hover, which is confusing for users. This adds `cursor: pointer` to both `table-row-light` and `table-row-dark` in the API Monitoring explorer styles.

#### Screenshots / Screen Recordings (if applicable)

Before: cursor stays as default arrow on row hover
After: cursor changes to pointer, matching the clickable behavior

#### Issues closed by this PR

Closes #9403

---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
The `.table-row-light` and `.table-row-dark` CSS classes in `Explorer.styles.scss` did not set `cursor: pointer`, even though the rows have an `onClick` handler.

#### Fix Strategy
Added `cursor: pointer` to both row classes in the two table sections of the SCSS file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure styling change that only affects cursor behavior on table rows; minimal functional or regression risk.
> 
> **Overview**
> Improves UX in the API Monitoring Explorer External APIs domain table by adding `cursor: pointer` to clickable domain rows (`.table-row-light`/`.table-row-dark`) in both dark and light mode styles, so hover feedback matches the row navigation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a4832b72055b71aa8c83ab4bb30d426fd78fafb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->