### PR TITLE
fix: welcome checklist light mode illustration

### DIFF
--- a/frontend/public/Images/allInOneLightMode.svg
+++ b/frontend/public/Images/allInOneLightMode.svg
@@ -1,0 +1,2021 @@
+<svg width="246" height="628" viewBox="0 0 246 628" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_2754_8800)">
+<circle cx="3" cy="620" r="1" transform="rotate(-90 3 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="606" r="1" transform="rotate(-90 3 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="592" r="1" transform="rotate(-90 3 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="578" r="1" transform="rotate(-90 3 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="564" r="1" transform="rotate(-90 3 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="550" r="1" transform="rotate(-90 3 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="536" r="1" transform="rotate(-90 3 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="522" r="1" transform="rotate(-90 3 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="508" r="1" transform="rotate(-90 3 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="494" r="1" transform="rotate(-90 3 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="480" r="1" transform="rotate(-90 3 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="466" r="1" transform="rotate(-90 3 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="452" r="1" transform="rotate(-90 3 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="438" r="1" transform="rotate(-90 3 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="424" r="1" transform="rotate(-90 3 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="410" r="1" transform="rotate(-90 3 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="396" r="1" transform="rotate(-90 3 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="382" r="1" transform="rotate(-90 3 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="368" r="1" transform="rotate(-90 3 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="354" r="1" transform="rotate(-90 3 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="340" r="1" transform="rotate(-90 3 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="326" r="1" transform="rotate(-90 3 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="312" r="1" transform="rotate(-90 3 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="298" r="1" transform="rotate(-90 3 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="284" r="1" transform="rotate(-90 3 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="270" r="1" transform="rotate(-90 3 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="256" r="1" transform="rotate(-90 3 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="242" r="1" transform="rotate(-90 3 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="228" r="1" transform="rotate(-90 3 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="214" r="1" transform="rotate(-90 3 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="200" r="1" transform="rotate(-90 3 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="186" r="1" transform="rotate(-90 3 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="172" r="1" transform="rotate(-90 3 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="158" r="1" transform="rotate(-90 3 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="144" r="1" transform="rotate(-90 3 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="130" r="1" transform="rotate(-90 3 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="116" r="1" transform="rotate(-90 3 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="102" r="1" transform="rotate(-90 3 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="88" r="1" transform="rotate(-90 3 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="74" r="1" transform="rotate(-90 3 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="60" r="1" transform="rotate(-90 3 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="46" r="1" transform="rotate(-90 3 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="32" r="1" transform="rotate(-90 3 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="18" r="1" transform="rotate(-90 3 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="3" cy="4" r="1" transform="rotate(-90 3 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="620" r="1" transform="rotate(-90 13 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="606" r="1" transform="rotate(-90 13 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="592" r="1" transform="rotate(-90 13 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="578" r="1" transform="rotate(-90 13 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="564" r="1" transform="rotate(-90 13 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="550" r="1" transform="rotate(-90 13 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="536" r="1" transform="rotate(-90 13 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="522" r="1" transform="rotate(-90 13 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="508" r="1" transform="rotate(-90 13 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="494" r="1" transform="rotate(-90 13 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="480" r="1" transform="rotate(-90 13 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="466" r="1" transform="rotate(-90 13 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="452" r="1" transform="rotate(-90 13 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="438" r="1" transform="rotate(-90 13 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="424" r="1" transform="rotate(-90 13 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="410" r="1" transform="rotate(-90 13 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="396" r="1" transform="rotate(-90 13 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="382" r="1" transform="rotate(-90 13 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="368" r="1" transform="rotate(-90 13 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="354" r="1" transform="rotate(-90 13 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="340" r="1" transform="rotate(-90 13 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="326" r="1" transform="rotate(-90 13 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="312" r="1" transform="rotate(-90 13 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="298" r="1" transform="rotate(-90 13 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="284" r="1" transform="rotate(-90 13 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="270" r="1" transform="rotate(-90 13 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="256" r="1" transform="rotate(-90 13 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="242" r="1" transform="rotate(-90 13 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="228" r="1" transform="rotate(-90 13 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="214" r="1" transform="rotate(-90 13 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="200" r="1" transform="rotate(-90 13 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="186" r="1" transform="rotate(-90 13 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="172" r="1" transform="rotate(-90 13 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="158" r="1" transform="rotate(-90 13 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="144" r="1" transform="rotate(-90 13 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="130" r="1" transform="rotate(-90 13 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="116" r="1" transform="rotate(-90 13 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="102" r="1" transform="rotate(-90 13 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="88" r="1" transform="rotate(-90 13 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="74" r="1" transform="rotate(-90 13 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="60" r="1" transform="rotate(-90 13 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="46" r="1" transform="rotate(-90 13 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="32" r="1" transform="rotate(-90 13 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="18" r="1" transform="rotate(-90 13 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="13" cy="4" r="1" transform="rotate(-90 13 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="620" r="1" transform="rotate(-90 23 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="606" r="1" transform="rotate(-90 23 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="592" r="1" transform="rotate(-90 23 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="578" r="1" transform="rotate(-90 23 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="564" r="1" transform="rotate(-90 23 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="550" r="1" transform="rotate(-90 23 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="536" r="1" transform="rotate(-90 23 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="522" r="1" transform="rotate(-90 23 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="508" r="1" transform="rotate(-90 23 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="494" r="1" transform="rotate(-90 23 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="480" r="1" transform="rotate(-90 23 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="466" r="1" transform="rotate(-90 23 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="452" r="1" transform="rotate(-90 23 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="438" r="1" transform="rotate(-90 23 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="424" r="1" transform="rotate(-90 23 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="410" r="1" transform="rotate(-90 23 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="396" r="1" transform="rotate(-90 23 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="382" r="1" transform="rotate(-90 23 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="368" r="1" transform="rotate(-90 23 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="354" r="1" transform="rotate(-90 23 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="340" r="1" transform="rotate(-90 23 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="326" r="1" transform="rotate(-90 23 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="312" r="1" transform="rotate(-90 23 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="298" r="1" transform="rotate(-90 23 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="284" r="1" transform="rotate(-90 23 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="270" r="1" transform="rotate(-90 23 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="256" r="1" transform="rotate(-90 23 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="242" r="1" transform="rotate(-90 23 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="228" r="1" transform="rotate(-90 23 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="214" r="1" transform="rotate(-90 23 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="200" r="1" transform="rotate(-90 23 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="186" r="1" transform="rotate(-90 23 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="172" r="1" transform="rotate(-90 23 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="158" r="1" transform="rotate(-90 23 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="144" r="1" transform="rotate(-90 23 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="130" r="1" transform="rotate(-90 23 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="116" r="1" transform="rotate(-90 23 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="102" r="1" transform="rotate(-90 23 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="88" r="1" transform="rotate(-90 23 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="74" r="1" transform="rotate(-90 23 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="60" r="1" transform="rotate(-90 23 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="46" r="1" transform="rotate(-90 23 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="32" r="1" transform="rotate(-90 23 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="18" r="1" transform="rotate(-90 23 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="23" cy="4" r="1" transform="rotate(-90 23 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="620" r="1" transform="rotate(-90 33 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="606" r="1" transform="rotate(-90 33 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="592" r="1" transform="rotate(-90 33 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="578" r="1" transform="rotate(-90 33 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="564" r="1" transform="rotate(-90 33 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="550" r="1" transform="rotate(-90 33 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="536" r="1" transform="rotate(-90 33 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="522" r="1" transform="rotate(-90 33 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="508" r="1" transform="rotate(-90 33 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="494" r="1" transform="rotate(-90 33 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="480" r="1" transform="rotate(-90 33 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="466" r="1" transform="rotate(-90 33 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="452" r="1" transform="rotate(-90 33 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="438" r="1" transform="rotate(-90 33 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="424" r="1" transform="rotate(-90 33 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="410" r="1" transform="rotate(-90 33 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="396" r="1" transform="rotate(-90 33 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="382" r="1" transform="rotate(-90 33 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="368" r="1" transform="rotate(-90 33 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="354" r="1" transform="rotate(-90 33 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="340" r="1" transform="rotate(-90 33 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="326" r="1" transform="rotate(-90 33 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="312" r="1" transform="rotate(-90 33 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="298" r="1" transform="rotate(-90 33 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="284" r="1" transform="rotate(-90 33 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="270" r="1" transform="rotate(-90 33 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="256" r="1" transform="rotate(-90 33 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="242" r="1" transform="rotate(-90 33 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="228" r="1" transform="rotate(-90 33 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="214" r="1" transform="rotate(-90 33 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="200" r="1" transform="rotate(-90 33 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="186" r="1" transform="rotate(-90 33 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="172" r="1" transform="rotate(-90 33 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="158" r="1" transform="rotate(-90 33 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="144" r="1" transform="rotate(-90 33 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="130" r="1" transform="rotate(-90 33 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="116" r="1" transform="rotate(-90 33 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="102" r="1" transform="rotate(-90 33 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="88" r="1" transform="rotate(-90 33 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="74" r="1" transform="rotate(-90 33 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="60" r="1" transform="rotate(-90 33 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="46" r="1" transform="rotate(-90 33 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="32" r="1" transform="rotate(-90 33 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="18" r="1" transform="rotate(-90 33 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="33" cy="4" r="1" transform="rotate(-90 33 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="620" r="1" transform="rotate(-90 43 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="606" r="1" transform="rotate(-90 43 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="592" r="1" transform="rotate(-90 43 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="578" r="1" transform="rotate(-90 43 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="564" r="1" transform="rotate(-90 43 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="550" r="1" transform="rotate(-90 43 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="536" r="1" transform="rotate(-90 43 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="522" r="1" transform="rotate(-90 43 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="508" r="1" transform="rotate(-90 43 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="494" r="1" transform="rotate(-90 43 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="480" r="1" transform="rotate(-90 43 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="466" r="1" transform="rotate(-90 43 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="452" r="1" transform="rotate(-90 43 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="438" r="1" transform="rotate(-90 43 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="424" r="1" transform="rotate(-90 43 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="410" r="1" transform="rotate(-90 43 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="396" r="1" transform="rotate(-90 43 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="382" r="1" transform="rotate(-90 43 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="368" r="1" transform="rotate(-90 43 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="354" r="1" transform="rotate(-90 43 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="340" r="1" transform="rotate(-90 43 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="326" r="1" transform="rotate(-90 43 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="312" r="1" transform="rotate(-90 43 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="298" r="1" transform="rotate(-90 43 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="284" r="1" transform="rotate(-90 43 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="270" r="1" transform="rotate(-90 43 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="256" r="1" transform="rotate(-90 43 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="242" r="1" transform="rotate(-90 43 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="228" r="1" transform="rotate(-90 43 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="214" r="1" transform="rotate(-90 43 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="200" r="1" transform="rotate(-90 43 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="186" r="1" transform="rotate(-90 43 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="172" r="1" transform="rotate(-90 43 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="158" r="1" transform="rotate(-90 43 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="144" r="1" transform="rotate(-90 43 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="130" r="1" transform="rotate(-90 43 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="116" r="1" transform="rotate(-90 43 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="102" r="1" transform="rotate(-90 43 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="88" r="1" transform="rotate(-90 43 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="74" r="1" transform="rotate(-90 43 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="60" r="1" transform="rotate(-90 43 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="46" r="1" transform="rotate(-90 43 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="32" r="1" transform="rotate(-90 43 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="18" r="1" transform="rotate(-90 43 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="43" cy="4" r="1" transform="rotate(-90 43 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="620" r="1" transform="rotate(-90 53 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="606" r="1" transform="rotate(-90 53 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="592" r="1" transform="rotate(-90 53 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="578" r="1" transform="rotate(-90 53 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="564" r="1" transform="rotate(-90 53 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="550" r="1" transform="rotate(-90 53 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="536" r="1" transform="rotate(-90 53 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="522" r="1" transform="rotate(-90 53 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="508" r="1" transform="rotate(-90 53 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="494" r="1" transform="rotate(-90 53 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="480" r="1" transform="rotate(-90 53 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="466" r="1" transform="rotate(-90 53 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="452" r="1" transform="rotate(-90 53 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="438" r="1" transform="rotate(-90 53 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="424" r="1" transform="rotate(-90 53 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="410" r="1" transform="rotate(-90 53 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="396" r="1" transform="rotate(-90 53 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="382" r="1" transform="rotate(-90 53 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="368" r="1" transform="rotate(-90 53 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="354" r="1" transform="rotate(-90 53 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="340" r="1" transform="rotate(-90 53 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="326" r="1" transform="rotate(-90 53 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="312" r="1" transform="rotate(-90 53 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="298" r="1" transform="rotate(-90 53 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="284" r="1" transform="rotate(-90 53 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="270" r="1" transform="rotate(-90 53 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="256" r="1" transform="rotate(-90 53 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="242" r="1" transform="rotate(-90 53 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="228" r="1" transform="rotate(-90 53 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="214" r="1" transform="rotate(-90 53 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="200" r="1" transform="rotate(-90 53 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="186" r="1" transform="rotate(-90 53 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="172" r="1" transform="rotate(-90 53 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="158" r="1" transform="rotate(-90 53 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="144" r="1" transform="rotate(-90 53 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="130" r="1" transform="rotate(-90 53 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="116" r="1" transform="rotate(-90 53 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="102" r="1" transform="rotate(-90 53 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="88" r="1" transform="rotate(-90 53 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="74" r="1" transform="rotate(-90 53 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="60" r="1" transform="rotate(-90 53 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="46" r="1" transform="rotate(-90 53 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="32" r="1" transform="rotate(-90 53 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="18" r="1" transform="rotate(-90 53 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="53" cy="4" r="1" transform="rotate(-90 53 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="620" r="1" transform="rotate(-90 63 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="606" r="1" transform="rotate(-90 63 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="592" r="1" transform="rotate(-90 63 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="578" r="1" transform="rotate(-90 63 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="564" r="1" transform="rotate(-90 63 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="550" r="1" transform="rotate(-90 63 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="536" r="1" transform="rotate(-90 63 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="522" r="1" transform="rotate(-90 63 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="508" r="1" transform="rotate(-90 63 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="494" r="1" transform="rotate(-90 63 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="480" r="1" transform="rotate(-90 63 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="466" r="1" transform="rotate(-90 63 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="452" r="1" transform="rotate(-90 63 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="438" r="1" transform="rotate(-90 63 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="424" r="1" transform="rotate(-90 63 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="410" r="1" transform="rotate(-90 63 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="396" r="1" transform="rotate(-90 63 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="382" r="1" transform="rotate(-90 63 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="368" r="1" transform="rotate(-90 63 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="354" r="1" transform="rotate(-90 63 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="340" r="1" transform="rotate(-90 63 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="326" r="1" transform="rotate(-90 63 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="312" r="1" transform="rotate(-90 63 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="298" r="1" transform="rotate(-90 63 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="284" r="1" transform="rotate(-90 63 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="270" r="1" transform="rotate(-90 63 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="256" r="1" transform="rotate(-90 63 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="242" r="1" transform="rotate(-90 63 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="228" r="1" transform="rotate(-90 63 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="214" r="1" transform="rotate(-90 63 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="200" r="1" transform="rotate(-90 63 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="186" r="1" transform="rotate(-90 63 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="172" r="1" transform="rotate(-90 63 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="158" r="1" transform="rotate(-90 63 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="144" r="1" transform="rotate(-90 63 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="130" r="1" transform="rotate(-90 63 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="116" r="1" transform="rotate(-90 63 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="102" r="1" transform="rotate(-90 63 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="88" r="1" transform="rotate(-90 63 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="74" r="1" transform="rotate(-90 63 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="60" r="1" transform="rotate(-90 63 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="46" r="1" transform="rotate(-90 63 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="32" r="1" transform="rotate(-90 63 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="18" r="1" transform="rotate(-90 63 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="63" cy="4" r="1" transform="rotate(-90 63 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="620" r="1" transform="rotate(-90 73 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="606" r="1" transform="rotate(-90 73 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="592" r="1" transform="rotate(-90 73 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="578" r="1" transform="rotate(-90 73 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="564" r="1" transform="rotate(-90 73 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="550" r="1" transform="rotate(-90 73 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="536" r="1" transform="rotate(-90 73 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="522" r="1" transform="rotate(-90 73 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="508" r="1" transform="rotate(-90 73 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="494" r="1" transform="rotate(-90 73 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="480" r="1" transform="rotate(-90 73 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="466" r="1" transform="rotate(-90 73 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="452" r="1" transform="rotate(-90 73 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="438" r="1" transform="rotate(-90 73 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="424" r="1" transform="rotate(-90 73 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="410" r="1" transform="rotate(-90 73 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="396" r="1" transform="rotate(-90 73 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="382" r="1" transform="rotate(-90 73 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="368" r="1" transform="rotate(-90 73 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="354" r="1" transform="rotate(-90 73 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="340" r="1" transform="rotate(-90 73 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="326" r="1" transform="rotate(-90 73 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="312" r="1" transform="rotate(-90 73 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="298" r="1" transform="rotate(-90 73 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="284" r="1" transform="rotate(-90 73 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="270" r="1" transform="rotate(-90 73 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="256" r="1" transform="rotate(-90 73 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="242" r="1" transform="rotate(-90 73 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="228" r="1" transform="rotate(-90 73 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="214" r="1" transform="rotate(-90 73 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="200" r="1" transform="rotate(-90 73 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="186" r="1" transform="rotate(-90 73 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="172" r="1" transform="rotate(-90 73 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="158" r="1" transform="rotate(-90 73 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="144" r="1" transform="rotate(-90 73 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="130" r="1" transform="rotate(-90 73 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="116" r="1" transform="rotate(-90 73 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="102" r="1" transform="rotate(-90 73 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="88" r="1" transform="rotate(-90 73 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="74" r="1" transform="rotate(-90 73 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="60" r="1" transform="rotate(-90 73 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="46" r="1" transform="rotate(-90 73 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="32" r="1" transform="rotate(-90 73 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="18" r="1" transform="rotate(-90 73 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="73" cy="4" r="1" transform="rotate(-90 73 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="620" r="1" transform="rotate(-90 83 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="606" r="1" transform="rotate(-90 83 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="592" r="1" transform="rotate(-90 83 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="578" r="1" transform="rotate(-90 83 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="564" r="1" transform="rotate(-90 83 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="550" r="1" transform="rotate(-90 83 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="536" r="1" transform="rotate(-90 83 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="522" r="1" transform="rotate(-90 83 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="508" r="1" transform="rotate(-90 83 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="494" r="1" transform="rotate(-90 83 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="480" r="1" transform="rotate(-90 83 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="466" r="1" transform="rotate(-90 83 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="452" r="1" transform="rotate(-90 83 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="438" r="1" transform="rotate(-90 83 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="424" r="1" transform="rotate(-90 83 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="410" r="1" transform="rotate(-90 83 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="396" r="1" transform="rotate(-90 83 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="382" r="1" transform="rotate(-90 83 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="368" r="1" transform="rotate(-90 83 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="354" r="1" transform="rotate(-90 83 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="340" r="1" transform="rotate(-90 83 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="326" r="1" transform="rotate(-90 83 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="312" r="1" transform="rotate(-90 83 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="298" r="1" transform="rotate(-90 83 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="284" r="1" transform="rotate(-90 83 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="270" r="1" transform="rotate(-90 83 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="256" r="1" transform="rotate(-90 83 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="242" r="1" transform="rotate(-90 83 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="228" r="1" transform="rotate(-90 83 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="214" r="1" transform="rotate(-90 83 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="200" r="1" transform="rotate(-90 83 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="186" r="1" transform="rotate(-90 83 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="172" r="1" transform="rotate(-90 83 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="158" r="1" transform="rotate(-90 83 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="144" r="1" transform="rotate(-90 83 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="130" r="1" transform="rotate(-90 83 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="116" r="1" transform="rotate(-90 83 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="102" r="1" transform="rotate(-90 83 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="88" r="1" transform="rotate(-90 83 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="74" r="1" transform="rotate(-90 83 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="60" r="1" transform="rotate(-90 83 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="46" r="1" transform="rotate(-90 83 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="32" r="1" transform="rotate(-90 83 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="18" r="1" transform="rotate(-90 83 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="83" cy="4" r="1" transform="rotate(-90 83 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="620" r="1" transform="rotate(-90 93 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="606" r="1" transform="rotate(-90 93 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="592" r="1" transform="rotate(-90 93 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="578" r="1" transform="rotate(-90 93 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="564" r="1" transform="rotate(-90 93 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="550" r="1" transform="rotate(-90 93 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="536" r="1" transform="rotate(-90 93 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="522" r="1" transform="rotate(-90 93 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="508" r="1" transform="rotate(-90 93 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="494" r="1" transform="rotate(-90 93 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="480" r="1" transform="rotate(-90 93 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="466" r="1" transform="rotate(-90 93 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="452" r="1" transform="rotate(-90 93 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="438" r="1" transform="rotate(-90 93 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="424" r="1" transform="rotate(-90 93 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="410" r="1" transform="rotate(-90 93 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="396" r="1" transform="rotate(-90 93 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="382" r="1" transform="rotate(-90 93 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="368" r="1" transform="rotate(-90 93 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="354" r="1" transform="rotate(-90 93 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="340" r="1" transform="rotate(-90 93 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="326" r="1" transform="rotate(-90 93 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="312" r="1" transform="rotate(-90 93 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="298" r="1" transform="rotate(-90 93 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="284" r="1" transform="rotate(-90 93 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="270" r="1" transform="rotate(-90 93 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="256" r="1" transform="rotate(-90 93 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="242" r="1" transform="rotate(-90 93 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="228" r="1" transform="rotate(-90 93 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="214" r="1" transform="rotate(-90 93 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="200" r="1" transform="rotate(-90 93 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="186" r="1" transform="rotate(-90 93 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="172" r="1" transform="rotate(-90 93 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="158" r="1" transform="rotate(-90 93 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="144" r="1" transform="rotate(-90 93 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="130" r="1" transform="rotate(-90 93 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="116" r="1" transform="rotate(-90 93 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="102" r="1" transform="rotate(-90 93 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="88" r="1" transform="rotate(-90 93 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="74" r="1" transform="rotate(-90 93 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="60" r="1" transform="rotate(-90 93 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="46" r="1" transform="rotate(-90 93 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="32" r="1" transform="rotate(-90 93 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="18" r="1" transform="rotate(-90 93 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="93" cy="4" r="1" transform="rotate(-90 93 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="620" r="1" transform="rotate(-90 103 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="606" r="1" transform="rotate(-90 103 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="592" r="1" transform="rotate(-90 103 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="578" r="1" transform="rotate(-90 103 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="564" r="1" transform="rotate(-90 103 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="550" r="1" transform="rotate(-90 103 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="536" r="1" transform="rotate(-90 103 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="522" r="1" transform="rotate(-90 103 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="508" r="1" transform="rotate(-90 103 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="494" r="1" transform="rotate(-90 103 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="480" r="1" transform="rotate(-90 103 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="466" r="1" transform="rotate(-90 103 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="452" r="1" transform="rotate(-90 103 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="438" r="1" transform="rotate(-90 103 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="424" r="1" transform="rotate(-90 103 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="410" r="1" transform="rotate(-90 103 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="396" r="1" transform="rotate(-90 103 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="382" r="1" transform="rotate(-90 103 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="368" r="1" transform="rotate(-90 103 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="354" r="1" transform="rotate(-90 103 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="340" r="1" transform="rotate(-90 103 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="326" r="1" transform="rotate(-90 103 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="312" r="1" transform="rotate(-90 103 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="298" r="1" transform="rotate(-90 103 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="284" r="1" transform="rotate(-90 103 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="270" r="1" transform="rotate(-90 103 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="256" r="1" transform="rotate(-90 103 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="242" r="1" transform="rotate(-90 103 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="228" r="1" transform="rotate(-90 103 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="214" r="1" transform="rotate(-90 103 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="200" r="1" transform="rotate(-90 103 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="186" r="1" transform="rotate(-90 103 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="172" r="1" transform="rotate(-90 103 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="158" r="1" transform="rotate(-90 103 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="144" r="1" transform="rotate(-90 103 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="130" r="1" transform="rotate(-90 103 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="116" r="1" transform="rotate(-90 103 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="102" r="1" transform="rotate(-90 103 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="88" r="1" transform="rotate(-90 103 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="74" r="1" transform="rotate(-90 103 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="60" r="1" transform="rotate(-90 103 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="46" r="1" transform="rotate(-90 103 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="32" r="1" transform="rotate(-90 103 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="18" r="1" transform="rotate(-90 103 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="103" cy="4" r="1" transform="rotate(-90 103 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="620" r="1" transform="rotate(-90 113 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="606" r="1" transform="rotate(-90 113 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="592" r="1" transform="rotate(-90 113 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="578" r="1" transform="rotate(-90 113 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="564" r="1" transform="rotate(-90 113 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="550" r="1" transform="rotate(-90 113 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="536" r="1" transform="rotate(-90 113 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="522" r="1" transform="rotate(-90 113 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="508" r="1" transform="rotate(-90 113 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="494" r="1" transform="rotate(-90 113 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="480" r="1" transform="rotate(-90 113 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="466" r="1" transform="rotate(-90 113 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="452" r="1" transform="rotate(-90 113 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="438" r="1" transform="rotate(-90 113 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="424" r="1" transform="rotate(-90 113 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="410" r="1" transform="rotate(-90 113 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="396" r="1" transform="rotate(-90 113 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="382" r="1" transform="rotate(-90 113 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="368" r="1" transform="rotate(-90 113 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="354" r="1" transform="rotate(-90 113 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="340" r="1" transform="rotate(-90 113 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="326" r="1" transform="rotate(-90 113 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="312" r="1" transform="rotate(-90 113 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="298" r="1" transform="rotate(-90 113 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="284" r="1" transform="rotate(-90 113 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="270" r="1" transform="rotate(-90 113 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="256" r="1" transform="rotate(-90 113 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="242" r="1" transform="rotate(-90 113 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="228" r="1" transform="rotate(-90 113 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="214" r="1" transform="rotate(-90 113 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="200" r="1" transform="rotate(-90 113 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="186" r="1" transform="rotate(-90 113 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="172" r="1" transform="rotate(-90 113 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="158" r="1" transform="rotate(-90 113 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="144" r="1" transform="rotate(-90 113 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="130" r="1" transform="rotate(-90 113 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="116" r="1" transform="rotate(-90 113 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="102" r="1" transform="rotate(-90 113 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="88" r="1" transform="rotate(-90 113 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="74" r="1" transform="rotate(-90 113 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="60" r="1" transform="rotate(-90 113 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="46" r="1" transform="rotate(-90 113 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="32" r="1" transform="rotate(-90 113 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="18" r="1" transform="rotate(-90 113 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="113" cy="4" r="1" transform="rotate(-90 113 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="620" r="1" transform="rotate(-90 123 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="606" r="1" transform="rotate(-90 123 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="592" r="1" transform="rotate(-90 123 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="578" r="1" transform="rotate(-90 123 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="564" r="1" transform="rotate(-90 123 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="550" r="1" transform="rotate(-90 123 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="536" r="1" transform="rotate(-90 123 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="522" r="1" transform="rotate(-90 123 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="508" r="1" transform="rotate(-90 123 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="494" r="1" transform="rotate(-90 123 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="480" r="1" transform="rotate(-90 123 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="466" r="1" transform="rotate(-90 123 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="452" r="1" transform="rotate(-90 123 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="438" r="1" transform="rotate(-90 123 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="424" r="1" transform="rotate(-90 123 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="410" r="1" transform="rotate(-90 123 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="396" r="1" transform="rotate(-90 123 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="382" r="1" transform="rotate(-90 123 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="368" r="1" transform="rotate(-90 123 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="354" r="1" transform="rotate(-90 123 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="340" r="1" transform="rotate(-90 123 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="326" r="1" transform="rotate(-90 123 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="312" r="1" transform="rotate(-90 123 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="298" r="1" transform="rotate(-90 123 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="284" r="1" transform="rotate(-90 123 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="270" r="1" transform="rotate(-90 123 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="256" r="1" transform="rotate(-90 123 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="242" r="1" transform="rotate(-90 123 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="228" r="1" transform="rotate(-90 123 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="214" r="1" transform="rotate(-90 123 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="200" r="1" transform="rotate(-90 123 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="186" r="1" transform="rotate(-90 123 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="172" r="1" transform="rotate(-90 123 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="158" r="1" transform="rotate(-90 123 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="144" r="1" transform="rotate(-90 123 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="130" r="1" transform="rotate(-90 123 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="116" r="1" transform="rotate(-90 123 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="102" r="1" transform="rotate(-90 123 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="88" r="1" transform="rotate(-90 123 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="74" r="1" transform="rotate(-90 123 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="60" r="1" transform="rotate(-90 123 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="46" r="1" transform="rotate(-90 123 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="32" r="1" transform="rotate(-90 123 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="18" r="1" transform="rotate(-90 123 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="123" cy="4" r="1" transform="rotate(-90 123 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="620" r="1" transform="rotate(-90 133 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="606" r="1" transform="rotate(-90 133 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="592" r="1" transform="rotate(-90 133 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="578" r="1" transform="rotate(-90 133 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="564" r="1" transform="rotate(-90 133 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="550" r="1" transform="rotate(-90 133 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="536" r="1" transform="rotate(-90 133 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="522" r="1" transform="rotate(-90 133 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="508" r="1" transform="rotate(-90 133 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="494" r="1" transform="rotate(-90 133 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="480" r="1" transform="rotate(-90 133 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="466" r="1" transform="rotate(-90 133 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="452" r="1" transform="rotate(-90 133 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="438" r="1" transform="rotate(-90 133 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="424" r="1" transform="rotate(-90 133 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="410" r="1" transform="rotate(-90 133 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="396" r="1" transform="rotate(-90 133 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="382" r="1" transform="rotate(-90 133 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="368" r="1" transform="rotate(-90 133 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="354" r="1" transform="rotate(-90 133 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="340" r="1" transform="rotate(-90 133 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="326" r="1" transform="rotate(-90 133 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="312" r="1" transform="rotate(-90 133 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="298" r="1" transform="rotate(-90 133 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="284" r="1" transform="rotate(-90 133 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="270" r="1" transform="rotate(-90 133 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="256" r="1" transform="rotate(-90 133 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="242" r="1" transform="rotate(-90 133 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="228" r="1" transform="rotate(-90 133 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="214" r="1" transform="rotate(-90 133 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="200" r="1" transform="rotate(-90 133 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="186" r="1" transform="rotate(-90 133 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="172" r="1" transform="rotate(-90 133 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="158" r="1" transform="rotate(-90 133 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="144" r="1" transform="rotate(-90 133 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="130" r="1" transform="rotate(-90 133 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="116" r="1" transform="rotate(-90 133 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="102" r="1" transform="rotate(-90 133 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="88" r="1" transform="rotate(-90 133 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="74" r="1" transform="rotate(-90 133 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="60" r="1" transform="rotate(-90 133 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="46" r="1" transform="rotate(-90 133 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="32" r="1" transform="rotate(-90 133 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="18" r="1" transform="rotate(-90 133 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="133" cy="4" r="1" transform="rotate(-90 133 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="620" r="1" transform="rotate(-90 143 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="606" r="1" transform="rotate(-90 143 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="592" r="1" transform="rotate(-90 143 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="578" r="1" transform="rotate(-90 143 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="564" r="1" transform="rotate(-90 143 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="550" r="1" transform="rotate(-90 143 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="536" r="1" transform="rotate(-90 143 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="522" r="1" transform="rotate(-90 143 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="508" r="1" transform="rotate(-90 143 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="494" r="1" transform="rotate(-90 143 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="480" r="1" transform="rotate(-90 143 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="466" r="1" transform="rotate(-90 143 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="452" r="1" transform="rotate(-90 143 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="438" r="1" transform="rotate(-90 143 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="424" r="1" transform="rotate(-90 143 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="410" r="1" transform="rotate(-90 143 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="396" r="1" transform="rotate(-90 143 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="382" r="1" transform="rotate(-90 143 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="368" r="1" transform="rotate(-90 143 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="354" r="1" transform="rotate(-90 143 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="340" r="1" transform="rotate(-90 143 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="326" r="1" transform="rotate(-90 143 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="312" r="1" transform="rotate(-90 143 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="298" r="1" transform="rotate(-90 143 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="284" r="1" transform="rotate(-90 143 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="270" r="1" transform="rotate(-90 143 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="256" r="1" transform="rotate(-90 143 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="242" r="1" transform="rotate(-90 143 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="228" r="1" transform="rotate(-90 143 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="214" r="1" transform="rotate(-90 143 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="200" r="1" transform="rotate(-90 143 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="186" r="1" transform="rotate(-90 143 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="172" r="1" transform="rotate(-90 143 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="158" r="1" transform="rotate(-90 143 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="144" r="1" transform="rotate(-90 143 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="130" r="1" transform="rotate(-90 143 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="116" r="1" transform="rotate(-90 143 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="102" r="1" transform="rotate(-90 143 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="88" r="1" transform="rotate(-90 143 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="74" r="1" transform="rotate(-90 143 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="60" r="1" transform="rotate(-90 143 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="46" r="1" transform="rotate(-90 143 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="32" r="1" transform="rotate(-90 143 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="18" r="1" transform="rotate(-90 143 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="143" cy="4" r="1" transform="rotate(-90 143 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="620" r="1" transform="rotate(-90 153 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="606" r="1" transform="rotate(-90 153 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="592" r="1" transform="rotate(-90 153 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="578" r="1" transform="rotate(-90 153 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="564" r="1" transform="rotate(-90 153 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="550" r="1" transform="rotate(-90 153 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="536" r="1" transform="rotate(-90 153 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="522" r="1" transform="rotate(-90 153 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="508" r="1" transform="rotate(-90 153 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="494" r="1" transform="rotate(-90 153 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="480" r="1" transform="rotate(-90 153 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="466" r="1" transform="rotate(-90 153 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="452" r="1" transform="rotate(-90 153 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="438" r="1" transform="rotate(-90 153 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="424" r="1" transform="rotate(-90 153 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="410" r="1" transform="rotate(-90 153 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="396" r="1" transform="rotate(-90 153 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="382" r="1" transform="rotate(-90 153 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="368" r="1" transform="rotate(-90 153 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="354" r="1" transform="rotate(-90 153 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="340" r="1" transform="rotate(-90 153 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="326" r="1" transform="rotate(-90 153 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="312" r="1" transform="rotate(-90 153 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="298" r="1" transform="rotate(-90 153 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="284" r="1" transform="rotate(-90 153 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="270" r="1" transform="rotate(-90 153 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="256" r="1" transform="rotate(-90 153 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="242" r="1" transform="rotate(-90 153 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="228" r="1" transform="rotate(-90 153 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="214" r="1" transform="rotate(-90 153 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="200" r="1" transform="rotate(-90 153 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="186" r="1" transform="rotate(-90 153 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="172" r="1" transform="rotate(-90 153 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="158" r="1" transform="rotate(-90 153 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="144" r="1" transform="rotate(-90 153 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="130" r="1" transform="rotate(-90 153 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="116" r="1" transform="rotate(-90 153 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="102" r="1" transform="rotate(-90 153 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="88" r="1" transform="rotate(-90 153 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="74" r="1" transform="rotate(-90 153 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="60" r="1" transform="rotate(-90 153 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="46" r="1" transform="rotate(-90 153 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="32" r="1" transform="rotate(-90 153 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="18" r="1" transform="rotate(-90 153 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="153" cy="4" r="1" transform="rotate(-90 153 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="620" r="1" transform="rotate(-90 163 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="606" r="1" transform="rotate(-90 163 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="592" r="1" transform="rotate(-90 163 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="578" r="1" transform="rotate(-90 163 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="564" r="1" transform="rotate(-90 163 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="550" r="1" transform="rotate(-90 163 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="536" r="1" transform="rotate(-90 163 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="522" r="1" transform="rotate(-90 163 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="508" r="1" transform="rotate(-90 163 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="494" r="1" transform="rotate(-90 163 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="480" r="1" transform="rotate(-90 163 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="466" r="1" transform="rotate(-90 163 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="452" r="1" transform="rotate(-90 163 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="438" r="1" transform="rotate(-90 163 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="424" r="1" transform="rotate(-90 163 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="410" r="1" transform="rotate(-90 163 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="396" r="1" transform="rotate(-90 163 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="382" r="1" transform="rotate(-90 163 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="368" r="1" transform="rotate(-90 163 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="354" r="1" transform="rotate(-90 163 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="340" r="1" transform="rotate(-90 163 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="326" r="1" transform="rotate(-90 163 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="312" r="1" transform="rotate(-90 163 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="298" r="1" transform="rotate(-90 163 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="284" r="1" transform="rotate(-90 163 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="270" r="1" transform="rotate(-90 163 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="256" r="1" transform="rotate(-90 163 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="242" r="1" transform="rotate(-90 163 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="228" r="1" transform="rotate(-90 163 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="214" r="1" transform="rotate(-90 163 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="200" r="1" transform="rotate(-90 163 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="186" r="1" transform="rotate(-90 163 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="172" r="1" transform="rotate(-90 163 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="158" r="1" transform="rotate(-90 163 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="144" r="1" transform="rotate(-90 163 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="130" r="1" transform="rotate(-90 163 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="116" r="1" transform="rotate(-90 163 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="102" r="1" transform="rotate(-90 163 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="88" r="1" transform="rotate(-90 163 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="74" r="1" transform="rotate(-90 163 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="60" r="1" transform="rotate(-90 163 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="46" r="1" transform="rotate(-90 163 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="32" r="1" transform="rotate(-90 163 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="18" r="1" transform="rotate(-90 163 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="163" cy="4" r="1" transform="rotate(-90 163 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="620" r="1" transform="rotate(-90 173 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="606" r="1" transform="rotate(-90 173 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="592" r="1" transform="rotate(-90 173 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="578" r="1" transform="rotate(-90 173 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="564" r="1" transform="rotate(-90 173 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="550" r="1" transform="rotate(-90 173 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="536" r="1" transform="rotate(-90 173 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="522" r="1" transform="rotate(-90 173 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="508" r="1" transform="rotate(-90 173 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="494" r="1" transform="rotate(-90 173 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="480" r="1" transform="rotate(-90 173 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="466" r="1" transform="rotate(-90 173 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="452" r="1" transform="rotate(-90 173 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="438" r="1" transform="rotate(-90 173 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="424" r="1" transform="rotate(-90 173 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="410" r="1" transform="rotate(-90 173 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="396" r="1" transform="rotate(-90 173 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="382" r="1" transform="rotate(-90 173 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="368" r="1" transform="rotate(-90 173 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="354" r="1" transform="rotate(-90 173 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="340" r="1" transform="rotate(-90 173 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="326" r="1" transform="rotate(-90 173 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="312" r="1" transform="rotate(-90 173 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="298" r="1" transform="rotate(-90 173 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="284" r="1" transform="rotate(-90 173 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="270" r="1" transform="rotate(-90 173 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="256" r="1" transform="rotate(-90 173 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="242" r="1" transform="rotate(-90 173 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="228" r="1" transform="rotate(-90 173 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="214" r="1" transform="rotate(-90 173 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="200" r="1" transform="rotate(-90 173 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="186" r="1" transform="rotate(-90 173 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="172" r="1" transform="rotate(-90 173 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="158" r="1" transform="rotate(-90 173 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="144" r="1" transform="rotate(-90 173 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="130" r="1" transform="rotate(-90 173 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="116" r="1" transform="rotate(-90 173 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="102" r="1" transform="rotate(-90 173 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="88" r="1" transform="rotate(-90 173 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="74" r="1" transform="rotate(-90 173 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="60" r="1" transform="rotate(-90 173 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="46" r="1" transform="rotate(-90 173 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="32" r="1" transform="rotate(-90 173 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="18" r="1" transform="rotate(-90 173 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="173" cy="4" r="1" transform="rotate(-90 173 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="620" r="1" transform="rotate(-90 183 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="606" r="1" transform="rotate(-90 183 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="592" r="1" transform="rotate(-90 183 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="578" r="1" transform="rotate(-90 183 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="564" r="1" transform="rotate(-90 183 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="550" r="1" transform="rotate(-90 183 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="536" r="1" transform="rotate(-90 183 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="522" r="1" transform="rotate(-90 183 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="508" r="1" transform="rotate(-90 183 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="494" r="1" transform="rotate(-90 183 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="480" r="1" transform="rotate(-90 183 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="466" r="1" transform="rotate(-90 183 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="452" r="1" transform="rotate(-90 183 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="438" r="1" transform="rotate(-90 183 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="424" r="1" transform="rotate(-90 183 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="410" r="1" transform="rotate(-90 183 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="396" r="1" transform="rotate(-90 183 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="382" r="1" transform="rotate(-90 183 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="368" r="1" transform="rotate(-90 183 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="354" r="1" transform="rotate(-90 183 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="340" r="1" transform="rotate(-90 183 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="326" r="1" transform="rotate(-90 183 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="312" r="1" transform="rotate(-90 183 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="298" r="1" transform="rotate(-90 183 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="284" r="1" transform="rotate(-90 183 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="270" r="1" transform="rotate(-90 183 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="256" r="1" transform="rotate(-90 183 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="242" r="1" transform="rotate(-90 183 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="228" r="1" transform="rotate(-90 183 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="214" r="1" transform="rotate(-90 183 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="200" r="1" transform="rotate(-90 183 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="186" r="1" transform="rotate(-90 183 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="172" r="1" transform="rotate(-90 183 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="158" r="1" transform="rotate(-90 183 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="144" r="1" transform="rotate(-90 183 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="130" r="1" transform="rotate(-90 183 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="116" r="1" transform="rotate(-90 183 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="102" r="1" transform="rotate(-90 183 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="88" r="1" transform="rotate(-90 183 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="74" r="1" transform="rotate(-90 183 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="60" r="1" transform="rotate(-90 183 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="46" r="1" transform="rotate(-90 183 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="32" r="1" transform="rotate(-90 183 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="18" r="1" transform="rotate(-90 183 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="183" cy="4" r="1" transform="rotate(-90 183 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="620" r="1" transform="rotate(-90 193 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="606" r="1" transform="rotate(-90 193 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="592" r="1" transform="rotate(-90 193 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="578" r="1" transform="rotate(-90 193 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="564" r="1" transform="rotate(-90 193 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="550" r="1" transform="rotate(-90 193 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="536" r="1" transform="rotate(-90 193 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="522" r="1" transform="rotate(-90 193 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="508" r="1" transform="rotate(-90 193 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="494" r="1" transform="rotate(-90 193 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="480" r="1" transform="rotate(-90 193 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="466" r="1" transform="rotate(-90 193 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="452" r="1" transform="rotate(-90 193 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="438" r="1" transform="rotate(-90 193 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="424" r="1" transform="rotate(-90 193 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="410" r="1" transform="rotate(-90 193 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="396" r="1" transform="rotate(-90 193 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="382" r="1" transform="rotate(-90 193 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="368" r="1" transform="rotate(-90 193 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="354" r="1" transform="rotate(-90 193 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="340" r="1" transform="rotate(-90 193 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="326" r="1" transform="rotate(-90 193 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="312" r="1" transform="rotate(-90 193 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="298" r="1" transform="rotate(-90 193 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="284" r="1" transform="rotate(-90 193 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="270" r="1" transform="rotate(-90 193 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="256" r="1" transform="rotate(-90 193 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="242" r="1" transform="rotate(-90 193 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="228" r="1" transform="rotate(-90 193 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="214" r="1" transform="rotate(-90 193 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="200" r="1" transform="rotate(-90 193 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="186" r="1" transform="rotate(-90 193 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="172" r="1" transform="rotate(-90 193 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="158" r="1" transform="rotate(-90 193 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="144" r="1" transform="rotate(-90 193 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="130" r="1" transform="rotate(-90 193 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="116" r="1" transform="rotate(-90 193 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="102" r="1" transform="rotate(-90 193 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="88" r="1" transform="rotate(-90 193 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="74" r="1" transform="rotate(-90 193 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="60" r="1" transform="rotate(-90 193 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="46" r="1" transform="rotate(-90 193 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="32" r="1" transform="rotate(-90 193 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="18" r="1" transform="rotate(-90 193 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="193" cy="4" r="1" transform="rotate(-90 193 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="620" r="1" transform="rotate(-90 203 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="606" r="1" transform="rotate(-90 203 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="592" r="1" transform="rotate(-90 203 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="578" r="1" transform="rotate(-90 203 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="564" r="1" transform="rotate(-90 203 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="550" r="1" transform="rotate(-90 203 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="536" r="1" transform="rotate(-90 203 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="522" r="1" transform="rotate(-90 203 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="508" r="1" transform="rotate(-90 203 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="494" r="1" transform="rotate(-90 203 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="480" r="1" transform="rotate(-90 203 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="466" r="1" transform="rotate(-90 203 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="452" r="1" transform="rotate(-90 203 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="438" r="1" transform="rotate(-90 203 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="424" r="1" transform="rotate(-90 203 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="410" r="1" transform="rotate(-90 203 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="396" r="1" transform="rotate(-90 203 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="382" r="1" transform="rotate(-90 203 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="368" r="1" transform="rotate(-90 203 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="354" r="1" transform="rotate(-90 203 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="340" r="1" transform="rotate(-90 203 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="326" r="1" transform="rotate(-90 203 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="312" r="1" transform="rotate(-90 203 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="298" r="1" transform="rotate(-90 203 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="284" r="1" transform="rotate(-90 203 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="270" r="1" transform="rotate(-90 203 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="256" r="1" transform="rotate(-90 203 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="242" r="1" transform="rotate(-90 203 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="228" r="1" transform="rotate(-90 203 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="214" r="1" transform="rotate(-90 203 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="200" r="1" transform="rotate(-90 203 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="186" r="1" transform="rotate(-90 203 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="172" r="1" transform="rotate(-90 203 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="158" r="1" transform="rotate(-90 203 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="144" r="1" transform="rotate(-90 203 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="130" r="1" transform="rotate(-90 203 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="116" r="1" transform="rotate(-90 203 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="102" r="1" transform="rotate(-90 203 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="88" r="1" transform="rotate(-90 203 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="74" r="1" transform="rotate(-90 203 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="60" r="1" transform="rotate(-90 203 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="46" r="1" transform="rotate(-90 203 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="32" r="1" transform="rotate(-90 203 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="18" r="1" transform="rotate(-90 203 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="203" cy="4" r="1" transform="rotate(-90 203 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="620" r="1" transform="rotate(-90 213 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="606" r="1" transform="rotate(-90 213 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="592" r="1" transform="rotate(-90 213 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="578" r="1" transform="rotate(-90 213 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="564" r="1" transform="rotate(-90 213 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="550" r="1" transform="rotate(-90 213 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="536" r="1" transform="rotate(-90 213 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="522" r="1" transform="rotate(-90 213 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="508" r="1" transform="rotate(-90 213 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="494" r="1" transform="rotate(-90 213 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="480" r="1" transform="rotate(-90 213 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="466" r="1" transform="rotate(-90 213 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="452" r="1" transform="rotate(-90 213 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="438" r="1" transform="rotate(-90 213 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="424" r="1" transform="rotate(-90 213 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="410" r="1" transform="rotate(-90 213 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="396" r="1" transform="rotate(-90 213 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="382" r="1" transform="rotate(-90 213 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="368" r="1" transform="rotate(-90 213 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="354" r="1" transform="rotate(-90 213 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="340" r="1" transform="rotate(-90 213 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="326" r="1" transform="rotate(-90 213 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="312" r="1" transform="rotate(-90 213 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="298" r="1" transform="rotate(-90 213 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="284" r="1" transform="rotate(-90 213 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="270" r="1" transform="rotate(-90 213 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="256" r="1" transform="rotate(-90 213 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="242" r="1" transform="rotate(-90 213 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="228" r="1" transform="rotate(-90 213 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="214" r="1" transform="rotate(-90 213 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="200" r="1" transform="rotate(-90 213 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="186" r="1" transform="rotate(-90 213 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="172" r="1" transform="rotate(-90 213 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="158" r="1" transform="rotate(-90 213 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="144" r="1" transform="rotate(-90 213 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="130" r="1" transform="rotate(-90 213 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="116" r="1" transform="rotate(-90 213 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="102" r="1" transform="rotate(-90 213 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="88" r="1" transform="rotate(-90 213 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="74" r="1" transform="rotate(-90 213 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="60" r="1" transform="rotate(-90 213 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="46" r="1" transform="rotate(-90 213 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="32" r="1" transform="rotate(-90 213 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="18" r="1" transform="rotate(-90 213 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="213" cy="4" r="1" transform="rotate(-90 213 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="620" r="1" transform="rotate(-90 223 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="606" r="1" transform="rotate(-90 223 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="592" r="1" transform="rotate(-90 223 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="578" r="1" transform="rotate(-90 223 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="564" r="1" transform="rotate(-90 223 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="550" r="1" transform="rotate(-90 223 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="536" r="1" transform="rotate(-90 223 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="522" r="1" transform="rotate(-90 223 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="508" r="1" transform="rotate(-90 223 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="494" r="1" transform="rotate(-90 223 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="480" r="1" transform="rotate(-90 223 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="466" r="1" transform="rotate(-90 223 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="452" r="1" transform="rotate(-90 223 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="438" r="1" transform="rotate(-90 223 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="424" r="1" transform="rotate(-90 223 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="410" r="1" transform="rotate(-90 223 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="396" r="1" transform="rotate(-90 223 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="382" r="1" transform="rotate(-90 223 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="368" r="1" transform="rotate(-90 223 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="354" r="1" transform="rotate(-90 223 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="340" r="1" transform="rotate(-90 223 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="326" r="1" transform="rotate(-90 223 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="312" r="1" transform="rotate(-90 223 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="298" r="1" transform="rotate(-90 223 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="284" r="1" transform="rotate(-90 223 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="270" r="1" transform="rotate(-90 223 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="256" r="1" transform="rotate(-90 223 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="242" r="1" transform="rotate(-90 223 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="228" r="1" transform="rotate(-90 223 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="214" r="1" transform="rotate(-90 223 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="200" r="1" transform="rotate(-90 223 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="186" r="1" transform="rotate(-90 223 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="172" r="1" transform="rotate(-90 223 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="158" r="1" transform="rotate(-90 223 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="144" r="1" transform="rotate(-90 223 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="130" r="1" transform="rotate(-90 223 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="116" r="1" transform="rotate(-90 223 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="102" r="1" transform="rotate(-90 223 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="88" r="1" transform="rotate(-90 223 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="74" r="1" transform="rotate(-90 223 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="60" r="1" transform="rotate(-90 223 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="46" r="1" transform="rotate(-90 223 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="32" r="1" transform="rotate(-90 223 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="18" r="1" transform="rotate(-90 223 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="223" cy="4" r="1" transform="rotate(-90 223 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="620" r="1" transform="rotate(-90 233 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="606" r="1" transform="rotate(-90 233 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="592" r="1" transform="rotate(-90 233 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="578" r="1" transform="rotate(-90 233 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="564" r="1" transform="rotate(-90 233 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="550" r="1" transform="rotate(-90 233 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="536" r="1" transform="rotate(-90 233 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="522" r="1" transform="rotate(-90 233 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="508" r="1" transform="rotate(-90 233 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="494" r="1" transform="rotate(-90 233 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="480" r="1" transform="rotate(-90 233 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="466" r="1" transform="rotate(-90 233 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="452" r="1" transform="rotate(-90 233 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="438" r="1" transform="rotate(-90 233 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="424" r="1" transform="rotate(-90 233 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="410" r="1" transform="rotate(-90 233 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="396" r="1" transform="rotate(-90 233 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="382" r="1" transform="rotate(-90 233 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="368" r="1" transform="rotate(-90 233 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="354" r="1" transform="rotate(-90 233 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="340" r="1" transform="rotate(-90 233 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="326" r="1" transform="rotate(-90 233 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="312" r="1" transform="rotate(-90 233 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="298" r="1" transform="rotate(-90 233 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="284" r="1" transform="rotate(-90 233 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="270" r="1" transform="rotate(-90 233 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="256" r="1" transform="rotate(-90 233 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="242" r="1" transform="rotate(-90 233 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="228" r="1" transform="rotate(-90 233 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="214" r="1" transform="rotate(-90 233 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="200" r="1" transform="rotate(-90 233 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="186" r="1" transform="rotate(-90 233 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="172" r="1" transform="rotate(-90 233 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="158" r="1" transform="rotate(-90 233 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="144" r="1" transform="rotate(-90 233 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="130" r="1" transform="rotate(-90 233 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="116" r="1" transform="rotate(-90 233 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="102" r="1" transform="rotate(-90 233 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="88" r="1" transform="rotate(-90 233 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="74" r="1" transform="rotate(-90 233 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="60" r="1" transform="rotate(-90 233 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="46" r="1" transform="rotate(-90 233 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="32" r="1" transform="rotate(-90 233 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="18" r="1" transform="rotate(-90 233 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="233" cy="4" r="1" transform="rotate(-90 233 4)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="620" r="1" transform="rotate(-90 243 620)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="606" r="1" transform="rotate(-90 243 606)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="592" r="1" transform="rotate(-90 243 592)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="578" r="1" transform="rotate(-90 243 578)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="564" r="1" transform="rotate(-90 243 564)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="550" r="1" transform="rotate(-90 243 550)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="536" r="1" transform="rotate(-90 243 536)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="522" r="1" transform="rotate(-90 243 522)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="508" r="1" transform="rotate(-90 243 508)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="494" r="1" transform="rotate(-90 243 494)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="480" r="1" transform="rotate(-90 243 480)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="466" r="1" transform="rotate(-90 243 466)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="452" r="1" transform="rotate(-90 243 452)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="438" r="1" transform="rotate(-90 243 438)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="424" r="1" transform="rotate(-90 243 424)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="410" r="1" transform="rotate(-90 243 410)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="396" r="1" transform="rotate(-90 243 396)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="382" r="1" transform="rotate(-90 243 382)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="368" r="1" transform="rotate(-90 243 368)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="354" r="1" transform="rotate(-90 243 354)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="340" r="1" transform="rotate(-90 243 340)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="326" r="1" transform="rotate(-90 243 326)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="312" r="1" transform="rotate(-90 243 312)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="298" r="1" transform="rotate(-90 243 298)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="284" r="1" transform="rotate(-90 243 284)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="270" r="1" transform="rotate(-90 243 270)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="256" r="1" transform="rotate(-90 243 256)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="242" r="1" transform="rotate(-90 243 242)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="228" r="1" transform="rotate(-90 243 228)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="214" r="1" transform="rotate(-90 243 214)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="200" r="1" transform="rotate(-90 243 200)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="186" r="1" transform="rotate(-90 243 186)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="172" r="1" transform="rotate(-90 243 172)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="158" r="1" transform="rotate(-90 243 158)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="144" r="1" transform="rotate(-90 243 144)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="130" r="1" transform="rotate(-90 243 130)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="116" r="1" transform="rotate(-90 243 116)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="102" r="1" transform="rotate(-90 243 102)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="88" r="1" transform="rotate(-90 243 88)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="74" r="1" transform="rotate(-90 243 74)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="60" r="1" transform="rotate(-90 243 60)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="46" r="1" transform="rotate(-90 243 46)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="32" r="1" transform="rotate(-90 243 32)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="18" r="1" transform="rotate(-90 243 18)" fill="#62687C" fill-opacity="0.1"/>
+<circle cx="243" cy="4" r="1" transform="rotate(-90 243 4)" fill="#62687C" fill-opacity="0.1"/>
+<g clip-path="url(#clip1_2754_8800)">
+<path d="M125.35 664.208L125.35 401.113V64.2222C125.35 59.7856 121.753 56.189 117.316 56.189H48.9732C44.5366 56.189 40.94 59.7856 40.94 64.2222L40.94 128.067C40.94 132.503 37.3433 136.1 32.9067 136.1H-177.384" stroke="#E5484D" stroke-opacity="0.1" stroke-width="8.03328"/>
+<path d="M125.35 664.208L125.35 401.113V64.2222C125.35 59.7856 121.753 56.189 117.316 56.189H48.9732C44.5366 56.189 40.94 59.7856 40.94 64.2222L40.94 128.388C40.94 132.825 37.3433 136.421 32.9067 136.421H-177.384" stroke="#E5484D" stroke-width="0.963993"/>
+<path d="M137.398 664.208L137.398 392.988L137.398 45.4449C137.398 41.0083 133.802 37.4117 129.365 37.4117H57.3711C52.9344 37.4117 49.3378 41.0083 49.3378 45.445L49.3378 158.682C49.3378 163.118 45.7412 166.715 41.3045 166.715H-178.43" stroke="#4E74F8" stroke-opacity="0.1" stroke-width="8.03328"/>
+<path d="M137.398 664.208L137.398 392.988L137.398 45.4449C137.398 41.0083 133.802 37.4117 129.365 37.4117H57.3711C52.9344 37.4117 49.3378 41.0083 49.3378 45.445L49.3378 158.682C49.3378 163.118 45.7412 166.715 41.3045 166.715H-178.43" stroke="#4E74F8" stroke-width="0.963993"/>
+<path d="M113.7 664.208L113.7 401.114V77.0759C113.7 72.6392 110.104 69.0426 105.667 69.0426H37.3238C32.8872 69.0426 29.2905 72.6393 29.2905 77.0759L29.2905 98.2637C29.2905 102.7 25.6939 106.297 21.2573 106.297H-179.675" stroke="#FFCD56" stroke-opacity="0.1" stroke-width="8.03328"/>
+<path d="M113.7 664.208L113.7 401.114V77.0759C113.7 72.6392 110.104 69.0426 105.667 69.0426H37.3238C32.8872 69.0426 29.2905 72.6393 29.2905 77.0759L29.2905 98.2637C29.2905 102.7 25.6939 106.297 21.2573 106.297H-179.675" stroke="#FFCD56" stroke-width="0.963993"/>
+<rect x="59.1973" y="107.083" width="133.474" height="54.1309" fill="white"/>
+<rect x="72.6768" y="291.088" width="105.882" height="35.2941" fill="white"/>
+<rect x="79.2939" y="527.118" width="92.6471" height="52.9412" fill="white"/>
+<g clip-path="url(#clip2_2754_8800)">
+<line x1="154.065" y1="456.594" x2="160.003" y2="450.656" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="461.953" x2="160.003" y2="456.015" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="467.312" x2="160.003" y2="461.374" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="472.671" x2="160.003" y2="466.733" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="478.03" x2="160.003" y2="472.092" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="483.389" x2="160.003" y2="477.451" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="488.748" x2="160.003" y2="482.81" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="494.107" x2="160.003" y2="488.169" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="499.465" x2="160.003" y2="493.527" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="504.824" x2="160.003" y2="498.886" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="510.184" x2="160.003" y2="504.246" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="515.543" x2="160.003" y2="509.605" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="520.901" x2="160.003" y2="514.963" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="526.26" x2="160.003" y2="520.322" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="531.619" x2="160.003" y2="525.681" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="536.978" x2="160.003" y2="531.04" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="542.337" x2="160.003" y2="536.399" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="547.696" x2="160.003" y2="541.758" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="553.055" x2="160.003" y2="547.117" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="558.414" x2="160.003" y2="552.476" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="563.773" x2="160.003" y2="557.835" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="569.132" x2="160.003" y2="563.194" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="574.491" x2="160.003" y2="568.553" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="579.85" x2="160.003" y2="573.912" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="585.209" x2="160.003" y2="579.271" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="590.568" x2="160.003" y2="584.629" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="154.065" y1="595.926" x2="160.003" y2="589.988" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="154.312" y="450.903" width="5.64852" height="144.981" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip3_2754_8800)">
+<line x1="151.458" y1="456.594" x2="157.396" y2="450.656" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="461.953" x2="157.396" y2="456.015" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="467.312" x2="157.396" y2="461.374" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="472.671" x2="157.396" y2="466.733" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="478.03" x2="157.396" y2="472.092" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="483.389" x2="157.396" y2="477.451" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="488.748" x2="157.396" y2="482.81" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="494.107" x2="157.396" y2="488.169" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="499.465" x2="157.396" y2="493.527" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="504.824" x2="157.396" y2="498.886" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="510.184" x2="157.396" y2="504.246" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="515.543" x2="157.396" y2="509.605" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="520.901" x2="157.396" y2="514.963" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="526.26" x2="157.396" y2="520.322" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="531.619" x2="157.396" y2="525.681" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="536.978" x2="157.396" y2="531.04" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="542.337" x2="157.396" y2="536.399" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="547.696" x2="157.396" y2="541.758" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="553.055" x2="157.396" y2="547.117" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="558.414" x2="157.396" y2="552.476" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="563.773" x2="157.396" y2="557.835" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="569.132" x2="157.396" y2="563.194" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="574.491" x2="157.396" y2="568.553" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="579.85" x2="157.396" y2="573.912" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="585.209" x2="157.396" y2="579.271" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="590.568" x2="157.396" y2="584.629" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="151.458" y1="595.926" x2="157.396" y2="589.988" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="151.705" y="450.903" width="5.64852" height="144.981" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip4_2754_8800)">
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 456.696)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 462.056)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 467.415)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 472.773)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 478.132)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 483.491)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 488.85)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 494.209)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 499.568)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 504.927)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 510.286)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 515.645)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 521.003)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 526.363)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 531.722)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 537.081)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 542.439)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 547.798)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 553.157)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 558.517)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 563.875)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 569.234)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 574.593)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 579.952)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 585.311)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 590.67)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 96.6875 596.029)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="0.144789" width="5.64852" height="144.981" transform="matrix(-1 0 0 1 96.3979 450.758)" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip5_2754_8800)">
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 338.549)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 342.171)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 345.792)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 349.414)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 353.035)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 356.657)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 360.278)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 363.9)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 367.521)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 371.143)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 374.764)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="0.144789" width="5.79155" height="38.2242" transform="matrix(-1 0 0 1 108.124 332.611)" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip6_2754_8800)">
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 173.49)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 177.111)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 180.733)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 184.354)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 187.976)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 191.597)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 195.219)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 198.84)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 202.462)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 206.083)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 108.343 209.705)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="0.144789" width="5.79155" height="38.2242" transform="matrix(-1 0 0 1 108.124 167.552)" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip7_2754_8800)">
+<line x1="142.553" y1="338.447" x2="148.491" y2="332.509" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="342.069" x2="148.491" y2="336.13" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="345.69" x2="148.491" y2="339.752" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="349.312" x2="148.491" y2="343.374" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="352.933" x2="148.491" y2="346.995" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="356.554" x2="148.491" y2="350.616" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="360.176" x2="148.491" y2="354.238" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="363.798" x2="148.491" y2="357.859" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="367.419" x2="148.491" y2="361.481" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="371.04" x2="148.491" y2="365.102" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="374.662" x2="148.491" y2="368.724" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="142.729" y="332.756" width="5.79155" height="38.2242" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip8_2754_8800)">
+<line x1="142.553" y1="173.387" x2="148.491" y2="167.449" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="177.009" x2="148.491" y2="171.071" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="180.631" x2="148.491" y2="174.692" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="184.252" x2="148.491" y2="178.314" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="187.873" x2="148.491" y2="181.935" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="191.495" x2="148.491" y2="185.557" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="195.116" x2="148.491" y2="189.178" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="198.738" x2="148.491" y2="192.8" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="202.36" x2="148.491" y2="196.421" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="205.981" x2="148.491" y2="200.043" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="142.553" y1="209.602" x2="148.491" y2="203.664" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="142.729" y="167.697" width="5.79155" height="38.2242" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip9_2754_8800)">
+<line x1="163.693" y1="563.448" x2="169.631" y2="557.51" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="163.693" y1="567.069" x2="169.631" y2="561.131" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="163.693" y1="570.691" x2="169.631" y2="564.753" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="163.693" y1="574.313" x2="169.631" y2="568.375" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="163.693" y1="577.934" x2="169.631" y2="571.996" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="163.693" y1="581.555" x2="169.631" y2="575.617" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="163.693" y1="585.177" x2="169.631" y2="579.239" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="163.693" y1="588.798" x2="169.631" y2="582.86" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="163.693" y1="592.42" x2="169.631" y2="586.482" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="163.693" y1="596.041" x2="169.631" y2="590.103" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="163.693" y1="599.663" x2="169.631" y2="593.725" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="163.868" y="557.757" width="5.79155" height="38.2242" rx="2.89577" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip10_2754_8800)">
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 87.2031 563.55)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 87.2031 567.172)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 87.2031 570.793)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 87.2031 574.415)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 87.2031 578.036)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 87.2031 581.658)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 87.2031 585.279)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 87.2031 588.901)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 87.2031 592.522)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 87.2031 596.144)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 87.2031 599.765)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="0.144789" width="5.79155" height="38.2242" rx="2.89577" transform="matrix(-1 0 0 1 86.9848 557.612)" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip11_2754_8800)">
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 83.4395 223.587)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 83.4395 227.208)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 83.4395 230.83)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 83.4395 234.452)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 83.4395 238.073)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 83.4395 241.694)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 83.4395 245.316)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 83.4395 248.938)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 83.4395 252.559)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 83.4395 256.18)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 83.4395 259.802)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="0.144789" width="5.79155" height="38.2242" rx="2.89577" transform="matrix(-1 0 0 1 83.2212 217.649)" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip12_2754_8800)">
+<line x1="167.167" y1="223.485" x2="173.105" y2="217.546" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="167.167" y1="227.106" x2="173.105" y2="221.168" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="167.167" y1="230.728" x2="173.105" y2="224.79" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="167.167" y1="234.349" x2="173.105" y2="228.411" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="167.167" y1="237.97" x2="173.105" y2="232.032" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="167.167" y1="241.592" x2="173.105" y2="235.654" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="167.167" y1="245.214" x2="173.105" y2="239.275" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="167.167" y1="248.835" x2="173.105" y2="242.897" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="167.167" y1="252.457" x2="173.105" y2="246.519" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="167.167" y1="256.078" x2="173.105" y2="250.14" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="167.167" y1="259.699" x2="173.105" y2="253.761" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="167.343" y="217.794" width="5.79155" height="38.2242" rx="2.89577" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="173.134" y="222.716" width="7.52901" height="2.02704" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="173.134" y="231.403" width="7.52901" height="2.02704" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="173.134" y="240.091" width="7.52901" height="2.02704" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="173.134" y="248.778" width="7.52901" height="2.02704" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="70.3342" y="222.716" width="7.23943" height="2.02704" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="70.3342" y="231.403" width="7.23943" height="2.02704" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="70.3342" y="240.091" width="7.23943" height="2.02704" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="70.3342" y="248.778" width="7.23943" height="2.02704" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip13_2754_8800)">
+<rect width="5.79155" height="35.3284" transform="matrix(0 -1 -1 0 141.715 585.702)" fill="white"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 135.776 585.775)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 130.418 585.775)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 125.059 585.775)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 119.7 585.775)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 114.341 585.775)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 108.982 585.775)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 103.623 585.775)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="-0.144789" width="5.50197" height="35.0389" transform="matrix(0 -1 -1 0 141.425 585.412)" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip14_2754_8800)">
+<rect width="2.61081" height="31.7314" transform="matrix(0 -1 -1 0 141.416 591.628)" fill="white"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 135.478 593.292)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 133.015 593.292)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 130.552 593.292)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 128.089 593.292)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 125.625 593.292)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 123.162 593.292)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 120.699 593.292)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 118.235 593.292)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 115.772 593.292)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 113.31 593.292)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 110.846 593.292)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 108.383 593.292)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(0.707107 -0.707107 -0.707107 -0.707107 105.92 593.292)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="-0.144789" width="2.32124" height="31.4419" transform="matrix(0 -1 -1 0 141.126 591.338)" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip15_2754_8800)">
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 456.696)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 462.056)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 467.415)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 472.773)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 478.132)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 483.491)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 488.85)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 494.209)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 499.568)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 504.927)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 510.286)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 515.645)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 521.003)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 526.363)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 531.722)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 537.081)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 542.439)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 547.798)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 553.157)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 558.517)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 563.875)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 569.234)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 574.593)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 579.952)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 585.311)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 590.67)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 99.2939 596.029)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="0.144789" width="5.64852" height="144.981" transform="matrix(-1 0 0 1 99.0044 450.758)" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="93.5012" y="450.903" width="3.04056" height="27.2203" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="154.312" y="450.903" width="3.04056" height="27.2203" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip16_2754_8800)">
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 297.429)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 302.788)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 308.147)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 313.506)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 318.865)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 324.224)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 329.583)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 334.942)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 340.301)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 345.66)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 351.019)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 356.378)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 361.737)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 367.096)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 372.455)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 377.813)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 383.172)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 388.532)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 393.89)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 399.249)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 404.608)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 409.967)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 415.326)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 420.685)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 426.044)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 431.403)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 174.584 436.762)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="0.144789" width="5.64852" height="144.981" transform="matrix(-1 0 0 1 174.294 291.491)" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip17_2754_8800)">
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 297.429)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 302.788)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 308.147)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 313.506)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 318.865)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 324.224)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 329.583)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 334.942)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 340.301)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 345.66)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 351.019)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 356.378)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 361.737)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 367.096)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 372.455)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 377.813)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 383.172)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 388.532)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 393.89)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 399.249)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 404.608)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 409.967)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 415.326)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 420.685)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 426.044)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 431.403)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 171.979 436.762)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="0.144789" width="5.64852" height="144.981" transform="matrix(-1 0 0 1 171.689 291.491)" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="168.791" y="291.636" width="3.04056" height="27.2203" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip18_2754_8800)">
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 132.37)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 137.729)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 143.087)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 148.446)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 153.806)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 159.165)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 164.523)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 169.882)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 175.241)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 180.6)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 185.959)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 191.318)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 196.677)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 202.036)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 207.395)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 212.754)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 218.113)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 223.472)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 228.831)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 234.19)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 239.549)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 244.907)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 250.267)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 255.625)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 260.984)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 266.343)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 189.062 271.702)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="0.144789" width="5.64852" height="144.981" transform="matrix(-1 0 0 1 188.773 126.432)" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip19_2754_8800)">
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 132.37)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 137.729)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 143.087)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 148.446)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 153.806)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 159.165)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 164.523)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 169.882)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 175.241)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 180.6)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 185.959)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 191.318)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 196.677)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 202.036)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 207.395)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 212.754)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 218.113)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 223.472)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 228.831)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 234.19)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 239.549)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 244.907)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 250.267)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 255.625)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 260.984)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 266.343)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 186.457 271.702)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="0.144789" width="5.64852" height="144.981" transform="matrix(-1 0 0 1 186.167 126.432)" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="183.27" y="126.576" width="3.04056" height="27.2203" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip20_2754_8800)">
+<line x1="78.7746" y1="297.327" x2="84.7127" y2="291.389" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="302.686" x2="84.7127" y2="296.748" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="308.045" x2="84.7127" y2="302.107" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="313.404" x2="84.7127" y2="307.466" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="318.763" x2="84.7127" y2="312.825" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="324.121" x2="84.7127" y2="318.183" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="329.481" x2="84.7127" y2="323.543" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="334.84" x2="84.7127" y2="328.901" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="340.199" x2="84.7127" y2="334.261" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="345.557" x2="84.7127" y2="339.619" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="350.916" x2="84.7127" y2="344.978" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="356.276" x2="84.7127" y2="350.337" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="361.634" x2="84.7127" y2="355.696" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="366.993" x2="84.7127" y2="361.055" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="372.352" x2="84.7127" y2="366.414" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="377.711" x2="84.7127" y2="371.773" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="383.07" x2="84.7127" y2="377.132" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="388.429" x2="84.7127" y2="382.491" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="393.788" x2="84.7127" y2="387.85" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="399.147" x2="84.7127" y2="393.209" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="404.506" x2="84.7127" y2="398.568" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="409.865" x2="84.7127" y2="403.927" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="415.224" x2="84.7127" y2="409.286" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="420.583" x2="84.7127" y2="414.645" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="425.942" x2="84.7127" y2="420.003" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="431.3" x2="84.7127" y2="425.362" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="78.7746" y1="436.659" x2="84.7127" y2="430.721" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="79.0217" y="291.636" width="5.64852" height="144.981" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip21_2754_8800)">
+<line x1="76.1681" y1="297.327" x2="82.1062" y2="291.389" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="302.686" x2="82.1062" y2="296.748" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="308.045" x2="82.1062" y2="302.107" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="313.404" x2="82.1062" y2="307.466" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="318.763" x2="82.1062" y2="312.825" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="324.121" x2="82.1062" y2="318.183" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="329.481" x2="82.1062" y2="323.543" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="334.84" x2="82.1062" y2="328.901" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="340.198" x2="82.1062" y2="334.26" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="345.557" x2="82.1062" y2="339.619" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="350.916" x2="82.1062" y2="344.978" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="356.276" x2="82.1062" y2="350.337" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="361.634" x2="82.1062" y2="355.696" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="366.993" x2="82.1062" y2="361.055" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="372.352" x2="82.1062" y2="366.414" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="377.711" x2="82.1062" y2="371.773" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="383.07" x2="82.1062" y2="377.132" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="388.429" x2="82.1062" y2="382.491" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="393.788" x2="82.1062" y2="387.85" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="399.147" x2="82.1062" y2="393.209" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="404.506" x2="82.1062" y2="398.568" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="409.865" x2="82.1062" y2="403.927" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="415.224" x2="82.1062" y2="409.286" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="420.583" x2="82.1062" y2="414.645" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="425.942" x2="82.1062" y2="420.003" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="431.3" x2="82.1062" y2="425.362" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="76.1681" y1="436.66" x2="82.1062" y2="430.722" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="76.4153" y="291.636" width="5.64852" height="144.981" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip22_2754_8800)">
+<line x1="90.6466" y1="334.972" x2="96.5847" y2="329.034" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="338.594" x2="96.5847" y2="332.656" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="342.215" x2="96.5847" y2="336.277" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="345.837" x2="96.5847" y2="339.898" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="349.459" x2="96.5847" y2="343.521" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="353.08" x2="96.5847" y2="347.142" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="356.701" x2="96.5847" y2="350.763" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="360.323" x2="96.5847" y2="354.385" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="363.944" x2="96.5847" y2="358.006" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="367.566" x2="96.5847" y2="361.628" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="371.187" x2="96.5847" y2="365.249" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="374.809" x2="96.5847" y2="368.871" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="378.43" x2="96.5847" y2="372.492" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="382.052" x2="96.5847" y2="376.114" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="385.673" x2="96.5847" y2="379.735" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="389.295" x2="96.5847" y2="383.357" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="392.916" x2="96.5847" y2="386.978" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="396.538" x2="96.5847" y2="390.6" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="400.159" x2="96.5847" y2="394.221" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="403.78" x2="96.5847" y2="397.842" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="407.402" x2="96.5847" y2="401.464" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="411.023" x2="96.5847" y2="405.085" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="414.645" x2="96.5847" y2="408.707" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="418.267" x2="96.5847" y2="412.329" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="421.888" x2="96.5847" y2="415.95" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="425.509" x2="96.5847" y2="419.571" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6466" y1="429.131" x2="96.5847" y2="423.193" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="90.8938" y="329.282" width="5.64852" height="99.8071" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip23_2754_8800)">
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 335.075)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 338.696)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 342.318)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 345.939)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 349.561)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 353.182)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 356.804)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 360.425)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 364.046)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 367.668)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 371.29)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 374.911)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 378.532)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 382.154)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 385.775)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 389.397)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 393.019)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 396.64)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 400.262)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 403.883)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 407.504)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 411.125)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 414.748)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 418.369)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 421.99)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 425.612)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.104 429.233)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="0.144789" width="5.64852" height="99.8071" transform="matrix(-1 0 0 1 159.815 329.137)" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="79.0217" y="291.636" width="3.04056" height="27.2203" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip24_2754_8800)">
+<line x1="64.2961" y1="132.267" x2="70.2342" y2="126.329" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="137.627" x2="70.2342" y2="131.689" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="142.985" x2="70.2342" y2="137.047" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="148.344" x2="70.2342" y2="142.406" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="153.703" x2="70.2342" y2="147.765" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="159.062" x2="70.2342" y2="153.124" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="164.421" x2="70.2342" y2="158.483" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="169.78" x2="70.2342" y2="163.842" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="175.139" x2="70.2342" y2="169.201" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="180.498" x2="70.2342" y2="174.56" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="185.857" x2="70.2342" y2="179.919" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="191.216" x2="70.2342" y2="185.278" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="196.574" x2="70.2342" y2="190.636" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="201.934" x2="70.2342" y2="195.996" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="207.293" x2="70.2342" y2="201.355" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="212.652" x2="70.2342" y2="206.713" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="218.01" x2="70.2342" y2="212.072" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="223.369" x2="70.2342" y2="217.431" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="228.728" x2="70.2342" y2="222.79" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="234.088" x2="70.2342" y2="228.149" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="239.446" x2="70.2342" y2="233.508" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="244.805" x2="70.2342" y2="238.867" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="250.164" x2="70.2342" y2="244.226" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="255.523" x2="70.2342" y2="249.585" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="260.882" x2="70.2342" y2="254.944" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="266.241" x2="70.2342" y2="260.303" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="64.2961" y1="271.6" x2="70.2342" y2="265.662" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="64.5432" y="126.576" width="5.64852" height="144.981" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip25_2754_8800)">
+<line x1="61.6896" y1="132.267" x2="67.6277" y2="126.329" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="137.627" x2="67.6277" y2="131.689" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="142.985" x2="67.6277" y2="137.047" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="148.344" x2="67.6277" y2="142.406" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="153.703" x2="67.6277" y2="147.765" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="159.062" x2="67.6277" y2="153.124" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="164.421" x2="67.6277" y2="158.483" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="169.78" x2="67.6277" y2="163.842" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="175.139" x2="67.6277" y2="169.201" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="180.498" x2="67.6277" y2="174.56" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="185.857" x2="67.6277" y2="179.919" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="191.216" x2="67.6277" y2="185.278" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="196.574" x2="67.6277" y2="190.636" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="201.934" x2="67.6277" y2="195.996" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="207.293" x2="67.6277" y2="201.355" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="212.652" x2="67.6277" y2="206.713" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="218.01" x2="67.6277" y2="212.072" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="223.369" x2="67.6277" y2="217.431" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="228.728" x2="67.6277" y2="222.79" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="234.088" x2="67.6277" y2="228.149" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="239.446" x2="67.6277" y2="233.508" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="244.805" x2="67.6277" y2="238.867" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="250.164" x2="67.6277" y2="244.226" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="255.523" x2="67.6277" y2="249.585" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="260.882" x2="67.6277" y2="254.944" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="266.241" x2="67.6277" y2="260.303" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="61.6896" y1="271.6" x2="67.6277" y2="265.662" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="61.9368" y="126.576" width="5.64852" height="144.981" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="64.5432" y="126.576" width="3.04056" height="27.2203" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip26_2754_8800)">
+<line x1="90.6476" y1="169.913" x2="96.5857" y2="163.975" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="173.534" x2="96.5857" y2="167.596" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="177.155" x2="96.5857" y2="171.217" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="180.778" x2="96.5857" y2="174.839" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="184.399" x2="96.5857" y2="178.46" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="188.02" x2="96.5857" y2="182.082" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="191.642" x2="96.5857" y2="185.704" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="195.263" x2="96.5857" y2="189.325" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="198.885" x2="96.5857" y2="192.947" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="202.506" x2="96.5857" y2="196.568" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="206.128" x2="96.5857" y2="200.189" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="209.749" x2="96.5857" y2="203.811" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="213.371" x2="96.5857" y2="207.433" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="216.992" x2="96.5857" y2="211.054" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="220.613" x2="96.5857" y2="214.675" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="224.236" x2="96.5857" y2="218.297" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="227.857" x2="96.5857" y2="221.919" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="231.478" x2="96.5857" y2="225.54" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="235.099" x2="96.5857" y2="229.161" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="238.721" x2="96.5857" y2="232.783" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="242.342" x2="96.5857" y2="236.404" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="245.964" x2="96.5857" y2="240.026" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="249.586" x2="96.5857" y2="243.648" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="253.207" x2="96.5857" y2="247.269" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="256.829" x2="96.5857" y2="250.891" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="260.45" x2="96.5857" y2="254.512" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="90.6476" y1="264.071" x2="96.5857" y2="258.133" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="90.8948" y="164.222" width="5.64852" height="99.8071" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip27_2754_8800)">
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 170.015)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 173.637)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 177.258)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 180.88)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 184.501)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 188.123)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 191.744)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 195.366)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 198.987)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 202.608)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 206.23)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 209.852)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 213.473)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 217.095)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 220.716)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 224.338)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 227.959)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 231.581)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 235.202)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 238.823)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 242.445)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 246.066)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 249.688)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 253.309)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 256.931)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 260.552)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="8.39774" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 160.105 264.174)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<rect x="-0.144789" y="0.144789" width="5.64852" height="99.8071" transform="matrix(-1 0 0 1 159.816 164.077)" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="90.8948" y="329.281" width="2.89577" height="69.0613" transform="rotate(-90 90.8948 329.281)" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="90.8948" y="164.221" width="2.89577" height="69.0613" transform="rotate(-90 90.8948 164.221)" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M96.6855 329.281H108.269V334.204H106.676V335.941H103.636V334.204H100.45V335.941H98.2783V334.204H96.6855V329.281Z" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M96.6855 164.222H108.269V169.145H106.676V170.882H103.636V169.145H100.45V170.882H98.2783V169.145H96.6855V164.222Z" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M96.542 402.109V413.692H101.465V412.099H103.202V409.059H101.465V405.874H103.202V403.702H101.465V402.109H96.542Z" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M96.542 237.05V248.633H101.465V247.041H103.202V244H101.465V240.815H103.202V238.643H101.465V237.05H96.542Z" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M73.5205 90.6694H61.9375V95.5923H63.5303V97.3296H66.5703V95.5923H69.7559V97.3296H71.9277V95.5923H73.5205V90.6694Z" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M177.478 90.6694H189.061V95.5923H187.468V97.3296H184.428V95.5923H181.242V97.3296H179.07V95.5923H177.478V90.6694Z" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M189.062 90.6694H177.479V95.5923H179.071V97.3296H182.111V95.5923H185.297V97.3296H187.469V95.5923H189.062V90.6694Z" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M61.9365 90.6694H73.5195V95.5923H71.9268V97.3296H68.8867V95.5923H65.7012V97.3296H63.5293V95.5923H61.9365V90.6694Z" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M154.312 402.109V413.692H149.389V412.099H147.651V409.059H149.389V405.874H147.651V403.702H149.389V402.109H154.312Z" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M154.312 237.05V248.633H149.389V247.041H147.651V244H149.389V240.815H147.651V238.643H149.389V237.05H154.312Z" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M154.312 329.281H142.729V334.204H144.322V335.941H147.362V334.204H150.548V335.941H152.72V334.204H154.312V329.281Z" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M154.312 164.222H142.729V169.145H144.322V170.882H147.362V169.145H150.548V170.882H152.72V169.145H154.312V164.222Z" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="98.5684" y="585.702" width="53.5718" height="3.47493" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="98.5684" y="591.493" width="53.5718" height="2.02704" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="98.5684" y="370.98" width="53.5718" height="2.02704" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="98.5684" y="205.921" width="53.5718" height="2.02704" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="101.03" y1="527.207" x2="101.03" y2="539.369" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M99.4688 543.857C115.738 535.6 134.97 535.6 151.239 543.857C134.97 552.114 115.738 552.114 99.4688 543.857Z" stroke="#62687C" stroke-width="0.289577"/>
+<mask id="path-1761-inside-1_2754_8800" fill="white">
+<path d="M151.851 540.817H151.559C151.656 540.768 151.754 540.721 151.851 540.671C135.246 532.257 115.643 532.208 99.0029 540.525V527.207H151.851V540.817Z"/>
+</mask>
+<path d="M151.851 540.817V541.106H152.14V540.817H151.851ZM151.559 540.817L151.429 540.558L151.559 541.106V540.817ZM151.851 540.671L151.981 540.93L152.491 540.671L151.981 540.413L151.851 540.671ZM99.0029 540.525H98.7134V540.993L99.1324 540.784L99.0029 540.525ZM99.0029 527.207V526.917H98.7134V527.207H99.0029ZM151.851 527.207H152.14V526.917H151.851V527.207ZM151.851 540.817V540.527H151.559V540.817V541.106H151.851V540.817ZM151.559 540.817L151.688 541.076C151.782 541.029 151.884 540.979 151.981 540.93L151.851 540.671L151.72 540.413C151.623 540.462 151.53 540.507 151.429 540.558L151.559 540.817ZM151.851 540.671L151.981 540.413C135.295 531.957 115.595 531.908 98.8735 540.266L99.0029 540.525L99.1324 540.784C115.69 532.508 135.197 532.556 151.72 540.93L151.851 540.671ZM99.0029 540.525H99.2925V527.207H99.0029H98.7134V540.525H99.0029ZM99.0029 527.207V527.496H151.851V527.207V526.917H99.0029V527.207ZM151.851 527.207H151.561V540.817H151.851H152.14V527.207H151.851Z" fill="#62687C" mask="url(#path-1761-inside-1_2754_8800)"/>
+<path d="M125.354 547.246C123.79 545.259 123.791 542.458 125.354 540.471C126.917 542.458 126.917 545.259 125.354 547.246Z" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="124.63" y1="543.857" x2="126.078" y2="543.857" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="124.92" y1="542.989" x2="125.789" y2="542.989" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="124.92" y1="544.726" x2="125.789" y2="544.726" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="125.209" y1="545.594" x2="125.499" y2="545.594" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="125.209" y1="542.12" x2="125.499" y2="542.12" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M132.014 547.246C130.45 545.259 130.451 542.458 132.014 540.471C133.577 542.458 133.577 545.259 132.014 547.246Z" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="131.29" y1="543.857" x2="132.738" y2="543.857" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="131.58" y1="542.989" x2="132.449" y2="542.989" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="131.58" y1="544.726" x2="132.449" y2="544.726" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="131.869" y1="545.594" x2="132.159" y2="545.594" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="131.869" y1="542.12" x2="132.159" y2="542.12" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M138.675 547.246C137.112 545.259 137.112 542.458 138.675 540.471C140.238 542.458 140.239 545.259 138.675 547.246Z" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="137.951" y1="543.857" x2="139.399" y2="543.857" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="138.241" y1="542.989" x2="139.11" y2="542.989" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="138.241" y1="544.726" x2="139.11" y2="544.726" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="138.53" y1="545.594" x2="138.82" y2="545.594" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="138.53" y1="542.12" x2="138.82" y2="542.12" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M118.693 547.246C117.13 545.259 117.13 542.458 118.693 540.471C120.257 542.458 120.257 545.259 118.693 547.246Z" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="117.97" y1="543.857" x2="119.418" y2="543.857" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="118.26" y1="542.989" x2="119.128" y2="542.989" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="118.26" y1="544.726" x2="119.128" y2="544.726" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="118.549" y1="545.594" x2="118.838" y2="545.594" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="118.549" y1="542.12" x2="118.838" y2="542.12" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M112.033 547.246C110.47 545.259 110.47 542.458 112.033 540.471C113.597 542.458 113.597 545.259 112.033 547.246Z" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="111.31" y1="543.857" x2="112.757" y2="543.857" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="111.6" y1="542.989" x2="112.468" y2="542.989" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="111.6" y1="544.726" x2="112.468" y2="544.726" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="111.889" y1="545.594" x2="112.178" y2="545.594" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="111.889" y1="542.12" x2="112.178" y2="542.12" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M150.113 527.207V539.659" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M91.3604 313.268C112.666 302.454 137.853 302.455 159.158 313.268C137.852 324.081 112.666 324.081 91.3604 313.268Z" stroke="#62687C" stroke-width="0.379227"/>
+<mask id="path-1795-inside-2_2754_8800" fill="white">
+<path d="M159.959 309.285H159.578C159.705 309.222 159.833 309.16 159.959 309.096C138.213 298.076 112.542 298.013 90.75 308.904V291.462H159.959V309.285Z"/>
+</mask>
+<path d="M159.959 309.285V309.664H160.338V309.285H159.959ZM159.578 309.285L159.409 308.946L159.578 309.664V309.285ZM159.959 309.096L160.13 309.434L160.798 309.096L160.13 308.757L159.959 309.096ZM90.75 308.904H90.3708V309.518L90.9195 309.244L90.75 308.904ZM90.75 291.462V291.083H90.3708V291.462H90.75ZM159.959 291.462H160.338V291.083H159.959V291.462ZM159.959 309.285V308.906H159.578V309.285V309.664H159.959V309.285ZM159.578 309.285L159.748 309.624C159.868 309.564 160.004 309.498 160.13 309.434L159.959 309.096L159.788 308.757C159.661 308.822 159.542 308.879 159.409 308.946L159.578 309.285ZM159.959 309.096L160.13 308.757C138.277 297.683 112.479 297.62 90.5805 308.565L90.75 308.904L90.9195 309.244C112.604 298.406 138.149 298.468 159.788 309.434L159.959 309.096ZM90.75 308.904H91.1292V291.462H90.75H90.3708V308.904H90.75ZM90.75 291.462V291.841H159.959V291.462V291.083H90.75V291.462ZM159.959 291.462H159.58V309.285H159.959H160.338V291.462H159.959Z" fill="#62687C" mask="url(#path-1795-inside-2_2754_8800)"/>
+<path d="M125.259 317.706C123.211 315.103 123.212 311.434 125.259 308.832C127.306 311.434 127.307 315.103 125.259 317.706Z" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="124.312" y1="313.268" x2="126.208" y2="313.268" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="124.69" y1="312.131" x2="125.828" y2="312.131" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="124.69" y1="314.406" x2="125.828" y2="314.406" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="125.069" y1="315.543" x2="125.449" y2="315.543" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="125.069" y1="310.993" x2="125.449" y2="310.993" stroke="#62687C" stroke-width="0.379227"/>
+<path d="M133.981 317.706C131.934 315.103 131.934 311.434 133.981 308.832C136.029 311.434 136.03 315.103 133.981 317.706Z" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="133.033" y1="313.268" x2="134.929" y2="313.268" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="133.413" y1="312.131" x2="134.551" y2="312.131" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="133.413" y1="314.406" x2="134.551" y2="314.406" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="133.792" y1="315.543" x2="134.171" y2="315.543" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="133.792" y1="310.993" x2="134.171" y2="310.993" stroke="#62687C" stroke-width="0.379227"/>
+<path d="M142.704 317.706C140.656 315.103 140.657 311.434 142.704 308.832C144.752 311.434 144.752 315.103 142.704 317.706Z" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="141.756" y1="313.268" x2="143.652" y2="313.268" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="142.136" y1="312.131" x2="143.273" y2="312.131" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="142.136" y1="314.406" x2="143.273" y2="314.406" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="142.515" y1="315.543" x2="142.894" y2="315.543" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="142.515" y1="310.993" x2="142.894" y2="310.993" stroke="#62687C" stroke-width="0.379227"/>
+<path d="M116.537 317.706C114.489 315.103 114.49 311.434 116.537 308.832C118.585 311.434 118.585 315.103 116.537 317.706Z" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="115.59" y1="313.268" x2="117.486" y2="313.268" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="115.969" y1="312.131" x2="117.106" y2="312.131" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="115.969" y1="314.406" x2="117.106" y2="314.406" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="116.348" y1="315.543" x2="116.727" y2="315.543" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="116.348" y1="310.993" x2="116.727" y2="310.993" stroke="#62687C" stroke-width="0.379227"/>
+<path d="M107.814 317.706C105.767 315.103 105.767 311.434 107.814 308.832C109.862 311.434 109.863 315.103 107.814 317.706Z" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="106.866" y1="313.268" x2="108.762" y2="313.268" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="107.246" y1="312.131" x2="108.384" y2="312.131" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="107.246" y1="314.406" x2="108.384" y2="314.406" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="107.625" y1="315.543" x2="108.004" y2="315.543" stroke="#62687C" stroke-width="0.379227"/>
+<line x1="107.625" y1="310.993" x2="108.004" y2="310.993" stroke="#62687C" stroke-width="0.379227"/>
+<path d="M157.684 291.462V307.769" stroke="#62687C" stroke-width="0.379227"/>
+<path d="M79.0781 137.448C108.785 122.371 143.903 122.371 173.61 137.448C143.903 152.525 108.785 152.525 79.0781 137.448Z" stroke="#62687C" stroke-width="0.528769"/>
+<mask id="path-1829-inside-3_2754_8800" fill="white">
+<path d="M174.727 131.896H174.194C174.371 131.807 174.55 131.721 174.727 131.631C144.406 116.266 108.611 116.178 78.2266 131.364V107.043H174.727V131.896Z"/>
+</mask>
+<path d="M174.727 131.896V132.186H175.016V131.896H174.727ZM174.194 131.896L174.065 131.637L174.194 132.186V131.896ZM174.727 131.631L174.857 131.89L175.367 131.631L174.857 131.373L174.727 131.631ZM78.2266 131.364H77.937V131.832L78.356 131.623L78.2266 131.364ZM78.2266 107.043V106.754H77.937V107.043H78.2266ZM174.727 107.043H175.016V106.754H174.727V107.043ZM174.727 131.896V131.606H174.194V131.896V132.186H174.727V131.896ZM174.194 131.896L174.324 132.155C174.496 132.069 174.681 131.979 174.857 131.89L174.727 131.631L174.596 131.373C174.419 131.463 174.247 131.546 174.065 131.637L174.194 131.896ZM174.727 131.631L174.857 131.373C144.455 115.966 108.564 115.878 78.0971 131.105L78.2266 131.364L78.356 131.623C108.659 116.478 144.357 116.565 174.596 131.89L174.727 131.631ZM78.2266 131.364H78.5161V107.043H78.2266H77.937V131.364H78.2266ZM78.2266 107.043V107.333H174.727V107.043V106.754H78.2266V107.043ZM174.727 107.043H174.437V131.896H174.727H175.016V107.043H174.727Z" fill="#62687C" mask="url(#path-1829-inside-3_2754_8800)"/>
+<path d="M126.344 143.636C123.488 140.008 123.489 134.891 126.344 131.262C129.199 134.891 129.2 140.008 126.344 143.636Z" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="125.022" y1="137.448" x2="127.666" y2="137.448" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="125.551" y1="135.863" x2="127.137" y2="135.863" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="125.551" y1="139.035" x2="127.137" y2="139.035" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="126.08" y1="140.621" x2="126.609" y2="140.621" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="126.08" y1="134.276" x2="126.609" y2="134.276" stroke="#62687C" stroke-width="0.528769"/>
+<path d="M138.506 143.636C135.65 140.008 135.651 134.891 138.506 131.262C141.361 134.891 141.362 140.008 138.506 143.636Z" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="137.185" y1="137.448" x2="139.828" y2="137.448" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="137.713" y1="135.863" x2="139.299" y2="135.863" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="137.713" y1="139.035" x2="139.299" y2="139.035" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="138.242" y1="140.621" x2="138.771" y2="140.621" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="138.242" y1="134.276" x2="138.771" y2="134.276" stroke="#62687C" stroke-width="0.528769"/>
+<path d="M150.667 143.636C147.812 140.008 147.812 134.891 150.667 131.262C153.522 134.891 153.523 140.008 150.667 143.636Z" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="149.346" y1="137.448" x2="151.99" y2="137.448" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="149.874" y1="135.863" x2="151.46" y2="135.863" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="149.874" y1="139.035" x2="151.46" y2="139.035" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="150.403" y1="140.621" x2="150.932" y2="140.621" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="150.403" y1="134.276" x2="150.932" y2="134.276" stroke="#62687C" stroke-width="0.528769"/>
+<path d="M114.183 143.636C111.327 140.008 111.328 134.891 114.183 131.262C117.038 134.891 117.038 140.008 114.183 143.636Z" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="112.861" y1="137.448" x2="115.505" y2="137.448" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="113.39" y1="135.863" x2="114.976" y2="135.863" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="113.39" y1="139.035" x2="114.976" y2="139.035" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="113.919" y1="140.621" x2="114.448" y2="140.621" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="113.919" y1="134.276" x2="114.448" y2="134.276" stroke="#62687C" stroke-width="0.528769"/>
+<path d="M102.021 143.636C99.1651 140.008 99.1655 134.891 102.021 131.262C104.876 134.891 104.876 140.008 102.021 143.636Z" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="100.699" y1="137.448" x2="103.343" y2="137.448" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="101.228" y1="135.863" x2="102.814" y2="135.863" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="101.228" y1="139.035" x2="102.814" y2="139.035" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="101.757" y1="140.621" x2="102.286" y2="140.621" stroke="#62687C" stroke-width="0.528769"/>
+<line x1="101.757" y1="134.276" x2="102.286" y2="134.276" stroke="#62687C" stroke-width="0.528769"/>
+<path d="M171.554 107.044V129.781" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="81.0481" y="109.782" width="5.45875" height="10.7144" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="84.3323" y="113.559" width="5.45875" height="3.15942" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M99.1475 450.903H102.567C103.001 450.903 103.431 450.985 103.835 451.146C104.827 451.54 105.945 451.451 106.862 450.904L107.509 450.518C108.91 449.682 110.652 449.664 112.071 450.47C112.575 450.756 113.128 450.943 113.702 451.021L117.56 451.544C118.674 451.695 119.803 451.683 120.913 451.509L122.556 451.251C124.018 451.021 125.512 451.087 126.949 451.444C127.824 451.662 128.722 451.772 129.623 451.772H132.056C133.471 451.772 134.848 451.315 135.982 450.469C137.117 449.623 138.494 449.166 139.909 449.166H141.564C142.759 449.166 143.92 449.564 144.863 450.298C146.068 451.236 147.615 451.616 149.118 451.345L151.561 450.903" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M84.6689 436.28H89.9402C90.6471 436.28 91.3409 436.471 91.9483 436.832C93.4209 437.71 95.2925 437.53 96.5707 436.387L97.6281 435.442C99.6909 433.599 102.798 433.562 104.904 435.355C105.617 435.961 106.473 436.377 107.39 436.564L113.485 437.802C115.124 438.134 116.815 438.109 118.442 437.726L121.182 437.082C123.406 436.559 125.734 436.705 127.875 437.502L128.081 437.579C129.374 438.06 130.743 438.307 132.123 438.307H135.255C137.852 438.307 140.326 437.201 142.058 435.266C143.79 433.331 146.264 432.226 148.861 432.226H150.251C152.394 432.226 154.43 433.161 155.825 434.788C157.669 436.938 160.585 437.835 163.319 437.095L166.33 436.28" stroke="#62687C" stroke-width="0.289577"/>
+<path d="M70.1895 271.221H77.3911C78.3157 271.221 79.2301 271.413 80.0765 271.785C82.1498 272.697 84.5443 272.494 86.4349 271.247L87.8183 270.334C90.7428 268.405 94.5251 268.363 97.4917 270.227C98.5348 270.882 99.702 271.315 100.92 271.498L110.74 272.97C111.968 273.154 113.216 273.139 114.439 272.927L121.717 271.664C123.398 271.372 125.123 271.455 126.768 271.907L130.137 272.833C131.137 273.108 132.17 273.248 133.207 273.248H140.083C142.772 273.248 145.377 272.312 147.452 270.601L148.408 269.813C150.482 268.102 153.088 267.167 155.777 267.167H159.573C162.172 267.167 164.684 268.099 166.653 269.793C169.187 271.973 172.584 272.865 175.861 272.209L180.808 271.221" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="-0.144789" y="0.144789" width="9.84563" height="19.1121" transform="matrix(-1 0 0 1 180.519 167.551)" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="-0.144789" y="0.144789" width="9.84563" height="5.79155" transform="matrix(-1 0 0 1 174.727 174.211)" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="162.71" y="167.696" width="9.84563" height="19.1121" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="168.501" y="174.356" width="9.84563" height="5.79155" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="-0.144789" y="0.144789" width="9.84563" height="19.1121" transform="matrix(-1 0 0 1 87.9985 167.551)" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="-0.144789" y="0.144789" width="9.84563" height="5.79155" transform="matrix(-1 0 0 1 82.2065 174.211)" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="70.1897" y="167.696" width="9.84563" height="19.1121" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="75.9807" y="174.356" width="9.84563" height="5.79155" stroke="#62687C" stroke-width="0.289577"/>
+<rect x="54.1448" y="75.1448" width="139.71" height="15.7104" fill="white" stroke="#62687C" stroke-width="0.289577"/>
+<g clip-path="url(#clip28_2754_8800)">
+<line x1="167.096" y1="90.7111" x2="182.733" y2="75.0744" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="173.466" y1="90.7111" x2="189.103" y2="75.0744" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="179.836" y1="90.7111" x2="195.473" y2="75.0744" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="186.206" y1="90.7111" x2="201.843" y2="75.0744" stroke="#62687C" stroke-width="0.289577"/>
+<line x1="192.576" y1="90.7111" x2="208.213" y2="75.0744" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+<g clip-path="url(#clip29_2754_8800)">
+<line y1="-0.144789" x2="22.1136" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 81.1934 90.8135)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="22.1136" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 74.8232 90.8135)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="22.1136" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 68.4531 90.8135)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="22.1136" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 62.083 90.8135)" stroke="#62687C" stroke-width="0.289577"/>
+<line y1="-0.144789" x2="22.1136" y2="-0.144789" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 55.7129 90.8135)" stroke="#62687C" stroke-width="0.289577"/>
+</g>
+</g>
+</g>
+<defs>
+<clipPath id="clip0_2754_8800">
+<rect width="246" height="628" fill="white"/>
+</clipPath>
+<clipPath id="clip1_2754_8800">
+<rect width="375" height="591.176" fill="white" transform="translate(-181 37.4116)"/>
+</clipPath>
+<clipPath id="clip2_2754_8800">
+<rect x="154.167" y="450.758" width="5.9381" height="145.271" fill="white"/>
+</clipPath>
+<clipPath id="clip3_2754_8800">
+<rect x="151.561" y="450.758" width="5.9381" height="145.271" fill="white"/>
+</clipPath>
+<clipPath id="clip4_2754_8800">
+<rect width="5.9381" height="145.271" transform="matrix(-1 0 0 1 96.6875 450.758)" fill="white"/>
+</clipPath>
+<clipPath id="clip5_2754_8800">
+<rect width="6.08112" height="38.5138" transform="matrix(-1 0 0 1 108.414 332.611)" fill="white"/>
+</clipPath>
+<clipPath id="clip6_2754_8800">
+<rect width="6.08112" height="38.5138" transform="matrix(-1 0 0 1 108.414 167.552)" fill="white"/>
+</clipPath>
+<clipPath id="clip7_2754_8800">
+<rect x="142.584" y="332.611" width="6.08112" height="38.5138" fill="white"/>
+</clipPath>
+<clipPath id="clip8_2754_8800">
+<rect x="142.584" y="167.552" width="6.08112" height="38.5138" fill="white"/>
+</clipPath>
+<clipPath id="clip9_2754_8800">
+<rect x="163.724" y="557.612" width="6.08112" height="38.5138" rx="3.04056" fill="white"/>
+</clipPath>
+<clipPath id="clip10_2754_8800">
+<rect width="6.08112" height="38.5138" rx="3.04056" transform="matrix(-1 0 0 1 87.2744 557.612)" fill="white"/>
+</clipPath>
+<clipPath id="clip11_2754_8800">
+<rect width="6.08112" height="38.5138" rx="3.04056" transform="matrix(-1 0 0 1 83.5107 217.649)" fill="white"/>
+</clipPath>
+<clipPath id="clip12_2754_8800">
+<rect x="167.198" y="217.649" width="6.08112" height="38.5138" rx="3.04056" fill="white"/>
+</clipPath>
+<clipPath id="clip13_2754_8800">
+<rect width="5.79155" height="35.3284" transform="matrix(0 -1 -1 0 141.715 585.702)" fill="white"/>
+</clipPath>
+<clipPath id="clip14_2754_8800">
+<rect width="2.61081" height="31.7314" transform="matrix(0 -1 -1 0 141.416 591.628)" fill="white"/>
+</clipPath>
+<clipPath id="clip15_2754_8800">
+<rect width="5.9381" height="145.271" transform="matrix(-1 0 0 1 99.2939 450.758)" fill="white"/>
+</clipPath>
+<clipPath id="clip16_2754_8800">
+<rect width="5.9381" height="145.271" transform="matrix(-1 0 0 1 174.584 291.491)" fill="white"/>
+</clipPath>
+<clipPath id="clip17_2754_8800">
+<rect width="5.9381" height="145.271" transform="matrix(-1 0 0 1 171.979 291.491)" fill="white"/>
+</clipPath>
+<clipPath id="clip18_2754_8800">
+<rect width="5.9381" height="145.271" transform="matrix(-1 0 0 1 189.062 126.432)" fill="white"/>
+</clipPath>
+<clipPath id="clip19_2754_8800">
+<rect width="5.9381" height="145.271" transform="matrix(-1 0 0 1 186.457 126.432)" fill="white"/>
+</clipPath>
+<clipPath id="clip20_2754_8800">
+<rect x="78.877" y="291.491" width="5.9381" height="145.271" fill="white"/>
+</clipPath>
+<clipPath id="clip21_2754_8800">
+<rect x="76.2705" y="291.491" width="5.9381" height="145.271" fill="white"/>
+</clipPath>
+<clipPath id="clip22_2754_8800">
+<rect x="90.749" y="329.137" width="5.9381" height="100.097" fill="white"/>
+</clipPath>
+<clipPath id="clip23_2754_8800">
+<rect width="5.9381" height="100.097" transform="matrix(-1 0 0 1 160.104 329.137)" fill="white"/>
+</clipPath>
+<clipPath id="clip24_2754_8800">
+<rect x="64.3984" y="126.432" width="5.9381" height="145.271" fill="white"/>
+</clipPath>
+<clipPath id="clip25_2754_8800">
+<rect x="61.792" y="126.432" width="5.9381" height="145.271" fill="white"/>
+</clipPath>
+<clipPath id="clip26_2754_8800">
+<rect x="90.75" y="164.077" width="5.9381" height="100.097" fill="white"/>
+</clipPath>
+<clipPath id="clip27_2754_8800">
+<rect width="5.9381" height="100.097" transform="matrix(-1 0 0 1 160.105 164.077)" fill="white"/>
+</clipPath>
+<clipPath id="clip28_2754_8800">
+<rect width="27.2203" height="16.2163" fill="white" transform="translate(167.198 74.8872)"/>
+</clipPath>
+<clipPath id="clip29_2754_8800">
+<rect width="27.2203" height="16.2163" fill="white" transform="matrix(-1 0 0 1 81.1934 74.8872)"/>
+</clipPath>
+</defs>
+</svg>

--- a/frontend/src/container/Home/Home.tsx
+++ b/frontend/src/container/Home/Home.tsx
@@ -15,6 +15,7 @@ import ROUTES from 'constants/routes';
 import { getMetricsListQuery } from 'container/MetricsExplorer/Summary/utils';
 import { useGetMetricsList } from 'hooks/metricsExplorer/useGetMetricsList';
 import { useGetQueryRange } from 'hooks/queryBuilder/useGetQueryRange';
+import { useIsDarkMode } from 'hooks/useDarkMode';
 import history from 'lib/history';
 import cloneDeep from 'lodash-es/cloneDeep';
 import { AnimatePresence } from 'motion/react';
@@ -43,6 +44,7 @@ const homeInterval = 30 * 60 * 1000;
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export default function Home(): JSX.Element {
 	const { user } = useAppContext();
+	const isDarkMode = useIsDarkMode();
 
 	const [startTime, setStartTime] = useState<number | null>(null);
 	const [endTime, setEndTime] = useState<number | null>(null);
@@ -680,7 +682,11 @@ export default function Home(): JSX.Element {
 
 												<div className="checklist-img-container">
 													<img
-														src="/Images/allInOne.svg"
+														src={
+															isDarkMode
+																? '/Images/allInOne.svg'
+																: '/Images/allInOneLightMode.svg'
+														}
 														alt="checklist-img"
 														className="checklist-img"
 													/>


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The welcome checklist on the Home page was using the dark-mode `allInOne.svg` illustration in both light and dark themes. In light mode, this caused poor contrast and visibility. This PR adds a dedicated `allInOneLightMode.svg` asset and switches the Home component to use the appropriate illustration based on the current theme.


#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. Helps reviewers quickly understand the impact and verify the update.

_Add before/after screenshots of the welcome checklist in light mode._


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
The welcome checklist illustration was hardcoded to use `allInOne.svg`, which is optimized for dark backgrounds. In light mode, the illustration did not provide sufficient contrast.

#### Fix Strategy
Added `allInOneLightMode.svg` optimized for light backgrounds and updated `Home.tsx` to select the illustration based on `isDarkMode` (dark mode → `allInOne.svg`, light mode → `allInOneLightMode.svg`).

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A (UI-only change)
- Manual verification: Toggle between light and dark mode on the Home page; verify the welcome checklist shows the correct illustration for each theme.
- Edge cases covered: Theme switch while on Home page.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Home page welcome checklist only
- Potential regressions: None expected; additive change with conditional rendering
- Rollback plan: Revert to single SVG if needed

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Welcome checklist now shows a light-mode-optimized illustration when using light theme |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
