### PR TITLE
chore: send slack notification on dequeue only and not merge

### DIFF
--- a/.github/workflows/mergequeueci.yaml
+++ b/.github/workflows/mergequeueci.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == false
     steps:
       - name: alert
         uses: slackapi/slack-github-action@v2.1.1


### PR DESCRIPTION
### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Slack notification was set up on dequeue workflow triggers. This also sent out notification for PRs being merged successfully to main. This PR only sends notification on dequeue scenario other than merge to main.