### PR TITLE
fix(frontend/vite): avoid inlining whole process.env into bundle

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,8 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import react from '@vitejs/plugin-react';
-import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { visualizer } from 'rollup-plugin-visualizer';
-import type { Plugin, UserConfig } from 'vite';
+import type { Plugin, TransformResult, UserConfig } from 'vite';
 import { defineConfig, loadEnv } from 'vite';
 import vitePluginChecker from 'vite-plugin-checker';
 import viteCompression from 'vite-plugin-compression';
@@ -14,15 +13,14 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 function rawMarkdownPlugin(): Plugin {
 	return {
 		name: 'raw-markdown',
-		transform(_, id): any {
-			if (id.endsWith('.md')) {
-				const content = readFileSync(id, 'utf-8');
-				return {
-					code: `export default ${JSON.stringify(content)};`,
-					map: null,
-				};
+		transform(code, id): TransformResult | undefined {
+			if (!id.endsWith('.md')) {
+				return undefined;
 			}
-			return undefined;
+			return {
+				code: `export default ${JSON.stringify(code)};`,
+				map: null,
+			};
 		},
 	};
 }
@@ -71,7 +69,7 @@ export default defineConfig(
 			);
 		}
 
-		if (env.NODE_ENV === 'production') {
+		if (mode === 'production') {
 			plugins.push(
 				ViteImageOptimizer({
 					jpeg: { quality: 80 },
@@ -102,22 +100,25 @@ export default defineConfig(
 			},
 			define: {
 				// TODO: Remove this in favor of import.meta.env
-				'process.env': JSON.stringify({
-					NODE_ENV: mode,
-					FRONTEND_API_ENDPOINT: env.VITE_FRONTEND_API_ENDPOINT,
-					WEBSOCKET_API_ENDPOINT: env.VITE_WEBSOCKET_API_ENDPOINT,
-					PYLON_APP_ID: env.VITE_PYLON_APP_ID,
-					PYLON_IDENTITY_SECRET: env.VITE_PYLON_IDENTITY_SECRET,
-					APPCUES_APP_ID: env.VITE_APPCUES_APP_ID,
-					POSTHOG_KEY: env.VITE_POSTHOG_KEY,
-					SENTRY_AUTH_TOKEN: env.VITE_SENTRY_AUTH_TOKEN,
-					SENTRY_ORG: env.VITE_SENTRY_ORG,
-					SENTRY_PROJECT_ID: env.VITE_SENTRY_PROJECT_ID,
-					SENTRY_DSN: env.VITE_SENTRY_DSN,
-					TUNNEL_URL: env.VITE_TUNNEL_URL,
-					TUNNEL_DOMAIN: env.VITE_TUNNEL_DOMAIN,
-					DOCS_BASE_URL: env.VITE_DOCS_BASE_URL,
-				}),
+				'process.env.NODE_ENV': JSON.stringify(mode),
+				'process.env.FRONTEND_API_ENDPOINT': JSON.stringify(
+					env.VITE_FRONTEND_API_ENDPOINT,
+				),
+				'process.env.WEBSOCKET_API_ENDPOINT': JSON.stringify(
+					env.VITE_WEBSOCKET_API_ENDPOINT,
+				),
+				'process.env.PYLON_APP_ID': JSON.stringify(env.VITE_PYLON_APP_ID),
+				'process.env.PYLON_IDENTITY_SECRET': JSON.stringify(
+					env.VITE_PYLON_IDENTITY_SECRET,
+				),
+				'process.env.APPCUES_APP_ID': JSON.stringify(env.VITE_APPCUES_APP_ID),
+				'process.env.POSTHOG_KEY': JSON.stringify(env.VITE_POSTHOG_KEY),
+				'process.env.SENTRY_ORG': JSON.stringify(env.VITE_SENTRY_ORG),
+				'process.env.SENTRY_PROJECT_ID': JSON.stringify(env.VITE_SENTRY_PROJECT_ID),
+				'process.env.SENTRY_DSN': JSON.stringify(env.VITE_SENTRY_DSN),
+				'process.env.TUNNEL_URL': JSON.stringify(env.VITE_TUNNEL_URL),
+				'process.env.TUNNEL_DOMAIN': JSON.stringify(env.VITE_TUNNEL_DOMAIN),
+				'process.env.DOCS_BASE_URL': JSON.stringify(env.VITE_DOCS_BASE_URL),
 			},
 			build: {
 				sourcemap: true,


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  

- Build-time environment variables were being unintentionally inlined into the production JavaScript bundle, exposing secrets and unnecessary configuration to users. This PR fixes that by restructuring how `process.env`  variables are defined in the Vite config.

- Additionally, the Vite config was using runtime environment variables (process.env.NODE_ENV) to control build behavior instead of Vite's native mode parameter.

> What problem does it solve, and why is this the right approach?

Previously, we were using 'process.env': JSON.stringify({...all env vars...}) which caused the entire object to be embedded as a single string literal wherever process.env was referenced. This meant any build-time secret (like SENTRY_AUTH_TOKEN or PYLON_IDENTITY_SECRET) leaked into multiple chunks.

The fix replaces this with explicit per-key definitions: 'process.env.KEY': JSON.stringify(value). This allows the bundler to:

- Tree-shake unused variables
- Inline only the keys actually referenced in the code
- Keep build-time secrets out of the final bundle

Additionally, I:

- Remove SENTRY_AUTH_TOKEN from client defines entirely (it's build-time only)
- Fix rawMarkdownPlugin to use Vite's transform(code, id) parameter instead of redundant disk reads 
-  Used mode for production checks: Changed the plugin loading guard from if (env.NODE_ENV === 'production') to if (mode === 'production'). 
  This:
    - Aligns with Vite best practices
    - Uses the intended Vite API for mode differentiation

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

| Before  (inlined entire object)              | After    (only the keys actually referenced)                | 
| ----------------------- | -------------------------- | 
|   <img width="1710" height="1090" alt="Screenshot 2026-03-17 at 2 53 51 AM" src="https://github.com/user-attachments/assets/f59e05ce-09c3-4189-982a-e8d81742cce1" /> |   <img width="1710" height="1037" alt="Screenshot 2026-03-17 at 3 21 08 AM" src="https://github.com/user-attachments/assets/f2b42734-4b5d-43c0-bf03-2c59a219c536" /> | 

---

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  

The Vite define config was stringifying the entire process.env object instead of individual keys. When the bundler resolved process.env.KEY references, it inlined the full object as a string blob everywhere, even for keys that weren't used. Verified: a test secret appeared 5 times across 2 chunks in the old bundle.

> Regression, faulty assumption, edge case, refactor, etc.

#### Fix Strategy
> How does this PR address the root cause?

- Per-key defines: Replace 'process.env': JSON.stringify({...}) with individual entries like 'process.env.NODE_ENV': JSON.stringify(mode). The bundler only inlines keys that are actually referenced.

addition made a couple of changes also:
- Remove SENTRY_AUTH_TOKEN: This token is only used at build time (uploading sourcemaps to Sentry). It should never reach the browser. Removed from define entirely.
 - rawMarkdownPlugin cleanup: Vite's transform(code, id) already provides the file content as the first argument. The old code ignored it and did readFileSync(id, 'utf-8') redundantly. Now uses the code param directly.
- Changed the plugin loading guard from if (env.NODE_ENV === 'production') to if (mode === 'production')
---

### 🧪 Testing Strategy
> How was this change validated?
- Manual verification:
I manual verified the change -  Ran yarn build with test .env values, inspected chunks with grep to confirm secrets were removed
TypeScript check: Ran npx tsc --noEmit — no new errors introduced
Bundle inspection: Verified that the per-key define approach correctly tree-shakes unused variables

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Frontend build artifacts. No impact to backend, API, or runtime behavior.

- Potential regressions:
  - If any code was relying on process.env as a full object (unlikely, since it's an anti-pattern), it will break. Grep search   confirmed no such usage in codebase.
 - Runtime behavior unchanged: all keys defined in define are still available where used.

- Rollback plan:
  - Revert this PR; rebuild. The old define object will be restored.
---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise (All) |
| Change Type | Bug Fix  |
| Description | Fixed build-time secret leakage: Restructured Vite process.env defines to prevent entire object inlining into bundle. Removed unused SENTRY_AUTH_TOKEN from client code. Improved rawMarkdownPlugin to use Vite's code parameter. No user-facing behavior changes. |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

- `PYLON_IDENTITY_SECRET` -  This secret is still in the bundle because it's used for HMAC signing in AppRoutes/index.tsx:258. This is a separate security issue (HMAC should be computed server-side, not in browser). A follow-up issue should be created to move this computation to the backend. (e.g. GET /api/pylon-identity-hash) so the secret never leaves the server.


<!-- Anything reviewers should keep in mind while reviewing -->

---
