### PR TITLE
fix: adding migration to fix wrong index on cloud integration table

### DIFF
--- a/pkg/query-service/app/cloudintegrations/accountsRepo.go
+++ b/pkg/query-service/app/cloudintegrations/accountsRepo.go
@@ -177,7 +177,7 @@ func (r *cloudProviderAccountsSQLRepository) upsert(
 	onConflictClause := ""
 	if len(onConflictSetStmts) > 0 {
 		onConflictClause = fmt.Sprintf(
-			"conflict(id, provider, org_id) do update SET\n%s",
+			"conflict(id) do update SET\n%s",
 			strings.Join(onConflictSetStmts, ",\n"),
 		)
 	}
@@ -202,6 +202,8 @@ func (r *cloudProviderAccountsSQLRepository) upsert(
 		Exec(ctx)
 
 	if dbErr != nil {
+		// for now returning internal error even if there is a conflict,
+		// will be handled better in the future iteration
 		return nil, model.InternalError(fmt.Errorf(
 			"could not upsert cloud account record: %w", dbErr,
 		))

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -175,7 +175,7 @@ func NewSQLMigrationProviderFactories(
 		sqlmigration.NewMigrateRulesV4ToV5Factory(sqlstore, telemetryStore),
 		sqlmigration.NewAddStatusUserFactory(sqlstore, sqlschema),
 		sqlmigration.NewDeprecateUserInviteFactory(sqlstore, sqlschema),
-		sqlmigration.NewFixCloudIntegrationUniqueIndexFactory(sqlstore, sqlschema),
+		sqlmigration.NewUpdateCloudIntegrationUniqueIndexFactory(sqlstore, sqlschema),
 	)
 }
 

--- a/pkg/sqlmigration/069_update_cloud_integration_index.go
+++ b/pkg/sqlmigration/069_update_cloud_integration_index.go
@@ -14,16 +14,16 @@ import (
 	"github.com/uptrace/bun/migrate"
 )
 
-type fixCloudIntegrationUniqueIndex struct {
+type updateCloudIntegrationUniqueIndex struct {
 	sqlstore  sqlstore.SQLStore
 	sqlschema sqlschema.SQLSchema
 }
 
-func NewFixCloudIntegrationUniqueIndexFactory(sqlstore sqlstore.SQLStore, sqlschema sqlschema.SQLSchema) factory.ProviderFactory[SQLMigration, Config] {
+func NewUpdateCloudIntegrationUniqueIndexFactory(sqlstore sqlstore.SQLStore, sqlschema sqlschema.SQLSchema) factory.ProviderFactory[SQLMigration, Config] {
 	return factory.NewProviderFactory(
-		factory.MustNewName("fix_cloud_integration_index"),
+		factory.MustNewName("update_cloud_integration_index"),
 		func(ctx context.Context, ps factory.ProviderSettings, c Config) (SQLMigration, error) {
-			return &fixCloudIntegrationUniqueIndex{
+			return &updateCloudIntegrationUniqueIndex{
 				sqlstore:  sqlstore,
 				sqlschema: sqlschema,
 			}, nil
@@ -31,7 +31,7 @@ func NewFixCloudIntegrationUniqueIndexFactory(sqlstore sqlstore.SQLStore, sqlsch
 	)
 }
 
-func (migration *fixCloudIntegrationUniqueIndex) Register(migrations *migrate.Migrations) error {
+func (migration *updateCloudIntegrationUniqueIndex) Register(migrations *migrate.Migrations) error {
 	if err := migrations.Register(migration.Up, migration.Down); err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ type duplicateGroup struct {
 	losers []*cloudIntegrationRow
 }
 
-func (migration *fixCloudIntegrationUniqueIndex) Up(ctx context.Context, db *bun.DB) error {
+func (migration *updateCloudIntegrationUniqueIndex) Up(ctx context.Context, db *bun.DB) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -69,6 +69,8 @@ func (migration *fixCloudIntegrationUniqueIndex) Up(ctx context.Context, db *bun
 		_ = tx.Rollback()
 	}()
 
+	sqls := [][]byte{}
+
 	// Step 1: Drop the wrong index on (id, provider, org_id)
 	dropSqls := migration.sqlschema.Operator().DropIndex(
 		(&sqlschema.UniqueIndex{
@@ -76,11 +78,7 @@ func (migration *fixCloudIntegrationUniqueIndex) Up(ctx context.Context, db *bun
 			ColumnNames: []sqlschema.ColumnName{"id", "provider", "org_id"},
 		}).Named("unique_cloud_integration"),
 	)
-	for _, sql := range dropSqls {
-		if _, err := tx.ExecContext(ctx, string(sql)); err != nil {
-			return err
-		}
-	}
+	sqls = append(sqls, dropSqls...)
 
 	// Step 2: Normalize empty-string account_id to NULL
 	// Older table structure could store "" instead of NULL for unconnected accounts.
@@ -122,28 +120,19 @@ func (migration *fixCloudIntegrationUniqueIndex) Up(ctx context.Context, db *bun
 			return err
 		}
 
-		// Step 5: Reassign orphaned cloud_integration_service rows
+		// Step 5: Reassign non-conflicting cloud_integration_service rows to keeper
 		for _, loser := range group.losers {
-			// Delete services from loser that would conflict with keeper's services (same type)
-			_, err = tx.NewDelete().
+			_, err = tx.NewUpdate().
 				TableExpr("cloud_integration_service").
+				Set("cloud_integration_id = ?", group.keeper.ID).
 				Where("cloud_integration_id = ?", loser.ID).
-				Where("type IN (?)",
+				Where("type NOT IN (?)",
 					tx.NewSelect().
 						TableExpr("cloud_integration_service").
 						Column("type").
 						Where("cloud_integration_id = ?", group.keeper.ID),
 				).
 				Exec(ctx)
-			if err != nil {
-				return err
-			}
-
-			// Reassign remaining services to the keeper
-			_, err = tx.ExecContext(ctx,
-				"UPDATE cloud_integration_service SET cloud_integration_id = ? WHERE cloud_integration_id = ?",
-				group.keeper.ID, loser.ID,
-			)
 			if err != nil {
 				return err
 			}
@@ -173,7 +162,9 @@ func (migration *fixCloudIntegrationUniqueIndex) Up(ctx context.Context, db *bun
 			Where:       "removed_at IS NULL",
 		},
 	)
-	for _, sql := range createSqls {
+	sqls = append(sqls, createSqls...)
+
+	for _, sql := range sqls {
 		if _, err = tx.ExecContext(ctx, string(sql)); err != nil {
 			return err
 		}
@@ -182,7 +173,7 @@ func (migration *fixCloudIntegrationUniqueIndex) Up(ctx context.Context, db *bun
 	return tx.Commit()
 }
 
-func (migration *fixCloudIntegrationUniqueIndex) Down(ctx context.Context, db *bun.DB) error {
+func (migration *updateCloudIntegrationUniqueIndex) Down(ctx context.Context, db *bun.DB) error {
 	return nil
 }
 

--- a/tests/integration/fixtures/cloudintegrations.py
+++ b/tests/integration/fixtures/cloudintegrations.py
@@ -1,7 +1,7 @@
 """Fixtures for cloud integration tests."""
 
 from http import HTTPStatus
-from typing import Callable, Optional
+from typing import Callable
 
 import pytest
 import requests
@@ -18,14 +18,12 @@ def create_cloud_integration_account(
     request: pytest.FixtureRequest,
     signoz: types.SigNoz,
 ) -> Callable[[str, str], dict]:
-    created_account_id: Optional[str] = None
-    cloud_provider_used: Optional[str] = None
+    created_accounts: list[tuple[str, str]] = []
 
     def _create(
         admin_token: str,
         cloud_provider: str = "aws",
     ) -> dict:
-        nonlocal created_account_id, cloud_provider_used
         endpoint = f"/api/v1/cloud-integrations/{cloud_provider}/accounts/generate-connection-url"
 
         request_payload = {
@@ -52,35 +50,31 @@ def create_cloud_integration_account(
         ), f"Failed to create test account: {response.status_code}"
 
         data = response.json().get("data", response.json())
-        created_account_id = data.get("account_id")
-        cloud_provider_used = cloud_provider
+        created_accounts.append((data.get("account_id"), cloud_provider))
 
         return data
-
-    def _disconnect(admin_token: str, cloud_provider: str) -> requests.Response:
-        assert created_account_id
-        disconnect_endpoint = f"/api/v1/cloud-integrations/{cloud_provider}/accounts/{created_account_id}/disconnect"
-        return requests.post(
-            signoz.self.host_configs["8080"].get(disconnect_endpoint),
-            headers={"Authorization": f"Bearer {admin_token}"},
-            timeout=10,
-        )
 
     # Yield factory to the test
     yield _create
 
-    # Post-test cleanup: generate admin token and disconnect the created account
-    if created_account_id and cloud_provider_used:
+    # Post-test cleanup: disconnect all created accounts
+    if created_accounts:
         get_token = request.getfixturevalue("get_token")
         try:
             admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
-            r = _disconnect(admin_token, cloud_provider_used)
-            if r.status_code != HTTPStatus.OK:
-                logger.info(
-                    "Disconnect cleanup returned %s for account %s",
-                    r.status_code,
-                    created_account_id,
+            for account_id, cloud_provider in created_accounts:
+                disconnect_endpoint = f"/api/v1/cloud-integrations/{cloud_provider}/accounts/{account_id}/disconnect"
+                r = requests.post(
+                    signoz.self.host_configs["8080"].get(disconnect_endpoint),
+                    headers={"Authorization": f"Bearer {admin_token}"},
+                    timeout=10,
                 )
-            logger.info("Cleaned up test account: %s", created_account_id)
+                if r.status_code != HTTPStatus.OK:
+                    logger.info(
+                        "Disconnect cleanup returned %s for account %s",
+                        r.status_code,
+                        account_id,
+                    )
+                logger.info("Cleaned up test account: %s", account_id)
         except Exception as exc:  # pylint: disable=broad-except
             logger.info("Post-test disconnect cleanup failed: %s", exc)

--- a/tests/integration/fixtures/cloudintegrationsutils.py
+++ b/tests/integration/fixtures/cloudintegrationsutils.py
@@ -1,7 +1,5 @@
 """Fixtures for cloud integration tests."""
 
-from http import HTTPStatus
-
 import requests
 
 from fixtures import types
@@ -16,7 +14,7 @@ def simulate_agent_checkin(
     cloud_provider: str,
     account_id: str,
     cloud_account_id: str,
-) -> dict:
+) -> requests.Response:
     endpoint = f"/api/v1/cloud-integrations/{cloud_provider}/agent-check-in"
 
     checkin_payload = {
@@ -32,16 +30,11 @@ def simulate_agent_checkin(
         timeout=10,
     )
 
-    if response.status_code != HTTPStatus.OK:
+    if not response.ok:
         logger.error(
             "Agent check-in failed: %s, response: %s",
             response.status_code,
             response.text,
         )
 
-    assert (
-        response.status_code == HTTPStatus.OK
-    ), f"Agent check-in failed: {response.status_code}"
-
-    response_data = response.json()
-    return response_data.get("data", response_data)
+    return response

--- a/tests/integration/src/cloudintegrations/02_generate_connection_url.py
+++ b/tests/integration/src/cloudintegrations/02_generate_connection_url.py
@@ -1,3 +1,4 @@
+import uuid
 from http import HTTPStatus
 from typing import Callable
 
@@ -5,6 +6,8 @@ import requests
 
 from fixtures import types
 from fixtures.auth import USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD
+from fixtures.cloudintegrations import create_cloud_integration_account
+from fixtures.cloudintegrationsutils import simulate_agent_checkin
 from fixtures.logger import setup_logger
 
 logger = setup_logger(__name__)
@@ -142,3 +145,42 @@ def test_generate_connection_url_unsupported_provider(
     assert (
         "unsupported cloud provider" in response_data["error"].lower()
     ), "Error message should indicate unsupported provider"
+
+
+def test_duplicate_cloud_account_checkins(
+    signoz: types.SigNoz,
+    create_user_admin: types.Operation,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+    create_cloud_integration_account: Callable,
+) -> None:
+    """Test that two accounts cannot check in with the same cloud_account_id."""
+
+    admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+    cloud_provider = "aws"
+    same_cloud_account_id = str(uuid.uuid4())
+
+    # Create two separate cloud integration accounts via generate-connection-url
+    account1 = create_cloud_integration_account(admin_token, cloud_provider)
+    account1_id = account1["account_id"]
+
+    account2 = create_cloud_integration_account(admin_token, cloud_provider)
+    account2_id = account2["account_id"]
+
+    assert account1_id != account2_id, "Two accounts should have different internal IDs"
+
+#     First check-in succeeds: account1 claims cloud_account_id
+    response = simulate_agent_checkin(
+        signoz, admin_token, cloud_provider, account1_id, same_cloud_account_id
+    )
+    assert (
+        response.status_code == HTTPStatus.OK
+    ), f"Expected 200 for first check-in, got {response.status_code}: {response.text}"
+#
+    # Second check-in should fail: account2 tries to use the same cloud_account_id
+    response = simulate_agent_checkin(
+        signoz, admin_token, cloud_provider, account2_id, same_cloud_account_id
+    )
+
+    assert (
+        response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    ), f"Expected 500 for duplicate cloud_account_id, got {response.status_code}: {response.text}"

--- a/tests/integration/src/cloudintegrations/03_accounts.py
+++ b/tests/integration/src/cloudintegrations/03_accounts.py
@@ -57,9 +57,12 @@ def test_list_connected_accounts_with_account(
 
     # Simulate agent check-in to mark as connected
     cloud_account_id = str(uuid.uuid4())
-    simulate_agent_checkin(
+    response = simulate_agent_checkin(
         signoz, admin_token, cloud_provider, account_id, cloud_account_id
     )
+    assert (
+        response.status_code == HTTPStatus.OK
+    ), f"Expected 200 for agent check-in, got {response.status_code}: {response.text}"
 
     # List accounts
     endpoint = f"/api/v1/cloud-integrations/{cloud_provider}/accounts"
@@ -161,9 +164,12 @@ def test_update_account_config(
 
     # Simulate agent check-in to mark as connected
     cloud_account_id = str(uuid.uuid4())
-    simulate_agent_checkin(
+    response = simulate_agent_checkin(
         signoz, admin_token, cloud_provider, account_id, cloud_account_id
     )
+    assert (
+        response.status_code == HTTPStatus.OK
+    ), f"Expected 200 for agent check-in, got {response.status_code}: {response.text}"
 
     # Update account configuration
     endpoint = (
@@ -226,9 +232,12 @@ def test_disconnect_account(
 
     # Simulate agent check-in to mark as connected
     cloud_account_id = str(uuid.uuid4())
-    simulate_agent_checkin(
+    response = simulate_agent_checkin(
         signoz, admin_token, cloud_provider, account_id, cloud_account_id
     )
+    assert (
+        response.status_code == HTTPStatus.OK
+    ), f"Expected 200 for agent check-in, got {response.status_code}: {response.text}"
 
     # Disconnect the account
     endpoint = (

--- a/tests/integration/src/cloudintegrations/04_services.py
+++ b/tests/integration/src/cloudintegrations/04_services.py
@@ -61,9 +61,12 @@ def test_list_services_with_account(
     account_id = account_data["account_id"]
 
     cloud_account_id = str(uuid.uuid4())
-    simulate_agent_checkin(
+    response = simulate_agent_checkin(
         signoz, admin_token, cloud_provider, account_id, cloud_account_id
     )
+    assert (
+        response.status_code == HTTPStatus.OK
+    ), f"Expected 200 for agent check-in, got {response.status_code}: {response.text}"
 
     # List services for the account
     endpoint = f"/api/v1/cloud-integrations/{cloud_provider}/services?cloud_account_id={cloud_account_id}"
@@ -152,9 +155,12 @@ def test_get_service_details_with_account(
     account_id = account_data["account_id"]
 
     cloud_account_id = str(uuid.uuid4())
-    simulate_agent_checkin(
+    response = simulate_agent_checkin(
         signoz, admin_token, cloud_provider, account_id, cloud_account_id
     )
+    assert (
+        response.status_code == HTTPStatus.OK
+    ), f"Expected 200 for agent check-in, got {response.status_code}: {response.text}"
 
     # Get list of services first
     list_endpoint = f"/api/v1/cloud-integrations/{cloud_provider}/services"
@@ -253,9 +259,12 @@ def test_update_service_config(
     account_id = account_data["account_id"]
 
     cloud_account_id = str(uuid.uuid4())
-    simulate_agent_checkin(
+    response = simulate_agent_checkin(
         signoz, admin_token, cloud_provider, account_id, cloud_account_id
     )
+    assert (
+        response.status_code == HTTPStatus.OK
+    ), f"Expected 200 for agent check-in, got {response.status_code}: {response.text}"
 
     # Get list of services to pick a valid service ID
     list_endpoint = f"/api/v1/cloud-integrations/{cloud_provider}/services"
@@ -365,9 +374,12 @@ def test_update_service_config_invalid_service(
     account_id = account_data["account_id"]
 
     cloud_account_id = str(uuid.uuid4())
-    simulate_agent_checkin(
+    response = simulate_agent_checkin(
         signoz, admin_token, cloud_provider, account_id, cloud_account_id
     )
+    assert (
+        response.status_code == HTTPStatus.OK
+    ), f"Expected 200 for agent check-in, got {response.status_code}: {response.text}"
 
     # Try to update config for invalid service
     fake_service_id = "non-existent-service"
@@ -409,9 +421,12 @@ def test_update_service_config_disable_service(
     account_id = account_data["account_id"]
 
     cloud_account_id = str(uuid.uuid4())
-    simulate_agent_checkin(
+    response = simulate_agent_checkin(
         signoz, admin_token, cloud_provider, account_id, cloud_account_id
     )
+    assert (
+        response.status_code == HTTPStatus.OK
+    ), f"Expected 200 for agent check-in, got {response.status_code}: {response.text}"
 
     # Get a valid service
     list_endpoint = f"/api/v1/cloud-integrations/{cloud_provider}/services"


### PR DESCRIPTION
## Pull Request

Fixes: https://github.com/SigNoz/engineering-pod/issues/4224

---

### 📄 Summary
Added migration to fix the wrong unique index on `cloud_integration` table. More info in the [issue](https://github.com/SigNoz/engineering-pod/issues/4224).

### Approach (AI)
Migration steps (within a single transaction):

  1. Drop wrong index unique_cloud_integration on (id, provider, org_id) using sqlschema.Operator().DropIndex() with Named()
  2. Normalize empty account_id to NULL — UPDATE cloud_integration SET account_id = NULL WHERE account_id = '' (older table structure could store "" instead of
  NULL; empty strings would violate the partial unique index since '' = '' unlike NULL != NULL)
  3. Fetch active rows with non-null account_id, ordered for grouping by (account_id, provider, org_id, updated_at DESC)
  4. Group duplicates in Go — keeper = most recently updated, rest = losers
  5. Merge config — union of EnabledRegions from all duplicates into keeper's config
  6. Reassign services — delete conflicting services from losers (same type as keeper), reassign remaining to keeper
  7. Soft-delete losers — set removed_at and updated_at
  8. Create partial unique index on (account_id, provider, org_id) WHERE removed_at IS NULL using sqlschema.PartialUniqueIndex


#### Issues closed by this PR
Closes https://github.com/SigNoz/engineering-pod/issues/4224

