### PR TITLE
feat(frontend): trigger keyboard shortcut actions immediately

### DIFF
--- a/frontend/src/hooks/hotkeys/__tests__/useKeyboardHotkeys.test.tsx
+++ b/frontend/src/hooks/hotkeys/__tests__/useKeyboardHotkeys.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
+	HOLD_FIRE_DELAY_MS,
 	KeyboardHotkeysProvider,
 	useKeyboardHotkeys,
 } from '../useKeyboardHotkeys';
@@ -72,5 +73,199 @@ describe('KeyboardHotkeysProvider', () => {
 		await user.keyboard('{b}');
 
 		expect(handleShortcut).not.toHaveBeenCalled();
+	});
+});
+
+// ---- Hold-fire & combo-extension timing tests ----
+/**
+ * Test component that registers two shortcuts that share a prefix:
+ *   shift+m  → handleParent
+ *   shift+m+e → handleChild
+ * This mirrors the real metrics shortcuts (Metrics Summary vs Metrics Explorer).
+ */
+function TestComponentWithChords({
+	handleParent,
+	handleChild,
+}: {
+	handleParent: () => void;
+	handleChild: () => void;
+}): JSX.Element {
+	const { registerShortcut } = useKeyboardHotkeys();
+
+	useEffect(() => {
+		registerShortcut('shift+m', handleParent);
+		registerShortcut('shift+m+e', handleChild);
+	}, [registerShortcut, handleParent, handleChild]);
+
+	return <span>Chord Test</span>;
+}
+
+/** Dispatch a keydown event from document.body so event.target is an HTMLElement (has .closest) */
+function fireKeyDown(key: string, opts: Partial<KeyboardEventInit> = {}): void {
+	document.body.dispatchEvent(
+		new KeyboardEvent('keydown', { key, bubbles: true, ...opts }),
+	);
+}
+
+/** Dispatch a keyup event from document.body */
+function fireKeyUp(key: string, opts: Partial<KeyboardEventInit> = {}): void {
+	document.body.dispatchEvent(
+		new KeyboardEvent('keyup', { key, bubbles: true, ...opts }),
+	);
+}
+
+describe('Hold-fire timing behaviour', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	/**
+	 * Scenario 1: Quick tap — keys pressed and released immediately (before timeout)
+	 *
+	 * Timeline: Shift↓ → M↓ → M↑ → Shift↑  (all within < 200ms)
+	 * Expected: shift+m fires on keyup, NOT via hold timer
+	 */
+	it('fires on keyup when keys are released before hold timeout', () => {
+		const handleParent = jest.fn();
+		const handleChild = jest.fn();
+
+		render(
+			<KeyboardHotkeysProvider>
+				<TestComponentWithChords
+					handleParent={handleParent}
+					handleChild={handleChild}
+				/>
+			</KeyboardHotkeysProvider>,
+		);
+
+		fireKeyDown('Shift', { shiftKey: true });
+		fireKeyDown('m', { shiftKey: true });
+
+		expect(handleParent).not.toHaveBeenCalled();
+
+		fireKeyUp('m', { shiftKey: true });
+		fireKeyUp('Shift');
+
+		expect(handleParent).toHaveBeenCalledTimes(1);
+		expect(handleChild).not.toHaveBeenCalled();
+
+		jest.advanceTimersByTime(HOLD_FIRE_DELAY_MS + 50);
+		expect(handleParent).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * Scenario 2: Hold — keys pressed and NOT released; fires via hold timer
+	 *
+	 * Timeline: Shift↓ → M↓ → ... 200ms passes ... → action fires
+	 * Expected: shift+m fires after HOLD_FIRE_DELAY_MS without waiting for keyup
+	 */
+	it('fires via hold timer when keys are held beyond timeout', () => {
+		const handleParent = jest.fn();
+		const handleChild = jest.fn();
+
+		render(
+			<KeyboardHotkeysProvider>
+				<TestComponentWithChords
+					handleParent={handleParent}
+					handleChild={handleChild}
+				/>
+			</KeyboardHotkeysProvider>,
+		);
+
+		fireKeyDown('Shift', { shiftKey: true });
+		fireKeyDown('m', { shiftKey: true });
+
+		jest.advanceTimersByTime(HOLD_FIRE_DELAY_MS - 10);
+		expect(handleParent).not.toHaveBeenCalled();
+
+		jest.advanceTimersByTime(20);
+		expect(handleParent).toHaveBeenCalledTimes(1);
+
+		fireKeyUp('m', { shiftKey: true });
+		fireKeyUp('Shift');
+		expect(handleParent).toHaveBeenCalledTimes(1);
+		expect(handleChild).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * Scenario 3: Extended combo with quick release — shift+m extended to shift+m+e,
+	 *             then keys released immediately (before timeout)
+	 *
+	 * Timeline: Shift↓ → M↓ → E↓ → E↑ → M↑ → Shift↑  (all within < 200ms)
+	 * Expected: shift+m does NOT fire; shift+m+e fires on keyup
+	 */
+	it('does not fire parent when combo is extended; fires child on keyup', () => {
+		const handleParent = jest.fn();
+		const handleChild = jest.fn();
+
+		render(
+			<KeyboardHotkeysProvider>
+				<TestComponentWithChords
+					handleParent={handleParent}
+					handleChild={handleChild}
+				/>
+			</KeyboardHotkeysProvider>,
+		);
+
+		fireKeyDown('Shift', { shiftKey: true });
+		fireKeyDown('m', { shiftKey: true });
+
+		fireKeyDown('e', { shiftKey: true });
+
+		expect(handleParent).not.toHaveBeenCalled();
+
+		fireKeyUp('e', { shiftKey: true });
+		fireKeyUp('m', { shiftKey: true });
+		fireKeyUp('Shift');
+
+		expect(handleParent).not.toHaveBeenCalled();
+		expect(handleChild).toHaveBeenCalledTimes(1);
+
+		jest.advanceTimersByTime(HOLD_FIRE_DELAY_MS + 50);
+		expect(handleChild).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * Scenario 4: Extended combo with hold — shift+m extended to shift+m+e,
+	 *             then keys held past timeout
+	 *
+	 * Timeline: Shift↓ → M↓ → E↓ → ... 200ms passes ... → shift+m+e fires
+	 * Expected: shift+m does NOT fire; shift+m+e fires via hold timer
+	 */
+	it('does not fire parent when combo is extended; fires child via hold timer', () => {
+		const handleParent = jest.fn();
+		const handleChild = jest.fn();
+
+		render(
+			<KeyboardHotkeysProvider>
+				<TestComponentWithChords
+					handleParent={handleParent}
+					handleChild={handleChild}
+				/>
+			</KeyboardHotkeysProvider>,
+		);
+
+		fireKeyDown('Shift', { shiftKey: true });
+		fireKeyDown('m', { shiftKey: true });
+
+		fireKeyDown('e', { shiftKey: true });
+
+		jest.advanceTimersByTime(HOLD_FIRE_DELAY_MS - 10);
+		expect(handleParent).not.toHaveBeenCalled();
+		expect(handleChild).not.toHaveBeenCalled();
+
+		jest.advanceTimersByTime(20);
+		expect(handleParent).not.toHaveBeenCalled();
+		expect(handleChild).toHaveBeenCalledTimes(1);
+
+		fireKeyUp('e', { shiftKey: true });
+		fireKeyUp('m', { shiftKey: true });
+		fireKeyUp('Shift');
+		expect(handleParent).not.toHaveBeenCalled();
+		expect(handleChild).toHaveBeenCalledTimes(1);
 	});
 });

--- a/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
+++ b/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
@@ -36,6 +36,9 @@ const KeyboardHotkeysContext = createContext<KeyboardHotkeysContextReturnValue>(
 
 const IGNORE_INPUTS = ['input', 'textarea', 'cm-editor']; // Inputs in which hotkey events will be ignored
 
+/** Fire shortcut after keys held this long without releasing */
+export const HOLD_FIRE_DELAY_MS = 200;
+
 export function useKeyboardHotkeys(): KeyboardHotkeysContextReturnValue {
 	const context = useContext(KeyboardHotkeysContext);
 	if (!context) {
@@ -63,6 +66,19 @@ function normalizeComboString(combo: string): string {
 	return normalizeChord(new Set(combo.split('+')));
 }
 
+/** Sync modifier flags from the event into the pressed-keys set. */
+function syncModifiers(event: KeyboardEvent, keys: Set<string>): void {
+	if (event.shiftKey) {
+		keys.add('shift');
+	}
+	if (event.metaKey || event.ctrlKey) {
+		keys.add('meta');
+	}
+	if (event.altKey) {
+		keys.add('alt');
+	}
+}
+
 export function KeyboardHotkeysProvider({
 	children,
 }: {
@@ -78,18 +94,29 @@ export function KeyboardHotkeysProvider({
 	// Tracks whether user extended the combo
 	const wasExtended = useRef(false);
 
-	const handleKeyDown = (event: KeyboardEvent): void => {
-		if (event.repeat) {
-			return;
-		}
+	const holdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+	const clearHoldTimer = (): void => {
+		if (holdTimerRef.current !== null) {
+			clearTimeout(holdTimerRef.current);
+			holdTimerRef.current = null;
+		}
+	};
+
+	/** Returns true when the event should be ignored (input fields, code editors, repeats). */
+	function shouldIgnoreKeyDown(event: KeyboardEvent): boolean {
+		if (event.repeat) {
+			return true;
+		}
 		const target = event.target as HTMLElement;
-		const isCodeMirrorEditor =
-			(target as HTMLElement).closest('.cm-editor') !== null;
-		if (
-			IGNORE_INPUTS.includes((target as HTMLElement).tagName.toLowerCase()) ||
-			isCodeMirrorEditor
-		) {
+		if (target.closest?.('.cm-editor')) {
+			return true;
+		}
+		return IGNORE_INPUTS.includes(target.tagName?.toLowerCase());
+	}
+
+	const handleKeyDown = (event: KeyboardEvent): void => {
+		if (shouldIgnoreKeyDown(event)) {
 			return;
 		}
 
@@ -104,16 +131,7 @@ export function KeyboardHotkeysProvider({
 		}
 
 		pressedKeys.current.add(key);
-
-		if (event.shiftKey) {
-			pressedKeys.current.add('shift');
-		}
-		if (event.metaKey || event.ctrlKey) {
-			pressedKeys.current.add('meta');
-		}
-		if (event.altKey) {
-			pressedKeys.current.add('alt');
-		}
+		syncModifiers(event, pressedKeys.current);
 
 		const combo = normalizeChord(pressedKeys.current);
 
@@ -122,6 +140,19 @@ export function KeyboardHotkeysProvider({
 			event.stopPropagation();
 			pendingCombo.current = combo;
 			wasExtended.current = false;
+
+			clearHoldTimer();
+			holdTimerRef.current = setTimeout(() => {
+				if (pendingCombo.current === combo && !wasExtended.current) {
+					try {
+						shortcuts.current[combo]?.();
+					} catch (error) {
+						console.error('Error executing hotkey callback:', error);
+					}
+					// Mark as fired so keyup doesn't double-fire
+					pendingCombo.current = null;
+				}
+			}, HOLD_FIRE_DELAY_MS);
 		}
 	};
 
@@ -142,6 +173,8 @@ export function KeyboardHotkeysProvider({
 		if (!event.altKey) {
 			pressedKeys.current.delete('alt');
 		}
+
+		clearHoldTimer();
 
 		if (!pendingCombo.current) {
 			return;
@@ -169,6 +202,7 @@ export function KeyboardHotkeysProvider({
 			pressedKeys.current.clear();
 			pendingCombo.current = null;
 			wasExtended.current = false;
+			clearHoldTimer();
 		};
 
 		window.addEventListener('blur', reset);
@@ -186,6 +220,7 @@ export function KeyboardHotkeysProvider({
 			pressedKeys.current.clear();
 			pendingCombo.current = null;
 			wasExtended.current = false;
+			clearHoldTimer();
 		}
 	}, [cmdKOpen]);
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  

Keyboard shortcuts (e.g., Shift+D for Dashboards) only fire when keys are released
User experience feels delayed and unintuitive, especially for rapid navigation
Power users expect immediate action feedback, not reaction to release


> What problem does it solve, and why is this the right approach?

This PR implements immediate action firing for keyboard shortcuts when held for ~200ms, replacing the old behavior of waiting for key release. Power users now get instant feedback without the release-wait delay.

#### User Experience Change
Before: User presses Shift+M → must release keys → action fires
After: User presses Shift+M → holds for 200ms → action fires instantly (no need to release)


#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

[![Watch video](thumbnail.png)](https://github.com/user-attachments/assets/5c8f06d4-5f9a-42a4-91a9-fccd4ffac07a)


After:

[![Watch video](thumbnail.png)](https://github.com/user-attachments/assets/8d42595e-41bd-4c32-bc0f-3f3e7de4b9e3)

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.
Fixes - https://github.com/SigNoz/signoz/issues/9847
---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?   - ot a bug fix
> Regression, faulty assumption, edge case, refactor, etc.

#### Fix Strategy
> How does this PR address the root cause?


Implemented a `dual-fire mechanism` with hold-fire timing:

1. **Immediate Hold-Fire**: When user presses keys for ≥200ms, action fires via timer without waiting for release
2. **Fast-Tap Fallback**: If user releases before 200ms, action fires on keyup (preserves existing fast-tap behavior)
3. **Chord Safety**: Extended `wasExtended` flag prevents parent combos from firing when user extends to a chord

Here's a summary of the 4 scenarios covered:

| # | Scenario | What happens | Result |
|---|----------|-------------|--------|
| 1 | Quick tap — Shift+M pressed & released immediately (< 200ms) | Hold timer cancelled on keyup, fires on keyup | ✅ shift+m fires once, no double-fire |
| 2 | Hold — Shift+M pressed & held ≥ 200ms | Hold timer fires, pendingCombo cleared, keyup skips | ✅ shift+m fires once via timer, no double-fire on release |
| 3 | Extended + quick release — Shift+M then +E, released immediately | wasExtended blocks shift+m, shift+m+e fires on keyup | ✅ Parent NOT fired, child fires once |
| 4 | Extended + hold — Shift+M then +E, held ≥ 200ms | wasExtended blocks shift+m, shift+m+e fires via timer | ✅ Parent NOT fired, child fires once via timer, no double-fire on release |

---

### 🧪 Testing Strategy
> How was this change validated?
Added tests and verified manually as well.
**4 comprehensive scenarios** 
- Tests added/updated: 
    1. **Quick Tap** (< 200ms)
       - User presses `Shift+M` and releases within 200ms
       - Expected: Fires on keyup, no double-fire
    
    2. **Hold** (≥ 200ms)
       - User holds `Shift+M` for 300ms
       - Expected: Fires via timer at 200ms mark, doesn't fire again on release
    
    3. **Chord Extension + Quick Release**
       - User presses `Shift+M`, then quickly presses `E` (→ `Shift+M+E`), releases within 200ms
       - Expected: Only `Shift+M+E` fires; `Shift+M` blocked by `wasExtended` flag
    
    4. **Chord Extension + Hold**
       - User presses `Shift+M`, then presses `E` (→ `Shift+M+E`), holds for 300ms
       - Expected: Only `Shift+M+E` fires via timer; `Shift+M` blocked

- Manual verification:
    -  Tested `Shift+D` (Dashboards) — fires at 200ms when held
    -  Tested `Shift+M` (Metrics) — fires at 200ms when held
    -  Tested `Shift+L` (Logs) — fires at 200ms when held
    -  Tested quick taps (< 200ms) — still fire on release (backward compatible)
    -  Tested Cmd+K with shortcuts — no conflicts, palette closes cleanly
    -  Tested in input fields — shortcuts correctly ignored
    -  Verified no memory leaks — timers cleaned up on unmount/blur
- Edge cases covered:
      all the scenarios covered mainly we have 4 four scenarios Quick Tap, Hold, Chord Extension, Chord Extenion + Hold
      
---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
      - Affects all keyboard shortcuts globally (Shift+D, Shift+M, Shift+L, etc.)
      - Only keyboard input—no API or data changes
- Potential regressions:
- Rollback plan:
   - Revert the pr  
---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type |Cloud / OSS / Enterprise (All) |
| Change Type | Feature  |
| Description | Keyboard shortcuts now fire immediately on hold instead of on release|

---

### 📋 Checklist
- [x] Tests added or explicitly not required
      - Added 4 comprehensive hold-fire test scenarios
      - All 6 tests passing (2 existing + 4 new)
- [x] Manually tested
      - Tested all major shortcuts: Shift+D, Shift+M, Shift+L, etc.
      - Verified backward compatibility with fast taps
      - Tested chord extensions (Shift+M+E)
      - Verified input field exclusions
- [x] Breaking changes documented
      - No breaking changes (fully backward compatible)
- [x] Backward compatibility considered
      - Fast-tap behavior preserved (< 200ms still fires on keyup)
      - All existing shortcuts work unchanged
      - Input fields and editors properly excluded

---

## 👀 Notes for Reviewers
1. Is 200ms the right threshold? (Adjustable via `HOLD_FIRE_DELAY_MS` constant)

<!-- Anything reviewers should keep in mind while reviewing -->

---
