### PR TITLE
chore: derive dashboard locked state from global state

### DIFF
--- a/frontend/src/container/DashboardContainer/DashboardDescription/index.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardDescription/index.tsx
@@ -21,6 +21,7 @@ import { DeleteButton } from 'container/ListOfDashboard/TableComponents/DeleteBu
 import DateTimeSelectionV2 from 'container/TopNav/DateTimeSelectionV2';
 import { useDashboardVariables } from 'hooks/dashboard/useDashboardVariables';
 import { useGetPublicDashboardMeta } from 'hooks/dashboard/useGetPublicDashboardMeta';
+import { useLockDashboard } from 'hooks/dashboard/useLockDashboard';
 import { useUpdateDashboard } from 'hooks/dashboard/useUpdateDashboard';
 import useComponentPermission from 'hooks/useComponentPermission';
 import { useGetTenantLicense } from 'hooks/useGetTenantLicense';
@@ -40,7 +41,10 @@ import {
 } from 'lucide-react';
 import { useAppContext } from 'providers/App/App';
 import { usePanelTypeSelectionModalStore } from 'providers/Dashboard/helpers/panelTypeSelectionModalHelper';
-import { useDashboardStore } from 'providers/Dashboard/store/useDashboardStore';
+import {
+	selectIsDashboardLocked,
+	useDashboardStore,
+} from 'providers/Dashboard/store/useDashboardStore';
 import { sortLayout } from 'providers/Dashboard/util';
 import { DashboardData } from 'types/api/dashboard/getAll';
 import { Props } from 'types/api/dashboard/update';
@@ -79,10 +83,11 @@ function DashboardDescription(props: DashboardDescriptionProps): JSX.Element {
 		setPanelMap,
 		layouts,
 		setLayouts,
-		isDashboardLocked,
 		setSelectedDashboard,
-		handleDashboardLockToggle,
 	} = useDashboardStore();
+
+	const isDashboardLocked = useDashboardStore(selectIsDashboardLocked);
+	const handleDashboardLockToggle = useLockDashboard();
 
 	const variablesSettingsTabHandle = useRef<VariablesSettingsTab>(null);
 	const [isSettingsDrawerOpen, setIsSettingsDrawerOpen] = useState<boolean>(

--- a/frontend/src/container/DashboardContainer/visualization/components/ChartManager/ChartManager.tsx
+++ b/frontend/src/container/DashboardContainer/visualization/components/ChartManager/ChartManager.tsx
@@ -6,7 +6,10 @@ import { useNotifications } from 'hooks/useNotifications';
 import { UPlotConfigBuilder } from 'lib/uPlotV2/config/UPlotConfigBuilder';
 import { usePlotContext } from 'lib/uPlotV2/context/PlotContext';
 import useLegendsSync from 'lib/uPlotV2/hooks/useLegendsSync';
-import { useDashboardStore } from 'providers/Dashboard/store/useDashboardStore';
+import {
+	selectIsDashboardLocked,
+	useDashboardStore,
+} from 'providers/Dashboard/store/useDashboardStore';
 
 import { getChartManagerColumns } from './getChartMangerColumns';
 import { ExtendedChartDataset, getDefaultTableDataSet } from './utils';
@@ -50,7 +53,7 @@ export default function ChartManager({
 		onToggleSeriesVisibility,
 		syncSeriesVisibilityToLocalStorage,
 	} = usePlotContext();
-	const { isDashboardLocked } = useDashboardStore();
+	const isDashboardLocked = useDashboardStore(selectIsDashboardLocked);
 
 	const [tableDataSet, setTableDataSet] = useState<ExtendedChartDataset[]>(() =>
 		getDefaultTableDataSet(

--- a/frontend/src/container/GridCardLayout/DashboardEmptyState/DashboardEmptyState.tsx
+++ b/frontend/src/container/GridCardLayout/DashboardEmptyState/DashboardEmptyState.tsx
@@ -9,7 +9,10 @@ import DashboardSettings from 'container/DashboardContainer/DashboardSettings';
 import useComponentPermission from 'hooks/useComponentPermission';
 import { useAppContext } from 'providers/App/App';
 import { usePanelTypeSelectionModalStore } from 'providers/Dashboard/helpers/panelTypeSelectionModalHelper';
-import { useDashboardStore } from 'providers/Dashboard/store/useDashboardStore';
+import {
+	selectIsDashboardLocked,
+	useDashboardStore,
+} from 'providers/Dashboard/store/useDashboardStore';
 import { ROLES, USER_ROLES } from 'types/roles';
 import { ComponentTypes } from 'utils/permission';
 
@@ -20,7 +23,8 @@ export default function DashboardEmptyState(): JSX.Element {
 		(s) => s.setIsPanelTypeSelectionModalOpen,
 	);
 
-	const { selectedDashboard, isDashboardLocked } = useDashboardStore();
+	const { selectedDashboard } = useDashboardStore();
+	const isDashboardLocked = useDashboardStore(selectIsDashboardLocked);
 
 	const variablesSettingsTabHandle = useRef<VariablesSettingsTab>(null);
 	const [isSettingsDrawerOpen, setIsSettingsDrawerOpen] = useState<boolean>(

--- a/frontend/src/container/GridCardLayout/GridCard/FullView/GraphManager.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/FullView/GraphManager.tsx
@@ -3,7 +3,10 @@ import { Button, Input } from 'antd';
 import type { CheckboxChangeEvent } from 'antd/es/checkbox';
 import { ResizeTable } from 'components/ResizeTable';
 import { useNotifications } from 'hooks/useNotifications';
-import { useDashboardStore } from 'providers/Dashboard/store/useDashboardStore';
+import {
+	selectIsDashboardLocked,
+	useDashboardStore,
+} from 'providers/Dashboard/store/useDashboardStore';
 
 import { getGraphManagerTableColumns } from './TableRender/GraphManagerColumns';
 import { ExtendedChartDataset, GraphManagerProps } from './types';
@@ -34,7 +37,7 @@ function GraphManager({
 	}, [data, options]);
 
 	const { notifications } = useNotifications();
-	const { isDashboardLocked } = useDashboardStore();
+	const isDashboardLocked = useDashboardStore(selectIsDashboardLocked);
 
 	const checkBoxOnChangeHandler = useCallback(
 		(e: CheckboxChangeEvent, index: number): void => {

--- a/frontend/src/container/GridCardLayout/GridCard/FullView/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/FullView/index.tsx
@@ -39,7 +39,10 @@ import { getDashboardVariables } from 'lib/dashboardVariables/getDashboardVariab
 import GetMinMax from 'lib/getMinMax';
 import { isEmpty } from 'lodash-es';
 import { useAppContext } from 'providers/App/App';
-import { useDashboardStore } from 'providers/Dashboard/store/useDashboardStore';
+import {
+	selectIsDashboardLocked,
+	useDashboardStore,
+} from 'providers/Dashboard/store/useDashboardStore';
 import { AppState } from 'store/reducers';
 import { Warning } from 'types/api';
 import { GlobalReducer } from 'types/reducer/globalTime';
@@ -81,11 +84,8 @@ function FullView({
 		setCurrentGraphRef(fullViewRef);
 	}, [setCurrentGraphRef]);
 
-	const {
-		selectedDashboard,
-		isDashboardLocked,
-		setColumnWidths,
-	} = useDashboardStore();
+	const { selectedDashboard, setColumnWidths } = useDashboardStore();
+	const isDashboardLocked = useDashboardStore(selectIsDashboardLocked);
 
 	const onColumnWidthsChange = useCallback(
 		(widths: Record<string, number>) => {

--- a/frontend/src/container/GridCardLayout/GridCardLayout.tsx
+++ b/frontend/src/container/GridCardLayout/GridCardLayout.tsx
@@ -31,7 +31,10 @@ import {
 	X,
 } from 'lucide-react';
 import { useAppContext } from 'providers/App/App';
-import { useDashboardStore } from 'providers/Dashboard/store/useDashboardStore';
+import {
+	selectIsDashboardLocked,
+	useDashboardStore,
+} from 'providers/Dashboard/store/useDashboardStore';
 import { sortLayout } from 'providers/Dashboard/util';
 import { UpdateTimeInterval } from 'store/actions';
 import { Widgets } from 'types/api/dashboard/getAll';
@@ -68,12 +71,12 @@ function GraphLayout(props: GraphLayoutProps): JSX.Element {
 		panelMap,
 		setPanelMap,
 		setSelectedDashboard,
-		isDashboardLocked,
 		dashboardQueryRangeCalled,
 		setDashboardQueryRangeCalled,
 		isDashboardFetching,
 		columnWidths,
 	} = useDashboardStore();
+	const isDashboardLocked = useDashboardStore(selectIsDashboardLocked);
 	const { data } = selectedDashboard || {};
 	const { pathname } = useLocation();
 	const dispatch = useDispatch();

--- a/frontend/src/container/GridCardLayout/WidgetRow.tsx
+++ b/frontend/src/container/GridCardLayout/WidgetRow.tsx
@@ -6,7 +6,10 @@ import { EllipsisIcon, PenLine, Plus, X } from 'lucide-react';
 import { useAppContext } from 'providers/App/App';
 import { usePanelTypeSelectionModalStore } from 'providers/Dashboard/helpers/panelTypeSelectionModalHelper';
 import { setSelectedRowWidgetId } from 'providers/Dashboard/helpers/selectedRowWidgetIdHelper';
-import { useDashboardStore } from 'providers/Dashboard/store/useDashboardStore';
+import {
+	selectIsDashboardLocked,
+	useDashboardStore,
+} from 'providers/Dashboard/store/useDashboardStore';
 import { ROLES, USER_ROLES } from 'types/roles';
 import { ComponentTypes } from 'utils/permission';
 
@@ -39,7 +42,8 @@ export function WidgetRowHeader(props: WidgetRowHeaderProps): JSX.Element {
 		(s) => s.setIsPanelTypeSelectionModalOpen,
 	);
 
-	const { selectedDashboard, isDashboardLocked } = useDashboardStore();
+	const { selectedDashboard } = useDashboardStore();
+	const isDashboardLocked = useDashboardStore(selectIsDashboardLocked);
 
 	const permissions: ComponentTypes[] = ['add_panel'];
 	const { user } = useAppContext();

--- a/frontend/src/providers/Dashboard/store/slices/dashboardUISlice.ts
+++ b/frontend/src/providers/Dashboard/store/slices/dashboardUISlice.ts
@@ -42,8 +42,6 @@ export interface DashboardUISlice {
 
 export const initialDashboardUIState = {
 	selectedDashboard: undefined as Dashboard | undefined,
-	isDashboardLocked: false,
-	isDashboardSliderOpen: false,
 	dashboardQueryRangeCalled: false,
 	isDashboardFetching: false,
 	columnWidths: {} as WidgetColumnWidths,
@@ -62,13 +60,6 @@ export const createDashboardUISlice: StateCreator<
 		set((state: DashboardUISlice): void => {
 			state.selectedDashboard =
 				typeof updater === 'function' ? updater(state.selectedDashboard) : updater;
-		}),
-
-	setIsDashboardLocked: (v: boolean): void =>
-		set((state: DashboardUISlice): void => {
-			if (state.selectedDashboard) {
-				state.selectedDashboard.locked = v;
-			}
 		}),
 
 	setDashboardQueryRangeCalled: (v): void =>

--- a/frontend/src/providers/Dashboard/store/useDashboardStore.ts
+++ b/frontend/src/providers/Dashboard/store/useDashboardStore.ts
@@ -17,6 +17,14 @@ export type DashboardStore = DashboardUISlice &
 		reset: () => void;
 	};
 
+/**
+ * 'select*' is a redux naming convention that can be carried over to zustand.
+ * It is used to select a piece of state from the store.
+ * In this case, we are selecting the locked state of the selected dashboard.
+ * */
+export const selectIsDashboardLocked = (s: DashboardStore): boolean =>
+	s.selectedDashboard?.locked ?? false;
+
 export const useDashboardStore = create<DashboardStore>()(
 	immer((set, get, api) => ({
 		...createDashboardUISlice(set, get, api),


### PR DESCRIPTION
### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Derive dashboard locked state from global dashboard state rather than creating a new variable and handling it differently

Closes https://github.com/SigNoz/engineering-pod/issues/4054