### PR TITLE
feat: add --config flag for YAML configuration files

### DIFF
--- a/cmd/community/server.go
+++ b/cmd/community/server.go
@@ -33,13 +33,14 @@ import (
 
 func registerServer(parentCmd *cobra.Command, logger *slog.Logger) {
 	var flags signoz.DeprecatedFlags
+	var configFiles []string
 
 	serverCmd := &cobra.Command{
 		Use:                "server",
 		Short:              "Run the SigNoz server",
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		RunE: func(currCmd *cobra.Command, args []string) error {
-			config, err := cmd.NewSigNozConfig(currCmd.Context(), logger, flags)
+			config, err := cmd.NewSigNozConfig(currCmd.Context(), logger, configFiles, flags)
 			if err != nil {
 				return err
 			}
@@ -48,6 +49,7 @@ func registerServer(parentCmd *cobra.Command, logger *slog.Logger) {
 		},
 	}
 
+	serverCmd.Flags().StringArrayVar(&configFiles, "config", nil, "path to a YAML configuration file (can be specified multiple times, later files override earlier ones)")
 	flags.RegisterFlags(serverCmd)
 	parentCmd.AddCommand(serverCmd)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,12 +10,18 @@ import (
 	"github.com/SigNoz/signoz/pkg/signoz"
 )
 
-func NewSigNozConfig(ctx context.Context, logger *slog.Logger, flags signoz.DeprecatedFlags) (signoz.Config, error) {
+func NewSigNozConfig(ctx context.Context, logger *slog.Logger, configFiles []string, flags signoz.DeprecatedFlags) (signoz.Config, error) {
+	uris := make([]string, 0, len(configFiles)+1)
+	for _, f := range configFiles {
+		uris = append(uris, "file:"+f)
+	}
+	uris = append(uris, "env:")
+
 	config, err := signoz.NewConfig(
 		ctx,
 		logger,
 		config.ResolverConfig{
-			Uris: []string{"env:"},
+			Uris: uris,
 			ProviderFactories: []config.ProviderFactory{
 				envprovider.NewFactory(),
 				fileprovider.NewFactory(),

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/signoz"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSigNozConfig_NoConfigFiles(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	config, err := NewSigNozConfig(context.Background(), logger, nil, signoz.DeprecatedFlags{})
+	require.NoError(t, err)
+	assert.NotZero(t, config)
+}
+
+func TestNewSigNozConfig_SingleConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(configPath, []byte(`
+cache:
+  provider: "redis"
+`), 0644)
+	require.NoError(t, err)
+
+	logger := slog.New(slog.DiscardHandler)
+	config, err := NewSigNozConfig(context.Background(), logger, []string{configPath}, signoz.DeprecatedFlags{})
+	require.NoError(t, err)
+	assert.Equal(t, "redis", config.Cache.Provider)
+}
+
+func TestNewSigNozConfig_MultipleConfigFiles_LaterOverridesEarlier(t *testing.T) {
+	dir := t.TempDir()
+
+	basePath := filepath.Join(dir, "base.yaml")
+	err := os.WriteFile(basePath, []byte(`
+cache:
+  provider: "memory"
+sqlstore:
+  provider: "sqlite"
+`), 0644)
+	require.NoError(t, err)
+
+	overridePath := filepath.Join(dir, "override.yaml")
+	err = os.WriteFile(overridePath, []byte(`
+cache:
+  provider: "redis"
+`), 0644)
+	require.NoError(t, err)
+
+	logger := slog.New(slog.DiscardHandler)
+	config, err := NewSigNozConfig(context.Background(), logger, []string{basePath, overridePath}, signoz.DeprecatedFlags{})
+	require.NoError(t, err)
+	// Later file overrides earlier
+	assert.Equal(t, "redis", config.Cache.Provider)
+	// Value from base file that wasn't overridden persists
+	assert.Equal(t, "sqlite", config.SQLStore.Provider)
+}
+
+func TestNewSigNozConfig_EnvOverridesConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(configPath, []byte(`
+cache:
+  provider: "fromfile"
+`), 0644)
+	require.NoError(t, err)
+
+	t.Setenv("SIGNOZ_CACHE_PROVIDER", "fromenv")
+
+	logger := slog.New(slog.DiscardHandler)
+	config, err := NewSigNozConfig(context.Background(), logger, []string{configPath}, signoz.DeprecatedFlags{})
+	require.NoError(t, err)
+	// Env should override file
+	assert.Equal(t, "fromenv", config.Cache.Provider)
+}
+
+func TestNewSigNozConfig_NonexistentFile(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	_, err := NewSigNozConfig(context.Background(), logger, []string{"/nonexistent/config.yaml"}, signoz.DeprecatedFlags{})
+	assert.Error(t, err)
+}

--- a/cmd/enterprise/server.go
+++ b/cmd/enterprise/server.go
@@ -43,13 +43,14 @@ import (
 
 func registerServer(parentCmd *cobra.Command, logger *slog.Logger) {
 	var flags signoz.DeprecatedFlags
+	var configFiles []string
 
 	serverCmd := &cobra.Command{
 		Use:                "server",
 		Short:              "Run the SigNoz server",
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		RunE: func(currCmd *cobra.Command, args []string) error {
-			config, err := cmd.NewSigNozConfig(currCmd.Context(), logger, flags)
+			config, err := cmd.NewSigNozConfig(currCmd.Context(), logger, configFiles, flags)
 			if err != nil {
 				return err
 			}
@@ -58,6 +59,7 @@ func registerServer(parentCmd *cobra.Command, logger *slog.Logger) {
 		},
 	}
 
+	serverCmd.Flags().StringArrayVar(&configFiles, "config", nil, "path to a YAML configuration file (can be specified multiple times, later files override earlier ones)")
 	flags.RegisterFlags(serverCmd)
 	parentCmd.AddCommand(serverCmd)
 }

--- a/pkg/signoz/config.go
+++ b/pkg/signoz/config.go
@@ -125,7 +125,6 @@ type DeprecatedFlags struct {
 	MaxIdleConns               int
 	MaxOpenConns               int
 	DialTimeout                time.Duration
-	Config                     string
 	FluxInterval               string
 	FluxIntervalForTraceDetail string
 	PreferSpanMetrics          bool
@@ -137,7 +136,6 @@ func (df *DeprecatedFlags) RegisterFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&df.MaxIdleConns, "max-idle-conns", 50, "max idle connections to the database")
 	cmd.Flags().IntVar(&df.MaxOpenConns, "max-open-conns", 100, "max open connections to the database")
 	cmd.Flags().DurationVar(&df.DialTimeout, "dial-timeout", 5*time.Second, "dial timeout for the database")
-	cmd.Flags().StringVar(&df.Config, "config", "./config/prometheus.yml", "(prometheus config to read metrics)")
 	cmd.Flags().StringVar(&df.FluxInterval, "flux-interval", "5m", "flux interval")
 	cmd.Flags().StringVar(&df.FluxIntervalForTraceDetail, "flux-interval-for-trace-detail", "2m", "flux interval for trace detail")
 	cmd.Flags().BoolVar(&df.PreferSpanMetrics, "prefer-span-metrics", false, "(prefer span metrics for service level metrics)")
@@ -147,7 +145,6 @@ func (df *DeprecatedFlags) RegisterFlags(cmd *cobra.Command) {
 	_ = cmd.Flags().MarkDeprecated("max-idle-conns", "use SIGNOZ_TELEMETRYSTORE_MAX__IDLE__CONNS instead")
 	_ = cmd.Flags().MarkDeprecated("max-open-conns", "use SIGNOZ_TELEMETRYSTORE_MAX__OPEN__CONNS instead")
 	_ = cmd.Flags().MarkDeprecated("dial-timeout", "use SIGNOZ_TELEMETRYSTORE_DIAL__TIMEOUT instead")
-	_ = cmd.Flags().MarkDeprecated("config", "use SIGNOZ_PROMETHEUS_CONFIG instead")
 	_ = cmd.Flags().MarkDeprecated("flux-interval", "use SIGNOZ_QUERIER_FLUX__INTERVAL instead")
 	_ = cmd.Flags().MarkDeprecated("flux-interval-for-trace-detail", "use SIGNOZ_QUERIER_FLUX__INTERVAL instead")
 	_ = cmd.Flags().MarkDeprecated("cluster", "use SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_CLUSTER instead")
@@ -268,10 +265,6 @@ func mergeAndEnsureBackwardCompatibility(ctx context.Context, logger *slog.Logge
 	if deprecatedFlags.DialTimeout != 5*time.Second {
 		logger.WarnContext(ctx, "[Deprecated] flag --dial-timeout is deprecated and scheduled for removal. Please use SIGNOZ_TELEMETRYSTORE_DIAL__TIMEOUT instead.")
 		config.TelemetryStore.Connection.DialTimeout = deprecatedFlags.DialTimeout
-	}
-
-	if deprecatedFlags.Config != "" {
-		logger.WarnContext(ctx, "[Deprecated] flag --config is deprecated for passing prometheus config. The flag will be used for passing the entire SigNoz config. More details can be found at https://github.com/SigNoz/signoz/issues/6805.")
 	}
 
 	if os.Getenv("INVITE_EMAIL_TEMPLATE") != "" {


### PR DESCRIPTION
## Summary
- Adds a repeatable `--config` CLI flag to load configuration from YAML files (`--config base.yaml --config override.yaml`)
- Later files override earlier ones, and environment variables always take highest precedence
- Removes the old deprecated `--config` flag that was used for the prometheus config path

Closes #6805

## Changes
- **`pkg/signoz/config.go`**: Removed `Config` field from `DeprecatedFlags`, its flag registration, and backward-compat check
- **`cmd/config.go`**: `NewSigNozConfig` now accepts `configFiles []string` and builds `file:<path>` URIs for the resolver
- **`cmd/community/server.go`** and **`cmd/enterprise/server.go`**: Register `--config` as a `StringArrayVar` flag
- **`cmd/config_test.go`**: Tests for single file, multiple file precedence, env override, backward compat, and missing file error