### PR TITLE
fix(infra-monitoring): not fetching correct group by keys

### DIFF
--- a/frontend/src/container/InfraMonitoringK8s/Volumes/K8sVolumesList.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Volumes/K8sVolumesList.tsx
@@ -217,7 +217,7 @@ function K8sVolumesList({
 		{
 			dataSource: currentQuery.builder.queryData[0].dataSource,
 			aggregateAttribute: GetK8sEntityToAggregateAttribute(
-				K8sCategory.NODES,
+				K8sCategory.VOLUMES,
 				dotMetricsEnabled,
 			),
 			aggregateOperator: 'noop',
@@ -228,7 +228,7 @@ function K8sVolumesList({
 			queryKey: [currentQuery.builder.queryData[0].dataSource, 'noop'],
 		},
 		true,
-		K8sCategory.NODES,
+		K8sCategory.VOLUMES,
 	);
 
 	const query = useMemo(() => {
@@ -597,7 +597,7 @@ function K8sVolumesList({
 				isLoadingGroupByFilters={isLoadingGroupByFilters}
 				handleGroupByChange={handleGroupByChange}
 				selectedGroupBy={groupBy}
-				entity={K8sCategory.NODES}
+				entity={K8sCategory.VOLUMES}
 				showAutoRefresh={!selectedVolumeData}
 			/>
 			{isError && <Typography>{data?.error || 'Something went wrong'}</Typography>}

--- a/frontend/src/container/InfraMonitoringK8s/__tests__/Volumes/K8sVolumesList.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/__tests__/Volumes/K8sVolumesList.test.tsx
@@ -1,0 +1,162 @@
+import setupCommonMocks from '../commonMocks';
+
+setupCommonMocks();
+
+import { QueryClient, QueryClientProvider } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { render, waitFor } from '@testing-library/react';
+import { FeatureKeys } from 'constants/features';
+import K8sVolumesList from 'container/InfraMonitoringK8s/Volumes/K8sVolumesList';
+import { rest, server } from 'mocks-server/server';
+import { IAppContext, IUser } from 'providers/App/types';
+import store from 'store';
+import { LicenseResModel } from 'types/api/licensesV3/getActive';
+
+const queryClient = new QueryClient({
+	defaultOptions: {
+		queries: {
+			retry: false,
+			cacheTime: 0,
+		},
+	},
+});
+
+const SERVER_URL = 'http://localhost/api';
+
+describe('K8sVolumesList - useGetAggregateKeys Category Regression', () => {
+	let requestsMade: Array<{
+		url: string;
+		params: URLSearchParams;
+		body?: any;
+	}> = [];
+
+	beforeEach(() => {
+		requestsMade = [];
+		queryClient.clear();
+
+		server.use(
+			rest.get(`${SERVER_URL}/v3/autocomplete/attribute_keys`, (req, res, ctx) => {
+				const url = req.url.toString();
+				const params = req.url.searchParams;
+
+				requestsMade.push({
+					url,
+					params,
+				});
+
+				return res(
+					ctx.status(200),
+					ctx.json({
+						status: 'success',
+						data: {
+							attributeKeys: [],
+						},
+					}),
+				);
+			}),
+			rest.post(`${SERVER_URL}/v1/pvcs/list`, (req, res, ctx) =>
+				res(
+					ctx.status(200),
+					ctx.json({
+						status: 'success',
+						data: {
+							type: 'list',
+							records: [],
+							groups: null,
+							total: 0,
+							sentAnyHostMetricsData: false,
+							isSendingK8SAgentMetrics: false,
+						},
+					}),
+				),
+			),
+		);
+	});
+
+	afterEach(() => {
+		server.resetHandlers();
+	});
+
+	it('should call aggregate keys API with k8s_volume_capacity', async () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<K8sVolumesList
+							isFiltersVisible={false}
+							handleFilterVisibilityChange={jest.fn()}
+							quickFiltersLastUpdated={-1}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		await waitFor(() => {
+			expect(requestsMade.length).toBeGreaterThan(0);
+		});
+
+		// Find the attribute_keys request
+		const attributeKeysRequest = requestsMade.find((req) =>
+			req.url.includes('/autocomplete/attribute_keys'),
+		);
+
+		expect(attributeKeysRequest).toBeDefined();
+
+		const aggregateAttribute = attributeKeysRequest?.params.get(
+			'aggregateAttribute',
+		);
+
+		expect(aggregateAttribute).toBe('k8s_volume_capacity');
+	});
+
+	it('should call aggregate keys API with k8s.volume.capacity when dotMetrics enabled', async () => {
+		jest
+			.spyOn(await import('providers/App/App'), 'useAppContext')
+			.mockReturnValue({
+				featureFlags: [
+					{
+						name: FeatureKeys.DOT_METRICS_ENABLED,
+						active: true,
+						usage: 0,
+						usage_limit: 0,
+						route: '',
+					},
+				],
+				user: { role: 'ADMIN' } as IUser,
+				activeLicense: (null as unknown) as LicenseResModel,
+			} as IAppContext);
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<Provider store={store}>
+					<MemoryRouter>
+						<K8sVolumesList
+							isFiltersVisible={false}
+							handleFilterVisibilityChange={jest.fn()}
+							quickFiltersLastUpdated={-1}
+						/>
+					</MemoryRouter>
+				</Provider>
+			</QueryClientProvider>,
+		);
+
+		await waitFor(() => {
+			expect(requestsMade.length).toBeGreaterThan(0);
+		});
+
+		const attributeKeysRequest = requestsMade.find((req) =>
+			req.url.includes('/autocomplete/attribute_keys'),
+		);
+
+		expect(attributeKeysRequest).toBeDefined();
+
+		const aggregateAttribute = attributeKeysRequest?.params.get(
+			'aggregateAttribute',
+		);
+
+		expect(aggregateAttribute).toBe('k8s.volume.capacity');
+	});
+});


### PR DESCRIPTION
## Pull Request

The group by selector was not showing the correct fields to group by for Volumes Page.

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The fetch keys was using the wrong category.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:
<img width="272" height="285" alt="image" src="https://github.com/user-attachments/assets/f5ffc1e1-535b-4117-a79b-afe5629d946a" />

After:
<img width="306" height="359" alt="image" src="https://github.com/user-attachments/assets/dd2d9d0c-f4bb-4de6-8740-4ff826f326ba" />

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

It was introduced this way, so it has this bug a long time ago.

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

Was introduced with bug, likely just copy/paste from other page and forgot to update the category.

#### Fix Strategy
> How does this PR address the root cause?

Just update to the correct category.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification:
- Edge cases covered:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | The Infrastructure Monitoring page for Volumes now suggest the correct attributes related to volumes. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

