### PR TITLE
fix(ui): correct border color of metric tags in External APIs light mode

### DIFF
--- a/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
+++ b/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
@@ -266,6 +266,7 @@
 			}
 
 			.round-metric-tag {
+				border-color: rgba(0, 0, 0, 0.12);
 				color: var(--bg-vanilla-100);
 			}
 		}


### PR DESCRIPTION
In light mode, the .round-metric-tag border was inheriting var(--bg-slate-400) — a dark-mode CSS variable that resolves to a near-black color (#1d212d), making tags look broken against the light background.

Added a light-mode override using rgba(0, 0, 0, 0.12) to align with the subtle border convention used elsewhere in SigNoz light mode (e.g. traces table, ant-table borders).

Fixes #9393

## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?



#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

#### Fix Strategy
> How does this PR address the root cause?

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification:
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix / Maintenance |
| Description | User-facing summary |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, CSS-only change that adjusts styling for `.round-metric-tag` in light mode without affecting application logic.
> 
> **Overview**
> Fixes External APIs Explorer light-mode styling by overriding `.round-metric-tag` to use a subtle `rgba(0, 0, 0, 0.12)` border color (instead of inheriting the darker theme variable), improving contrast against the light table background.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 868ba0f8311cc43699f93748a42792cd116f895b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->