### PR TITLE
fix(infra-monitoring): volume details charts rendering undefined as legend

### DIFF
--- a/frontend/src/container/InfraMonitoringK8s/Volumes/VolumeDetails/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8s/Volumes/VolumeDetails/constants.ts
@@ -62,9 +62,6 @@ export const getVolumeQueryPayload = (
 	const k8sPVCNameKey = dotMetricsEnabled
 		? 'k8s.persistentvolumeclaim.name'
 		: 'k8s_persistentvolumeclaim_name';
-	const legendTemplate = dotMetricsEnabled
-		? '{{k8s.namespace.name}}-{{k8s.pod.name}}'
-		: '{{k8s_namespace_name}}-{{k8s_pod_name}}';
 
 	return [
 		{
@@ -136,7 +133,7 @@ export const getVolumeQueryPayload = (
 							functions: [],
 							groupBy: [],
 							having: [],
-							legend: legendTemplate,
+							legend: 'Available',
 							limit: null,
 							orderBy: [],
 							queryName: 'A',
@@ -228,7 +225,7 @@ export const getVolumeQueryPayload = (
 							functions: [],
 							groupBy: [],
 							having: [],
-							legend: legendTemplate,
+							legend: 'Capacity',
 							limit: null,
 							orderBy: [],
 							queryName: 'A',
@@ -319,7 +316,7 @@ export const getVolumeQueryPayload = (
 							},
 							groupBy: [],
 							having: [],
-							legend: legendTemplate,
+							legend: 'Inodes Used',
 							limit: null,
 							orderBy: [],
 							queryName: 'A',
@@ -411,7 +408,7 @@ export const getVolumeQueryPayload = (
 							},
 							groupBy: [],
 							having: [],
-							legend: legendTemplate,
+							legend: 'Total Inodes',
 							limit: null,
 							orderBy: [],
 							queryName: 'A',
@@ -503,7 +500,7 @@ export const getVolumeQueryPayload = (
 							},
 							groupBy: [],
 							having: [],
-							legend: legendTemplate,
+							legend: 'Inodes Free',
 							limit: null,
 							orderBy: [],
 							queryName: 'A',


### PR DESCRIPTION
## Pull Request
---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The labels for these charts were all undefined due to legend using variables instead of hardcoded values like the other options.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

<img width="1122" height="1194" alt="image" src="https://github.com/user-attachments/assets/a673da55-3605-431f-920e-6e8563213480" />


After:

<img width="1112" height="1192" alt="image" src="https://github.com/user-attachments/assets/5c229ef5-36c2-4537-9b04-5c368a597612" />

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

The legends were not being rendered.

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

The backend query does not populate the legend using variables that are not in groupBy (not 100% sure if this is correct).

#### Fix Strategy
> How does this PR address the root cause?

Use static values like the other charts inside Infrastructure monitoring.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification: Yes
- Edge cases covered:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Volume Details page of Infrastructure Monitoring now shows correctly the legend for the charts. |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
