### PR TITLE
refactor: remove DeprecatedFlags CLI flag backward compatibility

### DIFF
--- a/cmd/community/server.go
+++ b/cmd/community/server.go
@@ -32,7 +32,6 @@ import (
 )
 
 func registerServer(parentCmd *cobra.Command, logger *slog.Logger) {
-	var flags signoz.DeprecatedFlags
 	var configFiles []string
 
 	serverCmd := &cobra.Command{
@@ -40,7 +39,7 @@ func registerServer(parentCmd *cobra.Command, logger *slog.Logger) {
 		Short:              "Run the SigNoz server",
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		RunE: func(currCmd *cobra.Command, args []string) error {
-			config, err := cmd.NewSigNozConfig(currCmd.Context(), logger, configFiles, flags)
+			config, err := cmd.NewSigNozConfig(currCmd.Context(), logger, configFiles)
 			if err != nil {
 				return err
 			}
@@ -50,7 +49,6 @@ func registerServer(parentCmd *cobra.Command, logger *slog.Logger) {
 	}
 
 	serverCmd.Flags().StringArrayVar(&configFiles, "config", nil, "path to a YAML configuration file (can be specified multiple times, later files override earlier ones)")
-	flags.RegisterFlags(serverCmd)
 	parentCmd.AddCommand(serverCmd)
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/signoz"
 )
 
-func NewSigNozConfig(ctx context.Context, logger *slog.Logger, configFiles []string, flags signoz.DeprecatedFlags) (signoz.Config, error) {
+func NewSigNozConfig(ctx context.Context, logger *slog.Logger, configFiles []string) (signoz.Config, error) {
 	uris := make([]string, 0, len(configFiles)+1)
 	for _, f := range configFiles {
 		uris = append(uris, "file:"+f)
@@ -27,7 +27,6 @@ func NewSigNozConfig(ctx context.Context, logger *slog.Logger, configFiles []str
 				fileprovider.NewFactory(),
 			},
 		},
-		flags,
 	)
 	if err != nil {
 		return signoz.Config{}, err

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -7,14 +7,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/SigNoz/signoz/pkg/signoz"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewSigNozConfig_NoConfigFiles(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
-	config, err := NewSigNozConfig(context.Background(), logger, nil, signoz.DeprecatedFlags{})
+	config, err := NewSigNozConfig(context.Background(), logger, nil)
 	require.NoError(t, err)
 	assert.NotZero(t, config)
 }
@@ -29,7 +28,7 @@ cache:
 	require.NoError(t, err)
 
 	logger := slog.New(slog.DiscardHandler)
-	config, err := NewSigNozConfig(context.Background(), logger, []string{configPath}, signoz.DeprecatedFlags{})
+	config, err := NewSigNozConfig(context.Background(), logger, []string{configPath})
 	require.NoError(t, err)
 	assert.Equal(t, "redis", config.Cache.Provider)
 }
@@ -54,7 +53,7 @@ cache:
 	require.NoError(t, err)
 
 	logger := slog.New(slog.DiscardHandler)
-	config, err := NewSigNozConfig(context.Background(), logger, []string{basePath, overridePath}, signoz.DeprecatedFlags{})
+	config, err := NewSigNozConfig(context.Background(), logger, []string{basePath, overridePath})
 	require.NoError(t, err)
 	// Later file overrides earlier
 	assert.Equal(t, "redis", config.Cache.Provider)
@@ -74,7 +73,7 @@ cache:
 	t.Setenv("SIGNOZ_CACHE_PROVIDER", "fromenv")
 
 	logger := slog.New(slog.DiscardHandler)
-	config, err := NewSigNozConfig(context.Background(), logger, []string{configPath}, signoz.DeprecatedFlags{})
+	config, err := NewSigNozConfig(context.Background(), logger, []string{configPath})
 	require.NoError(t, err)
 	// Env should override file
 	assert.Equal(t, "fromenv", config.Cache.Provider)
@@ -82,6 +81,6 @@ cache:
 
 func TestNewSigNozConfig_NonexistentFile(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
-	_, err := NewSigNozConfig(context.Background(), logger, []string{"/nonexistent/config.yaml"}, signoz.DeprecatedFlags{})
+	_, err := NewSigNozConfig(context.Background(), logger, []string{"/nonexistent/config.yaml"})
 	assert.Error(t, err)
 }

--- a/cmd/enterprise/server.go
+++ b/cmd/enterprise/server.go
@@ -42,7 +42,6 @@ import (
 )
 
 func registerServer(parentCmd *cobra.Command, logger *slog.Logger) {
-	var flags signoz.DeprecatedFlags
 	var configFiles []string
 
 	serverCmd := &cobra.Command{
@@ -50,7 +49,7 @@ func registerServer(parentCmd *cobra.Command, logger *slog.Logger) {
 		Short:              "Run the SigNoz server",
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		RunE: func(currCmd *cobra.Command, args []string) error {
-			config, err := cmd.NewSigNozConfig(currCmd.Context(), logger, configFiles, flags)
+			config, err := cmd.NewSigNozConfig(currCmd.Context(), logger, configFiles)
 			if err != nil {
 				return err
 			}
@@ -60,7 +59,6 @@ func registerServer(parentCmd *cobra.Command, logger *slog.Logger) {
 	}
 
 	serverCmd.Flags().StringArrayVar(&configFiles, "config", nil, "path to a YAML configuration file (can be specified multiple times, later files override earlier ones)")
-	flags.RegisterFlags(serverCmd)
 	parentCmd.AddCommand(serverCmd)
 }
 

--- a/pkg/signoz/config.go
+++ b/pkg/signoz/config.go
@@ -3,7 +3,6 @@ package signoz
 import (
 	"context"
 	"log/slog"
-	"net/url"
 	"os"
 	"path"
 	"reflect"
@@ -38,7 +37,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/SigNoz/signoz/pkg/version"
 	"github.com/SigNoz/signoz/pkg/web"
-	"github.com/spf13/cobra"
 )
 
 // Config defines the entire input configuration of signoz.
@@ -119,40 +117,7 @@ type Config struct {
 	IdentN identn.Config `mapstructure:"identn"`
 }
 
-// DeprecatedFlags are the flags that are deprecated and scheduled for removal.
-// These flags are used to ensure backward compatibility with the old flags.
-type DeprecatedFlags struct {
-	MaxIdleConns               int
-	MaxOpenConns               int
-	DialTimeout                time.Duration
-	FluxInterval               string
-	FluxIntervalForTraceDetail string
-	PreferSpanMetrics          bool
-	Cluster                    string
-	GatewayUrl                 string
-}
-
-func (df *DeprecatedFlags) RegisterFlags(cmd *cobra.Command) {
-	cmd.Flags().IntVar(&df.MaxIdleConns, "max-idle-conns", 50, "max idle connections to the database")
-	cmd.Flags().IntVar(&df.MaxOpenConns, "max-open-conns", 100, "max open connections to the database")
-	cmd.Flags().DurationVar(&df.DialTimeout, "dial-timeout", 5*time.Second, "dial timeout for the database")
-	cmd.Flags().StringVar(&df.FluxInterval, "flux-interval", "5m", "flux interval")
-	cmd.Flags().StringVar(&df.FluxIntervalForTraceDetail, "flux-interval-for-trace-detail", "2m", "flux interval for trace detail")
-	cmd.Flags().BoolVar(&df.PreferSpanMetrics, "prefer-span-metrics", false, "(prefer span metrics for service level metrics)")
-	cmd.Flags().StringVar(&df.Cluster, "cluster", "cluster", "(cluster name - defaults to 'cluster')")
-	cmd.Flags().StringVar(&df.GatewayUrl, "gateway-url", "", "(url to the gateway)")
-
-	_ = cmd.Flags().MarkDeprecated("max-idle-conns", "use SIGNOZ_TELEMETRYSTORE_MAX__IDLE__CONNS instead")
-	_ = cmd.Flags().MarkDeprecated("max-open-conns", "use SIGNOZ_TELEMETRYSTORE_MAX__OPEN__CONNS instead")
-	_ = cmd.Flags().MarkDeprecated("dial-timeout", "use SIGNOZ_TELEMETRYSTORE_DIAL__TIMEOUT instead")
-	_ = cmd.Flags().MarkDeprecated("flux-interval", "use SIGNOZ_QUERIER_FLUX__INTERVAL instead")
-	_ = cmd.Flags().MarkDeprecated("flux-interval-for-trace-detail", "use SIGNOZ_QUERIER_FLUX__INTERVAL instead")
-	_ = cmd.Flags().MarkDeprecated("cluster", "use SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_CLUSTER instead")
-	_ = cmd.Flags().MarkDeprecated("prefer-span-metrics", "use SIGNOZ_FLAGGER_CONFIG_BOOLEAN_USE__SPAN__METRICS instead")
-	_ = cmd.Flags().MarkDeprecated("gateway-url", "use SIGNOZ_GATEWAY_URL instead")
-}
-
-func NewConfig(ctx context.Context, logger *slog.Logger, resolverConfig config.ResolverConfig, deprecatedFlags DeprecatedFlags) (Config, error) {
+func NewConfig(ctx context.Context, logger *slog.Logger, resolverConfig config.ResolverConfig) (Config, error) {
 	configFactories := []factory.ConfigFactory{
 		global.NewConfigFactory(),
 		version.NewConfigFactory(),
@@ -190,7 +155,7 @@ func NewConfig(ctx context.Context, logger *slog.Logger, resolverConfig config.R
 		return Config{}, err
 	}
 
-	mergeAndEnsureBackwardCompatibility(ctx, logger, &config, deprecatedFlags)
+	mergeAndEnsureBackwardCompatibility(ctx, logger, &config)
 
 	if err := validateConfig(config); err != nil {
 		return Config{}, err
@@ -215,7 +180,7 @@ func validateConfig(config Config) error {
 	return nil
 }
 
-func mergeAndEnsureBackwardCompatibility(ctx context.Context, logger *slog.Logger, config *Config, deprecatedFlags DeprecatedFlags) {
+func mergeAndEnsureBackwardCompatibility(ctx context.Context, logger *slog.Logger, config *Config) {
 	if os.Getenv("SIGNOZ_LOCAL_DB_PATH") != "" {
 		logger.WarnContext(ctx, "[Deprecated] env SIGNOZ_LOCAL_DB_PATH is deprecated and scheduled for removal. Please use SIGNOZ_SQLSTORE_SQLITE_PATH instead.")
 		config.SQLStore.Sqlite.Path = os.Getenv("SIGNOZ_LOCAL_DB_PATH")
@@ -250,21 +215,6 @@ func mergeAndEnsureBackwardCompatibility(ctx context.Context, logger *slog.Logge
 	if os.Getenv("ClickHouseUrl") != "" {
 		logger.WarnContext(ctx, "[Deprecated] env ClickHouseUrl is deprecated and scheduled for removal. Please use SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_DSN instead.")
 		config.TelemetryStore.Clickhouse.DSN = os.Getenv("ClickHouseUrl")
-	}
-
-	if deprecatedFlags.MaxIdleConns != 50 {
-		logger.WarnContext(ctx, "[Deprecated] flag --max-idle-conns is deprecated and scheduled for removal. Please use SIGNOZ_TELEMETRYSTORE_MAX__IDLE__CONNS instead.")
-		config.TelemetryStore.Connection.MaxIdleConns = deprecatedFlags.MaxIdleConns
-	}
-
-	if deprecatedFlags.MaxOpenConns != 100 {
-		logger.WarnContext(ctx, "[Deprecated] flag --max-open-conns is deprecated and scheduled for removal. Please use SIGNOZ_TELEMETRYSTORE_MAX__OPEN__CONNS instead.")
-		config.TelemetryStore.Connection.MaxOpenConns = deprecatedFlags.MaxOpenConns
-	}
-
-	if deprecatedFlags.DialTimeout != 5*time.Second {
-		logger.WarnContext(ctx, "[Deprecated] flag --dial-timeout is deprecated and scheduled for removal. Please use SIGNOZ_TELEMETRYSTORE_DIAL__TIMEOUT instead.")
-		config.TelemetryStore.Connection.DialTimeout = deprecatedFlags.DialTimeout
 	}
 
 	if os.Getenv("INVITE_EMAIL_TEMPLATE") != "" {
@@ -315,49 +265,12 @@ func mergeAndEnsureBackwardCompatibility(ctx context.Context, logger *slog.Logge
 		config.Analytics.Enabled = os.Getenv("TELEMETRY_ENABLED") == "true"
 	}
 
-	if deprecatedFlags.FluxInterval != "" {
-		logger.WarnContext(ctx, "[Deprecated] flag --flux-interval is deprecated and scheduled for removal. Please use SIGNOZ_QUERIER_FLUX__INTERVAL instead.")
-		fluxInterval, err := time.ParseDuration(deprecatedFlags.FluxInterval)
-		if err != nil {
-			logger.WarnContext(ctx, "Error parsing --flux-interval, using default value.")
-		} else {
-			config.Querier.FluxInterval = fluxInterval
-		}
-	}
-
-	if deprecatedFlags.FluxIntervalForTraceDetail != "" {
-		logger.WarnContext(ctx, "[Deprecated] flag --flux-interval-for-trace-detail is deprecated and scheduled for complete removal. Please use SIGNOZ_QUERIER_FLUX__INTERVAL instead.")
-	}
-
-	if deprecatedFlags.Cluster != "" {
-		logger.WarnContext(ctx, "[Deprecated] flag --cluster is deprecated and scheduled for removal. Please use SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_CLUSTER instead.")
-		config.TelemetryStore.Clickhouse.Cluster = deprecatedFlags.Cluster
-	}
-
-	if deprecatedFlags.PreferSpanMetrics {
-		logger.WarnContext(ctx, "[Deprecated] flag --prefer-span-metrics is deprecated and scheduled for removal. Please use SIGNOZ_FLAGGER_CONFIG_BOOLEAN_USE__SPAN__METRICS instead.")
-		if config.Flagger.Config.Boolean == nil {
-			config.Flagger.Config.Boolean = make(map[string]bool)
-		}
-		config.Flagger.Config.Boolean[flagger.FeatureUseSpanMetrics.String()] = deprecatedFlags.PreferSpanMetrics
-	}
-
 	if os.Getenv("USE_SPAN_METRICS") != "" {
 		logger.WarnContext(ctx, "[Deprecated] env USE_SPAN_METRICS is deprecated and scheduled for removal. Please use SIGNOZ_FLAGGER_CONFIG_BOOLEAN_USE__SPAN__METRICS instead.")
 		if config.Flagger.Config.Boolean == nil {
 			config.Flagger.Config.Boolean = make(map[string]bool)
 		}
 		config.Flagger.Config.Boolean[flagger.FeatureUseSpanMetrics.String()] = os.Getenv("USE_SPAN_METRICS") == "true"
-	}
-
-	if deprecatedFlags.GatewayUrl != "" {
-		logger.WarnContext(ctx, "[Deprecated] flag --gateway-url is deprecated and scheduled for removal. Please use SIGNOZ_GATEWAY_URL instead.")
-		u, err := url.Parse(deprecatedFlags.GatewayUrl)
-		if err != nil {
-			logger.WarnContext(ctx, "Error parsing --gateway-url, using default value.")
-		} else {
-			config.Gateway.URL = u
-		}
 	}
 
 	if os.Getenv("SIGNOZ_JWT_SECRET") != "" {

--- a/pkg/signoz/config_test.go
+++ b/pkg/signoz/config_test.go
@@ -13,6 +13,6 @@ import (
 // their default values.
 func TestValidateConfig(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
-	_, err := NewConfig(context.Background(), logger, configtest.NewResolverConfig(), DeprecatedFlags{})
+	_, err := NewConfig(context.Background(), logger, configtest.NewResolverConfig())
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
- Remove the `DeprecatedFlags` struct, `RegisterFlags` method, and all 8 deprecated CLI flags (`--max-idle-conns`, `--max-open-conns`, `--dial-timeout`, `--flux-interval`, `--flux-interval-for-trace-detail`, `--prefer-span-metrics`, `--cluster`, `--gateway-url`)
- Clean up all call sites in `cmd/config.go`, `cmd/community/server.go`, `cmd/enterprise/server.go`, and tests
- Deprecated environment variable handling in `mergeAndEnsureBackwardCompatibility` is intentionally retained

Closes #6805

## Test plan
- [x] `go build ./cmd/community/` succeeds
- [x] `go build ./cmd/enterprise/` succeeds
- [x] `go test ./cmd/... ./pkg/signoz/...` passes