### PR TITLE
refactor(instrumentation): flatten code source into flat keys

### DIFF
--- a/pkg/instrumentation/logger.go
+++ b/pkg/instrumentation/logger.go
@@ -13,13 +13,7 @@ type zapToSlogConverter struct{}
 func NewLogger(config Config) *slog.Logger {
 	logger := slog.New(
 		loghandler.New(
-			slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: config.Logs.Level, AddSource: true, ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
-				// This is more in line with OpenTelemetry semantic conventions
-				if a.Key == slog.SourceKey {
-					a.Key = "code"
-					return a
-				}
-
+			slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: config.Logs.Level, ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 				if a.Key == slog.TimeKey {
 					a.Key = "timestamp"
 					return a
@@ -27,6 +21,7 @@ func NewLogger(config Config) *slog.Logger {
 
 				return a
 			}}),
+			loghandler.NewSource(),
 			loghandler.NewCorrelation(),
 			loghandler.NewFiltering(),
 			loghandler.NewException(),

--- a/pkg/instrumentation/loghandler/source.go
+++ b/pkg/instrumentation/loghandler/source.go
@@ -1,0 +1,28 @@
+package loghandler
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+)
+
+type source struct{}
+
+func NewSource() *source {
+	return &source{}
+}
+
+func (h *source) Wrap(next LogHandler) LogHandler {
+	return LogHandlerFunc(func(ctx context.Context, record slog.Record) error {
+		if record.PC != 0 {
+			frame, _ := runtime.CallersFrames([]uintptr{record.PC}).Next()
+			record.AddAttrs(
+				slog.String("code.filepath", frame.File),
+				slog.String("code.function", frame.Function),
+				slog.Int("code.lineno", frame.Line),
+			)
+		}
+
+		return next.Handle(ctx, record)
+	})
+}

--- a/pkg/instrumentation/loghandler/source_test.go
+++ b/pkg/instrumentation/loghandler/source_test.go
@@ -1,0 +1,37 @@
+package loghandler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSource(t *testing.T) {
+	src := NewSource()
+
+	buf := bytes.NewBuffer(nil)
+	logger := slog.New(&handler{base: slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}), wrappers: []Wrapper{src}})
+
+	logger.InfoContext(context.Background(), "test")
+
+	m := make(map[string]any)
+	err := json.Unmarshal(buf.Bytes(), &m)
+	require.NoError(t, err)
+
+	assert.Contains(t, m, "code.filepath")
+	assert.Contains(t, m, "code.function")
+	assert.Contains(t, m, "code.lineno")
+
+	assert.Contains(t, m["code.filepath"], "source_test.go")
+	assert.Contains(t, m["code.function"], "TestSource")
+	assert.NotZero(t, m["code.lineno"])
+
+	// Ensure the nested "source" key is not present.
+	assert.NotContains(t, m, "source")
+	assert.NotContains(t, m, "code")
+}


### PR DESCRIPTION
## Summary
- Add a `Source` log handler wrapper that extracts source info from `record.PC` and adds flat `code.filepath`, `code.function`, `code.lineno` keys to log output
- Remove `AddSource: true` from the JSON handler since the wrapper handles source resolution directly
- Produces flat keys matching OTel semantic conventions, consistent with `exception.type`, `exception.message` etc.

## Test plan
- [x] Unit test verifying flat keys are present and nested `source`/`code` group is absent
- [x] All existing instrumentation tests pass