### PR TITLE
fix(querycache): avoid pointer aliasing in cached ranges

### DIFF
--- a/pkg/query-service/querycache/query_range_cache.go
+++ b/pkg/query-service/querycache/query_range_cache.go
@@ -242,9 +242,9 @@ func (q *queryCache) getCachedSeriesData(orgID valuer.UUID, cacheKey string) []*
 	if err != nil && !errors.Ast(err, errors.TypeNotFound) {
 		return nil
 	}
-	cachedSeriesData := make([]*CachedSeriesData, 0)
-	for _, cachedSeries := range cacheableSeriesData.Series {
-		cachedSeriesData = append(cachedSeriesData, &cachedSeries)
+	cachedSeriesData := make([]*CachedSeriesData, 0, len(cacheableSeriesData.Series))
+	for i := range cacheableSeriesData.Series {
+		cachedSeriesData = append(cachedSeriesData, &cacheableSeriesData.Series[i])
 	}
 	return cachedSeriesData
 }


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?



#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

#### Fix Strategy
> How does this PR address the root cause?

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification:
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix / Maintenance |
| Description | User-facing summary |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, localized change to how cached series slices are converted to pointers; could affect cache hit/miss behavior if prior aliasing bug caused incorrect range comparisons, but logic is otherwise unchanged.
> 
> **Overview**
> Fixes `getCachedSeriesData` to avoid Go range-variable pointer aliasing by taking pointers to slice elements (`&Series[i]`) and preallocating the result capacity.
> 
> This ensures each returned `*CachedSeriesData` references the correct cached range, preventing incorrect/mutated range data when computing missing intervals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b62753f759e1743e124317692afaf16d03ef1477. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->