### PR TITLE
fix(ui): render error state before loading in DataStateRenderer

### DIFF
--- a/frontend/src/periscope/components/DataStateRenderer/DataStateRenderer.tsx
+++ b/frontend/src/periscope/components/DataStateRenderer/DataStateRenderer.tsx
@@ -27,12 +27,16 @@ function DataStateRenderer<T>({
 }: DataStateRendererProps<T>): JSX.Element {
 	const { t } = useTranslation('common');
 
-	if (isLoading || isRefetching || !data) {
+	if (isError) {
+		return <div>{errorMessage || t('something_went_wrong')}</div>;
+	}
+
+	if (isLoading || isRefetching) {
 		return <Spinner tip={loadingMessage} height="100%" />;
 	}
 
-	if (isError || data === null) {
-		return <div>{errorMessage ?? t('something_went_wrong')}</div>;
+	if (data === null) {
+		return <div>{errorMessage || t('something_went_wrong')}</div>;
 	}
 
 	return <>{children(data)}</>;


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?



#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

#### Fix Strategy
> How does this PR address the root cause?

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification:
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix / Maintenance |
| Description | User-facing summary |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI logic change that only reorders state precedence; main potential regression is different rendering when `isError` and loading/refetching are both true or when `data` is temporarily undefined.
> 
> **Overview**
> **Updates `DataStateRenderer` state precedence.** It now renders the error message immediately when `isError` is true (even if `isLoading`/`isRefetching` are also true), and shows the spinner only for explicit loading/refetching states.
> 
> **Tightens null-data handling.** The component no longer treats `!data` as loading; it only renders an error fallback when `data === null`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65853c0467747df7aecfb38f0eb84cae3fc9fc42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->