### PR TITLE
fix: allow deleting pending admin invite (fixes #10623)

### DIFF
--- a/pkg/modules/user/impluser/module.go
+++ b/pkg/modules/user/impluser/module.go
@@ -294,13 +294,16 @@ func (module *Module) DeleteUser(ctx context.Context, orgID valuer.UUID, id stri
 	}
 
 	// don't allow to delete the last admin user
-	adminUsers, err := module.store.GetActiveUsersByRoleAndOrgID(ctx, types.RoleAdmin, orgID)
-	if err != nil {
-		return err
-	}
+	// Skip for pending_invite: they're not active admins, so revoking their invite cannot reduce the active admin count
+	if user.Status != types.UserStatusPendingInvite {
+		adminUsers, err := module.store.GetActiveUsersByRoleAndOrgID(ctx, types.RoleAdmin, orgID)
+		if err != nil {
+			return err
+		}
 
-	if len(adminUsers) == 1 && user.Role == types.RoleAdmin {
-		return errors.New(errors.TypeForbidden, errors.CodeForbidden, "cannot delete the last admin")
+		if len(adminUsers) == 1 && user.Role == types.RoleAdmin {
+			return errors.New(errors.TypeForbidden, errors.CodeForbidden, "cannot delete the last admin")
+		}
 	}
 
 	// since revoke is idempotant multiple calls to revoke won't cause issues in case of retries


### PR DESCRIPTION


## Pull Request

---

### 📄 Summary
-The last-admin guard in DeleteUser incorrectly blocked deletion of pending admin invites.



#### Screenshots / Screen Recordings (if applicable)
<img width="1899" height="952" alt="image" src="https://github.com/user-attachments/assets/b9693b0c-5274-4dda-a9a8-919a05f17320" />



#### Issues closed by this PR
> #10623

---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
The last-admin guard in DeleteUser (around line 296) checked user.Role == types.RoleAdmin without considering user.Status. Pending invites create user records with Admin role, but they are not counted by GetActiveUsersByRoleAndOrgID. Deleting a pending admin invite therefore cannot remove the last active admin, yet the guard blocked the operation.

#### Fix Strategy
> How does this PR address the root cause?
Skip the last-admin guard when user.Status == types.UserStatusPendingInvite. These users are never included in the active admin count, so deleting them cannot make the caller the last admin.
---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A
- Manual verification: Invite a user as Admin, cancel the pending invite via UI, confirm 200/204 instead of 403
- Edge cases covered: Viewer/Editor invites and active admin deletion still protected; guard only skipped for pending invites

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Limited to DeleteUser when deleting users with UserStatusPendingInvite
- Potential regressions: None; pending invite users were never considered active admins
- Rollback plan: Revert the change to restore the previous behavior

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fix deletion of pending admin invites being incorrectly blocked (403) when only one active admin exists |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers
The guard still runs for non-pending users. The only change is wrapping it in if user.Status != types.UserStatusPendingInvite { ... } so pending invite deletions bypass the check, since pending invite users are never included in the active admin count.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, small conditional change to `DeleteUser` that only affects users in `pending_invite` status; active admin deletion protection remains unchanged.
> 
> **Overview**
> Fixes `DeleteUser` incorrectly blocking deletion of *pending admin invites* under the “last admin” safeguard.
> 
> The last-admin check now runs only for non-`pending_invite` users, allowing invite revocation/soft-delete for pending users while keeping the existing guard for active admins.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 056af999be0eaef52c0d813a70562f79cc3b3f5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->