### PR TITLE
test: fix flaky public dashboard query range integration test

### DIFF
--- a/tests/integration/src/dashboard/02_public_dashboard.py
+++ b/tests/integration/src/dashboard/02_public_dashboard.py
@@ -175,7 +175,7 @@ def test_public_dashboard_widget_query_range(
         ),
         json={
             "timeRangeEnabled": False,
-            "defaultTimeRange": "10s",
+            "defaultTimeRange": "10m",
         },
         headers={"Authorization": f"Bearer {admin_token}"},
         timeout=2,


### PR DESCRIPTION
## Summary
- widen the fixed public dashboard default time range in the integration test from 10s to 10m
- align the test window with the seeded metrics inserted 1 to 5 minutes before the query
- keep the test validating the public widget query_range path after the querier started returning 404 for missing metric data in range (In https://github.com/SigNoz/signoz/pull/10560)