### PR TITLE
fix: accept user-friendly timeshift inputs

### DIFF
--- a/frontend/src/constants/queryFunctionOptions.ts
+++ b/frontend/src/constants/queryFunctionOptions.ts
@@ -154,6 +154,7 @@ export const queryFunctionsTypesConfig: QueryFunctionConfigType = {
 	timeShift: {
 		showInput: true,
 		inputType: 'text',
+		placeholder: 'e.g. 5m, 1h, 1 day ago',
 	},
 	fillZero: {
 		showInput: false,

--- a/frontend/src/container/QueryBuilder/components/QueryFunctions/Function.tsx
+++ b/frontend/src/container/QueryBuilder/components/QueryFunctions/Function.tsx
@@ -35,9 +35,11 @@ export default function Function({
 	const isDarkMode = useIsDarkMode();
 	// Normalize function name to handle backend response case sensitivity
 	const normalizedFunctionName = normalizeFunctionName(funcData.name);
-	const { showInput, disabled } = queryFunctionsTypesConfig[
-		normalizedFunctionName
-	];
+	const {
+		showInput,
+		disabled,
+		placeholder,
+	} = queryFunctionsTypesConfig[normalizedFunctionName];
 
 	let functionValue;
 
@@ -104,6 +106,7 @@ export default function Function({
 					minAutoWidth={70}
 					maxAutoWidth={150}
 					className="query-function-value"
+					placeholder={placeholder}
 				/>
 			)}
 

--- a/frontend/src/container/QueryBuilder/components/QueryFunctions/QueryFunctions.tsx
+++ b/frontend/src/container/QueryBuilder/components/QueryFunctions/QueryFunctions.tsx
@@ -10,7 +10,6 @@ import { DataSource, QueryFunctionsTypes } from 'types/common/queryBuilder';
 import { normalizeFunctionName } from 'utils/functionNameNormalizer';
 
 import Function from './Function';
-import { toFloat64 } from './utils';
 
 import './QueryFunctions.styles.scss';
 
@@ -166,10 +165,7 @@ export default function QueryFunctions({
 		if (updateFunctions && updateFunctions.length > 0 && updateFunctions[index]) {
 			updateFunctions[index].args = [
 				{
-					value:
-						updateFunctions[index].name === QueryFunctionsTypes.TIME_SHIFT
-							? toFloat64(value)
-							: value,
+					value,
 				},
 			];
 			setFunctions(updateFunctions);

--- a/frontend/src/container/QueryBuilder/components/QueryFunctions/utils.ts
+++ b/frontend/src/container/QueryBuilder/components/QueryFunctions/utils.ts
@@ -1,7 +1,0 @@
-export const toFloat64 = (value: string): number => {
-	const parsed = parseFloat(value);
-	if (!Number.isFinite(parsed)) {
-		console.error(`Invalid value for timeshift. value: ${value}`);
-	}
-	return parsed;
-};

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -80,17 +79,9 @@ func New(
 func extractShiftFromBuilderQuery[T any](spec qbtypes.QueryBuilderQuery[T]) int64 {
 	for _, fn := range spec.Functions {
 		if fn.Name == qbtypes.FunctionNameTimeShift && len(fn.Args) > 0 {
-			switch v := fn.Args[0].Value.(type) {
-			case float64:
-				return int64(v)
-			case int64:
-				return v
-			case int:
-				return int64(v)
-			case string:
-				if shiftFloat, err := strconv.ParseFloat(v, 64); err == nil {
-					return int64(shiftFloat)
-				}
+			shiftSeconds, err := valuer.ParseTimeShiftSeconds(fn.Args[0].Value)
+			if err == nil {
+				return int64(shiftSeconds)
 			}
 		}
 	}

--- a/pkg/querier/shift_test.go
+++ b/pkg/querier/shift_test.go
@@ -51,6 +51,46 @@ func TestAdjustTimeRangeForShift(t *testing.T) {
 			expectedToMS:   1940000, // 2000000 - 60000
 		},
 		{
+			name: "shift by compact duration string",
+			spec: qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]{
+				Functions: []qbtypes.Function{
+					{
+						Name: qbtypes.FunctionNameTimeShift,
+						Args: []qbtypes.FunctionArg{
+							{Value: "5m"},
+						},
+					},
+				},
+			},
+			timeRange: qbtypes.TimeRange{
+				From: 1000000,
+				To:   2000000,
+			},
+			requestType:    qbtypes.RequestTypeTimeSeries,
+			expectedFromMS: 700000,
+			expectedToMS:   1700000,
+		},
+		{
+			name: "shift by human readable string",
+			spec: qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]{
+				Functions: []qbtypes.Function{
+					{
+						Name: qbtypes.FunctionNameTimeShift,
+						Args: []qbtypes.FunctionArg{
+							{Value: "1 hour ago"},
+						},
+					},
+				},
+			},
+			timeRange: qbtypes.TimeRange{
+				From: 10000000,
+				To:   20000000,
+			},
+			requestType:    qbtypes.RequestTypeScalar,
+			expectedFromMS: 6400000,
+			expectedToMS:   16400000,
+		},
+		{
 			name: "shift by negative 30 seconds (future shift)",
 			spec: qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]{
 				Functions: []qbtypes.Function{
@@ -169,6 +209,34 @@ func TestExtractShiftFromBuilderQuery(t *testing.T) {
 				},
 			},
 			expectedShiftBy: 3600,
+		},
+		{
+			name: "extract from timeShift function with compact duration string",
+			spec: qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]{
+				Functions: []qbtypes.Function{
+					{
+						Name: qbtypes.FunctionNameTimeShift,
+						Args: []qbtypes.FunctionArg{
+							{Value: "5m"},
+						},
+					},
+				},
+			},
+			expectedShiftBy: 300,
+		},
+		{
+			name: "extract from timeShift function with human readable string",
+			spec: qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]{
+				Functions: []qbtypes.Function{
+					{
+						Name: qbtypes.FunctionNameTimeShift,
+						Args: []qbtypes.FunctionArg{
+							{Value: "1 week ago"},
+						},
+					},
+				},
+			},
+			expectedShiftBy: 604800,
 		},
 		{
 			name: "no timeShift function",

--- a/pkg/query-service/app/parser_test.go
+++ b/pkg/query-service/app/parser_test.go
@@ -581,6 +581,56 @@ func TestParseQueryRangeParamsCompositeQuery(t *testing.T) {
 			hasShiftBy: true,
 			shiftBy:    3600,
 		},
+		{
+			desc: "builder query with shift by as compact duration string",
+			compositeQuery: v3.CompositeQuery{
+				PanelType: v3.PanelTypeGraph,
+				QueryType: v3.QueryTypeBuilder,
+				BuilderQueries: map[string]*v3.BuilderQuery{
+					"A": {
+						QueryName:          "A",
+						DataSource:         "logs",
+						AggregateOperator:  "sum",
+						AggregateAttribute: v3.AttributeKey{Key: "attribute"},
+						GroupBy:            []v3.AttributeKey{{Key: "group_key"}},
+						Expression:         "A",
+						Functions: []v3.Function{
+							{
+								Name: v3.FunctionNameTimeShift,
+								Args: []interface{}{"5m"},
+							},
+						},
+					},
+				},
+			},
+			hasShiftBy: true,
+			shiftBy:    300,
+		},
+		{
+			desc: "builder query with shift by as human readable string",
+			compositeQuery: v3.CompositeQuery{
+				PanelType: v3.PanelTypeGraph,
+				QueryType: v3.QueryTypeBuilder,
+				BuilderQueries: map[string]*v3.BuilderQuery{
+					"A": {
+						QueryName:          "A",
+						DataSource:         "logs",
+						AggregateOperator:  "sum",
+						AggregateAttribute: v3.AttributeKey{Key: "attribute"},
+						GroupBy:            []v3.AttributeKey{{Key: "group_key"}},
+						Expression:         "A",
+						Functions: []v3.Function{
+							{
+								Name: v3.FunctionNameTimeShift,
+								Args: []interface{}{"1 hour ago"},
+							},
+						},
+					},
+				},
+			},
+			hasShiftBy: true,
+			shiftBy:    3600,
+		},
 	}
 
 	for _, tc := range reqCases {

--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -935,13 +935,10 @@ func (b *BuilderQuery) SetShiftByFromFunc() {
 				fns = append(fns, b.Functions[idx+1:]...)
 				b.Functions = fns
 				if len(function.Args) > 0 {
-					if shift, ok := function.Args[0].(float64); ok {
-						timeShiftBy = int64(shift)
-					} else if shift, ok := function.Args[0].(string); ok {
-						shiftBy, err := strconv.ParseFloat(shift, 64)
-						if err != nil {
-							slog.Error("failed to parse time shift by", "shift", shift, signozerrors.Attr(err))
-						}
+					shiftBy, err := valuer.ParseTimeShiftSeconds(function.Args[0])
+					if err != nil {
+						slog.Error("failed to parse time shift by", "shift", function.Args[0], signozerrors.Attr(err))
+					} else {
 						timeShiftBy = int64(shiftBy)
 					}
 				}
@@ -1112,15 +1109,11 @@ func (b *BuilderQuery) Validate(panelType PanelType) error {
 				if len(function.Args) == 0 {
 					return fmt.Errorf("timeShiftBy param missing in query")
 				}
-				_, ok := function.Args[0].(float64)
-				if !ok {
-					// if string, attempt to convert to float
-					timeShiftBy, err := strconv.ParseFloat(function.Args[0].(string), 64)
-					if err != nil {
-						return fmt.Errorf("timeShiftBy param should be a number")
-					}
-					function.Args[0] = timeShiftBy
+				timeShiftBy, err := valuer.ParseTimeShiftSeconds(function.Args[0])
+				if err != nil {
+					return fmt.Errorf("timeShiftBy param should be a valid duration or second value")
 				}
+				function.Args[0] = timeShiftBy
 			} else if function.Name == FunctionNameEWMA3 ||
 				function.Name == FunctionNameEWMA5 ||
 				function.Name == FunctionNameEWMA7 {

--- a/pkg/types/querybuildertypes/querybuildertypesv5/functions.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/functions.go
@@ -148,7 +148,7 @@ func ApplyFunction(fn Function, result *TimeSeries) *TimeSeries {
 		if len(args) == 0 {
 			return result
 		}
-		shift, err := parseFloat64Arg(args[0].Value)
+		shift, err := valuer.ParseTimeShiftSeconds(args[0].Value)
 		if err != nil {
 			return result
 		}
@@ -222,11 +222,11 @@ func (fn Function) ValidateArgs() error {
 				name.StringValue(),
 			)
 		}
-		_, err := parseFloat64Arg(args[0].Value)
+		_, err := valuer.ParseTimeShiftSeconds(args[0].Value)
 		if err != nil {
 			return errors.NewInvalidInputf(
 				errors.CodeInvalidInput,
-				"time shift value must be a floating value for function %s",
+				"time shift value must be a valid duration or second value for function %s",
 				name.StringValue(),
 			)
 		}

--- a/pkg/types/querybuildertypes/querybuildertypesv5/functions_test.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/functions_test.go
@@ -592,6 +592,73 @@ func TestFuncTimeShift(t *testing.T) {
 	}
 }
 
+func TestFunctionValidateArgsTimeShift(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     any
+		wantErr bool
+	}{
+		{
+			name:    "accepts compact duration",
+			arg:     "5m",
+			wantErr: false,
+		},
+		{
+			name:    "accepts human readable duration",
+			arg:     "1 week ago",
+			wantErr: false,
+		},
+		{
+			name:    "rejects invalid text",
+			arg:     "later",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Function{
+				Name: FunctionNameTimeShift,
+				Args: []FunctionArg{
+					{Value: tt.arg},
+				},
+			}.ValidateArgs()
+
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestApplyFunctionTimeShiftFriendlyInput(t *testing.T) {
+	result := createTestTimeSeriesData([]float64{1, 2, 3})
+	newResult := ApplyFunction(
+		Function{
+			Name: FunctionNameTimeShift,
+			Args: []FunctionArg{
+				{Value: "5m"},
+			},
+		},
+		result,
+	)
+
+	got := make([]int64, len(newResult.Values))
+	for i, point := range newResult.Values {
+		got[i] = point.Timestamp
+	}
+
+	want := []int64{300001, 300002, 300003}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("ApplyFunction(timeShift) at index %d timestamp = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
 func TestApplyFunction(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/valuer/time_shift.go
+++ b/pkg/valuer/time_shift.go
@@ -1,0 +1,166 @@
+package valuer
+
+import (
+	"encoding/json"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+)
+
+var (
+	timeShiftAgoSuffixPattern = regexp.MustCompile(`\s+ago$`)
+	timeShiftTextPattern      = regexp.MustCompile(`^(?:(a|an)\s+)?([+-]?\d+(?:\.\d+)?)?\s*([a-z]+)$`)
+	timeShiftTextUnits        = map[string]time.Duration{
+		"s":       time.Second,
+		"sec":     time.Second,
+		"secs":    time.Second,
+		"second":  time.Second,
+		"seconds": time.Second,
+		"m":       time.Minute,
+		"min":     time.Minute,
+		"mins":    time.Minute,
+		"minute":  time.Minute,
+		"minutes": time.Minute,
+		"h":       time.Hour,
+		"hr":      time.Hour,
+		"hrs":     time.Hour,
+		"hour":    time.Hour,
+		"hours":   time.Hour,
+		"d":       24 * time.Hour,
+		"day":     24 * time.Hour,
+		"days":    24 * time.Hour,
+		"w":       7 * 24 * time.Hour,
+		"week":    7 * 24 * time.Hour,
+		"weeks":   7 * 24 * time.Hour,
+	}
+)
+
+// ParseTimeShiftSeconds parses a timeShift value as a floating-point second count.
+// It accepts raw numeric seconds as well as user-friendly text like "5m",
+// "1.5h", "hour ago", "1 day ago", and "1 week".
+func ParseTimeShiftSeconds(value any) (float64, error) {
+	switch v := value.(type) {
+	case float64:
+		return v, nil
+	case float32:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case int32:
+		return float64(v), nil
+	case int:
+		return float64(v), nil
+	case json.Number:
+		return v.Float64()
+	case string:
+		return parseTimeShiftString(v)
+	default:
+		return 0, errors.NewInvalidInputf(
+			errors.CodeInvalidInput,
+			"invalid time shift value type %T",
+			value,
+		)
+	}
+}
+
+func parseTimeShiftString(input string) (float64, error) {
+	normalized := strings.ToLower(strings.TrimSpace(input))
+	if normalized == "" {
+		return 0, errors.NewInvalidInputf(
+			errors.CodeInvalidInput,
+			"time shift value cannot be empty",
+		)
+	}
+
+	hasAgoSuffix := timeShiftAgoSuffixPattern.MatchString(normalized)
+	if hasAgoSuffix {
+		normalized = strings.TrimSpace(timeShiftAgoSuffixPattern.ReplaceAllString(normalized, ""))
+	}
+
+	if shiftSeconds, err := strconv.ParseFloat(normalized, 64); err == nil {
+		if hasAgoSuffix && shiftSeconds < 0 {
+			return 0, errors.NewInvalidInputf(
+				errors.CodeInvalidInput,
+				"time shift value %q cannot be negative when using \"ago\"",
+				input,
+			)
+		}
+		return shiftSeconds, nil
+	}
+
+	if duration, err := time.ParseDuration(strings.ReplaceAll(normalized, " ", "")); err == nil {
+		return durationToSeconds(input, duration, hasAgoSuffix)
+	}
+
+	duration, err := parseTimeShiftTextDuration(normalized)
+	if err != nil {
+		return 0, errors.NewInvalidInputf(
+			errors.CodeInvalidInput,
+			"invalid time shift value %q",
+			input,
+		)
+	}
+
+	return durationToSeconds(input, duration, hasAgoSuffix)
+}
+
+func parseTimeShiftTextDuration(input string) (time.Duration, error) {
+	matches := timeShiftTextPattern.FindStringSubmatch(input)
+	if matches == nil {
+		return 0, errors.NewInvalidInputf(
+			errors.CodeInvalidInput,
+			"invalid time shift value %q",
+			input,
+		)
+	}
+
+	quantityText := matches[2]
+	unitText := matches[3]
+
+	if quantityText == "" {
+		quantityText = "1"
+	}
+
+	quantity, err := strconv.ParseFloat(quantityText, 64)
+	if err != nil {
+		return 0, errors.NewInvalidInputf(
+			errors.CodeInvalidInput,
+			"invalid time shift quantity %q",
+			quantityText,
+		)
+	}
+
+	unit, ok := timeShiftTextUnits[unitText]
+	if !ok {
+		return 0, errors.NewInvalidInputf(
+			errors.CodeInvalidInput,
+			"invalid time shift unit %q",
+			unitText,
+		)
+	}
+
+	return time.Duration(quantity * float64(unit)), nil
+}
+
+func durationToSeconds(input string, duration time.Duration, hasAgoSuffix bool) (float64, error) {
+	if hasAgoSuffix && duration < 0 {
+		return 0, errors.NewInvalidInputf(
+			errors.CodeInvalidInput,
+			"time shift value %q cannot be negative when using \"ago\"",
+			input,
+		)
+	}
+
+	if duration%time.Second != 0 {
+		return 0, errors.NewInvalidInputf(
+			errors.CodeInvalidInput,
+			"time shift value %q must resolve to whole seconds",
+			input,
+		)
+	}
+
+	return duration.Seconds(), nil
+}

--- a/pkg/valuer/time_shift_test.go
+++ b/pkg/valuer/time_shift_test.go
@@ -1,0 +1,96 @@
+package valuer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTimeShiftSeconds(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    any
+		expected float64
+		wantErr  bool
+	}{
+		{
+			name:     "numeric string seconds",
+			input:    "3600",
+			expected: 3600,
+		},
+		{
+			name:     "numeric float seconds",
+			input:    3600.0,
+			expected: 3600,
+		},
+		{
+			name:     "compact minutes",
+			input:    "5m",
+			expected: 300,
+		},
+		{
+			name:     "compact fractional hours",
+			input:    "1.5h",
+			expected: 5400,
+		},
+		{
+			name:     "compact compound duration",
+			input:    "1h30m",
+			expected: 5400,
+		},
+		{
+			name:     "day unit",
+			input:    "1 day",
+			expected: 86400,
+		},
+		{
+			name:     "week ago",
+			input:    "1 week ago",
+			expected: 604800,
+		},
+		{
+			name:     "hour ago without count",
+			input:    "hour ago",
+			expected: 3600,
+		},
+		{
+			name:     "spaced compact duration",
+			input:    "1 h",
+			expected: 3600,
+		},
+		{
+			name:     "negative numeric string",
+			input:    "-30",
+			expected: -30,
+		},
+		{
+			name:    "sub-second duration rejected",
+			input:   "500ms",
+			wantErr: true,
+		},
+		{
+			name:    "negative ago duration rejected",
+			input:   "-1h ago",
+			wantErr: true,
+		},
+		{
+			name:    "invalid input rejected",
+			input:   "later",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			shift, err := ParseTimeShiftSeconds(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, shift)
+		})
+	}
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
This fixes `timeShift` so it can consume user-friendly inputs like `5m`, `1.5h`, and `1 hour ago` instead of only raw numeric seconds.

The issue had two gaps in the current tree:
- the old QueryBuilder UI coerced `timeShift` with `parseFloat`, so `5m` was serialized as `5`
- backend validation and shift extraction only accepted numeric seconds in a few different places

This PR adds a shared parser and routes all affected paths through it so the input format is handled consistently.

#### Screenshots / Screen Recordings (if applicable)
N/A

#### Issues closed by this PR
Closes #10188

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
`timeShift` parsing was inconsistent across the stack. The old frontend query builder converted the input with `parseFloat`, which truncated friendly inputs like `5m` to `5`. On the backend, time shift validation and extraction only accepted numeric seconds, so compact duration strings and human-readable `ago` phrases were rejected or ignored depending on the code path.

#### Fix Strategy
- add a shared backend parser for `timeShift` values that accepts numeric seconds, compact duration strings, and `ago` phrases
- reuse that parser in v5 function validation/execution, querier shift extraction, and v3 builder query validation
- preserve the raw text input in the old QueryBuilder UI and add a placeholder with supported examples
- add tests covering compact and human-readable inputs across the affected backend paths

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
  - `pkg/valuer/time_shift_test.go`
  - `pkg/querier/shift_test.go`
  - `pkg/types/querybuildertypes/querybuildertypesv5/functions_test.go`
  - `pkg/query-service/app/parser_test.go`
- Manual verification:
  - Verified the old QueryBuilder now preserves the typed `timeShift` string instead of coercing it with `parseFloat`
  - Verified the backend call sites now share the same `timeShift` parsing rules
- Edge cases covered:
  - raw numeric seconds, including negative numeric seconds
  - compact durations like `5m`, `1.5h`, `1h30m`
  - human-readable inputs like `hour ago`, `1 hour ago`, `1 week ago`
  - invalid inputs and sub-second duration strings

Note: I could not run Go tests in this environment because a Go toolchain is not installed on PATH, and this clone does not currently have `frontend/node_modules` installed for local frontend test execution.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: limited to `timeShift` parsing and the old QueryBuilder function input handling
- Potential regressions: sub-second duration strings are rejected because the existing query window shift logic stores shifts in seconds
- Rollback plan: revert commit `61a4f42b2`

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | OSS |
| Change Type | Bug Fix |
| Description | `timeShift` now accepts friendly duration inputs like `5m` and `1 hour ago` in the old QueryBuilder/backend parsing flow |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

There is an open PR for timeshift + formula ordering (`#9659`), but this change is separate: it only addresses input parsing and serialization for `timeShift` values.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes time-shift parsing/validation across multiple backend query paths and the legacy QueryBuilder UI, which could alter how existing dashboards interpret `timeShift` values. Risk is mitigated by broad new unit tests covering numeric, duration, and human-readable inputs.
> 
> **Overview**
> Fixes `timeShift` end-to-end to accept *user-friendly durations* (e.g. `5m`, `1.5h`, `1 hour ago`) instead of only raw numeric seconds.
> 
> On the frontend, the legacy QueryBuilder now preserves the raw `timeShift` string (removing `parseFloat` coercion) and shows an input placeholder with examples. On the backend, a shared parser `valuer.ParseTimeShiftSeconds` is introduced and wired into v3 builder validation/`ShiftBy` extraction, v5 function validation/execution, and querier time-range shifting, with new tests added to cover the expanded input formats and edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61a4f42b29cdcd390b488509a933b0f5b5aba114. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->