### PR TITLE
fix: optional chain orderBy access in useLogsData to prevent crash

### DIFF
--- a/frontend/src/hooks/useLogsData.ts
+++ b/frontend/src/hooks/useLogsData.ts
@@ -71,7 +71,7 @@ export const useLogsData = ({
 	}, [logs.length, listQuery]);
 
 	const orderByTimestamp: OrderByPayload | null = useMemo(() => {
-		const timestampOrderBy = listQuery?.orderBy.find(
+		const timestampOrderBy = listQuery?.orderBy?.find(
 			(item) => item.columnName === 'timestamp',
 		);
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
`useLogsData` crashed when `listQuery.orderBy` was `undefined`, even though `listQuery` itself was optional-chained. The missing `?.` on `orderBy` caused a `TypeError` in `LogsPanelComponent`.

#### Issues closed by this PR
Closes https://github.com/SigNoz/engineering-pod/issues/4123

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause
`listQuery?.orderBy.find(...)` — the optional chain only guards against `listQuery` being nullish, but `orderBy` itself can also be `undefined`, causing the crash.

#### Fix Strategy
Changed to `listQuery?.orderBy?.find(...)` so both accesses are safely guarded.

---

### 🧪 Testing Strategy

- Tests added/updated: N/A
- Manual verification: Logs panel no longer crashes when `orderBy` is absent
- Edge cases covered: `listQuery` undefined, `orderBy` undefined

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Only affects `orderByTimestamp` memo in `useLogsData.ts`
- Potential regressions: None — returns `null` when `orderBy` is absent, same as before
- Rollback plan: Revert single character change

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed crash in logs panel when orderBy is undefined |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---