### PR TITLE
fix: optional chain queryFormulas access in QueryBuilderV2 to prevent crash

### DIFF
--- a/frontend/src/components/QueryBuilderV2/QueryBuilderV2.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryBuilderV2.tsx
@@ -239,28 +239,29 @@ export const QueryBuilderV2 = memo(function QueryBuilderV2({
 						))
 					)}
 
-					{!showOnlyWhereClause && currentQuery.builder.queryFormulas.length > 0 && (
-						<div className="qb-formulas-container">
-							{currentQuery.builder.queryFormulas.map((formula, index) => {
-								const query =
-									currentQuery.builder.queryData[index] ||
-									currentQuery.builder.queryData[0];
+					{!showOnlyWhereClause &&
+						(currentQuery.builder.queryFormulas?.length ?? 0) > 0 && (
+							<div className="qb-formulas-container">
+								{currentQuery.builder.queryFormulas?.map((formula, index) => {
+									const query =
+										currentQuery.builder.queryData[index] ||
+										currentQuery.builder.queryData[0];
 
-								return (
-									<div key={formula.queryName} className="qb-formula">
-										<Formula
-											filterConfigs={filterConfigs}
-											query={query}
-											formula={formula}
-											index={index}
-											isAdditionalFilterEnable={false}
-											isQBV2
-										/>
-									</div>
-								);
-							})}
-						</div>
-					)}
+									return (
+										<div key={formula.queryName} className="qb-formula">
+											<Formula
+												filterConfigs={filterConfigs}
+												query={query}
+												formula={formula}
+												index={index}
+												isAdditionalFilterEnable={false}
+												isQBV2
+											/>
+										</div>
+									);
+								})}
+							</div>
+						)}
 
 					{shouldShowFooter && (
 						<QueryFooter
@@ -288,7 +289,7 @@ export const QueryBuilderV2 = memo(function QueryBuilderV2({
 							</div>
 						))}
 
-						{currentQuery.builder.queryFormulas.map((formula) => (
+						{currentQuery.builder.queryFormulas?.map((formula) => (
 							<div key={formula.queryName} className="formula-name">
 								{formula.queryName}
 							</div>


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
`QueryBuilderV2` crashed when `currentQuery.builder.queryFormulas` was `undefined`, as it was accessed directly without optional chaining.

#### Issues closed by this PR
Closes https://github.com/SigNoz/engineering-pod/issues/4280

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause
`currentQuery.builder.queryFormulas.length` and `.map(...)` were called without optional chaining. When a widget is loaded with a query that has no `queryFormulas` field (e.g. legacy or partial data), this throws `TypeError: undefined is not an object`.

#### Fix Strategy
Added optional chaining (`?.`) and a nullish coalescing fallback (`?? 0`) for the length check, so both the condition and the map are safe when `queryFormulas` is absent.

---

### 🧪 Testing Strategy

- Tests added/updated: N/A
- Manual verification: Widget loads without crash when queryFormulas is absent
- Edge cases covered: `undefined`, `null` queryFormulas

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Only affects the formulas section rendering in `QueryBuilderV2`
- Potential regressions: None — falls back to not rendering formulas, same as before for valid data
- Rollback plan: Revert two-line change

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed crash in QueryBuilderV2 when queryFormulas is undefined |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---