### PR TITLE
fix: guard groupBy against undefined before map in QueryBuilder

### DIFF
--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -184,7 +184,7 @@ export function QueryBuilderProvider({
 			const setupedQueryData = builder.queryData.map((item) => {
 				const currentElement: IBuilderQuery = {
 					...item,
-					groupBy: item.groupBy.map(({ id: _, ...item }) => ({
+					groupBy: (item.groupBy ?? []).map(({ id: _, ...item }) => ({
 						...item,
 						id: createIdFromObjectFields(item, baseAutoCompleteIdKeysOrder),
 					})),


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
`QueryBuilder` crashed when a query's `groupBy` field was `undefined`, as it was mapped directly without a null guard.

#### Issues closed by this PR
Closes https://github.com/SigNoz/engineering-pod/issues/4282

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause
`item.groupBy.map(...)` in `setupedQueryData` inside `prepareQueryBuilderData` assumes `groupBy` is always an array. Legacy or partial query data may not include this field, causing `TypeError: e.groupBy.map is not a function`.

#### Fix Strategy
Changed to `(item.groupBy ?? []).map(...)` to fall back to an empty array when `groupBy` is absent.

---

### 🧪 Testing Strategy

- Tests added/updated: N/A
- Manual verification: Query builder loads without crash when groupBy is absent from query data
- Edge cases covered: `undefined`, `null` groupBy

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Only affects `setupedQueryData` in `QueryBuilder.tsx`
- Potential regressions: None — empty array fallback is the correct default
- Rollback plan: Revert one-character change

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed crash in QueryBuilder when groupBy is undefined in query data |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---