### PR TITLE
fix: guard widgets against undefined in handleRowCollapse

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCardLayout.tsx
+++ b/frontend/src/container/GridCardLayout/GridCardLayout.tsx
@@ -337,9 +337,9 @@ function GraphLayout(props: GraphLayoutProps): JSX.Element {
 			for (let j = idxCurrentRow + 1; j < dashboardLayout.length; j++) {
 				updatedDashboardLayout[j].y += maxY;
 				if (updatedPanelMap[updatedDashboardLayout[j].i]) {
-					updatedPanelMap[updatedDashboardLayout[j].i].widgets = updatedPanelMap[
-						updatedDashboardLayout[j].i
-					].widgets.map((w) => ({
+					updatedPanelMap[updatedDashboardLayout[j].i].widgets = (
+						updatedPanelMap[updatedDashboardLayout[j].i].widgets ?? []
+					).map((w) => ({
 						...w,
 						y: w.y + maxY,
 					}));
@@ -376,9 +376,9 @@ function GraphLayout(props: GraphLayoutProps): JSX.Element {
 			for (let j = currentIdx + 1; j < updatedDashboardLayout.length; j++) {
 				updatedDashboardLayout[j].y += maxY;
 				if (updatedPanelMap[updatedDashboardLayout[j].i]) {
-					updatedPanelMap[updatedDashboardLayout[j].i].widgets = updatedPanelMap[
-						updatedDashboardLayout[j].i
-					].widgets.map((w) => ({
+					updatedPanelMap[updatedDashboardLayout[j].i].widgets = (
+						updatedPanelMap[updatedDashboardLayout[j].i].widgets ?? []
+					).map((w) => ({
 						...w,
 						y: w.y + maxY,
 					}));


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
`handleRowCollapse` in `GridCardLayout` crashed when `widgets` was `undefined` on a panel map entry, as it was mapped directly without a null guard.

#### Issues closed by this PR
Closes https://github.com/SigNoz/engineering-pod/issues/4283

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause
`updatedPanelMap[id].widgets.map(...)` assumed `widgets` is always an array. A panel map entry can exist without a `widgets` field if the row was created in a state where it had no children, causing `TypeError: Cannot read properties of undefined (reading 'map')`.

#### Fix Strategy
Changed both `widgets.map(...)` calls in the collapse loop to `(widgets ?? []).map(...)`.

---

### 🧪 Testing Strategy

- Tests added/updated: N/A
- Manual verification: Collapsing a row with no child widgets no longer crashes
- Edge cases covered: `undefined` widgets on a panel map entry

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Only affects row collapse logic in `GridCardLayout`
- Potential regressions: None — empty array fallback is correct when no widgets exist
- Rollback plan: Revert two-line change

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed crash when collapsing a dashboard row with no child widgets |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---