### PR TITLE
fix: guard promql against undefined before map in QueryBuilder

### DIFF
--- a/frontend/src/providers/QueryBuilder.tsx
+++ b/frontend/src/providers/QueryBuilder.tsx
@@ -211,7 +211,7 @@ export function QueryBuilderProvider({
 				return currentElement;
 			});
 
-			const promql: IPromQLQuery[] = query.promql.map((item) => ({
+			const promql: IPromQLQuery[] = (query.promql ?? []).map((item) => ({
 				...initialQueryPromQLData,
 				...item,
 			}));


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
`QueryBuilder` crashed when `query.promql` was `undefined`, as it was mapped directly without a null guard in `prepareQueryBuilderData`.

#### Issues closed by this PR
Closes https://github.com/SigNoz/engineering-pod/issues/4285

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause
`query.promql.map(...)` in `prepareQueryBuilderData` assumes `promql` is always an array. Legacy or partial query data may omit this field, causing `TypeError: e.promql.map is not a function`.

#### Fix Strategy
Changed to `(query.promql ?? []).map(...)` to fall back to an empty array when `promql` is absent.

---

### 🧪 Testing Strategy

- Tests added/updated: N/A
- Manual verification: Query builder loads without crash when promql is absent from query data
- Edge cases covered: `undefined`, `null` promql

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Only affects `prepareQueryBuilderData` in `QueryBuilder.tsx`
- Potential regressions: None — empty array fallback is the correct default
- Rollback plan: Revert one-character change

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed crash in QueryBuilder when promql is undefined in query data |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---