### PR TITLE
fix: update panel waiting state condition

### DIFF
--- a/frontend/src/hooks/dashboard/__test__/useIsPanelWaitingOnVariable.test.ts
+++ b/frontend/src/hooks/dashboard/__test__/useIsPanelWaitingOnVariable.test.ts
@@ -137,7 +137,7 @@ describe('useIsPanelWaitingOnVariable', () => {
 		expect(result.current).toBe(false);
 	});
 
-	it('should return true for DYNAMIC variable with allSelected=true that is loading', () => {
+	it('should return false for DYNAMIC variable with allSelected=true that is loading but has a selectedValue', () => {
 		setFetchStates({ dyn: 'loading' });
 		setDashboardVariables({
 			variables: {
@@ -152,10 +152,10 @@ describe('useIsPanelWaitingOnVariable', () => {
 		});
 
 		const { result } = renderHook(() => useIsPanelWaitingOnVariable(['dyn']));
-		expect(result.current).toBe(true);
+		expect(result.current).toBe(false);
 	});
 
-	it('should return true for DYNAMIC variable with allSelected=true that is waiting', () => {
+	it('should return false for DYNAMIC variable with allSelected=true that is waiting but has a selectedValue', () => {
 		setFetchStates({ dyn: 'waiting' });
 		setDashboardVariables({
 			variables: {
@@ -170,7 +170,7 @@ describe('useIsPanelWaitingOnVariable', () => {
 		});
 
 		const { result } = renderHook(() => useIsPanelWaitingOnVariable(['dyn']));
-		expect(result.current).toBe(true);
+		expect(result.current).toBe(false);
 	});
 
 	it('should return false for DYNAMIC variable with allSelected=true that is idle', () => {

--- a/frontend/src/hooks/dashboard/useVariableFetchState.ts
+++ b/frontend/src/hooks/dashboard/useVariableFetchState.ts
@@ -133,23 +133,18 @@ export function useVariableFetchState(
 export function useIsPanelWaitingOnVariable(variableNames: string[]): boolean {
 	const states = useVariableFetchSelector((s) => s.states);
 	const dashboardVariables = useDashboardVariablesSelector((s) => s.variables);
-	const variableTypesMap = useDashboardVariablesSelector((s) => s.variableTypes);
 
 	return variableNames.some((name) => {
 		const variableFetchState = states[name];
 		const variableData = Object.values(dashboardVariables).find(
 			(v) => v.name === name,
 		);
-		const { selectedValue, allSelected } = variableData || {};
+		const { selectedValue } = variableData || {};
 
 		const isVariableInFetchingOrWaitingState =
 			variableFetchState === 'loading' ||
 			variableFetchState === 'revalidating' ||
 			variableFetchState === 'waiting';
-
-		if (variableTypesMap[name] === 'DYNAMIC' && allSelected) {
-			return isVariableInFetchingOrWaitingState;
-		}
 
 		return isEmpty(selectedValue) ? isVariableInFetchingOrWaitingState : false;
 	});


### PR DESCRIPTION
### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Some variable structures caused panels to wait on variable load even when value is selected. This PR fixes that


#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

##### Before (panel waits on variable)

https://github.com/user-attachments/assets/53846dd3-6b19-4570-8e90-fba21f05e393

##### After (panel waits on variable)

https://github.com/user-attachments/assets/d0df5cc4-3b0a-404b-a723-ecc873ce5d2f

##### Before (panel query triggered on refresh)

https://github.com/user-attachments/assets/44efbab8-063e-4af1-8a65-e20b25a5787f

##### After (panel query triggered on refresh)

https://github.com/user-attachments/assets/c5a3be6b-f5c4-4417-8a94-43cd5d06042e

