### PR TITLE
fix: sidebar resize button not working when sidebar is closed

### DIFF
--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -840,7 +840,7 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 				)}
 			>
 				{isToDisplayLayout && !renderFullScreen && (
-					<SideNav isPinned={isSideNavPinned} />
+					<SideNav isPinned={isSideNavPinned} onToggleSidebar={handleToggleSidebar} />
 				)}
 				<div
 					className={cx('app-content', {

--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -722,34 +722,46 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 		? sideNavPinnedPreference
 		: getSidebarStateFromLocalStorage();
 
-	const handleToggleSidebar = useCallback((): void => {
-		const newState = !isSideNavPinned;
+	const handleToggleSidebar = useCallback(
+		(source: 'shortcut' | 'button' = 'shortcut'): void => {
+			const newState = !isSideNavPinned;
 
-		logEvent('Global Shortcut: Sidebar Toggle', {
-			previousState: isSideNavPinned,
-			newState,
-		});
+			logEvent(
+				source === 'shortcut'
+					? 'Global Shortcut: Sidebar Toggle'
+					: 'Sidebar V2: Toggle button clicked',
+				{
+					previousState: isSideNavPinned,
+					newState,
+				},
+			);
 
-		// Save to localStorage immediately for instant feedback
-		setLocalStorageApi(USER_PREFERENCES.SIDENAV_PINNED, newState.toString());
+			// Save to localStorage immediately for instant feedback
+			setLocalStorageApi(USER_PREFERENCES.SIDENAV_PINNED, newState.toString());
 
-		// Update the context immediately
-		const save = {
-			name: USER_PREFERENCES.SIDENAV_PINNED,
-			value: newState,
-		};
-		updateUserPreferenceInContext(save as UserPreference);
+			// Update the context immediately
+			const save = {
+				name: USER_PREFERENCES.SIDENAV_PINNED,
+				value: newState,
+			};
+			updateUserPreferenceInContext(save as UserPreference);
 
-		// Make the API call in the background
-		updateUserPreferenceMutation({
-			name: USER_PREFERENCES.SIDENAV_PINNED,
-			value: newState,
-		});
-	}, [
-		isSideNavPinned,
-		updateUserPreferenceInContext,
-		updateUserPreferenceMutation,
-	]);
+			// Make the API call in the background
+			updateUserPreferenceMutation({
+				name: USER_PREFERENCES.SIDENAV_PINNED,
+				value: newState,
+			});
+		},
+		[
+			isSideNavPinned,
+			updateUserPreferenceInContext,
+			updateUserPreferenceMutation,
+		],
+	);
+
+	const handleToggleSidebarButton = useCallback((): void => {
+		handleToggleSidebar('button');
+	}, [handleToggleSidebar]);
 
 	// Register the sidebar toggle shortcut
 	useEffect(() => {
@@ -840,7 +852,10 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 				)}
 			>
 				{isToDisplayLayout && !renderFullScreen && (
-					<SideNav isPinned={isSideNavPinned} onToggleSidebar={handleToggleSidebar} />
+					<SideNav
+						isPinned={isSideNavPinned}
+						onToggleSidebar={handleToggleSidebarButton}
+					/>
 				)}
 				<div
 					className={cx('app-content', {

--- a/frontend/src/container/SideNav/SideNav.styles.scss
+++ b/frontend/src/container/SideNav/SideNav.styles.scss
@@ -22,7 +22,7 @@
 	transition: all 0.08s ease, background 0s, border 0s;
 
 	.brand-container {
-		padding: 8px 15px;
+		padding: 8px 6px;
 		max-width: 100%;
 		background: transparent;
 	}
@@ -31,8 +31,9 @@
 		display: flex;
 		align-items: center;
 		gap: 6px;
-		flex-shrink: 0;
-		width: 100%;
+		flex: 1 1 auto;
+		min-width: 0;
+		width: auto;
 		justify-content: center;
 	}
 
@@ -44,7 +45,7 @@
 		max-width: 100%;
 		overflow: hidden;
 
-		gap: 32px;
+		gap: 6px;
 		height: 32px;
 		width: 100%;
 
@@ -168,14 +169,15 @@
 			padding: 0;
 			height: 16px;
 			width: 16px;
-			color: var(--bg-vanilla-400, #c0c1c3);
+			color: var(--l2-foreground, var(--bg-vanilla-400, #c0c1c3));
 			display: flex;
 			align-items: center;
 			justify-content: center;
+			flex-shrink: 0;
 			transition: color 0.2s ease;
 
 			&:hover {
-				color: var(--bg-vanilla-100, #fff);
+				color: var(--l1-foreground, var(--bg-vanilla-100, #fff));
 			}
 
 			&:focus {
@@ -665,6 +667,7 @@
 
 		.brand {
 			justify-content: flex-start;
+			gap: 32px;
 
 			.brand-company-meta {
 				justify-content: flex-start;
@@ -845,6 +848,7 @@
 
 		.brand {
 			justify-content: flex-start;
+			gap: 32px;
 
 			.brand-company-meta {
 				justify-content: flex-start;
@@ -1318,14 +1322,6 @@
 
 				.version {
 					color: var(--bg-ink-400);
-				}
-			}
-
-			.dockBtn {
-				color: var(--bg-slate-50, #62687c);
-
-				&:hover {
-					color: var(--bg-slate-500, #161922);
 				}
 			}
 		}

--- a/frontend/src/container/SideNav/SideNav.styles.scss
+++ b/frontend/src/container/SideNav/SideNav.styles.scss
@@ -168,6 +168,19 @@
 			padding: 0;
 			height: 16px;
 			width: 16px;
+			color: var(--bg-vanilla-400, #c0c1c3);
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			transition: color 0.2s ease;
+
+			&:hover {
+				color: var(--bg-vanilla-100, #fff);
+			}
+
+			&:focus {
+				outline: none;
+			}
 		}
 	}
 
@@ -1305,6 +1318,14 @@
 
 				.version {
 					color: var(--bg-ink-400);
+				}
+			}
+
+			.dockBtn {
+				color: var(--bg-slate-50, #62687c);
+
+				&:hover {
+					color: var(--bg-slate-500, #161922);
 				}
 			}
 		}

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -54,6 +54,7 @@ import {
 	Logs,
 	MousePointerClick,
 	PackagePlus,
+	PanelLeft,
 	ScrollText,
 	X,
 } from 'lucide-react';
@@ -119,7 +120,13 @@ function SortableFilter({ item }: { item: SidebarItem }): JSX.Element {
 }
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
-function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
+function SideNav({
+	isPinned,
+	onToggleSidebar,
+}: {
+	isPinned: boolean;
+	onToggleSidebar?: () => void;
+}): JSX.Element {
 	const { openCmdK } = useCmdK();
 	const { pathname, search } = useLocation();
 	const { currentVersion, latestVersion, isCurrentVersionError } = useSelector<
@@ -973,6 +980,17 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 								</div>
 							)}
 						</div>
+
+						{onToggleSidebar && (
+							<button
+								type="button"
+								className="dockBtn"
+								onClick={onToggleSidebar}
+								aria-label={isPinned ? 'Collapse sidebar' : 'Expand sidebar'}
+							>
+								<PanelLeft size={16} />
+							</button>
+						)}
 					</div>
 				</div>
 


### PR DESCRIPTION
## Summary

This PR fixes the resize button not working when the sidebar is closed (issue #9370).

## Problem

When the sidebar was in a collapsed state (not pinned, not hovered, and no dropdown open), there was no visible button to expand it. Users had to either:
- Hover over the sidebar to temporarily expand it
- Use the keyboard shortcut (Shift+B) to pin it

## Solution

Added a toggle button (using the PanelLeft icon from lucide-react) in the brand section of the sidebar that:
1. Appears when the sidebar is collapsed
2. Allows users to click to toggle the pinned state
3. Has proper hover effects for both dark and light modes
4. Is accessible with proper aria-label

## Changes

- Added  optional callback prop to  component
- Added dock button in the brand section that calls  when clicked
- Updated CSS styles for  with hover effects and transitions
- Added light mode styles for the dock button
- Passed  from  to 

## Testing

- Verified the button appears in the collapsed sidebar
- Verified clicking the button toggles the sidebar pinned state
- Verified hover effects work in both dark and light modes
- Verified the button is accessible with keyboard navigation

Fixes #9370

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a new button path to toggle the sidebar pinned state; main risk is minor styling/accessibility regressions in light/dark modes.
> 
> **Overview**
> Fixes the collapsed sidebar having no visible way to re-open it by adding an optional `onToggleSidebar` callback to `SideNav` and wiring it from `AppLayout`.
> 
> When provided, `SideNav` now renders a new `PanelLeft` toggle button in the brand area (with an `aria-label` reflecting pinned state) and includes updated `.dockBtn` styling/hover behavior for both dark and light modes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6404875ee532e8509d83b51b985ff6cd2a80979. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->