### PR TITLE
feat(ch-query): add docs and agent skill info banner to ClickHouse query editor

### DIFF
--- a/frontend/src/container/NewWidget/LeftContainer/QuerySection/QueryBuilder/clickHouse/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/QuerySection/QueryBuilder/clickHouse/index.tsx
@@ -1,6 +1,8 @@
 import { PlusOutlined } from '@ant-design/icons';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
+import { Info } from 'lucide-react';
 import { EQueryType } from 'types/common/dashboard';
+import DOCLINKS from 'utils/docLinks';
 
 import { QueryButton } from '../../styles';
 import ClickHouseQueryBuilder from './query';
@@ -13,6 +15,49 @@ function ClickHouseQueryContainer(): JSX.Element | null {
 
 	return (
 		<>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'flex-start',
+					gap: 8,
+					margin: '8px 8px 16px 16px',
+					padding: '8px 12px',
+					borderRadius: 4,
+					background: 'var(--callout-primary-background)',
+					border: '1px solid var(--callout-primary-border)',
+					color: 'var(--callout-primary-description)',
+				}}
+			>
+				<Info
+					size={14}
+					style={{
+						marginTop: 2,
+						flexShrink: 0,
+						color: 'var(--callout-primary-icon)',
+					}}
+				/>
+				<span>
+					<a
+						href={DOCLINKS.QUERY_CLICKHOUSE_TRACES}
+						target="_blank"
+						rel="noreferrer"
+						style={{ color: 'var(--bg-robin-400)', textDecoration: 'underline' }}
+					>
+						Learn how to write optimized queries
+					</a>
+					{' · '}
+					If you are using LLMs,{' '}
+					<a
+						href="https://signoz.io/docs/ai/agent-skills/#installation"
+						target="_blank"
+						rel="noreferrer"
+						style={{ color: 'var(--bg-robin-400)', textDecoration: 'underline' }}
+					>
+						install SigNoz clickhouse-query agent skill
+					</a>{' '}
+					to write optimized queries
+				</span>
+			</div>
 			{currentQuery.clickhouse_sql.map((q, idx) => (
 				<ClickHouseQueryBuilder
 					key={q.name}

--- a/frontend/src/utils/docLinks.ts
+++ b/frontend/src/utils/docLinks.ts
@@ -8,6 +8,8 @@ const DOCLINKS = {
 		'https://signoz.io/docs/userguide/send-metrics-cloud/',
 	EXTERNAL_API_MONITORING:
 		'https://signoz.io/docs/external-api-monitoring/overview/',
+	QUERY_CLICKHOUSE_TRACES:
+		'https://signoz.io/docs/userguide/writing-clickhouse-traces-query/#timestamp-bucketing-for-distributed_signoz_index_v3',
 };
 
 export default DOCLINKS;


### PR DESCRIPTION
## Summary
- Adds a persistent info banner above the ClickHouse query editor in dashboard panel creation
- Banner includes a link to optimized query writing docs and a link to install the SigNoz ClickHouse query agent skill for LLM-assisted query writing
- Uses `--callout-primary-*` CSS variables for automatic light/dark theme support; no antd dependency
- Banner renders once above all queries (not repeated per query), using lucide-react `Info` icon

## Test plan
- [ ] Open dashboard → create new panel → switch to **ClickHouse Query** tab
- [ ] Verify info banner appears above query A with both links underlined and clickable
- [ ] Add a second query and confirm the banner does **not** repeat
- [ ] Toggle light mode and verify the banner colors adapt correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)