### PR TITLE
fix(alerts): alert header breaking with unknown severity

### DIFF
--- a/frontend/src/pages/AlertDetails/AlertHeader/AlertSeverity/AlertSeverity.tsx
+++ b/frontend/src/pages/AlertDetails/AlertHeader/AlertSeverity/AlertSeverity.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+import * as Sentry from '@sentry/react';
 import SeverityCriticalIcon from 'assets/AlertHistory/SeverityCriticalIcon';
 import SeverityErrorIcon from 'assets/AlertHistory/SeverityErrorIcon';
 import SeverityInfoIcon from 'assets/AlertHistory/SeverityInfoIcon';
@@ -5,34 +7,50 @@ import SeverityWarningIcon from 'assets/AlertHistory/SeverityWarningIcon';
 
 import './AlertSeverity.styles.scss';
 
+const severityConfig: Record<string, Record<string, string | JSX.Element>> = {
+	critical: {
+		text: 'Critical',
+		className: 'alert-severity--critical',
+		icon: <SeverityCriticalIcon />,
+	},
+	error: {
+		text: 'Error',
+		className: 'alert-severity--error',
+		icon: <SeverityErrorIcon />,
+	},
+	warning: {
+		text: 'Warning',
+		className: 'alert-severity--warning',
+		icon: <SeverityWarningIcon />,
+	},
+	info: {
+		text: 'Info',
+		className: 'alert-severity--info',
+		icon: <SeverityInfoIcon />,
+	},
+};
+
 export default function AlertSeverity({
 	severity,
 }: {
 	severity: string;
 }): JSX.Element {
-	const severityConfig: Record<string, Record<string, string | JSX.Element>> = {
-		critical: {
-			text: 'Critical',
-			className: 'alert-severity--critical',
-			icon: <SeverityCriticalIcon />,
-		},
-		error: {
-			text: 'Error',
-			className: 'alert-severity--error',
-			icon: <SeverityErrorIcon />,
-		},
-		warning: {
-			text: 'Warning',
-			className: 'alert-severity--warning',
-			icon: <SeverityWarningIcon />,
-		},
-		info: {
-			text: 'Info',
+	const severityDetails = useMemo(() => {
+		if (severityConfig[severity]) {
+			return severityConfig[severity];
+		}
+
+		Sentry.captureEvent({
+			message: `Received unknown severity on Alert Details: ${severity}`,
+			level: 'error',
+		});
+
+		return {
+			text: severity,
 			className: 'alert-severity--info',
 			icon: <SeverityInfoIcon />,
-		},
-	};
-	const severityDetails = severityConfig[severity];
+		};
+	}, [severity]);
 	return (
 		<div className={`alert-severity ${severityDetails.className}`}>
 			<div className="alert-severity__icon">{severityDetails.icon}</div>


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

On Alerts V1, the severity is mapped, but on V2 is free to accept whatever you want.

I don't know exactly what caused the Alert being created on V1 with a Severity that was not mapped but it happened.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

When severity is know:
<img width="698" height="395" alt="image" src="https://github.com/user-attachments/assets/771046bd-e7ac-4b4c-9dd5-66fd338f679f" />

When is unknown:

<img width="648" height="386" alt="image" src="https://github.com/user-attachments/assets/96c1f29b-c54a-4fcb-92fc-0c306b147e79" />

This only affects V1.

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Fixes https://github.com/SigNoz/engineering-pod/issues/4315

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

Something caused the alert to have an unknown severity, found at https://github.com/SigNoz/engineering-pod/issues/4315

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

The code was not expecting an unknown severity.

#### Fix Strategy
> How does this PR address the root cause?

Add fallback to render even with unknown severity value, fallback to colors of info.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Alert Rule Details V1
- Potential regressions: Uknown
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | When unknown severity was passed to Alert Rules Details, the page was crashing due to lack of fallback. |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
