### PR TITLE
fix: light mode border color mismatch in External APIs

### DIFF
--- a/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
+++ b/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
@@ -237,6 +237,22 @@
 			}
 		}
 	}
+
+	.api-monitoring-page {
+		.api-quick-filter-left-section {
+			.api-quick-filters-header {
+				border-bottom-color: var(--bg-vanilla-300);
+				border-right-color: var(--bg-vanilla-300);
+			}
+		}
+
+		.api-module-right-section {
+			.toolbar {
+				border-bottom-color: var(--bg-vanilla-300);
+			}
+		}
+	}
+
 	.api-monitoring-domain-list-table {
 		.ant-table {
 			.ant-table-thead > tr > th {
@@ -271,6 +287,7 @@
 
 			.round-metric-tag {
 				color: var(--bg-vanilla-100);
+				border-color: var(--bg-vanilla-300);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixes border color mismatch in the External APIs (domain list) page when using light mode
- Updates dark-mode border variables (`--bg-slate-400`) to the light-mode equivalent (`--bg-vanilla-300`) for:
  - Quick filters header borders
  - Toolbar bottom border
  - Round metric tag borders

## What changed

**File:** `frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss`

**Before:** In light mode, the toolbar border, quick filters header borders, and round metric tag borders still used the dark mode variable `var(--bg-slate-400)`, causing a visible mismatch with other borders on the page.

**After:** Added light mode overrides in the `.lightMode` block:
- `.api-quick-filters-header` border-bottom and border-right → `var(--bg-vanilla-300)`
- `.toolbar` border-bottom → `var(--bg-vanilla-300)`
- `.round-metric-tag` border-color → `var(--bg-vanilla-300)`

This is consistent with how light mode borders are handled in `DomainDetails.styles.scss` (which already uses `var(--bg-vanilla-300)` for light mode borders).

Fixes #9402

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that adjusts light-mode border colors; potential impact is limited to visual styling on the API Monitoring Explorer page.
> 
> **Overview**
> Fixes **light mode** border color mismatches in the External APIs/Explorer view by adding `.lightMode` overrides to use `var(--bg-vanilla-300)` for the quick filters header and toolbar borders.
> 
> Also updates the light-mode styling for `.round-metric-tag` to apply a matching `border-color`, improving visual consistency across the domain list table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5a14c89b45de316428d203595b5b93df027c959. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->