### PR TITLE
fix(querier): skip error log and fallback on context cancellation in executeWithCache

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -749,10 +749,13 @@ func (q *querier) executeWithCache(ctx context.Context, orgID valuer.UUID, query
 	for _, err := range errs {
 		if err != nil {
 			// If the context was canceled (e.g., the client disconnected or
-			// navigated away), return immediately. Retrying with a canceled
-			// context would fail again, and this is not a server-side error
-			// worth logging at ERROR level.
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			// navigated away) or deadline exceeded, return immediately.
+			// Retrying with a canceled context would fail again, and this
+			// is not a server-side error worth logging at ERROR level.
+			// We check ctx.Err() directly because errors.Is cannot
+			// traverse wrapped errors whose wrapper does not implement
+			// the Unwrap interface.
+			if ctx.Err() != nil {
 				return nil, err
 			}
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

When a frontend request is canceled (e.g., user navigates away or re-queries while a dashboard is loading), the HTTP context is canceled. In-flight ClickHouse queries fail with `context.Canceled`, and `executeWithCache` in `pkg/querier/querier.go` unconditionally logs this at ERROR level before attempting a fallback `query.Execute()` with the same dead context — which also fails immediately.

This produces noisy `"parallel query execution failed"` / `"failed to get metrics keys"` ERROR logs that obscure real issues. The fix adds an early return when any parallel sub-query error wraps `context.Canceled` or `context.DeadlineExceeded`, skipping both the ERROR log and the pointless fallback execution.

This matches the established patterns already used in the same package:
- `builder_query.go` (line 242): silently passes `context.Canceled` through
- `promql_query.go` (line 52): wraps `context.Canceled` into a typed canceled error

#### Issues closed by this PR
Closes #10216

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

The `executeWithCache` error handling loop treats all parallel query failures identically — logging at ERROR level and retrying. It does not distinguish between genuine server-side failures and expected client-initiated context cancellations. This is a missing edge case: the parallel execution path (added with bucket caching) lacked the `context.Canceled` guard that already exists in the individual query execution paths (`builder_query.go`, `promql_query.go`).

#### Fix Strategy
> How does this PR address the root cause?

Before logging the error and attempting fallback execution, the error loop now checks `errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)`. If either matches, the function returns immediately with the original error — no ERROR log, no retry with a dead context.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No — the existing codebase has no tests for `executeWithCache`, and the analogous `context.Canceled` guards in `builder_query.go` and `promql_query.go` are also untested. The change is a 4-line defensive check following an established pattern.
- Manual verification: Verified the package builds and all existing querier tests pass (`go test ./pkg/querier/... -v -count=1`).
- Edge cases covered: Both `context.Canceled` (client disconnect) and `context.DeadlineExceeded` (query timeout) are handled.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Only affects the parallel query fallback path in `executeWithCache`. The happy path (no errors, or genuine server errors) is unchanged.
- Potential regressions: None — previously, a canceled context would log an error and then fail the fallback anyway (since the context is dead). The end result (returning an error) is the same; the only difference is no spurious ERROR log.
- Rollback plan: Revert this commit.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Suppress noisy ERROR logs caused by client-canceled requests during parallel query execution |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The fix is intentionally minimal — a single `if` guard before the existing error handling. This follows the same pattern used in `builder_query.go:242` and `promql_query.go:52` within the same package. The key insight from the issue discussion (comment by @srikanthccv) is that context cancellation from client disconnects is expected behavior, not a server error.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes error handling when the request context is canceled/deadline exceeded, avoiding noisy ERROR logs and skipping a fallback execution that would immediately fail anyway.
> 
> **Overview**
> Prevents `executeWithCache` from logging an ERROR and attempting a full-query fallback when parallel sub-queries fail due to a canceled or timed-out request context.
> 
> On any parallel range error, it now checks `ctx.Err()` and returns immediately for cancellations/deadlines, leaving the existing fallback-and-cache behavior unchanged for genuine server-side failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd6f71ee5320050345a7ac953f751abee5229877. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->