### PR TITLE
fix: dashboard variables — block duplicate name save and clean panel filters on DYNAMIC variable deletion

### DIFF
--- a/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/VariableItem.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/VariableItem.tsx
@@ -348,6 +348,11 @@ function VariableItem({
 	]);
 
 	const handleSave = (): void => {
+		// Block save if name validation failed (e.g. duplicate or whitespace)
+		if (errorName) {
+			return;
+		}
+
 		// Check for cyclic dependencies
 		const newVariable = {
 			name: variableName,

--- a/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/index.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/index.tsx
@@ -15,6 +15,8 @@ import { Button, Modal, Row, RowProps, Space, Table, Typography } from 'antd';
 import { VariablesSettingsTabHandle } from 'container/DashboardContainer/DashboardDescription/types';
 import { convertVariablesToDbFormat } from 'container/DashboardContainer/DashboardVariablesSelection/util';
 import { useAddDynamicVariableToPanels } from 'hooks/dashboard/useAddDynamicVariableToPanels';
+import { getFiltersFromKeyValue } from 'hooks/dashboard/utils';
+import { addTagFiltersToDashboard } from './addTagFiltersToDashboard';
 import { useDashboardVariables } from 'hooks/dashboard/useDashboardVariables';
 import { useUpdateDashboard } from 'hooks/dashboard/useUpdateDashboard';
 import { useNotifications } from 'hooks/useNotifications';
@@ -256,14 +258,58 @@ function VariablesSettings({
 	};
 
 	const handleDeleteConfirm = (): void => {
+		const deletedVariable = variableToDelete.current;
 		const newVariablesArr = variablesTableData.filter(
 			(variable: IDashboardVariable) =>
-				variable.id !== variableToDelete?.current?.id,
+				variable.id !== deletedVariable?.id,
 		);
 
 		const updatedVariables = convertVariablesToDbFormat(newVariablesArr);
 
-		updateVariables(updatedVariables);
+		// When deleting a DYNAMIC variable, remove its filter references from all
+		// panel queries so no dangling AND/OR operators are left in expressions.
+		let dashboardToUpdate = selectedDashboard;
+		if (deletedVariable?.type === 'DYNAMIC' && selectedDashboard) {
+			const tagFilter = getFiltersFromKeyValue(
+				deletedVariable.dynamicVariablesAttribute || '',
+				`$${deletedVariable.name}`,
+				'',
+				'IN',
+			);
+			dashboardToUpdate = addTagFiltersToDashboard(
+				selectedDashboard,
+				tagFilter,
+				[],
+				false,
+			);
+		}
+
+		if (!dashboardToUpdate) {
+			variableToDelete.current = null;
+			setDeleteVariableModal(false);
+			return;
+		}
+
+		updateMutation.mutateAsync(
+			{
+				id: dashboardToUpdate.id,
+				data: {
+					...dashboardToUpdate.data,
+					variables: updatedVariables,
+				},
+			},
+			{
+				onSuccess: (updatedDashboard) => {
+					if (updatedDashboard.data) {
+						setSelectedDashboard(updatedDashboard.data);
+						notifications.success({
+							message: t('variable_updated_successfully'),
+						});
+					}
+				},
+			},
+		);
+
 		variableToDelete.current = null;
 		setDeleteVariableModal(false);
 	};


### PR DESCRIPTION
Fixes two bugs reported in #10674.

## Bug 1: Dangling `AND` after DYNAMIC variable deletion

**Root cause:** `handleDeleteConfirm` removed the variable from the variables list but never cleaned up filter expressions in panel queries that referenced the deleted variable. At render time, `AND operation IN $top_level_operation` became `AND ` — a dangling operator.

**Fix:** Before persisting the dashboard, call `addTagFiltersToDashboard` with an empty widget-ID list. This triggers `updateAfterRemoval` for every widget, which calls `removeKeysFromExpression` to strip the variable's filter entry and any surrounding `AND`/`OR` conjunctions from all panel builder expressions.

Changed file: `frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/index.tsx`

## Bug 2: Duplicate variable names silently accepted

**Root cause:** `handleSave` in `VariableItem` performed cycle-detection but never checked `errorName` before calling `onSave`. A user could type a duplicate name, see the warning label, and still persist the duplicate by clicking Save.

**Fix:** Added an early `return` at the top of `handleSave` when `errorName` is `true`. The existing input-change handler already sets `errorName` for duplicates, whitespace, and empty names — this just makes `handleSave` respect that state.

Changed file: `frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/VariableItem.tsx`

## Test plan

- [ ] Create a dashboard variable, then delete it — verify no `AND ` remnant appears in any panel's filter expression
- [ ] Create a DYNAMIC variable applied to panels, delete it — verify the `key IN $var` clause is fully removed from all panel expressions
- [ ] Attempt to create two variables with the same name — verify the second save is blocked and the warning remains visible
- [ ] Rename an existing variable to a name already used by another variable — verify save is blocked
- [ ] Rename a variable to its own current name — verify save succeeds (editing without changing name still works)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dashboard update flow and mutates panel query/filter expressions when deleting DYNAMIC variables, so regressions could impact saved dashboards and panel queries. Scope is small and localized to variable settings UI logic.
> 
> **Overview**
> Fixes two dashboard-variable edge cases.
> 
> `VariableItem.handleSave` now **blocks saving** when `errorName` is set, preventing variables with invalid/duplicate/whitespace names from being persisted.
> 
> Deleting a `DYNAMIC` variable now also **removes its tag-filter references from all panel queries** before persisting the dashboard (via `getFiltersFromKeyValue` + `addTagFiltersToDashboard`), avoiding dangling `AND`/`OR` fragments in query expressions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e95a65ab4a7fd655d62da8900a244fbf3927e9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->