### PR TITLE
fix(docker): add non-root USER directive to Dockerfiles

### DIFF
--- a/cmd/community/Dockerfile
+++ b/cmd/community/Dockerfile
@@ -18,6 +18,10 @@ RUN chmod 755 /root /root/signoz
 
 # Security: run as non-root user
 RUN addgroup --system --gid 1001 signoz && adduser --system --uid 1001 --ingroup signoz signoz
+
+# Create data directory with correct ownership for SQLite database
+RUN mkdir -p /var/lib/signoz && chown signoz:signoz /var/lib/signoz
+
 USER signoz
 
 ENTRYPOINT ["./signoz", "server"]

--- a/cmd/community/Dockerfile
+++ b/cmd/community/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine:3.20.3
 LABEL maintainer="signoz"
-WORKDIR /root
 
 ARG OS="linux"
 ARG TARGETARCH
@@ -9,19 +8,19 @@ RUN apk update && \
 	apk add ca-certificates && \
 	rm -rf /var/cache/apk/*
 
-
-COPY ./target/${OS}-${TARGETARCH}/signoz-community /root/signoz
-COPY ./templates/email /root/templates
-COPY frontend/build/ /etc/signoz/web/
-
-RUN chmod 755 /root /root/signoz
-
-# Security: run as non-root user
+# Security: create non-root user and writable data directory
 RUN addgroup --system --gid 1001 signoz && adduser --system --uid 1001 --ingroup signoz signoz
-
-# Create data directory with correct ownership for SQLite database
 RUN mkdir -p /var/lib/signoz && chown signoz:signoz /var/lib/signoz
 
+# Copy application files (still as root for correct permissions)
+COPY ./target/${OS}-${TARGETARCH}/signoz-community /var/lib/signoz/signoz
+COPY ./templates/email /var/lib/signoz/templates
+COPY frontend/build/ /etc/signoz/web/
+
+RUN chmod 755 /var/lib/signoz/signoz
+
+# Switch to non-root user and writable working directory
+WORKDIR /var/lib/signoz
 USER signoz
 
 ENTRYPOINT ["./signoz", "server"]

--- a/cmd/community/Dockerfile
+++ b/cmd/community/Dockerfile
@@ -16,4 +16,8 @@ COPY frontend/build/ /etc/signoz/web/
 
 RUN chmod 755 /root /root/signoz
 
+# Security: run as non-root user
+RUN addgroup --system --gid 1001 signoz && adduser --system --uid 1001 --ingroup signoz signoz
+USER signoz
+
 ENTRYPOINT ["./signoz", "server"]

--- a/cmd/enterprise/Dockerfile
+++ b/cmd/enterprise/Dockerfile
@@ -18,6 +18,10 @@ RUN chmod 755 /root /root/signoz
 
 # Security: run as non-root user
 RUN addgroup --system --gid 1001 signoz && adduser --system --uid 1001 --ingroup signoz signoz
+
+# Create data directory with correct ownership for SQLite database
+RUN mkdir -p /var/lib/signoz && chown signoz:signoz /var/lib/signoz
+
 USER signoz
 
 ENTRYPOINT ["./signoz", "server"]

--- a/cmd/enterprise/Dockerfile
+++ b/cmd/enterprise/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine:3.20.3
 LABEL maintainer="signoz"
-WORKDIR /root
 
 ARG OS="linux"
 ARG TARGETARCH
@@ -9,19 +8,19 @@ RUN apk update && \
 	apk add ca-certificates && \
 	rm -rf /var/cache/apk/*
 
-
-COPY ./target/${OS}-${TARGETARCH}/signoz /root/signoz
-COPY ./templates/email /root/templates
-COPY frontend/build/ /etc/signoz/web/
-
-RUN chmod 755 /root /root/signoz
-
-# Security: run as non-root user
+# Security: create non-root user and writable data directory
 RUN addgroup --system --gid 1001 signoz && adduser --system --uid 1001 --ingroup signoz signoz
-
-# Create data directory with correct ownership for SQLite database
 RUN mkdir -p /var/lib/signoz && chown signoz:signoz /var/lib/signoz
 
+# Copy application files (still as root for correct permissions)
+COPY ./target/${OS}-${TARGETARCH}/signoz /var/lib/signoz/signoz
+COPY ./templates/email /var/lib/signoz/templates
+COPY frontend/build/ /etc/signoz/web/
+
+RUN chmod 755 /var/lib/signoz/signoz
+
+# Switch to non-root user and writable working directory
+WORKDIR /var/lib/signoz
 USER signoz
 
 ENTRYPOINT ["./signoz", "server"]

--- a/cmd/enterprise/Dockerfile
+++ b/cmd/enterprise/Dockerfile
@@ -16,4 +16,8 @@ COPY frontend/build/ /etc/signoz/web/
 
 RUN chmod 755 /root /root/signoz
 
+# Security: run as non-root user
+RUN addgroup --system --gid 1001 signoz && adduser --system --uid 1001 --ingroup signoz signoz
+USER signoz
+
 ENTRYPOINT ["./signoz", "server"]


### PR DESCRIPTION
Both community and enterprise Dockerfiles run as root by default. If a container escape vulnerability is discovered, the attacker gains root access on the host.

Changes:
- Create dedicated 'signoz' system user (UID 1001) and group
- Switch to non-root user before ENTRYPOINT
- Affects cmd/community/Dockerfile and cmd/enterprise/Dockerfile

Real Risk Score: 7/10 — container escape → host root access
Ref: CIS Docker Benchmark 4.1 - Ensure a user for the container has been created

## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?



#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

#### Fix Strategy
> How does this PR address the root cause?

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification:
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix / Maintenance |
| Description | User-facing summary |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because changing the runtime user can surface file permission issues at startup or when writing SQLite/data files, but the change is isolated to container packaging.
> 
> **Overview**
> **Docker hardening:** both `cmd/community/Dockerfile` and `cmd/enterprise/Dockerfile` now create a dedicated `signoz` system user/group (UID/GID 1001) and switch to `USER signoz` before the `ENTRYPOINT`.
> 
> Also creates `/var/lib/signoz` and assigns ownership to `signoz:signoz` to ensure the container can write its SQLite/data files without running as root.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a1ede8451fb5dcfdc6a49e40d0cf0f567b9700a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->