### PR TITLE
feat(logs): pretty-print JSON attribute values when copying to clipboard

### DIFF
--- a/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
+++ b/frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx
@@ -284,6 +284,15 @@ export default function TableViewActions(
 				error,
 			);
 		}
+		// If the value is valid JSON (object or array), pretty-print it for copying
+		try {
+			const parsed = JSON.parse(text);
+			if (typeof parsed === 'object' && parsed !== null) {
+				return JSON.stringify(parsed, null, 2);
+			}
+		} catch {
+			// not JSON, return as-is
+		}
 		return text;
 	}, [fieldData.value]);
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

When copying log attribute values that contain JSON objects or arrays (e.g. `request_body`, `headers`), the copied text is currently a single-line escaped string like `{"userId":1,"amount":500}`.

This PR pretty-prints valid JSON values with 2-space indentation before copying to clipboard, so users get:

```json
{
  "userId": 1,
  "amount": 500
}
```

Non-JSON values (strings, numbers, booleans) are unaffected.

#### Screenshots / Screen Recordings (if applicable)

N/A — behavior change is in clipboard output only, no visual change.

#### Issues closed by this PR

Related #8208

---

### ✅ Change Type

- [x] ✨ Feature

---

### 🐛 Bug Context

N/A

---

### 🧪 Testing Strategy

- Tests added/updated: N/A — no existing tests for `textToCopy` memo; change is minimal and isolated
- Manual verification: Verified that `JSON.parse` + `JSON.stringify(parsed, null, 2)` correctly pretty-prints object/array values and falls through for primitives
- Edge cases covered:
  - Plain strings → copied as-is
  - Numbers/booleans → copied as-is (`typeof parsed !== 'object'`)
  - `null` values → copied as-is (`parsed !== null` guard)
  - Nested JSON objects → pretty-printed
  - JSON arrays → pretty-printed
  - Invalid JSON → copied as-is (catch block)

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Minimal — only affects clipboard content when copying log attribute values, no visual or query changes
- Potential regressions: None — the display rendering is untouched, only the `textToCopy` memo is modified
- Rollback plan: Revert single commit

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Copying a log attribute value that contains JSON now copies pretty-printed JSON instead of a single-line string |

---

### 📋 Checklist

- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Single change in `frontend/src/container/LogDetailedView/TableView/TableViewActions.tsx` — adds a `JSON.parse` + `JSON.stringify(parsed, null, 2)` step to the `textToCopy` memo. The try/catch ensures non-JSON values pass through unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to clipboard `textToCopy` formatting and falls back to the original value for non-JSON or parse failures.
> 
> **Overview**
> Copying a log attribute value now attempts to `JSON.parse` the (de-quoted) text and, when it’s a non-null object/array, copies a 2-space indented pretty-printed version via `JSON.stringify(parsed, null, 2)`.
> 
> Non-JSON values and JSON primitives keep the previous behavior by falling back to the original string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ab45e58147ab901e70be0a87e99e6dd74cb73e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->