### PR TITLE
feat(sqlstore): add support for sqlite transaction modes

### DIFF
--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -85,10 +85,12 @@ sqlstore:
   sqlite:
     # The path to the SQLite database file.
     path: /var/lib/signoz/signoz.db
-    # Mode is the mode to use for the sqlite database.
+    # The journal mode for the sqlite database. Supported values: delete, wal.
     mode: delete
-    # BusyTimeout is the timeout for the sqlite database to wait for a lock.
+    # The timeout for the sqlite database to wait for a lock.
     busy_timeout: 10s
+    # The default transaction locking behavior. Supported values: deferred, immediate, exclusive.
+    transaction_mode: deferred
 
 ##################### APIServer #####################
 apiserver:

--- a/pkg/sqlstore/config.go
+++ b/pkg/sqlstore/config.go
@@ -26,11 +26,14 @@ type SqliteConfig struct {
 	// Path is the path to the sqlite database.
 	Path string `mapstructure:"path"`
 
-	// Mode is the mode to use for the sqlite database.
+	// Mode is the journal mode for the sqlite database.
 	Mode string `mapstructure:"mode"`
 
 	// BusyTimeout is the timeout for the sqlite database to wait for a lock.
 	BusyTimeout time.Duration `mapstructure:"busy_timeout"`
+
+	// TransactionMode is the default transaction locking behavior for the sqlite database.
+	TransactionMode string `mapstructure:"transaction_mode"`
 }
 
 type ConnectionConfig struct {
@@ -49,9 +52,10 @@ func newConfig() factory.Config {
 			MaxOpenConns: 100,
 		},
 		Sqlite: SqliteConfig{
-			Path:        "/var/lib/signoz/signoz.db",
-			Mode:        "delete",
-			BusyTimeout: 10000 * time.Millisecond, // increasing the defaults from https://github.com/mattn/go-sqlite3/blob/master/sqlite3.go#L1098 because of transpilation from C to GO
+			Path:            "/var/lib/signoz/signoz.db",
+			Mode:            "delete",
+			BusyTimeout:     10000 * time.Millisecond, // increasing the defaults from https://github.com/mattn/go-sqlite3/blob/master/sqlite3.go#L1098 because of transpilation from C to GO
+			TransactionMode: "deferred",
 		},
 	}
 

--- a/pkg/sqlstore/config_test.go
+++ b/pkg/sqlstore/config_test.go
@@ -1,0 +1,56 @@
+package sqlstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/config"
+	"github.com/SigNoz/signoz/pkg/config/envprovider"
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWithEnvProvider(t *testing.T) {
+	t.Setenv("SIGNOZ_SQLSTORE_PROVIDER", "sqlite")
+	t.Setenv("SIGNOZ_SQLSTORE_SQLITE_PATH", "/tmp/test.db")
+	t.Setenv("SIGNOZ_SQLSTORE_SQLITE_MODE", "wal")
+	t.Setenv("SIGNOZ_SQLSTORE_SQLITE_BUSY__TIMEOUT", "5s")
+	t.Setenv("SIGNOZ_SQLSTORE_SQLITE_TRANSACTION__MODE", "immediate")
+	t.Setenv("SIGNOZ_SQLSTORE_MAX__OPEN__CONNS", "50")
+
+	conf, err := config.New(
+		context.Background(),
+		config.ResolverConfig{
+			Uris: []string{"env:"},
+			ProviderFactories: []config.ProviderFactory{
+				envprovider.NewFactory(),
+			},
+		},
+		[]factory.ConfigFactory{
+			NewConfigFactory(),
+		},
+	)
+	require.NoError(t, err)
+
+	actual := &Config{}
+	err = conf.Unmarshal("sqlstore", actual)
+	require.NoError(t, err)
+
+	expected := &Config{
+		Provider: "sqlite",
+		Connection: ConnectionConfig{
+			MaxOpenConns: 50,
+		},
+		Sqlite: SqliteConfig{
+			Path:            "/tmp/test.db",
+			Mode:            "wal",
+			BusyTimeout:     5 * time.Second,
+			TransactionMode: "immediate",
+		},
+	}
+
+	assert.Equal(t, expected, actual)
+	assert.NoError(t, actual.Validate())
+}

--- a/pkg/sqlstore/sqlitesqlstore/provider.go
+++ b/pkg/sqlstore/sqlitesqlstore/provider.go
@@ -49,6 +49,7 @@ func New(ctx context.Context, providerSettings factory.ProviderSettings, config 
 	connectionParams.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", config.Sqlite.BusyTimeout.Milliseconds()))
 	connectionParams.Add("_pragma", fmt.Sprintf("journal_mode(%s)", config.Sqlite.Mode))
 	connectionParams.Add("_pragma", "foreign_keys(1)")
+	connectionParams.Set("_txlock", config.Sqlite.TransactionMode)
 	sqldb, err := sql.Open("sqlite", "file:"+config.Sqlite.Path+"?"+connectionParams.Encode())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### 📄 Summary
- add support for sqlite transaction modes

contributes to: https://github.com/SigNoz/platform-pod/issues/1953