### PR TITLE
fix(date-time-selection): reset to the correct value under modal

### DIFF
--- a/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
+++ b/frontend/src/container/TopNav/DateTimeSelectionV2/index.tsx
@@ -360,7 +360,11 @@ function DateTimeSelection({
 	const invalidateQueries = useGlobalTimeQueryInvalidate();
 	const onRefreshHandler = (): void => {
 		invalidateQueries();
-		onSelectHandler(selectedTime);
+		onSelectHandler(
+			isModalTimeSelection && modalSelectedInterval
+				? modalSelectedInterval
+				: selectedTime,
+		);
 		onLastRefreshHandler();
 	};
 	const handleReset = useCallback(() => {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The selected time was being reset to default value after change the value under modal mode.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

https://github.com/user-attachments/assets/abeaaa12-c12f-4bc1-ad17-1a2b88b8bd56

After:

https://github.com/user-attachments/assets/aa658dd6-6ebd-4126-9e51-07ca3bf3e31e


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Fixes https://github.com/SigNoz/engineering-pod/issues/4385

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

The bug only happens under modal mode.

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

The refresh was using the wrong value when modal mode.

#### Fix Strategy
> How does this PR address the root cause?

Just add check for the correct value.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: When click to refresh button in DateTimeSelectionV2
- Potential regressions: -
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | When selecting custom interval under a modal on Infrastructure Monitoring, this custom interval was being reset to default value when click to refresh the charts. |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered