### PR TITLE
fix: update border colors in External APIs for light mode

### DIFF
--- a/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
+++ b/frontend/src/container/ApiMonitoring/Explorer/Explorer.styles.scss
@@ -220,6 +220,21 @@
 }
 
 .lightMode {
+	.api-monitoring-page {
+		.api-quick-filter-left-section {
+			.api-quick-filters-header {
+				border-bottom: 1px solid var(--bg-slate-200);
+				border-right: 1px solid var(--bg-slate-200);
+			}
+		}
+
+		.api-module-right-section {
+			.toolbar {
+				border-bottom: 1px solid var(--bg-slate-200);
+			}
+		}
+	}
+
 	.no-filtered-domains-message-container {
 		.no-filtered-domains-message-content {
 			.no-filtered-domains-message {
@@ -271,6 +286,8 @@
 
 			.round-metric-tag {
 				color: var(--bg-vanilla-100);
+				border: 1px solid var(--bg-slate-200);
+				background: var(--bg-slate-100);
 			}
 		}
 	}


### PR DESCRIPTION
Hi team! 👋

I noticed the border colors in the External APIs page don't look quite right in light mode. The borders are using bg-slate-400 which works well for dark mode, but in light mode it makes the borders look a bit too harsh.

## Changes
- Updated .api-quick-filters-header border colors from bg-slate-400 to bg-slate-200 in light mode
- Updated .toolbar border-bottom color from bg-slate-400 to bg-slate-200 in light mode
- Updated .round-metric-tag border and background colors for better visibility in light mode

## Testing
- [x] Verified changes in light mode
- [x] Verified no impact on dark mode
- [x] Checked External APIs page renders correctly

The changes are minimal and only affect the .lightMode CSS class, so there's no risk of breaking anything in dark mode.

Let me know if you'd like any adjustments! 😊

Thanks for maintaining this awesome project! 🙏