### PR TITLE
fix: guard against undefined resources_string in dashboard list panel

### DIFF
--- a/frontend/src/container/LogsExplorerContext/utils.ts
+++ b/frontend/src/container/LogsExplorerContext/utils.ts
@@ -34,7 +34,7 @@ const SERVICE_AND_ENVIRONMENT_KEYS = [
 export const getFiltersFromResources = (
 	resources: ILog['resources_string'],
 ): TagFilterItem[] =>
-	Object.keys(resources).map((key: string) => {
+	Object.keys(resources ?? {}).map((key: string) => {
 		const resourceValue = resources[key] as string;
 		return {
 			id: uuid(),

--- a/frontend/src/container/LogsExplorerContext/utils.ts
+++ b/frontend/src/container/LogsExplorerContext/utils.ts
@@ -35,7 +35,7 @@ export const getFiltersFromResources = (
 	resources: ILog['resources_string'],
 ): TagFilterItem[] =>
 	Object.keys(resources ?? {}).map((key: string) => {
-		const resourceValue = resources[key] as string;
+		const resourceValue = (resources ?? {})[key] as string;
 		return {
 			id: uuid(),
 			key: {

--- a/frontend/src/types/api/logs/log.ts
+++ b/frontend/src/types/api/logs/log.ts
@@ -9,7 +9,7 @@ export interface ILog {
 	severityText: string;
 	severityNumber: number;
 	body: string;
-	resources_string: Record<string, never>;
+	resources_string: Record<string, never> | undefined;
 	scope_string: Record<string, never>;
 	attributesString: Record<string, never>;
 	attributes_string: Record<string, never>;


### PR DESCRIPTION
## Summary

Fixes #10815 — clicking a log row in a dashboard **list** panel crashes the frontend.

## Root Cause

`getFiltersFromResources()` in `frontend/src/container/LogsExplorerContext/utils.ts` calls `Object.keys(resources)` where `resources` is `log.resources_string`. When a log is rendered in a dashboard list panel (not the Logs explorer), `resources_string` can be `undefined`, causing:

```
TypeError: undefined is not an object (evaluating 'Object.keys(e)')
```

## Fix

Add nullish coalescing: `Object.keys(resources ?? {})` — returns an empty array when `resources_string` is undefined, so no filters are created and the log detail view opens normally.

## Test plan

- [ ] Open a dashboard with a list panel querying logs
- [ ] Click on a log row — should open log detail view without crash
- [ ] Verify Logs explorer page still works (resources_string is populated there)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive change that prevents a frontend crash when `resources_string` is missing; behavior when resources are present is unchanged.
> 
> **Overview**
> Prevents crashes when opening log details from dashboard list panels by making `getFiltersFromResources` tolerate an undefined `resources_string` (treats it as an empty object and returns no resource-derived filters).
> 
> Updates the `ILog` type so `resources_string` is allowed to be `undefined`, aligning the type with observed API/UI usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86a4656176910e00fefa4e9f57b9dd26be377fe3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->