### PR TITLE
chore(frontend): sync pylon chat widget theme with app theme

### DIFF
--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -18,7 +18,7 @@ import AppLayout from 'container/AppLayout';
 import Hex from 'crypto-js/enc-hex';
 import HmacSHA256 from 'crypto-js/hmac-sha256';
 import { KeyboardHotkeysProvider } from 'hooks/hotkeys/useKeyboardHotkeys';
-import { useThemeConfig } from 'hooks/useDarkMode';
+import { useIsDarkMode, useThemeConfig } from 'hooks/useDarkMode';
 import { useGetTenantLicense } from 'hooks/useGetTenantLicense';
 import { NotificationProvider } from 'hooks/useNotifications';
 import { ResourceProvider } from 'hooks/useResourceAttribute';
@@ -211,6 +211,12 @@ function App(): JSX.Element {
 		activeLicense,
 		activeLicenseFetchError,
 	]);
+
+	const isDarkMode = useIsDarkMode();
+
+	useEffect(() => {
+		window.Pylon?.('setTheme', isDarkMode ? 'dark' : 'light');
+	}, [isDarkMode]);
 
 	useEffect(() => {
 		if (


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Syncs the Pylon chat widget theme (dark/light) with the SigNoz app theme using the `window.Pylon('setTheme', ...)` API. Previously, the Pylon widget always used its default theme regardless of the user's SigNoz theme preference.

#### Screenshots / Screen Recordings (if applicable)
Dark mode
<img width="1509" height="880" alt="Screenshot 2026-04-04 at 08 10 36" src="https://github.com/user-attachments/assets/6cb5934a-1809-4f58-a161-a717bbb712bb" />

Light mode
<img width="1511" height="857" alt="Screenshot 2026-04-04 at 08 10 52" src="https://github.com/user-attachments/assets/e6bbecad-0bf3-423e-8546-c25c7414efc3" />

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Manual verification:
  - Toggle SigNoz theme to dark mode → verify Pylon chat widget renders in dark theme
  - Toggle SigNoz theme to light mode → verify Pylon chat widget renders in light theme
  - Verify the chat widget loads with the correct theme on initial page load
  - Verify no errors for non-cloud users (where Pylon is not loaded)
- Edge cases covered: Non-cloud users where `window.Pylon` is undefined (handled via optional chaining)

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Cloud users only — Pylon widget is not loaded for non-cloud users
- Potential regressions: None — uses optional chaining, no-op when Pylon is absent
- Rollback plan: Revert commit

---

### 📝 Changelog
N/A — non-user-facing cosmetic alignment

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Small change: adds a `useEffect` that calls `window.Pylon('setTheme', 'dark' | 'light')` whenever `isDarkMode` changes. Follows the same optional chaining pattern used by the existing `showChatBubble`/`hideChatBubble` effect.

---