### PR TITLE
fix(alerts): normalize legacy compositeQuery payloads for v5 rule evaluation

### DIFF
--- a/pkg/types/ruletypes/api_params.go
+++ b/pkg/types/ruletypes/api_params.go
@@ -287,9 +287,11 @@ func appendLegacyBuilderQueries(dst map[string]any, payload any) bool {
 			continue
 		}
 
-		name := getLegacyQueryName(queryMap)
+		originalName := getLegacyQueryName(queryMap)
+		name := originalName
 		if name == "" {
 			name = fmt.Sprintf("Q%d", idx+1)
+			originalName = name
 		}
 
 		if _, exists := dst[name]; exists {
@@ -303,6 +305,20 @@ func appendLegacyBuilderQueries(dst map[string]any, payload any) bool {
 			}
 		}
 
+		if name != originalName {
+			if queryName, ok := queryMap["queryName"].(string); ok && queryName == originalName {
+				queryMap["queryName"] = name
+			}
+			if queryName, ok := queryMap["name"].(string); ok && queryName == originalName {
+				queryMap["name"] = name
+			}
+			// WrapInV5Envelope uses name != expression to detect formulas.
+			// Keep expression aligned for renamed builder queries.
+			if expression, ok := queryMap["expression"].(string); ok && expression == originalName {
+				queryMap["expression"] = name
+			}
+		}
+
 		dst[name] = queryMap
 		updated = true
 	}
@@ -311,6 +327,11 @@ func appendLegacyBuilderQueries(dst map[string]any, payload any) bool {
 }
 
 func flattenBuilderCompositeQuery(compositeQuery map[string]any) bool {
+	queryType, _ := compositeQuery["queryType"].(string)
+	if queryType != QueryTypeBuilder.StringValue() {
+		return false
+	}
+
 	builder, ok := compositeQuery["builder"].(map[string]any)
 	if !ok {
 		return false
@@ -424,16 +445,19 @@ func (r *PostableRule) UnmarshalJSON(data []byte) error {
 	}
 
 	type Alias PostableRule
-	aux := (*Alias)(r)
-	if err := json.Unmarshal(normalizedBytes, aux); err != nil {
+	var parsed Alias
+	if err := json.Unmarshal(normalizedBytes, &parsed); err != nil {
 		if !bytes.Equal(normalizedBytes, data) {
-			if fallbackErr := json.Unmarshal(data, aux); fallbackErr == nil {
+			var fallback Alias
+			if fallbackErr := json.Unmarshal(data, &fallback); fallbackErr == nil {
+				*r = PostableRule(fallback)
 				r.processRuleDefaults()
 				return r.validate()
 			}
 		}
 		return errors.NewInvalidInputf(errors.CodeInvalidInput, "failed to parse json: %v", err)
 	}
+	*r = PostableRule(parsed)
 	r.processRuleDefaults()
 	return r.validate()
 }

--- a/pkg/types/ruletypes/api_params_test.go
+++ b/pkg/types/ruletypes/api_params_test.go
@@ -271,6 +271,187 @@ func TestParseIntoRuleLegacyBuilderQueryDataPopulatesV5Queries(t *testing.T) {
 	}
 }
 
+func TestFlattenBuilderCompositeQuerySkipsNonBuilderQueryType(t *testing.T) {
+	compositeQuery := map[string]any{
+		"queryType": QueryTypePromQL.StringValue(),
+		"builder": map[string]any{
+			"queryData": []any{
+				map[string]any{
+					"queryName":         "A",
+					"expression":        "A",
+					"dataSource":        "logs",
+					"aggregateOperator": "count",
+					"disabled":          false,
+				},
+			},
+		},
+	}
+
+	updated := flattenBuilderCompositeQuery(compositeQuery)
+
+	assert.False(t, updated)
+	_, hasBuilder := compositeQuery["builder"]
+	assert.True(t, hasBuilder)
+	_, hasBuilderQueries := compositeQuery["builderQueries"]
+	assert.False(t, hasBuilderQueries)
+}
+
+func TestNormalizeLegacyRulePayloadDoesNotDropBuilderQueryDataForNonBuilderType(t *testing.T) {
+	content := []byte(`{
+		"version": "v5",
+		"condition": {
+			"compositeQuery": {
+				"queryType": "promql",
+				"builder": {
+					"queryData": [{
+						"queryName": "A",
+						"stepInterval": 60,
+						"dataSource": "logs",
+						"aggregateOperator": "count",
+						"aggregateAttribute": {"key": "", "dataType": "", "type": "", "isColumn": false},
+						"filters": {"op": "AND", "items": []},
+						"expression": "A",
+						"disabled": false
+					}]
+				}
+			}
+		}
+	}`)
+
+	normalized, err := normalizeLegacyRulePayload(content)
+	assert.NoError(t, err)
+
+	var payload map[string]any
+	err = json.Unmarshal(normalized, &payload)
+	assert.NoError(t, err)
+
+	condition, ok := payload["condition"].(map[string]any)
+	if !assert.True(t, ok) {
+		return
+	}
+	compositeQuery, ok := condition["compositeQuery"].(map[string]any)
+	if !assert.True(t, ok) {
+		return
+	}
+
+	_, hasBuilder := compositeQuery["builder"]
+	assert.True(t, hasBuilder)
+	_, hasQueries := compositeQuery["queries"]
+	assert.False(t, hasQueries)
+}
+
+func TestParseIntoRuleFallbackUnmarshalDoesNotRetainNormalizedState(t *testing.T) {
+	content := []byte(`{
+		"alert": "FallbackNoResidualState",
+		"ruleType": "threshold_rule",
+		"version": "v5",
+		"condition": {
+			"compositeQuery": {
+				"queryType": "builder",
+				"builderQueries": {
+					"A": {
+						"expression": "A",
+						"disabled": false,
+						"aggregateAttribute": {
+							"key": "test_metric"
+						}
+					}
+				}
+			},
+			"target": 1,
+			"matchType": "1",
+			"op": "1"
+		}
+	}`)
+
+	rule := PostableRule{}
+	err := json.Unmarshal(content, &rule)
+	assert.NoError(t, err)
+	if !assert.NotNil(t, rule.RuleCondition) || !assert.NotNil(t, rule.RuleCondition.CompositeQuery) {
+		return
+	}
+	assert.Empty(t, rule.RuleCondition.CompositeQuery.Queries)
+}
+
+func TestNormalizeLegacyRulePayloadDuplicateBuilderQueryNamesRemainBuilderQueries(t *testing.T) {
+	content := []byte(`{
+		"version": "v5",
+		"condition": {
+			"compositeQuery": {
+				"queryType": "builder",
+				"panelType": "graph",
+				"builder": {
+					"queryData": [
+						{
+							"queryName": "A",
+							"stepInterval": 60,
+							"dataSource": "logs",
+							"aggregateOperator": "count",
+							"aggregateAttribute": {"key": "", "dataType": "", "type": "", "isColumn": false},
+							"filters": {"op": "AND", "items": []},
+							"expression": "A",
+							"disabled": false
+						},
+						{
+							"queryName": "A",
+							"stepInterval": 60,
+							"dataSource": "logs",
+							"aggregateOperator": "count",
+							"aggregateAttribute": {"key": "", "dataType": "", "type": "", "isColumn": false},
+							"filters": {"op": "AND", "items": []},
+							"expression": "A",
+							"disabled": false
+						}
+					]
+				}
+			}
+		}
+	}`)
+
+	normalized, err := normalizeLegacyRulePayload(content)
+	assert.NoError(t, err)
+
+	var payload map[string]any
+	err = json.Unmarshal(normalized, &payload)
+	assert.NoError(t, err)
+
+	condition, ok := payload["condition"].(map[string]any)
+	if !assert.True(t, ok) {
+		return
+	}
+	compositeQuery, ok := condition["compositeQuery"].(map[string]any)
+	if !assert.True(t, ok) {
+		return
+	}
+	queries, ok := compositeQuery["queries"].([]any)
+	if !assert.True(t, ok) {
+		return
+	}
+	if !assert.Len(t, queries, 2) {
+		return
+	}
+
+	queryNames := make([]string, 0, len(queries))
+	for _, query := range queries {
+		queryMap, ok := query.(map[string]any)
+		if !assert.True(t, ok) {
+			return
+		}
+		assert.Equal(t, "builder_query", queryMap["type"])
+		spec, ok := queryMap["spec"].(map[string]any)
+		if !assert.True(t, ok) {
+			return
+		}
+		queryName, ok := spec["name"].(string)
+		if !assert.True(t, ok) {
+			return
+		}
+		queryNames = append(queryNames, queryName)
+	}
+
+	assert.ElementsMatch(t, []string{"A", "A_1"}, queryNames)
+}
+
 func TestParseIntoRuleSchemaVersioning(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary
- normalize legacy rule payloads before PostableRule unmarshal
- convert condition.compositeQuery.builder.queryData/queryFormulas into legacy maps when present
- run existing alert v4->v5 migration path to populate condition.compositeQuery.queries
- add regression tests for both uilderQueries and uilder.queryData payloads

## Why
Rules created via API with legacy payload shapes were accepted but stored without v5 queries, so ruler evaluation found no executable query.

Closes #10823

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `PostableRule` JSON unmarshalling to rewrite and migrate incoming rule payloads, which can affect how alert queries are interpreted and stored. Risk is moderate because it touches alert ingestion/migration logic but is scoped to legacy payload normalization with added regression tests.
> 
> **Overview**
> Fixes v5 rule creation for *legacy `condition.compositeQuery` shapes* by normalizing the incoming JSON before `PostableRule.UnmarshalJSON` runs.
> 
> The unmarshal path now (1) flattens `compositeQuery.builder.queryData/queryFormulas` into `builderQueries` entries (with stable/unique query names) and (2) invokes the existing `transition.NewAlertMigrateV5` migrator (temporarily treating `version: "v5"` as `v4`) to populate `compositeQuery.queries` when only legacy query maps exist; it falls back to the raw payload if normalization breaks parsing.
> 
> Adds regression tests ensuring both `builderQueries` and nested `builder.queryData` payloads result in populated v5 `CompositeQuery.Queries`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8948170e102fd6488f7d6779b4a15ac78dd300b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->