### PR TITLE
fix: disable autocomplete on time selection inputs

### DIFF
--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -603,6 +603,7 @@ function CustomTimePicker({
 							inputStatus === CustomTimePickerInputStatus.ERROR ? 'error' : '',
 						)}
 						type="text"
+						autoComplete="off"
 						status={
 							inputValue && inputStatus === CustomTimePickerInputStatus.ERROR
 								? 'error'

--- a/frontend/src/pages/MessagingQueues/MQDetails/DropRateView/EvaluationTimeSelector.tsx
+++ b/frontend/src/pages/MessagingQueues/MQDetails/DropRateView/EvaluationTimeSelector.tsx
@@ -30,6 +30,7 @@ function SelectDropdownRender({
 				onKeyDown={handleKeyDown}
 				onBlur={handleAddCustomValue}
 				className="select-dropdown-render"
+				autoComplete="off"
 			/>
 		</>
 	);


### PR DESCRIPTION
## Summary
- Adds `autoComplete="off"` to the `CustomTimePicker` input component and the `EvaluationTimeSelector` custom time input
- Prevents password managers (1Password, LastPass, Bitwarden, etc.) from injecting credentials into time selection fields

## Related Issue
Fixes #5875

## Changes
- `frontend/src/components/CustomTimePicker/CustomTimePicker.tsx` — added `autoComplete="off"` to the main time picker input
- `frontend/src/pages/MessagingQueues/MQDetails/DropRateView/EvaluationTimeSelector.tsx` — added `autoComplete="off"` to the custom time interval input

## Test Plan
- [ ] Open the app with a password manager extension enabled
- [ ] Navigate to any page with the time selection picker
- [ ] Verify password manager no longer injects values into the time input field
- [ ] Verify time selection still works correctly (custom input, relative time shortcuts, date ranges)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that only tweaks browser/password-manager behavior on two `Input` fields and should not affect time parsing or selection logic.
> 
> **Overview**
> Disables browser/password-manager autocomplete on time selection inputs by adding `autoComplete="off"` to the main `CustomTimePicker` field and the `EvaluationTimeSelector` custom interval input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6693e3868636d4dd93d7b885180af8763003651f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->