### PR TITLE
fix(frontend): restore sidebar resize button and functionality (#9370)

### DIFF
--- a/frontend/src/container/AppLayout/index.tsx
+++ b/frontend/src/container/AppLayout/index.tsx
@@ -840,7 +840,10 @@ function AppLayout(props: AppLayoutProps): JSX.Element {
 				)}
 			>
 				{isToDisplayLayout && !renderFullScreen && (
-					<SideNav isPinned={isSideNavPinned} />
+					<SideNav
+						isPinned={isSideNavPinned}
+						handleTogglePinned={handleToggleSidebar}
+					/>
 				)}
 				<div
 					className={cx('app-content', {

--- a/frontend/src/container/SideNav/SideNav.styles.scss
+++ b/frontend/src/container/SideNav/SideNav.styles.scss
@@ -471,9 +471,23 @@
 					right: -9px;
 					cursor: pointer;
 
-					display: none;
+					display: flex;
+					align-items: center;
+					justify-content: center;
 
-					transition: display 0.3s;
+					width: 18px;
+					height: 18px;
+					border-radius: 50%;
+					background: var(--bg-slate-400, #1d212d);
+					border: 1px solid var(--bg-slate-300, #242834);
+					z-index: 10;
+
+					transition: all 0.2s ease;
+
+					&:hover {
+						background: var(--bg-slate-300, #242834);
+						transform: scale(1.1);
+					}
 
 					svg {
 						fill: var(--bg-vanilla-400);

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
 	MouseEvent,
 	useCallback,
 	useEffect,
@@ -46,6 +46,8 @@ import {
 	ChevronDown,
 	ChevronsDown,
 	ChevronUp,
+	ChevronLeft,
+	ChevronRight,
 	Cog,
 	Ellipsis,
 	GitCommitVertical,
@@ -120,8 +122,16 @@ function SortableFilter({ item }: { item: SidebarItem }): JSX.Element {
 	);
 }
 
+interface SideNavProps {
+	isPinned: boolean;
+	handleTogglePinned: () => void;
+}
+
 // eslint-disable-next-line sonarjs/cognitive-complexity
-function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
+function SideNav({
+	isPinned,
+	handleTogglePinned,
+}: SideNavProps): React.JSX.Element {
 	const { openCmdK } = useCmdK();
 	const { pathname, search } = useLocation();
 	const { currentVersion, latestVersion, isCurrentVersionError } = useSelector<
@@ -1201,6 +1211,14 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 										</div>
 									</div>
 								</Dropdown>
+							</div>
+
+							<div
+								className="collapse-expand-handlers"
+								onClick={handleTogglePinned}
+								data-testid="sidebar-resize-button"
+							>
+								{isPinned ? <ChevronLeft size={16} /> : <ChevronRight size={16} />}
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
### Description
This PR fixes issue #9370 where the sidebar resize (expand/collapse) button was missing from the UI and non-functional when the sidebar was closed.

### Changes Made
- **SideNav Component**: Restored the `collapse-expand-handlers` div and added `handleTogglePinned` prop.
- **AppLayout Integration**: Passed the `handleToggleSidebar` function to `SideNav` so the button can trigger the state change.
- **Styling**: Updated `SideNav.styles.scss` to make the button visible and added premium hover/interactive styles.
- **Icons**: Used `ChevronLeft` and `ChevronRight` from `lucide-react` to clearly indicate the button's action.

### Verification Results
- Verified that the button is now visible at the bottom of the sidebar.
- Confirmed that clicking the button successfully toggles the sidebar state between collapsed and expanded.
- Fixed a syntax error in the component props that was causing TypeScript lint errors.

Fixes #9370

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change: adds a missing sidebar toggle control and styles; main risk is minor layout/CSS regressions or incorrect toggle state wiring.
> 
> **Overview**
> Restores the sidebar collapse/expand button in `SideNav` and wires it to the existing toggle logic via a new `handleTogglePinned` prop passed from `AppLayout`.
> 
> Updates the `collapse-expand-handlers` styles to ensure the control is visible and adds hover/interaction styling, and uses `ChevronLeft`/`ChevronRight` icons to reflect the pinned state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2594363bc863f3f4e5490ca780c48c0adef91de7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->