### PR TITLE
feat(billing): use meter api from zeus

### DIFF
--- a/ee/query-service/app/api/license.go
+++ b/ee/query-service/app/api/license.go
@@ -78,7 +78,7 @@ func (ah *APIHandler) getBilling(w http.ResponseWriter, r *http.Request) {
 
 	orgID := valuer.MustNewUUID(claims.OrgID)
 	evalCtx := featuretypes.NewFlaggerEvaluationContext(orgID)
-	useZeus := ah.Signoz.Flagger.BooleanOrEmpty(r.Context(), flagger.FeatureBillingZeus, evalCtx)
+	useZeus := ah.Signoz.Flagger.BooleanOrEmpty(r.Context(), flagger.FeatureGetMetersFromZeus, evalCtx)
 
 	if useZeus {
 		data, err := ah.Signoz.Zeus.GetMeters(r.Context(), licenseKey)

--- a/ee/query-service/app/api/license.go
+++ b/ee/query-service/app/api/license.go
@@ -5,7 +5,12 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/SigNoz/signoz/ee/query-service/constants"
 	"github.com/SigNoz/signoz/ee/query-service/model"
+	"github.com/SigNoz/signoz/pkg/flagger"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	"github.com/SigNoz/signoz/pkg/types/featuretypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
 )
 
 type DayWiseBreakdown struct {
@@ -52,6 +57,11 @@ type billingData struct {
 	SubscriptionStatus string  `json:"subscriptionStatus"`
 }
 
+type billingDetails struct {
+	Status string      `json:"status"`
+	Data   billingData `json:"data"`
+}
+
 func (ah *APIHandler) getBilling(w http.ResponseWriter, r *http.Request) {
 	licenseKey := r.URL.Query().Get("licenseKey")
 
@@ -60,17 +70,53 @@ func (ah *APIHandler) getBilling(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := ah.Signoz.Zeus.GetMeters(r.Context(), licenseKey)
+	claims, err := authtypes.ClaimsFromContext(r.Context())
 	if err != nil {
 		RespondError(w, model.InternalError(err), nil)
 		return
 	}
 
-	var billing billingData
-	if err := json.Unmarshal(data, &billing); err != nil {
+	orgID := valuer.MustNewUUID(claims.OrgID)
+	evalCtx := featuretypes.NewFlaggerEvaluationContext(orgID)
+	useZeus := ah.Signoz.Flagger.BooleanOrEmpty(r.Context(), flagger.FeatureBillingZeus, evalCtx)
+
+	if useZeus {
+		data, err := ah.Signoz.Zeus.GetMeters(r.Context(), licenseKey)
+		if err != nil {
+			RespondError(w, model.InternalError(err), nil)
+			return
+		}
+
+		var billing billingData
+		if err := json.Unmarshal(data, &billing); err != nil {
+			RespondError(w, model.InternalError(err), nil)
+			return
+		}
+
+		ah.Respond(w, billing)
+		return
+	}
+
+	billingURL := fmt.Sprintf("%s/usage?licenseKey=%s", constants.LicenseSignozIo, licenseKey)
+
+	hClient := &http.Client{}
+	req, err := http.NewRequest("GET", billingURL, nil)
+	if err != nil {
+		RespondError(w, model.InternalError(err), nil)
+		return
+	}
+	req.Header.Add("X-SigNoz-SecretKey", constants.LicenseAPIKey)
+	billingResp, err := hClient.Do(req)
+	if err != nil {
 		RespondError(w, model.InternalError(err), nil)
 		return
 	}
 
-	ah.Respond(w, billing)
+	var billingResponse billingDetails
+	if err := json.NewDecoder(billingResp.Body).Decode(&billingResponse); err != nil {
+		RespondError(w, model.InternalError(err), nil)
+		return
+	}
+
+	ah.Respond(w, billingResponse.Data)
 }

--- a/ee/query-service/app/api/license.go
+++ b/ee/query-service/app/api/license.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/SigNoz/signoz/ee/query-service/constants"
 	"github.com/SigNoz/signoz/ee/query-service/model"
 )
 
@@ -45,15 +44,12 @@ type details struct {
 	BillTotal float64         `json:"billTotal"`
 }
 
-type billingDetails struct {
-	Status string `json:"status"`
-	Data   struct {
-		BillingPeriodStart int64   `json:"billingPeriodStart"`
-		BillingPeriodEnd   int64   `json:"billingPeriodEnd"`
-		Details            details `json:"details"`
-		Discount           float64 `json:"discount"`
-		SubscriptionStatus string  `json:"subscriptionStatus"`
-	} `json:"data"`
+type billingData struct {
+	BillingPeriodStart int64   `json:"billingPeriodStart"`
+	BillingPeriodEnd   int64   `json:"billingPeriodEnd"`
+	Details            details `json:"details"`
+	Discount           float64 `json:"discount"`
+	SubscriptionStatus string  `json:"subscriptionStatus"`
 }
 
 func (ah *APIHandler) getBilling(w http.ResponseWriter, r *http.Request) {
@@ -64,28 +60,17 @@ func (ah *APIHandler) getBilling(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	billingURL := fmt.Sprintf("%s/usage?licenseKey=%s", constants.LicenseSignozIo, licenseKey)
-
-	hClient := &http.Client{}
-	req, err := http.NewRequest("GET", billingURL, nil)
-	if err != nil {
-		RespondError(w, model.InternalError(err), nil)
-		return
-	}
-	req.Header.Add("X-SigNoz-SecretKey", constants.LicenseAPIKey)
-	billingResp, err := hClient.Do(req)
+	data, err := ah.Signoz.Zeus.GetMeters(r.Context(), licenseKey)
 	if err != nil {
 		RespondError(w, model.InternalError(err), nil)
 		return
 	}
 
-	// decode response body
-	var billingResponse billingDetails
-	if err := json.NewDecoder(billingResp.Body).Decode(&billingResponse); err != nil {
+	var billing billingData
+	if err := json.Unmarshal(data, &billing); err != nil {
 		RespondError(w, model.InternalError(err), nil)
 		return
 	}
 
-	// TODO(srikanthccv):Fetch the current day usage and add it to the response
-	ah.Respond(w, billingResponse.Data)
+	ah.Respond(w, billing)
 }

--- a/ee/zeus/httpzeus/provider.go
+++ b/ee/zeus/httpzeus/provider.go
@@ -109,6 +109,21 @@ func (provider *Provider) GetDeployment(ctx context.Context, key string) ([]byte
 	return []byte(gjson.GetBytes(response, "data").String()), nil
 }
 
+func (provider *Provider) GetMeters(ctx context.Context, key string) ([]byte, error) {
+	response, err := provider.do(
+		ctx,
+		provider.config.URL.JoinPath("/v1/meters"),
+		http.MethodGet,
+		key,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(gjson.GetBytes(response, "data").String()), nil
+}
+
 func (provider *Provider) PutMeters(ctx context.Context, key string, data []byte) error {
 	_, err := provider.do(
 		ctx,

--- a/pkg/flagger/registry.go
+++ b/pkg/flagger/registry.go
@@ -6,6 +6,7 @@ var (
 	FeatureUseSpanMetrics = featuretypes.MustNewName("use_span_metrics")
 	FeatureKafkaSpanEval  = featuretypes.MustNewName("kafka_span_eval")
 	FeatureHideRootUser   = featuretypes.MustNewName("hide_root_user")
+	FeatureBillingZeus    = featuretypes.MustNewName("billing_zeus")
 )
 
 func MustNewRegistry() featuretypes.Registry {
@@ -31,6 +32,14 @@ func MustNewRegistry() featuretypes.Registry {
 			Kind:           featuretypes.KindBoolean,
 			Stage:          featuretypes.StageStable,
 			Description:    "Controls whether root admin user is hidden or not",
+			DefaultVariant: featuretypes.MustNewName("disabled"),
+			Variants:       featuretypes.NewBooleanVariants(),
+		},
+		&featuretypes.Feature{
+			Name:           FeatureBillingZeus,
+			Kind:           featuretypes.KindBoolean,
+			Stage:          featuretypes.StageExperimental,
+			Description:    "Controls whether billing details are fetched from Zeus instead of the legacy subscriptions service",
 			DefaultVariant: featuretypes.MustNewName("disabled"),
 			Variants:       featuretypes.NewBooleanVariants(),
 		},

--- a/pkg/flagger/registry.go
+++ b/pkg/flagger/registry.go
@@ -6,7 +6,7 @@ var (
 	FeatureUseSpanMetrics = featuretypes.MustNewName("use_span_metrics")
 	FeatureKafkaSpanEval  = featuretypes.MustNewName("kafka_span_eval")
 	FeatureHideRootUser   = featuretypes.MustNewName("hide_root_user")
-	FeatureBillingZeus    = featuretypes.MustNewName("billing_zeus")
+	FeatureGetMetersFromZeus = featuretypes.MustNewName("get_meters_from_zeus")
 )
 
 func MustNewRegistry() featuretypes.Registry {
@@ -36,7 +36,7 @@ func MustNewRegistry() featuretypes.Registry {
 			Variants:       featuretypes.NewBooleanVariants(),
 		},
 		&featuretypes.Feature{
-			Name:           FeatureBillingZeus,
+			Name:           FeatureGetMetersFromZeus,
 			Kind:           featuretypes.KindBoolean,
 			Stage:          featuretypes.StageExperimental,
 			Description:    "Controls whether billing details are fetched from Zeus instead of the legacy subscriptions service",

--- a/pkg/flagger/registry.go
+++ b/pkg/flagger/registry.go
@@ -3,9 +3,9 @@ package flagger
 import "github.com/SigNoz/signoz/pkg/types/featuretypes"
 
 var (
-	FeatureUseSpanMetrics = featuretypes.MustNewName("use_span_metrics")
-	FeatureKafkaSpanEval  = featuretypes.MustNewName("kafka_span_eval")
-	FeatureHideRootUser   = featuretypes.MustNewName("hide_root_user")
+	FeatureUseSpanMetrics    = featuretypes.MustNewName("use_span_metrics")
+	FeatureKafkaSpanEval     = featuretypes.MustNewName("kafka_span_eval")
+	FeatureHideRootUser      = featuretypes.MustNewName("hide_root_user")
 	FeatureGetMetersFromZeus = featuretypes.MustNewName("get_meters_from_zeus")
 )
 

--- a/pkg/zeus/noopzeus/provider.go
+++ b/pkg/zeus/noopzeus/provider.go
@@ -37,6 +37,10 @@ func (provider *provider) GetDeployment(_ context.Context, _ string) ([]byte, er
 	return nil, errors.New(errors.TypeUnsupported, zeus.ErrCodeUnsupported, "getting the deployment is not supported")
 }
 
+func (provider *provider) GetMeters(_ context.Context, _ string) ([]byte, error) {
+	return nil, errors.New(errors.TypeUnsupported, zeus.ErrCodeUnsupported, "getting meters is not supported")
+}
+
 func (provider *provider) PutMeters(_ context.Context, _ string, _ []byte) error {
 	return errors.New(errors.TypeUnsupported, zeus.ErrCodeUnsupported, "putting meters is not supported")
 }

--- a/pkg/zeus/zeus.go
+++ b/pkg/zeus/zeus.go
@@ -26,6 +26,9 @@ type Zeus interface {
 	// Returns the deployment for the given license key.
 	GetDeployment(context.Context, string) ([]byte, error)
 
+	// Returns the billing details for the given license key.
+	GetMeters(context.Context, string) ([]byte, error)
+
 	// Puts the meters for the given license key.
 	PutMeters(context.Context, string, []byte) error
 


### PR DESCRIPTION
 📄 Summary                          

  The SigNoz backend's /api/v1/billing endpoint was calling the legacy                
  license.signoz.io subscriptions service directly via a raw HTTP client to fetch
  billing/usage details. Zeus is the new billing service that is replacing the        
  subscriptions service. This PR switches the billing endpoint to call Zeus's
  /v1/meters API instead, using the same authenticated Zeus HTTP client already used
  for license and deployment lookups.
  
  
  Screenshots: 
  
  
<img width="1085" height="752" alt="Screenshot 2026-04-10 at 4 18 04 PM" src="https://github.com/user-attachments/assets/9d3012f5-ad4e-4fa2-93b9-0ce9e8ba0cab" />
