### PR TITLE
fix(logs): guard missing resources in log detail initial query

### DIFF
--- a/frontend/src/container/LogsExplorerContext/__tests__/useInitialQuery.test.ts
+++ b/frontend/src/container/LogsExplorerContext/__tests__/useInitialQuery.test.ts
@@ -375,4 +375,40 @@ describe('useInitialQuery - Priority-Based Resource Filtering', () => {
 			expect(mockUpdateAllQueriesOperators).toHaveBeenCalledTimes(1);
 		});
 	});
+
+	describe('Missing Resources Guard', () => {
+		it('should not crash when resources_string is undefined', () => {
+			const testLog = {
+				...createTestLog({}),
+				resources_string: (undefined as unknown) as Record<string, never>,
+			};
+
+			const { result } = renderHook(() => useInitialQuery(testLog));
+
+			expect(result.current).toBeDefined();
+			expect(mockedConvertFiltersToExpression).toHaveBeenCalledWith(
+				expect.objectContaining({
+					items: [],
+					op: 'AND',
+				}),
+			);
+		});
+
+		it('should not crash when resources_string is null', () => {
+			const testLog = {
+				...createTestLog({}),
+				resources_string: (null as unknown) as Record<string, never>,
+			};
+
+			const { result } = renderHook(() => useInitialQuery(testLog));
+
+			expect(result.current).toBeDefined();
+			expect(mockedConvertFiltersToExpression).toHaveBeenCalledWith(
+				expect.objectContaining({
+					items: [],
+					op: 'AND',
+				}),
+			);
+		});
+	});
 });

--- a/frontend/src/container/LogsExplorerContext/utils.ts
+++ b/frontend/src/container/LogsExplorerContext/utils.ts
@@ -32,21 +32,23 @@ const SERVICE_AND_ENVIRONMENT_KEYS = [
 ];
 
 export const getFiltersFromResources = (
-	resources: ILog['resources_string'],
+	resources: ILog['resources_string'] | null | undefined,
 ): TagFilterItem[] =>
-	Object.keys(resources).map((key: string) => {
-		const resourceValue = resources[key] as string;
-		return {
-			id: uuid(),
-			key: {
-				key,
-				dataType: DataTypes.String,
-				type: 'resource',
-			},
-			op: OPERATORS['='],
-			value: resourceValue,
-		};
-	});
+	!resources || typeof resources !== 'object'
+		? []
+		: Object.keys(resources).map((key: string) => {
+				const resourceValue = resources[key] as string;
+				return {
+					id: uuid(),
+					key: {
+						key,
+						dataType: DataTypes.String,
+						type: 'resource',
+					},
+					op: OPERATORS['='],
+					value: resourceValue,
+				};
+		  });
 
 export const isServiceOrEnvironmentAttribute = (key: string): boolean =>
 	SERVICE_AND_ENVIRONMENT_KEYS.includes(key);


### PR DESCRIPTION
## Summary
- guard against missing resources in the log detail initial query path
- prevent row-click crashes when resource attributes are absent
- add regression coverage for the missing-resources case

## Testing
- frontend unit test updated: useInitialQuery.test.ts
