### PR TITLE
fix(timepicker): disable browser autofill on time input

### DIFF
--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.test.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.test.tsx
@@ -103,6 +103,14 @@ function Wrapper({
 }
 
 describe('CustomTimePicker', () => {
+	it('disables browser autocomplete for time input', () => {
+		render(<Wrapper />);
+
+		const input = screen.getByRole('textbox');
+
+		expect(input).toHaveAttribute('autocomplete', 'off');
+	});
+
 	it('does not close or reset when clicking input while open', () => {
 		render(<Wrapper />);
 

--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -622,6 +622,7 @@ function CustomTimePicker({
 						onChange={handleInputChange}
 						onPressEnter={handleInputPressEnter}
 						onBlur={handleInputBlur}
+						autoComplete="off"
 						data-1p-ignore
 						prefix={getInputPrefix()}
 						suffix={


### PR DESCRIPTION
## Summary
- disable browser/password-manager autocomplete on the custom time range input used by DateTimeSelectionV2
- keep existing `data-1p-ignore` behavior and explicitly set `autoComplete="off"`
- add a unit test to lock the attribute and prevent regressions

## Testing
- npm run test -- src/components/CustomTimePicker/CustomTimePicker.test.tsx --runInBand

Closes #5875
