### PR TITLE
chore: added test-ids to identify elements better in e2es

### DIFF
--- a/frontend/src/components/QueryBuilderV2/QueryV2/MetricsSelect/MetricsSelect.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/MetricsSelect/MetricsSelect.tsx
@@ -150,6 +150,7 @@ export const MetricsSelect = memo(function MetricsSelect({
 					options={SOURCE_OPTIONS}
 					value={source}
 					defaultValue="metrics"
+					data-testid={`metrics-source-selector-${index}`}
 					onChange={handleSignalSourceChange}
 				/>
 			)}
@@ -157,6 +158,7 @@ export const MetricsSelect = memo(function MetricsSelect({
 			<MetricNameSelector
 				onChange={handleChangeAggregatorAttribute}
 				query={query}
+				data-testid={`metric-name-selector-${index}`}
 				signalSource={signalSource || ''}
 			/>
 		</div>

--- a/frontend/src/container/DashboardContainer/PanelTypeSelectionModal/index.tsx
+++ b/frontend/src/container/DashboardContainer/PanelTypeSelectionModal/index.tsx
@@ -55,7 +55,12 @@ function PanelTypeSelectionModal(): JSX.Element {
 		>
 			<div className="panel-selection">
 				{PanelTypesWithData.map(({ name, icon, display }) => (
-					<Card onClick={(): void => handleCardClick(name)} id={name} key={name}>
+					<Card
+						onClick={(): void => handleCardClick(name)}
+						id={name}
+						key={name}
+						data-testid={`panel-type-${name}`}
+					>
 						{icon}
 						<Typography className="panel-type-text">{display}</Typography>
 					</Card>

--- a/frontend/src/container/ListOfDashboard/DashboardsList.tsx
+++ b/frontend/src/container/ListOfDashboard/DashboardsList.tsx
@@ -560,6 +560,7 @@ function DashboardsList(): JSX.Element {
 				label: (
 					<div
 						className="create-dashboard-menu-item"
+						data-testid="import-json-menu-cta"
 						onClick={(): void => onModalHandler(false)}
 					>
 						<Radius size={14} /> Import JSON
@@ -573,6 +574,7 @@ function DashboardsList(): JSX.Element {
 						href="https://signoz.io/docs/dashboards/dashboard-templates/overview/"
 						target="_blank"
 						rel="noopener noreferrer"
+						data-testid="view-templates-menu-cta"
 					>
 						<Flex
 							justify="space-between"
@@ -596,6 +598,7 @@ function DashboardsList(): JSX.Element {
 				label: (
 					<div
 						className="create-dashboard-menu-item"
+						data-testid="create-dashboard-menu-cta"
 						onClick={(): void => {
 							onNewDashboardHandler();
 						}}
@@ -759,6 +762,7 @@ function DashboardsList(): JSX.Element {
 								placeholder="Search by name, description, or tags..."
 								prefix={<Search size={12} color={Color.BG_VANILLA_400} />}
 								value={searchString}
+								data-testid="dashboards-list-search"
 								onChange={handleSearch}
 							/>
 							{createNewDashboard && (
@@ -772,6 +776,7 @@ function DashboardsList(): JSX.Element {
 										type="primary"
 										className="periscope-btn primary btn"
 										icon={<Plus size={14} />}
+										data-testid="new-dashboard-cta"
 										onClick={(): void => {
 											logEvent('Dashboard List: New dashboard clicked', {});
 										}}

--- a/frontend/src/container/NewWidget/RightContainer/ColumnUnitSelector/ColumnUnitSelector.tsx
+++ b/frontend/src/container/NewWidget/RightContainer/ColumnUnitSelector/ColumnUnitSelector.tsx
@@ -13,6 +13,7 @@ interface ColumnUnitSelectorProps {
 	columnUnits: ColumnUnit;
 	setColumnUnits: Dispatch<SetStateAction<ColumnUnit>>;
 	isNewDashboard: boolean;
+	'data-testid'?: string;
 }
 
 export function ColumnUnitSelector(
@@ -83,6 +84,7 @@ export function ColumnUnitSelector(
 							}
 							fieldLabel={label}
 							key={value}
+							data-testid={props['data-testid']}
 							selectedQueryName={baseQueryName}
 							// Update the column unit value automatically only in create mode
 							shouldUpdateYAxisUnit={isNewDashboard}

--- a/frontend/src/container/NewWidget/RightContainer/ContextLinks/index.tsx
+++ b/frontend/src/container/NewWidget/RightContainer/ContextLinks/index.tsx
@@ -138,6 +138,7 @@ function ContextLinks({
 				<Button
 					type="default"
 					className="add-context-link-button"
+					data-testid="add-context-link-cta"
 					icon={<Plus size={12} />}
 					style={{ width: '100%' }}
 					onClick={handleAddContextLink}

--- a/frontend/src/container/NewWidget/RightContainer/DashboardYAxisUnitSelectorWrapper.tsx
+++ b/frontend/src/container/NewWidget/RightContainer/DashboardYAxisUnitSelectorWrapper.tsx
@@ -15,12 +15,14 @@ function DashboardYAxisUnitSelectorWrapper({
 	fieldLabel,
 	shouldUpdateYAxisUnit,
 	selectedQueryName,
+	'data-testid': dataTestId,
 }: {
 	value: string;
 	onSelect: OnSelectType;
 	fieldLabel: string;
 	shouldUpdateYAxisUnit: boolean;
 	selectedQueryName?: string;
+	'data-testid'?: string;
 }): JSX.Element {
 	const { yAxisUnit: initialYAxisUnit, isLoading } = useGetYAxisUnit(
 		selectedQueryName,
@@ -42,6 +44,7 @@ function DashboardYAxisUnitSelectorWrapper({
 				initialValue={initialYAxisUnit}
 				source={YAxisSource.DASHBOARDS}
 				loading={isLoading}
+				data-testid={dataTestId}
 			/>
 		</div>
 	);

--- a/frontend/src/container/NewWidget/RightContainer/SettingSections/FormattingUnitsSection/FormattingUnitsSection.tsx
+++ b/frontend/src/container/NewWidget/RightContainer/SettingSections/FormattingUnitsSection/FormattingUnitsSection.tsx
@@ -66,6 +66,7 @@ export default function FormattingUnitsSection({
 						options={decimapPrecisionOptions}
 						value={decimalPrecision}
 						className="panel-type-select"
+						data-testid="decimal-precision-selector"
 						defaultValue={decimapPrecisionOptions[0]?.value}
 						onChange={(val: PrecisionOption): void => setDecimalPrecision(val)}
 					/>
@@ -77,6 +78,7 @@ export default function FormattingUnitsSection({
 					columnUnits={columnUnits}
 					setColumnUnits={setColumnUnits}
 					isNewDashboard={isNewDashboard}
+					data-testid="column-unit-selector"
 				/>
 			)}
 		</SettingsSection>

--- a/frontend/src/container/NewWidget/RightContainer/SettingSections/GeneralSettingsSection/GeneralSettingsSection.tsx
+++ b/frontend/src/container/NewWidget/RightContainer/SettingSections/GeneralSettingsSection/GeneralSettingsSection.tsx
@@ -135,6 +135,7 @@ export default function GeneralSettingsSection({
 						rootClassName="general-settings__name-input"
 						ref={inputRef}
 						onSelect={handleInputCursor}
+						data-testid="panel-name-input"
 						onClick={handleInputCursor}
 						onBlur={(): void => setAutoCompleteOpen(false)}
 					/>
@@ -145,6 +146,7 @@ export default function GeneralSettingsSection({
 					bordered
 					allowClear
 					value={description}
+					data-testid="panel-description-input"
 					onChange={(event): void =>
 						onChangeHandler(setDescription, event.target.value)
 					}

--- a/frontend/src/container/NewWidget/RightContainer/Threshold/Threshold.tsx
+++ b/frontend/src/container/NewWidget/RightContainer/Threshold/Threshold.tsx
@@ -249,6 +249,7 @@ function Threshold({
 								<Input
 									defaultValue={label}
 									onChange={handleLabelChange}
+									data-testid="threshold-label-input"
 									bordered={!isDarkMode}
 									className="label-input"
 								/>
@@ -275,6 +276,7 @@ function Threshold({
 												onChange={handleTableOptionsChange}
 												rootClassName="operator-input-root"
 												className="operator-input"
+												data-testid="table-operator-input-selector"
 											/>
 											<Typography.Text className="typography">is</Typography.Text>
 										</Space>
@@ -287,6 +289,7 @@ function Threshold({
 										style={{ marginLeft: '10px' }}
 										rootClassName="operator-input-root"
 										className="operator-input"
+										data-testid="operator-input-selector"
 									/>
 								</div>
 							) : (
@@ -321,6 +324,7 @@ function Threshold({
 							defaultValue={value}
 							onChange={handleValueChange}
 							className="unit-input"
+							data-testid="threshold-value-input"
 						/>
 					) : (
 						<ShowCaseValue value={value} className="unit-input" />
@@ -332,6 +336,7 @@ function Threshold({
 							placeholder="Select unit"
 							source={YAxisSource.DASHBOARDS}
 							initialValue={unit}
+							data-testid="threshold-unit-input"
 							categoriesOverride={unitSelectCategories}
 							containerClassName="unit-selection"
 						/>
@@ -349,6 +354,7 @@ function Threshold({
 								defaultValue={format}
 								options={showAsOptions}
 								onChange={handlerFormatChange}
+								data-testid="threshold-color-selector"
 								rootClassName="color-format"
 							/>
 						</>

--- a/frontend/src/container/NewWidget/RightContainer/Threshold/ThresholdSelector.tsx
+++ b/frontend/src/container/NewWidget/RightContainer/Threshold/ThresholdSelector.tsx
@@ -72,6 +72,7 @@ function ThresholdSelector({
 						type="default"
 						icon={<Plus size={14} />}
 						style={{ width: '100%' }}
+						data-testid="add-threshold-cta"
 						onClick={addThresholdHandler}
 					>
 						Add Threshold

--- a/frontend/src/container/QueryBuilder/components/DataSourceDropdown/DataSourceDropdown.interfaces.ts
+++ b/frontend/src/container/QueryBuilder/components/DataSourceDropdown/DataSourceDropdown.interfaces.ts
@@ -4,4 +4,5 @@ import { DataSource } from 'types/common/queryBuilder';
 export type QueryLabelProps = {
 	onChange: (value: DataSource) => void;
 	isListViewPanel?: boolean;
+	'data-testid'?: string;
 } & Omit<SelectProps, 'onChange'>;

--- a/frontend/src/container/QueryBuilder/components/DataSourceDropdown/DataSourceDropdown.tsx
+++ b/frontend/src/container/QueryBuilder/components/DataSourceDropdown/DataSourceDropdown.tsx
@@ -32,6 +32,7 @@ export const DataSourceDropdown = memo(function DataSourceDropdown(
 			defaultValue={dataSourceOptions[0].value}
 			options={dataSourceOptions}
 			onChange={onChange}
+			data-testid={props['data-testid']}
 			value={value}
 			style={style}
 		/>

--- a/frontend/src/container/QueryBuilder/components/QBEntityOptions/QBEntityOptions.tsx
+++ b/frontend/src/container/QueryBuilder/components/QBEntityOptions/QBEntityOptions.tsx
@@ -136,6 +136,7 @@ export default function QBEntityOptions({
 												onChangeDataSource(value);
 											}
 										}}
+										data-testid={`query-data-source-selector-${index}`}
 										value={query?.dataSource || DataSource.METRICS}
 										isListViewPanel={isListViewPanel}
 										className="query-data-source-dropdown"

--- a/frontend/src/container/QueryBuilder/filters/MetricNameSelector/MetricNameSelector.tsx
+++ b/frontend/src/container/QueryBuilder/filters/MetricNameSelector/MetricNameSelector.tsx
@@ -27,6 +27,7 @@ export type MetricNameSelectorProps = {
 	defaultValue?: string;
 	onSelect?: (value: BaseAutocompleteData) => void;
 	signalSource?: 'meter' | '';
+	'data-testid'?: string;
 };
 
 function getAttributeType(
@@ -81,6 +82,7 @@ export const MetricNameSelector = memo(function MetricNameSelector({
 	defaultValue,
 	onSelect,
 	signalSource,
+	'data-testid': dataTestId,
 }: MetricNameSelectorProps): JSX.Element {
 	const currentMetricName =
 		(query.aggregations?.[0] as MetricAggregation)?.metricName ||
@@ -279,6 +281,7 @@ export const MetricNameSelector = memo(function MetricNameSelector({
 					</Typography.Text>
 				) : null
 			}
+			data-testid={dataTestId}
 			options={optionsData}
 			value={inputValue}
 			onBlur={handleBlur}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
End-to-end tests targeting dashboard-related flows had to rely on brittle CSS class names or positional selectors to find elements. This PR adds `data-testid` attributes across dashboard creation, widget configuration, query builder, and threshold components so that E2E tests can use stable, intent-revealing selectors.

#### Screenshots / Screen Recordings (if applicable)
N/A — purely additive attribute changes with no visual impact.

#### Issues closed by this PR
N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [x] 🧪 Test-only

---

### 🐛 Bug Context
N/A

---

### 🧪 Testing Strategy

- Tests added/updated: N/A — this change exists to unblock E2E test authoring; no unit tests required for attribute additions
- Manual verification: Inspected rendered DOM in browser to confirm `data-testid` attributes appear on the correct elements
- Edge cases covered: Attributes that need to be threaded through component props (e.g. `ColumnUnitSelector`, `DashboardYAxisUnitSelectorWrapper`) have their prop types updated to accept and forward `data-testid`

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Zero — `data-testid` attributes are inert in production; no logic or rendering is changed
- Potential regressions: None
- Rollback plan: Revert the PR; no state or API changes to undo

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | N/A |
| Change Type | Maintenance |
| Description | N/A |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The testids added span several widget settings panels and the dashboards list:

- **Dashboard list**: `dashboards-list-search`, `new-dashboard-cta`, `create-dashboard-menu-cta`, `import-json-menu-cta`, `view-templates-menu-cta`
- **Panel type modal**: `panel-type-<name>` (one per panel type)
- **Widget settings — General**: `panel-name-input`, `panel-description-input`
- **Widget settings — Formatting**: `decimal-precision-selector`, `column-unit-selector`
- **Widget settings — Thresholds**: `threshold-label-input`
- **Widget settings — Context links**: `add-context-link-cta`
- **Query builder (V2/metrics)**: `metrics-source-selector-<index>`, `metric-name-selector-<index>`

`data-testid` was threaded through component props for `ColumnUnitSelector` and `DashboardYAxisUnitSelectorWrapper` — reviewers should verify the prop forwarding is consistent with how those components are called elsewhere.

---