### PR TITLE
fix: flaky integration tests

### DIFF
--- a/tests/integration/src/querier/14_list_query_expectations.py
+++ b/tests/integration/src/querier/14_list_query_expectations.py
@@ -390,12 +390,12 @@ def test_logs_list_query_timestamp_expectations(
 
     token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
 
-    # Query Logs for the last 1 minute and check if the logs are returned in the correct order
+    # Query Logs for the last 10 minute and check if the logs are returned in the correct order
     response = make_query_request(
         signoz,
         token,
         start_ms=int(
-            (datetime.now(tz=timezone.utc) - timedelta(minutes=1)).timestamp() * 1000
+            (datetime.now(tz=timezone.utc) - timedelta(minutes=10)).timestamp() * 1000
         ),
         end_ms=int(datetime.now(tz=timezone.utc).timestamp() * 1000),
         request_type="raw",
@@ -721,7 +721,7 @@ def test_logs_list_query_trace_id_expectations(
 
     token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
 
-    # Query Logs for the last 1 minute and check if the logs are returned in the correct order
+    # Query Logs for the last 10 minute and check if the logs are returned in the correct order
     response = make_query_request(
         signoz,
         token,


### PR DESCRIPTION
## Pull Request
Integration tests are flaky
---

### 📄 Summary
The Fake Logs that are being created have `now = datetime.now(tz=timezone.utc).replace(second=0, microsecond=0)`

Now if a test is running lets say at 1 minute and 55 sec mark. now = 1 minute. and If we query it at 2 minute, 1 sec mark. 
Because we're querying for last 1 minute, the generated logs are out of query range hence the flakiness.