### PR TITLE
chore: updating cloud integration agent version

### DIFF
--- a/pkg/modules/cloudintegration/config.go
+++ b/pkg/modules/cloudintegration/config.go
@@ -22,7 +22,7 @@ func newConfig() factory.Config {
 		Agent: AgentConfig{
 			// we will maintain the latest version of cloud integration agent from here,
 			// till we automate it externally or figure out a way to validate it.
-			Version: "v0.0.8",
+			Version: "v0.0.9",
 		},
 	}
 }


### PR DESCRIPTION
## Pull Request

### 📄 Summary
- Updating cloud integration agent version from `v0.0.8` to `v0.0.9`
- Agent version has already been released [here](https://github.com/SigNoz/cloud-integration/releases/tag/v0.0.9)