### PR TITLE
fix(route-policy): allow undefined variables for expression

### DIFF
--- a/pkg/alertmanager/nfmanager/rulebasednotification/provider.go
+++ b/pkg/alertmanager/nfmanager/rulebasednotification/provider.go
@@ -223,6 +223,9 @@ func (r *provider) Match(ctx context.Context, orgID string, ruleID string, set m
 	for _, route := range expressionRoutes {
 		evaluateExpr, err := r.evaluateExpr(ctx, route.Expression, set)
 		if err != nil {
+			r.settings.Logger().WarnContext(
+				ctx, "failed to evaluate route policy expression", errors.Attr(err), slog.String("rule.id", ruleID),
+			)
 			continue
 		}
 		if evaluateExpr {
@@ -298,7 +301,7 @@ func (r *provider) convertLabelSetToEnv(ctx context.Context, labelSet model.Labe
 func (r *provider) evaluateExpr(ctx context.Context, expression string, labelSet model.LabelSet) (bool, error) {
 	env := r.convertLabelSetToEnv(ctx, labelSet)
 
-	program, err := expr.Compile(expression, expr.Env(env))
+	program, err := expr.Compile(expression, expr.Env(env), expr.AllowUndefinedVariables())
 	if err != nil {
 		return false, errors.NewInternalf(errors.CodeInternal, "error compiling route policy %s: %v", expression, err)
 	}

--- a/pkg/alertmanager/nfmanager/rulebasednotification/provider.go
+++ b/pkg/alertmanager/nfmanager/rulebasednotification/provider.go
@@ -223,9 +223,8 @@ func (r *provider) Match(ctx context.Context, orgID string, ruleID string, set m
 	for _, route := range expressionRoutes {
 		evaluateExpr, err := r.evaluateExpr(ctx, route.Expression, set)
 		if err != nil {
-			r.settings.Logger().WarnContext(
-				ctx, "failed to evaluate route policy expression", errors.Attr(err), slog.String("rule.id", ruleID),
-			)
+			//nolint:sloglint
+			r.settings.Logger().WarnContext(ctx, "failed to evaluate route policy expression", errors.Attr(err), slog.String("rule.id", ruleID))
 			continue
 		}
 		if evaluateExpr {

--- a/pkg/alertmanager/nfmanager/rulebasednotification/provider_test.go
+++ b/pkg/alertmanager/nfmanager/rulebasednotification/provider_test.go
@@ -644,6 +644,22 @@ func TestProvider_EvaluateExpression(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name:       "nonexistent key OR check",
+			expression: `threshold.name = 'warning' OR ruleId = 'rule1'`,
+			labelSet: model.LabelSet{
+				"threshold.name": "warning",
+			},
+			expected: true,
+		},
+		{
+			name:       "nonexistent key && check",
+			expression: `threshold.name = 'warning' && nonexistent = 'auth'`,
+			labelSet: model.LabelSet{
+				"threshold.name": "warning",
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Pull Request

### ✅ Change Type

- [x] 🐛 Bug fix


### 🐛 Bug Context

The route policy doesn't match if all variables in the expression do not existing in the incoming labels

#### Root Cause

unhandled case

#### Fix Strategy

By allowing undefined variables

### 🧪 Testing Strategy

- Tests added/updated: yes
- Manual verification: yes
- Edge cases covered: yes


### ⚠️ Risk & Impact Assessment

- Blast radius: routing policies
- Potential regressions:no
- Rollback plan:forward fixing


### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix  |
| Description | routing policy gracefully handles missing variables in the expression |

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested

