### PR TITLE
refactor: migrate forgot password page to @signozhq/ui

### DIFF
--- a/frontend/src/container/ForgotPassword/ForgotPassword.styles.scss
+++ b/frontend/src/container/ForgotPassword/ForgotPassword.styles.scss
@@ -63,31 +63,8 @@
 	gap: 12px;
 	width: 100%;
 
-	> .forgot-password-back-button,
-	> .login-submit-btn {
+	> button {
 		flex: 1 1 0%;
-	}
-}
-
-.forgot-password-back-button {
-	height: 32px;
-	padding: 10px 16px;
-	border-radius: 2px;
-	font-family: Inter, sans-serif;
-	font-size: 11px;
-	font-weight: 500;
-	line-height: 1;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 8px;
-	background: var(--l3-background);
-	border: 1px solid var(--l3-border);
-	color: var(--l1-foreground);
-
-	&:hover:not(:disabled) {
-		background: var(--l3-border);
-		border-color: var(--l3-border);
-		opacity: 0.9;
+		min-width: 0;
 	}
 }

--- a/frontend/src/container/ForgotPassword/SuccessScreen.tsx
+++ b/frontend/src/container/ForgotPassword/SuccessScreen.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@signozhq/button';
 import { ArrowLeft, Mail } from '@signozhq/icons';
+import { Button } from '@signozhq/ui';
 
 interface SuccessScreenProps {
 	onBackToLogin: () => void;
@@ -28,7 +28,7 @@ function SuccessScreen({ onBackToLogin }: SuccessScreenProps): JSX.Element {
 						data-testid="back-to-login"
 						className="login-submit-btn"
 						onClick={onBackToLogin}
-						prefixIcon={<ArrowLeft size={12} />}
+						prefix={<ArrowLeft size={12} />}
 					>
 						Back to login
 					</Button>

--- a/frontend/src/container/ForgotPassword/SuccessScreen.tsx
+++ b/frontend/src/container/ForgotPassword/SuccessScreen.tsx
@@ -26,7 +26,6 @@ function SuccessScreen({ onBackToLogin }: SuccessScreenProps): JSX.Element {
 						color="primary"
 						type="button"
 						data-testid="back-to-login"
-						className="login-submit-btn"
 						onClick={onBackToLogin}
 						prefix={<ArrowLeft size={12} />}
 					>

--- a/frontend/src/container/ForgotPassword/index.tsx
+++ b/frontend/src/container/ForgotPassword/index.tsx
@@ -184,6 +184,7 @@ function ForgotPassword({
 				<div className="login-form-actions forgot-password-actions">
 					<Button
 						variant="solid"
+						color="secondary"
 						type="button"
 						data-testid="forgot-password-back"
 						className="forgot-password-back-button"

--- a/frontend/src/container/ForgotPassword/index.tsx
+++ b/frontend/src/container/ForgotPassword/index.tsx
@@ -187,7 +187,6 @@ function ForgotPassword({
 						color="secondary"
 						type="button"
 						data-testid="forgot-password-back"
-						className="forgot-password-back-button"
 						onClick={handleBackToLogin}
 						prefix={<ArrowLeft size={12} />}
 					>
@@ -201,7 +200,6 @@ function ForgotPassword({
 						color="primary"
 						type="submit"
 						data-testid="forgot-password-submit"
-						className="login-submit-btn"
 						suffix={<ArrowRight size={12} />}
 					>
 						{isLoading ? 'Sending...' : 'Send reset link'}

--- a/frontend/src/container/ForgotPassword/index.tsx
+++ b/frontend/src/container/ForgotPassword/index.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react';
-import { Button } from '@signozhq/button';
 import { ArrowLeft, ArrowRight } from '@signozhq/icons';
-import { Input } from '@signozhq/input';
+import { Button, Input } from '@signozhq/ui';
 import { Form, Select } from 'antd';
 import { ErrorResponseHandlerForGeneratedAPIs } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import { useForgotPassword } from 'api/generated/services/users';
@@ -189,7 +188,7 @@ function ForgotPassword({
 						data-testid="forgot-password-back"
 						className="forgot-password-back-button"
 						onClick={handleBackToLogin}
-						prefixIcon={<ArrowLeft size={12} />}
+						prefix={<ArrowLeft size={12} />}
 					>
 						Back to login
 					</Button>
@@ -202,7 +201,7 @@ function ForgotPassword({
 						type="submit"
 						data-testid="forgot-password-submit"
 						className="login-submit-btn"
-						suffixIcon={<ArrowRight size={12} />}
+						suffix={<ArrowRight size={12} />}
 					>
 						{isLoading ? 'Sending...' : 'Send reset link'}
 					</Button>


### PR DESCRIPTION
### Description
This PR systematically migrates legacy frontend components from various `@signozhq/*` packages to the centralized `@signozhq/ui` library as part of the effort defined in Issue #10615.

#### Key Changes:
- **Component Migrations**: Refactored `ForgotPassword` container and related sub-components to use `@signozhq/ui`.
- **API Standardisation**:
  - **Button**:
    - changed  `prefixIcon` to `prefix` prop for icons
    - changed  `suffixIcon ` to `suffix ` prop for icons

#### Files Modified:
1. `frontend/src/container/ForgotPassword/index.tsx`
2. `frontend/src/container/ForgotPassword/SuccessScreen.tsx`

### Screenshots:
before:
<img width="1203" height="990" alt="image" src="https://github.com/user-attachments/assets/c414ec6b-e348-4ac0-bcb2-547b0f87bfac" />

after:
<img width="1203" height="991" alt="image" src="https://github.com/user-attachments/assets/8bb7ec8b-c208-403c-a9a5-5ab5df0ca098" />

Related #10615 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-library migration limited to the Forgot Password flow; main risk is minor visual/behavioral differences due to `Button` prop API changes (`prefixIcon`/`suffixIcon` to `prefix`/`suffix`).
> 
> **Overview**
> Migrates the Forgot Password form and success screen to use centralized `@signozhq/ui` components, replacing legacy `@signozhq/button` and `@signozhq/input` imports.
> 
> Updates `Button` icon props to the new API (`prefix`/`suffix`) while keeping the underlying forgot-password submission flow and routing unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e40bb5f722f977928d73ba35ad4c4edfc2d2cce1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->