### PR TITLE
chore: added backend changes for storing user dashbaord preference

### DIFF
--- a/frontend/src/constants/userPreferences.ts
+++ b/frontend/src/constants/userPreferences.ts
@@ -4,4 +4,5 @@ export const USER_PREFERENCES = {
 	LAST_SEEN_CHANGELOG_VERSION: 'last_seen_changelog_version',
 	SPAN_DETAILS_PINNED_ATTRIBUTES: 'span_details_pinned_attributes',
 	SPAN_PERCENTILE_RESOURCE_ATTRIBUTES: 'span_percentile_resource_attributes',
+	DASHBOARD_PREFERENCES: 'dashboard_preferences',
 };

--- a/pkg/types/preferencetypes/dashboard_preference.go
+++ b/pkg/types/preferencetypes/dashboard_preference.go
@@ -5,21 +5,20 @@ import (
 	"slices"
 
 	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/valuer"
 )
 
 // CursorSyncMode controls how chart cursors are synchronised across panels in a dashboard.
-type CursorSyncMode string
+type CursorSyncMode struct{ valuer.String }
 
-const (
-	CursorSyncModeCrosshair CursorSyncMode = "crosshair"
-	CursorSyncModeTooltip   CursorSyncMode = "tooltip"
-	CursorSyncModeNone      CursorSyncMode = "none"
+var (
+	CursorSyncModeCrosshair = CursorSyncMode{valuer.NewString("crosshair")}
+	CursorSyncModeTooltip   = CursorSyncMode{valuer.NewString("tooltip")}
 )
 
 var allowedCursorSyncModes = []CursorSyncMode{
 	CursorSyncModeCrosshair,
 	CursorSyncModeTooltip,
-	CursorSyncModeNone,
 }
 
 // DashboardPreference holds user-specific overrides for a single dashboard.
@@ -30,7 +29,7 @@ type DashboardPreference struct {
 func (p DashboardPreference) Validate() error {
 	if !slices.Contains(allowedCursorSyncModes, p.CursorSyncMode) {
 		return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput,
-			"invalid cursorSyncMode %q: must be one of crosshair, tooltip, none", p.CursorSyncMode)
+			"invalid cursorSyncMode %q: must be one of crosshair or tooltip", p.CursorSyncMode)
 	}
 	return nil
 }

--- a/pkg/types/preferencetypes/dashboard_preference.go
+++ b/pkg/types/preferencetypes/dashboard_preference.go
@@ -1,0 +1,80 @@
+package preferencetypes
+
+import (
+	"encoding/json"
+	"slices"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+)
+
+// CursorSyncMode controls how chart cursors are synchronised across panels in a dashboard.
+type CursorSyncMode string
+
+const (
+	CursorSyncModeCrosshair CursorSyncMode = "crosshair"
+	CursorSyncModeTooltip   CursorSyncMode = "tooltip"
+	CursorSyncModeNone      CursorSyncMode = "none"
+)
+
+var allowedCursorSyncModes = []CursorSyncMode{
+	CursorSyncModeCrosshair,
+	CursorSyncModeTooltip,
+	CursorSyncModeNone,
+}
+
+// DashboardPreference holds user-specific overrides for a single dashboard.
+type DashboardPreference struct {
+	CursorSyncMode CursorSyncMode `json:"cursorSyncMode"`
+}
+
+func (p DashboardPreference) Validate() error {
+	if !slices.Contains(allowedCursorSyncModes, p.CursorSyncMode) {
+		return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput,
+			"invalid cursorSyncMode %q: must be one of crosshair, tooltip, none", p.CursorSyncMode)
+	}
+	return nil
+}
+
+// DashboardPreferences maps dashboard IDs to their per-dashboard user overrides.
+// The key is the dashboard UUID string.
+type DashboardPreferences map[string]DashboardPreference
+
+func (p DashboardPreferences) Validate() error {
+	for id, pref := range p {
+		if err := pref.Validate(); err != nil {
+			return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput,
+				"invalid preference for dashboard %s: %s", id, err.Error())
+		}
+	}
+	return nil
+}
+
+// NewDashboardPreferencesValue validates prefs and wraps it in a Value suitable
+// for storage as the dashboard_preferences user preference.
+func NewDashboardPreferencesValue(prefs DashboardPreferences) (Value, error) {
+	if err := prefs.Validate(); err != nil {
+		return Value{}, err
+	}
+	// DashboardPreferences is map[string]DashboardPreference — a map kind — so
+	// NewValue's ValueTypeObject check passes without any reflection gymnastics.
+	return NewValue(prefs, ValueTypeObject)
+}
+
+// DashboardPreferencesFromValue decodes a Value that was stored as
+// dashboard_preferences back into the strongly-typed DashboardPreferences map.
+func DashboardPreferencesFromValue(v Value) (DashboardPreferences, error) {
+	// MarshalJSON returns the raw JSON string stored inside Value.
+	jsonBytes, err := json.Marshal(v)
+	if err != nil {
+		return nil, errors.WrapInvalidInputf(err, errors.CodeInvalidInput,
+			"cannot marshal dashboard preferences value")
+	}
+
+	var prefs DashboardPreferences
+	if err := json.Unmarshal(jsonBytes, &prefs); err != nil {
+		return nil, errors.WrapInvalidInputf(err, errors.CodeInvalidInput,
+			"cannot decode dashboard preferences")
+	}
+
+	return prefs, nil
+}

--- a/pkg/types/preferencetypes/name.go
+++ b/pkg/types/preferencetypes/name.go
@@ -21,6 +21,7 @@ var (
 	NameLastSeenChangelogVersion                = Name{valuer.NewString("last_seen_changelog_version")}
 	NameSpanDetailsPinnedAttributes             = Name{valuer.NewString("span_details_pinned_attributes")}
 	NameSpanPercentileResourceAttributes        = Name{valuer.NewString("span_percentile_resource_attributes")}
+	NameDashboardPreferences                    = Name{valuer.NewString("dashboard_preferences")}
 )
 
 type Name struct{ valuer.String }
@@ -41,6 +42,7 @@ func NewName(name string) (Name, error) {
 			NameLastSeenChangelogVersion.StringValue(),
 			NameSpanDetailsPinnedAttributes.StringValue(),
 			NameSpanPercentileResourceAttributes.StringValue(),
+			NameDashboardPreferences.StringValue(),
 		},
 		name,
 	)

--- a/pkg/types/preferencetypes/preference.go
+++ b/pkg/types/preferencetypes/preference.go
@@ -172,6 +172,15 @@ func NewAvailablePreference() map[Name]Preference {
 			AllowedValues: []string{},
 			Value:         MustNewValue([]any{}, ValueTypeArray),
 		},
+		NameDashboardPreferences: {
+			Name:          NameDashboardPreferences,
+			Description:   "User preferences for dashboards, such as cursor sync behaviour. Keyed by dashboard ID.",
+			ValueType:     ValueTypeObject,
+			DefaultValue:  MustNewValue(DashboardPreferences{}, ValueTypeObject),
+			AllowedScopes: []Scope{ScopeUser},
+			AllowedValues: []string{},
+			Value:         MustNewValue(DashboardPreferences{}, ValueTypeObject),
+		},
 	}
 }
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Adds backend support for storing per-user, per-dashboard preferences in the existing user preference system.

Currently introduces `DashboardPreferences` — a map of dashboard UUID → `DashboardPreference` — with `CursorSyncMode` as the first field (values: `crosshair`, `tooltip`, `none`). This allows the frontend to persist cursor sync behaviour per dashboard without touching the dashboard document itself.

Changes:
- **Go**: New `preferencetypes.DashboardPreference` / `DashboardPreferences` types with validation, encode/decode helpers, and registration in the available-preferences map (`preference.go`, `name.go`, `dashboard_preference.go`)
- **Frontend**: Adds `DASHBOARD_PREFERENCES` key to `USER_PREFERENCES` constants so the frontend can reference it consistently

#### Screenshots / Screen Recordings (if applicable)
N/A — backend plumbing only, no UI changes in this PR.

#### Issues closed by this PR
<!-- Closes #issue-number -->
Closes https://github.com/SigNoz/engineering-pod/issues/4674

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
N/A

---

### 🧪 Testing Strategy

- Tests added/updated: None yet — types and helpers will be exercised by integration tests in follow-up PRs that wire up the API handler
- Manual verification: Preference registered, validates input correctly (invalid `cursorSyncMode` returns `TypeInvalidInput` error), and defaults to an empty map
- Edge cases covered: Validation rejects unknown `CursorSyncMode` values via `slices.Contains`

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Additive only — new preference key, no changes to existing preferences
- Potential regressions: None; existing preferences are untouched
- Rollback plan: Remove the new preference key and types; no DB migration required (preferences are stored as key-value JSON)

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | N/A — internal preference plumbing, not yet user-visible |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- `DashboardPreferences` is `map[string]DashboardPreference` (keyed by dashboard UUID). Future fields (e.g. panel collapse state, default time range) can be added to `DashboardPreference` without a schema change.
- `CursorSyncMode` is currently the only field. The crosshair/tooltip/none values mirror the existing frontend `CURSOR_SYNC_MODES` enum.
- This is the first of two PRs — the follow-up will wire up the API handler and frontend store to read/write this preference.

---
