### PR TITLE
refactor: migrate alert chart preview to AUTO_REFRESH_QUERY pattern

### DIFF
--- a/frontend/src/container/FormAlertRules/ChartPreview/index.tsx
+++ b/frontend/src/container/FormAlertRules/ChartPreview/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 // eslint-disable-next-line no-restricted-imports
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import ErrorInPlace from 'components/ErrorInPlace/ErrorInPlace';
 import Spinner from 'components/Spinner';
@@ -37,14 +37,14 @@ import { isEmpty } from 'lodash-es';
 import { useAppContext } from 'providers/App/App';
 import { useTimezone } from 'providers/Timezone';
 import { UpdateTimeInterval } from 'store/actions';
-import { AppState } from 'store/reducers';
+import { useGlobalTimeStore } from 'store/globalTime';
+import { getAutoRefreshQueryKey } from 'store/globalTime/utils';
 import { Warning } from 'types/api';
 import { AlertDef } from 'types/api/alerts/def';
 import { LegendPosition } from 'types/api/dashboard/getAll';
 import APIError from 'types/api/error';
 import { Query } from 'types/api/queryBuilder/queryBuilderData';
 import { EQueryType } from 'types/common/dashboard';
-import { GlobalReducer } from 'types/reducer/globalTime';
 import uPlot from 'uplot';
 import { getGraphType } from 'utils/getGraphType';
 import { getSortedSeriesData } from 'utils/getSortedSeriesData';
@@ -122,10 +122,7 @@ function ChartPreview({
 	});
 	const { currentQuery } = useQueryBuilder();
 
-	const { minTime, maxTime, selectedTime: globalSelectedInterval } = useSelector<
-		AppState,
-		GlobalReducer
-	>((state) => state.globalTime);
+	const globalSelectedInterval = useGlobalTimeStore((s) => s.selectedTime);
 
 	const { featureFlags } = useAppContext();
 
@@ -189,14 +186,13 @@ function ChartPreview({
 		// alertDef?.version || DEFAULT_ENTITY_VERSION,
 		ENTITY_VERSION_V5,
 		{
-			queryKey: [
+			queryKey: getAutoRefreshQueryKey(
+				globalSelectedInterval,
 				REACT_QUERY_KEY.ALERT_RULES_CHART_PREVIEW,
 				userQueryKey || JSON.stringify(query),
 				selectedInterval,
-				minTime,
-				maxTime,
 				alertDef?.ruleType,
-			],
+			),
 			enabled: canQuery,
 			keepPreviousData: true,
 		},
@@ -215,7 +211,7 @@ function ChartPreview({
 		}
 		setMinTimeScale(startTime);
 		setMaxTimeScale(endTime);
-	}, [maxTime, minTime, globalSelectedInterval, queryResponse, setQueryStatus]);
+	}, [globalSelectedInterval, queryResponse, setQueryStatus]);
 
 	// Initialize graph visibility from localStorage
 	useEffect(() => {

--- a/frontend/src/container/FormAlertRules/index.tsx
+++ b/frontend/src/container/FormAlertRules/index.tsx
@@ -131,7 +131,7 @@ function FormAlertRules({
 	const [isLoadingAlertQuery, setIsLoadingAlertQuery] = useState(false);
 
 	const handleCancelAlertQuery = useCallback(() => {
-		ruleCache.cancelQueries(REACT_QUERY_KEY.ALERT_RULES_CHART_PREVIEW);
+		ruleCache.cancelQueries([REACT_QUERY_KEY.AUTO_REFRESH_QUERY]);
 		setIsChartQueryCancelled(true);
 	}, [ruleCache]);
 
@@ -926,9 +926,7 @@ function FormAlertRules({
 							alertType={alertType || AlertTypes.METRICS_BASED_ALERT}
 							runQuery={(): void => {
 								setIsChartQueryCancelled(false);
-								ruleCache.invalidateQueries([
-									REACT_QUERY_KEY.ALERT_RULES_CHART_PREVIEW,
-								]);
+								ruleCache.invalidateQueries([REACT_QUERY_KEY.AUTO_REFRESH_QUERY]);
 								handleRunQuery();
 							}}
 							isLoadingQueries={isLoadingAlertQuery}


### PR DESCRIPTION
## Summary
- **ChartPreview**: Replace `[ALERT_RULES_CHART_PREVIEW, ..., minTime, maxTime]` queryKey with `getAutoRefreshQueryKey(selectedTime, ALERT_RULES_CHART_PREVIEW, ...)`; use `useGlobalTimeStore` instead of redux selector
- **FormAlertRules/index.tsx**: Simplify cancel/invalidate to `AUTO_REFRESH_QUERY` prefix match

> **PR 13/16** of the metrics run query cancel support stack.

## Screenshots / Screen Recordings
<!-- Add any relevant screenshots or recordings -->

## Change Type
- [x] Refactor / Enhancement

## Testing Strategy
- TypeScript compilation passes
- Verify: Alert rule editing → chart preview → cancel → re-run

## Risk & Impact Assessment
- Medium: changes alert chart preview query cache key structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)