### PR TITLE
refactor: migrate dashboard widgets to AUTO_REFRESH_QUERY pattern

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCard/FullView/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/FullView/index.tsx
@@ -25,6 +25,7 @@ import WarningPopover from 'components/WarningPopover/WarningPopover';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { QueryParams } from 'constants/query';
 import { PANEL_TYPES } from 'constants/queryBuilder';
+import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { PanelMode } from 'container/DashboardContainer/visualization/panels/types';
 import useDrilldown from 'container/GridCardLayout/GridCard/FullView/useDrilldown';
 import { populateMultipleResults } from 'container/NewWidget/LeftContainer/WidgetGraph/util';
@@ -50,6 +51,8 @@ import {
 	selectIsDashboardLocked,
 	useDashboardStore,
 } from 'providers/Dashboard/store/useDashboardStore';
+import { useGlobalTimeStore } from 'store/globalTime';
+import { getAutoRefreshQueryKey } from 'store/globalTime/utils';
 import { AppState } from 'store/reducers';
 import { Warning } from 'types/api';
 import { GlobalReducer } from 'types/reducer/globalTime';
@@ -88,6 +91,7 @@ function FullView({
 	const fullViewRef = useRef<HTMLDivElement>(null);
 	const { handleRunQuery } = useQueryBuilder();
 	const queryClient = useQueryClient();
+	const selectedTimeFromStore = useGlobalTimeStore((s) => s.selectedTime);
 
 	useEffect(() => {
 		setCurrentGraphRef(fullViewRef);
@@ -206,15 +210,21 @@ function FullView({
 	}, [selectedPanelType]);
 
 	const queryRangeKey = useMemo(
-		() => [
+		() =>
+			getAutoRefreshQueryKey(
+				selectedTimeFromStore,
+				widget?.query,
+				selectedPanelType,
+				requestData,
+				version,
+			),
+		[
+			selectedTimeFromStore,
 			widget?.query,
 			selectedPanelType,
 			requestData,
 			version,
-			minTime,
-			maxTime,
 		],
-		[widget?.query, selectedPanelType, requestData, version, minTime, maxTime],
 	);
 
 	const response = useGetQueryRange(requestData, ENTITY_VERSION_V5, {
@@ -224,8 +234,8 @@ function FullView({
 	});
 
 	const handleCancelQuery = useCallback(() => {
-		queryClient.cancelQueries(queryRangeKey);
-	}, [queryClient, queryRangeKey]);
+		queryClient.cancelQueries([REACT_QUERY_KEY.AUTO_REFRESH_QUERY]);
+	}, [queryClient]);
 
 	const onDragSelect = useCallback((start: number, end: number): void => {
 		const startTimestamp = Math.trunc(start);

--- a/frontend/src/container/NewWidget/LeftContainer/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/index.tsx
@@ -1,14 +1,12 @@
 import { memo, useCallback, useEffect, useMemo } from 'react';
 import { useQueryClient } from 'react-query';
-// eslint-disable-next-line no-restricted-imports
-import { useSelector } from 'react-redux';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { useGetQueryRange } from 'hooks/queryBuilder/useGetQueryRange';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
-import { AppState } from 'store/reducers';
-import { GlobalReducer } from 'types/reducer/globalTime';
+import { useGlobalTimeStore } from 'store/globalTime';
+import { getAutoRefreshQueryKey } from 'store/globalTime/utils';
 
 import { WidgetGraphProps } from '../types';
 import ExplorerColumnsRenderer from './ExplorerColumnsRenderer';
@@ -35,24 +33,20 @@ function LeftContainer({
 }: WidgetGraphProps): JSX.Element {
 	const { stagedQuery } = useQueryBuilder();
 	const queryClient = useQueryClient();
+	const selectedTime = useGlobalTimeStore((s) => s.selectedTime);
 
-	const { selectedTime: globalSelectedInterval, minTime, maxTime } = useSelector<
-		AppState,
-		GlobalReducer
-	>((state) => state.globalTime);
 	const queryRangeKey = useMemo(
-		() => [
-			REACT_QUERY_KEY.GET_QUERY_RANGE,
-			globalSelectedInterval,
-			requestData,
-			minTime,
-			maxTime,
-		],
-		[globalSelectedInterval, requestData, minTime, maxTime],
+		() =>
+			getAutoRefreshQueryKey(
+				selectedTime,
+				REACT_QUERY_KEY.GET_QUERY_RANGE,
+				requestData,
+			),
+		[selectedTime, requestData],
 	);
 	const handleCancelQuery = useCallback(() => {
-		queryClient.cancelQueries(queryRangeKey);
-	}, [queryClient, queryRangeKey]);
+		queryClient.cancelQueries([REACT_QUERY_KEY.AUTO_REFRESH_QUERY]);
+	}, [queryClient]);
 
 	const queryResponse = useGetQueryRange(requestData, ENTITY_VERSION_V5, {
 		enabled: !!stagedQuery,


### PR DESCRIPTION
## Summary
- **NewWidget/LeftContainer**: Replace `[GET_QUERY_RANGE, interval, requestData, minTime, maxTime]` with `getAutoRefreshQueryKey(selectedTime, ...)`. Use `useGlobalTimeStore` instead of redux selector. Simplify cancel to `AUTO_REFRESH_QUERY` prefix.
- **GridCardLayout/FullView**: Wrap queryRangeKey with `getAutoRefreshQueryKey`. Simplify cancel to `AUTO_REFRESH_QUERY` prefix.

> **PR 14/16** of the metrics run query cancel support stack.

## Screenshots / Screen Recordings
<!-- Add any relevant screenshots or recordings -->

## Change Type
- [x] Refactor / Enhancement

## Testing Strategy
- TypeScript compilation passes
- Verify: Dashboard widget editing → run query → cancel

## Risk & Impact Assessment
- Medium: changes dashboard query cache key structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)