### PR TITLE
refactor: migrate all errors to AUTO_REFRESH_QUERY pattern

### DIFF
--- a/frontend/src/container/AllError/index.tsx
+++ b/frontend/src/container/AllError/index.tsx
@@ -38,6 +38,8 @@ import history from 'lib/history';
 import { isUndefined } from 'lodash-es';
 import { useAllErrorsQueryState } from 'pages/AllErrors/QueryStateContext';
 import { useTimezone } from 'providers/Timezone';
+import { useGlobalTimeStore } from 'store/globalTime';
+import { getAutoRefreshQueryKey } from 'store/globalTime/utils';
 import { AppState } from 'store/reducers';
 import { ErrorResponse, SuccessResponse } from 'types/api';
 import { Exception, PayloadProps } from 'types/api/errors/getAll';
@@ -71,9 +73,11 @@ type QueryParams = {
 };
 
 function AllErrors(): JSX.Element {
-	const { maxTime, minTime, loading } = useSelector<AppState, GlobalReducer>(
+	const { loading } = useSelector<AppState, GlobalReducer>(
 		(state) => state.globalTime,
 	);
+	const selectedTime = useGlobalTimeStore((s) => s.selectedTime);
+	const getMinMaxTime = useGlobalTimeStore((s) => s.getMinMaxTime);
 	const { pathname } = useLocation();
 	const params = useUrlQuery();
 	const { t } = useTranslation(['common']);
@@ -129,9 +133,15 @@ function AllErrors(): JSX.Element {
 		errorCountResponse,
 	] = useQueries([
 		{
-			queryKey: ['getAllErrors', updatedPath, maxTime, minTime, compositeData],
-			queryFn: (): Promise<SuccessResponse<PayloadProps> | ErrorResponse> =>
-				getAll({
+			queryKey: getAutoRefreshQueryKey(
+				selectedTime,
+				'getAllErrors',
+				updatedPath,
+				compositeData,
+			),
+			queryFn: (): Promise<SuccessResponse<PayloadProps> | ErrorResponse> => {
+				const { minTime, maxTime } = getMinMaxTime();
+				return getAll({
 					end: maxTime,
 					start: minTime,
 					order: updatedOrder,
@@ -143,20 +153,21 @@ function AllErrors(): JSX.Element {
 					tags: convertCompositeQueryToTraceSelectedTags(
 						compositeData?.builder.queryData?.[0]?.filters?.items || [],
 					),
-				}),
+				});
+			},
 			enabled: !loading,
 		},
 		{
-			queryKey: [
+			queryKey: getAutoRefreshQueryKey(
+				selectedTime,
 				'getErrorCounts',
-				maxTime,
-				minTime,
 				getUpdatedExceptionType,
 				getUpdatedServiceName,
 				compositeData,
-			],
-			queryFn: (): Promise<ErrorResponse | SuccessResponse<number>> =>
-				getErrorCounts({
+			),
+			queryFn: (): Promise<ErrorResponse | SuccessResponse<number>> => {
+				const { minTime, maxTime } = getMinMaxTime();
+				return getErrorCounts({
 					end: maxTime,
 					start: minTime,
 					exceptionType: getUpdatedExceptionType,
@@ -164,7 +175,8 @@ function AllErrors(): JSX.Element {
 					tags: convertCompositeQueryToTraceSelectedTags(
 						compositeData?.builder.queryData?.[0]?.filters?.items || [],
 					),
-				}),
+				});
+			},
 			enabled: !loading,
 		},
 	]);

--- a/frontend/src/pages/AllErrors/index.tsx
+++ b/frontend/src/pages/AllErrors/index.tsx
@@ -12,6 +12,7 @@ import { QuickFiltersSource, SignalType } from 'components/QuickFilters/types';
 import RouteTab from 'components/RouteTab';
 import TypicalOverlayScrollbar from 'components/TypicalOverlayScrollbar/TypicalOverlayScrollbar';
 import { LOCALSTORAGE } from 'constants/localStorage';
+import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import RightToolbarActions from 'container/QueryBuilder/components/ToolbarActions/RightToolbarActions';
 import ResourceAttributesFilterV2 from 'container/ResourceAttributeFilterV2/ResourceAttributesFilterV2';
 import Toolbar from 'container/Toolbar/Toolbar';
@@ -31,8 +32,7 @@ function AllErrors(): JSX.Element {
 
 	const isLoadingQueries = useAllErrorsQueryState((s) => s.isFetching);
 	const handleCancelQuery = useCallback(() => {
-		queryClient.cancelQueries(['getAllErrors']);
-		queryClient.cancelQueries(['getErrorCounts']);
+		queryClient.cancelQueries([REACT_QUERY_KEY.AUTO_REFRESH_QUERY]);
 	}, [queryClient]);
 
 	const [showFilters, setShowFilters] = useState<boolean>(() => {


### PR DESCRIPTION
## Summary
- **AllError/index.tsx**: Migrate both `getAllErrors` and `getErrorCounts` query keys to `getAutoRefreshQueryKey`; compute `minTime`/`maxTime` fresh in `queryFn` via `getMinMaxTime()`; remove raw time from redux selector
- **AllErrors/index.tsx**: Simplify cancel to single `AUTO_REFRESH_QUERY` prefix match

> **PR 15/16** of the metrics run query cancel support stack.

## Screenshots / Screen Recordings
<!-- Add any relevant screenshots or recordings -->

## Change Type
- [x] Refactor / Enhancement

## Testing Strategy
- TypeScript compilation passes
- Verify: Exceptions page → loading → cancel → re-run

## Risk & Impact Assessment
- Medium: changes AllErrors query cache key structure and time computation

🤖 Generated with [Claude Code](https://claude.com/claude-code)