### PR TITLE
refactor: remove onFetchingStateChange plumbing, use useIsGlobalTimeQueryRefreshing

### DIFF
--- a/frontend/src/container/MeterExplorer/Explorer/Explorer.tsx
+++ b/frontend/src/container/MeterExplorer/Explorer/Explorer.tsx
@@ -13,6 +13,7 @@ import ExplorerOptionWrapper from 'container/ExplorerOptions/ExplorerOptionWrapp
 import RightToolbarActions from 'container/QueryBuilder/components/ToolbarActions/RightToolbarActions';
 import { QueryBuilderProps } from 'container/QueryBuilder/QueryBuilder.interfaces';
 import DateTimeSelector from 'container/TopNav/DateTimeSelectionV2';
+import { useIsGlobalTimeQueryRefreshing } from 'hooks/globalTime/useIsGlobalTimeQueryRefreshing';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useShareBuilderUrl } from 'hooks/queryBuilder/useShareBuilderUrl';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
@@ -40,7 +41,7 @@ function Explorer(): JSX.Element {
 	} = useQueryBuilder();
 	const { safeNavigate } = useSafeNavigate();
 	const queryClient = useQueryClient();
-	const [isLoadingQueries, setIsLoadingQueries] = useState(false);
+	const isLoadingQueries = useIsGlobalTimeQueryRefreshing();
 
 	const handleCancelQuery = useCallback(() => {
 		queryClient.cancelQueries([REACT_QUERY_KEY.AUTO_REFRESH_QUERY]);
@@ -183,7 +184,7 @@ function Explorer(): JSX.Element {
 						/>
 
 						<div className="explore-content">
-							<TimeSeries onFetchingStateChange={setIsLoadingQueries} />
+							<TimeSeries />
 						</div>
 					</div>
 					<ExplorerOptionWrapper

--- a/frontend/src/container/MeterExplorer/Explorer/TimeSeries.tsx
+++ b/frontend/src/container/MeterExplorer/Explorer/TimeSeries.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useQueries } from 'react-query';
 import { isAxiosError } from 'axios';
 import { ENTITY_VERSION_V5 } from 'constants/app';
@@ -20,11 +20,7 @@ import APIError from 'types/api/error';
 import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
 import { DataSource } from 'types/common/queryBuilder';
 
-interface TimeSeriesProps {
-	onFetchingStateChange?: (isFetching: boolean) => void;
-}
-
-function TimeSeries({ onFetchingStateChange }: TimeSeriesProps): JSX.Element {
+function TimeSeries(): JSX.Element {
 	const { stagedQuery, currentQuery } = useQueryBuilder();
 	const { yAxisUnit, onUnitChange } = useUrlYAxisUnit('');
 
@@ -109,11 +105,6 @@ function TimeSeries({ onFetchingStateChange }: TimeSeriesProps): JSX.Element {
 			},
 		})),
 	);
-
-	const isFetching = queries.some((q) => q.isFetching);
-	useEffect(() => {
-		onFetchingStateChange?.(isFetching);
-	}, [isFetching, onFetchingStateChange]);
 
 	const data = useMemo(() => queries.map(({ data }) => data) ?? [], [queries]);
 

--- a/frontend/src/container/MetricsExplorer/Explorer/Explorer.tsx
+++ b/frontend/src/container/MetricsExplorer/Explorer/Explorer.tsx
@@ -12,6 +12,7 @@ import ExplorerOptionWrapper from 'container/ExplorerOptions/ExplorerOptionWrapp
 import RightToolbarActions from 'container/QueryBuilder/components/ToolbarActions/RightToolbarActions';
 import { QueryBuilderProps } from 'container/QueryBuilder/QueryBuilder.interfaces';
 import DateTimeSelector from 'container/TopNav/DateTimeSelectionV2';
+import { useIsGlobalTimeQueryRefreshing } from 'hooks/globalTime/useIsGlobalTimeQueryRefreshing';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useShareBuilderUrl } from 'hooks/queryBuilder/useShareBuilderUrl';
 import {
@@ -57,7 +58,7 @@ function Explorer(): JSX.Element {
 	const [isMetricDetailsOpen, setIsMetricDetailsOpen] = useState(false);
 
 	const queryClient = useQueryClient();
-	const [isLoadingQueries, setIsLoadingQueries] = useState(false);
+	const isLoadingQueries = useIsGlobalTimeQueryRefreshing();
 	const handleCancelQuery = useCallback(() => {
 		queryClient.cancelQueries([REACT_QUERY_KEY.AUTO_REFRESH_QUERY]);
 	}, [queryClient]);
@@ -331,7 +332,6 @@ function Explorer(): JSX.Element {
 				/>
 				<div className="explore-content">
 					<TimeSeries
-						onFetchingStateChange={setIsLoadingQueries}
 						showOneChartPerQuery={showOneChartPerQuery}
 						setWarning={setWarning}
 						areAllMetricUnitsSame={areAllMetricUnitsSame}

--- a/frontend/src/container/MetricsExplorer/Explorer/TimeSeries.tsx
+++ b/frontend/src/container/MetricsExplorer/Explorer/TimeSeries.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useQueries, useQueryClient } from 'react-query';
 import { Color } from '@signozhq/design-tokens';
 import { toast } from '@signozhq/sonner';
@@ -35,7 +35,6 @@ import {
 } from './utils';
 
 function TimeSeries({
-	onFetchingStateChange,
 	showOneChartPerQuery,
 	setWarning,
 	isMetricUnitsLoading,
@@ -134,11 +133,6 @@ function TimeSeries({
 			},
 		})),
 	);
-
-	const isFetching = queries.some((q) => q.isFetching);
-	useEffect(() => {
-		onFetchingStateChange?.(isFetching);
-	}, [isFetching, onFetchingStateChange]);
 
 	const data = useMemo(() => queries.map(({ data }) => data) ?? [], [queries]);
 

--- a/frontend/src/container/MetricsExplorer/Explorer/types.ts
+++ b/frontend/src/container/MetricsExplorer/Explorer/types.ts
@@ -3,7 +3,6 @@ import { MetricsexplorertypesMetricMetadataDTO } from 'api/generated/services/si
 import { Warning } from 'types/api';
 
 export interface TimeSeriesProps {
-	onFetchingStateChange?: (isFetching: boolean) => void;
 	showOneChartPerQuery: boolean;
 	setWarning: Dispatch<SetStateAction<Warning | undefined>>;
 	areAllMetricUnitsSame: boolean;

--- a/frontend/src/container/NewWidget/LeftContainer/QuerySection/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/QuerySection/index.tsx
@@ -18,7 +18,7 @@ import { Atom, Terminal } from 'lucide-react';
 import { Widgets } from 'types/api/dashboard/getAll';
 import { EQueryType } from 'types/common/dashboard';
 
-import ClickHouseQueryContainer from './QueryBuilder/clickHouse';
+import ClickHouseQueryContainer from './QueryBuilder/ClickHouse';
 import PromQLQueryContainer from './QueryBuilder/promQL';
 
 import './QuerySection.styles.scss';

--- a/frontend/src/hooks/globalTime/useIsGlobalTimeQueryRefreshing.ts
+++ b/frontend/src/hooks/globalTime/useIsGlobalTimeQueryRefreshing.ts
@@ -5,9 +5,5 @@ import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
  * Use when you want to know if any query tracked by {@link REACT_QUERY_KEY.AUTO_REFRESH_QUERY} is refreshing
  */
 export function useIsGlobalTimeQueryRefreshing(): boolean {
-	return (
-		useIsFetching({
-			queryKey: [REACT_QUERY_KEY.AUTO_REFRESH_QUERY],
-		}) > 0
-	);
+	return useIsFetching([REACT_QUERY_KEY.AUTO_REFRESH_QUERY]) > 0;
 }


### PR DESCRIPTION
## Summary
Now that Explorer queries use the `AUTO_REFRESH_QUERY` prefix, the manual `onFetchingStateChange` callback pattern is redundant. This PR:

- **useIsGlobalTimeQueryRefreshing**: Fix v3 syntax bug (`useIsFetching({queryKey:...})` → `useIsFetching([...])`)
- **MetricsExplorer/Explorer**: Replace `[isLoadingQueries, setIsLoadingQueries]` state with `useIsGlobalTimeQueryRefreshing()` hook; remove `onFetchingStateChange` from `<TimeSeries>`
- **MeterExplorer/Explorer**: Same replacement
- **MetricsExplorer/TimeSeries**: Remove `onFetchingStateChange` prop, `isFetching` effect, `useEffect` import
- **MeterExplorer/TimeSeries**: Remove `TimeSeriesProps` interface and `onFetchingStateChange` plumbing
- **MetricsExplorer/types.ts**: Remove `onFetchingStateChange` from `TimeSeriesProps`

> **PR 16/16** — final PR of the metrics run query cancel support stack.

## Screenshots / Screen Recordings
<!-- Add any relevant screenshots or recordings -->

## Change Type
- [x] Refactor / Enhancement
- [x] Bug fix (v3 syntax fix in useIsGlobalTimeQueryRefreshing)

## Testing Strategy
- TypeScript compilation passes
- Verify: MetricsExplorer → run query → cancel button appears → cancel works

## Risk & Impact Assessment
- Low risk: removes code, simplifies state management
- The v3 syntax fix in `useIsGlobalTimeQueryRefreshing` fixes a pre-existing bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)