### PR TITLE
fix: api monitoring cancel and run query bugs

### DIFF
--- a/frontend/src/api/thirdPartyApis/listOverview.ts
+++ b/frontend/src/api/thirdPartyApis/listOverview.ts
@@ -6,15 +6,20 @@ import { PayloadProps, Props } from 'types/api/thirdPartyApis/listOverview';
 
 const listOverview = async (
 	props: Props,
+	signal?: AbortSignal,
 ): Promise<SuccessResponseV2<PayloadProps>> => {
 	const { start, end, show_ip: showIp, filter } = props;
 	try {
-		const response = await axios.post(`/third-party-apis/overview/list`, {
-			start,
-			end,
-			show_ip: showIp,
-			filter,
-		});
+		const response = await axios.post(
+			`/third-party-apis/overview/list`,
+			{
+				start,
+				end,
+				show_ip: showIp,
+				filter,
+			},
+			{ signal },
+		);
 
 		return {
 			httpStatusCode: response.status,

--- a/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainList.tsx
+++ b/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainList.tsx
@@ -59,6 +59,11 @@ function DomainList(): JSX.Element {
 		queryClient.cancelQueries([REACT_QUERY_KEY.GET_DOMAINS_LIST]);
 	}, [queryClient]);
 
+	const handleStageAndRunQuery = useCallback(() => {
+		queryClient.invalidateQueries([REACT_QUERY_KEY.GET_DOMAINS_LIST]);
+		handleRunQuery();
+	}, [queryClient, handleRunQuery]);
+
 	const { data, isLoading, isFetching } = useListOverview({
 		start: minTime,
 		end: maxTime,
@@ -127,7 +132,7 @@ function DomainList(): JSX.Element {
 				showAutoRefresh={false}
 				rightActions={
 					<RightToolbarActions
-						onStageRunQuery={handleRunQuery}
+						onStageRunQuery={handleStageAndRunQuery}
 						isLoadingQueries={isFetching}
 						handleCancelQuery={handleCancelQuery}
 					/>

--- a/frontend/src/container/NewWidget/LeftContainer/QuerySection/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/QuerySection/index.tsx
@@ -18,7 +18,7 @@ import { Atom, Terminal } from 'lucide-react';
 import { Widgets } from 'types/api/dashboard/getAll';
 import { EQueryType } from 'types/common/dashboard';
 
-import ClickHouseQueryContainer from './QueryBuilder/clickHouse';
+import ClickHouseQueryContainer from './QueryBuilder/ClickHouse';
 import PromQLQueryContainer from './QueryBuilder/promQL';
 
 import './QuerySection.styles.scss';

--- a/frontend/src/hooks/thirdPartyApis/useListOverview.ts
+++ b/frontend/src/hooks/thirdPartyApis/useListOverview.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryResult } from 'react-query';
 import listOverview from 'api/thirdPartyApis/listOverview';
+import { isAxiosError } from 'axios';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { SuccessResponseV2 } from 'types/api';
 import APIError from 'types/api/error';
@@ -20,12 +21,21 @@ export const useListOverview = (
 			showIp,
 			filter.expression,
 		],
-		queryFn: () =>
-			listOverview({
-				start,
-				end,
-				show_ip: showIp,
-				filter,
-			}),
+		queryFn: ({ signal }) =>
+			listOverview(
+				{
+					start,
+					end,
+					show_ip: showIp,
+					filter,
+				},
+				signal,
+			),
+		retry: (failureCount, error): boolean => {
+			if (isAxiosError(error) && error.code === 'ERR_CANCELED') {
+				return false;
+			}
+			return failureCount < 3;
+		},
 	});
 };


### PR DESCRIPTION
## Summary
- **listOverview API**: Accept optional `AbortSignal` parameter and pass to axios config
- **useListOverview hook**: Pass `signal` from react-query's queryFn context to API; add ERR_CANCELED retry skip
- **DomainList**: Wrap `handleRunQuery` with explicit `invalidateQueries` so clicking "Run Query" always re-fetches (even if URL params didn't change, e.g. after cancel)

## Bug Context

**Root cause of cancel not working**: `cancelQueries` was called on the react-query cache, but the underlying axios request had no `AbortSignal`, so the HTTP request kept running until the server responded.

**Root cause of run query not working**: `onStageRunQuery` called `handleRunQuery` which redirects with query-builder data to the URL. If the user cancelled and then clicked Run without changing anything, the URL stayed the same → `compositeData` stayed the same → query key stayed the same → no re-fetch. Now the handler explicitly invalidates the query before running.

**Fix strategy**: Follow the same AbortSignal + invalidate pattern used in `useGetQueryRange` and `MetricsExplorer Inspect`.

## Screenshots / Screen Recordings
<!-- Add any relevant screenshots or recordings -->

https://github.com/user-attachments/assets/8c0ed6b3-6f30-44e2-90e7-2027f19c08d5

## Change Type
- [x] Bug fix

## Testing Strategy
- TypeScript compilation passes
- Manual: API Monitoring → run query → cancel → verify cancel button returns to Run → click Run → verify data loads
- Manual: API Monitoring → run query → without changing anything, click Run → verify query re-fetches

## Risk & Impact Assessment
- Low risk: scoped to API Monitoring domain list
- Backward compatible: `signal` param is optional on `listOverview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)