### PR TITLE
feat: add cancelled query placeholder UI to alerts, explorers, and exceptions

### DIFF
--- a/frontend/src/components/QueryCancelledPlaceholder/QueryCancelledPlaceholder.styles.scss
+++ b/frontend/src/components/QueryCancelledPlaceholder/QueryCancelledPlaceholder.styles.scss
@@ -1,0 +1,26 @@
+.query-cancelled-placeholder {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	min-height: 240px;
+	width: 100%;
+	padding: 24px;
+	gap: 12px;
+
+	&__emoji {
+		width: 48px;
+		height: 48px;
+	}
+
+	&__text {
+		text-align: center;
+		font-size: 14px;
+		color: var(--bg-vanilla-400);
+	}
+
+	&__sub-text {
+		color: var(--bg-vanilla-300);
+	}
+}

--- a/frontend/src/components/QueryCancelledPlaceholder/QueryCancelledPlaceholder.tsx
+++ b/frontend/src/components/QueryCancelledPlaceholder/QueryCancelledPlaceholder.tsx
@@ -1,0 +1,35 @@
+import { Typography } from 'antd';
+import eyesEmojiUrl from 'assets/Images/eyesEmoji.svg';
+
+import './QueryCancelledPlaceholder.styles.scss';
+
+interface QueryCancelledPlaceholderProps {
+	subText?: string;
+}
+
+function QueryCancelledPlaceholder({
+	subText,
+}: QueryCancelledPlaceholderProps): JSX.Element {
+	return (
+		<div className="query-cancelled-placeholder">
+			<img
+				className="query-cancelled-placeholder__emoji"
+				src={eyesEmojiUrl}
+				alt="eyes emoji"
+			/>
+			<Typography className="query-cancelled-placeholder__text">
+				Query cancelled.
+				<span className="query-cancelled-placeholder__sub-text">
+					{' '}
+					{subText || 'Click "Run Query" to load data.'}
+				</span>
+			</Typography>
+		</div>
+	);
+}
+
+QueryCancelledPlaceholder.defaultProps = {
+	subText: undefined,
+};
+
+export default QueryCancelledPlaceholder;

--- a/frontend/src/components/QueryCancelledPlaceholder/index.ts
+++ b/frontend/src/components/QueryCancelledPlaceholder/index.ts
@@ -1,0 +1,1 @@
+export { default } from './QueryCancelledPlaceholder';

--- a/frontend/src/container/AllError/index.tsx
+++ b/frontend/src/container/AllError/index.tsx
@@ -21,6 +21,7 @@ import { FilterConfirmProps } from 'antd/lib/table/interface';
 import logEvent from 'api/common/logEvent';
 import getAll from 'api/errors/getAll';
 import getErrorCounts from 'api/errors/getErrorCounts';
+import QueryCancelledPlaceholder from 'components/QueryCancelledPlaceholder';
 import { ResizeTable } from 'components/ResizeTable';
 import { DATE_TIME_FORMATS } from 'constants/dateTimeFormats';
 import ROUTES from 'constants/routes';
@@ -127,6 +128,7 @@ function AllErrors(): JSX.Element {
 	const compositeData = useGetCompositeQueryParam();
 
 	const setIsFetching = useAllErrorsQueryState((s) => s.setIsFetching);
+	const isCancelled = useAllErrorsQueryState((s) => s.isCancelled);
 
 	const [
 		{ isLoading, isFetching: isErrorsFetching, data },
@@ -496,6 +498,12 @@ function AllErrors(): JSX.Element {
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [errorCountResponse.data?.payload]);
+
+	if (isCancelled && !data?.payload?.length) {
+		return (
+			<QueryCancelledPlaceholder subText='Click "Run Query" to load exceptions.' />
+		);
+	}
 
 	return (
 		<ResizeTable

--- a/frontend/src/container/FormAlertRules/ChartPreview/index.tsx
+++ b/frontend/src/container/FormAlertRules/ChartPreview/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import ErrorInPlace from 'components/ErrorInPlace/ErrorInPlace';
+import QueryCancelledPlaceholder from 'components/QueryCancelledPlaceholder';
 import Spinner from 'components/Spinner';
 import WarningPopover from 'components/WarningPopover/WarningPopover';
 import { ENTITY_VERSION_V5 } from 'constants/app';
@@ -369,6 +370,10 @@ function ChartPreview({
 					)}
 					{(queryResponse?.isError || queryResponse?.error) && !isCancelled && (
 						<ErrorInPlace error={queryResponse.error as APIError} />
+					)}
+
+					{isCancelled && !chartData && !queryResponse.isLoading && (
+						<QueryCancelledPlaceholder subText='Click "Run Query" to load the chart preview.' />
 					)}
 
 					{chartDataAvailable && !isAnomalyDetectionAlert && (

--- a/frontend/src/container/MeterExplorer/Explorer/Explorer.tsx
+++ b/frontend/src/container/MeterExplorer/Explorer/Explorer.tsx
@@ -42,9 +42,17 @@ function Explorer(): JSX.Element {
 	const { safeNavigate } = useSafeNavigate();
 	const queryClient = useQueryClient();
 	const isLoadingQueries = useIsGlobalTimeQueryRefreshing();
+	const [isCancelled, setIsCancelled] = useState(false);
+
+	useEffect(() => {
+		if (isLoadingQueries) {
+			setIsCancelled(false);
+		}
+	}, [isLoadingQueries]);
 
 	const handleCancelQuery = useCallback(() => {
 		queryClient.cancelQueries([REACT_QUERY_KEY.AUTO_REFRESH_QUERY]);
+		setIsCancelled(true);
 	}, [queryClient]);
 
 	const [showQuickFilters, setShowQuickFilters] = useState(true);
@@ -184,7 +192,7 @@ function Explorer(): JSX.Element {
 						/>
 
 						<div className="explore-content">
-							<TimeSeries />
+							<TimeSeries isCancelled={isCancelled} />
 						</div>
 					</div>
 					<ExplorerOptionWrapper

--- a/frontend/src/container/MeterExplorer/Explorer/TimeSeries.tsx
+++ b/frontend/src/container/MeterExplorer/Explorer/TimeSeries.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useQueries } from 'react-query';
 import { isAxiosError } from 'axios';
+import QueryCancelledPlaceholder from 'components/QueryCancelledPlaceholder';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { initialQueryMeterWithType, PANEL_TYPES } from 'constants/queryBuilder';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
@@ -20,7 +21,11 @@ import APIError from 'types/api/error';
 import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
 import { DataSource } from 'types/common/queryBuilder';
 
-function TimeSeries(): JSX.Element {
+interface TimeSeriesProps {
+	isCancelled?: boolean;
+}
+
+function TimeSeries({ isCancelled = false }: TimeSeriesProps): JSX.Element {
 	const { stagedQuery, currentQuery } = useQueryBuilder();
 	const { yAxisUnit, onUnitChange } = useUrlYAxisUnit('');
 
@@ -126,7 +131,11 @@ function TimeSeries(): JSX.Element {
 			<BuilderUnitsFilter onChange={onUnitChange} yAxisUnit={yAxisUnit} />
 			<div className="time-series-container">
 				{!hasMetricSelected && <EmptyMetricsSearch />}
-				{hasMetricSelected &&
+				{isCancelled && hasMetricSelected && (
+					<QueryCancelledPlaceholder subText='Click "Run Query" to load metrics.' />
+				)}
+				{!isCancelled &&
+					hasMetricSelected &&
 					responseData.map((datapoint, index) => (
 						<div
 							className="time-series-view-panel"

--- a/frontend/src/container/MetricsExplorer/Explorer/Explorer.tsx
+++ b/frontend/src/container/MetricsExplorer/Explorer/Explorer.tsx
@@ -59,8 +59,17 @@ function Explorer(): JSX.Element {
 
 	const queryClient = useQueryClient();
 	const isLoadingQueries = useIsGlobalTimeQueryRefreshing();
+	const [isCancelled, setIsCancelled] = useState(false);
+
+	useEffect(() => {
+		if (isLoadingQueries) {
+			setIsCancelled(false);
+		}
+	}, [isLoadingQueries]);
+
 	const handleCancelQuery = useCallback(() => {
 		queryClient.cancelQueries([REACT_QUERY_KEY.AUTO_REFRESH_QUERY]);
+		setIsCancelled(true);
 	}, [queryClient]);
 
 	const metricNames = useMemo(() => {
@@ -344,6 +353,7 @@ function Explorer(): JSX.Element {
 						yAxisUnit={yAxisUnit}
 						setYAxisUnit={setYAxisUnit}
 						showYAxisUnitSelector={showYAxisUnitSelector}
+						isCancelled={isCancelled}
 					/>
 				</div>
 			</div>

--- a/frontend/src/container/MetricsExplorer/Explorer/TimeSeries.tsx
+++ b/frontend/src/container/MetricsExplorer/Explorer/TimeSeries.tsx
@@ -9,6 +9,7 @@ import {
 } from 'api/generated/services/metrics';
 import { isAxiosError } from 'axios';
 import classNames from 'classnames';
+import QueryCancelledPlaceholder from 'components/QueryCancelledPlaceholder';
 import YAxisUnitSelector from 'components/YAxisUnitSelector';
 import { YAxisSource } from 'components/YAxisUnitSelector/types';
 import { ENTITY_VERSION_V5 } from 'constants/app';
@@ -45,6 +46,7 @@ function TimeSeries({
 	setYAxisUnit,
 	showYAxisUnitSelector,
 	metrics,
+	isCancelled = false,
 }: TimeSeriesProps): JSX.Element {
 	const { stagedQuery, currentQuery } = useQueryBuilder();
 
@@ -234,7 +236,11 @@ function TimeSeries({
 				})}
 			>
 				{metricNames.length === 0 && <EmptyMetricsSearch />}
-				{metricNames.length > 0 &&
+				{isCancelled && metricNames.length > 0 && (
+					<QueryCancelledPlaceholder subText='Click "Run Query" to load metrics.' />
+				)}
+				{!isCancelled &&
+					metricNames.length > 0 &&
 					responseData.map((datapoint, index) => {
 						const isQueryDataItem = index < metricNames.length;
 						const metricName = isQueryDataItem ? metricNames[index] : undefined;

--- a/frontend/src/container/MetricsExplorer/Explorer/types.ts
+++ b/frontend/src/container/MetricsExplorer/Explorer/types.ts
@@ -15,4 +15,5 @@ export interface TimeSeriesProps {
 	yAxisUnit: string | undefined;
 	setYAxisUnit: (unit: string) => void;
 	showYAxisUnitSelector: boolean;
+	isCancelled?: boolean;
 }

--- a/frontend/src/pages/AllErrors/QueryStateContext.ts
+++ b/frontend/src/pages/AllErrors/QueryStateContext.ts
@@ -2,12 +2,22 @@ import { create } from 'zustand';
 
 interface AllErrorsQueryState {
 	isFetching: boolean;
+	isCancelled: boolean;
 	setIsFetching: (isFetching: boolean) => void;
+	setIsCancelled: (isCancelled: boolean) => void;
 }
 
 export const useAllErrorsQueryState = create<AllErrorsQueryState>((set) => ({
 	isFetching: false,
+	isCancelled: false,
 	setIsFetching: (isFetching): void => {
-		set({ isFetching });
+		set((state) => ({
+			isFetching,
+			// Auto-reset cancelled when a new fetch starts
+			isCancelled: isFetching ? false : state.isCancelled,
+		}));
+	},
+	setIsCancelled: (isCancelled): void => {
+		set({ isCancelled });
 	},
 }));

--- a/frontend/src/pages/AllErrors/index.tsx
+++ b/frontend/src/pages/AllErrors/index.tsx
@@ -31,9 +31,11 @@ function AllErrors(): JSX.Element {
 	const queryClient = useQueryClient();
 
 	const isLoadingQueries = useAllErrorsQueryState((s) => s.isFetching);
+	const setIsCancelled = useAllErrorsQueryState((s) => s.setIsCancelled);
 	const handleCancelQuery = useCallback(() => {
 		queryClient.cancelQueries([REACT_QUERY_KEY.AUTO_REFRESH_QUERY]);
-	}, [queryClient]);
+		setIsCancelled(true);
+	}, [queryClient, setIsCancelled]);
 
 	const [showFilters, setShowFilters] = useState<boolean>(() => {
 		const localStorageValue = getLocalStorageKey(


### PR DESCRIPTION
## Summary
Add a consistent \"Query cancelled\" placeholder UI across the easy-to-reach areas, so cancelling a query gives clear feedback instead of stale/empty/blank state.

- **NEW**: Shared `<QueryCancelledPlaceholder />` component (eyes-emoji + message, customizable subtext)
- **FormAlertRules ChartPreview**: Show placeholder when cancelled and no chart data exists yet (still keeps stale chart via \`keepPreviousData\` when previous data existed)
- **MetricsExplorer Explorer**: Add \`isCancelled\` state in \`Explorer.tsx\` (auto-resets when fetching restarts), pass to \`TimeSeries\`, render placeholder in place of charts
- **MeterExplorer Explorer**: Same pattern as MetricsExplorer
- **AllErrors (Exceptions)**: Add \`isCancelled\` to the existing Zustand store with auto-reset behavior, render placeholder in place of the table when cancelled with no data

## Auto-reset pattern
All cases reset \`isCancelled\` to \`false\` when a new query starts fetching, so the placeholder doesn't linger after the user changes filters/time range.

## Areas not included (medium difficulty, separate PR)
- Logs Explorer / Traces Explorer — queries live in deeply nested view containers, needs prop threading
- Dashboard widgets (FullView, NewWidget) — need \`isCancelled\` threaded through ChartPreview/PanelWrapper
- API Monitoring DomainList — its fix is on a separate branch (\`fix/api-monitoring-cancel-run-fix\`)

## Screenshots / Screen Recordings
<!-- Add any relevant screenshots or recordings -->

## Change Type
- [x] Feature

## Testing Strategy
- TypeScript compilation passes
- Manual: each area → run query → cancel → verify placeholder appears → click Run → verify it goes away

## Risk & Impact Assessment
- Low risk: purely additive UI; existing flows unchanged when not cancelled
- Auto-reset ensures no stale \"cancelled\" state can linger

🤖 Generated with [Claude Code](https://claude.com/claude-code)