### PR TITLE
fix: disable autofill for time selection field

### DIFF
--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -603,6 +603,7 @@ function CustomTimePicker({
 							inputStatus === CustomTimePickerInputStatus.ERROR ? 'error' : '',
 						)}
 						type="text"
+						autoComplete="off"
 						status={
 							inputValue && inputStatus === CustomTimePickerInputStatus.ERROR
 								? 'error'


### PR DESCRIPTION
## Summary

Adds `autoComplete="off"` to the time selection `Input` component in `CustomTimePicker` to prevent password managers from injecting values into the time selection field.

## Problem

Password managers (1Password, Bitwarden, etc.) detect the time selection input and inject credentials or auto-fill values, which interferes with the time range selection. While `data-1p-ignore` was already present (for 1Password), the standard `autoComplete="off"` attribute was missing, leaving other password managers unhandled.

## Solution

Added `autoComplete="off"` attribute to the `<Input>` component in `CustomTimePicker.tsx`.

Closes #5875

## Test Plan

- Open the time picker with a password manager extension active
- Verify that the password manager no longer injects values into the time selection field
- Verify that the time picker still functions normally for manual input and selection

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds `autoComplete="off"` to prevent password manager/browser autofill from injecting values into the time range field.
> 
> **Overview**
> Disables autofill on the `CustomTimePicker` time range `Input` by adding `autoComplete="off"`, reducing interference from password managers injecting unexpected values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b24e13b3adc3f77ecb6bca775faa8622b39eecc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->