### PR TITLE
fix: handle v prefix in version comparison on /status page

### DIFF
--- a/frontend/src/utils/app.ts
+++ b/frontend/src/utils/app.ts
@@ -20,8 +20,10 @@ export const checkVersionState = (
 	currentVersion: string,
 	latestVersion: string,
 ): boolean => {
-	const versionCore = currentVersion?.split('-')[0];
-	return versionCore === latestVersion;
+	const stripPrefix = (v: string): string => (v?.startsWith('v') ? v.slice(1) : v) ?? '';
+	const versionCore = stripPrefix(currentVersion?.split('-')[0]);
+	const latest = stripPrefix(latestVersion?.split('-')[0]);
+	return versionCore === latest;
 };
 
 // list of forbidden tags to remove in dompurify


### PR DESCRIPTION
## Summary

Fixes the `/status` page incorrectly showing that an upgrade is available when the installed version matches the latest version but differs in `v` prefix formatting.

## Problem

The GitHub releases API returns versions with a `v` prefix (e.g. `v0.76.2`), while the locally installed version typically does not have one (e.g. `0.76.2`). The `checkVersionState` function compared these strings directly without normalizing the prefix, causing `"0.76.2" !== "v0.76.2"` to evaluate as true even for matching versions.

## Changes

Updated `checkVersionState()` in `utils/app.ts` to strip the `v` prefix and pre-release suffix from both versions before comparing.

Closes #7484

## Test Plan

- Install SigNoz via Linux standalone binary
- Navigate to `/status` page
- Verify that when the installed version matches the latest GitHub release, the page shows "You are on the latest version" instead of suggesting an upgrade

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk utility change that only affects UI version comparison logic; it may slightly alter when upgrade notifications appear if version strings include prefixes/suffixes.
> 
> **Overview**
> Fixes version checks to treat `v0.x.y` and `0.x.y` as equivalent by stripping an optional leading `v` (and still ignoring pre-release suffixes) before comparing current vs latest versions. This prevents false “upgrade available” indicators on pages that rely on `checkVersionState` (e.g., `/status` and the side nav).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 264fa2d8d61dabc2594539f59d0fa887c3bb7ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->