### PR TITLE
fix: open trace details in new tab from funnel results table

### DIFF
--- a/frontend/src/pages/TracesFunnelDetails/components/FunnelResults/utils.tsx
+++ b/frontend/src/pages/TracesFunnelDetails/components/FunnelResults/utils.tsx
@@ -7,7 +7,7 @@ export const topTracesTableColumns = [
 		dataIndex: 'trace_id',
 		key: 'trace_id',
 		render: (traceId: string): JSX.Element => (
-			<Link to={`/trace/${traceId}`} className="trace-id-cell">
+			<Link to={`/trace/${traceId}`} target="_blank" className="trace-id-cell">
 				{traceId}
 			</Link>
 		),


### PR DESCRIPTION
## Summary

Clicking a trace ID in the Trace Funnels results table now opens the trace details in a new browser tab instead of navigating in the current tab.

## Problem

When analyzing multiple traces from the Trace Funnels results table, clicking a trace ID would navigate away from the funnels view, losing the analysis context. Users had to navigate back to the funnels page each time.

## Changes

Added `target="_blank"` to the `<Link>` component rendering trace IDs in `FunnelResults/utils.tsx`.

Closes #9369

## Test Plan

1. Navigate to Trace Funnels and run a funnel query
2. Click a trace ID in the results table
3. Verify the trace details open in a new browser tab
4. Verify the funnels page remains open in the original tab

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to navigation: trace ID links now open a separate tab, with minimal chance of unexpected routing/UX side effects.
> 
> **Overview**
> Trace IDs in the Trace Funnels results table now open the corresponding `/trace/:id` page in a new tab by adding `target="_blank"` to the `Link` in `FunnelResults/utils.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9a06c272e46a0744c341f201141baf392849f6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->