### PR TITLE
feat: add cancelled query placeholder to logs, traces, and dashboard widgets

### DIFF
--- a/frontend/src/constants/reactQuery.ts
+++ b/frontend/src/constants/reactQuery.ts
@@ -1,0 +1,8 @@
+/**
+ * Maximum number of retries for a failed react-query request before giving up.
+ * Used as the upper bound in the default `retry` predicate:
+ *   `return failureCount < MAX_QUERY_RETRIES;`
+ *
+ * This retries up to 3 times (4 attempts total including the initial request).
+ */
+export const MAX_QUERY_RETRIES = 3;

--- a/frontend/src/container/GridCardLayout/GridCard/FullView/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/FullView/index.tsx
@@ -19,6 +19,7 @@ import cx from 'classnames';
 import { ToggleGraphProps } from 'components/Graph/types';
 import OverlayScrollbar from 'components/OverlayScrollbar/OverlayScrollbar';
 import { QueryBuilderV2 } from 'components/QueryBuilderV2/QueryBuilderV2';
+import QueryCancelledPlaceholder from 'components/QueryCancelledPlaceholder';
 import Spinner from 'components/Spinner';
 import TimePreference from 'components/TimePreferenceDropDown';
 import WarningPopover from 'components/WarningPopover/WarningPopover';
@@ -223,8 +224,17 @@ function FullView({
 		keepPreviousData: true,
 	});
 
+	const [isCancelled, setIsCancelled] = useState(false);
+
+	useEffect(() => {
+		if (response.isFetching) {
+			setIsCancelled(false);
+		}
+	}, [response.isFetching]);
+
 	const handleCancelQuery = useCallback(() => {
 		queryClient.cancelQueries(queryRangeKey);
+		setIsCancelled(true);
 	}, [queryClient, queryRangeKey]);
 
 	const onDragSelect = useCallback((start: number, end: number): void => {
@@ -399,23 +409,27 @@ function FullView({
 									}}
 								/>
 							)}
-							<PanelWrapper
-								panelMode={PanelMode.STANDALONE_VIEW}
-								queryResponse={response}
-								widget={widget}
-								setRequestData={setRequestData}
-								isFullViewMode
-								onToggleModelHandler={onToggleModelHandler}
-								setGraphVisibility={setGraphsVisibilityStates}
-								graphVisibility={graphsVisibilityStates}
-								onDragSelect={customOnDragSelect ?? onDragSelect}
-								tableProcessedDataRef={tableProcessedDataRef}
-								searchTerm={searchTerm}
-								onClickHandler={onClickHandler}
-								enableDrillDown={enableDrillDown}
-								selectedGraph={selectedPanelType}
-								onColumnWidthsChange={onColumnWidthsChange}
-							/>
+							{isCancelled ? (
+								<QueryCancelledPlaceholder subText='Click "Run Query" to reload the widget.' />
+							) : (
+								<PanelWrapper
+									panelMode={PanelMode.STANDALONE_VIEW}
+									queryResponse={response}
+									widget={widget}
+									setRequestData={setRequestData}
+									isFullViewMode
+									onToggleModelHandler={onToggleModelHandler}
+									setGraphVisibility={setGraphsVisibilityStates}
+									graphVisibility={graphsVisibilityStates}
+									onDragSelect={customOnDragSelect ?? onDragSelect}
+									tableProcessedDataRef={tableProcessedDataRef}
+									searchTerm={searchTerm}
+									onClickHandler={onClickHandler}
+									enableDrillDown={enableDrillDown}
+									selectedGraph={selectedPanelType}
+									onColumnWidthsChange={onColumnWidthsChange}
+								/>
+							)}
 						</GraphContainer>
 					</div>
 				</>

--- a/frontend/src/container/MeterExplorer/Explorer/TimeSeries.tsx
+++ b/frontend/src/container/MeterExplorer/Explorer/TimeSeries.tsx
@@ -6,6 +6,7 @@ import { isAxiosError } from 'axios';
 import QueryCancelledPlaceholder from 'components/QueryCancelledPlaceholder';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { initialQueryMeterWithType, PANEL_TYPES } from 'constants/queryBuilder';
+import { MAX_QUERY_RETRIES } from 'constants/reactQuery';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import EmptyMetricsSearch from 'container/MetricsExplorer/Explorer/EmptyMetricsSearch';
 import { BuilderUnitsFilter } from 'container/QueryBuilder/filters/BuilderUnitsFilter';
@@ -113,7 +114,7 @@ function TimeSeries({
 					return false;
 				}
 
-				return failureCount < 3;
+				return failureCount < MAX_QUERY_RETRIES;
 			},
 			onError: (error: APIError): void => {
 				showErrorModal(error);

--- a/frontend/src/container/MetricsExplorer/Explorer/TimeSeries.tsx
+++ b/frontend/src/container/MetricsExplorer/Explorer/TimeSeries.tsx
@@ -16,6 +16,7 @@ import YAxisUnitSelector from 'components/YAxisUnitSelector';
 import { YAxisSource } from 'components/YAxisUnitSelector/types';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
+import { MAX_QUERY_RETRIES } from 'constants/reactQuery';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import TimeSeriesView from 'container/TimeSeriesView/TimeSeriesView';
 import { convertDataValueToMs } from 'container/TimeSeriesView/utils';
@@ -139,7 +140,7 @@ function TimeSeries({
 					return false;
 				}
 
-				return failureCount < 3;
+				return failureCount < MAX_QUERY_RETRIES;
 			},
 		})),
 	);

--- a/frontend/src/container/MetricsExplorer/Inspect/useInspectMetrics.ts
+++ b/frontend/src/container/MetricsExplorer/Inspect/useInspectMetrics.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { useQuery } from 'react-query';
 import { inspectMetrics } from 'api/generated/services/metrics';
 import { isAxiosError } from 'axios';
+import { MAX_QUERY_RETRIES } from 'constants/reactQuery';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { themeColors } from 'constants/theme';
 import { useIsDarkMode } from 'hooks/useDarkMode';
@@ -133,7 +134,7 @@ export function useInspectMetrics(
 			if (isAxiosError(error) && error.code === 'ERR_CANCELED') {
 				return false;
 			}
-			return failureCount < 3;
+			return failureCount < MAX_QUERY_RETRIES;
 		},
 	});
 

--- a/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/index.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { InfoCircleOutlined } from '@ant-design/icons';
+import QueryCancelledPlaceholder from 'components/QueryCancelledPlaceholder';
 import WarningPopover from 'components/WarningPopover/WarningPopover';
 import { Card } from 'container/GridCardLayout/styles';
 import DateTimeSelectionV2 from 'container/TopNav/DateTimeSelectionV2';
@@ -22,6 +23,7 @@ function WidgetGraph({
 	selectedWidget,
 	isLoadingPanelData,
 	enableDrillDown = false,
+	isCancelled = false,
 }: WidgetGraphContainerProps): JSX.Element {
 	const { currentQuery } = useQueryBuilder();
 
@@ -46,20 +48,24 @@ function WidgetGraph({
 				</div>
 				<DateTimeSelectionV2 showAutoRefresh={false} hideShareModal />
 			</div>
-			{queryResponse.error && (
+			{!isCancelled && queryResponse.error && (
 				<AlertIconContainer color="red" title={queryResponse.error.message}>
 					<InfoCircleOutlined />
 				</AlertIconContainer>
 			)}
 
-			<WidgetGraphComponent
-				isLoadingPanelData={isLoadingPanelData}
-				selectedGraph={selectedGraph}
-				queryResponse={queryResponse}
-				setRequestData={setRequestData}
-				selectedWidget={selectedWidget}
-				enableDrillDown={enableDrillDown}
-			/>
+			{isCancelled ? (
+				<QueryCancelledPlaceholder subText='Click "Run Query" to reload the chart.' />
+			) : (
+				<WidgetGraphComponent
+					isLoadingPanelData={isLoadingPanelData}
+					selectedGraph={selectedGraph}
+					queryResponse={queryResponse}
+					setRequestData={setRequestData}
+					selectedWidget={selectedWidget}
+					enableDrillDown={enableDrillDown}
+				/>
+			)}
 		</Container>
 	);
 }

--- a/frontend/src/container/NewWidget/LeftContainer/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/index.tsx
@@ -1,7 +1,8 @@
-import { memo, useCallback, useEffect, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from 'react-query';
 // eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
+import QueryCancelledPlaceholder from 'components/QueryCancelledPlaceholder';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
@@ -50,8 +51,11 @@ function LeftContainer({
 		],
 		[globalSelectedInterval, requestData, minTime, maxTime],
 	);
+	const [isCancelled, setIsCancelled] = useState(false);
+
 	const handleCancelQuery = useCallback(() => {
 		queryClient.cancelQueries(queryRangeKey);
+		setIsCancelled(true);
 	}, [queryClient, queryRangeKey]);
 
 	const queryResponse = useGetQueryRange(requestData, ENTITY_VERSION_V5, {
@@ -59,6 +63,12 @@ function LeftContainer({
 		queryKey: queryRangeKey,
 		keepPreviousData: true,
 	});
+
+	useEffect(() => {
+		if (queryResponse.isFetching) {
+			setIsCancelled(false);
+		}
+	}, [queryResponse.isFetching]);
 
 	// Update parent component with query response for legend colors
 	useEffect(() => {
@@ -69,14 +79,18 @@ function LeftContainer({
 
 	return (
 		<>
-			<WidgetGraph
-				selectedGraph={selectedGraph}
-				queryResponse={queryResponse}
-				setRequestData={setRequestData}
-				selectedWidget={selectedWidget}
-				isLoadingPanelData={isLoadingPanelData}
-				enableDrillDown={enableDrillDown}
-			/>
+			{isCancelled ? (
+				<QueryCancelledPlaceholder subText='Click "Run Query" to reload the chart.' />
+			) : (
+				<WidgetGraph
+					selectedGraph={selectedGraph}
+					queryResponse={queryResponse}
+					setRequestData={setRequestData}
+					selectedWidget={selectedWidget}
+					isLoadingPanelData={isLoadingPanelData}
+					enableDrillDown={enableDrillDown}
+				/>
+			)}
 			<QueryContainer className="query-section-left-container">
 				<QuerySection
 					selectedGraph={selectedGraph}

--- a/frontend/src/container/NewWidget/LeftContainer/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/index.tsx
@@ -2,7 +2,6 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from 'react-query';
 // eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
-import QueryCancelledPlaceholder from 'components/QueryCancelledPlaceholder';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
@@ -79,18 +78,15 @@ function LeftContainer({
 
 	return (
 		<>
-			{isCancelled ? (
-				<QueryCancelledPlaceholder subText='Click "Run Query" to reload the chart.' />
-			) : (
-				<WidgetGraph
-					selectedGraph={selectedGraph}
-					queryResponse={queryResponse}
-					setRequestData={setRequestData}
-					selectedWidget={selectedWidget}
-					isLoadingPanelData={isLoadingPanelData}
-					enableDrillDown={enableDrillDown}
-				/>
-			)}
+			<WidgetGraph
+				selectedGraph={selectedGraph}
+				queryResponse={queryResponse}
+				setRequestData={setRequestData}
+				selectedWidget={selectedWidget}
+				isLoadingPanelData={isLoadingPanelData}
+				enableDrillDown={enableDrillDown}
+				isCancelled={isCancelled}
+			/>
 			<QueryContainer className="query-section-left-container">
 				<QuerySection
 					selectedGraph={selectedGraph}

--- a/frontend/src/container/NewWidget/types.ts
+++ b/frontend/src/container/NewWidget/types.ts
@@ -50,4 +50,5 @@ export type WidgetGraphContainerProps = {
 	selectedWidget: Widgets;
 	isLoadingPanelData: boolean;
 	enableDrillDown?: boolean;
+	isCancelled?: boolean;
 };

--- a/frontend/src/hooks/queryBuilder/useGetQueryRange.ts
+++ b/frontend/src/hooks/queryBuilder/useGetQueryRange.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useQuery, UseQueryOptions, UseQueryResult } from 'react-query';
 import { isAxiosError } from 'axios';
 import { PANEL_TYPES } from 'constants/queryBuilder';
+import { MAX_QUERY_RETRIES } from 'constants/reactQuery';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { updateBarStepInterval } from 'container/GridCardLayout/utils';
 import { useDashboardVariablesByType } from 'hooks/dashboard/useDashboardVariablesByType';
@@ -148,7 +149,7 @@ export const useGetQueryRange: UseGetQueryRange = (
 				return false;
 			}
 
-			return failureCount < 3;
+			return failureCount < MAX_QUERY_RETRIES;
 		};
 	}, [options?.retry]);
 

--- a/frontend/src/hooks/thirdPartyApis/useListOverview.ts
+++ b/frontend/src/hooks/thirdPartyApis/useListOverview.ts
@@ -1,6 +1,7 @@
 import { useQuery, UseQueryResult } from 'react-query';
 import listOverview from 'api/thirdPartyApis/listOverview';
 import { isAxiosError } from 'axios';
+import { MAX_QUERY_RETRIES } from 'constants/reactQuery';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { SuccessResponseV2 } from 'types/api';
 import APIError from 'types/api/error';
@@ -35,7 +36,7 @@ export const useListOverview = (
 			if (isAxiosError(error) && error.code === 'ERR_CANCELED') {
 				return false;
 			}
-			return failureCount < 3;
+			return failureCount < MAX_QUERY_RETRIES;
 		},
 	});
 };

--- a/frontend/src/pages/LogsExplorer/index.tsx
+++ b/frontend/src/pages/LogsExplorer/index.tsx
@@ -6,6 +6,7 @@ import setLocalStorageApi from 'api/browser/localstorage/set';
 import { TelemetryFieldKey } from 'api/v5/v5';
 import cx from 'classnames';
 import ExplorerCard from 'components/ExplorerCard/ExplorerCard';
+import QueryCancelledPlaceholder from 'components/QueryCancelledPlaceholder';
 import QuickFilters from 'components/QuickFilters/QuickFilters';
 import { QuickFiltersSource, SignalType } from 'components/QuickFilters/types';
 import WarningPopover from 'components/WarningPopover/WarningPopover';
@@ -75,6 +76,13 @@ function LogsExplorer(): JSX.Element {
 	const chartQueryKeyRef = useRef<any>();
 
 	const [isLoadingQueries, setIsLoadingQueries] = useState<boolean>(false);
+	const [isCancelled, setIsCancelled] = useState(false);
+
+	useEffect(() => {
+		if (isLoadingQueries) {
+			setIsCancelled(false);
+		}
+	}, [isLoadingQueries]);
 
 	const queryClient = useQueryClient();
 	const handleCancelQuery = useCallback(() => {
@@ -84,6 +92,7 @@ function LogsExplorer(): JSX.Element {
 		if (chartQueryKeyRef.current) {
 			queryClient.cancelQueries(chartQueryKeyRef.current);
 		}
+		setIsCancelled(true);
 	}, [queryClient]);
 
 	const [warning, setWarning] = useState<Warning | undefined>(undefined);
@@ -325,14 +334,18 @@ function LogsExplorer(): JSX.Element {
 								</ExplorerCard>
 							</div>
 							<div className="logs-explorer-views">
-								<LogsExplorerViewsContainer
-									listQueryKeyRef={listQueryKeyRef}
-									chartQueryKeyRef={chartQueryKeyRef}
-									setIsLoadingQueries={setIsLoadingQueries}
-									setWarning={setWarning}
-									showLiveLogs={showLiveLogs}
-									handleChangeSelectedView={handleChangeSelectedView}
-								/>
+								{isCancelled ? (
+									<QueryCancelledPlaceholder subText='Click "Run Query" to load logs.' />
+								) : (
+									<LogsExplorerViewsContainer
+										listQueryKeyRef={listQueryKeyRef}
+										chartQueryKeyRef={chartQueryKeyRef}
+										setIsLoadingQueries={setIsLoadingQueries}
+										setWarning={setWarning}
+										showLiveLogs={showLiveLogs}
+										handleChangeSelectedView={handleChangeSelectedView}
+									/>
+								)}
 							</div>
 						</div>
 					</section>

--- a/frontend/src/pages/LogsExplorer/index.tsx
+++ b/frontend/src/pages/LogsExplorer/index.tsx
@@ -93,6 +93,9 @@ function LogsExplorer(): JSX.Element {
 			queryClient.cancelQueries(chartQueryKeyRef.current);
 		}
 		setIsCancelled(true);
+		// Reset loading state — the views container unmounts when cancelled, so
+		// no child will call setIsLoadingQueries(false) otherwise.
+		setIsLoadingQueries(false);
 	}, [queryClient]);
 
 	const [warning, setWarning] = useState<Warning | undefined>(undefined);
@@ -316,7 +319,10 @@ function LogsExplorer(): JSX.Element {
 							}
 							rightActions={
 								<RightToolbarActions
-									onStageRunQuery={(): void => handleRunQuery()}
+									onStageRunQuery={(): void => {
+										setIsCancelled(false);
+										handleRunQuery();
+									}}
 									isLoadingQueries={isLoadingQueries}
 									handleCancelQuery={handleCancelQuery}
 									showLiveLogs={showLiveLogs}

--- a/frontend/src/pages/TracesExplorer/index.tsx
+++ b/frontend/src/pages/TracesExplorer/index.tsx
@@ -92,6 +92,9 @@ function TracesExplorer(): JSX.Element {
 			queryClient.cancelQueries(listQueryKeyRef.current);
 		}
 		setIsCancelled(true);
+		// Reset loading state — the active view unmounts when cancelled, so no
+		// child will call setIsLoadingQueries(false) otherwise.
+		setIsLoadingQueries(false);
 	}, [queryClient]);
 
 	const [selectedView, setSelectedView] = useState<ExplorerViews>(() =>
@@ -227,7 +230,10 @@ function TracesExplorer(): JSX.Element {
 							}
 							rightActions={
 								<RightToolbarActions
-									onStageRunQuery={(): void => handleRunQuery()}
+									onStageRunQuery={(): void => {
+										setIsCancelled(false);
+										handleRunQuery();
+									}}
 									isLoadingQueries={isLoadingQueries}
 									handleCancelQuery={handleCancelQuery}
 								/>

--- a/frontend/src/pages/TracesExplorer/index.tsx
+++ b/frontend/src/pages/TracesExplorer/index.tsx
@@ -6,6 +6,7 @@ import { Card } from 'antd';
 import logEvent from 'api/common/logEvent';
 import cx from 'classnames';
 import ExplorerCard from 'components/ExplorerCard/ExplorerCard';
+import QueryCancelledPlaceholder from 'components/QueryCancelledPlaceholder';
 import QuickFilters from 'components/QuickFilters/QuickFilters';
 import { QuickFiltersSource, SignalType } from 'components/QuickFilters/types';
 import WarningPopover from 'components/WarningPopover/WarningPopover';
@@ -78,11 +79,19 @@ function TracesExplorer(): JSX.Element {
 	// Get panel type from URL
 	const panelTypesFromUrl = useGetPanelTypesQueryParam(PANEL_TYPES.LIST);
 	const [isLoadingQueries, setIsLoadingQueries] = useState<boolean>(false);
+	const [isCancelled, setIsCancelled] = useState(false);
+
+	useEffect(() => {
+		if (isLoadingQueries) {
+			setIsCancelled(false);
+		}
+	}, [isLoadingQueries]);
 
 	const handleCancelQuery = useCallback(() => {
 		if (listQueryKeyRef.current) {
 			queryClient.cancelQueries(listQueryKeyRef.current);
 		}
+		setIsCancelled(true);
 	}, [queryClient]);
 
 	const [selectedView, setSelectedView] = useState<ExplorerViews>(() =>
@@ -232,7 +241,11 @@ function TracesExplorer(): JSX.Element {
 					</ExplorerCard>
 
 					<div className="traces-explorer-views">
-						{selectedView === ExplorerViews.LIST && (
+						{isCancelled && (
+							<QueryCancelledPlaceholder subText='Click "Run Query" to load traces.' />
+						)}
+
+						{!isCancelled && selectedView === ExplorerViews.LIST && (
 							<div className="trace-explorer-list-view">
 								<ListView
 									isFilterApplied={isFilterApplied}
@@ -243,7 +256,7 @@ function TracesExplorer(): JSX.Element {
 							</div>
 						)}
 
-						{selectedView === ExplorerViews.TRACE && (
+						{!isCancelled && selectedView === ExplorerViews.TRACE && (
 							<div className="trace-explorer-traces-view">
 								<TracesView
 									isFilterApplied={isFilterApplied}
@@ -254,7 +267,7 @@ function TracesExplorer(): JSX.Element {
 							</div>
 						)}
 
-						{selectedView === ExplorerViews.TIMESERIES && (
+						{!isCancelled && selectedView === ExplorerViews.TIMESERIES && (
 							<div className="trace-explorer-time-series-view">
 								<TimeSeriesView
 									dataSource={DataSource.TRACES}
@@ -266,7 +279,7 @@ function TracesExplorer(): JSX.Element {
 							</div>
 						)}
 
-						{selectedView === ExplorerViews.TABLE && (
+						{!isCancelled && selectedView === ExplorerViews.TABLE && (
 							<div className="trace-explorer-table-view">
 								<TableView
 									setWarning={setWarning}


### PR DESCRIPTION
## Summary
Completes the cancelled-query placeholder coverage for the remaining 4 areas that were previously skipped. All use the same shared `<QueryCancelledPlaceholder />` and the same auto-reset pattern established in the parent PR.

- **LogsExplorer** — `isCancelled` state in page, auto-reset on `isLoadingQueries`; `LogsExplorerViewsContainer` swapped with placeholder when cancelled (query editor + filters remain visible above)
- **TracesExplorer** — same pattern; all 4 trace views (List/Trace/TimeSeries/Table) hidden behind a single `isCancelled` gate
- **GridCardLayout FullView** — `isCancelled` state in FullView, auto-reset on `response.isFetching`; `PanelWrapper` swapped with placeholder when cancelled
- **NewWidget LeftContainer** — same pattern; `WidgetGraph` swapped with placeholder when cancelled

## Approach
Top-level swap at the chart/results container rather than threading `isCancelled` through every child view. Keeps the blast radius small and consistent with the pattern used for MetricsExplorer/MeterExplorer in the parent PR.

## Screenshots / Screen Recordings
<!-- Add any relevant screenshots or recordings -->

### Logs Explorer
<img width="1725" height="961" alt="Screenshot 2026-04-20 at 9 58 01 PM" src="https://github.com/user-attachments/assets/bca3efe1-85ea-43e7-b07e-4c0242e0cefd" />

### Traces Explorer
<img width="1725" height="961" alt="Screenshot 2026-04-20 at 9 58 12 PM" src="https://github.com/user-attachments/assets/6bafeedc-d631-4051-90fc-9da8ad97193b" />

### Dashboard Panel Full Screen View
<img width="1725" height="961" alt="Screenshot 2026-04-20 at 9 28 10 PM" src="https://github.com/user-attachments/assets/3baab122-938a-488e-b0ef-f21fc50d717a" />

### Dashboard Edit Panel
<img width="1725" height="961" alt="Screenshot 2026-04-20 at 9 57 45 PM" src="https://github.com/user-attachments/assets/c39dec02-3502-4cd8-9774-d07bdad24f41" />


## Change Type
- [x] Feature

## Testing Strategy
- TypeScript compilation passes
- Manual: each page → run query → cancel → verify placeholder shows in chart/results area → filters/query editor still usable → click Run → placeholder disappears

## Risk & Impact Assessment
- Low risk: purely additive UI; existing flows unchanged when not cancelled
- Auto-reset ensures no stale "cancelled" state can linger after re-run or filter change