### PR TITLE
fix(status): strip 'v' prefix before comparing versions

### DIFF
--- a/frontend/src/utils/app.test.ts
+++ b/frontend/src/utils/app.test.ts
@@ -1,0 +1,28 @@
+import { checkVersionState } from './app';
+
+describe('checkVersionState', () => {
+	it('returns true when both versions match exactly', () => {
+		expect(checkVersionState('0.76.2', '0.76.2')).toBe(true);
+	});
+
+	it('returns true when current version has a leading "v" and latest does not', () => {
+		expect(checkVersionState('v0.76.2', '0.76.2')).toBe(true);
+	});
+
+	it('returns true when latest version has a leading "v" and current does not', () => {
+		expect(checkVersionState('0.76.2', 'v0.76.2')).toBe(true);
+	});
+
+	it('returns true when both versions have a leading "v"', () => {
+		expect(checkVersionState('v0.76.2', 'v0.76.2')).toBe(true);
+	});
+
+	it('treats pre-release suffix on current as equivalent to the core version', () => {
+		expect(checkVersionState('v0.76.2-rc.1', '0.76.2')).toBe(true);
+	});
+
+	it('returns false for different versions regardless of prefix', () => {
+		expect(checkVersionState('v0.76.1', '0.76.2')).toBe(false);
+		expect(checkVersionState('0.76.1', 'v0.76.2')).toBe(false);
+	});
+});

--- a/frontend/src/utils/app.ts
+++ b/frontend/src/utils/app.ts
@@ -16,12 +16,15 @@ export function extractDomain(email: string): string {
 	return emailParts[1];
 }
 
+const stripVersionPrefix = (version: string): string =>
+	version?.replace(/^v/i, '') ?? '';
+
 export const checkVersionState = (
 	currentVersion: string,
 	latestVersion: string,
 ): boolean => {
 	const versionCore = currentVersion?.split('-')[0];
-	return versionCore === latestVersion;
+	return stripVersionPrefix(versionCore) === stripVersionPrefix(latestVersion);
 };
 
 // list of forbidden tags to remove in dompurify


### PR DESCRIPTION
## Summary
Fixes #7484 — \`/status\` was showing an upgrade-available banner even when the running build matched the latest release.

## Problem
\`checkVersionState\` in [frontend/src/utils/app.ts](https://github.com/SigNoz/signoz/blob/main/frontend/src/utils/app.ts#L19) compared the two versions via raw string equality:

```ts
const versionCore = currentVersion?.split('-')[0];
return versionCore === latestVersion;
```

In practice one side comes back with a \`v\` prefix (e.g. \`v0.76.2\` from the build) and the other without it (e.g. \`0.76.2\` from the GitHub release API response), so equality fails and the UI reports a phantom upgrade.

## Fix
Strip a leading \`v\`/\`V\` before comparing:

\`\`\`ts
const stripVersionPrefix = (version: string): string =>
    version?.replace(/^v/i, '') ?? '';

return stripVersionPrefix(versionCore) === stripVersionPrefix(latestVersion);
\`\`\`

Existing pre-release normalization (\`0.76.2-rc.1\` → \`0.76.2\`) is preserved.

## Test plan
Added \`frontend/src/utils/app.test.ts\` covering:
- Exact match
- Either side prefixed with \`v\`
- Both prefixed
- Pre-release current version (\`v0.76.2-rc.1\` vs \`0.76.2\`)
- True mismatch (different minor/patch) — still returns false regardless of prefix

- [x] \`yarn test app.test\` passes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to frontend version comparison logic with added unit tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes `/status` upgrade detection by normalizing version strings before comparing them, stripping a leading `v`/`V` while preserving existing pre-release suffix handling.
> 
> Adds a focused `checkVersionState` test suite covering prefixed/unprefixed matches, pre-release normalization, and mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06f87875fd9676cadb6036314be665f42edb6a78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->