### PR TITLE
fix: disallow group by timestamp for timeseries request

### DIFF
--- a/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
@@ -47,13 +47,13 @@ const (
 type ValidationOption func(*validationConfig)
 
 type validationConfig struct {
-	skipLimitOffsetValidation bool
-	skipAggregationValidation bool
-	skipHavingValidation      bool
-	skipAggregationOrderBy    bool
-	skipSelectFieldValidation bool
-	skipGroupByValidation     bool
-	requestType               RequestType
+	skipLimitOffsetValidation      bool
+	skipAggregationValidation      bool
+	skipHavingValidation           bool
+	skipAggregationOrderBy         bool
+	skipSelectFieldValidation      bool
+	skipGroupByValidation          bool
+	WithTimestampGroupByValidation bool
 }
 
 func applyValidationOptions(opts []ValidationOption) validationConfig {
@@ -113,9 +113,9 @@ func WithSkipGroupByValidation() ValidationOption {
 }
 
 // WithRequestType sets the request type for validation.
-func WithRequestType(requestType RequestType) ValidationOption {
+func WithTimestampGroupByValidation() ValidationOption {
 	return func(cfg *validationConfig) {
-		cfg.requestType = requestType
+		cfg.WithTimestampGroupByValidation = true
 	}
 }
 
@@ -185,9 +185,9 @@ func (q *QueryBuilderQuery[T]) validateGroupBy(cfg validationConfig) error {
 				errors.CodeInvalidInput, "invalid empty key name for group by at index %d", idx,
 			)
 		}
-		if cfg.requestType == RequestTypeTimeSeries && item.Name == "timestamp" {
+		if cfg.WithTimestampGroupByValidation && item.Name == "timestamp" {
 			return errors.NewInvalidInputf(
-				errors.CodeInvalidInput, "group by on timestamp is not allowed for request type %s", cfg.requestType.StringValue(),
+				errors.CodeInvalidInput, "group by on timestamp is not allowed",
 			).WithAdditional("Timeseries request already accounts for timestamp in the response")
 		}
 	}
@@ -678,11 +678,13 @@ func validateQueryEnvelope(envelope QueryEnvelope, opts ...ValidationOption) err
 
 func GetValidationOptions(requestType RequestType) []ValidationOption {
 	switch requestType {
-	case RequestTypeTimeSeries, RequestTypeScalar:
-		return []ValidationOption{WithSkipSelectFieldValidation(), WithRequestType(requestType)}
+	case RequestTypeTimeSeries:
+		return []ValidationOption{WithSkipSelectFieldValidation(), WithTimestampGroupByValidation()}
+	case RequestTypeScalar:
+		return []ValidationOption{WithSkipSelectFieldValidation()}
 	case RequestTypeRaw, RequestTypeRawStream, RequestTypeTrace:
-		return []ValidationOption{WithSkipAggregationValidation(), WithSkipHavingValidation(), WithSkipAggregationOrderBy(), WithSkipGroupByValidation(), WithRequestType(requestType)}
+		return []ValidationOption{WithSkipAggregationValidation(), WithSkipHavingValidation(), WithSkipAggregationOrderBy(), WithSkipGroupByValidation()}
 	default:
-		return []ValidationOption{WithRequestType(requestType)}
+		return []ValidationOption{}
 	}
 }

--- a/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
@@ -53,6 +53,7 @@ type validationConfig struct {
 	skipAggregationOrderBy    bool
 	skipSelectFieldValidation bool
 	skipGroupByValidation     bool
+	requestType               RequestType
 }
 
 func applyValidationOptions(opts []ValidationOption) validationConfig {
@@ -108,6 +109,13 @@ func WithSkipSelectFieldValidation() ValidationOption {
 func WithSkipGroupByValidation() ValidationOption {
 	return func(cfg *validationConfig) {
 		cfg.skipGroupByValidation = true
+	}
+}
+
+// WithRequestType sets the request type for validation.
+func WithRequestType(requestType RequestType) ValidationOption {
+	return func(cfg *validationConfig) {
+		cfg.requestType = requestType
 	}
 }
 
@@ -176,6 +184,11 @@ func (q *QueryBuilderQuery[T]) validateGroupBy(cfg validationConfig) error {
 			return errors.NewInvalidInputf(
 				errors.CodeInvalidInput, "invalid empty key name for group by at index %d", idx,
 			)
+		}
+		if cfg.requestType == RequestTypeTimeSeries && item.Name == "timestamp" {
+			return errors.NewInvalidInputf(
+				errors.CodeInvalidInput, "group by on timestamp is not allowed for request type %s", cfg.requestType.StringValue(),
+			).WithAdditional("Timeseries request already accounts for timestamp in the response")
 		}
 	}
 	return nil
@@ -666,10 +679,10 @@ func validateQueryEnvelope(envelope QueryEnvelope, opts ...ValidationOption) err
 func GetValidationOptions(requestType RequestType) []ValidationOption {
 	switch requestType {
 	case RequestTypeTimeSeries, RequestTypeScalar:
-		return []ValidationOption{WithSkipSelectFieldValidation()}
+		return []ValidationOption{WithSkipSelectFieldValidation(), WithRequestType(requestType)}
 	case RequestTypeRaw, RequestTypeRawStream, RequestTypeTrace:
-		return []ValidationOption{WithSkipAggregationValidation(), WithSkipHavingValidation(), WithSkipAggregationOrderBy(), WithSkipGroupByValidation()}
+		return []ValidationOption{WithSkipAggregationValidation(), WithSkipHavingValidation(), WithSkipAggregationOrderBy(), WithSkipGroupByValidation(), WithRequestType(requestType)}
 	default:
-		return []ValidationOption{}
+		return []ValidationOption{WithRequestType(requestType)}
 	}
 }

--- a/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
@@ -53,7 +53,7 @@ type validationConfig struct {
 	skipAggregationOrderBy         bool
 	skipSelectFieldValidation      bool
 	skipGroupByValidation          bool
-	WithTimestampGroupByValidation bool
+	withTimestampGroupByValidation bool
 }
 
 func applyValidationOptions(opts []ValidationOption) validationConfig {
@@ -115,7 +115,7 @@ func WithSkipGroupByValidation() ValidationOption {
 // WithRequestType sets the request type for validation.
 func WithTimestampGroupByValidation() ValidationOption {
 	return func(cfg *validationConfig) {
-		cfg.WithTimestampGroupByValidation = true
+		cfg.withTimestampGroupByValidation = true
 	}
 }
 
@@ -185,7 +185,7 @@ func (q *QueryBuilderQuery[T]) validateGroupBy(cfg validationConfig) error {
 				errors.CodeInvalidInput, "invalid empty key name for group by at index %d", idx,
 			)
 		}
-		if cfg.WithTimestampGroupByValidation && item.Name == "timestamp" {
+		if cfg.withTimestampGroupByValidation && item.Name == "timestamp" {
 			return errors.NewInvalidInputf(
 				errors.CodeInvalidInput, "group by on timestamp is not allowed",
 			).WithAdditional("Timeseries request already accounts for timestamp in the response")

--- a/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
@@ -112,7 +112,7 @@ func WithSkipGroupByValidation() ValidationOption {
 	}
 }
 
-// WithRequestType sets the request type for validation.
+// WithTimestampGroupByValidation enables validation to disallow grouping by timestamp field.
 func WithTimestampGroupByValidation() ValidationOption {
 	return func(cfg *validationConfig) {
 		cfg.withTimestampGroupByValidation = true
@@ -188,7 +188,7 @@ func (q *QueryBuilderQuery[T]) validateGroupBy(cfg validationConfig) error {
 		if cfg.withTimestampGroupByValidation && item.Name == "timestamp" {
 			return errors.NewInvalidInputf(
 				errors.CodeInvalidInput, "group by on timestamp is not allowed",
-			).WithAdditional("Timeseries request already accounts for timestamp in the response")
+			)
 		}
 	}
 	return nil

--- a/pkg/types/querybuildertypes/querybuildertypesv5/validation_test.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/validation_test.go
@@ -696,6 +696,59 @@ func TestQueryRangeRequest_ValidateCompositeQuery(t *testing.T) {
 			errMsg:  "raw request type is not supported for metric queries",
 		},
 		{
+			name: "timeseries request with group by timestamp should return error",
+			request: QueryRangeRequest{
+				Start:       1640995200000,
+				End:         1640998800000,
+				RequestType: RequestTypeTimeSeries,
+				CompositeQuery: CompositeQuery{
+					Queries: []QueryEnvelope{
+						{
+							Type: QueryTypeBuilder,
+							Spec: QueryBuilderQuery[LogAggregation]{
+								Name:   "A",
+								Signal: telemetrytypes.SignalLogs,
+								Aggregations: []LogAggregation{
+									{Expression: "count()"},
+								},
+								GroupBy: []GroupByKey{
+									{TelemetryFieldKey: telemetrytypes.TelemetryFieldKey{Name: "timestamp"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "group by on timestamp is not allowed",
+		},
+		{
+			name: "scalar request with group by timestamp should pass",
+			request: QueryRangeRequest{
+				Start:       1640995200000,
+				End:         1640998800000,
+				RequestType: RequestTypeScalar,
+				CompositeQuery: CompositeQuery{
+					Queries: []QueryEnvelope{
+						{
+							Type: QueryTypeBuilder,
+							Spec: QueryBuilderQuery[LogAggregation]{
+								Name:   "A",
+								Signal: telemetrytypes.SignalLogs,
+								Aggregations: []LogAggregation{
+									{Expression: "count()"},
+								},
+								GroupBy: []GroupByKey{
+									{TelemetryFieldKey: telemetrytypes.TelemetryFieldKey{Name: "timestamp"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "raw request with log query without aggregations should pass",
 			request: QueryRangeRequest{
 				Start:       1640995200000,


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Disallow `GROUP BY timestamp` in query-builder queries when the request type is `timeseries`. Timeseries responses already bucket results by timestamp via the step interval, so grouping by `timestamp` produces duplicated/incorrect series and confusing downstream rendering.

The validation is wired through a new `WithRequestType` option so `validateGroupBy` knows the request type and can reject `timestamp` as a group-by key specifically for `RequestTypeTimeSeries`. Other request types (raw, scalar, trace) are unaffected.

#### Issues closed by this PR

N/A

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause
Group-by validation had no awareness of the request type, so a timeseries query could include `timestamp` in `group_by`. Since timeseries queries are already bucketed by timestamp, this led to nonsensical groupings in the response.

#### Fix Strategy
- Add `requestType` to `validationConfig` and expose it via a new `WithRequestType` option.
- In `validateGroupBy`, reject `timestamp` as a group-by key when `requestType == RequestTypeTimeSeries`.
- Plumb `WithRequestType(requestType)` through `GetValidationOptions` for all request types so the config is always populated.

---

### 🧪 Testing Strategy

- Manual verification: submitting a timeseries builder query with `timestamp` in `group_by` now returns `CodeInvalidInput` with a clear message; other request types still accept the same payload.
- Edge cases covered: raw/scalar/trace request types remain unaffected; empty/other group-by keys go through the existing validation path unchanged.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: query-builder validation only; no query execution or storage changes.
- Potential regressions: any client that was (incorrectly) sending `timestamp` in `group_by` for a timeseries request will now receive a 400. This is the intended behavior.
- Rollback plan: revert this commit — change is isolated to `pkg/types/querybuildertypes/querybuildertypesv5/validation.go`.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Timeseries queries can no longer group by `timestamp`; the API rejects such requests with a clear validation error. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required (validation-only, covered manually)
- [x] Manually tested
- [x] Breaking changes documented (rejects previously-accepted but incorrect payloads)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The new `WithRequestType` option is also passed for raw/scalar/trace/default so `validationConfig.requestType` is consistently populated — only the timeseries branch currently uses it, but this leaves the door open for other request-type-specific rules without further plumbing.