### PR TITLE
fix: alerts creation for query types other than builder

### DIFF
--- a/frontend/src/hooks/queryBuilder/__tests__/useCreateAlerts.test.tsx
+++ b/frontend/src/hooks/queryBuilder/__tests__/useCreateAlerts.test.tsx
@@ -1,0 +1,197 @@
+import { useMutation } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
+import { useSelector } from 'react-redux';
+import { act, renderHook } from '@testing-library/react';
+import { QueryParams } from 'constants/query';
+import { mapQueryDataFromApi } from 'lib/newQueryBuilder/queryBuilderMappers/mapQueryDataFromApi';
+import { Widgets } from 'types/api/dashboard/getAll';
+import { EQueryType } from 'types/common/dashboard';
+
+import useCreateAlerts from '../useCreateAlerts';
+
+jest.mock('react-query', () => ({
+	useMutation: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+	useSelector: jest.fn(),
+}));
+
+jest.mock('api/common/logEvent', () => ({
+	__esModule: true,
+	default: jest.fn(),
+}));
+
+jest.mock('api/dashboard/substitute_vars', () => ({
+	getSubstituteVars: jest.fn(),
+}));
+
+jest.mock('api/v5/v5', () => ({
+	prepareQueryRangePayloadV5: jest.fn().mockReturnValue({ queryPayload: {} }),
+}));
+
+jest.mock(
+	'lib/newQueryBuilder/queryBuilderMappers/mapQueryDataFromApi',
+	() => ({
+		mapQueryDataFromApi: jest.fn(),
+	}),
+);
+
+jest.mock('hooks/dashboard/useDashboardVariables', () => ({
+	useDashboardVariables: (): unknown => ({ dashboardVariables: {} }),
+}));
+
+jest.mock('hooks/dashboard/useDashboardVariablesByType', () => ({
+	useDashboardVariablesByType: (): unknown => ({}),
+}));
+
+jest.mock('hooks/useNotifications', () => ({
+	useNotifications: (): unknown => ({
+		notifications: { error: jest.fn() },
+	}),
+}));
+
+jest.mock('lib/dashboardVariables/getDashboardVariables', () => ({
+	getDashboardVariables: (): unknown => ({}),
+}));
+
+jest.mock('providers/Dashboard/store/useDashboardStore', () => ({
+	useDashboardStore: (): unknown => ({ selectedDashboard: undefined }),
+}));
+
+jest.mock('utils/getGraphType', () => ({
+	getGraphType: jest.fn().mockReturnValue('time_series'),
+}));
+
+const mockMapQueryDataFromApi = mapQueryDataFromApi as jest.MockedFunction<
+	typeof mapQueryDataFromApi
+>;
+const mockUseMutation = useMutation as jest.MockedFunction<typeof useMutation>;
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+const buildWidget = (queryType: EQueryType | undefined): Widgets =>
+	(({
+		id: 'widget-1',
+		panelTypes: 'graph',
+		timePreferance: 'GLOBAL_TIME',
+		yAxisUnit: '',
+		query: {
+			queryType,
+			builder: { queryData: [], queryFormulas: [] },
+			clickhouse_sql: [],
+			promql: [],
+			id: 'q-1',
+		},
+	} as unknown) as Widgets);
+
+const getCompositeQueryFromLastOpen = (): Record<string, unknown> => {
+	const [url] = (window.open as jest.Mock).mock.calls[0];
+	const query = new URLSearchParams((url as string).split('?')[1]);
+	const raw = query.get(QueryParams.compositeQuery);
+	if (!raw) {
+		throw new Error('compositeQuery not found in URL');
+	}
+	return JSON.parse(decodeURIComponent(raw));
+};
+
+describe('useCreateAlerts', () => {
+	let capturedOnSuccess:
+		| ((data: { data: { compositeQuery: unknown } }) => void)
+		| null = null;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		capturedOnSuccess = null;
+
+		mockUseSelector.mockReturnValue({ selectedTime: '1h' });
+
+		mockUseMutation.mockReturnValue(({
+			mutate: jest.fn((_payload, opts) => {
+				capturedOnSuccess = opts?.onSuccess ?? null;
+			}),
+		} as unknown) as ReturnType<typeof useMutation>);
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(window as any).open = jest.fn();
+	});
+
+	it('preserves widget queryType when the API response maps to a different queryType', () => {
+		mockMapQueryDataFromApi.mockReturnValue({
+			queryType: EQueryType.QUERY_BUILDER,
+			builder: { queryData: [], queryFormulas: [] },
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
+
+		const widget = buildWidget(EQueryType.CLICKHOUSE);
+		const { result } = renderHook(() => useCreateAlerts(widget));
+
+		act(() => {
+			result.current();
+		});
+
+		expect(capturedOnSuccess).not.toBeNull();
+
+		act(() => {
+			capturedOnSuccess?.({ data: { compositeQuery: {} } });
+		});
+
+		const composite = getCompositeQueryFromLastOpen();
+		expect(composite.queryType).toBe(EQueryType.CLICKHOUSE);
+	});
+
+	it('preserves promql queryType through the alert navigation URL', () => {
+		mockMapQueryDataFromApi.mockReturnValue({
+			queryType: EQueryType.QUERY_BUILDER,
+			builder: { queryData: [], queryFormulas: [] },
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
+
+		const widget = buildWidget(EQueryType.PROM);
+		const { result } = renderHook(() => useCreateAlerts(widget));
+
+		act(() => {
+			result.current();
+		});
+		act(() => {
+			capturedOnSuccess?.({ data: { compositeQuery: {} } });
+		});
+
+		const composite = getCompositeQueryFromLastOpen();
+		expect(composite.queryType).toBe(EQueryType.PROM);
+	});
+
+	it('falls back to the mapped queryType when widget has no queryType', () => {
+		mockMapQueryDataFromApi.mockReturnValue({
+			queryType: EQueryType.QUERY_BUILDER,
+			builder: { queryData: [], queryFormulas: [] },
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
+
+		const widget = buildWidget(undefined);
+		const { result } = renderHook(() => useCreateAlerts(widget));
+
+		act(() => {
+			result.current();
+		});
+		act(() => {
+			capturedOnSuccess?.({ data: { compositeQuery: {} } });
+		});
+
+		const composite = getCompositeQueryFromLastOpen();
+		// No override, so the mapped value wins.
+		expect(composite.queryType).toBe(EQueryType.QUERY_BUILDER);
+	});
+
+	it('does nothing when widget is undefined', () => {
+		const { result } = renderHook(() => useCreateAlerts(undefined));
+
+		act(() => {
+			result.current();
+		});
+
+		const mutateCalls = (mockUseMutation.mock.results[0].value as ReturnType<
+			typeof useMutation
+		>).mutate as jest.Mock;
+		expect(mutateCalls).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/hooks/queryBuilder/useCreateAlerts.tsx
+++ b/frontend/src/hooks/queryBuilder/useCreateAlerts.tsx
@@ -76,6 +76,9 @@ const useCreateAlerts = (widget?: Widgets, caller?: string): VoidFunction => {
 		queryRangeMutation.mutate(queryPayload, {
 			onSuccess: (data) => {
 				const updatedQuery = mapQueryDataFromApi(data.data.compositeQuery);
+				if (widget.query.queryType) {
+					updatedQuery.queryType = widget.query.queryType;
+				}
 				// If widget has a y-axis unit, set it to the updated query if it is not already set
 				if (widget.yAxisUnit && !isEmpty(widget.yAxisUnit)) {
 					updatedQuery.unit = widget.yAxisUnit;


### PR DESCRIPTION
### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

When creating an alert when viewing or editing a panel, the query does not get defaulted to the panel query if the query type is not builder query. This PR fixes that.

There is an issue with substitute_vars api for clickhouse sql and promql. That is something found while testing this change out. Created issue here - https://github.com/SigNoz/engineering-pod/issues/4724

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

https://github.com/user-attachments/assets/3a4f7a51-7be1-4f42-94b3-b74691ac3061

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/signoz/issues/11020

---

### ✅ Change Type
_Select all that apply_

- [x] 🐛 Bug fix