### PR TITLE
feat: show related values section, always

### DIFF
--- a/frontend/src/components/NewSelect/CustomMultiSelect.tsx
+++ b/frontend/src/components/NewSelect/CustomMultiSelect.tsx
@@ -1445,14 +1445,18 @@ const CustomMultiSelect: React.FC<CustomMultiSelectProps> = ({
 
 	// Custom dropdown render with sections support
 	const customDropdownRender = useCallback((): React.ReactElement => {
-		// When ALL is selected, skip prioritization so section headers
-		// (e.g. "Related values" / "All values") remain visible instead of
-		// being collapsed away by every option getting hoisted to the top.
+		// When ALL is selected and the options contain sections (groups),
+		// skip prioritization so section headers (e.g. "Related values" /
+		// "All values") remain visible instead of being collapsed away by
+		// every option getting hoisted to the top. For flat option lists we
+		// still prioritize so selected/synthesized values stay rendered.
+		const hasSections = filteredOptions.some(
+			(opt) => 'options' in opt && Array.isArray(opt.options),
+		);
 		const shouldPrioritize =
 			selectedValues.length > 0 &&
 			isEmpty(searchText) &&
-			!allOptionShown &&
-			!isAllSelected;
+			!(hasSections && (allOptionShown || isAllSelected));
 
 		const processedOptions = shouldPrioritize
 			? prioritizeOrAddOptionForMultiSelect(filteredOptions, selectedValues)

--- a/frontend/src/components/NewSelect/CustomMultiSelect.tsx
+++ b/frontend/src/components/NewSelect/CustomMultiSelect.tsx
@@ -1445,11 +1445,18 @@ const CustomMultiSelect: React.FC<CustomMultiSelectProps> = ({
 
 	// Custom dropdown render with sections support
 	const customDropdownRender = useCallback((): React.ReactElement => {
-		// Process options based on current search
-		const processedOptions =
-			selectedValues.length > 0 && isEmpty(searchText)
-				? prioritizeOrAddOptionForMultiSelect(filteredOptions, selectedValues)
-				: filteredOptions;
+		// When ALL is selected, skip prioritization so section headers
+		// (e.g. "Related values" / "All values") remain visible instead of
+		// being collapsed away by every option getting hoisted to the top.
+		const shouldPrioritize =
+			selectedValues.length > 0 &&
+			isEmpty(searchText) &&
+			!allOptionShown &&
+			!isAllSelected;
+
+		const processedOptions = shouldPrioritize
+			? prioritizeOrAddOptionForMultiSelect(filteredOptions, selectedValues)
+			: filteredOptions;
 
 		const { sectionOptions, nonSectionOptions } = splitOptions(processedOptions);
 
@@ -1747,6 +1754,8 @@ const CustomMultiSelect: React.FC<CustomMultiSelectProps> = ({
 	}, [
 		selectedValues,
 		searchText,
+		allOptionShown,
+		isAllSelected,
 		filteredOptions,
 		splitOptions,
 		isLabelPresent,

--- a/frontend/src/components/NewSelect/__test__/CustomMultiSelect.test.tsx
+++ b/frontend/src/components/NewSelect/__test__/CustomMultiSelect.test.tsx
@@ -6,6 +6,7 @@ import {
 	screen,
 	waitFor,
 } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import CustomMultiSelect from '../CustomMultiSelect';
 
@@ -286,6 +287,7 @@ describe('CustomMultiSelect Component', () => {
 
 	describe('section visibility when ALL is selected', () => {
 		it('keeps group headers visible when every grouped value is selected', async () => {
+			const user = userEvent.setup();
 			renderWithVirtuoso(
 				<CustomMultiSelect
 					options={mockGroupedOptions}
@@ -293,7 +295,7 @@ describe('CustomMultiSelect Component', () => {
 				/>,
 			);
 
-			fireEvent.mouseDown(screen.getByRole('combobox'));
+			await user.click(screen.getByRole('combobox'));
 
 			await waitFor(() => {
 				expect(screen.getByText('Group 1')).toBeInTheDocument();
@@ -302,6 +304,7 @@ describe('CustomMultiSelect Component', () => {
 		});
 
 		it('keeps every grouped option visible within its section when all are selected', async () => {
+			const user = userEvent.setup();
 			renderWithVirtuoso(
 				<CustomMultiSelect
 					options={mockGroupedOptions}
@@ -309,7 +312,7 @@ describe('CustomMultiSelect Component', () => {
 				/>,
 			);
 
-			fireEvent.mouseDown(screen.getByRole('combobox'));
+			await user.click(screen.getByRole('combobox'));
 
 			await waitFor(() => {
 				const group1Region = screen.getByRole('group', {
@@ -329,6 +332,7 @@ describe('CustomMultiSelect Component', () => {
 		});
 
 		it('keeps group headers visible when value is the ALL sentinel', async () => {
+			const user = userEvent.setup();
 			renderWithVirtuoso(
 				<CustomMultiSelect
 					options={mockGroupedOptions}
@@ -336,7 +340,7 @@ describe('CustomMultiSelect Component', () => {
 				/>,
 			);
 
-			fireEvent.mouseDown(screen.getByRole('combobox'));
+			await user.click(screen.getByRole('combobox'));
 
 			await waitFor(() => {
 				expect(screen.getByText('Group 1')).toBeInTheDocument();

--- a/frontend/src/components/NewSelect/__test__/CustomMultiSelect.test.tsx
+++ b/frontend/src/components/NewSelect/__test__/CustomMultiSelect.test.tsx
@@ -283,4 +283,65 @@ describe('CustomMultiSelect Component', () => {
 		// When all options are selected, component shows ALL tag instead
 		expect(screen.getByText('ALL')).toBeInTheDocument();
 	});
+
+	describe('section visibility when ALL is selected', () => {
+		it('keeps group headers visible when every grouped value is selected', async () => {
+			renderWithVirtuoso(
+				<CustomMultiSelect
+					options={mockGroupedOptions}
+					value={['g1-option1', 'g1-option2', 'g2-option1', 'g2-option2']}
+				/>,
+			);
+
+			fireEvent.mouseDown(screen.getByRole('combobox'));
+
+			await waitFor(() => {
+				expect(screen.getByText('Group 1')).toBeInTheDocument();
+				expect(screen.getByText('Group 2')).toBeInTheDocument();
+			});
+		});
+
+		it('keeps every grouped option visible within its section when all are selected', async () => {
+			renderWithVirtuoso(
+				<CustomMultiSelect
+					options={mockGroupedOptions}
+					value={['g1-option1', 'g1-option2', 'g2-option1', 'g2-option2']}
+				/>,
+			);
+
+			fireEvent.mouseDown(screen.getByRole('combobox'));
+
+			await waitFor(() => {
+				const group1Region = screen.getByRole('group', {
+					name: 'Group 1 options',
+				});
+				const group2Region = screen.getByRole('group', {
+					name: 'Group 2 options',
+				});
+
+				// Each option stays inside its original section rather than being
+				// hoisted into a flat selected-first list.
+				expect(group1Region).toHaveTextContent('Group 1 - Option 1');
+				expect(group1Region).toHaveTextContent('Group 1 - Option 2');
+				expect(group2Region).toHaveTextContent('Group 2 - Option 1');
+				expect(group2Region).toHaveTextContent('Group 2 - Option 2');
+			});
+		});
+
+		it('keeps group headers visible when value is the ALL sentinel', async () => {
+			renderWithVirtuoso(
+				<CustomMultiSelect
+					options={mockGroupedOptions}
+					value={('__ALL__' as unknown) as string[]}
+				/>,
+			);
+
+			fireEvent.mouseDown(screen.getByRole('combobox'));
+
+			await waitFor(() => {
+				expect(screen.getByText('Group 1')).toBeInTheDocument();
+				expect(screen.getByText('Group 2')).toBeInTheDocument();
+			});
+		});
+	});
 });


### PR DESCRIPTION
### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

When ALL is selected for dynamic variables, we now show Related Values along with All Values as well. It is just not on individual selection.


#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

<img width="1721" height="964" alt="image" src="https://github.com/user-attachments/assets/694becf9-a84a-4d84-a5ce-d7cd2cfd126c" />



#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/signoz/issues/9077

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature