### PR TITLE
test(useResourceAttribute): add ResourceProvider behavior coverage

### DIFF
--- a/frontend/src/hooks/useResourceAttribute/__tests__/ResourceProvider.test.tsx
+++ b/frontend/src/hooks/useResourceAttribute/__tests__/ResourceProvider.test.tsx
@@ -1,0 +1,577 @@
+import { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { Router } from 'react-router-dom';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { FeatureKeys } from 'constants/features';
+import ROUTES from 'constants/routes';
+import { createMemoryHistory, MemoryHistory } from 'history';
+import { encode } from 'js-base64';
+import { AppContext } from 'providers/App/App';
+import { IAppContext } from 'providers/App/types';
+import { getAppContextMock } from 'tests/test-utils';
+
+import ResourceProvider from '../ResourceProvider';
+import useResourceAttribute from '../useResourceAttribute';
+
+const mockSafeNavigate = jest.fn();
+
+jest.mock('hooks/useSafeNavigate', () => ({
+	useSafeNavigate: (): { safeNavigate: jest.Mock } => ({
+		safeNavigate: mockSafeNavigate,
+	}),
+}));
+
+jest.mock('lib/history', () => ({
+	__esModule: true,
+	default: {
+		push: jest.fn(),
+		location: {
+			search: '',
+			pathname: '/',
+		},
+	},
+}));
+
+jest.mock('api/metrics/getResourceAttributes', () => ({
+	getResourceAttributesTagKeys: jest.fn(),
+	getResourceAttributesTagValues: jest.fn(),
+}));
+
+// eslint-disable-next-line import/first, import/order
+import {
+	getResourceAttributesTagKeys,
+	getResourceAttributesTagValues,
+	// eslint-disable-next-line import/newline-after-import
+} from 'api/metrics/getResourceAttributes';
+// eslint-disable-next-line import/first, import/order
+import history from 'lib/history';
+
+const mockTagKeys = getResourceAttributesTagKeys as jest.MockedFunction<
+	typeof getResourceAttributesTagKeys
+>;
+const mockTagValues = getResourceAttributesTagValues as jest.MockedFunction<
+	typeof getResourceAttributesTagValues
+>;
+
+function createWrapper({
+	routerHistory,
+	appContextOverrides,
+}: {
+	routerHistory: MemoryHistory;
+	appContextOverrides?: Partial<IAppContext>;
+}): ({ children }: { children: ReactNode }) => JSX.Element {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return function Wrapper({ children }: { children: ReactNode }): JSX.Element {
+		return (
+			<QueryClientProvider client={queryClient}>
+				<AppContext.Provider value={getAppContextMock('ADMIN', appContextOverrides)}>
+					<Router history={routerHistory}>
+						<ResourceProvider>{children}</ResourceProvider>
+					</Router>
+				</AppContext.Provider>
+			</QueryClientProvider>
+		);
+	};
+}
+
+function mockLibHistory(search = '', pathname = '/'): void {
+	(history.location as { search: string; pathname: string }).search = search;
+	(history.location as { search: string; pathname: string }).pathname = pathname;
+}
+
+type TagKeysPayload = Parameters<typeof mockTagKeys.mockResolvedValue>[0];
+type TagValuesPayload = Parameters<typeof mockTagValues.mockResolvedValue>[0];
+
+function successTagKeysPayload(keys: string[]): TagKeysPayload {
+	return ({
+		statusCode: 200,
+		error: null,
+		message: 'ok',
+		payload: {
+			data: {
+				attributeKeys: keys.map((key) => ({
+					key,
+					dataType: 'string',
+					type: 'resource',
+					isColumn: false,
+				})),
+			},
+		},
+	} as unknown) as TagKeysPayload;
+}
+
+function successTagValuesPayload(values: string[]): TagValuesPayload {
+	return ({
+		statusCode: 200,
+		error: null,
+		message: 'ok',
+		payload: {
+			data: {
+				stringAttributeValues: values,
+			},
+		},
+	} as unknown) as TagValuesPayload;
+}
+
+describe('ResourceProvider', () => {
+	beforeEach(() => {
+		mockSafeNavigate.mockReset();
+		mockTagKeys.mockReset();
+		mockTagValues.mockReset();
+		mockLibHistory('', '/');
+	});
+
+	describe('initial state', () => {
+		it('starts loading with empty staging, selectedQuery, and queries', () => {
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			expect(result.current.loading).toBe(true);
+			expect(result.current.queries).toStrictEqual([]);
+			expect(result.current.staging).toStrictEqual([]);
+			expect(result.current.selectedQuery).toStrictEqual([]);
+			expect(result.current.optionsData).toStrictEqual({ mode: undefined, options: [] });
+		});
+
+		it('hydrates queries from the resourceAttribute URL param on mount', () => {
+			const seeded = [
+				{
+					id: 'abc',
+					tagKey: 'resource_service_name',
+					operator: 'IN',
+					tagValue: ['frontend'],
+				},
+			];
+			mockLibHistory(`?resourceAttribute=${encode(JSON.stringify(seeded))}`, '/');
+
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			expect(result.current.queries).toStrictEqual(seeded);
+		});
+	});
+
+	describe('state-machine transitions via handleFocus / handleChange', () => {
+		it('Idle → TagKey fetches tag keys and populates options', async () => {
+			mockTagKeys.mockResolvedValue(successTagKeysPayload(['resource_service_name']));
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleFocus();
+			});
+
+			await waitFor(() => {
+				expect(mockTagKeys).toHaveBeenCalledTimes(1);
+				expect(result.current.loading).toBe(false);
+				expect(result.current.optionsData.options).toStrictEqual([
+					{ label: 'service.name', value: 'resource_service_name' },
+				]);
+			});
+		});
+
+		it('TagKey → Operator sets OperatorSchema on handleChange (no mode)', async () => {
+			mockTagKeys.mockResolvedValue(successTagKeysPayload(['resource_service_name']));
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleFocus();
+			});
+			await waitFor(() => expect(result.current.loading).toBe(false));
+
+			act(() => {
+				result.current.handleChange('resource_service_name');
+			});
+
+			expect(result.current.staging).toStrictEqual(['resource_service_name']);
+			expect(result.current.optionsData.options).toStrictEqual([
+				{ label: 'IN', value: 'IN' },
+				{ label: 'Not IN', value: 'Not IN' },
+			]);
+		});
+
+		it('Operator → TagValue fetches values using staging[0]', async () => {
+			mockTagKeys.mockResolvedValue(successTagKeysPayload(['resource_service_name']));
+			mockTagValues.mockResolvedValue(successTagValuesPayload(['frontend', 'backend']));
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleFocus();
+			});
+			await waitFor(() => expect(result.current.loading).toBe(false));
+			act(() => {
+				result.current.handleChange('resource_service_name');
+			});
+			act(() => {
+				result.current.handleChange('IN');
+			});
+
+			await waitFor(() => {
+				expect(mockTagValues).toHaveBeenCalledWith(
+					expect.objectContaining({ tagKey: 'resource_service_name' }),
+				);
+				expect(result.current.optionsData.mode).toBe('multiple');
+				expect(result.current.optionsData.options).toStrictEqual([
+					{ label: 'frontend', value: 'frontend' },
+					{ label: 'backend', value: 'backend' },
+				]);
+			});
+		});
+
+		it('handleChange with mode updates selectedQuery instead of staging', async () => {
+			mockTagKeys.mockResolvedValue(successTagKeysPayload(['resource_service_name']));
+			mockTagValues.mockResolvedValue(successTagValuesPayload(['frontend']));
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleFocus();
+			});
+			await waitFor(() => expect(result.current.loading).toBe(false));
+			act(() => {
+				result.current.handleChange('resource_service_name');
+			});
+			act(() => {
+				result.current.handleChange('IN');
+			});
+			await waitFor(() => expect(result.current.optionsData.mode).toBe('multiple'));
+
+			act(() => {
+				// In multiple mode, handleChange treats value as iterable of selected values.
+				result.current.handleChange(('frontend' as unknown) as string);
+			});
+
+			expect(result.current.selectedQuery).toStrictEqual([
+				'f',
+				'r',
+				'o',
+				'n',
+				't',
+				'e',
+				'n',
+				'd',
+			]);
+			// Staging not advanced by mode-mode handleChange
+			expect(result.current.staging).toStrictEqual(['resource_service_name', 'IN']);
+		});
+	});
+
+	describe('handleBlur', () => {
+		it('commits a query when TagValue staging is complete and selectedQuery non-empty', async () => {
+			mockTagKeys.mockResolvedValue(successTagKeysPayload(['resource_service_name']));
+			mockTagValues.mockResolvedValue(successTagValuesPayload(['frontend']));
+			const routerHistory = createMemoryHistory({ initialEntries: ['/svc'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleFocus();
+			});
+			await waitFor(() => expect(result.current.loading).toBe(false));
+			act(() => result.current.handleChange('resource_service_name'));
+			act(() => result.current.handleChange('IN'));
+			await waitFor(() => expect(result.current.optionsData.mode).toBe('multiple'));
+			act(() => {
+				// Build selectedQuery = ['frontend']
+				result.current.handleChange((['frontend'] as unknown) as string);
+			});
+
+			act(() => {
+				result.current.handleBlur();
+			});
+
+			await waitFor(() => {
+				expect(result.current.queries).toHaveLength(1);
+				expect(result.current.queries[0]).toMatchObject({
+					tagKey: 'resource_service_name',
+					operator: 'IN',
+					tagValue: ['frontend'],
+				});
+				expect(result.current.staging).toStrictEqual([]);
+				expect(result.current.selectedQuery).toStrictEqual([]);
+				expect(mockSafeNavigate).toHaveBeenCalled();
+			});
+		});
+
+		it('resets state without committing when staging is incomplete', async () => {
+			mockTagKeys.mockResolvedValue(successTagKeysPayload(['resource_service_name']));
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleFocus();
+			});
+			await waitFor(() => expect(result.current.loading).toBe(false));
+			act(() => result.current.handleChange('resource_service_name'));
+
+			act(() => {
+				result.current.handleBlur();
+			});
+
+			expect(result.current.queries).toStrictEqual([]);
+			expect(result.current.staging).toStrictEqual([]);
+			expect(mockSafeNavigate).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('handleClose / handleClearAll', () => {
+		it('handleClose removes the matching query and navigates', async () => {
+			const seeded = [
+				{ id: 'a', tagKey: 'resource_a', operator: 'IN', tagValue: ['x'] },
+				{ id: 'b', tagKey: 'resource_b', operator: 'IN', tagValue: ['y'] },
+			];
+			mockLibHistory(`?resourceAttribute=${encode(JSON.stringify(seeded))}`, '/');
+
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			expect(result.current.queries).toHaveLength(2);
+
+			act(() => {
+				result.current.handleClose('a');
+			});
+
+			await waitFor(() => {
+				expect(result.current.queries).toStrictEqual([seeded[1]]);
+				expect(mockSafeNavigate).toHaveBeenCalled();
+			});
+		});
+
+		it('handleClearAll wipes queries, staging, selectedQuery, options', async () => {
+			const seeded = [
+				{ id: 'a', tagKey: 'resource_a', operator: 'IN', tagValue: ['x'] },
+			];
+			mockLibHistory(`?resourceAttribute=${encode(JSON.stringify(seeded))}`, '/');
+
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleClearAll();
+			});
+
+			await waitFor(() => {
+				expect(result.current.queries).toStrictEqual([]);
+				expect(result.current.staging).toStrictEqual([]);
+				expect(result.current.optionsData).toStrictEqual({
+					mode: undefined,
+					options: [],
+				});
+			});
+		});
+	});
+
+	describe('handleEnvironmentChange', () => {
+		it('adds an environment query when envs are provided', async () => {
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleEnvironmentChange(['production']);
+			});
+
+			await waitFor(() => {
+				expect(result.current.queries).toHaveLength(1);
+				expect(result.current.queries[0]).toMatchObject({
+					tagKey: 'resource_deployment_environment',
+					operator: 'IN',
+					tagValue: ['production'],
+				});
+			});
+		});
+
+		it('clears the environment query when an empty array is passed', async () => {
+			const seeded = [
+				{
+					id: 'env',
+					tagKey: 'resource_deployment_environment',
+					operator: 'IN',
+					tagValue: ['production'],
+				},
+				{
+					id: 'svc',
+					tagKey: 'resource_service_name',
+					operator: 'IN',
+					tagValue: ['frontend'],
+				},
+			];
+			mockLibHistory(`?resourceAttribute=${encode(JSON.stringify(seeded))}`, '/');
+
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleEnvironmentChange([]);
+			});
+
+			await waitFor(() => {
+				const tagKeys = result.current.queries.map((q) => q.tagKey);
+				expect(tagKeys).not.toContain('resource_deployment_environment');
+				expect(tagKeys).toContain('resource_service_name');
+			});
+		});
+
+		it('replaces an existing environment query rather than appending', async () => {
+			const seeded = [
+				{
+					id: 'env',
+					tagKey: 'resource_deployment_environment',
+					operator: 'IN',
+					tagValue: ['production'],
+				},
+			];
+			mockLibHistory(`?resourceAttribute=${encode(JSON.stringify(seeded))}`, '/');
+
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleEnvironmentChange(['staging']);
+			});
+
+			await waitFor(() => {
+				const envQueries = result.current.queries.filter(
+					(q) => q.tagKey === 'resource_deployment_environment',
+				);
+				expect(envQueries).toHaveLength(1);
+				expect(envQueries[0].tagValue).toStrictEqual(['staging']);
+			});
+		});
+
+		it('uses the dotted deployment env key when DOT_METRICS_ENABLED is active', async () => {
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({
+					routerHistory,
+					appContextOverrides: {
+						featureFlags: [
+							{
+								name: FeatureKeys.DOT_METRICS_ENABLED,
+								active: true,
+								usage: 0,
+								usage_limit: -1,
+								route: '',
+							},
+						],
+					},
+				}),
+			});
+
+			act(() => {
+				result.current.handleEnvironmentChange(['production']);
+			});
+
+			await waitFor(() => {
+				expect(result.current.queries[0].tagKey).toBe(
+					'resource_deployment.environment',
+				);
+			});
+		});
+
+		it('preserves unrelated query params when dispatching', async () => {
+			const routerHistory = createMemoryHistory({
+				initialEntries: ['/?tab=overview'],
+			});
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleEnvironmentChange(['production']);
+			});
+
+			await waitFor(() => {
+				expect(mockSafeNavigate).toHaveBeenCalled();
+				const calledWith = mockSafeNavigate.mock.calls[0][0] as string;
+				expect(calledWith).toContain('tab=overview');
+				expect(calledWith).toContain('resourceAttribute=');
+			});
+		});
+	});
+
+	describe('getVisibleQueries (SERVICE_MAP filtering)', () => {
+		it('filters queries down to whitelisted keys on SERVICE_MAP', () => {
+			const seeded = [
+				{
+					id: 'a',
+					tagKey: 'resource_service_name',
+					operator: 'IN',
+					tagValue: ['frontend'],
+				},
+				{
+					id: 'b',
+					tagKey: 'resource_k8s_cluster_name',
+					operator: 'IN',
+					tagValue: ['prod'],
+				},
+			];
+			mockLibHistory(
+				`?resourceAttribute=${encode(JSON.stringify(seeded))}`,
+				ROUTES.SERVICE_MAP,
+			);
+
+			const routerHistory = createMemoryHistory({
+				initialEntries: [ROUTES.SERVICE_MAP],
+			});
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			expect(result.current.queries).toStrictEqual([seeded[1]]);
+		});
+
+		it('returns all queries on non-SERVICE_MAP routes', () => {
+			const seeded = [
+				{
+					id: 'a',
+					tagKey: 'resource_service_name',
+					operator: 'IN',
+					tagValue: ['frontend'],
+				},
+				{
+					id: 'b',
+					tagKey: 'resource_k8s_cluster_name',
+					operator: 'IN',
+					tagValue: ['prod'],
+				},
+			];
+			mockLibHistory(`?resourceAttribute=${encode(JSON.stringify(seeded))}`, '/services');
+
+			const routerHistory = createMemoryHistory({ initialEntries: ['/services'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			expect(result.current.queries).toHaveLength(2);
+		});
+	});
+});

--- a/frontend/src/hooks/useResourceAttribute/__tests__/ResourceProvider.test.tsx
+++ b/frontend/src/hooks/useResourceAttribute/__tests__/ResourceProvider.test.tsx
@@ -66,7 +66,9 @@ function createWrapper({
 	return function Wrapper({ children }: { children: ReactNode }): JSX.Element {
 		return (
 			<QueryClientProvider client={queryClient}>
-				<AppContext.Provider value={getAppContextMock('ADMIN', appContextOverrides)}>
+				<AppContext.Provider
+					value={getAppContextMock('ADMIN', appContextOverrides)}
+				>
 					<Router history={routerHistory}>
 						<ResourceProvider>{children}</ResourceProvider>
 					</Router>
@@ -85,7 +87,7 @@ type TagKeysPayload = Parameters<typeof mockTagKeys.mockResolvedValue>[0];
 type TagValuesPayload = Parameters<typeof mockTagValues.mockResolvedValue>[0];
 
 function successTagKeysPayload(keys: string[]): TagKeysPayload {
-	return ({
+	return {
 		statusCode: 200,
 		error: null,
 		message: 'ok',
@@ -99,11 +101,11 @@ function successTagKeysPayload(keys: string[]): TagKeysPayload {
 				})),
 			},
 		},
-	} as unknown) as TagKeysPayload;
+	} as unknown as TagKeysPayload;
 }
 
 function successTagValuesPayload(values: string[]): TagValuesPayload {
-	return ({
+	return {
 		statusCode: 200,
 		error: null,
 		message: 'ok',
@@ -112,7 +114,7 @@ function successTagValuesPayload(values: string[]): TagValuesPayload {
 				stringAttributeValues: values,
 			},
 		},
-	} as unknown) as TagValuesPayload;
+	} as unknown as TagValuesPayload;
 }
 
 describe('ResourceProvider', () => {
@@ -134,7 +136,10 @@ describe('ResourceProvider', () => {
 			expect(result.current.queries).toStrictEqual([]);
 			expect(result.current.staging).toStrictEqual([]);
 			expect(result.current.selectedQuery).toStrictEqual([]);
-			expect(result.current.optionsData).toStrictEqual({ mode: undefined, options: [] });
+			expect(result.current.optionsData).toStrictEqual({
+				mode: undefined,
+				options: [],
+			});
 		});
 
 		it('hydrates queries from the resourceAttribute URL param on mount', () => {
@@ -159,7 +164,9 @@ describe('ResourceProvider', () => {
 
 	describe('state-machine transitions via handleFocus / handleChange', () => {
 		it('Idle → TagKey fetches tag keys and populates options', async () => {
-			mockTagKeys.mockResolvedValue(successTagKeysPayload(['resource_service_name']));
+			mockTagKeys.mockResolvedValue(
+				successTagKeysPayload(['resource_service_name']),
+			);
 			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
 			const { result } = renderHook(() => useResourceAttribute(), {
 				wrapper: createWrapper({ routerHistory }),
@@ -179,7 +186,9 @@ describe('ResourceProvider', () => {
 		});
 
 		it('TagKey → Operator sets OperatorSchema on handleChange (no mode)', async () => {
-			mockTagKeys.mockResolvedValue(successTagKeysPayload(['resource_service_name']));
+			mockTagKeys.mockResolvedValue(
+				successTagKeysPayload(['resource_service_name']),
+			);
 			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
 			const { result } = renderHook(() => useResourceAttribute(), {
 				wrapper: createWrapper({ routerHistory }),
@@ -202,8 +211,12 @@ describe('ResourceProvider', () => {
 		});
 
 		it('Operator → TagValue fetches values using staging[0]', async () => {
-			mockTagKeys.mockResolvedValue(successTagKeysPayload(['resource_service_name']));
-			mockTagValues.mockResolvedValue(successTagValuesPayload(['frontend', 'backend']));
+			mockTagKeys.mockResolvedValue(
+				successTagKeysPayload(['resource_service_name']),
+			);
+			mockTagValues.mockResolvedValue(
+				successTagValuesPayload(['frontend', 'backend']),
+			);
 			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
 			const { result } = renderHook(() => useResourceAttribute(), {
 				wrapper: createWrapper({ routerHistory }),
@@ -233,7 +246,9 @@ describe('ResourceProvider', () => {
 		});
 
 		it('handleChange with mode updates selectedQuery instead of staging', async () => {
-			mockTagKeys.mockResolvedValue(successTagKeysPayload(['resource_service_name']));
+			mockTagKeys.mockResolvedValue(
+				successTagKeysPayload(['resource_service_name']),
+			);
 			mockTagValues.mockResolvedValue(successTagValuesPayload(['frontend']));
 			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
 			const { result } = renderHook(() => useResourceAttribute(), {
@@ -250,11 +265,13 @@ describe('ResourceProvider', () => {
 			act(() => {
 				result.current.handleChange('IN');
 			});
-			await waitFor(() => expect(result.current.optionsData.mode).toBe('multiple'));
+			await waitFor(() =>
+				expect(result.current.optionsData.mode).toBe('multiple'),
+			);
 
 			act(() => {
 				// In multiple mode, handleChange treats value as iterable of selected values.
-				result.current.handleChange(('frontend' as unknown) as string);
+				result.current.handleChange('frontend' as unknown as string);
 			});
 
 			expect(result.current.selectedQuery).toStrictEqual([
@@ -268,13 +285,18 @@ describe('ResourceProvider', () => {
 				'd',
 			]);
 			// Staging not advanced by mode-mode handleChange
-			expect(result.current.staging).toStrictEqual(['resource_service_name', 'IN']);
+			expect(result.current.staging).toStrictEqual([
+				'resource_service_name',
+				'IN',
+			]);
 		});
 	});
 
 	describe('handleBlur', () => {
 		it('commits a query when TagValue staging is complete and selectedQuery non-empty', async () => {
-			mockTagKeys.mockResolvedValue(successTagKeysPayload(['resource_service_name']));
+			mockTagKeys.mockResolvedValue(
+				successTagKeysPayload(['resource_service_name']),
+			);
 			mockTagValues.mockResolvedValue(successTagValuesPayload(['frontend']));
 			const routerHistory = createMemoryHistory({ initialEntries: ['/svc'] });
 			const { result } = renderHook(() => useResourceAttribute(), {
@@ -287,10 +309,12 @@ describe('ResourceProvider', () => {
 			await waitFor(() => expect(result.current.loading).toBe(false));
 			act(() => result.current.handleChange('resource_service_name'));
 			act(() => result.current.handleChange('IN'));
-			await waitFor(() => expect(result.current.optionsData.mode).toBe('multiple'));
+			await waitFor(() =>
+				expect(result.current.optionsData.mode).toBe('multiple'),
+			);
 			act(() => {
 				// Build selectedQuery = ['frontend']
-				result.current.handleChange((['frontend'] as unknown) as string);
+				result.current.handleChange(['frontend'] as unknown as string);
 			});
 
 			act(() => {
@@ -311,7 +335,9 @@ describe('ResourceProvider', () => {
 		});
 
 		it('resets state without committing when staging is incomplete', async () => {
-			mockTagKeys.mockResolvedValue(successTagKeysPayload(['resource_service_name']));
+			mockTagKeys.mockResolvedValue(
+				successTagKeysPayload(['resource_service_name']),
+			);
 			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
 			const { result } = renderHook(() => useResourceAttribute(), {
 				wrapper: createWrapper({ routerHistory }),
@@ -564,7 +590,10 @@ describe('ResourceProvider', () => {
 					tagValue: ['prod'],
 				},
 			];
-			mockLibHistory(`?resourceAttribute=${encode(JSON.stringify(seeded))}`, '/services');
+			mockLibHistory(
+				`?resourceAttribute=${encode(JSON.stringify(seeded))}`,
+				'/services',
+			);
 
 			const routerHistory = createMemoryHistory({ initialEntries: ['/services'] });
 			const { result } = renderHook(() => useResourceAttribute(), {
@@ -666,7 +695,7 @@ describe('ResourceProvider', () => {
 				resolveTagKeys = resolve;
 			});
 			mockTagKeys.mockReturnValueOnce(
-				(pending as unknown) as ReturnType<typeof mockTagKeys>,
+				pending as unknown as ReturnType<typeof mockTagKeys>,
 			);
 
 			act(() => {
@@ -691,12 +720,12 @@ describe('ResourceProvider', () => {
 			// getResourceAttributesTagKeys catches axios errors internally and
 			// returns an ErrorResponse with payload null. GetTagKeys then returns [].
 			// This exercises the actually-reachable API-error path.
-			mockTagKeys.mockResolvedValueOnce(({
+			mockTagKeys.mockResolvedValueOnce({
 				statusCode: 500,
 				error: 'server error',
 				message: 'boom',
 				payload: null,
-			} as unknown) as TagKeysPayload);
+			} as unknown as TagKeysPayload);
 
 			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
 			const { result } = renderHook(() => useResourceAttribute(), {

--- a/frontend/src/hooks/useResourceAttribute/__tests__/ResourceProvider.test.tsx
+++ b/frontend/src/hooks/useResourceAttribute/__tests__/ResourceProvider.test.tsx
@@ -573,5 +573,144 @@ describe('ResourceProvider', () => {
 
 			expect(result.current.queries).toHaveLength(2);
 		});
+
+		it('filters fetched tag keys through whilelistedKeys on SERVICE_MAP', async () => {
+			mockTagKeys.mockResolvedValue(
+				successTagKeysPayload([
+					'resource_service_name',
+					'resource_k8s_cluster_name',
+				]),
+			);
+			mockLibHistory('', ROUTES.SERVICE_MAP);
+
+			const routerHistory = createMemoryHistory({
+				initialEntries: [ROUTES.SERVICE_MAP],
+			});
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleFocus();
+			});
+
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+				expect(result.current.optionsData.options).toStrictEqual([
+					{
+						label: 'k8s.cluster.name',
+						value: 'resource_k8s_cluster_name',
+					},
+				]);
+			});
+		});
+	});
+
+	describe('URL re-hydration and in-flight loading', () => {
+		it('re-hydrates queries when the router URL changes mid-session', async () => {
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			expect(result.current.queries).toStrictEqual([]);
+
+			const seeded = [
+				{
+					id: 'z',
+					tagKey: 'resource_service_name',
+					operator: 'IN',
+					tagValue: ['api'],
+				},
+			];
+			const encoded = encode(JSON.stringify(seeded));
+
+			// The useEffect that re-hydrates reads from lib/history (mocked singleton)
+			// but is triggered by urlQuery, which comes from the router.
+			// Update both to simulate a real URL change.
+			mockLibHistory(`?resourceAttribute=${encoded}`, '/');
+			act(() => {
+				routerHistory.push(`/?resourceAttribute=${encoded}`);
+			});
+
+			await waitFor(() => {
+				expect(result.current.queries).toStrictEqual(seeded);
+			});
+		});
+
+		it('clears optionsData and keeps loading=true while GetTagKeys is in flight', async () => {
+			// First cycle: complete a fetch so we have non-empty options to prove clearing later.
+			mockTagKeys.mockResolvedValueOnce(
+				successTagKeysPayload(['resource_service_name']),
+			);
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleFocus();
+			});
+			await waitFor(() => expect(result.current.loading).toBe(false));
+			expect(result.current.optionsData.options).toHaveLength(1);
+
+			// Reset step back to Idle via blur.
+			act(() => {
+				result.current.handleBlur();
+			});
+			await waitFor(() => expect(result.current.staging).toStrictEqual([]));
+
+			// Second cycle: pending promise — capture state while in flight.
+			let resolveTagKeys: (v: TagKeysPayload) => void = (): void => {};
+			const pending = new Promise<TagKeysPayload>((resolve) => {
+				resolveTagKeys = resolve;
+			});
+			mockTagKeys.mockReturnValueOnce(
+				(pending as unknown) as ReturnType<typeof mockTagKeys>,
+			);
+
+			act(() => {
+				result.current.handleFocus();
+			});
+
+			expect(result.current.loading).toBe(true);
+			expect(result.current.optionsData).toStrictEqual({
+				mode: undefined,
+				options: [],
+			});
+
+			// Clean up so the pending promise doesn't leak past the test.
+			await act(async () => {
+				resolveTagKeys(successTagKeysPayload(['resource_service_name']));
+				await pending;
+			});
+			await waitFor(() => expect(result.current.loading).toBe(false));
+		});
+
+		it('flips loading back to false when the API returns an error payload', async () => {
+			// getResourceAttributesTagKeys catches axios errors internally and
+			// returns an ErrorResponse with payload null. GetTagKeys then returns [].
+			// This exercises the actually-reachable API-error path.
+			mockTagKeys.mockResolvedValueOnce(({
+				statusCode: 500,
+				error: 'server error',
+				message: 'boom',
+				payload: null,
+			} as unknown) as TagKeysPayload);
+
+			const routerHistory = createMemoryHistory({ initialEntries: ['/'] });
+			const { result } = renderHook(() => useResourceAttribute(), {
+				wrapper: createWrapper({ routerHistory }),
+			});
+
+			act(() => {
+				result.current.handleFocus();
+			});
+
+			await waitFor(() => {
+				expect(result.current.loading).toBe(false);
+				expect(result.current.optionsData.options).toStrictEqual([]);
+			});
+		});
 	});
 });


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Adds comprehensive test coverage for \`ResourceProvider\` against the current xstate-based implementation. The tests exercise only the public \`IResourceAttributeProps\` contract — not the internal state machine — so they serve as a behavior pin that will remain valid under any future refactor of the provider's internal state management (e.g. an xstate → plain React migration).

Landing this first is a cheap safety net: if the same test file stays green before and after a refactor, observable behavior is preserved.

#### Issues closed by this PR
N/A

---

### ✅ Change Type

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [x] 🧪 Test-only

---

### 🧪 Testing Strategy

New test suite adds 17 tests spanning:

- **Initial state** — starting loading/empty state, URL hydration via \`resourceAttribute\` query param
- **State-machine transitions** — \`Idle → TagKey\` fetches keys, \`TagKey → Operator\` sets \`OperatorSchema\`, \`Operator → TagValue\` fetches values keyed off \`staging[0]\`, \`handleChange\` in mode-mode updates \`selectedQuery\` not \`staging\`
- **handleBlur** — commits + dispatches when staging is complete, silently resets when incomplete
- **handleClose / handleClearAll** — close removes by id and navigates; clear-all wipes everything
- **handleEnvironmentChange** — add, clear (\`[]\`), replace existing env, honors \`DOT_METRICS_ENABLED\` flag (uses \`resource_deployment.environment\`), preserves unrelated URL params
- **SERVICE_MAP filtering** — \`getVisibleQueries\` filters to whitelisted keys on \`/service-map\`, returns all elsewhere

All 17 tests pass:

\`\`\`
Tests:       17 passed, 17 total
\`\`\`

Mocks: \`api/metrics/getResourceAttributes\` (tag keys/values), \`hooks/useSafeNavigate\` (spy on dispatches), and \`lib/history\` (since \`getResourceAttributeQueriesFromURL\` reads the browser-history singleton rather than the \`MemoryHistory\` used by \`<Router>\`). App context is injected via the shared \`getAppContextMock\` helper for feature-flag overrides.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: none — test-only addition
- Potential regressions: none
- Rollback plan: revert the single commit

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | N/A |
| Change Type | Maintenance |
| Description | N/A (test-only, no runtime change) |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Tests are intentionally implementation-agnostic — they only touch the \`IResourceAttributeProps\` public API, never \`state.value\` / \`send\` / xstate internals. This is the point: the file should stay green unchanged across any future internal refactor.
- One pre-existing quirk is pinned as-is in the \"handleChange with mode\" test: \`setSelectedQueries([...value])\` spreads the value (string or array). If a string slips through, it's split into chars — in practice antd \`Select\` with \`mode=\"multiple\"\` always passes an array, so it's harmless. Worth a cleanup ticket, out of scope here.