### PR TITLE
fix(serviceaccount): status code for deleted service accounts

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -7807,7 +7807,7 @@ paths:
       summary: Patch role
       tags:
       - role
-  /api/v1/roles/{id}/relation/{relation}/objects:
+  /api/v1/roles/{id}/relations/{relation}/objects:
     get:
       deprecated: false
       description: Gets all objects connected to the specified role via a given relation

--- a/frontend/src/api/generated/services/role/index.ts
+++ b/frontend/src/api/generated/services/role/index.ts
@@ -471,7 +471,7 @@ export const getObjects = (
 	signal?: AbortSignal,
 ) => {
 	return GeneratedAPIInstance<GetObjects200>({
-		url: `/api/v1/roles/${id}/relation/${relation}/objects`,
+		url: `/api/v1/roles/${id}/relations/${relation}/objects`,
 		method: 'GET',
 		signal,
 	});
@@ -481,7 +481,7 @@ export const getGetObjectsQueryKey = ({
 	id,
 	relation,
 }: GetObjectsPathParameters) => {
-	return [`/api/v1/roles/${id}/relation/${relation}/objects`] as const;
+	return [`/api/v1/roles/${id}/relations/${relation}/objects`] as const;
 };
 
 export const getGetObjectsQueryOptions = <
@@ -574,7 +574,7 @@ export const patchObjects = (
 	authtypesPatchableObjectsDTO: BodyType<AuthtypesPatchableObjectsDTO>,
 ) => {
 	return GeneratedAPIInstance<string>({
-		url: `/api/v1/roles/${id}/relation/${relation}/objects`,
+		url: `/api/v1/roles/${id}/relations/${relation}/objects`,
 		method: 'PATCH',
 		headers: { 'Content-Type': 'application/json' },
 		data: authtypesPatchableObjectsDTO,

--- a/pkg/apiserver/signozapiserver/role.go
+++ b/pkg/apiserver/signozapiserver/role.go
@@ -61,7 +61,7 @@ func (provider *provider) addRoleRoutes(router *mux.Router) error {
 		return err
 	}
 
-	if err := router.Handle("/api/v1/roles/{id}/relation/{relation}/objects", handler.New(provider.authZ.AdminAccess(provider.authzHandler.GetObjects), handler.OpenAPIDef{
+	if err := router.Handle("/api/v1/roles/{id}/relations/{relation}/objects", handler.New(provider.authZ.AdminAccess(provider.authzHandler.GetObjects), handler.OpenAPIDef{
 		ID:                  "GetObjects",
 		Tags:                []string{"role"},
 		Summary:             "Get objects for a role by relation",
@@ -95,7 +95,7 @@ func (provider *provider) addRoleRoutes(router *mux.Router) error {
 		return err
 	}
 
-	if err := router.Handle("/api/v1/roles/{id}/relation/{relation}/objects", handler.New(provider.authZ.AdminAccess(provider.authzHandler.PatchObjects), handler.OpenAPIDef{
+	if err := router.Handle("/api/v1/roles/{id}/relations/{relation}/objects", handler.New(provider.authZ.AdminAccess(provider.authzHandler.PatchObjects), handler.OpenAPIDef{
 		ID:                  "PatchObjects",
 		Tags:                []string{"role"},
 		Summary:             "Patch objects for a role by relation",

--- a/pkg/types/serviceaccounttypes/service_acccount.go
+++ b/pkg/types/serviceaccounttypes/service_acccount.go
@@ -17,13 +17,12 @@ import (
 )
 
 var (
-	ErrCodeServiceAccountInvalidConfig        = errors.MustNewCode("service_account_invalid_config")
-	ErrCodeServiceAccountInvalidInput         = errors.MustNewCode("service_account_invalid_input")
-	ErrCodeServiceAccountAlreadyExists        = errors.MustNewCode("service_account_already_exists")
-	ErrCodeServiceAccountNotFound             = errors.MustNewCode("service_account_not_found")
-	ErrCodeServiceAccountRoleAlreadyExists    = errors.MustNewCode("service_account_role_already_exists")
-	ErrCodeServiceAccountOperationUnsupported = errors.MustNewCode("service_account_operation_unsupported")
-	errInvalidServiceAccountName              = errors.New(errors.TypeInvalidInput, ErrCodeServiceAccountInvalidInput, "name must start with a lowercase letter (a-z), contain only lowercase letters, numbers (0-9), and hyphens (-), and be at most 50 characters long")
+	ErrCodeServiceAccountInvalidConfig     = errors.MustNewCode("service_account_invalid_config")
+	ErrCodeServiceAccountInvalidInput      = errors.MustNewCode("service_account_invalid_input")
+	ErrCodeServiceAccountAlreadyExists     = errors.MustNewCode("service_account_already_exists")
+	ErrCodeServiceAccountNotFound          = errors.MustNewCode("service_account_not_found")
+	ErrCodeServiceAccountRoleAlreadyExists = errors.MustNewCode("service_account_role_already_exists")
+	errInvalidServiceAccountName           = errors.New(errors.TypeInvalidInput, ErrCodeServiceAccountInvalidInput, "name must start with a lowercase letter (a-z), contain only lowercase letters, numbers (0-9), and hyphens (-), and be at most 50 characters long")
 )
 
 var (
@@ -120,7 +119,7 @@ func (serviceAccount *ServiceAccount) UpdateStatus(status ServiceAccountStatus) 
 
 func (serviceAccount *ServiceAccount) ErrIfDeleted() error {
 	if serviceAccount.Status == ServiceAccountStatusDeleted {
-		return errors.New(errors.TypeUnsupported, ErrCodeServiceAccountOperationUnsupported, "this operation is not supported for disabled service account")
+		return errors.Newf(errors.TypeNotFound, ErrCodeServiceAccountNotFound, "an active service account with id: %s does not exist", serviceAccount.ID)
 	}
 
 	return nil

--- a/tests/integration/tests/serviceaccount/01_crud.py
+++ b/tests/integration/tests/serviceaccount/01_crud.py
@@ -227,4 +227,4 @@ def test_delete_already_deleted_service_account(
         timeout=5,
     )
 
-    assert response.status_code == HTTPStatus.NOT_IMPLEMENTED, f"Expected 501 for already-deleted SA, got {response.status_code}: {response.text}"
+    assert response.status_code == HTTPStatus.NOT_FOUND, f"Expected 404 for already-deleted SA, got {response.status_code}: {response.text}"


### PR DESCRIPTION

### 📄 Summary
- 404 status code for deleted service accounts instead of 501
- update the role patch endpoints to plural 


contributes to: https://github.com/SigNoz/platform-pod/issues/2037