### PR TITLE
fix: minor fixes in tooltip ui

### DIFF
--- a/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipHeader/TooltipHeader.module.scss
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipHeader/TooltipHeader.module.scss
@@ -6,7 +6,7 @@
 
 
 .headerRow {
-	padding: var(--spacing-4) var(--spacing-4) 0 var(--spacing-4);
+	padding: var(--spacing-8) var(--spacing-8) 0 var(--spacing-8);
 	font-size: var(--font-size-sm);
 	font-weight: 500;
 	display: flex;
@@ -17,7 +17,7 @@
 }
 
 .pinnedItem {
-	padding: var(--spacing-2) var(--spacing-2) 0 var(--spacing-2);
+	padding: var(--spacing-4) var(--spacing-4) 0 var(--spacing-4);
 }
 
 .status {

--- a/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipHeader/TooltipHeader.module.scss
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipHeader/TooltipHeader.module.scss
@@ -6,17 +6,18 @@
 
 
 .headerRow {
-	padding: 12px 12px 0 12px;
+	padding: var(--spacing-4) var(--spacing-4) 0 var(--spacing-4);
 	font-size: var(--font-size-sm);
 	font-weight: 500;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	gap: var(--spacing-2);
+	margin-bottom: var(--spacing-2);
 }
 
 .pinnedItem {
-	padding: 8px 8px 0 8px;
+	padding: var(--spacing-2) var(--spacing-2) 0 var(--spacing-2);
 }
 
 .status {

--- a/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipHeader/TooltipHeader.module.scss
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipHeader/TooltipHeader.module.scss
@@ -1,21 +1,22 @@
 .headerContainer {
-	padding: 1rem 1rem 0 1rem;
 	display: flex;
 	flex-direction: column;
-	gap: var(--spacing-4);
 
-	&:last-child {
-		padding-bottom: var(--spacing-4);
-	}
 }
 
+
 .headerRow {
+	padding: 12px 12px 0 12px;
 	font-size: var(--font-size-sm);
 	font-weight: 500;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	gap: var(--spacing-2);
+}
+
+.pinnedItem {
+	padding: 8px 8px 0 8px;
 }
 
 .status {

--- a/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipHeader/TooltipHeader.tsx
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipHeader/TooltipHeader.tsx
@@ -72,13 +72,15 @@ export default function TooltipHeader({
 			)}
 
 			{activeItem && (
-				<TooltipItem
-					item={activeItem}
-					isItemActive={true}
-					containerTestId="uplot-tooltip-pinned"
-					markerTestId="uplot-tooltip-pinned-marker"
-					contentTestId="uplot-tooltip-pinned-content"
-				/>
+				<div className={Styles.pinnedItem} data-testid="uplot-tooltip-pinned-item">
+					<TooltipItem
+						item={activeItem}
+						isItemActive={true}
+						containerTestId="uplot-tooltip-pinned"
+						markerTestId="uplot-tooltip-pinned-marker"
+						contentTestId="uplot-tooltip-pinned-content"
+					/>
+				</div>
 			)}
 		</div>
 	);

--- a/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipItem/TooltipItem.module.scss
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipItem/TooltipItem.module.scss
@@ -1,36 +1,44 @@
-.uplot-tooltip-item {
+.uplotTooltipItem {
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	padding: 4px 0;
+	padding: 6px;
+	cursor: pointer;
 
-	.uplot-tooltip-item-marker {
-		border-radius: 50%;
-		border-style: solid;
-		border-width: 2px;
-		width: 12px;
-		height: 12px;
-		flex-shrink: 0;
+	&:hover {
+		opacity: 1 !important;
+		font-weight: 700;
+		background-color: var(--l2-border);
+		border-radius: 4px;
 	}
+}
 
-	.uplot-tooltip-item-content {
-		width: 100%;
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		justify-content: space-between;
+.uplotTooltipItemMarker {
+	border-radius: 50%;
+	border-style: solid;
+	border-width: 2px;
+	width: 10px;
+	height: 10px;
+	flex-shrink: 0;
+}
 
-		.uplot-tooltip-item-label {
-			white-space: normal;
-			overflow-wrap: anywhere;
-		}
+.uplotTooltipItemContent {
+	width: 100%;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	justify-content: space-between;
+}
 
-		&-separator {
-			flex: 1;
-			border-width: 0.5px;
-			border-style: dashed;
-			min-width: 24px;
-			opacity: 0.5;
-		}
-	}
+.uplotTooltipItemLabel {
+	white-space: normal;
+	overflow-wrap: anywhere;
+}
+
+.uplotTooltipItemContentSeparator {
+	flex: 1;
+	border-width: 0.5px;
+	border-style: dashed;
+	min-width: 24px;
+	opacity: 0.5;
 }

--- a/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipItem/TooltipItem.module.scss
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipItem/TooltipItem.module.scss
@@ -1,13 +1,19 @@
 .uplotTooltipItem {
 	display: flex;
 	align-items: center;
-	gap: 8px;
+	gap: var(--spacing-2);
 	padding: 6px;
 	cursor: pointer;
+	opacity: 0.7;
+	font-weight: 400;
+
+	&[data-is-active='true'] {
+		opacity: 1;
+		font-weight: 700;
+	}
 
 	&:hover {
 		opacity: 1 !important;
-		font-weight: 700;
 		background-color: var(--l2-border);
 		border-radius: 4px;
 	}
@@ -17,8 +23,9 @@
 	border-radius: 50%;
 	border-style: solid;
 	border-width: 2px;
-	width: 10px;
-	height: 10px;
+	width: 12px;
+	height: 12px;
+	box-sizing: border-box;
 	flex-shrink: 0;
 }
 
@@ -26,7 +33,7 @@
 	width: 100%;
 	display: flex;
 	align-items: center;
-	gap: 8px;
+	gap: var(--spacing-2);
 	justify-content: space-between;
 }
 

--- a/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipItem/TooltipItem.tsx
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipItem/TooltipItem.tsx
@@ -20,10 +20,7 @@ export default function TooltipItem({
 	return (
 		<div
 			className={Styles.uplotTooltipItem}
-			style={{
-				opacity: isItemActive ? 1 : 0.7,
-				fontWeight: isItemActive ? 700 : 400,
-			}}
+			data-is-active={isItemActive}
 			data-testid={containerTestId}
 		>
 			<div

--- a/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipList/TooltipList.module.scss
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipList/TooltipList.module.scss
@@ -3,7 +3,11 @@
 	:global(div[data-viewport-type='element']) {
 		left: 0;
 		box-sizing: border-box;
-		padding: 4px 12px 4px 16px;
+		padding: 0px 4px 0 8px;
+
+		[data-test-id='virtuoso-item-list'] > * + * {
+			margin-top: 4px;
+		}
 	}
 
 	&::-webkit-scrollbar {

--- a/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipList/TooltipList.module.scss
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipList/TooltipList.module.scss
@@ -3,10 +3,10 @@
 	:global(div[data-viewport-type='element']) {
 		left: 0;
 		box-sizing: border-box;
-		padding: 0px var(--spacing-1) 0 var(--spacing-2);
+		padding: 0px var(--spacing-2) 0 var(--spacing-4);
 
 		[data-test-id='virtuoso-item-list'] > * + * {
-			margin-top: var(--spacing-1);
+			margin-top: var(--spacing-2);
 		}
 	}
 

--- a/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipList/TooltipList.module.scss
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipList/TooltipList.module.scss
@@ -3,10 +3,10 @@
 	:global(div[data-viewport-type='element']) {
 		left: 0;
 		box-sizing: border-box;
-		padding: 0px 4px 0 8px;
+		padding: 0px var(--spacing-1) 0 var(--spacing-2);
 
 		[data-test-id='virtuoso-item-list'] > * + * {
-			margin-top: 4px;
+			margin-top: var(--spacing-1);
 		}
 	}
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
This PR polishes the tooltip UI in the uPlot v2 component by fixing spacing, alignment, and style inconsistencies introduced during the tooltip refactor.

Key changes:
- Moved padding from the header container to individual rows so spacing is applied correctly at each level
- Wrapped the pinned (active) item in a dedicated `.pinnedItem` div with its own padding, separating it visually from the header row
- Refactored `TooltipItem` SCSS from nested BEM-style rules to flat CSS Modules class names (e.g. `.uplot-tooltip-item` → `.uplotTooltipItem`), fixing broken style references
- Replaced inline `opacity`/`fontWeight` styles on `TooltipItem` with a `data-is-active` attribute and CSS attribute selectors, keeping the active/inactive state in CSS
- Added hover highlight (`background-color: var(--l2-border)`) and `cursor: pointer` to tooltip items
- Tightened list item spacing using a `> * + * { margin-top }` selector instead of padding on the virtual scroll container

#### Screenshots / Screen Recordings (if applicable)
<!-- Add before/after screenshots of the tooltip -->
Before
<img width="456" height="523" alt="image" src="https://github.com/user-attachments/assets/6ac9eaba-8ccc-4a7f-84bf-a648f3cd59bd" />

After
<img width="472" height="536" alt="image" src="https://github.com/user-attachments/assets/0c01856e-8bc2-4e66-881e-adb4196a3028" />


#### Issues closed by this PR
<!-- Closes #issue-number -->
Closes https://github.com/SigNoz/signoz/issues/11079

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
The tooltip UI had incorrect spacing and broken CSS class references after the initial uPlot v2 tooltip refactor. The SCSS used nested BEM-style selectors (`.uplot-tooltip-item .uplot-tooltip-item-marker`) which don't compose correctly with CSS Modules, causing styles to not apply. Inline styles were also used for active/inactive state instead of CSS.

#### Fix Strategy
Flattened SCSS to top-level CSS Modules classes, replaced inline style props with `data-is-active` attribute selectors, and restructured padding to be applied at the right DOM level.

---

### 🧪 Testing Strategy

- Tests added/updated: None — style-only changes
- Manual verification: Visually verified tooltip header, pinned item, and list item spacing and hover state
- Edge cases covered: Pinned item padding, active vs. inactive item contrast, list item gap with virtual scroll

---

### ⚠️ Risk & Impact Assessment

- Blast radius: uPlot v2 tooltip component only
- Potential regressions: Any chart tooltip using uPlot v2 — verify hover, active item highlight, and pinned item display
- Rollback plan: Revert this branch; no data or config changes involved

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance |
| Description | N/A — internal tooltip UI style fix, no user-facing behavior change |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The CSS class rename from `.uplot-tooltip-item` (kebab-case) to `.uplotTooltipItem` (camelCase) is required for CSS Modules to correctly scope and export the class names — kebab-case names aren't valid JS identifiers and were likely silently not applying. All class references in the `.tsx` files have been updated accordingly.

---
