### PR TITLE
feat(global): add mcp_url to global config

### DIFF
--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -11,6 +11,8 @@ global:
   external_url: <unset>
   # the url where the SigNoz backend receives telemetry data (traces, metrics, logs) from instrumented applications.
   ingestion_url: <unset>
+  # the url of the SigNoz MCP server. when unset, the MCP settings page is hidden in the frontend.
+  # mcp_url: https://mcp.signoz.cloud
 
 ##################### Version #####################
 version:

--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -12,7 +12,7 @@ global:
   # the url where the SigNoz backend receives telemetry data (traces, metrics, logs) from instrumented applications.
   ingestion_url: <unset>
   # the url of the SigNoz MCP server. when unset, the MCP settings page is hidden in the frontend.
-  # mcp_url: https://mcp.signoz.cloud
+  # mcp_url: <unset>
 
 ##################### Version #####################
 version:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -2369,6 +2369,9 @@ components:
           $ref: '#/components/schemas/GlobaltypesIdentNConfig'
         ingestion_url:
           type: string
+        mcp_url:
+          nullable: true
+          type: string
       type: object
     GlobaltypesIdentNConfig:
       properties:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -2372,6 +2372,10 @@ components:
         mcp_url:
           nullable: true
           type: string
+      required:
+      - external_url
+      - ingestion_url
+      - mcp_url
       type: object
     GlobaltypesIdentNConfig:
       properties:

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -3125,17 +3125,17 @@ export interface GlobaltypesConfigDTO {
 	/**
 	 * @type string
 	 */
-	external_url?: string;
+	external_url: string;
 	identN?: GlobaltypesIdentNConfigDTO;
 	/**
 	 * @type string
 	 */
-	ingestion_url?: string;
+	ingestion_url: string;
 	/**
 	 * @type string
 	 * @nullable true
 	 */
-	mcp_url?: string | null;
+	mcp_url: string | null;
 }
 
 export interface GlobaltypesIdentNConfigDTO {

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -3131,6 +3131,11 @@ export interface GlobaltypesConfigDTO {
 	 * @type string
 	 */
 	ingestion_url?: string;
+	/**
+	 * @type string
+	 * @nullable true
+	 */
+	mcp_url?: string | null;
 }
 
 export interface GlobaltypesIdentNConfigDTO {

--- a/frontend/src/types/api/globalConfig/types.ts
+++ b/frontend/src/types/api/globalConfig/types.ts
@@ -1,7 +1,6 @@
 export interface GlobalConfigData {
 	external_url: string;
 	ingestion_url: string;
-	mcp_url: string | null;
 }
 
 export interface GlobalConfigDataProps {

--- a/frontend/src/types/api/globalConfig/types.ts
+++ b/frontend/src/types/api/globalConfig/types.ts
@@ -1,6 +1,7 @@
 export interface GlobalConfigData {
 	external_url: string;
 	ingestion_url: string;
+	mcp_url: string | null;
 }
 
 export interface GlobalConfigDataProps {

--- a/pkg/global/config.go
+++ b/pkg/global/config.go
@@ -17,6 +17,7 @@ var (
 type Config struct {
 	ExternalURL  *url.URL `mapstructure:"external_url"`
 	IngestionURL *url.URL `mapstructure:"ingestion_url"`
+	MCPURL       *url.URL `mapstructure:"mcp_url"`
 }
 
 func NewConfigFactory() factory.ConfigFactory {

--- a/pkg/global/signozglobal/provider.go
+++ b/pkg/global/signozglobal/provider.go
@@ -36,6 +36,7 @@ func (provider *provider) GetConfig(context.Context) *globaltypes.Config {
 		s := provider.config.MCPURL.String()
 		mcpURL = &s
 	}
+
 	return globaltypes.NewConfig(
 		globaltypes.NewEndpoint(provider.config.ExternalURL.String(), provider.config.IngestionURL.String(), mcpURL),
 		globaltypes.NewIdentNConfig(

--- a/pkg/global/signozglobal/provider.go
+++ b/pkg/global/signozglobal/provider.go
@@ -31,8 +31,13 @@ func newProvider(_ context.Context, providerSettings factory.ProviderSettings, c
 }
 
 func (provider *provider) GetConfig(context.Context) *globaltypes.Config {
+	var mcpURL *string
+	if provider.config.MCPURL != nil {
+		s := provider.config.MCPURL.String()
+		mcpURL = &s
+	}
 	return globaltypes.NewConfig(
-		globaltypes.NewEndpoint(provider.config.ExternalURL.String(), provider.config.IngestionURL.String()),
+		globaltypes.NewEndpoint(provider.config.ExternalURL.String(), provider.config.IngestionURL.String(), mcpURL),
 		globaltypes.NewIdentNConfig(
 			globaltypes.TokenizerConfig{Enabled: provider.identNConfig.Tokenizer.Enabled},
 			globaltypes.APIKeyConfig{Enabled: provider.identNConfig.APIKeyConfig.Enabled},

--- a/pkg/types/globaltypes/endpoint.go
+++ b/pkg/types/globaltypes/endpoint.go
@@ -1,13 +1,15 @@
 package globaltypes
 
 type Endpoint struct {
-	ExternalURL  string `json:"external_url"`
-	IngestionURL string `json:"ingestion_url"`
+	ExternalURL  string  `json:"external_url"`
+	IngestionURL string  `json:"ingestion_url"`
+	MCPURL       *string `json:"mcp_url" nullable:"true"`
 }
 
-func NewEndpoint(externalURL, ingestionURL string) Endpoint {
+func NewEndpoint(externalURL, ingestionURL string, mcpURL *string) Endpoint {
 	return Endpoint{
 		ExternalURL:  externalURL,
 		IngestionURL: ingestionURL,
+		MCPURL:       mcpURL,
 	}
 }

--- a/pkg/types/globaltypes/endpoint.go
+++ b/pkg/types/globaltypes/endpoint.go
@@ -1,9 +1,9 @@
 package globaltypes
 
 type Endpoint struct {
-	ExternalURL  string  `json:"external_url"`
-	IngestionURL string  `json:"ingestion_url"`
-	MCPURL       *string `json:"mcp_url" nullable:"true"`
+	ExternalURL  string  `json:"external_url" required:"true"`
+	IngestionURL string  `json:"ingestion_url" required:"true"`
+	MCPURL       *string `json:"mcp_url" required:"true" nullable:"true"`
 }
 
 func NewEndpoint(externalURL, ingestionURL string, mcpURL *string) Endpoint {


### PR DESCRIPTION
## Summary
- Adds an optional `mcp_url` to the backend global config (runtime config + wire DTO + provider wiring). When unset, `GET /api/v1/global/config` returns `"mcp_url": null`; when set via YAML/env, it emits the parsed URL.
- Documents the new field in `conf/example.yaml` (commented) and regenerates `docs/api/openapi.yml` with `nullable: true`.
- Surfaces `mcp_url: string | null` on the frontend `GlobalConfigData` type and refreshes the generated OpenAPI client so the MCP settings page in #11025 can gate on `mcp_url != null`.

closes SigNoz/platform-pod#2138