### PR TITLE
fix: add config path and fmt config path in vs code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "oxc.typeAware": true,
   "oxc.tsConfigPath": "./frontend/tsconfig.json",
   "oxc.configPath": "./frontend/.oxlintrc.json",
+  "oxc.fmt.configPath": "./frontend/.oxfmtrc.json",
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.codeActionsOnSave": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "oxc.typeAware": true,
   "oxc.tsConfigPath": "./frontend/tsconfig.json",
+  "oxc.configPath": "./frontend/.oxlintrc.json",
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.codeActionsOnSave": {
@@ -19,4 +20,3 @@
   "python-envs.defaultEnvManager": "ms-python.python:system",
   "python-envs.pythonProjects": []
 }
-

--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -538,8 +538,8 @@
     "sonarjs/no-nested-template-literals": "error",
     // Avoids nested template literals
     "sonarjs/no-redundant-boolean": "warn", // TODO: Change to error after migration
-    // Removes redundant boolean literals
-    "sonarjs/no-redundant-jump": "error",
+    // Removes redundant boolean literals - turned off because it clashes with unicorn rules
+    "sonarjs/no-redundant-jump": "off",
     // Removes unnecessary returns/continues
     "sonarjs/no-same-line-conditional": "error",
     // Prevents same-line conditionals

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -241,7 +241,7 @@
   "lint-staged": {
     "*.(js|jsx|ts|tsx)": [
       "oxfmt --check",
-      "oxlint --fix",
+      "oxlint --quiet",
       "sh scripts/typecheck-staged.sh"
     ]
   },


### PR DESCRIPTION
### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

- add config path in vs code settings. helps tag lint errors inline in code when opening from root folder
- add fmt config path in vs code settings. helps tag format errors inline in code when opening from root folder
- remove clashing sonar rule
- lint-stage to use quiet instead of fix. Drawback - Auto fix will not work for some time. Is undergoing investigation