### PR TITLE
feat(apiserver): instrument user v2 P0 routes with AuditDef

### DIFF
--- a/pkg/apiserver/signozapiserver/user.go
+++ b/pkg/apiserver/signozapiserver/user.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/SigNoz/signoz/pkg/http/handler"
 	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/audittypes"
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
 	"github.com/gorilla/mux"
 )
@@ -111,20 +112,28 @@ func (provider *provider) addUserRoutes(router *mux.Router) error {
 		return err
 	}
 
-	if err := router.Handle("/api/v2/users/me", handler.New(provider.authZ.OpenAccess(provider.userHandler.UpdateMyUser), handler.OpenAPIDef{
-		ID:                  "UpdateMyUserV2",
-		Tags:                []string{"users"},
-		Summary:             "Update my user v2",
-		Description:         "This endpoint updates the user I belong to",
-		Request:             new(types.UpdatableUser),
-		RequestContentType:  "application/json",
-		Response:            nil,
-		ResponseContentType: "",
-		SuccessStatusCode:   http.StatusNoContent,
-		ErrorStatusCodes:    []int{},
-		Deprecated:          false,
-		SecuritySchemes:     []handler.OpenAPISecurityScheme{{Name: authtypes.IdentNProviderTokenizer.StringValue()}},
-	})).Methods(http.MethodPut).GetError(); err != nil {
+	if err := router.Handle("/api/v2/users/me", handler.New(
+		provider.authZ.OpenAccess(provider.userHandler.UpdateMyUser),
+		handler.OpenAPIDef{
+			ID:                  "UpdateMyUserV2",
+			Tags:                []string{"users"},
+			Summary:             "Update my user v2",
+			Description:         "This endpoint updates the user I belong to",
+			Request:             new(types.UpdatableUser),
+			RequestContentType:  "application/json",
+			Response:            nil,
+			ResponseContentType: "",
+			SuccessStatusCode:   http.StatusNoContent,
+			ErrorStatusCodes:    []int{},
+			Deprecated:          false,
+			SecuritySchemes:     []handler.OpenAPISecurityScheme{{Name: authtypes.IdentNProviderTokenizer.StringValue()}},
+		},
+		handler.WithAuditDef(handler.AuditDef{
+			ResourceKind: "user",
+			Action:       audittypes.ActionUpdate,
+			Category:     audittypes.ActionCategoryConfigurationChange,
+		}),
+	)).Methods(http.MethodPut).GetError(); err != nil {
 		return err
 	}
 
@@ -179,20 +188,29 @@ func (provider *provider) addUserRoutes(router *mux.Router) error {
 		return err
 	}
 
-	if err := router.Handle("/api/v2/users/{id}", handler.New(provider.authZ.AdminAccess(provider.userHandler.UpdateUser), handler.OpenAPIDef{
-		ID:                  "UpdateUser",
-		Tags:                []string{"users"},
-		Summary:             "Update user v2",
-		Description:         "This endpoint updates the user by id",
-		Request:             new(types.UpdatableUser),
-		RequestContentType:  "application/json",
-		Response:            nil,
-		ResponseContentType: "",
-		SuccessStatusCode:   http.StatusNoContent,
-		ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
-		Deprecated:          false,
-		SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
-	})).Methods(http.MethodPut).GetError(); err != nil {
+	if err := router.Handle("/api/v2/users/{id}", handler.New(
+		provider.authZ.AdminAccess(provider.userHandler.UpdateUser),
+		handler.OpenAPIDef{
+			ID:                  "UpdateUser",
+			Tags:                []string{"users"},
+			Summary:             "Update user v2",
+			Description:         "This endpoint updates the user by id",
+			Request:             new(types.UpdatableUser),
+			RequestContentType:  "application/json",
+			Response:            nil,
+			ResponseContentType: "",
+			SuccessStatusCode:   http.StatusNoContent,
+			ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
+			Deprecated:          false,
+			SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
+		},
+		handler.WithAuditDef(handler.AuditDef{
+			ResourceKind:    "user",
+			Action:          audittypes.ActionUpdate,
+			Category:        audittypes.ActionCategoryConfigurationChange,
+			ResourceIDParam: "id",
+		}),
+	)).Methods(http.MethodPut).GetError(); err != nil {
 		return err
 	}
 
@@ -247,20 +265,29 @@ func (provider *provider) addUserRoutes(router *mux.Router) error {
 		return err
 	}
 
-	if err := router.Handle("/api/v2/users/{id}/reset_password_tokens", handler.New(provider.authZ.AdminAccess(provider.userHandler.CreateResetPasswordToken), handler.OpenAPIDef{
-		ID:                  "CreateResetPasswordToken",
-		Tags:                []string{"users"},
-		Summary:             "Create or regenerate reset password token for a user",
-		Description:         "This endpoint creates or regenerates a reset password token for a user. If a valid token exists, it is returned. If expired, a new one is created.",
-		Request:             nil,
-		RequestContentType:  "",
-		Response:            new(types.ResetPasswordToken),
-		ResponseContentType: "application/json",
-		SuccessStatusCode:   http.StatusCreated,
-		ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
-		Deprecated:          false,
-		SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
-	})).Methods(http.MethodPut).GetError(); err != nil {
+	if err := router.Handle("/api/v2/users/{id}/reset_password_tokens", handler.New(
+		provider.authZ.AdminAccess(provider.userHandler.CreateResetPasswordToken),
+		handler.OpenAPIDef{
+			ID:                  "CreateResetPasswordToken",
+			Tags:                []string{"users"},
+			Summary:             "Create or regenerate reset password token for a user",
+			Description:         "This endpoint creates or regenerates a reset password token for a user. If a valid token exists, it is returned. If expired, a new one is created.",
+			Request:             nil,
+			RequestContentType:  "",
+			Response:            new(types.ResetPasswordToken),
+			ResponseContentType: "application/json",
+			SuccessStatusCode:   http.StatusCreated,
+			ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
+			Deprecated:          false,
+			SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
+		},
+		handler.WithAuditDef(handler.AuditDef{
+			ResourceKind:    "reset-password-token",
+			Action:          audittypes.ActionCreate,
+			Category:        audittypes.ActionCategoryAccessControl,
+			ResourceIDParam: "id",
+		}),
+	)).Methods(http.MethodPut).GetError(); err != nil {
 		return err
 	}
 
@@ -281,37 +308,53 @@ func (provider *provider) addUserRoutes(router *mux.Router) error {
 		return err
 	}
 
-	if err := router.Handle("/api/v2/users/me/factor_password", handler.New(provider.authZ.OpenAccess(provider.userHandler.ChangePassword), handler.OpenAPIDef{
-		ID:                  "UpdateMyPassword",
-		Tags:                []string{"users"},
-		Summary:             "Updates my password",
-		Description:         "This endpoint updates the password of the user I belong to",
-		Request:             new(types.ChangePasswordRequest),
-		RequestContentType:  "application/json",
-		Response:            nil,
-		ResponseContentType: "",
-		SuccessStatusCode:   http.StatusNoContent,
-		ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
-		Deprecated:          false,
-		SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
-	})).Methods(http.MethodPut).GetError(); err != nil {
+	if err := router.Handle("/api/v2/users/me/factor_password", handler.New(
+		provider.authZ.OpenAccess(provider.userHandler.ChangePassword),
+		handler.OpenAPIDef{
+			ID:                  "UpdateMyPassword",
+			Tags:                []string{"users"},
+			Summary:             "Updates my password",
+			Description:         "This endpoint updates the password of the user I belong to",
+			Request:             new(types.ChangePasswordRequest),
+			RequestContentType:  "application/json",
+			Response:            nil,
+			ResponseContentType: "",
+			SuccessStatusCode:   http.StatusNoContent,
+			ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
+			Deprecated:          false,
+			SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
+		},
+		handler.WithAuditDef(handler.AuditDef{
+			ResourceKind: "factor-password",
+			Action:       audittypes.ActionUpdate,
+			Category:     audittypes.ActionCategoryAccessControl,
+		}),
+	)).Methods(http.MethodPut).GetError(); err != nil {
 		return err
 	}
 
-	if err := router.Handle("/api/v2/factor_password/forgot", handler.New(provider.authZ.OpenAccess(provider.userHandler.ForgotPassword), handler.OpenAPIDef{
-		ID:                  "ForgotPassword",
-		Tags:                []string{"users"},
-		Summary:             "Forgot password",
-		Description:         "This endpoint initiates the forgot password flow by sending a reset password email",
-		Request:             new(types.PostableForgotPassword),
-		RequestContentType:  "application/json",
-		Response:            nil,
-		ResponseContentType: "",
-		SuccessStatusCode:   http.StatusNoContent,
-		ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusUnprocessableEntity},
-		Deprecated:          false,
-		SecuritySchemes:     []handler.OpenAPISecurityScheme{},
-	})).Methods(http.MethodPost).GetError(); err != nil {
+	if err := router.Handle("/api/v2/factor_password/forgot", handler.New(
+		provider.authZ.OpenAccess(provider.userHandler.ForgotPassword),
+		handler.OpenAPIDef{
+			ID:                  "ForgotPassword",
+			Tags:                []string{"users"},
+			Summary:             "Forgot password",
+			Description:         "This endpoint initiates the forgot password flow by sending a reset password email",
+			Request:             new(types.PostableForgotPassword),
+			RequestContentType:  "application/json",
+			Response:            nil,
+			ResponseContentType: "",
+			SuccessStatusCode:   http.StatusNoContent,
+			ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusUnprocessableEntity},
+			Deprecated:          false,
+			SecuritySchemes:     []handler.OpenAPISecurityScheme{},
+		},
+		handler.WithAuditDef(handler.AuditDef{
+			ResourceKind: "factor-password",
+			Action:       audittypes.ActionUpdate,
+			Category:     audittypes.ActionCategoryAccessControl,
+		}),
+	)).Methods(http.MethodPost).GetError(); err != nil {
 		return err
 	}
 
@@ -332,37 +375,55 @@ func (provider *provider) addUserRoutes(router *mux.Router) error {
 		return err
 	}
 
-	if err := router.Handle("/api/v2/users/{id}/roles", handler.New(provider.authZ.AdminAccess(provider.userHandler.SetRoleByUserID), handler.OpenAPIDef{
-		ID:                  "SetRoleByUserID",
-		Tags:                []string{"users"},
-		Summary:             "Set user roles",
-		Description:         "This endpoint assigns the role to the user roles by user id",
-		Request:             new(types.PostableRole),
-		RequestContentType:  "application/json",
-		Response:            nil,
-		ResponseContentType: "",
-		SuccessStatusCode:   http.StatusOK,
-		ErrorStatusCodes:    []int{http.StatusNotFound},
-		Deprecated:          false,
-		SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
-	})).Methods(http.MethodPost).GetError(); err != nil {
+	if err := router.Handle("/api/v2/users/{id}/roles", handler.New(
+		provider.authZ.AdminAccess(provider.userHandler.SetRoleByUserID),
+		handler.OpenAPIDef{
+			ID:                  "SetRoleByUserID",
+			Tags:                []string{"users"},
+			Summary:             "Set user roles",
+			Description:         "This endpoint assigns the role to the user roles by user id",
+			Request:             new(types.PostableRole),
+			RequestContentType:  "application/json",
+			Response:            nil,
+			ResponseContentType: "",
+			SuccessStatusCode:   http.StatusOK,
+			ErrorStatusCodes:    []int{http.StatusNotFound},
+			Deprecated:          false,
+			SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
+		},
+		handler.WithAuditDef(handler.AuditDef{
+			ResourceKind:    "user-role",
+			Action:          audittypes.ActionCreate,
+			Category:        audittypes.ActionCategoryAccessControl,
+			ResourceIDParam: "id",
+		}),
+	)).Methods(http.MethodPost).GetError(); err != nil {
 		return err
 	}
 
-	if err := router.Handle("/api/v2/users/{id}/roles/{roleId}", handler.New(provider.authZ.AdminAccess(provider.userHandler.RemoveUserRoleByRoleID), handler.OpenAPIDef{
-		ID:                  "RemoveUserRoleByUserIDAndRoleID",
-		Tags:                []string{"users"},
-		Summary:             "Remove a role from user",
-		Description:         "This endpoint removes a role from the user by user id and role id",
-		Request:             nil,
-		RequestContentType:  "",
-		Response:            nil,
-		ResponseContentType: "",
-		SuccessStatusCode:   http.StatusNoContent,
-		ErrorStatusCodes:    []int{http.StatusNotFound},
-		Deprecated:          false,
-		SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
-	})).Methods(http.MethodDelete).GetError(); err != nil {
+	if err := router.Handle("/api/v2/users/{id}/roles/{roleId}", handler.New(
+		provider.authZ.AdminAccess(provider.userHandler.RemoveUserRoleByRoleID),
+		handler.OpenAPIDef{
+			ID:                  "RemoveUserRoleByUserIDAndRoleID",
+			Tags:                []string{"users"},
+			Summary:             "Remove a role from user",
+			Description:         "This endpoint removes a role from the user by user id and role id",
+			Request:             nil,
+			RequestContentType:  "",
+			Response:            nil,
+			ResponseContentType: "",
+			SuccessStatusCode:   http.StatusNoContent,
+			ErrorStatusCodes:    []int{http.StatusNotFound},
+			Deprecated:          false,
+			SecuritySchemes:     newSecuritySchemes(types.RoleAdmin),
+		},
+		handler.WithAuditDef(handler.AuditDef{
+			ResourceKind:    "user-role",
+			Action:          audittypes.ActionDelete,
+			Category:        audittypes.ActionCategoryAccessControl,
+			ResourceIDParam: "id",
+		}),
+	)).Methods(http.MethodDelete).GetError(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

Second slice of #1938 — instrument the seven v2 user mutation routes in `pkg/apiserver/signozapiserver/user.go` with `AuditDef`. **v1 user routes are intentionally untouched** and will be retired separately.

| Route | EventName |
|---|---|
| `PUT /api/v2/users/me` | `user.updated` |
| `PUT /api/v2/users/{id}` | `user.updated` |
| `PUT /api/v2/users/{id}/reset_password_tokens` | `reset-password-token.created` |
| `PUT /api/v2/users/me/factor_password` | `factor-password.updated` |
| `POST /api/v2/factor_password/forgot` | `factor-password.updated` |
| `POST /api/v2/users/{id}/roles` | `user-role.created` |
| `DELETE /api/v2/users/{id}/roles/{roleId}` | `user-role.deleted` |

Single-segment hyphenated `ResourceKind` values per the agreed naming. CRUD-only `audittypes.Action` retained — domain meaning is encoded in the resource kind, not the verb.

## Notes

- **factor-password collapse** — `PUT /factor_password` (change) and `POST /factor_password/forgot` both emit `factor-password.updated`. Disambiguation is via the `http.route` attribute on the audit event.
- **Role delete `ResourceIDParam` = `id`** (the user) rather than `roleId`. The audit subject is "this user lost a role".
- **Pre-auth caveat** — `POST /api/v2/factor_password/forgot` is pre-auth and will silently drop at the licensing gate (no `orgID`). Same v1 behaviour as the session login slice; documented for follow-up.
- No module code changes — instrumentation lives entirely in route registration. Each `handler.New(...)` reformatted to multi-line shape so the `WithAuditDef` option scans cleanly.

## Test plan

- [ ] `make go-build-community` and `make go-build-enterprise`
- [ ] Admin updates another user (`PUT /api/v2/users/{id}`) → `user.updated` row in `signoz_audit.logs` with `signoz.audit.resource.id` = the user id
- [ ] Admin grants a role (`POST /api/v2/users/{id}/roles`) → `user-role.created` row
- [ ] Admin revokes a role (`DELETE /api/v2/users/{id}/roles/{roleId}`) → `user-role.deleted` row
- [ ] User changes own password (`PUT /api/v2/users/me/factor_password`) → `factor-password.updated` row
- [ ] Admin issues reset token (`PUT /api/v2/users/{id}/reset_password_tokens`) → `reset-password-token.created` row
- [ ] `POST /api/v2/factor_password/forgot` is dropped at the licensing gate (verify `audit_events_dropped_total` increments)

closes SigNoz/platform-pod#1938
