### PR TITLE
chore: updated drilldown popup ui to match tooltip

### DIFF
--- a/frontend/src/container/DashboardContainer/visualization/hooks/usePanelContextMenu.ts
+++ b/frontend/src/container/DashboardContainer/visualization/hooks/usePanelContextMenu.ts
@@ -104,7 +104,12 @@ export const usePanelContextMenu = ({
 			}
 
 			if (data && data?.record?.queryName) {
-				onClick(data.coord, { ...data.record, label: data.label, timeRange });
+				onClick(data.coord, {
+					...data.record,
+					label: data.label,
+					seriesColor: data.seriesColor,
+					timeRange,
+				});
 			}
 		},
 		[onClick, queryResponse],

--- a/frontend/src/container/QueryTable/Drilldown/drilldownUtils.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/drilldownUtils.tsx
@@ -196,6 +196,7 @@ export const getUplotClickData = ({
 	coord: { x: number; y: number };
 	record: { queryName: string; filters: FilterData[] };
 	label: string | React.ReactNode;
+	seriesColor?: string;
 } | null => {
 	if (!queryData?.queryName || !metric) {
 		return null;
@@ -208,6 +209,8 @@ export const getUplotClickData = ({
 
 	// Generate label from focusedSeries data
 	let label: string | React.ReactNode = '';
+	const seriesColor = focusedSeries?.color;
+
 	if (focusedSeries && focusedSeries.seriesName) {
 		label = (
 			<span style={{ color: focusedSeries.color }}>
@@ -223,6 +226,7 @@ export const getUplotClickData = ({
 		},
 		record,
 		label,
+		seriesColor,
 	};
 };
 
@@ -237,6 +241,7 @@ export const getPieChartClickData = (
 	queryName: string;
 	filters: FilterData[];
 	label: string | React.ReactNode;
+	seriesColor?: string;
 } | null => {
 	const { metric, queryName } = arc.data.record;
 	if (!queryName || !metric) {
@@ -248,6 +253,7 @@ export const getPieChartClickData = (
 		queryName,
 		filters: getFiltersFromMetric(metric), // TODO: add where clause query as well.
 		label,
+		seriesColor: arc.data.color,
 	};
 };
 

--- a/frontend/src/container/QueryTable/Drilldown/useAggregateDrilldown.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/useAggregateDrilldown.tsx
@@ -22,6 +22,7 @@ export interface AggregateData {
 		endTime: number;
 	};
 	label?: string | React.ReactNode;
+	seriesColor?: string;
 }
 
 const useAggregateDrilldown = ({

--- a/frontend/src/container/QueryTable/Drilldown/useBaseAggregateOptions.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/useBaseAggregateOptions.tsx
@@ -228,7 +228,13 @@ const useBaseAggregateOptions = ({
 									return (
 										<ContextMenu.Item
 											key={key}
-											icon={isLoading ? <LoadingOutlined spin /> : icon}
+											icon={
+												isLoading ? (
+													<LoadingOutlined spin />
+												) : (
+													<span style={{ color: aggregateData?.seriesColor }}>{icon}</span>
+												)
+											}
 											onClick={(): void => onClick()}
 											disabled={isLoading}
 										>

--- a/frontend/src/periscope/components/ContextMenu/styles.scss
+++ b/frontend/src/periscope/components/ContextMenu/styles.scss
@@ -4,7 +4,7 @@
 	gap: 8px;
 	padding: 8px;
 	cursor: pointer;
-	color: var(--foreground);
+	color: var(--muted-foreground);
 	font-family: Inter;
 	font-size: var(--font-size-sm);
 	font-weight: 600;
@@ -20,13 +20,10 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 
-	&:hover {
-		background-color: var(--l1-background);
-	}
-
+	&:hover,
 	&:focus {
 		outline: none;
-		background-color: var(--l1-background);
+		background-color: var(--l2-background-hover);
 	}
 
 	&.disabled {
@@ -47,7 +44,8 @@
 		}
 
 		&:hover {
-			background-color: var(--bg-cherry-100);
+			background-color: var(--danger-background);
+			color: var(--l1-foreground);
 		}
 	}
 
@@ -74,73 +72,24 @@
 }
 
 .context-menu-header {
-	padding-bottom: 4px;
-	border-bottom: 1px solid var(--l1-border);
+	padding: 8px 12px;
+	border-bottom: 1px solid var(--l2-border);
 	color: var(--muted-foreground);
 }
 
-// Target the popover inner specifically for context menu
 .context-menu .ant-popover-inner {
-	padding: 12px 8px !important;
-	// max-height: 254px !important;
-	max-width: 300px !important;
+	padding: 0;
+	border-radius: 6px;
+	max-width: 300px;
+	background: var(--l2-background) !important;
+	border: 1px solid var(--l2-border) !important;
 }
 
-// Dark mode support
-.darkMode {
-	.context-menu-item {
-		color: var(--muted-foreground);
-
-		&:hover,
-		&:focus {
-			background-color: var(--l2-background);
-		}
-
-		&.danger {
-			color: var(--bg-cherry-400);
-
-			.icon {
-				color: var(--bg-cherry-400);
-			}
-
-			&:hover {
-				background-color: var(--danger-background);
-				color: var(--l1-foreground);
-			}
-		}
-
-		.icon {
-			color: var(--bg-robin-400);
-		}
-	}
-
-	.context-menu-header {
-		border-bottom: 1px solid var(--l1-border);
-		color: var(--muted-foreground);
-	}
-
-	// Set the menu popover background
-	.context-menu .ant-popover-inner {
-		background: var(--l1-background) !important;
-		border: 1px solid var(--border) !important;
-	}
-}
-
-// Context menu backdrop overlay
 .context-menu-backdrop {
 	position: fixed;
-	top: 0;
-	left: 0;
-	width: 100vw;
-	height: 100vh;
+	inset: 0;
 	z-index: 9999;
 	background: transparent;
 	cursor: default;
-
-	// Prevent any pointer events from reaching elements behind
 	pointer-events: auto;
-
-	// Ensure it covers the entire viewport including any scrollable areas
-	position: fixed !important;
-	inset: 0;
 }


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The drilldown popup UI (context menu that appears when clicking a data point on a chart) was visually inconsistent with the tooltip that appears on hover — icon colors did not reflect the series color and the overall styling diverged from the design system.

This PR aligns the drilldown popup to match the tooltip by:
- Passing `seriesColor` through the click-data pipeline (uplot, pie chart, panel context menu → `AggregateData`) so the icon in each drilldown menu item is tinted with the correct series color.
- Refactoring `ContextMenu/styles.scss` to remove duplicated dark-mode overrides (the styles are now applied unconditionally via CSS variables), consolidate hover/focus backgrounds, update header padding/border tokens, and clean up the popover inner styles to match the tooltip's visual spec.

#### Screenshots / Screen Recordings (if applicable)

<!-- Before/after screenshot of the drilldown popup -->
Before
<img width="689" height="502" alt="image" src="https://github.com/user-attachments/assets/b2d8bbca-fd75-45c0-bedd-c9da11d0ed5c" />



After
<img width="445" height="347" alt="image" src="https://github.com/user-attachments/assets/e139ec09-0ef1-4f24-b687-eda6d8cf875f" />


#### Issues closed by this PR

---

### ✅ Change Type

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

N/A — visual polish / consistency fix, not a functional bug.

---

### 🧪 Testing Strategy

- Tests added/updated: None required (pure visual/styling change)
- Manual verification: Clicked data points on line, bar, and pie chart panels; confirmed icon color matches series color and popup styling matches tooltip
- Edge cases covered: Loading state (spinner still shown instead of colored icon), disabled items, danger (delete) items

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Context menu component used across chart drilldown flows (uplot panels, pie charts, dashboard panels)
- Potential regressions: Hover/focus background color change from `--l1-background` → `--l2-background-hover`; danger item hover now uses `--danger-background` token — verify in both light and dark themes
- Rollback plan: Revert this commit; no data or API changes involved

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance |
| Description | Drilldown popup UI now matches the chart tooltip — series icon colors are reflected in the context menu items |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The `styles.scss` diff looks large but is mostly deletion of the duplicated `.darkMode { ... }` block — the same tokens now apply globally since the design system CSS variables handle theming.
- `seriesColor` is threaded as an optional field through `getUplotClickData`, `getPieChartClickData`, `usePanelContextMenu`, and `AggregateData` — no existing callsites are broken; the color is simply `undefined` where it was not previously available.
