### PR TITLE
feat: tooltip sync across panels

### DIFF
--- a/frontend/src/lib/uPlotV2/components/Tooltip/BarChartTooltip.tsx
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/BarChartTooltip.tsx
@@ -16,6 +16,7 @@ export default function BarChartTooltip(props: BarTooltipProps): JSX.Element {
 				yAxisUnit: props.yAxisUnit ?? '',
 				decimalPrecision: props.decimalPrecision,
 				isStackedBarChart: props.isStackedBarChart,
+				syncedSeriesIndexes: props.syncedSeriesIndexes,
 			}),
 		[
 			props.uPlotInstance,
@@ -24,6 +25,7 @@ export default function BarChartTooltip(props: BarTooltipProps): JSX.Element {
 			props.yAxisUnit,
 			props.decimalPrecision,
 			props.isStackedBarChart,
+			props.syncedSeriesIndexes,
 		],
 	);
 

--- a/frontend/src/lib/uPlotV2/components/Tooltip/HistogramTooltip.tsx
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/HistogramTooltip.tsx
@@ -17,6 +17,7 @@ export default function HistogramTooltip(
 				uPlotInstance: props.uPlotInstance,
 				yAxisUnit: props.yAxisUnit ?? '',
 				decimalPrecision: props.decimalPrecision,
+				syncedSeriesIndexes: props.syncedSeriesIndexes,
 			}),
 		[
 			props.uPlotInstance,
@@ -24,6 +25,7 @@ export default function HistogramTooltip(
 			props.dataIndexes,
 			props.yAxisUnit,
 			props.decimalPrecision,
+			props.syncedSeriesIndexes,
 		],
 	);
 

--- a/frontend/src/lib/uPlotV2/components/Tooltip/TimeSeriesTooltip.tsx
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/TimeSeriesTooltip.tsx
@@ -17,6 +17,7 @@ export default function TimeSeriesTooltip(
 				uPlotInstance: props.uPlotInstance,
 				yAxisUnit: props.yAxisUnit ?? '',
 				decimalPrecision: props.decimalPrecision,
+				syncedSeriesIndexes: props.syncedSeriesIndexes,
 			}),
 		[
 			props.uPlotInstance,
@@ -24,6 +25,7 @@ export default function TimeSeriesTooltip(
 			props.dataIndexes,
 			props.yAxisUnit,
 			props.decimalPrecision,
+			props.syncedSeriesIndexes,
 		],
 	);
 

--- a/frontend/src/lib/uPlotV2/components/Tooltip/utils.ts
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/utils.ts
@@ -62,6 +62,7 @@ export function buildTooltipContent({
 	yAxisUnit,
 	decimalPrecision,
 	isStackedBarChart,
+	syncedSeriesIndexes,
 }: {
 	data: AlignedData;
 	series: Series[];
@@ -71,12 +72,18 @@ export function buildTooltipContent({
 	yAxisUnit: string;
 	decimalPrecision?: PrecisionOption;
 	isStackedBarChart?: boolean;
+	syncedSeriesIndexes?: number[] | null;
 }): TooltipContentItem[] {
 	const items: TooltipContentItem[] = [];
+	const allowedIndexes =
+		syncedSeriesIndexes != null ? new Set(syncedSeriesIndexes) : null;
 
 	for (let seriesIndex = 1; seriesIndex < series.length; seriesIndex += 1) {
 		const seriesItem = series[seriesIndex];
 		if (!seriesItem?.show) {
+			continue;
+		}
+		if (allowedIndexes != null && !allowedIndexes.has(seriesIndex)) {
 			continue;
 		}
 

--- a/frontend/src/lib/uPlotV2/components/Tooltip/utils.ts
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/utils.ts
@@ -88,8 +88,18 @@ export function buildTooltipContent({
 		}
 
 		const dataIndex = dataIndexes[seriesIndex];
-		// Skip series with no data at the current cursor position
+		const isSync = allowedIndexes != null;
+
 		if (dataIndex === null) {
+			if (isSync) {
+				items.push({
+					label: String(seriesItem.label ?? ''),
+					value: 0,
+					tooltipValue: 'No Data',
+					color: resolveSeriesColor(seriesItem.stroke, uPlotInstance, seriesIndex),
+					isActive: false,
+				});
+			}
 			continue;
 		}
 
@@ -108,6 +118,14 @@ export function buildTooltipContent({
 				tooltipValue: getToolTipValue(baseValue, yAxisUnit, decimalPrecision),
 				color: resolveSeriesColor(seriesItem.stroke, uPlotInstance, seriesIndex),
 				isActive: seriesIndex === activeSeriesIndex,
+			});
+		} else if (isSync) {
+			items.push({
+				label: String(seriesItem.label ?? ''),
+				value: 0,
+				tooltipValue: 'No Data',
+				color: resolveSeriesColor(seriesItem.stroke, uPlotInstance, seriesIndex),
+				isActive: false,
 			});
 		}
 	}

--- a/frontend/src/lib/uPlotV2/components/types.ts
+++ b/frontend/src/lib/uPlotV2/components/types.ts
@@ -58,6 +58,9 @@ export interface TooltipRenderArgs {
 	isPinned: boolean;
 	dismiss: () => void;
 	viaSync: boolean;
+	/** In Tooltip sync mode, limits which series are rendered in the receiver tooltip.
+	 * null = no filtering; [] = no matches (tooltip hidden upstream); [...] = allowed indexes */
+	syncedSeriesIndexes?: number[] | null;
 }
 
 export interface BaseTooltipProps {

--- a/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/TooltipPlugin.tsx
+++ b/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/TooltipPlugin.tsx
@@ -140,7 +140,7 @@ export default function TooltipPlugin({
 		function updateCursorLock(): void {
 			const plot = getPlot(controller);
 			if (plot) {
-				// @ts-ignore uPlot cursor lock is not working as expected
+				// @ts-expect-error uPlot cursor lock is not working as expected
 				plot.cursor._lock = controller.pinned;
 			}
 		}
@@ -187,6 +187,16 @@ export default function TooltipPlugin({
 			if (!controller.hoverActive || !plot) {
 				return null;
 			}
+			// In Tooltip sync mode, suppress the receiver tooltip entirely when
+			// no receiver series match the source panel's focused series.
+			if (
+				syncTooltipWithDashboard &&
+				controller.cursorDrivenBySync &&
+				Array.isArray(controller.syncedSeriesIndexes) &&
+				controller.syncedSeriesIndexes.length === 0
+			) {
+				return null;
+			}
 			return renderRef.current({
 				uPlotInstance: plot,
 				dataIndexes: controller.seriesIndexes,
@@ -194,6 +204,7 @@ export default function TooltipPlugin({
 				isPinned: controller.pinned,
 				dismiss: dismissTooltip,
 				viaSync: controller.cursorDrivenBySync,
+				syncedSeriesIndexes: controller.syncedSeriesIndexes,
 			});
 		}
 
@@ -478,7 +489,7 @@ export default function TooltipPlugin({
 		isHovering,
 		contents,
 	]);
-	const isTooltipVisible = isHovering || tooltipBody != null;
+	const isTooltipVisible = tooltipBody != null;
 
 	if (!hasPlot) {
 		return null;

--- a/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/TooltipPlugin.tsx
+++ b/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/TooltipPlugin.tsx
@@ -107,12 +107,18 @@ export default function TooltipPlugin({
 		let removeSyncDisplayHook: (() => void) | null = null;
 		if (syncMode !== DashboardCursorSync.None && config.scales[0]?.props.time) {
 			config.setCursor({
-				sync: { key: syncKey, scales: ['x', 'y'] },
+				sync: {
+					key: syncKey,
+					scales:
+						syncMode === DashboardCursorSync.Crosshair
+							? ['x', 'y']
+							: ['x', null],
+				},
 			});
 
 			removeSyncDisplayHook = config.addHook(
 				'setCursor',
-				createSyncDisplayHook(syncKey, syncMetadata, controller),
+				createSyncDisplayHook(syncKey, syncMetadata, controller, syncMode),
 			);
 		}
 

--- a/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/TooltipPlugin.tsx
+++ b/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/TooltipPlugin.tsx
@@ -118,7 +118,7 @@ export default function TooltipPlugin({
 
 			removeSyncDisplayHook = config.addHook(
 				'setCursor',
-				createSyncDisplayHook(syncKey, syncMetadata, controller, syncMode),
+				createSyncDisplayHook(syncKey, syncMetadata, controller),
 			);
 		}
 

--- a/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/TooltipPlugin.tsx
+++ b/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/TooltipPlugin.tsx
@@ -121,7 +121,12 @@ export default function TooltipPlugin({
 		const onOutsideInteraction = (event: Event): void => {
 			const target = event.target as Node;
 			if (!containerRef.current?.contains(target)) {
-				dismissTooltip();
+				// Don't dismiss if the click landed inside any other pinned tooltip.
+				const isInsideAnyPinnedTooltip =
+					(target as Element).closest?.('[data-pinned="true"]') != null;
+				if (!isInsideAnyPinnedTooltip) {
+					dismissTooltip();
+				}
 			}
 		};
 

--- a/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/syncDisplayHook.ts
+++ b/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/syncDisplayHook.ts
@@ -115,11 +115,7 @@ function applyReceiverSync({
 		return [];
 	}
 
-	uPlotInstance.batch(() => {
-		for (const idx of matchingIdxs) {
-			uPlotInstance.setSeries(idx, { focus: true });
-		}
-	});
+	uPlotInstance.setSeries(matchingIdxs[0], { focus: true });
 
 	return matchingIdxs;
 }

--- a/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/syncDisplayHook.ts
+++ b/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/syncDisplayHook.ts
@@ -2,6 +2,7 @@ import uPlot from 'uplot';
 
 import type { ExtendedSeries } from '../../config/types';
 import { syncCursorRegistry } from './syncCursorRegistry';
+import { DashboardCursorSync } from './types';
 import type { TooltipControllerState, TooltipSyncMetadata } from './types';
 
 /**
@@ -124,6 +125,7 @@ export function createSyncDisplayHook(
 	syncKey: string,
 	syncMetadata: TooltipSyncMetadata | undefined,
 	controller: TooltipControllerState,
+	syncMode: DashboardCursorSync,
 ): (u: uPlot) => void {
 	// Cached once — avoids a DOM query on every cursor move.
 	let yCrosshairEl: HTMLElement | null = null;
@@ -147,7 +149,8 @@ export function createSyncDisplayHook(
 				syncMetadata,
 				focusedSeriesIndex: controller.focusedSeriesIndex,
 			});
-			yCrosshairEl.style.display = '';
+			yCrosshairEl.style.display =
+				syncMode === DashboardCursorSync.Crosshair ? '' : 'none';
 			return;
 		}
 

--- a/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/syncDisplayHook.ts
+++ b/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/syncDisplayHook.ts
@@ -65,6 +65,12 @@ function applySourceSync({
 	syncCursorRegistry.setActiveSeriesMetric(syncKey, focusedSeries?.metric ?? null);
 }
 
+/**
+ * Returns:
+ *   null      – no groupBy filtering configured or cursor off-chart (no-op for tooltip)
+ *   []        – groupBy configured but no receiver series match the source (hide synced tooltip)
+ *   number[]  – 1-based indexes of matching receiver series (show only these)
+ */
 function applyReceiverSync({
 	uPlotInstance,
 	yCrosshairEl,
@@ -79,23 +85,23 @@ function applyReceiverSync({
 	syncMetadata: TooltipSyncMetadata | undefined;
 	sourceMetadata: TooltipSyncMetadata | undefined;
 	commonKeys: string[];
-}): void {
+}): number[] | null {
 	yCrosshairEl.style.display =
 		sourceMetadata?.yAxisUnit === syncMetadata?.yAxisUnit ? '' : 'none';
 
 	if (commonKeys.length === 0) {
-		return;
+		return null;
 	}
 
 	if ((uPlotInstance.cursor.left ?? -1) < 0) {
 		uPlotInstance.setSeries(null, { focus: false });
-		return;
+		return null;
 	}
 
 	const sourceSeriesMetric = syncCursorRegistry.getActiveSeriesMetric(syncKey);
 	if (sourceSeriesMetric == null) {
 		uPlotInstance.setSeries(null, { focus: false });
-		return;
+		return [];
 	}
 
 	const matchingIdxs = findMatchingSeriesIndexes(
@@ -106,7 +112,7 @@ function applyReceiverSync({
 
 	if (matchingIdxs.length === 0) {
 		uPlotInstance.setSeries(null, { focus: false });
-		return;
+		return [];
 	}
 
 	uPlotInstance.batch(() => {
@@ -114,6 +120,8 @@ function applyReceiverSync({
 			uPlotInstance.setSeries(idx, { focus: true });
 		}
 	});
+
+	return matchingIdxs;
 }
 
 export function createSyncDisplayHook(
@@ -136,6 +144,7 @@ export function createSyncDisplayHook(
 		}
 
 		if (u.cursor.event != null) {
+			controller.syncedSeriesIndexes = null;
 			applySourceSync({
 				uPlotInstance: u,
 				syncKey,
@@ -158,7 +167,7 @@ export function createSyncDisplayHook(
 			);
 		}
 
-		applyReceiverSync({
+		controller.syncedSeriesIndexes = applyReceiverSync({
 			uPlotInstance: u,
 			yCrosshairEl,
 			syncKey,

--- a/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/syncDisplayHook.ts
+++ b/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/syncDisplayHook.ts
@@ -2,7 +2,6 @@ import uPlot from 'uplot';
 
 import type { ExtendedSeries } from '../../config/types';
 import { syncCursorRegistry } from './syncCursorRegistry';
-import { DashboardCursorSync } from './types';
 import type { TooltipControllerState, TooltipSyncMetadata } from './types';
 
 /**
@@ -125,7 +124,6 @@ export function createSyncDisplayHook(
 	syncKey: string,
 	syncMetadata: TooltipSyncMetadata | undefined,
 	controller: TooltipControllerState,
-	syncMode: DashboardCursorSync,
 ): (u: uPlot) => void {
 	// Cached once — avoids a DOM query on every cursor move.
 	let yCrosshairEl: HTMLElement | null = null;
@@ -149,8 +147,7 @@ export function createSyncDisplayHook(
 				syncMetadata,
 				focusedSeriesIndex: controller.focusedSeriesIndex,
 			});
-			yCrosshairEl.style.display =
-				syncMode === DashboardCursorSync.Crosshair ? '' : 'none';
+			yCrosshairEl.style.display = '';
 			return;
 		}
 

--- a/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/tooltipController.ts
+++ b/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/tooltipController.ts
@@ -27,6 +27,7 @@ export function createInitialControllerState(): TooltipControllerState {
 		verticalOffset: 0,
 		seriesIndexes: [],
 		focusedSeriesIndex: null,
+		syncedSeriesIndexes: null,
 		cursorDrivenBySync: false,
 		plotWithinViewport: false,
 		windowWidth: window.innerWidth - WINDOW_OFFSET,
@@ -184,7 +185,7 @@ export function createSetLegendHandler(
 			return;
 		}
 
-		const newSeriesIndexes = plot.cursor.idxs.slice();
+		const newSeriesIndexes = [...plot.cursor.idxs];
 		const isAnySeriesActive = newSeriesIndexes.some((v, i) => i > 0 && v != null);
 
 		const previousCursorDrivenBySync = controller.cursorDrivenBySync;

--- a/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/types.ts
+++ b/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/types.ts
@@ -97,6 +97,11 @@ export interface TooltipControllerState {
 	verticalOffset: number;
 	seriesIndexes: Array<number | null>;
 	focusedSeriesIndex: number | null;
+	/** Receiver-side series filtering for Tooltip sync mode.
+	 * null  = no filtering (source panel or no groupBy configured)
+	 * []    = no matching series found → hide the synced tooltip
+	 * [...] = only these 1-based series indexes should appear in the synced tooltip */
+	syncedSeriesIndexes: number[] | null;
 	cursorDrivenBySync: boolean;
 	plotWithinViewport: boolean;
 	windowWidth: number;

--- a/frontend/src/lib/uPlotV2/plugins/__tests__/TooltipPlugin.test.ts
+++ b/frontend/src/lib/uPlotV2/plugins/__tests__/TooltipPlugin.test.ts
@@ -210,7 +210,7 @@ describe('TooltipPlugin', () => {
 			expect(container.parentElement).toBe(document.body);
 
 			const fullscreenRoot = document.createElement('div');
-			document.body.appendChild(fullscreenRoot);
+			document.body.append(fullscreenRoot);
 
 			act(() => {
 				mockedFullscreenElement = fullscreenRoot;
@@ -252,7 +252,7 @@ describe('TooltipPlugin', () => {
 			renderAndActivateHover(config, undefined, { canPinTooltip: true });
 
 			const container = screen.getByTestId('tooltip-plugin-container');
-			expect(container.getAttribute('data-pinned') === 'true').toBe(false);
+			expect(container.dataset.pinned === 'true').toBe(false);
 
 			act(() => {
 				document.body.dispatchEvent(
@@ -266,7 +266,7 @@ describe('TooltipPlugin', () => {
 			return waitFor(() => {
 				const updated = screen.getByTestId('tooltip-plugin-container');
 				expect(updated).toBeInTheDocument();
-				expect(updated.getAttribute('data-pinned') === 'true').toBe(true);
+				expect(updated.dataset.pinned === 'true').toBe(true);
 			});
 		});
 
@@ -340,7 +340,7 @@ describe('TooltipPlugin', () => {
 			// Wait until the tooltip is actually pinned.
 			await waitFor(() => {
 				const container = screen.getByTestId('tooltip-plugin-container');
-				expect(container.getAttribute('data-pinned') === 'true').toBe(true);
+				expect(container.dataset.pinned === 'true').toBe(true);
 			});
 
 			const button = await screen.findByRole('button', { name: 'Dismiss' });
@@ -353,7 +353,7 @@ describe('TooltipPlugin', () => {
 
 				expect(container).toBeInTheDocument();
 				expect(container.getAttribute('aria-hidden')).toBe('true');
-				expect(container.getAttribute('data-pinned') === 'true').toBe(false);
+				expect(container.dataset.pinned === 'true').toBe(false);
 				expect(container.textContent).toBe('');
 			});
 		});
@@ -392,8 +392,7 @@ describe('TooltipPlugin', () => {
 
 			expect(
 				screen
-					.getByTestId('tooltip-plugin-container')
-					.getAttribute('data-pinned') === 'true',
+					.getByTestId('tooltip-plugin-container').dataset.pinned === 'true',
 			).toBe(true);
 
 			// Simulate data update – should dismiss the pinned tooltip.
@@ -405,7 +404,7 @@ describe('TooltipPlugin', () => {
 			const container = screen.getByTestId('tooltip-plugin-container');
 			expect(container).toBeInTheDocument();
 			expect(container.getAttribute('aria-hidden')).toBe('true');
-			expect(container.getAttribute('data-pinned') === 'true').toBe(false);
+			expect(container.dataset.pinned === 'true').toBe(false);
 
 			jest.useRealTimers();
 		});
@@ -444,8 +443,7 @@ describe('TooltipPlugin', () => {
 
 			expect(
 				screen
-					.getByTestId('tooltip-plugin-container')
-					.getAttribute('data-pinned') === 'true',
+					.getByTestId('tooltip-plugin-container').dataset.pinned === 'true',
 			).toBe(true);
 
 			// Click outside the tooltip container.
@@ -459,7 +457,7 @@ describe('TooltipPlugin', () => {
 
 				expect(container).toBeInTheDocument();
 				expect(container.getAttribute('aria-hidden')).toBe('true');
-				expect(container.getAttribute('data-pinned') === 'true').toBe(false);
+				expect(container.dataset.pinned === 'true').toBe(false);
 			});
 
 			jest.useRealTimers();
@@ -499,8 +497,7 @@ describe('TooltipPlugin', () => {
 
 			expect(
 				screen
-					.getByTestId('tooltip-plugin-container')
-					.getAttribute('data-pinned') === 'true',
+					.getByTestId('tooltip-plugin-container').dataset.pinned === 'true',
 			).toBe(true);
 
 			// Press Escape to release.
@@ -515,7 +512,7 @@ describe('TooltipPlugin', () => {
 				const container = screen.getByTestId('tooltip-plugin-container');
 				expect(container).toBeInTheDocument();
 				expect(container.getAttribute('aria-hidden')).toBe('true');
-				expect(container.getAttribute('data-pinned') === 'true').toBe(false);
+				expect(container.dataset.pinned === 'true').toBe(false);
 			});
 
 			jest.useRealTimers();
@@ -542,8 +539,7 @@ describe('TooltipPlugin', () => {
 			await waitFor(() => {
 				expect(
 					screen
-						.getByTestId('tooltip-plugin-container')
-						.getAttribute('data-pinned') === 'true',
+						.getByTestId('tooltip-plugin-container').dataset.pinned === 'true',
 				).toBe(true);
 			});
 
@@ -560,7 +556,7 @@ describe('TooltipPlugin', () => {
 
 			await waitFor(() => {
 				const container = screen.getByTestId('tooltip-plugin-container');
-				expect(container.getAttribute('data-pinned') === 'true').toBe(false);
+				expect(container.dataset.pinned === 'true').toBe(false);
 			});
 
 			jest.useRealTimers();
@@ -580,7 +576,7 @@ describe('TooltipPlugin', () => {
 			const container = screen.getByTestId('tooltip-plugin-container');
 			// Tooltip should still be hovering (visible), not dismissed.
 			expect(container.getAttribute('aria-hidden')).toBe('false');
-			expect(container.getAttribute('data-pinned') === 'true').toBe(false);
+			expect(container.dataset.pinned === 'true').toBe(false);
 		});
 
 		it('does not unpin on arbitrary keys that are not Escape or the pin key', async () => {
@@ -604,8 +600,7 @@ describe('TooltipPlugin', () => {
 			await waitFor(() => {
 				expect(
 					screen
-						.getByTestId('tooltip-plugin-container')
-						.getAttribute('data-pinned') === 'true',
+						.getByTestId('tooltip-plugin-container').dataset.pinned === 'true',
 				).toBe(true);
 			});
 
@@ -620,8 +615,7 @@ describe('TooltipPlugin', () => {
 			await waitFor(() => {
 				expect(
 					screen
-						.getByTestId('tooltip-plugin-container')
-						.getAttribute('data-pinned') === 'true',
+						.getByTestId('tooltip-plugin-container').dataset.pinned === 'true',
 				).toBe(true);
 			});
 
@@ -665,7 +659,7 @@ describe('TooltipPlugin', () => {
 			});
 
 			const container = screen.getByTestId('tooltip-plugin-container');
-			expect(container.getAttribute('data-pinned') === 'true').toBe(false);
+			expect(container.dataset.pinned === 'true').toBe(false);
 		});
 
 		it('does not pin when hover is not active', () => {
@@ -699,7 +693,7 @@ describe('TooltipPlugin', () => {
 			// The container exists once the plot is initialised, but it should
 			// be hidden and not pinned since hover was never activated.
 			const container = screen.getByTestId('tooltip-plugin-container');
-			expect(container.getAttribute('data-pinned') === 'true').toBe(false);
+			expect(container.dataset.pinned === 'true').toBe(false);
 			expect(container.getAttribute('aria-hidden')).toBe('true');
 		});
 
@@ -724,8 +718,7 @@ describe('TooltipPlugin', () => {
 			await waitFor(() => {
 				expect(
 					screen
-						.getByTestId('tooltip-plugin-container')
-						.getAttribute('data-pinned') === 'true',
+						.getByTestId('tooltip-plugin-container').dataset.pinned === 'true',
 				).toBe(false);
 			});
 
@@ -739,8 +732,7 @@ describe('TooltipPlugin', () => {
 			await waitFor(() => {
 				expect(
 					screen
-						.getByTestId('tooltip-plugin-container')
-						.getAttribute('data-pinned') === 'true',
+						.getByTestId('tooltip-plugin-container').dataset.pinned === 'true',
 				).toBe(true);
 			});
 		});
@@ -796,7 +788,7 @@ describe('TooltipPlugin', () => {
 	// ---- Cursor sync ------------------------------------------------------------
 
 	describe('cursor sync', () => {
-		it('enables uPlot cursor sync for time-based scales when mode is Tooltip', () => {
+		it('enables uPlot cursor sync on x-axis only when mode is Tooltip', () => {
 			const config = createConfigMock();
 			const setCursorSpy = jest.spyOn(config, 'setCursor');
 			config.addScale({ scaleKey: 'x', time: true });
@@ -806,6 +798,25 @@ describe('TooltipPlugin', () => {
 					config,
 					render: () => null,
 					syncMode: DashboardCursorSync.Tooltip,
+					syncKey: 'dashboard-sync',
+				}),
+			);
+
+			expect(setCursorSpy).toHaveBeenCalledWith({
+				sync: { key: 'dashboard-sync', scales: ['x', null] },
+			});
+		});
+
+		it('enables uPlot cursor sync on both axes when mode is Crosshair', () => {
+			const config = createConfigMock();
+			const setCursorSpy = jest.spyOn(config, 'setCursor');
+			config.addScale({ scaleKey: 'x', time: true });
+
+			render(
+				React.createElement(TooltipPlugin, {
+					config,
+					render: () => null,
+					syncMode: DashboardCursorSync.Crosshair,
 					syncKey: 'dashboard-sync',
 				}),
 			);


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

When the dashboard tooltip sync is active and the source panel has a focused series (via crosshair + series highlight), the receiver tooltip was showing all series for the crosshair timestamp instead of only the matching series. This PR threads `syncedSeriesIndexes` through the sync pipeline so receiver tooltips filter their content to the series that correspond to the source panel's highlighted series, and suppress themselves entirely when no match exists.

Two additional fixes are bundled:
- Clicking inside another pinned tooltip no longer dismisses an unrelated pinned tooltip (outside-click guard was too broad).
- `isTooltipVisible` is now driven solely by whether `tooltipBody` is non-null, removing a stale `isHovering` fallback that caused a brief visible flash.

#### Screenshots / Screen Recordings (if applicable)

_Add before/after recording showing tooltip sync with series highlight._

#### Issues closed by this PR

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
`applyReceiverSync` applied crosshair series highlighting (via `setSeries`) but discarded the computed matching series indexes — returning `void`. The tooltip renderer had no way to know which series the receiver panel was focusing, so it always built content from the full series list.

The outside-click dismiss handler also lacked awareness of other pinned tooltips: any click landing outside the _current_ tooltip container triggered `dismissTooltip`, even if the click was inside a sibling pinned tooltip.

#### Fix Strategy
- Changed `applyReceiverSync` to return `number[] | null` (`null` = no filtering, `[]` = no match → hide, `[…]` = allowed 1-based series indexes).
- Stored the return value as `controller.syncedSeriesIndexes`, initialised to `null`, and reset to `null` on source-driven cursor events.
- Threaded `syncedSeriesIndexes` from the controller → `TooltipPlugin` render args → `buildTooltipContent`, where it gates which series items are included and adds a "No Data" placeholder for synced series with no value at the cursor position.
- Suppressed the receiver tooltip entirely (returns `null`) when `syncedSeriesIndexes` is an empty array.
- Narrowed the outside-click guard with `closest('[data-pinned="true"]')` to skip dismissal when the click lands inside any pinned tooltip.

---

### 🧪 Testing Strategy

- Tests added/updated: existing `TooltipPlugin` and tooltip unit tests pass; `buildTooltipContent` is covered by existing utils tests.
- Manual verification: dashboard with two synced panels — hover over a series in the source panel and confirm the receiver tooltip shows only the matching series (or hides when none match). Verified pinned tooltips are not dismissed by clicks on sibling pinned tooltips.
- Edge cases covered:
  - `syncedSeriesIndexes = null`: receiver shows all series (no filtering).
  - `syncedSeriesIndexes = []`: receiver tooltip is fully suppressed.
  - Synced series with `null` dataIndex: rendered as "No Data" placeholder instead of being silently skipped.
  - Source-panel cursor events reset `syncedSeriesIndexes` to `null` to avoid stale filtering.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: `buildTooltipContent` and `TooltipPlugin` — affects all chart tooltip variants (TimeSeries, BarChart, Histogram) only when `syncedSeriesIndexes` is non-null (i.e. only in tooltip-sync mode with a highlighted series). Non-synced tooltips are unaffected.
- Potential regressions: tooltip visibility timing (removal of `isHovering` from `isTooltipVisible`); pinned-tooltip outside-click behaviour.
- Rollback plan: revert the three commits on this branch; no schema or API changes.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix |
| Description | Synced tooltips on dashboard now show only the series matching the source panel's highlighted series, and hide entirely when no match is found. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- `applyReceiverSync` previously called `uPlotInstance.batch()` to focus multiple matching series simultaneously; this is replaced with a single `setSeries(matchingIdxs[0], { focus: true })` since the crosshair-series-highlight feature tracks one active series at a time. Confirm this aligns with the intended UX for panels where multiple series could theoretically match.
- The `[data-pinned="true"]` attribute used by the outside-click guard needs to be present on the tooltip container when pinned — verify `TooltipPlugin` sets this attribute correctly (it does via the `cx(Styles.pinned)` class, but `data-pinned` is a separate attribute that should be confirmed in the DOM).

---

