### PR TITLE
fix: improve password validation logic, error reporting, and frontend…

### DIFF
--- a/frontend/src/pages/SignUp/SignUp.tsx
+++ b/frontend/src/pages/SignUp/SignUp.tsx
@@ -87,6 +87,11 @@ function SignUp(): JSX.Element {
 	const handleValuesChange: (changedValues: Partial<FormValues>) => void = (
 		changedValues,
 	) => {
+		// Clear backend error on any change
+		if (formError) {
+			setFormError(null);
+		}
+
 		// Clear error if passwords match while typing (but don't set error until blur)
 		if ('password' in changedValues || 'confirmPassword' in changedValues) {
 			const { password, confirmPassword } = form.getFieldsValue();
@@ -117,11 +122,12 @@ function SignUp(): JSX.Element {
 	const isValidForm = useMemo(
 		(): boolean =>
 			!loading &&
+			!formError &&
 			Boolean(email?.trim()) &&
 			Boolean(password?.trim()) &&
 			Boolean(confirmPassword?.trim()) &&
 			!confirmPasswordError,
-		[loading, email, password, confirmPassword, confirmPasswordError],
+		[loading, email, password, confirmPassword, confirmPasswordError, formError],
 	);
 
 	return (

--- a/pkg/types/factor_password.go
+++ b/pkg/types/factor_password.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/valuer"
@@ -17,7 +18,7 @@ import (
 var (
 	symbols                                []rune = []rune("~!@#$%^&*()_+`-={}|[]\\:\"<>?,./")
 	minPasswordLength                      int    = 12
-	ErrInvalidPassword                            = errors.Newf(errors.TypeInvalidInput, errors.MustNewCode("invalid_password"), "password must be at least %d characters long, should contain at least one uppercase letter [A-Z], one lowercase letter [a-z], one number [0-9], and one symbol [%c].", minPasswordLength, symbols)
+	ErrInvalidPassword                            = errors.Newf(errors.TypeInvalidInput, errors.MustNewCode("invalid_password"), "password must be at least %d characters long, should contain at least one uppercase letter [A-Z], one lowercase letter [a-z], one number [0-9], and one symbol [%s].", minPasswordLength, string(symbols))
 	ErrCodeResetPasswordTokenAlreadyExists        = errors.MustNewCode("reset_password_token_already_exists")
 	ErrCodePasswordNotFound                       = errors.MustNewCode("password_not_found")
 	ErrCodeResetPasswordTokenNotFound             = errors.MustNewCode("reset_password_token_not_found")
@@ -155,7 +156,7 @@ func NewResetPasswordToken(passwordID valuer.UUID, expiresAt time.Time) (*ResetP
 }
 
 func IsPasswordValid(password string) bool {
-	if len(password) < minPasswordLength {
+	if utf8.RuneCountInString(password) < minPasswordLength {
 		return false
 	}
 


### PR DESCRIPTION

### 📄 Summary
 **Why does this change exist?**
 This PR addresses two critical issues in the SigNoz password validation flow:
 1.  **Backend Logic Error:** The password length was calculated using `len()`, which counts bytes instead of characters. This allowed 12-byte passwords (like 4 emojis) to pass a "12 character" requirement, while the error message itself was incorrectly formatted.
 2.  **Frontend UX Flaw:** Backend validation errors (e.g., "Password must contain...") persisted in the UI even after the user began correcting their input, leading to a "stale" error state and a confusing experience where the submit button remained disabled despite the user fixing the issue.

 **What problem does it solve?**
 It ensures that password length is correctly enforced for multi-byte characters and improves the Signup UX by clearing stale errors instantly upon user interaction. Tested locally


#### Issues closed by this PR
 Closes #11111

---

### ✅ Change Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
#### Root Cause
1.  **Backend:** Use of `len(password)` instead of `utf8.RuneCountInString(password)` and incorrect `%c` formatting in the error template.
2.  **Frontend:** The `SignUp` component lacked a trigger to reset `formError` state when `onValuesChange` occurred, and the submit button enablement logic didn't account for active backend errors.

#### Fix Strategy
1.  **Backend:** Migrated to `utf8` character counting and fixed the symbol whitelist string formatting in `pkg/types/factor_password.go`.
2.  **Frontend:** Added a `formError` reset to `handleValuesChange` and incorporated the error state into the `isValidForm` memoization to prevent premature submission attempts.

---

### 🧪 Testing Strategy
- **Tests added/updated:** Verified with `go test ./pkg/types/...`.
- **Manual verification:** Tested locally by wiping `signoz.db`, triggering validation errors, and verifying that they clear immediately upon typing. Verified that 6-character emoji passwords are now correctly rejected.

---

### ⚠️ Risk & Impact Assessment
- **Blast radius:** Limited to the Signup/Password validation logic.
- **Potential regressions:** None expected; the restrictive symbol whitelist remains unchanged as per maintainer preference.

---

### 📝 Changelog
| Field | Value |
|------|-------|
| Deployment Type | OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed password length calculation for multi-byte characters and resolved stale error messages on the signup page. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers
The restrictive symbol whitelist is maintained for now; a broader discussion on expanding this (e.g., adding `;` or spaces) should be held separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches password validation and signup UX: stricter rune-based length checks may reject some previously-accepted passwords and affects account creation flows. Changes are small and localized but in authentication-adjacent paths.
> 
> **Overview**
> Fixes password validation to count *characters* (UTF-8 runes) instead of bytes, and corrects the invalid-password error message to render the full allowed symbol set.
> 
> Improves the signup form UX by clearing backend `formError` as soon as the user edits any field and by keeping the submit button disabled while a backend error is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e61ff7f15fd424d25a47cd1a73edde307121f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->