### PR TITLE
fix(alertmanager): initialize email headers map

### DIFF
--- a/pkg/alertmanager/alertmanagernotify/email/email.go
+++ b/pkg/alertmanager/alertmanagernotify/email/email.go
@@ -48,6 +48,9 @@ var errNoAuthUsernameConfigured = errors.NewInternalf(errors.CodeInternal, "no a
 
 // New returns a new Email notifier.
 func New(c *config.EmailConfig, t *template.Template, l *slog.Logger) *Email {
+	if c.Headers == nil {
+		c.Headers = make(map[string]string)
+	}
 	if _, ok := c.Headers["Subject"]; !ok {
 		c.Headers["Subject"] = config.DefaultEmailSubject
 	}

--- a/pkg/alertmanager/alertmanagernotify/email/email_test.go
+++ b/pkg/alertmanager/alertmanagernotify/email/email_test.go
@@ -206,6 +206,21 @@ func prepare(cfg *config.EmailConfig) (*template.Template, *types.Alert, error) 
 	return tmpl, firingAlert, nil
 }
 
+func TestNewInitializesHeadersWhenNil(t *testing.T) {
+	cfg := &config.EmailConfig{
+		To:   emailTo,
+		From: emailFrom,
+	}
+
+	require.NotPanics(t, func() {
+		_ = New(cfg, &template.Template{}, promslog.NewNopLogger())
+	})
+	require.NotNil(t, cfg.Headers)
+	assert.Equal(t, config.DefaultEmailSubject, cfg.Headers["Subject"])
+	assert.Equal(t, cfg.To, cfg.Headers["To"])
+	assert.Equal(t, cfg.From, cfg.Headers["From"])
+}
+
 // TestEmailNotifyWithErrors tries to send emails with buggy inputs.
 func TestEmailNotifyWithErrors(t *testing.T) {
 	cfgFile := os.Getenv(emailNoAuthConfigVar)


### PR DESCRIPTION
`email.New` backfills Subject/To/From into `EmailConfig.Headers`, but configs created without a `headers` block leave that map nil and panic on the first write.

Initialize the headers map before applying those defaults, and add a regression test that hits the nil-map path.

Tests: `go test ./pkg/alertmanager/alertmanagernotify/... ./pkg/types/alertmanagertypes -count=1`

Fixes #11100

Submitted via ClawOSS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small defensive initialization in `email.New` plus a targeted unit test; behavior only changes for configs that previously had `Headers` unset (nil).
> 
> **Overview**
> Fixes a panic in the email notifier when `EmailConfig.Headers` is unset by initializing the headers map before defaulting `Subject`/`To`/`From` in `email.New`.
> 
> Adds a regression test (`TestNewInitializesHeadersWhenNil`) to ensure `New` does not panic and that the default header values are populated when `Headers` is nil.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6fabcc0416a5658539d15f317fdb72a47b11458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->