### PR TITLE
fix: improve table overflow handling in panel editor

### DIFF
--- a/frontend/src/components/ResizeTable/ResizeTable.styles.scss
+++ b/frontend/src/components/ResizeTable/ResizeTable.styles.scss
@@ -13,6 +13,27 @@
 }
 
 .resize-main-table {
+	.resize-handle {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		inset-inline-end: -5px;
+		width: 10px;
+		cursor: col-resize;
+
+		&::after {
+			content: '';
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			width: 1px;
+			height: 1.6em;
+			background-color: var(--l3-background);
+			transform: translate(-50%, -50%);
+			transition: background-color 0.2s;
+		}
+	}
+
 	.ant-table-body {
 		.ant-table-tbody {
 			.ant-table-row {
@@ -21,32 +42,6 @@
 						white-space: unset;
 					}
 				}
-			}
-		}
-	}
-}
-
-.logs-table,
-.traces-table {
-	.resize-table {
-		.resize-handle {
-			position: absolute;
-			top: 0;
-			bottom: 0;
-			inset-inline-end: -5px;
-			width: 10px;
-			cursor: col-resize;
-
-			&::after {
-				content: '';
-				position: absolute;
-				top: 50%;
-				left: 50%;
-				transform: translate(-50%, -50%);
-				width: 1px;
-				height: 1.6em;
-				background-color: var(--l3-background);
-				transition: background-color 0.2s;
 			}
 		}
 	}

--- a/frontend/src/container/GridTableComponent/styles.ts
+++ b/frontend/src/container/GridTableComponent/styles.ts
@@ -2,26 +2,35 @@ import styled from 'styled-components';
 
 export const WrapperStyled = styled.div`
 	height: 95%;
+	min-width: 0;
 	overflow: hidden;
 
 	& .ant-table-wrapper {
 		height: 100%;
+		min-width: 0;
 	}
 	& .ant-spin-nested-loading {
 		height: 100%;
+		min-width: 0;
 	}
 
 	& .ant-spin-container {
 		height: 100%;
+		min-width: 0;
 		display: flex;
 		flex-direction: column;
 	}
 	& .ant-table {
 		flex: 1;
-		overflow: auto;
+		min-width: 0;
+		overflow: hidden;
 
 		> .ant-table-container {
+			min-width: 0;
+
 			> .ant-table-content {
+				overflow-x: auto !important;
+
 				> table {
 					min-width: 99% !important;
 				}

--- a/frontend/src/container/GridTableComponent/styles.ts
+++ b/frontend/src/container/GridTableComponent/styles.ts
@@ -23,7 +23,8 @@ export const WrapperStyled = styled.div`
 	& .ant-table {
 		flex: 1;
 		min-width: 0;
-		overflow: hidden;
+		overflow-x: hidden;
+		overflow-y: auto;
 
 		> .ant-table-container {
 			min-width: 0;

--- a/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/WidgetGraphContainer.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/WidgetGraphContainer.tsx
@@ -17,6 +17,7 @@ function WidgetGraphContainer({
 	selectedWidget,
 	isLoadingPanelData,
 	enableDrillDown = false,
+	onColumnWidthsChange,
 }: WidgetGraphContainerProps): JSX.Element {
 	if (queryResponse.data && selectedGraph === PANEL_TYPES.BAR) {
 		const sortedSeriesData = getSortedSeriesData(
@@ -64,6 +65,7 @@ function WidgetGraphContainer({
 			setRequestData={setRequestData}
 			selectedGraph={selectedGraph}
 			enableDrillDown={enableDrillDown}
+			onColumnWidthsChange={onColumnWidthsChange}
 		/>
 	);
 }

--- a/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/WidgetGraphs.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/WidgetGraphs.tsx
@@ -39,6 +39,7 @@ function WidgetGraph({
 	setRequestData,
 	selectedGraph,
 	enableDrillDown = false,
+	onColumnWidthsChange,
 }: WidgetGraphProps): JSX.Element {
 	const graphRef = useRef<HTMLDivElement>(null);
 	const lineChartRef = useRef<ToggleGraphProps>();
@@ -195,6 +196,7 @@ function WidgetGraph({
 				graphVisibility={graphVisibility}
 				setGraphVisibility={setGraphVisibility}
 				enableDrillDown={enableDrillDown}
+				onColumnWidthsChange={onColumnWidthsChange}
 			/>
 		</div>
 	);
@@ -209,6 +211,7 @@ interface WidgetGraphProps {
 	setRequestData: Dispatch<SetStateAction<GetQueryResultsProps>>;
 	selectedGraph: PANEL_TYPES;
 	enableDrillDown?: boolean;
+	onColumnWidthsChange?: (widths: Record<string, number>) => void;
 }
 
 export default WidgetGraph;

--- a/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/index.tsx
@@ -24,6 +24,7 @@ function WidgetGraph({
 	isLoadingPanelData,
 	enableDrillDown = false,
 	isCancelled = false,
+	onColumnWidthsChange,
 }: WidgetGraphContainerProps): JSX.Element {
 	const { currentQuery } = useQueryBuilder();
 
@@ -64,6 +65,7 @@ function WidgetGraph({
 					setRequestData={setRequestData}
 					selectedWidget={selectedWidget}
 					enableDrillDown={enableDrillDown}
+					onColumnWidthsChange={onColumnWidthsChange}
 				/>
 			)}
 		</Container>

--- a/frontend/src/container/NewWidget/LeftContainer/index.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/index.tsx
@@ -32,6 +32,7 @@ function LeftContainer({
 	enableDrillDown = false,
 	dashboardData,
 	isNewPanel = false,
+	onColumnWidthsChange,
 }: WidgetGraphProps): JSX.Element {
 	const { stagedQuery } = useQueryBuilder();
 	const queryClient = useQueryClient();
@@ -87,6 +88,7 @@ function LeftContainer({
 				isLoadingPanelData={isLoadingPanelData}
 				enableDrillDown={enableDrillDown}
 				isCancelled={isCancelled}
+				onColumnWidthsChange={onColumnWidthsChange}
 			/>
 			<QueryContainer className="query-section-left-container">
 				<QuerySection

--- a/frontend/src/container/NewWidget/NewWidget.styles.scss
+++ b/frontend/src/container/NewWidget/NewWidget.styles.scss
@@ -44,11 +44,13 @@
 
 .new-widget-container {
 	.resizable-panel-left-container {
+		min-width: 0;
 		overflow-x: hidden;
 		overflow-y: auto;
 	}
 
 	.resizable-panel-right-container {
+		flex-shrink: 0;
 		overflow-y: auto !important;
 		min-width: 350px;
 
@@ -65,6 +67,9 @@
 	}
 
 	.widget-resizable-panel-group {
+		min-width: 0;
+		width: 100%;
+
 		.widget-resizable-handle {
 			height: 100vh;
 			background: color-mix(in srgb, var(--l3-background) 20%, transparent);

--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -320,7 +320,7 @@ function NewWidget({
 				isLogScale,
 				legendPosition,
 				customLegendColors,
-				columnWidths: selectedWidget.columnWidths,
+				columnWidths: prev.columnWidths,
 				contextLinks,
 			};
 		});
@@ -352,7 +352,6 @@ function NewWidget({
 		spanGaps,
 		customLegendColors,
 		contextLinks,
-		selectedWidget.columnWidths,
 	]);
 
 	const closeModal = (): void => {

--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -176,6 +176,22 @@ function NewWidget({
 
 	const [selectedWidget, setSelectedWidget] = useState(getWidget());
 
+	const handleColumnWidthsChange = useCallback(
+		(widths: Record<string, number>): void => {
+			setSelectedWidget((prev) => {
+				if (!prev) {
+					return prev;
+				}
+
+				return {
+					...prev,
+					columnWidths: widths,
+				};
+			});
+		},
+		[],
+	);
+
 	const [title, setTitle] = useState<string>(
 		selectedWidget?.title?.toString() || '',
 	);
@@ -879,6 +895,7 @@ function NewWidget({
 									isLoadingPanelData={isLoadingPanelData}
 									setQueryResponse={setQueryResponse}
 									enableDrillDown={enableDrillDown}
+									onColumnWidthsChange={handleColumnWidthsChange}
 								/>
 							)}
 						</OverlayScrollbar>

--- a/frontend/src/container/NewWidget/styles.ts
+++ b/frontend/src/container/NewWidget/styles.ts
@@ -17,7 +17,10 @@ export const ButtonContainer = styled.div`
 
 export const PanelContainer = styled.div`
 	display: flex;
-	overflow-y: auto;
+	flex: 1;
+	min-height: 0;
+	width: 100%;
+	overflow: hidden;
 `;
 
 export const Tag = styled(AntDTag)`

--- a/frontend/src/container/NewWidget/types.ts
+++ b/frontend/src/container/NewWidget/types.ts
@@ -36,6 +36,7 @@ export interface WidgetGraphProps {
 	enableDrillDown?: boolean;
 	dashboardData: Dashboard | undefined;
 	isNewPanel?: boolean;
+	onColumnWidthsChange?: (widths: Record<string, number>) => void;
 }
 
 export type WidgetGraphContainerProps = {
@@ -51,4 +52,5 @@ export type WidgetGraphContainerProps = {
 	isLoadingPanelData: boolean;
 	enableDrillDown?: boolean;
 	isCancelled?: boolean;
+	onColumnWidthsChange?: (widths: Record<string, number>) => void;
 };

--- a/frontend/src/container/QueryTable/QueryTable.styles.scss
+++ b/frontend/src/container/QueryTable/QueryTable.styles.scss
@@ -1,6 +1,9 @@
 .query-table {
 	position: relative;
 	height: inherit;
+	min-width: 0;
+	overflow: hidden;
+
 	.query-table--download {
 		position: absolute;
 		top: 15px;
@@ -9,9 +12,23 @@
 	}
 
 	.ant-table {
+		min-width: 0;
+		overflow: hidden;
+
 		&::-webkit-scrollbar {
 			width: 0.1rem;
 		}
+	}
+
+	.ant-table-wrapper,
+	.ant-spin-nested-loading,
+	.ant-spin-container,
+	.ant-table-container {
+		min-width: 0;
+	}
+
+	.ant-table-content {
+		overflow-x: auto !important;
 	}
 
 	.clickable-cell {

--- a/frontend/src/container/QueryTable/QueryTable.styles.scss
+++ b/frontend/src/container/QueryTable/QueryTable.styles.scss
@@ -13,7 +13,8 @@
 
 	.ant-table {
 		min-width: 0;
-		overflow: hidden;
+		overflow-x: hidden;
+		overflow-y: auto;
 
 		&::-webkit-scrollbar {
 			width: 0.1rem;


### PR DESCRIPTION
## Summary
- Added horizontal overflow guardrails for table panels in the panel editor.
- Wired edit-mode table column resize changes into widget state so resized column widths are preserved on save.
- Made the table column resize handle visible for table panels.

## Why
Fixes #7170. Wide table panels could overlap or become hard to inspect inside the panel editor, especially with the right settings panel visible.

## Testing
- Ran the frontend locally and verified table overflow handling in the panel editor.
- Verified horizontal scroll, vertical scroll, and column resize behavior with the right settings panel open.
- Ran `git diff --check`.
- Could not run automated frontend tests locally because `node_modules` was not available in the original workspace check, so `jest` and `oxlint` were not executed.


## Demo
- Video showing table overflow handling, horizontal scroll, vertical scroll, and column resize behavior in the panel editor.


https://github.com/user-attachments/assets/75ff1218-2100-453b-a2d9-e4caf6c10407

