### PR TITLE
fix: added fix for groupby being undefined

### DIFF
--- a/frontend/src/container/DashboardContainer/visualization/panels/BarPanel/BarPanel.tsx
+++ b/frontend/src/container/DashboardContainer/visualization/panels/BarPanel/BarPanel.tsx
@@ -14,6 +14,7 @@ import { usePanelContextMenu } from '../../hooks/usePanelContextMenu';
 import { prepareBarPanelConfig, prepareBarPanelData } from './utils';
 
 import '../Panel.styles.scss';
+import get from 'lodash/get';
 
 function BarPanel(props: PanelWrapperProps): JSX.Element {
 	const {
@@ -114,7 +115,7 @@ function BarPanel(props: PanelWrapperProps): JSX.Element {
 	}, []);
 
 	const groupBy = useMemo(() => {
-		return widget.query.builder.queryData[0].groupBy;
+		return get(widget, 'query.builder.queryData[0].groupBy', []);
 	}, [widget.query]);
 
 	return (

--- a/frontend/src/container/DashboardContainer/visualization/panels/TimeSeriesPanel/TimeSeriesPanel.tsx
+++ b/frontend/src/container/DashboardContainer/visualization/panels/TimeSeriesPanel/TimeSeriesPanel.tsx
@@ -10,6 +10,7 @@ import { ContextMenu } from 'periscope/components/ContextMenu';
 import { useTimezone } from 'providers/Timezone';
 import uPlot from 'uplot';
 import { getTimeRange } from 'utils/getTimeRange';
+import get from 'lodash/get';
 
 import { prepareChartData, prepareUPlotConfig } from '../TimeSeriesPanel/utils';
 
@@ -105,7 +106,7 @@ function TimeSeriesPanel(props: PanelWrapperProps): JSX.Element {
 	]);
 
 	const groupBy = useMemo(() => {
-		return widget.query.builder.queryData[0].groupBy;
+		return get(widget, 'query.builder.queryData[0].groupBy', []);
 	}, [widget.query]);
 
 	return (


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Two dashboard panel components (`BarPanel` and `TimeSeriesPanel`) read `groupBy` directly from `widget.query.builder.queryData[0].groupBy`. When the widget query shape is partially populated (e.g. a freshly added panel, an in-flight migration, or a widget without builder query data), `queryData[0]` can be undefined, causing a `TypeError` when accessing `.groupBy` and breaking panel rendering. This PR guards both reads with `lodash/get` and a default of `[]` so panels render safely regardless of the intermediate widget state.

#### Screenshots / Screen Recordings (if applicable)
N/A — defensive read against undefined; no visual change on the happy path.

#### Issues closed by this PR
N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
`BarPanel` and `TimeSeriesPanel` accessed `widget.query.builder.queryData[0].groupBy` without guarding against `queryData[0]` being undefined. In states where the widget's builder query data is empty/not yet hydrated, this throws `TypeError: Cannot read properties of undefined (reading 'groupBy')` and the panel fails to render.

#### Fix Strategy
Replace the direct property access with `get(widget, 'query.builder.queryData[0].groupBy', [])` in both panels so a missing path resolves to an empty array, matching the downstream consumer's expected shape.

---

### 🧪 Testing Strategy

- Tests added/updated: None — change is a localized null-safety guard with the same semantics as the previous code path when data is present.
- Manual verification: Loaded dashboards containing bar and time-series panels; verified panels render correctly when `groupBy` is populated and no longer crash when `queryData[0]` is missing.
- Edge cases covered: `widget.query` undefined, `builder.queryData` empty, `queryData[0]` undefined — all now resolve to `[]`.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Limited to two panel components (`BarPanel`, `TimeSeriesPanel`) on dashboards. Behavior is unchanged when `groupBy` exists.
- Potential regressions: Very low. Default `[]` matches the type previously returned when `groupBy` was set; downstream code already iterates this list.
- Rollback plan: Revert this single commit (`fbd45bb99`).

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fix dashboard bar and time-series panels crashing when widget query data is not fully populated. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Two new `import get from 'lodash/get';` lines were added below the existing SCSS import in each file. If the project's import-order lint rule prefers grouping these with the other `lodash/*` or third-party imports, feel free to reorder.
- Same fix applied symmetrically in both panels — kept identical for consistency.

---
