### PR TITLE
chore(openapi): clean up generated schema names

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -1,6 +1,6 @@
 components:
   schemas:
-    AlertmanagertypesChannel:
+    AlertManagerChannel:
       properties:
         createdAt:
           format: date-time
@@ -25,7 +25,7 @@ components:
       - data
       - orgId
       type: object
-    AlertmanagertypesDeprecatedGettableAlert:
+    AlertManagerDeprecatedGettableAlert:
       properties:
         annotations:
           $ref: '#/components/schemas/ModelLabelSet'
@@ -47,14 +47,14 @@ components:
           format: date-time
           type: string
         status:
-          $ref: '#/components/schemas/TypesAlertStatus'
+          $ref: '#/components/schemas/AlertStatus'
       type: object
-    AlertmanagertypesExpressionKind:
+    AlertManagerExpressionKind:
       enum:
       - rule
       - policy
       type: string
-    AlertmanagertypesGettableRoutePolicy:
+    AlertManagerGettableRoutePolicy:
       properties:
         channels:
           items:
@@ -74,7 +74,7 @@ components:
         id:
           type: string
         kind:
-          $ref: '#/components/schemas/AlertmanagertypesExpressionKind'
+          $ref: '#/components/schemas/AlertManagerExpressionKind'
         name:
           type: string
         tags:
@@ -96,7 +96,7 @@ components:
       - createdAt
       - updatedAt
       type: object
-    AlertmanagertypesPostableRoutePolicy:
+    AlertManagerPostableRoutePolicy:
       properties:
         channels:
           items:
@@ -108,7 +108,7 @@ components:
         expression:
           type: string
         kind:
-          $ref: '#/components/schemas/AlertmanagertypesExpressionKind'
+          $ref: '#/components/schemas/AlertManagerExpressionKind'
         name:
           type: string
         tags:
@@ -121,7 +121,22 @@ components:
       - channels
       - name
       type: object
-    AuthtypesAttributeMapping:
+    AlertStatus:
+      properties:
+        inhibitedBy:
+          items:
+            type: string
+          nullable: true
+          type: array
+        silencedBy:
+          items:
+            type: string
+          nullable: true
+          type: array
+        state:
+          type: string
+      type: object
+    AuthAttributeMapping:
       properties:
         email:
           type: string
@@ -132,68 +147,49 @@ components:
         role:
           type: string
       type: object
-    AuthtypesAuthDomainConfig:
-      properties:
-        googleAuthConfig:
-          $ref: '#/components/schemas/AuthtypesGoogleConfig'
-        oidcConfig:
-          $ref: '#/components/schemas/AuthtypesOIDCConfig'
-        roleMapping:
-          $ref: '#/components/schemas/AuthtypesRoleMapping'
-        samlConfig:
-          $ref: '#/components/schemas/AuthtypesSamlConfig'
-        ssoEnabled:
-          type: boolean
-        ssoType:
-          type: string
-      type: object
-    AuthtypesAuthNProviderInfo:
-      properties:
-        relayStatePath:
-          nullable: true
-          type: string
-      type: object
-    AuthtypesAuthNSupport:
-      properties:
-        callback:
-          items:
-            $ref: '#/components/schemas/AuthtypesCallbackAuthNSupport'
-          nullable: true
-          type: array
-        password:
-          items:
-            $ref: '#/components/schemas/AuthtypesPasswordAuthNSupport'
-          nullable: true
-          type: array
-      type: object
-    AuthtypesCallbackAuthNSupport:
+    AuthCallbackAuthNSupport:
       properties:
         provider:
           type: string
         url:
           type: string
       type: object
-    AuthtypesGettableAuthDomain:
+    AuthDomainConfig:
+      properties:
+        googleAuthConfig:
+          $ref: '#/components/schemas/AuthGoogleConfig'
+        oidcConfig:
+          $ref: '#/components/schemas/AuthOIDCConfig'
+        roleMapping:
+          $ref: '#/components/schemas/AuthRoleMapping'
+        samlConfig:
+          $ref: '#/components/schemas/AuthSamlConfig'
+        ssoEnabled:
+          type: boolean
+        ssoType:
+          type: string
+      type: object
+    AuthGettableAuthDomain:
       properties:
         authNProviderInfo:
-          $ref: '#/components/schemas/AuthtypesAuthNProviderInfo'
+          $ref: '#/components/schemas/AuthNProviderInfo'
         createdAt:
           format: date-time
           type: string
         googleAuthConfig:
-          $ref: '#/components/schemas/AuthtypesGoogleConfig'
+          $ref: '#/components/schemas/AuthGoogleConfig'
         id:
           type: string
         name:
           type: string
         oidcConfig:
-          $ref: '#/components/schemas/AuthtypesOIDCConfig'
+          $ref: '#/components/schemas/AuthOIDCConfig'
         orgId:
           type: string
         roleMapping:
-          $ref: '#/components/schemas/AuthtypesRoleMapping'
+          $ref: '#/components/schemas/AuthRoleMapping'
         samlConfig:
-          $ref: '#/components/schemas/AuthtypesSamlConfig'
+          $ref: '#/components/schemas/AuthSamlConfig'
         ssoEnabled:
           type: boolean
         ssoType:
@@ -204,10 +200,10 @@ components:
       required:
       - id
       type: object
-    AuthtypesGettableObjects:
+    AuthGettableObjects:
       properties:
         resource:
-          $ref: '#/components/schemas/AuthtypesResource'
+          $ref: '#/components/schemas/AuthResource'
         selectors:
           items:
             type: string
@@ -216,7 +212,7 @@ components:
       - resource
       - selectors
       type: object
-    AuthtypesGettableResources:
+    AuthGettableResources:
       properties:
         relations:
           additionalProperties:
@@ -227,13 +223,13 @@ components:
           type: object
         resources:
           items:
-            $ref: '#/components/schemas/AuthtypesResource'
+            $ref: '#/components/schemas/AuthResource'
           type: array
       required:
       - resources
       - relations
       type: object
-    AuthtypesGettableToken:
+    AuthGettableToken:
       properties:
         accessToken:
           type: string
@@ -244,12 +240,12 @@ components:
         tokenType:
           type: string
       type: object
-    AuthtypesGettableTransaction:
+    AuthGettableTransaction:
       properties:
         authorized:
           type: boolean
         object:
-          $ref: '#/components/schemas/AuthtypesObject'
+          $ref: '#/components/schemas/AuthObject'
         relation:
           type: string
       required:
@@ -257,7 +253,7 @@ components:
       - object
       - authorized
       type: object
-    AuthtypesGoogleConfig:
+    AuthGoogleConfig:
       properties:
         allowedGroups:
           items:
@@ -282,10 +278,29 @@ components:
         serviceAccountJson:
           type: string
       type: object
-    AuthtypesOIDCConfig:
+    AuthNProviderInfo:
+      properties:
+        relayStatePath:
+          nullable: true
+          type: string
+      type: object
+    AuthNSupport:
+      properties:
+        callback:
+          items:
+            $ref: '#/components/schemas/AuthCallbackAuthNSupport'
+          nullable: true
+          type: array
+        password:
+          items:
+            $ref: '#/components/schemas/AuthPasswordAuthNSupport'
+          nullable: true
+          type: array
+      type: object
+    AuthOIDCConfig:
       properties:
         claimMapping:
-          $ref: '#/components/schemas/AuthtypesAttributeMapping'
+          $ref: '#/components/schemas/AuthAttributeMapping'
         clientId:
           type: string
         clientSecret:
@@ -299,20 +314,20 @@ components:
         issuerAlias:
           type: string
       type: object
-    AuthtypesObject:
+    AuthObject:
       properties:
         resource:
-          $ref: '#/components/schemas/AuthtypesResource'
+          $ref: '#/components/schemas/AuthResource'
         selector:
           type: string
       required:
       - resource
       - selector
       type: object
-    AuthtypesOrgSessionContext:
+    AuthOrgSessionContext:
       properties:
         authNSupport:
-          $ref: '#/components/schemas/AuthtypesAuthNSupport'
+          $ref: '#/components/schemas/AuthNSupport'
         id:
           type: string
         name:
@@ -320,42 +335,42 @@ components:
         warning:
           $ref: '#/components/schemas/ErrorsJSON'
       type: object
-    AuthtypesPasswordAuthNSupport:
+    AuthPasswordAuthNSupport:
       properties:
         provider:
           type: string
       type: object
-    AuthtypesPatchableObjects:
+    AuthPatchableObjects:
       properties:
         additions:
           items:
-            $ref: '#/components/schemas/AuthtypesGettableObjects'
+            $ref: '#/components/schemas/AuthGettableObjects'
           nullable: true
           type: array
         deletions:
           items:
-            $ref: '#/components/schemas/AuthtypesGettableObjects'
+            $ref: '#/components/schemas/AuthGettableObjects'
           nullable: true
           type: array
       required:
       - additions
       - deletions
       type: object
-    AuthtypesPatchableRole:
+    AuthPatchableRole:
       properties:
         description:
           type: string
       required:
       - description
       type: object
-    AuthtypesPostableAuthDomain:
+    AuthPostableAuthDomain:
       properties:
         config:
-          $ref: '#/components/schemas/AuthtypesAuthDomainConfig'
+          $ref: '#/components/schemas/AuthDomainConfig'
         name:
           type: string
       type: object
-    AuthtypesPostableEmailPasswordSession:
+    AuthPostableEmailPasswordSession:
       properties:
         email:
           type: string
@@ -364,7 +379,7 @@ components:
         password:
           type: string
       type: object
-    AuthtypesPostableRole:
+    AuthPostableRole:
       properties:
         description:
           type: string
@@ -373,12 +388,12 @@ components:
       required:
       - name
       type: object
-    AuthtypesPostableRotateToken:
+    AuthPostableRotateToken:
       properties:
         refreshToken:
           type: string
       type: object
-    AuthtypesResource:
+    AuthResource:
       properties:
         name:
           type: string
@@ -388,7 +403,7 @@ components:
       - name
       - type
       type: object
-    AuthtypesRole:
+    AuthRole:
       properties:
         createdAt:
           format: date-time
@@ -413,7 +428,7 @@ components:
       - type
       - orgId
       type: object
-    AuthtypesRoleMapping:
+    AuthRoleMapping:
       properties:
         defaultRole:
           type: string
@@ -425,10 +440,10 @@ components:
         useRoleAttribute:
           type: boolean
       type: object
-    AuthtypesSamlConfig:
+    AuthSamlConfig:
       properties:
         attributeMapping:
-          $ref: '#/components/schemas/AuthtypesAttributeMapping'
+          $ref: '#/components/schemas/AuthAttributeMapping'
         insecureSkipAuthNRequestsSigned:
           type: boolean
         samlCert:
@@ -438,32 +453,32 @@ components:
         samlIdp:
           type: string
       type: object
-    AuthtypesSessionContext:
+    AuthSessionContext:
       properties:
         exists:
           type: boolean
         orgs:
           items:
-            $ref: '#/components/schemas/AuthtypesOrgSessionContext'
+            $ref: '#/components/schemas/AuthOrgSessionContext'
           nullable: true
           type: array
       type: object
-    AuthtypesTransaction:
+    AuthTransaction:
       properties:
         object:
-          $ref: '#/components/schemas/AuthtypesObject'
+          $ref: '#/components/schemas/AuthObject'
         relation:
           type: string
       required:
       - relation
       - object
       type: object
-    AuthtypesUpdateableAuthDomain:
+    AuthUpdateableAuthDomain:
       properties:
         config:
-          $ref: '#/components/schemas/AuthtypesAuthDomainConfig'
+          $ref: '#/components/schemas/AuthDomainConfig'
       type: object
-    AuthtypesUserRole:
+    AuthUserRole:
       properties:
         createdAt:
           format: date-time
@@ -471,7 +486,7 @@ components:
         id:
           type: string
         role:
-          $ref: '#/components/schemas/AuthtypesRole'
+          $ref: '#/components/schemas/AuthRole'
         roleId:
           type: string
         updatedAt:
@@ -487,7 +502,7 @@ components:
       - updatedAt
       - role
       type: object
-    AuthtypesUserWithRoles:
+    AuthUserWithRoles:
       properties:
         createdAt:
           format: date-time
@@ -509,13 +524,20 @@ components:
           type: string
         userRoles:
           items:
-            $ref: '#/components/schemas/AuthtypesUserRole'
+            $ref: '#/components/schemas/AuthUserRole'
           nullable: true
           type: array
       required:
       - id
       type: object
-    CloudintegrationtypesAWSAccountConfig:
+    ChangePasswordRequest:
+      properties:
+        newPassword:
+          type: string
+        oldPassword:
+          type: string
+      type: object
+    CloudIntegrationAWSAccountConfig:
       properties:
         regions:
           items:
@@ -524,7 +546,7 @@ components:
       required:
       - regions
       type: object
-    CloudintegrationtypesAWSCloudWatchLogsSubscription:
+    CloudIntegrationAWSCloudWatchLogsSubscription:
       properties:
         filterPattern:
           type: string
@@ -534,7 +556,7 @@ components:
       - logGroupNamePrefix
       - filterPattern
       type: object
-    CloudintegrationtypesAWSCloudWatchMetricStreamFilter:
+    CloudIntegrationAWSCloudWatchMetricStreamFilter:
       properties:
         metricNames:
           items:
@@ -545,44 +567,44 @@ components:
       required:
       - namespace
       type: object
-    CloudintegrationtypesAWSConnectionArtifact:
+    CloudIntegrationAWSConnectionArtifact:
       properties:
         connectionUrl:
           type: string
       required:
       - connectionUrl
       type: object
-    CloudintegrationtypesAWSIntegrationConfig:
+    CloudIntegrationAWSIntegrationConfig:
       properties:
         enabledRegions:
           items:
             type: string
           type: array
         telemetryCollectionStrategy:
-          $ref: '#/components/schemas/CloudintegrationtypesAWSTelemetryCollectionStrategy'
+          $ref: '#/components/schemas/CloudIntegrationAWSTelemetryCollectionStrategy'
       required:
       - enabledRegions
       - telemetryCollectionStrategy
       type: object
-    CloudintegrationtypesAWSLogsCollectionStrategy:
+    CloudIntegrationAWSLogsCollectionStrategy:
       properties:
         subscriptions:
           items:
-            $ref: '#/components/schemas/CloudintegrationtypesAWSCloudWatchLogsSubscription'
+            $ref: '#/components/schemas/CloudIntegrationAWSCloudWatchLogsSubscription'
           type: array
       required:
       - subscriptions
       type: object
-    CloudintegrationtypesAWSMetricsCollectionStrategy:
+    CloudIntegrationAWSMetricsCollectionStrategy:
       properties:
         streamFilters:
           items:
-            $ref: '#/components/schemas/CloudintegrationtypesAWSCloudWatchMetricStreamFilter'
+            $ref: '#/components/schemas/CloudIntegrationAWSCloudWatchMetricStreamFilter'
           type: array
       required:
       - streamFilters
       type: object
-    CloudintegrationtypesAWSPostableAccountConfig:
+    CloudIntegrationAWSPostableAccountConfig:
       properties:
         deploymentRegion:
           type: string
@@ -594,14 +616,14 @@ components:
       - deploymentRegion
       - regions
       type: object
-    CloudintegrationtypesAWSServiceConfig:
+    CloudIntegrationAWSServiceConfig:
       properties:
         logs:
-          $ref: '#/components/schemas/CloudintegrationtypesAWSServiceLogsConfig'
+          $ref: '#/components/schemas/CloudIntegrationAWSServiceLogsConfig'
         metrics:
-          $ref: '#/components/schemas/CloudintegrationtypesAWSServiceMetricsConfig'
+          $ref: '#/components/schemas/CloudIntegrationAWSServiceMetricsConfig'
       type: object
-    CloudintegrationtypesAWSServiceLogsConfig:
+    CloudIntegrationAWSServiceLogsConfig:
       properties:
         enabled:
           type: boolean
@@ -612,17 +634,17 @@ components:
             type: array
           type: object
       type: object
-    CloudintegrationtypesAWSServiceMetricsConfig:
+    CloudIntegrationAWSServiceMetricsConfig:
       properties:
         enabled:
           type: boolean
       type: object
-    CloudintegrationtypesAWSTelemetryCollectionStrategy:
+    CloudIntegrationAWSTelemetryCollectionStrategy:
       properties:
         logs:
-          $ref: '#/components/schemas/CloudintegrationtypesAWSLogsCollectionStrategy'
+          $ref: '#/components/schemas/CloudIntegrationAWSLogsCollectionStrategy'
         metrics:
-          $ref: '#/components/schemas/CloudintegrationtypesAWSMetricsCollectionStrategy'
+          $ref: '#/components/schemas/CloudIntegrationAWSMetricsCollectionStrategy'
         s3Buckets:
           additionalProperties:
             items:
@@ -630,12 +652,12 @@ components:
             type: array
           type: object
       type: object
-    CloudintegrationtypesAccount:
+    CloudIntegrationAccount:
       properties:
         agentReport:
-          $ref: '#/components/schemas/CloudintegrationtypesAgentReport'
+          $ref: '#/components/schemas/CloudIntegrationAgentReport'
         config:
-          $ref: '#/components/schemas/CloudintegrationtypesAccountConfig'
+          $ref: '#/components/schemas/CloudIntegrationAccountConfig'
         createdAt:
           format: date-time
           type: string
@@ -664,14 +686,14 @@ components:
       - orgId
       - config
       type: object
-    CloudintegrationtypesAccountConfig:
+    CloudIntegrationAccountConfig:
       properties:
         aws:
-          $ref: '#/components/schemas/CloudintegrationtypesAWSAccountConfig'
+          $ref: '#/components/schemas/CloudIntegrationAWSAccountConfig'
         azure:
-          $ref: '#/components/schemas/CloudintegrationtypesAzureAccountConfig'
+          $ref: '#/components/schemas/CloudIntegrationAzureAccountConfig'
       type: object
-    CloudintegrationtypesAgentReport:
+    CloudIntegrationAgentReport:
       nullable: true
       properties:
         data:
@@ -685,15 +707,15 @@ components:
       - timestampMillis
       - data
       type: object
-    CloudintegrationtypesAssets:
+    CloudIntegrationAssets:
       properties:
         dashboards:
           items:
-            $ref: '#/components/schemas/CloudintegrationtypesDashboard'
+            $ref: '#/components/schemas/CloudIntegrationDashboard'
           nullable: true
           type: array
       type: object
-    CloudintegrationtypesAzureAccountConfig:
+    CloudIntegrationAzureAccountConfig:
       properties:
         deploymentRegion:
           type: string
@@ -705,7 +727,7 @@ components:
       - deploymentRegion
       - resourceGroups
       type: object
-    CloudintegrationtypesAzureConnectionArtifact:
+    CloudIntegrationAzureConnectionArtifact:
       properties:
         cliCommand:
           type: string
@@ -715,7 +737,7 @@ components:
       - cliCommand
       - cloudPowerShellCommand
       type: object
-    CloudintegrationtypesAzureIntegrationConfig:
+    CloudIntegrationAzureIntegrationConfig:
       properties:
         deploymentRegion:
           type: string
@@ -725,14 +747,14 @@ components:
           type: array
         telemetryCollectionStrategy:
           items:
-            $ref: '#/components/schemas/CloudintegrationtypesAzureTelemetryCollectionStrategy'
+            $ref: '#/components/schemas/CloudIntegrationAzureTelemetryCollectionStrategy'
           type: array
       required:
       - deploymentRegion
       - resourceGroups
       - telemetryCollectionStrategy
       type: object
-    CloudintegrationtypesAzureLogsCollectionStrategy:
+    CloudIntegrationAzureLogsCollectionStrategy:
       properties:
         categoryGroups:
           items:
@@ -741,34 +763,34 @@ components:
       required:
       - categoryGroups
       type: object
-    CloudintegrationtypesAzureMetricsCollectionStrategy:
+    CloudIntegrationAzureMetricsCollectionStrategy:
       type: object
-    CloudintegrationtypesAzureServiceConfig:
+    CloudIntegrationAzureServiceConfig:
       properties:
         logs:
-          $ref: '#/components/schemas/CloudintegrationtypesAzureServiceLogsConfig'
+          $ref: '#/components/schemas/CloudIntegrationAzureServiceLogsConfig'
         metrics:
-          $ref: '#/components/schemas/CloudintegrationtypesAzureServiceMetricsConfig'
+          $ref: '#/components/schemas/CloudIntegrationAzureServiceMetricsConfig'
       required:
       - logs
       - metrics
       type: object
-    CloudintegrationtypesAzureServiceLogsConfig:
+    CloudIntegrationAzureServiceLogsConfig:
       properties:
         enabled:
           type: boolean
       type: object
-    CloudintegrationtypesAzureServiceMetricsConfig:
+    CloudIntegrationAzureServiceMetricsConfig:
       properties:
         enabled:
           type: boolean
       type: object
-    CloudintegrationtypesAzureTelemetryCollectionStrategy:
+    CloudIntegrationAzureTelemetryCollectionStrategy:
       properties:
         logs:
-          $ref: '#/components/schemas/CloudintegrationtypesAzureLogsCollectionStrategy'
+          $ref: '#/components/schemas/CloudIntegrationAzureLogsCollectionStrategy'
         metrics:
-          $ref: '#/components/schemas/CloudintegrationtypesAzureMetricsCollectionStrategy'
+          $ref: '#/components/schemas/CloudIntegrationAzureMetricsCollectionStrategy'
         resourceProvider:
           type: string
         resourceType:
@@ -777,27 +799,7 @@ components:
       - resourceProvider
       - resourceType
       type: object
-    CloudintegrationtypesCloudIntegrationService:
-      nullable: true
-      properties:
-        cloudIntegrationId:
-          type: string
-        config:
-          $ref: '#/components/schemas/CloudintegrationtypesServiceConfig'
-        createdAt:
-          format: date-time
-          type: string
-        id:
-          type: string
-        type:
-          $ref: '#/components/schemas/CloudintegrationtypesServiceID'
-        updatedAt:
-          format: date-time
-          type: string
-      required:
-      - id
-      type: object
-    CloudintegrationtypesCollectedLogAttribute:
+    CloudIntegrationCollectedLogAttribute:
       properties:
         name:
           type: string
@@ -806,7 +808,7 @@ components:
         type:
           type: string
       type: object
-    CloudintegrationtypesCollectedMetric:
+    CloudIntegrationCollectedMetric:
       properties:
         description:
           type: string
@@ -817,14 +819,14 @@ components:
         unit:
           type: string
       type: object
-    CloudintegrationtypesConnectionArtifact:
+    CloudIntegrationConnectionArtifact:
       properties:
         aws:
-          $ref: '#/components/schemas/CloudintegrationtypesAWSConnectionArtifact'
+          $ref: '#/components/schemas/CloudIntegrationAWSConnectionArtifact'
         azure:
-          $ref: '#/components/schemas/CloudintegrationtypesAzureConnectionArtifact'
+          $ref: '#/components/schemas/CloudIntegrationAzureConnectionArtifact'
       type: object
-    CloudintegrationtypesCredentials:
+    CloudIntegrationCredentials:
       properties:
         ingestionKey:
           type: string
@@ -840,10 +842,10 @@ components:
       - ingestionUrl
       - ingestionKey
       type: object
-    CloudintegrationtypesDashboard:
+    CloudIntegrationDashboard:
       properties:
         definition:
-          $ref: '#/components/schemas/DashboardtypesStorableDashboardData'
+          $ref: '#/components/schemas/DashboardStorableDashboardData'
         description:
           type: string
         id:
@@ -851,39 +853,39 @@ components:
         title:
           type: string
       type: object
-    CloudintegrationtypesDataCollected:
+    CloudIntegrationDataCollected:
       properties:
         logs:
           items:
-            $ref: '#/components/schemas/CloudintegrationtypesCollectedLogAttribute'
+            $ref: '#/components/schemas/CloudIntegrationCollectedLogAttribute'
           nullable: true
           type: array
         metrics:
           items:
-            $ref: '#/components/schemas/CloudintegrationtypesCollectedMetric'
+            $ref: '#/components/schemas/CloudIntegrationCollectedMetric'
           nullable: true
           type: array
       type: object
-    CloudintegrationtypesGettableAccountWithConnectionArtifact:
+    CloudIntegrationGettableAccountWithConnectionArtifact:
       properties:
         connectionArtifact:
-          $ref: '#/components/schemas/CloudintegrationtypesConnectionArtifact'
+          $ref: '#/components/schemas/CloudIntegrationConnectionArtifact'
         id:
           type: string
       required:
       - id
       - connectionArtifact
       type: object
-    CloudintegrationtypesGettableAccounts:
+    CloudIntegrationGettableAccounts:
       properties:
         accounts:
           items:
-            $ref: '#/components/schemas/CloudintegrationtypesAccount'
+            $ref: '#/components/schemas/CloudIntegrationAccount'
           type: array
       required:
       - accounts
       type: object
-    CloudintegrationtypesGettableAgentCheckIn:
+    CloudIntegrationGettableAgentCheckIn:
       properties:
         account_id:
           type: string
@@ -892,9 +894,9 @@ components:
         cloudIntegrationId:
           type: string
         integration_config:
-          $ref: '#/components/schemas/CloudintegrationtypesIntegrationConfig'
+          $ref: '#/components/schemas/CloudIntegrationIntegrationConfig'
         integrationConfig:
-          $ref: '#/components/schemas/CloudintegrationtypesProviderIntegrationConfig'
+          $ref: '#/components/schemas/CloudIntegrationProviderIntegrationConfig'
         providerAccountId:
           type: string
         removed_at:
@@ -915,16 +917,16 @@ components:
       - integrationConfig
       - removedAt
       type: object
-    CloudintegrationtypesGettableServicesMetadata:
+    CloudIntegrationGettableServicesMetadata:
       properties:
         services:
           items:
-            $ref: '#/components/schemas/CloudintegrationtypesServiceMetadata'
+            $ref: '#/components/schemas/CloudIntegrationServiceMetadata'
           type: array
       required:
       - services
       type: object
-    CloudintegrationtypesIntegrationConfig:
+    CloudIntegrationIntegrationConfig:
       nullable: true
       properties:
         enabled_regions:
@@ -932,17 +934,17 @@ components:
             type: string
           type: array
         telemetry:
-          $ref: '#/components/schemas/CloudintegrationtypesOldAWSCollectionStrategy'
+          $ref: '#/components/schemas/CloudIntegrationOldAWSCollectionStrategy'
       required:
       - enabled_regions
       - telemetry
       type: object
-    CloudintegrationtypesOldAWSCollectionStrategy:
+    CloudIntegrationOldAWSCollectionStrategy:
       properties:
         aws_logs:
-          $ref: '#/components/schemas/CloudintegrationtypesOldAWSLogsStrategy'
+          $ref: '#/components/schemas/CloudIntegrationOldAWSLogsStrategy'
         aws_metrics:
-          $ref: '#/components/schemas/CloudintegrationtypesOldAWSMetricsStrategy'
+          $ref: '#/components/schemas/CloudIntegrationOldAWSMetricsStrategy'
         provider:
           type: string
         s3_buckets:
@@ -952,7 +954,7 @@ components:
             type: array
           type: object
       type: object
-    CloudintegrationtypesOldAWSLogsStrategy:
+    CloudIntegrationOldAWSLogsStrategy:
       properties:
         cloudwatch_logs_subscriptions:
           items:
@@ -965,7 +967,7 @@ components:
           nullable: true
           type: array
       type: object
-    CloudintegrationtypesOldAWSMetricsStrategy:
+    CloudIntegrationOldAWSMetricsStrategy:
       properties:
         cloudwatch_metric_stream_filters:
           items:
@@ -980,24 +982,24 @@ components:
           nullable: true
           type: array
       type: object
-    CloudintegrationtypesPostableAccount:
+    CloudIntegrationPostableAccount:
       properties:
         config:
-          $ref: '#/components/schemas/CloudintegrationtypesPostableAccountConfig'
+          $ref: '#/components/schemas/CloudIntegrationPostableAccountConfig'
         credentials:
-          $ref: '#/components/schemas/CloudintegrationtypesCredentials'
+          $ref: '#/components/schemas/CloudIntegrationCredentials'
       required:
       - config
       - credentials
       type: object
-    CloudintegrationtypesPostableAccountConfig:
+    CloudIntegrationPostableAccountConfig:
       properties:
         aws:
-          $ref: '#/components/schemas/CloudintegrationtypesAWSPostableAccountConfig'
+          $ref: '#/components/schemas/CloudIntegrationAWSPostableAccountConfig'
         azure:
-          $ref: '#/components/schemas/CloudintegrationtypesAzureAccountConfig'
+          $ref: '#/components/schemas/CloudIntegrationAzureAccountConfig'
       type: object
-    CloudintegrationtypesPostableAgentCheckIn:
+    CloudIntegrationPostableAgentCheckIn:
       properties:
         account_id:
           type: string
@@ -1014,21 +1016,21 @@ components:
       required:
       - data
       type: object
-    CloudintegrationtypesProviderIntegrationConfig:
+    CloudIntegrationProviderIntegrationConfig:
       properties:
         aws:
-          $ref: '#/components/schemas/CloudintegrationtypesAWSIntegrationConfig'
+          $ref: '#/components/schemas/CloudIntegrationAWSIntegrationConfig'
         azure:
-          $ref: '#/components/schemas/CloudintegrationtypesAzureIntegrationConfig'
+          $ref: '#/components/schemas/CloudIntegrationAzureIntegrationConfig'
       type: object
-    CloudintegrationtypesService:
+    CloudIntegrationService:
       properties:
         assets:
-          $ref: '#/components/schemas/CloudintegrationtypesAssets'
+          $ref: '#/components/schemas/CloudIntegrationAssets'
         cloudIntegrationService:
-          $ref: '#/components/schemas/CloudintegrationtypesCloudIntegrationService'
+          $ref: '#/components/schemas/CloudIntegrationServiceType2'
         dataCollected:
-          $ref: '#/components/schemas/CloudintegrationtypesDataCollected'
+          $ref: '#/components/schemas/CloudIntegrationDataCollected'
         icon:
           type: string
         id:
@@ -1036,9 +1038,9 @@ components:
         overview:
           type: string
         supportedSignals:
-          $ref: '#/components/schemas/CloudintegrationtypesSupportedSignals'
+          $ref: '#/components/schemas/CloudIntegrationSupportedSignals'
         telemetryCollectionStrategy:
-          $ref: '#/components/schemas/CloudintegrationtypesTelemetryCollectionStrategy'
+          $ref: '#/components/schemas/CloudIntegrationTelemetryCollectionStrategy'
         title:
           type: string
       required:
@@ -1052,14 +1054,14 @@ components:
       - telemetryCollectionStrategy
       - cloudIntegrationService
       type: object
-    CloudintegrationtypesServiceConfig:
+    CloudIntegrationServiceConfig:
       properties:
         aws:
-          $ref: '#/components/schemas/CloudintegrationtypesAWSServiceConfig'
+          $ref: '#/components/schemas/CloudIntegrationAWSServiceConfig'
         azure:
-          $ref: '#/components/schemas/CloudintegrationtypesAzureServiceConfig'
+          $ref: '#/components/schemas/CloudIntegrationAzureServiceConfig'
       type: object
-    CloudintegrationtypesServiceID:
+    CloudIntegrationServiceID:
       enum:
       - alb
       - api-gateway
@@ -1077,7 +1079,7 @@ components:
       - storageaccountsblob
       - cdnprofile
       type: string
-    CloudintegrationtypesServiceMetadata:
+    CloudIntegrationServiceMetadata:
       properties:
         enabled:
           type: boolean
@@ -1093,35 +1095,55 @@ components:
       - icon
       - enabled
       type: object
-    CloudintegrationtypesSupportedSignals:
+    CloudIntegrationServiceType2:
+      nullable: true
+      properties:
+        cloudIntegrationId:
+          type: string
+        config:
+          $ref: '#/components/schemas/CloudIntegrationServiceConfig'
+        createdAt:
+          format: date-time
+          type: string
+        id:
+          type: string
+        type:
+          $ref: '#/components/schemas/CloudIntegrationServiceID'
+        updatedAt:
+          format: date-time
+          type: string
+      required:
+      - id
+      type: object
+    CloudIntegrationSupportedSignals:
       properties:
         logs:
           type: boolean
         metrics:
           type: boolean
       type: object
-    CloudintegrationtypesTelemetryCollectionStrategy:
+    CloudIntegrationTelemetryCollectionStrategy:
       properties:
         aws:
-          $ref: '#/components/schemas/CloudintegrationtypesAWSTelemetryCollectionStrategy'
+          $ref: '#/components/schemas/CloudIntegrationAWSTelemetryCollectionStrategy'
         azure:
-          $ref: '#/components/schemas/CloudintegrationtypesAzureTelemetryCollectionStrategy'
+          $ref: '#/components/schemas/CloudIntegrationAzureTelemetryCollectionStrategy'
       type: object
-    CloudintegrationtypesUpdatableAccount:
+    CloudIntegrationUpdatableAccount:
       properties:
         config:
-          $ref: '#/components/schemas/CloudintegrationtypesUpdatableAccountConfig'
+          $ref: '#/components/schemas/CloudIntegrationUpdatableAccountConfig'
       required:
       - config
       type: object
-    CloudintegrationtypesUpdatableAccountConfig:
+    CloudIntegrationUpdatableAccountConfig:
       properties:
         aws:
-          $ref: '#/components/schemas/CloudintegrationtypesAWSAccountConfig'
+          $ref: '#/components/schemas/CloudIntegrationAWSAccountConfig'
         azure:
-          $ref: '#/components/schemas/CloudintegrationtypesUpdatableAzureAccountConfig'
+          $ref: '#/components/schemas/CloudIntegrationUpdatableAzureAccountConfig'
       type: object
-    CloudintegrationtypesUpdatableAzureAccountConfig:
+    CloudIntegrationUpdatableAzureAccountConfig:
       properties:
         resourceGroups:
           items:
@@ -1130,10 +1152,10 @@ components:
       required:
       - resourceGroups
       type: object
-    CloudintegrationtypesUpdatableService:
+    CloudIntegrationUpdatableService:
       properties:
         config:
-          $ref: '#/components/schemas/CloudintegrationtypesServiceConfig'
+          $ref: '#/components/schemas/CloudIntegrationServiceConfig'
       required:
       - config
       type: object
@@ -1824,7 +1846,7 @@ components:
         send_resolved:
           type: boolean
         sigv4:
-          $ref: '#/components/schemas/Sigv4SigV4Config'
+          $ref: '#/components/schemas/SigV4Config'
         subject:
           type: string
         target_arn:
@@ -2088,7 +2110,7 @@ components:
         to_user:
           type: string
       type: object
-    DashboardtypesDashboard:
+    Dashboard:
       properties:
         createdAt:
           format: date-time
@@ -2096,7 +2118,7 @@ components:
         createdBy:
           type: string
         data:
-          $ref: '#/components/schemas/DashboardtypesStorableDashboardData'
+          $ref: '#/components/schemas/DashboardStorableDashboardData'
         id:
           type: string
         locked:
@@ -2109,7 +2131,7 @@ components:
         updatedBy:
           type: string
       type: object
-    DashboardtypesGettablePublicDasbhboard:
+    DashboardGettablePublicDasbhboard:
       properties:
         defaultTimeRange:
           type: string
@@ -2118,29 +2140,54 @@ components:
         timeRangeEnabled:
           type: boolean
       type: object
-    DashboardtypesGettablePublicDashboardData:
+    DashboardGettablePublicDashboardData:
       properties:
         dashboard:
-          $ref: '#/components/schemas/DashboardtypesDashboard'
+          $ref: '#/components/schemas/Dashboard'
         publicDashboard:
-          $ref: '#/components/schemas/DashboardtypesGettablePublicDasbhboard'
+          $ref: '#/components/schemas/DashboardGettablePublicDasbhboard'
       type: object
-    DashboardtypesPostablePublicDashboard:
+    DashboardPostablePublicDashboard:
       properties:
         defaultTimeRange:
           type: string
         timeRangeEnabled:
           type: boolean
       type: object
-    DashboardtypesStorableDashboardData:
+    DashboardStorableDashboardData:
       additionalProperties: {}
       type: object
-    DashboardtypesUpdatablePublicDashboard:
+    DashboardUpdatablePublicDashboard:
       properties:
         defaultTimeRange:
           type: string
         timeRangeEnabled:
           type: boolean
+      type: object
+    DeprecatedUser:
+      properties:
+        createdAt:
+          format: date-time
+          type: string
+        displayName:
+          type: string
+        email:
+          type: string
+        id:
+          type: string
+        isRoot:
+          type: boolean
+        orgId:
+          type: string
+        role:
+          type: string
+        status:
+          type: string
+        updatedAt:
+          format: date-time
+          type: string
+      required:
+      - id
       type: object
     ErrorsJSON:
       properties:
@@ -2175,7 +2222,7 @@ components:
           nullable: true
           type: object
       type: object
-    FeaturetypesGettableFeature:
+    FeatureGettableFeature:
       properties:
         defaultVariant:
           type: string
@@ -2193,7 +2240,7 @@ components:
           nullable: true
           type: object
       type: object
-    GatewaytypesGettableCreatedIngestionKey:
+    GatewayGettableCreatedIngestionKey:
       properties:
         id:
           type: string
@@ -2203,24 +2250,24 @@ components:
       - id
       - value
       type: object
-    GatewaytypesGettableCreatedIngestionKeyLimit:
+    GatewayGettableCreatedIngestionKeyLimit:
       properties:
         id:
           type: string
       required:
       - id
       type: object
-    GatewaytypesGettableIngestionKeys:
+    GatewayGettableIngestionKeys:
       properties:
         _pagination:
-          $ref: '#/components/schemas/GatewaytypesPagination'
+          $ref: '#/components/schemas/GatewayPagination'
         keys:
           items:
-            $ref: '#/components/schemas/GatewaytypesIngestionKey'
+            $ref: '#/components/schemas/GatewayIngestionKey'
           nullable: true
           type: array
       type: object
-    GatewaytypesIngestionKey:
+    GatewayIngestionKey:
       properties:
         created_at:
           format: date-time
@@ -2232,7 +2279,7 @@ components:
           type: string
         limits:
           items:
-            $ref: '#/components/schemas/GatewaytypesLimit'
+            $ref: '#/components/schemas/GatewayLimit'
           nullable: true
           type: array
         name:
@@ -2250,10 +2297,10 @@ components:
         workspace_id:
           type: string
       type: object
-    GatewaytypesLimit:
+    GatewayLimit:
       properties:
         config:
-          $ref: '#/components/schemas/GatewaytypesLimitConfig'
+          $ref: '#/components/schemas/GatewayLimitConfig'
         created_at:
           format: date-time
           type: string
@@ -2262,7 +2309,7 @@ components:
         key_id:
           type: string
         metric:
-          $ref: '#/components/schemas/GatewaytypesLimitMetric'
+          $ref: '#/components/schemas/GatewayLimitMetric'
         signal:
           type: string
         tags:
@@ -2274,21 +2321,21 @@ components:
           format: date-time
           type: string
       type: object
-    GatewaytypesLimitConfig:
+    GatewayLimitConfig:
       properties:
         day:
-          $ref: '#/components/schemas/GatewaytypesLimitValue'
+          $ref: '#/components/schemas/GatewayLimitValue'
         second:
-          $ref: '#/components/schemas/GatewaytypesLimitValue'
+          $ref: '#/components/schemas/GatewayLimitValue'
       type: object
-    GatewaytypesLimitMetric:
+    GatewayLimitMetric:
       properties:
         day:
-          $ref: '#/components/schemas/GatewaytypesLimitMetricValue'
+          $ref: '#/components/schemas/GatewayLimitMetricValue'
         second:
-          $ref: '#/components/schemas/GatewaytypesLimitMetricValue'
+          $ref: '#/components/schemas/GatewayLimitMetricValue'
       type: object
-    GatewaytypesLimitMetricValue:
+    GatewayLimitMetricValue:
       properties:
         count:
           format: int64
@@ -2297,7 +2344,7 @@ components:
           format: int64
           type: integer
       type: object
-    GatewaytypesLimitValue:
+    GatewayLimitValue:
       properties:
         count:
           nullable: true
@@ -2306,7 +2353,7 @@ components:
           nullable: true
           type: integer
       type: object
-    GatewaytypesPagination:
+    GatewayPagination:
       properties:
         page:
           type: integer
@@ -2317,7 +2364,7 @@ components:
         total:
           type: integer
       type: object
-    GatewaytypesPostableIngestionKey:
+    GatewayPostableIngestionKey:
       properties:
         expires_at:
           format: date-time
@@ -2332,10 +2379,10 @@ components:
       required:
       - name
       type: object
-    GatewaytypesPostableIngestionKeyLimit:
+    GatewayPostableIngestionKeyLimit:
       properties:
         config:
-          $ref: '#/components/schemas/GatewaytypesLimitConfig'
+          $ref: '#/components/schemas/GatewayLimitConfig'
         signal:
           type: string
         tags:
@@ -2344,10 +2391,10 @@ components:
           nullable: true
           type: array
       type: object
-    GatewaytypesUpdatableIngestionKeyLimit:
+    GatewayUpdatableIngestionKeyLimit:
       properties:
         config:
-          $ref: '#/components/schemas/GatewaytypesLimitConfig'
+          $ref: '#/components/schemas/GatewayLimitConfig'
         tags:
           items:
             type: string
@@ -2356,17 +2403,17 @@ components:
       required:
       - config
       type: object
-    GlobaltypesAPIKeyConfig:
+    GlobalAPIKeyConfig:
       properties:
         enabled:
           type: boolean
       type: object
-    GlobaltypesConfig:
+    GlobalConfig:
       properties:
         external_url:
           type: string
         identN:
-          $ref: '#/components/schemas/GlobaltypesIdentNConfig'
+          $ref: '#/components/schemas/GlobalIdentNConfig'
         ingestion_url:
           type: string
         mcp_url:
@@ -2377,33 +2424,40 @@ components:
       - ingestion_url
       - mcp_url
       type: object
-    GlobaltypesIdentNConfig:
+    GlobalIdentNConfig:
       properties:
         apikey:
-          $ref: '#/components/schemas/GlobaltypesAPIKeyConfig'
+          $ref: '#/components/schemas/GlobalAPIKeyConfig'
         impersonation:
-          $ref: '#/components/schemas/GlobaltypesImpersonationConfig'
+          $ref: '#/components/schemas/GlobalImpersonationConfig'
         tokenizer:
-          $ref: '#/components/schemas/GlobaltypesTokenizerConfig'
+          $ref: '#/components/schemas/GlobalTokenizerConfig'
       type: object
-    GlobaltypesImpersonationConfig:
+    GlobalImpersonationConfig:
       properties:
         enabled:
           type: boolean
       type: object
-    GlobaltypesTokenizerConfig:
+    GlobalTokenizerConfig:
       properties:
         enabled:
           type: boolean
       type: object
-    InframonitoringtypesHostFilter:
+    Identifiable:
+      properties:
+        id:
+          type: string
+      required:
+      - id
+      type: object
+    InfraMonitoringHostFilter:
       properties:
         expression:
           type: string
         filterByStatus:
-          $ref: '#/components/schemas/InframonitoringtypesHostStatus'
+          $ref: '#/components/schemas/InfraMonitoringHostStatus'
       type: object
-    InframonitoringtypesHostRecord:
+    InfraMonitoringHostRecord:
       properties:
         activeHostCount:
           type: integer
@@ -2428,7 +2482,7 @@ components:
           nullable: true
           type: object
         status:
-          $ref: '#/components/schemas/InframonitoringtypesHostStatus'
+          $ref: '#/components/schemas/InfraMonitoringHostStatus'
         wait:
           format: double
           type: number
@@ -2444,29 +2498,29 @@ components:
       - diskUsage
       - meta
       type: object
-    InframonitoringtypesHostStatus:
+    InfraMonitoringHostStatus:
       enum:
       - active
       - inactive
       - ""
       type: string
-    InframonitoringtypesHosts:
+    InfraMonitoringHosts:
       properties:
         endTimeBeforeRetention:
           type: boolean
         records:
           items:
-            $ref: '#/components/schemas/InframonitoringtypesHostRecord'
+            $ref: '#/components/schemas/InfraMonitoringHostRecord'
           nullable: true
           type: array
         requiredMetricsCheck:
-          $ref: '#/components/schemas/InframonitoringtypesRequiredMetricsCheck'
+          $ref: '#/components/schemas/InfraMonitoringRequiredMetricsCheck'
         total:
           type: integer
         type:
-          $ref: '#/components/schemas/InframonitoringtypesResponseType'
+          $ref: '#/components/schemas/InfraMonitoringResponseType'
         warning:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryWarnData'
+          $ref: '#/components/schemas/QueryBuilderV5QueryWarnData'
       required:
       - type
       - records
@@ -2474,7 +2528,7 @@ components:
       - requiredMetricsCheck
       - endTimeBeforeRetention
       type: object
-    InframonitoringtypesPodPhase:
+    InfraMonitoringPodPhase:
       enum:
       - pending
       - running
@@ -2483,7 +2537,7 @@ components:
       - unknown
       - ""
       type: string
-    InframonitoringtypesPodRecord:
+    InfraMonitoringPodRecord:
       properties:
         failedPodCount:
           type: integer
@@ -2515,7 +2569,7 @@ components:
           format: double
           type: number
         podPhase:
-          $ref: '#/components/schemas/InframonitoringtypesPodPhase'
+          $ref: '#/components/schemas/InfraMonitoringPodPhase'
         podUID:
           type: string
         runningPodCount:
@@ -2541,23 +2595,23 @@ components:
       - podAge
       - meta
       type: object
-    InframonitoringtypesPods:
+    InfraMonitoringPods:
       properties:
         endTimeBeforeRetention:
           type: boolean
         records:
           items:
-            $ref: '#/components/schemas/InframonitoringtypesPodRecord'
+            $ref: '#/components/schemas/InfraMonitoringPodRecord'
           nullable: true
           type: array
         requiredMetricsCheck:
-          $ref: '#/components/schemas/InframonitoringtypesRequiredMetricsCheck'
+          $ref: '#/components/schemas/InfraMonitoringRequiredMetricsCheck'
         total:
           type: integer
         type:
-          $ref: '#/components/schemas/InframonitoringtypesResponseType'
+          $ref: '#/components/schemas/InfraMonitoringResponseType'
         warning:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryWarnData'
+          $ref: '#/components/schemas/QueryBuilderV5QueryWarnData'
       required:
       - type
       - records
@@ -2565,16 +2619,16 @@ components:
       - requiredMetricsCheck
       - endTimeBeforeRetention
       type: object
-    InframonitoringtypesPostableHosts:
+    InfraMonitoringPostableHosts:
       properties:
         end:
           format: int64
           type: integer
         filter:
-          $ref: '#/components/schemas/InframonitoringtypesHostFilter'
+          $ref: '#/components/schemas/InfraMonitoringHostFilter'
         groupBy:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5GroupByKey'
+            $ref: '#/components/schemas/QueryBuilderV5GroupByKey'
           nullable: true
           type: array
         limit:
@@ -2582,7 +2636,7 @@ components:
         offset:
           type: integer
         orderBy:
-          $ref: '#/components/schemas/Querybuildertypesv5OrderBy'
+          $ref: '#/components/schemas/QueryBuilderV5OrderBy'
         start:
           format: int64
           type: integer
@@ -2591,16 +2645,16 @@ components:
       - end
       - limit
       type: object
-    InframonitoringtypesPostablePods:
+    InfraMonitoringPostablePods:
       properties:
         end:
           format: int64
           type: integer
         filter:
-          $ref: '#/components/schemas/Querybuildertypesv5Filter'
+          $ref: '#/components/schemas/QueryBuilderV5Filter'
         groupBy:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5GroupByKey'
+            $ref: '#/components/schemas/QueryBuilderV5GroupByKey'
           nullable: true
           type: array
         limit:
@@ -2608,7 +2662,7 @@ components:
         offset:
           type: integer
         orderBy:
-          $ref: '#/components/schemas/Querybuildertypesv5OrderBy'
+          $ref: '#/components/schemas/QueryBuilderV5OrderBy'
         start:
           format: int64
           type: integer
@@ -2617,7 +2671,7 @@ components:
       - end
       - limit
       type: object
-    InframonitoringtypesRequiredMetricsCheck:
+    InfraMonitoringRequiredMetricsCheck:
       properties:
         missingMetrics:
           items:
@@ -2627,44 +2681,37 @@ components:
       required:
       - missingMetrics
       type: object
-    InframonitoringtypesResponseType:
+    InfraMonitoringResponseType:
       enum:
       - list
       - grouped_list
       type: string
-    LlmpricingruletypesGettablePricingRules:
+    Invite:
       properties:
-        items:
-          items:
-            $ref: '#/components/schemas/LlmpricingruletypesLLMPricingRule'
-          nullable: true
-          type: array
-        limit:
-          type: integer
-        offset:
-          type: integer
-        total:
-          type: integer
+        createdAt:
+          format: date-time
+          type: string
+        email:
+          type: string
+        id:
+          type: string
+        inviteLink:
+          type: string
+        name:
+          type: string
+        orgId:
+          type: string
+        role:
+          type: string
+        token:
+          type: string
+        updatedAt:
+          format: date-time
+          type: string
       required:
-      - items
-      - total
-      - offset
-      - limit
+      - id
       type: object
-    LlmpricingruletypesLLMPricingCacheCosts:
-      properties:
-        mode:
-          $ref: '#/components/schemas/LlmpricingruletypesLLMPricingRuleCacheMode'
-        read:
-          format: double
-          type: number
-        write:
-          format: double
-          type: number
-      required:
-      - mode
-      type: object
-    LlmpricingruletypesLLMPricingRule:
+    LLMPricingRule:
       properties:
         createdAt:
           format: date-time
@@ -2680,11 +2727,11 @@ components:
         modelName:
           type: string
         modelPattern:
-          $ref: '#/components/schemas/LlmpricingruletypesStringSlice'
+          $ref: '#/components/schemas/LLMPricingRuleStringSlice'
         orgId:
           type: string
         pricing:
-          $ref: '#/components/schemas/LlmpricingruletypesLLMRulePricing'
+          $ref: '#/components/schemas/LLMPricingRuleLLMRulePricing'
         provider:
           type: string
         sourceId:
@@ -2694,7 +2741,7 @@ components:
           nullable: true
           type: string
         unit:
-          $ref: '#/components/schemas/LlmpricingruletypesLLMPricingRuleUnit'
+          $ref: '#/components/schemas/LLMPricingRuleUnit'
         updatedAt:
           format: date-time
           type: string
@@ -2711,20 +2758,48 @@ components:
       - isOverride
       - enabled
       type: object
-    LlmpricingruletypesLLMPricingRuleCacheMode:
+    LLMPricingRuleCacheMode:
       enum:
       - subtract
       - additive
       - unknown
       type: string
-    LlmpricingruletypesLLMPricingRuleUnit:
-      enum:
-      - per_million_tokens
-      type: string
-    LlmpricingruletypesLLMRulePricing:
+    LLMPricingRuleGettablePricingRules:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/LLMPricingRule'
+          nullable: true
+          type: array
+        limit:
+          type: integer
+        offset:
+          type: integer
+        total:
+          type: integer
+      required:
+      - items
+      - total
+      - offset
+      - limit
+      type: object
+    LLMPricingRuleLLMPricingCacheCosts:
+      properties:
+        mode:
+          $ref: '#/components/schemas/LLMPricingRuleCacheMode'
+        read:
+          format: double
+          type: number
+        write:
+          format: double
+          type: number
+      required:
+      - mode
+      type: object
+    LLMPricingRuleLLMRulePricing:
       properties:
         cache:
-          $ref: '#/components/schemas/LlmpricingruletypesLLMPricingCacheCosts'
+          $ref: '#/components/schemas/LLMPricingRuleLLMPricingCacheCosts'
         input:
           format: double
           type: number
@@ -2735,12 +2810,16 @@ components:
       - input
       - output
       type: object
-    LlmpricingruletypesStringSlice:
+    LLMPricingRuleStringSlice:
       items:
         type: string
       nullable: true
       type: array
-    LlmpricingruletypesUpdatableLLMPricingRule:
+    LLMPricingRuleUnit:
+      enum:
+      - per_million_tokens
+      type: string
+    LLMPricingRuleUpdatableLLMPricingRule:
       properties:
         enabled:
           type: boolean
@@ -2758,14 +2837,14 @@ components:
           nullable: true
           type: array
         pricing:
-          $ref: '#/components/schemas/LlmpricingruletypesLLMRulePricing'
+          $ref: '#/components/schemas/LLMPricingRuleLLMRulePricing'
         provider:
           type: string
         sourceId:
           nullable: true
           type: string
         unit:
-          $ref: '#/components/schemas/LlmpricingruletypesLLMPricingRuleUnit'
+          $ref: '#/components/schemas/LLMPricingRuleUnit'
       required:
       - modelName
       - provider
@@ -2774,23 +2853,73 @@ components:
       - pricing
       - enabled
       type: object
-    LlmpricingruletypesUpdatableLLMPricingRules:
+    LLMPricingRuleUpdatableLLMPricingRules:
       properties:
         rules:
           items:
-            $ref: '#/components/schemas/LlmpricingruletypesUpdatableLLMPricingRule'
+            $ref: '#/components/schemas/LLMPricingRuleUpdatableLLMPricingRule'
           nullable: true
           type: array
       required:
       - rules
       type: object
-    MetricsexplorertypesInspectMetricsRequest:
+    MetricComparisonSpaceAggregationParam:
+      properties:
+        operator:
+          type: string
+        threshold:
+          format: double
+          type: number
+      required:
+      - operator
+      - threshold
+      type: object
+    MetricSpaceAggregation:
+      enum:
+      - sum
+      - avg
+      - min
+      - max
+      - count
+      - p50
+      - p75
+      - p90
+      - p95
+      - p99
+      type: string
+    MetricTemporality:
+      enum:
+      - delta
+      - cumulative
+      - unspecified
+      type: string
+    MetricTimeAggregation:
+      enum:
+      - latest
+      - sum
+      - avg
+      - min
+      - max
+      - count
+      - count_distinct
+      - rate
+      - increase
+      type: string
+    MetricType:
+      enum:
+      - gauge
+      - sum
+      - histogram
+      - summary
+      - exponentialhistogram
+      type: string
+    MetricsExplorerInspectMetricsRequest:
       properties:
         end:
           format: int64
           type: integer
         filter:
-          $ref: '#/components/schemas/Querybuildertypesv5Filter'
+          $ref: '#/components/schemas/QueryBuilderV5Filter'
         metricName:
           type: string
         start:
@@ -2801,17 +2930,17 @@ components:
       - start
       - end
       type: object
-    MetricsexplorertypesInspectMetricsResponse:
+    MetricsExplorerInspectMetricsResponse:
       properties:
         series:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5TimeSeries'
+            $ref: '#/components/schemas/QueryBuilderV5TimeSeries'
           nullable: true
           type: array
       required:
       - series
       type: object
-    MetricsexplorertypesListMetric:
+    MetricsExplorerListMetric:
       properties:
         description:
           type: string
@@ -2820,9 +2949,9 @@ components:
         metricName:
           type: string
         temporality:
-          $ref: '#/components/schemas/MetrictypesTemporality'
+          $ref: '#/components/schemas/MetricTemporality'
         type:
-          $ref: '#/components/schemas/MetrictypesType'
+          $ref: '#/components/schemas/MetricType'
         unit:
           type: string
       required:
@@ -2833,17 +2962,17 @@ components:
       - temporality
       - isMonotonic
       type: object
-    MetricsexplorertypesListMetricsResponse:
+    MetricsExplorerListMetricsResponse:
       properties:
         metrics:
           items:
-            $ref: '#/components/schemas/MetricsexplorertypesListMetric'
+            $ref: '#/components/schemas/MetricsExplorerListMetric'
           nullable: true
           type: array
       required:
       - metrics
       type: object
-    MetricsexplorertypesMetricAlert:
+    MetricsExplorerMetricAlert:
       properties:
         alertId:
           type: string
@@ -2853,17 +2982,17 @@ components:
       - alertName
       - alertId
       type: object
-    MetricsexplorertypesMetricAlertsResponse:
+    MetricsExplorerMetricAlertsResponse:
       properties:
         alerts:
           items:
-            $ref: '#/components/schemas/MetricsexplorertypesMetricAlert'
+            $ref: '#/components/schemas/MetricsExplorerMetricAlert'
           nullable: true
           type: array
       required:
       - alerts
       type: object
-    MetricsexplorertypesMetricAttribute:
+    MetricsExplorerMetricAttribute:
       properties:
         key:
           type: string
@@ -2880,11 +3009,11 @@ components:
       - values
       - valueCount
       type: object
-    MetricsexplorertypesMetricAttributesResponse:
+    MetricsExplorerMetricAttributesResponse:
       properties:
         attributes:
           items:
-            $ref: '#/components/schemas/MetricsexplorertypesMetricAttribute'
+            $ref: '#/components/schemas/MetricsExplorerMetricAttribute'
           nullable: true
           type: array
         totalKeys:
@@ -2894,7 +3023,7 @@ components:
       - attributes
       - totalKeys
       type: object
-    MetricsexplorertypesMetricDashboard:
+    MetricsExplorerMetricDashboard:
       properties:
         dashboardId:
           type: string
@@ -2910,17 +3039,17 @@ components:
       - widgetId
       - widgetName
       type: object
-    MetricsexplorertypesMetricDashboardsResponse:
+    MetricsExplorerMetricDashboardsResponse:
       properties:
         dashboards:
           items:
-            $ref: '#/components/schemas/MetricsexplorertypesMetricDashboard'
+            $ref: '#/components/schemas/MetricsExplorerMetricDashboard'
           nullable: true
           type: array
       required:
       - dashboards
       type: object
-    MetricsexplorertypesMetricHighlightsResponse:
+    MetricsExplorerMetricHighlightsResponse:
       properties:
         activeTimeSeries:
           minimum: 0
@@ -2940,16 +3069,16 @@ components:
       - totalTimeSeries
       - activeTimeSeries
       type: object
-    MetricsexplorertypesMetricMetadata:
+    MetricsExplorerMetricMetadata:
       properties:
         description:
           type: string
         isMonotonic:
           type: boolean
         temporality:
-          $ref: '#/components/schemas/MetrictypesTemporality'
+          $ref: '#/components/schemas/MetricTemporality'
         type:
-          $ref: '#/components/schemas/MetrictypesType'
+          $ref: '#/components/schemas/MetricType'
         unit:
           type: string
       required:
@@ -2959,14 +3088,14 @@ components:
       - temporality
       - isMonotonic
       type: object
-    MetricsexplorertypesMetricsOnboardingResponse:
+    MetricsExplorerMetricsOnboardingResponse:
       properties:
         hasMetrics:
           type: boolean
       required:
       - hasMetrics
       type: object
-    MetricsexplorertypesStat:
+    MetricsExplorerStat:
       properties:
         description:
           type: string
@@ -2979,7 +3108,7 @@ components:
           minimum: 0
           type: integer
         type:
-          $ref: '#/components/schemas/MetrictypesType'
+          $ref: '#/components/schemas/MetricType'
         unit:
           type: string
       required:
@@ -2990,19 +3119,19 @@ components:
       - timeseries
       - samples
       type: object
-    MetricsexplorertypesStatsRequest:
+    MetricsExplorerStatsRequest:
       properties:
         end:
           format: int64
           type: integer
         filter:
-          $ref: '#/components/schemas/Querybuildertypesv5Filter'
+          $ref: '#/components/schemas/QueryBuilderV5Filter'
         limit:
           type: integer
         offset:
           type: integer
         orderBy:
-          $ref: '#/components/schemas/Querybuildertypesv5OrderBy'
+          $ref: '#/components/schemas/QueryBuilderV5OrderBy'
         start:
           format: int64
           type: integer
@@ -3011,11 +3140,11 @@ components:
       - end
       - limit
       type: object
-    MetricsexplorertypesStatsResponse:
+    MetricsExplorerStatsResponse:
       properties:
         metrics:
           items:
-            $ref: '#/components/schemas/MetricsexplorertypesStat'
+            $ref: '#/components/schemas/MetricsExplorerStat'
           nullable: true
           type: array
         total:
@@ -3025,7 +3154,7 @@ components:
       - metrics
       - total
       type: object
-    MetricsexplorertypesTreemapEntry:
+    MetricsExplorerTreemapEntry:
       properties:
         metricName:
           type: string
@@ -3040,22 +3169,22 @@ components:
       - percentage
       - totalValue
       type: object
-    MetricsexplorertypesTreemapMode:
+    MetricsExplorerTreemapMode:
       enum:
       - timeseries
       - samples
       type: string
-    MetricsexplorertypesTreemapRequest:
+    MetricsExplorerTreemapRequest:
       properties:
         end:
           format: int64
           type: integer
         filter:
-          $ref: '#/components/schemas/Querybuildertypesv5Filter'
+          $ref: '#/components/schemas/QueryBuilderV5Filter'
         limit:
           type: integer
         mode:
-          $ref: '#/components/schemas/MetricsexplorertypesTreemapMode'
+          $ref: '#/components/schemas/MetricsExplorerTreemapMode'
         start:
           format: int64
           type: integer
@@ -3065,23 +3194,23 @@ components:
       - limit
       - mode
       type: object
-    MetricsexplorertypesTreemapResponse:
+    MetricsExplorerTreemapResponse:
       properties:
         samples:
           items:
-            $ref: '#/components/schemas/MetricsexplorertypesTreemapEntry'
+            $ref: '#/components/schemas/MetricsExplorerTreemapEntry'
           nullable: true
           type: array
         timeseries:
           items:
-            $ref: '#/components/schemas/MetricsexplorertypesTreemapEntry'
+            $ref: '#/components/schemas/MetricsExplorerTreemapEntry'
           nullable: true
           type: array
       required:
       - timeseries
       - samples
       type: object
-    MetricsexplorertypesUpdateMetricMetadataRequest:
+    MetricsExplorerUpdateMetricMetadataRequest:
       properties:
         description:
           type: string
@@ -3090,9 +3219,9 @@ components:
         metricName:
           type: string
         temporality:
-          $ref: '#/components/schemas/MetrictypesTemporality'
+          $ref: '#/components/schemas/MetricTemporality'
         type:
-          $ref: '#/components/schemas/MetrictypesType'
+          $ref: '#/components/schemas/MetricType'
         unit:
           type: string
       required:
@@ -3103,56 +3232,6 @@ components:
       - temporality
       - isMonotonic
       type: object
-    MetrictypesComparisonSpaceAggregationParam:
-      properties:
-        operator:
-          type: string
-        threshold:
-          format: double
-          type: number
-      required:
-      - operator
-      - threshold
-      type: object
-    MetrictypesSpaceAggregation:
-      enum:
-      - sum
-      - avg
-      - min
-      - max
-      - count
-      - p50
-      - p75
-      - p90
-      - p95
-      - p99
-      type: string
-    MetrictypesTemporality:
-      enum:
-      - delta
-      - cumulative
-      - unspecified
-      type: string
-    MetrictypesTimeAggregation:
-      enum:
-      - latest
-      - sum
-      - avg
-      - min
-      - max
-      - count
-      - count_distinct
-      - rate
-      - increase
-      type: string
-    MetrictypesType:
-      enum:
-      - gauge
-      - sum
-      - histogram
-      - summary
-      - exponentialhistogram
-      type: string
     ModelDuration:
       format: int64
       type: integer
@@ -3160,7 +3239,75 @@ components:
       additionalProperties:
         type: string
       type: object
-    PreferencetypesPreference:
+    Organization:
+      properties:
+        alias:
+          type: string
+        createdAt:
+          format: date-time
+          type: string
+        displayName:
+          type: string
+        id:
+          type: string
+        key:
+          minimum: 0
+          type: integer
+        name:
+          type: string
+        updatedAt:
+          format: date-time
+          type: string
+      required:
+      - id
+      type: object
+    PostableBulkInviteRequest:
+      properties:
+        invites:
+          items:
+            $ref: '#/components/schemas/PostableInvite'
+          type: array
+      required:
+      - invites
+      type: object
+    PostableForgotPassword:
+      properties:
+        email:
+          type: string
+        frontendBaseURL:
+          type: string
+        orgId:
+          type: string
+      required:
+      - orgId
+      - email
+      type: object
+    PostableInvite:
+      properties:
+        email:
+          type: string
+        frontendBaseUrl:
+          type: string
+        name:
+          type: string
+        role:
+          type: string
+      type: object
+    PostableResetPassword:
+      properties:
+        password:
+          type: string
+        token:
+          type: string
+      type: object
+    PostableRole:
+      properties:
+        name:
+          type: string
+      required:
+      - name
+      type: object
+    Preference:
       properties:
         allowedScopes:
           items:
@@ -3173,55 +3320,208 @@ components:
           nullable: true
           type: array
         defaultValue:
-          $ref: '#/components/schemas/PreferencetypesValue'
+          $ref: '#/components/schemas/PreferenceValue'
         description:
           type: string
         name:
           type: string
         value:
-          $ref: '#/components/schemas/PreferencetypesValue'
+          $ref: '#/components/schemas/PreferenceValue'
         valueType:
           type: string
       type: object
-    PreferencetypesUpdatablePreference:
+    PreferenceUpdatablePreference:
       properties:
         value: {}
       type: object
-    PreferencetypesValue:
+    PreferenceValue:
       type: object
-    PromotetypesPromotePath:
+    PromotePath:
       properties:
         indexes:
           items:
-            $ref: '#/components/schemas/PromotetypesWrappedIndex'
+            $ref: '#/components/schemas/PromoteWrappedIndex'
           type: array
         path:
           type: string
         promote:
           type: boolean
       type: object
-    PromotetypesWrappedIndex:
+    PromoteWrappedIndex:
       properties:
         fieldDataType:
-          $ref: '#/components/schemas/TelemetrytypesFieldDataType'
+          $ref: '#/components/schemas/TelemetryFieldDataType'
         granularity:
           type: integer
         type:
           type: string
       type: object
-    Querybuildertypesv5AggregationBucket:
+    QueryBuilderQueryLogAggregation:
+      properties:
+        aggregations:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5LogAggregation'
+          type: array
+        cursor:
+          type: string
+        disabled:
+          type: boolean
+        filter:
+          $ref: '#/components/schemas/QueryBuilderV5Filter'
+        functions:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5Function'
+          type: array
+        groupBy:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5GroupByKey'
+          type: array
+        having:
+          $ref: '#/components/schemas/QueryBuilderV5Having'
+        legend:
+          type: string
+        limit:
+          type: integer
+        limitBy:
+          $ref: '#/components/schemas/QueryBuilderV5LimitBy'
+        name:
+          type: string
+        offset:
+          type: integer
+        order:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5OrderBy'
+          type: array
+        secondaryAggregations:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5SecondaryAggregation'
+          type: array
+        selectFields:
+          items:
+            $ref: '#/components/schemas/TelemetryFieldKey'
+          type: array
+        signal:
+          $ref: '#/components/schemas/TelemetrySignal'
+        source:
+          $ref: '#/components/schemas/TelemetrySource'
+        stepInterval:
+          $ref: '#/components/schemas/QueryBuilderV5Step'
+      type: object
+    QueryBuilderQueryMetricAggregation:
+      properties:
+        aggregations:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5MetricAggregation'
+          type: array
+        cursor:
+          type: string
+        disabled:
+          type: boolean
+        filter:
+          $ref: '#/components/schemas/QueryBuilderV5Filter'
+        functions:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5Function'
+          type: array
+        groupBy:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5GroupByKey'
+          type: array
+        having:
+          $ref: '#/components/schemas/QueryBuilderV5Having'
+        legend:
+          type: string
+        limit:
+          type: integer
+        limitBy:
+          $ref: '#/components/schemas/QueryBuilderV5LimitBy'
+        name:
+          type: string
+        offset:
+          type: integer
+        order:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5OrderBy'
+          type: array
+        secondaryAggregations:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5SecondaryAggregation'
+          type: array
+        selectFields:
+          items:
+            $ref: '#/components/schemas/TelemetryFieldKey'
+          type: array
+        signal:
+          $ref: '#/components/schemas/TelemetrySignal'
+        source:
+          $ref: '#/components/schemas/TelemetrySource'
+        stepInterval:
+          $ref: '#/components/schemas/QueryBuilderV5Step'
+      type: object
+    QueryBuilderQueryTraceAggregation:
+      properties:
+        aggregations:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5TraceAggregation'
+          type: array
+        cursor:
+          type: string
+        disabled:
+          type: boolean
+        filter:
+          $ref: '#/components/schemas/QueryBuilderV5Filter'
+        functions:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5Function'
+          type: array
+        groupBy:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5GroupByKey'
+          type: array
+        having:
+          $ref: '#/components/schemas/QueryBuilderV5Having'
+        legend:
+          type: string
+        limit:
+          type: integer
+        limitBy:
+          $ref: '#/components/schemas/QueryBuilderV5LimitBy'
+        name:
+          type: string
+        offset:
+          type: integer
+        order:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5OrderBy'
+          type: array
+        secondaryAggregations:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5SecondaryAggregation'
+          type: array
+        selectFields:
+          items:
+            $ref: '#/components/schemas/TelemetryFieldKey'
+          type: array
+        signal:
+          $ref: '#/components/schemas/TelemetrySignal'
+        source:
+          $ref: '#/components/schemas/TelemetrySource'
+        stepInterval:
+          $ref: '#/components/schemas/QueryBuilderV5Step'
+      type: object
+    QueryBuilderV5AggregationBucket:
       properties:
         alias:
           type: string
         anomalyScores:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5TimeSeries'
+            $ref: '#/components/schemas/QueryBuilderV5TimeSeries'
           type: array
         index:
           type: integer
         lowerBoundSeries:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5TimeSeries'
+            $ref: '#/components/schemas/QueryBuilderV5TimeSeries'
           type: array
         meta:
           properties:
@@ -3230,25 +3530,25 @@ components:
           type: object
         predictedSeries:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5TimeSeries'
+            $ref: '#/components/schemas/QueryBuilderV5TimeSeries'
           type: array
         series:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5TimeSeries'
+            $ref: '#/components/schemas/QueryBuilderV5TimeSeries'
           nullable: true
           type: array
         upperBoundSeries:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5TimeSeries'
+            $ref: '#/components/schemas/QueryBuilderV5TimeSeries'
           type: array
       type: object
-    Querybuildertypesv5Bucket:
+    QueryBuilderV5Bucket:
       properties:
         step:
           format: double
           type: number
       type: object
-    Querybuildertypesv5ClickHouseQuery:
+    QueryBuilderV5ClickHouseQuery:
       properties:
         disabled:
           type: boolean
@@ -3259,19 +3559,19 @@ components:
         query:
           type: string
       type: object
-    Querybuildertypesv5ColumnDescriptor:
+    QueryBuilderV5ColumnDescriptor:
       properties:
         aggregationIndex:
           format: int64
           type: integer
         columnType:
-          $ref: '#/components/schemas/Querybuildertypesv5ColumnType'
+          $ref: '#/components/schemas/QueryBuilderV5ColumnType'
         description:
           type: string
         fieldContext:
-          $ref: '#/components/schemas/TelemetrytypesFieldContext'
+          $ref: '#/components/schemas/TelemetryFieldContext'
         fieldDataType:
-          $ref: '#/components/schemas/TelemetrytypesFieldDataType'
+          $ref: '#/components/schemas/TelemetryFieldDataType'
         meta:
           properties:
             unit:
@@ -3282,28 +3582,28 @@ components:
         queryName:
           type: string
         signal:
-          $ref: '#/components/schemas/TelemetrytypesSignal'
+          $ref: '#/components/schemas/TelemetrySignal'
         unit:
           type: string
       required:
       - name
       type: object
-    Querybuildertypesv5ColumnType:
+    QueryBuilderV5ColumnType:
       enum:
       - group
       - aggregation
       type: string
-    Querybuildertypesv5CompositeQuery:
+    QueryBuilderV5CompositeQuery:
       description: Composite query containing one or more query envelopes. Each query
         envelope specifies its type and corresponding spec.
       properties:
         queries:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5QueryEnvelope'
+            $ref: '#/components/schemas/QueryBuilderV5QueryEnvelope'
           nullable: true
           type: array
       type: object
-    Querybuildertypesv5ExecStats:
+    QueryBuilderV5ExecStats:
       description: Execution statistics for the query, including rows scanned, bytes
         scanned, and duration.
       properties:
@@ -3322,34 +3622,34 @@ components:
             type: integer
           type: object
       type: object
-    Querybuildertypesv5Filter:
+    QueryBuilderV5Filter:
       properties:
         expression:
           type: string
       type: object
-    Querybuildertypesv5FormatOptions:
+    QueryBuilderV5FormatOptions:
       properties:
         fillGaps:
           type: boolean
         formatTableResultForUI:
           type: boolean
       type: object
-    Querybuildertypesv5Function:
+    QueryBuilderV5Function:
       properties:
         args:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5FunctionArg'
+            $ref: '#/components/schemas/QueryBuilderV5FunctionArg'
           type: array
         name:
-          $ref: '#/components/schemas/Querybuildertypesv5FunctionName'
+          $ref: '#/components/schemas/QueryBuilderV5FunctionName'
       type: object
-    Querybuildertypesv5FunctionArg:
+    QueryBuilderV5FunctionArg:
       properties:
         name:
           type: string
         value: {}
       type: object
-    Querybuildertypesv5FunctionName:
+    QueryBuilderV5FunctionName:
       enum:
       - cutoffmin
       - cutoffmax
@@ -3370,35 +3670,35 @@ components:
       - anomaly
       - fillzero
       type: string
-    Querybuildertypesv5GroupByKey:
+    QueryBuilderV5GroupByKey:
       properties:
         description:
           type: string
         fieldContext:
-          $ref: '#/components/schemas/TelemetrytypesFieldContext'
+          $ref: '#/components/schemas/TelemetryFieldContext'
         fieldDataType:
-          $ref: '#/components/schemas/TelemetrytypesFieldDataType'
+          $ref: '#/components/schemas/TelemetryFieldDataType'
         name:
           type: string
         signal:
-          $ref: '#/components/schemas/TelemetrytypesSignal'
+          $ref: '#/components/schemas/TelemetrySignal'
         unit:
           type: string
       required:
       - name
       type: object
-    Querybuildertypesv5Having:
+    QueryBuilderV5Having:
       properties:
         expression:
           type: string
       type: object
-    Querybuildertypesv5Label:
+    QueryBuilderV5Label:
       properties:
         key:
-          $ref: '#/components/schemas/TelemetrytypesTelemetryFieldKey'
+          $ref: '#/components/schemas/TelemetryFieldKey'
         value: {}
       type: object
-    Querybuildertypesv5LimitBy:
+    QueryBuilderV5LimitBy:
       properties:
         keys:
           items:
@@ -3408,58 +3708,58 @@ components:
         value:
           type: string
       type: object
-    Querybuildertypesv5LogAggregation:
+    QueryBuilderV5LogAggregation:
       properties:
         alias:
           type: string
         expression:
           type: string
       type: object
-    Querybuildertypesv5MetricAggregation:
+    QueryBuilderV5MetricAggregation:
       properties:
         comparisonSpaceAggregationParam:
-          $ref: '#/components/schemas/MetrictypesComparisonSpaceAggregationParam'
+          $ref: '#/components/schemas/MetricComparisonSpaceAggregationParam'
         metricName:
           type: string
         reduceTo:
-          $ref: '#/components/schemas/Querybuildertypesv5ReduceTo'
+          $ref: '#/components/schemas/QueryBuilderV5ReduceTo'
         spaceAggregation:
-          $ref: '#/components/schemas/MetrictypesSpaceAggregation'
+          $ref: '#/components/schemas/MetricSpaceAggregation'
         temporality:
-          $ref: '#/components/schemas/MetrictypesTemporality'
+          $ref: '#/components/schemas/MetricTemporality'
         timeAggregation:
-          $ref: '#/components/schemas/MetrictypesTimeAggregation'
+          $ref: '#/components/schemas/MetricTimeAggregation'
       type: object
-    Querybuildertypesv5OrderBy:
+    QueryBuilderV5OrderBy:
       properties:
         direction:
-          $ref: '#/components/schemas/Querybuildertypesv5OrderDirection'
+          $ref: '#/components/schemas/QueryBuilderV5OrderDirection'
         key:
-          $ref: '#/components/schemas/Querybuildertypesv5OrderByKey'
+          $ref: '#/components/schemas/QueryBuilderV5OrderByKey'
       type: object
-    Querybuildertypesv5OrderByKey:
+    QueryBuilderV5OrderByKey:
       properties:
         description:
           type: string
         fieldContext:
-          $ref: '#/components/schemas/TelemetrytypesFieldContext'
+          $ref: '#/components/schemas/TelemetryFieldContext'
         fieldDataType:
-          $ref: '#/components/schemas/TelemetrytypesFieldDataType'
+          $ref: '#/components/schemas/TelemetryFieldDataType'
         name:
           type: string
         signal:
-          $ref: '#/components/schemas/TelemetrytypesSignal'
+          $ref: '#/components/schemas/TelemetrySignal'
         unit:
           type: string
       required:
       - name
       type: object
-    Querybuildertypesv5OrderDirection:
+    QueryBuilderV5OrderDirection:
       enum:
       - asc
       - desc
       type: string
-    Querybuildertypesv5PromQuery:
+    QueryBuilderV5PromQuery:
       properties:
         disabled:
           type: boolean
@@ -3472,9 +3772,9 @@ components:
         stats:
           type: boolean
         step:
-          $ref: '#/components/schemas/Querybuildertypesv5Step'
+          $ref: '#/components/schemas/QueryBuilderV5Step'
       type: object
-    Querybuildertypesv5QueryBuilderFormula:
+    QueryBuilderV5QueryBuilderFormula:
       properties:
         disabled:
           type: boolean
@@ -3482,10 +3782,10 @@ components:
           type: string
         functions:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5Function'
+            $ref: '#/components/schemas/QueryBuilderV5Function'
           type: array
         having:
-          $ref: '#/components/schemas/Querybuildertypesv5Having'
+          $ref: '#/components/schemas/QueryBuilderV5Having'
         legend:
           type: string
         limit:
@@ -3494,167 +3794,14 @@ components:
           type: string
         order:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5OrderBy'
+            $ref: '#/components/schemas/QueryBuilderV5OrderBy'
           type: array
       type: object
-    Querybuildertypesv5QueryBuilderQueryGithubComSigNozSignozPkgTypesQuerybuildertypesQuerybuildertypesv5LogAggregation:
+    QueryBuilderV5QueryBuilderTraceOperator:
       properties:
         aggregations:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5LogAggregation'
-          type: array
-        cursor:
-          type: string
-        disabled:
-          type: boolean
-        filter:
-          $ref: '#/components/schemas/Querybuildertypesv5Filter'
-        functions:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5Function'
-          type: array
-        groupBy:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5GroupByKey'
-          type: array
-        having:
-          $ref: '#/components/schemas/Querybuildertypesv5Having'
-        legend:
-          type: string
-        limit:
-          type: integer
-        limitBy:
-          $ref: '#/components/schemas/Querybuildertypesv5LimitBy'
-        name:
-          type: string
-        offset:
-          type: integer
-        order:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5OrderBy'
-          type: array
-        secondaryAggregations:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5SecondaryAggregation'
-          type: array
-        selectFields:
-          items:
-            $ref: '#/components/schemas/TelemetrytypesTelemetryFieldKey'
-          type: array
-        signal:
-          $ref: '#/components/schemas/TelemetrytypesSignal'
-        source:
-          $ref: '#/components/schemas/TelemetrytypesSource'
-        stepInterval:
-          $ref: '#/components/schemas/Querybuildertypesv5Step'
-      type: object
-    Querybuildertypesv5QueryBuilderQueryGithubComSigNozSignozPkgTypesQuerybuildertypesQuerybuildertypesv5MetricAggregation:
-      properties:
-        aggregations:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5MetricAggregation'
-          type: array
-        cursor:
-          type: string
-        disabled:
-          type: boolean
-        filter:
-          $ref: '#/components/schemas/Querybuildertypesv5Filter'
-        functions:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5Function'
-          type: array
-        groupBy:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5GroupByKey'
-          type: array
-        having:
-          $ref: '#/components/schemas/Querybuildertypesv5Having'
-        legend:
-          type: string
-        limit:
-          type: integer
-        limitBy:
-          $ref: '#/components/schemas/Querybuildertypesv5LimitBy'
-        name:
-          type: string
-        offset:
-          type: integer
-        order:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5OrderBy'
-          type: array
-        secondaryAggregations:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5SecondaryAggregation'
-          type: array
-        selectFields:
-          items:
-            $ref: '#/components/schemas/TelemetrytypesTelemetryFieldKey'
-          type: array
-        signal:
-          $ref: '#/components/schemas/TelemetrytypesSignal'
-        source:
-          $ref: '#/components/schemas/TelemetrytypesSource'
-        stepInterval:
-          $ref: '#/components/schemas/Querybuildertypesv5Step'
-      type: object
-    Querybuildertypesv5QueryBuilderQueryGithubComSigNozSignozPkgTypesQuerybuildertypesQuerybuildertypesv5TraceAggregation:
-      properties:
-        aggregations:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5TraceAggregation'
-          type: array
-        cursor:
-          type: string
-        disabled:
-          type: boolean
-        filter:
-          $ref: '#/components/schemas/Querybuildertypesv5Filter'
-        functions:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5Function'
-          type: array
-        groupBy:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5GroupByKey'
-          type: array
-        having:
-          $ref: '#/components/schemas/Querybuildertypesv5Having'
-        legend:
-          type: string
-        limit:
-          type: integer
-        limitBy:
-          $ref: '#/components/schemas/Querybuildertypesv5LimitBy'
-        name:
-          type: string
-        offset:
-          type: integer
-        order:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5OrderBy'
-          type: array
-        secondaryAggregations:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5SecondaryAggregation'
-          type: array
-        selectFields:
-          items:
-            $ref: '#/components/schemas/TelemetrytypesTelemetryFieldKey'
-          type: array
-        signal:
-          $ref: '#/components/schemas/TelemetrytypesSignal'
-        source:
-          $ref: '#/components/schemas/TelemetrytypesSource'
-        stepInterval:
-          $ref: '#/components/schemas/Querybuildertypesv5Step'
-      type: object
-    Querybuildertypesv5QueryBuilderTraceOperator:
-      properties:
-        aggregations:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5TraceAggregation'
+            $ref: '#/components/schemas/QueryBuilderV5TraceAggregation'
           type: array
         cursor:
           type: string
@@ -3663,17 +3810,17 @@ components:
         expression:
           type: string
         filter:
-          $ref: '#/components/schemas/Querybuildertypesv5Filter'
+          $ref: '#/components/schemas/QueryBuilderV5Filter'
         functions:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5Function'
+            $ref: '#/components/schemas/QueryBuilderV5Function'
           type: array
         groupBy:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5GroupByKey'
+            $ref: '#/components/schemas/QueryBuilderV5GroupByKey'
           type: array
         having:
-          $ref: '#/components/schemas/Querybuildertypesv5Having'
+          $ref: '#/components/schemas/QueryBuilderV5Having'
         legend:
           type: string
         limit:
@@ -3684,107 +3831,107 @@ components:
           type: integer
         order:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5OrderBy'
+            $ref: '#/components/schemas/QueryBuilderV5OrderBy'
           type: array
         returnSpansFrom:
           type: string
         selectFields:
           items:
-            $ref: '#/components/schemas/TelemetrytypesTelemetryFieldKey'
+            $ref: '#/components/schemas/TelemetryFieldKey'
           type: array
         stepInterval:
-          $ref: '#/components/schemas/Querybuildertypesv5Step'
+          $ref: '#/components/schemas/QueryBuilderV5Step'
       type: object
-    Querybuildertypesv5QueryData:
+    QueryBuilderV5QueryData:
       oneOf:
-      - $ref: '#/components/schemas/Querybuildertypesv5TimeSeriesData'
-      - $ref: '#/components/schemas/Querybuildertypesv5ScalarData'
-      - $ref: '#/components/schemas/Querybuildertypesv5RawData'
+      - $ref: '#/components/schemas/QueryBuilderV5TimeSeriesData'
+      - $ref: '#/components/schemas/QueryBuilderV5ScalarData'
+      - $ref: '#/components/schemas/QueryBuilderV5RawData'
       properties:
         results:
           items: {}
           nullable: true
           type: array
       type: object
-    Querybuildertypesv5QueryEnvelope:
+    QueryBuilderV5QueryEnvelope:
       oneOf:
-      - $ref: '#/components/schemas/Querybuildertypesv5QueryEnvelopeBuilderTrace'
-      - $ref: '#/components/schemas/Querybuildertypesv5QueryEnvelopeBuilderLog'
-      - $ref: '#/components/schemas/Querybuildertypesv5QueryEnvelopeBuilderMetric'
-      - $ref: '#/components/schemas/Querybuildertypesv5QueryEnvelopeFormula'
-      - $ref: '#/components/schemas/Querybuildertypesv5QueryEnvelopeTraceOperator'
-      - $ref: '#/components/schemas/Querybuildertypesv5QueryEnvelopePromQL'
-      - $ref: '#/components/schemas/Querybuildertypesv5QueryEnvelopeClickHouseSQL'
+      - $ref: '#/components/schemas/QueryBuilderV5QueryEnvelopeBuilderTrace'
+      - $ref: '#/components/schemas/QueryBuilderV5QueryEnvelopeBuilderLog'
+      - $ref: '#/components/schemas/QueryBuilderV5QueryEnvelopeBuilderMetric'
+      - $ref: '#/components/schemas/QueryBuilderV5QueryEnvelopeFormula'
+      - $ref: '#/components/schemas/QueryBuilderV5QueryEnvelopeTraceOperator'
+      - $ref: '#/components/schemas/QueryBuilderV5QueryEnvelopePromQL'
+      - $ref: '#/components/schemas/QueryBuilderV5QueryEnvelopeClickHouseSQL'
       properties:
         spec: {}
         type:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryType'
+          $ref: '#/components/schemas/QueryBuilderV5QueryType'
       type: object
-    Querybuildertypesv5QueryEnvelopeBuilderLog:
+    QueryBuilderV5QueryEnvelopeBuilderLog:
       properties:
         spec:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryBuilderQueryGithubComSigNozSignozPkgTypesQuerybuildertypesQuerybuildertypesv5LogAggregation'
+          $ref: '#/components/schemas/QueryBuilderQueryLogAggregation'
         type:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryType'
+          $ref: '#/components/schemas/QueryBuilderV5QueryType'
       type: object
-    Querybuildertypesv5QueryEnvelopeBuilderMetric:
+    QueryBuilderV5QueryEnvelopeBuilderMetric:
       properties:
         spec:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryBuilderQueryGithubComSigNozSignozPkgTypesQuerybuildertypesQuerybuildertypesv5MetricAggregation'
+          $ref: '#/components/schemas/QueryBuilderQueryMetricAggregation'
         type:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryType'
+          $ref: '#/components/schemas/QueryBuilderV5QueryType'
       type: object
-    Querybuildertypesv5QueryEnvelopeBuilderTrace:
+    QueryBuilderV5QueryEnvelopeBuilderTrace:
       properties:
         spec:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryBuilderQueryGithubComSigNozSignozPkgTypesQuerybuildertypesQuerybuildertypesv5TraceAggregation'
+          $ref: '#/components/schemas/QueryBuilderQueryTraceAggregation'
         type:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryType'
+          $ref: '#/components/schemas/QueryBuilderV5QueryType'
       type: object
-    Querybuildertypesv5QueryEnvelopeClickHouseSQL:
+    QueryBuilderV5QueryEnvelopeClickHouseSQL:
       properties:
         spec:
-          $ref: '#/components/schemas/Querybuildertypesv5ClickHouseQuery'
+          $ref: '#/components/schemas/QueryBuilderV5ClickHouseQuery'
         type:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryType'
+          $ref: '#/components/schemas/QueryBuilderV5QueryType'
       type: object
-    Querybuildertypesv5QueryEnvelopeFormula:
+    QueryBuilderV5QueryEnvelopeFormula:
       properties:
         spec:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryBuilderFormula'
+          $ref: '#/components/schemas/QueryBuilderV5QueryBuilderFormula'
         type:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryType'
+          $ref: '#/components/schemas/QueryBuilderV5QueryType'
       type: object
-    Querybuildertypesv5QueryEnvelopePromQL:
+    QueryBuilderV5QueryEnvelopePromQL:
       properties:
         spec:
-          $ref: '#/components/schemas/Querybuildertypesv5PromQuery'
+          $ref: '#/components/schemas/QueryBuilderV5PromQuery'
         type:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryType'
+          $ref: '#/components/schemas/QueryBuilderV5QueryType'
       type: object
-    Querybuildertypesv5QueryEnvelopeTraceOperator:
+    QueryBuilderV5QueryEnvelopeTraceOperator:
       properties:
         spec:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryBuilderTraceOperator'
+          $ref: '#/components/schemas/QueryBuilderV5QueryBuilderTraceOperator'
         type:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryType'
+          $ref: '#/components/schemas/QueryBuilderV5QueryType'
       type: object
-    Querybuildertypesv5QueryRangeRequest:
+    QueryBuilderV5QueryRangeRequest:
       description: Request body for the v5 query range endpoint. Supports builder
         queries (traces, logs, metrics), formulas, joins, trace operators, PromQL,
         and ClickHouse SQL queries.
       properties:
         compositeQuery:
-          $ref: '#/components/schemas/Querybuildertypesv5CompositeQuery'
+          $ref: '#/components/schemas/QueryBuilderV5CompositeQuery'
         end:
           minimum: 0
           type: integer
         formatOptions:
-          $ref: '#/components/schemas/Querybuildertypesv5FormatOptions'
+          $ref: '#/components/schemas/QueryBuilderV5FormatOptions'
         noCache:
           type: boolean
         requestType:
-          $ref: '#/components/schemas/Querybuildertypesv5RequestType'
+          $ref: '#/components/schemas/QueryBuilderV5RequestType'
         schemaVersion:
           type: string
         start:
@@ -3792,24 +3939,24 @@ components:
           type: integer
         variables:
           additionalProperties:
-            $ref: '#/components/schemas/Querybuildertypesv5VariableItem'
+            $ref: '#/components/schemas/QueryBuilderV5VariableItem'
           type: object
       type: object
-    Querybuildertypesv5QueryRangeResponse:
+    QueryBuilderV5QueryRangeResponse:
       description: 'Response from the v5 query range endpoint. The data.results array
         contains typed results depending on the requestType: TimeSeriesData for time_series,
         ScalarData for scalar, or RawData for raw requests.'
       properties:
         data:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryData'
+          $ref: '#/components/schemas/QueryBuilderV5QueryData'
         meta:
-          $ref: '#/components/schemas/Querybuildertypesv5ExecStats'
+          $ref: '#/components/schemas/QueryBuilderV5ExecStats'
         type:
-          $ref: '#/components/schemas/Querybuildertypesv5RequestType'
+          $ref: '#/components/schemas/QueryBuilderV5RequestType'
         warning:
-          $ref: '#/components/schemas/Querybuildertypesv5QueryWarnData'
+          $ref: '#/components/schemas/QueryBuilderV5QueryWarnData'
       type: object
-    Querybuildertypesv5QueryType:
+    QueryBuilderV5QueryType:
       enum:
       - builder_query
       - builder_formula
@@ -3817,7 +3964,7 @@ components:
       - clickhouse_sql
       - promql
       type: string
-    Querybuildertypesv5QueryWarnData:
+    QueryBuilderV5QueryWarnData:
       properties:
         message:
           type: string
@@ -3825,15 +3972,15 @@ components:
           type: string
         warnings:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5QueryWarnDataAdditional'
+            $ref: '#/components/schemas/QueryBuilderV5QueryWarnDataAdditional'
           type: array
       type: object
-    Querybuildertypesv5QueryWarnDataAdditional:
+    QueryBuilderV5QueryWarnDataAdditional:
       properties:
         message:
           type: string
       type: object
-    Querybuildertypesv5RawData:
+    QueryBuilderV5RawData:
       properties:
         nextCursor:
           type: string
@@ -3841,11 +3988,11 @@ components:
           type: string
         rows:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5RawRow'
+            $ref: '#/components/schemas/QueryBuilderV5RawRow'
           nullable: true
           type: array
       type: object
-    Querybuildertypesv5RawRow:
+    QueryBuilderV5RawRow:
       properties:
         data:
           additionalProperties: {}
@@ -3855,7 +4002,7 @@ components:
           format: date-time
           type: string
       type: object
-    Querybuildertypesv5ReduceTo:
+    QueryBuilderV5ReduceTo:
       enum:
       - sum
       - count
@@ -3865,7 +4012,7 @@ components:
       - last
       - median
       type: string
-    Querybuildertypesv5RequestType:
+    QueryBuilderV5RequestType:
       enum:
       - scalar
       - time_series
@@ -3873,11 +4020,11 @@ components:
       - raw_stream
       - trace
       type: string
-    Querybuildertypesv5ScalarData:
+    QueryBuilderV5ScalarData:
       properties:
         columns:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5ColumnDescriptor'
+            $ref: '#/components/schemas/QueryBuilderV5ColumnDescriptor'
           nullable: true
           type: array
         data:
@@ -3889,7 +4036,7 @@ components:
         queryName:
           type: string
       type: object
-    Querybuildertypesv5SecondaryAggregation:
+    QueryBuilderV5SecondaryAggregation:
       properties:
         alias:
           type: string
@@ -3897,20 +4044,20 @@ components:
           type: string
         groupBy:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5GroupByKey'
+            $ref: '#/components/schemas/QueryBuilderV5GroupByKey'
           type: array
         limit:
           type: integer
         limitBy:
-          $ref: '#/components/schemas/Querybuildertypesv5LimitBy'
+          $ref: '#/components/schemas/QueryBuilderV5LimitBy'
         order:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5OrderBy'
+            $ref: '#/components/schemas/QueryBuilderV5OrderBy'
           type: array
         stepInterval:
-          $ref: '#/components/schemas/Querybuildertypesv5Step'
+          $ref: '#/components/schemas/QueryBuilderV5Step'
       type: object
-    Querybuildertypesv5Step:
+    QueryBuilderV5Step:
       description: Step interval. Accepts a Go duration string (e.g., "60s", "1m",
         "1h") or a number representing seconds (e.g., 60).
       oneOf:
@@ -3920,32 +4067,32 @@ components:
       - description: Duration in seconds.
         example: 60
         type: number
-    Querybuildertypesv5TimeSeries:
+    QueryBuilderV5TimeSeries:
       properties:
         labels:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5Label'
+            $ref: '#/components/schemas/QueryBuilderV5Label'
           type: array
         values:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5TimeSeriesValue'
+            $ref: '#/components/schemas/QueryBuilderV5TimeSeriesValue'
           nullable: true
           type: array
       type: object
-    Querybuildertypesv5TimeSeriesData:
+    QueryBuilderV5TimeSeriesData:
       properties:
         aggregations:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5AggregationBucket'
+            $ref: '#/components/schemas/QueryBuilderV5AggregationBucket'
           nullable: true
           type: array
         queryName:
           type: string
       type: object
-    Querybuildertypesv5TimeSeriesValue:
+    QueryBuilderV5TimeSeriesValue:
       properties:
         bucket:
-          $ref: '#/components/schemas/Querybuildertypesv5Bucket'
+          $ref: '#/components/schemas/QueryBuilderV5Bucket'
         partial:
           type: boolean
         timestamp:
@@ -3960,20 +4107,20 @@ components:
             type: number
           type: array
       type: object
-    Querybuildertypesv5TraceAggregation:
+    QueryBuilderV5TraceAggregation:
       properties:
         alias:
           type: string
         expression:
           type: string
       type: object
-    Querybuildertypesv5VariableItem:
+    QueryBuilderV5VariableItem:
       properties:
         type:
-          $ref: '#/components/schemas/Querybuildertypesv5VariableType'
+          $ref: '#/components/schemas/QueryBuilderV5VariableType'
         value: {}
       type: object
-    Querybuildertypesv5VariableType:
+    QueryBuilderV5VariableType:
       enum:
       - query
       - dynamic
@@ -3990,18 +4137,502 @@ components:
       - status
       - error
       type: object
-    RulestatehistorytypesGettableRuleStateHistory:
+    ResetPasswordToken:
+      properties:
+        expiresAt:
+          format: date-time
+          type: string
+        id:
+          type: string
+        passwordId:
+          type: string
+        token:
+          type: string
+      required:
+      - id
+      type: object
+    Rule:
+      properties:
+        alert:
+          type: string
+        alertType:
+          $ref: '#/components/schemas/RuleAlertType'
+        annotations:
+          additionalProperties:
+            type: string
+          type: object
+        condition:
+          $ref: '#/components/schemas/RuleCondition'
+        createdAt:
+          format: date-time
+          type: string
+        createdBy:
+          type: string
+        description:
+          type: string
+        disabled:
+          type: boolean
+        evalWindow:
+          type: string
+        evaluation:
+          $ref: '#/components/schemas/RuleEvaluationEnvelope'
+        frequency:
+          type: string
+        id:
+          type: string
+        labels:
+          additionalProperties:
+            type: string
+          type: object
+        notificationSettings:
+          $ref: '#/components/schemas/RuleNotificationSettings'
+        preferredChannels:
+          items:
+            type: string
+          type: array
+        ruleType:
+          $ref: '#/components/schemas/RuleType'
+        schemaVersion:
+          type: string
+        source:
+          type: string
+        state:
+          $ref: '#/components/schemas/RuleAlertState'
+        updatedAt:
+          format: date-time
+          type: string
+        updatedBy:
+          type: string
+        version:
+          type: string
+      required:
+      - id
+      - state
+      - alert
+      - alertType
+      - ruleType
+      - condition
+      type: object
+    RuleAlertCompositeQuery:
+      properties:
+        panelType:
+          $ref: '#/components/schemas/RulePanelType'
+        queries:
+          items:
+            $ref: '#/components/schemas/QueryBuilderV5QueryEnvelope'
+          nullable: true
+          type: array
+        queryType:
+          $ref: '#/components/schemas/RuleQueryType'
+        unit:
+          type: string
+      required:
+      - queries
+      - panelType
+      - queryType
+      type: object
+    RuleAlertState:
+      enum:
+      - inactive
+      - pending
+      - recovering
+      - firing
+      - nodata
+      - disabled
+      type: string
+    RuleAlertType:
+      enum:
+      - METRIC_BASED_ALERT
+      - TRACES_BASED_ALERT
+      - LOGS_BASED_ALERT
+      - EXCEPTIONS_BASED_ALERT
+      type: string
+    RuleBasicRuleThreshold:
+      properties:
+        channels:
+          items:
+            type: string
+          nullable: true
+          type: array
+        matchType:
+          $ref: '#/components/schemas/RuleMatchType'
+        name:
+          type: string
+        op:
+          $ref: '#/components/schemas/RuleCompareOperator'
+        recoveryTarget:
+          nullable: true
+          type: number
+        target:
+          nullable: true
+          type: number
+        targetUnit:
+          type: string
+      required:
+      - name
+      - target
+      - matchType
+      - op
+      type: object
+    RuleBasicRuleThresholds:
+      items:
+        $ref: '#/components/schemas/RuleBasicRuleThreshold'
+      nullable: true
+      type: array
+    RuleCompareOperator:
+      enum:
+      - above
+      - below
+      - equal
+      - not_equal
+      - outside_bounds
+      type: string
+    RuleCondition:
+      properties:
+        absentFor:
+          minimum: 0
+          type: integer
+        alertOnAbsent:
+          type: boolean
+        algorithm:
+          type: string
+        compositeQuery:
+          $ref: '#/components/schemas/RuleAlertCompositeQuery'
+        matchType:
+          $ref: '#/components/schemas/RuleMatchType'
+        op:
+          $ref: '#/components/schemas/RuleCompareOperator'
+        requireMinPoints:
+          type: boolean
+        requiredNumPoints:
+          type: integer
+        seasonality:
+          $ref: '#/components/schemas/RuleSeasonality'
+        selectedQueryName:
+          type: string
+        target:
+          nullable: true
+          type: number
+        targetUnit:
+          type: string
+        thresholds:
+          $ref: '#/components/schemas/RuleThresholdData'
+      required:
+      - compositeQuery
+      type: object
+    RuleCumulativeSchedule:
+      properties:
+        day:
+          nullable: true
+          type: integer
+        hour:
+          nullable: true
+          type: integer
+        minute:
+          nullable: true
+          type: integer
+        type:
+          $ref: '#/components/schemas/RuleScheduleType'
+        weekday:
+          nullable: true
+          type: integer
+      required:
+      - type
+      type: object
+    RuleCumulativeWindow:
+      properties:
+        frequency:
+          type: string
+        schedule:
+          $ref: '#/components/schemas/RuleCumulativeSchedule'
+        timezone:
+          type: string
+      required:
+      - schedule
+      - frequency
+      - timezone
+      type: object
+    RuleEvaluationCumulative:
+      properties:
+        kind:
+          $ref: '#/components/schemas/RuleEvaluationKind'
+        spec:
+          $ref: '#/components/schemas/RuleCumulativeWindow'
+      type: object
+    RuleEvaluationEnvelope:
+      oneOf:
+      - $ref: '#/components/schemas/RuleEvaluationRolling'
+      - $ref: '#/components/schemas/RuleEvaluationCumulative'
+      properties:
+        kind:
+          $ref: '#/components/schemas/RuleEvaluationKind'
+        spec: {}
+      required:
+      - kind
+      - spec
+      type: object
+    RuleEvaluationKind:
+      enum:
+      - rolling
+      - cumulative
+      type: string
+    RuleEvaluationRolling:
+      properties:
+        kind:
+          $ref: '#/components/schemas/RuleEvaluationKind'
+        spec:
+          $ref: '#/components/schemas/RuleRollingWindow'
+      type: object
+    RuleGettableTestRule:
+      properties:
+        alertCount:
+          type: integer
+        message:
+          type: string
+      type: object
+    RuleMaintenanceKind:
+      enum:
+      - fixed
+      - recurring
+      type: string
+    RuleMaintenanceStatus:
+      enum:
+      - active
+      - upcoming
+      - expired
+      type: string
+    RuleMatchType:
+      enum:
+      - at_least_once
+      - all_the_times
+      - on_average
+      - in_total
+      - last
+      type: string
+    RuleNotificationSettings:
+      properties:
+        groupBy:
+          items:
+            type: string
+          type: array
+        newGroupEvalDelay:
+          type: string
+        renotify:
+          $ref: '#/components/schemas/RuleRenotify'
+        usePolicy:
+          type: boolean
+      type: object
+    RulePanelType:
+      enum:
+      - value
+      - table
+      - graph
+      type: string
+    RulePlannedMaintenance:
+      properties:
+        alertIds:
+          items:
+            type: string
+          nullable: true
+          type: array
+        createdAt:
+          format: date-time
+          type: string
+        createdBy:
+          type: string
+        description:
+          type: string
+        id:
+          type: string
+        kind:
+          $ref: '#/components/schemas/RuleMaintenanceKind'
+        name:
+          type: string
+        schedule:
+          $ref: '#/components/schemas/RuleSchedule'
+        status:
+          $ref: '#/components/schemas/RuleMaintenanceStatus'
+        updatedAt:
+          format: date-time
+          type: string
+        updatedBy:
+          type: string
+      required:
+      - id
+      - name
+      - schedule
+      - status
+      - kind
+      type: object
+    RulePostablePlannedMaintenance:
+      properties:
+        alertIds:
+          items:
+            type: string
+          nullable: true
+          type: array
+        description:
+          type: string
+        name:
+          type: string
+        schedule:
+          $ref: '#/components/schemas/RuleSchedule'
+      required:
+      - name
+      - schedule
+      type: object
+    RulePostableRule:
+      properties:
+        alert:
+          type: string
+        alertType:
+          $ref: '#/components/schemas/RuleAlertType'
+        annotations:
+          additionalProperties:
+            type: string
+          type: object
+        condition:
+          $ref: '#/components/schemas/RuleCondition'
+        description:
+          type: string
+        disabled:
+          type: boolean
+        evalWindow:
+          type: string
+        evaluation:
+          $ref: '#/components/schemas/RuleEvaluationEnvelope'
+        frequency:
+          type: string
+        labels:
+          additionalProperties:
+            type: string
+          type: object
+        notificationSettings:
+          $ref: '#/components/schemas/RuleNotificationSettings'
+        preferredChannels:
+          items:
+            type: string
+          type: array
+        ruleType:
+          $ref: '#/components/schemas/RuleType'
+        schemaVersion:
+          type: string
+        source:
+          type: string
+        version:
+          type: string
+      required:
+      - alert
+      - alertType
+      - ruleType
+      - condition
+      type: object
+    RuleQueryType:
+      enum:
+      - builder
+      - clickhouse_sql
+      - promql
+      type: string
+    RuleRecurrence:
+      properties:
+        duration:
+          type: string
+        endTime:
+          format: date-time
+          nullable: true
+          type: string
+        repeatOn:
+          items:
+            $ref: '#/components/schemas/RuleRepeatOn'
+          nullable: true
+          type: array
+        repeatType:
+          $ref: '#/components/schemas/RuleRepeatType'
+        startTime:
+          format: date-time
+          type: string
+      required:
+      - startTime
+      - duration
+      - repeatType
+      type: object
+    RuleRenotify:
+      properties:
+        alertStates:
+          items:
+            $ref: '#/components/schemas/RuleAlertState'
+          type: array
+        enabled:
+          type: boolean
+        interval:
+          type: string
+      type: object
+    RuleRepeatOn:
+      enum:
+      - sunday
+      - monday
+      - tuesday
+      - wednesday
+      - thursday
+      - friday
+      - saturday
+      type: string
+    RuleRepeatType:
+      enum:
+      - daily
+      - weekly
+      - monthly
+      type: string
+    RuleRollingWindow:
+      properties:
+        evalWindow:
+          type: string
+        frequency:
+          type: string
+      required:
+      - evalWindow
+      - frequency
+      type: object
+    RuleSchedule:
+      properties:
+        endTime:
+          format: date-time
+          type: string
+        recurrence:
+          $ref: '#/components/schemas/RuleRecurrence'
+        startTime:
+          format: date-time
+          type: string
+        timezone:
+          type: string
+      required:
+      - timezone
+      type: object
+    RuleScheduleType:
+      enum:
+      - hourly
+      - daily
+      - weekly
+      - monthly
+      type: string
+    RuleSeasonality:
+      enum:
+      - hourly
+      - daily
+      - weekly
+      type: string
+    RuleStateHistoryGettableRuleStateHistory:
       properties:
         fingerprint:
           minimum: 0
           type: integer
         labels:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5Label'
+            $ref: '#/components/schemas/QueryBuilderV5Label'
           nullable: true
           type: array
         overallState:
-          $ref: '#/components/schemas/RuletypesAlertState'
+          $ref: '#/components/schemas/RuleAlertState'
         overallStateChanged:
           type: boolean
         ruleId:
@@ -4009,7 +4640,7 @@ components:
         ruleName:
           type: string
         state:
-          $ref: '#/components/schemas/RuletypesAlertState'
+          $ref: '#/components/schemas/RuleAlertState'
         stateChanged:
           type: boolean
         unixMilli:
@@ -4030,7 +4661,7 @@ components:
       - fingerprint
       - value
       type: object
-    RulestatehistorytypesGettableRuleStateHistoryContributor:
+    RuleStateHistoryGettableRuleStateHistoryContributor:
       properties:
         count:
           minimum: 0
@@ -4040,7 +4671,7 @@ components:
           type: integer
         labels:
           items:
-            $ref: '#/components/schemas/Querybuildertypesv5Label'
+            $ref: '#/components/schemas/QueryBuilderV5Label'
           nullable: true
           type: array
         relatedLogsLink:
@@ -4052,22 +4683,22 @@ components:
       - labels
       - count
       type: object
-    RulestatehistorytypesGettableRuleStateHistoryStats:
+    RuleStateHistoryGettableRuleStateHistoryStats:
       properties:
         currentAvgResolutionTime:
           format: double
           type: number
         currentAvgResolutionTimeSeries:
-          $ref: '#/components/schemas/Querybuildertypesv5TimeSeries'
+          $ref: '#/components/schemas/QueryBuilderV5TimeSeries'
         currentTriggersSeries:
-          $ref: '#/components/schemas/Querybuildertypesv5TimeSeries'
+          $ref: '#/components/schemas/QueryBuilderV5TimeSeries'
         pastAvgResolutionTime:
           format: double
           type: number
         pastAvgResolutionTimeSeries:
-          $ref: '#/components/schemas/Querybuildertypesv5TimeSeries'
+          $ref: '#/components/schemas/QueryBuilderV5TimeSeries'
         pastTriggersSeries:
-          $ref: '#/components/schemas/Querybuildertypesv5TimeSeries'
+          $ref: '#/components/schemas/QueryBuilderV5TimeSeries'
         totalCurrentTriggers:
           minimum: 0
           type: integer
@@ -4084,11 +4715,11 @@ components:
       - currentAvgResolutionTimeSeries
       - pastAvgResolutionTimeSeries
       type: object
-    RulestatehistorytypesGettableRuleStateTimeline:
+    RuleStateHistoryGettableRuleStateTimeline:
       properties:
         items:
           items:
-            $ref: '#/components/schemas/RulestatehistorytypesGettableRuleStateHistory'
+            $ref: '#/components/schemas/RuleStateHistoryGettableRuleStateHistory'
           nullable: true
           type: array
         nextCursor:
@@ -4100,7 +4731,7 @@ components:
       - items
       - total
       type: object
-    RulestatehistorytypesGettableRuleStateWindow:
+    RuleStateHistoryGettableRuleStateWindow:
       properties:
         end:
           format: int64
@@ -4109,511 +4740,66 @@ components:
           format: int64
           type: integer
         state:
-          $ref: '#/components/schemas/RuletypesAlertState'
+          $ref: '#/components/schemas/RuleAlertState'
       required:
       - state
       - start
       - end
       type: object
-    RuletypesAlertCompositeQuery:
-      properties:
-        panelType:
-          $ref: '#/components/schemas/RuletypesPanelType'
-        queries:
-          items:
-            $ref: '#/components/schemas/Querybuildertypesv5QueryEnvelope'
-          nullable: true
-          type: array
-        queryType:
-          $ref: '#/components/schemas/RuletypesQueryType'
-        unit:
-          type: string
-      required:
-      - queries
-      - panelType
-      - queryType
-      type: object
-    RuletypesAlertState:
-      enum:
-      - inactive
-      - pending
-      - recovering
-      - firing
-      - nodata
-      - disabled
-      type: string
-    RuletypesAlertType:
-      enum:
-      - METRIC_BASED_ALERT
-      - TRACES_BASED_ALERT
-      - LOGS_BASED_ALERT
-      - EXCEPTIONS_BASED_ALERT
-      type: string
-    RuletypesBasicRuleThreshold:
-      properties:
-        channels:
-          items:
-            type: string
-          nullable: true
-          type: array
-        matchType:
-          $ref: '#/components/schemas/RuletypesMatchType'
-        name:
-          type: string
-        op:
-          $ref: '#/components/schemas/RuletypesCompareOperator'
-        recoveryTarget:
-          nullable: true
-          type: number
-        target:
-          nullable: true
-          type: number
-        targetUnit:
-          type: string
-      required:
-      - name
-      - target
-      - matchType
-      - op
-      type: object
-    RuletypesBasicRuleThresholds:
-      items:
-        $ref: '#/components/schemas/RuletypesBasicRuleThreshold'
-      nullable: true
-      type: array
-    RuletypesCompareOperator:
-      enum:
-      - above
-      - below
-      - equal
-      - not_equal
-      - outside_bounds
-      type: string
-    RuletypesCumulativeSchedule:
-      properties:
-        day:
-          nullable: true
-          type: integer
-        hour:
-          nullable: true
-          type: integer
-        minute:
-          nullable: true
-          type: integer
-        type:
-          $ref: '#/components/schemas/RuletypesScheduleType'
-        weekday:
-          nullable: true
-          type: integer
-      required:
-      - type
-      type: object
-    RuletypesCumulativeWindow:
-      properties:
-        frequency:
-          type: string
-        schedule:
-          $ref: '#/components/schemas/RuletypesCumulativeSchedule'
-        timezone:
-          type: string
-      required:
-      - schedule
-      - frequency
-      - timezone
-      type: object
-    RuletypesEvaluationCumulative:
+    RuleThresholdBasic:
       properties:
         kind:
-          $ref: '#/components/schemas/RuletypesEvaluationKind'
+          $ref: '#/components/schemas/RuleThresholdKind'
         spec:
-          $ref: '#/components/schemas/RuletypesCumulativeWindow'
+          $ref: '#/components/schemas/RuleBasicRuleThresholds'
       type: object
-    RuletypesEvaluationEnvelope:
+    RuleThresholdData:
       oneOf:
-      - $ref: '#/components/schemas/RuletypesEvaluationRolling'
-      - $ref: '#/components/schemas/RuletypesEvaluationCumulative'
+      - $ref: '#/components/schemas/RuleThresholdBasic'
       properties:
         kind:
-          $ref: '#/components/schemas/RuletypesEvaluationKind'
+          $ref: '#/components/schemas/RuleThresholdKind'
         spec: {}
       required:
       - kind
       - spec
       type: object
-    RuletypesEvaluationKind:
+    RuleThresholdKind:
       enum:
-      - rolling
-      - cumulative
+      - basic
       type: string
-    RuletypesEvaluationRolling:
-      properties:
-        kind:
-          $ref: '#/components/schemas/RuletypesEvaluationKind'
-        spec:
-          $ref: '#/components/schemas/RuletypesRollingWindow'
-      type: object
-    RuletypesGettableTestRule:
-      properties:
-        alertCount:
-          type: integer
-        message:
-          type: string
-      type: object
-    RuletypesMaintenanceKind:
-      enum:
-      - fixed
-      - recurring
-      type: string
-    RuletypesMaintenanceStatus:
-      enum:
-      - active
-      - upcoming
-      - expired
-      type: string
-    RuletypesMatchType:
-      enum:
-      - at_least_once
-      - all_the_times
-      - on_average
-      - in_total
-      - last
-      type: string
-    RuletypesNotificationSettings:
-      properties:
-        groupBy:
-          items:
-            type: string
-          type: array
-        newGroupEvalDelay:
-          type: string
-        renotify:
-          $ref: '#/components/schemas/RuletypesRenotify'
-        usePolicy:
-          type: boolean
-      type: object
-    RuletypesPanelType:
-      enum:
-      - value
-      - table
-      - graph
-      type: string
-    RuletypesPlannedMaintenance:
-      properties:
-        alertIds:
-          items:
-            type: string
-          nullable: true
-          type: array
-        createdAt:
-          format: date-time
-          type: string
-        createdBy:
-          type: string
-        description:
-          type: string
-        id:
-          type: string
-        kind:
-          $ref: '#/components/schemas/RuletypesMaintenanceKind'
-        name:
-          type: string
-        schedule:
-          $ref: '#/components/schemas/RuletypesSchedule'
-        status:
-          $ref: '#/components/schemas/RuletypesMaintenanceStatus'
-        updatedAt:
-          format: date-time
-          type: string
-        updatedBy:
-          type: string
-      required:
-      - id
-      - name
-      - schedule
-      - status
-      - kind
-      type: object
-    RuletypesPostablePlannedMaintenance:
-      properties:
-        alertIds:
-          items:
-            type: string
-          nullable: true
-          type: array
-        description:
-          type: string
-        name:
-          type: string
-        schedule:
-          $ref: '#/components/schemas/RuletypesSchedule'
-      required:
-      - name
-      - schedule
-      type: object
-    RuletypesPostableRule:
-      properties:
-        alert:
-          type: string
-        alertType:
-          $ref: '#/components/schemas/RuletypesAlertType'
-        annotations:
-          additionalProperties:
-            type: string
-          type: object
-        condition:
-          $ref: '#/components/schemas/RuletypesRuleCondition'
-        description:
-          type: string
-        disabled:
-          type: boolean
-        evalWindow:
-          type: string
-        evaluation:
-          $ref: '#/components/schemas/RuletypesEvaluationEnvelope'
-        frequency:
-          type: string
-        labels:
-          additionalProperties:
-            type: string
-          type: object
-        notificationSettings:
-          $ref: '#/components/schemas/RuletypesNotificationSettings'
-        preferredChannels:
-          items:
-            type: string
-          type: array
-        ruleType:
-          $ref: '#/components/schemas/RuletypesRuleType'
-        schemaVersion:
-          type: string
-        source:
-          type: string
-        version:
-          type: string
-      required:
-      - alert
-      - alertType
-      - ruleType
-      - condition
-      type: object
-    RuletypesQueryType:
-      enum:
-      - builder
-      - clickhouse_sql
-      - promql
-      type: string
-    RuletypesRecurrence:
-      properties:
-        duration:
-          type: string
-        endTime:
-          format: date-time
-          nullable: true
-          type: string
-        repeatOn:
-          items:
-            $ref: '#/components/schemas/RuletypesRepeatOn'
-          nullable: true
-          type: array
-        repeatType:
-          $ref: '#/components/schemas/RuletypesRepeatType'
-        startTime:
-          format: date-time
-          type: string
-      required:
-      - startTime
-      - duration
-      - repeatType
-      type: object
-    RuletypesRenotify:
-      properties:
-        alertStates:
-          items:
-            $ref: '#/components/schemas/RuletypesAlertState'
-          type: array
-        enabled:
-          type: boolean
-        interval:
-          type: string
-      type: object
-    RuletypesRepeatOn:
-      enum:
-      - sunday
-      - monday
-      - tuesday
-      - wednesday
-      - thursday
-      - friday
-      - saturday
-      type: string
-    RuletypesRepeatType:
-      enum:
-      - daily
-      - weekly
-      - monthly
-      type: string
-    RuletypesRollingWindow:
-      properties:
-        evalWindow:
-          type: string
-        frequency:
-          type: string
-      required:
-      - evalWindow
-      - frequency
-      type: object
-    RuletypesRule:
-      properties:
-        alert:
-          type: string
-        alertType:
-          $ref: '#/components/schemas/RuletypesAlertType'
-        annotations:
-          additionalProperties:
-            type: string
-          type: object
-        condition:
-          $ref: '#/components/schemas/RuletypesRuleCondition'
-        createdAt:
-          format: date-time
-          type: string
-        createdBy:
-          type: string
-        description:
-          type: string
-        disabled:
-          type: boolean
-        evalWindow:
-          type: string
-        evaluation:
-          $ref: '#/components/schemas/RuletypesEvaluationEnvelope'
-        frequency:
-          type: string
-        id:
-          type: string
-        labels:
-          additionalProperties:
-            type: string
-          type: object
-        notificationSettings:
-          $ref: '#/components/schemas/RuletypesNotificationSettings'
-        preferredChannels:
-          items:
-            type: string
-          type: array
-        ruleType:
-          $ref: '#/components/schemas/RuletypesRuleType'
-        schemaVersion:
-          type: string
-        source:
-          type: string
-        state:
-          $ref: '#/components/schemas/RuletypesAlertState'
-        updatedAt:
-          format: date-time
-          type: string
-        updatedBy:
-          type: string
-        version:
-          type: string
-      required:
-      - id
-      - state
-      - alert
-      - alertType
-      - ruleType
-      - condition
-      type: object
-    RuletypesRuleCondition:
-      properties:
-        absentFor:
-          minimum: 0
-          type: integer
-        alertOnAbsent:
-          type: boolean
-        algorithm:
-          type: string
-        compositeQuery:
-          $ref: '#/components/schemas/RuletypesAlertCompositeQuery'
-        matchType:
-          $ref: '#/components/schemas/RuletypesMatchType'
-        op:
-          $ref: '#/components/schemas/RuletypesCompareOperator'
-        requireMinPoints:
-          type: boolean
-        requiredNumPoints:
-          type: integer
-        seasonality:
-          $ref: '#/components/schemas/RuletypesSeasonality'
-        selectedQueryName:
-          type: string
-        target:
-          nullable: true
-          type: number
-        targetUnit:
-          type: string
-        thresholds:
-          $ref: '#/components/schemas/RuletypesRuleThresholdData'
-      required:
-      - compositeQuery
-      type: object
-    RuletypesRuleThresholdData:
-      oneOf:
-      - $ref: '#/components/schemas/RuletypesThresholdBasic'
-      properties:
-        kind:
-          $ref: '#/components/schemas/RuletypesThresholdKind'
-        spec: {}
-      required:
-      - kind
-      - spec
-      type: object
-    RuletypesRuleType:
+    RuleType:
       enum:
       - threshold_rule
       - promql_rule
       - anomaly_rule
       type: string
-    RuletypesSchedule:
+    ServiceAccount:
       properties:
-        endTime:
+        createdAt:
           format: date-time
           type: string
-        recurrence:
-          $ref: '#/components/schemas/RuletypesRecurrence'
-        startTime:
-          format: date-time
+        email:
           type: string
-        timezone:
+        id:
+          type: string
+        name:
+          type: string
+        orgId:
+          type: string
+        status:
+          type: string
+        updatedAt:
+          format: date-time
           type: string
       required:
-      - timezone
+      - id
+      - name
+      - email
+      - status
+      - orgId
       type: object
-    RuletypesScheduleType:
-      enum:
-      - hourly
-      - daily
-      - weekly
-      - monthly
-      type: string
-    RuletypesSeasonality:
-      enum:
-      - hourly
-      - daily
-      - weekly
-      type: string
-    RuletypesThresholdBasic:
-      properties:
-        kind:
-          $ref: '#/components/schemas/RuletypesThresholdKind'
-        spec:
-          $ref: '#/components/schemas/RuletypesBasicRuleThresholds'
-      type: object
-    RuletypesThresholdKind:
-      enum:
-      - basic
-      type: string
-    ServiceaccounttypesGettableFactorAPIKey:
+    ServiceAccountGettableFactorAPIKey:
       properties:
         createdAt:
           format: date-time
@@ -4639,7 +4825,7 @@ components:
       - lastObservedAt
       - serviceAccountId
       type: object
-    ServiceaccounttypesGettableFactorAPIKeyWithKey:
+    ServiceAccountGettableFactorAPIKeyWithKey:
       properties:
         id:
           type: string
@@ -4649,7 +4835,7 @@ components:
       - id
       - key
       type: object
-    ServiceaccounttypesPostableFactorAPIKey:
+    ServiceAccountPostableFactorAPIKey:
       properties:
         expiresAt:
           minimum: 0
@@ -4660,46 +4846,21 @@ components:
       - name
       - expiresAt
       type: object
-    ServiceaccounttypesPostableServiceAccount:
+    ServiceAccountPostableServiceAccount:
       properties:
         name:
           type: string
       required:
       - name
       type: object
-    ServiceaccounttypesPostableServiceAccountRole:
+    ServiceAccountPostableServiceAccountRole:
       properties:
         id:
           type: string
       required:
       - id
       type: object
-    ServiceaccounttypesServiceAccount:
-      properties:
-        createdAt:
-          format: date-time
-          type: string
-        email:
-          type: string
-        id:
-          type: string
-        name:
-          type: string
-        orgId:
-          type: string
-        status:
-          type: string
-        updatedAt:
-          format: date-time
-          type: string
-      required:
-      - id
-      - name
-      - email
-      - status
-      - orgId
-      type: object
-    ServiceaccounttypesServiceAccountRole:
+    ServiceAccountRole:
       properties:
         createdAt:
           format: date-time
@@ -4707,7 +4868,7 @@ components:
         id:
           type: string
         role:
-          $ref: '#/components/schemas/AuthtypesRole'
+          $ref: '#/components/schemas/AuthRole'
         roleId:
           type: string
         serviceAccountId:
@@ -4721,7 +4882,18 @@ components:
       - roleId
       - role
       type: object
-    ServiceaccounttypesServiceAccountWithRoles:
+    ServiceAccountUpdatableFactorAPIKey:
+      properties:
+        expiresAt:
+          minimum: 0
+          type: integer
+        name:
+          type: string
+      required:
+      - name
+      - expiresAt
+      type: object
+    ServiceAccountWithRoles:
       properties:
         createdAt:
           format: date-time
@@ -4736,7 +4908,7 @@ components:
           type: string
         serviceAccountRoles:
           items:
-            $ref: '#/components/schemas/ServiceaccounttypesServiceAccountRole'
+            $ref: '#/components/schemas/ServiceAccountRole'
           nullable: true
           type: array
         status:
@@ -4752,67 +4924,26 @@ components:
       - orgId
       - serviceAccountRoles
       type: object
-    ServiceaccounttypesUpdatableFactorAPIKey:
-      properties:
-        expiresAt:
-          minimum: 0
-          type: integer
-        name:
-          type: string
-      required:
-      - name
-      - expiresAt
+    SigV4Config:
       type: object
-    Sigv4SigV4Config:
-      type: object
-    SpantypesFieldContext:
+    SpanFieldContext:
       enum:
       - attribute
       - resource
       type: string
-    SpantypesGettableSpanMapperGroups:
+    SpanGettableSpanMapperGroups:
       properties:
         items:
           items:
-            $ref: '#/components/schemas/SpantypesSpanMapperGroup'
+            $ref: '#/components/schemas/SpanMapperGroup'
           type: array
       required:
       - items
       type: object
-    SpantypesPostableSpanMapper:
+    SpanMapper:
       properties:
         config:
-          $ref: '#/components/schemas/SpantypesSpanMapperConfig'
-        enabled:
-          type: boolean
-        field_context:
-          $ref: '#/components/schemas/SpantypesFieldContext'
-        name:
-          type: string
-      required:
-      - name
-      - field_context
-      - config
-      type: object
-    SpantypesPostableSpanMapperGroup:
-      properties:
-        category:
-          $ref: '#/components/schemas/SpantypesSpanMapperGroupCategory'
-        condition:
-          $ref: '#/components/schemas/SpantypesSpanMapperGroupCondition'
-        enabled:
-          type: boolean
-        name:
-          type: string
-      required:
-      - name
-      - category
-      - condition
-      type: object
-    SpantypesSpanMapper:
-      properties:
-        config:
-          $ref: '#/components/schemas/SpantypesSpanMapperConfig'
+          $ref: '#/components/schemas/SpanMapperConfig'
         createdAt:
           format: date-time
           type: string
@@ -4821,7 +4952,7 @@ components:
         enabled:
           type: boolean
         field_context:
-          $ref: '#/components/schemas/SpantypesFieldContext'
+          $ref: '#/components/schemas/SpanFieldContext'
         group_id:
           type: string
         id:
@@ -4841,22 +4972,22 @@ components:
       - config
       - enabled
       type: object
-    SpantypesSpanMapperConfig:
+    SpanMapperConfig:
       properties:
         sources:
           items:
-            $ref: '#/components/schemas/SpantypesSpanMapperSource'
+            $ref: '#/components/schemas/SpanMapperSource'
           nullable: true
           type: array
       required:
       - sources
       type: object
-    SpantypesSpanMapperGroup:
+    SpanMapperGroup:
       properties:
         category:
-          $ref: '#/components/schemas/SpantypesSpanMapperGroupCategory'
+          $ref: '#/components/schemas/SpanMapperGroupCategory'
         condition:
-          $ref: '#/components/schemas/SpantypesSpanMapperGroupCondition'
+          $ref: '#/components/schemas/SpanMapperGroupCondition'
         createdAt:
           format: date-time
           type: string
@@ -4883,9 +5014,9 @@ components:
       - condition
       - enabled
       type: object
-    SpantypesSpanMapperGroupCategory:
+    SpanMapperGroupCategory:
       type: object
-    SpantypesSpanMapperGroupCondition:
+    SpanMapperGroupCondition:
       properties:
         attributes:
           items:
@@ -4901,19 +5032,19 @@ components:
       - attributes
       - resource
       type: object
-    SpantypesSpanMapperOperation:
+    SpanMapperOperation:
       enum:
       - move
       - copy
       type: string
-    SpantypesSpanMapperSource:
+    SpanMapperSource:
       properties:
         context:
-          $ref: '#/components/schemas/SpantypesFieldContext'
+          $ref: '#/components/schemas/SpanFieldContext'
         key:
           type: string
         operation:
-          $ref: '#/components/schemas/SpantypesSpanMapperOperation'
+          $ref: '#/components/schemas/SpanMapperOperation'
         priority:
           type: integer
       required:
@@ -4922,20 +5053,50 @@ components:
       - operation
       - priority
       type: object
-    SpantypesUpdatableSpanMapper:
+    SpanPostableSpanMapper:
       properties:
         config:
-          $ref: '#/components/schemas/SpantypesSpanMapperConfig'
+          $ref: '#/components/schemas/SpanMapperConfig'
+        enabled:
+          type: boolean
+        field_context:
+          $ref: '#/components/schemas/SpanFieldContext'
+        name:
+          type: string
+      required:
+      - name
+      - field_context
+      - config
+      type: object
+    SpanPostableSpanMapperGroup:
+      properties:
+        category:
+          $ref: '#/components/schemas/SpanMapperGroupCategory'
+        condition:
+          $ref: '#/components/schemas/SpanMapperGroupCondition'
+        enabled:
+          type: boolean
+        name:
+          type: string
+      required:
+      - name
+      - category
+      - condition
+      type: object
+    SpanUpdatableSpanMapper:
+      properties:
+        config:
+          $ref: '#/components/schemas/SpanMapperConfig'
         enabled:
           nullable: true
           type: boolean
         field_context:
-          $ref: '#/components/schemas/SpantypesFieldContext'
+          $ref: '#/components/schemas/SpanFieldContext'
       type: object
-    SpantypesUpdatableSpanMapperGroup:
+    SpanUpdatableSpanMapperGroup:
       properties:
         condition:
-          $ref: '#/components/schemas/SpantypesSpanMapperGroupCondition'
+          $ref: '#/components/schemas/SpanMapperGroupCondition'
         enabled:
           nullable: true
           type: boolean
@@ -4943,7 +5104,7 @@ components:
           nullable: true
           type: string
       type: object
-    TelemetrytypesFieldContext:
+    TelemetryFieldContext:
       enum:
       - metric
       - log
@@ -4952,7 +5113,7 @@ components:
       - attribute
       - body
       type: string
-    TelemetrytypesFieldDataType:
+    TelemetryFieldDataType:
       enum:
       - string
       - bool
@@ -4960,59 +5121,24 @@ components:
       - int64
       - number
       type: string
-    TelemetrytypesGettableFieldKeys:
-      properties:
-        complete:
-          type: boolean
-        keys:
-          additionalProperties:
-            items:
-              $ref: '#/components/schemas/TelemetrytypesTelemetryFieldKey'
-            type: array
-          nullable: true
-          type: object
-      required:
-      - keys
-      - complete
-      type: object
-    TelemetrytypesGettableFieldValues:
-      properties:
-        complete:
-          type: boolean
-        values:
-          $ref: '#/components/schemas/TelemetrytypesTelemetryFieldValues'
-      required:
-      - values
-      - complete
-      type: object
-    TelemetrytypesSignal:
-      enum:
-      - traces
-      - logs
-      - metrics
-      type: string
-    TelemetrytypesSource:
-      enum:
-      - meter
-      type: string
-    TelemetrytypesTelemetryFieldKey:
+    TelemetryFieldKey:
       properties:
         description:
           type: string
         fieldContext:
-          $ref: '#/components/schemas/TelemetrytypesFieldContext'
+          $ref: '#/components/schemas/TelemetryFieldContext'
         fieldDataType:
-          $ref: '#/components/schemas/TelemetrytypesFieldDataType'
+          $ref: '#/components/schemas/TelemetryFieldDataType'
         name:
           type: string
         signal:
-          $ref: '#/components/schemas/TelemetrytypesSignal'
+          $ref: '#/components/schemas/TelemetrySignal'
         unit:
           type: string
       required:
       - name
       type: object
-    TelemetrytypesTelemetryFieldValues:
+    TelemetryFieldValues:
       properties:
         boolValues:
           items:
@@ -5032,10 +5158,45 @@ components:
             type: string
           type: array
       type: object
+    TelemetryGettableFieldKeys:
+      properties:
+        complete:
+          type: boolean
+        keys:
+          additionalProperties:
+            items:
+              $ref: '#/components/schemas/TelemetryFieldKey'
+            type: array
+          nullable: true
+          type: object
+      required:
+      - keys
+      - complete
+      type: object
+    TelemetryGettableFieldValues:
+      properties:
+        complete:
+          type: boolean
+        values:
+          $ref: '#/components/schemas/TelemetryFieldValues'
+      required:
+      - values
+      - complete
+      type: object
+    TelemetrySignal:
+      enum:
+      - traces
+      - logs
+      - metrics
+      type: string
+    TelemetrySource:
+      enum:
+      - meter
+      type: string
     TimeDuration:
       format: int64
       type: integer
-    TracedetailtypesEvent:
+    TraceDetailEvent:
       properties:
         attributeMap:
           additionalProperties: {}
@@ -5048,11 +5209,11 @@ components:
           minimum: 0
           type: integer
       type: object
-    TracedetailtypesGettableWaterfallTrace:
+    TraceDetailGettableWaterfallTrace:
       properties:
         aggregations:
           items:
-            $ref: '#/components/schemas/TracedetailtypesSpanAggregationResult'
+            $ref: '#/components/schemas/TraceDetailSpanAggregationResult'
           nullable: true
           type: array
         endTimestampMillis:
@@ -5074,7 +5235,7 @@ components:
           type: object
         spans:
           items:
-            $ref: '#/components/schemas/TracedetailtypesWaterfallSpan'
+            $ref: '#/components/schemas/TraceDetailWaterfallSpan'
           nullable: true
           type: array
         startTimestampMillis:
@@ -5092,11 +5253,11 @@ components:
           nullable: true
           type: array
       type: object
-    TracedetailtypesPostableWaterfall:
+    TraceDetailPostableWaterfall:
       properties:
         aggregations:
           items:
-            $ref: '#/components/schemas/TracedetailtypesSpanAggregation'
+            $ref: '#/components/schemas/TraceDetailSpanAggregation'
           nullable: true
           type: array
         limit:
@@ -5110,19 +5271,19 @@ components:
           nullable: true
           type: array
       type: object
-    TracedetailtypesSpanAggregation:
+    TraceDetailSpanAggregation:
       properties:
         aggregation:
-          $ref: '#/components/schemas/TracedetailtypesSpanAggregationType'
+          $ref: '#/components/schemas/TraceDetailSpanAggregationType'
         field:
-          $ref: '#/components/schemas/TelemetrytypesTelemetryFieldKey'
+          $ref: '#/components/schemas/TelemetryFieldKey'
       type: object
-    TracedetailtypesSpanAggregationResult:
+    TraceDetailSpanAggregationResult:
       properties:
         aggregation:
-          $ref: '#/components/schemas/TracedetailtypesSpanAggregationType'
+          $ref: '#/components/schemas/TraceDetailSpanAggregationType'
         field:
-          $ref: '#/components/schemas/TelemetrytypesTelemetryFieldKey'
+          $ref: '#/components/schemas/TelemetryFieldKey'
         value:
           additionalProperties:
             minimum: 0
@@ -5130,13 +5291,13 @@ components:
           nullable: true
           type: object
       type: object
-    TracedetailtypesSpanAggregationType:
+    TraceDetailSpanAggregationType:
       enum:
       - span_count
       - execution_time_percentage
       - duration
       type: string
-    TracedetailtypesWaterfallSpan:
+    TraceDetailWaterfallSpan:
       properties:
         attributes:
           additionalProperties: {}
@@ -5151,7 +5312,7 @@ components:
           type: integer
         events:
           items:
-            $ref: '#/components/schemas/TracedetailtypesEvent'
+            $ref: '#/components/schemas/TraceDetailEvent'
           nullable: true
           type: array
         external_http_method:
@@ -5205,175 +5366,14 @@ components:
         trace_state:
           type: string
       type: object
-    TypesAlertStatus:
-      properties:
-        inhibitedBy:
-          items:
-            type: string
-          nullable: true
-          type: array
-        silencedBy:
-          items:
-            type: string
-          nullable: true
-          type: array
-        state:
-          type: string
-      type: object
-    TypesChangePasswordRequest:
-      properties:
-        newPassword:
-          type: string
-        oldPassword:
-          type: string
-      type: object
-    TypesDeprecatedUser:
-      properties:
-        createdAt:
-          format: date-time
-          type: string
-        displayName:
-          type: string
-        email:
-          type: string
-        id:
-          type: string
-        isRoot:
-          type: boolean
-        orgId:
-          type: string
-        role:
-          type: string
-        status:
-          type: string
-        updatedAt:
-          format: date-time
-          type: string
-      required:
-      - id
-      type: object
-    TypesIdentifiable:
-      properties:
-        id:
-          type: string
-      required:
-      - id
-      type: object
-    TypesInvite:
-      properties:
-        createdAt:
-          format: date-time
-          type: string
-        email:
-          type: string
-        id:
-          type: string
-        inviteLink:
-          type: string
-        name:
-          type: string
-        orgId:
-          type: string
-        role:
-          type: string
-        token:
-          type: string
-        updatedAt:
-          format: date-time
-          type: string
-      required:
-      - id
-      type: object
-    TypesOrganization:
-      properties:
-        alias:
-          type: string
-        createdAt:
-          format: date-time
-          type: string
-        displayName:
-          type: string
-        id:
-          type: string
-        key:
-          minimum: 0
-          type: integer
-        name:
-          type: string
-        updatedAt:
-          format: date-time
-          type: string
-      required:
-      - id
-      type: object
-    TypesPostableBulkInviteRequest:
-      properties:
-        invites:
-          items:
-            $ref: '#/components/schemas/TypesPostableInvite'
-          type: array
-      required:
-      - invites
-      type: object
-    TypesPostableForgotPassword:
-      properties:
-        email:
-          type: string
-        frontendBaseURL:
-          type: string
-        orgId:
-          type: string
-      required:
-      - orgId
-      - email
-      type: object
-    TypesPostableInvite:
-      properties:
-        email:
-          type: string
-        frontendBaseUrl:
-          type: string
-        name:
-          type: string
-        role:
-          type: string
-      type: object
-    TypesPostableResetPassword:
-      properties:
-        password:
-          type: string
-        token:
-          type: string
-      type: object
-    TypesPostableRole:
-      properties:
-        name:
-          type: string
-      required:
-      - name
-      type: object
-    TypesResetPasswordToken:
-      properties:
-        expiresAt:
-          format: date-time
-          type: string
-        id:
-          type: string
-        passwordId:
-          type: string
-        token:
-          type: string
-      required:
-      - id
-      type: object
-    TypesUpdatableUser:
+    UpdatableUser:
       properties:
         displayName:
           type: string
       required:
       - displayName
       type: object
-    TypesUser:
+    User:
       properties:
         createdAt:
           format: date-time
@@ -5396,11 +5396,11 @@ components:
       required:
       - id
       type: object
-    ZeustypesGettableHost:
+    ZeusGettableHost:
       properties:
         hosts:
           items:
-            $ref: '#/components/schemas/ZeustypesHost'
+            $ref: '#/components/schemas/ZeusHost'
           nullable: true
           type: array
         name:
@@ -5415,7 +5415,7 @@ components:
       - tier
       - hosts
       type: object
-    ZeustypesHost:
+    ZeusHost:
       properties:
         is_default:
           type: boolean
@@ -5428,14 +5428,14 @@ components:
       - is_default
       - url
       type: object
-    ZeustypesPostableHost:
+    ZeusPostableHost:
       properties:
         name:
           type: string
       required:
       - name
       type: object
-    ZeustypesPostableProfile:
+    ZeusPostableProfile:
       properties:
         existing_observability_tool:
           type: string
@@ -5507,7 +5507,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/AlertmanagertypesDeprecatedGettableAlert'
+                      $ref: '#/components/schemas/AlertManagerDeprecatedGettableAlert'
                     type: array
                   status:
                     type: string
@@ -5552,7 +5552,7 @@ paths:
           application/json:
             schema:
               items:
-                $ref: '#/components/schemas/AuthtypesTransaction'
+                $ref: '#/components/schemas/AuthTransaction'
               type: array
       responses:
         "200":
@@ -5562,7 +5562,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/AuthtypesGettableTransaction'
+                      $ref: '#/components/schemas/AuthGettableTransaction'
                     type: array
                   status:
                     type: string
@@ -5592,7 +5592,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AuthtypesGettableResources'
+                    $ref: '#/components/schemas/AuthGettableResources'
                   status:
                     type: string
                 required:
@@ -5622,7 +5622,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/AlertmanagertypesChannel'
+                      $ref: '#/components/schemas/AlertManagerChannel'
                     type: array
                   status:
                     type: string
@@ -5673,7 +5673,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AlertmanagertypesChannel'
+                    $ref: '#/components/schemas/AlertManagerChannel'
                   status:
                     type: string
                 required:
@@ -5776,7 +5776,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AlertmanagertypesChannel'
+                    $ref: '#/components/schemas/AlertManagerChannel'
                   status:
                     type: string
                 required:
@@ -5933,7 +5933,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CloudintegrationtypesPostableAgentCheckIn'
+              $ref: '#/components/schemas/CloudIntegrationPostableAgentCheckIn'
       responses:
         "200":
           content:
@@ -5941,7 +5941,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/CloudintegrationtypesGettableAgentCheckIn'
+                    $ref: '#/components/schemas/CloudIntegrationGettableAgentCheckIn'
                   status:
                     type: string
                 required:
@@ -5993,7 +5993,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/CloudintegrationtypesGettableAccounts'
+                    $ref: '#/components/schemas/CloudIntegrationGettableAccounts'
                   status:
                     type: string
                 required:
@@ -6042,7 +6042,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CloudintegrationtypesPostableAccount'
+              $ref: '#/components/schemas/CloudIntegrationPostableAccount'
       responses:
         "201":
           content:
@@ -6050,7 +6050,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/CloudintegrationtypesGettableAccountWithConnectionArtifact'
+                    $ref: '#/components/schemas/CloudIntegrationGettableAccountWithConnectionArtifact'
                   status:
                     type: string
                 required:
@@ -6151,7 +6151,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/CloudintegrationtypesAccount'
+                    $ref: '#/components/schemas/CloudIntegrationAccount'
                   status:
                     type: string
                 required:
@@ -6216,7 +6216,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CloudintegrationtypesUpdatableAccount'
+              $ref: '#/components/schemas/CloudIntegrationUpdatableAccount'
       responses:
         "204":
           description: No Content
@@ -6271,7 +6271,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CloudintegrationtypesUpdatableService'
+              $ref: '#/components/schemas/CloudIntegrationUpdatableService'
       responses:
         "204":
           description: No Content
@@ -6316,7 +6316,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CloudintegrationtypesPostableAgentCheckIn'
+              $ref: '#/components/schemas/CloudIntegrationPostableAgentCheckIn'
       responses:
         "200":
           content:
@@ -6324,7 +6324,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/CloudintegrationtypesGettableAgentCheckIn'
+                    $ref: '#/components/schemas/CloudIntegrationGettableAgentCheckIn'
                   status:
                     type: string
                 required:
@@ -6377,7 +6377,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/CloudintegrationtypesCredentials'
+                    $ref: '#/components/schemas/CloudIntegrationCredentials'
                   status:
                     type: string
                 required:
@@ -6435,7 +6435,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/CloudintegrationtypesGettableServicesMetadata'
+                    $ref: '#/components/schemas/CloudIntegrationGettableServicesMetadata'
                   status:
                     type: string
                 required:
@@ -6497,7 +6497,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/CloudintegrationtypesService'
+                    $ref: '#/components/schemas/CloudIntegrationService'
                   status:
                     type: string
                 required:
@@ -6543,7 +6543,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AuthtypesGettableToken'
+                    $ref: '#/components/schemas/AuthGettableToken'
                   status:
                     type: string
                 required:
@@ -6584,7 +6584,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AuthtypesGettableToken'
+                    $ref: '#/components/schemas/AuthGettableToken'
                   status:
                     type: string
                 required:
@@ -6650,7 +6650,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AuthtypesGettableToken'
+                    $ref: '#/components/schemas/AuthGettableToken'
                   status:
                     type: string
                 required:
@@ -6747,7 +6747,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/DashboardtypesGettablePublicDasbhboard'
+                    $ref: '#/components/schemas/DashboardGettablePublicDasbhboard'
                   status:
                     type: string
                 required:
@@ -6796,7 +6796,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DashboardtypesPostablePublicDashboard'
+              $ref: '#/components/schemas/DashboardPostablePublicDashboard'
       responses:
         "201":
           content:
@@ -6804,7 +6804,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TypesIdentifiable'
+                    $ref: '#/components/schemas/Identifiable'
                   status:
                     type: string
                 required:
@@ -6852,7 +6852,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DashboardtypesUpdatablePublicDashboard'
+              $ref: '#/components/schemas/DashboardUpdatablePublicDashboard'
       responses:
         "204":
           content:
@@ -6899,7 +6899,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/AuthtypesGettableAuthDomain'
+                      $ref: '#/components/schemas/AuthGettableAuthDomain'
                     type: array
                   status:
                     type: string
@@ -6942,7 +6942,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthtypesPostableAuthDomain'
+              $ref: '#/components/schemas/AuthPostableAuthDomain'
       responses:
         "200":
           content:
@@ -6950,7 +6950,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AuthtypesGettableAuthDomain'
+                    $ref: '#/components/schemas/AuthGettableAuthDomain'
                   status:
                     type: string
                 required:
@@ -7056,7 +7056,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthtypesUpdateableAuthDomain'
+              $ref: '#/components/schemas/AuthUpdateableAuthDomain'
       responses:
         "204":
           description: No Content
@@ -7122,7 +7122,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/RuletypesPlannedMaintenance'
+                      $ref: '#/components/schemas/RulePlannedMaintenance'
                     type: array
                   status:
                     type: string
@@ -7165,7 +7165,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RuletypesPostablePlannedMaintenance'
+              $ref: '#/components/schemas/RulePostablePlannedMaintenance'
       responses:
         "201":
           content:
@@ -7173,7 +7173,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/RuletypesPlannedMaintenance'
+                    $ref: '#/components/schemas/RulePlannedMaintenance'
                   status:
                     type: string
                 required:
@@ -7276,7 +7276,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/RuletypesPlannedMaintenance'
+                    $ref: '#/components/schemas/RulePlannedMaintenance'
                   status:
                     type: string
                 required:
@@ -7330,7 +7330,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RuletypesPostablePlannedMaintenance'
+              $ref: '#/components/schemas/RulePostablePlannedMaintenance'
       responses:
         "204":
           description: No Content
@@ -7393,7 +7393,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Querybuildertypesv5QueryRangeRequest'
+              $ref: '#/components/schemas/QueryBuilderV5QueryRangeRequest'
       responses:
         "200":
           content:
@@ -7443,11 +7443,11 @@ paths:
       - in: query
         name: signal
         schema:
-          $ref: '#/components/schemas/TelemetrytypesSignal'
+          $ref: '#/components/schemas/TelemetrySignal'
       - in: query
         name: source
         schema:
-          $ref: '#/components/schemas/TelemetrytypesSource'
+          $ref: '#/components/schemas/TelemetrySource'
       - in: query
         name: limit
         schema:
@@ -7465,11 +7465,11 @@ paths:
       - in: query
         name: fieldContext
         schema:
-          $ref: '#/components/schemas/TelemetrytypesFieldContext'
+          $ref: '#/components/schemas/TelemetryFieldContext'
       - in: query
         name: fieldDataType
         schema:
-          $ref: '#/components/schemas/TelemetrytypesFieldDataType'
+          $ref: '#/components/schemas/TelemetryFieldDataType'
       - in: query
         name: metricName
         schema:
@@ -7489,7 +7489,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TelemetrytypesGettableFieldKeys'
+                    $ref: '#/components/schemas/TelemetryGettableFieldKeys'
                   status:
                     type: string
                 required:
@@ -7532,11 +7532,11 @@ paths:
       - in: query
         name: signal
         schema:
-          $ref: '#/components/schemas/TelemetrytypesSignal'
+          $ref: '#/components/schemas/TelemetrySignal'
       - in: query
         name: source
         schema:
-          $ref: '#/components/schemas/TelemetrytypesSource'
+          $ref: '#/components/schemas/TelemetrySource'
       - in: query
         name: limit
         schema:
@@ -7554,11 +7554,11 @@ paths:
       - in: query
         name: fieldContext
         schema:
-          $ref: '#/components/schemas/TelemetrytypesFieldContext'
+          $ref: '#/components/schemas/TelemetryFieldContext'
       - in: query
         name: fieldDataType
         schema:
-          $ref: '#/components/schemas/TelemetrytypesFieldDataType'
+          $ref: '#/components/schemas/TelemetryFieldDataType'
       - in: query
         name: metricName
         schema:
@@ -7586,7 +7586,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TelemetrytypesGettableFieldValues'
+                    $ref: '#/components/schemas/TelemetryGettableFieldValues'
                   status:
                     type: string
                 required:
@@ -7638,7 +7638,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TypesResetPasswordToken'
+                    $ref: '#/components/schemas/ResetPasswordToken'
                   status:
                     type: string
                 required:
@@ -7696,7 +7696,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/GlobaltypesConfig'
+                    $ref: '#/components/schemas/GlobalConfig'
                   status:
                     type: string
                 required:
@@ -7722,7 +7722,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TypesPostableInvite'
+              $ref: '#/components/schemas/PostableInvite'
       responses:
         "201":
           content:
@@ -7730,7 +7730,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TypesInvite'
+                    $ref: '#/components/schemas/Invite'
                   status:
                     type: string
                 required:
@@ -7785,7 +7785,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TypesPostableBulkInviteRequest'
+              $ref: '#/components/schemas/PostableBulkInviteRequest'
       responses:
         "201":
           description: Created
@@ -7848,7 +7848,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/LlmpricingruletypesGettablePricingRules'
+                    $ref: '#/components/schemas/LLMPricingRuleGettablePricingRules'
                   status:
                     type: string
                 required:
@@ -7899,7 +7899,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LlmpricingruletypesUpdatableLLMPricingRules'
+              $ref: '#/components/schemas/LLMPricingRuleUpdatableLLMPricingRules'
       responses:
         "204":
           description: No Content
@@ -7999,7 +7999,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/LlmpricingruletypesLLMPricingRule'
+                    $ref: '#/components/schemas/LLMPricingRule'
                   status:
                     type: string
                 required:
@@ -8052,7 +8052,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/PromotetypesPromotePath'
+                      $ref: '#/components/schemas/PromotePath'
                     nullable: true
                     type: array
                   status:
@@ -8103,7 +8103,7 @@ paths:
           application/json:
             schema:
               items:
-                $ref: '#/components/schemas/PromotetypesPromotePath'
+                $ref: '#/components/schemas/PromotePath'
               nullable: true
               type: array
       responses:
@@ -8154,7 +8154,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/PreferencetypesPreference'
+                      $ref: '#/components/schemas/Preference'
                     type: array
                   status:
                     type: string
@@ -8207,7 +8207,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/PreferencetypesPreference'
+                    $ref: '#/components/schemas/Preference'
                   status:
                     type: string
                 required:
@@ -8267,7 +8267,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PreferencetypesUpdatablePreference'
+              $ref: '#/components/schemas/PreferenceUpdatablePreference'
       responses:
         "204":
           description: No Content
@@ -8327,7 +8327,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/DashboardtypesGettablePublicDashboardData'
+                    $ref: '#/components/schemas/DashboardGettablePublicDashboardData'
                   status:
                     type: string
                 required:
@@ -8383,7 +8383,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/Querybuildertypesv5QueryRangeResponse'
+                    $ref: '#/components/schemas/QueryBuilderV5QueryRangeResponse'
                   status:
                     type: string
                 required:
@@ -8424,7 +8424,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TypesPostableResetPassword'
+              $ref: '#/components/schemas/PostableResetPassword'
       responses:
         "204":
           description: No Content
@@ -8462,7 +8462,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/AuthtypesRole'
+                      $ref: '#/components/schemas/AuthRole'
                     type: array
                   status:
                     type: string
@@ -8505,7 +8505,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthtypesPostableRole'
+              $ref: '#/components/schemas/AuthPostableRole'
       responses:
         "201":
           content:
@@ -8513,7 +8513,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TypesIdentifiable'
+                    $ref: '#/components/schemas/Identifiable'
                   status:
                     type: string
                 required:
@@ -8650,7 +8650,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AuthtypesRole'
+                    $ref: '#/components/schemas/AuthRole'
                   status:
                     type: string
                 required:
@@ -8698,7 +8698,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthtypesPatchableRole'
+              $ref: '#/components/schemas/AuthPatchableRole'
       responses:
         "204":
           content:
@@ -8775,7 +8775,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/AuthtypesGettableObjects'
+                      $ref: '#/components/schemas/AuthGettableObjects'
                     type: array
                   status:
                     type: string
@@ -8848,7 +8848,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthtypesPatchableObjects'
+              $ref: '#/components/schemas/AuthPatchableObjects'
       responses:
         "204":
           content:
@@ -8919,7 +8919,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/AlertmanagertypesGettableRoutePolicy'
+                      $ref: '#/components/schemas/AlertManagerGettableRoutePolicy'
                     type: array
                   status:
                     type: string
@@ -8962,7 +8962,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AlertmanagertypesPostableRoutePolicy'
+              $ref: '#/components/schemas/AlertManagerPostableRoutePolicy'
       responses:
         "201":
           content:
@@ -8970,7 +8970,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AlertmanagertypesGettableRoutePolicy'
+                    $ref: '#/components/schemas/AlertManagerGettableRoutePolicy'
                   status:
                     type: string
                 required:
@@ -9073,7 +9073,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AlertmanagertypesGettableRoutePolicy'
+                    $ref: '#/components/schemas/AlertManagerGettableRoutePolicy'
                   status:
                     type: string
                 required:
@@ -9127,7 +9127,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AlertmanagertypesPostableRoutePolicy'
+              $ref: '#/components/schemas/AlertManagerPostableRoutePolicy'
       responses:
         "200":
           content:
@@ -9135,7 +9135,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AlertmanagertypesGettableRoutePolicy'
+                    $ref: '#/components/schemas/AlertManagerGettableRoutePolicy'
                   status:
                     type: string
                 required:
@@ -9194,7 +9194,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/ServiceaccounttypesServiceAccount'
+                      $ref: '#/components/schemas/ServiceAccount'
                     type: array
                   status:
                     type: string
@@ -9237,7 +9237,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServiceaccounttypesPostableServiceAccount'
+              $ref: '#/components/schemas/ServiceAccountPostableServiceAccount'
       responses:
         "201":
           content:
@@ -9245,7 +9245,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TypesIdentifiable'
+                    $ref: '#/components/schemas/Identifiable'
                   status:
                     type: string
                 required:
@@ -9358,7 +9358,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/ServiceaccounttypesServiceAccountWithRoles'
+                    $ref: '#/components/schemas/ServiceAccountWithRoles'
                   status:
                     type: string
                 required:
@@ -9412,7 +9412,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServiceaccounttypesPostableServiceAccount'
+              $ref: '#/components/schemas/ServiceAccountPostableServiceAccount'
       responses:
         "204":
           content:
@@ -9477,7 +9477,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/ServiceaccounttypesGettableFactorAPIKey'
+                      $ref: '#/components/schemas/ServiceAccountGettableFactorAPIKey'
                     type: array
                   status:
                     type: string
@@ -9526,7 +9526,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServiceaccounttypesPostableFactorAPIKey'
+              $ref: '#/components/schemas/ServiceAccountPostableFactorAPIKey'
       responses:
         "201":
           content:
@@ -9534,7 +9534,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/ServiceaccounttypesGettableFactorAPIKeyWithKey'
+                    $ref: '#/components/schemas/ServiceAccountGettableFactorAPIKeyWithKey'
                   status:
                     type: string
                 required:
@@ -9654,7 +9654,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServiceaccounttypesUpdatableFactorAPIKey'
+              $ref: '#/components/schemas/ServiceAccountUpdatableFactorAPIKey'
       responses:
         "204":
           content:
@@ -9719,7 +9719,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/AuthtypesRole'
+                      $ref: '#/components/schemas/AuthRole'
                     nullable: true
                     type: array
                   status:
@@ -9775,7 +9775,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServiceaccounttypesPostableServiceAccountRole'
+              $ref: '#/components/schemas/ServiceAccountPostableServiceAccountRole'
       responses:
         "201":
           content:
@@ -9783,7 +9783,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TypesIdentifiable'
+                    $ref: '#/components/schemas/Identifiable'
                   status:
                     type: string
                 required:
@@ -9884,7 +9884,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/ServiceaccounttypesServiceAccountWithRoles'
+                    $ref: '#/components/schemas/ServiceAccountWithRoles'
                   status:
                     type: string
                 required:
@@ -9915,7 +9915,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServiceaccounttypesPostableServiceAccount'
+              $ref: '#/components/schemas/ServiceAccountPostableServiceAccount'
       responses:
         "204":
           content:
@@ -9949,7 +9949,7 @@ paths:
         in: query
         name: category
         schema:
-          $ref: '#/components/schemas/SpantypesSpanMapperGroupCategory'
+          $ref: '#/components/schemas/SpanMapperGroupCategory'
         style: deepObject
       - in: query
         name: enabled
@@ -9963,7 +9963,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/SpantypesGettableSpanMapperGroups'
+                    $ref: '#/components/schemas/SpanGettableSpanMapperGroups'
                   status:
                     type: string
                 required:
@@ -10011,7 +10011,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SpantypesPostableSpanMapperGroup'
+              $ref: '#/components/schemas/SpanPostableSpanMapperGroup'
       responses:
         "201":
           content:
@@ -10019,7 +10019,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/SpantypesSpanMapperGroup'
+                    $ref: '#/components/schemas/SpanMapperGroup'
                   status:
                     type: string
                 required:
@@ -10126,7 +10126,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SpantypesUpdatableSpanMapperGroup'
+              $ref: '#/components/schemas/SpanUpdatableSpanMapperGroup'
       responses:
         "204":
           description: No Content
@@ -10186,7 +10186,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/SpantypesGettableSpanMapperGroups'
+                    $ref: '#/components/schemas/SpanGettableSpanMapperGroups'
                   status:
                     type: string
                 required:
@@ -10246,7 +10246,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SpantypesPostableSpanMapper'
+              $ref: '#/components/schemas/SpanPostableSpanMapper'
       responses:
         "201":
           content:
@@ -10254,7 +10254,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/SpantypesSpanMapper'
+                    $ref: '#/components/schemas/SpanMapper'
                   status:
                     type: string
                 required:
@@ -10377,7 +10377,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SpantypesUpdatableSpanMapper'
+              $ref: '#/components/schemas/SpanUpdatableSpanMapper'
       responses:
         "204":
           description: No Content
@@ -10477,7 +10477,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/TypesDeprecatedUser'
+                      $ref: '#/components/schemas/DeprecatedUser'
                     type: array
                   status:
                     type: string
@@ -10575,7 +10575,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TypesDeprecatedUser'
+                    $ref: '#/components/schemas/DeprecatedUser'
                   status:
                     type: string
                 required:
@@ -10629,7 +10629,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TypesDeprecatedUser'
+              $ref: '#/components/schemas/DeprecatedUser'
       responses:
         "200":
           content:
@@ -10637,7 +10637,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TypesDeprecatedUser'
+                    $ref: '#/components/schemas/DeprecatedUser'
                   status:
                     type: string
                 required:
@@ -10695,7 +10695,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TypesDeprecatedUser'
+                    $ref: '#/components/schemas/DeprecatedUser'
                   status:
                     type: string
                 required:
@@ -10739,7 +10739,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/PreferencetypesPreference'
+                      $ref: '#/components/schemas/Preference'
                     type: array
                   status:
                     type: string
@@ -10792,7 +10792,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/PreferencetypesPreference'
+                    $ref: '#/components/schemas/Preference'
                   status:
                     type: string
                 required:
@@ -10846,7 +10846,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PreferencetypesUpdatablePreference'
+              $ref: '#/components/schemas/PreferenceUpdatablePreference'
       responses:
         "204":
           description: No Content
@@ -10898,7 +10898,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TypesPostableForgotPassword'
+              $ref: '#/components/schemas/PostableForgotPassword'
       responses:
         "204":
           description: No Content
@@ -10936,7 +10936,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/FeaturetypesGettableFeature'
+                      $ref: '#/components/schemas/FeatureGettableFeature'
                     type: array
                   status:
                     type: string
@@ -10992,7 +10992,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/GatewaytypesGettableIngestionKeys'
+                    $ref: '#/components/schemas/GatewayGettableIngestionKeys'
                   status:
                     type: string
                 required:
@@ -11034,7 +11034,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GatewaytypesPostableIngestionKey'
+              $ref: '#/components/schemas/GatewayPostableIngestionKey'
       responses:
         "201":
           content:
@@ -11042,7 +11042,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/GatewaytypesGettableCreatedIngestionKey'
+                    $ref: '#/components/schemas/GatewayGettableCreatedIngestionKey'
                   status:
                     type: string
                 required:
@@ -11130,7 +11130,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GatewaytypesPostableIngestionKey'
+              $ref: '#/components/schemas/GatewayPostableIngestionKey'
       responses:
         "204":
           description: No Content
@@ -11175,7 +11175,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GatewaytypesPostableIngestionKeyLimit'
+              $ref: '#/components/schemas/GatewayPostableIngestionKeyLimit'
       responses:
         "201":
           content:
@@ -11183,7 +11183,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/GatewaytypesGettableCreatedIngestionKeyLimit'
+                    $ref: '#/components/schemas/GatewayGettableCreatedIngestionKeyLimit'
                   status:
                     type: string
                 required:
@@ -11271,7 +11271,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GatewaytypesUpdatableIngestionKeyLimit'
+              $ref: '#/components/schemas/GatewayUpdatableIngestionKeyLimit'
       responses:
         "204":
           description: No Content
@@ -11327,7 +11327,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/GatewaytypesGettableIngestionKeys'
+                    $ref: '#/components/schemas/GatewayGettableIngestionKeys'
                   status:
                     type: string
                 required:
@@ -11416,7 +11416,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InframonitoringtypesPostableHosts'
+              $ref: '#/components/schemas/InfraMonitoringPostableHosts'
       responses:
         "200":
           content:
@@ -11424,7 +11424,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/InframonitoringtypesHosts'
+                    $ref: '#/components/schemas/InfraMonitoringHosts'
                   status:
                     type: string
                 required:
@@ -11489,7 +11489,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InframonitoringtypesPostablePods'
+              $ref: '#/components/schemas/InfraMonitoringPostablePods'
       responses:
         "200":
           content:
@@ -11497,7 +11497,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/InframonitoringtypesPods'
+                    $ref: '#/components/schemas/InfraMonitoringPods'
                   status:
                     type: string
                 required:
@@ -11602,7 +11602,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/MetricsexplorertypesListMetricsResponse'
+                    $ref: '#/components/schemas/MetricsExplorerListMetricsResponse'
                   status:
                     type: string
                 required:
@@ -11660,7 +11660,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/MetricsexplorertypesMetricAlertsResponse'
+                    $ref: '#/components/schemas/MetricsExplorerMetricAlertsResponse'
                   status:
                     type: string
                 required:
@@ -11735,7 +11735,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/MetricsexplorertypesMetricAttributesResponse'
+                    $ref: '#/components/schemas/MetricsExplorerMetricAttributesResponse'
                   status:
                     type: string
                 required:
@@ -11799,7 +11799,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/MetricsexplorertypesMetricDashboardsResponse'
+                    $ref: '#/components/schemas/MetricsExplorerMetricDashboardsResponse'
                   status:
                     type: string
                 required:
@@ -11864,7 +11864,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/MetricsexplorertypesMetricHighlightsResponse'
+                    $ref: '#/components/schemas/MetricsExplorerMetricHighlightsResponse'
                   status:
                     type: string
                 required:
@@ -11929,7 +11929,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/MetricsexplorertypesMetricMetadata'
+                    $ref: '#/components/schemas/MetricsExplorerMetricMetadata'
                   status:
                     type: string
                 required:
@@ -11990,7 +11990,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MetricsexplorertypesUpdateMetricMetadataRequest'
+              $ref: '#/components/schemas/MetricsExplorerUpdateMetricMetadataRequest'
       responses:
         "200":
           content:
@@ -12040,7 +12040,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MetricsexplorertypesInspectMetricsRequest'
+              $ref: '#/components/schemas/MetricsExplorerInspectMetricsRequest'
       responses:
         "200":
           content:
@@ -12048,7 +12048,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/MetricsexplorertypesInspectMetricsResponse'
+                    $ref: '#/components/schemas/MetricsExplorerInspectMetricsResponse'
                   status:
                     type: string
                 required:
@@ -12101,7 +12101,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/MetricsexplorertypesMetricsOnboardingResponse'
+                    $ref: '#/components/schemas/MetricsExplorerMetricsOnboardingResponse'
                   status:
                     type: string
                 required:
@@ -12145,7 +12145,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MetricsexplorertypesStatsRequest'
+              $ref: '#/components/schemas/MetricsExplorerStatsRequest'
       responses:
         "200":
           content:
@@ -12153,7 +12153,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/MetricsexplorertypesStatsResponse'
+                    $ref: '#/components/schemas/MetricsExplorerStatsResponse'
                   status:
                     type: string
                 required:
@@ -12203,7 +12203,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MetricsexplorertypesTreemapRequest'
+              $ref: '#/components/schemas/MetricsExplorerTreemapRequest'
       responses:
         "200":
           content:
@@ -12211,7 +12211,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/MetricsexplorertypesTreemapResponse'
+                    $ref: '#/components/schemas/MetricsExplorerTreemapResponse'
                   status:
                     type: string
                 required:
@@ -12263,7 +12263,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TypesOrganization'
+                    $ref: '#/components/schemas/Organization'
                   status:
                     type: string
                 required:
@@ -12305,7 +12305,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TypesOrganization'
+              $ref: '#/components/schemas/Organization'
       responses:
         "204":
           description: No Content
@@ -12401,7 +12401,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/TypesUser'
+                      $ref: '#/components/schemas/User'
                     type: array
                   status:
                     type: string
@@ -12456,7 +12456,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/RuletypesRule'
+                      $ref: '#/components/schemas/Rule'
                     type: array
                   status:
                     type: string
@@ -13283,7 +13283,7 @@ paths:
                   schemaVersion: v2alpha1
                   version: v5
             schema:
-              $ref: '#/components/schemas/RuletypesPostableRule'
+              $ref: '#/components/schemas/RulePostableRule'
       responses:
         "201":
           content:
@@ -13291,7 +13291,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/RuletypesRule'
+                    $ref: '#/components/schemas/Rule'
                   status:
                     type: string
                 required:
@@ -13394,7 +13394,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/RuletypesRule'
+                    $ref: '#/components/schemas/Rule'
                   status:
                     type: string
                 required:
@@ -14232,7 +14232,7 @@ paths:
                   schemaVersion: v2alpha1
                   version: v5
             schema:
-              $ref: '#/components/schemas/RuletypesPostableRule'
+              $ref: '#/components/schemas/RulePostableRule'
       responses:
         "200":
           content:
@@ -14240,7 +14240,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/RuletypesRule'
+                    $ref: '#/components/schemas/Rule'
                   status:
                     type: string
                 required:
@@ -15084,7 +15084,7 @@ paths:
                   schemaVersion: v2alpha1
                   version: v5
             schema:
-              $ref: '#/components/schemas/RuletypesPostableRule'
+              $ref: '#/components/schemas/RulePostableRule'
       responses:
         "204":
           description: No Content
@@ -15136,11 +15136,11 @@ paths:
       - in: query
         name: signal
         schema:
-          $ref: '#/components/schemas/TelemetrytypesSignal'
+          $ref: '#/components/schemas/TelemetrySignal'
       - in: query
         name: source
         schema:
-          $ref: '#/components/schemas/TelemetrytypesSource'
+          $ref: '#/components/schemas/TelemetrySource'
       - in: query
         name: limit
         schema:
@@ -15158,11 +15158,11 @@ paths:
       - in: query
         name: fieldContext
         schema:
-          $ref: '#/components/schemas/TelemetrytypesFieldContext'
+          $ref: '#/components/schemas/TelemetryFieldContext'
       - in: query
         name: fieldDataType
         schema:
-          $ref: '#/components/schemas/TelemetrytypesFieldDataType'
+          $ref: '#/components/schemas/TelemetryFieldDataType'
       - in: query
         name: metricName
         schema:
@@ -15187,7 +15187,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TelemetrytypesGettableFieldKeys'
+                    $ref: '#/components/schemas/TelemetryGettableFieldKeys'
                   status:
                     type: string
                 required:
@@ -15237,11 +15237,11 @@ paths:
       - in: query
         name: signal
         schema:
-          $ref: '#/components/schemas/TelemetrytypesSignal'
+          $ref: '#/components/schemas/TelemetrySignal'
       - in: query
         name: source
         schema:
-          $ref: '#/components/schemas/TelemetrytypesSource'
+          $ref: '#/components/schemas/TelemetrySource'
       - in: query
         name: limit
         schema:
@@ -15259,11 +15259,11 @@ paths:
       - in: query
         name: fieldContext
         schema:
-          $ref: '#/components/schemas/TelemetrytypesFieldContext'
+          $ref: '#/components/schemas/TelemetryFieldContext'
       - in: query
         name: fieldDataType
         schema:
-          $ref: '#/components/schemas/TelemetrytypesFieldDataType'
+          $ref: '#/components/schemas/TelemetryFieldDataType'
       - in: query
         name: metricName
         schema:
@@ -15296,7 +15296,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TelemetrytypesGettableFieldValues'
+                    $ref: '#/components/schemas/TelemetryGettableFieldValues'
                   status:
                     type: string
                 required:
@@ -15368,7 +15368,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/RulestatehistorytypesGettableRuleStateWindow'
+                      $ref: '#/components/schemas/RuleStateHistoryGettableRuleStateWindow'
                     nullable: true
                     type: array
                   status:
@@ -15441,7 +15441,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/RulestatehistorytypesGettableRuleStateHistoryStats'
+                    $ref: '#/components/schemas/RuleStateHistoryGettableRuleStateHistoryStats'
                   status:
                     type: string
                 required:
@@ -15502,7 +15502,7 @@ paths:
       - in: query
         name: state
         schema:
-          $ref: '#/components/schemas/RuletypesAlertState'
+          $ref: '#/components/schemas/RuleAlertState'
       - in: query
         name: filterExpression
         schema:
@@ -15515,7 +15515,7 @@ paths:
       - in: query
         name: order
         schema:
-          $ref: '#/components/schemas/Querybuildertypesv5OrderDirection'
+          $ref: '#/components/schemas/QueryBuilderV5OrderDirection'
       - in: query
         name: cursor
         schema:
@@ -15532,7 +15532,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/RulestatehistorytypesGettableRuleStateTimeline'
+                    $ref: '#/components/schemas/RuleStateHistoryGettableRuleStateTimeline'
                   status:
                     type: string
                 required:
@@ -15604,7 +15604,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/RulestatehistorytypesGettableRuleStateHistoryContributor'
+                      $ref: '#/components/schemas/RuleStateHistoryGettableRuleStateHistoryContributor'
                     nullable: true
                     type: array
                   status:
@@ -16439,7 +16439,7 @@ paths:
                   schemaVersion: v2alpha1
                   version: v5
             schema:
-              $ref: '#/components/schemas/RuletypesPostableRule'
+              $ref: '#/components/schemas/RulePostableRule'
       responses:
         "200":
           content:
@@ -16447,7 +16447,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/RuletypesGettableTestRule'
+                    $ref: '#/components/schemas/RuleGettableTestRule'
                   status:
                     type: string
                 required:
@@ -16536,7 +16536,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AuthtypesSessionContext'
+                    $ref: '#/components/schemas/AuthSessionContext'
                   status:
                     type: string
                 required:
@@ -16568,7 +16568,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthtypesPostableEmailPasswordSession'
+              $ref: '#/components/schemas/AuthPostableEmailPasswordSession'
       responses:
         "200":
           content:
@@ -16576,7 +16576,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AuthtypesGettableToken'
+                    $ref: '#/components/schemas/AuthGettableToken'
                   status:
                     type: string
                 required:
@@ -16614,7 +16614,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthtypesPostableRotateToken'
+              $ref: '#/components/schemas/AuthPostableRotateToken'
       responses:
         "200":
           content:
@@ -16622,7 +16622,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AuthtypesGettableToken'
+                    $ref: '#/components/schemas/AuthGettableToken'
                   status:
                     type: string
                 required:
@@ -16658,7 +16658,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/TypesUser'
+                      $ref: '#/components/schemas/User'
                     type: array
                   status:
                     type: string
@@ -16711,7 +16711,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AuthtypesUserWithRoles'
+                    $ref: '#/components/schemas/AuthUserWithRoles'
                   status:
                     type: string
                 required:
@@ -16765,7 +16765,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TypesUpdatableUser'
+              $ref: '#/components/schemas/UpdatableUser'
       responses:
         "204":
           description: No Content
@@ -16825,7 +16825,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TypesResetPasswordToken'
+                    $ref: '#/components/schemas/ResetPasswordToken'
                   status:
                     type: string
                 required:
@@ -16884,7 +16884,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TypesResetPasswordToken'
+                    $ref: '#/components/schemas/ResetPasswordToken'
                   status:
                     type: string
                 required:
@@ -16949,7 +16949,7 @@ paths:
                 properties:
                   data:
                     items:
-                      $ref: '#/components/schemas/AuthtypesRole'
+                      $ref: '#/components/schemas/AuthRole'
                     type: array
                   status:
                     type: string
@@ -17004,7 +17004,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TypesPostableRole'
+              $ref: '#/components/schemas/PostableRole'
       responses:
         "200":
           description: OK
@@ -17104,7 +17104,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/AuthtypesUserWithRoles'
+                    $ref: '#/components/schemas/AuthUserWithRoles'
                   status:
                     type: string
                 required:
@@ -17143,7 +17143,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TypesUpdatableUser'
+              $ref: '#/components/schemas/UpdatableUser'
       responses:
         "204":
           description: No Content
@@ -17179,7 +17179,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TypesChangePasswordRequest'
+              $ref: '#/components/schemas/ChangePasswordRequest'
       responses:
         "204":
           description: No Content
@@ -17233,7 +17233,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/ZeustypesGettableHost'
+                    $ref: '#/components/schemas/ZeusGettableHost'
                   status:
                     type: string
                 required:
@@ -17287,7 +17287,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ZeustypesPostableHost'
+              $ref: '#/components/schemas/ZeusPostableHost'
       responses:
         "204":
           description: No Content
@@ -17344,7 +17344,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ZeustypesPostableProfile'
+              $ref: '#/components/schemas/ZeusPostableProfile'
       responses:
         "204":
           description: No Content
@@ -17408,7 +17408,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TracedetailtypesPostableWaterfall'
+              $ref: '#/components/schemas/TraceDetailPostableWaterfall'
       responses:
         "200":
           content:
@@ -17416,7 +17416,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/TracedetailtypesGettableWaterfallTrace'
+                    $ref: '#/components/schemas/TraceDetailGettableWaterfallTrace'
                   status:
                     type: string
                 required:
@@ -17812,7 +17812,7 @@ paths:
                   schemaVersion: v1
                   start: 1640995200000
             schema:
-              $ref: '#/components/schemas/Querybuildertypesv5QueryRangeRequest'
+              $ref: '#/components/schemas/QueryBuilderV5QueryRangeRequest'
       responses:
         "200":
           content:
@@ -17820,7 +17820,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/Querybuildertypesv5QueryRangeResponse'
+                    $ref: '#/components/schemas/QueryBuilderV5QueryRangeResponse'
                   status:
                     type: string
                 required:
@@ -17869,7 +17869,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Querybuildertypesv5QueryRangeRequest'
+              $ref: '#/components/schemas/QueryBuilderV5QueryRangeRequest'
       responses:
         "200":
           content:
@@ -17877,7 +17877,7 @@ paths:
               schema:
                 properties:
                   data:
-                    $ref: '#/components/schemas/Querybuildertypesv5QueryRangeRequest'
+                    $ref: '#/components/schemas/QueryBuilderV5QueryRangeRequest'
                   status:
                     type: string
                 required:

--- a/pkg/signoz/openapi.go
+++ b/pkg/signoz/openapi.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path"
 	"reflect"
+	"strconv"
+	"strings"
 
 	"github.com/SigNoz/signoz/pkg/alertmanager"
 	"github.com/SigNoz/signoz/pkg/apiserver"
@@ -87,18 +90,10 @@ func NewOpenAPI(ctx context.Context, instrumentation instrumentation.Instrumenta
 	}
 
 	reflector := openapi3.NewReflector()
-	reflector.JSONSchemaReflector().DefaultOptions = append(reflector.JSONSchemaReflector().DefaultOptions, jsonschema.InterceptDefName(func(t reflect.Type, defaultDefName string) string {
-		if defaultDefName == "RenderSuccessResponse" {
-			field, ok := t.FieldByName("Data")
-			if !ok {
-				return defaultDefName
-			}
-
-			return field.Type.Name()
-		}
-
-		return defaultDefName
-	}))
+	reflector.JSONSchemaReflector().DefaultOptions = append(
+		reflector.JSONSchemaReflector().DefaultOptions,
+		jsonschema.InterceptDefName(defName),
+	)
 
 	reflector.Spec.WithInfo(*(&openapi3.Info{}).
 		WithTitle("SigNoz").
@@ -166,6 +161,127 @@ func (openapi *OpenAPI) CreateAndWrite(path string) error {
 	}
 
 	return os.WriteFile(path, spec, 0o600)
+}
+
+// pkgPrefixOverrides maps package basenames to CamelCase prefixes when
+// stripping "types" and capitalizing the first letter is not enough to
+// recover word boundaries. Add an entry when the algorithmic prefix reads
+// poorly.
+var pkgPrefixOverrides = map[string]string{
+	"alertmanagertypes":     "AlertManager",
+	"cloudintegrationtypes": "CloudIntegration",
+	"inframonitoringtypes":  "InfraMonitoring",
+	"llmpricingruletypes":   "LLMPricingRule",
+	"metricsexplorertypes":  "MetricsExplorer",
+	"querybuildertypesv5":   "QueryBuilderV5",
+	"rulestatehistorytypes": "RuleStateHistory",
+	"serviceaccounttypes":   "ServiceAccount",
+	"tracedetailtypes":      "TraceDetail",
+}
+
+// defName produces the OpenAPI schema key for a reflected type. It replaces
+// the verbose default that swaggest/jsonschema-go produces for generic
+// instantiations and for types in "*types" packages.
+func defName(t reflect.Type, defaultDefName string) string {
+	if defaultDefName == "RenderSuccessResponse" {
+		if field, ok := t.FieldByName("Data"); ok {
+			return field.Type.Name()
+		}
+		return defaultDefName
+	}
+
+	name := t.Name()
+	if strings.Contains(name, "[") && strings.HasSuffix(name, "]") {
+		return collapseGenericName(name)
+	}
+	if name == "" {
+		return defaultDefName
+	}
+
+	name = capitalize(name)
+	prefix := packagePrefix(t.PkgPath())
+	// Skip the prefix when the type name already starts with it (case-insensitive).
+	// For example, sigv4.SigV4Config becomes SigV4Config rather than Sigv4SigV4Config.
+	if prefix == "" || (len(name) >= len(prefix) && strings.EqualFold(name[:len(prefix)], prefix)) {
+		return name
+	}
+	return prefix + name
+}
+
+func packagePrefix(pkgPath string) string {
+	base := path.Base(pkgPath)
+	if base == "." || base == "" || base == "types" {
+		return ""
+	}
+	if v, ok := pkgPrefixOverrides[base]; ok {
+		return v
+	}
+	return capitalize(stripTypesSuffix(base))
+}
+
+func stripTypesSuffix(s string) string {
+	if rest, ok := strings.CutSuffix(s, "types"); ok {
+		return rest
+	}
+	if i := strings.LastIndex(s, "typesv"); i != -1 {
+		if v := s[i+len("typesv"):]; v != "" {
+			if _, err := strconv.Atoi(v); err == nil {
+				return s[:i] + "V" + v
+			}
+		}
+	}
+	return s
+}
+
+// collapseGenericName turns a reflect.Type.Name() like
+// "QueryBuilderQuery[github.com/SigNoz/.../v5.LogAggregation]" into
+// "QueryBuilderQueryLogAggregation" by concatenating the leaf name of the
+// base and each type parameter.
+func collapseGenericName(typeName string) string {
+	open := strings.Index(typeName, "[")
+	if open == -1 {
+		if i := strings.LastIndex(typeName, "."); i != -1 {
+			return typeName[i+1:]
+		}
+		return typeName
+	}
+	end := strings.LastIndex(typeName, "]")
+	if end <= open {
+		return collapseGenericName(typeName[:open])
+	}
+
+	var sb strings.Builder
+	sb.WriteString(collapseGenericName(typeName[:open]))
+	for _, param := range splitTypeParams(typeName[open+1 : end]) {
+		sb.WriteString(collapseGenericName(param))
+	}
+	return sb.String()
+}
+
+func splitTypeParams(s string) []string {
+	var params []string
+	depth, start := 0, 0
+	for i, c := range s {
+		switch c {
+		case '[':
+			depth++
+		case ']':
+			depth--
+		case ',':
+			if depth == 0 {
+				params = append(params, strings.TrimSpace(s[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	return append(params, strings.TrimSpace(s[start:]))
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
 }
 
 // convertJSONNumbers recursively walks a decoded JSON structure and converts


### PR DESCRIPTION
## Summary

Default schema names from `swaggest/jsonschema-go` produce verbose keys for generic instantiations and `*types` packages, e.g.
`Querybuildertypesv5QueryBuilderQueryGithubComSigNozSignozPkgTypesQuerybuildertypesQuerybuildertypesv5LogAggregation`.

The `InterceptDefName` hook in `pkg/signoz/openapi.go` now:

- Collapses generic instantiations to base + leaf-name concatenation, so `QueryBuilderQuery[…LogAggregation]` becomes `QueryBuilderQueryLogAggregation`.
- Strips the `types` / `typesvN` suffix from the package basename and de-stutters when the type name already starts with the prefix (`sigv4.SigV4Config` becomes `SigV4Config`; `types.User` becomes `User`).
- Falls back to a small override map for packages whose all-lowercase Go names lose word boundaries (`alertmanagertypes` becomes `AlertManager`, `inframonitoringtypes` becomes `InfraMonitoring`, etc).

Only schema keys and `$ref` strings change. Property names, JSON shapes, operation IDs, tags, and the existing `RenderSuccessResponse` handling are all unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e06c1b73b54d54794284d09be25d9c0439e4d3ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->