### PR TITLE
fix(tsgo): does not accept lint staged args

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -241,7 +241,7 @@
     "*.(js|jsx|ts|tsx)": [
       "oxlint --fix",
       "oxfmt --write",
-      "tsgo --noEmit"
+      "sh -c tsgo --noEmit"
     ],
     "*.(scss|css)": [
       "stylelint"


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Forgot to change how to call tsgo during lint staged, the current way is cause error on commit due to tsgo not allowing file as args.

Previous behavior:

<img width="1154" height="392" alt="image" src="https://github.com/user-attachments/assets/54db8e21-0ab6-4b36-834f-68834b81f66b" />

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

To test, just add a ts file and commit.