### PR TITLE
fix: sidebar resize button opens sidebar when closed

### DIFF
--- a/frontend/src/container/SideNav/SideNav.styles.scss
+++ b/frontend/src/container/SideNav/SideNav.styles.scss
@@ -486,7 +486,11 @@
 					right: -9px;
 					cursor: pointer;
 
-					display: none;
+					// Keep the resize/expand handle visible and clickable even when
+					// the sidebar is collapsed so users can re-open it from this
+					// state (fixes #9370). It used to be display: none here.
+					display: block;
+					pointer-events: auto;
 
 					transition: display 0.3s;
 


### PR DESCRIPTION
## What does this PR do?
Keeps the sidebar resize/expand handle clickable when the sidebar is collapsed, so users can click it to open and pin the sidebar.

## Root cause
`.collapse-expand-handlers` was set to `display: none` in the default (collapsed) state, hiding the click target entirely. The existing `handleToggleSidebar` already pins the sidebar correctly when toggled from a closed state — the only issue was that the control wasn't reachable.

## Fix
Switch `.collapse-expand-handlers` to `display: block` with `pointer-events: auto` in `frontend/src/container/SideNav/SideNav.styles.scss` so the handle remains visible and clickable while collapsed.

## Related Issue
Closes #9370

## How was this tested?
- Manually verified: closing the sidebar and clicking the resize button now opens it.
- Verified toggling still works when the sidebar is already open.

## Checklist
- [x] My code follows the existing code style
- [x] I tested this manually

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that makes the sidebar resize/expand handle visible/clickable in the collapsed state; potential impact is limited to side-nav UI layout and hit targets.
> 
> **Overview**
> Fixes an issue where the SideNav resize/expand handle disappeared when the sidebar was collapsed by changing `.collapse-expand-handlers` to `display: block` with `pointer-events: auto`, allowing users to reopen/pin the sidebar from the collapsed state (closes #9370).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d7129a2b98c71860b9c8d52c2a0eeaa7acb1a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->