### PR TITLE
feat(global): add ai_assistant_url to global config

### DIFF
--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -13,6 +13,8 @@ global:
   ingestion_url: <unset>
   # the url of the SigNoz MCP server. when unset, the MCP settings page is hidden in the frontend.
   # mcp_url: <unset>
+  # the url of the SigNoz AI Assistant server. when unset, the AI Assistant is hidden in the frontend.
+  # ai_assistant_url: <unset>
 
 ##################### Version #####################
 version:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -2494,6 +2494,9 @@ components:
       type: object
     GlobaltypesConfig:
       properties:
+        ai_assistant_url:
+          nullable: true
+          type: string
         external_url:
           type: string
         identN:
@@ -2507,6 +2510,7 @@ components:
       - external_url
       - ingestion_url
       - mcp_url
+      - ai_assistant_url
       type: object
     GlobaltypesIdentNConfig:
       properties:

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -4616,6 +4616,11 @@ export interface GlobaltypesAPIKeyConfigDTO {
 export interface GlobaltypesConfigDTO {
 	/**
 	 * @type string
+	 * @nullable true
+	 */
+	ai_assistant_url: string | null;
+	/**
+	 * @type string
 	 */
 	external_url: string;
 	identN?: GlobaltypesIdentNConfigDTO;

--- a/pkg/global/config.go
+++ b/pkg/global/config.go
@@ -15,9 +15,10 @@ var (
 )
 
 type Config struct {
-	ExternalURL  *url.URL `mapstructure:"external_url"`
-	IngestionURL *url.URL `mapstructure:"ingestion_url"`
-	MCPURL       *url.URL `mapstructure:"mcp_url"`
+	ExternalURL    *url.URL `mapstructure:"external_url"`
+	IngestionURL   *url.URL `mapstructure:"ingestion_url"`
+	MCPURL         *url.URL `mapstructure:"mcp_url"`
+	AIAssistantURL *url.URL `mapstructure:"ai_assistant_url"`
 }
 
 func NewConfigFactory() factory.ConfigFactory {

--- a/pkg/global/signozglobal/provider.go
+++ b/pkg/global/signozglobal/provider.go
@@ -37,8 +37,19 @@ func (provider *provider) GetConfig(context.Context) *globaltypes.Config {
 		mcpURL = &s
 	}
 
+	var aiAssistantURL *string
+	if provider.config.AIAssistantURL != nil {
+		s := provider.config.AIAssistantURL.String()
+		aiAssistantURL = &s
+	}
+
 	return globaltypes.NewConfig(
-		globaltypes.NewEndpoint(provider.config.ExternalURL.String(), provider.config.IngestionURL.String(), mcpURL),
+		globaltypes.NewEndpoint(
+			provider.config.ExternalURL.String(),
+			provider.config.IngestionURL.String(),
+			mcpURL,
+			aiAssistantURL,
+		),
 		globaltypes.NewIdentNConfig(
 			globaltypes.TokenizerConfig{Enabled: provider.identNConfig.Tokenizer.Enabled},
 			globaltypes.APIKeyConfig{Enabled: provider.identNConfig.APIKeyConfig.Enabled},

--- a/pkg/types/globaltypes/endpoint.go
+++ b/pkg/types/globaltypes/endpoint.go
@@ -1,15 +1,17 @@
 package globaltypes
 
 type Endpoint struct {
-	ExternalURL  string  `json:"external_url" required:"true"`
-	IngestionURL string  `json:"ingestion_url" required:"true"`
-	MCPURL       *string `json:"mcp_url" required:"true" nullable:"true"`
+	ExternalURL    string  `json:"external_url" required:"true"`
+	IngestionURL   string  `json:"ingestion_url" required:"true"`
+	MCPURL         *string `json:"mcp_url" required:"true" nullable:"true"`
+	AIAssistantURL *string `json:"ai_assistant_url" required:"true" nullable:"true"`
 }
 
-func NewEndpoint(externalURL, ingestionURL string, mcpURL *string) Endpoint {
+func NewEndpoint(externalURL, ingestionURL string, mcpURL, aiAssistantURL *string) Endpoint {
 	return Endpoint{
-		ExternalURL:  externalURL,
-		IngestionURL: ingestionURL,
-		MCPURL:       mcpURL,
+		ExternalURL:    externalURL,
+		IngestionURL:   ingestionURL,
+		MCPURL:         mcpURL,
+		AIAssistantURL: aiAssistantURL,
 	}
 }


### PR DESCRIPTION
## Summary
- Adds an optional `ai_assistant_url` to the backend global config, wire DTO, and provider wiring. When unset, `GET /api/v1/global/config` returns `"ai_assistant_url": null`; when set via YAML/env, it emits the parsed URL.
- Documents the new field in `conf/example.yaml` and regenerates `docs/api/openapi.yml` with `nullable: true`.
- Surfaces `ai_assistant_url: string | null` on the generated frontend global config type so AI Assistant entry points can gate on `ai_assistant_url != null`.