### PR TITLE
fix(frontend): simplify password matching logic

### DIFF
--- a/frontend/src/pages/SignUp/SignUp.tsx
+++ b/frontend/src/pages/SignUp/SignUp.tsx
@@ -66,6 +66,7 @@ function SignUp(): JSX.Element {
 			try {
 				const values = form.getFieldsValue();
 				if (values.password !== values.confirmPassword) {
+					setConfirmPasswordTouched(true);
 					return;
 				}
 				setLoading(true);
@@ -156,11 +157,11 @@ function SignUp(): JSX.Element {
 								<FormContainer.Item
 									name="confirmPassword"
 									validateTrigger="onBlur"
-									validateStatus={showPasswordMismatchError ? 'error' : ''}
+									validateStatus={showPasswordMismatchError ? 'error' : undefined}
 									help={
 										showPasswordMismatchError
 											? "Passwords don't match. Please try again."
-											: ''
+											: undefined
 									}
 									rules={[{ required: true, message: 'Please enter confirm password!' }]}
 								>

--- a/frontend/src/pages/SignUp/SignUp.tsx
+++ b/frontend/src/pages/SignUp/SignUp.tsx
@@ -65,10 +65,6 @@ function SignUp(): JSX.Element {
 		(async (): Promise<void> => {
 			try {
 				const values = form.getFieldsValue();
-				if (values.password !== values.confirmPassword) {
-					setConfirmPasswordTouched(true);
-					return;
-				}
 				setLoading(true);
 				setFormError(null);
 

--- a/frontend/src/pages/SignUp/SignUp.tsx
+++ b/frontend/src/pages/SignUp/SignUp.tsx
@@ -8,7 +8,7 @@ import afterLogin from 'AppRoutes/utils';
 import AuthError from 'components/AuthError/AuthError';
 import AuthPageContainer from 'components/AuthPageContainer';
 import { useNotifications } from 'hooks/useNotifications';
-import { ArrowRight, CircleAlert } from 'lucide-react';
+import { ArrowRight } from 'lucide-react';
 import APIError from 'types/api/error';
 
 import tvUrl from '@/assets/svgs/tv.svg';
@@ -28,9 +28,8 @@ type FormValues = {
 
 function SignUp(): JSX.Element {
 	const [loading, setLoading] = useState(false);
+	const [confirmPasswordTouched, setConfirmPasswordTouched] = useState(false);
 
-	const [confirmPasswordError, setConfirmPasswordError] =
-		useState<boolean>(false);
 	const [formError, setFormError] = useState<APIError | null>();
 
 	const { notifications } = useNotifications();
@@ -66,6 +65,9 @@ function SignUp(): JSX.Element {
 		(async (): Promise<void> => {
 			try {
 				const values = form.getFieldsValue();
+				if (values.password !== values.confirmPassword) {
+					return;
+				}
 				setLoading(true);
 				setFormError(null);
 
@@ -84,35 +86,10 @@ function SignUp(): JSX.Element {
 		})();
 	};
 
-	const handleValuesChange: (changedValues: Partial<FormValues>) => void = (
-		changedValues,
-	) => {
-		// Clear error if passwords match while typing (but don't set error until blur)
-		if ('password' in changedValues || 'confirmPassword' in changedValues) {
-			const { password, confirmPassword } = form.getFieldsValue();
+	const isPasswordMismatch =
+		Boolean(confirmPassword) && password !== confirmPassword;
 
-			if (password && confirmPassword && password === confirmPassword) {
-				setConfirmPasswordError(false);
-			}
-		}
-	};
-
-	const handlePasswordBlur = (): void => {
-		const { password, confirmPassword } = form.getFieldsValue();
-		// Only validate if confirm password has a value
-		if (confirmPassword) {
-			const isSamePassword = password === confirmPassword;
-			setConfirmPasswordError(!isSamePassword);
-		}
-	};
-
-	const handleConfirmPasswordBlur = (): void => {
-		const { password, confirmPassword } = form.getFieldsValue();
-		if (password && confirmPassword) {
-			const isSamePassword = password === confirmPassword;
-			setConfirmPasswordError(!isSamePassword);
-		}
-	};
+	const showPasswordMismatchError = confirmPasswordTouched && isPasswordMismatch;
 
 	const isValidForm = useMemo(
 		(): boolean =>
@@ -120,8 +97,8 @@ function SignUp(): JSX.Element {
 			Boolean(email?.trim()) &&
 			Boolean(password?.trim()) &&
 			Boolean(confirmPassword?.trim()) &&
-			!confirmPasswordError,
-		[loading, email, password, confirmPassword, confirmPasswordError],
+			password === confirmPassword,
+		[loading, email, password, confirmPassword],
 	);
 
 	return (
@@ -140,12 +117,7 @@ function SignUp(): JSX.Element {
 					</Typography.Paragraph>
 				</div>
 
-				<FormContainer
-					onFinish={handleSubmit}
-					onValuesChange={handleValuesChange}
-					form={form}
-					className="signup-form"
-				>
+				<FormContainer onFinish={handleSubmit} form={form} className="signup-form">
 					<div className="signup-form-container">
 						<div className="signup-form-fields">
 							<div className="signup-field-container">
@@ -175,7 +147,6 @@ function SignUp(): JSX.Element {
 										placeholder="Enter new password"
 										disabled={loading}
 										className="signup-antd-input"
-										onBlur={handlePasswordBlur}
 									/>
 								</FormContainer.Item>
 							</div>
@@ -185,6 +156,12 @@ function SignUp(): JSX.Element {
 								<FormContainer.Item
 									name="confirmPassword"
 									validateTrigger="onBlur"
+									validateStatus={showPasswordMismatchError ? 'error' : ''}
+									help={
+										showPasswordMismatchError
+											? "Passwords don't match. Please try again."
+											: ''
+									}
 									rules={[{ required: true, message: 'Please enter confirm password!' }]}
 								>
 									<AntdInput.Password
@@ -193,7 +170,7 @@ function SignUp(): JSX.Element {
 										placeholder="Confirm your new password"
 										disabled={loading}
 										className="signup-antd-input"
-										onBlur={handleConfirmPasswordBlur}
+										onBlur={() => setConfirmPasswordTouched(true)}
 									/>
 								</FormContainer.Item>
 							</div>
@@ -205,19 +182,7 @@ function SignUp(): JSX.Element {
 						your admin for an invite link
 					</Callout>
 
-					{confirmPasswordError && (
-						<Callout
-							type="error"
-							size="small"
-							showIcon
-							icon={<CircleAlert size={12} />}
-							className="signup-error-callout"
-						>
-							Passwords don&apos;t match. Please try again.
-						</Callout>
-					)}
-
-					{formError && !confirmPasswordError && <AuthError error={formError} />}
+					{formError && <AuthError error={formError} />}
 
 					<div className="signup-form-actions">
 						<Button


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Fixes a bug where users could bypass password matching validation during signup by pressing `Enter` rapidly. 

https://github.com/user-attachments/assets/97dc0ff5-8d65-4435-8a54-cced78f050e0




#### Screenshots / Screen Recordings (if applicable)



#### Issues closed by this PR
N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
The validation relied on `onBlur`. If a user pressed `Enter` while still typing in the confirm password field, the blur event never fired, and the mismatched passwords were submitted.

#### Fix Strategy
Added strict manual validation directly inside `handleSubmit` to block mismatched passwords, and simplified the UI error state logic using `useWatch`.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: SignUp Page
- Potential regressions: -
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed a race-condition issue on UI allowing the first user to be created even when passwords does not match. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes signup form validation/submit flow and could inadvertently block valid signups or alter error display behavior, though it is confined to frontend UI logic.
> 
> **Overview**
> Prevents signup submission when `password` and `confirmPassword` don’t match by adding an explicit check inside `handleSubmit`, closing a path where rapid `Enter` presses could bypass blur-based validation.
> 
> Simplifies password-mismatch UI handling by deriving mismatch state from `useWatch` values and showing inline field errors after the confirm-password field is touched, removing the separate mismatch callout and related blur/value-change handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25e7420f900ff826c24651cb78a529a22d7d2156. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->