### PR TITLE
fix(ruletypes): v2alpha1 read returns evaluation envelope, not decomposed top-level fields

### DIFF
--- a/pkg/types/ruletypes/api_params.go
+++ b/pkg/types/ruletypes/api_params.go
@@ -633,6 +633,7 @@ func (g *GettableRule) MarshalJSON() ([]byte, error) {
 		return json.Marshal(aux)
 	case SchemaVersionV2Alpha1:
 		copyStruct := *g
+		copyStruct.PostableRule.populateEvaluationForResponse()
 		aux := Alias(copyStruct)
 		return json.Marshal(aux)
 	default:
@@ -687,11 +688,49 @@ func (r *Rule) MarshalJSON() ([]byte, error) {
 		return json.Marshal(aux)
 	case SchemaVersionV2Alpha1:
 		copyStruct := *r
+		copyStruct.PostableRule.populateEvaluationForResponse()
 		aux := Alias(copyStruct)
 		return json.Marshal(aux)
 	default:
 		copyStruct := *r
 		aux := Alias(copyStruct)
 		return json.Marshal(aux)
+	}
+}
+
+// populateEvaluationForResponse normalizes the v2alpha1 read shape so that
+// `evaluation` is the single canonical home of the evaluation window and
+// the legacy top-level `evalWindow` / `frequency` fields don't leak into
+// the response. Two cases:
+//
+//   - rule was POSTed under v2alpha1 with `evaluation: {...}` — the
+//     envelope is already populated; the top-level fields are zero from
+//     unmarshaling. Just leave the envelope alone.
+//   - rule was originally created under v1 (top-level fields, no
+//     envelope) and is now being read back under v2alpha1 — synthesize a
+//     RollingWindow envelope from the legacy fields so the wire output
+//     matches what a v2alpha1 client would have sent.
+//
+// In both cases the top-level legacy fields get zeroed; their `omitzero`
+// json tags drop them from the response, and clients see exactly the
+// `evaluation` envelope they POST/PUT with.
+//
+// v1 (DefaultSchemaVersion) responses keep the legacy decomposed shape —
+// existing v1 clients (older SDKs, terraform-provider's signoz/ tree)
+// rely on it. The MarshalJSON case above already nils out Evaluation
+// for v1 so the two responses stay distinct.
+func (r *PostableRule) populateEvaluationForResponse() {
+	if r.Evaluation == nil && (!r.EvalWindow.IsZero() || !r.Frequency.IsZero()) {
+		r.Evaluation = &EvaluationEnvelope{
+			Kind: RollingEvaluation,
+			Spec: RollingWindow{
+				EvalWindow: r.EvalWindow,
+				Frequency:  r.Frequency,
+			},
+		}
+	}
+	if r.Evaluation != nil {
+		r.EvalWindow = valuer.TextDuration{}
+		r.Frequency = valuer.TextDuration{}
 	}
 }


### PR DESCRIPTION
## Summary
For v2alpha1 rules the GET response was carrying both `evaluation` AND the legacy top-level `evalWindow` / `frequency` simultaneously, while the POST/PUT body only accepts `evaluation`. The asymmetry has three costs:

- doubles the flatten code on every client (terraform, frontend) — they re-construct the envelope from the top-level fields
- breaks symmetry with the request shape, so request and response can't share a typed model
- can't generalize to cumulative evaluations — those don't have a clean `{evalWindow, frequency}` decomposition

## Fix
Make `MarshalJSON` for both `GettableRule` and `Rule` symmetric with the request under v2alpha1:

- ensure `evaluation` is populated. If a v1 rule is being read back under v2alpha1, synthesize a `RollingWindow` envelope from the legacy fields.
- zero out `EvalWindow` / `Frequency` so their `omitzero` tags drop them from the response.

v1 (`DefaultSchemaVersion`) responses keep the legacy decomposed shape — existing v1 clients depend on it, and the existing v1 branch already nils `Evaluation` so the two response shapes stay distinct.

## Test plan
- [x] `go test ./pkg/types/ruletypes/...` passes
- [x] `go build ./...` clean
- [ ] Verify a rule POSTed with `schemaVersion=v2alpha1` and `evaluation: {kind: rolling, spec: {evalWindow, frequency}}` round-trips on GET — response carries `evaluation` but not the legacy fields
- [ ] Verify a v1 rule still GETs back as `{evalWindow, frequency}` (no envelope)
- [ ] Verify a v1 rule read back through a v2alpha1 GET path (if such a path exists in tests) renders the envelope synthesized from legacy fields