### PR TITLE
feat(ruletypes): publish OpenAPI 3 discriminator on RuleThresholdData and EvaluationEnvelope

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -4350,6 +4350,11 @@ components:
           $ref: '#/components/schemas/RuletypesCumulativeWindow'
       type: object
     RuletypesEvaluationEnvelope:
+      discriminator:
+        mapping:
+          cumulative: '#/components/schemas/RuletypesEvaluationCumulative'
+          rolling: '#/components/schemas/RuletypesEvaluationRolling'
+        propertyName: kind
       oneOf:
       - $ref: '#/components/schemas/RuletypesEvaluationRolling'
       - $ref: '#/components/schemas/RuletypesEvaluationCumulative'
@@ -4679,6 +4684,10 @@ components:
       - compositeQuery
       type: object
     RuletypesRuleThresholdData:
+      discriminator:
+        mapping:
+          basic: '#/components/schemas/RuletypesThresholdBasic'
+        propertyName: kind
       oneOf:
       - $ref: '#/components/schemas/RuletypesThresholdBasic'
       properties:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -4348,6 +4348,9 @@ components:
           $ref: '#/components/schemas/RuletypesEvaluationKind'
         spec:
           $ref: '#/components/schemas/RuletypesCumulativeWindow'
+      required:
+      - kind
+      - spec
       type: object
     RuletypesEvaluationEnvelope:
       discriminator:
@@ -4377,6 +4380,9 @@ components:
           $ref: '#/components/schemas/RuletypesEvaluationKind'
         spec:
           $ref: '#/components/schemas/RuletypesRollingWindow'
+      required:
+      - kind
+      - spec
       type: object
     RuletypesGettableTestRule:
       properties:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -4730,6 +4730,9 @@ components:
           $ref: '#/components/schemas/RuletypesThresholdKind'
         spec:
           $ref: '#/components/schemas/RuletypesBasicRuleThresholds'
+      required:
+      - kind
+      - spec
       type: object
     RuletypesThresholdKind:
       enum:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -4361,13 +4361,6 @@ components:
       oneOf:
       - $ref: '#/components/schemas/RuletypesEvaluationRolling'
       - $ref: '#/components/schemas/RuletypesEvaluationCumulative'
-      properties:
-        kind:
-          $ref: '#/components/schemas/RuletypesEvaluationKind'
-        spec: {}
-      required:
-      - kind
-      - spec
       type: object
     RuletypesEvaluationKind:
       enum:
@@ -4696,13 +4689,6 @@ components:
         propertyName: kind
       oneOf:
       - $ref: '#/components/schemas/RuletypesThresholdBasic'
-      properties:
-        kind:
-          $ref: '#/components/schemas/RuletypesThresholdKind'
-        spec: {}
-      required:
-      - kind
-      - spec
       type: object
     RuletypesRuleType:
       enum:

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -6591,14 +6591,8 @@ export interface RuletypesEvaluationCumulativeDTO {
 }
 
 export type RuletypesEvaluationEnvelopeDTO =
-	| (RuletypesEvaluationRollingDTO & {
-			kind: RuletypesEvaluationKindDTO;
-			spec: unknown;
-	  })
-	| (RuletypesEvaluationCumulativeDTO & {
-			kind: RuletypesEvaluationKindDTO;
-			spec: unknown;
-	  });
+	| RuletypesEvaluationRollingDTO
+	| RuletypesEvaluationCumulativeDTO;
 
 export enum RuletypesEvaluationKindDTO {
 	rolling = 'rolling',
@@ -6968,10 +6962,7 @@ export interface RuletypesRuleConditionDTO {
 	thresholds?: RuletypesRuleThresholdDataDTO;
 }
 
-export type RuletypesRuleThresholdDataDTO = RuletypesThresholdBasicDTO & {
-	kind: RuletypesThresholdKindDTO;
-	spec: unknown;
-};
+export type RuletypesRuleThresholdDataDTO = RuletypesThresholdBasicDTO;
 
 export enum RuletypesRuleTypeDTO {
 	threshold_rule = 'threshold_rule',

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -6578,8 +6578,15 @@ export interface RuletypesCumulativeWindowDTO {
 	timezone: string;
 }
 
+export enum RuletypesEvaluationCumulativeDTOKind {
+	cumulative = 'cumulative',
+}
 export interface RuletypesEvaluationCumulativeDTO {
-	kind?: RuletypesEvaluationKindDTO;
+	/**
+	 * @type string
+	 * @enum cumulative
+	 */
+	kind: RuletypesEvaluationCumulativeDTOKind;
 	spec?: RuletypesCumulativeWindowDTO;
 }
 
@@ -6597,8 +6604,15 @@ export enum RuletypesEvaluationKindDTO {
 	rolling = 'rolling',
 	cumulative = 'cumulative',
 }
+export enum RuletypesEvaluationRollingDTOKind {
+	rolling = 'rolling',
+}
 export interface RuletypesEvaluationRollingDTO {
-	kind?: RuletypesEvaluationKindDTO;
+	/**
+	 * @type string
+	 * @enum rolling
+	 */
+	kind: RuletypesEvaluationRollingDTOKind;
 	spec?: RuletypesRollingWindowDTO;
 }
 
@@ -6993,8 +7007,15 @@ export enum RuletypesSeasonalityDTO {
 	daily = 'daily',
 	weekly = 'weekly',
 }
+export enum RuletypesThresholdBasicDTOKind {
+	basic = 'basic',
+}
 export interface RuletypesThresholdBasicDTO {
-	kind?: RuletypesThresholdKindDTO;
+	/**
+	 * @type string
+	 * @enum basic
+	 */
+	kind: RuletypesThresholdBasicDTOKind;
 	spec?: RuletypesBasicRuleThresholdsDTO;
 }
 

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -6587,7 +6587,7 @@ export interface RuletypesEvaluationCumulativeDTO {
 	 * @enum cumulative
 	 */
 	kind: RuletypesEvaluationCumulativeDTOKind;
-	spec?: RuletypesCumulativeWindowDTO;
+	spec: RuletypesCumulativeWindowDTO;
 }
 
 export type RuletypesEvaluationEnvelopeDTO =
@@ -6613,7 +6613,7 @@ export interface RuletypesEvaluationRollingDTO {
 	 * @enum rolling
 	 */
 	kind: RuletypesEvaluationRollingDTOKind;
-	spec?: RuletypesRollingWindowDTO;
+	spec: RuletypesRollingWindowDTO;
 }
 
 export interface RuletypesGettableTestRuleDTO {

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -7007,7 +7007,7 @@ export interface RuletypesThresholdBasicDTO {
 	 * @enum basic
 	 */
 	kind: RuletypesThresholdBasicDTOKind;
-	spec?: RuletypesBasicRuleThresholdsDTO;
+	spec: RuletypesBasicRuleThresholdsDTO;
 }
 
 export enum RuletypesThresholdKindDTO {

--- a/pkg/signoz/openapi.go
+++ b/pkg/signoz/openapi.go
@@ -242,6 +242,12 @@ func attachDiscriminators(spec *openapi3.Spec) {
 		}
 		entry.Schema.Discriminator = &disc
 		delete(entry.Schema.MapOfAnything, signozDiscriminatorKey)
+		// The parent's reflected `properties` / `required` duplicate
+		// what the oneOf variants already declare, and orval intersects
+		// the two — turning a clean discriminated union DTO into a
+		// noisy union of intersections. Drop them here.
+		entry.Schema.Properties = nil
+		entry.Schema.Required = nil
 		spec.Components.Schemas.MapOfSchemaOrRefValues[name] = entry
 	}
 }

--- a/pkg/signoz/openapi.go
+++ b/pkg/signoz/openapi.go
@@ -210,22 +210,27 @@ func attachDiscriminators(spec *openapi3.Spec) {
 	if spec.Components == nil || spec.Components.Schemas == nil {
 		return
 	}
+
 	for name, entry := range spec.Components.Schemas.MapOfSchemaOrRefValues {
 		if entry.Schema == nil {
 			continue
 		}
+
 		raw, ok := entry.Schema.MapOfAnything[signozDiscriminatorKey]
 		if !ok {
 			continue
 		}
+
 		marker, ok := raw.(map[string]any)
 		if !ok {
 			continue
 		}
+
 		propertyName, ok := marker["propertyName"].(string)
 		if !ok || propertyName == "" {
 			continue
 		}
+
 		disc := openapi3.Discriminator{PropertyName: propertyName}
 		if rawMapping, ok := marker["mapping"]; ok {
 			if mapping, ok := rawMapping.(map[string]string); ok {
@@ -240,14 +245,17 @@ func attachDiscriminators(spec *openapi3.Spec) {
 				disc.Mapping = converted
 			}
 		}
+
 		entry.Schema.Discriminator = &disc
 		delete(entry.Schema.MapOfAnything, signozDiscriminatorKey)
+
 		// The parent's reflected `properties` / `required` duplicate
 		// what the oneOf variants already declare, and orval intersects
 		// the two — turning a clean discriminated union DTO into a
 		// noisy union of intersections. Drop them here.
 		entry.Schema.Properties = nil
 		entry.Schema.Required = nil
+
 		spec.Components.Schemas.MapOfSchemaOrRefValues[name] = entry
 	}
 }

--- a/pkg/signoz/openapi.go
+++ b/pkg/signoz/openapi.go
@@ -44,6 +44,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const signozDiscriminatorKey string = "x-signoz-discriminator"
+
 type OpenAPI struct {
 	apiserver apiserver.APIServer
 	reflector *openapi3.Reflector
@@ -142,13 +144,6 @@ func (openapi *OpenAPI) CreateAndWrite(path string) error {
 		return err
 	}
 
-	// Promote `x-signoz-discriminator` markers (set by Exposer impls
-	// in pkg/types via `Schema.ExtraProperties`) into real OpenAPI 3
-	// `discriminator` fields. jsonschema-go.Schema has no
-	// Discriminator field of its own and openapi-go only carries
-	// `x-` prefixed extras through ExtraProperties unchanged, so the
-	// type-side declaration goes through this marker convention and
-	// the spec-side promotion happens here.
 	attachDiscriminators(openapi.reflector.Spec)
 
 	// The library's MarshalYAML does a JSON round-trip that converts all numbers
@@ -177,20 +172,37 @@ func (openapi *OpenAPI) CreateAndWrite(path string) error {
 	return os.WriteFile(path, spec, 0o600)
 }
 
-// signozDiscriminatorKey is the marker that `JSONSchema()` Exposer
-// impls in pkg/types use to declare an OpenAPI 3 discriminator. The
-// keyword itself isn't a JSON Schema concept and the marker can't be
-// promoted from `jsonschema-go.Schema.ExtraProperties` to
-// `openapi3.Schema.Discriminator` by the upstream conversion code
-// (which only carries through `x-`-prefixed extras into
-// `MapOfAnything`). `attachDiscriminators` reads this marker and
-// promotes it to a real `Discriminator` field on the openapi3 schema
-// (then deletes the marker so it doesn't pollute the rendered YAML).
-//
-// The marker value is a `map[string]any` with:
-//   - "propertyName" (string, required)  — the discriminator field
-//   - "mapping"      (map[string]string, optional) — value→$ref
-const signozDiscriminatorKey = "x-signoz-discriminator"
+// convertJSONNumbers recursively walks a decoded JSON structure and converts
+// json.Number values to int64 (preferred) or float64 so that YAML marshaling
+// renders them as plain numbers instead of quoted strings.
+func convertJSONNumbers(v interface{}) {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		for k, elem := range val {
+			if n, ok := elem.(json.Number); ok {
+				if i, err := n.Int64(); err == nil {
+					val[k] = i
+				} else if f, err := n.Float64(); err == nil {
+					val[k] = f
+				}
+			} else {
+				convertJSONNumbers(elem)
+			}
+		}
+	case []interface{}:
+		for i, elem := range val {
+			if n, ok := elem.(json.Number); ok {
+				if i64, err := n.Int64(); err == nil {
+					val[i] = i64
+				} else if f, err := n.Float64(); err == nil {
+					val[i] = f
+				}
+			} else {
+				convertJSONNumbers(elem)
+			}
+		}
+	}
+}
 
 // attachDiscriminators walks every component schema in the spec and
 // promotes any `x-signoz-discriminator` extension into a proper
@@ -235,37 +247,5 @@ func attachDiscriminators(spec *openapi3.Spec) {
 		entry.Schema.Discriminator = &disc
 		delete(entry.Schema.MapOfAnything, signozDiscriminatorKey)
 		spec.Components.Schemas.MapOfSchemaOrRefValues[name] = entry
-	}
-}
-
-// convertJSONNumbers recursively walks a decoded JSON structure and converts
-// json.Number values to int64 (preferred) or float64 so that YAML marshaling
-// renders them as plain numbers instead of quoted strings.
-func convertJSONNumbers(v interface{}) {
-	switch val := v.(type) {
-	case map[string]interface{}:
-		for k, elem := range val {
-			if n, ok := elem.(json.Number); ok {
-				if i, err := n.Int64(); err == nil {
-					val[k] = i
-				} else if f, err := n.Float64(); err == nil {
-					val[k] = f
-				}
-			} else {
-				convertJSONNumbers(elem)
-			}
-		}
-	case []interface{}:
-		for i, elem := range val {
-			if n, ok := elem.(json.Number); ok {
-				if i64, err := n.Int64(); err == nil {
-					val[i] = i64
-				} else if f, err := n.Float64(); err == nil {
-					val[i] = f
-				}
-			} else {
-				convertJSONNumbers(elem)
-			}
-		}
 	}
 }

--- a/pkg/signoz/openapi.go
+++ b/pkg/signoz/openapi.go
@@ -142,6 +142,15 @@ func (openapi *OpenAPI) CreateAndWrite(path string) error {
 		return err
 	}
 
+	// Promote `x-signoz-discriminator` markers (set by Exposer impls
+	// in pkg/types via `Schema.ExtraProperties`) into real OpenAPI 3
+	// `discriminator` fields. jsonschema-go.Schema has no
+	// Discriminator field of its own and openapi-go only carries
+	// `x-` prefixed extras through ExtraProperties unchanged, so the
+	// type-side declaration goes through this marker convention and
+	// the spec-side promotion happens here.
+	attachDiscriminators(openapi.reflector.Spec)
+
 	// The library's MarshalYAML does a JSON round-trip that converts all numbers
 	// to float64, causing large integers (e.g. epoch millisecond timestamps) to
 	// render in scientific notation (1.6409952e+12).
@@ -166,6 +175,67 @@ func (openapi *OpenAPI) CreateAndWrite(path string) error {
 	}
 
 	return os.WriteFile(path, spec, 0o600)
+}
+
+// signozDiscriminatorKey is the marker that `JSONSchema()` Exposer
+// impls in pkg/types use to declare an OpenAPI 3 discriminator. The
+// keyword itself isn't a JSON Schema concept and the marker can't be
+// promoted from `jsonschema-go.Schema.ExtraProperties` to
+// `openapi3.Schema.Discriminator` by the upstream conversion code
+// (which only carries through `x-`-prefixed extras into
+// `MapOfAnything`). `attachDiscriminators` reads this marker and
+// promotes it to a real `Discriminator` field on the openapi3 schema
+// (then deletes the marker so it doesn't pollute the rendered YAML).
+//
+// The marker value is a `map[string]any` with:
+//   - "propertyName" (string, required)  — the discriminator field
+//   - "mapping"      (map[string]string, optional) — value→$ref
+const signozDiscriminatorKey = "x-signoz-discriminator"
+
+// attachDiscriminators walks every component schema in the spec and
+// promotes any `x-signoz-discriminator` extension into a proper
+// OpenAPI 3 `discriminator` object on the parent schema. Schemas
+// without the marker are untouched; malformed markers (wrong shape,
+// missing propertyName) are silently dropped — better to leave the
+// schema discriminator-less than to fail OpenAPI generation.
+func attachDiscriminators(spec *openapi3.Spec) {
+	if spec.Components == nil || spec.Components.Schemas == nil {
+		return
+	}
+	for name, entry := range spec.Components.Schemas.MapOfSchemaOrRefValues {
+		if entry.Schema == nil {
+			continue
+		}
+		raw, ok := entry.Schema.MapOfAnything[signozDiscriminatorKey]
+		if !ok {
+			continue
+		}
+		marker, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		propertyName, ok := marker["propertyName"].(string)
+		if !ok || propertyName == "" {
+			continue
+		}
+		disc := openapi3.Discriminator{PropertyName: propertyName}
+		if rawMapping, ok := marker["mapping"]; ok {
+			if mapping, ok := rawMapping.(map[string]string); ok {
+				disc.Mapping = mapping
+			} else if mapping, ok := rawMapping.(map[string]any); ok {
+				converted := make(map[string]string, len(mapping))
+				for k, v := range mapping {
+					if s, ok := v.(string); ok {
+						converted[k] = s
+					}
+				}
+				disc.Mapping = converted
+			}
+		}
+		entry.Schema.Discriminator = &disc
+		delete(entry.Schema.MapOfAnything, signozDiscriminatorKey)
+		spec.Components.Schemas.MapOfSchemaOrRefValues[name] = entry
+	}
 }
 
 // convertJSONNumbers recursively walks a decoded JSON structure and converts

--- a/pkg/signoz/openapi.go
+++ b/pkg/signoz/openapi.go
@@ -204,12 +204,8 @@ func convertJSONNumbers(v interface{}) {
 	}
 }
 
-// attachDiscriminators walks every component schema in the spec and
-// promotes any `x-signoz-discriminator` extension into a proper
-// OpenAPI 3 `discriminator` object on the parent schema. Schemas
-// without the marker are untouched; malformed markers (wrong shape,
-// missing propertyName) are silently dropped — better to leave the
-// schema discriminator-less than to fail OpenAPI generation.
+// attachDiscriminators promotes x-signoz-discriminator extensions
+// into openapi3 Discriminator fields. Malformed markers are dropped.
 func attachDiscriminators(spec *openapi3.Spec) {
 	if spec.Components == nil || spec.Components.Schemas == nil {
 		return

--- a/pkg/types/ruletypes/evaluation.go
+++ b/pkg/types/ruletypes/evaluation.go
@@ -250,14 +250,14 @@ type EvaluationEnvelope struct {
 
 // evaluationRolling is the OpenAPI schema for an EvaluationEnvelope with kind=rolling.
 type evaluationRolling struct {
-	Kind EvaluationKind `json:"kind" description:"The kind of evaluation."`
-	Spec RollingWindow  `json:"spec" description:"The rolling window evaluation specification."`
+	Kind EvaluationKind `json:"kind" description:"The kind of evaluation." required:"true"`
+	Spec RollingWindow  `json:"spec" description:"The rolling window evaluation specification." required:"true"`
 }
 
 // evaluationCumulative is the OpenAPI schema for an EvaluationEnvelope with kind=cumulative.
 type evaluationCumulative struct {
-	Kind EvaluationKind   `json:"kind" description:"The kind of evaluation."`
-	Spec CumulativeWindow `json:"spec" description:"The cumulative window evaluation specification."`
+	Kind EvaluationKind   `json:"kind" description:"The kind of evaluation." required:"true"`
+	Spec CumulativeWindow `json:"spec" description:"The cumulative window evaluation specification." required:"true"`
 }
 
 var (

--- a/pkg/types/ruletypes/evaluation.go
+++ b/pkg/types/ruletypes/evaluation.go
@@ -260,7 +260,10 @@ type evaluationCumulative struct {
 	Spec CumulativeWindow `json:"spec" description:"The cumulative window evaluation specification."`
 }
 
-var _ jsonschema.OneOfExposer = EvaluationEnvelope{}
+var (
+	_ jsonschema.OneOfExposer = EvaluationEnvelope{}
+	_ jsonschema.Preparer     = EvaluationEnvelope{}
+)
 
 // JSONSchemaOneOf returns the oneOf variants for the EvaluationEnvelope discriminated union.
 // Each variant represents a different evaluation kind with its corresponding spec schema.
@@ -269,6 +272,27 @@ func (EvaluationEnvelope) JSONSchemaOneOf() []any {
 		evaluationRolling{},
 		evaluationCumulative{},
 	}
+}
+
+// PrepareJSONSchema attaches the `x-signoz-discriminator` ExtraProperty;
+// `signoz.attachDiscriminators` promotes it into a real OpenAPI 3
+// `discriminator` field after reflection. See the matching method on
+// `RuleThresholdData` for rationale.
+//
+// Adding a new evaluation kind: add the variant to `JSONSchemaOneOf`
+// AND the mapping below.
+func (EvaluationEnvelope) PrepareJSONSchema(schema *jsonschema.Schema) error {
+	if schema.ExtraProperties == nil {
+		schema.ExtraProperties = map[string]any{}
+	}
+	schema.ExtraProperties["x-signoz-discriminator"] = map[string]any{
+		"propertyName": "kind",
+		"mapping": map[string]string{
+			"rolling":    "#/components/schemas/RuletypesEvaluationRolling",
+			"cumulative": "#/components/schemas/RuletypesEvaluationCumulative",
+		},
+	}
+	return nil
 }
 
 func (e *EvaluationEnvelope) UnmarshalJSON(data []byte) error {

--- a/pkg/types/ruletypes/evaluation.go
+++ b/pkg/types/ruletypes/evaluation.go
@@ -274,13 +274,6 @@ func (EvaluationEnvelope) JSONSchemaOneOf() []any {
 	}
 }
 
-// PrepareJSONSchema attaches the `x-signoz-discriminator` ExtraProperty;
-// `signoz.attachDiscriminators` promotes it into a real OpenAPI 3
-// `discriminator` field after reflection. See the matching method on
-// `RuleThresholdData` for rationale.
-//
-// Adding a new evaluation kind: add the variant to `JSONSchemaOneOf`
-// AND the mapping below.
 func (EvaluationEnvelope) PrepareJSONSchema(schema *jsonschema.Schema) error {
 	if schema.ExtraProperties == nil {
 		schema.ExtraProperties = map[string]any{}

--- a/pkg/types/ruletypes/evaluation.go
+++ b/pkg/types/ruletypes/evaluation.go
@@ -278,6 +278,7 @@ func (EvaluationEnvelope) PrepareJSONSchema(schema *jsonschema.Schema) error {
 	if schema.ExtraProperties == nil {
 		schema.ExtraProperties = map[string]any{}
 	}
+
 	schema.ExtraProperties["x-signoz-discriminator"] = map[string]any{
 		"propertyName": "kind",
 		"mapping": map[string]string{
@@ -285,6 +286,7 @@ func (EvaluationEnvelope) PrepareJSONSchema(schema *jsonschema.Schema) error {
 			"cumulative": "#/components/schemas/RuletypesEvaluationCumulative",
 		},
 	}
+
 	return nil
 }
 

--- a/pkg/types/ruletypes/evaluation.go
+++ b/pkg/types/ruletypes/evaluation.go
@@ -243,21 +243,9 @@ func (cumulativeWindow CumulativeWindow) GetFrequency() valuer.TextDuration {
 	return cumulativeWindow.Frequency
 }
 
-// EvaluationEnvelope's Kind/Spec are tagged json:"-" so the schema
-// reflector skips them — the oneOf variants already declare both
-// fields and would otherwise be intersected with this parent's
-// duplicate properties block. Wire serialization goes through
-// MarshalJSON below.
 type EvaluationEnvelope struct {
-	Kind EvaluationKind `json:"-"`
-	Spec any            `json:"-"`
-}
-
-func (e EvaluationEnvelope) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		Kind EvaluationKind `json:"kind"`
-		Spec any            `json:"spec"`
-	}{e.Kind, e.Spec})
+	Kind EvaluationKind `json:"kind" required:"true"`
+	Spec any            `json:"spec" required:"true"`
 }
 
 // evaluationRolling is the OpenAPI schema for an EvaluationEnvelope with kind=rolling.

--- a/pkg/types/ruletypes/evaluation.go
+++ b/pkg/types/ruletypes/evaluation.go
@@ -243,9 +243,21 @@ func (cumulativeWindow CumulativeWindow) GetFrequency() valuer.TextDuration {
 	return cumulativeWindow.Frequency
 }
 
+// EvaluationEnvelope's Kind/Spec are tagged json:"-" so the schema
+// reflector skips them — the oneOf variants already declare both
+// fields and would otherwise be intersected with this parent's
+// duplicate properties block. Wire serialization goes through
+// MarshalJSON below.
 type EvaluationEnvelope struct {
-	Kind EvaluationKind `json:"kind" required:"true"`
-	Spec any            `json:"spec" required:"true"`
+	Kind EvaluationKind `json:"-"`
+	Spec any            `json:"-"`
+}
+
+func (e EvaluationEnvelope) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind EvaluationKind `json:"kind"`
+		Spec any            `json:"spec"`
+	}{e.Kind, e.Spec})
 }
 
 // evaluationRolling is the OpenAPI schema for an EvaluationEnvelope with kind=rolling.

--- a/pkg/types/ruletypes/threshold.go
+++ b/pkg/types/ruletypes/threshold.go
@@ -29,19 +29,9 @@ func (ThresholdKind) Enum() []any {
 	}
 }
 
-// RuleThresholdData's Kind/Spec are tagged json:"-" so the schema
-// reflector skips them — the oneOf variants already declare both
-// fields. Wire serialization goes through MarshalJSON below.
 type RuleThresholdData struct {
-	Kind ThresholdKind `json:"-"`
-	Spec any           `json:"-"`
-}
-
-func (r RuleThresholdData) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		Kind ThresholdKind `json:"kind"`
-		Spec any           `json:"spec"`
-	}{r.Kind, r.Spec})
+	Kind ThresholdKind `json:"kind" required:"true"`
+	Spec any           `json:"spec" required:"true"`
 }
 
 // thresholdBasic is the OpenAPI schema for a RuleThresholdData with kind=basic.

--- a/pkg/types/ruletypes/threshold.go
+++ b/pkg/types/ruletypes/threshold.go
@@ -60,12 +60,14 @@ func (RuleThresholdData) PrepareJSONSchema(schema *jsonschema.Schema) error {
 	if schema.ExtraProperties == nil {
 		schema.ExtraProperties = map[string]any{}
 	}
+
 	schema.ExtraProperties["x-signoz-discriminator"] = map[string]any{
 		"propertyName": "kind",
 		"mapping": map[string]string{
 			"basic": "#/components/schemas/RuletypesThresholdBasic",
 		},
 	}
+
 	return nil
 }
 

--- a/pkg/types/ruletypes/threshold.go
+++ b/pkg/types/ruletypes/threshold.go
@@ -53,16 +53,9 @@ func (RuleThresholdData) JSONSchemaOneOf() []any {
 	}
 }
 
-// PrepareJSONSchema attaches the `x-signoz-discriminator` ExtraProperty.
-// `signoz.attachDiscriminators` (called once after spec reflection)
-// promotes this marker into a real OpenAPI 3 `discriminator` field on
-// the openapi3.Schema. jsonschema-go.Schema has no Discriminator field
-// of its own, so this two-step (declare on the type, promote in the
-// spec) is what gets a literal `discriminator:` keyword into the
-// output without changing the wire shape.
-//
-// Adding a new threshold kind: add the variant to `JSONSchemaOneOf`
-// AND the mapping below.
+// PrepareJSONSchema marks the schema with x-signoz-discriminator;
+// signoz.attachDiscriminators promotes it to a real OpenAPI 3
+// discriminator after reflection.
 func (RuleThresholdData) PrepareJSONSchema(schema *jsonschema.Schema) error {
 	if schema.ExtraProperties == nil {
 		schema.ExtraProperties = map[string]any{}

--- a/pkg/types/ruletypes/threshold.go
+++ b/pkg/types/ruletypes/threshold.go
@@ -40,7 +40,10 @@ type thresholdBasic struct {
 	Spec BasicRuleThresholds `json:"spec" description:"The basic threshold specification (array of thresholds)."`
 }
 
-var _ jsonschema.OneOfExposer = RuleThresholdData{}
+var (
+	_ jsonschema.OneOfExposer = RuleThresholdData{}
+	_ jsonschema.Preparer     = RuleThresholdData{}
+)
 
 // JSONSchemaOneOf returns the oneOf variants for the RuleThresholdData discriminated union.
 // Each variant represents a different threshold kind with its corresponding spec schema.
@@ -48,6 +51,29 @@ func (RuleThresholdData) JSONSchemaOneOf() []any {
 	return []any{
 		thresholdBasic{},
 	}
+}
+
+// PrepareJSONSchema attaches the `x-signoz-discriminator` ExtraProperty.
+// `signoz.attachDiscriminators` (called once after spec reflection)
+// promotes this marker into a real OpenAPI 3 `discriminator` field on
+// the openapi3.Schema. jsonschema-go.Schema has no Discriminator field
+// of its own, so this two-step (declare on the type, promote in the
+// spec) is what gets a literal `discriminator:` keyword into the
+// output without changing the wire shape.
+//
+// Adding a new threshold kind: add the variant to `JSONSchemaOneOf`
+// AND the mapping below.
+func (RuleThresholdData) PrepareJSONSchema(schema *jsonschema.Schema) error {
+	if schema.ExtraProperties == nil {
+		schema.ExtraProperties = map[string]any{}
+	}
+	schema.ExtraProperties["x-signoz-discriminator"] = map[string]any{
+		"propertyName": "kind",
+		"mapping": map[string]string{
+			"basic": "#/components/schemas/RuletypesThresholdBasic",
+		},
+	}
+	return nil
 }
 
 func (r *RuleThresholdData) UnmarshalJSON(data []byte) error {

--- a/pkg/types/ruletypes/threshold.go
+++ b/pkg/types/ruletypes/threshold.go
@@ -29,9 +29,19 @@ func (ThresholdKind) Enum() []any {
 	}
 }
 
+// RuleThresholdData's Kind/Spec are tagged json:"-" so the schema
+// reflector skips them — the oneOf variants already declare both
+// fields. Wire serialization goes through MarshalJSON below.
 type RuleThresholdData struct {
-	Kind ThresholdKind `json:"kind" required:"true"`
-	Spec any           `json:"spec" required:"true"`
+	Kind ThresholdKind `json:"-"`
+	Spec any           `json:"-"`
+}
+
+func (r RuleThresholdData) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind ThresholdKind `json:"kind"`
+		Spec any           `json:"spec"`
+	}{r.Kind, r.Spec})
 }
 
 // thresholdBasic is the OpenAPI schema for a RuleThresholdData with kind=basic.

--- a/pkg/types/ruletypes/threshold.go
+++ b/pkg/types/ruletypes/threshold.go
@@ -36,8 +36,8 @@ type RuleThresholdData struct {
 
 // thresholdBasic is the OpenAPI schema for a RuleThresholdData with kind=basic.
 type thresholdBasic struct {
-	Kind ThresholdKind       `json:"kind" description:"The kind of threshold."`
-	Spec BasicRuleThresholds `json:"spec" description:"The basic threshold specification (array of thresholds)."`
+	Kind ThresholdKind       `json:"kind" description:"The kind of threshold." required:"true"`
+	Spec BasicRuleThresholds `json:"spec" description:"The basic threshold specification (array of thresholds)." required:"true"`
 }
 
 var (


### PR DESCRIPTION
## Summary
Both `RuleThresholdData` and `EvaluationEnvelope` model `{kind, spec}` discriminated unions on the wire, but the generated OpenAPI lacked the `discriminator:` keyword. Codegen tools (oapi-codegen, terraform-plugin-codegen-openapi) saw a bare \`oneOf\` and fell back to opaque \`Spec: any\`, forcing consumers to hand-write JSON-bridges instead of using typed Expand/Flatten.

After this PR:

```yaml
RuletypesEvaluationEnvelope:
  discriminator:
    propertyName: kind
    mapping:
      cumulative: '#/components/schemas/RuletypesEvaluationCumulative'
      rolling: '#/components/schemas/RuletypesEvaluationRolling'
  oneOf:
  - \$ref: '#/components/schemas/RuletypesEvaluationRolling'
  - \$ref: '#/components/schemas/RuletypesEvaluationCumulative'
  ...

RuletypesRuleThresholdData:
  discriminator:
    propertyName: kind
    mapping:
      basic: '#/components/schemas/RuletypesThresholdBasic'
  oneOf:
  - \$ref: '#/components/schemas/RuletypesThresholdBasic'
  ...
```

## How
\`jsonschema-go.Schema\` has no Discriminator field of its own (the keyword is OpenAPI-specific, not JSON Schema), and \`openapi-go\` only carries through \`x-\`-prefixed extras unchanged. So the discriminator goes through a marker convention:

1. Each parent type implements \`jsonschema.Preparer\` to set an \`x-signoz-discriminator\` extra property carrying \`propertyName\` and the per-kind \`mapping\`. Preparer runs after \`OneOfExposer\` populates the \`oneOf\` list, so both coexist cleanly.
2. A small \`attachDiscriminators\` pass in \`pkg/signoz/openapi.go\` runs after spec reflection, walks every component schema, promotes the marker into a real \`openapi3.Discriminator\`, and removes the marker so it doesn't leak into the rendered YAML.

The pass is generic — it doesn't know about RuleThresholdData or EvaluationEnvelope by name. Any future type that wants a discriminator just implements \`Preparer\` with the same marker convention.

## Wire shape
Unchanged. \`{kind: "<value>", spec: <variant>}\` is still what's sent and received. Only the published schema metadata changes.