### PR TITLE
fix: added fix for panel sync mode in non-view panels

### DIFF
--- a/frontend/src/hooks/dashboard/__test__/useDashboardCursorSyncMode.test.ts
+++ b/frontend/src/hooks/dashboard/__test__/useDashboardCursorSyncMode.test.ts
@@ -118,7 +118,7 @@ describe('useDashboardCursorSyncMode', () => {
 	describe.each([[PanelMode.DASHBOARD_EDIT], [PanelMode.STANDALONE_VIEW]])(
 		'in %s mode (cursor sync disabled)',
 		(panelMode) => {
-			it('returns the Crosshair default and ignores any stored value', () => {
+			it('returns None and ignores any stored value', () => {
 				useDashboardPreferencesStore.setState({
 					preferences: { 'dash-1': { cursorSyncMode: DashboardCursorSync.Tooltip } },
 				});
@@ -127,7 +127,7 @@ describe('useDashboardCursorSyncMode', () => {
 					useDashboardCursorSyncMode('dash-1', panelMode),
 				);
 
-				expect(result.current[0]).toBe(DashboardCursorSync.Crosshair);
+				expect(result.current[0]).toBe(DashboardCursorSync.None);
 			});
 
 			it('treats the setter as a no-op and does not write to the store', () => {
@@ -136,14 +136,14 @@ describe('useDashboardCursorSyncMode', () => {
 				);
 
 				act(() => {
-					result.current[1](DashboardCursorSync.None);
+					result.current[1](DashboardCursorSync.Tooltip);
 				});
 
 				expect(useDashboardPreferencesStore.getState().preferences).toStrictEqual(
 					{},
 				);
 				expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
-				expect(result.current[0]).toBe(DashboardCursorSync.Crosshair);
+				expect(result.current[0]).toBe(DashboardCursorSync.None);
 			});
 		},
 	);

--- a/frontend/src/hooks/dashboard/useDashboardCursorSyncMode.ts
+++ b/frontend/src/hooks/dashboard/useDashboardCursorSyncMode.ts
@@ -3,8 +3,6 @@ import { DashboardCursorSync } from 'lib/uPlotV2/plugins/TooltipPlugin/types';
 import { useDashboardPreference } from './useDashboardPreference';
 import { PanelMode } from 'container/DashboardContainer/visualization/panels/types';
 
-const DEFAULT_CURSOR_SYNC_MODE = DashboardCursorSync.Crosshair;
-
 const NOOP = (): void => {};
 
 export function useDashboardCursorSyncMode(
@@ -14,14 +12,14 @@ export function useDashboardCursorSyncMode(
 	const [value, setValue] = useDashboardPreference(
 		dashboardId,
 		'cursorSyncMode',
-		DEFAULT_CURSOR_SYNC_MODE,
+		DashboardCursorSync.Crosshair,
 	);
 
 	// Chart panels in edit / standalone modes don't participate in cross-panel
 	// sync, so surface the default with a no-op setter for them. Callers without
 	// a panelMode (e.g. dashboard settings) read/write the preference normally.
 	if (panelMode && panelMode !== PanelMode.DASHBOARD_VIEW) {
-		return [DEFAULT_CURSOR_SYNC_MODE, NOOP];
+		return [DashboardCursorSync.None, NOOP];
 	}
 
 	return [value, setValue];


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Cursor sync should only be active for charts rendered inside the dashboard view. In `DASHBOARD_EDIT` and `STANDALONE_VIEW` modes a chart is the only panel on screen, so cross-panel sync has nothing to sync with — but the hook was still returning `Crosshair`, which left a stray crosshair guide on the panel.

The fix swaps the disabled-mode return value from `DashboardCursorSync.Crosshair` to `DashboardCursorSync.None` so non-view panels render with no sync cursor at all. The setter remains a no-op for these modes (the user's stored preference is untouched), and the dashboard-view + dashboard-settings call sites continue to read/write the preference normally.

#### Screenshots / Screen Recordings (if applicable)
N/A

#### Issues closed by this PR
N/A

---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
`useDashboardCursorSyncMode` returned `DashboardCursorSync.Crosshair` (the default) when called from a panel in `DASHBOARD_EDIT` or `STANDALONE_VIEW` mode. Those panels don't participate in cross-panel sync, so the crosshair guide was being drawn for no reason.

#### Fix Strategy
Return `DashboardCursorSync.None` (paired with the existing no-op setter) for any `panelMode` other than `DASHBOARD_VIEW`. The stored user preference is read/written only in dashboard-view and the dashboard-settings call site (which passes no `panelMode`).

---

### 🧪 Testing Strategy

- Tests added/updated:
  - `frontend/src/hooks/dashboard/__test__/useDashboardCursorSyncMode.test.ts` — the `DASHBOARD_EDIT` / `STANDALONE_VIEW` parameterized cases now assert `DashboardCursorSync.None` is returned and that the setter is a no-op (write attempts to the store and localStorage are ignored).
- Manual verification: open a chart in edit mode and standalone view — no crosshair sync indicator is rendered; switching back to dashboard view restores the user's chosen sync mode.
- Edge cases covered: stored preference is `Tooltip` but panel is in edit mode → still returns `None`; setter invocation in disabled mode does not mutate store or localStorage.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: scoped to `useDashboardCursorSyncMode`. Affects only chart panels rendered in `DASHBOARD_EDIT` or `STANDALONE_VIEW`. Dashboard view and dashboard settings behavior is unchanged.
- Potential regressions: if any caller in edit/standalone mode was relying on receiving `Crosshair` from this hook, it will now receive `None`. No such caller was found — the hook's return is consumed by uPlot's cursor-sync plugin, which treats `None` as "no sync".
- Rollback plan: revert the single commit on this branch.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Removed the stray crosshair sync indicator from chart panels in edit and standalone view modes. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The unused `DEFAULT_CURSOR_SYNC_MODE` constant was inlined since it now only has one call site after the disabled-mode branch was changed.
- The dashboard-settings call site (which omits `panelMode`) is intentionally left on the read/write path so users can still toggle the preference globally.

---
