### PR TITLE
chore(service-account): remove api keys deprecation banner

### DIFF
--- a/frontend/src/container/Home/Home.tsx
+++ b/frontend/src/container/Home/Home.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useMutation, useQuery } from 'react-query';
 import { Color } from '@signozhq/design-tokens';
 import { Compass, Dot, House, Plus, Wrench } from '@signozhq/icons';
-import { Button, PersistedAnnouncementBanner } from '@signozhq/ui';
+import { Button } from '@signozhq/ui';
 import { Popover } from 'antd';
 import logEvent from 'api/common/logEvent';
 import { useGetMetricsOnboardingStatus } from 'api/generated/services/metrics';
@@ -11,7 +11,6 @@ import listUserPreferences from 'api/v1/user/preferences/list';
 import updateUserPreferenceAPI from 'api/v1/user/preferences/name/update';
 import Header from 'components/Header/Header';
 import { ENTITY_VERSION_V5 } from 'constants/app';
-import { LOCALSTORAGE } from 'constants/localStorage';
 import { ORG_PREFERENCES } from 'constants/orgPreferences';
 import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
@@ -271,23 +270,6 @@ export default function Home(): JSX.Element {
 
 	return (
 		<div className="home-container">
-			{user?.role === USER_ROLES.ADMIN && (
-				<PersistedAnnouncementBanner
-					type="info"
-					storageKey={LOCALSTORAGE.DISMISSED_API_KEYS_DEPRECATION_BANNER}
-					action={{
-						label: 'Go to Service Accounts',
-						onClick: (): void => history.push(ROUTES.SERVICE_ACCOUNTS_SETTINGS),
-					}}
-				>
-					<>
-						<strong>API keys</strong> have been deprecated in favour of{' '}
-						<strong>Service accounts</strong>. The existing API Keys have been
-						migrated to service accounts.
-					</>
-				</PersistedAnnouncementBanner>
-			)}
-
 			<div className="sticky-header">
 				<Header
 					leftComponent={


### PR DESCRIPTION

### 📄 Summary
-  remove api keys deprecation banner


### Screenshots 
<img width="1512" height="187" alt="Screenshot 2026-05-05 at 2 37 08 PM" src="https://github.com/user-attachments/assets/03b211b7-134b-43a4-9f9a-3409af0e0ebf" />
