### PR TITLE
feat: sidebar navigation shortcuts and tooltip UX improvement

### DIFF
--- a/frontend/src/container/SideNav/NavItem/NavItem.tsx
+++ b/frontend/src/container/SideNav/NavItem/NavItem.tsx
@@ -5,7 +5,6 @@ import { Pin, PinOff } from 'lucide-react';
 import { SidebarItem } from '../sideNav.types';
 
 import './NavItem.styles.scss';
-import './NavItem.styles.scss';
 
 export default function NavItem({
 	item,
@@ -16,6 +15,7 @@ export default function NavItem({
 	isPinned,
 	showIcon,
 	dataTestId,
+	shortcut,
 }: {
 	item: SidebarItem;
 	isActive: boolean;
@@ -25,6 +25,7 @@ export default function NavItem({
 	isPinned?: boolean;
 	showIcon?: boolean;
 	dataTestId?: string;
+	shortcut?: string;
 }): JSX.Element {
 	const { label, icon, isBeta, isNew } = item;
 
@@ -35,66 +36,74 @@ export default function NavItem({
 		onTogglePin?.(item);
 	};
 
+	const tooltipTitle = (
+		<span>
+			{label} {shortcut ? `(${shortcut.toUpperCase()})` : ''}
+		</span>
+	);
+
 	return (
-		<div
-			className={cx(
-				'nav-item',
-				isActive ? 'active' : '',
-				isDisabled ? 'disabled' : '',
-			)}
-			onClick={(event): void => {
-				if (isDisabled) {
-					return;
-				}
-				onClick(event);
-			}}
-			data-testid={dataTestId}
-		>
-			{showIcon && <div className="nav-item-active-marker" />}
-			<div className={cx('nav-item-data', isBeta ? 'beta-tag' : '')}>
-				{showIcon && <div className="nav-item-icon">{icon}</div>}
-
-				<div className="nav-item-label">{label}</div>
-
-				{isBeta && (
-					<div className="nav-item-beta">
-						<Tag bordered={false} className="sidenav-beta-tag">
-							Beta
-						</Tag>
-					</div>
+		<Tooltip title={tooltipTitle} placement="right" mouseEnterDelay={0.5}>
+			<div
+				className={cx(
+					'nav-item',
+					isActive ? 'active' : '',
+					isDisabled ? 'disabled' : '',
 				)}
+				onClick={(event): void => {
+					if (isDisabled) {
+						return;
+					}
+					onClick(event);
+				}}
+				data-testid={dataTestId}
+			>
+				{showIcon && <div className="nav-item-active-marker" />}
+				<div className={cx('nav-item-data', isBeta ? 'beta-tag' : '')}>
+					{showIcon && <div className="nav-item-icon">{icon}</div>}
 
-				{isNew && (
-					<div className="nav-item-new">
-						<Tag bordered={false} className="sidenav-new-tag">
-							New
-						</Tag>
-					</div>
-				)}
+					<div className="nav-item-label">{label}</div>
 
-				{onTogglePin && !isPinned && (
-					<Tooltip title="Add to shortcuts" placement="right">
-						<Pin
-							size={12}
-							className="nav-item-pin-icon"
-							onClick={handleTogglePinClick}
-							color="var(--Vanilla-400, #c0c1c3)"
-						/>
-					</Tooltip>
-				)}
+					{isBeta && (
+						<div className="nav-item-beta">
+							<Tag bordered={false} className="sidenav-beta-tag">
+								Beta
+							</Tag>
+						</div>
+					)}
 
-				{onTogglePin && isPinned && (
-					<Tooltip title="Remove from shortcuts" placement="right">
-						<PinOff
-							size={12}
-							className="nav-item-pin-icon"
-							onClick={handleTogglePinClick}
-							color="var(--Vanilla-400, #c0c1c3)"
-						/>
-					</Tooltip>
-				)}
+					{isNew && (
+						<div className="nav-item-new">
+							<Tag bordered={false} className="sidenav-new-tag">
+								New
+							</Tag>
+						</div>
+					)}
+
+					{onTogglePin && !isPinned && (
+						<Tooltip title="Add to shortcuts" placement="right">
+							<Pin
+								size={12}
+								className="nav-item-pin-icon"
+								onClick={handleTogglePinClick}
+								color="var(--Vanilla-400, #c0c1c3)"
+							/>
+						</Tooltip>
+					)}
+
+					{onTogglePin && isPinned && (
+						<Tooltip title="Remove from shortcuts" placement="right">
+							<PinOff
+								size={12}
+								className="nav-item-pin-icon"
+								onClick={handleTogglePinClick}
+								color="var(--Vanilla-400, #c0c1c3)"
+							/>
+						</Tooltip>
+					)}
+				</div>
 			</div>
-		</div>
+		</Tooltip>
 	);
 }
 
@@ -103,4 +112,5 @@ NavItem.defaultProps = {
 	isPinned: false,
 	showIcon: false,
 	dataTestId: undefined,
+	shortcut: undefined,
 };

--- a/frontend/src/container/SideNav/NavItem/NavItem.tsx
+++ b/frontend/src/container/SideNav/NavItem/NavItem.tsx
@@ -1,6 +1,7 @@
 import { Tag, Tooltip } from 'antd';
 import cx from 'classnames';
 import { Pin, PinOff } from 'lucide-react';
+import { useState } from 'react';
 
 import { SidebarItem } from '../sideNav.types';
 
@@ -28,6 +29,7 @@ export default function NavItem({
 	shortcut?: string;
 }): JSX.Element {
 	const { label, icon, isBeta, isNew } = item;
+	const [isPinHovered, setIsPinHovered] = useState(false);
 
 	const handleTogglePinClick = (
 		event: React.MouseEvent<SVGSVGElement, MouseEvent>,
@@ -43,7 +45,11 @@ export default function NavItem({
 	);
 
 	return (
-		<Tooltip title={tooltipTitle} placement="right" mouseEnterDelay={0.5}>
+		<Tooltip
+			title={isPinHovered ? null : tooltipTitle}
+			placement="right"
+			mouseEnterDelay={0.5}
+		>
 			<div
 				className={cx(
 					'nav-item',
@@ -86,6 +92,8 @@ export default function NavItem({
 								size={12}
 								className="nav-item-pin-icon"
 								onClick={handleTogglePinClick}
+								onMouseEnter={(): void => setIsPinHovered(true)}
+								onMouseLeave={(): void => setIsPinHovered(false)}
 								color="var(--Vanilla-400, #c0c1c3)"
 							/>
 						</Tooltip>
@@ -97,6 +105,8 @@ export default function NavItem({
 								size={12}
 								className="nav-item-pin-icon"
 								onClick={handleTogglePinClick}
+								onMouseEnter={(): void => setIsPinHovered(true)}
+								onMouseLeave={(): void => setIsPinHovered(false)}
 								color="var(--Vanilla-400, #c0c1c3)"
 							/>
 						</Tooltip>

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -637,7 +637,10 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 	const NAVIGATION_SHORTCUT_MAP = useMemo(
 		() =>
 			[
-				{ shortcut: GlobalShortcuts.NavigateToHome, route: ROUTES.HOME },
+				{ 	
+					shortcut: GlobalShortcuts.NavigateToHome, 
+					route: ROUTES.HOME 
+				},
 				{
 					shortcut: GlobalShortcuts.NavigateToServices,
 					route: ROUTES.APPLICATION,
@@ -646,7 +649,10 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 					shortcut: GlobalShortcuts.NavigateToTraces,
 					route: ROUTES.TRACES_EXPLORER,
 				},
-				{ shortcut: GlobalShortcuts.NavigateToLogs, route: ROUTES.LOGS },
+				{ 	
+					shortcut: GlobalShortcuts.NavigateToLogs, 
+					route: ROUTES.LOGS 
+				},
 				{
 					shortcut: GlobalShortcuts.NavigateToDashboards,
 					route: ROUTES.ALL_DASHBOARD,
@@ -683,7 +689,10 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 					shortcut: GlobalShortcuts.NavigateToMetricsViews,
 					route: ROUTES.METRICS_EXPLORER_VIEWS,
 				},
-				{ shortcut: GlobalShortcuts.NavigateToSettings, route: ROUTES.SETTINGS },
+				{ 	
+					shortcut: GlobalShortcuts.NavigateToSettings, 
+					route: ROUTES.SETTINGS 
+				},
 				{
 					shortcut: GlobalShortcuts.NavigateToSettingsIngestion,
 					route: ROUTES.INGESTION_SETTINGS,

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -446,7 +446,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 	};
 
 	const onClickHandler = useCallback(
-		(key: string, event: MouseEvent | null) => {
+		(key: keyof typeof routeConfig, event: MouseEvent | null) => {
 			const params = new URLSearchParams(search);
 			const availableParams = routeConfig[key];
 
@@ -626,7 +626,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 		} else if (item.key === 'quick-search') {
 			openCmdK();
 		} else if (item) {
-			onClickHandler(item?.key as string, event);
+			onClickHandler(item?.key as keyof typeof routeConfig, event);
 		}
 		logEvent('Sidebar V2: Menu clicked', {
 			menuRoute: item?.key,
@@ -634,102 +634,108 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 		});
 	};
 
+	const NAVIGATION_SHORTCUT_MAP = useMemo(
+		() =>
+			[
+				{ shortcut: GlobalShortcuts.NavigateToHome, route: ROUTES.HOME },
+				{
+					shortcut: GlobalShortcuts.NavigateToServices,
+					route: ROUTES.APPLICATION,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToTraces,
+					route: ROUTES.TRACES_EXPLORER,
+				},
+				{ shortcut: GlobalShortcuts.NavigateToLogs, route: ROUTES.LOGS },
+				{
+					shortcut: GlobalShortcuts.NavigateToDashboards,
+					route: ROUTES.ALL_DASHBOARD,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToMessagingQueues,
+					route: ROUTES.MESSAGING_QUEUES_OVERVIEW,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToAlerts,
+					route: ROUTES.LIST_ALL_ALERT,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToExceptions,
+					route: ROUTES.ALL_ERROR,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToTracesFunnel,
+					route: ROUTES.TRACES_FUNNELS,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToTracesViews,
+					route: ROUTES.TRACES_SAVE_VIEWS,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToMetricsSummary,
+					route: ROUTES.METRICS_EXPLORER,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToMetricsExplorer,
+					route: ROUTES.METRICS_EXPLORER_EXPLORER,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToMetricsViews,
+					route: ROUTES.METRICS_EXPLORER_VIEWS,
+				},
+				{ shortcut: GlobalShortcuts.NavigateToSettings, route: ROUTES.SETTINGS },
+				{
+					shortcut: GlobalShortcuts.NavigateToSettingsIngestion,
+					route: ROUTES.INGESTION_SETTINGS,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToSettingsBilling,
+					route: ROUTES.BILLING,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToSettingsNotificationChannels,
+					route: ROUTES.ALL_CHANNELS,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToSettingsServiceAccounts,
+					route: ROUTES.SERVICE_ACCOUNTS_SETTINGS,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToSettingsRoles,
+					route: ROUTES.ROLES_SETTINGS,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToSettingsMembers,
+					route: ROUTES.MEMBERS_SETTINGS,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToLogsPipelines,
+					route: ROUTES.LOGS_PIPELINES,
+				},
+				{
+					shortcut: GlobalShortcuts.NavigateToLogsViews,
+					route: ROUTES.LOGS_SAVE_VIEWS,
+				},
+			] as const,
+		[],
+	);
+
 	useEffect(() => {
-		registerShortcut(GlobalShortcuts.NavigateToHome, () =>
-			onClickHandler(ROUTES.HOME, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToServices, () =>
-			onClickHandler(ROUTES.APPLICATION, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToTraces, () =>
-			onClickHandler(ROUTES.TRACES_EXPLORER, null),
-		);
+		NAVIGATION_SHORTCUT_MAP.forEach(({ shortcut, route }) => {
+			registerShortcut(shortcut, () => onClickHandler(route, null));
+		});
 
-		registerShortcut(GlobalShortcuts.NavigateToLogs, () =>
-			onClickHandler(ROUTES.LOGS, null),
-		);
-
-		registerShortcut(GlobalShortcuts.NavigateToDashboards, () =>
-			onClickHandler(ROUTES.ALL_DASHBOARD, null),
-		);
-
-		registerShortcut(GlobalShortcuts.NavigateToMessagingQueues, () =>
-			onClickHandler(ROUTES.MESSAGING_QUEUES_OVERVIEW, null),
-		);
-
-		registerShortcut(GlobalShortcuts.NavigateToAlerts, () =>
-			onClickHandler(ROUTES.LIST_ALL_ALERT, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToExceptions, () =>
-			onClickHandler(ROUTES.ALL_ERROR, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToTracesFunnel, () =>
-			onClickHandler(ROUTES.TRACES_FUNNELS, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToTracesViews, () =>
-			onClickHandler(ROUTES.TRACES_SAVE_VIEWS, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToMetricsSummary, () =>
-			onClickHandler(ROUTES.METRICS_EXPLORER, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToMetricsExplorer, () =>
-			onClickHandler(ROUTES.METRICS_EXPLORER_EXPLORER, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToMetricsViews, () =>
-			onClickHandler(ROUTES.METRICS_EXPLORER_VIEWS, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToSettings, () =>
-			onClickHandler(ROUTES.SETTINGS, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToSettingsIngestion, () =>
-			onClickHandler(ROUTES.INGESTION_SETTINGS, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToSettingsBilling, () =>
-			onClickHandler(ROUTES.BILLING, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToSettingsNotificationChannels, () =>
-			onClickHandler(ROUTES.ALL_CHANNELS, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToSettingsServiceAccounts, () =>
-			onClickHandler(ROUTES.SERVICE_ACCOUNTS_SETTINGS, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToSettingsRoles, () =>
-			onClickHandler(ROUTES.ROLES_SETTINGS, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToSettingsMembers, () =>
-			onClickHandler(ROUTES.MEMBERS_SETTINGS, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToLogsPipelines, () =>
-			onClickHandler(ROUTES.LOGS_PIPELINES, null),
-		);
-		registerShortcut(GlobalShortcuts.NavigateToLogsViews, () =>
-			onClickHandler(ROUTES.LOGS_SAVE_VIEWS, null),
-		);
 		return (): void => {
-			deregisterShortcut(GlobalShortcuts.NavigateToHome);
-			deregisterShortcut(GlobalShortcuts.NavigateToServices);
-			deregisterShortcut(GlobalShortcuts.NavigateToTraces);
-			deregisterShortcut(GlobalShortcuts.NavigateToLogs);
-			deregisterShortcut(GlobalShortcuts.NavigateToDashboards);
-			deregisterShortcut(GlobalShortcuts.NavigateToAlerts);
-			deregisterShortcut(GlobalShortcuts.NavigateToExceptions);
-			deregisterShortcut(GlobalShortcuts.NavigateToMessagingQueues);
-			deregisterShortcut(GlobalShortcuts.NavigateToTracesFunnel);
-			deregisterShortcut(GlobalShortcuts.NavigateToMetricsSummary);
-			deregisterShortcut(GlobalShortcuts.NavigateToMetricsExplorer);
-			deregisterShortcut(GlobalShortcuts.NavigateToMetricsViews);
-			deregisterShortcut(GlobalShortcuts.NavigateToSettings);
-			deregisterShortcut(GlobalShortcuts.NavigateToSettingsIngestion);
-			deregisterShortcut(GlobalShortcuts.NavigateToSettingsBilling);
-			deregisterShortcut(GlobalShortcuts.NavigateToSettingsNotificationChannels);
-			deregisterShortcut(GlobalShortcuts.NavigateToSettingsServiceAccounts);
-			deregisterShortcut(GlobalShortcuts.NavigateToSettingsRoles);
-			deregisterShortcut(GlobalShortcuts.NavigateToSettingsMembers);
-			deregisterShortcut(GlobalShortcuts.NavigateToLogsPipelines);
-			deregisterShortcut(GlobalShortcuts.NavigateToLogsViews);
-			deregisterShortcut(GlobalShortcuts.NavigateToTracesViews);
+			NAVIGATION_SHORTCUT_MAP.forEach(({ shortcut }) => {
+				deregisterShortcut(shortcut);
+			});
 		};
-	}, [deregisterShortcut, onClickHandler, registerShortcut]);
+	}, [
+		deregisterShortcut,
+		onClickHandler,
+		registerShortcut,
+		NAVIGATION_SHORTCUT_MAP,
+	]);
 
 	const isPinnedItem = useMemo(
 		() =>
@@ -755,41 +761,48 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 	const renderNavItems = (
 		items: SidebarItem[],
 		allowPin?: boolean,
-	): JSX.Element => (
-		<>
-			{items.map((item, index) => (
-				<NavItem
-					showIcon
-					key={item.key || index}
-					item={item}
-					isActive={activeMenuKey === item.key}
-					isDisabled={
-						isWorkspaceBlocked &&
-						item.key !== ROUTES.BILLING &&
-						item.key !== ROUTES.SETTINGS
-					}
-					onTogglePin={
-						allowPin
-							? (item): void => {
-									logEvent(
-										`Sidebar V2: Menu item ${item.isPinned ? 'unpinned' : 'pinned'}`,
-										{
-											menuRoute: item.key,
-											menuLabel: item.label,
-										},
-									);
-									onTogglePin(item);
-								}
-							: undefined
-					}
-					onClick={(event): void => {
-						handleMenuItemClick(event, item);
-					}}
-					isPinned={isPinnedItem(item)}
-				/>
-			))}
-		</>
-	);
+	): JSX.Element => {
+		const shortcutMap = new Map<string, string>(
+			NAVIGATION_SHORTCUT_MAP.map((item) => [item.route, item.shortcut]),
+		);
+
+		return (
+			<>
+				{items.map((item, index) => (
+					<NavItem
+						showIcon
+						key={item.key || index}
+						item={item}
+						shortcut={shortcutMap.get(String(item.key))}
+						isActive={activeMenuKey === item.key}
+						isDisabled={
+							isWorkspaceBlocked &&
+							item.key !== ROUTES.BILLING &&
+							item.key !== ROUTES.SETTINGS
+						}
+						onTogglePin={
+							allowPin
+								? (item): void => {
+										logEvent(
+											`Sidebar V2: Menu item ${item.isPinned ? 'unpinned' : 'pinned'}`,
+											{
+												menuRoute: item.key,
+												menuLabel: item.label,
+											},
+										);
+										onTogglePin(item);
+									}
+								: undefined
+						}
+						onClick={(event): void => {
+							handleMenuItemClick(event, item);
+						}}
+						isPinned={isPinnedItem(item)}
+					/>
+				))}
+			</>
+		);
+	};
 
 	// Check scroll when menu items change
 	useEffect(() => {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
**What's changing?** I've added keyboard shortcut hints to the sidebar tooltips (like "Traces (Shift+T)") so users don't have to guess how to navigate faster. I also cleaned up the backend of the sidebar to make it easier to add new shortcuts and fixed some loose typing that could have caused bugs later.

#### Screenshot
<img width="1920" height="1080" alt="Screenshot 2026-05-05 at 8 57 24 PM" src="https://github.com/user-attachments/assets/adf63c29-528c-4768-905f-a53552f4ab89" />


---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [x] ♻️ Refactor

---

### 🧪 Testing Strategy

- Manual: Checked every shortcut. Hovering feels much better with the new 0.5s delay—no more tooltip spam.
- Auto: Ran tsc and the main frontend test suites; everything is green.
---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Low. Changes are localized to the sidebar navigation and tooltip display.
- Potential regressions: Incorrect shortcut mappings (already verified against GlobalShortcuts constants).
- Rollback plan: Revert commits to SideNav.tsx and NavItem.tsx.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Description | Added shortcut hints to sidebar tooltips and cleaned up navigation logic. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered


---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/UX and small refactor localized to sidebar navigation; main potential regression is incorrect route/shortcut mapping or tooltip behavior affecting discoverability.
> 
> **Overview**
> Sidebar navigation tooltips now display the relevant keyboard shortcut hint (passed from `SideNav` into `NavItem`) and apply a short hover delay to reduce tooltip noise.
> 
> Shortcut registration/deregistration is refactored into a single `NAVIGATION_SHORTCUT_MAP` list, and sidebar navigation routing is tightened by typing `onClickHandler` to `keyof typeof routeConfig` and using that type when handling menu clicks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 656c674f72926fa856c0ff44fe501e18134e7176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->