### PR TITLE
fix: use ms in prepareFillZeroArgsWithStep

### DIFF
--- a/pkg/querier/postprocess.go
+++ b/pkg/querier/postprocess.go
@@ -12,6 +12,7 @@ import (
 	"github.com/SigNoz/govaluate"
 
 	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/querybuilder"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 )
@@ -969,11 +970,19 @@ func (q *querier) prepareFillZeroArgsWithStep(functions []qbtypes.Function, req 
 	updatedFunctions := make([]qbtypes.Function, len(functions))
 	copy(updatedFunctions, functions)
 
+	// funcFillZero expects start/end in milliseconds. req.Start/req.End may
+	// arrive in s/ms/μs/ns depending on the caller; normalize via ToNanoSecs
+	// (same pattern used elsewhere in the codebase, e.g. RecommendedStepInterval)
+	// then convert to ms. Without this, an ns payload makes (end-start)/step
+	// 10^6× too large and OOMs the process.
+	startMs := querybuilder.ToNanoSecs(req.Start) / 1_000_000
+	endMs := querybuilder.ToNanoSecs(req.End) / 1_000_000
+
 	for i, fn := range updatedFunctions {
 		if fn.Name == qbtypes.FunctionNameFillZero && len(fn.Args) == 0 {
 			fn.Args = []qbtypes.FunctionArg{
-				{Value: float64(req.Start)},
-				{Value: float64(req.End)},
+				{Value: float64(startMs)},
+				{Value: float64(endMs)},
 				{Value: float64(step)},
 			}
 			updatedFunctions[i] = fn


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
This makes sure that it uses ms regardless of whether the input is ms or ns in prepareFillZeroArgsWithStep



#### Issues closed by this PR
Fixes https://github.com/SigNoz/platform-pod/issues/2205
---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
If the timestamp was in ns, then this function created too many iterations as the step is in ms.  So now the interval is converted to ms

#### Fix Strategy
The start and end is converted to ms

---

### 🧪 Testing Strategy
> How was this change validated?

- Manual verification:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: None
- Potential regressions:
- Rollback plan:

---