### PR TITLE
fix: added fix for all series in tooltip sync mode

### DIFF
--- a/frontend/src/lib/uPlotV2/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/Tooltip.tsx
@@ -25,9 +25,16 @@ export default function Tooltip({
 
 	const showHeader = showTooltipHeader || activeItem != null;
 	// With a single series the active item is fully represented in the header —
-	// hide the divider and list to avoid showing a duplicate row.
-	const showList = tooltipContent.length > 1;
-	const showDivider = showList && showHeader;
+	// hide the divider and list to avoid showing a duplicate row. When there is
+	// no active item (e.g. a sync-driven tooltip with no focused series), still
+	// render the row so the value is visible.
+	const showList =
+		tooltipContent.length > 1 ||
+		(tooltipContent.length === 1 && activeItem == null);
+	// Divider separates the active row rendered inside the header from the list.
+	// With no active item, the header is just a timestamp and the divider would
+	// sit directly under it without visual purpose.
+	const showDivider = showList && showHeader && activeItem != null;
 
 	return (
 		<div

--- a/frontend/src/lib/uPlotV2/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/Tooltip.tsx
@@ -24,16 +24,14 @@ export default function Tooltip({
 	);
 
 	const showHeader = showTooltipHeader || activeItem != null;
-	// With a single series the active item is fully represented in the header —
-	// hide the divider and list to avoid showing a duplicate row. When there is
-	// no active item (e.g. a sync-driven tooltip with no focused series), still
-	// render the row so the value is visible.
+	// A single row collapses into the header when it's the active item, but
+	// must stay in the list when there's no active item (e.g. sync-driven
+	// tooltips with no focused series) — otherwise the row would vanish.
 	const showList =
 		tooltipContent.length > 1 ||
 		(tooltipContent.length === 1 && activeItem == null);
-	// Divider separates the active row rendered inside the header from the list.
-	// With no active item, the header is just a timestamp and the divider would
-	// sit directly under it without visual purpose.
+	// The divider separates the active row in the header from the list; with
+	// no active item it has nothing to separate.
 	const showDivider = showList && showHeader && activeItem != null;
 
 	return (

--- a/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/syncDisplayHook.ts
+++ b/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/syncDisplayHook.ts
@@ -137,7 +137,7 @@ function applyReceiverSync({
 
 	if (commonKeys.length === 0) {
 		uPlotInstance.setSeries(null, { focus: false });
-		return [];
+		return noMatchResult;
 	}
 
 	if ((uPlotInstance.cursor.left ?? -1) < 0) {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

In `Tooltip`-mode dashboard cursor sync with `filterMode: All` (the "show every series" variant — opposed to `Filtered`), receiver tooltips for single-series panels were rendering with only the timestamp header and no row content. On a typical APM dashboard, hovering the multi-series Latency panel produced empty synced tooltips on the single-series Request rate / Error percentage panels — the user could see the cursor land but couldn't read the value.

There are two compounding issues fixed here:

1. `syncDisplayHook.applyReceiverSync` returned `[]` unconditionally from the "no `groupBy` overlap" branch, even though its own contract comment said the `All` filter mode "never returns `[]` so the synced tooltip is not suppressed when matches are missing." This was a latent contract bug — in practice it didn't drive the empty-tooltip rendering (downstream `buildTooltipContent` collapses `[]` and `null` to the same behavior in `All` mode), but it disagreed with the documented intent and would have bitten any future consumer that relied on the contract.
2. The visible bug lived in `Tooltip.tsx`. With a single tooltip row, the component's "single-row dedupe" hid the list under the assumption that the row must already be rendered as the active item in the header. That assumption holds for hover-driven tooltips, but breaks for sync-driven receivers: when `applyReceiverSync` calls `setSeries(null, { focus: false })` (which happens whenever there's no `groupBy` overlap with the source), the receiver has no active item, the header renders only the timestamp, and the list is hidden — leaving an empty tooltip frame.

Fixing only the `Tooltip.tsx` side surfaced a follow-on layout issue: with the row now in the list but no active item in the header, the divider sat directly under the timestamp with no padding above it, looking misplaced. Since the divider's purpose is to separate the active row from the list, dropping it when there's no active item is the cleanest fix.

#### Screenshots / Screen Recordings (if applicable)

### Issue Image
<img width="2056" height="1329" alt="image" src="https://github.com/user-attachments/assets/c466e4e3-4c1a-4d53-bacf-e9940a59668f" />


#### Issues closed by this PR

N/A

---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

`Tooltip.tsx` had `const showList = tooltipContent.length > 1;` — a single-row dedupe that assumed the only row was always the active item rendered inside the header. For sync-driven receivers, `applyReceiverSync` calls `setSeries(null, { focus: false })` when there's no `groupBy` overlap with the source, which clears `focusedSeriesIndex` and therefore `activeItem`. With one row but no active item, the list was hidden AND the header had no row to render — so the tooltip showed only the timestamp.

Separately, `syncDisplayHook.applyReceiverSync`'s `commonKeys.length === 0` branch always returned `[]`, contradicting the documented contract that `All` mode never returns `[]`.

#### Fix Strategy

1. `Tooltip.tsx` — extend `showList` so a single row also renders when there is no active item:
   ```ts
   const showList =
     tooltipContent.length > 1 ||
     (tooltipContent.length === 1 && activeItem == null);
   ```
   Drop the divider in the no-active-item case (`showDivider && activeItem != null`) since it has no row in the header to separate from the list.
2. `syncDisplayHook.ts` — return `noMatchResult` from the `commonKeys.length === 0` branch instead of `[]`, so the documented contract holds (`All` mode → `null`, `Filtered` → `[]`).

---

### 🧪 Testing Strategy

- Tests added/updated: none in this PR. Worth a small follow-up — `Tooltip.test.tsx` has a "single active item collapses into header" test but no companion "single non-active item still renders in list" test, and `syncDisplayHook.test.ts` doesn't currently exercise `SyncTooltipFilterMode.All` at all.
- Manual verification on the APM Metrics dashboard with `Tooltip` cursor sync, `filterMode: All`:
  - Hover the multi-series Latency panel → synced single-series Request rate and Error percentage tooltips render their row with a value at the synced timestamp.
  - Source Latency tooltip is unchanged (multi-row, with active item in header).
  - With `filterMode: Filtered` (the existing default), receivers still suppress when there are no matches — verified that the syncDisplayHook change doesn't accidentally re-enable rendering in that path.
- Edge cases covered:
  - Single-series receiver with no `groupBy` overlap with source (the original repro).
  - Multi-series receiver with overlap — header shows active item, list shows all rows including the active one (existing behavior preserved).
  - Single-series tooltip with active item set (e.g. local hover on a single-series panel) — still collapses into the header without a duplicate row in the list (existing dedupe preserved).
  - Empty tooltip content — no list, no divider (unchanged).

---

### ⚠️ Risk & Impact Assessment

- Blast radius: tooltip rendering for any uPlotV2 chart, but the behavioral change is gated on `tooltipContent.length === 1 && activeItem == null` — a state that previously rendered an empty tooltip and now renders a single row. No path that previously rendered a row is altered.
- Potential regressions: the only observable difference for non-sync tooltips is when a single-series panel ends up with `activeItem == null` (e.g. cursor moved without selecting any series). Previously that rendered an empty frame; now it renders the row. This matches the visible curve and is the more useful behavior.
- Rollback plan: revert this PR. The change is contained to two files and adds no schema, network, or persistence surface.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Synced tooltips on single-series panels now render their value when dashboard cursor sync is set to "All" mode. Previously the synced tooltip frame appeared empty for receivers that didn't share a `groupBy` with the source panel. |

---

### 📋 Checklist

- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The `syncDisplayHook` one-liner is a contract fix, not the visible-bug fix. In the current `buildTooltipContent`, `[]` and `null` produce the same rendering in `All` mode (because `allowedIndexes` is forced to `null` for All). The change still matters: the documented contract said this branch must not return `[]` in `All` mode, and any future consumer or refactor that distinguishes between the two would have hit a confusing bug.
- The `showDivider` change might look like a separate concern, but it's the same underlying assumption: the divider exists to separate the active row in the header from the list. Without an active row, the divider has nothing to separate, and visually it sits flush against the timestamp because the `pinnedItem` block (which would normally provide bottom padding) isn't rendered.
- The two existing single-series tests still pass: "renders single active item in header only, without a list" still holds because it sets `isActive: true`, which makes `activeItem != null` and triggers the dedupe. The new behavior is the previously-untested complement case.

---
