### PR TITLE
fix: added fix for pinning tooltips in case of multiple tooltip

### DIFF
--- a/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/TooltipPlugin.tsx
+++ b/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/TooltipPlugin.tsx
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import uPlot from 'uplot';
 import logEvent from 'api/common/logEvent';
 
+import { syncCursorRegistry } from './syncCursorRegistry';
 import { createSyncDisplayHook } from './syncDisplayHook';
 import {
 	createInitialControllerState,
@@ -12,6 +13,7 @@ import {
 	createSetSeriesHandler,
 	getPlot,
 	isScrollEventInPlot,
+	shouldShowTooltipForSync,
 	updatePlotVisibility,
 	updateWindowSize,
 } from './tooltipController';
@@ -300,49 +302,17 @@ export default function TooltipPlugin({
 			}
 		};
 
-		// Handles all tooltip-pin keyboard interactions:
-		//   Escape  — always releases the tooltip when pinned (never steals Escape
-		//             from other handlers since we do not call stopPropagation).
-		//   pinKey  — toggles: pins when hovering+unpinned, unpins when pinned.
-		const handleKeyDown = (event: KeyboardEvent): void => {
-			// Escape: release-only (never toggles on).
-			if (event.key === 'Escape') {
-				if (controller.pinned) {
-					logEvent(Events.TOOLTIP_UNPINNED, {
-						id: config.getId(),
-					});
-					dismissTooltip();
-				}
-				return;
-			}
-
-			if (event.key.toLowerCase() !== pinKey.toLowerCase()) {
-				return;
-			}
-
-			// Toggle off: P pressed while already pinned.
-			if (controller.pinned) {
-				logEvent(Events.TOOLTIP_UNPINNED, {
-					id: config.getId(),
-				});
-				dismissTooltip();
-				return;
-			}
-
-			// Toggle on: P pressed while hovering.
+		// Returns false when the cursor is offscreen so the caller can bail
+		// without scheduling side effects.
+		function pinAtCursor(): boolean {
 			const plot = getPlot(controller);
-			if (
-				!plot ||
-				!controller.hoverActive ||
-				controller.focusedSeriesIndex == null
-			) {
-				return;
+			if (!plot) {
+				return false;
 			}
-
 			const cursorLeft = plot.cursor.left ?? -1;
 			const cursorTop = plot.cursor.top ?? -1;
 			if (cursorLeft < 0 || cursorTop < 0) {
-				return;
+				return false;
 			}
 
 			const plotRect = plot.over.getBoundingClientRect();
@@ -360,7 +330,70 @@ export default function TooltipPlugin({
 				id: config.getId(),
 			});
 			scheduleRender(true);
+			return true;
+		}
+
+		// Escape always releases (never pins); pinKey toggles. Unpin fans out
+		// naturally — every pinned panel's document listener sees the same key
+		// event and dismisses itself — so only pinning needs a broadcast.
+		const handleKeyDown = (event: KeyboardEvent): void => {
+			if (event.key === 'Escape') {
+				if (controller.pinned) {
+					logEvent(Events.TOOLTIP_UNPINNED, {
+						id: config.getId(),
+					});
+					dismissTooltip();
+				}
+				return;
+			}
+
+			if (event.key.toLowerCase() !== pinKey.toLowerCase()) {
+				return;
+			}
+
+			if (controller.pinned) {
+				logEvent(Events.TOOLTIP_UNPINNED, {
+					id: config.getId(),
+				});
+				dismissTooltip();
+				return;
+			}
+
+			if (!controller.hoverActive || controller.focusedSeriesIndex == null) {
+				return;
+			}
+
+			if (!pinAtCursor()) {
+				return;
+			}
+
+			// Deferred to a macrotask so the same P keydown finishes dispatching
+			// to every panel's listener first. A microtask is not enough — those
+			// run between listener invocations, and once a receiver's `pinned`
+			// flips, its own listener takes the unpin branch on the same event.
+			if (syncTooltipWithDashboard) {
+				setTimeout(() => {
+					syncCursorRegistry.broadcastPin(syncKey);
+				}, 0);
+			}
 		};
+
+		// Skips the focusedSeriesIndex guard so single-series or no-overlap
+		// receivers still pin at the synced timestamp.
+		const handleSyncPinBroadcast = (): void => {
+			if (controller.pinned) {
+				return;
+			}
+			if (!shouldShowTooltipForSync(controller, syncTooltipWithDashboard)) {
+				return;
+			}
+			pinAtCursor();
+		};
+
+		const unsubscribeSyncPin =
+			syncTooltipWithDashboard && canPinTooltip
+				? syncCursorRegistry.subscribePin(syncKey, handleSyncPinBroadcast)
+				: null;
 
 		// Forward overlay clicks to the consumer-provided onClick callback.
 		const handleOverClick = (event: MouseEvent): void => {
@@ -453,6 +486,7 @@ export default function TooltipPlugin({
 			removeSetLegendHook();
 			removeSetCursorHook();
 			removeSyncDisplayHook?.();
+			unsubscribeSyncPin?.();
 			if (overClickHandler) {
 				const plot = getPlot(controller);
 				plot?.over.removeEventListener('click', overClickHandler);

--- a/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/syncCursorRegistry.ts
+++ b/frontend/src/lib/uPlotV2/plugins/TooltipPlugin/syncCursorRegistry.ts
@@ -17,6 +17,9 @@ const activeSeriesMetricBySyncKey = new Map<
 	Record<string, string> | null
 >();
 
+type SyncPinListener = () => void;
+const pinListenersBySyncKey = new Map<string, Set<SyncPinListener>>();
+
 export const syncCursorRegistry = {
 	setMetadata(syncKey: string, metadata: TooltipSyncMetadata | undefined): void {
 		metadataBySyncKey.set(syncKey, metadata);
@@ -35,5 +38,21 @@ export const syncCursorRegistry = {
 
 	getActiveSeriesMetric(syncKey: string): Record<string, string> | null {
 		return activeSeriesMetricBySyncKey.get(syncKey) ?? null;
+	},
+
+	subscribePin(syncKey: string, listener: SyncPinListener): () => void {
+		let listeners = pinListenersBySyncKey.get(syncKey);
+		if (!listeners) {
+			listeners = new Set();
+			pinListenersBySyncKey.set(syncKey, listeners);
+		}
+		listeners.add(listener);
+		return (): void => {
+			pinListenersBySyncKey.get(syncKey)?.delete(listener);
+		};
+	},
+
+	broadcastPin(syncKey: string): void {
+		pinListenersBySyncKey.get(syncKey)?.forEach((listener) => listener());
 	},
 };


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

In `Tooltip`-mode dashboard cursor sync, pressing `P` only pinned the panel the user was hovering — every other panel in the sync group dismissed its synced tooltip instead of pinning at the same timestamp. Users who wanted to compare multiple metrics at a fixed moment had to give up on the synced view as soon as they pinned anything.

Each `TooltipPlugin` instance owns its own `pinned` state, so this PR adds a tiny per-`syncKey` pubsub on `syncCursorRegistry` (`subscribePin` / `broadcastPin`). When the hovered panel pins via the `P` key, it broadcasts to every other panel in the same sync group; each receiver pins itself at its current synced cursor position. Unpin already fans out for free — every panel's document-level keydown / outside-click listener fires on the same event and dismisses itself — so only pinning needs the broadcast.

The broadcast is deferred to a macrotask (`setTimeout(..., 0)`) on purpose: the same `P` keydown is still being dispatched to every panel's listener, and a microtask wouldn't be enough since microtasks run *between* listener invocations. If the broadcast ran before all listeners had seen the event, receivers' `pinned` flag would flip mid-dispatch and their own listener would take the unpin-toggle branch on the same key press.

#### Screenshots / Screen Recordings (if applicable)

_Before:_ pressing `P` on the hovered Latency panel pinned only Latency; the synced Request rate / Error percentage tooltips disappeared.
_After:_ pressing `P` pins all panels in the sync group at the same timestamp. ESC or `P` on any of them unpins all; clicking outside any of them dismisses all.

#### Issues closed by this PR

N/A

---

### ✅ Change Type

- [x] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

`TooltipPlugin` is instantiated once per panel and each instance holds its own `pinned` state. Pin (`P`) and unpin (ESC / `P` again / outside-click) were already wired as document-level listeners on every instance, but there was no signal that crossed instances when one of them pinned — so panels that were sharing a synced cursor lost their tooltip the moment the user tried to lock it.

A receiver also couldn't pin on its own: the existing keyboard guard required `controller.focusedSeriesIndex != null`, which is null on receivers when there's no `groupBy` overlap with the source.

#### Fix Strategy

1. Extend `syncCursorRegistry` with `subscribePin(syncKey, listener)` / `broadcastPin(syncKey)`. Listeners are scoped per `syncKey` so unrelated dashboards don't interfere.
2. Factor the pin body out of `handleKeyDown` into `pinAtCursor()` so the same code path is used for keyboard-triggered pins and broadcast-triggered pins.
3. On the source's `P` keypress, after pinning locally, schedule `broadcastPin(syncKey)` via `setTimeout(..., 0)` to defer past the rest of the keydown dispatch.
4. Each plugin subscribes on mount (only when `syncMode === Tooltip` and `canPinTooltip`); the broadcast handler skips the `focusedSeriesIndex` guard so single-series or no-overlap receivers still pin, but keeps the `shouldShowTooltipForSync` check so panels scrolled offscreen don't silently pin.
5. Unsubscribe in the existing cleanup so plugin instances don't leak listeners across remounts.
6. No unpin broadcast — every pinned panel's existing listeners (keydown for `P` / `Esc`, mousedown for outside clicks, `setData` for data changes) already dismiss themselves on the same event, so unpin fans out without any new code.

---

### 🧪 Testing Strategy

- Tests added/updated: none in this PR. Existing single-panel pin tests in `TooltipPlugin.test.ts` still pass and cover the per-instance pin lifecycle. A follow-up to add a unit test for `syncCursorRegistry.subscribePin` / `broadcastPin` is worth doing but kept out of this PR to keep the change small.
- Manual verification on the APM Metrics dashboard with `Tooltip` cursor sync enabled:
  - Hover Latency, press `P` → Latency, Request rate, and Error percentage all pin at the same timestamp.
  - Press `P` again on any of the pinned panels → all three unpin.
  - Press `Esc` while pinned → all three unpin.
  - Click outside all tooltips → all three dismiss.
  - Confirmed that with `syncMode = Crosshair` (not `Tooltip`), pinning is still per-panel — the broadcast path only fires for tooltip-sync panels.
- Edge cases covered: receivers with no `groupBy` overlap with the source still pin (they'd previously had `focusedSeriesIndex == null`); receivers scrolled out of viewport are skipped via `shouldShowTooltipForSync`; receivers with no data at the cursor position are skipped because `isAnySeriesActive` is false.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: limited to the dashboard tooltip plugin. The pubsub is module-scoped, runs only on `P` keypresses (not in any hot path), and adds one `setTimeout(0)` per pin event. No effect on cursor-move performance, since the existing `setMetadata` / `setActiveSeriesMetric` flow on `syncCursorRegistry` is unchanged.
- Potential regressions: panels using `syncMode = None` or `syncMode = Crosshair` go through a code path with `syncTooltipWithDashboard === false` and skip both the broadcast and the subscription; their behavior is byte-identical to before. Single-panel pin (`canPinTooltip` without sync) is also unchanged. The only behavioral change is in `Tooltip`-mode sync.
- Rollback plan: revert this PR. The change is contained to two files and adds no schema, network, or persistence surface.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Pinning a tooltip with `P` on a dashboard panel that uses `Tooltip` cursor sync now pins every panel in the same sync group at the same timestamp; `Esc`, `P`, or clicking outside any of them unpins all of them. |

---

### 📋 Checklist

- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The `setTimeout(..., 0)` in `handleKeyDown` is load-bearing — `queueMicrotask` is *not* a drop-in replacement here because microtask checkpoints fire between event-listener invocations on the same event, and we specifically need to defer past the rest of the keydown dispatch. There's a comment at the call site spelling this out.
- `broadcastPin` only carries a "pin" intent — there is no "unpin" broadcast. Unpin flows naturally because every pinned panel has its own document-level `keydown` and `mousedown` listeners that dismiss on the same event. If we ever change those listener attachments, we'll need to revisit.
- Each pinned panel still logs its own `TOOLTIP_PINNED` / `TOOLTIP_UNPINNED` event. If product wants single-event analytics for a sync-pin (one event tagged with the panel count), that's a small follow-up — currently every panel that pins logs independently.
- The `shouldShowTooltipForSync` check on the broadcast subscriber means a receiver scrolled out of viewport (or with no data at the cursor) silently skips the pin. If we'd rather pin them anyway and let the user discover them when they scroll back, that's a one-line change.

---
