### PR TITLE
fix: dashboard date refresh

### DIFF
--- a/frontend/src/hooks/dashboard/useDashboardBootstrap.test.tsx
+++ b/frontend/src/hooks/dashboard/useDashboardBootstrap.test.tsx
@@ -1,0 +1,158 @@
+import { act, render } from '@testing-library/react';
+import { Modal } from 'antd';
+import { useDashboardBootstrap } from 'hooks/dashboard/useDashboardBootstrap';
+import { useTransformDashboardVariables } from 'hooks/dashboard/useTransformDashboardVariables';
+import useTabVisibility from 'hooks/useTabFocus';
+import { getMinMaxForSelectedTime } from 'lib/getMinMax';
+import { useDashboardStore } from 'providers/Dashboard/store/useDashboardStore';
+import { useDashboardQuery } from './useDashboardQuery';
+
+const mockDispatch = jest.fn();
+const mockSetDashboardData = jest.fn();
+const mockSetLayouts = jest.fn();
+const mockSetPanelMap = jest.fn();
+const mockResetDashboardStore = jest.fn();
+const mockGetUrlVariables = jest.fn();
+const mockUpdateUrlVariable = jest.fn();
+const mockRefetch = jest.fn();
+
+let mockGlobalTime = {
+	selectedTime: 'custom',
+	minTime: 1710000000000000000,
+	maxTime: 1710000300000000000,
+	isAutoRefreshDisabled: true,
+};
+
+let currentQueryData: unknown;
+
+jest.mock('react-i18next', () => ({
+	useTranslation: (): { t: (key: string) => string } => ({
+		t: (key: string): string => key,
+	}),
+}));
+
+jest.mock('react-redux', () => ({
+	useDispatch: jest.fn(() => mockDispatch),
+	useSelector: jest.fn(
+		(
+			selectorFn: (state: { globalTime: typeof mockGlobalTime }) => unknown,
+		): unknown => selectorFn({ globalTime: mockGlobalTime }),
+	),
+}));
+
+jest.mock('hooks/useTabFocus', () => jest.fn(() => true));
+jest.mock('hooks/dashboard/useDashboardVariablesSync', () => ({
+	useDashboardVariablesSync: jest.fn(),
+}));
+jest.mock('./useDashboardQuery', () => ({
+	useDashboardQuery: jest.fn(),
+}));
+jest.mock('hooks/dashboard/useTransformDashboardVariables', () => ({
+	useTransformDashboardVariables: jest.fn(),
+}));
+jest.mock('providers/Dashboard/store/useDashboardStore', () => ({
+	useDashboardStore: jest.fn(),
+}));
+jest.mock('providers/Dashboard/initializeDefaultVariables', () => ({
+	initializeDefaultVariables: jest.fn(),
+}));
+jest.mock('lib/dashboard/getUpdatedLayout', () => ({
+	getUpdatedLayout: jest.fn(() => []),
+}));
+jest.mock('providers/Dashboard/util', () => ({
+	sortLayout: jest.fn((layout) => layout),
+}));
+jest.mock('lib/getMinMax', () => ({
+	getMinMaxForSelectedTime: jest.fn(),
+}));
+
+function TestComponent({ confirm }: { confirm: typeof Modal.confirm }): null {
+	useDashboardBootstrap('dashboard-1', { confirm });
+	return null;
+}
+
+describe('useDashboardBootstrap', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		mockGlobalTime = {
+			selectedTime: 'custom',
+			minTime: 1710000000000000000,
+			maxTime: 1710000300000000000,
+			isAutoRefreshDisabled: true,
+		};
+
+		jest.mocked(useDashboardStore as unknown as jest.Mock).mockReturnValue({
+			setDashboardData: mockSetDashboardData,
+			setLayouts: mockSetLayouts,
+			setPanelMap: mockSetPanelMap,
+			resetDashboardStore: mockResetDashboardStore,
+		});
+
+		jest
+			.mocked(useTransformDashboardVariables as unknown as jest.Mock)
+			.mockReturnValue({
+				getUrlVariables: mockGetUrlVariables,
+				updateUrlVariable: mockUpdateUrlVariable,
+				transformDashboardVariables: <T,>(data: T): T => data,
+			});
+
+		jest.mocked(useTabVisibility as unknown as jest.Mock).mockReturnValue(true);
+		jest
+			.mocked(useDashboardQuery as unknown as jest.Mock)
+			.mockImplementation(() => ({
+				data: currentQueryData,
+				isLoading: false,
+				isError: false,
+				isFetching: false,
+				error: null,
+				refetch: mockRefetch,
+			}));
+	});
+
+	it('keeps minTime and maxTime unchanged for custom range on refresh confirm', () => {
+		const initialDashboard = {
+			id: 'dashboard-1',
+			updatedAt: '2024-01-01T00:00:00.000Z',
+			data: { layout: [], panelMap: {}, variables: {} },
+		};
+
+		const updatedDashboard = {
+			id: 'dashboard-1',
+			updatedAt: '2024-01-01T01:00:00.000Z',
+			data: { layout: [], panelMap: {}, variables: {} },
+		};
+
+		const mockConfirm = jest.fn<
+			ReturnType<typeof Modal.confirm>,
+			Parameters<typeof Modal.confirm>
+		>(() => ({ destroy: jest.fn(), update: jest.fn() }));
+
+		currentQueryData = { data: initialDashboard };
+		const { rerender } = render(<TestComponent confirm={mockConfirm} />);
+
+		expect(mockConfirm).not.toHaveBeenCalled();
+
+		currentQueryData = { data: updatedDashboard };
+		rerender(<TestComponent confirm={mockConfirm} />);
+
+		expect(mockConfirm).toHaveBeenCalledTimes(1);
+		const firstCall = mockConfirm.mock.calls[0];
+		expect(firstCall).toBeDefined();
+		const [confirmProps] = firstCall as Parameters<typeof Modal.confirm>;
+
+		act(() => {
+			confirmProps.onOk?.();
+		});
+
+		expect(getMinMaxForSelectedTime).not.toHaveBeenCalled();
+		expect(mockDispatch).toHaveBeenCalledWith({
+			type: 'UPDATE_TIME_INTERVAL',
+			payload: {
+				selectedTime: 'custom',
+				minTime: mockGlobalTime.minTime,
+				maxTime: mockGlobalTime.maxTime,
+			},
+		});
+	});
+});

--- a/frontend/src/hooks/dashboard/useDashboardBootstrap.ts
+++ b/frontend/src/hooks/dashboard/useDashboardBootstrap.ts
@@ -102,11 +102,19 @@ export function useDashboardBootstrap(
 				onOk() {
 					setDashboardData(updatedDashboardData);
 
-					const { maxTime, minTime } = getMinMaxForSelectedTime(
-						globalTime.selectedTime,
-						globalTime.minTime,
-						globalTime.maxTime,
-					);
+					const { maxTime, minTime } =
+						globalTime.selectedTime === 'custom'
+							? {
+									// For custom ranges, min/max are already stored in nanoseconds.
+									// Recomputing via getMinMaxForSelectedTime would multiply them again.
+									maxTime: globalTime.maxTime,
+									minTime: globalTime.minTime,
+								}
+							: getMinMaxForSelectedTime(
+									globalTime.selectedTime,
+									globalTime.minTime,
+									globalTime.maxTime,
+								);
 					dispatch({
 						type: UPDATE_TIME_INTERVAL,
 						payload: { maxTime, minTime, selectedTime: globalTime.selectedTime },


### PR DESCRIPTION
## Pull Request
This change fixes a dashboard refresh regression where custom time ranges could become invalid after confirming the “dashboard updated” prompt.
The issue happened because refresh logic recomputed time bounds for all modes, but custom mode already stores minTime/maxTime in nanoseconds and should not be recalculated.

The fix preserves existing minTime and maxTime when selectedTime is custom, while keeping existing behavior for non-custom ranges.
This is the safest approach because it changes only the incorrect branch, avoids impacting other time presets, and directly aligns with how custom range values are represented.

To prevent regressions, a focused unit test was added for useDashboardBootstrap to verify that custom-range refresh:

does not call getMinMaxForSelectedTime
dispatches UPDATE_TIME_INTERVAL with unchanged custom minTime/maxTime values


#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

#### Fix Strategy
> How does this PR address the root cause?

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification:
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix / Maintenance |
| Description | User-facing summary |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
