### PR TITLE
fix: upgrade bytedance/sonic to v1.15.1 for Go 1.26+ compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -112,8 +112,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.1 // indirect
-	github.com/bytedance/sonic/loader v0.3.0 // indirect
+	github.com/bytedance/sonic v1.15.1 // indirect
+	github.com/bytedance/sonic/loader v0.5.1 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,12 @@ github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.14.1 h1:FBMC0zVz5XUmE4z9wF4Jey0An5FueFvOsTKKKtwIl7w=
 github.com/bytedance/sonic v1.14.1/go.mod h1:gi6uhQLMbTdeP0muCnrjHLeCUPyb70ujhnNlhOylAFc=
+github.com/bytedance/sonic v1.15.1 h1:nJD5PmM0vY7J8CT6MxoqbVAAMhkSmV2HgRAUrrpLoOw=
+github.com/bytedance/sonic v1.15.1/go.mod h1:mT2NbXunuaEbnZ+mRIX/vYqKISmgEuHFDI4UzmKx2SA=
 github.com/bytedance/sonic/loader v0.3.0 h1:dskwH8edlzNMctoruo8FPTJDF3vLtDT0sXZwvZJyqeA=
 github.com/bytedance/sonic/loader v0.3.0/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
+github.com/bytedance/sonic/loader v0.5.1 h1:Ygpfa9zwRCCKSlrp5bBP/b/Xzc3VxsAW+5NIYXrOOpI=
+github.com/bytedance/sonic/loader v0.5.1/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
@@ -1080,6 +1084,7 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

`bytedance/sonic` v1.14.1 references `GoMapIterator`, an internal Go runtime type that was removed in Go 1.24. This causes a compile-time failure on Go 1.24 and later with the error:

```
# github.com/bytedance/sonic/internal/rt
undefined: GoMapIterator
```

Upgrading to v1.15.1 (and its companion `sonic/loader` to v0.5.1) drops the dependency on that removed internal type and restores compatibility with Go 1.24+.

#### Issues closed by this PR
N/A

---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
`sonic` v1.14.1 calls `GoMapIterator` via `stubs.go`, an internal runtime struct that was removed in Go 1.24 as part of a runtime internals cleanup. Because `sonic` is an indirect dependency pulled in by `gin`'s JSON binding layer, every build against Go 1.24+ fails at compile time — even if `sonic` is never called directly.

#### Fix Strategy
Upgrade `github.com/bytedance/sonic` from v1.14.1 → v1.15.1 and `github.com/bytedance/sonic/loader` from v0.3.0 → v0.5.1. These releases explicitly add Go 1.24+ support by replacing the removed internal type references.

---

### 🧪 Testing Strategy

- Tests added/updated: none required — this is a pure dependency version bump
- Manual verification: full binary build (`make go-build-community-amd64`) confirmed clean on Go 1.26.2
- Edge cases covered: `pkg/http/binding` tests (the direct consumer of sonic via gin) pass with `-race`

---

### ⚠️ Risk & Impact Assessment

- Blast radius: `sonic` is the JSON codec used by gin's binding layer — affects all HTTP request/response encoding. The API surface is identical; sonic v1.15.1 is a drop-in compatible patch release.
- Potential regressions: none expected; sonic patch releases do not change codec behaviour
- Rollback plan: revert `go.mod`/`go.sum` to pin v1.14.1 and downgrade Go toolchain to ≤1.23

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | OSS / Cloud / Enterprise |
| Change Type | Bug Fix |
| Description | Build now succeeds on Go 1.24 and later |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

This is a prerequisite for any branch targeting Go 1.24+. The only files changed are `go.mod` and `go.sum` — no application code is touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; main impact is JSON codec behavior/perf via `sonic`, but this is a patch-level upgrade intended to restore Go 1.24+ build compatibility.
> 
> **Overview**
> Upgrades the indirect JSON dependency `github.com/bytedance/sonic` from `v1.14.1` to `v1.15.1` (and `sonic/loader` from `v0.3.0` to `v0.5.1`) to avoid Go 1.24+ build failures.
> 
> Updates `go.mod`/`go.sum` accordingly; no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21bb9264a36047bb76bc3c4f06fd0bf754e9e4e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->