### PR TITLE
chore: filter out warning and info level events

### DIFF
--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -327,6 +327,11 @@ function App(): JSX.Element {
 					replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
 					replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
 					beforeSend(event) {
+						// Drop the event if its level is 'warning' or 'info'
+						if (event.level === 'warning' || event.level === 'info') {
+							return null;
+						}
+
 						const sessionReplayUrl = posthog.get_session_replay_url?.({
 							withTimestamp: true,
 						});


### PR DESCRIPTION
### 📄 Summary
Filters out **`warning`** and **`info`** level events in the frontend error-reporting pipeline by dropping them in `beforeSend`, reducing noise and keeping reporting focused on actionable/error-level signals.

#### Screenshots / Screen Recordings (if applicable)
N/A

#### Issues closed by this PR
N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
Frontend error reporting was sending non-actionable `warning`/`info` level events, creating alerting/triage noise and burying real problems.

#### Fix Strategy
Short-circuit in `beforeSend(event)` to **return `null`** when `event.level` is `warning` or `info`, preventing those events from being sent.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A
- Manual verification:
  - Trigger a known `warning` / `info` level event and confirm it is **not** sent upstream
  - Trigger an `error` level event and confirm it **is** still sent as expected
- Edge cases covered:
  - Events without a `level` set (should continue through existing flow)
  - Ensure replay URL enrichment still runs for non-filtered events

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Frontend error-reporting only
- Potential regressions: Accidentally suppressing useful `warning` telemetry (by design); misclassification if upstream sets unexpected `level` values
- Rollback plan: Revert the change (restores prior event volume)

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance |
| Description | Reduce error-reporting noise by dropping `warning` and `info` level frontend events. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers
- This intentionally only drops `warning`/`info`; `error` and above still flow through unchanged.
- Change is localized to `frontend/src/AppRoutes/index.tsx` `beforeSend`.