### PR TITLE
fix(rules): handle legacy LOG_BASED_ALERT value when patching a rule

### DIFF
--- a/pkg/query-service/rules/manager.go
+++ b/pkg/query-service/rules/manager.go
@@ -952,6 +952,7 @@ func (m *Manager) PatchRule(ctx context.Context, ruleStr string, id valuer.UUID)
 		m.logger.ErrorContext(ctx, "failed to unmarshal rule from db", slog.String("rule.id", id.StringValue()), errors.Attr(err))
 		return nil, err
 	}
+	storedRule.NormalizeAlertType()
 
 	if err := json.Unmarshal([]byte(ruleStr), &storedRule); err != nil {
 		m.logger.ErrorContext(ctx, "failed to unmarshal patched rule with given id", slog.String("rule.id", id.StringValue()), errors.Attr(err))

--- a/pkg/types/ruletypes/api_params.go
+++ b/pkg/types/ruletypes/api_params.go
@@ -36,6 +36,15 @@ func (AlertType) Enum() []any {
 	}
 }
 
+// NormalizeAlertType corrects known legacy alert type values that were stored
+// before strict validation was introduced. The corrected value is persisted on
+// the next write, so the DB self-heals without a migration.
+func (r *PostableRule) NormalizeAlertType() {
+	if r.AlertType == "LOG_BASED_ALERT" {
+		r.AlertType = AlertTypeLogs
+	}
+}
+
 const (
 	DefaultSchemaVersion  = "v1"
 	SchemaVersionV2Alpha1 = "v2alpha1"


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Fix the error encountered in disabling the alert which might have alert type value already stored that doesn't fit the currently used enum. See Bug Context heading below for more details.

#### Issues closed by this PR
https://github.com/SigNoz/engineering-pod/issues/4814

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
PR #10808 added `storedRule.Validate()` in `PatchRule`. The stored rule for some customers has `alertType: "LOG_BASED_ALERT"` (no 'S') — a value found in some customer tenants. `Validate()` rejects it, so any PATCH (including toggling `disabled`) fails.

#### Fix Strategy
After unmarshalling the stored rule from the DB, call `NormalizeAlertType()` which rewrites `LOG_BASED_ALERT → LOGS_BASED_ALERT`. This happens before the patch is merged, so if the caller explicitly sends the wrong value it still gets validated and rejected. The normalization is a one-liner on `PostableRule` in `api_params.go` with no impact on any other code path.

---

### 🧪 Testing Strategy

- Tests added/updated: no
- Manual verification: reproduced the error by patching a rule with the legacy alertType in the DB; confirmed the patch now succeeds and the corrected value is persisted

---

### ⚠️ Risk & Impact Assessment

- Blast radius: only `PatchRule` (the PATCH `/api/v1|v2/rules/{id}` endpoint); `CreateRule` and `EditRule` are untouched
- Potential regressions: none
- Rollback plan: no schema or DB side effects

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Disabling or enabling an alert rule no longer fails for rules that have a legacy `LOG_BASED_ALERT` alert type stored in the database |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

`NormalizeAlertType` is intentionally placed **before** `json.Unmarshal(ruleStr, &storedRule)` so the patch JSON wins: if someone explicitly sends a bad `alertType` in the patch body, it overrides the normalization and `Validate()` rejects it as expected.