### PR TITLE
fix(signup): add frontend password validation matching backend rules

### DIFF
--- a/frontend/src/pages/SignUp/SignUp.tsx
+++ b/frontend/src/pages/SignUp/SignUp.tsx
@@ -27,6 +27,39 @@ type FormValues = {
 	isAnonymous: boolean;
 };
 
+const validatePassword = (pwd: string): string | null => {
+	if (pwd.length < 12) {
+		return 'Password must be at least 12 characters long';
+	}
+
+	const symbols = '~!@#$%^&*()_+`-={}|[]\\:"<>?,./';
+	let hasUpperCase = false;
+	let hasLowerCase = false;
+	let hasNumber = false;
+	let hasSymbol = false;
+
+	for (let i = 0; i < pwd.length; i++) {
+		const char = pwd[i];
+		if (char >= 'a' && char <= 'z') {
+			hasLowerCase = true;
+		} else if (char >= 'A' && char <= 'Z') {
+			hasUpperCase = true;
+		} else if (char >= '0' && char <= '9') {
+			hasNumber = true;
+		} else if (symbols.includes(char)) {
+			hasSymbol = true;
+		} else {
+			return 'Password contains invalid characters';
+		}
+	}
+
+	if (!hasUpperCase || !hasLowerCase || !hasNumber || !hasSymbol) {
+		return 'Password must contain at least one uppercase letter, one lowercase letter, one number, and one symbol';
+	}
+
+	return null;
+};
+
 function SignUp(): JSX.Element {
 	const [loading, setLoading] = useState(false);
 	const [confirmPasswordTouched, setConfirmPasswordTouched] = useState(false);
@@ -39,6 +72,7 @@ function SignUp(): JSX.Element {
 	// Watch form values for reactive validation
 	const email = Form.useWatch('email', form);
 	const password = Form.useWatch('password', form);
+	const passwordError = password ? validatePassword(password) : null;
 	const confirmPassword = Form.useWatch('confirmPassword', form);
 
 	const signUp = async (values: FormValues): Promise<void> => {
@@ -95,7 +129,8 @@ function SignUp(): JSX.Element {
 			Boolean(email?.trim()) &&
 			Boolean(password?.trim()) &&
 			Boolean(confirmPassword?.trim()) &&
-			password === confirmPassword,
+			password === confirmPassword &&
+			validatePassword(password) === null,
 		[loading, email, password, confirmPassword],
 	);
 
@@ -137,6 +172,8 @@ function SignUp(): JSX.Element {
 								<FormContainer.Item
 									name="password"
 									validateTrigger="onBlur"
+									validateStatus={passwordError ? 'error' : undefined}
+									help={passwordError}
 									rules={[{ required: true, message: 'Please enter password!' }]}
 								>
 									<AntdInput.Password


### PR DESCRIPTION
## Problem
The signup form had no password validation on the frontend — it only checked 
that the field was non-empty. The backend enforces strict rules via 
`IsPasswordValid()` in `pkg/types/factor_password.go`:
- Minimum 12 characters
- At least one uppercase letter [A-Z]
- At least one lowercase letter [a-z]
- At least one number [0-9]
- At least one symbol from the allowed set

This caused a poor UX where users would fill out the entire form, hit submit, 
and only then receive a cryptic backend error about invalid password.

## Fix
Added `validatePassword()` in `SignUp.tsx` that mirrors the backend rules exactly.
Users now get clear inline feedback on the password field before submitting.

## Changes
- Added `validatePassword()` function matching backend `IsPasswordValid()` logic
- Added `passwordError` derived state shown inline on the password field
- Updated `isValidForm` to require valid password before enabling submit button

Fixes #11111

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes signup form validation and could block some passwords client-side (e.g., non-ASCII letters/numbers) if the frontend rules diverge from backend expectations.
> 
> **Overview**
> Adds inline password policy validation to the signup form via a new `validatePassword()` helper (min length, required character classes, allowed symbol set, and invalid-character rejection), surfacing errors directly on the password field.
> 
> Updates submit gating (`isValidForm`) to require both password match and a passing password-policy check before enabling account creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 809f9b05bb40f3226bfa66e1409c8c77552555e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->