### PR TITLE
fix(alertmanager): initialize nil Headers map in email.New()

### DIFF
--- a/pkg/alertmanager/alertmanagernotify/email/email.go
+++ b/pkg/alertmanager/alertmanagernotify/email/email.go
@@ -48,6 +48,9 @@ var errNoAuthUsernameConfigured = errors.NewInternalf(errors.CodeInternal, "no a
 
 // New returns a new Email notifier.
 func New(c *config.EmailConfig, t *template.Template, l *slog.Logger) *Email {
+	if c.Headers == nil {
+		c.Headers = make(map[string]string)
+	}
 	if _, ok := c.Headers["Subject"]; !ok {
 		c.Headers["Subject"] = config.DefaultEmailSubject
 	}


### PR DESCRIPTION
## Problem
When `EmailConfig.Headers` is nil (not explicitly initialized in the config),
the `New()` function in `email.go` panics with `panic: nil map` because it
performs map lookups directly without checking if the map exists initialized.

Reported in #11100.

## Fix
Added a nil check at the start of `New()` to initialize the map before any access:

if c.Headers == nil {
    c.Headers = make(map[string]string)
}

## Changes
- 3-line fix in `pkg/alertmanager/alertmanagernotify/email/email.go`

Fixes #11100

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: initializes a nil map to avoid a runtime panic; behavior only changes for configs that omit `headers`.
> 
> **Overview**
> Fixes a panic in the email notifier by **initializing `EmailConfig.Headers` when it’s nil** before setting default `Subject`/`To`/`From` values in `email.New()`.
> 
> This makes email notification setup resilient when `headers` isn’t explicitly configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 974224b96426085238c8a5df88456a4232b3ad33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->