### PR TITLE
test(flaky): try reduce flakyness by increasing timeout

### DIFF
--- a/frontend/src/container/ExplorerOptions/__tests__/ExplorerOptionWrapper.test.tsx
+++ b/frontend/src/container/ExplorerOptions/__tests__/ExplorerOptionWrapper.test.tsx
@@ -268,6 +268,7 @@ describe('ExplorerOptionWrapper', () => {
 		});
 
 		it('should test actual handleExport function with generateExportToDashboardLink and verify useUpdateDashboard is NOT called', async () => {
+			jest.setTimeout(15000);
 			const user = userEvent.setup({ pointerEventsCheck: 0 });
 
 			// Mock the safeNavigate function

--- a/frontend/src/container/MetricsExplorer/MetricDetails/__tests__/Metadata.test.tsx
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/__tests__/Metadata.test.tsx
@@ -151,6 +151,7 @@ describe('Metadata', () => {
 	});
 
 	it('should update the metadata when the form is submitted', async () => {
+		jest.setTimeout(15000);
 		render(
 			<Metadata
 				metricName={MOCK_METRIC_NAME}

--- a/frontend/src/container/QueryBuilder/filters/HavingFilter/__tests__/utils.test.tsx
+++ b/frontend/src/container/QueryBuilder/filters/HavingFilter/__tests__/utils.test.tsx
@@ -79,6 +79,8 @@ describe('Having filter behaviour', () => {
 	});
 
 	it('Autocomplete in the having filter', async () => {
+		// Long test with many userEvent operations - needs extended timeout
+		jest.setTimeout(30000);
 		const onChange = jest.fn();
 		const user = userEvent.setup();
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

These tests depends heavily on userEvent, waitFor, etc... each interaction is a little heavy and the timeout for each one of them is usually 1s (waitFor), so it will be slower if the machine is not stronger enough.

The alternative is to rewrite the test to use fireEvent (less real), or try reduce the test size (not so good as well)

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [x] 🧪 Test-only