### PR TITLE
feat(identn): add trusted-header IdentN provider

### DIFF
--- a/pkg/identn/config.go
+++ b/pkg/identn/config.go
@@ -14,6 +14,9 @@ type Config struct {
 
 	// Config for impersonation identN resolver
 	Impersonation ImpersonationConfig `mapstructure:"impersonation"`
+
+	// Config for trusted-header identN resolver
+	TrustedHeader TrustedHeaderConfig `mapstructure:"trusted_header"`
 }
 
 type ImpersonationConfig struct {
@@ -37,6 +40,28 @@ type APIKeyConfig struct {
 	Headers []string `mapstructure:"headers"`
 }
 
+type TrustedHeaderConfig struct {
+	// Toggles the identN resolver. Defaults to false. Only enable when SigNoz is
+	// deployed behind a reverse proxy that strips client-supplied headers and injects
+	// its own (e.g., Authentik forward-auth, oauth2-proxy). Otherwise any client can
+	// forge identity by setting the header.
+	Enabled bool `mapstructure:"enabled"`
+
+	// EmailHeader is the request header that carries the authenticated user's email.
+	// Defaults to "X-Forwarded-Email" (the de-facto convention for oauth2-proxy and
+	// similar). Authentik users typically set this to "X-Authentik-Email".
+	EmailHeader string `mapstructure:"email_header"`
+
+	// NameHeader is optional; used during auto-provisioning to populate the user's
+	// display name. Falls back to the email local-part when not set or empty.
+	NameHeader string `mapstructure:"name_header"`
+
+	// AutoProvision controls whether unknown emails get a user record auto-created
+	// with role Viewer in the request's organization. When false, requests with
+	// unknown emails return 401. Default false (operators opt in explicitly).
+	AutoProvision bool `mapstructure:"auto_provision"`
+}
+
 func NewConfigFactory() factory.ConfigFactory {
 	return factory.NewConfigFactory(factory.MustNewName("identn"), newConfig)
 }
@@ -54,6 +79,10 @@ func newConfig() factory.Config {
 		Impersonation: ImpersonationConfig{
 			Enabled: false,
 		},
+		TrustedHeader: TrustedHeaderConfig{
+			Enabled:     false,
+			EmailHeader: "X-Forwarded-Email",
+		},
 	}
 }
 
@@ -66,6 +95,10 @@ func (c Config) Validate() error {
 		if c.APIKeyConfig.Enabled {
 			return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::impersonation cannot be enabled if identn::apikey is enabled")
 		}
+	}
+
+	if c.TrustedHeader.Enabled && c.TrustedHeader.EmailHeader == "" {
+		return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::email_header is required when identn::trusted_header is enabled")
 	}
 
 	return nil

--- a/pkg/identn/resolver.go
+++ b/pkg/identn/resolver.go
@@ -59,6 +59,20 @@ func NewIdentNResolver(ctx context.Context, providerSettings factory.ProviderSet
 		identNs = append(identNs, identN)
 	}
 
+	if identNConfig.TrustedHeader.Enabled {
+		identNFactory, err := identNFactories.Get(authtypes.IdentNProviderTrustedHeader.StringValue())
+		if err != nil {
+			return nil, err
+		}
+
+		identN, err := identNFactory.New(ctx, providerSettings, identNConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		identNs = append(identNs, identN)
+	}
+
 	return &identNResolver{
 		identNs:  identNs,
 		settings: factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/identn"),

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -102,18 +102,25 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 		return nil, err
 	}
 
-	// Drop deleted users; only active or pending-invite users are eligible.
-	users = slices.DeleteFunc(users, func(u *types.User) bool { return u.ErrIfDeleted() != nil })
+	// Drop ineligible users — deleted ones (soft-deleted accounts) and root users.
+	// Root users are filtered (not hard-failed on first encounter) because
+	// ListUsersByEmailAndOrgIDs has no guaranteed ordering: in a multi-org
+	// installation where the same email exists in multiple orgs, hard-failing
+	// on `users[0]` being root would non-deterministically block a valid
+	// non-root user that happens to come later in the slice.
+	//
+	// Root users are deliberately not authenticatable via trusted headers
+	// (matches the SAML/OIDC posture) — treating them as "not a match" here
+	// keeps the resolver consistent.
+	users = slices.DeleteFunc(users, func(u *types.User) bool {
+		return u.ErrIfDeleted() != nil || u.ErrIfRoot() != nil
+	})
 
 	if len(users) > 0 {
-		// Pick the first matching user. Multi-org installations should pin the
-		// user to a specific org via the proxy or a separate header in a
+		// Pick the first remaining match. Multi-org installations should pin
+		// the user to a specific org via the proxy or a separate header in a
 		// future enhancement.
 		matched := users[0]
-
-		if err := matched.ErrIfRoot(); err != nil {
-			return nil, errors.WithAdditionalf(err, "root user cannot authenticate via trusted headers")
-		}
 
 		return authtypes.NewPrincipalUserIdentity(
 			matched.ID,

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -1,0 +1,179 @@
+package trustedheaderidentn
+
+import (
+	"context"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/identn"
+	"github.com/SigNoz/signoz/pkg/modules/organization"
+	"github.com/SigNoz/signoz/pkg/modules/user"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+var (
+	ErrCodeTrustedHeaderEmailMissing = errors.MustNewCode("trusted_header_email_missing")
+	ErrCodeTrustedHeaderUserNotFound = errors.MustNewCode("trusted_header_user_not_found")
+	ErrCodeTrustedHeaderNoOrg        = errors.MustNewCode("trusted_header_no_org")
+)
+
+type provider struct {
+	config     identn.Config
+	settings   factory.ScopedProviderSettings
+	orgGetter  organization.Getter
+	userGetter user.Getter
+	userSetter user.Setter
+}
+
+func NewFactory(orgGetter organization.Getter, userGetter user.Getter, userSetter user.Setter) factory.ProviderFactory[identn.IdentN, identn.Config] {
+	return factory.NewProviderFactory(
+		factory.MustNewName(authtypes.IdentNProviderTrustedHeader.StringValue()),
+		func(ctx context.Context, providerSettings factory.ProviderSettings, config identn.Config) (identn.IdentN, error) {
+			return New(ctx, providerSettings, config, orgGetter, userGetter, userSetter)
+		},
+	)
+}
+
+func New(ctx context.Context, providerSettings factory.ProviderSettings, config identn.Config, orgGetter organization.Getter, userGetter user.Getter, userSetter user.Setter) (identn.IdentN, error) {
+	settings := factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/identn/trustedheaderidentn")
+
+	settings.Logger().WarnContext(ctx,
+		"trusted-header identity provider is enabled; SigNoz must be deployed behind a reverse proxy that strips client-supplied identity headers, otherwise any client can forge identity",
+	)
+
+	return &provider{
+		config:     config,
+		settings:   settings,
+		orgGetter:  orgGetter,
+		userGetter: userGetter,
+		userSetter: userSetter,
+	}, nil
+}
+
+func (provider *provider) Name() authtypes.IdentNProvider {
+	return authtypes.IdentNProviderTrustedHeader
+}
+
+// Test returns true when the configured email header is present on the request.
+// Test is intentionally cheap (header presence) — full email validation and the
+// user lookup happen in GetIdentity.
+func (provider *provider) Test(req *http.Request) bool {
+	return provider.extractEmail(req) != ""
+}
+
+// GetIdentity resolves the request to an authenticated identity using only
+// trusted headers injected by the upstream reverse proxy. The request is
+// expected to have already been authenticated by the proxy; SigNoz simply
+// trusts the headers.
+func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, error) {
+	ctx := req.Context()
+
+	rawEmail := provider.extractEmail(req)
+	if rawEmail == "" {
+		return nil, errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderEmailMissing, "trusted-header IdentN expected an email header but none was present")
+	}
+
+	email, err := valuer.NewEmail(rawEmail)
+	if err != nil {
+		return nil, err
+	}
+
+	orgs, err := provider.orgGetter.ListByOwnedKeyRange(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(orgs) == 0 {
+		return nil, errors.New(errors.TypeNotFound, ErrCodeTrustedHeaderNoOrg, "trusted-header IdentN cannot resolve identity because no organization exists")
+	}
+
+	orgIDs := make([]valuer.UUID, 0, len(orgs))
+	for _, org := range orgs {
+		orgIDs = append(orgIDs, org.ID)
+	}
+
+	users, err := provider.userGetter.ListUsersByEmailAndOrgIDs(ctx, email, orgIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Drop deleted users; only active or pending-invite users are eligible.
+	users = slices.DeleteFunc(users, func(u *types.User) bool { return u.ErrIfDeleted() != nil })
+
+	if len(users) > 0 {
+		// Pick the first matching user. Multi-org installations should pin the
+		// user to a specific org via the proxy or a separate header in a
+		// future enhancement.
+		matched := users[0]
+
+		if err := matched.ErrIfRoot(); err != nil {
+			return nil, errors.WithAdditionalf(err, "root user cannot authenticate via trusted headers")
+		}
+
+		return authtypes.NewPrincipalUserIdentity(
+			matched.ID,
+			matched.OrgID,
+			matched.Email,
+			authtypes.IdentNProviderTrustedHeader,
+		), nil
+	}
+
+	if !provider.config.TrustedHeader.AutoProvision {
+		return nil, errors.Newf(errors.TypeUnauthenticated, ErrCodeTrustedHeaderUserNotFound, "no user found for email %q and auto-provisioning is disabled", email.StringValue())
+	}
+
+	// Auto-provision: create the user with Viewer role in the (only) org.
+	// We refuse to guess when multiple orgs exist — operators must disable
+	// AutoProvision or pin a single org.
+	if len(orgs) > 1 {
+		return nil, errors.Newf(errors.TypeInvalidInput, ErrCodeTrustedHeaderNoOrg, "trusted-header auto-provisioning is not supported with multiple organizations (found %d)", len(orgs))
+	}
+
+	orgID := orgs[0].ID
+	displayName := provider.extractDisplayName(req, email)
+
+	newUser, err := types.NewUser(displayName, email, orgID, types.UserStatusActive)
+	if err != nil {
+		return nil, err
+	}
+
+	createdUser, err := provider.userSetter.GetOrCreateUser(ctx, newUser, user.WithRoleNames([]string{authtypes.SigNozViewerRoleName}))
+	if err != nil {
+		return nil, err
+	}
+
+	return authtypes.NewPrincipalUserIdentity(
+		createdUser.ID,
+		createdUser.OrgID,
+		createdUser.Email,
+		authtypes.IdentNProviderTrustedHeader,
+	), nil
+}
+
+// extractEmail reads the configured email header and trims whitespace.
+func (provider *provider) extractEmail(req *http.Request) string {
+	return strings.TrimSpace(req.Header.Get(provider.config.TrustedHeader.EmailHeader))
+}
+
+// extractDisplayName falls back through:
+//
+//  1. The configured NameHeader (when set and non-empty)
+//  2. The local-part of the email address
+func (provider *provider) extractDisplayName(req *http.Request, email valuer.Email) string {
+	if provider.config.TrustedHeader.NameHeader != "" {
+		if name := strings.TrimSpace(req.Header.Get(provider.config.TrustedHeader.NameHeader)); name != "" {
+			return name
+		}
+	}
+
+	if at := strings.IndexByte(email.StringValue(), '@'); at > 0 {
+		return email.StringValue()[:at]
+	}
+
+	return email.StringValue()
+}

--- a/pkg/identn/trustedheaderidentn/provider_test.go
+++ b/pkg/identn/trustedheaderidentn/provider_test.go
@@ -441,3 +441,43 @@ func TestGetIdentityRejectsRootUser(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, identity)
 }
+
+// Multi-org case: when ListUsersByEmailAndOrgIDs returns both a root user
+// and a regular user for the same email, the resolver must skip the root
+// and pick the non-root regardless of slice order — DB query order is not
+// guaranteed.
+func TestGetIdentityPicksNonRootWhenRootAndRegularShareEmail(t *testing.T) {
+	rootOrgID := valuer.GenerateUUID()
+	regularOrgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("shared@example.com")
+	require.NoError(t, err)
+
+	rootUser, err := types.NewRootUser("Root", email, rootOrgID)
+	require.NoError(t, err)
+	regularUser, err := types.NewUser("Regular", email, regularOrgID, types.UserStatusActive)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{
+		{Identifiable: types.Identifiable{ID: rootOrgID}, Name: "root-org"},
+		{Identifiable: types.Identifiable{ID: regularOrgID}, Name: "regular-org"},
+	}}
+
+	// Iterate both possible slice orderings so the test fails the same way
+	// regardless of whether the DB returns the root or the regular user first.
+	for _, ordering := range [][]*types.User{
+		{rootUser, regularUser},
+		{regularUser, rootUser},
+	} {
+		userGetter := &fakeUserGetter{users: ordering}
+		p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("X-Forwarded-Email", "shared@example.com")
+
+		identity, err := p.GetIdentity(req)
+		require.NoError(t, err)
+		require.NotNil(t, identity)
+		assert.Equal(t, regularUser.ID, identity.UserID)
+		assert.Equal(t, regularOrgID, identity.OrgID)
+	}
+}

--- a/pkg/identn/trustedheaderidentn/provider_test.go
+++ b/pkg/identn/trustedheaderidentn/provider_test.go
@@ -1,0 +1,443 @@
+package trustedheaderidentn
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/identn"
+	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
+	"github.com/SigNoz/signoz/pkg/modules/organization"
+	"github.com/SigNoz/signoz/pkg/modules/user"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+// fakeOrgGetter is a minimal organization.Getter test double.
+type fakeOrgGetter struct {
+	orgs []*types.Organization
+}
+
+func (f *fakeOrgGetter) Get(ctx context.Context, id valuer.UUID) (*types.Organization, error) {
+	for _, org := range f.orgs {
+		if org.ID == id {
+			return org, nil
+		}
+	}
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "organization not found")
+}
+
+func (f *fakeOrgGetter) GetByIDOrName(ctx context.Context, id valuer.UUID, name string) (*types.Organization, bool, error) {
+	for _, org := range f.orgs {
+		if org.ID == id {
+			return org, false, nil
+		}
+	}
+	for _, org := range f.orgs {
+		if org.Name == name {
+			return org, true, nil
+		}
+	}
+	return nil, false, errors.New(errors.TypeNotFound, errors.CodeNotFound, "organization not found")
+}
+
+func (f *fakeOrgGetter) ListByOwnedKeyRange(ctx context.Context) ([]*types.Organization, error) {
+	return f.orgs, nil
+}
+
+func (f *fakeOrgGetter) GetByName(ctx context.Context, name string) (*types.Organization, error) {
+	for _, org := range f.orgs {
+		if org.Name == name {
+			return org, nil
+		}
+	}
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "organization not found")
+}
+
+var _ organization.Getter = (*fakeOrgGetter)(nil)
+
+// fakeUserGetter is a minimal user.Getter test double; only methods used by
+// the trusted-header IdentN need real behaviour.
+type fakeUserGetter struct {
+	users []*types.User
+}
+
+func (f *fakeUserGetter) GetRootUserByOrgID(context.Context, valuer.UUID) (*types.User, []*authtypes.UserRole, error) {
+	return nil, nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "not implemented")
+}
+
+func (f *fakeUserGetter) ListDeprecatedUsersByOrgID(context.Context, valuer.UUID) ([]*types.DeprecatedUser, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) ListUsersByOrgID(context.Context, valuer.UUID) ([]*types.User, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) GetDeprecatedUserByOrgIDAndID(context.Context, valuer.UUID, valuer.UUID) (*types.DeprecatedUser, error) {
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "not implemented")
+}
+
+func (f *fakeUserGetter) GetUserByOrgIDAndID(context.Context, valuer.UUID, valuer.UUID) (*types.User, error) {
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "not implemented")
+}
+
+func (f *fakeUserGetter) Get(context.Context, valuer.UUID) (*types.DeprecatedUser, error) {
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "not implemented")
+}
+
+func (f *fakeUserGetter) ListUsersByEmailAndOrgIDs(_ context.Context, email valuer.Email, orgIDs []valuer.UUID) ([]*types.User, error) {
+	matches := make([]*types.User, 0)
+	for _, u := range f.users {
+		if u.Email != email {
+			continue
+		}
+		for _, orgID := range orgIDs {
+			if u.OrgID == orgID {
+				matches = append(matches, u)
+				break
+			}
+		}
+	}
+	return matches, nil
+}
+
+func (f *fakeUserGetter) CountByOrgID(context.Context, valuer.UUID) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeUserGetter) CountByOrgIDAndStatuses(context.Context, valuer.UUID, []string) (map[valuer.String]int64, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) GetFactorPasswordByUserID(context.Context, valuer.UUID) (*types.FactorPassword, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) GetResetPasswordTokenByOrgIDAndUserID(context.Context, valuer.UUID, valuer.UUID) (*types.ResetPasswordToken, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) GetNonDeletedUserByEmailAndOrgID(_ context.Context, email valuer.Email, orgID valuer.UUID) (*types.User, error) {
+	for _, u := range f.users {
+		if u.Email == email && u.OrgID == orgID && u.ErrIfDeleted() == nil {
+			return u, nil
+		}
+	}
+	return nil, errors.New(errors.TypeNotFound, types.ErrCodeUserNotFound, "user not found")
+}
+
+func (f *fakeUserGetter) GetRolesByUserID(context.Context, valuer.UUID) ([]*authtypes.UserRole, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) GetUsersByOrgIDAndRoleID(context.Context, valuer.UUID, valuer.UUID) ([]*types.User, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) OnBeforeRoleDelete(context.Context, valuer.UUID, valuer.UUID) error {
+	return nil
+}
+
+var _ user.Getter = (*fakeUserGetter)(nil)
+
+// fakeUserSetter records the last user passed to GetOrCreateUser.
+//
+// Most methods are stubs returning nil/zero — they exist purely to satisfy the
+// user.Setter interface. Only GetOrCreateUser is exercised by these tests.
+type fakeUserSetter struct {
+	createdUsers []*types.User
+	autoFail     bool
+}
+
+func (f *fakeUserSetter) CreateFirstUser(context.Context, *types.Organization, string, valuer.Email, string) (*types.User, error) {
+	return nil, nil
+}
+
+func (f *fakeUserSetter) CreateUser(_ context.Context, u *types.User, _ ...user.CreateUserOption) error {
+	if f.autoFail {
+		return errors.New(errors.TypeInternal, errors.CodeInternal, "create user failed")
+	}
+	f.createdUsers = append(f.createdUsers, u)
+	return nil
+}
+
+func (f *fakeUserSetter) GetOrCreateUser(_ context.Context, u *types.User, _ ...user.CreateUserOption) (*types.User, error) {
+	if f.autoFail {
+		return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "get or create user failed")
+	}
+	f.createdUsers = append(f.createdUsers, u)
+	return u, nil
+}
+
+func (f *fakeUserSetter) GetOrCreateResetPasswordToken(context.Context, valuer.UUID) (*types.ResetPasswordToken, error) {
+	return nil, nil
+}
+
+func (f *fakeUserSetter) UpdatePasswordByResetPasswordToken(context.Context, string, string) error {
+	return nil
+}
+
+func (f *fakeUserSetter) UpdatePassword(context.Context, valuer.UUID, string, string) error {
+	return nil
+}
+
+func (f *fakeUserSetter) ForgotPassword(context.Context, valuer.UUID, valuer.Email, string) error {
+	return nil
+}
+
+func (f *fakeUserSetter) UpdateUserDeprecated(context.Context, valuer.UUID, string, *types.DeprecatedUser) (*types.DeprecatedUser, error) {
+	return nil, nil
+}
+
+func (f *fakeUserSetter) UpdateUser(context.Context, valuer.UUID, valuer.UUID, *types.UpdatableUser) (*types.User, error) {
+	return nil, nil
+}
+
+func (f *fakeUserSetter) UpdateAnyUserDeprecated(context.Context, valuer.UUID, *types.DeprecatedUser) error {
+	return nil
+}
+
+func (f *fakeUserSetter) UpdateAnyUser(context.Context, valuer.UUID, *types.User) error {
+	return nil
+}
+
+func (f *fakeUserSetter) DeleteUser(context.Context, valuer.UUID, string, string) error {
+	return nil
+}
+
+func (f *fakeUserSetter) CreateBulkInvite(context.Context, valuer.UUID, valuer.UUID, valuer.Email, *types.PostableBulkInviteRequest) ([]*types.Invite, error) {
+	return nil, nil
+}
+
+func (f *fakeUserSetter) UpdateUserRoles(context.Context, valuer.UUID, valuer.UUID, []string) error {
+	return nil
+}
+
+func (f *fakeUserSetter) AddUserRole(context.Context, valuer.UUID, valuer.UUID, string) error {
+	return nil
+}
+
+func (f *fakeUserSetter) RemoveUserRole(context.Context, valuer.UUID, valuer.UUID, valuer.UUID) error {
+	return nil
+}
+
+func (f *fakeUserSetter) Collect(context.Context, valuer.UUID) (map[string]any, error) {
+	return nil, nil
+}
+
+var _ user.Setter = (*fakeUserSetter)(nil)
+
+func newConfig(emailHeader, nameHeader string, autoProvision bool) identn.Config {
+	return identn.Config{
+		TrustedHeader: identn.TrustedHeaderConfig{
+			Enabled:       true,
+			EmailHeader:   emailHeader,
+			NameHeader:    nameHeader,
+			AutoProvision: autoProvision,
+		},
+	}
+}
+
+func newProvider(t *testing.T, cfg identn.Config, orgGetter organization.Getter, userGetter user.Getter, userSetter user.Setter) identn.IdentN {
+	t.Helper()
+
+	p, err := New(context.Background(), instrumentationtest.New().ToProviderSettings(), cfg, orgGetter, userGetter, userSetter)
+	require.NoError(t, err)
+
+	return p
+}
+
+func TestProviderName(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	assert.Equal(t, authtypes.IdentNProviderTrustedHeader, p.Name())
+}
+
+func TestTestReturnsTrueWhenHeaderPresent(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+
+	assert.True(t, p.Test(req))
+}
+
+func TestTestReturnsFalseWhenHeaderMissing(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	assert.False(t, p.Test(req))
+}
+
+func TestTestReturnsFalseWhenHeaderBlank(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "   ")
+
+	assert.False(t, p.Test(req))
+}
+
+func TestGetIdentityReturnsExistingUser(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+
+	existing, err := types.NewUser("Alice", email, orgID, types.UserStatusActive)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{existing}}
+	userSetter := &fakeUserSetter{}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, userSetter)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.NoError(t, err)
+	require.NotNil(t, identity)
+
+	assert.Equal(t, existing.ID, identity.UserID)
+	assert.Equal(t, orgID, identity.OrgID)
+	assert.Equal(t, email, identity.Email)
+	assert.Equal(t, authtypes.PrincipalUser, identity.Principal)
+	assert.Equal(t, authtypes.IdentNProviderTrustedHeader, identity.IdenNProvider)
+	assert.Empty(t, userSetter.createdUsers, "expected no auto-provisioned users")
+}
+
+func TestGetIdentityErrorsWhenHeaderMissing(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+	assert.True(t, errors.Ast(err, errors.TypeUnauthenticated), "expected unauthenticated error type")
+}
+
+func TestGetIdentityErrorsWhenEmailInvalid(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "not-an-email")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+}
+
+func TestGetIdentityErrorsWhenUserUnknownAndAutoProvisionDisabled(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "ghost@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+	assert.True(t, errors.Ast(err, errors.TypeUnauthenticated), "expected unauthenticated error type")
+}
+
+func TestGetIdentityAutoProvisionsWhenEnabled(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userSetter := &fakeUserSetter{}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "X-Forwarded-User", true), orgGetter, &fakeUserGetter{}, userSetter)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "newcomer@example.com")
+	req.Header.Set("X-Forwarded-User", "Newcomer Bob")
+
+	identity, err := p.GetIdentity(req)
+	require.NoError(t, err)
+	require.NotNil(t, identity)
+	assert.Equal(t, orgID, identity.OrgID)
+	assert.Equal(t, "newcomer@example.com", identity.Email.StringValue())
+	assert.Equal(t, authtypes.IdentNProviderTrustedHeader, identity.IdenNProvider)
+
+	require.Len(t, userSetter.createdUsers, 1)
+	assert.Equal(t, "Newcomer Bob", userSetter.createdUsers[0].DisplayName)
+	assert.Equal(t, orgID, userSetter.createdUsers[0].OrgID)
+}
+
+func TestGetIdentityAutoProvisionUsesEmailLocalPartWhenNoNameHeader(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userSetter := &fakeUserSetter{}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), orgGetter, &fakeUserGetter{}, userSetter)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "carol@example.com")
+
+	_, err := p.GetIdentity(req)
+	require.NoError(t, err)
+
+	require.Len(t, userSetter.createdUsers, 1)
+	assert.Equal(t, "carol", userSetter.createdUsers[0].DisplayName)
+}
+
+func TestGetIdentityRefusesAutoProvisionWithMultipleOrgs(t *testing.T) {
+	orgGetter := &fakeOrgGetter{
+		orgs: []*types.Organization{
+			{Identifiable: types.Identifiable{ID: valuer.GenerateUUID()}, Name: "one"},
+			{Identifiable: types.Identifiable{ID: valuer.GenerateUUID()}, Name: "two"},
+		},
+	}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), orgGetter, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "newcomer@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+}
+
+func TestGetIdentityErrorsWhenNoOrganization(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+}
+
+func TestGetIdentityRejectsRootUser(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("root@example.com")
+	require.NoError(t, err)
+
+	rootUser, err := types.NewRootUser("Root", email, orgID)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{rootUser}}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "root@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+}

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -28,6 +28,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/identn/apikeyidentn"
 	"github.com/SigNoz/signoz/pkg/identn/impersonationidentn"
 	"github.com/SigNoz/signoz/pkg/identn/tokenizeridentn"
+	"github.com/SigNoz/signoz/pkg/identn/trustedheaderidentn"
 	"github.com/SigNoz/signoz/pkg/modules/authdomain/implauthdomain"
 	"github.com/SigNoz/signoz/pkg/modules/organization"
 	"github.com/SigNoz/signoz/pkg/modules/organization/implorganization"
@@ -299,11 +300,12 @@ func NewTokenizerProviderFactories(cache cache.Cache, sqlstore sqlstore.SQLStore
 	)
 }
 
-func NewIdentNProviderFactories(tokenizer tokenizer.Tokenizer, serviceAccount serviceaccount.Module, orgGetter organization.Getter, userGetter user.Getter, userConfig user.Config) factory.NamedMap[factory.ProviderFactory[identn.IdentN, identn.Config]] {
+func NewIdentNProviderFactories(tokenizer tokenizer.Tokenizer, serviceAccount serviceaccount.Module, orgGetter organization.Getter, userGetter user.Getter, userSetter user.Setter, userConfig user.Config) factory.NamedMap[factory.ProviderFactory[identn.IdentN, identn.Config]] {
 	return factory.MustNewNamedMap(
 		impersonationidentn.NewFactory(orgGetter, userGetter, userConfig),
 		tokenizeridentn.NewFactory(tokenizer),
 		apikeyidentn.NewFactory(serviceAccount),
+		trustedheaderidentn.NewFactory(orgGetter, userGetter, userSetter),
 	)
 }
 

--- a/pkg/signoz/signoz.go
+++ b/pkg/signoz/signoz.go
@@ -450,7 +450,7 @@ func New(
 	}
 
 	// Initialize identN resolver
-	identNFactories := NewIdentNProviderFactories(tokenizer, serviceAccount, orgGetter, userGetter, config.User)
+	identNFactories := NewIdentNProviderFactories(tokenizer, serviceAccount, orgGetter, userGetter, modules.UserSetter, config.User)
 	identNResolver, err := identn.NewIdentNResolver(ctx, providerSettings, config.IdentN, identNFactories)
 	if err != nil {
 		return nil, err

--- a/pkg/types/authtypes/authn.go
+++ b/pkg/types/authtypes/authn.go
@@ -20,6 +20,7 @@ var (
 	AuthNProviderSAML          = AuthNProvider{valuer.NewString("saml")}
 	AuthNProviderEmailPassword = AuthNProvider{valuer.NewString("email_password")}
 	AuthNProviderOIDC          = AuthNProvider{valuer.NewString("oidc")}
+	AuthNProviderTrustedHeader = AuthNProvider{valuer.NewString("trusted_header")}
 )
 
 var (
@@ -162,6 +163,7 @@ func (AuthNProvider) Enum() []any {
 		AuthNProviderSAML,
 		AuthNProviderEmailPassword,
 		AuthNProviderOIDC,
+		AuthNProviderTrustedHeader,
 	}
 }
 

--- a/pkg/types/authtypes/authn.go
+++ b/pkg/types/authtypes/authn.go
@@ -20,7 +20,6 @@ var (
 	AuthNProviderSAML          = AuthNProvider{valuer.NewString("saml")}
 	AuthNProviderEmailPassword = AuthNProvider{valuer.NewString("email_password")}
 	AuthNProviderOIDC          = AuthNProvider{valuer.NewString("oidc")}
-	AuthNProviderTrustedHeader = AuthNProvider{valuer.NewString("trusted_header")}
 )
 
 var (
@@ -163,7 +162,6 @@ func (AuthNProvider) Enum() []any {
 		AuthNProviderSAML,
 		AuthNProviderEmailPassword,
 		AuthNProviderOIDC,
-		AuthNProviderTrustedHeader,
 	}
 }
 

--- a/pkg/types/authtypes/identn.go
+++ b/pkg/types/authtypes/identn.go
@@ -8,6 +8,7 @@ var (
 	IdentNProviderAnonymous     = IdentNProvider{valuer.NewString("anonymous")}
 	IdentNProviderInternal      = IdentNProvider{valuer.NewString("internal")}
 	IdentNProviderImpersonation = IdentNProvider{valuer.NewString("impersonation")}
+	IdentNProviderTrustedHeader = IdentNProvider{valuer.NewString("trusted_header")}
 )
 
 type IdentNProvider struct{ valuer.String }


### PR DESCRIPTION
## Summary

This PR adds a new `IdentN` provider, `trustedheaderidentn`, that authenticates requests based on identity headers injected by an upstream reverse proxy. It is the implementation of `IdentN` invited in #6197.

The motivating use case is operators running SigNoz behind a forward-auth-style identity proxy (Authentik forward-auth, `oauth2-proxy`, Cloudflare Access, etc.). The proxy is the source of truth for the user's identity; SigNoz simply trusts the headers it receives and creates a session — no local password/SSO flow needed.

The provider is disabled by default and only activates when explicitly enabled in config. When enabled, SigNoz logs a startup warning, since the design assumes the proxy strips client-supplied identity headers — without that, any client could forge identity.

Closes #6197

## Behaviour

- `Test()` returns `true` when the configured email header is non-empty.
- `GetIdentity()`:
  - Reads the configured email header and validates it.
  - Looks up the user by email across all instance-owned organizations (mirrors `pkg/modules/session/implsession`).
  - If found and not the root user → returns the identity.
  - If not found and `auto_provision` is `true` AND the instance has exactly one org → creates a Viewer-role user via `user.Setter.GetOrCreateUser` and returns the identity.
  - If not found and `auto_provision` is `false` → 401.
  - Refuses to auto-provision when multiple orgs exist (operator must disable auto-provision or add per-org pinning).
  - Refuses root-user auth via headers (matches the SAML/OIDC posture in `implsession.CreateCallbackAuthNSession`).

## Config example

```yaml
identn:
  trusted_header:
    enabled: true
    email_header: X-Authentik-Email   # or X-Forwarded-Email (default), etc.
    name_header: X-Authentik-Name     # optional
    auto_provision: false             # opt-in
```

## Files

- `pkg/types/authtypes/identn.go` — `IdentNProviderTrustedHeader`
- `pkg/types/authtypes/authn.go` — `AuthNProviderTrustedHeader` (added to `Enum()` for completeness)
- `pkg/identn/config.go` — `TrustedHeaderConfig`, default, validation
- `pkg/identn/resolver.go` — wiring
- `pkg/identn/trustedheaderidentn/provider.go` — the IdentN itself
- `pkg/identn/trustedheaderidentn/provider_test.go` — unit tests covering Test/GetIdentity, auto-provision on/off, multi-org refusal, root-user refusal, missing/invalid email
- `pkg/signoz/provider.go` and `pkg/signoz/signoz.go` — register the factory and pass `modules.UserSetter`

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -race ./pkg/identn/trustedheaderidentn/...` — all 13 tests pass
- [x] `go test ./pkg/signoz/...` — pre-existing tests still pass
- [ ] Manual: deploy behind oauth2-proxy / Authentik forward-auth and verify a request with `X-Forwarded-Email` resolves to a session

## Notes

This is opened as a **draft** because I'd like maintainer feedback on the auto-provisioning ergonomics before polishing — specifically:

1. Should auto-provisioning support multiple orgs (e.g., via a configurable default org name, or a second `org_header`)? Right now it refuses rather than guess.
2. Should the default role be configurable (currently hardcoded Viewer)?
3. Is there a preferred place to surface the "trusted-header is enabled" warning beyond a startup log line?

Happy to iterate on any of the above.

Signed-off-by: CaffeineDuck <hello@samrid.me>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authentication path that trusts upstream-provided headers and can auto-provision users, which impacts access control if misconfigured behind an untrusted proxy.
> 
> **Overview**
> Adds an optional `trusted_header` IdentN provider that authenticates requests via a configured email header injected by a reverse proxy, with an explicit startup warning about header-forgery risk.
> 
> Extends `identn` configuration to include `TrustedHeader` settings (default disabled) with validation, wires the provider into the IdentN resolver/factory registration, and introduces auto-provisioning of unknown users as *Viewer* (single-org only) plus safeguards like rejecting root-user header auth and refusing multi-org auto-provisioning.
> 
> Updates auth type enums to include `trusted_header` and adds unit tests covering header detection, identity resolution, and auto-provisioning/error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cfb618c14e4f2d1d99a301bbecdb3a31b99cedd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->