### PR TITLE
fix(time-picker): disable browser autofill on time selection input

### DIFF
--- a/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePicker.tsx
@@ -596,6 +596,7 @@ function CustomTimePicker({
 				>
 					<Input
 						ref={inputRef}
+						autoComplete="off"
 						className={cx(
 							'timeSelection-input',
 							inputStatus === CustomTimePickerInputStatus.ERROR ? 'error' : '',


### PR DESCRIPTION
## Problem
The time selection input field in the top navigation bar was showing. 
browser autofill suggestions, which interfered with the custom time 
picker UX. Users would see irrelevant autofill suggestions (emails, 
addresses, etc.) when clicking on the time selection field.

## Fix
Added `autoComplete="off"` to the `<Input>` component in 
`CustomTimePicker.tsx` to prevent the browser from showing autofill 
suggestions on this field.

## Changes
- `frontend/src/components/CustomTimePicker/CustomTimePicker.tsx`: 
  added `autoComplete="off"` to the time selection Input component

Fixes #5875