### PR TITLE
feat(dashboard): render dashboard description as sanitized HTML

### DIFF
--- a/frontend/src/container/DashboardContainer/DashboardDescription/index.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardDescription/index.tsx
@@ -18,6 +18,7 @@ import { useUpdateDashboard } from 'hooks/dashboard/useUpdateDashboard';
 import useComponentPermission from 'hooks/useComponentPermission';
 import { useGetTenantLicense } from 'hooks/useGetTenantLicense';
 import { useNotifications } from 'hooks/useNotifications';
+import dompurify from 'dompurify';
 import { isEmpty } from 'lodash-es';
 import {
 	Check,
@@ -513,7 +514,11 @@ function DashboardDescription(props: DashboardDescriptionProps): JSX.Element {
 				</div>
 			)}
 			{!isEmpty(description) && (
-				<section className="dashboard-description-section">{description}</section>
+				<section
+					className="dashboard-description-section"
+					// eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={{ __html: dompurify.sanitize(description || '') }}
+				/>
 			)}
 
 			{!isEmpty(dashboardVariables) && (


### PR DESCRIPTION
## Problem
Dashboard descriptions were rendered as plain text, stripping any HTML 
formatting that users might add. This made it impossible to use rich 
text formatting (bold, links, lists, etc.) in dashboard descriptions.

## Fix
Used `dompurify.sanitize()` (already a project dependency used elsewhere 
in the codebase) with `dangerouslySetInnerHTML` to safely render HTML 
content in the dashboard description section. This prevents XSS while 
allowing valid HTML formatting.

## Changes
- `frontend/src/container/DashboardContainer/DashboardDescription/index.tsx`: 
  render description as sanitized HTML instead of plain text

Fixes #5256
