### PR TITLE
feat(auditor): add file provider

### DIFF
--- a/cmd/enterprise/server.go
+++ b/cmd/enterprise/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/SigNoz/signoz/cmd"
+	"github.com/SigNoz/signoz/ee/auditor/fileauditor"
 	"github.com/SigNoz/signoz/ee/auditor/otlphttpauditor"
 	"github.com/SigNoz/signoz/ee/authn/callbackauthn/oidccallbackauthn"
 	"github.com/SigNoz/signoz/ee/authn/callbackauthn/samlcallbackauthn"
@@ -153,6 +154,9 @@ func runServer(ctx context.Context, config signoz.Config, logger *slog.Logger) e
 		func(licensing licensing.Licensing) factory.NamedMap[factory.ProviderFactory[auditor.Auditor, auditor.Config]] {
 			factories := signoz.NewAuditorProviderFactories()
 			if err := factories.Add(otlphttpauditor.NewFactory(licensing, version.Info)); err != nil {
+				panic(err)
+			}
+			if err := factories.Add(fileauditor.NewFactory(licensing, version.Info)); err != nil {
 				panic(err)
 			}
 			return factories

--- a/ee/auditor/fileauditor/export.go
+++ b/ee/auditor/fileauditor/export.go
@@ -21,16 +21,17 @@ func (provider *provider) export(ctx context.Context, events []audittypes.AuditE
 		return errors.Wrapf(err, errors.TypeInternal, auditor.ErrCodeAuditExportFailed, "failed to marshal audit logs")
 	}
 
+	// Combine the payload and trailing newline into one Write call so the line
+	// is emitted in a single syscall — concurrent readers see either the full
+	// line or nothing, never a torn JSON object.
+	payload = append(payload, '\n')
+
 	provider.mu.Lock()
 	defer provider.mu.Unlock()
 
 	if _, err := provider.file.Write(payload); err != nil {
 		provider.settings.Logger().ErrorContext(ctx, "audit export failed", errors.Attr(err), slog.Int("dropped_log_records", len(events)))
 		return errors.Wrapf(err, errors.TypeInternal, auditor.ErrCodeAuditExportFailed, "failed to write audit logs")
-	}
-
-	if _, err := provider.file.Write([]byte("\n")); err != nil {
-		return errors.Wrapf(err, errors.TypeInternal, auditor.ErrCodeAuditExportFailed, "failed to write audit log newline")
 	}
 
 	return provider.file.Sync()

--- a/ee/auditor/fileauditor/export.go
+++ b/ee/auditor/fileauditor/export.go
@@ -1,0 +1,37 @@
+package fileauditor
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/SigNoz/signoz/pkg/auditor"
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/types/audittypes"
+)
+
+// export converts a batch of audit events to OTLP-JSON log records and appends
+// the encoded payload to the configured file as one NDJSON line per batch.
+// Mirrors the wire format that otlphttpauditor sends, so downstream tools can
+// consume both transports interchangeably.
+func (provider *provider) export(ctx context.Context, events []audittypes.AuditEvent) error {
+	logs := audittypes.NewPLogsFromAuditEvents(events, "signoz", provider.build.Version(), "signoz.audit")
+
+	payload, err := provider.marshaler.MarshalLogs(logs)
+	if err != nil {
+		return errors.Wrapf(err, errors.TypeInternal, auditor.ErrCodeAuditExportFailed, "failed to marshal audit logs")
+	}
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+
+	if _, err := provider.file.Write(payload); err != nil {
+		provider.settings.Logger().ErrorContext(ctx, "audit export failed", errors.Attr(err), slog.Int("dropped_log_records", len(events)))
+		return errors.Wrapf(err, errors.TypeInternal, auditor.ErrCodeAuditExportFailed, "failed to write audit logs")
+	}
+
+	if _, err := provider.file.Write([]byte("\n")); err != nil {
+		return errors.Wrapf(err, errors.TypeInternal, auditor.ErrCodeAuditExportFailed, "failed to write audit log newline")
+	}
+
+	return provider.file.Sync()
+}

--- a/ee/auditor/fileauditor/export.go
+++ b/ee/auditor/fileauditor/export.go
@@ -4,21 +4,16 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/SigNoz/signoz/pkg/auditor"
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/types/audittypes"
 )
 
-// export converts a batch of audit events to OTLP-JSON log records and appends
-// the encoded payload to the configured file as one NDJSON line per batch.
-// Mirrors the wire format that otlphttpauditor sends, so downstream tools can
-// consume both transports interchangeably.
 func (provider *provider) export(ctx context.Context, events []audittypes.AuditEvent) error {
 	logs := audittypes.NewPLogsFromAuditEvents(events, "signoz", provider.build.Version(), "signoz.audit")
 
 	payload, err := provider.marshaler.MarshalLogs(logs)
 	if err != nil {
-		return errors.Wrapf(err, errors.TypeInternal, auditor.ErrCodeAuditExportFailed, "failed to marshal audit logs")
+		return err
 	}
 
 	// Combine the payload and trailing newline into one Write call so the line
@@ -31,7 +26,7 @@ func (provider *provider) export(ctx context.Context, events []audittypes.AuditE
 
 	if _, err := provider.file.Write(payload); err != nil {
 		provider.settings.Logger().ErrorContext(ctx, "audit export failed", errors.Attr(err), slog.Int("dropped_log_records", len(events)))
-		return errors.Wrapf(err, errors.TypeInternal, auditor.ErrCodeAuditExportFailed, "failed to write audit logs")
+		return err
 	}
 
 	return provider.file.Sync()

--- a/ee/auditor/fileauditor/provider.go
+++ b/ee/auditor/fileauditor/provider.go
@@ -1,0 +1,99 @@
+package fileauditor
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	"github.com/SigNoz/signoz/pkg/auditor"
+	"github.com/SigNoz/signoz/pkg/auditor/auditorserver"
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/licensing"
+	"github.com/SigNoz/signoz/pkg/types/audittypes"
+	"github.com/SigNoz/signoz/pkg/version"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+var _ auditor.Auditor = (*provider)(nil)
+
+type provider struct {
+	settings  factory.ScopedProviderSettings
+	config    auditor.Config
+	licensing licensing.Licensing
+	build     version.Build
+	server    *auditorserver.Server
+	marshaler plog.JSONMarshaler
+	file      *os.File
+	mu        sync.Mutex
+}
+
+func NewFactory(licensing licensing.Licensing, build version.Build) factory.ProviderFactory[auditor.Auditor, auditor.Config] {
+	return factory.NewProviderFactory(factory.MustNewName("file"), func(ctx context.Context, providerSettings factory.ProviderSettings, config auditor.Config) (auditor.Auditor, error) {
+		return newProvider(ctx, providerSettings, config, licensing, build)
+	})
+}
+
+func newProvider(_ context.Context, providerSettings factory.ProviderSettings, config auditor.Config, licensing licensing.Licensing, build version.Build) (auditor.Auditor, error) {
+	settings := factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/ee/auditor/fileauditor")
+
+	file, err := os.OpenFile(config.File.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, errors.Wrapf(err, errors.TypeInvalidInput, auditor.ErrCodeAuditExportFailed, "failed to open audit file %q", config.File.Path)
+	}
+
+	provider := &provider{
+		settings:  settings,
+		config:    config,
+		licensing: licensing,
+		build:     build,
+		marshaler: plog.JSONMarshaler{},
+		file:      file,
+	}
+
+	server, err := auditorserver.New(settings,
+		auditorserver.Config{
+			BufferSize:    config.BufferSize,
+			BatchSize:     config.BatchSize,
+			FlushInterval: config.FlushInterval,
+		},
+		provider.export,
+	)
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+
+	provider.server = server
+	return provider, nil
+}
+
+func (provider *provider) Start(ctx context.Context) error {
+	return provider.server.Start(ctx)
+}
+
+func (provider *provider) Audit(ctx context.Context, event audittypes.AuditEvent) {
+	if event.PrincipalAttributes.PrincipalOrgID.IsZero() {
+		provider.settings.Logger().WarnContext(ctx, "audit event dropped as org_id is zero")
+		return
+	}
+
+	if _, err := provider.licensing.GetActive(ctx, event.PrincipalAttributes.PrincipalOrgID); err != nil {
+		return
+	}
+
+	provider.server.Add(ctx, event)
+}
+
+func (provider *provider) Healthy() <-chan struct{} {
+	return provider.server.Healthy()
+}
+
+func (provider *provider) Stop(ctx context.Context) error {
+	serverErr := provider.server.Stop(ctx)
+	fileErr := provider.file.Close()
+	if serverErr != nil {
+		return serverErr
+	}
+	return fileErr
+}

--- a/ee/auditor/fileauditor/provider.go
+++ b/ee/auditor/fileauditor/provider.go
@@ -95,5 +95,6 @@ func (provider *provider) Stop(ctx context.Context) error {
 	if serverErr != nil {
 		return serverErr
 	}
+
 	return fileErr
 }

--- a/pkg/auditor/config.go
+++ b/pkg/auditor/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	FlushInterval time.Duration `mapstructure:"flush_interval"`
 
 	OTLPHTTP OTLPHTTPConfig `mapstructure:"otlphttp"`
+
+	File FileConfig `mapstructure:"file"`
 }
 
 // OTLPHTTPConfig holds configuration for the OTLP HTTP exporter provider.
@@ -44,6 +46,14 @@ type OTLPHTTPConfig struct {
 
 	// Retry configures exponential backoff retry policy for failed exports.
 	Retry RetryConfig `mapstructure:"retry"`
+}
+
+// FileConfig holds configuration for the file exporter provider.
+// Audit events are encoded as OTLP-JSON log records and appended to the file.
+type FileConfig struct {
+	// Path is the absolute path to the audit log file. The file is opened with
+	// O_APPEND|O_CREATE|O_WRONLY; existing contents are preserved across runs.
+	Path string `mapstructure:"path"`
 }
 
 // RetryConfig configures exponential backoff for the OTLP HTTP exporter.
@@ -108,6 +118,12 @@ func (c Config) Validate() error {
 	if c.Provider == "otlphttp" {
 		if c.OTLPHTTP.Endpoint == nil {
 			return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "auditor::otlphttp::endpoint must be set when provider is otlphttp")
+		}
+	}
+
+	if c.Provider == "file" {
+		if c.File.Path == "" {
+			return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "auditor::file::path must be set when provider is file")
 		}
 	}
 

--- a/pkg/auditor/config.go
+++ b/pkg/auditor/config.go
@@ -48,8 +48,6 @@ type OTLPHTTPConfig struct {
 	Retry RetryConfig `mapstructure:"retry"`
 }
 
-// FileConfig holds configuration for the file exporter provider.
-// Audit events are encoded as OTLP-JSON log records and appended to the file.
 type FileConfig struct {
 	// Path is the absolute path to the audit log file. The file is opened with
 	// O_APPEND|O_CREATE|O_WRONLY; existing contents are preserved across runs.


### PR DESCRIPTION
## Summary

Adds a file-based auditor provider (`ee/auditor/fileauditor/`) alongside the existing `otlphttpauditor`. Audit events are encoded as OTLP-Logs JSON and appended one batch per line to a configured file, matching the wire format `otlphttpauditor` sends over HTTP — only the destination differs.

Selectable via `auditor.provider=file` + `auditor.file.path=...`. OSS still ships only `noopauditor`.

## Relationship to #11101

#11101 instruments the P0 mutation routes with `AuditDef` — the producer of audit events. This PR adds the file write target that consumes them. Both halves were originally on one branch; split so the route catalogue (#1938) and the write-target work (#1941) review and merge independently.

Integration tests against this provider follow in a separate PR once #11101 lands on `main`.

closes SigNoz/platform-pod#1941
