### PR TITLE
fix(infra-monitoring): handle -1 values on hosts metrics

### DIFF
--- a/frontend/src/container/InfraMonitoringHosts/table.config.tsx
+++ b/frontend/src/container/InfraMonitoringHosts/table.config.tsx
@@ -119,6 +119,7 @@ export const hostColumnsConfig: TableColumnDef<HostData>[] = [
 					<ValidateColumnValueWrapper
 						value={cpu}
 						entity={InfraMonitoringEntity.HOSTS}
+						attribute="CPU metric"
 					>
 						<EntityProgressBar value={cpu} type="cpu" />
 					</ValidateColumnValueWrapper>
@@ -146,6 +147,7 @@ export const hostColumnsConfig: TableColumnDef<HostData>[] = [
 					<ValidateColumnValueWrapper
 						value={memory}
 						entity={InfraMonitoringEntity.HOSTS}
+						attribute="memory metric"
 					>
 						<EntityProgressBar value={memory} type="memory" />
 					</ValidateColumnValueWrapper>
@@ -163,8 +165,15 @@ export const hostColumnsConfig: TableColumnDef<HostData>[] = [
 		enableSort: true,
 		cell: ({ value }): React.ReactNode => {
 			const wait = value as number;
+
 			return (
-				<TanStackTable.Text>{`${Number((wait * 100).toFixed(1))}%`}</TanStackTable.Text>
+				<ValidateColumnValueWrapper
+					value={wait}
+					entity={InfraMonitoringEntity.HOSTS}
+					attribute="IOWait metric"
+				>
+					<TanStackTable.Text>{`${Number((wait * 100).toFixed(1))}%`}</TanStackTable.Text>
+				</ValidateColumnValueWrapper>
 			);
 		},
 	},
@@ -176,8 +185,18 @@ export const hostColumnsConfig: TableColumnDef<HostData>[] = [
 		accessorFn: (row): number => row.load15,
 		width: { min: 100, default: 100 },
 		enableSort: true,
-		cell: ({ value }): React.ReactNode => (
-			<TanStackTable.Text>{value as number}</TanStackTable.Text>
-		),
+		cell: ({ value }): React.ReactNode => {
+			const load15 = value as number;
+
+			return (
+				<ValidateColumnValueWrapper
+					value={load15}
+					entity={InfraMonitoringEntity.HOSTS}
+					attribute="load average metric"
+				>
+					<TanStackTable.Text>{load15}</TanStackTable.Text>
+				</ValidateColumnValueWrapper>
+			);
+		},
 	},
 ];

--- a/frontend/src/container/InfraMonitoringK8s/Clusters/table.config.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Clusters/table.config.tsx
@@ -7,6 +7,7 @@ import EntityGroupHeader from '../Base/EntityGroupHeader';
 import K8sGroupCell from '../Base/K8sGroupCell';
 import { formatBytes } from '../commonUtils';
 import { ValidateColumnValueWrapper } from '../components';
+import { InfraMonitoringEntity } from '../constants';
 import { K8sClusterData, K8sClustersListPayload } from './api';
 import { Boxes } from 'lucide-react';
 
@@ -85,7 +86,11 @@ export const k8sClustersColumnsConfig: TableColumnDef<K8sClusterData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const cpu = value as number;
 			return (
-				<ValidateColumnValueWrapper value={cpu}>
+				<ValidateColumnValueWrapper
+					value={cpu}
+					entity={InfraMonitoringEntity.CLUSTERS}
+					attribute="CPU metric"
+				>
 					<TanStackTable.Text>{cpu}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -100,7 +105,11 @@ export const k8sClustersColumnsConfig: TableColumnDef<K8sClusterData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const cpuAllocatable = value as number;
 			return (
-				<ValidateColumnValueWrapper value={cpuAllocatable}>
+				<ValidateColumnValueWrapper
+					value={cpuAllocatable}
+					entity={InfraMonitoringEntity.CLUSTERS}
+					attribute="CPU allocatable metric"
+				>
 					<TanStackTable.Text>{cpuAllocatable}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -115,7 +124,11 @@ export const k8sClustersColumnsConfig: TableColumnDef<K8sClusterData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const memory = value as number;
 			return (
-				<ValidateColumnValueWrapper value={memory}>
+				<ValidateColumnValueWrapper
+					value={memory}
+					entity={InfraMonitoringEntity.CLUSTERS}
+					attribute="memory metric"
+				>
 					<TanStackTable.Text>{formatBytes(memory)}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -130,7 +143,11 @@ export const k8sClustersColumnsConfig: TableColumnDef<K8sClusterData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const memoryAllocatable = value as number;
 			return (
-				<ValidateColumnValueWrapper value={memoryAllocatable}>
+				<ValidateColumnValueWrapper
+					value={memoryAllocatable}
+					entity={InfraMonitoringEntity.CLUSTERS}
+					attribute="memory allocatable metric"
+				>
 					<TanStackTable.Text>{formatBytes(memoryAllocatable)}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);

--- a/frontend/src/container/InfraMonitoringK8s/DaemonSets/table.config.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/DaemonSets/table.config.tsx
@@ -93,7 +93,11 @@ export const k8sDaemonSetsColumnsConfig: TableColumnDef<K8sDaemonSetsData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const availableNodes = value as number;
 			return (
-				<ValidateColumnValueWrapper value={availableNodes}>
+				<ValidateColumnValueWrapper
+					value={availableNodes}
+					entity={InfraMonitoringEntity.DAEMONSETS}
+					attribute="available node"
+				>
 					<TanStackTable.Text>{availableNodes}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -108,7 +112,11 @@ export const k8sDaemonSetsColumnsConfig: TableColumnDef<K8sDaemonSetsData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const desiredNodes = value as number;
 			return (
-				<ValidateColumnValueWrapper value={desiredNodes}>
+				<ValidateColumnValueWrapper
+					value={desiredNodes}
+					entity={InfraMonitoringEntity.DAEMONSETS}
+					attribute="desired node"
+				>
 					<TanStackTable.Text>{desiredNodes}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -162,7 +170,11 @@ export const k8sDaemonSetsColumnsConfig: TableColumnDef<K8sDaemonSetsData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const cpu = value as number;
 			return (
-				<ValidateColumnValueWrapper value={cpu}>
+				<ValidateColumnValueWrapper
+					value={cpu}
+					entity={InfraMonitoringEntity.DAEMONSETS}
+					attribute="CPU metric"
+				>
 					<TanStackTable.Text>{cpu}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -216,7 +228,11 @@ export const k8sDaemonSetsColumnsConfig: TableColumnDef<K8sDaemonSetsData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const memory = value as number;
 			return (
-				<ValidateColumnValueWrapper value={memory}>
+				<ValidateColumnValueWrapper
+					value={memory}
+					entity={InfraMonitoringEntity.DAEMONSETS}
+					attribute="memory metric"
+				>
 					<TanStackTable.Text>{formatBytes(memory)}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);

--- a/frontend/src/container/InfraMonitoringK8s/Deployments/table.config.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Deployments/table.config.tsx
@@ -92,7 +92,11 @@ export const k8sDeploymentsColumnsConfig: TableColumnDef<K8sDeploymentsData>[] =
 			cell: ({ value }): React.ReactNode => {
 				const availablePods = value as number;
 				return (
-					<ValidateColumnValueWrapper value={availablePods}>
+					<ValidateColumnValueWrapper
+						value={availablePods}
+						entity={InfraMonitoringEntity.DEPLOYMENTS}
+						attribute="available pod"
+					>
 						<TanStackTable.Text>{availablePods}</TanStackTable.Text>
 					</ValidateColumnValueWrapper>
 				);
@@ -109,7 +113,11 @@ export const k8sDeploymentsColumnsConfig: TableColumnDef<K8sDeploymentsData>[] =
 			cell: ({ value }): React.ReactNode => {
 				const desiredPods = value as number;
 				return (
-					<ValidateColumnValueWrapper value={desiredPods}>
+					<ValidateColumnValueWrapper
+						value={desiredPods}
+						entity={InfraMonitoringEntity.DEPLOYMENTS}
+						attribute="desired pod"
+					>
 						<TanStackTable.Text>{desiredPods}</TanStackTable.Text>
 					</ValidateColumnValueWrapper>
 				);
@@ -165,7 +173,11 @@ export const k8sDeploymentsColumnsConfig: TableColumnDef<K8sDeploymentsData>[] =
 			cell: ({ value }): React.ReactNode => {
 				const cpu = value as number;
 				return (
-					<ValidateColumnValueWrapper value={cpu}>
+					<ValidateColumnValueWrapper
+						value={cpu}
+						entity={InfraMonitoringEntity.DEPLOYMENTS}
+						attribute="CPU metric"
+					>
 						<TanStackTable.Text>{cpu}</TanStackTable.Text>
 					</ValidateColumnValueWrapper>
 				);
@@ -221,7 +233,11 @@ export const k8sDeploymentsColumnsConfig: TableColumnDef<K8sDeploymentsData>[] =
 			cell: ({ value }): React.ReactNode => {
 				const memory = value as number;
 				return (
-					<ValidateColumnValueWrapper value={memory}>
+					<ValidateColumnValueWrapper
+						value={memory}
+						entity={InfraMonitoringEntity.DEPLOYMENTS}
+						attribute="memory metric"
+					>
 						<TanStackTable.Text>{formatBytes(memory)}</TanStackTable.Text>
 					</ValidateColumnValueWrapper>
 				);

--- a/frontend/src/container/InfraMonitoringK8s/Jobs/table.config.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Jobs/table.config.tsx
@@ -89,7 +89,11 @@ export const k8sJobsColumnsConfig: TableColumnDef<K8sJobsData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const successfulPods = value as number;
 			return (
-				<ValidateColumnValueWrapper value={successfulPods}>
+				<ValidateColumnValueWrapper
+					value={successfulPods}
+					entity={InfraMonitoringEntity.JOBS}
+					attribute="successful pod"
+				>
 					<TanStackTable.Text>{successfulPods}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -104,7 +108,11 @@ export const k8sJobsColumnsConfig: TableColumnDef<K8sJobsData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const failedPods = value as number;
 			return (
-				<ValidateColumnValueWrapper value={failedPods}>
+				<ValidateColumnValueWrapper
+					value={failedPods}
+					entity={InfraMonitoringEntity.JOBS}
+					attribute="failed pod"
+				>
 					<TanStackTable.Text>{failedPods}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -119,7 +127,11 @@ export const k8sJobsColumnsConfig: TableColumnDef<K8sJobsData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const desiredSuccessfulPods = value as number;
 			return (
-				<ValidateColumnValueWrapper value={desiredSuccessfulPods}>
+				<ValidateColumnValueWrapper
+					value={desiredSuccessfulPods}
+					entity={InfraMonitoringEntity.JOBS}
+					attribute="desired successful pod"
+				>
 					<TanStackTable.Text>{desiredSuccessfulPods}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -134,7 +146,11 @@ export const k8sJobsColumnsConfig: TableColumnDef<K8sJobsData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const activePods = value as number;
 			return (
-				<ValidateColumnValueWrapper value={activePods}>
+				<ValidateColumnValueWrapper
+					value={activePods}
+					entity={InfraMonitoringEntity.JOBS}
+					attribute="active pod"
+				>
 					<TanStackTable.Text>{activePods}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -187,7 +203,11 @@ export const k8sJobsColumnsConfig: TableColumnDef<K8sJobsData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const cpu = value as number;
 			return (
-				<ValidateColumnValueWrapper value={cpu}>
+				<ValidateColumnValueWrapper
+					value={cpu}
+					entity={InfraMonitoringEntity.JOBS}
+					attribute="CPU metric"
+				>
 					<TanStackTable.Text>{cpu}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -240,7 +260,11 @@ export const k8sJobsColumnsConfig: TableColumnDef<K8sJobsData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const memory = value as number;
 			return (
-				<ValidateColumnValueWrapper value={memory}>
+				<ValidateColumnValueWrapper
+					value={memory}
+					entity={InfraMonitoringEntity.JOBS}
+					attribute="memory metric"
+				>
 					<TanStackTable.Text>{formatBytes(memory)}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);

--- a/frontend/src/container/InfraMonitoringK8s/Namespaces/table.config.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Namespaces/table.config.tsx
@@ -6,6 +6,7 @@ import EntityGroupHeader from '../Base/EntityGroupHeader';
 import K8sGroupCell from '../Base/K8sGroupCell';
 import { formatBytes } from '../commonUtils';
 import { ValidateColumnValueWrapper } from '../components';
+import { InfraMonitoringEntity } from '../constants';
 import { K8sNamespacesData, K8sNamespacesListPayload } from './api';
 import { FilePenLine } from 'lucide-react';
 
@@ -90,7 +91,11 @@ export const k8sNamespacesColumnsConfig: TableColumnDef<K8sNamespacesData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const cpu = value as number;
 			return (
-				<ValidateColumnValueWrapper value={cpu}>
+				<ValidateColumnValueWrapper
+					value={cpu}
+					entity={InfraMonitoringEntity.NAMESPACES}
+					attribute="CPU metric"
+				>
 					<TanStackTable.Text>{cpu}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -105,7 +110,11 @@ export const k8sNamespacesColumnsConfig: TableColumnDef<K8sNamespacesData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const memory = value as number;
 			return (
-				<ValidateColumnValueWrapper value={memory}>
+				<ValidateColumnValueWrapper
+					value={memory}
+					entity={InfraMonitoringEntity.NAMESPACES}
+					attribute="memory metric"
+				>
 					<TanStackTable.Text>{formatBytes(memory)}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);

--- a/frontend/src/container/InfraMonitoringK8s/Nodes/table.config.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Nodes/table.config.tsx
@@ -7,6 +7,7 @@ import EntityGroupHeader from '../Base/EntityGroupHeader';
 import K8sGroupCell from '../Base/K8sGroupCell';
 import { formatBytes } from '../commonUtils';
 import { ValidateColumnValueWrapper } from '../components';
+import { InfraMonitoringEntity } from '../constants';
 import { K8sNodeData, K8sNodesListPayload } from './api';
 import { Workflow } from 'lucide-react';
 
@@ -91,7 +92,11 @@ export const k8sNodesColumnsConfig: TableColumnDef<K8sNodeData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const cpu = value as number;
 			return (
-				<ValidateColumnValueWrapper value={cpu}>
+				<ValidateColumnValueWrapper
+					value={cpu}
+					entity={InfraMonitoringEntity.NODES}
+					attribute="CPU metric"
+				>
 					<TanStackTable.Text>{cpu}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -106,7 +111,11 @@ export const k8sNodesColumnsConfig: TableColumnDef<K8sNodeData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const cpuAllocatable = value as number;
 			return (
-				<ValidateColumnValueWrapper value={cpuAllocatable}>
+				<ValidateColumnValueWrapper
+					value={cpuAllocatable}
+					entity={InfraMonitoringEntity.NODES}
+					attribute="CPU allocatable metric"
+				>
 					<TanStackTable.Text>{cpuAllocatable}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -121,7 +130,11 @@ export const k8sNodesColumnsConfig: TableColumnDef<K8sNodeData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const memory = value as number;
 			return (
-				<ValidateColumnValueWrapper value={memory}>
+				<ValidateColumnValueWrapper
+					value={memory}
+					entity={InfraMonitoringEntity.NODES}
+					attribute="memory metric"
+				>
 					<TanStackTable.Text>{formatBytes(memory)}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -136,7 +149,11 @@ export const k8sNodesColumnsConfig: TableColumnDef<K8sNodeData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const memoryAllocatable = value as number;
 			return (
-				<ValidateColumnValueWrapper value={memoryAllocatable}>
+				<ValidateColumnValueWrapper
+					value={memoryAllocatable}
+					entity={InfraMonitoringEntity.NODES}
+					attribute="memory allocatable metric"
+				>
 					<TanStackTable.Text>{formatBytes(memoryAllocatable)}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);

--- a/frontend/src/container/InfraMonitoringK8s/Pods/table.config.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Pods/table.config.tsx
@@ -112,7 +112,11 @@ export const k8sPodColumnsConfig: TableColumnDef<K8sPodsData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const cpu = value as number;
 			return (
-				<ValidateColumnValueWrapper value={cpu}>
+				<ValidateColumnValueWrapper
+					value={cpu}
+					entity={InfraMonitoringEntity.PODS}
+					attribute="CPU metric"
+				>
 					<TanStackTable.Text>{cpu}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -165,7 +169,11 @@ export const k8sPodColumnsConfig: TableColumnDef<K8sPodsData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const memory = value as number;
 			return (
-				<ValidateColumnValueWrapper value={memory}>
+				<ValidateColumnValueWrapper
+					value={memory}
+					entity={InfraMonitoringEntity.PODS}
+					attribute="memory metric"
+				>
 					<TanStackTable.Text>{formatBytes(memory)}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);

--- a/frontend/src/container/InfraMonitoringK8s/StatefulSets/table.config.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/StatefulSets/table.config.tsx
@@ -100,7 +100,11 @@ export const k8sStatefulSetsColumnsConfig: TableColumnDef<K8sStatefulSetsData>[]
 			cell: ({ value }): React.ReactNode => {
 				const availablePods = value as number;
 				return (
-					<ValidateColumnValueWrapper value={availablePods}>
+					<ValidateColumnValueWrapper
+						value={availablePods}
+						entity={InfraMonitoringEntity.STATEFULSETS}
+						attribute="available pod"
+					>
 						<TanStackTable.Text>{availablePods}</TanStackTable.Text>
 					</ValidateColumnValueWrapper>
 				);
@@ -116,7 +120,11 @@ export const k8sStatefulSetsColumnsConfig: TableColumnDef<K8sStatefulSetsData>[]
 			cell: ({ value }): React.ReactNode => {
 				const desiredPods = value as number;
 				return (
-					<ValidateColumnValueWrapper value={desiredPods}>
+					<ValidateColumnValueWrapper
+						value={desiredPods}
+						entity={InfraMonitoringEntity.STATEFULSETS}
+						attribute="desired pod"
+					>
 						<TanStackTable.Text>{desiredPods}</TanStackTable.Text>
 					</ValidateColumnValueWrapper>
 				);
@@ -173,7 +181,11 @@ export const k8sStatefulSetsColumnsConfig: TableColumnDef<K8sStatefulSetsData>[]
 			cell: ({ value }): React.ReactNode => {
 				const cpu = value as number;
 				return (
-					<ValidateColumnValueWrapper value={cpu}>
+					<ValidateColumnValueWrapper
+						value={cpu}
+						entity={InfraMonitoringEntity.STATEFULSETS}
+						attribute="CPU metric"
+					>
 						<TanStackTable.Text>{cpu}</TanStackTable.Text>
 					</ValidateColumnValueWrapper>
 				);
@@ -230,7 +242,11 @@ export const k8sStatefulSetsColumnsConfig: TableColumnDef<K8sStatefulSetsData>[]
 			cell: ({ value }): React.ReactNode => {
 				const memory = value as number;
 				return (
-					<ValidateColumnValueWrapper value={memory}>
+					<ValidateColumnValueWrapper
+						value={memory}
+						entity={InfraMonitoringEntity.STATEFULSETS}
+						attribute="memory metric"
+					>
 						<TanStackTable.Text>{formatBytes(memory)}</TanStackTable.Text>
 					</ValidateColumnValueWrapper>
 				);

--- a/frontend/src/container/InfraMonitoringK8s/Volumes/table.config.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Volumes/table.config.tsx
@@ -7,6 +7,7 @@ import EntityGroupHeader from '../Base/EntityGroupHeader';
 import K8sGroupCell from '../Base/K8sGroupCell';
 import { formatBytes } from '../commonUtils';
 import { ValidateColumnValueWrapper } from '../components';
+import { InfraMonitoringEntity } from '../constants';
 import { K8sVolumesData } from './api';
 import { HardDrive } from 'lucide-react';
 
@@ -92,7 +93,11 @@ export const k8sVolumesColumnsConfig: TableColumnDef<K8sVolumesData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const capacity = value as number;
 			return (
-				<ValidateColumnValueWrapper value={capacity}>
+				<ValidateColumnValueWrapper
+					value={capacity}
+					entity={InfraMonitoringEntity.VOLUMES}
+					attribute="capacity metric"
+				>
 					<TanStackTable.Text>{formatBytes(capacity)}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -107,7 +112,11 @@ export const k8sVolumesColumnsConfig: TableColumnDef<K8sVolumesData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const usage = value as number;
 			return (
-				<ValidateColumnValueWrapper value={usage}>
+				<ValidateColumnValueWrapper
+					value={usage}
+					entity={InfraMonitoringEntity.VOLUMES}
+					attribute="utilization metric"
+				>
 					<TanStackTable.Text>{formatBytes(usage)}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);
@@ -122,7 +131,11 @@ export const k8sVolumesColumnsConfig: TableColumnDef<K8sVolumesData>[] = [
 		cell: ({ value }): React.ReactNode => {
 			const available = value as number;
 			return (
-				<ValidateColumnValueWrapper value={available}>
+				<ValidateColumnValueWrapper
+					value={available}
+					entity={InfraMonitoringEntity.VOLUMES}
+					attribute="available metric"
+				>
 					<TanStackTable.Text>{formatBytes(available)}</TanStackTable.Text>
 				</ValidateColumnValueWrapper>
 			);


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

This handle negative values on hosts, and added attribute/entity props for the other lists to also show the tooltip when no data.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

<img width="1928" height="367" alt="image" src="https://github.com/user-attachments/assets/844b7af8-aefa-492a-abda-f751cf4b8fa4" />

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Fixes https://github.com/SigNoz/engineering-pod/issues/4871

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

Just missing handling for -1 values.

#### Fix Strategy
> How does this PR address the root cause?

Wrap the value with `ValidateColumnValueWrapper`

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Infrastructure Monitoring Pages
- Potential regressions: -
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed the issue on Infrastructure Monitoring showing -100% in IOWait for hosts with no data instead of "-" |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
