### PR TITLE
fix(global-time): initialize store with default value instead of 0

### DIFF
--- a/frontend/src/store/globalTime/__tests__/globalTimeStore.test.tsx
+++ b/frontend/src/store/globalTime/__tests__/globalTimeStore.test.tsx
@@ -54,9 +54,23 @@ describe('globalTimeStore', () => {
 			expect(result.current.lastRefreshTimestamp).toBe(0);
 		});
 
-		it('should have lastComputedMinMax with default values', () => {
+		it('should have lastComputedMinMax computed from initial selectedTime', () => {
 			const { result } = renderHook(() => useGlobalTimeStore());
-			expect(result.current.lastComputedMinMax).toStrictEqual({
+			// Now computes min/max on store creation, no longer starts with 0
+			expect(result.current.lastComputedMinMax.minTime).toBeGreaterThan(0);
+			expect(result.current.lastComputedMinMax.maxTime).toBeGreaterThan(0);
+		});
+
+		it('should not crash with invalid relative time format', () => {
+			// Invalid time formats should not crash store creation
+			const store = createGlobalTimeStore({
+				selectedTime: 'invalid_time' as GlobalTimeSelectedTime,
+			});
+
+			// Store should be created successfully
+			expect(store.getState().selectedTime).toBe('invalid_time');
+			// Should fallback to {0, 0} when parsing fails
+			expect(store.getState().lastComputedMinMax).toStrictEqual({
 				minTime: 0,
 				maxTime: 0,
 			});
@@ -724,8 +738,8 @@ describe('globalTimeStore', () => {
 			const wrapper = createIsolatedWrapper();
 			const { result } = renderHook(() => useGlobalTime(), { wrapper });
 
-			// Initial state has 0 values
-			expect(result.current.lastComputedMinMax.maxTime).toBe(0);
+			// Initial state now has computed values (no longer 0)
+			expect(result.current.lastComputedMinMax.maxTime).toBeGreaterThan(0);
 
 			act(() => {
 				result.current.setSelectedTime('15m');

--- a/frontend/src/store/globalTime/__tests__/hooks.test.tsx
+++ b/frontend/src/store/globalTime/__tests__/hooks.test.tsx
@@ -134,17 +134,17 @@ describe('useComputedMinMaxSync', () => {
 		jest.useRealTimers();
 	});
 
-	it('should compute min/max on mount when store has zero values', () => {
+	it('should have computed min/max on store creation (no longer needs mount sync)', () => {
 		const contextStore = createGlobalTimeStore({ selectedTime: '15m' });
 
-		expect(contextStore.getState().lastComputedMinMax).toStrictEqual({
-			minTime: 0,
-			maxTime: 0,
-		});
+		// Store now computes min/max on creation, not on mount
+		expect(contextStore.getState().lastComputedMinMax.minTime).toBeGreaterThan(0);
+		expect(contextStore.getState().lastComputedMinMax.maxTime).toBeGreaterThan(0);
 
+		// Hook still works but is a no-op when values already exist
 		renderHook(() => useComputedMinMaxSync(contextStore));
 
-		// Should have computed values now
+		// Values remain computed
 		expect(contextStore.getState().lastComputedMinMax.maxTime).toBeGreaterThan(0);
 		expect(contextStore.getState().lastComputedMinMax.minTime).toBeGreaterThan(0);
 	});

--- a/frontend/src/store/globalTime/globalTimeStore.ts
+++ b/frontend/src/store/globalTime/globalTimeStore.ts
@@ -12,6 +12,7 @@ import {
 	computeRounded5sMinMax,
 	isCustomTimeRange,
 	parseSelectedTime,
+	safeParseSelectedTime,
 } from './utils';
 
 export type GlobalTimeStoreApi = StoreApi<GlobalTimeStore>;
@@ -40,7 +41,7 @@ export function createGlobalTimeStore(
 		refreshInterval,
 		isRefreshEnabled: computeIsRefreshEnabled(selectedTime, refreshInterval),
 		lastRefreshTimestamp: 0,
-		lastComputedMinMax: { minTime: 0, maxTime: 0 },
+		lastComputedMinMax: safeParseSelectedTime(selectedTime),
 
 		setSelectedTime: (
 			time: GlobalTimeSelectedTime,

--- a/frontend/src/store/globalTime/utils.ts
+++ b/frontend/src/store/globalTime/utils.ts
@@ -61,6 +61,8 @@ const fallbackDurationInNanoSeconds = 30 * 1000 * NANO_SECOND_MULTIPLIER; // 30s
  * Parse the selectedTime string to get min/max time values.
  * For relative times, computes fresh values based on Date.now().
  * For custom times, extracts the stored min/max values.
+ *
+ * @throws Error - When selectedTime is relativeTime and it's invalid
  */
 export function parseSelectedTime(selectedTime: string): ParsedTimeRange {
 	if (isCustomTimeRange(selectedTime)) {
@@ -76,6 +78,18 @@ export function parseSelectedTime(selectedTime: string): ParsedTimeRange {
 	// It's a relative time like '15m', '1h', etc.
 	// Use getMinMaxForSelectedTime which computes from Date.now()
 	return getMinMaxForSelectedTime(selectedTime as Time, 0, 0);
+}
+
+/**
+ * The {@ref parseSelectedTime} can throw errors, this handles and fallbacks to 0,0 if invalid selected time is provided
+ */
+export function safeParseSelectedTime(selectedTime: string): ParsedTimeRange {
+	try {
+		return parseSelectedTime(selectedTime);
+	} catch (e) {
+		console.error('Error parsing selected time:', e);
+		return { minTime: 0, maxTime: 0 };
+	}
 }
 
 /**


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Instead of initialize as 0 that causes some lists to render incorrectly due to start/end being 0 as well.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

https://github.com/user-attachments/assets/bf4fca99-c91d-4eef-b124-50b007ab56ec

After:

https://github.com/user-attachments/assets/ed630725-7e7d-44f1-9348-091519dbca0b


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Fixes https://github.com/SigNoz/engineering-pod/issues/4880

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

Since 30m is also the default selected time, this causes the value to not be calculated.

#### Fix Strategy
> How does this PR address the root cause?

Initialize the store with the parsed value from 30m.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Yes
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Global Time store.
- Potential regressions: -
- Rollback plan: Revert this commit.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | For Infrastructure Monitoring, for relativeTime such as 30m, the page to loaded with no data due to store sync bug. Now the page is loaded correctly after a page refresh.  |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
