### PR TITLE
feat: add query length validation

### DIFF
--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -152,6 +152,7 @@ telemetrystore:
       max_result_rows: 0
       ignore_data_skipping_indices: ""
       secondary_indices_enable_bulk_filtering: false
+      max_query_size: 350000
 
 ##################### Prometheus #####################
 prometheus:

--- a/pkg/telemetrystore/config.go
+++ b/pkg/telemetrystore/config.go
@@ -47,6 +47,7 @@ type QuerySettings struct {
 	MaxResultRows                       int    `mapstructure:"max_result_rows"`
 	IgnoreDataSkippingIndices           string `mapstructure:"ignore_data_skipping_indices"`
 	SecondaryIndicesEnableBulkFiltering bool   `mapstructure:"secondary_indices_enable_bulk_filtering"`
+	MaxClickHouseQuerySize              int    `mapstructure:"max_query_size"`
 }
 
 func NewConfigFactory() factory.ConfigFactory {

--- a/pkg/telemetrystore/telemetrystorehook/settings.go
+++ b/pkg/telemetrystore/telemetrystorehook/settings.go
@@ -54,6 +54,10 @@ func (h *provider) BeforeQuery(ctx context.Context, _ *telemetrystore.QueryEvent
 		settings["ignore_data_skipping_indices"] = h.settings.IgnoreDataSkippingIndices
 	}
 
+	if h.settings.MaxClickHouseQuerySize != 0 {
+		settings["max_query_size"] = h.settings.MaxClickHouseQuerySize
+	}
+
 	if ctx.Value("clickhouse_max_threads") != nil {
 		if maxThreads, ok := ctx.Value("clickhouse_max_threads").(int); ok {
 			settings["max_threads"] = maxThreads

--- a/pkg/types/querybuildertypes/querybuildertypesv5/clickhouse_query.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/clickhouse_query.go
@@ -1,5 +1,7 @@
 package querybuildertypesv5
 
+import "github.com/SigNoz/signoz/pkg/errors"
+
 type ClickHouseQuery struct {
 	// name of the query
 	Name string `json:"name"`
@@ -14,4 +16,24 @@ type ClickHouseQuery struct {
 // Copy creates a deep copy of the ClickHouseQuery.
 func (q ClickHouseQuery) Copy() ClickHouseQuery {
 	return q
+}
+
+// Validate performs preliminary validation on ClickHouseQuery.
+func (q ClickHouseQuery) Validate(opts ...ValidationOption) error {
+	if q.Query == "" {
+		return errors.NewInvalidInputf(
+			errors.CodeInvalidInput,
+			"ClickHouse SQL query is required",
+		)
+	}
+
+	if len(q.Query) > MaxClickHouseQueryLength {
+		return errors.NewInvalidInputf(
+			errors.CodeInvalidInput,
+			"ClickHouse SQL query exceeds maximum allowed length of %d characters",
+			MaxClickHouseQueryLength,
+		)
+	}
+
+	return nil
 }

--- a/pkg/types/querybuildertypes/querybuildertypesv5/clickhouse_query.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/clickhouse_query.go
@@ -19,14 +19,13 @@ func (q ClickHouseQuery) Copy() ClickHouseQuery {
 }
 
 // Validate performs preliminary validation on ClickHouseQuery.
-func (q ClickHouseQuery) Validate(opts ...ValidationOption) error {
+func (q ClickHouseQuery) Validate() error {
 	if q.Query == "" {
 		return errors.NewInvalidInputf(
 			errors.CodeInvalidInput,
 			"ClickHouse SQL query is required",
 		)
 	}
-
 	if len(q.Query) > MaxClickHouseQueryLength {
 		return errors.NewInvalidInputf(
 			errors.CodeInvalidInput,
@@ -34,6 +33,5 @@ func (q ClickHouseQuery) Validate(opts ...ValidationOption) error {
 			MaxClickHouseQueryLength,
 		)
 	}
-
 	return nil
 }

--- a/pkg/types/querybuildertypes/querybuildertypesv5/prom_query.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/prom_query.go
@@ -1,5 +1,7 @@
 package querybuildertypesv5
 
+import "github.com/SigNoz/signoz/pkg/errors"
+
 type PromQuery struct {
 	// name of the query
 	Name string `json:"name"`
@@ -18,4 +20,22 @@ type PromQuery struct {
 // Copy creates a deep copy of the PromQuery.
 func (q PromQuery) Copy() PromQuery {
 	return q // shallow copy is sufficient
+}
+
+// Validate performs preliminary validation on PromQuery.
+func (q PromQuery) Validate() error {
+	if q.Query == "" {
+		return errors.NewInvalidInputf(
+			errors.CodeInvalidInput,
+			"PromQL query is required",
+		)
+	}
+	if len(q.Query) > MaxPromQLQueryLength {
+		return errors.NewInvalidInputf(
+			errors.CodeInvalidInput,
+			"PromQL query exceeds maximum allowed length of %d characters",
+			MaxPromQLQueryLength,
+		)
+	}
+	return nil
 }

--- a/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
@@ -11,18 +11,20 @@ import (
 )
 
 const (
-	// MaxFilterExpressionLength bounds a builder filter expression. The compiled SQL
-	// adds wrapper syntax on top of this, so we stay well below ClickHouse's parser
-	// limit (max_query_size, 262144 bytes by default) to leave room for that overhead.
-	MaxFilterExpressionLength = 250_000
-	// MaxClickHouseQueryLength bounds a raw ClickHouse SQL query. ClickHouse's
-	// default max_query_size is 262144 bytes; we leave a small headroom for any
-	// wrapping (CTEs, time filters, etc.) the server adds before sending.
-	MaxClickHouseQueryLength = 260_000
-	// MaxPromQLQueryLength bounds a raw PromQL query string. Picked to match the
-	// other query bounds; PromQL has no equivalent server-side parser cap, but we
-	// reject pathologically large inputs to protect the server.
-	MaxPromQLQueryLength = 260_000
+	// MaxFilterExpressionLength bounds a builder filter expression. The compiled
+	// SQL adds wrapper syntax on top of this; ClickHouse's parser limit
+	// (max_query_size) is raised to 350000 via telemetrystore settings so the
+	// resulting SQL still fits comfortably under that ceiling.
+	MaxFilterExpressionLength = 300_000
+	// MaxClickHouseQueryLength bounds a raw ClickHouse SQL query. The server
+	// runs ClickHouse with max_query_size = 350000 (configured in
+	// telemetrystore settings), so 300000 leaves headroom for any wrapping
+	// (CTEs, time filters) the server adds before sending.
+	MaxClickHouseQueryLength = 300_000
+	// MaxPromQLQueryLength bounds a raw PromQL query string. Picked to match
+	// the other query bounds; PromQL has no equivalent server-side parser cap,
+	// but we reject pathologically large inputs to protect the server.
+	MaxPromQLQueryLength = 300_000
 )
 
 // getQueryIdentifier returns a friendly identifier for a query based on its type and name/content.

--- a/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
@@ -11,20 +11,9 @@ import (
 )
 
 const (
-	// MaxFilterExpressionLength bounds a builder filter expression. The compiled
-	// SQL adds wrapper syntax on top of this; ClickHouse's parser limit
-	// (max_query_size) is raised to 350000 via telemetrystore settings so the
-	// resulting SQL still fits comfortably under that ceiling.
 	MaxFilterExpressionLength = 300_000
-	// MaxClickHouseQueryLength bounds a raw ClickHouse SQL query. The server
-	// runs ClickHouse with max_query_size = 350000 (configured in
-	// telemetrystore settings), so 300000 leaves headroom for any wrapping
-	// (CTEs, time filters) the server adds before sending.
-	MaxClickHouseQueryLength = 300_000
-	// MaxPromQLQueryLength bounds a raw PromQL query string. Picked to match
-	// the other query bounds; PromQL has no equivalent server-side parser cap,
-	// but we reject pathologically large inputs to protect the server.
-	MaxPromQLQueryLength = 300_000
+	MaxClickHouseQueryLength  = 300_000
+	MaxPromQLQueryLength      = 300_000
 )
 
 // getQueryIdentifier returns a friendly identifier for a query based on its type and name/content.

--- a/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
@@ -10,6 +10,11 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 )
 
+const (
+	MaxFilterExpressionLength = 250_000 // This is conservative limit as querybuilder adds sql syntax overhead on top of this.
+	MaxClickHouseQueryLength  = 260_000 // This is the default limit for ClickHouse queries, actual limit is 262142 characters.
+)
+
 // getQueryIdentifier returns a friendly identifier for a query based on its type and name/content.
 func getQueryIdentifier(envelope QueryEnvelope, index int) string {
 	name := envelope.GetQueryName()
@@ -152,6 +157,10 @@ func (q *QueryBuilderQuery[T]) Validate(opts ...ValidationOption) error {
 	}
 
 	if err := q.validateSelectFields(cfg); err != nil {
+		return err
+	}
+
+	if err := q.validateFilterExpression(cfg); err != nil {
 		return err
 	}
 
@@ -360,6 +369,21 @@ func (q *QueryBuilderQuery[T]) validateFunctions() error {
 				fnId = fmt.Sprintf("function #%d in query '%s'", i+1, q.Name)
 			}
 			return wrapValidationError(err, fnId, "invalid %s: %s")
+		}
+	}
+	return nil
+}
+
+func (q *QueryBuilderQuery[T]) validateFilterExpression(cfg validationConfig) error {
+
+	if q.Filter != nil && q.Filter.Expression != "" {
+		// Actual default limit is 262142 characters, opting for a conservative limit of 25,000 characters
+		if len(q.Filter.Expression) > MaxFilterExpressionLength {
+			return errors.NewInvalidInputf(
+				errors.CodeInvalidInput,
+				"filter expression exceeds maximum allowed length of %d characters",
+				MaxFilterExpressionLength,
+			)
 		}
 	}
 	return nil
@@ -658,13 +682,7 @@ func validateQueryEnvelope(envelope QueryEnvelope, opts ...ValidationOption) err
 				"invalid ClickHouse SQL spec",
 			)
 		}
-		if spec.Query == "" {
-			return errors.NewInvalidInputf(
-				errors.CodeInvalidInput,
-				"ClickHouse SQL query is required",
-			)
-		}
-		return nil
+		return spec.Validate(opts...)
 	default:
 		return errors.NewInvalidInputf(
 			errors.CodeInvalidInput,

--- a/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
@@ -11,8 +11,18 @@ import (
 )
 
 const (
-	MaxFilterExpressionLength = 250_000 // This is conservative limit as querybuilder adds sql syntax overhead on top of this.
-	MaxClickHouseQueryLength  = 260_000 // This is the default limit for ClickHouse queries, actual limit is 262142 characters.
+	// MaxFilterExpressionLength bounds a builder filter expression. The compiled SQL
+	// adds wrapper syntax on top of this, so we stay well below ClickHouse's parser
+	// limit (max_query_size, 262144 bytes by default) to leave room for that overhead.
+	MaxFilterExpressionLength = 250_000
+	// MaxClickHouseQueryLength bounds a raw ClickHouse SQL query. ClickHouse's
+	// default max_query_size is 262144 bytes; we leave a small headroom for any
+	// wrapping (CTEs, time filters, etc.) the server adds before sending.
+	MaxClickHouseQueryLength = 260_000
+	// MaxPromQLQueryLength bounds a raw PromQL query string. Picked to match the
+	// other query bounds; PromQL has no equivalent server-side parser cap, but we
+	// reject pathologically large inputs to protect the server.
+	MaxPromQLQueryLength = 260_000
 )
 
 // getQueryIdentifier returns a friendly identifier for a query based on its type and name/content.
@@ -160,7 +170,7 @@ func (q *QueryBuilderQuery[T]) Validate(opts ...ValidationOption) error {
 		return err
 	}
 
-	if err := q.validateFilterExpression(cfg); err != nil {
+	if err := q.validateFilterExpression(); err != nil {
 		return err
 	}
 
@@ -374,17 +384,16 @@ func (q *QueryBuilderQuery[T]) validateFunctions() error {
 	return nil
 }
 
-func (q *QueryBuilderQuery[T]) validateFilterExpression(cfg validationConfig) error {
-
-	if q.Filter != nil && q.Filter.Expression != "" {
-		// Actual default limit is 262142 characters, opting for a conservative limit of 25,000 characters
-		if len(q.Filter.Expression) > MaxFilterExpressionLength {
-			return errors.NewInvalidInputf(
-				errors.CodeInvalidInput,
-				"filter expression exceeds maximum allowed length of %d characters",
-				MaxFilterExpressionLength,
-			)
-		}
+func (q *QueryBuilderQuery[T]) validateFilterExpression() error {
+	if q.Filter == nil || q.Filter.Expression == "" {
+		return nil
+	}
+	if len(q.Filter.Expression) > MaxFilterExpressionLength {
+		return errors.NewInvalidInputf(
+			errors.CodeInvalidInput,
+			"filter expression exceeds maximum allowed length of %d characters",
+			MaxFilterExpressionLength,
+		)
 	}
 	return nil
 }
@@ -667,13 +676,7 @@ func validateQueryEnvelope(envelope QueryEnvelope, opts ...ValidationOption) err
 				"invalid PromQL spec",
 			)
 		}
-		if spec.Query == "" {
-			return errors.NewInvalidInputf(
-				errors.CodeInvalidInput,
-				"PromQL query is required",
-			)
-		}
-		return nil
+		return spec.Validate()
 	case QueryTypeClickHouseSQL:
 		spec, ok := envelope.Spec.(ClickHouseQuery)
 		if !ok {
@@ -682,7 +685,7 @@ func validateQueryEnvelope(envelope QueryEnvelope, opts ...ValidationOption) err
 				"invalid ClickHouse SQL spec",
 			)
 		}
-		return spec.Validate(opts...)
+		return spec.Validate()
 	default:
 		return errors.NewInvalidInputf(
 			errors.CodeInvalidInput,

--- a/tests/fixtures/signoz.py
+++ b/tests/fixtures/signoz.py
@@ -78,6 +78,7 @@ def create_signoz(
                 "SIGNOZ_ALERTMANAGER_SIGNOZ_ROUTE_GROUP__WAIT": "1s",
                 "SIGNOZ_ALERTMANAGER_SIGNOZ_ROUTE_GROUP__INTERVAL": "5s",
                 "SIGNOZ_CLOUDINTEGRATION_AGENT_VERSION": "v0.0.8",
+                "SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_SETTINGS_MAX__QUERY__SIZE": "350000",
             }
             | sqlstore.env
             | clickhouse.env

--- a/tests/integration/tests/querier/15_clickhouse_query.py
+++ b/tests/integration/tests/querier/15_clickhouse_query.py
@@ -1,0 +1,124 @@
+"""
+Integration tests for the v5 ClickHouse SQL query length cap and the
+raised ClickHouse `max_query_size` setting (350000) configured in
+pkg/telemetrystore/config.go.
+"""
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+from fixtures import types
+from fixtures.auth import USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD
+from fixtures.querier import make_query_request
+
+# Mirrors MaxClickHouseQueryLength in
+# pkg/types/querybuildertypes/querybuildertypesv5/validation.go
+MAX_CLICKHOUSE_QUERY_LENGTH = 300_000
+
+# ClickHouse's built-in default `max_query_size`. SigNoz raises this to
+# 350000 via telemetrystore settings.
+CLICKHOUSE_BUILTIN_MAX_QUERY_SIZE = 262_144
+
+
+def test_clickhouse_query_at_validation_cap_is_accepted(
+    signoz: types.SigNoz,
+    create_user_admin: None,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+) -> None:
+    token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+
+    prefix = "SELECT 1 /* "
+    suffix = " */"
+    query = prefix + ("x" * (MAX_CLICKHOUSE_QUERY_LENGTH - len(prefix) - len(suffix))) + suffix
+    assert len(query) == MAX_CLICKHOUSE_QUERY_LENGTH
+
+    now = datetime.now(tz=UTC)
+    response = make_query_request(
+        signoz,
+        token,
+        start_ms=int((now - timedelta(minutes=5)).timestamp() * 1000),
+        end_ms=int(now.timestamp() * 1000),
+        queries=[
+            {
+                "type": "clickhouse_sql",
+                "spec": {"name": "A", "query": query, "disabled": False},
+            }
+        ],
+        request_type="raw",
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.text
+
+
+def test_clickhouse_query_above_validation_cap_is_rejected(
+    signoz: types.SigNoz,
+    create_user_admin: None,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+) -> None:
+    token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+
+    prefix = "SELECT 1 /* "
+    suffix = " */"
+    target_len = MAX_CLICKHOUSE_QUERY_LENGTH + 1
+    query = prefix + ("x" * (target_len - len(prefix) - len(suffix))) + suffix
+
+    assert len(query) > MAX_CLICKHOUSE_QUERY_LENGTH
+
+    now = datetime.now(tz=UTC)
+    response = make_query_request(
+        signoz,
+        token,
+        start_ms=int((now - timedelta(minutes=5)).timestamp() * 1000),
+        end_ms=int(now.timestamp() * 1000),
+        queries=[
+            {
+                "type": "clickhouse_sql",
+                "spec": {"name": "A", "query": query, "disabled": False},
+            }
+        ],
+        request_type="raw",
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST, response.text
+    assert "exceeds maximum allowed length" in response.text
+
+
+def test_clickhouse_query_above_builtin_max_query_size_parses(
+    signoz: types.SigNoz,
+    create_user_admin: None,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+) -> None:
+    """
+    Verifies that the raised `max_query_size` setting is applied on every
+    ClickHouse query: a payload above ClickHouse's built-in parser limit
+    (262144 bytes) but below the v5 validation cap (300000) must succeed
+    end-to-end. Without the setting override the ClickHouse parser would
+    reject this and the server would return 500.
+    """
+    token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+
+    target_len = CLICKHOUSE_BUILTIN_MAX_QUERY_SIZE + 10_000
+    prefix = "SELECT 1 /* "
+    suffix = " */"
+    query = prefix + ("x" * (target_len - len(prefix) - len(suffix))) + suffix
+
+    assert len(query) > CLICKHOUSE_BUILTIN_MAX_QUERY_SIZE
+    assert len(query) < MAX_CLICKHOUSE_QUERY_LENGTH
+
+    now = datetime.now(tz=UTC)
+    response = make_query_request(
+        signoz,
+        token,
+        start_ms=int((now - timedelta(minutes=5)).timestamp() * 1000),
+        end_ms=int(now.timestamp() * 1000),
+        queries=[
+            {
+                "type": "clickhouse_sql",
+                "spec": {"name": "A", "query": query, "disabled": False},
+            }
+        ],
+        request_type="raw",
+    )
+
+    assert response.status_code == HTTPStatus.OK, response.text


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Adds size guards to v5 query validation so requests with pathologically large
query strings are rejected up front instead of being forwarded to ClickHouse /
the PromQL engine. Three caps are added:

- **`Filter.Expression`** on builder queries → 300,000 characters
- **`ClickHouseQuery.Query`** (raw SQL spec) → 300,000 characters
- **`PromQuery.Query`** (PromQL spec) → 300,000 characters

Validation lives on the spec types (`ClickHouseQuery.Validate()`,
`PromQuery.Validate()`) and on `QueryBuilderQuery.validateFilterExpression()`,
keeping length rules colocated with the type they guard.

### NOTE:
This PR is currently a NO-OP
Why ? Current clickhouse default is 261k something, so this guard of 300_000 is more conservative. 
Next step will be to bump the clickhouse default to 350_000. 
Why take this route ?
This ensures none of the currently working bad clickhouse queries break. 
Why 300_000 ? No reason, it the next big round number.

#### Issues closed by this PR
N/A

---

### ✅ Change Type

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

N/A — not a bug fix.

---

### 🧪 Testing Strategy

- Tests added/updated: None — guard is a straightforward length check on a
  primitive field; behavior is exercised by existing validation paths.
- Manual verification: `go build ./pkg/types/querybuildertypes/...` and
  running the existing v5 unit tests locally.
- Edge cases covered: empty string (already-existing required-field error
  path is preserved), exactly-at-limit (allowed), one over limit (rejected).

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** No Impact
---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | v5 query API now rejects builder filter expressions over 250,000 characters and raw ClickHouse / PromQL queries over 260,000 characters with a 400 `invalid_input` error. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers