### PR TITLE
fix: return 404 when no comparable spans are found

### DIFF
--- a/pkg/modules/spanpercentile/implspanpercentile/module.go
+++ b/pkg/modules/spanpercentile/implspanpercentile/module.go
@@ -52,7 +52,7 @@ func (m *module) GetSpanPercentile(ctx context.Context, orgID valuer.UUID, req *
 
 func transformToSpanPercentileResponse(queryResult *qbtypes.QueryRangeResponse) (*spanpercentiletypes.SpanPercentileResponse, error) {
 	if len(queryResult.Data.Results) == 0 {
-		return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "no data returned from query")
+		return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "no spans found matching the specified criteria")
 	}
 
 	scalarData, ok := queryResult.Data.Results[0].(*qbtypes.ScalarData)
@@ -61,7 +61,7 @@ func transformToSpanPercentileResponse(queryResult *qbtypes.QueryRangeResponse) 
 	}
 
 	if len(scalarData.Data) == 0 {
-		return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "no rows returned from query")
+		return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "no spans found matching the specified criteria")
 	}
 
 	row := scalarData.Data[0]


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
The `/api/v1/span_percentile` endpoint was returning HTTP 500 when the query returned no rows — for example, when no other spans with the same service name and operation existed in the selected time window. A 500 implies a server fault, which was incorrect: the request is valid, the query ran successfully, and the absence of data is an expected outcome (e.g. sparse operations, first-ever span of a type, or a time window with no traffic).

The frontend already hides the span percentile panel on any non-200 response, so UX change can be taken independently.

---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

#### Fix Strategy

---

### 🧪 Testing Strategy

- Tests added/updated: none required (logic is unchanged; only error type corrected)
- Manual verification: confirmed the endpoint previously returned 500 for a valid request with no historical spans in the query window
- Edge cases covered: 

---

### ⚠️ Risk & Impact Assessment

- Blast radius: single endpoint, two error-path branches only
- Potential regressions: none 
- Rollback plan: revert the two-line change

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | `GET /api/v1/span_percentile` no longer returns 500 when no comparable spans exist in the selected time window; returns 404 instead |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers
