### PR TITLE
fix(alert-details): missing icon for nodata alerts

### DIFF
--- a/frontend/src/pages/AlertDetails/AlertHeader/AlertState/AlertState.tsx
+++ b/frontend/src/pages/AlertDetails/AlertHeader/AlertState/AlertState.tsx
@@ -17,7 +17,7 @@ export default function AlertState({
 	let label;
 	const isDarkMode = useIsDarkMode();
 	switch (state) {
-		case 'no-data':
+		case 'nodata':
 			icon = (
 				<CircleOff
 					size={18}

--- a/frontend/src/types/api/alerts/def.ts
+++ b/frontend/src/types/api/alerts/def.ts
@@ -109,7 +109,8 @@ export type AlertRuleTimelineTableResponsePayload = {
 		labels: AlertLabelsProps['labels'];
 	};
 };
-type AlertState = 'firing' | 'normal' | 'no-data' | 'muted';
+
+type AlertState = 'firing' | 'normal' | 'nodata' | 'muted';
 
 export interface AlertRuleTimelineGraphResponse {
 	start: number;

--- a/pkg/query-service/model/alerting.go
+++ b/pkg/query-service/model/alerting.go
@@ -134,7 +134,7 @@ type RuleStateHistory struct {
 	// One of ["normal", "firing"]
 	OverallState        AlertState `json:"overallState" ch:"overall_state"`
 	OverallStateChanged bool       `json:"overallStateChanged" ch:"overall_state_changed"`
-	// One of ["normal", "firing", "no_data", "muted"]
+	// One of ["normal", "firing", "nodata", "muted"]
 	State        AlertState   `json:"state" ch:"state"`
 	StateChanged bool         `json:"stateChanged" ch:"state_changed"`
 	UnixMilli    int64        `json:"unixMilli" ch:"unix_milli"`


### PR DESCRIPTION
### 📄 Summary

The "state" column in the Alert history page is empty for no-data alerts.
This PR adds the missing icon and text.


#### Screenshots / Screen Recordings (if applicable)

Before
<img width="1012" height="390" alt="image" src="https://github.com/user-attachments/assets/776d9848-085d-4bc0-bd48-74b05a1dbda7" />

After
<img width="1004" height="339" alt="image" src="https://github.com/user-attachments/assets/ae02c968-5a2a-4a8b-b579-ba1d437bbb9a" />


#### Issues closed by this PR

- Closes https://github.com/SigNoz/engineering-pod/issues/4830

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

The "state" column in the Alert history page is empty for no-data alerts.

#### Root Cause

The state check compared the wrong text status: "no-data" instead of "nodata"

#### Fix Strategy

Use the correct alert state

---

### 🧪 Testing Strategy

- Tests added/updated:
- Manual verification: ✅
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Alert history page
- Potential regressions: Not expected
- Rollback plan: Revert PR

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | "No-data" alerts icon will now be visible in alert history |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
