### PR TITLE
fix: enforce minimum step interval for v3 promql queries

### DIFF
--- a/pkg/query-service/app/parser.go
+++ b/pkg/query-service/app/parser.go
@@ -769,6 +769,13 @@ func ParseQueryRangeParams(r *http.Request) (*v3.QueryRangeParamsV3, *model.ApiE
 		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: err}
 	}
 
+	// Clamp the top-level Step for PromQL
+	if queryRangeParams.CompositeQuery.QueryType == v3.QueryTypePromQL {
+		if minStep := common.MinAllowedStepInterval(queryRangeParams.Start, queryRangeParams.End); queryRangeParams.Step < minStep {
+			queryRangeParams.Step = minStep
+		}
+	}
+
 	// prepare the variables for the corresponding query type
 	formattedVars := make(map[string]interface{})
 	for name, value := range queryRangeParams.Variables {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

  The /api/v3/query_range and /api/v4/query_range handlers crash the process with panic: runtime error: integer divide by zero when a PromQL
   request arrives with step: 0 (or omitted). The panic originates in querycache.FindMissingTimeRanges at query_range_cache.go:197:

  adjustStep := int64(math.Min(float64(step), 60))
  roundedMillis := endMillis - (endMillis % (adjustStep * 1000))  // step=0 → mod 0 → panic

  runPromQueries passes the top-level params.Step straight to the cache without validation. The existing MinAllowedStepInterval clamp in
  ParseQueryRangeParams is gated on QueryTypeBuilder and only adjusts per-query BuilderQuery.StepInterval, so the PromQL top-level Step is
  never normalized.

  Fix

  Clamp queryRangeParams.Step to MinAllowedStepInterval(Start, End) (≥ 60s) for PromQL requests in ParseQueryRangeParams. Shared between v3
  and v4 handlers — one change, both paths covered. v5 already defaults zero step in its own querier and doesn't use this cache package, so
  no change needed there.


#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

#### Fix Strategy
> How does this PR address the root cause?

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification:
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix / Maintenance |
| Description | User-facing summary |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
