### PR TITLE
fix(alerts): invalidate rule cache after disable/enable toggle

### DIFF
--- a/frontend/src/container/ListAlertRules/ToggleAlertState.tsx
+++ b/frontend/src/container/ListAlertRules/ToggleAlertState.tsx
@@ -1,6 +1,8 @@
 import { Dispatch, SetStateAction, useState } from 'react';
+import { useQueryClient } from 'react-query';
 import { patchRulePartial } from 'api/alerts/patchRulePartial';
 import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
+import { getGetRuleByIDQueryKey } from 'api/generated/services/rules';
 import type {
 	RenderErrorResponseDTO,
 	RuletypesRuleDTO,
@@ -28,6 +30,7 @@ function ToggleAlertState({
 
 	const { notifications } = useNotifications();
 	const { showErrorModal } = useErrorModal();
+	const queryClient = useQueryClient();
 
 	const onToggleHandler = async (
 		id: string,
@@ -60,6 +63,9 @@ function ToggleAlertState({
 				loading: false,
 				payload: updatedRule,
 			}));
+
+			queryClient.invalidateQueries(getGetRuleByIDQueryKey({ id }));
+
 			notifications.success({
 				message: 'Success',
 			});

--- a/frontend/src/container/ListAlertRules/ToggleAlertState.tsx
+++ b/frontend/src/container/ListAlertRules/ToggleAlertState.tsx
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction, useState } from 'react';
 import { useQueryClient } from 'react-query';
 import { patchRulePartial } from 'api/alerts/patchRulePartial';
 import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
-import { getGetRuleByIDQueryKey } from 'api/generated/services/rules';
+import { invalidateGetRuleByID } from 'api/generated/services/rules';
 import type {
 	RenderErrorResponseDTO,
 	RuletypesRuleDTO,
@@ -64,7 +64,7 @@ function ToggleAlertState({
 				payload: updatedRule,
 			}));
 
-			queryClient.invalidateQueries(getGetRuleByIDQueryKey({ id }));
+			invalidateGetRuleByID(queryClient, { id });
 
 			notifications.success({
 				message: 'Success',

--- a/frontend/src/pages/AlertDetails/hooks.tsx
+++ b/frontend/src/pages/AlertDetails/hooks.tsx
@@ -12,7 +12,7 @@ import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import {
 	createRule,
 	deleteRuleByID,
-	getGetRuleByIDQueryKey,
+	invalidateGetRuleByID,
 	updateRuleByID,
 	useGetRuleByID,
 	useListRules,
@@ -409,8 +409,8 @@ export const useAlertRuleStatusToggle = ({
 		{
 			onSuccess: (data) => {
 				setAlertRuleState(data.data.state);
+				invalidateGetRuleByID(queryClient, { id: ruleId });
 				queryClient.refetchQueries([REACT_QUERY_KEY.ALERT_RULE_DETAILS, ruleId]);
-				queryClient.invalidateQueries(getGetRuleByIDQueryKey({ id: ruleId }));
 				notifications.success({
 					message: `Alert has been ${
 						data.data.state === 'disabled' ? 'disabled' : 'enabled'
@@ -418,8 +418,8 @@ export const useAlertRuleStatusToggle = ({
 				});
 			},
 			onError: (error) => {
+				invalidateGetRuleByID(queryClient, { id: ruleId });
 				queryClient.refetchQueries([REACT_QUERY_KEY.ALERT_RULE_DETAILS, ruleId]);
-				queryClient.invalidateQueries(getGetRuleByIDQueryKey({ id: ruleId }));
 				showErrorModal(
 					convertToApiError(error as AxiosError<RenderErrorResponseDTO>) as APIError,
 				);

--- a/frontend/src/pages/AlertDetails/hooks.tsx
+++ b/frontend/src/pages/AlertDetails/hooks.tsx
@@ -12,6 +12,7 @@ import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import {
 	createRule,
 	deleteRuleByID,
+	getGetRuleByIDQueryKey,
 	updateRuleByID,
 	useGetRuleByID,
 	useListRules,
@@ -409,6 +410,7 @@ export const useAlertRuleStatusToggle = ({
 			onSuccess: (data) => {
 				setAlertRuleState(data.data.state);
 				queryClient.refetchQueries([REACT_QUERY_KEY.ALERT_RULE_DETAILS, ruleId]);
+				queryClient.invalidateQueries(getGetRuleByIDQueryKey({ id: ruleId }));
 				notifications.success({
 					message: `Alert has been ${
 						data.data.state === 'disabled' ? 'disabled' : 'enabled'
@@ -417,6 +419,7 @@ export const useAlertRuleStatusToggle = ({
 			},
 			onError: (error) => {
 				queryClient.refetchQueries([REACT_QUERY_KEY.ALERT_RULE_DETAILS, ruleId]);
+				queryClient.invalidateQueries(getGetRuleByIDQueryKey({ id: ruleId }));
 				showErrorModal(
 					convertToApiError(error as AxiosError<RenderErrorResponseDTO>) as APIError,
 				);


### PR DESCRIPTION
### 📄 Summary

The Disable/Enable toggle on alert rules was being reverted whenever a user edited and saved the rule without reloading the page. The toggle updated the disabled state, but didn't invalidate the react-query cache used by the Edit form. When user saved the form, it sent the old values to the server, silently reverting the user's toggle.

The fix invalidates the generated `useGetRuleByID` query key after a successful toggle. This forces a refetch so the next save sends the correct disabled state.

#### Screenshots / Screen Recordings (if applicable)

NA


#### Issues closed by this PR

- Closes #11290

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

The two disable/enable toggle paths (`ToggleAlertState` and `useAlertRuleStatusToggle`) called patchRulePartial but never invalidated the generated useGetRuleByID query. On save, the form serialized the stale flag, overwriting the toggled state on the server.


#### Fix Strategy

After a successful call to enable/disable a rule, invalidate the cache so the Edit form refetches fresh data.

---

### 🧪 Testing Strategy

- Tests added/updated:
- Manual verification: Open an alert page. Enable/disable it. The click the save button. On reload, the disable rule toggle should not have reverted.
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Alert rules enable/disable toggle and the edit form.
- Potential regressions: Not a regression, but there there would be an extra API call after invalidation.
- Rollback plan: Revert the PR

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix / Maintenance |
| Description | Enabling/disabling an alert rule would no longer silently revert that status on subsequent save. |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
