### PR TITLE
chore(husky): ensure can run without xterm-256color

### DIFF
--- a/frontend/.husky/commit-msg
+++ b/frontend/.husky/commit-msg
@@ -5,9 +5,15 @@ cd frontend && pnpm run commitlint --edit $1
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
 
-color_red="$(tput setaf 1)"
-bold="$(tput bold)"
-reset="$(tput sgr0)"
+if [ -n "$TERM" ] && [ "$TERM" != "dumb" ]; then
+  color_red="$(tput setaf 1)"
+  bold="$(tput bold)"
+  reset="$(tput sgr0)"
+else
+  color_red=""
+  bold=""
+  reset=""
+fi
 
 if [ "$branch" = "main" ]; then
   echo "${color_red}${bold}You can't commit directly to the main branch${reset}"


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Solve issue when commiting via Webstorm UI.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: -
- Manual verification: Yes
- Edge cases covered: -

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance |
| Description | Allow developers to be able to commit on repository via Webstorm (or without $TERM) |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered