### PR TITLE
fix(infra-monitoring): error due to invalid operators on query builder

### DIFF
--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.tsx
@@ -32,9 +32,23 @@ import { isKeyMatch } from './utils';
 import './Checkbox.styles.scss';
 
 const SELECTED_OPERATORS = [OPERATORS['='], 'in'];
-const NON_SELECTED_OPERATORS = [OPERATORS['!='], 'not in'];
+const NON_SELECTED_OPERATORS = [OPERATORS['!='], 'not in', 'nin'];
 
 const SOURCES_WITH_EMPTY_STATE_ENABLED = [QuickFiltersSource.LOGS_EXPLORER];
+
+// Sources that use backend APIs expecting short operator format (e.g., 'nin' instead of 'not in')
+const SOURCES_WITH_SHORT_OPERATORS = [QuickFiltersSource.INFRA_MONITORING];
+
+/**
+ * Returns the correct NOT_IN operator value based on source.
+ * InfraMonitoring backend expects 'nin', others expect 'not in'.
+ */
+function getNotInOperator(source: QuickFiltersSource): string {
+	if (SOURCES_WITH_SHORT_OPERATORS.includes(source)) {
+		return 'nin';
+	}
+	return getOperatorValue('NOT_IN');
+}
 
 function setDefaultValues(
 	values: string[],
@@ -401,6 +415,7 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 								}
 							}
 							break;
+						case 'nin':
 						case 'not in':
 							// if the current running operator is NIN then when unchecking the value it gets
 							// added to the clause like key NIN [value1 , currentUnselectedValue]
@@ -495,7 +510,7 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 							if (!checked) {
 								const newFilter = {
 									...currentFilter,
-									op: getOperatorValue('NOT_IN'),
+									op: getNotInOperator(source),
 									value: [currentFilter.value as string, value],
 								};
 								query.filters.items = query.filters.items.map((item) => {
@@ -518,7 +533,7 @@ export default function CheckboxFilter(props: ICheckboxProps): JSX.Element {
 				// case  - when there is no filter for the current key that means all are selected right now.
 				const newFilterItem: TagFilterItem = {
 					id: uuid(),
-					op: getOperatorValue('NOT_IN'),
+					op: getNotInOperator(source),
 					key: filter.attributeKey,
 					value,
 				};

--- a/frontend/src/constants/queryBuilder.ts
+++ b/frontend/src/constants/queryBuilder.ts
@@ -431,6 +431,31 @@ export const OPERATORS = {
 	NOTILIKE: 'NOT_ILIKE',
 };
 
+/**
+ * Maps short-form InfraMonitoring operators to long-form display labels.
+ * InfraMonitoring backend uses short forms (NIN), UI displays long forms (NOT_IN).
+ */
+export const INFRA_SHORT_TO_LONG_OPERATOR_MAP: Record<string, string> = {
+	NIN: 'NOT_IN',
+	NLIKE: 'NOT_LIKE',
+	NOTILIKE: 'NOT_ILIKE',
+	NREGEX: 'NOT_REGEX',
+	NEXISTS: 'NOT_EXISTS',
+	NCONTAINS: 'NOT_CONTAINS',
+};
+
+/**
+ * Maps long-form operators to short-form for InfraMonitoring API.
+ */
+export const INFRA_LONG_TO_SHORT_OPERATOR_MAP: Record<string, string> = {
+	NOT_IN: 'NIN',
+	NOT_LIKE: 'NLIKE',
+	NOT_ILIKE: 'NOTILIKE',
+	NOT_REGEX: 'NREGEX',
+	NOT_EXISTS: 'NEXISTS',
+	NOT_CONTAINS: 'NCONTAINS',
+};
+
 export const QUERY_BUILDER_OPERATORS_BY_TYPES = {
 	string: [
 		OPERATORS['='],

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
@@ -12,7 +12,10 @@ import { useLocation } from 'react-router-dom';
 import { Button, Select, Spin, Tag, Tooltip } from 'antd';
 import { Typography } from '@signozhq/ui/typography';
 import cx from 'classnames';
-import { OPERATORS } from 'constants/queryBuilder';
+import {
+	INFRA_LONG_TO_SHORT_OPERATOR_MAP,
+	OPERATORS,
+} from 'constants/queryBuilder';
 import ROUTES from 'constants/routes';
 import { LogsExplorerShortcuts } from 'constants/shortcuts/logsExplorerShortcuts';
 import { InfraMonitoringEntity } from 'container/InfraMonitoringK8s/constants';
@@ -68,26 +71,13 @@ import {
 
 import './QueryBuilderSearch.styles.scss';
 
-/**
- * Maps long-form operators to short-form for InfraMonitoring when typed by user.
- * This ensures NOT_IN typed by user becomes 'nin' internally.
- */
-const INFRA_TYPED_OPERATOR_MAP: Record<string, string> = {
-	NOT_IN: 'NIN',
-	NOT_LIKE: 'NLIKE',
-	NOT_ILIKE: 'NOTILIKE',
-	NOT_REGEX: 'NREGEX',
-	NOT_EXISTS: 'NEXISTS',
-	NOT_CONTAINS: 'NCONTAINS',
-};
-
 function getOperatorValueForContext(
 	op: string,
 	isInfraMonitoring?: boolean,
 ): string {
 	const mappedOp =
-		isInfraMonitoring && INFRA_TYPED_OPERATOR_MAP[op]
-			? INFRA_TYPED_OPERATOR_MAP[op]
+		isInfraMonitoring && INFRA_LONG_TO_SHORT_OPERATOR_MAP[op]
+			? INFRA_LONG_TO_SHORT_OPERATOR_MAP[op]
 			: op;
 	return getOperatorValue(mappedOp);
 }

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/index.tsx
@@ -68,6 +68,30 @@ import {
 
 import './QueryBuilderSearch.styles.scss';
 
+/**
+ * Maps long-form operators to short-form for InfraMonitoring when typed by user.
+ * This ensures NOT_IN typed by user becomes 'nin' internally.
+ */
+const INFRA_TYPED_OPERATOR_MAP: Record<string, string> = {
+	NOT_IN: 'NIN',
+	NOT_LIKE: 'NLIKE',
+	NOT_ILIKE: 'NOTILIKE',
+	NOT_REGEX: 'NREGEX',
+	NOT_EXISTS: 'NEXISTS',
+	NOT_CONTAINS: 'NCONTAINS',
+};
+
+function getOperatorValueForContext(
+	op: string,
+	isInfraMonitoring?: boolean,
+): string {
+	const mappedOp =
+		isInfraMonitoring && INFRA_TYPED_OPERATOR_MAP[op]
+			? INFRA_TYPED_OPERATOR_MAP[op]
+			: op;
+	return getOperatorValue(mappedOp);
+}
+
 function QueryBuilderSearch({
 	query,
 	onChange,
@@ -301,7 +325,7 @@ function QueryBuilderSearch({
 					dataType: fetchValueDataType(computedTagValue, tagOperator),
 					type: '',
 				},
-				op: getOperatorValue(tagOperator),
+				op: getOperatorValueForContext(tagOperator, isInfraMonitoring),
 				value: computedTagValue,
 			};
 		});

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/utils.ts
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/utils.ts
@@ -15,6 +15,7 @@ export function isInNInOperator(value: string): boolean {
 		value === 'NOT_IN' ||
 		value === 'NIN' ||
 		value === 'in' ||
+		value === 'not in' ||
 		value === 'nin'
 	);
 }
@@ -51,7 +52,8 @@ export function isExistsNotExistsOperator(value: string): boolean {
 	const { tagOperator } = getTagToken(value);
 	return (
 		tagOperator?.trim() === OPERATORS.NOT_EXISTS ||
-		tagOperator?.trim() === OPERATORS.EXISTS
+		tagOperator?.trim() === OPERATORS.EXISTS ||
+		tagOperator?.trim() === 'NEXISTS'
 	);
 }
 

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/utils.ts
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearch/utils.ts
@@ -7,10 +7,16 @@ import { TagFilter } from 'types/api/queryBuilder/queryBuilderData';
 import { orderByValueDelimiter } from '../OrderByFilter/utils';
 
 export const tagRegexp =
-	/^\s*(.*?)\s*(\bIN\b|\bNOT_IN\b|\bLIKE\b|\bNOT_LIKE\b|\bILIKE\b|\bNOT_ILIKE\b|\bREGEX\b|\bNOT_REGEX\b|=|!=|\bEXISTS\b|\bNOT_EXISTS\b|\bCONTAINS\b|\bNOT_CONTAINS\b|>=|>|<=|<|\bHAS\b|\bNHAS\b)\s*(.*)$/gi;
+	/^\s*(.*?)\s*(\bIN\b|\bNOT_IN\b|\bNIN\b|\bLIKE\b|\bNOT_LIKE\b|\bNLIKE\b|\bILIKE\b|\bNOT_ILIKE\b|\bNOTILIKE\b|\bREGEX\b|\bNOT_REGEX\b|\bNREGEX\b|=|!=|\bEXISTS\b|\bNOT_EXISTS\b|\bNEXISTS\b|\bCONTAINS\b|\bNOT_CONTAINS\b|\bNCONTAINS\b|>=|>|<=|<|\bHAS\b|\bNHAS\b)\s*(.*)$/gi;
 
 export function isInNInOperator(value: string): boolean {
-	return value === OPERATORS.IN || value === OPERATORS.NIN;
+	return (
+		value === 'IN' ||
+		value === 'NOT_IN' ||
+		value === 'NIN' ||
+		value === 'in' ||
+		value === 'nin'
+	);
 }
 
 interface ITagToken {
@@ -83,6 +89,19 @@ export function getOperatorValue(op: string): string {
 			return 'contains';
 		case 'NOT_CONTAINS':
 			return 'not contains';
+		// Short form operators (InfraMonitoring)
+		case 'NIN':
+			return 'nin';
+		case 'NLIKE':
+			return 'nlike';
+		case 'NOTILIKE':
+			return 'notilike';
+		case 'NREGEX':
+			return 'nregex';
+		case 'NEXISTS':
+			return 'nexists';
+		case 'NCONTAINS':
+			return 'ncontains';
 		default:
 			return op;
 	}
@@ -114,6 +133,19 @@ export function getOperatorFromValue(op: string): string {
 			return OPERATORS.HAS;
 		case 'not has':
 			return OPERATORS.NHAS;
+		// Short-form operators (InfraMonitoring)
+		case 'nin':
+			return 'NIN';
+		case 'nlike':
+			return 'NLIKE';
+		case 'notilike':
+			return 'NOTILIKE';
+		case 'nregex':
+			return 'NREGEX';
+		case 'nexists':
+			return 'NEXISTS';
+		case 'ncontains':
+			return 'NCONTAINS';
 		default:
 			return op;
 	}

--- a/frontend/src/hooks/queryBuilder/useAutoComplete.ts
+++ b/frontend/src/hooks/queryBuilder/useAutoComplete.ts
@@ -67,6 +67,7 @@ export const useAutoComplete = (
 		query,
 		setSearchKey,
 		whereClauseConfig,
+		isInfraMonitoring,
 	);
 
 	const handleSelect = useCallback(

--- a/frontend/src/hooks/queryBuilder/useAutoComplete.ts
+++ b/frontend/src/hooks/queryBuilder/useAutoComplete.ts
@@ -142,6 +142,7 @@ export const useAutoComplete = (
 		result,
 		isFetching,
 		whereClauseConfig,
+		isInfraMonitoring,
 	);
 
 	return {

--- a/frontend/src/hooks/queryBuilder/useOperatorType.ts
+++ b/frontend/src/hooks/queryBuilder/useOperatorType.ts
@@ -27,6 +27,13 @@ export const operatorTypeMapper: Record<string, OperatorType> = {
 	[OPERATORS['!=']]: 'SINGLE_VALUE',
 	[OPERATORS.HAS]: 'SINGLE_VALUE',
 	[OPERATORS.NHAS]: 'SINGLE_VALUE',
+	// Short-form operators for InfraMonitoring
+	NIN: 'MULTIPLY_VALUE',
+	NLIKE: 'SINGLE_VALUE',
+	NOTILIKE: 'SINGLE_VALUE',
+	NREGEX: 'SINGLE_VALUE',
+	NEXISTS: 'NON_VALUE',
+	NCONTAINS: 'SINGLE_VALUE',
 };
 
 export const useOperatorType = (operator: string): OperatorType =>

--- a/frontend/src/hooks/queryBuilder/useOptions.ts
+++ b/frontend/src/hooks/queryBuilder/useOptions.ts
@@ -14,15 +14,16 @@ import { useOperators } from './useOperators';
 export const WHERE_CLAUSE_CUSTOM_SUFFIX = '-custom';
 
 /**
- * Maps long form operators to short form for InfraMonitoring.
+ * Maps short form operators to long form labels for InfraMonitoring display.
+ * Value stays as short form (NIN), label shows as long form (NOT_IN).
  */
-const INFRA_OPERATOR_DISPLAY_MAP: Record<string, string> = {
-	NOT_IN: 'NIN',
-	NOT_LIKE: 'NLIKE',
-	NOT_ILIKE: 'NOTILIKE',
-	NOT_REGEX: 'NREGEX',
-	NOT_EXISTS: 'NEXISTS',
-	NOT_CONTAINS: 'NCONTAINS',
+const INFRA_OPERATOR_LABEL_MAP: Record<string, string> = {
+	NIN: 'NOT_IN',
+	NLIKE: 'NOT_LIKE',
+	NOTILIKE: 'NOT_ILIKE',
+	NREGEX: 'NOT_REGEX',
+	NEXISTS: 'NOT_EXISTS',
+	NCONTAINS: 'NOT_CONTAINS',
 };
 
 export const useOptions = (
@@ -121,13 +122,13 @@ export const useOptions = (
 					)
 				: operators;
 			const operatorsOptions = filteredOperators?.map((op) => {
-				const displayOp =
-					isInfraMonitoring && INFRA_OPERATOR_DISPLAY_MAP[op]
-						? INFRA_OPERATOR_DISPLAY_MAP[op]
+				const labelOp =
+					isInfraMonitoring && INFRA_OPERATOR_LABEL_MAP[op]
+						? INFRA_OPERATOR_LABEL_MAP[op]
 						: op;
 				return {
-					value: `${partialKey} ${displayOp} `,
-					label: `${partialKey} ${displayOp} `,
+					value: `${partialKey} ${op} `,
+					label: `${partialKey} ${labelOp} `,
 				};
 			});
 			if (whereClauseConfig) {

--- a/frontend/src/hooks/queryBuilder/useOptions.ts
+++ b/frontend/src/hooks/queryBuilder/useOptions.ts
@@ -13,6 +13,18 @@ import { useOperators } from './useOperators';
 
 export const WHERE_CLAUSE_CUSTOM_SUFFIX = '-custom';
 
+/**
+ * Maps long form operators to short form for InfraMonitoring.
+ */
+const INFRA_OPERATOR_DISPLAY_MAP: Record<string, string> = {
+	NOT_IN: 'NIN',
+	NOT_LIKE: 'NLIKE',
+	NOT_ILIKE: 'NOTILIKE',
+	NOT_REGEX: 'NREGEX',
+	NOT_EXISTS: 'NEXISTS',
+	NOT_CONTAINS: 'NCONTAINS',
+};
+
 export const useOptions = (
 	key: string,
 	keys: BaseAutocompleteData[],
@@ -25,6 +37,7 @@ export const useOptions = (
 	result: string[],
 	isFetching: boolean,
 	whereClauseConfig?: WhereClauseConfig,
+	isInfraMonitoring?: boolean,
 	// eslint-disable-next-line sonarjs/cognitive-complexity
 ): Option[] => {
 	const [options, setOptions] = useState<Option[]>([]);
@@ -107,10 +120,16 @@ export const useOptions = (
 						operator.startsWith(partialOperator?.toUpperCase()),
 					)
 				: operators;
-			const operatorsOptions = filteredOperators?.map((operator) => ({
-				value: `${partialKey} ${operator} `,
-				label: `${partialKey} ${operator} `,
-			}));
+			const operatorsOptions = filteredOperators?.map((op) => {
+				const displayOp =
+					isInfraMonitoring && INFRA_OPERATOR_DISPLAY_MAP[op]
+						? INFRA_OPERATOR_DISPLAY_MAP[op]
+						: op;
+				return {
+					value: `${partialKey} ${displayOp} `,
+					label: `${partialKey} ${displayOp} `,
+				};
+			});
 			if (whereClauseConfig) {
 				return [
 					{
@@ -122,7 +141,7 @@ export const useOptions = (
 			}
 			return operatorsOptions;
 		},
-		[operators, searchValue, whereClauseConfig],
+		[isInfraMonitoring, operators, searchValue, whereClauseConfig],
 	);
 
 	useEffect(() => {

--- a/frontend/src/hooks/queryBuilder/useOptions.ts
+++ b/frontend/src/hooks/queryBuilder/useOptions.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { INFRA_SHORT_TO_LONG_OPERATOR_MAP } from 'constants/queryBuilder';
 import {
 	checkCommaInValue,
 	getTagToken,
@@ -12,19 +13,6 @@ import { WhereClauseConfig } from './useAutoComplete';
 import { useOperators } from './useOperators';
 
 export const WHERE_CLAUSE_CUSTOM_SUFFIX = '-custom';
-
-/**
- * Maps short form operators to long form labels for InfraMonitoring display.
- * Value stays as short form (NIN), label shows as long form (NOT_IN).
- */
-const INFRA_OPERATOR_LABEL_MAP: Record<string, string> = {
-	NIN: 'NOT_IN',
-	NLIKE: 'NOT_LIKE',
-	NOTILIKE: 'NOT_ILIKE',
-	NREGEX: 'NOT_REGEX',
-	NEXISTS: 'NOT_EXISTS',
-	NCONTAINS: 'NOT_CONTAINS',
-};
 
 export const useOptions = (
 	key: string,
@@ -123,8 +111,8 @@ export const useOptions = (
 				: operators;
 			const operatorsOptions = filteredOperators?.map((op) => {
 				const labelOp =
-					isInfraMonitoring && INFRA_OPERATOR_LABEL_MAP[op]
-						? INFRA_OPERATOR_LABEL_MAP[op]
+					isInfraMonitoring && INFRA_SHORT_TO_LONG_OPERATOR_MAP[op]
+						? INFRA_SHORT_TO_LONG_OPERATOR_MAP[op]
 						: op;
 				return {
 					value: `${partialKey} ${op} `,

--- a/frontend/src/hooks/queryBuilder/useTag.ts
+++ b/frontend/src/hooks/queryBuilder/useTag.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { INFRA_SHORT_TO_LONG_OPERATOR_MAP } from 'constants/queryBuilder';
 import {
 	getOperatorFromValue,
 	getTagToken,
@@ -14,18 +15,6 @@ import {
 import { WhereClauseConfig } from './useAutoComplete';
 
 /**
- * Maps short form operators to long form for display in InfraMonitoring.
- */
-const INFRA_OPERATOR_DISPLAY_MAP: Record<string, string> = {
-	NIN: 'NOT_IN',
-	NLIKE: 'NOT_LIKE',
-	NOTILIKE: 'NOT_ILIKE',
-	NREGEX: 'NOT_REGEX',
-	NEXISTS: 'NOT_EXISTS',
-	NCONTAINS: 'NOT_CONTAINS',
-};
-
-/**
  * Helper for formatting a TagFilter object into filter item strings
  * @param {TagFilter} filters - query filter object to be converted
  * @param {boolean} isInfraMonitoring - whether to use long form operator display
@@ -38,8 +27,8 @@ export function queryFilterTags(
 	return (filter?.items || []).map((ele) => {
 		const rawOp = getOperatorFromValue(ele.op);
 		const displayOp =
-			isInfraMonitoring && INFRA_OPERATOR_DISPLAY_MAP[rawOp]
-				? INFRA_OPERATOR_DISPLAY_MAP[rawOp]
+			isInfraMonitoring && INFRA_SHORT_TO_LONG_OPERATOR_MAP[rawOp]
+				? INFRA_SHORT_TO_LONG_OPERATOR_MAP[rawOp]
 				: rawOp;
 
 		if (isInNInOperator(rawOp)) {

--- a/frontend/src/hooks/queryBuilder/useTag.ts
+++ b/frontend/src/hooks/queryBuilder/useTag.ts
@@ -14,21 +14,43 @@ import {
 import { WhereClauseConfig } from './useAutoComplete';
 
 /**
+ * Maps short form operators to long form for display in InfraMonitoring.
+ */
+const INFRA_OPERATOR_DISPLAY_MAP: Record<string, string> = {
+	NIN: 'NOT_IN',
+	NLIKE: 'NOT_LIKE',
+	NOTILIKE: 'NOT_ILIKE',
+	NREGEX: 'NOT_REGEX',
+	NEXISTS: 'NOT_EXISTS',
+	NCONTAINS: 'NOT_CONTAINS',
+};
+
+/**
  * Helper for formatting a TagFilter object into filter item strings
  * @param {TagFilter} filters - query filter object to be converted
+ * @param {boolean} isInfraMonitoring - whether to use long form operator display
  * @returns {string[]} An array of formatted conditions. Eg: `["service = web", "severity_text = INFO"]`)
  */
-export function queryFilterTags(filter: TagFilter): string[] {
+export function queryFilterTags(
+	filter: TagFilter,
+	isInfraMonitoring?: boolean,
+): string[] {
 	return (filter?.items || []).map((ele) => {
-		if (isInNInOperator(getOperatorFromValue(ele.op))) {
+		const rawOp = getOperatorFromValue(ele.op);
+		const displayOp =
+			isInfraMonitoring && INFRA_OPERATOR_DISPLAY_MAP[rawOp]
+				? INFRA_OPERATOR_DISPLAY_MAP[rawOp]
+				: rawOp;
+
+		if (isInNInOperator(rawOp)) {
 			try {
 				const csvString = unparse([ele.value]);
-				return `${ele.key?.key} ${getOperatorFromValue(ele.op)} ${csvString}`;
+				return `${ele.key?.key} ${displayOp} ${csvString}`;
 			} catch {
-				return `${ele.key?.key} ${getOperatorFromValue(ele.op)} ${ele.value}`;
+				return `${ele.key?.key} ${displayOp} ${ele.value}`;
 			}
 		}
-		return `${ele.key?.key} ${getOperatorFromValue(ele.op)} ${ele.value}`;
+		return `${ele.key?.key} ${displayOp} ${ele.value}`;
 	});
 }
 
@@ -53,10 +75,15 @@ export const useTag = (
 	query: IBuilderQuery,
 	setSearchKey: (value: string) => void,
 	whereClauseConfig?: WhereClauseConfig,
+	isInfraMonitoring?: boolean,
 ): IUseTag => {
 	const initTagsData = useMemo(
-		() => queryFilterTags(query?.filters || { items: [], op: 'AND' }),
-		[query?.filters],
+		() =>
+			queryFilterTags(
+				query?.filters || { items: [], op: 'AND' },
+				isInfraMonitoring,
+			),
+		[query?.filters, isInfraMonitoring],
 	);
 
 	const [tags, setTags] = useState<string[]>(initTagsData);


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Add support for the following operators:
- nin
- nlike
- notilike
- nregex
- nexists
- ncontains

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

https://github.com/user-attachments/assets/01198b8a-f0a0-42d0-b48d-b0444ebbdc1c

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Fixes https://github.com/SigNoz/engineering-pod/issues/4680

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

The API does not handle operators like NOT_IN.

#### Fix Strategy
> How does this PR address the root cause?

Hide not supported operators and use the ones we actually support.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: -
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Infrastructure Monitoring and pages using QueryBuilderSearch.
- Potential regressions: An issue related to bad handling of operators.
- Rollback plan: Revert this commit or fix the issue directly.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed the issue that was not allowing to use operators of not in, ncontains, and other negate operators inside the query builder. |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered