### PR TITLE
chore: fix duplicated words in query_builder and sqlschema comments

### DIFF
--- a/pkg/query-service/app/logs/v4/query_builder.go
+++ b/pkg/query-service/app/logs/v4/query_builder.go
@@ -457,7 +457,7 @@ func buildLogsQuery(panelType v3.PanelType, start, end, step int64, mq *v3.Build
 	query := queryTmplPrefix + selectLabels + aggClause
 
 	// for limit query this is the first query,
-	// we don't the the aggregation value here as we are just concerned with the names of group by
+	// we don't the aggregation value here as we are just concerned with the names of group by
 	// for applying the limit
 	if graphLimitQtype == constants.FirstQueryGraphLimit {
 		query = "SELECT " + logsV3.GetSelectKeys(mq.AggregateOperator, mq.GroupBy) + " from (" + query + ")"

--- a/pkg/sqlschema/column.go
+++ b/pkg/sqlschema/column.go
@@ -31,7 +31,7 @@ type Column struct {
 	// The name of the column in the table.
 	Name ColumnName
 
-	// The data type of the column. This will be translated to the the appropriate data type as per the dialect.
+	// The data type of the column. This will be translated to the appropriate data type as per the dialect.
 	DataType DataType
 
 	// Whether the column is nullable.


### PR DESCRIPTION
Two small comment-only typos: doubled `the the` in `pkg/query-service/app/logs/v4/query_builder.go` and `pkg/sqlschema/column.go`. No functional change.