### PR TITLE
feat(cmd): add metastore migrate command

### DIFF
--- a/cmd/community/main.go
+++ b/cmd/community/main.go
@@ -14,6 +14,7 @@ func main() {
 	// register a list of commands to the root command
 	registerServer(cmd.RootCmd, logger)
 	cmd.RegisterGenerate(cmd.RootCmd, logger)
+	cmd.RegisterMetastore(cmd.RootCmd, logger, sqlstoreProviderFactories, sqlschemaProviderFactories)
 
 	cmd.Execute(logger)
 }

--- a/cmd/community/metastore.go
+++ b/cmd/community/metastore.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/signoz"
+	"github.com/SigNoz/signoz/pkg/sqlschema"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+)
+
+func sqlstoreProviderFactories() factory.NamedMap[factory.ProviderFactory[sqlstore.SQLStore, sqlstore.Config]] {
+	return signoz.NewSQLStoreProviderFactories()
+}
+
+func sqlschemaProviderFactories(sqlstore sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[sqlschema.SQLSchema, sqlschema.Config]] {
+	return signoz.NewSQLSchemaProviderFactories(sqlstore)
+}

--- a/cmd/community/server.go
+++ b/cmd/community/server.go
@@ -40,7 +40,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/ruler"
 	"github.com/SigNoz/signoz/pkg/ruler/signozruler"
 	"github.com/SigNoz/signoz/pkg/signoz"
-	"github.com/SigNoz/signoz/pkg/sqlschema"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
@@ -87,10 +86,8 @@ func runServer(ctx context.Context, config signoz.Config, logger *slog.Logger) e
 		signoz.NewEmailingProviderFactories(),
 		signoz.NewCacheProviderFactories(),
 		signoz.NewWebProviderFactories(config.Global),
-		func(sqlstore sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[sqlschema.SQLSchema, sqlschema.Config]] {
-			return signoz.NewSQLSchemaProviderFactories(sqlstore)
-		},
-		signoz.NewSQLStoreProviderFactories(),
+		sqlschemaProviderFactories,
+		sqlstoreProviderFactories(),
 		signoz.NewTelemetryStoreProviderFactories(),
 		func(ctx context.Context, providerSettings factory.ProviderSettings, store authtypes.AuthNStore, licensing licensing.Licensing) (map[authtypes.AuthNProvider]authn.AuthN, error) {
 			return signoz.NewAuthNs(ctx, providerSettings, store, licensing)

--- a/cmd/enterprise/main.go
+++ b/cmd/enterprise/main.go
@@ -14,6 +14,7 @@ func main() {
 	// register a list of commands to the root command
 	registerServer(cmd.RootCmd, logger)
 	cmd.RegisterGenerate(cmd.RootCmd, logger)
+	cmd.RegisterMetastore(cmd.RootCmd, logger, sqlstoreProviderFactories, sqlschemaProviderFactories)
 
 	cmd.Execute(logger)
 }

--- a/cmd/enterprise/metastore.go
+++ b/cmd/enterprise/metastore.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"github.com/SigNoz/signoz/ee/sqlschema/postgressqlschema"
+	"github.com/SigNoz/signoz/ee/sqlstore/postgressqlstore"
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/signoz"
+	"github.com/SigNoz/signoz/pkg/sqlschema"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstorehook"
+)
+
+func sqlstoreProviderFactories() factory.NamedMap[factory.ProviderFactory[sqlstore.SQLStore, sqlstore.Config]] {
+	existingFactories := signoz.NewSQLStoreProviderFactories()
+	if err := existingFactories.Add(postgressqlstore.NewFactory(sqlstorehook.NewLoggingFactory(), sqlstorehook.NewInstrumentationFactory())); err != nil {
+		panic(err)
+	}
+
+	return existingFactories
+}
+
+func sqlschemaProviderFactories(sqlstore sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[sqlschema.SQLSchema, sqlschema.Config]] {
+	existingFactories := signoz.NewSQLSchemaProviderFactories(sqlstore)
+	if err := existingFactories.Add(postgressqlschema.NewFactory(sqlstore)); err != nil {
+		panic(err)
+	}
+
+	return existingFactories
+}

--- a/cmd/enterprise/server.go
+++ b/cmd/enterprise/server.go
@@ -27,8 +27,6 @@ import (
 	eequerier "github.com/SigNoz/signoz/ee/querier"
 	enterpriseapp "github.com/SigNoz/signoz/ee/query-service/app"
 	eerules "github.com/SigNoz/signoz/ee/query-service/rules"
-	"github.com/SigNoz/signoz/ee/sqlschema/postgressqlschema"
-	"github.com/SigNoz/signoz/ee/sqlstore/postgressqlstore"
 	enterprisezeus "github.com/SigNoz/signoz/ee/zeus"
 	"github.com/SigNoz/signoz/ee/zeus/httpzeus"
 	"github.com/SigNoz/signoz/pkg/alertmanager"
@@ -58,9 +56,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/ruler"
 	"github.com/SigNoz/signoz/pkg/ruler/signozruler"
 	"github.com/SigNoz/signoz/pkg/signoz"
-	"github.com/SigNoz/signoz/pkg/sqlschema"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
-	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstorehook"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
 	"github.com/SigNoz/signoz/pkg/types/cloudintegrationtypes"
@@ -94,13 +90,6 @@ func runServer(ctx context.Context, config signoz.Config, logger *slog.Logger) e
 	// print the version
 	version.Info.PrettyPrint(config.Version)
 
-	// add enterprise sqlstore factories to the community sqlstore factories
-	sqlstoreFactories := signoz.NewSQLStoreProviderFactories()
-	if err := sqlstoreFactories.Add(postgressqlstore.NewFactory(sqlstorehook.NewLoggingFactory(), sqlstorehook.NewInstrumentationFactory())); err != nil {
-		logger.ErrorContext(ctx, "failed to add postgressqlstore factory", errors.Attr(err))
-		return err
-	}
-
 	signoz, err := signoz.New(
 		ctx,
 		config,
@@ -113,15 +102,8 @@ func runServer(ctx context.Context, config signoz.Config, logger *slog.Logger) e
 		signoz.NewEmailingProviderFactories(),
 		signoz.NewCacheProviderFactories(),
 		signoz.NewWebProviderFactories(config.Global),
-		func(sqlstore sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[sqlschema.SQLSchema, sqlschema.Config]] {
-			existingFactories := signoz.NewSQLSchemaProviderFactories(sqlstore)
-			if err := existingFactories.Add(postgressqlschema.NewFactory(sqlstore)); err != nil {
-				panic(err)
-			}
-
-			return existingFactories
-		},
-		sqlstoreFactories,
+		sqlschemaProviderFactories,
+		sqlstoreProviderFactories(),
 		signoz.NewTelemetryStoreProviderFactories(),
 		func(ctx context.Context, providerSettings factory.ProviderSettings, store authtypes.AuthNStore, licensing licensing.Licensing) (map[authtypes.AuthNProvider]authn.AuthN, error) {
 			samlCallbackAuthN, err := samlcallbackauthn.New(ctx, store, licensing)

--- a/cmd/metastore.go
+++ b/cmd/metastore.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"log/slog"
 
 	"github.com/spf13/cobra"
@@ -15,7 +16,10 @@ import (
 	"github.com/SigNoz/signoz/pkg/version"
 )
 
-func RegisterMetastore(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProviderFactories func() factory.NamedMap[factory.ProviderFactory[sqlstore.SQLStore, sqlstore.Config]], sqlschemaProviderFactories func(sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[sqlschema.SQLSchema, sqlschema.Config]]) {
+type SQLStoreProviderFactories func() factory.NamedMap[factory.ProviderFactory[sqlstore.SQLStore, sqlstore.Config]]
+type SQLSchemaProviderFactories func(sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[sqlschema.SQLSchema, sqlschema.Config]]
+
+func RegisterMetastore(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProviderFactories SQLStoreProviderFactories, sqlschemaProviderFactories SQLSchemaProviderFactories) {
 	metastoreCmd := &cobra.Command{
 		Use:               "metastore",
 		Short:             "Run commands to interact with the Metastore",
@@ -29,7 +33,7 @@ func RegisterMetastore(parentCmd *cobra.Command, logger *slog.Logger, sqlstorePr
 	parentCmd.AddCommand(metastoreCmd)
 }
 
-func registerMigrate(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProviderFactories func() factory.NamedMap[factory.ProviderFactory[sqlstore.SQLStore, sqlstore.Config]], sqlschemaProviderFactories func(sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[sqlschema.SQLSchema, sqlschema.Config]]) {
+func registerMigrate(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProviderFactories SQLStoreProviderFactories, sqlschemaProviderFactories SQLSchemaProviderFactories) {
 	migrateCmd := &cobra.Command{
 		Use:               "migrate",
 		Short:             "Run migrations for the Metastore",
@@ -43,7 +47,7 @@ func registerMigrate(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProv
 	parentCmd.AddCommand(migrateCmd)
 }
 
-func registerSync(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProviderFactories func() factory.NamedMap[factory.ProviderFactory[sqlstore.SQLStore, sqlstore.Config]], sqlschemaProviderFactories func(sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[sqlschema.SQLSchema, sqlschema.Config]]) {
+func registerSync(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProviderFactories SQLStoreProviderFactories, sqlschemaProviderFactories SQLSchemaProviderFactories) {
 	syncCmd := &cobra.Command{
 		Use:               "sync",
 		Short:             "Runs 'sync' migrations for the metastore. Sync migrations are used to mutate schemas of the metastore. These migrations need to be successfully applied before bringing up the application.",
@@ -53,58 +57,98 @@ func registerSync(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProvide
 	}
 
 	registerSyncUp(syncCmd, logger, sqlstoreProviderFactories, sqlschemaProviderFactories)
+	registerSyncCheck(syncCmd, logger, sqlstoreProviderFactories, sqlschemaProviderFactories)
 
 	parentCmd.AddCommand(syncCmd)
 }
 
-func registerSyncUp(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProviderFactories func() factory.NamedMap[factory.ProviderFactory[sqlstore.SQLStore, sqlstore.Config]], sqlschemaProviderFactories func(sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[sqlschema.SQLSchema, sqlschema.Config]]) {
+func registerSyncUp(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProviderFactories SQLStoreProviderFactories, sqlschemaProviderFactories SQLSchemaProviderFactories) {
 	var configFiles []string
 
 	syncUpCmd := &cobra.Command{
-		Use:               "up",
-		Short:             "Runs 'up' migrations for the metastore. Up migrations are used to apply new migrations to the metastore",
-		SilenceUsage:      true,
-		SilenceErrors:     true,
-		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+		Use:                "up",
+		Short:              "Runs 'up' migrations for the metastore. Up migrations are used to apply new migrations to the metastore",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 		RunE: func(currCmd *cobra.Command, args []string) error {
-			ctx := currCmd.Context()
-
-			config, err := NewSigNozConfig(ctx, logger, configFiles)
+			config, err := NewSigNozConfig(currCmd.Context(), logger, configFiles)
 			if err != nil {
 				return err
 			}
 
-			instrumentation, err := instrumentation.New(ctx, config.Instrumentation, version.Info, "signoz")
-			if err != nil {
-				return err
-			}
-
-			providerSettings := instrumentation.ToProviderSettings()
-
-			sqlstore, err := factory.NewProviderFromNamedMap(ctx, providerSettings, config.SQLStore, sqlstoreProviderFactories(), config.SQLStore.Provider)
-			if err != nil {
-				return err
-			}
-
-			sqlschema, err := factory.NewProviderFromNamedMap(ctx, providerSettings, config.SQLSchema, sqlschemaProviderFactories(sqlstore), config.SQLStore.Provider)
-			if err != nil {
-				return err
-			}
-
-			telemetrystore, err := factory.NewProviderFromNamedMap(ctx, providerSettings, config.TelemetryStore, signoz.NewTelemetryStoreProviderFactories(), config.TelemetryStore.Provider)
-			if err != nil {
-				return err
-			}
-
-			sqlmigrations, err := sqlmigration.New(ctx, providerSettings, config.SQLMigration, signoz.NewSQLMigrationProviderFactories(sqlstore, sqlschema, telemetrystore, providerSettings))
-			if err != nil {
-				return err
-			}
-
-			return sqlmigrator.New(ctx, providerSettings, sqlstore, sqlmigrations, config.SQLMigrator).Migrate(ctx)
+			return runSyncUp(currCmd.Context(), config, sqlstoreProviderFactories, sqlschemaProviderFactories)
 		},
 	}
 
 	syncUpCmd.Flags().StringArrayVar(&configFiles, "config", nil, "path to a YAML configuration file (can be specified multiple times, later files override earlier ones)")
 	parentCmd.AddCommand(syncUpCmd)
+}
+
+func registerSyncCheck(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProviderFactories SQLStoreProviderFactories, sqlschemaProviderFactories SQLSchemaProviderFactories) {
+	var configFiles []string
+
+	syncCheckCmd := &cobra.Command{
+		Use:                "check",
+		Short:              "Runs a check for 'sync' migrations on the metastore. Returns a non-zero exit code if any migrations are pending.",
+		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+		RunE: func(currCmd *cobra.Command, args []string) error {
+			config, err := NewSigNozConfig(currCmd.Context(), logger, configFiles)
+			if err != nil {
+				return err
+			}
+
+			return runSyncCheck(currCmd.Context(), config, sqlstoreProviderFactories, sqlschemaProviderFactories)
+		},
+	}
+
+	syncCheckCmd.Flags().StringArrayVar(&configFiles, "config", nil, "path to a YAML configuration file (can be specified multiple times, later files override earlier ones)")
+	parentCmd.AddCommand(syncCheckCmd)
+}
+
+func runSyncUp(ctx context.Context, config signoz.Config, sqlstoreProviderFactories SQLStoreProviderFactories, sqlschemaProviderFactories SQLSchemaProviderFactories) error {
+	migrator, err := newSyncMigrator(ctx, config, sqlstoreProviderFactories, sqlschemaProviderFactories)
+	if err != nil {
+		return err
+	}
+
+	return migrator.Migrate(ctx)
+}
+
+func runSyncCheck(ctx context.Context, config signoz.Config, sqlstoreProviderFactories SQLStoreProviderFactories, sqlschemaProviderFactories SQLSchemaProviderFactories) error {
+	migrator, err := newSyncMigrator(ctx, config, sqlstoreProviderFactories, sqlschemaProviderFactories)
+	if err != nil {
+		return err
+	}
+
+	return migrator.Check(ctx)
+}
+
+func newSyncMigrator(ctx context.Context, config signoz.Config, sqlstoreProviderFactories SQLStoreProviderFactories, sqlschemaProviderFactories SQLSchemaProviderFactories) (sqlmigrator.SQLMigrator, error) {
+	instrumentation, err := instrumentation.New(ctx, config.Instrumentation, version.Info, "signoz")
+	if err != nil {
+		return nil, err
+	}
+
+	providerSettings := instrumentation.ToProviderSettings()
+
+	sqlstore, err := factory.NewProviderFromNamedMap(ctx, providerSettings, config.SQLStore, sqlstoreProviderFactories(), config.SQLStore.Provider)
+	if err != nil {
+		return nil, err
+	}
+
+	sqlschema, err := factory.NewProviderFromNamedMap(ctx, providerSettings, config.SQLSchema, sqlschemaProviderFactories(sqlstore), config.SQLStore.Provider)
+	if err != nil {
+		return nil, err
+	}
+
+	telemetrystore, err := factory.NewProviderFromNamedMap(ctx, providerSettings, config.TelemetryStore, signoz.NewTelemetryStoreProviderFactories(), config.TelemetryStore.Provider)
+	if err != nil {
+		return nil, err
+	}
+
+	sqlmigrations, err := sqlmigration.New(ctx, providerSettings, config.SQLMigration, signoz.NewSQLMigrationProviderFactories(sqlstore, sqlschema, telemetrystore, providerSettings))
+	if err != nil {
+		return nil, err
+	}
+
+	return sqlmigrator.New(ctx, providerSettings, sqlstore, sqlmigrations, config.SQLMigrator), nil
 }

--- a/cmd/metastore.go
+++ b/cmd/metastore.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"log/slog"
+
+	"github.com/spf13/cobra"
+
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/instrumentation"
+	"github.com/SigNoz/signoz/pkg/signoz"
+	"github.com/SigNoz/signoz/pkg/sqlmigration"
+	"github.com/SigNoz/signoz/pkg/sqlmigrator"
+	"github.com/SigNoz/signoz/pkg/sqlschema"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/version"
+)
+
+func RegisterMetastore(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProviderFactories func() factory.NamedMap[factory.ProviderFactory[sqlstore.SQLStore, sqlstore.Config]], sqlschemaProviderFactories func(sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[sqlschema.SQLSchema, sqlschema.Config]]) {
+	metastoreCmd := &cobra.Command{
+		Use:               "metastore",
+		Short:             "Run commands to interact with the Metastore",
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+	}
+
+	registerMigrate(metastoreCmd, logger, sqlstoreProviderFactories, sqlschemaProviderFactories)
+
+	parentCmd.AddCommand(metastoreCmd)
+}
+
+func registerMigrate(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProviderFactories func() factory.NamedMap[factory.ProviderFactory[sqlstore.SQLStore, sqlstore.Config]], sqlschemaProviderFactories func(sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[sqlschema.SQLSchema, sqlschema.Config]]) {
+	migrateCmd := &cobra.Command{
+		Use:               "migrate",
+		Short:             "Run migrations for the Metastore",
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+	}
+
+	registerSync(migrateCmd, logger, sqlstoreProviderFactories, sqlschemaProviderFactories)
+
+	parentCmd.AddCommand(migrateCmd)
+}
+
+func registerSync(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProviderFactories func() factory.NamedMap[factory.ProviderFactory[sqlstore.SQLStore, sqlstore.Config]], sqlschemaProviderFactories func(sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[sqlschema.SQLSchema, sqlschema.Config]]) {
+	syncCmd := &cobra.Command{
+		Use:               "sync",
+		Short:             "Runs 'sync' migrations for the metastore. Sync migrations are used to mutate schemas of the metastore. These migrations need to be successfully applied before bringing up the application.",
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+	}
+
+	registerSyncUp(syncCmd, logger, sqlstoreProviderFactories, sqlschemaProviderFactories)
+
+	parentCmd.AddCommand(syncCmd)
+}
+
+func registerSyncUp(parentCmd *cobra.Command, logger *slog.Logger, sqlstoreProviderFactories func() factory.NamedMap[factory.ProviderFactory[sqlstore.SQLStore, sqlstore.Config]], sqlschemaProviderFactories func(sqlstore.SQLStore) factory.NamedMap[factory.ProviderFactory[sqlschema.SQLSchema, sqlschema.Config]]) {
+	var configFiles []string
+
+	syncUpCmd := &cobra.Command{
+		Use:               "up",
+		Short:             "Runs 'up' migrations for the metastore. Up migrations are used to apply new migrations to the metastore",
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+		RunE: func(currCmd *cobra.Command, args []string) error {
+			ctx := currCmd.Context()
+
+			config, err := NewSigNozConfig(ctx, logger, configFiles)
+			if err != nil {
+				return err
+			}
+
+			instrumentation, err := instrumentation.New(ctx, config.Instrumentation, version.Info, "signoz")
+			if err != nil {
+				return err
+			}
+
+			providerSettings := instrumentation.ToProviderSettings()
+
+			sqlstore, err := factory.NewProviderFromNamedMap(ctx, providerSettings, config.SQLStore, sqlstoreProviderFactories(), config.SQLStore.Provider)
+			if err != nil {
+				return err
+			}
+
+			sqlschema, err := factory.NewProviderFromNamedMap(ctx, providerSettings, config.SQLSchema, sqlschemaProviderFactories(sqlstore), config.SQLStore.Provider)
+			if err != nil {
+				return err
+			}
+
+			telemetrystore, err := factory.NewProviderFromNamedMap(ctx, providerSettings, config.TelemetryStore, signoz.NewTelemetryStoreProviderFactories(), config.TelemetryStore.Provider)
+			if err != nil {
+				return err
+			}
+
+			sqlmigrations, err := sqlmigration.New(ctx, providerSettings, config.SQLMigration, signoz.NewSQLMigrationProviderFactories(sqlstore, sqlschema, telemetrystore, providerSettings))
+			if err != nil {
+				return err
+			}
+
+			return sqlmigrator.New(ctx, providerSettings, sqlstore, sqlmigrations, config.SQLMigrator).Migrate(ctx)
+		},
+	}
+
+	syncUpCmd.Flags().StringArrayVar(&configFiles, "config", nil, "path to a YAML configuration file (can be specified multiple times, later files override earlier ones)")
+	parentCmd.AddCommand(syncUpCmd)
+}

--- a/pkg/sqlmigrator/config.go
+++ b/pkg/sqlmigrator/config.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	ErrCodeInvalidSQLMigratorConfig = errors.MustNewCode("invalid_sqlmigrator_config")
+	ErrCodePendingSQLMigrations     = errors.MustNewCode("pending_sql_migrations")
 )
 
 type Config struct {

--- a/pkg/sqlmigrator/migrator.go
+++ b/pkg/sqlmigrator/migrator.go
@@ -87,7 +87,7 @@ func (migrator *migrator) Check(ctx context.Context) error {
 		names = append(names, migration.Name)
 	}
 
-	return errors.Newf(errors.TypeInternal, ErrCodePendingSQLMigrations, "%d pending migration(s): %v", len(unapplied), names)
+	return errors.Newf(errors.TypeNotFound, ErrCodePendingSQLMigrations, "%d pending migration(s): %v", len(unapplied), names)
 }
 
 func (migrator *migrator) Rollback(ctx context.Context) error {

--- a/pkg/sqlmigrator/migrator.go
+++ b/pkg/sqlmigrator/migrator.go
@@ -87,7 +87,7 @@ func (migrator *migrator) Check(ctx context.Context) error {
 		names = append(names, migration.Name)
 	}
 
-	return errors.Newf(errors.TypeInvalidInput, ErrCodePendingSQLMigrations, "%d pending migration(s): %v", len(unapplied), names)
+	return errors.Newf(errors.TypeUnexpected, ErrCodePendingSQLMigrations, "%d pending migration(s): %v", len(unapplied), names)
 }
 
 func (migrator *migrator) Rollback(ctx context.Context) error {

--- a/pkg/sqlmigrator/migrator.go
+++ b/pkg/sqlmigrator/migrator.go
@@ -87,7 +87,7 @@ func (migrator *migrator) Check(ctx context.Context) error {
 		names = append(names, migration.Name)
 	}
 
-	return errors.Newf(errors.TypeUnexpected, ErrCodePendingSQLMigrations, "%d pending migration(s): %v", len(unapplied), names)
+	return errors.Newf(errors.TypeInternal, ErrCodePendingSQLMigrations, "%d pending migration(s): %v", len(unapplied), names)
 }
 
 func (migrator *migrator) Rollback(ctx context.Context) error {

--- a/pkg/sqlmigrator/migrator.go
+++ b/pkg/sqlmigrator/migrator.go
@@ -70,9 +70,6 @@ func (migrator *migrator) Migrate(ctx context.Context) error {
 
 func (migrator *migrator) Check(ctx context.Context) error {
 	migrator.settings.Logger().InfoContext(ctx, "checking sqlstore migrations", slog.String("dialect", migrator.dialect))
-	if err := migrator.migrator.Init(ctx); err != nil {
-		return err
-	}
 
 	migrations, err := migrator.migrator.MigrationsWithStatus(ctx)
 	if err != nil {

--- a/pkg/sqlmigrator/migrator.go
+++ b/pkg/sqlmigrator/migrator.go
@@ -68,6 +68,31 @@ func (migrator *migrator) Migrate(ctx context.Context) error {
 	return nil
 }
 
+func (migrator *migrator) Check(ctx context.Context) error {
+	migrator.settings.Logger().InfoContext(ctx, "checking sqlstore migrations", slog.String("dialect", migrator.dialect))
+	if err := migrator.migrator.Init(ctx); err != nil {
+		return err
+	}
+
+	migrations, err := migrator.migrator.MigrationsWithStatus(ctx)
+	if err != nil {
+		return err
+	}
+
+	unapplied := migrations.Unapplied()
+	if len(unapplied) == 0 {
+		migrator.settings.Logger().InfoContext(ctx, "no pending migrations (database is up to date)", slog.String("dialect", migrator.dialect))
+		return nil
+	}
+
+	names := make([]string, 0, len(unapplied))
+	for _, migration := range unapplied {
+		names = append(names, migration.Name)
+	}
+
+	return errors.Newf(errors.TypeInvalidInput, ErrCodePendingSQLMigrations, "%d pending migration(s): %v", len(unapplied), names)
+}
+
 func (migrator *migrator) Rollback(ctx context.Context) error {
 	if err := migrator.Lock(ctx); err != nil {
 		return err

--- a/pkg/sqlmigrator/sqlmigrator.go
+++ b/pkg/sqlmigrator/sqlmigrator.go
@@ -10,4 +10,6 @@ type SQLMigrator interface {
 	Migrate(context.Context) error
 	// Rollback rolls back the database. Rollback acquires a lock on the database and rolls back the migrations.
 	Rollback(context.Context) error
+	// Check returns nil if the database is up to date and an error listing pending migrations otherwise.
+	Check(context.Context) error
 }


### PR DESCRIPTION
## Summary

Carved out of #8564 — adds a `metastore` cobra command tree so operators can drive SQL schema migrations from the CLI instead of relying on the implicit step inside `server`.

- `metastore migrate sync up` — applies pending migrations and exits 0.
- `metastore migrate sync check` — reports pending migrations and exits non-zero if any remain; intended as a deployment preflight gate. Does not call `Init`, so the migration table is never auto-created from a check.

Supporting changes:

- `pkg/sqlmigrator`: new `Check(ctx)` method on the `SQLMigrator` interface, plus an `ErrCodePendingSQLMigrations` typed error.
- `cmd/{community,enterprise}/metastore.go`: per-build composition of `sqlstore` / `sqlschema` provider factories, used by both the new `metastore` command and the existing `server` command — postgres opt-in is now expressed in exactly one place per build.
- `cmd/metastore.go`: mirrors the `server.go` register/run split — `register*` builds the cobra tree and parses flags; `run*` does the work; a shared `newSyncMigrator` helper centralises sqlstore/sqlschema/telemetrystore wiring.

The migration squash work tracked by SigNoz/platform-pod#706 stays open and will land in a follow-up PR.

refs SigNoz/platform-pod#706