### PR TITLE
refactor(infra-monitoring): handle keys not found & avoid re-renders on query search change

### DIFF
--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/Provider/context.ts
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/Provider/context.ts
@@ -45,17 +45,16 @@ export function useExpression(): string {
 
 export function useQuerySearchOnChange(): (expression: string) => void {
 	const store = useQuerySearchV2Store();
-	const initialExpression = useStore(store, (s) => s.initialExpression);
 
 	return useCallback(
 		(expression: string): void => {
 			const userOnly = getUserExpressionFromCombined(
-				initialExpression,
+				store.getState().initialExpression,
 				expression,
 			);
 			store.getState().setInputExpression(userOnly);
 		},
-		[store, initialExpression],
+		[store],
 	);
 }
 

--- a/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityLogs/EntityLogs.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityLogs/EntityLogs.tsx
@@ -40,6 +40,7 @@ import { validateQuery } from 'utils/queryValidationUtils';
 
 import EntityEmptyState from '../EntityEmptyState/EntityEmptyState';
 import EntityError from '../EntityError/EntityError';
+import { isKeyNotFoundError } from '../utils';
 import { K8S_ENTITY_LOGS_EXPRESSION_KEY, useInfiniteEntityLogs } from './hooks';
 import { getEntityLogsQueryPayload } from './utils';
 
@@ -110,6 +111,7 @@ function EntityLogsContent({
 		isLoading,
 		isFetching,
 		isError,
+		error,
 		refetch,
 		cancel,
 	} = useInfiniteEntityLogs({
@@ -228,7 +230,9 @@ function EntityLogsContent({
 
 	const showInitialLoading = isLoading || (isFetching && logs.length === 0);
 
-	const isDataEmpty = !showInitialLoading && !isError && logs.length === 0;
+	const isKeyNotFound = isKeyNotFoundError(error);
+	const isDataEmpty =
+		!showInitialLoading && (!isError || isKeyNotFound) && logs.length === 0;
 	const hasAdditionalFilters = !!userExpression?.trim();
 
 	return (
@@ -267,8 +271,8 @@ function EntityLogsContent({
 			<div className={styles.logs}>
 				{showInitialLoading && <LogsLoading />}
 				{isDataEmpty && <EntityEmptyState hasFilters={hasAdditionalFilters} />}
-				{isError && !showInitialLoading && <EntityError />}
-				{!showInitialLoading && !isError && logs.length > 0 && (
+				{isError && !isKeyNotFound && !showInitialLoading && <EntityError />}
+				{!showInitialLoading && (!isError || isKeyNotFound) && logs.length > 0 && (
 					<div className={styles.listContainer} data-log-detail-ignore="true">
 						{renderContent}
 					</div>

--- a/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityMetrics/EntityMetrics.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityMetrics/EntityMetrics.tsx
@@ -22,6 +22,7 @@ import { AlignedData, Options } from 'uplot';
 import { useMultiIntersectionObserver } from 'hooks/useMultiIntersectionObserver';
 
 import { useEntityMetrics } from './hooks';
+import { isKeyNotFoundError } from '../utils';
 
 import styles from './EntityMetrics.module.scss';
 import { MetricsTable } from './MetricsTable';
@@ -152,7 +153,7 @@ function EntityMetrics<T>({
 			return <Skeleton />;
 		}
 
-		if (query.error) {
+		if (query.error && !isKeyNotFoundError(query.error)) {
 			const errorMessage =
 				(query.error as Error)?.message || 'Something went wrong';
 			return <div>{errorMessage}</div>;

--- a/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityTraces/EntityTraces.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/EntityTraces/EntityTraces.tsx
@@ -35,6 +35,7 @@ import { validateQuery } from 'utils/queryValidationUtils';
 import EntityEmptyState from '../EntityEmptyState/EntityEmptyState';
 import EntityError from '../EntityError/EntityError';
 import { selectedEntityTracesColumns } from '../utils';
+import { isKeyNotFoundError } from '../utils';
 import { K8S_ENTITY_TRACES_EXPRESSION_KEY, useEntityTraces } from './hooks';
 import { getTraceListColumns } from './traceListColumns';
 import { getEntityTracesQueryPayload } from './utils';
@@ -86,6 +87,7 @@ function EntityTracesContent({
 		isLoading,
 		isFetching,
 		isError,
+		error,
 		currentCount,
 		hasMore,
 		refetch,
@@ -136,8 +138,12 @@ function EntityTracesContent({
 
 	const traceListColumns = getTraceListColumns(selectedEntityTracesColumns);
 
+	const isKeyNotFound = isKeyNotFoundError(error);
 	const isDataEmpty =
-		!isLoading && !isFetching && !isError && traces.length === 0;
+		!isLoading &&
+		!isFetching &&
+		(!isError || isKeyNotFound) &&
+		traces.length === 0;
 	const hasAdditionalFilters = !!userExpression?.trim();
 
 	const handleRowClick = useCallback(() => {
@@ -192,9 +198,9 @@ function EntityTracesContent({
 
 			{isDataEmpty && <EntityEmptyState hasFilters={hasAdditionalFilters} />}
 
-			{isError && !isLoading && <EntityError />}
+			{isError && !isKeyNotFound && !isLoading && <EntityError />}
 
-			{!isError && traces.length > 0 && (
+			{(!isError || isKeyNotFound) && traces.length > 0 && (
 				<div className={styles.entityTracesTable}>
 					<div className={styles.controls}>
 						<Controls

--- a/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/utils.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/EntityDetailsUtils/utils.tsx
@@ -8,10 +8,25 @@ import {
 	IBuilderQuery,
 	TagFilterItem,
 } from 'types/api/queryBuilder/queryBuilderData';
+import APIError from 'types/api/error';
 import { EQueryType } from 'types/common/dashboard';
 import { DataSource, ReduceOperators } from 'types/common/queryBuilder';
 import { nanoToMilli } from 'utils/timeUtils';
 import { v4 as uuidv4 } from 'uuid';
+
+export function isKeyNotFoundError(error: unknown): boolean {
+	if (!(error instanceof APIError)) {
+		return false;
+	}
+
+	const errorDetails = error.getErrorDetails();
+	if (errorDetails.error.code !== 'invalid_input') {
+		return false;
+	}
+
+	const errors = errorDetails.error.errors || [];
+	return errors.some((err) => err.message?.includes('not found'));
+}
 
 export const QUERY_KEYS = {
 	K8S_OBJECT_KIND: 'k8s.object.kind',


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Events was already handling when key not found happens but I forgot to include the handling for the metrics/traces/logs as well.

Also fixed a issue that caused many re-renders during query search change.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

<img width="1536" height="612" alt="image" src="https://github.com/user-attachments/assets/7b21544e-f457-4d53-b017-8eaa24d531c8" />

After:

<img width="1978" height="965" alt="image" src="https://github.com/user-attachments/assets/9cf4174e-a8fd-43b7-8317-d039096e97ad" />

The error still appears on logs but will not reflect in the UI.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered