### PR TITLE
fix: improve time shift wrapper (#10188)

### DIFF
--- a/frontend/src/constants/queryFunctionOptions.ts
+++ b/frontend/src/constants/queryFunctionOptions.ts
@@ -84,8 +84,19 @@ interface QueryFunctionConfigType {
 		inputType?: string;
 		placeholder?: string;
 		disabled?: boolean;
+		selectOptions?: SelectOption<string, string>[];
 	};
 }
+
+export const TIME_SHIFT_OPTIONS: SelectOption<string, string>[] = [
+	{ label: '1 hour ago', value: '3600' },
+	{ label: '6 hours ago', value: '21600' },
+	{ label: '12 hours ago', value: '43200' },
+	{ label: '1 day ago', value: '86400' },
+	{ label: '2 days ago', value: '172800' },
+	{ label: '1 week ago', value: '604800' },
+	{ label: 'Custom', value: 'custom' },
+];
 
 export const queryFunctionsTypesConfig: QueryFunctionConfigType = {
 	anomaly: {
@@ -153,7 +164,8 @@ export const queryFunctionsTypesConfig: QueryFunctionConfigType = {
 	},
 	timeShift: {
 		showInput: true,
-		inputType: 'text',
+		inputType: 'select',
+		selectOptions: TIME_SHIFT_OPTIONS,
 	},
 	fillZero: {
 		showInput: false,

--- a/frontend/src/container/QueryBuilder/components/QueryFunctions/Function.tsx
+++ b/frontend/src/container/QueryBuilder/components/QueryFunctions/Function.tsx
@@ -35,7 +35,7 @@ export default function Function({
 	const isDarkMode = useIsDarkMode();
 	// Normalize function name to handle backend response case sensitivity
 	const normalizedFunctionName = normalizeFunctionName(funcData.name);
-	const { showInput, disabled } =
+	const { showInput, disabled, inputType, selectOptions } =
 		queryFunctionsTypesConfig[normalizedFunctionName];
 
 	let functionValue;
@@ -53,6 +53,14 @@ export default function Function({
 	const debouncedhandleUpdateFunctionArgs = useMemo(
 		() => debounce(handleUpdateFunctionArgs, 500),
 		[handleUpdateFunctionArgs],
+	);
+
+	const predefinedValues = selectOptions
+		? selectOptions.filter((o) => o.value !== 'custom').map((o) => o.value)
+		: [];
+
+	const [isCustomMode, setIsCustomMode] = useState<boolean>(
+		!!value && !predefinedValues.includes(value),
 	);
 
 	// update the logic when we start supporting functions for traces
@@ -90,20 +98,65 @@ export default function Function({
 				options={functionOptions}
 			/>
 
-			{showInput && (
-				<OverflowInputToolTip
-					autoFocus
-					value={value}
-					onChange={(event): void => {
-						const newVal = event.target.value;
-						setValue(newVal);
-						debouncedhandleUpdateFunctionArgs(funcData, index, event.target.value);
-					}}
-					tooltipPlacement="top"
-					minAutoWidth={70}
-					maxAutoWidth={150}
-					className="query-function-value"
-				/>
+			{showInput && inputType === 'select' && selectOptions ? (
+				<>
+					<Select
+						value={isCustomMode ? 'custom' : value || undefined}
+						options={selectOptions}
+						onChange={(val): void => {
+							if (val === 'custom') {
+								setIsCustomMode(true);
+								setValue('');
+							} else {
+								setIsCustomMode(false);
+								setValue(val);
+								handleUpdateFunctionArgs(funcData, index, val);
+							}
+						}}
+						dropdownStyle={{
+							minWidth: 160,
+							borderRadius: '4px',
+							border: isDarkMode
+								? '1px solid var(--bg-slate-400)'
+								: '1px solid var(--bg-vanilla-300)',
+							boxShadow: `4px 10px 16px 2px rgba(0, 0, 0, 0.20)`,
+						}}
+						style={{ minWidth: '120px' }}
+						placement="bottomRight"
+						placeholder="Select offset"
+					/>
+					{isCustomMode && (
+						<OverflowInputToolTip
+							autoFocus
+							value={value}
+							onChange={(event): void => {
+								const newVal = event.target.value;
+								setValue(newVal);
+								debouncedhandleUpdateFunctionArgs(funcData, index, newVal);
+							}}
+							tooltipPlacement="top"
+							minAutoWidth={70}
+							maxAutoWidth={150}
+							className="query-function-value"
+						/>
+					)}
+				</>
+			) : (
+				showInput && (
+					<OverflowInputToolTip
+						autoFocus
+						value={value}
+						onChange={(event): void => {
+							const newVal = event.target.value;
+							setValue(newVal);
+							debouncedhandleUpdateFunctionArgs(funcData, index, event.target.value);
+						}}
+						tooltipPlacement="top"
+						minAutoWidth={70}
+						maxAutoWidth={150}
+						className="query-function-value"
+					/>
+				)
 			)}
 
 			<Button

--- a/frontend/src/container/QueryBuilder/components/QueryFunctions/Function.tsx
+++ b/frontend/src/container/QueryBuilder/components/QueryFunctions/Function.tsx
@@ -7,7 +7,6 @@ import {
 	metricQueryFunctionOptions,
 	queryFunctionsTypesConfig,
 } from 'constants/queryFunctionOptions';
-import { useIsDarkMode } from 'hooks/useDarkMode';
 import { debounce, isNil } from 'lodash-es';
 import { X } from '@signozhq/icons';
 import { IBuilderQuery } from 'types/api/queryBuilder/queryBuilderData';
@@ -32,7 +31,6 @@ export default function Function({
 	handleUpdateFunctionName,
 	handleDeleteFunction,
 }: FunctionProps): JSX.Element {
-	const isDarkMode = useIsDarkMode();
 	// Normalize function name to handle backend response case sensitivity
 	const normalizedFunctionName = normalizeFunctionName(funcData.name);
 	const { showInput, disabled, inputType, selectOptions } =
@@ -89,9 +87,7 @@ export default function Function({
 				dropdownStyle={{
 					minWidth: 200,
 					borderRadius: '4px',
-					border: isDarkMode
-						? '1px solid var(--bg-slate-400)'
-						: '1px solid var(--bg-vanilla-300)',
+					border: '1px solid var(--border)',
 					boxShadow: `4px 10px 16px 2px rgba(0, 0, 0, 0.20)`,
 				}}
 				placement="bottomRight"
@@ -116,9 +112,7 @@ export default function Function({
 						dropdownStyle={{
 							minWidth: 160,
 							borderRadius: '4px',
-							border: isDarkMode
-								? '1px solid var(--bg-slate-400)'
-								: '1px solid var(--bg-vanilla-300)',
+							border: '1px solid var(--border)',
 							boxShadow: `4px 10px 16px 2px rgba(0, 0, 0, 0.20)`,
 						}}
 						style={{ minWidth: '120px' }}

--- a/frontend/src/container/QueryBuilder/components/QueryFunctions/QueryFunctions.tsx
+++ b/frontend/src/container/QueryBuilder/components/QueryFunctions/QueryFunctions.tsx
@@ -10,7 +10,6 @@ import { DataSource, QueryFunctionsTypes } from 'types/common/queryBuilder';
 import { normalizeFunctionName } from 'utils/functionNameNormalizer';
 
 import Function from './Function';
-import { toFloat64 } from './utils';
 
 import './QueryFunctions.styles.scss';
 
@@ -162,14 +161,7 @@ export default function QueryFunctions({
 		const updateFunctions = cloneDeep(functions);
 
 		if (updateFunctions && updateFunctions.length > 0 && updateFunctions[index]) {
-			updateFunctions[index].args = [
-				{
-					value:
-						updateFunctions[index].name === QueryFunctionsTypes.TIME_SHIFT
-							? toFloat64(value)
-							: value,
-				},
-			];
+			updateFunctions[index].args = [{ value }];
 			setFunctions(updateFunctions);
 			onChange(updateFunctions);
 		}

--- a/frontend/src/container/QueryBuilder/components/QueryFunctions/utils.ts
+++ b/frontend/src/container/QueryBuilder/components/QueryFunctions/utils.ts
@@ -1,7 +1,0 @@
-export const toFloat64 = (value: string): number => {
-	const parsed = parseFloat(value);
-	if (!Number.isFinite(parsed)) {
-		console.error(`Invalid value for timeshift. value: ${value}`);
-	}
-	return parsed;
-};

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	gomaps "maps"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -84,17 +83,8 @@ func New(
 func extractShiftFromBuilderQuery[T any](spec qbtypes.QueryBuilderQuery[T]) int64 {
 	for _, fn := range spec.Functions {
 		if fn.Name == qbtypes.FunctionNameTimeShift && len(fn.Args) > 0 {
-			switch v := fn.Args[0].Value.(type) {
-			case float64:
-				return int64(v)
-			case int64:
-				return v
-			case int:
-				return int64(v)
-			case string:
-				if shiftFloat, err := strconv.ParseFloat(v, 64); err == nil {
-					return int64(shiftFloat)
-				}
+			if shiftSeconds, err := valuer.ParseTimeShiftSeconds(fn.Args[0].Value); err == nil {
+				return int64(shiftSeconds)
 			}
 		}
 	}

--- a/pkg/query-service/app/queryBuilder/functions.go
+++ b/pkg/query-service/app/queryBuilder/functions.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	v3 "github.com/SigNoz/signoz/pkg/query-service/model/v3"
+	"github.com/SigNoz/signoz/pkg/valuer"
 )
 
 // funcCutOffMin cuts off values below the threshold and replaces them with NaN
@@ -300,8 +301,8 @@ func ApplyFunction(fn v3.Function, result *v3.Result) *v3.Result {
 	case v3.FunctionNameMedian7:
 		return funcMedian7(result)
 	case v3.FunctionNameTimeShift:
-		shift, ok := fn.Args[0].(float64)
-		if !ok {
+		shift, err := valuer.ParseTimeShiftSeconds(fn.Args[0])
+		if err != nil {
 			return result
 		}
 		return funcTimeShift(result, shift)

--- a/pkg/query-service/model/v3/v3.go
+++ b/pkg/query-service/model/v3/v3.go
@@ -935,13 +935,10 @@ func (b *BuilderQuery) SetShiftByFromFunc() {
 				fns = append(fns, b.Functions[idx+1:]...)
 				b.Functions = fns
 				if len(function.Args) > 0 {
-					if shift, ok := function.Args[0].(float64); ok {
-						timeShiftBy = int64(shift)
-					} else if shift, ok := function.Args[0].(string); ok {
-						shiftBy, err := strconv.ParseFloat(shift, 64)
-						if err != nil {
-							slog.Error("failed to parse time shift by", "shift", shift, signozerrors.Attr(err))
-						}
+					shiftBy, err := valuer.ParseTimeShiftSeconds(function.Args[0])
+					if err != nil {
+						slog.Error("failed to parse time shift by", "shift", function.Args[0], signozerrors.Attr(err))
+					} else {
 						timeShiftBy = int64(shiftBy)
 					}
 				}
@@ -1112,15 +1109,11 @@ func (b *BuilderQuery) Validate(panelType PanelType) error {
 				if len(function.Args) == 0 {
 					return fmt.Errorf("timeShiftBy param missing in query")
 				}
-				_, ok := function.Args[0].(float64)
-				if !ok {
-					// if string, attempt to convert to float
-					timeShiftBy, err := strconv.ParseFloat(function.Args[0].(string), 64)
-					if err != nil {
-						return fmt.Errorf("timeShiftBy param should be a number")
-					}
-					function.Args[0] = timeShiftBy
+				timeShiftBy, err := valuer.ParseTimeShiftSeconds(function.Args[0])
+				if err != nil {
+					return fmt.Errorf("timeShiftBy param should be a valid duration or second value")
 				}
+				function.Args[0] = timeShiftBy
 			} else if function.Name == FunctionNameEWMA3 ||
 				function.Name == FunctionNameEWMA5 ||
 				function.Name == FunctionNameEWMA7 {

--- a/pkg/types/querybuildertypes/querybuildertypesv5/functions.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/functions.go
@@ -152,7 +152,7 @@ func ApplyFunction(fn Function, result *TimeSeries) *TimeSeries {
 		if len(args) == 0 {
 			return result
 		}
-		shift, err := parseFloat64Arg(args[0].Value)
+		shift, err := valuer.ParseTimeShiftSeconds(args[0].Value)
 		if err != nil {
 			return result
 		}
@@ -226,11 +226,11 @@ func (fn Function) ValidateArgs() error {
 				name.StringValue(),
 			)
 		}
-		_, err := parseFloat64Arg(args[0].Value)
+		_, err := valuer.ParseTimeShiftSeconds(args[0].Value)
 		if err != nil {
 			return errors.NewInvalidInputf(
 				errors.CodeInvalidInput,
-				"time shift value must be a floating value for function %s",
+				"time shift value must be a valid duration for function %s",
 				name.StringValue(),
 			)
 		}

--- a/pkg/valuer/time_shift.go
+++ b/pkg/valuer/time_shift.go
@@ -1,0 +1,71 @@
+package valuer
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var agoUnitSeconds = map[string]float64{
+	"second": 1, "seconds": 1,
+	"minute": 60, "minutes": 60,
+	"hour": 3600, "hours": 3600,
+	"day": 86400, "days": 86400,
+	"week": 604800, "weeks": 604800,
+}
+
+// ParseTimeShiftSeconds converts a timeShift argument into seconds (float64).
+// Accepts numeric seconds (3600, "3600"), Go duration strings ("5m", "1.5h"),
+// and human-readable phrases ("1 hour ago", "2 days ago", "1 week ago").
+func ParseTimeShiftSeconds(value any) (float64, error) {
+	switch v := value.(type) {
+	case float64:
+		return v, nil
+	case int64:
+		return float64(v), nil
+	case int:
+		return float64(v), nil
+	case string:
+		return parseTimeShiftSecondsFromString(v)
+	default:
+		return 0, fmt.Errorf("unsupported type %T for time shift", value)
+	}
+}
+
+func parseTimeShiftSecondsFromString(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty time shift value")
+	}
+
+	// Raw number: "3600", "-300", "86400.5"
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return f, nil
+	}
+
+	// "N unit ago" phrase: "1 hour ago", "2 days ago", "1 week ago"
+	lower := strings.ToLower(s)
+	if strings.HasSuffix(lower, " ago") {
+		phrase := strings.TrimSuffix(lower, " ago")
+		parts := strings.Fields(phrase)
+		if len(parts) == 2 {
+			if count, err := strconv.ParseFloat(parts[0], 64); err == nil {
+				if secs, ok := agoUnitSeconds[parts[1]]; ok {
+					return count * secs, nil
+				}
+			}
+		}
+	}
+
+	// Go duration string: "5m", "1.5h", "1h30m", "-10m"
+	if d, err := time.ParseDuration(s); err == nil {
+		secs := d.Seconds()
+		if secs > 0 && secs < 1 {
+			return 0, fmt.Errorf("time shift must be at least 1 second, got %q", s)
+		}
+		return secs, nil
+	}
+
+	return 0, fmt.Errorf("invalid time shift value %q: expected seconds, a duration like \"5m\", or a phrase like \"1 hour ago\"", s)
+}

--- a/pkg/valuer/time_shift.go
+++ b/pkg/valuer/time_shift.go
@@ -1,10 +1,11 @@
 package valuer
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/SigNoz/signoz/pkg/errors"
 )
 
 var agoUnitSeconds = map[string]float64{
@@ -29,14 +30,14 @@ func ParseTimeShiftSeconds(value any) (float64, error) {
 	case string:
 		return parseTimeShiftSecondsFromString(v)
 	default:
-		return 0, fmt.Errorf("unsupported type %T for time shift", value)
+		return 0, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "unsupported type %T for time shift", value)
 	}
 }
 
 func parseTimeShiftSecondsFromString(s string) (float64, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return 0, fmt.Errorf("empty time shift value")
+		return 0, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "empty time shift value")
 	}
 
 	// Raw number: "3600", "-300", "86400.5"
@@ -62,10 +63,10 @@ func parseTimeShiftSecondsFromString(s string) (float64, error) {
 	if d, err := time.ParseDuration(s); err == nil {
 		secs := d.Seconds()
 		if secs > 0 && secs < 1 {
-			return 0, fmt.Errorf("time shift must be at least 1 second, got %q", s)
+			return 0, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "time shift must be at least 1 second, got %q", s)
 		}
 		return secs, nil
 	}
 
-	return 0, fmt.Errorf("invalid time shift value %q: expected seconds, a duration like \"5m\", or a phrase like \"1 hour ago\"", s)
+	return 0, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "invalid time shift value %q: expected seconds, a duration like \"5m\", or a phrase like \"1 hour ago\"", s)
 }

--- a/pkg/valuer/time_shift_test.go
+++ b/pkg/valuer/time_shift_test.go
@@ -1,0 +1,84 @@
+package valuer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTimeShiftSeconds(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    any
+		expected float64
+		wantErr  bool
+	}{
+		// Numeric types
+		{name: "float64 value", input: float64(3600), expected: 3600},
+		{name: "int64 value", input: int64(86400), expected: 86400},
+		{name: "int value", input: int(300), expected: 300},
+		{name: "negative float64", input: float64(-300), expected: -300},
+		{name: "zero float64", input: float64(0), expected: 0},
+
+		// Raw numeric strings
+		{name: "string integer seconds", input: "3600", expected: 3600},
+		{name: "string float seconds", input: "86400.5", expected: 86400.5},
+		{name: "string negative seconds", input: "-300", expected: -300},
+		{name: "string zero", input: "0", expected: 0},
+
+		// Go duration strings
+		{name: "5 minutes", input: "5m", expected: 300},
+		{name: "1 hour", input: "1h", expected: 3600},
+		{name: "1.5 hours", input: "1.5h", expected: 5400},
+		{name: "1h30m", input: "1h30m", expected: 5400},
+		{name: "1 week as duration", input: "168h", expected: 604800},
+		{name: "negative duration", input: "-10m", expected: -600},
+		{name: "30 seconds", input: "30s", expected: 30},
+
+		// Human-readable "N unit ago" phrases
+		{name: "1 hour ago", input: "1 hour ago", expected: 3600},
+		{name: "6 hours ago", input: "6 hours ago", expected: 21600},
+		{name: "12 hours ago", input: "12 hours ago", expected: 43200},
+		{name: "1 day ago", input: "1 day ago", expected: 86400},
+		{name: "2 days ago", input: "2 days ago", expected: 172800},
+		{name: "1 week ago", input: "1 week ago", expected: 604800},
+		{name: "1 minute ago", input: "1 minute ago", expected: 60},
+		{name: "30 minutes ago", input: "30 minutes ago", expected: 1800},
+		{name: "1 second ago", input: "1 second ago", expected: 1},
+		{name: "60 seconds ago", input: "60 seconds ago", expected: 60},
+		{name: "uppercase phrase", input: "1 HOUR AGO", expected: 3600},
+		{name: "mixed case phrase", input: "2 Days Ago", expected: 172800},
+
+		// Sub-second duration string — should error
+		{name: "sub-second duration", input: "500ms", wantErr: true},
+		{name: "nanoseconds", input: "100ns", wantErr: true},
+
+		// Invalid inputs
+		{name: "empty string", input: "", wantErr: true},
+		{name: "whitespace only", input: "   ", wantErr: true},
+		{name: "random text", input: "yesterday", wantErr: true},
+		{name: "malformed ago phrase", input: "hour ago", wantErr: true},
+		{name: "unsupported unit ago", input: "1 fortnight ago", wantErr: true},
+		{name: "unsupported type bool", input: true, wantErr: true},
+		{name: "unsupported type slice", input: []int{1}, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseTimeShiftSeconds(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestParseTimeShiftSeconds_WhitespaceTrimmed(t *testing.T) {
+	got, err := ParseTimeShiftSeconds("  3600  ")
+	require.NoError(t, err)
+	assert.Equal(t, float64(3600), got)
+}


### PR DESCRIPTION
 ---                                                                                    
                                                                                       
  ## Pull Request                                                                        
                                                                                       
  ---                                                                                  
                                                                                       
  ### 📄 Summary                                                                         
  
  The `timeShift` query function previously accepted only raw numeric seconds (e.g.      
  `3600`), with type-assertion logic scattered across three separate backend files. Each
  site handled the conversion slightly differently, making the code fragile and hard to  
  extend. On the frontend, users had a bare text input with no guidance on valid values.
                                                                                       
  This PR consolidates all timeshift parsing into a single `valuer.ParseTimeShiftSeconds`
   function that accepts numeric types, raw numeric strings, Go duration strings (`"5m"`,
   `"1h30m"`), and human-readable phrases (`"1 hour ago"`, `"2 days ago"`). The frontend 
  input is replaced with a curated dropdown (1h, 6h, 12h, 1d, 2d, 1w) plus a **Custom**
  option that reveals a free-text field for arbitrary values.                          
                                                                                         
  #### Screenshots / Screen Recordings (if applicable)                                         

https://github.com/user-attachments/assets/4cb6364a-760c-4757-bbbd-9cb64c1d320f

<img width="1456" height="896" alt="Screenshot 2026-05-15 at 2 12 03 AM" src="https://github.com/user-attachments/assets/ed245af7-ce3b-4e77-b78d-8f89bea531a6" />




  #### Issues closed by this PR                                                          
  Closes #10188                                                                        
                                                                                       
  ---

  ### ✅ Change Type                                                                     
  
  - [x] 🐛 Bug fix                                                                       
  - [x] ♻️  Refactor                                                                    
                                                                                         
  ---
                                                                                         
  ### 🐛 Bug Context                                                                   
                                                                                       
  #### Root Cause
  Timeshift value parsing was duplicated across `querier.go`,
  `queryBuilder/functions.go`, and `model/v3/v3.go`. Each copy used ad-hoc type switches 
  with only partial coverage (`float64` or `float64 + string-to-float`), so values
  arriving as `int`, `int64`, Go duration strings, or human-readable phrases were        
  silently dropped or returned errors at runtime.                                      
                                                                                       
  #### Fix Strategy
  Introduce `pkg/valuer/time_shift.go` with a single `ParseTimeShiftSeconds(any)
  (float64, error)` function that handles all expected input formats. Replace all three  
  scattered type-switch blocks with calls to this function. Extend the frontend to emit
  string values from a structured dropdown instead of forcing the user to know the       
  raw-seconds format, and remove the now-redundant `toFloat64` frontend utility.       
                                                                                       
  ---

  ### 🧪 Testing Strategy

  - **Tests added/updated:** `pkg/valuer/time_shift_test.go` — 30+ table-driven cases    
  covering numeric types, raw strings, Go duration strings, human-readable phrases,
  sub-second rejections, and invalid inputs.                                             
  - **Manual verification:** Timeshift dropdown renders with preset offsets; selecting 
  "Custom" reveals the text input; existing dashboards using raw-second values continue  
  to load correctly.
  - **Edge cases covered:** Negative shifts, zero, fractional seconds, sub-second        
  durations (rejected), unknown units, malformed "ago" phrases, unsupported Go types.    
  ---                                                                                  
                                                                                         
  ### ⚠️  Risk & Impact Assessment                                                      
                                                                                         
  - **Blast radius:** Affects all queries that use the `timeShift` function — metrics and
   logs panels. No changes to data storage or query execution logic.                     
  - **Potential regressions:** Existing saved queries that stored timeshift as `float64`
  are parsed identically. Queries that stored the value as a plain numeric string now go 
  through `ParseTimeShiftSeconds`, which accepts them — no breakage expected.            
  - **Rollback plan:** Revert the PR; the old scattered type-switch logic is preserved in
   git history.                                                                          
                                                                                         
  ---                                                                                  
                                                                                         
  ### 📝 Changelog                                                                     
                                                                                         
  | Field | Value |
  |------|-------|                                                                       
  | Deployment Type | Cloud / OSS / Enterprise |                                       
  | Change Type | Bug Fix |                                                            
  | Description | The `timeShift` query function now accepts duration strings (`5m`,     
  `1h`) and human-readable offsets (`1 day ago`). The query builder UI replaces the bare
  text input with a dropdown of common offsets plus a Custom option. |                   
                                                                                       
  ---                                                                                    
                                                                                       
  ### 📋 Checklist                                                                     
  - [x] Tests added or explicitly not required
  - [x] Manually tested                       
  - [ ] Breaking changes documented                                                      
  - [x] Backward compatibility considered
                                                                                         
  ---                                                                                  
  Key decisions I made:                                                                  
  - Marked both Bug fix and Refactor since the scattered parsing was both buggy (silently
   dropped valid inputs) and a structural issue.                                         
  - The changelog description is user-facing: it highlights the new accepted formats and 
  the UI improvement.                                                                   
  - Breaking changes unchecked — the change is backwards compatible (raw seconds still   
  work identically).    

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
