### PR TITLE
fix: resolve contextLinks variable placeholders for per-row values

### DIFF
--- a/frontend/src/hooks/dashboard/useContextVariables.tsx
+++ b/frontend/src/hooks/dashboard/useContextVariables.tsx
@@ -233,7 +233,12 @@ const resolveText = (
 
 	return text.replace(combinedPattern, (match) => {
 		const varName = extractVarName(match, matcher, processedVariables);
-		const value = processedVariables[varName];
+		// Try the variable name as-is, then with the '_' prefix used by useContextVariables
+		// for custom (per-row) variables to avoid conflicts with dashboard/global variables.
+		let value = processedVariables[varName];
+		if (value == null) {
+			value = processedVariables[`_${varName}`];
+		}
 
 		if (value != null) {
 			const parts = value.split('-|-');
@@ -254,7 +259,11 @@ const resolveTextWithTruncation = (
 
 	const result = text.replace(combinedPattern, (match) => {
 		const varName = extractVarName(match, matcher, processedVariables);
-		const value = processedVariables[varName];
+		// Try the variable name as-is, then with the '_' prefix
+		let value = processedVariables[varName];
+		if (value == null) {
+			value = processedVariables[`_${varName}`];
+		}
 
 		if (value != null) {
 			const parts = value.split('-|-');


### PR DESCRIPTION
## Summary

Fixes #11325.

When a dashboard table panel has `contextLinks` configured with URL templates like:
```json
{
  "url": "/trace/{{trace_id}}?spanId={{span_id}}"
}
```

the `{{trace_id}}` and `{{span_id}}` placeholders were left URL-encoded in the final link instead of being replaced with the actual row values.

## Root cause

`useContextVariables` registers custom (per-row) field variables with a leading `_` prefix to avoid conflicts with dashboard and global variables (e.g. `_trace_id`, `_span_id`). The `resolveText` and `resolveTextWithTruncation` utility functions, however, looked up variable names exactly as extracted from the placeholder syntax (`{{trace_id}}` → `trace_id`), so the `_`-prefixed custom variables were never matched.

## Fix

Added a fallback lookup in both `resolveText` and `resolveTextWithTruncation`: when the exact variable name is not found, also try the `_`-prefixed variant before falling back to leaving the placeholder unresolved.

## Validation

- `resolveText("/trace/{{trace_id}}", { _trace_id: "abc123" })` → `"/trace/abc123"` (was `"/trace/{{trace_id}}"`)
- Existing `$var` and `[[var]]` placeholder syntaxes continue to work unchanged
- Dashboard and global variables without `_` prefix continue to match as before

## Related

- `frontend/src/hooks/dashboard/useContextVariables.tsx` — both `resolveText` and `resolveTextWithTruncation` updated