### PR TITLE
fix(authz): reserve signoz prefix for managed roles 

### DIFF
--- a/pkg/types/authtypes/role.go
+++ b/pkg/types/authtypes/role.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/SigNoz/signoz/pkg/errors"
@@ -26,7 +27,8 @@ var (
 )
 
 var (
-	roleNameRegex = regexp.MustCompile("^[a-z-]{1,50}$")
+	roleNameRegex     = regexp.MustCompile("^[a-z-]{1,50}$")
+	managedRolePrefix = "signoz-"
 )
 
 var (
@@ -140,7 +142,11 @@ func (role *PostableRole) UnmarshalJSON(data []byte) error {
 	}
 
 	if match := roleNameRegex.MatchString(shadowRole.Name); !match {
-		return errors.Newf(errors.TypeInvalidInput, ErrCodeRoleInvalidInput, "name must conform to the regex: %s", roleNameRegex.String())
+		return errors.New(errors.TypeInvalidInput, ErrCodeRoleInvalidInput, "name must contain only lowercase letters (a-z) and hyphens (-), and be at most 50 characters long.")
+	}
+
+	if strings.HasPrefix(shadowRole.Name, managedRolePrefix) {
+		return errors.Newf(errors.TypeInvalidInput, ErrCodeRoleInvalidInput, "role name cannot start with %q as it is reserved for SigNoz managed roles.", managedRolePrefix)
 	}
 
 	role.Name = shadowRole.Name

--- a/pkg/types/authtypes/role.go
+++ b/pkg/types/authtypes/role.go
@@ -28,7 +28,7 @@ var (
 
 var (
 	roleNameRegex     = regexp.MustCompile("^[a-z-]{1,50}$")
-	managedRolePrefix = "signoz-"
+	managedRolePrefix = "signoz"
 )
 
 var (

--- a/tests/integration/tests/role/03_fga.py
+++ b/tests/integration/tests/role/03_fga.py
@@ -60,13 +60,14 @@ def test_create_role_with_signoz_prefix_rejected(
 ):
     admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
 
-    resp = requests.post(
-        signoz.self.host_configs["8080"].get(ROLES_BASE),
-        json={"name": "signoz-custom"},
-        headers={"Authorization": f"Bearer {admin_token}"},
-        timeout=5,
-    )
-    assert resp.status_code == HTTPStatus.BAD_REQUEST, f"expected 400, got {resp.status_code}: {resp.text}"
+    for name in ("signoz-custom", "signozcustom"):
+        resp = requests.post(
+            signoz.self.host_configs["8080"].get(ROLES_BASE),
+            json={"name": name},
+            headers={"Authorization": f"Bearer {admin_token}"},
+            timeout=5,
+        )
+        assert resp.status_code == HTTPStatus.BAD_REQUEST, f"expected 400 for role name '{name}', got {resp.status_code}: {resp.text}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/tests/role/03_fga.py
+++ b/tests/integration/tests/role/03_fga.py
@@ -49,7 +49,28 @@ def test_apply_license(
 
 
 # ---------------------------------------------------------------------------
-# 2. Create custom role + user with read/list on roles
+# 2. Reject role names starting with "signoz-"
+# ---------------------------------------------------------------------------
+
+
+def test_create_role_with_signoz_prefix_rejected(
+    signoz: types.SigNoz,
+    create_user_admin: types.Operation,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+):
+    admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+
+    resp = requests.post(
+        signoz.self.host_configs["8080"].get(ROLES_BASE),
+        json={"name": "signoz-custom"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+        timeout=5,
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST, f"expected 400, got {resp.status_code}: {resp.text}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Create custom role + user with read/list on roles
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION

### 📄 Summary
- reserve signoz prefix for managed roles 

contributes to: https://github.com/SigNoz/platform-pod/issues/2256