### PR TITLE
refactor: only select the required map column in flamegraph query

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -1155,21 +1155,10 @@ func (r *ClickHouseReader) GetFlamegraphSpansForTrace(ctx context.Context, orgID
 	if err != nil {
 		r.logger.Info("cache miss for getFlamegraphSpansForTrace", "traceID", traceID)
 
-		needsAttrMap, needsResourceMap := false, false
-		for _, f := range req.SelectFields {
-			switch f.FieldContext {
-			case telemetrytypes.FieldContextAttribute:
-				needsAttrMap = true
-			case telemetrytypes.FieldContextResource:
-				needsResourceMap = true
-			}
-		}
 		selectCols := "timestamp, duration_nano, span_id, trace_id, has_error, links as references, resource_string_service$$name, name, events"
-		if needsAttrMap {
-			selectCols += ", attributes_string, attributes_number, attributes_bool"
-		}
-		if needsResourceMap {
-			selectCols += ", resources_string"
+		selectFieldCols := req.GetSelectedFeildsSourceColumns()
+		if len(selectFieldCols) > 0 {
+			selectCols = fmt.Sprintf("%s, %s", selectCols, strings.Join(selectFieldCols, ", "))
 		}
 
 		flamegraphQuery := fmt.Sprintf("SELECT %s FROM %s.%s WHERE trace_id=$1 and ts_bucket_start>=$2 and ts_bucket_start<=$3 ORDER BY timestamp ASC, name ASC", selectCols, r.TraceDB, r.traceTableName)

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -1156,7 +1156,7 @@ func (r *ClickHouseReader) GetFlamegraphSpansForTrace(ctx context.Context, orgID
 		r.logger.Info("cache miss for getFlamegraphSpansForTrace", "traceID", traceID)
 
 		selectCols := "timestamp, duration_nano, span_id, trace_id, has_error, links as references, resource_string_service$$name, name, events"
-		selectFieldCols := req.GetSelectedFeildsSourceColumns()
+		selectFieldCols := req.GetSelectedFieldsSourceColumns()
 		if len(selectFieldCols) > 0 {
 			selectCols = fmt.Sprintf("%s, %s", selectCols, strings.Join(selectFieldCols, ", "))
 		}

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -1155,10 +1155,23 @@ func (r *ClickHouseReader) GetFlamegraphSpansForTrace(ctx context.Context, orgID
 	if err != nil {
 		r.logger.Info("cache miss for getFlamegraphSpansForTrace", "traceID", traceID)
 
-		selectCols := "timestamp, duration_nano, span_id, trace_id, has_error, links as references, resource_string_service$$name, name, events"
-		if len(req.SelectFields) > 0 {
-			selectCols += ", attributes_string, attributes_number, attributes_bool, resources_string"
+		needsAttrMap, needsResourceMap := false, false
+		for _, f := range req.SelectFields {
+			switch f.FieldContext {
+			case telemetrytypes.FieldContextAttribute:
+				needsAttrMap = true
+			case telemetrytypes.FieldContextResource:
+				needsResourceMap = true
+			}
 		}
+		selectCols := "timestamp, duration_nano, span_id, trace_id, has_error, links as references, resource_string_service$$name, name, events"
+		if needsAttrMap {
+			selectCols += ", attributes_string, attributes_number, attributes_bool"
+		}
+		if needsResourceMap {
+			selectCols += ", resources_string"
+		}
+
 		flamegraphQuery := fmt.Sprintf("SELECT %s FROM %s.%s WHERE trace_id=$1 and ts_bucket_start>=$2 and ts_bucket_start<=$3 ORDER BY timestamp ASC, name ASC", selectCols, r.TraceDB, r.traceTableName)
 
 		searchScanResponses, err := r.GetSpansForTrace(ctx, traceID, flamegraphQuery)

--- a/pkg/query-service/model/queryParams.go
+++ b/pkg/query-service/model/queryParams.go
@@ -346,6 +346,27 @@ type GetFlamegraphSpansForTraceParams struct {
 	SelectFields    []telemetrytypes.TelemetryFieldKey `json:"selectFields"`
 }
 
+func (r *GetFlamegraphSpansForTraceParams) GetSelectedFeildsSourceColumns() []string {
+	needsAttrMap, needsResourceMap := false, false
+	for _, f := range r.SelectFields {
+		switch f.FieldContext {
+		case telemetrytypes.FieldContextAttribute:
+			needsAttrMap = true
+		case telemetrytypes.FieldContextResource:
+			needsResourceMap = true
+		}
+	}
+
+	var cols []string
+	if needsAttrMap {
+		cols = append(cols, "attributes_string", "attributes_number", "attributes_bool")
+	}
+	if needsResourceMap {
+		cols = append(cols, "resources_string")
+	}
+	return cols
+}
+
 type SpanFilterParams struct {
 	TraceID            []string `json:"traceID"`
 	Status             []string `json:"status"`

--- a/pkg/query-service/model/queryParams.go
+++ b/pkg/query-service/model/queryParams.go
@@ -346,20 +346,38 @@ type GetFlamegraphSpansForTraceParams struct {
 	SelectFields    []telemetrytypes.TelemetryFieldKey `json:"selectFields"`
 }
 
-func (r *GetFlamegraphSpansForTraceParams) GetSelectedFeildsSourceColumns() []string {
-	needsAttrMap, needsResourceMap := false, false
+func (r *GetFlamegraphSpansForTraceParams) GetSelectedFieldsSourceColumns() []string {
+	var needsAttrString, needsAttrNumber, needsAttrBool, needsResourceMap bool
 	for _, f := range r.SelectFields {
 		switch f.FieldContext {
 		case telemetrytypes.FieldContextAttribute:
-			needsAttrMap = true
+			switch f.FieldDataType {
+			case telemetrytypes.FieldDataTypeString:
+				needsAttrString = true
+			case telemetrytypes.FieldDataTypeFloat64, telemetrytypes.FieldDataTypeNumber, telemetrytypes.FieldDataTypeInt64:
+				needsAttrNumber = true
+			case telemetrytypes.FieldDataTypeBool:
+				needsAttrBool = true
+			default:
+				// Unknown type: AttributeValue searches all three maps, so we need all.
+				needsAttrString = true
+				needsAttrNumber = true
+				needsAttrBool = true
+			}
 		case telemetrytypes.FieldContextResource:
 			needsResourceMap = true
 		}
 	}
 
 	var cols []string
-	if needsAttrMap {
-		cols = append(cols, "attributes_string", "attributes_number", "attributes_bool")
+	if needsAttrString {
+		cols = append(cols, "attributes_string")
+	}
+	if needsAttrNumber {
+		cols = append(cols, "attributes_number")
+	}
+	if needsAttrBool {
+		cols = append(cols, "attributes_bool")
 	}
 	if needsResourceMap {
 		cols = append(cols, "resources_string")


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

When we added feature to allow flamegraph client to request certain attributes (https://github.com/SigNoz/signoz/pull/11092/changes?w=1), we started querying all the attributes in the flamegraph query which is not required. In our current UI implementation, we are only requesting some resource attributes, so this change will help in avoiding the unnecesary loading of unused attirbutes.


#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Part of https://github.com/SigNoz/engineering-pod/issues/4949

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only


### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
