### PR TITLE
chore(onboarding): shuffle ordering of interest in SigNoz based on version

### DIFF
--- a/frontend/src/container/OnboardingQuestionaire/AboutSigNozQuestions/AboutSigNozQuestions.tsx
+++ b/frontend/src/container/OnboardingQuestionaire/AboutSigNozQuestions/AboutSigNozQuestions.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@signozhq/ui/button';
 import { Checkbox } from '@signozhq/ui/checkbox';
 import { Input } from '@signozhq/ui/input';
 import { Input as AntdInput } from 'antd';
 import logEvent from 'api/common/logEvent';
 import { ArrowRight } from '@signozhq/icons';
+import { useAppContext } from 'providers/App/App';
 
 import { OnboardingQuestionHeader } from '../OnboardingQuestionHeader';
 
@@ -32,11 +33,31 @@ const interestedInOptions: Record<string, string> = {
 	openSourceTooling: 'Prefer open-source tooling',
 };
 
+function seededShuffle<T>(array: T[], seed: string): T[] {
+	const result = [...array];
+
+	let num = 0;
+	for (let i = 0; i < seed.length; i++) {
+		num = Math.imul(num + seed.charCodeAt(i), 2654435761);
+		num = Math.abs(num);
+	}
+
+	for (let i = result.length - 1; i > 0; i--) {
+		num = Math.abs(Math.imul(num, 1664525) + 1013904223);
+		const j = num % (i + 1);
+		[result[i], result[j]] = [result[j], result[i]];
+	}
+	
+	return result;
+}
+
 export function AboutSigNozQuestions({
 	signozDetails,
 	setSignozDetails,
 	onNext,
 }: AboutSigNozQuestionsProps): JSX.Element {
+	const { versionData } = useAppContext();
+
 	const [interestInSignoz, setInterestInSignoz] = useState<string[]>(
 		signozDetails?.interestInSignoz || [],
 	);
@@ -47,6 +68,12 @@ export function AboutSigNozQuestions({
 		signozDetails?.discoverSignoz || '',
 	);
 	const [isNextDisabled, setIsNextDisabled] = useState<boolean>(true);
+
+	const shuffledOptionKeys = useMemo(
+		() =>
+			seededShuffle(Object.keys(interestedInOptions), versionData?.version ?? ''),
+		[versionData?.version],
+	);
 
 	useEffect((): void => {
 		if (
@@ -115,7 +142,7 @@ export function AboutSigNozQuestions({
 					<div className="form-group">
 						<div className="question">What got you interested in SigNoz?</div>
 						<div className="checkbox-grid">
-							{Object.keys(interestedInOptions).map((option: string) => (
+							{shuffledOptionKeys.map((option: string) => (
 								<div key={option} className="checkbox-item">
 									<Checkbox
 										id={`checkbox-${option}`}

--- a/frontend/src/container/OnboardingQuestionaire/AboutSigNozQuestions/AboutSigNozQuestions.tsx
+++ b/frontend/src/container/OnboardingQuestionaire/AboutSigNozQuestions/AboutSigNozQuestions.tsx
@@ -47,7 +47,7 @@ function seededShuffle<T>(array: T[], seed: string): T[] {
 		const j = num % (i + 1);
 		[result[i], result[j]] = [result[j], result[i]];
 	}
-	
+
 	return result;
 }
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

The "What got you interested in SigNoz?" checkbox options on the onboarding questionnaire were always rendered in the same static order. This introduces **position bias** — users are more likely to select options near the top, skewing the data we collect and making it less useful for understanding genuine interest signals.

This PR randomizes the display order of `interestedInOptions` on a **per-release basis** using a deterministic seeded shuffle keyed off the app's version string (`versionData.version` from the existing `/version` API).

Closes https://github.com/SigNoz/engineering-pod/issues/4940 

**Approach:**

1. **Seed source — `versionData.version`**: Already available via `useAppContext()`. Changes every release (e.g., `v0.121.1` → `v0.122.0`), so no new env vars, build config, or backend changes are needed.

2. **Hash with strong avalanche**: The version string is hashed using `Math.imul` with the golden ratio prime (`2654435761`). This ensures that even very similar version strings (e.g., `v0.121.1` vs `v0.122.0`) produce vastly different hash values, resulting in substantially different option orderings between consecutive releases.

3. **Fisher-Yates shuffle with LCG PRNG**: The hash seeds a Linear Congruential Generator (`num * 1664525 + 1013904223`) that drives a standard Fisher-Yates shuffle. This is deterministic — same version always produces the same order — so all users on the same release see a consistent UI.

4. **"Others" always last**: The "Others" checkbox with its conditional text input is rendered separately outside the shuffle loop, so it always appears at the bottom regardless of the shuffle.

5. **`useMemo` with `[versionData?.version]`**: The shuffled order is computed and memoized.

**Verification — output for consecutive versions:**
```
v0.121.1: OTel-native → Open-source → Single Tool → Deployment flex → Correlate → Lowering costs
v0.122.0: Correlate → Single Tool → Deployment flex → Open-source → OTel-native → Lowering costs
v0.123.0: Lowering costs → Open-source → Deployment flex → OTel-native → Correlate → Single Tool
v0.124.0: OTel-native → Lowering costs → Single Tool → Correlate → Open-source → Deployment flex
v0.125.0: Correlate → Single Tool → Lowering costs → OTel-native → Deployment flex → Open-source
```

You can verify any version in the browser console:
```js
function seededShuffle(array, seed) {
  const result = [...array];
  
  let num = 0;
  for (let i = 0; i < seed.length; i++) {
    num = Math.imul(num + seed.charCodeAt(i), 2654435761);
    num = Math.abs(num);
  }
  
  for (let i = result.length - 1; i > 0; i--) {
    num = Math.abs(Math.imul(num, 1664525) + 1013904223);
    const j = num % (i + 1);
    [result[i], result[j]] = [result[j], result[i]];
  }
  
  return result;
}

const keys = ['loweringCosts', 'otelNativeStack', 'deploymentFlexibility', 'singleTool', 'correlateSignals', 'openSourceTooling'];

seededShuffle(keys, 'v0.125.0'); // replace with any version
```

#### Screenshots / Screen Recordings (if applicable)
<img width="703" height="431" alt="Screenshot 2026-05-18 at 13 19 29" src="https://github.com/user-attachments/assets/595e6611-1b30-42fa-ace5-02c28017bb53" />

example in browser console using above approach 

#### Issues closed by this PR

Closes https://github.com/SigNoz/engineering-pod/issues/4940 

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Existing `OnboardingQuestionaire.test.tsx` tests pass — they match options by label text, not by position, so shuffle order doesn't affect them.
- Manual verification: Ran `seededShuffle` for 5 consecutive versions in Node and verified (a) each version produces a distinct order, (b) consecutive versions have 0–1 positional overlaps.
- Edge cases covered: Empty/missing `versionData.version` falls back to `''`, producing a consistent (non-random) order — safe degradation.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Onboarding questionnaire only — specifically the "What got you interested in SigNoz?" step. No other components affected.
- Potential regressions: None expected. Option keys and values are unchanged; only render order changes. State management stores selected keys (not positions), so selections are unaffected.
- Rollback plan: Revert the PR

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Randomize "interested in SigNoz" options per release to reduce position bias in onboarding survey responses |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Only one file changed: `frontend/src/container/OnboardingQuestionaire/AboutSigNozQuestions/AboutSigNozQuestions.tsx`
- No new dependencies, env vars, or build config changes
- The shuffle is deterministic and pure — no `Math.random()`, no side effects
- `versionData` is already fetched and available in `AppContext` before the onboarding questionnaire renders

---
