### PR TITLE
Remove unused field from waterfall response (part 1 of memory opt)

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -5686,12 +5686,6 @@ components:
           type: string
         rootServiceName:
           type: string
-        serviceNameToTotalDurationMap:
-          additionalProperties:
-            minimum: 0
-            type: integer
-          nullable: true
-          type: object
         spans:
           items:
             $ref: '#/components/schemas/SpantypesWaterfallSpan'

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -6743,15 +6743,6 @@ export interface SpantypesGettableSpanMapperGroupsDTO {
 	items: SpantypesSpanMapperGroupDTO[];
 }
 
-export type SpantypesGettableWaterfallTraceDTOServiceNameToTotalDurationMapAnyOf =
-	{ [key: string]: number };
-
-/**
- * @nullable
- */
-export type SpantypesGettableWaterfallTraceDTOServiceNameToTotalDurationMap =
-	SpantypesGettableWaterfallTraceDTOServiceNameToTotalDurationMapAnyOf | null;
-
 export enum SpantypesSpanAggregationTypeDTO {
 	span_count = 'span_count',
 	execution_time_percentage = 'execution_time_percentage',
@@ -6940,10 +6931,6 @@ export interface SpantypesGettableWaterfallTraceDTO {
 	 * @type string
 	 */
 	rootServiceName?: string;
-	/**
-	 * @type object,null
-	 */
-	serviceNameToTotalDurationMap?: SpantypesGettableWaterfallTraceDTOServiceNameToTotalDurationMap;
 	/**
 	 * @type array,null
 	 */

--- a/pkg/modules/tracedetail/impltracedetail/waterfall_test.go
+++ b/pkg/modules/tracedetail/impltracedetail/waterfall_test.go
@@ -97,7 +97,7 @@ func makeChain(n int) (*spantypes.WaterfallSpan, map[string]*spantypes.Waterfall
 }
 
 func getWaterfallTrace(roots []*spantypes.WaterfallSpan, spanMap map[string]*spantypes.WaterfallSpan) *spantypes.WaterfallTrace {
-	return spantypes.NewWaterfallTrace(0, 0, uint64(len(spanMap)), 0, spanMap, nil, roots, false)
+	return spantypes.NewWaterfallTrace(0, 0, uint64(len(spanMap)), 0, spanMap, roots, false)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -1160,6 +1160,7 @@ func (r *ClickHouseReader) GetFlamegraphSpansForTrace(ctx context.Context, orgID
 			selectCols += ", attributes_string, attributes_number, attributes_bool, resources_string"
 		}
 		flamegraphQuery := fmt.Sprintf("SELECT %s FROM %s.%s WHERE trace_id=$1 and ts_bucket_start>=$2 and ts_bucket_start<=$3 ORDER BY timestamp ASC, name ASC", selectCols, r.TraceDB, r.traceTableName)
+		fmt.Printf("============== selectCols: %s, flamegraphQuery: %s", selectCols, flamegraphQuery)
 
 		searchScanResponses, err := r.GetSpansForTrace(ctx, traceID, flamegraphQuery)
 		if err != nil {

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -1160,7 +1160,6 @@ func (r *ClickHouseReader) GetFlamegraphSpansForTrace(ctx context.Context, orgID
 			selectCols += ", attributes_string, attributes_number, attributes_bool, resources_string"
 		}
 		flamegraphQuery := fmt.Sprintf("SELECT %s FROM %s.%s WHERE trace_id=$1 and ts_bucket_start>=$2 and ts_bucket_start<=$3 ORDER BY timestamp ASC, name ASC", selectCols, r.TraceDB, r.traceTableName)
-		fmt.Printf("============== selectCols: %s, flamegraphQuery: %s", selectCols, flamegraphQuery)
 
 		searchScanResponses, err := r.GetSpansForTrace(ctx, traceID, flamegraphQuery)
 		if err != nil {

--- a/pkg/types/spantypes/aggregation_test.go
+++ b/pkg/types/spantypes/aggregation_test.go
@@ -33,7 +33,7 @@ func buildTraceFromSpans(spans ...*WaterfallSpan) *WaterfallTrace {
 			endTime = end
 		}
 	}
-	return NewWaterfallTrace(startTime, endTime, uint64(len(spanMap)), 0, spanMap, nil, nil, false)
+	return NewWaterfallTrace(startTime, endTime, uint64(len(spanMap)), 0, spanMap, nil, false)
 }
 
 var (

--- a/pkg/types/spantypes/waterfall_trace.go
+++ b/pkg/types/spantypes/waterfall_trace.go
@@ -20,50 +20,45 @@ type TraceSummary struct {
 
 // WaterfallTrace holds processed trace data with childern populated in spans.
 type WaterfallTrace struct {
-	StartTime                     uint64                    `json:"startTime"`
-	EndTime                       uint64                    `json:"endTime"`
-	TotalSpans                    uint64                    `json:"totalSpans"`
-	TotalErrorSpans               uint64                    `json:"totalErrorSpans"`
-	ServiceNameToTotalDurationMap map[string]uint64         `json:"serviceNameToTotalDurationMap"`
-	SpanIDToSpanNodeMap           map[string]*WaterfallSpan `json:"spanIdToSpanNodeMap"`
-	TraceRoots                    []*WaterfallSpan          `json:"traceRoots"`
-	HasMissingSpans               bool                      `json:"hasMissingSpans"`
+	StartTime           uint64                    `json:"startTime"`
+	EndTime             uint64                    `json:"endTime"`
+	TotalSpans          uint64                    `json:"totalSpans"`
+	TotalErrorSpans     uint64                    `json:"totalErrorSpans"`
+	SpanIDToSpanNodeMap map[string]*WaterfallSpan `json:"spanIdToSpanNodeMap"`
+	TraceRoots          []*WaterfallSpan          `json:"traceRoots"`
+	HasMissingSpans     bool                      `json:"hasMissingSpans"`
 }
 
 // GettableWaterfallTrace is the response for the v3 waterfall API.
 type GettableWaterfallTrace struct {
-	StartTimestampMillis  uint64 `json:"startTimestampMillis"`
-	EndTimestampMillis    uint64 `json:"endTimestampMillis"`
-	RootServiceName       string `json:"rootServiceName"`
-	RootServiceEntryPoint string `json:"rootServiceEntryPoint"`
-	TotalSpansCount       uint64 `json:"totalSpansCount"`
-	TotalErrorSpansCount  uint64 `json:"totalErrorSpansCount"`
-	// Deprecated: use Aggregations with SpanAggregationExecutionTimePercentage on the service.name field instead.
-	ServiceNameToTotalDurationMap map[string]uint64       `json:"serviceNameToTotalDurationMap"`
-	Spans                         []*WaterfallSpan        `json:"spans"`
-	HasMissingSpans               bool                    `json:"hasMissingSpans"`
-	UncollapsedSpans              []string                `json:"uncollapsedSpans"`
-	HasMore                       bool                    `json:"hasMore"`
-	Aggregations                  []SpanAggregationResult `json:"aggregations"`
+	StartTimestampMillis  uint64                  `json:"startTimestampMillis"`
+	EndTimestampMillis    uint64                  `json:"endTimestampMillis"`
+	RootServiceName       string                  `json:"rootServiceName"`
+	RootServiceEntryPoint string                  `json:"rootServiceEntryPoint"`
+	TotalSpansCount       uint64                  `json:"totalSpansCount"`
+	TotalErrorSpansCount  uint64                  `json:"totalErrorSpansCount"`
+	Spans                 []*WaterfallSpan        `json:"spans"`
+	HasMissingSpans       bool                    `json:"hasMissingSpans"`
+	UncollapsedSpans      []string                `json:"uncollapsedSpans"`
+	HasMore               bool                    `json:"hasMore"`
+	Aggregations          []SpanAggregationResult `json:"aggregations"`
 }
 
 // NewWaterfallTrace constructs a WaterfallTrace from processed span data.
 func NewWaterfallTrace(
 	startTime, endTime, totalSpans, totalErrorSpans uint64,
 	spanIDToSpanNodeMap map[string]*WaterfallSpan,
-	serviceNameToTotalDurationMap map[string]uint64,
 	traceRoots []*WaterfallSpan,
 	hasMissingSpans bool,
 ) *WaterfallTrace {
 	return &WaterfallTrace{
-		StartTime:                     startTime,
-		EndTime:                       endTime,
-		TotalSpans:                    totalSpans,
-		TotalErrorSpans:               totalErrorSpans,
-		SpanIDToSpanNodeMap:           spanIDToSpanNodeMap,
-		ServiceNameToTotalDurationMap: serviceNameToTotalDurationMap,
-		TraceRoots:                    traceRoots,
-		HasMissingSpans:               hasMissingSpans,
+		StartTime:           startTime,
+		EndTime:             endTime,
+		TotalSpans:          totalSpans,
+		TotalErrorSpans:     totalErrorSpans,
+		SpanIDToSpanNodeMap: spanIDToSpanNodeMap,
+		TraceRoots:          traceRoots,
+		HasMissingSpans:     hasMissingSpans,
 	}
 }
 
@@ -124,7 +119,6 @@ func NewWaterfallTraceFromSpans(spans []StorableSpan) *WaterfallTrace {
 		uint64(len(spans)),
 		totalErrorSpans,
 		spanIDToSpanNodeMap,
-		calculateServiceTime(spanIDToSpanNodeMap),
 		traceRoots,
 		hasMissingSpans,
 	)
@@ -206,23 +200,19 @@ func (wt *WaterfallTrace) CalculateUncollapsedSpanIDs(uncollapsedSpanIDs []strin
 }
 
 func (wt *WaterfallTrace) Clone() cachetypes.Cacheable {
-	copyOfServiceNameToTotalDurationMap := make(map[string]uint64)
-	maps.Copy(copyOfServiceNameToTotalDurationMap, wt.ServiceNameToTotalDurationMap)
-
 	copyOfSpanIDToSpanNodeMap := make(map[string]*WaterfallSpan)
 	maps.Copy(copyOfSpanIDToSpanNodeMap, wt.SpanIDToSpanNodeMap)
 
 	copyOfTraceRoots := make([]*WaterfallSpan, len(wt.TraceRoots))
 	copy(copyOfTraceRoots, wt.TraceRoots)
 	return &WaterfallTrace{
-		StartTime:                     wt.StartTime,
-		EndTime:                       wt.EndTime,
-		TotalSpans:                    wt.TotalSpans,
-		TotalErrorSpans:               wt.TotalErrorSpans,
-		ServiceNameToTotalDurationMap: copyOfServiceNameToTotalDurationMap,
-		SpanIDToSpanNodeMap:           copyOfSpanIDToSpanNodeMap,
-		TraceRoots:                    copyOfTraceRoots,
-		HasMissingSpans:               wt.HasMissingSpans,
+		StartTime:           wt.StartTime,
+		EndTime:             wt.EndTime,
+		TotalSpans:          wt.TotalSpans,
+		TotalErrorSpans:     wt.TotalErrorSpans,
+		SpanIDToSpanNodeMap: copyOfSpanIDToSpanNodeMap,
+		TraceRoots:          copyOfTraceRoots,
+		HasMissingSpans:     wt.HasMissingSpans,
 	}
 }
 
@@ -257,11 +247,6 @@ func NewGettableWaterfallTrace(
 		rootServiceEntryPoint = traceData.TraceRoots[0].Name
 	}
 
-	serviceDurationsMillis := make(map[string]uint64, len(traceData.ServiceNameToTotalDurationMap))
-	for svc, dur := range traceData.ServiceNameToTotalDurationMap {
-		serviceDurationsMillis[svc] = dur / 1_000_000
-	}
-
 	// convert start timestamp to millis because client is expecting it in millis
 	for _, span := range selectedSpans {
 		span.TimeUnix = span.TimeUnix / 1_000_000
@@ -277,18 +262,17 @@ func NewGettableWaterfallTrace(
 	}
 
 	return &GettableWaterfallTrace{
-		Spans:                         selectedSpans,
-		UncollapsedSpans:              uncollapsedSpans,
-		StartTimestampMillis:          traceData.StartTime / 1_000_000,
-		EndTimestampMillis:            traceData.EndTime / 1_000_000,
-		TotalSpansCount:               traceData.TotalSpans,
-		TotalErrorSpansCount:          traceData.TotalErrorSpans,
-		RootServiceName:               rootServiceName,
-		RootServiceEntryPoint:         rootServiceEntryPoint,
-		ServiceNameToTotalDurationMap: serviceDurationsMillis,
-		HasMissingSpans:               traceData.HasMissingSpans,
-		HasMore:                       !selectAllSpans,
-		Aggregations:                  aggregations,
+		Spans:                 selectedSpans,
+		UncollapsedSpans:      uncollapsedSpans,
+		StartTimestampMillis:  traceData.StartTime / 1_000_000,
+		EndTimestampMillis:    traceData.EndTime / 1_000_000,
+		TotalSpansCount:       traceData.TotalSpans,
+		TotalErrorSpansCount:  traceData.TotalErrorSpans,
+		RootServiceName:       rootServiceName,
+		RootServiceEntryPoint: rootServiceEntryPoint,
+		HasMissingSpans:       traceData.HasMissingSpans,
+		HasMore:               !selectAllSpans,
+		Aggregations:          aggregations,
 	}
 }
 
@@ -309,21 +293,6 @@ func windowAroundIndex(selectedIndex, total int, spanLimitPerRequest float64) (s
 	}
 	start = max(start, 0)
 	return
-}
-
-func calculateServiceTime(spanIDToSpanNodeMap map[string]*WaterfallSpan) map[string]uint64 {
-	serviceSpans := make(map[string][]*WaterfallSpan)
-	for _, span := range spanIDToSpanNodeMap {
-		if span.ServiceName != "" {
-			serviceSpans[span.ServiceName] = append(serviceSpans[span.ServiceName], span)
-		}
-	}
-
-	totalTimes := make(map[string]uint64)
-	for service, spans := range serviceSpans {
-		totalTimes[service] = mergeSpanIntervals(spans)
-	}
-	return totalTimes
 }
 
 // mergeSpanIntervals computes non-overlapping execution time for a set of spans.


### PR DESCRIPTION
## Pull Request

Part of https://github.com/SigNoz/engineering-pod/issues/4787

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The response field in waterfall for service duration map (`serviceNameToTotalDurationMap`) is not being used currently in our UI. UI has already switched to a new way of showing the aggregation which is available in `aggregation` key in the response.

This PR removes the unused field.



#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification: ✅ 
- Edge cases covered:

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered