### PR TITLE
test: added test for timeseries and bar panel

### DIFF
--- a/frontend/src/components/YAxisUnitSelector/YAxisUnitSelector.tsx
+++ b/frontend/src/components/YAxisUnitSelector/YAxisUnitSelector.tsx
@@ -98,7 +98,11 @@ function YAxisUnitSelector({
 				{categoriesToRender.map((category) => (
 					<Select.OptGroup key={category.name} label={category.name}>
 						{category.units.map((unit) => (
-							<Select.Option key={unit.id} value={unit.id}>
+							<Select.Option
+								key={unit.id}
+								value={unit.id}
+								data-testid={`unit-option-${unit.id}`}
+							>
 								{unit.name}
 							</Select.Option>
 						))}

--- a/tests/e2e/tests/dashboards/panels/bar.spec.ts
+++ b/tests/e2e/tests/dashboards/panels/bar.spec.ts
@@ -1,0 +1,484 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../../../fixtures/auth';
+import { newAdminContext } from '../../../helpers/auth';
+import {
+	authToken,
+	changePanelType,
+	configureAndSavePanel,
+	createDashboardViaApi,
+	deleteDashboardViaApi,
+	findDashboardIdByTitle,
+	openWidgetEditor,
+	saveWidgetEdit,
+} from '../../../helpers/dashboards';
+
+test.describe.configure({ mode: 'serial' });
+
+const FIXTURE_DASHBOARD_TITLE = 'bar-controls-fixture';
+const FIXTURE_PANEL_TITLE = 'bar-controls-panel';
+
+const seedIds = new Set<string>();
+
+test.beforeAll(async ({ browser }) => {
+	const ctx = await newAdminContext(browser);
+	const page = await ctx.newPage();
+	try {
+		const id = await createDashboardViaApi(page, FIXTURE_DASHBOARD_TITLE);
+		seedIds.add(id);
+		await page.goto(`/dashboard/${id}`);
+		await page.getByTestId('add-panel').waitFor({ state: 'visible' });
+		await configureAndSavePanel(page, 'metrics', FIXTURE_PANEL_TITLE);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await changePanelType(page, 'Bar');
+		await saveWidgetEdit(page);
+	} finally {
+		await ctx.close();
+	}
+});
+
+test.afterAll(async ({ browser }) => {
+	if (seedIds.size === 0) return;
+	const ctx = await newAdminContext(browser);
+	const page = await ctx.newPage();
+	try {
+		const token = await authToken(page);
+		for (const id of [...seedIds]) {
+			await deleteDashboardViaApi(ctx.request, id, token);
+			seedIds.delete(id);
+		}
+	} finally {
+		await ctx.close();
+	}
+});
+
+async function gotoFixtureDashboard(page: Page): Promise<void> {
+	const id = await findDashboardIdByTitle(page, FIXTURE_DASHBOARD_TITLE);
+	expect(id, `${FIXTURE_DASHBOARD_TITLE} not found`).toBeTruthy();
+	await page.goto(`/dashboard/${id}`);
+	await page.getByTestId(FIXTURE_PANEL_TITLE).first().waitFor({ state: 'visible' });
+}
+
+async function expandSection(page: Page, title: string): Promise<void> {
+	const section = page
+		.locator('.settings-section')
+		.filter({ has: page.locator('button.settings-section-header', { hasText: title }) });
+	const contentDiv = section.locator('.settings-section-content');
+	const isOpen = await contentDiv.evaluate((el) =>
+		el.classList.contains('open'),
+	);
+	if (!isOpen) {
+		await section.locator('button.settings-section-header').click();
+		await contentDiv.waitFor({ state: 'visible' });
+	}
+}
+
+async function selectYAxisUnit(
+	page: Page,
+	wrapperSelector: string,
+	searchTerm: string,
+	optionText: string,
+): Promise<void> {
+	const wrapper = page.locator(wrapperSelector).first();
+	await wrapper.locator('.ant-select').click();
+	await wrapper.locator('.ant-select input').fill(searchTerm);
+	await page
+		.locator('.ant-select-item-option-content', { hasText: optionText })
+		.first()
+		.click();
+}
+
+test.describe('Bar Panel Controls', () => {
+	test('TC-01 panel name persists and is reflected in the widget header', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page.getByTestId('panel-name-input').fill('bar-controls-renamed');
+		await saveWidgetEdit(page);
+		await expect(page.getByTestId('bar-controls-renamed').first()).toBeVisible();
+
+		await openWidgetEditor(page, 'bar-controls-renamed');
+		await expect(page.getByTestId('panel-name-input')).toHaveValue(
+			'bar-controls-renamed',
+		);
+
+		await page.getByTestId('panel-name-input').fill(FIXTURE_PANEL_TITLE);
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-02 description persists and toggles the widget-header info icon', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page
+			.getByTestId('panel-description-input')
+			.fill('E2E bar description');
+		await saveWidgetEdit(page);
+
+		const header = page
+			.locator('.widget-header-container')
+			.filter({ hasText: FIXTURE_PANEL_TITLE });
+		await expect(header.locator('.info-tooltip').first()).toBeVisible();
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(page.getByTestId('panel-description-input')).toHaveValue(
+			'E2E bar description',
+		);
+
+		await page.getByTestId('panel-description-input').fill('');
+		await saveWidgetEdit(page);
+		await expect(header.locator('.info-tooltip')).toHaveCount(0);
+	});
+
+	test('TC-03 panel time preference switches to Last 15 min and persists', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page
+			.locator('section.panel-time-preference')
+			.getByRole('button', { name: /global time/i })
+			.click();
+		await page.getByRole('menuitem', { name: /Last 15 min/i }).click();
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(
+			page.locator('section.panel-time-preference').getByRole('button'),
+		).toContainText(/Last 15 min/i);
+
+		await page
+			.locator('section.panel-time-preference')
+			.getByRole('button')
+			.click();
+		await page.getByRole('menuitem', { name: /Global Time/i }).click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-04 stack series toggle persists; editor reflects state via data-stacking-state', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		const stackSwitch = page.locator('section.stack-chart').getByRole('switch');
+		const panelChangeSelect = page.getByTestId('panel-change-select');
+
+		await expect(stackSwitch).toHaveAttribute('aria-checked', 'false');
+		await expect(panelChangeSelect).toHaveAttribute('data-stacking-state', 'false');
+
+		await stackSwitch.click();
+		await expect(stackSwitch).toHaveAttribute('aria-checked', 'true');
+		await expect(panelChangeSelect).toHaveAttribute('data-stacking-state', 'true');
+
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(
+			page.locator('section.stack-chart').getByRole('switch'),
+		).toHaveAttribute('aria-checked', 'true');
+		await expect(page.getByTestId('panel-change-select')).toHaveAttribute(
+			'data-stacking-state',
+			'true',
+		);
+
+		// Reset
+		await page.locator('section.stack-chart').getByRole('switch').click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-05 Y-axis unit persists', async ({ authedPage: page }) => {
+		// Tooltip-based visible-change check is omitted — the test stack's
+		// `signoz_calls_total` data slides outside the dashboard's default
+		// "Last 30 minutes" window mid-suite, so the rendered panel often
+		// shows "No Data" and the tooltip never appears. Verify persistence
+		// only — the selector value round-trips through PUT.
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Formatting & Units');
+		await selectYAxisUnit(
+			page,
+			'.y-axis-unit-selector-v2',
+			'Milliseconds',
+			'Milliseconds (ms)',
+		);
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Formatting & Units');
+		await expect(
+			page.locator('.y-axis-unit-selector-v2 .ant-select-selection-item').first(),
+		).toContainText(/Milliseconds/);
+
+		await page.locator('.y-axis-unit-selector-v2').first().hover();
+		await page.locator('.y-axis-unit-selector-v2 .ant-select-clear').first().click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-06 decimal precision persists', async ({ authedPage: page }) => {
+		// Tooltip-based visible-change check is omitted for the same reason
+		// as TC-05.
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Formatting & Units');
+		await page.getByTestId('decimal-precision-selector').click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: '0 decimals' })
+			.first()
+			.click();
+
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Formatting & Units');
+		await expect(page.getByTestId('decimal-precision-selector')).toContainText(
+			/0 decimals/,
+		);
+
+		// Reset
+		await page.getByTestId('decimal-precision-selector').click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: '2 decimals' })
+			.first()
+			.click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-07 soft min and soft max persist (canvas-only visual)', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Axes');
+
+		await page.locator('section.soft-min-max .ant-input-number-input').first().fill('10');
+		await page.locator('section.soft-min-max .ant-input-number-input').last().fill('100');
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Axes');
+		await expect(
+			page.locator('section.soft-min-max .ant-input-number-input').first(),
+		).toHaveValue('10');
+		await expect(
+			page.locator('section.soft-min-max .ant-input-number-input').last(),
+		).toHaveValue('100');
+
+		await page.locator('section.soft-min-max .ant-input-number-input').first().fill('');
+		await page.locator('section.soft-min-max .ant-input-number-input').last().fill('');
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-08 log scale persists (canvas-only visual)', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Axes');
+		await page.locator('section.log-scale .ant-select').first().click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: /^Logarithmic$/ })
+			.first()
+			.click();
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Axes');
+		await expect(
+			page.locator('section.log-scale .ant-select-selection-item').first(),
+		).toContainText(/Logarithmic/);
+
+		await page.locator('section.log-scale .ant-select').first().click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: /^Linear$/ })
+			.first()
+			.click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-09 legend position swap toggles chart-layout--legend-right and shows the search input', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Legend');
+
+		await expect(page.locator('.chart-layout--legend-right')).toHaveCount(0);
+		await expect(page.getByTestId('legend-search-input')).toHaveCount(0);
+
+		await page.locator('section.legend-position .ant-select').first().click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: /^Right$/ })
+			.first()
+			.click();
+
+		await expect(page.locator('.chart-layout--legend-right').first()).toBeVisible();
+		await expect(page.getByTestId('legend-search-input').first()).toBeVisible();
+
+		await saveWidgetEdit(page);
+
+		await expect(page.locator('.chart-layout--legend-right').first()).toBeVisible();
+		await expect(page.getByTestId('legend-search-input').first()).toBeVisible();
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Legend');
+		await page.locator('section.legend-position .ant-select').first().click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: /^Bottom$/ })
+			.first()
+			.click();
+		await saveWidgetEdit(page);
+
+		await expect(page.locator('.chart-layout--legend-right')).toHaveCount(0);
+		await expect(page.getByTestId('legend-search-input')).toHaveCount(0);
+	});
+
+	test('TC-10 Legend Colors panel renders one row per query series with a default color swatch', async ({
+		authedPage: page,
+	}) => {
+		// Driving the Ant ColorPicker is fiddly across builds (trigger class
+		// varies, preset chips may not be configured). Per-option testids have
+		// been added in `YAxisUnitSelector.tsx` for the unit picker, but the
+		// LegendColors picker uses Ant's `ColorPicker` directly with no stable
+		// testids. The pragmatic check is structural: when a query has run
+		// and produced series, the Legend Colors collapse panel renders one
+		// row per legend label with a `.legend-marker` carrying an inline
+		// `background-color` (the auto-assigned default). This guards against
+		// regressions in the LegendColors → query-response wiring.
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Legend');
+
+		const legendColorsCollapse = page.locator('.legend-colors-collapse').first();
+		await legendColorsCollapse.locator('.ant-collapse-header').first().click();
+
+		const items = page.locator('.legend-items .legend-item');
+		await items.first().waitFor({ state: 'visible' });
+		expect(await items.count()).toBeGreaterThan(0);
+
+		const firstMarker = items.first().locator('.legend-marker');
+		const markerStyle = (await firstMarker.getAttribute('style')) ?? '';
+		expect(markerStyle).toMatch(/background-color:/);
+	});
+
+	test('TC-11 threshold add + persistence (canvas-only line)', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Thresholds');
+		await page.getByTestId('add-threshold-cta').click();
+		const card = page.locator('.threshold-container').first();
+
+		// Bar thresholds do NOT have a label input — the time-series-alerts block
+		// only renders for TIME_SERIES. Skip label.
+		await card.getByTestId('threshold-value-input').fill('100');
+
+		await card.getByRole('button', { name: /save changes/i }).click();
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Thresholds');
+		await expect(page.locator('.threshold-container').first()).toBeVisible();
+
+		const firstCard = page.locator('.threshold-card-container').first();
+		await firstCard.hover();
+		// TODO: switch to `getByTestId('threshold-delete-btn')` after stack rebuild.
+		await firstCard.locator('button.delete-btn').click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-12 panel type swap from Bar to Time Series and back persists', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await changePanelType(page, 'Time Series');
+
+		// Editor-side visual change: Time-Series-only section appears.
+		await expect(page.locator('section.fill-gaps').first()).toBeVisible();
+		await expect(page.locator('section.stack-chart')).toHaveCount(0);
+
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(page).toHaveURL(/graphType=graph/);
+
+		await changePanelType(page, 'Bar');
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-13 sections hidden for BAR are not rendered', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		// Hidden by the panel-type matrix for BAR.
+		await expect(page.locator('section.fill-gaps')).toHaveCount(0);
+		await expect(page.locator('.column-unit-selector')).toHaveCount(0);
+
+		// Expected to be present.
+		await expect(page.getByTestId('panel-name-input')).toBeVisible();
+		await expect(page.getByTestId('panel-change-select')).toBeVisible();
+		await expect(page.locator('section.stack-chart').first()).toBeVisible();
+		await expect(page.locator('section.panel-time-preference').first()).toBeVisible();
+
+		await expandSection(page, 'Axes');
+		await expect(page.locator('section.soft-min-max').first()).toBeVisible();
+		await expect(page.locator('section.log-scale').first()).toBeVisible();
+
+		await expandSection(page, 'Legend');
+		await expect(page.locator('section.legend-position').first()).toBeVisible();
+
+		await expandSection(page, 'Formatting & Units');
+		await expect(page.getByTestId('decimal-precision-selector')).toBeVisible();
+
+		await expandSection(page, 'Thresholds');
+		await expect(page.getByTestId('add-threshold-cta')).toBeVisible();
+	});
+
+	test('TC-14 discarding right-pane changes does not persist', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page.getByTestId('panel-name-input').fill('discard-bar-test');
+
+		let putFired = false;
+		await page.route(/\/api\/v1\/dashboards\//, (route) => {
+			if (route.request().method() === 'PUT') {
+				putFired = true;
+			}
+			route.continue();
+		});
+
+		await page.getByTestId('discard-button').click();
+		await page
+			.getByRole('dialog')
+			.last()
+			.getByRole('button', { name: /^OK$/i })
+			.click({ timeout: 1000 })
+			.catch(() => {
+				// no modal — direct navigation
+			});
+
+		await page.waitForURL(/\/dashboard\/[0-9a-f-]+(?:\?|$)/);
+		await expect(page.getByTestId(FIXTURE_PANEL_TITLE).first()).toBeVisible();
+		expect(putFired).toBe(false);
+	});
+});

--- a/tests/e2e/tests/dashboards/panels/time-series.spec.ts
+++ b/tests/e2e/tests/dashboards/panels/time-series.spec.ts
@@ -1,0 +1,584 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../../../fixtures/auth';
+import { newAdminContext } from '../../../helpers/auth';
+import {
+	authToken,
+	changePanelType,
+	configureAndSavePanel,
+	createDashboardViaApi,
+	deleteDashboardViaApi,
+	findDashboardIdByTitle,
+	openWidgetEditor,
+	saveWidgetEdit,
+} from '../../../helpers/dashboards';
+
+// All TCs share one fixture panel — run serially.
+test.describe.configure({ mode: 'serial' });
+
+const FIXTURE_DASHBOARD_TITLE = 'time-series-controls-fixture';
+const FIXTURE_PANEL_TITLE = 'time-series-controls-panel';
+
+const seedIds = new Set<string>();
+
+test.beforeAll(async ({ browser }) => {
+	const ctx = await newAdminContext(browser);
+	const page = await ctx.newPage();
+	try {
+		const id = await createDashboardViaApi(page, FIXTURE_DASHBOARD_TITLE);
+		seedIds.add(id);
+		await page.goto(`/dashboard/${id}`);
+		await page.getByTestId('add-panel').waitFor({ state: 'visible' });
+		// configureAndSavePanel creates a Time Series (graph) panel by default —
+		// no panel-type swap needed here.
+		await configureAndSavePanel(page, 'metrics', FIXTURE_PANEL_TITLE);
+	} finally {
+		await ctx.close();
+	}
+});
+
+test.afterAll(async ({ browser }) => {
+	if (seedIds.size === 0) return;
+	const ctx = await newAdminContext(browser);
+	const page = await ctx.newPage();
+	try {
+		const token = await authToken(page);
+		for (const id of [...seedIds]) {
+			await deleteDashboardViaApi(ctx.request, id, token);
+			seedIds.delete(id);
+		}
+	} finally {
+		await ctx.close();
+	}
+});
+
+async function gotoFixtureDashboard(page: Page): Promise<void> {
+	const id = await findDashboardIdByTitle(page, FIXTURE_DASHBOARD_TITLE);
+	expect(id, `${FIXTURE_DASHBOARD_TITLE} not found`).toBeTruthy();
+	await page.goto(`/dashboard/${id}`);
+	await page.getByTestId(FIXTURE_PANEL_TITLE).first().waitFor({ state: 'visible' });
+}
+
+/**
+ * Ensure a SettingsSection accordion in the widget editor right pane is
+ * expanded. No-op if already open.
+ */
+async function expandSection(page: Page, title: string): Promise<void> {
+	const section = page
+		.locator('.settings-section')
+		.filter({ has: page.locator('button.settings-section-header', { hasText: title }) });
+	const contentDiv = section.locator('.settings-section-content');
+	const isOpen = await contentDiv.evaluate((el) =>
+		el.classList.contains('open'),
+	);
+	if (!isOpen) {
+		await section.locator('button.settings-section-header').click();
+		await contentDiv.waitFor({ state: 'visible' });
+	}
+}
+
+/**
+ * Select a unit from a Y-axis-unit-selector wrapper by typing a search term
+ * first (Ant Select has a virtualised option list — typing first prevents
+ * detached-DOM failures when the target option is off-screen).
+ *
+ * `wrapperSelector` is the CSS selector for the enclosing
+ * `.y-axis-unit-selector-v2` instance (use `.y-axis-unit-selector-v2` for the
+ * Formatting Y-axis unit; threshold cards have their own nested instance —
+ * scope accordingly).
+ */
+async function selectYAxisUnit(
+	page: Page,
+	wrapperSelector: string,
+	searchTerm: string,
+	optionText: string,
+): Promise<void> {
+	const wrapper = page.locator(wrapperSelector).first();
+	await wrapper.locator('.ant-select').click();
+	await wrapper.locator('.ant-select input').fill(searchTerm);
+	await page
+		.locator('.ant-select-item-option-content', { hasText: optionText })
+		.first()
+		.click();
+}
+
+test.describe('Time Series Panel Controls', () => {
+	test('TC-01 panel name persists and is reflected in the widget header', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page.getByTestId('panel-name-input').fill('ts-controls-renamed');
+		await saveWidgetEdit(page);
+		await expect(page.getByTestId('ts-controls-renamed').first()).toBeVisible();
+
+		await openWidgetEditor(page, 'ts-controls-renamed');
+		await expect(page.getByTestId('panel-name-input')).toHaveValue(
+			'ts-controls-renamed',
+		);
+
+		await page.getByTestId('panel-name-input').fill(FIXTURE_PANEL_TITLE);
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-02 description persists and toggles the widget-header info icon', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page
+			.getByTestId('panel-description-input')
+			.fill('E2E time series description');
+		await saveWidgetEdit(page);
+
+		// Visible change: info icon appears in the widget header.
+		const header = page
+			.locator('.widget-header-container')
+			.filter({ hasText: FIXTURE_PANEL_TITLE });
+		await expect(header.locator('.info-tooltip').first()).toBeVisible();
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(page.getByTestId('panel-description-input')).toHaveValue(
+			'E2E time series description',
+		);
+
+		// Reset and assert the info icon disappears.
+		await page.getByTestId('panel-description-input').fill('');
+		await saveWidgetEdit(page);
+		await expect(header.locator('.info-tooltip')).toHaveCount(0);
+	});
+
+	test('TC-03 panel time preference switches to Last 15 min and persists', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page
+			.locator('section.panel-time-preference')
+			.getByRole('button', { name: /global time/i })
+			.click();
+		await page.getByRole('menuitem', { name: /Last 15 min/i }).click();
+		await expect(
+			page.locator('section.panel-time-preference').getByRole('button'),
+		).toContainText(/Last 15 min/i);
+
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(
+			page.locator('section.panel-time-preference').getByRole('button'),
+		).toContainText(/Last 15 min/i);
+
+		// Reset
+		await page
+			.locator('section.panel-time-preference')
+			.getByRole('button')
+			.click();
+		await page.getByRole('menuitem', { name: /Global Time/i }).click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-04 fill gaps toggle persists', async ({ authedPage: page }) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		// canvas-only — visible chart effect not asserted (canvas-drawn series).
+		const fillGapsSwitch = page.locator('section.fill-gaps').getByRole('switch');
+		await expect(fillGapsSwitch).toHaveAttribute('aria-checked', 'false');
+		await fillGapsSwitch.click();
+		await expect(fillGapsSwitch).toHaveAttribute('aria-checked', 'true');
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(
+			page.locator('section.fill-gaps').getByRole('switch'),
+		).toHaveAttribute('aria-checked', 'true');
+
+		// Reset
+		await page.locator('section.fill-gaps').getByRole('switch').click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-05 Y-axis unit persists', async ({ authedPage: page }) => {
+		// The plan asks for a tooltip-driven visible-change check (hover the
+		// chart, assert tooltip text contains `ms`). In practice the test
+		// stack's `signoz_calls_total` data slides outside the dashboard's
+		// default "Last 30 minutes" window between the suite-start golden
+		// reseed and the time TC-05 runs, so the rendered panel often shows
+		// "No Data" and the tooltip never appears. Until the seeder either
+		// emits points in a rolling-now window or the dashboard global-time
+		// preset gets widened from the test fixture, the tooltip assertion is
+		// not viable. Verify persistence only — the selector value round-trips
+		// through PUT and re-renders in the editor.
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Formatting & Units');
+		await selectYAxisUnit(
+			page,
+			'.y-axis-unit-selector-v2',
+			'Milliseconds',
+			'Milliseconds (ms)',
+		);
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Formatting & Units');
+		await expect(
+			page.locator('.y-axis-unit-selector-v2 .ant-select-selection-item').first(),
+		).toContainText(/Milliseconds/);
+
+		// Reset — clear via allowClear.
+		await page.locator('.y-axis-unit-selector-v2').first().hover();
+		await page.locator('.y-axis-unit-selector-v2 .ant-select-clear').first().click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-06 decimal precision persists', async ({ authedPage: page }) => {
+		// Tooltip-based visible-change assertion is omitted for the same reason
+		// as TC-05 — `signoz_calls_total` data window flakes mid-suite. Verify
+		// persistence only.
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Formatting & Units');
+		await page.getByTestId('decimal-precision-selector').click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: '0 decimals' })
+			.first()
+			.click();
+
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Formatting & Units');
+		await expect(page.getByTestId('decimal-precision-selector')).toContainText(
+			/0 decimals/,
+		);
+
+		// Reset
+		await page.getByTestId('decimal-precision-selector').click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: '2 decimals' })
+			.first()
+			.click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-07 soft min and soft max persist (canvas-only visual)', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Axes');
+
+		// Soft Min is the first .ant-input-number inside section.soft-min-max.
+		const softMin = page.locator('section.soft-min-max .ant-input-number-input').first();
+		const softMax = page.locator('section.soft-min-max .ant-input-number-input').last();
+
+		await softMin.fill('10');
+		await softMax.fill('100');
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Axes');
+		await expect(
+			page.locator('section.soft-min-max .ant-input-number-input').first(),
+		).toHaveValue('10');
+		await expect(
+			page.locator('section.soft-min-max .ant-input-number-input').last(),
+		).toHaveValue('100');
+
+		// Reset — clear both. (Note: the |...|| 0 coercion in onClickSaveHandler
+		// will persist 0 not null after this save; that's the known behaviour.)
+		await page
+			.locator('section.soft-min-max .ant-input-number-input')
+			.first()
+			.fill('');
+		await page
+			.locator('section.soft-min-max .ant-input-number-input')
+			.last()
+			.fill('');
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-08 log scale persists (canvas-only visual)', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Axes');
+		const logScaleSelect = page.locator('section.log-scale .ant-select').first();
+		await logScaleSelect.click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: /^Logarithmic$/ })
+			.first()
+			.click();
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Axes');
+		await expect(
+			page.locator('section.log-scale .ant-select-selection-item').first(),
+		).toContainText(/Logarithmic/);
+
+		// Reset
+		await page.locator('section.log-scale .ant-select').first().click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: /^Linear$/ })
+			.first()
+			.click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-09 legend position swap toggles the chart-layout--legend-right class and shows the search input', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Legend');
+
+		// Before: legend is at the bottom; no chart-layout--legend-right; no
+		// legend-search-input.
+		await expect(page.locator('.chart-layout--legend-right')).toHaveCount(0);
+		await expect(page.getByTestId('legend-search-input')).toHaveCount(0);
+
+		// Switch to Right.
+		await page.locator('section.legend-position .ant-select').first().click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: /^Right$/ })
+			.first()
+			.click();
+
+		// In-editor live preview: layout updates.
+		await expect(page.locator('.chart-layout--legend-right').first()).toBeVisible();
+		await expect(page.getByTestId('legend-search-input').first()).toBeVisible();
+
+		await saveWidgetEdit(page);
+
+		// Dashboard: same assertions hold on the rendered panel card.
+		await expect(page.locator('.chart-layout--legend-right').first()).toBeVisible();
+		await expect(page.getByTestId('legend-search-input').first()).toBeVisible();
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Legend');
+		await expect(
+			page.locator('section.legend-position .ant-select-selection-item').first(),
+		).toContainText(/Right/);
+
+		// Reset to Bottom and assert the class disappears.
+		await page.locator('section.legend-position .ant-select').first().click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: /^Bottom$/ })
+			.first()
+			.click();
+		await saveWidgetEdit(page);
+		await expect(page.locator('.chart-layout--legend-right')).toHaveCount(0);
+		await expect(page.getByTestId('legend-search-input')).toHaveCount(0);
+	});
+
+	test('TC-09b Legend Colors panel renders one row per query series with a default color swatch', async ({
+		authedPage: page,
+	}) => {
+		// The original plan was to drive the Ant `ColorPicker` and assert a
+		// custom color round-trips. The Ant ColorPicker DOM is fiddly to drive
+		// reliably from Playwright (the trigger is the wrapped child element,
+		// presets vary by build, and committing a color requires Escape /
+		// click-outside semantics that depend on portal positioning). The
+		// pragmatic check we ship here is the *structural* one: when a query
+		// has run and produced series, the LegendColors collapse panel renders
+		// one row per legend label with a `.legend-marker` that carries an
+		// inline `background-color` (the auto-assigned default). This guards
+		// against regressions in the LegendColors → query-response wiring,
+		// which is the part most likely to silently break.
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Legend');
+
+		// Expand the Ant Collapse panel "Legend Colors" (it sits below the
+		// Position selector inside the Legend SettingsSection).
+		const legendColorsCollapse = page.locator('.legend-colors-collapse').first();
+		await legendColorsCollapse.locator('.ant-collapse-header').first().click();
+
+		// After expansion: at least one per-series row, each with a coloured
+		// `.legend-marker` swatch carrying inline backgroundColor.
+		const items = page.locator('.legend-items .legend-item');
+		await items.first().waitFor({ state: 'visible' });
+		expect(await items.count()).toBeGreaterThan(0);
+
+		const firstMarker = items.first().locator('.legend-marker');
+		const markerStyle = (await firstMarker.getAttribute('style')) ?? '';
+		expect(markerStyle).toMatch(/background-color:/);
+	});
+
+	test('TC-10 threshold add + persistence (canvas-only line)', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Thresholds');
+		await page.getByTestId('add-threshold-cta').click();
+		const card = page.locator('.threshold-container').first();
+
+		// Time Series thresholds have a label input (unique to TIME_SERIES).
+		await card.getByTestId('threshold-label-input').fill('alert-threshold');
+		await card.getByTestId('threshold-value-input').fill('500');
+
+		await card.getByRole('button', { name: /save changes/i }).click();
+		await saveWidgetEdit(page);
+
+		// canvas-only — line is canvas-drawn. Verify persistence by re-open.
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Thresholds');
+		await expect(page.locator('.threshold-container').first()).toBeVisible();
+
+		// Reset — delete via hover-revealed button.
+		const firstCard = page.locator('.threshold-card-container').first();
+		await firstCard.hover();
+		// TODO: switch to `getByTestId('threshold-delete-btn')` after stack rebuild.
+		await firstCard.locator('button.delete-btn').click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-11 threshold value persists in edit mode after save + re-open', async ({
+		authedPage: page,
+	}) => {
+		// Originally drove the threshold's V1 unit selector to assert
+		// `'seconds (s)'` round-trips. The V1 selector's `handleSearch`
+		// filterOption hides every option when a V2-style search term is typed
+		// AND the dropdown options don't reliably surface in the
+		// currently-visible portal under Playwright. We've added per-option
+		// `data-testid="unit-option-<id>"` in `YAxisUnitSelector.tsx`; once the
+		// test stack frontend rebuilds with that testid, this TC can be
+		// upgraded to pick the unit deterministically via
+		// `page.getByTestId('unit-option-s')`. Meanwhile the TC verifies the
+		// numeric value field round-trips through edit mode — the most common
+		// regression vector and the one most worth guarding.
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Thresholds');
+		await page.getByTestId('add-threshold-cta').click();
+		const card = page.locator('.threshold-container').first();
+
+		await card.getByTestId('threshold-value-input').fill('100');
+		await card.getByRole('button', { name: /save changes/i }).click();
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Thresholds');
+
+		// Re-enter edit mode and assert the value field carries the saved 100.
+		const cardAfter = page.locator('.threshold-container').first();
+		await cardAfter.hover();
+		// TODO: switch to `getByTestId('threshold-edit-btn')` after stack rebuild.
+		await cardAfter.locator('button.edit-btn').click();
+		await expect(cardAfter.getByTestId('threshold-value-input')).toHaveValue(
+			'100',
+		);
+
+		// Reset — discard the edit, then delete.
+		await cardAfter.getByRole('button', { name: /^discard$/i }).click();
+		const firstCard = page.locator('.threshold-card-container').first();
+		await firstCard.hover();
+		// TODO: switch to `getByTestId('threshold-delete-btn')` after stack rebuild.
+		await firstCard.locator('button.delete-btn').click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-12 panel type swap from Time Series to Bar and back persists', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await changePanelType(page, 'Bar');
+
+		// Editor-side visual change: Bar-only section appears, Time-Series-only
+		// section disappears.
+		await expect(page.locator('section.stack-chart').first()).toBeVisible();
+		await expect(page.locator('section.fill-gaps')).toHaveCount(0);
+
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(page).toHaveURL(/graphType=bar/);
+
+		// Reset
+		await changePanelType(page, 'Time Series');
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-13 fill gaps and panel time preference persist together', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		// Set both.
+		await page.locator('section.fill-gaps').getByRole('switch').click();
+		await page
+			.locator('section.panel-time-preference')
+			.getByRole('button', { name: /global time/i })
+			.click();
+		await page.getByRole('menuitem', { name: /Last 1 hr/i }).click();
+
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(
+			page.locator('section.fill-gaps').getByRole('switch'),
+		).toHaveAttribute('aria-checked', 'true');
+		await expect(
+			page.locator('section.panel-time-preference').getByRole('button'),
+		).toContainText(/Last 1 hr/i);
+
+		// Reset both.
+		await page.locator('section.fill-gaps').getByRole('switch').click();
+		await page
+			.locator('section.panel-time-preference')
+			.getByRole('button')
+			.click();
+		await page.getByRole('menuitem', { name: /Global Time/i }).click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-14 discarding right-pane changes does not persist', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page.getByTestId('panel-name-input').fill('discard-ts-test');
+
+		let putFired = false;
+		await page.route(/\/api\/v1\/dashboards\//, (route) => {
+			if (route.request().method() === 'PUT') {
+				putFired = true;
+			}
+			route.continue();
+		});
+
+		await page.getByTestId('discard-button').click();
+		await page
+			.getByRole('dialog')
+			.last()
+			.getByRole('button', { name: /^OK$/i })
+			.click({ timeout: 1000 })
+			.catch(() => {
+				// no modal — direct navigation
+			});
+
+		await page.waitForURL(/\/dashboard\/[0-9a-f-]+(?:\?|$)/);
+		await expect(page.getByTestId(FIXTURE_PANEL_TITLE).first()).toBeVisible();
+		expect(putFired).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Follow-up to the value/table/list panel-controls PR — adds E2E coverage for the chart-based panel types (Time Series, Bar). Reuses the established fixture pattern (`openWidgetEditor`, `saveWidgetEdit`, `changePanelType` from the previous PR) and the shared-suite / serial-mode shape. One small frontend change: per-option `data-testid` on `YAxisUnitSelector` so future tests can pick units deterministically without fighting the V1 selector's filterOption.

## Change Type

- [x] 🧪 Test-only
- [x] 🛠️ Infra / Tooling _(one frontend `data-testid` addition)_

## Issues Closed
Closes https://github.com/SigNoz/engineering-pod/issues/4515
Closes https://github.com/SigNoz/engineering-pod/issues/4516

## Testing Strategy

- **Tests added:** 29 new TCs across two spec files
  - `tests/e2e/tests/dashboards/panels/time-series.spec.ts` — 15 TCs (name / description / time preference / fill gaps / Y-axis unit / decimal precision / soft min/max / log scale / legend position swap / Legend Colors panel render / threshold add / threshold value round-trip in edit mode / panel-type swap to Bar / fill gaps + time preference together / discard)
  - `tests/e2e/tests/dashboards/panels/bar.spec.ts` — 14 TCs (name / description / time preference / **Stack series toggle** / Y-axis unit / decimal precision / soft min/max / log scale / legend position swap / Legend Colors panel render / threshold add / panel-type swap to Time Series / section visibility regression guard / discard)
- **Manual verification:** All 29 TCs green on chromium against the local stack. `pnpm test --project=chromium tests/dashboards/panels` runs all 54 panel TCs (across the 5 spec files) plus setup/teardown = 57 passed in ~1.6 min.

## Visible-change assertions (DOM, not just persistence)

| Control | Time Series | Bar |
|---|---|---|
| Name | widget header testid | widget header testid |
| Description | `.info-tooltip` toggle | `.info-tooltip` toggle |
| Legend Position swap | `.chart-layout--legend-right` class + `data-testid="legend-search-input"` visibility | same |
| Legend Colors panel | structural — `.legend-items .legend-item .legend-marker` per series | same |
| Stack series | n/a | `data-stacking-state="true|false"` attribute on `panel-change-select` |
| Panel-type swap | URL `graphType` + right-pane section re-render | same |

## Persistence-only (canvas-only fields)

Soft min/max, log scale, fill gaps, threshold horizontal line, stack series layout, and the chart's Y-axis tick formatting are all uPlot-canvas-rendered — there is no DOM signal for the rendered visual. These TCs verify the value round-trips through `PUT /api/v1/dashboards/<id>` and re-loads correctly in the editor.

The original plan also called for tooltip-driven visible-change checks (hover the chart, assert tooltip text contains `ms` / has no `.`). In practice the test stack's `signoz_calls_total` data slides outside the dashboard's default "Last 30 min" window mid-suite, so the rendered panel often shows "No Data" and the tooltip never appears. The tooltip assertion is documented in the spec comments and can be re-added when the seeder produces rolling-now points or the dashboard time-picker default gets widened from the fixture.

## Frontend `data-testid` addition

`frontend/src/components/YAxisUnitSelector/YAxisUnitSelector.tsx` — `data-testid="unit-option-<unit.id>"` on each `<Select.Option>`. Lets tests pick a specific unit deterministically without depending on option text or fighting the V1 selector's `handleSearch` filterOption (which currently hides every option when a V2-style search term is typed). Once the test stack frontend rebuild includes this testid, the threshold-unit interaction in Time Series TC-11 can be upgraded from "value-only persistence" to "unit round-trips" via `getByTestId('unit-option-s')`.

## Risk & Impact Assessment

- **Blast radius:** Zero runtime behavior change. The frontend change is a single attribute addition on existing DOM elements.
- **Potential regressions:** None expected.
- **Rollback plan:** Revert is trivial — testid addition and new spec files are additive only.

## Changelog

| Field | Value |
|------|-------|
| Deployment Type | OSS |
| Change Type | Maintenance |
| Description | N/A — internal test coverage; the `data-testid` addition is not user-facing. |

## Checklist

- [x] Tests added
- [x] Manually tested (29 new TCs green on chromium)
- [x] No breaking changes
- [x] Backward compatible (additive attribute-only frontend change)

## Notes for Reviewers

- This PR is stacked on `e2e/table-list-value-panel`. Merge that one first, or rebase this to `main` once the parent merges.
- The pattern across all 5 panel-controls specs is identical — single `beforeAll` seeds one dashboard + one panel via `configureAndSavePanel`, then panel-type-swaps if needed; each TC opens the editor, tweaks one control, saves, asserts persistence + visible change, then resets. The serial dependency is acceptable because state is bounded and each TC self-resets — yields ~10× faster runs vs. fresh-seed-per-TC.
- Time Series TC-09b and Bar TC-10 are deliberately **structural** Legend Colors checks (not full color-picker drives). The Ant `ColorPicker` DOM has no stable testids and the preset palette varies by build, so the test asserts that one row per query-series renders with a default `.legend-marker` background — guarding the LegendColors → query-response wiring without depending on fragile ColorPicker interaction.
- Time Series TC-11 currently verifies only the threshold *value* field round-trips (not the unit). Once the test stack frontend rebuilds with the new `unit-option-<id>` testids, this can be widened to the unit picker.
- Test plans + functional checklists for both panel types live under `tests/e2e/specs/dashboards/panels/` (in the parent PR). Keep them in sync if any TC scope shifts.
