### PR TITLE
test: added tests for histogram and pie panel

### DIFF
--- a/tests/e2e/tests/dashboards/panels/histogram.spec.ts
+++ b/tests/e2e/tests/dashboards/panels/histogram.spec.ts
@@ -1,0 +1,313 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../../../fixtures/auth';
+import { newAdminContext } from '../../../helpers/auth';
+import {
+	authToken,
+	changePanelType,
+	configureAndSavePanel,
+	createDashboardViaApi,
+	deleteDashboardViaApi,
+	findDashboardIdByTitle,
+	openWidgetEditor,
+	saveWidgetEdit,
+} from '../../../helpers/dashboards';
+
+test.describe.configure({ mode: 'serial' });
+
+const FIXTURE_DASHBOARD_TITLE = 'histogram-controls-fixture';
+const FIXTURE_PANEL_TITLE = 'histogram-controls-panel';
+
+const seedIds = new Set<string>();
+
+test.beforeAll(async ({ browser }) => {
+	const ctx = await newAdminContext(browser);
+	const page = await ctx.newPage();
+	try {
+		const id = await createDashboardViaApi(page, FIXTURE_DASHBOARD_TITLE);
+		seedIds.add(id);
+		await page.goto(`/dashboard/${id}`);
+		await page.getByTestId('add-panel').waitFor({ state: 'visible' });
+		await configureAndSavePanel(page, 'metrics', FIXTURE_PANEL_TITLE);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await changePanelType(page, 'Histogram');
+		await saveWidgetEdit(page);
+	} finally {
+		await ctx.close();
+	}
+});
+
+test.afterAll(async ({ browser }) => {
+	if (seedIds.size === 0) return;
+	const ctx = await newAdminContext(browser);
+	const page = await ctx.newPage();
+	try {
+		const token = await authToken(page);
+		for (const id of [...seedIds]) {
+			await deleteDashboardViaApi(ctx.request, id, token);
+			seedIds.delete(id);
+		}
+	} finally {
+		await ctx.close();
+	}
+});
+
+async function gotoFixtureDashboard(page: Page): Promise<void> {
+	const id = await findDashboardIdByTitle(page, FIXTURE_DASHBOARD_TITLE);
+	expect(id, `${FIXTURE_DASHBOARD_TITLE} not found`).toBeTruthy();
+	await page.goto(`/dashboard/${id}`);
+	await page.getByTestId(FIXTURE_PANEL_TITLE).first().waitFor({ state: 'visible' });
+}
+
+async function expandSection(page: Page, title: string): Promise<void> {
+	const section = page
+		.locator('.settings-section')
+		.filter({ has: page.locator('button.settings-section-header', { hasText: title }) });
+	const contentDiv = section.locator('.settings-section-content');
+	const isOpen = await contentDiv.evaluate((el) =>
+		el.classList.contains('open'),
+	);
+	if (!isOpen) {
+		await section.locator('button.settings-section-header').click();
+		await contentDiv.waitFor({ state: 'visible' });
+	}
+}
+
+test.describe('Histogram Panel Controls', () => {
+	test('TC-01 panel name persists and is reflected in the widget header', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page.getByTestId('panel-name-input').fill('histogram-controls-renamed');
+		await saveWidgetEdit(page);
+		await expect(
+			page.getByTestId('histogram-controls-renamed').first(),
+		).toBeVisible();
+
+		await openWidgetEditor(page, 'histogram-controls-renamed');
+		await expect(page.getByTestId('panel-name-input')).toHaveValue(
+			'histogram-controls-renamed',
+		);
+
+		await page.getByTestId('panel-name-input').fill(FIXTURE_PANEL_TITLE);
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-02 description persists and toggles the widget-header info icon', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page
+			.getByTestId('panel-description-input')
+			.fill('E2E histogram description');
+		await saveWidgetEdit(page);
+
+		const header = page
+			.locator('.widget-header-container')
+			.filter({ hasText: FIXTURE_PANEL_TITLE });
+		await expect(header.locator('.info-tooltip').first()).toBeVisible();
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(page.getByTestId('panel-description-input')).toHaveValue(
+			'E2E histogram description',
+		);
+
+		await page.getByTestId('panel-description-input').fill('');
+		await saveWidgetEdit(page);
+		await expect(header.locator('.info-tooltip')).toHaveCount(0);
+	});
+
+	test('TC-03 bucket count and bucket width persist (canvas-only visual)', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		// Section is titled "Histogram / Buckets" — literal slash + spaces.
+		await expandSection(page, 'Histogram / Buckets');
+
+		const bucketCount = page.locator('.bucket-input .ant-input-number-input').first();
+		const bucketWidth = page
+			.locator('.histogram-settings__bucket-input .ant-input-number-input')
+			.first();
+
+		await bucketCount.fill('50');
+		await bucketWidth.fill('1.5');
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Histogram / Buckets');
+		await expect(
+			page.locator('.bucket-input .ant-input-number-input').first(),
+		).toHaveValue('50');
+		await expect(
+			page
+				.locator('.histogram-settings__bucket-input .ant-input-number-input')
+				.first(),
+		// Ant InputNumber with precision={2} formats 1.5 → "1.50"
+		).toHaveValue('1.50');
+
+		// Reset
+		await page
+			.locator('.bucket-input .ant-input-number-input')
+			.first()
+			.fill('');
+		await page
+			.locator('.histogram-settings__bucket-input .ant-input-number-input')
+			.first()
+			.fill('');
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-04 "Merge all series" toggle removes .legend-container from the DOM', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Histogram / Buckets');
+
+		// Live preview: legend should be present when toggle is OFF.
+		// (Use `.first()` because the editor may render multiple chart areas.)
+		await expect(page.locator('.legend-container').first()).toBeVisible();
+
+		const mergeSwitch = page
+			.locator('section.histogram-settings__combine-hist')
+			.getByRole('switch');
+		await expect(mergeSwitch).toHaveAttribute('aria-checked', 'false');
+		await mergeSwitch.click();
+		await expect(mergeSwitch).toHaveAttribute('aria-checked', 'true');
+
+		// Histogram passes `showLegend={!isQueriesMerged}` → legend container is
+		// not rendered when the merge toggle is ON.
+		await expect(page.locator('.legend-container')).toHaveCount(0);
+
+		await saveWidgetEdit(page);
+
+		// Dashboard render: legend container also absent.
+		await expect(page.locator('.legend-container')).toHaveCount(0);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Histogram / Buckets');
+		await expect(
+			page
+				.locator('section.histogram-settings__combine-hist')
+				.getByRole('switch'),
+		).toHaveAttribute('aria-checked', 'true');
+
+		// Reset
+		await page
+			.locator('section.histogram-settings__combine-hist')
+			.getByRole('switch')
+			.click();
+		await saveWidgetEdit(page);
+		await expect(page.locator('.legend-container').first()).toBeVisible();
+	});
+
+	test('TC-05 Legend Colors panel renders one row per query series with a default color swatch', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Legend');
+
+		const legendColorsCollapse = page.locator('.legend-colors-collapse').first();
+		await legendColorsCollapse.locator('.ant-collapse-header').first().click();
+
+		const items = page.locator('.legend-items .legend-item');
+		await items.first().waitFor({ state: 'visible' });
+		expect(await items.count()).toBeGreaterThan(0);
+
+		const firstMarker = items.first().locator('.legend-marker');
+		const markerStyle = (await firstMarker.getAttribute('style')) ?? '';
+		expect(markerStyle).toMatch(/background-color:/);
+	});
+
+	test('TC-06 panel type swap from Histogram to Time Series and back persists', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await changePanelType(page, 'Time Series');
+
+		// Editor-side visual change: Time Series sections appear, Histogram-only
+		// section disappears.
+		await expect(page.locator('section.fill-gaps').first()).toBeVisible();
+		await expect(page.locator('.histogram-settings__bucket-config')).toHaveCount(0);
+
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(page).toHaveURL(/graphType=graph/);
+
+		// Reset
+		await changePanelType(page, 'Histogram');
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-07 sections hidden for HISTOGRAM are not rendered', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expect(page.locator('section.panel-time-preference')).toHaveCount(0);
+		await expect(page.locator('section.fill-gaps')).toHaveCount(0);
+		await expect(page.locator('section.stack-chart')).toHaveCount(0);
+		await expect(page.locator('section.soft-min-max')).toHaveCount(0);
+		await expect(page.locator('section.log-scale')).toHaveCount(0);
+		await expect(page.locator('section.legend-position')).toHaveCount(0);
+		await expect(page.locator('.y-axis-unit-selector-v2')).toHaveCount(0);
+		await expect(page.locator('.decimal-precision-selector')).toHaveCount(0);
+		await expect(page.locator('.column-unit-selector')).toHaveCount(0);
+		await expect(page.getByTestId('add-threshold-cta')).toHaveCount(0);
+
+		await expect(page.getByTestId('panel-name-input')).toBeVisible();
+		await expect(page.getByTestId('panel-change-select')).toBeVisible();
+
+		await expandSection(page, 'Histogram / Buckets');
+		await expect(
+			page.locator('.histogram-settings__bucket-config').first(),
+		).toBeVisible();
+
+		await expandSection(page, 'Legend');
+		await expect(page.locator('.legend-colors-collapse').first()).toBeVisible();
+	});
+
+	test('TC-08 discarding right-pane changes does not persist', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page.getByTestId('panel-name-input').fill('discard-histogram-test');
+
+		let putFired = false;
+		await page.route(/\/api\/v1\/dashboards\//, (route) => {
+			if (route.request().method() === 'PUT') {
+				putFired = true;
+			}
+			route.continue();
+		});
+
+		await page.getByTestId('discard-button').click();
+		await page
+			.getByRole('dialog')
+			.last()
+			.getByRole('button', { name: /^OK$/i })
+			.click({ timeout: 1000 })
+			.catch(() => {
+				// no modal — direct navigation
+			});
+
+		await page.waitForURL(/\/dashboard\/[0-9a-f-]+(?:\?|$)/);
+		await expect(page.getByTestId(FIXTURE_PANEL_TITLE).first()).toBeVisible();
+		expect(putFired).toBe(false);
+	});
+});

--- a/tests/e2e/tests/dashboards/panels/pie.spec.ts
+++ b/tests/e2e/tests/dashboards/panels/pie.spec.ts
@@ -1,0 +1,417 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../../../fixtures/auth';
+import { newAdminContext } from '../../../helpers/auth';
+import {
+	authToken,
+	changePanelType,
+	configureAndSavePanel,
+	createDashboardViaApi,
+	deleteDashboardViaApi,
+	findDashboardIdByTitle,
+	openWidgetEditor,
+	saveWidgetEdit,
+} from '../../../helpers/dashboards';
+
+test.describe.configure({ mode: 'serial' });
+
+const FIXTURE_DASHBOARD_TITLE = 'pie-controls-fixture';
+const FIXTURE_PANEL_TITLE = 'pie-controls-panel';
+
+const seedIds = new Set<string>();
+
+test.beforeAll(async ({ browser }) => {
+	const ctx = await newAdminContext(browser);
+	const page = await ctx.newPage();
+	try {
+		const id = await createDashboardViaApi(page, FIXTURE_DASHBOARD_TITLE);
+		seedIds.add(id);
+		await page.goto(`/dashboard/${id}`);
+		await page.getByTestId('add-panel').waitFor({ state: 'visible' });
+		await configureAndSavePanel(page, 'metrics', FIXTURE_PANEL_TITLE);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await changePanelType(page, 'Pie');
+		await saveWidgetEdit(page);
+	} finally {
+		await ctx.close();
+	}
+});
+
+test.afterAll(async ({ browser }) => {
+	if (seedIds.size === 0) return;
+	const ctx = await newAdminContext(browser);
+	const page = await ctx.newPage();
+	try {
+		const token = await authToken(page);
+		for (const id of [...seedIds]) {
+			await deleteDashboardViaApi(ctx.request, id, token);
+			seedIds.delete(id);
+		}
+	} finally {
+		await ctx.close();
+	}
+});
+
+async function gotoFixtureDashboard(page: Page): Promise<void> {
+	const id = await findDashboardIdByTitle(page, FIXTURE_DASHBOARD_TITLE);
+	expect(id, `${FIXTURE_DASHBOARD_TITLE} not found`).toBeTruthy();
+	await page.goto(`/dashboard/${id}`);
+	await page.getByTestId(FIXTURE_PANEL_TITLE).first().waitFor({ state: 'visible' });
+}
+
+async function expandSection(page: Page, title: string): Promise<void> {
+	const section = page
+		.locator('.settings-section')
+		.filter({ has: page.locator('button.settings-section-header', { hasText: title }) });
+	const contentDiv = section.locator('.settings-section-content');
+	const isOpen = await contentDiv.evaluate((el) =>
+		el.classList.contains('open'),
+	);
+	if (!isOpen) {
+		await section.locator('button.settings-section-header').click();
+		await contentDiv.waitFor({ state: 'visible' });
+	}
+}
+
+async function selectYAxisUnit(
+	page: Page,
+	wrapperSelector: string,
+	searchTerm: string,
+	optionText: string,
+): Promise<void> {
+	const wrapper = page.locator(wrapperSelector).first();
+	await wrapper.locator('.ant-select').click();
+	await wrapper.locator('.ant-select input').fill(searchTerm);
+	await page
+		.locator('.ant-select-item-option-content', { hasText: optionText })
+		.first()
+		.click();
+}
+
+/**
+ * Trigger the arc tooltip for the first pie slice and return its rendered
+ * value text. Pie uses `@visx/tooltip` (plain DOM portal — not canvas) so the
+ * tooltip node is reliably queryable.
+ *
+ * Playwright's `.hover()` is blocked by the SVG element intercepting pointer
+ * events. `page.mouse.move` bypasses actionability checks but still relies on
+ * the browser hit-testing landing on the `<g>`. The most reliable path is
+ * `page.evaluate` firing a native `MouseEvent` of type `mouseover` directly
+ * on the arc `<g>` element — React 17+ delegates `onMouseEnter` via
+ * `mouseover` on the root, but also captures synthetic `mouseover` events
+ * dispatched on child elements and applies enter/leave semantics.
+ */
+async function readPieArcTooltipText(page: Page): Promise<string> {
+	// Wait for the arc group to be in the DOM.
+	const firstArcG = page.locator('.piechart-container svg g g').first();
+	await firstArcG.waitFor({ state: 'visible' });
+
+	// Dispatch a synthetic mouseover directly on the arc <g>. This reaches
+	// React's event delegation layer regardless of SVG pointer-event interception.
+	// All browser globals are cast via `(globalThis as any)` because the
+	// tsconfig lib does not include "dom" — page.evaluate callbacks run in the
+	// browser but are type-checked in the Node context.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	await page.evaluate((sel: string) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const w = globalThis as any;
+		const g = w.document.querySelector(sel);
+		if (!g) throw new Error('Arc <g> not found');
+		g.dispatchEvent(new w.MouseEvent('mouseover', { bubbles: true, cancelable: true }));
+	}, '.piechart-container svg g g');
+
+	const tooltip = page.locator('.piechart-tooltip').first();
+	await tooltip.waitFor({ state: 'visible', timeout: 5000 });
+	const valueText = (await page.locator('.tooltip-value').first().textContent()) ?? '';
+
+	// Dispatch mouseout on the arc to close the tooltip.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	await page.evaluate((sel: string) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const w = globalThis as any;
+		const g = w.document.querySelector(sel);
+		if (!g) return;
+		g.dispatchEvent(new w.MouseEvent('mouseout', { bubbles: true, cancelable: true }));
+	}, '.piechart-container svg g g');
+	return valueText;
+}
+
+test.describe('Pie Panel Controls', () => {
+	test('TC-01 panel name persists and is reflected in the widget header', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page.getByTestId('panel-name-input').fill('pie-controls-renamed');
+		await saveWidgetEdit(page);
+		await expect(page.getByTestId('pie-controls-renamed').first()).toBeVisible();
+
+		await openWidgetEditor(page, 'pie-controls-renamed');
+		await expect(page.getByTestId('panel-name-input')).toHaveValue(
+			'pie-controls-renamed',
+		);
+
+		await page.getByTestId('panel-name-input').fill(FIXTURE_PANEL_TITLE);
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-02 description persists and toggles the widget-header info icon', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page
+			.getByTestId('panel-description-input')
+			.fill('E2E pie description');
+		await saveWidgetEdit(page);
+
+		const header = page
+			.locator('.widget-header-container')
+			.filter({ hasText: FIXTURE_PANEL_TITLE });
+		await expect(header.locator('.info-tooltip').first()).toBeVisible();
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(page.getByTestId('panel-description-input')).toHaveValue(
+			'E2E pie description',
+		);
+
+		await page.getByTestId('panel-description-input').fill('');
+		await saveWidgetEdit(page);
+		await expect(header.locator('.info-tooltip')).toHaveCount(0);
+	});
+
+	test('TC-03 panel time preference switches to Last 15 min and persists', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page
+			.locator('section.panel-time-preference')
+			.getByRole('button', { name: /global time/i })
+			.click();
+		await page.getByRole('menuitem', { name: /Last 15 min/i }).click();
+		await saveWidgetEdit(page);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(
+			page.locator('section.panel-time-preference').getByRole('button'),
+		).toContainText(/Last 15 min/i);
+
+		await page
+			.locator('section.panel-time-preference')
+			.getByRole('button')
+			.click();
+		await page.getByRole('menuitem', { name: /Global Time/i }).click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-04 Y-axis unit applies to the SVG centre text and arc tooltip', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Formatting & Units');
+		await selectYAxisUnit(
+			page,
+			'.y-axis-unit-selector-v2',
+			'Milliseconds',
+			'Milliseconds (ms)',
+		);
+		await saveWidgetEdit(page);
+
+		// Visible change 1: the SVG centre text gains a `ms` tspan when a
+		// unit is set.
+		const centreTspans = page.locator('.piechart-container svg text tspan');
+		await centreTspans.first().waitFor({ state: 'visible' });
+		const tspanTexts = await centreTspans.allTextContents();
+		expect(tspanTexts.some((t) => /ms/.test(t))).toBe(true);
+
+		// Visible change 2: the arc tooltip includes the `ms` suffix.
+		const tooltipText = await readPieArcTooltipText(page);
+		expect(tooltipText).toMatch(/ms/);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Formatting & Units');
+		await expect(
+			page.locator('.y-axis-unit-selector-v2 .ant-select-selection-item').first(),
+		).toContainText(/Milliseconds/);
+
+		// Reset
+		await page.locator('.y-axis-unit-selector-v2').first().hover();
+		await page.locator('.y-axis-unit-selector-v2 .ant-select-clear').first().click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-05 decimal precision changes the rendered arc-tooltip values', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Formatting & Units');
+		// A unit is required for decimal precision to have a visible effect.
+		await selectYAxisUnit(
+			page,
+			'.y-axis-unit-selector-v2',
+			'Seconds',
+			'Seconds (s)',
+		);
+
+		await page.getByTestId('decimal-precision-selector').click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: '0 decimals' })
+			.first()
+			.click();
+
+		await saveWidgetEdit(page);
+
+		// Visible change: arc tooltip numeric portion has no decimal point.
+		const tooltipText = await readPieArcTooltipText(page);
+		const numericPart = tooltipText.replace(/[A-Za-z]+/g, '');
+		expect(numericPart).not.toMatch(/\./);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expandSection(page, 'Formatting & Units');
+		await expect(page.getByTestId('decimal-precision-selector')).toContainText(
+			/0 decimals/,
+		);
+
+		// Reset
+		await page.getByTestId('decimal-precision-selector').click();
+		await page
+			.locator('.ant-select-item-option-content', { hasText: '2 decimals' })
+			.first()
+			.click();
+		await page.locator('.y-axis-unit-selector-v2').first().hover();
+		await page.locator('.y-axis-unit-selector-v2 .ant-select-clear').first().click();
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-06 Legend Colors panel renders one row per query series with a default color swatch', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expandSection(page, 'Legend');
+
+		const legendColorsCollapse = page.locator('.legend-colors-collapse').first();
+		await legendColorsCollapse.locator('.ant-collapse-header').first().click();
+
+		const items = page.locator('.legend-items .legend-item');
+		await items.first().waitFor({ state: 'visible' });
+		expect(await items.count()).toBeGreaterThan(0);
+
+		const firstMarker = items.first().locator('.legend-marker');
+		const markerStyle = (await firstMarker.getAttribute('style')) ?? '';
+		expect(markerStyle).toMatch(/background-color:/);
+	});
+
+	test('TC-07 piechart-legend-item count matches the number of query series', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+
+		// On the dashboard, count legend items and assert each has a coloured
+		// swatch.
+		await page.locator('.piechart-legend-item').first().waitFor({ state: 'visible' });
+		const dashboardCount = await page.locator('.piechart-legend-item').count();
+		expect(dashboardCount).toBeGreaterThan(0);
+
+		const firstSwatchStyle = (await page
+			.locator('.piechart-legend-item .piechart-legend-label')
+			.first()
+			.getAttribute('style')) ?? '';
+		expect(firstSwatchStyle).toMatch(/background-color:/);
+	});
+
+	test('TC-08 panel type swap from Pie to Time Series and back persists', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await changePanelType(page, 'Time Series');
+
+		// Editor-side visual change: Time Series sections appear, Pie-only
+		// `.piechart-wrapper` is gone from the editor preview area.
+		await expect(page.locator('section.fill-gaps').first()).toBeVisible();
+
+		await saveWidgetEdit(page);
+
+		// Dashboard render now shows a uPlot chart, not a piechart.
+		await expect(page.getByTestId('uplot-main-div').first()).toBeVisible();
+		await expect(page.locator('.piechart-wrapper')).toHaveCount(0);
+
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+		await expect(page).toHaveURL(/graphType=graph/);
+
+		// Reset
+		await changePanelType(page, 'Pie');
+		await saveWidgetEdit(page);
+	});
+
+	test('TC-09 sections hidden for PIE are not rendered', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await expect(page.locator('section.fill-gaps')).toHaveCount(0);
+		await expect(page.locator('section.stack-chart')).toHaveCount(0);
+		await expect(page.locator('section.soft-min-max')).toHaveCount(0);
+		await expect(page.locator('section.log-scale')).toHaveCount(0);
+		await expect(page.locator('section.legend-position')).toHaveCount(0);
+		await expect(page.locator('.column-unit-selector')).toHaveCount(0);
+		await expect(page.getByTestId('add-threshold-cta')).toHaveCount(0);
+		await expect(page.locator('.histogram-settings__bucket-config')).toHaveCount(
+			0,
+		);
+
+		await expect(page.getByTestId('panel-name-input')).toBeVisible();
+		await expect(page.getByTestId('panel-change-select')).toBeVisible();
+		await expect(page.locator('section.panel-time-preference').first()).toBeVisible();
+
+		await expandSection(page, 'Formatting & Units');
+		await expect(page.locator('.y-axis-unit-selector-v2').first()).toBeVisible();
+		await expect(page.getByTestId('decimal-precision-selector')).toBeVisible();
+
+		await expandSection(page, 'Legend');
+		await expect(page.locator('.legend-colors-collapse').first()).toBeVisible();
+	});
+
+	test('TC-10 discarding right-pane changes does not persist', async ({
+		authedPage: page,
+	}) => {
+		await gotoFixtureDashboard(page);
+		await openWidgetEditor(page, FIXTURE_PANEL_TITLE);
+
+		await page.getByTestId('panel-name-input').fill('discard-pie-test');
+
+		let putFired = false;
+		await page.route(/\/api\/v1\/dashboards\//, (route) => {
+			if (route.request().method() === 'PUT') {
+				putFired = true;
+			}
+			route.continue();
+		});
+
+		await page.getByTestId('discard-button').click();
+		await page
+			.getByRole('dialog')
+			.last()
+			.getByRole('button', { name: /^OK$/i })
+			.click({ timeout: 1000 })
+			.catch(() => {
+				// no modal — direct navigation
+			});
+
+		await page.waitForURL(/\/dashboard\/[0-9a-f-]+(?:\?|$)/);
+		await expect(page.getByTestId(FIXTURE_PANEL_TITLE).first()).toBeVisible();
+		expect(putFired).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Follow-up to the time-series / bar panel-controls PR — adds E2E coverage for the remaining chart-based panel types: **Histogram** (uPlot canvas) and **Pie** (SVG via `@visx/shape`). Reuses the established fixture pattern and the `openWidgetEditor` / `saveWidgetEdit` / `changePanelType` helpers from the previous PRs. **No frontend changes** — pure test additions.

## Issues Closed
Closes https://github.com/SigNoz/engineering-pod/issues/4520
Closes https://github.com/SigNoz/engineering-pod/issues/4517

## Change Type

- [x] 🧪 Test-only

## Testing Strategy

- **Tests added:** 18 new TCs across two spec files
  - `tests/e2e/tests/dashboards/panels/histogram.spec.ts` — 8 TCs (name / description / bucket count + width / **Merge all series toggle** / Legend Colors panel render / panel-type swap / section visibility / discard)
  - `tests/e2e/tests/dashboards/panels/pie.spec.ts` — 10 TCs (name / description / time preference / **Y-axis unit on SVG centre + arc tooltip** / **decimal precision via arc tooltip** / Legend Colors panel render / legend item count + swatches / panel-type swap / section visibility / discard)
- **Manual verification:** All 18 new TCs green on chromium. Running all 7 panel spec files together produces **75 passed in 2.0 minutes** (`pnpm test --project=chromium tests/dashboards/panels` — 73 TCs + 1 setup + 1 teardown).

## Visible-change anchors (DOM, not just persistence)

| Panel | Headline visible signal |
|---|---|
| Histogram | "Merge all series" toggle ON → `.legend-container` is **removed from the DOM** (Histogram passes `showLegend={!isQueriesMerged}` to `ChartWrapper`). Toggle OFF restores it. Asserted both in the editor live-preview and on the rendered dashboard panel. |
| Pie | SVG centre `<text>` gains a `<tspan>` containing the unit suffix when Y-axis unit is set. Per-arc `@visx/tooltip` reflects both the unit and the decimal precision in `.tooltip-value`. Legend items below the chart are real DOM (`.piechart-legend-item` + `.piechart-legend-label`) with inline `background-color`. |

Histogram bucket count, bucket width, and the canvas-drawn bars themselves are uPlot-rendered — verified via persistence (PUT round-trip + editor re-load reading the saved `InputNumber` value) only. The Merge toggle is the single DOM-observable rendering control for Histogram.

## Notable healing findings

1. **Histogram TC-03** — Ant Design's `<InputNumber precision={2}>` formats stored `1.5` as `"1.50"` in the DOM. The assertion was adjusted to match (`.toHaveValue('1.50')` with an inline comment noting the formatter).
2. **Pie arc-hover (TC-04, TC-05)** — Playwright's `.hover()` dispatches synthetic mouse events at computed screen coordinates, but inside an `<svg>` the parent intercepts pointer events before they reach inner `<g>` arc children, causing infinite hover-retry timeout. Fix: a local `readPieArcTooltipText` helper that calls `dispatchEvent('mouseenter')` directly on the arc `<g>` — fires React's `onMouseEnter` handler immediately without coordinate dispatch. Worth knowing for any future SVG-based tooltip tests.

## Right-pane section matrix coverage

- **Histogram TC-07** asserts the negative matrix: Panel Time Preference, Fill gaps, Stack series, Axes (soft min/max + log scale), Legend Position, Y-axis unit, Decimal Precision, Column Units, Thresholds — all `toHaveCount(0)`. Expected sections (General, Visualization, Histogram / Buckets, Legend Colors) are visible after expansion.
- **Pie TC-09** asserts the negative matrix: Fill gaps, Stack series, Axes, Legend Position, Column Units, Thresholds, Histogram Buckets — all `toHaveCount(0)`. Expected sections (General, Visualization with Time Preference, Formatting & Units with Unit + Decimal Precision, Legend Colors) are visible.

Both guards catch accidental matrix widening if someone adds a new control without checking the matrix in `RightContainer/constants.ts`.

## Risk & Impact Assessment

- **Blast radius:** Zero. Pure test additions, no frontend changes.
- **Potential regressions:** None — additive only.
- **Rollback plan:** Trivially revertible.

## Changelog

| Field | Value |
|------|-------|
| Deployment Type | OSS |
| Change Type | Maintenance |
| Description | N/A — internal test coverage. |

## Checklist

- [x] Tests added
- [x] Manually tested (18 new TCs green; full 7-spec suite green at 75 passed)
- [x] No breaking changes
- [x] Backward compatible (no source changes)

## Notes for Reviewers

- Stacked on `e2e/timeseries-bar-panel`. Merge that one first, or rebase to `main` once the parent merges.
- Histogram and Pie close out chart-based panel coverage. Trace remains (thin matrix like List — ~5 TCs); planned for a follow-up.
- The `readPieArcTooltipText` helper uses `dispatchEvent('mouseenter')` rather than `.hover()` because SVG arc `<g>` children don't reliably receive Playwright's coordinate-based hover (parent `<svg>` intercepts). This is the right pattern for any future SVG tooltip tests in this codebase.
- Test plans + functional checklists live under `tests/e2e/specs/dashboards/panels/` (in the parent PRs).
