### PR TITLE
fix(tanstack-table): reset page to 1 when change page size

### DIFF
--- a/frontend/src/components/TanStackTableView/TanStackTable.tsx
+++ b/frontend/src/components/TanStackTableView/TanStackTable.tsx
@@ -625,6 +625,7 @@ function TanStackTableInner<TData>(
 										defaultValue="10"
 										onChange={(value): void => {
 											setLimit(+value);
+											setPage(1);
 											pagination.onLimitChange?.(+value);
 										}}
 										items={paginationPageSizeItems}

--- a/frontend/src/components/TanStackTableView/TanStackTable.tsx
+++ b/frontend/src/components/TanStackTableView/TanStackTable.tsx
@@ -625,8 +625,11 @@ function TanStackTableInner<TData>(
 										defaultValue="10"
 										onChange={(value): void => {
 											setLimit(+value);
-											setPage(1);
 											pagination.onLimitChange?.(+value);
+											if (page !== 1) {
+												setPage(1);
+												pagination.onPageChange?.(1);
+											}
 										}}
 										items={paginationPageSizeItems}
 									/>

--- a/frontend/src/components/TanStackTableView/__tests__/TanStackTableView.test.tsx
+++ b/frontend/src/components/TanStackTableView/__tests__/TanStackTableView.test.tsx
@@ -401,6 +401,58 @@ describe('TanStackTableView Integration', () => {
 				expect(onLimitChange).toHaveBeenCalledWith(20);
 			});
 		});
+
+		it('resets page to 1 when limit changes', async () => {
+			const user = userEvent.setup();
+			const onUrlUpdate = jest.fn<void, [UrlUpdateEvent]>();
+
+			renderTanStackTable({
+				props: {
+					pagination: { total: 100, defaultPage: 1, defaultLimit: 10 },
+					enableQueryParams: true,
+				},
+				onUrlUpdate,
+			});
+
+			await waitFor(() => {
+				expect(screen.getByRole('navigation')).toBeInTheDocument();
+			});
+
+			// Navigate to page 2
+			const nav = screen.getByRole('navigation');
+			const page2 = Array.from(nav.querySelectorAll('button')).find(
+				(btn) => btn.textContent?.trim() === '2',
+			);
+			if (!page2) {
+				throw new Error('Page 2 button not found in pagination');
+			}
+			await user.click(page2);
+
+			await waitFor(() => {
+				const lastPage = onUrlUpdate.mock.calls
+					.map((call) => call[0].searchParams.get('page'))
+					.filter(Boolean)
+					.pop();
+				expect(lastPage).toBe('2');
+			});
+
+			// Change page size
+			const comboboxTrigger = document.querySelector(
+				'button[aria-haspopup="dialog"]',
+			) as HTMLElement;
+			await user.click(comboboxTrigger);
+
+			const option20 = await screen.findByRole('option', { name: '20' });
+			await user.click(option20);
+
+			// Verify page reset to 1 (nuqs removes default values from URL)
+			await waitFor(() => {
+				const lastCall = onUrlUpdate.mock.calls[onUrlUpdate.mock.calls.length - 1];
+				const lastPage = lastCall[0].searchParams.get('page');
+				expect(lastPage === '1' || lastPage === null).toBe(true);
+				expect(lastCall[0].searchParams.get('limit')).toBe('20');
+			});
+		});
 	});
 
 	describe('sorting', () => {

--- a/frontend/src/components/TanStackTableView/__tests__/TanStackTableView.test.tsx
+++ b/frontend/src/components/TanStackTableView/__tests__/TanStackTableView.test.tsx
@@ -405,10 +405,11 @@ describe('TanStackTableView Integration', () => {
 		it('resets page to 1 when limit changes', async () => {
 			const user = userEvent.setup();
 			const onUrlUpdate = jest.fn<void, [UrlUpdateEvent]>();
+			const onPageChange = jest.fn();
 
 			renderTanStackTable({
 				props: {
-					pagination: { total: 100, defaultPage: 1, defaultLimit: 10 },
+					pagination: { total: 100, defaultPage: 1, defaultLimit: 10, onPageChange },
 					enableQueryParams: true,
 				},
 				onUrlUpdate,
@@ -452,6 +453,9 @@ describe('TanStackTableView Integration', () => {
 				expect(lastPage === '1' || lastPage === null).toBe(true);
 				expect(lastCall[0].searchParams.get('limit')).toBe('20');
 			});
+
+			// Verify onPageChange callback was called with 1
+			expect(onPageChange).toHaveBeenCalledWith(1);
 		});
 	});
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Fixes the issue of page not being reset to 1 after page size change.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

https://github.com/user-attachments/assets/44b53716-f7bb-4b94-a93c-0278e039150a

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Fixes https://github.com/SigNoz/engineering-pod/issues/4926

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Yes
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Tanstack Table
- Potential regressions: None
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | The tables of Infrastructure Monitoring were not reseting to page 1 after changing the page size, now this behavior was fixed. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered