### PR TITLE
fix(dashboard): align Delete dashboard with other action menu items

### DIFF
--- a/frontend/src/container/ListOfDashboard/DashboardActions.module.scss
+++ b/frontend/src/container/ListOfDashboard/DashboardActions.module.scss
@@ -1,0 +1,36 @@
+.actionContent {
+	display: flex;
+	flex-direction: column;
+}
+
+.actionBtn {
+	display: flex;
+	padding: 8px;
+	height: unset;
+	align-items: center;
+	gap: 6px;
+	color: var(--l2-foreground);
+	font-family: Inter;
+	font-size: 12px;
+	font-weight: 400;
+	line-height: normal;
+	letter-spacing: 0.14px;
+
+	:global(.ant-icon-btn) {
+		margin-inline-end: 0px;
+	}
+}
+
+.deleteBtn {
+	composes: actionBtn;
+	color: var(--danger-background) !important;
+	border-top: 1px solid var(--l1-border);
+}
+
+.deleteBtn:hover {
+	background-color: color-mix(in srgb, var(--l1-foreground) 12%, transparent);
+}
+
+.deleteModal :global(.ant-modal-confirm-body) {
+	align-items: center;
+}

--- a/frontend/src/container/ListOfDashboard/DashboardList.styles.scss
+++ b/frontend/src/container/ListOfDashboard/DashboardList.styles.scss
@@ -745,52 +745,6 @@
 		box-shadow: 4px 10px 16px 2px rgba(0, 0, 0, 0.2);
 		backdrop-filter: blur(20px);
 		padding: 0px;
-
-		.dashboard-action-content {
-			.section-1 {
-				display: flex;
-				flex-direction: column;
-
-				.action-btn {
-					display: flex;
-					padding: 8px;
-					height: unset;
-					align-items: center;
-					gap: 6px;
-					color: var(--l2-foreground);
-					font-family: Inter;
-					font-size: 12px;
-					font-style: normal;
-					font-weight: 400;
-					line-height: normal;
-					letter-spacing: 0.14px;
-
-					.ant-icon-btn {
-						margin-inline-end: 0px;
-					}
-				}
-			}
-
-			.section-2 {
-				display: flex;
-				flex-direction: column;
-				border-top: 1px solid var(--l1-border);
-
-				.ant-typography {
-					display: flex;
-					padding: 12px 8px;
-					align-items: center;
-					gap: 6px;
-					color: var(--bg-cherry-400) !important;
-					font-family: Inter;
-					font-size: 12px;
-					font-style: normal;
-					font-weight: 400;
-					line-height: normal;
-					letter-spacing: 0.14px;
-				}
-			}
-		}
 	}
 }
 

--- a/frontend/src/container/ListOfDashboard/DashboardsList.tsx
+++ b/frontend/src/container/ListOfDashboard/DashboardsList.tsx
@@ -102,6 +102,7 @@ import {
 	filterDashboards,
 } from './utils';
 
+import styles from './DashboardActions.module.scss';
 import './DashboardList.styles.scss';
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
@@ -436,57 +437,53 @@ function DashboardsList(): JSX.Element {
 							{action && (
 								<Popover
 									content={
-										<div className="dashboard-action-content">
-											<section className="section-1">
-												<Button
-													type="text"
-													className="action-btn"
-													icon={<Expand size={12} />}
-													onClick={onClickHandler}
-												>
-													View
-												</Button>
-												<Button
-													type="text"
-													className="action-btn"
-													icon={<SquareArrowOutUpRight size={12} />}
-													onClick={(e): void => {
-														e.stopPropagation();
-														e.preventDefault();
-														openInNewTab(getLink());
-													}}
-												>
-													Open in New Tab
-												</Button>
-												<Button
-													type="text"
-													className="action-btn"
-													icon={<Link2 size={12} />}
-													onClick={(e): void => {
-														e.stopPropagation();
-														e.preventDefault();
-														setCopy(getAbsoluteUrl(getLink()));
-													}}
-												>
-													Copy Link
-												</Button>
-												<Button
-													type="text"
-													className="action-btn"
-													icon={<FileJson size={12} />}
-													onClick={handleJsonExport}
-												>
-													Export JSON
-												</Button>
-											</section>
-											<section className="section-2">
-												<DeleteButton
-													name={dashboard.name}
-													id={dashboard.id}
-													isLocked={dashboard.isLocked}
-													createdBy={dashboard.createdBy}
-												/>
-											</section>
+										<div className={styles.actionContent}>
+											<Button
+												type="text"
+												className={styles.actionBtn}
+												icon={<Expand size={12} />}
+												onClick={onClickHandler}
+											>
+												View
+											</Button>
+											<Button
+												type="text"
+												className={styles.actionBtn}
+												icon={<SquareArrowOutUpRight size={12} />}
+												onClick={(e): void => {
+													e.stopPropagation();
+													e.preventDefault();
+													openInNewTab(getLink());
+												}}
+											>
+												Open in New Tab
+											</Button>
+											<Button
+												type="text"
+												className={styles.actionBtn}
+												icon={<Link2 size={12} />}
+												onClick={(e): void => {
+													e.stopPropagation();
+													e.preventDefault();
+													setCopy(getAbsoluteUrl(getLink()));
+												}}
+											>
+												Copy Link
+											</Button>
+											<Button
+												type="text"
+												className={styles.actionBtn}
+												icon={<FileJson size={12} />}
+												onClick={handleJsonExport}
+											>
+												Export JSON
+											</Button>
+											<DeleteButton
+												name={dashboard.name}
+												id={dashboard.id}
+												isLocked={dashboard.isLocked}
+												createdBy={dashboard.createdBy}
+											/>
 										</div>
 									}
 									placement="bottomRight"

--- a/frontend/src/container/ListOfDashboard/TableComponents/DeleteButton.styles.scss
+++ b/frontend/src/container/ListOfDashboard/TableComponents/DeleteButton.styles.scss
@@ -1,9 +1,0 @@
-.delete-modal {
-	.ant-modal-confirm-body {
-		align-items: center;
-	}
-}
-
-.delete-btn:hover {
-	background-color: color-mix(in srgb, var(--l1-foreground) 12%, transparent);
-}

--- a/frontend/src/container/ListOfDashboard/TableComponents/DeleteButton.tsx
+++ b/frontend/src/container/ListOfDashboard/TableComponents/DeleteButton.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from 'react-query';
 import { CircleAlert, Trash2 } from '@signozhq/icons';
-import { Flex, Modal, Tooltip } from 'antd';
+import { Button, Modal, Tooltip } from 'antd';
 import { Typography } from '@signozhq/ui/typography';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import ROUTES from 'constants/routes';
@@ -12,10 +12,8 @@ import history from 'lib/history';
 import { useAppContext } from 'providers/App/App';
 import { USER_ROLES } from 'types/roles';
 
+import styles from '../DashboardActions.module.scss';
 import { Data } from '../DashboardsList';
-import { TableLinkText } from './styles';
-
-import './DeleteButton.styles.scss';
 
 interface DeleteButtonProps {
 	createdBy: string;
@@ -85,7 +83,7 @@ export function DeleteButton({
 				},
 			},
 			centered: true,
-			className: 'delete-modal',
+			className: styles.deleteModal,
 		});
 	}, [
 		modal,
@@ -109,10 +107,16 @@ export function DeleteButton({
 		return '';
 	};
 
+	const isDisabled = isLocked || (user.role === USER_ROLES.VIEWER && !isAuthor);
+
 	return (
 		<>
 			<Tooltip placement="left" title={getDeleteTooltipContent()}>
-				<TableLinkText
+				<Button
+					type="text"
+					className={styles.deleteBtn}
+					icon={<Trash2 size={12} />}
+					disabled={isDisabled}
 					onClick={(e): void => {
 						e.preventDefault();
 						e.stopPropagation();
@@ -120,13 +124,9 @@ export function DeleteButton({
 							openConfirmationDialog();
 						}
 					}}
-					className="delete-btn"
-					disabled={isLocked || (user.role === USER_ROLES.VIEWER && !isAuthor)}
 				>
-					<Flex align="center" justify="center" gap={4}>
-						<Trash2 size={14} /> Delete dashboard
-					</Flex>
-				</TableLinkText>
+					Delete Dashboard
+				</Button>
 			</Tooltip>
 
 			{contextHolder}

--- a/frontend/src/container/ListOfDashboard/TableComponents/styles.ts
+++ b/frontend/src/container/ListOfDashboard/TableComponents/styles.ts
@@ -1,8 +1,0 @@
-import styled from 'styled-components';
-
-export const TableLinkText = styled.span<{ disabled: boolean }>`
-	color: var(--destructive);
-	cursor: ${({ disabled }): string => (disabled ? 'not-allowed' : 'pointer')};
-	${({ disabled }): string => (disabled ? 'opacity: 0.5;' : '')}
-	padding: var(--spacing-3) var(--spacing-4);
-`;


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The `Delete dashboard` entry in the dashboards list action menu was rendered with its own `<Flex justify="center" gap={4}>` + custom `<TableLinkText>` span (instead of the antd `<Button icon={...}>` + `.action-btn` structure used by the four sibling entries — `View`, `Open in New Tab`, `Copy Link`, `Export JSON`). This caused the icon and label to be center-aligned, with a different icon size and a tighter icon-to-text gap than the rest of the menu.

This PR switches the Delete entry to the same antd `<Button>` structure as the others so icon size, icon-to-text spacing and left alignment all match. While here it also consolidates the previously split `section-1` / `section-2` wrappers into a single `.actionContent` and moves the action-menu styles into a co-located CSS module (`DashboardActions.module.scss`), with a `deleteBtn` modifier carrying the divider + danger color via the `--danger-background` semantic token.

#### Screenshots / Screen Recordings

| Before | After |
| --- | --- |
| <img width="377" height="329" alt="image" src="https://github.com/user-attachments/assets/e5758564-b708-4d08-a43d-e95a3352de23" /> | <img width="379" height="328" alt="image" src="https://github.com/user-attachments/assets/59ac3ed1-7ede-4926-aac9-c82c5b07fd74" /> |

#### Issues closed by this PR

N/A

---

### ✅ Change Type

- [x] 🐛 Bug fix
- [x] ♻️ Refactor

---

### 🐛 Bug Context

#### Root Cause

Regression introduced in #11222 (`feat: migrate from lucide react and antD icons to signoz icons`). The icon swap itself (`DeleteOutlined` → `Trash2`) was fine — pre-#11222 the markup was just `<TableLinkText><DeleteOutlined /> Delete dashboard</TableLinkText>`, with the icon and text flowing inline and left-aligned. That PR additionally wrapped the icon + label in `<Flex align="center" justify="center" gap={4}>`, and **`justify="center"` is the bit that broke alignment** — it horizontally centers the icon + label inside the row, while the sibling items (which use antd `<Button icon={...}>` with `.action-btn` styles) flow left. The `gap={4}` and `size={14}` were also a step away from the sibling items' `gap: 6px` + antd's default 8px icon-to-text margin and `size={12}` icons, making the spacing visibly off as well.

#### Fix Strategy

- Render the Delete entry with the same antd `<Button type="text" icon={<Trash2 size={12} />}>` shape as the other menu items, so it inherits the same icon size, icon-to-text spacing, padding and left alignment by construction (no need for a `<Flex>` wrapper at all).
- Extract the previously split `.section-1` / `.section-2` block styles into a single `.actionContent` container and an `.actionBtn` class, with a `.deleteBtn` modifier that composes `.actionBtn` and adds the `border-top` divider + `var(--danger-background)` color.
- Move the styles into a co-located CSS module (`DashboardActions.module.scss`) per the project's CSS module conventions; remove the now-unused `TableLinkText` styled-component and `DeleteButton.styles.scss`.