### PR TITLE
fix: use community image in docker deploy configs

### DIFF
--- a/deploy/docker-swarm/docker-compose.ha.yaml
+++ b/deploy/docker-swarm/docker-compose.ha.yaml
@@ -190,7 +190,7 @@ services:
       # - ../common/clickhouse/storage.xml:/etc/clickhouse-server/config.d/storage.xml
   signoz:
     !!merge <<: *db-depend
-    image: signoz/signoz:v0.120.0
+    image: signoz/signoz-community:v0.120.0
     ports:
       - "8080:8080" # signoz port
     #   - "6060:6060"     # pprof port

--- a/deploy/docker-swarm/docker-compose.yaml
+++ b/deploy/docker-swarm/docker-compose.yaml
@@ -117,7 +117,7 @@ services:
       # - ../common/clickhouse/storage.xml:/etc/clickhouse-server/config.d/storage.xml
   signoz:
     !!merge <<: *db-depend
-    image: signoz/signoz:v0.120.0
+    image: signoz/signoz-community:v0.120.0
     ports:
       - "8080:8080" # signoz port
     volumes:

--- a/deploy/docker/docker-compose.ha.yaml
+++ b/deploy/docker/docker-compose.ha.yaml
@@ -181,7 +181,7 @@ services:
       # - ../common/clickhouse/storage.xml:/etc/clickhouse-server/config.d/storage.xml
   signoz:
     !!merge <<: *db-depend
-    image: signoz/signoz:${VERSION:-v0.120.0}
+    image: signoz/signoz-community:${VERSION:-v0.120.0}
     container_name: signoz
     ports:
       - "8080:8080" # signoz port

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -109,7 +109,7 @@ services:
       # - ../common/clickhouse/storage.xml:/etc/clickhouse-server/config.d/storage.xml
   signoz:
     !!merge <<: *db-depend
-    image: signoz/signoz:${VERSION:-v0.120.0}
+    image: signoz/signoz-community:${VERSION:-v0.120.0}
     container_name: signoz
     ports:
       - "8080:8080" # signoz port


### PR DESCRIPTION
## Summary

- All four Docker and Docker Swarm compose files (`deploy/docker/docker-compose.yaml`, `deploy/docker/docker-compose.ha.yaml`, `deploy/docker-swarm/docker-compose.yaml`, `deploy/docker-swarm/docker-compose.ha.yaml`) were referencing `signoz/signoz` (the enterprise image) instead of `signoz/signoz-community`
- The `Makefile` explicitly defines these as separate registries (`DOCKER_REGISTRY_COMMUNITY = docker.io/signoz/signoz-community` vs `DOCKER_REGISTRY_ENTERPRISE = docker.io/signoz/signoz`), so community deployments should use the community image
- Without this fix, community users running the deploy configs get the enterprise binary, which logs a recurring `no active license found` error on startup

## Test plan

- [x] Pull `signoz/signoz-community:v0.120.0` and confirm it starts with `"variant":"community"` in logs
- [x] Confirm no license error on startup
- [x] Verify API health endpoint returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)