### PR TITLE
Fix RootSpans does not sync with QB correctly

### DIFF
--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/SpanScopeSelector.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/SpanScopeSelector.tsx
@@ -16,35 +16,31 @@ enum SpanScope {
 	ENTRYPOINT_SPANS = 'entrypoint_spans',
 }
 
-interface SpanFilterConfig {
-	key: string;
-	type: string;
-}
-
 interface SpanScopeSelectorProps {
 	onChange?: (value: TagFilter) => void;
 	query?: IBuilderQuery;
 	skipQueryBuilderRedirect?: boolean;
 }
 
-const SPAN_FILTER_CONFIG: Record<SpanScope, SpanFilterConfig | null> = {
+const SPAN_FILTER_KEY: Record<SpanScope, string | null> = {
 	[SpanScope.ALL_SPANS]: null,
-	[SpanScope.ROOT_SPANS]: {
-		key: 'isRoot',
-		type: 'spanSearchScope',
-	},
-	[SpanScope.ENTRYPOINT_SPANS]: {
-		key: 'isEntryPoint',
-		type: 'spanSearchScope',
-	},
+	[SpanScope.ROOT_SPANS]: 'isRoot',
+	[SpanScope.ENTRYPOINT_SPANS]: 'isEntryPoint',
 };
 
-const createFilterItem = (config: SpanFilterConfig): TagFilterItem => ({
+const SCOPE_FILTER_KEYS = Object.values(SPAN_FILTER_KEY).filter(
+	(key): key is string => key !== null,
+);
+
+const isScopeFilter = (filter: TagFilterItem, key: string): boolean =>
+	filter.key?.key === key && String(filter.value) === 'true';
+
+const createFilterItem = (key: string): TagFilterItem => ({
 	id: uuid().slice(0, 8),
 	key: {
-		key: config.key,
+		key,
 		dataType: undefined,
-		type: config?.type,
+		type: '',
 	},
 	op: '=',
 	value: 'true',
@@ -70,12 +66,7 @@ function SpanScopeSelector({
 		filters: TagFilterItem[] = [],
 	): SpanScope => {
 		const hasFilter = (key: string): boolean =>
-			filters?.some(
-				(filter) =>
-					filter.key?.type === 'spanSearchScope' &&
-					filter.key.key === key &&
-					filter.value === 'true',
-			);
+			filters?.some((filter) => isScopeFilter(filter, key));
 
 		if (hasFilter('isRoot')) {
 			return SpanScope.ROOT_SPANS;
@@ -113,28 +104,21 @@ function SpanScopeSelector({
 
 			const nonScopeFilters = currentFilters.filter(
 				(filter) =>
-					!(
-						filter.key?.type === 'spanSearchScope' &&
-						(filter.key.key === 'isRoot' || filter.key.key === 'isEntryPoint')
-					),
+					!SCOPE_FILTER_KEYS.some((scopeKey) => isScopeFilter(filter, scopeKey)),
 			);
 
-			const config = SPAN_FILTER_CONFIG[newScope];
-			const newScopeFilter = config !== null ? [createFilterItem(config)] : [];
+			const scopeKey = SPAN_FILTER_KEY[newScope];
+			const newScopeFilter = scopeKey !== null ? [createFilterItem(scopeKey)] : [];
 
 			return [...nonScopeFilters, ...newScopeFilter];
 		};
-
-		const keysToRemove = Object.values(SPAN_FILTER_CONFIG)
-			.map((config) => config?.key)
-			.filter((key): key is string => typeof key === 'string');
 
 		newQuery.builder.queryData = newQuery.builder.queryData.map((item) => ({
 			...item,
 			filter: {
 				expression: removeKeysFromExpression(
 					item.filter?.expression ?? '',
-					keysToRemove,
+					SCOPE_FILTER_KEYS,
 				),
 			},
 			filters: {

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/__test__/SpanScopeSelector.test.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/__test__/SpanScopeSelector.test.tsx
@@ -20,12 +20,16 @@ import SpanScopeSelector from '../SpanScopeSelector';
 
 const mockRedirectWithQueryBuilderData = jest.fn();
 
+const SCOPE_KEYS = ['isRoot', 'isEntryPoint'];
+const isScopeFilter = (filter: TagFilterItem): boolean =>
+	SCOPE_KEYS.includes(filter.key?.key ?? '') && String(filter.value) === 'true';
+
 // Helper to create filter items
 const createSpanScopeFilter = (key: string): TagFilterItem => ({
 	id: 'span-filter',
 	key: {
 		key,
-		type: 'spanSearchScope',
+		type: '',
 	},
 	op: '=',
 	value: 'true',
@@ -143,7 +147,6 @@ describe('SpanScopeSelector', () => {
 				expect.objectContaining({
 					key: expect.objectContaining({
 						key: expectedKey,
-						type: 'spanSearchScope',
 					}),
 					op: '=',
 					value: 'true',
@@ -162,11 +165,7 @@ describe('SpanScopeSelector', () => {
 			expect(mockRedirectWithQueryBuilderData).toHaveBeenCalled();
 			const updatedQuery = mockRedirectWithQueryBuilderData.mock.calls[0][0];
 			const filters = updatedQuery.builder.queryData[0].filters.items;
-			expect(filters).not.toContainEqual(
-				expect.objectContaining({
-					key: expect.objectContaining({ type: 'spanSearchScope' }),
-				}),
-			);
+			expect(filters.some(isScopeFilter)).toBe(false);
 		});
 
 		it('should add isRoot filter when selecting ROOT_SPANS', async () => {
@@ -206,6 +205,27 @@ describe('SpanScopeSelector', () => {
 				await expect(screen.findByText(expectedText)).resolves.toBeInTheDocument();
 			},
 		);
+
+		// Round-trip from filter.expression can deserialize the value as a boolean
+		// `true` (unquoted in the expression) instead of the string `'true'` produced
+		// by the dropdown. The dropdown must still recognize that as the scope filter.
+		it.each([
+			['Root Spans', 'isRoot'],
+			['Entrypoint Spans', 'isEntryPoint'],
+		])(
+			'should initialize with %s selected when %s = true (boolean value)',
+			async (expectedText, filterKey) => {
+				const booleanScopeFilter: TagFilterItem = {
+					id: 'span-filter',
+					key: { key: filterKey, type: '' },
+					op: '=',
+					value: true as unknown as string,
+				};
+				const queryWithFilter = createQueryWithFilters([booleanScopeFilter]);
+				renderWithContext(queryWithFilter, undefined, defaultQueryBuilderQuery);
+				await expect(screen.findByText(expectedText)).resolves.toBeInTheDocument();
+			},
+		);
 	});
 
 	describe('when onChange and query props are provided', () => {
@@ -233,9 +253,7 @@ describe('SpanScopeSelector', () => {
 				expect(items).toContainEqual(nonScopeItem);
 			});
 
-			const scopeFiltersInPayload = items.filter(
-				(filter) => filter.key?.type === 'spanSearchScope',
-			);
+			const scopeFiltersInPayload = items.filter(isScopeFilter);
 
 			if (expectedScopeKey) {
 				expect(scopeFiltersInPayload).toHaveLength(1);
@@ -434,9 +452,7 @@ describe('SpanScopeSelector', () => {
 				items: [],
 			};
 			// Count non-scope filters
-			const nonScopeFilters = items.filter(
-				(filter) => filter.key?.type !== 'spanSearchScope',
-			);
+			const nonScopeFilters = items.filter((filter) => !isScopeFilter(filter));
 			expect(nonScopeFilters).toHaveLength(1);
 
 			expect(nonScopeFilters).toContainEqual(


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

On `/traces-explorer`, picking **Root Spans** (or **Entrypoint Spans**) from the trace view dropdown added the `isRoot = 'true'` filter as expected, but on any URL round-trip (e.g. changing the time range) the dropdown silently reverted to **All Spans** while the filter chip stayed in the search bar. Query and UI drifted apart, confusing customers.

This PR makes the dropdown's scope detection robust to the round-trip by matching scope filters on `key.key + value` only, removing a defensive provenance marker (`key.type = 'spanSearchScope'`) that did not survive serialization.

#### Screenshots / Screen Recordings
Before (Span selector value changes incorrectly)

https://github.com/user-attachments/assets/f2fe07fb-43c1-4b5c-8e87-662171c080a5



After(Span selector value stays in sync with the filter search)


https://github.com/user-attachments/assets/36540930-45e8-4375-9361-967386b29d72



#### Issues closed by this PR
Closes SigNoz/engineering-pod#4851

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause
`SpanScopeSelector` decided the current scope by checking each filter item for `key.type === 'spanSearchScope' && key.key === 'isRoot' && value === 'true'`. The `spanSearchScope` type was only ever set on the in-memory item — it never made it into `filter.expression`. On every URL round-trip, `useGetCompositeQueryParam` reconciles `filter.expression` and `filters.items` via `convertFiltersToExpressionWithExistingQuery`, which rebuilds the items with `type: ''`. The strict type check then failed and the dropdown fell through to "All Spans". The filter chip kept rendering because the expression survives the round-trip intact.

`spanSearchScope` was only referenced inside `SpanScopeSelector.tsx` and its test — no other consumer relied on it. It was a defensive provenance marker against a benign case (user manually typing `isRoot = 'true'`), and it was the only reason this bug existed.

#### Fix Strategy
Mirror the pattern already used (and proven) by `components/QuickFilters/FilterRenderers/Checkbox`: match on attribute name only. Concretely:

- Drop the `SpanFilterConfig` interface and `SPAN_FILTER_CONFIG` map; replace with a simpler `SPAN_FILTER_KEY: Record<SpanScope, string | null>`.
- Add a shared `isScopeFilter(filter, key)` predicate keyed on `filter.key?.key === key && String(filter.value) === 'true'` — the `String(...)` normalization handles both `'true'` (string, written by the dropdown) and `true` (boolean, what `convertExpressionToFilters` produces from an unquoted expression like `isRoot = true`).
- Use that predicate in both `getCurrentScopeFromFilters` (read) and `handleScopeChange`'s `nonScopeFilters` step (write), so switching scopes after a round-trip also cleans up stale items.
- No new combiner util needed: the URL round-trip itself merges `filters.items` and `filter.expression`, so reading `filters.items` post-parse is already reading the union.

Tech debt out of scope: the underlying `key.type` loss in `convertExpressionToFilters`/`convertFiltersToExpressionWithExistingQuery` (`components/QueryBuilderV2/utils.ts`). No remaining consumer depends on `key.type` surviving the round-trip after this change, so leaving as-is and flagging here.

---

### 🧪 Testing Strategy

- **Tests added/updated:** existing `SpanScopeSelector.test.tsx` fixtures updated to drop the removed `spanSearchScope` type and use a local `isScopeFilter` helper. Added two new cases covering the boolean-value path (`isRoot = true`, `isEntryPoint = true`) so the round-trip regression can't return. 17/17 tests pass.
- **Manual verification:**
  - Select Root Spans → change time range → dropdown stays "Root Spans" (was the original bug).
  - Same flow for Entrypoint Spans.
  - Switch Root → Entrypoint after a time-range change → `isRoot` chip is replaced cleanly, no stale duplicate.
  - User-typed `isRoot = true` (unquoted boolean) in the search bar correctly flips the dropdown to "Root Spans".
- **Edge cases covered:** boolean vs string `'true'` value; multiple non-scope filters preserved across scope changes; scope-filter cleanup when going back to All Spans.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** isolated to `SpanScopeSelector` — used in trace explorer (list view, trace view) and anywhere `QueryBuilderSearchV2` is rendered with `hideSpanScopeSelector={false}`. No other consumer of the query builder reads `key.type === 'spanSearchScope'`, so behavioral change is fully contained.
- **Potential regressions:** if a user manually types `isRoot = 'true'` in the search bar, the dropdown will now reflect "Root Spans" (previously it would have stayed at "All Spans"). This is semantically correct and matches how every other quick filter behaves.
- **Rollback plan:** straight revert — single-component change with no migrations or persisted state.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Trace view span-scope dropdown now stays in sync with the `isRoot` / `isEntryPoint` filter across time-range changes and other URL navigations. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The `spanSearchScope` `key.type` is removed. No other consumer of that string in the codebase (only `SpanScopeSelector.tsx` and its test), so this is a safe deletion.
- The loosened predicate intentionally matches user-typed `isRoot = 'true'` filters as "Root Spans" — same pattern as `components/QuickFilters/FilterRenderers/Checkbox`, which has been working this way without issue.
- The underlying `key.type` field is dropped to `''` on URL round-trip by `convertExpressionToFilters`. Worth knowing if anyone else builds a feature that relies on provenance metadata via `key.type` — they'll hit the same desync.
