### PR TITLE
fix: added fix for widget warning/save modal states

### DIFF
--- a/frontend/src/container/NewWidget/WidgetModals/DiscardChangesModal.tsx
+++ b/frontend/src/container/NewWidget/WidgetModals/DiscardChangesModal.tsx
@@ -1,0 +1,53 @@
+import { SolidAlertTriangle } from '@signozhq/icons';
+import { ConfirmDialog } from '@signozhq/ui/dialog';
+import { Typography } from '@signozhq/ui/typography';
+
+export interface DiscardChangesModalProps {
+	open: boolean;
+	isNewPanel: boolean;
+	panelTitle?: string;
+	dashboardTitle?: string;
+	onDiscard: () => void;
+	onClose: () => void;
+}
+
+export default function DiscardChangesModal({
+	open,
+	isNewPanel,
+	panelTitle,
+	dashboardTitle,
+	onDiscard,
+	onClose,
+}: DiscardChangesModalProps): JSX.Element {
+	const dashboardName = dashboardTitle ? (
+		<>
+			{' '}
+			to <strong>{dashboardTitle}</strong>
+		</>
+	) : null;
+	const panelLabel = panelTitle ? <strong>{panelTitle}</strong> : 'this panel';
+
+	return (
+		<ConfirmDialog
+			open={open}
+			onOpenChange={(next): void => {
+				if (!next) {
+					onClose();
+				}
+			}}
+			title="Discard changes?"
+			titleIcon={<SolidAlertTriangle size={14} color="#fdd600" />}
+			confirmText="Discard"
+			confirmColor="destructive"
+			cancelText="Keep editing"
+			onConfirm={onDiscard}
+			onCancel={onClose}
+		>
+			{isNewPanel ? (
+				<Typography>This new panel won&apos;t be added{dashboardName}.</Typography>
+			) : (
+				<Typography>Your unsaved edits to {panelLabel} will be lost.</Typography>
+			)}
+		</ConfirmDialog>
+	);
+}

--- a/frontend/src/container/NewWidget/__test__/utils.test.ts
+++ b/frontend/src/container/NewWidget/__test__/utils.test.ts
@@ -1,13 +1,17 @@
 import {
+	initialAutocompleteData,
 	initialQueryBuilderFormValuesMap,
 	PANEL_TYPES,
 } from 'constants/queryBuilder';
+import { cloneDeep } from 'lodash-es';
+import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { Query } from 'types/api/queryBuilder/queryBuilderData';
+import { MetricAggregation } from 'types/api/v5/queryRange';
 import { EQueryType } from 'types/common/dashboard';
 import { DataSource } from 'types/common/queryBuilder';
 
 import type { PartialPanelTypes } from '../utils';
-import { handleQueryChange } from '../utils';
+import { getIsQueryModified, handleQueryChange } from '../utils';
 
 const buildSupersetQuery = (extras?: Record<string, unknown>): Query => ({
 	queryType: EQueryType.QUERY_BUILDER,
@@ -35,6 +39,128 @@ const buildSupersetQuery = (extras?: Record<string, unknown>): Query => ({
 		],
 		queryTraceOperator: [],
 	},
+});
+
+const buildMetricsQuery = (
+	overrides?: Partial<{
+		metricName: string;
+		aggregateAttributeKey: string;
+		legend: string;
+		groupByKey: string;
+	}>,
+): Query => ({
+	queryType: EQueryType.QUERY_BUILDER,
+	promql: [],
+	clickhouse_sql: [],
+	id: 'query-id',
+	unit: '',
+	builder: {
+		queryFormulas: [],
+		queryData: [
+			{
+				...initialQueryBuilderFormValuesMap[DataSource.METRICS],
+				queryName: 'A',
+				aggregateAttribute: overrides?.aggregateAttributeKey
+					? {
+							...initialAutocompleteData,
+							key: overrides.aggregateAttributeKey,
+							type: 'tag',
+							dataType: DataTypes.Float64,
+						}
+					: cloneDeep(initialAutocompleteData),
+				aggregations: [
+					{
+						metricName: overrides?.metricName ?? 'system.cpu.load',
+						temporality: '',
+						timeAggregation: 'rate',
+						spaceAggregation: 'sum',
+						reduceTo: 'avg',
+					} as MetricAggregation,
+				],
+				legend: overrides?.legend ?? '',
+				groupBy: overrides?.groupByKey
+					? [
+							{
+								...initialAutocompleteData,
+								key: overrides.groupByKey,
+								type: 'tag',
+								dataType: DataTypes.String,
+							},
+						]
+					: [],
+			},
+		],
+		queryTraceOperator: [],
+	},
+});
+
+describe('getIsQueryModified', () => {
+	it('returns false when baseline is null (new unsaved panel with no edits anchor)', () => {
+		const current = buildMetricsQuery();
+		expect(getIsQueryModified(current, null)).toBe(false);
+	});
+
+	it('returns false when baseline is undefined', () => {
+		const current = buildMetricsQuery();
+		expect(getIsQueryModified(current, undefined)).toBe(false);
+	});
+
+	it('returns false when current only differs by auto-backfilled aggregateAttribute', () => {
+		// saved widget query: aggregateAttribute is the v5-style empty initial value
+		// (stripped from persisted spec; spread back in as initialAutocompleteData on load)
+		const savedQuery = buildMetricsQuery({ metricName: 'system.cpu.load' });
+		// after MetricNameSelector edit-mode backfill, currentQuery has the populated
+		// aggregateAttribute while the rest of the query is identical
+		const currentQuery = buildMetricsQuery({
+			metricName: 'system.cpu.load',
+			aggregateAttributeKey: 'system.cpu.load',
+		});
+		expect(getIsQueryModified(currentQuery, savedQuery)).toBe(false);
+	});
+
+	it('returns true when the user edits the legend', () => {
+		const baseline = buildMetricsQuery({ metricName: 'system.cpu.load' });
+		const edited = buildMetricsQuery({
+			metricName: 'system.cpu.load',
+			legend: 'cpu-load',
+		});
+		expect(getIsQueryModified(edited, baseline)).toBe(true);
+	});
+
+	it('returns true when the user picks a different metric (aggregations diverges)', () => {
+		const baseline = buildMetricsQuery({ metricName: 'system.cpu.load' });
+		const edited = buildMetricsQuery({ metricName: 'system.memory.usage' });
+		expect(getIsQueryModified(edited, baseline)).toBe(true);
+	});
+
+	it('returns true when the user adds a groupBy', () => {
+		const baseline = buildMetricsQuery({ metricName: 'system.cpu.load' });
+		const edited = buildMetricsQuery({
+			metricName: 'system.cpu.load',
+			groupByKey: 'host.name',
+		});
+		expect(getIsQueryModified(edited, baseline)).toBe(true);
+	});
+
+	it('returns true on existing widget when current diverges from saved (Stage-and-Run silent-loss flow)', () => {
+		// After Edit → Stage and Run, stagedQuery is reset to match currentQuery.
+		// The dirty check must compare against the SAVED widget query, not stagedQuery.
+		const savedQuery = buildMetricsQuery({ metricName: 'system.cpu.load' });
+		const currentQuery = buildMetricsQuery({ metricName: 'system.memory.usage' });
+		expect(getIsQueryModified(currentQuery, savedQuery)).toBe(true);
+	});
+
+	it('returns false for a new panel where currentQuery still matches stagedQuery baseline', () => {
+		const stagedQuery = buildMetricsQuery();
+		const currentQuery = buildMetricsQuery();
+		expect(getIsQueryModified(currentQuery, stagedQuery)).toBe(false);
+	});
+
+	it('returns true for a new panel where currentQuery has been edited away from stagedQuery', () => {
+		const stagedQuery = buildMetricsQuery();
+		const currentQuery = buildMetricsQuery({ legend: 'custom' });
+		expect(getIsQueryModified(currentQuery, stagedQuery)).toBe(true);
+	});
 });
 
 describe('handleQueryChange', () => {

--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -1,18 +1,17 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { UseQueryResult } from 'react-query';
 // eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { generatePath } from 'react-router-dom';
-import { Check, SolidAlertTriangle, X } from '@signozhq/icons';
+import { Check, X } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
 import {
 	ResizableHandle,
 	ResizablePanel,
 	ResizablePanelGroup,
 } from '@signozhq/ui/resizable';
-import { Flex, Modal, Space } from 'antd';
+import { Flex } from 'antd';
 import { Typography } from '@signozhq/ui/typography';
 import logEvent from 'api/common/logEvent';
 import { PrecisionOption, PrecisionOptionsEnum } from 'components/Graph/types';
@@ -69,7 +68,6 @@ import { GlobalReducer } from 'types/reducer/globalTime';
 import { getGraphType, getGraphTypeForFormat } from 'utils/getGraphType';
 
 import LeftContainer from './LeftContainer';
-import QueryTypeTag from './LeftContainer/QueryTypeTag';
 import RightContainer from './RightContainer';
 import { ThresholdProps } from './RightContainer/Threshold/types';
 import TimeItems, { timePreferance } from './RightContainer/timeItems';
@@ -82,6 +80,7 @@ import {
 	placeWidgetAtBottom,
 	placeWidgetBetweenRows,
 } from './utils';
+import DiscardChangesModal from './WidgetModals/DiscardChangesModal';
 
 import './NewWidget.styles.scss';
 
@@ -98,8 +97,6 @@ function NewWidget({
 
 	const { dashboardVariables } = useDashboardVariables();
 
-	const { t } = useTranslation(['dashboard']);
-
 	const { registerShortcut, deregisterShortcut } = useKeyboardHotkeys();
 
 	const {
@@ -109,11 +106,6 @@ function NewWidget({
 		supersetQuery,
 		setSupersetQuery,
 	} = useQueryBuilder();
-
-	const isQueryModified = useMemo(
-		() => getIsQueryModified(currentQuery, stagedQuery),
-		[currentQuery, stagedQuery],
-	);
 
 	const { selectedTime: globalSelectedInterval } = useSelector<
 		AppState,
@@ -138,6 +130,23 @@ function NewWidget({
 	const { widgets = [] } = dashboardData?.data || {};
 
 	const query = useUrlQuery();
+
+	// For existing widgets, compare currentQuery against the saved widget query
+	// (stable across Stage-and-Run cycles). For new panels with no saved baseline,
+	// fall back to stagedQuery so initial edits still trigger the warning.
+	const savedWidgetQuery = useMemo(() => {
+		const widgetId = query.get('widgetId');
+		const match = widgets?.find((w) => w.id === widgetId);
+		if (!match || match.panelTypes === PANEL_GROUP_TYPES.ROW) {
+			return null;
+		}
+		return (match as Widgets).query ?? null;
+	}, [widgets, query]);
+
+	const isQueryModified = useMemo(
+		() => getIsQueryModified(currentQuery, savedWidgetQuery ?? stagedQuery),
+		[currentQuery, savedWidgetQuery, stagedQuery],
+	);
 
 	const [isNewDashboard, setIsNewDashboard] = useState<boolean>(false);
 
@@ -228,7 +237,6 @@ function NewWidget({
 		Record<string, string>
 	>(selectedWidget?.customLegendColors || {});
 
-	const [saveModal, setSaveModal] = useState(false);
 	const [discardModal, setDiscardModal] = useState(false);
 
 	const [bucketWidth, setBucketWidth] = useState<number>(
@@ -340,7 +348,6 @@ function NewWidget({
 	]);
 
 	const closeModal = (): void => {
-		setSaveModal(false);
 		setDiscardModal(false);
 	};
 
@@ -593,7 +600,7 @@ function NewWidget({
 			},
 		};
 
-		updateDashboardMutation.mutateAsync(dashboard, {
+		return updateDashboardMutation.mutateAsync(dashboard, {
 			onSuccess: () => {
 				setToScrollWidgetId(selectedWidget?.id || '');
 				navigateToDashboardPage();
@@ -688,9 +695,9 @@ function NewWidget({
 				})),
 			}),
 		});
-		setSaveModal(true);
+		onClickSaveHandler();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isNewPanel]);
+	}, [onClickSaveHandler]);
 
 	const isNewTraceLogsAvailable =
 		currentQuery.queryType === EQueryType.QUERY_BUILDER &&
@@ -951,57 +958,14 @@ function NewWidget({
 					</ResizablePanel>
 				</ResizablePanelGroup>
 			</PanelContainer>
-			<Modal
-				title={
-					isQueryModified ? (
-						<Space>
-							<SolidAlertTriangle size={16} color="#fdd600" />
-							Unsaved Changes
-						</Space>
-					) : (
-						'Save Widget'
-					)
-				}
-				focusTriggerAfterClose
-				forceRender
-				destroyOnClose
-				closable
-				onCancel={closeModal}
-				onOk={onClickSaveHandler}
-				confirmLoading={updateDashboardMutation.isLoading}
-				centered
-				open={saveModal}
-				width={600}
-			>
-				{!isQueryModified ? (
-					<Typography>
-						{t('your_graph_build_with')}{' '}
-						<QueryTypeTag queryType={currentQuery.queryType} />{' '}
-						{t('dashboard_ok_confirm')}
-					</Typography>
-				) : (
-					<Typography>{t('dashboard_unsave_changes')} </Typography>
-				)}
-			</Modal>
-			<Modal
-				title={
-					<Space>
-						<SolidAlertTriangle size={16} color="#fdd600" />
-						Unsaved Changes
-					</Space>
-				}
-				focusTriggerAfterClose
-				forceRender
-				destroyOnClose
-				closable
-				onCancel={closeModal}
-				onOk={discardChanges}
-				centered
+			<DiscardChangesModal
 				open={discardModal}
-				width={600}
-			>
-				<Typography>{t('dashboard_unsave_changes')}</Typography>
-			</Modal>
+				isNewPanel={isNewPanel}
+				panelTitle={title}
+				dashboardTitle={dashboardData?.data?.title}
+				onDiscard={discardChanges}
+				onClose={closeModal}
+			/>
 		</Container>
 	);
 }

--- a/frontend/src/container/NewWidget/utils.ts
+++ b/frontend/src/container/NewWidget/utils.ts
@@ -1,5 +1,4 @@
 import { Layout } from 'react-grid-layout';
-import { omitIdFromQuery } from 'components/ExplorerCard/utils';
 import { PrecisionOptionsEnum } from 'components/Graph/types';
 import { YAxisCategoryNames } from 'components/YAxisUnitSelector/constants';
 import {
@@ -26,16 +25,84 @@ import { DataSource } from 'types/common/queryBuilder';
 
 import { getCategoryName } from './RightContainer/dataFormatCategories';
 
+// Asks "would saving the current panel change the persisted widget spec?".
+//
+// `adjustQueryForV5` is deliberately not reused here: in addition to stripping
+// the legacy v4 fields, it also resurrects them onto each metric
+// `aggregations[i]`. That migration step is correct on save but bleeds
+// asymmetrically across a comparator — the live query still carries the
+// legacy defaults from `initialQueryBuilderFormValuesMap` while a previously
+// saved widget had them stripped.
+const stripQueryDataForCompare = (
+	queryData: IBuilderQuery,
+): Record<string, unknown> => {
+	const {
+		aggregateAttribute: _aggregateAttribute,
+		aggregateOperator: _aggregateOperator,
+		timeAggregation: _timeAggregation,
+		spaceAggregation: _spaceAggregation,
+		reduceTo: _reduceTo,
+		filters: _filters,
+		...retained
+	} = queryData ?? ({} as IBuilderQuery);
+
+	const groupBy = (retained.groupBy ?? []).map((entry) => {
+		const { id: _id, ...rest } = entry;
+		return rest;
+	});
+
+	return {
+		...retained,
+		groupBy,
+		source: retained.source || '',
+	};
+};
+
+const normalizeForDirtyCheck = (query: Query): Record<string, unknown> => {
+	const { id: _id, unit, builder, ...rest } = query;
+	return {
+		...rest,
+		// `id` is regenerated on every Stage and Run; `unit` flips between ''
+		// and undefined depending on whether the user has touched the selector.
+		unit: unit || '',
+		builder: {
+			...builder,
+			queryData: (builder?.queryData ?? []).map(stripQueryDataForCompare),
+		},
+	};
+};
+
+// `lodash.isEqual` distinguishes `{a: undefined}` from `{}`; for the dirty
+// check those are the same. Initial-values spreads on the live query
+// frequently leave such explicit-undefined keys.
+const stripUndefined = (value: unknown): unknown => {
+	if (Array.isArray(value)) {
+		return value.map(stripUndefined);
+	}
+	if (value && typeof value === 'object') {
+		const out: Record<string, unknown> = {};
+		Object.entries(value as Record<string, unknown>).forEach(([k, v]) => {
+			if (v === undefined) {
+				return;
+			}
+			out[k] = stripUndefined(v);
+		});
+		return out;
+	}
+	return value;
+};
+
 export const getIsQueryModified = (
 	currentQuery: Query,
-	stagedQuery: Query | null,
+	baselineQuery: Query | null | undefined,
 ): boolean => {
-	if (!stagedQuery) {
+	if (!baselineQuery) {
 		return false;
 	}
-	const omitIdFromStageQuery = omitIdFromQuery(stagedQuery);
-	const omitIdFromCurrentQuery = omitIdFromQuery(currentQuery);
-	return !isEqual(omitIdFromStageQuery, omitIdFromCurrentQuery);
+	return !isEqual(
+		stripUndefined(normalizeForDirtyCheck(baselineQuery)),
+		stripUndefined(normalizeForDirtyCheck(currentQuery)),
+	);
 };
 
 export type PartialPanelTypes = {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The unsaved-changes warning on dashboard widgets was firing in two wrong ways and missing one correct way:

1. **False positive on edit-mode mount** — opening an existing widget showed "Unsaved Changes" before the user had touched anything. The dirty check did a deep-equal between `currentQuery` and `stagedQuery`, but the live query carries v4-legacy fields (`aggregateAttribute`, `aggregateOperator`, `timeAggregation`, `spaceAggregation`, `reduceTo`) that are stripped from the persisted widget spec — so the two never matched on first render.
2. **Silent data loss after Stage and Run** — the comparison baseline (`stagedQuery`) was reset to match `currentQuery` on every Stage and Run. After running once, the dirty check could never see a divergence, so discarding lost edits without warning.
3. **Redundant "Save Widget" confirmation modal** — pre-Save modal asked the user to confirm with the same copy the discard flow used; just removed.

The fix compares `currentQuery` against the **saved widget query** (stable across Stage-and-Run cycles) for existing widgets, falls back to `stagedQuery` only for brand-new panels, and normalizes both sides to strip the v4-vs-v5 noise and regenerated `id`s before equality.

#### Screenshots / Screen Recordings (if applicable)

Before
<img width="767" height="429" alt="image" src="https://github.com/user-attachments/assets/60fc93aa-fc5d-4ee6-afec-bffbe5932f5d" />


https://github.com/user-attachments/assets/ce8d5db3-3e3d-45d5-b64d-6f09b0446fab




After
<img width="712" height="397" alt="image" src="https://github.com/user-attachments/assets/78d44728-c73c-4b76-8c9c-72886371e05a" />


#### Issues closed by this PR

Closes https://github.com/SigNoz/signoz/issues/9186
Closes https://github.com/SigNoz/engineering-pod/issues/5002
Closes https://github.com/SigNoz/engineering-pod/issues/4941
Closes https://github.com/SigNoz/engineering-pod/issues/4849

---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

`getIsQueryModified` was doing a deep-equal between `currentQuery` and `stagedQuery` via `omitIdFromQuery`. Two structural issues made that wrong:

- `stagedQuery` is overwritten with `currentQuery` on every Stage and Run, so it isn't a stable baseline for an existing widget — after the first run, any subsequent edits compared dirty=against=clean and looked clean.
- The persisted widget spec is stored in v5 shape (`aggregations[]` only); when loaded into the form, `initialQueryBuilderFormValuesMap` spreads the legacy v4 fields back on top, and `MetricNameSelector` backfills `aggregateAttribute` for edit mode. The freshly-loaded query and the saved spec therefore differ even when the user hasn't touched anything.

#### Fix Strategy

- In [container/NewWidget/index.tsx](frontend/src/container/NewWidget/index.tsx), derive `savedWidgetQuery` from the persisted widget (looked up by `widgetId`) and compare against that. For new panels with no saved baseline, fall back to `stagedQuery` so initial edits still register.
- In [container/NewWidget/utils.ts](frontend/src/container/NewWidget/utils.ts), rewrote `getIsQueryModified` to normalize both sides before deep-equality:
  - Drop the v4 legacy fields (`aggregateAttribute`, `aggregateOperator`, `timeAggregation`, `spaceAggregation`, `reduceTo`, `filters`) from each `queryData`.
  - Drop regenerated identifiers — top-level `id` (new UUID every Stage and Run), `groupBy[].id` (rebuilt each load), and coerce `unit` from `undefined`/`''` to a stable `''`.
  - Strip explicit-`undefined` keys, since `lodash.isEqual` distinguishes `{a: undefined}` from `{}` and initial-values spreads leave those around.
  - `adjustQueryForV5` was deliberately not reused — its migration step resurrects the legacy fields onto each `aggregations[i]`, which is correct on save but bleeds asymmetrically into a comparator.
- Replaced the two inline antd `Modal` instances in `index.tsx` with a single [DiscardChangesModal](frontend/src/container/NewWidget/WidgetModals/DiscardChangesModal.tsx) (built on `@signozhq/ui/dialog`'s `ConfirmDialog`) that branches its copy on `isNewPanel`.
- Removed the pre-Save confirmation modal — Save now calls `onClickSaveHandler` directly.

---

### 🧪 Testing Strategy

- Tests added/updated: 8 new unit tests in [container/NewWidget/__test__/utils.test.ts](frontend/src/container/NewWidget/__test__/utils.test.ts) covering `getIsQueryModified`:
  - returns `false` when baseline is `null`/`undefined`
  - returns `false` when current differs only by auto-backfilled `aggregateAttribute` (the false-positive case)
  - returns `true` for genuine edits: legend change, metric swap, groupBy added
  - returns `true` on the Stage-and-Run silent-loss flow (current diverges from saved while stagedQuery matches current)
  - new-panel paths: clean baseline returns `false`; legend edit returns `true`
- Manual verification:
  - [ ] Open existing widget → no warning shown on mount
  - [ ] Edit widget → click Stage and Run → click Discard → warning fires
  - [ ] Edit widget → click Save → no extra confirmation, change persists
  - [ ] New panel → no warning on mount; edit then back-navigate → warning fires
- Edge cases covered: v4 → v5 mixed-shape queries, group-by id regeneration, `unit` flipping between `''` and `undefined`.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: scoped to the widget edit page (`NewWidget` container) and the discard/save warning flow. `getIsQueryModified` is only consumed inside that container.
- Potential regressions: false negatives where a genuine edit fails to mark the widget dirty (e.g. an edit on a field we now strip from the comparator). Manually verified the common-case fields (legend, metric, groupBy, panel type) still register.
- Rollback plan: single commit, easy revert. No data/schema changes.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fix incorrect "unsaved changes" warning when editing dashboard widgets — no longer fires on mount of an unchanged widget, and now correctly fires after Stage and Run when the user discards edits. |

---

### 📋 Checklist

- [x] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The `getIsQueryModified` rewrite intentionally avoids `adjustQueryForV5` even though it looks like the obvious tool — see the comment in [utils.ts](frontend/src/container/NewWidget/utils.ts) explaining the asymmetry.
- The `savedWidgetQuery` fallback (`?? stagedQuery`) is only there for new panels where no saved widget exists yet — once you've saved the widget once, the baseline becomes stable across Stage-and-Run cycles.
- `DiscardChangesModal` lives under a new `WidgetModals/` folder — keeping room for more modal extractions if the inline modal pattern in `index.tsx` keeps growing.

---
