### PR TITLE
fix(dashboard): component UX updates in widget header and settings panel

### DIFF
--- a/frontend/src/container/DashboardContainer/DashboardDescription/Description.styles.scss
+++ b/frontend/src/container/DashboardContainer/DashboardDescription/Description.styles.scss
@@ -186,77 +186,40 @@
 		display: flex;
 		flex-direction: column;
 
-		.section-1 {
+		section {
 			display: flex;
 			flex-direction: column;
 			align-items: start;
-			border-bottom: 1px solid var(--l1-border);
 
 			.ant-btn {
 				display: flex;
 				width: 100%;
-				height: 20px;
-				padding: 16px 18px 18px 14px;
+				height: unset;
+				padding: 8px;
 				align-items: center;
-				gap: 6px;
+				gap: 12px;
 				color: var(--l2-foreground);
 				font-family: Inter;
-				font-size: 14px;
+				font-size: 13px;
 				font-style: normal;
 				font-weight: 400;
 				line-height: normal;
 				letter-spacing: 0.14px;
+				border-top: none;
+
 				.ant-btn-icon {
 					margin-inline-end: 0px;
 				}
 			}
 		}
+
+		.section-1,
 		.section-2 {
-			display: flex;
-			flex-direction: column;
-			align-items: start;
 			border-bottom: 1px solid var(--l1-border);
-
-			.ant-btn {
-				display: flex;
-				width: 100%;
-				height: 20px;
-				padding: 16px 18px 18px 14px;
-				align-items: center;
-				gap: 6px;
-				color: var(--l2-foreground);
-				font-family: Inter;
-				font-size: 14px;
-				font-style: normal;
-				font-weight: 400;
-				line-height: normal;
-				letter-spacing: 0.14px;
-
-				.ant-btn-icon {
-					margin-inline-end: 0px;
-				}
-			}
 		}
-		.delete-dashboard {
-			display: flex;
-			flex-direction: column;
-			align-items: start;
 
-			.ant-typography {
-				display: flex;
-				width: 100%;
-				height: 20px;
-				padding: 16px 18px 18px 14px;
-				align-items: center;
-				gap: 6px;
-				color: var(--bg-cherry-400) !important;
-				font-family: Inter;
-				font-size: 14px;
-				font-style: normal;
-				font-weight: 400;
-				line-height: normal;
-				letter-spacing: 0.14px;
-			}
+		.delete-dashboard .ant-btn {
+			color: var(--bg-cherry-400) !important;
 		}
 	}
 }

--- a/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/VariableItem.styles.scss
+++ b/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/VariableItem.styles.scss
@@ -211,7 +211,12 @@
 			display: grid;
 			grid-template-columns: max-content 1fr;
 
+			.typography-variables {
+				display: block;
+			}
+
 			.default-value-description {
+				display: block;
 				color: var(--l2-foreground);
 				font-family: Inter;
 				font-size: 11px;

--- a/frontend/src/container/DashboardContainer/DashboardSettings/General/index.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardSettings/General/index.tsx
@@ -11,7 +11,7 @@ import {
 	SyncTooltipFilterMode,
 } from 'lib/uPlotV2/plugins/TooltipPlugin/types';
 import { isEqual } from 'lodash-es';
-import { Check, ExternalLink, Info, X } from '@signozhq/icons';
+import { Check, ExternalLink, SolidInfoCircle, X } from '@signozhq/icons';
 import { useDashboardStore } from 'providers/Dashboard/store/useDashboardStore';
 
 import styles from './GeneralSettings.module.scss';
@@ -201,7 +201,7 @@ function GeneralDashboardSettings(): JSX.Element {
 						placement="top"
 						mouseEnterDelay={0.5}
 					>
-						<Info size={14} className={styles.crossPanelSyncInfoIcon} />
+						<SolidInfoCircle size="md" className={styles.crossPanelSyncInfoIcon} />
 					</Tooltip>
 				</div>
 				<div className={styles.crossPanelSyncRow}>

--- a/frontend/src/container/GridCardLayout/WidgetHeader/WidgetHeader.styles.scss
+++ b/frontend/src/container/GridCardLayout/WidgetHeader/WidgetHeader.styles.scss
@@ -26,10 +26,13 @@
 	gap: 8px;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	flex: 1;
+	min-width: 0;
 }
 
 .widget-header-title {
 	max-width: 80%;
+	min-width: 0;
 }
 
 .widget-header-actions {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Bundles four small UX fixes — three regressions from the typography (#11199) and icons (#11222) migrations, plus the `DashboardDescription` fallout from #11352.

1. **Widget panel title truncates even when there's space.** `.widget-header-title-container` was a flex child with no `flex` rule, so it collapsed to its content width; the `max-width: 80%` on the title then triggered `-webkit-line-clamp` ellipsis at that already-narrow width. Adding `flex: 1` + `min-width: 0` to the container makes 80% resolve against the full header width minus the actions, so the title only truncates when it genuinely doesn't fit.

2. **"Default Value" label and helper text run together on one line.** `Typography` from `@signozhq/ui` defaults to `display: inline` (text variant), so the description sat next to the label instead of below it. Forced `display: block` on the label and the description inside `.default-value-section`.

3. **Cross-Panel Sync info icon is inconsistent with the rest of the UI.** Other info icons in the dashboard surfaces (widget header, threshold, status message) use `SolidInfoCircle`, but this one was using the outline `Info`. Swapped the import + usage to `SolidInfoCircle size="md"`.

4. **DashboardDescription "Delete dashboard" 3 duplicate blocks for description menu were consolidated into a single `section .ant-btn` rule, with section dividers and the danger color as the only per-section overrides. Padding was set at `8px` to match the list-page menu visually.

#### Screenshots / Screen Recordings (if applicable)

| Before | After |
| --- | --- |
| <img width="815" height="321" alt="image" src="https://github.com/user-attachments/assets/eae6e1f9-265a-4aea-be2b-4156dc32ba2c" /> | <img width="828" height="329" alt="image" src="https://github.com/user-attachments/assets/ac706440-a5db-4fc6-b233-1bddfec43828" /> |
| <img width="858" height="418" alt="image" src="https://github.com/user-attachments/assets/a7955fc8-0cd0-4fed-96e2-1319c2c5b2a9" /> | <img width="864" height="478" alt="image" src="https://github.com/user-attachments/assets/3c05da48-af79-4014-9f43-171863362c32" /> |
| <img width="870" height="168" alt="image" src="https://github.com/user-attachments/assets/027e3f4c-304f-4951-980f-8fd55740416b" /> | <img width="855" height="127" alt="image" src="https://github.com/user-attachments/assets/55f9dde4-02ec-42ba-93e6-2d8cfa63881a" /> |
| <img width="1049" height="401" alt="image" src="https://github.com/user-attachments/assets/6e74bf82-580f-48e8-88d9-ec4e66599ad3" /> | <img width="967" height="388" alt="image" src="https://github.com/user-attachments/assets/8b4e5847-f8c6-4883-b987-3428cde3adbb" /> |

#### Issues closed by this PR

N/A

---

### ✅ Change Type

- [x] 🐛 Bug fix