### PR TITLE
feat(ai-assistant): collapse thinking + tool-call steps into one row

### DIFF
--- a/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.module.scss
+++ b/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.module.scss
@@ -1,0 +1,64 @@
+// Collapsed activity summary — one row that hides the underlying
+// thinking + tool-call steps. Reuses the same quiet treatment as
+// ThinkingStep / ToolCallStep so it sits flush in the assistant bubble.
+.group {
+	width: 100%;
+	font-size: 12px;
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 4px 0;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	color: var(--l3-foreground);
+	user-select: none;
+	transition: color 0.12s ease;
+	width: 100%;
+	text-align: left;
+
+	&:hover {
+		color: var(--l1-foreground);
+	}
+}
+
+.icon {
+	flex-shrink: 0;
+	color: var(--accent-primary);
+
+	&.spin {
+		animation: pulse 1.4s ease-in-out infinite;
+	}
+}
+
+@keyframes pulse {
+	0%,
+	100% {
+		opacity: 0.55;
+	}
+	50% {
+		opacity: 1;
+	}
+}
+
+.label {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-weight: 400;
+}
+
+.chevron {
+	flex-shrink: 0;
+	color: inherit;
+}
+
+.body {
+	display: flex;
+	flex-direction: column;
+	padding: 2px 0 4px;
+}

--- a/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.module.scss
+++ b/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.module.scss
@@ -1,12 +1,12 @@
 // Collapsed activity summary — one row that hides the underlying
 // thinking + tool-call steps. Reuses the same quiet treatment as
 // ThinkingStep / ToolCallStep so it sits flush in the assistant bubble.
-.group {
+.activityGroup {
 	width: 100%;
 	font-size: 12px;
 }
 
-.header {
+.activityHeader {
 	display: flex;
 	align-items: center;
 	gap: 8px;
@@ -25,11 +25,11 @@
 	}
 }
 
-.icon {
+.sparkleIcon {
 	flex-shrink: 0;
 	color: var(--accent-primary);
 
-	&.spin {
+	&.iconPulsing {
 		animation: activityGroupPulse 1.4s ease-in-out infinite;
 	}
 }
@@ -44,7 +44,7 @@
 	}
 }
 
-.label {
+.activitySummary {
 	flex: 1;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -52,12 +52,12 @@
 	font-weight: 400;
 }
 
-.chevron {
+.toggleChevron {
 	flex-shrink: 0;
 	color: inherit;
 }
 
-.body {
+.activityBody {
 	display: flex;
 	flex-direction: column;
 	padding: 2px 0 4px;

--- a/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.module.scss
+++ b/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.module.scss
@@ -30,11 +30,11 @@
 	color: var(--accent-primary);
 
 	&.spin {
-		animation: pulse 1.4s ease-in-out infinite;
+		animation: activityGroupPulse 1.4s ease-in-out infinite;
 	}
 }
 
-@keyframes pulse {
+@keyframes activityGroupPulse {
 	0%,
 	100% {
 		opacity: 0.55;

--- a/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.tsx
+++ b/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import cx from 'classnames';
 import { ChevronDown, ChevronRight, Sparkles } from '@signozhq/icons';
 
@@ -23,9 +23,6 @@ interface ActivityGroupProps {
 }
 
 function formatElapsed(ms: number): string {
-	if (ms < 1000) {
-		return '<1s';
-	}
 	const seconds = Math.round(ms / 1000);
 	if (seconds < 60) {
 		return `${seconds}s`;
@@ -44,6 +41,7 @@ export default function ActivityGroup({
 	isLive = false,
 }: ActivityGroupProps): JSX.Element {
 	const [expanded, setExpanded] = useState(false);
+	const bodyId = useId();
 
 	// Captures the moment this live phase started. Re-stamped on every
 	// false→true transition so a stream that pauses on
@@ -64,9 +62,11 @@ export default function ActivityGroup({
 		if (!isLive) {
 			return undefined;
 		}
+		// Tick once per second — the display is integer-second precision, so
+		// faster ticks would just re-render the bubble for no visible change.
 		const id = window.setInterval(() => {
 			setElapsed(Date.now() - startedAtRef.current);
-		}, 500);
+		}, 1000);
 		return (): void => window.clearInterval(id);
 	}, [isLive]);
 
@@ -75,8 +75,10 @@ export default function ActivityGroup({
 
 	let summary: string;
 	if (isLive) {
+		// Suppress the elapsed token until ≥ 1s — the first tick fires after
+		// 1s anyway, and showing "0s" or "<1s" briefly adds noise.
 		summary =
-			elapsed > 0
+			elapsed >= 1000
 				? `Working… · ${formatElapsed(elapsed)} · ${stepLabel}`
 				: `Working… · ${stepLabel}`;
 	} else {
@@ -87,7 +89,13 @@ export default function ActivityGroup({
 
 	return (
 		<div className={styles.group}>
-			<button type="button" className={styles.header} onClick={toggle}>
+			<button
+				type="button"
+				className={styles.header}
+				onClick={toggle}
+				aria-expanded={expanded}
+				aria-controls={bodyId}
+			>
 				<Sparkles
 					size={12}
 					className={cx(styles.icon, { [styles.spin]: isLive })}
@@ -101,7 +109,7 @@ export default function ActivityGroup({
 			</button>
 
 			{expanded && (
-				<div className={styles.body}>
+				<div id={bodyId} className={styles.body}>
 					{/* eslint-disable react/no-array-index-key */}
 					{items.map((item, i) => {
 						// A thinking step is live only while it's the trailing item in

--- a/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.tsx
+++ b/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.tsx
@@ -2,6 +2,8 @@ import { useEffect, useId, useRef, useState } from 'react';
 import cx from 'classnames';
 import { ChevronDown, ChevronRight, Sparkles } from '@signozhq/icons';
 
+import { formatTime } from 'utils/timeUtils';
+
 import { StreamingToolCall } from '../../types';
 import ThinkingStep from '../ThinkingStep';
 import ToolCallStep from '../ToolCallStep';
@@ -15,21 +17,11 @@ export type ActivityItem =
 interface ActivityGroupProps {
 	items: ActivityItem[];
 	/**
-	 * True while this group is the trailing activity in an ongoing stream —
-	 * the underlying steps may still be growing or a tool may still be
-	 * running. Drives the live "Working…" label and elapsed-time tick.
+	 * True only for the trailing activity group of an active stream — drives
+	 * the live "Working…" label and the elapsed-time tick (which re-stamps on
+	 * approval/clarification resume so wait time isn't counted).
 	 */
 	isLive?: boolean;
-}
-
-function formatElapsed(ms: number): string {
-	const seconds = Math.round(ms / 1000);
-	if (seconds < 60) {
-		return `${seconds}s`;
-	}
-	const m = Math.floor(seconds / 60);
-	const s = seconds % 60;
-	return s === 0 ? `${m}m` : `${m}m ${s}s`;
 }
 
 /**
@@ -79,7 +71,7 @@ export default function ActivityGroup({
 		// 1s anyway, and showing "0s" or "<1s" briefly adds noise.
 		summary =
 			elapsed >= 1000
-				? `Working… · ${formatElapsed(elapsed)} · ${stepLabel}`
+				? `Working… · ${formatTime(elapsed / 1000)} · ${stepLabel}`
 				: `Working… · ${stepLabel}`;
 	} else {
 		summary = `Worked through ${stepLabel}`;

--- a/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.tsx
+++ b/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from 'react';
+import cx from 'classnames';
+import { ChevronDown, ChevronRight, Sparkles } from '@signozhq/icons';
+
+import { StreamingToolCall } from '../../types';
+import ThinkingStep from '../ThinkingStep';
+import ToolCallStep from '../ToolCallStep';
+
+import styles from './ActivityGroup.module.scss';
+
+export type ActivityItem =
+	| { kind: 'thinking'; content: string }
+	| { kind: 'tool'; toolCall: StreamingToolCall };
+
+interface ActivityGroupProps {
+	items: ActivityItem[];
+	/**
+	 * True while this group is the trailing activity in an ongoing stream —
+	 * the underlying steps may still be growing or a tool may still be
+	 * running. Drives the live "Working…" label and elapsed-time tick.
+	 */
+	isLive?: boolean;
+}
+
+function formatElapsed(ms: number): string {
+	if (ms < 1000) {
+		return '<1s';
+	}
+	const seconds = Math.round(ms / 1000);
+	if (seconds < 60) {
+		return `${seconds}s`;
+	}
+	const m = Math.floor(seconds / 60);
+	const s = seconds % 60;
+	return s === 0 ? `${m}m` : `${m}m ${s}s`;
+}
+
+/**
+ * Single collapsed summary row that hides a run of thinking + tool-call steps.
+ * Expands to show each underlying step inline.
+ */
+export default function ActivityGroup({
+	items,
+	isLive = false,
+}: ActivityGroupProps): JSX.Element {
+	const [expanded, setExpanded] = useState(false);
+
+	// Captures the moment this live phase started. Re-stamped on every
+	// false→true transition so a stream that pauses on
+	// approval/clarification and resumes doesn't roll the user's wait time
+	// into the elapsed counter.
+	const startedAtRef = useRef<number>(Date.now());
+	const wasLiveRef = useRef<boolean>(isLive);
+	const [elapsed, setElapsed] = useState(0);
+
+	useEffect(() => {
+		if (isLive && !wasLiveRef.current) {
+			// Entering a fresh live phase — reset the clock.
+			startedAtRef.current = Date.now();
+			setElapsed(0);
+		}
+		wasLiveRef.current = isLive;
+
+		if (!isLive) {
+			return undefined;
+		}
+		const id = window.setInterval(() => {
+			setElapsed(Date.now() - startedAtRef.current);
+		}, 500);
+		return (): void => window.clearInterval(id);
+	}, [isLive]);
+
+	const stepCount = items.length;
+	const stepLabel = stepCount === 1 ? '1 step' : `${stepCount} steps`;
+
+	let summary: string;
+	if (isLive) {
+		summary =
+			elapsed > 0
+				? `Working… · ${formatElapsed(elapsed)} · ${stepLabel}`
+				: `Working… · ${stepLabel}`;
+	} else {
+		summary = `Worked through ${stepLabel}`;
+	}
+
+	const toggle = (): void => setExpanded((v) => !v);
+
+	return (
+		<div className={styles.group}>
+			<button type="button" className={styles.header} onClick={toggle}>
+				<Sparkles
+					size={12}
+					className={cx(styles.icon, { [styles.spin]: isLive })}
+				/>
+				<span className={styles.label}>{summary}</span>
+				{expanded ? (
+					<ChevronDown size={12} className={styles.chevron} />
+				) : (
+					<ChevronRight size={12} className={styles.chevron} />
+				)}
+			</button>
+
+			{expanded && (
+				<div className={styles.body}>
+					{/* eslint-disable react/no-array-index-key */}
+					{items.map((item, i) => {
+						// A thinking step is live only while it's the trailing item in
+						// a trailing live group — once any later event (text or tool)
+						// arrives, the pass is done.
+						const isLastItem = i === items.length - 1;
+						return item.kind === 'thinking' ? (
+							<ThinkingStep
+								key={i}
+								content={item.content}
+								isLive={isLive && isLastItem}
+							/>
+						) : (
+							<ToolCallStep key={i} toolCall={item.toolCall} />
+						);
+					})}
+					{/* eslint-enable react/no-array-index-key */}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.tsx
+++ b/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.tsx
@@ -5,8 +5,11 @@ import { ChevronDown, ChevronRight, Sparkles } from '@signozhq/icons';
 import { formatTime } from 'utils/timeUtils';
 
 import { StreamingToolCall } from '../../types';
-import ThinkingStep from '../ThinkingStep';
-import ToolCallStep from '../ToolCallStep';
+import ThinkingStep, { ThinkingContent, thinkingLabel } from '../ThinkingStep';
+import ToolCallStep, {
+	getToolDisplayLabel,
+	ToolCallContent,
+} from '../ToolCallStep';
 
 import styles from './ActivityGroup.module.scss';
 
@@ -25,8 +28,38 @@ interface ActivityGroupProps {
 }
 
 /**
+ * Single-item groups get a step-specific summary so the user doesn't see a
+ * pointless "Worked through 1 step". Multi-item groups roll up into the
+ * generic "Working… / Worked through N steps" treatment.
+ */
+function buildSummary(
+	items: ActivityItem[],
+	isLive: boolean,
+	elapsed: number,
+): string {
+	if (items.length === 1) {
+		const [only] = items;
+		if (only.kind === 'thinking') {
+			return thinkingLabel(isLive);
+		}
+		return getToolDisplayLabel(only.toolCall);
+	}
+	const stepLabel = `${items.length} steps`;
+	if (!isLive) {
+		return `Worked through ${stepLabel}`;
+	}
+	// Suppress the elapsed token until ≥ 1s — the first tick fires after
+	// 1s anyway, and showing "0s" or "<1s" briefly adds noise.
+	return elapsed >= 1000
+		? `Working… · ${formatTime(elapsed / 1000)} · ${stepLabel}`
+		: `Working… · ${stepLabel}`;
+}
+
+/**
  * Single collapsed summary row that hides a run of thinking + tool-call steps.
- * Expands to show each underlying step inline.
+ * Expands to show each underlying step inline. Used for every activity row
+ * (including single-item ones) so all "what the agent did" rows share a
+ * consistent ✨-led visual contract.
  */
 export default function ActivityGroup({
 	items,
@@ -62,20 +95,8 @@ export default function ActivityGroup({
 		return (): void => window.clearInterval(id);
 	}, [isLive]);
 
-	const stepCount = items.length;
-	const stepLabel = stepCount === 1 ? '1 step' : `${stepCount} steps`;
-
-	let summary: string;
-	if (isLive) {
-		// Suppress the elapsed token until ≥ 1s — the first tick fires after
-		// 1s anyway, and showing "0s" or "<1s" briefly adds noise.
-		summary =
-			elapsed >= 1000
-				? `Working… · ${formatTime(elapsed / 1000)} · ${stepLabel}`
-				: `Working… · ${stepLabel}`;
-	} else {
-		summary = `Worked through ${stepLabel}`;
-	}
+	const summary = buildSummary(items, isLive, elapsed);
+	const isSingle = items.length === 1;
 
 	const toggle = (): void => setExpanded((v) => !v);
 
@@ -102,23 +123,34 @@ export default function ActivityGroup({
 
 			{expanded && (
 				<div id={bodyId} className={styles.body}>
-					{/* eslint-disable react/no-array-index-key */}
-					{items.map((item, i) => {
-						// A thinking step is live only while it's the trailing item in
-						// a trailing live group — once any later event (text or tool)
-						// arrives, the pass is done.
-						const isLastItem = i === items.length - 1;
-						return item.kind === 'thinking' ? (
-							<ThinkingStep
-								key={i}
-								content={item.content}
-								isLive={isLive && isLastItem}
-							/>
+					{isSingle ? (
+						// Single-item: the outer chevron already provides disclosure,
+						// so render the underlying content directly instead of wrapping
+						// it in a second collapsible step row.
+						items[0].kind === 'thinking' ? (
+							<ThinkingContent content={items[0].content} />
 						) : (
-							<ToolCallStep key={i} toolCall={item.toolCall} />
-						);
-					})}
-					{/* eslint-enable react/no-array-index-key */}
+							<ToolCallContent toolCall={items[0].toolCall} />
+						)
+					) : (
+						/* eslint-disable react/no-array-index-key */
+						items.map((item, i) => {
+							// A thinking step is live only while it's the trailing item
+							// in a trailing live group — once any later event (text or
+							// tool) arrives, the pass is done.
+							const isLastItem = i === items.length - 1;
+							return item.kind === 'thinking' ? (
+								<ThinkingStep
+									key={i}
+									content={item.content}
+									isLive={isLive && isLastItem}
+								/>
+							) : (
+								<ToolCallStep key={i} toolCall={item.toolCall} />
+							);
+						})
+						/* eslint-enable react/no-array-index-key */
+					)}
 				</div>
 			)}
 		</div>

--- a/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.tsx
+++ b/frontend/src/container/AIAssistant/components/ActivityGroup/ActivityGroup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import cx from 'classnames';
 import { ChevronDown, ChevronRight, Sparkles } from '@signozhq/icons';
 
@@ -14,8 +14,8 @@ import ToolCallStep, {
 import styles from './ActivityGroup.module.scss';
 
 export type ActivityItem =
-	| { kind: 'thinking'; content: string }
-	| { kind: 'tool'; toolCall: StreamingToolCall };
+	| { id: string; kind: 'thinking'; content: string }
+	| { id: string; kind: 'tool'; toolCall: StreamingToolCall };
 
 interface ActivityGroupProps {
 	items: ActivityItem[];
@@ -66,7 +66,6 @@ export default function ActivityGroup({
 	isLive = false,
 }: ActivityGroupProps): JSX.Element {
 	const [expanded, setExpanded] = useState(false);
-	const bodyId = useId();
 
 	// Captures the moment this live phase started. Re-stamped on every
 	// false→true transition so a stream that pauses on
@@ -78,7 +77,6 @@ export default function ActivityGroup({
 
 	useEffect(() => {
 		if (isLive && !wasLiveRef.current) {
-			// Entering a fresh live phase — reset the clock.
 			startedAtRef.current = Date.now();
 			setElapsed(0);
 		}
@@ -101,28 +99,22 @@ export default function ActivityGroup({
 	const toggle = (): void => setExpanded((v) => !v);
 
 	return (
-		<div className={styles.group}>
-			<button
-				type="button"
-				className={styles.header}
-				onClick={toggle}
-				aria-expanded={expanded}
-				aria-controls={bodyId}
-			>
+		<div className={styles.activityGroup}>
+			<div className={styles.activityHeader} onClick={toggle}>
 				<Sparkles
 					size={12}
-					className={cx(styles.icon, { [styles.spin]: isLive })}
+					className={cx(styles.sparkleIcon, { [styles.iconPulsing]: isLive })}
 				/>
-				<span className={styles.label}>{summary}</span>
+				<span className={styles.activitySummary}>{summary}</span>
 				{expanded ? (
-					<ChevronDown size={12} className={styles.chevron} />
+					<ChevronDown size={12} className={styles.toggleChevron} />
 				) : (
-					<ChevronRight size={12} className={styles.chevron} />
+					<ChevronRight size={12} className={styles.toggleChevron} />
 				)}
-			</button>
+			</div>
 
 			{expanded && (
-				<div id={bodyId} className={styles.body}>
+				<div className={styles.activityBody}>
 					{isSingle ? (
 						// Single-item: the outer chevron already provides disclosure,
 						// so render the underlying content directly instead of wrapping
@@ -133,7 +125,6 @@ export default function ActivityGroup({
 							<ToolCallContent toolCall={items[0].toolCall} />
 						)
 					) : (
-						/* eslint-disable react/no-array-index-key */
 						items.map((item, i) => {
 							// A thinking step is live only while it's the trailing item
 							// in a trailing live group — once any later event (text or
@@ -141,15 +132,14 @@ export default function ActivityGroup({
 							const isLastItem = i === items.length - 1;
 							return item.kind === 'thinking' ? (
 								<ThinkingStep
-									key={i}
+									key={item.id}
 									content={item.content}
 									isLive={isLive && isLastItem}
 								/>
 							) : (
-								<ToolCallStep key={i} toolCall={item.toolCall} />
+								<ToolCallStep key={item.id} toolCall={item.toolCall} />
 							);
 						})
-						/* eslint-enable react/no-array-index-key */
 					)}
 				</div>
 			)}

--- a/frontend/src/container/AIAssistant/components/ActivityGroup/index.ts
+++ b/frontend/src/container/AIAssistant/components/ActivityGroup/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ActivityGroup';
+export type { ActivityItem } from './ActivityGroup';

--- a/frontend/src/container/AIAssistant/components/MessageBubble/MessageBubble.tsx
+++ b/frontend/src/container/AIAssistant/components/MessageBubble/MessageBubble.tsx
@@ -9,11 +9,10 @@ import '../blocks';
 import { useVariant } from '../../VariantContext';
 import { Message, MessageBlock } from '../../types';
 import ActionsSection from '../ActionsSection';
+import ActivityGroup, { ActivityItem } from '../ActivityGroup';
 import { RichCodeBlock } from '../blocks';
 import { MessageContext } from '../MessageContext';
 import MessageFeedback from '../MessageFeedback';
-import ThinkingStep from '../ThinkingStep';
-import ToolCallStep from '../ToolCallStep';
 import UserMessageActions from '../UserMessageActions';
 
 import styles from './MessageBubble.module.scss';
@@ -40,38 +39,60 @@ function SmartPre({ children }: { children?: React.ReactNode }): JSX.Element {
 const MD_PLUGINS = [remarkGfm];
 const MD_COMPONENTS = { code: RichCodeBlock, pre: SmartPre };
 
-/** Renders a single MessageBlock by type. */
-function renderBlock(block: MessageBlock, index: number): JSX.Element {
-	switch (block.type) {
-		case 'thinking':
-			return <ThinkingStep key={index} content={block.content} />;
-		case 'tool_call':
-			// Blocks in a persisted message are always complete — done is always true.
-			return (
-				<ToolCallStep
-					key={index}
-					toolCall={{
-						toolName: block.toolName,
-						input: block.toolInput,
-						result: block.result,
-						done: true,
-						displayText: block.displayText,
-					}}
-				/>
-			);
-		case 'text':
-		default:
-			return (
-				<ReactMarkdown
-					key={index}
-					className={styles.markdown}
-					remarkPlugins={MD_PLUGINS}
-					components={MD_COMPONENTS}
-				>
-					{block.content}
-				</ReactMarkdown>
-			);
+type RenderGroup =
+	| { kind: 'text'; content: string }
+	| { kind: 'activity'; items: ActivityItem[] };
+
+/**
+ * Partition message blocks into render groups so consecutive thinking and
+ * tool_call blocks collapse into a single ActivityGroup row. Text blocks
+ * stand alone, mirroring the streaming view.
+ */
+function groupBlocks(blocks: MessageBlock[]): RenderGroup[] {
+	const groups: RenderGroup[] = [];
+	for (const block of blocks) {
+		if (block.type === 'text') {
+			groups.push({ kind: 'text', content: block.content });
+			continue;
+		}
+		const item: ActivityItem =
+			block.type === 'thinking'
+				? { kind: 'thinking', content: block.content }
+				: {
+						kind: 'tool',
+						// Persisted blocks are always complete.
+						toolCall: {
+							toolName: block.toolName,
+							input: block.toolInput,
+							result: block.result,
+							done: true,
+							displayText: block.displayText,
+						},
+					};
+		const last = groups[groups.length - 1];
+		if (last?.kind === 'activity') {
+			last.items.push(item);
+		} else {
+			groups.push({ kind: 'activity', items: [item] });
+		}
 	}
+	return groups;
+}
+
+function renderGroup(group: RenderGroup, index: number): JSX.Element {
+	if (group.kind === 'text') {
+		return (
+			<ReactMarkdown
+				key={index}
+				className={styles.markdown}
+				remarkPlugins={MD_PLUGINS}
+				components={MD_COMPONENTS}
+			>
+				{group.content}
+			</ReactMarkdown>
+		);
+	}
+	return <ActivityGroup key={index} items={group.items} />;
 }
 
 interface MessageBubbleProps {
@@ -129,7 +150,7 @@ export default function MessageBubble({
 						) : hasBlocks ? (
 							<MessageContext.Provider value={{ messageId: message.id }}>
 								{/* eslint-disable-next-line react/no-array-index-key */}
-								{message.blocks!.map((block, i) => renderBlock(block, i))}
+								{groupBlocks(message.blocks!).map((g, i) => renderGroup(g, i))}
 							</MessageContext.Provider>
 						) : (
 							<MessageContext.Provider value={{ messageId: message.id }}>

--- a/frontend/src/container/AIAssistant/components/MessageBubble/MessageBubble.tsx
+++ b/frontend/src/container/AIAssistant/components/MessageBubble/MessageBubble.tsx
@@ -40,8 +40,8 @@ const MD_PLUGINS = [remarkGfm];
 const MD_COMPONENTS = { code: RichCodeBlock, pre: SmartPre };
 
 type RenderGroup =
-	| { kind: 'text'; content: string }
-	| { kind: 'activity'; items: ActivityItem[] };
+	| { kind: 'text'; id: string; content: string }
+	| { kind: 'activity'; id: string; items: ActivityItem[] };
 
 /**
  * Partition message blocks into render groups so consecutive thinking and
@@ -50,15 +50,16 @@ type RenderGroup =
  */
 function groupBlocks(blocks: MessageBlock[]): RenderGroup[] {
 	const groups: RenderGroup[] = [];
-	for (const block of blocks) {
+	blocks.forEach((block, i) => {
 		if (block.type === 'text') {
-			groups.push({ kind: 'text', content: block.content });
-			continue;
+			groups.push({ kind: 'text', id: `text-${i}`, content: block.content });
+			return;
 		}
 		const item: ActivityItem =
 			block.type === 'thinking'
-				? { kind: 'thinking', content: block.content }
+				? { id: `t-${i}`, kind: 'thinking', content: block.content }
 				: {
+						id: `c-${block.toolCallId}`,
 						kind: 'tool',
 						// Persisted blocks are always complete.
 						toolCall: {
@@ -73,17 +74,17 @@ function groupBlocks(blocks: MessageBlock[]): RenderGroup[] {
 		if (last?.kind === 'activity') {
 			last.items.push(item);
 		} else {
-			groups.push({ kind: 'activity', items: [item] });
+			groups.push({ kind: 'activity', id: `a-${i}`, items: [item] });
 		}
-	}
+	});
 	return groups;
 }
 
-function renderGroup(group: RenderGroup, index: number): JSX.Element {
+function renderGroup(group: RenderGroup): JSX.Element {
 	if (group.kind === 'text') {
 		return (
 			<ReactMarkdown
-				key={index}
+				key={group.id}
 				className={styles.markdown}
 				remarkPlugins={MD_PLUGINS}
 				components={MD_COMPONENTS}
@@ -92,7 +93,7 @@ function renderGroup(group: RenderGroup, index: number): JSX.Element {
 			</ReactMarkdown>
 		);
 	}
-	return <ActivityGroup key={index} items={group.items} />;
+	return <ActivityGroup key={group.id} items={group.items} />;
 }
 
 interface MessageBubbleProps {
@@ -157,8 +158,7 @@ export default function MessageBubble({
 							<p className={styles.text}>{message.content}</p>
 						) : hasBlocks ? (
 							<MessageContext.Provider value={{ messageId: message.id }}>
-								{/* eslint-disable-next-line react/no-array-index-key */}
-								{groups.map((g, i) => renderGroup(g, i))}
+								{groups.map((g) => renderGroup(g))}
 							</MessageContext.Provider>
 						) : (
 							<MessageContext.Provider value={{ messageId: message.id }}>

--- a/frontend/src/container/AIAssistant/components/MessageBubble/MessageBubble.tsx
+++ b/frontend/src/container/AIAssistant/components/MessageBubble/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import cx from 'classnames';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -13,6 +13,8 @@ import ActivityGroup, { ActivityItem } from '../ActivityGroup';
 import { RichCodeBlock } from '../blocks';
 import { MessageContext } from '../MessageContext';
 import MessageFeedback from '../MessageFeedback';
+import ThinkingStep from '../ThinkingStep';
+import ToolCallStep from '../ToolCallStep';
 import UserMessageActions from '../UserMessageActions';
 
 import styles from './MessageBubble.module.scss';
@@ -79,6 +81,14 @@ function groupBlocks(blocks: MessageBlock[]): RenderGroup[] {
 	return groups;
 }
 
+function renderActivityItem(item: ActivityItem, index: number): JSX.Element {
+	return item.kind === 'thinking' ? (
+		<ThinkingStep key={index} content={item.content} />
+	) : (
+		<ToolCallStep key={index} toolCall={item.toolCall} />
+	);
+}
+
 function renderGroup(group: RenderGroup, index: number): JSX.Element {
 	if (group.kind === 'text') {
 		return (
@@ -91,6 +101,11 @@ function renderGroup(group: RenderGroup, index: number): JSX.Element {
 				{group.content}
 			</ReactMarkdown>
 		);
+	}
+	// A lone activity item doesn't need a "Worked through 1 step" wrapper —
+	// render it bare so the chevron on the underlying step does the disclosure.
+	if (group.items.length === 1) {
+		return renderActivityItem(group.items[0], index);
 	}
 	return <ActivityGroup key={index} items={group.items} />;
 }
@@ -110,6 +125,14 @@ export default function MessageBubble({
 	const isCompact = variant === 'panel';
 	const isUser = message.role === 'user';
 	const hasBlocks = !isUser && message.blocks && message.blocks.length > 0;
+
+	// Recompute groups only when the blocks array identity changes — store
+	// updates that don't touch this message's blocks should not re-render the
+	// underlying ThinkingStep/ToolCallStep children.
+	const groups = useMemo(
+		() => (hasBlocks ? groupBlocks(message.blocks!) : []),
+		[hasBlocks, message.blocks],
+	);
 
 	const messageClass = cx(
 		styles.message,
@@ -150,7 +173,7 @@ export default function MessageBubble({
 						) : hasBlocks ? (
 							<MessageContext.Provider value={{ messageId: message.id }}>
 								{/* eslint-disable-next-line react/no-array-index-key */}
-								{groupBlocks(message.blocks!).map((g, i) => renderGroup(g, i))}
+								{groups.map((g, i) => renderGroup(g, i))}
 							</MessageContext.Provider>
 						) : (
 							<MessageContext.Provider value={{ messageId: message.id }}>

--- a/frontend/src/container/AIAssistant/components/MessageBubble/MessageBubble.tsx
+++ b/frontend/src/container/AIAssistant/components/MessageBubble/MessageBubble.tsx
@@ -13,8 +13,6 @@ import ActivityGroup, { ActivityItem } from '../ActivityGroup';
 import { RichCodeBlock } from '../blocks';
 import { MessageContext } from '../MessageContext';
 import MessageFeedback from '../MessageFeedback';
-import ThinkingStep from '../ThinkingStep';
-import ToolCallStep from '../ToolCallStep';
 import UserMessageActions from '../UserMessageActions';
 
 import styles from './MessageBubble.module.scss';
@@ -81,14 +79,6 @@ function groupBlocks(blocks: MessageBlock[]): RenderGroup[] {
 	return groups;
 }
 
-function renderActivityItem(item: ActivityItem, index: number): JSX.Element {
-	return item.kind === 'thinking' ? (
-		<ThinkingStep key={index} content={item.content} />
-	) : (
-		<ToolCallStep key={index} toolCall={item.toolCall} />
-	);
-}
-
 function renderGroup(group: RenderGroup, index: number): JSX.Element {
 	if (group.kind === 'text') {
 		return (
@@ -101,11 +91,6 @@ function renderGroup(group: RenderGroup, index: number): JSX.Element {
 				{group.content}
 			</ReactMarkdown>
 		);
-	}
-	// A lone activity item doesn't need a "Worked through 1 step" wrapper —
-	// render it bare so the chevron on the underlying step does the disclosure.
-	if (group.items.length === 1) {
-		return renderActivityItem(group.items[0], index);
 	}
 	return <ActivityGroup key={index} items={group.items} />;
 }

--- a/frontend/src/container/AIAssistant/components/StreamingMessage/StreamingMessage.tsx
+++ b/frontend/src/container/AIAssistant/components/StreamingMessage/StreamingMessage.tsx
@@ -14,8 +14,6 @@ import ActivityGroup, { ActivityItem } from '../ActivityGroup';
 import ApprovalCard from '../ApprovalCard';
 import { RichCodeBlock } from '../blocks';
 import ClarificationForm from '../ClarificationForm';
-import ThinkingStep from '../ThinkingStep';
-import ToolCallStep from '../ToolCallStep';
 
 import messageStyles from '../MessageBubble/MessageBubble.module.scss';
 import styles from './StreamingMessage.module.scss';
@@ -73,22 +71,6 @@ function groupStreamingEvents(events: StreamingEventItem[]): RenderGroup[] {
 		last.isTrailing = true;
 	}
 	return groups;
-}
-
-/**
- * Renders a single activity item bare — used when an activity group has
- * only one item, so the user doesn't see a "Worked through 1 step" wrapper
- * around a single chevron row.
- */
-function renderBareActivity(
-	item: ActivityItem,
-	index: number,
-	isLive: boolean,
-): JSX.Element {
-	if (item.kind === 'thinking') {
-		return <ThinkingStep key={index} content={item.content} isLive={isLive} />;
-	}
-	return <ToolCallStep key={index} toolCall={item.toolCall} />;
 }
 
 /** Human-readable labels for execution status codes shown before any events arrive. */
@@ -170,12 +152,6 @@ export default function StreamingMessage({
 						);
 					}
 					const groupIsLive = group.isTrailing && !isWaitingOnUser;
-					// Bare-render a lone activity item — the chevron on the
-					// underlying step is enough disclosure without wrapping it in
-					// a "Worked through 1 step" summary row.
-					if (group.items.length === 1) {
-						return renderBareActivity(group.items[0], i, groupIsLive);
-					}
 					return <ActivityGroup key={i} items={group.items} isLive={groupIsLive} />;
 				})}
 				{/* eslint-enable react/no-array-index-key */}

--- a/frontend/src/container/AIAssistant/components/StreamingMessage/StreamingMessage.tsx
+++ b/frontend/src/container/AIAssistant/components/StreamingMessage/StreamingMessage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import cx from 'classnames';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -14,6 +14,8 @@ import ActivityGroup, { ActivityItem } from '../ActivityGroup';
 import ApprovalCard from '../ApprovalCard';
 import { RichCodeBlock } from '../blocks';
 import ClarificationForm from '../ClarificationForm';
+import ThinkingStep from '../ThinkingStep';
+import ToolCallStep from '../ToolCallStep';
 
 import messageStyles from '../MessageBubble/MessageBubble.module.scss';
 import styles from './StreamingMessage.module.scss';
@@ -41,6 +43,12 @@ type RenderGroup =
  * consecutive thinking/tool events fold into a single activity group, text
  * events stay standalone. The last group is flagged as trailing so the
  * caller can drive a "live" indicator on it.
+ *
+ * Invariant relied on by the ActivityGroup elapsed-time timer: once a
+ * group exists at a given array index, later events only extend its
+ * `items` — they never shrink the array or re-key existing groups. That
+ * keeps each ActivityGroup React instance stable across re-renders so the
+ * timer's `wasLive` → `isLive` re-stamp captures the right transition.
  */
 function groupStreamingEvents(events: StreamingEventItem[]): RenderGroup[] {
 	const groups: RenderGroup[] = [];
@@ -65,6 +73,22 @@ function groupStreamingEvents(events: StreamingEventItem[]): RenderGroup[] {
 		last.isTrailing = true;
 	}
 	return groups;
+}
+
+/**
+ * Renders a single activity item bare — used when an activity group has
+ * only one item, so the user doesn't see a "Worked through 1 step" wrapper
+ * around a single chevron row.
+ */
+function renderBareActivity(
+	item: ActivityItem,
+	index: number,
+	isLive: boolean,
+): JSX.Element {
+	if (item.kind === 'thinking') {
+		return <ThinkingStep key={index} content={item.content} isLive={isLive} />;
+	}
+	return <ToolCallStep key={index} toolCall={item.toolCall} />;
 }
 
 /** Human-readable labels for execution status codes shown before any events arrive. */
@@ -113,6 +137,11 @@ export default function StreamingMessage({
 		[messageStyles.compact]: isCompact,
 	});
 
+	// Recompute groups only when the events array identity changes. The
+	// streaming reducer pushes new entries into the same array reference
+	// once per tick, so this naturally invalidates as events arrive.
+	const groups = useMemo(() => groupStreamingEvents(events), [events]);
+
 	return (
 		<div className={messageClass}>
 			<div className={messageStyles.bubble}>
@@ -127,7 +156,7 @@ export default function StreamingMessage({
 				    single ActivityGroup; text events render inline between
 				    them. The trailing group is "live" while streaming is
 				    active and not blocked on the user. */}
-				{groupStreamingEvents(events).map((group, i) => {
+				{groups.map((group, i) => {
 					if (group.kind === 'text') {
 						return (
 							<ReactMarkdown
@@ -140,13 +169,14 @@ export default function StreamingMessage({
 							</ReactMarkdown>
 						);
 					}
-					return (
-						<ActivityGroup
-							key={i}
-							items={group.items}
-							isLive={group.isTrailing && !isWaitingOnUser}
-						/>
-					);
+					const groupIsLive = group.isTrailing && !isWaitingOnUser;
+					// Bare-render a lone activity item — the chevron on the
+					// underlying step is enough disclosure without wrapping it in
+					// a "Worked through 1 step" summary row.
+					if (group.items.length === 1) {
+						return renderBareActivity(group.items[0], i, groupIsLive);
+					}
+					return <ActivityGroup key={i} items={group.items} isLive={groupIsLive} />;
 				})}
 				{/* eslint-enable react/no-array-index-key */}
 

--- a/frontend/src/container/AIAssistant/components/StreamingMessage/StreamingMessage.tsx
+++ b/frontend/src/container/AIAssistant/components/StreamingMessage/StreamingMessage.tsx
@@ -10,11 +10,10 @@ import type {
 
 import { useVariant } from '../../VariantContext';
 import { StreamingEventItem } from '../../types';
+import ActivityGroup, { ActivityItem } from '../ActivityGroup';
 import ApprovalCard from '../ApprovalCard';
 import { RichCodeBlock } from '../blocks';
 import ClarificationForm from '../ClarificationForm';
-import ThinkingStep from '../ThinkingStep';
-import ToolCallStep from '../ToolCallStep';
 
 import messageStyles from '../MessageBubble/MessageBubble.module.scss';
 import styles from './StreamingMessage.module.scss';
@@ -32,6 +31,41 @@ function SmartPre({ children }: { children?: React.ReactNode }): JSX.Element {
 
 const MD_PLUGINS = [remarkGfm];
 const MD_COMPONENTS = { code: RichCodeBlock, pre: SmartPre };
+
+type RenderGroup =
+	| { kind: 'text'; content: string }
+	| { kind: 'activity'; items: ActivityItem[]; isTrailing: boolean };
+
+/**
+ * Partition the streaming event timeline into render groups: runs of
+ * consecutive thinking/tool events fold into a single activity group, text
+ * events stay standalone. The last group is flagged as trailing so the
+ * caller can drive a "live" indicator on it.
+ */
+function groupStreamingEvents(events: StreamingEventItem[]): RenderGroup[] {
+	const groups: RenderGroup[] = [];
+	for (const event of events) {
+		if (event.kind === 'text') {
+			groups.push({ kind: 'text', content: event.content });
+			continue;
+		}
+		const item: ActivityItem =
+			event.kind === 'thinking'
+				? { kind: 'thinking', content: event.content }
+				: { kind: 'tool', toolCall: event.toolCall };
+		const last = groups[groups.length - 1];
+		if (last?.kind === 'activity') {
+			last.items.push(item);
+		} else {
+			groups.push({ kind: 'activity', items: [item], isTrailing: false });
+		}
+	}
+	const last = groups[groups.length - 1];
+	if (last?.kind === 'activity') {
+		last.isTrailing = true;
+	}
+	return groups;
+}
 
 /** Human-readable labels for execution status codes shown before any events arrive. */
 const STATUS_LABEL: Record<string, string> = {
@@ -89,23 +123,29 @@ export default function StreamingMessage({
 				{isEmpty && !statusLabel && <TypingDots />}
 
 				{/* eslint-disable react/no-array-index-key */}
-				{/* Events rendered in arrival order: text, thinking, and tool calls interleaved */}
-				{events.map((event, i) => {
-					if (event.kind === 'tool') {
-						return <ToolCallStep key={i} toolCall={event.toolCall} />;
-					}
-					if (event.kind === 'thinking') {
-						return <ThinkingStep key={i} content={event.content} />;
+				{/* Runs of consecutive thinking + tool events collapse into a
+				    single ActivityGroup; text events render inline between
+				    them. The trailing group is "live" while streaming is
+				    active and not blocked on the user. */}
+				{groupStreamingEvents(events).map((group, i) => {
+					if (group.kind === 'text') {
+						return (
+							<ReactMarkdown
+								key={i}
+								className={messageStyles.markdown}
+								remarkPlugins={MD_PLUGINS}
+								components={MD_COMPONENTS}
+							>
+								{group.content}
+							</ReactMarkdown>
+						);
 					}
 					return (
-						<ReactMarkdown
+						<ActivityGroup
 							key={i}
-							className={messageStyles.markdown}
-							remarkPlugins={MD_PLUGINS}
-							components={MD_COMPONENTS}
-						>
-							{event.content}
-						</ReactMarkdown>
+							items={group.items}
+							isLive={group.isTrailing && !isWaitingOnUser}
+						/>
 					);
 				})}
 				{/* eslint-enable react/no-array-index-key */}

--- a/frontend/src/container/AIAssistant/components/StreamingMessage/StreamingMessage.tsx
+++ b/frontend/src/container/AIAssistant/components/StreamingMessage/StreamingMessage.tsx
@@ -33,8 +33,13 @@ const MD_PLUGINS = [remarkGfm];
 const MD_COMPONENTS = { code: RichCodeBlock, pre: SmartPre };
 
 type RenderGroup =
-	| { kind: 'text'; content: string }
-	| { kind: 'activity'; items: ActivityItem[]; isTrailing: boolean };
+	| { kind: 'text'; id: string; content: string }
+	| {
+			kind: 'activity';
+			id: string;
+			items: ActivityItem[];
+			isTrailing: boolean;
+	  };
 
 /**
  * Partition the streaming event timeline into render groups: runs of
@@ -47,25 +52,32 @@ type RenderGroup =
  * `items` — they never shrink the array or re-key existing groups. That
  * keeps each ActivityGroup React instance stable across re-renders so the
  * timer's `wasLive` → `isLive` re-stamp captures the right transition.
+ * The id fields below piggyback on that invariant: each event's position in
+ * `events` is stable, so the derived id stays stable across re-renders.
  */
 function groupStreamingEvents(events: StreamingEventItem[]): RenderGroup[] {
 	const groups: RenderGroup[] = [];
-	for (const event of events) {
+	events.forEach((event, i) => {
 		if (event.kind === 'text') {
-			groups.push({ kind: 'text', content: event.content });
-			continue;
+			groups.push({ kind: 'text', id: `text-${i}`, content: event.content });
+			return;
 		}
 		const item: ActivityItem =
 			event.kind === 'thinking'
-				? { kind: 'thinking', content: event.content }
-				: { kind: 'tool', toolCall: event.toolCall };
+				? { id: `t-${i}`, kind: 'thinking', content: event.content }
+				: { id: `c-${i}`, kind: 'tool', toolCall: event.toolCall };
 		const last = groups[groups.length - 1];
 		if (last?.kind === 'activity') {
 			last.items.push(item);
 		} else {
-			groups.push({ kind: 'activity', items: [item], isTrailing: false });
+			groups.push({
+				kind: 'activity',
+				id: `a-${i}`,
+				items: [item],
+				isTrailing: false,
+			});
 		}
-	}
+	});
 	const last = groups[groups.length - 1];
 	if (last?.kind === 'activity') {
 		last.isTrailing = true;
@@ -133,16 +145,15 @@ export default function StreamingMessage({
 				)}
 				{isEmpty && !statusLabel && <TypingDots />}
 
-				{/* eslint-disable react/no-array-index-key */}
 				{/* Runs of consecutive thinking + tool events collapse into a
 				    single ActivityGroup; text events render inline between
 				    them. The trailing group is "live" while streaming is
 				    active and not blocked on the user. */}
-				{groups.map((group, i) => {
+				{groups.map((group) => {
 					if (group.kind === 'text') {
 						return (
 							<ReactMarkdown
-								key={i}
+								key={group.id}
 								className={messageStyles.markdown}
 								remarkPlugins={MD_PLUGINS}
 								components={MD_COMPONENTS}
@@ -152,9 +163,10 @@ export default function StreamingMessage({
 						);
 					}
 					const groupIsLive = group.isTrailing && !isWaitingOnUser;
-					return <ActivityGroup key={i} items={group.items} isLive={groupIsLive} />;
+					return (
+						<ActivityGroup key={group.id} items={group.items} isLive={groupIsLive} />
+					);
 				})}
-				{/* eslint-enable react/no-array-index-key */}
 
 				{/* While events are still streaming, append the typing dots so the
 				    user has a clear "more is coming" signal. Hidden when the agent

--- a/frontend/src/container/AIAssistant/components/ThinkingStep/ThinkingStep.tsx
+++ b/frontend/src/container/AIAssistant/components/ThinkingStep/ThinkingStep.tsx
@@ -5,15 +5,27 @@ import styles from './ThinkingStep.module.scss';
 
 interface ThinkingStepProps {
 	content: string;
+	/**
+	 * True only while this thinking pass is still in flight — i.e. the latest
+	 * event in an active stream. Persisted (history) blocks and any thinking
+	 * step followed by a later event default to false and read as
+	 * "Thought for a few seconds". The phrase is intentionally vague: the API
+	 * doesn't persist precise timing, so we'd be inconsistent across fresh
+	 * vs reloaded threads if we tried to show seconds.
+	 */
+	isLive?: boolean;
 }
 
 /** Collapsible thinking row — chevron + label, content in the expanded body. */
 export default function ThinkingStep({
 	content,
+	isLive = false,
 }: ThinkingStepProps): JSX.Element {
 	const [expanded, setExpanded] = useState(false);
 
 	const toggle = (): void => setExpanded((v) => !v);
+
+	const label = isLive ? 'Thinking…' : 'Thought for a few seconds';
 
 	return (
 		<div className={styles.row}>
@@ -23,7 +35,7 @@ export default function ThinkingStep({
 				) : (
 					<ChevronRight size={12} className={styles.chevron} />
 				)}
-				<span className={styles.label}>Thinking</span>
+				<span className={styles.label}>{label}</span>
 			</div>
 
 			{expanded && (

--- a/frontend/src/container/AIAssistant/components/ThinkingStep/ThinkingStep.tsx
+++ b/frontend/src/container/AIAssistant/components/ThinkingStep/ThinkingStep.tsx
@@ -13,6 +13,19 @@ interface ThinkingStepProps {
 	isLive?: boolean;
 }
 
+/** Body of a thinking step — extracted so ActivityGroup can render it directly. */
+export function ThinkingContent({ content }: { content: string }): JSX.Element {
+	return (
+		<div className={styles.body}>
+			<p className={styles.content}>{content}</p>
+		</div>
+	);
+}
+
+export function thinkingLabel(isLive: boolean): string {
+	return isLive ? 'Thinking…' : 'Thought for a few seconds';
+}
+
 /** Collapsible thinking row — chevron + label, content in the expanded body. */
 export default function ThinkingStep({
 	content,
@@ -22,8 +35,6 @@ export default function ThinkingStep({
 
 	const toggle = (): void => setExpanded((v) => !v);
 
-	const label = isLive ? 'Thinking…' : 'Thought for a few seconds';
-
 	return (
 		<div className={styles.row}>
 			<div className={styles.header} onClick={toggle}>
@@ -32,14 +43,10 @@ export default function ThinkingStep({
 				) : (
 					<ChevronRight size={12} className={styles.chevron} />
 				)}
-				<span className={styles.label}>{label}</span>
+				<span className={styles.label}>{thinkingLabel(isLive)}</span>
 			</div>
 
-			{expanded && (
-				<div className={styles.body}>
-					<p className={styles.content}>{content}</p>
-				</div>
-			)}
+			{expanded && <ThinkingContent content={content} />}
 		</div>
 	);
 }

--- a/frontend/src/container/AIAssistant/components/ThinkingStep/ThinkingStep.tsx
+++ b/frontend/src/container/AIAssistant/components/ThinkingStep/ThinkingStep.tsx
@@ -6,12 +6,9 @@ import styles from './ThinkingStep.module.scss';
 interface ThinkingStepProps {
 	content: string;
 	/**
-	 * True only while this thinking pass is still in flight — i.e. the latest
-	 * event in an active stream. Persisted (history) blocks and any thinking
-	 * step followed by a later event default to false and read as
-	 * "Thought for a few seconds". The phrase is intentionally vague: the API
-	 * doesn't persist precise timing, so we'd be inconsistent across fresh
-	 * vs reloaded threads if we tried to show seconds.
+	 * When false, label reads "Thought for a few seconds" — intentionally
+	 * vague because the API doesn't persist precise timing, so showing
+	 * seconds would be inconsistent between fresh and reloaded threads.
 	 */
 	isLive?: boolean;
 }

--- a/frontend/src/container/AIAssistant/components/ToolCallStep/ToolCallStep.tsx
+++ b/frontend/src/container/AIAssistant/components/ToolCallStep/ToolCallStep.tsx
@@ -10,24 +10,58 @@ interface ToolCallStepProps {
 	toolCall: StreamingToolCall;
 }
 
+/**
+ * Server-supplied `displayText` is the human-friendly title the backend
+ * wants surfaced. Falls back to a derived label
+ * ("signoz_get_dashboard" → "Get Dashboard") when missing.
+ */
+export function getToolDisplayLabel(toolCall: StreamingToolCall): string {
+	const { toolName, displayText } = toolCall;
+	if (displayText && displayText.trim().length > 0) {
+		return displayText;
+	}
+	return toolName
+		.replace(/^[a-z]+_/, '') // strip prefix like "signoz_"
+		.replace(/_/g, ' ')
+		.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Body of a tool-call step — extracted so ActivityGroup can render it directly. */
+export function ToolCallContent({
+	toolCall,
+}: {
+	toolCall: StreamingToolCall;
+}): JSX.Element {
+	const { toolName, input, result, done } = toolCall;
+	return (
+		<div className={styles.body}>
+			<div className={styles.section}>
+				<span className={styles.sectionLabel}>Tool</span>
+				<span className={styles.toolName}>{toolName}</span>
+			</div>
+			<div className={styles.section}>
+				<span className={styles.sectionLabel}>Input</span>
+				<pre className={styles.json}>{JSON.stringify(input, null, 2)}</pre>
+			</div>
+			{done && result !== undefined && (
+				<div className={styles.section}>
+					<span className={styles.sectionLabel}>Output</span>
+					<pre className={styles.json}>
+						{typeof result === 'string' ? result : JSON.stringify(result, null, 2)}
+					</pre>
+				</div>
+			)}
+		</div>
+	);
+}
+
 /** Collapsible tool-call row — chevron + label, in/out detail in the body. */
 export default function ToolCallStep({
 	toolCall,
 }: ToolCallStepProps): JSX.Element {
 	const [expanded, setExpanded] = useState(false);
-	const { toolName, input, result, done, displayText } = toolCall;
-
-	// Prefer the server-supplied `displayText` from `ToolCallEventDTO` —
-	// it's the human-friendly title the backend wants surfaced. Fall back
-	// to a derived label ("signoz_get_dashboard" → "Get Dashboard") when
-	// the field is empty / null / missing.
-	const label =
-		displayText && displayText.trim().length > 0
-			? displayText
-			: toolName
-					.replace(/^[a-z]+_/, '') // strip prefix like "signoz_"
-					.replace(/_/g, ' ')
-					.replace(/\b\w/g, (c) => c.toUpperCase());
+	const { done } = toolCall;
+	const label = getToolDisplayLabel(toolCall);
 
 	const toggle = (): void => setExpanded((v) => !v);
 
@@ -44,26 +78,7 @@ export default function ToolCallStep({
 				<span className={styles.label}>{label}</span>
 			</div>
 
-			{expanded && (
-				<div className={styles.body}>
-					<div className={styles.section}>
-						<span className={styles.sectionLabel}>Tool</span>
-						<span className={styles.toolName}>{toolName}</span>
-					</div>
-					<div className={styles.section}>
-						<span className={styles.sectionLabel}>Input</span>
-						<pre className={styles.json}>{JSON.stringify(input, null, 2)}</pre>
-					</div>
-					{done && result !== undefined && (
-						<div className={styles.section}>
-							<span className={styles.sectionLabel}>Output</span>
-							<pre className={styles.json}>
-								{typeof result === 'string' ? result : JSON.stringify(result, null, 2)}
-							</pre>
-						</div>
-					)}
-				</div>
-			)}
+			{expanded && <ToolCallContent toolCall={toolCall} />}
 		</div>
 	);
 }


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Long sequences of `Thinking` / `Searched tools…` / `Loaded skill…` rows in the AI Assistant chat pushed the actual answer below the fold and made every response feel verbose, even when the model only did 2–3 steps. This PR routes **every** activity row (single-item or multi-item) through a single `ActivityGroup` component so all "what the agent did" rows share one visual contract: `✦ <summary>  ›` aligned at the same x, click to expand inline.

The summary adapts to the items:
- 1 thinking item → `✦ Thinking…` (live) / `✦ Thought for a few seconds` (settled)
- 1 tool call → `✦ <tool's display text>` (e.g. `✦ Get Dashboard`)
- N items → `✦ Working… · Xs · N steps` (live) / `✦ Worked through N steps` (settled)

Single-item groups expand directly to the underlying content (no second chevron disclosure); multi-item groups expand to a list of per-step `ThinkingStep` / `ToolCallStep` rows as before. The "Thought for a few seconds" wording is intentionally vague because the API doesn't persist precise timing — matches what we show for reloaded history threads.

#### Screenshots / Screen Recordings

Before
<img width="1508" height="907" alt="Screenshot 2026-05-19 at 22 46 07" src="https://github.com/user-attachments/assets/2516e592-e08d-421d-88a6-2eb42e811cf6" />

After
<img width="2304" height="1254" alt="Screenshot 2026-05-20 at 13 18 58" src="https://github.com/user-attachments/assets/e112579a-2e0d-4547-be7f-a6fe336e1f69" />


| Before (9 stacked rows) | After (collapsed) | After (expanded) |
|---|---|---|
| \`> Thinking\` × 5 interleaved with \`> Searched tools…\`, \`> Loaded skill…\`, \`> Searched docs…\` | \`✦ Worked through 9 steps\` on one row | Underlying step rows revealed inline; tool-call \`INPUT\` / \`OUTPUT\` JSON uses the full bubble width |

#### Issues closed by this PR

N/A

---

### ✅ Change Type

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy

- Tests added/updated: **N/A** — the AI Assistant module has no existing unit/spec coverage; this PR matches that convention. The component is pure render logic against typed input.
- Manual verification:
  - Triggered a multi-step assistant response (`how to instrument?` → 9 thinking + tool steps): verified the live \`Working… · Xs · N steps\` ticker advances once per second, freezes to \`Worked through N steps\` once text streams.
  - Expanded the collapsed row: each underlying \`ThinkingStep\` / \`ToolCallStep\` renders flush with the parent label; tool-call \`INPUT\` / \`OUTPUT\` JSON spans the full bubble width.
  - Reloaded a history thread: thinking rows read \`Thought for a few seconds\` (same wording as fresh streams), confirming no dependency on server-stored timing.
  - Single-step message: renders as \`✦ Thought for a few seconds\` (or the tool's display label) at the same x as multi-item groups — expanding shows the body content directly with no inner chevron.
  - Approval-pause path: while paused, the trailing group label freezes; on resume, the elapsed-time counter restarts from zero rather than rolling the user's wait time into the duration.
- Edge cases covered: empty events array, all-text message (no activity groups), interleaved \`[thinking, text, tool, text]\` (each becomes its own group, no trailing live group), compact panel variant.
- Lint: \`oxlint\` introduces zero new errors/warnings on touched files.
- Typecheck: \`yarn tsc --noEmit\` clean.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius**: AI Assistant chat UI only. No store, API, or backend changes — purely a render-layer reshuffle of the existing \`MessageBlock\` / \`StreamingEventItem\` data.
- **Potential regressions**: text/tool/thinking interleaving and approval/clarification pause paths are the highest-risk flows, since they exercise the partition logic and the \`isLive\` propagation. Both are verified manually above. Persisted history threads use the same \`groupBlocks\` path as fresh streams, so a regression would surface immediately on any reopened conversation.
- **Rollback plan**: revert the feature commits on this branch. The PR has no migrations, schema changes, or persisted state — reverting restores the previous flat-list rendering with no data cleanup required.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | AI Assistant chat collapses thinking + tool-call steps behind a single expandable summary row so the assistant's answer stays in view. |

---

### 📋 Checklist

- [x] Tests added or explicitly not required (no existing AI Assistant test coverage to extend)
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered (renders against the existing block schema; opportunistic forward-compat read for any future timing fields)

---

## 👀 Notes for Reviewers

- Every activity row now goes through \`ActivityGroup\` — including single-item ones. The component owns the summary text (\`buildSummary\`) and decides whether the expanded body is the underlying content directly (single-item) or a list of per-step rows (multi-item). This collapses two previously-divergent visual treatments into one.
- \`ThinkingStep\` and \`ToolCallStep\` now expose \`ThinkingContent\` / \`ToolCallContent\` body sub-components and \`thinkingLabel\` / \`getToolDisplayLabel\` helpers, so \`ActivityGroup\` can render single-item bodies without duplicating markup or relying on a "force-expanded headerless" mode on the step components.
- The two partition helpers (\`groupBlocks\` in \`MessageBubble.tsx\`, \`groupStreamingEvents\` in \`StreamingMessage.tsx\`) intentionally duplicate the same contract — \`MessageBlock\` and \`StreamingEventItem\` are separate types and we render into a shared \`ActivityItem\`. If a third call-site lands, factor out into \`types.ts\`; not worth the abstraction yet.
- \`ActivityGroup\`'s elapsed timer relies on each group's React instance surviving across re-renders. The invariant is documented in \`groupStreamingEvents\` (events only ever append; existing groups are never re-keyed). If a future change shrinks or re-orders the streaming events array, the \`wasLive → isLive\` re-stamp logic needs revisiting.
- \`aria-expanded\` + \`aria-controls\` are wired up on the disclosure button; the existing \`ThinkingStep\` is still a \`<div onClick>\` (pre-existing — out of scope).