### PR TITLE
fix(metrics-explorer): show actual timestamp in metric sidesheet 'Last Received' tooltip

### DIFF
--- a/frontend/src/container/LogDetailedView/FieldRenderer.styles.scss
+++ b/frontend/src/container/LogDetailedView/FieldRenderer.styles.scss
@@ -22,3 +22,9 @@
 		gap: 8px;
 	}
 }
+
+// FieldRenderer is used inside log/trace/metric detail drawers (z-index 1000).
+// The design-system tooltip defaults to z-index 50 and would render behind them.
+.field-renderer-tooltip-content {
+	--tooltip-z-index: 1000;
+}

--- a/frontend/src/container/LogDetailedView/FieldRenderer.tsx
+++ b/frontend/src/container/LogDetailedView/FieldRenderer.tsx
@@ -1,4 +1,5 @@
-import { Divider, Tooltip } from 'antd';
+import { Divider } from 'antd';
+import { TooltipSimple } from '@signozhq/ui/tooltip';
 import { Typography } from '@signozhq/ui/typography';
 
 import { TagContainer, TagLabel, TagValue } from './FieldRenderer.styles';
@@ -7,6 +8,10 @@ import { getFieldAttributes } from './utils';
 
 import './FieldRenderer.styles.scss';
 
+const TOOLTIP_CONTENT_PROPS = {
+	className: 'field-renderer-tooltip-content',
+};
+
 function FieldRenderer({ field }: FieldRendererProps): JSX.Element {
 	const { dataType, newField, logType } = getFieldAttributes(field);
 
@@ -14,11 +19,16 @@ function FieldRenderer({ field }: FieldRendererProps): JSX.Element {
 		<span className="field-renderer-container">
 			{dataType && newField && logType ? (
 				<>
-					<Tooltip placement="left" title={newField} mouseLeaveDelay={0}>
+					<TooltipSimple
+						title={newField}
+						side="left"
+						tooltipContentProps={TOOLTIP_CONTENT_PROPS}
+						arrow
+					>
 						<Typography.Text truncate={1} className="label">
 							{newField}{' '}
 						</Typography.Text>
-					</Tooltip>
+					</TooltipSimple>
 
 					<div className="tags">
 						<TagContainer>

--- a/frontend/src/container/MetricsExplorer/MetricDetails/Highlights.tsx
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/Highlights.tsx
@@ -1,8 +1,11 @@
 import { Color } from '@signozhq/design-tokens';
-import { Button, Spin, Tooltip } from 'antd';
+import { Button, Spin } from 'antd';
+import { TooltipSimple } from '@signozhq/ui/tooltip';
 import { Typography } from '@signozhq/ui/typography';
 import { useGetMetricHighlights } from 'api/generated/services/metrics';
+import { DATE_TIME_FORMATS } from 'constants/dateTimeFormats';
 import { Info } from '@signozhq/icons';
+import { useTimezone } from 'providers/Timezone';
 
 import { formatNumberIntoHumanReadableFormat } from '../Summary/utils';
 import { HighlightsProps } from './types';
@@ -10,6 +13,10 @@ import {
 	formatNumberToCompactFormat,
 	formatTimestampToReadableDate,
 } from './utils';
+
+const TOOLTIP_CONTENT_PROPS = {
+	className: 'metric-highlights-tooltip-content',
+};
 
 function Highlights({ metricName }: HighlightsProps): JSX.Element {
 	const {
@@ -39,6 +46,13 @@ function Highlights({ metricName }: HighlightsProps): JSX.Element {
 	const lastReceivedText = formatTimestampToReadableDate(
 		metricHighlights?.lastReceived,
 	);
+	const { formatTimezoneAdjustedTimestamp } = useTimezone();
+	const lastReceivedTooltipText = metricHighlights?.lastReceived
+		? `Last received on ${formatTimezoneAdjustedTimestamp(
+				metricHighlights.lastReceived,
+				DATE_TIME_FORMATS.DASH_DATETIME_UTC,
+			)}`
+		: 'No data received yet';
 
 	if (isErrorMetricHighlights) {
 		return (
@@ -90,27 +104,42 @@ function Highlights({ metricName }: HighlightsProps): JSX.Element {
 							className="metric-details-grid-value"
 							data-testid="metric-highlights-data-points"
 						>
-							<Tooltip title={metricHighlights?.dataPoints?.toLocaleString()}>
-								{formatNumberIntoHumanReadableFormat(metricHighlights?.dataPoints ?? 0)}
-							</Tooltip>
+							<TooltipSimple
+								title={metricHighlights?.dataPoints?.toLocaleString()}
+								tooltipContentProps={TOOLTIP_CONTENT_PROPS}
+								arrow
+							>
+								<span>
+									{formatNumberIntoHumanReadableFormat(
+										metricHighlights?.dataPoints ?? 0,
+									)}
+								</span>
+							</TooltipSimple>
 						</Typography.Text>
 						<Typography.Text
 							className="metric-details-grid-value"
 							data-testid="metric-highlights-time-series-total"
 						>
-							<Tooltip
-								title="Active time series are those that have received data points in the last 1
-							hour."
-								placement="top"
+							<TooltipSimple
+								title="Active time series are those that have received data points in the last 1 hour."
+								side="top"
+								tooltipContentProps={TOOLTIP_CONTENT_PROPS}
+								arrow
 							>
 								<span>{`${timeSeriesTotal} total ⎯ ${timeSeriesActive} active`}</span>
-							</Tooltip>
+							</TooltipSimple>
 						</Typography.Text>
 						<Typography.Text
 							className="metric-details-grid-value"
 							data-testid="metric-highlights-last-received"
 						>
-							<Tooltip title={lastReceivedText}>{lastReceivedText}</Tooltip>
+							<TooltipSimple
+								title={lastReceivedTooltipText}
+								tooltipContentProps={TOOLTIP_CONTENT_PROPS}
+								arrow
+							>
+								<span>{lastReceivedText}</span>
+							</TooltipSimple>
 						</Typography.Text>
 					</>
 				)}

--- a/frontend/src/container/MetricsExplorer/MetricDetails/MetricDetails.styles.scss
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/MetricDetails.styles.scss
@@ -510,6 +510,12 @@
 	color: var(--bg-robin-400) !important;
 }
 
+// The MetricDetails Drawer sits at z-index 1000; the design-system tooltip
+// defaults to z-index 50 and would otherwise render behind the drawer.
+.metric-highlights-tooltip-content {
+	--tooltip-z-index: 1000;
+}
+
 @keyframes fade-in-out {
 	0% {
 		opacity: 0;

--- a/frontend/src/container/MetricsExplorer/MetricDetails/__tests__/Highlights.test.tsx
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/__tests__/Highlights.test.tsx
@@ -1,9 +1,21 @@
 import { render, screen } from '@testing-library/react';
+import { TooltipProvider } from '@signozhq/ui/tooltip';
 import * as metricsExplorerHooks from 'api/generated/services/metrics';
+import TimezoneProvider from 'providers/Timezone';
 
 import Highlights from '../Highlights';
 import { formatTimestampToReadableDate } from '../utils';
 import { getMockMetricHighlightsData, MOCK_METRIC_NAME } from './testUtlls';
+
+function renderHighlights(metricName: string): ReturnType<typeof render> {
+	return render(
+		<TimezoneProvider>
+			<TooltipProvider>
+				<Highlights metricName={metricName} />
+			</TooltipProvider>
+		</TimezoneProvider>,
+	);
+}
 
 const useGetMetricHighlightsMock = jest.spyOn(
 	metricsExplorerHooks,
@@ -16,7 +28,7 @@ describe('Highlights', () => {
 	});
 
 	it('should render all highlights data correctly', () => {
-		render(<Highlights metricName={MOCK_METRIC_NAME} />);
+		renderHighlights(MOCK_METRIC_NAME);
 
 		const dataPoints = screen.getByTestId('metric-highlights-data-points');
 		const timeSeriesTotal = screen.getByTestId(
@@ -41,7 +53,7 @@ describe('Highlights', () => {
 			),
 		);
 
-		render(<Highlights metricName={MOCK_METRIC_NAME} />);
+		renderHighlights(MOCK_METRIC_NAME);
 
 		expect(
 			screen.getByTestId('metric-highlights-error-state'),
@@ -58,7 +70,7 @@ describe('Highlights', () => {
 			),
 		);
 
-		render(<Highlights metricName={MOCK_METRIC_NAME} />);
+		renderHighlights(MOCK_METRIC_NAME);
 
 		expect(screen.getByText('SAMPLES')).toBeInTheDocument();
 		expect(screen.getByText('TIME SERIES')).toBeInTheDocument();


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
In the Metrics Explorer → metric sidesheet, the "Last Received" entry shows the value relatively (e.g. *"2 minutes ago"*). Hovering should reveal the actual ingestion timestamp, but the tooltip was rendering the same relative string. The tooltip surface also blended into the dark drawer background — no border, no arrow, no visual feedback that it was a distinct surface.

This PR makes the tooltip show the real timestamp (timezone-adjusted) and replaces the antd `Tooltip` instances in the Highlights panel and shared `FieldRenderer` with the design-system `TooltipSimple`, which has a visible border, arrow, and proper hover feedback.

#### Screenshots / Screen Recordings
**Before**

https://github.com/user-attachments/assets/4063f583-b743-4372-b4fe-e08b82ddd748

**After**

https://github.com/user-attachments/assets/0951b831-2b6c-450e-8667-ac8e539fbff5

#### Issues closed by this PR
Closes https://github.com/SigNoz/signoz/issues/11364

---

### ✅ Change Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
- `Highlights.tsx` passed the same relative-time string to both the tooltip `title` and the rendered text, so hover never revealed the absolute timestamp.
- The antd `Tooltip` used in this panel and in the shared `FieldRenderer` did not produce visible feedback against the dark drawer background — no border, no arrow.
- The design-system `TooltipSimple` defaults to `z-index: 50`, which sits *behind* the antd `Drawer` (`z-index: 1000`); a naive swap would render the tooltip invisible inside the metric/log detail sidesheets.