### PR TITLE
fix(alerts): ensure tabs reset the url state

### DIFF
--- a/frontend/src/container/ListAlertRules/hooks.ts
+++ b/frontend/src/container/ListAlertRules/hooks.ts
@@ -1,9 +1,4 @@
-import {
-	Options,
-	parseAsInteger,
-	useQueryState,
-	UseQueryStateReturn,
-} from 'nuqs';
+import { Options, useQueryState, UseQueryStateReturn } from 'nuqs';
 import { parseAsJsonNoValidate } from 'utils/nuqsParsers';
 
 const defaultNuqsOptions: Options = {
@@ -16,23 +11,6 @@ export const ALERT_RULES_PARAMS = {
 	RULE_TYPE: 'ruleType',
 	FILTERS: 'alertRulesFilters',
 } as const;
-
-export const useAlertRulesPage = (): UseQueryStateReturn<number, number> =>
-	useQueryState(
-		ALERT_RULES_PARAMS.PAGE,
-		parseAsInteger.withDefault(1).withOptions(defaultNuqsOptions),
-	);
-
-export const useAlertRulesRuleType = (): UseQueryStateReturn<
-	string[],
-	string[]
-> =>
-	useQueryState(
-		ALERT_RULES_PARAMS.RULE_TYPE,
-		parseAsJsonNoValidate<string[]>()
-			.withDefault([])
-			.withOptions(defaultNuqsOptions),
-	);
 
 export const useAlertRulesFilters = (): UseQueryStateReturn<
 	string[],

--- a/frontend/src/container/TriggeredAlerts/hooks.ts
+++ b/frontend/src/container/TriggeredAlerts/hooks.ts
@@ -7,8 +7,8 @@ const defaultNuqsOptions: Options = {
 
 export const TRIGGERED_ALERTS_PARAMS = {
 	FILTERS: 'alertFilters',
-	GROUP_BY: 'alertGroupBy',
-	SEARCH: 'alertSearch',
+	GROUP_BY: 'groupBy',
+	SEARCH: 'search',
 } as const;
 
 export const useTriggeredAlertsFilters = (): UseQueryStateReturn<

--- a/frontend/src/pages/AlertList/__tests__/AlertList.test.tsx
+++ b/frontend/src/pages/AlertList/__tests__/AlertList.test.tsx
@@ -20,8 +20,6 @@ jest.mock('react-router-dom', () => ({
 }));
 
 let mockUrlQuery: URLSearchParams;
-const mockSet = jest.fn();
-const mockDelete = jest.fn();
 jest.mock('hooks/useUrlQuery', () => ({
 	__esModule: true,
 	default: (): URLSearchParams => mockUrlQuery,
@@ -78,25 +76,11 @@ const mockLocation = (pathname: string): void => {
 };
 
 const mockQueryParams = (params: Record<string, string | null>): void => {
-	const realUrlQuery = new URLSearchParams();
+	mockUrlQuery = new URLSearchParams();
 	Object.entries(params).forEach(([key, value]) => {
 		if (value !== null) {
-			realUrlQuery.set(key, value);
+			mockUrlQuery.set(key, value);
 		}
-	});
-
-	mockSet.mockImplementation((key: string, value: string) => {
-		realUrlQuery.set(key, value);
-	});
-	mockDelete.mockImplementation((key: string) => {
-		realUrlQuery.delete(key);
-	});
-
-	mockUrlQuery = Object.create(URLSearchParams.prototype, {
-		set: { value: mockSet },
-		delete: { value: mockDelete },
-		toString: { value: (): string => realUrlQuery.toString() },
-		get: { value: (key: string): string | null => realUrlQuery.get(key) },
 	});
 };
 
@@ -170,8 +154,6 @@ describe('AlertList', () => {
 
 			clickTab(TRIGGERED_ALERTS_TEXT);
 
-			expect(mockSet).toHaveBeenCalledWith('tab', 'TriggeredAlerts');
-			expect(mockDelete).toHaveBeenCalledWith('subTab');
 			expect(mockSafeNavigate).toHaveBeenCalledWith('/alerts?tab=TriggeredAlerts');
 		});
 
@@ -183,8 +165,6 @@ describe('AlertList', () => {
 
 			clickTab(ALERT_RULES_TEXT);
 
-			expect(mockSet).toHaveBeenCalledWith('tab', 'AlertRules');
-			expect(mockDelete).toHaveBeenCalledWith('subTab');
 			expect(mockSafeNavigate).toHaveBeenCalledWith('/alerts?tab=AlertRules');
 		});
 	});
@@ -224,8 +204,6 @@ describe('AlertList', () => {
 
 				clickTab(CONFIGURATION_TEXT);
 
-				expect(mockSet).toHaveBeenCalledWith('tab', CONFIGURATION_TEXT);
-				expect(mockSet).toHaveBeenCalledWith('subTab', PLANNED_DOWNTIME_SUB_TAB);
 				expect(mockSafeNavigate).toHaveBeenCalledWith(
 					`/alerts?tab=Configuration&subTab=${PLANNED_DOWNTIME_SUB_TAB}`,
 				);
@@ -255,7 +233,6 @@ describe('AlertList', () => {
 
 				clickTab(ALERT_RULES_TEXT);
 
-				expect(mockDelete).toHaveBeenCalledWith('subTab');
 				expect(mockSafeNavigate).toHaveBeenCalledWith('/alerts?tab=AlertRules');
 			});
 		});

--- a/frontend/src/pages/AlertList/index.tsx
+++ b/frontend/src/pages/AlertList/index.tsx
@@ -29,12 +29,13 @@ function AllAlertList(): JSX.Element {
 
 	const handleConfigurationTabChange = useCallback(
 		(subTab: string): void => {
-			urlQuery.set('tab', AlertListTabs.CONFIGURATION);
-			urlQuery.set('subTab', subTab);
-			urlQuery.delete('search');
-			safeNavigate(`/alerts?${urlQuery.toString()}`);
+			const queryParams = new URLSearchParams();
+
+			queryParams.set('tab', AlertListTabs.CONFIGURATION);
+			queryParams.set('subTab', subTab);
+			safeNavigate(`/alerts?${queryParams.toString()}`);
 		},
-		[safeNavigate, urlQuery],
+		[safeNavigate],
 	);
 
 	const configurationTab = useMemo(() => {
@@ -103,24 +104,20 @@ function AllAlertList(): JSX.Element {
 			items={items}
 			activeKey={tab || AlertListTabs.ALERT_RULES}
 			onChange={(tab): void => {
-				urlQuery.set('tab', tab);
+				const queryParams = new URLSearchParams();
+
+				queryParams.set('tab', tab);
 
 				// If navigating to Configuration tab, set default subTab
 				if (tab === AlertListTabs.CONFIGURATION) {
 					const currentSubTab = subTab || AlertListSubTabs.PLANNED_DOWNTIME;
-					urlQuery.set('subTab', currentSubTab);
+					queryParams.set('subTab', currentSubTab);
 				} else {
 					// Clear subTab when navigating out of Configuration tab
-					urlQuery.delete('subTab');
+					queryParams.delete('subTab');
 				}
 
-				// Clear search and table params when navigating to any tab
-				urlQuery.delete('search');
-				urlQuery.delete('page');
-				urlQuery.delete('limit');
-				urlQuery.delete('orderBy');
-
-				safeNavigate(`/alerts?${urlQuery.toString()}`);
+				safeNavigate(`/alerts?${queryParams.toString()}`);
 			}}
 			className={`alerts-container ${
 				isAlertHistory || isAlertOverview ? 'alert-details-tabs' : ''


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

I don't think we have any hard reason to keep the params while changing tabs.

With #11277, the filters were being persisted in the URL after changing between tabs and I don't think this should be the default behavior because none of the filters (except search) works in other pages, so keeping the state in URL just pollute the URL.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

https://github.com/user-attachments/assets/ebea4109-7b9e-4d2c-a4d8-f13fc08fe973


After:

https://github.com/user-attachments/assets/7650f74a-d5dd-4da8-aef5-c5baf25f21cc

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: -
- Manual verification: Yes
- Edge cases covered: -

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
