### PR TITLE
fix(alerts): use rule org ID for scheduled alert notifications

### DIFF
--- a/ee/query-service/rules/manager_test.go
+++ b/ee/query-service/rules/manager_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/prometheus"
 	"github.com/SigNoz/signoz/pkg/prometheus/prometheustest"
 	"github.com/SigNoz/signoz/pkg/query-service/rules"
-	"github.com/SigNoz/signoz/pkg/sqlstore"
-	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstoretest"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
 	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
@@ -60,14 +58,6 @@ func TestManager_TestNotification_SendUnmatched_ThresholdRule(t *testing.T) {
 				},
 				ManagerOptionsHook: func(opts *rules.ManagerOptions) {
 					opts.PrepareTestRuleFunc = TestNotification
-				},
-				SqlStoreHook: func(store sqlstore.SQLStore) {
-					mockStore := store.(*sqlstoretest.Provider)
-					// Mock the organizations query that SendAlerts makes
-					// Bun generates: SELECT id FROM organizations LIMIT 1 (or SELECT "id" FROM "organizations" LIMIT 1)
-					orgRows := mockStore.Mock().NewRows([]string{"id"}).AddRow(orgID.StringValue())
-					// Match bun's generated query pattern - bun may quote identifiers
-					mockStore.Mock().ExpectQuery("SELECT (.+) FROM (.+)organizations(.+) LIMIT (.+)").WillReturnRows(orgRows)
 				},
 				TelemetryStoreHook: func(store telemetrystore.TelemetryStore) {
 					telemetryStore := store.(*telemetrystoretest.Provider)
@@ -172,12 +162,6 @@ func TestManager_TestNotification_SendUnmatched_PromRule(t *testing.T) {
 							triggeredTestAlerts = append(triggeredTestAlerts, args.Get(3).(map[*alertmanagertypes.PostableAlert][]string))
 						}).Return(nil).Times(tc.ExpectAlerts)
 					}
-				},
-				SqlStoreHook: func(store sqlstore.SQLStore) {
-					mockStore := store.(*sqlstoretest.Provider)
-					// Mock the organizations query that SendAlerts makes
-					orgRows := mockStore.Mock().NewRows([]string{"id"}).AddRow(orgID.StringValue())
-					mockStore.Mock().ExpectQuery("SELECT (.+) FROM (.+)organizations(.+) LIMIT (.+)").WillReturnRows(orgRows)
 				},
 				TelemetryStoreHook: func(store telemetrystore.TelemetryStore) {
 					mockStore := store.(*telemetrystoretest.Provider)

--- a/pkg/query-service/rules/base_rule.go
+++ b/pkg/query-service/rules/base_rule.go
@@ -341,20 +341,6 @@ func (r *BaseRule) ActiveAlerts() []*ruletypes.Alert {
 }
 
 func (r *BaseRule) SendAlerts(ctx context.Context, ts time.Time, resendDelay time.Duration, interval time.Duration, notifyFunc NotifyFunc) {
-	var orgID string
-	err := r.
-		sqlstore.
-		BunDB().
-		NewSelect().
-		Table("organizations").
-		ColumnExpr("id").
-		Limit(1).
-		Scan(ctx, &orgID)
-	if err != nil {
-		r.logger.ErrorContext(ctx, "failed to get org ids", errors.Attr(err))
-		return
-	}
-
 	alerts := []*ruletypes.Alert{}
 	r.ForEachActiveAlert(func(alert *ruletypes.Alert) {
 		if alert.NeedsSending(ts, resendDelay) {
@@ -368,7 +354,7 @@ func (r *BaseRule) SendAlerts(ctx context.Context, ts time.Time, resendDelay tim
 			alerts = append(alerts, &anew)
 		}
 	})
-	notifyFunc(ctx, orgID, alerts...)
+	notifyFunc(ctx, r.orgID.StringValue(), alerts...)
 }
 
 func (r *BaseRule) ForEachActiveAlert(f func(*ruletypes.Alert)) {

--- a/pkg/query-service/rules/manager_test.go
+++ b/pkg/query-service/rules/manager_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/prometheus"
 	"github.com/SigNoz/signoz/pkg/prometheus/prometheustest"
-	"github.com/SigNoz/signoz/pkg/sqlstore"
-	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstoretest"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
 	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
@@ -56,14 +54,6 @@ func TestManager_TestNotification_SendUnmatched_ThresholdRule(t *testing.T) {
 							triggeredTestAlerts = append(triggeredTestAlerts, args.Get(3).(map[*alertmanagertypes.PostableAlert][]string))
 						}).Return(nil).Times(tc.ExpectAlerts)
 					}
-				},
-				SqlStoreHook: func(store sqlstore.SQLStore) {
-					mockStore := store.(*sqlstoretest.Provider)
-					// Mock the organizations query that SendAlerts makes
-					// Bun generates: SELECT id FROM organizations LIMIT 1 (or SELECT "id" FROM "organizations" LIMIT 1)
-					orgRows := mockStore.Mock().NewRows([]string{"id"}).AddRow(orgID.StringValue())
-					// Match bun's generated query pattern - bun may quote identifiers
-					mockStore.Mock().ExpectQuery("SELECT (.+) FROM (.+)organizations(.+) LIMIT (.+)").WillReturnRows(orgRows)
 				},
 				TelemetryStoreHook: func(store telemetrystore.TelemetryStore) {
 					mockStore := store.(*telemetrystoretest.Provider)
@@ -168,12 +158,6 @@ func TestManager_TestNotification_SendUnmatched_PromRule(t *testing.T) {
 							triggeredTestAlerts = append(triggeredTestAlerts, args.Get(3).(map[*alertmanagertypes.PostableAlert][]string))
 						}).Return(nil).Times(tc.ExpectAlerts)
 					}
-				},
-				SqlStoreHook: func(store sqlstore.SQLStore) {
-					mockStore := store.(*sqlstoretest.Provider)
-					// Mock the organizations query that SendAlerts makes
-					orgRows := mockStore.Mock().NewRows([]string{"id"}).AddRow(orgID.StringValue())
-					mockStore.Mock().ExpectQuery("SELECT (.+) FROM (.+)organizations(.+) LIMIT (.+)").WillReturnRows(orgRows)
 				},
 				TelemetryStoreHook: func(store telemetrystore.TelemetryStore) {
 					mockStore := store.(*telemetrystoretest.Provider)

--- a/pkg/query-service/rules/managertestfactory.go
+++ b/pkg/query-service/rules/managertestfactory.go
@@ -115,7 +115,7 @@ func NewTestManager(t *testing.T, testOpts *TestManagerOptions) *Manager {
 		Alertmanager:   fAlert,
 		Querier:        mockQuerier,
 		TelemetryStore: telemetryStore,
-		SQLStore:       sqlStore, // SQLStore needed for SendAlerts to query organizations
+		SQLStore:       sqlStore,
 	}
 
 	// Call the ManagerOptions hook if provided to allow customization


### PR DESCRIPTION
#### summary

- Scheduled alerts used organizations LIMIT 1 for notifications instead of the rule’s org. Multi-org setups sent alerts to the wrong org (no Slack, empty nflog). Fix: use r.orgID in SendAlerts.

#### Screenshots / Screen Recordings
N/A

#### Issues closed by this PR

Closes #11351

#### Change Type
[x] Bug fix

#### Bug Context

- Root Cause
SendAlerts queried first org row, not the rule’s org.

- Fix Strategy
Pass r.orgID to notifyFunc; remove the DB lookup.

#### Testing Strategy

- Tests added/updated: Removed org-query mocks in manager tests.
- Manual verification: N/A
- Edge cases covered: Multi-org scheduled alerts.

#### Risk & Impact Assessment

- Blast radius: Scheduled alert notifications.
- Potential regressions: Low.
- Rollback plan: Revert PR.