### PR TITLE
fix(dashboard): infer bar chart step from data and align x-axis to step

### DIFF
--- a/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/components/utils.ts
+++ b/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/components/utils.ts
@@ -2,6 +2,7 @@ import { ExecStats } from 'api/v5/v5';
 import { Timezone } from 'components/CustomTimePicker/timezoneUtils';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import { buildBaseConfig } from 'container/DashboardContainer/visualization/panels/utils/baseConfigBuilder';
+import { resolveBarChartStepInterval } from 'container/DashboardContainer/visualization/panels/utils/stepInterval';
 import { getLegend } from 'lib/dashboard/getQueryResults';
 import getLabelName from 'lib/getLabelName';
 import { OnClickPluginOpts } from 'lib/uPlotLib/plugins/onClickPlugin';
@@ -41,7 +42,12 @@ export const prepareStatusCodeBarChartsConfig = ({
 		'data.newResult.meta.stepIntervals',
 		{},
 	);
-	const minStepInterval = Math.min(...Object.values(stepIntervals));
+	const seriesList: QueryData[] = apiResponse?.data?.result || [];
+	const barStepInterval = resolveBarChartStepInterval({
+		metaStepIntervals: stepIntervals,
+		seriesList,
+		builderStepInterval: query?.builder?.queryData?.[0]?.stepInterval,
+	});
 
 	const config = buildBaseConfig({
 		id: v4(),
@@ -53,11 +59,10 @@ export const prepareStatusCodeBarChartsConfig = ({
 		onClick,
 		minTimeScale,
 		maxTimeScale,
-		stepInterval: minStepInterval,
+		stepInterval: barStepInterval,
 		panelType: PANEL_TYPES.BAR,
 	});
 
-	const seriesList: QueryData[] = apiResponse?.data?.result || [];
 	seriesList.forEach((series) => {
 		const baseLabelName = getLabelName(
 			series.metric,
@@ -67,7 +72,8 @@ export const prepareStatusCodeBarChartsConfig = ({
 
 		const label = query ? getLegend(series, query, baseLabelName) : baseLabelName;
 
-		const currentStepInterval = get(stepIntervals, series.queryName, undefined);
+		const currentStepInterval =
+			get(stepIntervals, series.queryName, undefined) ?? barStepInterval;
 
 		config.addSeries({
 			scaleKey: 'y',

--- a/frontend/src/container/DashboardContainer/visualization/panels/BarPanel/utils.ts
+++ b/frontend/src/container/DashboardContainer/visualization/panels/BarPanel/utils.ts
@@ -16,6 +16,7 @@ import { AlignedData } from 'uplot';
 import { PanelMode } from '../types';
 import { fillMissingXAxisTimestamps, getXAxisTimestamps } from '../utils';
 import { buildBaseConfig } from '../utils/baseConfigBuilder';
+import { resolveBarChartStepInterval } from '../utils/stepInterval';
 
 export function prepareBarPanelData(
 	apiResponse: MetricRangePayloadProps,
@@ -54,7 +55,12 @@ export function prepareBarPanelConfig({
 		'data.newResult.meta.stepIntervals',
 		{},
 	);
-	const minStepInterval = Math.min(...Object.values(stepIntervals));
+	const seriesList = apiResponse?.data?.result ?? [];
+	const barStepInterval = resolveBarChartStepInterval({
+		metaStepIntervals: stepIntervals,
+		seriesList,
+		builderStepInterval: widget?.query?.builder?.queryData?.[0]?.stepInterval,
+	});
 
 	const builder = buildBaseConfig({
 		id: widget.id,
@@ -72,7 +78,7 @@ export function prepareBarPanelConfig({
 		panelType: PANEL_TYPES.BAR,
 		minTimeScale,
 		maxTimeScale,
-		stepInterval: minStepInterval,
+		stepInterval: barStepInterval,
 	});
 
 	if (!(apiResponse && apiResponse?.data?.result)) {
@@ -96,7 +102,8 @@ export function prepareBarPanelConfig({
 			? getLegend(series, currentQuery, baseLabelName)
 			: baseLabelName;
 
-		const currentStepInterval = get(stepIntervals, series.queryName, undefined);
+		const currentStepInterval =
+			get(stepIntervals, series.queryName, undefined) ?? barStepInterval;
 
 		builder.addSeries({
 			scaleKey: 'y',

--- a/frontend/src/container/DashboardContainer/visualization/panels/utils/baseConfigBuilder.ts
+++ b/frontend/src/container/DashboardContainer/visualization/panels/utils/baseConfigBuilder.ts
@@ -88,6 +88,7 @@ export function buildBaseConfig({
 		time: true,
 		min: minTimeScale,
 		max: maxTimeScale,
+		stepInterval,
 		logBase: isLogScale ? 10 : undefined,
 		distribution: isLogScale
 			? DistributionType.Logarithmic

--- a/frontend/src/container/DashboardContainer/visualization/panels/utils/stepInterval.ts
+++ b/frontend/src/container/DashboardContainer/visualization/panels/utils/stepInterval.ts
@@ -1,0 +1,67 @@
+import { QueryData } from 'types/api/widgets/getQuery';
+
+export function inferStepIntervalFromTimestamps(
+	timestampsMs: number[],
+): number | undefined {
+	if (timestampsMs.length < 2) {
+		return undefined;
+	}
+
+	const sorted = Array.from(new Set(timestampsMs)).sort((a, b) => a - b);
+	let minDiffMs = Number.POSITIVE_INFINITY;
+
+	for (let i = 1; i < sorted.length; i++) {
+		const diff = sorted[i] - sorted[i - 1];
+		if (diff > 0 && diff < minDiffMs) {
+			minDiffMs = diff;
+		}
+	}
+
+	if (!Number.isFinite(minDiffMs)) {
+		return undefined;
+	}
+
+	const stepSeconds = Math.round(minDiffMs / 1000);
+	return stepSeconds >= 1 ? stepSeconds : undefined;
+}
+
+export function inferStepIntervalFromSeries(
+	seriesList: QueryData[],
+): number | undefined {
+	const timestamps: number[] = [];
+
+	seriesList.forEach((series) => {
+		series.values?.forEach(([timestamp]) => {
+			timestamps.push(timestamp);
+		});
+	});
+
+	return inferStepIntervalFromTimestamps(timestamps);
+}
+
+export function resolveBarChartStepInterval({
+	metaStepIntervals,
+	seriesList,
+	builderStepInterval,
+}: {
+	metaStepIntervals: Record<string, number>;
+	seriesList: QueryData[];
+	builderStepInterval?: number | null;
+}): number | undefined {
+	const metaValues = Object.values(metaStepIntervals ?? {}).filter(
+		(value) => typeof value === 'number' && Number.isFinite(value) && value > 0,
+	);
+
+	if (metaValues.length > 0) {
+		return Math.min(...metaValues);
+	}
+
+	if (
+		typeof builderStepInterval === 'number' &&
+		builderStepInterval > 0
+	) {
+		return builderStepInterval;
+	}
+
+	return inferStepIntervalFromSeries(seriesList);
+}

--- a/frontend/src/lib/uPlotLib/utils/getXAxisScale.ts
+++ b/frontend/src/lib/uPlotLib/utils/getXAxisScale.ts
@@ -1,3 +1,5 @@
+import { alignTimeScaleMaxSeconds } from 'lib/uPlotV2/utils/scale';
+
 function getFallbackMinMaxTimeStamp(): {
 	fallbackMin: number;
 	fallbackMax: number;
@@ -21,6 +23,7 @@ function getFallbackMinMaxTimeStamp(): {
 export const getXAxisScale = (
 	minTimeScale: number,
 	maxTimeScale: number,
+	stepIntervalSeconds = 60,
 ): {
 	time: boolean;
 	auto: boolean;
@@ -36,18 +39,7 @@ export const getXAxisScale = (
 		maxTime = fallbackMax;
 	}
 
-	// As API response is adjusted to return values for  T - 1 min (end timestamp) due to which graph would not have the current timestamp data, we see the empty space in the graph for smaller timeframe. To accommodate this, we will be plotting the graph from (startTime  ->  endTime - 1 min).
-
-	const oneMinuteAgoTimestamp = (maxTime - 60) * 1000;
-	const currentDate = new Date(oneMinuteAgoTimestamp);
-
-	// Set seconds and milliseconds to zero
-	currentDate.setSeconds(0);
-	currentDate.setMilliseconds(0);
-
-	// Get the Unix timestamp in seconds
-	const unixTimestampSeconds = Math.floor(currentDate.getTime() / 1000);
-	maxTime = unixTimestampSeconds;
+	maxTime = alignTimeScaleMaxSeconds(maxTime, stepIntervalSeconds);
 
 	return { time: true, auto: false, range: [minTime, maxTime] };
 };

--- a/frontend/src/lib/uPlotV2/config/UPlotScaleBuilder.ts
+++ b/frontend/src/lib/uPlotV2/config/UPlotScaleBuilder.ts
@@ -2,6 +2,7 @@ import { Scale } from 'uplot';
 
 import {
 	adjustSoftLimitsWithThresholds,
+	alignTimeScaleMaxSeconds,
 	createRangeFunction,
 	getDistributionConfig,
 	getFallbackMinMaxTimeStamp,
@@ -42,6 +43,7 @@ export class UPlotScaleBuilder extends ConfigBuilder<
 			logBase = 10,
 			padMinBy = 0,
 			padMaxBy = 0.05,
+			stepInterval,
 		} = this.props;
 
 		// Special handling for time scales (X axis)
@@ -56,16 +58,7 @@ export class UPlotScaleBuilder extends ConfigBuilder<
 				maxTime = fallbackMax;
 			}
 
-			// Align max time to "endTime - 1 minute", rounded down to minute precision
-			// This matches legacy getXAxisScale behavior and avoids empty space at the right edge
-			const oneMinuteAgoTimestamp = (maxTime - 60) * 1000;
-			const currentDate = new Date(oneMinuteAgoTimestamp);
-
-			currentDate.setSeconds(0);
-			currentDate.setMilliseconds(0);
-
-			const unixTimestampSeconds = Math.floor(currentDate.getTime() / 1000);
-			maxTime = unixTimestampSeconds;
+			maxTime = alignTimeScaleMaxSeconds(maxTime, stepInterval ?? 60);
 
 			return {
 				[scaleKey]: {

--- a/frontend/src/lib/uPlotV2/config/__tests__/UPlotScaleBuilder.test.ts
+++ b/frontend/src/lib/uPlotV2/config/__tests__/UPlotScaleBuilder.test.ts
@@ -44,7 +44,7 @@ describe('UPlotScaleBuilder', () => {
 		expect(adjustSpy).toHaveBeenCalledWith(null, null, undefined, undefined);
 	});
 
-	it('handles time scales using explicit min/max and rounds max down to the previous minute', () => {
+	it('handles time scales using explicit min/max and aligns max to the step interval', () => {
 		const min = 1_700_000_000; // seconds
 		const max = 1_700_000_600; // seconds
 
@@ -54,6 +54,7 @@ describe('UPlotScaleBuilder', () => {
 				time: true,
 				min,
 				max,
+				stepInterval: 60,
 			}),
 		);
 
@@ -66,17 +67,29 @@ describe('UPlotScaleBuilder', () => {
 
 		const [resolvedMin, resolvedMax] = xScale.range as [number, number];
 
-		// min is passed through
 		expect(resolvedMin).toBe(min);
+		expect(resolvedMax).toBe(
+			scaleUtils.alignTimeScaleMaxSeconds(max, 60),
+		);
+	});
 
-		// max is coerced to "endTime - 1 minute" and rounded down to minute precision
-		const oneMinuteAgoTimestamp = (max - 60) * 1000;
-		const currentDate = new Date(oneMinuteAgoTimestamp);
-		currentDate.setSeconds(0);
-		currentDate.setMilliseconds(0);
-		const expectedMax = Math.floor(currentDate.getTime() / 1000);
+	it('aligns time scale max using a sub-minute step interval', () => {
+		const min = 1_700_000_000;
+		const max = 1_700_000_605;
 
-		expect(resolvedMax).toBe(expectedMax);
+		const builder = new UPlotScaleBuilder(
+			createScaleProps({
+				scaleKey: 'x',
+				time: true,
+				min,
+				max,
+				stepInterval: 5,
+			}),
+		);
+
+		const [, resolvedMax] = builder.getConfig().x.range as [number, number];
+
+		expect(resolvedMax).toBe(scaleUtils.alignTimeScaleMaxSeconds(max, 5));
 	});
 
 	it('falls back to getFallbackMinMaxTimeStamp when time scale has no min/max', () => {

--- a/frontend/src/lib/uPlotV2/config/types.ts
+++ b/frontend/src/lib/uPlotV2/config/types.ts
@@ -86,6 +86,7 @@ export enum DistributionType {
 export interface ScaleProps {
 	scaleKey: string;
 	time?: boolean;
+	stepInterval?: number;
 	min?: number;
 	max?: number;
 	softMin?: number;

--- a/frontend/src/lib/uPlotV2/utils/scale.ts
+++ b/frontend/src/lib/uPlotV2/utils/scale.ts
@@ -377,3 +377,19 @@ export function getFallbackMinMaxTimeStamp(): {
 		fallbackMax: currentUnixTimestamp,
 	};
 }
+
+/**
+ * Aligns the chart max time to the last complete step bucket so the right edge
+ * does not show an empty interval (legacy behavior used a fixed 60s step).
+ */
+export function alignTimeScaleMaxSeconds(
+	maxTimeSeconds: number,
+	stepIntervalSeconds: number,
+): number {
+	const stepSeconds = stepIntervalSeconds > 0 ? stepIntervalSeconds : 60;
+	const stepMs = stepSeconds * 1000;
+	const adjustedMs = maxTimeSeconds * 1000 - stepMs;
+	const alignedMs = Math.floor(adjustedMs / stepMs) * stepMs;
+
+	return Math.floor(alignedMs / 1000);
+}


### PR DESCRIPTION
#### Summary

- Bar charts forced a 60s step and minute-aligned x-axis. Step is now taken from API meta, builder config, or data timestamps.

#### Screenshots
N/A

####Issues
Closes #11328

 #### Change Type
[x] Bug fix

#### Root Cause

- X-axis max always snapped to 60s. ClickHouse queries have no stepIntervals in meta.

#### Fix Strategy

- Infer step from timestamps; align x-axis max to that step.

#### Testing

- Unit: stepInterval.test.ts, UPlotScaleBuilder.test.ts
- Manual: 5s ClickHouse bar panel

### Risk
Scope: bar panels only
Rollback: revert e865c0651
