### PR TITLE
feat(trace-details): promote ExpandableValue to periscope + dropdown z-index fix

### DIFF
--- a/frontend/src/pages/TraceDetailsV3/SpanDetailsPanel/SpanDetailsPanel.module.scss
+++ b/frontend/src/pages/TraceDetailsV3/SpanDetailsPanel/SpanDetailsPanel.module.scss
@@ -119,6 +119,12 @@
 	flex-shrink: 0;
 }
 
+.statusMessageBadge {
+	width: 100%;
+	min-width: 0;
+	box-sizing: border-box;
+}
+
 .traceId {
 	color: var(--accent-primary);
 	overflow: hidden;

--- a/frontend/src/pages/TraceDetailsV3/SpanDetailsPanel/config.tsx
+++ b/frontend/src/pages/TraceDetailsV3/SpanDetailsPanel/config.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { Badge } from '@signozhq/ui/badge';
+import ExpandableValue from 'periscope/components/ExpandableValue';
 import { SpanV3 } from 'types/api/trace/getTraceV3';
 
 import styles from './SpanDetailsPanel.module.scss';
@@ -48,7 +49,15 @@ export const HIGHLIGHTED_OPTIONS: HighlightedOption[] = [
 		label: 'STATUS MESSAGE',
 		render: (span): ReactNode | null =>
 			span.status_message ? (
-				<Badge color="vanilla">{span.status_message}</Badge>
+				<ExpandableValue value={span.status_message} title="Status message">
+					<Badge
+						color="vanilla"
+						textEllipsis="end"
+						className={styles.statusMessageBadge}
+					>
+						{span.status_message}
+					</Badge>
+				</ExpandableValue>
 			) : null,
 	},
 ];

--- a/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/TraceOptionsMenu.module.scss
+++ b/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/TraceOptionsMenu.module.scss
@@ -1,0 +1,3 @@
+.traceOptionsDropdown {
+	z-index: 1100;
+}

--- a/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/TraceOptionsMenu.tsx
+++ b/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/TraceOptionsMenu.tsx
@@ -6,6 +6,8 @@ import { Ellipsis } from '@signozhq/icons';
 
 import { useTraceStore } from '../stores/traceStore';
 
+import styles from './TraceOptionsMenu.module.scss';
+
 interface TraceOptionsMenuProps {
 	showTraceDetails: boolean;
 	onToggleTraceDetails: () => void;
@@ -82,7 +84,11 @@ function TraceOptionsMenu({
 	]);
 
 	return (
-		<Dropdown menu={{ items: menuItems }} align="start">
+		<Dropdown
+			menu={{ items: menuItems }}
+			align="start"
+			className={styles.traceOptionsDropdown}
+		>
 			<Button
 				variant="ghost"
 				size="icon"

--- a/frontend/src/periscope/components/ExpandableValue/ExpandableValue.module.scss
+++ b/frontend/src/periscope/components/ExpandableValue/ExpandableValue.module.scss
@@ -3,6 +3,10 @@
 	min-width: 0;
 	max-width: 100%;
 	overflow: hidden;
+
+	[data-truncated='true'] {
+		pointer-events: none;
+	}
 }
 
 .tooltipContent {

--- a/frontend/src/periscope/components/ExpandableValue/ExpandableValue.module.scss
+++ b/frontend/src/periscope/components/ExpandableValue/ExpandableValue.module.scss
@@ -1,0 +1,45 @@
+.trigger {
+	display: block;
+	min-width: 0;
+	max-width: 100%;
+	overflow: hidden;
+}
+
+.tooltipContent {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	max-width: 480px;
+	padding: 8px;
+}
+
+.preview {
+	margin: 0;
+	max-height: 220px;
+	overflow: auto;
+	white-space: pre-wrap;
+	word-break: break-word;
+	font-family: var(--font-family-mono, monospace);
+	font-size: 12px;
+	line-height: 1.4;
+}
+
+.expandButton {
+	align-self: flex-end;
+}
+
+.dialog {
+	max-width: 80vw;
+	width: 80vw;
+}
+
+.fullValue {
+	margin: 0;
+	max-height: 70vh;
+	overflow: auto;
+	white-space: pre-wrap;
+	word-break: break-word;
+	font-family: var(--font-family-mono, monospace);
+	font-size: 13px;
+	line-height: 1.5;
+}

--- a/frontend/src/periscope/components/ExpandableValue/ExpandableValue.tsx
+++ b/frontend/src/periscope/components/ExpandableValue/ExpandableValue.tsx
@@ -1,0 +1,86 @@
+import { ReactNode, useState } from 'react';
+import { Button } from '@signozhq/ui/button';
+import { DialogWrapper } from '@signozhq/ui/dialog';
+import {
+	TooltipContent,
+	TooltipProvider,
+	TooltipRoot,
+	TooltipTrigger,
+} from '@signozhq/ui/tooltip';
+import { Fullscreen } from '@signozhq/icons';
+
+import styles from './ExpandableValue.module.scss';
+
+const DEFAULT_THRESHOLD = 100;
+const DEFAULT_DIALOG_TITLE = 'Value';
+// signoz tooltip defaults to `--tooltip-z-index: 50` and signoz dialog
+// hardcodes `z-index: 50`. ExpandableValue is meant to be embedded in
+// surfaces with much higher stacking — FloatingPanel (999), antd Drawer
+// / Modal (1000) — so we lift both above that range by default. Consumers
+// inside deeper layers can override via `zIndex`.
+const DEFAULT_Z_INDEX = 1100;
+
+interface ExpandableValueProps {
+	value: string;
+	title?: string;
+	threshold?: number;
+	zIndex?: number;
+	children: ReactNode;
+}
+
+// Self-contained TooltipProvider mirrors the AuthZTooltip / CopyIconButton
+// pattern: nesting inside AppLayout's global provider is benign, and the
+// alternative (relying on a hoisted provider) silently breaks the tooltip
+// if a consumer forgets to wrap.
+function ExpandableValue({
+	value,
+	title = DEFAULT_DIALOG_TITLE,
+	threshold = DEFAULT_THRESHOLD,
+	zIndex = DEFAULT_Z_INDEX,
+	children,
+}: ExpandableValueProps): JSX.Element {
+	const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+	if (value.length <= threshold) {
+		return <>{children}</>;
+	}
+
+	return (
+		<TooltipProvider>
+			<TooltipRoot>
+				<TooltipTrigger asChild>
+					<span className={styles.trigger}>{children}</span>
+				</TooltipTrigger>
+				<TooltipContent
+					className={styles.tooltipContent}
+					side="top"
+					style={{ zIndex }}
+				>
+					<pre className={styles.preview}>{value}</pre>
+					<Button
+						variant="outlined"
+						color="secondary"
+						size="sm"
+						prefix={<Fullscreen size={14} />}
+						onClick={(): void => setIsDialogOpen(true)}
+						className={styles.expandButton}
+					>
+						Expand
+					</Button>
+				</TooltipContent>
+			</TooltipRoot>
+
+			<DialogWrapper
+				title={title}
+				open={isDialogOpen}
+				onOpenChange={setIsDialogOpen}
+				className={styles.dialog}
+				style={{ zIndex }}
+			>
+				<pre className={styles.fullValue}>{value}</pre>
+			</DialogWrapper>
+		</TooltipProvider>
+	);
+}
+
+export default ExpandableValue;

--- a/frontend/src/periscope/components/ExpandableValue/ExpandableValue.tsx
+++ b/frontend/src/periscope/components/ExpandableValue/ExpandableValue.tsx
@@ -13,11 +13,7 @@ import styles from './ExpandableValue.module.scss';
 
 const DEFAULT_THRESHOLD = 100;
 const DEFAULT_DIALOG_TITLE = 'Value';
-// signoz tooltip defaults to `--tooltip-z-index: 50` and signoz dialog
-// hardcodes `z-index: 50`. ExpandableValue is meant to be embedded in
-// surfaces with much higher stacking — FloatingPanel (999), antd Drawer
-// / Modal (1000) — so we lift both above that range by default. Consumers
-// inside deeper layers can override via `zIndex`.
+
 const DEFAULT_Z_INDEX = 1100;
 
 interface ExpandableValueProps {
@@ -28,10 +24,6 @@ interface ExpandableValueProps {
 	children: ReactNode;
 }
 
-// Self-contained TooltipProvider mirrors the AuthZTooltip / CopyIconButton
-// pattern: nesting inside AppLayout's global provider is benign, and the
-// alternative (relying on a hoisted provider) silently breaks the tooltip
-// if a consumer forgets to wrap.
 function ExpandableValue({
 	value,
 	title = DEFAULT_DIALOG_TITLE,

--- a/frontend/src/periscope/components/ExpandableValue/index.ts
+++ b/frontend/src/periscope/components/ExpandableValue/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ExpandableValue';


### PR DESCRIPTION
## Summary

- Promote the long-value expand UX that already exists in the old `SpanDetailsDrawer` (`AttributeWithExpandablePopover`) into a reusable periscope component, ported off antd onto `@signozhq/ui` + `@signozhq/icons`.
- Use it in `TraceDetailsV3` to fix the `status_message` regression where long values (e.g. a stack trace) crammed into a single `Badge` broke the layout.
- Sibling fix: lift `TraceOptionsMenu` (the "..." dropdown in `TraceDetailsHeader`) above `FloatingPanel` (z-index 999) by setting `--dropdown-menu-content-z-index` via a CSS module class — it was being clipped by the panel.

## What's new

`periscope/components/ExpandableValue/` — wrapper-pattern component. Consumer passes their existing trigger UI as `children`; below `threshold` (default 100 chars) it renders children directly, above threshold it wraps them in a hover Tooltip with a `<pre>` preview + Expand button that opens a `DialogWrapper` with the full preformatted value. Self-contained `TooltipProvider` (matches `AuthZTooltip` / `CopyIconButton` pattern). Default `zIndex={1100}` clears both `FloatingPanel` (999) and antd Drawer/Modal (1000).

The old v2 component stays in place — it will be removed wholesale when `TraceDetailsV2` is retired.


Screenshots/Recordings

1. Ellipsis button now opens over the span details (earlier was hidden behind)

<img width="1322" height="966" alt="image" src="https://github.com/user-attachments/assets/d856a547-1a14-4150-b5fc-a51d2609cb8d" />

2. Status message now opens up in a pre-existing expandable popover.


https://github.com/user-attachments/assets/f9689101-34b3-459e-899d-2034a9a0f5d4

Ticket:
https://github.com/SigNoz/engineering-pod/issues/5046

## Notable details

## Test plan

- [x] Manual verification with an injected long `status_message` in V3.
- [x] `tsc --noEmit` clean.
- [ ] Confirm TraceOptionsMenu opens above the SpanDetailsPanel.
- [ ] Confirm v2 `SpanDetailsDrawer` is unaffected.
