### PR TITLE
fix(trace-details): make back button reliably return to previous in-app page

### DIFF
--- a/frontend/src/lib/history.ts
+++ b/frontend/src/lib/history.ts
@@ -1,4 +1,15 @@
 import { createBrowserHistory } from 'history';
 import { getBasePath } from 'utils/basePath';
 
-export default createBrowserHistory({ basename: getBasePath() });
+const history = createBrowserHistory({ basename: getBasePath() });
+
+let inAppPushCount = 0;
+history.listen((_, action) => {
+	if (action === 'PUSH') {
+		inAppPushCount += 1;
+	}
+});
+
+export const hasInAppHistory = (): boolean => inAppPushCount > 0;
+
+export default history;

--- a/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/TraceDetailsHeader.tsx
+++ b/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/TraceDetailsHeader.tsx
@@ -16,7 +16,7 @@ import { LOCALSTORAGE } from 'constants/localStorage';
 import ROUTES from 'constants/routes';
 import { convertTimeToRelevantUnit } from 'container/TraceDetail/utils';
 import dayjs from 'dayjs';
-import history from 'lib/history';
+import history, { hasInAppHistory } from 'lib/history';
 import {
 	ArrowLeft,
 	CalendarClock,
@@ -96,13 +96,7 @@ function TraceDetailsHeader({
 	}, [traceID]);
 
 	const handlePreviousBtnClick = useCallback((): void => {
-		const isSpaNavigate =
-			document.referrer &&
-			// oxlint-disable-next-line signoz/no-raw-absolute-path
-			new URL(document.referrer).origin === window.location.origin;
-		const hasBackHistory = window.history.length > 1;
-
-		if (isSpaNavigate && hasBackHistory) {
+		if (hasInAppHistory()) {
 			history.goBack();
 		} else {
 			history.push(ROUTES.TRACES_EXPLORER);

--- a/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/TraceDetailsHeader.tsx
+++ b/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/TraceDetailsHeader.tsx
@@ -124,6 +124,7 @@ function TraceDetailsHeader({
 							size="md"
 							className={styles.backBtn}
 							onClick={handlePreviousBtnClick}
+							aria-label="Back"
 						>
 							<ArrowLeft size={14} />
 						</Button>

--- a/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/__tests__/TraceDetailsHeader.test.tsx
+++ b/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/__tests__/TraceDetailsHeader.test.tsx
@@ -37,17 +37,11 @@ describe('TraceDetailsHeader – back button', () => {
 		mockHasInAppHistory.mockReset();
 	});
 
-	it('renders the back button', () => {
-		mockHasInAppHistory.mockReturnValue(false);
-		render(<TraceDetailsHeader {...baseProps} />);
-		expect(screen.getByRole('button')).toBeInTheDocument();
-	});
-
 	it('calls history.goBack() when there is in-app SPA history', () => {
 		mockHasInAppHistory.mockReturnValue(true);
 		render(<TraceDetailsHeader {...baseProps} />);
 
-		fireEvent.click(screen.getByRole('button'));
+		fireEvent.click(screen.getByRole('button', { name: /back/i }));
 
 		expect(mockGoBack).toHaveBeenCalledTimes(1);
 		expect(mockPush).not.toHaveBeenCalled();
@@ -57,11 +51,10 @@ describe('TraceDetailsHeader – back button', () => {
 		mockHasInAppHistory.mockReturnValue(false);
 		render(<TraceDetailsHeader {...baseProps} />);
 
-		fireEvent.click(screen.getByRole('button'));
+		fireEvent.click(screen.getByRole('button', { name: /back/i }));
 
 		expect(mockPush).toHaveBeenCalledTimes(1);
 		expect(mockPush).toHaveBeenCalledWith(ROUTES.TRACES_EXPLORER);
-		expect(mockPush).toHaveBeenCalledWith('/traces-explorer');
 		expect(mockGoBack).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/__tests__/TraceDetailsHeader.test.tsx
+++ b/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/__tests__/TraceDetailsHeader.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, screen } from '@testing-library/react';
+import ROUTES from 'constants/routes';
+import { render } from 'tests/test-utils';
+
+import TraceDetailsHeader from '../TraceDetailsHeader';
+
+const mockGoBack = jest.fn();
+const mockPush = jest.fn();
+const mockHasInAppHistory = jest.fn();
+
+jest.mock('lib/history', () => ({
+	__esModule: true,
+	default: {
+		goBack: (): void => mockGoBack(),
+		push: (path: string): void => mockPush(path),
+		replace: jest.fn(),
+		location: { pathname: '/', search: '' },
+		listen: (): (() => void) => (): void => undefined,
+	},
+	hasInAppHistory: (): boolean => mockHasInAppHistory(),
+}));
+
+const baseProps = {
+	filterMetadata: {
+		startTime: 0,
+		endTime: 1,
+		traceId: 'trace-123',
+	},
+	onFilteredSpansChange: jest.fn(),
+	isDataLoaded: false,
+};
+
+describe('TraceDetailsHeader – back button', () => {
+	beforeEach(() => {
+		mockGoBack.mockClear();
+		mockPush.mockClear();
+		mockHasInAppHistory.mockReset();
+	});
+
+	it('renders the back button', () => {
+		mockHasInAppHistory.mockReturnValue(false);
+		render(<TraceDetailsHeader {...baseProps} />);
+		expect(screen.getByRole('button')).toBeInTheDocument();
+	});
+
+	it('calls history.goBack() when there is in-app SPA history', () => {
+		mockHasInAppHistory.mockReturnValue(true);
+		render(<TraceDetailsHeader {...baseProps} />);
+
+		fireEvent.click(screen.getByRole('button'));
+
+		expect(mockGoBack).toHaveBeenCalledTimes(1);
+		expect(mockPush).not.toHaveBeenCalled();
+	});
+
+	it('pushes to the traces explorer route when there is no in-app SPA history', () => {
+		mockHasInAppHistory.mockReturnValue(false);
+		render(<TraceDetailsHeader {...baseProps} />);
+
+		fireEvent.click(screen.getByRole('button'));
+
+		expect(mockPush).toHaveBeenCalledTimes(1);
+		expect(mockPush).toHaveBeenCalledWith(ROUTES.TRACES_EXPLORER);
+		expect(mockPush).toHaveBeenCalledWith('/traces-explorer');
+		expect(mockGoBack).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
### Steps to recreate 

https://www.loom.com/share/5deaa44e96724cedbf1ddf7d99b6c3fd                         

1. Login into staging 
2. try to add filters  , go open trace/traceid , press back button , everything will work 
3. now open stagin in a new tab.  do step 2 again things will break.

                                                                                                                                                                                                                                                   
  ### What was happening                                                                                                                      
                                                                                                                                              
  The back arrow on the new trace details page was inconsistently sending users to the Traces Explorer even when they had navigated from      
  somewhere else inside SigNoz. The handler tried to detect "did the user come from inside the app?" using `document.referrer` and
  `window.history.length`, but neither signal answers that question reliably in a SPA:                                                        
                                                                                                                                              
  - **`document.referrer` is set once, at document load, and never updates for SPA navigations.** After that, every back-click in the tab gets
   the same answer regardless of where the user actually navigated. So the back button's behavior was determined by how the tab originally    
  arrived at SigNoz, not by the user's real navigation path. It happened to work after a login redirect or a hard refresh (referrer =       
  same-origin), but broke when the user opened SigNoz from Slack, a bookmark, a new tab, or any external link.                                
  - **`window.history.length` counts the entire tab's session history**, including pre-SigNoz entries, and never decreases. It tells you the
  back button is *clickable*, not where it *goes*.                                                                                            
                                                                                                                                            
  ### How this PR fixes it
                                                                                                                                              
  Subscribe to the shared React Router `history` singleton in `lib/history.ts` and count `PUSH` actions (the only action type that adds to the
   back-stack). Expose `hasInAppHistory()` which returns `true` once the SPA router has pushed at least one entry in this page load — i.e.,   
  the precise condition under which `history.goBack()` is guaranteed to land on a SigNoz route.                                             
                                                                                                                                              
  `handlePreviousBtnClick` now reads:         
                                                                                                                                              
  ```ts                                                                                                                                     
  if (hasInAppHistory()) history.goBack();                                                                                                    
  else history.push(ROUTES.TRACES_EXPLORER);

``` 
                                                                                                                                              
🤔  will check the code base and replace with this logic at all places in follow up 