### PR TITLE
feat(boot-settings): runtime enable/disable control for PostHog and Appcues

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -95,7 +95,9 @@
 			})();
 		</script>
 		<script>
-			window.signozBootData = { settings: [[.Settings]] };
+			try {
+				window.signozBootData = { settings: [[.Settings]] };
+			} catch (e) {}
 		</script>
 		<noscript>You need to enable JavaScript to run this app.</noscript>
 		<div id="root"></div>
@@ -138,8 +140,9 @@
 		</script>
 		<script>
 			var APPCUES_APP_ID = '<%- APPCUES_APP_ID %>';
-			var appcuesEnabled =
-				(window.signozBootData?.settings?.appcues || {}).enabled !== false;
+			var appcuesSettings =
+				(((window.signozBootData || {}).settings || {}).appcues || {});
+			var appcuesEnabled = appcuesSettings.enabled !== false;
 			if (APPCUES_APP_ID && appcuesEnabled) {
 				(function (d, t) {
 					var a = d.createElement(t);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -94,12 +94,15 @@
 				}
 			})();
 		</script>
+		<script>
+			window.signozBootData = { settings: [[.BootSettings]] };
+		</script>
 		<noscript>You need to enable JavaScript to run this app.</noscript>
 		<div id="root"></div>
 
 		<script>
-			var PYLON_APP_ID = '<%- PYLON_APP_ID %>';
-			if (PYLON_APP_ID) {
+			var pylonAppId = (window.signozBootData?.settings?.pylon || {}).appId || '';
+			if (pylonAppId) {
 				(function () {
 					var e = window;
 					var t = document;
@@ -115,10 +118,7 @@
 						var e = t.createElement('script');
 						e.setAttribute('type', 'text/javascript');
 						e.setAttribute('async', 'true');
-						e.setAttribute(
-							'src',
-							'https://widget.usepylon.com/widget/' + PYLON_APP_ID,
-						);
+						e.setAttribute('src', 'https://widget.usepylon.com/widget/' + pylonAppId);
 						var n = t.getElementsByTagName('script')[0];
 						n.parentNode.insertBefore(e, n);
 					};
@@ -130,16 +130,15 @@
 				})();
 			}
 		</script>
-		<script type="text/javascript">
-			window.AppcuesSettings = { enableURLDetection: true };
-		</script>
 		<script>
-			var APPCUES_APP_ID = '<%- APPCUES_APP_ID %>';
-			if (APPCUES_APP_ID) {
+			var appcuesAppId =
+				(window.signozBootData?.settings?.appcues || {}).appId || '';
+			if (appcuesAppId) {
+				window.AppcuesSettings = { enableURLDetection: true };
 				(function (d, t) {
 					var a = d.createElement(t);
 					a.async = 1;
-					a.src = '//fast.appcues.com/' + APPCUES_APP_ID + '.js';
+					a.src = '//fast.appcues.com/' + appcuesAppId + '.js';
 					var s = d.getElementsByTagName(t)[0];
 					s.parentNode.insertBefore(a, s);
 				})(document, 'script');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -94,10 +94,18 @@
 				}
 			})();
 		</script>
+		<script type="application/json" id="signoz-boot-settings">
+			[[.Settings]]
+		</script>
 		<script>
 			try {
-				window.signozBootData = { settings: [[.Settings]] };
-			} catch (e) {}
+				var _el = document.getElementById('signoz-boot-settings');
+				window.signozBootData = {
+					settings: _el ? JSON.parse(_el.textContent) : null,
+				};
+			} catch (e) {
+				window.signozBootData = { settings: null };
+			}
 		</script>
 		<noscript>You need to enable JavaScript to run this app.</noscript>
 		<div id="root"></div>
@@ -141,7 +149,7 @@
 		<script>
 			var APPCUES_APP_ID = '<%- APPCUES_APP_ID %>';
 			var appcuesSettings =
-				(((window.signozBootData || {}).settings || {}).appcues || {});
+				((window.signozBootData || {}).settings || {}).appcues || {};
 			var appcuesEnabled = appcuesSettings.enabled !== false;
 			if (APPCUES_APP_ID && appcuesEnabled) {
 				(function (d, t) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -95,14 +95,14 @@
 			})();
 		</script>
 		<script>
-			window.signozBootData = { settings: [[.BootSettings]] };
+			window.signozBootData = { settings: [[.Settings]] };
 		</script>
 		<noscript>You need to enable JavaScript to run this app.</noscript>
 		<div id="root"></div>
 
 		<script>
-			var pylonAppId = (window.signozBootData?.settings?.pylon || {}).appId || '';
-			if (pylonAppId) {
+			var PYLON_APP_ID = '<%- PYLON_APP_ID %>';
+			if (PYLON_APP_ID) {
 				(function () {
 					var e = window;
 					var t = document;
@@ -118,7 +118,10 @@
 						var e = t.createElement('script');
 						e.setAttribute('type', 'text/javascript');
 						e.setAttribute('async', 'true');
-						e.setAttribute('src', 'https://widget.usepylon.com/widget/' + pylonAppId);
+						e.setAttribute(
+							'src',
+							'https://widget.usepylon.com/widget/' + PYLON_APP_ID,
+						);
 						var n = t.getElementsByTagName('script')[0];
 						n.parentNode.insertBefore(e, n);
 					};
@@ -130,15 +133,18 @@
 				})();
 			}
 		</script>
+		<script type="text/javascript">
+			window.AppcuesSettings = { enableURLDetection: true };
+		</script>
 		<script>
-			var appcuesAppId =
-				(window.signozBootData?.settings?.appcues || {}).appId || '';
-			if (appcuesAppId) {
-				window.AppcuesSettings = { enableURLDetection: true };
+			var APPCUES_APP_ID = '<%- APPCUES_APP_ID %>';
+			var appcuesEnabled =
+				(window.signozBootData?.settings?.appcues || {}).enabled !== false;
+			if (APPCUES_APP_ID && appcuesEnabled) {
 				(function (d, t) {
 					var a = d.createElement(t);
 					a.async = 1;
-					a.src = '//fast.appcues.com/' + appcuesAppId + '.js';
+					a.src = '//fast.appcues.com/' + APPCUES_APP_ID + '.js';
 					var s = d.getElementsByTagName(t)[0];
 					s.parentNode.insertBefore(a, s);
 				})(document, 'script');

--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -333,7 +333,7 @@ function App(): JSX.Element {
 
 	useEffect(() => {
 		if (isCloudUser || isEnterpriseSelfHostedUser) {
-			if (bootSettings.posthog.enabled !== false && process.env.POSTHOG_KEY) {
+			if (bootSettings.posthog.enabled && process.env.POSTHOG_KEY) {
 				posthog.init(process.env.POSTHOG_KEY, {
 					api_host: 'https://us.i.posthog.com',
 					person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well

--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -35,6 +35,7 @@ import { PreferenceContextProvider } from 'providers/preferences/context/Prefere
 import { QueryBuilderProvider } from 'providers/QueryBuilder';
 import { LicenseStatus } from 'types/api/licensesV3/getActive';
 import { extractDomain } from 'utils/app';
+import { bootSettings } from 'utils/bootData';
 
 import { Home } from './pageComponents';
 import PrivateRoute from './Private';
@@ -293,7 +294,7 @@ function App(): JSX.Element {
 				(isCloudUser || isEnterpriseSelfHostedUser)
 			) {
 				const email = user.email || '';
-				const secret = process.env.PYLON_IDENTITY_SECRET || '';
+				const secret = bootSettings.pylon.identSecret ?? '';
 				let emailHash = '';
 
 				if (email && secret) {
@@ -302,7 +303,7 @@ function App(): JSX.Element {
 
 				window.pylon = {
 					chat_settings: {
-						app_id: process.env.PYLON_APP_ID,
+						app_id: bootSettings.pylon.appId,
 						email: user.email,
 						name: user.displayName || user.email,
 						email_hash: emailHash,
@@ -332,8 +333,8 @@ function App(): JSX.Element {
 
 	useEffect(() => {
 		if (isCloudUser || isEnterpriseSelfHostedUser) {
-			if (process.env.POSTHOG_KEY) {
-				posthog.init(process.env.POSTHOG_KEY, {
+			if (bootSettings.posthog.key) {
+				posthog.init(bootSettings.posthog.key, {
 					api_host: 'https://us.i.posthog.com',
 					person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
 				});
@@ -341,8 +342,8 @@ function App(): JSX.Element {
 
 			if (!isSentryInitialized) {
 				Sentry.init({
-					dsn: process.env.SENTRY_DSN,
-					tunnel: process.env.TUNNEL_URL,
+					dsn: bootSettings.sentry.dsn,
+					tunnel: bootSettings.sentry.tunnelUrl,
 					environment: 'production',
 					integrations: [
 						Sentry.browserTracingIntegration(),

--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -294,7 +294,7 @@ function App(): JSX.Element {
 				(isCloudUser || isEnterpriseSelfHostedUser)
 			) {
 				const email = user.email || '';
-				const secret = bootSettings.pylon.identSecret ?? '';
+				const secret = process.env.PYLON_IDENTITY_SECRET || '';
 				let emailHash = '';
 
 				if (email && secret) {
@@ -303,7 +303,7 @@ function App(): JSX.Element {
 
 				window.pylon = {
 					chat_settings: {
-						app_id: bootSettings.pylon.appId,
+						app_id: process.env.PYLON_APP_ID,
 						email: user.email,
 						name: user.displayName || user.email,
 						email_hash: emailHash,
@@ -333,8 +333,8 @@ function App(): JSX.Element {
 
 	useEffect(() => {
 		if (isCloudUser || isEnterpriseSelfHostedUser) {
-			if (bootSettings.posthog.key) {
-				posthog.init(bootSettings.posthog.key, {
+			if (bootSettings.posthog.enabled !== false && process.env.POSTHOG_KEY) {
+				posthog.init(process.env.POSTHOG_KEY, {
 					api_host: 'https://us.i.posthog.com',
 					person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
 				});
@@ -342,8 +342,8 @@ function App(): JSX.Element {
 
 			if (!isSentryInitialized) {
 				Sentry.init({
-					dsn: bootSettings.sentry.dsn,
-					tunnel: bootSettings.sentry.tunnelUrl,
+					dsn: process.env.SENTRY_DSN,
+					tunnel: process.env.TUNNEL_URL,
 					environment: 'production',
 					integrations: [
 						Sentry.browserTracingIntegration(),

--- a/frontend/src/typings/window.ts
+++ b/frontend/src/typings/window.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import { compose, Store } from 'redux';
-import type { SignozBootSettings } from 'utils/bootData';
+import type { WebSettings } from 'types/generated/webSettings';
 
 declare global {
 	interface Window {
@@ -8,7 +8,7 @@ declare global {
 		pylon: any;
 		Appcues: Record<string, any>;
 		__REDUX_DEVTOOLS_EXTENSION_COMPOSE__: typeof compose;
-		signozBootData?: { settings?: Partial<SignozBootSettings> };
+		signozBootData?: { settings: WebSettings | null };
 	}
 }
 

--- a/frontend/src/typings/window.ts
+++ b/frontend/src/typings/window.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-restricted-imports
 import { compose, Store } from 'redux';
+import type { SignozBootSettings } from 'utils/bootData';
 
 declare global {
 	interface Window {
@@ -7,6 +8,7 @@ declare global {
 		pylon: any;
 		Appcues: Record<string, any>;
 		__REDUX_DEVTOOLS_EXTENSION_COMPOSE__: typeof compose;
+		signozBootData?: { settings?: Partial<SignozBootSettings> };
 	}
 }
 

--- a/frontend/src/utils/__tests__/bootData.test.ts
+++ b/frontend/src/utils/__tests__/bootData.test.ts
@@ -2,7 +2,7 @@ export {};
 
 type BootData = typeof import('../bootData');
 
-function loadModule(settings?: object): BootData {
+function loadModule(settings?: object | null): BootData {
 	(window as any).signozBootData =
 		settings !== undefined ? { settings } : undefined;
 	let mod!: BootData;
@@ -18,56 +18,57 @@ afterEach(() => {
 });
 
 describe('when window.signozBootData is absent', () => {
-	it('all sub-objects are defined and empty', () => {
+	it('defaults posthog and appcues to enabled', () => {
 		const { bootSettings } = loadModule();
-		expect(bootSettings.posthog).toStrictEqual({});
-		expect(bootSettings.appcues).toStrictEqual({});
+		expect(bootSettings.posthog.enabled).toBe(true);
+		expect(bootSettings.appcues.enabled).toBe(true);
 	});
+});
 
-	it('enabled fields are undefined', () => {
-		const { bootSettings } = loadModule();
-		expect(bootSettings.posthog.enabled).toBeUndefined();
-		expect(bootSettings.appcues.enabled).toBeUndefined();
+describe('when window.signozBootData.settings is null (injection failed)', () => {
+	it('defaults posthog and appcues to enabled', () => {
+		const { bootSettings } = loadModule(null);
+		expect(bootSettings.posthog.enabled).toBe(true);
+		expect(bootSettings.appcues.enabled).toBe(true);
 	});
 });
 
 describe('when window.signozBootData.settings is populated', () => {
-	it('reads posthog enabled true', () => {
+	it('reads posthog enabled: true', () => {
 		const { bootSettings } = loadModule({ posthog: { enabled: true } });
 		expect(bootSettings.posthog.enabled).toBe(true);
 	});
 
-	it('reads posthog enabled false', () => {
+	it('reads posthog enabled: false', () => {
 		const { bootSettings } = loadModule({ posthog: { enabled: false } });
 		expect(bootSettings.posthog.enabled).toBe(false);
 	});
 
-	it('reads appcues enabled true', () => {
+	it('reads appcues enabled: true', () => {
 		const { bootSettings } = loadModule({ appcues: { enabled: true } });
 		expect(bootSettings.appcues.enabled).toBe(true);
 	});
 
-	it('reads appcues enabled false', () => {
+	it('reads appcues enabled: false', () => {
 		const { bootSettings } = loadModule({ appcues: { enabled: false } });
 		expect(bootSettings.appcues.enabled).toBe(false);
 	});
 
-	it('missing sub-namespaces fall back to empty objects', () => {
-		const { bootSettings } = loadModule({ posthog: { enabled: true } });
-		expect(bootSettings.appcues).toStrictEqual({});
-		expect(bootSettings.appcues.enabled).toBeUndefined();
+	it('missing sub-namespace defaults to enabled', () => {
+		const { bootSettings } = loadModule({ posthog: { enabled: false } });
+		expect(bootSettings.appcues.enabled).toBe(true);
 	});
 });
 
 describe('when window.signozBootData exists but settings is undefined', () => {
-	it('all sub-objects are empty', () => {
+	it('defaults posthog and appcues to enabled', () => {
 		(window as any).signozBootData = {};
 		let mod!: BootData;
 		jest.isolateModules(() => {
 			// oxlint-disable-next-line typescript-eslint/no-require-imports, typescript-eslint/no-var-requires
 			mod = require('../bootData');
 		});
-		expect(mod.bootSettings.posthog).toStrictEqual({});
-		expect(mod.bootSettings.appcues).toStrictEqual({});
+		expect(mod.bootSettings.posthog.enabled).toBe(true);
+		expect(mod.bootSettings.appcues.enabled).toBe(true);
 	});
 });

--- a/frontend/src/utils/__tests__/bootData.test.ts
+++ b/frontend/src/utils/__tests__/bootData.test.ts
@@ -20,68 +20,42 @@ afterEach(() => {
 describe('when window.signozBootData is absent', () => {
 	it('all sub-objects are defined and empty', () => {
 		const { bootSettings } = loadModule();
-		expect(bootSettings.sentry).toStrictEqual({});
 		expect(bootSettings.posthog).toStrictEqual({});
-		expect(bootSettings.pylon).toStrictEqual({});
 		expect(bootSettings.appcues).toStrictEqual({});
-		expect(bootSettings.roles).toStrictEqual({});
 	});
 
-	it('optional fields are undefined', () => {
+	it('enabled fields are undefined', () => {
 		const { bootSettings } = loadModule();
-		expect(bootSettings.sentry.dsn).toBeUndefined();
-		expect(bootSettings.sentry.tunnelUrl).toBeUndefined();
-		expect(bootSettings.posthog.key).toBeUndefined();
-		expect(bootSettings.pylon.appId).toBeUndefined();
-		expect(bootSettings.pylon.identSecret).toBeUndefined();
-		expect(bootSettings.appcues.appId).toBeUndefined();
-		expect(bootSettings.roles.isRolesDetailEnabled).toBeUndefined();
+		expect(bootSettings.posthog.enabled).toBeUndefined();
+		expect(bootSettings.appcues.enabled).toBeUndefined();
 	});
 });
 
 describe('when window.signozBootData.settings is populated', () => {
-	it('reads sentry config', () => {
-		const { bootSettings } = loadModule({
-			sentry: { dsn: 'https://abc@sentry.io/1', tunnelUrl: '/tunnel' },
-		});
-		expect(bootSettings.sentry.dsn).toBe('https://abc@sentry.io/1');
-		expect(bootSettings.sentry.tunnelUrl).toBe('/tunnel');
+	it('reads posthog enabled true', () => {
+		const { bootSettings } = loadModule({ posthog: { enabled: true } });
+		expect(bootSettings.posthog.enabled).toBe(true);
 	});
 
-	it('reads posthog config', () => {
-		const { bootSettings } = loadModule({ posthog: { key: 'phk_xxx' } });
-		expect(bootSettings.posthog.key).toBe('phk_xxx');
+	it('reads posthog enabled false', () => {
+		const { bootSettings } = loadModule({ posthog: { enabled: false } });
+		expect(bootSettings.posthog.enabled).toBe(false);
 	});
 
-	it('reads pylon config', () => {
-		const { bootSettings } = loadModule({
-			pylon: { appId: 'pylon-abc', identSecret: 'secret-xyz' },
-		});
-		expect(bootSettings.pylon.appId).toBe('pylon-abc');
-		expect(bootSettings.pylon.identSecret).toBe('secret-xyz');
+	it('reads appcues enabled true', () => {
+		const { bootSettings } = loadModule({ appcues: { enabled: true } });
+		expect(bootSettings.appcues.enabled).toBe(true);
 	});
 
-	it('reads appcues config', () => {
-		const { bootSettings } = loadModule({ appcues: { appId: 'appcues-123' } });
-		expect(bootSettings.appcues.appId).toBe('appcues-123');
-	});
-
-	it('reads roles config', () => {
-		const { bootSettings } = loadModule({
-			roles: { isRolesDetailEnabled: true },
-		});
-		expect(bootSettings.roles.isRolesDetailEnabled).toBe(true);
+	it('reads appcues enabled false', () => {
+		const { bootSettings } = loadModule({ appcues: { enabled: false } });
+		expect(bootSettings.appcues.enabled).toBe(false);
 	});
 
 	it('missing sub-namespaces fall back to empty objects', () => {
-		const { bootSettings } = loadModule({
-			sentry: { dsn: 'https://abc@sentry.io/1' },
-		});
-		expect(bootSettings.posthog).toStrictEqual({});
-		expect(bootSettings.posthog.key).toBeUndefined();
-		expect(bootSettings.pylon).toStrictEqual({});
+		const { bootSettings } = loadModule({ posthog: { enabled: true } });
 		expect(bootSettings.appcues).toStrictEqual({});
-		expect(bootSettings.roles).toStrictEqual({});
+		expect(bootSettings.appcues.enabled).toBeUndefined();
 	});
 });
 
@@ -93,7 +67,7 @@ describe('when window.signozBootData exists but settings is undefined', () => {
 			// oxlint-disable-next-line typescript-eslint/no-require-imports, typescript-eslint/no-var-requires
 			mod = require('../bootData');
 		});
-		expect(mod.bootSettings.sentry).toStrictEqual({});
 		expect(mod.bootSettings.posthog).toStrictEqual({});
+		expect(mod.bootSettings.appcues).toStrictEqual({});
 	});
 });

--- a/frontend/src/utils/__tests__/bootData.test.ts
+++ b/frontend/src/utils/__tests__/bootData.test.ts
@@ -1,0 +1,99 @@
+export {};
+
+type BootData = typeof import('../bootData');
+
+function loadModule(settings?: object): BootData {
+	(window as any).signozBootData =
+		settings !== undefined ? { settings } : undefined;
+	let mod!: BootData;
+	jest.isolateModules(() => {
+		// oxlint-disable-next-line typescript-eslint/no-require-imports, typescript-eslint/no-var-requires
+		mod = require('../bootData');
+	});
+	return mod;
+}
+
+afterEach(() => {
+	delete (window as any).signozBootData;
+});
+
+describe('when window.signozBootData is absent', () => {
+	it('all sub-objects are defined and empty', () => {
+		const { bootSettings } = loadModule();
+		expect(bootSettings.sentry).toStrictEqual({});
+		expect(bootSettings.posthog).toStrictEqual({});
+		expect(bootSettings.pylon).toStrictEqual({});
+		expect(bootSettings.appcues).toStrictEqual({});
+		expect(bootSettings.roles).toStrictEqual({});
+	});
+
+	it('optional fields are undefined', () => {
+		const { bootSettings } = loadModule();
+		expect(bootSettings.sentry.dsn).toBeUndefined();
+		expect(bootSettings.sentry.tunnelUrl).toBeUndefined();
+		expect(bootSettings.posthog.key).toBeUndefined();
+		expect(bootSettings.pylon.appId).toBeUndefined();
+		expect(bootSettings.pylon.identSecret).toBeUndefined();
+		expect(bootSettings.appcues.appId).toBeUndefined();
+		expect(bootSettings.roles.isRolesDetailEnabled).toBeUndefined();
+	});
+});
+
+describe('when window.signozBootData.settings is populated', () => {
+	it('reads sentry config', () => {
+		const { bootSettings } = loadModule({
+			sentry: { dsn: 'https://abc@sentry.io/1', tunnelUrl: '/tunnel' },
+		});
+		expect(bootSettings.sentry.dsn).toBe('https://abc@sentry.io/1');
+		expect(bootSettings.sentry.tunnelUrl).toBe('/tunnel');
+	});
+
+	it('reads posthog config', () => {
+		const { bootSettings } = loadModule({ posthog: { key: 'phk_xxx' } });
+		expect(bootSettings.posthog.key).toBe('phk_xxx');
+	});
+
+	it('reads pylon config', () => {
+		const { bootSettings } = loadModule({
+			pylon: { appId: 'pylon-abc', identSecret: 'secret-xyz' },
+		});
+		expect(bootSettings.pylon.appId).toBe('pylon-abc');
+		expect(bootSettings.pylon.identSecret).toBe('secret-xyz');
+	});
+
+	it('reads appcues config', () => {
+		const { bootSettings } = loadModule({ appcues: { appId: 'appcues-123' } });
+		expect(bootSettings.appcues.appId).toBe('appcues-123');
+	});
+
+	it('reads roles config', () => {
+		const { bootSettings } = loadModule({
+			roles: { isRolesDetailEnabled: true },
+		});
+		expect(bootSettings.roles.isRolesDetailEnabled).toBe(true);
+	});
+
+	it('missing sub-namespaces fall back to empty objects', () => {
+		const { bootSettings } = loadModule({
+			sentry: { dsn: 'https://abc@sentry.io/1' },
+		});
+		expect(bootSettings.posthog).toStrictEqual({});
+		expect(bootSettings.posthog.key).toBeUndefined();
+		expect(bootSettings.pylon).toStrictEqual({});
+		expect(bootSettings.appcues).toStrictEqual({});
+		expect(bootSettings.roles).toStrictEqual({});
+	});
+});
+
+describe('when window.signozBootData exists but settings is undefined', () => {
+	it('all sub-objects are empty', () => {
+		(window as any).signozBootData = {};
+		let mod!: BootData;
+		jest.isolateModules(() => {
+			// oxlint-disable-next-line typescript-eslint/no-require-imports, typescript-eslint/no-var-requires
+			mod = require('../bootData');
+		});
+		expect(mod.bootSettings.sentry).toStrictEqual({});
+		expect(mod.bootSettings.posthog).toStrictEqual({});
+	});
+});

--- a/frontend/src/utils/bootData.ts
+++ b/frontend/src/utils/bootData.ts
@@ -1,11 +1,11 @@
-export interface SignozBootSettings {
-	posthog: { enabled?: boolean };
-	appcues: { enabled?: boolean };
-}
+import type { WebSettings } from 'types/generated/webSettings';
 
-const raw = window.signozBootData?.settings;
+const raw = window.signozBootData?.settings as
+	| Partial<WebSettings>
+	| null
+	| undefined;
 
-export const bootSettings: Readonly<SignozBootSettings> = {
-	posthog: raw?.posthog ?? {},
-	appcues: raw?.appcues ?? {},
+export const bootSettings: Readonly<WebSettings> = {
+	posthog: { enabled: raw?.posthog?.enabled ?? true },
+	appcues: { enabled: raw?.appcues?.enabled ?? true },
 };

--- a/frontend/src/utils/bootData.ts
+++ b/frontend/src/utils/bootData.ts
@@ -1,0 +1,35 @@
+export interface SentryConfig {
+	dsn?: string;
+	tunnelUrl?: string;
+}
+export interface PosthogConfig {
+	key?: string;
+}
+export interface PylonConfig {
+	appId?: string;
+	identSecret?: string;
+}
+export interface AppcuesConfig {
+	appId?: string;
+}
+export interface RolesConfig {
+	isRolesDetailEnabled?: boolean;
+}
+
+export interface SignozBootSettings {
+	sentry: SentryConfig;
+	posthog: PosthogConfig;
+	pylon: PylonConfig;
+	appcues: AppcuesConfig;
+	roles: RolesConfig;
+}
+
+const raw = window.signozBootData?.settings;
+
+export const bootSettings: Readonly<SignozBootSettings> = {
+	sentry: raw?.sentry ?? {},
+	posthog: raw?.posthog ?? {},
+	pylon: raw?.pylon ?? {},
+	appcues: raw?.appcues ?? {},
+	roles: raw?.roles ?? {},
+};

--- a/frontend/src/utils/bootData.ts
+++ b/frontend/src/utils/bootData.ts
@@ -1,35 +1,11 @@
-export interface SentryConfig {
-	dsn?: string;
-	tunnelUrl?: string;
-}
-export interface PosthogConfig {
-	key?: string;
-}
-export interface PylonConfig {
-	appId?: string;
-	identSecret?: string;
-}
-export interface AppcuesConfig {
-	appId?: string;
-}
-export interface RolesConfig {
-	isRolesDetailEnabled?: boolean;
-}
-
 export interface SignozBootSettings {
-	sentry: SentryConfig;
-	posthog: PosthogConfig;
-	pylon: PylonConfig;
-	appcues: AppcuesConfig;
-	roles: RolesConfig;
+	posthog: { enabled?: boolean };
+	appcues: { enabled?: boolean };
 }
 
 const raw = window.signozBootData?.settings;
 
 export const bootSettings: Readonly<SignozBootSettings> = {
-	sentry: raw?.sentry ?? {},
 	posthog: raw?.posthog ?? {},
-	pylon: raw?.pylon ?? {},
 	appcues: raw?.appcues ?? {},
-	roles: raw?.roles ?? {},
 };

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -13,16 +13,9 @@ declare module '*.md?raw' {
 interface ImportMetaEnv {
 	readonly VITE_FRONTEND_API_ENDPOINT: string;
 	readonly VITE_WEBSOCKET_API_ENDPOINT: string;
-	readonly VITE_PYLON_APP_ID: string;
-	readonly VITE_PYLON_IDENTITY_SECRET: string;
-	readonly VITE_APPCUES_APP_ID: string;
-	readonly VITE_POSTHOG_KEY: string;
 	readonly VITE_SENTRY_AUTH_TOKEN: string;
 	readonly VITE_SENTRY_ORG: string;
 	readonly VITE_SENTRY_PROJECT_ID: string;
-	readonly VITE_SENTRY_DSN: string;
-	readonly VITE_TUNNEL_URL: string;
-	readonly VITE_TUNNEL_DOMAIN: string;
 	readonly VITE_DOCS_BASE_URL: string;
 }
 

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -13,9 +13,16 @@ declare module '*.md?raw' {
 interface ImportMetaEnv {
 	readonly VITE_FRONTEND_API_ENDPOINT: string;
 	readonly VITE_WEBSOCKET_API_ENDPOINT: string;
+	readonly VITE_PYLON_APP_ID: string;
+	readonly VITE_PYLON_IDENTITY_SECRET: string;
+	readonly VITE_APPCUES_APP_ID: string;
+	readonly VITE_POSTHOG_KEY: string;
 	readonly VITE_SENTRY_AUTH_TOKEN: string;
 	readonly VITE_SENTRY_ORG: string;
 	readonly VITE_SENTRY_PROJECT_ID: string;
+	readonly VITE_SENTRY_DSN: string;
+	readonly VITE_TUNNEL_URL: string;
+	readonly VITE_TUNNEL_DOMAIN: string;
 	readonly VITE_DOCS_BASE_URL: string;
 }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,6 @@ import type { Plugin, TransformResult, UserConfig } from 'vite';
 import { defineConfig, loadEnv } from 'vite';
 import vitePluginChecker from 'vite-plugin-checker';
 import viteCompression from 'vite-plugin-compression';
-import { createHtmlPlugin } from 'vite-plugin-html';
 import { ViteImageOptimizer } from 'vite-plugin-image-optimizer';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
@@ -19,6 +18,29 @@ function devBasePathPlugin(basePath: string): Plugin {
 		apply: 'serve',
 		transformIndexHtml(html): string {
 			return html.replaceAll('[[.BaseHref]]', basePath);
+		},
+	};
+}
+
+function devBootDataPlugin(env: Record<string, string>): Plugin {
+	return {
+		name: 'dev-boot-data',
+		apply: 'serve',
+		transformIndexHtml(html): string {
+			const bootSettings = {
+				sentry: {
+					dsn: env.VITE_SENTRY_DSN || undefined,
+					tunnelUrl: env.VITE_TUNNEL_URL || undefined,
+				},
+				posthog: { key: env.VITE_POSTHOG_KEY || undefined },
+				pylon: {
+					appId: env.VITE_PYLON_APP_ID || undefined,
+					identSecret: env.VITE_PYLON_IDENTITY_SECRET || undefined,
+				},
+				appcues: { appId: env.VITE_APPCUES_APP_ID || undefined },
+				roles: {},
+			};
+			return html.replaceAll('[[.BootSettings]]', JSON.stringify(bootSettings));
 		},
 	};
 }
@@ -47,15 +69,8 @@ export default defineConfig(({ mode }): UserConfig => {
 		tsconfigPaths(),
 		rawMarkdownPlugin(),
 		devBasePathPlugin(basePath),
+		devBootDataPlugin(env),
 		react(),
-		createHtmlPlugin({
-			inject: {
-				data: {
-					PYLON_APP_ID: env.VITE_PYLON_APP_ID || '',
-					APPCUES_APP_ID: env.VITE_APPCUES_APP_ID || '',
-				},
-			},
-		}),
 		vitePluginChecker({
 			typescript: true,
 			// this doubles the build tim
@@ -126,17 +141,8 @@ export default defineConfig(({ mode }): UserConfig => {
 			'process.env.WEBSOCKET_API_ENDPOINT': JSON.stringify(
 				env.VITE_WEBSOCKET_API_ENDPOINT,
 			),
-			'process.env.PYLON_APP_ID': JSON.stringify(env.VITE_PYLON_APP_ID),
-			'process.env.PYLON_IDENTITY_SECRET': JSON.stringify(
-				env.VITE_PYLON_IDENTITY_SECRET,
-			),
-			'process.env.APPCUES_APP_ID': JSON.stringify(env.VITE_APPCUES_APP_ID),
-			'process.env.POSTHOG_KEY': JSON.stringify(env.VITE_POSTHOG_KEY),
 			'process.env.SENTRY_ORG': JSON.stringify(env.VITE_SENTRY_ORG),
 			'process.env.SENTRY_PROJECT_ID': JSON.stringify(env.VITE_SENTRY_PROJECT_ID),
-			'process.env.SENTRY_DSN': JSON.stringify(env.VITE_SENTRY_DSN),
-			'process.env.TUNNEL_URL': JSON.stringify(env.VITE_TUNNEL_URL),
-			'process.env.TUNNEL_DOMAIN': JSON.stringify(env.VITE_TUNNEL_DOMAIN),
 			'process.env.DOCS_BASE_URL': JSON.stringify(env.VITE_DOCS_BASE_URL),
 		},
 		// In production, use relative paths so assets work with any base path injected by the backend.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,7 @@ import type { Plugin, TransformResult, UserConfig } from 'vite';
 import { defineConfig, loadEnv } from 'vite';
 import vitePluginChecker from 'vite-plugin-checker';
 import viteCompression from 'vite-plugin-compression';
+import { createHtmlPlugin } from 'vite-plugin-html';
 import { ViteImageOptimizer } from 'vite-plugin-image-optimizer';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
@@ -27,20 +28,11 @@ function devBootDataPlugin(env: Record<string, string>): Plugin {
 		name: 'dev-boot-data',
 		apply: 'serve',
 		transformIndexHtml(html): string {
-			const bootSettings = {
-				sentry: {
-					dsn: env.VITE_SENTRY_DSN || undefined,
-					tunnelUrl: env.VITE_TUNNEL_URL || undefined,
-				},
-				posthog: { key: env.VITE_POSTHOG_KEY || undefined },
-				pylon: {
-					appId: env.VITE_PYLON_APP_ID || undefined,
-					identSecret: env.VITE_PYLON_IDENTITY_SECRET || undefined,
-				},
-				appcues: { appId: env.VITE_APPCUES_APP_ID || undefined },
-				roles: {},
+			const settings = {
+				posthog: { enabled: env.VITE_POSTHOG_ENABLED !== 'false' },
+				appcues: { enabled: env.VITE_APPCUES_ENABLED !== 'false' },
 			};
-			return html.replaceAll('[[.BootSettings]]', JSON.stringify(bootSettings));
+			return html.replaceAll('[[.Settings]]', JSON.stringify(settings));
 		},
 	};
 }
@@ -71,6 +63,14 @@ export default defineConfig(({ mode }): UserConfig => {
 		devBasePathPlugin(basePath),
 		devBootDataPlugin(env),
 		react(),
+		createHtmlPlugin({
+			inject: {
+				data: {
+					PYLON_APP_ID: env.VITE_PYLON_APP_ID || '',
+					APPCUES_APP_ID: env.VITE_APPCUES_APP_ID || '',
+				},
+			},
+		}),
 		vitePluginChecker({
 			typescript: true,
 			// this doubles the build tim
@@ -141,8 +141,17 @@ export default defineConfig(({ mode }): UserConfig => {
 			'process.env.WEBSOCKET_API_ENDPOINT': JSON.stringify(
 				env.VITE_WEBSOCKET_API_ENDPOINT,
 			),
+			'process.env.PYLON_APP_ID': JSON.stringify(env.VITE_PYLON_APP_ID),
+			'process.env.PYLON_IDENTITY_SECRET': JSON.stringify(
+				env.VITE_PYLON_IDENTITY_SECRET,
+			),
+			'process.env.APPCUES_APP_ID': JSON.stringify(env.VITE_APPCUES_APP_ID),
+			'process.env.POSTHOG_KEY': JSON.stringify(env.VITE_POSTHOG_KEY),
 			'process.env.SENTRY_ORG': JSON.stringify(env.VITE_SENTRY_ORG),
 			'process.env.SENTRY_PROJECT_ID': JSON.stringify(env.VITE_SENTRY_PROJECT_ID),
+			'process.env.SENTRY_DSN': JSON.stringify(env.VITE_SENTRY_DSN),
+			'process.env.TUNNEL_URL': JSON.stringify(env.VITE_TUNNEL_URL),
+			'process.env.TUNNEL_DOMAIN': JSON.stringify(env.VITE_TUNNEL_DOMAIN),
 			'process.env.DOCS_BASE_URL': JSON.stringify(env.VITE_DOCS_BASE_URL),
 		},
 		// In production, use relative paths so assets work with any base path injected by the backend.


### PR DESCRIPTION
## What and why

PostHog and Appcues were always initialised whenever their build-time keys were present. There was no way to turn them off for a specific deployment without removing the key and doing a full rebuild.

This PR wires up the runtime control mechanism from [platform-pod#2144](https://github.com/SigNoz/platform-pod/issues/2144). The Go backend (#11444) injects `window.signozBootData` into `index.html` at serve time via a Go template. The frontend reads it once at startup and uses the `enabled` flags to gate SDK initialisation. Operators can disable either service by setting `enabled: false` in their deployment config and restarting — no rebuild needed.

The BE↔FE contract is enforced by auto-generated TypeScript types (#11445): the Go `Settings` struct → `docs/config/web-settings.json` → `src/types/generated/webSettings.ts`. CI fails on both sides if the schema drifts.

Closes: https://github.com/SigNoz/platform-pod/issues/2144

---

## What changed

### `index.html`

Settings are injected via a `<script type="application/json">` data tag — the browser never executes its content as JS, so the raw `[[.Settings]]` token is safe even when template substitution hasn't run (e.g. `pnpm preview`):

```html
<script type="application/json" id="signoz-boot-settings">[[.Settings]]</script>
<script>
  try {
    var _el = document.getElementById('signoz-boot-settings');
    window.signozBootData = { settings: _el ? JSON.parse(_el.textContent) : null };
  } catch (e) {
    window.signozBootData = { settings: null };
  }
</script>
```

Pylon keeps its existing EJS `<%- PYLON_APP_ID %>` substitution unchanged. The Appcues loader is gated on `appcues.enabled` from the injected settings, using ES5-safe property access (no optional chaining — inline scripts are not transpiled by Vite):

```js
var APPCUES_APP_ID = '<%- APPCUES_APP_ID %>';
var appcuesSettings = (((window.signozBootData || {}).settings || {}).appcues || {});
var appcuesEnabled = appcuesSettings.enabled !== false;
if (APPCUES_APP_ID && appcuesEnabled) { /* load */ }
```

### `src/utils/bootData.ts` (new)

Reads `window.signozBootData.settings` at module init and exports a typed `bootSettings` singleton. Uses the auto-generated `WebSettings` interface as the canonical type — no hand-rolled contract:

```ts
import type { WebSettings } from 'types/generated/webSettings';

const raw = window.signozBootData?.settings as Partial<WebSettings> | null | undefined;

export const bootSettings: Readonly<WebSettings> = {
  posthog: { enabled: raw?.posthog?.enabled ?? true },
  appcues: { enabled: raw?.appcues?.enabled ?? true },
};
```

`?? true` — when injection is absent or fails, both services default to enabled, preserving existing behaviour.

### `src/typings/window.ts`

`signozBootData` is typed against the generated `WebSettings`, not a hand-rolled interface:

```ts
signozBootData?: { settings: WebSettings | null };
```

### `vite.config.ts`

Adds `devBootDataPlugin` — in local dev (no Go backend), replaces `[[.Settings]]` with `{ posthog: { enabled: true }, appcues: { enabled: true } }`. Set `VITE_POSTHOG_ENABLED=false` or `VITE_APPCUES_ENABLED=false` in `.env` to test the disabled path locally.

Keeps `createHtmlPlugin` for Pylon and Appcues IDs, and all `process.env.*` SDK entries in the `define` block — unchanged from main.

### `src/AppRoutes/index.tsx`

PostHog init is gated on the `enabled` flag. Since `WebSettings.enabled` is `boolean` (never `undefined`), the check is a direct boolean:

```ts
if (bootSettings.posthog.enabled && process.env.POSTHOG_KEY) {
  posthog.init(process.env.POSTHOG_KEY, { ... });
}
```

Sentry and Pylon are unaffected — they read directly from `process.env.*`.

---

## How to test locally

No config changes needed. Existing `VITE_*` env vars in `.env` continue to work as before.

To test the disabled path: add `VITE_POSTHOG_ENABLED=false` or `VITE_APPCUES_ENABLED=false` to `.env` and run `pnpm dev`. Check `window.signozBootData` in the browser console to confirm the injected value.

---

## Reviewer notes

- Scope is limited to PostHog and Appcues. Sentry, Pylon, and Segment are not included.
- BE dependencies: #11444 (injection) and #11445 (generated types) are both merged.
- The `<script type="application/json">` pattern means an unsubstituted `[[.Settings]]` token never causes a JS parse error — `JSON.parse` throws at runtime instead, the catch sets `settings: null`, and both services default to enabled.
- `VITE_SENTRY_AUTH_TOKEN`, `VITE_SENTRY_ORG`, `VITE_SENTRY_PROJECT_ID` are kept — used by the Sentry source-maps Vite plugin at build time only.
- If `WebSettings` gains a new required field, `bootData.ts` will fail to compile until a default is added — drift is caught at build time, not in production.