### PR TITLE
feat: add total count to v2 dashboards list response

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -2782,10 +2782,16 @@ components:
         dashboards:
           items:
             $ref: '#/components/schemas/DashboardtypesGettableDashboardWithPin'
-          nullable: true
           type: array
         hasMore:
           type: boolean
+        total:
+          format: int64
+          type: integer
+      required:
+      - dashboards
+      - hasMore
+      - total
       type: object
     DashboardtypesNumberPanelSpec:
       properties:

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -4713,13 +4713,18 @@ export type DashboardtypesJSONPatchDocumentDTO =
 
 export interface DashboardtypesListableDashboardV2DTO {
 	/**
-	 * @type array,null
+	 * @type array
 	 */
-	dashboards?: DashboardtypesGettableDashboardWithPinDTO[] | null;
+	dashboards: DashboardtypesGettableDashboardWithPinDTO[];
 	/**
 	 * @type boolean
 	 */
-	hasMore?: boolean;
+	hasMore: boolean;
+	/**
+	 * @type integer
+	 * @format int64
+	 */
+	total: number;
 }
 
 export enum DashboardtypesPanelPluginKindDTO {

--- a/pkg/modules/dashboard/impldashboard/store.go
+++ b/pkg/modules/dashboard/impldashboard/store.go
@@ -122,10 +122,10 @@ func (store *store) ListV2(
 	orgID valuer.UUID,
 	userID valuer.UUID,
 	params *dashboardtypes.ListDashboardsV2Params,
-) ([]*dashboardtypes.DashboardListRow, bool, error) {
+) ([]*dashboardtypes.DashboardListRow, bool, int64, error) {
 	compiled, err := listfilter.Compile(params.Query, store.sqlstore.Formatter())
 	if err != nil {
-		return nil, false, err
+		return nil, false, 0, err
 	}
 	type listedRow struct {
 		*dashboardtypes.StorableDashboard `bun:",extend"`
@@ -158,8 +158,22 @@ func (store *store) ListV2(
 
 	sortExpr, err := store.sortExprForListV2(params.Sort)
 	if err != nil {
-		return nil, false, err
+		return nil, false, 0, err
 	}
+
+	countQ := store.sqlstore.
+		BunDB().
+		NewSelect().
+		Model((*dashboardtypes.StorableDashboard)(nil)).
+		Where("dashboard.org_id = ?", orgID)
+	if compiled != nil {
+		countQ = countQ.Where(compiled.SQL, compiled.Args...)
+	}
+	total, err := countQ.Count(ctx)
+	if err != nil {
+		return nil, false, 0, err
+	}
+
 	q = q.
 		OrderExpr("is_pinned DESC").
 		OrderExpr(sortExpr + " " + strings.ToUpper(string(params.Order))).
@@ -167,7 +181,7 @@ func (store *store) ListV2(
 		Offset(params.Offset)
 
 	if err := q.Scan(ctx); err != nil {
-		return nil, false, err
+		return nil, false, 0, err
 	}
 
 	hasMore := len(rows) > params.Limit
@@ -192,7 +206,7 @@ func (store *store) ListV2(
 		}
 		out[i] = row
 	}
-	return out, hasMore, nil
+	return out, hasMore, int64(total), nil
 }
 
 // sortExprForListV2 maps a sort enum to the SQL expression to plug into

--- a/pkg/modules/dashboard/impldashboard/v2_module.go
+++ b/pkg/modules/dashboard/impldashboard/v2_module.go
@@ -44,7 +44,7 @@ func (m *module) CreateV2(ctx context.Context, orgID valuer.UUID, createdBy stri
 // and limit+1/hasMore detection), batch-fetches tags for the returned
 // dashboard ids, and hands off to the type-side constructor for assembly.
 func (module *module) ListV2(ctx context.Context, orgID valuer.UUID, userID valuer.UUID, params *dashboardtypes.ListDashboardsV2Params) (*dashboardtypes.ListableDashboardV2, error) {
-	rows, hasMore, err := module.store.ListV2(ctx, orgID, userID, params)
+	rows, hasMore, total, err := module.store.ListV2(ctx, orgID, userID, params)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (module *module) ListV2(ctx context.Context, orgID valuer.UUID, userID valu
 		return nil, err
 	}
 
-	return dashboardtypes.NewListableDashboardV2(rows, tagsByDashboard, hasMore)
+	return dashboardtypes.NewListableDashboardV2(rows, tagsByDashboard, hasMore, total)
 }
 
 func (module *module) GetV2(ctx context.Context, orgID valuer.UUID, id valuer.UUID) (*dashboardtypes.DashboardV2, error) {

--- a/pkg/types/dashboardtypes/list_v2.go
+++ b/pkg/types/dashboardtypes/list_v2.go
@@ -92,8 +92,9 @@ type gettableDashboardWithPin struct {
 }
 
 type ListableDashboardV2 struct {
-	Dashboards []*gettableDashboardWithPin `json:"dashboards"`
-	HasMore    bool                        `json:"hasMore"`
+	Dashboards []*gettableDashboardWithPin `json:"dashboards" required:"true" nullable:"false"`
+	HasMore    bool                        `json:"hasMore" required:"true"`
+	Total      int64                       `json:"total" required:"true"`
 }
 
 // DashboardListRow is the per-row shape Store.ListV2 returns. Bundles the
@@ -105,7 +106,7 @@ type DashboardListRow struct {
 	Pinned    bool
 }
 
-func NewListableDashboardV2(rows []*DashboardListRow, tagsByEntity map[valuer.UUID][]*tagtypes.Tag, hasMore bool) (*ListableDashboardV2, error) {
+func NewListableDashboardV2(rows []*DashboardListRow, tagsByEntity map[valuer.UUID][]*tagtypes.Tag, hasMore bool, total int64) (*ListableDashboardV2, error) {
 	dashboards := make([]*gettableDashboardWithPin, len(rows))
 	for i, r := range rows {
 		v2, err := r.Dashboard.ToDashboardV2(tagsByEntity[r.Dashboard.ID])
@@ -121,5 +122,6 @@ func NewListableDashboardV2(rows []*DashboardListRow, tagsByEntity map[valuer.UU
 	return &ListableDashboardV2{
 		Dashboards: dashboards,
 		HasMore:    hasMore,
+		Total:      total,
 	}, nil
 }

--- a/pkg/types/dashboardtypes/store.go
+++ b/pkg/types/dashboardtypes/store.go
@@ -43,7 +43,8 @@ type Store interface {
 	LockUnlockV2(ctx context.Context, orgID valuer.UUID, id valuer.UUID, locked bool, updatedBy string) error
 
 	// bool return is hasMore — the store fetches Limit+1 to detect it.
-	ListV2(ctx context.Context, orgID valuer.UUID, userID valuer.UUID, params *ListDashboardsV2Params) ([]*DashboardListRow, bool, error)
+	// int64 return is the total count of rows matching the filter (ignoring limit/offset).
+	ListV2(ctx context.Context, orgID valuer.UUID, userID valuer.UUID, params *ListDashboardsV2Params) ([]*DashboardListRow, bool, int64, error)
 
 	// Returns ErrCodePinnedDashboardLimitHit when the user is at MaxPinnedDashboardsPerUser.
 	PinForUser(ctx context.Context, pd *PinnedDashboard) error


### PR DESCRIPTION
## Summary

Adds a `total` field to the `GET /api/v2/dashboards` response so the frontend can drive an antd `<Pagination>` with a real count instead of synthesising one from `hasMore`. Also tightens the response shape — `dashboards`, `hasMore`, and `total` are now required (and `dashboards` is non-nullable).

## Change Type

- [x] Feature

## Testing Strategy

- Manually verified the regenerated openapi.yml renders the `total` integer and adds the three required fields to `DashboardtypesListableDashboardV2`.
- Frontend codegen runs cleanly; downstream consumers can now treat `dashboards`/`hasMore`/`total` as guaranteed.
- COUNT query reuses the same `org_id` + filter DSL predicates as the SELECT, so it tracks the page exactly.

## Risk & Impact Assessment

- Adds one extra COUNT query per list call. Negligible for current dashboard volumes; same indexes apply.
- Response shape change is backward compatible — added fields, no removals.

## Changelog

- N/A (BE internal)

## Notes for Reviewers

- `dashboard.go` handler/router was already wired up via the `nv/v2-list-dashboard` branch — this PR only adds `Total` to the response type, the COUNT in the store, and the module passthrough.
- Frontend regen artifacts (`frontend/src/api/generated/`) are included so the consumer side stays in sync.