### PR TITLE
fix: show formula alias for missing series labels

### DIFF
--- a/frontend/src/container/PanelWrapper/__tests__/getQueryResults.test.ts
+++ b/frontend/src/container/PanelWrapper/__tests__/getQueryResults.test.ts
@@ -1,4 +1,7 @@
-import { getLegend } from 'lib/dashboard/getQueryResults';
+import {
+	getLegend,
+	shouldShowFormulaMissingDataLegendInfo,
+} from 'lib/dashboard/getQueryResults';
 import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { QueryData } from 'types/api/widgets/getQuery';
 import { EQueryType } from 'types/common/dashboard';
@@ -285,5 +288,81 @@ describe('getLegend', () => {
 
 		const legendsData = getLegend(mockQueryData, payloadQuery, MOCK_LABEL_NAME);
 		expect(legendsData).toBe(`total-${MOCK_LABEL_NAME}`);
+	});
+
+	it('should return formula query name when formula label has missing component data', () => {
+		const formulaQueryData = {
+			...mockQueryData,
+			queryName: 'F1',
+			metaData: {
+				...mockQueryData.metaData,
+				queryName: 'F1',
+			},
+		};
+		const payloadQuery = getMockQuery({
+			...mockQuery,
+			builder: {
+				...mockQuery.builder,
+				queryData: [
+					{
+						...mockQuery.builder.queryData[0],
+						queryName: 'A',
+						dataSource: DataSource.LOGS,
+					},
+					{
+						...mockQuery.builder.queryData[0],
+						queryName: 'B',
+						dataSource: DataSource.LOGS,
+					},
+				],
+				queryFormulas: [
+					{
+						queryName: 'F1',
+						expression: 'A / B',
+						legend: '{{service.name}}',
+						disabled: false,
+					},
+				],
+			},
+		});
+
+		const legendsData = getLegend(formulaQueryData, payloadQuery, 'undefined');
+
+		expect(legendsData).toBe('F1');
+		expect(
+			shouldShowFormulaMissingDataLegendInfo(
+				formulaQueryData,
+				payloadQuery,
+				'undefined',
+			),
+		).toBe(true);
+	});
+
+	it('should not replace non-formula labels that contain missing component data', () => {
+		const payloadQuery = getMockQuery({
+			...mockQuery,
+			builder: {
+				...mockQuery.builder,
+				queryData: [
+					{
+						...mockQuery.builder.queryData[0],
+						queryName: mockQueryData.queryName,
+						dataSource: DataSource.LOGS,
+					},
+				],
+				queryFormulas: [],
+			},
+		});
+
+		const legendsData = getLegend(mockQueryData, payloadQuery, 'undefined');
+
+		expect(legendsData).toBe('count()');
+		expect(
+			shouldShowFormulaMissingDataLegendInfo(
+				mockQueryData,
+				payloadQuery,
+				'undefined',
+			),
+		).toBe(false);
 	});
 });

--- a/frontend/src/lib/dashboard/getQueryResults.ts
+++ b/frontend/src/lib/dashboard/getQueryResults.ts
@@ -29,6 +29,23 @@ import { DataSource } from 'types/common/queryBuilder';
 
 import { prepareQueryRangePayload } from './prepareQueryRangePayload';
 
+export const FORMULA_MISSING_DATA_LEGEND_TOOLTIP =
+	'No data is available from one or more formula components.';
+
+export const hasMissingFormulaComponentLabel = (labelName: string): boolean =>
+	labelName.trim() === '' || /\bundefined\b/.test(labelName);
+
+export const shouldShowFormulaMissingDataLegendInfo = (
+	queryData: QueryData,
+	payloadQuery: Query | undefined,
+	labelName: string,
+): boolean =>
+	payloadQuery?.queryType === EQueryType.QUERY_BUILDER &&
+	payloadQuery.builder?.queryFormulas?.some(
+		(formula) => formula.queryName === queryData.queryName,
+	) &&
+	hasMissingFormulaComponentLabel(labelName);
+
 /**
  * Validates if metric name is available for METRICS data source
  */
@@ -123,6 +140,12 @@ export const getLegend = (
 	// For non-query builder queries, return the label name directly
 	if (payloadQuery.queryType !== EQueryType.QUERY_BUILDER) {
 		return labelName;
+	}
+
+	if (
+		shouldShowFormulaMissingDataLegendInfo(queryData, payloadQuery, labelName)
+	) {
+		return queryData.queryName;
 	}
 
 	// Combine queryData and queryTraceOperator

--- a/frontend/src/lib/uPlotLib/getUplotChartOptions.ts
+++ b/frontend/src/lib/uPlotLib/getUplotChartOptions.ts
@@ -9,7 +9,11 @@ import {
 	calculateEnhancedLegendConfig,
 } from 'container/PanelWrapper/enhancedLegend';
 import { Dimensions } from 'hooks/useDimensions';
-import { getLegend } from 'lib/dashboard/getQueryResults';
+import {
+	FORMULA_MISSING_DATA_LEGEND_TOOLTIP,
+	getLegend,
+	shouldShowFormulaMissingDataLegendInfo,
+} from 'lib/dashboard/getQueryResults';
 import { convertValue } from 'lib/getConvertedValue';
 import getLabelName from 'lib/getLabelName';
 import { cloneDeep, isUndefined } from 'lodash-es';
@@ -235,6 +239,16 @@ export const getUPlotChartOptions = ({
 	const seriesLabels = enhancedLegend
 		? (apiResponse?.data?.result || []).map((item) =>
 				getLegend(
+					item,
+					query || currentQuery,
+					getLabelName(item.metric || {}, item.queryName || '', item.legend || ''),
+				),
+			)
+		: [];
+
+	const formulaMissingDataLegendInfo = enhancedLegend
+		? (apiResponse?.data?.result || []).map((item) =>
+				shouldShowFormulaMissingDataLegendInfo(
 					item,
 					query || currentQuery,
 					getLabelName(item.metric || {}, item.queryName || '', item.legend || ''),
@@ -576,6 +590,18 @@ export const getUPlotChartOptions = ({
 								textSpan.className = 'legend-text';
 								textSpan.textContent = legendText;
 								fragment.appendChild(textSpan);
+
+								if (formulaMissingDataLegendInfo[index]) {
+									const infoIcon = document.createElement('span');
+									infoIcon.className = 'legend-info-icon';
+									infoIcon.textContent = 'i';
+									infoIcon.title = FORMULA_MISSING_DATA_LEGEND_TOOLTIP;
+									infoIcon.setAttribute(
+										'aria-label',
+										FORMULA_MISSING_DATA_LEGEND_TOOLTIP,
+									);
+									fragment.appendChild(infoIcon);
+								}
 
 								// Replace the children in a single operation
 								thElement.replaceChildren(fragment);

--- a/frontend/src/lib/uPlotLib/uPlotLib.styles.scss
+++ b/frontend/src/lib/uPlotLib/uPlotLib.styles.scss
@@ -37,3 +37,20 @@
 		}
 	}
 }
+
+.legend-info-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 12px;
+	height: 12px;
+	margin-left: 6px;
+	border: 1px solid currentColor;
+	border-radius: 50%;
+	font-size: 9px;
+	font-weight: 600;
+	line-height: 1;
+	opacity: 0.75;
+	vertical-align: middle;
+	cursor: help;
+}


### PR DESCRIPTION
## What changed
- Fall back to the formula query name when a formula legend resolves to a missing component label such as `undefined`.
- Add an inline info marker in the uPlot legend for formula series where one or more components have no data.
- Add focused tests for formula missing-component legend fallback and non-formula behavior.

## Why it changed
Formula series could render with `undefined` as the time series label when a referenced query had no data and the formula legend depended on that query's group-by value. Showing the formula name keeps the chart understandable, and the info marker explains why the fallback is shown.

## Tests run
- `npm test -- --runTestsByPath src/container/PanelWrapper/__tests__/getQueryResults.test.ts`
- `npx oxfmt --check src/container/PanelWrapper/__tests__/getQueryResults.test.ts src/lib/dashboard/getQueryResults.ts src/lib/uPlotLib/getUplotChartOptions.ts src/lib/uPlotLib/uPlotLib.styles.scss`
- `npx stylelint src/lib/uPlotLib/uPlotLib.styles.scss`
- `npx oxlint src/container/PanelWrapper/__tests__/getQueryResults.test.ts src/lib/dashboard/getQueryResults.ts src/lib/uPlotLib/getUplotChartOptions.ts` *(reports existing warning-level dependency-cycle / legacy `@ts-nocheck` warnings, no errors)*

Fixes #11280