### PR TITLE
fix: handle body json for default view

### DIFF
--- a/frontend/src/components/Logs/ListLogView/index.tsx
+++ b/frontend/src/components/Logs/ListLogView/index.tsx
@@ -5,7 +5,10 @@ import cx from 'classnames';
 import { VIEW_TYPES } from 'components/LogDetail/constants';
 import { DATE_TIME_FORMATS } from 'constants/dateTimeFormats';
 import { ChangeViewFunctionType } from 'container/ExplorerOptions/types';
-import { getSanitizedLogBody } from 'container/LogDetailedView/utils';
+import {
+	getBodyDisplayString,
+	getSanitizedLogBody,
+} from 'container/LogDetailedView/utils';
 import { FontSize } from 'container/OptionsMenu/types';
 import { useCopyLogLink } from 'hooks/logs/useCopyLogLink';
 import { useIsDarkMode } from 'hooks/useDarkMode';
@@ -196,7 +199,7 @@ function ListLogView({
 							{updatedSelecedFields.some((field) => field.name === 'body') && (
 								<LogGeneralField
 									fieldKey="Log"
-									fieldValue={flattenLogData.body}
+									fieldValue={getBodyDisplayString(logData.body)}
 									linesPerRow={linesPerRow}
 									fontSize={fontSize}
 								/>


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The default Logs Explorer view (ListLogView) crashes with `TypeError: Cannot read properties of undefined (reading 'replace')` when log `body` arrives as a JSON object instead of a string. The crash trips the ErrorBoundary and blanks the page. The Column and Raw views render fine because they already go through the `getBodyDisplayString` helper introduced in #11291 — this PR routes ListLogView through the same helper so all three views behave consistently.

#### Screenshots / Screen Recordings (if applicable)
N/A — fix unblocks the existing ListLogView; behavior matches the already-shipped Column/Raw views.

#### Issues closed by this PR
N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
Regression introduced by #11291 ("chore: Accept body as Map in FE"), which widened `ILog.body` from `string` to `string | ILogBody` and migrated render sites to `getBodyDisplayString`. Two of the three Logs Explorer views were migrated (Column → `useLogsTableColumns.tsx`, Raw → `RawLogView/index.tsx`), but the default view (`ListLogView/index.tsx`) was missed.

In the default view, `flattenLogData.body` was passed straight into `<LogGeneralField fieldValue=... />`, whose `useMemo` invokes `getSanitizedLogBody(fieldValue, { shouldEscapeHtml: true })` → `escapeHtml(text)` → `text.replace(/&/g, ...)`. With JSON-body enabled, `logData.body` is a plain object, so `FlatLogData` does not produce a top-level `body` string and `flattenLogData.body` is `undefined`. `escapeHtml(undefined)` then throws.

Observed in production from a real user session — frontend stack trace pointed to `LogDetailedView/utils.tsx:347` (`escapeHtml`) called from `:427` (`getSanitizedLogBody`) inside the `useMemo` at `ListLogView/index.tsx:48`, mounted under `LogsModulePage → EventSource`.

#### Fix Strategy
Pass `logData.body` through `getBodyDisplayString` (the helper added by #11291) before handing it to `LogGeneralField`. This produces a string in both branches: returns the value as-is when it's already a string, and `JSON.stringify`s it when it's an `ILogBody` object. ListLogView now matches the contract the Column and Raw views already rely on.

Minimal, surgical change — no new helper introduced and no signature changes.

---

### 🧪 Testing Strategy

- Tests added/updated: None — existing rendering tests for ListLogView still pass; the change is a one-line swap of the same shape.
- Manual verification:
  - Default view with string `body` (JSON-body feature disabled): renders identically to before.
  - Default view with object `body` (JSON-body feature enabled): renders the stringified JSON instead of crashing the ErrorBoundary.
  - Column and Raw views: unchanged.
- Edge cases covered:
  - `body` is a string → returned as-is.
  - `body` is an object → JSON-stringified for display.
  - Note: `getBodyDisplayString` does not currently guard against `null`/`undefined` body (`JSON.stringify(undefined)` returns the value `undefined`). That's a pre-existing latent issue in the helper itself; hardening it is left for a follow-up so this PR stays scoped to unblocking the default view.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: One file, one component (`Logs/ListLogView`). Only affects the default Logs Explorer list view.
- Potential regressions: Very low. The new value passed to `LogGeneralField` is always a string (matching the original type expectation of `fieldValue: string`), so all downstream code paths see a strictly narrower input than before.
- Rollback plan: Revert this commit. The default view returns to the previous broken state for object-body environments, but the Column/Raw views continue to work.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fix Logs Explorer default view crashing when log `body` is a JSON object (regression from #11291). |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Follow-up worth considering separately:
  - Harden `getBodyDisplayString` to handle `null`/`undefined` input (return `''`).
  - Harden `escapeHtml` / `getSanitizedLogBody` to short-circuit on non-string input so a single malformed row can never blank the entire Logs Explorer via ErrorBoundary.
  - Audit `lib/logs/flatLogData` — `LogDetailedView/TableView.tsx` already had to add an object-body normalization shim before calling `flattenObject`; the same concern likely exists for any other caller of `FlatLogData` that reads `.body`.