### PR TITLE
fix(apm): use dynamic stepInterval for API monitoring time range on endpoints page

### DIFF
--- a/frontend/src/container/MetricsApplication/Tabs/External.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/External.tsx
@@ -263,7 +263,7 @@ function External(): JSX.Element {
 							timestamp: selectedTimeStamp,
 							domainName: selectedData?.address || '',
 							isError: true,
-							stepInterval: 300,
+							stepInterval,
 							safeNavigate,
 						})}
 					/>
@@ -306,7 +306,7 @@ function External(): JSX.Element {
 							timestamp: selectedTimeStamp,
 							domainName: selectedData?.address,
 							isError: false,
-							stepInterval: 300,
+							stepInterval,
 							safeNavigate,
 						})}
 					/>
@@ -352,7 +352,7 @@ function External(): JSX.Element {
 							timestamp: selectedTimeStamp,
 							domainName: selectedData?.address,
 							isError: false,
-							stepInterval: 300,
+							stepInterval,
 							safeNavigate,
 						})}
 					/>
@@ -395,7 +395,7 @@ function External(): JSX.Element {
 							timestamp: selectedTimeStamp,
 							domainName: selectedData?.address,
 							isError: false,
-							stepInterval: 300,
+							stepInterval,
 							safeNavigate,
 						})}
 					/>

--- a/frontend/src/container/MetricsApplication/Tabs/util.ts
+++ b/frontend/src/container/MetricsApplication/Tabs/util.ts
@@ -151,7 +151,7 @@ export function onViewAPIMonitoringPopupClick({
 	safeNavigate,
 }: OnViewAPIMonitoringPopupClickProps): (e?: React.MouseEvent) => void {
 	return (e?: React.MouseEvent): void => {
-		const endTime = timestamp + (stepInterval || 60);
+		const endTime = timestamp;
 		const startTime = timestamp - (stepInterval || 60);
 		const filters = {
 			items: [


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

On the **External Metrics / Endpoints** tab, clicking a bar in any timeseries chart and pressing **View API Monitoring** opened the destination page with an incorrect time range. The window was hardcoded to 5 minutes (300 s) and extended one full bucket *past* the clicked bar, so the endpoint stats shown didn't match the spans that contributed to that bar.

#### Issues closed by this PR
https://github.com/SigNoz/engineering-pod/issues/4073

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause

Two separate issues combined to produce the wrong time range:

1. **Hardcoded `stepInterval: 300`** — all four `onViewAPIMonitoringPopupClick` calls in `External.tsx` passed a literal `300` instead of the `stepInterval` variable already computed via `getStep(globalTime.minTime, globalTime.maxTime)`.

2. **Wrong `endTime` formula in `util.ts`** — `onViewAPIMonitoringPopupClick` computed `endTime = timestamp + stepInterval`. Since `timestamp` is the bucket's *end* time (consistent with `onViewTracePopupClick` which uses `[timestamp − stepInterval, timestamp]`), the end time should simply be `timestamp`, not `timestamp + stepInterval`.

#### Fix Strategy

- Replace the four `stepInterval: 300` literals in `External.tsx` with the dynamic `stepInterval` variable.
- Change `endTime = timestamp + (stepInterval || 60)` → `endTime = timestamp` in `onViewAPIMonitoringPopupClick` (`util.ts`).

The resulting time range `[timestamp − stepInterval, timestamp]` = `[bucket_start, bucket_end]` now exactly matches the clicked bar.

---

### 🧪 Testing Strategy

- Tests added/updated: none (UI navigation logic)
- Manual verification: click a bar on each of the four charts on the External Metrics tab → View API Monitoring; confirm the destination time range spans exactly one bucket.
- Edge cases covered: time range changes (e.g., 6 h → 48 h) produce a wider step interval that propagates correctly.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: External Metrics tab only; `onViewAPIMonitoringPopupClick` is used exclusively in `External.tsx`.
- Potential regressions: none — `onViewTracePopupClick` is unchanged and `onViewAPIMonitoringPopupClick` is not called anywhere else.
- Rollback plan: revert the two-file change.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | "View API Monitoring" from the Endpoints timeseries charts now opens with a time range matching the clicked bar bucket instead of a hardcoded 5-minute window. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

`timestamp` in these handlers is the bucket's *end* time (the x-axis value Chart.js reports for the data point). `onViewTracePopupClick` already used `[timestamp − stepInterval, timestamp]` correctly; this PR brings `onViewAPIMonitoringPopupClick` in line with the same semantics.

---