### PR TITLE
fix: added utility functions to calculate minimum step intervals and …

### DIFF
--- a/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/components/StatusCodeBarCharts.tsx
+++ b/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/components/StatusCodeBarCharts.tsx
@@ -21,14 +21,17 @@ import { useResizeObserver } from 'hooks/useDimensions';
 import { useNotifications } from 'hooks/useNotifications';
 import { getUPlotChartData } from 'lib/uPlotLib/utils/getUplotChartData';
 import { LegendPosition } from 'lib/uPlotV2/components/types';
-import { getStartAndEndTimesInMilliseconds } from 'pages/MessagingQueues/MessagingQueuesUtils';
 import { useTimezone } from 'providers/Timezone';
 import { SuccessResponse } from 'types/api';
 import { Widgets } from 'types/api/dashboard/getAll';
 import { IBuilderQuery } from 'types/api/queryBuilder/queryBuilderData';
 
 import ErrorState from './ErrorState';
-import { prepareStatusCodeBarChartsConfig } from './utils';
+import {
+	getStepIntervalForQuery,
+	getTracesTimeRangeFromStepInterval,
+	prepareStatusCodeBarChartsConfig,
+} from './utils';
 
 function StatusCodeBarCharts({
 	endPointStatusCodeBarChartsDataQuery,
@@ -135,6 +138,18 @@ function StatusCodeBarCharts({
 		[domainName, filters],
 	);
 
+	const activeApiResponse = useMemo(
+		() =>
+			currentWidgetInfoIndex === 0
+				? formattedEndPointStatusCodeBarChartsDataPayload
+				: formattedEndPointStatusCodeLatencyBarChartsDataPayload,
+		[
+			currentWidgetInfoIndex,
+			formattedEndPointStatusCodeBarChartsDataPayload,
+			formattedEndPointStatusCodeLatencyBarChartsDataPayload,
+		],
+	);
+
 	const graphClickHandler = useCallback(
 		(
 			xValue: number,
@@ -144,11 +159,14 @@ function StatusCodeBarCharts({
 			metric?: { [key: string]: string },
 			queryData?: { queryName: string; inFocusOrNot: boolean },
 		): void => {
-			const TWO_AND_HALF_MINUTES_IN_MILLISECONDS = 2.5 * 60 * 1000; // 150,000 milliseconds
 			const customFilters = getCustomFiltersForBarChart(metric);
-			const { start, end } = getStartAndEndTimesInMilliseconds(
+			const stepInterval = getStepIntervalForQuery(
+				activeApiResponse,
+				queryData?.queryName,
+			);
+			const { start, end } = getTracesTimeRangeFromStepInterval(
 				xValue,
-				TWO_AND_HALF_MINUTES_IN_MILLISECONDS,
+				stepInterval,
 			);
 
 			handleGraphClick({
@@ -171,6 +189,7 @@ function StatusCodeBarCharts({
 			});
 		},
 		[
+			activeApiResponse,
 			widget,
 			navigateToExplorerPages,
 			navigateToExplorer,

--- a/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/components/__tests__/utils.test.ts
+++ b/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/components/__tests__/utils.test.ts
@@ -1,0 +1,68 @@
+import {
+	getMinStepIntervalFromApiResponse,
+	getStepIntervalForQuery,
+	getTracesTimeRangeFromStepInterval,
+} from '../utils';
+
+describe('StatusCodeBarCharts utils', () => {
+	describe('getTracesTimeRangeFromStepInterval', () => {
+		const xValue = 1609459200; // seconds
+
+		it('keeps start at click time with a minimum 5 minute end range', () => {
+			const { start, end } = getTracesTimeRangeFromStepInterval(xValue, 60);
+
+			expect(start).toBe(xValue * 1000);
+			expect(end - start).toBe(5 * 60 * 1000);
+			expect(end).toBe(xValue * 1000 + 5 * 60 * 1000);
+		});
+
+		it('extends end when step interval is larger than 5 minutes', () => {
+			const stepInterval = 600; // 10 minutes
+			const { start, end } = getTracesTimeRangeFromStepInterval(
+				xValue,
+				stepInterval,
+			);
+
+			expect(start).toBe(xValue * 1000);
+			expect(end - start).toBe(10 * 60 * 1000);
+			expect(end).toBe(xValue * 1000 + 10 * 60 * 1000);
+		});
+	});
+
+	describe('getMinStepIntervalFromApiResponse', () => {
+		it('returns 60 when step intervals are missing', () => {
+			expect(getMinStepIntervalFromApiResponse({} as any)).toBe(60);
+		});
+
+		it('returns the minimum step interval from the response', () => {
+			const apiResponse = {
+				data: {
+					newResult: {
+						meta: {
+							stepIntervals: { A: 120, B: 60 },
+						},
+					},
+				},
+			};
+
+			expect(getMinStepIntervalFromApiResponse(apiResponse as any)).toBe(60);
+		});
+	});
+
+	describe('getStepIntervalForQuery', () => {
+		it('returns query-specific step interval when available', () => {
+			const apiResponse = {
+				data: {
+					newResult: {
+						meta: {
+							stepIntervals: { A: 120, B: 60 },
+						},
+					},
+				},
+			};
+
+			expect(getStepIntervalForQuery(apiResponse as any, 'A')).toBe(120);
+			expect(getStepIntervalForQuery(apiResponse as any, 'B')).toBe(60);
+		});
+	});
+});

--- a/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/components/utils.ts
+++ b/frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/components/utils.ts
@@ -13,6 +13,65 @@ import { Query } from 'types/api/queryBuilder/queryBuilderData';
 import { QueryData } from 'types/api/widgets/getQuery';
 import { v4 } from 'uuid';
 
+const DEFAULT_STEP_INTERVAL_SECONDS = 60;
+const MIN_TRACES_TIME_RANGE_MINUTES = 5;
+
+export function getMinStepIntervalFromApiResponse(
+	apiResponse: MetricRangePayloadProps,
+): number {
+	const stepIntervals: ExecStats['stepIntervals'] = get(
+		apiResponse,
+		'data.newResult.meta.stepIntervals',
+		{},
+	);
+	const values = Object.values(stepIntervals).filter(
+		(value): value is number =>
+			typeof value === 'number' && Number.isFinite(value),
+	);
+
+	if (values.length === 0) {
+		return DEFAULT_STEP_INTERVAL_SECONDS;
+	}
+
+	return Math.min(...values);
+}
+
+export function getStepIntervalForQuery(
+	apiResponse: MetricRangePayloadProps,
+	queryName?: string,
+): number {
+	const minStepInterval = getMinStepIntervalFromApiResponse(apiResponse);
+
+	if (!queryName) {
+		return minStepInterval;
+	}
+
+	const stepIntervals: ExecStats['stepIntervals'] = get(
+		apiResponse,
+		'data.newResult.meta.stepIntervals',
+		{},
+	);
+
+	return get(stepIntervals, queryName, minStepInterval) ?? minStepInterval;
+}
+
+export function getTracesTimeRangeFromStepInterval(
+	xValue: number,
+	stepIntervalSeconds: number,
+): { start: number; end: number } {
+	const rangeMinutes = Math.max(
+		stepIntervalSeconds / 60,
+		MIN_TRACES_TIME_RANGE_MINUTES,
+	);
+	const rangeMs = rangeMinutes * 60 * 1000;
+	const start = Math.floor(xValue * 1000);
+
+	return {
+		start,
+		end: Math.ceil(start + rangeMs),
+	};
+}
+
 export const prepareStatusCodeBarChartsConfig = ({
 	timezone,
 	isDarkMode,
@@ -41,7 +100,7 @@ export const prepareStatusCodeBarChartsConfig = ({
 		'data.newResult.meta.stepIntervals',
 		{},
 	);
-	const minStepInterval = Math.min(...Object.values(stepIntervals));
+	const minStepInterval = getMinStepIntervalFromApiResponse(apiResponse);
 
 	const config = buildBaseConfig({
 		id: v4(),


### PR DESCRIPTION
…time ranges

## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Clicking a bar in **External APIs → Domain Details → Call response status** navigates to Traces with a time range derived from the click. That range was hardcoded to **2.5 minutes** via `getStartAndEndTimesInMilliseconds` from Messaging Queues utils, which did not match the chart’s actual **step interval** (bucket size). On wider time ranges or coarser aggregation, traces could be missing or the explorer window could feel misaligned with the bar that was clicked.

This PR derives the traces time range from the active chart’s API response metadata (`data.newResult.meta.stepIntervals`), using the clicked query’s step interval when available. The range is **at least 5 minutes** and grows with larger step intervals (e.g. 10-minute buckets → 10-minute trace window). Shared helpers also harden `prepareStatusCodeBarChartsConfig` when step intervals are missing (defaults to 60s instead of `Math.min` on an empty set).

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

| Before | After |
|--------|-------|
| Fixed 2.5 min trace window on bar click | Trace window = `max(stepInterval, 5 min)` from chart metadata |

_Add screen recording: click a bar on Domain Details status-code chart with a wide global time range → confirm Traces time picker matches the bar bucket (≥ 5 min)._



https://github.com/user-attachments/assets/f282c14e-eb23-4752-aaa7-d2c4ad7875fa




#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

<!-- Closes #XXXX -->

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
Bar-click navigation for External APIs domain status-code charts used a **fixed 2.5 minute** traces time range, independent of the query step interval returned in `meta.stepIntervals`. Chart bucket size varies with the selected time range and query, so the hardcoded window could be too narrow or inconsistent with what the bar represents.

#### Fix Strategy
- Add `getStepIntervalForQuery` / `getTracesTimeRangeFromStepInterval` in Domain Details `utils.ts`.
- On bar click, read step interval from the **active** chart payload (status count vs latency tab) and compute `{ start, end }` with a **5 minute minimum**.
- Pass `customTracesTimeRange` into `handleGraphClick` instead of Messaging Queues’ fixed-offset helper.
- Reuse `getMinStepIntervalFromApiResponse` in chart config prep for safer defaults when metadata is absent.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
  - `frontend/src/container/ApiMonitoring/Explorer/Domains/DomainDetails/components/__tests__/utils.test.ts`
    - `getTracesTimeRangeFromStepInterval` (5 min floor, larger step intervals)
    - `getMinStepIntervalFromApiResponse` (missing / multiple intervals)
    - `getStepIntervalForQuery` (per-query vs fallback)
- Manual verification:
  - External APIs → Domain Details → **Call response status**
  - Click a bar on **Number of calls** and **Latency** tabs with different global time ranges
  - Confirm Traces opens with start at click time and end ≥ 5 minutes, scaling with bucket size
- Edge cases covered:
  - Missing `stepIntervals` → default 60s step, 5 min minimum trace range
  - Step interval &gt; 5 minutes → range extends to full bucket width
  - Switching between status count and latency charts uses the correct active API response

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: External APIs Domain Details status-code bar chart click → Traces navigation only; chart rendering config uses shared min-step helper.
- Potential regressions: Trace windows wider than before for coarse buckets (intended); very fine buckets still clamped to 5 min minimum.
- Rollback plan: Revert branch; bar clicks revert to prior 2.5 min fixed window behavior.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | External APIs domain status-code bar clicks now open Traces with a time range aligned to the chart’s step interval (minimum 5 minutes), instead of a fixed 2.5 minute window. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

- Removes dependency on `getStartAndEndTimesInMilliseconds` from `MessagingQueuesUtils` for this flow; logic is colocated in Domain Details `utils.ts` with unit tests.
- `getMinStepIntervalFromApiResponse` replaces inline `Math.min(...Object.values(stepIntervals))` to avoid `Infinity` when intervals are empty.
- Please sanity-check bar click → Traces on both **Number of calls** and **Latency** tabs.

---