### PR TITLE
fix(planned-downtime): remove unused timezone dep from useMemo hooks

### DIFF
--- a/frontend/src/container/PlannedDowntime/PlannedDowntimeForm.tsx
+++ b/frontend/src/container/PlannedDowntime/PlannedDowntimeForm.tsx
@@ -311,7 +311,7 @@ export function PlannedDowntimeForm(
 			default:
 				return `Scheduled for ${formattedStartDate} starting at ${formattedStartTime}.`;
 		}
-	}, [formData, recurrenceType, timezone]);
+	}, [formData, recurrenceType]);
 
 	const endTimeText = useMemo((): string => {
 		const endTime = formData.endTime;
@@ -322,7 +322,7 @@ export function PlannedDowntimeForm(
 		const formattedEndTime = endTime.format(TIME_FORMAT);
 		const formattedEndDate = endTime.format(DATE_FORMAT);
 		return `Scheduled to end maintenance on ${formattedEndDate} at ${formattedEndTime}.`;
-	}, [formData, recurrenceType, timezone]);
+	}, [formData, recurrenceType]);
 
 	return (
 		<Modal


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
The `startTimeText` and `endTimeText` `useMemo` hooks in `PlannedDowntimeForm.tsx` listed `timezone` in their dependency arrays, but neither callback actually references `timezone`. This caused the memos to be recomputed whenever the form's timezone field changed, even though the output is unaffected.

This PR drops `timezone` from both dependency arrays so the memos only recompute when the values they actually use (`formData`, `recurrenceType`) change.

#### Screenshots / Screen Recordings (if applicable)
N/A — non-visual change.

#### Issues closed by this PR
N/A

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
`timezone` was included in the dependency arrays of two `useMemo` hooks even though it is not referenced inside either callback body — likely a leftover from an earlier iteration of the code. This led to unnecessary memo invalidations when only the timezone changed.

#### Fix Strategy
Remove `timezone` from the dependency arrays of both `startTimeText` and `endTimeText` `useMemo` hooks in [PlannedDowntimeForm.tsx](frontend/src/container/PlannedDowntime/PlannedDowntimeForm.tsx).

---

### 🧪 Testing Strategy

- Tests added/updated: None — dependency-array correction with no behavior change.
- Manual verification: Opened the planned downtime form and confirmed the start-time / end-time summary strings render and update as expected on schedule and recurrence changes.
- Edge cases covered: Daily, weekly, monthly, and one-off (non-recurring) schedules all continue to produce the correct summary text.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Limited to the Planned Downtime form's summary text computation.
- Potential regressions: None expected — `timezone` was unused inside the callbacks, so removing it cannot change the memoized output. Worst case is one extra recomputation skipped.
- Rollback plan: Revert the commit; trivial single-file change.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | N/A (internal hook-dependency cleanup, no user-facing behavior change) |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The two `useMemo` callbacks (lines ~289–325 of `PlannedDowntimeForm.tsx`) reference only `formData.startTime` / `formData.endTime`, `formData.recurrence`, and `recurrenceType` — there is no `timezone` usage inside, so dropping it from the deps is safe.

---