### PR TITLE
feat(tracedetail): add waterfall api with memory optimisations

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -18948,6 +18948,77 @@ paths:
       summary: Get waterfall view for a trace
       tags:
       - tracedetail
+  /api/v4/traces/{traceID}/waterfall:
+    post:
+      deprecated: false
+      description: 'Two-step fetch: minimal fields for all spans to build the tree,
+        full fields only for the visible window. Aggregations are not included in
+        the response.'
+      operationId: GetWaterfallV4
+      parameters:
+      - in: path
+        name: traceID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SpantypesPostableWaterfall'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: '#/components/schemas/SpantypesGettableWaterfallTrace'
+                  status:
+                    type: string
+                required:
+                - status
+                - data
+                type: object
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Internal Server Error
+      security:
+      - api_key:
+        - VIEWER
+      - tokenizer:
+        - VIEWER
+      summary: Get waterfall view for a trace (OOM-safe)
+      tags:
+      - tracedetail
   /api/v5/query_range:
     post:
       deprecated: false

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -18951,9 +18951,9 @@ paths:
   /api/v4/traces/{traceID}/waterfall:
     post:
       deprecated: false
-      description: 'Two-step fetch: minimal fields for all spans to build the tree,
-        full fields only for the visible window. Aggregations are not included in
-        the response.'
+      description: Returns the waterfall view of spans including all spans if total
+        spans are under a limit, a max count otherwise. Aggregations are dropped compared
+        to v3
       operationId: GetWaterfallV4
       parameters:
       - in: path
@@ -19016,7 +19016,7 @@ paths:
         - VIEWER
       - tokenizer:
         - VIEWER
-      summary: Get waterfall view for a trace (OOM-safe)
+      summary: Get waterfall view for a trace
       tags:
       - tracedetail
   /api/v5/query_range:

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -9232,6 +9232,17 @@ export type GetWaterfall200 = {
 	status: string;
 };
 
+export type GetWaterfallV4PathParameters = {
+	traceID: string;
+};
+export type GetWaterfallV4200 = {
+	data: SpantypesGettableWaterfallTraceDTO;
+	/**
+	 * @type string
+	 */
+	status: string;
+};
+
 export type QueryRangeV5200 = {
 	data: Querybuildertypesv5QueryRangeResponseDTO;
 	/**

--- a/frontend/src/api/generated/services/tracedetail/index.ts
+++ b/frontend/src/api/generated/services/tracedetail/index.ts
@@ -14,6 +14,8 @@ import type {
 import type {
 	GetWaterfall200,
 	GetWaterfallPathParameters,
+	GetWaterfallV4200,
+	GetWaterfallV4PathParameters,
 	RenderErrorResponseDTO,
 	SpantypesPostableWaterfallDTO,
 } from '../sigNoz.schemas';
@@ -119,4 +121,103 @@ export const useGetWaterfall = <
 	TContext
 > => {
 	return useMutation(getGetWaterfallMutationOptions(options));
+};
+/**
+ * Two-step fetch: minimal fields for all spans to build the tree, full fields only for the visible window. Aggregations are not included in the response.
+ * @summary Get waterfall view for a trace (OOM-safe)
+ */
+export const getWaterfallV4 = (
+	{ traceID }: GetWaterfallV4PathParameters,
+	spantypesPostableWaterfallDTO?: BodyType<SpantypesPostableWaterfallDTO>,
+	signal?: AbortSignal,
+) => {
+	return GeneratedAPIInstance<GetWaterfallV4200>({
+		url: `/api/v4/traces/${traceID}/waterfall`,
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		data: spantypesPostableWaterfallDTO,
+		signal,
+	});
+};
+
+export const getGetWaterfallV4MutationOptions = <
+	TError = ErrorType<RenderErrorResponseDTO>,
+	TContext = unknown,
+>(options?: {
+	mutation?: UseMutationOptions<
+		Awaited<ReturnType<typeof getWaterfallV4>>,
+		TError,
+		{
+			pathParams: GetWaterfallV4PathParameters;
+			data?: BodyType<SpantypesPostableWaterfallDTO>;
+		},
+		TContext
+	>;
+}): UseMutationOptions<
+	Awaited<ReturnType<typeof getWaterfallV4>>,
+	TError,
+	{
+		pathParams: GetWaterfallV4PathParameters;
+		data?: BodyType<SpantypesPostableWaterfallDTO>;
+	},
+	TContext
+> => {
+	const mutationKey = ['getWaterfallV4'];
+	const { mutation: mutationOptions } = options
+		? options.mutation &&
+			'mutationKey' in options.mutation &&
+			options.mutation.mutationKey
+			? options
+			: { ...options, mutation: { ...options.mutation, mutationKey } }
+		: { mutation: { mutationKey } };
+
+	const mutationFn: MutationFunction<
+		Awaited<ReturnType<typeof getWaterfallV4>>,
+		{
+			pathParams: GetWaterfallV4PathParameters;
+			data?: BodyType<SpantypesPostableWaterfallDTO>;
+		}
+	> = (props) => {
+		const { pathParams, data } = props ?? {};
+
+		return getWaterfallV4(pathParams, data);
+	};
+
+	return { mutationFn, ...mutationOptions };
+};
+
+export type GetWaterfallV4MutationResult = NonNullable<
+	Awaited<ReturnType<typeof getWaterfallV4>>
+>;
+export type GetWaterfallV4MutationBody =
+	| BodyType<SpantypesPostableWaterfallDTO>
+	| undefined;
+export type GetWaterfallV4MutationError = ErrorType<RenderErrorResponseDTO>;
+
+/**
+ * @summary Get waterfall view for a trace (OOM-safe)
+ */
+export const useGetWaterfallV4 = <
+	TError = ErrorType<RenderErrorResponseDTO>,
+	TContext = unknown,
+>(options?: {
+	mutation?: UseMutationOptions<
+		Awaited<ReturnType<typeof getWaterfallV4>>,
+		TError,
+		{
+			pathParams: GetWaterfallV4PathParameters;
+			data?: BodyType<SpantypesPostableWaterfallDTO>;
+		},
+		TContext
+	>;
+}): UseMutationResult<
+	Awaited<ReturnType<typeof getWaterfallV4>>,
+	TError,
+	{
+		pathParams: GetWaterfallV4PathParameters;
+		data?: BodyType<SpantypesPostableWaterfallDTO>;
+	},
+	TContext
+> => {
+	return useMutation(getGetWaterfallV4MutationOptions(options));
 };

--- a/frontend/src/api/generated/services/tracedetail/index.ts
+++ b/frontend/src/api/generated/services/tracedetail/index.ts
@@ -123,8 +123,8 @@ export const useGetWaterfall = <
 	return useMutation(getGetWaterfallMutationOptions(options));
 };
 /**
- * Two-step fetch: minimal fields for all spans to build the tree, full fields only for the visible window. Aggregations are not included in the response.
- * @summary Get waterfall view for a trace (OOM-safe)
+ * Returns the waterfall view of spans including all spans if total spans are under a limit, a max count otherwise. Aggregations are dropped compared to v3
+ * @summary Get waterfall view for a trace
  */
 export const getWaterfallV4 = (
 	{ traceID }: GetWaterfallV4PathParameters,
@@ -195,7 +195,7 @@ export type GetWaterfallV4MutationBody =
 export type GetWaterfallV4MutationError = ErrorType<RenderErrorResponseDTO>;
 
 /**
- * @summary Get waterfall view for a trace (OOM-safe)
+ * @summary Get waterfall view for a trace
  */
 export const useGetWaterfallV4 = <
 	TError = ErrorType<RenderErrorResponseDTO>,

--- a/pkg/apiserver/signozapiserver/tracedetail.go
+++ b/pkg/apiserver/signozapiserver/tracedetail.go
@@ -34,8 +34,8 @@ func (provider *provider) addTraceDetailRoutes(router *mux.Router) error {
 		handler.OpenAPIDef{
 			ID:                  "GetWaterfallV4",
 			Tags:                []string{"tracedetail"},
-			Summary:             "Get waterfall view for a trace (OOM-safe)",
-			Description:         "Two-step fetch: minimal fields for all spans to build the tree, full fields only for the visible window. Aggregations are not included in the response.",
+			Summary:             "Get waterfall view for a trace",
+			Description:         "Returns the waterfall view of spans including all spans if total spans are under a limit, a max count otherwise. Aggregations are dropped compared to v3",
 			Request:             new(spantypes.PostableWaterfall),
 			RequestContentType:  "application/json",
 			Response:            new(spantypes.GettableWaterfallTrace),

--- a/pkg/apiserver/signozapiserver/tracedetail.go
+++ b/pkg/apiserver/signozapiserver/tracedetail.go
@@ -29,5 +29,24 @@ func (provider *provider) addTraceDetailRoutes(router *mux.Router) error {
 		return err
 	}
 
+	if err := router.Handle("/api/v4/traces/{traceID}/waterfall", handler.New(
+		provider.authzMiddleware.ViewAccess(provider.traceDetailHandler.GetWaterfallV4),
+		handler.OpenAPIDef{
+			ID:                  "GetWaterfallV4",
+			Tags:                []string{"tracedetail"},
+			Summary:             "Get waterfall view for a trace (OOM-safe)",
+			Description:         "Two-step fetch: minimal fields for all spans to build the tree, full fields only for the visible window. Aggregations are not included in the response.",
+			Request:             new(spantypes.PostableWaterfall),
+			RequestContentType:  "application/json",
+			Response:            new(spantypes.GettableWaterfallTrace),
+			ResponseContentType: "application/json",
+			SuccessStatusCode:   http.StatusOK,
+			ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
+			SecuritySchemes:     newSecuritySchemes(types.RoleViewer),
+		},
+	)).Methods(http.MethodPost).GetError(); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/modules/tracedetail/impltracedetail/handler.go
+++ b/pkg/modules/tracedetail/impltracedetail/handler.go
@@ -38,3 +38,24 @@ func (h *handler) GetWaterfall(rw http.ResponseWriter, r *http.Request) {
 
 	render.Success(rw, http.StatusOK, result)
 }
+
+func (h *handler) GetWaterfallV4(rw http.ResponseWriter, r *http.Request) {
+	req := new(spantypes.PostableWaterfall)
+	if err := binding.JSON.BindBody(r.Body, req); err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	if err := req.Validate(); err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	result, err := h.module.GetWaterfallV4(r.Context(), mux.Vars(r)["traceID"], req)
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	render.Success(rw, http.StatusOK, result)
+}

--- a/pkg/modules/tracedetail/impltracedetail/handler.go
+++ b/pkg/modules/tracedetail/impltracedetail/handler.go
@@ -51,7 +51,7 @@ func (h *handler) GetWaterfallV4(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.module.GetWaterfallV4(r.Context(), mux.Vars(r)["traceID"], req)
+	result, err := h.module.GetWaterfallV4(r.Context(), mux.Vars(r)["traceID"], req.SelectedSpanID, req.UncollapsedSpans, req.Limit)
 	if err != nil {
 		render.Error(rw, err)
 		return

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -24,34 +24,18 @@ func NewModule(traceStore spantypes.TraceStore, providerSettings factory.Provide
 }
 
 func (m *module) GetWaterfall(ctx context.Context, traceID string, req *spantypes.PostableWaterfall) (*spantypes.GettableWaterfallTrace, error) {
-	waterfallTrace, err := m.getTraceData(ctx, traceID)
-	if err != nil {
-		return nil, err
-	}
-
-	selectedSpans, uncollapsedSpans, selectedAllSpans := waterfallTrace.GetWaterfallSpans(
-		req.UncollapsedSpans,
-		req.SelectedSpanID,
-		min(req.Limit, m.config.Waterfall.MaxLimitToSelectAllSpans),
-		m.config.Waterfall.SpanPageSize,
-		m.config.Waterfall.MaxDepthToAutoExpand,
-	)
-
-	aggregationResults := make([]spantypes.SpanAggregationResult, 0, len(req.Aggregations))
-	for _, a := range req.Aggregations {
-		aggregationResults = append(aggregationResults, waterfallTrace.GetSpanAggregation(a.Aggregation, a.Field))
-	}
-
-	return spantypes.NewGettableWaterfallTrace(waterfallTrace, selectedSpans, uncollapsedSpans, selectedAllSpans, aggregationResults), nil
-}
-
-// getTraceData returns the waterfall cache for the given traceID with fallback on DB.
-func (m *module) getTraceData(ctx context.Context, traceID string) (*spantypes.WaterfallTrace, error) {
 	summary, err := m.store.GetTraceSummary(ctx, traceID)
 	if err != nil {
 		return nil, err
 	}
+	effectiveLimit := min(req.Limit, m.config.Waterfall.MaxLimitToSelectAllSpans)
+	if summary.NumSpans > uint64(effectiveLimit) {
+		return m.getWindowedWaterfall(ctx, traceID, req, summary, effectiveLimit)
+	}
+	return m.getFullWaterfall(ctx, traceID, summary)
+}
 
+func (m *module) getFullWaterfall(ctx context.Context, traceID string, summary *spantypes.TraceSummary) (*spantypes.GettableWaterfallTrace, error) {
 	spanItems, err := m.store.GetTraceSpans(ctx, traceID, summary)
 	if err != nil {
 		return nil, err
@@ -61,6 +45,73 @@ func (m *module) getTraceData(ctx context.Context, traceID string) (*spantypes.W
 		return nil, spantypes.ErrTraceNotFound
 	}
 
-	traceData := spantypes.NewWaterfallTraceFromSpans(spanItems)
-	return traceData, nil
+	nodes := make([]*spantypes.WaterfallSpan, len(spanItems))
+	for i := range spanItems {
+		nodes[i] = spanItems[i].ToWaterfallSpan()
+	}
+	waterfallTrace := spantypes.NewWaterfallTraceFromSpans(nodes)
+	selectedSpans := waterfallTrace.GetAllSpans()
+
+	return spantypes.NewGettableWaterfallTrace(waterfallTrace, selectedSpans, nil, true, nil), nil
+}
+
+// getWindowedWaterfall builds the waterfall tree with minimal data and then returns only a window of full spans
+func (m *module) getWindowedWaterfall(ctx context.Context, traceID string, req *spantypes.PostableWaterfall, summary *spantypes.TraceSummary, effectiveLimit uint) (*spantypes.GettableWaterfallTrace, error) {
+	// Step 1: minimal fetch → build full tree → select visible window
+	minimalSpans, err := m.store.GetMinimalSpans(ctx, traceID, summary)
+	if err != nil {
+		return nil, err
+	}
+	if len(minimalSpans) == 0 {
+		return nil, spantypes.ErrTraceNotFound
+	}
+
+	nodes := make([]*spantypes.WaterfallSpan, len(minimalSpans))
+	for i := range minimalSpans {
+		nodes[i] = minimalSpans[i].ToWaterfallSpan()
+	}
+	waterfallTrace := spantypes.NewWaterfallTraceFromSpans(nodes)
+
+	selectedSpans, uncollapsedSpans := waterfallTrace.GetSelectedSpans(
+		req.UncollapsedSpans,
+		req.SelectedSpanID,
+		m.config.Waterfall.SpanPageSize,
+		m.config.Waterfall.MaxDepthToAutoExpand,
+	)
+
+	aggregationResults := make([]spantypes.SpanAggregationResult, 0, len(req.Aggregations))
+	for _, a := range req.Aggregations {
+		aggregationResults = append(aggregationResults, waterfallTrace.GetSpanAggregation(a.Aggregation, a.Field))
+	}
+
+	// Step 2: full fetch for the selected window only
+	spanIDs := make([]string, len(selectedSpans))
+	for i, s := range selectedSpans {
+		spanIDs[i] = s.SpanID
+	}
+	fullSpans, err := m.store.GetTraceSpansByIDs(ctx, traceID, summary, spanIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace minimal WaterfallSpans with full ones, preserving tree metadata.
+	fullByID := make(map[string]*spantypes.StorableSpan, len(fullSpans))
+	for i := range fullSpans {
+		fullByID[fullSpans[i].SpanID] = &fullSpans[i]
+	}
+	for i, ws := range selectedSpans {
+		full, ok := fullByID[ws.SpanID]
+		if !ok {
+			continue // synthesized MissingSpan — keep empty shell
+		}
+		newWS := full.ToWaterfallSpan()
+		newWS.Level = ws.Level
+		newWS.HasChildren = ws.HasChildren
+		newWS.SubTreeNodeCount = ws.SubTreeNodeCount
+		selectedSpans[i] = newWS
+	}
+
+	return spantypes.NewGettableWaterfallTrace(
+		waterfallTrace, selectedSpans, uncollapsedSpans, false, aggregationResults,
+	), nil
 }

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -64,7 +64,7 @@ func (m *module) getTraceData(ctx context.Context, traceID string) (*spantypes.W
 
 	nodes := make([]*spantypes.WaterfallSpan, len(spanItems))
 	for i := range spanItems {
-		nodes[i] = spanItems[i].ToWaterfallSpan()
+		nodes[i] = spanItems[i].ToWaterfallSpan(traceID)
 	}
 	return spantypes.NewWaterfallTraceFromSpans(nodes), nil
 }
@@ -97,7 +97,7 @@ func (m *module) getFullWaterfall(ctx context.Context, traceID string, summary *
 
 	nodes := make([]*spantypes.WaterfallSpan, len(spanItems))
 	for i := range spanItems {
-		nodes[i] = spanItems[i].ToWaterfallSpan()
+		nodes[i] = spanItems[i].ToWaterfallSpan(traceID)
 	}
 	waterfallTrace := spantypes.NewWaterfallTraceFromSpans(nodes)
 	selectedSpans := waterfallTrace.GetAllSpans()
@@ -118,7 +118,7 @@ func (m *module) getWindowedWaterfall(ctx context.Context, traceID, selectedSpan
 
 	nodes := make([]*spantypes.WaterfallSpan, len(minimalSpans))
 	for i := range minimalSpans {
-		nodes[i] = minimalSpans[i].ToWaterfallSpan()
+		nodes[i] = minimalSpans[i].ToWaterfallSpan(traceID)
 	}
 	waterfallTrace := spantypes.NewWaterfallTraceFromSpans(nodes)
 

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -23,9 +23,6 @@ func NewModule(traceStore spantypes.TraceStore, providerSettings factory.Provide
 	}
 }
 
-// GetWaterfall is the V3 waterfall — identical behavior to main branch.
-// Fetches all spans, builds the full in-memory tree, selects all-or-windowed
-// based on effectiveLimit, and returns in-memory aggregations.
 func (m *module) GetWaterfall(ctx context.Context, traceID string, req *spantypes.PostableWaterfall) (*spantypes.GettableWaterfallTrace, error) {
 	waterfallTrace, err := m.getTraceData(ctx, traceID)
 	if err != nil {
@@ -107,7 +104,7 @@ func (m *module) getFullWaterfall(ctx context.Context, traceID string, summary *
 	return spantypes.NewGettableWaterfallTrace(waterfallTrace, selectedSpans, nil, true, nil), nil
 }
 
-// getWindowedWaterfall builds the waterfall tree with minimal data and then returns only a window of full spans
+// getWindowedWaterfall builds the waterfall tree with minimal data and then returns only a window of full spans.
 func (m *module) getWindowedWaterfall(ctx context.Context, traceID string, req *spantypes.PostableWaterfall, summary *spantypes.TraceSummary, effectiveLimit uint) (*spantypes.GettableWaterfallTrace, error) {
 	// Step 1: minimal fetch → build full tree → select visible window
 	minimalSpans, err := m.store.GetMinimalSpans(ctx, traceID, summary)
@@ -141,22 +138,7 @@ func (m *module) getWindowedWaterfall(ctx context.Context, traceID string, req *
 		return nil, err
 	}
 
-	// Replace minimal WaterfallSpans with full ones, preserving tree metadata.
-	fullByID := make(map[string]*spantypes.StorableSpan, len(fullSpans))
-	for i := range fullSpans {
-		fullByID[fullSpans[i].SpanID] = &fullSpans[i]
-	}
-	for i, ws := range selectedSpans {
-		full, ok := fullByID[ws.SpanID]
-		if !ok {
-			continue // synthesized MissingSpan — keep empty shell
-		}
-		newWS := full.ToWaterfallSpan()
-		newWS.Level = ws.Level
-		newWS.HasChildren = ws.HasChildren
-		newWS.SubTreeNodeCount = ws.SubTreeNodeCount
-		selectedSpans[i] = newWS
-	}
+	spantypes.EnrichSelectedSpans(selectedSpans, fullSpans)
 
 	return spantypes.NewGettableWaterfallTrace(
 		waterfallTrace, selectedSpans, uncollapsedSpans, false, nil,

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -23,7 +23,59 @@ func NewModule(traceStore spantypes.TraceStore, providerSettings factory.Provide
 	}
 }
 
+// GetWaterfall is the V3 waterfall — identical behavior to main branch.
+// Fetches all spans, builds the full in-memory tree, selects all-or-windowed
+// based on effectiveLimit, and returns in-memory aggregations.
 func (m *module) GetWaterfall(ctx context.Context, traceID string, req *spantypes.PostableWaterfall) (*spantypes.GettableWaterfallTrace, error) {
+	waterfallTrace, err := m.getTraceData(ctx, traceID)
+	if err != nil {
+		return nil, err
+	}
+
+	selectedSpans, uncollapsedSpans, selectedAllSpans := waterfallTrace.GetWaterfallSpans(
+		req.UncollapsedSpans,
+		req.SelectedSpanID,
+		min(req.Limit, m.config.Waterfall.MaxLimitToSelectAllSpans),
+		m.config.Waterfall.SpanPageSize,
+		m.config.Waterfall.MaxDepthToAutoExpand,
+	)
+
+	aggregationResults := make([]spantypes.SpanAggregationResult, 0, len(req.Aggregations))
+	for _, a := range req.Aggregations {
+		aggregationResults = append(aggregationResults, waterfallTrace.GetSpanAggregation(a.Aggregation, a.Field))
+	}
+
+	return spantypes.NewGettableWaterfallTrace(waterfallTrace, selectedSpans, uncollapsedSpans, selectedAllSpans, aggregationResults), nil
+}
+
+// getTraceData fetches all spans for a trace and builds the WaterfallTrace.
+func (m *module) getTraceData(ctx context.Context, traceID string) (*spantypes.WaterfallTrace, error) {
+	summary, err := m.store.GetTraceSummary(ctx, traceID)
+	if err != nil {
+		return nil, err
+	}
+
+	spanItems, err := m.store.GetTraceSpans(ctx, traceID, summary)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(spanItems) == 0 {
+		return nil, spantypes.ErrTraceNotFound
+	}
+
+	nodes := make([]*spantypes.WaterfallSpan, len(spanItems))
+	for i := range spanItems {
+		nodes[i] = spanItems[i].ToWaterfallSpan()
+	}
+	return spantypes.NewWaterfallTraceFromSpans(nodes), nil
+}
+
+// GetWaterfallV4 is the OOM-safe V4 waterfall.
+// For large traces (NumSpans > effectiveLimit) it uses a two-step fetch:
+// minimal fields for all spans to build the tree, then full fields for the
+// visible window only. Aggregations are not returned.
+func (m *module) GetWaterfallV4(ctx context.Context, traceID string, req *spantypes.PostableWaterfall) (*spantypes.GettableWaterfallTrace, error) {
 	summary, err := m.store.GetTraceSummary(ctx, traceID)
 	if err != nil {
 		return nil, err
@@ -79,11 +131,6 @@ func (m *module) getWindowedWaterfall(ctx context.Context, traceID string, req *
 		m.config.Waterfall.MaxDepthToAutoExpand,
 	)
 
-	aggregationResults := make([]spantypes.SpanAggregationResult, 0, len(req.Aggregations))
-	for _, a := range req.Aggregations {
-		aggregationResults = append(aggregationResults, waterfallTrace.GetSpanAggregation(a.Aggregation, a.Field))
-	}
-
 	// Step 2: full fetch for the selected window only
 	spanIDs := make([]string, len(selectedSpans))
 	for i, s := range selectedSpans {
@@ -112,6 +159,6 @@ func (m *module) getWindowedWaterfall(ctx context.Context, traceID string, req *
 	}
 
 	return spantypes.NewGettableWaterfallTrace(
-		waterfallTrace, selectedSpans, uncollapsedSpans, false, aggregationResults,
+		waterfallTrace, selectedSpans, uncollapsedSpans, false, nil,
 	), nil
 }

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -2,6 +2,7 @@ package impltracedetail
 
 import (
 	"context"
+	"time"
 
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/modules/tracedetail"
@@ -79,7 +80,7 @@ func (m *module) GetWaterfallV4(ctx context.Context, traceID string, selectedSpa
 	}
 	effectiveLimit := min(selectAllLimit, m.config.Waterfall.MaxLimitToSelectAllSpans)
 	if summary.NumSpans > uint64(effectiveLimit) {
-		return m.getWindowedWaterfall(ctx, traceID, selectedSpanID, uncollapsedSpans, effectiveLimit, summary)
+		return m.getWindowedWaterfall(ctx, traceID, selectedSpanID, uncollapsedSpans, summary.Start, summary.End)
 	}
 	return m.getFullWaterfall(ctx, traceID, summary)
 }
@@ -105,9 +106,9 @@ func (m *module) getFullWaterfall(ctx context.Context, traceID string, summary *
 }
 
 // getWindowedWaterfall builds the waterfall tree with minimal data and then returns only a window of full spans.
-func (m *module) getWindowedWaterfall(ctx context.Context, traceID, selectedSpanID string, uncollapsedSpans []string, effectiveLimit uint, summary *spantypes.TraceSummary) (*spantypes.GettableWaterfallTrace, error) {
+func (m *module) getWindowedWaterfall(ctx context.Context, traceID, selectedSpanID string, uncollapsedSpans []string, start, end time.Time) (*spantypes.GettableWaterfallTrace, error) {
 	// Step 1: minimal fetch → build full tree → select visible window
-	minimalSpans, err := m.store.GetMinimalSpans(ctx, traceID, summary)
+	minimalSpans, err := m.store.GetMinimalSpans(ctx, traceID, start, end)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +134,7 @@ func (m *module) getWindowedWaterfall(ctx context.Context, traceID, selectedSpan
 	for i, s := range selectedSpans {
 		spanIDs[i] = s.SpanID
 	}
-	fullSpans, err := m.store.GetTraceSpansByIDs(ctx, traceID, summary, spanIDs)
+	fullSpans, err := m.store.GetTraceSpansByIDs(ctx, traceID, start, end, spanIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -72,14 +72,14 @@ func (m *module) getTraceData(ctx context.Context, traceID string) (*spantypes.W
 // For large traces (NumSpans > effectiveLimit) it uses a two-step fetch:
 // minimal fields for all spans to build the tree, then full fields for the
 // visible window only. Aggregations are not returned.
-func (m *module) GetWaterfallV4(ctx context.Context, traceID string, req *spantypes.PostableWaterfall) (*spantypes.GettableWaterfallTrace, error) {
+func (m *module) GetWaterfallV4(ctx context.Context, traceID string, selectedSpanID string, uncollapsedSpans []string, selectAllLimit uint) (*spantypes.GettableWaterfallTrace, error) {
 	summary, err := m.store.GetTraceSummary(ctx, traceID)
 	if err != nil {
 		return nil, err
 	}
-	effectiveLimit := min(req.Limit, m.config.Waterfall.MaxLimitToSelectAllSpans)
+	effectiveLimit := min(selectAllLimit, m.config.Waterfall.MaxLimitToSelectAllSpans)
 	if summary.NumSpans > uint64(effectiveLimit) {
-		return m.getWindowedWaterfall(ctx, traceID, req, summary, effectiveLimit)
+		return m.getWindowedWaterfall(ctx, traceID, selectedSpanID, uncollapsedSpans, effectiveLimit, summary)
 	}
 	return m.getFullWaterfall(ctx, traceID, summary)
 }
@@ -105,7 +105,7 @@ func (m *module) getFullWaterfall(ctx context.Context, traceID string, summary *
 }
 
 // getWindowedWaterfall builds the waterfall tree with minimal data and then returns only a window of full spans.
-func (m *module) getWindowedWaterfall(ctx context.Context, traceID string, req *spantypes.PostableWaterfall, summary *spantypes.TraceSummary, effectiveLimit uint) (*spantypes.GettableWaterfallTrace, error) {
+func (m *module) getWindowedWaterfall(ctx context.Context, traceID, selectedSpanID string, uncollapsedSpans []string, effectiveLimit uint, summary *spantypes.TraceSummary) (*spantypes.GettableWaterfallTrace, error) {
 	// Step 1: minimal fetch → build full tree → select visible window
 	minimalSpans, err := m.store.GetMinimalSpans(ctx, traceID, summary)
 	if err != nil {
@@ -122,8 +122,8 @@ func (m *module) getWindowedWaterfall(ctx context.Context, traceID string, req *
 	waterfallTrace := spantypes.NewWaterfallTraceFromSpans(nodes)
 
 	selectedSpans, uncollapsedSpans := waterfallTrace.GetSelectedSpans(
-		req.UncollapsedSpans,
-		req.SelectedSpanID,
+		uncollapsedSpans,
+		selectedSpanID,
 		m.config.Waterfall.SpanPageSize,
 		m.config.Waterfall.MaxDepthToAutoExpand,
 	)

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -12,6 +12,9 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/spantypes"
 )
 
+// The $$$$ becomes $$ since go-sqlbuilder escapes $ sign
+const serviceNameCol = "resource_string_service$$$$name"
+
 type traceStore struct {
 	telemetryStore telemetrystore.TelemetryStore
 }
@@ -71,23 +74,24 @@ func (s *traceStore) GetTraceSpans(ctx context.Context, traceID string, summary 
 }
 
 func (s *traceStore) GetMinimalSpans(ctx context.Context, traceID string, summary *spantypes.TraceSummary) ([]spantypes.MinimalSpan, error) {
-	query := fmt.Sprintf(`
-		SELECT DISTINCT ON (span_id)
-			span_id, parent_span_id, timestamp, duration_nano, has_error,
-			resource_string_service$$name
-		FROM %s.%s
-		WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=?
-		ORDER BY timestamp ASC, name ASC`,
-		spantypes.TraceDB, spantypes.TraceTable,
+	sb := sqlbuilder.NewSelectBuilder()
+	sb.Select(
+		"DISTINCT ON (span_id) span_id",
+		"parent_span_id", "timestamp", "duration_nano", "has_error",
+		serviceNameCol,
 	)
+	sb.From(fmt.Sprintf("%s.%s", spantypes.TraceDB, spantypes.TraceTable))
+	sb.Where(
+		sb.E("trace_id", traceID),
+		sb.GE("ts_bucket_start", summary.Start.Unix()-1800),
+		sb.LE("ts_bucket_start", summary.End.Unix()),
+	)
+	sb.OrderByAsc("timestamp")
+	sb.OrderByAsc("name")
+	query, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+
 	var spans []spantypes.MinimalSpan
-	err := s.telemetryStore.ClickhouseDB().Select(
-		ctx, &spans, query,
-		traceID,
-		summary.Start.Unix()-1800,
-		summary.End.Unix(),
-	)
-	if err != nil {
+	if err := s.telemetryStore.ClickhouseDB().Select(ctx, &spans, query, args...); err != nil {
 		return nil, errors.WrapInternalf(err, errors.CodeInternal, "error querying minimal spans")
 	}
 	return spans, nil
@@ -97,28 +101,34 @@ func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, sum
 	if len(spanIDs) == 0 {
 		return []spantypes.StorableSpan{}, nil
 	}
-	query := fmt.Sprintf(`
-		SELECT DISTINCT ON (span_id)
-			timestamp, duration_nano, span_id, trace_id, has_error, kind,
-			resource_string_service$$name, name, links as references,
-			attributes_string, attributes_number, attributes_bool, resources_string,
-			events, status_message, status_code_string, kind_string, parent_span_id,
-			flags, is_remote, trace_state, status_code,
-			db_name, db_operation, http_method, http_url, http_host,
-			external_http_method, external_http_url, response_status_code
-		FROM %s.%s
-		WHERE trace_id=? AND span_id IN (?) AND ts_bucket_start>=? AND ts_bucket_start<=?
-		ORDER BY timestamp ASC, name ASC`,
-		spantypes.TraceDB, spantypes.TraceTable,
+	sb := sqlbuilder.NewSelectBuilder()
+	sb.Select(
+		"DISTINCT ON (span_id) timestamp",
+		"duration_nano", "span_id", "trace_id", "has_error", "kind",
+		serviceNameCol, "name", "links as references",
+		"attributes_string", "attributes_number", "attributes_bool", "resources_string",
+		"events", "status_message", "status_code_string", "kind_string", "parent_span_id",
+		"flags", "is_remote", "trace_state", "status_code",
+		"db_name", "db_operation", "http_method", "http_url", "http_host",
+		"external_http_method", "external_http_url", "response_status_code",
 	)
+	sb.From(fmt.Sprintf("%s.%s", spantypes.TraceDB, spantypes.TraceTable))
+	ids := make([]any, len(spanIDs))
+	for i, id := range spanIDs {
+		ids[i] = id
+	}
+	sb.Where(
+		sb.E("trace_id", traceID),
+		sb.In("span_id", ids...),
+		sb.GE("ts_bucket_start", summary.Start.Unix()-1800),
+		sb.LE("ts_bucket_start", summary.End.Unix()),
+	)
+	sb.OrderByAsc("timestamp")
+	sb.OrderByAsc("name")
+	query, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+
 	var spans []spantypes.StorableSpan
-	err := s.telemetryStore.ClickhouseDB().Select(
-		ctx, &spans, query,
-		traceID, spanIDs,
-		summary.Start.Unix()-1800,
-		summary.End.Unix(),
-	)
-	if err != nil {
+	if err := s.telemetryStore.ClickhouseDB().Select(ctx, &spans, query, args...); err != nil {
 		return nil, errors.WrapInternalf(err, errors.CodeInternal, "error querying trace spans by IDs")
 	}
 	return spans, nil

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -46,7 +46,7 @@ func (s *traceStore) GetTraceSpans(ctx context.Context, traceID string, summary 
 	// DISTINCT ON (span_id) is ClickHouse-specific syntax not supported by sqlbuilder
 	query := fmt.Sprintf(`
 		SELECT DISTINCT ON (span_id)
-			timestamp, duration_nano, span_id, trace_id, has_error, kind,
+			timestamp, duration_nano, span_id, has_error, kind,
 			resource_string_service$$name, name, links as references,
 			attributes_string, attributes_number, attributes_bool, resources_string,
 			events, status_message, status_code_string, kind_string, parent_span_id,
@@ -102,7 +102,7 @@ func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, sta
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select(
 		"DISTINCT ON (span_id) timestamp",
-		"duration_nano", "span_id", "trace_id", "has_error", "kind",
+		"duration_nano", "span_id", "has_error", "kind",
 		`resource_string_service$$name`, "name", "links as references",
 		"attributes_string", "attributes_number", "attributes_bool", "resources_string",
 		"events", "status_message", "status_code_string", "kind_string", "parent_span_id",

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -12,7 +12,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/spantypes"
 )
 
-// The $$$$ becomes $$ since go-sqlbuilder escapes $ sign
+// The $$$$ becomes $$ since go-sqlbuilder escapes $ sign.
 const serviceNameCol = "resource_string_service$$$$name"
 
 type traceStore struct {

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -12,9 +12,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/spantypes"
 )
 
-// The $$$$ becomes $$ since go-sqlbuilder escapes $ sign.
-const serviceNameCol = "resource_string_service$$$$name"
-
 type traceStore struct {
 	telemetryStore telemetrystore.TelemetryStore
 }
@@ -78,7 +75,7 @@ func (s *traceStore) GetMinimalSpans(ctx context.Context, traceID string, summar
 	sb.Select(
 		"DISTINCT ON (span_id) span_id",
 		"parent_span_id", "timestamp", "duration_nano", "has_error",
-		serviceNameCol,
+		`resource_string_service$$name`,
 	)
 	sb.From(fmt.Sprintf("%s.%s", spantypes.TraceDB, spantypes.TraceTable))
 	sb.Where(
@@ -105,7 +102,7 @@ func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, sum
 	sb.Select(
 		"DISTINCT ON (span_id) timestamp",
 		"duration_nano", "span_id", "trace_id", "has_error", "kind",
-		serviceNameCol, "name", "links as references",
+		`resource_string_service$$name`, "name", "links as references",
 		"attributes_string", "attributes_number", "attributes_bool", "resources_string",
 		"events", "status_message", "status_code_string", "kind_string", "parent_span_id",
 		"flags", "is_remote", "trace_state", "status_code",

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -69,3 +69,57 @@ func (s *traceStore) GetTraceSpans(ctx context.Context, traceID string, summary 
 	}
 	return spanItems, nil
 }
+
+func (s *traceStore) GetMinimalSpans(ctx context.Context, traceID string, summary *spantypes.TraceSummary) ([]spantypes.MinimalSpan, error) {
+	query := fmt.Sprintf(`
+		SELECT DISTINCT ON (span_id)
+			span_id, parent_span_id, timestamp, duration_nano, has_error,
+			resource_string_service$$name
+		FROM %s.%s
+		WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=?
+		ORDER BY timestamp ASC, name ASC`,
+		spantypes.TraceDB, spantypes.TraceTable,
+	)
+	var spans []spantypes.MinimalSpan
+	err := s.telemetryStore.ClickhouseDB().Select(
+		ctx, &spans, query,
+		traceID,
+		summary.Start.Unix()-1800,
+		summary.End.Unix(),
+	)
+	if err != nil {
+		return nil, errors.WrapInternalf(err, errors.CodeInternal, "error querying minimal spans")
+	}
+	return spans, nil
+}
+
+func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, summary *spantypes.TraceSummary, spanIDs []string) ([]spantypes.StorableSpan, error) {
+	if len(spanIDs) == 0 {
+		return []spantypes.StorableSpan{}, nil
+	}
+	query := fmt.Sprintf(`
+		SELECT DISTINCT ON (span_id)
+			timestamp, duration_nano, span_id, trace_id, has_error, kind,
+			resource_string_service$$name, name, links as references,
+			attributes_string, attributes_number, attributes_bool, resources_string,
+			events, status_message, status_code_string, kind_string, parent_span_id,
+			flags, is_remote, trace_state, status_code,
+			db_name, db_operation, http_method, http_url, http_host,
+			external_http_method, external_http_url, response_status_code
+		FROM %s.%s
+		WHERE trace_id=? AND span_id IN (?) AND ts_bucket_start>=? AND ts_bucket_start<=?
+		ORDER BY timestamp ASC, name ASC`,
+		spantypes.TraceDB, spantypes.TraceTable,
+	)
+	var spans []spantypes.StorableSpan
+	err := s.telemetryStore.ClickhouseDB().Select(
+		ctx, &spans, query,
+		traceID, spanIDs,
+		summary.Start.Unix()-1800,
+		summary.End.Unix(),
+	)
+	if err != nil {
+		return nil, errors.WrapInternalf(err, errors.CodeInternal, "error querying trace spans by IDs")
+	}
+	return spans, nil
+}

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	sqlbuilder "github.com/huandu/go-sqlbuilder"
 
@@ -70,7 +71,7 @@ func (s *traceStore) GetTraceSpans(ctx context.Context, traceID string, summary 
 	return spanItems, nil
 }
 
-func (s *traceStore) GetMinimalSpans(ctx context.Context, traceID string, summary *spantypes.TraceSummary) ([]spantypes.MinimalSpan, error) {
+func (s *traceStore) GetMinimalSpans(ctx context.Context, traceID string, start, end time.Time) ([]spantypes.MinimalSpan, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select(
 		"DISTINCT ON (span_id) span_id",
@@ -80,8 +81,8 @@ func (s *traceStore) GetMinimalSpans(ctx context.Context, traceID string, summar
 	sb.From(fmt.Sprintf("%s.%s", spantypes.TraceDB, spantypes.TraceTable))
 	sb.Where(
 		sb.E("trace_id", traceID),
-		sb.GE("ts_bucket_start", summary.Start.Unix()-1800),
-		sb.LE("ts_bucket_start", summary.End.Unix()),
+		sb.GE("ts_bucket_start", start.Unix()-1800),
+		sb.LE("ts_bucket_start", end.Unix()),
 	)
 	sb.OrderByAsc("timestamp")
 	sb.OrderByAsc("name")
@@ -94,7 +95,7 @@ func (s *traceStore) GetMinimalSpans(ctx context.Context, traceID string, summar
 	return spans, nil
 }
 
-func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, summary *spantypes.TraceSummary, spanIDs []string) ([]spantypes.StorableSpan, error) {
+func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, start, end time.Time, spanIDs []string) ([]spantypes.StorableSpan, error) {
 	if len(spanIDs) == 0 {
 		return []spantypes.StorableSpan{}, nil
 	}
@@ -117,8 +118,8 @@ func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, sum
 	sb.Where(
 		sb.E("trace_id", traceID),
 		sb.In("span_id", ids...),
-		sb.GE("ts_bucket_start", summary.Start.Unix()-1800),
-		sb.LE("ts_bucket_start", summary.End.Unix()),
+		sb.GE("ts_bucket_start", start.Unix()-1800),
+		sb.LE("ts_bucket_start", end.Unix()),
 	)
 	sb.OrderByAsc("timestamp")
 	sb.OrderByAsc("name")

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -13,6 +13,8 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/spantypes"
 )
 
+const colServiceName = `resource_string_service$$$$name` // $ gets escaped so $$$$ converts to $$.
+
 type traceStore struct {
 	telemetryStore telemetrystore.TelemetryStore
 }
@@ -47,7 +49,7 @@ func (s *traceStore) GetTraceSpans(ctx context.Context, traceID string, summary 
 	query := fmt.Sprintf(`
 		SELECT DISTINCT ON (span_id)
 			timestamp, duration_nano, span_id, has_error, kind,
-			resource_string_service$$name, name, links as references,
+			resource_string_service$$name, name,
 			attributes_string, attributes_number, attributes_bool, resources_string,
 			events, status_message, status_code_string, kind_string, parent_span_id,
 			flags, is_remote, trace_state, status_code,
@@ -76,7 +78,7 @@ func (s *traceStore) GetMinimalSpans(ctx context.Context, traceID string, start,
 	sb.Select(
 		"DISTINCT ON (span_id) span_id",
 		"parent_span_id", "timestamp", "duration_nano", "has_error",
-		`resource_string_service$$name`,
+		colServiceName,
 	)
 	sb.From(fmt.Sprintf("%s.%s", spantypes.TraceDB, spantypes.TraceTable))
 	sb.Where(
@@ -103,7 +105,7 @@ func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, sta
 	sb.Select(
 		"DISTINCT ON (span_id) timestamp",
 		"duration_nano", "span_id", "has_error", "kind",
-		`resource_string_service$$name`, "name", "links as references",
+		colServiceName, "name",
 		"attributes_string", "attributes_number", "attributes_bool", "resources_string",
 		"events", "status_message", "status_code_string", "kind_string", "parent_span_id",
 		"flags", "is_remote", "trace_state", "status_code",

--- a/pkg/modules/tracedetail/tracedetail.go
+++ b/pkg/modules/tracedetail/tracedetail.go
@@ -10,9 +10,11 @@ import (
 // Handler exposes HTTP handlers for trace detail APIs.
 type Handler interface {
 	GetWaterfall(http.ResponseWriter, *http.Request)
+	GetWaterfallV4(http.ResponseWriter, *http.Request)
 }
 
 // Module defines the business logic for trace detail operations.
 type Module interface {
 	GetWaterfall(ctx context.Context, traceID string, req *spantypes.PostableWaterfall) (*spantypes.GettableWaterfallTrace, error)
+	GetWaterfallV4(ctx context.Context, traceID string, req *spantypes.PostableWaterfall) (*spantypes.GettableWaterfallTrace, error)
 }

--- a/pkg/modules/tracedetail/tracedetail.go
+++ b/pkg/modules/tracedetail/tracedetail.go
@@ -16,5 +16,5 @@ type Handler interface {
 // Module defines the business logic for trace detail operations.
 type Module interface {
 	GetWaterfall(ctx context.Context, traceID string, req *spantypes.PostableWaterfall) (*spantypes.GettableWaterfallTrace, error)
-	GetWaterfallV4(ctx context.Context, traceID string, req *spantypes.PostableWaterfall) (*spantypes.GettableWaterfallTrace, error)
+	GetWaterfallV4(ctx context.Context, traceID string, selectedSpanID string, uncollapsedSpans []string, selectAllLimit uint) (*spantypes.GettableWaterfallTrace, error)
 }

--- a/pkg/types/spantypes/store.go
+++ b/pkg/types/spantypes/store.go
@@ -26,4 +26,6 @@ type SpanMapperStore interface {
 type TraceStore interface {
 	GetTraceSummary(ctx context.Context, traceID string) (*TraceSummary, error)
 	GetTraceSpans(ctx context.Context, traceID string, summary *TraceSummary) ([]StorableSpan, error)
+	GetMinimalSpans(ctx context.Context, traceID string, summary *TraceSummary) ([]MinimalSpan, error)
+	GetTraceSpansByIDs(ctx context.Context, traceID string, summary *TraceSummary, spanIDs []string) ([]StorableSpan, error)
 }

--- a/pkg/types/spantypes/store.go
+++ b/pkg/types/spantypes/store.go
@@ -2,6 +2,7 @@ package spantypes
 
 import (
 	"context"
+	"time"
 
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
@@ -26,6 +27,6 @@ type SpanMapperStore interface {
 type TraceStore interface {
 	GetTraceSummary(ctx context.Context, traceID string) (*TraceSummary, error)
 	GetTraceSpans(ctx context.Context, traceID string, summary *TraceSummary) ([]StorableSpan, error)
-	GetMinimalSpans(ctx context.Context, traceID string, summary *TraceSummary) ([]MinimalSpan, error)
-	GetTraceSpansByIDs(ctx context.Context, traceID string, summary *TraceSummary, spanIDs []string) ([]StorableSpan, error)
+	GetMinimalSpans(ctx context.Context, traceID string, start, end time.Time) ([]MinimalSpan, error)
+	GetTraceSpansByIDs(ctx context.Context, traceID string, start, end time.Time, spanIDs []string) ([]StorableSpan, error)
 }

--- a/pkg/types/spantypes/waterfall_span.go
+++ b/pkg/types/spantypes/waterfall_span.go
@@ -107,7 +107,6 @@ type StorableSpan struct {
 	Kind               int8               `ch:"kind"`
 	ServiceName        string             `ch:"resource_string_service$$name"`
 	Name               string             `ch:"name"`
-	References         string             `ch:"references"`
 	AttributesString   map[string]string  `ch:"attributes_string"`
 	AttributesNumber   map[string]float64 `ch:"attributes_number"`
 	AttributesBool     map[string]bool    `ch:"attributes_bool"`

--- a/pkg/types/spantypes/waterfall_span.go
+++ b/pkg/types/spantypes/waterfall_span.go
@@ -103,7 +103,6 @@ type StorableSpan struct {
 	StartTime          time.Time          `ch:"timestamp"`
 	DurationNano       uint64             `ch:"duration_nano"`
 	SpanID             string             `ch:"span_id"`
-	TraceID            string             `ch:"trace_id"`
 	HasError           bool               `ch:"has_error"`
 	Kind               int8               `ch:"kind"`
 	ServiceName        string             `ch:"resource_string_service$$name"`
@@ -142,9 +141,10 @@ type MinimalSpan struct {
 	ServiceName  string    `ch:"resource_string_service$$name"`
 }
 
-func (item *MinimalSpan) ToWaterfallSpan() *WaterfallSpan {
+func (item *MinimalSpan) ToWaterfallSpan(traceID string) *WaterfallSpan {
 	return &WaterfallSpan{
 		SpanID:       item.SpanID,
+		TraceID:      traceID,
 		ParentSpanID: item.ParentSpanID,
 		TimeUnix:     uint64(item.StartTime.UnixNano()),
 		DurationNano: item.DurationNano,
@@ -286,7 +286,7 @@ func (item *StorableSpan) UnmarshalledEvents() []Event {
 	return events
 }
 
-func (item *StorableSpan) ToWaterfallSpan() *WaterfallSpan {
+func (item *StorableSpan) ToWaterfallSpan(traceID string) *WaterfallSpan {
 	resources := make(map[string]string)
 	maps.Copy(resources, item.ResourcesString)
 
@@ -314,7 +314,7 @@ func (item *StorableSpan) ToWaterfallSpan() *WaterfallSpan {
 		StatusCode:         item.StatusCode,
 		StatusCodeString:   item.StatusCodeString,
 		StatusMessage:      item.StatusMessage,
-		TraceID:            item.TraceID,
+		TraceID:            traceID,
 		TraceState:         item.TraceState,
 		Children:           make([]*WaterfallSpan, 0),
 		TimeUnix:           uint64(item.StartTime.UnixNano()),
@@ -332,7 +332,7 @@ func EnrichSelectedSpans(window []*WaterfallSpan, fullSpans []StorableSpan) {
 		if !ok {
 			continue // synthesized MissingSpan — keep empty shell
 		}
-		newWS := full.ToWaterfallSpan()
+		newWS := full.ToWaterfallSpan(ws.TraceID)
 		newWS.Level = ws.Level
 		newWS.HasChildren = ws.HasChildren
 		newWS.SubTreeNodeCount = ws.SubTreeNodeCount

--- a/pkg/types/spantypes/waterfall_span.go
+++ b/pkg/types/spantypes/waterfall_span.go
@@ -132,7 +132,7 @@ type StorableSpan struct {
 	ResponseStatusCode string             `ch:"response_status_code"`
 }
 
-// MinimalSpan with only the fields needed to build the parent-child tree
+// MinimalSpan with only the fields needed to build the parent-child tree.
 type MinimalSpan struct {
 	SpanID       string    `ch:"span_id"`
 	ParentSpanID string    `ch:"parent_span_id"`
@@ -319,6 +319,24 @@ func (item *StorableSpan) ToWaterfallSpan() *WaterfallSpan {
 		Children:           make([]*WaterfallSpan, 0),
 		TimeUnix:           uint64(item.StartTime.UnixNano()),
 		ServiceName:        item.ServiceName,
+	}
+}
+
+func EnrichSelectedSpans(window []*WaterfallSpan, fullSpans []StorableSpan) {
+	fullByID := make(map[string]*StorableSpan, len(fullSpans))
+	for i := range fullSpans {
+		fullByID[fullSpans[i].SpanID] = &fullSpans[i]
+	}
+	for i, ws := range window {
+		full, ok := fullByID[ws.SpanID]
+		if !ok {
+			continue // synthesized MissingSpan — keep empty shell
+		}
+		newWS := full.ToWaterfallSpan()
+		newWS.Level = ws.Level
+		newWS.HasChildren = ws.HasChildren
+		newWS.SubTreeNodeCount = ws.SubTreeNodeCount
+		window[i] = newWS
 	}
 }
 

--- a/pkg/types/spantypes/waterfall_span.go
+++ b/pkg/types/spantypes/waterfall_span.go
@@ -132,6 +132,31 @@ type StorableSpan struct {
 	ResponseStatusCode string             `ch:"response_status_code"`
 }
 
+// MinimalSpan with only the fields needed to build the parent-child tree
+type MinimalSpan struct {
+	SpanID       string    `ch:"span_id"`
+	ParentSpanID string    `ch:"parent_span_id"`
+	StartTime    time.Time `ch:"timestamp"`
+	DurationNano uint64    `ch:"duration_nano"`
+	HasError     bool      `ch:"has_error"`
+	ServiceName  string    `ch:"resource_string_service$$name"`
+}
+
+func (item *MinimalSpan) ToWaterfallSpan() *WaterfallSpan {
+	return &WaterfallSpan{
+		SpanID:       item.SpanID,
+		ParentSpanID: item.ParentSpanID,
+		TimeUnix:     uint64(item.StartTime.UnixNano()),
+		DurationNano: item.DurationNano,
+		HasError:     item.HasError,
+		ServiceName:  item.ServiceName,
+		Resource:     map[string]string{"service.name": item.ServiceName},
+		Children:     make([]*WaterfallSpan, 0),
+		Attributes:   make(map[string]any),
+		Events:       make([]Event, 0),
+	}
+}
+
 // NewMissingWaterfallSpan creates a synthetic placeholder span for a parent that has no recorded data.
 func NewMissingWaterfallSpan(spanID, traceID string, timeUnixNano, durationNano uint64) *WaterfallSpan {
 	return &WaterfallSpan{

--- a/pkg/types/spantypes/waterfall_trace.go
+++ b/pkg/types/spantypes/waterfall_trace.go
@@ -62,26 +62,24 @@ func NewWaterfallTrace(
 	}
 }
 
-func NewWaterfallTraceFromSpans(spans []StorableSpan) *WaterfallTrace {
+// NewWaterfallTraceFromSpans constructs a trace tree from pre-converted WaterfallSpan nodes.
+// SpanID, ParentSpanID, TimeUnix, DurationNano, HasError, and ServiceName must be populated.
+func NewWaterfallTraceFromSpans(nodes []*WaterfallSpan) *WaterfallTrace {
 	var (
 		startTime, endTime, totalErrorSpans uint64
-		spanIDToSpanNodeMap                 = make(map[string]*WaterfallSpan, len(spans))
+		spanIDToSpanNodeMap                 = make(map[string]*WaterfallSpan, len(nodes))
 		traceRoots                          []*WaterfallSpan
 		hasMissingSpans                     bool
 	)
 
-	for _, item := range spans {
-		span := item.ToWaterfallSpan()
-		startTimeUnixNano := uint64(item.StartTime.UnixNano())
-		if startTime == 0 || startTimeUnixNano < startTime {
-			startTime = startTimeUnixNano
+	for _, span := range nodes {
+		if startTime == 0 || span.TimeUnix < startTime {
+			startTime = span.TimeUnix
 		}
-		endTime = max(endTime, startTimeUnixNano+span.DurationNano)
-
+		endTime = max(endTime, span.TimeUnix+span.DurationNano)
 		if span.HasError {
 			totalErrorSpans++
 		}
-
 		spanIDToSpanNodeMap[span.SpanID] = span
 	}
 
@@ -116,29 +114,12 @@ func NewWaterfallTraceFromSpans(spans []StorableSpan) *WaterfallTrace {
 	return NewWaterfallTrace(
 		startTime,
 		endTime,
-		uint64(len(spans)),
+		uint64(len(nodes)),
 		totalErrorSpans,
 		spanIDToSpanNodeMap,
 		traceRoots,
 		hasMissingSpans,
 	)
-}
-
-func (wt *WaterfallTrace) GetWaterfallSpans(uncollapsedSpanIDs []string, selectedSpanID string, limit uint, spanPageSize float64, maxDepthToAutoExpand int) ([]*WaterfallSpan, []string, bool) {
-	// Span selection decision: all spans or windowed
-	selectAllSpans := wt.TotalSpans <= uint64(limit)
-
-	var (
-		selectedSpans    []*WaterfallSpan
-		uncollapsedSpans []string
-	)
-
-	if selectAllSpans {
-		selectedSpans = wt.GetAllSpans()
-	} else {
-		selectedSpans, uncollapsedSpans = wt.GetSelectedSpans(uncollapsedSpanIDs, selectedSpanID, spanPageSize, maxDepthToAutoExpand)
-	}
-	return selectedSpans, uncollapsedSpans, selectAllSpans
 }
 
 // GetAllSpans returns all spans with pre order traversal.

--- a/pkg/types/spantypes/waterfall_trace.go
+++ b/pkg/types/spantypes/waterfall_trace.go
@@ -122,6 +122,14 @@ func NewWaterfallTraceFromSpans(nodes []*WaterfallSpan) *WaterfallTrace {
 	)
 }
 
+func (wt *WaterfallTrace) GetWaterfallSpans(uncollapsedSpanIDs []string, selectedSpanID string, limit uint, spanPageSize float64, maxDepthToAutoExpand int) ([]*WaterfallSpan, []string, bool) {
+	if wt.TotalSpans <= uint64(limit) {
+		return wt.GetAllSpans(), nil, true
+	}
+	spans, uncollapsed := wt.GetSelectedSpans(uncollapsedSpanIDs, selectedSpanID, spanPageSize, maxDepthToAutoExpand)
+	return spans, uncollapsed, false
+}
+
 // GetAllSpans returns all spans with pre order traversal.
 func (wt *WaterfallTrace) GetAllSpans() []*WaterfallSpan {
 	var preOrderedSpans []*WaterfallSpan

--- a/pkg/types/spantypes/waterfall_trace.go
+++ b/pkg/types/spantypes/waterfall_trace.go
@@ -123,11 +123,20 @@ func NewWaterfallTraceFromSpans(nodes []*WaterfallSpan) *WaterfallTrace {
 }
 
 func (wt *WaterfallTrace) GetWaterfallSpans(uncollapsedSpanIDs []string, selectedSpanID string, limit uint, spanPageSize float64, maxDepthToAutoExpand int) ([]*WaterfallSpan, []string, bool) {
-	if wt.TotalSpans <= uint64(limit) {
-		return wt.GetAllSpans(), nil, true
+	// Span selection decision: all spans or windowed
+	selectAllSpans := wt.TotalSpans <= uint64(limit)
+
+	var (
+		selectedSpans    []*WaterfallSpan
+		uncollapsedSpans []string
+	)
+
+	if selectAllSpans {
+		selectedSpans = wt.GetAllSpans()
+	} else {
+		selectedSpans, uncollapsedSpans = wt.GetSelectedSpans(uncollapsedSpanIDs, selectedSpanID, spanPageSize, maxDepthToAutoExpand)
 	}
-	spans, uncollapsed := wt.GetSelectedSpans(uncollapsedSpanIDs, selectedSpanID, spanPageSize, maxDepthToAutoExpand)
-	return spans, uncollapsed, false
+	return selectedSpans, uncollapsedSpans, selectAllSpans
 }
 
 // GetAllSpans returns all spans with pre order traversal.

--- a/pkg/types/spantypes/waterfall_trace.go
+++ b/pkg/types/spantypes/waterfall_trace.go
@@ -62,8 +62,8 @@ func NewWaterfallTrace(
 	}
 }
 
-// NewWaterfallTraceFromSpans constructs a trace tree from pre-converted WaterfallSpan nodes.
-// SpanID, ParentSpanID, TimeUnix, DurationNano, HasError, and ServiceName must be populated.
+// NewWaterfallTraceFromSpans requires WaterfallSpan nodes with only below fields:
+// SpanID, ParentSpanID, TimeUnix, DurationNano, HasError, and ServiceName.
 func NewWaterfallTraceFromSpans(nodes []*WaterfallSpan) *WaterfallTrace {
 	var (
 		startTime, endTime, totalErrorSpans uint64


### PR DESCRIPTION
Part of https://github.com/SigNoz/engineering-pod/issues/4787

Create waterfall in two steps for large traces to avoid high memory allocations. Creating a new API to maintain the backward compatibility since aggregations are not returned in the response now, we'll add a separate API to get the aggregations only for any trace.

Edit: Aggregations PR https://github.com/SigNoz/signoz/pull/11452