### PR TITLE
feat(trace-details): Add API endpoint & module for trace aggregations

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -6605,6 +6605,8 @@ components:
             $ref: '#/components/schemas/SpantypesSpanAggregation'
           nullable: true
           type: array
+      required:
+      - aggregations
       type: object
     SpantypesPostableWaterfall:
       properties:
@@ -6630,6 +6632,9 @@ components:
           $ref: '#/components/schemas/SpantypesSpanAggregationType'
         field:
           $ref: '#/components/schemas/TelemetrytypesTelemetryFieldKey'
+      required:
+      - field
+      - aggregation
       type: object
     SpantypesSpanAggregationResult:
       properties:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -6530,8 +6530,9 @@ components:
         aggregations:
           items:
             $ref: '#/components/schemas/SpantypesSpanAggregationResult'
-          nullable: true
           type: array
+      required:
+      - aggregations
       type: object
     SpantypesGettableWaterfallTrace:
       properties:
@@ -6647,6 +6648,10 @@ components:
             type: integer
           nullable: true
           type: object
+      required:
+      - field
+      - aggregation
+      - value
       type: object
     SpantypesSpanAggregationType:
       enum:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -6525,6 +6525,14 @@ components:
       required:
       - items
       type: object
+    SpantypesGettableTraceAggregations:
+      properties:
+        aggregations:
+          items:
+            $ref: '#/components/schemas/SpantypesSpanAggregationResult'
+          nullable: true
+          type: array
+      type: object
     SpantypesGettableWaterfallTrace:
       properties:
         aggregations:
@@ -6589,6 +6597,14 @@ components:
       required:
       - name
       - condition
+      type: object
+    SpantypesPostableTraceAggregations:
+      properties:
+        aggregations:
+          items:
+            $ref: '#/components/schemas/SpantypesSpanAggregation'
+          nullable: true
+          type: array
       type: object
     SpantypesPostableWaterfall:
       properties:
@@ -12265,6 +12281,75 @@ paths:
       summary: Test notification channel (deprecated)
       tags:
       - channels
+  /api/v1/traces/{traceID}/aggregations:
+    post:
+      deprecated: false
+      description: Computes span aggregations grouped by requested field.
+      operationId: GetTraceAggregations
+      parameters:
+      - in: path
+        name: traceID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SpantypesPostableTraceAggregations'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: '#/components/schemas/SpantypesGettableTraceAggregations'
+                  status:
+                    type: string
+                required:
+                - status
+                - data
+                type: object
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Internal Server Error
+      security:
+      - api_key:
+        - VIEWER
+      - tokenizer:
+        - VIEWER
+      summary: Get aggregations for a trace
+      tags:
+      - tracedetail
   /api/v1/user:
     get:
       deprecated: false

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -6603,7 +6603,6 @@ components:
         aggregations:
           items:
             $ref: '#/components/schemas/SpantypesSpanAggregation'
-          nullable: true
           type: array
       required:
       - aggregations

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -8013,9 +8013,9 @@ export interface SpantypesSpanAggregationDTO {
 
 export interface SpantypesPostableTraceAggregationsDTO {
 	/**
-	 * @type array,null
+	 * @type array
 	 */
-	aggregations: SpantypesSpanAggregationDTO[] | null;
+	aggregations: SpantypesSpanAggregationDTO[];
 }
 
 export interface SpantypesPostableWaterfallDTO {

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -7761,6 +7761,13 @@ export interface SpantypesSpanAggregationResultDTO {
 	value?: SpantypesSpanAggregationResultDTOValue;
 }
 
+export interface SpantypesGettableTraceAggregationsDTO {
+	/**
+	 * @type array,null
+	 */
+	aggregations?: SpantypesSpanAggregationResultDTO[] | null;
+}
+
 export type SpantypesWaterfallSpanDTOAttributesAnyOf = {
 	[key: string]: unknown;
 };
@@ -8002,6 +8009,13 @@ export interface SpantypesPostableSpanMapperGroupDTO {
 export interface SpantypesSpanAggregationDTO {
 	aggregation?: SpantypesSpanAggregationTypeDTO;
 	field?: TelemetrytypesTelemetryFieldKeyDTO;
+}
+
+export interface SpantypesPostableTraceAggregationsDTO {
+	/**
+	 * @type array,null
+	 */
+	aggregations?: SpantypesSpanAggregationDTO[] | null;
 }
 
 export interface SpantypesPostableWaterfallDTO {
@@ -9344,6 +9358,17 @@ export type UpdateSpanMapperPathParameters = {
 	groupId: string;
 	mapperId: string;
 };
+export type GetTraceAggregationsPathParameters = {
+	traceID: string;
+};
+export type GetTraceAggregations200 = {
+	data: SpantypesGettableTraceAggregationsDTO;
+	/**
+	 * @type string
+	 */
+	status: string;
+};
+
 export type ListUsersDeprecated200 = {
 	/**
 	 * @type array

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -8007,15 +8007,15 @@ export interface SpantypesPostableSpanMapperGroupDTO {
 }
 
 export interface SpantypesSpanAggregationDTO {
-	aggregation?: SpantypesSpanAggregationTypeDTO;
-	field?: TelemetrytypesTelemetryFieldKeyDTO;
+	aggregation: SpantypesSpanAggregationTypeDTO;
+	field: TelemetrytypesTelemetryFieldKeyDTO;
 }
 
 export interface SpantypesPostableTraceAggregationsDTO {
 	/**
 	 * @type array,null
 	 */
-	aggregations?: SpantypesSpanAggregationDTO[] | null;
+	aggregations: SpantypesSpanAggregationDTO[] | null;
 }
 
 export interface SpantypesPostableWaterfallDTO {

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -7753,19 +7753,19 @@ export type SpantypesSpanAggregationResultDTOValue =
 	SpantypesSpanAggregationResultDTOValueAnyOf | null;
 
 export interface SpantypesSpanAggregationResultDTO {
-	aggregation?: SpantypesSpanAggregationTypeDTO;
-	field?: TelemetrytypesTelemetryFieldKeyDTO;
+	aggregation: SpantypesSpanAggregationTypeDTO;
+	field: TelemetrytypesTelemetryFieldKeyDTO;
 	/**
 	 * @type object,null
 	 */
-	value?: SpantypesSpanAggregationResultDTOValue;
+	value: SpantypesSpanAggregationResultDTOValue;
 }
 
 export interface SpantypesGettableTraceAggregationsDTO {
 	/**
-	 * @type array,null
+	 * @type array
 	 */
-	aggregations?: SpantypesSpanAggregationResultDTO[] | null;
+	aggregations: SpantypesSpanAggregationResultDTO[];
 }
 
 export type SpantypesWaterfallSpanDTOAttributesAnyOf = {

--- a/frontend/src/api/generated/services/tracedetail/index.ts
+++ b/frontend/src/api/generated/services/tracedetail/index.ts
@@ -12,17 +12,120 @@ import type {
 } from 'react-query';
 
 import type {
+	GetTraceAggregations200,
+	GetTraceAggregationsPathParameters,
 	GetWaterfall200,
 	GetWaterfallPathParameters,
 	GetWaterfallV4200,
 	GetWaterfallV4PathParameters,
 	RenderErrorResponseDTO,
+	SpantypesPostableTraceAggregationsDTO,
 	SpantypesPostableWaterfallDTO,
 } from '../sigNoz.schemas';
 
 import { GeneratedAPIInstance } from '../../../generatedAPIInstance';
 import type { ErrorType, BodyType } from '../../../generatedAPIInstance';
 
+/**
+ * Computes span aggregations grouped by requested field.
+ * @summary Get aggregations for a trace
+ */
+export const getTraceAggregations = (
+	{ traceID }: GetTraceAggregationsPathParameters,
+	spantypesPostableTraceAggregationsDTO?: BodyType<SpantypesPostableTraceAggregationsDTO>,
+	signal?: AbortSignal,
+) => {
+	return GeneratedAPIInstance<GetTraceAggregations200>({
+		url: `/api/v1/traces/${traceID}/aggregations`,
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		data: spantypesPostableTraceAggregationsDTO,
+		signal,
+	});
+};
+
+export const getGetTraceAggregationsMutationOptions = <
+	TError = ErrorType<RenderErrorResponseDTO>,
+	TContext = unknown,
+>(options?: {
+	mutation?: UseMutationOptions<
+		Awaited<ReturnType<typeof getTraceAggregations>>,
+		TError,
+		{
+			pathParams: GetTraceAggregationsPathParameters;
+			data?: BodyType<SpantypesPostableTraceAggregationsDTO>;
+		},
+		TContext
+	>;
+}): UseMutationOptions<
+	Awaited<ReturnType<typeof getTraceAggregations>>,
+	TError,
+	{
+		pathParams: GetTraceAggregationsPathParameters;
+		data?: BodyType<SpantypesPostableTraceAggregationsDTO>;
+	},
+	TContext
+> => {
+	const mutationKey = ['getTraceAggregations'];
+	const { mutation: mutationOptions } = options
+		? options.mutation &&
+			'mutationKey' in options.mutation &&
+			options.mutation.mutationKey
+			? options
+			: { ...options, mutation: { ...options.mutation, mutationKey } }
+		: { mutation: { mutationKey } };
+
+	const mutationFn: MutationFunction<
+		Awaited<ReturnType<typeof getTraceAggregations>>,
+		{
+			pathParams: GetTraceAggregationsPathParameters;
+			data?: BodyType<SpantypesPostableTraceAggregationsDTO>;
+		}
+	> = (props) => {
+		const { pathParams, data } = props ?? {};
+
+		return getTraceAggregations(pathParams, data);
+	};
+
+	return { mutationFn, ...mutationOptions };
+};
+
+export type GetTraceAggregationsMutationResult = NonNullable<
+	Awaited<ReturnType<typeof getTraceAggregations>>
+>;
+export type GetTraceAggregationsMutationBody =
+	| BodyType<SpantypesPostableTraceAggregationsDTO>
+	| undefined;
+export type GetTraceAggregationsMutationError =
+	ErrorType<RenderErrorResponseDTO>;
+
+/**
+ * @summary Get aggregations for a trace
+ */
+export const useGetTraceAggregations = <
+	TError = ErrorType<RenderErrorResponseDTO>,
+	TContext = unknown,
+>(options?: {
+	mutation?: UseMutationOptions<
+		Awaited<ReturnType<typeof getTraceAggregations>>,
+		TError,
+		{
+			pathParams: GetTraceAggregationsPathParameters;
+			data?: BodyType<SpantypesPostableTraceAggregationsDTO>;
+		},
+		TContext
+	>;
+}): UseMutationResult<
+	Awaited<ReturnType<typeof getTraceAggregations>>,
+	TError,
+	{
+		pathParams: GetTraceAggregationsPathParameters;
+		data?: BodyType<SpantypesPostableTraceAggregationsDTO>;
+	},
+	TContext
+> => {
+	return useMutation(getGetTraceAggregationsMutationOptions(options));
+};
 /**
  * Returns the waterfall view of spans for a given trace ID with tree structure, metadata, and windowed pagination
  * @summary Get waterfall view for a trace

--- a/pkg/apiserver/signozapiserver/tracedetail.go
+++ b/pkg/apiserver/signozapiserver/tracedetail.go
@@ -48,5 +48,24 @@ func (provider *provider) addTraceDetailRoutes(router *mux.Router) error {
 		return err
 	}
 
+	if err := router.Handle("/api/v4/traces/{traceID}/aggregations", handler.New(
+		provider.authzMiddleware.ViewAccess(provider.traceDetailHandler.GetTraceAggregations),
+		handler.OpenAPIDef{
+			ID:                  "GetTraceAggregations",
+			Tags:                []string{"tracedetail"},
+			Summary:             "Get aggregations for a trace",
+			Description:         "Computes span aggregations grouped by requested field.",
+			Request:             new(spantypes.PostableTraceAggregations),
+			RequestContentType:  "application/json",
+			Response:            new(spantypes.GettableTraceAggregations),
+			ResponseContentType: "application/json",
+			SuccessStatusCode:   http.StatusOK,
+			ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
+			SecuritySchemes:     newSecuritySchemes(types.RoleViewer),
+		},
+	)).Methods(http.MethodPost).GetError(); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/apiserver/signozapiserver/tracedetail.go
+++ b/pkg/apiserver/signozapiserver/tracedetail.go
@@ -48,7 +48,7 @@ func (provider *provider) addTraceDetailRoutes(router *mux.Router) error {
 		return err
 	}
 
-	if err := router.Handle("/api/v4/traces/{traceID}/aggregations", handler.New(
+	if err := router.Handle("/api/v1/traces/{traceID}/aggregations", handler.New(
 		provider.authzMiddleware.ViewAccess(provider.traceDetailHandler.GetTraceAggregations),
 		handler.OpenAPIDef{
 			ID:                  "GetTraceAggregations",

--- a/pkg/modules/tracedetail/impltracedetail/handler.go
+++ b/pkg/modules/tracedetail/impltracedetail/handler.go
@@ -59,3 +59,24 @@ func (h *handler) GetWaterfallV4(rw http.ResponseWriter, r *http.Request) {
 
 	render.Success(rw, http.StatusOK, result)
 }
+
+func (h *handler) GetTraceAggregations(rw http.ResponseWriter, r *http.Request) {
+	req := new(spantypes.PostableTraceAggregations)
+	if err := binding.JSON.BindBody(r.Body, req); err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	if err := req.Validate(); err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	result, err := h.module.GetTraceAggregations(r.Context(), mux.Vars(r)["traceID"], req)
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	render.Success(rw, http.StatusOK, result)
+}

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -105,6 +105,49 @@ func (m *module) getFullWaterfall(ctx context.Context, traceID string, summary *
 	return spantypes.NewGettableWaterfallTrace(waterfallTrace, selectedSpans, nil, true, nil), nil
 }
 
+func (m *module) GetTraceAggregations(ctx context.Context, traceID string, req *spantypes.PostableTraceAggregations) (*spantypes.GettableTraceAggregations, error) {
+	summary, err := m.store.GetTraceSummary(ctx, traceID)
+	if err != nil {
+		return nil, err
+	}
+
+	traceDurationNs := uint64(summary.End.UnixNano()) - uint64(summary.Start.UnixNano())
+
+	results := make([]spantypes.SpanAggregationResult, 0, len(req.Aggregations))
+	for _, agg := range req.Aggregations {
+		result := spantypes.SpanAggregationResult{Field: agg.Field, Aggregation: agg.Aggregation}
+		switch agg.Aggregation {
+		case spantypes.SpanAggregationSpanCount:
+			result.Value, err = m.store.GetSpanCountByField(ctx, traceID, summary, agg.Field)
+			if err != nil {
+				return nil, err
+			}
+		case spantypes.SpanAggregationDuration:
+			durationNs, err2 := m.store.GetSpanDurationByField(ctx, traceID, summary, agg.Field)
+			if err2 != nil {
+				return nil, err2
+			}
+			result.Value = make(map[string]uint64, len(durationNs))
+			for k, ns := range durationNs {
+				result.Value[k] = ns / 1_000_000
+			}
+		case spantypes.SpanAggregationExecutionTimePercentage:
+			durationNs, err2 := m.store.GetSpanDurationByField(ctx, traceID, summary, agg.Field)
+			if err2 != nil {
+				return nil, err2
+			}
+			result.Value = make(map[string]uint64, len(durationNs))
+			if traceDurationNs > 0 {
+				for k, ns := range durationNs {
+					result.Value[k] = ns * 100 / traceDurationNs
+				}
+			}
+		}
+		results = append(results, result)
+	}
+	return &spantypes.GettableTraceAggregations{Aggregations: results}, nil
+}
+
 // getWindowedWaterfall builds the waterfall tree with minimal data and then returns only a window of full spans.
 func (m *module) getWindowedWaterfall(ctx context.Context, traceID, selectedSpanID string, uncollapsedSpans []string, start, end time.Time) (*spantypes.GettableWaterfallTrace, error) {
 	// Step 1: minimal fetch → build full tree → select visible window

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -20,23 +20,14 @@ const colServiceName = `resource_string_service$$$$name` // $ gets escaped so $$
 // validFieldName only allows characters safe to embed as ClickHouse map subscript literals.
 var validFieldName = regexp.MustCompile(`^[a-zA-Z0-9._\-]+$`)
 
-// buildFieldExpr returns a ClickHouse SQL expression for the value of fieldKey per span.
-func buildFieldExpr(fieldKey telemetrytypes.TelemetryFieldKey) (string, error) {
-	if !validFieldName.MatchString(fieldKey.Name) {
-		return "", errors.NewInvalidInputf(errors.CodeInvalidInput, "invalid field name: %q", fieldKey.Name)
-	}
-	n := fieldKey.Name
-	switch fieldKey.FieldContext {
-	case telemetrytypes.FieldContextResource:
-		return fmt.Sprintf("resources_string['%s']", n), nil
-	case telemetrytypes.FieldContextAttribute:
-		return fmt.Sprintf(
-			"multiIf(mapContains(attributes_string,'%[1]s'),attributes_string['%[1]s'],"+
-				"mapContains(attributes_number,'%[1]s'),toString(attributes_number['%[1]s']),"+
-				"mapContains(attributes_bool,'%[1]s'),toString(attributes_bool['%[1]s']),'')",
-			n), nil
-	}
-	return "", errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported field context: %v", fieldKey.FieldContext)
+type spanCountRow struct {
+	FieldValue string `ch:"field_value"`
+	Count      uint64 `ch:"count"`
+}
+
+type spanDurationRow struct {
+	FieldValue string `ch:"field_value"`
+	TotalNs    uint64 `ch:"total_ns"`
 }
 
 type traceStore struct {
@@ -121,14 +112,6 @@ func (s *traceStore) GetMinimalSpans(ctx context.Context, traceID string, start,
 	return spans, nil
 }
 
-func (s *traceStore) GetSpanCountByField(ctx context.Context, traceID string, summary *spantypes.TraceSummary, fieldKey telemetrytypes.TelemetryFieldKey) (map[string]uint64, error) {
-	return nil, nil
-}
-
-func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string, summary *spantypes.TraceSummary, fieldKey telemetrytypes.TelemetryFieldKey) (map[string]uint64, error) {
-	return nil, nil
-}
-
 func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, start, end time.Time, spanIDs []string) ([]spantypes.StorableSpan, error) {
 	if len(spanIDs) == 0 {
 		return []spantypes.StorableSpan{}, nil
@@ -166,28 +149,25 @@ func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, sta
 	return spans, nil
 }
 
-type spanCountRow struct {
-	FieldValue string `ch:"field_value"`
-	Count      uint64 `ch:"count"`
-}
-
 func (s *traceStore) GetSpanCountByField(ctx context.Context, traceID string, summary *spantypes.TraceSummary, fieldKey telemetrytypes.TelemetryFieldKey) (map[string]uint64, error) {
 	fieldExpr, err := buildFieldExpr(fieldKey)
 	if err != nil {
 		return nil, err
 	}
-	query := fmt.Sprintf(`
-		SELECT %[1]s AS field_value, count() AS count
-		FROM %[2]s.%[3]s
-		WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=?
-		  AND %[1]s != ''
-		GROUP BY field_value`,
-		fieldExpr, spantypes.TraceDB, spantypes.TraceTable,
+	sb := sqlbuilder.NewSelectBuilder()
+	sb.Select(fieldExpr+" AS field_value", "count(DISTINCT span_id) AS count")
+	sb.From(fmt.Sprintf("%s.%s", spantypes.TraceDB, spantypes.TraceTable))
+	sb.Where(
+		sb.E("trace_id", traceID),
+		sb.GE("ts_bucket_start", summary.Start.Unix()-1800),
+		sb.LE("ts_bucket_start", summary.End.Unix()),
+		fieldExpr+" != ''",
 	)
+	sb.GroupBy("field_value")
+	query, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+
 	var rows []spanCountRow
-	if err := s.telemetryStore.ClickhouseDB().Select(ctx, &rows, query,
-		traceID, summary.Start.Unix()-1800, summary.End.Unix(),
-	); err != nil {
+	if err := s.telemetryStore.ClickhouseDB().Select(ctx, &rows, query, args...); err != nil {
 		return nil, errors.WrapInternalf(err, errors.CodeInternal, "error querying span count by field")
 	}
 	result := make(map[string]uint64, len(rows))
@@ -197,51 +177,38 @@ func (s *traceStore) GetSpanCountByField(ctx context.Context, traceID string, su
 	return result, nil
 }
 
-type spanDurationRow struct {
-	FieldValue string `ch:"field_value"`
-	TotalNs    uint64 `ch:"total_ns"`
-}
-
 func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string, summary *spantypes.TraceSummary, fieldKey telemetrytypes.TelemetryFieldKey) (map[string]uint64, error) {
 	fieldExpr, err := buildFieldExpr(fieldKey)
 	if err != nil {
 		return nil, err
 	}
-	// 4-level query: deduplicate → window function → non-overlapping per span → sum per field.
-	// The window function computes the running max end time of preceding spans in the same
-	// field partition (ordered by start), so each span only contributes its non-overlapping
-	// tail — matching the Go-side mergeSpanIntervals semantics in V3.
+	// 3-level query: deduplicate → window function → sum non-overlapping per field.
+	// The window tracks the running max end time of preceding spans within each field_value
+	// partition (ordered by start). Each span contributes only its non-overlapping end
 	query := fmt.Sprintf(`
-		SELECT field_value, sum(non_overlapping_ns) AS total_ns
+		SELECT field_value, sum(multiIf(
+			start_ns >= prev_max_end_ns,                    duration_nano,
+			start_ns + duration_nano > prev_max_end_ns,     start_ns + duration_nano - prev_max_end_ns,
+			0
+		)) AS total_ns
 		FROM (
 			SELECT
-				field_value,
-				multiIf(
-					start_ns >= prev_max_end_ns,                          duration_nano,
-					start_ns + duration_nano > prev_max_end_ns,           start_ns + duration_nano - prev_max_end_ns,
-					0
-				) AS non_overlapping_ns
+				field_value, start_ns, duration_nano,
+				ifNull(max(start_ns + duration_nano) OVER (
+					PARTITION BY field_value
+					ORDER BY start_ns
+					ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+				), 0) AS prev_max_end_ns
 			FROM (
-				SELECT
-					field_value,
-					start_ns,
-					duration_nano,
-					ifNull(max(start_ns + duration_nano) OVER (
-						PARTITION BY field_value
-						ORDER BY start_ns
-						ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
-					), 0) AS prev_max_end_ns
-				FROM (
-					SELECT DISTINCT ON (span_id)
-						%[1]s AS field_value,
-						toUnixTimestamp64Nano(timestamp) AS start_ns,
-						duration_nano
-					FROM %[2]s.%[3]s
-					WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=?
-					ORDER BY toUnixTimestamp64Nano(timestamp) ASC, name ASC
-				)
-				WHERE field_value != ''
+				SELECT DISTINCT ON (span_id)
+					%[1]s AS field_value,
+					toUnixTimestamp64Nano(timestamp) AS start_ns,
+					duration_nano
+				FROM %[2]s.%[3]s
+				WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=?
+				ORDER BY toUnixTimestamp64Nano(timestamp) ASC, name ASC
 			)
+			WHERE field_value != ''
 		)
 		GROUP BY field_value`,
 		fieldExpr, spantypes.TraceDB, spantypes.TraceTable,
@@ -257,4 +224,31 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 		result[r.FieldValue] = r.TotalNs
 	}
 	return result, nil
+}
+
+func buildFieldExpr(fieldKey telemetrytypes.TelemetryFieldKey) (string, error) {
+	if !validFieldName.MatchString(fieldKey.Name) {
+		return "", errors.NewInvalidInputf(errors.CodeInvalidInput, "invalid field name: %q", fieldKey.Name)
+	}
+	n := fieldKey.Name
+	switch fieldKey.FieldContext {
+	case telemetrytypes.FieldContextResource:
+		return fmt.Sprintf("resource.`%s`::String", n), nil
+	case telemetrytypes.FieldContextAttribute:
+		switch fieldKey.FieldDataType {
+		case telemetrytypes.FieldDataTypeString:
+			return fmt.Sprintf("attributes_string['%s']", n), nil
+		case telemetrytypes.FieldDataTypeFloat64, telemetrytypes.FieldDataTypeInt64, telemetrytypes.FieldDataTypeNumber:
+			return fmt.Sprintf("if(mapContains(attributes_number,'%[1]s'),toString(attributes_number['%[1]s']),'')", n), nil
+		case telemetrytypes.FieldDataTypeBool:
+			return fmt.Sprintf("if(mapContains(attributes_bool,'%[1]s'),toString(attributes_bool['%[1]s']),'')", n), nil
+		default:
+			return fmt.Sprintf(
+				"multiIf(mapContains(attributes_string,'%[1]s'),attributes_string['%[1]s'],"+
+					"mapContains(attributes_number,'%[1]s'),toString(attributes_number['%[1]s']),"+
+					"mapContains(attributes_bool,'%[1]s'),toString(attributes_bool['%[1]s']),'')",
+				n), nil
+		}
+	}
+	return "", errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported field context: %v", fieldKey.FieldContext)
 }

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"regexp"
 	"time"
 
 	sqlbuilder "github.com/huandu/go-sqlbuilder"
@@ -17,8 +16,14 @@ import (
 
 const colServiceName = `resource_string_service$$$$name` // $ gets escaped so $$$$ converts to $$.
 
-// validFieldName only allows characters safe to embed as ClickHouse map subscript literals.
-var validFieldName = regexp.MustCompile(`^[a-zA-Z0-9._\-]+$`)
+func buildFieldExpr(fieldKey telemetrytypes.TelemetryFieldKey) (string, error) {
+	switch fieldKey.FieldContext {
+	case telemetrytypes.FieldContextResource:
+		// String cast required — Variant/Dynamic is rejected by GROUP BY.
+		return fmt.Sprintf("resource.`%s`::String", fieldKey.Name), nil
+	}
+	return "", errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported field context: %v", fieldKey.FieldContext)
+}
 
 type spanCountRow struct {
 	FieldValue string `ch:"field_value"`
@@ -182,9 +187,9 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 	if err != nil {
 		return nil, err
 	}
-	// 3-level query: deduplicate → window function → sum non-overlapping per field.
+	// query: deduplicate → window function for adding non-overlapping duration per field.
 	// The window tracks the running max end time of preceding spans within each field_value
-	// partition (ordered by start). Each span contributes only its non-overlapping end
+	// partition (ordered by start).
 	query := fmt.Sprintf(`
 		SELECT field_value, sum(multiIf(
 			start_ns >= prev_max_end_ns,                    duration_nano,
@@ -224,31 +229,4 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 		result[r.FieldValue] = r.TotalNs
 	}
 	return result, nil
-}
-
-func buildFieldExpr(fieldKey telemetrytypes.TelemetryFieldKey) (string, error) {
-	if !validFieldName.MatchString(fieldKey.Name) {
-		return "", errors.NewInvalidInputf(errors.CodeInvalidInput, "invalid field name: %q", fieldKey.Name)
-	}
-	n := fieldKey.Name
-	switch fieldKey.FieldContext {
-	case telemetrytypes.FieldContextResource:
-		return fmt.Sprintf("resource.`%s`::String", n), nil
-	case telemetrytypes.FieldContextAttribute:
-		switch fieldKey.FieldDataType {
-		case telemetrytypes.FieldDataTypeString:
-			return fmt.Sprintf("attributes_string['%s']", n), nil
-		case telemetrytypes.FieldDataTypeFloat64, telemetrytypes.FieldDataTypeInt64, telemetrytypes.FieldDataTypeNumber:
-			return fmt.Sprintf("if(mapContains(attributes_number,'%[1]s'),toString(attributes_number['%[1]s']),'')", n), nil
-		case telemetrytypes.FieldDataTypeBool:
-			return fmt.Sprintf("if(mapContains(attributes_bool,'%[1]s'),toString(attributes_bool['%[1]s']),'')", n), nil
-		default:
-			return fmt.Sprintf(
-				"multiIf(mapContains(attributes_string,'%[1]s'),attributes_string['%[1]s'],"+
-					"mapContains(attributes_number,'%[1]s'),toString(attributes_number['%[1]s']),"+
-					"mapContains(attributes_bool,'%[1]s'),toString(attributes_bool['%[1]s']),'')",
-				n), nil
-		}
-	}
-	return "", errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported field context: %v", fieldKey.FieldContext)
 }

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -196,7 +196,7 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 			SELECT DISTINCT ON (span_id)
 				%s AS field_value,
 				toUnixTimestamp64Nano(timestamp) AS start_ns,
-				duration_nano
+				start_ns + duration_nano AS end_ns
 			FROM %s.%s
 			WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=?
 			HAVING field_value != ''
@@ -206,8 +206,8 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 		-- calculate max end time of preceding spans
 		max_end_time AS (
 			SELECT
-				field_value, start_ns, duration_nano,
-				ifNull(max(start_ns + duration_nano) OVER (
+				field_value, start_ns, end_ns,
+				ifNull(max(end_ns) OVER (
 					PARTITION BY field_value
 					ORDER BY start_ns
 					ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
@@ -215,10 +215,8 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 			FROM field_duration
 		)
 
-		-- calculate non-overlapping sum: add duration that is extending over last span
-		SELECT field_value, sum(greatest(
-			start_ns + duration_nano - greatest(start_ns, prev_max_end_ns), 0
-		)) AS total_ns
+		-- add only duration that is extending over previous spans
+		SELECT field_value, sum(greatest(end_ns - greatest(start_ns, prev_max_end_ns), 0)) AS total_ns
 		FROM max_end_time
 		GROUP BY field_value`,
 		fieldExpr, spantypes.TraceDB, spantypes.TraceTable,

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"regexp"
 	"time"
 
 	sqlbuilder "github.com/huandu/go-sqlbuilder"
@@ -15,6 +16,28 @@ import (
 )
 
 const colServiceName = `resource_string_service$$$$name` // $ gets escaped so $$$$ converts to $$.
+
+// validFieldName only allows characters safe to embed as ClickHouse map subscript literals.
+var validFieldName = regexp.MustCompile(`^[a-zA-Z0-9._\-]+$`)
+
+// buildFieldExpr returns a ClickHouse SQL expression for the value of fieldKey per span.
+func buildFieldExpr(fieldKey telemetrytypes.TelemetryFieldKey) (string, error) {
+	if !validFieldName.MatchString(fieldKey.Name) {
+		return "", errors.NewInvalidInputf(errors.CodeInvalidInput, "invalid field name: %q", fieldKey.Name)
+	}
+	n := fieldKey.Name
+	switch fieldKey.FieldContext {
+	case telemetrytypes.FieldContextResource:
+		return fmt.Sprintf("resources_string['%s']", n), nil
+	case telemetrytypes.FieldContextAttribute:
+		return fmt.Sprintf(
+			"multiIf(mapContains(attributes_string,'%[1]s'),attributes_string['%[1]s'],"+
+				"mapContains(attributes_number,'%[1]s'),toString(attributes_number['%[1]s']),"+
+				"mapContains(attributes_bool,'%[1]s'),toString(attributes_bool['%[1]s']),'')",
+			n), nil
+	}
+	return "", errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported field context: %v", fieldKey.FieldContext)
+}
 
 type traceStore struct {
 	telemetryStore telemetrystore.TelemetryStore
@@ -141,4 +164,97 @@ func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, sta
 		return nil, errors.WrapInternalf(err, errors.CodeInternal, "error querying trace spans by IDs")
 	}
 	return spans, nil
+}
+
+type spanCountRow struct {
+	FieldValue string `ch:"field_value"`
+	Count      uint64 `ch:"count"`
+}
+
+func (s *traceStore) GetSpanCountByField(ctx context.Context, traceID string, summary *spantypes.TraceSummary, fieldKey telemetrytypes.TelemetryFieldKey) (map[string]uint64, error) {
+	fieldExpr, err := buildFieldExpr(fieldKey)
+	if err != nil {
+		return nil, err
+	}
+	query := fmt.Sprintf(`
+		SELECT %[1]s AS field_value, count() AS count
+		FROM %[2]s.%[3]s
+		WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=?
+		  AND %[1]s != ''
+		GROUP BY field_value`,
+		fieldExpr, spantypes.TraceDB, spantypes.TraceTable,
+	)
+	var rows []spanCountRow
+	if err := s.telemetryStore.ClickhouseDB().Select(ctx, &rows, query,
+		traceID, summary.Start.Unix()-1800, summary.End.Unix(),
+	); err != nil {
+		return nil, errors.WrapInternalf(err, errors.CodeInternal, "error querying span count by field")
+	}
+	result := make(map[string]uint64, len(rows))
+	for _, r := range rows {
+		result[r.FieldValue] = r.Count
+	}
+	return result, nil
+}
+
+type spanDurationRow struct {
+	FieldValue string `ch:"field_value"`
+	TotalNs    uint64 `ch:"total_ns"`
+}
+
+func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string, summary *spantypes.TraceSummary, fieldKey telemetrytypes.TelemetryFieldKey) (map[string]uint64, error) {
+	fieldExpr, err := buildFieldExpr(fieldKey)
+	if err != nil {
+		return nil, err
+	}
+	// 4-level query: deduplicate → window function → non-overlapping per span → sum per field.
+	// The window function computes the running max end time of preceding spans in the same
+	// field partition (ordered by start), so each span only contributes its non-overlapping
+	// tail — matching the Go-side mergeSpanIntervals semantics in V3.
+	query := fmt.Sprintf(`
+		SELECT field_value, sum(non_overlapping_ns) AS total_ns
+		FROM (
+			SELECT
+				field_value,
+				multiIf(
+					start_ns >= prev_max_end_ns,                          duration_nano,
+					start_ns + duration_nano > prev_max_end_ns,           start_ns + duration_nano - prev_max_end_ns,
+					0
+				) AS non_overlapping_ns
+			FROM (
+				SELECT
+					field_value,
+					start_ns,
+					duration_nano,
+					ifNull(max(start_ns + duration_nano) OVER (
+						PARTITION BY field_value
+						ORDER BY start_ns
+						ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+					), 0) AS prev_max_end_ns
+				FROM (
+					SELECT DISTINCT ON (span_id)
+						%[1]s AS field_value,
+						toUnixTimestamp64Nano(timestamp) AS start_ns,
+						duration_nano
+					FROM %[2]s.%[3]s
+					WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=?
+					ORDER BY toUnixTimestamp64Nano(timestamp) ASC, name ASC
+				)
+				WHERE field_value != ''
+			)
+		)
+		GROUP BY field_value`,
+		fieldExpr, spantypes.TraceDB, spantypes.TraceTable,
+	)
+	var rows []spanDurationRow
+	if err := s.telemetryStore.ClickhouseDB().Select(ctx, &rows, query,
+		traceID, summary.Start.Unix()-1800, summary.End.Unix(),
+	); err != nil {
+		return nil, errors.WrapInternalf(err, errors.CodeInternal, "error querying span duration by field")
+	}
+	result := make(map[string]uint64, len(rows))
+	for _, r := range rows {
+		result[r.FieldValue] = r.TotalNs
+	}
+	return result, nil
 }

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -189,8 +189,10 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 	}
 
 	query := fmt.Sprintf(`
-		-- query field with start time and duration
-		WITH field_duration AS (
+		WITH
+
+		-- query minimum span fields
+		field_duration AS (
 			SELECT DISTINCT ON (span_id)
 				%s AS field_value,
 				toUnixTimestamp64Nano(timestamp) AS start_ns,
@@ -199,15 +201,10 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 			WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=?
 			HAVING field_value != ''
 			ORDER BY timestamp ASC, name ASC
-		)
+		),
 
-		-- running window of non-overlapping duration
-		SELECT field_value, sum(multiIf(
-			start_ns >= prev_max_end_ns,                    duration_nano,
-			start_ns + duration_nano > prev_max_end_ns,     start_ns + duration_nano - prev_max_end_ns,
-			0
-		)) AS total_ns
-		FROM (
+		-- calculate max end time of preceding spans
+		max_end_time AS (
 			SELECT
 				field_value, start_ns, duration_nano,
 				ifNull(max(start_ns + duration_nano) OVER (
@@ -217,6 +214,12 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 				), 0) AS prev_max_end_ns
 			FROM field_duration
 		)
+
+		-- calculate non-overlapping sum: add duration that is extending over last span
+		SELECT field_value, sum(greatest(
+			start_ns + duration_nano - greatest(start_ns, prev_max_end_ns), 0
+		)) AS total_ns
+		FROM max_end_time
 		GROUP BY field_value`,
 		fieldExpr, spantypes.TraceDB, spantypes.TraceTable,
 	)

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -210,12 +210,12 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 					PARTITION BY field_value
 					ORDER BY start_ns
 					ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
-				), 0) AS prev_max_end_ns
+				), toUInt64(0)) AS prev_max_end_ns
 			FROM field_duration
 		)
 
 		-- add only duration that is extending over previous spans
-		SELECT field_value, sum(greatest(end_ns - greatest(start_ns, prev_max_end_ns), 0)) AS total_ns
+		SELECT field_value, sum(toUInt64(greatest(end_ns - greatest(start_ns, prev_max_end_ns), 0))) AS total_ns
 		FROM max_end_time
 		GROUP BY field_value`,
 		fieldExpr, spantypes.TraceDB, spantypes.TraceTable,

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -209,17 +209,7 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 	effectiveStartSB := sqlbuilder.NewSelectBuilder()
 	effectiveStartSB.Select(
 		"field_value", "end_ns",
-		`greatest(
-			start_ns,
-			ifNull(
-				max(end_ns) OVER (
-					PARTITION BY field_value
-					ORDER BY start_ns
-					ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
-				),
-				toUInt64(0)
-			)
-		) AS effective_start_ns`,
+		"greatest(start_ns, ifNull(max(end_ns) OVER (PARTITION BY field_value ORDER BY start_ns ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING), toUInt64(0))) AS effective_start_ns",
 	)
 	effectiveStartSB.From("all_spans")
 

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -166,7 +166,7 @@ func (s *traceStore) GetSpanCountByField(ctx context.Context, traceID string, su
 		sb.E("trace_id", traceID),
 		sb.GE("ts_bucket_start", summary.Start.Unix()-1800),
 		sb.LE("ts_bucket_start", summary.End.Unix()),
-		fieldExpr+" != ''",
+		"notEmpty("+fieldExpr+")",
 	)
 	sb.GroupBy("field_value")
 	query, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
@@ -198,8 +198,7 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 				toUnixTimestamp64Nano(timestamp) AS start_ns,
 				start_ns + duration_nano AS end_ns
 			FROM %s.%s
-			WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=?
-			HAVING field_value != ''
+			WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=? AND notEmpty(field_value)
 			ORDER BY timestamp ASC, name ASC
 		),
 

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -188,42 +188,55 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 		return nil, err
 	}
 
-	query := fmt.Sprintf(`
-		WITH
+	// CTE 1: all span with start and end timestamps.
+	allSpansSB := sqlbuilder.NewSelectBuilder()
+	allSpansSB.Select(
+		"DISTINCT ON (span_id) "+fieldExpr+" AS field_value",
+		"toUnixTimestamp64Nano(timestamp) AS start_ns",
+		"start_ns + duration_nano AS end_ns",
+	)
+	allSpansSB.From(fmt.Sprintf("%s.%s", spantypes.TraceDB, spantypes.TraceTable))
+	allSpansSB.Where(
+		allSpansSB.E("trace_id", traceID),
+		allSpansSB.GE("ts_bucket_start", summary.Start.Unix()-1800),
+		allSpansSB.LE("ts_bucket_start", summary.End.Unix()),
+		"notEmpty(field_value)",
+	)
+	allSpansSB.OrderByAsc("timestamp")
+	allSpansSB.OrderByAsc("name")
 
-		-- query minimum span fields
-		field_duration AS (
-			SELECT DISTINCT ON (span_id)
-				%s AS field_value,
-				toUnixTimestamp64Nano(timestamp) AS start_ns,
-				start_ns + duration_nano AS end_ns
-			FROM %s.%s
-			WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=? AND notEmpty(field_value)
-			ORDER BY timestamp ASC, name ASC
-		),
-
-		-- calculate max end time of preceding spans
-		max_end_time AS (
-			SELECT
-				field_value, start_ns, end_ns,
-				ifNull(max(end_ns) OVER (
+	// CTE 2: find max end time of all preceding spans.
+	effectiveStartSB := sqlbuilder.NewSelectBuilder()
+	effectiveStartSB.Select(
+		"field_value", "end_ns",
+		`greatest(
+			start_ns,
+			ifNull(
+				max(end_ns) OVER (
 					PARTITION BY field_value
 					ORDER BY start_ns
 					ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
-				), toUInt64(0)) AS prev_max_end_ns
-			FROM field_duration
-		)
-
-		-- add only duration that is extending over previous spans
-		SELECT field_value, sum(toUInt64(greatest(end_ns - greatest(start_ns, prev_max_end_ns), 0))) AS total_ns
-		FROM max_end_time
-		GROUP BY field_value`,
-		fieldExpr, spantypes.TraceDB, spantypes.TraceTable,
+				),
+				toUInt64(0)
+			)
+		) AS effective_start_ns`,
 	)
+	effectiveStartSB.From("all_spans")
+
+	// Final SELECT: each span contributes only the tail past its effective start.
+	sb := sqlbuilder.With(
+		sqlbuilder.CTEQuery("all_spans").As(allSpansSB),
+		sqlbuilder.CTEQuery("effective_start").As(effectiveStartSB),
+	).Select(
+		"field_value",
+		"sum(toUInt64(greatest(end_ns - effective_start_ns, 0))) AS total_ns",
+	)
+	sb.From("effective_start")
+	sb.GroupBy("field_value")
+
+	query, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
 	var rows []spanDurationRow
-	if err := s.telemetryStore.ClickhouseDB().Select(ctx, &rows, query,
-		traceID, summary.Start.Unix()-1800, summary.End.Unix(),
-	); err != nil {
+	if err := s.telemetryStore.ClickhouseDB().Select(ctx, &rows, query, args...); err != nil {
 		return nil, errors.WrapInternalf(err, errors.CodeInternal, "error querying span duration by field")
 	}
 	result := make(map[string]uint64, len(rows))

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/types/spantypes"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 )
 
 const colServiceName = `resource_string_service$$$$name` // $ gets escaped so $$$$ converts to $$.
@@ -95,6 +96,14 @@ func (s *traceStore) GetMinimalSpans(ctx context.Context, traceID string, start,
 		return nil, errors.WrapInternalf(err, errors.CodeInternal, "error querying minimal spans")
 	}
 	return spans, nil
+}
+
+func (s *traceStore) GetSpanCountByField(ctx context.Context, traceID string, summary *spantypes.TraceSummary, fieldKey telemetrytypes.TelemetryFieldKey) (map[string]uint64, error) {
+	return nil, nil
+}
+
+func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string, summary *spantypes.TraceSummary, fieldKey telemetrytypes.TelemetryFieldKey) (map[string]uint64, error) {
+	return nil, nil
 }
 
 func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, start, end time.Time, spanIDs []string) ([]spantypes.StorableSpan, error) {

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -187,10 +187,21 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 	if err != nil {
 		return nil, err
 	}
-	// query: deduplicate → window function for adding non-overlapping duration per field.
-	// The window tracks the running max end time of preceding spans within each field_value
-	// partition (ordered by start).
+
 	query := fmt.Sprintf(`
+		-- query field with start time and duration
+		WITH field_duration AS (
+			SELECT DISTINCT ON (span_id)
+				%s AS field_value,
+				toUnixTimestamp64Nano(timestamp) AS start_ns,
+				duration_nano
+			FROM %s.%s
+			WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=?
+			HAVING field_value != ''
+			ORDER BY timestamp ASC, name ASC
+		)
+
+		-- running window of non-overlapping duration
 		SELECT field_value, sum(multiIf(
 			start_ns >= prev_max_end_ns,                    duration_nano,
 			start_ns + duration_nano > prev_max_end_ns,     start_ns + duration_nano - prev_max_end_ns,
@@ -204,16 +215,7 @@ func (s *traceStore) GetSpanDurationByField(ctx context.Context, traceID string,
 					ORDER BY start_ns
 					ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
 				), 0) AS prev_max_end_ns
-			FROM (
-				SELECT DISTINCT ON (span_id)
-					%[1]s AS field_value,
-					toUnixTimestamp64Nano(timestamp) AS start_ns,
-					duration_nano
-				FROM %[2]s.%[3]s
-				WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=?
-				ORDER BY toUnixTimestamp64Nano(timestamp) ASC, name ASC
-			)
-			WHERE field_value != ''
+			FROM field_duration
 		)
 		GROUP BY field_value`,
 		fieldExpr, spantypes.TraceDB, spantypes.TraceTable,

--- a/pkg/modules/tracedetail/impltracedetail/store_test.go
+++ b/pkg/modules/tracedetail/impltracedetail/store_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	cmock "github.com/srikanthccv/ClickHouse-go-mock"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -44,149 +43,49 @@ func newTestStore(matcher sqlmock.QueryMatcher) *spantypestest.TraceStoreTest {
 }
 
 func TestGetTraceSummary(t *testing.T) {
-	expectedSQL := `
-		SELECT trace_id, min(start) AS start, max(end) AS end, sum(num_spans) AS num_spans
-		FROM signoz_traces.distributed_trace_summary WHERE trace_id = ?
-		GROUP BY trace_id`
+	expectedSQL := `SELECT trace_id, min(start) AS start, max(end) AS end, sum(num_spans) AS num_spans FROM signoz_traces.distributed_trace_summary WHERE trace_id = ? GROUP BY trace_id`
 
-	summaryCols := []cmock.ColumnType{
-		{Name: "trace_id", Type: "String"},
-		{Name: "start", Type: "DateTime64(9)"},
-		{Name: "end", Type: "DateTime64(9)"},
-		{Name: "num_spans", Type: "UInt64"},
-	}
-
-	tests := []struct {
-		name      string
-		setupMock func(cmock.ClickConnMockCommon)
-		wantErr   error
-	}{
-		{
-			name: "ValidTraceID_ReturnsSummary",
-			setupMock: func(m cmock.ClickConnMockCommon) {
-				m.ExpectQueryRow(regexp.QuoteMeta(expectedSQL)).
-					WillReturnRow(cmock.NewRow(summaryCols, []any{
-						testTraceID, testStart, testEnd, uint64(5),
-					}))
-			},
-		},
-		{
-			name: "NoRows_ReturnsErrTraceNotFound",
-			setupMock: func(m cmock.ClickConnMockCommon) {
-				m.ExpectQueryRow(regexp.QuoteMeta(expectedSQL)).
-					WillReturnRow(cmock.NewRow(summaryCols, nil))
-			},
-			wantErr: spantypes.ErrTraceNotFound,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			s := newTestStore(sqlmock.QueryMatcherRegexp)
-			tc.setupMock(s.Mock())
-
-			_, err := s.Store().GetTraceSummary(context.Background(), testTraceID)
-			if tc.wantErr != nil {
-				require.ErrorIs(t, err, tc.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			assert.NoError(t, s.Mock().ExpectationsWereMet())
-		})
-	}
+	t.Run("ValidTraceID_GeneratesExpectedSQL", func(t *testing.T) {
+		s := newTestStore(sqlmock.QueryMatcherRegexp)
+		s.Mock().ExpectQueryRow(regexp.QuoteMeta(expectedSQL)).
+			WillReturnRow(cmock.NewRow(nil, nil))
+		_, _ = s.Store().GetTraceSummary(context.Background(), testTraceID)
+		assert.NoError(t, s.Mock().ExpectationsWereMet())
+	})
 }
 
 func TestGetMinimalSpans(t *testing.T) {
 	expectedSQL := `SELECT DISTINCT ON (span_id) span_id, parent_span_id, timestamp, duration_nano, has_error, resource_string_service$$name FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? ORDER BY timestamp ASC, name ASC`
 
-	spanCols := []cmock.ColumnType{
-		{Name: "span_id", Type: "String"},
-		{Name: "parent_span_id", Type: "String"},
-		{Name: "timestamp", Type: "DateTime64(9)"},
-		{Name: "duration_nano", Type: "UInt64"},
-		{Name: "has_error", Type: "Bool"},
-		{Name: "resource_string_service$$name", Type: "String"},
-	}
-
-	tests := []struct {
-		name      string
-		setupMock func(cmock.ClickConnMockCommon)
-		wantLen   int
-	}{
-		{
-			name: "ValidRange_ReturnSpans",
-			setupMock: func(m cmock.ClickConnMockCommon) {
-				m.ExpectSelect(regexp.QuoteMeta(expectedSQL)).
-					WillReturnRows(cmock.NewRows(spanCols, [][]any{
-						{"span-1", "", testStart, uint64(1000), false, "svc-a"},
-						{"span-2", "span-1", testStart, uint64(2000), true, "svc-b"},
-					}))
-			},
-			wantLen: 2,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			s := newTestStore(sqlmock.QueryMatcherRegexp)
-			tc.setupMock(s.Mock())
-
-			got, err := s.Store().GetMinimalSpans(context.Background(), testTraceID, testStart, testEnd)
-			require.NoError(t, err)
-			assert.Len(t, got, tc.wantLen)
-			assert.NoError(t, s.Mock().ExpectationsWereMet())
-		})
-	}
+	t.Run("ValidRange_GeneratesExpectedSQL", func(t *testing.T) {
+		s := newTestStore(sqlmock.QueryMatcherRegexp)
+		s.Mock().ExpectSelect(regexp.QuoteMeta(expectedSQL)).
+			WillReturnRows(cmock.NewRows(nil, nil))
+		_, _ = s.Store().GetMinimalSpans(context.Background(), testTraceID, testStart, testEnd)
+		assert.NoError(t, s.Mock().ExpectationsWereMet())
+	})
 }
 
 func TestGetSpanCountByField(t *testing.T) {
 	expectedSQL := "SELECT resource.`service.name`::String AS field_value, count(DISTINCT span_id) AS count FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? AND notEmpty(resource.`service.name`::String) GROUP BY field_value"
 
-	countCols := []cmock.ColumnType{
-		{Name: "field_value", Type: "String"},
-		{Name: "count", Type: "UInt64"},
-	}
-
 	tests := []struct {
 		name      string
 		field     telemetrytypes.TelemetryFieldKey
-		setupMock func(cmock.ClickConnMockCommon)
-		want      map[string]uint64
-		wantErr   bool
+		wantQuery bool
 	}{
-		{
-			name:  "ResourceField_ReturnsCountMap",
-			field: svcNameField,
-			setupMock: func(m cmock.ClickConnMockCommon) {
-				m.ExpectSelect(regexp.QuoteMeta(expectedSQL)).
-					WillReturnRows(cmock.NewRows(countCols, [][]any{
-						{"svc-a", uint64(10)},
-						{"svc-b", uint64(5)},
-					}))
-			},
-			want: map[string]uint64{"svc-a": 10, "svc-b": 5},
-		},
-		{
-			name:    "NonResourceField_ReturnsInvalidInputError",
-			field:   unsupportedField,
-			wantErr: true,
-		},
+		{name: "ResourceField_GeneratesExpectedSQL", field: svcNameField, wantQuery: true},
+		{name: "NonResourceField_NoSQLGenerated", field: unsupportedField},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newTestStore(sqlmock.QueryMatcherRegexp)
-			if tc.setupMock != nil {
-				tc.setupMock(s.Mock())
+			if tc.wantQuery {
+				s.Mock().ExpectSelect(regexp.QuoteMeta(expectedSQL)).
+					WillReturnRows(cmock.NewRows(nil, nil))
 			}
-
-			got, err := s.Store().GetSpanCountByField(context.Background(), testTraceID, testSummary, tc.field)
-			if tc.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tc.want, got)
+			_, _ = s.Store().GetSpanCountByField(context.Background(), testTraceID, testSummary, tc.field)
 			assert.NoError(t, s.Mock().ExpectationsWereMet())
 		})
 	}
@@ -205,51 +104,23 @@ func TestGetSpanDurationByField(t *testing.T) {
 			)
 		) AS effective_start_ns FROM all_spans) SELECT field_value, sum(toUInt64(greatest(end_ns - effective_start_ns, 0))) AS total_ns FROM effective_start GROUP BY field_value`
 
-	durationCols := []cmock.ColumnType{
-		{Name: "field_value", Type: "String"},
-		{Name: "total_ns", Type: "UInt64"},
-	}
-
 	tests := []struct {
 		name      string
 		field     telemetrytypes.TelemetryFieldKey
-		setupMock func(cmock.ClickConnMockCommon)
-		want      map[string]uint64
-		wantErr   bool
+		wantQuery bool
 	}{
-		{
-			name:  "ResourceField_ReturnsDurationMap",
-			field: svcNameField,
-			setupMock: func(m cmock.ClickConnMockCommon) {
-				m.ExpectSelect(regexp.QuoteMeta(expectedSQL)).
-					WillReturnRows(cmock.NewRows(durationCols, [][]any{
-						{"svc-a", uint64(900_000_000)},
-						{"svc-b", uint64(100_000_000)},
-					}))
-			},
-			want: map[string]uint64{"svc-a": 900_000_000, "svc-b": 100_000_000},
-		},
-		{
-			name:    "NonResourceField_ReturnsInvalidInputError",
-			field:   unsupportedField,
-			wantErr: true,
-		},
+		{name: "ResourceField_GeneratesExpectedSQL", field: svcNameField, wantQuery: true},
+		{name: "NonResourceField_NoSQLGenerated", field: unsupportedField},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newTestStore(sqlmock.QueryMatcherRegexp)
-			if tc.setupMock != nil {
-				tc.setupMock(s.Mock())
+			if tc.wantQuery {
+				s.Mock().ExpectSelect(regexp.QuoteMeta(expectedSQL)).
+					WillReturnRows(cmock.NewRows(nil, nil))
 			}
-
-			got, err := s.Store().GetSpanDurationByField(context.Background(), testTraceID, testSummary, tc.field)
-			if tc.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tc.want, got)
+			_, _ = s.Store().GetSpanDurationByField(context.Background(), testTraceID, testSummary, tc.field)
 			assert.NoError(t, s.Mock().ExpectationsWereMet())
 		})
 	}

--- a/pkg/modules/tracedetail/impltracedetail/store_test.go
+++ b/pkg/modules/tracedetail/impltracedetail/store_test.go
@@ -43,7 +43,10 @@ func newTestStore(matcher sqlmock.QueryMatcher) *spantypestest.TraceStoreTest {
 }
 
 func TestGetTraceSummary(t *testing.T) {
-	expectedSQL := `SELECT trace_id, min(start) AS start, max(end) AS end, sum(num_spans) AS num_spans FROM signoz_traces.distributed_trace_summary WHERE trace_id = ? GROUP BY trace_id`
+	expectedSQL := `
+		SELECT trace_id, min(start) AS start, max(end) AS end, sum(num_spans) AS num_spans
+		FROM signoz_traces.distributed_trace_summary
+		WHERE trace_id = ? GROUP BY trace_id`
 
 	t.Run("ValidTraceID_GeneratesExpectedSQL", func(t *testing.T) {
 		s := newTestStore(sqlmock.QueryMatcherRegexp)
@@ -55,7 +58,12 @@ func TestGetTraceSummary(t *testing.T) {
 }
 
 func TestGetMinimalSpans(t *testing.T) {
-	expectedSQL := `SELECT DISTINCT ON (span_id) span_id, parent_span_id, timestamp, duration_nano, has_error, resource_string_service$$name FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? ORDER BY timestamp ASC, name ASC`
+	expectedSQL := `
+		SELECT DISTINCT ON (span_id) span_id, parent_span_id, timestamp, duration_nano,
+			has_error, resource_string_service$$name
+		FROM signoz_traces.distributed_signoz_index_v3
+		WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ?
+		ORDER BY timestamp ASC, name ASC`
 
 	t.Run("ValidRange_GeneratesExpectedSQL", func(t *testing.T) {
 		s := newTestStore(sqlmock.QueryMatcherRegexp)
@@ -92,17 +100,25 @@ func TestGetSpanCountByField(t *testing.T) {
 }
 
 func TestGetSpanDurationByField(t *testing.T) {
-	expectedSQL := "WITH all_spans AS (SELECT DISTINCT ON (span_id) resource.`service.name`::String AS field_value, toUnixTimestamp64Nano(timestamp) AS start_ns, start_ns + duration_nano AS end_ns FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? AND notEmpty(field_value) ORDER BY timestamp ASC, name ASC), effective_start AS (SELECT field_value, end_ns, greatest(" + `
-			start_ns,
-			ifNull(
-				max(end_ns) OVER (
-					PARTITION BY field_value
-					ORDER BY start_ns
-					ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
-				),
-				toUInt64(0)
+	expectedSQL := "WITH all_spans AS (SELECT DISTINCT ON (span_id) resource.`service.name`::String AS field_value, toUnixTimestamp64Nano(timestamp) AS start_ns, start_ns + duration_nano AS end_ns" + `
+			FROM signoz_traces.distributed_signoz_index_v3
+			WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? AND notEmpty(field_value)
+			ORDER BY timestamp ASC, name ASC),
+
+			effective_start AS (
+				SELECT field_value, end_ns, greatest(start_ns, ifNull(
+					max(end_ns) OVER (
+						PARTITION BY field_value
+						ORDER BY start_ns
+						ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+					),
+					toUInt64(0)
+				)) AS effective_start_ns FROM all_spans
 			)
-		) AS effective_start_ns FROM all_spans) SELECT field_value, sum(toUInt64(greatest(end_ns - effective_start_ns, 0))) AS total_ns FROM effective_start GROUP BY field_value`
+
+			SELECT field_value, sum(toUInt64(greatest(end_ns - effective_start_ns, 0))) AS total_ns
+			FROM effective_start
+			GROUP BY field_value`
 
 	tests := []struct {
 		name      string

--- a/pkg/modules/tracedetail/impltracedetail/store_test.go
+++ b/pkg/modules/tracedetail/impltracedetail/store_test.go
@@ -101,24 +101,25 @@ func TestGetSpanCountByField(t *testing.T) {
 
 func TestGetSpanDurationByField(t *testing.T) {
 	expectedSQL := "WITH all_spans AS (SELECT DISTINCT ON (span_id) resource.`service.name`::String AS field_value, toUnixTimestamp64Nano(timestamp) AS start_ns, start_ns + duration_nano AS end_ns" + `
-			FROM signoz_traces.distributed_signoz_index_v3
-			WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? AND notEmpty(field_value)
-			ORDER BY timestamp ASC, name ASC),
+		FROM signoz_traces.distributed_signoz_index_v3
+		WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? AND notEmpty(field_value)
+		ORDER BY timestamp ASC, name ASC),
 
-			effective_start AS (
-				SELECT field_value, end_ns, greatest(start_ns, ifNull(
-					max(end_ns) OVER (
-						PARTITION BY field_value
-						ORDER BY start_ns
-						ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
-					),
-					toUInt64(0)
-				)) AS effective_start_ns FROM all_spans
+		effective_start AS (SELECT field_value, end_ns, greatest(
+			start_ns,
+			ifNull(
+				max(end_ns) OVER (
+					PARTITION BY field_value
+					ORDER BY start_ns
+					ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+				),
+				toUInt64(0)
 			)
+		) AS effective_start_ns FROM all_spans)
 
-			SELECT field_value, sum(toUInt64(greatest(end_ns - effective_start_ns, 0))) AS total_ns
-			FROM effective_start
-			GROUP BY field_value`
+		SELECT field_value, sum(toUInt64(greatest(end_ns - effective_start_ns, 0))) AS total_ns
+		FROM effective_start
+		GROUP BY field_value`
 
 	tests := []struct {
 		name      string

--- a/pkg/modules/tracedetail/impltracedetail/store_test.go
+++ b/pkg/modules/tracedetail/impltracedetail/store_test.go
@@ -93,7 +93,7 @@ func TestGetSpanCountByField(t *testing.T) {
 
 func TestGetSpanDurationByField(t *testing.T) {
 
-	expectedSQL := "WITH all_spans AS (SELECT DISTINCT ON (span_id) resource.`service.name`::String AS field_value, toUnixTimestamp64Nano(timestamp) AS start_ns, start_ns + duration_nano AS end_ns FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? AND notEmpty(field_value) ORDER BY timestamp ASC, name ASC)), effective_start AS (SELECT field_value, end_ns, greatest(start_ns, ifNull( max(end_ns) OVER (PARTITION BY field_value ORDER BY start_ns  ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING), toUInt64(0))) AS effective_start_ns FROM all_spans) SELECT field_value, sum(toUInt64(greatest(end_ns - effective_start_ns, 0))) AS total_ns FROM effective_start GROUP BY field_value"
+	expectedSQL := "WITH all_spans AS (SELECT DISTINCT ON (span_id) resource.`service.name`::String AS field_value, toUnixTimestamp64Nano(timestamp) AS start_ns, start_ns + duration_nano AS end_ns FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? AND notEmpty(field_value) ORDER BY timestamp ASC, name ASC), effective_start AS (SELECT field_value, end_ns, greatest(start_ns, ifNull(max(end_ns) OVER (PARTITION BY field_value ORDER BY start_ns ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING), toUInt64(0))) AS effective_start_ns FROM all_spans) SELECT field_value, sum(toUInt64(greatest(end_ns - effective_start_ns, 0))) AS total_ns FROM effective_start GROUP BY field_value"
 
 	tests := []struct {
 		name      string

--- a/pkg/modules/tracedetail/impltracedetail/store_test.go
+++ b/pkg/modules/tracedetail/impltracedetail/store_test.go
@@ -1,0 +1,256 @@
+package impltracedetail_test
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/SigNoz/signoz/pkg/modules/tracedetail/impltracedetail"
+	"github.com/SigNoz/signoz/pkg/telemetrystore"
+	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
+	"github.com/SigNoz/signoz/pkg/types/spantypes"
+	"github.com/SigNoz/signoz/pkg/types/spantypes/spantypestest"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
+	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testTraceID = "trace-abc123"
+	testStart   = time.Unix(1000, 0).UTC()
+	testEnd     = time.Unix(2000, 0).UTC()
+	testSummary = &spantypes.TraceSummary{
+		TraceID:  testTraceID,
+		Start:    testStart,
+		End:      testEnd,
+		NumSpans: 10,
+	}
+	svcNameField = telemetrytypes.TelemetryFieldKey{
+		Name:         "service.name",
+		FieldContext: telemetrytypes.FieldContextResource,
+	}
+	unsupportedField = telemetrytypes.TelemetryFieldKey{
+		Name:         "http.method",
+		FieldContext: telemetrytypes.FieldContextSpan,
+	}
+)
+
+func newTestStore(matcher sqlmock.QueryMatcher) *spantypestest.TraceStoreTest {
+	ts := telemetrystoretest.New(telemetrystore.Config{}, matcher)
+	return spantypestest.New(impltracedetail.NewTraceStore(ts), ts.Mock())
+}
+
+func TestGetTraceSummary(t *testing.T) {
+	expectedSQL := `
+		SELECT trace_id, min(start) AS start, max(end) AS end, sum(num_spans) AS num_spans
+		FROM signoz_traces.distributed_trace_summary WHERE trace_id = ?
+		GROUP BY trace_id`
+
+	summaryCols := []cmock.ColumnType{
+		{Name: "trace_id", Type: "String"},
+		{Name: "start", Type: "DateTime64(9)"},
+		{Name: "end", Type: "DateTime64(9)"},
+		{Name: "num_spans", Type: "UInt64"},
+	}
+
+	tests := []struct {
+		name      string
+		setupMock func(cmock.ClickConnMockCommon)
+		wantErr   error
+	}{
+		{
+			name: "ValidTraceID_ReturnsSummary",
+			setupMock: func(m cmock.ClickConnMockCommon) {
+				m.ExpectQueryRow(regexp.QuoteMeta(expectedSQL)).
+					WillReturnRow(cmock.NewRow(summaryCols, []any{
+						testTraceID, testStart, testEnd, uint64(5),
+					}))
+			},
+		},
+		{
+			name: "NoRows_ReturnsErrTraceNotFound",
+			setupMock: func(m cmock.ClickConnMockCommon) {
+				m.ExpectQueryRow(regexp.QuoteMeta(expectedSQL)).
+					WillReturnRow(cmock.NewRow(summaryCols, nil))
+			},
+			wantErr: spantypes.ErrTraceNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(sqlmock.QueryMatcherRegexp)
+			tc.setupMock(s.Mock())
+
+			_, err := s.Store().GetTraceSummary(context.Background(), testTraceID)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.NoError(t, s.Mock().ExpectationsWereMet())
+		})
+	}
+}
+
+func TestGetMinimalSpans(t *testing.T) {
+	expectedSQL := `SELECT DISTINCT ON (span_id) span_id, parent_span_id, timestamp, duration_nano, has_error, resource_string_service$$name FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? ORDER BY timestamp ASC, name ASC`
+
+	spanCols := []cmock.ColumnType{
+		{Name: "span_id", Type: "String"},
+		{Name: "parent_span_id", Type: "String"},
+		{Name: "timestamp", Type: "DateTime64(9)"},
+		{Name: "duration_nano", Type: "UInt64"},
+		{Name: "has_error", Type: "Bool"},
+		{Name: "resource_string_service$$name", Type: "String"},
+	}
+
+	tests := []struct {
+		name      string
+		setupMock func(cmock.ClickConnMockCommon)
+		wantLen   int
+	}{
+		{
+			name: "ValidRange_ReturnSpans",
+			setupMock: func(m cmock.ClickConnMockCommon) {
+				m.ExpectSelect(regexp.QuoteMeta(expectedSQL)).
+					WillReturnRows(cmock.NewRows(spanCols, [][]any{
+						{"span-1", "", testStart, uint64(1000), false, "svc-a"},
+						{"span-2", "span-1", testStart, uint64(2000), true, "svc-b"},
+					}))
+			},
+			wantLen: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(sqlmock.QueryMatcherRegexp)
+			tc.setupMock(s.Mock())
+
+			got, err := s.Store().GetMinimalSpans(context.Background(), testTraceID, testStart, testEnd)
+			require.NoError(t, err)
+			assert.Len(t, got, tc.wantLen)
+			assert.NoError(t, s.Mock().ExpectationsWereMet())
+		})
+	}
+}
+
+func TestGetSpanCountByField(t *testing.T) {
+	expectedSQL := "SELECT resource.`service.name`::String AS field_value, count(DISTINCT span_id) AS count FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? AND notEmpty(resource.`service.name`::String) GROUP BY field_value"
+
+	countCols := []cmock.ColumnType{
+		{Name: "field_value", Type: "String"},
+		{Name: "count", Type: "UInt64"},
+	}
+
+	tests := []struct {
+		name      string
+		field     telemetrytypes.TelemetryFieldKey
+		setupMock func(cmock.ClickConnMockCommon)
+		want      map[string]uint64
+		wantErr   bool
+	}{
+		{
+			name:  "ResourceField_ReturnsCountMap",
+			field: svcNameField,
+			setupMock: func(m cmock.ClickConnMockCommon) {
+				m.ExpectSelect(regexp.QuoteMeta(expectedSQL)).
+					WillReturnRows(cmock.NewRows(countCols, [][]any{
+						{"svc-a", uint64(10)},
+						{"svc-b", uint64(5)},
+					}))
+			},
+			want: map[string]uint64{"svc-a": 10, "svc-b": 5},
+		},
+		{
+			name:    "NonResourceField_ReturnsInvalidInputError",
+			field:   unsupportedField,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(sqlmock.QueryMatcherRegexp)
+			if tc.setupMock != nil {
+				tc.setupMock(s.Mock())
+			}
+
+			got, err := s.Store().GetSpanCountByField(context.Background(), testTraceID, testSummary, tc.field)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+			assert.NoError(t, s.Mock().ExpectationsWereMet())
+		})
+	}
+}
+
+func TestGetSpanDurationByField(t *testing.T) {
+	expectedSQL := "WITH all_spans AS (SELECT DISTINCT ON (span_id) resource.`service.name`::String AS field_value, toUnixTimestamp64Nano(timestamp) AS start_ns, start_ns + duration_nano AS end_ns FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? AND notEmpty(field_value) ORDER BY timestamp ASC, name ASC), effective_start AS (SELECT field_value, end_ns, greatest(" + `
+			start_ns,
+			ifNull(
+				max(end_ns) OVER (
+					PARTITION BY field_value
+					ORDER BY start_ns
+					ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+				),
+				toUInt64(0)
+			)
+		) AS effective_start_ns FROM all_spans) SELECT field_value, sum(toUInt64(greatest(end_ns - effective_start_ns, 0))) AS total_ns FROM effective_start GROUP BY field_value`
+
+	durationCols := []cmock.ColumnType{
+		{Name: "field_value", Type: "String"},
+		{Name: "total_ns", Type: "UInt64"},
+	}
+
+	tests := []struct {
+		name      string
+		field     telemetrytypes.TelemetryFieldKey
+		setupMock func(cmock.ClickConnMockCommon)
+		want      map[string]uint64
+		wantErr   bool
+	}{
+		{
+			name:  "ResourceField_ReturnsDurationMap",
+			field: svcNameField,
+			setupMock: func(m cmock.ClickConnMockCommon) {
+				m.ExpectSelect(regexp.QuoteMeta(expectedSQL)).
+					WillReturnRows(cmock.NewRows(durationCols, [][]any{
+						{"svc-a", uint64(900_000_000)},
+						{"svc-b", uint64(100_000_000)},
+					}))
+			},
+			want: map[string]uint64{"svc-a": 900_000_000, "svc-b": 100_000_000},
+		},
+		{
+			name:    "NonResourceField_ReturnsInvalidInputError",
+			field:   unsupportedField,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(sqlmock.QueryMatcherRegexp)
+			if tc.setupMock != nil {
+				tc.setupMock(s.Mock())
+			}
+
+			got, err := s.Store().GetSpanDurationByField(context.Background(), testTraceID, testSummary, tc.field)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+			assert.NoError(t, s.Mock().ExpectationsWereMet())
+		})
+	}
+}

--- a/pkg/modules/tracedetail/impltracedetail/store_test.go
+++ b/pkg/modules/tracedetail/impltracedetail/store_test.go
@@ -7,13 +7,13 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/SigNoz/signoz/pkg/modules/tracedetail/impltracedetail"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
 	"github.com/SigNoz/signoz/pkg/types/spantypes"
 	"github.com/SigNoz/signoz/pkg/types/spantypes/spantypestest"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
-	cmock "github.com/srikanthccv/ClickHouse-go-mock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,10 +43,7 @@ func newTestStore(matcher sqlmock.QueryMatcher) *spantypestest.TraceStoreTest {
 }
 
 func TestGetTraceSummary(t *testing.T) {
-	expectedSQL := `
-		SELECT trace_id, min(start) AS start, max(end) AS end, sum(num_spans) AS num_spans
-		FROM signoz_traces.distributed_trace_summary
-		WHERE trace_id = ? GROUP BY trace_id`
+	expectedSQL := "SELECT trace_id, min(start) AS start, max(end) AS end, sum(num_spans) AS num_spans FROM signoz_traces.distributed_trace_summary WHERE trace_id = ? GROUP BY trace_id"
 
 	t.Run("ValidTraceID_GeneratesExpectedSQL", func(t *testing.T) {
 		s := newTestStore(sqlmock.QueryMatcherRegexp)
@@ -58,12 +55,7 @@ func TestGetTraceSummary(t *testing.T) {
 }
 
 func TestGetMinimalSpans(t *testing.T) {
-	expectedSQL := `
-		SELECT DISTINCT ON (span_id) span_id, parent_span_id, timestamp, duration_nano,
-			has_error, resource_string_service$$name
-		FROM signoz_traces.distributed_signoz_index_v3
-		WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ?
-		ORDER BY timestamp ASC, name ASC`
+	expectedSQL := "SELECT DISTINCT ON (span_id) span_id, parent_span_id, timestamp, duration_nano, has_error, resource_string_service$$name FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? ORDER BY timestamp ASC, name ASC"
 
 	t.Run("ValidRange_GeneratesExpectedSQL", func(t *testing.T) {
 		s := newTestStore(sqlmock.QueryMatcherRegexp)
@@ -100,26 +92,8 @@ func TestGetSpanCountByField(t *testing.T) {
 }
 
 func TestGetSpanDurationByField(t *testing.T) {
-	expectedSQL := "WITH all_spans AS (SELECT DISTINCT ON (span_id) resource.`service.name`::String AS field_value, toUnixTimestamp64Nano(timestamp) AS start_ns, start_ns + duration_nano AS end_ns" + `
-		FROM signoz_traces.distributed_signoz_index_v3
-		WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? AND notEmpty(field_value)
-		ORDER BY timestamp ASC, name ASC),
 
-		effective_start AS (SELECT field_value, end_ns, greatest(
-			start_ns,
-			ifNull(
-				max(end_ns) OVER (
-					PARTITION BY field_value
-					ORDER BY start_ns
-					ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
-				),
-				toUInt64(0)
-			)
-		) AS effective_start_ns FROM all_spans)
-
-		SELECT field_value, sum(toUInt64(greatest(end_ns - effective_start_ns, 0))) AS total_ns
-		FROM effective_start
-		GROUP BY field_value`
+	expectedSQL := "WITH all_spans AS (SELECT DISTINCT ON (span_id) resource.`service.name`::String AS field_value, toUnixTimestamp64Nano(timestamp) AS start_ns, start_ns + duration_nano AS end_ns FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? AND notEmpty(field_value) ORDER BY timestamp ASC, name ASC)), effective_start AS (SELECT field_value, end_ns, greatest(start_ns, ifNull( max(end_ns) OVER (PARTITION BY field_value ORDER BY start_ns  ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING), toUInt64(0))) AS effective_start_ns FROM all_spans) SELECT field_value, sum(toUInt64(greatest(end_ns - effective_start_ns, 0))) AS total_ns FROM effective_start GROUP BY field_value"
 
 	tests := []struct {
 		name      string

--- a/pkg/modules/tracedetail/tracedetail.go
+++ b/pkg/modules/tracedetail/tracedetail.go
@@ -11,10 +11,12 @@ import (
 type Handler interface {
 	GetWaterfall(http.ResponseWriter, *http.Request)
 	GetWaterfallV4(http.ResponseWriter, *http.Request)
+	GetTraceAggregations(http.ResponseWriter, *http.Request)
 }
 
 // Module defines the business logic for trace detail operations.
 type Module interface {
 	GetWaterfall(ctx context.Context, traceID string, req *spantypes.PostableWaterfall) (*spantypes.GettableWaterfallTrace, error)
 	GetWaterfallV4(ctx context.Context, traceID string, selectedSpanID string, uncollapsedSpans []string, selectAllLimit uint) (*spantypes.GettableWaterfallTrace, error)
+	GetTraceAggregations(ctx context.Context, traceID string, req *spantypes.PostableTraceAggregations) (*spantypes.GettableTraceAggregations, error)
 }

--- a/pkg/types/spantypes/aggregation.go
+++ b/pkg/types/spantypes/aggregation.go
@@ -28,8 +28,8 @@ var (
 
 // SpanAggregation is a single aggregation request item: which field to group by and how.
 type SpanAggregation struct {
-	Field       telemetrytypes.TelemetryFieldKey `json:"field"`
-	Aggregation SpanAggregationType              `json:"aggregation"`
+	Field       telemetrytypes.TelemetryFieldKey `json:"field"       required:"true"`
+	Aggregation SpanAggregationType              `json:"aggregation" required:"true"`
 }
 
 // SpanAggregationResult is the computed result for one aggregation request item.
@@ -54,10 +54,13 @@ func (s SpanAggregationType) isValid() bool {
 
 // PostableTraceAggregations is the request body for the V4 aggregations endpoint.
 type PostableTraceAggregations struct {
-	Aggregations []SpanAggregation `json:"aggregations"`
+	Aggregations []SpanAggregation `json:"aggregations" required:"true"`
 }
 
 func (p *PostableTraceAggregations) Validate() error {
+	if len(p.Aggregations) == 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "aggregations is required and must not be empty")
+	}
 	if len(p.Aggregations) > maxAggregationItems {
 		return ErrTooManyAggregationItems
 	}

--- a/pkg/types/spantypes/aggregation.go
+++ b/pkg/types/spantypes/aggregation.go
@@ -48,3 +48,30 @@ func (SpanAggregationType) Enum() []any {
 func (s SpanAggregationType) isValid() bool {
 	return slices.ContainsFunc(s.Enum(), func(v any) bool { return v == s })
 }
+
+// PostableTraceAggregations is the request body for the V4 aggregations endpoint.
+type PostableTraceAggregations struct {
+	Aggregations []SpanAggregation `json:"aggregations"`
+}
+
+func (p *PostableTraceAggregations) Validate() error {
+	if len(p.Aggregations) > maxAggregationItems {
+		return ErrTooManyAggregationItems
+	}
+	for _, a := range p.Aggregations {
+		if !a.Aggregation.isValid() {
+			return errors.NewInvalidInputf(errors.CodeInvalidInput, "unknown aggregation type: %q", a.Aggregation)
+		}
+		fc := a.Field.FieldContext
+		if fc != telemetrytypes.FieldContextResource && fc != telemetrytypes.FieldContextAttribute {
+			return errors.NewInvalidInputf(errors.CodeInvalidInput, "aggregation field context must be %q or %q, got %q",
+				telemetrytypes.FieldContextResource, telemetrytypes.FieldContextAttribute, fc)
+		}
+	}
+	return nil
+}
+
+// GettableTraceAggregations is the response for the V4 aggregations endpoint.
+type GettableTraceAggregations struct {
+	Aggregations []SpanAggregationResult `json:"aggregations"`
+}

--- a/pkg/types/spantypes/aggregation.go
+++ b/pkg/types/spantypes/aggregation.go
@@ -1,12 +1,15 @@
 package spantypes
 
 import (
+	"regexp"
 	"slices"
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
+
+var validAggregationFieldName = regexp.MustCompile(`^[a-zA-Z0-9._\-]+$`)
 
 const maxAggregationItems = 10
 
@@ -62,10 +65,12 @@ func (p *PostableTraceAggregations) Validate() error {
 		if !a.Aggregation.isValid() {
 			return errors.NewInvalidInputf(errors.CodeInvalidInput, "unknown aggregation type: %q", a.Aggregation)
 		}
-		fc := a.Field.FieldContext
-		if fc != telemetrytypes.FieldContextResource && fc != telemetrytypes.FieldContextAttribute {
-			return errors.NewInvalidInputf(errors.CodeInvalidInput, "aggregation field context must be %q or %q, got %q",
-				telemetrytypes.FieldContextResource, telemetrytypes.FieldContextAttribute, fc)
+		if a.Field.FieldContext != telemetrytypes.FieldContextResource {
+			return errors.NewInvalidInputf(errors.CodeInvalidInput, "aggregation field context must be %q, got %q",
+				telemetrytypes.FieldContextResource, a.Field.FieldContext)
+		}
+		if !validAggregationFieldName.MatchString(a.Field.Name) {
+			return errors.NewInvalidInputf(errors.CodeInvalidInput, "invalid field name: %q", a.Field.Name)
 		}
 	}
 	return nil

--- a/pkg/types/spantypes/aggregation.go
+++ b/pkg/types/spantypes/aggregation.go
@@ -28,16 +28,16 @@ var (
 
 // SpanAggregation is a single aggregation request item: which field to group by and how.
 type SpanAggregation struct {
-	Field       telemetrytypes.TelemetryFieldKey `json:"field"       required:"true"`
-	Aggregation SpanAggregationType              `json:"aggregation" required:"true"`
+	Field       telemetrytypes.TelemetryFieldKey `json:"field" required:"true" nullable:"false"`
+	Aggregation SpanAggregationType              `json:"aggregation" required:"true" nullable:"false"`
 }
 
 // SpanAggregationResult is the computed result for one aggregation request item.
 // Duration values are in milliseconds.
 type SpanAggregationResult struct {
-	Field       telemetrytypes.TelemetryFieldKey `json:"field"`
-	Aggregation SpanAggregationType              `json:"aggregation"`
-	Value       map[string]uint64                `json:"value" nullable:"true"`
+	Field       telemetrytypes.TelemetryFieldKey `json:"field" required:"true" nullable:"false"`
+	Aggregation SpanAggregationType              `json:"aggregation" required:"true" nullable:"false"`
+	Value       map[string]uint64                `json:"value" required:"true" nullable:"true"`
 }
 
 func (SpanAggregationType) Enum() []any {
@@ -81,5 +81,5 @@ func (p *PostableTraceAggregations) Validate() error {
 
 // GettableTraceAggregations is the response for the V4 aggregations endpoint.
 type GettableTraceAggregations struct {
-	Aggregations []SpanAggregationResult `json:"aggregations"`
+	Aggregations []SpanAggregationResult `json:"aggregations" required:"true" nullable:"false"`
 }

--- a/pkg/types/spantypes/aggregation.go
+++ b/pkg/types/spantypes/aggregation.go
@@ -54,7 +54,7 @@ func (s SpanAggregationType) isValid() bool {
 
 // PostableTraceAggregations is the request body for the V4 aggregations endpoint.
 type PostableTraceAggregations struct {
-	Aggregations []SpanAggregation `json:"aggregations" required:"true"`
+	Aggregations []SpanAggregation `json:"aggregations" required:"true" nullable:"false"`
 }
 
 func (p *PostableTraceAggregations) Validate() error {

--- a/pkg/types/spantypes/spantypestest/store.go
+++ b/pkg/types/spantypes/spantypestest/store.go
@@ -1,8 +1,8 @@
 package spantypestest
 
 import (
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/SigNoz/signoz/pkg/types/spantypes"
-	cmock "github.com/srikanthccv/ClickHouse-go-mock"
 )
 
 // TraceStoreTest pairs a TraceStore with the ClickHouse mock.

--- a/pkg/types/spantypes/spantypestest/store.go
+++ b/pkg/types/spantypes/spantypestest/store.go
@@ -1,0 +1,22 @@
+package spantypestest
+
+import (
+	"github.com/SigNoz/signoz/pkg/types/spantypes"
+	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+)
+
+// TraceStoreTest pairs a TraceStore with the ClickHouse mock.
+type TraceStoreTest struct {
+	store spantypes.TraceStore
+	mock  cmock.ClickConnMockCommon
+}
+
+func New(store spantypes.TraceStore, mock cmock.ClickConnMockCommon) *TraceStoreTest {
+	return &TraceStoreTest{store: store, mock: mock}
+}
+
+// Store returns the TraceStore for calling methods under test.
+func (t *TraceStoreTest) Store() spantypes.TraceStore { return t.store }
+
+// Mock returns the ClickHouse mock for setting query expectations.
+func (t *TraceStoreTest) Mock() cmock.ClickConnMockCommon { return t.mock }

--- a/pkg/types/spantypes/store.go
+++ b/pkg/types/spantypes/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
 
@@ -29,4 +30,7 @@ type TraceStore interface {
 	GetTraceSpans(ctx context.Context, traceID string, summary *TraceSummary) ([]StorableSpan, error)
 	GetMinimalSpans(ctx context.Context, traceID string, start, end time.Time) ([]MinimalSpan, error)
 	GetTraceSpansByIDs(ctx context.Context, traceID string, start, end time.Time, spanIDs []string) ([]StorableSpan, error)
+
+	GetSpanCountByField(ctx context.Context, traceID string, summary *TraceSummary, fieldKey telemetrytypes.TelemetryFieldKey) (map[string]uint64, error)
+	GetSpanDurationByField(ctx context.Context, traceID string, summary *TraceSummary, fieldKey telemetrytypes.TelemetryFieldKey) (map[string]uint64, error)
 }


### PR DESCRIPTION
Part of https://github.com/SigNoz/engineering-pod/issues/4787

Add API endpoint & module for trace aggregations. Will raise a follow up for implementation of store methods.

Query used for calculating the non-overlapping span execution time:

```sql
WITH

-- query minimum span fields
all_spans AS (
	SELECT DISTINCT ON (span_id)
		%s AS field_value,
		toUnixTimestamp64Nano(timestamp) AS start_ns,
		start_ns + duration_nano AS end_ns
	FROM %s.%s
	WHERE trace_id=? AND ts_bucket_start>=? AND ts_bucket_start<=? AND notEmpty(field_value)
	ORDER BY timestamp ASC, name ASC
),

-- calculate max end time of preceding spans
effective_start AS (
	SELECT
		field_value, end_ns,
		greatest(
			start_ns,
			ifNull(
				max(end_ns) OVER (
					PARTITION BY field_value
					ORDER BY start_ns
					ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
				),
				toUInt64(0)
			)
		) AS effective_start_ns
	FROM all_spans
)

-- each span contributes only the tail past its effective start.
SELECT field_value, sum(toUInt64(greatest(end_ns - effective_start_ns, 0))) AS total_ns
FROM effective_start
GROUP BY field_value
```

Another possible option using `arrayFold` and `arraySort` simpler but hard to understand (rejected):
```sql
WITH spans AS (
    SELECT DISTINCT ON (span_id)
        <field_expr> AS grp,
        toUInt64(timestamp)                AS s,
        toUInt64(timestamp) + duration_nano AS e
    FROM signoz_traces.distributed_signoz_index_v3
    WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ?
      AND notEmpty(grp)
)
SELECT
    grp,
    arrayFold(
        (acc, x) -> (
            greatest(acc.1, x.2),
            acc.2 + if(x.2 > greatest(x.1, acc.1),
                       x.2 - greatest(x.1, acc.1),
                       toUInt64(0))
        ),
        arraySort(t -> t.1, groupArray((s, e))),
        (toUInt64(0), toUInt64(0))
    ).2 AS value
FROM spans
GROUP BY grp
```