### PR TITLE
feat(ai-assistant): base route, auth-retry streaming, and rate-limit UX

### DIFF
--- a/frontend/src/AppRoutes/Private.tsx
+++ b/frontend/src/AppRoutes/Private.tsx
@@ -102,7 +102,11 @@ function PrivateRoute({ children }: PrivateRouteProps): JSX.Element {
 		return <>{children}</>;
 	}
 
-	if (pathname.startsWith('/ai-assistant/') && !isAIAssistantEnabled) {
+	if (
+		(pathname === ROUTES.AI_ASSISTANT_BASE ||
+			pathname.startsWith('/ai-assistant/')) &&
+		!isAIAssistantEnabled
+	) {
 		return <Redirect to={ROUTES.HOME} />;
 	}
 

--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -229,18 +229,18 @@ function App(): JSX.Element {
 		}
 
 		setRoutes((prev) => {
-			const hasAi = prev.some((r) => r.path === ROUTES.AI_ASSISTANT);
+			const hasAi = prev.some((r) => r.key === 'AI_ASSISTANT');
 			if (isAIAssistantEnabled === hasAi) {
 				return prev;
 			}
 			if (isAIAssistantEnabled) {
-				const aiRoute = defaultRoutes.find((r) => r.path === ROUTES.AI_ASSISTANT);
+				const aiRoute = defaultRoutes.find((r) => r.key === 'AI_ASSISTANT');
 				if (!aiRoute) {
 					return prev;
 				}
-				return [...prev.filter((r) => r.path !== ROUTES.AI_ASSISTANT), aiRoute];
+				return [...prev.filter((r) => r.key !== 'AI_ASSISTANT'), aiRoute];
 			}
-			return prev.filter((r) => r.path !== ROUTES.AI_ASSISTANT);
+			return prev.filter((r) => r.key !== 'AI_ASSISTANT');
 		});
 	}, [isLoggedInState, isAIAssistantEnabled]);
 
@@ -254,6 +254,7 @@ function App(): JSX.Element {
 		if (
 			pathname === ROUTES.ONBOARDING ||
 			pathname.startsWith('/public/dashboard/') ||
+			pathname === '/ai-assistant' ||
 			pathname.startsWith('/ai-assistant/')
 		) {
 			window.Pylon?.('hideChatBubble');

--- a/frontend/src/AppRoutes/routes.ts
+++ b/frontend/src/AppRoutes/routes.ts
@@ -501,7 +501,7 @@ const routes: AppRoutes[] = [
 		isPrivate: true,
 	},
 	{
-		path: ROUTES.AI_ASSISTANT,
+		path: [ROUTES.AI_ASSISTANT_BASE, ROUTES.AI_ASSISTANT],
 		exact: true,
 		component: AIAssistantPage,
 		key: 'AI_ASSISTANT',

--- a/frontend/src/api/AIAPIInstance.ts
+++ b/frontend/src/api/AIAPIInstance.ts
@@ -41,7 +41,6 @@ export function setAIBackendUrl(url: string | null): void {
 		return;
 	}
 
-	url = 'http://localhost:8001';
 	aiBackendUrl = url;
 	AIAssistantInstance.defaults.baseURL = url ? `${url}${AI_API_PATH}` : '';
 }

--- a/frontend/src/api/AIAPIInstance.ts
+++ b/frontend/src/api/AIAPIInstance.ts
@@ -40,6 +40,8 @@ export function setAIBackendUrl(url: string | null): void {
 	if (aiBackendUrl === url) {
 		return;
 	}
+
+	url = 'http://localhost:8001';
 	aiBackendUrl = url;
 	AIAssistantInstance.defaults.baseURL = url ? `${url}${AI_API_PATH}` : '';
 }

--- a/frontend/src/api/ai-assistant/sigNozAIAssistantAPI.schemas.ts
+++ b/frontend/src/api/ai-assistant/sigNozAIAssistantAPI.schemas.ts
@@ -37,6 +37,16 @@ export enum ApplyFilterSignalDTO {
 	traces = 'traces',
 	metrics = 'metrics',
 }
+export enum ApprovalStateDTO {
+	pending = 'pending',
+	approved = 'approved',
+	rejected = 'rejected',
+	superseded = 'superseded',
+}
+export enum ApprovalActionTypeDTO {
+	modify = 'modify',
+	delete = 'delete',
+}
 /**
  * Resolved approval (approved/rejected/superseded) anchored on the assistant message that proposed it. Pending approvals never appear here - they live at the top-level pendingApproval slot.
  */
@@ -63,16 +73,6 @@ export interface ApprovalActionSummaryDTO {
 	resolvedAt: string;
 }
 
-export enum ApprovalActionTypeDTO {
-	modify = 'modify',
-	delete = 'delete',
-}
-export enum ApprovalStateDTO {
-	pending = 'pending',
-	approved = 'approved',
-	rejected = 'rejected',
-	superseded = 'superseded',
-}
 export type ApprovalSummaryDTODiff = { [key: string]: unknown };
 
 export interface ApprovalSummaryDTO {
@@ -139,6 +139,16 @@ export interface CancelRequestDTO {
 	threadId: string;
 }
 
+export enum ExecutionStateDTO {
+	queued = 'queued',
+	running = 'running',
+	awaiting_approval = 'awaiting_approval',
+	awaiting_clarification = 'awaiting_clarification',
+	resumed = 'resumed',
+	completed = 'completed',
+	failed = 'failed',
+	canceled = 'canceled',
+}
 export interface CancelResponseDTO {
 	/**
 	 * @type string
@@ -153,6 +163,13 @@ export type ClarificationFieldDTOOptions = string[] | null;
 
 export type ClarificationFieldDTODefault = string | string[] | null;
 
+export enum ClarificationFieldTypeDTO {
+	text = 'text',
+	number = 'number',
+	select = 'select',
+	multi_select = 'multi_select',
+	boolean = 'boolean',
+}
 export interface ClarificationFieldDTO {
 	/**
 	 * @type string
@@ -175,13 +192,6 @@ export interface ClarificationFieldDTO {
 	default?: ClarificationFieldDTODefault;
 }
 
-export enum ClarificationFieldTypeDTO {
-	text = 'text',
-	number = 'number',
-	select = 'select',
-	multi_select = 'multi_select',
-	boolean = 'boolean',
-}
 export enum ClarificationStateDTO {
 	pending = 'pending',
 	submitted = 'submitted',
@@ -252,178 +262,21 @@ export interface ClarifyResponseDTO {
 	executionId: string;
 }
 
-export type CreateMessageRequestDTOContexts = MessageContextDTO[] | null;
-
-export type CreateMessageRequestDTOForkFromMessageId = string | null;
-
-export interface CreateMessageRequestDTO {
-	/**
-	 * @type string
-	 * @maxLength 20000
-	 * @minLength 1
-	 */
-	content: string;
-	contexts?: CreateMessageRequestDTOContexts;
-	forkFromMessageId?: CreateMessageRequestDTOForkFromMessageId;
-}
-
-export interface CreateMessageResponseDTO {
-	/**
-	 * @type string
-	 * @format uuid
-	 */
-	executionId: string;
-}
-
-export type CreateThreadRequestDTOTitle = string | null;
-
-export interface CreateThreadRequestDTO {
-	title?: CreateThreadRequestDTOTitle;
-}
-
-export interface CreateThreadResponseDTO {
-	/**
-	 * @type string
-	 * @format uuid
-	 */
-	threadId: string;
-}
-
-export type ErrorBodyDTOErrors = ErrorResponseAdditionalDTO[] | null;
-
-export type ErrorBodyDTOUrl = string | null;
-
 /**
- * Inner error object — matches Go ErrorsJSON.
- */
-export interface ErrorBodyDTO {
-	/**
-	 * @type string
-	 * @pattern ^[a-z_]+$
-	 */
-	code: string;
-	/**
-	 * @type string
-	 */
-	message: string;
-	errors?: ErrorBodyDTOErrors;
-	url?: ErrorBodyDTOUrl;
-}
-
-/**
- * Top-level error envelope — matches Go RenderErrorResponse.
- */
-export interface ErrorResponseDTO {
-	/**
-	 * @type string
-	 */
-	status?: string;
-	error: ErrorBodyDTO;
-}
-
-/**
- * Single sub-error entry — matches Go ErrorsResponseerroradditional.
- */
-export interface ErrorResponseAdditionalDTO {
-	/**
-	 * @type string
-	 */
-	message: string;
-}
-
-export enum ExecutionStateDTO {
-	queued = 'queued',
-	running = 'running',
-	awaiting_approval = 'awaiting_approval',
-	awaiting_clarification = 'awaiting_clarification',
-	resumed = 'resumed',
-	completed = 'completed',
-	failed = 'failed',
-	canceled = 'canceled',
-}
-export enum FeedbackRatingDTO {
-	positive = 'positive',
-	negative = 'negative',
-}
-export type FeedbackRequestDTOComment = string | null;
-
-export interface FeedbackRequestDTO {
-	rating: FeedbackRatingDTO;
-	comment?: FeedbackRequestDTOComment;
-}
-
-export interface FeedbackResponseDTO {
-	[key: string]: unknown;
-}
-
-export interface HTTPValidationErrorDTO {
-	/**
-	 * @type array
-	 */
-	detail?: ValidationErrorDTO[];
-}
-
-export const HealthResponseDTOValue = {
-	/**
-	 * @type string
-	 */
-	status: 'ok',
-} as const;
-export type HealthResponseDTO = typeof HealthResponseDTOValue;
-
-export type MessageActionDTOActionMetadataId = string | null;
-
-export type MessageActionDTOResourceType = string | null;
-
-export type MessageActionDTOResourceId = string | null;
-
-export type MessageActionDTOState = string | null;
-
-export type MessageActionDTOInputAnyOf = { [key: string]: unknown };
-
-export type MessageActionDTOInput = MessageActionDTOInputAnyOf | null;
-
-export type MessageActionDTOTooltip = string | null;
-
-export type MessageActionDTOSignal = ApplyFilterSignalDTO | null;
-
-export type MessageActionDTOQueryAnyOf = { [key: string]: unknown };
-
-export type MessageActionDTOQuery = MessageActionDTOQueryAnyOf | null;
-
-export type MessageActionDTOUrl = string | null;
-
-/**
- * Assistant action. Kind-specific requirements: rollback actions require actionMetadataId/resourceType/resourceId; follow_up requires input.intent; open_resource requires resourceType/resourceId; apply_filter requires signal and query; open_docs requires a SigNoz docs url.
- */
-export interface MessageActionDTO {
-	kind: MessageActionKindDTO;
-	/**
-	 * @type string
-	 */
-	label: string;
-	actionMetadataId?: MessageActionDTOActionMetadataId;
-	resourceType?: MessageActionDTOResourceType;
-	resourceId?: MessageActionDTOResourceId;
-	state?: MessageActionDTOState;
-	input?: MessageActionDTOInput;
-	tooltip?: MessageActionDTOTooltip;
-	signal?: MessageActionDTOSignal;
-	query?: MessageActionDTOQuery;
-	url?: MessageActionDTOUrl;
-}
-
-export enum MessageActionKindDTO {
-	undo = 'undo',
-	revert = 'revert',
-	restore = 'restore',
-	follow_up = 'follow_up',
-	open_resource = 'open_resource',
-	open_docs = 'open_docs',
-	apply_filter = 'apply_filter',
-}
-export enum MessageContentTypeDTO {
-	markdown = 'markdown',
+   * Identifier exposed on the wire for each counter row.
+  
+  Mirrors the ``RateLimitCounterType`` model enum minus the cost
+  counter. The daily-cost limit is enforced internally (Redis
+  counter + 429 from the pre-flight gate) but never surfaced on the
+  customer-facing API: shipping the raw provider cost to tenant users
+  pins our public pricing model to what we pay Anthropic and forecloses
+  markup, per-seat bundling, or tiered pricing. Cost stays internal on
+  ``assistant_executions`` + Redis for billing.
+   */
+export enum CounterTypeNameDTO {
+	hourly_message = 'hourly_message',
+	daily_message = 'daily_message',
+	daily_token = 'daily_token',
 }
 /**
  * "auto" if derived from current page; "mention" if explicitly @-picked.
@@ -482,6 +335,193 @@ export interface MessageContextDTO {
 	metadata?: MessageContextDTOMetadata;
 }
 
+export type CreateMessageRequestDTOContexts = MessageContextDTO[] | null;
+
+export type CreateMessageRequestDTOForkFromMessageId = string | null;
+
+export interface CreateMessageRequestDTO {
+	/**
+	 * @type string
+	 * @maxLength 20000
+	 * @minLength 1
+	 */
+	content: string;
+	contexts?: CreateMessageRequestDTOContexts;
+	forkFromMessageId?: CreateMessageRequestDTOForkFromMessageId;
+}
+
+export interface CreateMessageResponseDTO {
+	/**
+	 * @type string
+	 * @format uuid
+	 */
+	executionId: string;
+}
+
+export type CreateThreadRequestDTOTitle = string | null;
+
+export interface CreateThreadRequestDTO {
+	title?: CreateThreadRequestDTOTitle;
+}
+
+export interface CreateThreadResponseDTO {
+	/**
+	 * @type string
+	 * @format uuid
+	 */
+	threadId: string;
+}
+
+/**
+ * Single sub-error entry — matches Go ErrorsResponseerroradditional.
+ */
+export interface ErrorResponseAdditionalDTO {
+	/**
+	 * @type string
+	 */
+	message: string;
+}
+
+export type ErrorBodyDTOErrors = ErrorResponseAdditionalDTO[] | null;
+
+export type ErrorBodyDTOUrl = string | null;
+
+/**
+ * Inner error object — matches Go ErrorsJSON.
+ */
+export interface ErrorBodyDTO {
+	/**
+	 * @type string
+	 * @pattern ^[a-z_]+$
+	 */
+	code: string;
+	/**
+	 * @type string
+	 */
+	message: string;
+	errors?: ErrorBodyDTOErrors;
+	url?: ErrorBodyDTOUrl;
+}
+
+/**
+ * Top-level error envelope — matches Go RenderErrorResponse.
+ */
+export interface ErrorResponseDTO {
+	/**
+	 * @type string
+	 */
+	status?: string;
+	error: ErrorBodyDTO;
+}
+
+export enum FeedbackRatingDTO {
+	positive = 'positive',
+	negative = 'negative',
+}
+export type FeedbackRequestDTOComment = string | null;
+
+export interface FeedbackRequestDTO {
+	rating: FeedbackRatingDTO;
+	comment?: FeedbackRequestDTOComment;
+}
+
+export interface FeedbackResponseDTO {
+	[key: string]: unknown;
+}
+
+export type ValidationErrorDTOLocItem = string | number;
+
+export type ValidationErrorDTOCtx = { [key: string]: unknown };
+
+export interface ValidationErrorDTO {
+	/**
+	 * @type array
+	 */
+	loc: ValidationErrorDTOLocItem[];
+	/**
+	 * @type string
+	 */
+	msg: string;
+	/**
+	 * @type string
+	 */
+	type: string;
+	input?: unknown;
+	/**
+	 * @type object
+	 */
+	ctx?: ValidationErrorDTOCtx;
+}
+
+export interface HTTPValidationErrorDTO {
+	/**
+	 * @type array
+	 */
+	detail?: ValidationErrorDTO[];
+}
+
+export const HealthResponseDTOValue = {
+	/**
+	 * @type string
+	 */
+	status: 'ok',
+} as const;
+export type HealthResponseDTO = typeof HealthResponseDTOValue;
+
+export type MessageActionDTOActionMetadataId = string | null;
+
+export type MessageActionDTOResourceType = string | null;
+
+export type MessageActionDTOResourceId = string | null;
+
+export type MessageActionDTOState = string | null;
+
+export type MessageActionDTOInputAnyOf = { [key: string]: unknown };
+
+export type MessageActionDTOInput = MessageActionDTOInputAnyOf | null;
+
+export type MessageActionDTOTooltip = string | null;
+
+export type MessageActionDTOSignal = ApplyFilterSignalDTO | null;
+
+export type MessageActionDTOQueryAnyOf = { [key: string]: unknown };
+
+export type MessageActionDTOQuery = MessageActionDTOQueryAnyOf | null;
+
+export type MessageActionDTOUrl = string | null;
+
+export enum MessageActionKindDTO {
+	undo = 'undo',
+	revert = 'revert',
+	restore = 'restore',
+	follow_up = 'follow_up',
+	open_resource = 'open_resource',
+	open_docs = 'open_docs',
+	apply_filter = 'apply_filter',
+}
+/**
+ * Assistant action. Kind-specific requirements: rollback actions require actionMetadataId/resourceType/resourceId; follow_up requires input.intent; open_resource requires resourceType/resourceId; apply_filter requires signal and query; open_docs requires a SigNoz docs url.
+ */
+export interface MessageActionDTO {
+	kind: MessageActionKindDTO;
+	/**
+	 * @type string
+	 */
+	label: string;
+	actionMetadataId?: MessageActionDTOActionMetadataId;
+	resourceType?: MessageActionDTOResourceType;
+	resourceId?: MessageActionDTOResourceId;
+	state?: MessageActionDTOState;
+	input?: MessageActionDTOInput;
+	tooltip?: MessageActionDTOTooltip;
+	signal?: MessageActionDTOSignal;
+	query?: MessageActionDTOQuery;
+	url?: MessageActionDTOUrl;
+}
+
+export enum MessageContentTypeDTO {
+	markdown = 'markdown',
+}
 export enum MessageRoleDTO {
 	user = 'user',
 	assistant = 'assistant',
@@ -616,6 +656,10 @@ export interface RevertRequestDTO {
 	actionMetadataId: string;
 }
 
+export enum ScopeDTO {
+	user = 'user',
+	org = 'org',
+}
 export type ThreadDetailResponseDTOTitle = string | null;
 
 export type ThreadDetailResponseDTOState = ExecutionStateDTO | null;
@@ -663,18 +707,6 @@ export interface ThreadDetailResponseDTO {
 
 export type ThreadListResponseDTONextCursor = string | null;
 
-export interface ThreadListResponseDTO {
-	/**
-	 * @type array
-	 */
-	threads: ThreadSummaryDTO[];
-	nextCursor?: ThreadListResponseDTONextCursor;
-	/**
-	 * @type boolean
-	 */
-	hasMore?: boolean;
-}
-
 export type ThreadSummaryDTOTitle = string | null;
 
 export type ThreadSummaryDTOState = ExecutionStateDTO | null;
@@ -709,6 +741,18 @@ export interface ThreadSummaryDTO {
 	updatedAt: string;
 }
 
+export interface ThreadListResponseDTO {
+	/**
+	 * @type array
+	 */
+	threads: ThreadSummaryDTO[];
+	nextCursor?: ThreadListResponseDTONextCursor;
+	/**
+	 * @type boolean
+	 */
+	hasMore?: boolean;
+}
+
 export interface UndoRequestDTO {
 	/**
 	 * @type string
@@ -726,28 +770,29 @@ export interface UpdateThreadRequestDTO {
 	archived?: UpdateThreadRequestDTOArchived;
 }
 
-export type ValidationErrorDTOLocItem = string | number;
+export type UsageResponseDTONextPage = string | null;
 
-export type ValidationErrorDTOCtx = { [key: string]: unknown };
+/**
+ * One row in the ``GET /usage`` response.
+ */
+export interface UsageRowDTO {
+	type: CounterTypeNameDTO;
+	scope: ScopeDTO;
+	used: number;
+	limit: number;
+	/**
+	 * @type string
+	 * @format date-time
+	 */
+	resetsAt: string;
+}
 
-export interface ValidationErrorDTO {
+export interface UsageResponseDTO {
 	/**
 	 * @type array
 	 */
-	loc: ValidationErrorDTOLocItem[];
-	/**
-	 * @type string
-	 */
-	msg: string;
-	/**
-	 * @type string
-	 */
-	type: string;
-	input?: unknown;
-	/**
-	 * @type object
-	 */
-	ctx?: ValidationErrorDTOCtx;
+	data: UsageRowDTO[];
+	nextPage?: UsageResponseDTONextPage;
 }
 
 export type ApprovalEventDTODiff = { [key: string]: unknown };
@@ -908,6 +953,20 @@ export interface ErrorEventDTO {
 	error: ErrorBodyDTO;
 	retryAction?: RetryActionDTO;
 }
+
+/**
+   * Per-connection SSE keep-alive emitted every `sse_heartbeat_interval_seconds`.
+  
+  Carries no `executionId` and no `eventId` — heartbeats are wire-level
+  keep-alives, not part of the replayable event log.
+   */
+export const HeartbeatEventDTOValue = {
+	/**
+	 * @type string
+	 */
+	type: 'heartbeat',
+} as const;
+export type HeartbeatEventDTO = typeof HeartbeatEventDTOValue;
 
 export type MessageActionEventDTOActionMetadataId = string | null;
 
@@ -1306,6 +1365,17 @@ export type SubmitFeedbackApiV1AssistantMessagesMessageIdFeedbackPostPathParamet
 		messageId: string;
 	};
 export type SubmitFeedbackApiV1AssistantMessagesMessageIdFeedbackPostHeaders = {
+	/**
+	 * @description SigNoz auth token (Bearer or raw JWT)
+	 */
+	authorization?: string | null;
+	/**
+	 * @description SigNoz instance base URL for multi-tenant deployments. Falls back to SIGNOZ_API_URL env var when omitted.
+	 */
+	'X-SigNoz-URL'?: string | null;
+};
+
+export type GetUsageApiV1AssistantUsageGetHeaders = {
 	/**
 	 * @description SigNoz auth token (Bearer or raw JWT)
 	 */

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -88,6 +88,7 @@ const ROUTES = {
 	PUBLIC_DASHBOARD: '/public/dashboard/:dashboardId',
 	SERVICE_ACCOUNTS_SETTINGS: '/settings/service-accounts',
 	AI_ASSISTANT: '/ai-assistant/:conversationId',
+	AI_ASSISTANT_BASE: '/ai-assistant',
 	AI_ASSISTANT_ICON_PREVIEW: '/ai-assistant-icon-preview',
 	MCP_SERVER: '/settings/mcp-server',
 } as const;

--- a/frontend/src/container/AIAssistant/components/MessageBubble/MessageBubble.tsx
+++ b/frontend/src/container/AIAssistant/components/MessageBubble/MessageBubble.tsx
@@ -178,7 +178,7 @@ export default function MessageBubble({
 					</div>
 				</div>
 
-				{!isUser && (
+				{!isUser && !message.isRateLimitError && (
 					<MessageFeedback
 						message={message}
 						onRegenerate={onRegenerate}

--- a/frontend/src/container/AIAssistant/store/useAIAssistantStore.ts
+++ b/frontend/src/container/AIAssistant/store/useAIAssistantStore.ts
@@ -1,10 +1,12 @@
 /* eslint-disable sonarjs/cognitive-complexity */
+import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 
 import type {
+	ErrorResponseDTO,
 	MessageActionDTO,
 	MessageSummaryDTOBlocksAnyOfItem,
 } from 'api/ai-assistant/sigNozAIAssistantAPI.schemas';
@@ -21,7 +23,6 @@ import {
 	regenerateMessage,
 	rejectExecution,
 	sendMessage as sendMessageToThread,
-	SSEStreamError,
 	streamEvents,
 	submitFeedback,
 	ThreadSummary,
@@ -194,12 +195,74 @@ function resetStreamingState(
 }
 
 /**
+ * Marker thrown by `runStreamingLoop` when an SSE event reports
+ * `invalid_token`. Callers that own an originating action (sendMessage /
+ * approve / clarify / regenerate) catch this and re-issue that action via
+ * `streamWithAuthRetry`; the retry's first REST call will 401, at which point
+ * the shared axios `interceptorRejected` rotates the access token and replays.
+ */
+class AuthExpiredError extends Error {
+	constructor() {
+		super('Access token expired during execution');
+		this.name = 'AuthExpiredError';
+	}
+}
+
+/**
+ * Runs the originating action (e.g. sendMessage POST) and streams the
+ * resulting execution. On `AuthExpiredError`, re-issues `start` once — the
+ * retry's REST call hits 401, the shared axios interceptor rotates the
+ * access token and replays, and the new SSE picks up the rotated token from
+ * localStorage. Backend signals `retryAction: 'manual'` for `invalid_token`,
+ * so the dead execution can't be resumed — only a fresh one helps.
+ */
+async function streamWithAuthRetry(
+	conversationId: string,
+	start: () => Promise<string>,
+	set: StoreSetter,
+): Promise<void> {
+	for (let attempt = 0; attempt <= 1; attempt += 1) {
+		if (attempt > 0) {
+			// Drop any partial content/events from the previous attempt so the
+			// retried execution's stream isn't concatenated with the dead one.
+			set((s) => {
+				resetStreamingState(s, conversationId);
+			});
+		}
+		// eslint-disable-next-line no-await-in-loop
+		const executionId = await start();
+		const ctrl = newStreamController(conversationId);
+		try {
+			// eslint-disable-next-line no-await-in-loop
+			await runStreamingLoop(executionId, {
+				conversationId,
+				set,
+				signal: ctrl.signal,
+			});
+			streamControllers.delete(conversationId);
+			return;
+		} catch (err) {
+			streamControllers.delete(conversationId);
+			if (err instanceof AuthExpiredError && attempt < 1) {
+				continue;
+			}
+			throw err;
+		}
+	}
+}
+
+/**
  * Runs one SSE execution stream, updating the per-conversation stream state.
  *
  * Breaks early and sets pendingApproval / pendingClarification when the
  * agent needs user input before it can continue.
  *
- * Throws on `error` events — the caller's catch block handles UI feedback.
+ * On an `invalid_token` error event (e.g. MCP auth expired mid-execution),
+ * throws `AuthExpiredError` so the caller can re-issue the originating
+ * action via `streamWithAuthRetry`. We don't refresh here ourselves — the
+ * retry's REST call will 401 and the shared axios `interceptorRejected`
+ * handles rotation + replay. Throws on any other `error` event — the
+ * caller's catch block handles UI feedback.
  */
 // eslint-disable-next-line sonarjs/cognitive-complexity
 async function runStreamingLoop(
@@ -325,6 +388,15 @@ async function runStreamingLoop(
 			});
 			break;
 		} else if (event.type === 'error') {
+			// MCP/SigNoz auth expired mid-execution — signal the caller to
+			// re-issue the originating action. The retry's REST call will hit
+			// 401 and the shared axios `interceptorRejected` will rotate the
+			// access token + replay, so we don't refresh here ourselves.
+			// (Backend sets `retryAction: 'manual'`, so the failed execution
+			// can't itself be resumed — only a fresh one helps.)
+			if (event.error.code === 'invalid_token') {
+				throw new AuthExpiredError();
+			}
 			throw Object.assign(new Error(event.error.message), {
 				retryAction: event.retryAction,
 			});
@@ -412,13 +484,41 @@ function hasPendingInput(conversationId: string, get: StoreGetter): boolean {
 	return Boolean(stream?.pendingApproval || stream?.pendingClarification);
 }
 
+function parseErrorBody(value: unknown): string | null {
+	if (typeof value === 'string') {
+		try {
+			return parseErrorBody(JSON.parse(value));
+		} catch {
+			return null;
+		}
+	}
+	const message = (value as ErrorResponseDTO | undefined)?.error?.message;
+	return typeof message === 'string' && message.length > 0 ? message : null;
+}
+
 /**
- * Commits an error message and removes the stream entry.
+ * Returns the backend's `error.message` when `err` is a 429 axios response
+ * (typically from the threads API surface — createThread, sendMessage, approve,
+ * clarify, regenerate). Returns null for any other error so callers fall
+ * through to their generic copy.
+ */
+function rateLimitMessage(err: unknown): string | null {
+	if (axios.isAxiosError(err) && err.response?.status === 429) {
+		return parseErrorBody(err.response.data);
+	}
+	return null;
+}
+
+/**
+ * Commits an error message and removes the stream entry. When `isRateLimit`
+ * is true, the committed message is flagged so the feedback/regenerate bar
+ * is hidden — clicking regenerate would just 429 again.
  */
 function finalizeStreamingError(
 	conversationId: string,
 	errorContent: string,
 	set: StoreSetter,
+	isRateLimit = false,
 ): void {
 	set((s) => {
 		const conv = s.conversations[conversationId];
@@ -428,6 +528,7 @@ function finalizeStreamingError(
 				role: 'assistant',
 				content: errorContent,
 				createdAt: Date.now(),
+				...(isRateLimit ? { isRateLimitError: true } : {}),
 			});
 			conv.updatedAt = Date.now();
 		}
@@ -801,7 +902,12 @@ export const useAIAssistantStore = create<AIAssistantStore>()(
 					});
 
 					// Reconnect to SSE if backend execution is still running
-					// and we don't already have an active SSE reader for this thread
+					// and we don't already have an active SSE reader for this
+					// thread. No auth-retry wrapper here: on `invalid_token`
+					// there's no "originating action" to redo — reopening the
+					// same dead executionId would just re-emit the failure.
+					// Let the error bubble; the user can send a new message,
+					// which will go through `streamWithAuthRetry`.
 					if (
 						detail.activeExecutionId &&
 						!streamControllers.has(threadId) &&
@@ -1052,14 +1158,12 @@ export const useAIAssistantStore = create<AIAssistantStore>()(
 							}
 						});
 					}
-					const executionId = await sendMessageToThread(threadId, text, contexts);
-					const ctrl = newStreamController(convId);
-					await runStreamingLoop(executionId, {
-						conversationId: convId,
+					const tid = threadId;
+					await streamWithAuthRetry(
+						convId,
+						() => sendMessageToThread(tid, text, contexts),
 						set,
-						signal: ctrl.signal,
-					});
-					streamControllers.delete(convId);
+					);
 
 					if (!hasPendingInput(convId, get)) {
 						finalizeStreamingMessage(convId, set, get);
@@ -1070,11 +1174,14 @@ export const useAIAssistantStore = create<AIAssistantStore>()(
 						return;
 					}
 					console.error('[AIAssistant] sendMessage failed:', err);
-					const message =
-						err instanceof SSEStreamError && err.status === 429
-							? 'You sent that a bit too quickly. Please wait a moment and try again.'
-							: 'Something went wrong while fetching the response. Please try again.';
-					finalizeStreamingError(convId, message, set);
+					const rateLimit = rateLimitMessage(err);
+					finalizeStreamingError(
+						convId,
+						rateLimit ??
+							'Something went wrong while fetching the response. Please try again.',
+						set,
+						rateLimit !== null,
+					);
 				}
 			},
 
@@ -1094,14 +1201,11 @@ export const useAIAssistantStore = create<AIAssistantStore>()(
 				});
 
 				try {
-					const executionId = await approveExecution(approvalId);
-					const ctrl = newStreamController(conversationId);
-					await runStreamingLoop(executionId, {
+					await streamWithAuthRetry(
 						conversationId,
+						() => approveExecution(approvalId),
 						set,
-						signal: ctrl.signal,
-					});
-					streamControllers.delete(conversationId);
+					);
 					if (!hasPendingInput(conversationId, get)) {
 						finalizeStreamingMessage(conversationId, set, get);
 					}
@@ -1110,10 +1214,13 @@ export const useAIAssistantStore = create<AIAssistantStore>()(
 						return;
 					}
 					console.error('[AIAssistant] approveAction failed:', err);
+					const rateLimit = rateLimitMessage(err);
 					finalizeStreamingError(
 						conversationId,
-						'Something went wrong while processing the approval. Please try again.',
+						rateLimit ??
+							'Something went wrong while processing the approval. Please try again.',
 						set,
+						rateLimit !== null,
 					);
 				}
 			},
@@ -1176,14 +1283,11 @@ export const useAIAssistantStore = create<AIAssistantStore>()(
 				});
 
 				try {
-					const executionId = await regenerateMessage(messageId);
-					const ctrl = newStreamController(conversationId);
-					await runStreamingLoop(executionId, {
+					await streamWithAuthRetry(
 						conversationId,
+						() => regenerateMessage(messageId),
 						set,
-						signal: ctrl.signal,
-					});
-					streamControllers.delete(conversationId);
+					);
 					if (!hasPendingInput(conversationId, get)) {
 						finalizeStreamingMessage(conversationId, set, get);
 					}
@@ -1192,10 +1296,13 @@ export const useAIAssistantStore = create<AIAssistantStore>()(
 						return;
 					}
 					console.error('[AIAssistant] regenerateAssistantMessage failed:', err);
+					const rateLimit = rateLimitMessage(err);
 					finalizeStreamingError(
 						conversationId,
-						'Something went wrong while regenerating the response. Please try again.',
+						rateLimit ??
+							'Something went wrong while regenerating the response. Please try again.',
 						set,
+						rateLimit !== null,
 					);
 				}
 			},
@@ -1245,14 +1352,11 @@ export const useAIAssistantStore = create<AIAssistantStore>()(
 				});
 
 				try {
-					const executionId = await clarifyExecution(clarificationId, answers);
-					const ctrl = newStreamController(conversationId);
-					await runStreamingLoop(executionId, {
+					await streamWithAuthRetry(
 						conversationId,
+						() => clarifyExecution(clarificationId, answers),
 						set,
-						signal: ctrl.signal,
-					});
-					streamControllers.delete(conversationId);
+					);
 					if (!hasPendingInput(conversationId, get)) {
 						finalizeStreamingMessage(conversationId, set, get);
 					}
@@ -1261,10 +1365,13 @@ export const useAIAssistantStore = create<AIAssistantStore>()(
 						return;
 					}
 					console.error('[AIAssistant] submitClarification failed:', err);
+					const rateLimit = rateLimitMessage(err);
 					finalizeStreamingError(
 						conversationId,
-						'Something went wrong while processing your answers. Please try again.',
+						rateLimit ??
+							'Something went wrong while processing your answers. Please try again.',
 						set,
+						rateLimit !== null,
 					);
 				}
 			},

--- a/frontend/src/container/AIAssistant/types.ts
+++ b/frontend/src/container/AIAssistant/types.ts
@@ -86,6 +86,11 @@ export interface Message {
 	actions?: MessageActionDTO[];
 	/** Persisted feedback rating — set after user votes and the API confirms. */
 	feedbackRating?: FeedbackRating | null;
+	/**
+	 * Set on client-side rate-limit error messages so the feedback/regenerate
+	 * bar (copy/vote/regenerate) is hidden — retrying would just 429 again.
+	 */
+	isRateLimitError?: boolean;
 	createdAt: number;
 }
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -825,4 +825,5 @@ body.ai-assistant-panel-open {
 // overrides
 :root {
 	--input-focus-outline-width: 0;
+	--radius-2: 4px;
 }

--- a/frontend/src/utils/permission/index.ts
+++ b/frontend/src/utils/permission/index.ts
@@ -135,4 +135,5 @@ export const routePermission: Record<keyof typeof ROUTES, ROLES[]> = {
 	AI_ASSISTANT: ['ADMIN', 'EDITOR', 'VIEWER'],
 	AI_ASSISTANT_ICON_PREVIEW: ['ADMIN', 'EDITOR', 'VIEWER'],
 	MCP_SERVER: ['ADMIN', 'EDITOR', 'VIEWER'],
+	AI_ASSISTANT_BASE: ['ADMIN', 'EDITOR', 'VIEWER'],
 };


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

This PR hardens the AI Assistant frontend around **routing**, **mid-execution auth recovery**, and **rate-limit UX**, and syncs generated API types with the latest backend OpenAPI spec.

**Problems addressed**

1. **`/ai-assistant` was not a first-class route** — only `/ai-assistant/:conversationId` existed. Users landing on `/ai-assistant` could miss route registration, permission checks, and Pylon bubble hiding. Dynamic route toggling keyed off `path` was brittle when the route became a path array.
2. **MCP / SigNoz token expiry mid-SSE** — when the backend emits `invalid_token` during streaming, the execution cannot be resumed (`retryAction: 'manual'`). Users previously saw a dead stream with no automatic recovery.
3. **Rate limits surfaced poorly** — 429 responses from thread APIs used generic copy, and the feedback/regenerate bar remained visible even though retrying would immediately 429 again.

**Approach**

- Add `ROUTES.AI_ASSISTANT_BASE` (`/ai-assistant`) as a sibling route to the parameterized conversation route, with matching permissions and private-route guards.
- Centralize “start action → stream SSE” behind `streamWithAuthRetry`, which retries once on `AuthExpiredError` by re-issuing the originating REST call (send, approve, clarify, regenerate). Token rotation stays in the shared axios interceptor; the store only detects `invalid_token` and re-triggers the action.
- Parse backend `error.message` on 429, commit it as the assistant error bubble, and set `isRateLimitError` so `MessageFeedback` is hidden.

#### Screenshots / Screen Recordings (if applicable)

<img width="3024" height="1278" alt="Screenshot 2026-05-26 at 4 45 35 PM" src="https://github.com/user-attachments/assets/021482b7-91c9-40ff-adce-85dd9e70703e" />
<img width="3024" height="1278" alt="Screenshot 2026-05-26 at 4 43 09 PM" src="https://github.com/user-attachments/assets/fdc5180e-67de-4b4b-a6a9-21f0a1522921" />


#### Issues closed by this PR

> `Closes #<issue-number>` (fill in if applicable)

---

### ✅ Change Type

- [x] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

| Area | Cause |
|------|--------|
| Routing | Base path `/ai-assistant` was not registered; guards and feature-flag route injection compared `path` strings while the route definition needed multiple paths. |
| Auth mid-stream | SSE `error` events with `code: 'invalid_token'` ended the stream with no retry; backend cannot resume that execution. |
| Rate limits | Catch blocks used hardcoded generic messages; `MessageFeedback` rendered on all assistant error messages. |

#### Fix Strategy

| Area | Fix |
|------|-----|
| Routing | `AI_ASSISTANT_BASE` route, `path: [BASE, PARAM]` in `routes.ts`, guard + Pylon hide for base path, route injection by stable `key: 'AI_ASSISTANT'`. |
| Auth | `AuthExpiredError` from `runStreamingLoop` → `streamWithAuthRetry` resets partial stream state and re-runs `start()` once. |
| Rate limits | `rateLimitMessage()` + `finalizeStreamingError(..., isRateLimit: true)` + `MessageBubble` skips feedback when `isRateLimitError`. |

---

### 🧪 Testing Strategy

- Tests added/updated: None (manual validation recommended)
- Manual verification:
  - [ ] Feature flag on: open `/ai-assistant` and `/ai-assistant/<id>` — both load `AIAssistantPage`, sidenav highlights correctly
  - [ ] Feature flag off: `/ai-assistant` and `/ai-assistant/*` redirect to home
  - [ ] Send message → stream completes; approve / clarify / regenerate paths still work
  - [ ] Simulate 429 on `sendMessage` / `approve` / `regenerate` / `clarify` — backend message shown, no feedback bar
  - [ ] Simulate `invalid_token` mid-SSE — stream retries once via fresh execution (after interceptor token rotation)
  - [ ] Reload thread with `activeExecutionId` — SSE reconnects without auth-retry wrapper (user can send a new message if reconnect fails)
- Edge cases covered:
  - Auth retry limited to **one** attempt; partial stream state cleared before retry
  - Thread reconnect on load does **not** use `streamWithAuthRetry` (no originating action to replay)
  - `parseErrorBody` handles stringified JSON error payloads

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** AI Assistant routes, Zustand store streaming paths, `MessageBubble` feedback visibility, global `--radius-2` token
- **Potential regressions:**
  - Route injection if another route shares `key: 'AI_ASSISTANT'`
  - Double-submit if auth retry fires while user navigates away (stream controller cleanup unchanged)
  - OpenAPI schema reorder/additions — verify no import breakage outside AI Assistant
- **Rollback plan:** Revert branch; no migrations. Feature flag `isAIAssistantEnabled` still gates access.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix / Feature |
| Description | AI Assistant: support `/ai-assistant` landing route; recover from expired auth during streaming; show backend rate-limit messages and hide regenerate on limit errors. |

---

### 📋 Checklist

- [ ] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered (`/ai-assistant/:id` unchanged)

---

## 👀 Notes for Reviewers

### Files changed (by concern)

| File | Change |
|------|--------|
| `constants/routes.ts`, `AppRoutes/*`, `permission/index.ts` | Base route, dual-path registration, guard, Pylon hide |
| `useAIAssistantStore.ts` | `streamWithAuthRetry`, `AuthExpiredError`, `rateLimitMessage`, wired into send/approve/clarify/regenerate |
| `types.ts`, `MessageBubble.tsx` | `isRateLimitError` + hide `MessageFeedback` |
| `sigNozAIAssistantAPI.schemas.ts` | Regenerated/synced types (`MessageContextDTO`, `ErrorResponseDTO`, enum moves) |
| `styles.scss` | `--radius-2: 4px` for `@signozhq/ui` alignment |



## Detailed approach & flow

### 1. Routing: `/ai-assistant` as a first-class entry

```mermaid
flowchart LR
  A[User navigates] --> B{pathname?}
  B -->|/ai-assistant| C[AI_ASSISTANT_BASE route]
  B -->|/ai-assistant/:id| D[AI_ASSISTANT route]
  C --> E[AIAssistantPage]
  D --> E
  F[isAIAssistantEnabled?] -->|no| G[Redirect HOME]
  F -->|yes| E
```

**What changed**

- `ROUTES.AI_ASSISTANT_BASE` = `/ai-assistant` (no `conversationId`).
- `routes.ts` registers `path: [ROUTES.AI_ASSISTANT_BASE, ROUTES.AI_ASSISTANT]` with `key: 'AI_ASSISTANT'`.
- `AppRoutes/index.tsx` adds/removes the AI route by **`key`**, not `path`, so feature-flag toggling still works when `path` is an array.
- `Private.tsx` blocks both the base path and `/ai-assistant/*` when the feature flag is off.
- Pylon chat bubble is hidden on `/ai-assistant` (same as conversation URLs).

**User flow**

1. User opens `/ai-assistant` or `/ai-assistant/<threadId>`.
2. `PrivateRoute` checks `isAIAssistantEnabled` → redirect to home if disabled.
3. React Router matches `AIAssistantPage` for either path.
4. Page logic (existing) handles “new” vs existing thread from the URL param.

---

### 2. Streaming with auth retry (`streamWithAuthRetry`)

Actions that **start a new execution** all use the same wrapper:

| Store action | REST `start()` | SSE |
|--------------|----------------|-----|
| `sendMessage` | `sendMessageToThread` | `runStreamingLoop` |
| `approveAction` | `approveExecution` | `runStreamingLoop` |
| `submitClarification` | `clarifyExecution` | `runStreamingLoop` |
| `regenerateAssistantMessage` | `regenerateMessage` | `runStreamingLoop` |

**Control flow**

```
streamWithAuthRetry(conversationId, start, set)
│
├─ attempt 0
│    ├─ executionId = await start()          // POST → new execution
│    ├─ ctrl = newStreamController(convId)
│    └─ await runStreamingLoop(executionId, { set, signal })
│         │
│         ├─ status / message / thinking / tool_call → update streams[conversationId]
│         ├─ approval | clarification → set pending* ; exit loop (paused)
│         ├─ done → exit loop (success path)
│         └─ error
│              ├─ code === 'invalid_token' → throw AuthExpiredError
│              └─ else → throw Error (handled by action’s catch)
│
├─ catch AuthExpiredError (attempt < 1)
│    ├─ resetStreamingState(conversationId)  // drop partial deltas/events
│    └─ attempt 1 → re-run start() + runStreamingLoop
│
└─ success → finalizeStreamingMessage (if no pending approval/clarification)
```

**Design decisions**

| Decision | Rationale |
|----------|-----------|
| No token refresh inside SSE loop | Backend sets `retryAction: 'manual'` — dead execution cannot resume. Recovery = fresh REST + fresh SSE. |
| Retry re-issues `start()`, not reconnect | Reopening the same `executionId` re-emits the failure. |
| Axios interceptor owns rotation | Retry’s REST call 401s → `interceptorRejected` rotates token and replays. New SSE reads token from storage. |
| Single retry (`attempt <= 1`) | Prevents infinite loops if auth stays broken. |
| `resetStreamingState` before retry | Prevents concatenating partial content from the failed run with the new run. |

**Thread reload (no auth retry)**

When `loadThread` finds `activeExecutionId` and no pending approval/clarification:

- Calls `runStreamingLoop` **directly** (not `streamWithAuthRetry`).
- There is no originating POST to replay; reconnecting a dead execution would fail again.
- On `invalid_token`, error surfaces; user can send a new message (which goes through `streamWithAuthRetry`).

---

### 3. Rate-limit handling

```mermaid
sequenceDiagram
  participant UI as Store action
  participant API as Threads API
  participant Bubble as MessageBubble

  UI->>API: sendMessage / approve / clarify / regenerate
  API-->>UI: 429 + ErrorResponseDTO body
  UI->>UI: rateLimitMessage(err)
  UI->>UI: finalizeStreamingError(msg, isRateLimit: true)
  UI->>Bubble: message.isRateLimitError === true
  Note over Bubble: MessageFeedback hidden
```

**Pipeline**

1. REST call fails with HTTP 429.
2. `rateLimitMessage(err)` — if axios 429, `parseErrorBody(response.data)` extracts `error.message` (handles nested/stringified JSON).
3. `finalizeStreamingError(conversationId, message, set, isRateLimit: true)` — commits assistant error bubble with `isRateLimitError: true`, clears `streams[conversationId]`.
4. `MessageBubble` — `{!isUser && !message.isRateLimitError && <MessageFeedback />}` hides copy / vote / regenerate.

**Why hide feedback on rate-limit errors**

Regenerate or retry would hit the same limit immediately. Backend message is the source of truth for when the user can try again.

---

### 4. API schema sync

`sigNozAIAssistantAPI.schemas.ts` is aligned with the latest backend OpenAPI:

- Enum reordering / consolidation (`ApprovalStateDTO`, `ExecutionStateDTO`, `ClarificationFieldTypeDTO`, etc.).
- New or moved types: `MessageContextDTO`, `ErrorResponseDTO`, `CounterTypeNameDTO`, and related fields on request DTOs.

Runtime impact in this PR: `ErrorResponseDTO` used by `parseErrorBody` / `rateLimitMessage`. Other changes are type-level for existing imports.



