### PR TITLE
feat(trace-detail): add flamegraph v3 with optimized memory consumption (part 1)

### DIFF
--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -440,6 +440,17 @@ traces:
     max_depth_to_auto_expand: 5
     # Threshold below which all spans are returned without windowing.
     max_limit_to_select_all_spans: 10000
+  flamegraph:
+    # Maximum number of BFS depth levels included in a windowed response.
+    max_selected_levels: 50
+    # Maximum spans per level before sampling is applied.
+    max_spans_per_level: 100
+    # Number of highest-latency spans always included when sampling a level.
+    sampling_top_latency_count: 5
+    # Number of timestamp buckets used for uniform sampling within a level.
+    sampling_bucket_count: 50
+    # Threshold below which all spans are returned without windowing or sampling.
+    select_all_spans_limit: 100000
 
 ##################### Authz #################################
 authz:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -6541,8 +6541,6 @@ components:
           additionalProperties:
             type: string
           type: object
-        serviceName:
-          type: string
         spanId:
           type: string
         timestamp:
@@ -6569,6 +6567,9 @@ components:
           type: integer
       required:
       - spans
+      - startTimestampMillis
+      - endTimestampMillis
+      - hasMore
       type: object
     SpantypesGettableSpanMapperGroups:
       properties:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -6516,6 +6516,58 @@ components:
       - attribute
       - resource
       type: string
+    SpantypesFlamegraphSpan:
+      properties:
+        attributes:
+          additionalProperties: {}
+          type: object
+        durationNano:
+          minimum: 0
+          type: integer
+        event:
+          items:
+            $ref: '#/components/schemas/SpantypesEvent'
+          nullable: true
+          type: array
+        hasError:
+          type: boolean
+        level:
+          format: int64
+          type: integer
+        name:
+          type: string
+        parentSpanId:
+          type: string
+        resource:
+          additionalProperties:
+            type: string
+          type: object
+        serviceName:
+          type: string
+        spanId:
+          type: string
+        timestamp:
+          minimum: 0
+          type: integer
+      type: object
+    SpantypesGettableFlamegraphTrace:
+      properties:
+        endTimestampMillis:
+          format: int64
+          type: integer
+        hasMore:
+          type: boolean
+        spans:
+          items:
+            items:
+              $ref: '#/components/schemas/SpantypesFlamegraphSpan'
+            type: array
+          nullable: true
+          type: array
+        startTimestampMillis:
+          format: int64
+          type: integer
+      type: object
     SpantypesGettableSpanMapperGroups:
       properties:
         items:
@@ -6579,6 +6631,15 @@ components:
         spanId:
           type: string
         traceId:
+          type: string
+      type: object
+    SpantypesPostableFlamegraph:
+      properties:
+        selectFields:
+          items:
+            $ref: '#/components/schemas/TelemetrytypesTelemetryFieldKey'
+          type: array
+        selectedSpanId:
           type: string
       type: object
     SpantypesPostableSpanMapper:
@@ -20027,6 +20088,75 @@ paths:
       summary: Put profile in Zeus for a deployment.
       tags:
       - zeus
+  /api/v3/traces/{traceID}/flamegraph:
+    post:
+      deprecated: false
+      description: Returns the flamegraph view of spans for a given trace ID.
+      operationId: GetFlamegraph
+      parameters:
+      - in: path
+        name: traceID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SpantypesPostableFlamegraph'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: '#/components/schemas/SpantypesGettableFlamegraphTrace'
+                  status:
+                    type: string
+                required:
+                - status
+                - data
+                type: object
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Internal Server Error
+      security:
+      - api_key:
+        - VIEWER
+      - tokenizer:
+        - VIEWER
+      summary: Get flamegraph view for a trace
+      tags:
+      - tracedetail
   /api/v3/traces/{traceID}/waterfall:
     post:
       deprecated: false

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -6527,7 +6527,6 @@ components:
         event:
           items:
             $ref: '#/components/schemas/SpantypesEvent'
-          nullable: true
           type: array
         hasError:
           type: boolean
@@ -6549,6 +6548,8 @@ components:
         timestamp:
           minimum: 0
           type: integer
+      required:
+      - event
       type: object
     SpantypesGettableFlamegraphTrace:
       properties:
@@ -6562,11 +6563,12 @@ components:
             items:
               $ref: '#/components/schemas/SpantypesFlamegraphSpan'
             type: array
-          nullable: true
           type: array
         startTimestampMillis:
           format: int64
           type: integer
+      required:
+      - spans
       type: object
     SpantypesGettableSpanMapperGroups:
       properties:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -6520,6 +6520,7 @@ components:
       properties:
         attributes:
           additionalProperties: {}
+          nullable: true
           type: object
         durationNano:
           minimum: 0
@@ -6540,6 +6541,7 @@ components:
         resource:
           additionalProperties:
             type: string
+          nullable: true
           type: object
         spanId:
           type: string
@@ -6547,7 +6549,16 @@ components:
           minimum: 0
           type: integer
       required:
+      - spanId
+      - parentSpanId
+      - timestamp
+      - durationNano
+      - hasError
+      - name
+      - level
       - event
+      - attributes
+      - resource
       type: object
     SpantypesGettableFlamegraphTrace:
       properties:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -6520,7 +6520,6 @@ components:
       properties:
         attributes:
           additionalProperties: {}
-          nullable: true
           type: object
         durationNano:
           minimum: 0
@@ -6541,7 +6540,6 @@ components:
         resource:
           additionalProperties:
             type: string
-          nullable: true
           type: object
         spanId:
           type: string

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -7675,20 +7675,34 @@ export enum SpantypesFieldContextDTO {
 	attribute = 'attribute',
 	resource = 'resource',
 }
-export type SpantypesFlamegraphSpanDTOAttributes = { [key: string]: unknown };
+export type SpantypesFlamegraphSpanDTOAttributesAnyOf = {
+	[key: string]: unknown;
+};
 
-export type SpantypesFlamegraphSpanDTOResource = { [key: string]: string };
+/**
+ * @nullable
+ */
+export type SpantypesFlamegraphSpanDTOAttributes =
+	SpantypesFlamegraphSpanDTOAttributesAnyOf | null;
+
+export type SpantypesFlamegraphSpanDTOResourceAnyOf = { [key: string]: string };
+
+/**
+ * @nullable
+ */
+export type SpantypesFlamegraphSpanDTOResource =
+	SpantypesFlamegraphSpanDTOResourceAnyOf | null;
 
 export interface SpantypesFlamegraphSpanDTO {
 	/**
-	 * @type object
+	 * @type object,null
 	 */
-	attributes?: SpantypesFlamegraphSpanDTOAttributes;
+	attributes: SpantypesFlamegraphSpanDTOAttributes;
 	/**
 	 * @type integer
 	 * @minimum 0
 	 */
-	durationNano?: number;
+	durationNano: number;
 	/**
 	 * @type array
 	 */
@@ -7696,33 +7710,33 @@ export interface SpantypesFlamegraphSpanDTO {
 	/**
 	 * @type boolean
 	 */
-	hasError?: boolean;
+	hasError: boolean;
 	/**
 	 * @type integer
 	 * @format int64
 	 */
-	level?: number;
+	level: number;
 	/**
 	 * @type string
 	 */
-	name?: string;
+	name: string;
 	/**
 	 * @type string
 	 */
-	parentSpanId?: string;
+	parentSpanId: string;
 	/**
-	 * @type object
+	 * @type object,null
 	 */
-	resource?: SpantypesFlamegraphSpanDTOResource;
+	resource: SpantypesFlamegraphSpanDTOResource;
 	/**
 	 * @type string
 	 */
-	spanId?: string;
+	spanId: string;
 	/**
 	 * @type integer
 	 * @minimum 0
 	 */
-	timestamp?: number;
+	timestamp: number;
 }
 
 export interface SpantypesGettableFlamegraphTraceDTO {

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -7675,6 +7675,81 @@ export enum SpantypesFieldContextDTO {
 	attribute = 'attribute',
 	resource = 'resource',
 }
+export type SpantypesFlamegraphSpanDTOAttributes = { [key: string]: unknown };
+
+export type SpantypesFlamegraphSpanDTOResource = { [key: string]: string };
+
+export interface SpantypesFlamegraphSpanDTO {
+	/**
+	 * @type object
+	 */
+	attributes?: SpantypesFlamegraphSpanDTOAttributes;
+	/**
+	 * @type integer
+	 * @minimum 0
+	 */
+	durationNano?: number;
+	/**
+	 * @type array,null
+	 */
+	event?: SpantypesEventDTO[] | null;
+	/**
+	 * @type boolean
+	 */
+	hasError?: boolean;
+	/**
+	 * @type integer
+	 * @format int64
+	 */
+	level?: number;
+	/**
+	 * @type string
+	 */
+	name?: string;
+	/**
+	 * @type string
+	 */
+	parentSpanId?: string;
+	/**
+	 * @type object
+	 */
+	resource?: SpantypesFlamegraphSpanDTOResource;
+	/**
+	 * @type string
+	 */
+	serviceName?: string;
+	/**
+	 * @type string
+	 */
+	spanId?: string;
+	/**
+	 * @type integer
+	 * @minimum 0
+	 */
+	timestamp?: number;
+}
+
+export interface SpantypesGettableFlamegraphTraceDTO {
+	/**
+	 * @type integer
+	 * @format int64
+	 */
+	endTimestampMillis?: number;
+	/**
+	 * @type boolean
+	 */
+	hasMore?: boolean;
+	/**
+	 * @type array,null
+	 */
+	spans?: SpantypesFlamegraphSpanDTO[][] | null;
+	/**
+	 * @type integer
+	 * @format int64
+	 */
+	startTimestampMillis?: number;
+}
+
 export type SpantypesSpanMapperGroupConditionDTOAnyOf = {
 	/**
 	 * @type array,null
@@ -7974,6 +8049,17 @@ export interface SpantypesGettableWaterfallTraceDTO {
 	 * @type array,null
 	 */
 	uncollapsedSpans?: string[] | null;
+}
+
+export interface SpantypesPostableFlamegraphDTO {
+	/**
+	 * @type array
+	 */
+	selectFields?: TelemetrytypesTelemetryFieldKeyDTO[];
+	/**
+	 * @type string
+	 */
+	selectedSpanId?: string;
 }
 
 export enum SpantypesSpanMapperOperationDTO {
@@ -10271,6 +10357,17 @@ export type GetMyUser200 = {
 
 export type GetHosts200 = {
 	data: ZeustypesGettableHostDTO;
+	/**
+	 * @type string
+	 */
+	status: string;
+};
+
+export type GetFlamegraphPathParameters = {
+	traceID: string;
+};
+export type GetFlamegraph200 = {
+	data: SpantypesGettableFlamegraphTraceDTO;
 	/**
 	 * @type string
 	 */

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -7690,9 +7690,9 @@ export interface SpantypesFlamegraphSpanDTO {
 	 */
 	durationNano?: number;
 	/**
-	 * @type array,null
+	 * @type array
 	 */
-	event?: SpantypesEventDTO[] | null;
+	event: SpantypesEventDTO[];
 	/**
 	 * @type boolean
 	 */
@@ -7740,9 +7740,9 @@ export interface SpantypesGettableFlamegraphTraceDTO {
 	 */
 	hasMore?: boolean;
 	/**
-	 * @type array,null
+	 * @type array
 	 */
-	spans?: SpantypesFlamegraphSpanDTO[][] | null;
+	spans: SpantypesFlamegraphSpanDTO[][];
 	/**
 	 * @type integer
 	 * @format int64

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -7675,27 +7675,13 @@ export enum SpantypesFieldContextDTO {
 	attribute = 'attribute',
 	resource = 'resource',
 }
-export type SpantypesFlamegraphSpanDTOAttributesAnyOf = {
-	[key: string]: unknown;
-};
+export type SpantypesFlamegraphSpanDTOAttributes = { [key: string]: unknown };
 
-/**
- * @nullable
- */
-export type SpantypesFlamegraphSpanDTOAttributes =
-	SpantypesFlamegraphSpanDTOAttributesAnyOf | null;
-
-export type SpantypesFlamegraphSpanDTOResourceAnyOf = { [key: string]: string };
-
-/**
- * @nullable
- */
-export type SpantypesFlamegraphSpanDTOResource =
-	SpantypesFlamegraphSpanDTOResourceAnyOf | null;
+export type SpantypesFlamegraphSpanDTOResource = { [key: string]: string };
 
 export interface SpantypesFlamegraphSpanDTO {
 	/**
-	 * @type object,null
+	 * @type object
 	 */
 	attributes: SpantypesFlamegraphSpanDTOAttributes;
 	/**
@@ -7725,7 +7711,7 @@ export interface SpantypesFlamegraphSpanDTO {
 	 */
 	parentSpanId: string;
 	/**
-	 * @type object,null
+	 * @type object
 	 */
 	resource: SpantypesFlamegraphSpanDTOResource;
 	/**

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -7717,10 +7717,6 @@ export interface SpantypesFlamegraphSpanDTO {
 	/**
 	 * @type string
 	 */
-	serviceName?: string;
-	/**
-	 * @type string
-	 */
 	spanId?: string;
 	/**
 	 * @type integer
@@ -7734,11 +7730,11 @@ export interface SpantypesGettableFlamegraphTraceDTO {
 	 * @type integer
 	 * @format int64
 	 */
-	endTimestampMillis?: number;
+	endTimestampMillis: number;
 	/**
 	 * @type boolean
 	 */
-	hasMore?: boolean;
+	hasMore: boolean;
 	/**
 	 * @type array
 	 */
@@ -7747,7 +7743,7 @@ export interface SpantypesGettableFlamegraphTraceDTO {
 	 * @type integer
 	 * @format int64
 	 */
-	startTimestampMillis?: number;
+	startTimestampMillis: number;
 }
 
 export type SpantypesSpanMapperGroupConditionDTOAnyOf = {

--- a/frontend/src/api/generated/services/tracedetail/index.ts
+++ b/frontend/src/api/generated/services/tracedetail/index.ts
@@ -12,6 +12,8 @@ import type {
 } from 'react-query';
 
 import type {
+	GetFlamegraph200,
+	GetFlamegraphPathParameters,
 	GetTraceAggregations200,
 	GetTraceAggregationsPathParameters,
 	GetWaterfall200,
@@ -19,6 +21,7 @@ import type {
 	GetWaterfallV4200,
 	GetWaterfallV4PathParameters,
 	RenderErrorResponseDTO,
+	SpantypesPostableFlamegraphDTO,
 	SpantypesPostableTraceAggregationsDTO,
 	SpantypesPostableWaterfallDTO,
 } from '../sigNoz.schemas';
@@ -125,6 +128,105 @@ export const useGetTraceAggregations = <
 	TContext
 > => {
 	return useMutation(getGetTraceAggregationsMutationOptions(options));
+};
+/**
+ * Returns the flamegraph view of spans for a given trace ID.
+ * @summary Get flamegraph view for a trace
+ */
+export const getFlamegraph = (
+	{ traceID }: GetFlamegraphPathParameters,
+	spantypesPostableFlamegraphDTO?: BodyType<SpantypesPostableFlamegraphDTO>,
+	signal?: AbortSignal,
+) => {
+	return GeneratedAPIInstance<GetFlamegraph200>({
+		url: `/api/v3/traces/${traceID}/flamegraph`,
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		data: spantypesPostableFlamegraphDTO,
+		signal,
+	});
+};
+
+export const getGetFlamegraphMutationOptions = <
+	TError = ErrorType<RenderErrorResponseDTO>,
+	TContext = unknown,
+>(options?: {
+	mutation?: UseMutationOptions<
+		Awaited<ReturnType<typeof getFlamegraph>>,
+		TError,
+		{
+			pathParams: GetFlamegraphPathParameters;
+			data?: BodyType<SpantypesPostableFlamegraphDTO>;
+		},
+		TContext
+	>;
+}): UseMutationOptions<
+	Awaited<ReturnType<typeof getFlamegraph>>,
+	TError,
+	{
+		pathParams: GetFlamegraphPathParameters;
+		data?: BodyType<SpantypesPostableFlamegraphDTO>;
+	},
+	TContext
+> => {
+	const mutationKey = ['getFlamegraph'];
+	const { mutation: mutationOptions } = options
+		? options.mutation &&
+			'mutationKey' in options.mutation &&
+			options.mutation.mutationKey
+			? options
+			: { ...options, mutation: { ...options.mutation, mutationKey } }
+		: { mutation: { mutationKey } };
+
+	const mutationFn: MutationFunction<
+		Awaited<ReturnType<typeof getFlamegraph>>,
+		{
+			pathParams: GetFlamegraphPathParameters;
+			data?: BodyType<SpantypesPostableFlamegraphDTO>;
+		}
+	> = (props) => {
+		const { pathParams, data } = props ?? {};
+
+		return getFlamegraph(pathParams, data);
+	};
+
+	return { mutationFn, ...mutationOptions };
+};
+
+export type GetFlamegraphMutationResult = NonNullable<
+	Awaited<ReturnType<typeof getFlamegraph>>
+>;
+export type GetFlamegraphMutationBody =
+	| BodyType<SpantypesPostableFlamegraphDTO>
+	| undefined;
+export type GetFlamegraphMutationError = ErrorType<RenderErrorResponseDTO>;
+
+/**
+ * @summary Get flamegraph view for a trace
+ */
+export const useGetFlamegraph = <
+	TError = ErrorType<RenderErrorResponseDTO>,
+	TContext = unknown,
+>(options?: {
+	mutation?: UseMutationOptions<
+		Awaited<ReturnType<typeof getFlamegraph>>,
+		TError,
+		{
+			pathParams: GetFlamegraphPathParameters;
+			data?: BodyType<SpantypesPostableFlamegraphDTO>;
+		},
+		TContext
+	>;
+}): UseMutationResult<
+	Awaited<ReturnType<typeof getFlamegraph>>,
+	TError,
+	{
+		pathParams: GetFlamegraphPathParameters;
+		data?: BodyType<SpantypesPostableFlamegraphDTO>;
+	},
+	TContext
+> => {
+	return useMutation(getGetFlamegraphMutationOptions(options));
 };
 /**
  * Returns the waterfall view of spans for a given trace ID with tree structure, metadata, and windowed pagination

--- a/pkg/apiserver/signozapiserver/tracedetail.go
+++ b/pkg/apiserver/signozapiserver/tracedetail.go
@@ -67,5 +67,24 @@ func (provider *provider) addTraceDetailRoutes(router *mux.Router) error {
 		return err
 	}
 
+	if err := router.Handle("/api/v3/traces/{traceID}/flamegraph", handler.New(
+		provider.authzMiddleware.ViewAccess(provider.traceDetailHandler.GetFlamegraph),
+		handler.OpenAPIDef{
+			ID:                  "GetFlamegraph",
+			Tags:                []string{"tracedetail"},
+			Summary:             "Get flamegraph view for a trace",
+			Description:         "Returns the flamegraph view of spans for a given trace ID.",
+			Request:             new(spantypes.PostableFlamegraph),
+			RequestContentType:  "application/json",
+			Response:            new(spantypes.GettableFlamegraphTrace),
+			ResponseContentType: "application/json",
+			SuccessStatusCode:   http.StatusOK,
+			ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
+			SecuritySchemes:     newSecuritySchemes(types.RoleViewer),
+		},
+	)).Methods(http.MethodPost).GetError(); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/modules/tracedetail/config.go
+++ b/pkg/modules/tracedetail/config.go
@@ -59,24 +59,19 @@ func (c Config) Validate() error {
 		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.waterfall.max_limit_to_select_all_spans must be positive")
 	}
 	if c.Flamegraph.MaxSelectedLevels <= 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput,
-			"tracedetail.flamegraph.level_limit must be positive, got %d", c.Flamegraph.MaxSelectedLevels)
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tracedetail.flamegraph.level_limit must be positive, got %d", c.Flamegraph.MaxSelectedLevels)
 	}
 	if c.Flamegraph.MaxSpansPerLevel <= 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput,
-			"tracedetail.flamegraph.spans_per_level must be positive, got %d", c.Flamegraph.MaxSpansPerLevel)
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tracedetail.flamegraph.spans_per_level must be positive, got %d", c.Flamegraph.MaxSpansPerLevel)
 	}
 	if c.Flamegraph.SamplingTopLatencySpansCount < 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput,
-			"tracedetail.flamegraph.top_latency_count cannot be negative, got %d", c.Flamegraph.SamplingTopLatencySpansCount)
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tracedetail.flamegraph.top_latency_count cannot be negative, got %d", c.Flamegraph.SamplingTopLatencySpansCount)
 	}
 	if c.Flamegraph.SamplingBucketCount <= 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput,
-			"tracedetail.flamegraph.bucket_count must be positive, got %d", c.Flamegraph.SamplingBucketCount)
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tracedetail.flamegraph.bucket_count must be positive, got %d", c.Flamegraph.SamplingBucketCount)
 	}
 	if c.Flamegraph.SelectAllSpansLimit == 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput,
-			"tracedetail.flamegraph.max_limit_to_select_all_spans must be positive")
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tracedetail.flamegraph.max_limit_to_select_all_spans must be positive")
 	}
 	return nil
 }

--- a/pkg/modules/tracedetail/config.go
+++ b/pkg/modules/tracedetail/config.go
@@ -6,7 +6,16 @@ import (
 )
 
 type Config struct {
-	Waterfall WaterfallConfig `mapstructure:"waterfall"`
+	Waterfall  WaterfallConfig  `mapstructure:"waterfall"`
+	Flamegraph FlamegraphConfig `mapstructure:"flamegraph"`
+}
+
+type FlamegraphConfig struct {
+	MaxSelectedLevels            int  `mapstructure:"max_selected_levels"`
+	MaxSpansPerLevel             int  `mapstructure:"max_spans_per_level"`
+	SamplingTopLatencySpansCount int  `mapstructure:"sampling_top_latency_count"`
+	SamplingBucketCount          int  `mapstructure:"sampling_bucket_count"`
+	SelectAllSpansLimit          uint `mapstructure:"select_all_spans_limit"`
 }
 
 type WaterfallConfig struct {
@@ -29,6 +38,13 @@ func newConfig() factory.Config {
 			MaxDepthToAutoExpand:     5,
 			MaxLimitToSelectAllSpans: 10_000,
 		},
+		Flamegraph: FlamegraphConfig{
+			MaxSelectedLevels:            50,
+			MaxSpansPerLevel:             100,
+			SamplingTopLatencySpansCount: 5,
+			SamplingBucketCount:          50,
+			SelectAllSpansLimit:          100_000,
+		},
 	}
 }
 
@@ -41,6 +57,26 @@ func (c Config) Validate() error {
 	}
 	if c.Waterfall.MaxLimitToSelectAllSpans == 0 {
 		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.waterfall.max_limit_to_select_all_spans must be positive")
+	}
+	if c.Flamegraph.MaxSelectedLevels <= 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput,
+			"tracedetail.flamegraph.level_limit must be positive, got %d", c.Flamegraph.MaxSelectedLevels)
+	}
+	if c.Flamegraph.MaxSpansPerLevel <= 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput,
+			"tracedetail.flamegraph.spans_per_level must be positive, got %d", c.Flamegraph.MaxSpansPerLevel)
+	}
+	if c.Flamegraph.SamplingTopLatencySpansCount < 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput,
+			"tracedetail.flamegraph.top_latency_count cannot be negative, got %d", c.Flamegraph.SamplingTopLatencySpansCount)
+	}
+	if c.Flamegraph.SamplingBucketCount <= 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput,
+			"tracedetail.flamegraph.bucket_count must be positive, got %d", c.Flamegraph.SamplingBucketCount)
+	}
+	if c.Flamegraph.SelectAllSpansLimit == 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput,
+			"tracedetail.flamegraph.max_limit_to_select_all_spans must be positive")
 	}
 	return nil
 }

--- a/pkg/modules/tracedetail/impltracedetail/handler.go
+++ b/pkg/modules/tracedetail/impltracedetail/handler.go
@@ -80,3 +80,18 @@ func (h *handler) GetTraceAggregations(rw http.ResponseWriter, r *http.Request) 
 
 	render.Success(rw, http.StatusOK, result)
 }
+
+func (h *handler) GetFlamegraph(rw http.ResponseWriter, r *http.Request) {
+	req := new(spantypes.PostableFlamegraph)
+	if err := binding.JSON.BindBody(r.Body, req); err != nil {
+		render.Error(rw, err)
+		return
+	}
+	result, err := h.module.GetFlamegraph(r.Context(), mux.Vars(r)["traceID"], req)
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	render.Success(rw, http.StatusOK, result)
+}

--- a/pkg/modules/tracedetail/impltracedetail/handler.go
+++ b/pkg/modules/tracedetail/impltracedetail/handler.go
@@ -87,6 +87,7 @@ func (h *handler) GetFlamegraph(rw http.ResponseWriter, r *http.Request) {
 		render.Error(rw, err)
 		return
 	}
+
 	result, err := h.module.GetFlamegraph(r.Context(), mux.Vars(r)["traceID"], req)
 	if err != nil {
 		render.Error(rw, err)

--- a/pkg/modules/tracedetail/impltracedetail/handler.go
+++ b/pkg/modules/tracedetail/impltracedetail/handler.go
@@ -88,7 +88,7 @@ func (h *handler) GetFlamegraph(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.module.GetFlamegraph(r.Context(), mux.Vars(r)["traceID"], req.SelectedSpanID)
+	result, err := h.module.GetFlamegraph(r.Context(), mux.Vars(r)["traceID"], req.SelectedSpanID, req.SelectFields)
 	if err != nil {
 		render.Error(rw, err)
 		return

--- a/pkg/modules/tracedetail/impltracedetail/handler.go
+++ b/pkg/modules/tracedetail/impltracedetail/handler.go
@@ -88,7 +88,7 @@ func (h *handler) GetFlamegraph(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.module.GetFlamegraph(r.Context(), mux.Vars(r)["traceID"], req)
+	result, err := h.module.GetFlamegraph(r.Context(), mux.Vars(r)["traceID"], req.SelectedSpanID)
 	if err != nil {
 		render.Error(rw, err)
 		return

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -78,17 +78,6 @@ func (m *module) GetWaterfallV4(ctx context.Context, traceID string, selectedSpa
 	return m.getFullWaterfall(ctx, traceID, summary)
 }
 
-func (m *module) GetFlamegraph(ctx context.Context, traceID string, req *spantypes.PostableFlamegraph) (*spantypes.GettableFlamegraphTrace, error) {
-	summary, err := m.store.GetTraceSummary(ctx, traceID)
-	if err != nil {
-		return nil, err
-	}
-	if summary.NumSpans <= uint64(m.config.Flamegraph.SelectAllSpansLimit) {
-		return m.getFullFlamegraph(ctx, traceID, summary)
-	}
-	return m.getWindowedFlamegraph(ctx, traceID, req.SelectedSpanID, summary)
-}
-
 func (m *module) GetTraceAggregations(ctx context.Context, traceID string, req *spantypes.PostableTraceAggregations) (*spantypes.GettableTraceAggregations, error) {
 	summary, err := m.store.GetTraceSummary(ctx, traceID)
 	if err != nil {
@@ -129,6 +118,17 @@ func (m *module) GetTraceAggregations(ctx context.Context, traceID string, req *
 		results = append(results, result)
 	}
 	return &spantypes.GettableTraceAggregations{Aggregations: results}, nil
+}
+
+func (m *module) GetFlamegraph(ctx context.Context, traceID string, req *spantypes.PostableFlamegraph) (*spantypes.GettableFlamegraphTrace, error) {
+	summary, err := m.store.GetTraceSummary(ctx, traceID)
+	if err != nil {
+		return nil, err
+	}
+	if summary.NumSpans <= uint64(m.config.Flamegraph.SelectAllSpansLimit) {
+		return m.getFullFlamegraph(ctx, traceID, summary)
+	}
+	return m.getWindowedFlamegraph(ctx, traceID, req.SelectedSpanID, summary)
 }
 
 // getTraceData fetches all spans for a trace and builds the WaterfallTrace.

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -121,12 +121,22 @@ func (m *module) getFullWaterfall(ctx context.Context, traceID string, summary *
 	return spantypes.NewGettableWaterfallTrace(waterfallTrace, selectedSpans, nil, true, nil), nil
 }
 
+func (m *module) GetFlamegraph(ctx context.Context, traceID string, req *spantypes.PostableFlamegraph) (*spantypes.GettableFlamegraphTrace, error) {
+	summary, err := m.store.GetTraceSummary(ctx, traceID)
+	if err != nil {
+		return nil, err
+	}
+	if summary.NumSpans <= uint64(m.config.Flamegraph.SelectAllSpansLimit) {
+		return m.getFullFlamegraph(ctx, traceID, summary)
+	}
+	return m.getWindowedFlamegraph(ctx, traceID, req.SelectedSpanID, summary)
+}
+
 func (m *module) GetTraceAggregations(ctx context.Context, traceID string, req *spantypes.PostableTraceAggregations) (*spantypes.GettableTraceAggregations, error) {
 	summary, err := m.store.GetTraceSummary(ctx, traceID)
 	if err != nil {
 		return nil, err
 	}
-
 	traceDurationNs := uint64(summary.End.UnixNano()) - uint64(summary.Start.UnixNano())
 
 	results := make([]spantypes.SpanAggregationResult, 0, len(req.Aggregations))
@@ -164,12 +174,24 @@ func (m *module) GetTraceAggregations(ctx context.Context, traceID string, req *
 	return &spantypes.GettableTraceAggregations{Aggregations: results}, nil
 }
 
-func (m *module) GetFlamegraph(ctx context.Context, traceID string, req *spantypes.PostableFlamegraph) (*spantypes.GettableFlamegraphTrace, error) {
-	summary, err := m.store.GetTraceSummary(ctx, traceID)
+// Step 1: fetch minimal spans → BFS tree → window selection
+func (m *module) getFullFlamegraph(ctx context.Context, traceID string, summary *spantypes.TraceSummary) (*spantypes.GettableFlamegraphTrace, error) {
+	fullSpans, err := m.store.GetTraceSpans(ctx, traceID, summary)
 	if err != nil {
 		return nil, err
 	}
-	// Step 1: fetch minimal spans → BFS tree → window selection
+	if len(fullSpans) == 0 {
+		return nil, spantypes.ErrTraceNotFound
+	}
+	flamegraphTrace := spantypes.NewFlamegraphTraceFromStorable(fullSpans)
+	return spantypes.NewGettableFlamegraphTrace(
+		flamegraphTrace.GetAllLevels(),
+		summary.Start.UnixMilli(), summary.End.UnixMilli(), false,
+	), nil
+}
+
+// getWindowedFlamegraph returns a window of a max levels and max sampled spans per level around the selected span
+func (m *module) getWindowedFlamegraph(ctx context.Context, traceID, selectedSpanID string, summary *spantypes.TraceSummary) (*spantypes.GettableFlamegraphTrace, error) {
 	minimalSpans, err := m.store.GetMinimalSpans(ctx, traceID, summary.Start, summary.End)
 	if err != nil {
 		return nil, err
@@ -182,21 +204,22 @@ func (m *module) GetFlamegraph(ctx context.Context, traceID string, req *spantyp
 	minimalSpans = nil
 
 	cfg := m.config.Flamegraph
-	selectedSpans, hasMore := flamegraphTrace.GetSelectedSpans(req.SelectedSpanID, cfg.SelectAllSpansLimit,
+	selectedSpans := flamegraphTrace.GetSelectedLevels(selectedSpanID,
 		cfg.MaxSelectedLevels, cfg.MaxSpansPerLevel, cfg.SamplingTopLatencySpansCount, cfg.SamplingBucketCount)
 	if len(selectedSpans) == 0 {
 		return nil, spantypes.ErrTraceNotFound
 	}
 
-	// Step 2: fetch full data for selected spans
 	fullSpans, err := m.store.GetTraceSpansByIDs(ctx, traceID, summary.Start, summary.End,
 		spantypes.FlamegraphWindowSpanIDs(selectedSpans))
 	if err != nil {
 		return nil, err
 	}
 
-	resultSpans := flamegraphTrace.EnrichWindow(selectedSpans, fullSpans)
-	return spantypes.NewGettableFlamegraphTrace(resultSpans, summary.Start.UnixMilli(), summary.End.UnixMilli(), hasMore), nil
+	return spantypes.NewGettableFlamegraphTrace(
+		flamegraphTrace.EnrichSelectedSpans(selectedSpans, fullSpans),
+		summary.Start.UnixMilli(), summary.End.UnixMilli(), true,
+	), nil
 }
 
 // getWindowedWaterfall builds the waterfall tree with minimal data and then returns only a window of full spans.

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -59,29 +59,6 @@ func (m *module) GetWaterfall(ctx context.Context, traceID string, req *spantype
 	return spantypes.NewGettableWaterfallTrace(waterfallTrace, selectedSpans, uncollapsedSpans, selectedAllSpans, aggregationResults), nil
 }
 
-// getTraceData fetches all spans for a trace and builds the WaterfallTrace.
-func (m *module) getTraceData(ctx context.Context, traceID string) (*spantypes.WaterfallTrace, error) {
-	summary, err := m.store.GetTraceSummary(ctx, traceID)
-	if err != nil {
-		return nil, err
-	}
-
-	spanItems, err := m.store.GetTraceSpans(ctx, traceID, summary)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(spanItems) == 0 {
-		return nil, spantypes.ErrTraceNotFound
-	}
-
-	nodes := make([]*spantypes.WaterfallSpan, len(spanItems))
-	for i := range spanItems {
-		nodes[i] = spanItems[i].ToWaterfallSpan(traceID)
-	}
-	return spantypes.NewWaterfallTraceFromSpans(nodes), nil
-}
-
 // GetWaterfallV4 is the OOM-safe V4 waterfall.
 // For large traces (NumSpans > effectiveLimit) it uses a two-step fetch:
 // minimal fields for all spans to build the tree, then full fields for the
@@ -99,26 +76,6 @@ func (m *module) GetWaterfallV4(ctx context.Context, traceID string, selectedSpa
 		return m.getWindowedWaterfall(ctx, traceID, selectedSpanID, uncollapsedSpans, summary.Start, summary.End)
 	}
 	return m.getFullWaterfall(ctx, traceID, summary)
-}
-
-func (m *module) getFullWaterfall(ctx context.Context, traceID string, summary *spantypes.TraceSummary) (*spantypes.GettableWaterfallTrace, error) {
-	spanItems, err := m.store.GetTraceSpans(ctx, traceID, summary)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(spanItems) == 0 {
-		return nil, spantypes.ErrTraceNotFound
-	}
-
-	nodes := make([]*spantypes.WaterfallSpan, len(spanItems))
-	for i := range spanItems {
-		nodes[i] = spanItems[i].ToWaterfallSpan(traceID)
-	}
-	waterfallTrace := spantypes.NewWaterfallTraceFromSpans(nodes)
-	selectedSpans := waterfallTrace.GetAllSpans()
-
-	return spantypes.NewGettableWaterfallTrace(waterfallTrace, selectedSpans, nil, true, nil), nil
 }
 
 func (m *module) GetFlamegraph(ctx context.Context, traceID string, req *spantypes.PostableFlamegraph) (*spantypes.GettableFlamegraphTrace, error) {
@@ -174,52 +131,47 @@ func (m *module) GetTraceAggregations(ctx context.Context, traceID string, req *
 	return &spantypes.GettableTraceAggregations{Aggregations: results}, nil
 }
 
-// Step 1: fetch minimal spans → BFS tree → window selection
-func (m *module) getFullFlamegraph(ctx context.Context, traceID string, summary *spantypes.TraceSummary) (*spantypes.GettableFlamegraphTrace, error) {
-	fullSpans, err := m.store.GetTraceSpans(ctx, traceID, summary)
+// getTraceData fetches all spans for a trace and builds the WaterfallTrace.
+func (m *module) getTraceData(ctx context.Context, traceID string) (*spantypes.WaterfallTrace, error) {
+	summary, err := m.store.GetTraceSummary(ctx, traceID)
 	if err != nil {
 		return nil, err
 	}
-	if len(fullSpans) == 0 {
+
+	spanItems, err := m.store.GetTraceSpans(ctx, traceID, summary)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(spanItems) == 0 {
 		return nil, spantypes.ErrTraceNotFound
 	}
-	flamegraphTrace := spantypes.NewFlamegraphTraceFromStorable(fullSpans)
-	return spantypes.NewGettableFlamegraphTrace(
-		flamegraphTrace.GetAllLevels(),
-		summary.Start.UnixMilli(), summary.End.UnixMilli(), false,
-	), nil
+
+	nodes := make([]*spantypes.WaterfallSpan, len(spanItems))
+	for i := range spanItems {
+		nodes[i] = spanItems[i].ToWaterfallSpan(traceID)
+	}
+	return spantypes.NewWaterfallTraceFromSpans(nodes), nil
 }
 
-// getWindowedFlamegraph returns a window of a max levels and max sampled spans per level around the selected span
-func (m *module) getWindowedFlamegraph(ctx context.Context, traceID, selectedSpanID string, summary *spantypes.TraceSummary) (*spantypes.GettableFlamegraphTrace, error) {
-	minimalSpans, err := m.store.GetMinimalSpans(ctx, traceID, summary.Start, summary.End)
-	if err != nil {
-		return nil, err
-	}
-	if len(minimalSpans) == 0 {
-		return nil, spantypes.ErrTraceNotFound
-	}
-
-	flamegraphTrace := spantypes.NewFlamegraphTraceFromMinimal(minimalSpans)
-	minimalSpans = nil
-
-	cfg := m.config.Flamegraph
-	selectedSpans := flamegraphTrace.GetSelectedLevels(selectedSpanID,
-		cfg.MaxSelectedLevels, cfg.MaxSpansPerLevel, cfg.SamplingTopLatencySpansCount, cfg.SamplingBucketCount)
-	if len(selectedSpans) == 0 {
-		return nil, spantypes.ErrTraceNotFound
-	}
-
-	fullSpans, err := m.store.GetTraceSpansByIDs(ctx, traceID, summary.Start, summary.End,
-		spantypes.FlamegraphWindowSpanIDs(selectedSpans))
+func (m *module) getFullWaterfall(ctx context.Context, traceID string, summary *spantypes.TraceSummary) (*spantypes.GettableWaterfallTrace, error) {
+	spanItems, err := m.store.GetTraceSpans(ctx, traceID, summary)
 	if err != nil {
 		return nil, err
 	}
 
-	return spantypes.NewGettableFlamegraphTrace(
-		flamegraphTrace.EnrichSelectedSpans(selectedSpans, fullSpans),
-		summary.Start.UnixMilli(), summary.End.UnixMilli(), true,
-	), nil
+	if len(spanItems) == 0 {
+		return nil, spantypes.ErrTraceNotFound
+	}
+
+	nodes := make([]*spantypes.WaterfallSpan, len(spanItems))
+	for i := range spanItems {
+		nodes[i] = spanItems[i].ToWaterfallSpan(traceID)
+	}
+	waterfallTrace := spantypes.NewWaterfallTraceFromSpans(nodes)
+	selectedSpans := waterfallTrace.GetAllSpans()
+
+	return spantypes.NewGettableWaterfallTrace(waterfallTrace, selectedSpans, nil, true, nil), nil
 }
 
 // getWindowedWaterfall builds the waterfall tree with minimal data and then returns only a window of full spans.
@@ -260,5 +212,52 @@ func (m *module) getWindowedWaterfall(ctx context.Context, traceID, selectedSpan
 
 	return spantypes.NewGettableWaterfallTrace(
 		waterfallTrace, selectedSpans, uncollapsedSpans, false, nil,
+	), nil
+}
+
+func (m *module) getFullFlamegraph(ctx context.Context, traceID string, summary *spantypes.TraceSummary) (*spantypes.GettableFlamegraphTrace, error) {
+	fullSpans, err := m.store.GetTraceSpans(ctx, traceID, summary)
+	if err != nil {
+		return nil, err
+	}
+	if len(fullSpans) == 0 {
+		return nil, spantypes.ErrTraceNotFound
+	}
+	flamegraphTrace := spantypes.NewFlamegraphTraceFromStorable(fullSpans)
+	return spantypes.NewGettableFlamegraphTrace(
+		flamegraphTrace.GetAllLevels(),
+		summary.Start.UnixMilli(), summary.End.UnixMilli(), false,
+	), nil
+}
+
+// getWindowedFlamegraph returns a window of a max levels and max sampled spans per level around the selected span.
+func (m *module) getWindowedFlamegraph(ctx context.Context, traceID, selectedSpanID string, summary *spantypes.TraceSummary) (*spantypes.GettableFlamegraphTrace, error) {
+	minimalSpans, err := m.store.GetMinimalSpans(ctx, traceID, summary.Start, summary.End)
+	if err != nil {
+		return nil, err
+	}
+	if len(minimalSpans) == 0 {
+		return nil, spantypes.ErrTraceNotFound
+	}
+
+	flamegraphTrace := spantypes.NewFlamegraphTraceFromMinimal(minimalSpans)
+	minimalSpans = nil //nolint:ineffassign // release backing array before further db calls
+
+	cfg := m.config.Flamegraph
+	selectedSpans := flamegraphTrace.GetSelectedLevels(selectedSpanID,
+		cfg.MaxSelectedLevels, cfg.MaxSpansPerLevel, cfg.SamplingTopLatencySpansCount, cfg.SamplingBucketCount)
+	if len(selectedSpans) == 0 {
+		return nil, spantypes.ErrTraceNotFound
+	}
+
+	fullSpans, err := m.store.GetTraceSpansByIDs(ctx, traceID, summary.Start, summary.End,
+		spantypes.FlamegraphWindowSpanIDs(selectedSpans))
+	if err != nil {
+		return nil, err
+	}
+
+	return spantypes.NewGettableFlamegraphTrace(
+		flamegraphTrace.EnrichSelectedSpans(selectedSpans, fullSpans),
+		summary.Start.UnixMilli(), summary.End.UnixMilli(), true,
 	), nil
 }

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -59,6 +59,29 @@ func (m *module) GetWaterfall(ctx context.Context, traceID string, req *spantype
 	return spantypes.NewGettableWaterfallTrace(waterfallTrace, selectedSpans, uncollapsedSpans, selectedAllSpans, aggregationResults), nil
 }
 
+// getTraceData fetches all spans for a trace and builds the WaterfallTrace.
+func (m *module) getTraceData(ctx context.Context, traceID string) (*spantypes.WaterfallTrace, error) {
+	summary, err := m.store.GetTraceSummary(ctx, traceID)
+	if err != nil {
+		return nil, err
+	}
+
+	spanItems, err := m.store.GetTraceSpans(ctx, traceID, summary)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(spanItems) == 0 {
+		return nil, spantypes.ErrTraceNotFound
+	}
+
+	nodes := make([]*spantypes.WaterfallSpan, len(spanItems))
+	for i := range spanItems {
+		nodes[i] = spanItems[i].ToWaterfallSpan(traceID)
+	}
+	return spantypes.NewWaterfallTraceFromSpans(nodes), nil
+}
+
 // GetWaterfallV4 is the OOM-safe V4 waterfall.
 // For large traces (NumSpans > effectiveLimit) it uses a two-step fetch:
 // minimal fields for all spans to build the tree, then full fields for the
@@ -78,11 +101,32 @@ func (m *module) GetWaterfallV4(ctx context.Context, traceID string, selectedSpa
 	return m.getFullWaterfall(ctx, traceID, summary)
 }
 
+func (m *module) getFullWaterfall(ctx context.Context, traceID string, summary *spantypes.TraceSummary) (*spantypes.GettableWaterfallTrace, error) {
+	spanItems, err := m.store.GetTraceSpans(ctx, traceID, summary)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(spanItems) == 0 {
+		return nil, spantypes.ErrTraceNotFound
+	}
+
+	nodes := make([]*spantypes.WaterfallSpan, len(spanItems))
+	for i := range spanItems {
+		nodes[i] = spanItems[i].ToWaterfallSpan(traceID)
+	}
+	waterfallTrace := spantypes.NewWaterfallTraceFromSpans(nodes)
+	selectedSpans := waterfallTrace.GetAllSpans()
+
+	return spantypes.NewGettableWaterfallTrace(waterfallTrace, selectedSpans, nil, true, nil), nil
+}
+
 func (m *module) GetTraceAggregations(ctx context.Context, traceID string, req *spantypes.PostableTraceAggregations) (*spantypes.GettableTraceAggregations, error) {
 	summary, err := m.store.GetTraceSummary(ctx, traceID)
 	if err != nil {
 		return nil, err
 	}
+
 	traceDurationNs := uint64(summary.End.UnixNano()) - uint64(summary.Start.UnixNano())
 
 	results := make([]spantypes.SpanAggregationResult, 0, len(req.Aggregations))
@@ -129,49 +173,6 @@ func (m *module) GetFlamegraph(ctx context.Context, traceID string, req *spantyp
 		return m.getFullFlamegraph(ctx, traceID, summary)
 	}
 	return m.getWindowedFlamegraph(ctx, traceID, req.SelectedSpanID, summary)
-}
-
-// getTraceData fetches all spans for a trace and builds the WaterfallTrace.
-func (m *module) getTraceData(ctx context.Context, traceID string) (*spantypes.WaterfallTrace, error) {
-	summary, err := m.store.GetTraceSummary(ctx, traceID)
-	if err != nil {
-		return nil, err
-	}
-
-	spanItems, err := m.store.GetTraceSpans(ctx, traceID, summary)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(spanItems) == 0 {
-		return nil, spantypes.ErrTraceNotFound
-	}
-
-	nodes := make([]*spantypes.WaterfallSpan, len(spanItems))
-	for i := range spanItems {
-		nodes[i] = spanItems[i].ToWaterfallSpan(traceID)
-	}
-	return spantypes.NewWaterfallTraceFromSpans(nodes), nil
-}
-
-func (m *module) getFullWaterfall(ctx context.Context, traceID string, summary *spantypes.TraceSummary) (*spantypes.GettableWaterfallTrace, error) {
-	spanItems, err := m.store.GetTraceSpans(ctx, traceID, summary)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(spanItems) == 0 {
-		return nil, spantypes.ErrTraceNotFound
-	}
-
-	nodes := make([]*spantypes.WaterfallSpan, len(spanItems))
-	for i := range spanItems {
-		nodes[i] = spanItems[i].ToWaterfallSpan(traceID)
-	}
-	waterfallTrace := spantypes.NewWaterfallTraceFromSpans(nodes)
-	selectedSpans := waterfallTrace.GetAllSpans()
-
-	return spantypes.NewGettableWaterfallTrace(waterfallTrace, selectedSpans, nil, true, nil), nil
 }
 
 // getWindowedWaterfall builds the waterfall tree with minimal data and then returns only a window of full spans.

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -164,6 +164,41 @@ func (m *module) GetTraceAggregations(ctx context.Context, traceID string, req *
 	return &spantypes.GettableTraceAggregations{Aggregations: results}, nil
 }
 
+func (m *module) GetFlamegraph(ctx context.Context, traceID string, req *spantypes.PostableFlamegraph) (*spantypes.GettableFlamegraphTrace, error) {
+	summary, err := m.store.GetTraceSummary(ctx, traceID)
+	if err != nil {
+		return nil, err
+	}
+	// Step 1: fetch minimal spans → BFS tree → window selection
+	minimalSpans, err := m.store.GetMinimalSpans(ctx, traceID, summary.Start, summary.End)
+	if err != nil {
+		return nil, err
+	}
+	if len(minimalSpans) == 0 {
+		return nil, spantypes.ErrTraceNotFound
+	}
+
+	flamegraphTrace := spantypes.NewFlamegraphTraceFromMinimal(minimalSpans)
+	minimalSpans = nil
+
+	cfg := m.config.Flamegraph
+	selectedSpans, hasMore := flamegraphTrace.GetSelectedSpans(req.SelectedSpanID, cfg.SelectAllSpansLimit,
+		cfg.MaxSelectedLevels, cfg.MaxSpansPerLevel, cfg.SamplingTopLatencySpansCount, cfg.SamplingBucketCount)
+	if len(selectedSpans) == 0 {
+		return nil, spantypes.ErrTraceNotFound
+	}
+
+	// Step 2: fetch full data for selected spans
+	fullSpans, err := m.store.GetTraceSpansByIDs(ctx, traceID, summary.Start, summary.End,
+		spantypes.FlamegraphWindowSpanIDs(selectedSpans))
+	if err != nil {
+		return nil, err
+	}
+
+	resultSpans := flamegraphTrace.EnrichWindow(selectedSpans, fullSpans)
+	return spantypes.NewGettableFlamegraphTrace(resultSpans, summary.Start.UnixMilli(), summary.End.UnixMilli(), hasMore), nil
+}
+
 // getWindowedWaterfall builds the waterfall tree with minimal data and then returns only a window of full spans.
 func (m *module) getWindowedWaterfall(ctx context.Context, traceID, selectedSpanID string, uncollapsedSpans []string, start, end time.Time) (*spantypes.GettableWaterfallTrace, error) {
 	// Step 1: minimal fetch → build full tree → select visible window

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -164,7 +164,7 @@ func (m *module) GetTraceAggregations(ctx context.Context, traceID string, req *
 	return &spantypes.GettableTraceAggregations{Aggregations: results}, nil
 }
 
-func (m *module) GetFlamegraph(ctx context.Context, traceID string, req *spantypes.PostableFlamegraph) (*spantypes.GettableFlamegraphTrace, error) {
+func (m *module) GetFlamegraph(ctx context.Context, traceID string, selectedSpanID string) (*spantypes.GettableFlamegraphTrace, error) {
 	summary, err := m.store.GetTraceSummary(ctx, traceID)
 	if err != nil {
 		return nil, err
@@ -172,7 +172,7 @@ func (m *module) GetFlamegraph(ctx context.Context, traceID string, req *spantyp
 	if summary.NumSpans <= uint64(m.config.Flamegraph.SelectAllSpansLimit) {
 		return m.getFullFlamegraph(ctx, traceID, summary)
 	}
-	return m.getWindowedFlamegraph(ctx, traceID, req.SelectedSpanID, summary)
+	return m.getWindowedFlamegraph(ctx, traceID, selectedSpanID, summary)
 }
 
 // getWindowedWaterfall builds the waterfall tree with minimal data and then returns only a window of full spans.
@@ -225,10 +225,7 @@ func (m *module) getFullFlamegraph(ctx context.Context, traceID string, summary 
 		return nil, spantypes.ErrTraceNotFound
 	}
 	flamegraphTrace := spantypes.NewFlamegraphTraceFromStorable(fullSpans)
-	return spantypes.NewGettableFlamegraphTrace(
-		flamegraphTrace.GetAllLevels(),
-		summary.Start.UnixMilli(), summary.End.UnixMilli(), false,
-	), nil
+	return spantypes.NewGettableFlamegraphTrace(flamegraphTrace.GetAllLevels(), summary.Start.UnixMilli(), summary.End.UnixMilli(), false), nil
 }
 
 // getWindowedFlamegraph returns a window of a max levels and max sampled spans per level around the selected span.
@@ -245,8 +242,7 @@ func (m *module) getWindowedFlamegraph(ctx context.Context, traceID, selectedSpa
 	minimalSpans = nil //nolint:ineffassign,wastedassign // release backing array before further db calls
 
 	cfg := m.config.Flamegraph
-	selectedSpans := flamegraphTrace.GetSelectedLevels(selectedSpanID,
-		cfg.MaxSelectedLevels, cfg.MaxSpansPerLevel, cfg.SamplingTopLatencySpansCount, cfg.SamplingBucketCount)
+	selectedSpans := flamegraphTrace.GetSelectedLevels(selectedSpanID, cfg.MaxSelectedLevels, cfg.MaxSpansPerLevel, cfg.SamplingTopLatencySpansCount, cfg.SamplingBucketCount)
 	if len(selectedSpans) == 0 {
 		return nil, spantypes.ErrTraceNotFound
 	}
@@ -259,6 +255,8 @@ func (m *module) getWindowedFlamegraph(ctx context.Context, traceID, selectedSpa
 
 	return spantypes.NewGettableFlamegraphTrace(
 		flamegraphTrace.EnrichSelectedSpans(selectedSpans, fullSpans),
-		summary.Start.UnixMilli(), summary.End.UnixMilli(), true,
+		summary.Start.UnixMilli(),
+		summary.End.UnixMilli(),
+		true,
 	), nil
 }

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/modules/tracedetail"
 	"github.com/SigNoz/signoz/pkg/types/spantypes"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"go.opentelemetry.io/otel/metric"
 )
 
@@ -164,15 +165,15 @@ func (m *module) GetTraceAggregations(ctx context.Context, traceID string, req *
 	return &spantypes.GettableTraceAggregations{Aggregations: results}, nil
 }
 
-func (m *module) GetFlamegraph(ctx context.Context, traceID string, selectedSpanID string) (*spantypes.GettableFlamegraphTrace, error) {
+func (m *module) GetFlamegraph(ctx context.Context, traceID string, selectedSpanID string, selectFields []telemetrytypes.TelemetryFieldKey) (*spantypes.GettableFlamegraphTrace, error) {
 	summary, err := m.store.GetTraceSummary(ctx, traceID)
 	if err != nil {
 		return nil, err
 	}
 	if summary.NumSpans <= uint64(m.config.Flamegraph.SelectAllSpansLimit) {
-		return m.getFullFlamegraph(ctx, traceID, summary)
+		return m.getFullFlamegraph(ctx, traceID, summary, selectFields)
 	}
-	return m.getWindowedFlamegraph(ctx, traceID, selectedSpanID, summary)
+	return m.getWindowedFlamegraph(ctx, traceID, selectedSpanID, summary, selectFields)
 }
 
 // getWindowedWaterfall builds the waterfall tree with minimal data and then returns only a window of full spans.
@@ -216,20 +217,20 @@ func (m *module) getWindowedWaterfall(ctx context.Context, traceID, selectedSpan
 	), nil
 }
 
-func (m *module) getFullFlamegraph(ctx context.Context, traceID string, summary *spantypes.TraceSummary) (*spantypes.GettableFlamegraphTrace, error) {
-	fullSpans, err := m.store.GetTraceSpans(ctx, traceID, summary)
+func (m *module) getFullFlamegraph(ctx context.Context, traceID string, summary *spantypes.TraceSummary, selectFields []telemetrytypes.TelemetryFieldKey) (*spantypes.GettableFlamegraphTrace, error) {
+	fullSpans, err := m.store.GetFlamegraphSpans(ctx, traceID, summary.Start, summary.End, nil)
 	if err != nil {
 		return nil, err
 	}
 	if len(fullSpans) == 0 {
 		return nil, spantypes.ErrTraceNotFound
 	}
-	flamegraphTrace := spantypes.NewFlamegraphTraceFromStorable(fullSpans)
+	flamegraphTrace := spantypes.NewFlamegraphTraceFromStorable(fullSpans, selectFields)
 	return spantypes.NewGettableFlamegraphTrace(flamegraphTrace.GetAllLevels(), summary.Start.UnixMilli(), summary.End.UnixMilli(), false), nil
 }
 
 // getWindowedFlamegraph returns a window of a max levels and max sampled spans per level around the selected span.
-func (m *module) getWindowedFlamegraph(ctx context.Context, traceID, selectedSpanID string, summary *spantypes.TraceSummary) (*spantypes.GettableFlamegraphTrace, error) {
+func (m *module) getWindowedFlamegraph(ctx context.Context, traceID, selectedSpanID string, summary *spantypes.TraceSummary, selectFields []telemetrytypes.TelemetryFieldKey) (*spantypes.GettableFlamegraphTrace, error) {
 	minimalSpans, err := m.store.GetMinimalSpans(ctx, traceID, summary.Start, summary.End)
 	if err != nil {
 		return nil, err
@@ -247,14 +248,13 @@ func (m *module) getWindowedFlamegraph(ctx context.Context, traceID, selectedSpa
 		return nil, spantypes.ErrTraceNotFound
 	}
 
-	fullSpans, err := m.store.GetTraceSpansByIDs(ctx, traceID, summary.Start, summary.End,
-		spantypes.FlamegraphWindowSpanIDs(selectedSpans))
+	fullSpans, err := m.store.GetFlamegraphSpans(ctx, traceID, summary.Start, summary.End, spantypes.FlamegraphWindowSpanIDs(selectedSpans))
 	if err != nil {
 		return nil, err
 	}
 
 	return spantypes.NewGettableFlamegraphTrace(
-		flamegraphTrace.EnrichSelectedSpans(selectedSpans, fullSpans),
+		flamegraphTrace.EnrichSelectedSpans(selectedSpans, fullSpans, selectFields),
 		summary.Start.UnixMilli(),
 		summary.End.UnixMilli(),
 		true,

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -241,7 +241,7 @@ func (m *module) getWindowedFlamegraph(ctx context.Context, traceID, selectedSpa
 	}
 
 	flamegraphTrace := spantypes.NewFlamegraphTraceFromMinimal(minimalSpans)
-	minimalSpans = nil //nolint:ineffassign // release backing array before further db calls
+	minimalSpans = nil //nolint:ineffassign,wastedassign // release backing array before further db calls
 
 	cfg := m.config.Flamegraph
 	selectedSpans := flamegraphTrace.GetSelectedLevels(selectedSpanID,

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -162,7 +162,6 @@ func (s *traceStore) GetFlamegraphSpans(ctx context.Context, traceID string, sta
 		"any(timestamp) AS timestamp",
 		"any(duration_nano) AS duration_nano",
 		"any(has_error) AS has_error",
-		fmt.Sprintf("any(%s) AS %s", colServiceName, colServiceName),
 		"any(name) AS name",
 		"any(events) AS events",
 		"any(attributes_string) AS attributes_string",

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -154,6 +154,38 @@ func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, sta
 	return spans, nil
 }
 
+func (s *traceStore) GetFlamegraphSpans(ctx context.Context, traceID string, start, end time.Time, spanIDs []string) ([]spantypes.StorableSpan, error) {
+	sb := sqlbuilder.NewSelectBuilder()
+	sb.Select(
+		"DISTINCT ON (span_id) span_id",
+		"parent_span_id", "timestamp", "duration_nano", "has_error", "name", "events",
+		"attributes_string", "attributes_number", "attributes_bool", "resources_string",
+	)
+	sb.From(fmt.Sprintf("%s.%s", spantypes.TraceDB, spantypes.TraceTable))
+	conditions := []string{
+		sb.E("trace_id", traceID),
+		sb.GE("ts_bucket_start", start.Unix()-1800),
+		sb.LE("ts_bucket_start", end.Unix()),
+	}
+	if len(spanIDs) > 0 {
+		ids := make([]any, len(spanIDs))
+		for i, id := range spanIDs {
+			ids[i] = id
+		}
+		conditions = append(conditions, sb.In("span_id", ids...))
+	}
+	sb.Where(conditions...)
+	sb.OrderByAsc("timestamp")
+	sb.OrderByAsc("name")
+	query, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+
+	var spans []spantypes.StorableSpan
+	if err := s.telemetryStore.ClickhouseDB().Select(ctx, &spans, query, args...); err != nil {
+		return nil, errors.WrapInternalf(err, errors.CodeInternal, "error querying flamegraph spans")
+	}
+	return spans, nil
+}
+
 func (s *traceStore) GetSpanCountByField(ctx context.Context, traceID string, summary *spantypes.TraceSummary, fieldKey telemetrytypes.TelemetryFieldKey) (map[string]uint64, error) {
 	fieldExpr, err := buildFieldExpr(fieldKey)
 	if err != nil {

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -184,7 +184,8 @@ func (s *traceStore) GetFlamegraphSpans(ctx context.Context, traceID string, sta
 	}
 	sb.Where(conditions...)
 	sb.GroupBy("span_id")
-	sb.OrderBy("timestamp ASC", "name ASC")
+	sb.OrderByAsc("timestamp")
+	sb.OrderByAsc("name")
 	query, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
 
 	var spans []spantypes.StorableSpan

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -184,7 +184,7 @@ func (s *traceStore) GetFlamegraphSpans(ctx context.Context, traceID string, sta
 	}
 	sb.Where(conditions...)
 	sb.GroupBy("span_id")
-	sb.OrderBy("any(timestamp) ASC", "any(name) ASC")
+	sb.OrderBy("timestamp ASC", "name ASC")
 	query, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
 
 	var spans []spantypes.StorableSpan

--- a/pkg/modules/tracedetail/impltracedetail/store.go
+++ b/pkg/modules/tracedetail/impltracedetail/store.go
@@ -157,9 +157,18 @@ func (s *traceStore) GetTraceSpansByIDs(ctx context.Context, traceID string, sta
 func (s *traceStore) GetFlamegraphSpans(ctx context.Context, traceID string, start, end time.Time, spanIDs []string) ([]spantypes.StorableSpan, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select(
-		"DISTINCT ON (span_id) span_id",
-		"parent_span_id", "timestamp", "duration_nano", "has_error", "name", "events",
-		"attributes_string", "attributes_number", "attributes_bool", "resources_string",
+		"span_id",
+		"any(parent_span_id) AS parent_span_id",
+		"any(timestamp) AS timestamp",
+		"any(duration_nano) AS duration_nano",
+		"any(has_error) AS has_error",
+		fmt.Sprintf("any(%s) AS %s", colServiceName, colServiceName),
+		"any(name) AS name",
+		"any(events) AS events",
+		"any(attributes_string) AS attributes_string",
+		"any(attributes_number) AS attributes_number",
+		"any(attributes_bool) AS attributes_bool",
+		"any(resources_string) AS resources_string",
 	)
 	sb.From(fmt.Sprintf("%s.%s", spantypes.TraceDB, spantypes.TraceTable))
 	conditions := []string{
@@ -175,8 +184,8 @@ func (s *traceStore) GetFlamegraphSpans(ctx context.Context, traceID string, sta
 		conditions = append(conditions, sb.In("span_id", ids...))
 	}
 	sb.Where(conditions...)
-	sb.OrderByAsc("timestamp")
-	sb.OrderByAsc("name")
+	sb.GroupBy("span_id")
+	sb.OrderBy("any(timestamp) ASC", "any(name) ASC")
 	query, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
 
 	var spans []spantypes.StorableSpan

--- a/pkg/modules/tracedetail/impltracedetail/store_test.go
+++ b/pkg/modules/tracedetail/impltracedetail/store_test.go
@@ -91,6 +91,30 @@ func TestGetSpanCountByField(t *testing.T) {
 	}
 }
 
+func TestGetFlamegraphSpans(t *testing.T) {
+	baseSQL := "SELECT span_id, any(parent_span_id) AS parent_span_id, any(timestamp) AS timestamp, any(duration_nano) AS duration_nano, any(has_error) AS has_error, any(name) AS name, any(events) AS events, any(attributes_string) AS attributes_string, any(attributes_number) AS attributes_number, any(attributes_bool) AS attributes_bool, any(resources_string) AS resources_string FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? GROUP BY span_id ORDER BY timestamp ASC, name ASC"
+	withSpanIDsSQL := "SELECT span_id, any(parent_span_id) AS parent_span_id, any(timestamp) AS timestamp, any(duration_nano) AS duration_nano, any(has_error) AS has_error, any(name) AS name, any(events) AS events, any(attributes_string) AS attributes_string, any(attributes_number) AS attributes_number, any(attributes_bool) AS attributes_bool, any(resources_string) AS resources_string FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? AND span_id IN (?, ?) GROUP BY span_id ORDER BY timestamp ASC, name ASC"
+
+	tests := []struct {
+		name    string
+		spanIDs []string
+		sql     string
+	}{
+		{name: "NoSpanIDs_GeneratesBaseSQL", spanIDs: nil, sql: baseSQL},
+		{name: "WithSpanIDs_GeneratesInClauseSQL", spanIDs: []string{"span-1", "span-2"}, sql: withSpanIDsSQL},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(sqlmock.QueryMatcherRegexp)
+			s.Mock().ExpectSelect(regexp.QuoteMeta(tc.sql)).
+				WillReturnRows(cmock.NewRows(nil, nil))
+			_, _ = s.Store().GetFlamegraphSpans(context.Background(), testTraceID, testStart, testEnd, tc.spanIDs)
+			assert.NoError(t, s.Mock().ExpectationsWereMet())
+		})
+	}
+}
+
 func TestGetSpanDurationByField(t *testing.T) {
 
 	expectedSQL := "WITH all_spans AS (SELECT DISTINCT ON (span_id) resource.`service.name`::String AS field_value, toUnixTimestamp64Nano(timestamp) AS start_ns, start_ns + duration_nano AS end_ns FROM signoz_traces.distributed_signoz_index_v3 WHERE trace_id = ? AND ts_bucket_start >= ? AND ts_bucket_start <= ? AND notEmpty(field_value) ORDER BY timestamp ASC, name ASC), effective_start AS (SELECT field_value, end_ns, greatest(start_ns, ifNull(max(end_ns) OVER (PARTITION BY field_value ORDER BY start_ns ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING), toUInt64(0))) AS effective_start_ns FROM all_spans) SELECT field_value, sum(toUInt64(greatest(end_ns - effective_start_ns, 0))) AS total_ns FROM effective_start GROUP BY field_value"

--- a/pkg/modules/tracedetail/tracedetail.go
+++ b/pkg/modules/tracedetail/tracedetail.go
@@ -12,6 +12,7 @@ type Handler interface {
 	GetWaterfall(http.ResponseWriter, *http.Request)
 	GetWaterfallV4(http.ResponseWriter, *http.Request)
 	GetTraceAggregations(http.ResponseWriter, *http.Request)
+	GetFlamegraph(http.ResponseWriter, *http.Request)
 }
 
 // Module defines the business logic for trace detail operations.
@@ -19,4 +20,5 @@ type Module interface {
 	GetWaterfall(ctx context.Context, traceID string, req *spantypes.PostableWaterfall) (*spantypes.GettableWaterfallTrace, error)
 	GetWaterfallV4(ctx context.Context, traceID string, selectedSpanID string, uncollapsedSpans []string, selectAllLimit uint) (*spantypes.GettableWaterfallTrace, error)
 	GetTraceAggregations(ctx context.Context, traceID string, req *spantypes.PostableTraceAggregations) (*spantypes.GettableTraceAggregations, error)
+	GetFlamegraph(ctx context.Context, traceID string, req *spantypes.PostableFlamegraph) (*spantypes.GettableFlamegraphTrace, error)
 }

--- a/pkg/modules/tracedetail/tracedetail.go
+++ b/pkg/modules/tracedetail/tracedetail.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/SigNoz/signoz/pkg/types/spantypes"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 )
 
 // Handler exposes HTTP handlers for trace detail APIs.
@@ -20,5 +21,5 @@ type Module interface {
 	GetWaterfall(ctx context.Context, traceID string, req *spantypes.PostableWaterfall) (*spantypes.GettableWaterfallTrace, error)
 	GetWaterfallV4(ctx context.Context, traceID string, selectedSpanID string, uncollapsedSpans []string, selectAllLimit uint) (*spantypes.GettableWaterfallTrace, error)
 	GetTraceAggregations(ctx context.Context, traceID string, req *spantypes.PostableTraceAggregations) (*spantypes.GettableTraceAggregations, error)
-	GetFlamegraph(ctx context.Context, traceID string, selectedSpanID string) (*spantypes.GettableFlamegraphTrace, error)
+	GetFlamegraph(ctx context.Context, traceID string, selectedSpanID string, selectFields []telemetrytypes.TelemetryFieldKey) (*spantypes.GettableFlamegraphTrace, error)
 }

--- a/pkg/modules/tracedetail/tracedetail.go
+++ b/pkg/modules/tracedetail/tracedetail.go
@@ -20,5 +20,5 @@ type Module interface {
 	GetWaterfall(ctx context.Context, traceID string, req *spantypes.PostableWaterfall) (*spantypes.GettableWaterfallTrace, error)
 	GetWaterfallV4(ctx context.Context, traceID string, selectedSpanID string, uncollapsedSpans []string, selectAllLimit uint) (*spantypes.GettableWaterfallTrace, error)
 	GetTraceAggregations(ctx context.Context, traceID string, req *spantypes.PostableTraceAggregations) (*spantypes.GettableTraceAggregations, error)
-	GetFlamegraph(ctx context.Context, traceID string, req *spantypes.PostableFlamegraph) (*spantypes.GettableFlamegraphTrace, error)
+	GetFlamegraph(ctx context.Context, traceID string, selectedSpanID string) (*spantypes.GettableFlamegraphTrace, error)
 }

--- a/pkg/types/spantypes/flamegraph_span.go
+++ b/pkg/types/spantypes/flamegraph_span.go
@@ -1,8 +1,6 @@
 package spantypes
 
 import (
-	"maps"
-
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 )
 
@@ -49,10 +47,8 @@ func NewGettableFlamegraphTrace(spans [][]*FlamegraphSpan, startMs, endMs int64,
 	}
 }
 
-func NewFlamegraphSpanFromStorable(s *StorableSpan, level int64) *FlamegraphSpan {
-	resources := make(map[string]string, len(s.ResourcesString))
-	maps.Copy(resources, s.ResourcesString)
-	return &FlamegraphSpan{
+func NewFlamegraphSpanFromStorable(s *StorableSpan, level int64, selectFields []telemetrytypes.TelemetryFieldKey) *FlamegraphSpan {
+	span := &FlamegraphSpan{
 		SpanID:       s.SpanID,
 		ParentSpanID: s.ParentSpanID,
 		Timestamp:    uint64(s.StartTime.UnixNano()),
@@ -62,9 +58,29 @@ func NewFlamegraphSpanFromStorable(s *StorableSpan, level int64) *FlamegraphSpan
 		Name:         s.Name,
 		Level:        level,
 		Events:       s.UnmarshalledEvents(),
-		Attributes:   s.Attributes(),
-		Resource:     resources,
 	}
+	if len(selectFields) == 0 {
+		return span
+	}
+	for _, field := range selectFields {
+		switch field.FieldContext {
+		case telemetrytypes.FieldContextResource:
+			if v, ok := s.ResourcesString[field.Name]; ok && v != "" {
+				if span.Resource == nil {
+					span.Resource = make(map[string]string)
+				}
+				span.Resource[field.Name] = v
+			}
+		case telemetrytypes.FieldContextAttribute:
+			if v := s.AttributeValue(field.Name); v != nil {
+				if span.Attributes == nil {
+					span.Attributes = make(map[string]any)
+				}
+				span.Attributes[field.Name] = v
+			}
+		}
+	}
+	return span
 }
 
 // FlamegraphWindowSpanIDs collects all span IDs from a level window into a flat slice.

--- a/pkg/types/spantypes/flamegraph_span.go
+++ b/pkg/types/spantypes/flamegraph_span.go
@@ -10,7 +10,6 @@ type FlamegraphSpan struct {
 	Timestamp    uint64            `json:"timestamp"`
 	DurationNano uint64            `json:"durationNano"`
 	HasError     bool              `json:"hasError"`
-	ServiceName  string            `json:"serviceName"`
 	Name         string            `json:"name"`
 	Level        int64             `json:"level"`
 	Events       []Event           `json:"event" required:"true" nullable:"false"`
@@ -54,7 +53,6 @@ func NewFlamegraphSpanFromStorable(s *StorableSpan, level int64, selectFields []
 		Timestamp:    uint64(s.StartTime.UnixNano()),
 		DurationNano: s.DurationNano,
 		HasError:     s.HasError,
-		ServiceName:  s.ServiceName,
 		Name:         s.Name,
 		Level:        level,
 		Events:       s.UnmarshalledEvents(),

--- a/pkg/types/spantypes/flamegraph_span.go
+++ b/pkg/types/spantypes/flamegraph_span.go
@@ -1,0 +1,60 @@
+package spantypes
+
+import (
+	"maps"
+
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
+)
+
+type FlamegraphSpan struct {
+	SpanID       string            `json:"spanId"`
+	ParentSpanID string            `json:"parentSpanId"`
+	Timestamp    uint64            `json:"timestamp"`
+	DurationNano uint64            `json:"durationNano"`
+	HasError     bool              `json:"hasError"`
+	ServiceName  string            `json:"serviceName"`
+	Name         string            `json:"name"`
+	Level        int64             `json:"level"`
+	Events       []Event           `json:"event"`
+	Attributes   map[string]any    `json:"attributes,omitempty"`
+	Resource     map[string]string `json:"resource,omitempty"`
+	Children     []*FlamegraphSpan `json:"-"` // internal tree use only
+}
+
+// FlamegraphWindowLevel groups span IDs at a single level within the selected window.
+type FlamegraphWindowLevel struct {
+	Level   int64
+	SpanIDs []string
+}
+
+type PostableFlamegraph struct {
+	SelectedSpanID string                             `json:"selectedSpanId"`
+	Limit          uint                               `json:"limit"`
+	SelectFields   []telemetrytypes.TelemetryFieldKey `json:"selectFields,omitempty"`
+}
+
+// GettableFlamegraphTrace is the response for the v3 flamegraph API.
+type GettableFlamegraphTrace struct {
+	Spans                [][]*FlamegraphSpan `json:"spans"`
+	StartTimestampMillis int64               `json:"startTimestampMillis"`
+	EndTimestampMillis   int64               `json:"endTimestampMillis"`
+	HasMore              bool                `json:"hasMore"`
+}
+
+func NewFlamegraphSpanFromStorable(s *StorableSpan, level int64) *FlamegraphSpan {
+	resources := make(map[string]string, len(s.ResourcesString))
+	maps.Copy(resources, s.ResourcesString)
+	return &FlamegraphSpan{
+		SpanID:       s.SpanID,
+		ParentSpanID: s.ParentSpanID,
+		Timestamp:    uint64(s.StartTime.UnixNano()),
+		DurationNano: s.DurationNano,
+		HasError:     s.HasError,
+		ServiceName:  s.ServiceName,
+		Name:         s.Name,
+		Level:        level,
+		Events:       s.UnmarshalledEvents(),
+		Attributes:   s.Attributes(),
+		Resource:     resources,
+	}
+}

--- a/pkg/types/spantypes/flamegraph_span.go
+++ b/pkg/types/spantypes/flamegraph_span.go
@@ -29,8 +29,20 @@ type FlamegraphWindowLevel struct {
 
 type PostableFlamegraph struct {
 	SelectedSpanID string                             `json:"selectedSpanId"`
-	Limit          uint                               `json:"limit"`
 	SelectFields   []telemetrytypes.TelemetryFieldKey `json:"selectFields,omitempty"`
+}
+
+// FlamegraphWindowSpanIDs collects all span IDs from a level window into a flat slice.
+func FlamegraphWindowSpanIDs(window []FlamegraphWindowLevel) []string {
+	total := 0
+	for _, lvl := range window {
+		total += len(lvl.SpanIDs)
+	}
+	ids := make([]string, 0, total)
+	for _, lvl := range window {
+		ids = append(ids, lvl.SpanIDs...)
+	}
+	return ids
 }
 
 // GettableFlamegraphTrace is the response for the v3 flamegraph API.

--- a/pkg/types/spantypes/flamegraph_span.go
+++ b/pkg/types/spantypes/flamegraph_span.go
@@ -21,8 +21,8 @@ type FlamegraphSpan struct {
 	Children     []*FlamegraphSpan `json:"-"` // internal tree use only
 }
 
-// FlamegraphWindowLevel groups span IDs at a single level within the selected window.
-type FlamegraphWindowLevel struct {
+// FlamegraphLevel groups span IDs at a single level within the selected window.
+type FlamegraphLevel struct {
 	Level   int64
 	SpanIDs []string
 }
@@ -68,7 +68,7 @@ func NewFlamegraphSpanFromStorable(s *StorableSpan, level int64) *FlamegraphSpan
 }
 
 // FlamegraphWindowSpanIDs collects all span IDs from a level window into a flat slice.
-func FlamegraphWindowSpanIDs(window []FlamegraphWindowLevel) []string {
+func FlamegraphWindowSpanIDs(window []FlamegraphLevel) []string {
 	total := 0
 	for _, lvl := range window {
 		total += len(lvl.SpanIDs)

--- a/pkg/types/spantypes/flamegraph_span.go
+++ b/pkg/types/spantypes/flamegraph_span.go
@@ -13,7 +13,7 @@ type FlamegraphSpan struct {
 	ServiceName  string            `json:"serviceName"`
 	Name         string            `json:"name"`
 	Level        int64             `json:"level"`
-	Events       []Event           `json:"event"`
+	Events       []Event           `json:"event" required:"true" nullable:"false"`
 	Attributes   map[string]any    `json:"attributes,omitempty"`
 	Resource     map[string]string `json:"resource,omitempty"`
 	Children     []*FlamegraphSpan `json:"-"` // internal tree use only
@@ -32,7 +32,7 @@ type PostableFlamegraph struct {
 
 // GettableFlamegraphTrace is the response for the v3 flamegraph API.
 type GettableFlamegraphTrace struct {
-	Spans                [][]*FlamegraphSpan `json:"spans"`
+	Spans                [][]*FlamegraphSpan `json:"spans" required:"true" nullable:"false"`
 	StartTimestampMillis int64               `json:"startTimestampMillis"`
 	EndTimestampMillis   int64               `json:"endTimestampMillis"`
 	HasMore              bool                `json:"hasMore"`

--- a/pkg/types/spantypes/flamegraph_span.go
+++ b/pkg/types/spantypes/flamegraph_span.go
@@ -33,9 +33,9 @@ type PostableFlamegraph struct {
 // GettableFlamegraphTrace is the response for the v3 flamegraph API.
 type GettableFlamegraphTrace struct {
 	Spans                [][]*FlamegraphSpan `json:"spans" required:"true" nullable:"false"`
-	StartTimestampMillis int64               `json:"startTimestampMillis"`
-	EndTimestampMillis   int64               `json:"endTimestampMillis"`
-	HasMore              bool                `json:"hasMore"`
+	StartTimestampMillis int64               `json:"startTimestampMillis" required:"true"`
+	EndTimestampMillis   int64               `json:"endTimestampMillis" required:"true"`
+	HasMore              bool                `json:"hasMore" required:"true"`
 }
 
 func NewGettableFlamegraphTrace(spans [][]*FlamegraphSpan, startMs, endMs int64, hasMore bool) *GettableFlamegraphTrace {

--- a/pkg/types/spantypes/flamegraph_span.go
+++ b/pkg/types/spantypes/flamegraph_span.go
@@ -81,6 +81,18 @@ func NewFlamegraphSpanFromStorable(s *StorableSpan, level int64, selectFields []
 	return span
 }
 
+func NewMissingParentFlamegraphSpan(node *FlamegraphSpan) *FlamegraphSpan {
+	return &FlamegraphSpan{
+		SpanID:       node.ParentSpanID,
+		Name:         "Missing Span",
+		Timestamp:    node.Timestamp,
+		DurationNano: node.DurationNano,
+		Events:       []Event{},
+		References:   []OtelSpanRef{},
+		Children:     []*FlamegraphSpan{node},
+	}
+}
+
 // FlamegraphWindowSpanIDs collects all span IDs from a level window into a flat slice.
 func FlamegraphWindowSpanIDs(window []FlamegraphLevel) []string {
 	total := 0

--- a/pkg/types/spantypes/flamegraph_span.go
+++ b/pkg/types/spantypes/flamegraph_span.go
@@ -5,16 +5,16 @@ import (
 )
 
 type FlamegraphSpan struct {
-	SpanID       string            `json:"spanId"`
-	ParentSpanID string            `json:"parentSpanId"`
-	Timestamp    uint64            `json:"timestamp"`
-	DurationNano uint64            `json:"durationNano"`
-	HasError     bool              `json:"hasError"`
-	Name         string            `json:"name"`
-	Level        int64             `json:"level"`
+	SpanID       string            `json:"spanId" required:"true"`
+	ParentSpanID string            `json:"parentSpanId" required:"true"`
+	Timestamp    uint64            `json:"timestamp" required:"true"`
+	DurationNano uint64            `json:"durationNano" required:"true"`
+	HasError     bool              `json:"hasError" required:"true"`
+	Name         string            `json:"name" required:"true"`
+	Level        int64             `json:"level" required:"true"`
 	Events       []Event           `json:"event" required:"true" nullable:"false"`
-	Attributes   map[string]any    `json:"attributes,omitempty"`
-	Resource     map[string]string `json:"resource,omitempty"`
+	Attributes   map[string]any    `json:"attributes" required:"true" nullable:"false"`
+	Resource     map[string]string `json:"resource" required:"true" nullable:"false"`
 	Children     []*FlamegraphSpan `json:"-"` // internal tree use only
 }
 
@@ -56,6 +56,8 @@ func NewFlamegraphSpanFromStorable(s *StorableSpan, level int64, selectFields []
 		Name:         s.Name,
 		Level:        level,
 		Events:       s.UnmarshalledEvents(),
+		Attributes:   make(map[string]any),
+		Resource:     make(map[string]string),
 	}
 	if len(selectFields) == 0 {
 		return span
@@ -64,16 +66,10 @@ func NewFlamegraphSpanFromStorable(s *StorableSpan, level int64, selectFields []
 		switch field.FieldContext {
 		case telemetrytypes.FieldContextResource:
 			if v, ok := s.ResourcesString[field.Name]; ok && v != "" {
-				if span.Resource == nil {
-					span.Resource = make(map[string]string)
-				}
 				span.Resource[field.Name] = v
 			}
 		case telemetrytypes.FieldContextAttribute:
 			if v := s.AttributeValue(field.Name); v != nil {
-				if span.Attributes == nil {
-					span.Attributes = make(map[string]any)
-				}
 				span.Attributes[field.Name] = v
 			}
 		}
@@ -88,7 +84,6 @@ func NewMissingParentFlamegraphSpan(node *FlamegraphSpan) *FlamegraphSpan {
 		Timestamp:    node.Timestamp,
 		DurationNano: node.DurationNano,
 		Events:       []Event{},
-		References:   []OtelSpanRef{},
 		Children:     []*FlamegraphSpan{node},
 	}
 }

--- a/pkg/types/spantypes/flamegraph_span.go
+++ b/pkg/types/spantypes/flamegraph_span.go
@@ -32,25 +32,21 @@ type PostableFlamegraph struct {
 	SelectFields   []telemetrytypes.TelemetryFieldKey `json:"selectFields,omitempty"`
 }
 
-// FlamegraphWindowSpanIDs collects all span IDs from a level window into a flat slice.
-func FlamegraphWindowSpanIDs(window []FlamegraphWindowLevel) []string {
-	total := 0
-	for _, lvl := range window {
-		total += len(lvl.SpanIDs)
-	}
-	ids := make([]string, 0, total)
-	for _, lvl := range window {
-		ids = append(ids, lvl.SpanIDs...)
-	}
-	return ids
-}
-
 // GettableFlamegraphTrace is the response for the v3 flamegraph API.
 type GettableFlamegraphTrace struct {
 	Spans                [][]*FlamegraphSpan `json:"spans"`
 	StartTimestampMillis int64               `json:"startTimestampMillis"`
 	EndTimestampMillis   int64               `json:"endTimestampMillis"`
 	HasMore              bool                `json:"hasMore"`
+}
+
+func NewGettableFlamegraphTrace(spans [][]*FlamegraphSpan, startMs, endMs int64, hasMore bool) *GettableFlamegraphTrace {
+	return &GettableFlamegraphTrace{
+		Spans:                spans,
+		StartTimestampMillis: startMs,
+		EndTimestampMillis:   endMs,
+		HasMore:              hasMore,
+	}
 }
 
 func NewFlamegraphSpanFromStorable(s *StorableSpan, level int64) *FlamegraphSpan {
@@ -69,4 +65,17 @@ func NewFlamegraphSpanFromStorable(s *StorableSpan, level int64) *FlamegraphSpan
 		Attributes:   s.Attributes(),
 		Resource:     resources,
 	}
+}
+
+// FlamegraphWindowSpanIDs collects all span IDs from a level window into a flat slice.
+func FlamegraphWindowSpanIDs(window []FlamegraphWindowLevel) []string {
+	total := 0
+	for _, lvl := range window {
+		total += len(lvl.SpanIDs)
+	}
+	ids := make([]string, 0, total)
+	for _, lvl := range window {
+		ids = append(ids, lvl.SpanIDs...)
+	}
+	return ids
 }

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -16,82 +16,47 @@ func NewFlamegraphTraceFromMinimal(spans []MinimalSpan) *FlamegraphTrace {
 	t := &FlamegraphTrace{
 		nodeByID: make(map[string]*FlamegraphSpan, len(spans)),
 	}
-
 	for i := range spans {
 		node := spans[i].ToFlamegraphSpan()
-		if t.startTime == 0 || node.Timestamp < t.startTime {
-			t.startTime = node.Timestamp
-		}
-		if end := node.Timestamp + node.DurationNano; end > t.endTime {
-			t.endTime = end
-		}
+		t.updateTimeRange(node.Timestamp, node.DurationNano)
 		t.nodeByID[node.SpanID] = node
 	}
-
-	for _, node := range t.nodeByID {
-		if node.ParentSpanID != "" {
-			if parent, ok := t.nodeByID[node.ParentSpanID]; ok {
-				parent.Children = append(parent.Children, node)
-			} else {
-				missing := &FlamegraphSpan{
-					SpanID:       node.ParentSpanID,
-					Name:         "Missing Span",
-					Timestamp:    node.Timestamp,
-					DurationNano: node.DurationNano,
-					Children:     []*FlamegraphSpan{node},
-				}
-				t.nodeByID[missing.SpanID] = missing
-				t.roots = append(t.roots, missing)
-			}
-		} else if flamegraphSpanIndex(t.roots, node.SpanID) == -1 {
-			t.roots = append(t.roots, node)
-		}
-	}
-
-	sort.Slice(t.roots, func(i, j int) bool {
-		if t.roots[i].Timestamp == t.roots[j].Timestamp {
-			return t.roots[i].SpanID < t.roots[j].SpanID
-		}
-		return t.roots[i].Timestamp < t.roots[j].Timestamp
-	})
-
+	t.wireTree()
 	return t
 }
 
-// GetSelectedSpans builds all BFS levels, counts total spans, then either returns all
-// levels unchanged (totalSpans <= effectiveLimit) or applies a level window with
-// sampling for large traces. The bool return is true when windowing was applied.
-func (t *FlamegraphTrace) GetSelectedSpans(
-	selectedSpanID string, effectiveLimit uint,
-	levelLimit, spansPerLevel, topLatencyCount, bucketCount int,
-) ([]FlamegraphWindowLevel, bool) {
-	allLevels := t.buildAllLevels()
+func NewFlamegraphTraceFromStorable(spans []StorableSpan) *FlamegraphTrace {
+	t := &FlamegraphTrace{
+		nodeByID: make(map[string]*FlamegraphSpan, len(spans)),
+	}
+	for i := range spans {
+		node := NewFlamegraphSpanFromStorable(&spans[i], 0) // level is set later by BFS
+		t.updateTimeRange(node.Timestamp, node.DurationNano)
+		t.nodeByID[node.SpanID] = node
+	}
+	t.wireTree()
+	return t
+}
 
+func (t *FlamegraphTrace) GetAllLevels() [][]*FlamegraphSpan {
+	allLevels := t.buildAllLevels()
+	for _, node := range t.nodeByID {
+		node.Children = nil // children not required after building tree
+	}
+	return allLevels
+}
+
+// GetSelectedLevels returns the level window for selectedSpanID with sampling applied to
+// dense levels. It always applies windowing — callers should only invoke this when the
+// trace is known to exceed the select-all limit.
+// Children are cleared after traversal so the tree can be GC'd.
+func (t *FlamegraphTrace) GetSelectedLevels(
+	selectedSpanID string,
+	levelLimit, spansPerLevel, topLatencyCount, bucketCount int,
+) []FlamegraphLevel {
+	allLevels := t.buildAllLevels()
 	for _, node := range t.nodeByID {
 		node.Children = nil
-	}
-
-	var totalSpans uint
-	for _, lvl := range allLevels {
-		totalSpans += uint(len(lvl))
-	}
-
-	if totalSpans <= effectiveLimit {
-		result := make([]FlamegraphWindowLevel, 0, len(allLevels))
-		for _, lvl := range allLevels {
-			if len(lvl) == 0 {
-				continue
-			}
-			spanIDs := make([]string, len(lvl))
-			for i, s := range lvl {
-				spanIDs[i] = s.SpanID
-			}
-			result = append(result, FlamegraphWindowLevel{
-				Level:   lvl[0].Level,
-				SpanIDs: spanIDs,
-			})
-		}
-		return result, false
 	}
 
 	selectedIndex := 0
@@ -122,7 +87,7 @@ func (t *FlamegraphTrace) GetSelectedSpans(
 		lowerLimit = 0
 	}
 
-	result := make([]FlamegraphWindowLevel, 0, upperLimit-lowerLimit)
+	result := make([]FlamegraphLevel, 0, upperLimit-lowerLimit)
 	for i := lowerLimit; i < upperLimit; i++ {
 		lvl := allLevels[i]
 		if len(lvl) == 0 {
@@ -142,32 +107,23 @@ func (t *FlamegraphTrace) GetSelectedSpans(
 		for j, s := range sampled {
 			spanIDs[j] = s.SpanID
 		}
-		result = append(result, FlamegraphWindowLevel{
+		result = append(result, FlamegraphLevel{
 			Level:   sampled[0].Level,
 			SpanIDs: spanIDs,
 		})
 	}
 
-	return result, true
+	return result
 }
 
-// GetNode returns the lean tree node for spanID, if it exists.
-func (t *FlamegraphTrace) GetNode(spanID string) (*FlamegraphSpan, bool) {
-	node, ok := t.nodeByID[spanID]
-	return node, ok
-}
-
-// EnrichWindow hydrates a level window with full span data. For each span ID in the
-// window it looks up the corresponding StorableSpan and converts it; synthesized
-// "Missing Span" placeholders fall back to the lean tree node.
-func (t *FlamegraphTrace) EnrichWindow(window []FlamegraphWindowLevel, fullSpans []StorableSpan) [][]*FlamegraphSpan {
+func (t *FlamegraphTrace) EnrichSelectedSpans(selectedSpans []FlamegraphLevel, fullSpans []StorableSpan) [][]*FlamegraphSpan {
 	fullByID := make(map[string]*StorableSpan, len(fullSpans))
 	for i := range fullSpans {
 		fullByID[fullSpans[i].SpanID] = &fullSpans[i]
 	}
 
-	result := make([][]*FlamegraphSpan, len(window))
-	for i, lvl := range window {
+	result := make([][]*FlamegraphSpan, len(selectedSpans))
+	for i, lvl := range selectedSpans {
 		result[i] = make([]*FlamegraphSpan, 0, len(lvl.SpanIDs))
 		for _, spanID := range lvl.SpanIDs {
 			if full, ok := fullByID[spanID]; ok {
@@ -178,6 +134,44 @@ func (t *FlamegraphTrace) EnrichWindow(window []FlamegraphWindowLevel, fullSpans
 		}
 	}
 	return result
+}
+
+func (t *FlamegraphTrace) updateTimeRange(timestamp, durationNano uint64) {
+	if t.startTime == 0 || timestamp < t.startTime {
+		t.startTime = timestamp
+	}
+	if end := timestamp + durationNano; end > t.endTime {
+		t.endTime = end
+	}
+}
+
+func (t *FlamegraphTrace) wireTree() {
+	for _, node := range t.nodeByID {
+		if node.ParentSpanID != "" {
+			if parent, ok := t.nodeByID[node.ParentSpanID]; ok {
+				parent.Children = append(parent.Children, node)
+			} else {
+				missing := &FlamegraphSpan{
+					SpanID:       node.ParentSpanID,
+					Name:         "Missing Span",
+					Timestamp:    node.Timestamp,
+					DurationNano: node.DurationNano,
+					Children:     []*FlamegraphSpan{node},
+				}
+				t.nodeByID[missing.SpanID] = missing
+				t.roots = append(t.roots, missing)
+			}
+		} else if flamegraphSpanIndex(t.roots, node.SpanID) == -1 {
+			t.roots = append(t.roots, node)
+		}
+	}
+
+	sort.Slice(t.roots, func(i, j int) bool {
+		if t.roots[i].Timestamp == t.roots[j].Timestamp {
+			return t.roots[i].SpanID < t.roots[j].SpanID
+		}
+		return t.roots[i].Timestamp < t.roots[j].Timestamp
+	})
 }
 
 func (t *FlamegraphTrace) buildAllLevels() [][]*FlamegraphSpan {

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -109,7 +109,7 @@ func (t *FlamegraphTrace) buildSpanTree() {
 
 func flamegraphSpanIndex(spans []*FlamegraphSpan, spanID string) int {
 	for i, s := range spans {
-		if s != nil && s.SpanID == spanID {
+		if s.SpanID == spanID {
 			return i
 		}
 	}

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -39,81 +39,15 @@ func NewFlamegraphTraceFromStorable(spans []StorableSpan) *FlamegraphTrace {
 }
 
 func (t *FlamegraphTrace) GetAllLevels() [][]*FlamegraphSpan {
-	allLevels := t.buildAllLevels()
-	for _, node := range t.nodeByID {
-		node.Children = nil // children not required after building tree
-	}
-	return allLevels
+	return nil
 }
 
-// GetSelectedLevels returns the level window for selectedSpanID with sampling applied to
-// dense levels. It always applies windowing — callers should only invoke this when the
-// trace is known to exceed the select-all limit.
-// Children are cleared after traversal so the tree can be GC'd.
+// GetSelectedLevels returns the window of levels around selectedSpanID with sampling applied to dense levels.
 func (t *FlamegraphTrace) GetSelectedLevels(
 	selectedSpanID string,
 	levelLimit, spansPerLevel, topLatencyCount, bucketCount int,
 ) []FlamegraphLevel {
-	allLevels := t.buildAllLevels()
-	for _, node := range t.nodeByID {
-		node.Children = nil
-	}
-
-	selectedIndex := 0
-	if selectedSpanID != "" {
-	outer:
-		for i, lvl := range allLevels {
-			for _, span := range lvl {
-				if span.SpanID == selectedSpanID {
-					selectedIndex = i
-					break outer
-				}
-			}
-		}
-	}
-
-	lowerLimit := selectedIndex - int(float64(levelLimit)*0.4)
-	upperLimit := selectedIndex + int(float64(levelLimit)*0.6)
-
-	if lowerLimit < 0 {
-		upperLimit -= lowerLimit
-		lowerLimit = 0
-	}
-	if upperLimit > len(allLevels) {
-		lowerLimit -= upperLimit - len(allLevels)
-		upperLimit = len(allLevels)
-	}
-	if lowerLimit < 0 {
-		lowerLimit = 0
-	}
-
-	result := make([]FlamegraphLevel, 0, upperLimit-lowerLimit)
-	for i := lowerLimit; i < upperLimit; i++ {
-		lvl := allLevels[i]
-		if len(lvl) == 0 {
-			continue
-		}
-		var sampled []*FlamegraphSpan
-		if len(lvl) > spansPerLevel {
-			sampled = sampleFlamegraphLevel(lvl, selectedSpanID, i == selectedIndex,
-				t.startTime, t.endTime, topLatencyCount, bucketCount)
-		} else {
-			sampled = lvl
-		}
-		if len(sampled) == 0 {
-			continue
-		}
-		spanIDs := make([]string, len(sampled))
-		for j, s := range sampled {
-			spanIDs[j] = s.SpanID
-		}
-		result = append(result, FlamegraphLevel{
-			Level:   sampled[0].Level,
-			SpanIDs: spanIDs,
-		})
-	}
-
-	return result
+	return nil
 }
 
 func (t *FlamegraphTrace) EnrichSelectedSpans(selectedSpans []FlamegraphLevel, fullSpans []StorableSpan) [][]*FlamegraphSpan {
@@ -172,98 +106,6 @@ func (t *FlamegraphTrace) buildSpanTree() {
 		}
 		return t.roots[i].Timestamp < t.roots[j].Timestamp
 	})
-}
-
-func (t *FlamegraphTrace) buildAllLevels() [][]*FlamegraphSpan {
-	var result [][]*FlamegraphSpan
-
-	type entry struct {
-		node  *FlamegraphSpan
-		depth int64
-	}
-
-	for _, root := range t.roots {
-		levelMap := make(map[int64][]*FlamegraphSpan)
-		maxDepth := int64(-1)
-
-		queue := []entry{{root, 0}}
-		for len(queue) > 0 {
-			curr := queue[0]
-			queue = queue[1:]
-			curr.node.Level = curr.depth
-			levelMap[curr.depth] = append(levelMap[curr.depth], curr.node)
-			if curr.depth > maxDepth {
-				maxDepth = curr.depth
-			}
-			for _, child := range curr.node.Children {
-				queue = append(queue, entry{child, curr.depth + 1})
-			}
-		}
-
-		for depth := int64(0); depth <= maxDepth; depth++ {
-			if spans, ok := levelMap[depth]; ok {
-				result = append(result, spans)
-			}
-		}
-	}
-
-	return result
-}
-
-func sampleFlamegraphLevel(
-	spans []*FlamegraphSpan,
-	selectedSpanID string,
-	isSelectedLevel bool,
-	startTime, endTime uint64,
-	topLatencyCount, bucketCount int,
-) []*FlamegraphSpan {
-	sorted := make([]*FlamegraphSpan, len(spans))
-	copy(sorted, spans)
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].DurationNano > sorted[j].DurationNano
-	})
-
-	var sampled []*FlamegraphSpan
-
-	topK := min(topLatencyCount, len(sorted))
-	sampled = append(sampled, sorted[:topK]...)
-
-	if isSelectedLevel {
-		for _, span := range sorted {
-			if span.SpanID == selectedSpanID {
-				sampled = append(sampled, span)
-				break
-			}
-		}
-	}
-
-	bucketSize := (endTime - startTime) / uint64(bucketCount)
-	if bucketSize == 0 {
-		bucketSize = 1
-	}
-	buckets := make([][]*FlamegraphSpan, bucketCount)
-	for _, span := range sorted {
-		if span.Timestamp < startTime || span.Timestamp > endTime {
-			continue
-		}
-		idx := int((span.Timestamp - startTime) / bucketSize)
-		if idx < 0 {
-			idx = 0
-		} else if idx >= bucketCount {
-			idx = bucketCount - 1
-		}
-		buckets[idx] = append(buckets[idx], span)
-	}
-	for i := range buckets {
-		if len(buckets[i]) > 2 {
-			buckets[i] = buckets[i][:2]
-		}
-	}
-	for _, bucket := range buckets {
-		sampled = append(sampled, bucket...)
-	}
-
-	return sampled
 }
 
 func flamegraphSpanIndex(spans []*FlamegraphSpan, spanID string) int {

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -21,7 +21,7 @@ func NewFlamegraphTraceFromMinimal(spans []MinimalSpan) *FlamegraphTrace {
 		t.updateTimeRange(node.Timestamp, node.DurationNano)
 		t.nodeByID[node.SpanID] = node
 	}
-	t.wireTree()
+	t.buildSpanTree()
 	return t
 }
 
@@ -34,7 +34,7 @@ func NewFlamegraphTraceFromStorable(spans []StorableSpan) *FlamegraphTrace {
 		t.updateTimeRange(node.Timestamp, node.DurationNano)
 		t.nodeByID[node.SpanID] = node
 	}
-	t.wireTree()
+	t.buildSpanTree()
 	return t
 }
 
@@ -145,7 +145,7 @@ func (t *FlamegraphTrace) updateTimeRange(timestamp, durationNano uint64) {
 	}
 }
 
-func (t *FlamegraphTrace) wireTree() {
+func (t *FlamegraphTrace) buildSpanTree() {
 	for _, node := range t.nodeByID {
 		if node.ParentSpanID != "" {
 			if parent, ok := t.nodeByID[node.ParentSpanID]; ok {
@@ -225,10 +225,7 @@ func sampleFlamegraphLevel(
 
 	var sampled []*FlamegraphSpan
 
-	topK := topLatencyCount
-	if topK > len(sorted) {
-		topK = len(sorted)
-	}
+	topK := min(topLatencyCount, len(sorted))
 	sampled = append(sampled, sorted[:topK]...)
 
 	if isSelectedLevel {

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -84,13 +84,7 @@ func (t *FlamegraphTrace) buildSpanTree() {
 			if parent, ok := t.nodeByID[node.ParentSpanID]; ok {
 				parent.Children = append(parent.Children, node)
 			} else {
-				missing := &FlamegraphSpan{
-					SpanID:       node.ParentSpanID,
-					Name:         "Missing Span",
-					Timestamp:    node.Timestamp,
-					DurationNano: node.DurationNano,
-					Children:     []*FlamegraphSpan{node},
-				}
+				missing := NewMissingParentFlamegraphSpan(node)
 				t.nodeByID[missing.SpanID] = missing
 				t.roots = append(t.roots, missing)
 			}

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 )
 
-// FlamegraphTrace holds the level wise tree
+// FlamegraphTrace holds the level wise tree built from minimal spans.
 type FlamegraphTrace struct {
 	roots     []*FlamegraphSpan
 	nodeByID  map[string]*FlamegraphSpan
@@ -58,13 +58,11 @@ func NewFlamegraphTraceFromMinimal(spans []MinimalSpan) *FlamegraphTrace {
 	return t
 }
 
-// SelectWindow builds all BFS levels, counts total spans, then either returns all
+// GetSelectedSpans builds all BFS levels, counts total spans, then either returns all
 // levels unchanged (totalSpans <= effectiveLimit) or applies a level window with
 // sampling for large traces. The bool return is true when windowing was applied.
-// Children are cleared after traversal so the tree can be GC'd.
-func (t *FlamegraphTrace) SelectWindow(
-	selectedSpanID string,
-	effectiveLimit uint,
+func (t *FlamegraphTrace) GetSelectedSpans(
+	selectedSpanID string, effectiveLimit uint,
 	levelLimit, spansPerLevel, topLatencyCount, bucketCount int,
 ) ([]FlamegraphWindowLevel, bool) {
 	allLevels := t.buildAllLevels()
@@ -153,8 +151,35 @@ func (t *FlamegraphTrace) SelectWindow(
 	return result, true
 }
 
-// buildAllLevels performs per-root BFS, appending each root's levels sequentially.
-// This preserves the sequential-root semantics of the legacy GetAllSpansForFlamegraph.
+// GetNode returns the lean tree node for spanID, if it exists.
+func (t *FlamegraphTrace) GetNode(spanID string) (*FlamegraphSpan, bool) {
+	node, ok := t.nodeByID[spanID]
+	return node, ok
+}
+
+// EnrichWindow hydrates a level window with full span data. For each span ID in the
+// window it looks up the corresponding StorableSpan and converts it; synthesized
+// "Missing Span" placeholders fall back to the lean tree node.
+func (t *FlamegraphTrace) EnrichWindow(window []FlamegraphWindowLevel, fullSpans []StorableSpan) [][]*FlamegraphSpan {
+	fullByID := make(map[string]*StorableSpan, len(fullSpans))
+	for i := range fullSpans {
+		fullByID[fullSpans[i].SpanID] = &fullSpans[i]
+	}
+
+	result := make([][]*FlamegraphSpan, len(window))
+	for i, lvl := range window {
+		result[i] = make([]*FlamegraphSpan, 0, len(lvl.SpanIDs))
+		for _, spanID := range lvl.SpanIDs {
+			if full, ok := fullByID[spanID]; ok {
+				result[i] = append(result[i], NewFlamegraphSpanFromStorable(full, lvl.Level))
+			} else if lean, ok := t.nodeByID[spanID]; ok {
+				result[i] = append(result[i], lean)
+			}
+		}
+	}
+	return result
+}
+
 func (t *FlamegraphTrace) buildAllLevels() [][]*FlamegraphSpan {
 	var result [][]*FlamegraphSpan
 
@@ -191,8 +216,6 @@ func (t *FlamegraphTrace) buildAllLevels() [][]*FlamegraphSpan {
 	return result
 }
 
-// sampleFlamegraphLevel down-samples a dense level using latency-top + timestamp bucketing.
-// Mirrors the legacy getLatencyAndTimestampBucketedSpans behavior exactly.
 func sampleFlamegraphLevel(
 	spans []*FlamegraphSpan,
 	selectedSpanID string,
@@ -250,14 +273,6 @@ func sampleFlamegraphLevel(
 	}
 
 	return sampled
-}
-
-// GetNode returns the lean tree node for spanID, if it exists.
-// Useful for recovering synthesized "Missing Span" placeholders that are in the
-// window but will never be returned by GetTraceSpansByIDs.
-func (t *FlamegraphTrace) GetNode(spanID string) (*FlamegraphSpan, bool) {
-	node, ok := t.nodeByID[spanID]
-	return node, ok
 }
 
 func flamegraphSpanIndex(spans []*FlamegraphSpan, spanID string) int {

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -45,10 +45,7 @@ func (t *FlamegraphTrace) GetAllLevels() [][]*FlamegraphSpan {
 }
 
 // GetSelectedLevels returns the window of levels around selectedSpanID with sampling applied to dense levels.
-func (t *FlamegraphTrace) GetSelectedLevels(
-	selectedSpanID string,
-	levelLimit, spansPerLevel, topLatencyCount, bucketCount int,
-) []FlamegraphLevel {
+func (t *FlamegraphTrace) GetSelectedLevels(selectedSpanID string, levelLimit, spansPerLevel, topLatencyCount, bucketCount int) []FlamegraphLevel {
 	return nil
 }
 

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -2,6 +2,8 @@ package spantypes
 
 import (
 	"sort"
+
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 )
 
 // FlamegraphTrace holds the level wise tree built from minimal spans.
@@ -25,12 +27,12 @@ func NewFlamegraphTraceFromMinimal(spans []MinimalSpan) *FlamegraphTrace {
 	return t
 }
 
-func NewFlamegraphTraceFromStorable(spans []StorableSpan) *FlamegraphTrace {
+func NewFlamegraphTraceFromStorable(spans []StorableSpan, selectFields []telemetrytypes.TelemetryFieldKey) *FlamegraphTrace {
 	t := &FlamegraphTrace{
 		nodeByID: make(map[string]*FlamegraphSpan, len(spans)),
 	}
 	for i := range spans {
-		node := NewFlamegraphSpanFromStorable(&spans[i], 0) // level is set later by BFS
+		node := NewFlamegraphSpanFromStorable(&spans[i], 0, selectFields) // level is set later by BFS
 		t.updateTimeRange(node.Timestamp, node.DurationNano)
 		t.nodeByID[node.SpanID] = node
 	}
@@ -50,7 +52,7 @@ func (t *FlamegraphTrace) GetSelectedLevels(
 	return nil
 }
 
-func (t *FlamegraphTrace) EnrichSelectedSpans(selectedSpans []FlamegraphLevel, fullSpans []StorableSpan) [][]*FlamegraphSpan {
+func (t *FlamegraphTrace) EnrichSelectedSpans(selectedSpans []FlamegraphLevel, fullSpans []StorableSpan, selectFields []telemetrytypes.TelemetryFieldKey) [][]*FlamegraphSpan {
 	fullByID := make(map[string]*StorableSpan, len(fullSpans))
 	for i := range fullSpans {
 		fullByID[fullSpans[i].SpanID] = &fullSpans[i]
@@ -61,7 +63,7 @@ func (t *FlamegraphTrace) EnrichSelectedSpans(selectedSpans []FlamegraphLevel, f
 		result[i] = make([]*FlamegraphSpan, 0, len(lvl.SpanIDs))
 		for _, spanID := range lvl.SpanIDs {
 			if full, ok := fullByID[spanID]; ok {
-				result[i] = append(result[i], NewFlamegraphSpanFromStorable(full, lvl.Level))
+				result[i] = append(result[i], NewFlamegraphSpanFromStorable(full, lvl.Level, selectFields))
 			} else if lean, ok := t.nodeByID[spanID]; ok {
 				result[i] = append(result[i], lean)
 			}

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -1,0 +1,270 @@
+package spantypes
+
+import (
+	"sort"
+)
+
+// FlamegraphTrace holds the level wise tree
+type FlamegraphTrace struct {
+	roots     []*FlamegraphSpan
+	nodeByID  map[string]*FlamegraphSpan
+	startTime uint64
+	endTime   uint64
+}
+
+func NewFlamegraphTraceFromMinimal(spans []MinimalSpan) *FlamegraphTrace {
+	t := &FlamegraphTrace{
+		nodeByID: make(map[string]*FlamegraphSpan, len(spans)),
+	}
+
+	for i := range spans {
+		node := spans[i].ToFlamegraphSpan()
+		if t.startTime == 0 || node.Timestamp < t.startTime {
+			t.startTime = node.Timestamp
+		}
+		if end := node.Timestamp + node.DurationNano; end > t.endTime {
+			t.endTime = end
+		}
+		t.nodeByID[node.SpanID] = node
+	}
+
+	for _, node := range t.nodeByID {
+		if node.ParentSpanID != "" {
+			if parent, ok := t.nodeByID[node.ParentSpanID]; ok {
+				parent.Children = append(parent.Children, node)
+			} else {
+				missing := &FlamegraphSpan{
+					SpanID:       node.ParentSpanID,
+					Name:         "Missing Span",
+					Timestamp:    node.Timestamp,
+					DurationNano: node.DurationNano,
+					Children:     []*FlamegraphSpan{node},
+				}
+				t.nodeByID[missing.SpanID] = missing
+				t.roots = append(t.roots, missing)
+			}
+		} else if flamegraphSpanIndex(t.roots, node.SpanID) == -1 {
+			t.roots = append(t.roots, node)
+		}
+	}
+
+	sort.Slice(t.roots, func(i, j int) bool {
+		if t.roots[i].Timestamp == t.roots[j].Timestamp {
+			return t.roots[i].SpanID < t.roots[j].SpanID
+		}
+		return t.roots[i].Timestamp < t.roots[j].Timestamp
+	})
+
+	return t
+}
+
+// SelectWindow builds all BFS levels, counts total spans, then either returns all
+// levels unchanged (totalSpans <= effectiveLimit) or applies a level window with
+// sampling for large traces. The bool return is true when windowing was applied.
+// Children are cleared after traversal so the tree can be GC'd.
+func (t *FlamegraphTrace) SelectWindow(
+	selectedSpanID string,
+	effectiveLimit uint,
+	levelLimit, spansPerLevel, topLatencyCount, bucketCount int,
+) ([]FlamegraphWindowLevel, bool) {
+	allLevels := t.buildAllLevels()
+
+	for _, node := range t.nodeByID {
+		node.Children = nil
+	}
+
+	var totalSpans uint
+	for _, lvl := range allLevels {
+		totalSpans += uint(len(lvl))
+	}
+
+	if totalSpans <= effectiveLimit {
+		result := make([]FlamegraphWindowLevel, 0, len(allLevels))
+		for _, lvl := range allLevels {
+			if len(lvl) == 0 {
+				continue
+			}
+			spanIDs := make([]string, len(lvl))
+			for i, s := range lvl {
+				spanIDs[i] = s.SpanID
+			}
+			result = append(result, FlamegraphWindowLevel{
+				Level:   lvl[0].Level,
+				SpanIDs: spanIDs,
+			})
+		}
+		return result, false
+	}
+
+	selectedIndex := 0
+	if selectedSpanID != "" {
+	outer:
+		for i, lvl := range allLevels {
+			for _, span := range lvl {
+				if span.SpanID == selectedSpanID {
+					selectedIndex = i
+					break outer
+				}
+			}
+		}
+	}
+
+	lowerLimit := selectedIndex - int(float64(levelLimit)*0.4)
+	upperLimit := selectedIndex + int(float64(levelLimit)*0.6)
+
+	if lowerLimit < 0 {
+		upperLimit -= lowerLimit
+		lowerLimit = 0
+	}
+	if upperLimit > len(allLevels) {
+		lowerLimit -= upperLimit - len(allLevels)
+		upperLimit = len(allLevels)
+	}
+	if lowerLimit < 0 {
+		lowerLimit = 0
+	}
+
+	result := make([]FlamegraphWindowLevel, 0, upperLimit-lowerLimit)
+	for i := lowerLimit; i < upperLimit; i++ {
+		lvl := allLevels[i]
+		if len(lvl) == 0 {
+			continue
+		}
+		var sampled []*FlamegraphSpan
+		if len(lvl) > spansPerLevel {
+			sampled = sampleFlamegraphLevel(lvl, selectedSpanID, i == selectedIndex,
+				t.startTime, t.endTime, topLatencyCount, bucketCount)
+		} else {
+			sampled = lvl
+		}
+		if len(sampled) == 0 {
+			continue
+		}
+		spanIDs := make([]string, len(sampled))
+		for j, s := range sampled {
+			spanIDs[j] = s.SpanID
+		}
+		result = append(result, FlamegraphWindowLevel{
+			Level:   sampled[0].Level,
+			SpanIDs: spanIDs,
+		})
+	}
+
+	return result, true
+}
+
+// buildAllLevels performs per-root BFS, appending each root's levels sequentially.
+// This preserves the sequential-root semantics of the legacy GetAllSpansForFlamegraph.
+func (t *FlamegraphTrace) buildAllLevels() [][]*FlamegraphSpan {
+	var result [][]*FlamegraphSpan
+
+	type entry struct {
+		node  *FlamegraphSpan
+		depth int64
+	}
+
+	for _, root := range t.roots {
+		levelMap := make(map[int64][]*FlamegraphSpan)
+		maxDepth := int64(-1)
+
+		queue := []entry{{root, 0}}
+		for len(queue) > 0 {
+			curr := queue[0]
+			queue = queue[1:]
+			curr.node.Level = curr.depth
+			levelMap[curr.depth] = append(levelMap[curr.depth], curr.node)
+			if curr.depth > maxDepth {
+				maxDepth = curr.depth
+			}
+			for _, child := range curr.node.Children {
+				queue = append(queue, entry{child, curr.depth + 1})
+			}
+		}
+
+		for depth := int64(0); depth <= maxDepth; depth++ {
+			if spans, ok := levelMap[depth]; ok {
+				result = append(result, spans)
+			}
+		}
+	}
+
+	return result
+}
+
+// sampleFlamegraphLevel down-samples a dense level using latency-top + timestamp bucketing.
+// Mirrors the legacy getLatencyAndTimestampBucketedSpans behavior exactly.
+func sampleFlamegraphLevel(
+	spans []*FlamegraphSpan,
+	selectedSpanID string,
+	isSelectedLevel bool,
+	startTime, endTime uint64,
+	topLatencyCount, bucketCount int,
+) []*FlamegraphSpan {
+	sorted := make([]*FlamegraphSpan, len(spans))
+	copy(sorted, spans)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].DurationNano > sorted[j].DurationNano
+	})
+
+	var sampled []*FlamegraphSpan
+
+	topK := topLatencyCount
+	if topK > len(sorted) {
+		topK = len(sorted)
+	}
+	sampled = append(sampled, sorted[:topK]...)
+
+	if isSelectedLevel {
+		for _, span := range sorted {
+			if span.SpanID == selectedSpanID {
+				sampled = append(sampled, span)
+				break
+			}
+		}
+	}
+
+	bucketSize := (endTime - startTime) / uint64(bucketCount)
+	if bucketSize == 0 {
+		bucketSize = 1
+	}
+	buckets := make([][]*FlamegraphSpan, bucketCount)
+	for _, span := range sorted {
+		if span.Timestamp < startTime || span.Timestamp > endTime {
+			continue
+		}
+		idx := int((span.Timestamp - startTime) / bucketSize)
+		if idx < 0 {
+			idx = 0
+		} else if idx >= bucketCount {
+			idx = bucketCount - 1
+		}
+		buckets[idx] = append(buckets[idx], span)
+	}
+	for i := range buckets {
+		if len(buckets[i]) > 2 {
+			buckets[i] = buckets[i][:2]
+		}
+	}
+	for _, bucket := range buckets {
+		sampled = append(sampled, bucket...)
+	}
+
+	return sampled
+}
+
+// GetNode returns the lean tree node for spanID, if it exists.
+// Useful for recovering synthesized "Missing Span" placeholders that are in the
+// window but will never be returned by GetTraceSpansByIDs.
+func (t *FlamegraphTrace) GetNode(spanID string) (*FlamegraphSpan, bool) {
+	node, ok := t.nodeByID[spanID]
+	return node, ok
+}
+
+func flamegraphSpanIndex(spans []*FlamegraphSpan, spanID string) int {
+	for i, s := range spans {
+		if s != nil && s.SpanID == spanID {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/types/spantypes/store.go
+++ b/pkg/types/spantypes/store.go
@@ -30,6 +30,7 @@ type TraceStore interface {
 	GetTraceSpans(ctx context.Context, traceID string, summary *TraceSummary) ([]StorableSpan, error)
 	GetMinimalSpans(ctx context.Context, traceID string, start, end time.Time) ([]MinimalSpan, error)
 	GetTraceSpansByIDs(ctx context.Context, traceID string, start, end time.Time, spanIDs []string) ([]StorableSpan, error)
+	GetFlamegraphSpans(ctx context.Context, traceID string, start, end time.Time, spanIDs []string) ([]StorableSpan, error)
 
 	GetSpanCountByField(ctx context.Context, traceID string, summary *TraceSummary, fieldKey telemetrytypes.TelemetryFieldKey) (map[string]uint64, error)
 	GetSpanDurationByField(ctx context.Context, traceID string, summary *TraceSummary, fieldKey telemetrytypes.TelemetryFieldKey) (map[string]uint64, error)

--- a/pkg/types/spantypes/waterfall_span.go
+++ b/pkg/types/spantypes/waterfall_span.go
@@ -279,6 +279,19 @@ func (ws *WaterfallSpan) getPathToSelectedSpanID(selectedSpanID string) ([]strin
 	return nil, false
 }
 
+func (item *StorableSpan) AttributeValue(name string) any {
+	if v, ok := item.AttributesString[name]; ok {
+		return v
+	}
+	if v, ok := item.AttributesNumber[name]; ok {
+		return v
+	}
+	if v, ok := item.AttributesBool[name]; ok {
+		return v
+	}
+	return nil
+}
+
 func (item *StorableSpan) Attributes() map[string]any {
 	attributes := make(map[string]any, len(item.AttributesString)+len(item.AttributesNumber)+len(item.AttributesBool))
 	for k, v := range item.AttributesString {

--- a/pkg/types/spantypes/waterfall_span.go
+++ b/pkg/types/spantypes/waterfall_span.go
@@ -320,7 +320,7 @@ func (item *StorableSpan) UnmarshalledEvents() []Event {
 func (item *StorableSpan) UnmarshalledRefs() []OtelSpanRef {
 	refs := []OtelSpanRef{}
 	if err := json.Unmarshal([]byte(item.References), &refs); err != nil {
-		return []OtelSpanRef{}
+		return []OtelSpanRef{} // skip malformed values
 	}
 	return refs
 }

--- a/pkg/types/spantypes/waterfall_span.go
+++ b/pkg/types/spantypes/waterfall_span.go
@@ -171,7 +171,6 @@ func (item *MinimalSpan) ToFlamegraphSpan() *FlamegraphSpan {
 		Timestamp:    uint64(item.StartTime.UnixNano()),
 		DurationNano: item.DurationNano,
 		HasError:     item.HasError,
-		ServiceName:  item.ServiceName,
 		Children:     make([]*FlamegraphSpan, 0),
 	}
 }

--- a/pkg/types/spantypes/waterfall_span.go
+++ b/pkg/types/spantypes/waterfall_span.go
@@ -320,7 +320,7 @@ func (item *StorableSpan) UnmarshalledEvents() []Event {
 func (item *StorableSpan) UnmarshalledRefs() []OtelSpanRef {
 	refs := []OtelSpanRef{}
 	if err := json.Unmarshal([]byte(item.References), &refs); err != nil {
-		return nil // skip malformed values
+		return []OtelSpanRef{}
 	}
 	return refs
 }

--- a/pkg/types/spantypes/waterfall_span.go
+++ b/pkg/types/spantypes/waterfall_span.go
@@ -164,6 +164,18 @@ func (item *MinimalSpan) ToWaterfallSpan(traceID string) *WaterfallSpan {
 	}
 }
 
+func (item *MinimalSpan) ToFlamegraphSpan() *FlamegraphSpan {
+	return &FlamegraphSpan{
+		SpanID:       item.SpanID,
+		ParentSpanID: item.ParentSpanID,
+		Timestamp:    uint64(item.StartTime.UnixNano()),
+		DurationNano: item.DurationNano,
+		HasError:     item.HasError,
+		ServiceName:  item.ServiceName,
+		Children:     make([]*FlamegraphSpan, 0),
+	}
+}
+
 // NewMissingWaterfallSpan creates a synthetic placeholder span for a parent that has no recorded data.
 func NewMissingWaterfallSpan(spanID, traceID string, timeUnixNano, durationNano uint64) *WaterfallSpan {
 	return &WaterfallSpan{


### PR DESCRIPTION
## Pull Request

Part of https://github.com/SigNoz/engineering-pod/issues/4787

Closes https://github.com/SigNoz/engineering-pod/issues/4949 (sub-issue)

Objective: Creates a new version for flamegraph that builds the flamegraph tree with minimal fields and only queries the full spans after sampling the supported no. (`selectedAllSpanLImit`) of spans.

Contract change from v2:
- No need for `limit` in request payload (it was added in v2 for backward compatibility only)
- service name is removed from the span 
- references is removed from the span and `parent_span_id` is added instead.

Follow up PR: https://github.com/SigNoz/signoz/pull/11491

TDD: https://www.notion.so/signoz/TDD-Waterfall-Flamegraph-Memory-Allocation-Optimization-364fcc6bcd19804fac09d844e96cb5a2?v=2a7fcc6bcd198049b122000c4ff33372&source=copy_link#364fcc6bcd1980969633f867a5679285