### PR TITLE
chore(oxlint): disable max-params, jsdoc, and more rules for tests

### DIFF
--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -123,6 +123,7 @@
     "react/require-render-return": "error",
     "react/no-unsafe": "off",
     "no-array-constructor": "error",
+    "jsdoc/check-tag-names": "off",
     "@typescript-eslint/no-duplicate-enum-values": "warn",
     // TODO: Change to error after migration to oxlint
     "@typescript-eslint/no-empty-object-type": "error",
@@ -197,10 +198,7 @@
         ]
       }
     ],
-    "max-params": [
-      "warn",
-      3
-    ],
+    "max-params": "off",
     // Warns when functions have more than 3 parameters
     "@typescript-eslint/explicit-function-return-type": "error",
     // Requires explicit return types on functions
@@ -538,7 +536,10 @@
         "signoz/no-raw-absolute-path":"off",
         "no-restricted-globals": "off",
         // Tests need raw localStorage/sessionStorage to seed DOM state for isolation
-        "signoz/no-zustand-getstate-in-hooks": "off"
+        "signoz/no-zustand-getstate-in-hooks": "off",
+        "@typescript-eslint/no-explicit-any": "off", // Tests often need any for mocks/stubs
+        "@typescript-eslint/explicit-module-boundary-types": "off", // Return types not required in tests
+        "@typescript-eslint/explicit-function-return-type": "off" // Same as above rule, don't need to care about return type
       }
     },
     {

--- a/frontend/tsconfig.jest.json
+++ b/frontend/tsconfig.jest.json
@@ -2,6 +2,7 @@
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
 		"target": "es6",
-		"noEmit": false
+		"noEmit": false,
+		"noImplicitAny": false
 	}
 }


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

A few changes on oxlint:
- disable max-params: we don't actually use it or care to reduce it, most of the times is just noise
- disable check-tag-names: orval emit some non-standard tags, most of the usages are from them, don't make sense to not allow custom tags on jsdoc.
- for test files:
  - disable explicit return types
  - allow usage of any

This reduces the amount of warnings from ~4,2k to ~3,1k

By rule:

| Rule | Amount of Warnings |
|--------|--------|
| eslint(max-params) | 256 |
| eslint-plugin-jsdoc(check-tag-names) | 286 |
| typescript-eslint(no-explicit-any) | ~500 only on tests, 1k in total |

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Part of https://github.com/SigNoz/engineering-pod/issues/5087, we need to first reduce this amount of warnings before trying to add any other rule.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: No
- Potential regressions: No
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance |
| Description | N/A |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
