### PR TITLE
feat: new soft colour palette for waterfall + flamegraph

### DIFF
--- a/frontend/src/pages/TraceDetailsV3/SpanDetailsPanel/AnalyticsPanel/AnalyticsPanel.tsx
+++ b/frontend/src/pages/TraceDetailsV3/SpanDetailsPanel/AnalyticsPanel/AnalyticsPanel.tsx
@@ -7,8 +7,8 @@ import {
 } from '@signozhq/ui/tabs';
 import cx from 'classnames';
 import { DetailsHeader } from 'components/DetailsPanel';
-import { themeColors } from 'constants/theme';
-import { generateColor } from 'lib/uPlotLib/utils/generateColor';
+import { useIsDarkMode } from 'hooks/useDarkMode';
+import { generateColorPair } from 'pages/TraceDetailsV3/utils/generateColorPair';
 import { FloatingPanel } from 'periscope/components/FloatingPanel';
 
 import { useTraceStore } from '../../stores/traceStore';
@@ -35,6 +35,7 @@ function AnalyticsPanel({
 }: AnalyticsPanelProps): JSX.Element | null {
 	const aggregations = useTraceStore((s) => s.aggregations);
 	const colorByFieldName = useTraceStore((s) => s.colorByField.name);
+	const isDarkMode = useIsDarkMode();
 
 	const execTimePct = useMemo(
 		() =>
@@ -57,13 +58,16 @@ function AnalyticsPanel({
 			return [];
 		}
 		return Object.entries(execTimePct)
-			.map(([group, percentage]) => ({
-				group,
-				percentage,
-				color: generateColor(group, themeColors.traceDetailColorsV3),
-			}))
+			.map(([group, percentage]) => {
+				const pair = generateColorPair(group);
+				return {
+					group,
+					percentage,
+					color: isDarkMode ? pair.color : pair.colorDark,
+				};
+			})
 			.sort((a, b) => b.percentage - a.percentage);
-	}, [execTimePct]);
+	}, [execTimePct, isDarkMode]);
 
 	const spanCountRows = useMemo(() => {
 		if (!spanCounts) {
@@ -71,14 +75,17 @@ function AnalyticsPanel({
 		}
 		const max = Math.max(...Object.values(spanCounts), 1);
 		return Object.entries(spanCounts)
-			.map(([group, count]) => ({
-				group,
-				count,
-				max,
-				color: generateColor(group, themeColors.traceDetailColorsV3),
-			}))
+			.map(([group, count]) => {
+				const pair = generateColorPair(group);
+				return {
+					group,
+					count,
+					max,
+					color: isDarkMode ? pair.color : pair.colorDark,
+				};
+			})
 			.sort((a, b) => b.count - a.count);
-	}, [spanCounts]);
+	}, [spanCounts, isDarkMode]);
 
 	if (!isOpen) {
 		return null;

--- a/frontend/src/pages/TraceDetailsV3/SpanHoverCard/SpanHoverCard.tsx
+++ b/frontend/src/pages/TraceDetailsV3/SpanHoverCard/SpanHoverCard.tsx
@@ -5,6 +5,7 @@ import {
 	TooltipTrigger,
 } from '@signozhq/ui/tooltip';
 import { convertTimeToRelevantUnit } from 'container/TraceDetail/utils';
+import { useIsDarkMode } from 'hooks/useDarkMode';
 import { useTraceStore } from 'pages/TraceDetailsV3/stores/traceStore';
 import { getSpanAttribute, resolveSpanColor } from 'pages/TraceDetailsV3/utils';
 import { useMemo } from 'react';
@@ -101,6 +102,7 @@ export function SpanHoverCard({
 }: SpanHoverCardProps): JSX.Element {
 	const previewFields = useTraceStore((s) => s.previewFields);
 	const colorByFieldName = useTraceStore((s) => s.colorByField.name);
+	const isDarkMode = useIsDarkMode();
 
 	const hoverCardData = useMemo(() => {
 		if (!hoveredSpanId) {
@@ -121,11 +123,12 @@ export function SpanHoverCard({
 			})
 			.filter((r): r is SpanPreviewRow => r !== null);
 
+		const pair = resolveSpanColor(span, colorByFieldName);
 		return {
 			anchorTop: idx * rowHeight,
 			tooltip: {
 				spanName: span.name,
-				color: resolveSpanColor(span, colorByFieldName),
+				color: isDarkMode ? pair.color : pair.colorDark,
 				hasError: span.has_error,
 				relativeStartMs: span.timestamp - traceStartTime,
 				durationMs: span.duration_nano / 1e6,
@@ -139,6 +142,7 @@ export function SpanHoverCard({
 		colorByFieldName,
 		rowHeight,
 		traceStartTime,
+		isDarkMode,
 	]);
 
 	return (

--- a/frontend/src/pages/TraceDetailsV3/TraceFlamegraph/__tests__/drawUtils.test.ts
+++ b/frontend/src/pages/TraceDetailsV3/TraceFlamegraph/__tests__/drawUtils.test.ts
@@ -87,6 +87,7 @@ describe('Canvas Draw Utils', () => {
 				spanRectsArray,
 				eventRectsArray: [],
 				color: '#1890ff',
+				colorDark: '#000',
 				isDarkMode: false,
 				metrics: METRICS,
 			});
@@ -94,7 +95,9 @@ describe('Canvas Draw Utils', () => {
 			expect(ctx.beginPath).toHaveBeenCalled();
 			expect(ctx.roundRect).toHaveBeenCalledWith(10, 1, 100, 22, 2);
 			expect(ctx.fill).toHaveBeenCalled();
-			expect(ctx.stroke).not.toHaveBeenCalled();
+			// Rest state draws a subtle 1px rgba(0,0,0,0.3) outline to match spec
+			expect(ctx.stroke).toHaveBeenCalled();
+			expect(ctx.strokeStyle).toBe('rgba(0, 0, 0, 0.3)');
 			expect(spanRectsArray).toHaveLength(1);
 			expect(spanRectsArray[0]).toMatchObject({
 				x: 10,
@@ -126,15 +129,17 @@ describe('Canvas Draw Utils', () => {
 				spanRectsArray,
 				eventRectsArray: [],
 				color: '#2F80ED',
+				colorDark: '#000',
 				isDarkMode: false,
 				metrics: METRICS,
 				selectedSpanId: 'sel',
 			});
 
-			// Selected spans get solid l2-background fill + dashed border
+			// Selected spans get solid l2-background fill + dashed border.
+			// Light mode uses colorDark for the stroke for contrast against l2-background.
 			expect(ctx.fill).toHaveBeenCalled();
 			expect(ctx.setLineDash).toHaveBeenCalledWith(DASHED_BORDER_LINE_DASH);
-			expect(ctx.strokeStyle).toBe('#2F80ED');
+			expect(ctx.strokeStyle).toBe('#000');
 			expect(ctx.lineWidth).toBe(2);
 			expect(ctx.stroke).toHaveBeenCalled();
 			expect(ctx.setLineDash).toHaveBeenLastCalledWith([]);
@@ -161,6 +166,7 @@ describe('Canvas Draw Utils', () => {
 				spanRectsArray,
 				eventRectsArray: [],
 				color: '#2F80ED',
+				colorDark: '#000',
 				isDarkMode: false,
 				metrics: METRICS,
 				hoveredSpanId: 'hov',
@@ -193,6 +199,7 @@ describe('Canvas Draw Utils', () => {
 				spanRectsArray,
 				eventRectsArray: [],
 				color: '#000',
+				colorDark: '#000',
 				isDarkMode: false,
 				metrics: METRICS,
 			});
@@ -230,6 +237,7 @@ describe('Canvas Draw Utils', () => {
 				spanRectsArray,
 				eventRectsArray: [],
 				color: '#000',
+				colorDark: '#000',
 				isDarkMode: false,
 				metrics: METRICS,
 			});
@@ -254,6 +262,7 @@ describe('Canvas Draw Utils', () => {
 				spanRectsArray: [],
 				eventRectsArray: [],
 				color: '#000',
+				colorDark: '#000',
 				isDarkMode: false,
 				metrics: METRICS,
 			});
@@ -279,6 +288,7 @@ describe('Canvas Draw Utils', () => {
 				spanRectsArray: [],
 				eventRectsArray: [],
 				color: '#000',
+				colorDark: '#000',
 				isDarkMode: false,
 				metrics: METRICS,
 			});
@@ -314,6 +324,7 @@ describe('Canvas Draw Utils', () => {
 				spanRectsArray: [],
 				eventRectsArray: [],
 				color: '#000',
+				colorDark: '#000',
 				isDarkMode: false,
 				metrics: METRICS,
 			});
@@ -344,6 +355,7 @@ describe('Canvas Draw Utils', () => {
 				spanRectsArray: [],
 				eventRectsArray: [],
 				color: '#000',
+				colorDark: '#000',
 				isDarkMode: false,
 				metrics: METRICS,
 			});
@@ -371,8 +383,8 @@ describe('Canvas Draw Utils', () => {
 			expect(ctx.save).toHaveBeenCalled();
 			expect(ctx.translate).toHaveBeenCalledWith(50, 11);
 			expect(ctx.rotate).toHaveBeenCalledWith(Math.PI / 4);
-			expect(ctx.fillStyle).toBe('rgb(220, 38, 38)');
-			expect(ctx.strokeStyle).toBe('rgb(153, 27, 27)');
+			expect(ctx.fillStyle).toBe('#FC4E4E');
+			expect(ctx.strokeStyle).toBe('#fd2c2c');
 			expect(ctx.fillRect).toHaveBeenCalledWith(-3, -3, 6, 6);
 			expect(ctx.strokeRect).toHaveBeenCalledWith(-3, -3, 6, 6);
 			expect(ctx.restore).toHaveBeenCalled();
@@ -408,8 +420,8 @@ describe('Canvas Draw Utils', () => {
 				eventDotSize: 6,
 			});
 
-			expect(ctx.fillStyle).toBe('rgb(239, 68, 68)');
-			expect(ctx.strokeStyle).toBe('rgb(185, 28, 28)');
+			expect(ctx.fillStyle).toBe('#FC4E4E');
+			expect(ctx.strokeStyle).toBe('#fd2c2c');
 		});
 
 		it('falls back to cyan/blue for unparseable span colors', () => {
@@ -461,6 +473,7 @@ describe('Canvas Draw Utils', () => {
 				spanRectsArray: [],
 				eventRectsArray: [],
 				color: '#000',
+				colorDark: '#000',
 				isDarkMode: false,
 				metrics: METRICS,
 				hoveredSpanId: 'p',
@@ -483,6 +496,7 @@ describe('Canvas Draw Utils', () => {
 				spanRectsArray: [],
 				eventRectsArray: [],
 				color: '#000',
+				colorDark: '#000',
 				isDarkMode: false,
 				metrics: METRICS,
 				selectedSpanId: 'p',
@@ -524,6 +538,7 @@ describe('Canvas Draw Utils', () => {
 				spanRectsArray: [],
 				eventRectsArray: [],
 				color: '#000',
+				colorDark: '#000',
 				isDarkMode: false,
 				metrics: METRICS,
 			});

--- a/frontend/src/pages/TraceDetailsV3/TraceFlamegraph/__tests__/utils.presentation.test.ts
+++ b/frontend/src/pages/TraceDetailsV3/TraceFlamegraph/__tests__/utils.presentation.test.ts
@@ -3,11 +3,13 @@ import { TelemetryFieldKey } from 'types/api/v5/queryRange';
 import { getFlamegraphSpanGroupValue, getSpanColor } from '../utils';
 import { MOCK_SPAN } from './testUtils';
 
-const mockGenerateColor = jest.fn();
+const mockGenerateColorPair = jest.fn();
 
-jest.mock('lib/uPlotLib/utils/generateColor', () => ({
-	generateColor: (key: string, colorMap: Record<string, string>): string =>
-		mockGenerateColor(key, colorMap),
+jest.mock('pages/TraceDetailsV3/utils/generateColorPair', () => ({
+	generateColorPair: (name: string): { color: string; colorDark: string } =>
+		mockGenerateColorPair(name),
+	RESERVED_ERROR: '#FC4E4E',
+	darkenHex: (hex: string): string => hex,
 }));
 
 const SERVICE_FIELD: TelemetryFieldKey = {
@@ -24,48 +26,39 @@ const HOST_FIELD: TelemetryFieldKey = {
 describe('Presentation / Styling Utils', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
-		mockGenerateColor.mockReturnValue('#2F80ED');
+		mockGenerateColorPair.mockReturnValue({
+			color: '#2F80ED',
+			colorDark: '#1a4d99',
+		});
 	});
 
 	describe('getSpanColor', () => {
 		it('uses generated colour from groupValue for normal span', () => {
-			mockGenerateColor.mockReturnValue('#1890ff');
+			mockGenerateColorPair.mockReturnValue({
+				color: '#1890ff',
+				colorDark: '#0d5599',
+			});
 
-			const color = getSpanColor({
+			const result = getSpanColor({
 				span: { ...MOCK_SPAN, hasError: false },
 				isDarkMode: false,
 				groupValue: 'my-bucket',
 			});
 
-			expect(mockGenerateColor).toHaveBeenCalledWith(
-				'my-bucket',
-				expect.any(Object),
-			);
-			expect(color).toBe('#1890ff');
+			expect(mockGenerateColorPair).toHaveBeenCalledWith('my-bucket');
+			expect(result.color).toBe('#1890ff');
+			expect(result.colorDark).toBe('#0d5599');
 		});
 
-		it('overrides with error color in light mode when span has error', () => {
-			mockGenerateColor.mockReturnValue('#1890ff');
-
-			const color = getSpanColor({
+		it('overrides with reserved error color when span has error', () => {
+			const result = getSpanColor({
 				span: { ...MOCK_SPAN, hasError: true },
 				isDarkMode: false,
 				groupValue: 'my-bucket',
 			});
 
-			expect(color).toBe('rgb(220, 38, 38)');
-		});
-
-		it('overrides with error color in dark mode when span has error', () => {
-			mockGenerateColor.mockReturnValue('#1890ff');
-
-			const color = getSpanColor({
-				span: { ...MOCK_SPAN, hasError: true },
-				isDarkMode: true,
-				groupValue: 'my-bucket',
-			});
-
-			expect(color).toBe('rgb(239, 68, 68)');
+			expect(result.color).toBe('#FC4E4E');
+			expect(result.colorDark).toBe('#FC4E4E');
 		});
 	});
 

--- a/frontend/src/pages/TraceDetailsV3/TraceFlamegraph/constants.ts
+++ b/frontend/src/pages/TraceDetailsV3/TraceFlamegraph/constants.ts
@@ -13,7 +13,7 @@ export const EVENT_DOT_SIZE_RATIO = EVENT_DOT_SIZE / SPAN_BAR_HEIGHT;
 export const MIN_EVENT_DOT_SIZE = 4;
 export const MAX_EVENT_DOT_SIZE = EVENT_DOT_SIZE;
 
-export const LABEL_FONT = '11px Inter, sans-serif';
+export const LABEL_FONT = '500 11px Inter, sans-serif';
 export const LABEL_PADDING_X = 8;
 export const MIN_WIDTH_FOR_NAME = 30;
 export const MIN_WIDTH_FOR_NAME_AND_DURATION = 80;

--- a/frontend/src/pages/TraceDetailsV3/TraceFlamegraph/hooks/useFlamegraphDraw.ts
+++ b/frontend/src/pages/TraceDetailsV3/TraceFlamegraph/hooks/useFlamegraphDraw.ts
@@ -1,6 +1,5 @@
 import React, { RefObject, useCallback, useMemo, useRef } from 'react';
-import { themeColors } from 'constants/theme';
-import { generateColor } from 'lib/uPlotLib/utils/generateColor';
+import { generateColorPair } from 'pages/TraceDetailsV3/utils/generateColorPair';
 import { useTraceStore } from 'pages/TraceDetailsV3/stores/traceStore';
 import { FlamegraphSpan } from 'types/api/trace/getTraceFlamegraph';
 import { TelemetryFieldKey } from 'types/api/v5/queryRange';
@@ -118,7 +117,11 @@ function drawLevel(args: DrawLevelArgs): void {
 		width = clamp(width, 1, Infinity);
 
 		const groupValue = getFlamegraphSpanGroupValue(span, colorByField);
-		const color = getSpanColor({ span, isDarkMode, groupValue });
+		const { color, colorDark } = getSpanColor({
+			span,
+			isDarkMode,
+			groupValue,
+		});
 
 		const isDimmedByFilter =
 			!!isFilterActiveInLevel &&
@@ -135,6 +138,7 @@ function drawLevel(args: DrawLevelArgs): void {
 			spanRectsArray,
 			eventRectsArray,
 			color,
+			colorDark,
 			isDarkMode,
 			metrics,
 			selectedSpanId,
@@ -155,6 +159,7 @@ interface DrawConnectorLinesArgs {
 	viewportHeight: number;
 	metrics: FlamegraphRowMetrics;
 	colorByField: TelemetryFieldKey;
+	isDarkMode: boolean;
 }
 
 function drawConnectorLines(args: DrawConnectorLinesArgs): void {
@@ -168,6 +173,7 @@ function drawConnectorLines(args: DrawConnectorLinesArgs): void {
 		viewportHeight,
 		metrics,
 		colorByField,
+		isDarkMode,
 	} = args;
 
 	ctx.save();
@@ -197,8 +203,8 @@ function drawConnectorLines(args: DrawConnectorLinesArgs): void {
 			{ serviceName: conn.serviceName, resource: conn.resource },
 			colorByField,
 		);
-		const color = generateColor(groupValue, themeColors.traceDetailColorsV3);
-		ctx.strokeStyle = color;
+		const pair = generateColorPair(groupValue);
+		ctx.strokeStyle = isDarkMode ? pair.color : pair.colorDark;
 
 		const x = clamp(xFrac * cssWidth, 0, cssWidth);
 		ctx.beginPath();
@@ -294,6 +300,7 @@ export function useFlamegraphDraw(
 			viewportHeight,
 			metrics,
 			colorByField,
+			isDarkMode,
 		});
 
 		const spanRectsArray: SpanRect[] = [];

--- a/frontend/src/pages/TraceDetailsV3/TraceFlamegraph/hooks/useFlamegraphHover.ts
+++ b/frontend/src/pages/TraceDetailsV3/TraceFlamegraph/hooks/useFlamegraphHover.ts
@@ -211,11 +211,14 @@ export function useFlamegraphHover(
 					durationMs: span.durationNano / 1e6,
 					clientX: e.clientX,
 					clientY: e.clientY,
-					spanColor: getSpanColor({
-						span,
-						isDarkMode,
-						groupValue: getFlamegraphSpanGroupValue(span, colorByField),
-					}),
+					spanColor: ((): string => {
+						const pair = getSpanColor({
+							span,
+							isDarkMode,
+							groupValue: getFlamegraphSpanGroupValue(span, colorByField),
+						});
+						return isDarkMode ? pair.color : pair.colorDark;
+					})(),
 					event: {
 						name: event.name,
 						timeOffsetMs: eventTimeMs - span.timestamp,
@@ -244,11 +247,14 @@ export function useFlamegraphHover(
 					durationMs: span.durationNano / 1e6,
 					clientX: e.clientX,
 					clientY: e.clientY,
-					spanColor: getSpanColor({
-						span,
-						isDarkMode,
-						groupValue: getFlamegraphSpanGroupValue(span, colorByField),
-					}),
+					spanColor: ((): string => {
+						const pair = getSpanColor({
+							span,
+							isDarkMode,
+							groupValue: getFlamegraphSpanGroupValue(span, colorByField),
+						});
+						return isDarkMode ? pair.color : pair.colorDark;
+					})(),
 					previewRows: buildPreviewRows(span),
 				});
 				updateCursor(canvas, span);

--- a/frontend/src/pages/TraceDetailsV3/TraceFlamegraph/utils.ts
+++ b/frontend/src/pages/TraceDetailsV3/TraceFlamegraph/utils.ts
@@ -1,8 +1,12 @@
 /* eslint-disable sonarjs/cognitive-complexity */
-import { themeColors } from 'constants/theme';
 import { convertTimeToRelevantUnit } from 'container/TraceDetail/utils';
-import { generateColor } from 'lib/uPlotLib/utils/generateColor';
 import { getSpanAttribute } from 'pages/TraceDetailsV3/utils';
+import {
+	ColorPair,
+	darkenHex,
+	generateColorPair,
+	RESERVED_ERROR,
+} from 'pages/TraceDetailsV3/utils/generateColorPair';
 import { FlamegraphSpan } from 'types/api/trace/getTraceFlamegraph';
 import { TelemetryFieldKey } from 'types/api/v5/queryRange';
 
@@ -106,15 +110,12 @@ interface GetSpanColorArgs {
 	groupValue: string;
 }
 
-export function getSpanColor(args: GetSpanColorArgs): string {
-	const { span, isDarkMode, groupValue } = args;
-	let color = generateColor(groupValue, themeColors.traceDetailColorsV3);
-
+export function getSpanColor(args: GetSpanColorArgs): ColorPair {
+	const { span, groupValue } = args;
 	if (span.hasError) {
-		color = isDarkMode ? 'rgb(239, 68, 68)' : 'rgb(220, 38, 38)';
+		return { color: RESERVED_ERROR, colorDark: RESERVED_ERROR };
 	}
-
-	return color;
+	return generateColorPair(groupValue);
 }
 
 export interface EventDotColor {
@@ -130,8 +131,8 @@ export function getEventDotColor(
 ): EventDotColor {
 	if (isError) {
 		return {
-			fill: isDarkMode ? 'rgb(239, 68, 68)' : 'rgb(220, 38, 38)',
-			stroke: isDarkMode ? 'rgb(185, 28, 28)' : 'rgb(153, 27, 27)',
+			fill: RESERVED_ERROR,
+			stroke: darkenHex(RESERVED_ERROR, 0.22),
 		};
 	}
 
@@ -209,6 +210,9 @@ interface DrawSpanBarArgs {
 	spanRectsArray: SpanRect[];
 	eventRectsArray: EventRect[];
 	color: string;
+	// Darkened variant used as foreground (stroke + label) on light mode
+	// hover/selected, where the base color sits against a near-white panel.
+	colorDark: string;
 	isDarkMode: boolean;
 	metrics: FlamegraphRowMetrics;
 	selectedSpanId?: string | null;
@@ -228,6 +232,7 @@ export function drawSpanBar(args: DrawSpanBarArgs): void {
 		spanRectsArray,
 		eventRectsArray,
 		color,
+		colorDark,
 		isDarkMode,
 		metrics,
 		selectedSpanId,
@@ -259,15 +264,21 @@ export function drawSpanBar(args: DrawSpanBarArgs): void {
 		if (isSelected) {
 			ctx.setLineDash(DASHED_BORDER_LINE_DASH);
 		}
-		ctx.strokeStyle = color;
+		ctx.strokeStyle = isDarkMode ? color : colorDark;
 		ctx.lineWidth = isSelected ? 2 : 1;
 		ctx.stroke();
 		if (isSelected) {
 			ctx.setLineDash([]);
 		}
 	} else {
-		ctx.fillStyle = color;
+		// Light mode uses the darkened variant as fill so bars contrast against
+		// the white panel background; dark mode keeps the bright base.
+		ctx.fillStyle = isDarkMode ? color : colorDark;
 		ctx.fill();
+		// Subtle outline to match spec: 1px semi-transparent black border at rest
+		ctx.strokeStyle = 'rgba(0, 0, 0, 0.3)';
+		ctx.lineWidth = 1;
+		ctx.stroke();
 	}
 
 	spanRectsArray.push({
@@ -292,7 +303,10 @@ export function drawSpanBar(args: DrawSpanBarArgs): void {
 		const eventX = x + (clampedOffset / 100) * width;
 		const eventY = spanY + metrics.SPAN_BAR_HEIGHT / 2;
 
-		const dotColor = getEventDotColor(color, event.isError, isDarkMode);
+		// Event dots derive from the effective bar color so they track the
+		// light/dark variant the bar is rendered with.
+		const parentBarColor = isDarkMode ? color : colorDark;
+		const dotColor = getEventDotColor(parentBarColor, event.isError, isDarkMode);
 		const eventKey = `${span.spanId}-${event.name}-${event.timeUnixNano}`;
 		const isEventHovered = hoveredEventKey === eventKey;
 		const dotSize = isEventHovered
@@ -328,6 +342,7 @@ export function drawSpanBar(args: DrawSpanBarArgs): void {
 		y: spanY,
 		width,
 		color,
+		colorDark,
 		isSelectedOrHovered,
 		isDarkMode,
 		spanBarHeight: metrics.SPAN_BAR_HEIGHT,
@@ -347,6 +362,7 @@ interface DrawSpanLabelArgs {
 	y: number;
 	width: number;
 	color: string;
+	colorDark: string;
 	isSelectedOrHovered: boolean;
 	isDarkMode: boolean;
 	spanBarHeight: number;
@@ -360,6 +376,7 @@ function drawSpanLabel(args: DrawSpanLabelArgs): void {
 		y,
 		width,
 		color,
+		colorDark,
 		isSelectedOrHovered,
 		isDarkMode,
 		spanBarHeight,
@@ -379,11 +396,12 @@ function drawSpanLabel(args: DrawSpanLabelArgs): void {
 	ctx.clip();
 
 	ctx.font = LABEL_FONT;
+	const hoverLabelColor = isDarkMode ? color : colorDark;
 	ctx.fillStyle = isSelectedOrHovered
-		? color
+		? hoverLabelColor
 		: isDarkMode
-			? 'rgba(0, 0, 0, 0.9)'
-			: 'rgba(255, 255, 255, 0.9)';
+			? 'rgba(0, 0, 0, 0.7)'
+			: 'rgba(255, 255, 255, 0.95)';
 	ctx.textBaseline = 'middle';
 
 	const textY = y + spanBarHeight / 2;

--- a/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/Success.module.scss
+++ b/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/Success.module.scss
@@ -433,6 +433,7 @@
 	border-radius: 50%;
 	flex-shrink: 0;
 	margin: 0 6px;
+	background-color: var(--service-dot-color);
 
 	&.hasError {
 		box-shadow: 0 0 0 2px rgba(255, 70, 70, 0.3);
@@ -514,7 +515,7 @@
 .spanBar {
 	position: absolute;
 	height: 18px;
-	top: 5px;
+	top: 3px;
 	border-radius: 2px;
 	display: flex;
 	align-items: center;
@@ -522,7 +523,9 @@
 	overflow: hidden;
 	cursor: pointer;
 	white-space: nowrap;
-	color: rgba(0, 0, 0, 0.9);
+	// Theme-resolved in JS: dark text on the bright dark-mode fill, white text on
+	// the darkened light-mode fill. See SpanDuration in Success.tsx.
+	color: var(--span-text-color);
 	background-color: var(--span-color);
 	border: 1px solid transparent;
 }
@@ -548,7 +551,6 @@
 
 .spanDurationText {
 	color: inherit;
-	opacity: 0.8;
 	font-size: 10px;
 	margin-left: 8px;
 	flex-shrink: 0;
@@ -604,25 +606,6 @@
 .isSelectedNonMatching {
 	.treeLabel {
 		opacity: 0.5;
-	}
-}
-
-// `.spanBar` text color is the one place where semantic tokens don't fit
-// cleanly: in dark mode the bar's bright `--span-color` background needs dark
-// text; in light mode `generateColor` produces darker bar fills, so the text
-// must flip to white.
-:global(.lightMode) {
-	.root {
-		.spanDuration .spanBar {
-			color: rgba(255, 255, 255, 0.9);
-		}
-
-		.timelineRow:hover .spanBar,
-		.timelineRow.hoveredSpan .spanBar,
-		.isInterested .spanBar,
-		.isSelectedNonMatching .spanBar {
-			color: var(--span-color);
-		}
 	}
 }
 

--- a/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
+++ b/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
@@ -29,6 +29,7 @@ import HttpStatusBadge from 'components/HttpStatusBadge/HttpStatusBadge';
 import TimelineV3 from 'components/TimelineV3/TimelineV3';
 import { convertTimeToRelevantUnit } from 'container/TraceDetail/utils';
 import { useCopySpanLink } from 'hooks/trace/useCopySpanLink';
+import { useIsDarkMode } from 'hooks/useDarkMode';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import useUrlQuery from 'hooks/useUrlQuery';
 import { colorToRgb } from 'lib/uPlotLib/utils/generateColor';
@@ -214,8 +215,12 @@ const SpanOverview = memo(function SpanOverview({
 	const isRootSpan = span.level === 0;
 	const { onSpanCopy } = useCopySpanLink(span);
 	const colorByFieldName = useTraceStore((s) => s.colorByField.name);
+	const isDarkMode = useIsDarkMode();
 
-	const color = resolveSpanColor(span, colorByFieldName);
+	const { color, colorDark } = resolveSpanColor(span, colorByFieldName);
+	// Single theme-resolved color: bright base in dark mode, darkened variant in
+	// light mode so the dot stands out against the white panel.
+	const effectiveColor = isDarkMode ? color : colorDark;
 
 	// Smart highlighting logic
 	const {
@@ -317,7 +322,11 @@ const SpanOverview = memo(function SpanOverview({
 			{/* Colored service dot */}
 			<span
 				className={cx(styles.treeIcon, { [styles.hasError]: span.has_error })}
-				style={{ backgroundColor: color }}
+				style={
+					{
+						'--service-dot-color': effectiveColor,
+					} as React.CSSProperties
+				}
 			/>
 
 			{/* Span name + service name */}
@@ -391,9 +400,16 @@ export const SpanDuration = memo(function SpanDuration({
 	const width = (span.duration_nano * 1e2) / (spread * 1e6);
 
 	const colorByFieldName = useTraceStore((s) => s.colorByField.name);
-	const color = resolveSpanColor(span, colorByFieldName);
-	// `resolveSpanColor` returns a CSS variable for errors; `colorToRgb` can't parse it.
-	const rgbColor = span.has_error ? '239, 68, 68' : colorToRgb(color);
+	const isDarkMode = useIsDarkMode();
+	const { color, colorDark } = resolveSpanColor(span, colorByFieldName);
+	// Single theme-resolved color: bright base in dark mode, darkened variant in
+	// light mode (so the bar stands out against the white panel and hover/selected
+	// foregrounds stay legible). The bar's text flips dark↔white to suit the fill.
+	const effectiveColor = isDarkMode ? color : colorDark;
+	const rgbColor = colorToRgb(effectiveColor);
+	const spanTextColor = isDarkMode
+		? 'rgba(0, 0, 0, 0.7)'
+		: 'rgba(255, 255, 255, 0.95)';
 
 	const {
 		isSelected,
@@ -424,8 +440,9 @@ export const SpanDuration = memo(function SpanDuration({
 					{
 						left: `${leftOffset}%`,
 						width: `${width}%`,
-						'--span-color': color,
+						'--span-color': effectiveColor,
 						'--span-color-rgb': rgbColor,
+						'--span-text-color': spanTextColor,
 					} as React.CSSProperties
 				}
 			>

--- a/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/__tests__/UnifiedSpanClick.test.tsx
+++ b/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/__tests__/UnifiedSpanClick.test.tsx
@@ -103,6 +103,7 @@ jest.mock('components/TimelineV3/TimelineV3', () => {
 jest.mock('lib/uPlotLib/utils/generateColor', () => ({
 	generateColor: (): string => '#1890ff',
 	colorToRgb: (): string => '24, 144, 255',
+	hashFn: (): number => 0,
 }));
 
 jest.mock('container/TraceDetail/utils', () => ({

--- a/frontend/src/pages/TraceDetailsV3/utils.ts
+++ b/frontend/src/pages/TraceDetailsV3/utils.ts
@@ -1,6 +1,10 @@
-import { themeColors } from 'constants/theme';
-import { generateColor } from 'lib/uPlotLib/utils/generateColor';
 import { SpanV3 } from 'types/api/trace/getTraceV3';
+
+import {
+	ColorPair,
+	generateColorPair,
+	RESERVED_ERROR,
+} from './utils/generateColorPair';
 
 /**
  * Look up an attribute from both `resource` and `attributes` on a span.
@@ -92,18 +96,16 @@ export function getSpanGroupValue(
 
 /**
  * Resolves the rendering colour for a span. Error spans always get the
- * semantic destructive colour; everything else is derived deterministically
- * from its group value via `generateColor`.
+ * reserved error colour; everything else is derived deterministically from its
+ * group value via `generateColorPair`. Returns both the base color and a
+ * darkened variant for light-mode hover/selected foregrounds.
  */
 export function resolveSpanColor(
 	span: SpanV3,
 	colorByFieldName: string,
-): string {
+): ColorPair {
 	if (span.has_error) {
-		return 'var(--destructive)';
+		return { color: RESERVED_ERROR, colorDark: RESERVED_ERROR };
 	}
-	return generateColor(
-		getSpanGroupValue(span, colorByFieldName),
-		themeColors.traceDetailColorsV3,
-	);
+	return generateColorPair(getSpanGroupValue(span, colorByFieldName));
 }

--- a/frontend/src/pages/TraceDetailsV3/utils/__tests__/generateColorPair.test.ts
+++ b/frontend/src/pages/TraceDetailsV3/utils/__tests__/generateColorPair.test.ts
@@ -1,0 +1,126 @@
+import {
+	darkenHex,
+	generateColorPair,
+	PALETTE_V3,
+	RESERVED_ERROR,
+	RESERVED_OK,
+	RESERVED_WARNING,
+} from '../generateColorPair';
+
+describe('generateColorPair', () => {
+	it('is deterministic: same name returns the same pair across calls', () => {
+		const a = generateColorPair('payment-service');
+		const b = generateColorPair('payment-service');
+		expect(a).toBe(b); // cache hit returns the same reference
+		expect(a.color).toBe(b.color);
+		expect(a.colorDark).toBe(b.colorDark);
+	});
+
+	it('returns a palette color for a normal name', () => {
+		const { color } = generateColorPair('any-service');
+		expect(PALETTE_V3).toContain(color);
+	});
+
+	it('colorDark differs from color (darker variant computed via darkenHex)', () => {
+		const { color, colorDark } = generateColorPair('checkout-svc');
+		expect(colorDark).not.toBe(color);
+		expect(colorDark).toMatch(/^#[0-9a-f]{6}$/i);
+	});
+
+	it('produces different colors for different names (palette wraps modulo length)', () => {
+		const a = generateColorPair('aaa');
+		const b = generateColorPair('bbb');
+		// Not strictly guaranteed (hash collisions exist with 28 buckets), but
+		// for these two short strings djb2 produces different bucket indices.
+		expect(a.color).not.toBe(b.color);
+	});
+});
+
+describe('darkenHex', () => {
+	it('returns a darker hex than the input for amount > 0', () => {
+		const input = '#4D6BD8';
+		const out = darkenHex(input, 0.22);
+		expect(out).toMatch(/^#[0-9a-f]{6}$/i);
+		expect(out).not.toBe(input);
+	});
+
+	it('handles amount = 0 as a near-identity', () => {
+		const out = darkenHex('#4D6BD8', 0);
+		// HSL round-trip may shift a digit; only assert format.
+		expect(out).toMatch(/^#[0-9a-f]{6}$/i);
+	});
+});
+
+describe('reserved status colors', () => {
+	it('matches spec section 8 hexes', () => {
+		expect(RESERVED_ERROR).toBe('#FC4E4E');
+		expect(RESERVED_WARNING).toBe('#fbbf24');
+		expect(RESERVED_OK).toBe('#4ade80');
+	});
+});
+
+// Visual inspection table: each palette color paired with its darkenHex(0.22)
+// variant. Confirms the darkening produces a distinct, non-collapsed hex per
+// entry. Run with `yarn jest generateColorPair --verbose` to see the table.
+describe('PALETTE_V3 darken-pair table', () => {
+	const PALETTE_NAMES = [
+		'Slate blue',
+		'Sage',
+		'Amber',
+		'Dusty pink',
+		'Lavender',
+		'Peach',
+		'Sky teal',
+		'Fuchsia',
+		'Terracotta',
+		'Forest',
+		'Cornflower',
+		'Iris',
+		'Olive gold',
+		'Mint',
+		'Mauve',
+		'Dusty teal',
+		'Burnt orange',
+		'Pistachio',
+		'Periwinkle',
+		'Coral blush',
+		'Sienna',
+		'Robin',
+		'Sandy gold',
+		'Powder blue',
+		'Umber',
+		'Aqua',
+		'Warm tan',
+		'Antique rose',
+	];
+
+	it.each(
+		PALETTE_V3.map((hex, i) => [PALETTE_NAMES[i] ?? `idx-${i}`, hex] as const),
+	)('%s (%s) darkens to a distinct hex', (name, hex) => {
+		const dark = darkenHex(hex, 0.22);
+		expect(dark).toMatch(/^#[0-9a-f]{6}$/i);
+		expect(dark.toLowerCase()).not.toBe(hex.toLowerCase());
+	});
+
+	it('all 28 darkened variants are unique (no collisions)', () => {
+		const darks = PALETTE_V3.map((hex) => darkenHex(hex, 0.22).toLowerCase());
+		const unique = new Set(darks);
+		expect(unique.size).toBe(PALETTE_V3.length);
+	});
+
+	it('prints the base→dark table for visual inspection', () => {
+		// eslint-disable-next-line no-console
+		console.log('\nPALETTE_V3 base → darkenHex(0.22) pairs:');
+		// eslint-disable-next-line no-console
+		console.log('idx  name          base     dark');
+		PALETTE_V3.forEach((hex, i) => {
+			const dark = darkenHex(hex, 0.22);
+			const name = (PALETTE_NAMES[i] ?? '').padEnd(13);
+			const idx = String(i).padStart(2, ' ');
+			// eslint-disable-next-line no-console
+			console.log(`${idx}   ${name} ${hex}  ${dark}`);
+		});
+		// Sentinel assertion so the test is not flagged as having none.
+		expect(PALETTE_V3).toHaveLength(28);
+	});
+});

--- a/frontend/src/pages/TraceDetailsV3/utils/generateColorPair.ts
+++ b/frontend/src/pages/TraceDetailsV3/utils/generateColorPair.ts
@@ -1,0 +1,116 @@
+// Source-of-truth doc: ./COLOR_PALETTE.md
+//
+// Color system for TraceDetailsV3 (waterfall + flamegraph). Returns a base
+// color (deterministic per group name) plus a darkened variant used as the
+// light-mode foreground / fill. Reuses the shared djb2 `hashFn`.
+
+import { hashFn } from 'lib/uPlotLib/utils/generateColor';
+
+// 28 colors from the doc's "Updated Colour Palette" (Section 1), in doc order.
+// Hash output `% PALETTE.length` adjusts automatically if entries are added.
+export const PALETTE_V3: readonly string[] = [
+	'#4D6BD8', // Slate blue
+	'#84B270', // Sage
+	'#EB9E40', // Amber
+	'#D58998', // Dusty pink
+	'#8278D5', // Lavender
+	'#E69C6F', // Peach
+	'#3CB4DA', // Sky teal
+	'#E85DA8', // Fuchsia
+	'#D4694A', // Terracotta
+	'#4FCC8E', // Forest
+	'#5BA2D6', // Cornflower
+	'#9D57D0', // Iris
+	'#D4B638', // Olive gold
+	'#6CC4A4', // Mint
+	'#D188CB', // Mauve
+	'#2FB59B', // Dusty teal
+	'#E68340', // Burnt orange
+	'#B8C474', // Pistachio
+	'#3C84E5', // Periwinkle
+	'#E29F8E', // Coral blush
+	'#C56330', // Sienna
+	'#4E8CF8', // Robin
+	'#E8B752', // Sandy gold
+	'#8DBEDF', // Powder blue
+	'#8B7544', // Umber
+	'#23E0E8', // Aqua
+	'#CB874A', // Warm tan
+	'#C886A9', // Antique rose
+];
+
+// Reserved status colors per spec section 8. Error is wired today;
+// warning + OK are exported for future use (no render path consumes them yet).
+export const RESERVED_ERROR = '#FC4E4E';
+export const RESERVED_WARNING = '#fbbf24';
+export const RESERVED_OK = '#4ade80';
+
+function hexToHsl(hex: string): [number, number, number] {
+	const n = parseInt(hex.slice(1), 16);
+	const r = ((n >> 16) & 255) / 255;
+	const g = ((n >> 8) & 255) / 255;
+	const b = (n & 255) / 255;
+	const mx = Math.max(r, g, b);
+	const mn = Math.min(r, g, b);
+	const d = mx - mn;
+	const l = (mx + mn) / 2;
+	const s = d === 0 ? 0 : d / (1 - Math.abs(2 * l - 1));
+	let h: number;
+	if (d === 0) {
+		h = 0;
+	} else if (mx === r) {
+		h = 60 * (((g - b) / d) % 6);
+	} else if (mx === g) {
+		h = 60 * ((b - r) / d + 2);
+	} else {
+		h = 60 * ((r - g) / d + 4);
+	}
+	return [(h + 360) % 360, s * 100, l * 100];
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+	const S = s / 100;
+	const L = l / 100;
+	const k = (n: number): number => (n + h / 30) % 12;
+	const a = S * Math.min(L, 1 - L);
+	const f = (n: number): number =>
+		Math.round(
+			255 * (L - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)))),
+		);
+	return `#${[f(0), f(8), f(4)]
+		.map((v) => v.toString(16).padStart(2, '0'))
+		.join('')}`;
+}
+
+// Gentle darken: compress lightness relatively (l reduced by ~amount*0.45 of
+// itself) and barely bump saturation. hexToHsl here returns 0–100, so the
+// spec's 0–1 saturation step (`amount * 0.06`) is scaled by 100.
+export function darkenHex(hex: string, amount: number): string {
+	const [h, s, l] = hexToHsl(hex);
+	const newL = Math.max(0, l - l * amount * 0.45);
+	const newS = Math.min(100, s + amount * 6);
+	return hslToHex(h, newS, newL);
+}
+
+export interface ColorPair {
+	color: string;
+	colorDark: string;
+}
+
+// Distinct-name cardinality is bounded by deployment service count (~10s, not 1000s),
+// so unbounded growth is not a concern.
+const cache = new Map<string, ColorPair>();
+
+export function generateColorPair(name: string): ColorPair {
+	const hit = cache.get(name);
+	if (hit) {
+		return hit;
+	}
+	const base = PALETTE_V3[hashFn(name) % PALETTE_V3.length];
+	const result: ColorPair = {
+		color: base,
+		colorDark: darkenHex(base, 0.22),
+	};
+	cache.set(name, result);
+	return result;
+}


### PR DESCRIPTION
### Summary

Replaces the Trace Details V3 colour system (waterfall + flamegraph) with the new soft 28-colour palette from the [Trace Color Palette Guide](https://www.notion.so/signoz/Trace-Color-Palette-Guide-327fcc6bcd1980f2b1a3f33982c9e560).

The previous palette had loud/harsh colours that strained the eye in dark mode and had accessibility gaps. The new palette uses softer hues optimised for **both** themes: a single base colour per service is picked deterministically, and the light-mode appearance is derived on the fly via a darken function (`darkenHex(color, 0.22)`) rather than maintaining two palettes. Red is now reserved exclusively for error spans, and the softer, lower-chroma set reduces "rainbow-wall" fatigue so traces stay scannable in long debugging sessions.

How it works:
- **Deterministic assignment** — each group value (service.name / host.name / etc.) hashes to a fixed palette index, so a given service keeps the same colour across reloads, zoom, and re-renders. We reuse the existing `hashFn` rather than introducing a new hash.
- **Theme adaptation in one place** — the colour module returns `{ color, colorDark }`. The theme decision lives in JS: dark mode renders the bright base; light mode renders the darkened variant (so bars stand out against the white panel). Each surface picks the right one via `useIsDarkMode()` and writes a single CSS var — no `.lightMode` style overrides.
- **Errors** — `#FC4E4E` is reserved and applied to error spans on both surfaces; no palette colour is red.

Coverage: waterfall bars + service dots + hover card, and flamegraph bars + labels + event dots + connector lines + the analytics breakdown — all theme-aware and consistent with each other (matched label text colour/weight across surfaces).

#### Screenshots / Screen Recordings (if applicable)
Before

- Light
<img width="3456" height="1934" alt="image" src="https://github.com/user-attachments/assets/5e0da241-838d-4b6f-a6b1-78f3d8a9eae6" />



- Dark
<img width="3456" height="1926" alt="image" src="https://github.com/user-attachments/assets/3765f69b-acda-412c-adac-36568eacee1e" />


After

- Light
<img width="3456" height="1914" alt="image" src="https://github.com/user-attachments/assets/fc75e232-d3de-4a71-b0e6-36b62ac6dbe1" />



- Dark
<img width="3416" height="1924" alt="image" src="https://github.com/user-attachments/assets/3a8c2a61-1887-44f8-9fbd-8cbd41148a58" />






#### Issues closed by this PR

Addresses SigNoz/engineering-pod#4739

---

### ✅ Change Type

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy

- **Tests added/updated:** unit tests for `generateColorPair` (determinism, palette membership, `darkenHex`, full 28-colour base→dark pair table); updated flamegraph `drawUtils` / presentation tests and the `UnifiedSpanClick` mock for the new return shape and reserved-error colour.
- **Manual verification:** dark and light mode on a multi-service trace — confirmed deterministic colours across reloads, light-mode bars use the darkened variant, error spans render `#FC4E4E`, and waterfall/flamegraph label text matches.
- **Edge cases:** error spans, light-mode hover/selected foreground contrast, unattributed spans (fall back to a single bucket).

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** Trace Details **V3** only. V2 (`container/TraceDetail`) and other `generateColor` consumers are untouched.
- **Potential regressions:** every user's service→colour mapping changes once (new palette) — cosmetic, expected. No data/behaviour change.
- **Rollback plan:** revert the commit; V3 falls back to the previous palette with no migration needed.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Trace Details V3 adopts a new soft colour palette, optimised for dark and light themes with better contrast and reduced visual fatigue. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Intentional deviations from the design doc, for context:

- **Hash:** kept the existing djb2 `hashFn` instead of the doc's Java-style hash. Both are deterministic; switching gains nothing functionally and would re-shuffle every existing user's service→colour mapping a second time.
- **Heat modulation + depth shading:** implemented behind flags, but the on-screen result wasn't right for v1 so both were pulled. The FlameScope rationale for heat still stands and the doc itself flags depth shading as optional — both are follow-up candidates.
- **No single-pass `recolorSpans`:** colours are computed per render with a name-keyed memo cache, which is sufficient given list virtualisation and avoids mutating span objects.
- **Warning/OK colours:** `#fbbf24` / `#4ade80` are exported as constants for future use but nothing renders them yet.
- The colour module lives at `pages/TraceDetailsV3/utils/generateColorPair.ts` (co-located with V3, reuses `hashFn` from the shared uPlot util).
