### PR TITLE
fix: classify numeric columns as aggregation in readAsScalar

### DIFF
--- a/pkg/querier/consume.go
+++ b/pkg/querier/consume.go
@@ -292,6 +292,11 @@ func readAsScalar(rows driver.Rows, queryName string) (*qbtypes.ScalarData, erro
 		colType := qbtypes.ColumnTypeGroup
 		if aggRe.MatchString(name) {
 			colType = qbtypes.ColumnTypeAggregation
+		} else if slices.Contains(legacyReservedColumnTargetAliases, name) {
+			colType = qbtypes.ColumnTypeAggregation
+		} else if numericKind(colTypes[i].ScanType().Kind()) {
+			// Custom alias or unnamed aggregation: infer from numeric type.
+			colType = qbtypes.ColumnTypeAggregation
 		}
 		cd[i] = &qbtypes.ColumnDescriptor{
 			TelemetryFieldKey: telemetrytypes.TelemetryFieldKey{Name: name},


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

`readAsScalar` only recognised columns named `__result_N` as aggregations. Any other name — including user-defined aliases like `count() AS total_requests` — defaulted to `columnType: "group"`. The frontend uses this field to split columns into labels vs values for pie charts and scalar panels, so custom aliases caused charts to show "No Data".

The fix mirrors the fallback logic already present in `readAsTimeSeries`: if a column doesn't match an explicit marker (`__result_N` or a legacy alias like `result`/`value`), infer aggregation intent from the DB column's numeric type.

#### Issues closed by this PR

Closes #8844

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause

`readAsScalar` classified columns purely by name regex (`^__result_(\d+)$`). `readAsTimeSeries` had a fuller fallback chain (single numeric column, legacy aliases) but `readAsScalar` never received the same treatment.

#### Fix Strategy

Add two fallback conditions to `readAsScalar`, in priority order:
1. Name in `legacyReservedColumnTargetAliases` (`result`, `value`, `res`, …) → aggregation
2. Column has a numeric DB type → aggregation

Explicit `__result_N` markers still take priority, so all existing queries are unaffected.

---

### 🧪 Testing Strategy

- Manual verification: pie chart with `count() AS total_requests` now renders correctly; `count() AS __result_0` continues to work.
- Edge cases covered: mixed query (`__result_0` + custom alias), legacy aliases, string-only group columns.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: `readAsScalar` only — time-series and raw query paths are untouched.
- Potential regressions: queries that intentionally used a numeric column as a group dimension will now be classified as aggregation. This is an edge case unlikely in practice (scalar queries for pie/table panels).
- Rollback plan: revert the 5-line addition to `consume.go`.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Pie charts and scalar panels now render correctly when ClickHouse queries use custom aggregation column aliases. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The change is 5 lines in `readAsScalar`. The key insight: `readAsTimeSeries` already had this fallback logic but `readAsScalar` never did. The fix brings them in line with each other.

---