### PR TITLE
fix(opamp): remove DISTINCT from KeepOnlyLast50Agents subquery for PostgreSQL compatibility

### DIFF
--- a/pkg/query-service/app/opamp/model/agent.go
+++ b/pkg/query-service/app/opamp/model/agent.go
@@ -79,7 +79,7 @@ func (agent *Agent) KeepOnlyLast50Agents(ctx context.Context) {
 		Where("agent_id NOT IN (?)",
 			agent.store.BunDB().
 				NewSelect().
-				ColumnExpr("distinct(agent_id)").
+				Column("agent_id").
 				Model(new(opamptypes.StorableAgent)).
 				Where("org_id = ?", agent.OrgID).
 				OrderExpr("created_at DESC").


### PR DESCRIPTION
## What

Remove `DISTINCT` from the subquery in `KeepOnlyLast50Agents` (`pkg/query-service/app/opamp/model/agent.go`).

```go
// Before
.ColumnExpr("distinct(agent_id)").
.OrderExpr("created_at DESC").

// After
.Column("agent_id").
.OrderExpr("created_at DESC").
```

## Why

PostgreSQL requires that all `ORDER BY` expressions appear in the `SELECT` list when `SELECT DISTINCT` is used ([SQLSTATE 42P10](https://www.postgresql.org/docs/current/errcodes-appendix.html)). The subquery was selecting `DISTINCT(agent_id)` but ordering by `created_at`, which is valid in SQLite but rejected by PostgreSQL at planning time — before any execution occurs.

This causes `KeepOnlyLast50Agents` to fail silently on every call on PostgreSQL deployments:

```
ERROR failed to delete old agents
  code.filepath: pkg/query-service/app/opamp/model/agent.go
  code.function: KeepOnlyLast50Agents
  code.lineno: 89
  exception.message: ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list (SQLSTATE 42P10)
```

## Why DISTINCT is safe to remove on both SQLite and PostgreSQL

The `StorableAgent` struct declares `agent_id` as `unique` in the bun tag:

```go
AgentID string `bun:"agent_id,type:text,notnull,unique"`
```

This `UNIQUE` constraint is enforced by Bun on both SQLite and PostgreSQL. Additionally, `Upsert()` uses `ON CONFLICT (agent_id) DO UPDATE`, which means the same agent reconnecting always updates its existing row rather than inserting a new one.

Since `agent_id` is always unique per row, `DISTINCT` was a no-op on both backends. Removing it:
- Fixes the PostgreSQL `SQLSTATE 42P10` error
- Produces identical results on SQLite (no behaviour change)

## Impact without this fix

- `KeepOnlyLast50Agents` never runs on PostgreSQL
- The `agent` table grows unbounded (~10–35 rows/day per deployment)
- Error is logged every ~5 minutes but swallowed, so it goes unnoticed

## Tested

Verified against a live PostgreSQL deployment:

| Query | Result |
|---|---|
| `SELECT DISTINCT(agent_id) ... ORDER BY created_at DESC LIMIT 50` | `ERROR 42P10` |
| `SELECT agent_id ... ORDER BY created_at DESC LIMIT 50` | Returns 50 rows ✓ |
| Full `DELETE ... NOT IN (fixed subquery)` inside `BEGIN/ROLLBACK` | Deletes correct rows, 50 remain ✓ |