### PR TITLE
fix(divider): mismatch on margin/colors

### DIFF
--- a/frontend/src/components/AlertBreadcrumb/AlertBreadcrumb.module.scss
+++ b/frontend/src/components/AlertBreadcrumb/AlertBreadcrumb.module.scss
@@ -11,7 +11,6 @@
 }
 
 .divider {
-	border-color: var(--l1-border);
-	margin: 16px 0;
-	margin-top: 10px;
+	--divider-color: var(--l1-border);
+	--divider-margin: 10px 0 16px 0;
 }

--- a/frontend/src/container/ExplorerOptions/ExplorerOptions.styles.scss
+++ b/frontend/src/container/ExplorerOptions/ExplorerOptions.styles.scss
@@ -23,6 +23,10 @@
 			}
 		}
 	}
+
+	&__divider {
+		--divider-vertical-margin: 0;
+	}
 }
 
 .hide-update {
@@ -54,12 +58,6 @@
 
 	.hidden {
 		display: none;
-	}
-
-	.ant-divider {
-		margin: 0;
-		height: 28px;
-		border: 1px solid var(--l1-border);
 	}
 }
 

--- a/frontend/src/container/ExplorerOptions/ExplorerOptions.tsx
+++ b/frontend/src/container/ExplorerOptions/ExplorerOptions.tsx
@@ -874,7 +874,9 @@ function ExplorerOptions({
 						<>
 							<Divider
 								type="vertical"
-								className={isEditDeleteSupported ? '' : 'hidden'}
+								className={cx('explorer-options-container__divider', {
+									hidden: !isEditDeleteSupported,
+								})}
 							/>
 							<Tooltip title="Update this view" placement="top">
 								<Button

--- a/frontend/src/container/ListAlertRules/AlertsEmptyState/AlertsEmptyState.styles.scss
+++ b/frontend/src/container/ListAlertRules/AlertsEmptyState/AlertsEmptyState.styles.scss
@@ -94,11 +94,8 @@
 			margin-bottom: 24px;
 			width: 100%;
 
-			.ant-divider::before,
-			.ant-divider::after {
-				border-bottom: 2px dotted var(--l1-border);
-				border-top: 2px dotted var(--l1-border);
-				height: 8px;
+			&__divider {
+				--divider-border-width: 1px;
 			}
 
 			.ant-typography {

--- a/frontend/src/container/ListAlertRules/AlertsEmptyState/AlertsEmptyState.tsx
+++ b/frontend/src/container/ListAlertRules/AlertsEmptyState/AlertsEmptyState.tsx
@@ -125,7 +125,7 @@ export function AlertsEmptyState(): JSX.Element {
 					</div>
 				</section>
 				<div className="get-started-text">
-					<Divider>
+					<Divider className="get-started-text__divider">
 						<Typography.Text className="get-started-text">
 							Or get started with these sample alerts
 						</Typography.Text>

--- a/frontend/src/container/NewWidget/LeftContainer/ExplorerColumnsRenderer.styles.scss
+++ b/frontend/src/container/NewWidget/LeftContainer/ExplorerColumnsRenderer.styles.scss
@@ -19,9 +19,9 @@
 		letter-spacing: 0.5px;
 	}
 
-	.ant-divider {
-		margin: 8px 0 !important;
-		border: 0.5px solid var(--l1-border);
+	&__divider {
+		--divider-color: var(--l1-border);
+		--divider-margin: 8px 0;
 	}
 
 	.explorer-columns-contents {

--- a/frontend/src/container/NewWidget/LeftContainer/ExplorerColumnsRenderer.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/ExplorerColumnsRenderer.tsx
@@ -234,7 +234,7 @@ function ExplorerColumnsRenderer({
 					</Tooltip>
 				)}
 			</div>
-			<Divider />
+			<Divider className="explorer-columns-renderer__divider" />
 			{!isError && (
 				<div className="explorer-columns-contents">
 					<DragDropContext onDragEnd={onDragEnd}>

--- a/frontend/src/container/PlannedDowntime/PlannedDowntime.styles.scss
+++ b/frontend/src/container/PlannedDowntime/PlannedDowntime.styles.scss
@@ -19,12 +19,6 @@
 			}
 		}
 
-		.ant-modal-body {
-			.ant-divider {
-				margin: 16px 0;
-				border: 0.5px solid var(--l1-border);
-			}
-		}
 		.downtime-schedule-btn {
 			display: flex;
 		}

--- a/frontend/src/container/RoutingPolicies/styles.scss
+++ b/frontend/src/container/RoutingPolicies/styles.scss
@@ -191,13 +191,6 @@
 				line-height: 20px;
 			}
 		}
-
-		.ant-modal-body {
-			.ant-divider {
-				margin: 16px 0;
-				border: 0.5px solid var(--l1-border);
-			}
-		}
 	}
 
 	.create-policy-container {

--- a/frontend/src/container/SpanDetailsDrawer/SpanRelatedSignals/SpanRelatedSignals.styles.scss
+++ b/frontend/src/container/SpanDetailsDrawer/SpanRelatedSignals/SpanRelatedSignals.styles.scss
@@ -15,11 +15,8 @@
 		}
 	}
 
-	.ant-divider {
-		margin-inline-start: 10px !important;
-		margin-inline-end: 16px !important;
-		height: 16px;
-		border-color: var(--l1-border);
+	&__divider {
+		--divider-vertical-margin: 10px;
 	}
 	.ant-drawer-close {
 		margin: 0 !important;

--- a/frontend/src/container/SpanDetailsDrawer/SpanRelatedSignals/SpanRelatedSignals.tsx
+++ b/frontend/src/container/SpanDetailsDrawer/SpanRelatedSignals/SpanRelatedSignals.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Color, Spacing } from '@signozhq/design-tokens';
+import { Color } from '@signozhq/design-tokens';
 import { Button, Drawer } from 'antd';
 import { Divider } from '@signozhq/ui/divider';
 import { Typography } from '@signozhq/ui/typography';
@@ -179,7 +179,10 @@ function SpanRelatedSignals({
 			width="50%"
 			title={
 				<>
-					<Divider type="vertical" />
+					<Divider
+						type="vertical"
+						className="span-related-signals-drawer__divider"
+					/>
 					<Typography.Text className="title">
 						Related Signals - {selectedSpan.name}
 					</Typography.Text>
@@ -194,7 +197,7 @@ function SpanRelatedSignals({
 			}}
 			className="span-related-signals-drawer"
 			destroyOnClose
-			closeIcon={<X size={16} style={{ marginTop: Spacing.MARGIN_1 }} />}
+			closeIcon={<X size={16} />}
 		>
 			{selectedSpan && (
 				<div className="span-related-signals-drawer__content">

--- a/frontend/src/pages/AlertDetails/AlertDetails.styles.scss
+++ b/frontend/src/pages/AlertDetails/AlertDetails.styles.scss
@@ -41,9 +41,9 @@
 }
 
 .alert-details {
-	.divider {
-		border-color: var(--l1-border);
-		margin: 16px 0;
+	&__divider {
+		--divider-color: var(--l1-border);
+		--divider-margin: 16px 0;
 	}
 	.breadcrumb-divider {
 		margin-top: 10px;

--- a/frontend/src/pages/AlertDetails/AlertDetails.tsx
+++ b/frontend/src/pages/AlertDetails/AlertDetails.tsx
@@ -104,7 +104,7 @@ function AlertDetails(): JSX.Element {
 				/>
 
 				{alertRuleDetails && <AlertHeader alertDetails={alertRuleDetails} />}
-				<Divider className="divider" />
+				<Divider className="alert-details__divider" />
 				<div className="tabs-and-filters">
 					<RouteTab
 						routes={routes}

--- a/frontend/src/pages/AlertDetails/AlertHeader/ActionButtons/ActionButtons.styles.scss
+++ b/frontend/src/pages/AlertDetails/AlertHeader/ActionButtons/ActionButtons.styles.scss
@@ -3,10 +3,9 @@
 	align-items: center;
 	gap: 12px;
 	color: var(--l1-border);
-	.ant-divider-vertical {
-		height: 16px;
-		border-color: var(--l1-border);
-		margin: 0;
+	&__divider {
+		--divider-color: var(--l1-border);
+		--divider-vertical-margin: 0;
 	}
 	.dropdown-trigger-wrapper {
 		display: flex;

--- a/frontend/src/pages/AlertDetails/AlertHeader/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/pages/AlertDetails/AlertHeader/ActionButtons/ActionButtons.tsx
@@ -122,7 +122,7 @@ function AlertActionButtons({
 				</Tooltip>
 				<CopyToClipboard textToCopy={window.location.href} />
 
-				<Divider type="vertical" />
+				<Divider type="vertical" className="alert-action-buttons__divider" />
 
 				<DropdownMenuSimple menu={{ items: menuItems }}>
 					<span className="dropdown-trigger-wrapper">

--- a/frontend/src/pages/TracesExplorer/Filter/Filter.styles.scss
+++ b/frontend/src/pages/TracesExplorer/Filter/Filter.styles.scss
@@ -47,10 +47,9 @@
 	}
 }
 
-.divider {
-	background-color: var(--l1-border);
-	margin: 0;
-	border-color: var(--l1-border);
+.section-body__divider {
+	--divider-color: var(--l1-border);
+	--divider-margin: 0;
 }
 
 .filter-header {

--- a/frontend/src/pages/TracesExplorer/Filter/Section.tsx
+++ b/frontend/src/pages/TracesExplorer/Filter/Section.tsx
@@ -65,7 +65,7 @@ export function Section(props: SectionProps): JSX.Element {
 
 	return (
 		<div>
-			<Divider plain className="divider" />
+			<Divider plain className="section-body__divider" />
 			<div className="section-body-header" data-testid={`collapse-${panelName}`}>
 				<Collapse
 					bordered={false}

--- a/frontend/src/pages/TracesFunnelDetails/components/FunnelConfiguration/FunnelConfiguration.styles.scss
+++ b/frontend/src/pages/TracesFunnelDetails/components/FunnelConfiguration/FunnelConfiguration.styles.scss
@@ -24,9 +24,6 @@
 				align-items: center;
 			}
 			gap: 12px;
-			.ant-divider-vertical {
-				margin: 0;
-			}
 			.funnel-configuration__rename-btn {
 				padding: 4px;
 				width: 24px;
@@ -73,5 +70,8 @@
 		flex-direction: column;
 		gap: 12px;
 		padding: 16px;
+	}
+	&__divider {
+		--divider-margin: 0px;
 	}
 }

--- a/frontend/src/pages/TracesFunnelDetails/components/FunnelConfiguration/FunnelConfiguration.tsx
+++ b/frontend/src/pages/TracesFunnelDetails/components/FunnelConfiguration/FunnelConfiguration.tsx
@@ -77,7 +77,7 @@ function FunnelConfiguration({
 							/>
 						</Tooltip>
 						<CopyToClipboard textToCopy={window.location.href} />
-						<Divider type="vertical" />
+						<Divider type="vertical" className="funnel-configuration__divider" />
 						<FunnelItemPopover
 							isPopoverOpen={isPopoverOpen}
 							setIsPopoverOpen={setIsPopoverOpen}

--- a/frontend/src/pages/TracesFunnelDetails/components/FunnelConfiguration/FunnelStep.styles.scss
+++ b/frontend/src/pages/TracesFunnelDetails/components/FunnelConfiguration/FunnelStep.styles.scss
@@ -94,9 +94,6 @@
 				display: flex;
 				align-items: center;
 			}
-			.ant-divider-vertical {
-				margin: 0 12px;
-			}
 			.funnel-item__action-btn {
 				border: none;
 				padding: 4px;

--- a/frontend/src/pages/TracesFunnelDetails/components/FunnelConfiguration/InterStepConfig.styles.scss
+++ b/frontend/src/pages/TracesFunnelDetails/components/FunnelConfiguration/InterStepConfig.styles.scss
@@ -26,10 +26,7 @@
 	}
 	&__divider {
 		width: 100%;
-		.ant-divider {
-			margin: 0;
-			border-color: var(--l1-border);
-		}
+		--divider-margin: 0;
 	}
 	&__latency-options {
 		flex-shrink: 0;

--- a/frontend/src/pages/TracesFunnelDetails/components/FunnelConfiguration/StepsHeader.styles.scss
+++ b/frontend/src/pages/TracesFunnelDetails/components/FunnelConfiguration/StepsHeader.styles.scss
@@ -17,14 +17,6 @@
 		flex-shrink: 0;
 	}
 
-	&__divider {
-		width: 100%;
-		.ant-divider {
-			margin: 0;
-			border-color: var(--l1-border);
-		}
-	}
-
 	&__time-range {
 		width: 100%;
 		height: 32px;


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

For some reason, after the build, the style order was changed and caused the CSS applied via `margin` or `border-color` to be overriden by our lib.

The fix was to use the CSS variables to override the styles.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

## Before

<img width="763" height="357" alt="image" src="https://github.com/user-attachments/assets/2840cf75-f88c-4de1-94dd-b5d2d4b62207" />

<img width="530" height="279" alt="image" src="https://github.com/user-attachments/assets/a622f10b-c3e5-499d-b0f2-ad7251694dd4" />

<img width="604" height="459" alt="image" src="https://github.com/user-attachments/assets/d2eedc48-2d31-4074-8674-12ddb7c9d142" />

<img width="664" height="533" alt="screenshot-2026-05-28_11-10-27" src="https://github.com/user-attachments/assets/8d60a78d-1cde-44d8-a09c-3a96a2a33823" />

## After

<img width="555" height="66" alt="screenshot-2026-05-28_11-05-40" src="https://github.com/user-attachments/assets/64376648-286e-400e-a3ec-996a297acb39" />
<img width="562" height="165" alt="screenshot-2026-05-28_11-02-24" src="https://github.com/user-attachments/assets/65ec5552-5566-482a-9bb0-e8c438a60a45" />
<img width="678" height="266" alt="screenshot-2026-05-28_10-51-54" src="https://github.com/user-attachments/assets/e04e6800-97c7-486c-8db6-90a0c3685160" />
<img width="452" height="143" alt="screenshot-2026-05-28_10-50-29" src="https://github.com/user-attachments/assets/5feb95ad-8cbd-4bc3-b49a-f48de0b2ba95" />
<img width="1110" height="124" alt="screenshot-2026-05-28_10-42-48" src="https://github.com/user-attachments/assets/3b3aae0a-62c4-40df-ae2f-3786d48bd70c" />
<img width="945" height="248" alt="screenshot-2026-05-28_10-35-47" src="https://github.com/user-attachments/assets/49ee0631-1d04-4bf3-90ac-10c8c0cb05e1" />
<img width="507" height="242" alt="screenshot-2026-05-28_10-33-23" src="https://github.com/user-attachments/assets/2e5dfcfa-2402-41d7-8777-ebff05b496c4" />
<img width="499" height="400" alt="screenshot-2026-05-28_10-28-55" src="https://github.com/user-attachments/assets/ea857d87-7639-4b05-ba96-8f0803b22df4" />
<img width="755" height="500" alt="screenshot-2026-05-28_10-28-47" src="https://github.com/user-attachments/assets/dcae5bfd-57e8-4ffe-8c28-630cd07dc469" />
<img width="764" height="481" alt="screenshot-2026-05-28_10-28-36" src="https://github.com/user-attachments/assets/01c1f523-f705-425b-84ee-e23d519c3d44" />

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Fixes https://github.com/SigNoz/engineering-pod/issues/5120

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

After the build, style order changed causing issues with specificity.

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

The issue is likely caused by https://github.com/vitejs/vite/issues/4890

#### Fix Strategy
> How does this PR address the root cause?

Use CSS Variables

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: -
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Pages using Divider
- Potential regressions: UI Regressions
- Rollback plan: Find and fix directly.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed an issue in some parts of the UI, specially on Alerts, causing the spacing of the divided sections to be wrong. |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered