### PR TITLE
fix: do not close suggestion on typing period

### DIFF
--- a/frontend/src/utils/__tests__/queryContextUtils.test.ts
+++ b/frontend/src/utils/__tests__/queryContextUtils.test.ts
@@ -3,6 +3,7 @@ import {
 	extractQueryPairs,
 	getCurrentQueryPair,
 	getCurrentValueIndexAtCursor,
+	getQueryContextAtCursor,
 } from '../queryContextUtils';
 
 describe('extractQueryPairs', () => {
@@ -606,5 +607,44 @@ describe('getCurrentQueryPair', () => {
 		const result = getCurrentQueryPair(queryPairs, query, 5);
 
 		expect(result).toStrictEqual(queryPairs[0]);
+	});
+});
+
+describe('getQueryContextAtCursor - trailing dot in key/value', () => {
+	// A token ending with "." (e.g. "service.") is lexed as FREETEXT rather than
+	// KEY, which previously collapsed the context to "nothing" and made the
+	// suggestion dropdown render empty (appearing closed). These cases lock in
+	// that a partial key/value still resolves to the correct context.
+	it('keeps key context while typing a key that ends with a dot', () => {
+		['service.', 'k8s.', 'attribute.', 'k8s.pod.'].forEach((q) => {
+			const ctx = getQueryContextAtCursor(q, q.length);
+			expect(ctx.isInKey).toBe(true);
+			expect(ctx.isInValue).toBe(false);
+			expect(ctx.isInOperator).toBe(false);
+			expect(ctx.keyToken).toBe(q);
+		});
+	});
+
+	it('treats a new key after a conjunction as key context', () => {
+		const q = 'a = b AND k8s.';
+		const ctx = getQueryContextAtCursor(q, q.length);
+		expect(ctx.isInKey).toBe(true);
+		expect(ctx.isInValue).toBe(false);
+	});
+
+	it('keeps value context while typing a value that ends with a dot', () => {
+		const q = 'service.name = foo.';
+		const ctx = getQueryContextAtCursor(q, q.length);
+		expect(ctx.isInValue).toBe(true);
+		expect(ctx.isInKey).toBe(false);
+		expect(ctx.keyToken).toBe('service.name');
+		expect(ctx.operatorToken).toBe('=');
+	});
+
+	it('still resolves a complete dotted key to key context', () => {
+		const q = 'k8s.namespace';
+		const ctx = getQueryContextAtCursor(q, q.length);
+		expect(ctx.isInKey).toBe(true);
+		expect(ctx.keyToken).toBe('k8s.namespace');
 	});
 });

--- a/frontend/src/utils/queryContextUtils.ts
+++ b/frontend/src/utils/queryContextUtils.ts
@@ -766,6 +766,58 @@ export function getQueryContextAtCursor(
 			}
 		}
 
+		// A token that ends with a '.' (e.g. "service." or "k8s.pod.") is lexed as
+		// FREETEXT, not KEY, because the KEY rule requires a character after the dot.
+		// While the user is mid-typing such a key/value the token stays FREETEXT, which
+		// is otherwise unclassified and would collapse the context to "nothing" — making
+		// the suggestion dropdown render empty (and appear closed). Classify the partial
+		// token by the slot it occupies so suggestions keep flowing until the next
+		// character turns it back into a valid KEY token.
+		const partialToken = exactToken ?? lastTokenBeforeCursor;
+		if (
+			partialToken &&
+			partialToken.channel === 0 &&
+			partialToken.type === FilterQueryLexer.FREETEXT
+		) {
+			// Closest meaningful token before the partial one determines the slot:
+			// right after an operator we are typing a value, otherwise a key.
+			const prevMeaningful =
+				allTokens
+					.filter(
+						(t) =>
+							t.channel === 0 &&
+							t.type !== FilterQueryLexer.EOF &&
+							t.stop < partialToken.start,
+					)
+					.pop() || null;
+
+			const prevContext = prevMeaningful
+				? determineTokenContext(prevMeaningful, input)
+				: null;
+			const isValuePosition = !!prevContext?.isInOperator;
+
+			return {
+				tokenType: partialToken.type,
+				text: partialToken.text,
+				start: partialToken.start,
+				stop: partialToken.stop,
+				currentToken: partialToken.text,
+				isInKey: !isValuePosition,
+				isInNegation: false,
+				isInOperator: false,
+				isInValue: isValuePosition,
+				isInFunction: false,
+				isInConjunction: false,
+				isInParenthesis: false,
+				isInBracketList: false,
+				keyToken: isValuePosition ? currentPair?.key || '' : partialToken.text,
+				operatorToken: isValuePosition ? currentPair?.operator || '' : undefined,
+				valueToken: isValuePosition ? partialToken.text : undefined,
+				queryPairs,
+				currentPair,
+			};
+		}
+
 		// If we don't have tokens yet, return default context
 		if (!previousToken && !nextToken && !exactToken && !lastTokenBeforeCursor) {
 			return {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?

Trailing `.` is treated as a value instead of a key and hence no suggestions.
The suggestion box closes as soon as on types `.`. For example typing `service` will suggest auto-complete but after `serice.` it will close itl   

> What problem does it solve, and why is this the right approach?

Before

https://github.com/user-attachments/assets/9144d840-7044-4cac-aad5-7b5a7775acc0



After


https://github.com/user-attachments/assets/34443c04-3a04-4cd8-a40b-f7efbbe48e86

