### PR TITLE
feat(trace-details): add implementation for flamegraph building (part 2)

### DIFF
--- a/pkg/modules/tracedetail/config.go
+++ b/pkg/modules/tracedetail/config.go
@@ -59,19 +59,19 @@ func (c Config) Validate() error {
 		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.waterfall.max_limit_to_select_all_spans must be positive")
 	}
 	if c.Flamegraph.MaxSelectedLevels <= 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.level_limit must be positive, got %d", c.Flamegraph.MaxSelectedLevels)
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.max_selected_levels must be positive, got %d", c.Flamegraph.MaxSelectedLevels)
 	}
 	if c.Flamegraph.MaxSpansPerLevel <= 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.spans_per_level must be positive, got %d", c.Flamegraph.MaxSpansPerLevel)
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.max_spans_per_level must be positive, got %d", c.Flamegraph.MaxSpansPerLevel)
 	}
 	if c.Flamegraph.SamplingTopLatencySpansCount < 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.top_latency_count cannot be negative, got %d", c.Flamegraph.SamplingTopLatencySpansCount)
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.sampling_top_latency_count cannot be negative, got %d", c.Flamegraph.SamplingTopLatencySpansCount)
 	}
 	if c.Flamegraph.SamplingBucketCount <= 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.bucket_count must be positive, got %d", c.Flamegraph.SamplingBucketCount)
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.sampling_bucket_count must be positive, got %d", c.Flamegraph.SamplingBucketCount)
 	}
 	if c.Flamegraph.SelectAllSpansLimit == 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.max_limit_to_select_all_spans must be positive")
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.select_all_spans_limit must be positive")
 	}
 	return nil
 }

--- a/pkg/modules/tracedetail/config.go
+++ b/pkg/modules/tracedetail/config.go
@@ -59,39 +59,19 @@ func (c Config) Validate() error {
 		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.waterfall.max_limit_to_select_all_spans must be positive")
 	}
 	if c.Flamegraph.MaxSelectedLevels <= 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tracedetail.flamegraph.level_limit must be positive, got %d", c.Flamegraph.MaxSelectedLevels)
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.level_limit must be positive, got %d", c.Flamegraph.MaxSelectedLevels)
 	}
 	if c.Flamegraph.MaxSpansPerLevel <= 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tracedetail.flamegraph.spans_per_level must be positive, got %d", c.Flamegraph.MaxSpansPerLevel)
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.spans_per_level must be positive, got %d", c.Flamegraph.MaxSpansPerLevel)
 	}
 	if c.Flamegraph.SamplingTopLatencySpansCount < 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tracedetail.flamegraph.top_latency_count cannot be negative, got %d", c.Flamegraph.SamplingTopLatencySpansCount)
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.top_latency_count cannot be negative, got %d", c.Flamegraph.SamplingTopLatencySpansCount)
 	}
 	if c.Flamegraph.SamplingBucketCount <= 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tracedetail.flamegraph.bucket_count must be positive, got %d", c.Flamegraph.SamplingBucketCount)
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.bucket_count must be positive, got %d", c.Flamegraph.SamplingBucketCount)
 	}
 	if c.Flamegraph.SelectAllSpansLimit == 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tracedetail.flamegraph.max_limit_to_select_all_spans must be positive")
-	}
-	if c.Flamegraph.MaxSelectedLevels <= 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput,
-			"tracedetail.flamegraph.level_limit must be positive, got %d", c.Flamegraph.MaxSelectedLevels)
-	}
-	if c.Flamegraph.MaxSpansPerLevel <= 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput,
-			"tracedetail.flamegraph.spans_per_level must be positive, got %d", c.Flamegraph.MaxSpansPerLevel)
-	}
-	if c.Flamegraph.SamplingTopLatencySpansCount < 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput,
-			"tracedetail.flamegraph.top_latency_count cannot be negative, got %d", c.Flamegraph.SamplingTopLatencySpansCount)
-	}
-	if c.Flamegraph.SamplingBucketCount <= 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput,
-			"tracedetail.flamegraph.bucket_count must be positive, got %d", c.Flamegraph.SamplingBucketCount)
-	}
-	if c.Flamegraph.SelectAllSpansLimit == 0 {
-		return errors.NewInvalidInputf(errors.CodeInvalidInput,
-			"tracedetail.flamegraph.max_limit_to_select_all_spans must be positive")
+		return errors.NewInvalidInputf(errors.CodeInvalidInput, "traces.flamegraph.max_limit_to_select_all_spans must be positive")
 	}
 	return nil
 }

--- a/pkg/modules/tracedetail/config.go
+++ b/pkg/modules/tracedetail/config.go
@@ -73,5 +73,25 @@ func (c Config) Validate() error {
 	if c.Flamegraph.SelectAllSpansLimit == 0 {
 		return errors.NewInvalidInputf(errors.CodeInvalidInput, "tracedetail.flamegraph.max_limit_to_select_all_spans must be positive")
 	}
+	if c.Flamegraph.MaxSelectedLevels <= 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput,
+			"tracedetail.flamegraph.level_limit must be positive, got %d", c.Flamegraph.MaxSelectedLevels)
+	}
+	if c.Flamegraph.MaxSpansPerLevel <= 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput,
+			"tracedetail.flamegraph.spans_per_level must be positive, got %d", c.Flamegraph.MaxSpansPerLevel)
+	}
+	if c.Flamegraph.SamplingTopLatencySpansCount < 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput,
+			"tracedetail.flamegraph.top_latency_count cannot be negative, got %d", c.Flamegraph.SamplingTopLatencySpansCount)
+	}
+	if c.Flamegraph.SamplingBucketCount <= 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput,
+			"tracedetail.flamegraph.bucket_count must be positive, got %d", c.Flamegraph.SamplingBucketCount)
+	}
+	if c.Flamegraph.SelectAllSpansLimit == 0 {
+		return errors.NewInvalidInputf(errors.CodeInvalidInput,
+			"tracedetail.flamegraph.max_limit_to_select_all_spans must be positive")
+	}
 	return nil
 }

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -34,6 +34,7 @@ func NewModule(traceStore spantypes.TraceStore, providerSettings factory.Provide
 	}
 
 	m.metrics.waterfallSpanLimit.Record(context.Background(), int64(cfg.Waterfall.MaxLimitToSelectAllSpans), metric.WithAttributes(attrResponseType.String(attrResponseTypeWindowed)))
+	m.metrics.flamegraphSpanLimit.Record(context.Background(), int64(cfg.Flamegraph.SelectAllSpansLimit), metric.WithAttributes(attrResponseType.String(attrResponseTypeSampled)))
 
 	return m
 }
@@ -173,6 +174,7 @@ func (m *module) GetFlamegraph(ctx context.Context, traceID string, selectedSpan
 	if summary.NumSpans <= uint64(m.config.Flamegraph.SelectAllSpansLimit) {
 		return m.getFullFlamegraph(ctx, traceID, summary, selectFields)
 	}
+	m.metrics.flamegraphRequestCount.Add(ctx, 1, metric.WithAttributes(attrResponseType.String(attrResponseTypeSampled)))
 	return m.getWindowedFlamegraph(ctx, traceID, selectedSpanID, summary, selectFields)
 }
 

--- a/pkg/modules/tracedetail/impltracedetail/telemetry.go
+++ b/pkg/modules/tracedetail/impltracedetail/telemetry.go
@@ -9,12 +9,16 @@ import (
 const (
 	attrResponseType         = attribute.Key("response_type")
 	attrResponseTypeWindowed = "windowed"
+	attrResponseTypeSampled  = "sampled"
 )
 
 type moduleMetrics struct {
 	waterfallSpanLimit    metric.Int64Gauge
 	waterfallRequestCount metric.Int64Counter
 	waterfallSpanCount    metric.Int64Counter
+
+	flamegraphSpanLimit    metric.Int64Gauge
+	flamegraphRequestCount metric.Int64Counter
 }
 
 func newModuleMetrics(meter metric.Meter) (*moduleMetrics, error) {
@@ -47,9 +51,30 @@ func newModuleMetrics(meter metric.Meter) (*moduleMetrics, error) {
 		errs = errors.Join(errs, err)
 	}
 
+	flamegraphSpanLimit, err := meter.Int64Gauge(
+		"signoz.traces.flamegraph.span.limit",
+		metric.WithDescription("The span count limit above which sampled flamegraph is returned instead of the full flamegraph."),
+		metric.WithUnit("{span}"),
+	)
+	if err != nil {
+		errs = errors.Join(errs, err)
+	}
+
+	flamegraphRequestCount, err := meter.Int64Counter(
+		"signoz.traces.flamegraph.request.count",
+		metric.WithDescription("Total number of flamegraph requests, by response_type."),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		errs = errors.Join(errs, err)
+	}
+
 	return &moduleMetrics{
 		waterfallSpanLimit:    spanLimit,
 		waterfallRequestCount: requestCount,
 		waterfallSpanCount:    spanCount,
+
+		flamegraphSpanLimit:    flamegraphSpanLimit,
+		flamegraphRequestCount: flamegraphRequestCount,
 	}, errs
 }

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -41,19 +41,47 @@ func NewFlamegraphTraceFromStorable(spans []StorableSpan, selectFields []telemet
 }
 
 func (t *FlamegraphTrace) GetAllLevels() [][]*FlamegraphSpan {
-	allLevels := t.buildAllLevels()
-	for _, node := range t.nodeByID {
-		node.Children = nil // children not required after building tree
+	var result [][]*FlamegraphSpan
+
+	type entry struct {
+		node  *FlamegraphSpan
+		depth int64
 	}
-	return allLevels
+
+	for _, root := range t.roots {
+		levelMap := make(map[int64][]*FlamegraphSpan)
+		maxDepth := int64(-1)
+
+		queue := []entry{{root, 0}}
+		for len(queue) > 0 {
+			curr := queue[0]
+			queue = queue[1:]
+			curr.node.Level = curr.depth
+			levelMap[curr.depth] = append(levelMap[curr.depth], curr.node)
+			if curr.depth > maxDepth {
+				maxDepth = curr.depth
+			}
+			for _, child := range curr.node.Children {
+				queue = append(queue, entry{child, curr.depth + 1})
+			}
+		}
+
+		for depth := int64(0); depth <= maxDepth; depth++ {
+			if spans, ok := levelMap[depth]; ok {
+				result = append(result, spans)
+			}
+		}
+	}
+
+	for _, node := range t.nodeByID {
+		node.Children = nil
+	}
+	return result
 }
 
 // GetSelectedLevels returns the window of levels around selectedSpanID with sampling applied to dense levels.
 func (t *FlamegraphTrace) GetSelectedLevels(selectedSpanID string, levelLimit, spansPerLevel, topLatencyCount, bucketCount int) []FlamegraphLevel {
-	allLevels := t.buildAllLevels()
-	for _, node := range t.nodeByID {
-		node.Children = nil
-	}
+	allLevels := t.GetAllLevels()
 
 	selectedIndex := 0
 	if selectedSpanID != "" {
@@ -162,42 +190,6 @@ func (t *FlamegraphTrace) buildSpanTree() {
 		}
 		return t.roots[i].Timestamp < t.roots[j].Timestamp
 	})
-}
-
-func (t *FlamegraphTrace) buildAllLevels() [][]*FlamegraphSpan {
-	var result [][]*FlamegraphSpan
-
-	type entry struct {
-		node  *FlamegraphSpan
-		depth int64
-	}
-
-	for _, root := range t.roots {
-		levelMap := make(map[int64][]*FlamegraphSpan)
-		maxDepth := int64(-1)
-
-		queue := []entry{{root, 0}}
-		for len(queue) > 0 {
-			curr := queue[0]
-			queue = queue[1:]
-			curr.node.Level = curr.depth
-			levelMap[curr.depth] = append(levelMap[curr.depth], curr.node)
-			if curr.depth > maxDepth {
-				maxDepth = curr.depth
-			}
-			for _, child := range curr.node.Children {
-				queue = append(queue, entry{child, curr.depth + 1})
-			}
-		}
-
-		for depth := int64(0); depth <= maxDepth; depth++ {
-			if spans, ok := levelMap[depth]; ok {
-				result = append(result, spans)
-			}
-		}
-	}
-
-	return result
 }
 
 func sampleFlamegraphLevel(

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -41,12 +41,75 @@ func NewFlamegraphTraceFromStorable(spans []StorableSpan, selectFields []telemet
 }
 
 func (t *FlamegraphTrace) GetAllLevels() [][]*FlamegraphSpan {
-	return nil
+	allLevels := t.buildAllLevels()
+	for _, node := range t.nodeByID {
+		node.Children = nil // children not required after building tree
+	}
+	return allLevels
 }
 
 // GetSelectedLevels returns the window of levels around selectedSpanID with sampling applied to dense levels.
 func (t *FlamegraphTrace) GetSelectedLevels(selectedSpanID string, levelLimit, spansPerLevel, topLatencyCount, bucketCount int) []FlamegraphLevel {
-	return nil
+	allLevels := t.buildAllLevels()
+	for _, node := range t.nodeByID {
+		node.Children = nil
+	}
+
+	selectedIndex := 0
+	if selectedSpanID != "" {
+	outer:
+		for i, lvl := range allLevels {
+			for _, span := range lvl {
+				if span.SpanID == selectedSpanID {
+					selectedIndex = i
+					break outer
+				}
+			}
+		}
+	}
+
+	lowerLimit := selectedIndex - int(float64(levelLimit)*0.4)
+	upperLimit := selectedIndex + int(float64(levelLimit)*0.6)
+
+	if lowerLimit < 0 {
+		upperLimit -= lowerLimit
+		lowerLimit = 0
+	}
+	if upperLimit > len(allLevels) {
+		lowerLimit -= upperLimit - len(allLevels)
+		upperLimit = len(allLevels)
+	}
+	if lowerLimit < 0 {
+		lowerLimit = 0
+	}
+
+	result := make([]FlamegraphLevel, 0, upperLimit-lowerLimit)
+	for i := lowerLimit; i < upperLimit; i++ {
+		lvl := allLevels[i]
+		if len(lvl) == 0 {
+			continue
+		}
+		var sampled []*FlamegraphSpan
+		if len(lvl) > spansPerLevel {
+			sampled = sampleFlamegraphLevel(lvl, selectedSpanID, i == selectedIndex,
+				t.startTime, t.endTime, topLatencyCount, bucketCount)
+		} else {
+			sampled = lvl
+		}
+		if len(sampled) == 0 {
+			continue
+		}
+		spanIDs := make([]string, len(sampled))
+		for j, s := range sampled {
+			spanIDs[j] = s.SpanID
+		}
+		result = append(result, FlamegraphLevel{
+			Level:   sampled[0].Level,
+			SpanIDs: spanIDs,
+		})
+	}
+
+	return result
 }
 
 func (t *FlamegraphTrace) EnrichSelectedSpans(selectedSpans []FlamegraphLevel, fullSpans []StorableSpan, selectFields []telemetrytypes.TelemetryFieldKey) [][]*FlamegraphSpan {
@@ -99,6 +162,98 @@ func (t *FlamegraphTrace) buildSpanTree() {
 		}
 		return t.roots[i].Timestamp < t.roots[j].Timestamp
 	})
+}
+
+func (t *FlamegraphTrace) buildAllLevels() [][]*FlamegraphSpan {
+	var result [][]*FlamegraphSpan
+
+	type entry struct {
+		node  *FlamegraphSpan
+		depth int64
+	}
+
+	for _, root := range t.roots {
+		levelMap := make(map[int64][]*FlamegraphSpan)
+		maxDepth := int64(-1)
+
+		queue := []entry{{root, 0}}
+		for len(queue) > 0 {
+			curr := queue[0]
+			queue = queue[1:]
+			curr.node.Level = curr.depth
+			levelMap[curr.depth] = append(levelMap[curr.depth], curr.node)
+			if curr.depth > maxDepth {
+				maxDepth = curr.depth
+			}
+			for _, child := range curr.node.Children {
+				queue = append(queue, entry{child, curr.depth + 1})
+			}
+		}
+
+		for depth := int64(0); depth <= maxDepth; depth++ {
+			if spans, ok := levelMap[depth]; ok {
+				result = append(result, spans)
+			}
+		}
+	}
+
+	return result
+}
+
+func sampleFlamegraphLevel(
+	spans []*FlamegraphSpan,
+	selectedSpanID string,
+	isSelectedLevel bool,
+	startTime, endTime uint64,
+	topLatencyCount, bucketCount int,
+) []*FlamegraphSpan {
+	sorted := make([]*FlamegraphSpan, len(spans))
+	copy(sorted, spans)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].DurationNano > sorted[j].DurationNano
+	})
+
+	var sampled []*FlamegraphSpan
+
+	topK := min(topLatencyCount, len(sorted))
+	sampled = append(sampled, sorted[:topK]...)
+
+	if isSelectedLevel {
+		for _, span := range sorted {
+			if span.SpanID == selectedSpanID {
+				sampled = append(sampled, span)
+				break
+			}
+		}
+	}
+
+	bucketSize := (endTime - startTime) / uint64(bucketCount)
+	if bucketSize == 0 {
+		bucketSize = 1
+	}
+	buckets := make([][]*FlamegraphSpan, bucketCount)
+	for _, span := range sorted {
+		if span.Timestamp < startTime || span.Timestamp > endTime {
+			continue
+		}
+		idx := int((span.Timestamp - startTime) / bucketSize)
+		if idx < 0 {
+			idx = 0
+		} else if idx >= bucketCount {
+			idx = bucketCount - 1
+		}
+		buckets[idx] = append(buckets[idx], span)
+	}
+	for i := range buckets {
+		if len(buckets[i]) > 2 {
+			buckets[i] = buckets[i][:2]
+		}
+	}
+	for _, bucket := range buckets {
+		sampled = append(sampled, bucket...)
+	}
+
+	return sampled
 }
 
 func flamegraphSpanIndex(spans []*FlamegraphSpan, spanID string) int {

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -83,46 +83,19 @@ func (t *FlamegraphTrace) GetAllLevels() [][]*FlamegraphSpan {
 func (t *FlamegraphTrace) GetSelectedLevels(selectedSpanID string, levelLimit, spansPerLevel, topLatencyCount, bucketCount int) []FlamegraphLevel {
 	allLevels := t.GetAllLevels()
 
-	selectedIndex := 0
-	if selectedSpanID != "" {
-	outer:
-		for i, lvl := range allLevels {
-			for _, span := range lvl {
-				if span.SpanID == selectedSpanID {
-					selectedIndex = i
-					break outer
-				}
-			}
-		}
-	}
+	selectedIndex := getLevelIndex(allLevels, selectedSpanID)
 
-	lowerLimit := selectedIndex - int(float64(levelLimit)*0.4)
-	upperLimit := selectedIndex + int(float64(levelLimit)*0.6)
+	beforeSelectedLevel := int(float64(levelLimit) * 0.4)
+	startLevel := max(0, selectedIndex-beforeSelectedLevel)
+	endLevel := min(len(allLevels), startLevel+levelLimit)
 
-	if lowerLimit < 0 {
-		upperLimit -= lowerLimit
-		lowerLimit = 0
-	}
-	if upperLimit > len(allLevels) {
-		lowerLimit -= upperLimit - len(allLevels)
-		upperLimit = len(allLevels)
-	}
-	if lowerLimit < 0 {
-		lowerLimit = 0
-	}
-
-	result := make([]FlamegraphLevel, 0, upperLimit-lowerLimit)
-	for i := lowerLimit; i < upperLimit; i++ {
-		lvl := allLevels[i]
-		if len(lvl) == 0 {
-			continue
-		}
-		var sampled []*FlamegraphSpan
-		if len(lvl) > spansPerLevel {
-			sampled = sampleFlamegraphLevel(lvl, selectedSpanID, i == selectedIndex,
+	result := make([]FlamegraphLevel, 0, endLevel-startLevel)
+	for i := startLevel; i < endLevel; i++ {
+		spans := allLevels[i]
+		sampled := spans
+		if len(spans) > spansPerLevel {
+			sampled = sampleFlamegraphLevel(spans, selectedSpanID, i == selectedIndex,
 				t.startTime, t.endTime, topLatencyCount, bucketCount)
-		} else {
-			sampled = lvl
 		}
 		if len(sampled) == 0 {
 			continue
@@ -131,10 +104,7 @@ func (t *FlamegraphTrace) GetSelectedLevels(selectedSpanID string, levelLimit, s
 		for j, s := range sampled {
 			spanIDs[j] = s.SpanID
 		}
-		result = append(result, FlamegraphLevel{
-			Level:   sampled[0].Level,
-			SpanIDs: spanIDs,
-		})
+		result = append(result, FlamegraphLevel{Level: spans[0].Level, SpanIDs: spanIDs})
 	}
 
 	return result
@@ -192,13 +162,7 @@ func (t *FlamegraphTrace) buildSpanTree() {
 	})
 }
 
-func sampleFlamegraphLevel(
-	spans []*FlamegraphSpan,
-	selectedSpanID string,
-	isSelectedLevel bool,
-	startTime, endTime uint64,
-	topLatencyCount, bucketCount int,
-) []*FlamegraphSpan {
+func sampleFlamegraphLevel(spans []*FlamegraphSpan, selectedSpanID string, isSelectedLevel bool, startTime, endTime uint64, topLatencyCount, bucketCount int) []*FlamegraphSpan {
 	sorted := make([]*FlamegraphSpan, len(spans))
 	copy(sorted, spans)
 	sort.Slice(sorted, func(i, j int) bool {
@@ -246,6 +210,17 @@ func sampleFlamegraphLevel(
 	}
 
 	return sampled
+}
+
+func getLevelIndex(levels [][]*FlamegraphSpan, spanID string) int {
+	for i, lvl := range levels {
+		for _, span := range lvl {
+			if span.SpanID == spanID {
+				return i
+			}
+		}
+	}
+	return 0
 }
 
 func flamegraphSpanIndex(spans []*FlamegraphSpan, spanID string) int {

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -85,6 +85,7 @@ func (t *FlamegraphTrace) GetSelectedLevels(selectedSpanID string, levelLimit, s
 
 	selectedIndex := getLevelIndex(allLevels, selectedSpanID)
 
+	// 40% window above level with selected span and 60% below that
 	beforeSelectedLevel := int(float64(levelLimit) * 0.4)
 	startLevel := max(0, selectedIndex-beforeSelectedLevel)
 	endLevel := min(len(allLevels), startLevel+levelLimit)
@@ -94,8 +95,7 @@ func (t *FlamegraphTrace) GetSelectedLevels(selectedSpanID string, levelLimit, s
 		spans := allLevels[i]
 		sampled := spans
 		if len(spans) > spansPerLevel {
-			sampled = sampleFlamegraphLevel(spans, selectedSpanID, i == selectedIndex,
-				t.startTime, t.endTime, topLatencyCount, bucketCount)
+			sampled = t.sampleLevel(spans, selectedSpanID, i == selectedIndex, topLatencyCount, bucketCount)
 		}
 		if len(sampled) == 0 {
 			continue
@@ -162,17 +162,16 @@ func (t *FlamegraphTrace) buildSpanTree() {
 	})
 }
 
-func sampleFlamegraphLevel(spans []*FlamegraphSpan, selectedSpanID string, isSelectedLevel bool, startTime, endTime uint64, topLatencyCount, bucketCount int) []*FlamegraphSpan {
+func (t *FlamegraphTrace) sampleLevel(spans []*FlamegraphSpan, selectedSpanID string, isSelectedLevel bool, topLatencyCount, bucketCount int) []*FlamegraphSpan {
 	sorted := make([]*FlamegraphSpan, len(spans))
 	copy(sorted, spans)
 	sort.Slice(sorted, func(i, j int) bool {
 		return sorted[i].DurationNano > sorted[j].DurationNano
 	})
 
-	var sampled []*FlamegraphSpan
-
 	topK := min(topLatencyCount, len(sorted))
-	sampled = append(sampled, sorted[:topK]...)
+	sampled := make([]*FlamegraphSpan, topK, topK+1)
+	copy(sampled, sorted[:topK])
 
 	if isSelectedLevel {
 		for _, span := range sorted {
@@ -183,33 +182,29 @@ func sampleFlamegraphLevel(spans []*FlamegraphSpan, selectedSpanID string, isSel
 		}
 	}
 
-	bucketSize := (endTime - startTime) / uint64(bucketCount)
+	return append(sampled, t.bucketSampleSpans(sorted, bucketCount)...)
+}
+
+func (t *FlamegraphTrace) bucketSampleSpans(sorted []*FlamegraphSpan, bucketCount int) []*FlamegraphSpan {
+	bucketSize := (t.endTime - t.startTime) / uint64(bucketCount)
 	if bucketSize == 0 {
 		bucketSize = 1
 	}
 	buckets := make([][]*FlamegraphSpan, bucketCount)
 	for _, span := range sorted {
-		if span.Timestamp < startTime || span.Timestamp > endTime {
+		if span.Timestamp < t.startTime || span.Timestamp > t.endTime {
 			continue
 		}
-		idx := int((span.Timestamp - startTime) / bucketSize)
-		if idx < 0 {
-			idx = 0
-		} else if idx >= bucketCount {
-			idx = bucketCount - 1
-		}
-		buckets[idx] = append(buckets[idx], span)
-	}
-	for i := range buckets {
-		if len(buckets[i]) > 2 {
-			buckets[i] = buckets[i][:2]
+		idx := min(int((span.Timestamp-t.startTime)/bucketSize), bucketCount-1)
+		if len(buckets[idx]) < 2 {
+			buckets[idx] = append(buckets[idx], span)
 		}
 	}
+	var result []*FlamegraphSpan
 	for _, bucket := range buckets {
-		sampled = append(sampled, bucket...)
+		result = append(result, bucket...)
 	}
-
-	return sampled
+	return result
 }
 
 func getLevelIndex(levels [][]*FlamegraphSpan, spanID string) int {

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -40,6 +40,7 @@ func NewFlamegraphTraceFromStorable(spans []StorableSpan, selectFields []telemet
 	return t
 }
 
+// GetAllLevels return level wise spans using BFS on trace.
 func (t *FlamegraphTrace) GetAllLevels() [][]*FlamegraphSpan {
 	var result [][]*FlamegraphSpan
 	for _, root := range t.roots {
@@ -49,6 +50,7 @@ func (t *FlamegraphTrace) GetAllLevels() [][]*FlamegraphSpan {
 			for _, node := range currentLevel {
 				node.Level = depth
 				nextLevel = append(nextLevel, node.Children...)
+				node.Children = nil // release tree reference
 			}
 			result = append(result, currentLevel)
 			currentLevel = nextLevel
@@ -68,6 +70,7 @@ func (t *FlamegraphTrace) GetSelectedLevels(selectedSpanID string, levelLimit, s
 	beforeSelectedLevel := int(float64(levelLimit) * 0.4)
 	startLevel := max(0, selectedIndex-beforeSelectedLevel)
 	endLevel := min(len(allLevels), startLevel+levelLimit)
+	startLevel = max(0, endLevel-levelLimit) // utilize the page size if endLevel is clamped
 
 	result := make([]FlamegraphLevel, 0, endLevel-startLevel)
 	for i := startLevel; i < endLevel; i++ {
@@ -148,29 +151,44 @@ func (t *FlamegraphTrace) sampleLevel(spans []*FlamegraphSpan, selectedSpanID st
 		return sorted[i].DurationNano > sorted[j].DurationNano
 	})
 
-	topK := min(topLatencyCount, len(sorted))
-	sampled := make([]*FlamegraphSpan, topK, topK+1)
-	copy(sampled, sorted[:topK])
+	sampled := make(map[string]*FlamegraphSpan, topLatencyCount+1)
 
+	topK := min(topLatencyCount, len(sorted))
+	for _, span := range sorted[:topK] {
+		sampled[span.SpanID] = span
+	}
+
+	// include the selected span.
 	if isSelectedLevel {
 		for _, span := range sorted {
 			if span.SpanID == selectedSpanID {
-				sampled = append(sampled, span)
+				sampled[span.SpanID] = span
 				break
 			}
 		}
 	}
 
-	return append(sampled, t.bucketSampleSpans(sorted, bucketCount)...)
+	for _, span := range t.bucketSampleSpans(sorted, bucketCount, sampled) {
+		sampled[span.SpanID] = span
+	}
+
+	result := make([]*FlamegraphSpan, 0, len(sampled))
+	for _, span := range sampled {
+		result = append(result, span)
+	}
+	return result
 }
 
-func (t *FlamegraphTrace) bucketSampleSpans(sorted []*FlamegraphSpan, bucketCount int) []*FlamegraphSpan {
+func (t *FlamegraphTrace) bucketSampleSpans(sorted []*FlamegraphSpan, bucketCount int, exclude map[string]*FlamegraphSpan) []*FlamegraphSpan {
 	bucketSize := (t.endTime - t.startTime) / uint64(bucketCount)
 	if bucketSize == 0 {
 		bucketSize = 1
 	}
 	buckets := make([][]*FlamegraphSpan, bucketCount)
 	for _, span := range sorted {
+		if _, ok := exclude[span.SpanID]; ok {
+			continue
+		}
 		if span.Timestamp < t.startTime || span.Timestamp > t.endTime {
 			continue
 		}

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -42,40 +42,19 @@ func NewFlamegraphTraceFromStorable(spans []StorableSpan, selectFields []telemet
 
 func (t *FlamegraphTrace) GetAllLevels() [][]*FlamegraphSpan {
 	var result [][]*FlamegraphSpan
-
-	type entry struct {
-		node  *FlamegraphSpan
-		depth int64
-	}
-
 	for _, root := range t.roots {
-		levelMap := make(map[int64][]*FlamegraphSpan)
-		maxDepth := int64(-1)
-
-		queue := []entry{{root, 0}}
-		for len(queue) > 0 {
-			curr := queue[0]
-			queue = queue[1:]
-			curr.node.Level = curr.depth
-			levelMap[curr.depth] = append(levelMap[curr.depth], curr.node)
-			if curr.depth > maxDepth {
-				maxDepth = curr.depth
+		currentLevel := []*FlamegraphSpan{root}
+		for depth := int64(0); len(currentLevel) > 0; depth++ {
+			var nextLevel []*FlamegraphSpan
+			for _, node := range currentLevel {
+				node.Level = depth
+				nextLevel = append(nextLevel, node.Children...)
 			}
-			for _, child := range curr.node.Children {
-				queue = append(queue, entry{child, curr.depth + 1})
-			}
-		}
-
-		for depth := int64(0); depth <= maxDepth; depth++ {
-			if spans, ok := levelMap[depth]; ok {
-				result = append(result, spans)
-			}
+			result = append(result, currentLevel)
+			currentLevel = nextLevel
 		}
 	}
 
-	for _, node := range t.nodeByID {
-		node.Children = nil
-	}
 	return result
 }
 

--- a/pkg/types/spantypes/flamegraph_trace_test.go
+++ b/pkg/types/spantypes/flamegraph_trace_test.go
@@ -1,0 +1,270 @@
+package spantypes
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mkMinimal builds a MinimalSpan. timestamp and duration are in nanoseconds.
+func mkMinimal(id, parentID string, timestamp, duration uint64) MinimalSpan {
+	return MinimalSpan{
+		SpanID:       id,
+		ParentSpanID: parentID,
+		StartTime:    time.Unix(0, int64(timestamp)),
+		DurationNano: duration,
+	}
+}
+
+// levelIDs extracts span IDs level-by-level from GetAllLevels output.
+func levelIDs(levels [][]*FlamegraphSpan) [][]string {
+	out := make([][]string, len(levels))
+	for i, lvl := range levels {
+		ids := make([]string, len(lvl))
+		for j, s := range lvl {
+			ids[j] = s.SpanID
+		}
+		out[i] = ids
+	}
+	return out
+}
+
+// makeChainFG builds a linear trace of n spans: span0 → span1 → … → span(n-1).
+func makeChainFG(n int) *FlamegraphTrace {
+	spans := make([]MinimalSpan, n)
+	for i := range n {
+		parent := ""
+		if i > 0 {
+			parent = fmt.Sprintf("span%d", i-1)
+		}
+		spans[i] = mkMinimal(fmt.Sprintf("span%d", i), parent, uint64(i*100), 100)
+	}
+	return NewFlamegraphTraceFromMinimal(spans)
+}
+
+// makeBroadTrace builds a trace: root → N children (wide, one level deep).
+func makeBroadTrace(n int) *FlamegraphTrace {
+	spans := make([]MinimalSpan, n+1)
+	spans[0] = mkMinimal("root", "", 0, uint64(n*100))
+	for i := range n {
+		spans[i+1] = mkMinimal(fmt.Sprintf("child%d", i), "root", uint64(i*100), 100)
+	}
+	return NewFlamegraphTraceFromMinimal(spans)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildSpanTree / GetAllLevels
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestGetAllLevels(t *testing.T) {
+	tests := []struct {
+		name  string
+		spans []MinimalSpan
+		check func(t *testing.T, levels [][]*FlamegraphSpan)
+	}{
+		{
+			// root → child → grandchild: three levels, one span each.
+			name: "linear_chain",
+			spans: []MinimalSpan{
+				mkMinimal("root", "", 100, 300),
+				mkMinimal("child", "root", 150, 200),
+				mkMinimal("grandchild", "child", 200, 100),
+			},
+			check: func(t *testing.T, levels [][]*FlamegraphSpan) {
+				assert.Equal(t, [][]string{{"root"}, {"child"}, {"grandchild"}}, levelIDs(levels))
+			},
+		},
+		{
+			// root → [A, B]: level 0 has root, level 1 has both children.
+			name: "two_siblings",
+			spans: []MinimalSpan{
+				mkMinimal("root", "", 100, 300),
+				mkMinimal("A", "root", 150, 100),
+				mkMinimal("B", "root", 200, 100),
+			},
+			check: func(t *testing.T, levels [][]*FlamegraphSpan) {
+				assert.Equal(t, []string{"root"}, levelIDs(levels)[0])
+				assert.ElementsMatch(t, []string{"A", "B"}, levelIDs(levels)[1])
+			},
+		},
+		{
+			// child references a non-existent parent → synthetic "Missing Span" root at level 0.
+			name: "missing_parent",
+			spans: []MinimalSpan{
+				mkMinimal("child", "ghost", 100, 100),
+			},
+			check: func(t *testing.T, levels [][]*FlamegraphSpan) {
+				assert.Len(t, levels, 2)
+				assert.Equal(t, "ghost", levels[0][0].SpanID)
+				assert.Equal(t, "Missing Span", levels[0][0].Name)
+				assert.Equal(t, "child", levels[1][0].SpanID)
+			},
+		},
+		{
+			// Children must be nil after BFS so the tree does not stay live in memory.
+			name: "children_nilled_after_bfs",
+			spans: []MinimalSpan{
+				mkMinimal("root", "", 100, 200),
+				mkMinimal("child", "root", 150, 100),
+			},
+			check: func(t *testing.T, levels [][]*FlamegraphSpan) {
+				for _, lvl := range levels {
+					for _, s := range lvl {
+						assert.Nil(t, s.Children)
+					}
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.check(t, NewFlamegraphTraceFromMinimal(tc.spans).GetAllLevels())
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GetSelectedLevels
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestGetSelectedLevels(t *testing.T) {
+	tests := []struct {
+		name          string
+		buildTrace    func() *FlamegraphTrace
+		selectedSpan  string
+		levelLimit    int
+		spansPerLevel int
+		topK          int
+		bucketCount   int
+		check         func(t *testing.T, levels []FlamegraphLevel)
+	}{
+		{
+			// Middle: 40% above (20 levels) + 60% below (30 levels) = 50 total.
+			name:          "window_middle",
+			buildTrace:    func() *FlamegraphTrace { return makeChainFG(100) },
+			selectedSpan:  "span50",
+			levelLimit:    50,
+			spansPerLevel: 1000,
+			topK:          5,
+			bucketCount:   50,
+			check: func(t *testing.T, levels []FlamegraphLevel) {
+				assert.Equal(t, 50, len(levels))
+				assert.Equal(t, "span30", levels[0].SpanIDs[0])
+			},
+		},
+		{
+			// Near start: clamp at 0, redistribute budget downward — still 50 levels.
+			name:          "window_near_start",
+			buildTrace:    func() *FlamegraphTrace { return makeChainFG(100) },
+			selectedSpan:  "span5",
+			levelLimit:    50,
+			spansPerLevel: 1000,
+			topK:          5,
+			bucketCount:   50,
+			check: func(t *testing.T, levels []FlamegraphLevel) {
+				assert.Equal(t, 50, len(levels))
+				assert.Equal(t, "span0", levels[0].SpanIDs[0])
+			},
+		},
+		{
+			// Near end: clamp at total, redistribute budget upward — still 50 levels.
+			name:          "window_near_end",
+			buildTrace:    func() *FlamegraphTrace { return makeChainFG(100) },
+			selectedSpan:  "span95",
+			levelLimit:    50,
+			spansPerLevel: 1000,
+			topK:          5,
+			bucketCount:   50,
+			check: func(t *testing.T, levels []FlamegraphLevel) {
+				assert.Equal(t, 50, len(levels))
+				assert.Equal(t, "span50", levels[0].SpanIDs[0])
+			},
+		},
+		{
+			// Unknown span ID falls back to level 0.
+			name:          "unknown_span_defaults_to_level_zero",
+			buildTrace:    func() *FlamegraphTrace { return makeChainFG(10) },
+			selectedSpan:  "nonexistent",
+			levelLimit:    5,
+			spansPerLevel: 1000,
+			topK:          5,
+			bucketCount:   50,
+			check: func(t *testing.T, levels []FlamegraphLevel) {
+				assert.Equal(t, "span0", levels[0].SpanIDs[0])
+			},
+		},
+		{
+			// Dense levels are sampled down to approximately spansPerLevel.
+			name:          "sampling_respects_cap",
+			buildTrace:    func() *FlamegraphTrace { return makeBroadTrace(200) },
+			selectedSpan:  "root",
+			levelLimit:    10,
+			spansPerLevel: 10,
+			topK:          3,
+			bucketCount:   5,
+			check: func(t *testing.T, levels []FlamegraphLevel) {
+				for _, lvl := range levels {
+					assert.LessOrEqual(t, len(lvl.SpanIDs), 10+3+5*2)
+				}
+			},
+		},
+		{
+			// Selected span always survives sampling even when not in topK.
+			name:          "selected_span_always_included",
+			buildTrace:    func() *FlamegraphTrace { return makeBroadTrace(200) },
+			selectedSpan:  "child99",
+			levelLimit:    10,
+			spansPerLevel: 5,
+			topK:          3,
+			bucketCount:   5,
+			check: func(t *testing.T, levels []FlamegraphLevel) {
+				found := false
+				for _, lvl := range levels {
+					for _, id := range lvl.SpanIDs {
+						if id == "child99" {
+							found = true
+						}
+					}
+				}
+				assert.True(t, found, "selected span must survive sampling")
+			},
+		},
+		{
+			// Selected span is also the highest-latency span (lands in topK) — must not appear twice.
+			name: "no_duplicate_span_ids",
+			buildTrace: func() *FlamegraphTrace {
+				spans := make([]MinimalSpan, 201)
+				spans[0] = mkMinimal("root", "", 0, 10000)
+				for i := range 200 {
+					spans[i+1] = mkMinimal(fmt.Sprintf("child%d", i), "root", uint64(i*50), uint64(200-i)*10)
+				}
+				return NewFlamegraphTraceFromMinimal(spans)
+			},
+			selectedSpan:  "child0",
+			levelLimit:    10,
+			spansPerLevel: 5,
+			topK:          3,
+			bucketCount:   10,
+			check: func(t *testing.T, levels []FlamegraphLevel) {
+				for _, lvl := range levels {
+					seen := map[string]bool{}
+					for _, id := range lvl.SpanIDs {
+						assert.False(t, seen[id], "duplicate span ID %q at level %d", id, lvl.Level)
+						seen[id] = true
+					}
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// fresh trace per subtest: GetAllLevels is destructive (nils Children)
+			levels := tc.buildTrace().GetSelectedLevels(tc.selectedSpan, tc.levelLimit, tc.spansPerLevel, tc.topK, tc.bucketCount)
+			tc.check(t, levels)
+		})
+	}
+}


### PR DESCRIPTION
Part of https://github.com/SigNoz/engineering-pod/issues/4787
Closes https://github.com/SigNoz/engineering-pod/issues/4949

Follow up on https://github.com/SigNoz/signoz/pull/11462

This adds the missing implementation for flamegraph trace building, all the logic is directly copied from v2 logic and refactored to smaller methods in types for readability.