### PR TITLE
fix: badge label color in logs

### DIFF
--- a/frontend/src/container/LogDetailedView/FieldRenderer.styles.ts
+++ b/frontend/src/container/LogDetailedView/FieldRenderer.styles.ts
@@ -12,6 +12,7 @@ export const TagContainer = styled(Badge)`
 `;
 
 export const TagLabel = styled.span`
+	color: var(--foreground);
 	font-weight: 400;
 	font-size: 12px;
 `;


### PR DESCRIPTION
Issue - 

https://signoz-team.slack.com/archives/C02TJ466H8U/p1779970190359879 

<img width="958" height="868" alt="image" src="https://github.com/user-attachments/assets/4aa21a78-fd1d-40c8-8b52-88e820658f58" />

Root cause - 

  @signozhq/ui/badge defaults to color="primary", which the component's colorMap resolves to robin. Its stylesheet then sets, directly on the  The TagContainer styled wrapper only override border-color, border-radius, font-weight, font-size, line-height — it did not override
  
  background-color or color. So every field pill rendered as a solid robin-blue background with white text inherited by TagLabel (which has poor contrast against robin-blue.)
  
  have added. color: var(--foreground)
  
  which fixes this issue 


<img width="951" height="594" alt="image" src="https://github.com/user-attachments/assets/a3fdc433-193f-43d4-a7b8-52584887f178" />
 
<img width="780" height="661" alt="image" src="https://github.com/user-attachments/assets/595c598c-7a23-49d5-a85a-fd22af6201a1" />
