### PR TITLE
feat(web): gate sentry and pylon init behind boot settings flags

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -112,7 +112,10 @@
 
 		<script>
 			var PYLON_APP_ID = '<%- PYLON_APP_ID %>';
-			if (PYLON_APP_ID) {
+			var pylonSettings =
+				((window.signozBootData || {}).settings || {}).pylon || {};
+			var pylonEnabled = pylonSettings.enabled !== false;
+			if (PYLON_APP_ID && pylonEnabled) {
 				(function () {
 					var e = window;
 					var t = document;

--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -291,7 +291,8 @@ function App(): JSX.Element {
 				isLoggedInState &&
 				isChatSupportEnabled &&
 				!showAddCreditCardModal &&
-				(isCloudUser || isEnterpriseSelfHostedUser)
+				(isCloudUser || isEnterpriseSelfHostedUser) &&
+				(window.signozBootData?.settings?.pylon.enabled ?? true)
 			) {
 				const email = user.email || '';
 				const secret = process.env.PYLON_IDENTITY_SECRET || '';
@@ -343,7 +344,10 @@ function App(): JSX.Element {
 				});
 			}
 
-			if (!isSentryInitialized) {
+			if (
+				!isSentryInitialized &&
+				(window.signozBootData?.settings?.sentry.enabled ?? true)
+			) {
 				Sentry.init({
 					dsn: process.env.SENTRY_DSN,
 					tunnel: process.env.TUNNEL_URL,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -31,6 +31,8 @@ function devBootDataPlugin(env: Record<string, string>): Plugin {
 			const settings = {
 				posthog: { enabled: env.VITE_POSTHOG_ENABLED !== 'false' },
 				appcues: { enabled: env.VITE_APPCUES_ENABLED !== 'false' },
+				sentry: { enabled: env.VITE_SENTRY_ENABLED !== 'false' },
+				pylon: { enabled: env.VITE_PYLON_ENABLED !== 'false' },
 			};
 			return html.replaceAll('[[.Settings]]', JSON.stringify(settings));
 		},


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Adds runtime enable/disable control for **Sentry** and **Pylon** via `window.signozBootData.settings`, matching the existing posthog/appcues pattern introduced in #11416.

**What changed:**
- `index.html` — Pylon SDK widget script is now gated behind `pylon.enabled` from boot settings (mirrors the Appcues pattern exactly)
- `AppRoutes/index.tsx` — `Sentry.init()` gated behind `sentry.enabled`; `window.pylon` chat config assignment gated behind `pylon.enabled`
- `vite.config.ts` — `devBootDataPlugin` updated to include `sentry` and `pylon` fields so local dev gets a complete `WebSettings` shape matching what the BE injects in production

**Why this approach:**
All four SDKs (posthog, appcues, sentry, pylon) now follow the same gate pattern: boot settings flag → SDK loads/inits, flag off → SDK never loads. Disabling any SDK is a zero-code-change operator config.

**Fallback behaviour (if BE injection fails):** all SDKs default to `enabled: true` — same as before this change.

#### Issues closed by this PR
Contributes to platform-pod#2144

---

### ✅ Change Type

- [x] ✨ Feature

---

### 🧪 Testing Strategy

- Manual verification:
  - Set `VITE_PYLON_ENABLED=false` → Pylon widget script not injected in `index.html`, `window.pylon` config never set, all `window.Pylon?.()` calls are no-ops
  - Set `VITE_SENTRY_ENABLED=false` → `Sentry.init()` not called, Sentry stays uninitialised (ErrorBoundary still works as passthrough)
  - Default (`true`) → behaviour unchanged from before this PR
- Edge cases covered:
  - BE injection failure (`settings: null`) → `?? true` defaults keep SDKs enabled
  - `window.Pylon` show/hide/setTheme calls use `?.` — safe no-ops if SDK not loaded

---

### ⚠️ Risk & Impact Assessment

- Blast radius: limited to Sentry and Pylon initialisation paths
- Potential regressions: none — default is `enabled: true`, identical to pre-PR behaviour
- Rollback plan: revert this PR; SDKs revert to always-on

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / Enterprise |
| Change Type | Feature |
| Description | Operators can now disable Sentry and Pylon at runtime via boot settings without a code change |

---

### 📋 Checklist
- [x] Manually tested
- [x] Backward compatibility considered — defaults to enabled, no behaviour change for existing deployments

---

## 👀 Notes for Reviewers

- Depends on BE PR #11495 (adds `sentry` and `pylon` to the `Settings` struct)
- `devBootDataPlugin` in `vite.config.ts` must stay in sync with the BE `Settings` struct — if BE adds a new field, the plugin needs a corresponding `VITE_<SDK>_ENABLED` entry