### PR TITLE
refactor: updating cloud integration service dashboard handling

### DIFF
--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -2440,33 +2440,6 @@ export interface CloudintegrationtypesAccountDTO {
 	updatedAt?: string;
 }
 
-export interface DashboardtypesStorableDashboardDataDTO {
-	[key: string]: unknown;
-}
-
-export interface CloudintegrationtypesDashboardDTO {
-	definition?: DashboardtypesStorableDashboardDataDTO;
-	/**
-	 * @type string
-	 */
-	description?: string;
-	/**
-	 * @type string
-	 */
-	id?: string;
-	/**
-	 * @type string
-	 */
-	title?: string;
-}
-
-export interface CloudintegrationtypesAssetsDTO {
-	/**
-	 * @type array,null
-	 */
-	dashboards?: CloudintegrationtypesDashboardDTO[] | null;
-}
-
 export interface CloudintegrationtypesAzureConnectionArtifactDTO {
 	/**
 	 * @type string
@@ -2849,6 +2822,28 @@ export interface CloudintegrationtypesPostableAgentCheckInDTO {
 	providerAccountId?: string;
 }
 
+export interface CloudintegrationtypesServiceDashboardDTO {
+	/**
+	 * @type string
+	 */
+	description?: string;
+	/**
+	 * @type string
+	 */
+	id?: string;
+	/**
+	 * @type string
+	 */
+	title?: string;
+}
+
+export interface CloudintegrationtypesServiceAssetsDTO {
+	/**
+	 * @type array,null
+	 */
+	dashboards: CloudintegrationtypesServiceDashboardDTO[] | null;
+}
+
 export interface CloudintegrationtypesSupportedSignalsDTO {
 	/**
 	 * @type boolean
@@ -2860,13 +2855,8 @@ export interface CloudintegrationtypesSupportedSignalsDTO {
 	metrics?: boolean;
 }
 
-export interface CloudintegrationtypesTelemetryCollectionStrategyDTO {
-	aws?: CloudintegrationtypesAWSTelemetryCollectionStrategyDTO;
-	azure?: CloudintegrationtypesAzureTelemetryCollectionStrategyDTO;
-}
-
 export interface CloudintegrationtypesServiceDTO {
-	assets: CloudintegrationtypesAssetsDTO;
+	assets: CloudintegrationtypesServiceAssetsDTO;
 	cloudIntegrationService: CloudintegrationtypesCloudIntegrationServiceDTO | null;
 	dataCollected: CloudintegrationtypesDataCollectedDTO;
 	/**
@@ -2882,7 +2872,6 @@ export interface CloudintegrationtypesServiceDTO {
 	 */
 	overview: string;
 	supportedSignals: CloudintegrationtypesSupportedSignalsDTO;
-	telemetryCollectionStrategy: CloudintegrationtypesTelemetryCollectionStrategyDTO;
 	/**
 	 * @type string
 	 */
@@ -3686,6 +3675,10 @@ export interface DashboardtypesCustomVariableSpecDTO {
 	 * @type string
 	 */
 	customValue: string;
+}
+
+export interface DashboardtypesStorableDashboardDataDTO {
+	[key: string]: unknown;
 }
 
 export enum DashboardtypesSourceDTO {

--- a/frontend/src/container/Integrations/CloudIntegration/AmazonWebServices/__tests__/mockData.ts
+++ b/frontend/src/container/Integrations/CloudIntegration/AmazonWebServices/__tests__/mockData.ts
@@ -55,7 +55,6 @@ const buildServiceDetailsResponse = (
 				},
 			},
 		},
-		telemetryCollectionStrategy: { aws: {} },
 	},
 });
 

--- a/frontend/src/container/Integrations/CloudIntegration/ServiceDashboards/ServiceDashboards.tsx
+++ b/frontend/src/container/Integrations/CloudIntegration/ServiceDashboards/ServiceDashboards.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 import {
-	CloudintegrationtypesDashboardDTO,
+	CloudintegrationtypesServiceDashboardDTO,
 	CloudintegrationtypesServiceDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
@@ -25,68 +25,67 @@ function ServiceDashboards({
 		<div className="aws-service-dashboards">
 			<div className="aws-service-dashboards-title">Dashboards</div>
 			<div className="aws-service-dashboards-items">
-				{dashboards.map((dashboard: CloudintegrationtypesDashboardDTO) => {
-					if (!dashboard.id) {
-						return null;
-					}
+				{dashboards.map(
+					(dashboard: CloudintegrationtypesServiceDashboardDTO, index: number) => {
+						const isClickable = isInteractive && !!dashboard.id;
+						const dashboardUrl = dashboard.id ? `/dashboard/${dashboard.id}` : '';
 
-					const dashboardUrl = `/dashboard/${dashboard.id}`;
-
-					return (
-						<div
-							key={dashboard.id}
-							className={`aws-service-dashboard-item ${
-								isInteractive ? 'aws-service-dashboard-item-clickable' : ''
-							}`}
-							role={isInteractive ? 'button' : undefined}
-							tabIndex={isInteractive ? 0 : -1}
-							onClick={(event): void => {
-								if (!isInteractive) {
-									return;
-								}
-								if (event.metaKey || event.ctrlKey) {
-									window.open(
-										withBasePath(dashboardUrl),
-										'_blank',
-										'noopener,noreferrer',
-									);
-									return;
-								}
-								safeNavigate(dashboardUrl);
-							}}
-							onAuxClick={(event): void => {
-								if (!isInteractive) {
-									return;
-								}
-								if (event.button === 1) {
-									window.open(
-										withBasePath(dashboardUrl),
-										'_blank',
-										'noopener,noreferrer',
-									);
-								}
-							}}
-							onKeyDown={(event): void => {
-								if (!isInteractive) {
-									return;
-								}
-								if (event.key === 'Enter' || event.key === ' ') {
-									event.preventDefault();
+						return (
+							<div
+								key={dashboard.id || `dashboard-${index}`}
+								className={`aws-service-dashboard-item ${
+									isClickable ? 'aws-service-dashboard-item-clickable' : ''
+								}`}
+								role={isClickable ? 'button' : undefined}
+								tabIndex={isClickable ? 0 : -1}
+								onClick={(event): void => {
+									if (!isClickable) {
+										return;
+									}
+									if (event.metaKey || event.ctrlKey) {
+										window.open(
+											withBasePath(dashboardUrl),
+											'_blank',
+											'noopener,noreferrer',
+										);
+										return;
+									}
 									safeNavigate(dashboardUrl);
-								}
-							}}
-						>
-							<div className="aws-service-dashboard-item-content">
-								<div className="aws-service-dashboard-item-title">
-									{dashboard.title}
-								</div>
-								<div className="aws-service-dashboard-item-description">
-									{dashboard.description}
+								}}
+								onAuxClick={(event): void => {
+									if (!isClickable) {
+										return;
+									}
+									if (event.button === 1) {
+										window.open(
+											withBasePath(dashboardUrl),
+											'_blank',
+											'noopener,noreferrer',
+										);
+									}
+								}}
+								onKeyDown={(event): void => {
+									if (!isClickable) {
+										return;
+									}
+									if (event.key === 'Enter' || event.key === ' ') {
+										event.preventDefault();
+										safeNavigate(dashboardUrl);
+									}
+								}}
+							>
+								<div className="aws-service-dashboard-item-content">
+									<div className="aws-service-dashboard-item-title">
+										{dashboard.title}
+									</div>
+									<div className="aws-service-dashboard-item-description">
+										{dashboard.description}
+									</div>
 								</div>
 							</div>
-						</div>
-					);
-				})}
+						);
+					},
+				)}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Pull Request

Frontend changes to handle response changes in cloud integration service details API.

---

### 📄 Summary
Why does this change exist?  
- OpenAPI spec changes reflection in frontend code
- Fixed a bug where dashboards where clickable when only logs were enabled for the service

#### Issues closed by this PR
https://github.com/SigNoz/engineering-pod/issues/5058

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
When logs where enabled and metrics were NOT enabled for the service, dashboards were clickable, but they should be clickable only when metrics are enabled.

<img width="1701" height="823" alt="image" src="https://github.com/user-attachments/assets/23406381-790a-4bf1-b7e8-9527eefcfad5" />

---

#### Fix Strategy
Changed the code part with right conditional logic
