### PR TITLE
fix(telemetrystore): fix clickhouse connection-pool slot leak (acquire conn timeout)

### DIFF
--- a/ee/query-service/rules/manager_test.go
+++ b/ee/query-service/rules/manager_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 )
 
 func TestManager_TestNotification_SendUnmatched_ThresholdRule(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.25.7
 require (
 	dario.cat/mergo v1.0.2
 	github.com/AfterShip/clickhouse-sql-parser v0.4.16
-	github.com/ClickHouse/clickhouse-go/v2 v2.43.0
+	github.com/ClickHouse/clickhouse-go/v2 v2.44.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/SigNoz/clickhouse-go-mock v0.14.0
 	github.com/SigNoz/govaluate v0.0.0-20240203125216-988004ccc7fd
 	github.com/SigNoz/signoz-otel-collector v0.144.3
 	github.com/antlr4-go/antlr/v4 v4.13.1
@@ -58,7 +59,6 @@ require (
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.10.2
-	github.com/srikanthccv/ClickHouse-go-mock v0.13.0
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggest/jsonschema-go v0.3.78
 	github.com/swaggest/rest v0.2.75

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ClickHouse/ch-go v0.71.0 h1:bUdZ/EZj/LcVHsMqaRUP2holqygrPWQKeMjc6nZoyRM=
 github.com/ClickHouse/ch-go v0.71.0/go.mod h1:NwbNc+7jaqfY58dmdDUbG4Jl22vThgx1cYjBw0vtgXw=
-github.com/ClickHouse/clickhouse-go/v2 v2.43.0 h1:fUR05TrF1GyvLDa/mAQjkx7KbgwdLRffs2n9O3WobtE=
-github.com/ClickHouse/clickhouse-go/v2 v2.43.0/go.mod h1:o6jf7JM/zveWC/PP277BLxjHy5KjnGX/jfljhM4s34g=
+github.com/ClickHouse/clickhouse-go/v2 v2.44.0 h1:9pxs5pRwIvhni5BDRPn/n5A8DeUod5TnBaeulFBX8EQ=
+github.com/ClickHouse/clickhouse-go/v2 v2.44.0/go.mod h1:giJfUVlMkcfUEPVfRpt51zZaGEx9i17gCos8gBl392c=
 github.com/Code-Hex/go-generics-cache v1.5.1 h1:6vhZGc5M7Y/YD8cIUcY8kcuQLB4cHR7U+0KMqAA0KcU=
 github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1vxyillCVzX13KZG8dl4=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
@@ -104,6 +104,8 @@ github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA4
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/SigNoz/clickhouse-go-mock v0.14.0 h1:yYoGMJk0UDVvLCk12dover/zoRIuznW3BfoqUhMoJSY=
+github.com/SigNoz/clickhouse-go-mock v0.14.0/go.mod h1:tXmSXVLWz7N/yVLCianszmNIN4cHozXvwEXCOLzzqzI=
 github.com/SigNoz/expr v1.17.7-beta h1:FyZkleM5dTQ0O6muQfwGpoH5A2ohmN/XTasRCO72gAA=
 github.com/SigNoz/expr v1.17.7-beta/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/SigNoz/govaluate v0.0.0-20240203125216-988004ccc7fd h1:Bk43AsDYe0fhkbj57eGXx8H3ZJ4zhmQXBnrW523ktj8=
@@ -1062,8 +1064,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/spf13/viper v1.13.0/go.mod h1:Icm2xNL3/8uyh/wFuB1jI7TiTNKp8632Nwegu+zgdYw=
 github.com/spf13/viper v1.20.1 h1:ZMi+z/lvLyPSCoNtFCpqjy0S4kPbirhpTMwl8BkW9X4=
 github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqjJvu4=
-github.com/srikanthccv/ClickHouse-go-mock v0.13.0 h1:/b7DQphGkh29ocNtLh4DGmQxQYA0CfHz65Wy2zAH2GM=
-github.com/srikanthccv/ClickHouse-go-mock v0.13.0/go.mod h1:LiiyBUdXNwB/1DE9rgK/8q9qjVYsTzg6WXQ/3mU3TeY=
+github.com/srikanthccv/ClickHouse-go-mock v0.12.0 h1:KUzaWTwuqMc2uf5FylM/oAcTFdE2DdZjvISm9V0/NAA=
+github.com/srikanthccv/ClickHouse-go-mock v0.12.0/go.mod h1:1oUmLtXEXOyS0EEWVKlKEfLfv9y02agCMAvD3tVnhlo=
 github.com/stackitcloud/stackit-sdk-go/core v0.23.0 h1:zPrOhf3Xe47rKRs1fg/AqKYUiJJRYjdcv+3qsS50mEs=
 github.com/stackitcloud/stackit-sdk-go/core v0.23.0/go.mod h1:osMglDby4csGZ5sIfhNyYq1bS1TxIdPY88+skE/kkmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/prometheus/clickhouseprometheus/client_query_test.go
+++ b/pkg/prometheus/clickhouseprometheus/client_query_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
-	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DATA-DOG/go-sqlmock"

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 
 	"github.com/SigNoz/signoz/pkg/flagger/flaggertest"
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"

--- a/pkg/query-service/app/querier/querier_test.go
+++ b/pkg/query-service/app/querier/querier_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
 	"github.com/SigNoz/signoz/pkg/valuer"
-	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/query-service/app/querier/v2/querier_test.go
+++ b/pkg/query-service/app/querier/v2/querier_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
 	"github.com/SigNoz/signoz/pkg/valuer"
-	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/query-service/rules/manager_test.go
+++ b/pkg/query-service/rules/manager_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 )
 
 func TestManager_TestNotification_SendUnmatched_ThresholdRule(t *testing.T) {

--- a/pkg/query-service/rules/prom_rule_test.go
+++ b/pkg/query-service/rules/prom_rule_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pql "github.com/prometheus/prometheus/promql"
-	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/prometheus"

--- a/pkg/query-service/rules/threshold_rule_test.go
+++ b/pkg/query-service/rules/threshold_rule_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"

--- a/pkg/telemetrymetadata/metadata_query_test.go
+++ b/pkg/telemetrymetadata/metadata_query_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
 	"github.com/SigNoz/signoz/pkg/telemetrytraces"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
-	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/SigNoz/signoz/pkg/flagger/flaggertest"
 	"github.com/stretchr/testify/require"

--- a/pkg/telemetrymetadata/metadata_test.go
+++ b/pkg/telemetrymetadata/metadata_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
 	"github.com/SigNoz/signoz/pkg/telemetrytraces"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
-	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/SigNoz/signoz/pkg/flagger/flaggertest"
 	"github.com/stretchr/testify/require"

--- a/pkg/telemetrystore/clickhousetelemetrystore/provider.go
+++ b/pkg/telemetrystore/clickhousetelemetrystore/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
+	"go.opentelemetry.io/otel/metric"
 )
 
 type provider struct {
@@ -47,6 +48,23 @@ func New(ctx context.Context, providerSettings factory.ProviderSettings, config 
 			return nil, err
 		}
 		hooks[i] = hook
+	}
+
+	metrics, err := newMetrics(settings.Meter())
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = settings.Meter().RegisterCallback(func(_ context.Context, observer metric.Observer) error {
+		stats := chConn.Stats()
+		observer.ObserveInt64(metrics.open, int64(stats.Open))
+		observer.ObserveInt64(metrics.idle, int64(stats.Idle))
+		observer.ObserveInt64(metrics.maxOpen, int64(stats.MaxOpenConns))
+		observer.ObserveInt64(metrics.maxIdle, int64(stats.MaxIdleConns))
+		return nil
+	}, metrics.open, metrics.idle, metrics.maxOpen, metrics.maxIdle)
+	if err != nil {
+		return nil, err
 	}
 
 	return &provider{

--- a/pkg/telemetrystore/clickhousetelemetrystore/telemetry.go
+++ b/pkg/telemetrystore/clickhousetelemetrystore/telemetry.go
@@ -1,0 +1,48 @@
+package clickhousetelemetrystore
+
+import (
+	"github.com/SigNoz/signoz/pkg/errors"
+	"go.opentelemetry.io/otel/metric"
+)
+
+type metrics struct {
+	open    metric.Int64ObservableGauge
+	idle    metric.Int64ObservableGauge
+	maxOpen metric.Int64ObservableGauge
+	maxIdle metric.Int64ObservableGauge
+}
+
+func newMetrics(meter metric.Meter) (*metrics, error) {
+	var errs error
+
+	open, err := meter.Int64ObservableGauge("signoz.telemetrystore.connection.open", metric.WithDescription("Open is the current number of open connections to the telemetry store."))
+	if err != nil {
+		errs = errors.Join(errs, err)
+	}
+
+	idle, err := meter.Int64ObservableGauge("signoz.telemetrystore.connection.idle", metric.WithDescription("Idle is the current number of idle connections in the telemetry store pool."))
+	if err != nil {
+		errs = errors.Join(errs, err)
+	}
+
+	maxOpen, err := meter.Int64ObservableGauge("signoz.telemetrystore.connection.max_open", metric.WithDescription("MaxOpen is the configured maximum number of open connections to the telemetry store."))
+	if err != nil {
+		errs = errors.Join(errs, err)
+	}
+
+	maxIdle, err := meter.Int64ObservableGauge("signoz.telemetrystore.connection.max_idle", metric.WithDescription("MaxIdle is the configured maximum number of idle connections in the telemetry store pool."))
+	if err != nil {
+		errs = errors.Join(errs, err)
+	}
+
+	if errs != nil {
+		return nil, errs
+	}
+
+	return &metrics{
+		open:    open,
+		idle:    idle,
+		maxOpen: maxOpen,
+		maxIdle: maxIdle,
+	}, nil
+}

--- a/pkg/telemetrystore/telemetrystoretest/provider.go
+++ b/pkg/telemetrystore/telemetrystoretest/provider.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
-	cmock "github.com/srikanthccv/ClickHouse-go-mock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 )
 
 var _ telemetrystore.TelemetryStore = (*Provider)(nil)


### PR DESCRIPTION
## Problem

Since v0.126.0, production hits `clickhouse: acquire conn timeout. you can increase the number of max open conn or the dial timeout`. It surfaces first in **rule state history** (the alerting engine runs those queries continuously with cancellable contexts). This is a connection-pool **slot leak**, not a misconfiguration — once `MaxOpenConns` slots leak, every query blocks for `DialTimeout` then errors.

## Root cause

PR #11475 (OpenFGA upgrade) transitively bumped `clickhouse-go/v2` **v2.40.1 → v2.43.0**. v2.43.0 rewrote the connection pool and shipped two slot-leak bugs, both triggered by **context cancellation**:

- **acquire() slot leak** ([ClickHouse/clickhouse-go#1759](https://github.com/ClickHouse/clickhouse-go/pull/1759)) — after taking an `ch.open` slot, if `ch.idle.Get(ctx)` returns a cancellation error the slot is never released. Affects every query path (`Query`/`QueryRow`/`Select`/`Exec`/`PrepareBatch` all call `acquire()`).
- **batch.Close() leak** ([ClickHouse/clickhouse-go#1795](https://github.com/ClickHouse/clickhouse-go/pull/1795)) — when `closeQuery()` fails on a cancelled context, the connection is never returned. Hits the rule-state-history `PrepareBatch` write path.

Both are fixed in **clickhouse-go v2.44.0**.

## Changes

1. **Upgrade `clickhouse-go/v2` v2.43.0 → v2.44.0** (the fix).
2. v2.44.0 adds `HasData()` to the `driver.Rows` interface, which the old test mock didn't implement. **Swap the mock to `github.com/SigNoz/clickhouse-go-mock` v0.14.0** (SigNoz/clickhouse-go-mock#4), which implements `HasData()` and tracks v2.44.0.
3. **Emit connection-pool metrics** — new OTel observable gauges `signoz.telemetrystore.connection.{open,idle,max_open,max_idle}` from `driver.Stats()`, so pool saturation/leaks are visible in Prometheus (plot `open` vs `max_open`).

## Verification

- `go build ./...` ✅
- `go vet ./pkg/telemetrystore/...` ✅
- `go test ./...` for all mock-consuming packages (telemetrystore, querier, telemetrymetadata, clickhouseprometheus, rules, ee rules) ✅