### PR TITLE
fix: redirect to login when invite/reset-password token is invalid or expired

### DIFF
--- a/frontend/src/container/ResetPassword/index.tsx
+++ b/frontend/src/container/ResetPassword/index.tsx
@@ -7,6 +7,7 @@ import { Form, Input as AntdInput } from 'antd';
 import { Typography } from '@signozhq/ui/typography';
 import { Logout } from 'api/utils';
 import resetPasswordApi from 'api/v1/factor_password/resetPassword';
+import { verifyResetPasswordToken } from 'api/generated/services/users';
 import AuthError from 'components/AuthError/AuthError';
 import AuthPageContainer from 'components/AuthPageContainer';
 import ROUTES from 'constants/routes';
@@ -37,13 +38,31 @@ function ResetPassword({ version }: ResetPasswordProps): JSX.Element {
 	const token = params.get('token');
 	const { notifications } = useNotifications();
 
+	const [tokenValid, setTokenValid] = useState<boolean | null>(null);
+
 	const [form] = Form.useForm<FormValues>();
+
 	useEffect(() => {
 		if (!token) {
 			Logout();
 			history.push(ROUTES.LOGIN);
+			return;
 		}
-	}, [token]);
+
+		// Validate the token before showing the form. If the token is invalid,
+		// expired, or already used, redirect to login with an error message so
+		// the user doesn't waste time filling out a form that will fail.
+		verifyResetPasswordToken({ token })
+			.then(() => setTokenValid(true))
+			.catch(() => {
+				notifications.error({
+					message:
+						'Invalid or expired invitation token. Please contact your admin for a new invite link.',
+				});
+				Logout();
+				history.push(ROUTES.LOGIN);
+			});
+	}, [token, notifications]);
 
 	const handleFormSubmit: () => Promise<void> = async () => {
 		try {
@@ -143,6 +162,13 @@ function ResetPassword({ version }: ResetPasswordProps): JSX.Element {
 			handleFormSubmit();
 		}
 	};
+
+	// Don't render the form until the token has been validated.
+	// A null state means validation is still in progress; false means the
+	// redirect has already been triggered by the useEffect above.
+	if (tokenValid !== true) {
+		return null;
+	}
 
 	return (
 		<AuthPageContainer>


### PR DESCRIPTION
## Problem

Resolves #7011.

When a user followed an expired, already-used, or tampered invitation link, the reset-password form was displayed unconditionally. The error was only shown **after** the user completed and submitted the form — a confusing experience.

## Fix

Use the existing `/api/v2/reset_password_tokens/verify` endpoint to validate the token on mount, **before** rendering the form:

- If validation succeeds → show the form as normal.
- If validation fails (expired / used / invalid) → show an error notification and redirect to the login page immediately.
- While validation is in progress → render `null` (brief flash, no layout shift).

## Before / After

**Before:** User opens stale invite link → sees the full reset-password form → fills it out → submits → sees "invalid token" error.

**After:** User opens stale invite link → brief loading → error notification "Invalid or expired invitation token. Please contact your admin for a new invite link." → redirected to login page.

## Changes

`frontend/src/container/ResetPassword/index.tsx`:
- Import `verifyResetPasswordToken` from generated API.
- Add `tokenValid` state (`null | boolean`).
- In `useEffect`: call `verifyResetPasswordToken({ token })` after confirming the token is present; redirect to login with an error notification on failure.
- Guard the JSX render behind `tokenValid === true`.