### PR TITLE
chore: added caching for chromium in e2e CI

### DIFF
--- a/.github/workflows/e2eci.yaml
+++ b/.github/workflows/e2eci.yaml
@@ -68,9 +68,22 @@ jobs:
       - name: pnpm-install
         run: |
           cd tests/e2e && pnpm install --frozen-lockfile
+      - name: playwright-cache
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('tests/e2e/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: playwright-browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: |
           cd tests/e2e && pnpm playwright install --with-deps ${{ matrix.project }}
+      - name: playwright-system-deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: |
+          cd tests/e2e && pnpm playwright install-deps ${{ matrix.project }}
       - name: bring-up-stack
         run: |
           cd tests && \


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Caches the Playwright browser binaries (`~/.cache/ms-playwright`) between e2e CI runs, keyed on `tests/e2e/pnpm-lock.yaml`. The full `playwright install --with-deps` step (which downloads ~150MB of browser binaries and installs system packages) only runs on cache miss; on cache hit we just run `playwright install-deps` to ensure system libraries are present on the runner.

This shaves a significant chunk off every e2e CI run since the browser version rarely changes between PRs.

#### Screenshots / Screen Recordings (if applicable)
N/A — CI-only change.

#### Issues closed by this PR
N/A

---

### ✅ Change Type

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
N/A

---

### 🧪 Testing Strategy

- Tests added/updated: N/A (CI workflow change)
- Manual verification: Observe e2e CI run on this PR — first run populates the cache (`playwright-browsers` step runs), subsequent runs should hit the cache and skip the download (`playwright-system-deps` step runs instead).
- Edge cases covered:
  - **Cache miss** (first run or `pnpm-lock.yaml` change) → full `playwright install --with-deps` runs.
  - **Cache hit** → only `playwright install-deps` runs so OS-level libs are still present on the runner.
  - `restore-keys` falls back to the latest available `${{ runner.os }}-playwright-` cache when the exact hash misses, so cache benefit is retained across minor lockfile bumps.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius**: e2e CI workflow only. No runtime, product, or API impact.
- **Potential regressions**:
  - If the Playwright version in the cached binaries drifts from the version expected by `@playwright/test` (e.g. a transitive update that doesn't change `pnpm-lock.yaml`), tests could fail with a version mismatch. The lockfile-based cache key should prevent this in practice.
  - System dependency installation still runs on every job, so missing OS libs shouldn't surface as a new failure mode.
- **Rollback plan**: Revert this single-file change to `.github/workflows/e2eci.yaml`.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | N/A |
| Change Type | Maintenance |
| Description | N/A — internal CI improvement |

---

### 📋 Checklist
- [x] Tests added or explicitly not required (CI infra change)
- [x] Manually tested (via CI run on this PR)
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Single-file change to `.github/workflows/e2eci.yaml`.
- Cache key uses `hashFiles('tests/e2e/pnpm-lock.yaml')`, so the cache invalidates automatically when Playwright (or any e2e dep) is bumped.
- Worth confirming: is `~/.cache/ms-playwright` the correct path for all matrix runners we use? It is for `ubuntu-latest`; if any matrix entry runs on macOS the path would be `~/Library/Caches/ms-playwright` and a per-OS path would be needed. (Current matrix appears to be Linux-only, so this is fine as-is.)

---
