### PR TITLE
feat: added panel plugin registry base changes

### DIFF
--- a/frontend/src/container/DashboardContainerV2/Panels/TimeSeriesPanel/Renderer.tsx
+++ b/frontend/src/container/DashboardContainerV2/Panels/TimeSeriesPanel/Renderer.tsx
@@ -1,0 +1,42 @@
+import { Typography } from '@signozhq/ui/typography';
+import type { DashboardtypesTimeSeriesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
+
+import type { PanelRendererProps } from '../types';
+
+function TimeSeriesRenderer({
+	isLoading,
+	error,
+	data,
+}: PanelRendererProps<DashboardtypesTimeSeriesPanelSpecDTO>): JSX.Element {
+	let status = 'idle';
+	if (isLoading) {
+		status = 'loading';
+	} else if (error) {
+		status = `error: ${error.message}`;
+	} else if (data) {
+		status = 'data available';
+	}
+
+	return (
+		<div
+			data-testid="time-series-renderer-stub"
+			style={{
+				display: 'flex',
+				flex: 1,
+				alignItems: 'center',
+				justifyContent: 'center',
+				padding: 12,
+				color: 'var(--bg-vanilla-400, #8993ae)',
+				fontSize: 12,
+				textAlign: 'center',
+			}}
+		>
+			<div>
+				<Typography.Text>TimeSeries renderer (stub)</Typography.Text>
+				<div style={{ marginTop: 6 }}>{status}</div>
+			</div>
+		</div>
+	);
+}
+
+export default TimeSeriesRenderer;

--- a/frontend/src/container/DashboardContainerV2/Panels/TimeSeriesPanel/Renderer.tsx
+++ b/frontend/src/container/DashboardContainerV2/Panels/TimeSeriesPanel/Renderer.tsx
@@ -3,6 +3,10 @@ import type { DashboardtypesTimeSeriesPanelSpecDTO } from 'api/generated/service
 
 import type { PanelRendererProps } from '../types';
 
+/** Skeleton Component for TimeSeriesPanel
+ * TODO: will be replaced by actual implementation in subsequent PRs. This is to unblock the integration of the panel into the dashboard and work on other dependent features.
+ */
+
 function TimeSeriesRenderer({
 	isLoading,
 	error,

--- a/frontend/src/container/DashboardContainerV2/Panels/TimeSeriesPanel/sections.ts
+++ b/frontend/src/container/DashboardContainerV2/Panels/TimeSeriesPanel/sections.ts
@@ -1,0 +1,15 @@
+import type { SectionConfig } from '../types';
+
+export const sections: SectionConfig[] = [
+	{
+		kind: 'formatting',
+		controls: {
+			unit: true,
+			decimals: true,
+		},
+	},
+	{ kind: 'axes', controls: { minMax: true, unit: true, logScale: true } },
+	{ kind: 'legend', controls: { position: true, mode: true } },
+	{ kind: 'thresholds', controls: { list: true } },
+	{ kind: 'chartAppearance', controls: { lineStyle: true, fillOpacity: true } },
+];

--- a/frontend/src/container/DashboardContainerV2/Panels/index.ts
+++ b/frontend/src/container/DashboardContainerV2/Panels/index.ts
@@ -1,0 +1,36 @@
+import { DataSource } from 'types/common/queryBuilder';
+import TimeSeriesRenderer from './TimeSeriesPanel/Renderer';
+import { sections as timeSeriesSections } from './TimeSeriesPanel/sections';
+import type {
+	PanelDefinition,
+	PanelKind,
+	PanelRegistry,
+	SpecForKind,
+} from './types';
+
+const TimeSeriesPanelDef: PanelDefinition<
+	SpecForKind<'signoz/TimeSeriesPanel'>
+> = {
+	kind: 'signoz/TimeSeriesPanel',
+	displayName: 'Time Series',
+	Renderer: TimeSeriesRenderer,
+	sections: timeSeriesSections,
+	supportedSignals: [DataSource.METRICS, DataSource.LOGS, DataSource.TRACES],
+};
+
+export const PANELS: PanelRegistry = {
+	'signoz/TimeSeriesPanel': TimeSeriesPanelDef,
+};
+
+// Polymorphic lookup helper. ComponentType is contravariant in props, so indexing
+// PANELS with a runtime string widens to an unusable intersection of all Renderer
+// types. This helper localizes the necessary widening cast — callers receive a
+// PanelDefinition<unknown> whose Renderer accepts any spec at the call site.
+export function getPanelDefinition(
+	kind: string | undefined,
+): PanelDefinition<unknown> | undefined {
+	if (!kind) {
+		return undefined;
+	}
+	return PANELS[kind as PanelKind] as PanelDefinition<unknown> | undefined;
+}

--- a/frontend/src/container/DashboardContainerV2/Panels/types.ts
+++ b/frontend/src/container/DashboardContainerV2/Panels/types.ts
@@ -1,0 +1,132 @@
+import type { ComponentType } from 'react';
+import {
+	BarChart,
+	Columns3,
+	Hash,
+	ListEnd,
+	Palette,
+	Ruler,
+	SlidersHorizontal,
+} from '@signozhq/icons';
+import type {
+	DashboardtypesBarChartPanelSpecDTO,
+	DashboardtypesHistogramPanelSpecDTO,
+	DashboardtypesListPanelSpecDTO,
+	DashboardtypesNumberPanelSpecDTO,
+	DashboardtypesPieChartPanelSpecDTO,
+	DashboardtypesTablePanelSpecDTO,
+	DashboardtypesTimeSeriesPanelSpecDTO,
+} from 'api/generated/services/sigNoz.schemas';
+import type { MetricQueryRangeSuccessResponse } from 'types/api/metrics/getQueryRange';
+import type { Query } from 'types/api/queryBuilder/queryBuilderData';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { DataSource } from 'types/common/queryBuilder';
+
+export type PanelKind =
+	| 'signoz/TimeSeriesPanel'
+	| 'signoz/BarChartPanel'
+	| 'signoz/NumberPanel'
+	| 'signoz/PieChartPanel'
+	| 'signoz/TablePanel'
+	| 'signoz/HistogramPanel'
+	| 'signoz/ListPanel';
+
+// Maps each PanelKind to its concrete perses spec type. Keeping this in lockstep
+// with PanelKind is the (single) maintenance cost of the keyed registry — in
+// exchange we get cast-free registration and precise types after kind narrowing.
+export type SpecForKind<K extends PanelKind> =
+	K extends 'signoz/TimeSeriesPanel'
+		? DashboardtypesTimeSeriesPanelSpecDTO
+		: K extends 'signoz/BarChartPanel'
+			? DashboardtypesBarChartPanelSpecDTO
+			: K extends 'signoz/NumberPanel'
+				? DashboardtypesNumberPanelSpecDTO
+				: K extends 'signoz/PieChartPanel'
+					? DashboardtypesPieChartPanelSpecDTO
+					: K extends 'signoz/TablePanel'
+						? DashboardtypesTablePanelSpecDTO
+						: K extends 'signoz/HistogramPanel'
+							? DashboardtypesHistogramPanelSpecDTO
+							: K extends 'signoz/ListPanel'
+								? DashboardtypesListPanelSpecDTO
+								: never;
+
+// Derived from an actual icon component so the type stays exact (size is a
+// constrained IconSize union, not arbitrary strings) and ForwardRef-compatible.
+type SectionIcon = typeof Hash;
+
+export interface SectionMetadata {
+	title: string;
+	icon: SectionIcon;
+	description?: string;
+}
+
+// Source of truth for sections. Its keys define SectionKind; its values are the
+// runtime UI metadata (consumed by PanelEditor in 1.8). Adding a new section =
+// one entry here + one entry in SectionControls.
+export const SECTIONS = {
+	formatting: { title: 'Formatting', icon: Hash },
+	axes: { title: 'Axes', icon: Ruler },
+	legend: { title: 'Legend', icon: ListEnd },
+	thresholds: { title: 'Thresholds', icon: SlidersHorizontal },
+	chartAppearance: { title: 'Chart appearance', icon: Palette },
+	columnUnits: { title: 'Column units', icon: Columns3 },
+	buckets: { title: 'Buckets', icon: BarChart },
+} as const satisfies Record<string, SectionMetadata>;
+
+export type SectionKind = keyof typeof SECTIONS;
+
+// Per-kind control toggles (type-only — runtime metadata is in SECTIONS).
+// Section components type their controls prop via `SectionControls['axes']`.
+export type SectionControls = {
+	formatting: { unit?: boolean; decimals?: boolean };
+	axes: { minMax?: boolean; unit?: boolean; logScale?: boolean };
+	legend: { position?: boolean; mode?: boolean };
+	thresholds: { list?: boolean };
+	chartAppearance: {
+		lineStyle?: boolean;
+		fillOpacity?: boolean;
+		stacked?: boolean;
+	};
+	columnUnits: { perColumnUnit?: boolean };
+	buckets: { count?: boolean; min?: boolean; max?: boolean };
+};
+
+// Discriminated union derived from SectionControls — kept in lockstep automatically.
+export type SectionConfig = {
+	[K in SectionKind]: { kind: K; controls: SectionControls[K] };
+}[SectionKind];
+
+export interface PanelRendererProps<Spec> {
+	panelId: string;
+	spec: Spec;
+	query: Query | undefined;
+	data: MetricQueryRangeSuccessResponse | undefined;
+	isLoading: boolean;
+	error: Error | null;
+}
+
+export interface PanelDefinition<Spec> {
+	kind: PanelKind;
+	displayName: string;
+	Renderer: ComponentType<PanelRendererProps<Spec>>;
+	sections: SectionConfig[];
+	supportedSignals: DataSource[];
+}
+
+// The registry is a keyed map from PanelKind to a PanelDefinition with the
+// matching concrete spec. Looking up by a kind variable yields a discriminated
+// union of all registered definitions, each with its precise Spec.
+export type PanelRegistry = {
+	[K in PanelKind]?: PanelDefinition<SpecForKind<K>>;
+};
+
+export const PANEL_KIND_TO_PANEL_TYPE: Record<PanelKind, PANEL_TYPES> = {
+	'signoz/TimeSeriesPanel': PANEL_TYPES.TIME_SERIES,
+	'signoz/BarChartPanel': PANEL_TYPES.BAR,
+	'signoz/NumberPanel': PANEL_TYPES.VALUE,
+	'signoz/PieChartPanel': PANEL_TYPES.PIE,
+	'signoz/TablePanel': PANEL_TYPES.TABLE,
+	'signoz/HistogramPanel': PANEL_TYPES.HISTOGRAM,
+	'signoz/ListPanel': PANEL_TYPES.LIST,
+};


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Introduces the **panel plugin registry** for V2 dashboards — the foundational types and runtime map that future panel implementations (renderers, edit-shell sections, panel-type switching) will plug into. This is the first PR in a series migrating panel rendering from V1's `panelTypes`-switch model to perses-style `plugin.kind` dispatch.

**Why a registry instead of a switch?** V1 maps a string panel type to a renderer via a hard-coded `switch`. The V2 (perses) schema has `plugin.kind` as the discriminator and a **different `spec` shape per kind** (`signoz/NumberPanel` has no `axes`; `signoz/TimeSeriesPanel` has `axes` + `chartAppearance`, etc.). A switch can't carry that — each kind needs its own renderer, edit sections, and spec validation. The registry lets each kind own those concerns and lets the dashboard shell dispatch generically.

**What this PR adds:**
- `Panels/types.ts` — `PanelKind` union, `SpecForKind<K>` (maps each kind to its concrete perses spec), `PanelDefinition<Spec>`, `PanelRendererProps<Spec>`, `PanelRegistry` keyed type, central `SECTIONS` metadata table (title + icon per section), `SectionControls`, derived `SectionConfig`, and `PANEL_KIND_TO_PANEL_TYPE` bridge to V1 `PANEL_TYPES`.
- `Panels/index.ts` — `PANELS` registry (just `signoz/TimeSeriesPanel` registered for now) and a `getPanelDefinition(kind)` lookup helper.
- `Panels/TimeSeriesPanel/Renderer.tsx` — **stub renderer**; shows idle/loading/error/data status as text. Real uPlot rendering is intentionally deferred to a follow-up PR so this one stays small and reviewable.
- `Panels/TimeSeriesPanel/sections.ts` — declarative section list for TimeSeries (formatting / axes / legend / thresholds / chartAppearance).

**What this PR does *not* include (follow-ups):**
- `PanelV2` wiring to the registry (lookup + dispatch).
- Query adapter (`toPerses` / `fromPerses`) between perses query envelopes and the QB's in-memory shape.
- Real chart rendering — uPlot config built from the perses spec.
- Per-section controlled components and `PanelEditor`.
- Panel-type switching with the superspec / type-keyed save-time projection.

#### Issues closed by this PR
N/A

---

### ✅ Change Type
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy

- Tests added/updated: **None.** This PR is pure scaffolding — type definitions, a runtime map with one entry, and a stub component with no fetch/render logic. There's no behavior to assert beyond what TypeScript already enforces. Tests will be added alongside the renderer and adapter work in the follow-up PRs.
- Manual verification: `pnpm tsgo --noEmit` clean, `pnpm oxlint ./src` 0 errors, `pnpm build` succeeds.
- Edge cases covered: registry registration is **cast-free** (the keyed `PanelRegistry` + `SpecForKind` mapping ensures each plugin's `Renderer` accepts the spec matching its `kind` at compile time). Polymorphic lookup (`getPanelDefinition(runtimeString)`) localizes the unavoidable widening cast — `ComponentType` is contravariant, so indexing with a runtime union widens to an unusable intersection without help.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** Zero impact on V1. All new files live under `DashboardContainerV2/Panels/`; no existing file is modified. The V2 dashboard itself is feature-gated by `useIsDashboardV2` and `PanelV2` does not yet consume this registry.
- **Potential regressions:** None expected. The exported types/constants are not yet imported anywhere else.
- **Rollback plan:** Revert the PR. No schema migrations, no API surface changes, no on-wire format changes.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance |
| Description | N/A — internal V2 dashboard scaffolding, not user-visible until the full V2 panel render path ships. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required *(not required — pure types + stub)*
- [x] Manually tested *(tsgo / oxlint / build)*
- [x] Breaking changes documented *(no breaking changes)*
- [x] Backward compatibility considered *(V1 path untouched; V2 still feature-gated)*

---

## 👀 Notes for Reviewers
