### PR TITLE
feat(ai-assistant): show descriptive Noz hover tooltip on all entry points

### DIFF
--- a/frontend/src/components/HeaderRightSection/HeaderRightSection.tsx
+++ b/frontend/src/components/HeaderRightSection/HeaderRightSection.tsx
@@ -4,6 +4,7 @@ import { Dot } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
 import { TooltipSimple } from '@signozhq/ui/tooltip';
 import Noz from 'components/Noz/Noz';
+import { NOZ_TOOLTIP_TITLE } from 'components/Noz/Noz.constants';
 import { Popover } from 'antd';
 import logEvent from 'api/common/logEvent';
 import { AIAssistantEvents } from 'container/AIAssistant/events';
@@ -109,7 +110,7 @@ function HeaderRightSection({
 						</span>
 					) : null}
 
-					<TooltipSimple title="Noz">
+					<TooltipSimple title={NOZ_TOOLTIP_TITLE}>
 						<Button
 							variant="solid"
 							color="secondary"

--- a/frontend/src/components/Noz/Noz.constants.ts
+++ b/frontend/src/components/Noz/Noz.constants.ts
@@ -1,0 +1,2 @@
+/** Shared hover copy for every Noz entry point (header, floating trigger, sidebar). */
+export const NOZ_TOOLTIP_TITLE = 'Noz, your AI teammate';

--- a/frontend/src/container/AIAssistant/AIAssistantTrigger/AIAssistantTrigger.tsx
+++ b/frontend/src/container/AIAssistant/AIAssistantTrigger/AIAssistantTrigger.tsx
@@ -5,6 +5,7 @@ import { TooltipSimple } from '@signozhq/ui/tooltip';
 import logEvent from 'api/common/logEvent';
 import ROUTES from 'constants/routes';
 import Noz from 'components/Noz/Noz';
+import { NOZ_TOOLTIP_TITLE } from 'components/Noz/Noz.constants';
 
 import { AIAssistantEvents, AIAssistantOpenSource } from '../events';
 import { normalizePage } from '../hooks/useAIAssistantAnalyticsContext';
@@ -42,16 +43,15 @@ export default function AIAssistantTrigger(): JSX.Element | null {
 	}
 
 	return (
-		<TooltipSimple title="Noz">
+		<TooltipSimple title={NOZ_TOOLTIP_TITLE}>
 			<Button
 				variant="solid"
 				color="primary"
 				className={`${styles.trigger} noz-wave`}
 				onClick={handleOpen}
 				aria-label="Open Noz"
-			>
-				<Noz size={24} />
-			</Button>
+				prefix={<Noz size={24} />}
+			/>
 		</TooltipSimple>
 	);
 }

--- a/frontend/src/container/SideNav/NavItem/NavItem.tsx
+++ b/frontend/src/container/SideNav/NavItem/NavItem.tsx
@@ -6,7 +6,6 @@ import { Pin, PinOff } from '@signozhq/icons';
 import { SidebarItem } from '../sideNav.types';
 
 import './NavItem.styles.scss';
-import './NavItem.styles.scss';
 
 export default function NavItem({
 	item,
@@ -27,7 +26,7 @@ export default function NavItem({
 	showIcon?: boolean;
 	dataTestId?: string;
 }): JSX.Element {
-	const { label, icon, isBeta, isNew, isEarlyAccess } = item;
+	const { label, icon, isBeta, isNew, isEarlyAccess, tooltip } = item;
 
 	const handleTogglePinClick = (
 		event: React.MouseEvent<SVGSVGElement, MouseEvent>,
@@ -36,7 +35,7 @@ export default function NavItem({
 		onTogglePin?.(item);
 	};
 
-	return (
+	const navItem = (
 		<div
 			className={cx(
 				'nav-item',
@@ -106,6 +105,15 @@ export default function NavItem({
 				)}
 			</div>
 		</div>
+	);
+
+	// Only non-pinnable items set `tooltip`; it would nest with the pin tooltip.
+	return tooltip ? (
+		<Tooltip title={tooltip} placement="right">
+			{navItem}
+		</Tooltip>
+	) : (
+		navItem
 	);
 }
 

--- a/frontend/src/container/SideNav/menuItems.tsx
+++ b/frontend/src/container/SideNav/menuItems.tsx
@@ -45,6 +45,7 @@ import {
 } from './sideNav.types';
 import { Style } from '@signozhq/design-tokens';
 import Noz from 'components/Noz/Noz';
+import { NOZ_TOOLTIP_TITLE } from 'components/Noz/Noz.constants';
 
 export const getStartedMenuItem = {
 	key: ROUTES.GET_STARTED,
@@ -97,6 +98,7 @@ export const aiAssistantMenuItem = {
 	icon: <Noz size={16} />,
 	itemKey: 'ai-assistant',
 	isEarlyAccess: true,
+	tooltip: NOZ_TOOLTIP_TITLE,
 };
 
 export const shortcutMenuItem = {

--- a/frontend/src/container/SideNav/sideNav.types.ts
+++ b/frontend/src/container/SideNav/sideNav.types.ts
@@ -15,6 +15,8 @@ export interface SidebarItem {
 	isBeta?: boolean;
 	isNew?: boolean;
 	isEarlyAccess?: boolean;
+	/** Hover copy for the whole item row (e.g. Noz's early-access tagline). */
+	tooltip?: ReactNode;
 	isPinned?: boolean;
 	children?: SidebarItem[];
 	isExternal?: boolean;


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Noz recently launched under early access. Users who don't yet recognize the name get no help from the current hover tooltip, which just echoes the word "Noz" on all three entry points (header button, floating trigger, sidebar nav item).

This replaces that bare label with a short, descriptive tooltip — **"Noz, your AI teammate"** — sourced from a single shared constant (`NOZ_TOOLTIP_TITLE`) so the three surfaces can never drift apart. The sidebar nav item, which had no tooltip before, now shows it across the whole row on hover (its "Early Access" badge stays as-is).

#### Screenshots / Screen Recordings (if applicable)
<img width="151" height="154" alt="Screenshot 2026-06-02 at 12 16 32" src="https://github.com/user-attachments/assets/2ab2d0f7-878f-43ea-ae45-202e80473cdc" />
<img width="428" height="449" alt="Screenshot 2026-06-02 at 12 17 03" src="https://github.com/user-attachments/assets/1a5c738b-9f83-4a2d-9875-0a0a85a7786d" />

> The visible change is hover-only: the tooltip text on the header Noz button, the floating Noz button, and the sidebar Noz item now reads "Noz, your AI teammate" instead of "Noz". 

#### Issues closed by this PR
N/A

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
N/A — not a bug fix.

---

### 🧪 Testing Strategy
> How was this change validated?

- **Tests added/updated:** None required. No existing assertion depended on the old "Noz" tooltip text. Existing suites pass: `HeaderRightSection` (12/12), `SideNav` `menuItems` + `helper` (8/8).
- **Manual verification:** `pnpm tsgo --noEmit` clean, `pnpm oxlint` clean on all touched files (only pre-existing warnings remain), `pnpm build` (vite) succeeds. In-browser hover not verified headlessly.
- **Edge cases covered:** Sidebar tooltip is applied to non-pinnable items only, so it never nests with the existing pin tooltip; the floating trigger's `noz-wave` hover animation still fires after moving the icon into the `prefix` slot (Noz stays inside the `.noz-wave` element).

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** Three Noz entry points, plus a new optional `tooltip?: ReactNode` field on the generic `SidebarItem` that `NavItem` renders. Additive and opt-in.
- **Potential regressions:** Floating trigger icon now renders via the Button `prefix` slot rather than as a child — visual centering is low-risk since `.trigger` is a custom flex-centered FAB. Sidebar row tooltip would nest with the pin tooltip if both were set; guarded by a comment and only set on the (non-pinnable) Noz item.
- **Rollback plan:** Revert the commit. The change is additive UI copy with no data or API impact.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Hovering Noz (header, floating button, or sidebar) now shows "Noz, your AI teammate" to help users discover what the early-access assistant is. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested (automated checks pass; in-browser hover not yet verified)
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered (new `SidebarItem.tooltip` is optional)

---

## 👀 Notes for Reviewers

- **Single source of truth:** `NOZ_TOOLTIP_TITLE` in `frontend/src/components/Noz/Noz.constants.ts`. All three surfaces import it.
- **Sidebar:** added optional `tooltip?: ReactNode` to `SidebarItem`; `NavItem` wraps the whole row in an antd `Tooltip` (matching the existing pin tooltips). Only set on the Noz item, which is non-pinnable, to avoid nesting two tooltips.
- **Convention fix:** `AIAssistantTrigger` now passes the Noz icon via the Button `prefix` slot (was a child) to match the icon-only-button pattern used by its siblings in `HeaderRightSection`.
- **Out of scope (flagged, not fixed):** `HeaderRightSection`'s Feedback/Share/Announcements handlers send raw `location.pathname` as `page` and have floating `logEvent` promises. Both are pre-existing and unrelated to this tooltip change — suggest a separate cleanup PR rather than widening this diff.

---
