### PR TITLE
fix(metrics-explorer): handle in case .data is undefined

### DIFF
--- a/frontend/src/container/MetricsExplorer/MetricDetails/MetricDetails.tsx
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/MetricDetails.tsx
@@ -56,7 +56,7 @@ function MetricDetails({
 	);
 
 	const metadata = useMemo(() => {
-		if (!metricMetadataResponse) {
+		if (!metricMetadataResponse?.data) {
 			return null;
 		}
 		const { type, description, unit, temporality, isMonotonic } =


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

When metric name has `/`, like `amazonaws.com/AWS/RDS/DiskQueueDepth.quantile`, the query fails and return 200 with HTML instead of 400 with JSON

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Fixes https://github.com/SigNoz/engineering-pod/issues/5158

Related to https://github.com/SigNoz/engineering-pod/issues/4820

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

We don't support `/` as the param for the route.

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

This is treated as new route, the route is not found since it does not exists, and returns HTML.

#### Fix Strategy
> How does this PR address the root cause?

Handle the value being undefined, we do the same for other part of the UI using this API.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A
- Manual verification: N/A
- Edge cases covered: N/A

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Metrics Explorer
- Potential regressions: None
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | On Metrics Explorer, when metric has `/` in the name, the data returned was HTML causing the page to break, this issue was fixed by guarding the data to handle this value. |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
