### PR TITLE
feat(trace-detail): add analytics instrumentation for new trace details page

### DIFF
--- a/frontend/src/pages/TraceDetailsV3/SpanDetailsPanel/AnalyticsPanel/AnalyticsPanel.tsx
+++ b/frontend/src/pages/TraceDetailsV3/SpanDetailsPanel/AnalyticsPanel/AnalyticsPanel.tsx
@@ -22,6 +22,7 @@ import styles from './AnalyticsPanel.module.scss';
 interface AnalyticsPanelProps {
 	isOpen: boolean;
 	onClose: () => void;
+	onTabChange: (tab: string) => void;
 }
 
 const PANEL_WIDTH = 350;
@@ -32,6 +33,7 @@ const PANEL_MARGIN_BOTTOM = 50;
 function AnalyticsPanel({
 	isOpen,
 	onClose,
+	onTabChange,
 }: AnalyticsPanelProps): JSX.Element | null {
 	const aggregations = useTraceStore((s) => s.aggregations);
 	const colorByFieldName = useTraceStore((s) => s.colorByField.name);
@@ -118,7 +120,7 @@ function AnalyticsPanel({
 			/>
 
 			<div className={styles.body}>
-				<TabsRoot defaultValue="exec-time">
+				<TabsRoot defaultValue="exec-time" onValueChange={onTabChange}>
 					<TabsList variant="secondary">
 						<TabsTrigger value="exec-time" variant="secondary">
 							% exec time

--- a/frontend/src/pages/TraceDetailsV3/SpanDetailsPanel/SpanDetailsPanel.tsx
+++ b/frontend/src/pages/TraceDetailsV3/SpanDetailsPanel/SpanDetailsPanel.tsx
@@ -31,7 +31,12 @@ import Events from 'container/SpanDetailsDrawer/Events/Events';
 import SpanLogs from 'container/SpanDetailsDrawer/SpanLogs/SpanLogs';
 import { useSpanContextLogs } from 'container/SpanDetailsDrawer/SpanLogs/useSpanContextLogs';
 import dayjs from 'dayjs';
+import {
+	TraceDetailEventKeys,
+	TraceDetailEvents,
+} from 'pages/TraceDetailsV3/events';
 import { useMigratePinnedAttributes } from 'pages/TraceDetailsV3/hooks/useMigratePinnedAttributes';
+import { useTraceDetailLogEvent } from 'pages/TraceDetailsV3/hooks/useTraceDetailLogEvent';
 import {
 	getSpanAttribute,
 	getSpanDisplayData,
@@ -86,6 +91,16 @@ function SpanDetailsContent({
 }): JSX.Element {
 	const FIVE_MINUTES_IN_MS = 5 * 60 * 1000;
 	const spanAttributeActions = useSpanAttributeActions();
+	const logTraceEvent = useTraceDetailLogEvent('v3', selectedSpan.trace_id);
+	const handleTabChange = useCallback(
+		(tab: string): void => {
+			logTraceEvent(TraceDetailEvents.SpanPanelTabChanged, {
+				[TraceDetailEventKeys.Tab]: tab,
+				[TraceDetailEventKeys.SpanId]: selectedSpan.span_id,
+			});
+		},
+		[logTraceEvent, selectedSpan.span_id],
+	);
 	const percentile = useSpanPercentile(selectedSpan);
 	const linkedSpans = useLinkedSpans((selectedSpan as any).references);
 
@@ -376,7 +391,7 @@ function SpanDetailsContent({
 
 			<div className={styles.tabsSection}>
 				{/* Step 9: ContentTabs */}
-				<TabsRoot defaultValue="overview">
+				<TabsRoot defaultValue="overview" onValueChange={handleTabChange}>
 					<TabsList variant="secondary">
 						<TabsTrigger value="overview" variant="secondary">
 							<Bookmark size={14} /> Overview

--- a/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/TraceDetailsHeader.tsx
+++ b/frontend/src/pages/TraceDetailsV3/TraceDetailsHeader/TraceDetailsHeader.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Button } from '@signozhq/ui/button';
 import {
@@ -29,6 +29,8 @@ import KeyValueLabel from 'periscope/components/KeyValueLabel';
 import { TraceDetailV2URLProps } from 'types/api/trace/getTraceV2';
 import { DataSource } from 'types/common/queryBuilder';
 
+import { TraceDetailEventKeys, TraceDetailEvents } from '../events';
+import { useTraceDetailLogEvent } from '../hooks/useTraceDetailLogEvent';
 import { useTraceStore } from '../stores/traceStore';
 import AnalyticsPanel from '../SpanDetailsPanel/AnalyticsPanel/AnalyticsPanel';
 import Filters from '../TraceWaterfall/TraceWaterfallStates/Success/Filters/Filters';
@@ -90,11 +92,35 @@ function TraceDetailsHeader({
 	const previewFields = useTraceStore((s) => s.previewFields);
 	const setPreviewFields = useTraceStore((s) => s.setPreviewFields);
 
+	const logTraceEvent = useTraceDetailLogEvent('v3', traceID || '');
+	const pageLoadedAtRef = useRef(Date.now());
+
 	const handleSwitchToOldView = useCallback((): void => {
+		logTraceEvent(TraceDetailEvents.ViewSwitched, {
+			[TraceDetailEventKeys.From]: 'v3',
+			[TraceDetailEventKeys.To]: 'v2',
+			[TraceDetailEventKeys.DwellMs]: Date.now() - pageLoadedAtRef.current,
+		});
 		setLocalStorageKey(LOCALSTORAGE.TRACE_DETAILS_PREFER_OLD_VIEW, 'true');
 		const oldUrl = `/trace-old/${traceID}${window.location.search}`;
 		history.replace(oldUrl);
-	}, [traceID]);
+	}, [traceID, logTraceEvent]);
+
+	const handleToggleAnalytics = useCallback((): void => {
+		logTraceEvent(TraceDetailEvents.AnalyticsPanelToggled, {
+			[TraceDetailEventKeys.Open]: !isAnalyticsOpen,
+		});
+		setIsAnalyticsOpen((prev) => !prev);
+	}, [logTraceEvent, isAnalyticsOpen]);
+
+	const handleAnalyticsTabChange = useCallback(
+		(tab: string): void => {
+			logTraceEvent(TraceDetailEvents.AnalyticsTabChanged, {
+				[TraceDetailEventKeys.Tab]: tab,
+			});
+		},
+		[logTraceEvent],
+	);
 
 	const handlePreviousBtnClick = useCallback((): void => {
 		if (hasInAppHistory()) {
@@ -167,7 +193,7 @@ function TraceDetailsHeader({
 												size="icon"
 												color="secondary"
 												aria-label="Analytics"
-												onClick={(): void => setIsAnalyticsOpen((prev) => !prev)}
+												onClick={handleToggleAnalytics}
 											>
 												<ChartPie size={14} />
 											</Button>
@@ -245,6 +271,7 @@ function TraceDetailsHeader({
 			<AnalyticsPanel
 				isOpen={isAnalyticsOpen}
 				onClose={(): void => setIsAnalyticsOpen(false)}
+				onTabChange={handleAnalyticsTabChange}
 			/>
 		</div>
 	);

--- a/frontend/src/pages/TraceDetailsV3/events.ts
+++ b/frontend/src/pages/TraceDetailsV3/events.ts
@@ -1,0 +1,38 @@
+export enum TraceDetailEvents {
+	DataLoaded = 'Trace Detail: Data loaded',
+	ViewSwitched = 'Trace Detail: View switched',
+	FlameGraphToggled = 'Trace Detail: Flame graph toggled',
+	WaterfallToggled = 'Trace Detail: Waterfall toggled',
+	AnalyticsPanelToggled = 'Trace Detail: Analytics panel toggled',
+	AnalyticsTabChanged = 'Trace Detail: Analytics tab changed',
+	SpanPanelTabChanged = 'Trace Detail: Span panel tab changed',
+}
+
+export enum TraceDetailEventKeys {
+	// Injected on every event by useTraceDetailLogEvent
+	View = 'view',
+	TraceId = 'traceId',
+	// Data loaded — trace shape
+	TotalSpansCount = 'totalSpansCount',
+	NumServices = 'numServices',
+	TraceDurationMs = 'traceDurationMs',
+	HadErrors = 'hadErrors',
+	FlamegraphSampled = 'flamegraphSampled',
+	// Data loaded — persisted settings
+	SpanPanelVariant = 'spanPanelVariant',
+	ColorByField = 'colorByField',
+	PreviewFieldsCount = 'previewFieldsCount',
+	EntryPreferOldView = 'entryPreferOldView',
+	// View switched
+	From = 'from',
+	To = 'to',
+	DwellMs = 'dwellMs',
+	// Toggles / tabs
+	Expanded = 'expanded',
+	Open = 'open',
+	Tab = 'tab',
+	// Span panel tab changed
+	SpanId = 'spanId',
+}
+
+export type TraceDetailView = 'v2' | 'v3';

--- a/frontend/src/pages/TraceDetailsV3/hooks/__tests__/useTraceDetailLogEvent.test.tsx
+++ b/frontend/src/pages/TraceDetailsV3/hooks/__tests__/useTraceDetailLogEvent.test.tsx
@@ -1,0 +1,88 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { TraceDetailEvents } from '../../events';
+import { useTraceDetailLogEvent } from '../useTraceDetailLogEvent';
+
+const logEventMock = jest.fn();
+
+jest.mock('api/common/logEvent', () => ({
+	__esModule: true,
+	default: (...args: unknown[]): void => logEventMock(...args),
+}));
+
+describe('useTraceDetailLogEvent', () => {
+	beforeEach(() => {
+		logEventMock.mockClear();
+	});
+
+	it('injects view and traceId on every event', () => {
+		const { result } = renderHook(() =>
+			useTraceDetailLogEvent('v3', 'trace-123'),
+		);
+
+		act(() => {
+			result.current(TraceDetailEvents.DataLoaded, { totalSpansCount: 42 });
+		});
+
+		expect(logEventMock).toHaveBeenCalledTimes(1);
+		expect(logEventMock).toHaveBeenCalledWith(TraceDetailEvents.DataLoaded, {
+			view: 'v3',
+			traceId: 'trace-123',
+			totalSpansCount: 42,
+		});
+	});
+
+	it('injects view and traceId even when no attributes are passed', () => {
+		const { result } = renderHook(() =>
+			useTraceDetailLogEvent('v2', 'trace-456'),
+		);
+
+		act(() => {
+			result.current(TraceDetailEvents.ViewSwitched);
+		});
+
+		expect(logEventMock).toHaveBeenCalledWith(TraceDetailEvents.ViewSwitched, {
+			view: 'v2',
+			traceId: 'trace-456',
+		});
+	});
+
+	it('keeps a stable callback identity and emits the latest traceId', () => {
+		const { result, rerender } = renderHook(
+			({ traceId }) => useTraceDetailLogEvent('v3', traceId),
+			{ initialProps: { traceId: 'trace-1' } },
+		);
+
+		const firstIdentity = result.current;
+		rerender({ traceId: 'trace-2' });
+
+		expect(result.current).toBe(firstIdentity);
+
+		act(() => {
+			result.current(TraceDetailEvents.SpanPanelTabChanged, { spanId: 's1' });
+		});
+		expect(logEventMock).toHaveBeenCalledWith(
+			TraceDetailEvents.SpanPanelTabChanged,
+			{
+				view: 'v3',
+				traceId: 'trace-2',
+				spanId: 's1',
+			},
+		);
+	});
+
+	it('never throws if logEvent throws (analytics must not break the UI)', () => {
+		logEventMock.mockImplementationOnce(() => {
+			throw new Error('network down');
+		});
+		const { result } = renderHook(() =>
+			useTraceDetailLogEvent('v3', 'trace-123'),
+		);
+
+		expect(() => {
+			act(() => {
+				result.current(TraceDetailEvents.DataLoaded);
+			});
+		}).not.toThrow();
+	});
+});

--- a/frontend/src/pages/TraceDetailsV3/hooks/useTraceDetailLogEvent.ts
+++ b/frontend/src/pages/TraceDetailsV3/hooks/useTraceDetailLogEvent.ts
@@ -1,0 +1,39 @@
+import { useCallback, useRef } from 'react';
+import logEvent from 'api/common/logEvent';
+
+import {
+	TraceDetailEventKeys,
+	TraceDetailEvents,
+	TraceDetailView,
+} from '../events';
+
+export type TraceDetailLogEvent = (
+	event: TraceDetailEvents,
+	attributes?: Record<string, unknown>,
+) => void;
+
+export function useTraceDetailLogEvent(
+	view: TraceDetailView,
+	traceId: string,
+): TraceDetailLogEvent {
+	const contextRef = useRef({ view, traceId });
+	contextRef.current = { view, traceId };
+
+	return useCallback(
+		(
+			event: TraceDetailEvents,
+			attributes: Record<string, unknown> = {},
+		): void => {
+			try {
+				void logEvent(event, {
+					[TraceDetailEventKeys.View]: contextRef.current.view,
+					[TraceDetailEventKeys.TraceId]: contextRef.current.traceId,
+					...attributes,
+				});
+			} catch {
+				// No-op. Logging must never throw into the UI.
+			}
+		},
+		[],
+	);
+}

--- a/frontend/src/pages/TraceDetailsV3/index.tsx
+++ b/frontend/src/pages/TraceDetailsV3/index.tsx
@@ -20,7 +20,10 @@ import {
 } from 'types/api/trace/getTraceV3';
 
 import { COLOR_BY_FIELDS } from './constants';
+import { TraceDetailEventKeys, TraceDetailEvents } from './events';
+import { useTraceDetailLogEvent } from './hooks/useTraceDetailLogEvent';
 import TraceStoreSync from './stores/TraceStoreSync';
+import { useTraceStore } from './stores/traceStore';
 import { AGGREGATIONS } from './utils/aggregations';
 import { SpanDetailVariant } from './SpanDetailsPanel/constants';
 import SpanDetailsPanel from './SpanDetailsPanel/SpanDetailsPanel';
@@ -55,6 +58,14 @@ function TraceDetailsV3(): JSX.Element {
 
 	const selectedSpanId = urlQuery.get('spanId') || undefined;
 	const { safeNavigate } = useSafeNavigate();
+
+	const logTraceEvent = useTraceDetailLogEvent('v3', traceId || '');
+	// Tracks which traceId the load event already fired for, so navigating
+	// between traces (the route component stays mounted) re-fires it once each.
+	const dataLoadedFiredForRef = useRef('');
+	const colorByField = useTraceStore((s) => s.colorByField);
+	const previewFieldsCount = useTraceStore((s) => s.previewFields.length);
+	const userPrefsReady = useTraceStore((s) => s.userPreferences !== null);
 
 	const handleSpanDetailsClose = useCallback((): void => {
 		urlQuery.delete('spanId');
@@ -154,6 +165,46 @@ function TraceDetailsV3(): JSX.Element {
 		allSpansRef.current = allSpans;
 	}, [allSpans]);
 
+	useEffect(() => {
+		if (
+			!traceId ||
+			dataLoadedFiredForRef.current === traceId ||
+			!userPrefsReady
+		) {
+			return;
+		}
+		const payload = traceData?.payload;
+		if (!payload?.spans?.length) {
+			return;
+		}
+		dataLoadedFiredForRef.current = traceId;
+		const numServices = new Set(payload.spans.map((s) => s['service.name'])).size;
+		logTraceEvent(TraceDetailEvents.DataLoaded, {
+			[TraceDetailEventKeys.TotalSpansCount]: totalSpansCount,
+			[TraceDetailEventKeys.NumServices]: numServices,
+			[TraceDetailEventKeys.TraceDurationMs]:
+				payload.endTimestampMillis - payload.startTimestampMillis,
+			[TraceDetailEventKeys.HadErrors]: (payload.totalErrorSpansCount || 0) > 0,
+			[TraceDetailEventKeys.FlamegraphSampled]:
+				totalSpansCount > FLAMEGRAPH_SPAN_LIMIT,
+			[TraceDetailEventKeys.SpanPanelVariant]:
+				getLocalStorageKey(LOCALSTORAGE.TRACE_DETAILS_SPAN_DETAILS_POSITION) ||
+				SpanDetailVariant.DOCKED_RIGHT,
+			[TraceDetailEventKeys.ColorByField]: colorByField.name,
+			[TraceDetailEventKeys.PreviewFieldsCount]: previewFieldsCount,
+			[TraceDetailEventKeys.EntryPreferOldView]:
+				getLocalStorageKey(LOCALSTORAGE.TRACE_DETAILS_PREFER_OLD_VIEW) === 'true',
+		});
+	}, [
+		traceId,
+		userPrefsReady,
+		traceData,
+		totalSpansCount,
+		colorByField,
+		previewFieldsCount,
+		logTraceEvent,
+	]);
+
 	// Frontend mode: expand all parents by default when full data arrives
 	useEffect(() => {
 		if (isFullDataLoaded && allSpans.length > 0) {
@@ -233,6 +284,12 @@ function TraceDetailsV3(): JSX.Element {
 	const [activeKeys, setActiveKeys] = useState<string[]>(['flame', 'waterfall']);
 
 	const handleCollapseChange = (key: string): void => {
+		logTraceEvent(
+			key === 'flame'
+				? TraceDetailEvents.FlameGraphToggled
+				: TraceDetailEvents.WaterfallToggled,
+			{ [TraceDetailEventKeys.Expanded]: !activeKeys.includes(key) },
+		);
 		setActiveKeys((prev) =>
 			prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
 		);

--- a/frontend/src/periscope/components/DataViewer/DataViewer.tsx
+++ b/frontend/src/periscope/components/DataViewer/DataViewer.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, Copy } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
 import { DropdownMenuSimple as Dropdown } from '@signozhq/ui/dropdown-menu';
 import { toast } from '@signozhq/ui/sonner';
+import logEvent from 'api/common/logEvent';
 import { JsonView } from 'periscope/components/JsonView';
 import { PrettyView } from 'periscope/components/PrettyView';
 import { PrettyViewProps } from 'periscope/components/PrettyView';
@@ -11,6 +12,8 @@ import { PrettyViewProps } from 'periscope/components/PrettyView';
 import './DataViewer.styles.scss';
 
 type ViewMode = 'pretty' | 'json';
+
+const VIEW_MODE_CHANGED_EVENT = 'Data Viewer: View mode changed';
 
 const VIEW_MODE_OPTIONS: { label: string; value: ViewMode }[] = [
 	{ label: 'Pretty', value: 'pretty' },
@@ -34,6 +37,20 @@ function DataViewer({
 
 	const jsonString = useMemo(() => JSON.stringify(data, null, 2), [data]);
 
+	const handleViewModeChange = (value: string): void => {
+		const next = value as ViewMode;
+		setViewMode(next);
+		try {
+			logEvent(VIEW_MODE_CHANGED_EVENT, {
+				viewMode: next,
+				path: window.location.pathname,
+				drawerKey,
+			});
+		} catch {
+			// No op
+		}
+	};
+
 	const handleCopy = (): void => {
 		const text = JSON.stringify(data, null, 2);
 		setCopy(text);
@@ -56,7 +73,7 @@ function DataViewer({
 							{
 								type: 'radio-group',
 								value: viewMode,
-								onChange: (value): void => setViewMode(value as ViewMode),
+								onChange: handleViewModeChange,
 								children: VIEW_MODE_OPTIONS.map((opt) => ({
 									type: 'radio',
 									key: opt.value,


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Adds analytics instrumentation to **Trace Detail V3** — 8 events to measure which V3 surfaces users use. Persisted settings (color-by, preview fields, dock position) are read once on load in a single `Data loaded` event; only non-persisting interactions get their own events. A `useTraceDetailLogEvent(view, traceId)` hook injects `view` + `traceId` on every event and wraps `logEvent` in try/catch so analytics can't throw into the UI.

| # | Event | Fires on | Key attributes |
|---|---|---|---|
| 1 | `Trace Detail: Data loaded` | once per trace, when waterfall response has spans | `totalSpansCount`, `numServices`, `traceDurationMs`, `hadErrors`, `flamegraphSampled`, `spanPanelVariant`, `colorByField`, `previewFieldsCount`, `entryPreferOldView` |
| 2 | `Trace Detail: View switched` | "Legacy View" click | `from`, `to`, `dwellMs` |
| 3 | `Trace Detail: Flame graph toggled` | collapse/expand flamegraph panel | `expanded` |
| 4 | `Trace Detail: Waterfall toggled` | collapse/expand waterfall panel | `expanded` |
| 5 | `Trace Detail: Analytics panel toggled` | ChartPie button | `open` |
| 6 | `Trace Detail: Analytics tab changed` | switch exec-time / spans | `tab` |
| 7 | `Trace Detail: Span panel tab changed` | Overview / Events / Logs / Metrics | `tab`, `spanId` |
| 8 | `Data Viewer: View mode changed` (generic) | Pretty ↔ JSON toggle in any data viewer | `viewMode`, `path`, `drawerKey` |

#### Issues closed by this PR

Closes SigNoz/engineering-pod#4955

---

### ✅ Change Type

- [x] ✨ Feature

---

### 🧪 Testing Strategy

- Tests added: `useTraceDetailLogEvent.test.tsx` — injects `view`/`traceId` on every event, stable callback identity across re-renders, never throws if `logEvent` throws.
- Manual: confirmed each interaction fires a single `POST /event` with expected payload; `Data loaded` fires once per trace and re-fires on navigation.
- `tsgo --noEmit`, `oxlint`, `pnpm build` clean; `TraceDetailsV3` suite green.

---

### ⚠️ Risk & Impact Assessment

- Additive analytics only — no UI behavior change. Every emit is try/catch-wrapped, so a failing call can't break rendering.
- `Data Viewer: View mode changed` fires wherever the shared `DataViewer` is used (logs explorer, traces, drawers).
- Rollback: revert the PR (no migrations/schema changes).

---

### 📝 Changelog

N/A — internal instrumentation, not user-facing.

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered (additive only)

---

## 👀 Notes for Reviewers

- No Color-by-changed / Preview-fields / Span-variant / Span-clicked events by design — persisted settings are read once in `Data loaded`.
- `Data loaded` is **not** gated on `isFullDataLoaded` (frontend-mode-only; would suppress the event for backend-paginated traces) — it fires once spans are present + prefs hydrated, guard keyed to `traceId`.
