### PR TITLE
feat(dashboards): V2 dashboard details — base scaffolding

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardContainer.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardContainer.module.scss
@@ -1,0 +1,5 @@
+.container {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardDescription/DashboardActions/DashboardActions.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardDescription/DashboardActions/DashboardActions.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState } from 'react';
+import { FullScreenHandle } from 'react-full-screen';
+import { useTranslation } from 'react-i18next';
+import { useCopyToClipboard } from 'react-use';
+import {
+	ClipboardCopy,
+	Ellipsis,
+	FileJson,
+	Fullscreen,
+	LockKeyhole,
+	PenLine,
+	Plus,
+} from '@signozhq/icons';
+import { Popover } from 'antd';
+import { Button } from '@signozhq/ui/button';
+import { toast } from '@signozhq/ui/sonner';
+import { TooltipSimple } from '@signozhq/ui/tooltip';
+import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
+import { DeleteButton } from 'container/ListOfDashboard/TableComponents/DeleteButton';
+import DateTimeSelectionV2 from 'container/TopNav/DateTimeSelectionV2';
+import { useAppContext } from 'providers/App/App';
+import { USER_ROLES } from 'types/roles';
+
+import styles from '../DashboardDescription.module.scss';
+
+interface Props {
+	dashboard: DashboardtypesGettableDashboardV2DTO;
+	handle: FullScreenHandle;
+	isDashboardLocked: boolean;
+	editDashboard: boolean;
+	isAuthor: boolean;
+	addPanelPermission: boolean;
+	onAddPanel: () => void;
+	onLockToggle: () => void;
+	onOpenRename: () => void;
+}
+
+function DashboardActions({
+	dashboard,
+	handle,
+	isDashboardLocked,
+	editDashboard,
+	isAuthor,
+	addPanelPermission,
+	onAddPanel,
+	onLockToggle,
+	onOpenRename,
+}: Props): JSX.Element {
+	const { user } = useAppContext();
+	const { t } = useTranslation(['dashboard', 'common']);
+
+	const id = dashboard.id;
+	const title = dashboard.spec?.display?.name ?? '';
+
+	const [isDashboardSettingsOpen, setIsDashboardSettingsOpen] =
+		useState<boolean>(false);
+
+	const [state, setCopy] = useCopyToClipboard();
+
+	useEffect(() => {
+		if (state.error) {
+			toast.error(t('something_went_wrong', { ns: 'common' }));
+		}
+		if (state.value) {
+			toast.success(t('success', { ns: 'common' }));
+		}
+	}, [state.error, state.value, t]);
+
+	const dashboardDataJSON = (): string => JSON.stringify(dashboard, null, 2);
+
+	const exportJSON = (): void => {
+		const blob = new Blob([dashboardDataJSON()], { type: 'application/json' });
+		const url = URL.createObjectURL(blob);
+		const link = document.createElement('a');
+		link.href = url;
+		link.download = `${title || 'dashboard'}.json`;
+		document.body.appendChild(link);
+		link.click();
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
+	};
+
+	return (
+		<div className={styles.rightSection}>
+			<DateTimeSelectionV2 showAutoRefresh hideShareModal />
+			<Popover
+				open={isDashboardSettingsOpen}
+				arrow={false}
+				onOpenChange={(visible): void => setIsDashboardSettingsOpen(visible)}
+				rootClassName={styles.dashboardSettings}
+				content={
+					<div className={styles.menuContent}>
+						<section className={styles.section1}>
+							{(isAuthor || user.role === USER_ROLES.ADMIN) && (
+								<TooltipSimple
+									title={
+										dashboard.createdBy === 'integration'
+											? 'Dashboards created by integrations cannot be unlocked'
+											: ''
+									}
+								>
+									<Button
+										variant="ghost"
+										prefix={<LockKeyhole size={14} />}
+										disabled={dashboard.createdBy === 'integration'}
+										onClick={(): void => {
+											setIsDashboardSettingsOpen(false);
+											onLockToggle();
+										}}
+										testId="lock-unlock-dashboard"
+									>
+										{isDashboardLocked ? 'Unlock Dashboard' : 'Lock Dashboard'}
+									</Button>
+								</TooltipSimple>
+							)}
+
+							{!isDashboardLocked && editDashboard && (
+								<Button
+									variant="ghost"
+									prefix={<PenLine size={14} />}
+									onClick={(): void => {
+										onOpenRename();
+										setIsDashboardSettingsOpen(false);
+									}}
+								>
+									Rename
+								</Button>
+							)}
+
+							<Button
+								variant="ghost"
+								prefix={<Fullscreen size={14} />}
+								onClick={handle.enter}
+							>
+								Full screen
+							</Button>
+						</section>
+						<section className={styles.section2}>
+							<Button
+								variant="ghost"
+								prefix={<FileJson size={14} />}
+								onClick={(): void => {
+									exportJSON();
+									setIsDashboardSettingsOpen(false);
+								}}
+							>
+								Export JSON
+							</Button>
+							<Button
+								variant="ghost"
+								prefix={<ClipboardCopy size={14} />}
+								onClick={(): void => {
+									setCopy(dashboardDataJSON());
+									setIsDashboardSettingsOpen(false);
+								}}
+							>
+								Copy as JSON
+							</Button>
+						</section>
+						<section className={styles.deleteDashboard}>
+							<DeleteButton
+								createdBy={dashboard.createdBy || ''}
+								name={title}
+								id={id}
+								isLocked={isDashboardLocked}
+								routeToListPage
+							/>
+						</section>
+					</div>
+				}
+				trigger="click"
+				placement="bottomRight"
+			>
+				<Button
+					variant="ghost"
+					size="icon"
+					prefix={<Ellipsis size={14} />}
+					className={styles.icons}
+					testId="options"
+				/>
+			</Popover>
+			{!isDashboardLocked && addPanelPermission && (
+				<Button
+					variant="solid"
+					color="primary"
+					className={styles.addPanelBtn}
+					onClick={onAddPanel}
+					prefix={<Plus size="md" />}
+					testId="add-panel-header"
+				>
+					New Panel
+				</Button>
+			)}
+		</div>
+	);
+}
+
+export default DashboardActions;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardDescription/DashboardDescription.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardDescription/DashboardDescription.module.scss
@@ -1,0 +1,303 @@
+.dashboardDescriptionContainer {
+	box-shadow: none;
+	border: none;
+	background: unset;
+	color: var(--l2-foreground);
+
+	:global(.ant-card-body) {
+		padding: 0px;
+	}
+
+	.dashboardDetails {
+		display: flex;
+		justify-content: space-between;
+		gap: 8px;
+		padding: 16px 16px 0px 16px;
+		align-items: flex-start;
+
+		.leftSection {
+			display: flex;
+			align-items: center;
+			gap: 8px;
+			width: 45%;
+
+			.dashboardImg {
+				height: 16px;
+				width: 16px;
+			}
+
+			.dashboardTitle {
+				color: var(--l1-foreground);
+				font-family: Inter;
+				font-size: 16px;
+				font-style: normal;
+				font-weight: 500;
+				line-height: 24px; /* 150% */
+				letter-spacing: -0.08px;
+				max-width: 80%;
+
+				display: -webkit-box;
+				-webkit-line-clamp: 1;
+				-webkit-box-orient: vertical;
+				overflow: hidden;
+			}
+
+			.publicDashboardIcon {
+				margin-right: 4px;
+			}
+		}
+
+		.rightSection {
+			display: flex;
+			width: 55%;
+			justify-content: flex-end;
+			flex-wrap: wrap;
+			align-items: center;
+			gap: 14px;
+
+			.icons {
+				display: flex;
+				align-items: center;
+				width: 32px;
+				height: 34px;
+				padding: 6px;
+				justify-content: center;
+				border-radius: 2px;
+				border: 1px solid var(--l1-border);
+				background: var(--l3-background);
+				color: var(--l2-foreground);
+				font-family: Inter;
+				font-size: 12px;
+				font-style: normal;
+				font-weight: 500;
+				line-height: 10px; /* 83.333% */
+				letter-spacing: 0.12px;
+			}
+
+			.icons:hover {
+				background-color: unset;
+			}
+
+			.configureButton {
+				display: flex;
+				align-items: center;
+				width: 93px;
+				height: 34px;
+				padding: 6px;
+				justify-content: center;
+				border-radius: 2px;
+				border: 1px solid var(--l1-border);
+				background: var(--l3-background);
+				color: var(--l2-foreground);
+				font-family: Inter;
+				font-size: 12px;
+				font-style: normal;
+				font-weight: 500;
+				line-height: 10px; /* 83.333% */
+				letter-spacing: 0.12px;
+			}
+
+			.addPanelBtn {
+				display: flex;
+				width: 119px;
+				height: 34px;
+				padding: 5.937px 11.875px;
+				justify-content: center;
+				align-items: center;
+				color: var(--primary-foreground);
+				background: var(--primary-background);
+				font-family: Inter;
+				font-size: 11.875px;
+				font-style: normal;
+				font-weight: 500;
+				line-height: 17.812px; /* 150% */
+			}
+		}
+	}
+
+	.dashboardTags {
+		display: flex;
+		gap: 6px;
+		padding: 16px 16px 0px 16px;
+		flex-wrap: wrap;
+
+		.tag {
+			display: flex;
+			padding: 4px 8px;
+			justify-content: center;
+			align-items: center;
+			border-radius: 20px;
+			border: 1px solid color-mix(in srgb, var(--bg-sienna-500) 20%, transparent);
+			background: color-mix(in srgb, var(--bg-sienna-500) 10%, transparent);
+			color: var(--bg-sienna-400);
+			text-align: center;
+			font-family: Inter;
+			font-size: 14px;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 20px; /* 142.857% */
+			letter-spacing: -0.07px;
+			margin-inline-end: 0px;
+		}
+	}
+
+	.dashboardDescriptionSection {
+		color: var(--l2-foreground);
+		font-family: Inter;
+		font-size: 14px;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 22px; /* 157.143% */
+		letter-spacing: -0.07px;
+		padding: 20px 16px 0px 16px;
+	}
+}
+
+.dashboardSettings {
+	width: 191px;
+	height: 302px;
+	flex-shrink: 0;
+
+	:global(.ant-popover-inner) {
+		padding: 0px;
+		border-radius: 4px;
+		border: 1px solid var(--l1-border);
+		background: linear-gradient(
+			139deg,
+			color-mix(in srgb, var(--card) 80%, transparent) 0%,
+			color-mix(in srgb, var(--card) 90%, transparent) 98.68%
+		) !important;
+		box-shadow: 4px 10px 16px 2px rgba(0, 0, 0, 0.2);
+		backdrop-filter: blur(20px);
+	}
+
+	.menuContent {
+		display: flex;
+		flex-direction: column;
+
+		section {
+			display: flex;
+			flex-direction: column;
+			align-items: start;
+
+			button {
+				display: flex;
+				width: 100%;
+				height: unset;
+				padding: 8px;
+				align-items: center;
+				gap: 12px;
+				color: var(--l2-foreground);
+				font-family: Inter;
+				font-size: 13px;
+				font-style: normal;
+				font-weight: 400;
+				line-height: normal;
+				letter-spacing: 0.14px;
+				border-top: none;
+			}
+		}
+
+		.section1,
+		.section2 {
+			border-bottom: 1px solid var(--l1-border);
+		}
+
+		.deleteDashboard button {
+			color: var(--bg-cherry-400) !important;
+		}
+	}
+}
+
+.renameDashboard {
+	:global(.ant-modal-content) {
+		width: 384px;
+		flex-shrink: 0;
+		border-radius: 4px;
+		border: 1px solid var(--l1-border);
+		background: var(--l2-background);
+		box-shadow: 0px -4px 16px 2px rgba(0, 0, 0, 0.2);
+		padding: 0px;
+
+		:global(.ant-modal-header) {
+			height: 52px;
+			padding: 16px;
+			background: var(--l2-background);
+			border-bottom: 1px solid var(--l1-border);
+			margin-bottom: 0px;
+
+			:global(.ant-modal-title) {
+				color: var(--l1-foreground);
+				font-family: Inter;
+				font-size: 14px;
+				font-style: normal;
+				font-weight: 400;
+				line-height: 20px; /* 142.857% */
+				width: 349px;
+				height: 20px;
+			}
+		}
+
+		:global(.ant-modal-body) {
+			padding: 16px;
+
+			.dashboardContent {
+				display: flex;
+				flex-direction: column;
+				gap: 8px;
+
+				.nameText {
+					color: var(--l1-foreground);
+					font-family: Inter;
+					font-size: 14px;
+					font-style: normal;
+					font-weight: 500;
+					line-height: 20px; /* 142.857% */
+				}
+
+				.dashboardNameInput {
+					display: flex;
+					padding: 6px 6px 6px 8px;
+					align-items: center;
+					gap: 4px;
+					align-self: stretch;
+					border-radius: 0px 2px 2px 0px;
+					border: 1px solid var(--l1-border);
+					background: var(--l3-background);
+				}
+			}
+		}
+
+		:global(.ant-modal-footer) {
+			padding: 16px;
+			margin-top: 0px;
+
+			.dashboardRename {
+				display: flex;
+				flex-direction: row-reverse;
+				gap: 12px;
+
+				.cancelBtn {
+					display: flex;
+					padding: 4px 8px;
+					justify-content: center;
+					align-items: center;
+					gap: 4px;
+					border-radius: 2px;
+					background: var(--l1-border);
+				}
+
+				.renameBtn {
+					display: flex;
+					align-items: center;
+					width: 169px;
+					padding: 4px 8px;
+					justify-content: center;
+					gap: 4px;
+					border-radius: 2px;
+					background: var(--primary-background);
+				}
+			}
+		}
+	}
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardDescription/DashboardMeta/DashboardMeta.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardDescription/DashboardMeta/DashboardMeta.tsx
@@ -1,0 +1,32 @@
+import { Badge } from '@signozhq/ui/badge';
+import { isEmpty } from 'lodash-es';
+
+import styles from '../DashboardDescription.module.scss';
+
+interface Props {
+	tags: string[];
+	description: string;
+}
+
+function DashboardMeta({ tags, description }: Props): JSX.Element {
+	return (
+		<>
+			{tags.length > 0 && (
+				<div className={styles.dashboardTags}>
+					{tags.map((tag) => (
+						<Badge key={tag} className={styles.tag}>
+							{tag}
+						</Badge>
+					))}
+				</div>
+			)}
+			{!isEmpty(description) && (
+				<section className={styles.dashboardDescriptionSection}>
+					{description}
+				</section>
+			)}
+		</>
+	);
+}
+
+export default DashboardMeta;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardDescription/DashboardTitle/DashboardTitle.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardDescription/DashboardTitle/DashboardTitle.tsx
@@ -1,0 +1,47 @@
+import { Globe, LockKeyhole } from '@signozhq/icons';
+import { TooltipSimple } from '@signozhq/ui/tooltip';
+import { Typography } from '@signozhq/ui/typography';
+
+import styles from '../DashboardDescription.module.scss';
+
+interface Props {
+	title: string;
+	image: string;
+	isPublicDashboard: boolean;
+	isDashboardLocked: boolean;
+}
+
+function DashboardTitle({
+	title,
+	image,
+	isPublicDashboard,
+	isDashboardLocked,
+}: Props): JSX.Element {
+	return (
+		<div className={styles.leftSection}>
+			<img src={image} alt="dashboard-img" className={styles.dashboardImg} />
+			<TooltipSimple title={title.length > 30 ? title : ''}>
+				<Typography.Text
+					className={styles.dashboardTitle}
+					data-testid="dashboard-title"
+				>
+					{title}
+				</Typography.Text>
+			</TooltipSimple>
+
+			{isPublicDashboard && (
+				<TooltipSimple title="This dashboard is publicly accessible">
+					<Globe size={14} className={styles.publicDashboardIcon} />
+				</TooltipSimple>
+			)}
+
+			{isDashboardLocked && (
+				<TooltipSimple title="This dashboard is locked">
+					<LockKeyhole size={14} />
+				</TooltipSimple>
+			)}
+		</div>
+	);
+}
+
+export default DashboardTitle;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardDescription/RenameDashboardModal/RenameDashboardModal.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardDescription/RenameDashboardModal/RenameDashboardModal.tsx
@@ -1,0 +1,70 @@
+import { Input, Modal } from 'antd';
+import { Button } from '@signozhq/ui/button';
+import { Check, X } from '@signozhq/icons';
+import { Typography } from '@signozhq/ui/typography';
+
+import styles from '../DashboardDescription.module.scss';
+
+interface Props {
+	open: boolean;
+	value: string;
+	isLoading: boolean;
+	onChange: (value: string) => void;
+	onRename: () => void;
+	onClose: () => void;
+}
+
+function RenameDashboardModal({
+	open,
+	value,
+	isLoading,
+	onChange,
+	onRename,
+	onClose,
+}: Props): JSX.Element {
+	return (
+		<Modal
+			open={open}
+			title="Rename Dashboard"
+			onOk={onRename}
+			onCancel={onClose}
+			rootClassName={styles.renameDashboard}
+			footer={
+				<div className={styles.dashboardRename}>
+					<Button
+						variant="solid"
+						color="primary"
+						prefix={<Check size={14} />}
+						className={styles.renameBtn}
+						onClick={onRename}
+						disabled={isLoading}
+					>
+						Rename Dashboard
+					</Button>
+					<Button
+						variant="ghost"
+						prefix={<X size={14} />}
+						className={styles.cancelBtn}
+						onClick={onClose}
+					>
+						Cancel
+					</Button>
+				</div>
+			}
+		>
+			<div className={styles.dashboardContent}>
+				<Typography.Text className={styles.nameText}>
+					Enter a new name
+				</Typography.Text>
+				<Input
+					data-testid="dashboard-name"
+					className={styles.dashboardNameInput}
+					value={value}
+					onChange={(e): void => onChange(e.target.value)}
+				/>
+			</div>
+		</Modal>
+	);
+}
+
+export default RenameDashboardModal;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardDescription/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardDescription/index.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useState } from 'react';
+import { FullScreenHandle } from 'react-full-screen';
+import { Card } from 'antd';
+import { toast } from '@signozhq/ui/sonner';
+import logEvent from 'api/common/logEvent';
+import {
+	lockDashboardV2,
+	patchDashboardV2,
+	unlockDashboardV2,
+} from 'api/generated/services/dashboard';
+import type {
+	DashboardtypesGettableDashboardV2DTO,
+	DashboardtypesJSONPatchOperationDTO,
+} from 'api/generated/services/sigNoz.schemas';
+import { Base64Icons } from 'container/DashboardContainer/DashboardSettings/General/utils';
+import useComponentPermission from 'hooks/useComponentPermission';
+import { useAppContext } from 'providers/App/App';
+import { useErrorModal } from 'providers/ErrorModalProvider';
+import APIError from 'types/api/error';
+
+import DashboardHeader from '../components/DashboardHeader/DashboardHeader';
+import DashboardActions from './DashboardActions/DashboardActions';
+import DashboardMeta from './DashboardMeta/DashboardMeta';
+import DashboardTitle from './DashboardTitle/DashboardTitle';
+import RenameDashboardModal from './RenameDashboardModal/RenameDashboardModal';
+
+import styles from './DashboardDescription.module.scss';
+
+interface DashboardDescriptionProps {
+	dashboard: DashboardtypesGettableDashboardV2DTO;
+	handle: FullScreenHandle;
+	refetch: () => void;
+}
+
+function DashboardDescription(props: DashboardDescriptionProps): JSX.Element {
+	const { dashboard, handle, refetch } = props;
+
+	const id = dashboard.id;
+	const isDashboardLocked = !!dashboard.locked;
+
+	const title = dashboard.spec?.display?.name ?? '';
+	const description = dashboard.spec?.display?.description ?? '';
+	const image = dashboard.image || Base64Icons[0];
+	const tags = useMemo(
+		() =>
+			(dashboard.tags ?? []).map((t) =>
+				t.key === t.value ? t.key : `${t.key}:${t.value}`,
+			),
+		[dashboard.tags],
+	);
+
+	const { user } = useAppContext();
+	const [editDashboard] = useComponentPermission(['edit_dashboard'], user.role);
+	const { showErrorModal } = useErrorModal();
+
+	const isAuthor =
+		!!user?.email && !!dashboard.createdBy && dashboard.createdBy === user.email;
+	const addPanelPermission = !isDashboardLocked;
+	// V2 public dashboard wiring lives separately; treat as not-public for chrome.
+	const isPublicDashboard = false;
+
+	const [isRenameDashboardOpen, setIsRenameDashboardOpen] =
+		useState<boolean>(false);
+	const [updatedTitle, setUpdatedTitle] = useState<string>(title);
+	const [isRenameLoading, setIsRenameLoading] = useState<boolean>(false);
+
+	useEffect(() => {
+		setUpdatedTitle(title);
+	}, [title]);
+
+	const handleLockDashboardToggle = async (): Promise<void> => {
+		if (!id) {
+			return;
+		}
+		try {
+			if (isDashboardLocked) {
+				await unlockDashboardV2({ id });
+				toast.success('Dashboard unlocked');
+			} else {
+				await lockDashboardV2({ id });
+				toast.success('Dashboard locked');
+			}
+			refetch();
+		} catch (error) {
+			showErrorModal(error as APIError);
+		}
+	};
+
+	const onNameChangeHandler = async (): Promise<void> => {
+		const trimmed = updatedTitle.trim();
+		if (!id || !trimmed || trimmed === title) {
+			setIsRenameDashboardOpen(false);
+			return;
+		}
+		try {
+			setIsRenameLoading(true);
+			const patch: DashboardtypesJSONPatchOperationDTO[] = [
+				{
+					op: 'replace' as DashboardtypesJSONPatchOperationDTO['op'],
+					path: '/spec/display/name',
+					value: trimmed,
+				},
+			];
+			await patchDashboardV2({ id }, patch);
+			toast.success('Dashboard renamed successfully');
+			setIsRenameDashboardOpen(false);
+			refetch();
+		} catch (error) {
+			showErrorModal(error as APIError);
+			setIsRenameDashboardOpen(true);
+		} finally {
+			setIsRenameLoading(false);
+		}
+	};
+
+	const onEmptyWidgetHandler = (): void => {
+		void logEvent('Dashboard Detail V2: Add new panel clicked', {
+			dashboardId: id,
+		});
+		toast.info('V2 panel editor coming next');
+	};
+
+	return (
+		<Card className={styles.dashboardDescriptionContainer}>
+			<DashboardHeader title={title} image={image} />
+			<section className={styles.dashboardDetails}>
+				<DashboardTitle
+					title={title}
+					image={image}
+					isPublicDashboard={isPublicDashboard}
+					isDashboardLocked={isDashboardLocked}
+				/>
+				<DashboardActions
+					dashboard={dashboard}
+					handle={handle}
+					isDashboardLocked={isDashboardLocked}
+					editDashboard={editDashboard}
+					isAuthor={isAuthor}
+					addPanelPermission={addPanelPermission}
+					onAddPanel={onEmptyWidgetHandler}
+					onLockToggle={handleLockDashboardToggle}
+					onOpenRename={(): void => setIsRenameDashboardOpen(true)}
+				/>
+			</section>
+			<DashboardMeta tags={tags} description={description} />
+
+			<RenameDashboardModal
+				open={isRenameDashboardOpen}
+				value={updatedTitle}
+				isLoading={isRenameLoading}
+				onChange={setUpdatedTitle}
+				onRename={onNameChangeHandler}
+				onClose={(): void => setIsRenameDashboardOpen(false)}
+			/>
+		</Card>
+	);
+}
+
+export default DashboardDescription;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/Panel.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/Panel.module.scss
@@ -1,0 +1,52 @@
+.panel {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	width: 100%;
+	background: var(--bg-ink-400, #0b0c0e);
+	border: 1px solid var(--bg-slate-400, #1d212d);
+	border-radius: 4px;
+	overflow: hidden;
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 8px 12px;
+	border-bottom: 1px solid var(--bg-slate-400, #1d212d);
+	cursor: grab;
+}
+
+.headerLeft {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+}
+
+.headerTitle {
+	margin: 0;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.badge {
+	margin-inline-end: 0;
+}
+
+.body {
+	flex: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 12px;
+	color: var(--bg-vanilla-400, #8993ae);
+	font-size: 12px;
+	text-align: center;
+}
+
+.bodyKind {
+	margin-bottom: 6px;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/Panel.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/Panel.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import { Badge } from '@signozhq/ui/badge';
+import { TooltipSimple } from '@signozhq/ui/tooltip';
+import { Typography } from '@signozhq/ui/typography';
+import { EllipsisVertical } from '@signozhq/icons';
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import cx from 'classnames';
+
+import styles from './Panel.module.scss';
+
+interface Props {
+	panel: DashboardtypesPanelDTO | undefined;
+	panelId: string;
+	/**
+	 * Placeholder: true once this panel's section enters the viewport. The panel
+	 * query-loading implementation (later PR) will consume this to lazily fetch
+	 * data. Currently unused on purpose.
+	 */
+	isVisible?: boolean;
+}
+
+function Panel({ panel, panelId, isVisible }: Props): JSX.Element {
+	const name = panel?.spec?.display?.name || `Panel ${panelId.slice(0, 6)}`;
+	const description = panel?.spec?.display?.description;
+	const kind = panel?.spec?.plugin?.kind?.replace(/^signoz\//, '') ?? 'unknown';
+	const queryCount = panel?.spec?.queries?.length ?? 0;
+
+	const headerTitle = useMemo(() => {
+		if (!description) {
+			return name;
+		}
+		return (
+			<TooltipSimple title={description}>
+				<span>{name}</span>
+			</TooltipSimple>
+		);
+	}, [name, description]);
+
+	return (
+		<div
+			className={styles.panel}
+			data-panel-visible={isVisible ? 'true' : 'false'}
+		>
+			<div className={cx(styles.header, 'panel-drag-handle')}>
+				<div className={styles.headerLeft}>
+					<Typography.Text className={styles.headerTitle}>
+						{headerTitle}
+					</Typography.Text>
+					<Badge className={styles.badge}>{kind}</Badge>
+				</div>
+				<EllipsisVertical size={14} />
+			</div>
+
+			<div className={styles.body}>
+				<div>
+					<div className={styles.bodyKind}>{kind} panel</div>
+					<div>
+						{queryCount} {queryCount === 1 ? 'query' : 'queries'} · chart rendering
+						coming next
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default Panel;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/PanelsAndSectionsLayout.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/PanelsAndSectionsLayout.module.scss
@@ -1,0 +1,10 @@
+.body {
+	flex: 1;
+	padding: 12px 24px;
+	overflow: auto;
+}
+
+.emptyState {
+	padding: 48px;
+	text-align: center;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/Section/Section.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/Section/Section.module.scss
@@ -1,0 +1,9 @@
+.section {
+	margin-bottom: 12px;
+	border: 1px solid var(--bg-slate-500);
+	border-radius: 4px;
+}
+
+.dragging {
+	opacity: 0.8;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/Section/Section.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/Section/Section.tsx
@@ -1,0 +1,60 @@
+import { useRef, useState } from 'react';
+
+import { useIntersectionObserver } from 'hooks/useIntersectionObserver';
+
+import type { DashboardSection } from '../../../utils';
+import SectionGrid from '../SectionGrid/SectionGrid';
+import SectionHeader from '../SectionHeader/SectionHeader';
+import styles from './Section.module.scss';
+
+interface Props {
+	section: DashboardSection;
+}
+
+function Section({ section }: Props): JSX.Element {
+	const containerRef = useRef<HTMLDivElement>(null);
+	// Placeholder signal for lazy panel query-loading (consumed in a later PR):
+	// true once the section scrolls into (or near) the viewport.
+	const isVisible = useIntersectionObserver(containerRef, {
+		rootMargin: '200px',
+	});
+
+	const [open, setOpen] = useState<boolean>(section.open);
+	const toggle = (): void => setOpen((prev) => !prev);
+
+	const grid = <SectionGrid items={section.items} isVisible={isVisible} />;
+
+	if (!section.title) {
+		// Untitled section — just the grid (no header chrome), but still observed
+		// for the viewport signal.
+		return (
+			<div
+				ref={containerRef}
+				data-testid={`dashboard-section-${section.id}`}
+				data-section-layout-index={section.layoutIndex}
+			>
+				{grid}
+			</div>
+		);
+	}
+
+	return (
+		<div
+			ref={containerRef}
+			className={styles.section}
+			data-testid={`dashboard-section-${section.id}`}
+			data-section-layout-index={section.layoutIndex}
+		>
+			<SectionHeader
+				sectionId={section.id}
+				title={section.title}
+				open={open}
+				onToggle={toggle}
+				repeatVariable={section.repeatVariable}
+			/>
+			{open ? grid : null}
+		</div>
+	);
+}
+
+export default Section;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionGrid/SectionGrid.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionGrid/SectionGrid.module.scss
@@ -1,0 +1,12 @@
+.grid {
+	// Override react-grid-layout's default red drag/resize placeholder with the
+	// SigNoz brand blue.
+	:global(.react-grid-item.react-grid-placeholder) {
+		background: var(--bg-robin-500);
+		opacity: 0.2;
+		border-radius: 4px;
+		transition-duration: 100ms;
+		z-index: 2;
+		user-select: none;
+	}
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionGrid/SectionGrid.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionGrid/SectionGrid.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+import GridLayout, { WidthProvider, type Layout } from 'react-grid-layout';
+
+import type { DashboardSection } from '../../../utils';
+import Panel from '../../Panel/Panel';
+import styles from './SectionGrid.module.scss';
+
+const ResponsiveGridLayout = WidthProvider(GridLayout);
+
+interface Props {
+	items: DashboardSection['items'];
+	/** Forwarded to panels — true when the parent section is in the viewport. */
+	isVisible?: boolean;
+}
+
+function SectionGrid({ items, isVisible }: Props): JSX.Element {
+	const rglLayout = useMemo<Layout[]>(
+		() =>
+			items.map((item) => ({
+				i: item.id,
+				x: item.x,
+				y: item.y,
+				w: item.width,
+				h: item.height,
+			})),
+		[items],
+	);
+
+	return (
+		<ResponsiveGridLayout
+			className={styles.grid}
+			cols={12}
+			rowHeight={45}
+			autoSize
+			useCSSTransforms
+			layout={rglLayout}
+			isDraggable={false}
+			isResizable={false}
+			margin={[8, 8]}
+		>
+			{items.map((item) => (
+				<div key={item.id}>
+					<Panel panel={item.panel} panelId={item.id} isVisible={isVisible} />
+				</div>
+			))}
+		</ResponsiveGridLayout>
+	);
+}
+
+export default SectionGrid;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionHeader/SectionHeader.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionHeader/SectionHeader.module.scss
@@ -1,0 +1,52 @@
+.header {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	padding: 8px 12px;
+
+	&.headerOpen {
+		border-bottom: 1px solid var(--bg-slate-500);
+	}
+}
+
+.dragHandle {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	background: transparent;
+	border: none;
+	color: var(--bg-vanilla-400, #8993ae);
+	cursor: grab;
+
+	&:active {
+		cursor: grabbing;
+	}
+}
+
+.toggle {
+	flex: 1;
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+	gap: 4px;
+	padding: 0;
+	background: transparent;
+	border: none;
+	color: inherit;
+	text-align: left;
+	cursor: pointer;
+	min-width: 0;
+}
+
+.title {
+	margin-left: 4px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.repeatBadge {
+	margin-left: 8px;
+	opacity: 0.6;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionHeader/SectionHeader.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionHeader/SectionHeader.tsx
@@ -1,0 +1,42 @@
+import { ChevronDown, ChevronRight } from '@signozhq/icons';
+import { Typography } from '@signozhq/ui/typography';
+import cx from 'classnames';
+
+import styles from './SectionHeader.module.scss';
+
+interface Props {
+	sectionId: string;
+	title: string;
+	open: boolean;
+	onToggle: () => void;
+	repeatVariable?: string;
+}
+
+function SectionHeader({
+	sectionId,
+	title,
+	open,
+	onToggle,
+	repeatVariable,
+}: Props): JSX.Element {
+	return (
+		<div className={cx(styles.header, { [styles.headerOpen]: open })}>
+			<button
+				type="button"
+				className={styles.toggle}
+				onClick={onToggle}
+				data-testid={`dashboard-section-toggle-${sectionId}`}
+			>
+				{open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+				<Typography.Text className={styles.title}>{title}</Typography.Text>
+				{repeatVariable ? (
+					<Typography.Text className={styles.repeatBadge}>
+						(repeats per ${repeatVariable})
+					</Typography.Text>
+				) : null}
+			</button>
+		</div>
+	);
+}
+
+export default SectionHeader;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/index.tsx
@@ -1,0 +1,53 @@
+import { ReactNode, useMemo } from 'react';
+
+import { Empty } from 'antd';
+import { Typography } from '@signozhq/ui/typography';
+import type {
+	DashboardtypesLayoutDTO,
+	DashboardtypesPanelDTO,
+} from 'api/generated/services/sigNoz.schemas';
+
+import { layoutsToSections } from '../utils';
+import Section from './Section/Section/Section';
+import styles from './PanelsAndSectionsLayout.module.scss';
+
+import 'react-grid-layout/css/styles.css';
+import 'react-resizable/css/styles.css';
+
+interface Props {
+	layouts: DashboardtypesLayoutDTO[];
+	panels: Record<string, DashboardtypesPanelDTO | undefined>;
+}
+
+function PanelsAndSectionsLayout({ layouts, panels }: Props): JSX.Element {
+	const sections = useMemo(
+		() => layoutsToSections(layouts, panels),
+		[layouts, panels],
+	);
+
+	const isEmpty =
+		sections.length === 0 || sections.every((s) => s.items.length === 0);
+
+	const renderContent = (): ReactNode => {
+		if (isEmpty) {
+			return (
+				<div className={styles.emptyState}>
+					<Empty
+						image={Empty.PRESENTED_IMAGE_SIMPLE}
+						description={
+							<Typography.Text>No panels in this dashboard yet</Typography.Text>
+						}
+					/>
+				</div>
+			);
+		}
+
+		return sections.map((section) => (
+			<Section key={section.id} section={section} />
+		));
+	};
+
+	return <div className={styles.body}>{renderContent()}</div>;
+}
+
+export default PanelsAndSectionsLayout;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardHeader/DashboardBreadcrumbs.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardHeader/DashboardBreadcrumbs.module.scss
@@ -1,0 +1,63 @@
+.dashboardBreadcrumbs {
+	width: 100%;
+	height: 48px;
+	display: flex;
+	gap: 6px;
+	align-items: center;
+	max-width: 80%;
+
+	.dashboardBtn {
+		display: flex;
+		align-items: center;
+		color: var(--l2-foreground);
+		font-family: Inter;
+		font-size: 14px;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 20px; /* 142.857% */
+		letter-spacing: -0.07px;
+		padding: 0px;
+		height: 20px;
+	}
+
+	.dashboardBtn:hover {
+		background-color: unset;
+	}
+
+	.idBtn {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 0px 2px;
+		border-radius: 2px;
+		background: color-mix(in srgb, var(--bg-robin-400) 10%, transparent);
+		color: var(--bg-robin-400);
+		font-family: Inter;
+		font-size: 14px;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 20px; /* 142.857% */
+		height: 20px;
+
+		max-width: calc(100% - 120px);
+
+		span {
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+
+		:global(.ant-btn-icon) {
+			margin-inline-end: 4px;
+		}
+	}
+	.idBtn:hover {
+		background: color-mix(in srgb, var(--bg-robin-400) 10%, transparent);
+		color: var(--bg-robin-300);
+	}
+
+	.dashboardIconImage {
+		height: 14px;
+		width: 14px;
+	}
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardHeader/DashboardBreadcrumbs.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardHeader/DashboardBreadcrumbs.tsx
@@ -1,0 +1,56 @@
+import { useCallback } from 'react';
+import { Button } from '@signozhq/ui/button';
+import getSessionStorageApi from 'api/browser/sessionstorage/get';
+import ROUTES from 'constants/routes';
+import { DASHBOARDS_LIST_QUERY_PARAMS_STORAGE_KEY } from 'hooks/dashboard/useDashboardsListQueryParams';
+import { useSafeNavigate } from 'hooks/useSafeNavigate';
+import { LayoutGrid } from '@signozhq/icons';
+
+import styles from './DashboardBreadcrumbs.module.scss';
+
+interface Props {
+	title: string;
+	image: string;
+}
+
+function DashboardBreadcrumbs({ title, image }: Props): JSX.Element {
+	const { safeNavigate } = useSafeNavigate();
+
+	const goToListPage = useCallback(() => {
+		const dashboardsListQueryParamsString = getSessionStorageApi(
+			DASHBOARDS_LIST_QUERY_PARAMS_STORAGE_KEY,
+		);
+
+		if (dashboardsListQueryParamsString) {
+			safeNavigate({
+				pathname: ROUTES.ALL_DASHBOARD,
+				search: `?${dashboardsListQueryParamsString}`,
+			});
+		} else {
+			safeNavigate(ROUTES.ALL_DASHBOARD);
+		}
+	}, [safeNavigate]);
+
+	return (
+		<div className={styles.dashboardBreadcrumbs}>
+			<Button
+				variant="ghost"
+				prefix={<LayoutGrid size={14} />}
+				className={styles.dashboardBtn}
+				onClick={goToListPage}
+			>
+				Dashboard /
+			</Button>
+			<Button variant="ghost" className={styles.idBtn}>
+				<img
+					src={image}
+					alt="dashboard-icon"
+					className={styles.dashboardIconImage}
+				/>
+				{title}
+			</Button>
+		</div>
+	);
+}
+
+export default DashboardBreadcrumbs;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardHeader/DashboardHeader.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardHeader/DashboardHeader.module.scss
@@ -1,0 +1,9 @@
+.dashboardHeader {
+	border-bottom: 1px solid var(--l1-border);
+	display: flex;
+	justify-content: space-between;
+	gap: 16px;
+	align-items: center;
+	padding: 0 8px;
+	box-sizing: border-box;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardHeader/DashboardHeader.tsx
@@ -1,0 +1,22 @@
+import { memo } from 'react';
+import HeaderRightSection from 'components/HeaderRightSection/HeaderRightSection';
+
+import DashboardBreadcrumbs from './DashboardBreadcrumbs';
+
+import styles from './DashboardHeader.module.scss';
+
+interface Props {
+	title: string;
+	image: string;
+}
+
+function DashboardHeader({ title, image }: Props): JSX.Element {
+	return (
+		<div className={styles.dashboardHeader}>
+			<DashboardBreadcrumbs title={title} image={image} />
+			<HeaderRightSection enableAnnouncements={false} enableShare enableFeedback />
+		</div>
+	);
+}
+
+export default memo(DashboardHeader);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { FullScreen, useFullScreenHandle } from 'react-full-screen';
+
+import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
+
+import DashboardDescription from './DashboardDescription';
+import PanelsAndSectionsLayout from './PanelsAndSectionsLayout';
+import styles from './DashboardContainer.module.scss';
+
+interface Props {
+	dashboard: DashboardtypesGettableDashboardV2DTO;
+	refetch: () => void;
+}
+
+function DashboardContainer({ dashboard, refetch }: Props): JSX.Element {
+	const fullScreenHandle = useFullScreenHandle();
+
+	const { spec } = dashboard;
+	const layouts = useMemo(() => spec?.layouts ?? [], [spec?.layouts]);
+	const panels = useMemo(() => spec?.panels ?? {}, [spec?.panels]);
+
+	return (
+		<FullScreen handle={fullScreenHandle}>
+			<div className={styles.container}>
+				<DashboardDescription
+					dashboard={dashboard}
+					handle={fullScreenHandle}
+					refetch={refetch}
+				/>
+				<PanelsAndSectionsLayout layouts={layouts} panels={panels} />
+			</div>
+		</FullScreen>
+	);
+}
+
+export default DashboardContainer;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/utils.ts
@@ -1,0 +1,154 @@
+import type {
+	DashboardtypesLayoutDTO,
+	DashboardtypesPanelDTO,
+} from 'api/generated/services/sigNoz.schemas';
+
+export interface GridItem {
+	id: string;
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	panel: DashboardtypesPanelDTO | undefined;
+}
+
+const PANEL_REF_PREFIX = '#/spec/panels/';
+
+export function extractPanelIdFromRef(ref: string | undefined): string | null {
+	if (!ref) {
+		return null;
+	}
+	if (!ref.startsWith(PANEL_REF_PREFIX)) {
+		return null;
+	}
+	return ref.slice(PANEL_REF_PREFIX.length);
+}
+
+export function flattenGridLayout(
+	layouts: DashboardtypesLayoutDTO[] | undefined | null,
+	panels: Record<string, DashboardtypesPanelDTO | undefined> | undefined,
+): GridItem[] {
+	if (!layouts?.length) {
+		return [];
+	}
+
+	const items: GridItem[] = [];
+	layouts.forEach((layoutEnvelope) => {
+		if (layoutEnvelope?.kind !== 'Grid') {
+			return;
+		}
+		const gridItems = layoutEnvelope.spec?.items ?? [];
+		gridItems.forEach((item) => {
+			const id = extractPanelIdFromRef(item.content?.$ref);
+			if (!id) {
+				return;
+			}
+			items.push({
+				id,
+				x: item.x ?? 0,
+				y: item.y ?? 0,
+				width: item.width ?? 6,
+				height: item.height ?? 6,
+				panel: panels?.[id],
+			});
+		});
+	});
+
+	return items;
+}
+
+/**
+ * A section corresponds to one entry in `spec.layouts`. If the Grid has a
+ * `display.title`, it renders with a collapsible header; otherwise it is a
+ * "default" untitled section (visually just the grid).
+ */
+export interface DashboardSection {
+	/**
+	 * Stable identity used for React keys and dnd-kit sortable item ids. Derived
+	 * from the section's content (its first panel ref) so it survives reordering
+	 * — unlike the positional `layoutIndex`. See `getSectionStableId`.
+	 */
+	id: string;
+	/** Position of this section's Grid in `spec.layouts`. All JSON-Patch ops target by this. */
+	layoutIndex: number;
+	title: string | undefined;
+	open: boolean;
+	items: GridItem[];
+	repeatVariable: string | undefined;
+}
+
+/**
+ * Derives a stable id for a section from its content. Reordering sections changes
+ * their `layoutIndex` but not their content, so keying off the first panel ref
+ * keeps React component instances (and any local state) bound to the right
+ * section across a reorder. Empty sections fall back to a positional id — they
+ * are rarely reordered, and a future backend `id` on the layout spec is the
+ * proper long-term fix.
+ */
+export function getSectionStableId(
+	items: GridItem[],
+	layoutIndex: number,
+): string {
+	if (items.length > 0) {
+		return `sec-${items[0].id}`;
+	}
+	return `sec-empty-${layoutIndex}`;
+}
+
+export function layoutsToSections(
+	layouts: DashboardtypesLayoutDTO[] | undefined | null,
+	panels: Record<string, DashboardtypesPanelDTO | undefined> | undefined,
+): DashboardSection[] {
+	if (!layouts?.length) {
+		return [];
+	}
+
+	return layouts
+		.map((layoutEnvelope, idx) => {
+			if (layoutEnvelope?.kind !== 'Grid') {
+				return null;
+			}
+			const spec = layoutEnvelope.spec;
+			const items: GridItem[] = (spec?.items ?? [])
+				.map((item) => {
+					const id = extractPanelIdFromRef(item.content?.$ref);
+					if (!id) {
+						return null;
+					}
+					return {
+						id,
+						x: item.x ?? 0,
+						y: item.y ?? 0,
+						width: item.width ?? 6,
+						height: item.height ?? 6,
+						panel: panels?.[id],
+					};
+				})
+				.filter((it): it is GridItem => it !== null);
+
+			const title = spec?.display?.title;
+			// `open` defaults to true when no collapse field is set (the section
+			// is expanded by default).
+			const open = spec?.display?.collapse?.open !== false;
+
+			return {
+				id: getSectionStableId(items, idx),
+				layoutIndex: idx,
+				title,
+				open,
+				items,
+				repeatVariable: spec?.repeatVariable,
+			};
+		})
+		.filter((s): s is DashboardSection => s !== null);
+}
+
+export function getPanelKindLabel(
+	panel: DashboardtypesPanelDTO | undefined,
+): string {
+	const kind = panel?.spec?.plugin?.kind;
+	if (!kind) {
+		return 'unknown';
+	}
+	return kind.replace(/^signoz\//, '');
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardPageV2.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardPageV2.module.scss
@@ -1,0 +1,3 @@
+.errorState {
+	padding: 24px;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardPageV2.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardPageV2.tsx
@@ -1,5 +1,43 @@
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { Typography } from '@signozhq/ui/typography';
+import { useGetDashboardV2 } from 'api/generated/services/dashboard';
+import Spinner from 'components/Spinner';
+
+import DashboardContainer from './DashboardContainer';
+import styles from './DashboardPageV2.module.scss';
+
 function DashboardPageV2(): JSX.Element {
-	return <>DashboardPageV2</>;
+	const { dashboardId } = useParams<{ dashboardId: string }>();
+
+	const { data, isLoading, isError, error, refetch } = useGetDashboardV2({
+		id: dashboardId,
+	});
+
+	const dashboard = data?.data;
+	const name = dashboard?.spec?.display?.name;
+
+	useEffect(() => {
+		if (name) {
+			document.title = name;
+		}
+	}, [name]);
+
+	if (isLoading) {
+		return <Spinner tip="Loading dashboard..." />;
+	}
+
+	if (isError || !dashboard) {
+		return (
+			<div className={styles.errorState}>
+				<Typography.Title>Failed to load dashboard</Typography.Title>
+				<Typography.Text>{(error as Error)?.message}</Typography.Text>
+			</div>
+		);
+	}
+
+	return <DashboardContainer dashboard={dashboard} refetch={refetch} />;
 }
 
 export default DashboardPageV2;


### PR DESCRIPTION
## What

Introduces the **V2 dashboard details** surface as **read-only scaffolding** — the foundation the sections & configuration PRs build on. `DashboardPageV2` fetches the dashboard and renders a presentational `DashboardContainer`.

- **Route entry** — `DashboardPageV2` owns the data fetch (`useGetDashboardV2`), `document.title`, and the loading/error gate, then renders the container with a non-optional `dashboard`.
- **Presentational container** — `DashboardContainer` composes the description + the sections/panels layout (no data fetching of its own).
- **Header chrome** — breadcrumbs + dashboard header.
- **Dashboard description** — title, meta (tags/description), a basic actions menu (lock/rename/export/copy/delete/full-screen), and the rename modal.
- **Read-only panels & sections layout** — sections render with `react-grid-layout` locked (`isDraggable`/`isResizable` off); panels are placeholder cards (chart rendering comes later).

## Out of scope (later PRs)

- **Sections & panel management** (add/delete/drag/reorder, cross-section moves) → **PR 2**.
- **Configuration** — settings drawer + general settings, inline-editable title, redesigned actions menu, **variables** → **PR 3**.

## Conventions

- Container is named by purpose (`DashboardContainer`, not `…V2`) since it already lives under the versioned `pages/DashboardPageV2/` path; only the page keeps the `V2` route-fork suffix (mirrors `DashboardsListPageV2`).
- Children receive non-optional props (`dashboard`, `layouts`, `panels`, `image`) — no `dashboard | undefined` threading.
- CSS Modules + `cx`; `@signozhq/ui` over antd where an equivalent exists (e.g. `TooltipSimple`).

## Dark-shipped + parked

- **Not routed/bundled**: nothing imports `DashboardPageV2` (no `useIsDashboardV2` switch), so it isn't reachable or bundled.
- **Parked from type-check with no `tsconfig` change**: the whole surface lives under `src/pages/DashboardPageV2/**`, which is **already** in `tsconfig.json` `exclude` (alongside `DashboardsListPageV2`). This keeps `tsc` green while the V2 **mutation** API (`patchDashboardV2`, `lockDashboardV2`, `unlockDashboardV2`, `DashboardtypesJSONPatchOperationDTO`) is still off `main` (only GET/CREATE landed). When the mutation API + routing land, remove the exclude to re-enable type-checking.
- **Generated API client is intentionally not included** — it lands with the list-dashboard API PR.

## CI

`tsc` / `fmt` / `lint` pass with the surface parked. (oxlint emits a few `no-redundant-type-constituents` *warnings* — a side effect of the exclude making the V2 DTOs `any`; warnings don't fail CI and clear once the surface is un-parked.)

## Stack

**PR 1 of 3** (base) on latest `main`. Stacked: **PR 2 — sections** (#11544), **PR 3 — config**.
