### PR TITLE
fix: resolve UX regressions across dashboards, metrics and alerts pages after component migration

### DIFF
--- a/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
+++ b/frontend/src/components/CustomTimePicker/CustomTimePickerPopoverContent.tsx
@@ -359,8 +359,7 @@ function CustomTimePickerPopoverContent({
 						<Clock
 							color={Color.BG_ROBIN_400}
 							className="timezone-container__clock-icon"
-							height={12}
-							width={12}
+							size={14}
 						/>
 
 						<span className="timezone__name">{timezone.name}</span>

--- a/frontend/src/components/NewSelect/styles.scss
+++ b/frontend/src/components/NewSelect/styles.scss
@@ -109,6 +109,16 @@ $custom-border-color: #2c3044;
 		color: color-mix(in srgb, var(--l2-foreground) 45%, transparent);
 	}
 
+	.ant-select-clear {
+		background-color: var(--l2-background);
+		color: var(--l2-foreground);
+		font-size: 12px;
+
+		&:hover {
+			color: var(--l1-foreground);
+		}
+	}
+
 	// Customize tags in multiselect (dark mode by default)
 	.ant-select-selection-item {
 		background-color: var(--l1-border);
@@ -392,7 +402,9 @@ $custom-border-color: #2c3044;
 // Custom dropdown styles for multi-select
 .custom-multiselect-dropdown {
 	padding: 8px 0 0 0;
-	max-height: 350px;
+	// Tall enough to hold the react-virtuoso list (<=300px) + header/footer
+	// so only the list scrolls (avoids a second scrollbar on this container).
+	max-height: 410px;
 	overflow-y: auto;
 	overflow-x: hidden;
 	scrollbar-width: thin;

--- a/frontend/src/components/NewSelect/styles.scss
+++ b/frontend/src/components/NewSelect/styles.scss
@@ -483,8 +483,12 @@ $custom-border-color: #2c3044;
 		.option-checkbox {
 			width: 100%;
 
-			> span:not(.ant-checkbox) {
-				width: 100%;
+			// @signozhq/ui Checkbox renders children inside a <label> that is
+			// content-sized by default. Make it fill the row (min-width: 0 lets it
+			// shrink) so the option text below can truncate instead of overflowing.
+			> label {
+				flex: 1 1 auto;
+				min-width: 0;
 			}
 
 			.all-option-text {
@@ -501,7 +505,12 @@ $custom-border-color: #2c3044;
 				width: 100%;
 
 				.option-label-text {
+					flex: 1 1 auto;
+					min-width: 0;
 					margin-bottom: 0;
+					overflow: hidden;
+					white-space: nowrap;
+					text-overflow: ellipsis;
 				}
 
 				.option-badge {
@@ -514,26 +523,30 @@ $custom-border-color: #2c3044;
 				}
 			}
 
-			.only-btn {
-				display: none;
-			}
+			// Size the buttons to the row's resting content height (20px) and fully
+			// override antd's default 32px Button box, so revealing them on hover
+			// never changes the row height.
+			.only-btn,
 			.toggle-btn {
 				display: none;
-			}
+				align-items: center;
+				justify-content: center;
+				height: 18px;
+				min-height: 0;
+				padding: 0 6px;
+				font-size: 12px;
+				line-height: 1;
+				border: none;
+				box-shadow: none;
 
-			.only-btn:hover {
-				background-color: unset;
-			}
-			.toggle-btn:hover {
-				background-color: unset;
+				&:hover {
+					background-color: unset;
+				}
 			}
 
 			.option-content:hover {
 				.only-btn {
 					display: flex;
-					align-items: center;
-					justify-content: center;
-					height: 21px;
 				}
 				.toggle-btn {
 					display: none;
@@ -548,9 +561,6 @@ $custom-border-color: #2c3044;
 		.option-checkbox:hover {
 			.toggle-btn {
 				display: flex;
-				align-items: center;
-				justify-content: center;
-				height: 21px;
 			}
 			.option-badge {
 				display: none;

--- a/frontend/src/container/AlertHistory/Statistics/StatsCard/StatsCard.styles.scss
+++ b/frontend/src/container/AlertHistory/Statistics/StatsCard/StatsCard.styles.scss
@@ -67,8 +67,8 @@
 	gap: 4px;
 
 	&--success {
-		background: color-mix(in srgb, var(--success-background) 10%, transparent);
-		color: var(--success-foreground);
+		background: color-mix(in srgb, var(--text-forest-500) 10%, transparent);
+		color: var(--text-forest-400);
 	}
 
 	&--error {

--- a/frontend/src/container/AlertHistory/Statistics/StatsCard/StatsCard.styles.scss
+++ b/frontend/src/container/AlertHistory/Statistics/StatsCard/StatsCard.styles.scss
@@ -42,7 +42,7 @@
 		flex-direction: column;
 		gap: 4px;
 		.count-label {
-			color: var(--l1-foreground);
+			color: var(--l1-foreground) !important;
 			font-family: 'Geist Mono';
 			font-size: 24px;
 			line-height: 36px;

--- a/frontend/src/container/AlertHistory/Statistics/StatsCard/StatsCard.styles.scss
+++ b/frontend/src/container/AlertHistory/Statistics/StatsCard/StatsCard.styles.scss
@@ -42,7 +42,7 @@
 		flex-direction: column;
 		gap: 4px;
 		.count-label {
-			color: var(--l1-foreground) !important;
+			color: var(--l1-foreground);
 			font-family: 'Geist Mono';
 			font-size: 24px;
 			line-height: 36px;

--- a/frontend/src/container/CreateAlertV2/NotificationSettings/styles.scss
+++ b/frontend/src/container/CreateAlertV2/NotificationSettings/styles.scss
@@ -153,6 +153,7 @@
 				font-size: 10px;
 				color: var(--l2-foreground);
 				margin-top: 4px;
+				display: block;
 			}
 		}
 

--- a/frontend/src/container/DashboardContainer/DashboardSettings/DashboardSettingsContent.styles.scss
+++ b/frontend/src/container/DashboardContainer/DashboardSettings/DashboardSettingsContent.styles.scss
@@ -47,18 +47,10 @@
 		}
 
 		.ant-tabs-tab-active {
-			.overview-btn {
-				border-radius: 2px 0px 0px 2px;
-				background: var(--l1-border);
-			}
-
-			.variables-btn {
-				border-radius: 2px 0px 0px 2px;
-				background: var(--l1-border);
-			}
-
+			.overview-btn,
+			.variables-btn,
 			.public-dashboard-btn {
-				border-radius: 2px 0px 0px 2px;
+				color: var(--primary-background);
 				background: var(--l1-border);
 			}
 		}

--- a/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/VariableItem.styles.scss
+++ b/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/VariableItem.styles.scss
@@ -127,6 +127,15 @@
 					align-items: center;
 					justify-content: center;
 					gap: 4px;
+
+					.sidenav-beta-tag {
+						margin-left: 4px;
+					}
+
+					div {
+						display: flex;
+						align-items: center;
+					}
 				}
 
 				.variable-type-btn + .variable-type-btn {
@@ -177,6 +186,7 @@
 
 		.multiple-values-section {
 			justify-content: space-between;
+			align-items: flex-start;
 			margin-bottom: 0;
 
 			.typography-variables {
@@ -193,6 +203,7 @@
 
 		.all-option-section {
 			justify-content: space-between;
+			align-items: flex-start;
 			margin-bottom: 0;
 
 			.typography-variables {

--- a/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/VariableItem.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/VariableItem.tsx
@@ -518,7 +518,6 @@ function VariableItem({
 										size={14}
 										style={{
 											color: isDarkMode ? Color.BG_VANILLA_100 : Color.BG_INK_500,
-											marginTop: 1,
 										}}
 									/>
 								}
@@ -614,7 +613,6 @@ function VariableItem({
 												size={14}
 												style={{
 													color: isDarkMode ? Color.BG_VANILLA_100 : Color.BG_INK_500,
-													marginTop: 1,
 												}}
 											/>
 										}

--- a/frontend/src/container/FormAlertRules/QuerySection.styles.scss
+++ b/frontend/src/container/FormAlertRules/QuerySection.styles.scss
@@ -19,6 +19,7 @@
 		}
 		.ant-btn-default {
 			border-color: transparent;
+			box-shadow: none;
 		}
 	}
 	.ant-tabs-tab-active {

--- a/frontend/src/container/PlannedDowntime/PlannedDowntime.styles.scss
+++ b/frontend/src/container/PlannedDowntime/PlannedDowntime.styles.scss
@@ -72,8 +72,20 @@
 	.alert-rule-scope {
 		margin-bottom: 12px;
 
-		.ant-radio-wrapper {
-			color: var(--l1-foreground);
+		// `.createForm label` styles field labels (font-weight 500, 14px,
+		// 6px bottom padding). Those bleed into the @signozhq/ui RadioGroup
+		// option labels, making them bold and vertically misaligned with the
+		// radio control. Reset them back to plain option-text styling.
+		label {
+			padding: 0;
+			font-weight: 400;
+			line-height: normal;
+		}
+
+		// Loosen the design-system default (grid gap 0.5rem) between options.
+		.silence-alerts-radio-group {
+			margin-top: 8px;
+			gap: 12px;
 		}
 	}
 
@@ -144,10 +156,7 @@
 			display: flex;
 			align-items: center;
 			gap: 8px;
-
-			.ant-btn {
-				margin-top: 8px;
-			}
+			margin-top: 12px;
 		}
 
 		.schedule-created-at {

--- a/frontend/src/container/PlannedDowntime/PlannedDowntimeForm.tsx
+++ b/frontend/src/container/PlannedDowntime/PlannedDowntimeForm.tsx
@@ -54,8 +54,7 @@ import {
 } from './PlannedDowntimeutils';
 
 import './PlannedDowntime.styles.scss';
-import { RadioGroupItem } from '@signozhq/ui/radio-group';
-import { RadioGroup } from '@signozhq/ui/radio-group';
+import { RadioGroupItem, RadioGroup } from '@signozhq/ui/radio-group';
 
 dayjs.locale('en');
 dayjs.extend(utc);
@@ -471,7 +470,7 @@ export function PlannedDowntimeForm(
 						initialValue="specific"
 						className="alert-rule-scope"
 					>
-						<RadioGroup>
+						<RadioGroup className="silence-alerts-radio-group">
 							<RadioGroupItem value="all">All alert rules</RadioGroupItem>
 							<RadioGroupItem value="specific">Specific alert rules</RadioGroupItem>
 						</RadioGroup>

--- a/frontend/src/container/RoutingPolicies/styles.scss
+++ b/frontend/src/container/RoutingPolicies/styles.scss
@@ -35,10 +35,7 @@
 			display: flex;
 			align-items: center;
 			gap: 8px;
-
-			.ant-btn {
-				margin-top: 8px;
-			}
+			margin-top: 12px;
 		}
 
 		.routing-policies-table {

--- a/frontend/src/container/TopNav/AutoRefreshV2/AutoRefreshV2.styles.scss
+++ b/frontend/src/container/TopNav/AutoRefreshV2/AutoRefreshV2.styles.scss
@@ -8,7 +8,7 @@
 			139deg,
 			color-mix(in srgb, var(--card) 80%, transparent) 0%,
 			color-mix(in srgb, var(--card) 90%, transparent) 98.68%
-		);
+		) !important;
 		box-shadow: 4px 10px 16px 2px rgba(0, 0, 0, 0.2);
 		backdrop-filter: blur(20px);
 		padding: 0;
@@ -34,9 +34,9 @@
 }
 
 .refresh-interval-text {
-	padding: 12px 14px 8px 14px;
+	padding: 12px 14px 8px 14px !important;
 	color: var(--muted-foreground);
-	font-size: 11px;
+	font-size: 13px;
 	font-style: normal;
 	font-weight: 500;
 	line-height: 18px; /* 163.636% */

--- a/frontend/src/pages/MetricsExplorer/MetricsExplorerPage.styles.scss
+++ b/frontend/src/pages/MetricsExplorer/MetricsExplorerPage.styles.scss
@@ -9,7 +9,7 @@
 	}
 
 	.ant-tabs-nav {
-		padding: 0 8px;
+		padding-left: 16px;
 		margin-bottom: 0px;
 
 		&::before {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?

Several UI inconsistencies surfaced across the **Dashboards**, **Metrics**, and **Alerts** pages after the recent component migration (antd → `@signozhq/ui`). This PR cleans them up — contrast, spacing, alignment, icon sizing, and a few CSS-precedence regressions — and fixes two functional styling issues in the migrated `CustomMultiSelect` and the Planned Downtime radio group.

#### Screenshots / Screen Recordings (if applicable)
Before screenshots are catalogued in the linked issue (https://github.com/SigNoz/engineering-pod/issues/5167).
After screenshots below:

<img width="520" height="877" alt="Screenshot 2026-06-02 at 4 53 05 PM" src="https://github.com/user-attachments/assets/30c300e1-6ff0-4595-8126-6dc0e2ff3b1c" />
<img width="799" height="155" alt="Screenshot 2026-06-02 at 4 53 14 PM" src="https://github.com/user-attachments/assets/9c63863d-cf8f-4fcb-9b9d-f3e90a122fca" />
<img width="336" height="414" alt="Screenshot 2026-06-02 at 6 02 28 PM" src="https://github.com/user-attachments/assets/1e2b0ee4-ef46-4db9-bd66-337e68f8c5e5" />
<img width="364" height="423" alt="Screenshot 2026-06-02 at 6 13 36 PM" src="https://github.com/user-attachments/assets/c317391e-0a58-4fab-9175-494d839158ec" />
<img width="608" height="478" alt="Screenshot 2026-06-02 at 3 06 22 PM" src="https://github.com/user-attachments/assets/98388daf-48c1-4a17-bd86-307c34dc6fdc" />
<img width="307" height="465" alt="Screenshot 2026-06-02 at 3 06 39 PM" src="https://github.com/user-attachments/assets/cd28cbc8-7dc1-45e2-9402-04eb4a7b6bc6" />
<img width="631" height="94" alt="Screenshot 2026-06-02 at 3 06 56 PM" src="https://github.com/user-attachments/assets/a1df7b19-a6f2-42ad-a027-d06ec5468223" />
<img width="652" height="192" alt="Screenshot 2026-06-02 at 3 07 13 PM" src="https://github.com/user-attachments/assets/d0a16972-d527-4fda-8711-f9b1f21093c7" />
<img width="669" height="201" alt="Screenshot 2026-06-02 at 3 07 20 PM" src="https://github.com/user-attachments/assets/60844d8a-18ef-4909-aea0-86004775e285" />
<img width="606" height="231" alt="Screenshot 2026-06-02 at 3 07 44 PM" src="https://github.com/user-attachments/assets/8fb35602-575e-4eba-af1b-6ee31c21b4f0" />
<img width="1839" height="211" alt="Screenshot 2026-06-02 at 3 39 22 PM" src="https://github.com/user-attachments/assets/243ea472-73ce-4181-ae47-3a23d9a86daf" />
<img width="529" height="883" alt="Screenshot 2026-06-02 at 4 52 55 PM" src="https://github.com/user-attachments/assets/dadc1904-a811-4e85-acb5-957b977a6698" />


#### Issues closed by this PR
Closes https://github.com/SigNoz/engineering-pod/issues/5167

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only
