### PR TITLE
fix(logs): dedupe body/timestamp columns in explorer picker

### DIFF
--- a/frontend/src/components/FieldsSelector/AddedFields.tsx
+++ b/frontend/src/components/FieldsSelector/AddedFields.tsx
@@ -144,10 +144,7 @@ function AddedFields({
 										field={field}
 										onRemove={handleRemove}
 										allowDrag={allowDrag}
-										isRequired={
-											requiredFields.includes(field.name) ||
-											requiredFields.includes(field.key as string)
-										}
+										isRequired={requiredFields.includes(field.key as string)}
 									/>
 								))}
 							</SortableContext>

--- a/frontend/src/components/FieldsSelector/__tests__/AddedFields.test.tsx
+++ b/frontend/src/components/FieldsSelector/__tests__/AddedFields.test.tsx
@@ -25,7 +25,7 @@ describe('AddedFields — requiredFields', () => {
 		expect(screen.getAllByRole('button', { name: /remove/i })).toHaveLength(3);
 	});
 
-	it('hides the Remove button for fields whose name is in requiredFields', () => {
+	it('hides the Remove button for fields whose composite key is in requiredFields', () => {
 		const fields = [makeField('a'), makeField('b'), makeField('c')];
 
 		render(
@@ -33,7 +33,7 @@ describe('AddedFields — requiredFields', () => {
 				inputValue=""
 				fields={fields}
 				onFieldsChange={jest.fn()}
-				requiredFields={['a', 'c']}
+				requiredFields={['log.a', 'log.c']}
 			/>,
 		);
 
@@ -50,7 +50,7 @@ describe('AddedFields — requiredFields', () => {
 				inputValue=""
 				fields={fields}
 				onFieldsChange={jest.fn()}
-				requiredFields={['a']}
+				requiredFields={['log.a']}
 			/>,
 		);
 
@@ -58,9 +58,26 @@ describe('AddedFields — requiredFields', () => {
 		expect(screen.getByText('b')).toBeInTheDocument();
 	});
 
-	it('locks all variants of a required name regardless of fieldContext', () => {
-		// Two `body` fields with different contexts — both should lock when
-		// `body` is in requiredFields.
+	it('locks ONLY the canonical variant — a same-name field from another context stays removable', () => {
+		// Two `body` fields with different contexts. requiredFields holds the
+		// canonical composite key only, so the attribute variant is deletable.
+		const fields = [makeField('body', 'log'), makeField('body', 'attribute')];
+
+		render(
+			<AddedFields
+				inputValue=""
+				fields={fields}
+				onFieldsChange={jest.fn()}
+				requiredFields={['log.body']}
+			/>,
+		);
+
+		// One Remove button: the attribute variant. log variant is locked.
+		expect(screen.getAllByRole('button', { name: /remove/i })).toHaveLength(1);
+	});
+
+	it('does not lock anything when a bare name is passed (composite key required)', () => {
+		// Bare `body` no longer matches — matching is composite-key only now.
 		const fields = [makeField('body', 'log'), makeField('body', 'attribute')];
 
 		render(
@@ -72,11 +89,11 @@ describe('AddedFields — requiredFields', () => {
 			/>,
 		);
 
-		// Both 'body' variants locked → zero Remove buttons.
-		expect(screen.queryAllByRole('button', { name: /remove/i })).toHaveLength(0);
+		// Neither variant locked → both removable.
+		expect(screen.getAllByRole('button', { name: /remove/i })).toHaveLength(2);
 	});
 
-	it('treats requiredFields as exact-name match (substring does not lock)', () => {
+	it('treats requiredFields as exact composite-key match (substring does not lock)', () => {
 		const fields = [makeField('body'), makeField('body_extra')];
 
 		render(
@@ -84,30 +101,11 @@ describe('AddedFields — requiredFields', () => {
 				inputValue=""
 				fields={fields}
 				onFieldsChange={jest.fn()}
-				requiredFields={['body']}
-			/>,
-		);
-
-		// 'body' locked, 'body_extra' removable.
-		expect(screen.getAllByRole('button', { name: /remove/i })).toHaveLength(1);
-	});
-
-	it('also accepts composite IDs in requiredFields (locks a specific variant)', () => {
-		// Two `body` fields with different contexts.
-		const fields = [makeField('body', 'log'), makeField('body', 'attribute')];
-
-		render(
-			<AddedFields
-				inputValue=""
-				fields={fields}
-				onFieldsChange={jest.fn()}
-				// Composite ID — locks ONLY the log variant, attribute variant stays
-				// removable.
 				requiredFields={['log.body']}
 			/>,
 		);
 
-		// One Remove button: the attribute variant. log variant is locked.
+		// 'log.body' locked, 'log.body_extra' removable.
 		expect(screen.getAllByRole('button', { name: /remove/i })).toHaveLength(1);
 	});
 });

--- a/frontend/src/components/Logs/TableView/__tests__/useLogsTableColumns.test.tsx
+++ b/frontend/src/components/Logs/TableView/__tests__/useLogsTableColumns.test.tsx
@@ -10,9 +10,9 @@ jest.mock('providers/Timezone', () => ({
 	}),
 }));
 
-const field = (name: string): IField => ({
+const field = (name: string, type = ''): IField => ({
 	name,
-	type: '',
+	type,
 	dataType: 'string',
 });
 
@@ -38,18 +38,16 @@ describe('useLogsTableColumns — selectColumns-order respected', () => {
 			useLogsTableColumns({
 				fields: [
 					field('service.name'),
-					field('body'),
+					field('body', 'log'),
 					field('request.id'),
-					field('timestamp'),
+					field('timestamp', 'log'),
 				],
 				fontSize: FontSize.SMALL,
 			}),
 		);
 
-		// body/timestamp are NOT pinned to fixed positions — they appear where the
-		// caller placed them in `fields`. body/timestamp use composite IDs
-		// ('log.body', 'log.timestamp') since their fieldContext is fixed; user
-		// fields here have empty `type` so their composite collapses to bare name.
+		// body/timestamp appear where the caller placed them, keyed by their
+		// composite IDs ('log.*'); contextless user fields collapse to bare name.
 		expect(result.current.map((c) => c.id)).toStrictEqual([
 			'state-indicator',
 			'service.name',
@@ -57,6 +55,43 @@ describe('useLogsTableColumns — selectColumns-order respected', () => {
 			'request.id',
 			'log.timestamp',
 		]);
+	});
+
+	it('renders a same-name field from another context as a DISTINCT column (no collision)', () => {
+		const { result } = renderHook(() =>
+			useLogsTableColumns({
+				fields: [field('body', 'log'), field('body', 'attribute')],
+				fontSize: FontSize.SMALL,
+			}),
+		);
+
+		const byId = new Map(result.current.map((c) => [c.id, c]));
+		// Attribute variant is its own column, not a duplicate 'log.body'.
+		expect(result.current.map((c) => c.id)).toStrictEqual([
+			'state-indicator',
+			'log.body',
+			'attribute.body',
+		]);
+		expect(byId.get('log.body')?.enableRemove).toBe(false);
+		expect(byId.get('attribute.body')?.enableRemove).toBe(true);
+	});
+
+	it('applies the same distinct-column treatment to timestamp variants', () => {
+		const { result } = renderHook(() =>
+			useLogsTableColumns({
+				fields: [field('timestamp', 'log'), field('timestamp', 'attribute')],
+				fontSize: FontSize.SMALL,
+			}),
+		);
+
+		const byId = new Map(result.current.map((c) => [c.id, c]));
+		expect(result.current.map((c) => c.id)).toStrictEqual([
+			'state-indicator',
+			'log.timestamp',
+			'attribute.timestamp',
+		]);
+		expect(byId.get('log.timestamp')?.enableRemove).toBe(false);
+		expect(byId.get('attribute.timestamp')?.enableRemove).toBe(true);
 	});
 
 	it('skips the synthetic "id" field name', () => {
@@ -77,7 +112,11 @@ describe('useLogsTableColumns — selectColumns-order respected', () => {
 	it('uses the special body/timestamp coldefs (canBeHidden=false), not the generic user field def', () => {
 		const { result } = renderHook(() =>
 			useLogsTableColumns({
-				fields: [field('body'), field('timestamp'), field('user_field')],
+				fields: [
+					field('body', 'log'),
+					field('timestamp', 'log'),
+					field('user_field'),
+				],
 				fontSize: FontSize.SMALL,
 			}),
 		);

--- a/frontend/src/components/Logs/TableView/useLogsTableColumns.tsx
+++ b/frontend/src/components/Logs/TableView/useLogsTableColumns.tsx
@@ -96,15 +96,18 @@ export function useLogsTableColumns({
 			),
 		});
 
+		// Match body/timestamp by composite key, not bare name — else a variant
+		// like `attribute.body` collapses onto `log.body`, duplicating the column.
 		const fieldCols = fields
 			.map((f): TableColumnDef<ILog> | null => {
 				if (f.name === 'id') {
 					return null;
 				}
-				if (f.name === 'timestamp') {
+				const compositeKey = buildCompositeKey(f.name, f.type);
+				if (compositeKey === timestampCol.id) {
 					return timestampCol;
 				}
-				if (f.name === 'body') {
+				if (compositeKey === bodyCol.id) {
 					return bodyCol;
 				}
 				return makeUserFieldCol(f);

--- a/frontend/src/container/OptionsMenu/__test__/ensureLogsRequiredColumns.test.ts
+++ b/frontend/src/container/OptionsMenu/__test__/ensureLogsRequiredColumns.test.ts
@@ -68,9 +68,7 @@ describe('ensureLogsRequiredColumns', () => {
 	});
 
 	it('collapses composite-key duplicates in the input', () => {
-		// Two identical `body` entries (same name + context → same composite key)
-		// are corrupted state; the invariant dedupes them down to one, then
-		// prepends the missing timestamp.
+		// Two identical `body` entries → deduped to one, then timestamp prepended.
 		const input = [BODY, BODY, ATTR_A];
 		const result = ensureLogsRequiredColumns(input);
 		expect(result).toStrictEqual([TIMESTAMP, BODY, ATTR_A]);
@@ -78,8 +76,7 @@ describe('ensureLogsRequiredColumns', () => {
 	});
 
 	it('keeps same-name fields with different contexts as distinct columns', () => {
-		// `body` (log) and a hypothetical `body` (attribute) have different
-		// composite keys → both legitimate, neither deduped.
+		// Different composite keys → both legitimate, neither deduped.
 		const ATTR_BODY: TelemetryFieldKey = {
 			name: 'body',
 			signal: 'logs',

--- a/frontend/src/container/OptionsMenu/__test__/ensureLogsRequiredColumns.test.ts
+++ b/frontend/src/container/OptionsMenu/__test__/ensureLogsRequiredColumns.test.ts
@@ -67,13 +67,26 @@ describe('ensureLogsRequiredColumns', () => {
 		]);
 	});
 
-	it('does not duplicate if a required column appears twice in the input', () => {
-		// Tolerant of malformed input — invariant only adds *missing* required
-		// columns; it does not deduplicate existing entries (that's a separate
-		// concern, not its job).
+	it('collapses composite-key duplicates in the input', () => {
+		// Two identical `body` entries (same name + context → same composite key)
+		// are corrupted state; the invariant dedupes them down to one, then
+		// prepends the missing timestamp.
 		const input = [BODY, BODY, ATTR_A];
 		const result = ensureLogsRequiredColumns(input);
-		expect(result.filter((c) => c.name === 'timestamp')).toHaveLength(1);
-		expect(result[0]).toStrictEqual(TIMESTAMP);
+		expect(result).toStrictEqual([TIMESTAMP, BODY, ATTR_A]);
+		expect(result.filter((c) => c.name === 'body')).toHaveLength(1);
+	});
+
+	it('keeps same-name fields with different contexts as distinct columns', () => {
+		// `body` (log) and a hypothetical `body` (attribute) have different
+		// composite keys → both legitimate, neither deduped.
+		const ATTR_BODY: TelemetryFieldKey = {
+			name: 'body',
+			signal: 'logs',
+			fieldContext: 'attribute',
+			fieldDataType: 'string',
+		};
+		const input = [TIMESTAMP, BODY, ATTR_BODY];
+		expect(ensureLogsRequiredColumns(input)).toStrictEqual(input);
 	});
 });

--- a/frontend/src/container/OptionsMenu/constants.ts
+++ b/frontend/src/container/OptionsMenu/constants.ts
@@ -2,6 +2,7 @@ import { TelemetryFieldKey } from 'api/v5/v5';
 import { DataSource } from 'types/common/queryBuilder';
 
 import { FontSize, OptionsQuery } from './types';
+import { buildCompositeKey } from './utils';
 
 export const URL_OPTIONS = 'options';
 
@@ -35,22 +36,48 @@ export const defaultLogsSelectedColumns: TelemetryFieldKey[] = [
 	},
 ];
 
-export const LOGS_REQUIRED_COLUMNS = ['timestamp', 'body'] as const;
+// Names that must always be present in logs selectColumns (writer invariant).
+const LOGS_REQUIRED_COLUMN_NAMES = defaultLogsSelectedColumns.map(
+	(c) => c.name,
+);
 
-/**
- * Always-on invariant: every logs selectColumns array must contain `body` and
- * `timestamp`. Applied at both loader and writer boundaries so the picker, the
- * table, and persisted state can never diverge into a "missing required
- * column" state.
- */
+// Composite keys (not bare names) so the picker locks ONLY the canonical
+// `log.body`/`log.timestamp` — a same-name variant like `attribute.body` stays
+// removable.
+export const LOGS_REQUIRED_COLUMNS = defaultLogsSelectedColumns.map((c) =>
+	buildCompositeKey(c.name, c.fieldContext),
+);
+
+// Drop composite-key duplicates (never legitimate — they only come from
+// corrupted state). Returns the same array reference when nothing to dedupe.
+export function dedupeColumnsByCompositeKey(
+	columns: TelemetryFieldKey[],
+): TelemetryFieldKey[] {
+	const seen = new Set<string>();
+	let hasDuplicate = false;
+	const deduped = columns.filter((c) => {
+		const key = buildCompositeKey(c.name, c.fieldContext);
+		if (seen.has(key)) {
+			hasDuplicate = true;
+			return false;
+		}
+		seen.add(key);
+		return true;
+	});
+	return hasDuplicate ? deduped : columns;
+}
+
+// Logs selectColumns invariant: no composite-key duplicates, and body +
+// timestamp always present. Applied at loader + writer boundaries.
 export function ensureLogsRequiredColumns(
 	columns: TelemetryFieldKey[],
 ): TelemetryFieldKey[] {
-	const missing = LOGS_REQUIRED_COLUMNS.filter(
-		(name) => !columns.some((c) => c.name === name),
+	const deduped = dedupeColumnsByCompositeKey(columns);
+	const missing = LOGS_REQUIRED_COLUMN_NAMES.filter(
+		(name) => !deduped.some((c) => c.name === name),
 	);
 	if (missing.length === 0) {
-		return columns;
+		return deduped;
 	}
 	const defaultsByName = new Map(
 		defaultLogsSelectedColumns.map((c) => [c.name, c]),
@@ -58,7 +85,7 @@ export function ensureLogsRequiredColumns(
 	const prepended = missing
 		.map((name) => defaultsByName.get(name))
 		.filter((c): c is TelemetryFieldKey => c !== undefined);
-	return [...prepended, ...columns];
+	return [...prepended, ...deduped];
 }
 
 export const defaultTraceSelectedColumns: TelemetryFieldKey[] = [


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Fixes duplicate `body` columns in the logs explorer column picker and table. The composite-identity model (`fieldContext.name`) shipped in #11516 was applied inconsistently: the picker's required-field lock and the logs table column-builder still keyed off the **bare field name**. So a same-named field from a non-`log` context (e.g. `attribute.body`) collided with the canonical `log.body` — it rendered as a duplicate column, couldn't be removed, and a table reorder laundered it into a permanent duplicate.

#### Issues closed by this PR

N/A

---

## Screenshots

Before

https://github.com/user-attachments/assets/d741828e-3010-4efa-a8b9-d9916a4f3c2e

After

https://github.com/user-attachments/assets/9b7d6324-24a5-4eec-b256-49cb987512e8



### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause

Three layers identified columns by bare `name` instead of the composite key:
- **Picker lock** (`AddedFields`) hid Remove for *every* field named `body`/`timestamp`, so a duplicate couldn't be deleted.
- **Column build** (`useLogsTableColumns`) collapsed any `body`/`timestamp` field onto the hardcoded `log.body`/`log.timestamp` id → multiple identical columns.
- **Reorder** (`reorderSelectColumns`) then resolved both collided ids back to the same canonical field, rewriting `attribute.body` into a second identical `log.body` — making the duplicate permanent. This is why reordering was the visible trigger.

#### Fix Strategy

- **Lock by composite key** — `LOGS_REQUIRED_COLUMNS` now holds composite keys (`log.body`, `log.timestamp`); `AddedFields` matches `field.key`. Only the canonical variant is locked; same-name variants stay removable.
- **Build columns by composite key** — `useLogsTableColumns` matches body/timestamp on composite key, so a non-`log` variant renders as its own distinct, reorder-safe column instead of colliding.
- **Heal corrupted state** — `ensureLogsRequiredColumns` drops composite-key duplicates at the loader + writer boundaries, collapsing already-persisted duplicates on next load/write.

---

### 🧪 Testing Strategy

- **Tests added/updated:** `AddedFields` (composite-key lock contract), `useLogsTableColumns` (distinct-column rendering for body **and** timestamp variants), `ensureLogsRequiredColumns` (composite-key dedup).
- **Manual verification:** add an `attribute.body` variant → renders as a distinct, removable column; reorder no longer multiplies `body`; canonical `body`/`timestamp` stay locked.
- `tsgo --noEmit` and `oxlint` clean on all changed files.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** Logs explorer + Live Logs column selection (picker, table, persisted preferences).
- **Potential regressions:** Low — required `body`/`timestamp` remain locked; canonical column ids unchanged.
- **Known limitation (pre-existing, out of scope):** a duplicate variant column still resolves its cell via `FlatLogData[name]` (bare name), so it shows the same content as the canonical column. Tracked as the deferred FlatLogData data-path gap.
- **Rollback plan:** Revert the PR; no migration or persisted-schema change.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS |
| Change Type | Bug Fix |
| Description | Fixes duplicate `body`/`timestamp` columns in the logs explorer; same-name fields from different contexts now render as distinct, removable columns. |

---

### 📋 Checklist

- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered (dedup heals existing persisted state)

---

## 👀 Notes for Reviewers

- Direct follow-on to the composite-identity work in #11516, closing the body/timestamp collision that model didn't cover.
- `ensureLogsRequiredColumns` returns the original array reference untouched when there's nothing to dedupe, so the loader/writer fast path is unchanged for clean state.
