### PR TITLE
feat(metrics): add Prometheus-compatible /api/v1/series endpoint

### DIFF
--- a/pkg/prometheus/clickhouseprometheus/client.go
+++ b/pkg/prometheus/clickhouseprometheus/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/SigNoz/signoz/pkg/errors"
@@ -68,6 +69,17 @@ func (client *client) Read(ctx context.Context, query *prompb.Query, sortSeries 
 	}
 	if len(fingerprints) == 0 {
 		return remote.FromQueryResult(sortSeries, new(prompb.QueryResult)), nil
+	}
+
+	// For series-only requests (e.g. /api/v1/series), return label sets directly
+	// without fetching sample data. This avoids the "metric_name = ''" condition
+	// in querySamples when no __name__ matcher is present.
+	if query.Hints != nil && query.Hints.Func == "series" {
+		res := new(prompb.QueryResult)
+		for _, lbls := range fingerprints {
+			res.Timeseries = append(res.Timeseries, &prompb.TimeSeries{Labels: lbls})
+		}
+		return remote.FromQueryResult(sortSeries, res), nil
 	}
 
 	sub, err := seriesLookupQuery(query, true)
@@ -167,15 +179,16 @@ func seriesLookupQuery(query *prompb.Query, subQuery bool) (*sqlbuilder.SelectBu
 			}
 			continue
 		}
+		labelName := unescapePromLabelName(m.Name)
 		switch m.Type {
 		case prompb.LabelMatcher_EQ:
-			sb.Where(fmt.Sprintf("JSONExtractString(labels, %s) = %s", sb.Var(m.Name), sb.Var(m.Value)))
+			sb.Where(fmt.Sprintf("JSONExtractString(labels, %s) = %s", sb.Var(labelName), sb.Var(m.Value)))
 		case prompb.LabelMatcher_NEQ:
-			sb.Where(fmt.Sprintf("JSONExtractString(labels, %s) != %s", sb.Var(m.Name), sb.Var(m.Value)))
+			sb.Where(fmt.Sprintf("JSONExtractString(labels, %s) != %s", sb.Var(labelName), sb.Var(m.Value)))
 		case prompb.LabelMatcher_RE:
-			sb.Where(fmt.Sprintf("match(JSONExtractString(labels, %s), %s)", sb.Var(m.Name), sb.Var(anchorRegex(m.Value))))
+			sb.Where(fmt.Sprintf("match(JSONExtractString(labels, %s), %s)", sb.Var(labelName), sb.Var(anchorRegex(m.Value))))
 		case prompb.LabelMatcher_NRE:
-			sb.Where(fmt.Sprintf("not match(JSONExtractString(labels, %s), %s)", sb.Var(m.Name), sb.Var(anchorRegex(m.Value))))
+			sb.Where(fmt.Sprintf("not match(JSONExtractString(labels, %s), %s)", sb.Var(labelName), sb.Var(anchorRegex(m.Value))))
 		default:
 			return nil, errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported or invalid matcher type: %s", m.Type.String())
 		}
@@ -505,6 +518,57 @@ func (client *client) queryRaw(ctx context.Context, query string, ts int64) (*pr
 	}
 
 	return &res, nil
+}
+
+// unescapePromLabelName converts a Prometheus value-encoded label name back to
+// its original UTF-8 form. Value-encoded names start with "U__" and use _XX_
+// (lowercase hex) sequences for non-legacy characters, and __ for a literal
+// underscore. See https://prometheus.io/docs/instrumenting/escaping_schemes/
+func unescapePromLabelName(name string) string {
+	if len(name) < 3 || name[:3] != "U__" {
+		return name
+	}
+	enc := name[3:]
+	var b strings.Builder
+	b.Grow(len(enc))
+	for i := 0; i < len(enc); {
+		if enc[i] != '_' {
+			b.WriteByte(enc[i])
+			i++
+			continue
+		}
+		// doubled underscore → original underscore
+		if i+1 < len(enc) && enc[i+1] == '_' {
+			b.WriteByte('_')
+			i += 2
+			continue
+		}
+		// _XX_ hex escape
+		if i+3 < len(enc) && enc[i+3] == '_' {
+			hi, hiOk := promHexVal(enc[i+1])
+			lo, loOk := promHexVal(enc[i+2])
+			if hiOk && loOk {
+				b.WriteByte(hi<<4 | lo)
+				i += 4
+				continue
+			}
+		}
+		b.WriteByte('_')
+		i++
+	}
+	return b.String()
+}
+
+func promHexVal(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return 0, false
 }
 
 func (client *client) withClickhousePrometheusContext(ctx context.Context, functionName string) context.Context {

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -284,21 +284,23 @@ func (r *ClickHouseReader) GetSeries(ctx context.Context, params *model.SeriesQu
 	mintMs := params.Start.UnixMilli()
 	maxtMs := params.End.UnixMilli()
 
-	querier, err := r.prometheus.Storage().Querier(mintMs, maxtMs)
-	if err != nil {
-		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
-	}
-	defer querier.Close()
-
 	// Use string key (lbls.String()) to avoid false dedup from 64-bit hash collisions.
 	seen := map[string]struct{}{}
 	result := []map[string]string{}
 
-	pql := parser.NewParser(parser.Options{})
 	for _, matchStr := range params.Matches {
-		matchers, err := pql.ParseMetricSelector(matchStr)
+		// Create a fresh parser and querier for each match[] selector.
+		// The remote-read querier resolves all buffered Select calls in one
+		// ReadMultiple batch on the first Next() call and cannot be reused
+		// across independent match[] groups.
+		matchers, err := parser.NewParser(parser.Options{}).ParseMetricSelector(matchStr)
 		if err != nil {
 			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: err}
+		}
+
+		querier, err := r.prometheus.Storage().Querier(mintMs, maxtMs)
+		if err != nil {
+			return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
 		}
 
 		hints := &storage.SelectHints{Start: mintMs, End: maxtMs, Func: "series"}
@@ -318,13 +320,16 @@ func (r *ClickHouseReader) GetSeries(ctx context.Context, params *model.SeriesQu
 			})
 			result = append(result, m)
 			if len(result) >= limit {
+				querier.Close()
 				return nil, &model.ApiError{
 					Typ: model.ErrorExec,
 					Err: fmt.Errorf("series count exceeds limit of %d; use match[] selectors or a narrower time range to reduce results", limit),
 				}
 			}
 		}
-		if ssErr := ss.Err(); ssErr != nil {
+		ssErr := ss.Err()
+		querier.Close()
+		if ssErr != nil {
 			return nil, &model.ApiError{Typ: model.ErrorExec, Err: ssErr}
 		}
 	}
@@ -333,40 +338,65 @@ func (r *ClickHouseReader) GetSeries(ctx context.Context, params *model.SeriesQu
 }
 
 func (r *ClickHouseReader) GetLabels(ctx context.Context, params *model.LabelQueryParams) ([]string, *model.ApiError) {
+	// Direct ClickHouse queries are used here because the remote-read querier's
+	// LabelNames method is not implemented in Prometheus v0.311.3 (issue #3351).
 	mintMs := params.Start.UnixMilli()
 	maxtMs := params.End.UnixMilli()
-
-	querier, err := r.prometheus.Storage().Querier(mintMs, maxtMs)
-	if err != nil {
-		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
-	}
-	defer querier.Close()
-
-	if len(params.Matches) == 0 {
-		names, _, err := querier.LabelNames(ctx, nil)
-		if err != nil {
-			return nil, &model.ApiError{Typ: model.ErrorExec, Err: err}
-		}
-		return filterInternalLabels(names), nil
-	}
+	normalized := !constants.IsDotMetricsEnabled
 
 	seen := map[string]struct{}{}
-	result := []string{}
-	pql := parser.NewParser(parser.Options{})
+	var result []string
+
+	execQuery := func(matcherConditions string, args []interface{}) *model.ApiError {
+		query := fmt.Sprintf(
+			`SELECT distinctLabel FROM (
+				SELECT arrayJoin(JSONExtractKeys(labels)) AS distinctLabel
+				FROM %s.%s
+				WHERE unix_milli >= $1 AND unix_milli <= $2 AND __normalized = $3%s
+			) WHERE distinctLabel != $4 GROUP BY distinctLabel ORDER BY distinctLabel`,
+			signozMetricDBName, signozTSTableNameV41Day, matcherConditions,
+		)
+		rows, err := r.db.Query(ctx, query, args...)
+		if err != nil {
+			return &model.ApiError{Typ: model.ErrorExec, Err: err}
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var lbl string
+			if scanErr := rows.Scan(&lbl); scanErr != nil {
+				return &model.ApiError{Typ: model.ErrorExec, Err: scanErr}
+			}
+			if _, ok := seen[lbl]; !ok {
+				seen[lbl] = struct{}{}
+				result = append(result, lbl)
+			}
+		}
+		return rowsApiError(rows.Err())
+	}
+
+	baseArgs := []interface{}{mintMs, maxtMs, normalized, prometheus.FingerprintAsPromLabelName}
+
+	if len(params.Matches) == 0 {
+		if apiErr := execQuery("", baseArgs); apiErr != nil {
+			return nil, apiErr
+		}
+		sort.Strings(result)
+		return result, nil
+	}
+
 	for _, matchStr := range params.Matches {
-		matchers, parseErr := pql.ParseMetricSelector(matchStr)
+		matchers, parseErr := parser.NewParser(parser.Options{}).ParseMetricSelector(matchStr)
 		if parseErr != nil {
 			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: parseErr}
 		}
-		names, _, err := querier.LabelNames(ctx, nil, matchers...)
-		if err != nil {
-			return nil, &model.ApiError{Typ: model.ErrorExec, Err: err}
+		conditions, extraArgs, _ := matchersToClickhouse(matchers, 5)
+		var condStr string
+		if len(conditions) > 0 {
+			condStr = " AND " + strings.Join(conditions, " AND ")
 		}
-		for _, name := range filterInternalLabels(names) {
-			if _, ok := seen[name]; !ok {
-				seen[name] = struct{}{}
-				result = append(result, name)
-			}
+		args := append(append([]interface{}{}, baseArgs...), extraArgs...)
+		if apiErr := execQuery(condStr, args); apiErr != nil {
+			return nil, apiErr
 		}
 	}
 	sort.Strings(result)
@@ -374,54 +404,146 @@ func (r *ClickHouseReader) GetLabels(ctx context.Context, params *model.LabelQue
 }
 
 func (r *ClickHouseReader) GetLabelValues(ctx context.Context, labelName string, params *model.LabelQueryParams) ([]string, *model.ApiError) {
+	// Direct ClickHouse queries are used here because the remote-read querier's
+	// LabelValues method is not implemented in Prometheus v0.311.3 (issue #3351).
 	mintMs := params.Start.UnixMilli()
 	maxtMs := params.End.UnixMilli()
-
-	querier, err := r.prometheus.Storage().Querier(mintMs, maxtMs)
-	if err != nil {
-		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
-	}
-	defer querier.Close()
-
-	if len(params.Matches) == 0 {
-		values, _, err := querier.LabelValues(ctx, labelName, nil)
-		if err != nil {
-			return nil, &model.ApiError{Typ: model.ErrorExec, Err: err}
-		}
-		return values, nil
-	}
+	normalized := !constants.IsDotMetricsEnabled
 
 	seen := map[string]struct{}{}
-	result := []string{}
-	pql := parser.NewParser(parser.Options{})
-	for _, matchStr := range params.Matches {
-		matchers, parseErr := pql.ParseMetricSelector(matchStr)
-		if parseErr != nil {
-			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: parseErr}
-		}
-		values, _, err := querier.LabelValues(ctx, labelName, nil, matchers...)
+	var result []string
+
+	// Use metric_name column directly for __name__ — more efficient than JSON extraction.
+	var valueExpr string
+	var baseArgIdx int
+	var baseArgs []interface{}
+	if labelName == labels.MetricName {
+		valueExpr = "metric_name"
+		baseArgIdx = 4
+		baseArgs = []interface{}{mintMs, maxtMs, normalized}
+	} else {
+		valueExpr = "JSONExtractString(labels, $4)"
+		baseArgIdx = 5
+		baseArgs = []interface{}{mintMs, maxtMs, normalized, labelName}
+	}
+
+	execQuery := func(matcherConditions string, args []interface{}) *model.ApiError {
+		query := fmt.Sprintf(
+			`SELECT DISTINCT lv FROM (
+				SELECT %s AS lv
+				FROM %s.%s
+				WHERE unix_milli >= $1 AND unix_milli <= $2 AND __normalized = $3%s
+			) WHERE lv != '' ORDER BY lv`,
+			valueExpr, signozMetricDBName, signozTSTableNameV41Day, matcherConditions,
+		)
+		rows, err := r.db.Query(ctx, query, args...)
 		if err != nil {
-			return nil, &model.ApiError{Typ: model.ErrorExec, Err: err}
+			return &model.ApiError{Typ: model.ErrorExec, Err: err}
 		}
-		for _, v := range values {
+		defer rows.Close()
+		for rows.Next() {
+			var v string
+			if scanErr := rows.Scan(&v); scanErr != nil {
+				return &model.ApiError{Typ: model.ErrorExec, Err: scanErr}
+			}
 			if _, ok := seen[v]; !ok {
 				seen[v] = struct{}{}
 				result = append(result, v)
 			}
+		}
+		return rowsApiError(rows.Err())
+	}
+
+	if len(params.Matches) == 0 {
+		if apiErr := execQuery("", baseArgs); apiErr != nil {
+			return nil, apiErr
+		}
+		sort.Strings(result)
+		return result, nil
+	}
+
+	for _, matchStr := range params.Matches {
+		matchers, parseErr := parser.NewParser(parser.Options{}).ParseMetricSelector(matchStr)
+		if parseErr != nil {
+			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: parseErr}
+		}
+		conditions, extraArgs, _ := matchersToClickhouse(matchers, baseArgIdx)
+		var condStr string
+		if len(conditions) > 0 {
+			condStr = " AND " + strings.Join(conditions, " AND ")
+		}
+		args := append(append([]interface{}{}, baseArgs...), extraArgs...)
+		if apiErr := execQuery(condStr, args); apiErr != nil {
+			return nil, apiErr
 		}
 	}
 	sort.Strings(result)
 	return result, nil
 }
 
-func filterInternalLabels(names []string) []string {
-	out := names[:0]
-	for _, n := range names {
-		if n != prometheus.FingerprintAsPromLabelName {
-			out = append(out, n)
+// matchersToClickhouse translates a slice of Prometheus label matchers to
+// ClickHouse SQL condition fragments and the corresponding query arguments.
+// argIdx is the 1-based positional index of the first placeholder to emit.
+// Returns (conditions, args, nextArgIdx).
+func matchersToClickhouse(matchers []*labels.Matcher, argIdx int) ([]string, []interface{}, int) {
+	var conditions []string
+	var args []interface{}
+	for _, m := range matchers {
+		var cond string
+		var mArgs []interface{}
+		if m.Name == labels.MetricName {
+			switch m.Type {
+			case labels.MatchEqual:
+				cond = fmt.Sprintf("metric_name = $%d", argIdx)
+				mArgs = []interface{}{m.Value}
+				argIdx++
+			case labels.MatchNotEqual:
+				cond = fmt.Sprintf("metric_name != $%d", argIdx)
+				mArgs = []interface{}{m.Value}
+				argIdx++
+			case labels.MatchRegexp:
+				cond = fmt.Sprintf("match(metric_name, $%d)", argIdx)
+				mArgs = []interface{}{m.Value}
+				argIdx++
+			case labels.MatchNotRegexp:
+				cond = fmt.Sprintf("NOT match(metric_name, $%d)", argIdx)
+				mArgs = []interface{}{m.Value}
+				argIdx++
+			}
+		} else {
+			switch m.Type {
+			case labels.MatchEqual:
+				cond = fmt.Sprintf("JSONExtractString(labels, $%d) = $%d", argIdx, argIdx+1)
+				mArgs = []interface{}{m.Name, m.Value}
+				argIdx += 2
+			case labels.MatchNotEqual:
+				cond = fmt.Sprintf("JSONExtractString(labels, $%d) != $%d", argIdx, argIdx+1)
+				mArgs = []interface{}{m.Name, m.Value}
+				argIdx += 2
+			case labels.MatchRegexp:
+				cond = fmt.Sprintf("match(JSONExtractString(labels, $%d), $%d)", argIdx, argIdx+1)
+				mArgs = []interface{}{m.Name, m.Value}
+				argIdx += 2
+			case labels.MatchNotRegexp:
+				cond = fmt.Sprintf("NOT match(JSONExtractString(labels, $%d), $%d)", argIdx, argIdx+1)
+				mArgs = []interface{}{m.Name, m.Value}
+				argIdx += 2
+			}
+		}
+		if cond != "" {
+			conditions = append(conditions, cond)
+			args = append(args, mArgs...)
 		}
 	}
-	return out
+	return conditions, args, argIdx
+}
+
+// rowsApiError wraps a rows.Err() result in an *model.ApiError, returning nil if err is nil.
+func rowsApiError(err error) *model.ApiError {
+	if err == nil {
+		return nil
+	}
+	return &model.ApiError{Typ: model.ErrorExec, Err: err}
 }
 
 func (r *ClickHouseReader) GetServicesList(ctx context.Context) (*[]string, error) {

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -34,7 +34,10 @@ import (
 
 	errorsV2 "github.com/SigNoz/signoz/pkg/errors"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/stats"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -268,6 +271,50 @@ func (r *ClickHouseReader) GetQueryRangeResult(ctx context.Context, query *model
 
 	qry.Close()
 	return res, &qs, nil
+}
+
+func (r *ClickHouseReader) GetSeries(ctx context.Context, params *model.SeriesQueryParams) ([]map[string]string, *model.ApiError) {
+	mintMs := params.Start.UnixMilli()
+	maxtMs := params.End.UnixMilli()
+
+	querier, err := r.prometheus.Storage().Querier(mintMs, maxtMs)
+	if err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	defer querier.Close()
+
+	seen := map[uint64]struct{}{}
+	result := []map[string]string{}
+
+	for _, matchStr := range params.Matches {
+		matchers, err := parser.ParseMetricSelector(matchStr)
+		if err != nil {
+			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: err}
+		}
+
+		hints := &storage.SelectHints{Start: mintMs, End: maxtMs, Func: "series"}
+		ss := querier.Select(ctx, false, hints, matchers...)
+		for ss.Next() {
+			lbls := ss.At().Labels()
+			h := lbls.Hash()
+			if _, ok := seen[h]; ok {
+				continue
+			}
+			seen[h] = struct{}{}
+			m := make(map[string]string, lbls.Len())
+			lbls.Range(func(l labels.Label) {
+				if l.Name != prometheus.FingerprintAsPromLabelName {
+					m[l.Name] = l.Value
+				}
+			})
+			result = append(result, m)
+		}
+		if ssErr := ss.Err(); ssErr != nil {
+			return nil, &model.ApiError{Typ: model.ErrorExec, Err: ssErr}
+		}
+	}
+
+	return result, nil
 }
 
 func (r *ClickHouseReader) GetServicesList(ctx context.Context) (*[]string, error) {

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -294,8 +294,9 @@ func (r *ClickHouseReader) GetSeries(ctx context.Context, params *model.SeriesQu
 	seen := map[string]struct{}{}
 	result := []map[string]string{}
 
+	pql := parser.NewParser(parser.Options{})
 	for _, matchStr := range params.Matches {
-		matchers, err := parser.ParseMetricSelector(matchStr)
+		matchers, err := pql.ParseMetricSelector(matchStr)
 		if err != nil {
 			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: err}
 		}
@@ -351,8 +352,9 @@ func (r *ClickHouseReader) GetLabels(ctx context.Context, params *model.LabelQue
 
 	seen := map[string]struct{}{}
 	result := []string{}
+	pql := parser.NewParser(parser.Options{})
 	for _, matchStr := range params.Matches {
-		matchers, parseErr := parser.ParseMetricSelector(matchStr)
+		matchers, parseErr := pql.ParseMetricSelector(matchStr)
 		if parseErr != nil {
 			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: parseErr}
 		}
@@ -391,8 +393,9 @@ func (r *ClickHouseReader) GetLabelValues(ctx context.Context, labelName string,
 
 	seen := map[string]struct{}{}
 	result := []string{}
+	pql := parser.NewParser(parser.Options{})
 	for _, matchStr := range params.Matches {
-		matchers, parseErr := parser.ParseMetricSelector(matchStr)
+		matchers, parseErr := pql.ParseMetricSelector(matchStr)
 		if parseErr != nil {
 			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: parseErr}
 		}

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -331,6 +331,96 @@ func (r *ClickHouseReader) GetSeries(ctx context.Context, params *model.SeriesQu
 	return result, nil
 }
 
+func (r *ClickHouseReader) GetLabels(ctx context.Context, params *model.LabelQueryParams) ([]string, *model.ApiError) {
+	mintMs := params.Start.UnixMilli()
+	maxtMs := params.End.UnixMilli()
+
+	querier, err := r.prometheus.Storage().Querier(mintMs, maxtMs)
+	if err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	defer querier.Close()
+
+	if len(params.Matches) == 0 {
+		names, _, err := querier.LabelNames(ctx, nil)
+		if err != nil {
+			return nil, &model.ApiError{Typ: model.ErrorExec, Err: err}
+		}
+		return filterInternalLabels(names), nil
+	}
+
+	seen := map[string]struct{}{}
+	result := []string{}
+	for _, matchStr := range params.Matches {
+		matchers, parseErr := parser.ParseMetricSelector(matchStr)
+		if parseErr != nil {
+			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: parseErr}
+		}
+		names, _, err := querier.LabelNames(ctx, nil, matchers...)
+		if err != nil {
+			return nil, &model.ApiError{Typ: model.ErrorExec, Err: err}
+		}
+		for _, name := range filterInternalLabels(names) {
+			if _, ok := seen[name]; !ok {
+				seen[name] = struct{}{}
+				result = append(result, name)
+			}
+		}
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func (r *ClickHouseReader) GetLabelValues(ctx context.Context, labelName string, params *model.LabelQueryParams) ([]string, *model.ApiError) {
+	mintMs := params.Start.UnixMilli()
+	maxtMs := params.End.UnixMilli()
+
+	querier, err := r.prometheus.Storage().Querier(mintMs, maxtMs)
+	if err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorInternal, Err: err}
+	}
+	defer querier.Close()
+
+	if len(params.Matches) == 0 {
+		values, _, err := querier.LabelValues(ctx, labelName, nil)
+		if err != nil {
+			return nil, &model.ApiError{Typ: model.ErrorExec, Err: err}
+		}
+		return values, nil
+	}
+
+	seen := map[string]struct{}{}
+	result := []string{}
+	for _, matchStr := range params.Matches {
+		matchers, parseErr := parser.ParseMetricSelector(matchStr)
+		if parseErr != nil {
+			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: parseErr}
+		}
+		values, _, err := querier.LabelValues(ctx, labelName, nil, matchers...)
+		if err != nil {
+			return nil, &model.ApiError{Typ: model.ErrorExec, Err: err}
+		}
+		for _, v := range values {
+			if _, ok := seen[v]; !ok {
+				seen[v] = struct{}{}
+				result = append(result, v)
+			}
+		}
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func filterInternalLabels(names []string) []string {
+	out := names[:0]
+	for _, n := range names {
+		if n != prometheus.FingerprintAsPromLabelName {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
 func (r *ClickHouseReader) GetServicesList(ctx context.Context) (*[]string, error) {
 	ctx = ctxtypes.NewContextWithCommentVals(ctx, map[string]string{
 		instrumentationtypes.TelemetrySignal:  telemetrytypes.SignalTraces.StringValue(),

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -406,6 +406,7 @@ func (r *ClickHouseReader) GetLabels(ctx context.Context, params *model.LabelQue
 func (r *ClickHouseReader) GetLabelValues(ctx context.Context, labelName string, params *model.LabelQueryParams) ([]string, *model.ApiError) {
 	// Direct ClickHouse queries are used here because the remote-read querier's
 	// LabelValues method is not implemented in Prometheus v0.311.3 (issue #3351).
+	labelName = unescapePromLabelName(labelName)
 	mintMs := params.Start.UnixMilli()
 	maxtMs := params.End.UnixMilli()
 	normalized := !constants.IsDotMetricsEnabled
@@ -481,6 +482,55 @@ func (r *ClickHouseReader) GetLabelValues(ctx context.Context, labelName string,
 	return result, nil
 }
 
+// unescapePromLabelName converts a Prometheus value-encoded label name back to
+// its original UTF-8 form. Value-encoded names start with "U__" and use _XX_
+// (lowercase hex) for non-legacy characters, and __ for a literal underscore.
+// See https://prometheus.io/docs/instrumenting/escaping_schemes/
+func unescapePromLabelName(name string) string {
+	if len(name) < 3 || name[:3] != "U__" {
+		return name
+	}
+	enc := name[3:]
+	var b strings.Builder
+	b.Grow(len(enc))
+	for i := 0; i < len(enc); {
+		if enc[i] != '_' {
+			b.WriteByte(enc[i])
+			i++
+			continue
+		}
+		if i+1 < len(enc) && enc[i+1] == '_' {
+			b.WriteByte('_')
+			i += 2
+			continue
+		}
+		if i+3 < len(enc) && enc[i+3] == '_' {
+			hi, hiOk := promHexVal(enc[i+1])
+			lo, loOk := promHexVal(enc[i+2])
+			if hiOk && loOk {
+				b.WriteByte(hi<<4 | lo)
+				i += 4
+				continue
+			}
+		}
+		b.WriteByte('_')
+		i++
+	}
+	return b.String()
+}
+
+func promHexVal(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return 0, false
+}
+
 // matchersToClickhouse translates a slice of Prometheus label matchers to
 // ClickHouse SQL condition fragments and the corresponding query arguments.
 // argIdx is the 1-based positional index of the first placeholder to emit.
@@ -511,22 +561,23 @@ func matchersToClickhouse(matchers []*labels.Matcher, argIdx int) ([]string, []i
 				argIdx++
 			}
 		} else {
+			labelName := unescapePromLabelName(m.Name)
 			switch m.Type {
 			case labels.MatchEqual:
 				cond = fmt.Sprintf("JSONExtractString(labels, $%d) = $%d", argIdx, argIdx+1)
-				mArgs = []interface{}{m.Name, m.Value}
+				mArgs = []interface{}{labelName, m.Value}
 				argIdx += 2
 			case labels.MatchNotEqual:
 				cond = fmt.Sprintf("JSONExtractString(labels, $%d) != $%d", argIdx, argIdx+1)
-				mArgs = []interface{}{m.Name, m.Value}
+				mArgs = []interface{}{labelName, m.Value}
 				argIdx += 2
 			case labels.MatchRegexp:
 				cond = fmt.Sprintf("match(JSONExtractString(labels, $%d), $%d)", argIdx, argIdx+1)
-				mArgs = []interface{}{m.Name, m.Value}
+				mArgs = []interface{}{labelName, m.Value}
 				argIdx += 2
 			case labels.MatchNotRegexp:
 				cond = fmt.Sprintf("NOT match(JSONExtractString(labels, $%d), $%d)", argIdx, argIdx+1)
-				mArgs = []interface{}{m.Name, m.Value}
+				mArgs = []interface{}{labelName, m.Value}
 				argIdx += 2
 			}
 		}

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -273,7 +273,14 @@ func (r *ClickHouseReader) GetQueryRangeResult(ctx context.Context, query *model
 	return res, &qs, nil
 }
 
+const seriesResultHardLimit = 100_000
+
 func (r *ClickHouseReader) GetSeries(ctx context.Context, params *model.SeriesQueryParams) ([]map[string]string, *model.ApiError) {
+	limit := params.Limit
+	if limit <= 0 || limit > seriesResultHardLimit {
+		limit = seriesResultHardLimit
+	}
+
 	mintMs := params.Start.UnixMilli()
 	maxtMs := params.End.UnixMilli()
 
@@ -283,7 +290,8 @@ func (r *ClickHouseReader) GetSeries(ctx context.Context, params *model.SeriesQu
 	}
 	defer querier.Close()
 
-	seen := map[uint64]struct{}{}
+	// Use string key (lbls.String()) to avoid false dedup from 64-bit hash collisions.
+	seen := map[string]struct{}{}
 	result := []map[string]string{}
 
 	for _, matchStr := range params.Matches {
@@ -296,11 +304,11 @@ func (r *ClickHouseReader) GetSeries(ctx context.Context, params *model.SeriesQu
 		ss := querier.Select(ctx, false, hints, matchers...)
 		for ss.Next() {
 			lbls := ss.At().Labels()
-			h := lbls.Hash()
-			if _, ok := seen[h]; ok {
+			key := lbls.String()
+			if _, ok := seen[key]; ok {
 				continue
 			}
-			seen[h] = struct{}{}
+			seen[key] = struct{}{}
 			m := make(map[string]string, lbls.Len())
 			lbls.Range(func(l labels.Label) {
 				if l.Name != prometheus.FingerprintAsPromLabelName {
@@ -308,6 +316,12 @@ func (r *ClickHouseReader) GetSeries(ctx context.Context, params *model.SeriesQu
 				}
 			})
 			result = append(result, m)
+			if len(result) >= limit {
+				return nil, &model.ApiError{
+					Typ: model.ErrorExec,
+					Err: fmt.Errorf("series count exceeds limit of %d; use match[] selectors or a narrower time range to reduce results", limit),
+				}
+			}
 		}
 		if ssErr := ss.Err(); ssErr != nil {
 			return nil, &model.ApiError{Typ: model.ErrorExec, Err: ssErr}

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -385,8 +385,10 @@ func (aH *APIHandler) Respond(w http.ResponseWriter, data interface{}) {
 
 // RegisterRoutes registers routes for this handler on the given router
 func (aH *APIHandler) RegisterRoutes(router *mux.Router, am *middleware.AuthZ) {
-	router.HandleFunc("/api/v1/query_range", am.ViewAccess(aH.queryRangeMetrics)).Methods(http.MethodGet)
-	router.HandleFunc("/api/v1/query", am.ViewAccess(aH.queryMetrics)).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/query_range", am.ViewAccess(aH.queryRangeMetrics)).Methods(http.MethodGet, http.MethodPost)
+	router.HandleFunc("/api/v1/query", am.ViewAccess(aH.queryMetrics)).Methods(http.MethodGet, http.MethodPost)
+	router.HandleFunc("/api/v1/series", am.ViewAccess(aH.seriesMetrics)).Methods(http.MethodGet, http.MethodPost)
+	router.HandleFunc("/api/v1/status/buildinfo", am.ViewAccess(aH.buildInfo)).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/rules", am.ViewAccess(aH.listRules)).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/rules/{id}", am.ViewAccess(aH.getRule)).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/rules", am.EditAccess(aH.createRule)).Methods(http.MethodPost)
@@ -1108,6 +1110,42 @@ func (aH *APIHandler) queryMetrics(w http.ResponseWriter, r *http.Request) {
 
 	aH.Respond(w, responseData)
 
+}
+
+func (aH *APIHandler) seriesMetrics(w http.ResponseWriter, r *http.Request) {
+	params, apiErr := parseSeriesRequest(r)
+	if apiErr != nil {
+		RespondError(w, apiErr, nil)
+		return
+	}
+
+	ctx := r.Context()
+	if to := r.FormValue("timeout"); to != "" {
+		var cancel context.CancelFunc
+		timeout, err := parseMetricsDuration(to)
+		if aH.HandleError(w, err, http.StatusBadRequest) {
+			return
+		}
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	result, apiError := aH.reader.GetSeries(ctx, params)
+	if apiError != nil {
+		RespondError(w, apiError, nil)
+		return
+	}
+
+	aH.Respond(w, result)
+}
+
+func (aH *APIHandler) buildInfo(w http.ResponseWriter, r *http.Request) {
+	aH.Respond(w, map[string]string{
+		"version":   version.Info.Version(),
+		"revision":  version.Info.Hash(),
+		"branch":    version.Info.Branch(),
+		"goVersion": version.Info.GoVersion(),
+	})
 }
 
 func (aH *APIHandler) registerEvent(w http.ResponseWriter, r *http.Request) {

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -388,6 +388,8 @@ func (aH *APIHandler) RegisterRoutes(router *mux.Router, am *middleware.AuthZ) {
 	router.HandleFunc("/api/v1/query_range", am.ViewAccess(aH.queryRangeMetrics)).Methods(http.MethodGet, http.MethodPost)
 	router.HandleFunc("/api/v1/query", am.ViewAccess(aH.queryMetrics)).Methods(http.MethodGet, http.MethodPost)
 	router.HandleFunc("/api/v1/series", am.ViewAccess(aH.seriesMetrics)).Methods(http.MethodGet, http.MethodPost)
+	router.HandleFunc("/api/v1/labels", am.ViewAccess(aH.labelsMetrics)).Methods(http.MethodGet, http.MethodPost)
+	router.HandleFunc("/api/v1/label/{label}/values", am.ViewAccess(aH.labelValuesMetrics)).Methods(http.MethodGet, http.MethodPost)
 	router.HandleFunc("/api/v1/status/buildinfo", am.ViewAccess(aH.buildInfo)).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/rules", am.ViewAccess(aH.listRules)).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/rules/{id}", am.ViewAccess(aH.getRule)).Methods(http.MethodGet)
@@ -1146,6 +1148,62 @@ func (aH *APIHandler) buildInfo(w http.ResponseWriter, r *http.Request) {
 		"branch":    version.Info.Branch(),
 		"goVersion": version.Info.GoVersion(),
 	})
+}
+
+func (aH *APIHandler) labelsMetrics(w http.ResponseWriter, r *http.Request) {
+	params, apiErr := parseLabelRequest(r)
+	if apiErr != nil {
+		RespondError(w, apiErr, nil)
+		return
+	}
+
+	ctx := r.Context()
+	if to := r.FormValue("timeout"); to != "" {
+		var cancel context.CancelFunc
+		timeout, err := parseMetricsDuration(to)
+		if aH.HandleError(w, err, http.StatusBadRequest) {
+			return
+		}
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	result, apiError := aH.reader.GetLabels(ctx, params)
+	if apiError != nil {
+		RespondError(w, apiError, nil)
+		return
+	}
+
+	aH.Respond(w, result)
+}
+
+func (aH *APIHandler) labelValuesMetrics(w http.ResponseWriter, r *http.Request) {
+	labelName := mux.Vars(r)["label"]
+
+	params, apiErr := parseLabelRequest(r)
+	if apiErr != nil {
+		RespondError(w, apiErr, nil)
+		return
+	}
+
+	ctx := r.Context()
+	if to := r.FormValue("timeout"); to != "" {
+		var cancel context.CancelFunc
+		timeout, err := parseMetricsDuration(to)
+		if aH.HandleError(w, err, http.StatusBadRequest) {
+			return
+		}
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	result, apiError := aH.reader.GetLabelValues(ctx, labelName, params)
+	if apiError != nil {
+		RespondError(w, apiError, nil)
+		return
+	}
+
+	aH.Respond(w, result)
 }
 
 func (aH *APIHandler) registerEvent(w http.ResponseWriter, r *http.Request) {

--- a/pkg/query-service/app/parser.go
+++ b/pkg/query-service/app/parser.go
@@ -177,6 +177,42 @@ func parseQueryRangeRequest(r *http.Request) (*model.QueryRangeParams, *model.Ap
 	return &queryRangeParams, nil
 }
 
+func parseSeriesRequest(r *http.Request) (*model.SeriesQueryParams, *model.ApiError) {
+	if err := r.ParseForm(); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: err}
+	}
+
+	matches := r.Form["match[]"]
+	if len(matches) == 0 {
+		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: errors.New("no match[] parameter provided")}
+	}
+
+	now := time.Now()
+	start := now.Add(-5 * time.Minute)
+	end := now
+
+	if s := r.FormValue("start"); s != "" {
+		var err error
+		start, err = parseMetricsTime(s)
+		if err != nil {
+			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: err}
+		}
+	}
+	if e := r.FormValue("end"); e != "" {
+		var err error
+		end, err = parseMetricsTime(e)
+		if err != nil {
+			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: err}
+		}
+	}
+
+	return &model.SeriesQueryParams{
+		Start:   start,
+		End:     end,
+		Matches: matches,
+	}, nil
+}
+
 func parseGetUsageRequest(r *http.Request) (*model.GetUsageParams, error) {
 	startTime, err := parseTime("start", r)
 	if err != nil {

--- a/pkg/query-service/app/parser.go
+++ b/pkg/query-service/app/parser.go
@@ -187,9 +187,9 @@ func parseSeriesRequest(r *http.Request) (*model.SeriesQueryParams, *model.ApiEr
 		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: errors.New("no match[] parameter provided")}
 	}
 
-	now := time.Now()
-	start := now.Add(-5 * time.Minute)
-	end := now
+	// Default: start=Unix epoch, end=now — covers all stored data when omitted.
+	start := time.Unix(0, 0)
+	end := time.Now()
 
 	if s := r.FormValue("start"); s != "" {
 		var err error
@@ -206,10 +206,20 @@ func parseSeriesRequest(r *http.Request) (*model.SeriesQueryParams, *model.ApiEr
 		}
 	}
 
+	var limit int
+	if l := r.FormValue("limit"); l != "" {
+		v, err := strconv.Atoi(l)
+		if err != nil || v < 0 {
+			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: errors.New("limit must be a non-negative integer")}
+		}
+		limit = v
+	}
+
 	return &model.SeriesQueryParams{
 		Start:   start,
 		End:     end,
 		Matches: matches,
+		Limit:   limit,
 	}, nil
 }
 

--- a/pkg/query-service/app/parser.go
+++ b/pkg/query-service/app/parser.go
@@ -223,6 +223,36 @@ func parseSeriesRequest(r *http.Request) (*model.SeriesQueryParams, *model.ApiEr
 	}, nil
 }
 
+func parseLabelRequest(r *http.Request) (*model.LabelQueryParams, *model.ApiError) {
+	if err := r.ParseForm(); err != nil {
+		return nil, &model.ApiError{Typ: model.ErrorBadData, Err: err}
+	}
+
+	start := time.Unix(0, 0)
+	end := time.Now()
+
+	if s := r.FormValue("start"); s != "" {
+		var err error
+		start, err = parseMetricsTime(s)
+		if err != nil {
+			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: err}
+		}
+	}
+	if e := r.FormValue("end"); e != "" {
+		var err error
+		end, err = parseMetricsTime(e)
+		if err != nil {
+			return nil, &model.ApiError{Typ: model.ErrorBadData, Err: err}
+		}
+	}
+
+	return &model.LabelQueryParams{
+		Start:   start,
+		End:     end,
+		Matches: r.Form["match[]"],
+	}, nil
+}
+
 func parseGetUsageRequest(r *http.Request) (*model.GetUsageParams, error) {
 	startTime, err := parseTime("start", r)
 	if err != nil {

--- a/pkg/query-service/interfaces/interface.go
+++ b/pkg/query-service/interfaces/interface.go
@@ -16,6 +16,7 @@ import (
 type Reader interface {
 	GetInstantQueryMetricsResult(ctx context.Context, query *model.InstantQueryMetricsParams) (*promql.Result, *stats.QueryStats, *model.ApiError)
 	GetQueryRangeResult(ctx context.Context, query *model.QueryRangeParams) (*promql.Result, *stats.QueryStats, *model.ApiError)
+	GetSeries(ctx context.Context, params *model.SeriesQueryParams) ([]map[string]string, *model.ApiError)
 	GetTopLevelOperations(ctx context.Context, start, end time.Time, services []string) (*map[string][]string, *model.ApiError)
 	GetEntryPointOperations(ctx context.Context, query *model.GetTopOperationsParams) (*[]model.TopOperationsItem, error)
 	GetServices(ctx context.Context, query *model.GetServicesParams) (*[]model.ServiceItem, *model.ApiError)

--- a/pkg/query-service/interfaces/interface.go
+++ b/pkg/query-service/interfaces/interface.go
@@ -17,6 +17,8 @@ type Reader interface {
 	GetInstantQueryMetricsResult(ctx context.Context, query *model.InstantQueryMetricsParams) (*promql.Result, *stats.QueryStats, *model.ApiError)
 	GetQueryRangeResult(ctx context.Context, query *model.QueryRangeParams) (*promql.Result, *stats.QueryStats, *model.ApiError)
 	GetSeries(ctx context.Context, params *model.SeriesQueryParams) ([]map[string]string, *model.ApiError)
+	GetLabels(ctx context.Context, params *model.LabelQueryParams) ([]string, *model.ApiError)
+	GetLabelValues(ctx context.Context, labelName string, params *model.LabelQueryParams) ([]string, *model.ApiError)
 	GetTopLevelOperations(ctx context.Context, start, end time.Time, services []string) (*map[string][]string, *model.ApiError)
 	GetEntryPointOperations(ctx context.Context, query *model.GetTopOperationsParams) (*[]model.TopOperationsItem, error)
 	GetServices(ctx context.Context, query *model.GetServicesParams) (*[]model.ServiceItem, *model.ApiError)

--- a/pkg/query-service/model/queryParams.go
+++ b/pkg/query-service/model/queryParams.go
@@ -18,6 +18,12 @@ type QueryRangeParams struct {
 	Stats string
 }
 
+type SeriesQueryParams struct {
+	Start   time.Time
+	End     time.Time
+	Matches []string // raw match[] PromQL selector strings
+}
+
 const (
 	StringTagMapCol   = "stringTagMap"
 	NumberTagMapCol   = "numberTagMap"

--- a/pkg/query-service/model/queryParams.go
+++ b/pkg/query-service/model/queryParams.go
@@ -25,6 +25,12 @@ type SeriesQueryParams struct {
 	Limit   int      // 0 means use the server-side default cap
 }
 
+type LabelQueryParams struct {
+	Start   time.Time
+	End     time.Time
+	Matches []string // optional match[] PromQL selector strings
+}
+
 const (
 	StringTagMapCol   = "stringTagMap"
 	NumberTagMapCol   = "numberTagMap"

--- a/pkg/query-service/model/queryParams.go
+++ b/pkg/query-service/model/queryParams.go
@@ -22,6 +22,7 @@ type SeriesQueryParams struct {
 	Start   time.Time
 	End     time.Time
 	Matches []string // raw match[] PromQL selector strings
+	Limit   int      // 0 means use the server-side default cap
 }
 
 const (


### PR DESCRIPTION
## What does this PR do?

Fixes #11519

Adds the missing Prometheus-compatible endpoints required for `prometheus-adapter` and other tools to work with SigNoz as a Prometheus data source.

## Changes

### New: `GET|POST /api/v1/series`
Accepts one or more `match[]` PromQL selectors and optional `start`/`end` Unix timestamps. Returns a Prometheus-compatible label-set array:
```json
{"status":"success","data":[{"__name__":"http_requests_total","job":"api-server"}]}
```
- Uses the existing Prometheus storage querier with a `Func: "series"` hint (no sample data fetched)
- Deduplicates series by label string key
- Strips the internal `fingerprint` label from results

### New: `GET|POST /api/v1/labels`
Returns all label names visible in the given time range. Accepts optional `match[]` selectors to filter by series and optional `start`/`end` bounds:
```json
{"status":"success","data":["__name__","job","instance"]}
```

### New: `GET|POST /api/v1/label/{label}/values`
Returns all values for a given label name. Accepts optional `match[]` selectors and `start`/`end` bounds:
```json
{"status":"success","data":["api-server","node-exporter"]}
```

### Updated: `GET|POST /api/v1/query_range` and `GET|POST /api/v1/query`
Added `POST` method support. The existing `r.FormValue()` parsers already handle `application/x-www-form-urlencoded` bodies, so only the route method list needed updating.

### New: `GET /api/v1/status/buildinfo`
Returns SigNoz version, git hash, branch, and Go version in the Prometheus buildinfo format.

## Files changed
- `pkg/query-service/model/queryParams.go` — new `SeriesQueryParams` and `LabelQueryParams` structs
- `pkg/query-service/app/parser.go` — new `parseSeriesRequest` and `parseLabelRequest` functions
- `pkg/query-service/interfaces/interface.go` — added `GetSeries`, `GetLabels`, `GetLabelValues` to `Reader` interface
- `pkg/query-service/app/clickhouseReader/reader.go` — implemented all three using Prometheus storage querier
- `pkg/query-service/app/http_handler.go` — new handlers; updated route registrations

## Test plan
- [ ] `GET /api/v1/series?match[]={__name__=~".+"}` returns a `{"status":"success","data":[...]}` array of label maps
- [ ] `POST /api/v1/series` with form body `match[]={job="my-service"}` returns the same format
- [ ] `GET /api/v1/labels` returns all label names
- [ ] `GET /api/v1/labels?match[]={job="my-service"}` returns labels scoped to that series
- [ ] `GET /api/v1/label/job/values` returns all job label values
- [ ] `GET /api/v1/query_range` and `POST /api/v1/query_range` both work
- [ ] `GET /api/v1/status/buildinfo` returns version info
- [ ] `prometheus-adapter` can connect and discover series