### PR TITLE
refactor(types): tighten MetricQueryRangeSuccessResponse shape

### DIFF
--- a/frontend/src/api/v5/queryRange/convertV5Response.ts
+++ b/frontend/src/api/v5/queryRange/convertV5Response.ts
@@ -349,7 +349,7 @@ function convertV5DataByType(
  */
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export function convertV5ResponseToLegacy(
-	v5Response: SuccessResponse<MetricRangePayloadV5>,
+	v5Response: SuccessResponse<MetricRangePayloadV5, QueryRangeRequestV5>,
 	legendMap: Record<string, string>,
 	formatForWeb?: boolean,
 ): SuccessResponse<MetricRangePayloadV3> & { warning?: Warning } {
@@ -357,7 +357,7 @@ export function convertV5ResponseToLegacy(
 	const v5Data = payload?.data;
 
 	const aggregationPerQuery =
-		(params as QueryRangeRequestV5)?.compositeQuery?.queries
+		params?.compositeQuery?.queries
 			?.filter((query) => query.type === 'builder_query')
 			.reduce(
 				(acc, query) => {

--- a/frontend/src/container/DashboardContainer/visualization/hooks/__tests__/usePanelContextMenu.test.ts
+++ b/frontend/src/container/DashboardContainer/visualization/hooks/__tests__/usePanelContextMenu.test.ts
@@ -1,8 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { UseQueryResult } from 'react-query';
-import { SuccessResponse } from 'types/api';
 import { Widgets } from 'types/api/dashboard/getAll';
-import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { MetricQueryRangeSuccessResponse } from 'types/api/metrics/getQueryRange';
 
 import { usePanelContextMenu } from '../usePanelContextMenu';
 
@@ -47,10 +46,7 @@ const mockWidget = { id: 'w-1', query: {} } as unknown as Widgets;
 const mockQueryResponse = {
 	data: undefined,
 	isLoading: false,
-} as unknown as UseQueryResult<
-	SuccessResponse<MetricRangePayloadProps, unknown>,
-	Error
->;
+} as unknown as UseQueryResult<MetricQueryRangeSuccessResponse, Error>;
 
 describe('usePanelContextMenu', () => {
 	beforeEach(() => {

--- a/frontend/src/container/DashboardContainer/visualization/hooks/usePanelContextMenu.ts
+++ b/frontend/src/container/DashboardContainer/visualization/hooks/usePanelContextMenu.ts
@@ -10,17 +10,13 @@ import {
 	PopoverPosition,
 	useCoordinates,
 } from 'periscope/components/ContextMenu';
-import { SuccessResponse } from 'types/api';
 import { Widgets } from 'types/api/dashboard/getAll';
-import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { MetricQueryRangeSuccessResponse } from 'types/api/metrics/getQueryRange';
 import { DataSource } from 'types/common/queryBuilder';
 
 interface UseTimeSeriesContextMenuParams {
 	widget: Widgets;
-	queryResponse: UseQueryResult<
-		SuccessResponse<MetricRangePayloadProps, unknown>,
-		Error
-	>;
+	queryResponse: UseQueryResult<MetricQueryRangeSuccessResponse, Error>;
 	enableDrillDown?: boolean;
 }
 

--- a/frontend/src/container/GridCardLayout/GridCard/types.ts
+++ b/frontend/src/container/GridCardLayout/GridCard/types.ts
@@ -5,9 +5,11 @@ import { GetQueryResultsProps } from 'lib/dashboard/getQueryResults';
 import { RowData } from 'lib/query/createTableColumnsFromQuery';
 import { OnClickPluginOpts } from 'lib/uPlotLib/plugins/onClickPlugin';
 import { IDashboardVariables } from 'providers/Dashboard/store/dashboardVariables/dashboardVariablesStoreTypes';
-import { SuccessResponse } from 'types/api';
 import { Widgets } from 'types/api/dashboard/getAll';
-import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import {
+	MetricQueryRangeSuccessResponse,
+	MetricRangePayloadProps,
+} from 'types/api/metrics/getQueryRange';
 import { QueryData } from 'types/api/widgets/getQuery';
 import uPlot from 'uplot';
 
@@ -21,10 +23,7 @@ export interface GraphVisibilityLegendEntryProps {
 
 export interface WidgetGraphComponentProps {
 	widget: Widgets;
-	queryResponse: UseQueryResult<
-		SuccessResponse<MetricRangePayloadProps, unknown>,
-		Error
-	>;
+	queryResponse: UseQueryResult<MetricQueryRangeSuccessResponse, Error>;
 	errorMessage: string | undefined;
 	version?: string;
 	threshold?: ReactNode;

--- a/frontend/src/container/GridValueComponent/types.ts
+++ b/frontend/src/container/GridValueComponent/types.ts
@@ -1,8 +1,7 @@
 import { UseQueryResult } from 'react-query';
 import { ThresholdProps } from 'container/NewWidget/RightContainer/Threshold/types';
-import { SuccessResponse } from 'types/api';
 import { ContextLinksData, Widgets } from 'types/api/dashboard/getAll';
-import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { MetricQueryRangeSuccessResponse } from 'types/api/metrics/getQueryRange';
 import uPlot from 'uplot';
 
 export type GridValueComponentProps = {
@@ -13,10 +12,7 @@ export type GridValueComponentProps = {
 	thresholds?: ThresholdProps[];
 	// Context menu related props
 	widget?: Widgets;
-	queryResponse?: UseQueryResult<
-		SuccessResponse<MetricRangePayloadProps, unknown>,
-		Error
-	>;
+	queryResponse?: UseQueryResult<MetricQueryRangeSuccessResponse, Error>;
 	contextLinks?: ContextLinksData;
 	enableDrillDown?: boolean;
 };

--- a/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/WidgetGraphs.tsx
+++ b/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/WidgetGraphs.tsx
@@ -28,9 +28,8 @@ import { GetQueryResultsProps } from 'lib/dashboard/getQueryResults';
 import GetMinMax from 'lib/getMinMax';
 import getTimeString from 'lib/getTimeString';
 import { UpdateTimeInterval } from 'store/actions';
-import { SuccessResponse } from 'types/api';
 import { Widgets } from 'types/api/dashboard/getAll';
-import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { MetricQueryRangeSuccessResponse } from 'types/api/metrics/getQueryRange';
 import { DataSource } from 'types/common/queryBuilder';
 
 function WidgetGraph({
@@ -202,10 +201,7 @@ function WidgetGraph({
 
 interface WidgetGraphProps {
 	selectedWidget: Widgets;
-	queryResponse: UseQueryResult<
-		SuccessResponse<MetricRangePayloadProps, unknown>,
-		Error
-	>;
+	queryResponse: UseQueryResult<MetricQueryRangeSuccessResponse, Error>;
 	setRequestData: Dispatch<SetStateAction<GetQueryResultsProps>>;
 	selectedGraph: PANEL_TYPES;
 	enableDrillDown?: boolean;

--- a/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/util.ts
+++ b/frontend/src/container/NewWidget/LeftContainer/WidgetGraph/util.ts
@@ -1,11 +1,12 @@
+import { QueryRangeRequestV5 } from 'api/v5/v5';
 import { SuccessResponse } from 'types/api';
 import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
 import { Column, QueryData, QueryDataV3 } from 'types/api/widgets/getQuery';
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export function populateMultipleResults(
-	responseData: SuccessResponse<MetricRangePayloadProps, unknown>,
-): SuccessResponse<MetricRangePayloadProps, unknown> {
+	responseData: SuccessResponse<MetricRangePayloadProps, QueryRangeRequestV5>,
+): SuccessResponse<MetricRangePayloadProps, QueryRangeRequestV5> {
 	const queryResults = responseData?.payload?.data?.newResult?.data?.result;
 	const allFormattedResults: QueryData[] = [];
 
@@ -66,17 +67,19 @@ export function populateMultipleResults(
 	}
 
 	// Create a copy instead of mutating the original
-	const updatedResponseData: SuccessResponse<MetricRangePayloadProps, unknown> =
-		{
-			...responseData,
-			payload: {
-				...responseData.payload,
-				data: {
-					...responseData.payload.data,
-					result: allFormattedResults,
-				},
+	const updatedResponseData: SuccessResponse<
+		MetricRangePayloadProps,
+		QueryRangeRequestV5
+	> = {
+		...responseData,
+		payload: {
+			...responseData.payload,
+			data: {
+				...responseData.payload.data,
+				result: allFormattedResults,
 			},
-		};
+		},
+	};
 
 	return updatedResponseData;
 }

--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -52,7 +52,6 @@ import {
 	getSelectedWidgetIndex,
 } from 'providers/Dashboard/util';
 import { AppState } from 'store/reducers';
-import { SuccessResponse } from 'types/api';
 import {
 	ColumnUnit,
 	ContextLinksData,
@@ -61,7 +60,7 @@ import {
 } from 'types/api/dashboard/getAll';
 import { Props } from 'types/api/dashboard/update';
 import { IField } from 'types/api/logs/fields';
-import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { MetricQueryRangeSuccessResponse } from 'types/api/metrics/getQueryRange';
 import { EQueryType } from 'types/common/dashboard';
 import { DataSource } from 'types/common/queryBuilder';
 import { GlobalReducer } from 'types/reducer/globalTime';
@@ -398,7 +397,7 @@ function NewWidget({
 
 	// State to hold query response for sharing between left and right containers
 	const [queryResponse, setQueryResponse] = useState<
-		UseQueryResult<SuccessResponse<MetricRangePayloadProps, unknown>, Error>
+		UseQueryResult<MetricQueryRangeSuccessResponse, Error>
 	>(null as any);
 
 	// request data should be handled by the parent and the child components should consume the same

--- a/frontend/src/container/NewWidget/types.ts
+++ b/frontend/src/container/NewWidget/types.ts
@@ -2,9 +2,8 @@ import { Dispatch, SetStateAction } from 'react';
 import { UseQueryResult } from 'react-query';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import { GetQueryResultsProps } from 'lib/dashboard/getQueryResults';
-import { SuccessResponse, Warning } from 'types/api';
 import { Dashboard, Widgets } from 'types/api/dashboard/getAll';
-import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { MetricQueryRangeSuccessResponse } from 'types/api/metrics/getQueryRange';
 
 import { timePreferance } from './RightContainer/timeItems';
 
@@ -29,9 +28,7 @@ export interface WidgetGraphProps {
 	setRequestData: Dispatch<SetStateAction<GetQueryResultsProps>>;
 	isLoadingPanelData: boolean;
 	setQueryResponse?: Dispatch<
-		SetStateAction<
-			UseQueryResult<SuccessResponse<MetricRangePayloadProps, unknown>, Error>
-		>
+		SetStateAction<UseQueryResult<MetricQueryRangeSuccessResponse, Error>>
 	>;
 	enableDrillDown?: boolean;
 	dashboardData: Dashboard | undefined;
@@ -39,12 +36,7 @@ export interface WidgetGraphProps {
 }
 
 export type WidgetGraphContainerProps = {
-	queryResponse: UseQueryResult<
-		SuccessResponse<MetricRangePayloadProps, unknown> & {
-			warning?: Warning;
-		},
-		Error
-	>;
+	queryResponse: UseQueryResult<MetricQueryRangeSuccessResponse, Error>;
 	setRequestData: Dispatch<SetStateAction<GetQueryResultsProps>>;
 	selectedGraph: PANEL_TYPES;
 	selectedWidget: Widgets;

--- a/frontend/src/container/PanelWrapper/TablePanelWrapper.tsx
+++ b/frontend/src/container/PanelWrapper/TablePanelWrapper.tsx
@@ -1,7 +1,6 @@
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import GridTableComponent from 'container/GridTableComponent';
 import { GRID_TABLE_CONFIG } from 'container/GridTableComponent/config';
-import { QueryRangeRequestV5 } from 'types/api/v5/queryRange';
 
 import { PanelWrapperProps } from './panelWrapper.types';
 
@@ -20,7 +19,7 @@ function TablePanelWrapper({
 		(queryResponse.data?.payload?.data?.result?.[0] as any)?.table || [];
 	const { thresholds } = widget;
 
-	const queryRangeRequest = queryResponse.data?.params as QueryRangeRequestV5;
+	const queryRangeRequest = queryResponse.data?.params;
 
 	return (
 		<GridTableComponent

--- a/frontend/src/container/QueryTable/Drilldown/useAggregateDrilldown.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/useAggregateDrilldown.tsx
@@ -2,9 +2,8 @@ import { useMemo } from 'react';
 import { UseQueryResult } from 'react-query';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import useDashboardVarConfig from 'container/QueryTable/Drilldown/useDashboardVarConfig';
-import { SuccessResponse } from 'types/api';
 import { ContextLinksData } from 'types/api/dashboard/getAll';
-import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { MetricQueryRangeSuccessResponse } from 'types/api/metrics/getQueryRange';
 import { Query } from 'types/api/queryBuilder/queryBuilderData';
 import { getTimeRange } from 'utils/getTimeRange';
 
@@ -44,10 +43,7 @@ const useAggregateDrilldown = ({
 	aggregateData: AggregateData | null;
 	contextLinks?: ContextLinksData;
 	panelType?: PANEL_TYPES;
-	queryRange?: UseQueryResult<
-		SuccessResponse<MetricRangePayloadProps, unknown>,
-		Error
-	>;
+	queryRange?: UseQueryResult<MetricQueryRangeSuccessResponse, Error>;
 }): {
 	aggregateDrilldownConfig: {
 		header?: string | React.ReactNode;

--- a/frontend/src/container/QueryTable/Drilldown/useGraphContextMenu.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/useGraphContextMenu.tsx
@@ -2,9 +2,8 @@ import { useMemo } from 'react';
 import { UseQueryResult } from 'react-query';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import { useGetCompositeQueryParam } from 'hooks/queryBuilder/useGetCompositeQueryParam';
-import { SuccessResponse } from 'types/api';
 import { ContextLinksData } from 'types/api/dashboard/getAll';
-import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { MetricQueryRangeSuccessResponse } from 'types/api/metrics/getQueryRange';
 import { Query } from 'types/api/queryBuilder/queryBuilderData';
 
 import { isValidQueryName } from './drilldownUtils';
@@ -20,10 +19,7 @@ interface UseGraphContextMenuProps {
 	setSubMenu: (subMenu: string) => void;
 	contextLinks?: ContextLinksData;
 	panelType?: PANEL_TYPES;
-	queryRange?: UseQueryResult<
-		SuccessResponse<MetricRangePayloadProps, unknown>,
-		Error
-	>;
+	queryRange?: UseQueryResult<MetricQueryRangeSuccessResponse, Error>;
 }
 
 export function useGraphContextMenu({

--- a/frontend/src/hooks/queryBuilder/useGetExplorerQueryRange.ts
+++ b/frontend/src/hooks/queryBuilder/useGetExplorerQueryRange.ts
@@ -7,8 +7,7 @@ import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { GetQueryResultsProps } from 'lib/dashboard/getQueryResults';
 import { AppState } from 'store/reducers';
-import { SuccessResponse, Warning } from 'types/api';
-import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { MetricQueryRangeSuccessResponse } from 'types/api/metrics/getQueryRange';
 import { Query } from 'types/api/queryBuilder/queryBuilderData';
 import { GlobalReducer } from 'types/reducer/globalTime';
 
@@ -19,16 +18,13 @@ export const useGetExplorerQueryRange = (
 	requestData: Query | null,
 	panelType: PANEL_TYPES | null,
 	version: string,
-	options?: UseQueryOptions<SuccessResponse<MetricRangePayloadProps>, Error>,
+	options?: UseQueryOptions<MetricQueryRangeSuccessResponse, Error>,
 	params?: Record<string, unknown>,
 	isDependentOnQB = true,
 	keyRef?: MutableRefObject<any>,
 	headers?: Record<string, string>,
 	selectedTimeInterval?: GetQueryResultsProps['globalSelectedInterval'],
-): UseQueryResult<
-	SuccessResponse<MetricRangePayloadProps> & { warning?: Warning },
-	Error
-> => {
+): UseQueryResult<MetricQueryRangeSuccessResponse, Error> => {
 	const { isEnabledQuery } = useQueryBuilder();
 	const {
 		selectedTime: globalSelectedInterval,

--- a/frontend/src/types/api/metrics/getQueryRange.ts
+++ b/frontend/src/types/api/metrics/getQueryRange.ts
@@ -8,7 +8,7 @@ import {
 	IClickHouseQuery,
 	IPromQLQuery,
 } from '../queryBuilder/queryBuilderData';
-import { ExecStats } from '../v5/queryRange';
+import { ExecStats, QueryRangeRequestV5 } from '../v5/queryRange';
 import { QueryData, QueryDataV3 } from '../widgets/getQuery';
 
 export type QueryRangePayload = {
@@ -39,11 +39,16 @@ export interface MetricRangePayloadProps {
 	meta?: ExecStats;
 }
 
-/** Query range success response including optional warning and meta */
-export type MetricQueryRangeSuccessResponse = SuccessResponse<
+/** Query range success response. `params` is the request that produced the
+ *  payload; `warning` and `meta` are lifted from the payload to the top level
+ *  by `getQueryResults.ts` for consumer convenience. */
+export interface MetricQueryRangeSuccessResponse extends SuccessResponse<
 	MetricRangePayloadProps,
-	unknown
-> & { warning?: Warning; meta?: ExecStats };
+	QueryRangeRequestV5
+> {
+	warning?: Warning;
+	meta?: ExecStats;
+}
 
 export interface MetricRangePayloadV3 {
 	data: {

--- a/frontend/src/utils/getTimeRange.ts
+++ b/frontend/src/utils/getTimeRange.ts
@@ -1,8 +1,7 @@
 import { UseQueryResult } from 'react-query';
 import getStartEndRangeTime from 'lib/getStartEndRangeTime';
 import store from 'store';
-import { SuccessResponse } from 'types/api';
-import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { MetricQueryRangeSuccessResponse } from 'types/api/metrics/getQueryRange';
 import { QueryRangeRequestV5 } from 'types/api/v5/queryRange';
 
 export const getTimeRangeFromQueryRangeRequest = (
@@ -28,13 +27,9 @@ export const getTimeRangeFromQueryRangeRequest = (
 };
 
 export const getTimeRange = (
-	widgetQueryRange?: UseQueryResult<
-		SuccessResponse<MetricRangePayloadProps, unknown>,
-		Error
-	>,
+	widgetQueryRange?: UseQueryResult<MetricQueryRangeSuccessResponse, Error>,
 ): Record<string, number> => {
-	const widgetParams =
-		(widgetQueryRange?.data?.params as QueryRangeRequestV5) || null;
+	const widgetParams = widgetQueryRange?.data?.params;
 
 	return getTimeRangeFromQueryRangeRequest(widgetParams);
 };


### PR DESCRIPTION
## Pull Request

### 📄 Summary

Cleans up `MetricQueryRangeSuccessResponse` — the success-response shape returned by every query-range fetch.

**Before:**
```ts
export type MetricQueryRangeSuccessResponse = SuccessResponse<
  MetricRangePayloadProps,
  unknown
> & { warning?: Warning; meta?: ExecStats };
```

Two specific things were wrong with this:

1. The `& { warning?, meta? }` intersection — `warning` and `meta` are documented top-level fields of the response, not bolted-on extras. Defining them via `&` reads like a hack and made the type harder to grep for / extend.
2. `params: unknown` — every consumer that wanted the request shape had to write `data.params as QueryRangeRequestV5`. The cast had no real boundary semantics; `params` is always `QueryRangeRequestV5` for this response type.

**After:**
```ts
export interface MetricQueryRangeSuccessResponse extends SuccessResponse<
  MetricRangePayloadProps,
  QueryRangeRequestV5
> {
  warning?: Warning;
  meta?: ExecStats;
}
```

No runtime behavior change. `getQueryResults.ts` still lifts `warning`/`meta` from `payload` to the top level the same way it always did — only the type that describes the result changed shape.

#### Issues closed by this PR

Closes https://github.com/SigNoz/engineering-pod/issues/5207

---

### ✅ Change Type

- [x] ♻️ Refactor

---

### 🐛 Bug Context

N/A — no bug, no behavior change.

---

### 🧪 Testing Strategy

- **Tests added/updated:** None new. Updated one test fixture (`usePanelContextMenu.test.ts`) to match the new return shape.
- **Manual verification:** `tsgo --noEmit` clean across the whole tree. All affected test suites green (`usePanelContextMenu`, `convertV5Response`, `getQueryResults`, `baseConfigBuilder`, `TablePanelWrapper`) — 34 tests, all passing.
- **Edge cases covered:** Type-level only. The interface form is structurally identical to the prior intersection, so all existing call sites that read `data.warning` / `data.meta` continue to compile and execute exactly as before.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** 15 files. Most are 1–4 line touches replacing `SuccessResponse<MetricRangePayloadProps, unknown>` (and friends) with `MetricQueryRangeSuccessResponse`. The bulk of the changes are import swaps.
- **Potential regressions:** Very low. The new interface is assignment-compatible with the old intersection — anything that was correctly typed before still typechecks. Runtime is untouched.
- **Rollback plan:** Single squashable commit; revert the PR if anything surfaces.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | N/A |
| Change Type | Maintenance |
| Description | N/A — internal type refactor, no user-facing change |

---

### 📋 Checklist

- [x] Tests added or explicitly not required (none needed — no behavior change; existing tests still cover)
- [x] Manually tested (tsgo + jest + lint, all clean)
- [x] Breaking changes documented (none — interface form is structurally compatible with the prior intersection)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

**Recommended review path:**

1. Start at [`frontend/src/types/api/metrics/getQueryRange.ts`](https://github.com/SigNoz/signoz/blob/chore/metric-query-range-types/frontend/src/types/api/metrics/getQueryRange.ts) — the type change is the only meaningful diff. Everything else is mechanical.
2. Skim [`frontend/src/lib/dashboard/getQueryResults.ts`](https://github.com/SigNoz/signoz/blob/chore/metric-query-range-types/frontend/src/lib/dashboard/getQueryResults.ts) to confirm the runtime spread of `warning` + `meta` is unchanged.
3. The other 13 files are import swaps:
   - 9 consumers (`UseQueryResult<SuccessResponse<MetricRangePayloadProps, unknown>, Error>` → `UseQueryResult<MetricQueryRangeSuccessResponse, Error>`)
   - 3 redundant `as QueryRangeRequestV5` casts dropped
   - 2 helper signatures tightened (`convertV5ResponseToLegacy` and `getTimeRange` now declare their `params` type explicitly instead of relying on caller casts)

**Why an interface instead of an intersection-with-named-fields?** Interface declaration is the canonical way to extend a generic and add fields. It's discoverable (`Go to definition` lands on a clean shape), it's extendable by other consumers, and it doesn't carry the "this was bolted on after the fact" vibe that an `&` intersection does.

**Why include `warning?` / `meta?` directly on the response interface and not on `MetricRangePayloadProps`?** They live at the *top level* of the response at runtime (lifted from `payload` by `getQueryResults.ts` for consumer convenience). Putting them on the response type matches the runtime; putting them on the payload type would be a lie.