### PR TITLE
refactor(cloud-integrations): use account-scoped  ListAccountServices endpoint when an account is connected

### DIFF
--- a/frontend/src/api/generated/services/cloudintegration/index.ts
+++ b/frontend/src/api/generated/services/cloudintegration/index.ts
@@ -36,6 +36,8 @@ import type {
 	GetService200,
 	GetServiceParams,
 	GetServicePathParameters,
+	ListAccountServicesMetadata200,
+	ListAccountServicesMetadataPathParameters,
 	ListAccounts200,
 	ListAccountsPathParameters,
 	ListServicesMetadata200,
@@ -631,6 +633,116 @@ export const useUpdateAccount = <
 > => {
 	return useMutation(getUpdateAccountMutationOptions(options));
 };
+/**
+ * This endpoint lists the services metadata for the specified account and cloud provider
+ * @summary List account services metadata
+ */
+export const listAccountServicesMetadata = (
+	{ cloudProvider, id }: ListAccountServicesMetadataPathParameters,
+	signal?: AbortSignal,
+) => {
+	return GeneratedAPIInstance<ListAccountServicesMetadata200>({
+		url: `/api/v1/cloud_integrations/${cloudProvider}/accounts/${id}/services`,
+		method: 'GET',
+		signal,
+	});
+};
+
+export const getListAccountServicesMetadataQueryKey = ({
+	cloudProvider,
+	id,
+}: ListAccountServicesMetadataPathParameters) => {
+	return [
+		`/api/v1/cloud_integrations/${cloudProvider}/accounts/${id}/services`,
+	] as const;
+};
+
+export const getListAccountServicesMetadataQueryOptions = <
+	TData = Awaited<ReturnType<typeof listAccountServicesMetadata>>,
+	TError = ErrorType<RenderErrorResponseDTO>,
+>(
+	{ cloudProvider, id }: ListAccountServicesMetadataPathParameters,
+	options?: {
+		query?: UseQueryOptions<
+			Awaited<ReturnType<typeof listAccountServicesMetadata>>,
+			TError,
+			TData
+		>;
+	},
+) => {
+	const { query: queryOptions } = options ?? {};
+
+	const queryKey =
+		queryOptions?.queryKey ??
+		getListAccountServicesMetadataQueryKey({ cloudProvider, id });
+
+	const queryFn: QueryFunction<
+		Awaited<ReturnType<typeof listAccountServicesMetadata>>
+	> = ({ signal }) => listAccountServicesMetadata({ cloudProvider, id }, signal);
+
+	return {
+		queryKey,
+		queryFn,
+		enabled: !!(cloudProvider && id),
+		...queryOptions,
+	} as UseQueryOptions<
+		Awaited<ReturnType<typeof listAccountServicesMetadata>>,
+		TError,
+		TData
+	> & { queryKey: QueryKey };
+};
+
+export type ListAccountServicesMetadataQueryResult = NonNullable<
+	Awaited<ReturnType<typeof listAccountServicesMetadata>>
+>;
+export type ListAccountServicesMetadataQueryError =
+	ErrorType<RenderErrorResponseDTO>;
+
+/**
+ * @summary List account services metadata
+ */
+
+export function useListAccountServicesMetadata<
+	TData = Awaited<ReturnType<typeof listAccountServicesMetadata>>,
+	TError = ErrorType<RenderErrorResponseDTO>,
+>(
+	{ cloudProvider, id }: ListAccountServicesMetadataPathParameters,
+	options?: {
+		query?: UseQueryOptions<
+			Awaited<ReturnType<typeof listAccountServicesMetadata>>,
+			TError,
+			TData
+		>;
+	},
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
+	const queryOptions = getListAccountServicesMetadataQueryOptions(
+		{ cloudProvider, id },
+		options,
+	);
+
+	const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
+		queryKey: QueryKey;
+	};
+
+	return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * @summary List account services metadata
+ */
+export const invalidateListAccountServicesMetadata = async (
+	queryClient: QueryClient,
+	{ cloudProvider, id }: ListAccountServicesMetadataPathParameters,
+	options?: InvalidateOptions,
+): Promise<QueryClient> => {
+	await queryClient.invalidateQueries(
+		{ queryKey: getListAccountServicesMetadataQueryKey({ cloudProvider, id }) },
+		options,
+	);
+
+	return queryClient;
+};
+
 /**
  * This endpoint updates a service for the specified cloud provider
  * @summary Update service

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -8623,6 +8623,18 @@ export type UpdateAccountPathParameters = {
 	cloudProvider: string;
 	id: string;
 };
+export type ListAccountServicesMetadataPathParameters = {
+	cloudProvider: string;
+	id: string;
+};
+export type ListAccountServicesMetadata200 = {
+	data: CloudintegrationtypesGettableServicesMetadataDTO;
+	/**
+	 * @type string
+	 */
+	status: string;
+};
+
 export type UpdateServicePathParameters = {
 	cloudProvider: string;
 	id: string;

--- a/frontend/src/container/Integrations/CloudIntegration/AmazonWebServices/ServiceDetails/ServiceDetails.tsx
+++ b/frontend/src/container/Integrations/CloudIntegration/AmazonWebServices/ServiceDetails/ServiceDetails.tsx
@@ -8,16 +8,16 @@ import { Tabs } from '@signozhq/ui/tabs';
 import { Skeleton } from 'antd';
 import logEvent from 'api/common/logEvent';
 import {
-	getListServicesMetadataQueryKey,
+	getListAccountServicesMetadataQueryKey,
 	invalidateGetService,
-	invalidateListServicesMetadata,
+	invalidateListAccountServicesMetadata,
 	useGetService,
 	useUpdateService,
 } from 'api/generated/services/cloudintegration';
 import {
 	CloudintegrationtypesServiceConfigDTO,
 	CloudintegrationtypesServiceDTO,
-	ListServicesMetadata200,
+	ListAccountServicesMetadata200,
 } from 'api/generated/services/sigNoz.schemas';
 import CloudServiceDataCollected from 'components/CloudIntegrations/CloudServiceDataCollected/CloudServiceDataCollected';
 import { MarkdownRenderer } from 'components/MarkdownRenderer/MarkdownRenderer';
@@ -240,16 +240,12 @@ function ServiceDetails({
 							// instead of waiting for the refetch to complete.
 							reset(nextFormValues);
 
-							const servicesListQueryKey = getListServicesMetadataQueryKey(
-								{
-									cloudProvider: type,
-								},
-								{
-									cloud_integration_id: cloudAccountId,
-								},
-							);
+							const servicesListQueryKey = getListAccountServicesMetadataQueryKey({
+								cloudProvider: type,
+								id: cloudAccountId,
+							});
 
-							queryClient.setQueryData<ListServicesMetadata200 | undefined>(
+							queryClient.setQueryData<ListAccountServicesMetadata200 | undefined>(
 								servicesListQueryKey,
 								(prev) => {
 									if (!prev?.data?.services?.length) {
@@ -283,15 +279,10 @@ function ServiceDetails({
 								},
 							);
 
-							invalidateListServicesMetadata(
-								queryClient,
-								{
-									cloudProvider: type,
-								},
-								{
-									cloud_integration_id: cloudAccountId,
-								},
-							);
+							invalidateListAccountServicesMetadata(queryClient, {
+								cloudProvider: type,
+								id: cloudAccountId,
+							});
 
 							logEvent(`${type} Integration: Service settings saved`, {
 								cloudAccountId,

--- a/frontend/src/container/Integrations/CloudIntegration/ServicesList.tsx
+++ b/frontend/src/container/Integrations/CloudIntegration/ServicesList.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { Skeleton } from 'antd';
-import { useListAccountServicesMetadata } from 'api/generated/services/cloudintegration';
+import {
+	useListAccounts,
+	useListAccountServicesMetadata,
+	useListServicesMetadata,
+} from 'api/generated/services/cloudintegration';
 import type { CloudintegrationtypesServiceMetadataDTO } from 'api/generated/services/sigNoz.schemas';
 import cx from 'classnames';
 import { IntegrationType } from 'container/Integrations/types';
@@ -20,11 +24,33 @@ function ServicesList({
 }: ServicesListProps): JSX.Element {
 	const urlQuery = useUrlQuery();
 	const navigate = useNavigate();
+	const isAccountConnected = Boolean(cloudAccountId);
+	const { data: listAccountsResponse, isLoading: isAccountsLoading } =
+		useListAccounts({ cloudProvider: type });
+	const hasConnectedAccounts =
+		(listAccountsResponse?.data?.accounts?.length ?? 0) > 0;
 
-	const { data: servicesMetadata, isLoading } = useListAccountServicesMetadata({
-		cloudProvider: type,
-		id: cloudAccountId,
+	const { data: accountServicesMetadata, isLoading: isAccountServicesLoading } =
+		useListAccountServicesMetadata(
+			{ cloudProvider: type, id: cloudAccountId },
+			{ query: { enabled: isAccountConnected } },
+		);
+
+	const {
+		data: providerServicesMetadata,
+		isLoading: isProviderServicesLoading,
+	} = useListServicesMetadata({ cloudProvider: type }, undefined, {
+		query: { enabled: !isAccountsLoading && !hasConnectedAccounts },
 	});
+
+	const servicesMetadata = hasConnectedAccounts
+		? accountServicesMetadata
+		: providerServicesMetadata;
+	const isLoading =
+		isAccountsLoading ||
+		(hasConnectedAccounts
+			? isAccountServicesLoading || !isAccountConnected
+			: isProviderServicesLoading);
 
 	const awsServices = useMemo(
 		() => servicesMetadata?.data?.services ?? [],

--- a/frontend/src/container/Integrations/CloudIntegration/ServicesList.tsx
+++ b/frontend/src/container/Integrations/CloudIntegration/ServicesList.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { Skeleton } from 'antd';
-import { useListServicesMetadata } from 'api/generated/services/cloudintegration';
+import { useListAccountServicesMetadata } from 'api/generated/services/cloudintegration';
 import type { CloudintegrationtypesServiceMetadataDTO } from 'api/generated/services/sigNoz.schemas';
 import cx from 'classnames';
 import { IntegrationType } from 'container/Integrations/types';
@@ -20,17 +20,11 @@ function ServicesList({
 }: ServicesListProps): JSX.Element {
 	const urlQuery = useUrlQuery();
 	const navigate = useNavigate();
-	const hasValidCloudAccountId = Boolean(cloudAccountId);
-	const serviceQueryParams = hasValidCloudAccountId
-		? { cloud_integration_id: cloudAccountId }
-		: undefined;
 
-	const { data: servicesMetadata, isLoading } = useListServicesMetadata(
-		{
-			cloudProvider: type,
-		},
-		serviceQueryParams,
-	);
+	const { data: servicesMetadata, isLoading } = useListAccountServicesMetadata({
+		cloudProvider: type,
+		id: cloudAccountId,
+	});
 
 	const awsServices = useMemo(
 		() => servicesMetadata?.data?.services ?? [],


### PR DESCRIPTION
## Pull Request
follow up pr for - https://github.com/SigNoz/signoz/pull/11563 
 cloud-integrations services list from the provider-level
  `listServicesMetadata` endpoint to the new account-scoped
  `listAccountServicesMetadata` endpoint (`/api/v1/cloud_integrations/{provider}/accounts/{id}/services`),
  falling back to the provider-level endpoint when no account is connected yet.
  

  **What changes**

  1. **Generated client** (`frontend/src/api/generated/services/cloudintegration/index.ts`,
     `sigNoz.schemas.ts`) — adds `useListAccountServicesMetadata`,
     `getListAccountServicesMetadataQueryKey`,
     `invalidateListAccountServicesMetadata`, plus the
     `ListAccountServicesMetadata200` / `ListAccountServicesMetadataPathParameters`
     types for the new endpoint.

  2. **`ServicesList.tsx`** — picks the right endpoint based on account state:
     - Calls `useListAccounts` first to learn whether any accounts are connected.
     - **If at least one account is connected:** uses the account-scoped
       `useListAccountServicesMetadata({ cloudProvider, id })`, gated by
       `isAccountConnected` so it doesn't fire without a `cloudAccountId`.
     - **If no accounts are connected:** falls back to the existing
       `useListServicesMetadata` so the empty/onboarding state still has
       services to show.
     - `isLoading` now composes the accounts query + whichever services query is
       active, so we don't flash an empty state while accounts are still
       loading.

  3. **`ServiceDetails.tsx`** — service-toggle optimistic update and cache
     invalidation now target the account-scoped query key
     (`getListAccountServicesMetadataQueryKey({ cloudProvider, id })` /
     `invalidateListAccountServicesMetadata`). Previously these used the
     provider-level key with a `cloud_integration_id` query param, which no
     longer matches the cache entry the list view writes.  



#### Screenshots / Screen Recordings (if applicable)


(please turn on audio)

https://github.com/user-attachments/assets/2789a3a2-3b00-4849-877f-2c0c3ce8aa94


https://github.com/user-attachments/assets/5943b384-37d0-43e3-8f38-37fcbd13bc31






#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

#### Fix Strategy
> How does this PR address the root cause?

---

### 🧪 Testing Strategy
> How was this change validated?
 
 have tested manually
---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix / Maintenance |
| Description | User-facing summary |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers
- **Merge order:** needs #11563 to land first so the new endpoint exists.


---
