### PR TITLE
 refactor(cloud-integrations): use account-scoped getService endpoint when an account is connected 

### DIFF
--- a/frontend/src/container/Integrations/CloudIntegration/AmazonWebServices/ServiceDetails/ServiceDetails.tsx
+++ b/frontend/src/container/Integrations/CloudIntegration/AmazonWebServices/ServiceDetails/ServiceDetails.tsx
@@ -9,8 +9,9 @@ import { Skeleton } from 'antd';
 import logEvent from 'api/common/logEvent';
 import {
 	getListServicesMetadataQueryKey,
-	invalidateGetService,
+	invalidateGetAccountService,
 	invalidateListServicesMetadata,
+	useGetAccountService,
 	useGetService,
 	useUpdateService,
 } from 'api/generated/services/cloudintegration';
@@ -118,29 +119,49 @@ function ServiceDetails({
 	const cloudAccountId = urlQuery.get('cloudAccountId');
 	const serviceId = urlQuery.get('service');
 	const isReadOnly = !cloudAccountId;
-	const serviceQueryParams = cloudAccountId
-		? { cloud_integration_id: cloudAccountId }
-		: undefined;
 
 	const {
-		queryKey: _queryKey,
-		data: serviceDetailsData,
-		isLoading: isServiceDetailsLoading,
+		queryKey: _accountServiceQueryKey,
+		data: accountServiceData,
+		isLoading: isAccountServiceLoading,
+	} = useGetAccountService(
+		{
+			cloudProvider: type,
+			id: cloudAccountId || '',
+			serviceId: serviceId || '',
+		},
+		{
+			query: {
+				enabled: !!serviceId && !!cloudAccountId,
+				select: (response): ServiceDetailsData => response.data,
+			},
+		},
+	);
+
+	const {
+		queryKey: _readOnlyServiceQueryKey,
+		data: readOnlyServiceData,
+		isLoading: isReadOnlyServiceLoading,
 	} = useGetService(
 		{
 			cloudProvider: type,
 			serviceId: serviceId || '',
 		},
-		{
-			...serviceQueryParams,
-		},
+		undefined,
 		{
 			query: {
-				enabled: !!serviceId,
+				enabled: !!serviceId && !cloudAccountId,
 				select: (response): ServiceDetailsData => response.data,
 			},
 		},
 	);
+
+	const serviceDetailsData = cloudAccountId
+		? accountServiceData
+		: readOnlyServiceData;
+	const isServiceDetailsLoading = cloudAccountId
+		? isAccountServiceLoading
+		: isReadOnlyServiceLoading;
 
 	const integrationConfig =
 		type === IntegrationType.AWS_SERVICES
@@ -272,16 +293,11 @@ function ServiceDetails({
 								},
 							);
 
-							invalidateGetService(
-								queryClient,
-								{
-									cloudProvider: type,
-									serviceId,
-								},
-								{
-									cloud_integration_id: cloudAccountId,
-								},
-							);
+							invalidateGetAccountService(queryClient, {
+								cloudProvider: type,
+								id: cloudAccountId,
+								serviceId,
+							});
 
 							invalidateListServicesMetadata(
 								queryClient,


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
this is a follow up pr for https://github.com/SigNoz/signoz/pull/11497 

Switches
  the service-details view from the provider-level `getService` endpoint to
  the new account-scoped `getAccountService` endpoint
  (`/api/v1/cloud_integrations/{provider}/accounts/{id}/services/{serviceId}`),
  while keeping the provider-level endpoint as a fallback for the
  read-only/pre-connection view.


**What changes** (single file: `ServiceDetails.tsx`)

  1. **Two queries, one active at a time.**
     - `useGetAccountService({ cloudProvider, id: cloudAccountId, serviceId })`
       — enabled only when both `serviceId` *and* `cloudAccountId` are present.
       This is the path users hit once an AWS account is connected.
     - `useGetService({ cloudProvider, serviceId })` — enabled only when
       `serviceId` is set but `cloudAccountId` is **not**. This keeps the
       pre-connection / read-only marketing view working with the existing
       provider-level endpoint.

  2. **Pick-the-right-result wiring.** `serviceDetailsData` and
     `isServiceDetailsLoading` are now selected based on `cloudAccountId`, so
     the component sees a single source of truth regardless of which query
     actually ran.

  3. **Invalidation updated.** On service-config save, the success path now
     calls `invalidateGetAccountService(queryClient, { cloudProvider, id,
     serviceId })` so the account-scoped cache entry is the one that gets
     refreshed (the previous `invalidateGetService` + `cloud_integration_id`
     query param no longer matches the cache key).


for this the generated type where already updated in backend PR 

for frontend changes 
#### Screenshots / Screen Recordings (if applicable)

prev - 

<img width="915" height="1033" alt="image" src="https://github.com/user-attachments/assets/c468b4d0-2571-42b0-a475-6fee0a96aa23" />


now - 
<img width="1706" height="981" alt="image" src="https://github.com/user-attachments/assets/f97d2fa7-fe61-487a-94ac-6a980d1d5c33" />



#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

#### Fix Strategy
> How does this PR address the root cause?

---

### 🧪 Testing Strategy

have tested these changes manully

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix / Maintenance |
| Description | User-facing summary |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

  - The two `useQuery` hooks are intentionally gated so only one is active
  - Pairs with #11569 (services-list switch). Both move different parts of
    the cloud-integrations UI onto the account-scoped endpoints.

---
