### PR TITLE
chore(dashboard): remove obsolete Sentry query-range timeout warning

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCard/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/index.tsx
@@ -1,7 +1,6 @@
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { useDispatch, useSelector } from 'react-redux';
-import * as Sentry from '@sentry/react';
 import logEvent from 'api/common/logEvent';
 import { DEFAULT_ENTITY_VERSION, ENTITY_VERSION_V5 } from 'constants/app';
 import { QueryParams } from 'constants/query';
@@ -67,20 +66,6 @@ function GridCardGraph({
 	const [errorMessage, setErrorMessage] = useState<string>();
 	const [isInternalServerError, setIsInternalServerError] =
 		useState<boolean>(false);
-	const queryRangeCalledRef = useRef(false);
-
-	useEffect(() => {
-		const timeoutId = setTimeout(() => {
-			if (!queryRangeCalledRef.current) {
-				Sentry.captureEvent({
-					message: `Dashboard query range not called within expected timeframe for widget ${widget?.id}`,
-					level: 'warning',
-				});
-			}
-		}, 120000);
-		return (): void => clearTimeout(timeoutId);
-	}, [widget?.id]);
-
 	const {
 		minTime,
 		maxTime,
@@ -271,14 +256,12 @@ function GridCardGraph({
 						});
 					}
 				}
-				queryRangeCalledRef.current = true;
 			},
 			onSettled: (data) => {
 				dataAvailable?.(
 					isDataAvailableByPanelType(data?.payload?.data, widget?.panelTypes),
 				);
 				getGraphData?.(data?.payload?.data);
-				queryRangeCalledRef.current = true;
 			},
 		},
 	);


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Removes a debug-only `useEffect` in `GridCardGraph` that captured a Sentry **warning** event when a widget's query range was not called within 120s. This instrumentation was added to investigate a specific dashboard query-range issue and is no longer required, so it's removed along with the supporting `queryRangeCalledRef` and the now-unused `@sentry/react` import.

#### Issues closed by this PR
Closes [#5217](https://github.com/SigNoz/engineering-pod/issues/5217)

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
- Tests added/updated: none (pure dead-code removal)
- Manual verification: `pnpm tsgo --noEmit` and `pnpm oxlint` pass; no remaining references to `queryRangeCalledRef` or `Sentry` in the file. `useEffect` / `useRef` imports retained (still used elsewhere in the file).

---

### ⚠️ Risk & Impact Assessment
- Blast radius: single file (`GridCard/index.tsx`); only removes a Sentry warning emitter.
- Potential regressions: none expected — the removed code had no functional/UI effect, only telemetry.
- Rollback plan: revert this commit.