### PR TITLE
fix(frontend): always show SigNoz version in sidebar header

### DIFF
--- a/frontend/src/container/SideNav/SideNav.styles.scss
+++ b/frontend/src/container/SideNav/SideNav.styles.scss
@@ -32,9 +32,8 @@
 
 	.brand-company-meta {
 		display: flex;
-		flex-direction: column;
 		align-items: center;
-		gap: 4px;
+		gap: 6px;
 		flex-shrink: 0;
 		width: 100%;
 		justify-content: center;
@@ -49,8 +48,7 @@
 		overflow: hidden;
 
 		gap: 32px;
-		height: auto;
-		min-height: 32px;
+		height: 32px;
 		width: 100%;
 
 		.brand-logo {
@@ -83,12 +81,11 @@
 		}
 
 		.brand-title-section {
-			display: flex;
+			display: none;
 			flex-shrink: 0;
 			align-items: center;
 			gap: 0;
 			position: relative;
-			max-width: 100%;
 
 			.license-type {
 				display: flex;
@@ -704,13 +701,16 @@
 		}
 
 		.brand {
-			height: 32px;
 			justify-content: flex-start;
 
 			.brand-company-meta {
-				flex-direction: row;
 				justify-content: flex-start;
 				width: 100%;
+			}
+
+			.brand-title-section {
+				display: flex;
+				align-items: center;
 			}
 		}
 
@@ -882,13 +882,16 @@
 		}
 
 		.brand {
-			height: 32px;
 			justify-content: flex-start;
 
 			.brand-company-meta {
-				flex-direction: row;
 				justify-content: flex-start;
 				width: 100%;
+			}
+
+			.brand-title-section {
+				display: flex;
+				align-items: center;
 			}
 		}
 

--- a/frontend/src/container/SideNav/SideNav.styles.scss
+++ b/frontend/src/container/SideNav/SideNav.styles.scss
@@ -32,8 +32,9 @@
 
 	.brand-company-meta {
 		display: flex;
+		flex-direction: column;
 		align-items: center;
-		gap: 6px;
+		gap: 4px;
 		flex-shrink: 0;
 		width: 100%;
 		justify-content: center;
@@ -48,7 +49,8 @@
 		overflow: hidden;
 
 		gap: 32px;
-		height: 32px;
+		height: auto;
+		min-height: 32px;
 		width: 100%;
 
 		.brand-logo {
@@ -81,11 +83,12 @@
 		}
 
 		.brand-title-section {
-			display: none;
+			display: flex;
 			flex-shrink: 0;
 			align-items: center;
 			gap: 0;
 			position: relative;
+			max-width: 100%;
 
 			.license-type {
 				display: flex;
@@ -119,6 +122,10 @@
 
 				border-radius: 0px 4px 4px 0px;
 				background: var(--l3-background);
+
+				&.version-container-standalone {
+					border-radius: 4px;
+				}
 			}
 
 			.version {
@@ -697,16 +704,13 @@
 		}
 
 		.brand {
+			height: 32px;
 			justify-content: flex-start;
 
 			.brand-company-meta {
+				flex-direction: row;
 				justify-content: flex-start;
 				width: 100%;
-			}
-
-			.brand-title-section {
-				display: flex;
-				align-items: center;
 			}
 		}
 
@@ -878,16 +882,13 @@
 		}
 
 		.brand {
+			height: 32px;
 			justify-content: flex-start;
 
 			.brand-company-meta {
+				flex-direction: row;
 				justify-content: flex-start;
 				width: 100%;
-			}
-
-			.brand-title-section {
-				display: flex;
-				align-items: center;
 			}
 		}
 

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -1010,7 +1010,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 								<img src={signozBrandLogoUrl} alt="SigNoz" />
 							</div>
 
-							{licenseTag && (
+							{(licenseTag || currentVersion) && (
 								<div
 									className={cx(
 										'brand-title-section',
@@ -1021,7 +1021,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 											'version-update-notification',
 									)}
 								>
-									<span className="license-type"> {licenseTag} </span>
+									{licenseTag && <span className="license-type"> {licenseTag} </span>}
 
 									{currentVersion && (
 										<Tooltip
@@ -1043,7 +1043,12 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 												)
 											}
 										>
-											<div className="version-container">
+											<div
+												className={cx(
+													'version-container',
+													!licenseTag && 'version-container-standalone',
+												)}
+											>
 												<span
 													className={cx('version', changelog && 'version-clickable')}
 													onClick={onClickVersionHandler}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The SigNoz version badge in the left sidebar header was intermittently missing when users expanded the sidebar. It only rendered when the license type (`licenseTag`) had loaded, so the version often did not appear even after hover or pin.

This PR keeps the version in the header next to the logo and shows it when the sidebar is expanded (hovered, pinned, or dropdown open). When the sidebar is collapsed, only the SigNoz logo is shown. The version is decoupled from `licenseTag`, so it appears as soon as `currentVersion` is available. This is a minimal, UI-only fix that restores discoverability without adding new navigation surfaces.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

**Before:** Sidebar expanded but version missing when license tag had not loaded.

**After (collapsed):** Only SigNoz logo visible.

**After (expanded):** License tag and version visible next to logo.

_Add screenshots or a short screen recording showing collapsed vs expanded sidebar states._

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes #11454

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

The header version was wrapped in `{licenseTag && (...)}`, so it did not render while license info was loading or unavailable. Users who expanded the sidebar still could not see the version in those cases.

#### Fix Strategy
> How does this PR address the root cause?

- Show the header version when `currentVersion` is available, independent of `licenseTag`
- Keep version hidden when sidebar is collapsed (logo only)
- Show version in `.brand-title-section` when sidebar is expanded (pinned, hovered, or dropdown open)
- Add `.version-container-standalone` styling when only the version badge is shown (no license tag)

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A
- Manual verification:
  - Sidebar collapsed — only SigNoz logo visible, no version badge
  - Sidebar expanded (hover/pin) — version visible next to logo
  - Version visible before `licenseTag` loads on expansion
  - Confirmed no version in bottom nav or Help & Support menu
- Edge cases covered:
  - Version-only display when license tag is absent
  - Collapsed vs expanded sidebar states
  - Changelog update notification dot on expanded sidebar

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: `SideNav.tsx`, `SideNav.styles.scss` only
- Potential regressions: Header layout/spacing when sidebar expands; version badge truncation with long version strings
- Rollback plan: Revert the two SideNav files

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | SigNoz version is now visible in the sidebar header when the sidebar is expanded |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Scope is limited to the header badge only — no bottom-nav or Help & Support menu changes
- Collapsed sidebar intentionally shows logo only; version appears on expansion
- Main files: `frontend/src/container/SideNav/SideNav.tsx`, `frontend/src/container/SideNav/SideNav.styles.scss`
- Please verify expanded sidebar header layout and version visibility when license API is slow

---