### PR TITLE
fix(infra): use hostname instead of host.name

### DIFF
--- a/frontend/src/container/InfraMonitoringHosts/Hosts.tsx
+++ b/frontend/src/container/InfraMonitoringHosts/Hosts.tsx
@@ -117,8 +117,8 @@ function Hosts(): JSX.Element {
 
 	const getInitialLogTracesFilters = useCallback(
 		(host: import('api/infraMonitoring/getHostLists').HostData) =>
-			hostInitialLogTracesFilter(host, dotMetricsEnabled),
-		[dotMetricsEnabled],
+			hostInitialLogTracesFilter(host),
+		[],
 	);
 
 	const controlListPrefix = !showFilters ? (

--- a/frontend/src/container/InfraMonitoringHosts/constants.tsx
+++ b/frontend/src/container/InfraMonitoringHosts/constants.tsx
@@ -120,12 +120,8 @@ export function hostGetSelectedItemFilters(
 	};
 }
 
-export function hostInitialLogTracesFilter(
-	host: HostData,
-	dotMetricsEnabled: boolean,
-): TagFilterItem[] {
-	const hostKey = dotMetricsEnabled ? 'host.name' : 'host_name';
-	return [createFilterItem(hostKey, host.hostName || '')];
+export function hostInitialLogTracesFilter(host: HostData): TagFilterItem[] {
+	return [createFilterItem('hostname', host.hostName || '')];
 }
 
 export function hostInitialEventsFilter(_host: HostData): TagFilterItem[] {


### PR DESCRIPTION
## Pull Request

---
#### Issues closed by this PR
> #11314

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> That helper reused metrics attribute keys (`host.name` or `host_name`, depending on the dot-metrics flag). Logs and traces use `hostname` instead, so queries like `host.name = "my-host"` returned no results and showed a `“key not found”` error.

#### Fix Strategy
> How does this PR address the root cause?

---

### 🧪 Testing Strategy
> Use `hostname` for the logs/traces filter. Metrics filtering (`hostGetSelectedItemFilters`) is unchanged and still correctly uses `host.name / host_name`.


---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

After this change:

 - The Logs tab on a host detail drawer should show logs for that host.
 - The compass button to open Logs Explorer should query `hostname = "<host>"` instead of `host.name`.


---

Fixes #11314 