### PR TITLE
fix(frontend): dropdown menu rendering behind antd drawer/modal (z-index regression)

### DIFF
--- a/frontend/src/container/LogDetailedView/BodyTitleRenderer.tsx
+++ b/frontend/src/container/LogDetailedView/BodyTitleRenderer.tsx
@@ -225,7 +225,7 @@ function BodyTitleRenderer({
 						<DropdownMenuTrigger asChild>
 							<Settings style={{ marginRight: 8 }} className="hover-reveal" />
 						</DropdownMenuTrigger>
-						<DropdownMenuContent>
+						<DropdownMenuContent align="start">
 							<div data-log-detail-ignore="true">
 								{menuItems.map((item) => (
 									<DropdownMenuItem

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -826,4 +826,10 @@ body.ai-assistant-panel-open {
 :root {
 	--input-focus-outline-width: 0;
 	--radius-2: 4px;
+
+	// @signozhq/ui dropdown content portals to body with a default z-index of 50,
+	// antd defines it at z-index of 1050. Keeping this till we have components from both
+	// design libraries.
+	--dropdown-menu-content-z-index: 1050;
+	--dropdown-menu-sub-content-z-index: 1050;
 }


### PR DESCRIPTION
## Summary

Fixes SigNoz/platform-pod#2452 — in the log details drawer, the gear menu on body JSON keys (Filter for / Filter out / Group by) opens invisibly behind the drawer, making per-key filtering on JSON log bodies unusable.

## Root cause

SigNoz/signoz#11400 migrated the antd `Dropdown` in `BodyTitleRenderer` to `@signozhq/ui/dropdown-menu`. The new menu portals to `document.body` with the design-system default `--dropdown-menu-content-z-index: 50`, which renders behind antd overlays (Drawer/Modal at `z-index: 1000`). antd's own dropdowns never had this problem because they sit at `1050` (`zIndexPopupBase: 1000` + 50).

A codebase audit found a second instance of the same regression: the dashboards/alert-rules dropdowns in the Metrics Explorer metric-details drawer (`DashboardsAndAlertsPopover`).

## Fix

One global change instead of per-instance patches: align the design-system dropdown layer with the app's documented z-index scale (see the chart in `styles.scss` — drawer 1000, dropdown 1050) by setting in the existing `:root` overrides block:

```scss
--dropdown-menu-content-z-index: 1050;
--dropdown-menu-sub-content-z-index: 1050;
```

This fixes both known instances and any design-system dropdown rendered inside an antd Drawer/Modal, now and in the future.

### Why this is safe

- These vars are consumed only by the `@signozhq/ui` dropdown content/sub-content; nothing else reads them.
- Radix dropdowns are modal — outside `pointerdown` closes them — so an open menu never coexists with interaction on another overlay.
- Existing scoped overrides still win over `:root` (element-level custom properties: DataViewer/PrettyView at 1000, TraceOptionsMenu at 1100) — zero behavior change there.
- Relative order matches what antd dropdowns (1050) have always done in this app: below tooltips (1070) and notifications (2050), above drawer/modal/popover/intercom.

Follow-up (separate ticket): unify the overlay z-index scale between antd and `@signozhq/ui` via seed + offset tokens and fix the package defaults (`dialog` hardcodes 50; `select`/`popover`/`combobox` have no z-index hooks).


##Screenshots/Recording
**Before**
Logs body

https://github.com/user-attachments/assets/becf94aa-e963-46d9-9c37-016f65030dc7


Metrics explorer dashboard/alert pills do not show dropdown


https://github.com/user-attachments/assets/d50f4414-d617-4102-afc1-f687a98f8655



**After**
Logs body


https://github.com/user-attachments/assets/a5fdf44b-0b8a-436b-a3db-fcfebb9e6f2b



Metrics explorer 

https://github.com/user-attachments/assets/9cad21b5-8c72-4217-bb6e-c1761149f9dd




## Testing

- Logs explorer → log details drawer → JSON body tree → gear on a key → menu now renders above the drawer; Filter for / Filter out / Group by work.
- Metrics explorer → metric details drawer → "N dashboards" / "N alert rules" chips → list renders above the drawer.
- Regression pass on page-level dropdowns (dashboard list actions, alert list actions, widget header menu) — unchanged.
