### PR TITLE
fix(web): app crash when web speech api access throws

### DIFF
--- a/frontend/src/container/AIAssistant/hooks/useSpeechRecognition.ts
+++ b/frontend/src/container/AIAssistant/hooks/useSpeechRecognition.ts
@@ -40,13 +40,31 @@ type SpeechRecognitionConstructor = new () => ISpeechRecognition;
 
 // ── Vendor-prefix shim for Safari / older browsers ────────────────────────────
 
-const SpeechRecognitionAPI: SpeechRecognitionConstructor | null =
-	typeof window !== 'undefined'
-		? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-			((window as any).SpeechRecognition ??
+// Some hardened/enterprise browsers install a getter
+// on window.SpeechRecognition that THROWS on access ("Web Speech API is disabled
+// due to your security policy") instead of leaving the property undefined.
+// Because this resolves at module-evaluation time, an uncaught throw here aborts
+// the entire bundle and the app renders a blank page. Read defensively so a
+// throwing getter degrades to "unsupported" rather than crashing the app.
+function resolveSpeechRecognitionAPI(): SpeechRecognitionConstructor | null {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+	try {
+		return (
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(window as any).SpeechRecognition ??
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(window as any).webkitSpeechRecognition ??
-			null)
-		: null;
+			null
+		);
+	} catch {
+		return null;
+	}
+}
+
+const SpeechRecognitionAPI: SpeechRecognitionConstructor | null =
+	resolveSpeechRecognitionAPI();
 
 export type SpeechRecognitionError =
 	| 'not-supported'


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

`useSpeechRecognition.ts` reads `window.SpeechRecognition` / `window.webkitSpeechRecognition` at module-evaluation time. The `??` null guards against the API being absent, but some hardened/enterprise browsers install a getter that throws on access ("Web Speech API is disabled due to your security policy"). 

Because the read is at module top level, the uncaught throw aborts bundle evaluation and the entire app renders a blank page. This wraps the access in try/catch so a throwing getter degrades to "unsupported" (feature-detection best practice) instead of crashing.


#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Reproduction steps: Open SigNoz in the a hardened browser → blank page + uncaught error:

`Web Speech API is disabled at useSpeechRecognition.ts:46`

<img width="541" height="79" alt="image" src="https://github.com/user-attachments/assets/91d742fa-99d5-4127-b2e3-1b179a93a1b5" />


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes #11617

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

Browser edge case

#### Fix Strategy
> How does this PR address the root cause?

Allows the check to fail gracefully when the Web Speech API isn't available due to security requirements.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Web Speech Feature
- Potential regressions: -
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud |
| Change Type | Bug Fix |
| Description | For more hardened browsers, the home would appear blank due to access to a property that could generate an error without proper error handling. |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
