### PR TITLE
fix(frontend): size Metrics Explorer treemap from container width

### DIFF
--- a/frontend/src/container/MetricsExplorer/Summary/MetricsTreemap.tsx
+++ b/frontend/src/container/MetricsExplorer/Summary/MetricsTreemap.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useMemo } from 'react';
-import { useWindowSize } from 'react-use';
+import { useCallback, useMemo, useRef } from 'react';
 import { Group } from '@visx/group';
 import { Treemap } from '@visx/hierarchy';
 import { Empty, Select, Skeleton, Tooltip } from 'antd';
@@ -7,6 +6,7 @@ import { Typography } from '@signozhq/ui/typography';
 import { MetricsexplorertypesTreemapModeDTO } from 'api/generated/services/sigNoz.schemas';
 import ErrorInPlace from 'components/ErrorInPlace/ErrorInPlace';
 import { HierarchyNode, stratify, treemapBinary } from 'd3-hierarchy';
+import { useResizeObserver } from 'hooks/useDimensions';
 import { Info } from '@signozhq/icons';
 
 import {
@@ -33,17 +33,9 @@ function MetricsTreemapInternal({
 	data,
 	viewType,
 	openMetricDetails,
+	containerWidth,
 }: MetricsTreemapInternalProps): JSX.Element {
-	const { width: windowWidth } = useWindowSize();
-
-	const treemapWidth = useMemo(
-		() =>
-			Math.max(
-				windowWidth - TREEMAP_MARGINS.LEFT - TREEMAP_MARGINS.RIGHT - 70,
-				300,
-			),
-		[windowWidth],
-	);
+	const treemapWidth = useMemo(() => Math.max(containerWidth, 300), [containerWidth]);
 
 	const treemapData = useMemo(() => {
 		const extracedTreemapData =
@@ -185,6 +177,9 @@ function MetricsTreemap({
 	openMetricDetails,
 	setHeatmapView,
 }: MetricsTreemapProps): JSX.Element {
+	const treemapContainerRef = useRef<HTMLDivElement>(null);
+	const { width: containerWidth } = useResizeObserver(treemapContainerRef);
+
 	return (
 		<div
 			className="metrics-treemap-container"
@@ -207,14 +202,17 @@ function MetricsTreemap({
 					disabled={isLoading}
 				/>
 			</div>
-			<MetricsTreemapInternal
-				isLoading={isLoading}
-				isError={isError}
-				error={error}
-				data={data}
-				viewType={viewType}
-				openMetricDetails={openMetricDetails}
-			/>
+			<div className="metrics-treemap-content" ref={treemapContainerRef}>
+				<MetricsTreemapInternal
+					isLoading={isLoading}
+					isError={isError}
+					error={error}
+					data={data}
+					viewType={viewType}
+					openMetricDetails={openMetricDetails}
+					containerWidth={containerWidth}
+				/>
+			</div>
 		</div>
 	);
 }

--- a/frontend/src/container/MetricsExplorer/Summary/Summary.styles.scss
+++ b/frontend/src/container/MetricsExplorer/Summary/Summary.styles.scss
@@ -212,6 +212,11 @@
 		margin-right: -12px;
 	}
 
+	.metrics-treemap-content {
+		width: 100%;
+		min-width: 0;
+	}
+
 	.no-metrics-message-container {
 		display: flex;
 		flex-direction: column;

--- a/frontend/src/container/MetricsExplorer/Summary/__tests__/MetricsTreemap.test.tsx
+++ b/frontend/src/container/MetricsExplorer/Summary/__tests__/MetricsTreemap.test.tsx
@@ -22,8 +22,8 @@ jest.mock('d3-hierarchy', () => ({
 	}),
 	treemapBinary: jest.fn(),
 }));
-jest.mock('react-use', () => ({
-	useWindowSize: jest.fn().mockReturnValue({ width: 1000, height: 1000 }),
+jest.mock('hooks/useDimensions', () => ({
+	useResizeObserver: jest.fn().mockReturnValue({ width: 640, height: 400 }),
 }));
 
 const mockData = [

--- a/frontend/src/container/MetricsExplorer/Summary/types.ts
+++ b/frontend/src/container/MetricsExplorer/Summary/types.ts
@@ -57,6 +57,7 @@ export interface MetricsTreemapInternalProps {
 	error?: APIError;
 	data: MetricsexplorertypesTreemapResponseDTO | undefined;
 	viewType: MetricsexplorertypesTreemapModeDTO;
+	containerWidth: number;
 	openMetricDetails: (
 		metricName: string,
 		view: 'list' | 'treemap',


### PR DESCRIPTION
## Summary
- measure the Metrics Explorer treemap from its rendered container instead of the full window width
- keep the treemap responsive when the sidebar changes the available content width
- update the treemap test to mock the resize observer based sizing path

## Testing
- pnpm test -- --runTestsByPath src/container/MetricsExplorer/Summary/__tests__/MetricsTreemap.test.tsx --runInBand

Closes #9120