### PR TITLE
fix(traces): prevent premature waterfall ellipsis

### DIFF
--- a/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
+++ b/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
@@ -53,6 +53,7 @@ import { EventTooltipContent } from '../../../SpanHoverCard/EventTooltipContent'
 import { SpanHoverCard } from '../../../SpanHoverCard/SpanHoverCard';
 import AddSpanToFunnelModal from '../../AddSpanToFunnelModal/AddSpanToFunnelModal';
 import { IInterestedSpan } from '../../types';
+import { getTraceWaterfallSidebarContentWidth } from '../../utils';
 
 import styles from './Success.module.scss';
 
@@ -137,7 +138,6 @@ const LazyEventDotPopover = memo(function LazyEventDotPopover({
 
 // css config
 const CONNECTOR_WIDTH = 30;
-const VERTICAL_CONNECTOR_WIDTH = 1;
 
 interface SpanStateClasses {
 	isSelected: boolean;
@@ -494,7 +494,6 @@ const WATERFALL_BOTTOM_PADDING = 24;
 const DEFAULT_SIDEBAR_WIDTH = 450;
 const MIN_SIDEBAR_WIDTH = 240;
 const MAX_SIDEBAR_WIDTH = 900;
-const BASE_CONTENT_WIDTH = 300;
 
 function Success(props: ISuccessProps): JSX.Element {
 	const {
@@ -747,14 +746,9 @@ function Success(props: ISuccessProps): JSX.Element {
 
 	// Compute max content width for sidebar horizontal scroll
 	const maxContentWidth = useMemo(() => {
-		if (spans.length === 0) {
-			return sidebarWidth;
-		}
-		const maxLevel = spans.reduce((max, span) => Math.max(max, span.level), 0);
-		return Math.max(
-			sidebarWidth,
-			maxLevel * (CONNECTOR_WIDTH + VERTICAL_CONNECTOR_WIDTH) + BASE_CONTENT_WIDTH,
-		);
+		return getTraceWaterfallSidebarContentWidth(spans, sidebarWidth, {
+			indentWidthPerLevel: CONNECTOR_WIDTH,
+		});
 	}, [spans, sidebarWidth]);
 
 	// Scroll a span to viewport center if it isn't already visible. Shared by

--- a/frontend/src/pages/TraceDetailsV3/TraceWaterfall/__tests__/getVisibleSpans.test.ts
+++ b/frontend/src/pages/TraceDetailsV3/TraceWaterfall/__tests__/getVisibleSpans.test.ts
@@ -1,6 +1,10 @@
 import { SpanV3 } from 'types/api/trace/getTraceV3';
 
-import { getAncestorSpanIds, getVisibleSpans } from '../utils';
+import {
+	getAncestorSpanIds,
+	getTraceWaterfallSidebarContentWidth,
+	getVisibleSpans,
+} from '../utils';
 
 function makeSpan(
 	overrides: Partial<SpanV3> & { span_id: string; level: number },
@@ -267,5 +271,91 @@ describe('getAncestorSpanIds', () => {
 	it('returns empty set for unknown span', () => {
 		const spans = [makeSpan({ span_id: 'root', level: 0 })];
 		expect(getAncestorSpanIds(spans, 'unknown').size).toBe(0);
+	});
+});
+
+describe('getTraceWaterfallSidebarContentWidth', () => {
+	const originalCreateElement = document.createElement.bind(document);
+
+	beforeEach(() => {
+		document.createElement = ((tagName: string): HTMLElement => {
+			const element = originalCreateElement(tagName);
+			if (tagName.toLowerCase() === 'canvas') {
+				(element as HTMLCanvasElement).getContext = (() =>
+					({
+						font: '',
+						measureText: (text: string): TextMetrics =>
+							({ width: text.length * 10 }) as TextMetrics,
+					} as CanvasRenderingContext2D)) as unknown as HTMLCanvasElement['getContext'];
+			}
+			return element;
+		}) as typeof document.createElement;
+	});
+
+	afterEach(() => {
+		document.createElement = originalCreateElement;
+	});
+
+	it('returns the sidebar width when there are no spans', () => {
+		expect(
+			getTraceWaterfallSidebarContentWidth([], 450, {
+				indentWidthPerLevel: 30,
+			}),
+		).toBe(450);
+	});
+
+	it('grows for long labels instead of relying only on nesting depth', () => {
+		const spans = [
+			makeSpan({
+				span_id: 'wide-label',
+				level: 1,
+				name: 'checkout-step-'.repeat(12),
+				'service.name': 'checkout-service',
+			}),
+			makeSpan({
+				span_id: 'deep-but-short',
+				level: 10,
+				name: 'db',
+				'service.name': 'svc',
+			}),
+		];
+
+		const width = getTraceWaterfallSidebarContentWidth(spans, 300, {
+			indentWidthPerLevel: 30,
+		});
+
+		expect(width).toBeGreaterThan(600);
+	});
+
+	it('accounts for service names in the computed row width', () => {
+		const spanWithoutServiceName = makeSpan({
+			span_id: 'without-service',
+			level: 2,
+			name: 'payment-span-name',
+			'service.name': '',
+		});
+		const spanWithServiceName = makeSpan({
+			span_id: 'with-service',
+			level: 2,
+			name: 'payment-span-name',
+			'service.name': 'payments-api-west-region',
+		});
+
+		const widthWithoutServiceName = getTraceWaterfallSidebarContentWidth(
+			[spanWithoutServiceName],
+			240,
+			{
+				indentWidthPerLevel: 30,
+			},
+		);
+		const widthWithServiceName = getTraceWaterfallSidebarContentWidth(
+			[spanWithServiceName],
+			240,
+			{
+				indentWidthPerLevel: 30,
+			},
+		);
+
+		expect(widthWithServiceName).toBeGreaterThan(widthWithoutServiceName);
 	});
 });

--- a/frontend/src/pages/TraceDetailsV3/TraceWaterfall/utils.ts
+++ b/frontend/src/pages/TraceDetailsV3/TraceWaterfall/utils.ts
@@ -1,5 +1,38 @@
 import { SpanV3 } from 'types/api/trace/getTraceV3';
 
+type TraceWaterfallSidebarWidthOptions = {
+	indentWidthPerLevel: number;
+};
+
+const TREE_ARROW_SLOT_WIDTH = 18;
+const TREE_SUBTREE_COUNT_SLOT_WIDTH = 34;
+const TREE_ICON_TOTAL_WIDTH = 19;
+const TREE_SERVICE_NAME_GAP_WIDTH = 18;
+const TREE_ROW_ACTIONS_WIDTH = 64;
+const TREE_CONTENT_PADDING_WIDTH = 32;
+const TREE_FALLBACK_CHAR_WIDTH = 7.5;
+
+function measureTraceWaterfallTextWidth(text: string): number {
+	if (!text) {
+		return 0;
+	}
+
+	if (typeof document === 'undefined') {
+		return text.length * TREE_FALLBACK_CHAR_WIDTH;
+	}
+
+	const canvas = document.createElement('canvas');
+	const context = canvas.getContext('2d');
+
+	if (!context) {
+		return text.length * TREE_FALLBACK_CHAR_WIDTH;
+	}
+
+	context.font = '400 13px Inter';
+
+	return context.measureText(text).width;
+}
+
 /**
  * Computes the visible spans from a complete span list based on collapse state.
  *
@@ -59,4 +92,34 @@ export function getAncestorSpanIds(
 	}
 
 	return ancestors;
+}
+
+export function getTraceWaterfallSidebarContentWidth(
+	allSpans: SpanV3[],
+	sidebarWidth: number,
+	{ indentWidthPerLevel }: TraceWaterfallSidebarWidthOptions,
+): number {
+	if (allSpans.length === 0) {
+		return sidebarWidth;
+	}
+
+	const maxSpanWidth = allSpans.reduce((currentMax, span) => {
+		const baseWidth =
+			span.level * indentWidthPerLevel +
+			TREE_ARROW_SLOT_WIDTH +
+			TREE_SUBTREE_COUNT_SLOT_WIDTH +
+			TREE_ICON_TOTAL_WIDTH +
+			TREE_ROW_ACTIONS_WIDTH +
+			TREE_CONTENT_PADDING_WIDTH;
+
+		const labelWidth = measureTraceWaterfallTextWidth(span.name);
+		const serviceNameWidth = span['service.name']
+			? TREE_SERVICE_NAME_GAP_WIDTH +
+				measureTraceWaterfallTextWidth(span['service.name'])
+			: 0;
+
+		return Math.max(currentMax, Math.ceil(baseWidth + labelWidth + serviceNameWidth));
+	}, sidebarWidth);
+
+	return Math.max(sidebarWidth, maxSpanWidth);
 }


### PR DESCRIPTION
## Summary
- replace the Trace Waterfall sidebar's depth-only width estimate with a content-aware width calculation that measures span and service labels
- reuse that helper in `TraceDetailsV3` so large traces can scroll horizontally instead of truncating span names too early
- add regression coverage for empty input, long labels, and service-name width contribution

## Root Cause
The virtualized waterfall sidebar sized itself mostly from nesting depth, so rows with long span names or service names still got ellipsized even when horizontal scrolling space should have been available.

## Validation
- `pnpm exec jest --runInBand --testMatch "**/getVisibleSpans.test.ts"`
- `pnpm exec jest --runInBand --testMatch "**/SpanDuration.test.tsx"`
- `pnpm exec jest --runInBand --testMatch "**/UnifiedSpanClick.test.tsx"`
- `pnpm tsgo --noEmit`
- `pnpm build`
- `pnpm oxlint src/pages/TraceDetailsV3/TraceWaterfall/utils.ts src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx src/pages/TraceDetailsV3/TraceWaterfall/__tests__/getVisibleSpans.test.ts --threads 1`

## Notes
- `pnpm lint:js --quiet` hit a local Windows `tsgolint` out-of-memory failure, so the touched files were validated with `oxlint` directly instead.

Closes #11572
