### PR TITLE
feat(auth): add back to login CTA on reset password token error screen

### DIFF
--- a/frontend/src/container/ResetPassword/ResetPassword.styles.scss
+++ b/frontend/src/container/ResetPassword/ResetPassword.styles.scss
@@ -142,6 +142,15 @@
 		}
 	}
 
+	.reset-password-back-action {
+		margin-top: var(--spacing-12);
+		width: 100%;
+
+		button {
+			width: 100%;
+		}
+	}
+
 	@media (max-width: 768px) {
 		width: 100%;
 		padding: 0 16px;

--- a/frontend/src/container/ResetPassword/TokenError.tsx
+++ b/frontend/src/container/ResetPassword/TokenError.tsx
@@ -1,7 +1,10 @@
-import { CircleAlert } from '@signozhq/icons';
+import { ArrowLeft, CircleAlert } from '@signozhq/icons';
+import { Button } from '@signozhq/ui/button';
 import { Typography } from '@signozhq/ui/typography';
 import AuthError from 'components/AuthError/AuthError';
 import AuthPageContainer from 'components/AuthPageContainer';
+import ROUTES from 'constants/routes';
+import history from 'lib/history';
 import APIError from 'types/api/error';
 
 import './ResetPassword.styles.scss';
@@ -59,6 +62,16 @@ function TokenError({ error }: TokenErrorProps): JSX.Element {
 					</Typography.Text>
 				</div>
 				{error && <AuthError error={error} />}
+				<div className="reset-password-back-action">
+					<Button
+						variant="solid"
+						data-testid="back-to-login"
+						prefix={<ArrowLeft size={12} />}
+						onClick={(): void => history.push(ROUTES.LOGIN)}
+					>
+						Back to login
+					</Button>
+				</div>
 			</div>
 		</AuthPageContainer>
 	);

--- a/frontend/src/pages/ResetPassword/__tests__/ResetPasswordPage.test.tsx
+++ b/frontend/src/pages/ResetPassword/__tests__/ResetPasswordPage.test.tsx
@@ -2,7 +2,7 @@ import { Logout } from 'api/utils';
 import ROUTES from 'constants/routes';
 import history from 'lib/history';
 import { createErrorResponse, rest, server } from 'mocks-server/server';
-import { render, screen, waitFor } from 'tests/test-utils';
+import { render, screen, waitFor, fireEvent } from 'tests/test-utils';
 
 import ResetPassword from '../index';
 
@@ -103,6 +103,7 @@ describe('ResetPassword Page', () => {
 			expect(
 				screen.getByText(/reset password token does not exist/i),
 			).toBeInTheDocument();
+			expect(screen.getByTestId('back-to-login')).toBeInTheDocument();
 		});
 
 		it('shows "token is expired" when token is expired (401) without redirecting to login', async () => {
@@ -137,6 +138,32 @@ describe('ResetPassword Page', () => {
 			// 401 from this endpoint must NOT trigger logout/redirect
 			expect(mockHistoryPush).not.toHaveBeenCalledWith(ROUTES.LOGIN);
 			expect(Logout).not.toHaveBeenCalled();
+			expect(screen.getByTestId('back-to-login')).toBeInTheDocument();
+		});
+
+		it('navigates to login when "Back to login" is clicked on error screen', async () => {
+			server.use(
+				rest.post(
+					VERIFY_TOKEN_ENDPOINT,
+					createErrorResponse(
+						404,
+						'reset_password_token_not_found',
+						'reset password token does not exist',
+					),
+				),
+			);
+
+			window.history.pushState({}, '', '/password-reset?token=invalid-token');
+			render(<ResetPassword />, undefined, {
+				initialRoute: '/password-reset?token=invalid-token',
+			});
+
+			await waitFor(() => {
+				expect(screen.getByTestId('back-to-login')).toBeInTheDocument();
+			});
+
+			fireEvent.click(screen.getByTestId('back-to-login'));
+			expect(mockHistoryPush).toHaveBeenCalledWith(ROUTES.LOGIN);
 		});
 
 		it('redirects to login when no token is in the URL', async () => {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The token error screen introduced in #11522 (shown when a reset password link is expired or invalid) had no way for the user to navigate away - they were blocked with no CTA.

This PR adds a **"Back to login"** button at the bottom of the `TokenError` component, giving users a clear escape path from both error states (`reset_password_token_expired` and `reset_password_token_not_found`).

#### Issues closed by this PR

- Follow-up to: https://github.com/SigNoz/platform-pod/issues/2316#issuecomment-4667099608
- Closes: https://github.com/SigNoz/platform-pod/issues/2316

---

### Image / video Demo
---

<img width="1728" height="993" alt="image" src="https://github.com/user-attachments/assets/9965bee2-0249-4378-b978-a449254e152d" />


---

### ✅ Change Type

- [x] ✨ Feature

---

### 🧪 Testing Strategy

- **Tests updated:** `src/pages/ResetPassword/__tests__/ResetPasswordPage.test.tsx`
  - Both error-state tests (`404` and `401`) now assert the back-to-login button is present
  - New test: clicking the button calls `history.push(ROUTES.LOGIN)`
- **Manual verification:** Tested on both expired and invalid token error screens
- **Edge cases covered:** Button is only on the error screen — the form screen is unaffected

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** `TokenError.tsx` only — a single presentational component
- **Potential regressions:** None; no logic changed, only a navigation button added
- **Rollback plan:** Revert this PR

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Reset password error screen now has a "Back to login" button so users aren't blocked when their reset link is expired or invalid |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- `TokenError.tsx` — only file changed in production code; adds a `Button` + `ArrowLeft` icon following the exact same pattern as `ForgotPassword`'s back button
- Uses `history` from `lib/history` (not `useNavigate`) to stay consistent with the rest of the auth flow and to respect the base path config