### PR TITLE
feat(infra-monitoring) : add useful tags for infra-monitoring `clickhouse.query_log.log_comment`

### DIFF
--- a/pkg/modules/inframonitoring/implinframonitoring/module.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/module.go
@@ -10,7 +10,9 @@ import (
 	"github.com/SigNoz/signoz/pkg/querier"
 	"github.com/SigNoz/signoz/pkg/telemetrymetrics"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
+	"github.com/SigNoz/signoz/pkg/types/ctxtypes"
 	"github.com/SigNoz/signoz/pkg/types/inframonitoringtypes"
+	"github.com/SigNoz/signoz/pkg/types/instrumentationtypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
@@ -48,6 +50,8 @@ func NewModule(
 }
 
 func (m *module) ListHosts(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableHosts) (*inframonitoringtypes.Hosts, error) {
+	ctx = m.withInfraMonitoringContext(ctx, "ListHosts")
+
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
@@ -161,6 +165,8 @@ func (m *module) ListHosts(ctx context.Context, orgID valuer.UUID, req *inframon
 }
 
 func (m *module) ListPods(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostablePods) (*inframonitoringtypes.Pods, error) {
+	ctx = m.withInfraMonitoringContext(ctx, "ListPods")
+
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
@@ -244,6 +250,8 @@ func (m *module) ListPods(ctx context.Context, orgID valuer.UUID, req *inframoni
 }
 
 func (m *module) ListNodes(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableNodes) (*inframonitoringtypes.Nodes, error) {
+	ctx = m.withInfraMonitoringContext(ctx, "ListNodes")
+
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
@@ -332,6 +340,8 @@ func (m *module) ListNodes(ctx context.Context, orgID valuer.UUID, req *inframon
 }
 
 func (m *module) ListNamespaces(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableNamespaces) (*inframonitoringtypes.Namespaces, error) {
+	ctx = m.withInfraMonitoringContext(ctx, "ListNamespaces")
+
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
@@ -414,6 +424,8 @@ func (m *module) ListNamespaces(ctx context.Context, orgID valuer.UUID, req *inf
 }
 
 func (m *module) ListClusters(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableClusters) (*inframonitoringtypes.Clusters, error) {
+	ctx = m.withInfraMonitoringContext(ctx, "ListClusters")
+
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
@@ -503,6 +515,8 @@ func (m *module) ListClusters(ctx context.Context, orgID valuer.UUID, req *infra
 }
 
 func (m *module) ListVolumes(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableVolumes) (*inframonitoringtypes.Volumes, error) {
+	ctx = m.withInfraMonitoringContext(ctx, "ListVolumes")
+
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
@@ -586,6 +600,8 @@ func (m *module) ListVolumes(ctx context.Context, orgID valuer.UUID, req *infram
 }
 
 func (m *module) ListDeployments(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableDeployments) (*inframonitoringtypes.Deployments, error) {
+	ctx = m.withInfraMonitoringContext(ctx, "ListDeployments")
+
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
@@ -674,6 +690,8 @@ func (m *module) ListDeployments(ctx context.Context, orgID valuer.UUID, req *in
 }
 
 func (m *module) ListStatefulSets(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableStatefulSets) (*inframonitoringtypes.StatefulSets, error) {
+	ctx = m.withInfraMonitoringContext(ctx, "ListStatefulSets")
+
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
@@ -764,6 +782,8 @@ func (m *module) ListStatefulSets(ctx context.Context, orgID valuer.UUID, req *i
 }
 
 func (m *module) ListJobs(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableJobs) (*inframonitoringtypes.Jobs, error) {
+	ctx = m.withInfraMonitoringContext(ctx, "ListJobs")
+
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
@@ -854,6 +874,8 @@ func (m *module) ListJobs(ctx context.Context, orgID valuer.UUID, req *inframoni
 }
 
 func (m *module) ListDaemonSets(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableDaemonSets) (*inframonitoringtypes.DaemonSets, error) {
+	ctx = m.withInfraMonitoringContext(ctx, "ListDaemonSets")
+
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
@@ -941,4 +963,13 @@ func (m *module) ListDaemonSets(ctx context.Context, orgID valuer.UUID, req *inf
 	resp.Warning = queryResp.Warning
 
 	return resp, nil
+}
+
+func (m *module) withInfraMonitoringContext(ctx context.Context, functionName string) context.Context {
+	comments := map[string]string{
+		instrumentationtypes.TelemetrySignal:  telemetrytypes.SignalMetrics.StringValue(),
+		instrumentationtypes.CodeNamespace:    "infra-monitoring",
+		instrumentationtypes.CodeFunctionName: functionName,
+	}
+	return ctxtypes.NewContextWithCommentVals(ctx, comments)
 }


### PR DESCRIPTION
## Pull Request

  ### 📄 Summary

  Instruments the v2 infra-monitoring backend module so every ClickHouse query it issues is attributable to the API endpoint that issued it.

  Adds a `withInfraMonitoringContext` helper (mirroring the existing `metricsexplorer` pattern) and calls it at the top of all 10 public `List*` methods. The tags ride the request `ctx` → get serialized into ClickHouse's `log_comment` setting → land in `system.query_log`. Because `ctx` propagates down the call chain, *every* query in a request (the main `QueryRange` + all helper queries like active-hosts / metadata / per-group counts) inherits the endpoint tag.

  Each query row now carries:
  `{"code.namespace":"infra-monitoring","code.function":"ListHosts","telemetry.signal":"metrics", ...}`

  This lets us rank infra-monitoring endpoints by p99 duration / bytes read in `system.query_log` to find which API logic is the bottleneck.

  #### Issues closed by this PR
  Part of SigNoz/engineering-pod#4979

  ---

  ### ✅ Change Type

  - [x] 🛠️ Infra / Tooling (observability instrumentation)

  ---

  ### 🧪 Testing Strategy

  - **Tests added/updated:** None — purely additive ctx tagging; `ctxtypes` comment behavior already covered by `pkg/types/ctxtypes/comment_test.go`. Matches `metricsexplorer` precedent (no
  test there either).
  - **Manual verification:** `make devenv-up` + `make go-run-community`, hit an Infra Monitoring page, then query the dev ClickHouse:
    ```sql
    SELECT JSONExtractString(log_comment,'code.namespace') ns,
           JSONExtractString(log_comment,'code.function')  fn,
           count(), avg(query_duration_ms)
    FROM system.query_log
    WHERE type='QueryFinish'
      AND JSONExtractString(log_comment,'code.namespace')='infra-monitoring'
      AND event_time > now() - INTERVAL 15 MINUTE
    GROUP BY ns, fn ORDER BY avg(query_duration_ms) DESC;
    Confirms rows tagged infra-monitoring with the correct endpoint in code.function, covering both the main query and helper queries.
  - go build / go vet pass.

  ---
  ⚠️ Risk & Impact Assessment

  - Blast radius: Single file, pkg/modules/inframonitoring/implinframonitoring/module.go. No behavior change to queries/responses — only adds metadata to the query log_comment.
  - Potential regressions: None expected; tagging is read-only context enrichment. Does not clobber querier-set keys (panel.type/query.type/etc.).
  - Rollback plan: Revert the PR; no migrations or state.

  ---
  📝 Changelog

  N/A — internal, non-user-facing observability instrumentation.

  ---
  📋 Checklist

  - [x] Tests added or explicitly not required
  - [x] Manually tested
  - [x] Breaking changes documented (none)
  - [x] Backward compatibility considered

  ---
  👀 Notes for Reviewers

  - Endpoint-level granularity is intentional (not per-helper): the actionable unit for #4979 is "which API to optimize," and shared helpers (getMetricsExistenceAndEarliestTime, getPerGroupPodPhaseCounts) would lose the endpoint axis if tagged by helper name. Helper-level drill-down is still recoverable from the raw SQL + per-row duration in query_log.
  - The code.function key is literally code.function (semconv v1.6.1), not code.function.name — relevant for downstream dashboards/alerts.