### PR TITLE
feat(dashboards): serve V2 dashboard pages behind use_dashboard_v2 flag

### DIFF
--- a/frontend/src/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage/DashboardPage.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { Modal } from 'antd';
+import { Typography } from '@signozhq/ui/typography';
+import { AxiosError } from 'axios';
+import NotFound from 'components/NotFound';
+import Spinner from 'components/Spinner';
+import DashboardContainer from 'container/DashboardContainer';
+import { useDashboardBootstrap } from 'hooks/dashboard/useDashboardBootstrap';
+import { useDashboardStore } from 'providers/Dashboard/store/useDashboardStore';
+import { ErrorType } from 'types/common';
+
+function DashboardPage(): JSX.Element {
+	const { dashboardId } = useParams<{ dashboardId: string }>();
+
+	const [onModal, Content] = Modal.useModal();
+
+	const { isLoading, isError, isFetching, error } = useDashboardBootstrap(
+		dashboardId,
+		{ confirm: onModal.confirm },
+	);
+
+	const dashboardTitle = useDashboardStore((s) => s.dashboardData?.data.title);
+
+	useEffect(() => {
+		document.title = dashboardTitle || document.title;
+	}, [dashboardTitle]);
+
+	const errorMessage = isError
+		? (error as AxiosError<{ errorType: string }>)?.response?.data?.errorType
+		: 'Something went wrong';
+
+	if (isError && !isFetching && errorMessage === ErrorType.NotFound) {
+		return <NotFound />;
+	}
+
+	if (isError && errorMessage) {
+		return <Typography>{errorMessage}</Typography>;
+	}
+
+	if (isLoading) {
+		return <Spinner tip="Loading.." />;
+	}
+
+	return (
+		<>
+			{Content}
+			<DashboardContainer />
+		</>
+	);
+}
+
+export default DashboardPage;

--- a/frontend/src/pages/DashboardPage/index.tsx
+++ b/frontend/src/pages/DashboardPage/index.tsx
@@ -1,53 +1,15 @@
-import { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import { Modal } from 'antd';
-import { Typography } from '@signozhq/ui/typography';
-import { AxiosError } from 'axios';
-import NotFound from 'components/NotFound';
-import Spinner from 'components/Spinner';
-import DashboardContainer from 'container/DashboardContainer';
-import { useDashboardBootstrap } from 'hooks/dashboard/useDashboardBootstrap';
-import { useDashboardStore } from 'providers/Dashboard/store/useDashboardStore';
-import { ErrorType } from 'types/common';
+import { useIsDashboardV2 } from 'hooks/useIsDashboardV2';
+import DashboardPageV2 from 'pages/DashboardPageV2';
 
-function DashboardPage(): JSX.Element {
-	const { dashboardId } = useParams<{ dashboardId: string }>();
+import DashboardPage from './DashboardPage';
 
-	const [onModal, Content] = Modal.useModal();
+// Serves the V2 dashboard detail page when the `use_dashboard_v2` flag is active;
+// otherwise the existing V1 page. Lets V2 dark-ship behind the flag without
+// changing route definitions.
+function DashboardPageEntry(): JSX.Element {
+	const isDashboardV2 = useIsDashboardV2();
 
-	const { isLoading, isError, isFetching, error } = useDashboardBootstrap(
-		dashboardId,
-		{ confirm: onModal.confirm },
-	);
-
-	const dashboardTitle = useDashboardStore((s) => s.dashboardData?.data.title);
-
-	useEffect(() => {
-		document.title = dashboardTitle || document.title;
-	}, [dashboardTitle]);
-
-	const errorMessage = isError
-		? (error as AxiosError<{ errorType: string }>)?.response?.data?.errorType
-		: 'Something went wrong';
-
-	if (isError && !isFetching && errorMessage === ErrorType.NotFound) {
-		return <NotFound />;
-	}
-
-	if (isError && errorMessage) {
-		return <Typography>{errorMessage}</Typography>;
-	}
-
-	if (isLoading) {
-		return <Spinner tip="Loading.." />;
-	}
-
-	return (
-		<>
-			{Content}
-			<DashboardContainer />
-		</>
-	);
+	return isDashboardV2 ? <DashboardPageV2 /> : <DashboardPage />;
 }
 
-export default DashboardPage;
+export default DashboardPageEntry;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/patchOps.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/patchOps.ts
@@ -4,7 +4,7 @@ import type {
 	DashboardtypesLayoutDTO,
 	DashboardtypesPanelDTO,
 } from 'api/generated/services/sigNoz.schemas';
-import { DashboardtypesJSONPatchOperationDTOOp } from 'api/generated/services/sigNoz.schemas';
+import { DashboardtypesPatchOpDTO } from 'api/generated/services/sigNoz.schemas';
 
 import type { GridItem } from './utils';
 
@@ -16,7 +16,7 @@ import type { GridItem } from './utils';
  * patches in DashboardSettings/General and DashboardDescription).
  */
 
-const { add, replace, remove } = DashboardtypesJSONPatchOperationDTOOp;
+const { add, replace, remove } = DashboardtypesPatchOpDTO;
 
 const PANEL_REF_PREFIX = '#/spec/panels/';
 

--- a/frontend/src/pages/DashboardsListPage/index.tsx
+++ b/frontend/src/pages/DashboardsListPage/index.tsx
@@ -1,3 +1,15 @@
+import { useIsDashboardV2 } from 'hooks/useIsDashboardV2';
+import DashboardsListPageV2 from 'pages/DashboardsListPageV2';
+
 import DashboardsListPage from './DashboardsListPage';
 
-export default DashboardsListPage;
+// Serves the V2 dashboards list when the `use_dashboard_v2` flag is active;
+// otherwise the existing V1 list. Lets V2 dark-ship behind the flag without
+// changing route definitions.
+function DashboardsListPageEntry(): JSX.Element {
+	const isDashboardV2 = useIsDashboardV2();
+
+	return isDashboardV2 ? <DashboardsListPageV2 /> : <DashboardsListPage />;
+}
+
+export default DashboardsListPageEntry;

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
@@ -28,8 +28,6 @@ import {
 	useSearch,
 	useSortColumn,
 	useSortOrder,
-	type SortColumn,
-	type SortOrder,
 } from '../../hooks/useDashboardsListQueryParams';
 import type { DashboardListItem } from '../../utils';
 import ConfigureMetadataModal from '../ConfigureMetadataModal/ConfigureMetadataModal';
@@ -86,10 +84,8 @@ function DashboardsList(): JSX.Element {
 	const listParams = useMemo(
 		() => ({
 			query: searchString.trim() || undefined,
-			// SortColumn/SortOrder string-literal unions mirror these generated
-			// enums 1:1 (identical values); cast to satisfy the client param.
-			sort: sortColumn as DashboardtypesListSortDTO,
-			order: sortOrder as DashboardtypesListOrderDTO,
+			sort: sortColumn,
+			order: sortOrder,
 			limit: PAGE_SIZE,
 			offset: (page - 1) * PAGE_SIZE,
 		}),
@@ -156,7 +152,7 @@ function DashboardsList(): JSX.Element {
 	}, []);
 
 	const onSortChange = useCallback(
-		(column: SortColumn): void => {
+		(column: DashboardtypesListSortDTO): void => {
 			void setSortColumn(column);
 			void setPage(1);
 		},
@@ -164,7 +160,7 @@ function DashboardsList(): JSX.Element {
 	);
 
 	const onOrderChange = useCallback(
-		(order: SortOrder): void => {
+		(order: DashboardtypesListOrderDTO): void => {
 			void setSortOrder(order);
 			void setPage(1);
 		},

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
@@ -8,6 +8,10 @@ import {
 	createDashboardV2,
 	useListDashboardsV2,
 } from 'api/generated/services/dashboard';
+import {
+	DashboardtypesListOrderDTO,
+	DashboardtypesListSortDTO,
+} from 'api/generated/services/sigNoz.schemas';
 import ROUTES from 'constants/routes';
 import { RequestDashboardBtn } from 'container/ListOfDashboard/RequestDashboardBtn';
 import useComponentPermission from 'hooks/useComponentPermission';
@@ -82,8 +86,10 @@ function DashboardsList(): JSX.Element {
 	const listParams = useMemo(
 		() => ({
 			query: searchString.trim() || undefined,
-			sort: sortColumn,
-			order: sortOrder,
+			// SortColumn/SortOrder string-literal unions mirror these generated
+			// enums 1:1 (identical values); cast to satisfy the client param.
+			sort: sortColumn as DashboardtypesListSortDTO,
+			order: sortOrder as DashboardtypesListOrderDTO,
 			limit: PAGE_SIZE,
 			offset: (page - 1) * PAGE_SIZE,
 		}),

--- a/frontend/src/pages/DashboardsListPageV2/components/ListHeader/ListHeader.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ListHeader/ListHeader.tsx
@@ -7,18 +7,18 @@ import {
 	HdmiPort,
 } from '@signozhq/icons';
 
-import type {
-	SortColumn,
-	SortOrder,
-} from '../../hooks/useDashboardsListQueryParams';
+import {
+	DashboardtypesListOrderDTO,
+	DashboardtypesListSortDTO,
+} from 'api/generated/services/sigNoz.schemas';
 
 import styles from './ListHeader.module.scss';
 
 interface Props {
-	sortColumn: SortColumn;
-	onSortChange: (column: SortColumn) => void;
-	sortOrder: SortOrder;
-	onOrderChange: (order: SortOrder) => void;
+	sortColumn: DashboardtypesListSortDTO;
+	onSortChange: (column: DashboardtypesListSortDTO) => void;
+	sortOrder: DashboardtypesListOrderDTO;
+	onOrderChange: (order: DashboardtypesListOrderDTO) => void;
 	onConfigureMetadata: () => void;
 }
 
@@ -44,49 +44,57 @@ function ListHeader({
 								<Button
 									type="text"
 									className={styles.sortButton}
-									onClick={(): void => onSortChange('name')}
+									onClick={(): void => onSortChange(DashboardtypesListSortDTO.name)}
 									data-testid="sort-by-name"
 								>
 									Name
-									{sortColumn === 'name' && <Check size={14} />}
+									{sortColumn === DashboardtypesListSortDTO.name && <Check size={14} />}
 								</Button>
 								<Button
 									type="text"
 									className={styles.sortButton}
-									onClick={(): void => onSortChange('created_at')}
+									onClick={(): void =>
+										onSortChange(DashboardtypesListSortDTO.created_at)
+									}
 									data-testid="sort-by-last-created"
 								>
 									Last created
-									{sortColumn === 'created_at' && <Check size={14} />}
+									{sortColumn === DashboardtypesListSortDTO.created_at && (
+										<Check size={14} />
+									)}
 								</Button>
 								<Button
 									type="text"
 									className={styles.sortButton}
-									onClick={(): void => onSortChange('updated_at')}
+									onClick={(): void =>
+										onSortChange(DashboardtypesListSortDTO.updated_at)
+									}
 									data-testid="sort-by-last-updated"
 								>
 									Last updated
-									{sortColumn === 'updated_at' && <Check size={14} />}
+									{sortColumn === DashboardtypesListSortDTO.updated_at && (
+										<Check size={14} />
+									)}
 								</Button>
 								<div className={styles.sortDivider} />
 								<Typography.Text className={styles.sortHeading}>Order</Typography.Text>
 								<Button
 									type="text"
 									className={styles.sortButton}
-									onClick={(): void => onOrderChange('asc')}
+									onClick={(): void => onOrderChange(DashboardtypesListOrderDTO.asc)}
 									data-testid="sort-order-asc"
 								>
 									Ascending
-									{sortOrder === 'asc' && <Check size={14} />}
+									{sortOrder === DashboardtypesListOrderDTO.asc && <Check size={14} />}
 								</Button>
 								<Button
 									type="text"
 									className={styles.sortButton}
-									onClick={(): void => onOrderChange('desc')}
+									onClick={(): void => onOrderChange(DashboardtypesListOrderDTO.desc)}
 									data-testid="sort-order-desc"
 								>
 									Descending
-									{sortOrder === 'desc' && <Check size={14} />}
+									{sortOrder === DashboardtypesListOrderDTO.desc && <Check size={14} />}
 								</Button>
 							</div>
 						}

--- a/frontend/src/pages/DashboardsListPageV2/components/states/states.module.scss
+++ b/frontend/src/pages/DashboardsListPageV2/components/states/states.module.scss
@@ -1,5 +1,5 @@
-// Shared building blocks for the dashboards-list view states.
-// Composed via CSS-modules `composes:` from each state's own SCSS.
+/* Shared building blocks for the dashboards-list view states. */
+/* Composed via CSS-modules `composes:` from each state's own SCSS. */
 
 .cardWrapper {
 	display: flex;

--- a/frontend/src/pages/DashboardsListPageV2/hooks/useDashboardsListQueryParams.ts
+++ b/frontend/src/pages/DashboardsListPageV2/hooks/useDashboardsListQueryParams.ts
@@ -1,4 +1,8 @@
 import {
+	DashboardtypesListOrderDTO,
+	DashboardtypesListSortDTO,
+} from 'api/generated/services/sigNoz.schemas';
+import {
 	parseAsInteger,
 	parseAsString,
 	parseAsStringLiteral,
@@ -7,26 +11,31 @@ import {
 	type UseQueryStateReturn,
 } from 'nuqs';
 
-export const SORT_COLUMNS = ['updated_at', 'created_at', 'name'] as const;
-export type SortColumn = (typeof SORT_COLUMNS)[number];
-
-export const SORT_ORDERS = ['asc', 'desc'] as const;
-export type SortOrder = (typeof SORT_ORDERS)[number];
+export const SORT_COLUMNS = Object.values(DashboardtypesListSortDTO);
+export const SORT_ORDERS = Object.values(DashboardtypesListOrderDTO);
 
 const opts: Options = { history: 'push' };
 
-export const useSortColumn = (): UseQueryStateReturn<SortColumn, SortColumn> =>
+export const useSortColumn = (): UseQueryStateReturn<
+	DashboardtypesListSortDTO,
+	DashboardtypesListSortDTO
+> =>
 	useQueryState(
 		'sort',
 		parseAsStringLiteral(SORT_COLUMNS)
-			.withDefault('updated_at')
+			.withDefault(DashboardtypesListSortDTO.updated_at)
 			.withOptions(opts),
 	);
 
-export const useSortOrder = (): UseQueryStateReturn<SortOrder, SortOrder> =>
+export const useSortOrder = (): UseQueryStateReturn<
+	DashboardtypesListOrderDTO,
+	DashboardtypesListOrderDTO
+> =>
 	useQueryState(
 		'order',
-		parseAsStringLiteral(SORT_ORDERS).withDefault('desc').withOptions(opts),
+		parseAsStringLiteral(SORT_ORDERS)
+			.withDefault(DashboardtypesListOrderDTO.desc)
+			.withOptions(opts),
 	);
 
 export const usePage = (): UseQueryStateReturn<number, number> =>

--- a/frontend/src/pages/DashboardsListPageV2/utils.ts
+++ b/frontend/src/pages/DashboardsListPageV2/utils.ts
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs';
 import { isEmpty } from 'lodash-es';
-import type { DashboardtypesGettableDashboardWithPinDTO } from 'api/generated/services/sigNoz.schemas';
+import type { DashboardtypesListedDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
 
-export type DashboardListItem = DashboardtypesGettableDashboardWithPinDTO;
+export type DashboardListItem = DashboardtypesListedDashboardV2DTO;
 
 export const tagsToStrings = (
 	tags: { key: string; value: string }[] | null | undefined,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -48,9 +48,7 @@
 		"node_modules",
 		"src/parser/*.ts",
 		"src/parser/TraceOperatorParser/*.ts",
-		"orval.config.ts",
-		"src/pages/DashboardsListPageV2/**/*",
-		"src/pages/DashboardPageV2/**/*"
+		"orval.config.ts"
 	],
 	"include": [
 		"./src",


### PR DESCRIPTION
## What

Serves the V2 dashboard **list** and **detail** pages behind the existing `use_dashboard_v2` feature flag, and un-parks the V2 page directories so they typecheck and build.

- `DashboardPage` / `DashboardsListPage` entry points now render the V2 page when `useIsDashboardV2()` is `true`, and fall through to the existing V1 page when the flag is off. The V1 detail logic moved into `DashboardPage/DashboardPage.tsx`; the entry `index.tsx` is now a thin flag switch.
- `tsconfig.json`: removed the `DashboardPageV2/**` and `DashboardsListPageV2/**` `exclude` globs, so the V2 code is type-checked and bundled (no longer dark-parked from `tsc`).
- Aligned the V2 list/patch code with the now-upstream generated client: `PatchOpDTO` (was `JSONPatchOperationDTOOp`), `ListedDashboardV2DTO` as the list item type, and `ListSortDTO` / `ListOrderDTO` casts on the list params.
- Converted the `//` header comments in `states.module.scss` to `/* */`. Once the V2 list is wired into the import graph, vite compiles that stylesheet and the backtick inside the `//` comment crashed the CSS-modules parser ("Unclosed string").

## Behaviour

- **Flag off (default):** unchanged — V1 list & detail.
- **Flag on:** V2 list & detail.

## Verification

- `pnpm tsgo --noEmit` → 0 errors
- `pnpm build` → success