### PR TITLE
feat(dashboard-v2): runtime variable selection

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/index.tsx
@@ -20,7 +20,7 @@ import APIError from 'types/api/error';
 import DashboardActions from './DashboardActions/DashboardActions';
 import DashboardInfo from './DashboardInfo/DashboardInfo';
 import { useEditableTitle } from './DashboardInfo/useEditableTitle';
-import { usePublicDashboardMeta } from '../DashboardSettings/PublicDashboard/usePublicDashboardMeta';
+import VariablesBar from '../VariablesBar/VariablesBar';
 
 import styles from './DashboardPageToolbar.module.scss';
 
@@ -52,10 +52,6 @@ function DashboardPageToolbar(props: DashboardPageToolbarProps): JSX.Element {
 	const setIsPanelTypeSelectionModalOpen = usePanelTypeSelectionModalStore(
 		(s) => s.setIsPanelTypeSelectionModalOpen,
 	);
-
-	// Single global fetch of the public-sharing meta (the drawer reuses this cache);
-	// drives the public-access badge.
-	const { isPublic: isPublicDashboard } = usePublicDashboardMeta(id);
 
 	const isAuthor =
 		!!user?.email && !!dashboard.createdBy && dashboard.createdBy === user.email;
@@ -122,7 +118,7 @@ function DashboardPageToolbar(props: DashboardPageToolbarProps): JSX.Element {
 					image={image}
 					tags={tags}
 					description={description}
-					isPublicDashboard={isPublicDashboard}
+					isPublicDashboard={false}
 					isDashboardLocked={isDashboardLocked}
 					isEditing={isEditing}
 					draft={draft}
@@ -142,6 +138,8 @@ function DashboardPageToolbar(props: DashboardPageToolbarProps): JSX.Element {
 					onOpenRename={startEdit}
 				/>
 			</div>
+
+			<VariablesBar dashboard={dashboard} />
 		</section>
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableModel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableModel.ts
@@ -1,3 +1,4 @@
+import { sortBy } from 'lodash-es';
 import type { VariableDefaultValueDTO } from 'api/generated/services/sigNoz.schemas';
 
 /**
@@ -75,4 +76,27 @@ export function emptyVariableFormModel(): VariableFormModel {
 		dynamicAttribute: '',
 		dynamicSignal: 'traces',
 	};
+}
+
+/** Maps the dynamic-variable signal to the field-values API signal. */
+export function signalForApi(
+	signal: TelemetrySignal,
+): TelemetrySignal | undefined {
+	return signal;
+}
+
+type SortableValues = (string | number | boolean)[];
+
+/** Sorts option/preview values by the variable's chosen order (no-op when disabled). */
+export function sortValuesByOrder(
+	values: SortableValues,
+	sort: VariableSort,
+): SortableValues {
+	if (sort === 'ASC') {
+		return sortBy(values);
+	}
+	if (sort === 'DESC') {
+		return sortBy(values).reverse();
+	}
+	return values;
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariableSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariableSelector.tsx
@@ -1,0 +1,114 @@
+import { useMemo } from 'react';
+import { SolidInfoCircle } from '@signozhq/icons';
+import { Typography } from '@signozhq/ui/typography';
+// eslint-disable-next-line signoz/no-antd-components -- lightweight description tooltip, matches V1
+import { Tooltip } from 'antd';
+import { commaValuesParser } from 'lib/dashboardVariables/customCommaValuesParser';
+
+import { sortValuesByOrder } from '../DashboardSettings/Variables/variableModel';
+import type { VariableFormModel } from '../DashboardSettings/Variables/variableModel';
+import type { VariableSelection, VariableSelectionMap } from './selectionTypes';
+import DynamicSelector from './selectors/DynamicSelector';
+import QuerySelector from './selectors/QuerySelector';
+import TextSelector from './selectors/TextSelector';
+import ValueSelector from './selectors/ValueSelector';
+import styles from './VariablesBar.module.scss';
+
+interface VariableSelectorProps {
+	variable: VariableFormModel;
+	/** All variables (Dynamic uses them to scope options by sibling selections). */
+	variables: VariableFormModel[];
+	/** Names this variable depends on (for Query gating). */
+	parents: string[];
+	/** All current selections (Query passes them as the request payload). */
+	selections: VariableSelectionMap;
+	selection: VariableSelection;
+	onChange: (selection: VariableSelection) => void;
+}
+
+/** One labelled variable control; dispatches on the variable type. */
+function VariableSelector({
+	variable,
+	variables,
+	parents,
+	selections,
+	selection,
+	onChange,
+}: VariableSelectorProps): JSX.Element {
+	const customOptions = useMemo(
+		() =>
+			variable.type === 'CUSTOM'
+				? sortValuesByOrder(
+						commaValuesParser(variable.customValue),
+						variable.sort,
+					).map(String)
+				: [],
+		[variable],
+	);
+
+	const renderControl = (): JSX.Element => {
+		switch (variable.type) {
+			case 'TEXT':
+				return (
+					<TextSelector
+						selection={selection}
+						defaultValue={variable.textValue}
+						onChange={onChange}
+						testId={`variable-input-${variable.name}`}
+					/>
+				);
+			case 'QUERY':
+				return (
+					<QuerySelector
+						variable={variable}
+						parents={parents}
+						selections={selections}
+						selection={selection}
+						onChange={onChange}
+					/>
+				);
+			case 'DYNAMIC':
+				return (
+					<DynamicSelector
+						variable={variable}
+						variables={variables}
+						selections={selections}
+						selection={selection}
+						onChange={onChange}
+					/>
+				);
+			case 'CUSTOM':
+			default:
+				return (
+					<ValueSelector
+						options={customOptions}
+						multiSelect={variable.multiSelect}
+						showAllOption={variable.showAllOption}
+						selection={selection}
+						onChange={onChange}
+						testId={`variable-select-${variable.name}`}
+					/>
+				);
+		}
+	};
+
+	return (
+		<div
+			className={styles.variableItem}
+			data-testid={`variable-${variable.name}`}
+		>
+			<Typography.Text className={styles.variableName}>
+				${variable.name}
+				{variable.description ? (
+					<Tooltip title={variable.description}>
+						<SolidInfoCircle className={styles.infoIcon} size="md" />
+					</Tooltip>
+				) : null}
+			</Typography.Text>
+
+			<div className={styles.variableValue}>{renderControl()}</div>
+		</div>
+	);
+}
+
+export default VariableSelector;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.module.scss
@@ -1,0 +1,71 @@
+/* Mirrors the V1 dashboard variable bar: each variable is a connected pill —
+   a robin `$name` segment joined to a value segment. */
+/* Sits inside the already-padded sticky toolbar section, so it only needs a top
+   gap from the tags — horizontal/bottom padding comes from the toolbar. */
+.bar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+	padding-top: 12px;
+}
+
+.variableItem {
+	display: flex;
+	align-items: center;
+}
+
+.variableName {
+	display: flex;
+	min-width: 56px;
+	height: 32px;
+	align-items: center;
+	gap: 4px;
+	padding: 6px 6px 6px 8px;
+	border: 1px solid var(--l1-border);
+	border-radius: 2px 0 0 2px;
+	background: var(--l3-background);
+	color: var(--bg-robin-300);
+	font-family: Inter;
+	font-size: 12px;
+	font-weight: 400;
+	line-height: 16px;
+	white-space: nowrap;
+}
+
+.infoIcon {
+	margin-left: 4px;
+	color: var(--l2-foreground);
+}
+
+.variableValue {
+	display: flex;
+	min-width: 120px;
+	height: 32px;
+	align-items: center;
+	border: 1px solid var(--l1-border);
+	border-left: none;
+	border-radius: 0 2px 2px 0;
+	background: var(--l2-background);
+	color: var(--l2-foreground);
+	font-size: 12px;
+
+	&:hover,
+	&:focus-within {
+		outline: 1px solid var(--bg-robin-400);
+	}
+}
+
+/* Inner control fills the value segment; the segment provides the frame, so the
+   control itself is borderless/transparent. */
+.control {
+	width: 100%;
+	min-width: 120px;
+
+	:global(.ant-select-selector),
+	:global(.ant-input),
+	&:global(.ant-input) {
+		border: none !important;
+		background: transparent !important;
+		box-shadow: none !important;
+	}
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
@@ -1,0 +1,45 @@
+import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
+
+import { useVariableSelection } from './useVariableSelection';
+import VariableSelector from './VariableSelector';
+import styles from './VariablesBar.module.scss';
+
+interface VariablesBarProps {
+	dashboard: DashboardtypesGettableDashboardV2DTO;
+}
+
+/**
+ * Runtime variable selector bar shown above the panels. Renders one control per
+ * dashboard variable; selections live in the store + URL (never the spec).
+ */
+function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
+	const { variables, dependencyData, selection, setSelection } =
+		useVariableSelection(dashboard);
+
+	if (variables.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className={styles.bar} data-testid="dashboard-variables-bar">
+			{variables.map((variable) => (
+				<VariableSelector
+					key={variable.name}
+					variable={variable}
+					variables={variables}
+					parents={dependencyData.parentGraph[variable.name] ?? []}
+					selections={selection}
+					selection={
+						selection[variable.name] ?? {
+							value: variable.multiSelect ? [] : '',
+							allSelected: false,
+						}
+					}
+					onChange={(next): void => setSelection(variable.name, next)}
+				/>
+			))}
+		</div>
+	);
+}
+
+export default VariablesBar;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/dynamicFilter.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/dynamicFilter.ts
@@ -1,0 +1,56 @@
+import type { VariableFormModel } from '../DashboardSettings/Variables/variableModel';
+import type { VariableSelectionMap } from './selectionTypes';
+
+function formatQueryValue(val: string): string {
+	const num = Number(val);
+	if (!Number.isNaN(num) && Number.isFinite(num)) {
+		return val;
+	}
+	return `'${val.replace(/'/g, "\\'")}'`;
+}
+
+function buildQueryPart(attribute: string, values: string[]): string {
+	const formatted = values.map(formatQueryValue);
+	if (formatted.length === 1) {
+		return `${attribute} = ${formatted[0]}`;
+	}
+	return `${attribute} IN [${formatted.join(', ')}]`;
+}
+
+/**
+ * Builds a filter expression from the OTHER dynamic variables' current
+ * selections (e.g. `k8s.namespace.name IN ['prod'] AND service = 'api'`), so a
+ * dynamic variable's option list is scoped by its sibling selections. Variables
+ * in the ALL state, with no selection, or non-dynamic are skipped. Ported from
+ * the V1 dynamic-variable runtime.
+ */
+export function buildExistingDynamicVariableQuery(
+	variables: VariableFormModel[],
+	selections: VariableSelectionMap,
+	currentName: string,
+): string {
+	const parts: string[] = [];
+	variables.forEach((variable) => {
+		if (
+			variable.name === currentName ||
+			variable.type !== 'DYNAMIC' ||
+			!variable.dynamicAttribute
+		) {
+			return;
+		}
+		const selection = selections[variable.name];
+		if (!selection || selection.allSelected) {
+			return;
+		}
+		const raw = Array.isArray(selection.value)
+			? selection.value
+			: [selection.value];
+		const valid = raw
+			.filter((v) => v !== null && v !== undefined && v !== '')
+			.map((v) => String(v));
+		if (valid.length > 0) {
+			parts.push(buildQueryPart(variable.dynamicAttribute, valid));
+		}
+	});
+	return parts.join(' AND ');
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectionTypes.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectionTypes.ts
@@ -1,0 +1,16 @@
+/** A user-selected variable value at runtime (not persisted to the spec). */
+export type SelectedVariableValue =
+	| string
+	| number
+	| boolean
+	| (string | number | boolean)[]
+	| null;
+
+export interface VariableSelection {
+	value: SelectedVariableValue;
+	/** True when every option is selected ("ALL"); for dynamic vars value may be null. */
+	allSelected: boolean;
+}
+
+/** Selected values for a dashboard's variables, keyed by variable name. */
+export type VariableSelectionMap = Record<string, VariableSelection>;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectionUtils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectionUtils.ts
@@ -1,0 +1,31 @@
+import type {
+	SelectedVariableValue,
+	VariableSelection,
+	VariableSelectionMap,
+} from './selectionTypes';
+
+/** A selection counts as resolved (usable as a parent value) when it's non-empty. */
+export function isResolved(selection?: VariableSelection): boolean {
+	if (!selection) {
+		return false;
+	}
+	if (selection.allSelected) {
+		return true;
+	}
+	const { value } = selection;
+	if (Array.isArray(value)) {
+		return value.length > 0;
+	}
+	return value !== '' && value !== null && value !== undefined;
+}
+
+/** Flatten the selection map into the `{ name: value }` payload a query expects. */
+export function selectionToPayload(
+	selection: VariableSelectionMap,
+): Record<string, SelectedVariableValue> {
+	const payload: Record<string, SelectedVariableValue> = {};
+	Object.entries(selection).forEach(([name, sel]) => {
+		payload[name] = sel.value;
+	});
+	return payload;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
@@ -1,0 +1,82 @@
+import { useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports
+import { useSelector } from 'react-redux';
+import { useGetFieldValues } from 'hooks/dynamicVariables/useGetFieldValues';
+import type { AppState } from 'store/reducers';
+import type { GlobalReducer } from 'types/reducer/globalTime';
+
+import {
+	signalForApi,
+	sortValuesByOrder,
+} from '../../DashboardSettings/Variables/variableModel';
+import type { VariableFormModel } from '../../DashboardSettings/Variables/variableModel';
+import { buildExistingDynamicVariableQuery } from '../dynamicFilter';
+import type {
+	VariableSelection,
+	VariableSelectionMap,
+} from '../selectionTypes';
+import { useAutoSelect } from '../useAutoSelect';
+import ValueSelector from './ValueSelector';
+
+interface DynamicSelectorProps {
+	variable: VariableFormModel;
+	/** All variables + current selections, to scope options by sibling dynamics. */
+	variables: VariableFormModel[];
+	selections: VariableSelectionMap;
+	selection: VariableSelection;
+	onChange: (selection: VariableSelection) => void;
+}
+
+/**
+ * Dynamic-variable options sourced from live telemetry field values for the
+ * chosen signal + attribute, scoped by the other dynamic variables' selections
+ * (so e.g. `pod` narrows to the chosen `namespace`).
+ */
+function DynamicSelector({
+	variable,
+	variables,
+	selections,
+	selection,
+	onChange,
+}: DynamicSelectorProps): JSX.Element {
+	const { minTime, maxTime } = useSelector<AppState, GlobalReducer>(
+		(state) => state.globalTime,
+	);
+
+	const existingQuery = useMemo(
+		() => buildExistingDynamicVariableQuery(variables, selections, variable.name),
+		[variables, selections, variable.name],
+	);
+
+	const { data, isFetching } = useGetFieldValues({
+		signal: signalForApi(variable.dynamicSignal),
+		name: variable.dynamicAttribute,
+		startUnixMilli: minTime,
+		endUnixMilli: maxTime,
+		existingQuery: existingQuery || undefined,
+		enabled: !!variable.dynamicAttribute,
+	});
+
+	const options = useMemo(() => {
+		const payload = data?.data;
+		const values =
+			payload?.normalizedValues ?? payload?.values?.StringValues ?? [];
+		return sortValuesByOrder(values, variable.sort).map(String);
+	}, [data, variable.sort]);
+
+	useAutoSelect(variable, options, selection, onChange);
+
+	return (
+		<ValueSelector
+			options={options}
+			multiSelect={variable.multiSelect}
+			showAllOption={variable.showAllOption}
+			loading={isFetching}
+			selection={selection}
+			onChange={onChange}
+			testId={`variable-select-${variable.name}`}
+		/>
+	);
+}
+
+export default DynamicSelector;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/QuerySelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/QuerySelector.tsx
@@ -1,0 +1,90 @@
+import { useMemo } from 'react';
+import { useQuery } from 'react-query';
+// eslint-disable-next-line no-restricted-imports
+import { useSelector } from 'react-redux';
+import dashboardVariablesQuery from 'api/dashboard/variables/dashboardVariablesQuery';
+import type { AppState } from 'store/reducers';
+import type { GlobalReducer } from 'types/reducer/globalTime';
+
+import { sortValuesByOrder } from '../../DashboardSettings/Variables/variableModel';
+import type { VariableFormModel } from '../../DashboardSettings/Variables/variableModel';
+import type {
+	VariableSelection,
+	VariableSelectionMap,
+} from '../selectionTypes';
+import { isResolved, selectionToPayload } from '../selectionUtils';
+import { useAutoSelect } from '../useAutoSelect';
+import ValueSelector from './ValueSelector';
+
+interface QuerySelectorProps {
+	variable: VariableFormModel;
+	/** Names this variable's query references; it waits until they're resolved. */
+	parents: string[];
+	/** All current selections, fed to the query as `{ name: value }`. */
+	selections: VariableSelectionMap;
+	selection: VariableSelection;
+	onChange: (selection: VariableSelection) => void;
+}
+
+/**
+ * Query-driven options. Dependency orchestration is declarative: the query is
+ * `enabled` only once every parent is resolved, and the parent values are in the
+ * query key — so it refetches automatically when a parent changes (and a cyclic
+ * dependency is simply never enabled).
+ */
+function QuerySelector({
+	variable,
+	parents,
+	selections,
+	selection,
+	onChange,
+}: QuerySelectorProps): JSX.Element {
+	const { minTime, maxTime } = useSelector<AppState, GlobalReducer>(
+		(state) => state.globalTime,
+	);
+	const payload = useMemo(() => selectionToPayload(selections), [selections]);
+	const enabled = parents.every((parent) => isResolved(selections[parent]));
+
+	const { data, isFetching } = useQuery(
+		[
+			'dashboard-variable',
+			variable.name,
+			variable.queryValue,
+			payload,
+			minTime,
+			maxTime,
+		],
+		() =>
+			dashboardVariablesQuery({
+				query: variable.queryValue,
+				variables: payload,
+			}),
+		{ enabled, refetchOnWindowFocus: false },
+	);
+
+	const options = useMemo(() => {
+		if (!data || data.statusCode !== 200 || !data.payload) {
+			return [] as string[];
+		}
+		return sortValuesByOrder(
+			data.payload.variableValues ?? [],
+			variable.sort,
+		).map(String);
+	}, [data, variable.sort]);
+
+	useAutoSelect(variable, options, selection, onChange);
+
+	return (
+		<ValueSelector
+			options={options}
+			multiSelect={variable.multiSelect}
+			showAllOption={variable.showAllOption}
+			loading={isFetching}
+			selection={selection}
+			onChange={onChange}
+			testId={`variable-select-${variable.name}`}
+		/>
+	);
+}
+
+export default QuerySelector;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/TextSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/TextSelector.tsx
@@ -1,0 +1,70 @@
+import { useCallback, useRef, useState } from 'react';
+import type { InputRef } from 'antd';
+// eslint-disable-next-line signoz/no-antd-components -- match V1 textbox behaviour (commit on blur/Enter, borderless)
+import { Input } from 'antd';
+
+import type { VariableSelection } from '../selectionTypes';
+import styles from '../VariablesBar.module.scss';
+
+interface TextSelectorProps {
+	selection: VariableSelection;
+	/** Configured default; an emptied input falls back to it (V1 behaviour). */
+	defaultValue?: string;
+	onChange: (selection: VariableSelection) => void;
+	testId?: string;
+}
+
+/**
+ * Free-text variable input. Mirrors V1: edits are local and only committed on
+ * blur / Enter (not per keystroke), and clearing the field restores the default.
+ */
+function TextSelector({
+	selection,
+	defaultValue,
+	onChange,
+	testId,
+}: TextSelectorProps): JSX.Element {
+	const inputRef = useRef<InputRef>(null);
+	const [value, setValue] = useState<string>(
+		typeof selection.value === 'string' ? selection.value : (defaultValue ?? ''),
+	);
+
+	const commit = useCallback(
+		(next: string): void => onChange({ value: next, allSelected: false }),
+		[onChange],
+	);
+
+	const handleBlur = useCallback(
+		(event: React.FocusEvent<HTMLInputElement>): void => {
+			const trimmed = event.target.value.trim();
+			if (!trimmed && defaultValue) {
+				setValue(defaultValue);
+				commit(defaultValue);
+			} else {
+				commit(trimmed);
+			}
+		},
+		[commit, defaultValue],
+	);
+
+	return (
+		<Input
+			ref={inputRef}
+			className={styles.control}
+			bordered={false}
+			placeholder="Enter value"
+			value={value}
+			title={value}
+			onChange={(e): void => setValue(e.target.value)}
+			onBlur={handleBlur}
+			onKeyDown={(e): void => {
+				if (e.key === 'Enter') {
+					inputRef.current?.blur();
+				}
+			}}
+			data-testid={testId}
+		/>
+	);
+}
+
+export default TextSelector;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/ValueSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/ValueSelector.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from 'react';
+import { CustomMultiSelect, CustomSelect } from 'components/NewSelect';
+import type { OptionData } from 'components/NewSelect/types';
+import { ALL_SELECT_VALUE } from 'container/DashboardContainer/utils';
+
+import type { VariableSelection } from '../selectionTypes';
+import styles from '../VariablesBar.module.scss';
+
+interface ValueSelectorProps {
+	options: string[];
+	multiSelect: boolean;
+	showAllOption: boolean;
+	loading?: boolean;
+	selection: VariableSelection;
+	onChange: (selection: VariableSelection) => void;
+	testId?: string;
+}
+
+/**
+ * Single/multi value picker for Custom/Query/Dynamic variables. Reuses the
+ * shared NewSelect components, which provide search, the "ALL" option and
+ * apply-on-close batching (so multi-select edits don't cascade per toggle).
+ */
+function ValueSelector({
+	options,
+	multiSelect,
+	showAllOption,
+	loading,
+	selection,
+	onChange,
+	testId,
+}: ValueSelectorProps): JSX.Element {
+	const optionData = useMemo<OptionData[]>(
+		() => options.map((option) => ({ label: option, value: option })),
+		[options],
+	);
+
+	if (multiSelect) {
+		const value = selection.allSelected
+			? ALL_SELECT_VALUE
+			: (Array.isArray(selection.value) ? selection.value : []).map(String);
+		return (
+			<CustomMultiSelect
+				className={styles.control}
+				data-testid={testId}
+				options={optionData}
+				value={value}
+				loading={loading}
+				showSearch
+				placeholder="Select value"
+				enableAllSelection={showAllOption}
+				onChange={(next): void => {
+					const values = Array.isArray(next)
+						? next.map(String)
+						: next
+							? [String(next)]
+							: [];
+					if (values.length === 0) {
+						onChange({ value: [], allSelected: false });
+						return;
+					}
+					// CustomMultiSelect emits the full value set when ALL is picked.
+					const isAll =
+						showAllOption &&
+						options.length > 0 &&
+						options.every((option) => values.includes(option));
+					onChange({ value: values, allSelected: isAll });
+				}}
+				onClear={(): void => onChange({ value: [], allSelected: false })}
+			/>
+		);
+	}
+
+	return (
+		<CustomSelect
+			className={styles.select}
+			data-testid={testId}
+			options={optionData}
+			value={
+				selection.value == null || Array.isArray(selection.value)
+					? undefined
+					: String(selection.value)
+			}
+			loading={loading}
+			showSearch
+			placeholder="Select value"
+			onChange={(next): void =>
+				onChange({ value: next == null ? '' : String(next), allSelected: false })
+			}
+		/>
+	);
+}
+
+export default ValueSelector;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useAutoSelect.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useAutoSelect.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+
+import type { VariableFormModel } from '../DashboardSettings/Variables/variableModel';
+import type { VariableSelection } from './selectionTypes';
+
+/**
+ * When fetched options arrive and the current selection isn't one of them,
+ * auto-pick the variable's default (if present in the options) or the first
+ * option — so dependent children always have a usable parent value.
+ */
+export function useAutoSelect(
+	variable: VariableFormModel,
+	options: string[],
+	selection: VariableSelection,
+	onChange: (selection: VariableSelection) => void,
+): void {
+	useEffect(() => {
+		if (options.length === 0 || selection.allSelected) {
+			return;
+		}
+		const current = selection.value;
+		const isValid = Array.isArray(current)
+			? current.length > 0 && current.every((c) => options.includes(String(c)))
+			: current !== '' &&
+				current !== null &&
+				current !== undefined &&
+				options.includes(String(current));
+		if (isValid) {
+			return;
+		}
+		const fallback = (variable.defaultValue as { value?: string } | undefined)
+			?.value;
+		const initial =
+			fallback && options.includes(fallback) ? fallback : options[0];
+		onChange({
+			value: variable.multiSelect ? [initial] : initial,
+			allSelected: false,
+		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [options]);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { parseAsJson, useQueryState } from 'nuqs';
+import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
+
+import { dtoToFormModel } from '../DashboardSettings/Variables/variableAdapters';
+import type { VariableFormModel } from '../DashboardSettings/Variables/variableModel';
+import { selectVariableValues } from '../store/slices/variableSelectionSlice';
+import { useDashboardStore } from '../store/useDashboardStore';
+import type {
+	SelectedVariableValue,
+	VariableSelection,
+	VariableSelectionMap,
+} from './selectionTypes';
+import {
+	computeVariableDependencies,
+	type VariableDependencyData,
+} from './variableDependencies';
+
+/** URL sentinel for an "ALL values selected" state (matches V1). */
+export const ALL_SELECTED = '__ALL__';
+
+/** `?variables=` holds `{ [name]: value }` (ALL encoded as the sentinel). */
+const variablesUrlParser = parseAsJson<Record<string, SelectedVariableValue>>(
+	(v) =>
+		typeof v === 'object' && v !== null
+			? (v as Record<string, SelectedVariableValue>)
+			: null,
+);
+
+function defaultSelection(model: VariableFormModel): VariableSelection {
+	const def = (
+		model.defaultValue as { value?: SelectedVariableValue } | undefined
+	)?.value;
+	if (def !== undefined && def !== null && def !== '') {
+		return { value: def, allSelected: false };
+	}
+	return { value: model.multiSelect ? [] : '', allSelected: false };
+}
+
+function fromUrlValue(raw: SelectedVariableValue): VariableSelection {
+	return raw === ALL_SELECTED
+		? { value: null, allSelected: true }
+		: { value: raw, allSelected: false };
+}
+
+interface UseVariableSelection {
+	variables: VariableFormModel[];
+	dependencyData: VariableDependencyData;
+	selection: VariableSelectionMap;
+	setSelection: (name: string, selection: VariableSelection) => void;
+}
+
+/**
+ * Runtime variable selection: derives the variable list from the spec, seeds
+ * each value from URL → localStorage(store) → default, and persists changes to
+ * both the store and the URL. Never writes to the dashboard spec.
+ */
+export function useVariableSelection(
+	dashboard: DashboardtypesGettableDashboardV2DTO,
+): UseVariableSelection {
+	const dashboardId = dashboard.id ?? '';
+
+	const variables = useMemo(
+		() => (dashboard.spec?.variables ?? []).map(dtoToFormModel),
+		[dashboard.spec?.variables],
+	);
+	const dependencyData = useMemo(
+		() => computeVariableDependencies(variables),
+		[variables],
+	);
+
+	const selection = useDashboardStore(selectVariableValues(dashboardId));
+	const setVariableValue = useDashboardStore((s) => s.setVariableValue);
+	const setVariableValues = useDashboardStore((s) => s.setVariableValues);
+
+	const [urlValues, setUrlValues] = useQueryState(
+		'variables',
+		variablesUrlParser.withOptions({ history: 'replace' }),
+	);
+
+	// Seed selections for this dashboard: URL wins, then persisted store, then default.
+	useEffect(() => {
+		if (!dashboardId || variables.length === 0) {
+			return;
+		}
+		// `selection` here is the persisted (localStorage) map on mount — the
+		// effect deliberately doesn't depend on it, so seeding runs once per set.
+		const stored = selection;
+		const seeded: VariableSelectionMap = {};
+		variables.forEach((variable) => {
+			const urlValue = urlValues?.[variable.name];
+			if (urlValue !== undefined) {
+				seeded[variable.name] = fromUrlValue(urlValue);
+			} else if (stored[variable.name]) {
+				seeded[variable.name] = stored[variable.name];
+			} else {
+				seeded[variable.name] = defaultSelection(variable);
+			}
+		});
+		setVariableValues(dashboardId, seeded);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [dashboardId, variables]);
+
+	const setSelection = useCallback(
+		(name: string, next: VariableSelection): void => {
+			setVariableValue(dashboardId, name, next);
+			void setUrlValues((prev) => ({
+				...(prev ?? {}),
+				[name]: next.allSelected ? ALL_SELECTED : next.value,
+			}));
+		},
+		[dashboardId, setVariableValue, setUrlValues],
+	);
+
+	return { variables, dependencyData, selection, setSelection };
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/variableDependencies.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/variableDependencies.ts
@@ -1,0 +1,199 @@
+import { textContainsVariableReference } from 'lib/dashboardVariables/variableReference';
+
+import type { VariableFormModel } from '../DashboardSettings/Variables/variableModel';
+
+/**
+ * Inter-variable dependency graph for runtime selection. A QUERY variable
+ * "depends on" another variable when its query text references that variable
+ * (`{{.name}}`, `{{name}}`, `$name`, `[[name]]`). When a variable's value
+ * changes, its dependent QUERY variables must refetch. Ported from the V1
+ * dashboard-variables runtime; operates on the V2 flat variable model.
+ */
+
+export type VariableGraph = Record<string, string[]>;
+
+export interface VariableDependencyData {
+	/** Topological order of variables (parents before children). */
+	order: string[];
+	/** Direct children (dependents) of each variable. */
+	graph: VariableGraph;
+	/** Direct parents of each variable. */
+	parentGraph: VariableGraph;
+	/** All transitive descendants of each variable (precomputed). */
+	transitiveDescendants: VariableGraph;
+	hasCycle: boolean;
+	cycleNodes?: string[];
+}
+
+/** Names of QUERY variables whose query references `variableName`. */
+function getDependents(
+	variableName: string,
+	variables: VariableFormModel[],
+): string[] {
+	return variables
+		.filter(
+			(v) =>
+				v.type === 'QUERY' &&
+				!!v.name &&
+				textContainsVariableReference(v.queryValue || '', variableName),
+		)
+		.map((v) => v.name);
+}
+
+/** variable name → its direct dependents (children). */
+export function buildDependencies(
+	variables: VariableFormModel[],
+): VariableGraph {
+	const graph: VariableGraph = {};
+	variables.forEach((v) => {
+		if (v.name) {
+			graph[v.name] = getDependents(v.name, variables);
+		}
+	});
+	return graph;
+}
+
+/** Invert a child graph into a parent graph. */
+export function buildParentGraph(graph: VariableGraph): VariableGraph {
+	const parents: VariableGraph = {};
+	Object.keys(graph).forEach((node) => {
+		parents[node] = parents[node] ?? [];
+	});
+	Object.entries(graph).forEach(([node, children]) => {
+		children.forEach((child) => {
+			parents[child] = parents[child] ?? [];
+			parents[child].push(node);
+		});
+	});
+	return parents;
+}
+
+function collectCyclePath(
+	graph: VariableGraph,
+	start: string,
+	end: string,
+): string[] {
+	const path: string[] = [];
+	let current = start;
+	const findParent = (node: string): string | undefined =>
+		Object.keys(graph).find((key) => graph[key]?.includes(node));
+	while (current !== end) {
+		const parent = findParent(current);
+		if (!parent) {
+			break;
+		}
+		path.push(parent);
+		current = parent;
+	}
+	return [start, ...path];
+}
+
+function detectCycle(
+	graph: VariableGraph,
+	node: string,
+	visited: Set<string>,
+	recStack: Set<string>,
+): string[] | null {
+	if (!visited.has(node)) {
+		visited.add(node);
+		recStack.add(node);
+		let cycleNodes: string[] | null = null;
+		(graph[node] || []).some((neighbor) => {
+			if (!visited.has(neighbor)) {
+				const found = detectCycle(graph, neighbor, visited, recStack);
+				if (found) {
+					cycleNodes = found;
+					return true;
+				}
+			} else if (recStack.has(neighbor)) {
+				cycleNodes = collectCyclePath(graph, node, neighbor);
+				return true;
+			}
+			return false;
+		});
+		if (cycleNodes) {
+			return cycleNodes;
+		}
+	}
+	recStack.delete(node);
+	return null;
+}
+
+/** Build the full dependency data (topo order, parents, transitive descendants, cycle info). */
+export function buildDependencyData(
+	dependencies: VariableGraph,
+): VariableDependencyData {
+	const inDegree: Record<string, number> = {};
+	const adjList: VariableGraph = {};
+
+	Object.keys(dependencies).forEach((node) => {
+		inDegree[node] = inDegree[node] ?? 0;
+		adjList[node] = adjList[node] ?? [];
+		(dependencies[node] || []).forEach((child) => {
+			inDegree[child] = inDegree[child] ?? 0;
+			inDegree[child] += 1;
+			adjList[node].push(child);
+		});
+	});
+
+	const visited = new Set<string>();
+	const recStack = new Set<string>();
+	let cycleNodes: string[] | undefined;
+	Object.keys(dependencies).some((node) => {
+		if (!visited.has(node)) {
+			const found = detectCycle(dependencies, node, visited, recStack);
+			if (found) {
+				cycleNodes = found;
+				return true;
+			}
+		}
+		return false;
+	});
+
+	// Topological sort (Kahn's algorithm).
+	const queue = Object.keys(inDegree).filter((n) => inDegree[n] === 0);
+	const order: string[] = [];
+	while (queue.length > 0) {
+		const current = queue.shift();
+		if (current === undefined) {
+			break;
+		}
+		order.push(current);
+		(adjList[current] || []).forEach((neighbor) => {
+			inDegree[neighbor] -= 1;
+			if (inDegree[neighbor] === 0) {
+				queue.push(neighbor);
+			}
+		});
+	}
+
+	const hasCycle = order.length !== Object.keys(dependencies).length;
+
+	// Transitive descendants: walk topo order in reverse.
+	const transitiveDescendants: VariableGraph = {};
+	for (let i = order.length - 1; i >= 0; i--) {
+		const node = order[i];
+		const desc = new Set<string>();
+		(adjList[node] || []).forEach((child) => {
+			desc.add(child);
+			(transitiveDescendants[child] || []).forEach((d) => desc.add(d));
+		});
+		transitiveDescendants[node] = Array.from(desc);
+	}
+
+	return {
+		order,
+		graph: adjList,
+		parentGraph: buildParentGraph(adjList),
+		transitiveDescendants,
+		hasCycle,
+		cycleNodes,
+	};
+}
+
+/** Compute the full dependency data straight from the variable list. */
+export function computeVariableDependencies(
+	variables: VariableFormModel[],
+): VariableDependencyData {
+	return buildDependencyData(buildDependencies(variables));
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableSelectionSlice.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableSelectionSlice.ts
@@ -1,0 +1,55 @@
+import type { StateCreator } from 'zustand';
+
+import type {
+	VariableSelection,
+	VariableSelectionMap,
+} from '../../VariablesBar/selectionTypes';
+import type { DashboardStore } from '../useDashboardStore';
+
+/**
+ * Runtime variable selection — the values the user picks in the variable bar.
+ * Keyed by dashboardId → variable name. Frontend-only and persisted to
+ * localStorage (mirrored to the URL by the bar for shareable links); it is
+ * deliberately NOT part of the dashboard spec, so selecting a value never
+ * patches the dashboard.
+ */
+export interface VariableSelectionSlice {
+	variableValues: Record<string, VariableSelectionMap>;
+	setVariableValue: (
+		dashboardId: string,
+		name: string,
+		selection: VariableSelection,
+	) => void;
+	/** Bulk set (used to seed from URL/localStorage/defaults on load). */
+	setVariableValues: (dashboardId: string, values: VariableSelectionMap) => void;
+}
+
+export const createVariableSelectionSlice: StateCreator<
+	DashboardStore,
+	[['zustand/persist', unknown]],
+	[],
+	VariableSelectionSlice
+> = (set, get) => ({
+	variableValues: {},
+	setVariableValue: (dashboardId, name, selection): void => {
+		const { variableValues } = get();
+		set({
+			variableValues: {
+				...variableValues,
+				[dashboardId]: { ...variableValues[dashboardId], [name]: selection },
+			},
+		});
+	},
+	setVariableValues: (dashboardId, values): void => {
+		const { variableValues } = get();
+		set({
+			variableValues: { ...variableValues, [dashboardId]: values },
+		});
+	},
+});
+
+/** Selector: the selection map for a dashboard (empty if none). */
+export const selectVariableValues =
+	(dashboardId: string) =>
+	(state: DashboardStore): VariableSelectionMap =>
+		state.variableValues[dashboardId] ?? {};

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/useDashboardStore.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/useDashboardStore.ts
@@ -9,25 +9,36 @@ import {
 	createCollapseSlice,
 	type CollapseSlice,
 } from './slices/collapseSlice';
+import {
+	createVariableSelectionSlice,
+	type VariableSelectionSlice,
+} from './slices/variableSelectionSlice';
 
-export type DashboardStore = EditContextSlice & CollapseSlice;
+export type DashboardStore = EditContextSlice &
+	CollapseSlice &
+	VariableSelectionSlice;
 
 /**
  * V2 dashboard session store. Holds cross-cutting client state only — never the
- * dashboard spec (that stays in react-query via useGetDashboardV2). Two slices:
+ * dashboard spec (that stays in react-query via useGetDashboardV2). Slices:
  * - edit-context: dashboardId / isEditable / refetch (set once, not persisted).
  * - collapse: per-section open state (frontend-only, persisted to localStorage).
+ * - variable-selection: runtime variable values (frontend-only, persisted).
  */
 export const useDashboardStore = create<DashboardStore>()(
 	persist(
 		(...a) => ({
 			...createEditContextSlice(...a),
 			...createCollapseSlice(...a),
+			...createVariableSelectionSlice(...a),
 		}),
 		{
 			name: '@signoz/dashboard-v2',
-			// Persist only the collapse map — context (incl. the refetch fn) is transient.
-			partialize: (state) => ({ collapsed: state.collapsed }),
+			// Persist UI-only state (context incl. the refetch fn is transient).
+			partialize: (state) => ({
+				collapsed: state.collapsed,
+				variableValues: state.variableValues,
+			}),
 		},
 	),
 );


### PR DESCRIPTION
Stacked on #11645 (variables settings tab) — this PR adds the **runtime variable selection** experience: the selector bar above the panels, per-type value selection, and inter-variable dependency orchestration.

## Design

- Selected values live in a persisted zustand `variableValues` slice + the URL (`?variables=`), seeded **URL → localStorage → default**. They are **never** written to the dashboard spec.
- Inter-variable dependencies are derived from query references (`{{.name}}` / `$name` / `[[name]]`): a topological graph with cycle detection. Orchestration is **declarative** — a Query selector is `enabled` only once its parents resolve and its query key carries the parent values, so it refetches when a parent changes (cycles are starved by the gate).
- Value pickers reuse the shared `NewSelect` (`CustomSelect`/`CustomMultiSelect`) for search, the ALL option and apply-on-close batching.

## What's included

- [x] Foundation: dependency graph + selection value types + persisted store slice.
- [x] Selector bar: `VariablesBar` above the panels; store + URL sync with seeding.
- [x] All four selector types: Custom, Text, Query (`/variables/query`, parent values) and Dynamic (`/fields/values`).
- [x] Dependency orchestration: declarative parent-gating + parent values in the query key.
- [x] Sibling-dynamic option filtering: dynamic variables scope each other via an `existingQuery` (e.g. `pod` narrows to the chosen `namespace`).
- [x] Multi-select / ALL UX via `NewSelect` (apply-on-close batching, no per-toggle cascade).

## Notes

- Dark-shipped/parked like the rest of V2 (renders once #11642 un-parks). Since V2 panels don't render queries yet, selected values populate the store/URL but don't yet drive panels.