### PR TITLE
fix(infra-monitoring-k8s-pods): working set memory should use space aggregation sum

### DIFF
--- a/frontend/src/container/InfraMonitoringK8s/Pods/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8s/Pods/constants.ts
@@ -1366,7 +1366,7 @@ export const getPodMetricsQueryPayload = (
 							orderBy: [],
 							queryName: 'B',
 							reduceTo: ReduceOperators.AVG,
-							spaceAggregation: 'avg',
+							spaceAggregation: 'sum',
 							stepInterval: 60,
 							timeAggregation: 'avg',
 						},


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Just a one-line fix for an inconsistency found by Nikhil. 

I didn't see any perceptive change in the chart but this can cause subtle differences in the chart in case we have duplicated data being ingested. This could lead the memory of the pod to appear higher since the memory will `sum` instead of `avg`.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before / After:

<img width="2695" height="1276" alt="image" src="https://github.com/user-attachments/assets/6aacf95a-784b-4376-996b-17f8df58acf5" />

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Fixes https://github.com/SigNoz/engineering-pod/issues/5331

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

One of the queries uses `avg` and the other uses `sum`.

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

Likely something that was forgot to be updated.

#### Fix Strategy
> How does this PR address the root cause?

We are prefering to use `sum` instead of `avg`, so we just need to update the code.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Infrastructure Monitoring - Pods - Working Memory Chart
- Potential regressions: Higher values when data is being duplicated during ingestion, but this is something expected.
- Rollback plan: None

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Ensure the chart of "Memory by State" on Pods inside Infrastructure Monitoring is consistent on space aggregation, previously the Working Set Memory was usingg `avg`, we changed to use `sum`. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
