### PR TITLE
fix(settings): trial banner causing the scroll of the sub-pages to be broken

### DIFF
--- a/frontend/src/container/BillingContainer/BillingContainer.module.scss
+++ b/frontend/src/container/BillingContainer/BillingContainer.module.scss
@@ -1,8 +1,7 @@
 .billingContainer {
-	margin-bottom: var(--spacing-20);
 	padding-top: 36px;
 	width: 90%;
-	margin: 0 auto;
+	margin: 0 auto var(--spacing-20);
 
 	.pageHeader {
 		margin-bottom: var(--spacing-8);

--- a/frontend/src/container/GeneralSettings/LicenseKeyRow/LicenseRowDismissibleCallout/LicenseRowDismissible.styles.scss
+++ b/frontend/src/container/GeneralSettings/LicenseKeyRow/LicenseRowDismissibleCallout/LicenseRowDismissible.styles.scss
@@ -1,6 +1,6 @@
 .license-key-callout {
 	margin: var(--spacing-4) var(--spacing-6);
-	width: auto;
+	width: auto !important;
 
 	.license-key-callout__description {
 		display: flex;

--- a/frontend/src/container/SideNav/SideNav.styles.scss
+++ b/frontend/src/container/SideNav/SideNav.styles.scss
@@ -1135,17 +1135,9 @@
 
 .settings-dropdown,
 .help-support-dropdown {
-	.ant-dropdown-menu-item {
-		min-height: 32px;
-
-		.ant-dropdown-menu-title-content {
-			color: var(--l1-foreground) !important;
-		}
-
-		.user-settings-dropdown-logout-section {
-			color: var(--danger-background);
-			pointer-events: auto;
-		}
+	.user-settings-dropdown-logout-section {
+		color: var(--danger-background);
+		pointer-events: auto;
 	}
 }
 

--- a/frontend/src/pages/Settings/Settings.styles.scss
+++ b/frontend/src/pages/Settings/Settings.styles.scss
@@ -1,8 +1,12 @@
 .settings-page {
-	max-height: 100vh;
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
 	overflow: hidden;
 
 	.settings-page-header {
+		flex-shrink: 0;
 		border-bottom: 1px solid var(--l1-border);
 		background: var(--l1-background);
 		backdrop-filter: blur(20px);
@@ -24,13 +28,14 @@
 	}
 
 	.settings-page-content-container {
+		flex: 1;
+		min-height: 0;
 		display: flex;
 		flex-direction: row;
-		align-items: flex-start;
+		align-items: stretch;
 
 		.settings-page-sidenav {
 			width: 240px;
-			height: calc(100vh - 48px);
 			border-right: 1px solid var(--l1-border);
 			background: var(--l1-background);
 			padding-top: var(--padding-1);
@@ -74,7 +79,6 @@
 
 		.settings-page-content {
 			flex: 1;
-			height: calc(100vh - 48px);
 			background: var(--l1-background);
 			padding: 10px 8px;
 			overflow-y: auto;


### PR DESCRIPTION
## Summary

Three UI regressions fixed: 

Closes: https://github.com/SigNoz/platform-pod/issues/2501

### 1. **Billing page bottom content clipped on free trial**: 

Settings layout used hardcoded `max-height: 100vh` and `height: calc(100vh - 48px)` which didn't account for the 48px trial banner. Replaced with a flex-based layout (`flex: 1; min-height: 0`) so heights derive from the actual container. Also fixed a dead `margin-bottom` on `BillingContainer` that was silently overridden by a subsequent `margin` shorthand.

#### Before (video) - 

https://github.com/user-attachments/assets/7caee22f-9781-4373-87cc-710d6d507cc6

------

#### After (video) - 


https://github.com/user-attachments/assets/47b7f491-a66f-4e05-96e4-c9d1c3ff0891



-------


### 2. **Workspace callout overflowing its container**:

The `@signozhq/ui` Callout component sets `width: 100%` on its root. Adding horizontal `margin` to the same element caused total width to exceed the parent. Fixed with `width: auto !important` to override the design system default.

| Before | After |
|---|---|
| <img width="779" height="155" alt="image" src="https://github.com/user-attachments/assets/e1afaeae-493d-493e-9ee4-26a0a859e71f" /> | <img width="786" height="163" alt="image" src="https://github.com/user-attachments/assets/d3f7a18d-51b5-4e73-b5ab-35c5e47e0e19" /> |

---------

### 3. **Sign-out text lost red color**:

PR #11400 migrated the user settings dropdown from `antd` to `@signozhq/ui/dropdown-menu`. The new component doesn't use `ant-dropdown-menu-item` or `ant-dropdown-menu-title-content` class names, so the `.user-settings-dropdown-logout-section` color rule (nested under those dead selectors) never matched. Lifted the selector out of the stale Ant Design nesting.

| Before | After |
|---|---|
| <img width="241" height="274" alt="image" src="https://github.com/user-attachments/assets/3af1d043-609d-4eed-bf48-167cabd53ec1" /> | <img width="240" height="281" alt="image" src="https://github.com/user-attachments/assets/fc507d26-846a-4df3-849e-ea4a578b0d04" /> |

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🧪 Testing Strategy

- Manual verification on free trial account (billing page, workspace page, sign-out menu)

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** Settings layout, workspace callout, sign-out menu item
- **Potential regressions:** None - flex layout change only affects the Settings shell; callout fix is scoped to the license key callout; sign-out fix removes dead selectors
- **Rollback plan:** Revert commit