### PR TITLE
fix(settings): guard against non-APIError in logs retention error state

### DIFF
--- a/frontend/src/container/GeneralSettings/__tests__/index.test.tsx
+++ b/frontend/src/container/GeneralSettings/__tests__/index.test.tsx
@@ -1,0 +1,41 @@
+import { useQueries } from 'react-query';
+import { render, screen } from 'tests/test-utils';
+
+import GeneralSettings from '../index';
+
+jest.mock('react-query', () => ({
+	...jest.requireActual('react-query'),
+	useQueries: jest.fn(),
+}));
+
+const baseQueryResult = {
+	isError: false,
+	isLoading: false,
+	isFetching: false,
+	isSuccess: true,
+	data: undefined,
+	error: null,
+	refetch: jest.fn(),
+};
+
+describe('GeneralSettings index', () => {
+	it('renders fallback message when logs query fails with a non-APIError', () => {
+		(useQueries as jest.Mock).mockReturnValue([
+			{ ...baseQueryResult },
+			{ ...baseQueryResult },
+			{
+				...baseQueryResult,
+				isError: true,
+				isSuccess: false,
+				error: new TypeError(
+					"Cannot read properties of undefined (reading 'code')",
+				),
+			},
+			{ ...baseQueryResult },
+		]);
+
+		render(<GeneralSettings />);
+
+		expect(screen.getByText('something_went_wrong')).toBeInTheDocument();
+	});
+});

--- a/frontend/src/container/GeneralSettings/index.tsx
+++ b/frontend/src/container/GeneralSettings/index.tsx
@@ -76,7 +76,9 @@ function GeneralSettings(): JSX.Element {
 	if (getRetentionPeriodLogsApiResponse.isError || getDisksResponse.isError) {
 		return (
 			<Typography>
-				{(getRetentionPeriodLogsApiResponse.error as APIError).getErrorMessage() ||
+				{(getRetentionPeriodLogsApiResponse.error instanceof APIError
+					? getRetentionPeriodLogsApiResponse.error.getErrorMessage()
+					: undefined) ||
 					getDisksResponse.data?.error ||
 					t('something_went_wrong')}
 			</Typography>


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Fixes a production crash on the General Settings page when the backend returns a non-JSON 503 error (e.g. from a load balancer), caught via Sentry.

---

### 🐛 Bug Context

**Sentry issue fixed:**
- [SIGNOZ-UI-1KM](https://signoz-io.sentry.io/issues/7326436692/events/88a01ea6566549e8be124e859b0d6f83/) - `TypeError: getErrorMessage is not a function` on `/settings/my-settings`

**Root Cause:**
Two-stage failure when the backend returns a 503 with an HTML body (from a load balancer / infra layer, not SigNoz itself):

1. `ErrorResponseHandlerV2` tries to read `response.data.error.code` — but `response.data` is an HTML string, so `response.data.error` is `undefined` → throws a plain `TypeError` before ever constructing `APIError`.
2. `GeneralSettings/index.tsx:79` had `(error as APIError).getErrorMessage()` — an unsafe cast that silences TypeScript. At runtime the `.error` field held a `TypeError` (not `APIError`), so `.getErrorMessage` didn't exist → crash.

**Fix:**
```tsx
// Before - unsafe cast, crashes on non-APIError
(getRetentionPeriodLogsApiResponse.error as APIError).getErrorMessage()

// After - type-safe, no crash
getRetentionPeriodLogsApiResponse.error instanceof APIError
    ? getRetentionPeriodLogsApiResponse.error.getErrorMessage()
    : undefined
```

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🧪 Testing Strategy

- Added test for `GeneralSettings/index.tsx` simulating a `TypeError` in the logs query `.error` field — asserts fallback message renders instead of crashing.
- All existing tests pass.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** Single file, single error-state path in `GeneralSettings`. The `instanceof` guard is strictly safer than the cast — all existing error paths produce `APIError` and are unaffected.
- **Potential regressions:** None.
- **Rollback plan:** Single commit, fully isolated.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed crash on the General Settings page when the backend returns a non-JSON 503 error — replaced an unsafe `APIError` cast with an `instanceof` guard so infra-layer errors fall through to a generic message instead of crashing. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered
