### PR TITLE
fix(types): validate password length by rune count instead of bytes

### DIFF
--- a/pkg/types/factor_password.go
+++ b/pkg/types/factor_password.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/valuer"
@@ -17,7 +18,7 @@ import (
 var (
 	symbols                                []rune = []rune("~!@#$%^&*()_+`-={}|[]\\:\"<>?,./")
 	minPasswordLength                      int    = 12
-	ErrInvalidPassword                            = errors.Newf(errors.TypeInvalidInput, errors.MustNewCode("invalid_password"), "password must be at least %d characters long, should contain at least one uppercase letter [A-Z], one lowercase letter [a-z], one number [0-9], and one symbol [%c].", minPasswordLength, symbols)
+	ErrInvalidPassword                            = errors.Newf(errors.TypeInvalidInput, errors.MustNewCode("invalid_password"), "password must be at least %d characters long, should contain at least one uppercase letter [A-Z], one lowercase letter [a-z], one number [0-9], and one symbol [%s].", minPasswordLength, string(symbols))
 	ErrCodeResetPasswordTokenAlreadyExists        = errors.MustNewCode("reset_password_token_already_exists")
 	ErrCodePasswordNotFound                       = errors.MustNewCode("password_not_found")
 	ErrCodeResetPasswordTokenNotFound             = errors.MustNewCode("reset_password_token_not_found")
@@ -160,7 +161,7 @@ func NewResetPasswordToken(passwordID valuer.UUID, expiresAt time.Time) (*ResetP
 }
 
 func IsPasswordValid(password string) bool {
-	if len(password) < minPasswordLength {
+	if utf8.RuneCountInString(password) < minPasswordLength {
 		return false
 	}
 

--- a/pkg/types/factor_password_test.go
+++ b/pkg/types/factor_password_test.go
@@ -12,3 +12,41 @@ func TestMustGenerateFactorPassword(t *testing.T) {
 		MustGenerateFactorPassword(valuer.GenerateUUID().String())
 	})
 }
+
+func TestIsPasswordValid(t *testing.T) {
+	// length is measured in runes (characters), not bytes, so a password
+	// that satisfies the rule on byte-length but not character-length must
+	// be rejected. See https://github.com/SigNoz/signoz/issues/11111.
+	valid := []string{
+		"Abcdefghijk1!", // 13 ASCII chars
+	}
+	for _, pwd := range valid {
+		assert.Truef(t, IsPasswordValid(pwd), "expected password %q to be valid", pwd)
+	}
+
+	invalid := []string{
+		"",             // empty
+		"Abc1!",        // too short
+		"abcdefghijk1", // no uppercase, no symbol
+		"ABCDEFGHIJK1", // no lowercase, no symbol
+		"Abcdefghijk!", // no number
+		"Abcdefghijk1", // no symbol
+		"日本語Aa1!",      // only 7 characters; 13 bytes but fewer runes than minPasswordLength
+	}
+	for _, pwd := range invalid {
+		assert.Falsef(t, IsPasswordValid(pwd), "expected password %q to be invalid", pwd)
+	}
+
+	// a password of exactly minPasswordLength runes, using multibyte letters
+	// that are neutral to case, should still be accepted when all rules pass.
+	exactlyMin := "日本語Abcdefg1!" // 12 runes: 3 CJK + A + bcdefg + 1 + !
+	assert.True(t, IsPasswordValid(exactlyMin))
+}
+
+func TestErrInvalidPasswordMessage(t *testing.T) {
+	// the symbol list must render as a readable string, not as Go's default
+	// slice formatting (e.g. "%!c([]int=[...])").
+	msg := ErrInvalidPassword.Error()
+	assert.NotContains(t, msg, "%!")
+	assert.Contains(t, msg, string(symbols))
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?

`IsPasswordValid` enforced the minimum password length using `len(password)`, which counts **bytes**, not characters. A multibyte password such as `日本語Aa1!` is 7 characters but 13 bytes, so it passed the 12-character rule despite being far too short. This is the case confirmed in the issue's repro.

This PR fixes the length check to count characters (`utf8.RuneCountInString`) and also corrects the `ErrInvalidPassword` message, which formatted the symbol list with `%c` on a `[]rune` and rendered Go's default slice output (e.g. `%!c([]int=[...])`) instead of the allowed symbols.

#### Screenshots / Screen Recordings (if applicable)
N/A — backend validation only.

#### Issues closed by this PR
Refs #11111 (addresses points 1 and 5; see "Notes for Reviewers" for the remaining points)

---

### ✅ Change Type
- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
- `IsPasswordValid` used `len(password) < minPasswordLength`. `len` on a Go string returns byte length, so multibyte (non-Latin / emoji) passwords could satisfy the length rule with only a handful of actual characters.
- `ErrInvalidPassword` passed the `symbols` slice (`[]rune`) as an argument to `%c`, which expects a single code point. `fmt` falls back to printing the slice verbatim, producing an unreadable `%!c(...)` error message.

#### Fix Strategy
- Replace `len(password)` with `utf8.RuneCountInString(password)` so the minimum length is measured in characters.
- Format the symbol set as a string (`%s` with `string(symbols)`) so the error message shows the actual allowed symbols.

---

### 🧪 Testing Strategy
- Tests added/updated: `TestIsPasswordValid` covers valid/invalid cases, the multibyte repro (`日本語Aa1!`), and a password of exactly `minPasswordLength` runes that uses case-neutral CJK letters. `TestErrInvalidPasswordMessage` asserts the message renders cleanly (no `%!` tokens) and contains the symbol set.
- Manual verification: `go test ./pkg/types/`
- Edge cases covered: empty string, too-short ASCII, missing uppercase/lowercase/number/symbol, multibyte under-length, exactly-at-minimum multibyte password.

---

### ⚠️ Risk & Impact Assessment
- Blast radius: password validation on signup/reset/change flows. The only behavioral change is that previously-accepted multibyte passwords that were under the *intended* length are now correctly rejected — which is the intended fix.
- Potential regressions: existing users with valid ASCII passwords are unaffected (byte count and rune count are equal for ASCII).
- Rollback plan: revert the two-line change in `IsPasswordValid` and the error-format argument.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | OSS / Cloud / Enterprise |
| Change Type | Bug Fix |
| Description | Password length validation now counts characters instead of bytes; the invalid-password error message now renders the allowed symbols correctly. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested (`go test ./pkg/types/`)
- [x] Breaking changes documented (none — only tightens an under-enforced validation rule)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

This PR is intentionally scoped to the two backend items from #11111 that are clearly correct and low-risk:
- **Point 1** — rune-count length check (the confirmed repro).
- **Point 5** — broken error-message formatting.

The remaining items in the issue are deliberately left out of this PR and are good follow-ups:
- **Point 2** — broadening the symbol whitelist (e.g. `;`, `'`, space) is a security-posture decision and is best handled in its own change.
- **Point 3** — the `MustGenerateFactorPassword` panic is entangled with the whitelist (the generator can emit symbols the validator rejects); fixing it cleanly depends on point 2.
- **Point 4** — clearing stale frontend validation errors is a frontend-only change.

Happy to split or re-scope if a different approach is preferred.

---
