### PR TITLE
feat(statsreporter): expose collected stats via GET /api/v1/stats

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -12790,6 +12790,53 @@ paths:
       summary: Update a span mapper
       tags:
       - spanmapper
+  /api/v1/stats:
+    get:
+      deprecated: false
+      description: This endpoint returns the collected stats for the organization
+      operationId: GetStats
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    additionalProperties: {}
+                    type: object
+                  status:
+                    type: string
+                required:
+                - status
+                - data
+                type: object
+          description: OK
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Forbidden
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Internal Server Error
+      security:
+      - api_key:
+        - VIEWER
+      - tokenizer:
+        - VIEWER
+      summary: Get stats
+      tags:
+      - stats
   /api/v1/testChannel:
     post:
       deprecated: true

--- a/docs/contributing/go/handler.md
+++ b/docs/contributing/go/handler.md
@@ -109,6 +109,20 @@ func (h *handler) CreateThing(rw http.ResponseWriter, req *http.Request) {
 }
 ```
 
+When you need an ID from `claims` as a `valuer.UUID` (for example to pass it to a module), derive it with the `Must*` constructor instead of `NewUUID` plus an error check. Claims are validated by the auth middleware, so the conversion cannot fail and the error branch would be dead code:
+
+```go
+// Good — claims are pre-validated, the conversion cannot fail.
+orgID := valuer.MustNewUUID(claims.OrgID)
+
+// Avoid — the error path is unreachable.
+orgID, err := valuer.NewUUID(claims.OrgID)
+if err != nil {
+    render.Error(rw, err)
+    return
+}
+```
+
 ### 3. Register the handler in `signozapiserver`
 
 In `pkg/apiserver/signozapiserver`, add a route in the appropriate `add*Routes` function (`addUserRoutes`, `addSessionRoutes`, `addOrgRoutes`, etc.). The pattern is:
@@ -387,3 +401,4 @@ Note the discriminator property lives in the variants, not on the parent — the
 - **Add `nullable:"true"`** on fields that can be `null`. Pay special attention to slices and maps -- in Go these default to `nil` which serializes to `null`. If the field should always be an array, initialize it and do not mark it nullable.
 - **Implement `Enum()`** on every type that has a fixed set of acceptable values so the JSON schema generates proper `enum` constraints.
 - **Add request examples** via `RequestExamples` in `OpenAPIDef` for any non-trivial endpoint. See `pkg/apiserver/signozapiserver/querier.go` for reference.
+- **Derive IDs from `claims` with `valuer.MustNewUUID`** (e.g. `claims.OrgID`, `claims.UserID`). Claims are pre-validated by the auth middleware, so use the `Must*` constructor — don't write `NewUUID` followed by an `if err != nil { render.Error(...); return }` block.

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -9746,6 +9746,19 @@ export type UpdateSpanMapperPathParameters = {
 	groupId: string;
 	mapperId: string;
 };
+export type GetStats200Data = { [key: string]: unknown };
+
+export type GetStats200 = {
+	/**
+	 * @type object
+	 */
+	data: GetStats200Data;
+	/**
+	 * @type string
+	 */
+	status: string;
+};
+
 export type GetTraceAggregationsPathParameters = {
 	traceID: string;
 };

--- a/frontend/src/api/generated/services/stats/index.ts
+++ b/frontend/src/api/generated/services/stats/index.ts
@@ -1,0 +1,96 @@
+/**
+ * ! Do not edit manually
+ * * The file has been auto-generated using Orval for SigNoz
+ * * regenerate with 'pnpm generate:api'
+ * SigNoz
+ */
+import { useQuery } from 'react-query';
+import type {
+	InvalidateOptions,
+	QueryClient,
+	QueryFunction,
+	QueryKey,
+	UseQueryOptions,
+	UseQueryResult,
+} from 'react-query';
+
+import type { GetStats200, RenderErrorResponseDTO } from '../sigNoz.schemas';
+
+import { GeneratedAPIInstance } from '../../../generatedAPIInstance';
+import type { ErrorType } from '../../../generatedAPIInstance';
+
+/**
+ * This endpoint returns the collected stats for the organization
+ * @summary Get stats
+ */
+export const getStats = (signal?: AbortSignal) => {
+	return GeneratedAPIInstance<GetStats200>({
+		url: `/api/v1/stats`,
+		method: 'GET',
+		signal,
+	});
+};
+
+export const getGetStatsQueryKey = () => {
+	return [`/api/v1/stats`] as const;
+};
+
+export const getGetStatsQueryOptions = <
+	TData = Awaited<ReturnType<typeof getStats>>,
+	TError = ErrorType<RenderErrorResponseDTO>,
+>(options?: {
+	query?: UseQueryOptions<Awaited<ReturnType<typeof getStats>>, TError, TData>;
+}) => {
+	const { query: queryOptions } = options ?? {};
+
+	const queryKey = queryOptions?.queryKey ?? getGetStatsQueryKey();
+
+	const queryFn: QueryFunction<Awaited<ReturnType<typeof getStats>>> = ({
+		signal,
+	}) => getStats(signal);
+
+	return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+		Awaited<ReturnType<typeof getStats>>,
+		TError,
+		TData
+	> & { queryKey: QueryKey };
+};
+
+export type GetStatsQueryResult = NonNullable<
+	Awaited<ReturnType<typeof getStats>>
+>;
+export type GetStatsQueryError = ErrorType<RenderErrorResponseDTO>;
+
+/**
+ * @summary Get stats
+ */
+
+export function useGetStats<
+	TData = Awaited<ReturnType<typeof getStats>>,
+	TError = ErrorType<RenderErrorResponseDTO>,
+>(options?: {
+	query?: UseQueryOptions<Awaited<ReturnType<typeof getStats>>, TError, TData>;
+}): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
+	const queryOptions = getGetStatsQueryOptions(options);
+
+	const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
+		queryKey: QueryKey;
+	};
+
+	return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * @summary Get stats
+ */
+export const invalidateGetStats = async (
+	queryClient: QueryClient,
+	options?: InvalidateOptions,
+): Promise<QueryClient> => {
+	await queryClient.invalidateQueries(
+		{ queryKey: getGetStatsQueryKey() },
+		options,
+	);
+
+	return queryClient;
+};

--- a/pkg/apiserver/signozapiserver/provider.go
+++ b/pkg/apiserver/signozapiserver/provider.go
@@ -31,6 +31,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/modules/user"
 	"github.com/SigNoz/signoz/pkg/querier"
 	"github.com/SigNoz/signoz/pkg/ruler"
+	"github.com/SigNoz/signoz/pkg/statsreporter"
 	"github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
 	"github.com/SigNoz/signoz/pkg/zeus"
@@ -70,6 +71,7 @@ type provider struct {
 	traceDetailHandler      tracedetail.Handler
 	rulerHandler            ruler.Handler
 	llmPricingRuleHandler   llmpricingrule.Handler
+	statsHandler            statsreporter.Handler
 }
 
 func NewFactory(
@@ -102,6 +104,7 @@ func NewFactory(
 	llmPricingRuleHandler llmpricingrule.Handler,
 	traceDetailHandler tracedetail.Handler,
 	rulerHandler ruler.Handler,
+	statsHandler statsreporter.Handler,
 ) factory.ProviderFactory[apiserver.APIServer, apiserver.Config] {
 	return factory.NewProviderFactory(factory.MustNewName("signoz"), func(ctx context.Context, providerSettings factory.ProviderSettings, config apiserver.Config) (apiserver.APIServer, error) {
 		return newProvider(
@@ -137,6 +140,7 @@ func NewFactory(
 			llmPricingRuleHandler,
 			traceDetailHandler,
 			rulerHandler,
+			statsHandler,
 		)
 	})
 }
@@ -174,6 +178,7 @@ func newProvider(
 	llmPricingRuleHandler llmpricingrule.Handler,
 	traceDetailHandler tracedetail.Handler,
 	rulerHandler ruler.Handler,
+	statsHandler statsreporter.Handler,
 ) (apiserver.APIServer, error) {
 	settings := factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/apiserver/signozapiserver")
 	router := mux.NewRouter().UseEncodedPath()
@@ -210,6 +215,7 @@ func newProvider(
 		traceDetailHandler:      traceDetailHandler,
 		rulerHandler:            rulerHandler,
 		llmPricingRuleHandler:   llmPricingRuleHandler,
+		statsHandler:            statsHandler,
 	}
 
 	provider.authzMiddleware = middleware.NewAuthZ(settings.Logger(), orgGetter, authzService)
@@ -331,6 +337,10 @@ func (provider *provider) AddToRouter(router *mux.Router) error {
 	}
 
 	if err := provider.addRulerRoutes(router); err != nil {
+		return err
+	}
+
+	if err := provider.addStatsReporterRoutes(router); err != nil {
 		return err
 	}
 

--- a/pkg/apiserver/signozapiserver/statsreporter.go
+++ b/pkg/apiserver/signozapiserver/statsreporter.go
@@ -1,0 +1,33 @@
+package signozapiserver
+
+import (
+	"net/http"
+
+	"github.com/SigNoz/signoz/pkg/http/handler"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/gorilla/mux"
+)
+
+func (provider *provider) addStatsReporterRoutes(router *mux.Router) error {
+	if err := router.Handle("/api/v1/stats", handler.New(
+		provider.authzMiddleware.ViewAccess(provider.statsHandler.Get),
+		handler.OpenAPIDef{
+			ID:                  "GetStats",
+			Tags:                []string{"stats"},
+			Summary:             "Get stats",
+			Description:         "This endpoint returns the collected stats for the organization",
+			Request:             nil,
+			RequestContentType:  "",
+			Response:            map[string]any{},
+			ResponseContentType: "application/json",
+			SuccessStatusCode:   http.StatusOK,
+			ErrorStatusCodes:    []int{},
+			Deprecated:          false,
+			SecuritySchemes:     newSecuritySchemes(types.RoleViewer),
+		},
+	)).Methods(http.MethodGet).GetError(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/flagger/handler.go
+++ b/pkg/flagger/handler.go
@@ -35,11 +35,7 @@ func (handler *handler) GetFeatures(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
+	orgID := valuer.MustNewUUID(claims.OrgID)
 
 	evalCtx := featuretypes.NewFlaggerEvaluationContext(orgID)
 

--- a/pkg/querier/collect.go
+++ b/pkg/querier/collect.go
@@ -12,10 +12,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
 
-// Collect implements statsreporter.StatsCollector. It returns telemetry counts and last-observed
-// times for traces, logs and metrics. orgID is unused because the underlying tables are
-// cluster-global. Collection is best-effort: a failing query is logged and its key omitted rather
-// than failing the whole collection.
 func (q *querier) Collect(ctx context.Context, _ valuer.UUID) (map[string]any, error) {
 	stats := make(map[string]any)
 

--- a/pkg/querier/collect.go
+++ b/pkg/querier/collect.go
@@ -19,55 +19,46 @@ func (q *querier) Collect(ctx context.Context, _ valuer.UUID) (map[string]any, e
 	logsTable := fmt.Sprintf("%s.%s", telemetrylogs.DBName, telemetrylogs.LogsV2TableName)
 	metricsTable := fmt.Sprintf("%s.%s", telemetrymetrics.DBName, telemetrymetrics.SamplesV4TableName)
 
-	var traces uint64
-	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", tracesTable)).Scan(&traces); err == nil {
+	var (
+		traces           uint64
+		tracesLastSeenAt time.Time
+	)
+	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*), max(timestamp) FROM %s", tracesTable)).Scan(&traces, &tracesLastSeenAt); err == nil {
 		stats["telemetry.traces.count"] = traces
-	} else {
-		q.logger.DebugContext(ctx, "failed to collect traces count", errors.Attr(err))
-	}
-
-	var logs uint64
-	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", logsTable)).Scan(&logs); err == nil {
-		stats["telemetry.logs.count"] = logs
-	} else {
-		q.logger.DebugContext(ctx, "failed to collect logs count", errors.Attr(err))
-	}
-
-	var metrics uint64
-	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", metricsTable)).Scan(&metrics); err == nil {
-		stats["telemetry.metrics.count"] = metrics
-	} else {
-		q.logger.DebugContext(ctx, "failed to collect metrics count", errors.Attr(err))
-	}
-
-	var tracesLastSeenAt time.Time
-	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT max(timestamp) FROM %s", tracesTable)).Scan(&tracesLastSeenAt); err == nil {
 		if tracesLastSeenAt.Unix() != 0 {
 			stats["telemetry.traces.last_observed.time"] = tracesLastSeenAt.UTC()
 			stats["telemetry.traces.last_observed.time_unix"] = tracesLastSeenAt.Unix()
 		}
 	} else {
-		q.logger.DebugContext(ctx, "failed to collect traces last observed", errors.Attr(err))
+		q.logger.DebugContext(ctx, "failed to collect traces stats", errors.Attr(err))
 	}
 
-	var logsLastSeenAt time.Time
-	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT fromUnixTimestamp64Nano(max(timestamp)) FROM %s", logsTable)).Scan(&logsLastSeenAt); err == nil {
+	var (
+		logs           uint64
+		logsLastSeenAt time.Time
+	)
+	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*), fromUnixTimestamp64Nano(max(timestamp)) FROM %s", logsTable)).Scan(&logs, &logsLastSeenAt); err == nil {
+		stats["telemetry.logs.count"] = logs
 		if logsLastSeenAt.Unix() != 0 {
 			stats["telemetry.logs.last_observed.time"] = logsLastSeenAt.UTC()
 			stats["telemetry.logs.last_observed.time_unix"] = logsLastSeenAt.Unix()
 		}
 	} else {
-		q.logger.DebugContext(ctx, "failed to collect logs last observed", errors.Attr(err))
+		q.logger.DebugContext(ctx, "failed to collect logs stats", errors.Attr(err))
 	}
 
-	var metricsLastSeenAt time.Time
-	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT toDateTime(max(unix_milli) / 1000) FROM %s", metricsTable)).Scan(&metricsLastSeenAt); err == nil {
+	var (
+		metrics           uint64
+		metricsLastSeenAt time.Time
+	)
+	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*), toDateTime(max(unix_milli) / 1000) FROM %s", metricsTable)).Scan(&metrics, &metricsLastSeenAt); err == nil {
+		stats["telemetry.metrics.count"] = metrics
 		if metricsLastSeenAt.Unix() != 0 {
 			stats["telemetry.metrics.last_observed.time"] = metricsLastSeenAt.UTC()
 			stats["telemetry.metrics.last_observed.time_unix"] = metricsLastSeenAt.Unix()
 		}
 	} else {
-		q.logger.DebugContext(ctx, "failed to collect metrics last observed", errors.Attr(err))
+		q.logger.DebugContext(ctx, "failed to collect metrics stats", errors.Attr(err))
 	}
 
 	return stats, nil

--- a/pkg/querier/collect.go
+++ b/pkg/querier/collect.go
@@ -1,0 +1,78 @@
+package querier
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/telemetrylogs"
+	"github.com/SigNoz/signoz/pkg/telemetrymetrics"
+	"github.com/SigNoz/signoz/pkg/telemetrytraces"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+// Collect implements statsreporter.StatsCollector. It returns telemetry counts and last-observed
+// times for traces, logs and metrics. orgID is unused because the underlying tables are
+// cluster-global. Collection is best-effort: a failing query is logged and its key omitted rather
+// than failing the whole collection.
+func (q *querier) Collect(ctx context.Context, _ valuer.UUID) (map[string]any, error) {
+	stats := make(map[string]any)
+
+	tracesTable := fmt.Sprintf("%s.%s", telemetrytraces.DBName, telemetrytraces.SpanIndexV3TableName)
+	logsTable := fmt.Sprintf("%s.%s", telemetrylogs.DBName, telemetrylogs.LogsV2TableName)
+	metricsTable := fmt.Sprintf("%s.%s", telemetrymetrics.DBName, telemetrymetrics.SamplesV4TableName)
+
+	var traces uint64
+	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", tracesTable)).Scan(&traces); err == nil {
+		stats["telemetry.traces.count"] = traces
+	} else {
+		q.logger.DebugContext(ctx, "failed to collect traces count", errors.Attr(err))
+	}
+
+	var logs uint64
+	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", logsTable)).Scan(&logs); err == nil {
+		stats["telemetry.logs.count"] = logs
+	} else {
+		q.logger.DebugContext(ctx, "failed to collect logs count", errors.Attr(err))
+	}
+
+	var metrics uint64
+	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", metricsTable)).Scan(&metrics); err == nil {
+		stats["telemetry.metrics.count"] = metrics
+	} else {
+		q.logger.DebugContext(ctx, "failed to collect metrics count", errors.Attr(err))
+	}
+
+	var tracesLastSeenAt time.Time
+	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT max(timestamp) FROM %s", tracesTable)).Scan(&tracesLastSeenAt); err == nil {
+		if tracesLastSeenAt.Unix() != 0 {
+			stats["telemetry.traces.last_observed.time"] = tracesLastSeenAt.UTC()
+			stats["telemetry.traces.last_observed.time_unix"] = tracesLastSeenAt.Unix()
+		}
+	} else {
+		q.logger.DebugContext(ctx, "failed to collect traces last observed", errors.Attr(err))
+	}
+
+	var logsLastSeenAt time.Time
+	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT fromUnixTimestamp64Nano(max(timestamp)) FROM %s", logsTable)).Scan(&logsLastSeenAt); err == nil {
+		if logsLastSeenAt.Unix() != 0 {
+			stats["telemetry.logs.last_observed.time"] = logsLastSeenAt.UTC()
+			stats["telemetry.logs.last_observed.time_unix"] = logsLastSeenAt.Unix()
+		}
+	} else {
+		q.logger.DebugContext(ctx, "failed to collect logs last observed", errors.Attr(err))
+	}
+
+	var metricsLastSeenAt time.Time
+	if err := q.telemetryStore.ClickhouseDB().QueryRow(ctx, fmt.Sprintf("SELECT toDateTime(max(unix_milli) / 1000) FROM %s", metricsTable)).Scan(&metricsLastSeenAt); err == nil {
+		if metricsLastSeenAt.Unix() != 0 {
+			stats["telemetry.metrics.last_observed.time"] = metricsLastSeenAt.UTC()
+			stats["telemetry.metrics.last_observed.time_unix"] = metricsLastSeenAt.Unix()
+		}
+	} else {
+		q.logger.DebugContext(ctx, "failed to collect metrics last observed", errors.Attr(err))
+	}
+
+	return stats, nil
+}

--- a/pkg/querier/interfaces.go
+++ b/pkg/querier/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/SigNoz/signoz/pkg/statsreporter"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
@@ -12,6 +13,7 @@ import (
 type Querier interface {
 	QueryRange(ctx context.Context, orgID valuer.UUID, req *qbtypes.QueryRangeRequest) (*qbtypes.QueryRangeResponse, error)
 	QueryRawStream(ctx context.Context, orgID valuer.UUID, req *qbtypes.QueryRangeRequest, client *qbtypes.RawStream)
+	statsreporter.StatsCollector
 }
 
 // BucketCache is the interface for bucket-based caching.

--- a/pkg/signoz/handler.go
+++ b/pkg/signoz/handler.go
@@ -49,6 +49,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/querier"
 	"github.com/SigNoz/signoz/pkg/ruler"
 	"github.com/SigNoz/signoz/pkg/ruler/signozruler"
+	"github.com/SigNoz/signoz/pkg/statsreporter"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/zeus"
 )
@@ -80,6 +81,7 @@ type Handlers struct {
 	TraceDetail             tracedetail.Handler
 	RulerHandler            ruler.Handler
 	LLMPricingRuleHandler   llmpricingrule.Handler
+	StatsHandler            statsreporter.Handler
 }
 
 func NewHandlers(
@@ -97,6 +99,7 @@ func NewHandlers(
 	registryHandler factory.Handler,
 	alertmanagerService alertmanager.Alertmanager,
 	rulerService ruler.Ruler,
+	statsAggregator statsreporter.Aggregator,
 ) Handlers {
 	return Handlers{
 		SavedView:               implsavedview.NewHandler(modules.SavedView),
@@ -125,5 +128,6 @@ func NewHandlers(
 		TraceDetail:             impltracedetail.NewHandler(modules.TraceDetail),
 		RulerHandler:            signozruler.NewHandler(rulerService),
 		LLMPricingRuleHandler:   impllmpricingrule.NewHandler(modules.LLMPricingRule),
+		StatsHandler:            statsreporter.NewHandler(statsAggregator),
 	}
 }

--- a/pkg/signoz/handler_test.go
+++ b/pkg/signoz/handler_test.go
@@ -63,7 +63,7 @@ func TestNewHandlers(t *testing.T) {
 
 	querierHandler := querier.NewHandler(providerSettings, nil, nil)
 	registryHandler := factory.NewHandler(nil)
-	handlers := NewHandlers(modules, providerSettings, nil, querierHandler, nil, nil, nil, nil, nil, nil, nil, registryHandler, alertmanager, nil)
+	handlers := NewHandlers(modules, providerSettings, nil, querierHandler, nil, nil, nil, nil, nil, nil, nil, registryHandler, alertmanager, nil, nil)
 	reflectVal := reflect.ValueOf(handlers)
 	for i := 0; i < reflectVal.NumField(); i++ {
 		f := reflectVal.Field(i)

--- a/pkg/signoz/openapi.go
+++ b/pkg/signoz/openapi.go
@@ -36,6 +36,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/modules/user"
 	"github.com/SigNoz/signoz/pkg/querier"
 	"github.com/SigNoz/signoz/pkg/ruler"
+	"github.com/SigNoz/signoz/pkg/statsreporter"
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
 	"github.com/SigNoz/signoz/pkg/zeus"
 	"github.com/swaggest/jsonschema-go"
@@ -83,6 +84,7 @@ func NewOpenAPI(ctx context.Context, instrumentation instrumentation.Instrumenta
 		struct{ llmpricingrule.Handler }{},
 		struct{ tracedetail.Handler }{},
 		struct{ ruler.Handler }{},
+		struct{ statsreporter.Handler }{},
 	).New(ctx, instrumentation.ToProviderSettings(), apiserver.Config{})
 	if err != nil {
 		return nil, err

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -264,9 +264,9 @@ func NewSharderProviderFactories() factory.NamedMap[factory.ProviderFactory[shar
 	)
 }
 
-func NewStatsReporterProviderFactories(telemetryStore telemetrystore.TelemetryStore, collectors []statsreporter.StatsCollector, orgGetter organization.Getter, userGetter user.Getter, tokenizer tokenizer.Tokenizer, build version.Build, analyticsConfig analytics.Config) factory.NamedMap[factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config]] {
+func NewStatsReporterProviderFactories(aggregator statsreporter.Aggregator, orgGetter organization.Getter, userGetter user.Getter, tokenizer tokenizer.Tokenizer, build version.Build, analyticsConfig analytics.Config) factory.NamedMap[factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config]] {
 	return factory.MustNewNamedMap(
-		analyticsstatsreporter.NewFactory(telemetryStore, collectors, orgGetter, userGetter, tokenizer, build, analyticsConfig),
+		analyticsstatsreporter.NewFactory(aggregator, orgGetter, userGetter, tokenizer, build, analyticsConfig),
 		noopstatsreporter.NewFactory(),
 	)
 }
@@ -309,6 +309,7 @@ func NewAPIServerProviderFactories(orgGetter organization.Getter, authz authz.Au
 			handlers.LLMPricingRuleHandler,
 			handlers.TraceDetail,
 			handlers.RulerHandler,
+			handlers.StatsHandler,
 		),
 	)
 }

--- a/pkg/signoz/provider_test.go
+++ b/pkg/signoz/provider_test.go
@@ -85,8 +85,7 @@ func TestNewProviderFactories(t *testing.T) {
 
 		userGetter := impluser.NewGetter(impluser.NewStore(sqlstoretest.New(sqlstore.Config{Provider: "sqlite"}, sqlmock.QueryMatcherEqual), instrumentationtest.New().ToProviderSettings()), userRoleStore, flagger)
 		orgGetter := implorganization.NewGetter(implorganization.NewStore(sqlstoretest.New(sqlstore.Config{Provider: "sqlite"}, sqlmock.QueryMatcherEqual)), nil)
-		telemetryStore := telemetrystoretest.New(telemetrystore.Config{Provider: "clickhouse"}, sqlmock.QueryMatcherEqual)
-		statsAggregator := statsreporter.NewAggregator(providerSettings, telemetryStore, []statsreporter.StatsCollector{})
+		statsAggregator := statsreporter.NewAggregator(providerSettings, []statsreporter.StatsCollector{})
 		NewStatsReporterProviderFactories(statsAggregator, orgGetter, userGetter, tokenizertest.NewMockTokenizer(t), version.Build{}, analytics.Config{Enabled: true})
 	})
 

--- a/pkg/signoz/provider_test.go
+++ b/pkg/signoz/provider_test.go
@@ -86,7 +86,8 @@ func TestNewProviderFactories(t *testing.T) {
 		userGetter := impluser.NewGetter(impluser.NewStore(sqlstoretest.New(sqlstore.Config{Provider: "sqlite"}, sqlmock.QueryMatcherEqual), instrumentationtest.New().ToProviderSettings()), userRoleStore, flagger)
 		orgGetter := implorganization.NewGetter(implorganization.NewStore(sqlstoretest.New(sqlstore.Config{Provider: "sqlite"}, sqlmock.QueryMatcherEqual)), nil)
 		telemetryStore := telemetrystoretest.New(telemetrystore.Config{Provider: "clickhouse"}, sqlmock.QueryMatcherEqual)
-		NewStatsReporterProviderFactories(telemetryStore, []statsreporter.StatsCollector{}, orgGetter, userGetter, tokenizertest.NewMockTokenizer(t), version.Build{}, analytics.Config{Enabled: true})
+		statsAggregator := statsreporter.NewAggregator(providerSettings, telemetryStore, []statsreporter.StatsCollector{})
+		NewStatsReporterProviderFactories(statsAggregator, orgGetter, userGetter, tokenizertest.NewMockTokenizer(t), version.Build{}, analytics.Config{Enabled: true})
 	})
 
 	assert.NotPanics(t, func() {

--- a/pkg/signoz/signoz.go
+++ b/pkg/signoz/signoz.go
@@ -499,10 +499,11 @@ func New(
 		serviceAccount,
 		cloudIntegrationModule,
 		modules.LogsPipeline,
+		querier,
 	}
 
 	// Initialize the stats aggregator (always-on, independent of whether reporting is enabled)
-	statsAggregator := statsreporter.NewAggregator(providerSettings, telemetrystore, statsCollectors)
+	statsAggregator := statsreporter.NewAggregator(providerSettings, statsCollectors)
 
 	// Initialize stats reporter from the available stats reporter provider factories
 	statsReporter, err := factory.NewProviderFromNamedMap(

--- a/pkg/signoz/signoz.go
+++ b/pkg/signoz/signoz.go
@@ -501,12 +501,15 @@ func New(
 		modules.LogsPipeline,
 	}
 
+	// Initialize the stats aggregator (always-on, independent of whether reporting is enabled)
+	statsAggregator := statsreporter.NewAggregator(providerSettings, telemetrystore, statsCollectors)
+
 	// Initialize stats reporter from the available stats reporter provider factories
 	statsReporter, err := factory.NewProviderFromNamedMap(
 		ctx,
 		providerSettings,
 		config.StatsReporter,
-		NewStatsReporterProviderFactories(telemetrystore, statsCollectors, orgGetter, userGetter, tokenizer, version.Info, config.Analytics),
+		NewStatsReporterProviderFactories(statsAggregator, orgGetter, userGetter, tokenizer, version.Info, config.Analytics),
 		config.StatsReporter.Provider(),
 	)
 	if err != nil {
@@ -535,7 +538,7 @@ func New(
 
 	// Initialize all handlers for the modules
 	registryHandler := factory.NewHandler(registry)
-	handlers := NewHandlers(modules, providerSettings, analytics, querierHandler, licensing, global, flagger, gateway, telemetryMetadataStore, authz, zeus, registryHandler, alertmanager, rulerInstance)
+	handlers := NewHandlers(modules, providerSettings, analytics, querierHandler, licensing, global, flagger, gateway, telemetryMetadataStore, authz, zeus, registryHandler, alertmanager, rulerInstance, statsAggregator)
 
 	// Initialize the API server (after registry so it can access service health)
 	apiserverInstance, err := factory.NewProviderFromNamedMap(

--- a/pkg/statsreporter/aggregator.go
+++ b/pkg/statsreporter/aggregator.go
@@ -3,18 +3,15 @@ package statsreporter
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
-	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/types/ctxtypes"
 	"github.com/SigNoz/signoz/pkg/types/instrumentationtypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
 
-// Aggregator aggregates stats from every registered StatsCollector together with
-// telemetry-store counts for a single organization.
+// Aggregator aggregates stats from every registered StatsCollector for a single organization.
 type Aggregator interface {
 	Aggregate(ctx context.Context, orgID valuer.UUID) (map[string]any, error)
 }
@@ -23,20 +20,16 @@ type aggregator struct {
 	// settings
 	settings factory.ScopedProviderSettings
 
-	// used to get telemetry details. srikanthcvv to move this to the querier layer
-	telemetryStore telemetrystore.TelemetryStore
-
 	// a list of collectors, used to collect stats from across the codebase
 	collectors []StatsCollector
 }
 
-func NewAggregator(providerSettings factory.ProviderSettings, telemetryStore telemetrystore.TelemetryStore, collectors []StatsCollector) Aggregator {
+func NewAggregator(providerSettings factory.ProviderSettings, collectors []StatsCollector) Aggregator {
 	settings := factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/statsreporter")
 
 	return &aggregator{
-		settings:       settings,
-		telemetryStore: telemetryStore,
-		collectors:     collectors,
+		settings:   settings,
+		collectors: collectors,
 	}
 }
 
@@ -69,45 +62,6 @@ func (aggregator *aggregator) Aggregate(ctx context.Context, orgID valuer.UUID) 
 		}(collector)
 	}
 	wg.Wait()
-
-	var traces uint64
-	if err := aggregator.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT COUNT(*) FROM signoz_traces.distributed_signoz_index_v3").Scan(&traces); err == nil {
-		stats["telemetry.traces.count"] = traces
-	}
-
-	var logs uint64
-	if err := aggregator.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT COUNT(*) FROM signoz_logs.distributed_logs_v2").Scan(&logs); err == nil {
-		stats["telemetry.logs.count"] = logs
-	}
-
-	var metrics uint64
-	if err := aggregator.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT COUNT(*) FROM signoz_metrics.distributed_samples_v4").Scan(&metrics); err == nil {
-		stats["telemetry.metrics.count"] = metrics
-	}
-
-	var tracesLastSeenAt time.Time
-	if err := aggregator.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT max(timestamp) FROM signoz_traces.distributed_signoz_index_v3").Scan(&tracesLastSeenAt); err == nil {
-		if tracesLastSeenAt.Unix() != 0 {
-			stats["telemetry.traces.last_observed.time"] = tracesLastSeenAt.UTC()
-			stats["telemetry.traces.last_observed.time_unix"] = tracesLastSeenAt.Unix()
-		}
-	}
-
-	var logsLastSeenAt time.Time
-	if err := aggregator.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT fromUnixTimestamp64Nano(max(timestamp)) FROM signoz_logs.distributed_logs_v2").Scan(&logsLastSeenAt); err == nil {
-		if logsLastSeenAt.Unix() != 0 {
-			stats["telemetry.logs.last_observed.time"] = logsLastSeenAt.UTC()
-			stats["telemetry.logs.last_observed.time_unix"] = logsLastSeenAt.Unix()
-		}
-	}
-
-	var metricsLastSeenAt time.Time
-	if err := aggregator.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT toDateTime(max(unix_milli) / 1000) FROM signoz_metrics.distributed_samples_v4").Scan(&metricsLastSeenAt); err == nil {
-		if metricsLastSeenAt.Unix() != 0 {
-			stats["telemetry.metrics.last_observed.time"] = metricsLastSeenAt.UTC()
-			stats["telemetry.metrics.last_observed.time_unix"] = metricsLastSeenAt.Unix()
-		}
-	}
 
 	return stats, nil
 }

--- a/pkg/statsreporter/aggregator.go
+++ b/pkg/statsreporter/aggregator.go
@@ -1,0 +1,113 @@
+package statsreporter
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/telemetrystore"
+	"github.com/SigNoz/signoz/pkg/types/ctxtypes"
+	"github.com/SigNoz/signoz/pkg/types/instrumentationtypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+// Aggregator aggregates stats from every registered StatsCollector together with
+// telemetry-store counts for a single organization.
+type Aggregator interface {
+	Aggregate(ctx context.Context, orgID valuer.UUID) (map[string]any, error)
+}
+
+type aggregator struct {
+	// settings
+	settings factory.ScopedProviderSettings
+
+	// used to get telemetry details. srikanthcvv to move this to the querier layer
+	telemetryStore telemetrystore.TelemetryStore
+
+	// a list of collectors, used to collect stats from across the codebase
+	collectors []StatsCollector
+}
+
+func NewAggregator(providerSettings factory.ProviderSettings, telemetryStore telemetrystore.TelemetryStore, collectors []StatsCollector) Aggregator {
+	settings := factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/statsreporter")
+
+	return &aggregator{
+		settings:       settings,
+		telemetryStore: telemetryStore,
+		collectors:     collectors,
+	}
+}
+
+func (aggregator *aggregator) Aggregate(ctx context.Context, orgID valuer.UUID) (map[string]any, error) {
+	ctx = ctxtypes.NewContextWithCommentVals(ctx, map[string]string{
+		instrumentationtypes.CodeNamespace:    "statsreporter",
+		instrumentationtypes.CodeFunctionName: "Aggregate",
+	})
+	var wg sync.WaitGroup
+	wg.Add(len(aggregator.collectors))
+
+	stats := make(map[string]any, 0)
+	mtx := sync.Mutex{}
+
+	for _, collector := range aggregator.collectors {
+		go func(collector StatsCollector) {
+			defer wg.Done()
+
+			collectorStats, err := collector.Collect(ctx, orgID)
+			if err != nil {
+				aggregator.settings.Logger().ErrorContext(ctx, "failed to collect stats", errors.Attr(err))
+				return
+			}
+
+			mtx.Lock()
+			for k, v := range collectorStats {
+				stats[k] = v
+			}
+			mtx.Unlock()
+		}(collector)
+	}
+	wg.Wait()
+
+	var traces uint64
+	if err := aggregator.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT COUNT(*) FROM signoz_traces.distributed_signoz_index_v3").Scan(&traces); err == nil {
+		stats["telemetry.traces.count"] = traces
+	}
+
+	var logs uint64
+	if err := aggregator.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT COUNT(*) FROM signoz_logs.distributed_logs_v2").Scan(&logs); err == nil {
+		stats["telemetry.logs.count"] = logs
+	}
+
+	var metrics uint64
+	if err := aggregator.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT COUNT(*) FROM signoz_metrics.distributed_samples_v4").Scan(&metrics); err == nil {
+		stats["telemetry.metrics.count"] = metrics
+	}
+
+	var tracesLastSeenAt time.Time
+	if err := aggregator.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT max(timestamp) FROM signoz_traces.distributed_signoz_index_v3").Scan(&tracesLastSeenAt); err == nil {
+		if tracesLastSeenAt.Unix() != 0 {
+			stats["telemetry.traces.last_observed.time"] = tracesLastSeenAt.UTC()
+			stats["telemetry.traces.last_observed.time_unix"] = tracesLastSeenAt.Unix()
+		}
+	}
+
+	var logsLastSeenAt time.Time
+	if err := aggregator.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT fromUnixTimestamp64Nano(max(timestamp)) FROM signoz_logs.distributed_logs_v2").Scan(&logsLastSeenAt); err == nil {
+		if logsLastSeenAt.Unix() != 0 {
+			stats["telemetry.logs.last_observed.time"] = logsLastSeenAt.UTC()
+			stats["telemetry.logs.last_observed.time_unix"] = logsLastSeenAt.Unix()
+		}
+	}
+
+	var metricsLastSeenAt time.Time
+	if err := aggregator.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT toDateTime(max(unix_milli) / 1000) FROM signoz_metrics.distributed_samples_v4").Scan(&metricsLastSeenAt); err == nil {
+		if metricsLastSeenAt.Unix() != 0 {
+			stats["telemetry.metrics.last_observed.time"] = metricsLastSeenAt.UTC()
+			stats["telemetry.metrics.last_observed.time_unix"] = metricsLastSeenAt.Unix()
+		}
+	}
+
+	return stats, nil
+}

--- a/pkg/statsreporter/analyticsstatsreporter/provider.go
+++ b/pkg/statsreporter/analyticsstatsreporter/provider.go
@@ -3,7 +3,6 @@ package analyticsstatsreporter
 import (
 	"context"
 	"log/slog"
-	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -16,11 +15,8 @@ import (
 	"github.com/SigNoz/signoz/pkg/modules/organization"
 	"github.com/SigNoz/signoz/pkg/modules/user"
 	"github.com/SigNoz/signoz/pkg/statsreporter"
-	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/tokenizer"
 	"github.com/SigNoz/signoz/pkg/types"
-	"github.com/SigNoz/signoz/pkg/types/ctxtypes"
-	"github.com/SigNoz/signoz/pkg/types/instrumentationtypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/SigNoz/signoz/pkg/version"
 )
@@ -32,11 +28,8 @@ type provider struct {
 	// config
 	config statsreporter.Config
 
-	// used to get telemetry details. srikanthcvv to move this to the querier layer
-	telemetryStore telemetrystore.TelemetryStore
-
-	// a list of collectors, used to collect stats from across the codebase
-	collectors []statsreporter.StatsCollector
+	// used to aggregate stats for an organization
+	aggregator statsreporter.Aggregator
 
 	// used to get organizations
 	orgGetter organization.Getter
@@ -60,9 +53,9 @@ type provider struct {
 	stopC chan struct{}
 }
 
-func NewFactory(telemetryStore telemetrystore.TelemetryStore, collectors []statsreporter.StatsCollector, orgGetter organization.Getter, userGetter user.Getter, tokenizer tokenizer.Tokenizer, build version.Build, analyticsConfig analytics.Config) factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config] {
+func NewFactory(aggregator statsreporter.Aggregator, orgGetter organization.Getter, userGetter user.Getter, tokenizer tokenizer.Tokenizer, build version.Build, analyticsConfig analytics.Config) factory.ProviderFactory[statsreporter.StatsReporter, statsreporter.Config] {
 	return factory.NewProviderFactory(factory.MustNewName("analytics"), func(ctx context.Context, settings factory.ProviderSettings, config statsreporter.Config) (statsreporter.StatsReporter, error) {
-		return New(ctx, settings, config, telemetryStore, collectors, orgGetter, userGetter, tokenizer, build, analyticsConfig)
+		return New(ctx, settings, config, aggregator, orgGetter, userGetter, tokenizer, build, analyticsConfig)
 	})
 }
 
@@ -70,8 +63,7 @@ func New(
 	ctx context.Context,
 	providerSettings factory.ProviderSettings,
 	config statsreporter.Config,
-	telemetryStore telemetrystore.TelemetryStore,
-	collectors []statsreporter.StatsCollector,
+	aggregator statsreporter.Aggregator,
 	orgGetter organization.Getter,
 	userGetter user.Getter,
 	tokenizer tokenizer.Tokenizer,
@@ -86,17 +78,16 @@ func New(
 	}
 
 	return &provider{
-		settings:       settings,
-		config:         config,
-		telemetryStore: telemetryStore,
-		collectors:     collectors,
-		orgGetter:      orgGetter,
-		userGetter:     userGetter,
-		analytics:      analytics,
-		tokenizer:      tokenizer,
-		build:          build,
-		deployment:     deployment,
-		stopC:          make(chan struct{}),
+		settings:   settings,
+		config:     config,
+		aggregator: aggregator,
+		orgGetter:  orgGetter,
+		userGetter: userGetter,
+		analytics:  analytics,
+		tokenizer:  tokenizer,
+		build:      build,
+		deployment: deployment,
+		stopC:      make(chan struct{}),
 	}, nil
 }
 
@@ -134,7 +125,12 @@ func (provider *provider) Report(ctx context.Context) error {
 	}
 
 	for _, org := range orgs {
-		stats := provider.collectOrg(ctx, org.ID)
+		stats, err := provider.aggregator.Aggregate(ctx, org.ID)
+		if err != nil {
+			provider.settings.Logger().WarnContext(ctx, "failed to aggregate stats", errors.Attr(err), slog.Any("org_id", org.ID))
+			continue
+		}
+
 		if len(stats) == 0 {
 			provider.settings.Logger().WarnContext(ctx, "no stats collected", slog.Any("org_id", org.ID))
 			continue
@@ -203,76 +199,4 @@ func (provider *provider) Stop(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (provider *provider) collectOrg(ctx context.Context, orgID valuer.UUID) map[string]any {
-	ctx = ctxtypes.NewContextWithCommentVals(ctx, map[string]string{
-		instrumentationtypes.CodeNamespace:    "statsreporter",
-		instrumentationtypes.CodeFunctionName: "collectOrg",
-	})
-	var wg sync.WaitGroup
-	wg.Add(len(provider.collectors))
-
-	stats := make(map[string]any, 0)
-	mtx := sync.Mutex{}
-
-	for _, collector := range provider.collectors {
-		go func(collector statsreporter.StatsCollector) {
-			defer wg.Done()
-
-			collectorStats, err := collector.Collect(ctx, orgID)
-			if err != nil {
-				provider.settings.Logger().ErrorContext(ctx, "failed to collect stats", errors.Attr(err))
-				return
-			}
-
-			mtx.Lock()
-			for k, v := range collectorStats {
-				stats[k] = v
-			}
-			mtx.Unlock()
-		}(collector)
-	}
-	wg.Wait()
-
-	var traces uint64
-	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT COUNT(*) FROM signoz_traces.distributed_signoz_index_v3").Scan(&traces); err == nil {
-		stats["telemetry.traces.count"] = traces
-	}
-
-	var logs uint64
-	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT COUNT(*) FROM signoz_logs.distributed_logs_v2").Scan(&logs); err == nil {
-		stats["telemetry.logs.count"] = logs
-	}
-
-	var metrics uint64
-	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT COUNT(*) FROM signoz_metrics.distributed_samples_v4").Scan(&metrics); err == nil {
-		stats["telemetry.metrics.count"] = metrics
-	}
-
-	var tracesLastSeenAt time.Time
-	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT max(timestamp) FROM signoz_traces.distributed_signoz_index_v3").Scan(&tracesLastSeenAt); err == nil {
-		if tracesLastSeenAt.Unix() != 0 {
-			stats["telemetry.traces.last_observed.time"] = tracesLastSeenAt.UTC()
-			stats["telemetry.traces.last_observed.time_unix"] = tracesLastSeenAt.Unix()
-		}
-	}
-
-	var logsLastSeenAt time.Time
-	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT fromUnixTimestamp64Nano(max(timestamp)) FROM signoz_logs.distributed_logs_v2").Scan(&logsLastSeenAt); err == nil {
-		if logsLastSeenAt.Unix() != 0 {
-			stats["telemetry.logs.last_observed.time"] = logsLastSeenAt.UTC()
-			stats["telemetry.logs.last_observed.time_unix"] = logsLastSeenAt.Unix()
-		}
-	}
-
-	var metricsLastSeenAt time.Time
-	if err := provider.telemetryStore.ClickhouseDB().QueryRow(ctx, "SELECT toDateTime(max(unix_milli) / 1000) FROM signoz_metrics.distributed_samples_v4").Scan(&metricsLastSeenAt); err == nil {
-		if metricsLastSeenAt.Unix() != 0 {
-			stats["telemetry.metrics.last_observed.time"] = metricsLastSeenAt.UTC()
-			stats["telemetry.metrics.last_observed.time_unix"] = metricsLastSeenAt.Unix()
-		}
-	}
-
-	return stats
 }

--- a/pkg/statsreporter/handler.go
+++ b/pkg/statsreporter/handler.go
@@ -1,0 +1,50 @@
+package statsreporter
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/http/render"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+type Handler interface {
+	Get(http.ResponseWriter, *http.Request)
+}
+
+type handler struct {
+	aggregator Aggregator
+}
+
+func NewHandler(aggregator Aggregator) Handler {
+	return &handler{
+		aggregator: aggregator,
+	}
+}
+
+func (handler *handler) Get(rw http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	claims, err := authtypes.ClaimsFromContext(ctx)
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	orgID, err := valuer.NewUUID(claims.OrgID)
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	stats, err := handler.aggregator.Aggregate(ctx, orgID)
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	render.Success(rw, http.StatusOK, stats)
+}

--- a/pkg/statsreporter/handler.go
+++ b/pkg/statsreporter/handler.go
@@ -34,11 +34,7 @@ func (handler *handler) Get(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
+	orgID := valuer.MustNewUUID(claims.OrgID)
 
 	stats, err := handler.aggregator.Aggregate(ctx, orgID)
 	if err != nil {


### PR DESCRIPTION
## What

Adds `GET /api/v1/stats`, exposing the per-org stats bag that was previously only pushed to analytics on a 6-hour timer.

- **Always-on collection.** Stats collection is extracted out of the analytics reporter into a shared `Aggregator` used by both the reporter and a new HTTP handler, so the endpoint works regardless of whether scheduled reporting is enabled (`statsreporter.enabled`). The endpoint requires viewer access.
- **Telemetry reads moved to the querier.** The trace/log/metric row-count and last-observed ClickHouse queries move out of `statsreporter` into the querier, which now implements `statsreporter.StatsCollector` and is wired in as one of the collectors. The aggregator becomes a pure collector fan-out and no longer depends on `telemetrystore` - - addressing the standing _"move this to the querier layer"_ TODO.

closes SigNoz/platform-pod#2489
