### PR TITLE
feat: add ORDER BY and LIMIT support for metrics queries

### DIFF
--- a/frontend/src/constants/queryBuilder.ts
+++ b/frontend/src/constants/queryBuilder.ts
@@ -103,6 +103,8 @@ export const metricsSpaceAggregationOperatorsByType = {
 
 export const mapOfQueryFilters: Record<DataSource, QueryAdditionalFilter[]> = {
 	metrics: [
+		{ text: 'Order by', field: 'orderBy' },
+		{ text: 'Limit', field: 'limit' },
 		{ text: 'Aggregation interval', field: 'stepInterval' },
 		{ text: 'Having', field: 'having' },
 	],

--- a/pkg/telemetrymetrics/statement_builder.go
+++ b/pkg/telemetrymetrics/statement_builder.go
@@ -619,10 +619,26 @@ func (b *MetricQueryStatementBuilder) BuildFinalSelect(
 			sb.Where(rewrittenExpr)
 		}
 	}
-	sb.OrderBy(querybuilder.GroupByKeys(query.GroupBy)...)
-	sb.OrderBy("ts")
+	if len(query.Order) > 0 {
+		for _, orderBy := range query.Order {
+			colName := orderBy.Key.Name
+			if colName == "value" {
+				sb.OrderBy(fmt.Sprintf("value %s", orderBy.Direction.StringValue()))
+			} else {
+				sb.OrderBy(fmt.Sprintf("`%s` %s", colName, orderBy.Direction.StringValue()))
+			}
+		}
+		sb.OrderBy("ts")
+	} else {
+		sb.OrderBy(querybuilder.GroupByKeys(query.GroupBy)...)
+		sb.OrderBy("ts")
+	}
 	if metricType == metrictypes.HistogramType && spaceAgg == metrictypes.SpaceAggregationCount && query.Aggregations[0].ComparisonSpaceAggregationParam == nil {
 		sb.OrderBy("toFloat64(le)")
+	}
+
+	if query.Limit > 0 {
+		sb.Limit(query.Limit)
 	}
 
 	q, a := sb.BuildWithFlavor(sqlbuilder.ClickHouse)


### PR DESCRIPTION
## Summary

Add ORDER BY and LIMIT support for metrics data source in the query builder, enabling users to rank grouped metric results and keep only the top (or bottom) N entries.

Fixes #11678

## Problem

The metrics data source was missing ORDER BY and LIMIT controls that already exist for logs and traces. Users could not sort and limit grouped metric query results (e.g., "show the top 10 endpoints by p99 latency").

The backend metrics statement builder also ignored `query.Order` and `query.Limit` fields, always defaulting to group-by key + timestamp ordering.

## Changes

### Frontend (`frontend/src/constants/queryBuilder.ts`)
- Added `Order by` and `Limit` filter entries to `mapOfQueryFilters` for the metrics data source, matching the existing logs and traces support.

### Backend (`pkg/telemetrymetrics/statement_builder.go`)
- Updated `BuildFinalSelect` to respect `query.Order` when provided:
  - Applies user-specified column ordering (supports `value` for aggregation results and group-by column names)
  - Falls back to default group-by key + timestamp ordering when no user ordering is specified
- Added `query.Limit` support: applies `LIMIT` clause when `query.Limit > 0`

## Testing

- Go build passes: `go build ./pkg/telemetrymetrics/`
- The existing `ApplySeriesLimit` post-processing continues to handle time-series panel type ordering and limiting as before

## Use Cases Enabled

- **Top-N latency**: p99(duration) grouped by endpoint, ordered desc, limit 10
- **Top-N errors**: countIf(has_error) grouped by service, ordered desc, limit 5
- **Bottom-N traffic**: count() grouped by endpoint, ordered asc, limit 20