### PR TITLE
fix: enable scroll for left and right panels in NewWidget to prevent table overlap

### DIFF
--- a/frontend/src/container/NewWidget/NewWidget.styles.scss
+++ b/frontend/src/container/NewWidget/NewWidget.styles.scss
@@ -71,3 +71,22 @@
 		}
 	}
 }
+
+.widget-resizable-panel-group {
+	height: 100%;
+}
+
+.resizable-panel-left-container,
+.resizable-panel-right-container {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	height: 100%;
+}
+
+.left-panel-scrollbar,
+.right-panel-scrollbar {
+	flex: 1;
+	min-height: 0;
+	overflow: hidden;
+}

--- a/frontend/src/container/NewWidget/index.tsx
+++ b/frontend/src/container/NewWidget/index.tsx
@@ -869,7 +869,7 @@ function NewWidget({
 						defaultSize={80}
 						className="resizable-panel-left-container"
 					>
-						<OverlayScrollbar>
+						<OverlayScrollbar className="left-panel-scrollbar">
 							{selectedWidget && (
 								<LeftContainer
 									dashboardData={dashboardData}
@@ -896,7 +896,8 @@ function NewWidget({
 						defaultSize={20}
 						className="resizable-panel-right-container"
 					>
-						<RightContainer
+						<OverlayScrollbar className="right-panel-scrollbar">
+							<RightContainer
 							setGraphHandler={setGraphHandler}
 							title={title}
 							setTitle={setTitle}
@@ -954,6 +955,7 @@ function NewWidget({
 							enableDrillDown={enableDrillDown}
 							isNewDashboard={isNewDashboard}
 						/>
+						</OverlayScrollbar>
 					</ResizablePanel>
 				</ResizablePanelGroup>
 			</PanelContainer>

--- a/frontend/src/container/NewWidget/styles.ts
+++ b/frontend/src/container/NewWidget/styles.ts
@@ -15,6 +15,9 @@ export const ButtonContainer = styled.div`
 `;
 
 export const PanelContainer = styled.div`
+	flex: 1;
+	overflow: hidden;
 	display: flex;
-	overflow-y: auto;
+	flex-direction: column;
+	min-height: 0;
 `;


### PR DESCRIPTION
## Summary
The NewWidget panel editor had no bounded height on either the left or right panels, causing the table preview to overflow and visually overlap the right settings sidebar (issue #7170).

Fixed by:
- Wrapping `RightContainer` in `OverlayScrollbar` (consistent with how `LeftContainer` is already wrapped)
- Adding `overflow: hidden` and `height: 100%` CSS to both panel containers so the scrollbars actually activate
- Ensuring `PanelContainer` has `flex: 1; overflow: hidden` as a bounded scroll anchor

#### Screenshots / Screen Recordings
> Before: table content overflows and overlaps the right panel  
> After: both panels scroll independently within their bounds  

## Testing
- [ ] Table panel scrolls vertically instead of overlapping
- [ ] Right settings panel scrolls when content is tall
- [ ] ResizableHandle still works correctly
- [ ] Other panel types (Time series, Bar, Value) unaffected

Fixes #7170