### PR TITLE
fix: add horizontal scroll to metrics table to prevent overlap with sidebar

### DIFF
--- a/frontend/src/container/MetricsExplorer/Summary/Summary.styles.scss
+++ b/frontend/src/container/MetricsExplorer/Summary/Summary.styles.scss
@@ -58,6 +58,7 @@
 	}
 
 	.metrics-table-container {
+		overflow-x: auto;
 		.ant-table {
 			margin-left: -16px;
 			margin-right: -16px;


### PR DESCRIPTION
Fixes #7170

When the left sidebar is open, the Metrics Explorer Summary table overlaps. This fix adds `overflow-x: auto` to the table container so users can scroll horizontally when the sidebar reduces available width.

This is a minimal CSS-only fix that doesn't affect existing functionality.