### PR TITLE
fix(dashboard): persist list panel page size across refetch

### DIFF
--- a/frontend/src/container/LogsPanelTable/LogsPanelComponent.tsx
+++ b/frontend/src/container/LogsPanelTable/LogsPanelComponent.tsx
@@ -4,19 +4,21 @@ import {
 	SetStateAction,
 	useCallback,
 	useMemo,
-	useState,
 } from 'react';
 import { UseQueryResult } from 'react-query';
 import LogDetail from 'components/LogDetail';
 import OverlayScrollbar from 'components/OverlayScrollbar/OverlayScrollbar';
 import { ResizeTable } from 'components/ResizeTable';
 import { SOMETHING_WENT_WRONG } from 'constants/api';
+import { QueryParams } from 'constants/query';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import Controls from 'container/Controls';
 import { PER_PAGE_OPTIONS } from 'container/TracesExplorer/ListView/configs';
 import { tableStyles } from 'container/TracesExplorer/ListView/styles';
 import useLogDetailHandlers from 'hooks/logs/useLogDetailHandlers';
+import { Pagination } from 'hooks/queryPagination';
 import { useLogsData } from 'hooks/useLogsData';
+import useUrlQueryData from 'hooks/useUrlQueryData';
 import { GetQueryResultsProps } from 'lib/dashboard/getQueryResults';
 import { FlatLogData } from 'lib/logs/flatLogData';
 import { RowData } from 'lib/query/createTableColumnsFromQuery';
@@ -29,18 +31,26 @@ import { getLogPanelColumnsList } from './utils';
 
 import './LogsPanelComponent.styles.scss';
 
+// Pagination is persisted in the URL (keyed per widget so multiple list panels
+// on the same dashboard don't collide) rather than in component-local state,
+// which would be lost when the panel briefly unmounts during a refetch.
+const DEFAULT_PAGINATION_CONFIG: Pagination = { offset: 0, limit: 10 };
+
 function LogsPanelComponent({
 	widget,
 	setRequestData,
 	queryResponse,
 	onColumnWidthsChange,
 }: LogsPanelComponentProps): JSX.Element {
-	const [pageSize, setPageSize] = useState<number>(10);
-	const [offset, setOffset] = useState<number>(0);
+	const { queryData: paginationQueryData, redirectWithQuery } = useUrlQueryData<
+		Pagination
+	>(`${QueryParams.pagination}-${widget.id}`);
+	const pagination = paginationQueryData ?? DEFAULT_PAGINATION_CONFIG;
+	const pageSize = pagination.limit;
+	const offset = pagination.offset;
 
 	const handleChangePageSize = (value: number): void => {
-		setPageSize(value);
-		setOffset(0);
+		redirectWithQuery({ offset: 0, limit: value });
 		setRequestData((prev) => {
 			const newQueryData = {
 				...prev.query,
@@ -111,13 +121,14 @@ function LogsPanelComponent({
 	);
 
 	const handleRequestData = (newOffset: number): void => {
-		setOffset(newOffset);
+		const nextOffset = newOffset < 0 ? 0 : newOffset;
+		redirectWithQuery({ offset: nextOffset, limit: pageSize });
 		setRequestData((prev) => ({
 			...prev,
 			tableParams: {
 				pagination: {
 					limit: widget.query?.builder?.queryData[0]?.limit || 0,
-					offset: newOffset < 0 ? 0 : newOffset,
+					offset: nextOffset,
 				},
 			},
 		}));

--- a/frontend/src/container/LogsPanelTable/__tests__/LogsPanelComponentPagination.test.tsx
+++ b/frontend/src/container/LogsPanelTable/__tests__/LogsPanelComponentPagination.test.tsx
@@ -1,0 +1,76 @@
+import { QueryParams } from 'constants/query';
+import { render, screen } from 'tests/test-utils';
+import { Widgets } from 'types/api/dashboard/getAll';
+
+import LogsPanelComponent from '../LogsPanelComponent';
+
+jest.mock('components/OverlayScrollbar/OverlayScrollbar', () => ({
+	__esModule: true,
+	default: ({ children }: { children: React.ReactNode }): JSX.Element => (
+		<div>{children}</div>
+	),
+}));
+
+// LogDetail pulls in a UI subpath jest can't resolve and only renders on row
+// click, which this test never triggers.
+jest.mock('components/LogDetail', () => ({
+	__esModule: true,
+	default: (): JSX.Element | null => null,
+}));
+
+Object.defineProperty(globalThis, 'matchMedia', {
+	writable: true,
+	value: jest.fn().mockImplementation((query) => ({
+		matches: false,
+		media: query,
+		addListener: jest.fn(),
+		removeListener: jest.fn(),
+		addEventListener: jest.fn(),
+		removeEventListener: jest.fn(),
+	})),
+});
+
+const WIDGET_ID = 'logs-panel-widget-id';
+
+const widget = ({
+	id: WIDGET_ID,
+	selectedLogFields: [],
+	// limit must be falsy so the pagination controls render
+	query: {
+		builder: {
+			queryData: [
+				{ dataSource: 'logs', queryName: 'A', limit: null, orderBy: [] },
+			],
+		},
+	},
+} as unknown) as Widgets;
+
+const queryResponse = ({
+	data: { payload: { data: { newResult: { data: { result: [] } } } } },
+	isError: false,
+	isFetching: false,
+} as unknown) as never;
+
+const renderWithPaginationInUrl = (limit: number): void => {
+	const paginationValue = encodeURIComponent(
+		JSON.stringify({ offset: 0, limit }),
+	);
+	render(
+		<LogsPanelComponent
+			widget={widget}
+			queryResponse={queryResponse}
+			setRequestData={jest.fn()}
+		/>,
+		undefined,
+		{ initialRoute: `/?${QueryParams.pagination}-${WIDGET_ID}=${paginationValue}` },
+	);
+};
+
+describe('LogsPanelComponent pagination', () => {
+	it('reflects the page size persisted in the URL instead of resetting to the default', () => {
+		renderWithPaginationInUrl(25);
+
+		expect(screen.getByText('25 / page')).toBeInTheDocument();
+		expect(screen.queryByText('10 / page')).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/container/TracesTableComponent/TracesTableComponent.tsx
+++ b/frontend/src/container/TracesTableComponent/TracesTableComponent.tsx
@@ -5,12 +5,12 @@ import {
 	useCallback,
 	useEffect,
 	useMemo,
-	useState,
 } from 'react';
 import { UseQueryResult } from 'react-query';
 import OverlayScrollbar from 'components/OverlayScrollbar/OverlayScrollbar';
 import { ResizeTable } from 'components/ResizeTable';
 import { SOMETHING_WENT_WRONG } from 'constants/api';
+import { QueryParams } from 'constants/query';
 import Controls from 'container/Controls';
 import { PER_PAGE_OPTIONS } from 'container/TracesExplorer/ListView/configs';
 import { tableStyles } from 'container/TracesExplorer/ListView/styles';
@@ -20,7 +20,7 @@ import {
 	transformDataWithDate,
 } from 'container/TracesExplorer/ListView/utils';
 import { Pagination } from 'hooks/queryPagination';
-import { useSafeNavigate } from 'hooks/useSafeNavigate';
+import useUrlQueryData from 'hooks/useUrlQueryData';
 import { GetQueryResultsProps } from 'lib/dashboard/getQueryResults';
 import history from 'lib/history';
 import { RowData } from 'lib/query/createTableColumnsFromQuery';
@@ -32,17 +32,21 @@ import { openInNewTab } from 'utils/navigation';
 
 import './TracesTableComponent.styles.scss';
 
+// Pagination is persisted in the URL (keyed per widget so multiple list panels
+// on the same dashboard don't collide) rather than in component-local state,
+// which would be lost when the panel briefly unmounts during a refetch.
+const DEFAULT_PAGINATION_CONFIG: Pagination = { offset: 0, limit: 10 };
+
 function TracesTableComponent({
 	widget,
 	queryResponse,
 	setRequestData,
 	onColumnWidthsChange,
 }: TracesTableComponentProps): JSX.Element {
-	const [pagination, setPagination] = useState<Pagination>({
-		offset: 0,
-		limit: 10,
-	});
-	const { safeNavigate } = useSafeNavigate();
+	const { queryData: paginationQueryData, redirectWithQuery } = useUrlQueryData<
+		Pagination
+	>(`${QueryParams.pagination}-${widget.id}`);
+	const pagination = paginationQueryData ?? DEFAULT_PAGINATION_CONFIG;
 
 	useEffect(() => {
 		setRequestData((prev) => ({
@@ -99,21 +103,9 @@ function TracesTableComponent({
 
 	const handlePaginationChange = useCallback(
 		(newPagination: Pagination) => {
-			const urlQuery = new URLSearchParams(window.location.search);
-
-			// Update URL with new pagination values
-			urlQuery.set('offset', newPagination.offset.toString());
-			urlQuery.set('limit', newPagination.limit.toString());
-
-			// Update URL without page reload
-			safeNavigate({
-				search: urlQuery.toString(),
-			});
-
-			// Update component state
-			setPagination(newPagination);
+			redirectWithQuery(newPagination);
 		},
-		[safeNavigate],
+		[redirectWithQuery],
 	);
 
 	if (queryResponse.isError) {

--- a/frontend/src/container/TracesTableComponent/__tests__/TracesTableComponent.test.tsx
+++ b/frontend/src/container/TracesTableComponent/__tests__/TracesTableComponent.test.tsx
@@ -1,0 +1,62 @@
+import { QueryParams } from 'constants/query';
+import { render, screen } from 'tests/test-utils';
+import { Widgets } from 'types/api/dashboard/getAll';
+
+import TracesTableComponent from '../TracesTableComponent';
+
+jest.mock('components/OverlayScrollbar/OverlayScrollbar', () => ({
+	__esModule: true,
+	default: ({ children }: { children: React.ReactNode }): JSX.Element => (
+		<div>{children}</div>
+	),
+}));
+
+Object.defineProperty(globalThis, 'matchMedia', {
+	writable: true,
+	value: jest.fn().mockImplementation((query) => ({
+		matches: false,
+		media: query,
+		addListener: jest.fn(),
+		removeListener: jest.fn(),
+		addEventListener: jest.fn(),
+		removeEventListener: jest.fn(),
+	})),
+});
+
+const WIDGET_ID = 'traces-panel-widget-id';
+
+const widget = ({
+	id: WIDGET_ID,
+	selectedTracesFields: [],
+	query: { builder: { queryData: [{ dataSource: 'traces' }] } },
+} as unknown) as Widgets;
+
+const queryResponse = ({
+	data: { payload: { data: { newResult: { data: { result: [] } } } } },
+	isError: false,
+	isFetching: false,
+} as unknown) as never;
+
+const renderWithPaginationInUrl = (limit: number): void => {
+	const paginationValue = encodeURIComponent(
+		JSON.stringify({ offset: 0, limit }),
+	);
+	render(
+		<TracesTableComponent
+			widget={widget}
+			queryResponse={queryResponse}
+			setRequestData={jest.fn()}
+		/>,
+		undefined,
+		{ initialRoute: `/?${QueryParams.pagination}-${WIDGET_ID}=${paginationValue}` },
+	);
+};
+
+describe('TracesTableComponent pagination', () => {
+	it('reflects the page size persisted in the URL instead of resetting to the default', () => {
+		renderWithPaginationInUrl(25);
+
+		expect(screen.getByText('25 / page')).toBeInTheDocument();
+		expect(screen.queryByText('10 / page')).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

Page size selector in the dashboard Logs and Traces list panels didn't stick — picking `25 / page` reset back to `10 / page`. The panels stored pagination in local state, which got wiped when the panel briefly unmounts during a refetch. Moved pagination to the URL (keyed per widget) so the selection survives, matching how the explorer list views already work.

Closes #11582.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Yes — one per panel; each seeds the page size in the URL and asserts the selector reflects it (fails on the old code, passes on the fix)
- Manual verification: Yes
- Edge cases covered: Multiple list panels on one dashboard (per-widget URL key avoids collisions)

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Dashboard Logs & Traces list panels only
- Potential regressions: Pagination state now lives in the URL
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug fix |
| Description | Page size selection in dashboard Logs and Traces list panels now persists instead of resetting to 10 / page. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered
