### PR TITLE
feat(export): move to cursor pagination for raw_data_export api

### DIFF
--- a/pkg/modules/rawdataexport/implrawdataexport/constants.go
+++ b/pkg/modules/rawdataexport/implrawdataexport/constants.go
@@ -6,8 +6,13 @@ import (
 
 const (
 	// Row Limits.
-	MaxExportRowCountLimit     = 50_000 // 50k
+	MaxExportRowCountLimit     = 50_000 // 50k — applies to logs/metrics
 	DefaultExportRowCountLimit = 10_000 // 10k
+
+	// Higher ceiling for trace exports. Full-trace download needs to enumerate
+	// every span; a single big trace can easily exceed 50k. The 10 GB byte cap
+	// and ClickhouseExportRawDataTimeout still apply as backstops.
+	MaxExportRowCountLimitTraces = 2_000_000 // 2M
 
 	// Data Limits.
 	MaxExportBytesLimit = 10 * 1024 * 1024 * 1024 // 10 GB

--- a/pkg/modules/rawdataexport/implrawdataexport/constants.go
+++ b/pkg/modules/rawdataexport/implrawdataexport/constants.go
@@ -5,15 +5,6 @@ import (
 )
 
 const (
-	// Row Limits.
-	MaxExportRowCountLimit     = 50_000 // 50k — applies to logs/metrics
-	DefaultExportRowCountLimit = 10_000 // 10k
-
-	// Higher ceiling for trace exports. Full-trace download needs to enumerate
-	// every span; a single big trace can easily exceed 50k. The 10 GB byte cap
-	// and ClickhouseExportRawDataTimeout still apply as backstops.
-	MaxExportRowCountLimitTraces = 2_000_000 // 2M
-
 	// Data Limits.
 	MaxExportBytesLimit = 10 * 1024 * 1024 * 1024 // 10 GB
 

--- a/pkg/modules/rawdataexport/implrawdataexport/constants.go
+++ b/pkg/modules/rawdataexport/implrawdataexport/constants.go
@@ -9,7 +9,7 @@ const (
 	MaxExportBytesLimit = 10 * 1024 * 1024 * 1024 // 10 GB
 
 	// Query Limits.
-	ChunkSize                         = 5_000 // 5k
+	ChunkSize                         = 10_000
 	ClickhouseExportRawDataMaxThreads = 2
 	ClickhouseExportRawDataTimeout    = 10 * time.Minute
 )

--- a/pkg/modules/rawdataexport/implrawdataexport/handler.go
+++ b/pkg/modules/rawdataexport/implrawdataexport/handler.go
@@ -19,7 +19,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
 	"github.com/SigNoz/signoz/pkg/types/exporttypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
-	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
 
@@ -106,33 +105,11 @@ func validateSpecForExport(req *qbtypes.QueryRangeRequest) error {
 
 func validateAndApplyDefaultExportLimits(queries []qbtypes.QueryEnvelope) error {
 	for idx := range queries {
-		limit := queries[idx].GetLimit()
-		maxLimit := maxLimitForQuery(queries[idx])
-		if limit == 0 {
-			limit = DefaultExportRowCountLimit
-		} else if limit < 0 {
-			return errors.NewInvalidInputf(errors.CodeInvalidInput, "limit must be positive")
-		} else if limit > maxLimit {
-			return errors.NewInvalidInputf(errors.CodeInvalidInput, "limit cannot be more than %d", maxLimit)
+		if queries[idx].GetLimit() < 0 {
+			return errors.NewInvalidInputf(errors.CodeInvalidInput, "limit must be non-negative (0 = unlimited)")
 		}
-		queries[idx].SetLimit(limit)
 	}
 	return nil
-}
-
-// maxLimitForQuery returns the per-signal export ceiling. Traces use a higher
-// cap because exhaustive full-trace downloads need every span; logs/metrics
-// keep the original conservative cap.
-func maxLimitForQuery(q qbtypes.QueryEnvelope) int {
-	switch spec := q.Spec.(type) {
-	case qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]:
-		if spec.Signal == telemetrytypes.SignalTraces {
-			return MaxExportRowCountLimitTraces
-		}
-	case qbtypes.QueryBuilderTraceOperator:
-		return MaxExportRowCountLimitTraces
-	}
-	return MaxExportRowCountLimit
 }
 
 // setExportResponseHeaders sets common HTTP headers for export responses.

--- a/pkg/modules/rawdataexport/implrawdataexport/handler.go
+++ b/pkg/modules/rawdataexport/implrawdataexport/handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
 	"github.com/SigNoz/signoz/pkg/types/exporttypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
 
@@ -106,16 +107,32 @@ func validateSpecForExport(req *qbtypes.QueryRangeRequest) error {
 func validateAndApplyDefaultExportLimits(queries []qbtypes.QueryEnvelope) error {
 	for idx := range queries {
 		limit := queries[idx].GetLimit()
+		maxLimit := maxLimitForQuery(queries[idx])
 		if limit == 0 {
 			limit = DefaultExportRowCountLimit
 		} else if limit < 0 {
 			return errors.NewInvalidInputf(errors.CodeInvalidInput, "limit must be positive")
-		} else if limit > MaxExportRowCountLimit {
-			return errors.NewInvalidInputf(errors.CodeInvalidInput, "limit cannot be more than %d", MaxExportRowCountLimit)
+		} else if limit > maxLimit {
+			return errors.NewInvalidInputf(errors.CodeInvalidInput, "limit cannot be more than %d", maxLimit)
 		}
 		queries[idx].SetLimit(limit)
 	}
 	return nil
+}
+
+// maxLimitForQuery returns the per-signal export ceiling. Traces use a higher
+// cap because exhaustive full-trace downloads need every span; logs/metrics
+// keep the original conservative cap.
+func maxLimitForQuery(q qbtypes.QueryEnvelope) int {
+	switch spec := q.Spec.(type) {
+	case qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]:
+		if spec.Signal == telemetrytypes.SignalTraces {
+			return MaxExportRowCountLimitTraces
+		}
+	case qbtypes.QueryBuilderTraceOperator:
+		return MaxExportRowCountLimitTraces
+	}
+	return MaxExportRowCountLimit
 }
 
 // setExportResponseHeaders sets common HTTP headers for export responses.

--- a/pkg/modules/rawdataexport/implrawdataexport/handler_test.go
+++ b/pkg/modules/rawdataexport/implrawdataexport/handler_test.go
@@ -97,48 +97,29 @@ func TestValidateAndApplyDefaultExportLimits(t *testing.T) {
 		checkQueries  func(t *testing.T, queries []qbtypes.QueryEnvelope)
 	}{
 		{
-			name:    "single log query, zero limit gets default",
+			name:    "zero limit kept as-is (unlimited)",
 			queries: makeRequest(logQuery(0)).CompositeQuery.Queries,
 			checkQueries: func(t *testing.T, q []qbtypes.QueryEnvelope) {
-				assert.Equal(t, DefaultExportRowCountLimit, q[0].GetLimit())
+				assert.Equal(t, 0, q[0].GetLimit())
 			},
 		},
 		{
-			name:    "single log query, valid limit kept",
+			name:    "positive limit kept",
 			queries: makeRequest(logQuery(1000)).CompositeQuery.Queries,
 			checkQueries: func(t *testing.T, q []qbtypes.QueryEnvelope) {
 				assert.Equal(t, 1000, q[0].GetLimit())
 			},
 		},
 		{
-			name:    "single log query, max limit kept",
-			queries: makeRequest(logQuery(MaxExportRowCountLimit)).CompositeQuery.Queries,
-			checkQueries: func(t *testing.T, q []qbtypes.QueryEnvelope) {
-				assert.Equal(t, MaxExportRowCountLimit, q[0].GetLimit())
-			},
-		},
-		{
-			name:          "single log query, limit exceeds max",
-			queries:       makeRequest(logQuery(MaxExportRowCountLimit + 1)).CompositeQuery.Queries,
-			expectedError: true,
-		},
-		{
-			name:          "single log query, negative limit",
+			name:          "negative limit rejected",
 			queries:       makeRequest(logQuery(-1)).CompositeQuery.Queries,
 			expectedError: true,
 		},
 		{
-			name:    "single trace query, zero limit gets default",
-			queries: makeRequest(traceQuery(0)).CompositeQuery.Queries,
+			name:    "large trace limit kept",
+			queries: makeRequest(traceQuery(2_000_000)).CompositeQuery.Queries,
 			checkQueries: func(t *testing.T, q []qbtypes.QueryEnvelope) {
-				assert.Equal(t, DefaultExportRowCountLimit, q[0].GetLimit())
-			},
-		},
-		{
-			name:    "trace operator alone, zero limit gets default",
-			queries: makeRequest(traceOperatorQuery(0)).CompositeQuery.Queries,
-			checkQueries: func(t *testing.T, q []qbtypes.QueryEnvelope) {
-				assert.Equal(t, DefaultExportRowCountLimit, q[0].GetLimit())
+				assert.Equal(t, 2_000_000, q[0].GetLimit())
 			},
 		},
 	}

--- a/pkg/modules/rawdataexport/implrawdataexport/module.go
+++ b/pkg/modules/rawdataexport/implrawdataexport/module.go
@@ -69,7 +69,7 @@ func (m *Module) ExportRawData(ctx context.Context, orgID valuer.UUID, rangeRequ
 func exportRawDataForSingleQuery(querier querier.Querier, ctx context.Context, orgID valuer.UUID, rangeRequest *qbtypes.QueryRangeRequest, rowChan chan *qbtypes.RawRow, errChan chan error, doneChan chan any, queryIndex int) {
 
 	queries := rangeRequest.CompositeQuery.Queries
-	rowCountLimit := queries[queryIndex].GetLimit()
+	clientLimit := queries[queryIndex].GetLimit() // 0 means unlimited
 	rowCount := 0
 
 	// Page using the querier's cursor. At large offsets ClickHouse still has to
@@ -78,8 +78,16 @@ func exportRawDataForSingleQuery(querier querier.Querier, ctx context.Context, o
 	queries[queryIndex].SetOffset(0)
 	cursor := ""
 
-	for rowCount < rowCountLimit {
-		chunkSize := min(ChunkSize, rowCountLimit-rowCount)
+	for {
+		chunkSize := ChunkSize
+		if clientLimit > 0 {
+			remaining := clientLimit - rowCount
+			if remaining <= 0 {
+				return
+			}
+			chunkSize = min(ChunkSize, remaining)
+		}
+
 		queries[queryIndex].SetLimit(chunkSize)
 		queries[queryIndex].SetCursor(cursor)
 
@@ -116,6 +124,7 @@ func exportRawDataForSingleQuery(querier querier.Querier, ctx context.Context, o
 
 		rowCount += newRowsCount
 
+		// Stop when the querier returns no cursor (last page) or a short chunk.
 		if nextCursor == "" || newRowsCount < chunkSize {
 			return
 		}

--- a/pkg/modules/rawdataexport/implrawdataexport/module.go
+++ b/pkg/modules/rawdataexport/implrawdataexport/module.go
@@ -72,10 +72,16 @@ func exportRawDataForSingleQuery(querier querier.Querier, ctx context.Context, o
 	rowCountLimit := queries[queryIndex].GetLimit()
 	rowCount := 0
 
+	// Page using the querier's cursor. At large offsets ClickHouse still has to
+	// scan and discard every prior row on each chunk. The cursor lets us
+	// advance the time window directly.
+	queries[queryIndex].SetOffset(0)
+	cursor := ""
+
 	for rowCount < rowCountLimit {
 		chunkSize := min(ChunkSize, rowCountLimit-rowCount)
 		queries[queryIndex].SetLimit(chunkSize)
-		queries[queryIndex].SetOffset(rowCount)
+		queries[queryIndex].SetCursor(cursor)
 
 		response, err := querier.QueryRange(ctx, orgID, rangeRequest)
 		if err != nil {
@@ -84,6 +90,7 @@ func exportRawDataForSingleQuery(querier querier.Querier, ctx context.Context, o
 		}
 
 		newRowsCount := 0
+		nextCursor := ""
 		for _, result := range response.Data.Results {
 			resultData, ok := result.(*qbtypes.RawData)
 			if !ok {
@@ -91,6 +98,9 @@ func exportRawDataForSingleQuery(querier querier.Querier, ctx context.Context, o
 				return
 			}
 
+			if resultData.NextCursor != "" {
+				nextCursor = resultData.NextCursor
+			}
 			newRowsCount += len(resultData.Rows)
 			for _, row := range resultData.Rows {
 				select {
@@ -106,9 +116,9 @@ func exportRawDataForSingleQuery(querier querier.Querier, ctx context.Context, o
 
 		rowCount += newRowsCount
 
-		// Stop if we received fewer rows than requested — no more data available
-		if newRowsCount < chunkSize {
+		if nextCursor == "" || newRowsCount < chunkSize {
 			return
 		}
+		cursor = nextCursor
 	}
 }

--- a/pkg/modules/rawdataexport/implrawdataexport/module.go
+++ b/pkg/modules/rawdataexport/implrawdataexport/module.go
@@ -69,25 +69,20 @@ func (m *Module) ExportRawData(ctx context.Context, orgID valuer.UUID, rangeRequ
 func exportRawDataForSingleQuery(querier querier.Querier, ctx context.Context, orgID valuer.UUID, rangeRequest *qbtypes.QueryRangeRequest, rowChan chan *qbtypes.RawRow, errChan chan error, doneChan chan any, queryIndex int) {
 
 	queries := rangeRequest.CompositeQuery.Queries
-	clientLimit := queries[queryIndex].GetLimit() // 0 means unlimited
+	rowCountLimit := queries[queryIndex].GetLimit() // 0 means no limit
 	rowCount := 0
 
-	// Page using the querier's cursor. At large offsets ClickHouse still has to
-	// scan and discard every prior row on each chunk. The cursor lets us
-	// advance the time window directly.
 	queries[queryIndex].SetOffset(0)
 	cursor := ""
 
 	for {
 		chunkSize := ChunkSize
-		if clientLimit > 0 {
-			remaining := clientLimit - rowCount
-			if remaining <= 0 {
-				return
-			}
-			chunkSize = min(ChunkSize, remaining)
+		if rowCountLimit > 0 {
+			chunkSize = min(ChunkSize, rowCountLimit-rowCount)
 		}
-
+		if chunkSize <= 0 {
+			return
+		}
 		queries[queryIndex].SetLimit(chunkSize)
 		queries[queryIndex].SetCursor(cursor)
 
@@ -124,7 +119,6 @@ func exportRawDataForSingleQuery(querier querier.Querier, ctx context.Context, o
 
 		rowCount += newRowsCount
 
-		// Stop when the querier returns no cursor (last page) or a short chunk.
 		if nextCursor == "" || newRowsCount < chunkSize {
 			return
 		}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Modify raw data export API to use cursor based pagination while calling query range and remove limits to support large data request like trace download.

Sample single line from downloaded file jsonl format file is shared below, this contains derived fields as well which are [documented](https://signoz.io/docs/traces-management/guides/derived-fields-spans/) already. If we want to change the format or fields in the response, that can be an incremental change and should not block this PR.

Blocker: raw_data_export api depends on QueryRange module, which currently doesn't allow selecting the fields like `attributes`, `resource`, so this PR can be merged but download trace feature will be blocked on https://github.com/SigNoz/signoz/pull/10583 which changes `QueryRange` to return all fields if none field is selected.

Note: cursor returned from `QueryRange` is only based on timestamp in ms currently, which means next page can miss the spans which are at the same timestamp. https://github.com/SigNoz/engineering-pod/issues/5373


```json
{
   "attributes":{
      "span.depth":22,
      "span.operation":"db.query",
      "span.structure":"tree"
   },
   "db_name":"",
   "db_operation":"",
   "duration_nano":45000000,
   "events":[],
   "external_http_method":"",
   "external_http_url":"",
   "flags":257,
   "has_error":false,
   "http_host":"",
   "http_method":"",
   "http_url":"",
   "is_remote":"no",
   "kind":1,
   "kind_string":"Internal",
   "links":[
      {
         "traceId":"6737eb19fcc82a36585052e30c90d1f4",
         "spanId":"d500ecdf51f13563"
      }
   ],
   "name":"db.query/d22",
   "parent_span_id":"d500ecdf51f13563",
   "resource":{
      "dev.name":"nikhilsoni",
      "service.name":"go-large-500k",
      "service.version":"1.1.0",
      "signoz.collector.id":"4eae02c3-94f7-4404-a053-3544ec6d6c98"
   },
   "response_status_code":"",
   "span_id":"59b451ba28236998",
   "status_code":0,
   "status_code_string":"Unset",
   "status_message":"",
   "timestamp":"2026-05-15T18:56:15.419507Z",
   "trace_id":"6737eb19fcc82a36585052e30c90d1f4",
   "trace_state":""
}
```


#### Issues closed by this PR
Closes https://github.com/SigNoz/engineering-pod/issues/4734

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification: ✅ 
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Existing download options in log and traces explorer
- Potential regressions:
- Rollback plan:

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
