### PR TITLE
chore: refactor error response + normalize ClickHouse telemetrystore errors

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -3743,7 +3743,6 @@ components:
         errors:
           items:
             $ref: '#/components/schemas/ErrorsResponseerroradditional'
-          nullable: true
           type: array
         message:
           type: string
@@ -3752,7 +3751,6 @@ components:
         suggestions:
           items:
             type: string
-          nullable: true
           type: array
         type:
           type: string
@@ -3775,7 +3773,6 @@ components:
         suggestions:
           items:
             type: string
-          nullable: true
           type: array
       required:
       - message

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -3743,6 +3743,7 @@ components:
         errors:
           items:
             $ref: '#/components/schemas/ErrorsResponseerroradditional'
+          nullable: true
           type: array
         message:
           type: string
@@ -3751,14 +3752,21 @@ components:
         suggestions:
           items:
             type: string
+          nullable: true
           type: array
         type:
           type: string
         url:
+          nullable: true
           type: string
       required:
+      - type
       - code
       - message
+      - url
+      - errors
+      - retry
+      - suggestions
       type: object
     ErrorsResponseerroradditional:
       properties:
@@ -3767,12 +3775,19 @@ components:
         suggestions:
           items:
             type: string
+          nullable: true
           type: array
+      required:
+      - message
+      - suggestions
       type: object
     ErrorsResponseretryjson:
+      nullable: true
       properties:
         delay:
           $ref: '#/components/schemas/TimeDuration'
+      required:
+      - delay
       type: object
     FactoryResponse:
       properties:

--- a/docs/contributing/go/errors.md
+++ b/docs/contributing/go/errors.md
@@ -36,6 +36,55 @@ var (
 
 > 💡 **Note**: Error codes must match the regex `^[a-z_]+$` otherwise the code will panic.
 
+### Message
+The primary, human-readable summary of what went wrong, set when the error is created via `errors.New` / `errors.Newf`. Note there are two distinct `message` fields in the response: this top-level one states the overall failure, while each entry under [Additional](#additional) carries its own [message](#message-1) explaining one specific facet of it.
+
+### Url
+An optional link to documentation that explains the error in more depth, set with `WithUrl`. It is left empty when the error has no associated doc.
+
+```go
+return errors.New(errors.TypeInvalidInput, CodeBadThing, "bad thing").
+    WithUrl("https://signoz.io/docs/...")
+```
+
+### Additional
+`errors` is a list of supplementary details that explain the top-level `message`. Each entry has its own `message` and `suggestions`, so a single error can surface several distinct problems individually. Attach details with `WithAdditional` (message only) or `WithSuggestiveAdditional` (message plus the suggestions that belong to it):
+
+#### Message
+A single, self-contained sentence describing one specific facet of the error (e.g. ``field `filed` not found``), distinct from the top-level [Message](#message). Prefer one detail per distinct problem over concatenating several into one message.
+
+#### Suggestions
+The suggestions tied to that specific detail — typically a ``did you mean: `x` `` correction for the value the detail is about. These are distinct from the error-wide [Suggestions](#suggestions) below: detail-scoped suggestions never leak into the top-level list.
+
+```go
+return errors.NewInvalidInputf(errors.CodeInvalidInput, "unknown field %q", field).
+    WithAdditional("field `field` not found")
+return errors.NewInvalidInputf(errors.CodeInvalidInput, "unknown field %q", field).
+    WithSuggestiveAdditional("field `filed` not found", "did you mean: `field`")
+```
+
+### Retry
+Carries the `delay` the client should wait before retrying, set with `WithRetryAfter`. It is `null` when the error is not retryable.
+
+```go
+return errors.NewTimeoutf(CodeSlow, "upstream timed out").
+    WithRetryAfter(5 * time.Second)
+```
+
+### Suggestions
+`WithSuggestions` sets the error-wide `suggestions` list — hints about the error as a whole (e.g. "narrow the time range window"), as opposed to suggestions tied to a single detail. Prefer the builders in [pkg/errors/suggestions.go](/pkg/errors/suggestions.go) over hand-writing the strings so the phrasing stays consistent:
+
+- `NewSuggestionsOnLevenshteinDistance(invalidInput, noun, validInputs)` — returns a ``did you mean: `x` `` correction (when a close typo match exists) followed by the valid-references list.
+- `NewValidReferences(noun, values...)` — formats a capped list as ``valid <noun> are `a`, `b` `` (e.g. `"valid fields are"`, `"valid keys are"`). Returns `""` for an empty set.
+- `NewSuggestionsFromFunc(produce)` — wraps a caller-computed correction string as a one-element ``did you mean: `x` `` slice (or nil when it returns `""`), for callers with their own matching strategy.
+
+`noun` names the kind of value being suggested. Use one of the exported `Noun*` constants (`errors.NounFields`, `errors.NounKeys`, `errors.NounServices`, …) so the wording stays uniform across the codebase.
+
+```go
+return errors.NewInvalidInputf(errors.CodeInvalidInput, "unknown field %q", field).
+    WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field, errors.NounFields, validFields)...)
+```
+
 ## Show me some examples
 
 ### Using the error

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -2180,9 +2180,9 @@ export interface ErrorsResponseerroradditionalDTO {
 	 */
 	message: string;
 	/**
-	 * @type array,null
+	 * @type array
 	 */
-	suggestions: string[] | null;
+	suggestions: string[];
 }
 
 export type ErrorsResponseretryjsonDTOAnyOf = {
@@ -2200,18 +2200,18 @@ export interface ErrorsJSONDTO {
 	 */
 	code: string;
 	/**
-	 * @type array,null
+	 * @type array
 	 */
-	errors: ErrorsResponseerroradditionalDTO[] | null;
+	errors: ErrorsResponseerroradditionalDTO[];
 	/**
 	 * @type string
 	 */
 	message: string;
 	retry: ErrorsResponseretryjsonDTO | null;
 	/**
-	 * @type array,null
+	 * @type array
 	 */
-	suggestions: string[] | null;
+	suggestions: string[];
 	/**
 	 * @type string
 	 */

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -2178,16 +2178,21 @@ export interface ErrorsResponseerroradditionalDTO {
 	/**
 	 * @type string
 	 */
-	message?: string;
+	message: string;
 	/**
-	 * @type array
+	 * @type array,null
 	 */
-	suggestions?: string[];
+	suggestions: string[] | null;
 }
 
-export interface ErrorsResponseretryjsonDTO {
-	delay?: TimeDurationDTO;
-}
+export type ErrorsResponseretryjsonDTOAnyOf = {
+	delay: TimeDurationDTO;
+};
+
+/**
+ * @nullable
+ */
+export type ErrorsResponseretryjsonDTO = ErrorsResponseretryjsonDTOAnyOf | null;
 
 export interface ErrorsJSONDTO {
 	/**
@@ -2195,26 +2200,26 @@ export interface ErrorsJSONDTO {
 	 */
 	code: string;
 	/**
-	 * @type array
+	 * @type array,null
 	 */
-	errors?: ErrorsResponseerroradditionalDTO[];
+	errors: ErrorsResponseerroradditionalDTO[] | null;
 	/**
 	 * @type string
 	 */
 	message: string;
-	retry?: ErrorsResponseretryjsonDTO;
+	retry: ErrorsResponseretryjsonDTO | null;
 	/**
-	 * @type array
+	 * @type array,null
 	 */
-	suggestions?: string[];
-	/**
-	 * @type string
-	 */
-	type?: string;
+	suggestions: string[] | null;
 	/**
 	 * @type string
 	 */
-	url?: string;
+	type: string;
+	/**
+	 * @type string,null
+	 */
+	url: string | null;
 }
 
 export interface AuthtypesOrgSessionContextDTO {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelStatus/__tests__/utils.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelStatus/__tests__/utils.test.ts
@@ -27,11 +27,11 @@ describe('panelStatusFromError', () => {
 			message: 'Query is invalid',
 			url: 'https://docs/err',
 			errors: [
-				{ message: 'missing aggregation', suggestions: null },
-				{ message: 'bad filter', suggestions: null },
+				{ message: 'missing aggregation', suggestions: [] },
+				{ message: 'bad filter', suggestions: [] },
 			],
 			retry: null,
-			suggestions: null,
+			suggestions: [],
 			type: '',
 		});
 
@@ -60,7 +60,7 @@ describe('panelStatusFromError', () => {
 				url: '',
 				errors: [],
 				retry: null,
-				suggestions: null,
+				suggestions: [],
 				type: '',
 			},
 			StatusCodes.INTERNAL_SERVER_ERROR,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelStatus/__tests__/utils.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelStatus/__tests__/utils.test.ts
@@ -26,7 +26,13 @@ describe('panelStatusFromError', () => {
 			code: 'invalid_query',
 			message: 'Query is invalid',
 			url: 'https://docs/err',
-			errors: [{ message: 'missing aggregation' }, { message: 'bad filter' }],
+			errors: [
+				{ message: 'missing aggregation', suggestions: null },
+				{ message: 'bad filter', suggestions: null },
+			],
+			retry: null,
+			suggestions: null,
+			type: '',
 		});
 
 		expect(panelStatusFromError(error)).toStrictEqual({
@@ -48,7 +54,15 @@ describe('panelStatusFromError', () => {
 
 	it('omits docsUrl when the API error has no url', () => {
 		const error = axiosErrorWith(
-			{ code: 'x', message: 'y', url: '', errors: [] },
+			{
+				code: 'x',
+				message: 'y',
+				url: '',
+				errors: [],
+				retry: null,
+				suggestions: null,
+				type: '',
+			},
 			StatusCodes.INTERNAL_SERVER_ERROR,
 		);
 

--- a/go.mod
+++ b/go.mod
@@ -180,7 +180,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
-	github.com/ClickHouse/ch-go v0.71.0 // indirect
+	github.com/ClickHouse/ch-go v0.71.0
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Yiling-J/theine-go v0.6.2 // indirect
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b

--- a/pkg/errors/code.go
+++ b/pkg/errors/code.go
@@ -28,7 +28,7 @@ var (
 )
 
 var (
-	codeRegex = regexp.MustCompile(`^[a-z_.]+$`)
+	codeRegex = regexp.MustCompile(`^[a-z_]+$`)
 )
 
 type Code struct{ s string }

--- a/pkg/errors/code.go
+++ b/pkg/errors/code.go
@@ -28,7 +28,7 @@ var (
 )
 
 var (
-	codeRegex = regexp.MustCompile(`^[a-z_]+$`)
+	codeRegex = regexp.MustCompile(`^[a-z_.]+$`)
 )
 
 type Code struct{ s string }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -75,6 +75,12 @@ func (b *base) Error() string {
 	return b.m
 }
 
+// Unwrap exposes the wrapped cause so stdlib errors.Is / errors.As can walk
+// the chain — e.g. errors.Is(WrapCanceledf(context.Canceled, …), context.Canceled).
+func (b *base) Unwrap() error {
+	return b.e
+}
+
 // New returns a base error. It requires type, code and message as input.
 func New(t typ, code Code, message string) *base {
 	return &base{
@@ -335,6 +341,16 @@ func WrapTimeoutf(cause error, code Code, format string, args ...any) *base {
 // NewTimeoutf is a wrapper around Newf with TypeTimeout.
 func NewTimeoutf(code Code, format string, args ...any) *base {
 	return Newf(TypeTimeout, code, format, args...)
+}
+
+// WrapCanceledf is a wrapper around Wrapf with TypeCanceled.
+func WrapCanceledf(cause error, code Code, format string, args ...any) *base {
+	return Wrapf(cause, TypeCanceled, code, format, args...)
+}
+
+// NewCanceledf is a wrapper around Newf with TypeCanceled.
+func NewCanceledf(code Code, format string, args ...any) *base {
+	return Newf(TypeCanceled, code, format, args...)
 }
 
 // WrapUnauthenticatedf is a wrapper around Wrapf with TypeUnauthenticated.

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -107,11 +107,11 @@ func TestAsJSONBaseError(t *testing.T) {
 	assert.Equal(t, "bad_input", j.Code)
 	assert.Equal(t, "field foo is bad", j.Message)
 	assert.Equal(t, "https://docs/bad_input", j.Url)
-	// A detail with no suggestions carries a nil slice (the suggestions field is
-	// nullable, so it marshals to null rather than []).
+	// A detail with no suggestions carries an empty (non-nil) slice — the
+	// suggestions field is non-nullable, so it marshals to [] rather than null.
 	assert.Equal(t, []responseerroradditional{
-		{Message: "hint1"},
-		{Message: "hint2"},
+		{Message: "hint1", Suggestions: []string{}},
+		{Message: "hint2", Suggestions: []string{}},
 	}, j.Errors)
 
 	// InvalidInput auto-applies the after_fix policy via NewInvalidInputf — but
@@ -164,11 +164,14 @@ func TestAsJSONRetryBlock(t *testing.T) {
 }
 
 func TestAsJSONEmptyWhenNoneSet(t *testing.T) {
-	// errors and suggestions are nullable in the OpenAPI spec, so AsJSON leaves
-	// them empty when the error carries none (they marshal to null / []).
+	// errors and suggestions are non-nullable in the OpenAPI spec, so AsJSON
+	// leaves them as empty (non-nil) slices when the error carries none — they
+	// marshal to [] rather than null.
 	j := AsJSON(New(TypeInternal, MustNewCode("boom"), "boom"))
 
+	assert.NotNil(t, j.Suggestions)
 	assert.Empty(t, j.Suggestions)
+	assert.NotNil(t, j.Errors)
 	assert.Empty(t, j.Errors)
 }
 

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"context"
 	"errors" //nolint:depguard
 	"testing"
 	"time"
@@ -181,4 +182,17 @@ func TestWithStacktrace(t *testing.T) {
 	assert.Equal(t, TypeInternal, typ)
 	assert.Equal(t, "test_code", code.String())
 	assert.Equal(t, "panic", message)
+}
+
+// Wrapped context sentinels must remain detectable via errors.Is so callers
+// that branch on context.Canceled / context.DeadlineExceeded keep working
+// after the error passes through one of the signoz Wrap* helpers.
+func TestWrapPreservesContextSentinels(t *testing.T) {
+	canceled := WrapCanceledf(context.Canceled, MustNewCode("canceled"), "op canceled")
+	assert.True(t, Is(canceled, context.Canceled))
+	assert.False(t, Is(canceled, context.DeadlineExceeded))
+
+	deadline := WrapTimeoutf(context.DeadlineExceeded, MustNewCode("timeout"), "op timed out")
+	assert.True(t, Is(deadline, context.DeadlineExceeded))
+	assert.False(t, Is(deadline, context.Canceled))
 }

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -84,7 +84,7 @@ func TestWithSuggestiveAdditional(t *testing.T) {
 	assert.Equal(t, []responseerroradditional{
 		{Message: "field `filed` not found", Suggestions: []string{"did you mean: `field`"}},
 	}, j.Errors)
-	assert.Nil(t, j.Suggestions, "detail-scoped suggestions must not leak into the error-wide list")
+	assert.Empty(t, j.Suggestions, "detail-scoped suggestions must not leak into the error-wide list")
 }
 
 func TestWithRetryAfter(t *testing.T) {
@@ -106,7 +106,12 @@ func TestAsJSONBaseError(t *testing.T) {
 	assert.Equal(t, "bad_input", j.Code)
 	assert.Equal(t, "field foo is bad", j.Message)
 	assert.Equal(t, "https://docs/bad_input", j.Url)
-	assert.Equal(t, []responseerroradditional{{Message: "hint1"}, {Message: "hint2"}}, j.Errors)
+	// A detail with no suggestions carries a nil slice (the suggestions field is
+	// nullable, so it marshals to null rather than []).
+	assert.Equal(t, []responseerroradditional{
+		{Message: "hint1"},
+		{Message: "hint2"},
+	}, j.Errors)
 
 	// InvalidInput auto-applies the after_fix policy via NewInvalidInputf — but
 	// New (bare constructor) does not. The retry block should reflect that.
@@ -157,9 +162,13 @@ func TestAsJSONRetryBlock(t *testing.T) {
 	})
 }
 
-func TestAsJSONOptionalFieldsOmittedWhenEmpty(t *testing.T) {
+func TestAsJSONEmptyWhenNoneSet(t *testing.T) {
+	// errors and suggestions are nullable in the OpenAPI spec, so AsJSON leaves
+	// them empty when the error carries none (they marshal to null / []).
 	j := AsJSON(New(TypeInternal, MustNewCode("boom"), "boom"))
-	assert.Nil(t, j.Suggestions, "no suggestions set => Suggestions must be nil so json omitempty drops it")
+
+	assert.Empty(t, j.Suggestions)
+	assert.Empty(t, j.Errors)
 }
 
 func TestWithStacktrace(t *testing.T) {

--- a/pkg/errors/http.go
+++ b/pkg/errors/http.go
@@ -7,22 +7,22 @@ import (
 )
 
 type JSON struct {
-	Type        string                    `json:"type,omitempty"`
+	Type        string                    `json:"type" required:"true"`
 	Code        string                    `json:"code" required:"true"`
 	Message     string                    `json:"message" required:"true"`
-	Url         string                    `json:"url,omitempty"`
-	Errors      []responseerroradditional `json:"errors,omitempty"`
-	Retry       *responseretryjson        `json:"retry,omitempty"`
-	Suggestions []string                  `json:"suggestions,omitempty"`
+	Url         string                    `json:"url" required:"true" nullable:"true"`
+	Errors      []responseerroradditional `json:"errors" required:"true" nullable:"true"`
+	Retry       *responseretryjson        `json:"retry" required:"true" nullable:"true"`
+	Suggestions []string                  `json:"suggestions" required:"true" nullable:"true"`
 }
 
 type responseretryjson struct {
-	Delay time.Duration `json:"delay"`
+	Delay time.Duration `json:"delay" required:"true" nullable:"false"`
 }
 
 type responseerroradditional struct {
-	Message     string   `json:"message,omitempty"`
-	Suggestions []string `json:"suggestions,omitempty"`
+	Message     string   `json:"message" required:"true"`
+	Suggestions []string `json:"suggestions" required:"true" nullable:"true"`
 }
 
 func AsJSON(cause error) *JSON {

--- a/pkg/errors/http.go
+++ b/pkg/errors/http.go
@@ -29,9 +29,12 @@ func AsJSON(cause error) *JSON {
 	// See if this is an instance of the base error or not
 	t, c, m, _, u, a := Unwrapb(cause)
 
-	rea := make([]responseerroradditional, len(a))
-	for k, v := range a {
-		rea[k] = responseerroradditional{Message: v.message, Suggestions: v.suggestions}
+	var rea []responseerroradditional
+	if len(a) > 0 {
+		rea = make([]responseerroradditional, len(a))
+		for k, v := range a {
+			rea[k] = responseerroradditional{Message: v.message, Suggestions: v.suggestions}
+		}
 	}
 
 	var retry *responseretryjson
@@ -54,9 +57,12 @@ func AsURLValues(cause error) url.Values {
 	// See if this is an instance of the base error or not
 	_, c, m, _, u, a := Unwrapb(cause)
 
-	rea := make([]responseerroradditional, len(a))
-	for k, v := range a {
-		rea[k] = responseerroradditional{Message: v.message, Suggestions: v.suggestions}
+	var rea []responseerroradditional
+	if len(a) > 0 {
+		rea = make([]responseerroradditional, len(a))
+		for k, v := range a {
+			rea[k] = responseerroradditional{Message: v.message, Suggestions: v.suggestions}
+		}
 	}
 
 	errors, err := json.Marshal(rea)

--- a/pkg/errors/http.go
+++ b/pkg/errors/http.go
@@ -57,12 +57,12 @@ func AsURLValues(cause error) url.Values {
 	// See if this is an instance of the base error or not
 	_, c, m, _, u, a := Unwrapb(cause)
 
-	var rea []responseerroradditional
-	if len(a) > 0 {
-		rea = make([]responseerroradditional, len(a))
-		for k, v := range a {
-			rea[k] = responseerroradditional{Message: v.message, Suggestions: v.suggestions}
-		}
+	// Unlike AsJSON (whose null `errors` honors the OpenAPI nullable contract),
+	// this goes into a redirect query param that the frontend JSON.parses and
+	// .maps over, so keep a non-nil empty slice -> marshals to "[]", not "null".
+	rea := make([]responseerroradditional, len(a))
+	for k, v := range a {
+		rea[k] = responseerroradditional{Message: v.message, Suggestions: v.suggestions}
 	}
 
 	errors, err := json.Marshal(rea)

--- a/pkg/errors/http.go
+++ b/pkg/errors/http.go
@@ -11,9 +11,9 @@ type JSON struct {
 	Code        string                    `json:"code" required:"true"`
 	Message     string                    `json:"message" required:"true"`
 	Url         string                    `json:"url" required:"true" nullable:"true"`
-	Errors      []responseerroradditional `json:"errors" required:"true" nullable:"true"`
+	Errors      []responseerroradditional `json:"errors" required:"true" nullable:"false"`
 	Retry       *responseretryjson        `json:"retry" required:"true" nullable:"true"`
-	Suggestions []string                  `json:"suggestions" required:"true" nullable:"true"`
+	Suggestions []string                  `json:"suggestions" required:"true" nullable:"false"`
 }
 
 type responseretryjson struct {
@@ -22,20 +22,14 @@ type responseretryjson struct {
 
 type responseerroradditional struct {
 	Message     string   `json:"message" required:"true"`
-	Suggestions []string `json:"suggestions" required:"true" nullable:"true"`
+	Suggestions []string `json:"suggestions" required:"true" nullable:"false"`
 }
 
 func AsJSON(cause error) *JSON {
 	// See if this is an instance of the base error or not
 	t, c, m, _, u, a := Unwrapb(cause)
 
-	var rea []responseerroradditional
-	if len(a) > 0 {
-		rea = make([]responseerroradditional, len(a))
-		for k, v := range a {
-			rea[k] = responseerroradditional{Message: v.message, Suggestions: v.suggestions}
-		}
-	}
+	rea := responseAdditionals(a)
 
 	var retry *responseretryjson
 	if r := retryOf(cause); r != nil {
@@ -49,7 +43,7 @@ func AsJSON(cause error) *JSON {
 		Url:         u,
 		Errors:      rea,
 		Retry:       retry,
-		Suggestions: suggestionsOf(cause),
+		Suggestions: nonNilStrings(suggestionsOf(cause)),
 	}
 }
 
@@ -57,13 +51,7 @@ func AsURLValues(cause error) url.Values {
 	// See if this is an instance of the base error or not
 	_, c, m, _, u, a := Unwrapb(cause)
 
-	// Unlike AsJSON (whose null `errors` honors the OpenAPI nullable contract),
-	// this goes into a redirect query param that the frontend JSON.parses and
-	// .maps over, so keep a non-nil empty slice -> marshals to "[]", not "null".
-	rea := make([]responseerroradditional, len(a))
-	for k, v := range a {
-		rea[k] = responseerroradditional{Message: v.message, Suggestions: v.suggestions}
-	}
+	rea := responseAdditionals(a)
 
 	errors, err := json.Marshal(rea)
 	if err != nil {
@@ -80,4 +68,21 @@ func AsURLValues(cause error) url.Values {
 		"url":     {u},
 		"errors":  {string(errors)},
 	}
+}
+
+func responseAdditionals(a []additional) []responseerroradditional {
+	rea := make([]responseerroradditional, len(a))
+	for k, v := range a {
+		rea[k] = responseerroradditional{Message: v.message, Suggestions: nonNilStrings(v.suggestions)}
+	}
+
+	return rea
+}
+
+func nonNilStrings(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+
+	return s
 }

--- a/pkg/errors/suggestions.go
+++ b/pkg/errors/suggestions.go
@@ -5,6 +5,18 @@ import (
 	"strings"
 )
 
+// Nouns name the kind of value a suggestion refers to. Pass one to
+// NewValidReferences / NewSuggestionsOnLevenshteinDistance to phrase the
+// "valid <noun> are ..." list consistently across the codebase.
+const (
+	NounFields     = "fields"
+	NounKeys       = "keys"
+	NounServices   = "services"
+	NounQueryTypes = "query types"
+	NounSignals    = "signals"
+	NounReferences = "references"
+)
+
 const (
 	typoSuggestionThreshold = 0.75
 	// maxValidReferences caps how many valid references are listed so
@@ -13,17 +25,18 @@ const (
 	maxValidReferences = 20
 )
 
-// SuggestionsOnLevenshteinDistance returns a "did you mean" correction (only
+// NewSuggestionsOnLevenshteinDistance returns a "did you mean" correction (only
 // when a close match at least typoSuggestionThreshold similar exists) followed
-// by the valid-references list.
-func SuggestionsOnLevenshteinDistance(invalidInput string, validInputs []string) []string {
+// by the valid-references list. noun names the kind of value being suggested
+// (e.g. "fields", "keys") and is used to phrase the valid-references list.
+func NewSuggestionsOnLevenshteinDistance(invalidInput string, noun string, validInputs []string) []string {
 	suggestions := make([]string, 0, 2)
 
 	if match, ok := ClosestLevenshteinMatch(invalidInput, validInputs); ok {
 		suggestions = append(suggestions, didYouMean(match))
 	}
 
-	if refs := ValidReferences(validInputs...); refs != "" {
+	if refs := NewValidReferences(noun, validInputs...); refs != "" {
 		suggestions = append(suggestions, refs)
 	}
 
@@ -52,10 +65,10 @@ func ClosestLevenshteinMatch(input string, candidates []string) (string, bool) {
 	return "", false
 }
 
-// SuggestionsFromFunc formats the string produce returns as a one-element
+// NewSuggestionsFromFunc formats the string produce returns as a one-element
 // "did you mean: `x`" slice, or nil when it returns the empty string (so callers
 // with their own matching strategy compose into a suggestions list cleanly).
-func SuggestionsFromFunc(produce func() string) []string {
+func NewSuggestionsFromFunc(produce func() string) []string {
 	s := produce()
 	if s == "" {
 		return nil
@@ -64,12 +77,12 @@ func SuggestionsFromFunc(produce func() string) []string {
 	return []string{didYouMean(s)}
 }
 
-// ValidReferences formats values as "valid references: `a`, `b`", capped at
-// maxValidReferences with a "(+N more)" suffix. Each value is rendered as its
-// own string, an Enum() element's StringValue(), or fmt.Sprint as a fallback.
-// It returns "" when there are no values, so callers don't surface a bare
-// "valid references: " with nothing after it.
-func ValidReferences[T any](values ...T) string {
+// NewValidReferences formats values as "valid <noun> are `a`, `b`" (e.g. noun
+// "fields", "functions", "keys"), capped at maxValidReferences with a "(+N more)"
+// suffix. Each value is rendered as its own string, an Enum() element's
+// StringValue(), or fmt.Sprint as a fallback. It returns "" when there are no
+// values, so callers don't surface a bare "valid <noun> are" with nothing after it.
+func NewValidReferences[T any](noun string, values ...T) string {
 	if len(values) == 0 {
 		return ""
 	}
@@ -97,7 +110,7 @@ func ValidReferences[T any](values ...T) string {
 		quoted[i] = "`" + r + "`"
 	}
 
-	out := "valid references: " + strings.Join(quoted, ", ")
+	out := "valid " + noun + " are " + strings.Join(quoted, ", ")
 	if truncated > 0 {
 		out += fmt.Sprintf(" (+%d more)", truncated)
 	}

--- a/pkg/errors/suggestions_test.go
+++ b/pkg/errors/suggestions_test.go
@@ -6,26 +6,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidReferences(t *testing.T) {
-	// An empty set returns "" so callers don't surface a bare "valid references: ".
-	assert.Equal(t, "", ValidReferences[string]())
+func TestNewValidReferences(t *testing.T) {
+	// An empty set returns "" so callers don't surface a bare "valid <noun> are".
+	assert.Equal(t, "", NewValidReferences[string](NounFields))
 
-	assert.Equal(t, "valid references: `a`, `b`", ValidReferences("a", "b"))
+	// The noun phrases the list, e.g. "valid fields are", "valid keys are".
+	assert.Equal(t, "valid fields are `a`, `b`", NewValidReferences(NounFields, "a", "b"))
+	assert.Equal(t, "valid keys are `a`, `b`", NewValidReferences(NounKeys, "a", "b"))
 }
 
-func TestSuggestionsOnLevenshteinDistance(t *testing.T) {
-	// No valid inputs => no suggestions at all (no bare "valid references: ").
-	assert.Empty(t, SuggestionsOnLevenshteinDistance("foo", nil))
+func TestNewSuggestionsOnLevenshteinDistance(t *testing.T) {
+	// No valid inputs => no suggestions at all (no bare "valid <noun> are").
+	assert.Empty(t, NewSuggestionsOnLevenshteinDistance("foo", NounFields, nil))
 
 	// Close match => did-you-mean plus the valid-references list.
 	assert.Equal(t,
-		[]string{"did you mean: `name`", "valid references: `name`, `color`"},
-		SuggestionsOnLevenshteinDistance("nam", []string{"name", "color"}),
+		[]string{"did you mean: `name`", "valid fields are `name`, `color`"},
+		NewSuggestionsOnLevenshteinDistance("nam", NounFields, []string{"name", "color"}),
 	)
 
 	// No close match => valid-references list only.
 	assert.Equal(t,
-		[]string{"valid references: `name`, `color`"},
-		SuggestionsOnLevenshteinDistance("zzzzz", []string{"name", "color"}),
+		[]string{"valid fields are `name`, `color`"},
+		NewSuggestionsOnLevenshteinDistance("zzzzz", NounFields, []string{"name", "color"}),
 	)
 }

--- a/pkg/http/binding/json.go
+++ b/pkg/http/binding/json.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/SigNoz/signoz/pkg/errors"
-	"github.com/SigNoz/signoz/pkg/reflectutil"
+	"github.com/SigNoz/signoz/pkg/jsonschema"
 )
 
 const (
@@ -76,7 +76,7 @@ func (b *jsonBinding) BindBody(body io.Reader, obj any, opts ...BindBodyOption) 
 
 				return errors.
 					NewInvalidInputf(errors.CodeInvalidInput, message, field).
-					WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field, errors.NounFields, reflectutil.JSONFieldNames(obj))...)
+					WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field, errors.NounFields, jsonschema.JSONFieldNames(obj))...)
 			}
 		}
 

--- a/pkg/http/binding/json.go
+++ b/pkg/http/binding/json.go
@@ -3,10 +3,10 @@ package binding
 import (
 	"encoding/json"
 	"io"
-	"reflect"
 	"strings"
 
 	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/reflectutil"
 )
 
 const (
@@ -76,7 +76,7 @@ func (b *jsonBinding) BindBody(body io.Reader, obj any, opts ...BindBodyOption) 
 
 				return errors.
 					NewInvalidInputf(errors.CodeInvalidInput, message, field).
-					WithSuggestions(errors.SuggestionsOnLevenshteinDistance(field, JSONFieldNames(obj))...)
+					WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field, errors.NounFields, reflectutil.JSONFieldNames(obj))...)
 			}
 		}
 
@@ -84,37 +84,6 @@ func (b *jsonBinding) BindBody(body io.Reader, obj any, opts ...BindBodyOption) 
 	}
 
 	return nil
-}
-
-// JSONFieldNames returns the JSON field names of a struct (or pointer to one),
-// skipping fields tagged "-" or without a json tag.
-func JSONFieldNames(v any) []string {
-	var fields []string
-
-	t := reflect.TypeOf(v)
-	if t.Kind() == reflect.Pointer {
-		t = t.Elem()
-	}
-
-	if t.Kind() != reflect.Struct {
-		return fields
-	}
-
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
-		jsonTag := field.Tag.Get("json")
-
-		if jsonTag == "" || jsonTag == "-" {
-			continue
-		}
-
-		fieldName := strings.Split(jsonTag, ",")[0]
-		if fieldName != "" {
-			fields = append(fields, fieldName)
-		}
-	}
-
-	return fields
 }
 
 // extractUnknownField pulls fieldname out of a `json: unknown field "fieldname"`

--- a/pkg/http/binding/json_test.go
+++ b/pkg/http/binding/json_test.go
@@ -90,21 +90,21 @@ func TestJSONBinding_BindBody_UnknownFieldSuggestions(t *testing.T) {
 			body:        `{"shape":"round"}`,
 			opts:        []BindBodyOption{WithDisallowUnknownFields(true)},
 			message:     `unknown field "shape"`,
-			suggestions: []string{"valid references: `name`, `color`"},
+			suggestions: []string{"valid fields are `name`, `color`"},
 		},
 		{
 			name:        "WithContext",
 			body:        `{"shape":"round"}`,
 			opts:        []BindBodyOption{WithDisallowUnknownFields(true), WithUnknownFieldContext("widget spec")},
 			message:     `unknown field "shape" in widget spec`,
-			suggestions: []string{"valid references: `name`, `color`"},
+			suggestions: []string{"valid fields are `name`, `color`"},
 		},
 		{
 			name:        "NearMatch",
 			body:        `{"nam":"x"}`,
 			opts:        []BindBodyOption{WithDisallowUnknownFields(true)},
 			message:     `unknown field "nam"`,
-			suggestions: []string{"did you mean: `name`", "valid references: `name`, `color`"},
+			suggestions: []string{"did you mean: `name`", "valid fields are `name`, `color`"},
 		},
 	}
 

--- a/pkg/http/render/render_test.go
+++ b/pkg/http/render/render_test.go
@@ -99,13 +99,13 @@ func TestError(t *testing.T) {
 			name:       "AlreadyExists",
 			statusCode: http.StatusConflict,
 			err:        errors.New(errors.TypeAlreadyExists, errors.MustNewCode("already_exists"), "already exists").WithUrl("https://already_exists"),
-			expected:   []byte(`{"status":"error","error":{"type":"already-exists","code":"already_exists","message":"already exists","url":"https://already_exists","errors":null,"retry":null,"suggestions":null}}`),
+			expected:   []byte(`{"status":"error","error":{"type":"already-exists","code":"already_exists","message":"already exists","url":"https://already_exists","errors":[],"retry":null,"suggestions":[]}}`),
 		},
 		"/unauthenticated": {
 			name:       "Unauthenticated",
 			statusCode: http.StatusUnauthorized,
 			err:        errors.New(errors.TypeUnauthenticated, errors.MustNewCode("not_allowed"), "not allowed").WithUrl("https://unauthenticated").WithAdditional("a1", "a2"),
-			expected:   []byte(`{"status":"error","error":{"type":"unauthenticated","code":"not_allowed","message":"not allowed","url":"https://unauthenticated","errors":[{"message":"a1","suggestions":null},{"message":"a2","suggestions":null}],"retry":null,"suggestions":null}}`),
+			expected:   []byte(`{"status":"error","error":{"type":"unauthenticated","code":"not_allowed","message":"not allowed","url":"https://unauthenticated","errors":[{"message":"a1","suggestions":[]},{"message":"a2","suggestions":[]}],"retry":null,"suggestions":[]}}`),
 		},
 	}
 

--- a/pkg/http/render/render_test.go
+++ b/pkg/http/render/render_test.go
@@ -99,13 +99,13 @@ func TestError(t *testing.T) {
 			name:       "AlreadyExists",
 			statusCode: http.StatusConflict,
 			err:        errors.New(errors.TypeAlreadyExists, errors.MustNewCode("already_exists"), "already exists").WithUrl("https://already_exists"),
-			expected:   []byte(`{"status":"error","error":{"type":"already-exists","code":"already_exists","message":"already exists","url":"https://already_exists"}}`),
+			expected:   []byte(`{"status":"error","error":{"type":"already-exists","code":"already_exists","message":"already exists","url":"https://already_exists","errors":null,"retry":null,"suggestions":null}}`),
 		},
 		"/unauthenticated": {
 			name:       "Unauthenticated",
 			statusCode: http.StatusUnauthorized,
 			err:        errors.New(errors.TypeUnauthenticated, errors.MustNewCode("not_allowed"), "not allowed").WithUrl("https://unauthenticated").WithAdditional("a1", "a2"),
-			expected:   []byte(`{"status":"error","error":{"type":"unauthenticated","code":"not_allowed","message":"not allowed","url":"https://unauthenticated","errors":[{"message":"a1"},{"message":"a2"}]}}`),
+			expected:   []byte(`{"status":"error","error":{"type":"unauthenticated","code":"not_allowed","message":"not allowed","url":"https://unauthenticated","errors":[{"message":"a1","suggestions":null},{"message":"a2","suggestions":null}],"retry":null,"suggestions":null}}`),
 		},
 	}
 
@@ -177,8 +177,8 @@ func TestErrorRetryAfterHeader(t *testing.T) {
 			name:                "BareErrorNoHeaderNoRetryBlock",
 			err:                 errors.New(errors.TypeInternal, errors.MustNewCode("boom"), "boom"),
 			wantRetryAfter:      "",
-			wantBodyContains:    `"code":"boom"`,
-			wantBodyNotContains: `"retry"`,
+			wantBodyContains:    `"retry":null`,
+			wantBodyNotContains: `"delay"`,
 		},
 	}
 

--- a/pkg/jsonschema/fields.go
+++ b/pkg/jsonschema/fields.go
@@ -1,5 +1,5 @@
-// Package reflectutil holds small reflection helpers shared across packages.
-package reflectutil
+// Package jsonschema holds small reflection helpers shared across packages.
+package jsonschema
 
 import (
 	"reflect"

--- a/pkg/querybuilder/fallback_expr.go
+++ b/pkg/querybuilder/fallback_expr.go
@@ -81,7 +81,7 @@ func CollisionHandledFinalExpr(
 			// - it is not a static field
 			// - the next best thing to do is see if there is a typo
 			// and suggest a correction
-			wrappedErr := errors.WithSuggestiveAdditionalf(fieldForErr, errors.SuggestionsOnLevenshteinDistance(field.Name, maps.Keys(keys)), "field `%s` not found", field.Name)
+			wrappedErr := errors.WithSuggestiveAdditionalf(fieldForErr, errors.NewSuggestionsOnLevenshteinDistance(field.Name, errors.NounKeys, maps.Keys(keys)), "field `%s` not found", field.Name)
 			return "", nil, wrappedErr
 		} else {
 			for _, key := range keysForField {

--- a/pkg/querybuilder/having_expression_validator.go
+++ b/pkg/querybuilder/having_expression_validator.go
@@ -300,7 +300,7 @@ func (r *HavingExpressionRewriter) rewriteAndValidate(expression string) (string
 		var suggestions []string
 		if len(v.invalid) == 1 {
 			inv := v.invalid[0]
-			suggestions = errors.SuggestionsFromFunc(func() string {
+			suggestions = errors.NewSuggestionsFromFunc(func() string {
 				match, ok := errors.ClosestLevenshteinMatch(inv, validKeys)
 				if !ok || strings.Contains(original, inv+"(") || strings.Contains(match, "(") {
 					return ""
@@ -309,7 +309,7 @@ func (r *HavingExpressionRewriter) rewriteAndValidate(expression string) (string
 			})
 		}
 
-		suggestions = append(suggestions, errors.ValidReferences(validKeys...))
+		suggestions = append(suggestions, errors.NewValidReferences(errors.NounReferences, validKeys...))
 		havingErr := errors.NewInvalidInputf(
 			errors.CodeInvalidInput,
 			"Invalid references in `Having` expression: [%s]",
@@ -339,7 +339,7 @@ func (r *HavingExpressionRewriter) rewriteAndValidate(expression string) (string
 		// multiple errors are surfaced as one additional detail each. If the parser
 		// produced no message (rare), the top-level message stands on its own.
 		if len(allSyntaxErrors) == 1 && len(msgs) == 1 {
-			suggestions := errors.SuggestionsFromFunc(func() string {
+			suggestions := errors.NewSuggestionsFromFunc(func() string {
 				return havingSuggestion(allSyntaxErrors[0], original)
 			})
 

--- a/pkg/querybuilder/having_rewriter_test.go
+++ b/pkg/querybuilder/having_rewriter_test.go
@@ -593,7 +593,7 @@ func TestRewriteForLogsAndTraces_InOperator(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "Invalid references in `Having` expression: [ghost]",
 			wantAdditional:  []string{"Valid references are: [__result, __result0, count(), total]"},
-			wantSuggestions: []string{"valid references: `__result`, `__result0`, `count()`, `total`"},
+			wantSuggestions: []string{"valid references are `__result`, `__result0`, `count()`, `total`"},
 		},
 		{
 			name:       "IN with end bracked missing",
@@ -655,7 +655,7 @@ func TestRewriteForLogsAndTraces_ErrorInvalidReferences(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "Invalid references in `Having` expression: [unknown_alias]",
 			wantAdditional:  []string{"Valid references are: [__result, __result0, count(), total]"},
-			wantSuggestions: []string{"valid references: `__result`, `__result0`, `count()`, `total`"},
+			wantSuggestions: []string{"valid references are `__result`, `__result0`, `count()`, `total`"},
 		},
 		{
 			name:       "typo in identifier suggests closest match",
@@ -666,7 +666,7 @@ func TestRewriteForLogsAndTraces_ErrorInvalidReferences(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "Invalid references in `Having` expression: [totol]",
 			wantAdditional:  []string{"Valid references are: [__result, __result0, count(), total]"},
-			wantSuggestions: []string{"did you mean: `total > 100`", "valid references: `__result`, `__result0`, `count()`, `total`"},
+			wantSuggestions: []string{"did you mean: `total > 100`", "valid references are `__result`, `__result0`, `count()`, `total`"},
 		},
 		{
 			name:       "expression not in column map",
@@ -677,7 +677,7 @@ func TestRewriteForLogsAndTraces_ErrorInvalidReferences(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "Invalid references in `Having` expression: [sum]",
 			wantAdditional:  []string{"Valid references are: [__result, __result0, count()]"},
-			wantSuggestions: []string{"valid references: `__result`, `__result0`, `count()`"},
+			wantSuggestions: []string{"valid references are `__result`, `__result0`, `count()`"},
 		},
 		{
 			name:       "one valid one invalid reference",
@@ -688,7 +688,7 @@ func TestRewriteForLogsAndTraces_ErrorInvalidReferences(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "Invalid references in `Having` expression: [ghost]",
 			wantAdditional:  []string{"Valid references are: [__result, __result0, count(), total]"},
-			wantSuggestions: []string{"valid references: `__result`, `__result0`, `count()`, `total`"},
+			wantSuggestions: []string{"valid references are `__result`, `__result0`, `count()`, `total`"},
 		},
 		{
 			name:       "__result ambiguous with multiple aggregations",
@@ -700,7 +700,7 @@ func TestRewriteForLogsAndTraces_ErrorInvalidReferences(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "Invalid references in `Having` expression: [__result]",
 			wantAdditional:  []string{"Valid references are: [__result0, __result1, count(), sum(bytes)]"},
-			wantSuggestions: []string{"did you mean: `__result0 > 100`", "valid references: `__result0`, `__result1`, `count()`, `sum(bytes)`"},
+			wantSuggestions: []string{"did you mean: `__result0 > 100`", "valid references are `__result0`, `__result1`, `count()`, `sum(bytes)`"},
 		},
 		{
 			name:       "out-of-range __result_N index",
@@ -711,7 +711,7 @@ func TestRewriteForLogsAndTraces_ErrorInvalidReferences(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "Invalid references in `Having` expression: [__result_9]",
 			wantAdditional:  []string{"Valid references are: [__result, __result0, count()]"},
-			wantSuggestions: []string{"did you mean: `__result > 100`", "valid references: `__result`, `__result0`, `count()`"},
+			wantSuggestions: []string{"did you mean: `__result > 100`", "valid references are `__result`, `__result0`, `count()`"},
 		},
 		{
 			name:       "__result_1 out of range for single aggregation",
@@ -722,7 +722,7 @@ func TestRewriteForLogsAndTraces_ErrorInvalidReferences(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "Invalid references in `Having` expression: [__result_1]",
 			wantAdditional:  []string{"Valid references are: [__result, __result0, count()]"},
-			wantSuggestions: []string{"did you mean: `__result > 100`", "valid references: `__result`, `__result0`, `count()`"},
+			wantSuggestions: []string{"did you mean: `__result > 100`", "valid references are `__result`, `__result0`, `count()`"},
 		},
 		{
 			name:       "cascaded function calls",
@@ -733,7 +733,7 @@ func TestRewriteForLogsAndTraces_ErrorInvalidReferences(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "Invalid references in `Having` expression: [sum]",
 			wantAdditional:  []string{"Valid references are: [__result, __result0, count()]"},
-			wantSuggestions: []string{"valid references: `__result`, `__result0`, `count()`"},
+			wantSuggestions: []string{"valid references are `__result`, `__result0`, `count()`"},
 		},
 		{
 			name:       "function call with multiple args not in column map",
@@ -744,7 +744,7 @@ func TestRewriteForLogsAndTraces_ErrorInvalidReferences(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "Invalid references in `Having` expression: [sum]",
 			wantAdditional:  []string{"Valid references are: [__result, __result0, sum(a)]"},
-			wantSuggestions: []string{"valid references: `__result`, `__result0`, `sum(a)`"},
+			wantSuggestions: []string{"valid references are `__result`, `__result0`, `sum(a)`"},
 		},
 		{
 			name:       "unquoted string value treated as unknown identifier",
@@ -755,7 +755,7 @@ func TestRewriteForLogsAndTraces_ErrorInvalidReferences(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "Invalid references in `Having` expression: [xyz]",
 			wantAdditional:  []string{"Valid references are: [__result, __result0, sum(bytes)]"},
-			wantSuggestions: []string{"valid references: `__result`, `__result0`, `sum(bytes)`"},
+			wantSuggestions: []string{"valid references are `__result`, `__result0`, `sum(bytes)`"},
 		},
 	})
 }
@@ -1030,7 +1030,7 @@ func TestRewriteForMetrics(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "Invalid references in `Having` expression: [wrong_metric]",
 			wantAdditional:  []string{"Valid references are: [__result, __result0, sum(cpu_usage)]"},
-			wantSuggestions: []string{"valid references: `__result`, `__result0`, `sum(cpu_usage)`"},
+			wantSuggestions: []string{"valid references are `__result`, `__result0`, `sum(cpu_usage)`"},
 		},
 		// --- Error: string literal (not allowed in HAVING) ---
 		{
@@ -1077,7 +1077,7 @@ func TestRewriteForMetrics(t *testing.T) {
 			wantErr:         true,
 			wantErrMsg:      "Invalid references in `Having` expression: [count]",
 			wantAdditional:  []string{"Valid references are: [__result, __result0, sum(cpu_usage)]"},
-			wantSuggestions: []string{"valid references: `__result`, `__result0`, `sum(cpu_usage)`"},
+			wantSuggestions: []string{"valid references are `__result`, `__result0`, `sum(cpu_usage)`"},
 		},
 	}
 

--- a/pkg/reflectutil/reflectutil.go
+++ b/pkg/reflectutil/reflectutil.go
@@ -1,0 +1,38 @@
+// Package reflectutil holds small reflection helpers shared across packages.
+package reflectutil
+
+import (
+	"reflect"
+	"strings"
+)
+
+// JSONFieldNames returns the JSON field names of a struct (or pointer to one),
+// skipping fields tagged "-" or without a json tag.
+func JSONFieldNames(v any) []string {
+	var fields []string
+
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	if t.Kind() != reflect.Struct {
+		return fields
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		jsonTag := field.Tag.Get("json")
+
+		if jsonTag == "" || jsonTag == "-" {
+			continue
+		}
+
+		fieldName := strings.Split(jsonTag, ",")[0]
+		if fieldName != "" {
+			fields = append(fields, fieldName)
+		}
+	}
+
+	return fields
+}

--- a/pkg/telemetryaudit/field_mapper.go
+++ b/pkg/telemetryaudit/field_mapper.go
@@ -109,7 +109,7 @@ func (m *fieldMapper) ColumnExpressionFor(
 				field.FieldContext = telemetrytypes.FieldContextLog
 				fieldExpression, _ = m.FieldFor(ctx, tsStart, tsEnd, field)
 			} else {
-				wrappedErr := errors.Wrapf(err, errors.TypeInvalidInput, errors.CodeInvalidInput, "field `%s` not found", field.Name).WithSuggestions(errors.SuggestionsOnLevenshteinDistance(field.Name, maps.Keys(keys))...)
+				wrappedErr := errors.Wrapf(err, errors.TypeInvalidInput, errors.CodeInvalidInput, "field `%s` not found", field.Name).WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field.Name, errors.NounKeys, maps.Keys(keys))...)
 				return "", wrappedErr
 			}
 		} else {

--- a/pkg/telemetrylogs/field_mapper.go
+++ b/pkg/telemetrylogs/field_mapper.go
@@ -263,7 +263,7 @@ func (m *fieldMapper) ColumnExpressionFor(
 				// - it is not a static field
 				// - the next best thing to do is see if there is a typo
 				// and suggest a correction
-				wrappedErr := errors.Wrapf(err, errors.TypeInvalidInput, errors.CodeInvalidInput, "field `%s` not found", field.Name).WithSuggestions(errors.SuggestionsOnLevenshteinDistance(field.Name, maps.Keys(keys))...)
+				wrappedErr := errors.Wrapf(err, errors.TypeInvalidInput, errors.CodeInvalidInput, "field `%s` not found", field.Name).WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field.Name, errors.NounKeys, maps.Keys(keys))...)
 				return "", wrappedErr
 			}
 		} else if len(keysForField) == 1 {

--- a/pkg/telemetrymetadata/field_mapper.go
+++ b/pkg/telemetrymetadata/field_mapper.go
@@ -91,7 +91,7 @@ func (m *fieldMapper) ColumnExpressionFor(
 				// - it is not a static field
 				// - the next best thing to do is see if there is a typo
 				// and suggest a correction
-				wrappedErr := errors.Wrapf(err, errors.TypeInvalidInput, errors.CodeInvalidInput, "field `%s` not found", field.Name).WithSuggestions(errors.SuggestionsOnLevenshteinDistance(field.Name, maps.Keys(keys))...)
+				wrappedErr := errors.Wrapf(err, errors.TypeInvalidInput, errors.CodeInvalidInput, "field `%s` not found", field.Name).WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field.Name, errors.NounKeys, maps.Keys(keys))...)
 				return "", wrappedErr
 			}
 		} else if len(keysForField) == 1 {

--- a/pkg/telemetrystore/clickhousetelemetrystore/provider.go
+++ b/pkg/telemetrystore/clickhousetelemetrystore/provider.go
@@ -3,12 +3,32 @@ package clickhousetelemetrystore
 import (
 	"context"
 
+	chproto "github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"go.opentelemetry.io/otel/metric"
 )
+
+var userFacingClickHouseErrorCodes = map[chproto.Error]bool{
+	chproto.ErrSyntaxError:                  true,
+	chproto.ErrUnknownTable:                 true,
+	chproto.ErrUnknownDatabase:              true,
+	chproto.ErrUnknownIdentifier:            true,
+	chproto.ErrUnknownFunction:              true,
+	chproto.ErrUnknownAggregateFunction:     true,
+	chproto.ErrUnknownType:                  true,
+	chproto.ErrUnknownStorage:               true,
+	chproto.ErrUnknownElementInAst:          true,
+	chproto.ErrUnknownTypeOfQuery:           true,
+	chproto.ErrIllegalTypeOfArgument:        true,
+	chproto.ErrIllegalColumn:                true,
+	chproto.ErrNumberOfArgumentsDoesntMatch: true,
+	chproto.ErrTooManyArgumentsForFunction:  true,
+	chproto.ErrTooLessArgumentsForFunction:  true,
+}
 
 type provider struct {
 	settings       factory.ScopedProviderSettings
@@ -101,6 +121,7 @@ func (p *provider) Query(ctx context.Context, query string, args ...interface{})
 	ctx = telemetrystore.WrapBeforeQuery(p.hooks, ctx, event)
 	rows, err := p.clickHouseConn.Query(ctx, query, args...)
 	if err != nil {
+		err = castError(err)
 		event.Err = err
 		telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
 		return nil, err
@@ -120,7 +141,7 @@ func (p *provider) QueryRow(ctx context.Context, query string, args ...interface
 	ctx = telemetrystore.WrapBeforeQuery(p.hooks, ctx, event)
 	row := p.clickHouseConn.QueryRow(ctx, query, args...)
 
-	event.Err = row.Err()
+	event.Err = castError(row.Err())
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
 
 	return row
@@ -130,7 +151,7 @@ func (p *provider) Select(ctx context.Context, dest interface{}, query string, a
 	event := telemetrystore.NewQueryEvent(query, args)
 
 	ctx = telemetrystore.WrapBeforeQuery(p.hooks, ctx, event)
-	err := p.clickHouseConn.Select(ctx, dest, query, args...)
+	err := castError(p.clickHouseConn.Select(ctx, dest, query, args...))
 
 	event.Err = err
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
@@ -142,7 +163,7 @@ func (p *provider) Exec(ctx context.Context, query string, args ...interface{}) 
 	event := telemetrystore.NewQueryEvent(query, args)
 
 	ctx = telemetrystore.WrapBeforeQuery(p.hooks, ctx, event)
-	err := p.clickHouseConn.Exec(ctx, query, args...)
+	err := castError(p.clickHouseConn.Exec(ctx, query, args...))
 
 	event.Err = err
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
@@ -155,7 +176,7 @@ func (p *provider) AsyncInsert(ctx context.Context, query string, wait bool, arg
 
 	ctx = telemetrystore.WrapBeforeQuery(p.hooks, ctx, event)
 	// TODO: migrate to WithAsync() — https://github.com/SigNoz/engineering-pod/issues/5093
-	err := p.clickHouseConn.AsyncInsert(ctx, query, wait, args...) //nolint:staticcheck
+	err := castError(p.clickHouseConn.AsyncInsert(ctx, query, wait, args...)) //nolint:staticcheck
 
 	event.Err = err
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
@@ -168,6 +189,7 @@ func (p *provider) PrepareBatch(ctx context.Context, query string, opts ...drive
 
 	ctx = telemetrystore.WrapBeforeQuery(p.hooks, ctx, event)
 	batch, err := p.clickHouseConn.PrepareBatch(ctx, query, opts...)
+	err = castError(err)
 
 	event.Err = err
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
@@ -181,4 +203,18 @@ func (p *provider) ServerVersion() (*driver.ServerVersion, error) {
 
 func (p *provider) Contributors() []string {
 	return p.clickHouseConn.Contributors()
+}
+
+// castError classifies a ClickHouse server-side exception
+func castError(err error) error {
+	var ex *clickhouse.Exception
+	if !errors.As(err, &ex) {
+		return err
+	}
+
+	if userFacingClickHouseErrorCodes[chproto.Error(ex.Code)] {
+		return errors.WrapInvalidInputf(err, errors.CodeInvalidInput, "ClickHouse SQL execution failed")
+	}
+
+	return errors.WrapInternalf(err, errors.CodeInternal, "ClickHouse SQL execution failed")
 }

--- a/pkg/telemetrystore/clickhousetelemetrystore/provider.go
+++ b/pkg/telemetrystore/clickhousetelemetrystore/provider.go
@@ -183,6 +183,11 @@ func (p *provider) QueryRow(ctx context.Context, query string, args ...interface
 	ctx = telemetrystore.WrapBeforeQuery(p.hooks, ctx, event)
 	row := p.clickHouseConn.QueryRow(ctx, query, args...)
 
+	if row == nil {
+		telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
+		return nil
+	}
+
 	event.Err = row.Err()
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
 
@@ -234,6 +239,9 @@ func (p *provider) PrepareBatch(ctx context.Context, query string, opts ...drive
 	event.Err = err
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
 
+	if batch == nil {
+		return nil, castError(err)
+	}
 	return &batchWithCastError{Batch: batch}, castError(err)
 }
 

--- a/pkg/telemetrystore/clickhousetelemetrystore/provider.go
+++ b/pkg/telemetrystore/clickhousetelemetrystore/provider.go
@@ -13,18 +13,18 @@ import (
 )
 
 var (
-	ErrCodeSyntaxError       = errors.MustNewCode("telemetrystore.clickhouse.syntax_error")
-	ErrCodeUnknownTable      = errors.MustNewCode("telemetrystore.clickhouse.unknown_table")
-	ErrCodeUnknownDatabase   = errors.MustNewCode("telemetrystore.clickhouse.unknown_database")
-	ErrCodeUnknownIdentifier = errors.MustNewCode("telemetrystore.clickhouse.unknown_identifier")
-	ErrCodeIllegalArgument   = errors.MustNewCode("telemetrystore.clickhouse.illegal_argument")
+	ErrCodeSyntaxError       = errors.MustNewCode("syntax_error")
+	ErrCodeUnknownTable      = errors.MustNewCode("unknown_table")
+	ErrCodeUnknownDatabase   = errors.MustNewCode("unknown_database")
+	ErrCodeUnknownIdentifier = errors.MustNewCode("unknown_identifier")
+	ErrCodeIllegalArgument   = errors.MustNewCode("illegal_argument")
 
-	ErrCodeQueryCanceled   = errors.MustNewCode("telemetrystore.clickhouse.query_canceled")
-	ErrCodeQueryTimeout    = errors.MustNewCode("telemetrystore.clickhouse.query_timeout")
-	ErrCodeExecutionFailed = errors.MustNewCode("telemetrystore.clickhouse.execution_failed")
+	ErrCodeQueryCanceled   = errors.MustNewCode("query_canceled")
+	ErrCodeQueryTimeout    = errors.MustNewCode("query_timeout")
+	ErrCodeExecutionFailed = errors.MustNewCode("execution_failed")
 )
 
-// Codes absent from this map fall through to ErrCodeExecutionFailed in castError.
+// Codes absent from this map fall through to the raw driver error in castError.
 var clickHouseExceptionWrappers = map[chproto.Error]func(cause error, ex *clickhouse.Exception) error{
 	chproto.ErrSyntaxError: func(cause error, ex *clickhouse.Exception) error {
 		return errors.WrapInvalidInputf(cause, ErrCodeSyntaxError, "SQL syntax error: %s", ex.Message)
@@ -259,10 +259,10 @@ func castError(err error) error {
 	}
 
 	if errors.Is(err, context.Canceled) {
-		return errors.WrapCanceledf(err, ErrCodeQueryCanceled, "ClickHouse query canceled")
+		return errors.WrapCanceledf(err, ErrCodeQueryCanceled, "query canceled")
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
-		return errors.WrapTimeoutf(err, ErrCodeQueryTimeout, "ClickHouse query deadline exceeded")
+		return errors.WrapTimeoutf(err, ErrCodeQueryTimeout, "query timed out")
 	}
 
 	var ex *clickhouse.Exception
@@ -274,5 +274,5 @@ func castError(err error) error {
 		return wrap(err, ex)
 	}
 
-	return errors.WrapInternalf(err, ErrCodeExecutionFailed, "ClickHouse SQL execution failed")
+	return err
 }

--- a/pkg/telemetrystore/clickhousetelemetrystore/provider.go
+++ b/pkg/telemetrystore/clickhousetelemetrystore/provider.go
@@ -12,22 +12,65 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-var userFacingClickHouseErrorCodes = map[chproto.Error]bool{
-	chproto.ErrSyntaxError:                  true,
-	chproto.ErrUnknownTable:                 true,
-	chproto.ErrUnknownDatabase:              true,
-	chproto.ErrUnknownIdentifier:            true,
-	chproto.ErrUnknownFunction:              true,
-	chproto.ErrUnknownAggregateFunction:     true,
-	chproto.ErrUnknownType:                  true,
-	chproto.ErrUnknownStorage:               true,
-	chproto.ErrUnknownElementInAst:          true,
-	chproto.ErrUnknownTypeOfQuery:           true,
-	chproto.ErrIllegalTypeOfArgument:        true,
-	chproto.ErrIllegalColumn:                true,
-	chproto.ErrNumberOfArgumentsDoesntMatch: true,
-	chproto.ErrTooManyArgumentsForFunction:  true,
-	chproto.ErrTooLessArgumentsForFunction:  true,
+var (
+	ErrCodeSyntaxError       = errors.MustNewCode("telemetrystore.clickhouse.syntax_error")
+	ErrCodeUnknownTable      = errors.MustNewCode("telemetrystore.clickhouse.unknown_table")
+	ErrCodeUnknownDatabase   = errors.MustNewCode("telemetrystore.clickhouse.unknown_database")
+	ErrCodeUnknownIdentifier = errors.MustNewCode("telemetrystore.clickhouse.unknown_identifier")
+	ErrCodeIllegalArgument   = errors.MustNewCode("telemetrystore.clickhouse.illegal_argument")
+
+	ErrCodeQueryCanceled   = errors.MustNewCode("telemetrystore.clickhouse.query_canceled")
+	ErrCodeQueryTimeout    = errors.MustNewCode("telemetrystore.clickhouse.query_timeout")
+	ErrCodeExecutionFailed = errors.MustNewCode("telemetrystore.clickhouse.execution_failed")
+)
+
+// Codes absent from this map fall through to ErrCodeExecutionFailed in castError.
+var clickHouseExceptionWrappers = map[chproto.Error]func(cause error, ex *clickhouse.Exception) error{
+	chproto.ErrSyntaxError: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapInvalidInputf(cause, ErrCodeSyntaxError, "SQL syntax error: %s", ex.Message)
+	},
+	chproto.ErrUnknownTable: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapNotFoundf(cause, ErrCodeUnknownTable, "unknown table: %s", ex.Message)
+	},
+	chproto.ErrUnknownDatabase: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapNotFoundf(cause, ErrCodeUnknownDatabase, "unknown database: %s", ex.Message)
+	},
+	chproto.ErrUnknownIdentifier: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapInvalidInputf(cause, ErrCodeUnknownIdentifier, "unknown identifier: %s", ex.Message)
+	},
+	chproto.ErrUnknownFunction: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapInvalidInputf(cause, ErrCodeUnknownIdentifier, "unknown function: %s", ex.Message)
+	},
+	chproto.ErrUnknownAggregateFunction: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapInvalidInputf(cause, ErrCodeUnknownIdentifier, "unknown aggregate function: %s", ex.Message)
+	},
+	chproto.ErrUnknownType: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapInvalidInputf(cause, ErrCodeUnknownIdentifier, "unknown type: %s", ex.Message)
+	},
+	chproto.ErrUnknownStorage: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapInvalidInputf(cause, ErrCodeUnknownIdentifier, "unknown storage engine: %s", ex.Message)
+	},
+	chproto.ErrIllegalColumn: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapInvalidInputf(cause, ErrCodeUnknownIdentifier, "illegal column: %s", ex.Message)
+	},
+	chproto.ErrUnknownElementInAst: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapInvalidInputf(cause, ErrCodeSyntaxError, "unknown element in SQL AST: %s", ex.Message)
+	},
+	chproto.ErrUnknownTypeOfQuery: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapInvalidInputf(cause, ErrCodeSyntaxError, "unknown query type: %s", ex.Message)
+	},
+	chproto.ErrIllegalTypeOfArgument: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapInvalidInputf(cause, ErrCodeIllegalArgument, "illegal argument type: %s", ex.Message)
+	},
+	chproto.ErrNumberOfArgumentsDoesntMatch: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapInvalidInputf(cause, ErrCodeIllegalArgument, "wrong number of arguments: %s", ex.Message)
+	},
+	chproto.ErrTooManyArgumentsForFunction: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapInvalidInputf(cause, ErrCodeIllegalArgument, "too many arguments to function: %s", ex.Message)
+	},
+	chproto.ErrTooLessArgumentsForFunction: func(cause error, ex *clickhouse.Exception) error {
+		return errors.WrapInvalidInputf(cause, ErrCodeIllegalArgument, "too few arguments to function: %s", ex.Message)
+	},
 }
 
 type provider struct {
@@ -121,10 +164,9 @@ func (p *provider) Query(ctx context.Context, query string, args ...interface{})
 	ctx = telemetrystore.WrapBeforeQuery(p.hooks, ctx, event)
 	rows, err := p.clickHouseConn.Query(ctx, query, args...)
 	if err != nil {
-		err = castError(err)
 		event.Err = err
 		telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
-		return nil, err
+		return nil, castError(err)
 	}
 
 	return &rowsWithHooks{
@@ -141,7 +183,7 @@ func (p *provider) QueryRow(ctx context.Context, query string, args ...interface
 	ctx = telemetrystore.WrapBeforeQuery(p.hooks, ctx, event)
 	row := p.clickHouseConn.QueryRow(ctx, query, args...)
 
-	event.Err = castError(row.Err())
+	event.Err = row.Err()
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
 
 	return row
@@ -151,37 +193,36 @@ func (p *provider) Select(ctx context.Context, dest interface{}, query string, a
 	event := telemetrystore.NewQueryEvent(query, args)
 
 	ctx = telemetrystore.WrapBeforeQuery(p.hooks, ctx, event)
-	err := castError(p.clickHouseConn.Select(ctx, dest, query, args...))
+	err := p.clickHouseConn.Select(ctx, dest, query, args...)
 
 	event.Err = err
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
 
-	return err
+	return castError(err)
 }
 
 func (p *provider) Exec(ctx context.Context, query string, args ...interface{}) error {
 	event := telemetrystore.NewQueryEvent(query, args)
 
 	ctx = telemetrystore.WrapBeforeQuery(p.hooks, ctx, event)
-	err := castError(p.clickHouseConn.Exec(ctx, query, args...))
+	err := p.clickHouseConn.Exec(ctx, query, args...)
 
 	event.Err = err
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
 
-	return err
+	return castError(err)
 }
 
 func (p *provider) AsyncInsert(ctx context.Context, query string, wait bool, args ...interface{}) error {
 	event := telemetrystore.NewQueryEvent(query, args)
 
 	ctx = telemetrystore.WrapBeforeQuery(p.hooks, ctx, event)
-	// TODO: migrate to WithAsync() — https://github.com/SigNoz/engineering-pod/issues/5093
-	err := castError(p.clickHouseConn.AsyncInsert(ctx, query, wait, args...)) //nolint:staticcheck
+	err := p.clickHouseConn.Exec(clickhouse.Context(ctx, clickhouse.WithAsync(wait)), query, args...)
 
 	event.Err = err
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
 
-	return err
+	return castError(err)
 }
 
 func (p *provider) PrepareBatch(ctx context.Context, query string, opts ...driver.PrepareBatchOption) (driver.Batch, error) {
@@ -189,12 +230,11 @@ func (p *provider) PrepareBatch(ctx context.Context, query string, opts ...drive
 
 	ctx = telemetrystore.WrapBeforeQuery(p.hooks, ctx, event)
 	batch, err := p.clickHouseConn.PrepareBatch(ctx, query, opts...)
-	err = castError(err)
 
 	event.Err = err
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
 
-	return batch, err
+	return batch, castError(err)
 }
 
 func (p *provider) ServerVersion() (*driver.ServerVersion, error) {
@@ -205,16 +245,26 @@ func (p *provider) Contributors() []string {
 	return p.clickHouseConn.Contributors()
 }
 
-// castError classifies a ClickHouse server-side exception
 func castError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return errors.WrapCanceledf(err, ErrCodeQueryCanceled, "ClickHouse query canceled")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return errors.WrapTimeoutf(err, ErrCodeQueryTimeout, "ClickHouse query deadline exceeded")
+	}
+
 	var ex *clickhouse.Exception
 	if !errors.As(err, &ex) {
 		return err
 	}
 
-	if userFacingClickHouseErrorCodes[chproto.Error(ex.Code)] {
-		return errors.WrapInvalidInputf(err, errors.CodeInvalidInput, "ClickHouse SQL execution failed")
+	if wrap, ok := clickHouseExceptionWrappers[chproto.Error(ex.Code)]; ok {
+		return wrap(err, ex)
 	}
 
-	return errors.WrapInternalf(err, errors.CodeInternal, "ClickHouse SQL execution failed")
+	return errors.WrapInternalf(err, ErrCodeExecutionFailed, "ClickHouse SQL execution failed")
 }

--- a/pkg/telemetrystore/clickhousetelemetrystore/provider.go
+++ b/pkg/telemetrystore/clickhousetelemetrystore/provider.go
@@ -186,7 +186,7 @@ func (p *provider) QueryRow(ctx context.Context, query string, args ...interface
 	event.Err = row.Err()
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
 
-	return row
+	return &rowWithCastError{Row: row}
 }
 
 func (p *provider) Select(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
@@ -234,7 +234,7 @@ func (p *provider) PrepareBatch(ctx context.Context, query string, opts ...drive
 	event.Err = err
 	telemetrystore.WrapAfterQuery(p.hooks, ctx, event)
 
-	return batch, castError(err)
+	return &batchWithCastError{Batch: batch}, castError(err)
 }
 
 func (p *provider) ServerVersion() (*driver.ServerVersion, error) {

--- a/pkg/telemetrystore/clickhousetelemetrystore/rows.go
+++ b/pkg/telemetrystore/clickhousetelemetrystore/rows.go
@@ -25,13 +25,95 @@ func (r *rowsWithHooks) Close() error {
 
 	// mark as closed and run the onClose hook
 	r.closed = true
-	if err := r.Err(); err != nil {
+	if err := castError(r.Rows.Err()); err != nil {
 		r.event.Err = err
 	}
-	closeErr := r.Rows.Close()
+	closeErr := castError(r.Rows.Close())
 	if closeErr != nil {
 		r.event.Err = closeErr
 	}
 	r.onClose()
 	return closeErr
+}
+
+func (r *rowsWithHooks) Err() error {
+	return castError(r.Rows.Err())
+}
+
+func (r *rowsWithHooks) Scan(dest ...any) error {
+	return castError(r.Rows.Scan(dest...))
+}
+
+func (r *rowsWithHooks) ScanStruct(dest any) error {
+	return castError(r.Rows.ScanStruct(dest))
+}
+
+func (r *rowsWithHooks) Totals(dest ...any) error {
+	return castError(r.Rows.Totals(dest...))
+}
+
+// rowWithCastError wraps driver.Row so errors surfaced by Err/Scan/ScanStruct
+// are normalized through castError, matching the rest of the provider's API.
+type rowWithCastError struct {
+	driver.Row
+}
+
+func (r *rowWithCastError) Err() error {
+	return castError(r.Row.Err())
+}
+
+func (r *rowWithCastError) Scan(dest ...any) error {
+	return castError(r.Row.Scan(dest...))
+}
+
+func (r *rowWithCastError) ScanStruct(dest any) error {
+	return castError(r.Row.ScanStruct(dest))
+}
+
+// batchWithCastError wraps driver.Batch so error-returning methods (Append,
+// Send, Close, etc.) are normalized through castError.
+type batchWithCastError struct {
+	driver.Batch
+}
+
+func (b *batchWithCastError) Abort() error {
+	return castError(b.Batch.Abort())
+}
+
+func (b *batchWithCastError) Append(v ...any) error {
+	return castError(b.Batch.Append(v...))
+}
+
+func (b *batchWithCastError) AppendStruct(v any) error {
+	return castError(b.Batch.AppendStruct(v))
+}
+
+func (b *batchWithCastError) Flush() error {
+	return castError(b.Batch.Flush())
+}
+
+func (b *batchWithCastError) Send() error {
+	return castError(b.Batch.Send())
+}
+
+func (b *batchWithCastError) Close() error {
+	return castError(b.Batch.Close())
+}
+
+func (b *batchWithCastError) Column(i int) driver.BatchColumn {
+	return &batchColumnWithCastError{BatchColumn: b.Batch.Column(i)}
+}
+
+// batchColumnWithCastError wraps driver.BatchColumn so column-level appends
+// also flow through castError.
+type batchColumnWithCastError struct {
+	driver.BatchColumn
+}
+
+func (c *batchColumnWithCastError) Append(v any) error {
+	return castError(c.BatchColumn.Append(v))
+}
+
+func (c *batchColumnWithCastError) AppendRow(v any) error {
+	return castError(c.BatchColumn.AppendRow(v))
 }

--- a/pkg/telemetrytraces/field_mapper.go
+++ b/pkg/telemetrytraces/field_mapper.go
@@ -368,7 +368,7 @@ func (m *defaultFieldMapper) ColumnExpressionFor(
 				// - it is not a static field
 				// - the next best thing to do is see if there is a typo
 				// and suggest a correction
-				wrappedErr := errors.Wrapf(err, errors.TypeInvalidInput, errors.CodeInvalidInput, "field `%s` not found", field.Name).WithSuggestions(errors.SuggestionsOnLevenshteinDistance(field.Name, maps.Keys(keys))...)
+				wrappedErr := errors.Wrapf(err, errors.TypeInvalidInput, errors.CodeInvalidInput, "field `%s` not found", field.Name).WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field.Name, errors.NounKeys, maps.Keys(keys))...)
 				return "", wrappedErr
 			}
 		} else if len(keysForField) == 1 {

--- a/pkg/types/cloudintegrationtypes/serviceid.go
+++ b/pkg/types/cloudintegrationtypes/serviceid.go
@@ -123,5 +123,5 @@ func NewServiceID(provider CloudProviderType, service string) (ServiceID, error)
 
 	return ServiceID{}, errors.NewInvalidInputf(ErrCodeInvalidServiceID,
 		"invalid service id %q for %s cloud provider", service, provider.StringValue()).
-		WithSuggestions(errors.SuggestionsOnLevenshteinDistance(service, validServices)...)
+		WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(service, errors.NounServices, validServices)...)
 }

--- a/pkg/types/querybuildertypes/querybuildertypesv5/req.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/req.go
@@ -8,6 +8,7 @@ import (
 	"github.com/SigNoz/govaluate"
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/http/binding"
+	"github.com/SigNoz/signoz/pkg/reflectutil"
 	"github.com/SigNoz/signoz/pkg/types/metrictypes"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
@@ -152,7 +153,7 @@ func (q *QueryEnvelope) UnmarshalJSON(data []byte) error {
 			shadow.Type,
 		).WithAdditional(
 			"Valid query types are: builder_query, builder_sub_query, builder_formula, builder_join, builder_trace_operator, promql, clickhouse_sql",
-		).WithSuggestions(errors.ValidReferences(QueryType{}.Enum()...))
+		).WithSuggestions(errors.NewValidReferences(errors.NounQueryTypes, QueryType{}.Enum()...))
 	}
 
 	return nil
@@ -196,7 +197,7 @@ func UnmarshalBuilderQueryBySignal(data []byte) (any, error) {
 			errors.CodeInvalidInput,
 			"invalid signal %q",
 			header.Signal.StringValue(),
-		).WithSuggestions(errors.ValidReferences(telemetrytypes.Signal{}.Enum()...))
+		).WithSuggestions(errors.NewValidReferences(errors.NounSignals, telemetrytypes.Signal{}.Enum()...))
 	}
 }
 
@@ -229,7 +230,7 @@ func (c *CompositeQuery) UnmarshalJSON(data []byte) error {
 
 	// Valid field names are derived from the struct itself so this stays in
 	// sync with the schema (and the generated OpenAPI spec) automatically.
-	fieldNames := binding.JSONFieldNames((*CompositeQuery)(nil))
+	fieldNames := reflectutil.JSONFieldNames((*CompositeQuery)(nil))
 	validFields := make(map[string]bool, len(fieldNames))
 	for _, f := range fieldNames {
 		validFields[f] = true
@@ -243,7 +244,7 @@ func (c *CompositeQuery) UnmarshalJSON(data []byte) error {
 				field,
 			).WithAdditional(
 				"Valid fields are: " + strings.Join(fieldNames, ", "),
-			).WithSuggestions(errors.SuggestionsOnLevenshteinDistance(field, fieldNames)...)
+			).WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field, errors.NounFields, fieldNames)...)
 			return unknownFieldErr
 		}
 	}
@@ -556,7 +557,7 @@ func (r *QueryRangeRequest) UnmarshalJSON(data []byte) error {
 
 	// Valid field names are derived from the struct itself so this stays in
 	// sync with the schema (and the generated OpenAPI spec) automatically.
-	fieldNames := binding.JSONFieldNames((*QueryRangeRequest)(nil))
+	fieldNames := reflectutil.JSONFieldNames((*QueryRangeRequest)(nil))
 	validFields := make(map[string]bool, len(fieldNames))
 	for _, f := range fieldNames {
 		validFields[f] = true
@@ -570,7 +571,7 @@ func (r *QueryRangeRequest) UnmarshalJSON(data []byte) error {
 				field,
 			).WithAdditional(
 				"Valid fields are: " + strings.Join(fieldNames, ", "),
-			).WithSuggestions(errors.SuggestionsOnLevenshteinDistance(field, fieldNames)...)
+			).WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(field, errors.NounFields, fieldNames)...)
 			return unknownFieldErr
 		}
 	}

--- a/pkg/types/querybuildertypes/querybuildertypesv5/req.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/req.go
@@ -8,7 +8,7 @@ import (
 	"github.com/SigNoz/govaluate"
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/http/binding"
-	"github.com/SigNoz/signoz/pkg/reflectutil"
+	signozjsonschema "github.com/SigNoz/signoz/pkg/jsonschema"
 	"github.com/SigNoz/signoz/pkg/types/metrictypes"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
@@ -230,7 +230,7 @@ func (c *CompositeQuery) UnmarshalJSON(data []byte) error {
 
 	// Valid field names are derived from the struct itself so this stays in
 	// sync with the schema (and the generated OpenAPI spec) automatically.
-	fieldNames := reflectutil.JSONFieldNames((*CompositeQuery)(nil))
+	fieldNames := signozjsonschema.JSONFieldNames((*CompositeQuery)(nil))
 	validFields := make(map[string]bool, len(fieldNames))
 	for _, f := range fieldNames {
 		validFields[f] = true
@@ -557,7 +557,7 @@ func (r *QueryRangeRequest) UnmarshalJSON(data []byte) error {
 
 	// Valid field names are derived from the struct itself so this stays in
 	// sync with the schema (and the generated OpenAPI spec) automatically.
-	fieldNames := reflectutil.JSONFieldNames((*QueryRangeRequest)(nil))
+	fieldNames := signozjsonschema.JSONFieldNames((*QueryRangeRequest)(nil))
 	validFields := make(map[string]bool, len(fieldNames))
 	for _, f := range fieldNames {
 		validFields[f] = true

--- a/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/validation.go
@@ -518,7 +518,7 @@ func (q *QueryBuilderQuery[T]) validateOrderByForAggregation() error {
 				orderId,
 			).WithAdditional(
 				fmt.Sprintf("For aggregation queries, order by can only reference group by keys, aggregation aliases/expressions, or aggregation indices. Valid keys are: %s", strings.Join(validKeys, ", ")),
-			).WithSuggestions(errors.SuggestionsOnLevenshteinDistance(orderKey, validKeys)...)
+			).WithSuggestions(errors.NewSuggestionsOnLevenshteinDistance(orderKey, errors.NounKeys, validKeys)...)
 		}
 	}
 
@@ -712,7 +712,7 @@ func validateQueryEnvelope(envelope QueryEnvelope, opts ...ValidationOption) err
 			envelope.Type,
 		).WithAdditional(
 			"Valid query types are: builder_query, builder_sub_query, builder_formula, builder_join, promql, clickhouse_sql, trace_operator",
-		).WithSuggestions(errors.ValidReferences(QueryType{}.Enum()...))
+		).WithSuggestions(errors.NewValidReferences(errors.NounQueryTypes, QueryType{}.Enum()...))
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #11542 on the structured error response, plus a ClickHouse error-normalization layer in the telemetry store.

- **OpenAPI / frontend types** — every error-response field (`type`, `code`, `message`, `url`, `errors[]`, `retry`, `suggestions`) is now `required`; conditionally-empty ones are `nullable` (`T | null`) instead of optional, so the generated TS types drop the `?`. `errors` now serializes as `null` (not `[]`) when empty.
- **`errors` package** — suggestion builders are `New`-prefixed (`NewSuggestionsOnLevenshteinDistance`, `NewValidReferences`, `NewSuggestionsFromFunc`); `NewValidReferences` takes a `noun` and renders `valid <noun> are ...` via exported `errors.Noun*` constants. Added `base.Unwrap()` (so `errors.Is`/`As` reach the cause) and `WrapCanceledf`/`NewCanceledf`. Code regex widened to allow dotted codes.
- **ClickHouse telemetry store** — a new `castError` maps raw driver errors to structured base errors: server exceptions by `chproto.Error` code (→ `InvalidInput`/`NotFound`/`Internal`, each with a `telemetrystore.clickhouse.*` code), context cancel/deadline → `Canceled`/`Timeout`. Returned `Rows`/`Row`/`Batch` are wrapped so later scan/append/close errors normalize too. `AsyncInsert` moved to the non-deprecated `Exec(WithAsync)`; `ch-go` promoted to a direct dep.
- **Organization & docs** — `JSONFieldNames` moved from `pkg/http/binding` to a new `pkg/jsonschema`; `docs/contributing/go/errors.md` documents the response field-by-field.

## Change Type
- [x] ♻️ Refactor
- [x] 🛠️ Infra / Tooling (OpenAPI + frontend client regen)
- [x] ✨ Feature (structured ClickHouse query errors)

## Testing
- Unit tests in `pkg/errors`, `pkg/querybuilder`, `pkg/http/binding` updated and passing.
- Regenerated `docs/api/openapi.yml` + frontend client (`pnpm generate:api`); frontend type-check and `PanelStatus` tests pass.

## Risk & Impact
- Error responses always include the previously-optional fields (empty → `null`); frontend types are stricter.
- **Behavior change**: ClickHouse telemetry-store callers now get structured base errors instead of raw `clickhouse.Exception` — assert via `errors.As` (cause stays reachable through `Unwrap`).

## Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance |
| Description | N/A (internal error-response + telemetrystore error refactor) |
