### PR TITLE
chore: bump cloud integration agent version to v0.0.12

### DIFF
--- a/pkg/modules/cloudintegration/config.go
+++ b/pkg/modules/cloudintegration/config.go
@@ -22,7 +22,7 @@ func newConfig() factory.Config {
 		Agent: AgentConfig{
 			// we will maintain the latest version of cloud integration agent from here,
 			// till we automate it externally or figure out a way to validate it.
-			Version: "v0.0.11",
+			Version: "v0.0.12",
 		},
 	}
 }


### PR DESCRIPTION
### Pull Request

Bumping cloud integration agent version to v0.0.12
