### PR TITLE
feat: add clone dashboard API for perses dashboards

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -13721,6 +13721,74 @@ paths:
       summary: Update dashboard (v2)
       tags:
       - dashboard
+  /api/v2/dashboards/{id}/clone:
+    post:
+      deprecated: false
+      description: This endpoint clones an existing v2-shape dashboard. Only user
+        dashboards can be cloned; system and integration dashboards are rejected.
+        The clone keeps the source's display name, panels, and tags, but gets a freshly
+        generated unique internal name and is always created as an unlocked user dashboard
+        owned by the caller.
+      operationId: CloneDashboardV2
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: '#/components/schemas/DashboardtypesGettableDashboardV2'
+                  status:
+                    type: string
+                required:
+                - status
+                - data
+                type: object
+          description: Created
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Internal Server Error
+      security:
+      - api_key:
+        - EDITOR
+      - tokenizer:
+        - EDITOR
+      summary: Clone dashboard (v2)
+      tags:
+      - dashboard
   /api/v2/dashboards/{id}/lock:
     delete:
       deprecated: false

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -13724,11 +13724,11 @@ paths:
   /api/v2/dashboards/{id}/clone:
     post:
       deprecated: false
-      description: This endpoint clones an existing v2-shape dashboard. Only user
-        dashboards can be cloned; system and integration dashboards are rejected.
-        The clone keeps the source's display name, panels, and tags, but gets a freshly
-        generated unique internal name and is always created as an unlocked user dashboard
-        owned by the caller.
+      description: This endpoint clones an existing v2-shape dashboard. User and integration
+        dashboards can be cloned; system dashboards are rejected. The clone keeps
+        the source's display name, panels, and tags, but gets a freshly generated
+        unique internal name and is always created as an unlocked user dashboard owned
+        by the caller.
       operationId: CloneDashboardV2
       parameters:
       - in: path

--- a/ee/modules/dashboard/impldashboard/module.go
+++ b/ee/modules/dashboard/impldashboard/module.go
@@ -217,6 +217,10 @@ func (module *module) CreateV2(ctx context.Context, orgID valuer.UUID, createdBy
 	return module.pkgDashboardModule.CreateV2(ctx, orgID, createdBy, creator, source, postable)
 }
 
+func (module *module) CloneV2(ctx context.Context, orgID valuer.UUID, createdBy string, creator valuer.UUID, id valuer.UUID) (*dashboardtypes.DashboardV2, error) {
+	return module.pkgDashboardModule.CloneV2(ctx, orgID, createdBy, creator, id)
+}
+
 func (module *module) GetV2(ctx context.Context, orgID valuer.UUID, id valuer.UUID) (*dashboardtypes.DashboardV2, error) {
 	return module.pkgDashboardModule.GetV2(ctx, orgID, id)
 }

--- a/frontend/src/api/generated/services/dashboard/index.ts
+++ b/frontend/src/api/generated/services/dashboard/index.ts
@@ -1209,7 +1209,7 @@ export const useUpdateDashboardV2 = <
 	return useMutation(getUpdateDashboardV2MutationOptions(options));
 };
 /**
- * This endpoint clones an existing v2-shape dashboard. Only user dashboards can be cloned; system and integration dashboards are rejected. The clone keeps the source's display name, panels, and tags, but gets a freshly generated unique internal name and is always created as an unlocked user dashboard owned by the caller.
+ * This endpoint clones an existing v2-shape dashboard. User and integration dashboards can be cloned; system dashboards are rejected. The clone keeps the source's display name, panels, and tags, but gets a freshly generated unique internal name and is always created as an unlocked user dashboard owned by the caller.
  * @summary Clone dashboard (v2)
  */
 export const cloneDashboardV2 = (

--- a/frontend/src/api/generated/services/dashboard/index.ts
+++ b/frontend/src/api/generated/services/dashboard/index.ts
@@ -18,6 +18,8 @@ import type {
 } from 'react-query';
 
 import type {
+	CloneDashboardV2201,
+	CloneDashboardV2PathParameters,
 	CreateDashboardV2201,
 	CreatePublicDashboard201,
 	CreatePublicDashboardPathParameters,
@@ -1205,6 +1207,85 @@ export const useUpdateDashboardV2 = <
 	TContext
 > => {
 	return useMutation(getUpdateDashboardV2MutationOptions(options));
+};
+/**
+ * This endpoint clones an existing v2-shape dashboard. Only user dashboards can be cloned; system and integration dashboards are rejected. The clone keeps the source's display name, panels, and tags, but gets a freshly generated unique internal name and is always created as an unlocked user dashboard owned by the caller.
+ * @summary Clone dashboard (v2)
+ */
+export const cloneDashboardV2 = (
+	{ id }: CloneDashboardV2PathParameters,
+	signal?: AbortSignal,
+) => {
+	return GeneratedAPIInstance<CloneDashboardV2201>({
+		url: `/api/v2/dashboards/${id}/clone`,
+		method: 'POST',
+		signal,
+	});
+};
+
+export const getCloneDashboardV2MutationOptions = <
+	TError = ErrorType<RenderErrorResponseDTO>,
+	TContext = unknown,
+>(options?: {
+	mutation?: UseMutationOptions<
+		Awaited<ReturnType<typeof cloneDashboardV2>>,
+		TError,
+		{ pathParams: CloneDashboardV2PathParameters },
+		TContext
+	>;
+}): UseMutationOptions<
+	Awaited<ReturnType<typeof cloneDashboardV2>>,
+	TError,
+	{ pathParams: CloneDashboardV2PathParameters },
+	TContext
+> => {
+	const mutationKey = ['cloneDashboardV2'];
+	const { mutation: mutationOptions } = options
+		? options.mutation &&
+			'mutationKey' in options.mutation &&
+			options.mutation.mutationKey
+			? options
+			: { ...options, mutation: { ...options.mutation, mutationKey } }
+		: { mutation: { mutationKey } };
+
+	const mutationFn: MutationFunction<
+		Awaited<ReturnType<typeof cloneDashboardV2>>,
+		{ pathParams: CloneDashboardV2PathParameters }
+	> = (props) => {
+		const { pathParams } = props ?? {};
+
+		return cloneDashboardV2(pathParams);
+	};
+
+	return { mutationFn, ...mutationOptions };
+};
+
+export type CloneDashboardV2MutationResult = NonNullable<
+	Awaited<ReturnType<typeof cloneDashboardV2>>
+>;
+
+export type CloneDashboardV2MutationError = ErrorType<RenderErrorResponseDTO>;
+
+/**
+ * @summary Clone dashboard (v2)
+ */
+export const useCloneDashboardV2 = <
+	TError = ErrorType<RenderErrorResponseDTO>,
+	TContext = unknown,
+>(options?: {
+	mutation?: UseMutationOptions<
+		Awaited<ReturnType<typeof cloneDashboardV2>>,
+		TError,
+		{ pathParams: CloneDashboardV2PathParameters },
+		TContext
+	>;
+}): UseMutationResult<
+	Awaited<ReturnType<typeof cloneDashboardV2>>,
+	TError,
+	{ pathParams: CloneDashboardV2PathParameters },
+	TContext
+> => {
+	return useMutation(getCloneDashboardV2MutationOptions(options));
 };
 /**
  * This endpoint unlocks a v2-shape dashboard. Only the dashboard's creator or an org admin may lock or unlock.

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -9915,6 +9915,17 @@ export type UpdateDashboardV2200 = {
 	status: string;
 };
 
+export type CloneDashboardV2PathParameters = {
+	id: string;
+};
+export type CloneDashboardV2201 = {
+	data: DashboardtypesGettableDashboardV2DTO;
+	/**
+	 * @type string
+	 */
+	status: string;
+};
+
 export type UnlockDashboardV2PathParameters = {
 	id: string;
 };

--- a/pkg/apiserver/signozapiserver/dashboard.go
+++ b/pkg/apiserver/signozapiserver/dashboard.go
@@ -68,6 +68,23 @@ func (provider *provider) addDashboardRoutes(router *mux.Router) error {
 		return err
 	}
 
+	if err := router.Handle("/api/v2/dashboards/{id}/clone", handler.New(provider.authzMiddleware.EditAccess(provider.dashboardHandler.CloneV2), handler.OpenAPIDef{
+		ID:                  "CloneDashboardV2",
+		Tags:                []string{"dashboard"},
+		Summary:             "Clone dashboard (v2)",
+		Description:         "This endpoint clones an existing v2-shape dashboard. Only user dashboards can be cloned; system and integration dashboards are rejected. The clone keeps the source's display name, panels, and tags, but gets a freshly generated unique internal name and is always created as an unlocked user dashboard owned by the caller.",
+		Request:             nil,
+		RequestContentType:  "",
+		Response:            new(dashboardtypes.GettableDashboardV2),
+		ResponseContentType: "application/json",
+		SuccessStatusCode:   http.StatusCreated,
+		ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
+		Deprecated:          false,
+		SecuritySchemes:     newSecuritySchemes(types.RoleEditor),
+	})).Methods(http.MethodPost).GetError(); err != nil {
+		return err
+	}
+
 	if err := router.Handle("/api/v2/dashboards/{id}", handler.New(provider.authzMiddleware.ViewAccess(provider.dashboardHandler.GetV2), handler.OpenAPIDef{
 		ID:                  "GetDashboardV2",
 		Tags:                []string{"dashboard"},

--- a/pkg/apiserver/signozapiserver/dashboard.go
+++ b/pkg/apiserver/signozapiserver/dashboard.go
@@ -72,7 +72,7 @@ func (provider *provider) addDashboardRoutes(router *mux.Router) error {
 		ID:                  "CloneDashboardV2",
 		Tags:                []string{"dashboard"},
 		Summary:             "Clone dashboard (v2)",
-		Description:         "This endpoint clones an existing v2-shape dashboard. Only user dashboards can be cloned; system and integration dashboards are rejected. The clone keeps the source's display name, panels, and tags, but gets a freshly generated unique internal name and is always created as an unlocked user dashboard owned by the caller.",
+		Description:         "This endpoint clones an existing v2-shape dashboard. User and integration dashboards can be cloned; system dashboards are rejected. The clone keeps the source's display name, panels, and tags, but gets a freshly generated unique internal name and is always created as an unlocked user dashboard owned by the caller.",
 		Request:             nil,
 		RequestContentType:  "",
 		Response:            new(dashboardtypes.GettableDashboardV2),

--- a/pkg/modules/dashboard/dashboard.go
+++ b/pkg/modules/dashboard/dashboard.go
@@ -59,6 +59,8 @@ type Module interface {
 
 	CreateV2(ctx context.Context, orgID valuer.UUID, createdBy string, creator valuer.UUID, source dashboardtypes.Source, postable dashboardtypes.PostableDashboardV2) (*dashboardtypes.DashboardV2, error)
 
+	CloneV2(ctx context.Context, orgID valuer.UUID, createdBy string, creator valuer.UUID, id valuer.UUID) (*dashboardtypes.DashboardV2, error)
+
 	GetV2(ctx context.Context, orgID valuer.UUID, id valuer.UUID) (*dashboardtypes.DashboardV2, error)
 
 	ListV2(ctx context.Context, orgID valuer.UUID, params *dashboardtypes.ListDashboardsV2Params) (*dashboardtypes.ListableDashboardV2, error)
@@ -105,6 +107,8 @@ type Handler interface {
 	// v2 dashboard methods
 	// ════════════════════════════════════════════════════════════════════════
 	CreateV2(http.ResponseWriter, *http.Request)
+
+	CloneV2(http.ResponseWriter, *http.Request)
 
 	GetV2(http.ResponseWriter, *http.Request)
 

--- a/pkg/modules/dashboard/impldashboard/v2_handler.go
+++ b/pkg/modules/dashboard/impldashboard/v2_handler.go
@@ -42,6 +42,38 @@ func (handler *handler) CreateV2(rw http.ResponseWriter, r *http.Request) {
 	render.Success(rw, http.StatusCreated, dashboard.ToGettableDashboardV2())
 }
 
+func (handler *handler) CloneV2(rw http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	claims, err := authtypes.ClaimsFromContext(ctx)
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	orgID := valuer.MustNewUUID(claims.OrgID)
+
+	id := mux.Vars(r)["id"]
+	if id == "" {
+		render.Error(rw, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "id is missing in the path"))
+		return
+	}
+	dashboardID, err := valuer.NewUUID(id)
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	dashboard, err := handler.module.CloneV2(ctx, orgID, claims.Email, valuer.MustNewUUID(claims.IdentityID()), dashboardID)
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	render.Success(rw, http.StatusCreated, dashboard.ToGettableDashboardV2())
+}
+
 func (handler *handler) ListV2(rw http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()

--- a/pkg/modules/dashboard/impldashboard/v2_module.go
+++ b/pkg/modules/dashboard/impldashboard/v2_module.go
@@ -43,6 +43,18 @@ func (m *module) CreateV2(ctx context.Context, orgID valuer.UUID, createdBy stri
 	return dashboard, nil
 }
 
+func (m *module) CloneV2(ctx context.Context, orgID valuer.UUID, createdBy string, creator valuer.UUID, id valuer.UUID) (*dashboardtypes.DashboardV2, error) {
+	existing, err := m.GetV2(ctx, orgID, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := existing.ErrIfNotClonable(); err != nil {
+		return nil, err
+	}
+
+	return m.CreateV2(ctx, orgID, createdBy, creator, dashboardtypes.SourceUser, existing.ToPostableForCloning())
+}
+
 func (module *module) ListV2(ctx context.Context, orgID valuer.UUID, params *dashboardtypes.ListDashboardsV2Params) (*dashboardtypes.ListableDashboardV2, error) {
 	dashboards, total, err := module.store.ListV2(ctx, orgID, params)
 	if err != nil {

--- a/pkg/types/dashboardtypes/perses_dashboard.go
+++ b/pkg/types/dashboardtypes/perses_dashboard.go
@@ -126,6 +126,22 @@ func (d *DashboardV2) ErrIfNotDeletable() error {
 	return nil
 }
 
+func (d *DashboardV2) ErrIfNotClonable() error {
+	if d.Source != SourceUser {
+		return errors.Newf(errors.TypeInvalidInput, ErrCodeDashboardImmutable, "only user dashboards can be cloned, %s dashboards cannot be cloned", d.Source)
+	}
+	return nil
+}
+
+func (d DashboardV2) ToPostableForCloning() PostableDashboardV2 {
+	return PostableDashboardV2{
+		DashboardV2MetadataBase: d.DashboardV2MetadataBase,
+		GenerateName:            true,
+		Tags:                    tagtypes.NewPostableTagsFromTags(d.Tags),
+		Spec:                    d.Spec,
+	}
+}
+
 type DashboardV2MetadataBase struct {
 	SchemaVersion string `json:"schemaVersion" required:"true"`
 	Image         string `json:"image,omitempty"`

--- a/pkg/types/dashboardtypes/perses_dashboard.go
+++ b/pkg/types/dashboardtypes/perses_dashboard.go
@@ -127,8 +127,8 @@ func (d *DashboardV2) ErrIfNotDeletable() error {
 }
 
 func (d *DashboardV2) ErrIfNotClonable() error {
-	if d.Source != SourceUser {
-		return errors.Newf(errors.TypeInvalidInput, ErrCodeDashboardImmutable, "only user dashboards can be cloned, %s dashboards cannot be cloned", d.Source)
+	if !d.Source.isClonable() {
+		return errors.Newf(errors.TypeInvalidInput, ErrCodeDashboardImmutable, "%s dashboards cannot be cloned", d.Source)
 	}
 	return nil
 }

--- a/pkg/types/dashboardtypes/perses_dashboard_convertors_test.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_convertors_test.go
@@ -202,6 +202,24 @@ func TestDashboardV2ToGettableDashboardV2(t *testing.T) {
 	})
 }
 
+func TestDashboardV2ToPostableForCloning(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	dashboard := newTestDashboardV2(t, orgID, SourceUser)
+
+	postable := dashboard.ToPostableForCloning()
+
+	assert.True(t, postable.GenerateName, "internal name must be regenerated, not copied")
+	assert.Empty(t, postable.Name, "name must be empty so generateName can derive it")
+	assert.Equal(t, dashboard.DashboardV2MetadataBase, postable.DashboardV2MetadataBase, "schema version and image are carried over")
+	assert.Equal(t, dashboard.Spec, postable.Spec, "spec (incl. display name) is preserved verbatim")
+
+	require.Len(t, postable.Tags, len(dashboard.Tags))
+	for i, sourceTag := range dashboard.Tags {
+		assert.Equal(t, sourceTag.Key, postable.Tags[i].Key)
+		assert.Equal(t, sourceTag.Value, postable.Tags[i].Value)
+	}
+}
+
 func TestDashboardV2StorableRoundTrip(t *testing.T) {
 	orgID := valuer.GenerateUUID()
 	original := newTestDashboardV2(t, orgID, SourceIntegration)

--- a/pkg/types/dashboardtypes/source.go
+++ b/pkg/types/dashboardtypes/source.go
@@ -55,6 +55,10 @@ func (s Source) isUserDeletable() bool {
 	return s == SourceUser
 }
 
+func (s Source) isClonable() bool {
+	return s == SourceUser || s == SourceIntegration
+}
+
 func NewSource(source string) (Source, error) {
 	candidate := Source{s: valuer.NewString(source)}
 	if !candidate.IsValid() {

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -1,9 +1,12 @@
+import datetime
+import json
 import uuid
 from collections.abc import Callable
 from http import HTTPStatus
 
 import pytest
 import requests
+from sqlalchemy import sql
 
 from fixtures.auth import USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD
 from fixtures.types import Operation, SigNoz
@@ -784,6 +787,91 @@ def test_dashboard_v2_pin_limit(
         ).status_code
         == HTTPStatus.NO_CONTENT
     )
+
+
+# ─── clone an integration dashboard ──────────────────────────────────────────
+# Integration-source dashboards aren't creatable through the API — the create
+# endpoint hardcodes the user source, and the integrations installer writes v1
+# dashboards, not perses dashboards. Until the migration is done, seed a perses
+# integration dashboard straight into the DB to exercise the one branch that's
+# otherwise unreachable: cloning an integration dashboard give a user dashboard.
+
+
+def test_dashboard_v2_clone_integration_source(
+    signoz: SigNoz,
+    create_user_admin: Operation,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+):
+    token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+    _wipe_all_dashboards(signoz, token)
+
+    roles_response = requests.get(
+        signoz.self.host_configs["8080"].get("/api/v1/roles"),
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=5,
+    )
+    assert roles_response.status_code == HTTPStatus.OK, roles_response.text
+    org_id = roles_response.json()["data"][0]["orgId"]
+
+    integration_id = str(uuid.uuid4())
+    now = datetime.datetime.now(datetime.UTC)
+    data = json.dumps(
+        {
+            "metadata": {"schemaVersion": "v6"},
+            "spec": {"display": {"name": "Integration Source Dash"}, "panels": {}, "layouts": []},
+        }
+    )
+
+    try:
+        # A locked, integration-source v6 dashboard — the state the API can't produce.
+        with signoz.sqlstore.conn.begin() as conn:
+            conn.execute(
+                sql.text(
+                    "INSERT INTO dashboard "
+                    "(id, created_at, updated_at, created_by, updated_by, data, locked, org_id, source, name) "
+                    "VALUES (:id, :created_at, :updated_at, :created_by, :updated_by, :data, :locked, :org_id, :source, :name)"
+                ),
+                {
+                    "id": integration_id,
+                    "created_at": now,
+                    "updated_at": now,
+                    "created_by": USER_ADMIN_EMAIL,
+                    "updated_by": USER_ADMIN_EMAIL,
+                    "data": data,
+                    "locked": True,
+                    "org_id": org_id,
+                    "source": "integration",
+                    "name": "integration-source-dash",
+                },
+            )
+
+        response = requests.post(
+            signoz.self.host_configs["8080"].get(f"{BASE_URL}/{integration_id}/clone"),
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=5,
+        )
+        assert response.status_code == HTTPStatus.CREATED, response.text
+        clone = response.json()["data"]
+        assert clone["id"] != integration_id
+        assert clone["source"] == "user"  # the clone of an integration dashboard is a user dashboard
+        assert clone["locked"] is False  # and it is unlocked, regardless of the source's lock state
+        assert clone["spec"]["display"]["name"] == "Integration Source Dash"  # display name preserved
+
+        response = requests.get(
+            signoz.self.host_configs["8080"].get(f"{BASE_URL}/{clone['id']}"),
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=5,
+        )
+        assert response.status_code == HTTPStatus.OK, response.text
+        assert response.json()["data"]["id"] == clone["id"]
+    finally:
+        # The API can't delete a locked integration dashboard, so a leftover would
+        # break the next test's wipe — remove the seed directly.
+        with signoz.sqlstore.conn.begin() as conn:
+            conn.execute(
+                sql.text("DELETE FROM dashboard WHERE id = :id"),
+                {"id": integration_id},
+            )
 
 
 # ─── LIKE escaping ───────────────────────────────────────────────────────────

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -711,6 +711,7 @@ def test_dashboard_v2_lifecycle(  # pylint: disable=too-many-locals,too-many-sta
     assert response.status_code == HTTPStatus.OK, response.text
     assert response.json()["data"]["id"] == clone["id"]
 
+
 def test_dashboard_v2_pin_limit(
     signoz: SigNoz,
     create_user_admin: Operation,  # pylint: disable=unused-argument
@@ -826,11 +827,7 @@ def test_dashboard_v2_clone_integration_source(
         # A locked, integration-source v6 dashboard — the state the API can't produce.
         with signoz.sqlstore.conn.begin() as conn:
             conn.execute(
-                sql.text(
-                    "INSERT INTO dashboard "
-                    "(id, created_at, updated_at, created_by, updated_by, data, locked, org_id, source, name) "
-                    "VALUES (:id, :created_at, :updated_at, :created_by, :updated_by, :data, :locked, :org_id, :source, :name)"
-                ),
+                sql.text("INSERT INTO dashboard (id, created_at, updated_at, created_by, updated_by, data, locked, org_id, source, name) VALUES (:id, :created_at, :updated_at, :created_by, :updated_by, :data, :locked, :org_id, :source, :name)"),
                 {
                     "id": integration_id,
                     "created_at": now,

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -1,12 +1,9 @@
-import datetime
-import json
 import uuid
 from collections.abc import Callable
 from http import HTTPStatus
 
 import pytest
 import requests
-from sqlalchemy import sql
 
 from fixtures.auth import USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD
 from fixtures.types import Operation, SigNoz
@@ -790,85 +787,10 @@ def test_dashboard_v2_pin_limit(
     )
 
 
-# ─── clone an integration dashboard ──────────────────────────────────────────
-# Integration-source dashboards aren't creatable through the API — the create
-# endpoint hardcodes the user source, and the integrations installer writes v1
-# dashboards, not perses dashboards. Until the migration is done, seed a perses
-# integration dashboard straight into the DB to exercise the one branch that's
-# otherwise unreachable: cloning an integration dashboard give a user dashboard.
-
-
-def test_dashboard_v2_clone_integration_source(
-    signoz: SigNoz,
-    create_user_admin: Operation,  # pylint: disable=unused-argument
-    get_token: Callable[[str, str], str],
-):
-    token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
-    _wipe_all_dashboards(signoz, token)
-
-    roles_response = requests.get(
-        signoz.self.host_configs["8080"].get("/api/v1/roles"),
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=5,
-    )
-    assert roles_response.status_code == HTTPStatus.OK, roles_response.text
-    org_id = roles_response.json()["data"][0]["orgId"]
-
-    integration_id = str(uuid.uuid4())
-    now = datetime.datetime.now(datetime.UTC)
-    data = json.dumps(
-        {
-            "metadata": {"schemaVersion": "v6"},
-            "spec": {"display": {"name": "Integration Source Dash"}, "panels": {}, "layouts": []},
-        }
-    )
-
-    try:
-        # A locked, integration-source v6 dashboard — the state the API can't produce.
-        with signoz.sqlstore.conn.begin() as conn:
-            conn.execute(
-                sql.text("INSERT INTO dashboard (id, created_at, updated_at, created_by, updated_by, data, locked, org_id, source, name) VALUES (:id, :created_at, :updated_at, :created_by, :updated_by, :data, :locked, :org_id, :source, :name)"),
-                {
-                    "id": integration_id,
-                    "created_at": now,
-                    "updated_at": now,
-                    "created_by": USER_ADMIN_EMAIL,
-                    "updated_by": USER_ADMIN_EMAIL,
-                    "data": data,
-                    "locked": True,
-                    "org_id": org_id,
-                    "source": "integration",
-                    "name": "integration-source-dash",
-                },
-            )
-
-        response = requests.post(
-            signoz.self.host_configs["8080"].get(f"{BASE_URL}/{integration_id}/clone"),
-            headers={"Authorization": f"Bearer {token}"},
-            timeout=5,
-        )
-        assert response.status_code == HTTPStatus.CREATED, response.text
-        clone = response.json()["data"]
-        assert clone["id"] != integration_id
-        assert clone["source"] == "user"  # the clone of an integration dashboard is a user dashboard
-        assert clone["locked"] is False  # and it is unlocked, regardless of the source's lock state
-        assert clone["spec"]["display"]["name"] == "Integration Source Dash"  # display name preserved
-
-        response = requests.get(
-            signoz.self.host_configs["8080"].get(f"{BASE_URL}/{clone['id']}"),
-            headers={"Authorization": f"Bearer {token}"},
-            timeout=5,
-        )
-        assert response.status_code == HTTPStatus.OK, response.text
-        assert response.json()["data"]["id"] == clone["id"]
-    finally:
-        # The API can't delete a locked integration dashboard, so a leftover would
-        # break the next test's wipe — remove the seed directly.
-        with signoz.sqlstore.conn.begin() as conn:
-            conn.execute(
-                sql.text("DELETE FROM dashboard WHERE id = :id"),
-                {"id": integration_id},
-            )
+# TODO: add an integration test that clones an integration-source dashboard once
+# integration dashboards adopt the v2 (perses) flow. Today they're created via the
+# v1 path, and the v2 clone endpoint only operates on v6 dashboards — so the
+# integration-source branch of clone is unreachable through the API.
 
 
 # ─── LIKE escaping ───────────────────────────────────────────────────────────

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -686,6 +686,27 @@ def test_dashboard_v2_lifecycle(  # pylint: disable=too-many-locals,too-many-sta
         "Zeta Overview",
     }
 
+    # ── stage 11: clone keeps the display name but mints a new, retrievable one ─
+    response = requests.post(
+        signoz.self.host_configs["8080"].get(f"{BASE_URL}/{ids['lc-alpha']}/clone"),
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=5,
+    )
+    assert response.status_code == HTTPStatus.CREATED, response.text
+    clone = response.json()["data"]
+    assert clone["id"] != ids["lc-alpha"]
+    assert clone["name"] != "lc-alpha"  # internal name is regenerated
+    assert clone["spec"]["display"]["name"] == "Alpha Overview"  # display name preserved
+    assert clone["source"] == "user"
+    assert clone["locked"] is False
+
+    response = requests.get(
+        signoz.self.host_configs["8080"].get(f"{BASE_URL}/{clone['id']}"),
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=5,
+    )
+    assert response.status_code == HTTPStatus.OK, response.text
+    assert response.json()["data"]["id"] == clone["id"]
 
 def test_dashboard_v2_pin_limit(
     signoz: SigNoz,


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

To support cloning from the list page, where UI does not have all the info about a dashboard, an API call is needed, so might as well have that API call create a clone.

#### Issues closed by this PR

Closes https://github.com/SigNoz/engineering-pod/issues/5369

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy

- Tests added/updated: Integration tests and unit tests added
- Manual verification: API call tested manually
- Edge cases covered: Only source = user dashboards can be cloned

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Dashboards V2
- Potential regressions: None
- Rollback plan: Revert PR

---