### PR TITLE
test(llm-pricing): unit + e2e test suite (5/5)

### DIFF
--- a/frontend/src/container/LLMObservabilityModelPricing/ExtraPricingBuckets.tsx
+++ b/frontend/src/container/LLMObservabilityModelPricing/ExtraPricingBuckets.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+import { Button } from '@signozhq/ui/button';
+import { Input } from '@signozhq/ui/input';
+import { SelectSimple } from '@signozhq/ui/select';
+import { Plus, Trash2 } from '@signozhq/icons';
+import { LlmpricingruletypesLLMPricingRuleCacheModeDTO as CacheModeDTO } from 'api/generated/services/sigNoz.schemas';
+
+import { CACHE_BUCKETS, CACHE_MODE_OPTIONS } from './constants';
+import { parsePricingAmount } from './utils';
+import type { CacheBucketKey, DrawerDraft } from './types';
+
+type Pricing = DrawerDraft['pricing'];
+
+interface ExtraPricingBucketsProps {
+	pricing: Pricing;
+	isReadOnly: boolean;
+	onChange: (patch: Partial<Pricing>) => void;
+}
+
+// Optional, add-on-demand pricing buckets. A bucket is "added" once its value
+// is non-null; adding seeds it at 0 and removing clears it back to null. Only
+// the cache buckets are backed by the API today (pricing.cache.read/write).
+function ExtraPricingBuckets({
+	pricing,
+	isReadOnly,
+	onChange,
+}: ExtraPricingBucketsProps): JSX.Element {
+	const [isPicking, setIsPicking] = useState<boolean>(false);
+
+	const addedBuckets = CACHE_BUCKETS.filter((b) => pricing[b.key] !== null);
+	const availableBuckets = CACHE_BUCKETS.filter((b) => pricing[b.key] === null);
+
+	const addBucket = (key: CacheBucketKey): void => {
+		onChange({ [key]: 0 } as Partial<Pricing>);
+		// Close the picker once nothing is left to add.
+		if (availableBuckets.length <= 1) {
+			setIsPicking(false);
+		}
+	};
+
+	const removeBucket = (key: CacheBucketKey): void => {
+		onChange({ [key]: null } as Partial<Pricing>);
+	};
+
+	return (
+		<div className="extra-buckets-section drawer-section">
+			<div className="extra-buckets-section__head">
+				<span className="field-label">Extra pricing buckets</span>
+				<span className="optional-label">optional</span>
+			</div>
+
+			{addedBuckets.map((bucket) => (
+				<div className="bucket-row" key={bucket.key}>
+					<span className="bucket-row__name">{bucket.label}</span>
+					<Input
+						type="number"
+						min={0}
+						step={0.01}
+						value={pricing[bucket.key] ?? 0}
+						placeholder="0.00"
+						disabled={isReadOnly}
+						onChange={(e): void =>
+							// Empty coerces to 0 (not null) so editing never makes the row
+							// vanish — removal is explicit via the trash button.
+							onChange({
+								[bucket.key]: parsePricingAmount(e.target.value) ?? 0,
+							} as Partial<Pricing>)
+						}
+						testId={`drawer-${bucket.testId}-cost`}
+					/>
+					<span className="bucket-row__unit">/ 1M</span>
+					{!isReadOnly && (
+						<button
+							type="button"
+							className="bucket-row__remove"
+							onClick={(): void => removeBucket(bucket.key)}
+							aria-label={`Remove ${bucket.label}`}
+							data-testid={`drawer-remove-${bucket.testId}`}
+						>
+							<Trash2 size={14} />
+						</button>
+					)}
+				</div>
+			))}
+
+			{addedBuckets.length > 0 && (
+				<div className="pricing-field cache-mode-field">
+					<label htmlFor="cache-mode">Cache mode</label>
+					<SelectSimple
+						id="cache-mode"
+						value={pricing.cacheMode}
+						items={CACHE_MODE_OPTIONS}
+						onChange={(v): void => onChange({ cacheMode: v as CacheModeDTO })}
+						disabled={isReadOnly}
+						className="full-width"
+						withPortal={false}
+						testId="drawer-cache-mode"
+					/>
+				</div>
+			)}
+
+			{!isReadOnly && !isPicking && availableBuckets.length > 0 && (
+				<Button
+					variant="dashed"
+					color="secondary"
+					className="bucket-add-btn"
+					prefix={<Plus size={14} />}
+					onClick={(): void => setIsPicking(true)}
+					testId="drawer-add-bucket-btn"
+				>
+					Add pricing bucket
+				</Button>
+			)}
+
+			{!isReadOnly && isPicking && (
+				<div className="bucket-picker" data-testid="drawer-bucket-picker">
+					<div className="bucket-picker__title">Add a pricing bucket</div>
+					<div className="bucket-picker__chips">
+						{availableBuckets.map((bucket) => (
+							<Button
+								key={bucket.key}
+								variant="outlined"
+								color="secondary"
+								size="sm"
+								prefix={<Plus size={12} />}
+								onClick={(): void => addBucket(bucket.key)}
+								testId={`drawer-add-bucket-${bucket.testId}`}
+							>
+								{bucket.label}
+							</Button>
+						))}
+					</div>
+					<Button
+						variant="ghost"
+						color="secondary"
+						size="sm"
+						onClick={(): void => setIsPicking(false)}
+						testId="drawer-add-bucket-cancel"
+					>
+						Cancel
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+}
+
+export default ExtraPricingBuckets;

--- a/frontend/src/container/LLMObservabilityModelPricing/LLMObservabilityModelPricing.tsx
+++ b/frontend/src/container/LLMObservabilityModelPricing/LLMObservabilityModelPricing.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@signozhq/ui/button';
 import { Input } from '@signozhq/ui/input';
 import { Pagination } from '@signozhq/ui/pagination';
 import { SelectSimple } from '@signozhq/ui/select';
 import { Tabs } from '@signozhq/ui/tabs';
-import { Search } from '@signozhq/icons';
+import { Plus, Search } from '@signozhq/icons';
 import { useListLLMPricingRules } from 'api/generated/services/llmpricingrules';
+import useComponentPermission from 'hooks/useComponentPermission';
 import useDebounce from 'hooks/useDebounce';
+import { useAppContext } from 'providers/App/App';
 
+import ModelCostDrawer from './ModelCostDrawer';
 import ModelCostsTable from './ModelCostsTable';
+import { useModelCostDrawer } from './useModelCostDrawer';
 import { useModelPricingFilters } from './useModelPricingFilters';
 import type {
 	ListModelPricingParams,
@@ -57,8 +62,16 @@ function LLMObservabilityModelPricing(): JSX.Element {
 
 	const { data, isLoading, isError } = useListLLMPricingRules(listParams);
 
+	const { user } = useAppContext();
+	const [canManagePricing] = useComponentPermission(
+		['manage_llm_pricing'],
+		user.role,
+	);
+
 	const rules: PricingRule[] = useMemo(() => data?.data?.items || [], [data]);
 	const total = data?.data?.total ?? 0;
+
+	const drawer = useModelCostDrawer();
 
 	return (
 		<div
@@ -109,6 +122,18 @@ function LLMObservabilityModelPricing(): JSX.Element {
 					items={CURRENCY_OPTIONS}
 					testId="currency-select"
 				/>
+				{canManagePricing && (
+					<Button
+						variant="solid"
+						color="primary"
+						className="filters-bar__add"
+						prefix={<Plus size={14} />}
+						onClick={(): void => drawer.openForAdd()}
+						testId="add-model-cost-btn"
+					>
+						Add model cost
+					</Button>
+				)}
 			</div>
 
 			{isError && (
@@ -117,13 +142,12 @@ function LLMObservabilityModelPricing(): JSX.Element {
 				</div>
 			)}
 
-			{/* Read-only listing. Edit/Add wiring + the drawer land in the next PR. */}
 			<ModelCostsTable
 				rules={rules}
 				isLoading={isLoading}
-				selectedRuleId={null}
-				canManage={false}
-				onEdit={(): void => undefined}
+				selectedRuleId={drawer.selectedRuleId}
+				canManage={canManagePricing}
+				onEdit={drawer.openForEdit}
 			/>
 
 			{total > PAGE_SIZE && (
@@ -140,6 +164,20 @@ function LLMObservabilityModelPricing(): JSX.Element {
 				Showing {rules.length} of {total} model{total === 1 ? '' : 's'}
 				{' · '}All prices per 1M tokens (USD)
 			</footer>
+
+			<ModelCostDrawer
+				isOpen={drawer.isOpen}
+				mode={drawer.mode}
+				draft={drawer.draft}
+				setDraft={drawer.setDraft}
+				onClose={drawer.close}
+				onSave={drawer.save}
+				onDelete={drawer.deleteRule}
+				isSaving={drawer.isSaving}
+				isDeleting={drawer.isDeleting}
+				saveError={drawer.saveError}
+				canManage={canManagePricing}
+			/>
 		</div>
 	);
 }

--- a/frontend/src/container/LLMObservabilityModelPricing/ModelCostDrawer.styles.scss
+++ b/frontend/src/container/LLMObservabilityModelPricing/ModelCostDrawer.styles.scss
@@ -1,0 +1,388 @@
+.model-cost-drawer {
+	// Uniform horizontal padding across header / body / footer. The header and
+	// footer read these dialog vars; the body (rendered in drawer-description)
+	// is set directly below.
+	--dialog-header-padding: 20px 24px;
+	--dialog-footer-padding: 16px 24px;
+
+	// The drawer body — children render inside [data-slot='drawer-description']
+	// (this is the @signozhq drawer, not antd, so .ant-drawer-body was a no-op).
+	[data-slot='drawer-description'] {
+		display: flex;
+		flex-direction: column;
+		gap: 18px;
+		padding: 20px 24px;
+	}
+
+	[data-slot='select-content'] {
+		width: var(--radix-select-trigger-width);
+	}
+	display: flex;
+	overflow-y: auto;
+
+	&__title {
+		h3 {
+			margin: 0;
+			font-size: 16px;
+			font-weight: 600;
+		}
+
+		p {
+			margin: 4px 0 0;
+			color: var(--bg-vanilla-400);
+			font-size: 12px;
+		}
+	}
+
+	&__footer {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		// Horizontal padding is provided by the drawer-footer slot var above.
+		padding: 0;
+		width: 100%;
+
+		&-right {
+			display: flex;
+			gap: 8px;
+			margin-left: auto;
+		}
+	}
+
+	.drawer-section {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+
+		label,
+		.field-label {
+			font-size: 12px;
+			font-weight: 600;
+			color: var(--bg-vanilla-200);
+		}
+
+		.help {
+			margin: 0;
+			font-size: 11px;
+		}
+	}
+
+	.muted {
+		color: var(--bg-vanilla-400);
+	}
+
+	.required {
+		color: var(--bg-cherry-400);
+	}
+
+	.full-width {
+		width: 100%;
+	}
+
+	.drawer-surface {
+		padding: 14px;
+		border-radius: 6px;
+		background: rgba(255, 255, 255, 0.02);
+		border: 1px solid var(--bg-slate-300);
+
+		&__head {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			margin-bottom: 10px;
+
+			h4 {
+				margin: 0;
+				font-size: 13px;
+				font-weight: 600;
+				text-transform: uppercase;
+				letter-spacing: 0.04em;
+				color: var(--bg-vanilla-300);
+			}
+		}
+	}
+
+	.managed-label {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		font-size: 11px;
+		color: var(--bg-vanilla-400);
+	}
+
+	.pattern-box {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+		padding: 12px;
+		border-radius: 6px;
+		background: rgba(255, 255, 255, 0.02);
+		border: 1px solid var(--bg-slate-300);
+	}
+
+	.pattern-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+		min-height: 28px;
+	}
+
+	.pattern-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+
+		&__remove {
+			background: transparent;
+			border: none;
+			padding: 0;
+			margin-left: 2px;
+			cursor: pointer;
+			color: inherit;
+			display: inline-flex;
+			align-items: center;
+
+			&:hover {
+				color: var(--bg-cherry-400);
+			}
+		}
+	}
+
+	.pattern-add {
+		display: flex;
+		gap: 6px;
+	}
+
+	.help {
+		code {
+			padding: 1px 4px;
+			border-radius: 3px;
+			background: rgba(255, 255, 255, 0.06);
+			font-family: var(--code-font-family, monospace);
+			font-size: 10px;
+		}
+	}
+
+	.source-radio-group {
+		// @signozhq/ui's RadioGroupItem defaults its unchecked border to
+		// --l3-background, which matches the drawer surface and makes the dot
+		// invisible. Override with a contrasting border so users can see the
+		// unchecked state.
+		--radio-group-item-border-color: var(--bg-slate-200);
+
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		width: 100%;
+
+		// Layout overrides for @signozhq/ui's RadioGroupItem wrapper. The
+		// library injects single-class CSS at runtime (after our bundled
+		// stylesheet loads), so we use a two-class selector to win the
+		// cascade and force the wrapper to lay the dot on the left with the
+		// label text flush beside it.
+		.source-radio {
+			display: flex;
+			flex-direction: row;
+			align-items: flex-start;
+			justify-content: flex-start;
+			gap: 10px;
+			padding: 10px 12px;
+			border-radius: 4px;
+			border: 1px solid transparent;
+			background: rgba(255, 255, 255, 0.02);
+			margin: 0;
+			width: 100%;
+			// Include padding + border in the 100% width so the card fits inside
+			// the SOURCE surface instead of overflowing its right edge.
+			box-sizing: border-box;
+			cursor: pointer;
+			transition:
+				background-color 0.12s ease,
+				border-color 0.12s ease;
+
+			// The radio button itself: keep it fixed-size and aligned with
+			// the title baseline (margin-top compensates for align-items:
+			// flex-start vs the title's line-box).
+			> button[role='radio'] {
+				flex: 0 0 16px;
+				width: 16px;
+				height: 16px;
+				margin-top: 3px;
+			}
+
+			// The library wraps children in a <label>. Make it grow into the
+			// remaining width and reset the .drawer-section label typography
+			// leak (set earlier in this file) so the title/desc divs use
+			// their own styles.
+			> label {
+				flex: 1 1 auto;
+				min-width: 0;
+				display: block;
+				text-align: left;
+				cursor: pointer;
+				font-size: inherit;
+				font-weight: inherit;
+				color: inherit;
+			}
+
+			&__title {
+				font-weight: 600;
+				font-size: 13px;
+				color: var(--bg-vanilla-100);
+			}
+
+			&__desc {
+				margin-top: 2px;
+				font-size: 12px;
+				color: var(--bg-vanilla-400);
+			}
+
+			// Radix RadioGroupItem renders <button data-state="checked|unchecked">.
+			// Use :has() to highlight the wrapper card when its inner button is checked.
+			&.source-radio--auto:has(button[data-state='checked']) {
+				background: rgba(78, 116, 248, 0.1);
+				border-color: rgba(78, 116, 248, 0.3);
+			}
+
+			&.source-radio--override:has(button[data-state='checked']) {
+				background: rgba(245, 175, 25, 0.1);
+				border-color: rgba(245, 175, 25, 0.3);
+			}
+
+			&:hover {
+				background: rgba(255, 255, 255, 0.04);
+			}
+		}
+	}
+
+	.reset-confirm {
+		margin-top: 12px;
+		padding: 12px;
+		border-radius: 4px;
+		background: rgba(78, 116, 248, 0.06);
+		border: 1px solid rgba(78, 116, 248, 0.2);
+
+		p {
+			margin: 0 0 10px;
+			font-size: 12px;
+		}
+
+		&__actions {
+			display: flex;
+			gap: 8px;
+			justify-content: flex-end;
+		}
+	}
+
+	.pricing-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 12px;
+	}
+
+	.pricing-field {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+
+		input {
+			width: 100%;
+		}
+	}
+
+	.cache-mode-field {
+		margin-top: 10px;
+	}
+
+	.extra-buckets-section {
+		margin-top: 14px;
+		gap: 10px;
+
+		&__head {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+
+			.optional-label {
+				font-size: 11px;
+				font-weight: 400;
+				color: var(--bg-vanilla-400);
+			}
+		}
+	}
+
+	.bucket-row {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+
+		&__name {
+			flex: 0 0 110px;
+			font-size: 12px;
+			color: var(--bg-vanilla-200);
+			font-family: var(--code-font-family, monospace);
+		}
+
+		input {
+			flex: 1 1 auto;
+			min-width: 0;
+		}
+
+		&__unit {
+			flex: 0 0 auto;
+			font-size: 12px;
+			color: var(--bg-vanilla-400);
+		}
+
+		&__remove {
+			flex: 0 0 auto;
+			background: transparent;
+			border: none;
+			padding: 4px;
+			cursor: pointer;
+			color: var(--bg-vanilla-400);
+			display: inline-flex;
+			align-items: center;
+
+			&:hover {
+				color: var(--bg-cherry-400);
+			}
+		}
+	}
+
+	.bucket-add-btn {
+		width: 100%;
+	}
+
+	.bucket-picker {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 10px;
+		padding: 12px;
+		border-radius: 6px;
+		background: rgba(255, 255, 255, 0.02);
+		border: 1px solid var(--bg-slate-300);
+
+		&__title {
+			font-size: 11px;
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+			color: var(--bg-vanilla-400);
+		}
+
+		&__chips {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 8px;
+		}
+	}
+
+	.drawer-error {
+		padding: 10px 12px;
+		border-radius: 4px;
+		background: rgba(255, 90, 90, 0.08);
+		color: var(--bg-cherry-400);
+		font-size: 12px;
+	}
+}

--- a/frontend/src/container/LLMObservabilityModelPricing/ModelCostDrawer.tsx
+++ b/frontend/src/container/LLMObservabilityModelPricing/ModelCostDrawer.tsx
@@ -1,0 +1,177 @@
+import { Button } from '@signozhq/ui/button';
+import { DrawerWrapper } from '@signozhq/ui/drawer';
+import { Input } from '@signozhq/ui/input';
+import { SelectSimple } from '@signozhq/ui/select';
+import { TooltipSimple } from '@signozhq/ui/tooltip';
+import { Trash2 } from '@signozhq/icons';
+
+import PatternEditor from './PatternEditor';
+import PricingFields from './PricingFields';
+import SourceSelector from './SourceSelector';
+import { PROVIDER_OPTIONS } from './constants';
+import { validateDraft } from './utils';
+import type { DrawerDraft, DrawerMode } from './types';
+import './ModelCostDrawer.styles.scss';
+
+interface ModelCostDrawerProps {
+	isOpen: boolean;
+	mode: DrawerMode;
+	draft: DrawerDraft;
+	setDraft: (next: DrawerDraft) => void;
+	onClose: () => void;
+	onSave: () => void;
+	onDelete: () => void;
+	isSaving: boolean;
+	isDeleting: boolean;
+	saveError: string | null;
+	canManage: boolean;
+}
+
+function ModelCostDrawer({
+	isOpen,
+	mode,
+	draft,
+	setDraft,
+	onClose,
+	onSave,
+	onDelete,
+	isSaving,
+	isDeleting,
+	saveError,
+	canManage,
+}: ModelCostDrawerProps): JSX.Element {
+	// Metadata (model id / provider / patterns / source) is editable by any
+	// manager. Pricing fields are editable only once the user picks "User
+	// override" — auto-populated pricing is managed by SigNoz. Write APIs are
+	// Admin-only, so non-managers can't edit anything.
+	const metadataReadOnly = !canManage;
+	const pricingReadOnly = !canManage || !draft.isOverride;
+
+	const validation = validateDraft(draft, mode);
+	const showValidationTooltip =
+		canManage && !validation.ok && !!validation.message;
+
+	const update = (patch: Partial<DrawerDraft>): void => {
+		setDraft({ ...draft, ...patch });
+	};
+
+	const footer = (
+		<div className="model-cost-drawer__footer">
+			{mode === 'edit' && canManage && (
+				<Button
+					variant="ghost"
+					color="destructive"
+					prefix={<Trash2 size={14} />}
+					onClick={onDelete}
+					loading={isDeleting}
+					testId="drawer-delete-btn"
+				>
+					Delete
+				</Button>
+			)}
+			<div className="model-cost-drawer__footer-right">
+				<Button
+					variant="outlined"
+					color="secondary"
+					onClick={onClose}
+					testId="drawer-cancel-btn"
+				>
+					{canManage ? 'Cancel' : 'Close'}
+				</Button>
+				{canManage && (
+					<TooltipSimple
+						title={showValidationTooltip ? validation.message : ''}
+						withPortal={false}
+					>
+						{/* span wrapper so the tooltip fires even when the button is disabled */}
+						<span className="model-cost-drawer__save-wrap">
+							<Button
+								variant="solid"
+								color="primary"
+								onClick={onSave}
+								loading={isSaving}
+								disabled={!validation.ok}
+								testId="drawer-save-btn"
+							>
+								Save
+							</Button>
+						</span>
+					</TooltipSimple>
+				)}
+			</div>
+		</div>
+	);
+
+	return (
+		<DrawerWrapper
+			open={isOpen}
+			onOpenChange={(open): void => {
+				if (!open) {
+					onClose();
+				}
+			}}
+			direction="right"
+			width="base"
+			className="model-cost-drawer"
+			footer={footer}
+			title={mode === 'edit' ? 'Edit model cost' : 'Add model cost'}
+			subTitle="Pricing computes gen_ai.estimated_total_cost at ingest."
+			drawerHeaderProps={{ className: 'model-cost-drawer__title' }}
+		>
+			<div className="drawer-section">
+				<label htmlFor="billing-model-id">Billing model ID</label>
+				<Input
+					id="billing-model-id"
+					placeholder="e.g. openai:gpt-4o"
+					value={draft.modelName}
+					disabled={mode === 'edit' || metadataReadOnly}
+					onChange={(e): void => update({ modelName: e.target.value })}
+					testId="drawer-model-id-input"
+				/>
+			</div>
+
+			<div className="drawer-section">
+				<label htmlFor="provider-select">Provider</label>
+				<SelectSimple
+					id="provider-select"
+					value={draft.provider}
+					onChange={(value): void => update({ provider: value as string })}
+					items={PROVIDER_OPTIONS}
+					disabled={mode === 'edit' || metadataReadOnly}
+					className="full-width"
+					withPortal={false}
+					testId="drawer-provider-select"
+				/>
+			</div>
+
+			<PatternEditor
+				patterns={draft.patterns}
+				isReadOnly={metadataReadOnly}
+				onChange={(patterns): void => update({ patterns })}
+			/>
+
+			<SourceSelector
+				isOverride={draft.isOverride}
+				isReadOnly={metadataReadOnly}
+				disableAuto={mode === 'add'}
+				onChange={(isOverride): void => update({ isOverride })}
+			/>
+
+			<PricingFields
+				pricing={draft.pricing}
+				isReadOnly={pricingReadOnly}
+				onChange={(patch): void =>
+					setDraft({ ...draft, pricing: { ...draft.pricing, ...patch } })
+				}
+			/>
+
+			{saveError && (
+				<div className="drawer-error" role="alert">
+					{saveError}
+				</div>
+			)}
+		</DrawerWrapper>
+	);
+}
+
+export default ModelCostDrawer;

--- a/frontend/src/container/LLMObservabilityModelPricing/PatternEditor.tsx
+++ b/frontend/src/container/LLMObservabilityModelPricing/PatternEditor.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { Badge } from '@signozhq/ui/badge';
+import { Button } from '@signozhq/ui/button';
+import { Input } from '@signozhq/ui/input';
+import { X } from '@signozhq/icons';
+
+interface PatternEditorProps {
+	patterns: string[];
+	isReadOnly: boolean;
+	onChange: (patterns: string[]) => void;
+}
+
+// Model-name prefix patterns as removable chips + an add input.
+function PatternEditor({
+	patterns,
+	isReadOnly,
+	onChange,
+}: PatternEditorProps): JSX.Element {
+	const [patternInput, setPatternInput] = useState<string>('');
+
+	const addPattern = (): void => {
+		const next = patternInput.trim();
+		if (!next || patterns.includes(next)) {
+			setPatternInput('');
+			return;
+		}
+		onChange([...patterns, next]);
+		setPatternInput('');
+	};
+
+	const removePattern = (pattern: string): void => {
+		onChange(patterns.filter((p) => p !== pattern));
+	};
+
+	return (
+		<div className="drawer-section">
+			<span className="field-label">
+				Model name patterns <span className="muted">(prefix match)</span>
+			</span>
+			<div className="pattern-box">
+				<div className="pattern-chips">
+					{patterns.map((pattern) => (
+						<Badge
+							key={pattern}
+							color="vanilla"
+							variant="outline"
+							className="pattern-chip"
+						>
+							{pattern}*
+							{!isReadOnly && (
+								<button
+									type="button"
+									aria-label={`Remove pattern ${pattern}`}
+									className="pattern-chip__remove"
+									onClick={(): void => removePattern(pattern)}
+								>
+									<X size={10} />
+								</button>
+							)}
+						</Badge>
+					))}
+				</div>
+				{!isReadOnly && (
+					<div className="pattern-add">
+						<Input
+							placeholder="Add pattern…"
+							value={patternInput}
+							onChange={(e): void => setPatternInput(e.target.value)}
+							onKeyDown={(e): void => {
+								if (e.key === 'Enter') {
+									e.preventDefault();
+									addPattern();
+								}
+							}}
+							testId="drawer-pattern-input"
+						/>
+						<Button
+							variant="outlined"
+							color="secondary"
+							onClick={addPattern}
+							testId="drawer-pattern-add-btn"
+						>
+							+ Add
+						</Button>
+					</div>
+				)}
+			</div>
+			<p className="muted help">
+				Each pattern uses <strong>prefix matching</strong> against{' '}
+				<code>gen_ai.request.model</code>.
+			</p>
+		</div>
+	);
+}
+
+export default PatternEditor;

--- a/frontend/src/container/LLMObservabilityModelPricing/PricingFields.tsx
+++ b/frontend/src/container/LLMObservabilityModelPricing/PricingFields.tsx
@@ -1,0 +1,78 @@
+import { Input } from '@signozhq/ui/input';
+import { Lock } from '@signozhq/icons';
+
+import ExtraPricingBuckets from './ExtraPricingBuckets';
+import { parsePricingAmount } from './utils';
+import type { DrawerDraft } from './types';
+
+type Pricing = DrawerDraft['pricing'];
+
+interface PricingFieldsProps {
+	pricing: Pricing;
+	isReadOnly: boolean;
+	onChange: (patch: Partial<Pricing>) => void;
+}
+
+function PricingFields({
+	pricing,
+	isReadOnly,
+	onChange,
+}: PricingFieldsProps): JSX.Element {
+	return (
+		<div className="drawer-section drawer-surface">
+			<div className="drawer-surface__head">
+				<h4>Pricing (per 1M tokens, USD)</h4>
+				{isReadOnly && (
+					<span className="managed-label" data-testid="drawer-readonly-label">
+						<Lock size={12} />
+						Read-only
+					</span>
+				)}
+			</div>
+			<div className="pricing-grid">
+				<div className="pricing-field">
+					<label htmlFor="input-cost">
+						Input cost <span className="required">*</span>
+					</label>
+					<Input
+						id="input-cost"
+						type="number"
+						min={0}
+						step={0.01}
+						value={pricing.input}
+						disabled={isReadOnly}
+						onChange={(e): void =>
+							onChange({ input: parsePricingAmount(e.target.value) ?? 0 })
+						}
+						testId="drawer-input-cost"
+					/>
+				</div>
+				<div className="pricing-field">
+					<label htmlFor="output-cost">
+						Output cost <span className="required">*</span>
+					</label>
+					<Input
+						id="output-cost"
+						type="number"
+						min={0}
+						step={0.01}
+						value={pricing.output}
+						disabled={isReadOnly}
+						onChange={(e): void =>
+							onChange({ output: parsePricingAmount(e.target.value) ?? 0 })
+						}
+						testId="drawer-output-cost"
+					/>
+				</div>
+			</div>
+
+			<ExtraPricingBuckets
+				pricing={pricing}
+				isReadOnly={isReadOnly}
+				onChange={onChange}
+			/>
+		</div>
+	);
+}
+
+export default PricingFields;

--- a/frontend/src/container/LLMObservabilityModelPricing/SourceSelector.tsx
+++ b/frontend/src/container/LLMObservabilityModelPricing/SourceSelector.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { Button } from '@signozhq/ui/button';
+import { RadioGroup, RadioGroupItem } from '@signozhq/ui/radio-group';
+import { Lock } from '@signozhq/icons';
+
+interface SourceSelectorProps {
+	isOverride: boolean;
+	isReadOnly: boolean;
+	disableAuto?: boolean;
+	onChange: (isOverride: boolean) => void;
+}
+
+// Auto-populated vs user-override selector, with a confirm step before
+// discarding custom values back to defaults.
+function SourceSelector({
+	isOverride,
+	isReadOnly,
+	disableAuto = false,
+	onChange,
+}: SourceSelectorProps): JSX.Element {
+	const [showResetConfirm, setShowResetConfirm] = useState<boolean>(false);
+
+	const handleSourceChange = (value: 'auto' | 'override'): void => {
+		if (value === 'auto' && isOverride) {
+			setShowResetConfirm(true);
+			return;
+		}
+		if (value === 'override' && !isOverride) {
+			onChange(true);
+		}
+	};
+
+	const confirmReset = (): void => {
+		onChange(false);
+		setShowResetConfirm(false);
+	};
+
+	return (
+		<div className="drawer-section drawer-surface">
+			<div className="drawer-surface__head">
+				<h4>Source</h4>
+				{isReadOnly && (
+					<span className="managed-label" data-testid="drawer-managed-label">
+						<Lock size={12} />
+						Managed by SigNoz
+					</span>
+				)}
+			</div>
+			<RadioGroup
+				value={isOverride ? 'override' : 'auto'}
+				onChange={(value): void => handleSourceChange(value as 'auto' | 'override')}
+				className="source-radio-group"
+			>
+				<RadioGroupItem
+					value="auto"
+					containerClassName="source-radio source-radio--auto"
+					testId="drawer-source-auto"
+					disabled={disableAuto}
+				>
+					<div className="source-radio__title">Auto-populated</div>
+					<div className="source-radio__desc">
+						{disableAuto
+							? 'Available once SigNoz has default pricing for this model.'
+							: 'Default pricing from SigNoz.'}
+					</div>
+				</RadioGroupItem>
+				<RadioGroupItem
+					value="override"
+					containerClassName="source-radio source-radio--override"
+					testId="drawer-source-override"
+				>
+					<div className="source-radio__title">User override</div>
+					<div className="source-radio__desc">Custom pricing. Takes precedence.</div>
+				</RadioGroupItem>
+			</RadioGroup>
+			{showResetConfirm && (
+				<div
+					className="reset-confirm"
+					role="dialog"
+					aria-label="Reset to default pricing"
+				>
+					<p>
+						Reset to default pricing? Custom values will be discarded. it might take
+						24 hours for changes to take effect.
+					</p>
+					<div className="reset-confirm__actions">
+						<Button
+							variant="outlined"
+							color="secondary"
+							onClick={(): void => setShowResetConfirm(false)}
+							testId="drawer-reset-keep-btn"
+						>
+							Keep
+						</Button>
+						<Button
+							variant="solid"
+							color="primary"
+							onClick={confirmReset}
+							testId="drawer-reset-confirm-btn"
+						>
+							Reset
+						</Button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+export default SourceSelector;

--- a/frontend/src/container/LLMObservabilityModelPricing/__tests__/LLMObservabilityModelPricing.test.tsx
+++ b/frontend/src/container/LLMObservabilityModelPricing/__tests__/LLMObservabilityModelPricing.test.tsx
@@ -1,0 +1,194 @@
+import {
+	LlmpricingruletypesLLMPricingRuleUnitDTO as UnitDTO,
+	type LlmpricingruletypesLLMPricingRuleDTO,
+} from 'api/generated/services/sigNoz.schemas';
+import { rest, server } from 'mocks-server/server';
+import { fireEvent, render, screen, waitFor } from 'tests/test-utils';
+
+import LLMObservabilityModelPricing from '../LLMObservabilityModelPricing';
+
+const ENDPOINT = '*/api/v1/llm_pricing_rules';
+
+const mockRules: LlmpricingruletypesLLMPricingRuleDTO[] = [
+	{
+		id: 'rule-gpt4o',
+		orgId: 'org-1',
+		modelName: 'gpt-4o',
+		provider: 'OpenAI',
+		modelPattern: ['gpt-4o'],
+		isOverride: false,
+		enabled: true,
+		unit: UnitDTO.per_million_tokens,
+		pricing: { input: 15, output: 60 },
+	},
+	{
+		id: 'rule-llama',
+		orgId: 'org-1',
+		modelName: 'llama-3.1-70b',
+		provider: 'Self-hosted',
+		modelPattern: ['llama-3.1'],
+		isOverride: true,
+		enabled: true,
+		unit: UnitDTO.per_million_tokens,
+		pricing: { input: 0, output: 0 },
+	},
+];
+
+describe('LLMObservabilityModelPricing', () => {
+	beforeEach(() => {
+		server.use(
+			rest.get(ENDPOINT, (_, res, ctx) =>
+				res(
+					ctx.status(200),
+					ctx.json({
+						status: 'success',
+						data: {
+							items: mockRules,
+							limit: 100,
+							offset: 0,
+							total: mockRules.length,
+						},
+					}),
+				),
+			),
+		);
+	});
+
+	afterEach(() => {
+		server.resetHandlers();
+	});
+
+	it('renders the page header and both rules', async () => {
+		render(<LLMObservabilityModelPricing />);
+
+		await screen.findByText('gpt-4o');
+		expect(screen.getByText('Configuration')).toBeInTheDocument();
+		expect(screen.getByText('llama-3.1-70b')).toBeInTheDocument();
+		expect(screen.getByText('openai:gpt-4o')).toBeInTheDocument();
+	});
+
+	it('search is server-driven: typing sends the q param to the list request', async () => {
+		const requestedQ: (string | null)[] = [];
+		server.use(
+			rest.get(ENDPOINT, (req, res, ctx) => {
+				requestedQ.push(req.url.searchParams.get('q'));
+				return res(
+					ctx.status(200),
+					ctx.json({
+						status: 'success',
+						data: { items: mockRules, limit: 20, offset: 0, total: mockRules.length },
+					}),
+				);
+			}),
+		);
+
+		render(<LLMObservabilityModelPricing />);
+
+		await screen.findByText('gpt-4o');
+
+		fireEvent.change(screen.getByTestId('search-input'), {
+			target: { value: 'llama' },
+		});
+
+		// Debounced, so the request fires shortly after typing stops.
+		await waitFor(() => expect(requestedQ).toContain('llama'));
+	});
+
+	// TODO: drive this through the actual source <SelectSimple> UI (open the
+	// dropdown + click "User override") instead of seeding the URL. The radix
+	// Select popover doesn't open under jsdom, so for now we assert the wiring
+	// via the URL param. Fix once we have a reliable way to interact with the
+	// Select in tests.
+	it('source filter is server-driven: the URL source param is sent to the list request', async () => {
+		const requestedSource: (string | null)[] = [];
+		server.use(
+			rest.get(ENDPOINT, (req, res, ctx) => {
+				requestedSource.push(req.url.searchParams.get('source'));
+				return res(
+					ctx.status(200),
+					ctx.json({
+						status: 'success',
+						data: { items: mockRules, limit: 20, offset: 0, total: mockRules.length },
+					}),
+				);
+			}),
+		);
+
+		render(
+			<LLMObservabilityModelPricing />,
+			{},
+			{ initialRoute: '/?source=override' },
+		);
+
+		await screen.findByText('gpt-4o');
+
+		await waitFor(() => expect(requestedSource).toContain('override'));
+	});
+
+	it('opens the drawer in Add mode when the Add button is clicked', async () => {
+		render(<LLMObservabilityModelPricing />);
+
+		await screen.findByText('gpt-4o');
+		fireEvent.click(screen.getByTestId('add-model-cost-btn'));
+
+		const input = (await screen.findByTestId(
+			'drawer-model-id-input',
+		)) as HTMLInputElement;
+		expect(input).toBeInTheDocument();
+		expect(input.value).toBe('');
+	});
+
+	it('opens the drawer in Edit mode with prefilled values when a row Edit is clicked', async () => {
+		render(<LLMObservabilityModelPricing />);
+
+		await screen.findByText('gpt-4o');
+		fireEvent.click(screen.getByTestId('edit-rule-rule-gpt4o'));
+
+		const input = (await screen.findByTestId(
+			'drawer-model-id-input',
+		)) as HTMLInputElement;
+		expect(input).toBeInTheDocument();
+		expect(input.value).toBe('gpt-4o');
+	});
+
+	it('hides the Add button for non-admin users (write APIs are Admin-only)', async () => {
+		render(<LLMObservabilityModelPricing />, {}, { role: 'VIEWER' });
+
+		await screen.findByText('gpt-4o');
+		expect(screen.queryByTestId('add-model-cost-btn')).not.toBeInTheDocument();
+		// rows still open in read-only "View" mode
+		expect(screen.getByTestId('edit-rule-rule-gpt4o')).toHaveTextContent('View');
+	});
+
+	it('paginates server-side: selecting page 2 requests the next offset', async () => {
+		const requestedOffsets: number[] = [];
+		server.use(
+			rest.get(ENDPOINT, (req, res, ctx) => {
+				const offset = Number(req.url.searchParams.get('offset') ?? '0');
+				requestedOffsets.push(offset);
+				return res(
+					ctx.status(200),
+					ctx.json({
+						status: 'success',
+						data: {
+							items: [
+								{ ...mockRules[0], id: `rule-${offset}`, modelName: `model-${offset}` },
+							],
+							limit: 20,
+							offset,
+							total: 25,
+						},
+					}),
+				);
+			}),
+		);
+
+		render(<LLMObservabilityModelPricing />);
+
+		await screen.findByText('model-0');
+		fireEvent.click(screen.getByRole('button', { name: '2' }));
+
+		await screen.findByText('model-20');
+		expect(requestedOffsets).toContain(20);
+	});
+});

--- a/frontend/src/container/LLMObservabilityModelPricing/__tests__/ModelCostDrawer.test.tsx
+++ b/frontend/src/container/LLMObservabilityModelPricing/__tests__/ModelCostDrawer.test.tsx
@@ -1,0 +1,302 @@
+import { useState } from 'react';
+import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen } from 'tests/test-utils';
+
+import { EMPTY_DRAFT } from '../constants';
+import type { DrawerDraft } from '../types';
+import ModelCostDrawer from '../ModelCostDrawer';
+
+interface HarnessProps {
+	initialDraft?: DrawerDraft;
+	mode?: 'add' | 'edit';
+	canManage?: boolean;
+	onSave?: () => void;
+	onDelete?: () => void;
+}
+
+function Harness({
+	initialDraft = {
+		...EMPTY_DRAFT,
+		modelName: 'gpt-4o',
+		pricing: { ...EMPTY_DRAFT.pricing, input: 1, output: 1 },
+	},
+	mode = 'add',
+	canManage = true,
+	onSave = jest.fn(),
+	onDelete = jest.fn(),
+}: HarnessProps): JSX.Element {
+	const [draft, setDraft] = useState<DrawerDraft>(initialDraft);
+	return (
+		<ModelCostDrawer
+			isOpen
+			mode={mode}
+			draft={draft}
+			setDraft={setDraft}
+			onClose={jest.fn()}
+			onSave={onSave}
+			onDelete={onDelete}
+			isSaving={false}
+			isDeleting={false}
+			saveError={null}
+			canManage={canManage}
+		/>
+	);
+}
+
+describe('ModelCostDrawer', () => {
+	it('adds a pattern chip when the user types and presses Enter', () => {
+		render(<Harness />);
+
+		fireEvent.change(screen.getByTestId('drawer-pattern-input'), {
+			target: { value: 'gpt-4o-mini' },
+		});
+		fireEvent.keyDown(screen.getByTestId('drawer-pattern-input'), {
+			key: 'Enter',
+			code: 'Enter',
+		});
+
+		expect(screen.getByText('gpt-4o-mini*')).toBeInTheDocument();
+	});
+
+	it('disables pricing fields when isOverride is false', () => {
+		render(
+			<Harness
+				mode="edit"
+				initialDraft={{
+					...EMPTY_DRAFT,
+					id: 'rule-1',
+					modelName: 'gpt-4o',
+					provider: 'OpenAI',
+					isOverride: false,
+				}}
+			/>,
+		);
+
+		expect(screen.getByTestId('drawer-input-cost')).toBeDisabled();
+		expect(screen.getByTestId('drawer-output-cost')).toBeDisabled();
+	});
+
+	it('enables pricing fields when isOverride is true', () => {
+		render(
+			<Harness
+				mode="edit"
+				initialDraft={{
+					...EMPTY_DRAFT,
+					id: 'rule-1',
+					modelName: 'gpt-4o',
+					provider: 'OpenAI',
+					isOverride: true,
+				}}
+			/>,
+		);
+
+		expect(screen.getByTestId('drawer-input-cost')).not.toBeDisabled();
+		expect(screen.getByTestId('drawer-output-cost')).not.toBeDisabled();
+	});
+
+	it('shows only the Add pricing bucket button when no extra buckets are set', () => {
+		render(<Harness mode="add" />);
+
+		expect(screen.getByTestId('drawer-add-bucket-btn')).toBeInTheDocument();
+		expect(
+			screen.queryByTestId('drawer-cache-read-cost'),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId('drawer-cache-write-cost'),
+		).not.toBeInTheDocument();
+	});
+
+	it('adds a cache bucket from the picker', async () => {
+		const user = userEvent.setup({ pointerEventsCheck: 0 });
+		render(<Harness mode="add" />);
+
+		await user.click(screen.getByTestId('drawer-add-bucket-btn'));
+
+		// Picker offers both cache buckets…
+		expect(
+			screen.getByTestId('drawer-add-bucket-cache-read'),
+		).toBeInTheDocument();
+		expect(
+			screen.getByTestId('drawer-add-bucket-cache-write'),
+		).toBeInTheDocument();
+
+		await user.click(screen.getByTestId('drawer-add-bucket-cache-read'));
+
+		// …and picking one reveals its price input.
+		expect(screen.getByTestId('drawer-cache-read-cost')).toBeInTheDocument();
+	});
+
+	it('removes an existing cache bucket', async () => {
+		const user = userEvent.setup({ pointerEventsCheck: 0 });
+		render(
+			<Harness
+				mode="edit"
+				initialDraft={{
+					...EMPTY_DRAFT,
+					id: 'rule-1',
+					modelName: 'gpt-4o',
+					isOverride: true,
+					pricing: { ...EMPTY_DRAFT.pricing, input: 1, output: 1, cacheRead: 0.5 },
+				}}
+			/>,
+		);
+
+		expect(screen.getByTestId('drawer-cache-read-cost')).toBeInTheDocument();
+
+		await user.click(screen.getByTestId('drawer-remove-cache-read'));
+
+		expect(
+			screen.queryByTestId('drawer-cache-read-cost'),
+		).not.toBeInTheDocument();
+	});
+
+	it('hides bucket add/remove controls in read-only mode but shows set buckets', () => {
+		render(
+			<Harness
+				mode="edit"
+				canManage={false}
+				initialDraft={{
+					...EMPTY_DRAFT,
+					id: 'rule-1',
+					modelName: 'gpt-4o',
+					isOverride: true,
+					pricing: { ...EMPTY_DRAFT.pricing, cacheRead: 0.5 },
+				}}
+			/>,
+		);
+
+		expect(screen.getByTestId('drawer-cache-read-cost')).toBeDisabled();
+		expect(screen.queryByTestId('drawer-add-bucket-btn')).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId('drawer-remove-cache-read'),
+		).not.toBeInTheDocument();
+	});
+
+	it('disables the Provider select in Edit mode but allows it in Add mode', () => {
+		const { unmount } = render(<Harness mode="add" />);
+
+		expect(screen.getByTestId('drawer-provider-select')).not.toHaveAttribute(
+			'data-disabled',
+		);
+		unmount();
+
+		render(
+			<Harness
+				mode="edit"
+				initialDraft={{
+					...EMPTY_DRAFT,
+					id: 'rule-1',
+					modelName: 'gpt-4o',
+					provider: 'OpenAI',
+					isOverride: true,
+				}}
+			/>,
+		);
+
+		expect(screen.getByTestId('drawer-provider-select')).toHaveAttribute(
+			'data-disabled',
+		);
+	});
+
+	it('keeps metadata editable but locks pricing when source is auto-populated', () => {
+		render(
+			<Harness
+				mode="add"
+				initialDraft={{ ...EMPTY_DRAFT, modelName: 'gpt-4o', isOverride: false }}
+			/>,
+		);
+
+		// Metadata stays editable while the rule is auto-populated…
+		expect(screen.getByTestId('drawer-model-id-input')).not.toBeDisabled();
+		// …but pricing is read-only until "User override" is chosen.
+		expect(screen.getByTestId('drawer-input-cost')).toBeDisabled();
+	});
+
+	it('shows a reset confirmation when switching from Override to Auto', async () => {
+		const user = userEvent.setup({ pointerEventsCheck: 0 });
+		render(
+			<Harness
+				mode="edit"
+				initialDraft={{
+					...EMPTY_DRAFT,
+					id: 'rule-1',
+					modelName: 'gpt-4o',
+					isOverride: true,
+				}}
+			/>,
+		);
+
+		await user.click(screen.getByTestId('drawer-source-auto'));
+
+		expect(screen.getByTestId('drawer-reset-confirm-btn')).toBeInTheDocument();
+		expect(screen.getByTestId('drawer-reset-keep-btn')).toBeInTheDocument();
+	});
+
+	it('disables the Auto-populated source option in Add mode', () => {
+		render(<Harness mode="add" />);
+		expect(screen.getByTestId('drawer-source-auto')).toBeDisabled();
+	});
+
+	it('enables the Auto-populated source option in Edit mode', () => {
+		render(
+			<Harness
+				mode="edit"
+				initialDraft={{
+					...EMPTY_DRAFT,
+					id: 'rule-1',
+					modelName: 'gpt-4o',
+					isOverride: true,
+				}}
+			/>,
+		);
+		expect(screen.getByTestId('drawer-source-auto')).not.toBeDisabled();
+	});
+
+	it('hides the Delete action in Add mode', () => {
+		render(<Harness mode="add" />);
+		expect(screen.queryByTestId('drawer-delete-btn')).not.toBeInTheDocument();
+	});
+
+	it('shows the Delete action in Edit mode', () => {
+		render(
+			<Harness
+				mode="edit"
+				initialDraft={{
+					...EMPTY_DRAFT,
+					id: 'rule-1',
+					modelName: 'gpt-4o',
+					isOverride: true,
+				}}
+			/>,
+		);
+		expect(screen.getByTestId('drawer-delete-btn')).toBeInTheDocument();
+	});
+
+	it('calls onSave when the Save button is clicked', async () => {
+		const user = userEvent.setup({ pointerEventsCheck: 0 });
+		const onSave = jest.fn();
+		render(<Harness onSave={onSave} />);
+
+		await user.click(screen.getByTestId('drawer-save-btn'));
+		expect(onSave).toHaveBeenCalledTimes(1);
+	});
+
+	it('is read-only when the user cannot manage pricing (hides Save/Delete)', () => {
+		render(
+			<Harness
+				mode="edit"
+				canManage={false}
+				initialDraft={{
+					...EMPTY_DRAFT,
+					id: 'rule-1',
+					modelName: 'gpt-4o',
+					isOverride: true,
+				}}
+			/>,
+		);
+
+		expect(screen.queryByTestId('drawer-save-btn')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('drawer-delete-btn')).not.toBeInTheDocument();
+		expect(screen.getByTestId('drawer-model-id-input')).toBeDisabled();
+	});
+});

--- a/frontend/src/container/LLMObservabilityModelPricing/__tests__/drawerUtils.test.ts
+++ b/frontend/src/container/LLMObservabilityModelPricing/__tests__/drawerUtils.test.ts
@@ -1,0 +1,149 @@
+import {
+	LlmpricingruletypesLLMPricingRuleCacheModeDTO as CacheModeDTO,
+	LlmpricingruletypesLLMPricingRuleUnitDTO as UnitDTO,
+} from 'api/generated/services/sigNoz.schemas';
+
+import { EMPTY_DRAFT } from '../constants';
+import type { DrawerDraft, PricingRule } from '../types';
+import {
+	buildPricingPayload,
+	buildRulePayload,
+	draftFromRule,
+	validateDraft,
+} from '../utils';
+
+const makeRule = (overrides: Partial<PricingRule> = {}): PricingRule => ({
+	id: 'rule-1',
+	orgId: 'org-1',
+	modelName: 'gpt-4o',
+	provider: 'OpenAI',
+	modelPattern: ['gpt-4o'],
+	isOverride: false,
+	enabled: true,
+	unit: UnitDTO.per_million_tokens,
+	pricing: { input: 15, output: 60 },
+	...overrides,
+});
+
+describe('drawer draft utils', () => {
+	describe('draftFromRule', () => {
+		it('maps a rule to a draft with cache values when present', () => {
+			const rule = makeRule({
+				pricing: {
+					input: 3,
+					output: 15,
+					cache: {
+						mode: CacheModeDTO.additive,
+						read: 0.3,
+						write: 3.75,
+					},
+				},
+			});
+			const draft = draftFromRule(rule);
+			expect(draft.modelName).toBe('gpt-4o');
+			expect(draft.pricing.input).toBe(3);
+			expect(draft.pricing.cacheRead).toBe(0.3);
+			expect(draft.pricing.cacheWrite).toBe(3.75);
+			expect(draft.pricing.cacheMode).toBe(CacheModeDTO.additive);
+		});
+
+		it('falls back to defaults when cache is missing', () => {
+			const draft = draftFromRule(makeRule());
+			expect(draft.pricing.cacheRead).toBeNull();
+			expect(draft.pricing.cacheWrite).toBeNull();
+			expect(draft.pricing.cacheMode).toBe(CacheModeDTO.unknown);
+		});
+	});
+
+	describe('buildPricingPayload', () => {
+		it('omits the cache block when no cache values are set', () => {
+			const payload = buildPricingPayload(EMPTY_DRAFT);
+			expect(payload.cache).toBeUndefined();
+		});
+
+		it('includes only the cache values that are > 0', () => {
+			const draft: DrawerDraft = {
+				...EMPTY_DRAFT,
+				pricing: {
+					...EMPTY_DRAFT.pricing,
+					cacheRead: 1.5,
+					cacheWrite: 0,
+					cacheMode: CacheModeDTO.subtract,
+				},
+			};
+			const payload = buildPricingPayload(draft);
+			expect(payload.cache?.read).toBe(1.5);
+			expect(payload.cache?.write).toBeUndefined();
+			expect(payload.cache?.mode).toBe(CacheModeDTO.subtract);
+		});
+	});
+
+	describe('buildRulePayload', () => {
+		it('uses the modelName as a default pattern when no patterns are supplied', () => {
+			const draft: DrawerDraft = {
+				...EMPTY_DRAFT,
+				modelName: 'gpt-4o',
+				patterns: [],
+				provider: 'OpenAI',
+			};
+			const payload = buildRulePayload(draft);
+			expect(payload.modelPattern).toStrictEqual(['gpt-4o']);
+			expect(payload.unit).toBe(UnitDTO.per_million_tokens);
+			expect(payload.enabled).toBe(true);
+		});
+
+		it('omits id and sourceId for an Add draft', () => {
+			const payload = buildRulePayload(EMPTY_DRAFT);
+			expect(payload.id).toBeUndefined();
+			expect(payload.sourceId).toBeUndefined();
+		});
+	});
+
+	describe('validateDraft', () => {
+		it('requires a model name in Add mode', () => {
+			const result = validateDraft(EMPTY_DRAFT, 'add');
+			expect(result.ok).toBe(false);
+			expect(result.message).toMatch(/billing model id/i);
+		});
+
+		it('rejects negative pricing', () => {
+			const draft: DrawerDraft = {
+				...EMPTY_DRAFT,
+				modelName: 'gpt-4o',
+				pricing: { ...EMPTY_DRAFT.pricing, input: -1 },
+			};
+			expect(validateDraft(draft, 'add').ok).toBe(false);
+		});
+
+		it('accepts a valid Add draft', () => {
+			const draft: DrawerDraft = {
+				...EMPTY_DRAFT,
+				modelName: 'gpt-4o',
+				pricing: { ...EMPTY_DRAFT.pricing, input: 1, output: 2 },
+			};
+			expect(validateDraft(draft, 'add').ok).toBe(true);
+		});
+
+		it('rejects zero input/output cost for overrides', () => {
+			const draft: DrawerDraft = {
+				...EMPTY_DRAFT,
+				modelName: 'gpt-4o',
+				isOverride: true,
+				pricing: { ...EMPTY_DRAFT.pricing, input: 0, output: 5 },
+			};
+			const result = validateDraft(draft, 'add');
+			expect(result.ok).toBe(false);
+			expect(result.message).toMatch(/input cost must be greater than 0/i);
+		});
+
+		it('skips pricing validation for auto-populated (non-override) rules', () => {
+			const draft: DrawerDraft = {
+				...EMPTY_DRAFT,
+				modelName: 'gpt-4o',
+				isOverride: false,
+				pricing: { ...EMPTY_DRAFT.pricing, input: 0, output: 0 },
+			};
+			expect(validateDraft(draft, 'edit').ok).toBe(true);
+		});
+	});
+});

--- a/frontend/src/container/LLMObservabilityModelPricing/__tests__/utils.test.ts
+++ b/frontend/src/container/LLMObservabilityModelPricing/__tests__/utils.test.ts
@@ -1,0 +1,90 @@
+import {
+	LlmpricingruletypesLLMPricingRuleCacheModeDTO as CacheModeDTO,
+	LlmpricingruletypesLLMPricingRuleUnitDTO as UnitDTO,
+} from 'api/generated/services/sigNoz.schemas';
+
+import type { PricingRule } from '../types';
+import {
+	formatPricePerMillion,
+	getCanonicalId,
+	getExtraBuckets,
+	getRelativeLastSeen,
+	getSourceLabel,
+} from '../utils';
+
+const makeRule = (overrides: Partial<PricingRule> = {}): PricingRule => ({
+	id: 'rule-1',
+	orgId: 'org-1',
+	modelName: 'gpt-4o',
+	provider: 'OpenAI',
+	modelPattern: ['gpt-4o'],
+	isOverride: false,
+	enabled: true,
+	unit: UnitDTO.per_million_tokens,
+	pricing: { input: 15, output: 60 },
+	...overrides,
+});
+
+describe('utils', () => {
+	describe('formatPricePerMillion', () => {
+		it('formats numbers with 2 decimals and dollar prefix', () => {
+			expect(formatPricePerMillion(15)).toBe('$15.00');
+			expect(formatPricePerMillion(0.15)).toBe('$0.15');
+		});
+
+		it('returns em-dash for nullish or NaN', () => {
+			expect(formatPricePerMillion(undefined)).toBe('—');
+			expect(formatPricePerMillion(Number.NaN)).toBe('—');
+		});
+	});
+
+	describe('getExtraBuckets', () => {
+		it('returns an empty array when there is no cache pricing', () => {
+			expect(getExtraBuckets(makeRule())).toStrictEqual([]);
+		});
+
+		it('returns only buckets with values > 0', () => {
+			const rule = makeRule({
+				pricing: {
+					input: 3,
+					output: 15,
+					cache: {
+						mode: CacheModeDTO.additive,
+						read: 0.3,
+						write: 0,
+					},
+				},
+			});
+			const buckets = getExtraBuckets(rule);
+			expect(buckets).toStrictEqual([{ key: 'cache_read', pricePerMillion: 0.3 }]);
+		});
+	});
+
+	describe('getSourceLabel', () => {
+		it('returns "Auto" for non-override and "User override" otherwise', () => {
+			expect(getSourceLabel(makeRule({ isOverride: false }))).toBe('Auto');
+			expect(getSourceLabel(makeRule({ isOverride: true }))).toBe('User override');
+		});
+	});
+
+	describe('getCanonicalId', () => {
+		it('lowercases the provider and joins with the model name', () => {
+			expect(getCanonicalId(makeRule({ provider: 'OpenAI' }))).toBe(
+				'openai:gpt-4o',
+			);
+		});
+	});
+
+	describe('getRelativeLastSeen', () => {
+		it('returns em-dash when no timestamp is present', () => {
+			expect(getRelativeLastSeen(makeRule())).toBe('—');
+		});
+
+		it('formats minutes-old timestamps via dayjs fromNow', () => {
+			const recent = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+			expect(getRelativeLastSeen(makeRule({ updatedAt: recent }))).toMatch(
+				/minutes? ago/,
+			);
+		});
+	});
+});

--- a/frontend/src/container/LLMObservabilityModelPricing/constants.ts
+++ b/frontend/src/container/LLMObservabilityModelPricing/constants.ts
@@ -1,0 +1,41 @@
+import { LlmpricingruletypesLLMPricingRuleCacheModeDTO as CacheModeDTO } from 'api/generated/services/sigNoz.schemas';
+
+import type { CacheBucketDef, DrawerDraft } from './types';
+
+export const PROVIDER_OPTIONS = [
+	{ value: 'OpenAI', label: 'OpenAI' },
+	{ value: 'Anthropic', label: 'Anthropic' },
+	{ value: 'Azure OpenAI', label: 'Azure OpenAI' },
+	{ value: 'Google', label: 'Google' },
+	{ value: 'Self-hosted', label: 'Self-hosted' },
+	{ value: 'Other', label: 'Other' },
+];
+
+export const CACHE_MODE_OPTIONS = [
+	{ value: CacheModeDTO.subtract, label: 'Subtract (OpenAI style)' },
+	{ value: CacheModeDTO.additive, label: 'Additive (Anthropic style)' },
+	{ value: CacheModeDTO.unknown, label: 'Unknown' },
+];
+
+// Optional buckets offered in the "Add pricing bucket" picker. Only the cache
+// buckets are persisted by the API today (pricing.cache.read/write).
+export const CACHE_BUCKETS: CacheBucketDef[] = [
+	{ key: 'cacheRead', label: 'cache_read', testId: 'cache-read' },
+	{ key: 'cacheWrite', label: 'cache_write', testId: 'cache-write' },
+];
+
+export const EMPTY_DRAFT: DrawerDraft = {
+	id: null,
+	sourceId: null,
+	modelName: '',
+	provider: 'OpenAI',
+	patterns: [],
+	isOverride: true,
+	pricing: {
+		input: 0,
+		output: 0,
+		cacheMode: CacheModeDTO.unknown,
+		cacheRead: null,
+		cacheWrite: null,
+	},
+};

--- a/frontend/src/container/LLMObservabilityModelPricing/types.ts
+++ b/frontend/src/container/LLMObservabilityModelPricing/types.ts
@@ -1,4 +1,5 @@
 import {
+	LlmpricingruletypesLLMPricingRuleCacheModeDTO as CacheModeDTO,
 	type ListLLMPricingRulesParams,
 	type LlmpricingruletypesLLMPricingRuleDTO,
 } from 'api/generated/services/sigNoz.schemas';
@@ -18,4 +19,37 @@ export type ListModelPricingParams = ListLLMPricingRulesParams & {
 export interface ExtraBucket {
 	key: string;
 	pricePerMillion: number;
+}
+
+export type DrawerMode = 'add' | 'edit';
+
+// Optional pricing buckets the user can add/remove. Keyed by the matching
+// DrawerDraft['pricing'] field.
+export type CacheBucketKey = 'cacheRead' | 'cacheWrite';
+
+export interface CacheBucketDef {
+	key: CacheBucketKey;
+	label: string;
+	testId: string;
+}
+
+export interface DrawerDraft {
+	id: string | null;
+	sourceId: string | null;
+	modelName: string;
+	provider: string;
+	patterns: string[];
+	isOverride: boolean;
+	pricing: {
+		input: number;
+		output: number;
+		cacheMode: CacheModeDTO;
+		cacheRead: number | null;
+		cacheWrite: number | null;
+	};
+}
+
+export interface ValidationResult {
+	ok: boolean;
+	message?: string;
 }

--- a/frontend/src/container/LLMObservabilityModelPricing/useModelCostDrawer.ts
+++ b/frontend/src/container/LLMObservabilityModelPricing/useModelCostDrawer.ts
@@ -1,0 +1,123 @@
+import { useCallback, useState } from 'react';
+import { toast } from '@signozhq/ui/sonner';
+import { useQueryClient } from 'react-query';
+import {
+	getListLLMPricingRulesQueryKey,
+	useCreateOrUpdateLLMPricingRules,
+	useDeleteLLMPricingRule,
+} from 'api/generated/services/llmpricingrules';
+
+import { EMPTY_DRAFT } from './constants';
+import type { DrawerDraft, DrawerMode, PricingRule } from './types';
+import { buildRulePayload, draftFromRule } from './utils';
+
+interface UseModelCostDrawerResult {
+	isOpen: boolean;
+	mode: DrawerMode;
+	draft: DrawerDraft;
+	setDraft: (next: DrawerDraft) => void;
+	openForAdd: (prefillModelName?: string) => void;
+	openForEdit: (rule: PricingRule) => void;
+	close: () => void;
+	save: () => Promise<void>;
+	deleteRule: () => Promise<void>;
+	isSaving: boolean;
+	isDeleting: boolean;
+	saveError: string | null;
+	selectedRuleId: string | null;
+}
+
+export function useModelCostDrawer(): UseModelCostDrawerResult {
+	const queryClient = useQueryClient();
+	const [isOpen, setIsOpen] = useState<boolean>(false);
+	const [mode, setMode] = useState<DrawerMode>('add');
+	const [draft, setDraft] = useState<DrawerDraft>(EMPTY_DRAFT);
+	const [selectedRuleId, setSelectedRuleId] = useState<string | null>(null);
+	const [saveError, setSaveError] = useState<string | null>(null);
+
+	const { mutateAsync: createOrUpdate, isLoading: isSaving } =
+		useCreateOrUpdateLLMPricingRules();
+	const { mutateAsync: deleteRuleApi, isLoading: isDeleting } =
+		useDeleteLLMPricingRule();
+
+	const invalidateList = useCallback(async (): Promise<void> => {
+		await queryClient.invalidateQueries({
+			queryKey: getListLLMPricingRulesQueryKey(),
+		});
+	}, [queryClient]);
+
+	const openForAdd = useCallback((prefillModelName?: string): void => {
+		setMode('add');
+		setDraft({
+			...EMPTY_DRAFT,
+			modelName: prefillModelName || '',
+			patterns: prefillModelName ? [prefillModelName] : [],
+		});
+		setSelectedRuleId(null);
+		setSaveError(null);
+		setIsOpen(true);
+	}, []);
+
+	const openForEdit = useCallback((rule: PricingRule): void => {
+		setMode('edit');
+		setDraft(draftFromRule(rule));
+		setSelectedRuleId(rule.id);
+		setSaveError(null);
+		setIsOpen(true);
+	}, []);
+
+	const close = useCallback((): void => {
+		setIsOpen(false);
+		setSelectedRuleId(null);
+		setSaveError(null);
+	}, []);
+
+	const save = useCallback(async (): Promise<void> => {
+		setSaveError(null);
+		try {
+			await createOrUpdate({
+				data: { rules: [buildRulePayload(draft)] },
+			});
+			await invalidateList();
+			setIsOpen(false);
+			setSelectedRuleId(null);
+			toast.success(mode === 'edit' ? 'Model cost updated' : 'Model cost added');
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'Save failed';
+			setSaveError(message);
+		}
+	}, [createOrUpdate, draft, invalidateList, mode]);
+
+	const deleteRule = useCallback(async (): Promise<void> => {
+		if (!draft.id) {
+			return;
+		}
+		setSaveError(null);
+		try {
+			await deleteRuleApi({ pathParams: { id: draft.id } });
+			await invalidateList();
+			setIsOpen(false);
+			setSelectedRuleId(null);
+			toast.success('Model cost deleted');
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'Delete failed';
+			setSaveError(message);
+		}
+	}, [deleteRuleApi, draft.id, invalidateList]);
+
+	return {
+		isOpen,
+		mode,
+		draft,
+		setDraft,
+		openForAdd,
+		openForEdit,
+		close,
+		save,
+		deleteRule,
+		isSaving,
+		isDeleting,
+		saveError,
+		selectedRuleId,
+	};
+}

--- a/frontend/src/container/LLMObservabilityModelPricing/utils.ts
+++ b/frontend/src/container/LLMObservabilityModelPricing/utils.ts
@@ -1,12 +1,40 @@
+import {
+	LlmpricingruletypesLLMPricingRuleCacheModeDTO as CacheModeDTO,
+	LlmpricingruletypesLLMPricingRuleUnitDTO as UnitDTO,
+	type LlmpricingruletypesLLMPricingCacheCostsDTO,
+	type LlmpricingruletypesLLMRulePricingDTO,
+	type LlmpricingruletypesUpdatableLLMPricingRuleDTO,
+} from 'api/generated/services/sigNoz.schemas';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
-import type { ExtraBucket, PricingRule } from './types';
+import type {
+	DrawerDraft,
+	DrawerMode,
+	ExtraBucket,
+	PricingRule,
+	ValidationResult,
+} from './types';
 
 // Idempotent — relativeTime is also extended globally in utils/timeUtils.
 dayjs.extend(relativeTime);
 
 const lc = (value: string): string => value.toLowerCase();
+
+const hasCacheValue = (value: number | null): boolean =>
+	typeof value === 'number' && value > 0;
+
+// ─── Input helpers ───────────────────────────────────────────────────────────
+
+// Parses a price input's raw string. Empty → null (used by optional buckets),
+// otherwise a finite number (NaN coerced to 0).
+export const parsePricingAmount = (raw: string): number | null => {
+	if (raw.trim() === '') {
+		return null;
+	}
+	const value = Number(raw);
+	return Number.isFinite(value) ? value : 0;
+};
 
 // ─── Display helpers ─────────────────────────────────────────────────────────
 
@@ -44,4 +72,91 @@ export const getRelativeLastSeen = (rule: PricingRule): string => {
 export const getCanonicalId = (rule: PricingRule): string => {
 	const provider = rule.provider?.trim() || 'unknown';
 	return `${lc(provider)}:${rule.modelName}`;
+};
+
+// ─── Drawer draft <-> API helpers ────────────────────────────────────────────
+
+export const draftFromRule = (rule: PricingRule): DrawerDraft => ({
+	id: rule.id,
+	sourceId: rule.sourceId ?? null,
+	modelName: rule.modelName,
+	provider: rule.provider || 'OpenAI',
+	patterns: rule.modelPattern || [],
+	isOverride: !!rule.isOverride,
+	pricing: {
+		input: rule.pricing?.input ?? 0,
+		output: rule.pricing?.output ?? 0,
+		cacheMode: rule.pricing?.cache?.mode ?? CacheModeDTO.unknown,
+		cacheRead: rule.pricing?.cache?.read ?? null,
+		cacheWrite: rule.pricing?.cache?.write ?? null,
+	},
+});
+
+export const buildPricingPayload = (
+	draft: DrawerDraft,
+): LlmpricingruletypesLLMRulePricingDTO => {
+	const pricing: LlmpricingruletypesLLMRulePricingDTO = {
+		input: draft.pricing.input,
+		output: draft.pricing.output,
+	};
+	if (
+		hasCacheValue(draft.pricing.cacheRead) ||
+		hasCacheValue(draft.pricing.cacheWrite)
+	) {
+		const cache: LlmpricingruletypesLLMPricingCacheCostsDTO = {
+			mode: draft.pricing.cacheMode,
+		};
+		if (hasCacheValue(draft.pricing.cacheRead)) {
+			cache.read = draft.pricing.cacheRead as number;
+		}
+		if (hasCacheValue(draft.pricing.cacheWrite)) {
+			cache.write = draft.pricing.cacheWrite as number;
+		}
+		pricing.cache = cache;
+	}
+	return pricing;
+};
+
+export const buildRulePayload = (
+	draft: DrawerDraft,
+): LlmpricingruletypesUpdatableLLMPricingRuleDTO => ({
+	id: draft.id || undefined,
+	sourceId: draft.sourceId || undefined,
+	modelName: draft.modelName.trim(),
+	provider: draft.provider.trim(),
+	modelPattern:
+		draft.patterns.length > 0 ? draft.patterns : [draft.modelName.trim()],
+	isOverride: draft.isOverride,
+	enabled: true,
+	unit: UnitDTO.per_million_tokens,
+	pricing: buildPricingPayload(draft),
+});
+
+export const validateDraft = (
+	draft: DrawerDraft,
+	mode: DrawerMode,
+): ValidationResult => {
+	if (mode === 'add' && !draft.modelName.trim()) {
+		return { ok: false, message: 'Billing model ID is required.' };
+	}
+	if (!draft.provider.trim()) {
+		return { ok: false, message: 'Provider is required.' };
+	}
+	// Pricing is only user-entered for overrides; auto-populated rules are
+	// managed by SigNoz (and may legitimately be 0 for self-hosted models).
+	if (draft.isOverride) {
+		if (!(draft.pricing.input > 0)) {
+			return { ok: false, message: 'Input cost must be greater than 0.' };
+		}
+		if (!(draft.pricing.output > 0)) {
+			return { ok: false, message: 'Output cost must be greater than 0.' };
+		}
+		if (
+			(draft.pricing.cacheRead !== null && draft.pricing.cacheRead < 0) ||
+			(draft.pricing.cacheWrite !== null && draft.pricing.cacheWrite < 0)
+		) {
+			return { ok: false, message: 'Cache costs must be non-negative.' };
+		}
+	}
+	return { ok: true };
 };

--- a/frontend/src/tests/test-utils.tsx
+++ b/frontend/src/tests/test-utils.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render, RenderOptions, RenderResult } from '@testing-library/react';
+import { TooltipProvider } from '@signozhq/ui/tooltip';
 import { FeatureKeys } from 'constants/features';
 import { ORG_PREFERENCES } from 'constants/orgPreferences';
 import { ResourceProvider } from 'hooks/useResourceAttribute';
@@ -301,7 +302,7 @@ export function AllTheProviders({
 								<ErrorModalProvider>
 									<TimezoneProvider>
 										<PreferenceContextProvider>
-											{queryBuilderContent}
+											<TooltipProvider>{queryBuilderContent}</TooltipProvider>
 										</PreferenceContextProvider>
 									</TimezoneProvider>
 								</ErrorModalProvider>

--- a/frontend/src/utils/permission/index.ts
+++ b/frontend/src/utils/permission/index.ts
@@ -20,7 +20,8 @@ export type ComponentTypes =
 	| 'add_panel'
 	| 'page_pipelines'
 	| 'edit_locked_dashboard'
-	| 'add_panel_locked_dashboard';
+	| 'add_panel_locked_dashboard'
+	| 'manage_llm_pricing';
 
 export const componentPermission: Record<ComponentTypes, ROLES[]> = {
 	current_org_settings: ['ADMIN'],
@@ -42,6 +43,7 @@ export const componentPermission: Record<ComponentTypes, ROLES[]> = {
 	page_pipelines: ['ADMIN', 'EDITOR'],
 	edit_locked_dashboard: ['ADMIN', 'AUTHOR'],
 	add_panel_locked_dashboard: ['ADMIN', 'AUTHOR'],
+	manage_llm_pricing: ['ADMIN', 'EDITOR', 'AUTHOR'],
 };
 
 export const routePermission: Record<keyof typeof ROUTES, ROLES[]> = {

--- a/tests/e2e/helpers/llm-pricing.ts
+++ b/tests/e2e/helpers/llm-pricing.ts
@@ -1,0 +1,122 @@
+import type { APIRequestContext, Page } from '@playwright/test';
+
+export const LLM_PRICING_PATH = '/llm-observability/settings/model-pricing';
+
+// ─── Auth ────────────────────────────────────────────────────────────────────
+
+/**
+ * Read the JWT the auth fixture stored in `localStorage.AUTH_TOKEN`. The
+ * page must be on the SigNoz origin first; if not, this navigates to the
+ * pricing page to populate localStorage from the context's storageState.
+ */
+export async function authToken(page: Page): Promise<string> {
+	if (!page.url().startsWith('http')) {
+		await page.goto(LLM_PRICING_PATH);
+	}
+	return page.evaluate(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		() => (globalThis as any).localStorage.getItem('AUTH_TOKEN') || '',
+	);
+}
+
+// ─── Navigation ──────────────────────────────────────────────────────────────
+
+/**
+ * Navigate to the LLM pricing page and wait for the root container.
+ */
+export async function gotoLlmPricingPage(page: Page): Promise<void> {
+	await page.goto(LLM_PRICING_PATH);
+	await page
+		.getByTestId('llm-observability-model-pricing-page')
+		.waitFor({ state: 'visible' });
+}
+
+// ─── API helpers ─────────────────────────────────────────────────────────────
+
+interface SeedOptions {
+	modelName?: string;
+	provider?: string;
+	isOverride?: boolean;
+	inputCost?: number;
+	outputCost?: number;
+}
+
+/**
+ * Seed one pricing rule via `PUT /api/v1/llm_pricing_rules` and return its id.
+ * The PUT response is void (HTTP 200, no body), so a follow-up GET by modelName
+ * is required to obtain the id.
+ */
+export async function createPricingRuleViaApi(
+	page: Page,
+	overrides: SeedOptions = {},
+): Promise<string> {
+	const {
+		modelName = 'e2e-test-model',
+		provider = 'OpenAI',
+		isOverride = true,
+		inputCost = 10.0,
+		outputCost = 30.0,
+	} = overrides;
+
+	const token = await authToken(page);
+
+	const putRes = await page.request.put('/api/v1/llm_pricing_rules', {
+		data: {
+			rules: [
+				{
+					modelName,
+					provider,
+					modelPattern: [modelName],
+					isOverride,
+					enabled: true,
+					unit: 'per_million_tokens',
+					pricing: { input: inputCost, output: outputCost },
+				},
+			],
+		},
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!putRes.ok()) {
+		throw new Error(
+			`PUT /api/v1/llm_pricing_rules ${putRes.status()}: ${await putRes.text()}`,
+		);
+	}
+
+	// PUT returns void — fetch the list to find the newly-created rule's id.
+	const getRes = await page.request.get(
+		'/api/v1/llm_pricing_rules?offset=0&limit=200',
+		{
+			headers: { Authorization: `Bearer ${token}` },
+		},
+	);
+	if (!getRes.ok()) {
+		throw new Error(
+			`GET /api/v1/llm_pricing_rules ${getRes.status()}: ${await getRes.text()}`,
+		);
+	}
+	const body = (await getRes.json()) as {
+		data: { items: Array<{ id: string; modelName: string }> };
+	};
+	const rule = body.data.items.find((r) => r.modelName === modelName);
+	if (!rule) {
+		throw new Error(`Could not find seeded rule "${modelName}" in GET response`);
+	}
+	return rule.id;
+}
+
+/**
+ * Best-effort delete via API. Errors are swallowed so suite-level cleanup
+ * stays resilient when a UI flow already deleted the resource (404) or the
+ * stack is mid-shutdown.
+ */
+export async function deletePricingRuleViaApi(
+	request: APIRequestContext,
+	id: string,
+	token: string,
+): Promise<void> {
+	await request
+		.delete(`/api/v1/llm_pricing_rules/${id}`, {
+			headers: { Authorization: `Bearer ${token}` },
+		})
+		.catch(() => undefined);
+}

--- a/tests/e2e/tests/llm-pricing/delete.spec.ts
+++ b/tests/e2e/tests/llm-pricing/delete.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from '../../fixtures/auth';
+import {
+	authToken,
+	createPricingRuleViaApi,
+	deletePricingRuleViaApi,
+	gotoLlmPricingPage,
+} from '../../helpers/llm-pricing';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('LLM Pricing — Delete rule', () => {
+	test('TC-20 Delete button removes the rule from the list', async ({
+		authedPage: page,
+	}) => {
+		const ruleId = await createPricingRuleViaApi(page, {
+			modelName: 'e2e-delete-target',
+			provider: 'OpenAI',
+			isOverride: true,
+			inputCost: 5.0,
+			outputCost: 15.0,
+		});
+
+		await gotoLlmPricingPage(page);
+		await page.getByTestId(`edit-rule-${ruleId}`).click();
+		await expect(page.getByText('Edit model cost').first()).toBeVisible();
+
+		const deleteResponse = page.waitForResponse(
+			(r) =>
+				r.url().includes('llm_pricing_rules') && r.request().method() === 'DELETE',
+		);
+		const listRefresh = page.waitForResponse(
+			(r) =>
+				r.url().includes('llm_pricing_rules') && r.request().method() === 'GET',
+		);
+		await page.getByTestId('drawer-delete-btn').click();
+		const del = await deleteResponse;
+		// DELETE returns 200 or 204
+		expect([200, 204]).toContain(del.status());
+		await listRefresh;
+
+		await expect(page.getByText('Edit model cost').first()).not.toBeVisible();
+		await expect(page.getByTestId(`model-cell-name-${ruleId}`)).not.toBeVisible();
+
+		// Rule was deleted by the UI; best-effort API call swallows any 404
+		const token = await authToken(page);
+		await deletePricingRuleViaApi(page.request, ruleId, token);
+	});
+
+	test('TC-21 delete error is surfaced in the drawer', async ({
+		authedPage: page,
+	}) => {
+		const ruleId = await createPricingRuleViaApi(page, {
+			modelName: 'e2e-delete-error',
+			provider: 'OpenAI',
+			isOverride: true,
+			inputCost: 3.0,
+			outputCost: 9.0,
+		});
+		try {
+			await gotoLlmPricingPage(page);
+			await page.getByTestId(`edit-rule-${ruleId}`).click();
+			await expect(page.getByText('Edit model cost').first()).toBeVisible();
+
+			// Intercept the DELETE and return 500
+			await page.route(`**/api/v1/llm_pricing_rules/${ruleId}`, async (route) => {
+				if (route.request().method() === 'DELETE') {
+					await route.fulfill({ status: 500, body: '{"message":"internal error"}' });
+				} else {
+					await route.continue();
+				}
+			});
+
+			await page.getByTestId('drawer-delete-btn').click();
+
+			// Error alert must appear inside the open drawer
+			await expect(page.locator('[role="alert"].drawer-error')).toBeVisible();
+
+			// Drawer stays open
+			await expect(page.getByText('Edit model cost').first()).toBeVisible();
+
+			// Remove the route intercept so cleanup can proceed
+			await page.unrouteAll();
+		} finally {
+			await page.getByTestId('drawer-cancel-btn').click().catch(() => undefined);
+			const token = await authToken(page);
+			await deletePricingRuleViaApi(page.request, ruleId, token);
+		}
+	});
+
+	test('TC-22 save error is surfaced in the drawer', async ({
+		authedPage: page,
+	}) => {
+		await gotoLlmPricingPage(page);
+		await page.getByTestId('add-model-cost-btn').click();
+		await expect(page.getByText('Add model cost').first()).toBeVisible();
+
+		await page.getByTestId('drawer-model-id-input').fill('e2e-err-test');
+
+		// Intercept PUT and return 422
+		await page.route('**/api/v1/llm_pricing_rules', async (route) => {
+			if (route.request().method() === 'PUT') {
+				await route.fulfill({
+					status: 422,
+					contentType: 'application/json',
+					body: JSON.stringify({ message: 'duplicate key' }),
+				});
+			} else {
+				await route.continue();
+			}
+		});
+
+		await page.getByTestId('drawer-save-btn').click();
+
+		// Error alert appears inside the drawer
+		await expect(page.locator('[role="alert"].drawer-error')).toBeVisible();
+
+		// Drawer remains open
+		await expect(page.getByText('Add model cost').first()).toBeVisible();
+
+		await page.unrouteAll();
+		await page.getByTestId('drawer-cancel-btn').click();
+	});
+});

--- a/tests/e2e/tests/llm-pricing/drawer-add.spec.ts
+++ b/tests/e2e/tests/llm-pricing/drawer-add.spec.ts
@@ -1,0 +1,238 @@
+import { expect, test } from '../../fixtures/auth';
+import {
+	authToken,
+	deletePricingRuleViaApi,
+	gotoLlmPricingPage,
+} from '../../helpers/llm-pricing';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('LLM Pricing — Add drawer', () => {
+	test('TC-06 opening the drawer shows correct default state', async ({
+		authedPage: page,
+	}) => {
+		await gotoLlmPricingPage(page);
+		await page.getByTestId('add-model-cost-btn').click();
+
+		// Drawer must be visible before asserting field values
+		await expect(page.getByText('Add model cost').first()).toBeVisible();
+
+		await expect(page.getByTestId('drawer-model-id-input')).toBeVisible();
+		// Model ID field is empty by default
+		await expect(page.getByTestId('drawer-model-id-input')).toHaveValue('');
+
+		// Provider defaults to OpenAI
+		await expect(page.getByTestId('drawer-provider-select')).toContainText('OpenAI');
+
+		// Source radio: Override is checked, Auto is unchecked
+		await expect(page.getByTestId('drawer-source-override')).toHaveAttribute(
+			'data-state',
+			'checked',
+		);
+		await expect(page.getByTestId('drawer-source-auto')).toHaveAttribute(
+			'data-state',
+			'unchecked',
+		);
+		// Auto-populated is disabled in Add mode — there's no SigNoz default to
+		// fall back to for a brand-new model.
+		await expect(page.getByTestId('drawer-source-auto')).toBeDisabled();
+
+		// Pricing defaults to 0 (Ant InputNumber wraps a real <input>)
+		await expect(
+			page.locator('[data-testid="drawer-input-cost"] input'),
+		).toHaveValue('0');
+		await expect(
+			page.locator('[data-testid="drawer-output-cost"] input'),
+		).toHaveValue('0');
+
+		// Cache mode is hidden when no cache bucket value
+		await expect(page.getByTestId('drawer-cache-mode')).not.toBeVisible();
+
+		// Save is disabled (empty model name); Delete is absent in add mode
+		await expect(page.getByTestId('drawer-save-btn')).toBeDisabled();
+		await expect(page.getByTestId('drawer-cancel-btn')).toBeVisible();
+		await expect(page.getByTestId('drawer-delete-btn')).not.toBeVisible();
+
+		await page.getByTestId('drawer-cancel-btn').click();
+		await expect(page.getByText('Add model cost').first()).not.toBeVisible();
+	});
+
+	test('TC-07 Save button tooltip shows validation message when model name is empty', async ({
+		authedPage: page,
+	}) => {
+		await gotoLlmPricingPage(page);
+		await page.getByTestId('add-model-cost-btn').click();
+		await expect(page.getByText('Add model cost').first()).toBeVisible();
+
+		// Save is disabled; hover triggers tooltip
+		const saveBtn = page.getByTestId('drawer-save-btn');
+		await expect(saveBtn).toBeDisabled();
+		await saveBtn.hover();
+		await expect(page.getByText('Billing model ID is required.')).toBeVisible();
+
+		await page.getByTestId('drawer-cancel-btn').click();
+	});
+
+	test('TC-08 adding a pattern chip via Add button and Enter key', async ({
+		authedPage: page,
+	}) => {
+		await gotoLlmPricingPage(page);
+		await page.getByTestId('add-model-cost-btn').click();
+		await expect(page.getByText('Add model cost').first()).toBeVisible();
+
+		await page.getByTestId('drawer-model-id-input').fill('e2e-add-test');
+
+		// Add via button
+		await page.getByTestId('drawer-pattern-input').fill('e2e-add');
+		await page.getByTestId('drawer-pattern-add-btn').click();
+		await expect(page.getByText('e2e-add*')).toBeVisible();
+		await expect(page.getByTestId('drawer-pattern-input')).toHaveValue('');
+
+		// Add via Enter key
+		await page.getByTestId('drawer-pattern-input').fill('e2e-add-v2');
+		await page.getByTestId('drawer-pattern-input').press('Enter');
+		await expect(page.getByText('e2e-add-v2*')).toBeVisible();
+
+		// Deduplication: adding e2e-add again produces no second chip
+		await page.getByTestId('drawer-pattern-input').fill('e2e-add');
+		await page.getByTestId('drawer-pattern-add-btn').click();
+		const chips = page.locator('.pattern-chip');
+		await expect(chips).toHaveCount(2);
+
+		// Remove first chip
+		await page.getByRole('button', { name: 'Remove pattern e2e-add' }).click();
+		await expect(page.getByText('e2e-add*')).not.toBeVisible();
+		await expect(page.getByText('e2e-add-v2*')).toBeVisible();
+
+		await page.getByTestId('drawer-cancel-btn').click();
+	});
+
+	test('TC-09 save a new user-override rule end-to-end', async ({
+		authedPage: page,
+	}) => {
+		await gotoLlmPricingPage(page);
+		await page.getByTestId('add-model-cost-btn').click();
+		await expect(page.getByText('Add model cost').first()).toBeVisible();
+
+		await page.getByTestId('drawer-model-id-input').fill('e2e-save-model');
+
+		// Select Anthropic provider
+		await page.getByTestId('drawer-provider-select').click();
+		await page.getByText('Anthropic').click();
+
+		// Add pattern
+		await page.getByTestId('drawer-pattern-input').fill('e2e-save');
+		await page.getByTestId('drawer-pattern-add-btn').click();
+
+		// Override radio is the default
+		await expect(page.getByTestId('drawer-source-override')).toHaveAttribute(
+			'data-state',
+			'checked',
+		);
+
+		// Set pricing
+		await page.locator('[data-testid="drawer-input-cost"] input').fill('5.50');
+		await page.locator('[data-testid="drawer-output-cost"] input').fill('17.00');
+
+		// Wait for PUT before clicking Save to avoid a race
+		const putResponse = page.waitForResponse(
+			(r) =>
+				r.url().includes('llm_pricing_rules') && r.request().method() === 'PUT',
+		);
+		const listRefresh = page.waitForResponse(
+			(r) =>
+				r.url().includes('llm_pricing_rules') && r.request().method() === 'GET',
+		);
+		await page.getByTestId('drawer-save-btn').click();
+		const put = await putResponse;
+		expect(put.status()).toBe(200);
+		await listRefresh;
+
+		// Drawer closes
+		await expect(page.getByText('Add model cost').first()).not.toBeVisible();
+
+		// Row appears in table — locate by model name text since we don't know the id yet
+		await expect(page.getByText('e2e-save-model')).toBeVisible();
+		// Source badge says "User override"
+		await expect(page.getByText('User override').first()).toBeVisible();
+
+		// Cleanup: resolve the rule id and delete via API (deletePricingRuleViaApi swallows errors)
+		const token = await authToken(page);
+		const getRes = await page.request.get(
+			'/api/v1/llm_pricing_rules?offset=0&limit=200',
+			{ headers: { Authorization: `Bearer ${token}` } },
+		);
+		const body = (await getRes.json()) as {
+			data: { items: Array<{ id: string; modelName: string }> };
+		};
+		const createdId = body.data.items.find((r) => r.modelName === 'e2e-save-model')?.id ?? '';
+		await deletePricingRuleViaApi(page.request, createdId, token);
+	});
+
+	test('TC-10 cache bucket adds via the picker, toggles cache-mode, and removes via trash', async ({
+		authedPage: page,
+	}) => {
+		await gotoLlmPricingPage(page);
+		await page.getByTestId('add-model-cost-btn').click();
+		await expect(page.getByText('Add model cost').first()).toBeVisible();
+
+		await page.getByTestId('drawer-model-id-input').fill('e2e-cache-test');
+
+		// No bucket yet → its input and the cache-mode select are hidden; only the
+		// "Add pricing bucket" button shows.
+		await expect(page.getByTestId('drawer-cache-read-cost')).not.toBeVisible();
+		await expect(page.getByTestId('drawer-cache-mode')).not.toBeVisible();
+		await expect(page.getByTestId('drawer-add-bucket-btn')).toBeVisible();
+
+		// Add cache_read from the picker
+		await page.getByTestId('drawer-add-bucket-btn').click();
+		await page.getByTestId('drawer-add-bucket-cache-read').click();
+
+		// The bucket input and cache-mode select appear; cache mode defaults to "Unknown"
+		await expect(page.getByTestId('drawer-cache-read-cost')).toBeVisible();
+		await expect(page.getByTestId('drawer-cache-mode')).toBeVisible();
+		await expect(page.getByTestId('drawer-cache-mode')).toContainText('Unknown');
+
+		// Set the cache_read price
+		await page.locator('[data-testid="drawer-cache-read-cost"] input').fill('0.30');
+
+		// Change to Subtract
+		await page.getByTestId('drawer-cache-mode').click();
+		await page.getByText('Subtract (OpenAI style)').click();
+		await expect(page.getByTestId('drawer-cache-mode')).toContainText('Subtract');
+
+		// Removing the bucket via trash hides both the input and the cache-mode select
+		await page.getByTestId('drawer-remove-cache-read').click();
+		await expect(page.getByTestId('drawer-cache-read-cost')).not.toBeVisible();
+		await expect(page.getByTestId('drawer-cache-mode')).not.toBeVisible();
+
+		await page.getByTestId('drawer-cancel-btn').click();
+	});
+
+	test('TC-11 cancel closes the drawer without persisting data', async ({
+		authedPage: page,
+	}) => {
+		await gotoLlmPricingPage(page);
+		await page.getByTestId('add-model-cost-btn').click();
+		await expect(page.getByText('Add model cost').first()).toBeVisible();
+
+		await page.getByTestId('drawer-model-id-input').fill('e2e-cancel-test');
+		await page.locator('[data-testid="drawer-input-cost"] input').fill('99');
+
+		await page.getByTestId('drawer-cancel-btn').click();
+		await expect(page.getByText('Add model cost').first()).not.toBeVisible();
+
+		// No row created
+		await expect(page.getByText('e2e-cancel-test')).not.toBeVisible();
+
+		// Re-opening resets all fields to defaults
+		await page.getByTestId('add-model-cost-btn').click();
+		await expect(page.getByText('Add model cost').first()).toBeVisible();
+		await expect(page.getByTestId('drawer-model-id-input')).toHaveValue('');
+		await expect(
+			page.locator('[data-testid="drawer-input-cost"] input'),
+		).toHaveValue('0');
+
+		await page.getByTestId('drawer-cancel-btn').click();
+	});
+});

--- a/tests/e2e/tests/llm-pricing/drawer-edit.spec.ts
+++ b/tests/e2e/tests/llm-pricing/drawer-edit.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test } from '../../fixtures/auth';
+import {
+	authToken,
+	createPricingRuleViaApi,
+	deletePricingRuleViaApi,
+	gotoLlmPricingPage,
+} from '../../helpers/llm-pricing';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('LLM Pricing — Edit drawer', () => {
+	test('TC-12 Edit button opens drawer pre-filled with rule data', async ({
+		authedPage: page,
+	}) => {
+		const ruleId = await createPricingRuleViaApi(page, {
+			modelName: 'e2e-edit-subject',
+			provider: 'Google',
+			isOverride: true,
+			inputCost: 3.0,
+			outputCost: 12.0,
+		});
+		try {
+			await gotoLlmPricingPage(page);
+			await page.getByTestId(`edit-rule-${ruleId}`).click();
+
+			await expect(page.getByText('Edit model cost').first()).toBeVisible();
+
+			// Model ID is locked in edit mode
+			const modelInput = page.getByTestId('drawer-model-id-input');
+			await expect(modelInput).toBeDisabled();
+			await expect(modelInput).toHaveValue('e2e-edit-subject');
+
+			// Provider is locked and pre-filled
+			await expect(page.getByTestId('drawer-provider-select')).toBeDisabled();
+			await expect(page.getByTestId('drawer-provider-select')).toContainText('Google');
+
+			// Source radio
+			await expect(page.getByTestId('drawer-source-override')).toHaveAttribute(
+				'data-state',
+				'checked',
+			);
+
+			// Pricing values
+			await expect(
+				page.locator('[data-testid="drawer-input-cost"] input'),
+			).toHaveValue('3');
+			await expect(
+				page.locator('[data-testid="drawer-output-cost"] input'),
+			).toHaveValue('12');
+
+			// Delete button present in edit mode
+			await expect(page.getByTestId('drawer-delete-btn')).toBeVisible();
+		} finally {
+			await page.getByTestId('drawer-cancel-btn').click().catch(() => undefined);
+			const token = await authToken(page);
+			await deletePricingRuleViaApi(page.request, ruleId, token);
+		}
+	});
+
+	test('TC-13 editing pricing values and saving updates the row', async ({
+		authedPage: page,
+	}) => {
+		const ruleId = await createPricingRuleViaApi(page, {
+			modelName: 'e2e-edit-subject',
+			provider: 'Google',
+			isOverride: true,
+			inputCost: 3.0,
+			outputCost: 12.0,
+		});
+		try {
+			await gotoLlmPricingPage(page);
+			await page.getByTestId(`edit-rule-${ruleId}`).click();
+			await expect(page.getByText('Edit model cost').first()).toBeVisible();
+
+			// Update pricing
+			const inputField = page.locator('[data-testid="drawer-input-cost"] input');
+			const outputField = page.locator('[data-testid="drawer-output-cost"] input');
+
+			await inputField.click();
+			await inputField.press('Control+a');
+			await inputField.fill('7.00');
+
+			await outputField.click();
+			await outputField.press('Control+a');
+			await outputField.fill('21.00');
+
+			const putResponse = page.waitForResponse(
+				(r) =>
+					r.url().includes('llm_pricing_rules') && r.request().method() === 'PUT',
+			);
+			const listRefresh = page.waitForResponse(
+				(r) =>
+					r.url().includes('llm_pricing_rules') && r.request().method() === 'GET',
+			);
+			await page.getByTestId('drawer-save-btn').click();
+			const put = await putResponse;
+			expect(put.status()).toBe(200);
+			await listRefresh;
+
+			await expect(page.getByText('Edit model cost').first()).not.toBeVisible();
+
+			// Updated values visible in the row
+			await expect(page.getByTestId(`price-cell-input-${ruleId}`)).toHaveText('$7.00');
+			await expect(page.getByTestId(`price-cell-output-${ruleId}`)).toHaveText('$21.00');
+		} finally {
+			const token = await authToken(page);
+			await deletePricingRuleViaApi(page.request, ruleId, token);
+		}
+	});
+
+	test('TC-14 read-only mode — auto rule opens with Managed-by-SigNoz and Read-only badges', async ({
+		authedPage: page,
+	}) => {
+		const ruleId = await createPricingRuleViaApi(page, {
+			modelName: 'e2e-auto-rule',
+			provider: 'OpenAI',
+			isOverride: false,
+			inputCost: 2.0,
+			outputCost: 8.0,
+		});
+		try {
+			await gotoLlmPricingPage(page);
+			await page.getByTestId(`edit-rule-${ruleId}`).click();
+			await expect(page.getByText('Edit model cost').first()).toBeVisible();
+
+			// Source section lock badge
+			await expect(page.getByTestId('drawer-managed-label')).toBeVisible();
+			await expect(page.getByTestId('drawer-managed-label')).toContainText(
+				'Managed by SigNoz',
+			);
+
+			// Pricing section lock badge
+			await expect(page.getByTestId('drawer-readonly-label')).toBeVisible();
+			await expect(page.getByTestId('drawer-readonly-label')).toContainText('Read-only');
+
+			// Fields are locked
+			await expect(page.getByTestId('drawer-model-id-input')).toBeDisabled();
+
+			// Radio: auto is checked
+			await expect(page.getByTestId('drawer-source-auto')).toHaveAttribute(
+				'data-state',
+				'checked',
+			);
+			await expect(page.getByTestId('drawer-source-override')).toHaveAttribute(
+				'data-state',
+				'unchecked',
+			);
+
+			// Pricing inputs are disabled
+			await expect(
+				page.locator('[data-testid="drawer-input-cost"] input'),
+			).toBeDisabled();
+			await expect(
+				page.locator('[data-testid="drawer-output-cost"] input'),
+			).toBeDisabled();
+
+			// Pattern input is hidden when read-only
+			await expect(page.getByTestId('drawer-pattern-input')).not.toBeVisible();
+		} finally {
+			await page.getByTestId('drawer-cancel-btn').click().catch(() => undefined);
+			const token = await authToken(page);
+			await deletePricingRuleViaApi(page.request, ruleId, token);
+		}
+	});
+});

--- a/tests/e2e/tests/llm-pricing/listing.spec.ts
+++ b/tests/e2e/tests/llm-pricing/listing.spec.ts
@@ -1,0 +1,228 @@
+import { expect, test } from '../../fixtures/auth';
+import { newAdminContext } from '../../helpers/auth';
+import {
+	authToken,
+	createPricingRuleViaApi,
+	deletePricingRuleViaApi,
+	gotoLlmPricingPage,
+	LLM_PRICING_PATH,
+} from '../../helpers/llm-pricing';
+
+// Tests mutate the pricing rule list — run serially within the worker.
+test.describe.configure({ mode: 'serial' });
+
+// ─── Suite-level seed registry ────────────────────────────────────────────────
+//
+// TC-01 through TC-04 share two seeded rules (ruleA and ruleB) seeded in
+// beforeAll. TC-05 runs against an empty workspace and must not seed.
+
+const seedIds = new Set<string>();
+let ruleAId = '';
+let ruleBId = '';
+
+test.beforeAll(async ({ browser }) => {
+	const ctx = await newAdminContext(browser);
+	const page = await ctx.newPage();
+	try {
+		ruleAId = await createPricingRuleViaApi(page, {
+			modelName: 'e2e-gpt-4o',
+			provider: 'OpenAI',
+			isOverride: false,
+			inputCost: 5.0,
+			outputCost: 15.0,
+		});
+		seedIds.add(ruleAId);
+
+		ruleBId = await createPricingRuleViaApi(page, {
+			modelName: 'e2e-claude-3',
+			provider: 'Anthropic',
+			isOverride: true,
+			inputCost: 8.0,
+			outputCost: 24.0,
+		});
+		seedIds.add(ruleBId);
+	} finally {
+		await ctx.close();
+	}
+});
+
+test.afterAll(async ({ browser }) => {
+	if (seedIds.size === 0) return;
+	const ctx = await newAdminContext(browser);
+	const page = await ctx.newPage();
+	try {
+		const token = await authToken(page);
+		for (const id of seedIds) {
+			await deletePricingRuleViaApi(ctx.request, id, token);
+			seedIds.delete(id);
+		}
+	} finally {
+		await ctx.close();
+	}
+});
+
+test.describe('LLM Pricing — Listing', () => {
+	test('TC-01 listing page renders with data', async ({ authedPage: page }) => {
+		await gotoLlmPricingPage(page);
+
+		await expect(page.getByTestId('llm-observability-model-pricing-page')).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Configuration', level: 1 })).toBeVisible();
+
+		// Tabs
+		const modelCostsTab = page.getByRole('tab', { name: 'Model costs' });
+		await expect(modelCostsTab).toBeVisible();
+		await expect(modelCostsTab).toHaveAttribute('aria-selected', 'true');
+
+		const unpricedTab = page.getByRole('tab', { name: 'Unpriced models' });
+		await expect(unpricedTab).toBeVisible();
+		await expect(unpricedTab).toHaveAttribute('aria-disabled', 'true');
+
+		// Filter bar
+		await expect(page.getByTestId('search-input')).toBeVisible();
+		await expect(page.getByTestId('source-select')).toBeVisible();
+		await expect(page.getByTestId('add-model-cost-btn')).toBeVisible();
+
+		// Table and rows
+		await expect(page.getByTestId('model-costs-table')).toBeVisible();
+		await expect(page.getByTestId(`model-cell-name-${ruleAId}`)).toBeVisible();
+		await expect(page.getByTestId(`model-cell-name-${ruleBId}`)).toBeVisible();
+
+		// Footer
+		await expect(page.getByText(/Showing 2 models/)).toBeVisible();
+	});
+
+	test('TC-02 table columns and source badge render correctly', async ({
+		authedPage: page,
+	}) => {
+		await gotoLlmPricingPage(page);
+
+		// Rule A — auto (isOverride: false)
+		await expect(page.getByTestId(`model-cell-name-${ruleAId}`)).toHaveText('e2e-gpt-4o');
+		await expect(page.getByTestId(`model-cell-canonical-id-${ruleAId}`)).toHaveText(
+			'openai:e2e-gpt-4o',
+		);
+		const badgeA = page.getByTestId(`source-badge-${ruleAId}`);
+		await expect(badgeA).toHaveText('Auto');
+
+		// Rule B — user override (isOverride: true)
+		await expect(page.getByTestId(`model-cell-name-${ruleBId}`)).toHaveText('e2e-claude-3');
+		const badgeB = page.getByTestId(`source-badge-${ruleBId}`);
+		await expect(badgeB).toHaveText('User override');
+
+		// Price cells show $ prefix
+		await expect(page.getByTestId(`price-cell-input-${ruleAId}`)).toHaveText('$5.00');
+		await expect(page.getByTestId(`price-cell-output-${ruleAId}`)).toHaveText('$15.00');
+
+		// Edit button present for each row
+		await expect(page.getByTestId(`edit-rule-${ruleAId}`)).toBeVisible();
+		await expect(page.getByTestId(`edit-rule-${ruleBId}`)).toBeVisible();
+	});
+
+	// NOTE: search/source filtering is now backend-driven — the FE sends `q` /
+	// `source` on the list request and the backend does the filtering (support
+	// pending). These tests therefore assert the request is wired correctly
+	// rather than that rows are filtered client-side. Once the BE honours the
+	// params, add row-level assertions back (rows hidden, "Showing N models").
+	const isListGet = (url: string): boolean => url.includes('llm_pricing_rules');
+
+	test('TC-03 search is server-driven — typing sends the q param to the list request', async ({
+		authedPage: page,
+	}) => {
+		await gotoLlmPricingPage(page);
+
+		// Search text (debounced) is wired into the request as `q`.
+		const byModelReq = page.waitForRequest(
+			(r) =>
+				isListGet(r.url()) &&
+				r.method() === 'GET' &&
+				new URL(r.url()).searchParams.get('q') === 'e2e-gpt',
+		);
+		await page.getByTestId('search-input').fill('e2e-gpt');
+		expect(new URL((await byModelReq).url()).searchParams.get('q')).toBe('e2e-gpt');
+
+		// A different term is passed through verbatim.
+		const byProviderReq = page.waitForRequest(
+			(r) =>
+				isListGet(r.url()) &&
+				r.method() === 'GET' &&
+				new URL(r.url()).searchParams.get('q') === 'anthropic',
+		);
+		await page.getByTestId('search-input').fill('anthropic');
+		expect(new URL((await byProviderReq).url()).searchParams.get('q')).toBe(
+			'anthropic',
+		);
+
+		// Clearing the search drops the `q` param.
+		const clearedReq = page.waitForRequest(
+			(r) =>
+				isListGet(r.url()) &&
+				r.method() === 'GET' &&
+				!new URL(r.url()).searchParams.has('q'),
+		);
+		await page.getByTestId('search-input').fill('');
+		expect(new URL((await clearedReq).url()).searchParams.has('q')).toBe(false);
+	});
+
+	test('TC-04 source filter is server-driven — selecting a source sends the source param', async ({
+		authedPage: page,
+	}) => {
+		await gotoLlmPricingPage(page);
+
+		// Auto-populated → source=auto
+		const autoReq = page.waitForRequest(
+			(r) =>
+				isListGet(r.url()) &&
+				r.method() === 'GET' &&
+				new URL(r.url()).searchParams.get('source') === 'auto',
+		);
+		await page.getByTestId('source-select').click();
+		await page.getByText('Auto-populated').click();
+		expect(new URL((await autoReq).url()).searchParams.get('source')).toBe('auto');
+
+		// User override → source=override
+		const overrideReq = page.waitForRequest(
+			(r) =>
+				isListGet(r.url()) &&
+				r.method() === 'GET' &&
+				new URL(r.url()).searchParams.get('source') === 'override',
+		);
+		await page.getByTestId('source-select').click();
+		await page.getByText('User override').click();
+		expect(new URL((await overrideReq).url()).searchParams.get('source')).toBe(
+			'override',
+		);
+
+		// Source: All → the source param is omitted (default kept out of the URL)
+		const allReq = page.waitForRequest(
+			(r) =>
+				isListGet(r.url()) &&
+				r.method() === 'GET' &&
+				!new URL(r.url()).searchParams.has('source'),
+		);
+		await page.getByTestId('source-select').click();
+		await page.getByText('Source: All').click();
+		expect(new URL((await allReq).url()).searchParams.has('source')).toBe(false);
+	});
+});
+
+// TC-05 is isolated — no seeded data; runs in a standalone describe so it
+// does not inherit the shared beforeAll seed.
+test.describe('LLM Pricing — Empty state', () => {
+	test('TC-05 empty state — zero rules returns empty table', async ({
+		authedPage: page,
+	}) => {
+		// Wait for the list request to complete before asserting the empty state
+		// so the test does not race against the initial fetch.
+		const listResponse = page.waitForResponse(
+			(r) =>
+				r.url().includes('llm_pricing_rules') && r.request().method() === 'GET',
+		);
+		await page.goto(LLM_PRICING_PATH);
+		await page.getByTestId('llm-observability-model-pricing-page').waitFor({ state: 'visible' });
+		await listResponse;
+
+		await expect(page.getByTestId('model-costs-table')).toBeVisible();
+		// No data rows — Ant Table renders its empty placeholder
+		await expect(page.getByText(/Showing 0 models/)).toBeVisible();
+	});
+});

--- a/tests/e2e/tests/llm-pricing/source-radio.spec.ts
+++ b/tests/e2e/tests/llm-pricing/source-radio.spec.ts
@@ -1,0 +1,263 @@
+import { expect, test } from '../../fixtures/auth';
+import {
+	authToken,
+	createPricingRuleViaApi,
+	deletePricingRuleViaApi,
+	gotoLlmPricingPage,
+} from '../../helpers/llm-pricing';
+
+test.describe.configure({ mode: 'serial' });
+
+// Helper — executes in the browser context (Playwright evaluate). TypeScript
+// cannot see browser globals from Node, so we use `any` to avoid DOM-lib deps.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getBorderColor = (el: any): string =>
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(globalThis as any).getComputedStyle(el).borderColor;
+
+test.describe('LLM Pricing — Source radio behaviour', () => {
+	test('TC-15 Override → Auto triggers reset-confirm; Keep cancels it', async ({
+		authedPage: page,
+	}) => {
+		// Auto-populated is disabled in Add mode, so the Override→Auto switch is
+		// only reachable when editing an existing override rule.
+		const ruleId = await createPricingRuleViaApi(page, {
+			modelName: 'e2e-src-switch',
+			provider: 'OpenAI',
+			isOverride: true,
+			inputCost: 25,
+			outputCost: 75,
+		});
+		try {
+			await gotoLlmPricingPage(page);
+			await page.getByTestId(`edit-rule-${ruleId}`).click();
+			await expect(page.getByText('Edit model cost').first()).toBeVisible();
+
+			// Confirm starting state: Override checked
+			await expect(page.getByTestId('drawer-source-override')).toHaveAttribute(
+				'data-state',
+				'checked',
+			);
+
+			// Click Auto — should trigger the reset-confirm dialog
+			await page.getByTestId('drawer-source-auto').click();
+
+			const resetDialog = page.locator(
+				'[role="dialog"][aria-label="Reset to default pricing"]',
+			);
+			await expect(resetDialog).toBeVisible();
+			await expect(page.getByTestId('drawer-reset-keep-btn')).toBeVisible();
+			await expect(page.getByTestId('drawer-reset-confirm-btn')).toBeVisible();
+
+			// While confirm is showing, the switch has NOT been applied yet
+			await expect(page.getByTestId('drawer-source-auto')).toHaveAttribute(
+				'data-state',
+				'unchecked',
+			);
+			await expect(page.getByTestId('drawer-source-override')).toHaveAttribute(
+				'data-state',
+				'checked',
+			);
+
+			// Click Keep — dialog dismisses without changing the radio
+			await page.getByTestId('drawer-reset-keep-btn').click();
+			await expect(resetDialog).not.toBeVisible();
+			await expect(page.getByTestId('drawer-source-override')).toHaveAttribute(
+				'data-state',
+				'checked',
+			);
+			await expect(
+				page.locator('[data-testid="drawer-input-cost"] input'),
+			).toHaveValue('25');
+			await expect(
+				page.locator('[data-testid="drawer-output-cost"] input'),
+			).toHaveValue('75');
+		} finally {
+			await page
+				.getByTestId('drawer-cancel-btn')
+				.click()
+				.catch(() => undefined);
+			const token = await authToken(page);
+			await deletePricingRuleViaApi(page.request, ruleId, token);
+		}
+	});
+
+	test('TC-16 Override → Auto then Reset clears values and switches to auto mode', async ({
+		authedPage: page,
+	}) => {
+		// Reachable only in Edit mode (Auto is disabled when adding a new model).
+		const ruleId = await createPricingRuleViaApi(page, {
+			modelName: 'e2e-src-reset',
+			provider: 'OpenAI',
+			isOverride: true,
+			inputCost: 25,
+			outputCost: 75,
+		});
+		try {
+			await gotoLlmPricingPage(page);
+			await page.getByTestId(`edit-rule-${ruleId}`).click();
+			await expect(page.getByText('Edit model cost').first()).toBeVisible();
+
+			await page.getByTestId('drawer-source-auto').click();
+			const resetDialog = page.locator(
+				'[role="dialog"][aria-label="Reset to default pricing"]',
+			);
+			await expect(resetDialog).toBeVisible();
+
+			await page.getByTestId('drawer-reset-confirm-btn').click();
+			await expect(resetDialog).not.toBeVisible();
+
+			// Radio has switched to Auto
+			await expect(page.getByTestId('drawer-source-auto')).toHaveAttribute(
+				'data-state',
+				'checked',
+			);
+			await expect(page.getByTestId('drawer-source-override')).toHaveAttribute(
+				'data-state',
+				'unchecked',
+			);
+
+			// Pricing inputs are now read-only
+			await expect(
+				page.locator('[data-testid="drawer-input-cost"] input'),
+			).toBeDisabled();
+			await expect(
+				page.locator('[data-testid="drawer-output-cost"] input'),
+			).toBeDisabled();
+		} finally {
+			await page
+				.getByTestId('drawer-cancel-btn')
+				.click()
+				.catch(() => undefined);
+			const token = await authToken(page);
+			await deletePricingRuleViaApi(page.request, ruleId, token);
+		}
+	});
+
+	test('TC-17 Auto → Override switching works without confirm', async ({
+		authedPage: page,
+	}) => {
+		const ruleId = await createPricingRuleViaApi(page, {
+			modelName: 'e2e-auto-switch',
+			provider: 'OpenAI',
+			isOverride: false,
+			inputCost: 1.0,
+			outputCost: 4.0,
+		});
+		try {
+			await gotoLlmPricingPage(page);
+			await page.getByTestId(`edit-rule-${ruleId}`).click();
+			await expect(page.getByText('Edit model cost').first()).toBeVisible();
+
+			await expect(page.getByTestId('drawer-source-auto')).toHaveAttribute(
+				'data-state',
+				'checked',
+			);
+			await expect(
+				page.locator('[data-testid="drawer-input-cost"] input'),
+			).toBeDisabled();
+
+			// Click Override — no reset-confirm should appear
+			await page.getByTestId('drawer-source-override').click();
+			await expect(
+				page.locator('[role="dialog"][aria-label="Reset to default pricing"]'),
+			).not.toBeVisible();
+
+			await expect(page.getByTestId('drawer-source-override')).toHaveAttribute(
+				'data-state',
+				'checked',
+			);
+			await expect(
+				page.locator('[data-testid="drawer-input-cost"] input'),
+			).toBeEnabled();
+		} finally {
+			await page
+				.getByTestId('drawer-cancel-btn')
+				.click()
+				.catch(() => undefined);
+			const token = await authToken(page);
+			await deletePricingRuleViaApi(page.request, ruleId, token);
+		}
+	});
+
+	test('TC-18 source radio card highlight — checked state gets tinted border', async ({
+		authedPage: page,
+	}) => {
+		const ruleId = await createPricingRuleViaApi(page, {
+			modelName: 'e2e-border-check',
+			provider: 'OpenAI',
+			isOverride: true,
+			inputCost: 1.0,
+			outputCost: 4.0,
+		});
+		try {
+			await gotoLlmPricingPage(page);
+			await page.getByTestId(`edit-rule-${ruleId}`).click();
+			await expect(page.getByText('Edit model cost').first()).toBeVisible();
+
+			// Override card is checked — its border-color must be non-transparent
+			const overrideCard = page.locator('.source-radio--override');
+			await expect(
+				overrideCard.locator('button[data-state="checked"]'),
+			).toBeVisible();
+			const overrideBorder = await overrideCard.evaluate(getBorderColor);
+			expect(overrideBorder).not.toBe('transparent');
+			expect(overrideBorder).not.toBe('rgba(0, 0, 0, 0)');
+
+			// Auto card is unchecked — its border-color should be transparent
+			const autoCard = page.locator('.source-radio--auto');
+			await expect(
+				autoCard.locator('button[data-state="unchecked"]'),
+			).toBeVisible();
+			const autoBorder = await autoCard.evaluate(getBorderColor);
+			expect(autoBorder).toBe('rgba(0, 0, 0, 0)');
+
+			// Switch to Auto and confirm reset
+			await page.getByTestId('drawer-source-auto').click();
+			const resetDialog = page.locator(
+				'[role="dialog"][aria-label="Reset to default pricing"]',
+			);
+			await expect(resetDialog).toBeVisible();
+			await page.getByTestId('drawer-reset-confirm-btn').click();
+			await expect(resetDialog).not.toBeVisible();
+
+			// Now Auto card has the tinted border; Override card is transparent
+			const autoBorderAfter = await autoCard.evaluate(getBorderColor);
+			expect(autoBorderAfter).not.toBe('transparent');
+			expect(autoBorderAfter).not.toBe('rgba(0, 0, 0, 0)');
+
+			const overrideBorderAfter = await overrideCard.evaluate(getBorderColor);
+			expect(overrideBorderAfter).toBe('rgba(0, 0, 0, 0)');
+		} finally {
+			await page
+				.getByTestId('drawer-cancel-btn')
+				.click()
+				.catch(() => undefined);
+			const token = await authToken(page);
+			await deletePricingRuleViaApi(page.request, ruleId, token);
+		}
+	});
+
+	test('TC-19 unchecked radio dot is visible — border not invisible against drawer surface', async ({
+		authedPage: page,
+	}) => {
+		await gotoLlmPricingPage(page);
+		await page.getByTestId('add-model-cost-btn').click();
+		await expect(page.getByText('Add model cost').first()).toBeVisible();
+
+		// In add mode, Override is checked and Auto is unchecked
+		const autoBtn = page.getByTestId('drawer-source-auto');
+		await expect(autoBtn).toHaveAttribute('data-state', 'unchecked');
+
+		// The CSS fix sets --radio-group-item-border-color: var(--bg-slate-200)
+		// on .source-radio-group; assert the computed border is not invisible.
+		const borderColor = await autoBtn.evaluate(getBorderColor);
+		expect(borderColor).not.toBe('transparent');
+		expect(borderColor).not.toBe('rgba(0, 0, 0, 0)');
+
+		// Auto label text is visible alongside the dot
+		await expect(page.getByText('Auto-populated').first()).toBeVisible();
+
+		await page.getByTestId('drawer-cancel-btn').click();
+	});
+});


### PR DESCRIPTION
## Stack: 5 of 5

> ⏸️ **Closed for now** — this test-suite PR is held back and will be re-opened last, on top of `feat/llm-pricing-search-and-dropdown`, once the feature PRs (1–4) are settled.

| # | PR | Branch | Base |
|---|----|--------|------|
| 1 | Foundation — route, permission & page shell | `feat/llm-pricing-foundation` | `main` |
| 2 | Listing page + table | `feat/llm-pricing-listing-2` | `feat/llm-pricing-foundation` |
| 3 | Cost drawer + wiring | `feat/llm-pricing-drawer-3` | `feat/llm-pricing-listing-2` |
| 4 | Search + source filter & feature gate | `feat/llm-pricing-search-and-dropdown` | `feat/llm-pricing-drawer-3` |
| 5 | Test suite | `feat/llm-pricing-e2e-4` | `feat/llm-pricing-search-and-dropdown` |

## What this PR does

Adds the **complete test suite** — grouped here so the production code in PRs 1–4 stays test-free.

**Jest unit** — `__tests__/utils.test.ts`, `drawerUtils.test.ts`, `ModelCostDrawer.test.tsx`, `LLMObservabilityModelPricing.test.tsx`.
**Playwright e2e** — `tests/llm-pricing/{listing,source-radio,drawer-add,drawer-edit,delete}.spec.ts` + `helpers/llm-pricing.ts`.
**Test infra** — `tests/test-utils.tsx` wraps the render tree in `TooltipProvider`.

> When re-opened, this PR should also cover the search + source filtering added in PR 4.

## Verification
- Test files unchanged by the reorder/rename. Suites run in CI against the full stack.
