### PR TITLE
chore: added fix for infinite query call on services page

### DIFF
--- a/frontend/src/container/MetricsApplication/Tabs/Overview/ServiceOverview.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview/ServiceOverview.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
-import { Skeleton } from 'antd';
 import { ENTITY_VERSION_V4 } from 'constants/app';
 import { FeatureKeys } from 'constants/features';
 import { PANEL_TYPES } from 'constants/queryBuilder';
@@ -124,24 +123,14 @@ function ServiceOverview({
 			/>
 			<Card data-testid="service_latency">
 				<GraphContainer>
-					{topLevelOperationsIsLoading && (
-						<Skeleton
-							style={{
-								height: '100%',
-								padding: '16px',
-							}}
-						/>
-					)}
-					{!topLevelOperationsIsLoading && (
-						<Graph
-							onDragSelect={onDragSelect}
-							widget={latencyWidget}
-							onClickHandler={handleGraphClick('Service')}
-							isQueryEnabled={isQueryEnabled}
-							version={ENTITY_VERSION_V4}
-							enableDrillDown={SERVICE_DETAIL_DRILLDOWN_ENABLED}
-						/>
-					)}
+					<Graph
+						onDragSelect={onDragSelect}
+						widget={latencyWidget}
+						onClickHandler={handleGraphClick('Service')}
+						isQueryEnabled={isQueryEnabled}
+						version={ENTITY_VERSION_V4}
+						enableDrillDown={SERVICE_DETAIL_DRILLDOWN_ENABLED}
+					/>
 				</GraphContainer>
 			</Card>
 		</>

--- a/frontend/src/container/MetricsApplication/Tabs/Overview/TopLevelOperations.tsx
+++ b/frontend/src/container/MetricsApplication/Tabs/Overview/TopLevelOperations.tsx
@@ -1,4 +1,3 @@
-import { Skeleton } from 'antd';
 import { Typography } from '@signozhq/ui/typography';
 import axios from 'axios';
 import { SOMETHING_WENT_WRONG } from 'constants/api';
@@ -29,24 +28,14 @@ function TopLevelOperation({
 				</Typography>
 			) : (
 				<GraphContainer>
-					{topLevelOperationsIsLoading && (
-						<Skeleton
-							style={{
-								height: '100%',
-								padding: '16px',
-							}}
-						/>
-					)}
-					{!topLevelOperationsIsLoading && (
-						<Graph
-							widget={widget}
-							onClickHandler={handleGraphClick(opName)}
-							onDragSelect={onDragSelect}
-							isQueryEnabled={!topLevelOperationsIsLoading}
-							version={ENTITY_VERSION_V4}
-							enableDrillDown={SERVICE_DETAIL_DRILLDOWN_ENABLED}
-						/>
-					)}
+					<Graph
+						widget={widget}
+						onClickHandler={handleGraphClick(opName)}
+						onDragSelect={onDragSelect}
+						isQueryEnabled={!topLevelOperationsIsLoading}
+						version={ENTITY_VERSION_V4}
+						enableDrillDown={SERVICE_DETAIL_DRILLDOWN_ENABLED}
+					/>
 				</GraphContainer>
 			)}
 		</Card>


### PR DESCRIPTION
## Summary

Fixes an infinite `query_range` fetch/cancel loop on APM **service detail** pages. Opening a panel's **View (drilldown)** — e.g. the Latency panel on `/services/:name` — caused `query_range` to be fired and immediately cancelled in a tight loop (~16 req/s) that never settled, freezing the panel and hammering the backend. Most reproducible on the **second** open of the View modal. Dashboards were not affected.

> Suggested title: `fix(apm): stop infinite query_range loop when opening a service panel's drilldown`

## Root cause

A render feedback loop unique to the service Overview pages, formed by three pieces:

1. The panel was unmounted behind a loading gate — `{!topLevelOperationsIsLoading && <Graph/>}`. `topLevelOperations` is keyed on `[servicename, minTime, maxTime]`, so any time-window change re-keys it and flips `isLoading` → the panel (and its open drilldown) **unmounts**.
2. Opening/remounting the drilldown re-seeds the composite query via `redirectWithQueryBuilderData`, which mints a fresh `id: uuid()` every call → `stagedQuery.id` changes.
3. `useSyncTimeOnStagedQueryChange` dispatches `UpdateTimeInterval(selectedTime)` on every `stagedQuery.id` change → moves `minTime/maxTime`.

These close a cycle:

```text
open drilldown → seed (new uuid) → stagedQuery.id changes
→ useSyncTimeOnStagedQueryChange → UpdateTimeInterval → minTime/maxTime change
→ topLevelOperations refetch → isLoading=true → <Graph/> UNMOUNTS → REMOUNTS
→ drilldown re-seeds (new uuid) → … ↺
```

Each turn re-keyed the panel's `query_range`, so React Query cancelled the in-flight request and re-issued it. Dashboards render panels persistently (no time-keyed loading gate around the mount), so the seed runs once and it never loops.

## Fix

Render `<Graph/>` **unconditionally** and let its existing `isQueryEnabled` prop gate the query; `Graph` already handles its own loading and error states. With the panel always mounted, the drilldown seeds once, `stagedQuery.id` stays stable, and the unmount→re-seed link that closed the loop is gone.

- `ServiceOverview.tsx` — removed the `topLevelOperationsIsLoading` skeleton/gate around the Latency panel.
- `TopLevelOperations.tsx` — same for RPS / Error-rate (error branch preserved).

No changes to shared QueryBuilder / drilldown / dashboard code — the fix is isolated to the two service-page components.

## Testing

- Repro: service page → open a panel's **View** → close → reopen.
  - **Before:** continuous `query_range` fired + cancelled, never settles.
  - **After:** settles immediately — 0 `query_range` in the trailing 3s, 0 spurious `useSyncTimeOnStagedQueryChange` dispatches.
- Verified Latency, RPS, and Error-rate panels, plus drag-select and time-range changes.
- `tsgo` ✓ · `oxlint` ✓ · `build` ✓.

## Notes

- First-load only: while `topLevelOperations` is in flight the panel query is disabled (`idle` in React Query v3, not `loading`), so the panel briefly shows its header without a skeleton, then its own skeleton → data. Subsequent time changes are smooth.
- Follow-up (not in this PR): service widgets mint `id: uuid()` inside `useMemo` — stable today but worth hardening.

## Issues Closed
Closes https://github.com/SigNoz/engineering-pod/issues/5391
