### PR TITLE
fix(alerts): missing fields when duplicating via edit alert

### DIFF
--- a/frontend/src/types/api/alerts/convert.ts
+++ b/frontend/src/types/api/alerts/convert.ts
@@ -69,19 +69,24 @@ function stripUndefinedLabels(
 export function toPostableRuleDTO(
 	local: PostableAlertRuleV2,
 ): RuletypesPostableRuleDTO {
-	const payload = {
+	const payload: Record<keyof RuletypesPostableRuleDTO, any> = {
 		alert: local.alert,
 		alertType: toAlertTypeDTO(local.alertType),
 		ruleType: toRuleTypeDTO(local.ruleType),
 		condition: local.condition,
 		annotations: local.annotations,
 		labels: stripUndefinedLabels(local.labels),
+		evalWindow: (local as unknown as RuletypesPostableRuleDTO).evalWindow,
+		frequency: (local as unknown as RuletypesPostableRuleDTO).frequency,
+		preferredChannels: (local as unknown as RuletypesPostableRuleDTO)
+			.preferredChannels,
 		notificationSettings: local.notificationSettings,
 		evaluation: local.evaluation,
 		schemaVersion: local.schemaVersion,
 		source: local.source,
 		version: local.version,
 		disabled: local.disabled,
+		description: (local as unknown as RuletypesPostableRuleDTO).description,
 	};
 	return payload as unknown as RuletypesPostableRuleDTO;
 }
@@ -89,7 +94,7 @@ export function toPostableRuleDTO(
 export function toPostableRuleDTOFromAlertDef(
 	local: AlertDef,
 ): RuletypesPostableRuleDTO {
-	const payload = {
+	const payload: Record<keyof RuletypesPostableRuleDTO, any> = {
 		alert: local.alert,
 		alertType: toAlertTypeDTO(local.alertType),
 		ruleType: toRuleTypeDTO(local.ruleType),
@@ -99,11 +104,16 @@ export function toPostableRuleDTOFromAlertDef(
 		evalWindow: local.evalWindow,
 		frequency: local.frequency,
 		preferredChannels: local.preferredChannels,
+		notificationSettings: (local as unknown as RuletypesPostableRuleDTO)
+			.notificationSettings,
+		evaluation: (local as unknown as RuletypesPostableRuleDTO).evaluation,
+		schemaVersion: (local as unknown as RuletypesPostableRuleDTO).schemaVersion,
 		source: local.source,
 		version: local.version,
 		disabled: local.disabled,
+		description: (local as unknown as RuletypesPostableRuleDTO).description,
 	};
-	return payload as unknown as RuletypesPostableRuleDTO;
+	return payload;
 }
 
 export function fromRuleDTOToPostableRuleV2(


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Ensure the `toPostableRuleDTO` and `toPostableRuleDTOFromAlertDef` pass all the fields necessary for the `RuletypesPostableRuleDTO` type.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

https://github.com/user-attachments/assets/691482ee-9e91-405f-b434-a9f5ba3a0bfd


After:

https://github.com/user-attachments/assets/5a1d364f-d6bc-4b07-b424-092ce17a4f88

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Fixes https://github.com/SigNoz/engineering-pod/issues/5387

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

Introduced at https://github.com/SigNoz/signoz/pull/10968, while migrating alerts to use generated APIs.

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

The `AlertHeader` component is shared by V1 and V2, the implementation for duplicate uses the `toPostableRuleDTOFromAlertDef` to convert the types but was missing important fields for V2 that are not present on V1.

#### Fix Strategy
> How does this PR address the root cause?

Add the missing fields.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Enforced by type
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Alerts - V2
- Potential regressions: Unknown.
- Rollback plan: Revert this commit.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed the issue that was not allowing to duplicate the alert V2 while editing the alert. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
