### PR TITLE
feat(spanmapper): add preview endpoint for span attribute mapping

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -7240,6 +7240,49 @@ components:
       - operation
       - priority
       type: object
+    SpantypesSpanMappingPreviewGroup:
+      properties:
+        group:
+          $ref: '#/components/schemas/SpantypesPostableSpanMapperGroup'
+        mappers:
+          items:
+            $ref: '#/components/schemas/SpantypesPostableSpanMapper'
+          nullable: true
+          type: array
+      required:
+      - group
+      type: object
+    SpantypesSpanMappingPreviewRequest:
+      properties:
+        groups:
+          items:
+            $ref: '#/components/schemas/SpantypesSpanMappingPreviewGroup'
+          nullable: true
+          type: array
+        span:
+          $ref: '#/components/schemas/SpantypesSpanMappingPreviewSpan'
+      required:
+      - span
+      - groups
+      type: object
+    SpantypesSpanMappingPreviewResponse:
+      properties:
+        span:
+          $ref: '#/components/schemas/SpantypesSpanMappingPreviewSpan'
+      required:
+      - span
+      type: object
+    SpantypesSpanMappingPreviewSpan:
+      properties:
+        attributes:
+          additionalProperties: {}
+          nullable: true
+          type: object
+        resource:
+          additionalProperties: {}
+          nullable: true
+          type: object
+      type: object
     SpantypesUpdatableSpanMapper:
       properties:
         config:
@@ -12795,6 +12838,69 @@ paths:
       - tokenizer:
         - ADMIN
       summary: Update a span mapper
+      tags:
+      - spanmapper
+  /api/v1/span_mapper_groups/preview:
+    post:
+      deprecated: false
+      description: Previews how attribute mappings would transform a sample span.
+      operationId: PreviewSpanMapping
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SpantypesSpanMappingPreviewRequest'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: '#/components/schemas/SpantypesSpanMappingPreviewResponse'
+                  status:
+                    type: string
+                required:
+                - status
+                - data
+                type: object
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Not Found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RenderErrorResponse'
+          description: Internal Server Error
+      security:
+      - api_key:
+        - VIEWER
+      - tokenizer:
+        - VIEWER
+      summary: Preview span attribute mapping against a sample span
       tags:
       - spanmapper
   /api/v1/stats:

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -8492,6 +8492,57 @@ export interface SpantypesSpanMapperDTO {
 	updatedBy?: string;
 }
 
+export interface SpantypesSpanMappingPreviewGroupDTO {
+	group: SpantypesPostableSpanMapperGroupDTO;
+	/**
+	 * @type array,null
+	 */
+	mappers?: SpantypesPostableSpanMapperDTO[] | null;
+}
+
+export type SpantypesSpanMappingPreviewSpanDTOAttributesAnyOf = {
+	[key: string]: unknown;
+};
+
+/**
+ * @nullable
+ */
+export type SpantypesSpanMappingPreviewSpanDTOAttributes =
+	SpantypesSpanMappingPreviewSpanDTOAttributesAnyOf | null;
+
+export type SpantypesSpanMappingPreviewSpanDTOResourceAnyOf = {
+	[key: string]: unknown;
+};
+
+/**
+ * @nullable
+ */
+export type SpantypesSpanMappingPreviewSpanDTOResource =
+	SpantypesSpanMappingPreviewSpanDTOResourceAnyOf | null;
+
+export interface SpantypesSpanMappingPreviewSpanDTO {
+	/**
+	 * @type object,null
+	 */
+	attributes?: SpantypesSpanMappingPreviewSpanDTOAttributes;
+	/**
+	 * @type object,null
+	 */
+	resource?: SpantypesSpanMappingPreviewSpanDTOResource;
+}
+
+export interface SpantypesSpanMappingPreviewRequestDTO {
+	/**
+	 * @type array,null
+	 */
+	groups: SpantypesSpanMappingPreviewGroupDTO[] | null;
+	span: SpantypesSpanMappingPreviewSpanDTO;
+}
+
+export interface SpantypesSpanMappingPreviewResponseDTO {
+	span: SpantypesSpanMappingPreviewSpanDTO;
+}
+
 export interface SpantypesUpdatableSpanMapperDTO {
 	config?: SpantypesSpanMapperConfigDTO;
 	/**
@@ -9798,6 +9849,14 @@ export type UpdateSpanMapperPathParameters = {
 	groupId: string;
 	mapperId: string;
 };
+export type PreviewSpanMapping200 = {
+	data: SpantypesSpanMappingPreviewResponseDTO;
+	/**
+	 * @type string
+	 */
+	status: string;
+};
+
 export type GetStats200Data = { [key: string]: unknown };
 
 export type GetStats200 = {

--- a/frontend/src/api/generated/services/spanmapper/index.ts
+++ b/frontend/src/api/generated/services/spanmapper/index.ts
@@ -27,9 +27,11 @@ import type {
 	ListSpanMapperGroupsParams,
 	ListSpanMappers200,
 	ListSpanMappersPathParameters,
+	PreviewSpanMapping200,
 	RenderErrorResponseDTO,
 	SpantypesPostableSpanMapperDTO,
 	SpantypesPostableSpanMapperGroupDTO,
+	SpantypesSpanMappingPreviewRequestDTO,
 	SpantypesUpdatableSpanMapperDTO,
 	SpantypesUpdatableSpanMapperGroupDTO,
 	UpdateSpanMapperGroupPathParameters,
@@ -779,4 +781,87 @@ export const useUpdateSpanMapper = <
 	TContext
 > => {
 	return useMutation(getUpdateSpanMapperMutationOptions(options));
+};
+/**
+ * Previews how attribute mappings would transform a sample span.
+ * @summary Preview span attribute mapping against a sample span
+ */
+export const previewSpanMapping = (
+	spantypesSpanMappingPreviewRequestDTO?: BodyType<SpantypesSpanMappingPreviewRequestDTO>,
+	signal?: AbortSignal,
+) => {
+	return GeneratedAPIInstance<PreviewSpanMapping200>({
+		url: `/api/v1/span_mapper_groups/preview`,
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		data: spantypesSpanMappingPreviewRequestDTO,
+		signal,
+	});
+};
+
+export const getPreviewSpanMappingMutationOptions = <
+	TError = ErrorType<RenderErrorResponseDTO>,
+	TContext = unknown,
+>(options?: {
+	mutation?: UseMutationOptions<
+		Awaited<ReturnType<typeof previewSpanMapping>>,
+		TError,
+		{ data?: BodyType<SpantypesSpanMappingPreviewRequestDTO> },
+		TContext
+	>;
+}): UseMutationOptions<
+	Awaited<ReturnType<typeof previewSpanMapping>>,
+	TError,
+	{ data?: BodyType<SpantypesSpanMappingPreviewRequestDTO> },
+	TContext
+> => {
+	const mutationKey = ['previewSpanMapping'];
+	const { mutation: mutationOptions } = options
+		? options.mutation &&
+			'mutationKey' in options.mutation &&
+			options.mutation.mutationKey
+			? options
+			: { ...options, mutation: { ...options.mutation, mutationKey } }
+		: { mutation: { mutationKey } };
+
+	const mutationFn: MutationFunction<
+		Awaited<ReturnType<typeof previewSpanMapping>>,
+		{ data?: BodyType<SpantypesSpanMappingPreviewRequestDTO> }
+	> = (props) => {
+		const { data } = props ?? {};
+
+		return previewSpanMapping(data);
+	};
+
+	return { mutationFn, ...mutationOptions };
+};
+
+export type PreviewSpanMappingMutationResult = NonNullable<
+	Awaited<ReturnType<typeof previewSpanMapping>>
+>;
+export type PreviewSpanMappingMutationBody =
+	| BodyType<SpantypesSpanMappingPreviewRequestDTO>
+	| undefined;
+export type PreviewSpanMappingMutationError = ErrorType<RenderErrorResponseDTO>;
+
+/**
+ * @summary Preview span attribute mapping against a sample span
+ */
+export const usePreviewSpanMapping = <
+	TError = ErrorType<RenderErrorResponseDTO>,
+	TContext = unknown,
+>(options?: {
+	mutation?: UseMutationOptions<
+		Awaited<ReturnType<typeof previewSpanMapping>>,
+		TError,
+		{ data?: BodyType<SpantypesSpanMappingPreviewRequestDTO> },
+		TContext
+	>;
+}): UseMutationResult<
+	Awaited<ReturnType<typeof previewSpanMapping>>,
+	TError,
+	{ data?: BodyType<SpantypesSpanMappingPreviewRequestDTO> },
+	TContext
+> => {
+	return useMutation(getPreviewSpanMappingMutationOptions(options));
 };

--- a/pkg/apiserver/signozapiserver/spanmapper.go
+++ b/pkg/apiserver/signozapiserver/spanmapper.go
@@ -51,6 +51,26 @@ func (provider *provider) addSpanMapperRoutes(router *mux.Router) error {
 		return err
 	}
 
+	if err := router.Handle("/api/v1/span_mapper_groups/preview", handler.New(
+		provider.authzMiddleware.ViewAccess(provider.spanMapperHandler.PreviewMapping),
+		handler.OpenAPIDef{
+			ID:                  "PreviewSpanMapping",
+			Tags:                []string{"spanmapper"},
+			Summary:             "Preview span attribute mapping against a sample span",
+			Description:         "Previews how attribute mappings would transform a sample span.",
+			Request:             new(spantypes.SpanMappingPreviewRequest),
+			RequestContentType:  "application/json",
+			Response:            new(spantypes.SpanMappingPreviewResponse),
+			ResponseContentType: "application/json",
+			SuccessStatusCode:   http.StatusOK,
+			ErrorStatusCodes:    []int{http.StatusBadRequest, http.StatusNotFound},
+			Deprecated:          false,
+			SecuritySchemes:     newSecuritySchemes(types.RoleViewer),
+		},
+	)).Methods(http.MethodPost).GetError(); err != nil {
+		return err
+	}
+
 	if err := router.Handle("/api/v1/span_mapper_groups/{groupId}", handler.New(
 		provider.authzMiddleware.AdminAccess(provider.spanMapperHandler.UpdateGroup),
 		handler.OpenAPIDef{

--- a/pkg/modules/spanmapper/implspanmapper/handler.go
+++ b/pkg/modules/spanmapper/implspanmapper/handler.go
@@ -273,6 +273,35 @@ func (h *handler) DeleteMapper(rw http.ResponseWriter, r *http.Request) {
 	render.Success(rw, http.StatusNoContent, nil)
 }
 
+// PreviewMapping handles POST /api/v1/span_mapper_groups/preview.
+// used to get preview of attributes/resources after remapping.
+func (h *handler) PreviewMapping(rw http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	claims, err := authtypes.ClaimsFromContext(ctx)
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	orgID := valuer.MustNewUUID(claims.OrgID)
+
+	req := new(spantypes.SpanMappingPreviewRequest)
+	if err := binding.JSON.BindBody(r.Body, req); err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	result, err := h.module.PreviewMapping(ctx, orgID, req)
+	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	render.Success(rw, http.StatusOK, result)
+}
+
 // groupIDFromPath extracts and validates the {id} or {groupId} path variable.
 func groupIDFromPath(r *http.Request) (valuer.UUID, error) {
 	vars := mux.Vars(r)

--- a/pkg/modules/spanmapper/implspanmapper/module.go
+++ b/pkg/modules/spanmapper/implspanmapper/module.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/modules/spanmapper"
 	"github.com/SigNoz/signoz/pkg/query-service/agentConf"
 	"github.com/SigNoz/signoz/pkg/types/opamptypes"
@@ -100,6 +101,87 @@ func (module *module) DeleteMapper(ctx context.Context, orgID, groupID, id value
 	}
 	agentConf.NotifyConfigUpdate(ctx)
 	return nil
+}
+
+// PreviewMapping runs the sample span through the request's groups (in order)
+// and returns the transformed attribute and resource maps.
+func (module *module) PreviewMapping(ctx context.Context, orgID valuer.UUID, req *spantypes.SpanMappingPreviewRequest) (*spantypes.SpanMappingPreviewResponse, error) {
+	if len(req.Span.Attributes) == 0 && len(req.Span.Resource) == 0 {
+		return nil, errors.New(errors.TypeInvalidInput, spantypes.ErrCodeMappingInvalidInput, "'span' must contain attributes or resource")
+	}
+
+	groups, err := module.resolvePreviewGroups(ctx, orgID, req)
+	if err != nil {
+		return nil, err
+	}
+
+	outResource, outSpan := spantypes.SimulateMappingForAttributes(groups, req.Span.Resource, req.Span.Attributes)
+
+	return &spantypes.SpanMappingPreviewResponse{
+		Span: spantypes.SpanMappingPreviewSpan{Attributes: outSpan, Resource: outResource},
+	}, nil
+}
+
+// resolvePreviewGroups builds the ordered groups to simulate. Each group's meta
+// comes from the payload; its mappers come from the payload when provided, else
+// from the saved group with the same name.
+func (module *module) resolvePreviewGroups(ctx context.Context, orgID valuer.UUID, req *spantypes.SpanMappingPreviewRequest) ([]*spantypes.SpanMapperGroupWithMappers, error) {
+	var savedByName map[string]*spantypes.SpanMapperGroup
+
+	out := make([]*spantypes.SpanMapperGroupWithMappers, 0, len(req.Groups))
+	for _, spec := range req.Groups {
+		group := &spantypes.SpanMapperGroup{
+			OrgID:     orgID,
+			Name:      spec.Group.Name,
+			Condition: spec.Group.Condition,
+			Enabled:   spec.Group.Enabled,
+		}
+
+		var mappers []*spantypes.SpanMapper
+		if spec.Mappers != nil {
+			mappers = make([]*spantypes.SpanMapper, 0, len(*spec.Mappers))
+			for _, pm := range *spec.Mappers {
+				mappers = append(mappers, &spantypes.SpanMapper{
+					Name:         pm.Name,
+					FieldContext: pm.FieldContext,
+					Config:       pm.Config,
+					Enabled:      pm.Enabled,
+				})
+			}
+		} else {
+			if savedByName == nil {
+				saved, err := module.savedGroupsByName(ctx, orgID)
+				if err != nil {
+					return nil, err
+				}
+				savedByName = saved
+			}
+			saved, ok := savedByName[spec.Group.Name]
+			if !ok {
+				return nil, errors.Newf(errors.TypeInvalidInput, spantypes.ErrCodeMappingGroupNotFound, "no saved group named %q to load mappers from; send 'mappers' for new or edited groups", spec.Group.Name)
+			}
+			loaded, err := module.store.ListMappers(ctx, orgID, saved.ID)
+			if err != nil {
+				return nil, err
+			}
+			mappers = loaded
+		}
+
+		out = append(out, &spantypes.SpanMapperGroupWithMappers{Group: group, Mappers: mappers})
+	}
+	return out, nil
+}
+
+func (module *module) savedGroupsByName(ctx context.Context, orgID valuer.UUID) (map[string]*spantypes.SpanMapperGroup, error) {
+	groups, err := module.store.ListGroups(ctx, orgID, &spantypes.ListSpanMapperGroupsQuery{})
+	if err != nil {
+		return nil, err
+	}
+	byName := make(map[string]*spantypes.SpanMapperGroup, len(groups))
+	for _, g := range groups {
+		byName[g.Name] = g
+	}
+	return byName, nil
 }
 
 func (module *module) AgentFeatureType() agentConf.AgentFeatureType {

--- a/pkg/modules/spanmapper/implspanmapper/module_test.go
+++ b/pkg/modules/spanmapper/implspanmapper/module_test.go
@@ -1,0 +1,125 @@
+package implspanmapper
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/types/spantypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeStore is a minimal SpanMapperStore for previewing: only ListGroups and
+// ListMappers carry data; the rest are unused by PreviewMapping.
+type fakeStore struct {
+	groups  []*spantypes.SpanMapperGroup
+	mappers map[string][]*spantypes.SpanMapper
+}
+
+func (f *fakeStore) ListGroups(_ context.Context, _ valuer.UUID, _ *spantypes.ListSpanMapperGroupsQuery) ([]*spantypes.SpanMapperGroup, error) {
+	return f.groups, nil
+}
+
+func (f *fakeStore) ListMappers(_ context.Context, _, groupID valuer.UUID) ([]*spantypes.SpanMapper, error) {
+	return f.mappers[groupID.StringValue()], nil
+}
+
+func (f *fakeStore) GetGroup(context.Context, valuer.UUID, valuer.UUID) (*spantypes.SpanMapperGroup, error) {
+	return nil, nil
+}
+func (f *fakeStore) CreateGroup(context.Context, *spantypes.SpanMapperGroup) error { return nil }
+func (f *fakeStore) UpdateGroup(context.Context, *spantypes.SpanMapperGroup) error { return nil }
+func (f *fakeStore) DeleteGroup(context.Context, valuer.UUID, valuer.UUID) error   { return nil }
+func (f *fakeStore) GetMapper(context.Context, valuer.UUID, valuer.UUID, valuer.UUID) (*spantypes.SpanMapper, error) {
+	return nil, nil
+}
+func (f *fakeStore) CreateMapper(context.Context, *spantypes.SpanMapper) error { return nil }
+func (f *fakeStore) UpdateMapper(context.Context, *spantypes.SpanMapper) error { return nil }
+func (f *fakeStore) DeleteMapper(context.Context, valuer.UUID, valuer.UUID, valuer.UUID) error {
+	return nil
+}
+
+func postableGroup(name string, attrCond []string) spantypes.PostableSpanMapperGroup {
+	return spantypes.PostableSpanMapperGroup{
+		Name:      name,
+		Condition: spantypes.SpanMapperGroupCondition{Attributes: attrCond},
+		Enabled:   true,
+	}
+}
+
+func postableMapper(target, sourceKey string) spantypes.PostableSpanMapper {
+	return spantypes.PostableSpanMapper{
+		Name:         target,
+		FieldContext: spantypes.FieldContextSpanAttribute,
+		Config: spantypes.SpanMapperConfig{Sources: []spantypes.SpanMapperSource{
+			{Key: sourceKey, Context: spantypes.FieldContextSpanAttribute, Operation: spantypes.SpanMapperOperationCopy, Priority: 1},
+		}},
+		Enabled: true,
+	}
+}
+
+func savedMapper(target, sourceKey string) *spantypes.SpanMapper {
+	m := postableMapper(target, sourceKey)
+	return &spantypes.SpanMapper{Name: m.Name, FieldContext: m.FieldContext, Config: m.Config, Enabled: m.Enabled}
+}
+
+func TestPreviewMapping_UsesPayloadMappers(t *testing.T) {
+	m := NewModule(&fakeStore{})
+	mappers := []spantypes.PostableSpanMapper{postableMapper("gen_ai.request.model", "llm.model")}
+
+	resp, err := m.PreviewMapping(context.Background(), valuer.GenerateUUID(), &spantypes.SpanMappingPreviewRequest{
+		Span:   spantypes.SpanMappingPreviewSpan{Attributes: map[string]any{"llm.model": "gpt-4"}},
+		Groups: []spantypes.SpanMappingPreviewGroup{{Group: postableGroup("llm", []string{"model"}), Mappers: &mappers}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "gpt-4", resp.Span.Attributes["gen_ai.request.model"])
+}
+
+func TestPreviewMapping_BackfillsOmittedMappersByName(t *testing.T) {
+	gid := valuer.GenerateUUID()
+	store := &fakeStore{
+		groups:  []*spantypes.SpanMapperGroup{{ID: gid, Name: "llm", Enabled: true}},
+		mappers: map[string][]*spantypes.SpanMapper{gid.StringValue(): {savedMapper("gen_ai.request.model", "llm.model")}},
+	}
+	m := NewModule(store)
+
+	// Mappers omitted (nil) => loaded from the saved group named "llm".
+	resp, err := m.PreviewMapping(context.Background(), valuer.GenerateUUID(), &spantypes.SpanMappingPreviewRequest{
+		Span:   spantypes.SpanMappingPreviewSpan{Attributes: map[string]any{"llm.model": "gpt-4"}},
+		Groups: []spantypes.SpanMappingPreviewGroup{{Group: postableGroup("llm", []string{"model"})}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "gpt-4", resp.Span.Attributes["gen_ai.request.model"])
+}
+
+func TestPreviewMapping_OmittedMappersUnknownNameErrors(t *testing.T) {
+	m := NewModule(&fakeStore{})
+
+	_, err := m.PreviewMapping(context.Background(), valuer.GenerateUUID(), &spantypes.SpanMappingPreviewRequest{
+		Span:   spantypes.SpanMappingPreviewSpan{Attributes: map[string]any{"llm.model": "gpt-4"}},
+		Groups: []spantypes.SpanMappingPreviewGroup{{Group: postableGroup("missing", []string{"model"})}},
+	})
+
+	require.Error(t, err)
+}
+
+func TestPreviewMapping_AppliesGroupsInPayloadOrder(t *testing.T) {
+	m := NewModule(&fakeStore{})
+	first := []spantypes.PostableSpanMapper{postableMapper("gen_ai.request.model", "a.model")}
+	second := []spantypes.PostableSpanMapper{postableMapper("gen_ai.request.model", "b.model")}
+
+	resp, err := m.PreviewMapping(context.Background(), valuer.GenerateUUID(), &spantypes.SpanMappingPreviewRequest{
+		Span: spantypes.SpanMappingPreviewSpan{Attributes: map[string]any{"a.model": "from-a", "b.model": "from-b"}},
+		Groups: []spantypes.SpanMappingPreviewGroup{
+			{Group: postableGroup("g1", []string{"model"}), Mappers: &first},
+			{Group: postableGroup("g2", []string{"model"}), Mappers: &second},
+		},
+	})
+
+	require.NoError(t, err)
+	// Both groups write the same target; the last group in the array wins.
+	assert.Equal(t, "from-b", resp.Span.Attributes["gen_ai.request.model"])
+}

--- a/pkg/modules/spanmapper/spanmapper.go
+++ b/pkg/modules/spanmapper/spanmapper.go
@@ -27,6 +27,7 @@ type Module interface {
 	CreateMapper(ctx context.Context, orgID, groupID valuer.UUID, mapper *spantypes.SpanMapper) error
 	UpdateMapper(ctx context.Context, orgID, groupID, id valuer.UUID, fieldContext spantypes.FieldContext, config *spantypes.SpanMapperConfig, enabled *bool, updatedBy string) error
 	DeleteMapper(ctx context.Context, orgID, groupID, id valuer.UUID) error
+	PreviewMapping(ctx context.Context, orgID valuer.UUID, req *spantypes.SpanMappingPreviewRequest) (*spantypes.SpanMappingPreviewResponse, error)
 }
 
 // Handler defines the HTTP handler interface for mapping group and mapper endpoints.
@@ -42,4 +43,5 @@ type Handler interface {
 	CreateMapper(rw http.ResponseWriter, r *http.Request)
 	UpdateMapper(rw http.ResponseWriter, r *http.Request)
 	DeleteMapper(rw http.ResponseWriter, r *http.Request)
+	PreviewMapping(rw http.ResponseWriter, r *http.Request)
 }

--- a/pkg/types/spantypes/spanmappersimulator.go
+++ b/pkg/types/spantypes/spanmappersimulator.go
@@ -1,0 +1,126 @@
+package spantypes
+
+import (
+	"maps"
+	"strings"
+)
+
+// resourceSourcePrefix marks a source that reads from resource attributes:
+// buildAttributeRule prefixes those keys with "resource." (e.g. "resource.service.name").
+var resourceSourcePrefix = FieldContextResource.StringValue() + "."
+
+// SpanMappingPreviewSpan is the sample span a preview runs against. Only its
+// attribute and resource maps participate in mapping.
+type SpanMappingPreviewSpan struct {
+	Attributes map[string]any `json:"attributes" nullable:"true"`
+	Resource   map[string]any `json:"resource" nullable:"true"`
+}
+
+// SpanMappingPreviewGroup is one group to preview, applied in the order it
+// appears in the request. Mappers is nil when the group is unchanged (the API
+// loads its saved mappers by name) and non-nil (including empty) when the user
+// is editing them, in which case the payload is authoritative.
+type SpanMappingPreviewGroup struct {
+	Group   PostableSpanMapperGroup `json:"group" required:"true"`
+	Mappers *[]PostableSpanMapper   `json:"mappers" nullable:"true"`
+}
+
+type SpanMappingPreviewRequest struct {
+	Span   SpanMappingPreviewSpan    `json:"span" required:"true"`
+	Groups []SpanMappingPreviewGroup `json:"groups" required:"true" nullable:"true"`
+}
+
+type SpanMappingPreviewResponse struct {
+	Span SpanMappingPreviewSpan `json:"span" required:"true"`
+}
+
+func SimulateMappingForAttributes(groups []*SpanMapperGroupWithMappers, resourceAttrs, spanAttrs map[string]any) (outResource, outSpan map[string]any) {
+	cfg := buildProcessorConfig(filterEnabledGroupsWithMappers(groups))
+
+	outResource = cloneAttrs(resourceAttrs)
+	outSpan = cloneAttrs(spanAttrs)
+
+	applyEnabledGroups(cfg, outSpan, outResource)
+	return outResource, outSpan
+}
+
+func filterEnabledGroupsWithMappers(groups []*SpanMapperGroupWithMappers) []*SpanMapperGroupWithMappers {
+	out := make([]*SpanMapperGroupWithMappers, 0, len(groups))
+	for _, gm := range groups {
+		if gm == nil || gm.Group == nil || !gm.Group.Enabled {
+			continue
+		}
+		enabled := make([]*SpanMapper, 0, len(gm.Mappers))
+		for _, m := range gm.Mappers {
+			if m != nil && m.Enabled {
+				enabled = append(enabled, m)
+			}
+		}
+		if len(enabled) > 0 {
+			out = append(out, &SpanMapperGroupWithMappers{Group: gm.Group, Mappers: enabled})
+		}
+	}
+	return out
+}
+
+func cloneAttrs(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	maps.Copy(out, in)
+	return out
+}
+
+// The functions below are copied from signoz-otel-collector (processor/signozspanmappingprocessor, PR #796):
+// TODO(spanmapper-preview): delete them and call the real processor once that PR merges and the dependency is bumped.
+func applyEnabledGroups(cfg *spanMapperProcessorConfig, spanAttrs, resourceAttrs map[string]any) {
+	for i := range cfg.Groups {
+		g := &cfg.Groups[i]
+		if !spanMapperConditionMet(g.ExistsAny, spanAttrs, resourceAttrs) {
+			continue
+		}
+		for j := range g.Attributes {
+			applySpanMapperRule(&g.Attributes[j], spanAttrs, resourceAttrs)
+		}
+	}
+}
+
+func spanMapperConditionMet(cond spanMapperProcessorExistsAny, spanAttrs, resourceAttrs map[string]any) bool {
+	return anyKeyContains(spanAttrs, cond.Attributes) || anyKeyContains(resourceAttrs, cond.Resource)
+}
+
+func anyKeyContains(attrs map[string]any, patterns []string) bool {
+	for k := range attrs {
+		for _, p := range patterns {
+			if strings.Contains(k, p) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func applySpanMapperRule(rule *spanMapperProcessorAttribute, spanAttrs, resourceAttrs map[string]any) {
+	dst := spanAttrs
+	if rule.Context == FieldContextResource.StringValue() {
+		dst = resourceAttrs
+	}
+
+	for i := range rule.Sources {
+		src := &rule.Sources[i]
+		sourceKey, isResource := strings.CutPrefix(src.Key, resourceSourcePrefix)
+
+		from := spanAttrs
+		if isResource {
+			from = resourceAttrs
+		}
+		val, ok := from[sourceKey]
+		if !ok {
+			continue
+		}
+
+		dst[rule.Target] = val
+		if src.Action == SpanMapperOperationMove.StringValue() {
+			delete(from, sourceKey)
+		}
+		return
+	}
+}

--- a/pkg/types/spantypes/spanmappersimulator_test.go
+++ b/pkg/types/spantypes/spanmappersimulator_test.go
@@ -1,0 +1,159 @@
+package spantypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func simGroup(name string, attrCond, resCond []string, mappers ...*SpanMapper) *SpanMapperGroupWithMappers {
+	return &SpanMapperGroupWithMappers{
+		Group: &SpanMapperGroup{
+			Name:      name,
+			Condition: SpanMapperGroupCondition{Attributes: attrCond, Resource: resCond},
+			Enabled:   true,
+		},
+		Mappers: mappers,
+	}
+}
+
+func simMapper(target string, ctx FieldContext, sources ...SpanMapperSource) *SpanMapper {
+	return &SpanMapper{
+		Name:         target,
+		FieldContext: ctx,
+		Config:       SpanMapperConfig{Sources: sources},
+		Enabled:      true,
+	}
+}
+
+func simAttrSrc(key string, op SpanMapperOperation, priority int) SpanMapperSource {
+	return SpanMapperSource{Key: key, Context: FieldContextSpanAttribute, Operation: op, Priority: priority}
+}
+
+func simResSrc(key string, op SpanMapperOperation, priority int) SpanMapperSource {
+	return SpanMapperSource{Key: key, Context: FieldContextResource, Operation: op, Priority: priority}
+}
+
+func TestSimulate_MatchInSpanAttrs(t *testing.T) {
+	groups := []*SpanMapperGroupWithMappers{
+		simGroup("llm", []string{"model"}, nil,
+			simMapper("gen_ai.request.model", FieldContextSpanAttribute,
+				simAttrSrc("llm.model", SpanMapperOperationCopy, 1)),
+		),
+	}
+	_, outSpan := SimulateMappingForAttributes(groups, nil, map[string]any{"llm.model": "gpt-4", "gen_ai.llm.model": "gpt-40"})
+
+	assert.Equal(t, "gpt-4", outSpan["gen_ai.request.model"])
+}
+
+func TestSimulate_MatchInResourceAttrs(t *testing.T) {
+	groups := []*SpanMapperGroupWithMappers{
+		simGroup("llm", nil, []string{"service.name"},
+			simMapper("gen_ai.request.model", FieldContextSpanAttribute,
+				simResSrc("service.name", SpanMapperOperationCopy, 1)),
+		),
+	}
+	_, outSpan := SimulateMappingForAttributes(groups, map[string]any{"service.name": "my-llm-service"}, nil)
+
+	assert.Equal(t, "my-llm-service", outSpan["gen_ai.request.model"])
+}
+
+func TestSimulate_NoMatchSkipsGroup(t *testing.T) {
+	groups := []*SpanMapperGroupWithMappers{
+		simGroup("llm", []string{"model"}, nil,
+			simMapper("gen_ai.request.model", FieldContextSpanAttribute,
+				simAttrSrc("llm.model", SpanMapperOperationCopy, 1)),
+		),
+	}
+	_, outSpan := SimulateMappingForAttributes(groups, nil, map[string]any{"some.other.key": "value"})
+
+	_, ok := outSpan["gen_ai.request.model"]
+	assert.False(t, ok, "target must not be set when condition is not met")
+}
+
+func TestSimulate_SourceFirstMatchWins(t *testing.T) {
+	groups := []*SpanMapperGroupWithMappers{
+		simGroup("tokens", []string{"llm"}, nil,
+			simMapper("gen_ai.request.tokens", FieldContextSpanAttribute,
+				simAttrSrc("gen_ai.request_tokens", SpanMapperOperationCopy, 2),
+				simAttrSrc("llm.tokens", SpanMapperOperationCopy, 1)),
+		),
+	}
+	_, outSpan := SimulateMappingForAttributes(groups, nil, map[string]any{"gen_ai.request_tokens": "100", "llm.tokens": "200"})
+
+	assert.Equal(t, "100", outSpan["gen_ai.request.tokens"])
+}
+
+func TestSimulate_SourceFallsBackToSecond(t *testing.T) {
+	groups := []*SpanMapperGroupWithMappers{
+		simGroup("tokens", []string{"llm"}, nil,
+			simMapper("gen_ai.request.tokens", FieldContextSpanAttribute,
+				simAttrSrc("gen_ai.request_tokens", SpanMapperOperationCopy, 2),
+				simAttrSrc("llm.tokens", SpanMapperOperationCopy, 1)),
+		),
+	}
+	_, outSpan := SimulateMappingForAttributes(groups, nil, map[string]any{"llm.tokens": "200"})
+
+	assert.Equal(t, "200", outSpan["gen_ai.request.tokens"])
+}
+
+func TestSimulate_ActionMove(t *testing.T) {
+	groups := []*SpanMapperGroupWithMappers{
+		simGroup("input", []string{"gen_ai"}, nil,
+			simMapper("gen_ai.request.input", FieldContextSpanAttribute,
+				simAttrSrc("gen_ai.input", SpanMapperOperationMove, 1)),
+		),
+	}
+	_, outSpan := SimulateMappingForAttributes(groups, nil, map[string]any{"gen_ai.input": "hello"})
+
+	assert.Equal(t, "hello", outSpan["gen_ai.request.input"])
+	_, srcPresent := outSpan["gen_ai.input"]
+	assert.False(t, srcPresent, "source key must be deleted when action=move")
+}
+
+func TestSimulate_WriteToResourceContext(t *testing.T) {
+	groups := []*SpanMapperGroupWithMappers{
+		simGroup("llm", []string{"llm"}, nil,
+			simMapper("gen_ai.request.model", FieldContextResource,
+				simAttrSrc("llm.model", SpanMapperOperationCopy, 1)),
+		),
+	}
+	outResource, outSpan := SimulateMappingForAttributes(groups, nil, map[string]any{"llm.model": "gpt-4"})
+
+	assert.Equal(t, "gpt-4", outResource["gen_ai.request.model"], "target must be written to resource attributes")
+	_, inSpan := outSpan["gen_ai.request.model"]
+	assert.False(t, inSpan)
+}
+
+func TestSimulate_DisabledGroupsAndMappersSkipped(t *testing.T) {
+	disabledGroup := simGroup("g1", []string{"llm"}, nil,
+		simMapper("gen_ai.request.model", FieldContextSpanAttribute,
+			simAttrSrc("llm.model", SpanMapperOperationCopy, 1)))
+	disabledGroup.Group.Enabled = false
+
+	_, outSpan := SimulateMappingForAttributes([]*SpanMapperGroupWithMappers{disabledGroup}, nil, map[string]any{"llm.model": "gpt-4"})
+
+	_, ok := outSpan["gen_ai.request.model"]
+	assert.False(t, ok, "disabled groups must not be evaluated")
+}
+
+func TestSimulate_NoMappingsReturnsInputUnchanged(t *testing.T) {
+	outResource, outSpan := SimulateMappingForAttributes(nil, map[string]any{"host.name": "h1"}, map[string]any{"model": "gpt-5"})
+
+	assert.Equal(t, map[string]any{"host.name": "h1"}, outResource, "resource attributes returned unchanged")
+	assert.Equal(t, map[string]any{"model": "gpt-5"}, outSpan, "span attributes returned unchanged")
+}
+
+func TestSimulate_DoesNotMutateInput(t *testing.T) {
+	input := map[string]any{"gen_ai.input": "hi"}
+	groups := []*SpanMapperGroupWithMappers{
+		simGroup("input", []string{"gen_ai"}, nil,
+			simMapper("gen_ai.request.input", FieldContextSpanAttribute,
+				simAttrSrc("gen_ai.input", SpanMapperOperationMove, 1))),
+	}
+	_, _ = SimulateMappingForAttributes(groups, nil, input)
+
+	// Original input map must be untouched (move would have deleted the key).
+	_, ok := input["gen_ai.input"]
+	assert.True(t, ok, "input map must not be mutated by the preview")
+}


### PR DESCRIPTION
## What

Adds `POST /api/v1/span_mapper_groups/preview` — runs a sample span through an ordered list of mapping groups and returns the transformed `attributes` and `resource` maps, so the UI can show a live before/after while editing.

## Payload design

```jsonc
{
  "span": {
    "attributes": { "llm.model": "gpt-4" },
    "resource":   { "service.name": "svc" }
  },
  "groups": [
    { "group": { "name": "llm", "condition": {...}, "enabled": true } },              // mappers omitted -> load saved mappers by name
    { "group": { "name": "http", ... }, "mappers": [ /* edited */ ] }                  // mappers present -> authoritative
  ]
}
```

- **Every group always carries its meta** (`name`, `condition`, `enabled`).
- **`mappers` is optional per group.** Omitted (`null`) means "unchanged" — the API loads that group's saved mappers **by name**. Present (including `[]`) means the user is editing — the payload wins. The `*[]` pointer is what lets us tell "omitted" apart from "emptied".
- **Groups apply in the order they appear** in the request (no group-level priority column exists; source-level `Priority` still governs source selection within a mapper).
- **`span` is typed** (`{attributes, resource}`) instead of an opaque object, so the contract is documented in the spec.

This replaces the earlier tri-modal request (`groups` | `groupId` | implicit "all enabled"), which couldn't be expressed cleanly in OpenAPI.

## Notes / caveats

- Name-keyed backfill is safe **as long as the FE sends a group's mappers whenever anything in that group changes (including a rename)** — so name lookup only ever runs for fully-untouched groups, whose names still match the DB. If `mappers` is omitted but no saved group matches that name, the API returns a clear 400.

## Tests

- Unit tests for `PreviewMapping`: payload mappers used, omitted mappers backfilled by name, unknown-name error, and group apply-order (last writer wins).
- Existing `SimulateMappingForAttributes` tests unchanged.
- `docs/api/openapi.yml` and the generated frontend client regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)