### PR TITLE
feat(dashboards-v2): download panel as PNG/SVG/CSV

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,6 +79,7 @@
     "event-source-polyfill": "1.0.31",
     "eventemitter3": "5.0.1",
     "history": "4.10.1",
+    "html-to-image": "1.11.13",
     "http-status-codes": "2.3.0",
     "i18next": "^21.6.12",
     "i18next-browser-languagedetector": "^6.1.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       history:
         specifier: 4.10.1
         version: 4.10.1
+      html-to-image:
+        specifier: 1.11.13
+        version: 1.11.13
       http-status-codes:
         specifier: 2.3.0
         version: 2.3.0
@@ -5450,6 +5453,9 @@ packages:
   html-tags@5.1.0:
     resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
     engines: {node: '>=20.10'}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -14494,6 +14500,8 @@ snapshots:
       void-elements: 3.1.0
 
   html-tags@5.1.0: {}
+
+  html-to-image@1.11.13: {}
 
   html-void-elements@3.0.0: {}
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/PreviewPane/PreviewPane.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/PreviewPane/PreviewPane.tsx
@@ -103,6 +103,7 @@ function PreviewPane({
 					<PanelHeader
 						panelId={panelId}
 						panel={panel}
+						data={data}
 						isFetching={isFetching}
 						error={error}
 						warning={data.response?.data?.warning}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/BarChartPanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/BarChartPanel/definition.ts
@@ -24,7 +24,7 @@ export const definition: PanelDefinition<'signoz/BarChartPanel'> = {
 		view: true,
 		edit: true,
 		clone: true,
-		download: false,
+		download: { csv: false, png: true, svg: true },
 		createAlert: true,
 		search: false,
 		drilldown: true,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/HistogramPanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/HistogramPanel/definition.ts
@@ -24,7 +24,7 @@ export const definition: PanelDefinition<'signoz/HistogramPanel'> = {
 		view: true,
 		edit: true,
 		clone: true,
-		download: false,
+		download: { csv: false, png: true, svg: true },
 		createAlert: true,
 		search: false,
 		drilldown: false,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/ListPanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/ListPanel/definition.ts
@@ -34,7 +34,7 @@ export const definition: PanelDefinition<'signoz/ListPanel'> = {
 		view: true,
 		edit: true,
 		clone: true,
-		download: false,
+		download: { csv: false, png: true, svg: true },
 		createAlert: false,
 		search: true,
 		drilldown: false,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/NumberPanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/NumberPanel/definition.ts
@@ -24,7 +24,7 @@ export const definition: PanelDefinition<'signoz/NumberPanel'> = {
 		view: true,
 		edit: true,
 		clone: true,
-		download: false,
+		download: { csv: false, png: true, svg: true },
 		createAlert: true,
 		search: false,
 		drilldown: true,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/definition.ts
@@ -20,7 +20,7 @@ export const definition: PanelDefinition<'signoz/PieChartPanel'> = {
 		view: true,
 		edit: true,
 		clone: true,
-		download: false,
+		download: { csv: false, png: true, svg: true },
 		createAlert: false,
 		search: false,
 		drilldown: true,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/__tests__/Renderer.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/__tests__/Renderer.test.tsx
@@ -17,7 +17,10 @@ function panelWith(
 ): PanelOfKind<'signoz/TablePanel'> {
 	return {
 		kind: 'Panel',
-		spec: { plugin: { kind: 'signoz/TablePanel', spec } },
+		spec: {
+			display: { name: 'Table panel' },
+			plugin: { kind: 'signoz/TablePanel', spec },
+		},
 	} as unknown as PanelOfKind<'signoz/TablePanel'>;
 }
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/__tests__/tableCsv.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/__tests__/tableCsv.test.ts
@@ -1,0 +1,91 @@
+import type {
+	PanelQueryData,
+	PanelTable,
+} from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
+
+import type { PanelOfKind } from '../../../types/rendererProps';
+import { prepareScalarTables } from '../../../../queryV5/prepareScalarTables';
+import { buildTableCsvRows, getTableCsvRows } from '../tableCsv';
+
+// Stub number/unit formatting so assertions cover only the row-building.
+jest.mock('../../../utils/formatPanelValue', () => ({
+	formatPanelValue: (value: number, unit?: string): string =>
+		`${value}${unit ?? ''}`,
+}));
+
+jest.mock('../../../../queryV5/prepareScalarTables', () => ({
+	prepareScalarTables: jest.fn(),
+}));
+jest.mock('../../../../queryV5/v5ResponseData', () => ({
+	getScalarResults: jest.fn(() => []),
+}));
+
+const mockPrepareScalarTables = prepareScalarTables as jest.MockedFunction<
+	typeof prepareScalarTables
+>;
+
+const table: PanelTable = {
+	queryName: 'A',
+	legend: '',
+	columns: [
+		{ name: 'service', queryName: 'A', isValueColumn: false, id: 'service' },
+		{ name: 'p99', queryName: 'A', isValueColumn: true, id: 'A' },
+	],
+	rows: [
+		{ data: { service: 'frontend', A: 1234 } },
+		{ data: { service: 'cart', A: 56 } },
+	],
+};
+
+describe('buildTableCsvRows', () => {
+	it('keys rows by column name in display order and formats value columns', () => {
+		const rows = buildTableCsvRows({
+			table,
+			columnUnits: { A: 'ms' },
+			decimalPrecision: undefined,
+		});
+
+		expect(rows).toStrictEqual([
+			{ service: 'frontend', p99: '1234ms' },
+			{ service: 'cart', p99: '56ms' },
+		]);
+		expect(Object.keys(rows[0])).toStrictEqual(['service', 'p99']);
+	});
+
+	it('renders group columns and non-numeric value cells as raw text', () => {
+		const rows = buildTableCsvRows({
+			table: {
+				...table,
+				rows: [{ data: { service: 'api', A: 'n/a' } }],
+			},
+			columnUnits: {},
+			decimalPrecision: undefined,
+		});
+
+		expect(rows).toStrictEqual([{ service: 'api', p99: 'n/a' }]);
+	});
+});
+
+describe('getTableCsvRows', () => {
+	const panel = {
+		spec: { plugin: { spec: { formatting: { columnUnits: { A: 'ms' } } } } },
+	} as unknown as PanelOfKind<'signoz/TablePanel'>;
+	const data = {} as PanelQueryData;
+
+	beforeEach(() => jest.clearAllMocks());
+
+	it('prepares the scalar table and flattens the first non-empty one to rows', () => {
+		mockPrepareScalarTables.mockReturnValue([table]);
+
+		expect(getTableCsvRows(panel, data)).toStrictEqual([
+			{ service: 'frontend', p99: '1234ms' },
+			{ service: 'cart', p99: '56ms' },
+		]);
+	});
+
+	it('returns no rows when the response has no table', () => {
+		mockPrepareScalarTables.mockReturnValue([]);
+
+		expect(getTableCsvRows(panel, data)).toStrictEqual([]);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/definition.ts
@@ -21,7 +21,7 @@ export const definition: PanelDefinition<'signoz/TablePanel'> = {
 		view: true,
 		edit: true,
 		clone: true,
-		download: true,
+		download: { csv: true, png: true, svg: true },
 		createAlert: false,
 		// V1 parity: only tables (and lists) expose the header search box.
 		search: true,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/tableColumns.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/tableColumns.tsx
@@ -1,7 +1,10 @@
 import type { TableProps } from 'antd';
 import type { DashboardtypesTableThresholdDTO } from 'api/generated/services/sigNoz.schemas';
 import type { PrecisionOption } from 'components/Graph/types';
-import type { PanelTable } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
+import type {
+	PanelTable,
+	PanelTableColumn,
+} from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
 import { coerceToString } from 'utils/stringUtils';
 
 import type { PanelThreshold } from '../../types/threshold';
@@ -28,6 +31,26 @@ export function mapTableThresholds(
 		(byColumn[threshold.columnName] ??= []).push(toPanelThreshold(threshold));
 	});
 	return byColumn;
+}
+
+/**
+ * Plain-text value of a table cell (value columns formatted through unit +
+ * precision, group columns raw). Shared by the renderer and the CSV export.
+ */
+export function formatTableCellText(
+	col: PanelTableColumn,
+	raw: unknown,
+	unit: string | undefined,
+	decimalPrecision?: PrecisionOption,
+): string {
+	if (!col.isValueColumn) {
+		return coerceToString(raw);
+	}
+	const num = Number(raw);
+	if (!Number.isFinite(num)) {
+		return coerceToString(raw);
+	}
+	return formatPanelValue(num, unit, decimalPrecision);
 }
 
 // Sort comparator: numeric when both cells parse as numbers (value columns and
@@ -89,15 +112,13 @@ export function buildTableColumns({
 			sorter: (a: TableRowData, b: TableRowData): number =>
 				compareCells(a[key], b[key]),
 			render: (raw: unknown): React.ReactNode => {
-				if (!col.isValueColumn) {
-					return coerceToString(raw);
-				}
+				const text = formatTableCellText(col, raw, unit, decimalPrecision);
 				const num = Number(raw);
-				if (!Number.isFinite(num)) {
-					return coerceToString(raw);
-				}
-				const text = formatPanelValue(num, unit, decimalPrecision);
-				if (colThresholds.length === 0) {
+				if (
+					!col.isValueColumn ||
+					colThresholds.length === 0 ||
+					!Number.isFinite(num)
+				) {
 					return text;
 				}
 				const { threshold } = resolveActiveThreshold(colThresholds, num, unit);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/tableCsv.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/tableCsv.ts
@@ -1,0 +1,70 @@
+import type { PrecisionOption } from 'components/Graph/types';
+import { prepareScalarTables } from 'pages/DashboardPageV2/DashboardContainer/queryV5/prepareScalarTables';
+import type {
+	PanelQueryData,
+	PanelTable,
+} from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
+import { getScalarResults } from 'pages/DashboardPageV2/DashboardContainer/queryV5/v5ResponseData';
+
+import { resolveDecimalPrecision } from '../../utils/chartAppearance/resolvers';
+import { getColumnUnit } from '../../utils/getColumnUnit';
+import type { PanelOfKind } from '../../types/rendererProps';
+
+import { formatTableCellText } from './tableColumns';
+
+interface BuildTableCsvRowsArgs {
+	table: PanelTable;
+	/** Per-column display unit (`formatting.columnUnits`), keyed by column key. */
+	columnUnits: Record<string, string>;
+	decimalPrecision?: PrecisionOption;
+}
+
+/**
+ * Flattens a prepared table into CSV rows keyed by column name, reusing the
+ * on-screen cell formatting in display column order. Exports the full result
+ * set, not the paginated view (V1 parity).
+ */
+export function buildTableCsvRows({
+	table,
+	columnUnits,
+	decimalPrecision,
+}: BuildTableCsvRowsArgs): Record<string, string>[] {
+	return table.rows.map((row) => {
+		const csvRow: Record<string, string> = {};
+		table.columns.forEach((col) => {
+			const key = col.id || col.name;
+			const unit = getColumnUnit(key, columnUnits);
+			csvRow[col.name] = formatTableCellText(
+				col,
+				row.data[key],
+				unit,
+				decimalPrecision,
+			);
+		});
+		return csvRow;
+	});
+}
+
+/**
+ * Prepares the scalar table from the query response and flattens it to CSV rows,
+ * reusing the on-screen formatting. Returns [] when the response has no table.
+ */
+export function getTableCsvRows(
+	panel: PanelOfKind<'signoz/TablePanel'>,
+	data: PanelQueryData,
+): Record<string, string>[] {
+	const spec = panel.spec.plugin.spec;
+	const table = prepareScalarTables({
+		results: getScalarResults(data.response),
+		legendMap: data.legendMap ?? {},
+		requestPayload: data.requestPayload,
+	}).find((candidate) => candidate.columns.length > 0);
+	if (!table) {
+		return [];
+	}
+	return buildTableCsvRows({
+		table,
+		columnUnits: spec.formatting?.columnUnits ?? {},
+		decimalPrecision: resolveDecimalPrecision(spec.formatting?.decimalPrecision),
+	});
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TimeSeriesPanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TimeSeriesPanel/definition.ts
@@ -24,7 +24,7 @@ export const definition: PanelDefinition<'signoz/TimeSeriesPanel'> = {
 		view: true,
 		edit: true,
 		clone: true,
-		download: false,
+		download: { csv: false, png: true, svg: true },
 		createAlert: true,
 		search: false,
 		drilldown: true,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition.ts
@@ -8,27 +8,29 @@ import type { PanelKind } from './panelKind';
 import type { QueryBuilderFieldRule } from './panelCapabilities';
 import type { BaseRendererProps, PanelRendererProps } from './rendererProps';
 
+/** Export formats offered under the single "Download" action. */
+export enum DownloadFormat {
+	CSV = 'csv',
+	PNG = 'png',
+	SVG = 'svg',
+}
+
 /**
- * Which panel actions a kind supports. Required field, so registering a new
- * kind forces an explicit decision for every action. Chrome actions (move to
- * section, clone, delete) are dashboard-layout concerns available to every
- * panel and are intentionally not declarable here.
+ * Which actions a kind supports, declared per-kind in `kinds/<Kind>/definition.ts`.
+ * Chrome actions (move, clone, delete) are layout concerns and aren't declared here.
  */
 export interface PanelActionCapabilities {
-	/** Kind has a full-screen view — gates the "View" action. */
+	/** Gates the "View" action. */
 	view: boolean;
-	/** Kind is editable in the V2 panel editor — gates the "Edit panel" action. */
+	/** Gates the "Edit panel" action. */
 	edit: boolean;
-	/** Kind can be cloned — gates the "Clone" action. */
+	/** Gates the "Clone" action. */
 	clone: boolean;
-	/** Gates "Download as CSV". V1 parity: only table panels carry exportable data. */
-	download: boolean;
-	/** Kind's query can seed a new alert — gates "Create Alerts". */
+	/** Which formats this kind can be downloaded as (CSV is table-only). */
+	download: Record<DownloadFormat, boolean>;
+	/** Gates "Create Alerts". */
 	createAlert: boolean;
-	/**
-	 * Header search box that filters rendered rows client-side (V1 parity: only
-	 * tabular kinds). Not a menu action — the renderer must consume `searchTerm`.
-	 */
+	/** Client-side header search box, consumed by the renderer via `searchTerm`. */
 	search: boolean;
 	/**
 	 * Kind supports click-to-drilldown (context menu + View/Breakout). V1 parity: charts + scalar
@@ -51,13 +53,10 @@ export interface PanelDefinition<K extends PanelKind = PanelKind> {
 	actions: PanelActionCapabilities;
 }
 
-// Total over PanelKind: every kind must be registered (missing → compile error),
-// so getPanelDefinition never returns undefined.
+// Every kind must be registered, so getPanelDefinition never returns undefined.
 export type PanelRegistry = { [K in PanelKind]: PanelDefinition<K> };
 
 // PanelDefinition with its Renderer widened to the kind-agnostic prop surface.
-// getPanelDefinition resolves to this, concentrating the unavoidable cast in one
-// place rather than leaking it to every call site (the kind isn't known statically).
 export interface RenderablePanelDefinition extends Omit<
 	PanelDefinition,
 	'Renderer'

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/downloadCsv.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/downloadCsv.ts
@@ -1,0 +1,19 @@
+import { unparse } from 'papaparse';
+
+import { toSafeFileName } from './toSafeFileName';
+
+/** Serializes rows (keyed by column header) to CSV and downloads the file. */
+export function downloadCsv(
+	rows: Record<string, string>[],
+	fileBaseName: string,
+): void {
+	const csv = unparse(rows);
+	const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+	const url = URL.createObjectURL(blob);
+	const link = document.createElement('a');
+	link.href = url;
+	link.download = `${toSafeFileName(fileBaseName)}.csv`;
+	link.click();
+	link.remove();
+	URL.revokeObjectURL(url);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/toSafeFileName.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/toSafeFileName.ts
@@ -1,0 +1,8 @@
+/** Makes a download filename safe across OSes; falls back when empty. */
+export function toSafeFileName(name: string): string {
+	const trimmed = name.trim();
+	if (!trimmed) {
+		return 'panel';
+	}
+	return trimmed.replace(/[\\/:*?"<>|]+/g, '-');
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/Panel.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/Panel.tsx
@@ -76,10 +76,14 @@ function Panel({
 		<div
 			className={styles.panel}
 			data-panel-visible={isVisible ? 'true' : 'false'}
+			// Stable locator so the "Download as PNG" action can find this node to
+			// capture, without threading a ref through the header/actions chain.
+			data-panel-root={panelId}
 		>
 			<PanelHeader
 				panelId={panelId}
 				panel={panel}
+				data={data}
 				isFetching={isFetching}
 				error={error}
 				warning={data.response?.data?.warning}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/PanelActionsMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/PanelActionsMenu.tsx
@@ -2,6 +2,7 @@ import { EllipsisVertical } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
 import { DropdownMenuSimple } from '@signozhq/ui/dropdown-menu';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import type { PanelQueryData } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
 
 import ConfirmDeleteDialog from '../../../components/ConfirmDeleteDialog/ConfirmDeleteDialog';
 import type { PanelActionsConfig } from '../Panel';
@@ -10,8 +11,10 @@ import styles from './PanelActionsMenu.module.scss';
 
 interface PanelActionsMenuProps {
 	panelId: string;
-	/** The panel itself — its query seeds "Create Alerts". */
+	/** The panel itself — seeds "Create Alerts" and the download filename. */
 	panel: DashboardtypesPanelDTO;
+	/** The panel's query response — the source for "Download as CSV". */
+	data: PanelQueryData;
 	/** Layout context for move/delete — absent outside editable sectioned mode. */
 	panelActions?: PanelActionsConfig;
 }
@@ -24,11 +27,13 @@ interface PanelActionsMenuProps {
 function PanelActionsMenu({
 	panelId,
 	panel,
+	data,
 	panelActions,
 }: PanelActionsMenuProps): JSX.Element | null {
 	const { items, deleteConfirm } = usePanelActionItems({
 		panelId,
 		panel,
+		data,
 		panelActions,
 	});
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/__tests__/usePanelActionItems.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/__tests__/usePanelActionItems.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import type { PanelQueryData } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
 import type { ROLES } from 'types/roles';
 
 import type { DashboardSection } from '../../../../utils';
@@ -47,6 +48,13 @@ jest.mock('../../hooks/useCreateAlertFromPanel', () => ({
 	useCreateAlertFromPanel: (): jest.Mock => mockCreateAlert,
 }));
 
+const mockDownloadImage = jest.fn();
+jest.mock('../../hooks/useDownloadPanelImage', () => ({
+	useDownloadPanelImage: (): { downloadPanelImage: jest.Mock } => ({
+		downloadPanelImage: mockDownloadImage,
+	}),
+}));
+
 // Role is the only thing read off the app context; useComponentPermission runs
 // for real so the tests exercise the actual role → permission mapping.
 let mockRole: ROLES = 'ADMIN';
@@ -84,9 +92,16 @@ const mockPanel = {
 	},
 } as unknown as DashboardtypesPanelDTO;
 
+const mockData = {
+	response: undefined,
+	requestPayload: undefined,
+	legendMap: {},
+} as PanelQueryData;
+
 const baseArgs = {
 	panelId: 'panel-1',
 	panel: mockPanel,
+	data: mockData,
 	panelActions: { currentLayoutIndex: 0, sections: TWO_TITLED_SECTIONS },
 };
 
@@ -110,14 +125,15 @@ describe('usePanelActionItems', () => {
 			'edit-panel',
 			'clone-panel',
 			'divider',
+			'download',
 			'create-alert',
 			'divider',
 			'move',
 			'divider',
 			'delete-panel',
 		]);
-		// download stays hidden: no current kind declares the capability
-		// (V1 parity — CSV export was table-only).
+		// The single "Download" entry is a submenu (PNG/SVG, plus CSV on tables);
+		// it's present for every renderable kind.
 	});
 
 	it('AUTHOR loses edit and clone (edit_widget excludes AUTHOR) but keeps the rest', () => {
@@ -126,6 +142,7 @@ describe('usePanelActionItems', () => {
 		expect(itemKeys(result.current)).toStrictEqual([
 			'view-panel',
 			'divider',
+			'download',
 			'create-alert',
 			'divider',
 			'move',
@@ -134,26 +151,28 @@ describe('usePanelActionItems', () => {
 		]);
 	});
 
-	it('VIEWER keeps only the role-ungated actions (view, create-alert)', () => {
+	it('VIEWER keeps only the role-ungated actions (view, download, create-alert)', () => {
 		mockRole = 'VIEWER';
 		const { result } = renderHook(() => usePanelActionItems(baseArgs));
 		expect(itemKeys(result.current)).toStrictEqual([
 			'view-panel',
 			'divider',
+			'download',
 			'create-alert',
 		]);
 	});
 
-	it('read-only dashboard keeps View and Create Alerts (V1 parity: both survive a lock)', () => {
+	it('read-only dashboard keeps the non-mutating actions (View, Download, Create Alerts)', () => {
 		useDashboardStore.setState({ isEditable: false });
 		const { result } = renderHook(() =>
 			usePanelActionItems({ ...baseArgs, panelActions: undefined }),
 		);
-		// Create Alerts opens a new tab and never mutates the dashboard, so it
-		// isn't gated on edit access — matching V1's locked-dashboard menu.
+		// View, the Download submenu (PNG/SVG) and Create Alerts are all
+		// non-mutating, so they survive on a read-only dashboard (V1 parity).
 		expect(itemKeys(result.current)).toStrictEqual([
 			'view-panel',
 			'divider',
+			'download',
 			'create-alert',
 		]);
 	});
@@ -277,6 +296,25 @@ describe('usePanelActionItems', () => {
 		});
 	});
 
+	it('the Download submenu captures the panel by id, name and chosen format', () => {
+		const { result } = renderHook(() => usePanelActionItems(baseArgs));
+		const download = result.current.items.find(
+			(i) => 'key' in i && i.key === 'download',
+		) as { children: { key: string; onClick: () => void }[] };
+
+		// TimeSeries declares no CSV capability, so the submenu is just PNG + SVG.
+		expect(download.children.map((c) => c.key)).toStrictEqual([
+			'download-png',
+			'download-svg',
+		]);
+
+		download.children.find((c) => c.key === 'download-png')?.onClick();
+		expect(mockDownloadImage).toHaveBeenCalledWith('panel-1', 'CPU', 'png');
+
+		download.children.find((c) => c.key === 'download-svg')?.onClick();
+		expect(mockDownloadImage).toHaveBeenCalledWith('panel-1', 'CPU', 'svg');
+	});
+
 	it('view opens the View modal for the panel', () => {
 		const { result } = renderHook(() => usePanelActionItems(baseArgs));
 		const view = result.current.items.find(
@@ -284,15 +322,6 @@ describe('usePanelActionItems', () => {
 		);
 		(view as { onClick: () => void }).onClick();
 		expect(mockOpenView).toHaveBeenCalledWith('panel-1');
-	});
-
-	it('create-alert seeds an alert from this panel', () => {
-		const { result } = renderHook(() => usePanelActionItems(baseArgs));
-		const createAlert = result.current.items.find(
-			(i) => 'key' in i && i.key === 'create-alert',
-		);
-		(createAlert as { onClick: () => void }).onClick();
-		expect(mockCreateAlert).toHaveBeenCalledWith(mockPanel, 'panel-1');
 	});
 
 	it('create-alert seeds an alert from this panel', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/panelActionMeta.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/panelActionMeta.ts
@@ -37,6 +37,8 @@ export const PANEL_ACTION_META: Record<PanelActionId, PanelActionMeta> = {
 	view: { capability: 'view' },
 	edit: { permission: 'edit_widget', capability: 'edit' },
 	clone: { permission: 'edit_widget' },
+	// Single entry for every export format (CSV/PNG/SVG); like view it isn't
+	// role-gated (V1 parity). The per-format options live in usePanelActionItems.
 	download: { capability: 'download' },
 	createAlert: { capability: 'createAlert' },
 	// Moving a panel between sections mutates the dashboard layout.

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/usePanelActionItems.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/usePanelActionItems.tsx
@@ -1,14 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import {
-	Bell,
-	CloudDownload,
-	Copy,
-	FolderInput,
-	FolderOutput,
-	Fullscreen,
-	PenLine,
-	Trash2,
-} from '@signozhq/icons';
+import { Bell, Copy, Fullscreen, PenLine, Trash2 } from '@signozhq/icons';
 import type { MenuItem } from '@signozhq/ui/dropdown-menu';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
 import useComponentPermission from 'hooks/useComponentPermission';
@@ -18,6 +9,7 @@ import {
 } from 'hooks/useConfirmableAction';
 import { getPanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/registry';
 import { useOpenPanelEditor } from 'pages/DashboardPageV2/DashboardContainer/hooks/useOpenPanelEditor';
+import type { PanelQueryData } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
 import { useDashboardStore } from 'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore';
 import { useAppContext } from 'providers/App/App';
 
@@ -26,87 +18,22 @@ import type { PanelActionsConfig } from '../Panel';
 import { useClonePanel } from '../hooks/useClonePanel';
 import { useCreateAlertFromPanel } from '../hooks/useCreateAlertFromPanel';
 import { useDeletePanel } from '../hooks/useDeletePanel';
-import {
-	type MovePanelArgs,
-	useMovePanelToSection,
-} from '../hooks/useMovePanelToSection';
+import { useDownloadPanelMenuItem } from '../hooks/useDownloadPanelMenuItem';
+import { useMovePanelToSection } from '../hooks/useMovePanelToSection';
 import { useViewPanel } from '../hooks/useViewPanel';
+import { buildMoveItems } from '../utils/buildMoveItems';
 import { PANEL_ACTION_META } from './panelActionMeta';
 
 // Stable fallback so renders without layout context don't churn the mutation
 // hooks' deps (a fresh [] each render would re-create their callbacks).
 const EMPTY_SECTIONS: DashboardSection[] = [];
 
-/** Placeholder for V1-parity actions whose V2 implementations land later. */
-function notImplementedYet(feature: string): void {
-	// eslint-disable-next-line no-alert -- temporary placeholder, see above
-	alert(`${feature} option clicked`);
-}
-
-interface MoveItemsArgs {
-	sections: DashboardSection[];
-	currentLayoutIndex: number;
-	panelId: string;
-	movePanel: (args: MovePanelArgs) => Promise<void>;
-}
-
-/**
- * The "Move to section" submenu (other titled sections) plus a direct "Move out
- * of section" to the untitled root, shown only when the panel sits in a titled
- * section and a root section exists to receive it.
- */
-function buildMoveItems({
-	sections,
-	currentLayoutIndex,
-	panelId,
-	movePanel,
-}: MoveItemsArgs): MenuItem[] {
-	const targets = sections.filter(
-		(s) => s.title && s.layoutIndex !== currentLayoutIndex,
-	);
-	const items: MenuItem[] = [
-		{
-			key: 'move',
-			label: 'Move to section',
-			icon: <FolderInput size={14} />,
-			...(targets.length === 0
-				? { disabled: true }
-				: {
-						children: targets.map((s) => ({
-							key: `move-${s.layoutIndex}`,
-							label: s.title,
-							onClick: (): void =>
-								void movePanel({
-									panelId,
-									fromLayoutIndex: currentLayoutIndex,
-									toLayoutIndex: s.layoutIndex,
-								}),
-						})),
-					}),
-		},
-	];
-
-	const rootSection = sections.find((s) => !s.title);
-	if (rootSection && rootSection.layoutIndex !== currentLayoutIndex) {
-		items.push({
-			key: 'move-to-root',
-			label: 'Move out of section',
-			icon: <FolderOutput size={14} />,
-			onClick: (): void =>
-				void movePanel({
-					panelId,
-					fromLayoutIndex: currentLayoutIndex,
-					toLayoutIndex: rootSection.layoutIndex,
-				}),
-		});
-	}
-	return items;
-}
-
 interface UsePanelActionItemsArgs {
 	panelId: string;
-	/** The panel itself — its query seeds the "Create Alerts" action. */
+	/** The panel itself — seeds "Create Alerts" and the download filename. */
 	panel: DashboardtypesPanelDTO;
+	/** The panel's query response — the source for "Download as CSV". */
+	data: PanelQueryData;
 	/** Layout context for move/delete — absent outside editable mode. */
 	panelActions?: PanelActionsConfig;
 }
@@ -118,19 +45,15 @@ export interface PanelActionItems {
 }
 
 /**
- * Resolves the panel actions menu items (V1 WidgetHeader set plus V2's "Move to
- * section"). Every action passes three gates before it appears:
- *
- *   kind — what the panel kind declares it supports (PanelDefinition.actions);
- *          unknown kinds support no kind-gated actions.
- *   role — componentPermission lookup for the current user (PANEL_ACTION_META;
- *          actions without a permission key are open to every role, V1 parity).
- *   context — runtime state: dashboard editable (store), layout config present.
- *          View and Download remain available on read-only dashboards, as in V1.
+ * Resolves the panel actions menu items. Each action passes three gates before
+ * it appears: kind (PanelDefinition.actions), role (useComponentPermission) and
+ * context (dashboard editable + layout config present). View and Download stay
+ * available on read-only dashboards, as in V1.
  */
 export function usePanelActionItems({
 	panelId,
 	panel,
+	data,
 	panelActions,
 }: UsePanelActionItemsArgs): PanelActionItems {
 	const panelKind = panel.spec.plugin.kind;
@@ -149,14 +72,19 @@ export function usePanelActionItems({
 	const createAlert = useCreateAlertFromPanel();
 	const { openView } = useViewPanel();
 
-	// Mutations are store-backed (dashboardId/refetch) — the layout tree only
-	// supplies data (`sections`), so no callbacks are threaded through it.
+	// Mutations are store-backed; the layout tree only supplies `sections`.
 	const sections = panelActions?.sections ?? EMPTY_SECTIONS;
 	const movePanel = useMovePanelToSection({ sections });
 	const deletePanel = useDeletePanel({ sections });
 	const clonePanel = useClonePanel({ sections });
 
 	const panelCapabilities = getPanelDefinition(panelKind).actions;
+	const downloadItem = useDownloadPanelMenuItem({
+		panelId,
+		panel,
+		data,
+		actions: panelCapabilities,
+	});
 
 	// Delete runs on confirm, not on click — the menu item opens a prompt.
 	const deleteConfirm = useConfirmableAction(
@@ -191,8 +119,8 @@ export function usePanelActionItems({
 				onClick: (): void => openPanelEditor(panelId),
 			});
 		}
-		// Clone needs the section context (source spec + dimensions) to place the
-		// copy, so — unlike Edit — it requires panelActions.
+		// Clone needs the section context to place the copy, so — unlike Edit —
+		// it requires panelActions.
 		if (isEditable && canEditWidget && panelActions && panelCapabilities.clone) {
 			panelGroup.push({
 				key: 'clone-panel',
@@ -207,17 +135,12 @@ export function usePanelActionItems({
 		}
 
 		const dataGroup: MenuItem[] = [];
-		if (panelCapabilities.download) {
-			dataGroup.push({
-				key: 'download-panel',
-				label: 'Download as CSV',
-				icon: <CloudDownload size={14} />,
-				onClick: (): void => notImplementedYet('Download'),
-			});
+		if (downloadItem) {
+			dataGroup.push(downloadItem);
 		}
-		// Seeding an alert opens a new tab and never mutates the dashboard, so —
-		// unlike edit/clone — it isn't gated on `isEditable` (V1 parity: available
-		// on locked dashboards too).
+
+		// Create Alerts opens a new tab and never mutates the dashboard, so —
+		// unlike edit/clone — it isn't gated on `isEditable` (V1 parity).
 		if (panelCapabilities.createAlert) {
 			dataGroup.push({
 				key: 'create-alert',
@@ -265,6 +188,7 @@ export function usePanelActionItems({
 		panelActions,
 		sections,
 		panelId,
+		downloadItem,
 		openView,
 		openPanelEditor,
 		createAlert,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelHeader/PanelHeader.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelHeader/PanelHeader.tsx
@@ -7,6 +7,7 @@ import type {
 } from 'api/generated/services/sigNoz.schemas';
 import cx from 'classnames';
 import type { PanelTimePreferenceLabel } from 'pages/DashboardPageV2/DashboardContainer/hooks/resolvePanelTimeWindow';
+import type { PanelQueryData } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
 
 import type { PanelActionsConfig } from '../Panel';
 import PanelActionsMenu from '../PanelActionsMenu/PanelActionsMenu';
@@ -23,6 +24,8 @@ interface PanelHeaderProps {
 	panelId: string;
 	/** The panel itself — its query seeds the menu's "Create Alerts" action. */
 	panel: DashboardtypesPanelDTO;
+	/** The panel's query response — the menu's source for "Download as CSV". */
+	data: PanelQueryData;
 	/** Background refresh in flight — shows a spinner without blinking the chart. */
 	isFetching: boolean;
 	/** Latest query error — surfaced as a header error indicator. */
@@ -51,6 +54,7 @@ interface PanelHeaderProps {
 function PanelHeader({
 	panelId,
 	panel,
+	data,
 	isFetching,
 	error,
 	warning,
@@ -117,6 +121,7 @@ function PanelHeader({
 					<PanelActionsMenu
 						panelId={panelId}
 						panel={panel}
+						data={data}
 						panelActions={panelActions}
 					/>
 				)}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/utils.ts
@@ -1,6 +1,6 @@
 import { LayoutDashboard, Rows2 } from '@signozhq/icons';
 
-import type { DashboardSection } from '../../../utils';
+import { findRootSection, type DashboardSection } from '../../../utils';
 import type { SectionOption } from './types';
 
 const ROOT_LABEL = 'Dashboard (root)';
@@ -11,8 +11,9 @@ const SECTION_DESCRIPTION = 'Section';
 export function buildSectionOptions(
 	sections: DashboardSection[],
 ): SectionOption[] {
+	const rootSection = findRootSection(sections);
 	return sections.map((section) => {
-		const isRoot = !section.title && section.layoutIndex === 0;
+		const isRoot = rootSection === section;
 		return {
 			value: String(section.layoutIndex),
 			layoutIndex: section.layoutIndex,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/PanelHeader.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/PanelHeader.test.tsx
@@ -2,6 +2,7 @@ import { TooltipProvider } from '@signozhq/ui/tooltip';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import type { PanelQueryData } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
 import type { ReactElement } from 'react';
 import type { Warning } from 'types/api';
 
@@ -43,6 +44,11 @@ function makePanel(overrides?: {
 const baseProps = {
 	panel: makePanel(),
 	panelId: 'panel-1',
+	data: {
+		response: undefined,
+		requestPayload: undefined,
+		legendMap: {},
+	} as PanelQueryData,
 	isFetching: false,
 };
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useDownloadPanelCsv.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useDownloadPanelCsv.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from '@testing-library/react';
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import { getTableCsvRows } from 'pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/tableCsv';
+import { downloadCsv } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/downloadCsv';
+import type { PanelQueryData } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
+
+import { useDownloadPanelCsv } from '../useDownloadPanelCsv';
+
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/tableCsv',
+	() => ({ getTableCsvRows: jest.fn() }),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/Panels/utils/downloadCsv',
+	() => ({ downloadCsv: jest.fn() }),
+);
+
+const mockGetTableCsvRows = getTableCsvRows as jest.Mock;
+const mockDownloadCsv = downloadCsv as jest.Mock;
+
+const data = {} as PanelQueryData;
+const panelOf = (kind: string): DashboardtypesPanelDTO =>
+	({
+		spec: { display: { name: 'CPU' }, plugin: { kind } },
+	}) as DashboardtypesPanelDTO;
+
+describe('useDownloadPanelCsv', () => {
+	beforeEach(() => jest.clearAllMocks());
+
+	it('exports the table rows as CSV named after the panel', () => {
+		mockGetTableCsvRows.mockReturnValue([{ service: 'frontend', p99: '1ms' }]);
+
+		const { result } = renderHook(() =>
+			useDownloadPanelCsv({ panel: panelOf('signoz/TablePanel'), data }),
+		);
+		result.current();
+
+		expect(mockGetTableCsvRows).toHaveBeenCalledTimes(1);
+		expect(mockDownloadCsv).toHaveBeenCalledWith(
+			[{ service: 'frontend', p99: '1ms' }],
+			'CPU',
+		);
+	});
+
+	it('no-ops when the response has no rows', () => {
+		mockGetTableCsvRows.mockReturnValue([]);
+
+		const { result } = renderHook(() =>
+			useDownloadPanelCsv({ panel: panelOf('signoz/TablePanel'), data }),
+		);
+		result.current();
+
+		expect(mockDownloadCsv).not.toHaveBeenCalled();
+	});
+
+	it('no-ops for non-table kinds without building rows', () => {
+		const { result } = renderHook(() =>
+			useDownloadPanelCsv({ panel: panelOf('signoz/TimeSeriesPanel'), data }),
+		);
+		result.current();
+
+		expect(mockGetTableCsvRows).not.toHaveBeenCalled();
+		expect(mockDownloadCsv).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useDownloadPanelCsv.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useDownloadPanelCsv.test.ts
@@ -31,7 +31,11 @@ describe('useDownloadPanelCsv', () => {
 		mockGetTableCsvRows.mockReturnValue([{ service: 'frontend', p99: '1ms' }]);
 
 		const { result } = renderHook(() =>
-			useDownloadPanelCsv({ panel: panelOf('signoz/TablePanel'), data }),
+			useDownloadPanelCsv({
+				panel: panelOf('signoz/TablePanel'),
+				data,
+				canDownloadCsv: true,
+			}),
 		);
 		result.current();
 
@@ -46,16 +50,24 @@ describe('useDownloadPanelCsv', () => {
 		mockGetTableCsvRows.mockReturnValue([]);
 
 		const { result } = renderHook(() =>
-			useDownloadPanelCsv({ panel: panelOf('signoz/TablePanel'), data }),
+			useDownloadPanelCsv({
+				panel: panelOf('signoz/TablePanel'),
+				data,
+				canDownloadCsv: true,
+			}),
 		);
 		result.current();
 
 		expect(mockDownloadCsv).not.toHaveBeenCalled();
 	});
 
-	it('no-ops for non-table kinds without building rows', () => {
+	it('no-ops when the kind cannot download CSV, without building rows', () => {
 		const { result } = renderHook(() =>
-			useDownloadPanelCsv({ panel: panelOf('signoz/TimeSeriesPanel'), data }),
+			useDownloadPanelCsv({
+				panel: panelOf('signoz/TimeSeriesPanel'),
+				data,
+				canDownloadCsv: false,
+			}),
 		);
 		result.current();
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useDownloadPanelImage.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useDownloadPanelImage.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react';
+import { toast } from '@signozhq/ui/sonner';
+import { DownloadFormat } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition';
+
+import { downloadElementAsImage } from '../../utils/downloadPanelImage';
+import { useDownloadPanelImage } from '../useDownloadPanelImage';
+
+jest.mock('../../utils/downloadPanelImage', () => ({
+	downloadElementAsImage: jest.fn(),
+}));
+
+jest.mock('@signozhq/ui/sonner', () => ({
+	...jest.requireActual('@signozhq/ui/sonner'),
+	toast: { error: jest.fn(), dismiss: jest.fn() },
+}));
+
+const mockCapture = downloadElementAsImage as jest.MockedFunction<
+	typeof downloadElementAsImage
+>;
+const mockToastError = toast.error as jest.Mock;
+
+function mountPanel(panelId: string): HTMLElement {
+	const node = document.createElement('div');
+	node.setAttribute('data-panel-root', panelId);
+	document.body.appendChild(node);
+	return node;
+}
+
+describe('useDownloadPanelImage', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		document.body.innerHTML = '';
+	});
+
+	it('captures the panel node located by its data-panel-root marker, forwarding the format', async () => {
+		const node = mountPanel('panel-1');
+		mockCapture.mockResolvedValue();
+
+		const { result } = renderHook(() => useDownloadPanelImage());
+		await result.current.downloadPanelImage(
+			'panel-1',
+			'My panel',
+			DownloadFormat.SVG,
+		);
+
+		expect(mockCapture).toHaveBeenCalledWith(
+			node,
+			'My panel',
+			DownloadFormat.SVG,
+		);
+		expect(mockToastError).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when no panel matches the id (e.g. unmounted)', async () => {
+		const { result } = renderHook(() => useDownloadPanelImage());
+		await result.current.downloadPanelImage('missing', 'x', DownloadFormat.PNG);
+
+		expect(mockCapture).not.toHaveBeenCalled();
+		expect(mockToastError).not.toHaveBeenCalled();
+	});
+
+	it('surfaces an error notification when the capture fails', async () => {
+		mountPanel('panel-2');
+		mockCapture.mockRejectedValue(new Error('capture boom'));
+
+		const { result } = renderHook(() => useDownloadPanelImage());
+		await result.current.downloadPanelImage('panel-2', 'x', DownloadFormat.PNG);
+
+		expect(mockToastError).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useDownloadPanelMenuItem.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useDownloadPanelMenuItem.test.tsx
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react';
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import type { PanelActionCapabilities } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition';
+import type { PanelQueryData } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
+
+import { useDownloadPanelMenuItem } from '../useDownloadPanelMenuItem';
+
+const mockDownloadCsv = jest.fn();
+jest.mock('../useDownloadPanelCsv', () => ({
+	useDownloadPanelCsv: (): jest.Mock => mockDownloadCsv,
+}));
+
+const mockDownloadImage = jest.fn();
+jest.mock('../useDownloadPanelImage', () => ({
+	useDownloadPanelImage: (): { downloadPanelImage: jest.Mock } => ({
+		downloadPanelImage: mockDownloadImage,
+	}),
+}));
+
+const panel = {
+	spec: { display: { name: 'CPU' }, plugin: { kind: 'signoz/TablePanel' } },
+} as DashboardtypesPanelDTO;
+const data = {} as PanelQueryData;
+
+const download = (
+	formats: PanelActionCapabilities['download'],
+): PanelActionCapabilities => ({
+	view: true,
+	edit: true,
+	clone: true,
+	download: formats,
+	createAlert: true,
+	search: true,
+	drilldown: true,
+});
+
+type Submenu = { children: { key: string; onClick: () => void }[] };
+
+function render(actions: PanelActionCapabilities): { current: unknown } {
+	return renderHook(() =>
+		useDownloadPanelMenuItem({ panelId: 'panel-1', panel, data, actions }),
+	).result;
+}
+
+describe('useDownloadPanelMenuItem', () => {
+	beforeEach(() => jest.clearAllMocks());
+
+	it('returns null when the kind supports no download format', () => {
+		const result = render(download({ csv: false, png: false, svg: false }));
+		expect(result.current).toBeNull();
+	});
+
+	it('offers only the supported formats, dispatching CSV and image to their hooks', () => {
+		const result = render(download({ csv: true, png: true, svg: true }));
+		const item = result.current as Submenu;
+
+		expect(item.children.map((c) => c.key)).toStrictEqual([
+			'download-csv',
+			'download-png',
+			'download-svg',
+		]);
+
+		item.children.find((c) => c.key === 'download-csv')?.onClick();
+		expect(mockDownloadCsv).toHaveBeenCalledTimes(1);
+		expect(mockDownloadImage).not.toHaveBeenCalled();
+
+		item.children.find((c) => c.key === 'download-png')?.onClick();
+		expect(mockDownloadImage).toHaveBeenCalledWith('panel-1', 'CPU', 'png');
+
+		item.children.find((c) => c.key === 'download-svg')?.onClick();
+		expect(mockDownloadImage).toHaveBeenCalledWith('panel-1', 'CPU', 'svg');
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelCsv.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelCsv.ts
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import { getTableCsvRows } from 'pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/tableCsv';
+import type { PanelOfKind } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/rendererProps';
+import { downloadCsv } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/downloadCsv';
+import type { PanelQueryData } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
+
+interface UseDownloadPanelCsvArgs {
+	panel: DashboardtypesPanelDTO;
+	data: PanelQueryData;
+}
+
+/**
+ * Returns a callback that exports the panel's data as CSV. Only tables have
+ * tabular data to export; other kinds get a no-op.
+ */
+export function useDownloadPanelCsv({
+	panel,
+	data,
+}: UseDownloadPanelCsvArgs): () => void {
+	const kind = panel.spec.plugin.kind;
+	const fileName = panel.spec.display.name;
+
+	return useCallback((): void => {
+		if (kind !== 'signoz/TablePanel') {
+			return;
+		}
+		const rows = getTableCsvRows(panel as PanelOfKind<'signoz/TablePanel'>, data);
+		if (rows.length === 0) {
+			return;
+		}
+		downloadCsv(rows, fileName);
+	}, [kind, fileName, panel, data]);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelCsv.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelCsv.ts
@@ -8,21 +8,28 @@ import type { PanelQueryData } from 'pages/DashboardPageV2/DashboardContainer/qu
 interface UseDownloadPanelCsvArgs {
 	panel: DashboardtypesPanelDTO;
 	data: PanelQueryData;
+	/**
+	 * Whether the kind's definition declares CSV as a downloadable format
+	 * (`actions.download.csv`). Only tables carry tabular data, so this is the
+	 * same gate the menu uses — kept here so the callback stays a no-op when
+	 * invoked for a kind that can't produce CSV.
+	 */
+	canDownloadCsv: boolean;
 }
 
 /**
- * Returns a callback that exports the panel's data as CSV. Only tables have
- * tabular data to export; other kinds get a no-op.
+ * Returns a callback that exports the panel's data as CSV, gated on the kind's
+ * declared download capability. Non-CSV kinds get a no-op.
  */
 export function useDownloadPanelCsv({
 	panel,
 	data,
+	canDownloadCsv,
 }: UseDownloadPanelCsvArgs): () => void {
-	const kind = panel.spec.plugin.kind;
 	const fileName = panel.spec.display.name;
 
 	return useCallback((): void => {
-		if (kind !== 'signoz/TablePanel') {
+		if (!canDownloadCsv) {
 			return;
 		}
 		const rows = getTableCsvRows(panel as PanelOfKind<'signoz/TablePanel'>, data);
@@ -30,5 +37,5 @@ export function useDownloadPanelCsv({
 			return;
 		}
 		downloadCsv(rows, fileName);
-	}, [kind, fileName, panel, data]);
+	}, [canDownloadCsv, fileName, panel, data]);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelImage.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelImage.ts
@@ -1,0 +1,56 @@
+import { useCallback } from 'react';
+import { toast } from '@signozhq/ui/sonner';
+
+import {
+	downloadElementAsImage,
+	type PanelImageFormat,
+} from '../utils/downloadPanelImage';
+
+interface UseDownloadPanelImage {
+	downloadPanelImage: (
+		panelId: string,
+		panelName: string,
+		format: PanelImageFormat,
+	) => Promise<void>;
+}
+
+/**
+ * Downloads a V2 panel as an image (PNG or SVG). Locates the panel's root node
+ * by its `data-panel-root` marker (set in Panel.tsx) so the capture works
+ * without threading a ref through the header → actions-menu chain, then
+ * delegates to the pure capture util. Failures surface as an error toast.
+ */
+export function useDownloadPanelImage(): UseDownloadPanelImage {
+	const downloadPanelImage = useCallback(
+		async (
+			panelId: string,
+			panelName: string,
+			format: PanelImageFormat,
+		): Promise<void> => {
+			const node = document.querySelector<HTMLElement>(
+				`[data-panel-root="${CSS.escape(panelId)}"]`,
+			);
+			// The menu lives inside the panel, so the node is normally present;
+			// bail quietly if the panel unmounted between open and click.
+			if (!node) {
+				return;
+			}
+			try {
+				await downloadElementAsImage(node, panelName, format);
+			} catch {
+				toast.error('Could not download panel.', {
+					action: {
+						label: 'Dismiss',
+						onClick: (): void => {
+							toast.dismiss();
+						},
+					},
+					description: 'Something went wrong while capturing the panel image.',
+				});
+			}
+		},
+		[],
+	);
+
+	return { downloadPanelImage };
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelMenuItem.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelMenuItem.tsx
@@ -29,7 +29,11 @@ export function useDownloadPanelMenuItem({
 	actions,
 }: UseDownloadPanelMenuItemArgs): MenuItem | null {
 	const panelName = panel.spec.display.name;
-	const downloadPanelCsv = useDownloadPanelCsv({ panel, data });
+	const downloadPanelCsv = useDownloadPanelCsv({
+		panel,
+		data,
+		canDownloadCsv: actions.download[DownloadFormat.CSV],
+	});
 	const { downloadPanelImage } = useDownloadPanelImage();
 
 	const onDownload = useCallback(

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelMenuItem.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelMenuItem.tsx
@@ -1,0 +1,50 @@
+import { useCallback, useMemo } from 'react';
+import type { MenuItem } from '@signozhq/ui/dropdown-menu';
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import {
+	DownloadFormat,
+	type PanelActionCapabilities,
+} from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition';
+import type { PanelQueryData } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
+
+import { buildDownloadMenuItem } from '../utils/buildDownloadMenuItem';
+import { useDownloadPanelCsv } from './useDownloadPanelCsv';
+import { useDownloadPanelImage } from './useDownloadPanelImage';
+
+interface UseDownloadPanelMenuItemArgs {
+	panelId: string;
+	panel: DashboardtypesPanelDTO;
+	data: PanelQueryData;
+	actions: PanelActionCapabilities;
+}
+
+/**
+ * Resolves the panel's "Download" submenu item: CSV from the query response,
+ * PNG/SVG from the rendered node. Null when the kind supports no format.
+ */
+export function useDownloadPanelMenuItem({
+	panelId,
+	panel,
+	data,
+	actions,
+}: UseDownloadPanelMenuItemArgs): MenuItem | null {
+	const panelName = panel.spec.display.name;
+	const downloadPanelCsv = useDownloadPanelCsv({ panel, data });
+	const { downloadPanelImage } = useDownloadPanelImage();
+
+	const onDownload = useCallback(
+		(format: DownloadFormat): void => {
+			if (format === DownloadFormat.CSV) {
+				downloadPanelCsv();
+				return;
+			}
+			void downloadPanelImage(panelId, panelName, format);
+		},
+		[downloadPanelCsv, downloadPanelImage, panelId, panelName],
+	);
+
+	return useMemo(
+		() => buildDownloadMenuItem({ supported: actions.download, onDownload }),
+		[actions.download, onDownload],
+	);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/__tests__/downloadPanelImage.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/__tests__/downloadPanelImage.test.ts
@@ -1,0 +1,88 @@
+import { toPng, toSvg } from 'html-to-image';
+import { DownloadFormat } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition';
+
+import { downloadElementAsImage } from '../downloadPanelImage';
+
+jest.mock('html-to-image', () => ({ toPng: jest.fn(), toSvg: jest.fn() }));
+
+const mockToPng = toPng as jest.MockedFunction<typeof toPng>;
+const mockToSvg = toSvg as jest.MockedFunction<typeof toSvg>;
+
+describe('downloadElementAsImage', () => {
+	let node: HTMLElement;
+	let fakeLink: {
+		href: string;
+		download: string;
+		click: jest.Mock;
+		remove: jest.Mock;
+	};
+
+	beforeEach(() => {
+		mockToPng.mockReset();
+		mockToPng.mockResolvedValue('data:image/png;base64,AAAA');
+		mockToSvg.mockReset();
+		mockToSvg.mockResolvedValue('data:image/svg+xml;base64,BBBB');
+
+		fakeLink = { href: '', download: '', click: jest.fn(), remove: jest.fn() };
+		// Only stub the anchor used for the download; let every other tag (the
+		// elements the filter test builds) fall through to the real DOM.
+		const realCreateElement = document.createElement.bind(document);
+		jest
+			.spyOn(document, 'createElement')
+			.mockImplementation((tag: string) =>
+				tag === 'a'
+					? (fakeLink as unknown as HTMLAnchorElement)
+					: realCreateElement(tag),
+			);
+
+		node = document.createElement('div');
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('captures a PNG via the png encoder, named after the panel', async () => {
+		await downloadElementAsImage(node, 'My panel', DownloadFormat.PNG);
+
+		expect(mockToPng).toHaveBeenCalledTimes(1);
+		expect(mockToPng.mock.calls[0][0]).toBe(node);
+		expect(mockToSvg).not.toHaveBeenCalled();
+		expect(fakeLink.href).toBe('data:image/png;base64,AAAA');
+		expect(fakeLink.download).toBe('My panel.png');
+		expect(fakeLink.click).toHaveBeenCalledTimes(1);
+		expect(fakeLink.remove).toHaveBeenCalledTimes(1);
+	});
+
+	it('captures an SVG via the svg encoder and extension', async () => {
+		await downloadElementAsImage(node, 'My panel', DownloadFormat.SVG);
+
+		expect(mockToSvg).toHaveBeenCalledTimes(1);
+		expect(mockToPng).not.toHaveBeenCalled();
+		expect(fakeLink.href).toBe('data:image/svg+xml;base64,BBBB');
+		expect(fakeLink.download).toBe('My panel.svg');
+	});
+
+	it('filters the actions cluster (.panel-no-drag) out of the capture but keeps content', async () => {
+		await downloadElementAsImage(node, 'x', DownloadFormat.PNG);
+
+		const { filter } = mockToPng.mock.calls[0][1] as {
+			filter: (n: HTMLElement) => boolean;
+		};
+
+		const actions = document.createElement('div');
+		actions.classList.add('panel-no-drag');
+		const chart = document.createElement('canvas');
+
+		expect(filter(actions)).toBe(false);
+		expect(filter(chart)).toBe(true);
+	});
+
+	it('falls back to "panel" when untitled and sanitizes filesystem-unsafe characters', async () => {
+		await downloadElementAsImage(node, '   ', DownloadFormat.PNG);
+		expect(fakeLink.download).toBe('panel.png');
+
+		await downloadElementAsImage(node, 'errors/sec: p99', DownloadFormat.SVG);
+		expect(fakeLink.download).toBe('errors-sec- p99.svg');
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildDownloadMenuItem.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildDownloadMenuItem.tsx
@@ -1,0 +1,70 @@
+import {
+	CloudDownload,
+	FileCode,
+	FileImage,
+	FileSpreadsheet,
+} from '@signozhq/icons';
+import type { MenuItem } from '@signozhq/ui/dropdown-menu';
+import {
+	DownloadFormat,
+	type PanelActionCapabilities,
+} from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition';
+
+const DOWNLOAD_FORMAT_OPTIONS: {
+	format: DownloadFormat;
+	label: string;
+	icon: JSX.Element;
+}[] = [
+	{
+		format: DownloadFormat.CSV,
+		label: 'Download as CSV',
+		icon: <FileSpreadsheet size={14} />,
+	},
+	{
+		format: DownloadFormat.PNG,
+		label: 'Download as PNG',
+		icon: <FileImage size={14} />,
+	},
+	{
+		format: DownloadFormat.SVG,
+		label: 'Download as SVG',
+		icon: <FileCode size={14} />,
+	},
+];
+
+interface DownloadMenuItemArgs {
+	supported?: PanelActionCapabilities['download'];
+	onDownload: (format: DownloadFormat) => void;
+}
+
+/**
+ * The "Download" submenu: one option per format the kind supports, each handing
+ * the format to `onDownload`. Null when the kind supports no format.
+ */
+export function buildDownloadMenuItem({
+	supported,
+	onDownload,
+}: DownloadMenuItemArgs): MenuItem | null {
+	if (!supported) {
+		return null;
+	}
+
+	const children: MenuItem[] = DOWNLOAD_FORMAT_OPTIONS.filter(
+		({ format }) => supported[format],
+	).map(({ format, label, icon }) => ({
+		key: `download-${format}`,
+		label,
+		icon,
+		onClick: (): void => onDownload(format),
+	}));
+
+	if (children.length === 0) {
+		return null;
+	}
+	return {
+		key: 'download',
+		label: 'Download',
+		icon: <CloudDownload size={14} />,
+		children,
+	};
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildMoveItems.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildMoveItems.tsx
@@ -1,0 +1,65 @@
+import { FolderInput, FolderOutput } from '@signozhq/icons';
+import type { MenuItem } from '@signozhq/ui/dropdown-menu';
+
+import type { DashboardSection } from '../../../utils';
+import type { MovePanelArgs } from '../hooks/useMovePanelToSection';
+
+interface MoveItemsArgs {
+	sections: DashboardSection[];
+	currentLayoutIndex: number;
+	panelId: string;
+	movePanel: (args: MovePanelArgs) => Promise<void>;
+}
+
+/**
+ * The "Move to section" submenu plus a direct "Move out of section" to the
+ * untitled root, shown only when the panel sits in a titled section and a root
+ * section exists to receive it.
+ */
+export function buildMoveItems({
+	sections,
+	currentLayoutIndex,
+	panelId,
+	movePanel,
+}: MoveItemsArgs): MenuItem[] {
+	const targets = sections.filter(
+		(s) => s.title && s.layoutIndex !== currentLayoutIndex,
+	);
+	const items: MenuItem[] = [
+		{
+			key: 'move',
+			label: 'Move to section',
+			icon: <FolderInput size={14} />,
+			...(targets.length === 0
+				? { disabled: true }
+				: {
+						children: targets.map((s) => ({
+							key: `move-${s.layoutIndex}`,
+							label: s.title,
+							onClick: (): void =>
+								void movePanel({
+									panelId,
+									fromLayoutIndex: currentLayoutIndex,
+									toLayoutIndex: s.layoutIndex,
+								}),
+						})),
+					}),
+		},
+	];
+
+	const rootSection = sections.find((s) => !s.title);
+	if (rootSection && rootSection.layoutIndex !== currentLayoutIndex) {
+		items.push({
+			key: 'move-to-root',
+			label: 'Move out of section',
+			icon: <FolderOutput size={14} />,
+			onClick: (): void =>
+				void movePanel({
+					panelId,
+					fromLayoutIndex: currentLayoutIndex,
+					toLayoutIndex: rootSection.layoutIndex,
+				}),
+		});
+	}
+	return items;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildMoveItems.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildMoveItems.tsx
@@ -1,7 +1,7 @@
 import { FolderInput, FolderOutput } from '@signozhq/icons';
 import type { MenuItem } from '@signozhq/ui/dropdown-menu';
 
-import type { DashboardSection } from '../../../utils';
+import { findRootSection, type DashboardSection } from '../../../utils';
 import type { MovePanelArgs } from '../hooks/useMovePanelToSection';
 
 interface MoveItemsArgs {
@@ -47,7 +47,7 @@ export function buildMoveItems({
 		},
 	];
 
-	const rootSection = sections.find((s) => !s.title);
+	const rootSection = findRootSection(sections);
 	if (rootSection && rootSection.layoutIndex !== currentLayoutIndex) {
 		items.push({
 			key: 'move-to-root',

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/downloadPanelImage.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/downloadPanelImage.ts
@@ -1,0 +1,55 @@
+import { toPng, toSvg } from 'html-to-image';
+import { DownloadFormat } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition';
+import { toSafeFileName } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/toSafeFileName';
+
+/** Image formats a panel can be exported to (both via html-to-image). */
+export type PanelImageFormat = DownloadFormat.PNG | DownloadFormat.SVG;
+
+// The actions cluster (search box, status popovers, three-dot menu) is chrome,
+// not content — it carries this class to opt out of the grid drag handle (see
+// PanelHeader), and we reuse it to drop the whole cluster from the capture.
+const ACTIONS_CONTAINER_CLASS = 'panel-no-drag';
+
+// Render raster output at 2x so the PNG stays crisp on retina displays. SVG is
+// vector, so the ratio is irrelevant there (html-to-image ignores it).
+const CAPTURE_PIXEL_RATIO = 2;
+
+// Per-format encoder: html-to-image's toPng/toSvg share a signature and both
+// return a ready-to-download data URL, so they differ only by file extension.
+const FORMAT_ENCODERS: Record<
+	PanelImageFormat,
+	{ encode: typeof toPng; extension: PanelImageFormat }
+> = {
+	[DownloadFormat.PNG]: { encode: toPng, extension: DownloadFormat.PNG },
+	[DownloadFormat.SVG]: { encode: toSvg, extension: DownloadFormat.SVG },
+};
+
+/**
+ * Captures a panel's rendered DOM node as an image (PNG or SVG) and triggers a
+ * browser download. The hover-only actions cluster is filtered out so the image
+ * is just the panel title plus its chart/table. Resolves once the download is
+ * initiated; rejects if the capture fails (the caller surfaces the error).
+ */
+export async function downloadElementAsImage(
+	node: HTMLElement,
+	fileBaseName: string,
+	format: PanelImageFormat,
+): Promise<void> {
+	const { encode, extension } = FORMAT_ENCODERS[format];
+
+	const dataUrl = await encode(node, {
+		// Skip the actions cluster (and its subtree) — search/status/menu chrome.
+		filter: (domNode) => !domNode.classList?.contains(ACTIONS_CONTAINER_CLASS),
+		// `.panel` paints --l2-background; pass it explicitly so the rounded
+		// corners fill with the panel colour instead of staying transparent.
+		backgroundColor: window.getComputedStyle(node).backgroundColor,
+		pixelRatio: CAPTURE_PIXEL_RATIO,
+		cacheBust: true,
+	});
+
+	const link = document.createElement('a');
+	link.href = dataUrl;
+	link.download = `${toSafeFileName(fileBaseName)}.${extension}`;
+	link.click();
+	link.remove();
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/utils.ts
@@ -137,3 +137,14 @@ export function layoutsToSections(
 		})
 		.filter((s): s is DashboardSection => s !== null);
 }
+
+/**
+ * The untitled, free-flow root section that ungrouped panels live in — the
+ * first layout (`layoutIndex === 0`) when it has no title. Titled sections and
+ * any later untitled layout are never the root.
+ */
+export function findRootSection(
+	sections: DashboardSection[],
+): DashboardSection | undefined {
+	return sections.find((section) => !section.title && section.layoutIndex === 0);
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist? What problem does it solve, and why is this the right approach?

Adds a **Download** action to Dashboard V2 panels, bringing them to parity with V1. The panel actions menu (⋮) gains a single **Download** entry that opens a submenu of the formats the panel kind supports:

- **Download as PNG** / **Download as SVG** — capture the panel's rendered DOM (title + chart/table) as an image; available on every renderable kind.
- **Download as CSV** — table panels only; exports the full result set with the same values shown on screen.

The hover-only chrome (search box, status popovers, the actions button itself) is filtered out of the image capture, so the exported image is just the panel content.

**Why this approach:** the actions menu lives in the panel header, decoupled from the renderer. Image capture needs the rendered DOM node, so it's located at click time via a `data-panel-root={panelId}` marker — no ref threading through the header → menu chain. CSV needs the query response, which is threaded to the menu via props (`Panel → PanelHeader → PanelActionsMenu`) so it can export the **full result set** rather than the table's paginated DOM. Each format's wiring lives in a small hook — `useDownloadPanelMenuItem` composes the submenu and the actions menu just consumes a ready item — and kind-specific CSV shaping is localized in `useDownloadPanelCsv`, keeping the generic actions menu free of per-kind logic.

#### Screenshots / Screen Recordings (if applicable)

<img width="954" height="416" alt="image" src="https://github.com/user-attachments/assets/218ce3da-36d6-442f-8987-efa3ac565860" />

#### Issues closed by this PR
Closes https://github.com/SigNoz/pulse-pod/issues/21

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

N/A — not a bug fix.

---

### 🧪 Testing Strategy
> How was this change validated?

- **Tests added/updated:**
  - Image capture util (`downloadElementAsImage`): PNG/SVG encoders, `.panel-no-drag` chrome filter, filename sanitization.
  - `useDownloadPanelImage` hook: `data-panel-root` node lookup, error toast on failure.
  - CSV shaping: `getTableCsvRows` (prepares + flattens the scalar table) and `buildTableCsvRows` (column-name headers, display order, value-vs-group formatting).
  - `useDownloadPanelCsv` hook: table-kind dispatch, no-op for non-table kinds and empty responses.
  - `useDownloadPanelMenuItem`: per-format dispatch (CSV → data, PNG/SVG → capture), formats gated by the kind's `actions.download`.
  - Actions-menu composition (`usePanelActionItems`): the Download item is consumed and gated per role/kind/context.
- **Manual verification:**
  - Exported one PNG and one SVG in both dark and light themes.
  - CSV opens with headers = visible column titles and cells matching the on-screen formatting (units + precision); full result set, not just the current page.
  - `Download` submenu shows CSV only for table panels; PNG/SVG on every renderable kind.
  - `pnpm tsgo --noEmit`, `pnpm oxlint`, `pnpm build` — all clean.
- **Edge cases covered:**
  - Read-only dashboards: PNG/SVG/CSV are non-mutating, so they stay available (like **View**).
  - Untitled panel → safe fallback filename.
  - Panel unmounted between menu-open and click → image capture no-ops.
  - Empty / non-table response → CSV no-ops.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** Dashboard V2 panel actions menu only. No changes to V1, and none to the query/data-fetch paths. `PanelHeader` / `PanelActionsMenu` gain a `data` prop (the panel's query response) so the menu can build CSV. Adds one dependency (`html-to-image`); `papaparse` is already in the repo.
- **Potential regressions:** The panel-action capability model changed — `download` is now a per-format `Record<DownloadFormat, boolean>` (`DownloadFormat` is a string enum). Every kind must declare its formats, so a missing decision is a compile error rather than a silent gap.
- **Rollback plan:** Revert the PR. No migrations, no persisted state, no API or schema changes.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | OSS / Cloud / Enterprise |
| Change Type | Feature |
| Description | Dashboard V2 panels can now be downloaded from the panel actions menu — as PNG or SVG (any panel), or as CSV (table panels). |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (internal capability-model change noted above; no user-facing breaking change)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- **PNG/SVG:** worth eyeballing one exported PNG and one SVG for font/CSS rendering — SVG embeds fonts/styles differently than the raster path, and if a CSP blocks web-font embedding the text falls back gracefully. Background is taken from the panel's own computed `--l2-background`, so a quick check in dark + light themes helps.
- **CSV:** headers are the visible column titles and values reuse the table's on-screen formatting; it exports the full result set, not just the current page. CSV/data failures are currently silent (no error toast, unlike the image path) — happy to add one if preferred.
- Commits are self-contained and reviewable in order (bottom-up, each builds on the previous):
  1. `chore` — add the `html-to-image` dependency.
  2. `feat` — declare the per-kind download capability (`DownloadFormat` enum + `actions.download`).
  3. `feat` — panel image capture util (`downloadElementAsImage`) + `useDownloadPanelImage` hook.
  4. `feat` — table CSV export (`getTableCsvRows` / `downloadCsv`, `formatTableCellText` shared with the column renderer).
  5. `feat` — the Download action menu: composed hooks (`useDownloadPanelMenuItem` / `useDownloadPanelCsv`), the query response threaded to the menu via props, and the presentational menu builder.

---
