### PR TITLE
fix(metrics-explorer): resolve pagination overlap in table

### DIFF
--- a/frontend/src/container/MetricsExplorer/Summary/Summary.styles.scss
+++ b/frontend/src/container/MetricsExplorer/Summary/Summary.styles.scss
@@ -58,6 +58,7 @@
 	}
 
 	.metrics-table-container {
+		padding-bottom: 48px;
 		.ant-table {
 			margin-left: -16px;
 			margin-right: -16px;
@@ -182,13 +183,15 @@
 		}
 
 		.ant-pagination {
-			position: sticky;
+			position: fixed;
 			bottom: 0;
-			width: 100%;
+			width: calc(100% - 54px);
 			background: var(--l1-background);
 			padding: 16px;
 			margin: 0;
-			z-index: 10;
+
+			// this is to offset chat support icon till we improve the design
+			right: 20px;
 
 			.ant-pagination-item {
 				border-radius: 4px;

--- a/frontend/src/container/MetricsExplorer/Summary/Summary.styles.scss
+++ b/frontend/src/container/MetricsExplorer/Summary/Summary.styles.scss
@@ -182,15 +182,13 @@
 		}
 
 		.ant-pagination {
-			position: fixed;
+			position: sticky;
 			bottom: 0;
-			width: calc(100% - 54px);
+			width: 100%;
 			background: var(--l1-background);
 			padding: 16px;
 			margin: 0;
-
-			// this is to offset chat support icon till we improve the design
-			right: 20px;
+			z-index: 10;
 
 			.ant-pagination-item {
 				border-radius: 4px;


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

This PR fixes a UI bug in the Metrics Explorer where the pagination component at the bottom of the List View table would overlap the bottom rows of the table, making them unreadable.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:
<img width="1534" height="1023" alt="image" src="https://github.com/user-attachments/assets/b43c055a-0770-4aac-8aa6-cd15465dff90" />

After:
<img width="1915" height="902" alt="image" src="https://github.com/user-attachments/assets/f974545b-86e2-44a4-8fa2-e3cc13676703" />


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes #11807

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: N/A (CSS only)
- Manual verification: Ran the frontend locally against the community backend. Generated metrics and verified in the "Metrics Explorer" List View that the bottom rows (e.g., `otelcol_exporter_queue_capacity`) are fully visible and sit above the pagination bar.
- Edge cases covered: Verified that the pagination still stays at the bottom when there are few rows vs many rows.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Very small, only affects the metrics table in the Metrics Explorer Summary tab.
- Potential regressions: Pagination layout breaking on extremely small screens (mitigated by setting width to 100%).
- Rollback plan: Revert the CSS change in `Summary.styles.scss`.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | OSS |
| Change Type | Bug Fix |
| Description | Fixed a UI overlap issue in the Metrics Explorer where the table pagination obscured the bottom rows. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered
