### PR TITLE
feat: add regex filtering for dynamic variables

### DIFF
--- a/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/VariableItem.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardSettings/DashboardVariableSettings/VariableItem/VariableItem.tsx
@@ -21,6 +21,7 @@ import { getWidgetsHavingDynamicVariableAttribute } from 'hooks/dashboard/utils'
 import { useGetFieldValues } from 'hooks/dynamicVariables/useGetFieldValues';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { commaValuesParser } from 'lib/dashboardVariables/customCommaValuesParser';
+import { filterVariableValues } from 'lib/dashboardVariables/filterVariableValues';
 import sortValues from 'lib/dashboardVariables/sortVariableValues';
 import { isEmpty, map } from 'lodash-es';
 import {
@@ -123,6 +124,9 @@ function VariableItem({
 
 	const [dynamicVariablesSelectedValue, setDynamicVariablesSelectedValue] =
 		useState<{ name: string; value: string }>();
+	const [dynamicVariablesRegex, setDynamicVariablesRegex] = useState<string>(
+		variableData.dynamicVariablesRegex || '',
+	);
 
 	// Error messages
 	const [errorName, setErrorName] = useState<boolean>(false);
@@ -146,6 +150,10 @@ function VariableItem({
 		variableData.dynamicVariablesAttribute,
 		variableData.dynamicVariablesSource,
 	]);
+
+	useEffect(() => {
+		setDynamicVariablesRegex(variableData.dynamicVariablesRegex || '');
+	}, [variableData.dynamicVariablesRegex]);
 
 	// Validate attribute key uniqueness for dynamic variables
 	useEffect(() => {
@@ -285,15 +293,16 @@ function VariableItem({
 			dynamicVariablesSelectedValue?.name &&
 			dynamicVariablesSelectedValue?.value
 		) {
-			setPreviewValues(
-				sortValues(
-					fieldValues.data?.normalizedValues || [],
-					variableSortType,
-				) as never,
+			const result = filterVariableValues(
+				fieldValues.data?.normalizedValues || [],
+				dynamicVariablesRegex,
 			);
+			setPreviewValues(sortValues(result.values, variableSortType) as never);
+			setErrorPreview(result.error ?? null);
 		}
 	}, [
 		fieldValues,
+		dynamicVariablesRegex,
 		variableSortType,
 		queryType,
 		dynamicVariablesSelectedValue?.name,
@@ -364,6 +373,7 @@ function VariableItem({
 			...(queryType === 'DYNAMIC' && {
 				dynamicVariablesAttribute: dynamicVariablesSelectedValue?.name,
 				dynamicVariablesSource: dynamicVariablesSelectedValue?.value,
+				dynamicVariablesRegex: dynamicVariablesRegex || undefined,
 			}),
 			selectedValue: variableValue,
 			allSelected: variableData.allSelected,
@@ -629,6 +639,20 @@ function VariableItem({
 								errorAttributeKeyMessage={errorAttributeKeyMessage}
 							/>
 						</div>
+					)}
+					{queryType === 'DYNAMIC' && (
+						<VariableItemRow className="dynamic-regex-section">
+							<LabelContainer>
+								<Typography className="typography-variables">Regex</Typography>
+							</LabelContainer>
+							<Input
+								value={dynamicVariablesRegex}
+								className="default-input"
+								onChange={(e): void => setDynamicVariablesRegex(e.target.value)}
+								placeholder="^api-.*"
+								style={{ width: 400 }}
+							/>
+						</VariableItemRow>
 					)}
 					{queryType === 'QUERY' && (
 						<div className="query-container">

--- a/frontend/src/container/DashboardContainer/DashboardVariablesSelection/DynamicVariableInput.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardVariablesSelection/DynamicVariableInput.tsx
@@ -7,6 +7,7 @@ import { DEBOUNCE_DELAY } from 'constants/queryBuilderFilterConfig';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { useVariableFetchState } from 'hooks/dashboard/useVariableFetchState';
 import useDebounce from 'hooks/useDebounce';
+import { filterVariableValues } from 'lib/dashboardVariables/filterVariableValues';
 import { AppState } from 'store/reducers';
 import { SuccessResponseV2 } from 'types/api';
 import { FieldValueResponse } from 'types/api/dynamicVariables/getFieldValues';
@@ -147,8 +148,23 @@ function DynamicVariableInput({
 
 	const handleQuerySuccess = useCallback(
 		(data: SuccessResponseV2<FieldValueResponse>): void => {
-			const newNormalizedValues = data.data?.normalizedValues || [];
-			const newRelatedValues = data.data?.relatedValues || [];
+			const filteredNormalizedValues = filterVariableValues(
+				data.data?.normalizedValues || [],
+				variableData.dynamicVariablesRegex,
+			);
+			const filteredRelatedValues = filterVariableValues(
+				data.data?.relatedValues || [],
+				variableData.dynamicVariablesRegex,
+			);
+			const newNormalizedValues = filteredNormalizedValues.values;
+			const newRelatedValues = filteredRelatedValues.values.map((value) =>
+				value.toString(),
+			);
+			const regexError =
+				filteredNormalizedValues.error ?? filteredRelatedValues.error;
+
+			setErrorMessage(regexError ?? null);
+			setIsRetryableError(!regexError);
 
 			if (!debouncedApiSearchText) {
 				setOptionsData(newNormalizedValues);
@@ -192,6 +208,7 @@ function DynamicVariableInput({
 		[
 			debouncedApiSearchText,
 			variableData.allSelected,
+			variableData.dynamicVariablesRegex,
 			variableData.name,
 			isDropdownOpen,
 			tempSelection,
@@ -222,6 +239,7 @@ function DynamicVariableInput({
 			debouncedApiSearchText,
 			variableData.dynamicVariablesSource,
 			variableData.dynamicVariablesAttribute,
+			variableData.dynamicVariablesRegex,
 			variableFetchCycleId,
 		],
 		{

--- a/frontend/src/lib/dashboardVariables/filterVariableValues.test.ts
+++ b/frontend/src/lib/dashboardVariables/filterVariableValues.test.ts
@@ -1,0 +1,47 @@
+import { filterVariableValues } from './filterVariableValues';
+
+describe('filterVariableValues', () => {
+	it('returns values unchanged when pattern is empty', () => {
+		expect(
+			filterVariableValues(['frontend', 'backend'], '').values,
+		).toStrictEqual(['frontend', 'backend']);
+	});
+
+	it('filters values by regex pattern', () => {
+		expect(
+			filterVariableValues(['frontend-api', 'backend-api', 'worker'], '^front')
+				.values,
+		).toStrictEqual(['frontend-api']);
+	});
+
+	it('uses the first capture group as the returned value', () => {
+		expect(
+			filterVariableValues(
+				['k8s-prod-api-123', 'k8s-prod-worker-456', 'dev-api'],
+				'^k8s-prod-(.+)-\\d+$',
+			).values,
+		).toStrictEqual(['api', 'worker']);
+	});
+
+	it('supports slash-delimited regex with flags', () => {
+		expect(filterVariableValues(['API', 'web'], '/api/i').values).toStrictEqual([
+			'API',
+		]);
+	});
+
+	it('deduplicates captured values', () => {
+		expect(
+			filterVariableValues(
+				['pod-api-1', 'pod-api-2', 'pod-worker-1'],
+				'^pod-(.+)-\\d+$',
+			).values,
+		).toStrictEqual(['api', 'worker']);
+	});
+
+	it('returns the original values with an error for invalid regex', () => {
+		const result = filterVariableValues(['frontend'], '[');
+
+		expect(result.values).toStrictEqual(['frontend']);
+		expect(result.error).toBeTruthy();
+	});
+});

--- a/frontend/src/lib/dashboardVariables/filterVariableValues.ts
+++ b/frontend/src/lib/dashboardVariables/filterVariableValues.ts
@@ -1,0 +1,63 @@
+type VariableValue = string | number | boolean;
+
+export interface FilterVariableValuesResult {
+	values: VariableValue[];
+	error?: string;
+}
+
+function buildRegex(pattern: string): RegExp {
+	const slashDelimitedMatch = /^\/(.+)\/([gimsuy]*)$/.exec(pattern);
+
+	if (slashDelimitedMatch) {
+		const [, source, flags] = slashDelimitedMatch;
+		return new RegExp(source, flags);
+	}
+
+	return new RegExp(pattern);
+}
+
+export function filterVariableValues(
+	values: VariableValue[],
+	pattern?: string,
+): FilterVariableValuesResult {
+	const trimmedPattern = pattern?.trim();
+
+	if (!trimmedPattern) {
+		return { values };
+	}
+
+	let regex: RegExp;
+	try {
+		regex = buildRegex(trimmedPattern);
+	} catch (error) {
+		return {
+			values,
+			error: error instanceof Error ? error.message : 'Invalid regex',
+		};
+	}
+
+	const seen = new Set<string>();
+	const filteredValues: VariableValue[] = [];
+
+	values.forEach((value) => {
+		regex.lastIndex = 0;
+		const match = regex.exec(value.toString());
+
+		if (!match) {
+			return;
+		}
+
+		const capturedValue = match.slice(1).find((group) => group !== undefined);
+		const nextValue = capturedValue ?? value;
+		const nextValueKey = nextValue.toString();
+
+		if (seen.has(nextValueKey)) {
+			return;
+		}
+
+		seen.add(nextValueKey);
+		filteredValues.push(nextValue);
+	});
+
+	return { values: filteredValues };
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/DynamicVariableFields.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/DynamicVariableFields.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Input } from '@signozhq/ui/input';
 import { SelectSimple } from '@signozhq/ui/select';
 import { Typography } from '@signozhq/ui/typography';
 import cx from 'classnames';
@@ -7,6 +8,7 @@ import { Select } from 'antd';
 import { useGetFieldKeys } from 'hooks/dynamicVariables/useGetFieldKeys';
 import { useGetFieldValues } from 'hooks/dynamicVariables/useGetFieldValues';
 import useDebounce from 'hooks/useDebounce';
+import { filterVariableValues } from 'lib/dashboardVariables/filterVariableValues';
 
 import { TELEMETRY_SIGNALS, type TelemetrySignal } from '../variableModel';
 import styles from './VariableForm.module.scss';
@@ -14,19 +16,24 @@ import styles from './VariableForm.module.scss';
 interface DynamicVariableFieldsProps {
 	attribute: string;
 	signal: TelemetrySignal;
+	capturingRegexp: string;
 	onChange: (patch: {
 		dynamicAttribute?: string;
 		dynamicSignal?: TelemetrySignal;
+		capturingRegexp?: string;
 	}) => void;
 	onPreview: (values: (string | number)[]) => void;
+	onPreviewError: (error: string | null) => void;
 }
 
 /** Dynamic-variable body: telemetry signal + field, whose live values preview. */
 function DynamicVariableFields({
 	attribute,
 	signal,
+	capturingRegexp,
 	onChange,
 	onPreview,
+	onPreviewError,
 }: DynamicVariableFieldsProps): JSX.Element {
 	const [search, setSearch] = useState('');
 	const debouncedSearch = useDebounce(search, 300);
@@ -58,9 +65,11 @@ function DynamicVariableFields({
 		const payload = valueData?.data;
 		const values =
 			payload?.normalizedValues ?? payload?.values?.StringValues ?? [];
-		onPreview(values);
+		const result = filterVariableValues(values, capturingRegexp);
+		onPreview(result.values as (string | number)[]);
+		onPreviewError(result.error ?? null);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [valueData]);
+	}, [valueData, capturingRegexp]);
 
 	return (
 		<>
@@ -94,6 +103,18 @@ function DynamicVariableFields({
 					options={options}
 					notFoundContent={isLoading ? 'Loading…' : 'No fields found'}
 					data-testid="variable-field-select"
+				/>
+			</div>
+			<div className={cx(styles.row, styles.textboxSection)}>
+				<div className={styles.labelContainer}>
+					<Typography.Text className={styles.label}>Regex</Typography.Text>
+				</div>
+				<Input
+					className={styles.defaultInput}
+					value={capturingRegexp}
+					placeholder="^api-.*"
+					onChange={(e): void => onChange({ capturingRegexp: e.target.value })}
+					testId="variable-regex-input"
 				/>
 			</div>
 		</>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableForm.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableForm.tsx
@@ -165,8 +165,10 @@ function VariableForm({
 						<DynamicVariableFields
 							attribute={model.dynamicAttribute}
 							signal={model.dynamicSignal}
+							capturingRegexp={model.capturingRegexp}
 							onChange={(patch): void => set(patch)}
 							onPreview={setPreviewValues}
+							onPreviewError={setPreviewError}
 						/>
 					) : null}
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters.test.ts
@@ -1,0 +1,44 @@
+import type { DashboardtypesVariableDTO } from 'api/generated/services/sigNoz.schemas';
+
+import { dtoToFormModel, formModelToDto } from './variableAdapters';
+import { emptyVariableFormModel } from './variableModel';
+
+describe('variableAdapters', () => {
+	it('maps dynamic variable capturingRegexp from DTO to form model', () => {
+		const dto = {
+			kind: 'ListVariable',
+			spec: {
+				name: 'pod',
+				display: { name: 'pod' },
+				allowAllValue: false,
+				allowMultiple: false,
+				sort: 'DISABLED',
+				capturingRegexp: '^api-.*',
+				plugin: {
+					kind: 'signoz/DynamicVariable',
+					spec: {
+						name: 'k8s.pod.name',
+						signal: 'metrics',
+					},
+				},
+			},
+		} as DashboardtypesVariableDTO;
+
+		expect(dtoToFormModel(dto).capturingRegexp).toBe('^api-.*');
+	});
+
+	it('maps dynamic variable capturingRegexp from form model to DTO', () => {
+		const dto = formModelToDto({
+			...emptyVariableFormModel(),
+			name: 'pod',
+			type: 'DYNAMIC',
+			dynamicAttribute: 'k8s.pod.name',
+			dynamicSignal: 'metrics',
+			capturingRegexp: '^api-.*',
+		});
+
+		expect((dto.spec as { capturingRegexp?: string }).capturingRegexp).toBe(
+			'^api-.*',
+		);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters.ts
@@ -51,6 +51,7 @@ export function dtoToFormModel(
 		multiSelect: spec.allowMultiple ?? false,
 		showAllOption: spec.allowAllValue ?? false,
 		sort: (spec.sort as VariableSort) ?? 'DISABLED',
+		capturingRegexp: spec.capturingRegexp ?? '',
 		defaultValue: spec.defaultValue,
 	};
 	const plugin = spec.plugin;
@@ -137,6 +138,7 @@ export function formModelToDto(
 			allowMultiple: model.multiSelect,
 			allowAllValue: model.showAllOption,
 			sort: model.sort,
+			capturingRegexp: model.capturingRegexp || undefined,
 			defaultValue: model.defaultValue,
 			plugin: buildPlugin(model),
 		},

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableModel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableModel.ts
@@ -44,6 +44,7 @@ export interface VariableFormModel {
 	multiSelect: boolean;
 	showAllOption: boolean;
 	sort: VariableSort;
+	capturingRegexp: string;
 
 	// Type-specific.
 	queryValue: string; // QUERY
@@ -69,6 +70,7 @@ export function emptyVariableFormModel(): VariableFormModel {
 		multiSelect: false,
 		showAllOption: false,
 		sort: 'DISABLED',
+		capturingRegexp: '',
 		queryValue: '',
 		customValue: '',
 		textValue: '',

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { useGetFieldValues } from 'hooks/dynamicVariables/useGetFieldValues';
+import { filterVariableValues } from 'lib/dashboardVariables/filterVariableValues';
 import type { AppState } from 'store/reducers';
 import type { GlobalReducer } from 'types/reducer/globalTime';
 
@@ -61,8 +62,9 @@ function DynamicSelector({
 		const payload = data?.data;
 		const values =
 			payload?.normalizedValues ?? payload?.values?.StringValues ?? [];
-		return sortValuesByOrder(values, variable.sort).map(String);
-	}, [data, variable.sort]);
+		const result = filterVariableValues(values, variable.capturingRegexp);
+		return sortValuesByOrder(result.values, variable.sort).map(String);
+	}, [data, variable.capturingRegexp, variable.sort]);
 
 	useAutoSelect(variable, options, selection, onChange);
 

--- a/frontend/src/types/api/dashboard/getAll.ts
+++ b/frontend/src/types/api/dashboard/getAll.ts
@@ -61,6 +61,7 @@ export interface IDashboardVariable {
 	defaultValue?: string;
 	dynamicVariablesAttribute?: string;
 	dynamicVariablesSource?: string;
+	dynamicVariablesRegex?: string;
 	haveCustomValuesSelected?: boolean;
 }
 export interface Dashboard {


### PR DESCRIPTION
Closes #11715

## Summary
- add an optional regex field for dynamic variables in both dashboard variable editors
- persist V2 filters through the existing capturingRegexp field and legacy filters through dynamicVariablesRegex
- apply regex filtering to previews, defaults, ALL selection, and live dynamic variable dropdown values
- support capture groups for value extraction and slash-delimited regex patterns

## Testing
- pnpm test -- filterVariableValues.test.ts variableAdapters.test.ts --runInBand
- pnpm exec tsgo --noEmit
- pnpm exec oxlint <changed files>