### PR TITLE
fix: use rule orgID instead of SELECT LIMIT 1 in SendAlerts (#11351)

### DIFF
--- a/pkg/query-service/rules/base_rule.go
+++ b/pkg/query-service/rules/base_rule.go
@@ -358,19 +358,7 @@ func (r *BaseRule) ActiveAlerts() []*ruletypes.Alert {
 }
 
 func (r *BaseRule) SendAlerts(ctx context.Context, ts time.Time, resendDelay time.Duration, interval time.Duration, notifyFunc NotifyFunc) {
-	var orgID string
-	err := r.
-		sqlstore.
-		BunDB().
-		NewSelect().
-		Table("organizations").
-		ColumnExpr("id").
-		Limit(1).
-		Scan(ctx, &orgID)
-	if err != nil {
-		r.logger.ErrorContext(ctx, "failed to get org ids", errors.Attr(err))
-		return
-	}
+	orgID := r.orgID.StringValue()
 
 	alerts := []*ruletypes.Alert{}
 	r.ForEachActiveAlert(func(alert *ruletypes.Alert) {

--- a/pkg/query-service/rules/base_rule.go
+++ b/pkg/query-service/rules/base_rule.go
@@ -358,6 +358,10 @@ func (r *BaseRule) ActiveAlerts() []*ruletypes.Alert {
 }
 
 func (r *BaseRule) SendAlerts(ctx context.Context, ts time.Time, resendDelay time.Duration, interval time.Duration, notifyFunc NotifyFunc) {
+	if r.orgID.IsZero() {
+		r.logger.ErrorContext(ctx, "rule has no org id")
+		return
+	}
 	orgID := r.orgID.StringValue()
 
 	alerts := []*ruletypes.Alert{}

--- a/pkg/query-service/rules/manager_test.go
+++ b/pkg/query-service/rules/manager_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/prometheus"
 	"github.com/SigNoz/signoz/pkg/prometheus/prometheustest"
-	"github.com/SigNoz/signoz/pkg/sqlstore"
-	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstoretest"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
 	"github.com/SigNoz/signoz/pkg/types/alertmanagertypes"
@@ -58,14 +56,6 @@ func TestManager_TestNotification_SendUnmatched_ThresholdRule(t *testing.T) {
 							triggeredTestAlerts = append(triggeredTestAlerts, args.Get(3).(map[*alertmanagertypes.PostableAlert][]string))
 						}).Return(nil).Times(tc.ExpectAlerts)
 					}
-				},
-				SqlStoreHook: func(store sqlstore.SQLStore) {
-					mockStore := store.(*sqlstoretest.Provider)
-					// Mock the organizations query that SendAlerts makes
-					// Bun generates: SELECT id FROM organizations LIMIT 1 (or SELECT "id" FROM "organizations" LIMIT 1)
-					orgRows := mockStore.Mock().NewRows([]string{"id"}).AddRow(orgID.StringValue())
-					// Match bun's generated query pattern - bun may quote identifiers
-					mockStore.Mock().ExpectQuery("SELECT (.+) FROM (.+)organizations(.+) LIMIT (.+)").WillReturnRows(orgRows)
 				},
 				TelemetryStoreHook: func(store telemetrystore.TelemetryStore) {
 					mockStore := store.(*telemetrystoretest.Provider)
@@ -171,12 +161,6 @@ func TestManager_TestNotification_SendUnmatched_PromRule(t *testing.T) {
 							triggeredTestAlerts = append(triggeredTestAlerts, args.Get(3).(map[*alertmanagertypes.PostableAlert][]string))
 						}).Return(nil).Times(tc.ExpectAlerts)
 					}
-				},
-				SqlStoreHook: func(store sqlstore.SQLStore) {
-					mockStore := store.(*sqlstoretest.Provider)
-					// Mock the organizations query that SendAlerts makes
-					orgRows := mockStore.Mock().NewRows([]string{"id"}).AddRow(orgID.StringValue())
-					mockStore.Mock().ExpectQuery("SELECT (.+) FROM (.+)organizations(.+) LIMIT (.+)").WillReturnRows(orgRows)
 				},
 				TelemetryStoreHook: func(store telemetrystore.TelemetryStore) {
 					mockStore := store.(*telemetrystoretest.Provider)

--- a/pkg/query-service/rules/manager_test.go
+++ b/pkg/query-service/rules/manager_test.go
@@ -52,7 +52,7 @@ func TestManager_TestNotification_SendUnmatched_ThresholdRule(t *testing.T) {
 					mockAM.On("Config").Return(alertmanagerserver.Config{ExternalURL: mustParseURL(t, "http://localhost:8080")})
 					// for saving temp alerts that are triggered via TestNotification
 					if tc.ExpectAlerts > 0 {
-						mockAM.On("TestAlert", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+						mockAM.On("TestAlert", mock.Anything, orgID.StringValue(), mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 							triggeredTestAlerts = append(triggeredTestAlerts, args.Get(3).(map[*alertmanagertypes.PostableAlert][]string))
 						}).Return(nil).Times(tc.ExpectAlerts)
 					}
@@ -157,7 +157,7 @@ func TestManager_TestNotification_SendUnmatched_PromRule(t *testing.T) {
 					mockAM.On("Config").Return(alertmanagerserver.Config{ExternalURL: mustParseURL(t, "http://localhost:8080")})
 					// for saving temp alerts that are triggered via TestNotification
 					if tc.ExpectAlerts > 0 {
-						mockAM.On("TestAlert", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+						mockAM.On("TestAlert", mock.Anything, orgID.StringValue(), mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 							triggeredTestAlerts = append(triggeredTestAlerts, args.Get(3).(map[*alertmanagertypes.PostableAlert][]string))
 						}).Return(nil).Times(tc.ExpectAlerts)
 					}


### PR DESCRIPTION
Fixes #11351

## Problem

`BaseRule.SendAlerts` used `SELECT id FROM organizations LIMIT 1` to resolve the org ID when routing alert notifications. In a multi-tenant setup with multiple orgs, this always returned the first org in the database — causing alerts from rules in other orgs to be routed to the wrong Alertmanager server.

This meant notifications either went to the wrong org's channels or were silently dropped (since the wrong org's Alertmanager server had no matching receivers configured).

## Root Cause

The `BaseRule` struct already had the correct `orgID` field, populated via `NewBaseRule(orgID)` and exposed via `OrgID()` getter. `SendAlerts` simply wasn't using it.

## Fix

- **`base_rule.go`**: Replaced the `SELECT id FROM organizations LIMIT 1` SQL query with `orgID := r.orgID.StringValue()` — uses the org ID already stored on the rule struct.
- **`manager_test.go`**: Removed the two `SqlStoreHook` mock blocks that mocked the now-removed organizations query, and cleaned up the unused `sqlstore`/`sqlstoretest` imports.

## Verification

All existing tests pass:
```
=== RUN   TestManager_TestNotification_SendUnmatched_ThresholdRule
--- PASS: TestManager_TestNotification_SendUnmatched_ThresholdRule (0.01s)
=== RUN   TestManager_TestNotification_SendUnmatched_PromRule
--- PASS: TestManager_TestNotification_SendUnmatched_PromRule (0.00s)
PASS
```

## Changes

2 files changed, 1 insertion(+), 29 deletions(-)