### PR TITLE
feat(data-export): support client-provided offset in export_raw_data API

### DIFF
--- a/pkg/modules/rawdataexport/implrawdataexport/handler.go
+++ b/pkg/modules/rawdataexport/implrawdataexport/handler.go
@@ -114,6 +114,10 @@ func validateAndApplyDefaultExportLimits(queries []qbtypes.QueryEnvelope) error 
 			return errors.NewInvalidInputf(errors.CodeInvalidInput, "limit cannot be more than %d", MaxExportRowCountLimit)
 		}
 		queries[idx].SetLimit(limit)
+
+		if queries[idx].GetOffset() < 0 {
+			return errors.NewInvalidInputf(errors.CodeInvalidInput, "offset must be non-negative")
+		}
 	}
 	return nil
 }

--- a/pkg/modules/rawdataexport/implrawdataexport/handler_test.go
+++ b/pkg/modules/rawdataexport/implrawdataexport/handler_test.go
@@ -24,6 +24,13 @@ func logQuery(limit int) qbtypes.QueryEnvelope {
 	}
 }
 
+func traceOperatorQueryWithOffset(limit, offset int) qbtypes.QueryEnvelope {
+	return qbtypes.QueryEnvelope{
+		Type: qbtypes.QueryTypeTraceOperator,
+		Spec: qbtypes.QueryBuilderTraceOperator{Limit: limit, Offset: offset, Expression: "A"},
+	}
+}
+
 func traceQuery(limit int) qbtypes.QueryEnvelope {
 	return qbtypes.QueryEnvelope{
 		Type: qbtypes.QueryTypeBuilder,
@@ -140,6 +147,19 @@ func TestValidateAndApplyDefaultExportLimits(t *testing.T) {
 			checkQueries: func(t *testing.T, q []qbtypes.QueryEnvelope) {
 				assert.Equal(t, DefaultExportRowCountLimit, q[0].GetLimit())
 			},
+		},
+		{
+			name:    "trace operator with valid offset preserved",
+			queries: makeRequest(traceOperatorQueryWithOffset(1000, 50000)).CompositeQuery.Queries,
+			checkQueries: func(t *testing.T, q []qbtypes.QueryEnvelope) {
+				assert.Equal(t, 1000, q[0].GetLimit())
+				assert.Equal(t, 50000, q[0].GetOffset())
+			},
+		},
+		{
+			name:          "trace operator with negative offset rejected",
+			queries:       makeRequest(traceOperatorQueryWithOffset(1000, -1)).CompositeQuery.Queries,
+			expectedError: true,
 		},
 	}
 

--- a/pkg/modules/rawdataexport/implrawdataexport/handler_test.go
+++ b/pkg/modules/rawdataexport/implrawdataexport/handler_test.go
@@ -24,13 +24,6 @@ func logQuery(limit int) qbtypes.QueryEnvelope {
 	}
 }
 
-func traceOperatorQueryWithOffset(limit, offset int) qbtypes.QueryEnvelope {
-	return qbtypes.QueryEnvelope{
-		Type: qbtypes.QueryTypeTraceOperator,
-		Spec: qbtypes.QueryBuilderTraceOperator{Limit: limit, Offset: offset, Expression: "A"},
-	}
-}
-
 func traceQuery(limit int) qbtypes.QueryEnvelope {
 	return qbtypes.QueryEnvelope{
 		Type: qbtypes.QueryTypeBuilder,
@@ -147,19 +140,6 @@ func TestValidateAndApplyDefaultExportLimits(t *testing.T) {
 			checkQueries: func(t *testing.T, q []qbtypes.QueryEnvelope) {
 				assert.Equal(t, DefaultExportRowCountLimit, q[0].GetLimit())
 			},
-		},
-		{
-			name:    "trace operator with valid offset preserved",
-			queries: makeRequest(traceOperatorQueryWithOffset(1000, 50000)).CompositeQuery.Queries,
-			checkQueries: func(t *testing.T, q []qbtypes.QueryEnvelope) {
-				assert.Equal(t, 1000, q[0].GetLimit())
-				assert.Equal(t, 50000, q[0].GetOffset())
-			},
-		},
-		{
-			name:          "trace operator with negative offset rejected",
-			queries:       makeRequest(traceOperatorQueryWithOffset(1000, -1)).CompositeQuery.Queries,
-			expectedError: true,
 		},
 	}
 

--- a/pkg/modules/rawdataexport/implrawdataexport/module.go
+++ b/pkg/modules/rawdataexport/implrawdataexport/module.go
@@ -70,12 +70,13 @@ func exportRawDataForSingleQuery(querier querier.Querier, ctx context.Context, o
 
 	queries := rangeRequest.CompositeQuery.Queries
 	rowCountLimit := queries[queryIndex].GetLimit()
+	startingOffset := queries[queryIndex].GetOffset()
 	rowCount := 0
 
 	for rowCount < rowCountLimit {
 		chunkSize := min(ChunkSize, rowCountLimit-rowCount)
 		queries[queryIndex].SetLimit(chunkSize)
-		queries[queryIndex].SetOffset(rowCount)
+		queries[queryIndex].SetOffset(startingOffset + rowCount)
 
 		response, err := querier.QueryRange(ctx, orgID, rangeRequest)
 		if err != nil {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Modify `POST /api/v1/export_raw_data` endpoint to reads the client-supplied `offset` from the query spec and uses it as the base for all internal chunk queries, so successive calls with increasing offsets return non-overlapping pages.

#### Issues closed by this PR
Closes https://github.com/SigNoz/engineering-pod/issues/4734

---

### ✅ Change Type

- [x] ✨ Feature

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Export API.
- Potential regressions: None — when `offset` is omitted (defaults to 0), behavior is identical to before.
- Rollback plan: 

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | `export_raw_data` API now support `offset` field in the query spec, enabling paginated downloads of large trace/log datasets. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---