### PR TITLE
fix(ui): resolve monaco find widget clipping and flickering

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -794,6 +794,13 @@ notifications	-  2050
 	background: color-mix(in srgb, var(--l3-background) 20%, transparent);
 }
 
+// =================================================================
+// Monaco Editor style overrides
+.monaco-editor .find-widget.visible {
+	top: 30px !important;
+	right: 45px !important;
+}
+
 body.ai-assistant-panel-open {
 	.PylonChat-bubbleFrameContainer,
 	.PylonChat-chatWindowFrameContainer {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
This PR fixes an issue where the Monaco Editor Find Widget's tooltips (Next Match, Close, etc.) were getting clipped or flickering when hovered.

By adding a small global CSS offset specifically to the `.visible` state of the find widget, we ensure the tooltips have enough space to render on a single line. This approach was chosen because it cleanly resolves the issue across all editor instances in the app with just a few lines of CSS, rather than needing to manually update the JavaScript configuration for every individual editor component.


#### Screenshots

Before Screenshot:
<img width="1882" height="955" alt="Before" src="https://github.com/user-attachments/assets/74f00431-d0bf-417b-b892-d343ff73353c" />

After Screenshots:
<img width="1887" height="953" alt="After_1" src="https://github.com/user-attachments/assets/641656b3-4122-4976-88a5-5c3973fb47ad" />
<img width="1892" height="948" alt="After_2" src="https://github.com/user-attachments/assets/12d6f809-0d0a-4fac-94b7-a168b4dabbca" />



#### Issues closed by this PR
Closes #11804
---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
This is related to a known upstream behavior in the Monaco Editor [Monaco Editor GitHub Issue #5177](https://github.com/microsoft/monaco-editor/issues/5177). When the editor is rendered inside a constrained container with `overflow: hidden`, overlay widgets don't automatically escape the boundary. Furthermore, when the widget is too close to the right edge, the tooltips wrap to a second line, overlap the trigger button, and cause the hover event to continuously toggle (resulting in the flicker).

#### Fix Strategy
Added a global CSS rule in `frontend/src/styles.scss` targeting `.monaco-editor .find-widget.visible`. Shifting the widget slightly away from the edges (`top: 30px`, `right: 45px`) prevents the tooltips from wrapping and overlapping the buttons. Targeting the `.visible` class allows Monaco's native slide-up animation to still execute smoothly when the user closes the widget.

---

### 🧪 Testing Strategy

- Tests added/updated: N/A
- Manual verification: Verified the Find Widget renders properly and tooltips do not clip/flicker. Tested the Escape key and close button animations.
- Edge cases covered: Checked across multiple editor instances to ensure the fix applies globally (Log Details JSON view, ClickHouse Query Builder, Import JSON modal)

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Applies to the Monaco Editor Find Widget globally across the frontend.
- Potential regressions: Minor visual alignment shifts of the find widget depending on the specific editor's padding.
- Rollback plan: Revert the added CSS rule in frontend/src/styles.scss

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed an issue where the search/find bar tooltips inside code editors (Logs, Dashboards, Alerts) would get cut off or flicker |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

This PR contains a small CSS-only change that repositions Monaco Editor's Find Widget slightly away from the container edges.

- The change is isolated to `.monaco-editor .find-widget.visible` and prevents tooltip clipping and hover flickering without modifying any editor logic or configuration. 
- Monaco's existing animations and behavior remain fully intact.
- **How to verify:** Open the Find Widget (`Ctrl+F`) in any Monaco editor instance and hover over its action buttons.