### PR TITLE
chore: add @H4ad as frontend codeowner for authz, members and service accounts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,6 +109,25 @@ go.mod @therealpandey
 /pkg/modules/role/ @therealpandey
 /pkg/types/coretypes/ @therealpandey @vikrantgupta25
 
+/frontend/src/hooks/useAuthZ/ @H4ad
+/frontend/src/components/GuardAuthZ/ @H4ad
+/frontend/src/components/AuthZTooltip/ @H4ad
+/frontend/src/components/createGuardedRoute/ @H4ad
+/frontend/src/container/RolesSettings/ @H4ad
+/frontend/src/components/RolesSelect/ @H4ad
+/frontend/src/pages/MembersSettings/ @H4ad
+/frontend/src/container/MembersSettings/ @H4ad
+/frontend/src/components/MembersTable/ @H4ad
+/frontend/src/components/EditMemberDrawer/ @H4ad
+/frontend/src/components/InviteMembersModal/ @H4ad
+/frontend/src/hooks/member/ @H4ad
+/frontend/src/pages/ServiceAccountsSettings/ @H4ad
+/frontend/src/container/ServiceAccountsSettings/ @H4ad
+/frontend/src/components/ServiceAccountsTable/ @H4ad
+/frontend/src/components/ServiceAccountDrawer/ @H4ad
+/frontend/src/components/CreateServiceAccountModal/ @H4ad
+/frontend/src/hooks/serviceAccount/ @H4ad
+
 # IdentN Owners
 
 /pkg/identn/ @therealpandey


### PR DESCRIPTION
## Summary

- add @H4ad as AuthNZ frontend codeowner 