### PR TITLE
Fix dashboard source OpenAPI schema

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -3457,7 +3457,7 @@ components:
       - user
       - system
       - integration
-      type: object
+      type: string
     DashboardtypesSpanGaps:
       properties:
         fillLessThan:

--- a/pkg/types/dashboardtypes/source.go
+++ b/pkg/types/dashboardtypes/source.go
@@ -6,7 +6,10 @@ import (
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/swaggest/jsonschema-go"
 )
+
+var _ jsonschema.Exposer = Source{}
 
 type Source struct {
 	s valuer.String
@@ -20,6 +23,16 @@ var (
 
 func (Source) Enum() []any {
 	return []any{SourceUser, SourceSystem, SourceIntegration}
+}
+
+func (Source) JSONSchema() (jsonschema.Schema, error) {
+	return *new(jsonschema.Schema).
+		WithType(jsonschema.String.Type()).
+		WithEnum(
+			SourceUser.StringValue(),
+			SourceSystem.StringValue(),
+			SourceIntegration.StringValue(),
+		), nil
 }
 
 func (s Source) IsValid() bool {


### PR DESCRIPTION
Fixes the generated OpenAPI schema for `dashboardtypes.Source`.

It serializes as a string enum, but the reflector saw the private `valuer.String` field and emitted `type: object`. This exposes the schema explicitly and regenerates `docs/api/openapi.yml`.

Checks:
- `GOTOOLCHAIN=go1.25.7+auto go run cmd/enterprise/*.go generate openapi`
- `npx --yes openapi-typescript@7.8.0 docs/api/openapi.yml -o /tmp/signozApi.d.ts`
- `GOTOOLCHAIN=go1.25.7+auto go test ./pkg/types/dashboardtypes`