### PR TITLE
fix(querier): honor max_concurrent_queries config for missing-range execution

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -34,6 +34,10 @@ var (
 	intervalWarn = "Query %s is requesting aggregation interval %v seconds, which is smaller than the minimum allowed interval of %v seconds for selected time range. Using the minimum instead"
 )
 
+// defaultMaxConcurrentQueries is the fallback bound on goroutines used to fetch
+// the missing cache ranges of a single query when no valid value is configured.
+const defaultMaxConcurrentQueries = 4
+
 type querier struct {
 	logger                   *slog.Logger
 	fl                       flagger.Flagger
@@ -48,6 +52,7 @@ type querier struct {
 	traceOperatorStmtBuilder qbtypes.TraceOperatorStatementBuilder
 	bucketCache              BucketCache
 	liveDataRefresh          time.Duration
+	maxConcurrentQueries     int
 }
 
 var _ Querier = (*querier)(nil)
@@ -65,8 +70,14 @@ func New(
 	traceOperatorStmtBuilder qbtypes.TraceOperatorStatementBuilder,
 	bucketCache BucketCache,
 	flagger flagger.Flagger,
+	maxConcurrentQueries int,
 ) *querier {
 	querierSettings := factory.NewScopedProviderSettings(settings, "github.com/SigNoz/signoz/pkg/querier")
+	// Guard against an unset/invalid value so callers (e.g. tests) that don't
+	// plumb the config still get the historical bound.
+	if maxConcurrentQueries <= 0 {
+		maxConcurrentQueries = defaultMaxConcurrentQueries
+	}
 	return &querier{
 		logger:                   querierSettings.Logger(),
 		fl:                       flagger,
@@ -81,6 +92,7 @@ func New(
 		traceOperatorStmtBuilder: traceOperatorStmtBuilder,
 		bucketCache:              bucketCache,
 		liveDataRefresh:          5 * time.Second,
+		maxConcurrentQueries:     maxConcurrentQueries,
 	}
 }
 
@@ -735,7 +747,7 @@ func (q *querier) executeWithCache(ctx context.Context, orgID valuer.UUID, query
 		slog.Int("missing_ranges_count", len(missingRanges)),
 		slog.Any("ranges", missingRanges))
 
-	sem := make(chan struct{}, 4)
+	sem := make(chan struct{}, q.maxConcurrentQueries)
 	var wg sync.WaitGroup
 
 	for i, timeRange := range missingRanges {

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -35,6 +35,22 @@ func (m *mockMetricStmtBuilder) Build(_ context.Context, _, _ uint64, _ qbtypes.
 	}, nil
 }
 
+func TestNewMaxConcurrentQueries(t *testing.T) {
+	providerSettings := instrumentationtest.New().ToProviderSettings()
+	newQuerier := func(maxConcurrent int) *querier {
+		return New(
+			providerSettings,
+			nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			flaggertest.New(t),
+			maxConcurrent,
+		)
+	}
+
+	require.Equal(t, 8, newQuerier(8).maxConcurrentQueries, "configured value should be honored")
+	require.Equal(t, defaultMaxConcurrentQueries, newQuerier(0).maxConcurrentQueries, "zero should fall back to default")
+	require.Equal(t, defaultMaxConcurrentQueries, newQuerier(-3).maxConcurrentQueries, "negative should fall back to default")
+}
+
 func TestQueryRange_MetricTypeMissing(t *testing.T) {
 	// When a metric has UnspecifiedType and is not found in the metadata store,
 	// the querier should return an empty result with a warning instead of an error.
@@ -54,6 +70,7 @@ func TestQueryRange_MetricTypeMissing(t *testing.T) {
 		nil,                // traceOperatorStmtBuilder
 		nil,                // bucketCache
 		flaggertest.New(t), // flagger
+		0,                  // maxConcurrentQueries (use default)
 	)
 
 	req := &qbtypes.QueryRangeRequest{
@@ -124,6 +141,7 @@ func TestQueryRange_MetricTypeFromStore(t *testing.T) {
 		nil,                      // traceOperatorStmtBuilder
 		nil,                      // bucketCache
 		flaggertest.New(t),       // flagger
+		0,                        // maxConcurrentQueries (use default)
 	)
 
 	req := &qbtypes.QueryRangeRequest{

--- a/pkg/querier/signozquerier/provider.go
+++ b/pkg/querier/signozquerier/provider.go
@@ -192,5 +192,6 @@ func newProvider(
 		traceOperatorStmtBuilder,
 		bucketCache,
 		flagger,
+		cfg.MaxConcurrentQueries,
 	), nil
 }

--- a/pkg/query-service/rules/setups_test.go
+++ b/pkg/query-service/rules/setups_test.go
@@ -54,6 +54,7 @@ func prepareQuerierForMetrics(t *testing.T, telemetryStore telemetrystore.Teleme
 		nil, // traceOperatorStmtBuilder
 		nil, // bucketCache
 		flagger,
+		0, // maxConcurrentQueries (use default)
 	), metadataStore
 }
 
@@ -107,6 +108,7 @@ func prepareQuerierForLogs(t *testing.T, telemetryStore telemetrystore.Telemetry
 		nil,            // traceOperatorStmtBuilder
 		nil,            // bucketCache
 		fl,
+		0, // maxConcurrentQueries (use default)
 	)
 }
 
@@ -154,5 +156,6 @@ func prepareQuerierForTraces(t *testing.T, telemetryStore telemetrystore.Telemet
 		nil,              // traceOperatorStmtBuilder
 		nil,              // bucketCache
 		fl,
+		0, // maxConcurrentQueries (use default)
 	)
 }


### PR DESCRIPTION
## Problem

`querier.Config` exposes `max_concurrent_queries` (default 4, validated to be `> 0`), but `executeWithCache` hard-coded its missing-range fan-out semaphore to a literal `4`:

```go
sem := make(chan struct{}, 4)
```

So the documented, validated config knob was **silently ignored**. When a query range request has uncached time ranges, the querier splits them and fetches them concurrently — operators had no way to tune how many of those ClickHouse queries run in parallel per request.

## Change

Thread the configured value through `querier.New` into the semaphore:

- New `maxConcurrentQueries` field on the querier, set from `cfg.MaxConcurrentQueries` in the provider wiring.
- A non-positive value falls back to the historical default (`defaultMaxConcurrentQueries = 4`), so existing deployments and in-package test constructors are unaffected.

No behavioural change at the default; this only makes the existing knob actually take effect.

## Tests

- New `TestNewMaxConcurrentQueries` covers honored value + fallback for `0`/negative.
- `go test -race ./pkg/querier/` passes; `go vet` + `gofmt` clean across the querier, provider, and rules packages.