### PR TITLE
fix(dashboards-v2): stop infinite render loop on dashboards with no variable selections

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableSelectionSlice.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableSelectionSlice.ts
@@ -48,8 +48,15 @@ export const createVariableSelectionSlice: StateCreator<
 	},
 });
 
+/**
+ * Stable empty map for dashboards with no stored selections. Returning an inline
+ * `{}` here would hand zustand's useSyncExternalStore a new reference every call,
+ * which it reads as a changed snapshot → infinite re-render loop.
+ */
+const EMPTY_SELECTION_MAP: VariableSelectionMap = {};
+
 /** Selector: the selection map for a dashboard (empty if none). */
 export const selectVariableValues =
 	(dashboardId: string) =>
 	(state: DashboardStore): VariableSelectionMap =>
-		state.variableValues[dashboardId] ?? {};
+		state.variableValues[dashboardId] ?? EMPTY_SELECTION_MAP;


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Creating or opening a **V2 dashboard with no variables** (e.g. a brand-new, panel-less dashboard) crashed the page with a React `Maximum update depth exceeded` error, preceded by the `The result of getSnapshot should be cached to avoid an infinite loop` warning — both originating from `VariablesBar`.

The fix returns a referentially-stable empty map from the variable-selection selector so Zustand's `useSyncExternalStore` no longer sees a perpetually-changing snapshot. This is the right approach because the bug is purely a selector-identity issue, not a state/logic problem.

#### Screenshots / Screen Recordings (if applicable)

N/A — fix is a referential-stability change. Before: a new empty dashboard threw `Maximum update depth exceeded`. After: it loads normally.

#### Issues closed by this PR

Closes https://github.com/SigNoz/pulse-pod/issues/77

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

`selectVariableValues` returned an inline `{}` fallback when a dashboard had no stored selections:

```ts
(state) => state.variableValues[dashboardId] ?? {}
```

Zustand reads selectors through `useSyncExternalStore`, which compares snapshots with `Object.is`. A fresh object literal on every call is never equal to the previous one, so React treats the snapshot as perpetually changed and re-renders without end.

This surfaced specifically on fresh/empty dashboards: when a dashboard **has** variables, the seeding effect in `useVariableSelection` populates `variableValues[dashboardId]` with a stable object, so the loop never starts. With **no** variables that effect early-returns, the entry stays `undefined`, and the selector mints a new `{}` on every render. `VariablesBar` renders `null` in that case, but its hook still subscribes to the store — so the loop fires regardless of there being nothing on screen.

#### Fix Strategy

Return a single module-level empty map (`EMPTY_SELECTION_MAP`) from the selector so it hands `useSyncExternalStore` a referentially-stable snapshot.

---

### 🧪 Testing Strategy

- Tests added/updated: None — no test currently covers this slice; the change is a one-line referential-stability fix.
- Manual verification: Created a new empty (panel-less, variable-less) V2 dashboard — it now loads without the `Maximum update depth exceeded` crash. `pnpm tsgo --noEmit` and `pnpm oxlint` pass.
- Edge cases covered: dashboards with no variables (the crash path), and dashboards with variables (selector still returns the seeded stable map — unchanged behavior).

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Single selector in the V2 dashboard variable-selection store.
- Potential regressions: None expected — the returned value is `{}` in both old and new code; only its reference identity changed (now stable).
- Rollback plan: Revert this commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed a crash when opening a V2 dashboard that has no variables. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The fix lives in `selectVariableValues` (`variableSelectionSlice.ts`). The key insight is that Zustand selectors must return referentially-stable values for the no-data path; an inline `{}` is a new reference each call and triggers the `useSyncExternalStore` infinite-loop guard.

---