### PR TITLE
docs: document offset pagination for export_raw_data API

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -9907,8 +9907,19 @@ paths:
   /api/v1/export_raw_data:
     post:
       deprecated: false
-      description: This endpoints allows complex query exporting raw data for traces
-        and logs
+      description: |
+        Exports raw data for traces and logs using a query builder spec.
+
+        Pagination: set the `offset` field in a query spec to control the starting
+        row. The export begins at `offset` (default `0`) and returns up to `limit`
+        rows (default `10000`, max `50000`). To page through a large dataset, keep
+        `limit` fixed and increase `offset` by `limit` on each successive request;
+        stop when a response returns fewer rows than `limit`. An `offset` beyond the
+        available rows returns an empty result set, which signals the end of the
+        data. A negative `offset` is rejected with `400 Bad Request` and the message
+        `offset must be non-negative`. The per-request row cap (`50000`) applies to
+        each call independently; there is no cap on the total rows retrieved across
+        paginated requests.
       operationId: HandleExportRawDataPOST
       parameters:
       - description: The output format for the export.


### PR DESCRIPTION
## Summary

Expands the `POST /api/v1/export_raw_data` endpoint `description` in `docs/api/openapi.yml` to document the offset-pagination behavior introduced in #11825. The `offset` field already exists in the query-builder schema; this change documents the behavioral contract that the field now drives:

- **Offset pagination** — set `offset` in a query spec to start the export at that row; keep `limit` fixed and increment `offset` by `limit` across successive requests to page through large datasets.
- **Termination** — a response with fewer rows than `limit` (or an empty result when `offset` exceeds available rows) signals the end of the data.
- **Validation** — a negative `offset` returns `400 Bad Request` with `offset must be non-negative`.
- **Limits** — `limit` defaults to 10000 (max 50000) per request; the cap is per-request, with no total cap across paginated requests.

Spec-only change. The SigNoz docs site auto-generates its API Reference from this `openapi.yml` by release tag, so no separate signoz.io edit is needed or possible.

Source PRs: #11825

Auto-generated by docs-sync pipeline