### PR TITLE
fix(trace-detail): send span related-logs query window in seconds (not microseconds)

### DIFF
--- a/frontend/src/container/SpanDetailsDrawer/SpanLogs/__tests__/constants.test.ts
+++ b/frontend/src/container/SpanDetailsDrawer/SpanLogs/__tests__/constants.test.ts
@@ -1,0 +1,43 @@
+import { Filter } from 'types/api/v5/queryRange';
+
+import { getSpanLogsQueryPayload } from '../constants';
+
+describe('getSpanLogsQueryPayload', () => {
+	const filter: Filter = {
+		expression: "trace_id = 'abc' AND span_id = 'def'",
+	};
+
+	it('converts the millisecond time window to seconds for the V5 query payload', () => {
+		// `start`/`end` are passed in milliseconds (the span time window padded by
+		// ±5 min). GetQueryResultsProps -> prepareQueryRangePayloadV5 expects seconds
+		// and multiplies by 1e3, so the payload must carry seconds here. Passing
+		// milliseconds would yield a microsecond window (1000x too large) and the
+		// related-logs query would match nothing.
+		const startMs = 1782311871585;
+		const endMs = 1782312471617;
+
+		const payload = getSpanLogsQueryPayload(startMs, endMs, filter);
+
+		expect(payload.start).toBe(Math.floor(startMs / 1000));
+		expect(payload.end).toBe(Math.ceil(endMs / 1000));
+	});
+
+	it('keeps start/end at seconds magnitude (not milliseconds or microseconds)', () => {
+		const startMs = 1782311871585;
+		const endMs = 1782312471617;
+
+		const payload = getSpanLogsQueryPayload(startMs, endMs, filter);
+
+		// 10-digit epoch seconds, not 13-digit ms or 16-digit µs.
+		expect(payload.start.toString()).toHaveLength(10);
+		expect(payload.end.toString()).toHaveLength(10);
+	});
+
+	it('forwards the provided filter and ordering', () => {
+		const payload = getSpanLogsQueryPayload(1000, 2000, filter, 'asc');
+		const queryData = payload.query.builder.queryData[0];
+
+		expect(queryData.filter).toBe(filter);
+		expect(queryData.orderBy[0]).toEqual({ columnName: 'timestamp', order: 'asc' });
+	});
+});

--- a/frontend/src/container/SpanDetailsDrawer/SpanLogs/constants.ts
+++ b/frontend/src/container/SpanDetailsDrawer/SpanLogs/constants.ts
@@ -66,8 +66,14 @@ export const getSpanLogsQueryPayload = (
 		id: uuidv4(),
 		queryType: EQueryType.QUERY_BUILDER,
 	},
-	start,
-	end,
+	// `start`/`end` arrive in milliseconds, but GetQueryResultsProps (consumed by
+	// prepareQueryRangePayloadV5, which multiplies by 1e3) expects seconds. Convert
+	// here so the resulting query_range request is in milliseconds rather than
+	// microseconds — otherwise the log query window is 1000x too large and the
+	// related-logs tab returns nothing. See getStartEndRangeTime (seconds) used by
+	// the Logs Explorer path.
+	start: Math.floor(start / 1000),
+	end: Math.ceil(end / 1000),
 });
 
 /**


### PR DESCRIPTION
### Summary

Fixes the trace-detail **"Related logs"** tab returning no logs for any span (every span, every refresh), even though the same logs are queryable in Logs Explorer by `trace_id`/`span_id`.

Fixes #11843

### Root cause

`getSpanLogsQueryPayload` (`frontend/src/container/SpanDetailsDrawer/SpanLogs/constants.ts`) forwards the span time window in **milliseconds**, but the `start`/`end` of `GetQueryResultsProps` — consumed by `prepareQueryRangePayloadV5` (`frontend/src/api/v5/queryRange/prepareQueryRangePayloadV5.ts`, which multiplies by `1e3`) — are expected in **seconds**:

```ts
start: startTime ? startTime * 1e3 : parseInt(start, 10) * 1e3,
end:   endTime   ? endTime   * 1e3 : parseInt(end,   10) * 1e3,
```

So the span-logs `/query_range` request goes out in **microseconds** (16-digit), 1000× too large, placing the window far in the future → zero matches. The Logs Explorer path passes seconds (from `getStartEndRangeTime`) and is unaffected — same util, honored contract.

Captured from a v0.126.0 deployment:

| Stage | `start` | `end` | unit |
|-------|---------|-------|------|
| Trace waterfall API response (`startTimestampMillis`) | `1782312171585` | `1782312171617` | 13-digit ms ✓ |
| Frontend ±5 min pad (`SpanRelatedSignals`) | `1782311871585` | `1782312471617` | 13-digit ms ✓ |
| **Related-logs `query_range` request** | `1782311871585000` | `1782312471617000` | **16-digit µs ✗** |
| Logs Explorer `query_range` request | `1782308222000` | … | 13-digit ms ✓ |

### Fix

Convert ms→seconds in the caller, leaving the shared `prepareQueryRangePayloadV5` untouched (it's used by ~10 other call sites — `useGetQueryRange`, `useResolveQuery`, `useCreateAlerts`, alerts, etc. — that all correctly pass seconds). All four span-logs query phases in `useSpanContextLogs.ts` (span, before, after, trace-only) route through this one function, so the single change covers them all. Blast radius: the Related-logs tab only.

```ts
start: Math.floor(start / 1000),
end:   Math.ceil(end / 1000),
```

### Tests

Adds a unit test (`SpanLogs/__tests__/constants.test.ts`) asserting `getSpanLogsQueryPayload` emits epoch **seconds** (10-digit) for a millisecond window, and that the filter/ordering are forwarded.

### Notes

- Confirmed the affected lines are identical on `v0.126.0`, `v0.130.1`, and `main`.
- Introduced with the trace-based log time-window (#8965 / #11394) + span-logs drawer (#8387 / #8857), first shipped in v0.126.0.
