### PR TITLE
fix(keyboard-shortcut): monaco-editor should not trigger shortcut

### DIFF
--- a/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
+++ b/frontend/src/hooks/hotkeys/useKeyboardHotkeys.tsx
@@ -84,11 +84,12 @@ export function KeyboardHotkeysProvider({
 		}
 
 		const target = event.target as HTMLElement;
-		const isCodeMirrorEditor =
-			(target as HTMLElement).closest('.cm-editor') !== null;
+		const isCodeMirrorEditor = target.closest('.cm-editor') !== null;
+		const isMonacoEditor = target.closest('.monaco-editor') !== null;
 		if (
-			IGNORE_INPUTS.includes((target as HTMLElement).tagName.toLowerCase()) ||
-			isCodeMirrorEditor
+			IGNORE_INPUTS.includes(target.tagName.toLowerCase()) ||
+			isCodeMirrorEditor ||
+			isMonacoEditor
 		) {
 			return;
 		}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The keyboard shortcut should not be triggered when editing monaco editor, we forgot to include it to the ignore list.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

https://github.com/user-attachments/assets/63b39f27-5a45-441e-927c-433c786af83c

After:

https://github.com/user-attachments/assets/b47a8bfc-cf49-45a2-8721-4a79008fa60e


#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/signoz/issues/11847

Closes https://github.com/SigNoz/platform-pod/issues/2575

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

We have ignore list to skip inputs from triggering the shortcuts.

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

Forgot to include monaco-editor in the ignore list.

#### Fix Strategy
> How does this PR address the root cause?

Just add the ignore via `.monaco-editor`.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Keyboard Shortcuts
- Potential regressions: Any other component with class .monaco-editor.
- Rollback plan:  Remove usages of any class with `monaco-editor`.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Keyboard shortcuts no longer is triggered when typing in the Clickhouse Query Editor. |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered