### PR TITLE
chore: upgrade clickhouse to v25.12.5

### DIFF
--- a/.devenv/docker/clickhouse/compose.yaml
+++ b/.devenv/docker/clickhouse/compose.yaml
@@ -1,6 +1,6 @@
 services:
   init-clickhouse:
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     container_name: init-clickhouse
     command:
       - bash
@@ -18,7 +18,7 @@ services:
     volumes:
       - ${PWD}/fs/tmp/var/lib/clickhouse/user_scripts/:/var/lib/clickhouse/user_scripts/
   clickhouse:
-    image: clickhouse/clickhouse-server:25.5.6
+    image: clickhouse/clickhouse-server:25.12.5
     container_name: clickhouse
     volumes:
       - ${PWD}/fs/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml

--- a/.github/workflows/integrationci.yaml
+++ b/.github/workflows/integrationci.yaml
@@ -62,7 +62,6 @@ jobs:
         sqlite-mode:
           - wal
         clickhouse-version:
-          - 25.5.6
           - 25.12.5
         schema-migrator-version:
           - v0.144.3

--- a/docs/contributing/tests/integration.md
+++ b/docs/contributing/tests/integration.md
@@ -224,7 +224,7 @@ Tests can be configured using pytest options:
 - `--sqlstore-provider` — Choose the SQL store provider (default: `postgres`)
 - `--sqlite-mode` — SQLite journal mode: `delete` or `wal` (default: `delete`). Only relevant when `--sqlstore-provider=sqlite`.
 - `--postgres-version` — PostgreSQL version (default: `15`)
-- `--clickhouse-version` — ClickHouse version (default: `25.5.6`)
+- `--clickhouse-version` — ClickHouse version (default: `25.12.5`)
 - `--zookeeper-version` — Zookeeper version (default: `3.7.1`)
 - `--schema-migrator-version` — SigNoz schema migrator version (default: `v0.144.2`)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ def pytest_addoption(parser: pytest.Parser):
     parser.addoption(
         "--clickhouse-version",
         action="store",
-        default="25.5.6",
+        default="25.12.5",
         help="clickhouse version",
     )
     parser.addoption(


### PR DESCRIPTION
Update clickhouse version since collector v0.145+ requires atleast clickhouse v25.12.5 to support the table settings migration added in https://github.com/SigNoz/signoz-otel-collector/pull/833