### PR TITLE
fix(ui): add padding to prevent pagination overlap in Metrics Explorer

### DIFF
--- a/frontend/src/container/MetricsExplorer/Summary/Summary.styles.scss
+++ b/frontend/src/container/MetricsExplorer/Summary/Summary.styles.scss
@@ -58,6 +58,8 @@
 	}
 
 	.metrics-table-container {
+		padding-bottom: 80px;
+
 		.ant-table {
 			margin-left: -16px;
 			margin-right: -16px;


### PR DESCRIPTION
Fixes #11807

Adds `padding-bottom: 80px` to `.metrics-table-container` in order to prevent the fixed pagination bar at the bottom of the page from overlapping and hiding the last entry in the list view table.