### PR TITLE
fix(dashboards-v2): panel editor fixes + span-gaps Disconnect Values control

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.tsx
@@ -1,11 +1,8 @@
 import { Input } from 'antd';
 import { Typography } from '@signozhq/ui/typography';
-import type {
-	DashboardtypesPanelSpecDTO,
-	TelemetrytypesSignalDTO,
-} from 'api/generated/services/sigNoz.schemas';
+import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
 import { getPanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/registry';
-import { getBuilderQueries } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries';
+import { resolveSignal } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries';
 
 import type { LegendSeries } from '../hooks/useLegendSeries';
 import type { TableColumnOption } from '../hooks/useTableColumns';
@@ -45,9 +42,7 @@ function ConfigPane({
 	const definition = getPanelDefinition(panelKind);
 	const sections = definition.sections;
 
-	const signal = getBuilderQueries(spec.queries)[0]?.signal as
-		| TelemetrytypesSignalDTO
-		| undefined;
+	const signal = resolveSignal(spec.queries, definition.supportedSignals[0]);
 
 	// Title/description are just a slice of the spec — edit them through the same
 	// onChangeSpec path the sections use, so there's a single editing surface.

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.tsx
@@ -23,6 +23,8 @@ interface ConfigPaneProps {
 	legendSeries: LegendSeries[];
 	/** Table panel's resolved value columns, for the table-only editors. */
 	tableColumns: TableColumnOption[];
+	/** Query step interval (seconds), for the chart-appearance span-gaps floor. */
+	stepInterval?: number;
 }
 
 /**
@@ -38,6 +40,7 @@ function ConfigPane({
 	onChangePanelKind,
 	legendSeries,
 	tableColumns,
+	stepInterval,
 }: ConfigPaneProps): JSX.Element {
 	const definition = getPanelDefinition(panelKind);
 	const sections = definition.sections;
@@ -95,6 +98,7 @@ function ConfigPane({
 									signal={signal}
 									panelKind={panelKind}
 									onChangePanelKind={onChangePanelKind}
+									stepInterval={stepInterval}
 								/>
 							))}
 						</div>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.tsx
@@ -3,6 +3,7 @@ import { Typography } from '@signozhq/ui/typography';
 import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
 import { getPanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/registry';
 import { resolveSignal } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries';
+import type { EQueryType } from 'types/common/dashboard';
 
 import type { LegendSeries } from '../hooks/useLegendSeries';
 import type { TableColumnOption } from '../hooks/useTableColumns';
@@ -19,6 +20,12 @@ interface ConfigPaneProps {
 	onChangeSpec: (next: DashboardtypesPanelSpecDTO) => void;
 	/** Switch the panel to another visualization kind. */
 	onChangePanelKind: (kind: PanelKind) => void;
+	/**
+	 * Active query type from the query-builder provider (the selected tab). Drives which
+	 * panel types the visualization switcher disables — read from the provider, not the
+	 * spec, because a new panel's spec has no query until staged.
+	 */
+	queryType: EQueryType;
 	/** Panel's resolved series, provided to sections that need them (legend colors). */
 	legendSeries: LegendSeries[];
 	/** Table panel's resolved value columns, for the table-only editors. */
@@ -38,6 +45,7 @@ function ConfigPane({
 	spec,
 	onChangeSpec,
 	onChangePanelKind,
+	queryType,
 	legendSeries,
 	tableColumns,
 	stepInterval,
@@ -98,6 +106,7 @@ function ConfigPane({
 									signal={signal}
 									panelKind={panelKind}
 									onChangePanelKind={onChangePanelKind}
+									queryType={queryType}
 									stepInterval={stepInterval}
 								/>
 							))}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/PanelTypeSwitcher/PanelTypeSwitcher.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/PanelTypeSwitcher/PanelTypeSwitcher.tsx
@@ -1,39 +1,50 @@
 import { Typography } from '@signozhq/ui/typography';
 import type { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { EQueryType } from 'types/common/dashboard';
 
-import { getPanelDefinition } from '../../../Panels/registry';
 import type { PanelKind } from '../../../Panels/types/panelKind';
 import { PANEL_TYPES } from '../../../PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/constants';
 import ConfigSelect from '../controls/ConfigSelect/ConfigSelect';
 
 import styles from './PanelTypeSwitcher.module.scss';
+import { getPanelTypeDisabledReason } from './utils';
 
 interface PanelTypeSwitcherProps {
 	/** The current panel kind (selected value). */
 	panelKind: PanelKind;
-	/** Panel's current datasource — drives the disabled rule. */
+	/** Active query type — a kind that can't be authored in it is disabled (e.g. List is Query-Builder-only, so PromQL/ClickHouse disable it). Defaults to Query Builder. */
+	queryType?: EQueryType;
+	/** Panel's current signal — also gates the disabled rule (List needs logs/traces, not metrics). */
 	signal?: TelemetrytypesSignalDTO;
 	onChange: (kind: PanelKind) => void;
 }
 
 /**
- * Visualization-type selector (rendered inside the Visualization section). Types whose
- * supported signals exclude the panel's current datasource are disabled (V1 parity —
- * e.g. List needs logs/traces, not metrics). The datasource is unknown for
- * PromQL/ClickHouse queries, in which case no type is disabled.
+ * Visualization-type selector (rendered inside the Visualization section). A type is
+ * disabled when the active query type or signal is incompatible with it — resolved
+ * through the capabilities guard. The signal is unknown for PromQL/ClickHouse, but
+ * those query types still disable kinds that only support Query Builder (e.g. List).
  */
 function PanelTypeSwitcher({
 	panelKind,
+	queryType,
 	signal,
 	onChange,
 }: PanelTypeSwitcherProps): JSX.Element {
 	const items = PANEL_TYPES.map(({ panelKind, label, Icon }) => {
-		const definition = getPanelDefinition(panelKind);
+		// One reason drives both the disabled flag and the tooltip, so they can't disagree.
+		const disabledReason = getPanelTypeDisabledReason({
+			kind: panelKind,
+			queryType: queryType ?? EQueryType.QUERY_BUILDER,
+			signal,
+			label,
+		});
 		return {
 			value: panelKind,
 			label,
 			icon: <Icon size={14} />,
-			disabled: !!signal && !definition.supportedSignals.includes(signal),
+			disabled: !!disabledReason,
+			tooltip: disabledReason,
 		};
 	});
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/PanelTypeSwitcher/__tests__/PanelTypeSwitcher.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/PanelTypeSwitcher/__tests__/PanelTypeSwitcher.test.tsx
@@ -3,12 +3,26 @@ import { getPanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Pan
 
 import PanelTypeSwitcher from '../PanelTypeSwitcher';
 import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { EQueryType } from 'types/common/dashboard';
 
 jest.mock('pages/DashboardPageV2/DashboardContainer/Panels/registry', () => ({
 	getPanelDefinition: jest.fn(),
 }));
 
 const mockGetPanelDefinition = getPanelDefinition as unknown as jest.Mock;
+
+// Query-type support per kind: List is Query-Builder-only; Table/Pie drop PromQL.
+const SUPPORTED_QUERY_TYPES: Record<string, EQueryType[]> = {
+	'signoz/ListPanel': [EQueryType.QUERY_BUILDER],
+	'signoz/TablePanel': [EQueryType.QUERY_BUILDER, EQueryType.CLICKHOUSE],
+	'signoz/PieChartPanel': [EQueryType.QUERY_BUILDER, EQueryType.CLICKHOUSE],
+};
+
+function disabledLabels(): (string | null)[] {
+	return Array.from(
+		document.querySelectorAll('.ant-select-item-option-disabled'),
+	).map((el) => el.textContent);
+}
 
 function openDropdown(): void {
 	fireEvent.mouseDown(screen.getByRole('combobox'));
@@ -18,11 +32,17 @@ describe('PanelTypeSwitcher', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		// List supports only logs/traces; every other kind also supports metrics.
+		// Query-type support comes from SUPPORTED_QUERY_TYPES (all three by default).
 		mockGetPanelDefinition.mockImplementation((kind: string) => ({
 			supportedSignals:
 				kind === 'signoz/ListPanel'
 					? ['logs', 'traces']
 					: ['metrics', 'logs', 'traces'],
+			supportedQueryTypes: SUPPORTED_QUERY_TYPES[kind] ?? [
+				EQueryType.QUERY_BUILDER,
+				EQueryType.CLICKHOUSE,
+				EQueryType.PROM,
+			],
 		}));
 	});
 
@@ -38,7 +58,7 @@ describe('PanelTypeSwitcher', () => {
 		expect(onChange).toHaveBeenCalledWith('signoz/ListPanel');
 	});
 
-	it('disables types whose supported signals exclude the current datasource', () => {
+	it('disables types whose supported signals exclude the current signal', () => {
 		render(
 			<PanelTypeSwitcher
 				panelKind="signoz/TimeSeriesPanel"
@@ -48,16 +68,12 @@ describe('PanelTypeSwitcher', () => {
 		);
 
 		openDropdown();
-		const disabled = Array.from(
-			document.querySelectorAll('.ant-select-item-option-disabled'),
-		).map((el) => el.textContent);
-
 		// List can't render a metrics query, so it's disabled; Time Series stays enabled.
-		expect(disabled).toContain('List');
-		expect(disabled).not.toContain('Time Series');
+		expect(disabledLabels()).toContain('List');
+		expect(disabledLabels()).not.toContain('Time Series');
 	});
 
-	it('does not disable any type when the datasource is unknown', () => {
+	it('does not disable any type when the signal is unknown (builder, no signal)', () => {
 		render(
 			<PanelTypeSwitcher
 				panelKind="signoz/TimeSeriesPanel"
@@ -69,5 +85,38 @@ describe('PanelTypeSwitcher', () => {
 		expect(
 			document.querySelectorAll('.ant-select-item-option-disabled'),
 		).toHaveLength(0);
+	});
+
+	it('disables Query-Builder-only kinds under PromQL even without a signal', () => {
+		render(
+			<PanelTypeSwitcher
+				panelKind="signoz/TimeSeriesPanel"
+				queryType={EQueryType.PROM}
+				onChange={jest.fn()}
+			/>,
+		);
+
+		openDropdown();
+		// List/Table/Pie can't be authored in PromQL; Time Series can.
+		expect(disabledLabels()).toContain('List');
+		expect(disabledLabels()).toContain('Table');
+		expect(disabledLabels()).toContain('Pie Chart');
+		expect(disabledLabels()).not.toContain('Time Series');
+	});
+
+	it('disables List under ClickHouse while Table/Pie stay enabled', () => {
+		render(
+			<PanelTypeSwitcher
+				panelKind="signoz/TablePanel"
+				queryType={EQueryType.CLICKHOUSE}
+				onChange={jest.fn()}
+			/>,
+		);
+
+		openDropdown();
+		expect(disabledLabels()).toContain('List');
+		expect(disabledLabels()).not.toContain('Table');
+		expect(disabledLabels()).not.toContain('Pie Chart');
+		expect(disabledLabels()).not.toContain('Time Series');
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/PanelTypeSwitcher/__tests__/utils.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/PanelTypeSwitcher/__tests__/utils.test.ts
@@ -1,0 +1,73 @@
+import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { EQueryType } from 'types/common/dashboard';
+
+import { getPanelTypeDisabledReason } from '../utils';
+
+const { QUERY_BUILDER, CLICKHOUSE, PROM } = EQueryType;
+const { logs, metrics } = TelemetrytypesSignalDTO;
+
+describe('getPanelTypeDisabledReason', () => {
+	it('returns undefined for a supported combination', () => {
+		expect(
+			getPanelTypeDisabledReason({
+				kind: 'signoz/TimeSeriesPanel',
+				queryType: PROM,
+				label: 'Time Series',
+			}),
+		).toBeUndefined();
+		expect(
+			getPanelTypeDisabledReason({
+				kind: 'signoz/ListPanel',
+				queryType: QUERY_BUILDER,
+				signal: logs,
+				label: 'List',
+			}),
+		).toBeUndefined();
+	});
+
+	it('explains an unsupported query type', () => {
+		expect(
+			getPanelTypeDisabledReason({
+				kind: 'signoz/ListPanel',
+				queryType: PROM,
+				label: 'List',
+			}),
+		).toBe("List isn't available for PromQL queries");
+		expect(
+			getPanelTypeDisabledReason({
+				kind: 'signoz/ListPanel',
+				queryType: CLICKHOUSE,
+				label: 'List',
+			}),
+		).toBe("List isn't available for ClickHouse queries");
+		expect(
+			getPanelTypeDisabledReason({
+				kind: 'signoz/TablePanel',
+				queryType: PROM,
+				label: 'Table',
+			}),
+		).toBe("Table isn't available for PromQL queries");
+	});
+
+	it('explains an unsupported signal', () => {
+		expect(
+			getPanelTypeDisabledReason({
+				kind: 'signoz/ListPanel',
+				queryType: QUERY_BUILDER,
+				signal: metrics,
+				label: 'List',
+			}),
+		).toBe("List doesn't support metrics data");
+	});
+
+	it('prefers the query-type reason when both are incompatible', () => {
+		expect(
+			getPanelTypeDisabledReason({
+				kind: 'signoz/ListPanel',
+				queryType: PROM,
+				signal: metrics,
+				label: 'List',
+			}),
+		).toBe("List isn't available for PromQL queries");
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/PanelTypeSwitcher/utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/PanelTypeSwitcher/utils.ts
@@ -1,0 +1,46 @@
+import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { EQueryType } from 'types/common/dashboard';
+
+import {
+	isQueryTypeSupported,
+	isSignalSupported,
+} from '../../../Panels/capabilities';
+import type { PanelKind } from '../../../Panels/types/panelKind';
+
+const QUERY_TYPE_LABEL: Record<EQueryType, string> = {
+	[EQueryType.QUERY_BUILDER]: 'Query Builder',
+	[EQueryType.CLICKHOUSE]: 'ClickHouse',
+	[EQueryType.PROM]: 'PromQL',
+};
+
+const SIGNAL_LABEL: Record<TelemetrytypesSignalDTO, string> = {
+	[TelemetrytypesSignalDTO.logs]: 'logs',
+	[TelemetrytypesSignalDTO.traces]: 'traces',
+	[TelemetrytypesSignalDTO.metrics]: 'metrics',
+};
+
+/**
+ * Why a panel kind can't be selected for the current query type / signal, or
+ * `undefined` when it can. Drives both the type switcher's disabled state and its
+ * tooltip, so the two never disagree. The query-type reason takes precedence (it's the
+ * outer choice): query types carry no signal, so the signal only matters in builder.
+ */
+export function getPanelTypeDisabledReason({
+	kind,
+	queryType,
+	signal,
+	label,
+}: {
+	kind: PanelKind;
+	queryType: EQueryType;
+	signal?: TelemetrytypesSignalDTO;
+	label: string;
+}): string | undefined {
+	if (!isQueryTypeSupported(kind, queryType)) {
+		return `${label} isn't available for ${QUERY_TYPE_LABEL[queryType]} queries`;
+	}
+	if (signal !== undefined && !isSignalSupported(kind, signal)) {
+		return `${label} doesn't support ${SIGNAL_LABEL[signal]} data`;
+	}
+	return undefined;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
@@ -28,6 +28,8 @@ interface SectionSlotProps {
 	/** Current panel kind + switch handler, for the visualization section's type switcher. */
 	panelKind: PanelKind;
 	onChangePanelKind: (kind: PanelKind) => void;
+	/** Query step interval (seconds), for the chart-appearance span-gaps floor. */
+	stepInterval?: number;
 }
 
 /**
@@ -45,6 +47,7 @@ function SectionSlot({
 	signal,
 	panelKind,
 	onChangePanelKind,
+	stepInterval,
 }: SectionSlotProps): JSX.Element | null {
 	// A kind can hide a section based on current spec state (e.g. Histogram legend once
 	// queries are merged) — skip it before resolving the editor.
@@ -83,6 +86,7 @@ function SectionSlot({
 				signal={signal}
 				panelKind={panelKind}
 				onChangePanelKind={onChangePanelKind}
+				stepInterval={stepInterval}
 			/>
 		</SettingsSection>
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
@@ -5,7 +5,6 @@ import {
 	type SectionConfig,
 	SectionKind,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/sections';
-import type { EQueryType } from 'types/common/dashboard';
 
 import type { SectionEditorContext } from '../sectionContext';
 import { resolveSectionEditor } from '../sectionRegistry';

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
@@ -1,7 +1,4 @@
-import type {
-	DashboardtypesPanelSpecDTO,
-	TelemetrytypesSignalDTO,
-} from 'api/generated/services/sigNoz.schemas';
+import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
 import {
 	type PanelFormattingSlice,
 	SECTION_METADATA,
@@ -9,28 +6,16 @@ import {
 	SectionKind,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/sections';
 
-import type { PanelKind } from '../../../Panels/types/panelKind';
-import type { LegendSeries } from '../../hooks/useLegendSeries';
-import type { TableColumnOption } from '../../hooks/useTableColumns';
+import type { SectionEditorContext } from '../sectionContext';
 import { resolveSectionEditor } from '../sectionRegistry';
 import SettingsSection from '../SettingsSection/SettingsSection';
 
-interface SectionSlotProps {
+// `yAxisUnit` is derived from the spec below, not forwarded, so it's omitted.
+type SectionSlotProps = {
 	config: SectionConfig;
 	spec: DashboardtypesPanelSpecDTO;
 	onChangeSpec: (next: DashboardtypesPanelSpecDTO) => void;
-	/** Resolved series, forwarded to editors that need them (legend colors). */
-	legendSeries: LegendSeries[];
-	/** Table panel's resolved value columns, for the table-only editors. */
-	tableColumns: TableColumnOption[];
-	/** Panel's telemetry signal, for editors that fetch field suggestions (List columns). */
-	signal?: TelemetrytypesSignalDTO;
-	/** Current panel kind + switch handler, for the visualization section's type switcher. */
-	panelKind: PanelKind;
-	onChangePanelKind: (kind: PanelKind) => void;
-	/** Query step interval (seconds), for the chart-appearance span-gaps floor. */
-	stepInterval?: number;
-}
+} & Omit<SectionEditorContext, 'yAxisUnit'>;
 
 /**
  * Renders one configuration section: its collapsible wrapper plus the registered editor

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
@@ -5,6 +5,7 @@ import {
 	type SectionConfig,
 	SectionKind,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/sections';
+import type { EQueryType } from 'types/common/dashboard';
 
 import type { SectionEditorContext } from '../sectionContext';
 import { resolveSectionEditor } from '../sectionRegistry';
@@ -32,6 +33,7 @@ function SectionSlot({
 	signal,
 	panelKind,
 	onChangePanelKind,
+	queryType,
 	stepInterval,
 }: SectionSlotProps): JSX.Element | null {
 	// A kind can hide a section based on current spec state (e.g. Histogram legend once
@@ -71,6 +73,7 @@ function SectionSlot({
 				signal={signal}
 				panelKind={panelKind}
 				onChangePanelKind={onChangePanelKind}
+				queryType={queryType}
 				stepInterval={stepInterval}
 			/>
 		</SettingsSection>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SettingsSection/SettingsSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SettingsSection/SettingsSection.tsx
@@ -26,13 +26,15 @@ function SettingsSection({
 }: SettingsSectionProps): JSX.Element {
 	const [isOpen, setIsOpen] = useState(defaultOpen);
 
+	const serializedTitle = title.toLowerCase().replace(/\s+/g, '-');
+
 	return (
 		<section className={styles.section}>
 			<button
 				type="button"
 				className={styles.header}
 				aria-expanded={isOpen}
-				data-testid={`config-section-${title}`}
+				data-testid={`config-section-${serializedTitle}`}
 				onClick={(): void => setIsOpen((prev) => !prev)}
 			>
 				{icon && (

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/__tests__/ConfigPane.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/__tests__/ConfigPane.test.tsx
@@ -57,6 +57,8 @@ describe('ConfigPane', () => {
 	it('renders the Formatting section for a kind that declares it', () => {
 		renderConfigPane();
 		// The TimeSeries kind declares a Formatting section; its collapsible header shows.
-		expect(screen.getByTestId('config-section-Formatting')).toBeInTheDocument();
+		expect(
+			screen.getByTestId('config-section-formatting-&-units'),
+		).toBeInTheDocument();
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/__tests__/ConfigPane.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/__tests__/ConfigPane.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
+import { EQueryType } from 'types/common/dashboard';
 
 import ConfigPane from '../ConfigPane';
 
@@ -22,6 +23,7 @@ function renderConfigPane(
 		spec: spec(),
 		onChangeSpec: jest.fn(),
 		onChangePanelKind: jest.fn(),
+		queryType: EQueryType.QUERY_BUILDER,
 		legendSeries: [],
 		tableColumns: [],
 		...overrides,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/controls/ConfigSegmented/ConfigSegmented.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/controls/ConfigSegmented/ConfigSegmented.tsx
@@ -10,11 +10,11 @@ export interface ConfigSegmentedItem {
 	icon?: SegmentIconName;
 }
 
-interface ConfigSegmentedProps {
+interface ConfigSegmentedProps<T extends string = string> {
 	testId: string;
-	value: string | undefined;
+	value: T | undefined;
 	items: ConfigSegmentedItem[];
-	onChange: (value: string) => void;
+	onChange: (value: T) => void;
 }
 
 /**
@@ -23,12 +23,12 @@ interface ConfigSegmentedProps {
  * brightens with the selected state (it inherits the toggle's `currentColor`). Built on
  * the Periscope ToggleGroup so it stays theme-faithful.
  */
-function ConfigSegmented({
+function ConfigSegmented<T extends string = string>({
 	testId,
 	value,
 	items,
 	onChange,
-}: ConfigSegmentedProps): JSX.Element {
+}: ConfigSegmentedProps<T>): JSX.Element {
 	return (
 		<ToggleGroupSimple
 			type="single"
@@ -47,7 +47,7 @@ function ConfigSegmented({
 			}))}
 			// Single toggle-groups emit '' when the active segment is re-clicked; ignore that
 			// so a required choice (e.g. scale, position) can't be cleared to an empty value.
-			onChange={(next: string): void => {
+			onChange={(next: T): void => {
 				if (next) {
 					onChange(next);
 				}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/controls/ConfigSelect/ConfigSelect.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/controls/ConfigSelect/ConfigSelect.module.scss
@@ -8,3 +8,11 @@
 	align-items: center;
 	gap: 9px;
 }
+
+// Wraps a tooltip-bearing option so the hover target fills the row and still receives
+// pointer events when the option is disabled (antd dims it but doesn't block events).
+.tooltipTrigger {
+	display: block;
+	width: 100%;
+	pointer-events: auto;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/controls/ConfigSelect/ConfigSelect.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/controls/ConfigSelect/ConfigSelect.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Select } from 'antd';
+import { Select, Tooltip } from 'antd';
 
 import styles from './ConfigSelect.module.scss';
 
@@ -9,6 +9,8 @@ export interface ConfigSelectItem<T extends string = string> {
 	/** Optional leading icon node rendered before the label. */
 	icon?: ReactNode;
 	disabled?: boolean;
+	/** Hover hint shown on the option — typically the reason a disabled item is disabled. */
+	tooltip?: string;
 }
 
 interface ConfigSelectProps<T extends string = string> {
@@ -39,18 +41,27 @@ function ConfigSelect<T extends string = string>({
 			placeholder={placeholder}
 			onChange={onChange}
 			virtual={false}
-			options={items.map((item) => ({
-				value: item.value,
-				disabled: item.disabled,
-				label: item.icon ? (
+			options={items.map((item) => {
+				const content = item.icon ? (
 					<span className={styles.item}>
 						{item.icon}
 						{item.label}
 					</span>
 				) : (
 					item.label
-				),
-			}))}
+				);
+				return {
+					value: item.value,
+					disabled: item.disabled,
+					label: item.tooltip ? (
+						<Tooltip title={item.tooltip} placement="top">
+							<span className={styles.tooltipTrigger}>{content}</span>
+						</Tooltip>
+					) : (
+						content
+					),
+				};
+			})}
 		/>
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionContext.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionContext.ts
@@ -3,6 +3,7 @@ import type { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.sche
 import type { PanelKind } from '../../Panels/types/panelKind';
 import type { LegendSeries } from '../hooks/useLegendSeries';
 import type { TableColumnOption } from '../hooks/useTableColumns';
+import { EQueryType } from 'types/common/dashboard';
 
 /**
  * Context `SectionSlot` forwards to every section editor (not spec-slice fields — those
@@ -16,5 +17,6 @@ export interface SectionEditorContext {
 	panelKind?: PanelKind;
 	onChangePanelKind?: (kind: PanelKind) => void;
 	yAxisUnit?: string;
+	queryType?: EQueryType;
 	stepInterval?: number;
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionContext.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionContext.ts
@@ -1,0 +1,20 @@
+import type { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+
+import type { PanelKind } from '../../Panels/types/panelKind';
+import type { LegendSeries } from '../hooks/useLegendSeries';
+import type { TableColumnOption } from '../hooks/useTableColumns';
+
+/**
+ * Context `SectionSlot` forwards to every section editor (not spec-slice fields — those
+ * come from `SectionEditorProps<K>`); each editor `Pick`s what it consumes. All optional:
+ * editors resolve through the kind-erased descriptor, so receipt isn't type-guaranteed.
+ */
+export interface SectionEditorContext {
+	legendSeries?: LegendSeries[];
+	tableColumns?: TableColumnOption[];
+	signal?: TelemetrytypesSignalDTO;
+	panelKind?: PanelKind;
+	onChangePanelKind?: (kind: PanelKind) => void;
+	yAxisUnit?: string;
+	stepInterval?: number;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionRegistry.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionRegistry.tsx
@@ -161,6 +161,9 @@ export interface ErasedSectionDescriptor {
 		// type switcher.
 		panelKind?: unknown;
 		onChangePanelKind?: unknown;
+		// Query step interval (seconds); read by chart appearance to floor the
+		// span-gaps threshold.
+		stepInterval?: unknown;
 	}>;
 	get: (spec: PanelSpec) => unknown;
 	update: (spec: PanelSpec, value: unknown) => PanelSpec;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionRegistry.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionRegistry.tsx
@@ -16,6 +16,7 @@ import {
 	type SectionSpecMap,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/sections';
 
+import type { SectionEditorContext } from './sectionContext';
 import AxesSection from './sections/AxesSection/AxesSection';
 import BucketsSection from './sections/BucketsSection/BucketsSection';
 import ChartAppearanceSection from './sections/ChartAppearanceSection/ChartAppearanceSection';
@@ -142,29 +143,13 @@ export const SECTION_REGISTRY: {
  * `get` → `Component` → `update` without any further casts.
  */
 export interface ErasedSectionDescriptor {
-	Component: ComponentType<{
-		value: unknown;
-		controls?: unknown;
-		onChange: (next: unknown) => void;
-		// Forwarded to every editor; only sections that need the panel's resolved series
-		// (legend colors) read it. Optional so editors can ignore it.
-		legendSeries?: unknown;
-		// The panel's formatting unit; read by editors that scope to it (thresholds).
-		yAxisUnit?: unknown;
-		// The Table panel's resolved value columns; read by the table-only editors
-		// (column units, per-column thresholds) to offer real columns.
-		tableColumns?: unknown;
-		// The panel's telemetry signal; read by editors that fetch field-key
-		// suggestions scoped to it (List column picker).
-		signal?: unknown;
-		// Current panel kind + switch handler; read by the visualization section's
-		// type switcher.
-		panelKind?: unknown;
-		onChangePanelKind?: unknown;
-		// Query step interval (seconds); read by chart appearance to floor the
-		// span-gaps threshold.
-		stepInterval?: unknown;
-	}>;
+	Component: ComponentType<
+		{
+			value: unknown;
+			controls?: unknown;
+			onChange: (next: unknown) => void;
+		} & SectionEditorContext
+	>;
 	get: (spec: PanelSpec) => unknown;
 	update: (spec: PanelSpec, value: unknown) => PanelSpec;
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/ChartAppearanceSection.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/ChartAppearanceSection.module.scss
@@ -3,3 +3,14 @@
 	flex-direction: column;
 	gap: 8px;
 }
+
+.thresholdField {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.thresholdPrefix {
+	padding-right: 4px;
+	opacity: 0.6;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/ChartAppearanceSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/ChartAppearanceSection.tsx
@@ -13,6 +13,7 @@ import ConfigSegmented from '../../controls/ConfigSegmented/ConfigSegmented';
 import ConfigSelect from '../../controls/ConfigSelect/ConfigSelect';
 import ConfigSwitch from '../../controls/ConfigSwitch/ConfigSwitch';
 import { SegmentIcon } from '../../controls/segmentIcons';
+import type { SectionEditorContext } from '../../sectionContext';
 import DisconnectValuesField from './DisconnectValuesField';
 
 import styles from './ChartAppearanceSection.module.scss';
@@ -81,10 +82,8 @@ function ChartAppearanceSection({
 	controls,
 	onChange,
 	stepInterval,
-}: SectionEditorProps<SectionKind.ChartAppearance> & {
-	/** Query step interval (seconds) for the span-gaps threshold floor. */
-	stepInterval?: number;
-}): JSX.Element {
+}: SectionEditorProps<SectionKind.ChartAppearance> &
+	Pick<SectionEditorContext, 'stepInterval'>): JSX.Element {
 	return (
 		<>
 			{controls.lineStyle && (

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/ChartAppearanceSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/ChartAppearanceSection.tsx
@@ -1,6 +1,4 @@
-import type { ChangeEvent } from 'react';
 import { Typography } from '@signozhq/ui/typography';
-import { Input } from 'antd';
 import {
 	DashboardtypesFillModeDTO,
 	DashboardtypesLineInterpolationDTO,
@@ -15,6 +13,7 @@ import ConfigSegmented from '../../controls/ConfigSegmented/ConfigSegmented';
 import ConfigSelect from '../../controls/ConfigSelect/ConfigSelect';
 import ConfigSwitch from '../../controls/ConfigSwitch/ConfigSwitch';
 import { SegmentIcon } from '../../controls/segmentIcons';
+import DisconnectValuesField from './DisconnectValuesField';
 
 import styles from './ChartAppearanceSection.module.scss';
 
@@ -81,16 +80,11 @@ function ChartAppearanceSection({
 	value,
 	controls,
 	onChange,
-}: SectionEditorProps<SectionKind.ChartAppearance>): JSX.Element {
-	// `spanGaps.fillLessThan` is a stringified seconds threshold: empty means "connect
-	// every gap" (the chart default), a number means "only bridge gaps shorter than this".
-	const handleSpanGaps = (e: ChangeEvent<HTMLInputElement>): void => {
-		const raw = e.target.value;
-		onChange({
-			...value,
-			spanGaps: raw === '' ? undefined : { ...value?.spanGaps, fillLessThan: raw },
-		});
-	};
+	stepInterval,
+}: SectionEditorProps<SectionKind.ChartAppearance> & {
+	/** Query step interval (seconds) for the span-gaps threshold floor. */
+	stepInterval?: number;
+}): JSX.Element {
 	return (
 		<>
 			{controls.lineStyle && (
@@ -150,16 +144,12 @@ function ChartAppearanceSection({
 			)}
 
 			{controls.spanGaps && (
-				<div className={styles.field}>
-					<Typography.Text>Connect gaps shorter than (s)</Typography.Text>
-					<Input
-						data-testid="panel-editor-v2-span-gaps"
-						type="number"
-						placeholder="All gaps"
-						value={value?.spanGaps?.fillLessThan ?? ''}
-						onChange={handleSpanGaps}
-					/>
-				</div>
+				<DisconnectValuesField
+					testId="panel-editor-v2-span-gaps"
+					value={value?.spanGaps}
+					stepInterval={stepInterval}
+					onChange={(spanGaps): void => onChange({ ...value, spanGaps })}
+				/>
 			)}
 		</>
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/DisconnectValuesField.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/DisconnectValuesField.tsx
@@ -9,11 +9,13 @@ import DisconnectValuesThresholdInput from './DisconnectValuesThresholdInput';
 import styles from './ChartAppearanceSection.module.scss';
 
 const DEFAULT_THRESHOLD = '1m';
-const MODE_NEVER = 'never';
-const MODE_THRESHOLD = 'threshold';
+enum DisconnectValuesMode {
+	NEVER = 'never',
+	THRESHOLD = 'threshold',
+}
 const MODE_OPTIONS = [
-	{ value: MODE_NEVER, label: 'Never' },
-	{ value: MODE_THRESHOLD, label: 'Threshold' },
+	{ value: DisconnectValuesMode.NEVER, label: 'Never' },
+	{ value: DisconnectValuesMode.THRESHOLD, label: 'Threshold' },
 ];
 
 interface DisconnectValuesFieldProps {
@@ -56,9 +58,9 @@ function DisconnectValuesField({
 		}
 	}, [duration]);
 
-	const handleMode = (mode: string): void => {
+	const handleMode = (mode: DisconnectValuesMode): void => {
 		onChange(
-			mode === MODE_THRESHOLD
+			mode === DisconnectValuesMode.THRESHOLD
 				? { ...value, fillLessThan: lastDuration }
 				: undefined,
 		);
@@ -70,7 +72,9 @@ function DisconnectValuesField({
 				<Typography.Text>Disconnect values</Typography.Text>
 				<ConfigSegmented
 					testId={testId}
-					value={isThreshold ? MODE_THRESHOLD : MODE_NEVER}
+					value={
+						isThreshold ? DisconnectValuesMode.THRESHOLD : DisconnectValuesMode.NEVER
+					}
 					items={MODE_OPTIONS}
 					onChange={handleMode}
 				/>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/DisconnectValuesField.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/DisconnectValuesField.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { rangeUtil } from '@grafana/data';
+import { Typography } from '@signozhq/ui/typography';
+import type { DashboardtypesSpanGapsDTO } from 'api/generated/services/sigNoz.schemas';
+
+import ConfigSegmented from '../../controls/ConfigSegmented/ConfigSegmented';
+import DisconnectValuesThresholdInput from './DisconnectValuesThresholdInput';
+
+import styles from './ChartAppearanceSection.module.scss';
+
+const DEFAULT_THRESHOLD = '1m';
+const MODE_NEVER = 'never';
+const MODE_THRESHOLD = 'threshold';
+const MODE_OPTIONS = [
+	{ value: MODE_NEVER, label: 'Never' },
+	{ value: MODE_THRESHOLD, label: 'Threshold' },
+];
+
+interface DisconnectValuesFieldProps {
+	testId: string;
+	value: DashboardtypesSpanGapsDTO | undefined;
+	/** Query step interval (seconds): seeds the default threshold and floors it. */
+	stepInterval?: number;
+	onChange: (next: DashboardtypesSpanGapsDTO | undefined) => void;
+}
+
+/** Default threshold duration: the step interval (smallest meaningful), else 1m. */
+function defaultDuration(stepInterval?: number): string {
+	return stepInterval && stepInterval > 0
+		? rangeUtil.secondsToHms(stepInterval)
+		: DEFAULT_THRESHOLD;
+}
+
+/**
+ * "Disconnect values": Never (span every gap — the chart default) vs Threshold
+ * (only bridge gaps shorter than a duration). The threshold persists as a
+ * duration string in `spanGaps.fillLessThan` ("10m", "5s") — the wire format the
+ * backend expects.
+ */
+function DisconnectValuesField({
+	testId,
+	value,
+	stepInterval,
+	onChange,
+}: DisconnectValuesFieldProps): JSX.Element {
+	const duration = value?.fillLessThan || undefined;
+	const isThreshold = !!duration;
+	// Remember the last threshold so toggling Never → Threshold restores it.
+	const [lastDuration, setLastDuration] = useState(
+		duration ?? defaultDuration(stepInterval),
+	);
+
+	useEffect(() => {
+		if (duration) {
+			setLastDuration(duration);
+		}
+	}, [duration]);
+
+	const handleMode = (mode: string): void => {
+		onChange(
+			mode === MODE_THRESHOLD
+				? { ...value, fillLessThan: lastDuration }
+				: undefined,
+		);
+	};
+
+	return (
+		<>
+			<div className={styles.field}>
+				<Typography.Text>Disconnect values</Typography.Text>
+				<ConfigSegmented
+					testId={testId}
+					value={isThreshold ? MODE_THRESHOLD : MODE_NEVER}
+					items={MODE_OPTIONS}
+					onChange={handleMode}
+				/>
+			</div>
+			{isThreshold && (
+				<div className={styles.field}>
+					<Typography.Text>Threshold value</Typography.Text>
+					<DisconnectValuesThresholdInput
+						testId={`${testId}-value`}
+						value={lastDuration}
+						minValue={stepInterval}
+						onChange={(next): void => onChange({ ...value, fillLessThan: next })}
+					/>
+				</div>
+			)}
+		</>
+	);
+}
+
+export default DisconnectValuesField;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/DisconnectValuesThresholdInput.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/DisconnectValuesThresholdInput.tsx
@@ -1,0 +1,94 @@
+import { type ChangeEvent, useEffect, useState } from 'react';
+import { rangeUtil } from '@grafana/data';
+import { Callout } from '@signozhq/ui/callout';
+import { Input } from 'antd';
+
+import styles from './ChartAppearanceSection.module.scss';
+
+interface DisconnectValuesThresholdInputProps {
+	testId: string;
+	/** Current threshold as a duration string (e.g. "1m") — the stored wire value. */
+	value: string;
+	/** Smallest allowed threshold (the query step interval), in seconds. */
+	minValue?: number;
+	onChange: (duration: string) => void;
+}
+
+/**
+ * Duration input for the span-gaps threshold: shows/accepts and reports a human
+ * duration ("30s", "1m", "1h"), which is the value stored verbatim in
+ * `fillLessThan` (a bare number is read as seconds). It is only parsed to seconds
+ * to validate against the query step interval. Invalid entries, or values below
+ * that floor, surface an inline error and are not committed (V1 parity).
+ */
+function DisconnectValuesThresholdInput({
+	testId,
+	value,
+	minValue,
+	onChange,
+}: DisconnectValuesThresholdInputProps): JSX.Element {
+	const [text, setText] = useState(value);
+	const [error, setError] = useState<string | null>(null);
+
+	// Resync the displayed duration when the committed value changes upstream.
+	useEffect(() => {
+		setText(value);
+		setError(null);
+	}, [value]);
+
+	const commit = (raw: string): void => {
+		if (!raw) {
+			return;
+		}
+		let seconds: number;
+		try {
+			seconds = rangeUtil.isValidTimeSpan(raw)
+				? rangeUtil.intervalToSeconds(raw)
+				: NaN;
+		} catch {
+			seconds = NaN;
+		}
+		if (!Number.isFinite(seconds) || seconds <= 0) {
+			setError('Enter a valid duration (e.g. 30s, 1m, 1h)');
+			return;
+		}
+		if (minValue !== undefined && seconds < minValue) {
+			setError(`Threshold should be > ${rangeUtil.secondsToHms(minValue)}`);
+			return;
+		}
+		setError(null);
+		// Store the user's duration string as-is — the wire format the backend wants.
+		onChange(raw);
+	};
+
+	return (
+		<div className={styles.thresholdField}>
+			<Input
+				data-testid={testId}
+				type="text"
+				status={error ? 'error' : undefined}
+				prefix={<span className={styles.thresholdPrefix}>&gt;</span>}
+				value={text}
+				onChange={(e: ChangeEvent<HTMLInputElement>): void => {
+					setText(e.target.value);
+					if (error) {
+						setError(null);
+					}
+				}}
+				onBlur={(e): void => commit(e.currentTarget.value)}
+				onKeyDown={(e): void => {
+					if (e.key === 'Enter') {
+						commit(e.currentTarget.value);
+					}
+				}}
+			/>
+			{error && (
+				<Callout type="error" size="small" showIcon>
+					{error}
+				</Callout>
+			)}
+		</div>
+	);
+}
+
+export default DisconnectValuesThresholdInput;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/__tests__/ChartAppearanceSection.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/__tests__/ChartAppearanceSection.test.tsx
@@ -108,9 +108,24 @@ describe('ChartAppearanceSection', () => {
 		expect(onChange).toHaveBeenCalledWith({ showPoints: true });
 	});
 
-	it('writes a span-gaps threshold and clears it when emptied', () => {
+	it('defaults to "Never" (no threshold) and hides the threshold input', () => {
+		render(
+			<ChartAppearanceSection
+				value={undefined}
+				controls={{ spanGaps: true }}
+				onChange={jest.fn()}
+			/>,
+		);
+
+		expect(screen.getByText('Never')).toBeInTheDocument();
+		expect(
+			screen.queryByTestId('panel-editor-v2-span-gaps-value'),
+		).not.toBeInTheDocument();
+	});
+
+	it('switching to "Threshold" seeds the default 1m threshold', () => {
 		const onChange = jest.fn();
-		const { rerender } = render(
+		render(
 			<ChartAppearanceSection
 				value={undefined}
 				controls={{ spanGaps: true }}
@@ -118,23 +133,103 @@ describe('ChartAppearanceSection', () => {
 			/>,
 		);
 
-		fireEvent.change(screen.getByTestId('panel-editor-v2-span-gaps'), {
-			target: { value: '60' },
-		});
-		expect(onChange).toHaveBeenLastCalledWith({
-			spanGaps: { fillLessThan: '60' },
-		});
+		fireEvent.click(screen.getByText('Threshold'));
 
-		rerender(
+		expect(onChange).toHaveBeenLastCalledWith({
+			spanGaps: { fillLessThan: '1m' },
+		});
+	});
+
+	it('stores the threshold as a duration string (not seconds)', () => {
+		const onChange = jest.fn();
+		render(
 			<ChartAppearanceSection
-				value={{ spanGaps: { fillLessThan: '60' } }}
+				value={{ spanGaps: { fillLessThan: '1m' } }}
 				controls={{ spanGaps: true }}
 				onChange={onChange}
 			/>,
 		);
-		fireEvent.change(screen.getByTestId('panel-editor-v2-span-gaps'), {
-			target: { value: '' },
+
+		const input = screen.getByTestId('panel-editor-v2-span-gaps-value');
+		expect(input).toHaveValue('1m');
+
+		fireEvent.change(input, { target: { value: '5m' } });
+		fireEvent.blur(input);
+
+		expect(onChange).toHaveBeenLastCalledWith({
+			spanGaps: { fillLessThan: '5m' },
 		});
+	});
+
+	it('stores the entry verbatim (bare number kept as typed, not converted)', () => {
+		const onChange = jest.fn();
+		render(
+			<ChartAppearanceSection
+				value={{ spanGaps: { fillLessThan: '1m' } }}
+				controls={{ spanGaps: true }}
+				onChange={onChange}
+			/>,
+		);
+
+		const input = screen.getByTestId('panel-editor-v2-span-gaps-value');
+		fireEvent.change(input, { target: { value: '300' } });
+		fireEvent.blur(input);
+
+		expect(onChange).toHaveBeenLastCalledWith({
+			spanGaps: { fillLessThan: '300' },
+		});
+	});
+
+	it('switching back to "Never" clears the threshold', () => {
+		const onChange = jest.fn();
+		render(
+			<ChartAppearanceSection
+				value={{ spanGaps: { fillLessThan: '1m' } }}
+				controls={{ spanGaps: true }}
+				onChange={onChange}
+			/>,
+		);
+
+		fireEvent.click(screen.getByText('Never'));
+
 		expect(onChange).toHaveBeenLastCalledWith({ spanGaps: undefined });
+	});
+
+	it('shows an error and does not commit an invalid duration', () => {
+		const onChange = jest.fn();
+		render(
+			<ChartAppearanceSection
+				value={{ spanGaps: { fillLessThan: '1m' } }}
+				controls={{ spanGaps: true }}
+				onChange={onChange}
+			/>,
+		);
+
+		const input = screen.getByTestId('panel-editor-v2-span-gaps-value');
+		fireEvent.change(input, { target: { value: 'abc' } });
+		fireEvent.blur(input);
+
+		expect(screen.getByText(/valid duration/i)).toBeInTheDocument();
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it('rejects a threshold below the query step interval', () => {
+		const onChange = jest.fn();
+		render(
+			<ChartAppearanceSection
+				value={{ spanGaps: { fillLessThan: '2m' } }}
+				controls={{ spanGaps: true }}
+				stepInterval={120}
+				onChange={onChange}
+			/>,
+		);
+
+		const input = screen.getByTestId('panel-editor-v2-span-gaps-value');
+		// 1m (60s) is below the 2m (120s) step interval.
+		fireEvent.change(input, { target: { value: '1m' } });
+		fireEvent.blur(input);
+
+		expect(screen.getByText(/Threshold should be >/)).toBeInTheDocument();
+		expect(onChange).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/__tests__/ChartAppearanceSection.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ChartAppearanceSection/__tests__/ChartAppearanceSection.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DashboardtypesLineStyleDTO } from 'api/generated/services/sigNoz.schemas';
 
@@ -60,7 +60,8 @@ describe('ChartAppearanceSection', () => {
 		).not.toBeInTheDocument();
 	});
 
-	it('writes the chosen fill mode through the segmented control', () => {
+	it('writes the chosen fill mode through the segmented control', async () => {
+		const user = userEvent.setup();
 		const onChange = jest.fn();
 		render(
 			<ChartAppearanceSection
@@ -70,7 +71,7 @@ describe('ChartAppearanceSection', () => {
 			/>,
 		);
 
-		fireEvent.click(screen.getByText('Gradient'));
+		await user.click(screen.getByText('Gradient'));
 
 		expect(onChange).toHaveBeenCalledWith({
 			lineStyle: 'solid',
@@ -93,7 +94,8 @@ describe('ChartAppearanceSection', () => {
 		expect(onChange).toHaveBeenCalledWith({ lineInterpolation: 'spline' });
 	});
 
-	it('toggles show points through onChange', () => {
+	it('toggles show points through onChange', async () => {
+		const user = userEvent.setup();
 		const onChange = jest.fn();
 		render(
 			<ChartAppearanceSection
@@ -103,7 +105,7 @@ describe('ChartAppearanceSection', () => {
 			/>,
 		);
 
-		fireEvent.click(screen.getByTestId('panel-editor-v2-show-points'));
+		await user.click(screen.getByTestId('panel-editor-v2-show-points'));
 
 		expect(onChange).toHaveBeenCalledWith({ showPoints: true });
 	});
@@ -123,7 +125,8 @@ describe('ChartAppearanceSection', () => {
 		).not.toBeInTheDocument();
 	});
 
-	it('switching to "Threshold" seeds the default 1m threshold', () => {
+	it('switching to "Threshold" seeds the default 1m threshold', async () => {
+		const user = userEvent.setup();
 		const onChange = jest.fn();
 		render(
 			<ChartAppearanceSection
@@ -133,14 +136,15 @@ describe('ChartAppearanceSection', () => {
 			/>,
 		);
 
-		fireEvent.click(screen.getByText('Threshold'));
+		await user.click(screen.getByText('Threshold'));
 
 		expect(onChange).toHaveBeenLastCalledWith({
 			spanGaps: { fillLessThan: '1m' },
 		});
 	});
 
-	it('stores the threshold as a duration string (not seconds)', () => {
+	it('stores the threshold as a duration string (not seconds)', async () => {
+		const user = userEvent.setup();
 		const onChange = jest.fn();
 		render(
 			<ChartAppearanceSection
@@ -153,15 +157,17 @@ describe('ChartAppearanceSection', () => {
 		const input = screen.getByTestId('panel-editor-v2-span-gaps-value');
 		expect(input).toHaveValue('1m');
 
-		fireEvent.change(input, { target: { value: '5m' } });
-		fireEvent.blur(input);
+		await user.clear(input);
+		await user.type(input, '5m');
+		await user.tab();
 
 		expect(onChange).toHaveBeenLastCalledWith({
 			spanGaps: { fillLessThan: '5m' },
 		});
 	});
 
-	it('stores the entry verbatim (bare number kept as typed, not converted)', () => {
+	it('stores the entry verbatim (bare number kept as typed, not converted)', async () => {
+		const user = userEvent.setup();
 		const onChange = jest.fn();
 		render(
 			<ChartAppearanceSection
@@ -172,15 +178,17 @@ describe('ChartAppearanceSection', () => {
 		);
 
 		const input = screen.getByTestId('panel-editor-v2-span-gaps-value');
-		fireEvent.change(input, { target: { value: '300' } });
-		fireEvent.blur(input);
+		await user.clear(input);
+		await user.type(input, '300');
+		await user.tab();
 
 		expect(onChange).toHaveBeenLastCalledWith({
 			spanGaps: { fillLessThan: '300' },
 		});
 	});
 
-	it('switching back to "Never" clears the threshold', () => {
+	it('switching back to "Never" clears the threshold', async () => {
+		const user = userEvent.setup();
 		const onChange = jest.fn();
 		render(
 			<ChartAppearanceSection
@@ -190,12 +198,13 @@ describe('ChartAppearanceSection', () => {
 			/>,
 		);
 
-		fireEvent.click(screen.getByText('Never'));
+		await user.click(screen.getByText('Never'));
 
 		expect(onChange).toHaveBeenLastCalledWith({ spanGaps: undefined });
 	});
 
-	it('shows an error and does not commit an invalid duration', () => {
+	it('shows an error and does not commit an invalid duration', async () => {
+		const user = userEvent.setup();
 		const onChange = jest.fn();
 		render(
 			<ChartAppearanceSection
@@ -206,14 +215,16 @@ describe('ChartAppearanceSection', () => {
 		);
 
 		const input = screen.getByTestId('panel-editor-v2-span-gaps-value');
-		fireEvent.change(input, { target: { value: 'abc' } });
-		fireEvent.blur(input);
+		await user.clear(input);
+		await user.type(input, 'abc');
+		await user.tab();
 
 		expect(screen.getByText(/valid duration/i)).toBeInTheDocument();
 		expect(onChange).not.toHaveBeenCalled();
 	});
 
-	it('rejects a threshold below the query step interval', () => {
+	it('rejects a threshold below the query step interval', async () => {
+		const user = userEvent.setup();
 		const onChange = jest.fn();
 		render(
 			<ChartAppearanceSection
@@ -226,8 +237,9 @@ describe('ChartAppearanceSection', () => {
 
 		const input = screen.getByTestId('panel-editor-v2-span-gaps-value');
 		// 1m (60s) is below the 2m (120s) step interval.
-		fireEvent.change(input, { target: { value: '1m' } });
-		fireEvent.blur(input);
+		await user.clear(input);
+		await user.type(input, '1m');
+		await user.tab();
 
 		expect(screen.getByText(/Threshold should be >/)).toBeInTheDocument();
 		expect(onChange).not.toHaveBeenCalled();

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/FormattingSection/FormattingSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/FormattingSection/FormattingSection.tsx
@@ -7,16 +7,14 @@ import type {
 	SectionKind,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/sections';
 
-import type { TableColumnOption } from '../../../hooks/useTableColumns';
 import ConfigSelect from '../../controls/ConfigSelect/ConfigSelect';
+import type { SectionEditorContext } from '../../sectionContext';
 import ColumnUnits from './ColumnUnits';
 
 import styles from './FormattingSection.module.scss';
 
-type FormattingSectionProps = SectionEditorProps<SectionKind.Formatting> & {
-	/** Table panel's resolved value columns; required for the column-units editor. */
-	tableColumns?: TableColumnOption[];
-};
+type FormattingSectionProps = SectionEditorProps<SectionKind.Formatting> &
+	Pick<SectionEditorContext, 'tableColumns'>;
 
 // `full` means "show the raw value, no rounding"; the digits round to that many places.
 const DECIMAL_OPTIONS: {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/LegendSection/LegendSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/LegendSection/LegendSection.tsx
@@ -7,14 +7,12 @@ import type {
 
 import ConfigSegmented from '../../controls/ConfigSegmented/ConfigSegmented';
 import LegendColors from '../../controls/LegendColors/LegendColors';
-import type { LegendSeries } from '../../../hooks/useLegendSeries';
+import type { SectionEditorContext } from '../../sectionContext';
 
 import styles from './LegendSection.module.scss';
 
-type LegendSectionProps = SectionEditorProps<SectionKind.Legend> & {
-	/** Panel's resolved series, forwarded by SectionSlot for the colors control. */
-	legendSeries?: LegendSeries[];
-};
+type LegendSectionProps = SectionEditorProps<SectionKind.Legend> &
+	Pick<SectionEditorContext, 'legendSeries'>;
 
 const POSITION_OPTIONS = [
 	{

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/ThresholdsSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/ThresholdsSection.tsx
@@ -14,6 +14,7 @@ import type {
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/sections';
 
 import type { TableColumnOption } from '../../../hooks/useTableColumns';
+import type { SectionEditorContext } from '../../sectionContext';
 import ComparisonThresholdRow from './rows/ComparisonThresholdRow';
 import LabelThresholdRow from './rows/LabelThresholdRow';
 import TableThresholdRow from './rows/TableThresholdRow';
@@ -61,11 +62,7 @@ type ThresholdsSectionProps = {
 	/** `variant` picks the row editor + element shape; defaults to `label`. */
 	controls?: { variant?: ThresholdVariant };
 	onChange: (next: AnyThreshold[]) => void;
-	/** Panel formatting unit; scopes each row's unit picker to its category (V1 parity). */
-	yAxisUnit?: string;
-	/** Table panel's resolved value columns (table variant only). */
-	tableColumns?: TableColumnOption[];
-};
+} & Pick<SectionEditorContext, 'yAxisUnit' | 'tableColumns'>;
 
 /**
  * Edits the `thresholds` slice for every panel kind. All variants share the same

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/__tests__/ThresholdsSection.comparison.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/__tests__/ThresholdsSection.comparison.test.tsx
@@ -123,6 +123,25 @@ describe('ComparisonThresholdsSection', () => {
 		]);
 	});
 
+	it('lets the value input be cleared instead of snapping back to 0', async () => {
+		const user = userEvent.setup();
+		render(
+			<ComparisonThresholdsSection value={THRESHOLDS} onChange={jest.fn()} />,
+		);
+
+		await user.click(screen.getByTestId('comparison-threshold-edit-0'));
+		const valueInput = screen.getByTestId('comparison-threshold-value-0');
+
+		// Regression: clearing used to coerce "" → 0 and refill the field, so the
+		// seeded value could never be removed.
+		await user.clear(valueInput);
+		expect(valueInput).toHaveValue(null);
+
+		// And a fresh value can be typed into the now-empty field.
+		await user.type(valueInput, '5');
+		expect(valueInput).toHaveValue(5);
+	});
+
 	it('does not commit edits when Discard is clicked', async () => {
 		const user = userEvent.setup();
 		const onChange = jest.fn();

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/rows/shared/ThresholdValueField.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/rows/shared/ThresholdValueField.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Typography } from '@signozhq/ui/typography';
 import { Input } from 'antd';
 
@@ -16,6 +17,12 @@ function ThresholdValueField({
 	value,
 	onChange,
 }: ThresholdValueFieldProps): JSX.Element {
+	const [raw, setRaw] = useState(String(value));
+
+	useEffect(() => {
+		setRaw((prev) => (Number(prev) === value ? prev : String(value)));
+	}, [value]);
+
 	return (
 		<div className={styles.field}>
 			<Typography.Text className={styles.fieldLabel}>Value</Typography.Text>
@@ -23,8 +30,11 @@ function ThresholdValueField({
 				data-testid={testId}
 				type="number"
 				placeholder="Value"
-				value={value}
-				onChange={(e): void => onChange(e.target.value)}
+				value={raw}
+				onChange={(e): void => {
+					setRaw(e.target.value);
+					onChange(e.target.value);
+				}}
 			/>
 		</div>
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/VisualizationSection/VisualizationSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/VisualizationSection/VisualizationSection.tsx
@@ -13,7 +13,10 @@ import { TIME_PREFERENCE_OPTIONS } from './timePreferenceOptions';
 import styles from './VisualizationSection.module.scss';
 
 type VisualizationSectionProps = SectionEditorProps<SectionKind.Visualization> &
-	Pick<SectionEditorContext, 'panelKind' | 'onChangePanelKind' | 'signal'>;
+	Pick<
+		SectionEditorContext,
+		'panelKind' | 'onChangePanelKind' | 'signal' | 'queryType'
+	>;
 
 /**
  * Edits the `visualization` slice: the panel-type switcher (`switchPanelKind`, every
@@ -27,6 +30,7 @@ function VisualizationSection({
 	onChange,
 	panelKind,
 	onChangePanelKind,
+	queryType,
 	signal,
 }: VisualizationSectionProps): JSX.Element {
 	return (
@@ -34,6 +38,7 @@ function VisualizationSection({
 			{controls.switchPanelKind && panelKind && onChangePanelKind && (
 				<PanelTypeSwitcher
 					panelKind={panelKind}
+					queryType={queryType}
 					signal={signal}
 					onChange={onChangePanelKind}
 				/>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/VisualizationSection/VisualizationSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/VisualizationSection/VisualizationSection.tsx
@@ -1,26 +1,19 @@
 import { Typography } from '@signozhq/ui/typography';
-import type { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
 import type {
 	SectionEditorProps,
 	SectionKind,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/sections';
 
-import type { PanelKind } from '../../../../Panels/types/panelKind';
 import ConfigSelect from '../../controls/ConfigSelect/ConfigSelect';
 import ConfigSwitch from '../../controls/ConfigSwitch/ConfigSwitch';
 import PanelTypeSwitcher from '../../PanelTypeSwitcher/PanelTypeSwitcher';
+import type { SectionEditorContext } from '../../sectionContext';
 import { TIME_PREFERENCE_OPTIONS } from './timePreferenceOptions';
 
 import styles from './VisualizationSection.module.scss';
 
-type VisualizationSectionProps =
-	SectionEditorProps<SectionKind.Visualization> & {
-		/** Current panel kind + switch handler, forwarded by SectionSlot for the type switcher. */
-		panelKind?: PanelKind;
-		onChangePanelKind?: (kind: PanelKind) => void;
-		/** Panel's datasource, forwarded by SectionSlot — scopes the switcher's disabled types. */
-		signal?: TelemetrytypesSignalDTO;
-	};
+type VisualizationSectionProps = SectionEditorProps<SectionKind.Visualization> &
+	Pick<SectionEditorContext, 'panelKind' | 'onChangePanelKind' | 'signal'>;
 
 /**
  * Edits the `visualization` slice: the panel-type switcher (`switchPanelKind`, every

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/VisualizationSection/__tests__/VisualizationSection.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/VisualizationSection/__tests__/VisualizationSection.test.tsx
@@ -4,11 +4,12 @@ import { DashboardtypesTimePreferenceDTO } from 'api/generated/services/sigNoz.s
 
 import VisualizationSection from '../VisualizationSection';
 
-// The type switcher resolves each kind's supported signals; stub it so the test
-// doesn't pull the whole panel registry (renderers, chart libs).
+// The type switcher resolves each kind's supported signals + query types; stub it so
+// the test doesn't pull the whole panel registry (renderers, chart libs).
 jest.mock('pages/DashboardPageV2/DashboardContainer/Panels/registry', () => ({
 	getPanelDefinition: jest.fn(() => ({
 		supportedSignals: ['metrics', 'logs', 'traces'],
+		supportedQueryTypes: ['builder', 'clickhouse_sql', 'promql'],
 	})),
 }));
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/PanelEditorQueryBuilder/PanelEditorQueryBuilder.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/PanelEditorQueryBuilder/PanelEditorQueryBuilder.tsx
@@ -8,23 +8,35 @@ import { Color } from '@signozhq/design-tokens';
 import { Atom, Terminal } from '@signozhq/icons';
 import { Tabs } from 'antd';
 import { Typography } from '@signozhq/ui/typography';
+import type { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
 import PromQLIcon from 'assets/Dashboard/PromQl';
 import { QueryBuilderV2 } from 'components/QueryBuilderV2/QueryBuilderV2';
 import TextToolTip from 'components/TextToolTip';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import ClickHouseQueryContainer from 'container/NewWidget/LeftContainer/QuerySection/QueryBuilder/ClickHouse';
 import PromQLQueryContainer from 'container/NewWidget/LeftContainer/QuerySection/QueryBuilder/promQL';
-import { PANEL_TYPE_TO_QUERY_TYPES } from 'container/NewWidget/utils';
 import RunQueryBtn from 'container/QueryBuilder/components/RunQueryBtn/RunQueryBtn';
 import { QueryBuilderProps } from 'container/QueryBuilder/QueryBuilder.interfaces';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { EQueryType } from 'types/common/dashboard';
 
+import {
+	getHiddenQueryBuilderFields,
+	getSupportedQueryTypes,
+} from '../../Panels/capabilities';
+import {
+	PANEL_KIND_TO_PANEL_TYPE,
+	type PanelKind,
+} from '../../Panels/types/panelKind';
+
 import styles from './PanelEditorQueryBuilder.module.scss';
 
 interface PanelEditorQueryBuilderProps {
-	panelType: PANEL_TYPES;
+	/** The edited panel's visualization kind — drives supported query types + field visibility via the capabilities guard. */
+	panelKind: PanelKind;
+	/** The panel's current signal; selects per-signal query-builder field rules. */
+	signal: TelemetrytypesSignalDTO;
 	/** Preview fetch in flight — drives the Stage & Run button's loading/cancel state. */
 	isLoadingQueries: boolean;
 	/** Run the current query (Stage & Run button / ⌘↵). Always re-runs. */
@@ -41,12 +53,15 @@ interface PanelEditorQueryBuilderProps {
  * `QueryBuilderProvider`. `usePanelEditorQuerySync` owns the panel↔provider sync.
  */
 function PanelEditorQueryBuilder({
-	panelType,
+	panelKind,
+	signal,
 	isLoadingQueries,
 	onStageRunQuery,
 	onCancelQuery,
 	footer,
 }: PanelEditorQueryBuilderProps): JSX.Element {
+	// The shared QueryBuilderV2 / list-view checks still speak the legacy PANEL_TYPES.
+	const panelType = PANEL_KIND_TO_PANEL_TYPE[panelKind];
 	const { currentQuery, redirectWithQueryBuilderData } = useQueryBuilder();
 	const isDarkMode = useIsDarkMode();
 
@@ -74,13 +89,15 @@ function PanelEditorQueryBuilder({
 		[onStageRunQuery],
 	);
 
+	// Per-kind query-builder field rules from the guard (e.g. List hides step interval
+	// and having), passed to QueryBuilderV2 as its `filterConfigs`.
 	const filterConfigs: QueryBuilderProps['filterConfigs'] = useMemo(
-		() => ({ stepInterval: { isHidden: false, isDisabled: false } }),
-		[],
+		() => getHiddenQueryBuilderFields(panelKind, signal),
+		[panelKind, signal],
 	);
 
 	const items = useMemo(() => {
-		const supportedQueryTypes = PANEL_TYPE_TO_QUERY_TYPES[panelType] || [];
+		const supportedQueryTypes = getSupportedQueryTypes(panelKind);
 
 		const queryTypeComponents = {
 			[EQueryType.QUERY_BUILDER]: {
@@ -127,7 +144,7 @@ function PanelEditorQueryBuilder({
 			),
 			children: queryTypeComponents[queryType].component,
 		}));
-	}, [panelType, filterConfigs, isDarkMode]);
+	}, [panelKind, panelType, filterConfigs, isDarkMode]);
 
 	return (
 		<div

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/PanelEditorQueryBuilder/__tests__/PanelEditorQueryBuilder.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/PanelEditorQueryBuilder/__tests__/PanelEditorQueryBuilder.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen } from '@testing-library/react';
+import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { OPERATORS } from 'constants/queryBuilder';
+import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
+import { EQueryType } from 'types/common/dashboard';
+
+import PanelEditorQueryBuilder from '../PanelEditorQueryBuilder';
+
+// Capture the props the (real-guard-fed) QueryBuilderV2 receives without rendering it.
+const mockQueryBuilderV2 = jest.fn();
+
+jest.mock('hooks/queryBuilder/useQueryBuilder', () => ({
+	useQueryBuilder: jest.fn(),
+}));
+jest.mock('hooks/useDarkMode', () => ({ useIsDarkMode: (): boolean => false }));
+jest.mock('components/QueryBuilderV2/QueryBuilderV2', () => ({
+	QueryBuilderV2: (props: unknown): null => {
+		mockQueryBuilderV2(props);
+		return null;
+	},
+}));
+jest.mock(
+	'container/NewWidget/LeftContainer/QuerySection/QueryBuilder/ClickHouse',
+	() => ({ __esModule: true, default: (): null => null }),
+);
+jest.mock(
+	'container/NewWidget/LeftContainer/QuerySection/QueryBuilder/promQL',
+	() => ({ __esModule: true, default: (): null => null }),
+);
+jest.mock('container/QueryBuilder/components/RunQueryBtn/RunQueryBtn', () => ({
+	__esModule: true,
+	default: (): null => null,
+}));
+jest.mock('components/TextToolTip', () => ({
+	__esModule: true,
+	default: (): null => null,
+}));
+jest.mock('assets/Dashboard/PromQl', () => ({
+	__esModule: true,
+	default: (): null => null,
+}));
+
+const mockUseQueryBuilder = useQueryBuilder as unknown as jest.Mock;
+
+function renderBuilder(
+	panelKind: string,
+	signal: TelemetrytypesSignalDTO = TelemetrytypesSignalDTO.logs,
+): void {
+	render(
+		<PanelEditorQueryBuilder
+			panelKind={panelKind as never}
+			signal={signal}
+			isLoadingQueries={false}
+			onStageRunQuery={jest.fn()}
+			onCancelQuery={jest.fn()}
+		/>,
+	);
+}
+
+function lastQueryBuilderProps(): {
+	panelType: string;
+	isListViewPanel: boolean;
+	filterConfigs: unknown;
+} {
+	const calls = mockQueryBuilderV2.mock.calls;
+	return calls[calls.length - 1][0];
+}
+
+describe('PanelEditorQueryBuilder query-type tabs (driven by the capabilities guard)', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockUseQueryBuilder.mockReturnValue({
+			currentQuery: { queryType: EQueryType.QUERY_BUILDER },
+			redirectWithQueryBuilderData: jest.fn(),
+		});
+	});
+
+	it('shows only the Query Builder tab for the List kind', () => {
+		renderBuilder('signoz/ListPanel', TelemetrytypesSignalDTO.logs);
+
+		expect(screen.getByText('Query Builder')).toBeInTheDocument();
+		expect(screen.queryByText('ClickHouse Query')).not.toBeInTheDocument();
+		expect(screen.queryByText('PromQL')).not.toBeInTheDocument();
+	});
+
+	it('shows Query Builder + ClickHouse but not PromQL for the Table kind', () => {
+		renderBuilder('signoz/TablePanel');
+
+		expect(screen.getByText('Query Builder')).toBeInTheDocument();
+		expect(screen.getByText('ClickHouse Query')).toBeInTheDocument();
+		expect(screen.queryByText('PromQL')).not.toBeInTheDocument();
+	});
+
+	it('shows all three tabs for the Time Series kind', () => {
+		renderBuilder('signoz/TimeSeriesPanel');
+
+		expect(screen.getByText('Query Builder')).toBeInTheDocument();
+		expect(screen.getByText('ClickHouse Query')).toBeInTheDocument();
+		expect(screen.getByText('PromQL')).toBeInTheDocument();
+	});
+});
+
+describe('PanelEditorQueryBuilder field visibility (driven by the capabilities guard)', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockUseQueryBuilder.mockReturnValue({
+			currentQuery: { queryType: EQueryType.QUERY_BUILDER },
+			redirectWithQueryBuilderData: jest.fn(),
+		});
+	});
+
+	it('passes empty field config + non-list flag for a non-list kind', () => {
+		renderBuilder('signoz/TimeSeriesPanel', TelemetrytypesSignalDTO.metrics);
+
+		const props = lastQueryBuilderProps();
+		expect(props.panelType).toBe('graph');
+		expect(props.isListViewPanel).toBe(false);
+		expect(props.filterConfigs).toStrictEqual({});
+	});
+
+	it('hides step interval / having and sets body-contains for List + logs', () => {
+		renderBuilder('signoz/ListPanel', TelemetrytypesSignalDTO.logs);
+
+		const props = lastQueryBuilderProps();
+		expect(props.panelType).toBe('list');
+		expect(props.isListViewPanel).toBe(true);
+		expect(props.filterConfigs).toStrictEqual({
+			stepInterval: { isHidden: true, isDisabled: true },
+			having: { isHidden: true, isDisabled: true },
+			filters: { customKey: 'body', customOp: OPERATORS.CONTAINS },
+		});
+	});
+
+	it('additionally hides limit for List + traces', () => {
+		renderBuilder('signoz/ListPanel', TelemetrytypesSignalDTO.traces);
+
+		const props = lastQueryBuilderProps();
+		expect(props.filterConfigs).toStrictEqual({
+			stepInterval: { isHidden: true, isDisabled: true },
+			having: { isHidden: true, isDisabled: true },
+			limit: { isHidden: true, isDisabled: true },
+			filters: { customKey: 'body', customOp: OPERATORS.CONTAINS },
+		});
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/usePanelTypeSwitch.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/usePanelTypeSwitch.test.ts
@@ -5,6 +5,7 @@ import { handleQueryChange } from 'container/NewWidget/utils';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 
+import { resolveQueryType } from '../../../Panels/capabilities';
 import { getBuilderQueries } from '../../../Panels/utils/getBuilderQueries';
 import { toPerses } from '../../../queryV5/persesQueryAdapters';
 import { getSwitchedPluginSpec } from '../../getSwitchedPluginSpec';
@@ -15,15 +16,9 @@ jest.mock('hooks/queryBuilder/useQueryBuilder', () => ({
 }));
 jest.mock('container/NewWidget/utils', () => ({
 	handleQueryChange: jest.fn(),
-	PANEL_TYPE_TO_QUERY_TYPES: {
-		graph: ['builder', 'clickhouse', 'promql'],
-		table: ['builder', 'clickhouse'],
-		list: ['builder'],
-		value: ['builder', 'clickhouse', 'promql'],
-		bar: ['builder', 'clickhouse', 'promql'],
-		pie: ['builder', 'clickhouse'],
-		histogram: ['builder', 'clickhouse', 'promql'],
-	},
+}));
+jest.mock('../../../Panels/capabilities', () => ({
+	resolveQueryType: jest.fn(),
 }));
 jest.mock('../../../queryV5/persesQueryAdapters', () => ({
 	toPerses: jest.fn(),
@@ -37,6 +32,7 @@ jest.mock('../../../Panels/utils/getBuilderQueries', () => ({
 
 const mockUseQueryBuilder = useQueryBuilder as unknown as jest.Mock;
 const mockHandleQueryChange = handleQueryChange as unknown as jest.Mock;
+const mockResolveQueryType = resolveQueryType as unknown as jest.Mock;
 const mockToPerses = toPerses as unknown as jest.Mock;
 const mockGetSwitchedPluginSpec = getSwitchedPluginSpec as unknown as jest.Mock;
 const mockGetBuilderQueries = getBuilderQueries as unknown as jest.Mock;
@@ -92,6 +88,9 @@ describe('usePanelTypeSwitch', () => {
 		mockToPerses.mockReturnValue(CONVERTED);
 		mockGetSwitchedPluginSpec.mockReturnValue(SWITCHED_SPEC);
 		mockGetBuilderQueries.mockReturnValue([{ signal: 'logs' }]);
+		// The guard owns coercion (tested in capabilities.test.ts); here it always
+		// resolves to Query Builder so the coerced type flows into handleQueryChange.
+		mockResolveQueryType.mockReturnValue('builder');
 	});
 
 	it('does nothing when switching to the current kind', () => {
@@ -149,7 +148,12 @@ describe('usePanelTypeSwitch', () => {
 		);
 		act(() => result.current.onChangePanelKind('signoz/ListPanel'));
 
-		// List allows only Query Builder, so the promql query is coerced to 'builder'.
+		// The hook asks the guard to resolve the active query type against the new kind…
+		expect(mockResolveQueryType).toHaveBeenCalledWith(
+			'signoz/ListPanel',
+			'promql',
+		);
+		// …and the resolved type ('builder') flows into the query rebuild.
 		const [, queryArg] = mockHandleQueryChange.mock.calls[0];
 		expect((queryArg as Query).queryType).toBe('builder');
 	});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/usePanelTypeSwitch.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/usePanelTypeSwitch.ts
@@ -8,12 +8,12 @@ import type {
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import {
 	handleQueryChange,
-	PANEL_TYPE_TO_QUERY_TYPES,
 	type PartialPanelTypes,
 } from 'container/NewWidget/utils';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 
+import { resolveQueryType } from '../../Panels/capabilities';
 import {
 	PANEL_KIND_TO_PANEL_TYPE,
 	type PanelKind,
@@ -108,12 +108,9 @@ export function usePanelTypeSwitch({
 				return;
 			}
 
-			// First visit → coerce the query type if the new panel disallows it, then
+			// First visit → coerce the query type if the new kind disallows it, then
 			// rebuild the builder query for the new type.
-			const supported = PANEL_TYPE_TO_QUERY_TYPES[newPanelType] ?? [];
-			const queryType = supported.includes(query.queryType)
-				? query.queryType
-				: supported[0];
+			const queryType = resolveQueryType(newKind, query.queryType);
 			const transformed = handleQueryChange(
 				newPanelType as keyof PartialPanelTypes,
 				{ ...query, queryType },

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
 	ResizableHandle,
 	ResizablePanel,
@@ -18,6 +18,7 @@ import {
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import { getBuilderQueries } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries';
 
+import { getExecStats } from '../queryV5/v5ResponseData';
 import { usePanelInteractions } from '../PanelsAndSectionsLayout/Panel/hooks/usePanelInteractions';
 import ConfigPane from './ConfigPane/ConfigPane';
 import Header from './Header/Header';
@@ -150,6 +151,14 @@ function PanelEditorContainer({
 	const legendSeries = useLegendSeries(draft, data);
 	const tableColumns = useTableColumns(draft, data);
 
+	// Smallest query step interval (seconds) — the floor for the span-gaps
+	// threshold. Undefined until results carry step metadata.
+	const stepInterval = useMemo((): number | undefined => {
+		const intervals = getExecStats(data.response)?.stepIntervals;
+		const values = intervals ? Object.values(intervals) : [];
+		return values.length ? Math.min(...values) : undefined;
+	}, [data.response]);
+
 	const onSave = useCallback(async (): Promise<void> => {
 		try {
 			// Bake the live query into the spec so unstaged edits are saved too.
@@ -233,6 +242,7 @@ function PanelEditorContainer({
 						onChangePanelKind={onChangePanelKind}
 						legendSeries={legendSeries}
 						tableColumns={tableColumns}
+						stepInterval={stepInterval}
 					/>
 				</ResizablePanel>
 			</ResizablePanelGroup>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
@@ -11,6 +11,7 @@ import {
 	TelemetrytypesSignalDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { PANEL_TYPES } from 'constants/queryBuilder';
+import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { getPanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/registry';
 import {
 	PANEL_KIND_TO_PANEL_TYPE,
@@ -67,6 +68,10 @@ function PanelEditorContainer({
 	onSaved,
 }: PanelEditorContainerProps): JSX.Element {
 	const { draft, spec, setSpec, isSpecDirty } = usePanelEditorDraft(panel);
+	// Live query type (the selected tab) — the type switcher disables kinds that can't be
+	// authored in it. Read from the provider, not the spec: a new panel's spec carries no
+	// query until staged, so the spec would lag the tab.
+	const { currentQuery } = useQueryBuilder();
 	const { save, isSaving } = usePanelEditorSave({
 		dashboardId,
 		panelId,
@@ -210,7 +215,8 @@ function PanelEditorContainer({
 							<ResizableHandle withHandle className={styles.handle} />
 							<ResizablePanel minSize="35%" maxSize="45%" defaultSize="40%">
 								<PanelEditorQueryBuilder
-									panelType={panelType}
+									panelKind={fullKind}
+									signal={listSignal}
 									isLoadingQueries={isFetching}
 									onStageRunQuery={runQuery}
 									onCancelQuery={cancelQuery}
@@ -240,6 +246,7 @@ function PanelEditorContainer({
 						spec={spec}
 						onChangeSpec={setSpec}
 						onChangePanelKind={onChangePanelKind}
+						queryType={currentQuery.queryType}
 						legendSeries={legendSeries}
 						tableColumns={tableColumns}
 						stepInterval={stepInterval}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/__tests__/capabilities.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/__tests__/capabilities.test.ts
@@ -1,0 +1,167 @@
+import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { OPERATORS } from 'constants/queryBuilder';
+import { EQueryType } from 'types/common/dashboard';
+
+import {
+	getHiddenQueryBuilderFields,
+	getSupportedQueryTypes,
+	getSupportedSignals,
+	isPanelCombinationValid,
+	isQueryTypeSupported,
+	isSignalSupported,
+	resolveQueryType,
+} from '../capabilities';
+import type { PanelKind } from '../types/panelKind';
+
+const { QUERY_BUILDER, CLICKHOUSE, PROM } = EQueryType;
+const { logs, traces, metrics } = TelemetrytypesSignalDTO;
+
+const EXPECTED_QUERY_TYPES: Record<PanelKind, EQueryType[]> = {
+	'signoz/TimeSeriesPanel': [QUERY_BUILDER, CLICKHOUSE, PROM],
+	'signoz/BarChartPanel': [QUERY_BUILDER, CLICKHOUSE, PROM],
+	'signoz/NumberPanel': [QUERY_BUILDER, CLICKHOUSE, PROM],
+	'signoz/HistogramPanel': [QUERY_BUILDER, CLICKHOUSE, PROM],
+	'signoz/PieChartPanel': [QUERY_BUILDER, CLICKHOUSE],
+	'signoz/TablePanel': [QUERY_BUILDER, CLICKHOUSE],
+	'signoz/ListPanel': [QUERY_BUILDER],
+};
+
+const EXPECTED_SIGNALS: Record<PanelKind, TelemetrytypesSignalDTO[]> = {
+	'signoz/TimeSeriesPanel': [metrics, logs, traces],
+	'signoz/BarChartPanel': [metrics, logs, traces],
+	'signoz/NumberPanel': [metrics, logs, traces],
+	'signoz/HistogramPanel': [metrics, logs, traces],
+	'signoz/PieChartPanel': [metrics, logs, traces],
+	'signoz/TablePanel': [metrics, logs, traces],
+	// List renders raw rows; metrics produce no row data.
+	'signoz/ListPanel': [logs, traces],
+};
+
+const ALL_KINDS = Object.keys(EXPECTED_QUERY_TYPES) as PanelKind[];
+
+describe('panel capabilities guard', () => {
+	describe('query type support', () => {
+		it.each(ALL_KINDS)('declares the expected query types for %s', (kind) => {
+			expect(getSupportedQueryTypes(kind)).toStrictEqual(
+				EXPECTED_QUERY_TYPES[kind],
+			);
+		});
+
+		it('Table and Pie do not support PromQL', () => {
+			expect(isQueryTypeSupported('signoz/TablePanel', PROM)).toBe(false);
+			expect(isQueryTypeSupported('signoz/PieChartPanel', PROM)).toBe(false);
+		});
+
+		it('List only supports Query Builder', () => {
+			expect(isQueryTypeSupported('signoz/ListPanel', QUERY_BUILDER)).toBe(true);
+			expect(isQueryTypeSupported('signoz/ListPanel', CLICKHOUSE)).toBe(false);
+			expect(isQueryTypeSupported('signoz/ListPanel', PROM)).toBe(false);
+		});
+	});
+
+	describe('signal support', () => {
+		it.each(ALL_KINDS)('declares the expected signals for %s', (kind) => {
+			expect(getSupportedSignals(kind)).toStrictEqual(EXPECTED_SIGNALS[kind]);
+		});
+
+		it('List excludes metrics', () => {
+			expect(isSignalSupported('signoz/ListPanel', metrics)).toBe(false);
+			expect(isSignalSupported('signoz/ListPanel', logs)).toBe(true);
+			expect(isSignalSupported('signoz/ListPanel', traces)).toBe(true);
+		});
+	});
+
+	describe('isPanelCombinationValid', () => {
+		it('accepts a supported triad', () => {
+			expect(
+				isPanelCombinationValid({
+					kind: 'signoz/TimeSeriesPanel',
+					queryType: PROM,
+				}),
+			).toBe(true);
+			expect(
+				isPanelCombinationValid({
+					kind: 'signoz/ListPanel',
+					queryType: QUERY_BUILDER,
+					signal: logs,
+				}),
+			).toBe(true);
+		});
+
+		it('rejects an unsupported query type', () => {
+			expect(
+				isPanelCombinationValid({ kind: 'signoz/ListPanel', queryType: PROM }),
+			).toBe(false);
+			expect(
+				isPanelCombinationValid({ kind: 'signoz/TablePanel', queryType: PROM }),
+			).toBe(false);
+		});
+
+		it('rejects an unsupported signal when one is given', () => {
+			expect(
+				isPanelCombinationValid({
+					kind: 'signoz/ListPanel',
+					queryType: QUERY_BUILDER,
+					signal: metrics,
+				}),
+			).toBe(false);
+		});
+
+		it('ignores signal when none is given (ClickHouse/PromQL have no signal)', () => {
+			expect(
+				isPanelCombinationValid({
+					kind: 'signoz/ListPanel',
+					queryType: QUERY_BUILDER,
+				}),
+			).toBe(true);
+		});
+	});
+
+	describe('resolveQueryType', () => {
+		it('keeps a supported query type', () => {
+			expect(resolveQueryType('signoz/TimeSeriesPanel', PROM)).toBe(PROM);
+			expect(resolveQueryType('signoz/ListPanel', QUERY_BUILDER)).toBe(
+				QUERY_BUILDER,
+			);
+		});
+
+		it('coerces an unsupported query type to the first supported one', () => {
+			// PromQL → List has no PromQL, falls back to its first (and only) type.
+			expect(resolveQueryType('signoz/ListPanel', PROM)).toBe(QUERY_BUILDER);
+			expect(resolveQueryType('signoz/TablePanel', PROM)).toBe(QUERY_BUILDER);
+		});
+	});
+
+	describe('getHiddenQueryBuilderFields', () => {
+		it('returns {} for kinds that declare no field rules', () => {
+			expect(
+				getHiddenQueryBuilderFields('signoz/TimeSeriesPanel', logs),
+			).toStrictEqual({});
+			expect(getHiddenQueryBuilderFields('signoz/TablePanel', logs)).toStrictEqual(
+				{},
+			);
+		});
+
+		// Mirrors QueryBuilderV2's internal listViewLogFilterConfigs — the guard is the
+		// single source of truth for these values.
+		it('hides step interval / having and sets body-contains for List + logs', () => {
+			expect(getHiddenQueryBuilderFields('signoz/ListPanel', logs)).toStrictEqual({
+				stepInterval: { isHidden: true, isDisabled: true },
+				having: { isHidden: true, isDisabled: true },
+				filters: { customKey: 'body', customOp: OPERATORS.CONTAINS },
+			});
+		});
+
+		// Mirrors listViewTracesFilterConfigs — traces additionally hide `limit`.
+		it('additionally hides limit for List + traces', () => {
+			expect(
+				getHiddenQueryBuilderFields('signoz/ListPanel', traces),
+			).toStrictEqual({
+				stepInterval: { isHidden: true, isDisabled: true },
+				having: { isHidden: true, isDisabled: true },
+				limit: { isHidden: true, isDisabled: true },
+				filters: { customKey: 'body', customOp: OPERATORS.CONTAINS },
+			});
+		});
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/capabilities.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/capabilities.ts
@@ -1,0 +1,91 @@
+import type { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { EQueryType } from 'types/common/dashboard';
+
+import { getPanelDefinition } from './registry';
+import type { FilterConfigsPartial } from './types/panelCapabilities';
+import type { PanelKind } from './types/panelKind';
+
+/**
+ * The single deterministic guard for V2 dashboards. Every "what works with what"
+ * question — panel kind × query type × signal, and which query-builder fields a kind
+ * hides — is answered here by reading each kind's declared capabilities from the panel
+ * registry. Adding a new kind means declaring its capabilities once in its definition;
+ * these functions then cover it automatically. Pure and side-effect free.
+ */
+
+/** Signals a kind can visualize. */
+export function getSupportedSignals(
+	kind: PanelKind,
+): TelemetrytypesSignalDTO[] {
+	return getPanelDefinition(kind).supportedSignals;
+}
+
+export function isSignalSupported(
+	kind: PanelKind,
+	signal: TelemetrytypesSignalDTO,
+): boolean {
+	return getSupportedSignals(kind).includes(signal);
+}
+
+/** Query languages a kind supports (Query Builder / ClickHouse / PromQL). */
+export function getSupportedQueryTypes(kind: PanelKind): EQueryType[] {
+	return getPanelDefinition(kind).supportedQueryTypes;
+}
+
+export function isQueryTypeSupported(
+	kind: PanelKind,
+	queryType: EQueryType,
+): boolean {
+	return getSupportedQueryTypes(kind).includes(queryType);
+}
+
+/**
+ * Master guard: is this panel kind renderable with this query type (and, in builder
+ * mode, this signal)? ClickHouse/PromQL queries carry no signal, so the signal is
+ * validated only when one is given.
+ */
+export function isPanelCombinationValid({
+	kind,
+	queryType,
+	signal,
+}: {
+	kind: PanelKind;
+	queryType: EQueryType;
+	signal?: TelemetrytypesSignalDTO;
+}): boolean {
+	if (!isQueryTypeSupported(kind, queryType)) {
+		return false;
+	}
+	if (signal !== undefined && !isSignalSupported(kind, signal)) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * The query type to use for a kind given a `preferred` one: keep it if the kind
+ * supports it, otherwise fall back to the kind's first supported type. Used when
+ * switching panel kinds to coerce an unsupported active query type (e.g. PromQL → a
+ * List panel coerces to Query Builder).
+ */
+export function resolveQueryType(
+	kind: PanelKind,
+	preferred: EQueryType,
+): EQueryType {
+	const supported = getSupportedQueryTypes(kind);
+	return supported.includes(preferred) ? preferred : supported[0];
+}
+
+/**
+ * Query-builder field visibility for a kind + signal: the kind's `default` rule with
+ * its per-signal overrides merged over it (signal wins). `{}` when the kind hides
+ * nothing, i.e. the builder shows every field.
+ */
+export function getHiddenQueryBuilderFields(
+	kind: PanelKind,
+	signal: TelemetrytypesSignalDTO,
+): FilterConfigsPartial {
+	const rule = getPanelDefinition(kind).queryBuilderFields;
+	const perSignal = signal ? rule[signal] : undefined;
+	return { ...rule.default, ...perSignal };
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/BarChartPanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/BarChartPanel/definition.ts
@@ -2,6 +2,7 @@ import type { PanelDefinition } from '../../types/panelDefinition';
 import Renderer from './Renderer';
 import { sections } from './sections';
 import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { EQueryType } from 'types/common/dashboard';
 
 export const definition: PanelDefinition<'signoz/BarChartPanel'> = {
 	kind: 'signoz/BarChartPanel',
@@ -13,6 +14,12 @@ export const definition: PanelDefinition<'signoz/BarChartPanel'> = {
 		TelemetrytypesSignalDTO.logs,
 		TelemetrytypesSignalDTO.traces,
 	],
+	supportedQueryTypes: [
+		EQueryType.QUERY_BUILDER,
+		EQueryType.CLICKHOUSE,
+		EQueryType.PROM,
+	],
+	queryBuilderFields: {},
 	actions: {
 		view: true,
 		edit: true,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/HistogramPanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/HistogramPanel/definition.ts
@@ -2,6 +2,7 @@ import type { PanelDefinition } from '../../types/panelDefinition';
 import Renderer from './Renderer';
 import { sections } from './sections';
 import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { EQueryType } from 'types/common/dashboard';
 
 export const definition: PanelDefinition<'signoz/HistogramPanel'> = {
 	kind: 'signoz/HistogramPanel',
@@ -13,6 +14,12 @@ export const definition: PanelDefinition<'signoz/HistogramPanel'> = {
 		TelemetrytypesSignalDTO.logs,
 		TelemetrytypesSignalDTO.traces,
 	],
+	supportedQueryTypes: [
+		EQueryType.QUERY_BUILDER,
+		EQueryType.CLICKHOUSE,
+		EQueryType.PROM,
+	],
+	queryBuilderFields: {},
 	actions: {
 		view: true,
 		edit: true,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/ListPanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/ListPanel/definition.ts
@@ -2,6 +2,8 @@ import type { PanelDefinition } from '../../types/panelDefinition';
 import Renderer from './Renderer';
 import { sections } from './sections';
 import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { OPERATORS } from 'constants/queryBuilder';
+import { EQueryType } from 'types/common/dashboard';
 
 export const definition: PanelDefinition<'signoz/ListPanel'> = {
 	kind: 'signoz/ListPanel',
@@ -12,6 +14,21 @@ export const definition: PanelDefinition<'signoz/ListPanel'> = {
 		TelemetrytypesSignalDTO.logs,
 		TelemetrytypesSignalDTO.traces,
 	],
+	// Raw rows have no aggregation, so step interval / having never apply, and the
+	// Where clause searches the log/span body via `body CONTAINS`. Traces additionally
+	// hide `limit` (the server paginates raw spans). Mirrors QueryBuilderV2's internal
+	// list configs — the capabilities guard is the single source for both.
+	supportedQueryTypes: [EQueryType.QUERY_BUILDER],
+	queryBuilderFields: {
+		default: {
+			stepInterval: { isHidden: true, isDisabled: true },
+			having: { isHidden: true, isDisabled: true },
+			filters: { customKey: 'body', customOp: OPERATORS.CONTAINS },
+		},
+		[TelemetrytypesSignalDTO.traces]: {
+			limit: { isHidden: true, isDisabled: true },
+		},
+	},
 	sections,
 	actions: {
 		view: true,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/NumberPanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/NumberPanel/definition.ts
@@ -2,6 +2,7 @@ import type { PanelDefinition } from '../../types/panelDefinition';
 import Renderer from './Renderer';
 import { sections } from './sections';
 import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { EQueryType } from 'types/common/dashboard';
 
 export const definition: PanelDefinition<'signoz/NumberPanel'> = {
 	kind: 'signoz/NumberPanel',
@@ -13,6 +14,12 @@ export const definition: PanelDefinition<'signoz/NumberPanel'> = {
 		TelemetrytypesSignalDTO.logs,
 		TelemetrytypesSignalDTO.traces,
 	],
+	supportedQueryTypes: [
+		EQueryType.QUERY_BUILDER,
+		EQueryType.CLICKHOUSE,
+		EQueryType.PROM,
+	],
+	queryBuilderFields: {},
 	actions: {
 		view: true,
 		edit: true,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/definition.ts
@@ -2,6 +2,7 @@ import type { PanelDefinition } from '../../types/panelDefinition';
 import Renderer from './Renderer';
 import { sections } from './sections';
 import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { EQueryType } from 'types/common/dashboard';
 
 export const definition: PanelDefinition<'signoz/PieChartPanel'> = {
 	kind: 'signoz/PieChartPanel',
@@ -13,6 +14,8 @@ export const definition: PanelDefinition<'signoz/PieChartPanel'> = {
 		TelemetrytypesSignalDTO.logs,
 		TelemetrytypesSignalDTO.traces,
 	],
+	supportedQueryTypes: [EQueryType.QUERY_BUILDER, EQueryType.CLICKHOUSE],
+	queryBuilderFields: {},
 	actions: {
 		view: true,
 		edit: true,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/definition.ts
@@ -2,6 +2,7 @@ import type { PanelDefinition } from '../../types/panelDefinition';
 import Renderer from './Renderer';
 import { sections } from './sections';
 import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { EQueryType } from 'types/common/dashboard';
 
 export const definition: PanelDefinition<'signoz/TablePanel'> = {
 	kind: 'signoz/TablePanel',
@@ -13,6 +14,8 @@ export const definition: PanelDefinition<'signoz/TablePanel'> = {
 		TelemetrytypesSignalDTO.logs,
 		TelemetrytypesSignalDTO.traces,
 	],
+	supportedQueryTypes: [EQueryType.QUERY_BUILDER, EQueryType.CLICKHOUSE],
+	queryBuilderFields: {},
 	// Tables carry tabular data worth exporting (V1 parity: download is table-only).
 	actions: {
 		view: true,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TimeSeriesPanel/definition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TimeSeriesPanel/definition.ts
@@ -2,6 +2,7 @@ import type { PanelDefinition } from '../../types/panelDefinition';
 import Renderer from './Renderer';
 import { sections } from './sections';
 import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { EQueryType } from 'types/common/dashboard';
 
 export const definition: PanelDefinition<'signoz/TimeSeriesPanel'> = {
 	kind: 'signoz/TimeSeriesPanel',
@@ -13,6 +14,12 @@ export const definition: PanelDefinition<'signoz/TimeSeriesPanel'> = {
 		TelemetrytypesSignalDTO.logs,
 		TelemetrytypesSignalDTO.traces,
 	],
+	supportedQueryTypes: [
+		EQueryType.QUERY_BUILDER,
+		EQueryType.CLICKHOUSE,
+		EQueryType.PROM,
+	],
+	queryBuilderFields: {},
 	actions: {
 		view: true,
 		edit: true,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/panelCapabilities.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/panelCapabilities.ts
@@ -1,0 +1,20 @@
+import type { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import type { QueryBuilderProps } from 'container/QueryBuilder/QueryBuilder.interfaces';
+
+/**
+ * Query-builder field-visibility config a panel kind can declare, mirroring the
+ * shape `QueryBuilderV2` consumes via its `filterConfigs` prop. Derived from that
+ * prop type (the underlying `FilterConfigs` isn't exported) so the two never drift.
+ */
+export type FilterConfigsPartial = NonNullable<
+	QueryBuilderProps['filterConfigs']
+>;
+
+/**
+ * Per-signal query-builder field rules for a panel kind. `default` applies to every
+ * signal; a per-signal entry is merged over it (signal wins). The capabilities guard
+ * resolves this into a single `FilterConfigsPartial` via `getHiddenQueryBuilderFields`.
+ */
+export type QueryBuilderFieldRule = {
+	default?: FilterConfigsPartial;
+} & Partial<Record<TelemetrytypesSignalDTO, FilterConfigsPartial>>;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition.ts
@@ -1,9 +1,11 @@
 import type { ComponentType } from 'react';
 import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import type { EQueryType } from 'types/common/dashboard';
 
 import type { SectionConfig } from './sections';
 import type { AnyPanelInteractionProps } from './interactions';
 import type { PanelKind } from './panelKind';
+import type { QueryBuilderFieldRule } from './panelCapabilities';
 import type { BaseRendererProps, PanelRendererProps } from './rendererProps';
 
 /**
@@ -35,7 +37,12 @@ export interface PanelDefinition<K extends PanelKind = PanelKind> {
 	displayName: string;
 	Renderer: ComponentType<PanelRendererProps<K>>;
 	sections: SectionConfig[];
+	/** Signals this kind can visualize. */
 	supportedSignals: TelemetrytypesSignalDTO[];
+	/** Query languages this kind supports (Query Builder / ClickHouse / PromQL). */
+	supportedQueryTypes: EQueryType[];
+	/** Query-builder fields this kind hides/disables, optionally per signal (`{}` hides none). */
+	queryBuilderFields: QueryBuilderFieldRule;
 	actions: PanelActionCapabilities;
 }
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/sections.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/sections.ts
@@ -153,7 +153,7 @@ export type SectionConfig =
 // Per-section title + sidebar icon. Pure data; the editor component + spec lens
 // live in the ConfigPane section registry.
 export const SECTION_METADATA = {
-	[SectionKind.Formatting]: { title: 'Formatting', icon: Hash },
+	[SectionKind.Formatting]: { title: 'Formatting & Units', icon: Hash },
 	[SectionKind.Axes]: { title: 'Axes', icon: Ruler },
 	[SectionKind.Legend]: { title: 'Legend', icon: Layers },
 	[SectionKind.ChartAppearance]: { title: 'Chart appearance', icon: Palette },

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/getBuilderQueries.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/getBuilderQueries.test.ts
@@ -1,0 +1,34 @@
+import type { DashboardtypesQueryDTO } from 'api/generated/services/sigNoz.schemas';
+import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+
+import { resolveSignal } from '../getBuilderQueries';
+
+function builderQuery(signal: string): DashboardtypesQueryDTO {
+	return {
+		spec: { plugin: { kind: 'signoz/BuilderQuery', spec: { signal } } },
+	} as unknown as DashboardtypesQueryDTO;
+}
+
+const promqlQuery = {
+	spec: { plugin: { kind: 'signoz/PromQuery', spec: { query: 'up' } } },
+} as unknown as DashboardtypesQueryDTO;
+
+describe('resolveSignal', () => {
+	const DEFAULT = TelemetrytypesSignalDTO.metrics;
+
+	it("uses the first builder query's signal when present", () => {
+		expect(
+			resolveSignal([builderQuery('logs')], DEFAULT),
+		).toBe('logs');
+	});
+
+	it("prefers the builder signal over the default", () => {
+		expect(resolveSignal([builderQuery('traces')], DEFAULT)).toBe(
+			'traces',
+		);
+	});
+
+	it('stays undefined when queries exist but none are builder queries (PromQL/ClickHouse)', () => {
+		expect(resolveSignal([promqlQuery], DEFAULT)).toBeUndefined();
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/getBuilderQueries.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/getBuilderQueries.test.ts
@@ -17,15 +17,11 @@ describe('resolveSignal', () => {
 	const DEFAULT = TelemetrytypesSignalDTO.metrics;
 
 	it("uses the first builder query's signal when present", () => {
-		expect(
-			resolveSignal([builderQuery('logs')], DEFAULT),
-		).toBe('logs');
+		expect(resolveSignal([builderQuery('logs')], DEFAULT)).toBe('logs');
 	});
 
-	it("prefers the builder signal over the default", () => {
-		expect(resolveSignal([builderQuery('traces')], DEFAULT)).toBe(
-			'traces',
-		);
+	it('prefers the builder signal over the default', () => {
+		expect(resolveSignal([builderQuery('traces')], DEFAULT)).toBe('traces');
 	});
 
 	it('stays undefined when queries exist but none are builder queries (PromQL/ClickHouse)', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/chartAppearance/__tests__/resolvers.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/chartAppearance/__tests__/resolvers.test.ts
@@ -1,0 +1,22 @@
+import { resolveSpanGaps } from '../resolvers';
+
+describe('resolveSpanGaps', () => {
+	it('spans all gaps (true) when unset', () => {
+		expect(resolveSpanGaps(undefined)).toBe(true);
+		expect(resolveSpanGaps('')).toBe(true);
+	});
+
+	it('parses a duration string into seconds', () => {
+		expect(resolveSpanGaps('5s')).toBe(5);
+		expect(resolveSpanGaps('10m')).toBe(600);
+		expect(resolveSpanGaps('1h')).toBe(3600);
+	});
+
+	it('tolerates a bare seconds number (back-compat)', () => {
+		expect(resolveSpanGaps('600')).toBe(600);
+	});
+
+	it('falls back to true for unparseable input', () => {
+		expect(resolveSpanGaps('abc')).toBe(true);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/chartAppearance/resolvers.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/chartAppearance/resolvers.ts
@@ -1,3 +1,4 @@
+import { rangeUtil } from '@grafana/data';
 import {
 	DashboardtypesLegendPositionDTO,
 	DashboardtypesPrecisionOptionDTO,
@@ -38,9 +39,10 @@ export function resolveDecimalPrecision(
 }
 
 /**
- * `spec.chartAppearance.spanGaps.fillLessThan` is a stringified number on the
- * wire. Empty/missing → span all gaps (default); numeric → forward the threshold
- * so uPlot only bridges short runs of nulls.
+ * `spec.chartAppearance.spanGaps.fillLessThan` is a duration string on the wire
+ * ("10m", "5s"). Empty/missing → span all gaps (default); otherwise forward the
+ * threshold in seconds so uPlot only bridges short runs of nulls. Tolerates a
+ * bare seconds number for back-compat.
  */
 export function resolveSpanGaps(
 	fillLessThan: string | undefined,
@@ -48,8 +50,10 @@ export function resolveSpanGaps(
 	if (!fillLessThan) {
 		return true;
 	}
-	const parsed = Number(fillLessThan);
-	return Number.isFinite(parsed) ? parsed : true;
+	const seconds = rangeUtil.isValidTimeSpan(fillLessThan)
+		? rangeUtil.intervalToSeconds(fillLessThan)
+		: Number(fillLessThan);
+	return Number.isFinite(seconds) && seconds > 0 ? seconds : true;
 }
 
 /** Legend position; missing/unknown falls back to `BOTTOM` (chart default, V1 parity). */

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries.ts
@@ -1,4 +1,7 @@
-import type { DashboardtypesQueryDTO } from 'api/generated/services/sigNoz.schemas';
+import type {
+	DashboardtypesQueryDTO,
+	TelemetrytypesSignalDTO,
+} from 'api/generated/services/sigNoz.schemas';
 import type { BuilderQuery } from 'types/api/v5/queryRange';
 
 /**
@@ -26,4 +29,22 @@ export function getBuilderQueries(
 		}
 	});
 	return flattened;
+}
+
+/**
+ * Datasource signal scoping panel-type compatibility (List needs logs/traces, not
+ * metrics): the builder query's signal if present; else `defaultSignal` for a new
+ * panel (queries empty until edited); else undefined for PromQL/ClickHouse.
+ */
+export function resolveSignal(
+	queries: DashboardtypesQueryDTO[],
+	defaultSignal: TelemetrytypesSignalDTO,
+): TelemetrytypesSignalDTO | undefined {
+	const builderSignal = getBuilderQueries(queries ?? [])[0]?.signal as
+		| TelemetrytypesSignalDTO
+		| undefined;
+	if (builderSignal) {
+		return builderSignal;
+	}
+	return queries?.length ? undefined : defaultSignal;
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries.ts
@@ -40,11 +40,11 @@ export function resolveSignal(
 	queries: DashboardtypesQueryDTO[],
 	defaultSignal: TelemetrytypesSignalDTO,
 ): TelemetrytypesSignalDTO | undefined {
-	const builderSignal = getBuilderQueries(queries ?? [])[0]?.signal as
+	const builderSignal = getBuilderQueries(queries)[0]?.signal as
 		| TelemetrytypesSignalDTO
 		| undefined;
 	if (builderSignal) {
 		return builderSignal;
 	}
-	return queries?.length ? undefined : defaultSignal;
+	return queries.length ? undefined : defaultSignal;
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/__tests__/usePanelActionItems.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/__tests__/usePanelActionItems.test.tsx
@@ -52,6 +52,8 @@ function section(
 }
 
 const TWO_TITLED_SECTIONS = [section(0, 'Overview'), section(1, 'Latency')];
+// Index 0 is the untitled root (free-flow) section; index 1 is a titled section.
+const TITLED_WITH_ROOT = [section(0, undefined), section(1, 'Latency')];
 
 const baseArgs = {
 	panelId: 'panel-1',
@@ -175,6 +177,49 @@ describe('usePanelActionItems', () => {
 			fromLayoutIndex: 0,
 			toLayoutIndex: 1,
 		});
+	});
+
+	it('offers "Move out of section" for a panel in a titled section when an untitled root exists', () => {
+		const { result } = renderHook(() =>
+			usePanelActionItems({
+				...baseArgs,
+				panelActions: { currentLayoutIndex: 1, sections: TITLED_WITH_ROOT },
+			}),
+		);
+		expect(itemKeys(result.current)).toContain('move-to-root');
+	});
+
+	it('"Move out of section" moves the panel to the untitled root section', () => {
+		const { result } = renderHook(() =>
+			usePanelActionItems({
+				...baseArgs,
+				panelActions: { currentLayoutIndex: 1, sections: TITLED_WITH_ROOT },
+			}),
+		);
+		const moveOut = result.current.items.find(
+			(i) => 'key' in i && i.key === 'move-to-root',
+		);
+		(moveOut as { onClick: () => void }).onClick();
+		expect(mockMovePanel).toHaveBeenCalledWith({
+			panelId: 'panel-1',
+			fromLayoutIndex: 1,
+			toLayoutIndex: 0,
+		});
+	});
+
+	it('hides "Move out of section" when the panel already sits in the root section', () => {
+		const { result } = renderHook(() =>
+			usePanelActionItems({
+				...baseArgs,
+				panelActions: { currentLayoutIndex: 0, sections: TITLED_WITH_ROOT },
+			}),
+		);
+		expect(itemKeys(result.current)).not.toContain('move-to-root');
+	});
+
+	it('hides "Move out of section" when every section is titled (no root)', () => {
+		const { result } = renderHook(() => usePanelActionItems(baseArgs));
+		expect(itemKeys(result.current)).not.toContain('move-to-root');
 	});
 
 	it('delete defers to a confirmation: the item opens the dialog, confirm runs the mutation', async () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/usePanelActionItems.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/usePanelActionItems.tsx
@@ -4,6 +4,7 @@ import {
 	CloudDownload,
 	Copy,
 	FolderInput,
+	FolderOutput,
 	Fullscreen,
 	PenLine,
 	Trash2,
@@ -23,7 +24,10 @@ import type { DashboardSection } from '../../../utils';
 import type { PanelActionsConfig } from '../Panel';
 import { useClonePanel } from '../hooks/useClonePanel';
 import { useDeletePanel } from '../hooks/useDeletePanel';
-import { useMovePanelToSection } from '../hooks/useMovePanelToSection';
+import {
+	type MovePanelArgs,
+	useMovePanelToSection,
+} from '../hooks/useMovePanelToSection';
 import { PANEL_ACTION_META } from './panelActionMeta';
 import { PanelKind } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 
@@ -35,6 +39,66 @@ const EMPTY_SECTIONS: DashboardSection[] = [];
 function notImplementedYet(feature: string): void {
 	// eslint-disable-next-line no-alert -- temporary placeholder, see above
 	alert(`${feature} option clicked`);
+}
+
+interface MoveItemsArgs {
+	sections: DashboardSection[];
+	currentLayoutIndex: number;
+	panelId: string;
+	movePanel: (args: MovePanelArgs) => Promise<void>;
+}
+
+/**
+ * The "Move to section" submenu (other titled sections) plus a direct "Move out
+ * of section" to the untitled root, shown only when the panel sits in a titled
+ * section and a root section exists to receive it.
+ */
+function buildMoveItems({
+	sections,
+	currentLayoutIndex,
+	panelId,
+	movePanel,
+}: MoveItemsArgs): MenuItem[] {
+	const targets = sections.filter(
+		(s) => s.title && s.layoutIndex !== currentLayoutIndex,
+	);
+	const items: MenuItem[] = [
+		{
+			key: 'move',
+			label: 'Move to section',
+			icon: <FolderInput size={14} />,
+			...(targets.length === 0
+				? { disabled: true }
+				: {
+						children: targets.map((s) => ({
+							key: `move-${s.layoutIndex}`,
+							label: s.title,
+							onClick: (): void =>
+								void movePanel({
+									panelId,
+									fromLayoutIndex: currentLayoutIndex,
+									toLayoutIndex: s.layoutIndex,
+								}),
+						})),
+					}),
+		},
+	];
+
+	const rootSection = sections.find((s) => !s.title);
+	if (rootSection && rootSection.layoutIndex !== currentLayoutIndex) {
+		items.push({
+			key: 'move-to-root',
+			label: 'Move out of section',
+			icon: <FolderOutput size={14} />,
+			onClick: (): void =>
+				void movePanel({
+					panelId,
+					fromLayoutIndex: currentLayoutIndex,
+					toLayoutIndex: rootSection.layoutIndex,
+				}),
+		});
+	}
+	return items;
 }
 
 interface UsePanelActionItemsArgs {
@@ -155,31 +219,15 @@ export function usePanelActionItems({
 			});
 		}
 
-		const moveGroup: MenuItem[] = [];
-		if (canMove && panelActions) {
-			const targets = sections.filter(
-				(s) => s.title && s.layoutIndex !== panelActions.currentLayoutIndex,
-			);
-			moveGroup.push({
-				key: 'move',
-				label: 'Move to section',
-				icon: <FolderInput size={14} />,
-				...(targets.length === 0
-					? { disabled: true }
-					: {
-							children: targets.map((s) => ({
-								key: `move-${s.layoutIndex}`,
-								label: s.title,
-								onClick: (): void =>
-									void movePanel({
-										panelId,
-										fromLayoutIndex: panelActions.currentLayoutIndex,
-										toLayoutIndex: s.layoutIndex,
-									}),
-							})),
-						}),
-			});
-		}
+		const moveGroup: MenuItem[] =
+			canMove && panelActions
+				? buildMoveItems({
+						sections,
+						currentLayoutIndex: panelActions.currentLayoutIndex,
+						panelId,
+						movePanel,
+					})
+				: [];
 
 		const deleteGroup: MenuItem[] =
 			canDelete && panelActions

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/__tests__/patchOps.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/__tests__/patchOps.test.ts
@@ -107,7 +107,7 @@ describe('createPanelOps', () => {
 		expect(value.y).toBe(6);
 	});
 
-	it('falls back to the last section when no index is requested', () => {
+	it('falls back to the root (first) section when no index is requested', () => {
 		const layouts = [section([]), section([item(0, 6)])];
 		const ops = createPanelOps({
 			layouts,
@@ -116,11 +116,11 @@ describe('createPanelOps', () => {
 			panel,
 		});
 
-		expect(ops[1].path).toBe('/spec/layouts/1/spec/items/-');
+		expect(ops[1].path).toBe('/spec/layouts/0/spec/items/-');
 	});
 
-	it('falls back to the last section when the requested index is out of range', () => {
-		const layouts = [section([])];
+	it('falls back to the root (first) section when the requested index is out of range', () => {
+		const layouts = [section([item(0, 6)]), section([])];
 		const ops = createPanelOps({ layouts, layoutIndex: 5, panelId: 'p1', panel });
 		expect(ops[1].path).toBe('/spec/layouts/0/spec/items/-');
 	});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/patchOps.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/patchOps.ts
@@ -121,7 +121,7 @@ export function addPanelToSectionOps({
 interface CreatePanelOpsArgs {
 	/** Current sections, used to resolve the target and the next free row. */
 	layouts: DashboardtypesLayoutDTO[];
-	/** Preferred section (from the "Add panel" trigger); falls back to the last. */
+	/** Preferred section (from a section's "Add panel" trigger); falls back to the root (first) section. */
 	layoutIndex: number | undefined;
 	panelId: string;
 	panel: DashboardtypesPanelDTO;
@@ -166,8 +166,8 @@ export function findFreeSlot(
 
 /**
  * Ops to persist a brand-new panel (editor save path): resolve the target
- * section (requested index if valid, else last, else a freshly-created one) and
- * place the panel via `findFreeSlot`.
+ * section (requested index if valid, else the root/first section, else a
+ * freshly-created one) and place the panel via `findFreeSlot`.
  */
 export function createPanelOps({
 	layouts,
@@ -177,14 +177,17 @@ export function createPanelOps({
 }: CreatePanelOpsArgs): DashboardtypesJSONPatchOperationDTO[] {
 	const ops: DashboardtypesJSONPatchOperationDTO[] = [];
 
-	const requested =
-		layoutIndex !== undefined && layouts[layoutIndex] !== undefined
-			? layoutIndex
-			: layouts.length - 1;
-
-	let targetIndex = requested;
-	let items: DashboardGridItemDTO[] = layouts[requested]?.spec.items ?? [];
-	if (targetIndex < 0) {
+	let targetIndex: number;
+	let items: DashboardGridItemDTO[];
+	if (layoutIndex !== undefined && layouts[layoutIndex] !== undefined) {
+		// Explicit section — a section's own "New Panel" trigger.
+		targetIndex = layoutIndex;
+		items = layouts[layoutIndex]?.spec.items ?? [];
+	} else if (layouts.length > 0) {
+		// No section specified (toolbar "New Panel") → the root (first) section.
+		targetIndex = 0;
+		items = layouts[0]?.spec.items ?? [];
+	} else {
 		// No sections yet — create an untitled one and target it.
 		ops.push(addSectionOp(''));
 		targetIndex = 0;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/utils.ts
@@ -137,13 +137,3 @@ export function layoutsToSections(
 		})
 		.filter((s): s is DashboardSection => s !== null);
 }
-
-export function getPanelKindLabel(
-	panel: DashboardtypesPanelDTO | undefined,
-): string {
-	const kind = panel?.spec?.plugin?.kind;
-	if (!kind) {
-		return 'unknown';
-	}
-	return kind.replace(/^signoz\//, '');
-}


### PR DESCRIPTION
## Pull Request

> **Stacked on #11820** (`feat/panel-editor-v2-type-switch`). Review/merge that first; this PR targets that branch so the diff is only the fixes below.

---

### 📄 Summary

A batch of bug fixes and polish for the V2 dashboard **panel editor**, found while exercising the type-switcher flow. Each is an independent, self-contained commit:

1. **Disable panel types unsupported by the datasource** — a new metrics panel could be switched to *List* (which only supports logs/traces), breaking rendering. The type switcher now resolves the datasource correctly from the first render and disables incompatible types.
2. **Place toolbar-created panels in the root section** — the top-right **New Panel** button was adding panels to the *last* section instead of the root/top section.
3. **"Move out of section" panel action** — a panel inside a titled section had no way back to the untitled root; added a dedicated action.
4. **Allow clearing the threshold value input** — the threshold "Value" field seeded `0` and could never be emptied (an emptied numeric input snapped back to `0`).
5. **Span-gaps "Disconnect values" control** — replaced the raw seconds input with a Never/Threshold toggle + duration field; the threshold is stored as a duration string ("10m") on the wire, with step-interval validation.
6. **Rename "Formatting" → "Formatting & Units"** + serialize section header test ids.
7. **Tidy panel-editor query helpers** — null-safety + removal of an unused util.

#### Screenshots / Screen Recordings (if applicable)
Span-gaps "Disconnect values" control (Never / Threshold + `> 1m` duration):

_<!-- attach the editor screenshot here -->_

#### Issues closed by this PR
Closes https://github.com/SigNoz/pulse-pod/issues/23

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
- **Type compatibility:** a new panel's builder is seeded with the kind's default signal, but `spec.queries` stays empty until the query is edited, so the switcher saw an `undefined` datasource and disabled nothing.
- **Panel placement:** `createPanelOps` fell back to `layouts.length - 1` (last section) when no section index was supplied by the toolbar trigger.
- **Threshold value:** the field was a controlled numeric input; `Number("")` is `0` (not `NaN`), so clearing it re-committed `0`.
- **Span-gaps:** the editor stored/sent seconds and lacked the Never/Threshold UX and validation present in V1.

#### Fix Strategy
- Resolve the switcher's signal via a shared helper that falls back to the kind's default signal for a new panel, while keeping `undefined` for PromQL/ClickHouse (so nothing is disabled there).
- Default `createPanelOps` to the **root (first)** section; still create an untitled section when the dashboard has none.
- Back the threshold input with a local string so it can be cleared/edited.
- Rebuild span-gaps as a "Disconnect values" toggle + duration input; store the duration string verbatim and parse to seconds only for rendering/validation; thread the query step interval through the config pane as the floor.

---

### 🧪 Testing Strategy

- **Tests added/updated:**
  - `getBuilderQueries` → `resolveSignal` unit tests (builder signal, new-panel fallback, PromQL → undefined).
  - `createPanelOps` root-section fallback cases.
  - `usePanelActionItems` "Move out of section" visibility + mutation.
  - `ThresholdValueField` clearable-input regression.
  - `ChartAppearanceSection` Never/Threshold toggle, duration storage, invalid + below-step-interval validation.
  - `resolveSpanGaps` duration-string parsing.
- **Manual verification:** `tsgo --noEmit` clean, `oxlint` clean, all affected Jest suites pass (63 tests across the touched areas).
- **Edge cases covered:** new vs saved panel datasource resolution; PromQL/ClickHouse (no disabling); empty/invalid/below-floor threshold input; dashboards with no sections.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** V2 dashboard panel editor only (config pane + span-gaps rendering). No backend changes.
- **Potential regressions:** span-gaps wire format changes from seconds to a duration string; `resolveSpanGaps` tolerates a bare seconds number for back-compat.
- **Rollback plan:** revert the relevant commit(s); each fix is isolated.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | V2 dashboard panel editor: type-switcher datasource compatibility, new-panel placement, move-panel-to-root, clearable thresholds, and a "Disconnect values" span-gaps control. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- **Stacked PR** — targets `feat/panel-editor-v2-type-switch` (#11820), not `main`. The diff is only the 7 commits above.
- Commits are split one-per-fix for easy review.
- `frontend/src/hooks/useIsDashboardV2.ts` (a local `return true` force-enable hack) is intentionally **not** included.