### PR TITLE
feat(dashboards-v2): create alerts from a dashboard panel

### DIFF
--- a/frontend/src/hooks/queryBuilder/useCreateAlerts.tsx
+++ b/frontend/src/hooks/queryBuilder/useCreateAlerts.tsx
@@ -24,6 +24,11 @@ import { GlobalReducer } from 'types/reducer/globalTime';
 import { withBasePath } from 'utils/basePath';
 import { getGraphType } from 'utils/getGraphType';
 
+/**
+ * @deprecated V1-only. V2 dashboards seed alerts from a panel via
+ * `useCreateAlertFromPanel` / `buildCreateAlertUrl`
+ * (pages/DashboardPageV2/.../Panel). Do not use in new code.
+ */
 const useCreateAlerts = (widget?: Widgets, caller?: string): VoidFunction => {
 	const queryRangeMutation = useMutation(getSubstituteVars);
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigActions/ConfigActionRow.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigActions/ConfigActionRow.tsx
@@ -1,0 +1,43 @@
+import { SquareArrowOutUpRight } from '@signozhq/icons';
+import { Button } from '@signozhq/ui/button';
+import { Typography } from '@signozhq/ui/typography';
+import type { ReactNode } from 'react';
+
+import styles from './ConfigActions.module.scss';
+
+interface ConfigActionRowProps {
+	/** Leading glyph for the action. */
+	icon: ReactNode;
+	label: string;
+	onClick: () => void;
+	testId?: string;
+}
+
+/**
+ * One row in the config pane's "Actions" list — a cross-page navigation link
+ * (leading icon, label, trailing external-link affordance). The whole row is the
+ * click target.
+ */
+function ConfigActionRow({
+	icon,
+	label,
+	onClick,
+	testId,
+}: ConfigActionRowProps): JSX.Element {
+	return (
+		<Button
+			type="button"
+			variant="outlined"
+			color="secondary"
+			className={styles.row}
+			data-testid={testId}
+			onClick={onClick}
+			prefix={<span className={styles.icon}>{icon}</span>}
+			suffix={<SquareArrowOutUpRight size={14} />}
+		>
+			<Typography.Text className={styles.label}>{label}</Typography.Text>
+		</Button>
+	);
+}
+
+export default ConfigActionRow;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigActions/ConfigActions.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigActions/ConfigActions.module.scss
@@ -1,0 +1,57 @@
+/* The "Actions" group: a list of cross-page navigation links, visually separated
+   from the collapsible config sections above by the same hairline divider. */
+.divider {
+	height: 1px;
+	background: var(--l2-border);
+	margin: 18px 0;
+}
+
+.container {
+	padding: 0 16px;
+}
+
+.eyebrow {
+	display: block;
+	margin: 0 2px 10px;
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--l1-foreground);
+}
+
+.list {
+	display: flex;
+	flex-direction: column;
+}
+
+/* A navigation-link row: leading icon, label, trailing external-link affordance. */
+.row {
+	display: flex;
+	align-items: center;
+	gap: 11px;
+	width: 100%;
+	height: 44px;
+	padding: 0 4px;
+	border: none;
+	background: transparent;
+	cursor: pointer;
+	color: var(--text-vanilla-100);
+	border-radius: 4px;
+
+	&:hover {
+		background: color-mix(in srgb, var(--bg-vanilla-100) 6%, transparent);
+	}
+}
+
+.icon {
+	display: grid;
+	place-items: center;
+	flex: none;
+	color: var(--l2-foreground);
+}
+
+.label {
+	flex: 1;
+	text-align: left;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigActions/ConfigActions.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigActions/ConfigActions.tsx
@@ -1,0 +1,51 @@
+import { Bell } from '@signozhq/icons';
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import { getPanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/registry';
+import { useCreateAlertFromPanel } from 'pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useCreateAlertFromPanel';
+
+import ConfigActionRow from './ConfigActionRow';
+import styles from './ConfigActions.module.scss';
+
+interface ConfigActionsProps {
+	/** The draft panel — its current query seeds the actions (e.g. Create alert). */
+	panel: DashboardtypesPanelDTO;
+	panelId: string;
+}
+
+/**
+ * The "Actions" group at the foot of the config pane: cross-page navigation links,
+ * kept distinct from the collapsible config sections above. Each link is gated by the
+ * panel kind's capabilities; the whole group hides when none apply.
+ */
+function ConfigActions({
+	panel,
+	panelId,
+}: ConfigActionsProps): JSX.Element | null {
+	const createAlert = useCreateAlertFromPanel();
+	const { actions } = getPanelDefinition(panel.spec.plugin.kind);
+
+	// Only kinds whose query can seed an alert offer this today; mirror the panel
+	// menu's create-alert capability.
+	if (!actions.createAlert) {
+		return null;
+	}
+
+	return (
+		<>
+			<div className={styles.divider} />
+			<div className={styles.container}>
+				<span className={styles.eyebrow}>Actions</span>
+				<div className={styles.list}>
+					<ConfigActionRow
+						testId="panel-editor-v2-create-alert"
+						icon={<Bell size={14} />}
+						label="Create alert"
+						onClick={(): void => createAlert(panel, panelId)}
+					/>
+				</div>
+			</div>
+		</>
+	);
+}
+
+export default ConfigActions;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigActions/__tests__/ConfigActions.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigActions/__tests__/ConfigActions.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+
+import ConfigActions from '../ConfigActions';
+
+const mockCreateAlert = jest.fn();
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useCreateAlertFromPanel',
+	() => ({
+		useCreateAlertFromPanel: jest.fn(() => mockCreateAlert),
+	}),
+);
+
+function makePanel(kind: string): DashboardtypesPanelDTO {
+	return {
+		kind: 'Panel',
+		spec: {
+			display: { name: 'CPU' },
+			plugin: { kind, spec: {} },
+			queries: [],
+		},
+	} as unknown as DashboardtypesPanelDTO;
+}
+
+describe('ConfigActions', () => {
+	beforeEach(() => jest.clearAllMocks());
+
+	it('offers "Create alert rule" for a create-alert-capable kind and seeds from the panel', async () => {
+		const user = userEvent.setup();
+		const panel = makePanel('signoz/TimeSeriesPanel');
+		render(<ConfigActions panel={panel} panelId="panel-1" />);
+
+		const row = screen.getByTestId('panel-editor-v2-create-alert');
+		expect(row).toHaveTextContent('Create alert');
+
+		await user.click(row);
+		expect(mockCreateAlert).toHaveBeenCalledWith(panel, 'panel-1');
+	});
+
+	it('renders nothing for a kind that cannot seed an alert', () => {
+		const { container } = render(
+			<ConfigActions panel={makePanel('signoz/TablePanel')} panelId="panel-1" />,
+		);
+
+		expect(
+			screen.queryByTestId('panel-editor-v2-create-alert'),
+		).not.toBeInTheDocument();
+		expect(container).toBeEmptyDOMElement();
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.tsx
@@ -1,20 +1,22 @@
 import { Input } from 'antd';
 import { Typography } from '@signozhq/ui/typography';
-import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
+import type {
+	DashboardtypesPanelDTO,
+	DashboardtypesPanelSpecDTO,
+} from 'api/generated/services/sigNoz.schemas';
 import { getPanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/registry';
 import { resolveSignal } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries';
 import type { EQueryType } from 'types/common/dashboard';
 
 import type { LegendSeries } from '../hooks/useLegendSeries';
 import type { TableColumnOption } from '../hooks/useTableColumns';
+import ConfigActions from './ConfigActions/ConfigActions';
 import SectionSlot from './SectionSlot/SectionSlot';
 
 import styles from './ConfigPane.module.scss';
 import { PanelKind } from '../../Panels/types/panelKind';
 
 interface ConfigPaneProps {
-	/** Full plugin kind (e.g. `signoz/TimeSeriesPanel`); drives which sections show. */
-	panelKind: PanelKind;
 	/** The panel spec — the single editing surface (title/description + section slices). */
 	spec: DashboardtypesPanelSpecDTO;
 	onChangeSpec: (next: DashboardtypesPanelSpecDTO) => void;
@@ -32,6 +34,12 @@ interface ConfigPaneProps {
 	tableColumns: TableColumnOption[];
 	/** Query step interval (seconds), for the chart-appearance span-gaps floor. */
 	stepInterval?: number;
+	/**
+	 * The draft panel and its id — the "Actions" group seeds cross-page links
+	 * (Create alert) from the current query.
+	 */
+	panel: DashboardtypesPanelDTO;
+	panelId: string;
 }
 
 /**
@@ -41,7 +49,6 @@ interface ConfigPaneProps {
  * generically via the section registry — only sections with a built editor appear.
  */
 function ConfigPane({
-	panelKind,
 	spec,
 	onChangeSpec,
 	onChangePanelKind,
@@ -49,7 +56,10 @@ function ConfigPane({
 	legendSeries,
 	tableColumns,
 	stepInterval,
+	panel,
+	panelId,
 }: ConfigPaneProps): JSX.Element {
+	const panelKind = spec.plugin.kind;
 	const definition = getPanelDefinition(panelKind);
 	const sections = definition.sections;
 
@@ -114,6 +124,8 @@ function ConfigPane({
 					</div>
 				</>
 			)}
+
+			<ConfigActions panel={panel} panelId={panelId} />
 		</div>
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/__tests__/ConfigPane.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/__tests__/ConfigPane.test.tsx
@@ -1,8 +1,19 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
+import type {
+	DashboardtypesPanelDTO,
+	DashboardtypesPanelSpecDTO,
+} from 'api/generated/services/sigNoz.schemas';
 import { EQueryType } from 'types/common/dashboard';
 
 import ConfigPane from '../ConfigPane';
+
+// The Actions group's hook navigates/logs; stub it so ConfigPane renders without a router.
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useCreateAlertFromPanel',
+	() => ({
+		useCreateAlertFromPanel: (): jest.Mock => jest.fn(),
+	}),
+);
 
 function spec(unit?: string): DashboardtypesPanelSpecDTO {
 	return {
@@ -19,13 +30,14 @@ function renderConfigPane(
 	overrides: Partial<React.ComponentProps<typeof ConfigPane>> = {},
 ): React.ComponentProps<typeof ConfigPane> {
 	const props: React.ComponentProps<typeof ConfigPane> = {
-		panelKind: 'signoz/TimeSeriesPanel',
 		spec: spec(),
 		onChangeSpec: jest.fn(),
 		onChangePanelKind: jest.fn(),
 		queryType: EQueryType.QUERY_BUILDER,
 		legendSeries: [],
 		tableColumns: [],
+		panel: { kind: 'Panel', spec: spec() } as DashboardtypesPanelDTO,
+		panelId: 'panel-1',
 		...overrides,
 	};
 	render(<ConfigPane {...props} />);
@@ -62,5 +74,29 @@ describe('ConfigPane', () => {
 		expect(
 			screen.getByTestId('config-section-formatting-&-units'),
 		).toBeInTheDocument();
+	});
+
+	it('renders the Actions group for a create-alert-capable panel', () => {
+		// renderConfigPane defaults to a TimeSeries panel, which can seed an alert.
+		renderConfigPane();
+
+		expect(screen.getByText('Actions')).toBeInTheDocument();
+		expect(
+			screen.getByTestId('panel-editor-v2-create-alert'),
+		).toBeInTheDocument();
+	});
+
+	it('omits the create-alert action for a kind that cannot seed an alert', () => {
+		// Table panels can't seed alerts → the Actions group hides its row. Only the
+		// panel passed to ConfigActions needs the kind; sections are asserted elsewhere.
+		const panel = {
+			kind: 'Panel',
+			spec: { ...spec(), plugin: { kind: 'signoz/TablePanel', spec: {} } },
+		} as DashboardtypesPanelDTO;
+		renderConfigPane({ panel });
+
+		expect(
+			screen.queryByTestId('panel-editor-v2-create-alert'),
+		).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/PreviewPane/PreviewPane.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/PreviewPane/PreviewPane.tsx
@@ -71,10 +71,8 @@ function PreviewPane({
 			<div className={styles.container}>
 				<div className={styles.surface}>
 					<PanelHeader
-						name={panel.spec.display.name}
-						description={panel.spec.display.description}
 						panelId={panelId}
-						panelKind={panel.spec.plugin.kind}
+						panel={panel}
 						isFetching={isFetching}
 						error={error}
 						warning={data.response?.data?.warning}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
@@ -242,7 +242,8 @@ function PanelEditorContainer({
 					className={styles.right}
 				>
 					<ConfigPane
-						panelKind={draft.spec.plugin.kind}
+						panel={draft}
+						panelId={panelId}
 						spec={spec}
 						onChangeSpec={setSpec}
 						onChangePanelKind={onChangePanelKind}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/Panel.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/Panel.tsx
@@ -41,10 +41,6 @@ function Panel({
 	isVisible,
 	panelActions,
 }: PanelProps): JSX.Element {
-	const name = panel.spec.display.name;
-	const description = panel.spec.display?.description;
-	const fullKind = panel.spec.plugin.kind;
-
 	// A per-panel time preference is surfaced as a header pill. `visualization` is
 	// common to every plugin-spec variant — localized cast reads it without
 	// narrowing on kind.
@@ -55,7 +51,8 @@ function Panel({
 	)?.visualization?.timePreference;
 	const timeLabel = panelTimePreferenceLabel(timePreference);
 
-	const panelDefinition = getPanelDefinition(fullKind);
+	const panelKind = panel.spec.plugin.kind;
+	const panelDefinition = getPanelDefinition(panelKind);
 
 	// Header search: only kinds that declare it render the box. The term is owned
 	// here and threaded to both the header (input) and renderer (filter).
@@ -77,10 +74,8 @@ function Panel({
 			data-panel-visible={isVisible ? 'true' : 'false'}
 		>
 			<PanelHeader
-				name={name}
-				description={description}
 				panelId={panelId}
-				panelKind={fullKind}
+				panel={panel}
 				isFetching={isFetching}
 				error={error}
 				warning={data.response?.data?.warning}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/PanelActionsMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/PanelActionsMenu.tsx
@@ -1,17 +1,17 @@
 import { EllipsisVertical } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
 import { DropdownMenuSimple } from '@signozhq/ui/dropdown-menu';
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
 
 import ConfirmDeleteDialog from '../../../components/ConfirmDeleteDialog/ConfirmDeleteDialog';
 import type { PanelActionsConfig } from '../Panel';
 import { usePanelActionItems } from './usePanelActionItems';
 import styles from './PanelActionsMenu.module.scss';
-import { PanelKind } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 
 interface PanelActionsMenuProps {
 	panelId: string;
-	/** Full plugin kind (e.g. `signoz/TimeSeriesPanel`);*/
-	panelKind: PanelKind;
+	/** The panel itself — its query seeds "Create Alerts". */
+	panel: DashboardtypesPanelDTO;
 	/** Layout context for move/delete — absent outside editable sectioned mode. */
 	panelActions?: PanelActionsConfig;
 }
@@ -23,12 +23,12 @@ interface PanelActionsMenuProps {
  */
 function PanelActionsMenu({
 	panelId,
-	panelKind,
+	panel,
 	panelActions,
 }: PanelActionsMenuProps): JSX.Element | null {
 	const { items, deleteConfirm } = usePanelActionItems({
 		panelId,
-		panelKind,
+		panel,
 		panelActions,
 	});
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/__tests__/usePanelActionItems.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/__tests__/usePanelActionItems.test.tsx
@@ -1,10 +1,10 @@
 import { act, renderHook } from '@testing-library/react';
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
 import type { ROLES } from 'types/roles';
 
 import type { DashboardSection } from '../../../../utils';
 import { useDashboardStore } from '../../../../store/useDashboardStore';
 import { usePanelActionItems } from '../usePanelActionItems';
-import { PanelKind } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 
 const mockOpenEditor = jest.fn();
 jest.mock(
@@ -27,6 +27,11 @@ jest.mock('../../hooks/useDeletePanel', () => ({
 const mockClonePanel = jest.fn();
 jest.mock('../../hooks/useClonePanel', () => ({
 	useClonePanel: (): jest.Mock => mockClonePanel,
+}));
+
+const mockCreateAlert = jest.fn();
+jest.mock('../../hooks/useCreateAlertFromPanel', () => ({
+	useCreateAlertFromPanel: (): jest.Mock => mockCreateAlert,
 }));
 
 // Role is the only thing read off the app context; useComponentPermission runs
@@ -55,9 +60,20 @@ const TWO_TITLED_SECTIONS = [section(0, 'Overview'), section(1, 'Latency')];
 // Index 0 is the untitled root (free-flow) section; index 1 is a titled section.
 const TITLED_WITH_ROOT = [section(0, undefined), section(1, 'Latency')];
 
+// Minimal panel — only its presence gates "Create Alerts"; the query→URL
+// translation it drives is covered by buildCreateAlertUrl's own tests.
+const mockPanel = {
+	kind: 'Panel',
+	spec: {
+		display: { name: 'CPU' },
+		plugin: { kind: 'signoz/TimeSeriesPanel', spec: {} },
+		queries: [],
+	},
+} as unknown as DashboardtypesPanelDTO;
+
 const baseArgs = {
 	panelId: 'panel-1',
-	panelKind: 'signoz/TimeSeriesPanel' as PanelKind,
+	panel: mockPanel,
 	panelActions: { currentLayoutIndex: 0, sections: TWO_TITLED_SECTIONS },
 };
 
@@ -115,29 +131,18 @@ describe('usePanelActionItems', () => {
 		]);
 	});
 
-	it('unknown panel kind hides all kind-gated actions (incl. clone), keeping only move/delete', () => {
-		const { result } = renderHook(() =>
-			// A kind with no registered definition — exercises the "unsupported kind"
-			// branch. Clone is kind-gated (needs the kind to declare actions.clone),
-			// so it drops too; only the kind-agnostic layout actions remain.
-			usePanelActionItems({
-				...baseArgs,
-				panelKind: 'signoz/UnsupportedPanel' as PanelKind,
-			}),
-		);
-		expect(itemKeys(result.current)).toStrictEqual([
-			'move',
-			'divider',
-			'delete-panel',
-		]);
-	});
-
-	it('read-only dashboard keeps only View (V1 parity)', () => {
+	it('read-only dashboard keeps View and Create Alerts (V1 parity: both survive a lock)', () => {
 		useDashboardStore.setState({ isEditable: false });
 		const { result } = renderHook(() =>
 			usePanelActionItems({ ...baseArgs, panelActions: undefined }),
 		);
-		expect(itemKeys(result.current)).toStrictEqual(['view-panel']);
+		// Create Alerts opens a new tab and never mutates the dashboard, so it
+		// isn't gated on edit access — matching V1's locked-dashboard menu.
+		expect(itemKeys(result.current)).toStrictEqual([
+			'view-panel',
+			'divider',
+			'create-alert',
+		]);
 	});
 
 	it('move is disabled when there is no other titled section to move to', () => {
@@ -259,18 +264,26 @@ describe('usePanelActionItems', () => {
 		});
 	});
 
-	it('not-yet-implemented actions (view/create-alert) fire the placeholder alert with the feature name', () => {
+	it('not-yet-implemented actions (view) fire the placeholder alert with the feature name', () => {
 		const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
 		const { result } = renderHook(() => usePanelActionItems(baseArgs));
 
-		['view-panel', 'create-alert'].forEach((key) => {
-			const item = result.current.items.find((i) => 'key' in i && i.key === key);
-			(item as { onClick: () => void }).onClick();
-		});
+		const view = result.current.items.find(
+			(i) => 'key' in i && i.key === 'view-panel',
+		);
+		(view as { onClick: () => void }).onClick();
 
-		expect(alertSpy).toHaveBeenCalledTimes(2);
+		expect(alertSpy).toHaveBeenCalledTimes(1);
 		expect(alertSpy).toHaveBeenCalledWith('View option clicked');
-		expect(alertSpy).toHaveBeenCalledWith('Create Alerts option clicked');
 		alertSpy.mockRestore();
+	});
+
+	it('create-alert seeds an alert from this panel', () => {
+		const { result } = renderHook(() => usePanelActionItems(baseArgs));
+		const createAlert = result.current.items.find(
+			(i) => 'key' in i && i.key === 'create-alert',
+		);
+		(createAlert as { onClick: () => void }).onClick();
+		expect(mockCreateAlert).toHaveBeenCalledWith(mockPanel, 'panel-1');
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/usePanelActionItems.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/usePanelActionItems.tsx
@@ -154,7 +154,7 @@ export function usePanelActionItems({
 	const deletePanel = useDeletePanel({ sections });
 	const clonePanel = useClonePanel({ sections });
 
-	const kindActions = getPanelDefinition(panelKind).actions;
+	const panelCapabilities = getPanelDefinition(panelKind).actions;
 
 	// Delete runs on confirm, not on click — the menu item opens a prompt.
 	const deleteConfirm = useConfirmableAction(
@@ -173,7 +173,7 @@ export function usePanelActionItems({
 
 	const items = useMemo<MenuItem[]>(() => {
 		const panelGroup: MenuItem[] = [];
-		if (kindActions.view) {
+		if (panelCapabilities.view) {
 			panelGroup.push({
 				key: 'view-panel',
 				label: 'View',
@@ -181,7 +181,7 @@ export function usePanelActionItems({
 				onClick: (): void => notImplementedYet('View'),
 			});
 		}
-		if (isEditable && canEditWidget && kindActions.edit) {
+		if (isEditable && canEditWidget && panelCapabilities.edit) {
 			panelGroup.push({
 				key: 'edit-panel',
 				label: 'Edit panel',
@@ -191,7 +191,7 @@ export function usePanelActionItems({
 		}
 		// Clone needs the section context (source spec + dimensions) to place the
 		// copy, so — unlike Edit — it requires panelActions.
-		if (isEditable && canEditWidget && panelActions && kindActions.clone) {
+		if (isEditable && canEditWidget && panelActions && panelCapabilities.clone) {
 			panelGroup.push({
 				key: 'clone-panel',
 				label: 'Clone',
@@ -205,7 +205,7 @@ export function usePanelActionItems({
 		}
 
 		const dataGroup: MenuItem[] = [];
-		if (kindActions.download) {
+		if (panelCapabilities.download) {
 			dataGroup.push({
 				key: 'download-panel',
 				label: 'Download as CSV',
@@ -216,7 +216,7 @@ export function usePanelActionItems({
 		// Seeding an alert opens a new tab and never mutates the dashboard, so —
 		// unlike edit/clone — it isn't gated on `isEditable` (V1 parity: available
 		// on locked dashboards too).
-		if (kindActions.createAlert) {
+		if (panelCapabilities.createAlert) {
 			dataGroup.push({
 				key: 'create-alert',
 				label: 'Create Alerts',
@@ -258,7 +258,7 @@ export function usePanelActionItems({
 		canEditWidget,
 		canMove,
 		canDelete,
-		kindActions,
+		panelCapabilities,
 		panel,
 		panelActions,
 		sections,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/usePanelActionItems.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/usePanelActionItems.tsx
@@ -10,6 +10,7 @@ import {
 	Trash2,
 } from '@signozhq/icons';
 import type { MenuItem } from '@signozhq/ui/dropdown-menu';
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
 import useComponentPermission from 'hooks/useComponentPermission';
 import {
 	type ConfirmableAction,
@@ -23,13 +24,13 @@ import { useAppContext } from 'providers/App/App';
 import type { DashboardSection } from '../../../utils';
 import type { PanelActionsConfig } from '../Panel';
 import { useClonePanel } from '../hooks/useClonePanel';
+import { useCreateAlertFromPanel } from '../hooks/useCreateAlertFromPanel';
 import { useDeletePanel } from '../hooks/useDeletePanel';
 import {
 	type MovePanelArgs,
 	useMovePanelToSection,
 } from '../hooks/useMovePanelToSection';
 import { PANEL_ACTION_META } from './panelActionMeta';
-import { PanelKind } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 
 // Stable fallback so renders without layout context don't churn the mutation
 // hooks' deps (a fresh [] each render would re-create their callbacks).
@@ -103,8 +104,8 @@ function buildMoveItems({
 
 interface UsePanelActionItemsArgs {
 	panelId: string;
-	/** Full plugin kind (e.g. `signoz/TimeSeriesPanel`); */
-	panelKind: PanelKind;
+	/** The panel itself — its query seeds the "Create Alerts" action. */
+	panel: DashboardtypesPanelDTO;
 	/** Layout context for move/delete — absent outside editable mode. */
 	panelActions?: PanelActionsConfig;
 }
@@ -128,9 +129,10 @@ export interface PanelActionItems {
  */
 export function usePanelActionItems({
 	panelId,
-	panelKind,
+	panel,
 	panelActions,
 }: UsePanelActionItemsArgs): PanelActionItems {
+	const panelKind = panel.spec.plugin.kind;
 	const { user } = useAppContext();
 	const [canEditWidget, canMove, canDelete] = useComponentPermission(
 		[
@@ -143,6 +145,7 @@ export function usePanelActionItems({
 	);
 	const isEditable = useDashboardStore((s) => s.isEditable);
 	const openPanelEditor = useOpenPanelEditor();
+	const createAlert = useCreateAlertFromPanel();
 
 	// Mutations are store-backed (dashboardId/refetch) — the layout tree only
 	// supplies data (`sections`), so no callbacks are threaded through it.
@@ -151,7 +154,7 @@ export function usePanelActionItems({
 	const deletePanel = useDeletePanel({ sections });
 	const clonePanel = useClonePanel({ sections });
 
-	const kindActions = getPanelDefinition(panelKind)?.actions;
+	const kindActions = getPanelDefinition(panelKind).actions;
 
 	// Delete runs on confirm, not on click — the menu item opens a prompt.
 	const deleteConfirm = useConfirmableAction(
@@ -170,7 +173,7 @@ export function usePanelActionItems({
 
 	const items = useMemo<MenuItem[]>(() => {
 		const panelGroup: MenuItem[] = [];
-		if (kindActions?.view) {
+		if (kindActions.view) {
 			panelGroup.push({
 				key: 'view-panel',
 				label: 'View',
@@ -178,7 +181,7 @@ export function usePanelActionItems({
 				onClick: (): void => notImplementedYet('View'),
 			});
 		}
-		if (isEditable && canEditWidget && kindActions?.edit) {
+		if (isEditable && canEditWidget && kindActions.edit) {
 			panelGroup.push({
 				key: 'edit-panel',
 				label: 'Edit panel',
@@ -188,7 +191,7 @@ export function usePanelActionItems({
 		}
 		// Clone needs the section context (source spec + dimensions) to place the
 		// copy, so — unlike Edit — it requires panelActions.
-		if (isEditable && canEditWidget && panelActions && kindActions?.clone) {
+		if (isEditable && canEditWidget && panelActions && kindActions.clone) {
 			panelGroup.push({
 				key: 'clone-panel',
 				label: 'Clone',
@@ -202,7 +205,7 @@ export function usePanelActionItems({
 		}
 
 		const dataGroup: MenuItem[] = [];
-		if (kindActions?.download) {
+		if (kindActions.download) {
 			dataGroup.push({
 				key: 'download-panel',
 				label: 'Download as CSV',
@@ -210,12 +213,15 @@ export function usePanelActionItems({
 				onClick: (): void => notImplementedYet('Download'),
 			});
 		}
-		if (isEditable && kindActions?.createAlert) {
+		// Seeding an alert opens a new tab and never mutates the dashboard, so —
+		// unlike edit/clone — it isn't gated on `isEditable` (V1 parity: available
+		// on locked dashboards too).
+		if (kindActions.createAlert) {
 			dataGroup.push({
 				key: 'create-alert',
 				label: 'Create Alerts',
 				icon: <Bell size={14} />,
-				onClick: (): void => notImplementedYet('Create Alerts'),
+				onClick: (): void => createAlert(panel, panelId),
 			});
 		}
 
@@ -253,10 +259,12 @@ export function usePanelActionItems({
 		canMove,
 		canDelete,
 		kindActions,
+		panel,
 		panelActions,
 		sections,
 		panelId,
 		openPanelEditor,
+		createAlert,
 		movePanel,
 		clonePanel,
 		requestDelete,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelHeader/PanelHeader.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelHeader/PanelHeader.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from 'react';
 import { Info, Loader } from '@signozhq/icons';
 import { Typography } from '@signozhq/ui/typography';
-import type { Querybuildertypesv5QueryWarnDataDTO as WarningDTO } from 'api/generated/services/sigNoz.schemas';
+import type {
+	DashboardtypesPanelDTO,
+	Querybuildertypesv5QueryWarnDataDTO as WarningDTO,
+} from 'api/generated/services/sigNoz.schemas';
 import cx from 'classnames';
 import type { PanelTimePreferenceLabel } from 'pages/DashboardPageV2/DashboardContainer/hooks/resolvePanelTimeWindow';
 
@@ -14,15 +17,12 @@ import {
 	panelStatusFromWarning,
 } from '../PanelStatus/utils';
 import styles from './PanelHeader.module.scss';
-import { PanelKind } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import { TooltipSimple } from '@signozhq/ui/tooltip';
 
 interface PanelHeaderProps {
-	name: string;
-	description?: string;
 	panelId: string;
-	/** Full plugin kind — drives kind-gated menu actions. */
-	panelKind: PanelKind;
+	/** The panel itself — its query seeds the menu's "Create Alerts" action. */
+	panel: DashboardtypesPanelDTO;
 	/** Background refresh in flight — shows a spinner without blinking the chart. */
 	isFetching: boolean;
 	/** Latest query error — surfaced as a header error indicator. */
@@ -49,10 +49,8 @@ interface PanelHeaderProps {
 
 /** Panel chrome: drag handle, title, refetch + status indicators, actions. */
 function PanelHeader({
-	name,
-	description,
 	panelId,
-	panelKind,
+	panel,
 	isFetching,
 	error,
 	warning,
@@ -63,6 +61,8 @@ function PanelHeader({
 	onSearchChange,
 	hideActions,
 }: PanelHeaderProps): JSX.Element {
+	const name = panel.spec.display.name;
+	const description = panel.spec.display.description;
 	const errorDetail = useMemo(() => panelStatusFromError(error), [error]);
 
 	const warningDetail = useMemo(
@@ -116,7 +116,7 @@ function PanelHeader({
 				{!hideActions && (
 					<PanelActionsMenu
 						panelId={panelId}
-						panelKind={panelKind}
+						panel={panel}
 						panelActions={panelActions}
 					/>
 				)}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/PanelHeader.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/PanelHeader.test.tsx
@@ -1,11 +1,11 @@
 import { TooltipProvider } from '@signozhq/ui/tooltip';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
 import type { ReactElement } from 'react';
 import type { Warning } from 'types/api';
 
 import PanelHeader from '../PanelHeader/PanelHeader';
-import { PanelKind } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 
 // Status indicators use a radix tooltip, which needs a TooltipProvider ancestor
 // (supplied globally by AppLayout at runtime).
@@ -22,9 +22,26 @@ jest.mock(
 		},
 );
 
+// The header reads its name/description/kind off the panel itself.
+function makePanel(overrides?: {
+	name?: string;
+	description?: string;
+}): DashboardtypesPanelDTO {
+	return {
+		kind: 'Panel',
+		spec: {
+			display: {
+				name: overrides?.name ?? 'My panel',
+				description: overrides?.description,
+			},
+			plugin: { kind: 'signoz/TimeSeriesPanel', spec: {} },
+			queries: [],
+		},
+	} as unknown as DashboardtypesPanelDTO;
+}
+
 const baseProps = {
-	name: 'My panel',
-	panelKind: 'signoz/TimeSeriesPanel' as PanelKind,
+	panel: makePanel(),
 	panelId: 'panel-1',
 	isFetching: false,
 };
@@ -44,7 +61,10 @@ describe('PanelHeader title and description', () => {
 
 	it('shows the description info icon when a description is provided', () => {
 		renderWithProvider(
-			<PanelHeader {...baseProps} description="What this panel measures" />,
+			<PanelHeader
+				{...baseProps}
+				panel={makePanel({ description: 'What this panel measures' })}
+			/>,
 		);
 		expect(screen.getByTestId('panel-header-info-icon')).toBeInTheDocument();
 	});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useCreateAlertFromPanel.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useCreateAlertFromPanel.test.ts
@@ -1,0 +1,69 @@
+import { renderHook } from '@testing-library/react';
+import logEvent from 'api/common/logEvent';
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { useDashboardStore } from 'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore';
+
+import { useCreateAlertFromPanel } from '../useCreateAlertFromPanel';
+
+jest.mock('api/common/logEvent', () => ({
+	__esModule: true,
+	default: jest.fn(),
+}));
+
+const mockSafeNavigate = jest.fn();
+jest.mock('hooks/useSafeNavigate', () => ({
+	useSafeNavigate: (): { safeNavigate: jest.Mock } => ({
+		safeNavigate: mockSafeNavigate,
+	}),
+}));
+
+// The V5→V1 query→URL translation is covered by buildCreateAlertUrl's own tests;
+// stub it so this asserts only the hook's side effects (analytics + navigation).
+jest.mock('../../utils/buildCreateAlertUrl', () => ({
+	buildCreateAlertUrl: (): string => '/alerts/new?composite=1',
+}));
+
+const mockLogEvent = logEvent as jest.Mock;
+
+const panel = {
+	kind: 'Panel',
+	spec: {
+		display: { name: 'CPU' },
+		plugin: { kind: 'signoz/TimeSeriesPanel', spec: {} },
+		queries: [],
+	},
+} as unknown as DashboardtypesPanelDTO;
+
+describe('useCreateAlertFromPanel', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		useDashboardStore.setState({ dashboardId: 'dash-1' });
+	});
+
+	it('opens the seeded alert builder in a new tab', () => {
+		const { result } = renderHook(() => useCreateAlertFromPanel());
+
+		result.current(panel, 'panel-1');
+
+		expect(mockSafeNavigate).toHaveBeenCalledWith('/alerts/new?composite=1', {
+			newTab: true,
+		});
+	});
+
+	it('logs the create-alert action with panel and dashboard context (V1 parity)', () => {
+		const { result } = renderHook(() => useCreateAlertFromPanel());
+
+		result.current(panel, 'panel-1');
+
+		expect(mockLogEvent).toHaveBeenCalledWith(
+			'Dashboard Detail: Panel action',
+			expect.objectContaining({
+				action: 'createAlerts',
+				panelType: PANEL_TYPES.TIME_SERIES,
+				dashboardId: 'dash-1',
+				widgetId: 'panel-1',
+			}),
+		);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useCreateAlertFromPanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useCreateAlertFromPanel.ts
@@ -1,0 +1,37 @@
+import { useCallback } from 'react';
+import logEvent from 'api/common/logEvent';
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import { useSafeNavigate } from 'hooks/useSafeNavigate';
+import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
+import { getPanelQueryType } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getPanelQueryType';
+import { useDashboardStore } from 'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore';
+
+import { buildCreateAlertUrl } from '../utils/buildCreateAlertUrl';
+
+/**
+ * Returns a callback that opens the alert builder in a new tab, seeded from a
+ * panel's query, and logs the action — mirroring V1's `useCreateAlerts`
+ * ('dashboardView' caller). The panel is supplied at call time so the callback
+ * stays stable across panels (and the dashboard's react-query refetches).
+ */
+export function useCreateAlertFromPanel(): (
+	panel: DashboardtypesPanelDTO,
+	panelId: string,
+) => void {
+	const { safeNavigate } = useSafeNavigate();
+	const dashboardId = useDashboardStore((s) => s.dashboardId);
+
+	return useCallback(
+		(panel: DashboardtypesPanelDTO, panelId: string): void => {
+			void logEvent('Dashboard Detail: Panel action', {
+				action: 'createAlerts',
+				panelType: PANEL_KIND_TO_PANEL_TYPE[panel.spec.plugin.kind],
+				dashboardId,
+				widgetId: panelId,
+				queryType: getPanelQueryType(panel),
+			});
+			safeNavigate(buildCreateAlertUrl(panel), { newTab: true });
+		},
+		[dashboardId, safeNavigate],
+	);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/__tests__/buildCreateAlertUrl.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/__tests__/buildCreateAlertUrl.test.ts
@@ -1,0 +1,103 @@
+import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import { ENTITY_VERSION_V5 } from 'constants/app';
+import { QueryParams } from 'constants/query';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import ROUTES from 'constants/routes';
+import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
+import type { Query } from 'types/api/queryBuilder/queryBuilderData';
+import { EQueryType } from 'types/common/dashboard';
+
+import { buildCreateAlertUrl } from '../buildCreateAlertUrl';
+
+// The V5→V1 translation has its own coverage; stub it so this asserts only the
+// URL assembly (params, encoding, unit) buildCreateAlertUrl owns.
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters',
+	() => ({
+		fromPerses: jest.fn(),
+	}),
+);
+
+const mockFromPerses = fromPerses as jest.Mock;
+
+const translatedQuery: Query = {
+	queryType: EQueryType.QUERY_BUILDER,
+	promql: [],
+	clickhouse_sql: [],
+	builder: { queryData: [], queryFormulas: [], queryTraceOperator: [] },
+	id: 'q1',
+};
+
+function makePanel(
+	overrides?: Partial<{ unit: string; queries: unknown[] }>,
+): DashboardtypesPanelDTO {
+	return {
+		kind: 'Panel',
+		spec: {
+			display: { name: 'CPU' },
+			plugin: {
+				kind: 'signoz/TimeSeriesPanel',
+				spec: overrides?.unit ? { formatting: { unit: overrides.unit } } : {},
+			},
+			queries: overrides?.queries ?? [{ some: 'query' }],
+		},
+	} as unknown as DashboardtypesPanelDTO;
+}
+
+describe('buildCreateAlertUrl', () => {
+	beforeEach(() => {
+		mockFromPerses.mockReset();
+		mockFromPerses.mockReturnValue({ ...translatedQuery });
+	});
+
+	function parse(url: string): URLSearchParams {
+		expect(url.startsWith(`${ROUTES.ALERTS_NEW}?`)).toBe(true);
+		return new URLSearchParams(url.slice(url.indexOf('?') + 1));
+	}
+
+	it('translates the panel queries with the mapped panel type', () => {
+		const panel = makePanel();
+		buildCreateAlertUrl(panel);
+
+		expect(mockFromPerses).toHaveBeenCalledWith(
+			panel.spec.queries,
+			PANEL_TYPES.TIME_SERIES,
+		);
+	});
+
+	it('tags the URL with panel type, v5 version, and the dashboards source', () => {
+		const params = parse(buildCreateAlertUrl(makePanel()));
+
+		expect(params.get(QueryParams.panelTypes)).toBe(PANEL_TYPES.TIME_SERIES);
+		expect(params.get(QueryParams.version)).toBe(ENTITY_VERSION_V5);
+		expect(params.get(QueryParams.source)).toBe('dashboards');
+	});
+
+	it('encodes the translated query as the compositeQuery param', () => {
+		const params = parse(buildCreateAlertUrl(makePanel()));
+
+		const raw = params.get(QueryParams.compositeQuery);
+		expect(raw).toBeTruthy();
+		const decoded = JSON.parse(decodeURIComponent(raw as string));
+		expect(decoded.queryType).toBe(EQueryType.QUERY_BUILDER);
+		expect(decoded.id).toBe('q1');
+	});
+
+	it('carries the panel formatting unit onto the alert query when set', () => {
+		const params = parse(buildCreateAlertUrl(makePanel({ unit: 'bytes' })));
+
+		const decoded = JSON.parse(
+			decodeURIComponent(params.get(QueryParams.compositeQuery) as string),
+		);
+		expect(decoded.unit).toBe('bytes');
+	});
+
+	it('leaves the query unit unset when the panel has no formatting unit', () => {
+		const params = parse(buildCreateAlertUrl(makePanel()));
+
+		const decoded = JSON.parse(
+			decodeURIComponent(params.get(QueryParams.compositeQuery) as string),
+		);
+		expect(decoded.unit).toBeUndefined();
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildCreateAlertUrl.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildCreateAlertUrl.ts
@@ -9,6 +9,9 @@ import ROUTES from 'constants/routes';
 import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
 
+/** The `formatting` block shared by every formattable plugin spec, read without narrowing on kind. */
+type FormattablePluginSpec = { formatting?: DashboardtypesPanelFormattingDTO };
+
 /**
  * Builds the `/alerts/new` URL that seeds the alert builder from a panel's query,
  * mirroring V1's `useCreateAlerts`: the panel's V5 queries are translated to the
@@ -20,15 +23,12 @@ import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/per
  */
 export function buildCreateAlertUrl(panel: DashboardtypesPanelDTO): string {
 	const panelType = PANEL_KIND_TO_PANEL_TYPE[panel.spec.plugin.kind];
-	const query = fromPerses(panel.spec.queries ?? [], panelType);
+	const query = fromPerses(panel.spec.queries, panelType);
 
 	// `formatting.unit` is shared by the formattable plugin specs; read it with a
 	// localized cast rather than narrowing on kind (mirrors Panel's time-preference read).
-	const unit = (
-		panel.spec.plugin.spec as
-			| { formatting?: DashboardtypesPanelFormattingDTO }
-			| undefined
-	)?.formatting?.unit;
+	const unit = (panel.spec.plugin.spec as FormattablePluginSpec).formatting
+		?.unit;
 	if (unit) {
 		query.unit = unit;
 	}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildCreateAlertUrl.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildCreateAlertUrl.ts
@@ -1,6 +1,6 @@
 import type {
 	DashboardtypesPanelDTO,
-	DashboardtypesPanelFormattingDTO,
+	DashboardtypesPanelPluginDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { YAxisSource } from 'components/YAxisUnitSelector/types';
 import { ENTITY_VERSION_V5 } from 'constants/app';
@@ -9,8 +9,19 @@ import ROUTES from 'constants/routes';
 import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
 
-/** The `formatting` block shared by every formattable plugin spec, read without narrowing on kind. */
-type FormattablePluginSpec = { formatting?: DashboardtypesPanelFormattingDTO };
+function readPanelUnit(
+	plugin: DashboardtypesPanelPluginDTO,
+): string | undefined {
+	switch (plugin.kind) {
+		case 'signoz/TimeSeriesPanel':
+		case 'signoz/BarChartPanel':
+		case 'signoz/NumberPanel':
+		case 'signoz/PieChartPanel':
+			return plugin.spec.formatting?.unit;
+		default:
+			return undefined;
+	}
+}
 
 /**
  * Builds the `/alerts/new` URL that seeds the alert builder from a panel's query,
@@ -25,10 +36,7 @@ export function buildCreateAlertUrl(panel: DashboardtypesPanelDTO): string {
 	const panelType = PANEL_KIND_TO_PANEL_TYPE[panel.spec.plugin.kind];
 	const query = fromPerses(panel.spec.queries, panelType);
 
-	// `formatting.unit` is shared by the formattable plugin specs; read it with a
-	// localized cast rather than narrowing on kind (mirrors Panel's time-preference read).
-	const unit = (panel.spec.plugin.spec as FormattablePluginSpec).formatting
-		?.unit;
+	const unit = readPanelUnit(panel.spec.plugin);
 	if (unit) {
 		query.unit = unit;
 	}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildCreateAlertUrl.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/buildCreateAlertUrl.ts
@@ -1,0 +1,46 @@
+import type {
+	DashboardtypesPanelDTO,
+	DashboardtypesPanelFormattingDTO,
+} from 'api/generated/services/sigNoz.schemas';
+import { YAxisSource } from 'components/YAxisUnitSelector/types';
+import { ENTITY_VERSION_V5 } from 'constants/app';
+import { QueryParams } from 'constants/query';
+import ROUTES from 'constants/routes';
+import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
+import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
+
+/**
+ * Builds the `/alerts/new` URL that seeds the alert builder from a panel's query,
+ * mirroring V1's `useCreateAlerts`: the panel's V5 queries are translated to the
+ * V1 `Query` the alert page reads from `compositeQuery`, tagged with the panel
+ * type, entity version, and a `dashboards` source.
+ *
+ * Unlike V1 there is no `/substitute_vars` round-trip — V2 has no query-variable
+ * plumbing yet, so any dashboard-variable references travel through verbatim.
+ */
+export function buildCreateAlertUrl(panel: DashboardtypesPanelDTO): string {
+	const panelType = PANEL_KIND_TO_PANEL_TYPE[panel.spec.plugin.kind];
+	const query = fromPerses(panel.spec.queries ?? [], panelType);
+
+	// `formatting.unit` is shared by the formattable plugin specs; read it with a
+	// localized cast rather than narrowing on kind (mirrors Panel's time-preference read).
+	const unit = (
+		panel.spec.plugin.spec as
+			| { formatting?: DashboardtypesPanelFormattingDTO }
+			| undefined
+	)?.formatting?.unit;
+	if (unit) {
+		query.unit = unit;
+	}
+
+	const params = new URLSearchParams();
+	params.set(
+		QueryParams.compositeQuery,
+		encodeURIComponent(JSON.stringify(query)),
+	);
+	params.set(QueryParams.panelTypes, panelType);
+	params.set(QueryParams.version, ENTITY_VERSION_V5);
+	params.set(QueryParams.source, YAxisSource.DASHBOARDS);
+
+	return `${ROUTES.ALERTS_NEW}?${params.toString()}`;
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

Brings "Create alert" to V2 dashboard panels, matching V1. A panel's query is a natural starting point for an alert, so users should be able to jump from a panel straight into the alert builder with that query pre-loaded — without re-authoring it.

This adds the action on the two surfaces V1 has it:
- **Panel actions menu** ("Create Alerts") on the dashboard.
- **Panel editor config pane** — a new "Actions" group at the foot of the pane ("Create alert rule").

Both reuse one core: `buildCreateAlertUrl` translates the panel's V5 queries into the V1 `compositeQuery` the alert page reads (tagged with panel type, `version=v5`, `source=dashboards`), and `useCreateAlertFromPanel` opens `/alerts/new` in a new tab. The action is available regardless of edit access (V1 parity — Create Alerts works on locked dashboards too) and is gated by the per-kind `createAlert` capability (the single source of truth shared with the panel menu).

The editor "Actions" group is intentionally distinct from the collapsible config sections: config you edit in place above, cross-page navigation links below. It scales to more actions (e.g. "Open in Explorer") later.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change.

- Dashboard panel actions menu → **Create Alerts**
- Panel editor config pane → **Actions › Create alert rule**

_(UI-only addition; screenshots to be attached.)_

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.
Closes https://github.com/SigNoz/pulse-pod/issues/82

N/A — part of the V2 dashboard panel parity effort.

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

N/A — not a bug fix.

---

### 🧪 Testing Strategy
> How was this change validated?

- **Tests added/updated:**
  - `buildCreateAlertUrl` — URL params (`panelTypes`/`version`/`source`), compositeQuery encoding, unit carry-over.
  - `useCreateAlertFromPanel` — opens the seeded builder in a new tab; logs the action.
  - `usePanelActionItems` — Create Alerts gating across roles and a locked dashboard; seeds from the panel.
  - `PanelHeader` — updated for the panel-threading refactor.
  - `ConfigActions` / `ConfigPane` — Actions group renders for capable kinds and hides otherwise.
- **Manual verification:** `pnpm tsgo --noEmit`, `pnpm lint:js`, `pnpm build` all clean; full Panel + ConfigPane test suites green.
- **Edge cases covered:** kinds that can't seed an alert (Table/List/Pie) hide the action; read-only/locked dashboards still expose it.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** V2 dashboards only (`DashboardPageV2`). No V1 files changed.
- **Potential regressions:** the panel actions menu / header were refactored to thread the full `panel` (instead of just its kind); covered by updated unit tests. Note: with the panel now threaded, an unregistered panel kind would throw rather than degrade (kinds are always registered in practice).
- **Rollback plan:** revert the two commits; the feature is additive and gated, so removal is clean.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Create an alert directly from a V2 dashboard panel (actions menu) or the panel editor, with the panel's query pre-loaded. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- **Stacked PR:** based on `feat/dashboards-v2-panel-capability-guard`, not `main`. Review/merge that first; the diff here is only the two create-alert commits.
- **No dashboard-variable substitution yet:** unlike V1 (which resolves `$variables` via `/substitute_vars`), V2 has no query-variable plumbing, so variable references pass through verbatim. Documented in `buildCreateAlertUrl`'s doc comment; to be addressed when V2 grows variable support.
- **Histogram:** gated by the shared `createAlert` capability (so it shows the action), whereas V1's editor excluded Histogram. Kept V2 internally consistent (the menu and editor agree).
- **Analytics:** uses the dashboard `Dashboard Detail: Panel action` event for both surfaces; V1 used a separate `Panel Edit: Create alert` event in the editor — easy to re-add if desired.

