### PR TITLE
fix(frontend): default Traces Explorer to Trace View and root spans

### DIFF
--- a/frontend/src/container/TracesExplorer/QuerySection/index.tsx
+++ b/frontend/src/container/TracesExplorer/QuerySection/index.tsx
@@ -8,7 +8,7 @@ import { useGetPanelTypesQueryParam } from 'hooks/queryBuilder/useGetPanelTypesQ
 import { DataSource } from 'types/common/queryBuilder';
 
 function QuerySection(): JSX.Element {
-	const panelTypes = useGetPanelTypesQueryParam(PANEL_TYPES.LIST);
+	const panelTypes = useGetPanelTypesQueryParam(PANEL_TYPES.TRACE);
 
 	const filterConfigs: QueryBuilderProps['filterConfigs'] = useMemo(() => {
 		const isList = panelTypes === PANEL_TYPES.LIST;

--- a/frontend/src/container/TracesExplorer/explorerUtils.test.ts
+++ b/frontend/src/container/TracesExplorer/explorerUtils.test.ts
@@ -1,0 +1,31 @@
+import { initialQueriesMap } from 'constants/queryBuilder';
+import { cloneDeep } from 'lodash-es';
+
+import { withRootSpanFilter } from './explorerUtils';
+
+describe('withRootSpanFilter', () => {
+	it('adds isRoot=true filter to the default traces query', () => {
+		const query = withRootSpanFilter(cloneDeep(initialQueriesMap.traces));
+
+		expect(query.builder.queryData[0].filters?.items).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					key: expect.objectContaining({ key: 'isRoot' }),
+					op: '=',
+					value: 'true',
+				}),
+			]),
+		);
+	});
+
+	it('does not duplicate isRoot when already present', () => {
+		const query = withRootSpanFilter(cloneDeep(initialQueriesMap.traces));
+		const withDuplicate = withRootSpanFilter(cloneDeep(query));
+
+		const rootFilters = withDuplicate.builder.queryData[0].filters?.items.filter(
+			(filter) => filter.key?.key === 'isRoot',
+		);
+
+		expect(rootFilters).toHaveLength(1);
+	});
+});

--- a/frontend/src/container/TracesExplorer/explorerUtils.ts
+++ b/frontend/src/container/TracesExplorer/explorerUtils.ts
@@ -1,7 +1,47 @@
 import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
 import { OptionsQuery } from 'container/OptionsMenu/types';
 import { cloneDeep, set } from 'lodash-es';
-import { OrderByPayload, Query } from 'types/api/queryBuilder/queryBuilderData';
+import {
+	OrderByPayload,
+	Query,
+	TagFilterItem,
+} from 'types/api/queryBuilder/queryBuilderData';
+import { v4 as uuid } from 'uuid';
+
+export const createRootSpanFilterItem = (): TagFilterItem => ({
+	id: uuid().slice(0, 8),
+	key: {
+		key: 'isRoot',
+		dataType: undefined,
+		type: '',
+	},
+	op: '=',
+	value: 'true',
+});
+
+export const withRootSpanFilter = (query: Query): Query => {
+	const nextQuery = cloneDeep(query);
+	const queryData = nextQuery.builder?.queryData?.[0];
+
+	if (!queryData) {
+		return nextQuery;
+	}
+
+	if (!queryData.filters) {
+		queryData.filters = { items: [], op: 'AND' };
+	}
+
+	const hasRootFilter = queryData.filters.items.some(
+		(filter) =>
+			filter.key?.key === 'isRoot' && String(filter.value) === 'true',
+	);
+
+	if (!hasRootFilter) {
+		queryData.filters.items.push(createRootSpanFilterItem());
+	}
+
+	return nextQuery;
+};
 
 export const getListViewQuery = (
 	stagedQuery: Query,

--- a/frontend/src/hooks/queryBuilder/useShareBuilderUrl.ts
+++ b/frontend/src/hooks/queryBuilder/useShareBuilderUrl.ts
@@ -9,11 +9,14 @@ export type UseShareBuilderUrlParams = {
 	defaultValue: Query;
 	/** Force reset the query regardless of URL state */
 	forceReset?: boolean;
+	/** Extra URL params written on initial redirect (e.g. panelTypes) */
+	urlParams?: Record<string, unknown>;
 };
 
 export const useShareBuilderUrl = ({
 	defaultValue,
 	forceReset = false,
+	urlParams,
 }: UseShareBuilderUrlParams): void => {
 	const { resetQuery, redirectWithQueryBuilderData } = useQueryBuilder();
 	const urlQuery = useUrlQuery();
@@ -23,7 +26,7 @@ export const useShareBuilderUrl = ({
 	useEffect(() => {
 		if (!compositeQuery || forceReset) {
 			resetQuery(defaultValue);
-			redirectWithQueryBuilderData(defaultValue);
+			redirectWithQueryBuilderData(defaultValue, urlParams);
 		}
 	}, [
 		defaultValue,
@@ -32,5 +35,6 @@ export const useShareBuilderUrl = ({
 		compositeQuery,
 		resetQuery,
 		forceReset,
+		urlParams,
 	]);
 };

--- a/frontend/src/hooks/queryBuilder/useShareBuilderUrl.ts
+++ b/frontend/src/hooks/queryBuilder/useShareBuilderUrl.ts
@@ -9,11 +9,14 @@ export type UseShareBuilderUrlParams = {
 	defaultValue: Query;
 	/** Force reset the query regardless of URL state */
 	forceReset?: boolean;
+	/** Extra URL params written on initial redirect (e.g. panelTypes) */
+	urlParams?: Record<string, unknown>;
 };
 
 export const useShareBuilderUrl = ({
 	defaultValue,
 	forceReset = false,
+	urlParams,
 }: UseShareBuilderUrlParams): void => {
 	const { resetQuery, redirectWithQueryBuilderData } = useQueryBuilder();
 	const urlQuery = useUrlQuery();
@@ -23,12 +26,13 @@ export const useShareBuilderUrl = ({
 	useEffect(() => {
 		if (!compositeQuery || forceReset) {
 			resetQuery(defaultValue);
-			redirectWithQueryBuilderData(defaultValue);
+			redirectWithQueryBuilderData(defaultValue, urlParams);
 		}
 	}, [
 		defaultValue,
 		urlQuery,
 		redirectWithQueryBuilderData,
+		urlParams,
 		compositeQuery,
 		resetQuery,
 		forceReset,

--- a/frontend/src/pages/TracesExplorer/index.tsx
+++ b/frontend/src/pages/TracesExplorer/index.tsx
@@ -12,6 +12,7 @@ import { QuickFiltersSource, SignalType } from 'components/QuickFilters/types';
 import WarningPopover from 'components/WarningPopover/WarningPopover';
 import { LOCALSTORAGE } from 'constants/localStorage';
 import { AVAILABLE_EXPORT_PANEL_TYPES } from 'constants/panelTypes';
+import { QueryParams } from 'constants/query';
 import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
 import { usePageActions } from 'container/AIAssistant/pageActions/usePageActions';
 import ExplorerOptionWrapper from 'container/ExplorerOptions/ExplorerOptionWrapper';
@@ -22,12 +23,14 @@ import Toolbar from 'container/Toolbar/Toolbar';
 import {
 	getExportQueryData,
 	getQueryByPanelType,
+	withRootSpanFilter,
 } from 'container/TracesExplorer/explorerUtils';
 import ListView from 'container/TracesExplorer/ListView';
 import { defaultSelectedColumns } from 'container/TracesExplorer/ListView/configs';
 import QuerySection from 'container/TracesExplorer/QuerySection';
 import TableView from 'container/TracesExplorer/TableView';
 import TracesView from 'container/TracesExplorer/TracesView';
+import { useGetCompositeQueryParam } from 'hooks/queryBuilder/useGetCompositeQueryParam';
 import { useGetPanelTypesQueryParam } from 'hooks/queryBuilder/useGetPanelTypesQueryParam';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useShareBuilderUrl } from 'hooks/queryBuilder/useShareBuilderUrl';
@@ -89,8 +92,10 @@ function TracesExplorer(): JSX.Element {
 	const queryClient = useQueryClient();
 	const listQueryKeyRef = useRef<any>();
 
+	const compositeQueryParam = useGetCompositeQueryParam();
+
 	// Get panel type from URL
-	const panelTypesFromUrl = useGetPanelTypesQueryParam(PANEL_TYPES.LIST);
+	const panelTypesFromUrl = useGetPanelTypesQueryParam(PANEL_TYPES.TRACE);
 	const [isLoadingQueries, setIsLoadingQueries] = useState<boolean>(false);
 	const [isCancelled, setIsCancelled] = useState(false);
 
@@ -117,14 +122,22 @@ function TracesExplorer(): JSX.Element {
 	const [warning, setWarning] = useState<Warning | undefined>();
 	const [isOpen, setOpen] = useState<boolean>(true);
 
-	const defaultQuery = useMemo(
-		(): Query =>
-			updateAllQueriesOperators(
-				initialQueriesMap.traces,
-				PANEL_TYPES.LIST,
-				DataSource.TRACES,
-			),
-		[updateAllQueriesOperators],
+	const defaultQuery = useMemo((): Query => {
+		const baseQuery = updateAllQueriesOperators(
+			initialQueriesMap.traces,
+			PANEL_TYPES.TRACE,
+			DataSource.TRACES,
+		);
+
+		return withRootSpanFilter(baseQuery);
+	}, [updateAllQueriesOperators]);
+
+	const tracesExplorerDefaultUrlParams = useMemo(
+		() => ({
+			[QueryParams.panelTypes]: PANEL_TYPES.TRACE,
+			[QueryParams.selectedExplorerView]: ExplorerViews.TRACE,
+		}),
+		[],
 	);
 
 	const { handleExplorerTabChange } = useHandleExplorerTabChange();
@@ -187,7 +200,7 @@ function TracesExplorer(): JSX.Element {
 		() =>
 			getQueryByPanelType(
 				stagedQuery || initialQueriesMap.traces,
-				panelType || PANEL_TYPES.LIST,
+				panelType || PANEL_TYPES.TRACE,
 			),
 		[stagedQuery, panelType],
 	);
@@ -228,7 +241,16 @@ function TracesExplorer(): JSX.Element {
 		[exportDefaultQuery, panelType, safeNavigate, options],
 	);
 
-	useShareBuilderUrl({ defaultValue: defaultQuery });
+	useShareBuilderUrl({
+		defaultValue: defaultQuery,
+		urlParams: tracesExplorerDefaultUrlParams,
+	});
+
+	useEffect(() => {
+		if (!compositeQueryParam) {
+			handleSetConfig(PANEL_TYPES.TRACE, DataSource.TRACES);
+		}
+	}, [compositeQueryParam, handleSetConfig]);
 
 	const logEventCalledRef = useRef(false);
 

--- a/frontend/src/pages/TracesExplorer/index.tsx
+++ b/frontend/src/pages/TracesExplorer/index.tsx
@@ -12,6 +12,7 @@ import { QuickFiltersSource, SignalType } from 'components/QuickFilters/types';
 import WarningPopover from 'components/WarningPopover/WarningPopover';
 import { LOCALSTORAGE } from 'constants/localStorage';
 import { AVAILABLE_EXPORT_PANEL_TYPES } from 'constants/panelTypes';
+import { QueryParams } from 'constants/query';
 import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
 import { usePageActions } from 'container/AIAssistant/pageActions/usePageActions';
 import ExplorerOptionWrapper from 'container/ExplorerOptions/ExplorerOptionWrapper';
@@ -22,6 +23,7 @@ import Toolbar from 'container/Toolbar/Toolbar';
 import {
 	getExportQueryData,
 	getQueryByPanelType,
+	withRootSpanFilter,
 } from 'container/TracesExplorer/explorerUtils';
 import ListView from 'container/TracesExplorer/ListView';
 import { defaultSelectedColumns } from 'container/TracesExplorer/ListView/configs';
@@ -30,6 +32,7 @@ import TableView from 'container/TracesExplorer/TableView';
 import TracesView from 'container/TracesExplorer/TracesView';
 import { ExportDashboard } from 'hooks/dashboard/useExportDashboards';
 import { useGetExportToDashboardLink } from 'hooks/dashboard/useGetExportToDashboardLink';
+import { useGetCompositeQueryParam } from 'hooks/queryBuilder/useGetCompositeQueryParam';
 import { useGetPanelTypesQueryParam } from 'hooks/queryBuilder/useGetPanelTypesQueryParam';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useShareBuilderUrl } from 'hooks/queryBuilder/useShareBuilderUrl';
@@ -89,8 +92,10 @@ function TracesExplorer(): JSX.Element {
 	const queryClient = useQueryClient();
 	const listQueryKeyRef = useRef<any>();
 
+	const compositeQueryParam = useGetCompositeQueryParam();
+
 	// Get panel type from URL
-	const panelTypesFromUrl = useGetPanelTypesQueryParam(PANEL_TYPES.LIST);
+	const panelTypesFromUrl = useGetPanelTypesQueryParam(PANEL_TYPES.TRACE);
 	const [isLoadingQueries, setIsLoadingQueries] = useState<boolean>(false);
 	const [isCancelled, setIsCancelled] = useState(false);
 
@@ -117,14 +122,22 @@ function TracesExplorer(): JSX.Element {
 	const [warning, setWarning] = useState<Warning | undefined>();
 	const [isOpen, setOpen] = useState<boolean>(true);
 
-	const defaultQuery = useMemo(
-		(): Query =>
-			updateAllQueriesOperators(
-				initialQueriesMap.traces,
-				PANEL_TYPES.LIST,
-				DataSource.TRACES,
-			),
-		[updateAllQueriesOperators],
+	const defaultQuery = useMemo((): Query => {
+		const baseQuery = updateAllQueriesOperators(
+			initialQueriesMap.traces,
+			PANEL_TYPES.TRACE,
+			DataSource.TRACES,
+		);
+
+		return withRootSpanFilter(baseQuery);
+	}, [updateAllQueriesOperators]);
+
+	const tracesExplorerDefaultUrlParams = useMemo(
+		() => ({
+			[QueryParams.panelTypes]: PANEL_TYPES.TRACE,
+			[QueryParams.selectedExplorerView]: ExplorerViews.TRACE,
+		}),
+		[],
 	);
 
 	const { handleExplorerTabChange } = useHandleExplorerTabChange();
@@ -188,7 +201,7 @@ function TracesExplorer(): JSX.Element {
 		() =>
 			getQueryByPanelType(
 				stagedQuery || initialQueriesMap.traces,
-				panelType || PANEL_TYPES.LIST,
+				panelType || PANEL_TYPES.TRACE,
 			),
 		[stagedQuery, panelType],
 	);
@@ -237,7 +250,16 @@ function TracesExplorer(): JSX.Element {
 		],
 	);
 
-	useShareBuilderUrl({ defaultValue: defaultQuery });
+	useShareBuilderUrl({
+		defaultValue: defaultQuery,
+		urlParams: tracesExplorerDefaultUrlParams,
+	});
+
+	useEffect(() => {
+		if (!compositeQueryParam) {
+			handleSetConfig(PANEL_TYPES.TRACE, DataSource.TRACES);
+		}
+	}, [compositeQueryParam, handleSetConfig]);
 
 	const logEventCalledRef = useRef(false);
 


### PR DESCRIPTION
## Summary
- Default `/traces-explorer` to **Trace View** (`PANEL_TYPES.TRACE`) instead of List View.
- Add `isRoot=true` to the explorer's initial query via `withRootSpanFilter()` so the span scope defaults to **Root Spans** (scoped to Traces Explorer only).
- Persist defaults in the URL on first load (`panelTypes` + `selectedExplorerView`) and sync QueryBuilder `panelType` on mount.

Fixes #11861

## Problem
Users landing on Traces Explorer see **All Spans** in **List View**, which is noisy compared to tools like Datadog that default to trace/root-span oriented views.

## Out of scope
Back-navigation query persistence (third item in the issue) looks like a separate `panelType`/URL sync bug — happy to follow up in another PR if maintainers want it.

## Test plan
- [ ] Visit `/traces-explorer` with no query params → Trace View tab active, span scope shows **Root Spans**, results are root spans only
- [ ] URL includes `panelTypes` and `selectedExplorerView` for trace on first load
- [ ] Switching to List View / All Spans still works manually
- [ ] Dashboards, alerts, and other trace query entry points unchanged (no global `initialQueriesMap.traces` change)
- [x] `explorerUtils.test.ts` — `withRootSpanFilter` adds `isRoot` once, no duplicate

Made with [Cursor](https://cursor.com)