### PR TITLE
fix(e2e): open panel ⋮ menu via click, not hover

### DIFF
--- a/tests/e2e/tests/dashboards/details/12-sections.spec.ts
+++ b/tests/e2e/tests/dashboards/details/12-sections.spec.ts
@@ -392,17 +392,17 @@ test.describe('Dashboard Detail — Sections', () => {
 			page.getByText(panelName, { exact: true }).first(),
 		).toBeVisible();
 
-		// The panel ⋮ menu opens on HOVER (not click) — see
-		// `openPanelMoreMenu` in 21-panel-actions.spec.ts. Clicking the kebab
-		// can momentarily toggle the menu and immediately re-close it, racing
-		// the menuitem click on the next line. Use hover and wait for the
-		// menu role to be visible before clicking Delete.
+		// The panel ⋮ menu is a Radix `DropdownMenuSimple` — it opens on click,
+		// not hover (see `openPanelMoreMenu` in 21-panel-actions.spec.ts). The
+		// container hover only reveals the kebab (it's `visibility: hidden`
+		// until then); the click toggles the menu. Wait for the menu role to be
+		// visible before clicking Delete.
 		const panelTitle = page.getByText(panelName, { exact: true }).first();
 		await panelTitle.hover();
 		const panelContainer = panelTitle.locator('../..');
 		await panelContainer.scrollIntoViewIfNeeded();
 		await panelContainer.hover();
-		await panelContainer.getByTestId('widget-header-options').hover();
+		await panelContainer.getByTestId('widget-header-options').click();
 		const menu = page.getByRole('menu');
 		await menu.waitFor({ state: 'visible' });
 		await menu.getByRole('menuitem', { name: 'Delete', exact: true }).click();

--- a/tests/e2e/tests/dashboards/details/21-panel-actions.spec.ts
+++ b/tests/e2e/tests/dashboards/details/21-panel-actions.spec.ts
@@ -107,14 +107,15 @@ function panelContainer(page: Page, title: string, index = 0): Locator {
 }
 
 /**
- * Hover the panel header (the ⋮ icon is CSS-hidden until the row is hovered)
- * and open the action dropdown. Returns the opened menu locator.
+ * Reveal the panel header's ⋮ icon and open the action dropdown. Returns the
+ * opened menu locator.
  *
- * The antd `<Dropdown>` wrapping the ⋮ icon uses `trigger={['hover']}` (see
- * `WidgetHeader/index.tsx`), so the menu opens on hover, not click —
- * dispatching a click is a no-op. We hover the container first to reveal the
- * icon (it's CSS-hidden until then) and then hover the icon itself to fire
- * the antd Dropdown's mouseenter handler.
+ * The ⋮ icon is a `@signozhq/ui` `DropdownMenuSimple` (Radix
+ * `@radix-ui/react-dropdown-menu` under the hood — see `WidgetHeader/index.tsx`),
+ * so the menu opens on click, not hover. We still hover the container first
+ * because the icon is `visibility: hidden` until the row is hovered (see the
+ * `.widget-graph-component-container:hover` rule in `GridCardLayout.styles.scss`);
+ * then we click the revealed icon to toggle the Radix menu open.
  */
 async function openPanelMoreMenu(
 	page: Page,
@@ -125,7 +126,7 @@ async function openPanelMoreMenu(
 	await container.scrollIntoViewIfNeeded();
 	await container.hover();
 	const moreOptions = container.getByTestId('widget-header-options');
-	await moreOptions.hover();
+	await moreOptions.click();
 	const menu = page.getByRole('menu');
 	await menu.waitFor({ state: 'visible' });
 	return menu;

--- a/tests/e2e/tests/dashboards/details/44-edit-panel.spec.ts
+++ b/tests/e2e/tests/dashboards/details/44-edit-panel.spec.ts
@@ -66,9 +66,10 @@ test.describe('Dashboard Detail — Edit Panel (entry-point only)', () => {
 		await container.hover();
 
 		const options = container.getByTestId('widget-header-options');
-		// The ⋮ uses an antd `Dropdown` with `trigger=['hover']`; firing a real
-		// hover (not `dispatchEvent('click')`) is what opens the menu.
-		await options.hover({ force: true });
+		// The ⋮ is a `@signozhq/ui` `DropdownMenuSimple` (Radix-based); it opens
+		// on click, not hover. The container hover above only reveals the icon
+		// (it's `visibility: hidden` until then) — the click toggles the menu.
+		await options.click();
 
 		await page.getByRole('menuitem', { name: 'Edit' }).click();
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?

The dashboard-detail E2E specs that open a panel's `⋮` action menu were failing on **every** run. The menu was migrated from an antd `Dropdown` (`trigger={['hover']}`) to `@signozhq/ui`'s `DropdownMenuSimple` in #11400, which is built on `@radix-ui/react-dropdown-menu` — a **click**-triggered menu. The specs still opened it by **hovering** the kebab, so the menu never appeared and the tests timed out (30s) waiting for it.

Fix: keep hovering the panel container (the kebab is `visibility: hidden` until the row is hovered) but **click** the revealed icon to toggle the Radix menu, and correct the now-stale "opens on hover" comments.

This was also a major contributor to the E2E job's 30-min timeout: each affected test burned 30s × 3 retries (~90s) instead of ~5s, and `21-panel-actions.spec.ts` runs serially so its TC-01 failure skipped TC-02–TC-14 every run.

#### Issues closed by this PR
Tracking issue to follow.

---

### ✅ Change Type
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [x] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
PR #11400 swapped the panel `⋮` menu from a hover-triggered antd `Dropdown` to a click-triggered Radix `DropdownMenuSimple`. The E2E specs were written against the old hover behavior and were never updated, so the menu never opened under the new component.

#### Fix Strategy
Reveal the kebab via `container.hover()` (still required by the CSS visibility rule), then `click()` it instead of `hover()`. Applied to `openPanelMoreMenu` in `21-panel-actions.spec.ts`, the inline opener in `44-edit-panel.spec.ts`, and the panel-delete path in `12-sections.spec.ts`.

---

### 🧪 Testing Strategy

- Reproduced the failures locally against the pytest-provisioned e2e stack (golden seed), then confirmed the fix:
  - `21-panel-actions.spec.ts` + `12-sections.spec.ts`: **20 passed, 0 failed, 0 flaky** (6 pre-existing `test.skip`).
  - `44-edit-panel.spec.ts` TC-01: passes.
  - `67-variables.spec.ts`: **17 passed, 0 failed, 0 flaky** — confirming its earlier CI "failures" were timeout/cancellation artifacts, not a code bug.
- `oxfmt --check` and `oxlint` clean on all three files.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: three E2E spec files only; no product/runtime code touched.
- Potential regressions: none — interaction model now matches the shipped component.
- Rollback plan: revert the commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | OSS |
| Change Type | Maintenance |
| Description | N/A — test-only |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The `12-sections.spec.ts` change lands inside the currently-`test.skip`'d TC-07, so it has no immediate runtime effect but keeps that test correct for when it's re-enabled.
- The E2E job only runs on PRs labelled `safe-to-e2e` — please add the label to exercise these specs in CI.
- Separate from this PR: the e2e `test` job's 30-min timeout (backend bring-up alone is ~10 min). Fixing the hover hangs should cut a lot of wasted time; whether a timeout bump is still needed can be judged from a full run.
