### PR TITLE
fix(uplotV2): tooltip list clips last row and over-scrolls

### DIFF
--- a/frontend/src/lib/uPlotV2/components/Tooltip/__tests__/Tooltip.test.tsx
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/__tests__/Tooltip.test.tsx
@@ -177,7 +177,8 @@ describe('Tooltip', () => {
 		renderTooltip({ uPlotInstance, content });
 
 		const list = screen.getByTestId('uplot-tooltip-list');
-		expect(list).toHaveStyle({ height: '200px' });
+		// Measured height (200) + the scroll viewport's vertical padding (16)
+		expect(list).toHaveStyle({ height: '216px' });
 	});
 
 	it('sets tooltip list height based on content length when Virtuoso reports 0 height', () => {
@@ -188,8 +189,8 @@ describe('Tooltip', () => {
 		renderTooltip({ uPlotInstance, content });
 
 		const list = screen.getByTestId('uplot-tooltip-list');
-		// Falls back to content length: 2 items * 38px = 76px
-		expect(list).toHaveStyle({ height: '76px' });
+		// Falls back to content length (2 * 38 = 76) + vertical padding (16) = 92px
+		expect(list).toHaveStyle({ height: '92px' });
 	});
 });
 

--- a/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipList/TooltipList.tsx
+++ b/frontend/src/lib/uPlotV2/components/Tooltip/components/TooltipList/TooltipList.tsx
@@ -13,6 +13,11 @@ import Styles from './TooltipList.module.scss';
 // Fallback per-item height before Virtuoso reports the real total.
 const TOOLTIP_ITEM_HEIGHT = 38;
 const LIST_MAX_HEIGHT = 300;
+// Vertical padding (spacing-4 top + bottom) the SCSS applies to the scroll
+// viewport. Virtuoso's reported height covers only the items, so it must be
+// added back — otherwise the box is short by this amount, clipping the last
+// row and showing a scrollbar even when every row would fit.
+const LIST_VERTICAL_PADDING = 16;
 
 interface TooltipListProps {
 	id: string;
@@ -30,13 +35,13 @@ export default function TooltipList({
 	// Use the measured height from Virtuoso when available; fall back to a
 	// per-item estimate on first render. Math.ceil prevents a 1 px
 	// subpixel rounding gap from triggering a spurious scrollbar.
-	const height = useMemo(
-		() =>
-			totalListHeight > 0
-				? Math.ceil(Math.min(totalListHeight, LIST_MAX_HEIGHT))
-				: Math.min(content.length * TOOLTIP_ITEM_HEIGHT, LIST_MAX_HEIGHT),
-		[totalListHeight, content.length],
-	);
+	const height = useMemo(() => {
+		const contentHeight =
+			totalListHeight > 0 ? totalListHeight : content.length * TOOLTIP_ITEM_HEIGHT;
+		return Math.ceil(
+			Math.min(contentHeight + LIST_VERTICAL_PADDING, LIST_MAX_HEIGHT),
+		);
+	}, [totalListHeight, content.length]);
 
 	const handleScroll = useCallback(() => {
 		if (!isScrollEventTriggered.current) {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The uPlot v2 chart tooltip clipped its last series row and showed a scrollbar even when only a few series were present (see screenshot in the issue/Slack thread).

The `TooltipList` Virtuoso scroller height was set to `min(totalListHeight, 300)`. The scroll viewport (`div[data-viewport-type='element']`) adds `8px` top + `8px` bottom padding (`--spacing-4`), but `react-virtuoso`'s `totalListHeight` is derived only from item/header/footer measurements and does **not** include that custom CSS padding. As a result the scroller was always ~16px shorter than its actual content — clipping the last row and forcing a scrollbar.

The fix adds the viewport's vertical padding back into the computed height, so the list sizes to its content and only scrolls once it genuinely exceeds the 300px max.

#### Screenshots / Screen Recordings (if applicable)

Before: last row (e.g. "Retained") is cut off mid-row and a scrollbar appears with only a handful of series.
<img width="520" height="319" alt="image" src="https://github.com/user-attachments/assets/9644f7c1-e191-4d08-bf03-88980f3fb726" />

After: all rows render fully; the scrollbar only appears past the max height.
<img width="520" height="319" alt="image" src="https://github.com/user-attachments/assets/3583a133-9c37-4e17-a50e-7edb0f543cf9" />


---

#### Issues Closed
Closes https://github.com/SigNoz/engineering-pod/issues/5515

---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
`react-virtuoso`'s `totalListHeight` measures only items/header/footer, not the `8px` top + `8px` bottom padding the SCSS applies to the scroll viewport. The scroller height was set from `totalListHeight` alone, leaving it ~16px short of its real content.

#### Fix Strategy
Add the viewport's vertical padding (`LIST_VERTICAL_PADDING = 16`) to the content height before capping at `LIST_MAX_HEIGHT`, in both the measured and the first-render fallback paths.

---

### 🧪 Testing Strategy

- Tests added/updated: updated the two height assertions in `Tooltip.test.tsx` (measured `200 → 216`, fallback `76 → 92`).
- Manual verification: `yarn jest` Tooltip suite (16/16), `pnpm tsgo --noEmit` clean, `pnpm lint:js --quiet` clean.
- Edge cases covered: measured height, first-render fallback (Virtuoso reports 0), and the existing `> max height` cap continue to scroll.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: uPlot v2 chart tooltip list only (`TooltipList`).
- Potential regressions: minimal — a pure height calculation tweak in a leaf component; no API or data changes.
- Rollback plan: revert this commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Chart tooltips no longer clip the last series row or show a scrollbar when all rows fit. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

`LIST_VERTICAL_PADDING = 16` mirrors the `--spacing-4` top+bottom padding in `TooltipList.module.scss` and is documented inline. If we'd rather not couple the TS constant to the SCSS value, an alternative is moving the vertical padding off the scroll viewport onto the outer (non-scrolling) `.container`.

