### PR TITLE
fix(render): add missing Content-Type header in Error() response

### DIFF
--- a/pkg/http/render/render.go
+++ b/pkg/http/render/render.go
@@ -130,6 +130,7 @@ func Error(rw http.ResponseWriter, cause error) {
 		rw.Header().Set("Retry-After", strconv.Itoa(int(math.Ceil(d.Seconds()))))
 	}
 
+	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(httpCode)
 	_, _ = rw.Write(body)
 }


### PR DESCRIPTION
### 📄 Summary

`render.Error()` writes a JSON body but never sets the `Content-Type: application/json`
response header. The sibling function `render.Success()` in the same file correctly
sets it (line 42), but `Error()` was missing it.

This means all error responses from handlers using `render.Error()` were sent without
a Content-Type header — inconsistent with success responses and standard HTTP practice.

#### Issues closed by this PR
Closes #11889

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause

`render.Success()` sets `Content-Type: application/json` before `WriteHeader`.
`render.Error()` was written without this line — an oversight when the two functions diverged.

#### Fix Strategy

Add `rw.Header().Set("Content-Type", "application/json")` immediately before
`rw.WriteHeader(httpCode)` in `Error()`, mirroring `Success()`.

---

### 🧪 Testing Strategy

- Tests added/updated: N/A — no existing header tests in this package
- Manual verification: `go build ./pkg/http/render/...` passes cleanly
  consistent with how `net/http` requires headers to be set

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Minimal — adds one header, zero logic change
- Potential regressions: None — no client should break on receiving a previously missing header
- Rollback plan: Revert the single line

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Error responses now include `Content-Type: application/json` header |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered