### PR TITLE
fix: include query metadata in alert edit and new contexts

### DIFF
--- a/frontend/src/container/AIAssistant/__tests__/getAutoContexts.test.ts
+++ b/frontend/src/container/AIAssistant/__tests__/getAutoContexts.test.ts
@@ -48,6 +48,48 @@ describe('getAutoContexts', () => {
 		]);
 	});
 
+	it('includes the query in alert edit context', () => {
+		const ruleId = 'rule-edit';
+		const query = { queryType: 'builder', builder: { queryData: [] } };
+		const compositeQuery = encodeURIComponent(JSON.stringify(query));
+		const search = `?${QueryParams.ruleId}=${ruleId}&${QueryParams.compositeQuery}=${compositeQuery}`;
+
+		const contexts = getAutoContexts(ROUTES.EDIT_ALERTS, search);
+
+		expect(contexts).toStrictEqual([
+			{
+				source: 'auto',
+				type: 'alert',
+				resourceId: ruleId,
+				metadata: {
+					page: 'alert_edit',
+					ruleId,
+					query,
+				},
+			},
+		]);
+	});
+
+	it('includes the query in alert new context (no ruleId)', () => {
+		const query = { queryType: 'builder', builder: { queryData: [] } };
+		const compositeQuery = encodeURIComponent(JSON.stringify(query));
+		const search = `?${QueryParams.compositeQuery}=${compositeQuery}`;
+
+		const contexts = getAutoContexts(ROUTES.ALERTS_NEW, search);
+
+		expect(contexts).toStrictEqual([
+			{
+				source: 'auto',
+				type: 'alert',
+				resourceId: null,
+				metadata: {
+					page: 'alert_new',
+					query,
+				},
+			},
+		]);
+	});
+
 	it('returns triggered alerts context on alert history without ruleId', () => {
 		const contexts = getAutoContexts(ROUTES.ALERT_HISTORY, '');
 

--- a/frontend/src/container/AIAssistant/getAutoContexts.ts
+++ b/frontend/src/container/AIAssistant/getAutoContexts.ts
@@ -124,7 +124,9 @@ export function getAutoContexts(
 		}
 	}
 
-	// Alert edit — `/alerts/edit?ruleId=…`.
+	// Alert edit — `/alerts/edit?ruleId=…`. The form syncs its query-builder
+	// state to the URL (`useShareBuilderUrl`), so shared metadata carries the
+	// alert's query + time range, mirroring the dashboard panel editor.
 	if (matchPath(pathname, { path: ROUTES.EDIT_ALERTS, exact: true })) {
 		const ruleId = params.get(QueryParams.ruleId);
 		if (ruleId) {
@@ -133,19 +135,21 @@ export function getAutoContexts(
 					source: 'auto',
 					type: 'alert',
 					resourceId: ruleId,
-					metadata: { page: 'alert_edit', ruleId },
+					metadata: { page: 'alert_edit', ruleId, ...sharedMetadata },
 				},
 			];
 		}
 	}
 
+	// Alert new — `/alerts/new`. No rule id yet (draft), but the query-builder
+	// state is on the URL, so shared metadata carries the in-progress query.
 	if (matchPath(pathname, { path: ROUTES.ALERTS_NEW, exact: true })) {
 		return [
 			{
 				source: 'auto',
 				type: 'alert',
 				resourceId: null,
-				metadata: { page: 'alert_new' },
+				metadata: { page: 'alert_new', ...sharedMetadata },
 			},
 		];
 	}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The AI Assistant auto-context for alert **edit** and **new** pages only sent page identity (`alert_edit` / `alert_new` and `ruleId` when present). It did not include the alert’s query-builder state, even though that state is already synced to the URL via `useShareBuilderUrl` (`compositeQuery`, time range, etc.).


This change spreads `sharedMetadata` into alert edit/new auto-contexts—the same pattern already used for dashboard panel edit and alert detail—so the assistant receives the in-progress query (and time range when present) from URL params.

#### Screenshots / Screen Recordings (if applicable)
<img width="1496" height="843" alt="Screenshot 2026-06-29 at 19 31 52" src="https://github.com/user-attachments/assets/5d50a8d2-283a-4501-a55d-56ddcc3cba80" />



metadata-only change; behavior is visible in AI Assistant network payloads / agent context, not UI layout.

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

<!-- Closes #XXXX -->

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

`getAutoContexts` already collected URL-derived metadata (`query`, `timeRange`, etc.) via `collectSharedMetadata`, and used it for dashboard and alert detail routes. Alert edit (`/alerts/edit`) and alert new (`/alerts/new`) were added with minimal metadata and never wired up to `sharedMetadata`, despite the alert form syncing query-builder state to the URL.

#### Fix Strategy
> How does this PR address the root cause?

Spread `...sharedMetadata` into auto-context metadata for:
- **Alert edit** — `{ page: 'alert_edit', ruleId, ...sharedMetadata }`
- **Alert new** — `{ page: 'alert_new', ...sharedMetadata }`

This mirrors the dashboard panel editor pattern and reuses existing URL parsing—no Redux/context reads, no new API surface.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
  - `getAutoContexts.test.ts` — two cases asserting `query` is included for alert edit (with `ruleId`) and alert new (without `ruleId`)
- Manual verification:
  - Open alert edit/new with a query in the URL; confirm AI Assistant auto-context includes `metadata.query`
- Edge cases covered:
  - Alert new with no `ruleId` (draft)
  - Malformed `compositeQuery` in URL (silently omitted via existing `collectSharedMetadata` fallback)

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: AI Assistant auto-context on alert edit/new pages only
- Potential regressions: Slightly larger context payloads when `compositeQuery` is present in the URL; no change when URL has no query params
- Rollback plan: Revert commit; auto-context reverts to page-only metadata

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | AI Assistant now receives alert query context when editing or creating alerts |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

- Change is limited to `getAutoContexts.ts` + tests; no backend or API contract changes.
- Alert edit/new now behave consistently with dashboard panel edit and alert detail for URL-derived context.
- Only committed diff is included; local unstaged changes in `AIAPIInstance.ts` / `useIsAIAssistantEnabled.ts` are **not** part of this PR unless staged separately.

---