### PR TITLE
feat(dashboards-v2): panel drilldown — context links

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
@@ -13,6 +13,7 @@ import { enrichChartClick } from '../enrichChartClick';
 import { enrichNumberClick } from '../enrichNumberClick';
 import { enrichPieClick } from '../enrichPieClick';
 import { enrichTableClick } from '../enrichTableClick';
+import { resolvePanelContextLinks } from '../resolvePanelContextLinks';
 import { resolveDrilldownSignal } from '../signal';
 
 // The v5 BuilderQuery union is too verbose to construct field-typed inline; cast at the boundary.
@@ -348,6 +349,44 @@ describe('enrichPieClick', () => {
 				coordinates: { x: 0, y: 0 },
 			}),
 		).toBeNull();
+	});
+});
+
+describe('resolvePanelContextLinks', () => {
+	it('substitutes the clicked field value (_-prefixed) into the label and URL', () => {
+		const resolved = resolvePanelContextLinks(
+			[
+				{
+					name: 'Runbook for {{_service.name}}',
+					url: 'https://wiki/{{_service.name}}',
+				},
+			],
+			{ '_service.name': 'frontend' },
+		);
+
+		expect(resolved).toHaveLength(1);
+		expect(resolved[0].label).toBe('Runbook for frontend');
+		expect(resolved[0].url).toBe('https://wiki/frontend');
+	});
+
+	it('drops links without a URL', () => {
+		expect(resolvePanelContextLinks([{ name: 'No URL' }], {})).toStrictEqual([]);
+		expect(resolvePanelContextLinks(undefined, {})).toStrictEqual([]);
+	});
+
+	it('keeps the raw URL when renderVariables is false', () => {
+		const resolved = resolvePanelContextLinks(
+			[
+				{
+					name: 'Literal',
+					url: 'https://wiki/{{_service.name}}',
+					renderVariables: false,
+				},
+			],
+			{ '_service.name': 'frontend' },
+		);
+
+		expect(resolved[0].url).toBe('https://wiki/{{_service.name}}');
 	});
 });
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
@@ -13,6 +13,7 @@ import { enrichChartClick } from '../enrichChartClick';
 import { enrichNumberClick } from '../enrichNumberClick';
 import { enrichPieClick } from '../enrichPieClick';
 import { enrichTableClick } from '../enrichTableClick';
+import { getDataLinks } from '../getDataLinks';
 import { resolvePanelContextLinks } from '../resolvePanelContextLinks';
 import { resolveDrilldownSignal } from '../signal';
 
@@ -83,8 +84,16 @@ describe('enrichChartClick', () => {
 			clickData: chartClick(focused(2)),
 			series,
 			builderQueries: [
-				builderQuery({ name: 'A', signal: 'metrics' }),
-				builderQuery({ name: 'B', signal: 'logs' }),
+				builderQuery({
+					name: 'A',
+					signal: 'metrics',
+					groupBy: [{ name: 'service.name' }],
+				}),
+				builderQuery({
+					name: 'B',
+					signal: 'logs',
+					groupBy: [{ name: 'service.name' }],
+				}),
 			],
 		});
 
@@ -142,15 +151,38 @@ describe('enrichChartClick', () => {
 		).toBeNull();
 	});
 
-	it('emits empty filters for an ungrouped series', () => {
+	it('emits empty filters for an ungrouped series (drops the legend backfill label)', () => {
 		const payload = enrichChartClick({
 			clickData: chartClick(focused(1)),
-			series: [panelSeries({ queryName: 'A', labels: {} })],
+			series: [panelSeries({ queryName: 'A', labels: { A: 'A' } })],
 			builderQueries: [builderQuery({ name: 'A', signal: 'metrics' })],
 		});
 
 		expect(payload?.context.filters).toStrictEqual([]);
 		expect(payload?.context.queryName).toBe('A');
+	});
+
+	it('drops labels that are not group-by dimensions', () => {
+		const payload = enrichChartClick({
+			clickData: chartClick(focused(1)),
+			series: [
+				panelSeries({
+					queryName: 'A',
+					labels: { 'service.name': 'frontend', __name__: 'http_requests' },
+				}),
+			],
+			builderQueries: [
+				builderQuery({
+					name: 'A',
+					signal: 'metrics',
+					groupBy: [{ name: 'service.name' }],
+				}),
+			],
+		});
+
+		expect(payload?.context.filters).toStrictEqual([
+			{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
+		]);
 	});
 });
 
@@ -329,7 +361,13 @@ describe('enrichPieClick', () => {
 				queryName: 'A',
 				labels: { 'service.name': 'frontend' },
 			},
-			builderQueries: [builderQuery({ name: 'A', signal: 'traces' })],
+			builderQueries: [
+				builderQuery({
+					name: 'A',
+					signal: 'traces',
+					groupBy: [{ name: 'service.name' }],
+				}),
+			],
 			coordinates: { x: 7, y: 8 },
 			timeRange: { startTime: 1, endTime: 2 },
 		});
@@ -416,5 +454,30 @@ describe('stepClickTimeRange', () => {
 				],
 			}),
 		).toStrictEqual({ startTime: 1000, endTime: 1060 });
+	});
+});
+
+describe('getDataLinks', () => {
+	it('adds a "View Trace Details" link when the filters carry a trace_id', () => {
+		expect(
+			getDataLinks([
+				{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
+				{ filterKey: 'trace_id', filterValue: 'abc123', operator: '=' },
+			]),
+		).toStrictEqual([
+			{
+				id: 'view-trace-details',
+				label: 'View Trace Details',
+				url: '/trace/abc123',
+			},
+		]);
+	});
+
+	it('returns no links when there is no trace_id', () => {
+		expect(
+			getDataLinks([
+				{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
+			]),
+		).toStrictEqual([]);
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/enrichChartClick.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/enrichChartClick.ts
@@ -1,13 +1,11 @@
-import {
-	getFiltersFromMetric,
-	isValidQueryName,
-} from 'container/QueryTable/Drilldown/drilldownUtils';
+import { isValidQueryName } from 'container/QueryTable/Drilldown/drilldownUtils';
 import type { ChartClickData } from 'lib/uPlotV2/plugins/TooltipPlugin/types';
 import type { PanelSeries } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
 import type { BuilderQuery } from 'types/api/v5/queryRange';
 
 import type { DrilldownClickPayload } from '../../types/drilldown';
 
+import { getGroupByFilters } from './getGroupByFilters';
 import { resolveDrilldownSignal } from './signal';
 
 interface EnrichChartClickArgs {
@@ -23,7 +21,7 @@ interface EnrichChartClickArgs {
 /**
  * Turns a uPlot click (time-series or bar) into a drilldown payload. Resolves the clicked series via
  * uPlot's series index (index 0 is the x-axis, so data series start at 1 → `series[seriesIndex - 1]`)
- * and builds equality filters from its group-by labels. Returns `null` when the click can't be
+ * and builds equality filters from its group-by label values. Returns `null` when the click can't be
  * attributed to a drillable series (no focused series, unmapped index, or a formula query).
  */
 export function enrichChartClick({
@@ -46,12 +44,16 @@ export function enrichChartClick({
 		(query) => query.name === panelSeries.queryName,
 	);
 
+	const filters = builderQuery
+		? getGroupByFilters(panelSeries.labels, builderQuery)
+		: [];
+
 	return {
 		coordinates: { x: clickData.absoluteMouseX, y: clickData.absoluteMouseY },
 		context: {
 			queryName: panelSeries.queryName,
 			signal: resolveDrilldownSignal(builderQuery),
-			filters: getFiltersFromMetric(panelSeries.labels),
+			filters,
 			timeRange,
 			label: focusedSeries.seriesName,
 			seriesColor: focusedSeries.color,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/enrichPieClick.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/enrichPieClick.ts
@@ -1,12 +1,10 @@
 import type { PieSlice } from 'container/DashboardContainer/visualization/charts/types';
-import {
-	getFiltersFromMetric,
-	isValidQueryName,
-} from 'container/QueryTable/Drilldown/drilldownUtils';
+import { isValidQueryName } from 'container/QueryTable/Drilldown/drilldownUtils';
 import type { BuilderQuery } from 'types/api/v5/queryRange';
 
 import type { DrilldownClickPayload } from '../../types/drilldown';
 
+import { getGroupByFilters } from './getGroupByFilters';
 import { resolveDrilldownSignal } from './signal';
 
 interface EnrichPieClickArgs {
@@ -18,8 +16,9 @@ interface EnrichPieClickArgs {
 }
 
 /**
- * Turns a pie-slice click into a drilldown payload, using the slice's source-row labels (carried by
- * `preparePieData`) as equality filters. Returns `null` when the slice has no drillable query.
+ * Turns a pie-slice click into a drilldown payload, using the slice's source-row group-by label
+ * values (carried by `preparePieData`) as equality filters. Returns `null` when the slice has no
+ * drillable query.
  */
 export function enrichPieClick({
 	slice,
@@ -33,12 +32,16 @@ export function enrichPieClick({
 	}
 
 	const builderQuery = builderQueries.find((query) => query.name === queryName);
+
+	const filters = builderQuery
+		? getGroupByFilters(slice.labels ?? {}, builderQuery)
+		: [];
 	return {
 		coordinates,
 		context: {
 			queryName,
 			signal: resolveDrilldownSignal(builderQuery),
-			filters: getFiltersFromMetric(slice.labels ?? {}),
+			filters: filters,
 			timeRange,
 			label: slice.label,
 			seriesColor: slice.color,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getDataLinks.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getDataLinks.ts
@@ -1,0 +1,29 @@
+import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
+
+/** An auto-generated drilldown link (label + destination URL). */
+export interface DrilldownDataLink {
+	id: string;
+	label: string;
+	url: string;
+}
+
+/**
+ * Links derived automatically from the clicked point's filters — the V2 port of V1's `getDataLinks`.
+ * Currently a single "View Trace Details" link when the clicked row carries a `trace_id`.
+ */
+export function getDataLinks(filters: FilterData[]): DrilldownDataLink[] {
+	const links: DrilldownDataLink[] = [];
+
+	const traceId = filters.find(
+		(filter) => filter.filterKey === 'trace_id',
+	)?.filterValue;
+	if (traceId) {
+		links.push({
+			id: 'view-trace-details',
+			label: 'View Trace Details',
+			url: `/trace/${traceId}`,
+		});
+	}
+
+	return links;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getGroupByFilters.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getGroupByFilters.ts
@@ -1,0 +1,26 @@
+import {
+	type FilterData,
+	getFiltersFromMetric,
+} from 'container/QueryTable/Drilldown/drilldownUtils';
+import type { BuilderQuery } from 'types/api/v5/queryRange';
+
+/**
+ * Equality filters for the clicked series/slice, restricted to the query's group-by dimensions.
+ * `labels` also carry a display-only legend backfill (`{queryName: queryName}` when ungrouped, see
+ * `resolveLegendAndLabels`); intersecting with group-by drops it so `filters` stays empty when
+ * ungrouped, matching V1.
+ */
+export function getGroupByFilters(
+	labels: Record<string, string>,
+	builderQuery: BuilderQuery,
+): FilterData[] {
+	const groupByKeys = new Set(
+		(builderQuery.groupBy ?? []).map((group) => group.name),
+	);
+	if (groupByKeys.size === 0) {
+		return [];
+	}
+	return getFiltersFromMetric(labels).filter((filter) =>
+		groupByKeys.has(filter.filterKey),
+	);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks.ts
@@ -1,0 +1,50 @@
+import type { DashboardLinkDTO } from 'api/generated/services/sigNoz.schemas';
+import { processContextLinks } from 'container/NewWidget/RightContainer/ContextLinks/utils';
+import type { ContextLinkProps } from 'types/api/dashboard/getAll';
+
+/** A panel context link with its label and URL templates resolved, ready to render. */
+export interface ResolvedDrilldownLink {
+	id: string;
+	label: string;
+	url: string;
+}
+
+/**
+ * Resolves a panel's context links for the drilldown menu. Adapts each `DashboardLinkDTO` to the V1
+ * `ContextLinkProps` the shared `processContextLinks` resolver expects, substitutes variables in the
+ * label + URL, and drops links without a URL. Links with `renderVariables === false` keep their raw
+ * label/URL (no substitution).
+ */
+export function resolvePanelContextLinks(
+	links: DashboardLinkDTO[] | undefined,
+	processedVariables: Record<string, string>,
+): ResolvedDrilldownLink[] {
+	const usable = (links ?? []).filter((link) => !!link.url);
+	if (usable.length === 0) {
+		return [];
+	}
+
+	const adapted: ContextLinkProps[] = usable.map((link, index) => ({
+		id: String(index),
+		label: link.name || link.url || '',
+		url: link.url ?? '',
+	}));
+
+	const resolved = processContextLinks(adapted, processedVariables, 50);
+
+	return usable.map((link, index) => {
+		// `renderVariables` defaults to on; only an explicit `false` opts out of substitution.
+		if (link.renderVariables === false) {
+			return {
+				id: String(index),
+				label: link.name || link.url || '',
+				url: link.url ?? '',
+			};
+		}
+		return {
+			id: resolved[index].id,
+			label: resolved[index].label,
+			url: resolved[index].url,
+		};
+	});
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
@@ -1,9 +1,20 @@
 import { useMemo } from 'react';
-import { ChartBar, DraftingCompass, Loader, ScrollText } from '@signozhq/icons';
+import {
+	ChartBar,
+	DraftingCompass,
+	Link,
+	Loader,
+	ScrollText,
+} from '@signozhq/icons';
+import type { DashboardLinkDTO } from 'api/generated/services/sigNoz.schemas';
 import { getAggregateColumnHeader } from 'container/QueryTable/Drilldown/drilldownUtils';
 import ContextMenu from 'periscope/components/ContextMenu';
 import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
+import { resolvePanelContextLinks } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
+import { openInNewTab } from 'utils/navigation';
+
+import { useDrilldownContextVariables } from '../hooks/useDrilldownContextVariables';
 
 import styles from './DrilldownAggregateMenu.module.scss';
 
@@ -13,26 +24,39 @@ interface DrilldownAggregateMenuProps {
 	query: Query;
 	/** While dashboard variables resolve, the actions show a spinner and are disabled. */
 	isResolving?: boolean;
+	/** Panel's context links; resolved against the clicked point + variables here. */
+	links: DashboardLinkDTO[] | undefined;
 	onViewLogs: () => void;
 	onViewTraces: () => void;
 	onBreakout: () => void;
+	/** Close the popover (context-link clicks). */
+	onClose: () => void;
 }
 
 /**
- * The base aggregate drill-down menu: a tinted header + View in Logs/Traces + Breakout.
+ * The base aggregate drill-down menu: tinted header + View in Logs/Traces, Breakout, and the
+ * panel's context links. Mounted only while open, so the variable/link resolution runs only then.
  * Metrics is omitted — V1 surfaces only Logs/Traces.
  */
 function DrilldownAggregateMenu({
 	context,
 	query,
 	isResolving = false,
+	links,
 	onViewLogs,
 	onViewTraces,
 	onBreakout,
+	onClose,
 }: DrilldownAggregateMenuProps): JSX.Element {
 	const aggregations = useMemo(
 		() => getAggregateColumnHeader(query, context.queryName).aggregations,
 		[query, context.queryName],
+	);
+
+	const processedVariables = useDrilldownContextVariables(context);
+	const contextLinks = useMemo(
+		() => resolvePanelContextLinks(links, processedVariables),
+		[links, processedVariables],
 	);
 
 	return (
@@ -83,6 +107,18 @@ function DrilldownAggregateMenu({
 			>
 				<span data-testid="drilldown-breakout">Breakout by ..</span>
 			</ContextMenu.Item>
+			{contextLinks.map((link) => (
+				<ContextMenu.Item
+					key={link.id}
+					icon={<Link size={16} />}
+					onClick={(): void => {
+						openInNewTab(link.url);
+						onClose();
+					}}
+				>
+					<span data-testid="drilldown-context-link">{link.label}</span>
+				</ContextMenu.Item>
+			))}
 		</>
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import {
+	Braces,
 	ChartBar,
 	DraftingCompass,
 	Link,
@@ -10,6 +11,7 @@ import type { DashboardLinkDTO } from 'api/generated/services/sigNoz.schemas';
 import { getAggregateColumnHeader } from 'container/QueryTable/Drilldown/drilldownUtils';
 import ContextMenu from 'periscope/components/ContextMenu';
 import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
+import { getDataLinks } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getDataLinks';
 import { resolvePanelContextLinks } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 import { openInNewTab } from 'utils/navigation';
@@ -26,9 +28,13 @@ interface DrilldownAggregateMenuProps {
 	isResolving?: boolean;
 	/** Panel's context links; resolved against the clicked point + variables here. */
 	links: DashboardLinkDTO[] | undefined;
+	/** Whether the clicked point exposes group-by fields to bind to dashboard variables. */
+	canSetDashboardVariables: boolean;
 	onViewLogs: () => void;
 	onViewTraces: () => void;
 	onBreakout: () => void;
+	/** Open the Dashboard Variables submenu (set/unset/create from the clicked value). */
+	onSetDashboardVariables: () => void;
 	/** Close the popover (context-link clicks). */
 	onClose: () => void;
 }
@@ -43,9 +49,11 @@ function DrilldownAggregateMenu({
 	query,
 	isResolving = false,
 	links,
+	canSetDashboardVariables,
 	onViewLogs,
 	onViewTraces,
 	onBreakout,
+	onSetDashboardVariables,
 	onClose,
 }: DrilldownAggregateMenuProps): JSX.Element {
 	const aggregations = useMemo(
@@ -58,6 +66,11 @@ function DrilldownAggregateMenu({
 		() => resolvePanelContextLinks(links, processedVariables),
 		[links, processedVariables],
 	);
+	// Auto links derived from the clicked point itself (e.g. "View Trace Details" for a trace_id).
+	const dataLinks = useMemo(
+		() => getDataLinks(context.filters),
+		[context.filters],
+	);
 
 	return (
 		<>
@@ -67,6 +80,20 @@ function DrilldownAggregateMenu({
 					{context.label || aggregations}
 				</div>
 			</ContextMenu.Header>
+			{canSetDashboardVariables && (
+				<ContextMenu.Item
+					icon={
+						<span style={{ color: context.seriesColor }}>
+							<Braces size={16} />
+						</span>
+					}
+					onClick={onSetDashboardVariables}
+				>
+					<span data-testid="drilldown-dashboard-variables">
+						Dashboard Variables
+					</span>
+				</ContextMenu.Item>
+			)}
 			<ContextMenu.Item
 				icon={
 					isResolving ? (
@@ -107,10 +134,22 @@ function DrilldownAggregateMenu({
 			>
 				<span data-testid="drilldown-breakout">Breakout by ..</span>
 			</ContextMenu.Item>
+			{dataLinks.map((link) => (
+				<ContextMenu.Item
+					key={link.id}
+					icon={<Link size={16} color={context.seriesColor} />}
+					onClick={(): void => {
+						openInNewTab(link.url);
+						onClose();
+					}}
+				>
+					<span data-testid="drilldown-data-link">{link.label}</span>
+				</ContextMenu.Item>
+			))}
 			{contextLinks.map((link) => (
 				<ContextMenu.Item
 					key={link.id}
-					icon={<Link size={16} />}
+					icon={<Link size={16} color={context.seriesColor} />}
 					onClick={(): void => {
 						openInNewTab(link.url);
 						onClose();

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownDashboardVariablesMenu.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownDashboardVariablesMenu.module.scss
@@ -1,0 +1,9 @@
+.header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.backArrow {
+	cursor: pointer;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownDashboardVariablesMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownDashboardVariablesMenu.tsx
@@ -1,0 +1,79 @@
+import { ArrowLeft, Plus, Settings, X } from '@signozhq/icons';
+import OverlayScrollbar from 'components/OverlayScrollbar/OverlayScrollbar';
+import {
+	type DrilldownVariableAction,
+	DrilldownVariableActionKind,
+} from 'pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables';
+import ContextMenu from 'periscope/components/ContextMenu';
+
+import styles from './DrilldownDashboardVariablesMenu.module.scss';
+
+interface DrilldownDashboardVariablesMenuProps {
+	/** Resolved entries from `useDrilldownDashboardVariables`. */
+	actions: DrilldownVariableAction[];
+	/** Return to the base aggregate menu. */
+	onBack: () => void;
+}
+
+const ICON_BY_KIND: Record<DrilldownVariableActionKind, JSX.Element> = {
+	[DrilldownVariableActionKind.Set]: <Settings size={16} />,
+	[DrilldownVariableActionKind.Unset]: <X size={16} />,
+	[DrilldownVariableActionKind.Create]: <Plus size={16} />,
+};
+
+/**
+ * The "Dashboard Variables" drilldown submenu — renders the entries resolved by
+ * `useDrilldownDashboardVariables` (Set/Unset an existing dynamic variable, or Create one).
+ */
+function DrilldownDashboardVariablesMenu({
+	actions,
+	onBack,
+}: DrilldownDashboardVariablesMenuProps): JSX.Element {
+	return (
+		<>
+			<ContextMenu.Header>
+				<div className={styles.header}>
+					<ArrowLeft
+						size={14}
+						className={styles.backArrow}
+						onClick={onBack}
+						data-testid="drilldown-var-back"
+					/>
+					<span>Dashboard Variables</span>
+				</div>
+			</ContextMenu.Header>
+			<OverlayScrollbar
+				style={{ maxHeight: '200px' }}
+				options={{ overflow: { x: 'hidden' } }}
+			>
+				<>
+					{actions.map(({ fieldName, fieldValue, kind, onClick }) => (
+						<ContextMenu.Item
+							key={fieldName}
+							icon={ICON_BY_KIND[kind]}
+							onClick={onClick}
+						>
+							{kind === DrilldownVariableActionKind.Unset && (
+								<span data-testid="drilldown-var-unset">
+									Unset <strong>${fieldName}</strong>
+								</span>
+							)}
+							{kind === DrilldownVariableActionKind.Set && (
+								<span data-testid="drilldown-var-set">
+									Set <strong>${fieldName}</strong> to <strong>{fieldValue}</strong>
+								</span>
+							)}
+							{kind === DrilldownVariableActionKind.Create && (
+								<span data-testid="drilldown-var-create">
+									Create var <strong>${fieldName}</strong>:<strong>{fieldValue}</strong>
+								</span>
+							)}
+						</ContextMenu.Item>
+					))}
+				</>
+			</OverlayScrollbar>
+		</>
+	);
+}
+
+export default DrilldownDashboardVariablesMenu;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/DrilldownDashboardVariablesMenu.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/DrilldownDashboardVariablesMenu.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import DrilldownDashboardVariablesMenu from '../DrilldownMenu/DrilldownDashboardVariablesMenu';
+import {
+	type DrilldownVariableAction,
+	DrilldownVariableActionKind,
+} from '../hooks/useDrilldownDashboardVariables';
+
+jest.mock('components/OverlayScrollbar/OverlayScrollbar', () => ({
+	__esModule: true,
+	default: ({ children }: { children: React.ReactNode }): JSX.Element => (
+		<div>{children}</div>
+	),
+}));
+
+function action(
+	overrides: Partial<DrilldownVariableAction> = {},
+): DrilldownVariableAction {
+	return {
+		fieldName: 'service.name',
+		fieldValue: 'frontend',
+		kind: DrilldownVariableActionKind.Set,
+		onClick: jest.fn(),
+		...overrides,
+	};
+}
+
+describe('DrilldownDashboardVariablesMenu', () => {
+	it('renders each kind with its own label and fires its onClick', async () => {
+		const onSet = jest.fn();
+		const onUnset = jest.fn();
+		const onCreate = jest.fn();
+		render(
+			<DrilldownDashboardVariablesMenu
+				onBack={jest.fn()}
+				actions={[
+					action({
+						fieldName: 'a',
+						kind: DrilldownVariableActionKind.Set,
+						onClick: onSet,
+					}),
+					action({
+						fieldName: 'b',
+						kind: DrilldownVariableActionKind.Unset,
+						onClick: onUnset,
+					}),
+					action({
+						fieldName: 'c',
+						kind: DrilldownVariableActionKind.Create,
+						onClick: onCreate,
+					}),
+				]}
+			/>,
+		);
+
+		expect(screen.getByTestId('drilldown-var-set')).toBeInTheDocument();
+		expect(screen.getByTestId('drilldown-var-unset')).toBeInTheDocument();
+		expect(screen.getByTestId('drilldown-var-create')).toBeInTheDocument();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-set'));
+		expect(onSet).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns to the base menu when the back arrow is clicked', async () => {
+		const onBack = jest.fn();
+		render(
+			<DrilldownDashboardVariablesMenu onBack={onBack} actions={[action()]} />,
+		);
+
+		await userEvent.click(screen.getByTestId('drilldown-var-back'));
+		expect(onBack).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
@@ -13,6 +13,13 @@ const mockOpenViewWithQuery = jest.fn();
 const mockNavigate = jest.fn();
 const mockGetBuilderQueries = jest.fn();
 let mockResolved = { resolvedQuery: 'RESOLVED_QUERY', isResolving: false };
+let mockDashboardVariables: {
+	hasFieldVariables: boolean;
+	actions: unknown[];
+} = {
+	hasFieldVariables: true,
+	actions: [],
+};
 
 // Boundaries tested elsewhere / needing external context — mocked so this suite isolates
 // useDrilldown's orchestration (gating, which menu shows, the View-modal handoff).
@@ -32,6 +39,17 @@ jest.mock('../hooks/useDrilldownBreakout', () => ({
 jest.mock('../DrilldownMenu/DrilldownBreakoutMenu', () => ({
 	__esModule: true,
 	default: (): JSX.Element => <div data-testid="breakout-submenu" />,
+}));
+jest.mock('../hooks/useDrilldownDashboardVariables', () => ({
+	useDrilldownDashboardVariables: (): unknown => mockDashboardVariables,
+}));
+jest.mock('../DrilldownMenu/DrilldownDashboardVariablesMenu', () => ({
+	__esModule: true,
+	default: (): JSX.Element => <div data-testid="dashboard-variables-submenu" />,
+}));
+// Context-link variable map (redux global time + store) — out of scope for this suite.
+jest.mock('../hooks/useDrilldownContextVariables', () => ({
+	useDrilldownContextVariables: (): unknown => ({}),
 }));
 jest.mock('container/QueryTable/Drilldown/useBaseDrilldownNavigate', () => ({
 	__esModule: true,
@@ -116,6 +134,10 @@ describe('useDrilldown', () => {
 		jest.clearAllMocks();
 		mockGetBuilderQueries.mockReturnValue([{ name: 'A' }]);
 		mockResolved = { resolvedQuery: 'RESOLVED_QUERY', isResolving: false };
+		mockDashboardVariables = {
+			hasFieldVariables: true,
+			actions: [],
+		};
 	});
 
 	describe('enableDrillDown', () => {
@@ -200,6 +222,56 @@ describe('useDrilldown', () => {
 			view.rerender(<div>{result.current.contextMenuProps.items}</div>);
 
 			expect(screen.getByTestId('breakout-submenu')).toBeInTheDocument();
+		});
+
+		it('shows the Dashboard Variables entry when the click has group-by fields', () => {
+			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
+			act(() =>
+				result.current.onPanelClick({
+					coordinates: { x: 1, y: 1 },
+					context: aggregateContext,
+				}),
+			);
+			render(<div>{result.current.contextMenuProps.items}</div>);
+
+			expect(
+				screen.getByTestId('drilldown-dashboard-variables'),
+			).toBeInTheDocument();
+		});
+
+		it('hides the Dashboard Variables entry when there are no group-by fields', () => {
+			mockDashboardVariables = { hasFieldVariables: false, actions: [] };
+			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
+			act(() =>
+				result.current.onPanelClick({
+					coordinates: { x: 1, y: 1 },
+					context: aggregateContext,
+				}),
+			);
+			render(<div>{result.current.contextMenuProps.items}</div>);
+
+			expect(
+				screen.queryByTestId('drilldown-dashboard-variables'),
+			).not.toBeInTheDocument();
+		});
+
+		it('swaps to the Dashboard Variables submenu when clicked', async () => {
+			const user = userEvent.setup();
+			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
+			act(() =>
+				result.current.onPanelClick({
+					coordinates: { x: 1, y: 1 },
+					context: aggregateContext,
+				}),
+			);
+			const view = render(<div>{result.current.contextMenuProps.items}</div>);
+
+			await user.click(screen.getByTestId('drilldown-dashboard-variables'));
+			view.rerender(<div>{result.current.contextMenuProps.items}</div>);
+
+			expect(
+				screen.getByTestId('dashboard-variables-submenu'),
+			).toBeInTheDocument();
 		});
 	});
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldownDashboardVariables.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldownDashboardVariables.test.tsx
@@ -1,0 +1,213 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
+
+import DrilldownDashboardVariablesMenu from '../DrilldownMenu/DrilldownDashboardVariablesMenu';
+import { useDrilldownDashboardVariables } from '../hooks/useDrilldownDashboardVariables';
+
+// Fake dashboard variables + runtime selection, mutated per test. `dtoToFormModel` is mocked to
+// derive `type` from the plugin kind (like the real adapter), so these DTOs carry the plugin
+// discriminant plus the flat form-model fields the hook reads.
+let mockVariables: Array<{
+	name: string;
+	dynamicAttribute?: string;
+	multiSelect?: boolean;
+	spec: { plugin: { kind: string } };
+}> = [];
+let mockSelectionMap: Record<string, { value: unknown; allSelected: boolean }> =
+	{};
+
+const mockSetVariableValue = jest.fn();
+const mockSetUrlValues = jest.fn();
+const mockPatchAsync = jest.fn().mockResolvedValue(undefined);
+
+const DYNAMIC_KIND = 'signoz/DynamicVariable';
+const QUERY_KIND = 'signoz/QueryVariable';
+
+jest.mock('api/generated/services/dashboard', () => ({
+	useGetDashboardV2: (): unknown => ({
+		data: { data: { spec: { variables: mockVariables } } },
+	}),
+}));
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/hooks/useOptimisticPatch',
+	() => ({
+		useOptimisticPatch: (): unknown => ({ patchAsync: mockPatchAsync }),
+	}),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore',
+	() => ({
+		useDashboardStore: (selector: (state: unknown) => unknown): unknown =>
+			selector({
+				dashboardId: 'd1',
+				variableValues: { d1: mockSelectionMap },
+				setVariableValue: mockSetVariableValue,
+			}),
+	}),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters',
+	() => ({
+		dtoToFormModel: (dto: {
+			spec?: { plugin?: { kind?: string } };
+		}): unknown => ({
+			...dto,
+			type:
+				dto.spec?.plugin?.kind === 'signoz/DynamicVariable' ? 'DYNAMIC' : 'QUERY',
+		}),
+		formModelToDto: (model: { name: string }): unknown => ({ dto: model.name }),
+	}),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel',
+	() => ({
+		emptyVariableFormModel: (): unknown => ({}),
+		DYNAMIC_SIGNAL_ALL: 'all',
+	}),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection',
+	() => ({
+		ALL_SELECTED: '__ALL__',
+		variablesUrlParser: { withOptions: (): unknown => ({}) },
+	}),
+);
+jest.mock('nuqs', () => ({
+	useQueryState: (): unknown => [null, mockSetUrlValues],
+}));
+jest.mock('components/OverlayScrollbar/OverlayScrollbar', () => ({
+	__esModule: true,
+	default: ({ children }: { children: React.ReactNode }): JSX.Element => (
+		<div>{children}</div>
+	),
+}));
+jest.mock('@signozhq/ui/sonner', () => ({
+	toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const filters: FilterData[] = [
+	{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
+];
+
+function renderItems(): void {
+	const { result } = renderHook(() =>
+		useDrilldownDashboardVariables({
+			filters,
+			signal: TelemetrytypesSignalDTO.metrics,
+			onClose: jest.fn(),
+		}),
+	);
+	render(
+		<DrilldownDashboardVariablesMenu
+			actions={result.current.actions}
+			onBack={jest.fn()}
+		/>,
+	);
+}
+
+describe('useDrilldownDashboardVariables', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockVariables = [];
+		mockSelectionMap = {};
+	});
+
+	it('hasFieldVariables reflects the clicked point group-by fields', () => {
+		const withFields = renderHook(() =>
+			useDrilldownDashboardVariables({ filters, onClose: jest.fn() }),
+		);
+		expect(withFields.result.current.hasFieldVariables).toBe(true);
+
+		const noFields = renderHook(() =>
+			useDrilldownDashboardVariables({ filters: [], onClose: jest.fn() }),
+		);
+		expect(noFields.result.current.hasFieldVariables).toBe(false);
+	});
+
+	it('offers Set — writing an array for a multi-select var so the selector shows it', async () => {
+		mockVariables = [
+			{
+				name: 'svc',
+				dynamicAttribute: 'service.name',
+				multiSelect: true,
+				spec: { plugin: { kind: DYNAMIC_KIND } },
+			},
+		];
+		mockSelectionMap = { svc: { value: ['backend'], allSelected: false } };
+		renderItems();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-set'));
+		expect(mockSetVariableValue).toHaveBeenCalledWith('d1', 'svc', {
+			value: ['frontend'],
+			allSelected: false,
+		});
+	});
+
+	it('offers Set — writing a scalar for a single-select var', async () => {
+		mockVariables = [
+			{
+				name: 'svc',
+				dynamicAttribute: 'service.name',
+				multiSelect: false,
+				spec: { plugin: { kind: DYNAMIC_KIND } },
+			},
+		];
+		mockSelectionMap = { svc: { value: 'backend', allSelected: false } };
+		renderItems();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-set'));
+		expect(mockSetVariableValue).toHaveBeenCalledWith('d1', 'svc', {
+			value: 'frontend',
+			allSelected: false,
+		});
+	});
+
+	it('offers Unset when the matching dynamic var already holds the clicked value', async () => {
+		mockVariables = [
+			{
+				name: 'svc',
+				dynamicAttribute: 'service.name',
+				multiSelect: true,
+				spec: { plugin: { kind: DYNAMIC_KIND } },
+			},
+		];
+		mockSelectionMap = { svc: { value: ['frontend'], allSelected: false } };
+		renderItems();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-unset'));
+		expect(mockSetVariableValue).toHaveBeenCalledWith('d1', 'svc', {
+			value: [],
+			allSelected: false,
+		});
+	});
+
+	it('offers Create and persists a new dynamic variable when none matches', async () => {
+		mockVariables = [];
+		renderItems();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-create'));
+		// Persisted to the spec via the optimistic patch...
+		expect(mockPatchAsync).toHaveBeenCalledTimes(1);
+		// ...and seeded (as an array — the created var is multi-select) with the clicked value.
+		expect(mockSetVariableValue).toHaveBeenCalledWith('d1', 'service.name', {
+			value: ['frontend'],
+			allSelected: false,
+		});
+	});
+
+	it('ignores a non-dynamic variable with the same attribute (still offers Create)', () => {
+		mockVariables = [
+			{
+				name: 'svc',
+				dynamicAttribute: 'service.name',
+				spec: { plugin: { kind: QUERY_KIND } },
+			},
+		];
+		renderItems();
+
+		expect(screen.getByTestId('drilldown-var-create')).toBeInTheDocument();
+		expect(screen.queryByTestId('drilldown-var-set')).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -182,9 +182,11 @@ export function useDrilldown(
 				context={context}
 				query={v1Query}
 				isResolving={isResolving}
+				links={panel.spec.links}
 				onViewLogs={(): void => navigate('view_logs')}
 				onViewTraces={(): void => navigate('view_traces')}
 				onBreakout={openBreakout}
+				onClose={handleClose}
 			/>
 		);
 	}, [
@@ -197,8 +199,10 @@ export function useDrilldown(
 		context,
 		v1Query,
 		isResolving,
+		panel.spec.links,
 		navigate,
 		openBreakout,
+		handleClose,
 	]);
 
 	return {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
 import useBaseDrilldownNavigate from 'container/QueryTable/Drilldown/useBaseDrilldownNavigate';
 import type {
 	Coordinates,
@@ -10,10 +11,7 @@ import type {
 	DrilldownClickPayload,
 	DrilldownContext,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
-import {
-	PANEL_KIND_TO_PANEL_TYPE,
-	type PanelKind,
-} from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
+import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import { getPanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/registry';
 import { buildAggregateData } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/buildAggregateData';
 import { getBuilderQueries } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries';
@@ -21,9 +19,11 @@ import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/per
 
 import DrilldownAggregateMenu from '../DrilldownMenu/DrilldownAggregateMenu';
 import DrilldownBreakoutMenu from '../DrilldownMenu/DrilldownBreakoutMenu';
+import DrilldownDashboardVariablesMenu from '../DrilldownMenu/DrilldownDashboardVariablesMenu';
 import DrilldownFilterMenu from '../DrilldownMenu/DrilldownFilterMenu';
 import { useDrilldownBreakout } from './useDrilldownBreakout';
 import { useDrilldownCoordinates } from './useDrilldownCoordinates';
+import { useDrilldownDashboardVariables } from './useDrilldownDashboardVariables';
 import { useDrilldownFilter } from './useDrilldownFilter';
 import { useResolvedDrilldownQuery } from './useResolvedDrilldownQuery';
 import { useViewPanel } from './useViewPanel';
@@ -32,7 +32,11 @@ import { useViewPanel } from './useViewPanel';
 enum DrilldownSubMenu {
 	Base = 'base',
 	Breakout = 'breakout',
+	DashboardVariables = 'dashboardVariables',
 }
+
+/** Stable empty-filters ref so the dashboard-variables hook doesn't re-run on every no-click render. */
+const EMPTY_FILTERS: FilterData[] = [];
 
 /** Props the panel shell spreads onto `<ContextMenu>`. */
 export interface DrilldownContextMenuProps {
@@ -58,11 +62,9 @@ export function useDrilldown(
 	panel: DashboardtypesPanelDTO,
 	panelId: string,
 ): UseDrilldownResult {
-	const kind = panel.spec.plugin.kind as PanelKind;
+	const kind = panel.spec.plugin.kind;
 	const panelType = PANEL_KIND_TO_PANEL_TYPE[kind];
-	// Stable ref so the conversions below don't re-run every render (the `?? []` fallback would
-	// otherwise be a fresh array each time).
-	const queries = useMemo(() => panel.spec.queries ?? [], [panel.spec.queries]);
+	const queries = panel.spec.queries;
 
 	// Kind must opt in via its capability AND have a builder query to drill into.
 	const enableDrillDown = useMemo(
@@ -102,6 +104,10 @@ export function useDrilldown(
 		(): void => setSubMenu(DrilldownSubMenu.Base),
 		[],
 	);
+	const openDashboardVariables = useCallback(
+		(): void => setSubMenu(DrilldownSubMenu.DashboardVariables),
+		[],
+	);
 
 	const onPanelClick = useCallback(
 		(payload: DrilldownClickPayload): void => {
@@ -136,6 +142,12 @@ export function useDrilldown(
 		onClose: handleClose,
 	});
 
+	const dashboardVariables = useDrilldownDashboardVariables({
+		filters: context?.filters ?? EMPTY_FILTERS,
+		signal: context?.signal,
+		onClose: handleClose,
+	});
+
 	// The aggregate menu (View in Logs/Traces) shows for a non-group click on the base menu; the
 	// group click routes to filter-by-value instead. Only that menu resolves variables —
 	// filter/breakout open the View modal, which resolves at query-run time.
@@ -165,6 +177,14 @@ export function useDrilldown(
 				/>
 			) : null;
 		}
+		if (subMenu === DrilldownSubMenu.DashboardVariables) {
+			return (
+				<DrilldownDashboardVariablesMenu
+					actions={dashboardVariables.actions}
+					onBack={backToBase}
+				/>
+			);
+		}
 		if (filter.isGroupColumnClick && context?.clickedKey) {
 			return (
 				<DrilldownFilterMenu
@@ -183,9 +203,11 @@ export function useDrilldown(
 				query={v1Query}
 				isResolving={isResolving}
 				links={panel.spec.links}
+				canSetDashboardVariables={dashboardVariables.hasFieldVariables}
 				onViewLogs={(): void => navigate('view_logs')}
 				onViewTraces={(): void => navigate('view_traces')}
 				onBreakout={openBreakout}
+				onSetDashboardVariables={openDashboardVariables}
 				onClose={handleClose}
 			/>
 		);
@@ -193,7 +215,8 @@ export function useDrilldown(
 		subMenu,
 		breakout.queryData,
 		breakout.onBreakout,
-		backToBase,
+		dashboardVariables.actions,
+		dashboardVariables.hasFieldVariables,
 		filter.isGroupColumnClick,
 		filter.onFilter,
 		context,
@@ -202,6 +225,8 @@ export function useDrilldown(
 		panel.spec.links,
 		navigate,
 		openBreakout,
+		openDashboardVariables,
+		backToBase,
 		handleClose,
 	]);
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownContextVariables.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownContextVariables.ts
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports -- context links resolve global-time variables off redux (V1 parity)
+import { useSelector } from 'react-redux';
+import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
+import { useDashboardStore } from 'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore';
+import type { AppState } from 'store/reducers';
+import type { GlobalReducer } from 'types/reducer/globalTime';
+
+/**
+ * Builds the variable map that resolves context-link templates, mirroring V1's `useContextVariables`
+ * but sourced from V2 state: dashboard variable selections (by name), the global time window
+ * (`timestamp_start`/`timestamp_end`, ms), and the clicked point's field values (`_`-prefixed, the
+ * V1 convention that keeps them from clashing with dashboard variable names).
+ */
+export function useDrilldownContextVariables(
+	context: DrilldownContext | null,
+): Record<string, string> {
+	// dashboardId from the store's edit context (set once by DashboardContainer), the same
+	// source the rest of V2 uses — not react-router params.
+	const dashboardId = useDashboardStore((state) => state.dashboardId);
+	// Select the stable top-level map (not `state.variableValues[id] ?? {}`, whose fresh `{}` each
+	// render makes useSyncExternalStore loop); index by dashboard inside the memo.
+	const variableValuesByDashboard = useDashboardStore(
+		(state) => state.variableValues,
+	);
+	const globalTime = useSelector<AppState, GlobalReducer>(
+		(state) => state.globalTime,
+	);
+
+	return useMemo(() => {
+		const result: Record<string, string> = {};
+
+		const variableValues = variableValuesByDashboard[dashboardId] ?? {};
+		Object.entries(variableValues).forEach(([name, selection]) => {
+			const { value } = selection;
+			if (value == null) {
+				return;
+			}
+			result[name] = Array.isArray(value) ? value.join(', ') : String(value);
+		});
+
+		// Global time window, ns → ms (V1 parity).
+		result.timestamp_start = String(Math.floor(globalTime.minTime / 1e6));
+		result.timestamp_end = String(Math.floor(globalTime.maxTime / 1e6));
+
+		context?.filters.forEach(({ filterKey, filterValue }) => {
+			result[`_${filterKey}`] = String(filterValue);
+		});
+
+		return result;
+	}, [
+		variableValuesByDashboard,
+		dashboardId,
+		globalTime.minTime,
+		globalTime.maxTime,
+		context,
+	]);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
@@ -1,0 +1,191 @@
+import { useCallback, useMemo } from 'react';
+import { toast } from '@signozhq/ui/sonner';
+import type { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
+import { useQueryState } from 'nuqs';
+import {
+	dtoToFormModel,
+	formModelToDto,
+} from 'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters';
+import {
+	DYNAMIC_SIGNAL_ALL,
+	emptyVariableFormModel,
+	type VariableFormModel,
+} from 'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel';
+import { buildVariablesPatch } from 'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variablePatchOps';
+import { useDashboardFetchRequired } from 'pages/DashboardPageV2/DashboardContainer/hooks/useDashboardFetchRequired';
+import { useOptimisticPatch } from 'pages/DashboardPageV2/DashboardContainer/hooks/useOptimisticPatch';
+import { selectVariableValues } from 'pages/DashboardPageV2/DashboardContainer/store/slices/variableSelectionSlice';
+import { useDashboardStore } from 'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore';
+import type { VariableSelection } from 'pages/DashboardPageV2/DashboardContainer/VariablesBar/selectionTypes';
+import {
+	ALL_SELECTED,
+	variablesUrlParser,
+} from 'pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection';
+
+interface UseDrilldownDashboardVariablesArgs {
+	/** Group-by field filters from the clicked point (empty when the click has no group-by). */
+	filters: FilterData[];
+	/** Clicked query's telemetry signal — seeds a created variable's `dynamicSignal`. */
+	signal?: TelemetrytypesSignalDTO;
+	/** Close the popover after an action. */
+	onClose: () => void;
+}
+
+/** Set/Unset a matching dynamic variable's value, or Create one when none matches. */
+export enum DrilldownVariableActionKind {
+	Set = 'set',
+	Unset = 'unset',
+	Create = 'create',
+}
+
+/** A resolved "Dashboard Variables" menu entry; the caller renders it. */
+export interface DrilldownVariableAction {
+	fieldName: string;
+	fieldValue: string | number;
+	kind: DrilldownVariableActionKind;
+	/** Applies the action and closes the popover. */
+	onClick: () => void;
+}
+
+export interface UseDrilldownDashboardVariablesApi {
+	/** Whether the clicked point exposes any field to bind to a variable (gates the base-menu entry). */
+	hasFieldVariables: boolean;
+	/** Resolved menu entries, one per group-by field on the clicked point. */
+	actions: DrilldownVariableAction[];
+}
+
+/**
+ * "Dashboard Variables" submenu logic (V1 `useDashboardVarConfig` parity). Set/Unset are runtime-only
+ * (store + URL — V2 selections don't persist); Create is the one path that patches `spec.variables`.
+ */
+export function useDrilldownDashboardVariables({
+	filters,
+	signal,
+	onClose,
+}: UseDrilldownDashboardVariablesArgs): UseDrilldownDashboardVariablesApi {
+	const dashboardId = useDashboardStore((state) => state.dashboardId);
+	const { variables } = useDashboardFetchRequired();
+
+	const dynamicVariables = useMemo(
+		() => variables.map(dtoToFormModel).filter((v) => v.type === 'DYNAMIC'),
+		[variables],
+	);
+	const existingNames = useMemo(
+		() => new Set(variables.map((v) => dtoToFormModel(v).name)),
+		[variables],
+	);
+
+	const selection = useDashboardStore(selectVariableValues(dashboardId));
+	const setVariableValue = useDashboardStore((state) => state.setVariableValue);
+	const [, setUrlValues] = useQueryState(
+		'variables',
+		variablesUrlParser.withOptions({ history: 'replace' }),
+	);
+	const { patchAsync } = useOptimisticPatch();
+
+	const fieldVariables = useMemo<[string, string | number][]>(
+		() =>
+			filters
+				.filter(
+					(f) => f.filterKey && f.filterValue !== undefined && f.filterValue !== '',
+				)
+				.map((f) => [f.filterKey, f.filterValue]),
+		[filters],
+	);
+
+	// Runtime-only write (store + URL), never the spec — mirrors VariablesBar's setSelection.
+	const setSelection = useCallback(
+		(name: string, next: VariableSelection): void => {
+			setVariableValue(dashboardId, name, next);
+			void setUrlValues((prev) => ({
+				...(prev ?? {}),
+				[name]: next.allSelected ? ALL_SELECTED : next.value,
+			}));
+		},
+		[dashboardId, setVariableValue, setUrlValues],
+	);
+
+	const handleCreate = useCallback(
+		async (fieldName: string, fieldValue: string | number): Promise<void> => {
+			if (existingNames.has(fieldName)) {
+				toast.error(`Variable "${fieldName}" already exists`);
+				return;
+			}
+			const model: VariableFormModel = {
+				...emptyVariableFormModel(),
+				name: fieldName,
+				description: `Created from panel drilldown (field: ${fieldName})`,
+				type: 'DYNAMIC',
+				multiSelect: true,
+				dynamicAttribute: fieldName,
+				dynamicSignal: signal ?? DYNAMIC_SIGNAL_ALL,
+			};
+			try {
+				await patchAsync(
+					buildVariablesPatch([...variables, formModelToDto(model)]),
+				);
+				// Multi-select var → seed the value as an array (the selector renders scalars as empty).
+				setSelection(fieldName, { value: [fieldValue], allSelected: false });
+				toast.success(`Created variable "${fieldName}"`);
+			} catch {
+				toast.error('Failed to create variable');
+			}
+			onClose();
+		},
+		[existingNames, signal, variables, patchAsync, setSelection, onClose],
+	);
+
+	const actions = useMemo<DrilldownVariableAction[]>(
+		() =>
+			fieldVariables.map(([fieldName, fieldValue]) => {
+				const existing = dynamicVariables.find(
+					(v) => v.dynamicAttribute === fieldName,
+				);
+				if (!existing) {
+					return {
+						fieldName,
+						fieldValue,
+						kind: DrilldownVariableActionKind.Create,
+						onClick: (): void => {
+							void handleCreate(fieldName, fieldValue);
+						},
+					};
+				}
+
+				const current = selection[existing.name]?.value;
+				const isSame = Array.isArray(current)
+					? current.length === 1 && current[0] === fieldValue
+					: current === fieldValue;
+
+				// Multi-select values must be arrays (a scalar renders as empty in the selector).
+				const cleared = existing.multiSelect ? [] : '';
+				const assigned = existing.multiSelect ? [fieldValue] : fieldValue;
+
+				return {
+					fieldName,
+					fieldValue,
+					kind: isSame
+						? DrilldownVariableActionKind.Unset
+						: DrilldownVariableActionKind.Set,
+					onClick: (): void => {
+						setSelection(existing.name, {
+							value: isSame ? cleared : assigned,
+							allSelected: false,
+						});
+						onClose();
+					},
+				};
+			}),
+		[
+			fieldVariables,
+			dynamicVariables,
+			selection,
+			setSelection,
+			handleCreate,
+			onClose,
+		],
+	);
+
+	return { hasFieldVariables: fieldVariables.length > 0, actions };
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
@@ -20,11 +20,12 @@ import {
 export const ALL_SELECTED = '__ALL__';
 
 /** `?variables=` holds `{ [name]: value }` (ALL encoded as the sentinel). */
-const variablesUrlParser = parseAsJson<Record<string, SelectedVariableValue>>(
-	(v) =>
-		typeof v === 'object' && v !== null
-			? (v as Record<string, SelectedVariableValue>)
-			: null,
+export const variablesUrlParser = parseAsJson<
+	Record<string, SelectedVariableValue>
+>((v) =>
+	typeof v === 'object' && v !== null
+		? (v as Record<string, SelectedVariableValue>)
+		: null,
 );
 
 function defaultSelection(model: VariableFormModel): VariableSelection {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
@@ -38,22 +38,14 @@ function DashboardContainer({
 		user.role,
 	);
 
-	// Publish edit context to the store so hooks/components read it from there
-	// instead of receiving dashboardId/isEditable/refetch as props down the tree.
+	// Seed during render (not an effect) so the first Panel render already sees the id —
+	// useDashboardFetchRequired throws on a missing id. setEditContext self-guards.
 	const setEditContext = useDashboardStore((s) => s.setEditContext);
-	useEffect(() => {
-		setEditContext({
-			dashboardId: dashboard.id,
-			isEditable: !dashboard.locked && editDashboardPermission,
-			refetch,
-		});
-	}, [
-		dashboard.id,
-		dashboard.locked,
-		editDashboardPermission,
+	setEditContext({
+		dashboardId: dashboard.id,
+		isEditable: !dashboard.locked && editDashboardPermission,
 		refetch,
-		setEditContext,
-	]);
+	});
 
 	// Resolve the variable selection into the V5 query payload and publish it to
 	// the store, so each panel's query substitutes the bar's selected values.

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/editContextSlice.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/editContextSlice.ts
@@ -24,11 +24,20 @@ export const createEditContextSlice: StateCreator<
 	[['zustand/persist', unknown]],
 	[],
 	EditContextSlice
-> = (set) => ({
+> = (set, get) => ({
 	dashboardId: '',
 	isEditable: false,
 	refetch: (): void => undefined,
+	// Idempotent (no-op when unchanged) so it's safe to call during render.
 	setEditContext: (ctx): void => {
+		const { dashboardId, isEditable, refetch } = get();
+		if (
+			dashboardId === ctx.dashboardId &&
+			isEditable === ctx.isEditable &&
+			refetch === ctx.refetch
+		) {
+			return;
+		}
 		set({
 			dashboardId: ctx.dashboardId,
 			isEditable: ctx.isEditable,


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Renders a panel's user-defined **context links** in the V2 drill-down aggregate menu (V1 parity). Each link's label/URL template is resolved against the clicked point's field values, the dashboard-variable selections, and the global time window, then opens in a new tab.

**Approach:** `resolvePanelContextLinks` adapts each `DashboardLinkDTO` to the shared V1 `processContextLinks` resolver; `useDrilldownContextVariables` builds the V2-native variable map (dashboard vars from the Zustand store, global time, and `_`-prefixed clicked field values). Resolution lives inside `DrilldownAggregateMenu`, so it runs only while the menu is open.

> Dashboard-variable set / unset / create from the menu is a **follow-up** on this stack (#11964) — deferred because V2's variable model is runtime-only, unlike V1's persisted one.

#### Screenshots / Screen Recordings (if applicable)
> _To be added by author — recording of a panel with context links → resolved links in the drill-down menu._

#### Issues closed by this PR
> N/A

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> N/A — feature, not a bug fix.

---

### 🧪 Testing Strategy

- **Tests added/updated:** `resolvePanelContextLinks` unit tests (variable substitution, drop-without-URL, `renderVariables: false`). `tsgo --noEmit` clean; full V2 suite green.
- **Manual verification:** _pending (author)_.
- **Edge cases covered:** links without a URL are dropped; `renderVariables: false` keeps the raw template (no substitution).

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** adds context-link items to the V2 drill-down menu; reads dashboard-variable state + global time (read-only).
- **Potential regressions:** minimal — additive menu items; `useDrilldownContextVariables` selects the stable store map (avoids the `getSnapshot should be cached` loop).
- **Rollback plan:** revert the PR; the menu loses context links, base drill-down + breakout intact.

---

### 📝 Changelog
> V2 dashboards are behind a feature flag (not yet GA) — this entry applies when V2 ships.

| Field | Value |
|------|-------|
| Deployment Type | OSS / Cloud / Enterprise |
| Change Type | Feature |
| Description | Panel context links appear in the V2 dashboard drill-down menu, with variables resolved. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested _(pending — author)_
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Part of the panel drill-down **stack** — review/merge bottom-up: **#11895** (base) → `…-drilldown-filter-by-value` → **#11896** (breakout) → **this PR (#11897)** → **#11964** (dashboard variables + trace link).

Targets `feat/dashboards-v2-drilldown-breakout`, **not** `main`. The diff is the context-link layer only (`resolvePanelContextLinks`, `useDrilldownContextVariables`, the rendering in `DrilldownAggregateMenu`).