### PR TITLE
fix(query-service): correct error type and prevent double response on PromQL timeout/cancel

### DIFF
--- a/pkg/prometheus/label.go
+++ b/pkg/prometheus/label.go
@@ -13,6 +13,10 @@ func RemoveExtraLabels(res *promql.Result, labelsToRemove ...string) error {
 		return nil
 	}
 
+	if res.Err != nil {
+		return nil
+	}
+
 	switch res.Value.(type) {
 	case promql.Vector:
 		value := res.Value.(promql.Vector)

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1202,8 +1202,10 @@ func (aH *APIHandler) queryRangeMetrics(w http.ResponseWriter, r *http.Request) 
 		switch res.Err.(type) {
 		case promql.ErrQueryCanceled:
 			RespondError(w, &model.ApiError{Typ: model.ErrorCanceled, Err: res.Err}, nil)
+			return
 		case promql.ErrQueryTimeout:
 			RespondError(w, &model.ApiError{Typ: model.ErrorTimeout, Err: res.Err}, nil)
+			return
 		}
 		RespondError(w, &model.ApiError{Typ: model.ErrorExec, Err: res.Err}, nil)
 		return
@@ -1257,10 +1259,13 @@ func (aH *APIHandler) queryMetrics(w http.ResponseWriter, r *http.Request) {
 		switch res.Err.(type) {
 		case promql.ErrQueryCanceled:
 			RespondError(w, &model.ApiError{Typ: model.ErrorCanceled, Err: res.Err}, nil)
+			return
 		case promql.ErrQueryTimeout:
 			RespondError(w, &model.ApiError{Typ: model.ErrorTimeout, Err: res.Err}, nil)
+			return
 		}
 		RespondError(w, &model.ApiError{Typ: model.ErrorExec, Err: res.Err}, nil)
+		return
 	}
 
 	responseData := &model.QueryData{


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

While testing the `timeout` parameter on `/api/v1/query_range`, I discovered two chained bugs that together produce a misleading error type and an invalid double JSON response body on PromQL timeout and cancel errors.

- **Bug 1** — `RemoveExtraLabels` in `pkg/prometheus/label.go` inspected `res.Value` without first checking `res.Err`. When a query times out, `res.Value` is `nil`, so the `default` switch branch fires and returns a fake `internal` error, completely masking `ErrQueryTimeout`.
- **Bug 2** — `queryRangeMetrics` and `queryMetrics` in `pkg/query-service/app/http_handler.go` matched timeout/cancel in a `switch` and called `RespondError` — but without a `return`, execution always fell through to a second unconditional `RespondError(ErrorExec)`, writing two JSON objects to the same HTTP response.

Bug 1 masks Bug 2 in the unpatched codebase — the double-write is only reachable once the nil-error guard is in place. Both are fixed here since they form a chain.

#### Screenshots

<img width="977" height="784" alt="Image" src="https://github.com/user-attachments/assets/99434645-467a-4811-8c43-95089c1acb36" />
**Before — wrong `errorType: "internal"` with misleading message:**

_See issue #11899_


<img width="984" height="866" alt="Image" src="https://github.com/user-attachments/assets/cdb4dbb9-7009-4d90-9643-499af2e7d181" />
**Before — double JSON response visible after Bug 1 was fixed:**

_See issue #11899_

**After both fixes — single correct response:**

_See issue #11899_

<img width="967" height="786" alt="Image" src="https://github.com/user-attachments/assets/4b14a961-7cef-412d-b06b-87456d68dd1d" />

#### Issues closed by this PR
Closes #11899

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause

**Bug 1 — `pkg/prometheus/label.go`:**

```go
// Before: no guard — res.Value is nil on timeout, hits default
switch res.Value.(type) {
...
default:
    return errors.NewInternalf(errors.CodeInternal, "rule result is not a vector or scalar or matrix")
}

// After: return early so caller handles the real error
if res.Err != nil {
    return nil
}
```

**Bug 2 — `pkg/query-service/app/http_handler.go` (same pattern in both `queryRangeMetrics` and `queryMetrics`):**

```go
// Before: no return after RespondError, falls through to ErrorExec
case promql.ErrQueryTimeout:
    RespondError(w, &model.ApiError{Typ: model.ErrorTimeout, Err: res.Err}, nil)
    // ← missing return

// After:
case promql.ErrQueryTimeout:
    RespondError(w, &model.ApiError{Typ: model.ErrorTimeout, Err: res.Err}, nil)
    return
```

#### Fix Strategy

- Added `if res.Err != nil { return nil }` in `RemoveExtraLabels` before the type switch so the caller receives the original result untouched and can handle the real error.
- Added `return` after each specific-error `RespondError` call in both handlers, stopping the fallthrough to the generic `ErrorExec` response.

---

### 🧪 Testing Strategy

- Manual verification: `GET /api/v1/query_range?query=up&start=1700000000&end=1700003600&step=60&timeout=1ms` now returns a single valid JSON with `errorType: "timeout"`.
- Edge cases covered: timeout and cancel paths in both `queryRangeMetrics` and `queryMetrics`.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: only the timeout and cancel error paths in the two PromQL handlers. Happy path is untouched.
- Potential regressions: none — the `default` `ErrorExec` branch still fires for all other unmatched error types.
- Rollback plan: revert the two `return` statements and the nil-error guard.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | PromQL timeout and cancel errors now return the correct `errorType` and a single valid JSON response instead of a misleading internal error or double JSON body |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Bug 1 hides Bug 2 in the original code — the double-write in the handler is unreachable until `RemoveExtraLabels` is fixed. Both bugs are addressed in a single PR since they are causally linked.