### PR TITLE
refactor(authz): fixes on error feedback

### DIFF
--- a/frontend/src/components/AuthZTooltip/AuthZTooltip.authz.test.tsx
+++ b/frontend/src/components/AuthZTooltip/AuthZTooltip.authz.test.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react';
-import { render, screen } from 'tests/test-utils';
+import { render, screen, userEvent, waitFor } from 'tests/test-utils';
 import { buildPermission } from 'hooks/useAuthZ/utils';
 import type { AuthZObject, BrandedPermission } from 'hooks/useAuthZ/types';
 import { useAuthZ } from 'hooks/useAuthZ/useAuthZ';
@@ -64,6 +64,29 @@ describe('AuthZTooltip — single check', () => {
 		);
 
 		expect(screen.getByRole('button', { name: 'Action' })).toBeDisabled();
+	});
+
+	it('shows formatted permission message in tooltip when denied', async () => {
+		mockUseAuthZ.mockReturnValue({
+			...noPermissions,
+			permissions: { [createPerm]: { isGranted: false } },
+		});
+
+		render(
+			<AuthZTooltip checks={[createPerm]}>
+				<TestButton />
+			</AuthZTooltip>,
+		);
+
+		const user = userEvent.setup();
+		await user.hover(screen.getByRole('button', { name: 'Action' }));
+
+		const expectedMessage =
+			'user/some-user-id is not authorized to perform create:serviceaccount:*';
+		await waitFor(() => {
+			const matches = screen.queryAllByText(expectedMessage);
+			expect(matches.length).toBeGreaterThan(0);
+		});
 	});
 
 	it('disables child while loading', () => {
@@ -141,5 +164,32 @@ describe('AuthZTooltip — multi-check (checks array)', () => {
 		expect(wrapper?.getAttribute('data-denied-permissions')).toContain(
 			attachRolePerm,
 		);
+	});
+
+	it('shows multiple formatted permissions in tooltip when both denied', async () => {
+		const sa = attachSAPerm('sa-1');
+		mockUseAuthZ.mockReturnValue({
+			...noPermissions,
+			permissions: {
+				[sa]: { isGranted: false },
+				[attachRolePerm]: { isGranted: false },
+			},
+		});
+
+		render(
+			<AuthZTooltip checks={[sa, attachRolePerm]}>
+				<TestButton />
+			</AuthZTooltip>,
+		);
+
+		const user = userEvent.setup();
+		await user.hover(screen.getByRole('button', { name: 'Action' }));
+
+		const expectedMessage =
+			'user/some-user-id is not authorized to perform attach:serviceaccount:sa-1, attach:role:*';
+		await waitFor(() => {
+			const matches = screen.queryAllByText(expectedMessage);
+			expect(matches.length).toBeGreaterThan(0);
+		});
 	});
 });

--- a/frontend/src/components/AuthZTooltip/AuthZTooltip.tsx
+++ b/frontend/src/components/AuthZTooltip/AuthZTooltip.tsx
@@ -7,7 +7,8 @@ import {
 } from '@signozhq/ui/tooltip';
 import type { BrandedPermission } from 'hooks/useAuthZ/types';
 import { useAuthZ } from 'hooks/useAuthZ/useAuthZ';
-import { parsePermission } from 'hooks/useAuthZ/utils';
+import { formatPermission } from 'hooks/useAuthZ/utils';
+import { useAppContext } from 'providers/App/App';
 import styles from './AuthZTooltip.module.scss';
 
 interface AuthZTooltipProps {
@@ -19,19 +20,14 @@ interface AuthZTooltipProps {
 
 function formatDeniedMessage(
 	denied: BrandedPermission[],
+	userId: string,
 	override?: string,
 ): string {
 	if (override) {
 		return override;
 	}
-	const labels = denied.map((p) => {
-		const { relation, object } = parsePermission(p);
-		const resource = object.split(':')[0];
-		return `${relation} ${resource}`;
-	});
-	return labels.length === 1
-		? `You don't have ${labels[0]} permission`
-		: `You don't have ${labels.join(', ')} permissions`;
+	const permissions = denied.map(formatPermission).join(', ');
+	return `user/${userId} is not authorized to perform ${permissions}`;
 }
 
 function AuthZTooltip({
@@ -40,6 +36,7 @@ function AuthZTooltip({
 	enabled = true,
 	tooltipMessage,
 }: AuthZTooltipProps): JSX.Element {
+	const { user } = useAppContext();
 	const shouldCheck = enabled && checks.length > 0;
 
 	const { permissions, isLoading } = useAuthZ(checks, { enabled: shouldCheck });
@@ -75,7 +72,7 @@ function AuthZTooltip({
 					</span>
 				</TooltipTrigger>
 				<TooltipContent className={styles.errorContent}>
-					{formatDeniedMessage(deniedPermissions, tooltipMessage)}
+					{formatDeniedMessage(deniedPermissions, user.id, tooltipMessage)}
 				</TooltipContent>
 			</TooltipRoot>
 		</TooltipProvider>

--- a/frontend/src/components/PermissionDeniedCallout/PermissionDeniedCallout.module.scss
+++ b/frontend/src/components/PermissionDeniedCallout/PermissionDeniedCallout.module.scss
@@ -2,3 +2,11 @@
 	box-sizing: border-box;
 	width: 100%;
 }
+
+.permission {
+	color: var(--l2-foreground);
+}
+
+.permissionCode {
+	font-family: monospace;
+}

--- a/frontend/src/components/PermissionDeniedCallout/PermissionDeniedCallout.test.tsx
+++ b/frontend/src/components/PermissionDeniedCallout/PermissionDeniedCallout.test.tsx
@@ -5,9 +5,8 @@ describe('PermissionDeniedCallout', () => {
 	it('renders the permission name in the callout message', () => {
 		render(<PermissionDeniedCallout permissionName="serviceaccount:attach" />);
 
-		expect(screen.getByText(/You don't have/)).toBeInTheDocument();
+		expect(screen.getByText(/is not authorized/)).toBeInTheDocument();
 		expect(screen.getByText(/serviceaccount:attach/)).toBeInTheDocument();
-		expect(screen.getByText(/permission/)).toBeInTheDocument();
 	});
 
 	it('accepts an optional className', () => {

--- a/frontend/src/components/PermissionDeniedCallout/PermissionDeniedCallout.tsx
+++ b/frontend/src/components/PermissionDeniedCallout/PermissionDeniedCallout.tsx
@@ -1,6 +1,8 @@
 import { Callout } from '@signozhq/ui/callout';
 import cx from 'classnames';
 import styles from './PermissionDeniedCallout.module.scss';
+import { useAppContext } from 'providers/App/App';
+import { Typography } from '@signozhq/ui/typography';
 
 interface PermissionDeniedCalloutProps {
 	permissionName: string;
@@ -11,6 +13,8 @@ function PermissionDeniedCallout({
 	permissionName,
 	className,
 }: PermissionDeniedCalloutProps): JSX.Element {
+	const { user } = useAppContext();
+
 	return (
 		<Callout
 			type="error"
@@ -18,7 +22,11 @@ function PermissionDeniedCallout({
 			size="small"
 			className={cx(styles.callout, className)}
 		>
-			{`You don't have ${permissionName} permission`}
+			<Typography.Text className={styles.permission}>
+				<code className={styles.permissionCode}>user/{user.id}</code> is not
+				authorized to perform{' '}
+				<code className={styles.permissionCode}>{permissionName}</code>
+			</Typography.Text>
 		</Callout>
 	);
 }

--- a/frontend/src/components/createGuardedRoute/createGuardedRoute.authz.test.tsx
+++ b/frontend/src/components/createGuardedRoute/createGuardedRoute.authz.test.tsx
@@ -267,11 +267,10 @@ describe('createGuardedRoute', () => {
 		await waitFor(() => {
 			const heading = document.querySelector('h3');
 			expect(heading).toBeInTheDocument();
-			expect(heading?.textContent).toMatch(/permission to view/i);
+			expect(heading?.textContent).toMatch(/not authorized/i);
 		});
 
-		expect(screen.getByText('update')).toBeInTheDocument();
-		expect(screen.getByText('role:123')).toBeInTheDocument();
+		expect(screen.getByText(/update:role:123/)).toBeInTheDocument();
 		expect(
 			screen.queryByText('Test Component: test-value'),
 		).not.toBeInTheDocument();

--- a/frontend/src/components/createGuardedRoute/createGuardedRoute.tsx
+++ b/frontend/src/components/createGuardedRoute/createGuardedRoute.tsx
@@ -5,7 +5,8 @@ import {
 	AuthZRelation,
 	BrandedPermission,
 } from 'hooks/useAuthZ/types';
-import { parsePermission } from 'hooks/useAuthZ/utils';
+import { formatPermission } from 'hooks/useAuthZ/utils';
+import { useAppContext } from 'providers/App/App';
 
 import noDataUrl from '@/assets/Icons/no-data.svg';
 
@@ -17,21 +18,16 @@ import './createGuardedRoute.styles.scss';
 function OnNoPermissionsFallback(response: {
 	requiredPermissionName: BrandedPermission;
 }): ReactElement {
-	const { relation, object } = parsePermission(response.requiredPermissionName);
+	const { user } = useAppContext();
 
 	return (
 		<div className="guard-authz-error-no-authz">
 			<div className="guard-authz-error-no-authz-content">
 				<img src={noDataUrl} alt="No permission" />
-				<h3>Uh-oh! You don’t have permission to view this page.</h3>
+				<h3>Uh-oh! You are not authorized</h3>
 				<p>
-					You need the following permission to view this page:
-					<br />
-					Relation: <span>{relation}</span>
-					<br />
-					Object: <span>{object}</span>
-					<br />
-					Please ask your SigNoz administrator to grant access.
+					<code>user/{user.id}</code> is not authorized to perform{' '}
+					<code>{formatPermission(response.requiredPermissionName)}</code>
 				</p>
 			</div>
 		</div>

--- a/frontend/src/container/RolesSettings/CreateEditRolePage/CreateEditRolePage.module.scss
+++ b/frontend/src/container/RolesSettings/CreateEditRolePage/CreateEditRolePage.module.scss
@@ -105,3 +105,8 @@
 	height: 1px;
 	background: var(--l1-border);
 }
+
+.errorInPlaceContainer {
+	border-color: var(--callout-error-border) !important;
+	background: var(--callout-error-background) !important;
+}

--- a/frontend/src/container/RolesSettings/CreateEditRolePage/CreateEditRolePage.tsx
+++ b/frontend/src/container/RolesSettings/CreateEditRolePage/CreateEditRolePage.tsx
@@ -15,7 +15,7 @@ import APIError from 'types/api/error';
 
 import PermissionEditor from './components/PermissionEditor';
 import { useCreateEditRolePageActions } from './useCreateEditRolePageActions';
-import { useNavigationBlocker } from '../../../hooks/useNavigationBlocker';
+import { useNavigationBlocker } from 'hooks/useNavigationBlocker';
 
 import styles from './CreateEditRolePage.module.scss';
 
@@ -212,8 +212,10 @@ function CreateEditRolePage(): JSX.Element {
 				<ErrorInPlace
 					error={saveError}
 					height="auto"
-					bordered
 					data-testid="save-error-banner"
+					padding={0}
+					bordered={true}
+					className={styles.errorInPlaceContainer}
 				/>
 			)}
 

--- a/frontend/src/container/RolesSettings/CreateEditRolePage/__tests__/CreateRolePage.test.tsx
+++ b/frontend/src/container/RolesSettings/CreateEditRolePage/__tests__/CreateRolePage.test.tsx
@@ -216,6 +216,47 @@ describe('CreateRolePage', () => {
 			);
 		});
 
+		it('shows error banner with "Role name is required" when saving with empty name', async () => {
+			const user = userEvent.setup();
+			renderCreatePage();
+
+			const descInput = screen.getByTestId('role-description-input');
+			await user.type(descInput, 'Description only');
+
+			const saveBtn = screen.getByTestId('save-button');
+			await user.click(saveBtn);
+
+			await expect(
+				screen.findByTestId('save-error-banner'),
+			).resolves.toBeInTheDocument();
+
+			await expect(
+				screen.findByText('Role name is required'),
+			).resolves.toBeInTheDocument();
+		});
+
+		it('clears error banner when user starts typing in name field', async () => {
+			const user = userEvent.setup();
+			renderCreatePage();
+
+			const descInput = screen.getByTestId('role-description-input');
+			await user.type(descInput, 'Description only');
+
+			const saveBtn = screen.getByTestId('save-button');
+			await user.click(saveBtn);
+
+			await expect(
+				screen.findByTestId('save-error-banner'),
+			).resolves.toBeInTheDocument();
+
+			const nameInput = screen.getByTestId('role-name-input');
+			await user.type(nameInput, 'a');
+
+			await waitFor(() => {
+				expect(screen.queryByTestId('save-error-banner')).not.toBeInTheDocument();
+			});
+		});
+
 		it('shows error banner when API fails', async () => {
 			server.use(
 				rest.post(rolesApiBase, (_req, res, ctx) =>

--- a/frontend/src/container/RolesSettings/CreateEditRolePage/__tests__/PermissionEditor.test.tsx
+++ b/frontend/src/container/RolesSettings/CreateEditRolePage/__tests__/PermissionEditor.test.tsx
@@ -520,4 +520,115 @@ describe('PermissionEditor', () => {
 			expect(header).toHaveAttribute('aria-expanded', 'true');
 		});
 	});
+
+	describe('resource card error states', () => {
+		it('shows error border on collapsed card with validation error', async () => {
+			const user = userEvent.setup();
+			renderPage();
+
+			const nameInput = screen.getByTestId('role-name-input');
+			await user.type(nameInput, 'valid-role');
+
+			const apiKeyCard = screen.getByTestId('resource-card-factor-api-key');
+			const header = within(apiKeyCard).getByTestId(
+				'resource-card-header-factor-api-key',
+			);
+			await user.click(header);
+
+			const readToggle = within(apiKeyCard).getByTestId(
+				'action-toggle-factor-api-key-read',
+			);
+			const onlySelectedBtn = await within(readToggle).findByText('Only selected');
+			await user.click(onlySelectedBtn);
+
+			await user.click(header);
+
+			const saveBtn = screen.getByTestId('save-button');
+			await user.click(saveBtn);
+
+			await waitFor(() => {
+				const card = screen.getByTestId('resource-card-factor-api-key');
+				expect(card).toHaveAttribute('data-state', 'error');
+			});
+		});
+
+		it('hides error border when card is expanded', async () => {
+			const user = userEvent.setup();
+			renderPage();
+
+			const nameInput = screen.getByTestId('role-name-input');
+			await user.type(nameInput, 'valid-role');
+
+			const apiKeyCard = screen.getByTestId('resource-card-factor-api-key');
+			const header = within(apiKeyCard).getByTestId(
+				'resource-card-header-factor-api-key',
+			);
+			await user.click(header);
+
+			const readToggle = within(apiKeyCard).getByTestId(
+				'action-toggle-factor-api-key-read',
+			);
+			const onlySelectedBtn = await within(readToggle).findByText('Only selected');
+			await user.click(onlySelectedBtn);
+
+			await user.click(header);
+
+			const saveBtn = screen.getByTestId('save-button');
+			await user.click(saveBtn);
+
+			await waitFor(() => {
+				const card = screen.getByTestId('resource-card-factor-api-key');
+				expect(card).toHaveAttribute('data-state', 'error');
+			});
+
+			await user.click(header);
+
+			await waitFor(() => {
+				const card = screen.getByTestId('resource-card-factor-api-key');
+				expect(card).not.toHaveAttribute('data-state');
+			});
+		});
+
+		it('clears validation error when permission is changed', async () => {
+			const user = userEvent.setup();
+			renderPage();
+
+			const nameInput = screen.getByTestId('role-name-input');
+			await user.type(nameInput, 'valid-role');
+
+			const apiKeyCard = screen.getByTestId('resource-card-factor-api-key');
+			const header = within(apiKeyCard).getByTestId(
+				'resource-card-header-factor-api-key',
+			);
+			await user.click(header);
+
+			const readToggle = within(apiKeyCard).getByTestId(
+				'action-toggle-factor-api-key-read',
+			);
+			const onlySelectedBtn = await within(readToggle).findByText('Only selected');
+			await user.click(onlySelectedBtn);
+
+			await user.click(header);
+
+			const saveBtn = screen.getByTestId('save-button');
+			await user.click(saveBtn);
+
+			await expect(
+				screen.findByTestId('save-error-banner'),
+			).resolves.toBeInTheDocument();
+
+			await user.click(header);
+
+			const freshCard = screen.getByTestId('resource-card-factor-api-key');
+			const freshToggle = within(freshCard).getByTestId(
+				'action-toggle-factor-api-key-read',
+			);
+			const noneBtn = await within(freshToggle).findByText('None');
+			await user.click(noneBtn);
+
+			await waitFor(() => {
+				expect(screen.queryByTestId('save-error-banner')).not.toBeInTheDocument();
+			});
+		});
+	});
 });

--- a/frontend/src/container/RolesSettings/CreateEditRolePage/components/ResourceCard.module.scss
+++ b/frontend/src/container/RolesSettings/CreateEditRolePage/components/ResourceCard.module.scss
@@ -8,6 +8,10 @@
 	transition: border-color 0.15s ease;
 }
 
+.resourceCardError {
+	border-color: var(--destructive);
+}
+
 .resourceCardHeader {
 	display: flex;
 	align-items: center;

--- a/frontend/src/container/RolesSettings/CreateEditRolePage/components/ResourceCard.tsx
+++ b/frontend/src/container/RolesSettings/CreateEditRolePage/components/ResourceCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { ChevronDown, ChevronRight } from '@signozhq/icons';
 import type { AuthZResource, AuthZVerb } from 'hooks/useAuthZ/types';
 
@@ -10,6 +10,7 @@ import ActionToggle from './ActionToggle';
 
 import styles from './ResourceCard.module.scss';
 import { PermissionScope, ResourcePermissions } from '../../types';
+import cx from 'classnames';
 
 interface ResourceCardProps {
 	resource: ResourcePermissions;
@@ -74,10 +75,22 @@ function ResourceCard({
 
 	const [grantedCount, totalCount] = useRoleGrantedCount(resource);
 
+	const hasErrorOnResource = useMemo(
+		() =>
+			Array.from(validationErrors ?? []).some((r) =>
+				r.startsWith(resource.resourceId),
+			),
+		[validationErrors, resource.resourceId],
+	);
+
 	return (
 		<div
-			className={styles.resourceCard}
+			className={cx(
+				styles.resourceCard,
+				hasErrorOnResource && !isExpanded && styles.resourceCardError,
+			)}
 			data-testid={`resource-card-${resource.resourceId}`}
+			data-state={hasErrorOnResource && !isExpanded ? 'error' : undefined}
 		>
 			<button
 				type="button"

--- a/frontend/src/container/RolesSettings/CreateEditRolePage/useCreateEditRolePageActions.ts
+++ b/frontend/src/container/RolesSettings/CreateEditRolePage/useCreateEditRolePageActions.ts
@@ -125,8 +125,10 @@ export function useCreateEditRolePageActions(
 				...prev,
 				[field]: value,
 			}));
+			clearValidationErrors();
+			setSaveError(null);
 		},
-		[],
+		[clearValidationErrors],
 	);
 
 	const handleModeChange = useCallback(
@@ -139,8 +141,10 @@ export function useCreateEditRolePageActions(
 	const handleResourcesChange = useCallback(
 		(resources: ResourcePermissions[]): void => {
 			setLocalResources(resources);
+			clearValidationErrors();
+			setSaveError(null);
 		},
-		[],
+		[clearValidationErrors],
 	);
 
 	const hasUnsavedChanges = useRoleUnsavedChanges(
@@ -153,7 +157,17 @@ export function useCreateEditRolePageActions(
 
 	const handleSave = useCallback(async (): Promise<boolean> => {
 		if (!formData.name.trim()) {
-			toast.error('Role name is required', { position: 'bottom-center' });
+			setSaveError(
+				new APIError({
+					httpStatusCode: 400,
+					error: {
+						code: 'VALIDATION_ERROR',
+						message: 'Role name is required',
+						url: '',
+						errors: [],
+					},
+				}),
+			);
 			return false;
 		}
 

--- a/frontend/src/hooks/useAuthZ/utils.ts
+++ b/frontend/src/hooks/useAuthZ/utils.ts
@@ -41,6 +41,11 @@ export function parsePermission(
 	return { relation: relation as AuthZRelation, object };
 }
 
+export function formatPermission(permission: BrandedPermission): string {
+	const { relation, object } = parsePermission(permission);
+	return `${relation}:${object}`;
+}
+
 const kindsByType = permissionsType.data.resources.reduce(
 	(acc, r) => {
 		if (!acc[r.type]) {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

This PR has a couple fixes around AuthZ:

- Standardize the error message to follow the pattern of the API
- Add border/background for error message on Create/Edit Role
- Add border error for resourceCard when has validation error (only when collapsed)
- After error, if any field is changed, then reset the error message.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Error message cleaning after change fields:

https://github.com/user-attachments/assets/140cce45-6a78-40c1-a71c-6843f25c45e7

Service Account with new error message:

<img width="1155" height="1267" alt="image" src="https://github.com/user-attachments/assets/2393bedc-2f27-4d54-91e3-63be3ff09e01" />

Roles page:

<img width="1011" height="912" alt="image" src="https://github.com/user-attachments/assets/2cc3f0a9-7b03-423b-87e8-92010370f36d" />

<img width="1011" height="520" alt="image" src="https://github.com/user-attachments/assets/0edcb01f-a4c0-40c1-8274-f8e47c93d80d" />

<img width="1009" height="531" alt="image" src="https://github.com/user-attachments/assets/2ddb4d1f-8acb-4e8f-9eab-e18d403efd91" />

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/platform-pod/issues/2529

Related to https://github.com/SigNoz/platform-pod/issues/2529#issuecomment-4835722924

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Yes
- Manual verification: Yes
- Edge cases covered: Yes

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: AuthZ / Roles
- Potential regressions: -
- Rollback plan: Revert the commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance |
| Description | A couple UI changes for AuthZ around standarization of the error message & some fixes in the UI/UX of Roles page. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
