### PR TITLE
refactor(meter-explorer): convert bar to stacked bar

### DIFF
--- a/frontend/src/container/MeterExplorer/Explorer/TimeSeries.tsx
+++ b/frontend/src/container/MeterExplorer/Explorer/TimeSeries.tsx
@@ -167,6 +167,7 @@ function TimeSeries({
 								dataSource={DataSource.METRICS}
 								yAxisUnit={yAxisUnit}
 								panelType={PANEL_TYPES.BAR}
+								stackBarChart
 							/>
 						</div>
 					))}

--- a/frontend/src/container/TimeSeriesView/TimeSeriesView.tsx
+++ b/frontend/src/container/TimeSeriesView/TimeSeriesView.tsx
@@ -30,6 +30,7 @@ import useUrlQuery from 'hooks/useUrlQuery';
 import GetMinMax from 'lib/getMinMax';
 import getTimeString from 'lib/getTimeString';
 import history from 'lib/history';
+import { stackSeries } from 'container/DashboardContainer/visualization/charts/utils/stackSeriesUtils';
 import { getUPlotChartOptions } from 'lib/uPlotLib/getUplotChartOptions';
 import { getUPlotChartData } from 'lib/uPlotLib/utils/getUplotChartData';
 import { isEmpty } from 'lodash-es';
@@ -57,6 +58,7 @@ function TimeSeriesView({
 	dataSource,
 	setWarning,
 	panelType = PANEL_TYPES.TIME_SERIES,
+	stackBarChart = false,
 }: TimeSeriesViewProps): JSX.Element {
 	const graphRef = useRef<HTMLDivElement>(null);
 
@@ -65,10 +67,28 @@ function TimeSeriesView({
 	const location = useLocation();
 	const { currentQuery } = useQueryBuilder();
 
-	const chartData = useMemo(
+	const rawChartData = useMemo(
 		() => getUPlotChartData(data?.payload),
 		[data?.payload],
 	);
+
+	const { chartData, stackedBands } = useMemo(() => {
+		// AlignedData format: [timeAxis, series1, series2, ...]. Need 2+ data series to stack.
+		const minSeriesForStacking = 3;
+		if (
+			!stackBarChart ||
+			!rawChartData ||
+			rawChartData.length < minSeriesForStacking
+		) {
+			return { chartData: rawChartData, stackedBands: null };
+		}
+		const noSeriesHidden = (): boolean => false;
+		const { data: stacked, bands } = stackSeries(
+			rawChartData as uPlot.AlignedData,
+			noSeriesHidden,
+		);
+		return { chartData: stacked, stackedBands: bands };
+	}, [rawChartData, stackBarChart]);
 
 	useEffect(() => {
 		if (data?.payload) {
@@ -189,7 +209,7 @@ function TimeSeriesView({
 
 	const { timezone } = useTimezone();
 
-	const chartOptions = getUPlotChartOptions({
+	const baseChartOptions = getUPlotChartOptions({
 		id: 'time-series-explorer',
 		onDragSelect,
 		yAxisUnit: yAxisUnit || '',
@@ -220,7 +240,16 @@ function TimeSeriesView({
 		}) => {
 			legendScrollPositionRef.current = position;
 		},
+		stackBarChart,
 	});
+
+	const chartOptions = useMemo(
+		() =>
+			stackedBands
+				? { ...baseChartOptions, bands: stackedBands }
+				: baseChartOptions,
+		[baseChartOptions, stackedBands],
+	);
 
 	return (
 		<div className="time-series-view">
@@ -282,6 +311,7 @@ interface TimeSeriesViewProps {
 	dataSource: DataSource;
 	setWarning?: Dispatch<SetStateAction<Warning | undefined>>;
 	panelType?: PANEL_TYPES;
+	stackBarChart?: boolean;
 }
 
 TimeSeriesView.defaultProps = {
@@ -290,6 +320,7 @@ TimeSeriesView.defaultProps = {
 	error: undefined,
 	setWarning: undefined,
 	panelType: PANEL_TYPES.TIME_SERIES,
+	stackBarChart: false,
 };
 
 export default TimeSeriesView;


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

This convert the bar chart to be stacked bar, we will keep in the old API until we isolate the components around the new API for v2.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

<img width="2808" height="1263" alt="screenshot-2026-06-30_14-58-55" src="https://github.com/user-attachments/assets/ff397c87-564c-4439-b281-332c9a71c175" />

https://github.com/user-attachments/assets/b4719b26-b4c1-48fa-816e-502c01b4ecaa


After:

<img width="2807" height="1270" alt="screenshot-2026-06-30_14-56-41" src="https://github.com/user-attachments/assets/b1fac607-4890-470f-8972-6c7b7a212cb5" />

https://github.com/user-attachments/assets/1cc1f124-77ce-491e-8885-698cce47acf1

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/platform-pod/issues/2577

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: Yes, double chart

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Meter - Explorer
- Potential regressions: Issue around stacking bar charts
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | We changed the chart on Meter Explorer to be stacked instead of being bar to help visualize multiple values at once. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered