### PR TITLE
fix: correct mismatched doc comment names

### DIFF
--- a/pkg/types/audittypes/attributes.go
+++ b/pkg/types/audittypes/attributes.go
@@ -87,7 +87,7 @@ func NewResourceAttributes(resource coretypes.Resource, resourceID string) Resou
 	}
 }
 
-// NewAttachResourceAttributes builds resource attributes that additionally name
+// NewRelatedResourceAttributes builds resource attributes that additionally name
 // the target counterpart (used for attach/detach audit events).
 func NewRelatedResourceAttributes(resource coretypes.Resource, resourceID string, targetResource coretypes.Resource, targetResourceID string) ResourceAttributes {
 	return ResourceAttributes{

--- a/pkg/types/audittypes/event.go
+++ b/pkg/types/audittypes/event.go
@@ -44,7 +44,7 @@ type AuditEvent struct {
 	TransportAttributes TransportAttributes
 }
 
-// NewAuditEvent builds an audit event from pre-built resource attributes (which
+// NewAuditEventFromHTTPRequest builds an audit event from pre-built resource attributes (which
 // may carry attach/target context).
 func NewAuditEventFromHTTPRequest(
 	req *http.Request,

--- a/pkg/types/ctxtypes/comment.go
+++ b/pkg/types/ctxtypes/comment.go
@@ -104,7 +104,7 @@ func CommentFromHTTPRequest(req *http.Request) map[string]string {
 	return comments
 }
 
-// AddCommentsToContext returns a new context with all key-value pairs merged into the Comment in the context.
+// NewContextWithCommentVals returns a new context with all key-value pairs merged into the Comment in the context.
 func NewContextWithCommentVals(ctx context.Context, vals map[string]string) context.Context {
 	comment := CommentFromContext(ctx)
 	comment.Merge(vals)


### PR DESCRIPTION
### Summary

Three Go doc comments started with a different function's name (copy-paste leftovers). Go convention is for a function's doc comment to start with the function name:

- `NewRelatedResourceAttributes` - comment started with `NewAttachResourceAttributes`
- `NewContextWithCommentVals` - comment started with `AddCommentsToContext`
- `NewAuditEventFromHTTPRequest` - comment started with `NewAuditEvent`

Documentation-only change; no behaviour is affected.
