### PR TITLE
fix(settings): ensure scroll on tiny screens

### DIFF
--- a/frontend/src/components/MembersTable/MembersTable.styles.scss
+++ b/frontend/src/components/MembersTable/MembersTable.styles.scss
@@ -3,7 +3,6 @@
 	flex-direction: column;
 	flex: 1;
 	min-height: 0;
-	overflow: hidden;
 	border-radius: 4px;
 }
 

--- a/frontend/src/container/MembersSettings/MembersSettings.styles.scss
+++ b/frontend/src/container/MembersSettings/MembersSettings.styles.scss
@@ -1,9 +1,14 @@
+@use '../../styles/scrollbar' as *;
+
 .members-settings-page {
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing-8);
 	padding: var(--padding-4) var(--padding-2) var(--padding-6) var(--padding-4);
 	height: 100%;
+	overflow-y: auto;
+
+	@include custom-scrollbar;
 }
 
 .members-settings {

--- a/frontend/src/container/RolesSettings/RolesComponents/RolesListingTable.module.scss
+++ b/frontend/src/container/RolesSettings/RolesComponents/RolesListingTable.module.scss
@@ -1,7 +1,6 @@
 .rolesListingTable {
 	margin-top: 12px;
 	border-radius: 4px;
-	overflow: hidden;
 }
 
 .scrollContainer {

--- a/frontend/src/container/RolesSettings/RolesSettings.module.scss
+++ b/frontend/src/container/RolesSettings/RolesSettings.module.scss
@@ -40,6 +40,7 @@
 
 .rolesSettingsContent {
 	padding: 0 16px;
+	padding-bottom: 16px;
 }
 
 .rolesSettingsToolbar {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The Roles page was not adding a scroll when the screen is tiny.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

https://github.com/user-attachments/assets/ab4e65d3-f6bf-4dbe-92aa-8ab8ae487ec4

After:

https://github.com/user-attachments/assets/1e2b9bb2-d23f-4795-bec0-61302622b887

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Related to https://github.com/SigNoz/platform-pod/issues/2529

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: Yes

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Settings - Roles / Members
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Ensure the pages for members and roles has proper handling for tiny screens. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
