### PR TITLE
fix(dashboard): pie panel collapses multi-column ClickHouse query to a single slice

### DIFF
--- a/frontend/src/components/YAxisUnitSelector/__tests__/formatter.test.tsx
+++ b/frontend/src/components/YAxisUnitSelector/__tests__/formatter.test.tsx
@@ -680,6 +680,13 @@ describe('formatUniversalUnit', () => {
 	});
 
 	describe('Datetime', () => {
+		beforeAll(() => {
+			jest.useFakeTimers().setSystemTime(new Date('2026-01-01T00:00:00Z'));
+		});
+		afterAll(() => {
+			jest.useRealTimers();
+		});
+
 		it('formats datetime units', () => {
 			expect(formatUniversalUnit(900, UniversalYAxisUnit.DATETIME_FROM_NOW)).toBe(
 				'56 years ago',

--- a/frontend/src/container/PanelWrapper/PiePanelWrapper.tsx
+++ b/frontend/src/container/PanelWrapper/PiePanelWrapper.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Color } from '@signozhq/design-tokens';
 import { Group } from '@visx/group';
 import { Pie } from '@visx/shape';
@@ -8,12 +8,10 @@ import { themeColors } from 'constants/theme';
 import { getPieChartClickData } from 'container/QueryTable/Drilldown/drilldownUtils';
 import useGraphContextMenu from 'container/QueryTable/Drilldown/useGraphContextMenu';
 import { useIsDarkMode } from 'hooks/useDarkMode';
-import getLabelName from 'lib/getLabelName';
-import { generateColor } from 'lib/uPlotLib/utils/generateColor';
-import { isNaN } from 'lodash-es';
 import ContextMenu, { useCoordinates } from 'periscope/components/ContextMenu';
 
 import { PanelWrapperProps, TooltipData } from './panelWrapper.types';
+import { preparePieChartData } from './preparePieChartData';
 import { lightenColor, tooltipStyles } from './utils';
 
 import './PiePanelWrapper.styles.scss';
@@ -44,37 +42,15 @@ function PiePanelWrapper({
 		detectBounds: true,
 	});
 
-	const panelData = queryResponse.data?.payload?.data?.result || [];
-
 	const isDarkMode = useIsDarkMode();
 
-	let pieChartData: {
-		label: string;
-		value: string;
-		color: string;
-		record: any;
-	}[] = [].concat(
-		...(panelData
-			.map((d) => {
-				const label = getLabelName(d.metric, d.queryName || '', d.legend || '');
-				return {
-					label,
-					value: d?.values?.[0]?.[1],
-					record: d,
-					color:
-						widget?.customLegendColors?.[label] ||
-						generateColor(
-							label,
-							isDarkMode ? themeColors.chartcolors : themeColors.lightModeColor,
-						),
-				};
-			})
-			.filter((d) => d !== undefined) as never[]),
-	);
-
-	pieChartData = pieChartData.filter(
-		(arc) =>
-			arc.value && !isNaN(parseFloat(arc.value)) && parseFloat(arc.value) > 0,
+	const pieChartData = useMemo(
+		() =>
+			preparePieChartData(queryResponse.data?.payload, {
+				customLegendColors: widget?.customLegendColors,
+				colorMap: isDarkMode ? themeColors.chartcolors : themeColors.lightModeColor,
+			}),
+		[queryResponse.data?.payload, widget?.customLegendColors, isDarkMode],
 	);
 
 	let size = 0;

--- a/frontend/src/container/PanelWrapper/__tests__/preparePieChartData.test.ts
+++ b/frontend/src/container/PanelWrapper/__tests__/preparePieChartData.test.ts
@@ -1,0 +1,185 @@
+import { themeColors } from 'constants/theme';
+import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { QueryData, QueryDataV3 } from 'types/api/widgets/getQuery';
+
+import { preparePieChartData } from '../preparePieChartData';
+
+const options = { colorMap: themeColors.chartcolors };
+
+/**
+ * Mirrors a query-range payload: the (possibly collapsed) time-series `result`
+ * plus the scalar table nested under `newResult` (as getQueryResults produces it).
+ */
+function makePayload(
+	result: QueryData[],
+	tables: QueryDataV3[],
+): MetricRangePayloadProps {
+	return {
+		data: {
+			result,
+			resultType: 'scalar',
+			newResult: { data: { result: tables, resultType: 'scalar' } },
+		},
+	} as MetricRangePayloadProps;
+}
+
+function tableEntry(
+	columns: NonNullable<QueryDataV3['table']>['columns'],
+	rows: NonNullable<QueryDataV3['table']>['rows'],
+	overrides: Partial<QueryDataV3> = {},
+): QueryDataV3 {
+	return {
+		queryName: 'A',
+		legend: '',
+		series: null,
+		list: null,
+		table: { columns, rows },
+		...overrides,
+	} as QueryDataV3;
+}
+
+describe('preparePieChartData', () => {
+	it('renders a slice per value column for a multi-column ClickHouse scalar', () => {
+		// SELECT count() AS col1, sum(value) AS col2 — the backend collapses the
+		// time-series result onto col1; the full data lives in the scalar table.
+		const payload = makePayload(
+			[
+				{
+					metric: {},
+					queryName: 'A',
+					legend: '',
+					values: [[0, '23399927']],
+				} as QueryData,
+			],
+			[
+				tableEntry(
+					[
+						{ name: 'col1', queryName: 'A', isValueColumn: true, id: 'col1' },
+						{ name: 'col2', queryName: 'A', isValueColumn: true, id: 'col2' },
+					],
+					[{ data: { col1: 23399927, col2: 588691297 } }],
+				),
+			],
+		);
+
+		const slices = preparePieChartData(payload, options);
+
+		expect(slices).toHaveLength(2);
+		expect(slices.map((s) => [s.label, s.value])).toStrictEqual([
+			['col1', '23399927'],
+			['col2', '588691297'],
+		]);
+	});
+
+	it('prefixes the group when multiple value columns are grouped', () => {
+		const payload = makePayload(
+			[],
+			[
+				tableEntry(
+					[
+						{ name: 'env', queryName: 'A', isValueColumn: false, id: 'env' },
+						{ name: 'col1', queryName: 'A', isValueColumn: true, id: 'col1' },
+						{ name: 'col2', queryName: 'A', isValueColumn: true, id: 'col2' },
+					],
+					[{ data: { env: 'prod', col1: 10, col2: 20 } }],
+				),
+			],
+		);
+
+		const slices = preparePieChartData(payload, options);
+
+		expect(slices.map((s) => s.label)).toStrictEqual([
+			'prod · col1',
+			'prod · col2',
+		]);
+		expect(slices[0].record.metric).toStrictEqual({ env: 'prod' });
+	});
+
+	it('drops non-positive and non-numeric values', () => {
+		const payload = makePayload(
+			[],
+			[
+				tableEntry(
+					[
+						{ name: 'col1', queryName: 'A', isValueColumn: true, id: 'col1' },
+						{ name: 'col2', queryName: 'A', isValueColumn: true, id: 'col2' },
+						{ name: 'col3', queryName: 'A', isValueColumn: true, id: 'col3' },
+					],
+					[{ data: { col1: 5, col2: 0, col3: 'n/a' } }],
+				),
+			],
+		);
+
+		const slices = preparePieChartData(payload, options);
+
+		expect(slices.map((s) => s.label)).toStrictEqual(['col1']);
+	});
+
+	it('keeps the series path for a single value column (grouped panel)', () => {
+		// One value column → the time-series result is authoritative (one slice per
+		// group), so existing behaviour is preserved.
+		const payload = makePayload(
+			[
+				{
+					metric: { 'service.name': 'adservice' },
+					queryName: 'A',
+					legend: 'adservice',
+					values: [[0, '100']],
+				} as QueryData,
+				{
+					metric: { 'service.name': 'cartservice' },
+					queryName: 'A',
+					legend: 'cartservice',
+					values: [[0, '200']],
+				} as QueryData,
+			],
+			[
+				tableEntry(
+					[
+						{
+							name: 'service.name',
+							queryName: 'A',
+							isValueColumn: false,
+							id: 'service.name',
+						},
+						{ name: 'count', queryName: 'A', isValueColumn: true, id: 'A' },
+					],
+					[
+						{ data: { 'service.name': 'adservice', A: 100 } },
+						{ data: { 'service.name': 'cartservice', A: 200 } },
+					],
+				),
+			],
+		);
+
+		const slices = preparePieChartData(payload, options);
+
+		expect(slices.map((s) => [s.label, s.value])).toStrictEqual([
+			['adservice', '100'],
+			['cartservice', '200'],
+		]);
+	});
+
+	it('uses the legacy series result when there is no scalar table', () => {
+		const payload = makePayload(
+			[
+				{
+					metric: { 'service.name': 'adservice' },
+					queryName: 'A',
+					legend: '{{service.name}}',
+					values: [[1000, '42']],
+				} as QueryData,
+			],
+			[],
+		);
+
+		const slices = preparePieChartData(payload, options);
+
+		expect(slices).toHaveLength(1);
+		expect(slices[0].value).toBe('42');
+	});
+
+	it('returns no slices for an empty payload', () => {
+		expect(preparePieChartData(undefined, options)).toStrictEqual([]);
+	});
+});

--- a/frontend/src/container/PanelWrapper/preparePieChartData.ts
+++ b/frontend/src/container/PanelWrapper/preparePieChartData.ts
@@ -1,0 +1,144 @@
+import getLabelName from 'lib/getLabelName';
+import { generateColor } from 'lib/uPlotLib/utils/generateColor';
+import { isNaN } from 'lodash-es';
+import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { QueryData, QueryDataV3 } from 'types/api/widgets/getQuery';
+
+export interface PieChartSlice {
+	label: string;
+	value: string;
+	color: string;
+	record: {
+		queryName: string;
+		legend?: string;
+		/** Group-by labels, used for drilldown; absent when the slice has no group. */
+		metric?: QueryData['metric'];
+	};
+}
+
+interface PreparePieChartDataOptions {
+	customLegendColors?: Record<string, string>;
+	colorMap: Record<string, string>;
+}
+
+const colorFor = (
+	label: string,
+	{ customLegendColors, colorMap }: PreparePieChartDataOptions,
+): string => customLegendColors?.[label] || generateColor(label, colorMap);
+
+const isPositive = (value: string): boolean =>
+	!!value && !isNaN(parseFloat(value)) && parseFloat(value) > 0;
+
+/**
+ * Time-series result: one slice per series, value = first datapoint. This is the
+ * original pie behaviour — kept verbatim (same label/value/colour/record) so
+ * single-value and grouped panels are unaffected.
+ */
+function slicesFromSeries(
+	result: QueryData[],
+	options: PreparePieChartDataOptions,
+): PieChartSlice[] {
+	return result
+		.filter((d) => d?.values?.[0]?.[1] !== undefined)
+		.map((d) => {
+			const label = getLabelName(d.metric, d.queryName || '', d.legend || '');
+			return {
+				label,
+				value: d.values[0][1],
+				color: colorFor(label, options),
+				record: d,
+			};
+		});
+}
+
+/**
+ * V5 scalar table: one slice per (row × value column). With more than one value
+ * column the column name keeps the slices distinct, so a ClickHouse query like
+ * `count() AS col1, sum() AS col2` renders a slice per column instead of
+ * collapsing onto the first; group-by columns become the slice label.
+ */
+function slicesFromTables(
+	tables: QueryDataV3[],
+	options: PreparePieChartDataOptions,
+): PieChartSlice[] {
+	const slices: PieChartSlice[] = [];
+
+	tables.forEach((entry) => {
+		const { table } = entry;
+		if (!table?.columns?.length || !table?.rows?.length) {
+			return;
+		}
+
+		const valueColumns = table.columns.filter((column) => column.isValueColumn);
+		if (valueColumns.length === 0) {
+			return;
+		}
+		const labelColumns = table.columns.filter((column) => !column.isValueColumn);
+		const hasMultipleValueColumns = valueColumns.length > 1;
+
+		table.rows.forEach((row) => {
+			const groupLabel = labelColumns
+				.map((column) => row.data[column.id || column.name])
+				.filter((part) => part != null)
+				.map(String)
+				.join(', ');
+			// Drilldown filters by group-by labels; leave it undefined when there
+			// are none (e.g. a ClickHouse query) so no filterless menu is offered.
+			const metric = labelColumns.length
+				? labelColumns.reduce<Record<string, string>>((acc, column) => {
+						acc[column.name] = String(row.data[column.id || column.name]);
+						return acc;
+					}, {})
+				: undefined;
+
+			valueColumns.forEach((column) => {
+				let label: string;
+				if (hasMultipleValueColumns) {
+					label = groupLabel ? `${groupLabel} · ${column.name}` : column.name;
+				} else {
+					label = groupLabel || entry.legend || entry.queryName || '';
+				}
+
+				slices.push({
+					label,
+					value: String(row.data[column.id || column.name]),
+					color: colorFor(label, options),
+					record: { queryName: entry.queryName, legend: entry.legend, metric },
+				});
+			});
+		});
+	});
+
+	return slices;
+}
+
+/**
+ * Builds pie slices from a query-range payload, dropping non-positive/non-numeric
+ * values.
+ *
+ * A scalar response with several value columns (e.g. a ClickHouse
+ * `count() AS col1, sum() AS col2`) collapses to a single series in
+ * `data.result` — only the first value column survives. The full data is kept in
+ * the scalar table under `newResult`, so in that case slices are built from the
+ * table (one per value column). Otherwise the legacy time-series result is used,
+ * preserving existing behaviour for single-value and grouped panels.
+ */
+export function preparePieChartData(
+	payload: MetricRangePayloadProps | undefined,
+	options: PreparePieChartDataOptions,
+): PieChartSlice[] {
+	const tables = (payload?.data?.newResult?.data?.result || []).filter(
+		(entry) => entry?.table?.rows?.length,
+	);
+	const hasMultipleValueColumns = tables.some(
+		(entry) =>
+			(entry.table?.columns || []).filter((column) => column.isValueColumn)
+				.length > 1,
+	);
+
+	const slices = hasMultipleValueColumns
+		? slicesFromTables(tables, options)
+		: slicesFromSeries(payload?.data?.result || [], options);
+
+	return slices.filter((slice) => isPositive(slice.value));
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

A dashboard **Pie panel** backed by a **ClickHouse SQL query** with more than one aggregation (e.g. `SELECT count() AS col1, sum(value) AS col2`) rendered **a single slice** — labelled with the query name (`A`) and carrying only the **first** value column's value. The remaining value columns were silently dropped.

This is the **pie counterpart** of the table collapse fixed in #11794 — same underlying response shape, different consumer. The Table/Value panels were fixed there; the Pie panel was not, because it reads the data from a different field.

This is a **frontend-only** fix (V1 dashboards). The backend already returns correct, distinct columns.

#### Screenshots / Screen Recordings (if applicable)

Before
<img width="600" height="360" alt="image" src="https://github.com/user-attachments/assets/a5984fe3-89b6-4bb1-b50f-cbaf16f46910" />

After
<img width="600" height="360" alt="image" src="https://github.com/user-attachments/assets/5e59b3cf-cafd-4b1f-94ad-b85ec1bcd5aa" />


#### Issues closed by this PR
Closes https://github.com/SigNoz/engineering-pod/issues/5542

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause

A pie panel issues a **scalar** request (`getGraphType(PIE) → TABLE → requestType: scalar`). For a ClickHouse query every aggregation column is returned in the **scalar table**, which `convertV5ResponseToLegacy` places under `payload.data.newResult.data.result[*].table` — the same source the Table and Value panels read (and where #11794 made the columns distinct).

`PiePanelWrapper`, however, read the legacy time-series field `payload.data.result` and took `d.values[0][1]`:

```ts
const panelData = queryResponse.data?.payload?.data?.result || [];
// value: d?.values?.[0]?.[1]   // first datapoint of the first/only series
```

For a multi-value scalar that `result` field is the **collapsed** representation — a single series that carries only the **first** value column (`col1`). So the pie only ever plotted `col1` and never saw `col2+`. The complete data was sitting in `newResult…table` the whole time, unused by the pie.

Verified against the live payload: `data.result = [{ metric:{}, values:[[0,"23399927"]], queryName:"A" }]` (just `col1`) while `data.newResult.data.result[0].table` carried both `col1` and `col2`.

#### Fix Strategy

When the scalar table has **more than one value column**, build the pie slices from the **scalar table** (`newResult`) instead of the collapsed series — **one slice per value column**, with group-by columns forming the label (and prefixing the column name when both are present). Otherwise the original time-series path is used **verbatim** (same label / value / colour / `record`), so single-aggregation and grouped pies are untouched.

Slice-building was extracted into `preparePieChartData` (`src/container/PanelWrapper/preparePieChartData.ts`); `PiePanelWrapper` now memoizes a call to it.

---

### 🧪 Testing Strategy
> How was this change validated?

- **Tests added/updated:** `preparePieChartData.test.ts` (6 cases): multi-column ClickHouse scalar (the live payload) → one slice per column; grouped multi-value labelling + drilldown `metric`; non-positive/non-numeric filtering; single-value grouped panel staying on the series path; legacy series fallback; empty payload.
- **Manual verification:** ClickHouse `count() AS col1, sum() AS col2` pie now renders two slices (`col1`, `col2`) matching the Table panel for the same query.
- **Edge cases covered:** no `newResult`/table → graceful fallback to series; single value column → unchanged behaviour; non-numeric / zero / negative values dropped.
- Suites green: `PanelWrapper` (incl. Table/Value/legend) **60/60**, `WidgetGraphComponent` + `NewWidget` **14/14**, `usePieInteractions`. `tsgo --noEmit` and `oxlint` clean.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** V1 Pie panels only. New behaviour is gated strictly on `valueColumns > 1`; every other pie keeps the unchanged series path.
- **Potential regressions:** Builder queries with multiple aggregations as a pie now render one slice per aggregation (previously they collapsed to duplicate `A`-labelled slices) — an improvement, but a visible change worth noting.
- **Rollback plan:** Self-contained frontend change across `PiePanelWrapper.tsx` + new `preparePieChartData.ts`; revert the commit to restore prior behaviour. No data/schema/API impact.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Pie panels backed by a ClickHouse query with multiple aggregations now render one slice per value column instead of collapsing onto the first. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The fix deliberately keeps the existing **series path** for single-value-column pies so currently-working panels are byte-for-byte unchanged; only the multi-value-column (collapse) case switches to reading the scalar table.
- Grouped + multi-value slices are labelled `group · column` (middle-dot separator) — easy to change if a different convention is preferred.
- Scope is **V1 only**; no V2 (`DashboardPageV2`) files are touched.

---
