### PR TITLE
feat(frontend): allow opening sidebar nav items in new tab

### DIFF
--- a/frontend/src/container/SideNav/NavItem/NavItem.styles.scss
+++ b/frontend/src/container/SideNav/NavItem/NavItem.styles.scss
@@ -9,6 +9,18 @@
 	margin-bottom: 4px;
 	cursor: pointer;
 
+	// Reset anchor defaults when rendered as a <Link> (i.e. <a> tag)
+	text-decoration: none;
+	color: inherit;
+
+	&:hover,
+	&:focus,
+	&:active,
+	&:visited {
+		text-decoration: none;
+		color: inherit;
+	}
+
 	&.active {
 		.nav-item-active-marker {
 			background: var(--primary-background);

--- a/frontend/src/container/SideNav/NavItem/NavItem.tsx
+++ b/frontend/src/container/SideNav/NavItem/NavItem.tsx
@@ -2,6 +2,7 @@ import { Tooltip } from 'antd';
 import { Badge } from '@signozhq/ui/badge';
 import cx from 'classnames';
 import { Pin, PinOff } from '@signozhq/icons';
+import { Link } from 'react-router-dom';
 
 import { SidebarItem } from '../sideNav.types';
 
@@ -16,15 +17,18 @@ export default function NavItem({
 	isPinned,
 	showIcon,
 	dataTestId,
+	href,
 }: {
 	item: SidebarItem;
 	isActive: boolean;
-	onClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+	onClick: (event: React.MouseEvent) => void;
 	isDisabled: boolean;
 	onTogglePin?: (item: SidebarItem) => void;
 	isPinned?: boolean;
 	showIcon?: boolean;
 	dataTestId?: string;
+	/** When provided, the nav item renders as a <Link> with a real href. */
+	href?: string;
 }): JSX.Element {
 	const { label, icon, isBeta, isNew, isEarlyAccess, tooltip } = item;
 
@@ -32,24 +36,12 @@ export default function NavItem({
 		event: React.MouseEvent<SVGSVGElement, MouseEvent>,
 	): void => {
 		event.stopPropagation();
+		event.preventDefault();
 		onTogglePin?.(item);
 	};
 
-	const navItem = (
-		<div
-			className={cx(
-				'nav-item',
-				isActive ? 'active' : '',
-				isDisabled ? 'disabled' : '',
-			)}
-			onClick={(event): void => {
-				if (isDisabled) {
-					return;
-				}
-				onClick(event);
-			}}
-			data-testid={dataTestId}
-		>
+	const innerContent = (
+		<>
 			{showIcon && <div className="nav-item-active-marker" />}
 			<div className={cx('nav-item-data', isBeta ? 'beta-tag' : '')}>
 				{showIcon && (
@@ -104,8 +96,46 @@ export default function NavItem({
 					</Tooltip>
 				)}
 			</div>
-		</div>
+		</>
 	);
+
+	const sharedClassName = cx(
+		'nav-item',
+		isActive ? 'active' : '',
+		isDisabled ? 'disabled' : '',
+	);
+
+	const navItem =
+		href && !isDisabled ? (
+			<Link
+				to={href}
+				className={sharedClassName}
+				onClick={(event): void => {
+					if (isDisabled) {
+						event.preventDefault();
+						return;
+					}
+					onClick(event);
+				}}
+				data-testid={dataTestId}
+				draggable={false}
+			>
+				{innerContent}
+			</Link>
+		) : (
+			<div
+				className={sharedClassName}
+				onClick={(event): void => {
+					if (isDisabled) {
+						return;
+					}
+					onClick(event);
+				}}
+				data-testid={dataTestId}
+			>
+				{innerContent}
+			</div>
+		);
 
 	// Only non-pinnable items set `tooltip`; it would nest with the pin tooltip.
 	return tooltip ? (
@@ -122,4 +152,5 @@ NavItem.defaultProps = {
 	isPinned: false,
 	showIcon: false,
 	dataTestId: undefined,
+	href: undefined,
 };

--- a/frontend/src/container/SideNav/SideNav.styles.scss
+++ b/frontend/src/container/SideNav/SideNav.styles.scss
@@ -63,6 +63,10 @@
 
 			cursor: pointer;
 
+			// Reset anchor defaults when rendered as a <Link>
+			text-decoration: none;
+			color: inherit;
+
 			img {
 				height: 16px;
 				width: auto;
@@ -200,6 +204,9 @@
 
 			color: var(--l2-foreground);
 
+			// Reset anchor defaults when rendered as a <Link>
+			text-decoration: none;
+
 			svg {
 				color: var(--l2-foreground);
 			}
@@ -208,7 +215,7 @@
 				color: var(--l2-foreground);
 			}
 
-			&:hover:not(:disabled) {
+			&:hover:not([aria-disabled='true']) {
 				background: var(--l2-background);
 				border-color: var(--l2-background);
 

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -10,7 +10,7 @@ import {
 import { useMutation } from 'react-query';
 // eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import {
 	closestCenter,
 	DndContext,
@@ -459,26 +459,28 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 
 	const isWorkspaceBlocked = trialInfo?.workSpaceBlock || false;
 
-	const onClickGetStarted = (event: MouseEvent): void => {
+	const onClickGetStarted = (): void => {
 		void logEvent('Sidebar: Menu clicked', {
 			menuRoute: ROUTES.GET_STARTED_WITH_CLOUD,
 			menuLabel: 'Get Started',
 		});
-
-		if (isModifierKeyPressed(event)) {
-			openInNewTab(ROUTES.GET_STARTED_WITH_CLOUD);
-		} else {
-			history.push(ROUTES.GET_STARTED_WITH_CLOUD);
-		}
 	};
 
-	const onClickHandler = useCallback(
-		(key: string, event: MouseEvent | null) => {
+	/** Compute the href for a generic nav item key, preserving relevant query params. */
+	const getNavItemUrl = useCallback(
+		(key: string): string => {
 			const params = new URLSearchParams(search);
 			const availableParams = routeConfig[key];
 
 			const queryString = getQueryString(availableParams || [], params);
-			const url = buildNavUrl(key, queryString);
+			return buildNavUrl(key, queryString);
+		},
+		[search],
+	);
+
+	const onClickHandler = useCallback(
+		(key: string, event: MouseEvent | null) => {
+			const url = getNavItemUrl(key);
 
 			if (pathname !== key) {
 				if (event && isModifierKeyPressed(event)) {
@@ -490,7 +492,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 				}
 			}
 		},
-		[pathname, search],
+		[pathname, getNavItemUrl],
 	);
 
 	const activeMenuKey = useMemo(
@@ -644,34 +646,41 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 		? ROUTES.ORG_SETTINGS
 		: ROUTES.SETTINGS;
 
+	/**
+	 * Compute the href for a sidebar item.
+	 * Returns undefined for non-route actions (e.g. quick-search modal).
+	 */
+	const getNavItemHref = useCallback(
+		(item: SidebarItem): string | undefined => {
+			if (item.key === 'quick-search') {
+				// Opens a modal, not a route
+				return undefined;
+			}
+			if (item.key === ROUTES.SETTINGS) {
+				return settingsRoute;
+			}
+			if (item.key === aiAssistantMenuItem.key) {
+				return aiAssistantActiveConversationId
+					? ROUTES.AI_ASSISTANT.replace(
+							':conversationId',
+							aiAssistantActiveConversationId,
+						)
+					: String(aiAssistantMenuItem.key);
+			}
+			return getNavItemUrl(item.key as string);
+		},
+		[settingsRoute, aiAssistantActiveConversationId, getNavItemUrl],
+	);
+
 	const handleMenuItemClick = (event: MouseEvent, item: SidebarItem): void => {
-		if (item.key === ROUTES.SETTINGS) {
-			if (isModifierKeyPressed(event)) {
-				openInNewTab(settingsRoute);
-			} else {
-				history.push(settingsRoute);
-			}
-		} else if (item.key === 'quick-search') {
+		// Non-route actions: prevent Link navigation and handle imperatively
+		if (item.key === 'quick-search') {
+			event.preventDefault();
 			openCmdK();
-		} else if (item.key === aiAssistantMenuItem.key) {
-			// Resume the active conversation when one exists — without this
-			// every sidenav click hits `/ai-assistant/new` which the page
-			// resolves by spawning a fresh thread. Only fall back to /new
-			// when there's no active conversation to resume.
-			const aiPath = aiAssistantActiveConversationId
-				? ROUTES.AI_ASSISTANT.replace(
-						':conversationId',
-						aiAssistantActiveConversationId,
-					)
-				: aiAssistantMenuItem.key;
-			if (isModifierKeyPressed(event)) {
-				openInNewTab(aiPath);
-			} else {
-				history.push(aiPath);
-			}
-		} else if (item) {
-			onClickHandler(item?.key as string, event);
 		}
+		// For all route-based items, the <Link> handles navigation natively
+		// (including right-click, middle-click, Ctrl/Cmd+click).
+		// We only need to log the analytics event.
 		void logEvent('Sidebar V2: Menu clicked', {
 			menuRoute: item?.key,
 			menuLabel: item?.label,
@@ -830,6 +839,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 						handleMenuItemClick(event, item);
 					}}
 					isPinned={isPinnedItem(item)}
+					href={getNavItemHref(item)}
 				/>
 			))}
 		</>
@@ -993,15 +1003,13 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 				<div className="brand-container">
 					<div className="brand">
 						<div className="brand-company-meta">
-							<div
+							<Link
+								to={getNavItemUrl(ROUTES.HOME)}
 								className="brand-logo"
-								onClick={(event: MouseEvent): void => {
-									// Current home page
-									onClickHandler(ROUTES.HOME, event);
-								}}
+								draggable={false}
 							>
 								<img src={signozBrandLogoUrl} alt="SigNoz" />
-							</div>
+							</Link>
 
 							{(licenseTag || currentVersion) && (
 								<div
@@ -1071,19 +1079,22 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 					<div className={cx('nav-top-section')} ref={navTopSectionRef}>
 						{isCloudUser && user?.role !== USER_ROLES.VIEWER && (
 							<div className="get-started-nav-items">
-								<Button
+								<Link
+									to={ROUTES.GET_STARTED_WITH_CLOUD}
 									className="get-started-btn"
-									disabled={isWorkspaceBlocked}
-									onClick={(event: MouseEvent): void => {
+									onClick={(event): void => {
 										if (isWorkspaceBlocked) {
+											event.preventDefault();
 											return;
 										}
-										onClickGetStarted(event);
+										onClickGetStarted();
 									}}
+									draggable={false}
+									aria-disabled={isWorkspaceBlocked}
 								>
 									<PackagePlus size={16} />
 									<div className="license tag nav-item-label"> New source </div>
-								</Button>
+								</Link>
 							</div>
 						)}
 


### PR DESCRIPTION
### 📄 Summary

The left sidebar navigation rendered all nav items as `<div>` elements with `onClick` handlers calling `useNavigate()`. This broke standard browser behaviors that technical users rely on daily - right-click → "Open in new tab", middle-click, Ctrl/Cmd+click, and copying link addresses all silently did nothing.

This PR replaces those `<div>` elements with React Router `<Link>` components, which render as real `<a href="...">` tags in the DOM. This is the correct approach because `<Link>` preserves SPA routing (no full page reload on normal click) while restoring all native browser behaviors for free, with no extra event-handling logic needed.

**Scope:** Sidebar navigation only - primary nav items, pinned shortcuts, "More" section items, brand logo, and "Get Started" button. Dashboard cards, Services list, Alerts list, and trace/span links are follow-up PRs.

#### Screenshots / Screen Recordings (if applicable)

https://github.com/user-attachments/assets/a6923935-9744-4d0b-80c4-38e1f810ddec



#### Issues closed by this PR
Fixes part of #11822

---
### ✅ Change Type
_Select all that apply_
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---
### 🐛 Bug Context

#### Root Cause
Sidebar nav items were implemented as `<div>` elements with imperative `onClick` → `history.push()` navigation. The browser has no way to know these are navigable links, so right-click context menus, middle-click, and modifier-key clicks all silently do nothing. This is a structural issue, the element type itself is wrong for the intended behavior.

#### Fix Strategy
- Added an optional `href` prop to `NavItem`. When provided and the item is not disabled, it renders as `<Link to={href}>` instead of `<div>`, giving the DOM a real `<a>` tag with a valid `href`.
- Added `getNavItemHref()` in `SideNav.tsx` to compute the correct URL for each item at render time (reusing the existing `buildNavUrl` + `getQueryString` logic already used for keyboard shortcuts).
- `handleMenuItemClick` is simplified to analytics logging only, navigation is now handled natively by the browser via `<Link>`.
- Non-route items (Quick Search → CmdK modal) receive `href={undefined}` and remain as `<div>` elements intentionally.
- Anchor reset styles added to both SCSS files so `<a>` tags are visually identical to the previous `<div>` styling (no underline,
  inherited color, all states covered including `:visited`).

---
### 🧪 Testing Strategy

- Tests added/updated: None in this PR (can add tests in case needed)
- Manual verification:
  - Right-click → "Open link in new tab" works on all primary nav items 
  - Middle-click opens new tab 
  - Ctrl+Click opens new tab 
  - Normal left-click still does SPA navigation (no full page reload)
  - Active-state highlight follows current route correctly 
  - Quick Search still opens CmdK modal, no href exposed 
  - Keyboard Tab/Enter navigation intact, focus outlines visible 
  - Brand logo right-clickable with correct href 
- Edge cases covered:
  - Disabled items (workspace blocked): fall through to `<div>` path, `event.preventDefault()` guard also present inside Link onClick
  - Pin/unpin icon clicks: `stopPropagation` + `preventDefault` prevent the pin click from triggering Link navigation
  - AI Assistant item: href computed dynamically based on active conversation ID

---
### ⚠️ Risk & Impact Assessment

- Blast radius: Sidebar navigation only. No backend changes, no API changes, no data model changes.
- Potential regressions:
  - Visual: `<a>` tags could pick up global anchor styles if any exist outside the reset rules added, mitigated by the explicit resets on`.nav-item`, `.brand-logo`, and `.get-started-btn` covering all pseudo-states (`:hover`, `:focus`, `:active`, `:visited`)
  - Analytics: `logEvent` calls are preserved in the `onClick` prop on `<Link>`, so tracking is unaffected
  - Keyboard shortcuts: `onClickHandler` (used by `registerShortcut`) is unchanged and still calls `history.push()` directly
- Rollback plan: Revert the 4 changed files. No migrations or infrastructure changes involved.

---
### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Sidebar nav items now render as real anchor elements, enabling right-click → "Open in new tab", middle-click, and Ctrl/Cmd+click across all primary nav, shortcuts, and "More" section items |

---
### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---
## 👀 Notes for Reviewers

- Quick Search is intentionally left as a `<div>`, it triggers the CmdK modal and has no route URL to link to. It would not make sense as an anchor element.
- Help & Support and Settings dropdown items are out of scope, they live inside Radix dropdown portals and follow a different interaction
  pattern. They can be addressed separately if desired.
- The `getNavItemHref()` function reuses `buildNavUrl` + `getQueryString` which are the same utilities already used by keyboard shortcuts and `onClickHandler`-  no new URL-building logic was introduced.