### PR TITLE
fix(dashboards): stop query cache collisions on public dashboards

### DIFF
--- a/frontend/src/container/PublicDashboardContainer/Panel.tsx
+++ b/frontend/src/container/PublicDashboardContainer/Panel.tsx
@@ -79,13 +79,11 @@ function Panel({
 		},
 		ENTITY_VERSION_V5,
 		{
-			queryKey: [
-				widget?.query,
-				widget?.panelTypes,
-				requestData,
-				startTime,
-				endTime,
-			],
+			// Public data is fetched by index and the payload redacts each widget's
+			// filters, so query bodies are identical across panels. Key on panel
+			// identity + time — the only inputs that determine the response — so
+			// panels don't collapse onto one cache entry.
+			queryKey: [widget?.id, index, startTime, endTime],
 			retry(failureCount, error): boolean {
 				if (
 					String(error).includes('status: error') &&

--- a/frontend/src/container/PublicDashboardContainer/__tests__/Panel.test.tsx
+++ b/frontend/src/container/PublicDashboardContainer/__tests__/Panel.test.tsx
@@ -1,0 +1,79 @@
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { render } from 'tests/test-utils';
+import { Widgets } from 'types/api/dashboard/getAll';
+
+import Panel from '../Panel';
+
+const useGetQueryRangeMock = jest.fn();
+
+jest.mock('hooks/queryBuilder/useGetQueryRange', () => ({
+	useGetQueryRange: (...args: unknown[]): unknown => {
+		useGetQueryRangeMock(...args);
+		return {
+			data: undefined,
+			isFetching: false,
+			isLoading: false,
+			isSuccess: true,
+			isError: false,
+		};
+	},
+}));
+
+jest.mock('container/GridCardLayout/GridCard/WidgetGraphComponent', () => ({
+	__esModule: true,
+	default: (): JSX.Element => <div data-testid="widget-graph" />,
+}));
+
+const buildWidget = (id: string): Widgets =>
+	({
+		id,
+		panelTypes: PANEL_TYPES.LIST,
+		query: {
+			builder: {
+				queryData: [{ dataSource: 'logs', limit: 100, orderBy: [] }],
+			},
+		},
+		timePreferance: 'GLOBAL_TIME',
+	}) as unknown as Widgets;
+
+describe('Public dashboard Panel', () => {
+	beforeEach(() => {
+		useGetQueryRangeMock.mockClear();
+	});
+
+	it('keys each panel by widget id + index so identical queries do not collide (bug 5503)', () => {
+		render(
+			<>
+				<Panel
+					widget={buildWidget('widget-a')}
+					index={2}
+					dashboardId="dash-1"
+					startTime={100}
+					endTime={200}
+				/>
+				<Panel
+					widget={buildWidget('widget-b')}
+					index={62}
+					dashboardId="dash-1"
+					startTime={100}
+					endTime={200}
+				/>
+			</>,
+		);
+
+		const [callA, callB] = useGetQueryRangeMock.mock.calls;
+		const queryKeyA = callA[2].queryKey;
+		const metaA = callA[4];
+		const queryKeyB = callB[2].queryKey;
+		const metaB = callB[4];
+
+		// Key is panel identity + time only — the redacted query body is not part
+		// of it, so identical query bodies can't collapse two panels onto one key.
+		expect(queryKeyA).toStrictEqual(['widget-a', 2, 100, 200]);
+		expect(queryKeyB).toStrictEqual(['widget-b', 62, 100, 200]);
+		expect(queryKeyA).not.toStrictEqual(queryKeyB);
+
+		expect(metaA.widgetIndex).toBe(2);
+		expect(metaB.widgetIndex).toBe(62);
+	});
+});


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

On the public dashboard viewer (`/public/dashboard/:id`), panels fetched the **wrong data** — a single request filled many panels while others never fired a request at all.

Public widget data is fetched **by widget index** (`/public/dashboards/{id}/widgets/{idx}/query_range`), and the public payload **redacts each widget's query** (filters/limit/orderBy are stripped, only aggregations/groupBy/dataSource remain). So two panels that differ only by their filter arrive on the client with **identical query bodies**. The old react-query cache key was built from that query body, so those panels hashed to the **same key** and react-query deduped them into one query → one request (for whichever index won) → its result shared across every colliding panel.

Fix: key each panel on what actually determines its response — `widget.id` + `index` + time — instead of the redacted query body. Each panel then gets its own index-scoped cache entry and request.

#### Issues closed by this PR

Closes https://github.com/SigNoz/engineering-pod/issues/5503

### Screenshots

https://drive.google.com/drive/folders/1UtN4IBbSFKp8vKYBXBm3Hy5AVWUoqZsS?usp=sharing

---

### ✅ Change Type

- [x] 🐛 Bug fix
- [x] 🧪 Test-only (added coverage)

---

### 🐛 Bug Context

#### Root Cause

The panel's react-query key was `[widget.query, panelTypes, requestData, startTime, endTime]`. The public payload redacts each widget's query (filters/limit/orderBy stripped), so panels differing only by their filter serialize to an identical query body — and react-query, which keys by the JSON hash of the key, deduped them onto one cache entry. Since the backend fetches by index, those panels genuinely need separate requests, but only one fired and its data filled all of them.

#### Fix Strategy

Key the query on the inputs that actually determine the response — `widget.id` + `index` + `startTime` + `endTime` — and drop the redacted query body from the key. Each panel then resolves to a unique, index-scoped cache entry.

---

### 🧪 Testing Strategy

- **Tests added:** `PublicDashboardContainer/__tests__/Panel.test.tsx` — renders two panels with identical query bodies and asserts distinct query keys / widget indices.
- **Manual verification:** typecheck (`tsgo --noEmit`), `oxlint`, and `oxfmt --check` clean; full `PublicDashboardContainer` suite green.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** Public-dashboard viewer only; no change to the authenticated dashboard path.
- **Potential regressions:** Very low — the change only widens each panel's cache key.
- **Rollback plan:** Revert the commit; isolated to `PublicDashboardContainer/Panel.tsx`.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Public dashboards now fetch and display the correct data for each panel instead of one panel's data filling several. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered
