### PR TITLE
feat(dashboard-v2): optimistic updates for dashboard spec mutations

### DIFF
--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -328,6 +328,11 @@
           {
             "name": "immer",
             "message": "[State mgmt] Direct immer usage is deprecated. Use Zustand (which integrates immer via the immer middleware) instead."
+          },
+          {
+            "name": "api/generated/services/dashboard",
+            "importNames": ["patchDashboardV2", "usePatchDashboardV2"],
+            "message": "[dashboard-v2] Don't call patchDashboardV2/usePatchDashboardV2 directly — use useOptimisticPatch().patchAsync so spec edits update the react-query cache optimistically and reconcile on settle."
           }
         ]
       }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/index.tsx
@@ -4,7 +4,6 @@ import { toast } from '@signozhq/ui/sonner';
 import logEvent from 'api/common/logEvent';
 import {
 	lockDashboardV2,
-	patchDashboardV2,
 	unlockDashboardV2,
 } from 'api/generated/services/dashboard';
 import type {
@@ -18,6 +17,7 @@ import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
 import { useCreatePanel } from '../hooks/useCreatePanel';
+import { useOptimisticPatch } from '../hooks/useOptimisticPatch';
 import PanelTypeSelectionModal from '../PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal';
 import DashboardActions from './DashboardActions/DashboardActions';
 import DashboardInfo from './DashboardInfo/DashboardInfo';
@@ -51,6 +51,7 @@ function DashboardPageToolbar(props: DashboardPageToolbarProps): JSX.Element {
 
 	const { user } = useAppContext();
 	const { showErrorModal } = useErrorModal();
+	const { patchAsync } = useOptimisticPatch();
 	const { isPickerOpen, openPicker, closePicker, createPanel } =
 		useCreatePanel();
 
@@ -88,14 +89,13 @@ function DashboardPageToolbar(props: DashboardPageToolbarProps): JSX.Element {
 						value: next,
 					},
 				];
-				await patchDashboardV2({ id }, patch);
+				await patchAsync(patch);
 				toast.success('Dashboard renamed successfully');
-				refetch();
 			} catch (error) {
 				showErrorModal(error as APIError);
 			}
 		},
-		[id, refetch, showErrorModal],
+		[id, patchAsync, showErrorModal],
 	);
 
 	const { isEditing, draft, setDraft, startEdit, cancel, commit } =

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { patchDashboardV2 } from 'api/generated/services/dashboard';
 import type {
 	DashboardtypesGettableDashboardV2DTO,
 	DashboardtypesJSONPatchOperationDTO,
@@ -9,7 +8,7 @@ import { isEqual } from 'lodash-es';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
-import { useDashboardStore } from '../../store/useDashboardStore';
+import { useOptimisticPatch } from '../../hooks/useOptimisticPatch';
 import CrossPanelSync from './CrossPanelSync/CrossPanelSync';
 import DashboardInfoForm from './DashboardInfoForm/DashboardInfoForm';
 import UnsavedChangesFooter from './UnsavedChangesFooter/UnsavedChangesFooter';
@@ -23,7 +22,7 @@ interface OverviewProps {
 function Overview({ dashboard }: OverviewProps): JSX.Element {
 	const id = dashboard.id;
 
-	const refetch = useDashboardStore((s) => s.refetch);
+	const { patchAsync } = useOptimisticPatch();
 
 	const title = dashboard.spec.display.name;
 	const description = dashboard.spec.display.description ?? '';
@@ -96,15 +95,14 @@ function Overview({ dashboard }: OverviewProps): JSX.Element {
 
 		try {
 			setIsSaving(true);
-			await patchDashboardV2({ id }, ops);
+			await patchAsync(ops);
 			toast.success('Dashboard updated');
-			refetch();
 		} catch (error) {
 			showErrorModal(error as APIError);
 		} finally {
 			setIsSaving(false);
 		}
-	}, [id, buildPatch, refetch, showErrorModal]);
+	}, [buildPatch, patchAsync, showErrorModal]);
 
 	useEffect(() => {
 		let numberOfUnsavedChanges = 0;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/useSaveVariables.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/useSaveVariables.ts
@@ -1,9 +1,9 @@
 import { useCallback, useState } from 'react';
-import { patchDashboardV2 } from 'api/generated/services/dashboard';
 import { toast } from '@signozhq/ui/sonner';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
+import { useOptimisticPatch } from '../../hooks/useOptimisticPatch';
 import { useDashboardStore } from '../../store/useDashboardStore';
 import { formModelToDto } from './variableAdapters';
 import type { VariableFormModel } from './variableFormModel';
@@ -14,14 +14,9 @@ interface UseSaveVariables {
 	isSaving: boolean;
 }
 
-/**
- * Persists the dashboard's variable list via a single `/spec/variables` patch,
- * then refetches. Mirrors the General-settings save flow (patch → toast →
- * refetch → surface errors).
- */
 export function useSaveVariables(): UseSaveVariables {
 	const dashboardId = useDashboardStore((s) => s.dashboardId);
-	const refetch = useDashboardStore((s) => s.refetch);
+	const { patchAsync } = useOptimisticPatch();
 	const { showErrorModal } = useErrorModal();
 	const [isSaving, setIsSaving] = useState(false);
 
@@ -33,9 +28,8 @@ export function useSaveVariables(): UseSaveVariables {
 			const dtos = variables.map(formModelToDto);
 			try {
 				setIsSaving(true);
-				await patchDashboardV2({ id: dashboardId }, buildVariablesPatch(dtos));
+				await patchAsync(buildVariablesPatch(dtos));
 				toast.success('Variables updated');
-				refetch();
 				return true;
 			} catch (error) {
 				showErrorModal(error as APIError);
@@ -44,7 +38,7 @@ export function useSaveVariables(): UseSaveVariables {
 				setIsSaving(false);
 			}
 		},
-		[dashboardId, refetch, showErrorModal],
+		[dashboardId, patchAsync, showErrorModal],
 	);
 
 	return { save, isSaving };

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/usePanelEditorSave.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/usePanelEditorSave.test.ts
@@ -1,40 +1,36 @@
 import { renderHook } from '@testing-library/react';
-import {
-	getGetDashboardV2QueryKey,
-	usePatchDashboardV2,
-} from 'api/generated/services/dashboard';
 import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
 
 import { usePanelEditorSave } from '../usePanelEditorSave';
 
-const mockInvalidateQueries = jest.fn();
+const mockPatchAsync = jest.fn().mockResolvedValue(undefined);
+let mockIsPatching = false;
+jest.mock('../../../hooks/useOptimisticPatch', () => ({
+	useOptimisticPatch: (): {
+		patchAsync: jest.Mock;
+		isPatching: boolean;
+		error: Error | null;
+	} => ({ patchAsync: mockPatchAsync, isPatching: mockIsPatching, error: null }),
+}));
+
+// The hook reads getQueryData only for the isNew branch; a stub client is enough here.
 jest.mock('react-query', () => ({
-	useQueryClient: (): { invalidateQueries: jest.Mock } => ({
-		invalidateQueries: mockInvalidateQueries,
+	useQueryClient: (): { getQueryData: jest.Mock } => ({
+		getQueryData: jest.fn(),
 	}),
 }));
 
 jest.mock('api/generated/services/dashboard', () => ({
-	usePatchDashboardV2: jest.fn(),
 	getGetDashboardV2QueryKey: jest.fn(() => ['/api/v2/dashboards/dash-1']),
 }));
 
-const mockUsePatch = usePatchDashboardV2 as unknown as jest.Mock;
-const mockGetQueryKey = getGetDashboardV2QueryKey as unknown as jest.Mock;
-
 describe('usePanelEditorSave', () => {
-	const mutateAsync = jest.fn().mockResolvedValue(undefined);
-
 	beforeEach(() => {
 		jest.clearAllMocks();
-		mockUsePatch.mockReturnValue({
-			mutateAsync,
-			isLoading: false,
-			error: null,
-		});
+		mockIsPatching = false;
 	});
 
-	it('emits an add patch replacing the whole panel spec and invalidates the dashboard query', async () => {
+	it('optimistically patches an add replacing the whole panel spec', async () => {
 		const { result } = renderHook(() =>
 			usePanelEditorSave({ dashboardId: 'dash-1', panelId: 'panel-9' }),
 		);
@@ -50,28 +46,17 @@ describe('usePanelEditorSave', () => {
 
 		await result.current.save(spec);
 
-		expect(mutateAsync).toHaveBeenCalledWith({
-			pathParams: { id: 'dash-1' },
-			data: [
-				{
-					op: 'add',
-					path: '/spec/panels/panel-9/spec',
-					value: spec,
-				},
-			],
-		});
-		expect(mockGetQueryKey).toHaveBeenCalledWith({ id: 'dash-1' });
-		expect(mockInvalidateQueries).toHaveBeenCalledWith([
-			'/api/v2/dashboards/dash-1',
+		expect(mockPatchAsync).toHaveBeenCalledWith([
+			{
+				op: 'add',
+				path: '/spec/panels/panel-9/spec',
+				value: spec,
+			},
 		]);
 	});
 
-	it('surfaces the mutation loading state as isSaving', () => {
-		mockUsePatch.mockReturnValue({
-			mutateAsync,
-			isLoading: true,
-			error: null,
-		});
+	it('surfaces the patch in-flight state as isSaving', () => {
+		mockIsPatching = true;
 
 		const { result } = renderHook(() =>
 			usePanelEditorSave({ dashboardId: 'dash-1', panelId: 'panel-9' }),

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/usePanelEditorSave.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/usePanelEditorSave.ts
@@ -1,10 +1,7 @@
 import { useCallback } from 'react';
 import { useQueryClient } from 'react-query';
 import { v4 as uuid } from 'uuid';
-import {
-	getGetDashboardV2QueryKey,
-	usePatchDashboardV2,
-} from 'api/generated/services/dashboard';
+import { getGetDashboardV2QueryKey } from 'api/generated/services/dashboard';
 import {
 	type DashboardtypesJSONPatchOperationDTO,
 	type DashboardtypesPanelSpecDTO,
@@ -13,6 +10,7 @@ import {
 	type GetDashboardV2200,
 } from 'api/generated/services/sigNoz.schemas';
 
+import { useOptimisticPatch } from '../../hooks/useOptimisticPatch';
 import { createPanelOps } from '../../patchOps';
 
 interface UsePanelEditorSaveArgs {
@@ -43,15 +41,14 @@ export function usePanelEditorSave({
 	layoutIndex,
 }: UsePanelEditorSaveArgs): UsePanelEditorSaveApi {
 	const queryClient = useQueryClient();
-	const { mutateAsync, isLoading, error } = usePatchDashboardV2();
+	const { patchAsync, isPatching, error } = useOptimisticPatch(dashboardId);
 
 	const save = useCallback(
 		async (spec: DashboardtypesPanelSpecDTO): Promise<void> => {
-			const dashboardQueryKey = getGetDashboardV2QueryKey({ id: dashboardId });
-
 			let ops: DashboardtypesJSONPatchOperationDTO[];
 			if (isNew) {
 				// Resolve the target section against the freshest dashboard we have.
+				const dashboardQueryKey = getGetDashboardV2QueryKey({ id: dashboardId });
 				const cached =
 					queryClient.getQueryData<GetDashboardV2200>(dashboardQueryKey);
 				ops = createPanelOps({
@@ -70,11 +67,11 @@ export function usePanelEditorSave({
 				];
 			}
 
-			await mutateAsync({ pathParams: { id: dashboardId }, data: ops });
-			await queryClient.invalidateQueries(dashboardQueryKey);
+			// Optimistic cache write + settle refetch (replaces the manual invalidate).
+			await patchAsync(ops);
 		},
-		[dashboardId, panelId, isNew, layoutIndex, mutateAsync, queryClient],
+		[dashboardId, panelId, isNew, layoutIndex, patchAsync, queryClient],
 	);
 
-	return { save, isSaving: isLoading, error: (error as Error) ?? null };
+	return { save, isSaving: isPatching, error };
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useClonePanel.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/__tests__/useClonePanel.test.ts
@@ -1,12 +1,15 @@
 import { renderHook } from '@testing-library/react';
-import { patchDashboardV2 } from 'api/generated/services/dashboard';
 
 import { useDashboardStore } from '../../../../store/useDashboardStore';
 import type { DashboardSection } from '../../../../utils';
 import { useClonePanel } from '../useClonePanel';
 
-jest.mock('api/generated/services/dashboard', () => ({
-	patchDashboardV2: jest.fn().mockResolvedValue(undefined),
+const mockPatchAsync = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../../hooks/useOptimisticPatch', () => ({
+	useOptimisticPatch: (): { patchAsync: jest.Mock; isPatching: boolean } => ({
+		patchAsync: mockPatchAsync,
+		isPatching: false,
+	}),
 }));
 
 const mockToastPromise = jest.fn();
@@ -15,8 +18,6 @@ jest.mock('@signozhq/ui/sonner', () => ({
 }));
 
 jest.mock('uuid', () => ({ v4: (): string => 'cloned-id' }));
-
-const mockPatch = patchDashboardV2 as unknown as jest.Mock;
 
 const sourcePanel = {
 	kind: 'Panel',
@@ -45,7 +46,7 @@ function sections(): DashboardSection[] {
 describe('useClonePanel', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
-		useDashboardStore.setState({ dashboardId: 'dash-1', refetch: jest.fn() });
+		useDashboardStore.setState({ dashboardId: 'dash-1' });
 	});
 
 	it('patches an add of the deep-copied spec + a new item under the same section', async () => {
@@ -53,7 +54,7 @@ describe('useClonePanel', () => {
 
 		await result.current({ panelId: 'p1', layoutIndex: 0 });
 
-		expect(mockPatch).toHaveBeenCalledWith({ id: 'dash-1' }, [
+		expect(mockPatchAsync).toHaveBeenCalledWith([
 			{
 				op: 'add',
 				path: '/spec/panels/cloned-id',
@@ -92,7 +93,7 @@ describe('useClonePanel', () => {
 
 		await result.current({ panelId: 'p1', layoutIndex: 0 });
 
-		const ops = mockPatch.mock.calls[0][1];
+		const ops = mockPatchAsync.mock.calls[0][0];
 		// Room in the last row (4 + 4 = 8 ≤ 12 cols) → sits to the right at y:0.
 		expect(ops[1].value).toMatchObject({ x: 4, y: 0, width: 4, height: 5 });
 	});
@@ -102,7 +103,7 @@ describe('useClonePanel', () => {
 
 		await result.current({ panelId: 'p1', layoutIndex: 0 });
 
-		const ops = mockPatch.mock.calls[0][1];
+		const ops = mockPatchAsync.mock.calls[0][0];
 		expect(ops[0].value).toStrictEqual(sourcePanel);
 		expect(ops[0].value).not.toBe(sourcePanel);
 	});
@@ -112,7 +113,7 @@ describe('useClonePanel', () => {
 
 		await result.current({ panelId: 'missing', layoutIndex: 0 });
 
-		expect(mockPatch).not.toHaveBeenCalled();
+		expect(mockPatchAsync).not.toHaveBeenCalled();
 		expect(mockToastPromise).not.toHaveBeenCalled();
 	});
 
@@ -132,7 +133,7 @@ describe('useClonePanel', () => {
 	});
 
 	it('swallows a patch rejection (toast owns the error UX) — does not throw', async () => {
-		mockPatch.mockRejectedValueOnce(new Error('boom'));
+		mockPatchAsync.mockRejectedValueOnce(new Error('boom'));
 		const { result } = renderHook(() => useClonePanel({ sections: sections() }));
 
 		await expect(

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useClonePanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useClonePanel.ts
@@ -3,8 +3,7 @@ import { toast } from '@signozhq/ui/sonner';
 import { cloneDeep } from 'lodash-es';
 import { v4 as uuid } from 'uuid';
 
-import { patchDashboardV2 } from 'api/generated/services/dashboard';
-
+import { useOptimisticPatch } from '../../../hooks/useOptimisticPatch';
 import {
 	addPanelToSectionOps,
 	findFreeSlot,
@@ -32,7 +31,7 @@ export function useClonePanel({
 	sections,
 }: Params): (args: ClonePanelArgs) => Promise<void> {
 	const dashboardId = useDashboardStore((s) => s.dashboardId);
-	const refetch = useDashboardStore((s) => s.refetch);
+	const { patchAsync } = useOptimisticPatch();
 
 	return useCallback(
 		async ({ panelId, layoutIndex }: ClonePanelArgs): Promise<void> => {
@@ -45,8 +44,7 @@ export function useClonePanel({
 			const newPanelId = uuid();
 			const { x, y } = findFreeSlot(section.items, source.width);
 
-			const clone = patchDashboardV2(
-				{ id: dashboardId },
+			const clone = patchAsync(
 				addPanelToSectionOps({
 					panelId: newPanelId,
 					panel: cloneDeep(source.panel),
@@ -68,15 +66,14 @@ export function useClonePanel({
 				position: 'top-center',
 			});
 
-			// Refetch only on success; toast.promise owns the error UX, so swallow
-			// the rejection to avoid an unhandled rejection.
+			// toast.promise owns the error UX; swallow here to avoid an unhandled
+			// rejection (the optimistic cache write + settle refetch handle state).
 			try {
 				await clone;
-				refetch();
 			} catch {
 				// no-op
 			}
 		},
-		[sections, dashboardId, refetch],
+		[sections, dashboardId, patchAsync],
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDeletePanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDeletePanel.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 
-import { patchDashboardV2 } from 'api/generated/services/dashboard';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
+import { useOptimisticPatch } from '../../../hooks/useOptimisticPatch';
 import { removePanelOp, replaceSectionItemsOp } from '../../../patchOps';
 import { useDashboardStore } from '../../../store/useDashboardStore';
 import type { DashboardSection } from '../../../utils';
@@ -25,7 +25,7 @@ export function useDeletePanel({
 	sections,
 }: Params): (args: DeletePanelArgs) => Promise<void> {
 	const dashboardId = useDashboardStore((s) => s.dashboardId);
-	const refetch = useDashboardStore((s) => s.refetch);
+	const { patchAsync } = useOptimisticPatch();
 	const { showErrorModal } = useErrorModal();
 
 	return useCallback(
@@ -40,15 +40,14 @@ export function useDeletePanel({
 
 			const nextItems = section.items.filter((i) => i.id !== panelId);
 			try {
-				await patchDashboardV2({ id: dashboardId }, [
+				await patchAsync([
 					replaceSectionItemsOp(layoutIndex, nextItems),
 					removePanelOp(panelId),
 				]);
-				refetch();
 			} catch (error) {
 				showErrorModal(error as APIError);
 			}
 		},
-		[sections, dashboardId, refetch, showErrorModal],
+		[sections, dashboardId, patchAsync, showErrorModal],
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useMovePanelToSection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useMovePanelToSection.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 
-import { patchDashboardV2 } from 'api/generated/services/dashboard';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
+import { useOptimisticPatch } from '../../../hooks/useOptimisticPatch';
 import { movePanelBetweenSectionsOps } from '../../../patchOps';
 import { useDashboardStore } from '../../../store/useDashboardStore';
 import type { DashboardSection } from '../../../utils';
@@ -27,7 +27,7 @@ export function useMovePanelToSection({
 	sections,
 }: Params): (args: MovePanelArgs) => Promise<void> {
 	const dashboardId = useDashboardStore((s) => s.dashboardId);
-	const refetch = useDashboardStore((s) => s.refetch);
+	const { patchAsync } = useOptimisticPatch();
 	const { showErrorModal } = useErrorModal();
 
 	return useCallback(
@@ -60,8 +60,7 @@ export function useMovePanelToSection({
 			const targetItems = [...target.items, { ...moved, x: 0, y: nextY }];
 
 			try {
-				await patchDashboardV2(
-					{ id: dashboardId },
+				await patchAsync(
 					movePanelBetweenSectionsOps({
 						sourceIndex: fromLayoutIndex,
 						sourceItems,
@@ -69,11 +68,10 @@ export function useMovePanelToSection({
 						targetItems,
 					}),
 				);
-				refetch();
 			} catch (error) {
 				showErrorModal(error as APIError);
 			}
 		},
-		[sections, dashboardId, refetch, showErrorModal],
+		[sections, dashboardId, patchAsync, showErrorModal],
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useAddSection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useAddSection.ts
@@ -1,10 +1,10 @@
 import { useCallback, useState } from 'react';
 
-import { patchDashboardV2 } from 'api/generated/services/dashboard';
 import type { DashboardtypesLayoutDTO } from 'api/generated/services/sigNoz.schemas';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
+import { useOptimisticPatch } from '../../../hooks/useOptimisticPatch';
 import {
 	addSectionOp,
 	newGridLayout,
@@ -15,9 +15,9 @@ import { useDashboardStore } from '../../../store/useDashboardStore';
 const SECTION_SELECTOR = '[data-testid^="dashboard-section-"]';
 
 /**
- * Waits (via rAF) for the refetch to render the appended section, then scrolls
- * it into view. Polls because `refetch` resolves before React commits the new
- * section to the DOM; bails after ~40 frames.
+ * Waits (via rAF) for the appended section to render, then scrolls it into view.
+ * Polls because the optimistic cache write commits to the DOM a frame or two after
+ * the patch call; bails after ~40 frames.
  */
 function scrollToNewSection(prevCount: number, attempts = 40): void {
 	const sections = document.querySelectorAll(SECTION_SELECTOR);
@@ -49,7 +49,7 @@ interface Result {
  */
 export function useAddSection({ layouts }: Params): Result {
 	const dashboardId = useDashboardStore((s) => s.dashboardId);
-	const refetch = useDashboardStore((s) => s.refetch);
+	const { patchAsync } = useOptimisticPatch();
 	const [isSaving, setIsSaving] = useState(false);
 	const { showErrorModal } = useErrorModal();
 
@@ -66,8 +66,7 @@ export function useAddSection({ layouts }: Params): Result {
 			const prevSectionCount = document.querySelectorAll(SECTION_SELECTOR).length;
 			try {
 				setIsSaving(true);
-				await patchDashboardV2({ id: dashboardId }, [op]);
-				refetch();
+				await patchAsync([op]);
 				scrollToNewSection(prevSectionCount);
 			} catch (error) {
 				showErrorModal(error as APIError);
@@ -75,7 +74,7 @@ export function useAddSection({ layouts }: Params): Result {
 				setIsSaving(false);
 			}
 		},
-		[layouts, dashboardId, refetch, showErrorModal],
+		[layouts, dashboardId, patchAsync, showErrorModal],
 	);
 
 	return { addSection, isSaving };

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useDeleteSection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useDeleteSection.ts
@@ -1,10 +1,10 @@
 import { useCallback, useState } from 'react';
 
-import { patchDashboardV2 } from 'api/generated/services/dashboard';
 import type { DashboardtypesJSONPatchOperationDTO } from 'api/generated/services/sigNoz.schemas';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
+import { useOptimisticPatch } from '../../../hooks/useOptimisticPatch';
 import { removePanelOp, removeSectionOp } from '../../../patchOps';
 import { useDashboardStore } from '../../../store/useDashboardStore';
 import type { DashboardSection } from '../../../utils';
@@ -24,7 +24,7 @@ interface Result {
  */
 export function useDeleteSection({ section }: Params): Result {
 	const dashboardId = useDashboardStore((s) => s.dashboardId);
-	const refetch = useDashboardStore((s) => s.refetch);
+	const { patchAsync } = useOptimisticPatch();
 	const [isSaving, setIsSaving] = useState(false);
 	const { showErrorModal } = useErrorModal();
 
@@ -38,14 +38,13 @@ export function useDeleteSection({ section }: Params): Result {
 		ops.push(removeSectionOp(section.layoutIndex));
 		try {
 			setIsSaving(true);
-			await patchDashboardV2({ id: dashboardId }, ops);
-			refetch();
+			await patchAsync(ops);
 		} catch (error) {
 			showErrorModal(error as APIError);
 		} finally {
 			setIsSaving(false);
 		}
-	}, [section, dashboardId, refetch, showErrorModal]);
+	}, [section, dashboardId, patchAsync, showErrorModal]);
 
 	return { deleteSection, isSaving };
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useFirstSectionMigration.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useFirstSectionMigration.ts
@@ -1,10 +1,10 @@
 import { useCallback, useState } from 'react';
 
-import { patchDashboardV2 } from 'api/generated/services/dashboard';
 import type { DashboardtypesJSONPatchOperationDTO } from 'api/generated/services/sigNoz.schemas';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
+import { useOptimisticPatch } from '../../../hooks/useOptimisticPatch';
 import { addSectionOp, titleUntitledSectionOp } from '../../../patchOps';
 import { useDashboardStore } from '../../../store/useDashboardStore';
 import type { DashboardSection } from '../../../utils';
@@ -26,7 +26,7 @@ interface Result {
  */
 export function useFirstSectionMigration({ sections }: Params): Result {
 	const dashboardId = useDashboardStore((s) => s.dashboardId);
-	const refetch = useDashboardStore((s) => s.refetch);
+	const { patchAsync } = useOptimisticPatch();
 	const [isSaving, setIsSaving] = useState(false);
 	const { showErrorModal } = useErrorModal();
 
@@ -49,15 +49,14 @@ export function useFirstSectionMigration({ sections }: Params): Result {
 
 			try {
 				setIsSaving(true);
-				await patchDashboardV2({ id: dashboardId }, ops);
-				refetch();
+				await patchAsync(ops);
 			} catch (error) {
 				showErrorModal(error as APIError);
 			} finally {
 				setIsSaving(false);
 			}
 		},
-		[sections, dashboardId, refetch, showErrorModal],
+		[sections, dashboardId, patchAsync, showErrorModal],
 	);
 
 	return { migrate, isSaving };

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/usePersistLayout.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/usePersistLayout.ts
@@ -1,10 +1,10 @@
 import { useCallback, useState } from 'react';
 import type { Layout } from 'react-grid-layout';
 
-import { patchDashboardV2 } from 'api/generated/services/dashboard';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
+import { useOptimisticPatch } from '../../../hooks/useOptimisticPatch';
 import { replaceSectionItemsOp } from '../../../patchOps';
 import { useDashboardStore } from '../../../store/useDashboardStore';
 import type { GridItem } from '../../../utils';
@@ -65,7 +65,7 @@ function hasGeometryChanged(next: GridItem[], prev: GridItem[]): boolean {
  */
 export function usePersistLayout({ layoutIndex, items }: Params): Result {
 	const dashboardId = useDashboardStore((s) => s.dashboardId);
-	const refetch = useDashboardStore((s) => s.refetch);
+	const { patchAsync } = useOptimisticPatch();
 	const [isSaving, setIsSaving] = useState(false);
 	const { showErrorModal } = useErrorModal();
 
@@ -80,17 +80,14 @@ export function usePersistLayout({ layoutIndex, items }: Params): Result {
 			}
 			try {
 				setIsSaving(true);
-				await patchDashboardV2({ id: dashboardId }, [
-					replaceSectionItemsOp(layoutIndex, nextItems),
-				]);
-				refetch();
+				await patchAsync([replaceSectionItemsOp(layoutIndex, nextItems)]);
 			} catch (error) {
 				showErrorModal(error as APIError);
 			} finally {
 				setIsSaving(false);
 			}
 		},
-		[dashboardId, items, layoutIndex, refetch, showErrorModal],
+		[dashboardId, items, layoutIndex, patchAsync, showErrorModal],
 	);
 
 	return { handleLayoutChange, isSaving };

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useRenameSection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useRenameSection.ts
@@ -1,9 +1,9 @@
 import { useCallback, useState } from 'react';
 
-import { patchDashboardV2 } from 'api/generated/services/dashboard';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
+import { useOptimisticPatch } from '../../../hooks/useOptimisticPatch';
 import { renameSectionOp } from '../../../patchOps';
 import { useDashboardStore } from '../../../store/useDashboardStore';
 
@@ -19,7 +19,7 @@ interface Result {
 /** Renames a section's title via `replace /spec/layouts/<i>/spec/display/title`. */
 export function useRenameSection({ layoutIndex }: Params): Result {
 	const dashboardId = useDashboardStore((s) => s.dashboardId);
-	const refetch = useDashboardStore((s) => s.refetch);
+	const { patchAsync } = useOptimisticPatch();
 	const [isSaving, setIsSaving] = useState(false);
 	const { showErrorModal } = useErrorModal();
 
@@ -31,10 +31,7 @@ export function useRenameSection({ layoutIndex }: Params): Result {
 			}
 			try {
 				setIsSaving(true);
-				await patchDashboardV2({ id: dashboardId }, [
-					renameSectionOp(layoutIndex, trimmed),
-				]);
-				refetch();
+				await patchAsync([renameSectionOp(layoutIndex, trimmed)]);
 				return true;
 			} catch (error) {
 				showErrorModal(error as APIError);
@@ -43,7 +40,7 @@ export function useRenameSection({ layoutIndex }: Params): Result {
 				setIsSaving(false);
 			}
 		},
-		[dashboardId, layoutIndex, refetch, showErrorModal],
+		[dashboardId, layoutIndex, patchAsync, showErrorModal],
 	);
 
 	return { rename, isSaving };

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useSectionDragReorder.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useSectionDragReorder.ts
@@ -9,11 +9,11 @@ import {
 } from '@dnd-kit/core';
 import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 
-import { patchDashboardV2 } from 'api/generated/services/dashboard';
 import type { DashboardtypesLayoutDTO } from 'api/generated/services/sigNoz.schemas';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
+import { useOptimisticPatch } from '../../../hooks/useOptimisticPatch';
 import { reorderLayoutsOp } from '../../../patchOps';
 import { useDashboardStore } from '../../../store/useDashboardStore';
 import type { DashboardSection } from '../../../utils';
@@ -43,7 +43,7 @@ interface Result {
  */
 export function useSectionDragReorder({ sections, layouts }: Params): Result {
 	const dashboardId = useDashboardStore((s) => s.dashboardId);
-	const refetch = useDashboardStore((s) => s.refetch);
+	const { patchAsync } = useOptimisticPatch();
 	const [activeId, setActiveId] = useState<string | null>(null);
 	const [localOrderIds, setLocalOrderIds] = useState<string[] | null>(null);
 	const { showErrorModal } = useErrorModal();
@@ -99,14 +99,13 @@ export function useSectionDragReorder({ sections, layouts }: Params): Result {
 				.filter((l): l is DashboardtypesLayoutDTO => l !== undefined);
 
 			try {
-				await patchDashboardV2({ id: dashboardId }, [reorderLayoutsOp(newLayouts)]);
-				refetch();
+				await patchAsync([reorderLayoutsOp(newLayouts)]);
 			} catch (error) {
 				setLocalOrderIds(null); // revert optimistic order on failure
 				showErrorModal(error as APIError);
 			}
 		},
-		[orderedSections, layouts, dashboardId, refetch, showErrorModal],
+		[orderedSections, layouts, dashboardId, patchAsync, showErrorModal],
 	);
 
 	const activeSection = useMemo(

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useOptimisticPatch.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useOptimisticPatch.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { useMutation, useQueryClient } from 'react-query';
+// eslint-disable-next-line no-restricted-imports -- the hook's own test mocks and asserts the underlying patchDashboardV2 call.
 import { patchDashboardV2 } from 'api/generated/services/dashboard';
 import type { GetDashboardV2200 } from 'api/generated/services/sigNoz.schemas';
 import { DashboardtypesPatchOpDTO } from 'api/generated/services/sigNoz.schemas';

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useOptimisticPatch.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useOptimisticPatch.test.ts
@@ -1,0 +1,106 @@
+import { renderHook } from '@testing-library/react';
+import { useMutation, useQueryClient } from 'react-query';
+import { patchDashboardV2 } from 'api/generated/services/dashboard';
+import type { GetDashboardV2200 } from 'api/generated/services/sigNoz.schemas';
+import { DashboardtypesPatchOpDTO } from 'api/generated/services/sigNoz.schemas';
+
+import { useOptimisticPatch } from '../useOptimisticPatch';
+
+const QUERY_KEY = ['/api/v2/dashboards/dash-1'];
+
+jest.mock('react-query', () => ({
+	useMutation: jest.fn(),
+	useQueryClient: jest.fn(),
+}));
+
+jest.mock('api/generated/services/dashboard', () => ({
+	patchDashboardV2: jest.fn(),
+	getGetDashboardV2QueryKey: jest.fn(() => ['/api/v2/dashboards/dash-1']),
+}));
+
+jest.mock('../../store/useDashboardStore', () => ({
+	useDashboardStore: jest.fn(
+		(selector: (s: { dashboardId: string }) => unknown) =>
+			selector({ dashboardId: 'dash-1' }),
+	),
+}));
+
+const queryClient = {
+	cancelQueries: jest.fn().mockResolvedValue(undefined),
+	getQueryData: jest.fn(),
+	setQueryData: jest.fn(),
+	invalidateQueries: jest.fn().mockResolvedValue(undefined),
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let captured: { fn: (ops: any) => unknown; options: any };
+
+function dashboardEnvelope(name: string): GetDashboardV2200 {
+	return {
+		data: { spec: { display: { name } } },
+	} as unknown as GetDashboardV2200;
+}
+
+const replaceNameOp = {
+	op: DashboardtypesPatchOpDTO.replace,
+	path: '/spec/display/name',
+	value: 'B',
+};
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	(useQueryClient as jest.Mock).mockReturnValue(queryClient);
+	(useMutation as jest.Mock).mockImplementation((fn, options) => {
+		captured = { fn, options };
+		return { mutateAsync: jest.fn(), isLoading: false };
+	});
+	renderHook(() => useOptimisticPatch());
+});
+
+describe('useOptimisticPatch', () => {
+	it('mutationFn sends the ops to patchDashboardV2 for the current dashboard', () => {
+		captured.fn([replaceNameOp]);
+		expect(patchDashboardV2).toHaveBeenCalledWith({ id: 'dash-1' }, [
+			replaceNameOp,
+		]);
+	});
+
+	it('onMutate cancels fetches, snapshots, and writes the patched dashboard to the cache', async () => {
+		const previous = dashboardEnvelope('A');
+		queryClient.getQueryData.mockReturnValue(previous);
+
+		const context = await captured.options.onMutate([replaceNameOp]);
+
+		expect(queryClient.cancelQueries).toHaveBeenCalledWith(QUERY_KEY);
+		// Optimistic write reflects the op immediately.
+		expect(queryClient.setQueryData).toHaveBeenCalledWith(QUERY_KEY, {
+			data: { spec: { display: { name: 'B' } } },
+		});
+		// Snapshot returned for rollback; original left untouched.
+		expect(context).toStrictEqual({ previous });
+		expect(previous.data).toStrictEqual({ spec: { display: { name: 'A' } } });
+	});
+
+	it('onMutate is a no-op write when there is no cached dashboard', async () => {
+		queryClient.getQueryData.mockReturnValue(undefined);
+		const context = await captured.options.onMutate([replaceNameOp]);
+		expect(queryClient.setQueryData).not.toHaveBeenCalled();
+		expect(context).toStrictEqual({ previous: undefined });
+	});
+
+	it('onError rolls the cache back to the snapshot', () => {
+		const previous = dashboardEnvelope('A');
+		captured.options.onError(new Error('boom'), [replaceNameOp], { previous });
+		expect(queryClient.setQueryData).toHaveBeenCalledWith(QUERY_KEY, previous);
+	});
+
+	it('onError without a snapshot does not touch the cache', () => {
+		captured.options.onError(new Error('boom'), [replaceNameOp], {});
+		expect(queryClient.setQueryData).not.toHaveBeenCalled();
+	});
+
+	it('onSettled invalidates the dashboard query to reconcile', () => {
+		captured.options.onSettled();
+		expect(queryClient.invalidateQueries).toHaveBeenCalledWith(QUERY_KEY);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useOptimisticPatch.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useOptimisticPatch.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from 'react-query';
 import {
 	getGetDashboardV2QueryKey,
+	// eslint-disable-next-line no-restricted-imports -- this hook is the one sanctioned caller of patchDashboardV2; everything else goes through patchAsync.
 	patchDashboardV2,
 } from 'api/generated/services/dashboard';
 import type {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useOptimisticPatch.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useOptimisticPatch.ts
@@ -1,0 +1,72 @@
+import { useMutation, useQueryClient } from 'react-query';
+import {
+	getGetDashboardV2QueryKey,
+	patchDashboardV2,
+} from 'api/generated/services/dashboard';
+import type {
+	DashboardtypesJSONPatchOperationDTO,
+	GetDashboardV2200,
+} from 'api/generated/services/sigNoz.schemas';
+import APIError from 'types/api/error';
+
+import { applyJsonPatch } from '../optimistic/applyJsonPatch';
+import { useDashboardStore } from '../store/useDashboardStore';
+
+/** Cached dashboard snapshot, kept for rollback on error. */
+interface OptimisticPatchContext {
+	previous?: GetDashboardV2200;
+}
+
+export interface UseOptimisticPatch {
+	patchAsync: (ops: DashboardtypesJSONPatchOperationDTO[]) => Promise<unknown>;
+	isPatching: boolean;
+	error: Error | null;
+}
+
+/**
+ * Central optimistic mutation for V2 dashboard spec edits: writes the ops to the
+ * cached dashboard immediately, rolls back on error, reconciles on settle.
+ * `dashboardId` defaults to the edit-context store; the panel editor passes its own.
+ */
+export function useOptimisticPatch(
+	dashboardIdOverride?: string,
+): UseOptimisticPatch {
+	const storeDashboardId = useDashboardStore((s) => s.dashboardId);
+	const dashboardId = dashboardIdOverride ?? storeDashboardId;
+	const queryClient = useQueryClient();
+	const queryKey = getGetDashboardV2QueryKey({ id: dashboardId });
+
+	const mutation = useMutation<
+		Awaited<ReturnType<typeof patchDashboardV2>>,
+		APIError,
+		DashboardtypesJSONPatchOperationDTO[],
+		OptimisticPatchContext
+	>((ops) => patchDashboardV2({ id: dashboardId }, ops), {
+		onMutate: async (ops) => {
+			await queryClient.cancelQueries(queryKey);
+			const previous = queryClient.getQueryData<GetDashboardV2200>(queryKey);
+			if (previous?.data) {
+				// Ops are rooted at the DTO's `/spec`, so patch `.data`, keep the envelope.
+				queryClient.setQueryData<GetDashboardV2200>(queryKey, {
+					...previous,
+					data: applyJsonPatch(previous.data, ops),
+				});
+			}
+			return { previous };
+		},
+		onError: (_error, _ops, context) => {
+			if (context?.previous) {
+				queryClient.setQueryData(queryKey, context.previous);
+			}
+		},
+		onSettled: () => {
+			void queryClient.invalidateQueries(queryKey);
+		},
+	});
+
+	return {
+		patchAsync: mutation.mutateAsync,
+		isPatching: mutation.isLoading,
+		error: mutation.error ?? null,
+	};
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/optimistic/__tests__/applyJsonPatch.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/optimistic/__tests__/applyJsonPatch.test.ts
@@ -1,0 +1,138 @@
+import type { DashboardtypesJSONPatchOperationDTO } from 'api/generated/services/sigNoz.schemas';
+import { DashboardtypesPatchOpDTO } from 'api/generated/services/sigNoz.schemas';
+
+import { applyJsonPatch } from '../applyJsonPatch';
+
+const { add, replace, remove, move, test: testOp } = DashboardtypesPatchOpDTO;
+
+function op(
+	o: DashboardtypesPatchOpDTO,
+	path: string,
+	value?: unknown,
+): DashboardtypesJSONPatchOperationDTO {
+	return { op: o, path, value };
+}
+
+// A trimmed dashboard-spec shape; the applier is structural, so this stands in
+// for the full DTO.
+function spec(): Record<string, unknown> {
+	return {
+		spec: {
+			display: { name: 'dash' },
+			panels: { p1: { spec: { display: { name: 'A' } } } },
+			layouts: [
+				{ spec: { display: { title: 'S1' }, items: [{ x: 0 }] } },
+				{ spec: { items: [] } },
+			],
+			variables: [{ name: 'env' }],
+		},
+	};
+}
+
+describe('applyJsonPatch', () => {
+	it('does not mutate the input document', () => {
+		const doc = spec();
+		const snapshot = JSON.stringify(doc);
+		applyJsonPatch(doc, [op(replace, '/spec/display/name', 'renamed')]);
+		expect(JSON.stringify(doc)).toBe(snapshot);
+	});
+
+	it('replaces a leaf string', () => {
+		const next = applyJsonPatch(spec(), [
+			op(replace, '/spec/layouts/0/spec/display/title', 'S1-renamed'),
+		]);
+		const layouts = (next.spec as any).layouts;
+		expect(layouts[0].spec.display.title).toBe('S1-renamed');
+	});
+
+	it('adds a new object member (panel by id)', () => {
+		const next = applyJsonPatch(spec(), [
+			op(add, '/spec/panels/p2', { spec: { display: { name: 'B' } } }),
+		]);
+		expect((next.spec as any).panels.p2.spec.display.name).toBe('B');
+		// existing member untouched
+		expect((next.spec as any).panels.p1.spec.display.name).toBe('A');
+	});
+
+	it('appends to an array with the "-" token', () => {
+		const next = applyJsonPatch(spec(), [
+			op(add, '/spec/layouts/-', { spec: { items: [] } }),
+		]);
+		expect((next.spec as any).layouts).toHaveLength(3);
+	});
+
+	it('appends an item into a nested section array', () => {
+		const next = applyJsonPatch(spec(), [
+			op(add, '/spec/layouts/1/spec/items/-', { x: 5 }),
+		]);
+		expect((next.spec as any).layouts[1].spec.items).toStrictEqual([{ x: 5 }]);
+	});
+
+	it('replaces a whole array', () => {
+		const next = applyJsonPatch(spec(), [
+			op(replace, '/spec/variables', [{ name: 'region' }, { name: 'pod' }]),
+		]);
+		expect((next.spec as any).variables).toStrictEqual([
+			{ name: 'region' },
+			{ name: 'pod' },
+		]);
+	});
+
+	it('removes an array element by index (section)', () => {
+		const next = applyJsonPatch(spec(), [op(remove, '/spec/layouts/0')]);
+		const layouts = (next.spec as any).layouts;
+		expect(layouts).toHaveLength(1);
+		expect(layouts[0].spec.items).toStrictEqual([]);
+	});
+
+	it('removes an object member (panel by id)', () => {
+		const next = applyJsonPatch(spec(), [op(remove, '/spec/panels/p1')]);
+		expect((next.spec as any).panels).toStrictEqual({});
+	});
+
+	it('adds a missing object parent for an add op (title untitled section)', () => {
+		const next = applyJsonPatch(spec(), [
+			op(add, '/spec/layouts/1/spec/display', { title: 'S2' }),
+		]);
+		expect((next.spec as any).layouts[1].spec.display).toStrictEqual({
+			title: 'S2',
+		});
+	});
+
+	it('is lenient: remove on a missing path is a no-op', () => {
+		const next = applyJsonPatch(spec(), [op(remove, '/spec/panels/ghost')]);
+		expect((next.spec as any).panels.p1).toBeDefined();
+	});
+
+	it('is lenient: a path through a missing node is skipped', () => {
+		const next = applyJsonPatch(spec(), [op(replace, '/spec/nope/deep/leaf', 1)]);
+		expect(next).toStrictEqual(spec());
+	});
+
+	it('unescapes ~1 and ~0 in reference tokens', () => {
+		const doc = { spec: { m: { 'a/b': 1, 'c~d': 2 } } };
+		const next = applyJsonPatch(doc, [
+			op(replace, '/spec/m/a~1b', 9),
+			op(replace, '/spec/m/c~0d', 8),
+		]);
+		expect(next.spec.m).toStrictEqual({ 'a/b': 9, 'c~d': 8 });
+	});
+
+	it('applies multiple ops in order', () => {
+		const next = applyJsonPatch(spec(), [
+			op(add, '/spec/panels/p2', { spec: {} }),
+			op(remove, '/spec/panels/p1'),
+			op(replace, '/spec/display/name', 'z'),
+		]);
+		expect(Object.keys((next.spec as any).panels)).toStrictEqual(['p2']);
+		expect((next.spec as any).display.name).toBe('z');
+	});
+
+	it('treats move/copy/test as no-ops', () => {
+		const next = applyJsonPatch(spec(), [
+			op(move, '/spec/display/name'),
+			op(testOp, '/spec/display/name', 'dash'),
+		]);
+		expect(next).toStrictEqual(spec());
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/optimistic/applyJsonPatch.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/optimistic/applyJsonPatch.ts
@@ -1,0 +1,146 @@
+import type { DashboardtypesJSONPatchOperationDTO } from 'api/generated/services/sigNoz.schemas';
+import { DashboardtypesPatchOpDTO } from 'api/generated/services/sigNoz.schemas';
+import { cloneDeep } from 'lodash-es';
+
+/**
+ * Applies the RFC-6902 ops our `patchOps` builders emit to a document, so a
+ * dashboard edit can be reflected in the react-query cache optimistically before
+ * the server responds. Pure: deep-clones and returns a new document, never
+ * mutating the input.
+ *
+ * Deliberately lenient — mirrors the backend's apply (a `remove`/`replace` on a
+ * missing path is a no-op, `add` creates missing object parents) rather than
+ * throwing as strict RFC-6902 would. This is safe because the mutation always
+ * refetches on settle, so any mis-applied edge op self-corrects; the applier only
+ * needs to be right for the common case to kill the perceived lag.
+ *
+ * Scope: `add` / `replace` / `remove` (the only ops the builders produce).
+ * `move` / `copy` / `test` are never emitted, so they are treated as no-ops.
+ */
+export function applyJsonPatch<T>(
+	doc: T,
+	ops: DashboardtypesJSONPatchOperationDTO[],
+): T {
+	const next = cloneDeep(doc);
+	ops.forEach((op) => applyOperation(next as unknown, op));
+	return next;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function isArray(value: unknown): value is unknown[] {
+	return Array.isArray(value);
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Unescape one JSON-Pointer reference token (RFC-6901): `~1`→`/`, `~0`→`~`. */
+function unescapeToken(token: string): string {
+	return token.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+/** Parse a JSON Pointer into its reference tokens (`""`/`"/"` → root, `[]`). */
+function parsePointer(path: string): string[] {
+	if (!path || path === '/') {
+		return [];
+	}
+	return path.slice(1).split('/').map(unescapeToken);
+}
+
+/**
+ * Walks to the container that holds the pointer's last token. Returns `undefined`
+ * when the path can't be resolved (lenient skip). For `add`, missing intermediate
+ * object nodes are created (backend parity); array steps are never auto-created.
+ */
+function navigateToParent(
+	root: unknown,
+	tokens: string[],
+	createMissing: boolean,
+): unknown {
+	let current: unknown = root;
+	for (let i = 0; i < tokens.length - 1; i += 1) {
+		const token = tokens[i];
+		if (isArray(current)) {
+			const index = token === '-' ? current.length : Number(token);
+			current = current[index];
+		} else if (isRecord(current)) {
+			if (current[token] === undefined && createMissing) {
+				current[token] = {};
+			}
+			current = current[token];
+		} else {
+			return undefined;
+		}
+		if (current === undefined || current === null) {
+			return undefined;
+		}
+	}
+	return current;
+}
+
+/** `add`: array-insert (`-` = append) or object-set. */
+function addAt(parent: unknown, key: string, value: unknown): void {
+	if (isArray(parent)) {
+		const index = key === '-' ? parent.length : Number(key);
+		parent.splice(index, 0, value);
+	} else if (isRecord(parent)) {
+		parent[key] = value;
+	}
+}
+
+/** `replace`: overwrite an in-range array index or an object key. */
+function replaceAt(parent: unknown, key: string, value: unknown): void {
+	if (isArray(parent)) {
+		const index = Number(key);
+		if (index >= 0 && index < parent.length) {
+			parent[index] = value;
+		}
+	} else if (isRecord(parent)) {
+		parent[key] = value;
+	}
+}
+
+/** `remove`: splice an in-range array index or delete an object key (lenient). */
+function removeAt(parent: unknown, key: string): void {
+	if (isArray(parent)) {
+		const index = Number(key);
+		if (index >= 0 && index < parent.length) {
+			parent.splice(index, 1);
+		}
+	} else if (isRecord(parent)) {
+		delete parent[key];
+	}
+}
+
+function applyOperation(
+	root: unknown,
+	op: DashboardtypesJSONPatchOperationDTO,
+): void {
+	const tokens = parsePointer(op.path);
+	// Whole-document ops would need to reassign the root reference — our builders
+	// never target root, so skip rather than complicate the contract.
+	if (tokens.length === 0) {
+		return;
+	}
+
+	const parent = navigateToParent(
+		root,
+		tokens,
+		op.op === DashboardtypesPatchOpDTO.add,
+	);
+	if (parent === undefined || parent === null) {
+		return;
+	}
+	const key = tokens[tokens.length - 1];
+
+	// move / copy / test are never emitted by our builders → no-op (reconciled by refetch).
+	if (op.op === DashboardtypesPatchOpDTO.add) {
+		addAt(parent, key, op.value);
+	} else if (op.op === DashboardtypesPatchOpDTO.replace) {
+		replaceAt(parent, key, op.value);
+	} else if (op.op === DashboardtypesPatchOpDTO.remove) {
+		removeAt(parent, key);
+	}
+}


### PR DESCRIPTION
## Summary

Every V2 dashboard edit previously followed `await patchDashboardV2(...); refetch()` — the UI only reflected the change after the PATCH round-tripped **and** a full dashboard refetch completed, a visible lag on every edit (and the root cause of "deleting/renaming needs a reload to update").

This makes edits render **instantly** by applying the same RFC-6902 ops to the react-query cache optimistically, rolling back on error, and reconciling with the server in the background.

Builds on the merged variable-injection work (#11909).

### How it works

1. **`applyJsonPatch(doc, ops)`** — a pure, lenient RFC-6902 applier for the `add`/`replace`/`remove` ops our `patchOps` builders emit. Deep-clones (never mutates input) and mirrors the backend's leniency (remove/replace on a missing path is a no-op, add creates missing object parents). Correctness bar is modest by design — the settle refetch always reconciles, so a mis-applied edge op self-corrects.
2. **`useOptimisticPatch()`** — one react-query mutation over `patchDashboardV2`: `onMutate` snapshots the cached dashboard and writes the patched copy (`applyJsonPatch` on the envelope's `.data`), `onError` rolls back, `onSettled` invalidates to reconcile. Reads `dashboardId` from the edit-context store (optional override for the panel editor). Rethrows so call sites keep their own toast/`showErrorModal`.
3. **All 12 `patchDashboardV2` spec edits migrated** off `await patch; refetch()` onto `patchAsync`: section rename/add/delete/reorder/resize + first-section migration; panel delete/move/clone; panel-editor save; variable-definition save; Overview metadata; toolbar rename.

### Scope notes

- `refetch` is intentionally **kept** — still used by the JSON editor (full-document save) and the toolbar lock/unlock toggle, neither of which is a patch-op edit.
- The lock-toggle refetch (unlock re-fetches charts) is a known separate issue, not addressed here.

## Test plan

- **Unit**: `applyJsonPatch` (add/replace/remove, `-` append, index, nested, remove-missing no-op, `~` unescape, ordering, move/copy/test no-op); `useOptimisticPatch` (onMutate writes cache, onError rolls back, onSettled invalidates). Updated `useClonePanel` / `usePanelEditorSave` tests for the new call shape.
- Full V2 suite green: **516 tests / 71 suites**. Temp-unpark `tsgo --noEmit` → 0 V2 errors; `oxlint` → 0.
- **Manual**: rename a section / move / delete / clone a panel → instant UI update, then reconciles; simulate a failing PATCH (offline) → UI rolls back + error toast.

> Dark-shipped: all files are under the parked `DashboardPageV2` tree (`use_dashboard_v2` flag), so project CI does not typecheck them.