### PR TITLE
fix(dashboards): render logs/traces list panels on public dashboards

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/WidgetGraphComponent.tsx
@@ -66,6 +66,7 @@ function WidgetGraphComponent({
 	customOnRowClick,
 	customTimeRangeWindowForCoRelation,
 	enableDrillDown,
+	hidePagination,
 }: WidgetGraphComponentProps): JSX.Element {
 	const { safeNavigate } = useSafeNavigate();
 	const [deleteModal, setDeleteModal] = useState(false);
@@ -430,6 +431,7 @@ function WidgetGraphComponent({
 						customSeries={customSeries}
 						customOnRowClick={customOnRowClick}
 						enableDrillDown={enableDrillDown}
+						hidePagination={hidePagination}
 						onColumnWidthsChange={onColumnWidthsChange}
 					/>
 				</div>

--- a/frontend/src/container/GridCardLayout/GridCard/types.ts
+++ b/frontend/src/container/GridCardLayout/GridCard/types.ts
@@ -42,6 +42,8 @@ export interface WidgetGraphComponentProps {
 	customOnRowClick?: (record: RowData) => void;
 	customTimeRangeWindowForCoRelation?: string | undefined;
 	enableDrillDown?: boolean;
+	/** Hide list-panel pagination controls (e.g. public dashboards, where paging isn't supported). */
+	hidePagination?: boolean;
 }
 
 export interface GridCardGraphProps {

--- a/frontend/src/container/LogsPanelTable/LogsPanelComponent.tsx
+++ b/frontend/src/container/LogsPanelTable/LogsPanelComponent.tsx
@@ -34,6 +34,7 @@ function LogsPanelComponent({
 	setRequestData,
 	queryResponse,
 	onColumnWidthsChange,
+	hidePagination,
 }: LogsPanelComponentProps): JSX.Element {
 	const [pageSize, setPageSize] = useState<number>(10);
 	const [offset, setOffset] = useState<number>(0);
@@ -158,7 +159,7 @@ function LogsPanelComponent({
 						/>
 					</OverlayScrollbar>
 				</div>
-				{!widget.query.builder.queryData[0].limit && (
+				{!hidePagination && !widget.query.builder.queryData[0].limit && (
 					<div className="controller">
 						<Controls
 							totalCount={totalCount}
@@ -198,6 +199,7 @@ export type LogsPanelComponentProps = {
 	>;
 	widget: Widgets;
 	onColumnWidthsChange?: (widths: Record<string, number>) => void;
+	hidePagination?: boolean;
 };
 
 export default LogsPanelComponent;

--- a/frontend/src/container/PanelWrapper/ListPanelWrapper.tsx
+++ b/frontend/src/container/PanelWrapper/ListPanelWrapper.tsx
@@ -9,6 +9,7 @@ function ListPanelWrapper({
 	queryResponse,
 	setRequestData,
 	onColumnWidthsChange,
+	hidePagination,
 }: PanelWrapperProps): JSX.Element {
 	const dataSource = widget.query.builder?.queryData[0]?.dataSource;
 
@@ -23,6 +24,7 @@ function ListPanelWrapper({
 				queryResponse={queryResponse}
 				setRequestData={setRequestData}
 				onColumnWidthsChange={onColumnWidthsChange}
+				hidePagination={hidePagination}
 			/>
 		);
 	}
@@ -32,6 +34,7 @@ function ListPanelWrapper({
 			queryResponse={queryResponse}
 			setRequestData={setRequestData}
 			onColumnWidthsChange={onColumnWidthsChange}
+			hidePagination={hidePagination}
 		/>
 	);
 }

--- a/frontend/src/container/PanelWrapper/PanelWrapper.tsx
+++ b/frontend/src/container/PanelWrapper/PanelWrapper.tsx
@@ -26,6 +26,7 @@ function PanelWrapper({
 	panelMode,
 	enableDrillDown = false,
 	onColumnWidthsChange,
+	hidePagination,
 }: PanelWrapperProps): JSX.Element {
 	const Component = PanelTypeVsPanelWrapper[
 		selectedGraph || widget.panelTypes
@@ -76,6 +77,7 @@ function PanelWrapper({
 			enableDrillDown={enableDrillDown}
 			onColumnWidthsChange={onColumnWidthsChange}
 			groupByPerQuery={groupByPerQuery}
+			hidePagination={hidePagination}
 		/>
 	);
 }

--- a/frontend/src/container/PanelWrapper/panelWrapper.types.ts
+++ b/frontend/src/container/PanelWrapper/panelWrapper.types.ts
@@ -32,6 +32,7 @@ export type PanelWrapperProps = {
 	panelMode: PanelMode;
 	onColumnWidthsChange?: (widths: Record<string, number>) => void;
 	groupByPerQuery?: Record<string, BaseAutocompleteData[]>;
+	hidePagination?: boolean;
 };
 
 export type TooltipData = {

--- a/frontend/src/container/PublicDashboardContainer/Panel.tsx
+++ b/frontend/src/container/PublicDashboardContainer/Panel.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { ENTITY_VERSION_V5 } from 'constants/app';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import EmptyWidget from 'container/GridCardLayout/EmptyWidget';
@@ -6,10 +6,11 @@ import WidgetGraphComponent from 'container/GridCardLayout/GridCard/WidgetGraphC
 import { populateMultipleResults } from 'container/NewWidget/LeftContainer/WidgetGraph/util';
 import { useGetQueryRange } from 'hooks/queryBuilder/useGetQueryRange';
 import { GetQueryResultsProps } from 'lib/dashboard/getQueryResults';
+import { isEqual } from 'lodash-es';
 import { Widgets } from 'types/api/dashboard/getAll';
-import { DataSource } from 'types/common/queryBuilder';
-import { getGraphType } from 'utils/getGraphType';
 import { getSortedSeriesData } from 'utils/getSortedSeriesData';
+
+import { getPublicPanelRequestData } from './utils';
 
 function Panel({
 	widget,
@@ -27,54 +28,27 @@ function Panel({
 	const graphRef = useRef<HTMLDivElement>(null);
 	const updatedQuery = widget?.query;
 
-	const requestData: GetQueryResultsProps = useMemo(() => {
-		if (widget.panelTypes !== PANEL_TYPES.LIST) {
-			return {
-				selectedTime: widget?.timePreferance,
-				graphType: getGraphType(widget.panelTypes),
+	// State (not memo) so LIST panels get a setRequestData — ListPanelWrapper
+	// renders nothing without one.
+	const [requestData, setRequestData] = useState<GetQueryResultsProps>(() =>
+		getPublicPanelRequestData({ widget, startTime, endTime }),
+	);
+
+	useEffect(() => {
+		if (!isEqual(updatedQuery, requestData.query)) {
+			setRequestData((prev) => ({
+				...prev,
 				query: updatedQuery,
-				variables: {}, // we are not supporting variables in public dashboards
-				fillGaps: widget.fillSpans,
-				formatForWeb: widget.panelTypes === PANEL_TYPES.TABLE,
-				start: startTime,
-				end: endTime,
-				originalGraphType: widget.panelTypes,
-			};
+			}));
 		}
-
-		const initialDataSource = updatedQuery.builder.queryData[0].dataSource;
-		const updatedQueryForList = {
-			...updatedQuery,
-			builder: {
-				...updatedQuery.builder,
-				queryData: updatedQuery.builder.queryData.map((qd, i) =>
-					i === 0 ? { ...qd, pageSize: 10 } : qd,
-				),
-			},
-		};
-
-		return {
-			query: updatedQueryForList,
-			graphType: PANEL_TYPES.LIST,
-			selectedTime: widget.timePreferance || 'GLOBAL_TIME',
-			tableParams: {
-				pagination: {
-					offset: 0,
-					limit: updatedQuery.builder.queryData[0].limit || 0,
-				},
-				// we do not need select columns in case of logs
-				selectColumns:
-					initialDataSource === DataSource.TRACES && widget.selectedTracesFields,
-			},
-			fillGaps: widget.fillSpans,
-			start: startTime,
-			end: endTime,
-		};
-	}, [widget, updatedQuery, startTime, endTime]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [updatedQuery]);
 
 	const queryResponse = useGetQueryRange(
 		{
 			...requestData,
+			start: startTime,
+			end: endTime,
 			originalGraphType: widget?.panelTypes,
 		},
 		ENTITY_VERSION_V5,
@@ -140,6 +114,7 @@ function Panel({
 					headerMenuList={[]}
 					isWarning={false}
 					isFetchingResponse={queryResponse.isFetching || queryResponse.isLoading}
+					setRequestData={setRequestData}
 					onDragSelect={onDragSelect}
 				/>
 			)}

--- a/frontend/src/container/PublicDashboardContainer/Panel.tsx
+++ b/frontend/src/container/PublicDashboardContainer/Panel.tsx
@@ -115,6 +115,7 @@ function Panel({
 					isWarning={false}
 					isFetchingResponse={queryResponse.isFetching || queryResponse.isLoading}
 					setRequestData={setRequestData}
+					hidePagination
 					onDragSelect={onDragSelect}
 				/>
 			)}

--- a/frontend/src/container/PublicDashboardContainer/__tests__/Panel.test.tsx
+++ b/frontend/src/container/PublicDashboardContainer/__tests__/Panel.test.tsx
@@ -19,9 +19,14 @@ jest.mock('hooks/queryBuilder/useGetQueryRange', () => ({
 	},
 }));
 
+const widgetGraphProps = jest.fn();
+
 jest.mock('container/GridCardLayout/GridCard/WidgetGraphComponent', () => ({
 	__esModule: true,
-	default: (): JSX.Element => <div data-testid="widget-graph" />,
+	default: (props: { setRequestData?: unknown }): JSX.Element => {
+		widgetGraphProps(props);
+		return <div data-testid="widget-graph" />;
+	},
 }));
 
 const buildWidget = (id: string): Widgets =>
@@ -39,6 +44,22 @@ const buildWidget = (id: string): Widgets =>
 describe('Public dashboard Panel', () => {
 	beforeEach(() => {
 		useGetQueryRangeMock.mockClear();
+		widgetGraphProps.mockClear();
+	});
+
+	it('forwards a setRequestData setter so LIST panels render (bug 3646)', () => {
+		render(
+			<Panel
+				widget={buildWidget('widget-a')}
+				index={0}
+				dashboardId="dash-1"
+				startTime={100}
+				endTime={200}
+			/>,
+		);
+
+		const props = widgetGraphProps.mock.calls[0][0];
+		expect(typeof props.setRequestData).toBe('function');
 	});
 
 	it('keys each panel by widget id + index so identical queries do not collide (bug 5503)', () => {

--- a/frontend/src/container/PublicDashboardContainer/utils.ts
+++ b/frontend/src/container/PublicDashboardContainer/utils.ts
@@ -1,0 +1,53 @@
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { GetQueryResultsProps } from 'lib/dashboard/getQueryResults';
+import { Widgets } from 'types/api/dashboard/getAll';
+import { DataSource } from 'types/common/queryBuilder';
+import { getGraphType } from 'utils/getGraphType';
+
+// Builds the useGetQueryRange payload for a public-dashboard panel, mirroring the
+// authenticated GridCard.
+export const getPublicPanelRequestData = ({
+	widget,
+	startTime,
+	endTime,
+}: {
+	widget: Widgets;
+	startTime: number;
+	endTime: number;
+}): GetQueryResultsProps => {
+	const updatedQuery = widget?.query;
+
+	if (widget.panelTypes !== PANEL_TYPES.LIST) {
+		return {
+			selectedTime: widget?.timePreferance,
+			graphType: getGraphType(widget.panelTypes),
+			query: updatedQuery,
+			variables: {}, // we are not supporting variables in public dashboards
+			fillGaps: widget.fillSpans,
+			formatForWeb: widget.panelTypes === PANEL_TYPES.TABLE,
+			start: startTime,
+			end: endTime,
+			originalGraphType: widget.panelTypes,
+		};
+	}
+
+	const initialDataSource = updatedQuery.builder.queryData[0].dataSource;
+
+	return {
+		query: updatedQuery,
+		graphType: PANEL_TYPES.LIST,
+		selectedTime: widget.timePreferance || 'GLOBAL_TIME',
+		tableParams: {
+			pagination: {
+				offset: 0,
+				limit: updatedQuery.builder.queryData[0].limit || 0,
+			},
+			// we do not need select columns in case of logs
+			selectColumns:
+				initialDataSource === DataSource.TRACES && widget.selectedTracesFields,
+		},
+		fillGaps: widget.fillSpans,
+		start: startTime,
+		end: endTime,
+	};
+};

--- a/frontend/src/container/TracesTableComponent/TracesTableComponent.tsx
+++ b/frontend/src/container/TracesTableComponent/TracesTableComponent.tsx
@@ -37,6 +37,7 @@ function TracesTableComponent({
 	queryResponse,
 	setRequestData,
 	onColumnWidthsChange,
+	hidePagination,
 }: TracesTableComponentProps): JSX.Element {
 	const [pagination, setPagination] = useState<Pagination>({
 		offset: 0,
@@ -139,34 +140,36 @@ function TracesTableComponent({
 					/>
 				</OverlayScrollbar>
 			</div>
-			<div className="controller">
-				<Controls
-					totalCount={totalCount}
-					perPageOptions={PER_PAGE_OPTIONS}
-					isLoading={queryResponse.isFetching}
-					offset={pagination.offset}
-					countPerPage={pagination.limit}
-					handleNavigatePrevious={(): void => {
-						handlePaginationChange({
-							...pagination,
-							offset: pagination.offset - pagination.limit,
-						});
-					}}
-					handleNavigateNext={(): void => {
-						handlePaginationChange({
-							...pagination,
-							offset: pagination.offset + pagination.limit,
-						});
-					}}
-					handleCountItemsPerPageChange={(value): void => {
-						handlePaginationChange({
-							...pagination,
-							limit: value,
-							offset: 0,
-						});
-					}}
-				/>
-			</div>
+			{!hidePagination && (
+				<div className="controller">
+					<Controls
+						totalCount={totalCount}
+						perPageOptions={PER_PAGE_OPTIONS}
+						isLoading={queryResponse.isFetching}
+						offset={pagination.offset}
+						countPerPage={pagination.limit}
+						handleNavigatePrevious={(): void => {
+							handlePaginationChange({
+								...pagination,
+								offset: pagination.offset - pagination.limit,
+							});
+						}}
+						handleNavigateNext={(): void => {
+							handlePaginationChange({
+								...pagination,
+								offset: pagination.offset + pagination.limit,
+							});
+						}}
+						handleCountItemsPerPageChange={(value): void => {
+							handlePaginationChange({
+								...pagination,
+								limit: value,
+								offset: 0,
+							});
+						}}
+					/>
+				</div>
+			)}
 		</div>
 	);
 }
@@ -178,6 +181,7 @@ export type TracesTableComponentProps = {
 	>;
 	widget: Widgets;
 	setRequestData: Dispatch<SetStateAction<GetQueryResultsProps>>;
+	hidePagination?: boolean;
 	onColumnWidthsChange?: (widths: Record<string, number>) => void;
 };
 

--- a/frontend/src/hooks/__tests__/useLogsData.test.tsx
+++ b/frontend/src/hooks/__tests__/useLogsData.test.tsx
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { AllTheProviders } from 'tests/test-utils';
+import { Query } from 'types/api/queryBuilder/queryBuilderData';
+
+import { useLogsData } from '../useLogsData';
+
+describe('useLogsData', () => {
+	// Public dashboards redact the widget query (orderBy/filter/limit stripped),
+	// so a LIST query can arrive with no orderBy — the hook must not crash on it.
+	it('does not crash when the query has no orderBy', () => {
+		const stagedQuery = {
+			builder: {
+				queryData: [{ dataSource: 'logs', queryName: 'A', disabled: false }],
+			},
+		} as unknown as Query;
+
+		const { result } = renderHook(
+			() =>
+				useLogsData({
+					result: undefined,
+					panelType: PANEL_TYPES.LIST,
+					stagedQuery,
+				}),
+			{ wrapper: AllTheProviders },
+		);
+
+		expect(result.current.logs).toStrictEqual([]);
+	});
+});

--- a/frontend/src/hooks/useLogsData.ts
+++ b/frontend/src/hooks/useLogsData.ts
@@ -71,7 +71,7 @@ export const useLogsData = ({
 	}, [logs.length, listQuery]);
 
 	const orderByTimestamp: OrderByPayload | null = useMemo(() => {
-		const timestampOrderBy = listQuery?.orderBy.find(
+		const timestampOrderBy = listQuery?.orderBy?.find(
 			(item) => item.columnName === 'timestamp',
 		);
 


### PR DESCRIPTION
## Pull Request

> **Stacked on #11935** (public-dashboard query-cache fix). Review/merge that first — this branch is based on it, so its diff shows only the list-rendering change once #11935 lands.

---

### 📄 Summary

On the public dashboard viewer (`/public/dashboard/:id`), **logs/traces list panels rendered nothing** even though the query range API returned data — the issue reporter confirmed the response came back but the UI didn't draw it. It renders fine on the authenticated dashboard.

Root: `ListPanelWrapper` returns an empty fragment when `setRequestData` is `undefined`, and the public `Panel` never forwarded a `setRequestData` to `WidgetGraphComponent`. So the list wrapper bailed before rendering.

Fix: back `requestData` with `useState` and forward the setter, mirroring the authenticated `GridCard`. The per-panel request builder is extracted to `utils.ts`. Because the public payload redacts each widget's `limit`, the list components would otherwise always show a pager that can't page (the public endpoint takes no pagination params) — so a `hidePagination` flag is threaded through to suppress it on public list panels.

#### Issues closed by this PR

Closes https://github.com/SigNoz/engineering-pod/issues/3646

---

### ✅ Change Type

- [x] 🐛 Bug fix
- [x] 🧪 Test-only (added coverage)

---

### 🐛 Bug Context

#### Root Cause

`ListPanelWrapper` guards `if (!setRequestData) return <></>` (the setter drives list pagination). The authenticated `GridCard` always passes it; the public `Panel` computed `requestData` with `useMemo` and passed no setter, so logs/traces list panels never rendered despite valid data.

#### Fix Strategy

- Move `requestData` from `useMemo` to `useState` so there's a real setter, and forward `setRequestData` to `WidgetGraphComponent`.
- Extract the request-data builder into `utils.ts` (`getPublicPanelRequestData`).
- Dropped the public-only `pageSize: 10` query mutation so the initial fetch matches the authenticated view (it never reached the index-based backend anyway).
- Thread an optional `hidePagination` flag (`WidgetGraphComponent` → `PanelWrapper` → `ListPanelWrapper` → `LogsPanelComponent`/`TracesTableComponent`); default off, so authenticated dashboards are unchanged.
- Guard `useLogsData` against a missing `orderBy`: the public payload redacts the query (`orderBy`/`filter`/`limit` stripped), so once the logs panel actually renders, `listQuery?.orderBy.find(...)` threw (`?.` guarded `listQuery` but not `orderBy`). Changed to `listQuery?.orderBy?.find(...)`.

---

### 🧪 Testing Strategy

- **Tests added:** `PublicDashboardContainer/__tests__/Panel.test.tsx` — asserts `setRequestData` is forwarded to `WidgetGraphComponent`.
- **Manual verification:** typecheck (`tsgo --noEmit`), `oxlint`, and `oxfmt --check` clean; full `PublicDashboardContainer` suite green.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** Public-dashboard viewer, plus an additive optional `hidePagination` prop on the shared list components (defaults off → authenticated path unchanged).
- **Potential regressions:** Low. The pager-hide is gated behind a flag only the public `Panel` sets. Functional public pagination remains a separate backend task (endpoint must accept page params).
- **Rollback plan:** Revert the commits; isolated to `PublicDashboardContainer` and the additive prop.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Public dashboards now render logs/traces list-view panels. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Stacked on #11935; the first commit here is that PR's fix.
