### PR TITLE
feat(dashboards): add auto-refresh to public dashboards

### DIFF
--- a/frontend/src/container/PublicDashboardContainer/AutoRefresh.module.scss
+++ b/frontend/src/container/PublicDashboardContainer/AutoRefresh.module.scss
@@ -1,0 +1,13 @@
+.autoRefresh {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.icon {
+	color: var(--l2-foreground);
+}
+
+.select {
+	min-width: 96px;
+}

--- a/frontend/src/container/PublicDashboardContainer/AutoRefresh.tsx
+++ b/frontend/src/container/PublicDashboardContainer/AutoRefresh.tsx
@@ -1,0 +1,41 @@
+import { RefreshCw } from '@signozhq/icons';
+import { SelectSimple } from '@signozhq/ui/select';
+import { refreshIntervalOptions } from 'container/TopNav/AutoRefreshV2/constants';
+
+import styles from './AutoRefresh.module.scss';
+
+const REFRESH_ITEMS = refreshIntervalOptions.map((option) => ({
+	value: option.key,
+	label: option.key === 'off' ? 'Off' : option.label,
+}));
+
+interface AutoRefreshProps {
+	value: string;
+	disabled?: boolean;
+	onChange: (value: string) => void;
+}
+
+// Interval selector for the public dashboard. Self-contained (no Redux global
+// time); the container advances its own time window on each tick.
+function AutoRefresh({
+	value,
+	disabled = false,
+	onChange,
+}: AutoRefreshProps): JSX.Element {
+	return (
+		<div className={styles.autoRefresh}>
+			<RefreshCw size={14} className={styles.icon} />
+			<SelectSimple
+				className={styles.select}
+				testId="public-dashboard-auto-refresh"
+				items={REFRESH_ITEMS}
+				value={value}
+				disabled={disabled}
+				withPortal={false}
+				onChange={(next): void => onChange(next as string)}
+			/>
+		</div>
+	);
+}
+
+export default AutoRefresh;

--- a/frontend/src/container/PublicDashboardContainer/PublicDashboardContainer.tsx
+++ b/frontend/src/container/PublicDashboardContainer/PublicDashboardContainer.tsx
@@ -1,10 +1,12 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import RGL, { WidthProvider } from 'react-grid-layout';
+import { useInterval } from 'react-use';
 import { Typography } from '@signozhq/ui/typography';
 import cx from 'classnames';
 import { PANEL_GROUP_TYPES, PANEL_TYPES } from 'constants/queryBuilder';
 import { themeColors } from 'constants/theme';
 import { Card, CardContainer } from 'container/GridCardLayout/styles';
+import { refreshIntervalOptions } from 'container/TopNav/AutoRefreshV2/constants';
 import DateTimeSelectionV2 from 'container/TopNav/DateTimeSelectionV2';
 import { DEFAULT_TIME_RANGE } from 'container/TopNav/DateTimeSelectionV2/constants';
 import {
@@ -20,6 +22,7 @@ import { PublicDashboardDataProps } from 'types/api/dashboard/public/get';
 
 import signozBrandLogoUrl from '@/assets/Logos/signoz-brand-logo.svg';
 
+import AutoRefresh from './AutoRefresh';
 import Panel from './Panel';
 
 import './PublicDashboardContainer.styles.scss';
@@ -129,6 +132,35 @@ function PublicDashboardContainer({
 		setSelectedTimeRangeLabel(interval as string);
 	};
 
+	const [refreshIntervalKey, setRefreshIntervalKey] = useState<string>('off');
+
+	// Auto-refresh only makes sense for a rolling relative range, not a fixed
+	// custom window — pause it (and disable the control) when 'custom' is picked.
+	const isAutoRefreshPaused = selectedTimeRangeLabel === 'custom';
+
+	const refreshIntervalMs = useMemo(
+		() =>
+			refreshIntervalOptions.find((option) => option.key === refreshIntervalKey)
+				?.value || 0,
+		[refreshIntervalKey],
+	);
+
+	const refreshTimeRange = useCallback((): void => {
+		if (selectedTimeRangeLabel === 'custom') {
+			return;
+		}
+		const { maxTime, minTime } = GetMinMax(selectedTimeRangeLabel as Time);
+		setSelectedTimeRange({
+			startTime: Math.floor(minTime / 1000000000),
+			endTime: Math.floor(maxTime / 1000000000),
+		});
+	}, [selectedTimeRangeLabel]);
+
+	useInterval(
+		refreshTimeRange,
+		isAutoRefreshPaused || refreshIntervalMs === 0 ? null : refreshIntervalMs,
+	);
+
 	return (
 		<div className="public-dashboard-container">
 			<div className="public-dashboard-header">
@@ -148,6 +180,11 @@ function PublicDashboardContainer({
 
 				{isTimeRangeEnabled && (
 					<div className="public-dashboard-header-right">
+						<AutoRefresh
+							value={refreshIntervalKey}
+							disabled={isAutoRefreshPaused}
+							onChange={setRefreshIntervalKey}
+						/>
 						<div className="datetime-section">
 							<DateTimeSelectionV2
 								showAutoRefresh={false}

--- a/frontend/src/container/PublicDashboardContainer/PublicDashboardContainer.tsx
+++ b/frontend/src/container/PublicDashboardContainer/PublicDashboardContainer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import RGL, { WidthProvider } from 'react-grid-layout';
 import { useInterval } from 'react-use';
 import { Typography } from '@signozhq/ui/typography';
@@ -16,6 +16,7 @@ import {
 import dayjs from 'dayjs';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import GetMinMax from 'lib/getMinMax';
+import { NANO_SECOND_MULTIPLIER } from 'store/globalTime/utils';
 import { SuccessResponseV2 } from 'types/api';
 import { Widgets } from 'types/api/dashboard/getAll';
 import { PublicDashboardDataProps } from 'types/api/dashboard/public/get';
@@ -124,8 +125,8 @@ function PublicDashboardContainer({
 			const { maxTime, minTime } = GetMinMax(interval);
 
 			setSelectedTimeRange({
-				startTime: Math.floor(minTime / 1000000000),
-				endTime: Math.floor(maxTime / 1000000000),
+				startTime: Math.floor(minTime / NANO_SECOND_MULTIPLIER / 1000),
+				endTime: Math.floor(maxTime / NANO_SECOND_MULTIPLIER / 1000),
 			});
 		}
 
@@ -145,19 +146,10 @@ function PublicDashboardContainer({
 		[refreshIntervalKey],
 	);
 
-	const refreshTimeRange = useCallback((): void => {
-		if (selectedTimeRangeLabel === 'custom') {
-			return;
-		}
-		const { maxTime, minTime } = GetMinMax(selectedTimeRangeLabel as Time);
-		setSelectedTimeRange({
-			startTime: Math.floor(minTime / 1000000000),
-			endTime: Math.floor(maxTime / 1000000000),
-		});
-	}, [selectedTimeRangeLabel]);
-
+	// Re-run the existing time-change handler with the current relative range so
+	// the rolling window advances — no need to duplicate the GetMinMax logic.
 	useInterval(
-		refreshTimeRange,
+		() => handleTimeChange(selectedTimeRangeLabel as Time),
 		isAutoRefreshPaused || refreshIntervalMs === 0 ? null : refreshIntervalMs,
 	);
 

--- a/frontend/src/container/PublicDashboardContainer/__tests__/AutoRefresh.test.tsx
+++ b/frontend/src/container/PublicDashboardContainer/__tests__/AutoRefresh.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from 'tests/test-utils';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from 'tests/test-utils';
 
 import AutoRefresh from '../AutoRefresh';
 
@@ -10,12 +11,12 @@ describe('Public dashboard AutoRefresh', () => {
 		).toBeInTheDocument();
 	});
 
-	it('lets the viewer pick a refresh interval', () => {
+	it('lets the viewer pick a refresh interval', async () => {
 		const onChange = jest.fn();
 		render(<AutoRefresh value="off" onChange={onChange} />);
 
-		fireEvent.click(screen.getByTestId('public-dashboard-auto-refresh'));
-		fireEvent.click(screen.getByText('30 seconds'));
+		await userEvent.click(screen.getByTestId('public-dashboard-auto-refresh'));
+		await userEvent.click(screen.getByText('30 seconds'));
 
 		expect(onChange).toHaveBeenCalledWith('30s');
 	});

--- a/frontend/src/container/PublicDashboardContainer/__tests__/AutoRefresh.test.tsx
+++ b/frontend/src/container/PublicDashboardContainer/__tests__/AutoRefresh.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from 'tests/test-utils';
+
+import AutoRefresh from '../AutoRefresh';
+
+describe('Public dashboard AutoRefresh', () => {
+	it('renders the interval selector', () => {
+		render(<AutoRefresh value="off" onChange={jest.fn()} />);
+		expect(
+			screen.getByTestId('public-dashboard-auto-refresh'),
+		).toBeInTheDocument();
+	});
+
+	it('lets the viewer pick a refresh interval', () => {
+		const onChange = jest.fn();
+		render(<AutoRefresh value="off" onChange={onChange} />);
+
+		fireEvent.click(screen.getByTestId('public-dashboard-auto-refresh'));
+		fireEvent.click(screen.getByText('30 seconds'));
+
+		expect(onChange).toHaveBeenCalledWith('30s');
+	});
+});


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Adds auto-refresh to the public dashboard viewer (`/public/dashboard/:id`). A small interval selector appears in the header **next to the time picker** (only when the publisher enabled the time range). On each tick it recomputes the rolling window from the selected relative range and updates the viewer's local time state — so every panel refetches with an advanced window (panel query keys already include `startTime`/`endTime`).

The authenticated app's `AutoRefreshV2` is tied to Redux global-time and dispatches `UPDATE_TIME_INTERVAL`. The public viewer deliberately avoids Redux time (it holds its own `selectedTimeRange`), so this is a **self-contained** control + a `useInterval` in the container — no Redux, no `Panel` changes. It reuses the shared `refreshIntervalOptions`.

---

### ✅ Change Type

- [x] ✨ Feature
- [x] 🧪 Test-only (added coverage)

---

### 🛠️ Implementation

- New `AutoRefresh` control (`PublicDashboardContainer/AutoRefresh.tsx`) — a `SelectSimple` of intervals (Off / 5s / … / 1d), matching the public settings-form styling.
- Container holds `refreshIntervalKey` state and a `useInterval(refreshTimeRange, delay)`; `delay` is `null` (paused) when the interval is `Off` or the range is `custom`.
- `refreshTimeRange` recomputes `GetMinMax(selectedTimeRangeLabel)` and updates `selectedTimeRange`, advancing the rolling window.
- Shown only when `timeRangeEnabled`; disabled for fixed `custom` ranges (mirrors the app's disable-on-custom rule).

---

### 🧪 Testing Strategy

- **Tests added:** `PublicDashboardContainer/__tests__/AutoRefresh.test.tsx` — renders the selector and asserts picking an interval fires `onChange('30s')`. Existing `PublicDashboardContainer` suite still green (21 tests).
- **Manual verification:** typecheck (`tsgo --noEmit`), `oxlint`, `oxfmt --check`, and stylelint clean on the touched files.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** Public-dashboard viewer only; no change to the authenticated path or to `Panel`.
- **Potential regressions:** Low — auto-refresh defaults to `Off`; when off, `useInterval` is paused (`null` delay).
- **Rollback plan:** Revert the commit; isolated to `PublicDashboardContainer`.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Public dashboards can now auto-refresh on a chosen interval (when time range is enabled). |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Independent of the public-dashboard fixes in #11935 / #11937 (this only touches `PublicDashboardContainer`, which those PRs don't).
- Auto-refresh advances the *relative* window; it's intentionally hidden when the publisher locked the range (`timeRangeEnabled` off) and disabled for `custom` fixed ranges.
