### PR TITLE
feat(dashboard-v2): variable editor form, add-variable UX & styling

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.module.scss
@@ -6,7 +6,8 @@
 	gap: 12px;
 }
 
-/* Actions / Configure / Edit-as-JSON: a more visible l3 outline. */
+/* Actions / Configure / Edit-as-JSON: a flat l3 outline — no depth/shadow. */
 .toolbarButton {
-	border-color: var(--l3-border) !important;
+	border: 1px solid var(--l3-border) !important;
+	box-shadow: none !important;
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.module.scss
@@ -5,3 +5,8 @@
 	justify-content: flex-end;
 	gap: 12px;
 }
+
+/* Actions / Configure / Edit-as-JSON: a more visible l3 outline. */
+.toolbarButton {
+	border-color: var(--l3-border) !important;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
@@ -1,4 +1,10 @@
-import { type ReactNode, useCallback, useMemo, useState } from 'react';
+import {
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+} from 'react';
 import { FullScreenHandle } from 'react-full-screen';
 import { generatePath } from 'react-router-dom';
 import {
@@ -63,6 +69,8 @@ function DashboardActions({
 }: DashboardActionsProps): JSX.Element {
 	const canEditDashboard = useDashboardStore((s) => s.canEditDashboard);
 	const isLocked = useDashboardStore((s) => s.isLocked);
+	const settingsRequest = useDashboardStore((s) => s.settingsRequest);
+	const clearSettingsRequest = useDashboardStore((s) => s.clearSettingsRequest);
 	const { user } = useAppContext();
 	const { safeNavigate } = useSafeNavigate();
 	const { showErrorModal } = useErrorModal();
@@ -75,6 +83,14 @@ function DashboardActions({
 
 	const [isDeleteOpen, setIsDeleteOpen] = useState<boolean>(false);
 	const deleteDashboardMutation = useDeleteDashboard(dashboard.id);
+
+	// Open the settings drawer when something in the tree requests it (e.g. the
+	// variables bar's "Add variable" button).
+	useEffect(() => {
+		if (settingsRequest) {
+			setIsSettingsDrawerOpen(true);
+		}
+	}, [settingsRequest]);
 
 	const { addSection, isSaving: isAddingSection } = useAddSection({
 		layouts: dashboard.spec.layouts,
@@ -249,7 +265,11 @@ function DashboardActions({
 					<SettingsDrawer
 						drawerTitle="Dashboard Configuration"
 						isOpen={isSettingsDrawerOpen}
-						onClose={(): void => setIsSettingsDrawerOpen(false)}
+						destroyOnClose
+						onClose={(): void => {
+							setIsSettingsDrawerOpen(false);
+							clearSettingsRequest();
+						}}
 					>
 						<DashboardSettings dashboard={dashboard} />
 					</SettingsDrawer>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
@@ -238,6 +238,7 @@ function DashboardActions({
 					variant="solid"
 					color="secondary"
 					size="md"
+					className={styles.toolbarButton}
 					prefix={<Grid3X3 size="md" />}
 					testId="options"
 				>
@@ -253,6 +254,7 @@ function DashboardActions({
 						<Button
 							variant="solid"
 							color="secondary"
+							className={styles.toolbarButton}
 							prefix={<Configure size="md" />}
 							testId="show-drawer"
 							disabled={isLocked}
@@ -278,6 +280,7 @@ function DashboardActions({
 			<Button
 				variant="solid"
 				color="secondary"
+				className={styles.toolbarButton}
 				prefix={<Braces size="md" />}
 				testId="edit-json"
 				onClick={(): void => setIsJsonEditorOpen(true)}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/SettingsDrawer/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/SettingsDrawer/index.tsx
@@ -8,6 +8,8 @@ type SettingsDrawerProps = PropsWithChildren<{
 	drawerTitle: string;
 	isOpen: boolean;
 	onClose: () => void;
+	/** Unmount the content on close so it re-initializes on the next open. */
+	destroyOnClose?: boolean;
 }>;
 
 function SettingsDrawer({
@@ -15,6 +17,7 @@ function SettingsDrawer({
 	drawerTitle,
 	isOpen,
 	onClose,
+	destroyOnClose = false,
 }: SettingsDrawerProps): JSX.Element {
 	return (
 		<Drawer
@@ -23,6 +26,7 @@ function SettingsDrawer({
 			width="50%"
 			onClose={onClose}
 			open={isOpen}
+			destroyOnClose={destroyOnClose}
 			rootClassName={styles.settingsContainerRoot}
 		>
 			{/* Need to type cast because of OverlayScrollbar type definition. We should be good once we remove it. */}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/DynamicVariableFields.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/DynamicVariableFields.tsx
@@ -82,38 +82,14 @@ function DynamicVariableFields({
 
 	return (
 		<>
-			<div className={cx(styles.row, styles.sortSection)}>
-				<div className={cx(styles.labelContainer, styles.sourceLabel)}>
-					<Typography.Text className={styles.label}>Source</Typography.Text>
-					<TextToolTip
-						text="By default, this searches across logs, traces, and metrics, which can be slow. Selecting a single source improves performance. Many fields share the same values across different signals (for example, `k8s.pod.name` is identical in logs, traces and metrics) making one source enough. Only use `All telemetry` when you need fields that have different values in different signal types."
-						useFilledIcon={false}
-						outlinedIcon={<Info size={14} />}
-					/>
-				</div>
-				<Select
-					className={styles.sortSelect}
-					popupMatchSelectWidth={false}
-					value={signal}
-					options={DYNAMIC_SIGNALS.map((s) => ({
-						label: DYNAMIC_SIGNAL_LABEL[s],
-						value: s,
-					}))}
-					onChange={(value): void =>
-						onChange({ dynamicSignal: value as DynamicSignalOption })
-					}
-					data-testid="variable-signal-select"
-				/>
-			</div>
-			<div className={cx(styles.row, styles.sortSection)}>
-				<div className={styles.labelContainer}>
-					<Typography.Text className={styles.label}>Attribute</Typography.Text>
-				</div>
+			{/* Combined row retained from V1: the field on the left, `from` + the
+			    telemetry source on the right. */}
+			<div className={cx(styles.row, styles.dynamicCombinedRow)}>
 				<CustomSelect
-					className={styles.searchSelect}
+					className={styles.dynamicFieldSelect}
 					showSearch
 					value={attribute || undefined}
-					placeholder="Select a telemetry field"
+					placeholder="Select a field"
 					loading={isLoading}
 					options={options}
 					onSearch={setSearch}
@@ -125,6 +101,25 @@ function DynamicVariableFields({
 					}}
 					showRetryButton={error ? isRetryableError(error) : true}
 					data-testid="variable-field-select"
+				/>
+				<Typography.Text className={styles.fromText}>from</Typography.Text>
+				<TextToolTip
+					text="By default, this searches across logs, traces, and metrics, which can be slow. Selecting a single source improves performance. Many fields share the same values across different signals (for example, `k8s.pod.name` is identical in logs, traces and metrics) making one source enough. Only use `All telemetry` when you need fields that have different values in different signal types."
+					useFilledIcon={false}
+					outlinedIcon={<Info size={14} />}
+				/>
+				<Select
+					className={styles.dynamicSourceSelect}
+					popupMatchSelectWidth={false}
+					value={signal}
+					options={DYNAMIC_SIGNALS.map((s) => ({
+						label: DYNAMIC_SIGNAL_LABEL[s],
+						value: s,
+					}))}
+					onChange={(value): void =>
+						onChange({ dynamicSignal: value as DynamicSignalOption })
+					}
+					data-testid="variable-signal-select"
 				/>
 			</div>
 			{attributeError ? (

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/DynamicVariableFields.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/DynamicVariableFields.tsx
@@ -40,7 +40,7 @@ function DynamicVariableFields({
 	attributeError,
 }: DynamicVariableFieldsProps): JSX.Element {
 	const [search, setSearch] = useState('');
-	const debouncedSearch = useDebounce(search, 300);
+	const debouncedSearch = useDebounce(search, 500);
 	const apiSignal = signalForApi(signal);
 
 	const {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableForm.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableForm.module.scss
@@ -331,13 +331,39 @@
 /* All variable selects (Source / Attribute / Sort / Default Value) share width
    and a consistent --l2-border outline. */
 .sortSelect,
-.searchSelect {
-	width: 240px;
-	flex-shrink: 0;
-
+.searchSelect,
+.dynamicFieldSelect,
+.dynamicSourceSelect {
 	:global(.ant-select-selector) {
 		border-color: var(--l2-border) !important;
 	}
+}
+
+.sortSelect,
+.searchSelect {
+	width: 240px;
+	flex-shrink: 0;
+}
+
+/* Dynamic variable: field | "from" | info | source, retained from V1. */
+.dynamicCombinedRow {
+	display: grid;
+	grid-template-columns: 1fr auto 16px 180px;
+	gap: 12px;
+	align-items: center;
+}
+
+.dynamicFieldSelect,
+.dynamicSourceSelect {
+	width: 100%;
+	min-width: 0;
+}
+
+.fromText {
+	font-family: 'Space Mono';
+	font-size: 13px;
+	font-weight: var(--font-weight-medium);
+	white-space: nowrap;
 }
 
 .actionButtons {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableForm.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableForm.module.scss
@@ -138,7 +138,7 @@
 	align-items: center;
 	gap: 6px;
 	min-height: 24px;
-	padding: 6px 14px;
+	padding: 4px 16px !important;
 	white-space: nowrap;
 	border-radius: 0;
 	color: var(--l2-foreground);
@@ -157,6 +157,7 @@
 
 .betaTag {
 	margin-left: 4px;
+	vertical-align: middle;
 }
 
 /* Query */
@@ -264,6 +265,7 @@
 	flex-flow: wrap;
 	gap: 8px;
 	padding: 4.5px 11px;
+	max-height: 120px;
 	overflow-y: auto;
 }
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/index.tsx
@@ -23,6 +23,11 @@ interface VariablesSettingsProps {
 
 function VariablesSettings({ dashboard }: VariablesSettingsProps): JSX.Element {
 	const isEditable = useDashboardStore((s) => s.isEditable);
+	// The drawer destroys on close, so reading this once on mount is enough to
+	// open the add-form when deep-linked (e.g. the bar's "Add variable" button).
+	const openAddOnMount = useDashboardStore(
+		(s) => s.settingsRequest?.addVariable ?? false,
+	);
 	const { save, isSaving } = useSaveVariables();
 
 	const initialFormModels = useMemo(
@@ -38,7 +43,9 @@ function VariablesSettings({ dashboard }: VariablesSettingsProps): JSX.Element {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [dashboard.updatedAt]);
 
-	const [isEditing, setIsEditing] = useState<EditingState>(null);
+	const [isEditing, setIsEditing] = useState<EditingState>(
+		openAddOnMount && isEditable ? { type: 'new' } : null,
+	);
 	const [confirmDeleteIndex, setConfirmDeleteIndex] = useState<number | null>(
 		null,
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/index.tsx
@@ -17,6 +17,7 @@ import { useAppContext } from 'providers/App/App';
 import { useGetTenantLicense } from 'hooks/useGetTenantLicense';
 import { USER_ROLES } from 'types/roles';
 
+import { useDashboardStore } from '../store/useDashboardStore';
 import styles from './DashboardSettings.module.scss';
 
 interface DashboardSettingsProps {
@@ -38,6 +39,9 @@ const prefixIcons: Record<TabKeys, JSX.Element> = {
 function DashboardSettings({ dashboard }: DashboardSettingsProps): JSX.Element {
 	const { user } = useAppContext();
 	const { isCloudUser, isEnterpriseSelfHostedUser } = useGetTenantLicense();
+	// Opened once per drawer mount (the drawer destroys on close); a deep-link
+	// request lands us on the right tab.
+	const settingsRequest = useDashboardStore((s) => s.settingsRequest);
 
 	const enablePublicDashboard = isCloudUser || isEnterpriseSelfHostedUser;
 
@@ -69,7 +73,7 @@ function DashboardSettings({ dashboard }: DashboardSettingsProps): JSX.Element {
 	);
 
 	return (
-		<TabsRoot defaultValue={TabKeys.OVERVIEW}>
+		<TabsRoot defaultValue={settingsRequest?.tab ?? TabKeys.OVERVIEW}>
 			<TabsList variant="primary">
 				{Object.values(TabKeys).map((key) => (
 					<TabsTrigger value={key} key={key}>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/DashboardEmptyState/DashboardEmptyState.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/DashboardEmptyState/DashboardEmptyState.module.scss
@@ -25,7 +25,6 @@
 
 	.welcome {
 		color: var(--l1-foreground);
-		font-family: Inter;
 		font-size: 16px;
 		font-weight: 500;
 		line-height: 24px;
@@ -34,14 +33,19 @@
 
 	.welcomeInfo {
 		color: var(--l3-foreground);
-		font-family: Inter;
 		font-size: 13px;
 		font-weight: 400;
 		line-height: 18px;
 	}
 }
 
-.addPanel {
+.steps {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.step {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
@@ -51,35 +55,34 @@
 	border-radius: 6px;
 }
 
-.addPanelText {
+.stepText {
 	display: flex;
 	align-items: flex-start;
 	gap: 10px;
 
-	.icon {
+	.stepIcon {
 		height: 14px;
 		width: 14px;
 		margin-top: 2px;
+		flex: none;
 	}
 }
 
-.addPanelCopy {
+.stepCopy {
 	display: flex;
 	flex-direction: column;
 	gap: 2px;
 }
 
-.addPanelTitle {
+.stepTitle {
 	color: var(--l1-foreground);
-	font-family: Inter;
 	font-size: 14px;
 	font-weight: 500;
 	line-height: 20px;
 }
 
-.addPanelInfo {
+.stepInfo {
 	color: var(--l3-foreground);
-	font-family: Inter;
 	font-size: 13px;
 	font-weight: 400;
 	line-height: 18px;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/DashboardEmptyState/DashboardEmptyState.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/DashboardEmptyState/DashboardEmptyState.module.scss
@@ -47,7 +47,7 @@
 	justify-content: space-between;
 	gap: 16px;
 	padding: 16px;
-	border: 1px dashed var(--l1-border);
+	border: 1px dashed var(--l3-border);
 	border-radius: 6px;
 }
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/DashboardEmptyState/DashboardEmptyState.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/DashboardEmptyState/DashboardEmptyState.tsx
@@ -1,4 +1,4 @@
-import { Plus } from '@signozhq/icons';
+import { Configure, Plus } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
 import { Typography } from '@signozhq/ui/typography';
 
@@ -6,6 +6,7 @@ import dashboardEmojiUrl from '@/assets/Icons/dashboard_emoji.svg';
 import landscapeUrl from '@/assets/Icons/landscape.svg';
 
 import { useCreatePanel } from '../../hooks/useCreatePanel';
+import { useDashboardStore } from '../../store/useDashboardStore';
 import PanelTypeSelectionModal from '../Panel/PanelTypeSelectionModal/PanelTypeSelectionModal';
 import styles from './DashboardEmptyState.module.scss';
 
@@ -18,6 +19,8 @@ function DashboardEmptyState({
 }: DashboardEmptyStateProps): JSX.Element {
 	const { isPickerOpen, openPicker, closePicker, createPanel } =
 		useCreatePanel();
+	const isEditable = useDashboardStore((s) => s.isEditable);
+	const requestSettings = useDashboardStore((s) => s.requestSettings);
 
 	return (
 		<section className={styles.emptyState}>
@@ -32,28 +35,55 @@ function DashboardEmptyState({
 					</Typography.Text>
 				</div>
 
-				<div className={styles.addPanel}>
-					<div className={styles.addPanelText}>
-						<img src={landscapeUrl} alt="" className={styles.icon} />
-						<div className={styles.addPanelCopy}>
-							<Typography.Text className={styles.addPanelTitle}>
-								Add panels
-							</Typography.Text>
-							<Typography.Text className={styles.addPanelInfo}>
-								Add panels to visualize your data
-							</Typography.Text>
+				<div className={styles.steps}>
+					<div className={styles.step}>
+						<div className={styles.stepText}>
+							<Configure size={14} className={styles.stepIcon} />
+							<div className={styles.stepCopy}>
+								<Typography.Text className={styles.stepTitle}>
+									Configure your new dashboard
+								</Typography.Text>
+								<Typography.Text className={styles.stepInfo}>
+									Give it a name, add description, tags and variables
+								</Typography.Text>
+							</div>
 						</div>
+						{isEditable && (
+							<Button
+								variant="solid"
+								color="secondary"
+								prefix={<Configure size="md" />}
+								onClick={(): void => requestSettings({ tab: 'Overview' })}
+								testId="empty-configure"
+							>
+								Configure
+							</Button>
+						)}
 					</div>
-					{canAddPanel && (
-						<Button
-							color="primary"
-							prefix={<Plus size="md" />}
-							onClick={(): void => openPicker()}
-							testId="add-panel"
-						>
-							New Panel
-						</Button>
-					)}
+
+					<div className={styles.step}>
+						<div className={styles.stepText}>
+							<img src={landscapeUrl} alt="" className={styles.stepIcon} />
+							<div className={styles.stepCopy}>
+								<Typography.Text className={styles.stepTitle}>
+									Add panels
+								</Typography.Text>
+								<Typography.Text className={styles.stepInfo}>
+									Add panels to visualize your data
+								</Typography.Text>
+							</div>
+						</div>
+						{canAddPanel && (
+							<Button
+								color="primary"
+								prefix={<Plus size="md" />}
+								onClick={(): void => openPicker()}
+								testId="add-panel"
+							>
+								New Panel
+							</Button>
+						)}
+					</div>
 				</div>
 			</div>
 			<PanelTypeSelectionModal

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/AddVariableFull.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/AddVariableFull.tsx
@@ -1,0 +1,31 @@
+import { Plus } from '@signozhq/icons';
+import { Button } from '@signozhq/ui/button';
+
+import { useDashboardStore } from '../store/useDashboardStore';
+import styles from './VariablesBar.module.scss';
+
+/**
+ * Full-width labelled "Add variable" button shown in the empty state, before any
+ * variables exist. Opens the Variables settings tab with the add form primed.
+ */
+function AddVariableFull(): JSX.Element {
+	const requestSettings = useDashboardStore((s) => s.requestSettings);
+
+	return (
+		<Button
+			variant="outlined"
+			color="secondary"
+			size="md"
+			className={styles.addVariable}
+			prefix={<Plus size={14} />}
+			testId="dashboard-variables-add"
+			onClick={(): void =>
+				requestSettings({ tab: 'Variables', addVariable: true })
+			}
+		>
+			Add variable
+		</Button>
+	);
+}
+
+export default AddVariableFull;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/AddVariableIcon.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/AddVariableIcon.tsx
@@ -1,0 +1,35 @@
+import { Plus } from '@signozhq/icons';
+import { Button } from '@signozhq/ui/button';
+import { TooltipSimple } from '@signozhq/ui/tooltip';
+
+import { useDashboardStore } from '../store/useDashboardStore';
+import styles from './VariablesBar.module.scss';
+
+/**
+ * Compact "+" trigger (label on hover) shown after the variable pills once at
+ * least one variable exists. Opens the Variables settings tab with the add form
+ * primed.
+ */
+function AddVariableIcon(): JSX.Element {
+	const requestSettings = useDashboardStore((s) => s.requestSettings);
+
+	return (
+		<TooltipSimple side="top" title="Add variable">
+			<Button
+				variant="outlined"
+				color="secondary"
+				size="icon"
+				className={styles.addVariable}
+				aria-label="Add variable"
+				testId="dashboard-variables-add"
+				onClick={(): void =>
+					requestSettings({ tab: 'Variables', addVariable: true })
+				}
+			>
+				<Plus size={14} />
+			</Button>
+		</TooltipSimple>
+	);
+}
+
+export default AddVariableIcon;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.module.scss
@@ -8,6 +8,7 @@
 .addVariable {
 	flex: none;
 	border-style: dashed !important;
+	border-color: var(--l3-border) !important;
 }
 
 .strip {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.module.scss
@@ -1,7 +1,8 @@
+// Block (not flex) so the strip wraps around the floated time selector: one line
+// beside it when collapsed, and — via `.stripExpanded`'s `clear: both` — dropping
+// full-width below it when expanded. A flex `.bar` would be a BFC that sits beside
+// the float and makes the child strip's `clear` inert.
 .bar {
-	display: flex;
-	align-items: flex-start;
-	gap: 8px;
 	min-width: 0;
 }
 
@@ -24,7 +25,8 @@
 	clear: both;
 
 	.variableSlot,
-	.moreButton {
+	.moreButton,
+	.addSlot {
 		margin: 0;
 	}
 
@@ -57,6 +59,12 @@
 }
 
 .moreButton {
+	display: inline-flex;
+	margin-right: 8px;
+	vertical-align: top;
+}
+
+.addSlot {
 	display: inline-flex;
 	vertical-align: top;
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.module.scss
@@ -1,5 +1,13 @@
 .bar {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
 	min-width: 0;
+}
+
+.addVariable {
+	flex: none;
+	border-style: dashed !important;
 }
 
 .strip {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ChevronLeft, Plus } from '@signozhq/icons';
+import { ChevronLeft } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
 import { TooltipSimple } from '@signozhq/ui/tooltip';
 import cx from 'classnames';
@@ -7,6 +7,8 @@ import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/service
 import { useInlineOverflowCount } from 'hooks/useInlineOverflowCount';
 
 import { useDashboardStore } from '../store/useDashboardStore';
+import AddVariableFull from './AddVariableFull';
+import AddVariableIcon from './AddVariableIcon';
 import type { VariableSelection } from './selectionTypes';
 import { useVariableSelection } from './useVariableSelection';
 import VariableSelector from './VariableSelector';
@@ -46,7 +48,6 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 	const { variables, selection, setSelection, autoSelect } =
 		useVariableSelection(dashboard);
 	const isEditable = useDashboardStore((s) => s.isEditable);
-	const requestSettings = useDashboardStore((s) => s.requestSettings);
 	const [expanded, setExpanded] = useState(false);
 	const { containerRef, visibleCount, overflowCount } = useInlineOverflowCount({
 		itemCount: variables.length,
@@ -62,41 +63,6 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 	if (variables.length === 0 && !isEditable) {
 		return null;
 	}
-
-	const openAddVariable = (): void =>
-		requestSettings({ tab: 'Variables', addVariable: true });
-
-	// No variables yet: a full-width labelled button. Once variables exist it
-	// shrinks to a `+` icon (with the label on hover) that sits after them.
-	const addVariableFull = (
-		<Button
-			variant="outlined"
-			color="secondary"
-			size="md"
-			className={styles.addVariable}
-			prefix={<Plus size={14} />}
-			testId="dashboard-variables-add"
-			onClick={openAddVariable}
-		>
-			Add variable
-		</Button>
-	);
-
-	const addVariableIcon = (
-		<TooltipSimple side="top" title="Add variable">
-			<Button
-				variant="outlined"
-				color="secondary"
-				size="icon"
-				className={styles.addVariable}
-				aria-label="Add variable"
-				testId="dashboard-variables-add"
-				onClick={openAddVariable}
-			>
-				<Plus size={14} />
-			</Button>
-		</TooltipSimple>
-	);
 
 	const hasOverflow = overflowCount > 0;
 	const hiddenVariables =
@@ -119,7 +85,7 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 	if (variables.length === 0) {
 		return (
 			<div className={styles.bar} data-testid="dashboard-variables-bar">
-				{addVariableFull}
+				<AddVariableFull />
 			</div>
 		);
 	}
@@ -182,7 +148,11 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 				{/* After the more/less trigger, in every state. Kept inline (not block)
 				    so the row still flows under the floated time selector, and always
 				    mounted so measuring never toggles it. */}
-				{isEditable && <span className={styles.addSlot}>{addVariableIcon}</span>}
+				{isEditable && (
+					<span className={styles.addSlot}>
+						<AddVariableIcon />
+					</span>
+				)}
 			</div>
 		</div>
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
-import { ChevronLeft } from '@signozhq/icons';
+import { ChevronLeft, Plus } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
 import { TooltipSimple } from '@signozhq/ui/tooltip';
 import cx from 'classnames';
 import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
 import { useInlineOverflowCount } from 'hooks/useInlineOverflowCount';
 
+import { useDashboardStore } from '../store/useDashboardStore';
 import type { VariableSelection } from './selectionTypes';
 import { useVariableSelection } from './useVariableSelection';
 import VariableSelector from './VariableSelector';
@@ -44,6 +45,8 @@ interface VariablesBarProps {
 function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 	const { variables, selection, setSelection, autoSelect } =
 		useVariableSelection(dashboard);
+	const isEditable = useDashboardStore((s) => s.isEditable);
+	const requestSettings = useDashboardStore((s) => s.requestSettings);
 	const [expanded, setExpanded] = useState(false);
 	const { containerRef, visibleCount, overflowCount } = useInlineOverflowCount({
 		itemCount: variables.length,
@@ -52,9 +55,27 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 		enabled: !expanded,
 	});
 
-	if (variables.length === 0) {
+	// Editors can add a variable even before any exist; viewers with no variables
+	// have nothing to show.
+	if (variables.length === 0 && !isEditable) {
 		return null;
 	}
+
+	const addVariableButton = isEditable ? (
+		<Button
+			variant="outlined"
+			color="secondary"
+			size="md"
+			className={styles.addVariable}
+			prefix={<Plus size={14} />}
+			testId="dashboard-variables-add"
+			onClick={(): void =>
+				requestSettings({ tab: 'Variables', addVariable: true })
+			}
+		>
+			Add variable
+		</Button>
+	) : null;
 
 	const hasOverflow = overflowCount > 0;
 	const hiddenVariables =
@@ -76,6 +97,7 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 
 	return (
 		<div className={styles.bar} data-testid="dashboard-variables-bar">
+			{addVariableButton}
 			<div
 				ref={containerRef}
 				className={cx(styles.strip, { [styles.stripExpanded]: expanded })}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
@@ -176,8 +176,11 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 						)}
 					</span>
 				)}
+
+				{/* At the end of the list. Hidden while collapsed (the +N would clash);
+				    expand to reveal it, so the layout never breaks mid-wrap. */}
+				{isEditable && (!hasOverflow || expanded) && addVariableIcon}
 			</div>
-			{isEditable && addVariableIcon}
 		</div>
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
@@ -51,7 +51,9 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 	const { containerRef, visibleCount, overflowCount } = useInlineOverflowCount({
 		itemCount: variables.length,
 		gap: 8,
-		reserveWidth: 48,
+		// Reserve the trailing line space: the "+N" trigger, plus the always-present
+		// add-variable "+" when editable, so the collapse math accounts for both.
+		reserveWidth: isEditable ? 88 : 48,
 		enabled: !expanded,
 	});
 
@@ -177,9 +179,10 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 					</span>
 				)}
 
-				{/* At the end of the list. Hidden while collapsed (the +N would clash);
-				    expand to reveal it, so the layout never breaks mid-wrap. */}
-				{isEditable && (!hasOverflow || expanded) && addVariableIcon}
+				{/* After the more/less trigger, in every state. Kept inline (not block)
+				    so the row still flows under the floated time selector, and always
+				    mounted so measuring never toggles it. */}
+				{isEditable && <span className={styles.addSlot}>{addVariableIcon}</span>}
 			</div>
 		</div>
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
@@ -61,7 +61,12 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 		return null;
 	}
 
-	const addVariableButton = isEditable ? (
+	const openAddVariable = (): void =>
+		requestSettings({ tab: 'Variables', addVariable: true });
+
+	// No variables yet: a full-width labelled button. Once variables exist it
+	// shrinks to a `+` icon (with the label on hover) that sits after them.
+	const addVariableFull = (
 		<Button
 			variant="outlined"
 			color="secondary"
@@ -69,13 +74,27 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 			className={styles.addVariable}
 			prefix={<Plus size={14} />}
 			testId="dashboard-variables-add"
-			onClick={(): void =>
-				requestSettings({ tab: 'Variables', addVariable: true })
-			}
+			onClick={openAddVariable}
 		>
 			Add variable
 		</Button>
-	) : null;
+	);
+
+	const addVariableIcon = (
+		<TooltipSimple side="top" title="Add variable">
+			<Button
+				variant="outlined"
+				color="secondary"
+				size="icon"
+				className={styles.addVariable}
+				aria-label="Add variable"
+				testId="dashboard-variables-add"
+				onClick={openAddVariable}
+			>
+				<Plus size={14} />
+			</Button>
+		</TooltipSimple>
+	);
 
 	const hasOverflow = overflowCount > 0;
 	const hiddenVariables =
@@ -95,9 +114,16 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 		</Button>
 	);
 
+	if (variables.length === 0) {
+		return (
+			<div className={styles.bar} data-testid="dashboard-variables-bar">
+				{addVariableFull}
+			</div>
+		);
+	}
+
 	return (
 		<div className={styles.bar} data-testid="dashboard-variables-bar">
-			{addVariableButton}
 			<div
 				ref={containerRef}
 				className={cx(styles.strip, { [styles.stripExpanded]: expanded })}
@@ -151,6 +177,7 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 					</span>
 				)}
 			</div>
+			{isEditable && addVariableIcon}
 		</div>
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
@@ -53,11 +53,17 @@ function DashboardContainer({
 	// suggests them ($variable) in the panel editor and dashboards-page builder.
 	useSyncVariablesForSuggestions(dashboard);
 
+	// In full screen show only the sections and panels — the header/toolbar chrome
+	// is hidden for a clean presentation view (exit with Esc).
 	return (
 		<FullScreen handle={fullScreenHandle}>
 			<div className={styles.container}>
-				<DashboardPageHeader title={name} image={image} />
-				<DashboardPageToolbar dashboard={dashboard} handle={fullScreenHandle} />
+				{!fullScreenHandle.active && (
+					<>
+						<DashboardPageHeader title={name} image={image} />
+						<DashboardPageToolbar dashboard={dashboard} handle={fullScreenHandle} />
+					</>
+				)}
 				<PanelsAndSectionsLayout layouts={spec.layouts} panels={spec.panels} />
 				{isLocked && <LockedIndicator />}
 			</div>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/settingsRequestSlice.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/settingsRequestSlice.ts
@@ -1,0 +1,39 @@
+import type { StateCreator } from 'zustand';
+
+import type { DashboardStore } from '../useDashboardStore';
+
+/** Which settings-drawer tab to open. Mirrors the DashboardSettings tab keys. */
+export type SettingsTab = 'Overview' | 'Variables' | 'Publish';
+
+export interface SettingsRequest {
+	tab: SettingsTab;
+	/** Open the add-variable form immediately (Variables tab only). */
+	addVariable?: boolean;
+}
+
+/**
+ * A transient request to open the settings drawer at a given tab/action, so a
+ * control anywhere in the tree (e.g. the "Add variable" button in the variables
+ * bar) can deep-link into the drawer without prop-threading. Not persisted;
+ * cleared when the drawer closes.
+ */
+export interface SettingsRequestSlice {
+	settingsRequest: SettingsRequest | null;
+	requestSettings: (request: SettingsRequest) => void;
+	clearSettingsRequest: () => void;
+}
+
+export const createSettingsRequestSlice: StateCreator<
+	DashboardStore,
+	[['zustand/persist', unknown]],
+	[],
+	SettingsRequestSlice
+> = (set) => ({
+	settingsRequest: null,
+	requestSettings: (settingsRequest): void => {
+		set({ settingsRequest });
+	},
+	clearSettingsRequest: (): void => {
+		set({ settingsRequest: null });
+	},
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/useDashboardStore.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/useDashboardStore.ts
@@ -17,11 +17,16 @@ import {
 	createVariableFetchSlice,
 	type VariableFetchSlice,
 } from './slices/variableFetchSlice';
+import {
+	createSettingsRequestSlice,
+	type SettingsRequestSlice,
+} from './slices/settingsRequestSlice';
 
 export type DashboardStore = EditContextSlice &
 	CollapseSlice &
 	VariableSelectionSlice &
-	VariableFetchSlice;
+	VariableFetchSlice &
+	SettingsRequestSlice;
 
 /**
  * V2 dashboard session store. Holds cross-cutting client state only — never the
@@ -37,6 +42,7 @@ export const useDashboardStore = create<DashboardStore>()(
 			...createCollapseSlice(...a),
 			...createVariableSelectionSlice(...a),
 			...createVariableFetchSlice(...a),
+			...createSettingsRequestSlice(...a),
 		}),
 		{
 			name: '@signoz/dashboard-v2',


### PR DESCRIPTION
## Summary
Variable editor form, add-variable UX, and toolbar/empty-state styling for the V2 dashboard (dark-shipped behind `use_dashboard_v2`). Builds on the variable fetch engine and the panel-linking work.

**Variable editor form**
- Restore the V1 combined field/source row for dynamic variables (field on the left, `from` + telemetry source on the right).
- Cap the "Preview of values" box height.
- Raise the dynamic-variable attribute search debounce to 500 ms.

**Add-variable UX**
- Add-variable button in the variables bar: full-width labelled button when no variables exist; a `+` icon (label on hover) once they do. It opens the settings drawer straight to the Variables tab in add mode (via a transient `settingsRequest` store slice + `destroyOnClose` remount).
- The `+` sits after the `+N`/Less trigger, kept inline and always mounted so the overflow measurement never toggles it.

**Layout & styling**
- The variables bar flows under the floated time selector again (block wrapper, so the strip wraps around the float; expanded rows drop full-width below it).
- Flat `l3` borders on the Actions / Configure / JSON toolbar buttons (no depth/shadow); `l3` dashed border on the empty state.
- Add a "Configure your new dashboard" step to the empty state, opening the settings drawer on the Overview tab.

## Test plan
- Manual (dev, flag on): add/edit variables via the drawer; add-variable button in both empty and populated bars; collapse/expand the bar and confirm it flows under the time selector without layout shift; empty-state Configure button opens the drawer.

Stacked PR — base: `feat/dashboard-v2-link-variables-panels` (merge the two upstream PRs first).
