### PR TITLE
fix: ui fixes for panel selection modal

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/index.tsx
@@ -63,8 +63,13 @@ function DashboardPageToolbar(props: DashboardPageToolbarProps): JSX.Element {
 	const { user } = useAppContext();
 	const { showErrorModal } = useErrorModal();
 	const { patchAsync } = useOptimisticPatch();
-	const { isPickerOpen, openPicker, closePicker, createPanel } =
-		useCreatePanel();
+	const {
+		isPickerOpen,
+		openPicker,
+		closePicker,
+		createPanel,
+		targetLayoutIndex,
+	} = useCreatePanel();
 
 	const isAuthor =
 		!!user?.email && !!dashboard.createdBy && dashboard.createdBy === user.email;
@@ -183,6 +188,7 @@ function DashboardPageToolbar(props: DashboardPageToolbarProps): JSX.Element {
 				open={isPickerOpen}
 				onClose={closePicker}
 				onSelect={createPanel}
+				defaultLayoutIndex={targetLayoutIndex}
 			/>
 		</section>
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.module.scss
@@ -1,4 +1,12 @@
+.panelTypeSection {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	align-items: center;
+}
+
 .grid {
+	align-self: stretch;
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);
 	gap: 8px;
@@ -22,11 +30,10 @@
 
 	&:hover {
 		background-color: var(--l2-background-hover);
-		transform: translateY(-2px);
 		border-color: var(--bg-robin-400);
 	}
 	&:active {
-		transform: translateY(0px);
+		transform: translateY(2px);
 	}
 }
 
@@ -39,11 +46,13 @@
 .footerActions {
 	display: flex;
 	align-items: flex-end;
+	justify-content: flex-end;
 	gap: 8px;
 	width: 100%;
 }
 
 .footerPicker {
+	// Take all the width left over by the (natural-width) confirm button.
 	display: flex;
 	flex: 1;
 	flex-direction: column;
@@ -57,14 +66,4 @@
 	font-weight: 500;
 	letter-spacing: 0.06em;
 	text-transform: uppercase;
-}
-
-.footerConfirm {
-	display: flex;
-	flex: 1;
-	min-width: 0;
-}
-
-.confirmButton {
-	width: 100%;
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.module.scss
@@ -25,4 +25,46 @@
 		transform: translateY(-2px);
 		border-color: var(--bg-robin-400);
 	}
+	&:active {
+		transform: translateY(0px);
+	}
+}
+
+.panelTypeCardSelected {
+	border-color: var(--bg-robin-400);
+	background-color: var(--l2-background-hover);
+	box-shadow: inset 0 0 0 1px var(--bg-robin-400);
+}
+
+.footerActions {
+	display: flex;
+	align-items: flex-end;
+	gap: 8px;
+	width: 100%;
+}
+
+.footerPicker {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: 6px;
+	min-width: 0;
+}
+
+.pickerLabel {
+	color: var(--l3-foreground);
+	font-size: 11px;
+	font-weight: 500;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.footerConfirm {
+	display: flex;
+	flex: 1;
+	min-width: 0;
+}
+
+.confirmButton {
+	width: 100%;
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.module.scss
@@ -4,19 +4,25 @@
 	gap: 8px;
 }
 
-.typeButton {
+.panelTypeCard {
 	display: flex;
+	flex-direction: column;
 	align-items: center;
-	gap: 8px;
+	border: 1px solid var(--l2-border);
+	background: var(--l2-background);
 	padding: 12px;
-	background: var(--bg-ink-400, #0b0c0e);
-	border: 1px solid var(--l1-border);
+	gap: 12px;
+	cursor: pointer;
+	font: inherit;
 	border-radius: 4px;
 	color: var(--l1-foreground);
-	cursor: pointer;
-	text-align: left;
+	transition:
+		transform 180ms ease,
+		border-color 180ms ease;
 
 	&:hover {
-		border-color: var(--bg-robin-500);
+		background-color: var(--l2-background-hover);
+		transform: translateY(-2px);
+		border-color: var(--bg-robin-400);
 	}
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.tsx
@@ -10,6 +10,7 @@ import { PANEL_TYPES } from './constants';
 import SectionPicker from './SectionPicker';
 import { buildSectionOptions, resolveDefaultSectionValue } from './utils';
 import styles from './PanelTypeSelectionModal.module.scss';
+import { Plus } from '@signozhq/icons';
 
 interface PanelTypeSelectionModalProps {
 	open: boolean;
@@ -70,44 +71,36 @@ function PanelTypeSelectionModal({
 		}, CONFIRM_LOADER_MS);
 	};
 
-	const selectedPanel = PANEL_TYPES.find(
-		(p) => p.panelKind === selectedPanelKind,
-	);
-	const ConfirmIcon = selectedPanel?.Icon;
-
-	const footer =
-		selectedPanelKind !== null ? (
-			<div className={styles.footerActions}>
-				{hasSectionPicker && (
-					<div className={styles.footerPicker}>
-						<span className={styles.pickerLabel}>Add panel to</span>
-						<SectionPicker
-							options={options}
-							value={selectedValue}
-							onChange={setSelectedValue}
-						/>
-					</div>
-				)}
-				<div className={styles.footerConfirm}>
-					<Button
-						className={styles.confirmButton}
-						color="primary"
-						size="md"
-						loading={isSubmitting}
-						prefix={ConfirmIcon ? <ConfirmIcon size={16} /> : undefined}
-						onClick={handleConfirm}
-						testId="panel-type-confirm"
-					>
-						Add Panel
-					</Button>
+	// Footer is always shown; the confirm button is disabled until a panel type is picked.
+	const footer = (
+		<div className={styles.footerActions}>
+			{hasSectionPicker && (
+				<div className={styles.footerPicker}>
+					<span className={styles.pickerLabel}>Add panel to</span>
+					<SectionPicker
+						options={options}
+						value={selectedValue}
+						onChange={setSelectedValue}
+					/>
 				</div>
-			</div>
-		) : undefined;
+			)}
+			<Button
+				color="primary"
+				size="md"
+				disabled={selectedPanelKind === null}
+				loading={isSubmitting}
+				prefix={<Plus size={16} />}
+				onClick={handleConfirm}
+				testId="panel-type-confirm"
+			>
+				Add Panel
+			</Button>
+		</div>
+	);
 
 	return (
 		<DialogWrapper
 			open={open}
-			width="wide"
 			onOpenChange={(isOpen): void => {
 				if (!isOpen) {
 					onClose();
@@ -116,22 +109,25 @@ function PanelTypeSelectionModal({
 			title="New Panel"
 			footer={footer}
 		>
-			<div className={styles.grid}>
-				{PANEL_TYPES.map(({ panelKind, label, Icon }) => (
-					<button
-						key={panelKind}
-						type="button"
-						className={cx(styles.panelTypeCard, {
-							[styles.panelTypeCardSelected]: panelKind === selectedPanelKind,
-						})}
-						data-testid={`panel-type-${panelKind}`}
-						aria-pressed={panelKind === selectedPanelKind}
-						onClick={(): void => setSelectedPanelKind(panelKind)}
-					>
-						<Icon size={24} color={Color.BG_ROBIN_400} />
-						{label}
-					</button>
-				))}
+			<div className={styles.panelTypeSection}>
+				<span className={styles.pickerLabel}>Select panel type</span>
+				<div className={styles.grid}>
+					{PANEL_TYPES.map(({ panelKind, label, Icon }) => (
+						<button
+							key={panelKind}
+							type="button"
+							className={cx(styles.panelTypeCard, {
+								[styles.panelTypeCardSelected]: panelKind === selectedPanelKind,
+							})}
+							data-testid={`panel-type-${panelKind}`}
+							aria-pressed={panelKind === selectedPanelKind}
+							onClick={(): void => setSelectedPanelKind(panelKind)}
+						>
+							<Icon size={24} color={Color.BG_ROBIN_400} />
+							{label}
+						</button>
+					))}
+				</div>
 			</div>
 		</DialogWrapper>
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.tsx
@@ -1,5 +1,5 @@
-import { Modal } from 'antd';
-import { Button } from '@signozhq/ui/button';
+import { Color } from '@signozhq/design-tokens';
+import { DialogWrapper } from '@signozhq/ui/dialog';
 
 import type { PanelKind } from '../../../Panels/types/panelKind';
 import { PANEL_TYPES } from './constants';
@@ -17,29 +17,30 @@ function PanelTypeSelectionModal({
 	onSelect,
 }: PanelTypeSelectionModalProps): JSX.Element {
 	return (
-		<Modal
+		<DialogWrapper
 			open={open}
+			onOpenChange={(isOpen): void => {
+				if (!isOpen) {
+					onClose();
+				}
+			}}
 			title="Select a panel type"
-			onCancel={onClose}
-			footer={null}
-			destroyOnClose
 		>
 			<div className={styles.grid}>
 				{PANEL_TYPES.map(({ panelKind, label, Icon }) => (
-					<Button
+					<button
 						key={panelKind}
 						type="button"
-						variant="ghost"
-						className={styles.typeButton}
+						className={styles.panelTypeCard}
 						data-testid={`panel-type-${panelKind}`}
 						onClick={(): void => onSelect(panelKind)}
 					>
-						<Icon size={14} />
+						<Icon size={24} color={Color.BG_ROBIN_400} />
 						{label}
-					</Button>
+					</button>
 				))}
 			</div>
-		</Modal>
+		</DialogWrapper>
 	);
 }
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.tsx
@@ -1,39 +1,132 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Color } from '@signozhq/design-tokens';
+import { Button } from '@signozhq/ui/button';
 import { DialogWrapper } from '@signozhq/ui/dialog';
+import cx from 'classnames';
 
+import { useDashboardSections } from '../../../hooks/useDashboardSections';
 import type { PanelKind } from '../../../Panels/types/panelKind';
 import { PANEL_TYPES } from './constants';
+import SectionPicker from './SectionPicker';
+import { buildSectionOptions, resolveDefaultSectionValue } from './utils';
 import styles from './PanelTypeSelectionModal.module.scss';
 
 interface PanelTypeSelectionModalProps {
 	open: boolean;
 	onClose: () => void;
-	onSelect: (panelKind: PanelKind) => void;
+	onSelect: (panelKind: PanelKind, layoutIndex?: number) => void;
+	/** Section the picker opens on; omit → the untitled root / first section. */
+	defaultLayoutIndex?: number;
 }
+
+/** Fake loader shown on the confirm button before navigating to the editor. */
+const CONFIRM_LOADER_MS = 500;
 
 function PanelTypeSelectionModal({
 	open,
 	onClose,
 	onSelect,
+	defaultLayoutIndex,
 }: PanelTypeSelectionModalProps): JSX.Element {
+	const sections = useDashboardSections();
+	const options = useMemo(() => buildSectionOptions(sections), [sections]);
+	const hasSectionPicker = options.length > 1;
+
+	const [selectedValue, setSelectedValue] = useState('');
+	const [selectedPanelKind, setSelectedPanelKind] = useState<PanelKind | null>(
+		null,
+	);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const clearTimer = useCallback((): void => {
+		if (timerRef.current !== null) {
+			clearTimeout(timerRef.current);
+			timerRef.current = null;
+		}
+	}, []);
+
+	// Seed the target section on open; cancel a pending navigation on close.
+	useEffect(() => {
+		if (open) {
+			setSelectedValue(resolveDefaultSectionValue(options, defaultLayoutIndex));
+			setSelectedPanelKind(null);
+			setIsSubmitting(false);
+		} else {
+			clearTimer();
+		}
+	}, [open, options, defaultLayoutIndex, clearTimer]);
+
+	useEffect(() => clearTimer, [clearTimer]);
+
+	const handleConfirm = (): void => {
+		if (selectedPanelKind === null || isSubmitting) {
+			return;
+		}
+		setIsSubmitting(true);
+		const layoutIndex = selectedValue === '' ? undefined : Number(selectedValue);
+		timerRef.current = setTimeout(() => {
+			onSelect(selectedPanelKind, layoutIndex);
+		}, CONFIRM_LOADER_MS);
+	};
+
+	const selectedPanel = PANEL_TYPES.find(
+		(p) => p.panelKind === selectedPanelKind,
+	);
+	const ConfirmIcon = selectedPanel?.Icon;
+
+	const footer =
+		selectedPanelKind !== null ? (
+			<div className={styles.footerActions}>
+				{hasSectionPicker && (
+					<div className={styles.footerPicker}>
+						<span className={styles.pickerLabel}>Add panel to</span>
+						<SectionPicker
+							options={options}
+							value={selectedValue}
+							onChange={setSelectedValue}
+						/>
+					</div>
+				)}
+				<div className={styles.footerConfirm}>
+					<Button
+						className={styles.confirmButton}
+						color="primary"
+						size="md"
+						loading={isSubmitting}
+						prefix={ConfirmIcon ? <ConfirmIcon size={16} /> : undefined}
+						onClick={handleConfirm}
+						testId="panel-type-confirm"
+					>
+						Add Panel
+					</Button>
+				</div>
+			</div>
+		) : undefined;
+
 	return (
 		<DialogWrapper
 			open={open}
+			width="wide"
 			onOpenChange={(isOpen): void => {
 				if (!isOpen) {
 					onClose();
 				}
 			}}
-			title="Select a panel type"
+			title="New Panel"
+			footer={footer}
 		>
 			<div className={styles.grid}>
 				{PANEL_TYPES.map(({ panelKind, label, Icon }) => (
 					<button
 						key={panelKind}
 						type="button"
-						className={styles.panelTypeCard}
+						className={cx(styles.panelTypeCard, {
+							[styles.panelTypeCardSelected]: panelKind === selectedPanelKind,
+						})}
 						data-testid={`panel-type-${panelKind}`}
-						onClick={(): void => onSelect(panelKind)}
+						aria-pressed={panelKind === selectedPanelKind}
+						onClick={(): void => setSelectedPanelKind(panelKind)}
 					>
 						<Icon size={24} color={Color.BG_ROBIN_400} />
 						{label}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.tsx
@@ -1,27 +1,22 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Color } from '@signozhq/design-tokens';
-import { Button } from '@signozhq/ui/button';
 import { DialogWrapper } from '@signozhq/ui/dialog';
 import cx from 'classnames';
 
 import { useDashboardSections } from '../../../hooks/useDashboardSections';
 import type { PanelKind } from '../../../Panels/types/panelKind';
 import { PANEL_TYPES } from './constants';
-import SectionPicker from './SectionPicker';
+import PanelTypeSelectionModalFooter from './PanelTypeSelectionModalFooter';
 import { buildSectionOptions, resolveDefaultSectionValue } from './utils';
 import styles from './PanelTypeSelectionModal.module.scss';
-import { Plus } from '@signozhq/icons';
 
 interface PanelTypeSelectionModalProps {
 	open: boolean;
 	onClose: () => void;
 	onSelect: (panelKind: PanelKind, layoutIndex?: number) => void;
-	/** Section the picker opens on; omit → the untitled root / first section. */
+	/** Section the picker opens on; omit → the first section. */
 	defaultLayoutIndex?: number;
 }
-
-/** Fake loader shown on the confirm button before navigating to the editor. */
-const CONFIRM_LOADER_MS = 500;
 
 function PanelTypeSelectionModal({
 	open,
@@ -31,72 +26,27 @@ function PanelTypeSelectionModal({
 }: PanelTypeSelectionModalProps): JSX.Element {
 	const sections = useDashboardSections();
 	const options = useMemo(() => buildSectionOptions(sections), [sections]);
-	const hasSectionPicker = options.length > 1;
 
 	const [selectedValue, setSelectedValue] = useState('');
 	const [selectedPanelKind, setSelectedPanelKind] = useState<PanelKind | null>(
 		null,
 	);
-	const [isSubmitting, setIsSubmitting] = useState(false);
-	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-	const clearTimer = useCallback((): void => {
-		if (timerRef.current !== null) {
-			clearTimeout(timerRef.current);
-			timerRef.current = null;
-		}
-	}, []);
-
-	// Seed the target section on open; cancel a pending navigation on close.
+	// Seed the target section on open.
 	useEffect(() => {
 		if (open) {
 			setSelectedValue(resolveDefaultSectionValue(options, defaultLayoutIndex));
 			setSelectedPanelKind(null);
-			setIsSubmitting(false);
-		} else {
-			clearTimer();
 		}
-	}, [open, options, defaultLayoutIndex, clearTimer]);
-
-	useEffect(() => clearTimer, [clearTimer]);
+	}, [open, options, defaultLayoutIndex]);
 
 	const handleConfirm = (): void => {
-		if (selectedPanelKind === null || isSubmitting) {
+		if (selectedPanelKind === null) {
 			return;
 		}
-		setIsSubmitting(true);
 		const layoutIndex = selectedValue === '' ? undefined : Number(selectedValue);
-		timerRef.current = setTimeout(() => {
-			onSelect(selectedPanelKind, layoutIndex);
-		}, CONFIRM_LOADER_MS);
+		onSelect(selectedPanelKind, layoutIndex);
 	};
-
-	// Footer is always shown; the confirm button is disabled until a panel type is picked.
-	const footer = (
-		<div className={styles.footerActions}>
-			{hasSectionPicker && (
-				<div className={styles.footerPicker}>
-					<span className={styles.pickerLabel}>Add panel to</span>
-					<SectionPicker
-						options={options}
-						value={selectedValue}
-						onChange={setSelectedValue}
-					/>
-				</div>
-			)}
-			<Button
-				color="primary"
-				size="md"
-				disabled={selectedPanelKind === null}
-				loading={isSubmitting}
-				prefix={<Plus size={16} />}
-				onClick={handleConfirm}
-				testId="panel-type-confirm"
-			>
-				Add Panel
-			</Button>
-		</div>
-	);
 
 	return (
 		<DialogWrapper
@@ -107,7 +57,15 @@ function PanelTypeSelectionModal({
 				}
 			}}
 			title="New Panel"
-			footer={footer}
+			footer={
+				<PanelTypeSelectionModalFooter
+					options={options}
+					selectedValue={selectedValue}
+					onSectionChange={setSelectedValue}
+					isConfirmDisabled={selectedPanelKind === null}
+					onConfirm={handleConfirm}
+				/>
+			}
 		>
 			<div className={styles.panelTypeSection}>
 				<span className={styles.pickerLabel}>Select panel type</span>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModalFooter.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModalFooter.tsx
@@ -1,0 +1,56 @@
+import { Plus } from '@signozhq/icons';
+import { Button } from '@signozhq/ui/button';
+
+import SectionPicker from './SectionPicker';
+import type { SectionOption } from './types';
+import styles from './PanelTypeSelectionModal.module.scss';
+
+interface PanelTypeSelectionModalFooterProps {
+	options: SectionOption[];
+	selectedValue: string;
+	onSectionChange: (value: string) => void;
+	/** Disabled until a panel type is picked. */
+	isConfirmDisabled: boolean;
+	onConfirm: () => void;
+}
+
+/**
+ * Footer for the New Panel modal: an "Add panel to" section picker (shown only
+ * when the dashboard has more than one section) and the confirm button.
+ */
+function PanelTypeSelectionModalFooter({
+	options,
+	selectedValue,
+	onSectionChange,
+	isConfirmDisabled,
+	onConfirm,
+}: PanelTypeSelectionModalFooterProps): JSX.Element {
+	const hasSectionPicker = options.length > 1;
+
+	return (
+		<div className={styles.footerActions}>
+			{hasSectionPicker && (
+				<div className={styles.footerPicker}>
+					<span className={styles.pickerLabel}>Add panel to</span>
+					<SectionPicker
+						options={options}
+						value={selectedValue}
+						onChange={onSectionChange}
+					/>
+				</div>
+			)}
+			<Button
+				color="primary"
+				size="md"
+				disabled={isConfirmDisabled}
+				prefix={<Plus size={16} />}
+				onClick={onConfirm}
+				testId="panel-type-confirm"
+			>
+				Add Panel
+			</Button>
+		</div>
+	);
+}
+
+export default PanelTypeSelectionModalFooter;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/SectionPicker.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/SectionPicker.module.scss
@@ -1,0 +1,55 @@
+.select {
+	width: 100%;
+}
+
+.dropdown {
+	min-width: 260px;
+}
+
+.rootIcon {
+	color: var(--bg-robin-400);
+	flex-shrink: 0;
+}
+
+.sectionIcon {
+	color: var(--l3-foreground);
+	flex-shrink: 0;
+}
+
+.triggerValue {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	overflow: hidden;
+}
+
+.triggerLabel {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.optionRow {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 4px 0;
+}
+
+.optionText {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	overflow: hidden;
+}
+
+.optionLabel {
+	color: var(--l1-foreground);
+	line-height: 1.2;
+}
+
+.optionDescription {
+	color: var(--l3-foreground);
+	font-size: 12px;
+	line-height: 1.2;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/SectionPicker.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/SectionPicker.tsx
@@ -1,0 +1,65 @@
+import { useMemo } from 'react';
+// eslint-disable-next-line signoz/no-antd-components
+import { Select } from 'antd';
+
+import type { SectionOption } from './types';
+import styles from './SectionPicker.module.scss';
+
+interface SectionPickerProps {
+	options: SectionOption[];
+	value: string;
+	onChange: (value: string) => void;
+}
+
+function SectionPicker({
+	options,
+	value,
+	onChange,
+}: SectionPickerProps): JSX.Element {
+	// `selectedLabel` (one line) shows in the trigger; `label` (two lines) in the list.
+	const selectOptions = useMemo(
+		() =>
+			options.map((option) => {
+				const iconClass = option.isRoot ? styles.rootIcon : styles.sectionIcon;
+				return {
+					value: option.value,
+					selectedLabel: (
+						<span className={styles.triggerValue}>
+							<option.Icon size={16} className={iconClass} />
+							<span className={styles.triggerLabel}>{option.label}</span>
+						</span>
+					),
+					label: (
+						<span
+							className={styles.optionRow}
+							data-testid={`panel-section-option-${option.layoutIndex}`}
+						>
+							<option.Icon size={16} className={iconClass} />
+							<span className={styles.optionText}>
+								<span className={styles.optionLabel}>{option.label}</span>
+								<span className={styles.optionDescription}>{option.description}</span>
+							</span>
+						</span>
+					),
+				};
+			}),
+		[options],
+	);
+
+	return (
+		<Select<string>
+			className={styles.select}
+			popupClassName={styles.dropdown}
+			value={value}
+			onChange={onChange}
+			data-testid="panel-section-select"
+			optionLabelProp="selectedLabel"
+			getPopupContainer={(trigger): HTMLElement =>
+				trigger.parentElement ?? document.body
+			}
+			options={selectOptions}
+		/>
+	);
+}
+
+export default SectionPicker;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/types.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/types.ts
@@ -14,3 +14,16 @@ export interface PanelType {
 	/** Icon component — the consumer renders it and controls size/color/etc. */
 	Icon: ComponentType<IconProps>;
 }
+
+export interface SectionOption {
+	/** The section's `layoutIndex`, stringified for the Select value. */
+	value: string;
+	layoutIndex: number;
+	/** Section title, or "Dashboard (root)" for the untitled top-level layout. */
+	label: string;
+	/** Caption under the label. */
+	description: string;
+	/** Untitled top-level layout (has no section header). */
+	isRoot: boolean;
+	Icon: ComponentType<IconProps>;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/utils.ts
@@ -12,7 +12,7 @@ export function buildSectionOptions(
 	sections: DashboardSection[],
 ): SectionOption[] {
 	return sections.map((section) => {
-		const isRoot = !section.title;
+		const isRoot = !section.title && section.layoutIndex === 0;
 		return {
 			value: String(section.layoutIndex),
 			layoutIndex: section.layoutIndex,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/utils.ts
@@ -1,0 +1,41 @@
+import { LayoutDashboard, Rows2 } from '@signozhq/icons';
+
+import type { DashboardSection } from '../../../utils';
+import type { SectionOption } from './types';
+
+const ROOT_LABEL = 'Dashboard (root)';
+const ROOT_DESCRIPTION = 'Top level — no section';
+const SECTION_DESCRIPTION = 'Section';
+
+/** Maps dashboard sections to section-picker options (untitled → "root"). */
+export function buildSectionOptions(
+	sections: DashboardSection[],
+): SectionOption[] {
+	return sections.map((section) => {
+		const isRoot = !section.title;
+		return {
+			value: String(section.layoutIndex),
+			layoutIndex: section.layoutIndex,
+			label: isRoot ? ROOT_LABEL : (section.title as string),
+			description: isRoot ? ROOT_DESCRIPTION : SECTION_DESCRIPTION,
+			isRoot,
+			Icon: isRoot ? LayoutDashboard : Rows2,
+		};
+	});
+}
+
+/**
+ * Picks the option the picker should open on: the section the "Add panel" was
+ * triggered from when present and still valid, otherwise the first option.
+ */
+export function resolveDefaultSectionValue(
+	options: SectionOption[],
+	defaultLayoutIndex: number | undefined,
+): string {
+	const fallback = options[0]?.value ?? '';
+	if (defaultLayoutIndex === undefined) {
+		return fallback;
+	}
+	const target = String(defaultLayoutIndex);
+	return options.some((option) => option.value === target) ? target : fallback;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/Section/Section.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/Section/Section.tsx
@@ -29,8 +29,13 @@ interface SectionProps {
 
 function Section({ section, sections, dragHandle }: SectionProps): JSX.Element {
 	const isEditable = useDashboardStore((s) => s.isEditable);
-	const { isPickerOpen, openPicker, closePicker, createPanel } =
-		useCreatePanel();
+	const {
+		isPickerOpen,
+		openPicker,
+		closePicker,
+		createPanel,
+		targetLayoutIndex,
+	} = useCreatePanel();
 	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 	const containerRef = useRef<HTMLDivElement>(null);
 	// Placeholder signal for lazy panel query-loading (consumed in a later PR):
@@ -141,6 +146,7 @@ function Section({ section, sections, dragHandle }: SectionProps): JSX.Element {
 				open={isPickerOpen}
 				onClose={closePicker}
 				onSelect={createPanel}
+				defaultLayoutIndex={targetLayoutIndex}
 			/>
 			<ConfirmDeleteDialog
 				open={isDeleteOpen}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useCreatePanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useCreatePanel.ts
@@ -12,7 +12,10 @@ interface UseCreatePanelResult {
 	/** Pass the target section's layout index; omit → last/new section. */
 	openPicker: (layoutIndex?: number) => void;
 	closePicker: () => void;
-	createPanel: (panelKind: PanelKind) => void;
+	/** The section the picker was opened against — seeds its section dropdown. */
+	targetLayoutIndex: number | undefined;
+	/** `layoutIndex` overrides the opened-against target (the dropdown's choice). */
+	createPanel: (panelKind: PanelKind, layoutIndex?: number) => void;
 }
 
 /**
@@ -38,16 +41,23 @@ export function useCreatePanel(): UseCreatePanelResult {
 	}, []);
 
 	const createPanel = useCallback(
-		(panelKind: PanelKind): void => {
+		(panelKind: PanelKind, targetIndex?: number): void => {
 			setIsPickerOpen(false);
 			const path = generatePath(ROUTES.DASHBOARD_PANEL_EDITOR, {
 				dashboardId,
 				panelId: NEW_PANEL_ID,
 			});
-			safeNavigate(`${path}${newPanelSearch(panelKind, layoutIndex)}`);
+			const target = targetIndex ?? layoutIndex;
+			safeNavigate(`${path}${newPanelSearch(panelKind, target)}`);
 		},
 		[safeNavigate, dashboardId, layoutIndex],
 	);
 
-	return { isPickerOpen, openPicker, closePicker, createPanel };
+	return {
+		isPickerOpen,
+		openPicker,
+		closePicker,
+		targetLayoutIndex: layoutIndex,
+		createPanel,
+	};
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardSections.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardSections.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { useGetDashboardV2 } from 'api/generated/services/dashboard';
+
+import { useDashboardStore } from '../store/useDashboardStore';
+import { type DashboardSection, layoutsToSections } from '../utils';
+
+/**
+ * The current dashboard's sections, read from the already-loaded dashboard
+ * query. The page fetches via useGetDashboardV2 keyed by id, so this reuses that
+ * cache (no extra request) instead of prop-drilling the section list.
+ */
+export function useDashboardSections(): DashboardSection[] {
+	const dashboardId = useDashboardStore((s) => s.dashboardId);
+	const { data } = useGetDashboardV2({ id: dashboardId });
+	const spec = data?.data?.spec;
+
+	return useMemo(
+		() => layoutsToSections(spec?.layouts, spec?.panels),
+		[spec?.layouts, spec?.panels],
+	);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardSections.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardSections.ts
@@ -1,21 +1,18 @@
 import { useMemo } from 'react';
-import { useGetDashboardV2 } from 'api/generated/services/dashboard';
-
-import { useDashboardStore } from '../store/useDashboardStore';
 import { type DashboardSection, layoutsToSections } from '../utils';
+import { useDashboardFetchRequired } from './useDashboardFetchRequired';
 
 /**
- * The current dashboard's sections, read from the already-loaded dashboard
- * query. The page fetches via useGetDashboardV2 keyed by id, so this reuses that
- * cache (no extra request) instead of prop-drilling the section list.
+ * The current dashboard's sections, derived from the guaranteed-loaded dashboard
+ * via useDashboardFetchRequired. That reuses the shared react-query cache (no extra
+ * request) instead of prop-drilling the section list.
  */
 export function useDashboardSections(): DashboardSection[] {
-	const dashboardId = useDashboardStore((s) => s.dashboardId);
-	const { data } = useGetDashboardV2({ id: dashboardId });
-	const spec = data?.data?.spec;
+	const { dashboard } = useDashboardFetchRequired();
+	const spec = dashboard.spec;
 
 	return useMemo(
-		() => layoutsToSections(spec?.layouts, spec?.panels),
-		[spec?.layouts, spec?.panels],
+		() => layoutsToSections(spec.layouts, spec.panels),
+		[spec.layouts, spec.panels],
 	);
 }


### PR DESCRIPTION
## 📄 Summary

Polishes the **"Select a panel type"** modal in Dashboards V2 (the picker shown when adding a new panel) to align it with the SigNoz design system and give the panel-type tiles a clearer, more tactile layout.

Two things were off with the previous implementation:
- It used antd's `Modal` instead of the design-system `DialogWrapper` used elsewhere in V2.
- The panel-type options were rendered as ghost `Button`s with a small (14px) inline icon and left-aligned label, which read as a list of buttons rather than a set of selectable cards.

This change is scoped and low-risk — it only touches the presentation of this one modal; the selection behavior (`onSelect(panelKind)`) and the set of panel types are unchanged.

### What changed
- **Modal → `DialogWrapper`:** replaced antd `Modal` with `@signozhq/ui/dialog` `DialogWrapper`, wiring `onClose` through `onOpenChange` (close on `!isOpen`). Drops the antd-specific `footer`/`destroyOnClose` props.
- **Button → card tiles:** replaced the `@signozhq/ui` ghost `Button` with a native `<button>` styled as a card (`.panelTypeCard`) — vertical layout (icon stacked above the label), larger 24px icon tinted with `Color.BG_ROBIN_400`.
- **Hover affordance:** l2 border/background tokens with a hover lift (`translateY(-2px)`), robin border, and hover background, replacing the old flat ink background + l1 border.

#### Screenshots / Screen Recordings
<img width="681" height="623" alt="image" src="https://github.com/user-attachments/assets/4cb65efb-3ec6-4436-bbea-f92260cf0664" />

https://github.com/user-attachments/assets/94b7ee35-00e8-4a02-9943-bd7811851601




#### Issues closed by this PR
Closes https://github.com/SigNoz/pulse-pod/issues/84

---

## ✅ Change Type
- [x] 🐛 Bug fix
- [x] ♻️ Refactor

---

## 🐛 Bug Context

**Root Cause:** The modal predated the V2 move to `DialogWrapper` and used antd `Modal` + ghost `Button`s, so it was visually and structurally inconsistent with the rest of the panel-selection UI.

**Fix Strategy:** Swap in `DialogWrapper` and re-style the options as proper selectable cards, keeping selection logic untouched.

---

## 🧪 Testing Strategy
- **Tests added/updated:** None — presentation-only change; `data-testid="panel-type-<kind>"` hooks are preserved.
- **Manual verification:** Open a V2 dashboard → add panel → confirm the modal opens, tiles render with icon + label, hover lift works, clicking a tile selects the panel type, and closing (backdrop/escape) fires `onClose`.
- **Edge cases covered:** Close via `onOpenChange(false)` path.

---

## ⚠️ Risk & Impact Assessment
- **Blast radius:** A single component — `PanelTypeSelectionModal` in Dashboards V2.
- **Potential regressions:** Modal close wiring now goes through `onOpenChange` instead of `onCancel`; nothing else consumes this component's internals.
- **Rollback plan:** Revert the commit — isolated, no data/schema impact.

---

## 📝 Changelog

| Field | Value |
|------|------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Refreshed the "Select a panel type" modal in Dashboards V2 with design-system dialog and card-style panel-type tiles. |

---

## 📋 Checklist
- [x] Tests added or explicitly not required (presentation-only)
- [ ] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers
Native `<button>` (with `font: inherit`) is used instead of the `@signozhq/ui` `Button` because the tiles are card-shaped selectors, not standard buttons — the ghost variant didn't fit the layout. `data-testid`s are unchanged so any existing selectors still resolve.