### PR TITLE
feat(dashboards-v2): persist the View modal's query edits across refresh

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind.ts
@@ -17,3 +17,15 @@ export const PANEL_KIND_TO_PANEL_TYPE: Record<PanelKind, PANEL_TYPES> = {
 	'signoz/HistogramPanel': PANEL_TYPES.HISTOGRAM,
 	'signoz/ListPanel': PANEL_TYPES.LIST,
 };
+
+/**
+ * Reverse of {@link PANEL_KIND_TO_PANEL_TYPE} — the mapping is a bijection, so every
+ * panel kind round-trips. Partial because `PANEL_TYPES` also has types with no V2 kind
+ * (e.g. trace/empty); a lookup on those returns `undefined`.
+ */
+export const PANEL_TYPE_TO_PANEL_KIND: Partial<Record<PANEL_TYPES, PanelKind>> =
+	Object.fromEntries(
+		(Object.entries(PANEL_KIND_TO_PANEL_TYPE) as [PanelKind, PANEL_TYPES][]).map(
+			([kind, type]) => [type, kind],
+		),
+	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/__tests__/buildViewPanelSpec.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/__tests__/buildViewPanelSpec.test.ts
@@ -1,0 +1,73 @@
+import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { getSwitchedPluginSpec } from 'pages/DashboardPageV2/DashboardContainer/PanelEditor/getSwitchedPluginSpec';
+import { PANEL_TYPE_TO_PANEL_KIND } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
+import { toPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
+import type { Query } from 'types/api/queryBuilder/queryBuilderData';
+
+import { buildViewPanelSpec } from '../buildViewPanelSpec';
+
+// The query conversion + kind-switch spec builder are tested in their own suites; here we
+// isolate buildViewPanelSpec's branching (same kind vs. kind switch).
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters',
+	() => ({ toPerses: jest.fn(() => [{ kind: 'mock-query' }]) }),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/PanelEditor/getSwitchedPluginSpec',
+	() => ({ getSwitchedPluginSpec: jest.fn(() => ({ switched: true })) }),
+);
+
+const query = {} as Query;
+
+function specOfKind(kind: string): DashboardtypesPanelSpecDTO {
+	return {
+		plugin: { kind, spec: { formatting: {} } },
+		queries: [],
+		display: { name: 'panel' },
+	} as unknown as DashboardtypesPanelSpecDTO;
+}
+
+describe('PANEL_TYPE_TO_PANEL_KIND', () => {
+	it('is the inverse of the kind→type map', () => {
+		expect(PANEL_TYPE_TO_PANEL_KIND[PANEL_TYPES.VALUE]).toBe(
+			'signoz/NumberPanel',
+		);
+		expect(PANEL_TYPE_TO_PANEL_KIND[PANEL_TYPES.TABLE]).toBe('signoz/TablePanel');
+		expect(PANEL_TYPE_TO_PANEL_KIND[PANEL_TYPES.TIME_SERIES]).toBe(
+			'signoz/TimeSeriesPanel',
+		);
+	});
+});
+
+describe('buildViewPanelSpec', () => {
+	beforeEach(() => jest.clearAllMocks());
+
+	it('keeps the kind and only swaps the queries when the target type matches', () => {
+		const spec = specOfKind('signoz/TimeSeriesPanel');
+		const result = buildViewPanelSpec({
+			spec,
+			query,
+			panelType: PANEL_TYPES.TIME_SERIES,
+		});
+
+		expect(result.plugin.kind).toBe('signoz/TimeSeriesPanel');
+		expect(result.plugin.spec).toBe(spec.plugin.spec);
+		expect(result.queries).toStrictEqual([{ kind: 'mock-query' }]);
+		expect(toPerses).toHaveBeenCalledWith(query, PANEL_TYPES.TIME_SERIES);
+		expect(getSwitchedPluginSpec).not.toHaveBeenCalled();
+	});
+
+	it('switches the kind (Value → Table) and rebuilds the plugin spec', () => {
+		const result = buildViewPanelSpec({
+			spec: specOfKind('signoz/NumberPanel'),
+			query,
+			panelType: PANEL_TYPES.TABLE,
+		});
+
+		expect(result.plugin.kind).toBe('signoz/TablePanel');
+		expect(result.plugin.spec).toStrictEqual({ switched: true });
+		expect(getSwitchedPluginSpec).toHaveBeenCalled();
+		expect(toPerses).toHaveBeenCalledWith(query, PANEL_TYPES.TABLE);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/buildViewPanelSpec.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/buildViewPanelSpec.ts
@@ -1,0 +1,52 @@
+import type {
+	DashboardtypesPanelPluginDTO,
+	DashboardtypesPanelSpecDTO,
+	TelemetrytypesSignalDTO,
+} from 'api/generated/services/sigNoz.schemas';
+import type { PANEL_TYPES } from 'constants/queryBuilder';
+import { getSwitchedPluginSpec } from 'pages/DashboardPageV2/DashboardContainer/PanelEditor/getSwitchedPluginSpec';
+import {
+	PANEL_TYPE_TO_PANEL_KIND,
+	type PanelKind,
+} from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
+import { toPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
+import type { Query } from 'types/api/queryBuilder/queryBuilderData';
+
+import { getBuilderQueries } from '../getBuilderQueries';
+
+/**
+ * Bakes a V1 query + target panel type into a View-modal spec (drilldown seed + URL re-hydration).
+ * When `panelType` maps to a different kind than the panel's (e.g. a breakout turns Value → Table),
+ * the kind is switched via the editor's `getSwitchedPluginSpec` so it opens with populated config.
+ */
+export function buildViewPanelSpec({
+	spec,
+	query,
+	panelType,
+}: {
+	spec: DashboardtypesPanelSpecDTO;
+	query: Query;
+	panelType: PANEL_TYPES;
+}): DashboardtypesPanelSpecDTO {
+	const queries = toPerses(query, panelType);
+	const currentKind = spec.plugin.kind as PanelKind;
+	const newKind = PANEL_TYPE_TO_PANEL_KIND[panelType] ?? currentKind;
+
+	if (newKind === currentKind) {
+		return { ...spec, queries };
+	}
+
+	// The plugin cast mirrors the editor's type-switch — a dynamically chosen kind can't be
+	// correlated with its spec statically.
+	const signal = getBuilderQueries(spec.queries ?? [])[0]
+		?.signal as TelemetrytypesSignalDTO;
+	return {
+		...spec,
+		plugin: {
+			...spec.plugin,
+			kind: newKind,
+			spec: getSwitchedPluginSpec(spec, newKind, signal),
+		} as DashboardtypesPanelPluginDTO,
+		queries,
+	};
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/buildViewPanelSpec.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/buildViewPanelSpec.ts
@@ -38,7 +38,7 @@ export function buildViewPanelSpec({
 
 	// The plugin cast mirrors the editor's type-switch — a dynamically chosen kind can't be
 	// correlated with its spec statically.
-	const signal = getBuilderQueries(spec.queries ?? [])[0]
+	const signal = getBuilderQueries(spec.queries)[0]
 		?.signal as TelemetrytypesSignalDTO;
 	return {
 		...spec,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/useViewPanelMode.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/useViewPanelMode.ts
@@ -4,7 +4,11 @@ import type {
 	DashboardtypesPanelSpecDTO,
 	TelemetrytypesSignalDTO,
 } from 'api/generated/services/sigNoz.schemas';
+import { QueryParams } from 'constants/query';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { useGetCompositeQueryParam } from 'hooks/queryBuilder/useGetCompositeQueryParam';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
+import useUrlQuery from 'hooks/useUrlQuery';
 import { usePanelEditSession } from 'pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/usePanelEditSession';
 import type { RenderablePanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition';
 import {
@@ -12,6 +16,7 @@ import {
 	type PanelKind,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import { resolveSignal } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries';
+import { buildViewPanelSpec } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/buildViewPanelSpec';
 import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
 import {
 	type PanelQueryTimeOverride,
@@ -45,7 +50,7 @@ export interface UseViewPanelModeReturn {
 	runQuery: () => void;
 	/** Switch the draft's visualization kind (temporary; reversible per session). */
 	onChangePanelKind: (kind: PanelKind) => void;
-	/** Restore the saved panel's query + kind, discarding the drilldown edits. */
+	/** Restore the query the view opened with, discarding in-modal edits. */
 	resetQuery: () => void;
 	/** Bake the live (possibly un-run) query into a spec — used to hand edits to the full editor. */
 	buildSaveSpec: (
@@ -54,12 +59,8 @@ export interface UseViewPanelModeReturn {
 }
 
 /**
- * Powers the panel View modal's drilldown editing on top of the shared
- * `usePanelEditSession`: the same draft/query/query-sync/type-switch pipeline the
- * full editor uses, scoped to a per-view time window, plus drilldown-only extras
- * (the saved-query snapshot for Reset, and the builder signal for the type selector).
- * Edits are temporary — they live in the builder/URL and the draft, never the
- * dashboard, matching V1.
+ * The View modal's compact drilldown editor on the shared `usePanelEditSession`. Edits are
+ * temporary — they live in the builder/URL + draft, never the dashboard (V1 parity).
  */
 export function useViewPanelMode({
 	panel,
@@ -67,6 +68,29 @@ export function useViewPanelMode({
 	time,
 }: UseViewPanelModeArgs): UseViewPanelModeReturn {
 	const { currentQuery, redirectWithQueryBuilderData } = useQueryBuilder();
+
+	// Seed the draft from the URL (`compositeQuery` + `graphType`) when present, else the saved
+	// panel — mount-only, so a refresh re-seeds from the URL and in-modal edits survive (V1 parity).
+	const urlQuery = useGetCompositeQueryParam();
+	const urlGraphType = useUrlQuery().get(
+		QueryParams.graphType,
+	) as PANEL_TYPES | null;
+	const initialPanel = useMemo<DashboardtypesPanelDTO>(
+		() =>
+			urlQuery
+				? {
+						...panel,
+						spec: buildViewPanelSpec({
+							spec: panel.spec,
+							query: urlQuery,
+							panelType:
+								urlGraphType ?? PANEL_KIND_TO_PANEL_TYPE[panel.spec.plugin.kind],
+						}),
+					}
+				: panel,
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only seed from the URL
+		[],
+	);
 
 	const {
 		draft,
@@ -77,9 +101,9 @@ export function useViewPanelMode({
 		onChangePanelKind,
 		buildSaveSpec,
 		reset,
-	} = usePanelEditSession({ panel, panelId, time });
+	} = usePanelEditSession({ panel: initialPanel, panelId, time });
 
-	// The saved panel's query, captured once — the restore target for Reset Query.
+	// The query the view opened with, captured once — the Reset target.
 	const savedQuery = useMemo(
 		() =>
 			fromPerses(
@@ -91,7 +115,6 @@ export function useViewPanelMode({
 	);
 
 	const resetQuery = useCallback((): void => {
-		// Draft back to the saved panel (query + kind); builder back to the saved query.
 		reset();
 		redirectWithQueryBuilderData(savedQuery);
 	}, [reset, redirectWithQueryBuilderData, savedQuery]);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useViewPanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useViewPanel.ts
@@ -7,7 +7,7 @@ import useUrlQuery from 'hooks/useUrlQuery';
 export interface UseViewPanelApi {
 	/** Panel id currently expanded in the View modal; null when none is open. */
 	expandedPanelId: string | null;
-	/** Open the View modal for a panel by writing its id to the URL. */
+	/** Open the View modal on the saved panel (clears any leftover in-modal query/kind). */
 	openView: (panelId: string) => void;
 	/** Close the View modal by clearing the URL param. */
 	closeView: () => void;
@@ -30,6 +30,10 @@ export function useViewPanel(): UseViewPanelApi {
 			// Copy before mutating: useUrlQuery returns a memoized instance.
 			const next = new URLSearchParams(urlQuery);
 			next.set(QueryParams.expandedWidgetId, panelId);
+			// Drop any leftover in-modal query/kind so a plain View opens on the saved
+			// panel, not a stale URL query the modal would otherwise hydrate from.
+			next.delete(QueryParams.compositeQuery);
+			next.delete(QueryParams.graphType);
 			safeNavigate(`${pathname}?${next.toString()}`);
 		},
 		[pathname, safeNavigate, urlQuery],


### PR DESCRIPTION
## What

The View modal's in-modal query builder is URL-synced (`compositeQuery`, plus `graphType` when present), but the modal seeded its draft from the **saved panel** on mount — so a page refresh discarded any in-modal edits.

This change seeds the modal draft from the URL when a query is present (falling back to the saved panel otherwise), so in-modal edits are shareable and survive a refresh — matching V1 parity.

## Changes

- **`useViewPanelEditor.ts`** — mount-only read-seed: builds `initialPanel` from `compositeQuery` + `graphType` via `buildViewPanelSpec` when a URL query is present, else the saved panel. Reset still targets the query the view opened with.
- **`buildViewPanelSpec.ts`** (+test) — bakes a V1 query + target panel type into a View-modal spec, switching the panel kind via the editor's `getSwitchedPluginSpec` when the type maps to a different kind.
- **`useViewPanel.ts`** — `openView` now clears leftover `compositeQuery`/`graphType` so a plain View opens on the saved panel, not a stale URL query.
- **`panelKind.ts`** — adds `PANEL_TYPE_TO_PANEL_KIND` (inverse of `PANEL_KIND_TO_PANEL_TYPE`), needed by `buildViewPanelSpec`.

## Context

Extracted from the drilldown branch so the URL-state layer lands as its own change on top of the View-mode PR. The panel drilldown PR (#11895) stacks on top of this.

## Verification

- `tsgo --noEmit` — clean
- `oxlint` (files + project) — clean
- `buildViewPanelSpec.test.ts` + `ViewPanelModal.test.tsx` — pass
- `vite build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)