### PR TITLE
fix(dashboard-v2): stop optimistic-update flicker on panel delete/move

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useOptimisticPatch.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useOptimisticPatch.test.ts
@@ -100,8 +100,23 @@ describe('useOptimisticPatch', () => {
 		expect(queryClient.setQueryData).not.toHaveBeenCalled();
 	});
 
-	it('onSettled invalidates the dashboard query to reconcile', () => {
-		captured.options.onSettled();
-		expect(queryClient.invalidateQueries).toHaveBeenCalledWith(QUERY_KEY);
+	it('onSuccess reconciles the cache from the PATCH response without a refetch', () => {
+		const response = {
+			data: { spec: { display: { name: 'B' } } },
+			status: 'success',
+		};
+		captured.options.onSuccess(response);
+
+		expect(queryClient.setQueryData).toHaveBeenCalledWith(
+			QUERY_KEY,
+			expect.any(Function),
+		);
+		// The updater merges the server data into the existing envelope.
+		const updater = queryClient.setQueryData.mock.calls[0][1];
+		expect(
+			updater({ data: { spec: { display: { name: 'A' } } }, foo: 1 }),
+		).toStrictEqual({ data: { spec: { display: { name: 'B' } } }, foo: 1 });
+		// No follow-up GET (that could read stale data and flicker the UI back).
+		expect(queryClient.invalidateQueries).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useOptimisticPatch.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useOptimisticPatch.ts
@@ -26,7 +26,9 @@ export interface UseOptimisticPatch {
 
 /**
  * Central optimistic mutation for V2 dashboard spec edits: writes the ops to the
- * cached dashboard immediately, rolls back on error, reconciles on settle.
+ * cached dashboard immediately, rolls back on error, and reconciles from the PATCH
+ * response (which returns the updated dashboard) rather than a follow-up GET — an
+ * immediate refetch can read stale, pre-mutation data and flicker the UI back.
  * `dashboardId` defaults to the edit-context store; the panel editor passes its own.
  */
 export function useOptimisticPatch(
@@ -60,8 +62,10 @@ export function useOptimisticPatch(
 				queryClient.setQueryData(queryKey, context.previous);
 			}
 		},
-		onSettled: () => {
-			void queryClient.invalidateQueries(queryKey);
+		onSuccess: (response) => {
+			queryClient.setQueryData<GetDashboardV2200>(queryKey, (prev) =>
+				prev ? { ...prev, data: response.data } : (response as GetDashboardV2200),
+			);
 		},
 	});
 


### PR DESCRIPTION
## Problem
Deleting or moving a panel flickered: **A → B → (PATCH completes) → A → B**, instead of settling at B. Most visible for panels since layout changes are prominent.

## Cause
`useOptimisticPatch` applied the ops optimistically (A→B) but reconciled via `onSettled: invalidateQueries`, which fires an **immediate GET**. That GET can read **pre-mutation (stale) data** — read-after-write lag — rendering A before a later fetch settles to B.

## Fix
`patchDashboardV2` already returns the full updated dashboard (`PatchDashboardV2200.data`). Reconcile the react-query cache from that **response** (`onSuccess`) and drop the follow-up refetch. Sequence is now **A → B → B**. Optimistic write (`onMutate`) and error rollback (`onError`) are unchanged. Applies to every spec edit routed through the hook (delete, move, rename, section ops, etc.).

## Test plan
- Updated the hook unit test: asserts `onSuccess` merges `response.data` into the cache and does **not** invalidate/refetch.
- tsgo 0 errors, oxlint 0, hook tests pass.
- Manual: delete a panel / move a panel → no flash back to the old state; simulate a failed PATCH → rolls back.

> Separate PR on top of `main` (the optimistic mechanism merged in #11936).