### PR TITLE
fix(meter-explorer): not persisting query after page refresh

### DIFF
--- a/frontend/src/container/MeterExplorer/Explorer/Explorer.tsx
+++ b/frontend/src/container/MeterExplorer/Explorer/Explorer.tsx
@@ -35,7 +35,6 @@ function Explorer(): JSX.Element {
 		handleRunQuery,
 		stagedQuery,
 		updateAllQueriesOperators,
-		handleSetQueryData,
 		currentQuery,
 	} = useQueryBuilder();
 	const { safeNavigate } = useSafeNavigate();
@@ -66,15 +65,6 @@ function Explorer(): JSX.Element {
 			),
 		[updateAllQueriesOperators],
 	);
-
-	useEffect(() => {
-		handleSetQueryData(0, {
-			...initialQueryMeterWithType.builder.queryData[0],
-			source: 'meter',
-		});
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
 
 	const exportDefaultQuery = useMemo(
 		() =>


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

This PR fixes the issue of page reloading loosing all the query filters in the Meter Explorer.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

https://github.com/user-attachments/assets/2af19f04-3c85-4d4a-861c-cb8c439716af

After:

https://github.com/user-attachments/assets/89363508-53d8-4bce-9607-099279598a6b

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

https://github.com/SigNoz/platform-pod/issues/2609

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

The bug was introduced at https://github.com/SigNoz/signoz/pull/9142/changes#diff-7c8adfc6ac26dfc1fc0d5f2132dbcfe9fddc0de168256053fdf4d11266940a85

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

We added another hook to initialize the query with default query but we already did the initialization via `defaultQuery` and `useShareBuilderUrl`.

#### Fix Strategy
> How does this PR address the root cause?

Remove the double re-initialization.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | We fixed the issue on Meter Explorer where the filters were not being restored after page refresh.  |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
