### PR TITLE
feat(dashboard-v2): JSON drawer redaction, JSON action cleanup & breadcrumb SPA nav

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
@@ -1,14 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { FullScreenHandle } from 'react-full-screen';
-import { useTranslation } from 'react-i18next';
 import { generatePath } from 'react-router-dom';
-import { useCopyToClipboard } from 'react-use';
 import {
 	Braces,
-	ClipboardCopy,
 	Configure,
 	Copy,
-	FileJson,
 	Fullscreen,
 	Grid3X3,
 	LockKeyhole,
@@ -64,7 +60,6 @@ function DashboardActions({
 }: DashboardActionsProps): JSX.Element {
 	const canEdit = useDashboardStore((s) => s.isEditable);
 	const { user } = useAppContext();
-	const { t } = useTranslation(['dashboard', 'common']);
 	const { safeNavigate } = useSafeNavigate();
 	const { showErrorModal } = useErrorModal();
 
@@ -74,7 +69,6 @@ function DashboardActions({
 	const [isCloning, setIsCloning] = useState<boolean>(false);
 	const [isNewSectionOpen, setIsNewSectionOpen] = useState<boolean>(false);
 
-	const [state, setCopy] = useCopyToClipboard();
 	const [isDeleteOpen, setIsDeleteOpen] = useState<boolean>(false);
 	const deleteDashboardMutation = useDeleteDashboard(dashboard.id);
 
@@ -89,32 +83,6 @@ function DashboardActions({
 		},
 		[addSection],
 	);
-
-	useEffect(() => {
-		if (state.error) {
-			toast.error(t('something_went_wrong', { ns: 'common' }));
-		}
-		if (state.value) {
-			toast.success(t('success', { ns: 'common' }));
-		}
-	}, [state.error, state.value, t]);
-
-	const dashboardDataJSON = useCallback(
-		(): string => JSON.stringify(dashboard, null, 2),
-		[dashboard],
-	);
-
-	const exportJSON = useCallback((): void => {
-		const blob = new Blob([dashboardDataJSON()], { type: 'application/json' });
-		const url = URL.createObjectURL(blob);
-		const link = document.createElement('a');
-		link.href = url;
-		link.download = `${title || 'dashboard'}.json`;
-		document.body.appendChild(link);
-		link.click();
-		document.body.removeChild(link);
-		URL.revokeObjectURL(url);
-	}, [dashboardDataJSON, title]);
 
 	const handleClone = useCallback(async (): Promise<void> => {
 		if (!dashboard.id) {
@@ -176,21 +144,6 @@ function DashboardActions({
 			onClick: handle.enter,
 		});
 
-		const dataGroup: MenuItem[] = [
-			{
-				key: 'export',
-				label: 'Export JSON',
-				icon: <FileJson size={14} />,
-				onClick: exportJSON,
-			},
-			{
-				key: 'copy',
-				label: 'Copy as JSON',
-				icon: <ClipboardCopy size={14} />,
-				onClick: (): void => setCopy(dashboardDataJSON()),
-			},
-		];
-
 		const layoutGroup: MenuItem[] = [];
 		if (canEdit) {
 			layoutGroup.push({
@@ -208,7 +161,6 @@ function DashboardActions({
 				label: 'Dashboard',
 				children: dashboardGroup,
 			},
-			{ type: 'group', key: 'group-data', label: 'Data', children: dataGroup },
 		];
 		if (layoutGroup.length > 0) {
 			items.push({
@@ -240,9 +192,6 @@ function DashboardActions({
 		handleClone,
 		onLockToggle,
 		handle.enter,
-		exportJSON,
-		setCopy,
-		dashboardDataJSON,
 	]);
 
 	return (
@@ -287,7 +236,7 @@ function DashboardActions({
 				onClick={(): void => setIsJsonEditorOpen(true)}
 				size="md"
 			>
-				Edit as JSON
+				JSON
 			</Button>
 			{!isDashboardLocked && (
 				<Button

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/__tests__/useJsonEditor.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/__tests__/useJsonEditor.test.tsx
@@ -44,7 +44,9 @@ const dashboard = {
 	},
 } as unknown as DashboardtypesGettableDashboardV2DTO;
 
-const serialized = JSON.stringify(dashboard, null, 2);
+// The editor only exposes `tags` and `spec`; every other key is redacted.
+const redacted = { tags: dashboard.tags, spec: dashboard.spec };
+const serialized = JSON.stringify(redacted, null, 2);
 
 describe('useJsonEditor', () => {
 	beforeEach(() => {
@@ -61,6 +63,19 @@ describe('useJsonEditor', () => {
 		expect(result.current.isDirty).toBe(false);
 		expect(result.current.validity.valid).toBe(true);
 		expect(result.current.validity.lineCount).toBe(serialized.split('\n').length);
+	});
+
+	it('redacts server-owned keys from the editable draft', () => {
+		const { result } = renderHook(() =>
+			useJsonEditor({ dashboard, isOpen: true, onApplied: jest.fn() }),
+		);
+
+		const parsed = JSON.parse(result.current.draft);
+		expect(Object.keys(parsed).sort()).toStrictEqual(['spec', 'tags']);
+		expect(parsed.id).toBeUndefined();
+		expect(parsed.name).toBeUndefined();
+		expect(parsed.schemaVersion).toBeUndefined();
+		expect(parsed.image).toBeUndefined();
 	});
 
 	it('flags invalid JSON with a line number and marks the draft dirty', () => {
@@ -119,14 +134,23 @@ describe('useJsonEditor', () => {
 		expect(mockUpdate).not.toHaveBeenCalled();
 	});
 
-	it('apply() PUTs the narrowed body, toasts, refetches and calls onApplied', async () => {
+	it('apply() PUTs the edited spec/tags while preserving redacted keys, toasts, refetches and calls onApplied', async () => {
 		const onApplied = jest.fn();
 		const { result } = renderHook(() =>
 			useJsonEditor({ dashboard, isOpen: true, onApplied }),
 		);
 
-		const next = { ...dashboard, name: 'Renamed' };
-		act(() => result.current.setDraft(JSON.stringify(next)));
+		// Edit only what the redacted view exposes (spec/tags).
+		const editedSpec = {
+			...dashboard.spec,
+			display: { name: 'Renamed' },
+		};
+		const editedTags = [{ key: 'env', value: 'staging' }];
+		act(() =>
+			result.current.setDraft(
+				JSON.stringify({ tags: editedTags, spec: editedSpec }),
+			),
+		);
 		await act(async () => {
 			await result.current.apply();
 		});
@@ -135,10 +159,13 @@ describe('useJsonEditor', () => {
 		expect(mockUpdate).toHaveBeenCalledWith(
 			{ id: 'dash-1' },
 			expect.objectContaining({
-				name: 'Renamed',
+				// preserved from the original dashboard (redacted from the editor)
+				name: 'My dashboard',
 				schemaVersion: 'v6',
-				spec: next.spec,
-				tags: next.tags,
+				image: 'icon.png',
+				// edited via the draft
+				spec: editedSpec,
+				tags: editedTags,
 			}),
 		);
 		expect(mockToastSuccess).toHaveBeenCalled();

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/useJsonEditor.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/useJsonEditor.ts
@@ -33,8 +33,20 @@ interface Result {
 	apply: () => Promise<void>;
 }
 
+/**
+ * The editable, user-facing view: only `tags` and `spec`. Everything else
+ * (id, orgId, name, timestamps, locked, schemaVersion, image, …) is redacted so it
+ * can't be seen, copied, exported or edited; those keys are preserved on save (see `apply`).
+ */
+const redact = (
+	dashboard: DashboardtypesGettableDashboardV2DTO,
+): Pick<DashboardtypesGettableDashboardV2DTO, 'tags' | 'spec'> => ({
+	tags: dashboard.tags,
+	spec: dashboard.spec,
+});
+
 const serialize = (dashboard: DashboardtypesGettableDashboardV2DTO): string =>
-	JSON.stringify(dashboard, null, 2);
+	JSON.stringify(redact(dashboard), null, 2);
 
 /** Derive a 1-based line number from a `JSON.parse` "position N" error message. */
 function errorLineFromMessage(
@@ -115,8 +127,13 @@ export function useJsonEditor({
 		}
 		try {
 			setIsSaving(true);
-			const parsed = JSON.parse(draft) as Record<string, unknown>;
-			await updateDashboardV2({ id: dashboardId }, dashboardToUpdatable(parsed));
+			// The draft only carries name/tags/spec; overlay it on the current dashboard
+			// so the redacted fields (schemaVersion, image, …) are preserved on save.
+			const edited = JSON.parse(draft) as Record<string, unknown>;
+			await updateDashboardV2(
+				{ id: dashboardId },
+				dashboardToUpdatable({ ...dashboard, ...edited }),
+			);
 			toast.success('Dashboard updated');
 			refetch();
 			onApplied();
@@ -126,6 +143,7 @@ export function useJsonEditor({
 			setIsSaving(false);
 		}
 	}, [
+		dashboard,
 		dashboardId,
 		validity.valid,
 		isDirty,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardPageHeader/DashboardPageBreadcrumbs.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardPageHeader/DashboardPageBreadcrumbs.tsx
@@ -1,8 +1,10 @@
-import { useMemo } from 'react';
+import { MouseEvent, useMemo } from 'react';
 import { LayoutGrid } from '@signozhq/icons';
 import getSessionStorageApi from 'api/browser/sessionstorage/get';
 import ROUTES from 'constants/routes';
 import { DASHBOARDS_LIST_QUERY_PARAMS_STORAGE_KEY } from 'hooks/dashboard/useDashboardsListQueryParams';
+import { useSafeNavigate } from 'hooks/useSafeNavigate';
+import { isModifierKeyPressed } from 'utils/app';
 
 import {
 	Breadcrumb,
@@ -21,6 +23,8 @@ function DashboardPageBreadcrumbs({
 	title,
 	image,
 }: DashboardPageBreadcrumbsProps): JSX.Element {
+	const { safeNavigate } = useSafeNavigate();
+
 	const dashboardPageLink = useMemo(() => {
 		const dashboardsListQueryParamsString = getSessionStorageApi(
 			DASHBOARDS_LIST_QUERY_PARAMS_STORAGE_KEY,
@@ -31,11 +35,25 @@ function DashboardPageBreadcrumbs({
 			: ROUTES.ALL_DASHBOARD;
 	}, []);
 
+	// Keep the href for middle/modifier-click (open in new tab) but intercept a plain
+	// click for instant client-side navigation instead of a full-page reload.
+	const onDashboardLinkClick = (event: MouseEvent<HTMLAnchorElement>): void => {
+		if (isModifierKeyPressed(event)) {
+			return;
+		}
+		event.preventDefault();
+		safeNavigate(dashboardPageLink);
+	};
+
 	return (
 		<Breadcrumb>
 			<BreadcrumbList>
 				<BreadcrumbItem>
-					<BreadcrumbLink icon={<LayoutGrid size={14} />} href={dashboardPageLink}>
+					<BreadcrumbLink
+						icon={<LayoutGrid size={14} />}
+						href={dashboardPageLink}
+						onClick={onDashboardLinkClick}
+					>
 						Dashboard
 					</BreadcrumbLink>
 				</BreadcrumbItem>


### PR DESCRIPTION
## Summary

Details-page cleanup for the V2 dashboard (dark-shipped behind `use_dashboard_v2`):

- **JSON drawer shows only `{ tags, spec }`.** Server-owned/derived keys (id, orgId, name, timestamps, locked, schemaVersion, image, source) are redacted from the view — and therefore from Copy and Download too. On save, the edited draft is overlaid on the current dashboard so all redacted keys are preserved.
- **Removed the redundant JSON actions** from the Actions menu (the "Data" group: *Export JSON* / *Copy as JSON*) — they duplicate the JSON drawer's own Copy/Download.
- **Renamed the "Edit as JSON" toolbar button → "JSON"** (same `Braces` icon; drawer behaviour unchanged).
- **Breadcrumb "Dashboard" link is now client-side (SPA) navigation** — a plain click no longer triggers a full-page reload; the `href` is kept so middle/modifier-click still opens in a new tab.

## Test plan

- `useJsonEditor` unit tests updated: draft is redacted to `tags`/`spec`, and `apply()` preserves the redacted keys (name/schemaVersion/image) while PUTting the edited spec/tags. All 16 drawer tests pass.
- tsgo (temp-unparked) + oxlint clean on the changed files.
- Manual: open the JSON drawer → only tags/spec visible; Copy/Download emit only those; edit spec, save → other fields intact. Actions menu no longer shows Export/Copy JSON. Breadcrumb → list navigates instantly.