### PR TITLE
fix(query-service): prevent SQL injection in rule history APIs

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -4085,7 +4085,7 @@ func readRowsForTimeSeriesResult(rows driver.Rows, vars []interface{}, columnNam
 }
 
 // GetTimeSeriesResultV3 runs the query and returns list of time series
-func (r *ClickHouseReader) GetTimeSeriesResultV3(ctx context.Context, query string) ([]*v3.Series, error) {
+func (r *ClickHouseReader) GetTimeSeriesResultV3(ctx context.Context, query string, args ...any) ([]*v3.Series, error) {
 	ctx = ctxtypes.NewContextWithCommentVals(ctx, map[string]string{
 		instrumentationtypes.CodeNamespace:    "clickhouse-reader",
 		instrumentationtypes.CodeFunctionName: "GetTimeSeriesResultV3",
@@ -4111,7 +4111,7 @@ func (r *ClickHouseReader) GetTimeSeriesResultV3(ctx context.Context, query stri
 		}
 	}
 
-	rows, err := r.db.Query(ctx, query)
+	rows, err := r.db.Query(ctx, query, args...)
 
 	if err != nil {
 		r.logger.Error("error while reading time series result", errorsV2.Attr(err))
@@ -4803,8 +4803,8 @@ func (r *ClickHouseReader) GetOverallStateTransitions(ctx context.Context, ruleI
     FROM %s.%s
     WHERE overall_state = '` + model.StateFiring.String() + `'
       AND overall_state_changed = true
-      AND rule_id IN ('%s')
-	  AND unix_milli >= %d AND unix_milli <= %d
+      AND rule_id = ?
+	  AND unix_milli >= ? AND unix_milli <= ?
 ),
 resolution_events AS (
     SELECT
@@ -4814,8 +4814,8 @@ resolution_events AS (
     FROM %s.%s
     WHERE overall_state = '` + model.StateInactive.String() + `'
       AND overall_state_changed = true
-      AND rule_id IN ('%s')
-	  AND unix_milli >= %d AND unix_milli <= %d
+      AND rule_id = ?
+	  AND unix_milli >= ? AND unix_milli <= ?
 ),
 matched_events AS (
     SELECT
@@ -4833,14 +4833,12 @@ SELECT *
 FROM matched_events
 ORDER BY firing_time ASC;`
 
-	query := fmt.Sprintf(tmpl,
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.Start, params.End,
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.Start, params.End)
+	query := fmt.Sprintf(tmpl, signozHistoryDBName, ruleStateHistoryTableName, signozHistoryDBName, ruleStateHistoryTableName)
 
 	r.logger.Debug("overall state transitions query", "query", query)
 
 	transitions := []model.RuleStateTransition{}
-	err := r.db.Select(ctx, &transitions, query)
+	err := r.db.Select(ctx, &transitions, query, ruleID, params.Start, params.End, ruleID, params.Start, params.End)
 	if err != nil {
 		return nil, err
 	}
@@ -4869,9 +4867,9 @@ ORDER BY firing_time ASC;`
 
 	// fetch the most recent overall_state from the table
 	var state model.AlertState
-	stateQuery := fmt.Sprintf("SELECT state FROM %s.%s WHERE rule_id = '%s' AND unix_milli <= %d ORDER BY unix_milli DESC LIMIT 1",
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.End)
-	if err := r.db.QueryRow(ctx, stateQuery).Scan(&state); err != nil {
+	stateQuery := fmt.Sprintf("SELECT state FROM %s.%s WHERE rule_id = ? AND unix_milli <= ? ORDER BY unix_milli DESC LIMIT 1",
+		signozHistoryDBName, ruleStateHistoryTableName)
+	if err := r.db.QueryRow(ctx, stateQuery, ruleID, params.End).Scan(&state); err != nil {
 		if err != sql.ErrNoRows {
 			return nil, err
 		}
@@ -4900,9 +4898,9 @@ ORDER BY firing_time ASC;`
 			SELECT
 				unix_milli
 			FROM %s.%s
-			WHERE rule_id = '%s' AND overall_state_changed = true AND overall_state = '%s' AND unix_milli <= %d
-			ORDER BY unix_milli DESC LIMIT 1`, signozHistoryDBName, ruleStateHistoryTableName, ruleID, model.StateFiring.String(), params.End)
-			if err := r.db.QueryRow(ctx, firingQuery).Scan(&firingTime); err != nil {
+			WHERE rule_id = ? AND overall_state_changed = true AND overall_state = ? AND unix_milli <= ?
+			ORDER BY unix_milli DESC LIMIT 1`, signozHistoryDBName, ruleStateHistoryTableName)
+			if err := r.db.QueryRow(ctx, firingQuery, ruleID, model.StateFiring.String(), params.End).Scan(&firingTime); err != nil {
 				return nil, err
 			}
 			stateItems = append(stateItems, model.ReleStateItem{
@@ -4935,8 +4933,8 @@ WITH firing_events AS (
     FROM %s.%s
     WHERE overall_state = '` + model.StateFiring.String() + `'
       AND overall_state_changed = true
-      AND rule_id IN ('%s')
-	  AND unix_milli >= %d AND unix_milli <= %d
+      AND rule_id = ?
+	  AND unix_milli >= ? AND unix_milli <= ?
 ),
 resolution_events AS (
     SELECT
@@ -4946,8 +4944,8 @@ resolution_events AS (
     FROM %s.%s
     WHERE overall_state = '` + model.StateInactive.String() + `'
       AND overall_state_changed = true
-      AND rule_id IN ('%s')
-	  AND unix_milli >= %d AND unix_milli <= %d
+      AND rule_id = ?
+	  AND unix_milli >= ? AND unix_milli <= ?
 ),
 matched_events AS (
     SELECT
@@ -4965,13 +4963,11 @@ SELECT AVG(resolution_time - firing_time) / 1000 AS avg_resolution_time
 FROM matched_events;
 `
 
-	query := fmt.Sprintf(tmpl,
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.Start, params.End,
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.Start, params.End)
+	query := fmt.Sprintf(tmpl, signozHistoryDBName, ruleStateHistoryTableName, signozHistoryDBName, ruleStateHistoryTableName)
 
 	r.logger.Debug("avg resolution time query", "query", query)
 	var avgResolutionTime float64
-	err := r.db.QueryRow(ctx, query).Scan(&avgResolutionTime)
+	err := r.db.QueryRow(ctx, query, ruleID, params.Start, params.End, ruleID, params.Start, params.End).Scan(&avgResolutionTime)
 	if err != nil {
 		return 0, err
 	}
@@ -4992,8 +4988,8 @@ WITH firing_events AS (
     FROM %s.%s
     WHERE overall_state = '` + model.StateFiring.String() + `'
       AND overall_state_changed = true
-      AND rule_id IN ('%s')
-	  AND unix_milli >= %d AND unix_milli <= %d
+      AND rule_id = ?
+	  AND unix_milli >= ? AND unix_milli <= ?
 ),
 resolution_events AS (
     SELECT
@@ -5003,8 +4999,8 @@ resolution_events AS (
     FROM %s.%s
     WHERE overall_state = '` + model.StateInactive.String() + `'
       AND overall_state_changed = true
-      AND rule_id IN ('%s')
-	  AND unix_milli >= %d AND unix_milli <= %d
+      AND rule_id = ?
+	  AND unix_milli >= ? AND unix_milli <= ?
 ),
 matched_events AS (
     SELECT
@@ -5023,12 +5019,10 @@ FROM matched_events
 GROUP BY ts
 ORDER BY ts ASC;`
 
-	query := fmt.Sprintf(tmpl,
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.Start, params.End,
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.Start, params.End, step)
+	query := fmt.Sprintf(tmpl, signozHistoryDBName, ruleStateHistoryTableName, signozHistoryDBName, ruleStateHistoryTableName, step)
 
 	r.logger.Debug("avg resolution time by interval query", "query", query)
-	result, err := r.GetTimeSeriesResultV3(ctx, query)
+	result, err := r.GetTimeSeriesResultV3(ctx, query, ruleID, params.Start, params.End, ruleID, params.Start, params.End)
 	if err != nil || len(result) == 0 {
 		return nil, err
 	}
@@ -5041,12 +5035,12 @@ func (r *ClickHouseReader) GetTotalTriggers(ctx context.Context, ruleID string, 
 		instrumentationtypes.CodeNamespace:    "clickhouse-reader",
 		instrumentationtypes.CodeFunctionName: "GetTotalTriggers",
 	})
-	query := fmt.Sprintf("SELECT count(*) FROM %s.%s WHERE rule_id = '%s' AND (state_changed = true) AND (state = '%s') AND unix_milli >= %d AND unix_milli <= %d",
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, model.StateFiring.String(), params.Start, params.End)
+	query := fmt.Sprintf("SELECT count(*) FROM %s.%s WHERE rule_id = ? AND (state_changed = true) AND (state = ?) AND unix_milli >= ? AND unix_milli <= ?",
+		signozHistoryDBName, ruleStateHistoryTableName)
 
 	var totalTriggers uint64
 
-	err := r.db.QueryRow(ctx, query).Scan(&totalTriggers)
+	err := r.db.QueryRow(ctx, query, ruleID, model.StateFiring.String(), params.Start, params.End).Scan(&totalTriggers)
 	if err != nil {
 		return 0, err
 	}
@@ -5057,10 +5051,10 @@ func (r *ClickHouseReader) GetTotalTriggers(ctx context.Context, ruleID string, 
 func (r *ClickHouseReader) GetTriggersByInterval(ctx context.Context, ruleID string, params *model.QueryRuleStateHistory) (*v3.Series, error) {
 	step := common.MinAllowedStepInterval(params.Start, params.End)
 
-	query := fmt.Sprintf("SELECT count(*), toStartOfInterval(toDateTime(intDiv(unix_milli, 1000)), INTERVAL %d SECOND) as ts FROM %s.%s WHERE rule_id = '%s' AND (state_changed = true) AND (state = '%s') AND unix_milli >= %d AND unix_milli <= %d GROUP BY ts ORDER BY ts ASC",
-		step, signozHistoryDBName, ruleStateHistoryTableName, ruleID, model.StateFiring.String(), params.Start, params.End)
+	query := fmt.Sprintf("SELECT count(*), toStartOfInterval(toDateTime(intDiv(unix_milli, 1000)), INTERVAL ? SECOND) as ts FROM %s.%s WHERE rule_id = ? AND (state_changed = true) AND (state = ?) AND unix_milli >= ? AND unix_milli <= ? GROUP BY ts ORDER BY ts ASC",
+		signozHistoryDBName, ruleStateHistoryTableName)
 
-	result, err := r.GetTimeSeriesResultV3(ctx, query)
+	result, err := r.GetTimeSeriesResultV3(ctx, query, step, ruleID, model.StateFiring.String(), params.Start, params.End)
 	if err != nil || len(result) == 0 {
 		return nil, err
 	}

--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -4650,13 +4650,17 @@ func (r *ClickHouseReader) ReadRuleStateHistoryByRuleID(
 		instrumentationtypes.CodeFunctionName: "ReadRuleStateHistoryByRuleID",
 	})
 	var conditions []string
+	var args []any
 
-	conditions = append(conditions, fmt.Sprintf("rule_id = '%s'", ruleID))
+	conditions = append(conditions, "rule_id = ?")
+	args = append(args, ruleID)
 
-	conditions = append(conditions, fmt.Sprintf("unix_milli >= %d AND unix_milli < %d", params.Start, params.End))
+	conditions = append(conditions, "unix_milli >= ? AND unix_milli < ?")
+	args = append(args, params.Start, params.End)
 
 	if params.State != "" {
-		conditions = append(conditions, fmt.Sprintf("state = '%s'", params.State))
+		conditions = append(conditions, "state = ?")
+		args = append(args, params.State)
 	}
 
 	if params.Filters != nil && len(params.Filters.Items) != 0 {
@@ -4669,50 +4673,73 @@ func (r *ClickHouseReader) ReadRuleStateHistoryByRuleID(
 			fmtVal := utils.ClickHouseFormattedValue(toFormat)
 			switch op {
 			case v3.FilterOperatorEqual:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') = %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, ?) = %s", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorNotEqual:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') != %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, ?) != %s", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorIn:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') IN %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, ?) IN %s", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorNotIn:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') NOT IN %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, ?) NOT IN %s", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorLike:
-				conditions = append(conditions, fmt.Sprintf("like(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("like(JSONExtractString(labels, ?), %s)", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorNotLike:
-				conditions = append(conditions, fmt.Sprintf("notLike(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("notLike(JSONExtractString(labels, ?), %s)", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorRegex:
-				conditions = append(conditions, fmt.Sprintf("match(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("match(JSONExtractString(labels, ?), %s)", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorNotRegex:
-				conditions = append(conditions, fmt.Sprintf("not match(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("not match(JSONExtractString(labels, ?), %s)", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorGreaterThan:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') > %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, ?) > %s", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorGreaterThanOrEq:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') >= %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, ?) >= %s", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorLessThan:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') < %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, ?) < %s", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorLessThanOrEq:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') <= %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, ?) <= %s", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorContains:
-				conditions = append(conditions, fmt.Sprintf("like(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("like(JSONExtractString(labels, ?), %s)", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorNotContains:
-				conditions = append(conditions, fmt.Sprintf("notLike(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+				conditions = append(conditions, fmt.Sprintf("notLike(JSONExtractString(labels, ?), %s)", fmtVal))
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorExists:
-				conditions = append(conditions, fmt.Sprintf("has(JSONExtractKeys(labels), '%s')", item.Key.Key))
+				conditions = append(conditions, "has(JSONExtractKeys(labels), ?)")
+				args = append(args, item.Key.Key)
 			case v3.FilterOperatorNotExists:
-				conditions = append(conditions, fmt.Sprintf("not has(JSONExtractKeys(labels), '%s')", item.Key.Key))
+				conditions = append(conditions, "not has(JSONExtractKeys(labels), ?)")
+				args = append(args, item.Key.Key)
 			default:
 				return nil, fmt.Errorf("unsupported filter operator")
 			}
 		}
 	}
+	order := strings.ToLower(params.Order)
+	if order == "" {
+		order = "asc"
+	}
+	if order != "asc" && order != "desc" {
+		return nil, fmt.Errorf("invalid order parameter")
+	}
 	whereClause := strings.Join(conditions, " AND ")
 
 	query := fmt.Sprintf("SELECT * FROM %s.%s WHERE %s ORDER BY unix_milli %s LIMIT %d OFFSET %d",
-		signozHistoryDBName, ruleStateHistoryTableName, whereClause, params.Order, params.Limit, params.Offset)
+		signozHistoryDBName, ruleStateHistoryTableName, whereClause, order, params.Limit, params.Offset)
 
 	history := []model.RuleStateHistory{}
 	r.logger.Debug("rule state history query", "query", query)
-	err := r.db.Select(ctx, &history, query)
+	err := r.db.Select(ctx, &history, query, args...)
 	if err != nil {
 		r.logger.Error("Error while reading rule state history", errorsV2.Attr(err))
 		return nil, err
@@ -4722,7 +4749,7 @@ func (r *ClickHouseReader) ReadRuleStateHistoryByRuleID(
 	r.logger.Debug("rule state history total query", "query", fmt.Sprintf("SELECT count(*) FROM %s.%s WHERE %s",
 		signozHistoryDBName, ruleStateHistoryTableName, whereClause))
 	err = r.db.QueryRow(ctx, fmt.Sprintf("SELECT count(*) FROM %s.%s WHERE %s",
-		signozHistoryDBName, ruleStateHistoryTableName, whereClause)).Scan(&total)
+		signozHistoryDBName, ruleStateHistoryTableName, whereClause), args...).Scan(&total)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/query-service/app/clickhouseReader/reader_test.go
+++ b/pkg/query-service/app/clickhouseReader/reader_test.go
@@ -1,8 +1,10 @@
 package clickhouseReader
 
 import (
+	"context"
 	"testing"
 
+	"github.com/SigNoz/signoz/pkg/query-service/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,5 +27,27 @@ func TestGetStatusFilters(t *testing.T) {
 	}
 	for _, test := range tests {
 		assert.Equal(getStatusFilters(test.query, test.statusParams, test.excludeMap), test.expected)
+	}
+}
+
+func TestReadRuleStateHistoryByRuleID_InvalidOrder(t *testing.T) {
+	assert := assert.New(t)
+	r := &ClickHouseReader{}
+
+	tests := []struct {
+		name  string
+		order string
+	}{
+		{"sql injection attempt", "asc' OR '1'='1"},
+		{"garbage word", "ascending"},
+		{"numeric", "1"},
+		{"semicolon injection", "asc; DROP TABLE users"},
+	}
+
+	for _, tt := range tests {
+		params := &model.QueryRuleStateHistory{Start: 0, End: 1, Order: tt.order}
+		_, err := r.ReadRuleStateHistoryByRuleID(context.Background(), "some-rule-id", params)
+		assert.Error(err, tt.name)
+		assert.Contains(err.Error(), "invalid order parameter", tt.name)
 	}
 }

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/google/uuid"
-
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/flagger"
 	"github.com/SigNoz/signoz/pkg/modules/thirdpartyapi"
@@ -800,35 +798,38 @@ func (aH *APIHandler) testRule(w http.ResponseWriter, r *http.Request) {
 }
 
 func (aH *APIHandler) getRuleStats(w http.ResponseWriter, r *http.Request) {
-	ruleID := mux.Vars(r)["id"]
-	if _, err := uuid.Parse(ruleID); err != nil {
-		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("invalid rule id format")}, nil)
+	idStr := mux.Vars(r)["id"]
+	ruleID, err := valuer.NewUUID(idStr)
+	if err != nil {
+		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)
 		return
 	}
+	ruleIDStr := ruleID.StringValue()
+
 	params := model.QueryRuleStateHistory{}
-	err := json.NewDecoder(r.Body).Decode(&params)
+	err = json.NewDecoder(r.Body).Decode(&params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)
 		return
 	}
 
-	totalCurrentTriggers, err := aH.reader.GetTotalTriggers(r.Context(), ruleID, &params)
+	totalCurrentTriggers, err := aH.reader.GetTotalTriggers(r.Context(), ruleIDStr, &params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorInternal, Err: err}, nil)
 		return
 	}
-	currentTriggersSeries, err := aH.reader.GetTriggersByInterval(r.Context(), ruleID, &params)
+	currentTriggersSeries, err := aH.reader.GetTriggersByInterval(r.Context(), ruleIDStr, &params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorInternal, Err: err}, nil)
 		return
 	}
 
-	currentAvgResolutionTime, err := aH.reader.GetAvgResolutionTime(r.Context(), ruleID, &params)
+	currentAvgResolutionTime, err := aH.reader.GetAvgResolutionTime(r.Context(), ruleIDStr, &params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorInternal, Err: err}, nil)
 		return
 	}
-	currentAvgResolutionTimeSeries, err := aH.reader.GetAvgResolutionTimeByInterval(r.Context(), ruleID, &params)
+	currentAvgResolutionTimeSeries, err := aH.reader.GetAvgResolutionTimeByInterval(r.Context(), ruleIDStr, &params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorInternal, Err: err}, nil)
 		return
@@ -843,23 +844,23 @@ func (aH *APIHandler) getRuleStats(w http.ResponseWriter, r *http.Request) {
 		params.End -= 86400000
 	}
 
-	totalPastTriggers, err := aH.reader.GetTotalTriggers(r.Context(), ruleID, &params)
+	totalPastTriggers, err := aH.reader.GetTotalTriggers(r.Context(), ruleIDStr, &params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorInternal, Err: err}, nil)
 		return
 	}
-	pastTriggersSeries, err := aH.reader.GetTriggersByInterval(r.Context(), ruleID, &params)
+	pastTriggersSeries, err := aH.reader.GetTriggersByInterval(r.Context(), ruleIDStr, &params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorInternal, Err: err}, nil)
 		return
 	}
 
-	pastAvgResolutionTime, err := aH.reader.GetAvgResolutionTime(r.Context(), ruleID, &params)
+	pastAvgResolutionTime, err := aH.reader.GetAvgResolutionTime(r.Context(), ruleIDStr, &params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorInternal, Err: err}, nil)
 		return
 	}
-	pastAvgResolutionTimeSeries, err := aH.reader.GetAvgResolutionTimeByInterval(r.Context(), ruleID, &params)
+	pastAvgResolutionTimeSeries, err := aH.reader.GetAvgResolutionTimeByInterval(r.Context(), ruleIDStr, &params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorInternal, Err: err}, nil)
 		return
@@ -886,19 +887,21 @@ func (aH *APIHandler) getRuleStats(w http.ResponseWriter, r *http.Request) {
 }
 
 func (aH *APIHandler) getOverallStateTransitions(w http.ResponseWriter, r *http.Request) {
-	ruleID := mux.Vars(r)["id"]
-	if _, err := uuid.Parse(ruleID); err != nil {
-		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("invalid rule id format")}, nil)
-		return
-	}
-	params := model.QueryRuleStateHistory{}
-	err := json.NewDecoder(r.Body).Decode(&params)
+	idStr := mux.Vars(r)["id"]
+	ruleID, err := valuer.NewUUID(idStr)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)
 		return
 	}
 
-	stateItems, err := aH.reader.GetOverallStateTransitions(r.Context(), ruleID, &params)
+	params := model.QueryRuleStateHistory{}
+	err = json.NewDecoder(r.Body).Decode(&params)
+	if err != nil {
+		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)
+		return
+	}
+
+	stateItems, err := aH.reader.GetOverallStateTransitions(r.Context(), ruleID.StringValue(), &params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorInternal, Err: err}, nil)
 		return

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/google/uuid"
+
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/flagger"
 	"github.com/SigNoz/signoz/pkg/modules/thirdpartyapi"
@@ -799,6 +801,10 @@ func (aH *APIHandler) testRule(w http.ResponseWriter, r *http.Request) {
 
 func (aH *APIHandler) getRuleStats(w http.ResponseWriter, r *http.Request) {
 	ruleID := mux.Vars(r)["id"]
+	if _, err := uuid.Parse(ruleID); err != nil {
+		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("invalid rule id format")}, nil)
+		return
+	}
 	params := model.QueryRuleStateHistory{}
 	err := json.NewDecoder(r.Body).Decode(&params)
 	if err != nil {
@@ -881,6 +887,10 @@ func (aH *APIHandler) getRuleStats(w http.ResponseWriter, r *http.Request) {
 
 func (aH *APIHandler) getOverallStateTransitions(w http.ResponseWriter, r *http.Request) {
 	ruleID := mux.Vars(r)["id"]
+	if _, err := uuid.Parse(ruleID); err != nil {
+		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: fmt.Errorf("invalid rule id format")}, nil)
+		return
+	}
 	params := model.QueryRuleStateHistory{}
 	err := json.NewDecoder(r.Body).Decode(&params)
 	if err != nil {

--- a/pkg/query-service/app/http_handler_test.go
+++ b/pkg/query-service/app/http_handler_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/SigNoz/signoz/pkg/query-service/model"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPrepareQuery(t *testing.T) {
@@ -127,6 +129,48 @@ func TestPrepareQuery(t *testing.T) {
 					t.Errorf("expected query: %s, but got: %s", tc.query, query)
 				}
 			}
+		})
+	}
+}
+
+func TestGetRuleStats_InvalidUUID(t *testing.T) {
+	reqCases := []struct {
+		desc           string
+		ruleID         string
+		expectedStatus int
+	}{
+		{
+			desc:           "SQL Injection payload",
+			ruleID:         "123' OR 1=1 --",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			desc:           "Malformed text",
+			ruleID:         "not-a-valid-uuid",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			desc:           "Empty string",
+			ruleID:         " ",
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	aH := &APIHandler{}
+
+	for _, reqCase := range reqCases {
+		t.Run(reqCase.desc, func(t *testing.T) {
+			var b bytes.Buffer
+			_ = json.NewEncoder(&b).Encode(model.QueryRuleStateHistory{})
+
+			req := httptest.NewRequest("POST", "/api/v1/rules/dummy-id/history/stats", &b)
+
+			req = mux.SetURLVars(req, map[string]string{"id": reqCase.ruleID})
+
+			rr := httptest.NewRecorder()
+			aH.getRuleStats(rr, req)
+
+			assert.Equal(t, reqCase.expectedStatus, rr.Code)
 		})
 	}
 }

--- a/pkg/query-service/interfaces/interface.go
+++ b/pkg/query-service/interfaces/interface.go
@@ -60,7 +60,7 @@ type Reader interface {
 	) (*model.MetricStatus, *model.ApiError)
 
 	// QB V3 metrics/traces/logs
-	GetTimeSeriesResultV3(ctx context.Context, query string) ([]*v3.Series, error)
+	GetTimeSeriesResultV3(ctx context.Context, query string, args ...any) ([]*v3.Series, error)
 	GetListResultV3(ctx context.Context, query string) ([]*v3.Row, error)
 	// Logs
 	GetLogFields(ctx context.Context) (*model.GetFieldsResponse, *model.ApiError)


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

This PR addresses the SQL injection issues reported in #11747 by validating rule IDs before query execution and replacing string-formatted SQL with parameterized ClickHouse queries where user input is involved.

This PR secures the following areas:

- validates rule IDs before database access
- parameterizes ClickHouse queries used by rule history endpoints
- parameterizes dynamic filter values
- restricts ORDER BY direction to an allowlist
- updates the reader interface to support query arguments
- adds regression tests covering the identified SQL injection vectors



#### Screenshots / Screen Recordings (if applicable)

_Before:_

Invalid rule IDs containing SQL payloads reached the database layer, resulting in ClickHouse SQL parsing errors and HTTP 500 responses.

<img width="1892" height="1002" alt="Before 1" src="https://github.com/user-attachments/assets/68ad78f4-103b-4973-980d-c60e4ed03809" />
<img width="1889" height="997" alt="Before 2" src="https://github.com/user-attachments/assets/9c8daca5-537a-4535-8c0d-e60bdba5c8de" />

_After:_

The request is rejected during HTTP validation with 400 Bad Request. The database query is never executed.

<img width="1896" height="1000" alt="After 1" src="https://github.com/user-attachments/assets/fd847387-13f4-4f6b-8d2d-4a83d9d62b77" />
<img width="1894" height="998" alt="After 2" src="https://github.com/user-attachments/assets/b83b547b-d5d4-45fa-af61-c64682d5b2fe" />


#### Issues closed by this PR

Closes #11747 

---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [x] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

Multiple user-controlled values were interpolated into ClickHouse queries using `fmt.Sprintf`, allowing SQL syntax to be altered through crafted input. This occurred in two primary locations: 
1. The `{id}` URL path parameter in the HTTP handlers.
2. The dynamic JSON filter keys and `params.State` body parameters in `ReadRuleStateHistoryByRuleID`.

#### Fix Strategy

1. **Path parameter validation**: Implemented strict parsing using the internal `valuer.NewUUID` pattern before hitting the DB layer.
2. **Request Body parameter handling**: Refactored the reader logic to build a dynamic `args []any` slice, utilizing driver-level `?` placeholders for all user-supplied variables. 
3. **Array Handling**: Maintained `utils.ClickHouseFormattedValue` strictly for JSON filter *values* to securely support ClickHouse array formatting for `IN` operators.
4. **ORDER BY validation**: Replaced `ORDER BY %s` with a hardcoded allowlist validation (`asc`/`desc`).
5. **Contract Update**: Updated `interfaces.Reader` to accept variadic arguments (`...any`) to support the new parameterization pattern.


---

### 🧪 Testing Strategy

- Tests added/updated: Added unit tests for `ORDER BY` edge cases (`reader_test.go`) and mock HTTP tests for UUID validation rejection (`http_handler_test.go`).
- Manual verification: Verified via Postman that malformed rule IDs containing SQL injection payloads are rejected with `400 Bad Request` before reaching the database, while requests with valid UUIDs continue to be processed successfully by both affected endpoints.
- Edge cases covered: Explicitly defaulted empty string `params.Order` to `"asc"` to ensure legacy API clients omitting the order field do not break.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: `query-service` DB reads for alerting rule history and stats.
- Potential regressions: Any implementations or test mocks of `interfaces.Reader` must be updated to match the new `GetTimeSeriesResultV3(...any)` method signature.
- Rollback plan: Revert this PR to restore the previous implementation if unexpected regressions are discovered.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed ClickHouse SQL injection vulnerabilities in rule history and state APIs |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

`utils.ClickHouseFormattedValue` is intentionally retained only for formatting array values required by ClickHouse's `IN` syntax. User-controlled values are parameterized wherever supported, while SQL keywords such as sort direction are restricted through explicit allowlisting.

---
