### PR TITLE
feat(dashboards-v2): drill down filter-by-value into the View modal

### DIFF
--- a/frontend/src/container/DashboardContainer/visualization/layout/ChartLayout/ChartLayout.styles.scss
+++ b/frontend/src/container/DashboardContainer/visualization/layout/ChartLayout/ChartLayout.styles.scss
@@ -2,7 +2,7 @@
 	position: relative;
 	display: flex;
 	width: 100%;
-	height: 100%;
+	height: auto;
 	flex-direction: column;
 
 	// Stacked children (the FullView / standalone graph-manager) sit below the chart

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
@@ -5,6 +5,7 @@ import {
 	type SectionConfig,
 	SectionKind,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/sections';
+import type { EQueryType } from 'types/common/dashboard';
 
 import type { SectionEditorContext } from '../sectionContext';
 import { resolveSectionEditor } from '../sectionRegistry';

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/prepareData.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/prepareData.ts
@@ -2,6 +2,7 @@ import { themeColors } from 'constants/theme';
 import type { PieSlice } from 'container/DashboardContainer/visualization/charts/types';
 import { generateColor } from 'lib/uPlotLib/utils/generateColor';
 import type { PanelTable } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
+import { coerceToString } from 'utils/stringUtils';
 
 export interface PreparePieDataArgs {
 	/** Scalar tables from the V5 response (see `prepareScalarTables`). */

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
@@ -13,6 +13,8 @@ import { enrichChartClick } from '../enrichChartClick';
 import { enrichNumberClick } from '../enrichNumberClick';
 import { enrichPieClick } from '../enrichPieClick';
 import { enrichTableClick } from '../enrichTableClick';
+import { getDataLinks } from '../getDataLinks';
+import { resolvePanelContextLinks } from '../resolvePanelContextLinks';
 import { resolveDrilldownSignal } from '../signal';
 
 // The v5 BuilderQuery union is too verbose to construct field-typed inline; cast at the boundary.
@@ -82,8 +84,16 @@ describe('enrichChartClick', () => {
 			clickData: chartClick(focused(2)),
 			series,
 			builderQueries: [
-				builderQuery({ name: 'A', signal: 'metrics' }),
-				builderQuery({ name: 'B', signal: 'logs' }),
+				builderQuery({
+					name: 'A',
+					signal: 'metrics',
+					groupBy: [{ name: 'service.name' }],
+				}),
+				builderQuery({
+					name: 'B',
+					signal: 'logs',
+					groupBy: [{ name: 'service.name' }],
+				}),
 			],
 		});
 
@@ -141,15 +151,38 @@ describe('enrichChartClick', () => {
 		).toBeNull();
 	});
 
-	it('emits empty filters for an ungrouped series', () => {
+	it('emits empty filters for an ungrouped series (drops the legend backfill label)', () => {
 		const payload = enrichChartClick({
 			clickData: chartClick(focused(1)),
-			series: [panelSeries({ queryName: 'A', labels: {} })],
+			series: [panelSeries({ queryName: 'A', labels: { A: 'A' } })],
 			builderQueries: [builderQuery({ name: 'A', signal: 'metrics' })],
 		});
 
 		expect(payload?.context.filters).toStrictEqual([]);
 		expect(payload?.context.queryName).toBe('A');
+	});
+
+	it('drops labels that are not group-by dimensions', () => {
+		const payload = enrichChartClick({
+			clickData: chartClick(focused(1)),
+			series: [
+				panelSeries({
+					queryName: 'A',
+					labels: { 'service.name': 'frontend', __name__: 'http_requests' },
+				}),
+			],
+			builderQueries: [
+				builderQuery({
+					name: 'A',
+					signal: 'metrics',
+					groupBy: [{ name: 'service.name' }],
+				}),
+			],
+		});
+
+		expect(payload?.context.filters).toStrictEqual([
+			{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
+		]);
 	});
 });
 
@@ -328,7 +361,13 @@ describe('enrichPieClick', () => {
 				queryName: 'A',
 				labels: { 'service.name': 'frontend' },
 			},
-			builderQueries: [builderQuery({ name: 'A', signal: 'traces' })],
+			builderQueries: [
+				builderQuery({
+					name: 'A',
+					signal: 'traces',
+					groupBy: [{ name: 'service.name' }],
+				}),
+			],
 			coordinates: { x: 7, y: 8 },
 			timeRange: { startTime: 1, endTime: 2 },
 		});
@@ -348,6 +387,44 @@ describe('enrichPieClick', () => {
 				coordinates: { x: 0, y: 0 },
 			}),
 		).toBeNull();
+	});
+});
+
+describe('resolvePanelContextLinks', () => {
+	it('substitutes the clicked field value (_-prefixed) into the label and URL', () => {
+		const resolved = resolvePanelContextLinks(
+			[
+				{
+					name: 'Runbook for {{_service.name}}',
+					url: 'https://wiki/{{_service.name}}',
+				},
+			],
+			{ '_service.name': 'frontend' },
+		);
+
+		expect(resolved).toHaveLength(1);
+		expect(resolved[0].label).toBe('Runbook for frontend');
+		expect(resolved[0].url).toBe('https://wiki/frontend');
+	});
+
+	it('drops links without a URL', () => {
+		expect(resolvePanelContextLinks([{ name: 'No URL' }], {})).toStrictEqual([]);
+		expect(resolvePanelContextLinks(undefined, {})).toStrictEqual([]);
+	});
+
+	it('keeps the raw URL when renderVariables is false', () => {
+		const resolved = resolvePanelContextLinks(
+			[
+				{
+					name: 'Literal',
+					url: 'https://wiki/{{_service.name}}',
+					renderVariables: false,
+				},
+			],
+			{ '_service.name': 'frontend' },
+		);
+
+		expect(resolved[0].url).toBe('https://wiki/{{_service.name}}');
 	});
 });
 
@@ -377,5 +454,30 @@ describe('stepClickTimeRange', () => {
 				],
 			}),
 		).toStrictEqual({ startTime: 1000, endTime: 1060 });
+	});
+});
+
+describe('getDataLinks', () => {
+	it('adds a "View Trace Details" link when the filters carry a trace_id', () => {
+		expect(
+			getDataLinks([
+				{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
+				{ filterKey: 'trace_id', filterValue: 'abc123', operator: '=' },
+			]),
+		).toStrictEqual([
+			{
+				id: 'view-trace-details',
+				label: 'View Trace Details',
+				url: '/trace/abc123',
+			},
+		]);
+	});
+
+	it('returns no links when there is no trace_id', () => {
+		expect(
+			getDataLinks([
+				{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
+			]),
+		).toStrictEqual([]);
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/enrichChartClick.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/enrichChartClick.ts
@@ -1,13 +1,11 @@
-import {
-	getFiltersFromMetric,
-	isValidQueryName,
-} from 'container/QueryTable/Drilldown/drilldownUtils';
+import { isValidQueryName } from 'container/QueryTable/Drilldown/drilldownUtils';
 import type { ChartClickData } from 'lib/uPlotV2/plugins/TooltipPlugin/types';
 import type { PanelSeries } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
 import type { BuilderQuery } from 'types/api/v5/queryRange';
 
 import type { DrilldownClickPayload } from '../../types/drilldown';
 
+import { getGroupByFilters } from './getGroupByFilters';
 import { resolveDrilldownSignal } from './signal';
 
 interface EnrichChartClickArgs {
@@ -23,7 +21,7 @@ interface EnrichChartClickArgs {
 /**
  * Turns a uPlot click (time-series or bar) into a drilldown payload. Resolves the clicked series via
  * uPlot's series index (index 0 is the x-axis, so data series start at 1 → `series[seriesIndex - 1]`)
- * and builds equality filters from its group-by labels. Returns `null` when the click can't be
+ * and builds equality filters from its group-by label values. Returns `null` when the click can't be
  * attributed to a drillable series (no focused series, unmapped index, or a formula query).
  */
 export function enrichChartClick({
@@ -46,12 +44,16 @@ export function enrichChartClick({
 		(query) => query.name === panelSeries.queryName,
 	);
 
+	const filters = builderQuery
+		? getGroupByFilters(panelSeries.labels, builderQuery)
+		: [];
+
 	return {
 		coordinates: { x: clickData.absoluteMouseX, y: clickData.absoluteMouseY },
 		context: {
 			queryName: panelSeries.queryName,
 			signal: resolveDrilldownSignal(builderQuery),
-			filters: getFiltersFromMetric(panelSeries.labels),
+			filters,
 			timeRange,
 			label: focusedSeries.seriesName,
 			seriesColor: focusedSeries.color,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/enrichPieClick.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/enrichPieClick.ts
@@ -1,12 +1,10 @@
 import type { PieSlice } from 'container/DashboardContainer/visualization/charts/types';
-import {
-	getFiltersFromMetric,
-	isValidQueryName,
-} from 'container/QueryTable/Drilldown/drilldownUtils';
+import { isValidQueryName } from 'container/QueryTable/Drilldown/drilldownUtils';
 import type { BuilderQuery } from 'types/api/v5/queryRange';
 
 import type { DrilldownClickPayload } from '../../types/drilldown';
 
+import { getGroupByFilters } from './getGroupByFilters';
 import { resolveDrilldownSignal } from './signal';
 
 interface EnrichPieClickArgs {
@@ -18,8 +16,9 @@ interface EnrichPieClickArgs {
 }
 
 /**
- * Turns a pie-slice click into a drilldown payload, using the slice's source-row labels (carried by
- * `preparePieData`) as equality filters. Returns `null` when the slice has no drillable query.
+ * Turns a pie-slice click into a drilldown payload, using the slice's source-row group-by label
+ * values (carried by `preparePieData`) as equality filters. Returns `null` when the slice has no
+ * drillable query.
  */
 export function enrichPieClick({
 	slice,
@@ -33,12 +32,16 @@ export function enrichPieClick({
 	}
 
 	const builderQuery = builderQueries.find((query) => query.name === queryName);
+
+	const filters = builderQuery
+		? getGroupByFilters(slice.labels ?? {}, builderQuery)
+		: [];
 	return {
 		coordinates,
 		context: {
 			queryName,
 			signal: resolveDrilldownSignal(builderQuery),
-			filters: getFiltersFromMetric(slice.labels ?? {}),
+			filters: filters,
 			timeRange,
 			label: slice.label,
 			seriesColor: slice.color,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getDataLinks.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getDataLinks.ts
@@ -1,0 +1,29 @@
+import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
+
+/** An auto-generated drilldown link (label + destination URL). */
+export interface DrilldownDataLink {
+	id: string;
+	label: string;
+	url: string;
+}
+
+/**
+ * Links derived automatically from the clicked point's filters — the V2 port of V1's `getDataLinks`.
+ * Currently a single "View Trace Details" link when the clicked row carries a `trace_id`.
+ */
+export function getDataLinks(filters: FilterData[]): DrilldownDataLink[] {
+	const links: DrilldownDataLink[] = [];
+
+	const traceId = filters.find(
+		(filter) => filter.filterKey === 'trace_id',
+	)?.filterValue;
+	if (traceId) {
+		links.push({
+			id: 'view-trace-details',
+			label: 'View Trace Details',
+			url: `/trace/${traceId}`,
+		});
+	}
+
+	return links;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getGroupByFilters.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getGroupByFilters.ts
@@ -1,0 +1,26 @@
+import {
+	type FilterData,
+	getFiltersFromMetric,
+} from 'container/QueryTable/Drilldown/drilldownUtils';
+import type { BuilderQuery } from 'types/api/v5/queryRange';
+
+/**
+ * Equality filters for the clicked series/slice, restricted to the query's group-by dimensions.
+ * `labels` also carry a display-only legend backfill (`{queryName: queryName}` when ungrouped, see
+ * `resolveLegendAndLabels`); intersecting with group-by drops it so `filters` stays empty when
+ * ungrouped, matching V1.
+ */
+export function getGroupByFilters(
+	labels: Record<string, string>,
+	builderQuery: BuilderQuery,
+): FilterData[] {
+	const groupByKeys = new Set(
+		(builderQuery.groupBy ?? []).map((group) => group.name),
+	);
+	if (groupByKeys.size === 0) {
+		return [];
+	}
+	return getFiltersFromMetric(labels).filter((filter) =>
+		groupByKeys.has(filter.filterKey),
+	);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks.ts
@@ -1,0 +1,50 @@
+import type { DashboardLinkDTO } from 'api/generated/services/sigNoz.schemas';
+import { processContextLinks } from 'container/NewWidget/RightContainer/ContextLinks/utils';
+import type { ContextLinkProps } from 'types/api/dashboard/getAll';
+
+/** A panel context link with its label and URL templates resolved, ready to render. */
+export interface ResolvedDrilldownLink {
+	id: string;
+	label: string;
+	url: string;
+}
+
+/**
+ * Resolves a panel's context links for the drilldown menu. Adapts each `DashboardLinkDTO` to the V1
+ * `ContextLinkProps` the shared `processContextLinks` resolver expects, substitutes variables in the
+ * label + URL, and drops links without a URL. Links with `renderVariables === false` keep their raw
+ * label/URL (no substitution).
+ */
+export function resolvePanelContextLinks(
+	links: DashboardLinkDTO[] | undefined,
+	processedVariables: Record<string, string>,
+): ResolvedDrilldownLink[] {
+	const usable = (links ?? []).filter((link) => !!link.url);
+	if (usable.length === 0) {
+		return [];
+	}
+
+	const adapted: ContextLinkProps[] = usable.map((link, index) => ({
+		id: String(index),
+		label: link.name || link.url || '',
+		url: link.url ?? '',
+	}));
+
+	const resolved = processContextLinks(adapted, processedVariables, 50);
+
+	return usable.map((link, index) => {
+		// `renderVariables` defaults to on; only an explicit `false` opts out of substitution.
+		if (link.renderVariables === false) {
+			return {
+				id: String(index),
+				label: link.name || link.url || '',
+				url: link.url ?? '',
+			};
+		}
+		return {
+			id: resolved[index].id,
+			label: resolved[index].label,
+			url: resolved[index].url,
+		};
+	});
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
@@ -1,9 +1,22 @@
 import { useMemo } from 'react';
-import { DraftingCompass, Loader, ScrollText } from '@signozhq/icons';
+import {
+	Braces,
+	ChartBar,
+	DraftingCompass,
+	Link,
+	Loader,
+	ScrollText,
+} from '@signozhq/icons';
+import type { DashboardLinkDTO } from 'api/generated/services/sigNoz.schemas';
 import { getAggregateColumnHeader } from 'container/QueryTable/Drilldown/drilldownUtils';
 import ContextMenu from 'periscope/components/ContextMenu';
 import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
+import { getDataLinks } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getDataLinks';
+import { resolvePanelContextLinks } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
+import { openInNewTab } from 'utils/navigation';
+
+import { useDrilldownContextVariables } from '../hooks/useDrilldownContextVariables';
 
 import styles from './DrilldownAggregateMenu.module.scss';
 
@@ -13,24 +26,50 @@ interface DrilldownAggregateMenuProps {
 	query: Query;
 	/** While dashboard variables resolve, the actions show a spinner and are disabled. */
 	isResolving?: boolean;
+	/** Panel's context links; resolved against the clicked point + variables here. */
+	links: DashboardLinkDTO[] | undefined;
+	/** Whether the clicked point exposes group-by fields to bind to dashboard variables. */
+	canSetDashboardVariables: boolean;
 	onViewLogs: () => void;
 	onViewTraces: () => void;
+	onBreakout: () => void;
+	/** Open the Dashboard Variables submenu (set/unset/create from the clicked value). */
+	onSetDashboardVariables: () => void;
+	/** Close the popover (context-link clicks). */
+	onClose: () => void;
 }
 
 /**
- * The base aggregate drill-down menu: a tinted header + View in Logs/Traces. Metrics is
- * omitted — V1 surfaces only Logs/Traces.
+ * The base aggregate drill-down menu: tinted header + View in Logs/Traces, Breakout, and the
+ * panel's context links. Mounted only while open, so the variable/link resolution runs only then.
+ * Metrics is omitted — V1 surfaces only Logs/Traces.
  */
 function DrilldownAggregateMenu({
 	context,
 	query,
 	isResolving = false,
+	links,
+	canSetDashboardVariables,
 	onViewLogs,
 	onViewTraces,
+	onBreakout,
+	onSetDashboardVariables,
+	onClose,
 }: DrilldownAggregateMenuProps): JSX.Element {
 	const aggregations = useMemo(
 		() => getAggregateColumnHeader(query, context.queryName).aggregations,
 		[query, context.queryName],
+	);
+
+	const processedVariables = useDrilldownContextVariables(context);
+	const contextLinks = useMemo(
+		() => resolvePanelContextLinks(links, processedVariables),
+		[links, processedVariables],
+	);
+	// Auto links derived from the clicked point itself (e.g. "View Trace Details" for a trace_id).
+	const dataLinks = useMemo(
+		() => getDataLinks(context.filters),
+		[context.filters],
 	);
 
 	return (
@@ -41,6 +80,20 @@ function DrilldownAggregateMenu({
 					{context.label || aggregations}
 				</div>
 			</ContextMenu.Header>
+			{canSetDashboardVariables && (
+				<ContextMenu.Item
+					icon={
+						<span style={{ color: context.seriesColor }}>
+							<Braces size={16} />
+						</span>
+					}
+					onClick={onSetDashboardVariables}
+				>
+					<span data-testid="drilldown-dashboard-variables">
+						Dashboard Variables
+					</span>
+				</ContextMenu.Item>
+			)}
 			<ContextMenu.Item
 				icon={
 					isResolving ? (
@@ -71,6 +124,40 @@ function DrilldownAggregateMenu({
 			>
 				<span data-testid="drilldown-view-traces">View in Traces</span>
 			</ContextMenu.Item>
+			<ContextMenu.Item
+				icon={
+					<span style={{ color: context.seriesColor }}>
+						<ChartBar size={16} />
+					</span>
+				}
+				onClick={onBreakout}
+			>
+				<span data-testid="drilldown-breakout">Breakout by ..</span>
+			</ContextMenu.Item>
+			{dataLinks.map((link) => (
+				<ContextMenu.Item
+					key={link.id}
+					icon={<Link size={16} color={context.seriesColor} />}
+					onClick={(): void => {
+						openInNewTab(link.url);
+						onClose();
+					}}
+				>
+					<span data-testid="drilldown-data-link">{link.label}</span>
+				</ContextMenu.Item>
+			))}
+			{contextLinks.map((link) => (
+				<ContextMenu.Item
+					key={link.id}
+					icon={<Link size={16} color={context.seriesColor} />}
+					onClick={(): void => {
+						openInNewTab(link.url);
+						onClose();
+					}}
+				>
+					<span data-testid="drilldown-context-link">{link.label}</span>
+				</ContextMenu.Item>
+			))}
 		</>
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownBreakoutMenu.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownBreakoutMenu.module.scss
@@ -1,0 +1,9 @@
+.header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.backArrow {
+	cursor: pointer;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownBreakoutMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownBreakoutMenu.tsx
@@ -1,0 +1,45 @@
+import { ArrowLeft } from '@signozhq/icons';
+import BreakoutOptions from 'container/QueryTable/Drilldown/BreakoutOptions';
+import type { BreakoutAttributeType } from 'container/QueryTable/Drilldown/types';
+import ContextMenu from 'periscope/components/ContextMenu';
+import type { IBuilderQuery } from 'types/api/queryBuilder/queryBuilderData';
+
+import styles from './DrilldownBreakoutMenu.module.scss';
+
+interface DrilldownBreakoutMenuProps {
+	/** The clicked query's builder data — supplies the picker's available attributes. */
+	queryData: IBuilderQuery;
+	/** Regroup the clicked query by the picked attribute. */
+	onBreakout: (groupBy: BreakoutAttributeType) => void;
+	/** Return to the base aggregate menu. */
+	onBack: () => void;
+}
+
+/**
+ * The "Breakout by .." submenu — a back header + V1's read-only `BreakoutOptions` attribute picker,
+ * wired to `onBreakout`.
+ */
+function DrilldownBreakoutMenu({
+	queryData,
+	onBreakout,
+	onBack,
+}: DrilldownBreakoutMenuProps): JSX.Element {
+	return (
+		<>
+			<ContextMenu.Header>
+				<div className={styles.header}>
+					<ArrowLeft
+						size={14}
+						className={styles.backArrow}
+						onClick={onBack}
+						data-testid="drilldown-breakout-back"
+					/>
+					<span>Breakout by</span>
+				</div>
+			</ContextMenu.Header>
+			<BreakoutOptions queryData={queryData} onColumnClick={onBreakout} />
+		</>
+	);
+}
+
+export default DrilldownBreakoutMenu;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownDashboardVariablesMenu.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownDashboardVariablesMenu.module.scss
@@ -1,0 +1,9 @@
+.header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.backArrow {
+	cursor: pointer;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownDashboardVariablesMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownDashboardVariablesMenu.tsx
@@ -1,0 +1,79 @@
+import { ArrowLeft, Plus, Settings, X } from '@signozhq/icons';
+import OverlayScrollbar from 'components/OverlayScrollbar/OverlayScrollbar';
+import {
+	type DrilldownVariableAction,
+	DrilldownVariableActionKind,
+} from 'pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables';
+import ContextMenu from 'periscope/components/ContextMenu';
+
+import styles from './DrilldownDashboardVariablesMenu.module.scss';
+
+interface DrilldownDashboardVariablesMenuProps {
+	/** Resolved entries from `useDrilldownDashboardVariables`. */
+	actions: DrilldownVariableAction[];
+	/** Return to the base aggregate menu. */
+	onBack: () => void;
+}
+
+const ICON_BY_KIND: Record<DrilldownVariableActionKind, JSX.Element> = {
+	[DrilldownVariableActionKind.Set]: <Settings size={16} />,
+	[DrilldownVariableActionKind.Unset]: <X size={16} />,
+	[DrilldownVariableActionKind.Create]: <Plus size={16} />,
+};
+
+/**
+ * The "Dashboard Variables" drilldown submenu — renders the entries resolved by
+ * `useDrilldownDashboardVariables` (Set/Unset an existing dynamic variable, or Create one).
+ */
+function DrilldownDashboardVariablesMenu({
+	actions,
+	onBack,
+}: DrilldownDashboardVariablesMenuProps): JSX.Element {
+	return (
+		<>
+			<ContextMenu.Header>
+				<div className={styles.header}>
+					<ArrowLeft
+						size={14}
+						className={styles.backArrow}
+						onClick={onBack}
+						data-testid="drilldown-var-back"
+					/>
+					<span>Dashboard Variables</span>
+				</div>
+			</ContextMenu.Header>
+			<OverlayScrollbar
+				style={{ maxHeight: '200px' }}
+				options={{ overflow: { x: 'hidden' } }}
+			>
+				<>
+					{actions.map(({ fieldName, fieldValue, kind, onClick }) => (
+						<ContextMenu.Item
+							key={fieldName}
+							icon={ICON_BY_KIND[kind]}
+							onClick={onClick}
+						>
+							{kind === DrilldownVariableActionKind.Unset && (
+								<span data-testid="drilldown-var-unset">
+									Unset <strong>${fieldName}</strong>
+								</span>
+							)}
+							{kind === DrilldownVariableActionKind.Set && (
+								<span data-testid="drilldown-var-set">
+									Set <strong>${fieldName}</strong> to <strong>{fieldValue}</strong>
+								</span>
+							)}
+							{kind === DrilldownVariableActionKind.Create && (
+								<span data-testid="drilldown-var-create">
+									Create var <strong>${fieldName}</strong>:<strong>{fieldValue}</strong>
+								</span>
+							)}
+						</ContextMenu.Item>
+					))}
+				</>
+			</OverlayScrollbar>
+		</>
+	);
+}
+
+export default DrilldownDashboardVariablesMenu;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownFilterMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownFilterMenu.tsx
@@ -1,0 +1,40 @@
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { getGroupContextMenuConfig } from 'container/QueryTable/Drilldown/contextConfig';
+import type { ClickedData } from 'periscope/components/ContextMenu';
+import type { Query } from 'types/api/queryBuilder/queryBuilderData';
+
+interface DrilldownFilterMenuProps {
+	/** The panel's V5→V1 query the operator menu builds filters against. */
+	v1Query: Query;
+	/** The clicked group column's key. */
+	clickedKey: string;
+	/** Apply the chosen operator (adds the filter and opens the View modal). */
+	onFilter: (operator: string) => void;
+}
+
+/**
+ * The group-column "filter by value" submenu — the operator list from V1's read-only
+ * `getGroupContextMenuConfig`, wired to `onFilter`.
+ */
+function DrilldownFilterMenu({
+	v1Query,
+	clickedKey,
+	onFilter,
+}: DrilldownFilterMenuProps): JSX.Element {
+	const clickedData: ClickedData = {
+		column: { dataIndex: clickedKey },
+		record: { key: clickedKey, timestamp: 0 },
+	};
+	return (
+		<>
+			{getGroupContextMenuConfig({
+				query: v1Query,
+				clickedData,
+				panelType: PANEL_TYPES.TABLE,
+				onColumnClick: onFilter,
+			}).items ?? null}
+		</>
+	);
+}
+
+export default DrilldownFilterMenu;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/__tests__/usePanelActionItems.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelActionsMenu/__tests__/usePanelActionItems.test.tsx
@@ -294,4 +294,13 @@ describe('usePanelActionItems', () => {
 		(createAlert as { onClick: () => void }).onClick();
 		expect(mockCreateAlert).toHaveBeenCalledWith(mockPanel, 'panel-1');
 	});
+
+	it('create-alert seeds an alert from this panel', () => {
+		const { result } = renderHook(() => usePanelActionItems(baseArgs));
+		const createAlert = result.current.items.find(
+			(i) => 'key' in i && i.key === 'create-alert',
+		);
+		(createAlert as { onClick: () => void }).onClick();
+		expect(mockCreateAlert).toHaveBeenCalledWith(mockPanel, 'panel-1');
+	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/ViewPanelQueryBuilder.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/ViewPanelQueryBuilder.tsx
@@ -1,0 +1,64 @@
+import { type KeyboardEvent, useCallback } from 'react';
+import { QueryBuilderV2 } from 'components/QueryBuilderV2/QueryBuilderV2';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import RightToolbarActions from 'container/QueryBuilder/components/ToolbarActions/RightToolbarActions';
+
+import styles from './ViewPanelModal.module.scss';
+
+interface ViewPanelQueryBuilderProps {
+	panelType: PANEL_TYPES;
+	/** Preview fetch in flight — drives the Run/Cancel button state. */
+	isLoadingQueries: boolean;
+	/** Run the current query (Run Query button / ⌘↵). */
+	onStageRunQuery: () => void;
+	/** Abort the in-flight preview fetch. */
+	onCancelQuery: () => void;
+}
+
+/**
+ * Drilldown query editor for the View modal. Mirrors V1's FullView: the query builder
+ * rows + a "Run Query" button, with NO query-type tabs (ClickHouse/PromQL) — drilldown
+ * is query-builder only, exactly as V1.
+ */
+function ViewPanelQueryBuilder({
+	panelType,
+	isLoadingQueries,
+	onStageRunQuery,
+	onCancelQuery,
+}: ViewPanelQueryBuilderProps): JSX.Element {
+	const handleKeyDownCapture = useCallback(
+		(event: KeyboardEvent<HTMLDivElement>): void => {
+			if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+				event.preventDefault();
+				event.stopPropagation();
+				onStageRunQuery();
+			}
+		},
+		[onStageRunQuery],
+	);
+
+	return (
+		<div
+			className={styles.queryBuilder}
+			data-testid="view-panel-query-builder"
+			onKeyDownCapture={handleKeyDownCapture}
+			role="presentation"
+		>
+			<QueryBuilderV2
+				panelType={panelType}
+				version="v3"
+				isListViewPanel={panelType === PANEL_TYPES.LIST}
+				signalSourceChangeEnabled
+			/>
+			<div className={styles.queryBuilderToolbar}>
+				<RightToolbarActions
+					handleCancelQuery={onCancelQuery}
+					onStageRunQuery={onStageRunQuery}
+					isLoadingQueries={isLoadingQueries}
+				/>
+			</div>
+		</div>
+	);
+}
+
+export default ViewPanelQueryBuilder;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/DrilldownDashboardVariablesMenu.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/DrilldownDashboardVariablesMenu.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import DrilldownDashboardVariablesMenu from '../DrilldownMenu/DrilldownDashboardVariablesMenu';
+import {
+	type DrilldownVariableAction,
+	DrilldownVariableActionKind,
+} from '../hooks/useDrilldownDashboardVariables';
+
+jest.mock('components/OverlayScrollbar/OverlayScrollbar', () => ({
+	__esModule: true,
+	default: ({ children }: { children: React.ReactNode }): JSX.Element => (
+		<div>{children}</div>
+	),
+}));
+
+function action(
+	overrides: Partial<DrilldownVariableAction> = {},
+): DrilldownVariableAction {
+	return {
+		fieldName: 'service.name',
+		fieldValue: 'frontend',
+		kind: DrilldownVariableActionKind.Set,
+		onClick: jest.fn(),
+		...overrides,
+	};
+}
+
+describe('DrilldownDashboardVariablesMenu', () => {
+	it('renders each kind with its own label and fires its onClick', async () => {
+		const onSet = jest.fn();
+		const onUnset = jest.fn();
+		const onCreate = jest.fn();
+		render(
+			<DrilldownDashboardVariablesMenu
+				onBack={jest.fn()}
+				actions={[
+					action({
+						fieldName: 'a',
+						kind: DrilldownVariableActionKind.Set,
+						onClick: onSet,
+					}),
+					action({
+						fieldName: 'b',
+						kind: DrilldownVariableActionKind.Unset,
+						onClick: onUnset,
+					}),
+					action({
+						fieldName: 'c',
+						kind: DrilldownVariableActionKind.Create,
+						onClick: onCreate,
+					}),
+				]}
+			/>,
+		);
+
+		expect(screen.getByTestId('drilldown-var-set')).toBeInTheDocument();
+		expect(screen.getByTestId('drilldown-var-unset')).toBeInTheDocument();
+		expect(screen.getByTestId('drilldown-var-create')).toBeInTheDocument();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-set'));
+		expect(onSet).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns to the base menu when the back arrow is clicked', async () => {
+		const onBack = jest.fn();
+		render(
+			<DrilldownDashboardVariablesMenu onBack={onBack} actions={[action()]} />,
+		);
+
+		await userEvent.click(screen.getByTestId('drilldown-var-back'));
+		expect(onBack).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
@@ -4,34 +4,60 @@ import {
 	type DashboardtypesPanelDTO,
 	TelemetrytypesSignalDTO,
 } from 'api/generated/services/sigNoz.schemas';
+import { PANEL_TYPES } from 'constants/queryBuilder';
 import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
 
 import { useDrilldown } from '../hooks/useDrilldown';
 
+const mockOpenViewWithQuery = jest.fn();
 const mockNavigate = jest.fn();
 const mockGetBuilderQueries = jest.fn();
 let mockResolved = { resolvedQuery: 'RESOLVED_QUERY', isResolving: false };
 
 // Boundaries tested elsewhere / needing external context — mocked so this suite isolates
-// useDrilldown's orchestration (gating, the aggregate menu, navigation).
-jest.mock('container/QueryTable/Drilldown/useBaseDrilldownNavigate', () => ({
-	__esModule: true,
-	default: (): unknown => mockNavigate,
+// useDrilldown's orchestration (gating, which menu shows, the View-modal handoff).
+jest.mock('../hooks/useViewPanel', () => ({
+	useViewPanel: (): unknown => ({ openViewWithQuery: mockOpenViewWithQuery }),
 }));
 // Variable-substitution boundary (redux/store/react-query) — its own logic is out of scope here.
 jest.mock('../hooks/useResolvedDrilldownQuery', () => ({
 	useResolvedDrilldownQuery: (): unknown => mockResolved,
 }));
+jest.mock('container/QueryTable/Drilldown/useBaseDrilldownNavigate', () => ({
+	__esModule: true,
+	default: (): unknown => mockNavigate,
+}));
+jest.mock('container/QueryTable/Drilldown/contextConfig', () => ({
+	getGroupContextMenuConfig: ({
+		onColumnClick,
+	}: {
+		onColumnClick: (op: string) => void;
+	}): unknown => ({
+		items: (
+			<button
+				type="button"
+				data-testid="filter-op"
+				onClick={(): void => onColumnClick('=')}
+			>
+				Is this
+			</button>
+		),
+	}),
+}));
 jest.mock('container/QueryTable/Drilldown/drilldownUtils', () => ({
+	addFilterToQuery: jest.fn(() => 'REFINED_QUERY'),
 	getAggregateColumnHeader: (): unknown => ({
 		aggregations: 'sum(x)',
 		dataSource: 'metrics',
 	}),
+	getBaseMeta: (): unknown => undefined,
+	isNumberDataType: (): boolean => false,
 }));
 jest.mock(
 	'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters',
 	() => ({
 		fromPerses: (): string => 'V1_QUERY',
+		toPerses: jest.fn(() => [{ kind: 'REFINED' }]),
 	}),
 );
 jest.mock(
@@ -64,6 +90,15 @@ const aggregateContext: DrilldownContext = {
 	filters: [],
 	label: 'frontend',
 	seriesColor: '#fff',
+};
+
+const groupContext: DrilldownContext = {
+	queryName: 'A',
+	signal: TelemetrytypesSignalDTO.metrics,
+	filters: [],
+	columnKind: 'group',
+	clickedKey: 'service.name',
+	clickedValue: 'frontend',
 };
 
 describe('useDrilldown', () => {
@@ -137,6 +172,28 @@ describe('useDrilldown', () => {
 
 			await user.click(screen.getByTestId('drilldown-view-logs'));
 			expect(mockNavigate).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('filter-by-value', () => {
+		it('opens the View modal with the refined query on a group-column filter', async () => {
+			const user = userEvent.setup();
+			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
+			act(() =>
+				result.current.onPanelClick({
+					coordinates: { x: 1, y: 1 },
+					context: groupContext,
+				}),
+			);
+			render(<div>{result.current.contextMenuProps.items}</div>);
+
+			await user.click(screen.getByTestId('filter-op'));
+			// Opens the View modal on the refined query at the panel's kind — persisted in the URL.
+			expect(mockOpenViewWithQuery).toHaveBeenCalledWith(
+				'p1',
+				'REFINED_QUERY',
+				PANEL_TYPES.TIME_SERIES,
+			);
 		});
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
@@ -13,6 +13,13 @@ const mockOpenViewWithQuery = jest.fn();
 const mockNavigate = jest.fn();
 const mockGetBuilderQueries = jest.fn();
 let mockResolved = { resolvedQuery: 'RESOLVED_QUERY', isResolving: false };
+let mockDashboardVariables: {
+	hasFieldVariables: boolean;
+	actions: unknown[];
+} = {
+	hasFieldVariables: true,
+	actions: [],
+};
 
 // Boundaries tested elsewhere / needing external context — mocked so this suite isolates
 // useDrilldown's orchestration (gating, which menu shows, the View-modal handoff).
@@ -22,6 +29,27 @@ jest.mock('../hooks/useViewPanel', () => ({
 // Variable-substitution boundary (redux/store/react-query) — its own logic is out of scope here.
 jest.mock('../hooks/useResolvedDrilldownQuery', () => ({
 	useResolvedDrilldownQuery: (): unknown => mockResolved,
+}));
+jest.mock('../hooks/useDrilldownBreakout', () => ({
+	useDrilldownBreakout: (): unknown => ({
+		queryData: { queryName: 'A' },
+		onBreakout: jest.fn(),
+	}),
+}));
+jest.mock('../DrilldownMenu/DrilldownBreakoutMenu', () => ({
+	__esModule: true,
+	default: (): JSX.Element => <div data-testid="breakout-submenu" />,
+}));
+jest.mock('../hooks/useDrilldownDashboardVariables', () => ({
+	useDrilldownDashboardVariables: (): unknown => mockDashboardVariables,
+}));
+jest.mock('../DrilldownMenu/DrilldownDashboardVariablesMenu', () => ({
+	__esModule: true,
+	default: (): JSX.Element => <div data-testid="dashboard-variables-submenu" />,
+}));
+// Context-link variable map (redux global time + store) — out of scope for this suite.
+jest.mock('../hooks/useDrilldownContextVariables', () => ({
+	useDrilldownContextVariables: (): unknown => ({}),
 }));
 jest.mock('container/QueryTable/Drilldown/useBaseDrilldownNavigate', () => ({
 	__esModule: true,
@@ -106,6 +134,10 @@ describe('useDrilldown', () => {
 		jest.clearAllMocks();
 		mockGetBuilderQueries.mockReturnValue([{ name: 'A' }]);
 		mockResolved = { resolvedQuery: 'RESOLVED_QUERY', isResolving: false };
+		mockDashboardVariables = {
+			hasFieldVariables: true,
+			actions: [],
+		};
 	});
 
 	describe('enableDrillDown', () => {
@@ -129,7 +161,7 @@ describe('useDrilldown', () => {
 	});
 
 	describe('aggregate menu', () => {
-		it('shows View in Logs/Traces on an aggregate click', () => {
+		it('shows View in Logs/Traces + Breakout on an aggregate click', () => {
 			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
 			act(() =>
 				result.current.onPanelClick({
@@ -141,6 +173,7 @@ describe('useDrilldown', () => {
 
 			expect(screen.getByTestId('drilldown-view-logs')).toBeInTheDocument();
 			expect(screen.getByTestId('drilldown-view-traces')).toBeInTheDocument();
+			expect(screen.getByTestId('drilldown-breakout')).toBeInTheDocument();
 		});
 
 		it('navigates to logs when View in Logs is clicked', async () => {
@@ -172,6 +205,73 @@ describe('useDrilldown', () => {
 
 			await user.click(screen.getByTestId('drilldown-view-logs'));
 			expect(mockNavigate).not.toHaveBeenCalled();
+		});
+
+		it('swaps to the breakout submenu when "Breakout by .." is clicked', async () => {
+			const user = userEvent.setup();
+			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
+			act(() =>
+				result.current.onPanelClick({
+					coordinates: { x: 1, y: 1 },
+					context: aggregateContext,
+				}),
+			);
+			const view = render(<div>{result.current.contextMenuProps.items}</div>);
+
+			await user.click(screen.getByTestId('drilldown-breakout'));
+			view.rerender(<div>{result.current.contextMenuProps.items}</div>);
+
+			expect(screen.getByTestId('breakout-submenu')).toBeInTheDocument();
+		});
+
+		it('shows the Dashboard Variables entry when the click has group-by fields', () => {
+			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
+			act(() =>
+				result.current.onPanelClick({
+					coordinates: { x: 1, y: 1 },
+					context: aggregateContext,
+				}),
+			);
+			render(<div>{result.current.contextMenuProps.items}</div>);
+
+			expect(
+				screen.getByTestId('drilldown-dashboard-variables'),
+			).toBeInTheDocument();
+		});
+
+		it('hides the Dashboard Variables entry when there are no group-by fields', () => {
+			mockDashboardVariables = { hasFieldVariables: false, actions: [] };
+			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
+			act(() =>
+				result.current.onPanelClick({
+					coordinates: { x: 1, y: 1 },
+					context: aggregateContext,
+				}),
+			);
+			render(<div>{result.current.contextMenuProps.items}</div>);
+
+			expect(
+				screen.queryByTestId('drilldown-dashboard-variables'),
+			).not.toBeInTheDocument();
+		});
+
+		it('swaps to the Dashboard Variables submenu when clicked', async () => {
+			const user = userEvent.setup();
+			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
+			act(() =>
+				result.current.onPanelClick({
+					coordinates: { x: 1, y: 1 },
+					context: aggregateContext,
+				}),
+			);
+			const view = render(<div>{result.current.contextMenuProps.items}</div>);
+
+			await user.click(screen.getByTestId('drilldown-dashboard-variables'));
+			view.rerender(<div>{result.current.contextMenuProps.items}</div>);
+
+			expect(
+				screen.getByTestId('dashboard-variables-submenu'),
+			).toBeInTheDocument();
 		});
 	});
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldownDashboardVariables.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldownDashboardVariables.test.tsx
@@ -1,0 +1,213 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
+
+import DrilldownDashboardVariablesMenu from '../DrilldownMenu/DrilldownDashboardVariablesMenu';
+import { useDrilldownDashboardVariables } from '../hooks/useDrilldownDashboardVariables';
+
+// Fake dashboard variables + runtime selection, mutated per test. `dtoToFormModel` is mocked to
+// derive `type` from the plugin kind (like the real adapter), so these DTOs carry the plugin
+// discriminant plus the flat form-model fields the hook reads.
+let mockVariables: Array<{
+	name: string;
+	dynamicAttribute?: string;
+	multiSelect?: boolean;
+	spec: { plugin: { kind: string } };
+}> = [];
+let mockSelectionMap: Record<string, { value: unknown; allSelected: boolean }> =
+	{};
+
+const mockSetVariableValue = jest.fn();
+const mockSetUrlValues = jest.fn();
+const mockPatchAsync = jest.fn().mockResolvedValue(undefined);
+
+const DYNAMIC_KIND = 'signoz/DynamicVariable';
+const QUERY_KIND = 'signoz/QueryVariable';
+
+jest.mock('api/generated/services/dashboard', () => ({
+	useGetDashboardV2: (): unknown => ({
+		data: { data: { spec: { variables: mockVariables } } },
+	}),
+}));
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/hooks/useOptimisticPatch',
+	() => ({
+		useOptimisticPatch: (): unknown => ({ patchAsync: mockPatchAsync }),
+	}),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore',
+	() => ({
+		useDashboardStore: (selector: (state: unknown) => unknown): unknown =>
+			selector({
+				dashboardId: 'd1',
+				variableValues: { d1: mockSelectionMap },
+				setVariableValue: mockSetVariableValue,
+			}),
+	}),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters',
+	() => ({
+		dtoToFormModel: (dto: {
+			spec?: { plugin?: { kind?: string } };
+		}): unknown => ({
+			...dto,
+			type:
+				dto.spec?.plugin?.kind === 'signoz/DynamicVariable' ? 'DYNAMIC' : 'QUERY',
+		}),
+		formModelToDto: (model: { name: string }): unknown => ({ dto: model.name }),
+	}),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel',
+	() => ({
+		emptyVariableFormModel: (): unknown => ({}),
+		DYNAMIC_SIGNAL_ALL: 'all',
+	}),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection',
+	() => ({
+		ALL_SELECTED: '__ALL__',
+		variablesUrlParser: { withOptions: (): unknown => ({}) },
+	}),
+);
+jest.mock('nuqs', () => ({
+	useQueryState: (): unknown => [null, mockSetUrlValues],
+}));
+jest.mock('components/OverlayScrollbar/OverlayScrollbar', () => ({
+	__esModule: true,
+	default: ({ children }: { children: React.ReactNode }): JSX.Element => (
+		<div>{children}</div>
+	),
+}));
+jest.mock('@signozhq/ui/sonner', () => ({
+	toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const filters: FilterData[] = [
+	{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
+];
+
+function renderItems(): void {
+	const { result } = renderHook(() =>
+		useDrilldownDashboardVariables({
+			filters,
+			signal: TelemetrytypesSignalDTO.metrics,
+			onClose: jest.fn(),
+		}),
+	);
+	render(
+		<DrilldownDashboardVariablesMenu
+			actions={result.current.actions}
+			onBack={jest.fn()}
+		/>,
+	);
+}
+
+describe('useDrilldownDashboardVariables', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockVariables = [];
+		mockSelectionMap = {};
+	});
+
+	it('hasFieldVariables reflects the clicked point group-by fields', () => {
+		const withFields = renderHook(() =>
+			useDrilldownDashboardVariables({ filters, onClose: jest.fn() }),
+		);
+		expect(withFields.result.current.hasFieldVariables).toBe(true);
+
+		const noFields = renderHook(() =>
+			useDrilldownDashboardVariables({ filters: [], onClose: jest.fn() }),
+		);
+		expect(noFields.result.current.hasFieldVariables).toBe(false);
+	});
+
+	it('offers Set — writing an array for a multi-select var so the selector shows it', async () => {
+		mockVariables = [
+			{
+				name: 'svc',
+				dynamicAttribute: 'service.name',
+				multiSelect: true,
+				spec: { plugin: { kind: DYNAMIC_KIND } },
+			},
+		];
+		mockSelectionMap = { svc: { value: ['backend'], allSelected: false } };
+		renderItems();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-set'));
+		expect(mockSetVariableValue).toHaveBeenCalledWith('d1', 'svc', {
+			value: ['frontend'],
+			allSelected: false,
+		});
+	});
+
+	it('offers Set — writing a scalar for a single-select var', async () => {
+		mockVariables = [
+			{
+				name: 'svc',
+				dynamicAttribute: 'service.name',
+				multiSelect: false,
+				spec: { plugin: { kind: DYNAMIC_KIND } },
+			},
+		];
+		mockSelectionMap = { svc: { value: 'backend', allSelected: false } };
+		renderItems();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-set'));
+		expect(mockSetVariableValue).toHaveBeenCalledWith('d1', 'svc', {
+			value: 'frontend',
+			allSelected: false,
+		});
+	});
+
+	it('offers Unset when the matching dynamic var already holds the clicked value', async () => {
+		mockVariables = [
+			{
+				name: 'svc',
+				dynamicAttribute: 'service.name',
+				multiSelect: true,
+				spec: { plugin: { kind: DYNAMIC_KIND } },
+			},
+		];
+		mockSelectionMap = { svc: { value: ['frontend'], allSelected: false } };
+		renderItems();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-unset'));
+		expect(mockSetVariableValue).toHaveBeenCalledWith('d1', 'svc', {
+			value: [],
+			allSelected: false,
+		});
+	});
+
+	it('offers Create and persists a new dynamic variable when none matches', async () => {
+		mockVariables = [];
+		renderItems();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-create'));
+		// Persisted to the spec via the optimistic patch...
+		expect(mockPatchAsync).toHaveBeenCalledTimes(1);
+		// ...and seeded (as an array — the created var is multi-select) with the clicked value.
+		expect(mockSetVariableValue).toHaveBeenCalledWith('d1', 'service.name', {
+			value: ['frontend'],
+			allSelected: false,
+		});
+	});
+
+	it('ignores a non-dynamic variable with the same attribute (still offers Create)', () => {
+		mockVariables = [
+			{
+				name: 'svc',
+				dynamicAttribute: 'service.name',
+				spec: { plugin: { kind: QUERY_KIND } },
+			},
+		];
+		renderItems();
+
+		expect(screen.getByTestId('drilldown-var-create')).toBeInTheDocument();
+		expect(screen.queryByTestId('drilldown-var-set')).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -21,6 +21,7 @@ import { getBuilderQueries } from 'pages/DashboardPageV2/DashboardContainer/Pane
 import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
 
 import DrilldownAggregateMenu from '../DrilldownMenu/DrilldownAggregateMenu';
+import DrilldownFilterMenu from '../DrilldownMenu/DrilldownFilterMenu';
 import { useDrilldownFilter } from './useDrilldownFilter';
 import { useResolvedDrilldownQuery } from './useResolvedDrilldownQuery';
 import { useViewPanel } from './useViewPanel';
@@ -91,7 +92,7 @@ export function useDrilldown(
 	// The aggregate menu (View in Logs/Traces) shows for a non-group click; the group click
 	// routes to filter-by-value instead. Only that menu resolves variables — filter/breakout
 	// open the View modal, which resolves at query-run time.
-	const showAggregateMenu = !!context && !filter.items;
+	const showAggregateMenu = !!context && !filter.isGroupColumnClick;
 
 	const { resolvedQuery, isResolving } = useResolvedDrilldownQuery({
 		queries,
@@ -107,8 +108,14 @@ export function useDrilldown(
 	});
 
 	const items = useMemo<ReactNode>(() => {
-		if (filter.items) {
-			return filter.items;
+		if (filter.isGroupColumnClick && context?.clickedKey) {
+			return (
+				<DrilldownFilterMenu
+					v1Query={v1Query}
+					clickedKey={context.clickedKey}
+					onFilter={filter.onFilter}
+				/>
+			);
 		}
 		if (!context) {
 			return null;
@@ -122,7 +129,14 @@ export function useDrilldown(
 				onViewTraces={(): void => navigate('view_traces')}
 			/>
 		);
-	}, [filter.items, context, v1Query, isResolving, navigate]);
+	}, [
+		filter.isGroupColumnClick,
+		filter.onFilter,
+		context,
+		v1Query,
+		isResolving,
+		navigate,
+	]);
 
 	const onPanelClick = useCallback(
 		(payload: DrilldownClickPayload): void =>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
 import useBaseDrilldownNavigate from 'container/QueryTable/Drilldown/useBaseDrilldownNavigate';
 import type {
 	Coordinates,
@@ -10,21 +11,32 @@ import type {
 	DrilldownClickPayload,
 	DrilldownContext,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
-import {
-	PANEL_KIND_TO_PANEL_TYPE,
-	type PanelKind,
-} from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
+import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import { getPanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/registry';
 import { buildAggregateData } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/buildAggregateData';
 import { getBuilderQueries } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries';
 import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
 
 import DrilldownAggregateMenu from '../DrilldownMenu/DrilldownAggregateMenu';
+import DrilldownBreakoutMenu from '../DrilldownMenu/DrilldownBreakoutMenu';
+import DrilldownDashboardVariablesMenu from '../DrilldownMenu/DrilldownDashboardVariablesMenu';
 import DrilldownFilterMenu from '../DrilldownMenu/DrilldownFilterMenu';
+import { useDrilldownBreakout } from './useDrilldownBreakout';
 import { useDrilldownCoordinates } from './useDrilldownCoordinates';
+import { useDrilldownDashboardVariables } from './useDrilldownDashboardVariables';
 import { useDrilldownFilter } from './useDrilldownFilter';
 import { useResolvedDrilldownQuery } from './useResolvedDrilldownQuery';
 import { useViewPanel } from './useViewPanel';
+
+/** Which menu the popover shows; extend as submenus are added (e.g. dashboard variables). */
+enum DrilldownSubMenu {
+	Base = 'base',
+	Breakout = 'breakout',
+	DashboardVariables = 'dashboardVariables',
+}
+
+/** Stable empty-filters ref so the dashboard-variables hook doesn't re-run on every no-click render. */
+const EMPTY_FILTERS: FilterData[] = [];
 
 /** Props the panel shell spreads onto `<ContextMenu>`. */
 export interface DrilldownContextMenuProps {
@@ -43,18 +55,16 @@ export interface UseDrilldownResult {
 }
 
 /**
- * Orchestrates panel drill-down: owns the popover and routes the clicked point to the base
- * aggregate menu (View in Logs/Traces) or the group filter-by-value menu.
+ * Orchestrates panel drill-down: owns the popover + which submenu is open, and routes the clicked
+ * point to the base aggregate menu (View in Logs/Traces), the group filter menu, or the breakout picker.
  */
 export function useDrilldown(
 	panel: DashboardtypesPanelDTO,
 	panelId: string,
 ): UseDrilldownResult {
-	const kind = panel.spec.plugin.kind as PanelKind;
+	const kind = panel.spec.plugin.kind;
 	const panelType = PANEL_KIND_TO_PANEL_TYPE[kind];
-	// Stable ref so the conversions below don't re-run every render (the `?? []` fallback would
-	// otherwise be a fresh array each time).
-	const queries = useMemo(() => panel.spec.queries ?? [], [panel.spec.queries]);
+	const queries = panel.spec.queries;
 
 	// Kind must opt in via its capability AND have a builder query to drill into.
 	const enableDrillDown = useMemo(
@@ -82,7 +92,46 @@ export function useDrilldown(
 		[context],
 	);
 
+	// A fresh click and any close reset to the base menu.
+	const [subMenu, setSubMenu] = useState<DrilldownSubMenu>(
+		DrilldownSubMenu.Base,
+	);
+	const openBreakout = useCallback(
+		(): void => setSubMenu(DrilldownSubMenu.Breakout),
+		[],
+	);
+	const backToBase = useCallback(
+		(): void => setSubMenu(DrilldownSubMenu.Base),
+		[],
+	);
+	const openDashboardVariables = useCallback(
+		(): void => setSubMenu(DrilldownSubMenu.DashboardVariables),
+		[],
+	);
+
+	const onPanelClick = useCallback(
+		(payload: DrilldownClickPayload): void => {
+			setSubMenu(DrilldownSubMenu.Base);
+			onClick(payload.coordinates, payload.context);
+		},
+		[onClick],
+	);
+
+	const handleClose = useCallback((): void => {
+		setSubMenu(DrilldownSubMenu.Base);
+		onClose();
+	}, [onClose]);
+
 	const { openViewWithQuery } = useViewPanel();
+
+	const breakout = useDrilldownBreakout({
+		panelId,
+		v1Query,
+		panelType,
+		aggregateData,
+		openViewWithQuery,
+		onClose: handleClose,
+	});
 
 	const filter = useDrilldownFilter({
 		context,
@@ -90,13 +139,20 @@ export function useDrilldown(
 		panelId,
 		panelType,
 		openViewWithQuery,
-		onClose,
+		onClose: handleClose,
 	});
 
-	// The aggregate menu (View in Logs/Traces) shows for a non-group click; the group click
-	// routes to filter-by-value instead. Only that menu resolves variables — filter/breakout
-	// open the View modal, which resolves at query-run time.
-	const showAggregateMenu = !!context && !filter.isGroupColumnClick;
+	const dashboardVariables = useDrilldownDashboardVariables({
+		filters: context?.filters ?? EMPTY_FILTERS,
+		signal: context?.signal,
+		onClose: handleClose,
+	});
+
+	// The aggregate menu (View in Logs/Traces) shows for a non-group click on the base menu; the
+	// group click routes to filter-by-value instead. Only that menu resolves variables —
+	// filter/breakout open the View modal, which resolves at query-run time.
+	const showAggregateMenu =
+		subMenu === DrilldownSubMenu.Base && !!context && !filter.isGroupColumnClick;
 
 	const { resolvedQuery, isResolving } = useResolvedDrilldownQuery({
 		queries,
@@ -108,10 +164,27 @@ export function useDrilldown(
 	const navigate = useBaseDrilldownNavigate({
 		resolvedQuery,
 		aggregateData,
-		callback: onClose,
+		callback: handleClose,
 	});
 
 	const items = useMemo<ReactNode>(() => {
+		if (subMenu === DrilldownSubMenu.Breakout) {
+			return breakout.queryData ? (
+				<DrilldownBreakoutMenu
+					queryData={breakout.queryData}
+					onBreakout={breakout.onBreakout}
+					onBack={backToBase}
+				/>
+			) : null;
+		}
+		if (subMenu === DrilldownSubMenu.DashboardVariables) {
+			return (
+				<DrilldownDashboardVariablesMenu
+					actions={dashboardVariables.actions}
+					onBack={backToBase}
+				/>
+			);
+		}
 		if (filter.isGroupColumnClick && context?.clickedKey) {
 			return (
 				<DrilldownFilterMenu
@@ -129,28 +202,42 @@ export function useDrilldown(
 				context={context}
 				query={v1Query}
 				isResolving={isResolving}
+				links={panel.spec.links}
+				canSetDashboardVariables={dashboardVariables.hasFieldVariables}
 				onViewLogs={(): void => navigate('view_logs')}
 				onViewTraces={(): void => navigate('view_traces')}
+				onBreakout={openBreakout}
+				onSetDashboardVariables={openDashboardVariables}
+				onClose={handleClose}
 			/>
 		);
 	}, [
+		subMenu,
+		breakout.queryData,
+		breakout.onBreakout,
+		dashboardVariables.actions,
+		dashboardVariables.hasFieldVariables,
 		filter.isGroupColumnClick,
 		filter.onFilter,
 		context,
 		v1Query,
 		isResolving,
+		panel.spec.links,
 		navigate,
+		openBreakout,
+		openDashboardVariables,
+		backToBase,
+		handleClose,
 	]);
-
-	const onPanelClick = useCallback(
-		(payload: DrilldownClickPayload): void =>
-			onClick(payload.coordinates, payload.context),
-		[onClick],
-	);
 
 	return {
 		enableDrillDown,
 		onPanelClick,
-		contextMenuProps: { coordinates, popoverPosition, items, onClose },
+		contextMenuProps: {
+			coordinates,
+			popoverPosition,
+			items,
+			onClose: handleClose,
+		},
 	};
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from 'react';
 import type { ReactNode } from 'react';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
 import useBaseDrilldownNavigate from 'container/QueryTable/Drilldown/useBaseDrilldownNavigate';
-import { useCoordinates } from 'periscope/components/ContextMenu';
 import type {
 	Coordinates,
 	PopoverPosition,
@@ -22,6 +21,7 @@ import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/per
 
 import DrilldownAggregateMenu from '../DrilldownMenu/DrilldownAggregateMenu';
 import DrilldownFilterMenu from '../DrilldownMenu/DrilldownFilterMenu';
+import { useDrilldownCoordinates } from './useDrilldownCoordinates';
 import { useDrilldownFilter } from './useDrilldownFilter';
 import { useResolvedDrilldownQuery } from './useResolvedDrilldownQuery';
 import { useViewPanel } from './useViewPanel';
@@ -69,9 +69,13 @@ export function useDrilldown(
 		[queries, panelType],
 	);
 
-	const { coordinates, popoverPosition, clickedData, onClick, onClose } =
-		useCoordinates();
-	const context = clickedData as DrilldownContext | null;
+	const {
+		coordinates,
+		popoverPosition,
+		clickedData: context,
+		onClick,
+		onClose,
+	} = useDrilldownCoordinates<DrilldownContext>();
 
 	const aggregateData = useMemo(
 		() => (context ? buildAggregateData(context) : null),

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -21,7 +21,9 @@ import { getBuilderQueries } from 'pages/DashboardPageV2/DashboardContainer/Pane
 import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
 
 import DrilldownAggregateMenu from '../DrilldownMenu/DrilldownAggregateMenu';
+import { useDrilldownFilter } from './useDrilldownFilter';
 import { useResolvedDrilldownQuery } from './useResolvedDrilldownQuery';
+import { useViewPanel } from './useViewPanel';
 
 /** Props the panel shell spreads onto `<ContextMenu>`. */
 export interface DrilldownContextMenuProps {
@@ -40,12 +42,12 @@ export interface UseDrilldownResult {
 }
 
 /**
- * Orchestrates panel drill-down: owns the popover and renders the base aggregate menu
- * (View in Logs/Traces) at the clicked point.
+ * Orchestrates panel drill-down: owns the popover and routes the clicked point to the base
+ * aggregate menu (View in Logs/Traces) or the group filter-by-value menu.
  */
 export function useDrilldown(
 	panel: DashboardtypesPanelDTO,
-	_panelId: string,
+	panelId: string,
 ): UseDrilldownResult {
 	const kind = panel.spec.plugin.kind as PanelKind;
 	const panelType = PANEL_KIND_TO_PANEL_TYPE[kind];
@@ -75,13 +77,27 @@ export function useDrilldown(
 		[context],
 	);
 
-	// Resolve the panel's dashboard-variable refs before View-in-X builds the explorer URL
-	// (V1 parity); fires only while the menu is open.
+	const { openViewWithQuery } = useViewPanel();
+
+	const filter = useDrilldownFilter({
+		context,
+		v1Query,
+		panelId,
+		panelType,
+		openViewWithQuery,
+		onClose,
+	});
+
+	// The aggregate menu (View in Logs/Traces) shows for a non-group click; the group click
+	// routes to filter-by-value instead. Only that menu resolves variables — filter/breakout
+	// open the View modal, which resolves at query-run time.
+	const showAggregateMenu = !!context && !filter.items;
+
 	const { resolvedQuery, isResolving } = useResolvedDrilldownQuery({
 		queries,
 		panelType,
 		v1Query,
-		enabled: !!context,
+		enabled: showAggregateMenu,
 	});
 
 	const navigate = useBaseDrilldownNavigate({
@@ -91,6 +107,9 @@ export function useDrilldown(
 	});
 
 	const items = useMemo<ReactNode>(() => {
+		if (filter.items) {
+			return filter.items;
+		}
 		if (!context) {
 			return null;
 		}
@@ -103,7 +122,7 @@ export function useDrilldown(
 				onViewTraces={(): void => navigate('view_traces')}
 			/>
 		);
-	}, [context, v1Query, isResolving, navigate]);
+	}, [filter.items, context, v1Query, isResolving, navigate]);
 
 	const onPanelClick = useCallback(
 		(payload: DrilldownClickPayload): void =>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownBreakout.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownBreakout.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useMemo } from 'react';
+import type { PANEL_TYPES } from 'constants/queryBuilder';
+import { getQueryData } from 'container/QueryTable/Drilldown/drilldownUtils';
+import {
+	getBreakoutPanelType,
+	getBreakoutQuery,
+} from 'container/QueryTable/Drilldown/tableDrilldownUtils';
+import type { BreakoutAttributeType } from 'container/QueryTable/Drilldown/types';
+import type { AggregateData } from 'container/QueryTable/Drilldown/useAggregateDrilldown';
+import type {
+	IBuilderQuery,
+	Query,
+} from 'types/api/queryBuilder/queryBuilderData';
+
+interface UseDrilldownBreakoutArgs {
+	panelId: string;
+	/** The panel's V5→V1 query; the breakout regroups the clicked query within it. */
+	v1Query: Query;
+	/** The panel's current V1 panel type — drives the breakout target type. */
+	panelType: PANEL_TYPES;
+	aggregateData: AggregateData | null;
+	/** Opens the View modal on the breakout query (at the breakout's target kind), persisting it in the URL. */
+	openViewWithQuery: (
+		panelId: string,
+		query: Query,
+		panelType: PANEL_TYPES,
+	) => void;
+	/** Close the popover after navigating to the View modal. */
+	onClose: () => void;
+}
+
+export interface UseDrilldownBreakoutApi {
+	/** The clicked query's builder data for the attribute picker; `undefined` when there's no aggregate to break out. */
+	queryData: IBuilderQuery | undefined;
+	/** Regroup the clicked query by the picked attribute and open the result in the View modal. */
+	onBreakout: (groupBy: BreakoutAttributeType) => void;
+}
+
+/**
+ * The "Breakout by .." submenu logic: regroup the clicked query by a picked attribute and open the
+ * result in the View modal. Reuses V1's read-only `getBreakoutQuery`/`getBreakoutPanelType`; the
+ * caller renders `DrilldownBreakoutMenu` (V1's `BreakoutOptions` picker) from this hook's return.
+ */
+export function useDrilldownBreakout({
+	panelId,
+	v1Query,
+	panelType,
+	aggregateData,
+	openViewWithQuery,
+	onClose,
+}: UseDrilldownBreakoutArgs): UseDrilldownBreakoutApi {
+	const onBreakout = useCallback(
+		(groupBy: BreakoutAttributeType): void => {
+			if (!aggregateData) {
+				return;
+			}
+			const breakoutQuery = getBreakoutQuery(
+				v1Query,
+				aggregateData,
+				groupBy,
+				aggregateData.filters ?? [],
+			);
+			openViewWithQuery(panelId, breakoutQuery, getBreakoutPanelType(panelType));
+			onClose();
+		},
+		[aggregateData, v1Query, panelType, panelId, openViewWithQuery, onClose],
+	);
+
+	const queryData = useMemo(
+		() =>
+			aggregateData ? getQueryData(v1Query, aggregateData.queryName) : undefined,
+		[aggregateData, v1Query],
+	);
+
+	return { queryData, onBreakout };
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownContextVariables.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownContextVariables.ts
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+// eslint-disable-next-line no-restricted-imports -- context links resolve global-time variables off redux (V1 parity)
+import { useSelector } from 'react-redux';
+import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
+import { useDashboardStore } from 'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore';
+import type { AppState } from 'store/reducers';
+import type { GlobalReducer } from 'types/reducer/globalTime';
+
+/**
+ * Builds the variable map that resolves context-link templates, mirroring V1's `useContextVariables`
+ * but sourced from V2 state: dashboard variable selections (by name), the global time window
+ * (`timestamp_start`/`timestamp_end`, ms), and the clicked point's field values (`_`-prefixed, the
+ * V1 convention that keeps them from clashing with dashboard variable names).
+ */
+export function useDrilldownContextVariables(
+	context: DrilldownContext | null,
+): Record<string, string> {
+	// dashboardId from the store's edit context (set once by DashboardContainer), the same
+	// source the rest of V2 uses — not react-router params.
+	const dashboardId = useDashboardStore((state) => state.dashboardId);
+	// Select the stable top-level map (not `state.variableValues[id] ?? {}`, whose fresh `{}` each
+	// render makes useSyncExternalStore loop); index by dashboard inside the memo.
+	const variableValuesByDashboard = useDashboardStore(
+		(state) => state.variableValues,
+	);
+	const globalTime = useSelector<AppState, GlobalReducer>(
+		(state) => state.globalTime,
+	);
+
+	return useMemo(() => {
+		const result: Record<string, string> = {};
+
+		const variableValues = variableValuesByDashboard[dashboardId] ?? {};
+		Object.entries(variableValues).forEach(([name, selection]) => {
+			const { value } = selection;
+			if (value == null) {
+				return;
+			}
+			result[name] = Array.isArray(value) ? value.join(', ') : String(value);
+		});
+
+		// Global time window, ns → ms (V1 parity).
+		result.timestamp_start = String(Math.floor(globalTime.minTime / 1e6));
+		result.timestamp_end = String(Math.floor(globalTime.maxTime / 1e6));
+
+		context?.filters.forEach(({ filterKey, filterValue }) => {
+			result[`_${filterKey}`] = String(filterValue);
+		});
+
+		return result;
+	}, [
+		variableValuesByDashboard,
+		dashboardId,
+		globalTime.minTime,
+		globalTime.maxTime,
+		context,
+	]);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownCoordinates.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownCoordinates.ts
@@ -1,0 +1,44 @@
+import { useCallback, useState } from 'react';
+import type {
+	Coordinates,
+	PopoverPosition,
+} from 'periscope/components/ContextMenu';
+
+import { calculatePopoverPosition } from '../utils/calculatePopoverPosition';
+
+/**
+ * Popover state for the drill-down context menu. V2's strongly-typed counterpart to V1's
+ * `useCoordinates` (whose `clickedData` is `any`): the caller pins `TData` to the click payload,
+ * so it flows through without a cast. `null` fields mean the menu is closed.
+ */
+export interface UseDrilldownCoordinatesResult<TData> {
+	coordinates: Coordinates | null;
+	popoverPosition: PopoverPosition | null;
+	clickedData: TData | null;
+	onClick: (coordinates: Coordinates, data: TData) => void;
+	onClose: () => void;
+}
+
+export function useDrilldownCoordinates<
+	TData,
+>(): UseDrilldownCoordinatesResult<TData> {
+	const [coordinates, setCoordinates] = useState<Coordinates | null>(null);
+	const [popoverPosition, setPopoverPosition] = useState<PopoverPosition | null>(
+		null,
+	);
+	const [clickedData, setClickedData] = useState<TData | null>(null);
+
+	const onClick = useCallback((coords: Coordinates, data: TData): void => {
+		setClickedData(data);
+		setCoordinates(coords);
+		setPopoverPosition(calculatePopoverPosition(coords));
+	}, []);
+
+	const onClose = useCallback((): void => {
+		setCoordinates(null);
+		setPopoverPosition(null);
+		setClickedData(null);
+	}, []);
+
+	return { coordinates, popoverPosition, clickedData, onClick, onClose };
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
@@ -1,0 +1,191 @@
+import { useCallback, useMemo } from 'react';
+import { toast } from '@signozhq/ui/sonner';
+import type { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
+import { useQueryState } from 'nuqs';
+import {
+	dtoToFormModel,
+	formModelToDto,
+} from 'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters';
+import {
+	DYNAMIC_SIGNAL_ALL,
+	emptyVariableFormModel,
+	type VariableFormModel,
+} from 'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel';
+import { buildVariablesPatch } from 'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variablePatchOps';
+import { useDashboardFetchRequired } from 'pages/DashboardPageV2/DashboardContainer/hooks/useDashboardFetchRequired';
+import { useOptimisticPatch } from 'pages/DashboardPageV2/DashboardContainer/hooks/useOptimisticPatch';
+import { selectVariableValues } from 'pages/DashboardPageV2/DashboardContainer/store/slices/variableSelectionSlice';
+import { useDashboardStore } from 'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore';
+import type { VariableSelection } from 'pages/DashboardPageV2/DashboardContainer/VariablesBar/selectionTypes';
+import {
+	ALL_SELECTED,
+	variablesUrlParser,
+} from 'pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection';
+
+interface UseDrilldownDashboardVariablesArgs {
+	/** Group-by field filters from the clicked point (empty when the click has no group-by). */
+	filters: FilterData[];
+	/** Clicked query's telemetry signal — seeds a created variable's `dynamicSignal`. */
+	signal?: TelemetrytypesSignalDTO;
+	/** Close the popover after an action. */
+	onClose: () => void;
+}
+
+/** Set/Unset a matching dynamic variable's value, or Create one when none matches. */
+export enum DrilldownVariableActionKind {
+	Set = 'set',
+	Unset = 'unset',
+	Create = 'create',
+}
+
+/** A resolved "Dashboard Variables" menu entry; the caller renders it. */
+export interface DrilldownVariableAction {
+	fieldName: string;
+	fieldValue: string | number;
+	kind: DrilldownVariableActionKind;
+	/** Applies the action and closes the popover. */
+	onClick: () => void;
+}
+
+export interface UseDrilldownDashboardVariablesApi {
+	/** Whether the clicked point exposes any field to bind to a variable (gates the base-menu entry). */
+	hasFieldVariables: boolean;
+	/** Resolved menu entries, one per group-by field on the clicked point. */
+	actions: DrilldownVariableAction[];
+}
+
+/**
+ * "Dashboard Variables" submenu logic (V1 `useDashboardVarConfig` parity). Set/Unset are runtime-only
+ * (store + URL — V2 selections don't persist); Create is the one path that patches `spec.variables`.
+ */
+export function useDrilldownDashboardVariables({
+	filters,
+	signal,
+	onClose,
+}: UseDrilldownDashboardVariablesArgs): UseDrilldownDashboardVariablesApi {
+	const dashboardId = useDashboardStore((state) => state.dashboardId);
+	const { variables } = useDashboardFetchRequired();
+
+	const dynamicVariables = useMemo(
+		() => variables.map(dtoToFormModel).filter((v) => v.type === 'DYNAMIC'),
+		[variables],
+	);
+	const existingNames = useMemo(
+		() => new Set(variables.map((v) => dtoToFormModel(v).name)),
+		[variables],
+	);
+
+	const selection = useDashboardStore(selectVariableValues(dashboardId));
+	const setVariableValue = useDashboardStore((state) => state.setVariableValue);
+	const [, setUrlValues] = useQueryState(
+		'variables',
+		variablesUrlParser.withOptions({ history: 'replace' }),
+	);
+	const { patchAsync } = useOptimisticPatch();
+
+	const fieldVariables = useMemo<[string, string | number][]>(
+		() =>
+			filters
+				.filter(
+					(f) => f.filterKey && f.filterValue !== undefined && f.filterValue !== '',
+				)
+				.map((f) => [f.filterKey, f.filterValue]),
+		[filters],
+	);
+
+	// Runtime-only write (store + URL), never the spec — mirrors VariablesBar's setSelection.
+	const setSelection = useCallback(
+		(name: string, next: VariableSelection): void => {
+			setVariableValue(dashboardId, name, next);
+			void setUrlValues((prev) => ({
+				...(prev ?? {}),
+				[name]: next.allSelected ? ALL_SELECTED : next.value,
+			}));
+		},
+		[dashboardId, setVariableValue, setUrlValues],
+	);
+
+	const handleCreate = useCallback(
+		async (fieldName: string, fieldValue: string | number): Promise<void> => {
+			if (existingNames.has(fieldName)) {
+				toast.error(`Variable "${fieldName}" already exists`);
+				return;
+			}
+			const model: VariableFormModel = {
+				...emptyVariableFormModel(),
+				name: fieldName,
+				description: `Created from panel drilldown (field: ${fieldName})`,
+				type: 'DYNAMIC',
+				multiSelect: true,
+				dynamicAttribute: fieldName,
+				dynamicSignal: signal ?? DYNAMIC_SIGNAL_ALL,
+			};
+			try {
+				await patchAsync(
+					buildVariablesPatch([...variables, formModelToDto(model)]),
+				);
+				// Multi-select var → seed the value as an array (the selector renders scalars as empty).
+				setSelection(fieldName, { value: [fieldValue], allSelected: false });
+				toast.success(`Created variable "${fieldName}"`);
+			} catch {
+				toast.error('Failed to create variable');
+			}
+			onClose();
+		},
+		[existingNames, signal, variables, patchAsync, setSelection, onClose],
+	);
+
+	const actions = useMemo<DrilldownVariableAction[]>(
+		() =>
+			fieldVariables.map(([fieldName, fieldValue]) => {
+				const existing = dynamicVariables.find(
+					(v) => v.dynamicAttribute === fieldName,
+				);
+				if (!existing) {
+					return {
+						fieldName,
+						fieldValue,
+						kind: DrilldownVariableActionKind.Create,
+						onClick: (): void => {
+							void handleCreate(fieldName, fieldValue);
+						},
+					};
+				}
+
+				const current = selection[existing.name]?.value;
+				const isSame = Array.isArray(current)
+					? current.length === 1 && current[0] === fieldValue
+					: current === fieldValue;
+
+				// Multi-select values must be arrays (a scalar renders as empty in the selector).
+				const cleared = existing.multiSelect ? [] : '';
+				const assigned = existing.multiSelect ? [fieldValue] : fieldValue;
+
+				return {
+					fieldName,
+					fieldValue,
+					kind: isSame
+						? DrilldownVariableActionKind.Unset
+						: DrilldownVariableActionKind.Set,
+					onClick: (): void => {
+						setSelection(existing.name, {
+							value: isSame ? cleared : assigned,
+							allSelected: false,
+						});
+						onClose();
+					},
+				};
+			}),
+		[
+			fieldVariables,
+			dynamicVariables,
+			selection,
+			setSelection,
+			handleCreate,
+			onClose,
+		],
+	);
+
+	return { hasFieldVariables: fieldVariables.length > 0, actions };
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownFilter.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownFilter.ts
@@ -70,10 +70,10 @@ export function useDrilldownFilter({
 		if (!context || context.columnKind !== 'group' || !context.clickedKey) {
 			return null;
 		}
-		const clickedData = {
-			column: { dataIndex: context.clickedKey, title: context.clickedKey },
-			record: {},
-		} as unknown as ClickedData;
+		const clickedData: ClickedData = {
+			column: { dataIndex: context.clickedKey },
+			record: { key: context.clickedKey, timestamp: 0 },
+		};
 		return (
 			getGroupContextMenuConfig({
 				query: v1Query,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownFilter.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownFilter.ts
@@ -1,13 +1,10 @@
-import { useCallback, useMemo } from 'react';
-import type { ReactNode } from 'react';
+import { useCallback } from 'react';
 import { PANEL_TYPES } from 'constants/queryBuilder';
-import { getGroupContextMenuConfig } from 'container/QueryTable/Drilldown/contextConfig';
 import {
 	addFilterToQuery,
 	getBaseMeta,
 	isNumberDataType,
 } from 'container/QueryTable/Drilldown/drilldownUtils';
-import type { ClickedData } from 'periscope/components/ContextMenu';
 import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 
@@ -30,14 +27,16 @@ interface UseDrilldownFilterArgs {
 }
 
 export interface UseDrilldownFilterApi {
-	/** The filter-by-value operator menu for a group-column click; `null` otherwise. */
-	items: ReactNode;
+	/** True for a group-column click — the caller renders the filter-by-value menu. */
+	isGroupColumnClick: boolean;
+	/** Apply the chosen operator: add `key <op> value` and open the refined result in the View modal. */
+	onFilter: (operator: string) => void;
 }
 
 /**
- * The group-column "filter by value" drill-down (V1 parity): adds `key <op> value` to the
- * panel's query and opens the refined result in the View modal. Reuses V1's read-only
- * `getGroupContextMenuConfig` for the operator menu.
+ * The group-column "filter by value" drill-down (V1 parity): adds `key <op> value` to the panel's
+ * query and opens the refined result in the View modal. The caller renders `DrilldownFilterMenu`
+ * (V1's read-only `getGroupContextMenuConfig`) from this hook's return.
  */
 export function useDrilldownFilter({
 	context,
@@ -47,7 +46,7 @@ export function useDrilldownFilter({
 	openViewWithQuery,
 	onClose,
 }: UseDrilldownFilterArgs): UseDrilldownFilterApi {
-	const handleFilterDrilldown = useCallback(
+	const onFilter = useCallback(
 		(operator: string): void => {
 			if (!context?.clickedKey) {
 				return;
@@ -66,23 +65,8 @@ export function useDrilldownFilter({
 		[context, v1Query, panelType, panelId, openViewWithQuery, onClose],
 	);
 
-	const items = useMemo<ReactNode>(() => {
-		if (!context || context.columnKind !== 'group' || !context.clickedKey) {
-			return null;
-		}
-		const clickedData: ClickedData = {
-			column: { dataIndex: context.clickedKey },
-			record: { key: context.clickedKey, timestamp: 0 },
-		};
-		return (
-			getGroupContextMenuConfig({
-				query: v1Query,
-				clickedData,
-				panelType: PANEL_TYPES.TABLE,
-				onColumnClick: handleFilterDrilldown,
-			}).items ?? null
-		);
-	}, [context, v1Query, handleFilterDrilldown]);
+	const isGroupColumnClick =
+		!!context && context.columnKind === 'group' && !!context.clickedKey;
 
-	return { items };
+	return { isGroupColumnClick, onFilter };
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownFilter.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownFilter.ts
@@ -1,0 +1,88 @@
+import { useCallback, useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { getGroupContextMenuConfig } from 'container/QueryTable/Drilldown/contextConfig';
+import {
+	addFilterToQuery,
+	getBaseMeta,
+	isNumberDataType,
+} from 'container/QueryTable/Drilldown/drilldownUtils';
+import type { ClickedData } from 'periscope/components/ContextMenu';
+import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
+import type { Query } from 'types/api/queryBuilder/queryBuilderData';
+
+interface UseDrilldownFilterArgs {
+	/** The clicked point's context; the filter menu only appears for a group-column click. */
+	context: DrilldownContext | null;
+	/** The panel's V5→V1 query the filter is added to. */
+	v1Query: Query;
+	panelId: string;
+	/** Panel's V1 type — the kind the refined query opens the View modal as. */
+	panelType: PANEL_TYPES;
+	/** Opens the View modal on the refined query, persisting it in the URL. */
+	openViewWithQuery: (
+		panelId: string,
+		query: Query,
+		panelType: PANEL_TYPES,
+	) => void;
+	/** Close the popover after opening the View modal. */
+	onClose: () => void;
+}
+
+export interface UseDrilldownFilterApi {
+	/** The filter-by-value operator menu for a group-column click; `null` otherwise. */
+	items: ReactNode;
+}
+
+/**
+ * The group-column "filter by value" drill-down (V1 parity): adds `key <op> value` to the
+ * panel's query and opens the refined result in the View modal. Reuses V1's read-only
+ * `getGroupContextMenuConfig` for the operator menu.
+ */
+export function useDrilldownFilter({
+	context,
+	v1Query,
+	panelId,
+	panelType,
+	openViewWithQuery,
+	onClose,
+}: UseDrilldownFilterArgs): UseDrilldownFilterApi {
+	const handleFilterDrilldown = useCallback(
+		(operator: string): void => {
+			if (!context?.clickedKey) {
+				return;
+			}
+			let filterValue: string | number = context.clickedValue ?? '';
+			const baseMeta = getBaseMeta(v1Query, context.clickedKey);
+			if (baseMeta && isNumberDataType(baseMeta.dataType) && filterValue !== '') {
+				filterValue = Number(filterValue);
+			}
+			const refinedQuery = addFilterToQuery(v1Query, [
+				{ filterKey: context.clickedKey, filterValue, operator },
+			]);
+			openViewWithQuery(panelId, refinedQuery, panelType);
+			onClose();
+		},
+		[context, v1Query, panelType, panelId, openViewWithQuery, onClose],
+	);
+
+	const items = useMemo<ReactNode>(() => {
+		if (!context || context.columnKind !== 'group' || !context.clickedKey) {
+			return null;
+		}
+		const clickedData = {
+			column: { dataIndex: context.clickedKey, title: context.clickedKey },
+			record: {},
+		} as unknown as ClickedData;
+		return (
+			getGroupContextMenuConfig({
+				query: v1Query,
+				clickedData,
+				panelType: PANEL_TYPES.TABLE,
+				onColumnClick: handleFilterDrilldown,
+			}).items ?? null
+		);
+	}, [context, v1Query, handleFilterDrilldown]);
+
+	return { items };
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useViewPanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useViewPanel.ts
@@ -1,22 +1,33 @@
 import { useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 import { QueryParams } from 'constants/query';
+import type { PANEL_TYPES } from 'constants/queryBuilder';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import useUrlQuery from 'hooks/useUrlQuery';
+import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 
 export interface UseViewPanelApi {
 	/** Panel id currently expanded in the View modal; null when none is open. */
 	expandedPanelId: string | null;
 	/** Open the View modal on the saved panel (clears any leftover in-modal query/kind). */
 	openView: (panelId: string) => void;
-	/** Close the View modal by clearing the URL param. */
+	/**
+	 * Open the View modal pre-seeded with a drilldown query + kind, persisted in the URL so it
+	 * survives refresh (V1 parity); the modal hydrates its draft from these on mount.
+	 */
+	openViewWithQuery: (
+		panelId: string,
+		query: Query,
+		panelType: PANEL_TYPES,
+	) => void;
+	/** Close the View modal by clearing its URL params. */
 	closeView: () => void;
 }
 
 /**
- * Drives the panel View modal off the `expandedWidgetId` URL param (V1 parity):
- * the open state is shareable, survives refresh, and the browser back-button
- * closes it. Reuses V1's param key so a deep-linked V1 URL maps cleanly.
+ * Drives the panel View modal off the URL (V1 parity): `expandedWidgetId` holds the open
+ * panel, and a drilldown additionally seeds `compositeQuery` + `graphType`. URL-backed state
+ * is shareable, survives refresh, and the browser back-button closes it.
  */
 export function useViewPanel(): UseViewPanelApi {
 	const { safeNavigate } = useSafeNavigate();
@@ -39,6 +50,22 @@ export function useViewPanel(): UseViewPanelApi {
 		[pathname, safeNavigate, urlQuery],
 	);
 
+	const openViewWithQuery = useCallback(
+		(panelId: string, query: Query, panelType: PANEL_TYPES): void => {
+			const next = new URLSearchParams(urlQuery);
+			next.set(QueryParams.expandedWidgetId, panelId);
+			next.set(QueryParams.graphType, panelType);
+			// Same encoding the query builder uses (see `useGetCompositeQueryParam`): the URL
+			// value is `encodeURIComponent(JSON.stringify(query))`, decoded once on read.
+			next.set(
+				QueryParams.compositeQuery,
+				encodeURIComponent(JSON.stringify(query)),
+			);
+			safeNavigate(`${pathname}?${next.toString()}`);
+		},
+		[pathname, safeNavigate, urlQuery],
+	);
+
 	const closeView = useCallback((): void => {
 		const next = new URLSearchParams(urlQuery);
 		next.delete(QueryParams.expandedWidgetId);
@@ -50,5 +77,5 @@ export function useViewPanel(): UseViewPanelApi {
 		safeNavigate(search ? `${pathname}?${search}` : pathname);
 	}, [pathname, safeNavigate, urlQuery]);
 
-	return { expandedPanelId, openView, closeView };
+	return { expandedPanelId, openView, openViewWithQuery, closeView };
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/__tests__/calculatePopoverPosition.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/__tests__/calculatePopoverPosition.test.ts
@@ -1,0 +1,53 @@
+import { calculatePopoverPosition } from '../calculatePopoverPosition';
+
+// Popover is 300×254 with a 10px offset; these are the edges the placement flips against.
+const setViewport = (width: number, height: number): void => {
+	Object.defineProperty(window, 'innerWidth', {
+		value: width,
+		configurable: true,
+	});
+	Object.defineProperty(window, 'innerHeight', {
+		value: height,
+		configurable: true,
+	});
+};
+
+describe('calculatePopoverPosition', () => {
+	beforeEach(() => setViewport(1920, 1080));
+
+	it('anchors to the right of the click when there is room', () => {
+		expect(calculatePopoverPosition({ x: 100, y: 100 })).toStrictEqual({
+			left: 110,
+			top: 90,
+			placement: 'right',
+		});
+	});
+
+	it('flips to the left near the right edge', () => {
+		const { left, placement } = calculatePopoverPosition({ x: 1900, y: 100 });
+		expect(placement).toBe('left');
+		expect(left).toBe(1900 - 300 + 10);
+	});
+
+	it('clamps back in when the left flip would overflow a narrow viewport', () => {
+		setViewport(320, 1080);
+		// Right flip fires (60 + 300 > 320) but its left (50 - 300 + 10) is off-screen, so it clamps.
+		expect(calculatePopoverPosition({ x: 50, y: 100 })).toMatchObject({
+			left: 10,
+			placement: 'right',
+		});
+	});
+
+	it('drops below the click near the top edge', () => {
+		expect(calculatePopoverPosition({ x: 100, y: 2 })).toMatchObject({
+			top: 10,
+			placement: 'bottomRight',
+		});
+	});
+
+	it('lifts above the click near the bottom edge', () => {
+		const { top, placement } = calculatePopoverPosition({ x: 100, y: 1070 });
+		expect(placement).toBe('topRight');
+		expect(top).toBe(1080 - 254 - 10);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/calculatePopoverPosition.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/calculatePopoverPosition.ts
@@ -1,0 +1,46 @@
+import type {
+	Coordinates,
+	PopoverPosition,
+} from 'periscope/components/ContextMenu';
+
+// Kept in sync with the popover's `overlayStyle` in `ContextMenu` (width 300, maxHeight 254).
+const POPOVER_WIDTH = 300;
+const POPOVER_HEIGHT = 254;
+const OFFSET = 10;
+
+/**
+ * Places the drill-down popover next to the clicked point, flipping/clamping so it stays within the
+ * viewport. Anchors to the right by default and mirrors to the left (and top/bottom) near an edge.
+ */
+export function calculatePopoverPosition({
+	x,
+	y,
+}: Coordinates): PopoverPosition {
+	const { innerWidth: windowWidth, innerHeight: windowHeight } = window;
+
+	let left = x + OFFSET;
+	let top = y - OFFSET;
+	let placement: PopoverPosition['placement'] = 'right';
+
+	if (left + POPOVER_WIDTH > windowWidth) {
+		left = x - POPOVER_WIDTH + OFFSET;
+		placement = 'left';
+	}
+
+	if (left < 0) {
+		left = OFFSET;
+		placement = 'right';
+	}
+
+	if (top < 0) {
+		top = OFFSET;
+		placement = placement === 'right' ? 'bottomRight' : 'bottomLeft';
+	}
+
+	if (top + POPOVER_HEIGHT > windowHeight) {
+		top = windowHeight - POPOVER_HEIGHT - OFFSET;
+		placement = placement === 'right' ? 'topRight' : 'topLeft';
+	}
+
+	return { left, top, placement };
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/index.tsx
@@ -30,7 +30,9 @@ function PanelsAndSectionsLayout({
 
 	// Single View-modal host for the whole dashboard, driven by the URL
 	// (`expandedWidgetId`). One mounted modal beats one-per-panel: no N location
-	// subscriptions, and the expanded panel is looked up by id from the map.
+	// subscriptions, and the expanded panel is looked up by id from the map. A
+	// drilldown refinement rides in the URL (`compositeQuery`/`graphType`) and is
+	// hydrated inside the modal, so the host just hands it the saved panel.
 	const { expandedPanelId, closeView } = useViewPanel();
 	const expandedPanel = expandedPanelId ? panels[expandedPanelId] : undefined;
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
@@ -20,11 +20,12 @@ import {
 export const ALL_SELECTED = '__ALL__';
 
 /** `?variables=` holds `{ [name]: value }` (ALL encoded as the sentinel). */
-const variablesUrlParser = parseAsJson<Record<string, SelectedVariableValue>>(
-	(v) =>
-		typeof v === 'object' && v !== null
-			? (v as Record<string, SelectedVariableValue>)
-			: null,
+export const variablesUrlParser = parseAsJson<
+	Record<string, SelectedVariableValue>
+>((v) =>
+	typeof v === 'object' && v !== null
+		? (v as Record<string, SelectedVariableValue>)
+		: null,
 );
 
 function defaultSelection(model: VariableFormModel): VariableSelection {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
@@ -38,22 +38,14 @@ function DashboardContainer({
 		user.role,
 	);
 
-	// Publish edit context to the store so hooks/components read it from there
-	// instead of receiving dashboardId/isEditable/refetch as props down the tree.
+	// Seed during render (not an effect) so the first Panel render already sees the id —
+	// useDashboardFetchRequired throws on a missing id. setEditContext self-guards.
 	const setEditContext = useDashboardStore((s) => s.setEditContext);
-	useEffect(() => {
-		setEditContext({
-			dashboardId: dashboard.id,
-			isEditable: !dashboard.locked && editDashboardPermission,
-			refetch,
-		});
-	}, [
-		dashboard.id,
-		dashboard.locked,
-		editDashboardPermission,
+	setEditContext({
+		dashboardId: dashboard.id,
+		isEditable: !dashboard.locked && editDashboardPermission,
 		refetch,
-		setEditContext,
-	]);
+	});
 
 	// Resolve the variable selection into the V5 query payload and publish it to
 	// the store, so each panel's query substitutes the bar's selected values.

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/editContextSlice.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/editContextSlice.ts
@@ -24,11 +24,20 @@ export const createEditContextSlice: StateCreator<
 	[['zustand/persist', unknown]],
 	[],
 	EditContextSlice
-> = (set) => ({
+> = (set, get) => ({
 	dashboardId: '',
 	isEditable: false,
 	refetch: (): void => undefined,
+	// Idempotent (no-op when unchanged) so it's safe to call during render.
 	setEditContext: (ctx): void => {
+		const { dashboardId, isEditable, refetch } = get();
+		if (
+			dashboardId === ctx.dashboardId &&
+			isEditable === ctx.isEditable &&
+			refetch === ctx.refetch
+		) {
+			return;
+		}
 		set({
 			dashboardId: ctx.dashboardId,
 			isEditable: ctx.isEditable,


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Adds **table filter-by-value** to the V2 dashboard panel drill-down. Clicking a table group-cell opens a filter menu (**Is this** / **Is not this**); picking an operator adds the filter to the panel query and opens the refined result in the **View modal**, persisted in the URL (V1 parity).

Split out of #11895 so the base drill-down (View in Logs/Traces) and this land as separate, smaller reviews.

**Approach:** `useDrilldownFilter` builds the refined query and hands it to the layout-hosted View modal via `useViewPanel.openViewWithQuery` (URL-persisted). Reuses V1's read-only `getGroupContextMenuConfig` for the operator menu — **no V1 files modified** (V1/V2 split policy).

---

### ✅ Change Type
- [x] ✨ Feature

---

### 🧪 Testing Strategy
- **Tests:** `useDrilldown` orchestration test gains the filter-by-value case (group-cell click → refined query → View modal handoff). `tsgo --noEmit` clean; drilldown jest suite green.
- **Manual verification:** _pending (author)_.

---

### ⚠️ Risk & Impact Assessment
- **Blast radius:** V2 dashboards only, behind the V2 feature flag. No V1 files modified.
- **Rollback plan:** revert the PR; group-cell clicks fall back to the base aggregate menu.

---

## 👀 Notes for Reviewers

**Stacked on #11895** (`feat/dashboards-v2-drilldown`) — merge/review that first. This branch targets `feat/dashboards-v2-drilldown`, not `main`; its diff is only the filter-by-value files (one new hook + the `useDrilldown`/`useViewPanel` wiring).
