### PR TITLE
fix(types): guarantee lowercase letters in generated factor passwords

### DIFF
--- a/pkg/types/factor_password.go
+++ b/pkg/types/factor_password.go
@@ -127,7 +127,7 @@ func GenerateFactorPassword(userID string) (*FactorPassword, error) {
 		return nil, err
 	}
 
-	return NewFactorPassword(password+"Z", userID)
+	return NewFactorPassword(password+"zZ", userID)
 }
 
 func MustGenerateFactorPassword(userID string) *FactorPassword {


### PR DESCRIPTION
## Problem

`TestMustGenerateFactorPassword` fails intermittently in CI ([example run](https://github.com/SigNoz/signoz/actions/runs/28643007615/job/84943168378)) with a panic:

```
password must be at least 12 characters long, should contain at least one uppercase letter...
```

## Root cause

`GenerateFactorPassword` calls `password.Generate(12, 1, 1, false, false)`, which fills the 10 non-digit/non-symbol slots with letters drawn uniformly from **both** cases — it guarantees neither an uppercase nor a lowercase letter. The existing `+"Z"` suffix guarantees uppercase, but nothing guarantees lowercase. With probability ~(1/2)^10 ≈ 0.1%, all 10 letters come out uppercase, `IsPasswordValid` rejects the password, and `MustGenerateFactorPassword` panics.

This is not just a test problem — the same ~1-in-1000 panic can happen at the production call site (`pkg/modules/user/impluser/setter.go`).

## Fix

Append `"zZ"` instead of `"Z"` so both letter cases are guaranteed by the suffix, while the generated part stays mixed-case for entropy. Every character class is now deterministically present:

- lowercase — `"z"` suffix
- uppercase — `"Z"` suffix
- digit — `numDigits=1`
- symbol — `numSymbols=1` (go-password's symbol set is identical to `IsPasswordValid`'s)

`IsPasswordValid` can never reject the generated password, so the panic path is unreachable.

## Verification

- `go test ./pkg/types/ -run TestMustGenerateFactorPassword -count=1000` — passes (old code fails ~2 in 1000)
- `go test ./pkg/types/` — passes

closes SigNoz/platform-pod#2640