### PR TITLE
feat(dashboards-v2): panel drilldown — dashboard variables + trace link

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
@@ -84,8 +84,16 @@ describe('enrichChartClick', () => {
 			clickData: chartClick(focused(2)),
 			series,
 			builderQueries: [
-				builderQuery({ name: 'A', signal: 'metrics' }),
-				builderQuery({ name: 'B', signal: 'logs' }),
+				builderQuery({
+					name: 'A',
+					signal: 'metrics',
+					groupBy: [{ name: 'service.name' }],
+				}),
+				builderQuery({
+					name: 'B',
+					signal: 'logs',
+					groupBy: [{ name: 'service.name' }],
+				}),
 			],
 		});
 
@@ -143,15 +151,38 @@ describe('enrichChartClick', () => {
 		).toBeNull();
 	});
 
-	it('emits empty filters for an ungrouped series', () => {
+	it('emits empty filters for an ungrouped series (drops the legend backfill label)', () => {
 		const payload = enrichChartClick({
 			clickData: chartClick(focused(1)),
-			series: [panelSeries({ queryName: 'A', labels: {} })],
+			series: [panelSeries({ queryName: 'A', labels: { A: 'A' } })],
 			builderQueries: [builderQuery({ name: 'A', signal: 'metrics' })],
 		});
 
 		expect(payload?.context.filters).toStrictEqual([]);
 		expect(payload?.context.queryName).toBe('A');
+	});
+
+	it('drops labels that are not group-by dimensions', () => {
+		const payload = enrichChartClick({
+			clickData: chartClick(focused(1)),
+			series: [
+				panelSeries({
+					queryName: 'A',
+					labels: { 'service.name': 'frontend', __name__: 'http_requests' },
+				}),
+			],
+			builderQueries: [
+				builderQuery({
+					name: 'A',
+					signal: 'metrics',
+					groupBy: [{ name: 'service.name' }],
+				}),
+			],
+		});
+
+		expect(payload?.context.filters).toStrictEqual([
+			{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
+		]);
 	});
 });
 
@@ -330,7 +361,13 @@ describe('enrichPieClick', () => {
 				queryName: 'A',
 				labels: { 'service.name': 'frontend' },
 			},
-			builderQueries: [builderQuery({ name: 'A', signal: 'traces' })],
+			builderQueries: [
+				builderQuery({
+					name: 'A',
+					signal: 'traces',
+					groupBy: [{ name: 'service.name' }],
+				}),
+			],
 			coordinates: { x: 7, y: 8 },
 			timeRange: { startTime: 1, endTime: 2 },
 		});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/__tests__/drilldown.test.ts
@@ -13,6 +13,7 @@ import { enrichChartClick } from '../enrichChartClick';
 import { enrichNumberClick } from '../enrichNumberClick';
 import { enrichPieClick } from '../enrichPieClick';
 import { enrichTableClick } from '../enrichTableClick';
+import { getDataLinks } from '../getDataLinks';
 import { resolvePanelContextLinks } from '../resolvePanelContextLinks';
 import { resolveDrilldownSignal } from '../signal';
 
@@ -416,5 +417,30 @@ describe('stepClickTimeRange', () => {
 				],
 			}),
 		).toStrictEqual({ startTime: 1000, endTime: 1060 });
+	});
+});
+
+describe('getDataLinks', () => {
+	it('adds a "View Trace Details" link when the filters carry a trace_id', () => {
+		expect(
+			getDataLinks([
+				{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
+				{ filterKey: 'trace_id', filterValue: 'abc123', operator: '=' },
+			]),
+		).toStrictEqual([
+			{
+				id: 'view-trace-details',
+				label: 'View Trace Details',
+				url: '/trace/abc123',
+			},
+		]);
+	});
+
+	it('returns no links when there is no trace_id', () => {
+		expect(
+			getDataLinks([
+				{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
+			]),
+		).toStrictEqual([]);
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/enrichChartClick.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/enrichChartClick.ts
@@ -1,13 +1,11 @@
-import {
-	getFiltersFromMetric,
-	isValidQueryName,
-} from 'container/QueryTable/Drilldown/drilldownUtils';
+import { isValidQueryName } from 'container/QueryTable/Drilldown/drilldownUtils';
 import type { ChartClickData } from 'lib/uPlotV2/plugins/TooltipPlugin/types';
 import type { PanelSeries } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
 import type { BuilderQuery } from 'types/api/v5/queryRange';
 
 import type { DrilldownClickPayload } from '../../types/drilldown';
 
+import { getGroupByFilters } from './getGroupByFilters';
 import { resolveDrilldownSignal } from './signal';
 
 interface EnrichChartClickArgs {
@@ -23,7 +21,7 @@ interface EnrichChartClickArgs {
 /**
  * Turns a uPlot click (time-series or bar) into a drilldown payload. Resolves the clicked series via
  * uPlot's series index (index 0 is the x-axis, so data series start at 1 → `series[seriesIndex - 1]`)
- * and builds equality filters from its group-by labels. Returns `null` when the click can't be
+ * and builds equality filters from its group-by label values. Returns `null` when the click can't be
  * attributed to a drillable series (no focused series, unmapped index, or a formula query).
  */
 export function enrichChartClick({
@@ -46,12 +44,16 @@ export function enrichChartClick({
 		(query) => query.name === panelSeries.queryName,
 	);
 
+	const filters = builderQuery
+		? getGroupByFilters(panelSeries.labels, builderQuery)
+		: [];
+
 	return {
 		coordinates: { x: clickData.absoluteMouseX, y: clickData.absoluteMouseY },
 		context: {
 			queryName: panelSeries.queryName,
 			signal: resolveDrilldownSignal(builderQuery),
-			filters: getFiltersFromMetric(panelSeries.labels),
+			filters,
 			timeRange,
 			label: focusedSeries.seriesName,
 			seriesColor: focusedSeries.color,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/enrichPieClick.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/enrichPieClick.ts
@@ -1,12 +1,10 @@
 import type { PieSlice } from 'container/DashboardContainer/visualization/charts/types';
-import {
-	getFiltersFromMetric,
-	isValidQueryName,
-} from 'container/QueryTable/Drilldown/drilldownUtils';
+import { isValidQueryName } from 'container/QueryTable/Drilldown/drilldownUtils';
 import type { BuilderQuery } from 'types/api/v5/queryRange';
 
 import type { DrilldownClickPayload } from '../../types/drilldown';
 
+import { getGroupByFilters } from './getGroupByFilters';
 import { resolveDrilldownSignal } from './signal';
 
 interface EnrichPieClickArgs {
@@ -18,8 +16,9 @@ interface EnrichPieClickArgs {
 }
 
 /**
- * Turns a pie-slice click into a drilldown payload, using the slice's source-row labels (carried by
- * `preparePieData`) as equality filters. Returns `null` when the slice has no drillable query.
+ * Turns a pie-slice click into a drilldown payload, using the slice's source-row group-by label
+ * values (carried by `preparePieData`) as equality filters. Returns `null` when the slice has no
+ * drillable query.
  */
 export function enrichPieClick({
 	slice,
@@ -33,12 +32,16 @@ export function enrichPieClick({
 	}
 
 	const builderQuery = builderQueries.find((query) => query.name === queryName);
+
+	const filters = builderQuery
+		? getGroupByFilters(slice.labels ?? {}, builderQuery)
+		: [];
 	return {
 		coordinates,
 		context: {
 			queryName,
 			signal: resolveDrilldownSignal(builderQuery),
-			filters: getFiltersFromMetric(slice.labels ?? {}),
+			filters: filters,
 			timeRange,
 			label: slice.label,
 			seriesColor: slice.color,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getDataLinks.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getDataLinks.ts
@@ -1,0 +1,29 @@
+import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
+
+/** An auto-generated drilldown link (label + destination URL). */
+export interface DrilldownDataLink {
+	id: string;
+	label: string;
+	url: string;
+}
+
+/**
+ * Links derived automatically from the clicked point's filters — the V2 port of V1's `getDataLinks`.
+ * Currently a single "View Trace Details" link when the clicked row carries a `trace_id`.
+ */
+export function getDataLinks(filters: FilterData[]): DrilldownDataLink[] {
+	const links: DrilldownDataLink[] = [];
+
+	const traceId = filters.find(
+		(filter) => filter.filterKey === 'trace_id',
+	)?.filterValue;
+	if (traceId) {
+		links.push({
+			id: 'view-trace-details',
+			label: 'View Trace Details',
+			url: `/trace/${traceId}`,
+		});
+	}
+
+	return links;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getGroupByFilters.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getGroupByFilters.ts
@@ -1,0 +1,26 @@
+import {
+	type FilterData,
+	getFiltersFromMetric,
+} from 'container/QueryTable/Drilldown/drilldownUtils';
+import type { BuilderQuery } from 'types/api/v5/queryRange';
+
+/**
+ * Equality filters for the clicked series/slice, restricted to the query's group-by dimensions.
+ * `labels` also carry a display-only legend backfill (`{queryName: queryName}` when ungrouped, see
+ * `resolveLegendAndLabels`); intersecting with group-by drops it so `filters` stays empty when
+ * ungrouped, matching V1.
+ */
+export function getGroupByFilters(
+	labels: Record<string, string>,
+	builderQuery: BuilderQuery,
+): FilterData[] {
+	const groupByKeys = new Set(
+		(builderQuery.groupBy ?? []).map((group) => group.name),
+	);
+	if (groupByKeys.size === 0) {
+		return [];
+	}
+	return getFiltersFromMetric(labels).filter((filter) =>
+		groupByKeys.has(filter.filterKey),
+	);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import {
+	Braces,
 	ChartBar,
 	DraftingCompass,
 	Link,
@@ -10,6 +11,7 @@ import type { DashboardLinkDTO } from 'api/generated/services/sigNoz.schemas';
 import { getAggregateColumnHeader } from 'container/QueryTable/Drilldown/drilldownUtils';
 import ContextMenu from 'periscope/components/ContextMenu';
 import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
+import { getDataLinks } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getDataLinks';
 import { resolvePanelContextLinks } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 import { openInNewTab } from 'utils/navigation';
@@ -26,9 +28,13 @@ interface DrilldownAggregateMenuProps {
 	isResolving?: boolean;
 	/** Panel's context links; resolved against the clicked point + variables here. */
 	links: DashboardLinkDTO[] | undefined;
+	/** Whether the clicked point exposes group-by fields to bind to dashboard variables. */
+	canSetDashboardVariables: boolean;
 	onViewLogs: () => void;
 	onViewTraces: () => void;
 	onBreakout: () => void;
+	/** Open the Dashboard Variables submenu (set/unset/create from the clicked value). */
+	onSetDashboardVariables: () => void;
 	/** Close the popover (context-link clicks). */
 	onClose: () => void;
 }
@@ -43,9 +49,11 @@ function DrilldownAggregateMenu({
 	query,
 	isResolving = false,
 	links,
+	canSetDashboardVariables,
 	onViewLogs,
 	onViewTraces,
 	onBreakout,
+	onSetDashboardVariables,
 	onClose,
 }: DrilldownAggregateMenuProps): JSX.Element {
 	const aggregations = useMemo(
@@ -58,6 +66,11 @@ function DrilldownAggregateMenu({
 		() => resolvePanelContextLinks(links, processedVariables),
 		[links, processedVariables],
 	);
+	// Auto links derived from the clicked point itself (e.g. "View Trace Details" for a trace_id).
+	const dataLinks = useMemo(
+		() => getDataLinks(context.filters),
+		[context.filters],
+	);
 
 	return (
 		<>
@@ -67,6 +80,20 @@ function DrilldownAggregateMenu({
 					{context.label || aggregations}
 				</div>
 			</ContextMenu.Header>
+			{canSetDashboardVariables && (
+				<ContextMenu.Item
+					icon={
+						<span style={{ color: context.seriesColor }}>
+							<Braces size={16} />
+						</span>
+					}
+					onClick={onSetDashboardVariables}
+				>
+					<span data-testid="drilldown-dashboard-variables">
+						Dashboard Variables
+					</span>
+				</ContextMenu.Item>
+			)}
 			<ContextMenu.Item
 				icon={
 					isResolving ? (
@@ -107,10 +134,22 @@ function DrilldownAggregateMenu({
 			>
 				<span data-testid="drilldown-breakout">Breakout by ..</span>
 			</ContextMenu.Item>
+			{dataLinks.map((link) => (
+				<ContextMenu.Item
+					key={link.id}
+					icon={<Link size={16} color={context.seriesColor} />}
+					onClick={(): void => {
+						openInNewTab(link.url);
+						onClose();
+					}}
+				>
+					<span data-testid="drilldown-data-link">{link.label}</span>
+				</ContextMenu.Item>
+			))}
 			{contextLinks.map((link) => (
 				<ContextMenu.Item
 					key={link.id}
-					icon={<Link size={16} />}
+					icon={<Link size={16} color={context.seriesColor} />}
 					onClick={(): void => {
 						openInNewTab(link.url);
 						onClose();

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownDashboardVariablesMenu.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownDashboardVariablesMenu.module.scss
@@ -1,0 +1,9 @@
+.header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.backArrow {
+	cursor: pointer;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownDashboardVariablesMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownDashboardVariablesMenu.tsx
@@ -1,0 +1,79 @@
+import { ArrowLeft, Plus, Settings, X } from '@signozhq/icons';
+import OverlayScrollbar from 'components/OverlayScrollbar/OverlayScrollbar';
+import {
+	type DrilldownVariableAction,
+	DrilldownVariableActionKind,
+} from 'pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables';
+import ContextMenu from 'periscope/components/ContextMenu';
+
+import styles from './DrilldownDashboardVariablesMenu.module.scss';
+
+interface DrilldownDashboardVariablesMenuProps {
+	/** Resolved entries from `useDrilldownDashboardVariables`. */
+	actions: DrilldownVariableAction[];
+	/** Return to the base aggregate menu. */
+	onBack: () => void;
+}
+
+const ICON_BY_KIND: Record<DrilldownVariableActionKind, JSX.Element> = {
+	[DrilldownVariableActionKind.Set]: <Settings size={16} />,
+	[DrilldownVariableActionKind.Unset]: <X size={16} />,
+	[DrilldownVariableActionKind.Create]: <Plus size={16} />,
+};
+
+/**
+ * The "Dashboard Variables" drilldown submenu — renders the entries resolved by
+ * `useDrilldownDashboardVariables` (Set/Unset an existing dynamic variable, or Create one).
+ */
+function DrilldownDashboardVariablesMenu({
+	actions,
+	onBack,
+}: DrilldownDashboardVariablesMenuProps): JSX.Element {
+	return (
+		<>
+			<ContextMenu.Header>
+				<div className={styles.header}>
+					<ArrowLeft
+						size={14}
+						className={styles.backArrow}
+						onClick={onBack}
+						data-testid="drilldown-var-back"
+					/>
+					<span>Dashboard Variables</span>
+				</div>
+			</ContextMenu.Header>
+			<OverlayScrollbar
+				style={{ maxHeight: '200px' }}
+				options={{ overflow: { x: 'hidden' } }}
+			>
+				<>
+					{actions.map(({ fieldName, fieldValue, kind, onClick }) => (
+						<ContextMenu.Item
+							key={fieldName}
+							icon={ICON_BY_KIND[kind]}
+							onClick={onClick}
+						>
+							{kind === DrilldownVariableActionKind.Unset && (
+								<span data-testid="drilldown-var-unset">
+									Unset <strong>${fieldName}</strong>
+								</span>
+							)}
+							{kind === DrilldownVariableActionKind.Set && (
+								<span data-testid="drilldown-var-set">
+									Set <strong>${fieldName}</strong> to <strong>{fieldValue}</strong>
+								</span>
+							)}
+							{kind === DrilldownVariableActionKind.Create && (
+								<span data-testid="drilldown-var-create">
+									Create var <strong>${fieldName}</strong>:<strong>{fieldValue}</strong>
+								</span>
+							)}
+						</ContextMenu.Item>
+					))}
+				</>
+			</OverlayScrollbar>
+		</>
+	);
+}
+
+export default DrilldownDashboardVariablesMenu;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/DrilldownDashboardVariablesMenu.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/DrilldownDashboardVariablesMenu.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import DrilldownDashboardVariablesMenu from '../DrilldownMenu/DrilldownDashboardVariablesMenu';
+import {
+	type DrilldownVariableAction,
+	DrilldownVariableActionKind,
+} from '../hooks/useDrilldownDashboardVariables';
+
+jest.mock('components/OverlayScrollbar/OverlayScrollbar', () => ({
+	__esModule: true,
+	default: ({ children }: { children: React.ReactNode }): JSX.Element => (
+		<div>{children}</div>
+	),
+}));
+
+function action(
+	overrides: Partial<DrilldownVariableAction> = {},
+): DrilldownVariableAction {
+	return {
+		fieldName: 'service.name',
+		fieldValue: 'frontend',
+		kind: DrilldownVariableActionKind.Set,
+		onClick: jest.fn(),
+		...overrides,
+	};
+}
+
+describe('DrilldownDashboardVariablesMenu', () => {
+	it('renders each kind with its own label and fires its onClick', async () => {
+		const onSet = jest.fn();
+		const onUnset = jest.fn();
+		const onCreate = jest.fn();
+		render(
+			<DrilldownDashboardVariablesMenu
+				onBack={jest.fn()}
+				actions={[
+					action({
+						fieldName: 'a',
+						kind: DrilldownVariableActionKind.Set,
+						onClick: onSet,
+					}),
+					action({
+						fieldName: 'b',
+						kind: DrilldownVariableActionKind.Unset,
+						onClick: onUnset,
+					}),
+					action({
+						fieldName: 'c',
+						kind: DrilldownVariableActionKind.Create,
+						onClick: onCreate,
+					}),
+				]}
+			/>,
+		);
+
+		expect(screen.getByTestId('drilldown-var-set')).toBeInTheDocument();
+		expect(screen.getByTestId('drilldown-var-unset')).toBeInTheDocument();
+		expect(screen.getByTestId('drilldown-var-create')).toBeInTheDocument();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-set'));
+		expect(onSet).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns to the base menu when the back arrow is clicked', async () => {
+		const onBack = jest.fn();
+		render(
+			<DrilldownDashboardVariablesMenu onBack={onBack} actions={[action()]} />,
+		);
+
+		await userEvent.click(screen.getByTestId('drilldown-var-back'));
+		expect(onBack).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { act, render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -13,6 +14,13 @@ const mockOpenViewWithQuery = jest.fn();
 const mockNavigate = jest.fn();
 const mockGetBuilderQueries = jest.fn();
 let mockResolved = { resolvedQuery: 'RESOLVED_QUERY', isResolving: false };
+let mockDashboardVariables: {
+	hasFieldVariables: boolean;
+	items: ReactNode;
+} = {
+	hasFieldVariables: true,
+	items: <div data-testid="dashboard-variables-submenu" />,
+};
 
 // Boundaries tested elsewhere / needing external context — mocked so this suite isolates
 // useDrilldown's orchestration (gating, which menu shows, the View-modal handoff).
@@ -32,6 +40,13 @@ jest.mock('../hooks/useDrilldownBreakout', () => ({
 jest.mock('../DrilldownMenu/DrilldownBreakoutMenu', () => ({
 	__esModule: true,
 	default: (): JSX.Element => <div data-testid="breakout-submenu" />,
+}));
+jest.mock('../hooks/useDrilldownDashboardVariables', () => ({
+	useDrilldownDashboardVariables: (): unknown => mockDashboardVariables,
+}));
+// Context-link variable map (redux global time + store) — out of scope for this suite.
+jest.mock('../hooks/useDrilldownContextVariables', () => ({
+	useDrilldownContextVariables: (): unknown => ({}),
 }));
 jest.mock('container/QueryTable/Drilldown/useBaseDrilldownNavigate', () => ({
 	__esModule: true,
@@ -116,6 +131,10 @@ describe('useDrilldown', () => {
 		jest.clearAllMocks();
 		mockGetBuilderQueries.mockReturnValue([{ name: 'A' }]);
 		mockResolved = { resolvedQuery: 'RESOLVED_QUERY', isResolving: false };
+		mockDashboardVariables = {
+			hasFieldVariables: true,
+			items: <div data-testid="dashboard-variables-submenu" />,
+		};
 	});
 
 	describe('enableDrillDown', () => {
@@ -200,6 +219,56 @@ describe('useDrilldown', () => {
 			view.rerender(<div>{result.current.contextMenuProps.items}</div>);
 
 			expect(screen.getByTestId('breakout-submenu')).toBeInTheDocument();
+		});
+
+		it('shows the Dashboard Variables entry when the click has group-by fields', () => {
+			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
+			act(() =>
+				result.current.onPanelClick({
+					coordinates: { x: 1, y: 1 },
+					context: aggregateContext,
+				}),
+			);
+			render(<div>{result.current.contextMenuProps.items}</div>);
+
+			expect(
+				screen.getByTestId('drilldown-dashboard-variables'),
+			).toBeInTheDocument();
+		});
+
+		it('hides the Dashboard Variables entry when there are no group-by fields', () => {
+			mockDashboardVariables = { hasFieldVariables: false, items: null };
+			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
+			act(() =>
+				result.current.onPanelClick({
+					coordinates: { x: 1, y: 1 },
+					context: aggregateContext,
+				}),
+			);
+			render(<div>{result.current.contextMenuProps.items}</div>);
+
+			expect(
+				screen.queryByTestId('drilldown-dashboard-variables'),
+			).not.toBeInTheDocument();
+		});
+
+		it('swaps to the Dashboard Variables submenu when clicked', async () => {
+			const user = userEvent.setup();
+			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
+			act(() =>
+				result.current.onPanelClick({
+					coordinates: { x: 1, y: 1 },
+					context: aggregateContext,
+				}),
+			);
+			const view = render(<div>{result.current.contextMenuProps.items}</div>);
+
+			await user.click(screen.getByTestId('drilldown-dashboard-variables'));
+			view.rerender(<div>{result.current.contextMenuProps.items}</div>);
+
+			expect(
+				screen.getByTestId('dashboard-variables-submenu'),
+			).toBeInTheDocument();
 		});
 	});
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import { act, render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -16,10 +15,10 @@ const mockGetBuilderQueries = jest.fn();
 let mockResolved = { resolvedQuery: 'RESOLVED_QUERY', isResolving: false };
 let mockDashboardVariables: {
 	hasFieldVariables: boolean;
-	items: ReactNode;
+	actions: unknown[];
 } = {
 	hasFieldVariables: true,
-	items: <div data-testid="dashboard-variables-submenu" />,
+	actions: [],
 };
 
 // Boundaries tested elsewhere / needing external context — mocked so this suite isolates
@@ -43,6 +42,10 @@ jest.mock('../DrilldownMenu/DrilldownBreakoutMenu', () => ({
 }));
 jest.mock('../hooks/useDrilldownDashboardVariables', () => ({
 	useDrilldownDashboardVariables: (): unknown => mockDashboardVariables,
+}));
+jest.mock('../DrilldownMenu/DrilldownDashboardVariablesMenu', () => ({
+	__esModule: true,
+	default: (): JSX.Element => <div data-testid="dashboard-variables-submenu" />,
 }));
 // Context-link variable map (redux global time + store) — out of scope for this suite.
 jest.mock('../hooks/useDrilldownContextVariables', () => ({
@@ -133,7 +136,7 @@ describe('useDrilldown', () => {
 		mockResolved = { resolvedQuery: 'RESOLVED_QUERY', isResolving: false };
 		mockDashboardVariables = {
 			hasFieldVariables: true,
-			items: <div data-testid="dashboard-variables-submenu" />,
+			actions: [],
 		};
 	});
 
@@ -237,7 +240,7 @@ describe('useDrilldown', () => {
 		});
 
 		it('hides the Dashboard Variables entry when there are no group-by fields', () => {
-			mockDashboardVariables = { hasFieldVariables: false, items: null };
+			mockDashboardVariables = { hasFieldVariables: false, actions: [] };
 			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
 			act(() =>
 				result.current.onPanelClick({

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldownDashboardVariables.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldownDashboardVariables.test.tsx
@@ -1,17 +1,19 @@
 import { render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
-import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
+import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
 
+import DrilldownDashboardVariablesMenu from '../DrilldownMenu/DrilldownDashboardVariablesMenu';
 import { useDrilldownDashboardVariables } from '../hooks/useDrilldownDashboardVariables';
 
 // Fake dashboard variables + runtime selection, mutated per test. `dtoToFormModel` is mocked as
-// identity, so these DTOs are shaped like form models directly.
+// identity, so these DTOs carry both the plugin discriminant (for the dynamic filter) and the flat
+// form-model fields the hook reads.
 let mockVariables: Array<{
 	name: string;
-	type: string;
 	dynamicAttribute?: string;
 	multiSelect?: boolean;
+	spec: { plugin: { kind: string } };
 }> = [];
 let mockSelectionMap: Record<string, { value: unknown; allSelected: boolean }> =
 	{};
@@ -19,6 +21,9 @@ let mockSelectionMap: Record<string, { value: unknown; allSelected: boolean }> =
 const mockSetVariableValue = jest.fn();
 const mockSetUrlValues = jest.fn();
 const mockPatchAsync = jest.fn().mockResolvedValue(undefined);
+
+const DYNAMIC_KIND = 'signoz/DynamicVariable';
+const QUERY_KIND = 'signoz/QueryVariable';
 
 jest.mock('api/generated/services/dashboard', () => ({
 	useGetDashboardV2: (): unknown => ({
@@ -76,23 +81,24 @@ jest.mock('@signozhq/ui/sonner', () => ({
 	toast: { success: jest.fn(), error: jest.fn() },
 }));
 
-const context: DrilldownContext = {
-	queryName: 'A',
-	signal: TelemetrytypesSignalDTO.metrics,
-	filters: [
-		{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
-	],
-};
+const filters: FilterData[] = [
+	{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
+];
 
 function renderItems(): void {
 	const { result } = renderHook(() =>
 		useDrilldownDashboardVariables({
-			context,
-			onBack: jest.fn(),
+			filters,
+			signal: TelemetrytypesSignalDTO.metrics,
 			onClose: jest.fn(),
 		}),
 	);
-	render(<div>{result.current.items}</div>);
+	render(
+		<DrilldownDashboardVariablesMenu
+			actions={result.current.actions}
+			onBack={jest.fn()}
+		/>,
+	);
 }
 
 describe('useDrilldownDashboardVariables', () => {
@@ -104,20 +110,12 @@ describe('useDrilldownDashboardVariables', () => {
 
 	it('hasFieldVariables reflects the clicked point group-by fields', () => {
 		const withFields = renderHook(() =>
-			useDrilldownDashboardVariables({
-				context,
-				onBack: jest.fn(),
-				onClose: jest.fn(),
-			}),
+			useDrilldownDashboardVariables({ filters, onClose: jest.fn() }),
 		);
 		expect(withFields.result.current.hasFieldVariables).toBe(true);
 
 		const noFields = renderHook(() =>
-			useDrilldownDashboardVariables({
-				context: { ...context, filters: [] },
-				onBack: jest.fn(),
-				onClose: jest.fn(),
-			}),
+			useDrilldownDashboardVariables({ filters: [], onClose: jest.fn() }),
 		);
 		expect(noFields.result.current.hasFieldVariables).toBe(false);
 	});
@@ -126,9 +124,9 @@ describe('useDrilldownDashboardVariables', () => {
 		mockVariables = [
 			{
 				name: 'svc',
-				type: 'DYNAMIC',
 				dynamicAttribute: 'service.name',
 				multiSelect: true,
+				spec: { plugin: { kind: DYNAMIC_KIND } },
 			},
 		];
 		mockSelectionMap = { svc: { value: ['backend'], allSelected: false } };
@@ -145,9 +143,9 @@ describe('useDrilldownDashboardVariables', () => {
 		mockVariables = [
 			{
 				name: 'svc',
-				type: 'DYNAMIC',
 				dynamicAttribute: 'service.name',
 				multiSelect: false,
+				spec: { plugin: { kind: DYNAMIC_KIND } },
 			},
 		];
 		mockSelectionMap = { svc: { value: 'backend', allSelected: false } };
@@ -164,9 +162,9 @@ describe('useDrilldownDashboardVariables', () => {
 		mockVariables = [
 			{
 				name: 'svc',
-				type: 'DYNAMIC',
 				dynamicAttribute: 'service.name',
 				multiSelect: true,
+				spec: { plugin: { kind: DYNAMIC_KIND } },
 			},
 		];
 		mockSelectionMap = { svc: { value: ['frontend'], allSelected: false } };
@@ -195,7 +193,11 @@ describe('useDrilldownDashboardVariables', () => {
 
 	it('ignores a non-dynamic variable with the same attribute (still offers Create)', () => {
 		mockVariables = [
-			{ name: 'svc', type: 'QUERY', dynamicAttribute: 'service.name' },
+			{
+				name: 'svc',
+				dynamicAttribute: 'service.name',
+				spec: { plugin: { kind: QUERY_KIND } },
+			},
 		];
 		renderItems();
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldownDashboardVariables.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldownDashboardVariables.test.tsx
@@ -1,0 +1,205 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
+
+import { useDrilldownDashboardVariables } from '../hooks/useDrilldownDashboardVariables';
+
+// Fake dashboard variables + runtime selection, mutated per test. `dtoToFormModel` is mocked as
+// identity, so these DTOs are shaped like form models directly.
+let mockVariables: Array<{
+	name: string;
+	type: string;
+	dynamicAttribute?: string;
+	multiSelect?: boolean;
+}> = [];
+let mockSelectionMap: Record<string, { value: unknown; allSelected: boolean }> =
+	{};
+
+const mockSetVariableValue = jest.fn();
+const mockSetUrlValues = jest.fn();
+const mockPatchAsync = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('api/generated/services/dashboard', () => ({
+	useGetDashboardV2: (): unknown => ({
+		data: { data: { spec: { variables: mockVariables } } },
+	}),
+}));
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/hooks/useOptimisticPatch',
+	() => ({
+		useOptimisticPatch: (): unknown => ({ patchAsync: mockPatchAsync }),
+	}),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore',
+	() => ({
+		useDashboardStore: (selector: (state: unknown) => unknown): unknown =>
+			selector({
+				dashboardId: 'd1',
+				variableValues: { d1: mockSelectionMap },
+				setVariableValue: mockSetVariableValue,
+			}),
+	}),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters',
+	() => ({
+		dtoToFormModel: (dto: unknown): unknown => dto,
+		formModelToDto: (model: { name: string }): unknown => ({ dto: model.name }),
+	}),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel',
+	() => ({
+		emptyVariableFormModel: (): unknown => ({}),
+		DYNAMIC_SIGNAL_ALL: 'all',
+	}),
+);
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection',
+	() => ({
+		ALL_SELECTED: '__ALL__',
+		variablesUrlParser: { withOptions: (): unknown => ({}) },
+	}),
+);
+jest.mock('nuqs', () => ({
+	useQueryState: (): unknown => [null, mockSetUrlValues],
+}));
+jest.mock('components/OverlayScrollbar/OverlayScrollbar', () => ({
+	__esModule: true,
+	default: ({ children }: { children: React.ReactNode }): JSX.Element => (
+		<div>{children}</div>
+	),
+}));
+jest.mock('@signozhq/ui/sonner', () => ({
+	toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const context: DrilldownContext = {
+	queryName: 'A',
+	signal: TelemetrytypesSignalDTO.metrics,
+	filters: [
+		{ filterKey: 'service.name', filterValue: 'frontend', operator: '=' },
+	],
+};
+
+function renderItems(): void {
+	const { result } = renderHook(() =>
+		useDrilldownDashboardVariables({
+			context,
+			onBack: jest.fn(),
+			onClose: jest.fn(),
+		}),
+	);
+	render(<div>{result.current.items}</div>);
+}
+
+describe('useDrilldownDashboardVariables', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockVariables = [];
+		mockSelectionMap = {};
+	});
+
+	it('hasFieldVariables reflects the clicked point group-by fields', () => {
+		const withFields = renderHook(() =>
+			useDrilldownDashboardVariables({
+				context,
+				onBack: jest.fn(),
+				onClose: jest.fn(),
+			}),
+		);
+		expect(withFields.result.current.hasFieldVariables).toBe(true);
+
+		const noFields = renderHook(() =>
+			useDrilldownDashboardVariables({
+				context: { ...context, filters: [] },
+				onBack: jest.fn(),
+				onClose: jest.fn(),
+			}),
+		);
+		expect(noFields.result.current.hasFieldVariables).toBe(false);
+	});
+
+	it('offers Set — writing an array for a multi-select var so the selector shows it', async () => {
+		mockVariables = [
+			{
+				name: 'svc',
+				type: 'DYNAMIC',
+				dynamicAttribute: 'service.name',
+				multiSelect: true,
+			},
+		];
+		mockSelectionMap = { svc: { value: ['backend'], allSelected: false } };
+		renderItems();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-set'));
+		expect(mockSetVariableValue).toHaveBeenCalledWith('d1', 'svc', {
+			value: ['frontend'],
+			allSelected: false,
+		});
+	});
+
+	it('offers Set — writing a scalar for a single-select var', async () => {
+		mockVariables = [
+			{
+				name: 'svc',
+				type: 'DYNAMIC',
+				dynamicAttribute: 'service.name',
+				multiSelect: false,
+			},
+		];
+		mockSelectionMap = { svc: { value: 'backend', allSelected: false } };
+		renderItems();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-set'));
+		expect(mockSetVariableValue).toHaveBeenCalledWith('d1', 'svc', {
+			value: 'frontend',
+			allSelected: false,
+		});
+	});
+
+	it('offers Unset when the matching dynamic var already holds the clicked value', async () => {
+		mockVariables = [
+			{
+				name: 'svc',
+				type: 'DYNAMIC',
+				dynamicAttribute: 'service.name',
+				multiSelect: true,
+			},
+		];
+		mockSelectionMap = { svc: { value: ['frontend'], allSelected: false } };
+		renderItems();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-unset'));
+		expect(mockSetVariableValue).toHaveBeenCalledWith('d1', 'svc', {
+			value: [],
+			allSelected: false,
+		});
+	});
+
+	it('offers Create and persists a new dynamic variable when none matches', async () => {
+		mockVariables = [];
+		renderItems();
+
+		await userEvent.click(screen.getByTestId('drilldown-var-create'));
+		// Persisted to the spec via the optimistic patch...
+		expect(mockPatchAsync).toHaveBeenCalledTimes(1);
+		// ...and seeded (as an array — the created var is multi-select) with the clicked value.
+		expect(mockSetVariableValue).toHaveBeenCalledWith('d1', 'service.name', {
+			value: ['frontend'],
+			allSelected: false,
+		});
+	});
+
+	it('ignores a non-dynamic variable with the same attribute (still offers Create)', () => {
+		mockVariables = [
+			{ name: 'svc', type: 'QUERY', dynamicAttribute: 'service.name' },
+		];
+		renderItems();
+
+		expect(screen.getByTestId('drilldown-var-create')).toBeInTheDocument();
+		expect(screen.queryByTestId('drilldown-var-set')).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldownDashboardVariables.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldownDashboardVariables.test.tsx
@@ -6,9 +6,9 @@ import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
 import DrilldownDashboardVariablesMenu from '../DrilldownMenu/DrilldownDashboardVariablesMenu';
 import { useDrilldownDashboardVariables } from '../hooks/useDrilldownDashboardVariables';
 
-// Fake dashboard variables + runtime selection, mutated per test. `dtoToFormModel` is mocked as
-// identity, so these DTOs carry both the plugin discriminant (for the dynamic filter) and the flat
-// form-model fields the hook reads.
+// Fake dashboard variables + runtime selection, mutated per test. `dtoToFormModel` is mocked to
+// derive `type` from the plugin kind (like the real adapter), so these DTOs carry the plugin
+// discriminant plus the flat form-model fields the hook reads.
 let mockVariables: Array<{
 	name: string;
 	dynamicAttribute?: string;
@@ -50,7 +50,13 @@ jest.mock(
 jest.mock(
 	'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters',
 	() => ({
-		dtoToFormModel: (dto: unknown): unknown => dto,
+		dtoToFormModel: (dto: {
+			spec?: { plugin?: { kind?: string } };
+		}): unknown => ({
+			...dto,
+			type:
+				dto.spec?.plugin?.kind === 'signoz/DynamicVariable' ? 'DYNAMIC' : 'QUERY',
+		}),
 		formModelToDto: (model: { name: string }): unknown => ({ dto: model.name }),
 	}),
 );

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -24,6 +24,7 @@ import DrilldownBreakoutMenu from '../DrilldownMenu/DrilldownBreakoutMenu';
 import DrilldownFilterMenu from '../DrilldownMenu/DrilldownFilterMenu';
 import { useDrilldownBreakout } from './useDrilldownBreakout';
 import { useDrilldownCoordinates } from './useDrilldownCoordinates';
+import { useDrilldownDashboardVariables } from './useDrilldownDashboardVariables';
 import { useDrilldownFilter } from './useDrilldownFilter';
 import { useResolvedDrilldownQuery } from './useResolvedDrilldownQuery';
 import { useViewPanel } from './useViewPanel';
@@ -32,6 +33,7 @@ import { useViewPanel } from './useViewPanel';
 enum DrilldownSubMenu {
 	Base = 'base',
 	Breakout = 'breakout',
+	DashboardVariables = 'dashboardVariables',
 }
 
 /** Props the panel shell spreads onto `<ContextMenu>`. */
@@ -102,6 +104,10 @@ export function useDrilldown(
 		(): void => setSubMenu(DrilldownSubMenu.Base),
 		[],
 	);
+	const openDashboardVariables = useCallback(
+		(): void => setSubMenu(DrilldownSubMenu.DashboardVariables),
+		[],
+	);
 
 	const onPanelClick = useCallback(
 		(payload: DrilldownClickPayload): void => {
@@ -136,6 +142,12 @@ export function useDrilldown(
 		onClose: handleClose,
 	});
 
+	const dashboardVariables = useDrilldownDashboardVariables({
+		context,
+		onBack: backToBase,
+		onClose: handleClose,
+	});
+
 	// The aggregate menu (View in Logs/Traces) shows for a non-group click on the base menu; the
 	// group click routes to filter-by-value instead. Only that menu resolves variables —
 	// filter/breakout open the View modal, which resolves at query-run time.
@@ -165,6 +177,9 @@ export function useDrilldown(
 				/>
 			) : null;
 		}
+		if (subMenu === 'dashboardVariables') {
+			return dashboardVariables.items;
+		}
 		if (filter.isGroupColumnClick && context?.clickedKey) {
 			return (
 				<DrilldownFilterMenu
@@ -183,9 +198,11 @@ export function useDrilldown(
 				query={v1Query}
 				isResolving={isResolving}
 				links={panel.spec.links}
+				canSetDashboardVariables={dashboardVariables.hasFieldVariables}
 				onViewLogs={(): void => navigate('view_logs')}
 				onViewTraces={(): void => navigate('view_traces')}
 				onBreakout={openBreakout}
+				onSetDashboardVariables={openDashboardVariables}
 				onClose={handleClose}
 			/>
 		);
@@ -194,6 +211,8 @@ export function useDrilldown(
 		breakout.queryData,
 		breakout.onBreakout,
 		backToBase,
+		dashboardVariables.items,
+		dashboardVariables.hasFieldVariables,
 		filter.isGroupColumnClick,
 		filter.onFilter,
 		context,
@@ -202,6 +221,7 @@ export function useDrilldown(
 		panel.spec.links,
 		navigate,
 		openBreakout,
+		openDashboardVariables,
 		handleClose,
 	]);
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
 import useBaseDrilldownNavigate from 'container/QueryTable/Drilldown/useBaseDrilldownNavigate';
 import type {
 	Coordinates,
@@ -10,10 +11,7 @@ import type {
 	DrilldownClickPayload,
 	DrilldownContext,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
-import {
-	PANEL_KIND_TO_PANEL_TYPE,
-	type PanelKind,
-} from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
+import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import { getPanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/registry';
 import { buildAggregateData } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/buildAggregateData';
 import { getBuilderQueries } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries';
@@ -21,6 +19,7 @@ import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/per
 
 import DrilldownAggregateMenu from '../DrilldownMenu/DrilldownAggregateMenu';
 import DrilldownBreakoutMenu from '../DrilldownMenu/DrilldownBreakoutMenu';
+import DrilldownDashboardVariablesMenu from '../DrilldownMenu/DrilldownDashboardVariablesMenu';
 import DrilldownFilterMenu from '../DrilldownMenu/DrilldownFilterMenu';
 import { useDrilldownBreakout } from './useDrilldownBreakout';
 import { useDrilldownCoordinates } from './useDrilldownCoordinates';
@@ -35,6 +34,9 @@ enum DrilldownSubMenu {
 	Breakout = 'breakout',
 	DashboardVariables = 'dashboardVariables',
 }
+
+/** Stable empty-filters ref so the dashboard-variables hook doesn't re-run on every no-click render. */
+const EMPTY_FILTERS: FilterData[] = [];
 
 /** Props the panel shell spreads onto `<ContextMenu>`. */
 export interface DrilldownContextMenuProps {
@@ -60,11 +62,9 @@ export function useDrilldown(
 	panel: DashboardtypesPanelDTO,
 	panelId: string,
 ): UseDrilldownResult {
-	const kind = panel.spec.plugin.kind as PanelKind;
+	const kind = panel.spec.plugin.kind;
 	const panelType = PANEL_KIND_TO_PANEL_TYPE[kind];
-	// Stable ref so the conversions below don't re-run every render (the `?? []` fallback would
-	// otherwise be a fresh array each time).
-	const queries = useMemo(() => panel.spec.queries ?? [], [panel.spec.queries]);
+	const queries = panel.spec.queries;
 
 	// Kind must opt in via its capability AND have a builder query to drill into.
 	const enableDrillDown = useMemo(
@@ -143,8 +143,8 @@ export function useDrilldown(
 	});
 
 	const dashboardVariables = useDrilldownDashboardVariables({
-		context,
-		onBack: backToBase,
+		filters: context?.filters ?? EMPTY_FILTERS,
+		signal: context?.signal,
 		onClose: handleClose,
 	});
 
@@ -177,8 +177,13 @@ export function useDrilldown(
 				/>
 			) : null;
 		}
-		if (subMenu === 'dashboardVariables') {
-			return dashboardVariables.items;
+		if (subMenu === DrilldownSubMenu.DashboardVariables) {
+			return (
+				<DrilldownDashboardVariablesMenu
+					actions={dashboardVariables.actions}
+					onBack={backToBase}
+				/>
+			);
 		}
 		if (filter.isGroupColumnClick && context?.clickedKey) {
 			return (
@@ -210,8 +215,7 @@ export function useDrilldown(
 		subMenu,
 		breakout.queryData,
 		breakout.onBreakout,
-		backToBase,
-		dashboardVariables.items,
+		dashboardVariables.actions,
 		dashboardVariables.hasFieldVariables,
 		filter.isGroupColumnClick,
 		filter.onFilter,
@@ -222,6 +226,7 @@ export function useDrilldown(
 		navigate,
 		openBreakout,
 		openDashboardVariables,
+		backToBase,
 		handleClose,
 	]);
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
@@ -1,11 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { toast } from '@signozhq/ui/sonner';
-import { useGetDashboardV2 } from 'api/generated/services/dashboard';
-import {
-	type DashboardtypesListVariableSpecDTO,
-	DashboardtypesVariablePluginVariantGithubComSigNozSignozPkgTypesDashboardtypesDynamicVariableSpecDTOKind as DynamicPluginKind,
-	type TelemetrytypesSignalDTO,
-} from 'api/generated/services/sigNoz.schemas';
+import type { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
 import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
 import { useQueryState } from 'nuqs';
 import {
@@ -18,6 +13,7 @@ import {
 	type VariableFormModel,
 } from 'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel';
 import { buildVariablesPatch } from 'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variablePatchOps';
+import { useDashboardFetchRequired } from 'pages/DashboardPageV2/DashboardContainer/hooks/useDashboardFetchRequired';
 import { useOptimisticPatch } from 'pages/DashboardPageV2/DashboardContainer/hooks/useOptimisticPatch';
 import { selectVariableValues } from 'pages/DashboardPageV2/DashboardContainer/store/slices/variableSelectionSlice';
 import { useDashboardStore } from 'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore';
@@ -69,23 +65,14 @@ export function useDrilldownDashboardVariables({
 	onClose,
 }: UseDrilldownDashboardVariablesArgs): UseDrilldownDashboardVariablesApi {
 	const dashboardId = useDashboardStore((state) => state.dashboardId);
-	// The generated hook already gates itself on `enabled: !!id`, so no manual guard is needed.
-	const { data } = useGetDashboardV2({ id: dashboardId });
-	const variables = data?.data.spec?.variables;
+	const { variables } = useDashboardFetchRequired();
 
 	const dynamicVariables = useMemo(
-		() =>
-			(variables ?? [])
-				.filter(
-					(v) =>
-						(v.spec as DashboardtypesListVariableSpecDTO).plugin?.kind ===
-						DynamicPluginKind['signoz/DynamicVariable'],
-				)
-				.map(dtoToFormModel),
+		() => variables.map(dtoToFormModel).filter((v) => v.type === 'DYNAMIC'),
 		[variables],
 	);
 	const existingNames = useMemo(
-		() => new Set((variables ?? []).map((v) => dtoToFormModel(v).name)),
+		() => new Set(variables.map((v) => dtoToFormModel(v).name)),
 		[variables],
 	);
 
@@ -136,7 +123,7 @@ export function useDrilldownDashboardVariables({
 			};
 			try {
 				await patchAsync(
-					buildVariablesPatch([...(variables ?? []), formModelToDto(model)]),
+					buildVariablesPatch([...variables, formModelToDto(model)]),
 				);
 				// Multi-select var → seed the value as an array (the selector renders scalars as empty).
 				setSelection(fieldName, { value: [fieldValue], allSelected: false });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useMemo } from 'react';
-import type { ReactNode } from 'react';
-import { ArrowLeft, Plus, Settings, X } from '@signozhq/icons';
 import { toast } from '@signozhq/ui/sonner';
 import { useGetDashboardV2 } from 'api/generated/services/dashboard';
-import OverlayScrollbar from 'components/OverlayScrollbar/OverlayScrollbar';
+import {
+	type DashboardtypesListVariableSpecDTO,
+	DashboardtypesVariablePluginVariantGithubComSigNozSignozPkgTypesDashboardtypesDynamicVariableSpecDTOKind as DynamicPluginKind,
+	type TelemetrytypesSignalDTO,
+} from 'api/generated/services/sigNoz.schemas';
+import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
 import { useQueryState } from 'nuqs';
-import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
 import {
 	dtoToFormModel,
 	formModelToDto,
@@ -24,45 +26,62 @@ import {
 	ALL_SELECTED,
 	variablesUrlParser,
 } from 'pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection';
-import ContextMenu from 'periscope/components/ContextMenu';
 
 interface UseDrilldownDashboardVariablesArgs {
-	context: DrilldownContext | null;
-	/** Return to the base aggregate menu. */
-	onBack: () => void;
+	/** Group-by field filters from the clicked point (empty when the click has no group-by). */
+	filters: FilterData[];
+	/** Clicked query's telemetry signal — seeds a created variable's `dynamicSignal`. */
+	signal?: TelemetrytypesSignalDTO;
 	/** Close the popover after an action. */
 	onClose: () => void;
+}
+
+/** Set/Unset a matching dynamic variable's value, or Create one when none matches. */
+export enum DrilldownVariableActionKind {
+	Set = 'set',
+	Unset = 'unset',
+	Create = 'create',
+}
+
+/** A resolved "Dashboard Variables" menu entry; the caller renders it. */
+export interface DrilldownVariableAction {
+	fieldName: string;
+	fieldValue: string | number;
+	kind: DrilldownVariableActionKind;
+	/** Applies the action and closes the popover. */
+	onClick: () => void;
 }
 
 export interface UseDrilldownDashboardVariablesApi {
 	/** Whether the clicked point exposes any field to bind to a variable (gates the base-menu entry). */
 	hasFieldVariables: boolean;
-	/** The "Dashboard Variables" submenu content. */
-	items: ReactNode;
+	/** Resolved menu entries, one per group-by field on the clicked point. */
+	actions: DrilldownVariableAction[];
 }
 
 /**
- * The "Dashboard Variables" drilldown submenu — V1 `useDashboardVarConfig` parity. For each group-by
- * field on the clicked point it offers, against a matching dynamic variable, Set/Unset the value, or
- * Create the variable when none matches. Set/Unset are runtime-only (store + URL, never the spec, as
- * V2 selections don't persist); Create is the one persisted path — it appends a dynamic variable to
- * `spec.variables`.
+ * "Dashboard Variables" submenu logic (V1 `useDashboardVarConfig` parity). Set/Unset are runtime-only
+ * (store + URL — V2 selections don't persist); Create is the one path that patches `spec.variables`.
  */
 export function useDrilldownDashboardVariables({
-	context,
-	onBack,
+	filters,
+	signal,
 	onClose,
 }: UseDrilldownDashboardVariablesArgs): UseDrilldownDashboardVariablesApi {
 	const dashboardId = useDashboardStore((state) => state.dashboardId);
-	const { data } = useGetDashboardV2(
-		{ id: dashboardId },
-		{ query: { enabled: !!dashboardId } },
-	);
+	// The generated hook already gates itself on `enabled: !!id`, so no manual guard is needed.
+	const { data } = useGetDashboardV2({ id: dashboardId });
 	const variables = data?.data.spec?.variables;
 
 	const dynamicVariables = useMemo(
 		() =>
-			(variables ?? []).map(dtoToFormModel).filter((v) => v.type === 'DYNAMIC'),
+			(variables ?? [])
+				.filter(
+					(v) =>
+						(v.spec as DashboardtypesListVariableSpecDTO).plugin?.kind ===
+						DynamicPluginKind['signoz/DynamicVariable'],
+				)
+				.map(dtoToFormModel),
 		[variables],
 	);
 	const existingNames = useMemo(
@@ -78,19 +97,17 @@ export function useDrilldownDashboardVariables({
 	);
 	const { patchAsync } = useOptimisticPatch();
 
-	// Group-by field values on the clicked point — the candidates to bind to a variable. In V2 the
-	// enriched filters are already the clicked series'/row's group-by keys (V1 intersected manually).
 	const fieldVariables = useMemo<[string, string | number][]>(
 		() =>
-			(context?.filters ?? [])
+			filters
 				.filter(
 					(f) => f.filterKey && f.filterValue !== undefined && f.filterValue !== '',
 				)
 				.map((f) => [f.filterKey, f.filterValue]),
-		[context?.filters],
+		[filters],
 	);
 
-	// Runtime selection write — store + URL, mirroring VariablesBar's setSelection (no spec write).
+	// Runtime-only write (store + URL), never the spec — mirrors VariablesBar's setSelection.
 	const setSelection = useCallback(
 		(name: string, next: VariableSelection): void => {
 			setVariableValue(dashboardId, name, next);
@@ -115,14 +132,13 @@ export function useDrilldownDashboardVariables({
 				type: 'DYNAMIC',
 				multiSelect: true,
 				dynamicAttribute: fieldName,
-				dynamicSignal: context?.signal ?? DYNAMIC_SIGNAL_ALL,
+				dynamicSignal: signal ?? DYNAMIC_SIGNAL_ALL,
 			};
 			try {
 				await patchAsync(
 					buildVariablesPatch([...(variables ?? []), formModelToDto(model)]),
 				);
-				// Seed the new variable's runtime value to what was clicked. The created var is
-				// multi-select, so the value must be an array (the selector renders scalars as empty).
+				// Multi-select var → seed the value as an array (the selector renders scalars as empty).
 				setSelection(fieldName, { value: [fieldValue], allSelected: false });
 				toast.success(`Created variable "${fieldName}"`);
 			} catch {
@@ -130,86 +146,50 @@ export function useDrilldownDashboardVariables({
 			}
 			onClose();
 		},
-		[
-			existingNames,
-			context?.signal,
-			variables,
-			patchAsync,
-			setSelection,
-			onClose,
-		],
+		[existingNames, signal, variables, patchAsync, setSelection, onClose],
 	);
 
-	const contextItems = useMemo<JSX.Element>(
-		() => (
-			<>
-				{fieldVariables.map(([fieldName, fieldValue]) => {
-					const existing = dynamicVariables.find(
-						(v) => v.dynamicAttribute === fieldName,
-					);
+	const actions = useMemo<DrilldownVariableAction[]>(
+		() =>
+			fieldVariables.map(([fieldName, fieldValue]) => {
+				const existing = dynamicVariables.find(
+					(v) => v.dynamicAttribute === fieldName,
+				);
+				if (!existing) {
+					return {
+						fieldName,
+						fieldValue,
+						kind: DrilldownVariableActionKind.Create,
+						onClick: (): void => {
+							void handleCreate(fieldName, fieldValue);
+						},
+					};
+				}
 
-					if (existing) {
-						const current = selection[existing.name]?.value;
-						const isSame = Array.isArray(current)
-							? current.length === 1 && current[0] === fieldValue
-							: current === fieldValue;
+				const current = selection[existing.name]?.value;
+				const isSame = Array.isArray(current)
+					? current.length === 1 && current[0] === fieldValue
+					: current === fieldValue;
 
-						if (isSame) {
-							return (
-								<ContextMenu.Item
-									key={fieldName}
-									icon={<X size={16} />}
-									onClick={(): void => {
-										setSelection(existing.name, {
-											value: existing.multiSelect ? [] : '',
-											allSelected: false,
-										});
-										onClose();
-									}}
-								>
-									<span data-testid="drilldown-var-unset">
-										Unset <strong>${fieldName}</strong>
-									</span>
-								</ContextMenu.Item>
-							);
-						}
-						return (
-							<ContextMenu.Item
-								key={fieldName}
-								icon={<Settings size={16} />}
-								onClick={(): void => {
-									// Match the variable's shape: a multi-select selector renders a scalar
-									// value as empty, so wrap it in an array.
-									setSelection(existing.name, {
-										value: existing.multiSelect ? [fieldValue] : fieldValue,
-										allSelected: false,
-									});
-									onClose();
-								}}
-							>
-								<span data-testid="drilldown-var-set">
-									Set <strong>${fieldName}</strong> to <strong>{fieldValue}</strong>
-								</span>
-							</ContextMenu.Item>
-						);
-					}
+				// Multi-select values must be arrays (a scalar renders as empty in the selector).
+				const cleared = existing.multiSelect ? [] : '';
+				const assigned = existing.multiSelect ? [fieldValue] : fieldValue;
 
-					return (
-						<ContextMenu.Item
-							key={fieldName}
-							icon={<Plus size={16} />}
-							onClick={(): void => {
-								void handleCreate(fieldName, fieldValue);
-							}}
-						>
-							<span data-testid="drilldown-var-create">
-								Create var <strong>${fieldName}</strong>:<strong>{fieldValue}</strong>
-							</span>
-						</ContextMenu.Item>
-					);
-				})}
-			</>
-		),
+				return {
+					fieldName,
+					fieldValue,
+					kind: isSame
+						? DrilldownVariableActionKind.Unset
+						: DrilldownVariableActionKind.Set,
+					onClick: (): void => {
+						setSelection(existing.name, {
+							value: isSame ? cleared : assigned,
+							allSelected: false,
+						});
+						onClose();
+					},
+				};
+			}),
 		[
 			fieldVariables,
 			dynamicVariables,
@@ -220,25 +200,5 @@ export function useDrilldownDashboardVariables({
 		],
 	);
 
-	const items = useMemo<ReactNode>(
-		() => (
-			<>
-				<ContextMenu.Header>
-					<div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-						<ArrowLeft size={14} style={{ cursor: 'pointer' }} onClick={onBack} />
-						<span>Dashboard Variables</span>
-					</div>
-				</ContextMenu.Header>
-				<OverlayScrollbar
-					style={{ maxHeight: '200px' }}
-					options={{ overflow: { x: 'hidden' } }}
-				>
-					{contextItems}
-				</OverlayScrollbar>
-			</>
-		),
-		[contextItems, onBack],
-	);
-
-	return { hasFieldVariables: fieldVariables.length > 0, items };
+	return { hasFieldVariables: fieldVariables.length > 0, actions };
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
@@ -1,0 +1,244 @@
+import { useCallback, useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { ArrowLeft, Plus, Settings, X } from '@signozhq/icons';
+import { toast } from '@signozhq/ui/sonner';
+import { useGetDashboardV2 } from 'api/generated/services/dashboard';
+import OverlayScrollbar from 'components/OverlayScrollbar/OverlayScrollbar';
+import { useQueryState } from 'nuqs';
+import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
+import {
+	dtoToFormModel,
+	formModelToDto,
+} from 'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters';
+import {
+	DYNAMIC_SIGNAL_ALL,
+	emptyVariableFormModel,
+	type VariableFormModel,
+} from 'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel';
+import { buildVariablesPatch } from 'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variablePatchOps';
+import { useOptimisticPatch } from 'pages/DashboardPageV2/DashboardContainer/hooks/useOptimisticPatch';
+import { selectVariableValues } from 'pages/DashboardPageV2/DashboardContainer/store/slices/variableSelectionSlice';
+import { useDashboardStore } from 'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore';
+import type { VariableSelection } from 'pages/DashboardPageV2/DashboardContainer/VariablesBar/selectionTypes';
+import {
+	ALL_SELECTED,
+	variablesUrlParser,
+} from 'pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection';
+import ContextMenu from 'periscope/components/ContextMenu';
+
+interface UseDrilldownDashboardVariablesArgs {
+	context: DrilldownContext | null;
+	/** Return to the base aggregate menu. */
+	onBack: () => void;
+	/** Close the popover after an action. */
+	onClose: () => void;
+}
+
+export interface UseDrilldownDashboardVariablesApi {
+	/** Whether the clicked point exposes any field to bind to a variable (gates the base-menu entry). */
+	hasFieldVariables: boolean;
+	/** The "Dashboard Variables" submenu content. */
+	items: ReactNode;
+}
+
+/**
+ * The "Dashboard Variables" drilldown submenu — V1 `useDashboardVarConfig` parity. For each group-by
+ * field on the clicked point it offers, against a matching dynamic variable, Set/Unset the value, or
+ * Create the variable when none matches. Set/Unset are runtime-only (store + URL, never the spec, as
+ * V2 selections don't persist); Create is the one persisted path — it appends a dynamic variable to
+ * `spec.variables`.
+ */
+export function useDrilldownDashboardVariables({
+	context,
+	onBack,
+	onClose,
+}: UseDrilldownDashboardVariablesArgs): UseDrilldownDashboardVariablesApi {
+	const dashboardId = useDashboardStore((state) => state.dashboardId);
+	const { data } = useGetDashboardV2(
+		{ id: dashboardId },
+		{ query: { enabled: !!dashboardId } },
+	);
+	const variables = data?.data.spec?.variables;
+
+	const dynamicVariables = useMemo(
+		() =>
+			(variables ?? []).map(dtoToFormModel).filter((v) => v.type === 'DYNAMIC'),
+		[variables],
+	);
+	const existingNames = useMemo(
+		() => new Set((variables ?? []).map((v) => dtoToFormModel(v).name)),
+		[variables],
+	);
+
+	const selection = useDashboardStore(selectVariableValues(dashboardId));
+	const setVariableValue = useDashboardStore((state) => state.setVariableValue);
+	const [, setUrlValues] = useQueryState(
+		'variables',
+		variablesUrlParser.withOptions({ history: 'replace' }),
+	);
+	const { patchAsync } = useOptimisticPatch();
+
+	// Group-by field values on the clicked point — the candidates to bind to a variable. In V2 the
+	// enriched filters are already the clicked series'/row's group-by keys (V1 intersected manually).
+	const fieldVariables = useMemo<[string, string | number][]>(
+		() =>
+			(context?.filters ?? [])
+				.filter(
+					(f) => f.filterKey && f.filterValue !== undefined && f.filterValue !== '',
+				)
+				.map((f) => [f.filterKey, f.filterValue]),
+		[context?.filters],
+	);
+
+	// Runtime selection write — store + URL, mirroring VariablesBar's setSelection (no spec write).
+	const setSelection = useCallback(
+		(name: string, next: VariableSelection): void => {
+			setVariableValue(dashboardId, name, next);
+			void setUrlValues((prev) => ({
+				...(prev ?? {}),
+				[name]: next.allSelected ? ALL_SELECTED : next.value,
+			}));
+		},
+		[dashboardId, setVariableValue, setUrlValues],
+	);
+
+	const handleCreate = useCallback(
+		async (fieldName: string, fieldValue: string | number): Promise<void> => {
+			if (existingNames.has(fieldName)) {
+				toast.error(`Variable "${fieldName}" already exists`);
+				return;
+			}
+			const model: VariableFormModel = {
+				...emptyVariableFormModel(),
+				name: fieldName,
+				description: `Created from panel drilldown (field: ${fieldName})`,
+				type: 'DYNAMIC',
+				multiSelect: true,
+				dynamicAttribute: fieldName,
+				dynamicSignal: context?.signal ?? DYNAMIC_SIGNAL_ALL,
+			};
+			try {
+				await patchAsync(
+					buildVariablesPatch([...(variables ?? []), formModelToDto(model)]),
+				);
+				// Seed the new variable's runtime value to what was clicked. The created var is
+				// multi-select, so the value must be an array (the selector renders scalars as empty).
+				setSelection(fieldName, { value: [fieldValue], allSelected: false });
+				toast.success(`Created variable "${fieldName}"`);
+			} catch {
+				toast.error('Failed to create variable');
+			}
+			onClose();
+		},
+		[
+			existingNames,
+			context?.signal,
+			variables,
+			patchAsync,
+			setSelection,
+			onClose,
+		],
+	);
+
+	const contextItems = useMemo<JSX.Element>(
+		() => (
+			<>
+				{fieldVariables.map(([fieldName, fieldValue]) => {
+					const existing = dynamicVariables.find(
+						(v) => v.dynamicAttribute === fieldName,
+					);
+
+					if (existing) {
+						const current = selection[existing.name]?.value;
+						const isSame = Array.isArray(current)
+							? current.length === 1 && current[0] === fieldValue
+							: current === fieldValue;
+
+						if (isSame) {
+							return (
+								<ContextMenu.Item
+									key={fieldName}
+									icon={<X size={16} />}
+									onClick={(): void => {
+										setSelection(existing.name, {
+											value: existing.multiSelect ? [] : '',
+											allSelected: false,
+										});
+										onClose();
+									}}
+								>
+									<span data-testid="drilldown-var-unset">
+										Unset <strong>${fieldName}</strong>
+									</span>
+								</ContextMenu.Item>
+							);
+						}
+						return (
+							<ContextMenu.Item
+								key={fieldName}
+								icon={<Settings size={16} />}
+								onClick={(): void => {
+									// Match the variable's shape: a multi-select selector renders a scalar
+									// value as empty, so wrap it in an array.
+									setSelection(existing.name, {
+										value: existing.multiSelect ? [fieldValue] : fieldValue,
+										allSelected: false,
+									});
+									onClose();
+								}}
+							>
+								<span data-testid="drilldown-var-set">
+									Set <strong>${fieldName}</strong> to <strong>{fieldValue}</strong>
+								</span>
+							</ContextMenu.Item>
+						);
+					}
+
+					return (
+						<ContextMenu.Item
+							key={fieldName}
+							icon={<Plus size={16} />}
+							onClick={(): void => {
+								void handleCreate(fieldName, fieldValue);
+							}}
+						>
+							<span data-testid="drilldown-var-create">
+								Create var <strong>${fieldName}</strong>:<strong>{fieldValue}</strong>
+							</span>
+						</ContextMenu.Item>
+					);
+				})}
+			</>
+		),
+		[
+			fieldVariables,
+			dynamicVariables,
+			selection,
+			setSelection,
+			handleCreate,
+			onClose,
+		],
+	);
+
+	const items = useMemo<ReactNode>(
+		() => (
+			<>
+				<ContextMenu.Header>
+					<div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+						<ArrowLeft size={14} style={{ cursor: 'pointer' }} onClick={onBack} />
+						<span>Dashboard Variables</span>
+					</div>
+				</ContextMenu.Header>
+				<OverlayScrollbar
+					style={{ maxHeight: '200px' }}
+					options={{ overflow: { x: 'hidden' } }}
+				>
+					{contextItems}
+				</OverlayScrollbar>
+			</>
+		),
+		[contextItems, onBack],
+	);
+
+	return { hasFieldVariables: fieldVariables.length > 0, items };
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
@@ -20,11 +20,12 @@ import {
 export const ALL_SELECTED = '__ALL__';
 
 /** `?variables=` holds `{ [name]: value }` (ALL encoded as the sentinel). */
-const variablesUrlParser = parseAsJson<Record<string, SelectedVariableValue>>(
-	(v) =>
-		typeof v === 'object' && v !== null
-			? (v as Record<string, SelectedVariableValue>)
-			: null,
+export const variablesUrlParser = parseAsJson<
+	Record<string, SelectedVariableValue>
+>((v) =>
+	typeof v === 'object' && v !== null
+		? (v as Record<string, SelectedVariableValue>)
+		: null,
 );
 
 function defaultSelection(model: VariableFormModel): VariableSelection {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
@@ -38,22 +38,14 @@ function DashboardContainer({
 		user.role,
 	);
 
-	// Publish edit context to the store so hooks/components read it from there
-	// instead of receiving dashboardId/isEditable/refetch as props down the tree.
+	// Seed during render (not an effect) so the first Panel render already sees the id —
+	// useDashboardFetchRequired throws on a missing id. setEditContext self-guards.
 	const setEditContext = useDashboardStore((s) => s.setEditContext);
-	useEffect(() => {
-		setEditContext({
-			dashboardId: dashboard.id,
-			isEditable: !dashboard.locked && editDashboardPermission,
-			refetch,
-		});
-	}, [
-		dashboard.id,
-		dashboard.locked,
-		editDashboardPermission,
+	setEditContext({
+		dashboardId: dashboard.id,
+		isEditable: !dashboard.locked && editDashboardPermission,
 		refetch,
-		setEditContext,
-	]);
+	});
 
 	// Resolve the variable selection into the V5 query payload and publish it to
 	// the store, so each panel's query substitutes the bar's selected values.

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/editContextSlice.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/editContextSlice.ts
@@ -24,11 +24,20 @@ export const createEditContextSlice: StateCreator<
 	[['zustand/persist', unknown]],
 	[],
 	EditContextSlice
-> = (set) => ({
+> = (set, get) => ({
 	dashboardId: '',
 	isEditable: false,
 	refetch: (): void => undefined,
+	// Idempotent (no-op when unchanged) so it's safe to call during render.
 	setEditContext: (ctx): void => {
+		const { dashboardId, isEditable, refetch } = get();
+		if (
+			dashboardId === ctx.dashboardId &&
+			isEditable === ctx.isEditable &&
+			refetch === ctx.refetch
+		) {
+			return;
+		}
 		set({
 			dashboardId: ctx.dashboardId,
 			isEditable: ctx.isEditable,


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Completes V1 drill-down parity for V2 dashboard panels with the last two remaining features:

**Dashboard Variables submenu.** From a grouped click, the aggregate menu gains a **Dashboard Variables** entry (shown only when the clicked point carries group-by fields). Per group-by field it offers, against a matching dynamic variable: **Set** `$var` to the clicked value (value differs), **Unset** `$var` (already holds it), or **Create var** (none matches). Set/Unset are runtime-only (Zustand store + URL — matching how V2 variable selections work, never the spec); **Create** is the one persisted path, appending a dynamic variable to `spec.variables` via the optimistic patch.

**"View Trace Details" data link.** The aggregate menu shows a `/trace/{id}` link when the clicked point's filters carry a `trace_id` (V1 `getDataLinks` parity).

**Approach:** new `Panel/hooks/useDrilldownDashboardVariables.tsx` mirrors V1's `useDashboardVarConfig` and is wired into `useDrilldown` as a new `subMenu` arm; new pure `Panels/utils/drilldown/getDataLinks.ts` for the trace link. Variable definitions are read from `useGetDashboardV2`; selections write through the store + URL. `variablesUrlParser` is exported from `useVariableSelection` so the submenu reuses the runtime-selection URL contract **without** re-running that hook's seeding effect (which would double-fire per panel).

#### Screenshots / Screen Recordings (if applicable)
> _To be added by author — recording of Set/Create dashboard variable from a chart click updating the variable bar, and the View Trace Details link._

#### Issues closed by this PR
Closes https://github.com/SigNoz/engineering-pod/issues/5488

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> N/A — feature, not a bug fix. (One value-shape issue was caught and fixed during review — see _Notes for Reviewers_.)

---

### 🧪 Testing Strategy

- **Tests added/updated:** unit tests for `getDataLinks` and `useDrilldownDashboardVariables` (Set/Unset/Create, multi- vs single-select value shape, non-dynamic var ignored); integration coverage in `useDrilldown.test.tsx` (entry shown/hidden by field availability, submenu swap). `tsgo --noEmit` clean; `oxlint`/`oxfmt` clean; drill-down suite 42/42 green.
- **Manual verification:** set a dashboard variable from a chart drill-down and confirmed the variable-bar selector reflects it (this surfaced — and fixed — the multi-select value-shape bug below).
- **Edge cases covered:** multi-select vs single-select value shape; group-by-less clicks (no entry); a non-dynamic variable with the same attribute (still offers Create); duplicate-name guard on Create.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** adds one entry + a submenu to the V2 drill-down aggregate menu, plus the trace data link. Set/Unset touch runtime variable state (store + URL); Create is the only path that persists to the dashboard spec (via the existing optimistic patch).
- **Potential regressions:** minimal — additive menu items. `useVariableSelection` change is a single new `export` (no behaviour change); the submenu deliberately does **not** reuse that hook to avoid re-firing its seeding effect.
- **Rollback plan:** revert the PR; the menu loses the Dashboard Variables entry and the trace link, rest of drill-down intact.

---

### 📝 Changelog
> V2 dashboards are behind a feature flag (not yet GA) — this entry applies when V2 ships.

| Field | Value |
|------|-------|
| Deployment Type | OSS / Cloud / Enterprise |
| Change Type | Feature |
| Description | V2 dashboard drill-down can set/unset/create a dashboard variable from a clicked value, and links to trace details when a trace_id is present. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested (variable set-from-drill-down flow)
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Top of the panel drill-down **stack** — review/merge bottom-up: **#11895** (base) → `…-drilldown-filter-by-value` → **#11896** (breakout) → **#11897** (context links) → **this PR (#11964)**. Targets `feat/dashboards-v2-drilldown-context-links`, **not** `main`.

- **Value-shape fix worth a look:** a multi-select variable's selection must be an array — the selector renders a scalar into a multi-select as *empty*. Set/Create write `[value]` for multi-select vars (created vars are always multi-select); Unset writes `[]` / `''` by the same rule.
- **Create persists to the spec** immediately on click (matching V1), with a success/error toast; Set/Unset are runtime-only.