### PR TITLE
fix(frontend): use allowlist for top nav routes

### DIFF
--- a/frontend/src/container/TopNav/index.tsx
+++ b/frontend/src/container/TopNav/index.tsx
@@ -5,16 +5,34 @@ import ROUTES from 'constants/routes';
 
 import NewExplorerCTA from '../NewExplorerCTA';
 import DateTimeSelector from './DateTimeSelectionV2';
-import { routesToDisable, routesToSkip } from './DateTimeSelectionV2/constants';
+import { routesToDisable } from './DateTimeSelectionV2/constants';
 
 import './TopNav.styles.scss';
+
+const routesToShowTopNav = [
+	ROUTES.SERVICE_MAP,
+	ROUTES.TRACE,
+	ROUTES.APPLICATION,
+	ROUTES.SERVICE_METRICS,
+	ROUTES.ALL_DASHBOARD,
+	ROUTES.DASHBOARD,
+	ROUTES.ALL_ERROR,
+	ROUTES.TRACE_EXPLORER,
+	ROUTES.LOGS,
+	ROUTES.LIVE_LOGS,
+	ROUTES.MESSAGING_QUEUES_KAFKA,
+	ROUTES.MESSAGING_QUEUES_CELERY_TASK,
+	ROUTES.MESSAGING_QUEUES_OVERVIEW,
+	ROUTES.MESSAGING_QUEUES_KAFKA_DETAIL,
+	ROUTES.INFRASTRUCTURE_MONITORING_HOSTS,
+];
 
 function TopNav(): JSX.Element | null {
 	const { location } = useHistory();
 
-	const isRouteToSkip = useMemo(
+	const shouldShowTopNav = useMemo(
 		() =>
-			routesToSkip.some((route) =>
+			routesToShowTopNav.some((route) =>
 				matchPath(location.pathname, { path: route, exact: true }),
 			),
 		[location.pathname],
@@ -38,17 +56,17 @@ function TopNav(): JSX.Element | null {
 		[location.pathname],
 	);
 
-	if (isSignUpPage || isDisabled || isRouteToSkip || isAlertCreationPage) {
+	if (isSignUpPage || isDisabled || !shouldShowTopNav || isAlertCreationPage) {
 		return null;
 	}
 
-	return !isRouteToSkip ? (
+	return (
 		<div className="top-nav-container">
 			<NewExplorerCTA />
 			<DateTimeSelector showAutoRefresh />
 			<HeaderRightSection enableShare enableFeedback enableAnnouncements={false} />
 		</div>
-	) : null;
+	);
 }
 
 export default TopNav;


### PR DESCRIPTION
## Summary
Switch TopNav visibility from a denylist to a small allowlist so the global header is rendered only on the routes that explicitly need it.

## Changes
- Replaced the `routesToSkip` flow with a local `routesToShowTopNav` allowlist
- Kept the existing disabled-date-time-picker routes intact
- Preserved the special-case exclusions for signup and alert creation

## Validation
- `pnpm exec oxlint src/container/TopNav/index.tsx src/container/InfraMonitoringK8s/Base/K8sBaseDetails.tsx src/container/InfraMonitoringHosts/constants.tsx src/container/InfraMonitoringHosts/Hosts.tsx`

Fixes #1659