### PR TITLE
fix(frontend): use hostname for infra host logs

### DIFF
--- a/frontend/src/container/InfraMonitoringHosts/Hosts.tsx
+++ b/frontend/src/container/InfraMonitoringHosts/Hosts.tsx
@@ -26,8 +26,9 @@ import {
 	hostDetailsMetadataConfig,
 	hostGetEntityName,
 	hostGetSelectedItemFilters,
+	hostInitialLogFilter,
 	hostInitialEventsFilter,
-	hostInitialLogTracesFilter,
+	hostInitialTracesFilter,
 	hostWidgetInfo,
 } from './constants';
 import {
@@ -115,9 +116,15 @@ function Hosts(): JSX.Element {
 		[dotMetricsEnabled],
 	);
 
+	const getInitialLogFilters = useCallback(
+		(host: import('api/infraMonitoring/getHostLists').HostData) =>
+			hostInitialLogFilter(host),
+		[],
+	);
+
 	const getInitialLogTracesFilters = useCallback(
 		(host: import('api/infraMonitoring/getHostLists').HostData) =>
-			hostInitialLogTracesFilter(host, dotMetricsEnabled),
+			hostInitialTracesFilter(host, dotMetricsEnabled),
 		[dotMetricsEnabled],
 	);
 
@@ -181,7 +188,9 @@ function Hosts(): JSX.Element {
 				getSelectedItemFilters={getSelectedItemFilters}
 				fetchEntityData={fetchEntityData}
 				getEntityName={hostGetEntityName}
+				getInitialLogFilters={getInitialLogFilters}
 				getInitialLogTracesFilters={getInitialLogTracesFilters}
+				getInitialTracesFilters={getInitialLogTracesFilters}
 				getInitialEventsFilters={hostInitialEventsFilter}
 				metadataConfig={hostDetailsMetadataConfig}
 				entityWidgetInfo={hostWidgetInfo}

--- a/frontend/src/container/InfraMonitoringHosts/constants.tsx
+++ b/frontend/src/container/InfraMonitoringHosts/constants.tsx
@@ -120,7 +120,11 @@ export function hostGetSelectedItemFilters(
 	};
 }
 
-export function hostInitialLogTracesFilter(
+export function hostInitialLogFilter(_host: HostData): TagFilterItem[] {
+	return [createFilterItem('hostname', '')];
+}
+
+export function hostInitialTracesFilter(
 	host: HostData,
 	dotMetricsEnabled: boolean,
 ): TagFilterItem[] {

--- a/frontend/src/container/InfraMonitoringK8s/Base/K8sBaseDetails.tsx
+++ b/frontend/src/container/InfraMonitoringK8s/Base/K8sBaseDetails.tsx
@@ -100,6 +100,8 @@ export interface K8sBaseDetailsProps<T> {
 	// Entity configuration
 	getEntityName: (entity: T) => string;
 	getInitialLogTracesFilters: (entity: T) => TagFilterItem[];
+	getInitialLogFilters?: (entity: T) => TagFilterItem[];
+	getInitialTracesFilters?: (entity: T) => TagFilterItem[];
 	getInitialEventsFilters: (entity: T) => TagFilterItem[];
 	metadataConfig: K8sDetailsMetadataConfig<T>[];
 	entityWidgetInfo: {
@@ -165,6 +167,8 @@ export default function K8sBaseDetails<T>({
 	fetchEntityData,
 	getEntityName,
 	getInitialLogTracesFilters,
+	getInitialLogFilters,
+	getInitialTracesFilters,
 	getInitialEventsFilters,
 	metadataConfig,
 	entityWidgetInfo,
@@ -224,16 +228,31 @@ export default function K8sBaseDetails<T>({
 	const entity = entityResponse?.data ?? null;
 	const hasResponseError = !!entityResponse?.error;
 
-	const logsAndTracesInitialExpression = useMemo(() => {
+	const logsInitialExpression = useMemo(() => {
 		if (!entity) {
 			return '';
 		}
+		const initialFilters =
+			getInitialLogFilters?.(entity) ?? getInitialLogTracesFilters(entity);
 		const primaryFiltersOnly = {
 			op: 'AND' as const,
-			items: getInitialLogTracesFilters(entity),
+			items: initialFilters,
 		};
 		return convertFiltersToExpression(primaryFiltersOnly).expression;
-	}, [entity, getInitialLogTracesFilters]);
+	}, [entity, getInitialLogFilters, getInitialLogTracesFilters]);
+
+	const tracesInitialExpression = useMemo(() => {
+		if (!entity) {
+			return '';
+		}
+		const initialFilters =
+			getInitialTracesFilters?.(entity) ?? getInitialLogTracesFilters(entity);
+		const primaryFiltersOnly = {
+			op: 'AND' as const,
+			items: initialFilters,
+		};
+		return convertFiltersToExpression(primaryFiltersOnly).expression;
+	}, [entity, getInitialLogTracesFilters, getInitialTracesFilters]);
 
 	const eventsInitialExpression = useMemo(() => {
 		if (!entity) {
@@ -390,7 +409,7 @@ export default function K8sBaseDetails<T>({
 
 		if (selectedView === VIEW_TYPES.LOGS) {
 			const fullExpression = combineInitialAndUserExpression(
-				logsAndTracesInitialExpression,
+				logsInitialExpression,
 				userLogsExpression || '',
 			);
 
@@ -415,7 +434,7 @@ export default function K8sBaseDetails<T>({
 			openInNewTab(`${ROUTES.LOGS_EXPLORER}?${urlQuery.toString()}`);
 		} else if (selectedView === VIEW_TYPES.TRACES) {
 			const fullExpression = combineInitialAndUserExpression(
-				logsAndTracesInitialExpression,
+				tracesInitialExpression,
 				userTracesExpression || '',
 			);
 
@@ -655,7 +674,7 @@ export default function K8sBaseDetails<T>({
 							selectedInterval={selectedInterval}
 							queryKey={`${queryKeyPrefix}Logs`}
 							category={category}
-							initialExpression={logsAndTracesInitialExpression}
+							initialExpression={logsInitialExpression}
 						/>
 					)}
 					{effectiveView === VIEW_TYPES.TRACES && (
@@ -666,7 +685,7 @@ export default function K8sBaseDetails<T>({
 							selectedInterval={selectedInterval}
 							queryKey={`${queryKeyPrefix}Traces`}
 							category={category}
-							initialExpression={logsAndTracesInitialExpression}
+							initialExpression={tracesInitialExpression}
 						/>
 					)}
 					{effectiveView === VIEW_TYPES.EVENTS && tabVisibility.showEvents && (


### PR DESCRIPTION
## Summary
Fix the Infrastructure host detail Logs tab so it uses the logs index key (`hostname`) instead of the trace-style resource attribute (`host.name`).

## Changes
- Split the shared host initial filter helper into separate log and trace presets
- Keep traces on `host.name` / `host_name` as before
- Use `hostname` for the host Logs tab filter expression
- Update the shared K8s base details component to accept separate log and trace initial expressions

## Validation
- `pnpm exec oxlint src/container/TopNav/index.tsx src/container/InfraMonitoringK8s/Base/K8sBaseDetails.tsx src/container/InfraMonitoringHosts/constants.tsx src/container/InfraMonitoringHosts/Hosts.tsx`

Fixes #11314