### PR TITLE
fix(dashboards-v2): list panel pagination, spanGaps clamp, discard dialog & create-alert fixes

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/Header/Header.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/Header/Header.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { SolidAlertTriangle, X } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
-import { ConfirmDialog } from '@signozhq/ui/dialog';
+import { DialogWrapper } from '@signozhq/ui/dialog';
 import { Divider } from '@signozhq/ui/divider';
 import { Typography } from '@signozhq/ui/typography';
 import { useConfirmableAction } from 'hooks/useConfirmableAction';
@@ -61,24 +61,42 @@ function Header({
 				</Button>
 			</div>
 
-			<ConfirmDialog
+			<DialogWrapper
 				open={discard.open}
-				onOpenChange={(next): void => {
+				onOpenChange={(next: boolean): void => {
 					if (!next) {
 						discard.cancel();
 					}
 				}}
 				title="Discard changes?"
 				titleIcon={<SolidAlertTriangle size={14} color="#fdd600" />}
-				confirmText="Discard"
-				confirmColor="destructive"
-				cancelText="Keep editing"
-				onConfirm={discard.confirm}
-				onCancel={discard.cancel}
-				data-testid="panel-editor-v2-discard-modal"
+				testId="panel-editor-v2-discard-modal"
+				footer={
+					<>
+						<Button
+							type="button"
+							variant="solid"
+							color="destructive"
+							data-testid="panel-editor-v2-discard-confirm"
+							loading={discard.isPending}
+							onClick={discard.confirm}
+						>
+							Discard
+						</Button>
+						<Button
+							type="button"
+							variant="outlined"
+							color="secondary"
+							data-testid="panel-editor-v2-discard-cancel"
+							onClick={discard.cancel}
+						>
+							Keep editing
+						</Button>
+					</>
+				}
 			>
 				<Typography>Your unsaved edits to this panel will be lost.</Typography>
-			</ConfirmDialog>
+			</DialogWrapper>
 		</div>
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/PreviewPane/PreviewPane.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/PreviewPane/PreviewPane.tsx
@@ -23,6 +23,8 @@ interface PreviewPaneProps {
 	data: PanelQueryData;
 	/** Any fetch in flight — drives the header spinner and the body's loading state. */
 	isFetching: boolean;
+	/** Showing a prior page's data while the next loads; forwarded so the list shows skeleton rows. */
+	isPreviousData?: boolean;
 	error: Error | null;
 	/** Re-run the query (drives PanelBody's error-state retry). */
 	refetch: () => void;
@@ -43,6 +45,7 @@ function PreviewPane({
 	panelDefinition,
 	data,
 	isFetching,
+	isPreviousData,
 	error,
 	refetch,
 	onDragSelect,
@@ -87,6 +90,7 @@ function PreviewPane({
 						panelId={panelId}
 						data={data}
 						isFetching={isFetching}
+						isPreviousData={isPreviousData}
 						error={error}
 						refetch={refetch}
 						onDragSelect={onDragSelect}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/usePanelTypeSwitch.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/usePanelTypeSwitch.test.ts
@@ -49,6 +49,7 @@ const LIST_QUERIES = [{ id: 'list-q' }] as unknown as NonNullable<
 const TRANSFORMED = {
 	id: 'transformed',
 	queryType: 'builder',
+	builder: { queryData: [{ orderBy: [] }] },
 } as unknown as Query;
 const CONVERTED = [{ id: 'converted' }] as unknown as NonNullable<
 	DashboardtypesPanelSpecDTO['queries']
@@ -131,7 +132,39 @@ describe('usePanelTypeSwitch', () => {
 		expect(next.plugin.kind).toBe('signoz/ListPanel');
 		expect(next.plugin.spec).toBe(SWITCHED_SPEC);
 		expect(next.queries).toBe(CONVERTED);
-		expect(state.redirectWithQueryBuilderData).toHaveBeenCalledWith(TRANSFORMED);
+		const redirected = state.redirectWithQueryBuilderData.mock
+			.calls[0][0] as Query;
+		expect(redirected.builder.queryData[0].orderBy).toStrictEqual([
+			{ columnName: 'timestamp', order: 'desc' },
+		]);
+	});
+
+	it('seeds timestamp-desc Order By on every query when switching to a List panel', () => {
+		const setSpec = jest.fn();
+		mockUseQueryBuilder.mockReturnValue(
+			builderState({ id: 'ts-current', queryType: 'builder' } as Query),
+		);
+		mockHandleQueryChange.mockReturnValue({
+			id: 'transformed',
+			queryType: 'builder',
+			builder: { queryData: [{ orderBy: [] }, { orderBy: undefined }] },
+		} as unknown as Query);
+
+		const { result } = renderHook(() =>
+			usePanelTypeSwitch({
+				spec: makeSpec('signoz/TimeSeriesPanel', {}, TABLE_QUERIES),
+				panelType: PANEL_TYPES.TIME_SERIES,
+				setSpec,
+			}),
+		);
+		act(() => result.current.onChangePanelKind('signoz/ListPanel'));
+
+		const [persisted] = mockToPerses.mock.calls[0] as [Query];
+		persisted.builder.queryData.forEach((qd) => {
+			expect(qd.orderBy).toStrictEqual([
+				{ columnName: 'timestamp', order: 'desc' },
+			]);
+		});
 	});
 
 	it('coerces the query type when the new kind disallows it (promql → List)', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/usePanelTypeSwitch.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/usePanelTypeSwitch.ts
@@ -11,7 +11,10 @@ import {
 	type PartialPanelTypes,
 } from 'container/NewWidget/utils';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
-import type { Query } from 'types/api/queryBuilder/queryBuilderData';
+import type {
+	OrderByPayload,
+	Query,
+} from 'types/api/queryBuilder/queryBuilderData';
 
 import { resolveQueryType } from '../../Panels/capabilities';
 import {
@@ -24,6 +27,25 @@ import {
 	getSwitchedPluginSpec,
 	type SwitchedPluginSpec,
 } from '../getSwitchedPluginSpec';
+
+// V1's handleQueryChange clears orderBy for lists; re-seed the fresh-list default (timestamp desc).
+const DEFAULT_LIST_ORDER_BY: OrderByPayload[] = [
+	{ columnName: 'timestamp', order: 'desc' },
+];
+
+function withDefaultListOrder(query: Query): Query {
+	return {
+		...query,
+		builder: {
+			...query.builder,
+			queryData: query.builder.queryData.map((qd) =>
+				qd.orderBy && qd.orderBy.length > 0
+					? qd
+					: { ...qd, orderBy: DEFAULT_LIST_ORDER_BY },
+			),
+		},
+	};
+}
 
 /** What a kind looks like when you leave it; restored verbatim if you return. */
 interface KindState {
@@ -116,16 +138,21 @@ export function usePanelTypeSwitch({
 				{ ...query, queryType },
 				panelTypeRef.current,
 			);
+			// Match a fresh list panel's default order so the builder's Order By isn't empty.
+			const nextQuery =
+				newPanelType === PANEL_TYPES.LIST
+					? withDefaultListOrder(transformed)
+					: transformed;
 			const signal = getBuilderQueries(currentSpec.queries)[0]
 				?.signal as TelemetrytypesSignalDTO;
 
 			setSpec(
 				buildSpec(
 					getSwitchedPluginSpec(currentSpec, newKind, signal),
-					toPerses(transformed, newPanelType),
+					toPerses(nextQuery, newPanelType),
 				),
 			);
-			redirectWithQueryBuilderData(transformed);
+			redirectWithQueryBuilderData(nextQuery);
 		},
 		[setSpec, redirectWithQueryBuilderData],
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
@@ -102,12 +102,19 @@ function PanelEditorContainer({
 
 	// One shared query result for the whole editor; the preview renders it.
 	const panelDefinition = getPanelDefinition(draft.spec.plugin.kind);
-	const { data, isFetching, error, cancelQuery, refetch, pagination } =
-		usePanelQuery({
-			panel: draft,
-			panelId,
-			enabled: !!panelDefinition,
-		});
+	const {
+		data,
+		isFetching,
+		isPreviousData,
+		error,
+		cancelQuery,
+		refetch,
+		pagination,
+	} = usePanelQuery({
+		panel: draft,
+		panelId,
+		enabled: !!panelDefinition,
+	});
 
 	// A new panel's default signal (its kind's first supported) — seeds the query and columns.
 	const defaultSignal = panelDefinition.supportedSignals[0];
@@ -235,6 +242,7 @@ function PanelEditorContainer({
 										panelDefinition={panelDefinition}
 										data={data}
 										isFetching={isFetching}
+										isPreviousData={isPreviousData}
 										error={error}
 										refetch={refetch}
 										onDragSelect={onDragSelect}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/ListPanel/Renderer.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/ListPanel/Renderer.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef } from 'react';
-import { Select, Table } from 'antd';
+import { Select, Skeleton, Table } from 'antd';
 import cx from 'classnames';
 import { Button } from '@signozhq/ui/button';
 import { ChevronLeft, ChevronRight } from '@signozhq/icons';
@@ -36,6 +36,7 @@ function ListPanelRenderer({
 	refetch,
 	searchTerm = '',
 	pagination,
+	isPreviousData = false,
 }: PanelRendererProps<'signoz/ListPanel'>): JSX.Element {
 	// Pin the header while the body scrolls (shared with the Table kind).
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -115,6 +116,25 @@ function ListPanelRenderer({
 	// Show the footer whenever the panel pages server-side, so the page-size picker stays reachable (V1 parity).
 	const showPager = !!pagination;
 
+	// While the next page loads, swap the stale rows (held by keepPreviousData) for skeleton bars,
+	// keeping the header + pager. Row count mirrors the page being left.
+	const skeletonRowCount = dataSource.length || pagination?.pageSize || 10;
+	const skeletonColumns = useMemo(
+		() =>
+			resizableColumns.map((col) => ({
+				...col,
+				render: (): JSX.Element => <Skeleton.Input active block size="small" />,
+			})),
+		[resizableColumns],
+	);
+	const skeletonRows = useMemo(
+		() =>
+			Array.from({ length: skeletonRowCount }, (_, index) => ({
+				key: `skeleton-${index}`,
+			})) as unknown as typeof filteredDataSource,
+		[skeletonRowCount],
+	);
+
 	return (
 		<div
 			ref={containerRef}
@@ -134,13 +154,13 @@ function ListPanelRenderer({
 						<Table
 							size="small"
 							tableLayout="fixed"
-							columns={resizableColumns}
+							columns={isPreviousData ? skeletonColumns : resizableColumns}
 							components={components}
-							dataSource={filteredDataSource}
+							dataSource={isPreviousData ? skeletonRows : filteredDataSource}
 							pagination={false}
 							// Vertical scroll only; `x: 'max-content'` forced a content-width min that pushed columns off-screen.
 							scroll={{ y: scrollY }}
-							onRow={onRow}
+							onRow={isPreviousData ? undefined : onRow}
 						/>
 					</div>
 					{showPager && pagination && (

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/ListPanel/__tests__/Renderer.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/ListPanel/__tests__/Renderer.test.tsx
@@ -162,4 +162,18 @@ describe('ListPanelRenderer', () => {
 
 		expect(queryByTestId('list-panel-pager')).not.toBeInTheDocument();
 	});
+
+	it('swaps rows for skeletons while the next page loads (isPreviousData), keeping header + pager', () => {
+		const { getByText, queryByText, getByTestId, container } = renderPanel({
+			data: dataWith([{ data: { body: 'stale row' } }]),
+			pagination: makePagination({ canNext: true }),
+			isPreviousData: true,
+		});
+
+		expect(getByText('body')).toBeInTheDocument();
+		expect(getByTestId('list-panel-pager')).toBeInTheDocument();
+		// Stale page content is replaced by skeleton bars.
+		expect(queryByText('stale row')).not.toBeInTheDocument();
+		expect(container.querySelector('.ant-skeleton')).toBeInTheDocument();
+	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TimeSeriesPanel/utils/__tests__/buildConfig.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TimeSeriesPanel/utils/__tests__/buildConfig.test.ts
@@ -1,0 +1,76 @@
+import type { DashboardtypesTimeSeriesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
+import { UTC_TIMEZONE } from 'components/CustomTimePicker/timezoneUtils';
+import { PanelMode } from 'container/DashboardContainer/visualization/panels/types';
+import type { PanelSeries } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
+
+import { buildTimeSeriesConfig } from '../buildConfig';
+
+const series: PanelSeries[] = [
+	{
+		queryName: 'A',
+		legend: 'A',
+		labels: {},
+		values: [
+			{ timestamp: 1000, value: 1 },
+			{ timestamp: 61000, value: 2 },
+		],
+		kind: 'series',
+		aggregation: { index: 0, alias: 'A' },
+	},
+];
+
+/** Resolved per-series `spanGaps` values from a built TimeSeries config. */
+function spanGapsFor(
+	spanGaps: unknown,
+	stepIntervals?: Record<string, number>,
+): (boolean | number | undefined)[] {
+	const spec = {
+		chartAppearance: spanGaps ? { spanGaps } : {},
+	} as unknown as DashboardtypesTimeSeriesPanelSpecDTO;
+	return buildTimeSeriesConfig({
+		panelId: 'p1',
+		spec,
+		builderQueries: [],
+		series,
+		stepIntervals,
+		isDarkMode: false,
+		timezone: UTC_TIMEZONE,
+		panelMode: PanelMode.DASHBOARD_VIEW,
+	})
+		.getSeriesSpanGapsOptions()
+		.map((o) => o.spanGaps);
+}
+
+describe('buildTimeSeriesConfig spanGaps', () => {
+	it('floors a numeric threshold below the step interval at the step interval', () => {
+		expect(
+			spanGapsFor({ fillOnlyBelow: true, fillLessThan: '10s' }, { A: 60 }),
+		).toStrictEqual([60]);
+	});
+
+	it('keeps a numeric threshold larger than the step interval', () => {
+		expect(
+			spanGapsFor({ fillOnlyBelow: true, fillLessThan: '300s' }, { A: 60 }),
+		).toStrictEqual([300]);
+	});
+
+	it('uses the smallest step interval across queries as the floor', () => {
+		expect(
+			spanGapsFor({ fillOnlyBelow: true, fillLessThan: '10s' }, { A: 60, B: 30 }),
+		).toStrictEqual([30]);
+	});
+
+	it('leaves boolean span-all (true) untouched', () => {
+		expect(spanGapsFor(undefined, { A: 60 })).toStrictEqual([true]);
+		// fillOnlyBelow false → resolveSpanGaps returns true → not clamped.
+		expect(
+			spanGapsFor({ fillOnlyBelow: false, fillLessThan: '10s' }, { A: 60 }),
+		).toStrictEqual([true]);
+	});
+
+	it('passes a numeric threshold through when no step intervals are known', () => {
+		expect(
+			spanGapsFor({ fillOnlyBelow: true, fillLessThan: '10s' }),
+		).toStrictEqual([10]);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TimeSeriesPanel/utils/buildConfig.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TimeSeriesPanel/utils/buildConfig.ts
@@ -2,7 +2,10 @@ import type { DashboardtypesTimeSeriesPanelSpecDTO } from 'api/generated/service
 import { Timezone } from 'components/CustomTimePicker/timezoneUtils';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import { PanelMode } from 'container/DashboardContainer/visualization/panels/types';
-import { buildBaseConfig } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/baseConfigBuilder';
+import {
+	buildBaseConfig,
+	minStepInterval,
+} from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/baseConfigBuilder';
 import {
 	FILL_MODE_MAP,
 	LINE_INTERPOLATION_MAP,
@@ -80,7 +83,14 @@ export function buildTimeSeriesConfig({
 		onClick,
 	});
 
-	addSeries({ builder, spec, builderQueries, series, isDarkMode });
+	addSeries({
+		builder,
+		spec,
+		builderQueries,
+		series,
+		stepIntervals,
+		isDarkMode,
+	});
 
 	return builder;
 }
@@ -90,6 +100,8 @@ interface AddSeriesArgs {
 	spec: DashboardtypesTimeSeriesPanelSpecDTO;
 	builderQueries: BuilderQuery[];
 	series: PanelSeries[];
+	/** Per-query step intervals (seconds); floor for a numeric spanGaps threshold. */
+	stepIntervals?: Record<string, number>;
 	isDarkMode: boolean;
 }
 
@@ -102,15 +114,23 @@ function addSeries({
 	spec,
 	builderQueries,
 	series,
+	stepIntervals,
 	isDarkMode,
 }: AddSeriesArgs): void {
 	const chartAppearance = spec.chartAppearance;
 	// `customColors` is nullable on the spec; coerce so `addSeries` always gets
 	// a defined record (it dereferences keys without a guard).
 	const colorMapping = spec.legend?.customColors ?? {};
-	const spanGaps = chartAppearance?.spanGaps
-		? resolveSpanGaps(chartAppearance?.spanGaps)
+	const resolvedSpanGaps = chartAppearance?.spanGaps
+		? resolveSpanGaps(chartAppearance.spanGaps)
 		: true;
+	// A numeric spanGaps is a max-gap threshold (seconds); floor it at the step interval so a
+	// sub-step value doesn't break the line at every normal point. Boolean `true` passes through.
+	const minStep = stepIntervals ? minStepInterval(stepIntervals) : undefined;
+	const spanGaps =
+		typeof resolvedSpanGaps === 'number' && minStep !== undefined
+			? Math.max(minStep, resolvedSpanGaps)
+			: resolvedSpanGaps;
 
 	const lineStyle = chartAppearance?.lineStyle
 		? LINE_STYLE_MAP[chartAppearance.lineStyle]

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/rendererProps.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/rendererProps.ts
@@ -34,6 +34,8 @@ export interface BaseRendererProps {
 	/** Raw V5 fetch result — response + the request that produced it. */
 	data: PanelQueryData;
 	isFetching: boolean;
+	/** Showing a prior page's data while the next loads; list renderers swap in skeleton rows. */
+	isPreviousData?: boolean;
 	error: Error | null;
 	/** Re-run the panel query; wired to the no-data Retry affordance. Optional so standalone call sites (e.g. the editor preview) can omit it. */
 	refetch?: () => void;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/buildDefaultQueries.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/buildDefaultQueries.test.ts
@@ -13,6 +13,14 @@ describe('buildDefaultQueries', () => {
 		expect(serialized.toLowerCase()).toContain('logs');
 	});
 
+	it('seeds a List panel without a limit so it pages server-side by default', () => {
+		const queries = buildDefaultQueries('signoz/ListPanel');
+
+		// A limit would make usePanelQuery treat the panel as a static, unpaged list.
+		const spec = queries[0].spec.plugin.spec as { limit?: number };
+		expect(spec.limit).toBeUndefined();
+	});
+
 	it('seeds no query for non-List kinds (they seed from the builder)', () => {
 		expect(buildDefaultQueries('signoz/TimeSeriesPanel')).toStrictEqual([]);
 		expect(buildDefaultQueries('signoz/NumberPanel')).toStrictEqual([]);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/baseConfigBuilder.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/baseConfigBuilder.ts
@@ -178,11 +178,11 @@ export function mapThresholds(
 }
 
 /**
- * Smallest per-query step interval, fed to uPlot so tick density matches the
+ * Smallest per-query step interval (seconds), fed to uPlot so tick density matches the
  * densest query. Falls back to `undefined` (uPlot "auto") on an empty map, since
  * `Math.min` returns `Infinity` there and would corrupt scale math.
  */
-function minStepInterval(
+export function minStepInterval(
 	stepIntervals: Record<string, number>,
 ): number | undefined {
 	const values = Object.values(stepIntervals);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/Panel.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/Panel.tsx
@@ -59,12 +59,13 @@ function Panel({
 	const searchable = !!panelDefinition?.actions.search;
 	const [searchTerm, setSearchTerm] = useState('');
 
-	const { data, isFetching, error, refetch, pagination } = usePanelQuery({
-		panel,
-		panelId,
-		// Lazy: fetch only once on screen (undefined → visible) and a renderer exists.
-		enabled: !!panelDefinition && isVisible !== false,
-	});
+	const { data, isFetching, isPreviousData, error, refetch, pagination } =
+		usePanelQuery({
+			panel,
+			panelId,
+			// Lazy: fetch only once on screen (undefined → visible) and a renderer exists.
+			enabled: !!panelDefinition && isVisible !== false,
+		});
 
 	const { onDragSelect, dashboardPreference } = usePanelInteractions();
 
@@ -92,6 +93,7 @@ function Panel({
 					panelId={panelId}
 					data={data}
 					isFetching={isFetching}
+					isPreviousData={isPreviousData}
 					error={error}
 					refetch={refetch}
 					onDragSelect={onDragSelect}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelBody/PanelBody.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelBody/PanelBody.tsx
@@ -6,6 +6,7 @@ import PanelMessage from 'pages/DashboardPageV2/DashboardContainer/Panels/compon
 import type { RenderablePanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition';
 import type { DashboardPreference } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/rendererProps';
 import { hasRunnableQueries } from 'pages/DashboardPageV2/DashboardContainer/queryV5/buildQueryRangeRequest';
+import { getResponseType } from 'pages/DashboardPageV2/DashboardContainer/queryV5/v5ResponseData';
 import type {
 	PanelPagination,
 	PanelQueryData,
@@ -21,6 +22,8 @@ interface PanelBodyProps {
 	panelId: string;
 	data: PanelQueryData;
 	isFetching: boolean;
+	/** Showing a prior page's data while the next loads; forwarded so list renderers can show skeletons. */
+	isPreviousData?: boolean;
 	error: Error | null;
 	refetch: () => void;
 	onDragSelect: (start: number, end: number) => void;
@@ -44,6 +47,7 @@ function PanelBody({
 	panelId,
 	data,
 	isFetching,
+	isPreviousData,
 	error,
 	refetch,
 	onDragSelect,
@@ -52,9 +56,11 @@ function PanelBody({
 	searchTerm,
 	pagination,
 }: PanelBodyProps): JSX.Element {
-	// react-query keeps the previous response during refetches, so its presence is
-	// the "have something to show" signal — only fail hard when there's nothing.
-	const hasData = !!data.response;
+	// A retained response (keepPreviousData) counts as data only if its type matches the current
+	// request — else a prior panel kind's response (time_series → raw) flashes NoData on switch.
+	const hasData =
+		!!data.response &&
+		getResponseType(data.response) === data.requestPayload?.requestType;
 	const queries = panel.spec.queries;
 
 	// Not-configured panel: no runnable query, so nothing to error/load on.
@@ -89,7 +95,9 @@ function PanelBody({
 		);
 	}
 
-	if (isFetching) {
+	// Full-panel loader only on first fetch; a refetch over existing data keeps the renderer
+	// mounted (e.g. list page change) with the header carrying the in-flight indicator.
+	if (isFetching && !hasData) {
 		return (
 			<div className={styles.body} data-testid="panel-loading">
 				<Spin indicator={<Loader size={14} className="animate-spin" />} />
@@ -104,6 +112,7 @@ function PanelBody({
 				panel={panel}
 				data={data}
 				isFetching={isFetching}
+				isPreviousData={isPreviousData}
 				error={error}
 				refetch={refetch}
 				onDragSelect={onDragSelect}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelBody/__tests__/PanelBody.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelBody/__tests__/PanelBody.test.tsx
@@ -42,8 +42,8 @@ describe('PanelBody', () => {
 		expect(screen.queryByTestId('mock-renderer')).not.toBeInTheDocument();
 	});
 
-	it('renders the kind renderer once a runnable query is present', () => {
-		const panel = panelWith([
+	const runnablePanel = (): DashboardtypesPanelDTO =>
+		panelWith([
 			{
 				spec: {
 					plugin: {
@@ -58,9 +58,62 @@ describe('PanelBody', () => {
 			},
 		]);
 
-		render(<PanelBody {...baseProps} panel={panel} />);
+	it('renders the kind renderer once a runnable query is present', () => {
+		render(<PanelBody {...baseProps} panel={runnablePanel()} />);
 
 		expect(screen.getByTestId('mock-renderer')).toBeInTheDocument();
 		expect(screen.queryByTestId('panel-no-query')).not.toBeInTheDocument();
+	});
+
+	it('shows the full-panel loader only on the first fetch (no data yet)', () => {
+		render(
+			<PanelBody
+				{...baseProps}
+				panel={runnablePanel()}
+				data={{} as PanelQueryData}
+				isFetching
+			/>,
+		);
+
+		expect(screen.getByTestId('panel-loading')).toBeInTheDocument();
+		expect(screen.queryByTestId('mock-renderer')).not.toBeInTheDocument();
+	});
+
+	it('keeps the renderer mounted during a refetch over existing data (e.g. list page change)', () => {
+		render(
+			<PanelBody
+				{...baseProps}
+				panel={runnablePanel()}
+				data={
+					{
+						response: { data: { type: 'raw' } },
+						requestPayload: { requestType: 'raw' },
+					} as unknown as PanelQueryData
+				}
+				isFetching
+			/>,
+		);
+
+		expect(screen.getByTestId('mock-renderer')).toBeInTheDocument();
+		expect(screen.queryByTestId('panel-loading')).not.toBeInTheDocument();
+	});
+
+	it('shows the loader (not a NoData flash) while a stale cross-type response is replaced on a kind switch', () => {
+		render(
+			<PanelBody
+				{...baseProps}
+				panel={runnablePanel()}
+				data={
+					{
+						response: { data: { type: 'time_series' } },
+						requestPayload: { requestType: 'raw' },
+					} as unknown as PanelQueryData
+				}
+				isFetching
+			/>,
+		);
+
+		expect(screen.getByTestId('panel-loading')).toBeInTheDocument();
+		expect(screen.queryByTestId('mock-renderer')).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useCreateAlertFromPanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useCreateAlertFromPanel.ts
@@ -21,6 +21,7 @@ import {
 	buildCreateAlertUrl,
 	readPanelUnit,
 } from '../utils/buildCreateAlertUrl';
+import { NANO_SECOND_MULTIPLIER } from '@/store/globalTime';
 
 /**
  * Callback that seeds the alert builder from a panel's query in a new tab (V1 parity
@@ -61,8 +62,8 @@ export function useCreateAlertFromPanel(): (
 			const request = buildQueryRangeRequest({
 				queries: panel.spec.queries,
 				panelType,
-				startMs: minTime / 1e6,
-				endMs: maxTime / 1e6,
+				startMs: Math.floor(minTime / NANO_SECOND_MULTIPLIER),
+				endMs: Math.floor(maxTime / NANO_SECOND_MULTIPLIER),
 				variables,
 			});
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/usePanelQuery.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/usePanelQuery.test.tsx
@@ -328,6 +328,12 @@ describe('usePanelQuery', () => {
 			expect(result.current.pagination).toBeUndefined();
 		});
 
+		it('keeps previous data while paging so the table/pager stay mounted on page change', () => {
+			renderHook(() => usePanelQuery({ panel: listPanel({}), panelId: 'p1' }));
+			const [{ keepPreviousData }] = mockUseGetQueryRangeV5.mock.calls[0];
+			expect(keepPreviousData).toBe(true);
+		});
+
 		it('changes the page size (and re-requests with the new limit) via setPageSize', () => {
 			const { result } = renderHook(() =>
 				usePanelQuery({ panel: listPanel({}), panelId: 'p1' }),
@@ -377,26 +383,20 @@ describe('usePanelQuery', () => {
 			expect(result.current.pagination?.canNext).toBe(false);
 		});
 
-		it('flags canNext on a full page and clears it on a partial page', () => {
+		it('drives canNext from the response cursor, not the row count', () => {
+			// Full page but no cursor → backend says these are the last rows.
 			withResponse(rawResponse(25));
-			const full = renderHook(() =>
+			const noCursor = renderHook(() =>
 				usePanelQuery({ panel: listPanel({}), panelId: 'p1' }),
 			);
-			expect(full.result.current.pagination?.canNext).toBe(true);
+			expect(noCursor.result.current.pagination?.canNext).toBe(false);
 
-			withResponse(rawResponse(10));
-			const partial = renderHook(() =>
-				usePanelQuery({ panel: listPanel({}), panelId: 'p1' }),
-			);
-			expect(partial.result.current.pagination?.canNext).toBe(false);
-		});
-
-		it('flags canNext from a nextCursor even on a partial page', () => {
+			// Cursor present (even on a partial page) → more rows.
 			withResponse(rawResponse(3, 'cursor-1'));
-			const { result } = renderHook(() =>
+			const withCursor = renderHook(() =>
 				usePanelQuery({ panel: listPanel({}), panelId: 'p1' }),
 			);
-			expect(result.current.pagination?.canNext).toBe(true);
+			expect(withCursor.result.current.pagination?.canNext).toBe(true);
 		});
 
 		it('advances pageIndex and enables canPrev after goNext', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useGetQueryRangeV5.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useGetQueryRangeV5.ts
@@ -11,6 +11,8 @@ export interface UseGetQueryRangeV5Args {
 	requestPayload: Querybuildertypesv5QueryRangeRequestDTO;
 	queryKey: unknown[];
 	enabled: boolean;
+	/** Retain prior data across a key change (list paging) so the table + pager stay mounted. */
+	keepPreviousData?: boolean;
 }
 
 /**
@@ -40,11 +42,13 @@ export function useGetQueryRangeV5({
 	requestPayload,
 	queryKey,
 	enabled,
+	keepPreviousData,
 }: UseGetQueryRangeV5Args): UseQueryResult<QueryRangeV5200, Error> {
 	return useQuery<QueryRangeV5200, Error>({
 		queryKey,
 		queryFn: ({ signal }) => queryRangeV5(requestPayload, signal),
 		enabled,
 		retry: retryUnlessClientError,
+		keepPreviousData,
 	});
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/usePanelQuery.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/usePanelQuery.ts
@@ -55,6 +55,8 @@ export interface UsePanelQueryResult {
 	isLoading: boolean;
 	/** Any request in flight, including a background refetch over stale data — drives a "refreshing" affordance, never a blank panel. */
 	isFetching: boolean;
+	/** Showing a prior page's data (keepPreviousData) while the next page loads — list renderers swap in skeleton rows. */
+	isPreviousData: boolean;
 	error: Error | null;
 	/** Re-run the query (e.g. a retry button on the error state). */
 	refetch: () => void;
@@ -211,6 +213,8 @@ export function usePanelQuery({
 		requestPayload,
 		queryKey,
 		enabled: enabled && runnable,
+		// Hold the current page while the next loads (offset re-keys) so the pager doesn't flash.
+		keepPreviousData: isPaginated,
 	});
 
 	const queryClient = useQueryClient();
@@ -232,8 +236,8 @@ export function usePanelQuery({
 		[pageSize],
 	);
 
-	// Paging handles for raw/list panels. `canNext` is a heuristic (no total count on the wire):
-	// a full page or a response `nextCursor` implies more rows.
+	// Paging handles for raw/list panels. The backend sets `nextCursor` iff the page filled,
+	// so it's the authoritative has-more signal (there's no total count on the wire).
 	const pagination = useMemo<PanelPagination | undefined>(() => {
 		if (!isPaginated) {
 			return undefined;
@@ -246,11 +250,10 @@ export function usePanelQuery({
 		// `getRawResults` returns [] for a missing/non-raw response, so this stays
 		// defined and zero-rowed rather than throwing while data is absent.
 		const result = getRawResults(response.data)[0];
-		const rowCount = result?.rows?.length ?? 0;
 		return {
 			pageIndex: Math.floor(safeOffset / safePageSize),
 			canPrev: safeOffset > 0,
-			canNext: !!result?.nextCursor || rowCount >= safePageSize,
+			canNext: !!result?.nextCursor,
 			goPrev,
 			goNext,
 			pageSize: safePageSize,
@@ -271,6 +274,7 @@ export function usePanelQuery({
 		data,
 		isLoading: response.isLoading,
 		isFetching: response.isFetching,
+		isPreviousData: response.isPreviousData,
 		error: response.error ?? null,
 		refetch: response.refetch,
 		cancelQuery,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/optimistic/__tests__/applyJsonPatch.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/optimistic/__tests__/applyJsonPatch.test.ts
@@ -37,6 +37,24 @@ describe('applyJsonPatch', () => {
 		expect(JSON.stringify(doc)).toBe(snapshot);
 	});
 
+	it('does not mutate the input ops when a later op targets a just-added node', () => {
+		// New-panel-on-empty-dashboard batch: add an empty section, then add an
+		// item into it. The item must not leak back into the section-add op's value
+		// (which is still queued for the network request) via a shared reference.
+		const ops = [
+			op(add, '/spec/layouts/-', { spec: { items: [] } }),
+			op(add, '/spec/layouts/0/spec/items/-', { x: 0, y: 0 }),
+		];
+		const empty = { spec: { layouts: [] } };
+		const next = applyJsonPatch(empty, ops);
+
+		// The section-add op's value stays empty — only the applied document grows.
+		expect((ops[0].value as any).spec.items).toStrictEqual([]);
+		expect((next.spec as any).layouts[0].spec.items).toStrictEqual([
+			{ x: 0, y: 0 },
+		]);
+	});
+
 	it('replaces a leaf string', () => {
 		const next = applyJsonPatch(spec(), [
 			op(replace, '/spec/layouts/0/spec/display/title', 'S1-renamed'),

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/optimistic/applyJsonPatch.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/optimistic/applyJsonPatch.ts
@@ -136,10 +136,14 @@ function applyOperation(
 	const key = tokens[tokens.length - 1];
 
 	// move / copy / test are never emitted by our builders → no-op (reconciled by refetch).
+	// Clone the inserted value: a later op in the same batch can target a node we
+	// just added (e.g. add an empty section, then add an item into it), and writing
+	// the value by reference would mutate the caller's `op.value` — corrupting the
+	// ops still queued for the network request.
 	if (op.op === DashboardtypesPatchOpDTO.add) {
-		addAt(parent, key, op.value);
+		addAt(parent, key, cloneDeep(op.value));
 	} else if (op.op === DashboardtypesPatchOpDTO.replace) {
-		replaceAt(parent, key, op.value);
+		replaceAt(parent, key, cloneDeep(op.value));
 	} else if (op.op === DashboardtypesPatchOpDTO.remove) {
 		removeAt(parent, key);
 	}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/__tests__/buildQueryRangeRequest.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/__tests__/buildQueryRangeRequest.test.ts
@@ -188,7 +188,78 @@ describe('buildQueryRangeRequest', () => {
 			signal: 'logs',
 			offset: 100,
 			limit: 50,
+			order: [
+				{ key: { name: 'timestamp' }, direction: 'desc' },
+				{ key: { name: 'id' }, direction: 'desc' },
+			],
 		});
+	});
+
+	it('defaults a logs list with no order to timestamp desc + id tiebreaker', () => {
+		const request = buildQueryRangeRequest({
+			queries: bareBuilderQuery({ name: 'A', signal: 'logs' }),
+			panelType: PANEL_TYPES.LIST,
+			startMs: START_MS,
+			endMs: START_MS + HOUR_MS,
+		});
+		const spec = request.compositeQuery?.queries?.[0]?.spec as {
+			order?: { key?: { name?: string }; direction?: string }[];
+		};
+		expect(spec.order).toStrictEqual([
+			{ key: { name: 'timestamp' }, direction: 'desc' },
+			{ key: { name: 'id' }, direction: 'desc' },
+		]);
+	});
+
+	it('appends an id tiebreaker to a logs list order (mirroring the primary direction)', () => {
+		const request = buildQueryRangeRequest({
+			queries: bareBuilderQuery({
+				name: 'A',
+				signal: 'logs',
+				order: [{ key: { name: 'timestamp' }, direction: 'desc' }],
+			}),
+			panelType: PANEL_TYPES.LIST,
+			startMs: START_MS,
+			endMs: START_MS + HOUR_MS,
+		});
+		const spec = request.compositeQuery?.queries?.[0]?.spec as {
+			order?: { key?: { name?: string }; direction?: string }[];
+		};
+		expect(spec.order).toStrictEqual([
+			{ key: { name: 'timestamp' }, direction: 'desc' },
+			{ key: { name: 'id' }, direction: 'desc' },
+		]);
+	});
+
+	it('does not duplicate an id tiebreaker already present in the order', () => {
+		const order = [
+			{ key: { name: 'timestamp' }, direction: 'asc' },
+			{ key: { name: 'id' }, direction: 'asc' },
+		];
+		const request = buildQueryRangeRequest({
+			queries: bareBuilderQuery({ name: 'A', signal: 'logs', order }),
+			panelType: PANEL_TYPES.LIST,
+			startMs: START_MS,
+			endMs: START_MS + HOUR_MS,
+		});
+		const spec = request.compositeQuery?.queries?.[0]?.spec as {
+			order?: unknown[];
+		};
+		expect(spec.order).toStrictEqual(order);
+	});
+
+	it('does not add an id tiebreaker for a traces list order (explorer parity)', () => {
+		const order = [{ key: { name: 'timestamp' }, direction: 'desc' }];
+		const request = buildQueryRangeRequest({
+			queries: bareBuilderQuery({ name: 'A', signal: 'traces', order }),
+			panelType: PANEL_TYPES.LIST,
+			startMs: START_MS,
+			endMs: START_MS + HOUR_MS,
+		});
+		const spec = request.compositeQuery?.queries?.[0]?.spec as {
+			order?: unknown[];
+		};
+		expect(spec.order).toStrictEqual(order);
 	});
 
 	it('injects the range-derived stepInterval into BAR builder queries without one', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/__tests__/persesQueryAdapters.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/__tests__/persesQueryAdapters.test.ts
@@ -111,6 +111,45 @@ describe('persesQueryAdapters', () => {
 			expect(result[0].kind).toBe('raw');
 			expect(result[0].spec.plugin.kind).toBe('signoz/BuilderQuery');
 		});
+
+		it('drops the pageSize-promoted limit for a List query with no user limit (so it pages server-side)', () => {
+			// pageSize with no user limit would otherwise be folded into the V5 limit.
+			const withPageSize: Query = {
+				...initialQueriesMap[DataSource.LOGS],
+				builder: {
+					...initialQueriesMap[DataSource.LOGS].builder,
+					queryData: [
+						{
+							...initialQueriesMap[DataSource.LOGS].builder.queryData[0],
+							limit: null,
+							pageSize: 100,
+						},
+					],
+				},
+			};
+
+			const result = toPerses(withPageSize, PANEL_TYPES.LIST);
+
+			const spec = result[0].spec.plugin.spec as { limit?: number };
+			expect(spec.limit).toBeUndefined();
+		});
+
+		it('keeps an explicit user limit on a List query (V1 parity: static, unpaged cap)', () => {
+			const withLimit: Query = {
+				...initialQueriesMap[DataSource.LOGS],
+				builder: {
+					...initialQueriesMap[DataSource.LOGS].builder,
+					queryData: [
+						{ ...initialQueriesMap[DataSource.LOGS].builder.queryData[0], limit: 50 },
+					],
+				},
+			};
+
+			const result = toPerses(withLimit, PANEL_TYPES.LIST);
+
+			const spec = result[0].spec.plugin.spec as { limit?: number };
+			expect(spec.limit).toBe(50);
+		});
 	});
 
 	describe('round-trip', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/buildQueryRangeRequest.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/buildQueryRangeRequest.ts
@@ -3,12 +3,14 @@ import type {
 	Querybuildertypesv5BuilderQuerySpecDTO,
 	Querybuildertypesv5ClickHouseQueryDTO,
 	Querybuildertypesv5CompositeQueryDTO,
+	Querybuildertypesv5OrderByDTO,
 	Querybuildertypesv5PromQueryDTO,
 	Querybuildertypesv5QueryEnvelopeDTO,
 	Querybuildertypesv5QueryRangeRequestDTO,
 	Querybuildertypesv5QueryRangeRequestDTOVariables,
 } from 'api/generated/services/sigNoz.schemas';
 import {
+	Querybuildertypesv5OrderDirectionDTO,
 	Querybuildertypesv5QueryEnvelopeBuilderDTOType,
 	Querybuildertypesv5QueryEnvelopeClickHouseSQLDTOType,
 	Querybuildertypesv5QueryEnvelopePromQLDTOType,
@@ -24,6 +26,7 @@ interface QuerySpecView {
 	signal?: string;
 	stepInterval?: number | string;
 	aggregations?: { metricName?: string }[];
+	order?: Querybuildertypesv5OrderByDTO[];
 }
 
 /**
@@ -167,6 +170,48 @@ function withBarStepInterval(
 }
 
 /**
+ * Enforces a total order on logs-list requests so offset paging can't duplicate/drop
+ * same-millisecond rows: default the primary to `timestamp desc`, then always append `id`
+ * (logs-explorer parity). Request-only; traces keep their order.
+ */
+function withListOrderTiebreaker(
+	envelopes: Querybuildertypesv5QueryEnvelopeDTO[],
+): Querybuildertypesv5QueryEnvelopeDTO[] {
+	return envelopes.map((envelope) => {
+		if (
+			envelope.type !==
+			Querybuildertypesv5QueryEnvelopeBuilderDTOType.builder_query
+		) {
+			return envelope;
+		}
+		const spec = envelope.spec as QuerySpecView;
+		const order = spec.order ?? [];
+		if (spec.signal !== 'logs' || order.some((o) => o.key?.name === 'id')) {
+			return envelope;
+		}
+		const primary =
+			order.length > 0
+				? order
+				: [
+						{
+							key: { name: 'timestamp' },
+							direction: Querybuildertypesv5OrderDirectionDTO.desc,
+						},
+					];
+		return {
+			...envelope,
+			spec: {
+				...envelope.spec,
+				order: [
+					...primary,
+					{ key: { name: 'id' }, direction: primary[0].direction },
+				],
+			} as Querybuildertypesv5BuilderQuerySpecDTO,
+		};
+	});
+}
+
+/**
  * Stamps offset/limit onto builder-query envelopes (server-side paging for raw/list); other
  * kinds pass through.
  */
@@ -223,6 +268,9 @@ export function buildQueryRangeRequest({
 	let envelopes = toQueryEnvelopes(queries);
 	if (panelType === PANEL_TYPES.BAR) {
 		envelopes = withBarStepInterval(envelopes, startMs, endMs);
+	}
+	if (panelType === PANEL_TYPES.LIST) {
+		envelopes = withListOrderTiebreaker(envelopes);
 	}
 	if (pagination) {
 		envelopes = withPagination(envelopes, pagination);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters.ts
@@ -51,6 +51,23 @@ const isBuilderQueryEnvelope = (
 ): boolean =>
 	envelope.type === Querybuildertypesv5QueryEnvelopeBuilderDTOType.builder_query;
 
+/**
+ * Clears the V1 explorer's `pageSize`/`offset` before conversion — the shared mapper folds
+ * `pageSize` into the V5 `limit`, which usePanelQuery would read as a user cap and hide the
+ * pager. Dropped here, `limit` reflects only a real user limit and List panels page by default.
+ */
+const withoutExplorerPaging = (query: Query): Query => ({
+	...query,
+	builder: {
+		...query.builder,
+		queryData: query.builder.queryData.map((data) => ({
+			...data,
+			pageSize: undefined,
+			offset: undefined,
+		})),
+	},
+});
+
 export function deriveQueryType(
 	envelopes: Querybuildertypesv5QueryEnvelopeDTO[],
 ): EQueryType {
@@ -120,7 +137,11 @@ export function toPerses(
 	query: Query,
 	panelType: PANEL_TYPES,
 ): DashboardtypesQueryDTO[] {
-	const composite = mapCompositeQueryFromQuery(query, panelType);
+	// List panels page server-side via usePanelQuery, so drop the V1 explorer's paging
+	// fields before conversion — otherwise the shared mapper folds them into `limit`.
+	const source =
+		panelType === PANEL_TYPES.LIST ? withoutExplorerPaging(query) : query;
+	const composite = mapCompositeQueryFromQuery(source, panelType);
 	const envelopes = toGeneratedEnvelopes(composite.queries ?? []);
 
 	if (panelType === PANEL_TYPES.LIST) {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/v5ResponseData.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/v5ResponseData.ts
@@ -2,6 +2,7 @@ import type {
 	Querybuildertypesv5AggregationBucketDTO,
 	Querybuildertypesv5ExecStatsDTO,
 	Querybuildertypesv5RawDataDTO,
+	Querybuildertypesv5RequestTypeDTO,
 	Querybuildertypesv5ScalarDataDTO,
 	Querybuildertypesv5TimeSeriesDataDTO,
 	Querybuildertypesv5TimeSeriesDTO,
@@ -42,6 +43,13 @@ export function getRawResults(
 		return [];
 	}
 	return (data.data?.results ?? []) as Querybuildertypesv5RawDataDTO[];
+}
+
+/** Response request-type discriminator (raw/trace/scalar/time_series); detects a stale cross-type response. */
+export function getResponseType(
+	response: QueryRangeV5200 | undefined,
+): Querybuildertypesv5RequestTypeDTO | undefined {
+	return response?.data?.type;
 }
 
 /** Exec stats (incl. per-query `stepIntervals`) from the response top level. */


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

A batch of V2 dashboard panel fixes, mostly around the **List panel's server pagination**, plus a few smaller panel fixes. Each is a self-contained commit:

1. **Show the list panel pager** — a new/edited List panel never showed its pager. The shared V1→V5 mapper folds a list query's internal `pageSize` into the V5 `limit`, so a seeded panel always looked like it had a user limit, and `usePanelQuery` suppresses the pager when a limit is present. Fixed by stripping the V1 explorer's `pageSize`/`offset` in `toPerses` before conversion.
2. **Deterministic pagination order** — offset paging over a non-total order can duplicate/drop same-millisecond rows across pages. Every logs-list request now carries a total order (`timestamp desc, id`), request-only (logs-explorer parity).
3. **List pagination runtime behaviour** — `canNext` is driven by the backend `nextCursor` (not a row-count guess); the table + pager stay mounted on a page change (`keepPreviousData`); a stale cross-type response kept across a panel-kind switch no longer flashes "No data"; and the body shows horizontal **skeleton rows** while the next page loads (dashboard grid + editor preview).
4. **Order on panel-type switch** — switching to a List panel left the builder's Order By empty; it now seeds `timestamp desc` (parity with a fresh list panel).
5. **Time-series `spanGaps`** — a numeric threshold is now floored at the step interval so a sub-step value doesn't break the line at every normal point.
6. **Discard dialog** — "Keep editing" moved to the right and made outlined; "Discard" stays left (destructive).
7. **Create-alert time window** — floored the ns→ms conversion (V5 start/end are int64 ms) and used the named `NANO_SECOND_MULTIPLIER`.
8. **New-panel save on an empty dashboard** — creating the first panel failed with an `items overlap` error: the optimistic patch applier aliased op values by reference, mutating the outgoing ops so the panel was added to the layout twice. Fixed by cloning inserted values in `applyJsonPatch`.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change.

Verified manually: the pager now appears for logs List panels, page changes show skeleton rows (no NoData flash, no stale rows), switching to a list keeps `timestamp desc` in Order By, and the discard dialog shows `[Discard] [Keep editing]` with Keep editing outlined. (Screenshots shared during review.)

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/pulse-pod/issues/90

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
- **Pager never showed:** the shared V1→V5 mapper (`createBaseSpec`) computes `limit = limit || pageSize` for list/table, so the seed's internal `pageSize: 100` became a V5 `limit`, which the pager gate reads as an explicit user limit.
- **Dup/dropped rows & unreliable "next":** the backend emits `ORDER BY` verbatim (no auto tiebreaker), so `timestamp desc` alone is not a total order across separate offset queries.
- **NoData flash on kind switch:** `keepPreviousData` (added to keep the pager on page change) also retains the *previous* panel type's response across a query-key change; the new renderer can't read it.
- **Empty Order By on switch:** V1's `handleQueryChange` clears `orderBy` when switching to a list.
- **spanGaps:** a numeric threshold below one step interval breaks the line at every normal point.
- **New-panel double-add:** `applyJsonPatch` (run in `onMutate` before the request is sent) inserted each `op.value` by reference, so the cache's `layouts[0].spec.items` aliased the empty `items` array held inside the section-add op; applying the item op then mutated that op's value, and react-query sent a layout that already held the item *plus* the separate item-add op → two overlapping items. New-dashboard-only, since that is the only batch that adds a layout and an item into that same layout together.

#### Fix Strategy
- Strip `pageSize`/`offset` at the V2 conversion boundary (`toPerses`) so `limit` reflects only a real user limit.
- Enforce a total order (`timestamp desc, id`) at request-build time, request-only.
- Drive `canNext` from `nextCursor`; gate the full-panel loader on first-load only; require a retained response's type to match the current request before treating it as data.
- Re-seed the list default order in `usePanelTypeSwitch`.
- Clamp the numeric `spanGaps` to `max(minStepInterval, value)`.
- Clone the inserted value on `add`/`replace` in `applyJsonPatch` so the applied document never shares references with the input ops (restoring the purity the docstring already promises).

---

### 🧪 Testing Strategy
> How was this change validated?

- **Tests added/updated:** unit tests for `toPerses` (pageSize→limit strip), `buildQueryRangeRequest` (id tiebreaker + defaults), `usePanelQuery` (cursor `canNext`, `keepPreviousData`), `PanelBody` (first-load loader vs mounted refetch, cross-type stale response), `ListPanel/Renderer` (skeleton rows), `usePanelTypeSwitch` (default list order), `buildConfig` (spanGaps clamp), and `applyJsonPatch` (a later op targeting a just-added node must not mutate the input ops).
- **Manual verification:** ran the app and exercised list paging (next/prev, page-size change), panel-type switching, the discard dialog, and creating the first panel on a brand-new dashboard.
- **Edge cases covered:** last page (partial page → no cursor), traces list (no `id` tiebreaker, explorer parity), boolean `spanGaps` (span-all passes through), first fetch with no data (loader, not skeleton).
- `tsgo --noEmit`, `oxlint`, and `pnpm build` all green; pre-commit hook validated each commit.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** V2 dashboards only. Mostly the List panel; the spanGaps change is Time-series-only; the discard-dialog and create-alert changes are editor-only; the `applyJsonPatch` clone affects every optimistic spec mutation.
- **Potential regressions:** the `PanelBody` loader-gate change (`isFetching && !hasData`) affects **all V2 panels** — a same-key background refetch now keeps the chart mounted instead of showing a full-panel spinner (time-range changes still show the loader). The request-time `id` tiebreaker only affects logs list requests and is not persisted. The `applyJsonPatch` change only deep-clones values already destined for the cache, so it is behaviour-preserving apart from removing the aliasing.
- **Rollback plan:** each fix is an isolated commit and can be reverted independently.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | V2 dashboard List panels now show the pager, page deterministically, and display skeleton rows while loading the next page; switching to a list keeps timestamp ordering; time-series spanGaps respects the step interval; discard-dialog button layout updated; and creating the first panel on a new dashboard no longer fails with an items-overlap error. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The **list pagination runtime** fixes (cursor `canNext`, keep-pager, no-flash, skeletons) are in a single commit because they share `usePanelQuery.ts` / `PanelBody.tsx`; splitting them by hunk broke the pre-commit hook's project-wide `tsgo` under lint-staged's partial-stage stashing. Every commit compiles in isolation.
- The **create-alert** commit (`useCreateAlertFromPanel.ts`) was a pre-existing working-tree change, included at request.
- `@signozhq/ui/skeleton` isn't in the package's export map, so the skeleton rows use antd's `Skeleton.Input`.
- The **new-panel double-add** fix is in the optimistic applier, not the op builder: `createPanelOps` was already correct (it emits an empty section + a separate item add); the corruption came from `applyJsonPatch` aliasing the op values while writing the optimistic cache.
