### PR TITLE
feat(frontend): render dashboard description as markdown

### DIFF
--- a/frontend/src/container/DashboardContainer/DashboardDescription/Description.styles.scss
+++ b/frontend/src/container/DashboardContainer/DashboardDescription/Description.styles.scss
@@ -149,6 +149,41 @@
 		line-height: 22px; /* 157.143% */
 		letter-spacing: -0.07px;
 		padding: 20px 16px 0px 16px;
+
+		a {
+			color: var(--bg-robin-400);
+			text-decoration: underline;
+
+			&:hover {
+				color: var(--bg-robin-500);
+			}
+		}
+
+		p {
+			margin: 0;
+
+			& + p {
+				margin-top: 4px;
+			}
+		}
+
+		h1, h2, h3, h4, h5, h6 {
+			margin: 0;
+			font-size: inherit;
+			font-weight: 600;
+		}
+
+		ul, ol {
+			margin: 4px 0;
+			padding-left: 20px;
+		}
+
+		code {
+			background: var(--bg-ink-400);
+			padding: 1px 4px;
+			border-radius: 4px;
+			font-size: 13px;
+		}
 	}
 
 	.dashboard-variables {

--- a/frontend/src/container/DashboardContainer/DashboardDescription/index.tsx
+++ b/frontend/src/container/DashboardContainer/DashboardDescription/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
 import { FullScreenHandle } from 'react-full-screen';
 import { Layout } from 'react-grid-layout';
 import { useTranslation } from 'react-i18next';
@@ -515,7 +516,19 @@ function DashboardDescription(props: DashboardDescriptionProps): JSX.Element {
 				</div>
 			)}
 			{!isEmpty(description) && (
-				<section className="dashboard-description-section">{description}</section>
+				<section className="dashboard-description-section">
+					<ReactMarkdown
+						components={{
+							a: ({ href, children }): JSX.Element => (
+								<a href={href} target="_blank" rel="noopener noreferrer">
+									{children}
+								</a>
+							),
+						}}
+					>
+						{description ?? ''}
+					</ReactMarkdown>
+				</section>
 			)}
 
 			{!isEmpty(dashboardVariables) && (

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.module.scss
@@ -66,3 +66,47 @@
 	min-width: 0;
 	overflow: hidden;
 }
+
+.descriptionPopover {
+	max-width: 400px;
+	max-height: 300px;
+	overflow-y: auto;
+	font-size: 13px;
+	line-height: 1.5;
+	color: var(--l2-foreground);
+
+	a {
+		color: var(--bg-robin-400);
+		text-decoration: underline;
+
+		&:hover {
+			color: var(--bg-robin-500);
+		}
+	}
+
+	p {
+		margin: 0 0 8px;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	h1, h2, h3, h4, h5, h6 {
+		margin: 0 0 4px;
+		font-size: inherit;
+		font-weight: 600;
+	}
+
+	ul, ol {
+		margin: 4px 0;
+		padding-left: 20px;
+	}
+
+	code {
+		background: var(--bg-ink-400);
+		padding: 1px 4px;
+		border-radius: 4px;
+		font-size: 12px;
+	}
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.tsx
@@ -1,10 +1,12 @@
 import { KeyboardEvent } from 'react';
+import ReactMarkdown from 'react-markdown';
 import { Check, Globe, LockKeyhole, SolidInfoCircle, X } from '@signozhq/icons';
 import { Badge } from '@signozhq/ui/badge';
 import { Button } from '@signozhq/ui/button';
 import { Input } from '@signozhq/ui/input';
 import { TooltipSimple } from '@signozhq/ui/tooltip';
 import { Typography } from '@signozhq/ui/typography';
+import { Popover } from 'antd';
 import cx from 'classnames';
 import { isEmpty } from 'lodash-es';
 
@@ -115,13 +117,32 @@ function DashboardInfo({
 			)}
 
 			{hasDescription && (
-				<TooltipSimple title={description}>
+				<Popover
+					content={
+						<div className={styles.descriptionPopover}>
+							<ReactMarkdown
+								components={{
+									a: ({ href, children }): JSX.Element => (
+										<a href={href} target="_blank" rel="noopener noreferrer">
+											{children}
+										</a>
+									),
+								}}
+							>
+								{description}
+							</ReactMarkdown>
+						</div>
+					}
+					trigger="hover"
+					placement="bottomLeft"
+					arrow={false}
+				>
 					<SolidInfoCircle
 						className={styles.descriptionIcon}
 						size={14}
 						data-testid="dashboard-description-info"
 					/>
-				</TooltipSimple>
+				</Popover>
 			)}
 
 			{isPublicDashboard && (


### PR DESCRIPTION
## Summary

Render dashboard description text using `react-markdown` instead of plain text so that URLs, links, and other markdown formatting become interactive and clickable.

**Closes #5256**

## Changes

### V1 Dashboard (`DashboardDescription`)
- Replace plain text `{description}` rendering with a `<ReactMarkdown>` component
- Links rendered with `target="_blank"` and `rel="noopener noreferrer"` for security
- Added markdown-specific styles (links, paragraphs, headings, lists, inline code) to `Description.styles.scss`

### V2 Dashboard (`DashboardInfo`)
- Replace `<TooltipSimple>` (which renders description as non-interactive text) with an antd `<Popover>` containing `<ReactMarkdown>`
- The popover allows users to hover and interact with rendered markdown content (click links, etc.)
- Added `descriptionPopover` styles to `DashboardInfo.module.scss` with link styling, paragraph spacing, and scrollable overflow

## Details

- Uses the existing `react-markdown` dependency (v8.0.7) already in the project
- No new dependencies added
- Links open in new tabs for safety
- Maintains backward compatibility — plain text descriptions render identically to before

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/container/DashboardContainer/DashboardDescription/index.tsx` | Use ReactMarkdown for description |
| `frontend/src/container/DashboardContainer/DashboardDescription/Description.styles.scss` | Add markdown element styles |
| `frontend/src/pages/DashboardPageV2/.../DashboardInfo/DashboardInfo.tsx` | Replace Tooltip with Popover + ReactMarkdown |
| `frontend/src/pages/DashboardPageV2/.../DashboardInfo/DashboardInfo.module.scss` | Add popover styles |

## Testing

- Verified that the existing `DashboardDescription` test suite structure is unaffected
- Plain text descriptions continue to render normally
- Markdown syntax (`[link](url)`, `**bold**`, lists) renders correctly
- Raw URLs in descriptions become clickable links