### PR TITLE
feat(query-service): add keepFiringFor support to alert rules

### DIFF
--- a/pkg/query-service/rules/base_rule.go
+++ b/pkg/query-service/rules/base_rule.go
@@ -40,6 +40,9 @@ type BaseRule struct {
 	// holdDuration is the duration for which the alert waits before firing
 	holdDuration valuer.TextDuration
 
+	// keepFiringFor is the duration for which the alert keeps firing after condition is no longer met
+	keepFiringFor valuer.TextDuration
+
 	// evalDelay is the delay in evaluation of the rule
 	// this is useful in cases where the data is not available immediately
 	evalDelay valuer.TextDuration
@@ -163,6 +166,7 @@ func NewBaseRule(
 		typ:               p.AlertType,
 		ruleCondition:     p.RuleCondition,
 		evalWindow:        p.EvalWindow,
+		keepFiringFor:     p.KeepFiringFor,
 		labels:            ruletypes.FromMap(p.Labels),
 		annotations:       ruletypes.FromMap(p.Annotations),
 		preferredChannels: p.PreferredChannels,
@@ -237,6 +241,10 @@ func (r *BaseRule) EvalWindow() valuer.TextDuration {
 
 func (r *BaseRule) HoldDuration() valuer.TextDuration {
 	return r.holdDuration
+}
+
+func (r *BaseRule) KeepFiringFor() valuer.TextDuration {
+	return r.keepFiringFor
 }
 
 func (r *BaseRule) ID() string                          { return r.id }

--- a/pkg/query-service/rules/prom_rule.go
+++ b/pkg/query-service/rules/prom_rule.go
@@ -243,6 +243,7 @@ func (r *PromRule) Eval(ctx context.Context, ts time.Time) (int, error) {
 			Receivers:         ruleReceiverMap[lbs.Map()[ruletypes.LabelThresholdName]],
 			Missing:           result.IsMissing,
 			IsRecovering:      result.IsRecovering,
+			ConditionMetAt:    ts,
 		}
 	}
 
@@ -257,6 +258,7 @@ func (r *PromRule) Eval(ctx context.Context, ts time.Time) (int, error) {
 			// Update the recovering and missing state of existing alert
 			alert.IsRecovering = a.IsRecovering
 			alert.Missing = a.Missing
+			alert.ConditionMetAt = ts
 			if v, ok := alert.Labels.Map()[ruletypes.LabelThresholdName]; ok {
 				alert.Receivers = ruleReceiverMap[v]
 			}
@@ -276,6 +278,9 @@ func (r *PromRule) Eval(ctx context.Context, ts time.Time) (int, error) {
 			r.logger.ErrorContext(ctx, "error marshaling labels", errors.Attr(err))
 		}
 		if _, ok := resultFPs[fp]; !ok {
+			if a.State != ruletypes.StateInactive && a.State != ruletypes.StatePending && r.KeepFiringFor().Duration() > 0 && ts.Sub(a.ConditionMetAt) <= r.KeepFiringFor().Duration() {
+				continue
+			}
 			// If the alert was previously firing, keep it around for a given
 			// retention time so it is reported as resolved to the AlertManager.
 			if a.State == ruletypes.StatePending || (!a.ResolvedAt.IsZero() && ts.Sub(a.ResolvedAt) > ruletypes.ResolvedRetention) {

--- a/pkg/query-service/rules/threshold_rule.go
+++ b/pkg/query-service/rules/threshold_rule.go
@@ -373,6 +373,7 @@ func (r *ThresholdRule) Eval(ctx context.Context, ts time.Time) (int, error) {
 			Receivers:         ruleReceiverMap[lbs.Map()[ruletypes.LabelThresholdName]],
 			Missing:           smpl.IsMissing,
 			IsRecovering:      smpl.IsRecovering,
+			ConditionMetAt:    ts,
 		}
 	}
 
@@ -389,6 +390,7 @@ func (r *ThresholdRule) Eval(ctx context.Context, ts time.Time) (int, error) {
 			// Update the recovering and missing state of existing alert
 			alert.IsRecovering = a.IsRecovering
 			alert.Missing = a.Missing
+			alert.ConditionMetAt = ts
 			if v, ok := alert.Labels.Map()[ruletypes.LabelThresholdName]; ok {
 				alert.Receivers = ruleReceiverMap[v]
 			}
@@ -407,6 +409,9 @@ func (r *ThresholdRule) Eval(ctx context.Context, ts time.Time) (int, error) {
 			r.logger.ErrorContext(ctx, "error marshaling labels", errors.Attr(err), slog.Any("alert.labels", a.Labels))
 		}
 		if _, ok := resultFPs[fp]; !ok {
+			if a.State != ruletypes.StateInactive && a.State != ruletypes.StatePending && r.KeepFiringFor().Duration() > 0 && ts.Sub(a.ConditionMetAt) <= r.KeepFiringFor().Duration() {
+				continue
+			}
 			// If the alert was previously firing, keep it around for a given
 			// retention time so it is reported as resolved to the AlertManager.
 			if a.State == ruletypes.StatePending || (!a.ResolvedAt.IsZero() && ts.Sub(a.ResolvedAt) > ruletypes.ResolvedRetention) {

--- a/pkg/types/ruletypes/alerting.go
+++ b/pkg/types/ruletypes/alerting.go
@@ -38,6 +38,8 @@ type Alert struct {
 
 	Missing      bool
 	IsRecovering bool
+
+	ConditionMetAt time.Time
 }
 
 type NamedAlert struct {

--- a/pkg/types/ruletypes/api_params.go
+++ b/pkg/types/ruletypes/api_params.go
@@ -60,6 +60,8 @@ type PostableRule struct {
 	Labels        map[string]string `json:"labels,omitempty"`
 	Annotations   map[string]string `json:"annotations,omitempty"`
 
+	KeepFiringFor valuer.TextDuration `json:"keepFiringFor,omitzero"`
+
 	Disabled bool `json:"disabled"`
 
 	// Source captures the source url where rule has been created


### PR DESCRIPTION
### 📄 Summary

**Why does this change exist?**  
What problem does it solve, and why is this the right approach?

Right now, if you use a "missing data" alert (like a B/A time-shift formula), the alert fires correctly when a service first stops sending data. But if the data stays missing for a long time, the query eventually returns nothing at all. Because of this, the alert automatically resolves itself even though the problem isn't actually fixed!

This PR solves this by adding a new `keepFiringFor` setting to the backend. Just like in Prometheus, this allows an alert to stay in the **FIRING** state for a set amount of time after the condition stops being met. This stops alerts from flapping or resolving too early.

#### Screenshots / Screen Recordings (if applicable)

Include screenshots or screen recordings...

N/A (Backend API change only)

#### Issues closed by this PR

Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes #11493

---

### ✅ Change Type

Select all that apply

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

> Required if this PR fixes a bug

N/A (This is a feature request)

#### Root Cause

N/A

#### Fix Strategy

N/A

---

### 🧪 Testing Strategy

**How was this change validated?**

- Tests added/updated: N/A
- Manual verification: Checked that the new `keepFiringFor` field saves correctly to the database and correctly forces the alert to stay active during evaluation loops.
- Edge cases covered: Handled old rules that don't have this setting (it defaults to `0` and works just like before). Also handled alerts that bounce between **FIRING** and **RECOVERING**.

---

### ⚠️ Risk & Impact Assessment

**What could break? How do we recover?**

- **Blast radius:** Alert evaluation for both PromQL and Threshold rules.
- **Potential regressions:** Very low. Existing rules will default to `0` and work exactly the same as they do today. It is 100% backward compatible.
- **Rollback plan:** Revert this PR.

---

### 📝 Changelog

> Fill only if this affects users, APIs, UI, or documented behavior.  
> Use N/A for internal or non-user-facing changes.

| Field | Value |
|-------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Added `keepFiringFor` support to alert rules to persist missing data alerts and stop them from resolving too early. |

---

### 📋 Checklist

- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

This PR adds the complete backend engine and API support. The `keepFiringFor` setting is now successfully part of the rule schema and evaluation loops. The frontend UI team can now easily add a text box for this feature in the Alert Rules page whenever they are ready!