### PR TITLE
feat(dashboard-v2): rename saved views, org-wide creator filter & visible Locked-view query

### DIFF
--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/CommandHeader.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/CommandHeader.tsx
@@ -7,6 +7,7 @@ import styles from './DashboardsList.module.scss';
 interface Props {
 	label: string;
 	count: number;
+	isModified: boolean;
 	canCreate: boolean;
 	onCreate: () => void;
 }
@@ -14,6 +15,7 @@ interface Props {
 function CommandHeader({
 	label,
 	count,
+	isModified,
 	canCreate,
 	onCreate,
 }: Props): JSX.Element {
@@ -21,6 +23,7 @@ function CommandHeader({
 		<div className={styles.commandHeader}>
 			<div className={styles.headingBlock}>
 				<Typography.Title className={styles.title}>{label}</Typography.Title>
+				{isModified && <span className={styles.dirtyDot} title="Unsaved changes" />}
 				<span className={styles.countPill}>{count}</span>
 			</div>
 			<div className={styles.grow} />

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.module.scss
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.module.scss
@@ -93,6 +93,14 @@
 	flex: 1;
 }
 
+.dirtyDot {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--warning-background);
+	flex: none;
+}
+
 .countPill {
 	padding: 2px 9px;
 	border-radius: 999px;

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
@@ -10,7 +10,6 @@ import { useGetTenantLicense } from 'hooks/useGetTenantLicense';
 import { useAppContext } from 'providers/App/App';
 import { toAPIError } from 'utils/errorUtils';
 
-import { combineQueries } from '../../utils/filterQuery';
 import { useAccumulatedTags } from '../../hooks/useAccumulatedTags';
 import { useActiveView } from '../../hooks/useActiveView';
 import { useDashboardFilters } from '../../hooks/useDashboardFilters';
@@ -72,7 +71,6 @@ function DashboardsList(): JSX.Element {
 		customViewsLoading,
 		isCustomActive,
 		isModified,
-		viewQuery,
 		clientView,
 		selectView,
 		saveView,
@@ -154,13 +152,13 @@ function DashboardsList(): JSX.Element {
 
 	const listParams = useMemo(
 		() => ({
-			query: combineQueries(viewQuery, query) || undefined,
+			query: query || undefined,
 			sort: sortColumn,
 			order: sortOrder,
 			limit: clientView ? CLIENT_VIEW_LIMIT : PAGE_SIZE,
 			offset: clientView ? 0 : (page - 1) * PAGE_SIZE,
 		}),
-		[viewQuery, query, sortColumn, sortOrder, page, clientView],
+		[query, sortColumn, sortOrder, page, clientView],
 	);
 
 	const {

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
@@ -12,6 +12,7 @@ import { toAPIError } from 'utils/errorUtils';
 
 import { useAccumulatedTags } from '../../hooks/useAccumulatedTags';
 import { useActiveView } from '../../hooks/useActiveView';
+import { useCreatorOptions } from '../../hooks/useCreatorOptions';
 import { useDashboardFilters } from '../../hooks/useDashboardFilters';
 import {
 	usePage,
@@ -24,7 +25,6 @@ import { BuiltinViewId } from '../../types';
 import type { SelectedTag, UpdatedWindow } from '../../types';
 import type { DashboardListItem } from '../../utils/helpers';
 import { applyClientView } from '../../utils/views';
-import type { CreatorOption } from '../FilterZone/FilterChips';
 import FilterZone from '../FilterZone/FilterZone';
 import NewDashboardModal from '../NewDashboardModal/NewDashboardModal';
 import StatusBar from '../StatusBar/StatusBar';
@@ -194,24 +194,19 @@ function DashboardsList(): JSX.Element {
 	);
 	const total = clientView ? dashboards.length : (response?.data?.total ?? 0);
 
-	// Creator filter options: distinct authors on the loaded page plus the
-	// current user (so "me" is always selectable). Page-scoped until a members
-	// source backs this.
-	const creatorOptions = useMemo<CreatorOption[]>(() => {
-		const emails = new Set<string>();
-		if (user.email) {
-			emails.add(user.email);
-		}
-		rawDashboards.forEach((d) => {
-			if (d.createdBy) {
-				emails.add(d.createdBy);
-			}
-		});
-		return [...emails].sort().map((email) => ({
-			email,
-			label: email === user.email ? `${email} (me)` : email,
-		}));
-	}, [rawDashboards, user.email]);
+	// Authors present on the loaded page — a fallback for the creator filter until
+	// the org-wide user list resolves.
+	const pageAuthorEmails = useMemo<string[]>(
+		() =>
+			rawDashboards
+				.map((d) => d.createdBy)
+				.filter((email): email is string => !!email),
+		[rawDashboards],
+	);
+	const creatorOptions = useCreatorOptions({
+		currentUserEmail: user.email,
+		fallbackEmails: pageAuthorEmails,
+	});
 
 	// All key:value tags the API reports for the org's dashboards, powering the
 	// Tags filter chip and DSL key suggestions. Accumulated across refetches so

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
@@ -79,6 +79,7 @@ function DashboardsList(): JSX.Element {
 		saveActiveView,
 		resetView,
 		removeView,
+		renameView,
 	} = useActiveView({
 		filters,
 		applyFilters,
@@ -289,8 +290,8 @@ function DashboardsList(): JSX.Element {
 				onSave={saveView}
 				onSaveChanges={saveActiveView}
 				onReset={handleResetView}
-				onClearFilters={handleClearAll}
 				onDelete={handleRemoveView}
+				onRename={renameView}
 			/>
 			<div className={styles.main}>
 				<div className={styles.mainScroll}>

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
@@ -299,6 +299,7 @@ function DashboardsList(): JSX.Element {
 								<CommandHeader
 									label={activeLabel}
 									count={total}
+									isModified={isModified}
 									canCreate={canCreateNewDashboard}
 									onCreate={openCreate}
 								/>

--- a/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewNamePopover.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewNamePopover.tsx
@@ -6,32 +6,45 @@ import { Typography } from '@signozhq/ui/typography';
 
 import styles from './ViewsRail.module.scss';
 
+export const VIEW_NAME_MAX_LENGTH = 128;
+
 interface Props {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	onSave: (name: string) => void;
+	onSubmit: (name: string) => void;
 	trigger: ReactNode;
+	title: string;
+	confirmLabel: string;
+	initialName?: string;
+	testIdPrefix?: string;
 }
 
-function SaveViewPopover({
+// Name-input popover shared by "save as view" and "rename view"; enforces the
+// view-name length cap in one place.
+function ViewNamePopover({
 	open,
 	onOpenChange,
-	onSave,
+	onSubmit,
 	trigger,
+	title,
+	confirmLabel,
+	initialName = '',
+	testIdPrefix = 'view-name',
 }: Props): JSX.Element {
-	const [name, setName] = useState('');
+	const [name, setName] = useState(initialName);
 
 	useEffect(() => {
 		if (open) {
-			setName('');
+			setName(initialName);
 		}
-	}, [open]);
+	}, [open, initialName]);
 
-	const canSave = name.trim().length > 0;
+	const trimmed = name.trim();
+	const canSave = trimmed.length > 0 && trimmed.length <= VIEW_NAME_MAX_LENGTH;
 
 	const handleSave = (): void => {
 		if (canSave) {
-			onSave(name);
+			onSubmit(trimmed);
 			onOpenChange(false);
 		}
 	};
@@ -44,13 +57,14 @@ function SaveViewPopover({
 			trigger={trigger}
 		>
 			<div className={styles.savePopover}>
-				<div className={styles.saveTitle}>Save as view</div>
+				<div className={styles.saveTitle}>{title}</div>
 				<Typography.Text className={styles.saveLabel}>Name</Typography.Text>
 				<Input
 					value={name}
 					autoFocus
+					maxLength={VIEW_NAME_MAX_LENGTH}
 					placeholder="e.g. Prod alerts"
-					testId="save-view-name"
+					testId={`${testIdPrefix}-name`}
 					onChange={(e: ChangeEvent<HTMLInputElement>): void =>
 						setName(e.target.value)
 					}
@@ -74,10 +88,10 @@ function SaveViewPopover({
 						color="primary"
 						size="sm"
 						disabled={!canSave}
-						testId="save-view-confirm"
+						testId={`${testIdPrefix}-confirm`}
 						onClick={handleSave}
 					>
-						Save view
+						{confirmLabel}
 					</Button>
 				</div>
 			</div>
@@ -85,4 +99,4 @@ function SaveViewPopover({
 	);
 }
 
-export default SaveViewPopover;
+export default ViewNamePopover;

--- a/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewsRail.module.scss
+++ b/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewsRail.module.scss
@@ -145,30 +145,40 @@
 	flex: none;
 }
 
-.itemAction {
-	// Blended ghost icon overlaid on the row's right edge — absolutely positioned
-	// so it never reserves layout space or affects the row height. Transparent so
-	// the row's hover background shows through; turns red only on its own hover.
+// Ghost action icons overlaid on the row's right edge — absolutely positioned so
+// they never reserve layout space or affect row height. Hidden until row hover,
+// and inert while hidden so they can't intercept clicks meant for the row.
+.itemActions {
 	position: absolute;
 	right: 6px;
 	top: 50%;
 	transform: translateY(-50%);
-	--button-height: 20px;
-	--button-padding: 0;
-	--button-border-radius: 4px;
-	--button-variant-ghost-color: var(--l3-foreground);
-	--button-variant-ghost-hover-background-color: var(--danger-background);
-	--button-variant-ghost-hover-color: var(--danger-color, #fff);
-	width: 20px;
-	height: 20px;
+	display: flex;
+	align-items: center;
+	gap: 2px;
 	opacity: 0;
-	// Hidden until row hover, and inert while hidden so it can't intercept clicks
-	// meant for the row.
 	pointer-events: none;
 	transition: opacity 0.1s;
 }
 
-.row:hover .itemAction {
+.itemAction {
+	--button-height: 20px;
+	--button-padding: 0;
+	--button-border-radius: 4px;
+	--button-variant-ghost-color: var(--l3-foreground);
+	--button-variant-ghost-hover-background-color: var(--l1-background);
+	--button-variant-ghost-hover-color: var(--l1-foreground);
+	width: 20px;
+	height: 20px;
+	flex: none;
+}
+
+.itemActionDanger {
+	--button-variant-ghost-hover-background-color: var(--danger-background);
+	--button-variant-ghost-hover-color: var(--danger-color, #fff);
+}
+
+.row:hover .itemActions {
 	opacity: 1;
 	pointer-events: auto;
 }

--- a/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewsRail.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewsRail.tsx
@@ -3,12 +3,19 @@ import { Modal } from 'antd';
 import { Button } from '@signozhq/ui/button';
 import { Input } from '@signozhq/ui/input';
 import { Typography } from '@signozhq/ui/typography';
-import { Bookmark, CircleAlert, Plus, Search, Trash2 } from '@signozhq/icons';
+import {
+	Bookmark,
+	CircleAlert,
+	PenLine,
+	Plus,
+	Search,
+	Trash2,
+} from '@signozhq/icons';
 import cx from 'classnames';
 
 import type { SavedView } from '../../types';
 import { type BuiltinView } from '../../utils/views';
-import SaveViewPopover from './SaveViewPopover';
+import ViewNamePopover from './ViewNamePopover';
 
 import styles from './ViewsRail.module.scss';
 
@@ -24,8 +31,8 @@ interface Props {
 	onSave: (name: string) => void;
 	onSaveChanges: () => void;
 	onReset: () => void;
-	onClearFilters: () => void;
 	onDelete: (id: string) => void;
+	onRename: (id: string, name: string) => void;
 }
 
 interface ViewRow {
@@ -49,10 +56,11 @@ function ViewsRail({
 	onSave,
 	onSaveChanges,
 	onReset,
-	onClearFilters,
 	onDelete,
+	onRename,
 }: Props): JSX.Element {
 	const [saveOpen, setSaveOpen] = useState(false);
+	const [renamingId, setRenamingId] = useState<string | null>(null);
 	const [query, setQuery] = useState('');
 	const [modal, contextHolder] = Modal.useModal();
 
@@ -122,20 +130,44 @@ function ViewsRail({
 					)}
 				</Button>
 				{row.deletable && (
-					<Button
-						variant="ghost"
-						color="secondary"
-						size="icon"
-						className={styles.itemAction}
-						aria-label="Delete view"
-						title="Delete view"
-						onClick={(e): void => {
-							e.stopPropagation();
-							confirmDelete(row.id, row.label);
-						}}
-					>
-						<Trash2 size={12} />
-					</Button>
+					<div className={styles.itemActions}>
+						<ViewNamePopover
+							open={renamingId === row.id}
+							onOpenChange={(open): void => setRenamingId(open ? row.id : null)}
+							onSubmit={(name): void => onRename(row.id, name)}
+							title="Rename view"
+							confirmLabel="Rename"
+							initialName={row.label}
+							testIdPrefix="rename-view"
+							trigger={
+								<Button
+									variant="ghost"
+									color="secondary"
+									size="icon"
+									className={styles.itemAction}
+									aria-label="Rename view"
+									title="Rename view"
+									onClick={(e): void => e.stopPropagation()}
+								>
+									<PenLine size={12} />
+								</Button>
+							}
+						/>
+						<Button
+							variant="ghost"
+							color="secondary"
+							size="icon"
+							className={cx(styles.itemAction, styles.itemActionDanger)}
+							aria-label="Delete view"
+							title="Delete view"
+							onClick={(e): void => {
+								e.stopPropagation();
+								confirmDelete(row.id, row.label);
+							}}
+						>
+							<Trash2 size={12} />
+						</Button>
+					</div>
 				)}
 			</div>
 		);
@@ -145,10 +177,13 @@ function ViewsRail({
 		<aside className={cx(styles.rail, { [styles.collapsed]: collapsed })}>
 			<div className={styles.header}>
 				<h4 className={styles.headerTitle}>Views</h4>
-				<SaveViewPopover
+				<ViewNamePopover
 					open={saveOpen}
 					onOpenChange={setSaveOpen}
-					onSave={onSave}
+					onSubmit={onSave}
+					title="Save as view"
+					confirmLabel="Save view"
+					testIdPrefix="save-view"
 					trigger={
 						<Button
 							variant="ghost"
@@ -268,13 +303,8 @@ function ViewsRail({
 						>
 							Save as new view
 						</Button>
-						<Button
-							variant="ghost"
-							color="secondary"
-							size="sm"
-							onClick={onClearFilters}
-						>
-							Clear
+						<Button variant="ghost" color="secondary" size="sm" onClick={onReset}>
+							Reset
 						</Button>
 					</div>
 				</div>

--- a/frontend/src/pages/DashboardsListPageV2/hooks/useActiveView.ts
+++ b/frontend/src/pages/DashboardsListPageV2/hooks/useActiveView.ts
@@ -7,7 +7,6 @@ import type {
 
 import {
 	areFilterStatesEqual,
-	combineQueries,
 	DEFAULT_FILTER_STATE,
 	filterStateToQuery,
 } from '../utils/filterQuery';
@@ -15,7 +14,6 @@ import { BuiltinViewId } from '../types';
 import type { DashboardFilterState, SavedView } from '../types';
 import {
 	BUILTIN_VIEWS,
-	builtinViewQuery,
 	builtinViewSnapshot,
 	type BuiltinView,
 	isClientView,
@@ -42,9 +40,7 @@ export interface UseActiveViewResult {
 	isCustomActive: boolean;
 	// Current filters diverge from the active view's canonical snapshot.
 	isModified: boolean;
-	// Extra server-query fragment the active view contributes, and whether it
-	// constrains the list client-side (pinned/recent).
-	viewQuery: string;
+	// Whether the active view constrains the list client-side (pinned/recent).
 	clientView: boolean;
 	selectView: (id: string) => void;
 	saveView: (name: string) => void;
@@ -128,11 +124,9 @@ export function useActiveView({
 
 	const saveView = useCallback(
 		(name: string): void => {
-			// Fold the current built-in clause + chips into a single query string.
-			const query = combineQueries(
-				builtinViewQuery(activeViewId),
-				filterStateToQuery(filters),
-			);
+			// The active view's clause already lives in the filter state (e.g. Locked
+			// seeds `locked = true` into search), so the chips fold into one query.
+			const query = filterStateToQuery(filters);
 			void (async (): Promise<void> => {
 				const created = await createView({
 					name,
@@ -148,15 +142,7 @@ export function useActiveView({
 				}
 			})();
 		},
-		[
-			activeViewId,
-			filters,
-			createView,
-			sortColumn,
-			sortOrder,
-			setActiveViewId,
-			applyFilters,
-		],
+		[filters, createView, sortColumn, sortOrder, setActiveViewId, applyFilters],
 	);
 
 	const saveActiveView = useCallback((): void => {
@@ -225,7 +211,6 @@ export function useActiveView({
 		customViewsLoading,
 		isCustomActive: !!activeCustom,
 		isModified,
-		viewQuery: builtinViewQuery(activeViewId),
 		clientView: isClientView(activeViewId),
 		selectView,
 		saveView,

--- a/frontend/src/pages/DashboardsListPageV2/hooks/useActiveView.ts
+++ b/frontend/src/pages/DashboardsListPageV2/hooks/useActiveView.ts
@@ -51,6 +51,7 @@ export interface UseActiveViewResult {
 	saveActiveView: () => void;
 	resetView: () => void;
 	removeView: (id: string) => void;
+	renameView: (id: string, name: string) => void;
 }
 
 // The canonical filter snapshot a saved view "is": the backend stores a flat
@@ -200,6 +201,23 @@ export function useActiveView({
 		[deleteView, activeViewId, setActiveViewId, applyFilters],
 	);
 
+	// Rename only touches the view's name; its stored query/sort/order are preserved.
+	const renameView = useCallback(
+		(id: string, name: string): void => {
+			const view = customViews.find((v) => v.id === id);
+			if (!view) {
+				return;
+			}
+			updateView(id, {
+				name,
+				query: view.query,
+				sort: view.sort,
+				order: view.order,
+			});
+		},
+		[customViews, updateView],
+	);
+
 	return {
 		activeViewId,
 		builtinViews: BUILTIN_VIEWS,
@@ -214,5 +232,6 @@ export function useActiveView({
 		saveActiveView,
 		resetView,
 		removeView,
+		renameView,
 	};
 }

--- a/frontend/src/pages/DashboardsListPageV2/hooks/useCreatorOptions.ts
+++ b/frontend/src/pages/DashboardsListPageV2/hooks/useCreatorOptions.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+import { useListUsers } from 'api/generated/services/users';
+
+import type { CreatorOption } from '../components/FilterZone/FilterChips';
+
+interface Args {
+	currentUserEmail: string;
+	// Authors on the loaded page — kept selectable until the org list resolves.
+	fallbackEmails: string[];
+}
+
+// Creator-filter options sourced from the org's full user list, so authors who
+// aren't on the current page are still selectable (v2 "List users" API).
+export function useCreatorOptions({
+	currentUserEmail,
+	fallbackEmails,
+}: Args): CreatorOption[] {
+	const { data } = useListUsers();
+
+	return useMemo<CreatorOption[]>(() => {
+		const users = data?.data ?? [];
+		const emails = new Set<string>();
+		if (currentUserEmail) {
+			emails.add(currentUserEmail);
+		}
+		users.forEach((u) => u.email && emails.add(u.email));
+		// Until the org list resolves (or if it comes back empty), keep the page's
+		// authors selectable so the filter never regresses to just "me".
+		if (users.length === 0) {
+			fallbackEmails.forEach((e) => emails.add(e));
+		}
+
+		const labelFor = (email: string): string => {
+			if (email === currentUserEmail) {
+				return `${email} (me)`;
+			}
+			const match = users.find((u) => u.email === email);
+			return match?.displayName ? `${match.displayName} (${email})` : email;
+		};
+
+		return [...emails].sort().map((email) => ({ email, label: labelFor(email) }));
+	}, [data, currentUserEmail, fallbackEmails]);
+}

--- a/frontend/src/pages/DashboardsListPageV2/hooks/useSavedViews.ts
+++ b/frontend/src/pages/DashboardsListPageV2/hooks/useSavedViews.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useQueryClient } from 'react-query';
 import { toast } from '@signozhq/ui/sonner';
 import {
+	getListDashboardViewsQueryKey,
 	invalidateListDashboardViews,
 	useCreateDashboardView,
 	useDeleteDashboardView,
@@ -12,6 +13,7 @@ import {
 	type DashboardtypesDashboardViewDTO,
 	DashboardtypesListOrderDTO,
 	DashboardtypesListSortDTO,
+	type ListDashboardViews200,
 } from 'api/generated/services/sigNoz.schemas';
 
 import type { SavedView, SavedViewInput } from '../types';
@@ -70,9 +72,27 @@ export function useSavedViews(): UseSavedViewsResult {
 			},
 		},
 	});
+	// Rename/save-changes returns the updated view, so patch it into the cached
+	// list inline instead of refetching the whole list.
 	const updateMutation = useUpdateDashboardView({
 		mutation: {
-			onSuccess: invalidate,
+			onSuccess: (response): void => {
+				const updated = response?.data;
+				const key = getListDashboardViewsQueryKey();
+				const prev = queryClient.getQueryData<ListDashboardViews200>(key);
+				if (!updated || !prev) {
+					return;
+				}
+				queryClient.setQueryData<ListDashboardViews200>(key, {
+					...prev,
+					data: {
+						...prev.data,
+						views: (prev.data.views ?? []).map((v) =>
+							v.id === updated.id ? updated : v,
+						),
+					},
+				});
+			},
 			onError: (): void => {
 				toast.error('Failed to update view.');
 			},

--- a/frontend/src/pages/DashboardsListPageV2/utils/views.ts
+++ b/frontend/src/pages/DashboardsListPageV2/utils/views.ts
@@ -1,7 +1,7 @@
 // Built-in view catalogue + the pure logic that maps a view to how it
-// constrains the list. Views fall into three mechanisms:
-//   - snapshot:  selecting applies a filter snapshot (All, My dashboards, custom)
-//   - query:     contributes an extra server clause AND-ed with the chips (Locked)
+// constrains the list. Views fall into two mechanisms:
+//   - snapshot:  selecting applies a filter snapshot — some seed the search box
+//                with DSL (My dashboards → created_by; Locked → locked = true)
 //   - client:    constrains by a client-side id set (Favorites, Recently viewed)
 import { Clock, Layers, Lock, Pin, User } from '@signozhq/icons';
 
@@ -49,9 +49,9 @@ export const BUILTIN_VIEWS: BuiltinView[] = [
 export const isClientView = (id: string): boolean =>
 	id === BuiltinViewId.Pinned || id === BuiltinViewId.Recent;
 
-// Extra server query fragment a built-in view contributes (AND-ed with chips).
-export const builtinViewQuery = (id: string): string =>
-	id === BuiltinViewId.Locked ? 'locked = true' : '';
+// DSL the Locked view seeds into the search box, so the constraint is visible
+// (and editable) rather than applied invisibly behind the scenes.
+export const LOCKED_QUERY = 'locked = true';
 
 // The canonical filter snapshot a built-in view applies when selected. `null`
 // for ids that aren't built-in (custom views carry their own snapshot).
@@ -65,10 +65,11 @@ export const builtinViewSnapshot = (
 				...DEFAULT_FILTER_STATE,
 				createdBy: userEmail ? [userEmail] : [],
 			};
+		case BuiltinViewId.Locked:
+			return { ...DEFAULT_FILTER_STATE, search: LOCKED_QUERY };
 		case BuiltinViewId.All:
 		case BuiltinViewId.Pinned:
 		case BuiltinViewId.Recent:
-		case BuiltinViewId.Locked:
 			return { ...DEFAULT_FILTER_STATE };
 		default:
 			return null;


### PR DESCRIPTION
## Summary

A batch of V2 dashboard list-page improvements around saved views and filters (dark-shipped behind `use_dashboard_v2`):

- **Rename a saved view.** Each custom view row gets a rename action (pencil → name popover) wired to the existing `PUT /api/v2/dashboard_views/{id}`, updating only the name.
- **View name-length validation.** The save/rename name input is extracted into a shared `ViewNamePopover` that caps the name at **128 characters** in one place (replaces the old save-only popover).
- **The "Locked" view shows `locked = true` in the query.** It previously applied its filter as an invisible server-only clause; it now seeds the search box, so the constraint is visible and editable.
- **"Created by" filter lists all org users.** The filter previously only offered authors present on the currently-loaded page, so someone who hadn't authored a visible dashboard couldn't be selected. It now sources options from the v2 List-users API (page authors kept as a fallback until it resolves) and labels each row with the user's display name. Frontend-only.

## Follow-ups (not in this PR)
- Surfacing the tag-validation error in the UI (depends on the backend error contract).
- Two-way sync between the filter chips and the raw query box (needs a query→filter parser).

## Test plan
- tsgo + oxlint clean on the changed files; existing list-page tests pass (18/18).
- Manual: rename a view; try a >128-char name; select the Locked view (search shows `locked = true`); open the "Created by" filter and confirm users who don't own a visible dashboard are selectable.

Closes https://github.com/SigNoz/pulse-pod/issues/91
