### PR TITLE
fix(dashboard-v2): persist the dashboard description when it was previously empty

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { DashboardtypesPatchOpDTO } from 'api/generated/services/sigNoz.schemas';
 import type {
 	DashboardtypesGettableDashboardV2DTO,
 	DashboardtypesJSONPatchOperationDTO,
@@ -54,20 +55,32 @@ function Overview({ dashboard }: OverviewProps): JSX.Element {
 
 	const buildPatch = useCallback((): DashboardtypesJSONPatchOperationDTO[] => {
 		const ops: DashboardtypesJSONPatchOperationDTO[] = [];
+		const op = (
+			operation: DashboardtypesJSONPatchOperationDTO['op'],
+			path: string,
+			value: unknown,
+		): DashboardtypesJSONPatchOperationDTO => ({ op: operation, path, value });
 		const replace = (
 			path: string,
 			value: unknown,
-		): DashboardtypesJSONPatchOperationDTO => ({
-			op: 'replace' as DashboardtypesJSONPatchOperationDTO['op'],
-			path,
-			value,
-		});
+		): DashboardtypesJSONPatchOperationDTO =>
+			op(DashboardtypesPatchOpDTO.replace, path, value);
 
 		if (updatedTitle !== title && updatedTitle !== '') {
 			ops.push(replace('/spec/display/name', updatedTitle));
 		}
 		if (updatedDescription !== description) {
-			ops.push(replace('/spec/display/description', updatedDescription));
+			// `replace` fails when the description doesn't exist yet, so add it when
+			// the current one is empty (`add` creates or replaces the member).
+			ops.push(
+				op(
+					description
+						? DashboardtypesPatchOpDTO.replace
+						: DashboardtypesPatchOpDTO.add,
+					'/spec/display/description',
+					updatedDescription,
+				),
+			);
 		}
 		if (updatedImage !== image) {
 			ops.push(replace('/image', updatedImage));


### PR DESCRIPTION
## Summary

Adding a description to a V2 dashboard that didn't already have one silently failed — the new description never persisted, though the save appeared to succeed.

A dashboard with no description has no `/spec/display/description` field in its spec, so the settings form sent a JSON-Patch `replace` op against a path that didn't exist and the backend ignored it. The Overview form now emits an `add` op (which creates or replaces the member) when the current description is empty, and keeps `replace` when one already exists.

Scope: `DashboardSettings/Overview` on the V2 dashboard, dark-shipped behind the `use_dashboard_v2` flag.

## Test plan

- On a dashboard with **no** description: add one via Settings → Overview → Save → it now persists (previously silently no-op'd).
- On a dashboard with an **existing** description: editing and saving still works.
- Clearing a description still works.
- tsgo + oxlint clean on the changed file.

Closes https://github.com/SigNoz/pulse-pod/issues/92
