### PR TITLE
refactor(dashboard-v2): unify dashboard tag chips into one TagBadge component

### DIFF
--- a/frontend/src/components/TagBadge/TagBadge.tsx
+++ b/frontend/src/components/TagBadge/TagBadge.tsx
@@ -1,0 +1,34 @@
+import { type MouseEvent, type ReactNode } from 'react';
+import { Badge } from '@signozhq/ui/badge';
+
+interface TagBadgeProps {
+	children: ReactNode;
+	// Show a remove button (editable contexts: create modal, settings drawer).
+	closable?: boolean;
+	onClose?: (event: MouseEvent<HTMLButtonElement>) => void;
+	className?: string;
+}
+
+// The single sienna tag chip used everywhere dashboards render tags — list rows,
+// the details header, and the tag editors. Kept as one component so the tag
+// styling stays identical across all of them.
+function TagBadge({
+	children,
+	closable,
+	onClose,
+	className,
+}: TagBadgeProps): JSX.Element {
+	return (
+		<Badge
+			color="sienna"
+			variant="outline"
+			className={className}
+			closable={closable}
+			onClose={onClose}
+		>
+			{children}
+		</Badge>
+	);
+}
+
+export default TagBadge;

--- a/frontend/src/components/TagKeyValueInput/TagKeyValueInput.module.scss
+++ b/frontend/src/components/TagKeyValueInput/TagKeyValueInput.module.scss
@@ -15,24 +15,13 @@
 	border: 1px solid var(--l2-border);
 }
 
-// Sienna chip — matches the dashboard list-row tag badge.
+// Sienna chip via the @signozhq Badge; this only constrains its width.
 .tag {
-	display: inline-flex;
-	align-items: center;
-	gap: 4px;
 	max-width: 240px;
-	height: 24px;
-	padding: 2px 4px 2px 8px;
-	border-radius: 50px;
-	border: 1px solid color-mix(in srgb, var(--bg-sienna-500) 20%, transparent);
-	background: color-mix(in srgb, var(--bg-sienna-500) 10%, transparent);
-	color: var(--bg-sienna-400);
-	font-size: 13px;
-	font-weight: var(--font-weight-normal);
-	line-height: 20px;
-	cursor: text;
 }
 
+// The tag label is a bare, chrome-less button inside the Badge (double-click to
+// edit); strip its Button styling and let it ellipsize.
 .tagLabel {
 	--button-height: auto;
 	--button-padding: 0;
@@ -43,29 +32,9 @@
 	--button-variant-ghost-hover-color: inherit;
 	overflow: hidden;
 	max-width: 200px;
-	font-size: 13px;
-	font-weight: var(--font-weight-normal);
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	cursor: text;
-}
-
-.remove {
-	// Size overrides to fit the chip, plus a sienna-tinted hover — the Button's
-	// default ghost hover is a grey that clashes with the chip. Resting color is
-	// left at the Button default.
-	--button-height: 16px;
-	--button-padding: 0;
-	--button-border-radius: 50%;
-	--button-variant-ghost-hover-background-color: color-mix(
-		in srgb,
-		var(--bg-sienna-500) 22%,
-		transparent
-	);
-	--button-variant-ghost-hover-color: var(--bg-sienna-400);
-	width: 16px;
-	min-width: 16px;
-	flex: none;
 }
 
 .input {

--- a/frontend/src/components/TagKeyValueInput/TagKeyValueInput.module.scss
+++ b/frontend/src/components/TagKeyValueInput/TagKeyValueInput.module.scss
@@ -28,8 +28,8 @@
 	--button-gap: 0;
 	--button-variant-ghost-background-color: transparent;
 	--button-variant-ghost-hover-background-color: transparent;
-	--button-variant-ghost-color: inherit;
-	--button-variant-ghost-hover-color: inherit;
+	--button-variant-ghost-color: currentColor;
+	--button-variant-ghost-hover-color: currentColor;
 	overflow: hidden;
 	max-width: 200px;
 	text-overflow: ellipsis;

--- a/frontend/src/components/TagKeyValueInput/TagKeyValueInput.tsx
+++ b/frontend/src/components/TagKeyValueInput/TagKeyValueInput.tsx
@@ -1,10 +1,10 @@
 import { type ChangeEvent, type KeyboardEvent, useState } from 'react';
-import { Badge } from '@signozhq/ui/badge';
 import { Button } from '@signozhq/ui/button';
 import { Input } from '@signozhq/ui/input';
 import { Typography } from '@signozhq/ui/typography';
 import cx from 'classnames';
 
+import TagBadge from '../TagBadge/TagBadge';
 import { parseKeyValueTag } from './utils';
 
 import styles from './TagKeyValueInput.module.scss';
@@ -120,10 +120,8 @@ function TagKeyValueInput({
 							onBlur={commitEdit}
 						/>
 					) : (
-						<Badge
+						<TagBadge
 							key={tag}
-							color="sienna"
-							variant="outline"
 							className={styles.tag}
 							closable
 							onClose={(): void => removeTag(tag)}
@@ -138,7 +136,7 @@ function TagKeyValueInput({
 							>
 								{tag}
 							</Button>
-						</Badge>
+						</TagBadge>
 					),
 				)}
 				<Input

--- a/frontend/src/components/TagKeyValueInput/TagKeyValueInput.tsx
+++ b/frontend/src/components/TagKeyValueInput/TagKeyValueInput.tsx
@@ -1,8 +1,8 @@
 import { type ChangeEvent, type KeyboardEvent, useState } from 'react';
+import { Badge } from '@signozhq/ui/badge';
 import { Button } from '@signozhq/ui/button';
 import { Input } from '@signozhq/ui/input';
 import { Typography } from '@signozhq/ui/typography';
-import { X } from '@signozhq/icons';
 import cx from 'classnames';
 
 import { parseKeyValueTag } from './utils';
@@ -120,27 +120,25 @@ function TagKeyValueInput({
 							onBlur={commitEdit}
 						/>
 					) : (
-						<div key={tag} className={styles.tag} data-testid={`${testId}-chip`}>
+						<Badge
+							key={tag}
+							color="sienna"
+							variant="outline"
+							className={styles.tag}
+							closable
+							onClose={(): void => removeTag(tag)}
+						>
 							<Button
 								variant="ghost"
 								color="secondary"
 								className={styles.tagLabel}
 								title="Double-click to edit"
+								testId={`${testId}-chip`}
 								onDoubleClick={(): void => startEdit(index)}
 							>
 								{tag}
 							</Button>
-							<Button
-								variant="ghost"
-								color="secondary"
-								size="icon"
-								className={styles.remove}
-								aria-label={`Remove ${tag}`}
-								onClick={(): void => removeTag(tag)}
-							>
-								<X size={12} />
-							</Button>
-						</div>
+						</Badge>
 					),
 				)}
 				<Input

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.tsx
@@ -7,7 +7,7 @@ import {
 	SolidInfoCircle,
 	X,
 } from '@signozhq/icons';
-import { Badge } from '@signozhq/ui/badge';
+import TagBadge from 'components/TagBadge/TagBadge';
 import { Button } from '@signozhq/ui/button';
 import { Input } from '@signozhq/ui/input';
 import { TooltipSimple } from '@signozhq/ui/tooltip';
@@ -203,19 +203,13 @@ function DashboardInfo({
 						data-testid="dashboard-tags"
 					>
 						{visibleTags.map((tag) => (
-							<Badge key={tag} color="sienna" variant="outline">
-								{tag}
-							</Badge>
+							<TagBadge key={tag}>{tag}</TagBadge>
 						))}
 						{remainingTags.length > 0 && (
 							<TooltipSimple title={remainingTags.join(', ')}>
-								<Badge
-									color="sienna"
-									variant="outline"
-									data-testid="dashboard-tags-overflow"
-								>
-									+{remainingTags.length}
-								</Badge>
+								<span data-testid="dashboard-tags-overflow">
+									<TagBadge>+{remainingTags.length}</TagBadge>
+								</span>
 							</TooltipSimple>
 						)}
 					</div>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/utils.ts
@@ -3,10 +3,10 @@ import type { TagtypesPostableTagDTO } from 'api/generated/services/sigNoz.schem
 export { Base64Icons } from 'container/DashboardContainer/DashboardSettings/General/utils';
 export { parseKeyValueTag } from 'components/TagKeyValueInput/utils';
 
-// tag UX, a string with no ':' is round-tripped as `{key: x, value: x}` and
-// collapsed back to just `x` for display.
+// The tag editor is strictly key:value, so always render both sides — a
+// `key:key` tag stays `key:key` rather than collapsing to a bare `key`.
 export function tagsToStrings(tags: TagtypesPostableTagDTO[]): string[] {
-	return tags.map((t) => (t.key === t.value ? t.key : `${t.key}:${t.value}`));
+	return tags.map((t) => `${t.key}:${t.value}`);
 }
 
 export function stringsToTags(tagStrings: string[]): TagtypesPostableTagDTO[] {

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.module.scss
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.module.scss
@@ -130,27 +130,6 @@
 	justify-content: flex-end;
 }
 
-.tag {
-	display: flex;
-	padding: 4px 8px;
-	justify-content: center;
-	align-items: center;
-	gap: 4px;
-	height: 28px;
-	border-radius: 20px;
-	border: 1px solid color-mix(in srgb, var(--bg-sienna-500) 20%, transparent);
-	background: color-mix(in srgb, var(--bg-sienna-500) 10%, transparent);
-	color: var(--bg-sienna-400);
-	text-align: center;
-	font-family: Inter;
-	font-size: var(--font-size-sm);
-	font-style: normal;
-	font-weight: var(--font-weight-normal);
-	line-height: 20px;
-	letter-spacing: -0.07px;
-	margin-inline-end: 0px;
-}
-
 .details {
 	margin-top: 12px;
 	display: flex;

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@signozhq/ui/badge';
+import TagBadge from 'components/TagBadge/TagBadge';
 import { Button } from '@signozhq/ui/button';
 import { TooltipSimple } from '@signozhq/ui/tooltip';
 import { Typography } from '@signozhq/ui/typography';
@@ -105,14 +105,10 @@ function DashboardRow({
 					{tags.length > 0 && (
 						<div className={styles.tags}>
 							{tags.slice(0, 3).map((tag) => (
-								<Badge className={styles.tag} key={tag}>
-									{tag}
-								</Badge>
+								<TagBadge key={tag}>{tag}</TagBadge>
 							))}
 							{tags.length > 3 && (
-								<Badge className={styles.tag} key={tags[3]}>
-									+ <Typography.Text> {tags.length - 3} </Typography.Text>
-								</Badge>
+								<TagBadge key={tags[3]}>+{tags.length - 3}</TagBadge>
 							)}
 						</div>
 					)}


### PR DESCRIPTION
## Summary

Dashboard tags were rendered three different ways — the list rows and the create/settings tag editors each hand-rolled a sienna chip in SCSS, while the details header used an inline `Badge` with `color="sienna"`. They had drifted (e.g. the list-row chips weren't actually sienna), and a styling tweak meant editing several places.

Introduce a single **`TagBadge`** component (a sienna `@signozhq/ui` `Badge` with an optional `closable` prop) and use it in every place dashboards render a tag:

- **List rows** (`DashboardRow`) — display chips.
- **Details header** (`DashboardInfo`) — display chips + `+N` overflow.
- **Create-dashboard modal** and **Settings → Overview** — the `TagKeyValueInput` editor, which passes `closable` so each chip shows a remove button (the label stays double-click-to-edit).

Now one change to `TagBadge` updates tags everywhere. Also removes the two hand-rolled sienna SCSS blocks (one of which hardcoded `font-family: Inter`).

Also included (same tag-input surface):
- The tag editor keeps `key:key` tags intact instead of collapsing them to a bare `key`.

Scope: V2 dashboard, dark-shipped behind `use_dashboard_v2`.

## Test plan

- Tags render identically (sienna) across list rows, details header, create modal, and settings drawer.
- In the editors, chips show a remove button and double-click still edits; display chips have no remove button.
- A `key:key` tag shows in full in the editor and round-trips on save.
- tsgo + oxlint + stylelint clean; existing `TagKeyValueInput` tests pass.