### PR TITLE
fix: initalize querier in llmpricing

### DIFF
--- a/pkg/modules/llmpricingrule/impllmpricingrule/module.go
+++ b/pkg/modules/llmpricingrule/impllmpricingrule/module.go
@@ -29,7 +29,7 @@ type module struct {
 }
 
 func NewModule(store llmpricingruletypes.Store, flagger flagger.Flagger, querier querier.Querier) llmpricingrule.Module {
-	return &module{store: store, flagger: flagger}
+	return &module{store: store, flagger: flagger, querier: querier}
 }
 
 func (module *module) List(ctx context.Context, orgID valuer.UUID, offset, limit int, search string, isOverride *bool) ([]*llmpricingruletypes.LLMPricingRule, int, error) {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Initializes querier from params during new module.

The initialization was missed in the older PR while resolving merge conflicts.


#### Issues closed by this PR

Part of https://github.com/SigNoz/engineering-pod/issues/5325

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---
#### Root Cause
> What caused the issue?  

While fixing conflicts here https://github.com/SigNoz/signoz/pull/11763/changes/6b5a2cecbdedd215943cbd06d5d97cca7287e36c , should have been more careful
