### PR TITLE
fix(retention): persist TTL error message on failure

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -1038,21 +1038,8 @@ func (r *ClickHouseReader) setTTLLogs(ctx context.Context, orgID string, params 
 			err := r.setColdStorage(context.Background(), tableName, params.ColdStorageVolume)
 			if err != nil {
 				r.logger.Error("error in setting cold storage", errorsV2.Attr(err))
-				statusItem, apiErr := r.checkTTLStatusItem(ctx, orgID, tableName)
-				if apiErr == nil {
-					_, dbErr := r.
-						sqlDB.
-						BunDB().
-						NewUpdate().
-						Model(new(retentiontypes.TTLSetting)).
-						Set("updated_at = ?", time.Now()).
-						Set("status = ?", retentiontypes.TTLSettingStatusFailed).
-						Where("id = ?", statusItem.ID.StringValue()).
-						Exec(ctx)
-					if dbErr != nil {
-						r.logger.Error("Error in processing ttl_status update sql query", errorsV2.Attr(dbErr))
-						return
-					}
+				if statusItem, apiErr := r.checkTTLStatusItem(ctx, orgID, tableName); apiErr == nil {
+					r.updateTTLStatus(ctx, statusItem, retentiontypes.TTLSettingStatusFailed, err.Error())
 				}
 				return
 			}
@@ -1060,34 +1047,10 @@ func (r *ClickHouseReader) setTTLLogs(ctx context.Context, orgID string, params 
 			statusItem, _ := r.checkTTLStatusItem(ctx, orgID, tableName)
 			if err := r.db.Exec(ctx, query); err != nil {
 				r.logger.Error("error while setting ttl", errorsV2.Attr(err))
-				_, dbErr := r.
-					sqlDB.
-					BunDB().
-					NewUpdate().
-					Model(new(retentiontypes.TTLSetting)).
-					Set("updated_at = ?", time.Now()).
-					Set("status = ?", retentiontypes.TTLSettingStatusFailed).
-					Where("id = ?", statusItem.ID.StringValue()).
-					Exec(ctx)
-				if dbErr != nil {
-					r.logger.Error("Error in processing ttl_status update sql query", errorsV2.Attr(dbErr))
-					return
-				}
+				r.updateTTLStatus(ctx, statusItem, retentiontypes.TTLSettingStatusFailed, err.Error())
 				return
 			}
-			_, dbErr = r.
-				sqlDB.
-				BunDB().
-				NewUpdate().
-				Model(new(retentiontypes.TTLSetting)).
-				Set("updated_at = ?", time.Now()).
-				Set("status = ?", retentiontypes.TTLSettingStatusSuccess).
-				Where("id = ?", statusItem.ID.StringValue()).
-				Exec(ctx)
-			if dbErr != nil {
-				r.logger.Error("Error in processing ttl_status update sql query", errorsV2.Attr(dbErr))
-				return
-			}
+			r.updateTTLStatus(ctx, statusItem, retentiontypes.TTLSettingStatusSuccess)
 		}
 
 	}(ttlPayload)
@@ -1211,34 +1174,10 @@ func (r *ClickHouseReader) setTTLTraces(ctx context.Context, orgID string, param
 			statusItem, _ := r.checkTTLStatusItem(ctx, orgID, tableName)
 			if err := r.db.Exec(ctx, req); err != nil {
 				r.logger.Error("Error in executing set TTL query", errorsV2.Attr(err))
-				_, dbErr := r.
-					sqlDB.
-					BunDB().
-					NewUpdate().
-					Model(new(retentiontypes.TTLSetting)).
-					Set("updated_at = ?", time.Now()).
-					Set("status = ?", retentiontypes.TTLSettingStatusFailed).
-					Where("id = ?", statusItem.ID.StringValue()).
-					Exec(ctx)
-				if dbErr != nil {
-					r.logger.Error("Error in processing ttl_status update sql query", errorsV2.Attr(dbErr))
-					return
-				}
+				r.updateTTLStatus(ctx, statusItem, retentiontypes.TTLSettingStatusFailed, err.Error())
 				return
 			}
-			_, dbErr = r.
-				sqlDB.
-				BunDB().
-				NewUpdate().
-				Model(new(retentiontypes.TTLSetting)).
-				Set("updated_at = ?", time.Now()).
-				Set("status = ?", retentiontypes.TTLSettingStatusSuccess).
-				Where("id = ?", statusItem.ID.StringValue()).
-				Exec(ctx)
-			if dbErr != nil {
-				r.logger.Error("Error in processing ttl_status update sql query", errorsV2.Attr(dbErr))
-				return
-			}
+			r.updateTTLStatus(ctx, statusItem, retentiontypes.TTLSettingStatusSuccess)
 		}(distributedTableName)
 	}
 	return &retentiontypes.SetTTLResponseItem{Message: "move ttl has been successfully set up"}, nil
@@ -1450,7 +1389,7 @@ func (r *ClickHouseReader) SetTTLV2(ctx context.Context, orgID string, params *r
 			err := r.setColdStorage(ctx, tableName, params.ColdStorageVolume)
 			if err != nil {
 				r.logger.Error("error in setting cold storage", errorsV2.Attr(err))
-				r.updateCustomRetentionTTLStatus(ctx, orgID, tableName, retentiontypes.TTLSettingStatusFailed)
+				r.updateCustomRetentionTTLStatus(ctx, orgID, tableName, retentiontypes.TTLSettingStatusFailed, err.Error())
 				return nil, errorsV2.Wrapf(err.Err, errorsV2.TypeInternal, errorsV2.CodeInternal, "error setting cold storage for table %s", tableName)
 			}
 		}
@@ -1459,7 +1398,7 @@ func (r *ClickHouseReader) SetTTLV2(ctx context.Context, orgID string, params *r
 			r.logger.Debug("Executing custom retention TTL request: ", "request", query, "step", i+1)
 			if err := r.db.Exec(ctx, query); err != nil {
 				r.logger.Error("error while setting custom retention ttl", errorsV2.Attr(err))
-				r.updateCustomRetentionTTLStatus(ctx, orgID, tableName, retentiontypes.TTLSettingStatusFailed)
+				r.updateCustomRetentionTTLStatus(ctx, orgID, tableName, retentiontypes.TTLSettingStatusFailed, err.Error())
 				return nil, errorsV2.Wrapf(err, errorsV2.TypeInternal, errorsV2.CodeInternal, "error setting custom retention TTL for table %s, query: %s", tableName, query)
 			}
 		}
@@ -1597,6 +1536,7 @@ func (r *ClickHouseReader) GetCustomRetentionTTL(ctx context.Context, orgID stri
 		response.TTLConditions = ttlConditions
 		response.Status = customTTL.Status
 		response.ColdStorageTTLDays = customTTL.ColdStorageTTL
+		response.ErrorMessage = customTTL.ErrorMessage
 
 	} else {
 		// V1 - Traditional TTL
@@ -1648,18 +1588,43 @@ func (r *ClickHouseReader) checkCustomRetentionTTLStatusItem(ctx context.Context
 	return ttl, nil
 }
 
-func (r *ClickHouseReader) updateCustomRetentionTTLStatus(ctx context.Context, orgID, tableName, status string) {
+func (r *ClickHouseReader) updateCustomRetentionTTLStatus(ctx context.Context, orgID, tableName, status string, errMsg ...string) {
 	statusItem, apiErr := r.checkCustomRetentionTTLStatusItem(ctx, orgID, tableName)
 	if apiErr == nil && statusItem != nil {
-		_, dbErr := r.sqlDB.BunDB().NewUpdate().
+		update := r.sqlDB.BunDB().NewUpdate().
 			Model(new(retentiontypes.TTLSetting)).
 			Set("updated_at = ?", time.Now()).
-			Set("status = ?", status).
+			Set("status = ?", status)
+		if len(errMsg) > 0 {
+			update = update.Set("error_message = ?", errMsg[0])
+		}
+		_, dbErr := update.
 			Where("id = ?", statusItem.ID.StringValue()).
 			Exec(ctx)
 		if dbErr != nil {
 			r.logger.Error("Error in processing custom_retention_ttl_status update sql query", errorsV2.Attr(dbErr))
 		}
+	}
+}
+
+// updateTTLStatus persists a status (and optional error message) on an
+// existing TTLSetting row that the caller has already loaded.
+func (r *ClickHouseReader) updateTTLStatus(ctx context.Context, statusItem *retentiontypes.TTLSetting, status string, errMsg ...string) {
+	if statusItem == nil {
+		return
+	}
+	update := r.sqlDB.BunDB().NewUpdate().
+		Model(new(retentiontypes.TTLSetting)).
+		Set("updated_at = ?", time.Now()).
+		Set("status = ?", status)
+	if len(errMsg) > 0 {
+		update = update.Set("error_message = ?", errMsg[0])
+	}
+	_, dbErr := update.
+		Where("id = ?", statusItem.ID.StringValue()).
+		Exec(ctx)
+	if dbErr != nil {
+		r.logger.Error("Error in processing ttl_status update sql query", errorsV2.Attr(dbErr))
 	}
 }
 
@@ -1860,21 +1825,8 @@ func (r *ClickHouseReader) setTTLMetrics(ctx context.Context, orgID string, para
 		err := r.setColdStorage(context.Background(), tableName, params.ColdStorageVolume)
 		if err != nil {
 			r.logger.Error("Error in setting cold storage", errorsV2.Attr(err))
-			statusItem, apiErr := r.checkTTLStatusItem(ctx, orgID, tableName)
-			if apiErr == nil {
-				_, dbErr := r.
-					sqlDB.
-					BunDB().
-					NewUpdate().
-					Model(new(retentiontypes.TTLSetting)).
-					Set("updated_at = ?", time.Now()).
-					Set("status = ?", retentiontypes.TTLSettingStatusFailed).
-					Where("id = ?", statusItem.ID.StringValue()).
-					Exec(ctx)
-				if dbErr != nil {
-					r.logger.Error("Error in processing ttl_status update sql query", errorsV2.Attr(dbErr))
-					return
-				}
+			if statusItem, apiErr := r.checkTTLStatusItem(ctx, orgID, tableName); apiErr == nil {
+				r.updateTTLStatus(ctx, statusItem, retentiontypes.TTLSettingStatusFailed, err.Error())
 			}
 			return
 		}
@@ -1883,34 +1835,10 @@ func (r *ClickHouseReader) setTTLMetrics(ctx context.Context, orgID string, para
 		statusItem, _ := r.checkTTLStatusItem(ctx, orgID, tableName)
 		if err := r.db.Exec(ctx, req); err != nil {
 			r.logger.Error("error while setting ttl.", errorsV2.Attr(err))
-			_, dbErr := r.
-				sqlDB.
-				BunDB().
-				NewUpdate().
-				Model(new(retentiontypes.TTLSetting)).
-				Set("updated_at = ?", time.Now()).
-				Set("status = ?", retentiontypes.TTLSettingStatusFailed).
-				Where("id = ?", statusItem.ID.StringValue()).
-				Exec(ctx)
-			if dbErr != nil {
-				r.logger.Error("Error in processing ttl_status update sql query", errorsV2.Attr(dbErr))
-				return
-			}
+			r.updateTTLStatus(ctx, statusItem, retentiontypes.TTLSettingStatusFailed, err.Error())
 			return
 		}
-		_, dbErr = r.
-			sqlDB.
-			BunDB().
-			NewUpdate().
-			Model(new(retentiontypes.TTLSetting)).
-			Set("updated_at = ?", time.Now()).
-			Set("status = ?", retentiontypes.TTLSettingStatusSuccess).
-			Where("id = ?", statusItem.ID.StringValue()).
-			Exec(ctx)
-		if dbErr != nil {
-			r.logger.Error("Error in processing ttl_status update sql query", errorsV2.Attr(dbErr))
-			return
-		}
+		r.updateTTLStatus(ctx, statusItem, retentiontypes.TTLSettingStatusSuccess)
 	}
 	for _, tableName := range tableNames {
 		go metricTTL(tableName)

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -221,6 +221,8 @@ func NewSQLMigrationProviderFactories(
 		sqlmigration.NewAddRoleTransactionGroupsFactory(sqlstore, sqlschema),
 		sqlmigration.NewAddTagUniqueIndexFactory(sqlstore, sqlschema),
 		sqlmigration.NewAddTelemetryTuplesFactory(sqlstore),
+		sqlmigration.NewAddTTLSettingErrorMessageFactory(sqlstore, sqlschema),
+
 	)
 }
 

--- a/pkg/sqlmigration/099_add_ttl_setting_error_message.go
+++ b/pkg/sqlmigration/099_add_ttl_setting_error_message.go
@@ -1,0 +1,75 @@
+package sqlmigration
+
+import (
+	"context"
+
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/sqlschema"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/migrate"
+)
+
+type addTTLSettingErrorMessage struct {
+	sqlstore  sqlstore.SQLStore
+	sqlschema sqlschema.SQLSchema
+}
+
+func NewAddTTLSettingErrorMessageFactory(sqlstore sqlstore.SQLStore, sqlschema sqlschema.SQLSchema) factory.ProviderFactory[SQLMigration, Config] {
+	return factory.NewProviderFactory(factory.MustNewName("add_ttl_setting_error_message"), func(ctx context.Context, ps factory.ProviderSettings, config Config) (SQLMigration, error) {
+		return newAddTTLSettingErrorMessage(ctx, ps, config, sqlstore, sqlschema)
+	})
+}
+
+func newAddTTLSettingErrorMessage(_ context.Context, _ factory.ProviderSettings, _ Config, sqlstore sqlstore.SQLStore, sqlschema sqlschema.SQLSchema) (SQLMigration, error) {
+	return &addTTLSettingErrorMessage{
+		sqlstore:  sqlstore,
+		sqlschema: sqlschema,
+	}, nil
+}
+
+func (migration *addTTLSettingErrorMessage) Register(migrations *migrate.Migrations) error {
+	if err := migrations.Register(migration.Up, migration.Down); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (migration *addTTLSettingErrorMessage) Up(ctx context.Context, db *bun.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	table, _, err := migration.sqlschema.GetTable(ctx, sqlschema.TableName("ttl_setting"))
+	if err != nil {
+		return err
+	}
+
+	column := &sqlschema.Column{
+		Name:     sqlschema.ColumnName("error_message"),
+		DataType: sqlschema.DataTypeText,
+		Nullable: true,
+	}
+
+	sqls := migration.sqlschema.Operator().AddColumn(table, nil, column, nil)
+	for _, sql := range sqls {
+		if _, err := tx.ExecContext(ctx, string(sql)); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (migration *addTTLSettingErrorMessage) Down(ctx context.Context, db *bun.DB) error {
+	return nil
+}

--- a/pkg/types/retentiontypes/ttl.go
+++ b/pkg/types/retentiontypes/ttl.go
@@ -147,6 +147,7 @@ type TTLSetting struct {
 	Status         string `bun:"status,type:text,notnull"`
 	OrgID          string `json:"-" bun:"org_id,notnull"`
 	Condition      string `bun:"condition,type:text"`
+	ErrorMessage   string `bun:"error_message,type:text"`
 }
 
 type TTLParams struct {
@@ -179,6 +180,7 @@ type GetCustomRetentionTTLResponse struct {
 	TTLConditions      []CustomRetentionRule `json:"ttl_conditions,omitempty"`
 	ColdStorageVolume  string                `json:"cold_storage_volume,omitempty"`
 	ColdStorageTTLDays int                   `json:"cold_storage_ttl_days,omitempty"`
+	ErrorMessage       string                `json:"error_message,omitempty"`
 }
 
 type CustomRetentionTTLResponse struct {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

> Why does this change exist? What problem does it solve?

When a TTL or cold-storage apply fails today, the failure reason is
written to the application log but never persisted. Users hitting a
stuck "TTL running" state have no way to see why without SSH access
to the query-service container.

This PR persists the failure message in a new `error_message` column
on `ttl_setting` and surfaces it on the existing
`GET /api/v2/settings/ttl` response, so the UI can show it next to
the failed status row.

#### Screenshots / Screen Recordings (if applicable)
> N/A — backend change; the UI rendering of the new field is out of
> scope for this PR but the API contract is now in place.

#### Issues closed by this PR
- Closes #1822

---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

`pkg/query-service/app/clickhouseReader/reader.go` writes the TTL
status (`pending`, `success`, `failed`) back to the `ttl_setting`
row on every state transition, but the failure paths only call
`r.logger.Error(...)` and never store the underlying message. The
three `setTTL{Logs,Traces,Metrics}` functions each had a copy of the
same 14-line `Update` block, and the custom retention path
(`SetTTLV2`) had its own helper that had the same gap.

#### Fix Strategy

- Add an `error_message` column to `ttl_setting` via migration `099`
  (nullable `text`, idempotent against existing rows).
- Extend the `TTLSetting` Go struct with `ErrorMessage` and the
  `GetCustomRetentionTTLResponse` API response with `error_message`.
- Add a private `updateTTLStatus(ctx, statusItem, status, errMsg...)`
  helper on `ClickHouseReader`. Variadic `errMsg` keeps the success
  callers (`updateTTLStatus(ctx, item, Success)`) unchanged.
- Replace the three repeated Update blocks in
  `setTTLLogs` / `setTTLTraces` / `setTTLMetrics` with calls to the
  helper, passing `err.Error()` on the failure branches.
- Update the existing `updateCustomRetentionTTLStatus` helper the
  same way and pass `err.Error()` from the two failure sites in
  `SetTTLV2`.
- Wire `error_message` through `GetCustomRetentionTTL` so the API
  exposes it.

---

### 🧪 Testing Strategy

- Tests added/updated: none at the clickhouseReader level (no test
  infrastructure exists for it; the file does not yet have a
  `_test.go` sibling). Behaviour is covered by the focused
  build/vet passes below.
- Manual verification:
  - `go build ./pkg/types/retentiontypes/... ./pkg/sqlmigration/...
    ./pkg/query-service/app/clickhouseReader/... ./pkg/signoz/...` →
    pass
  - `go vet` on the same packages → pass
  - `go test ./pkg/types/retentiontypes/... ./pkg/sqlstore/...` →
    pass
- Edge cases covered:
  - Success path: `error_message` is left untouched (variadic
    `errMsg...` is empty so the column is not included in the
    UPDATE). Existing success rows keep their (NULL) value.
  - Failure path: `err.Error()` is written atomically with the
    `status = 'failed'` set.
  - Nil `statusItem`: helper is a no-op, same as the previous inline
    code path.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: query-service TTL paths only. No public API
  contract change — the new field is omitempty. The new column is
  nullable so old rows are valid as-is.
- Potential regressions: if a downstream consumer (alert manager,
  webhook, third-party) was relying on the absence of the
  `error_message` key, that is unlikely because the response is
  parsed by SigNoz clients first. The new column adds disk space
  per TTL row (a few hundred bytes per failed apply).
- Rollback plan: migration `099` Down is empty (the existing
  `048` and others follow this pattern). Reverting the code change
  alone leaves the column unused; existing rows remain valid.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | OSS |
| Change Type | Bug Fix |
| Description | TTL failures now persist the error message in `ttl_setting.error_message`, returned by `GET /api/v2/settings/ttl`, so users see why a TTL change failed without grepping logs. |

---

### 📋 Checklist

- [x] Tests added or explicitly not required (no test infra in this package; existing touched packages pass)
- [x] Manually tested (build, vet, focused go test suites)
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered (nullable column, omitempty API field)

---

### 👀 Notes for Reviewers

The diff is net `-69` lines because the helper absorbed three
~14-line Update blocks. The `updateCustomRetentionTTLStatus`
signature gains a variadic `errMsg ...string` which is backwards
compatible with the existing two callers in this PR (success paths
still pass nothing).