### PR TITLE
fix(docs): correct broken relative links in contributing docs

### DIFF
--- a/.claude/agents/playwright-test-planner.md
+++ b/.claude/agents/playwright-test-planner.md
@@ -21,7 +21,7 @@ You will:
 
 2. **Check what's already wired up.**
    - [tests/e2e/helpers/dashboards.ts](../../tests/e2e/helpers/dashboards.ts) and [tests/e2e/helpers/auth.ts](../../tests/e2e/helpers/auth.ts) hold reusable helpers (`createDashboardViaApi`, `gotoDashboardsList`, `openDashboardActionMenu`, `newAdminContext`, `importApmMetricsDashboardViaUI`, etc.). When the plan touches dashboards, reference these by name in the steps so the generator can reuse them rather than reinvent.
-   - [tests/e2e/fixtures/apm-metrics.json](../../tests/e2e/fixtures/apm-metrics.json) is a real-world dashboard payload (rich tags, panels, description) suitable as a seed fixture — note in the plan if a scenario benefits from it.
+   - [tests/e2e/testdata/apm-metrics.json](../../tests/e2e/testdata/apm-metrics.json) is a real-world dashboard payload (rich tags, panels, description) suitable as a seed fixture — note in the plan if a scenario benefits from it.
 
 3. **Navigate and explore**
    - Invoke `planner_setup_page` once before any other browser tool.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,4 +79,4 @@ Need assistance? Join our Slack community:
 - Set up your [development environment](docs/contributing/development.md)
 - Deploy and observe [SigNoz in action with OpenTelemetry Demo Application](docs/otel-demo-docs.md)
 - Explore the [SigNoz Community Advocate Program](ADVOCATE.md), which recognises contributors who support the community, share their expertise, and help shape SigNoz's future.
-- Write [integration tests](docs/contributing/go/integration.md)
+- Write [integration tests](docs/contributing/tests/integration.md)

--- a/docs/contributing/tests/e2e.md
+++ b/docs/contributing/tests/e2e.md
@@ -199,7 +199,7 @@ Three Claude agents in `.claude/agents/` accelerate writing and maintaining E2E 
 - **`playwright-test-generator`** — converts a test plan into Playwright spec files under `tests/e2e/tests/<feature>/`. Drives each scenario through MCP browser tools and emits TC-NN-titled tests using the `authedPage` fixture and the API-seed pattern.
 - **`playwright-test-healer`** — runs failing specs, debugs them with snapshots / console / network introspection, and edits the spec to fix selector drift, timing, or state-leak issues.
 
-The agents rely on the Playwright-test MCP server (`mcp__playwright-test__*` tools). Configure it in your Claude MCP settings; the permission allowlist lives in [.claude/settings.local.json](../../../.claude/settings.local.json).
+The agents rely on the Playwright-test MCP server (`mcp__playwright-test__*` tools). Configure it in your Claude MCP settings; the permission allowlist lives in `.claude/settings.local.json` (a per-developer local file that is not committed to the repo).
 
 ## How to run E2E tests?
 


### PR DESCRIPTION
Noticed a few doc links pointing to files that had been moved or renamed, so I went through and fixed them. While I was at it, I checked the rest of the repo for the same problem, turned out these were the only three.