### PR TITLE
feat(dashboard-v2): runtime variable fetch engine & selectors

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/useVariableForm.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/useVariableForm.ts
@@ -46,8 +46,12 @@ export interface UseVariableForm {
 	handleSave: () => void;
 }
 
-const readDefaultValue = (model: VariableFormModel): string =>
-	((model.defaultValue as { value?: string })?.value ?? '') as string;
+// `defaultValue` is a string | string[] on the wire; the editor uses a single
+// string, so take the first when it's an array.
+const readDefaultValue = (model: VariableFormModel): string => {
+	const dv = model.defaultValue;
+	return Array.isArray(dv) ? (dv[0] ?? '') : (dv ?? '');
+};
 
 /** Form state, derivations and handlers for the variable editor. */
 export function useVariableForm({

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariableSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariableSelector.tsx
@@ -22,6 +22,8 @@ interface VariableSelectorProps {
 	selections: VariableSelectionMap;
 	selection: VariableSelection;
 	onChange: (selection: VariableSelection) => void;
+	/** Batched fill applied when options resolve (Query/Dynamic auto-selection). */
+	onAutoSelect: (selection: VariableSelection) => void;
 }
 
 /** One labelled variable control; dispatches on the variable type. */
@@ -31,6 +33,7 @@ function VariableSelector({
 	selections,
 	selection,
 	onChange,
+	onAutoSelect,
 }: VariableSelectorProps): JSX.Element {
 	const customOptions = useMemo(
 		() =>
@@ -61,6 +64,7 @@ function VariableSelector({
 						selections={selections}
 						selection={selection}
 						onChange={onChange}
+						onAutoSelect={onAutoSelect}
 					/>
 				);
 			case 'DYNAMIC':
@@ -71,6 +75,7 @@ function VariableSelector({
 						selections={selections}
 						selection={selection}
 						onChange={onChange}
+						onAutoSelect={onAutoSelect}
 					/>
 				);
 			case 'CUSTOM':

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariableSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariableSelector.tsx
@@ -18,8 +18,6 @@ interface VariableSelectorProps {
 	variable: VariableFormModel;
 	/** All variables (Dynamic uses them to scope options by sibling selections). */
 	variables: VariableFormModel[];
-	/** Names this variable depends on (for Query gating). */
-	parents: string[];
 	/** All current selections (Query passes them as the request payload). */
 	selections: VariableSelectionMap;
 	selection: VariableSelection;
@@ -30,7 +28,6 @@ interface VariableSelectorProps {
 function VariableSelector({
 	variable,
 	variables,
-	parents,
 	selections,
 	selection,
 	onChange,
@@ -61,7 +58,6 @@ function VariableSelector({
 				return (
 					<QuerySelector
 						variable={variable}
-						parents={parents}
 						selections={selections}
 						selection={selection}
 						onChange={onChange}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.module.scss
@@ -112,3 +112,13 @@
 		box-shadow: none !important;
 	}
 }
+
+.overflowTooltip {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.overflowName {
+	font-weight: var(--font-weight-medium);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
@@ -42,7 +42,8 @@ interface VariablesBarProps {
  * either way so auto-selection and option fetching keep driving the panels.
  */
 function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
-	const { variables, selection, setSelection } = useVariableSelection(dashboard);
+	const { variables, selection, setSelection, autoSelect } =
+		useVariableSelection(dashboard);
 	const [expanded, setExpanded] = useState(false);
 	const { containerRef, visibleCount, overflowCount } = useInlineOverflowCount({
 		itemCount: variables.length,
@@ -99,6 +100,7 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 								}
 							}
 							onChange={(next): void => setSelection(variable.name, next)}
+							onAutoSelect={(next): void => autoSelect(variable.name, next)}
 						/>
 					</div>
 				))}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
@@ -23,8 +23,7 @@ interface VariablesBarProps {
  * either way so auto-selection and option fetching keep driving the panels.
  */
 function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
-	const { variables, dependencyData, selection, setSelection } =
-		useVariableSelection(dashboard);
+	const { variables, selection, setSelection } = useVariableSelection(dashboard);
 	const [expanded, setExpanded] = useState(false);
 	const { containerRef, visibleCount, overflowCount } = useInlineOverflowCount({
 		itemCount: variables.length,
@@ -57,7 +56,6 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 						<VariableSelector
 							variable={variable}
 							variables={variables}
-							parents={dependencyData.parentGraph[variable.name] ?? []}
 							selections={selection}
 							selection={
 								selection[variable.name] ?? {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
@@ -1,13 +1,32 @@
 import { useState } from 'react';
 import { ChevronLeft } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
+import { TooltipSimple } from '@signozhq/ui/tooltip';
 import cx from 'classnames';
 import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
 import { useInlineOverflowCount } from 'hooks/useInlineOverflowCount';
 
+import type { VariableSelection } from './selectionTypes';
 import { useVariableSelection } from './useVariableSelection';
 import VariableSelector from './VariableSelector';
 import styles from './VariablesBar.module.scss';
+
+// Short display of a variable's current selection, for the collapsed +N tooltip.
+function formatSelection(selection: VariableSelection | undefined): string {
+	if (!selection) {
+		return '—';
+	}
+	if (selection.allSelected) {
+		return 'ALL';
+	}
+	const { value } = selection;
+	if (Array.isArray(value)) {
+		return value.length > 0 ? value.join(', ') : '—';
+	}
+	return value === '' || value === null || value === undefined
+		? '—'
+		: String(value);
+}
 
 interface VariablesBarProps {
 	dashboard: DashboardtypesGettableDashboardV2DTO;
@@ -37,6 +56,22 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 	}
 
 	const hasOverflow = overflowCount > 0;
+	const hiddenVariables =
+		!expanded && hasOverflow ? variables.slice(visibleCount) : [];
+
+	const moreButton = (
+		<Button
+			variant="outlined"
+			color="secondary"
+			size="md"
+			prefix={expanded ? <ChevronLeft size={14} /> : undefined}
+			aria-expanded={expanded}
+			testId="dashboard-variables-more"
+			onClick={(): void => setExpanded((prev) => !prev)}
+		>
+			{expanded ? 'Less' : `+${overflowCount}`}
+		</Button>
+	);
 
 	return (
 		<div className={styles.bar} data-testid="dashboard-variables-bar">
@@ -70,17 +105,25 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 
 				{hasOverflow && (
 					<span className={styles.moreButton}>
-						<Button
-							variant="outlined"
-							color="secondary"
-							size="md"
-							prefix={expanded ? <ChevronLeft size={14} /> : undefined}
-							aria-expanded={expanded}
-							testId="dashboard-variables-more"
-							onClick={(): void => setExpanded((prev) => !prev)}
-						>
-							{expanded ? 'Less' : `+${overflowCount}`}
-						</Button>
+						{expanded ? (
+							moreButton
+						) : (
+							<TooltipSimple
+								side="top"
+								title={
+									<div className={styles.overflowTooltip}>
+										{hiddenVariables.map((variable) => (
+											<div key={variable.name}>
+												<span className={styles.overflowName}>{variable.name}</span>:{' '}
+												{formatSelection(selection[variable.name])}
+											</div>
+										))}
+									</div>
+								}
+							>
+								{moreButton}
+							</TooltipSimple>
+						)}
 					</span>
 				)}
 			</div>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
@@ -28,6 +28,8 @@ interface DynamicSelectorProps {
 	selections: VariableSelectionMap;
 	selection: VariableSelection;
 	onChange: (selection: VariableSelection) => void;
+	/** Batched auto-selection fill applied when options resolve. */
+	onAutoSelect: (selection: VariableSelection) => void;
 }
 
 /**
@@ -43,6 +45,7 @@ function DynamicSelector({
 	selections,
 	selection,
 	onChange,
+	onAutoSelect,
 }: DynamicSelectorProps): JSX.Element {
 	const { minTime, maxTime } = useSelector<AppState, GlobalReducer>(
 		(state) => state.globalTime,
@@ -106,7 +109,7 @@ function DynamicSelector({
 		return sortValuesByOrder(values, variable.sort).map(String);
 	}, [data, variable.sort]);
 
-	useAutoSelect(variable, options, selection, onChange);
+	useAutoSelect(variable, options, selection, onAutoSelect);
 
 	return (
 		<ValueSelector

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
+import { useQuery } from 'react-query';
 // eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
-import { useGetFieldValues } from 'hooks/dynamicVariables/useGetFieldValues';
+import { getFieldValues } from 'api/dynamicVariables/getFieldValues';
 import type { AppState } from 'store/reducers';
 import type { GlobalReducer } from 'types/reducer/globalTime';
 
@@ -10,12 +11,14 @@ import {
 	sortValuesByOrder,
 } from '../../DashboardSettings/Variables/variableFormModel';
 import type { VariableFormModel } from '../../DashboardSettings/Variables/variableFormModel';
+import { useDashboardStore } from '../../store/useDashboardStore';
 import { buildExistingDynamicVariableQuery } from '../dynamicFilter';
 import type {
 	VariableSelection,
 	VariableSelectionMap,
 } from '../selectionTypes';
 import { useAutoSelect } from '../useAutoSelect';
+import { useVariableFetchState } from '../useVariableFetchState';
 import ValueSelector from './ValueSelector';
 
 interface DynamicSelectorProps {
@@ -30,7 +33,9 @@ interface DynamicSelectorProps {
 /**
  * Dynamic-variable options sourced from live telemetry field values for the
  * chosen signal + attribute, scoped by the other dynamic variables' selections
- * (so e.g. `pod` narrows to the chosen `namespace`).
+ * (so e.g. `pod` narrows to the chosen `namespace`). WHEN to fetch is owned by
+ * the runtime fetch engine: dynamics fetch together once the query variables have
+ * values, and refetch (via a `cycleId` bump) whenever any variable value changes.
  */
 function DynamicSelector({
 	variable,
@@ -48,14 +53,51 @@ function DynamicSelector({
 		[variables, selections, variable.name],
 	);
 
-	const { data, isFetching } = useGetFieldValues({
-		signal: signalForApi(variable.dynamicSignal),
-		name: variable.dynamicAttribute,
-		startUnixMilli: minTime,
-		endUnixMilli: maxTime,
-		existingQuery: existingQuery || undefined,
-		enabled: !!variable.dynamicAttribute,
-	});
+	const {
+		variableFetchCycleId,
+		isVariableFetching,
+		isVariableSettled,
+		isVariableWaiting,
+		hasVariableFetchedOnce,
+	} = useVariableFetchState(variable.name);
+	const onVariableFetchComplete = useDashboardStore(
+		(s) => s.onVariableFetchComplete,
+	);
+	const onVariableFetchFailure = useDashboardStore(
+		(s) => s.onVariableFetchFailure,
+	);
+
+	const { data, isFetching } = useQuery(
+		[
+			'dashboard-variable-dynamic',
+			variable.name,
+			variable.dynamicSignal,
+			variable.dynamicAttribute,
+			existingQuery,
+			minTime,
+			maxTime,
+			variableFetchCycleId,
+		],
+		() =>
+			getFieldValues(
+				signalForApi(variable.dynamicSignal),
+				variable.dynamicAttribute,
+				undefined,
+				minTime,
+				maxTime,
+				existingQuery || undefined,
+			),
+		{
+			enabled:
+				!!variable.dynamicAttribute &&
+				(isVariableFetching || (isVariableSettled && hasVariableFetchedOnce)),
+			refetchOnWindowFocus: false,
+			onSettled: (_, error) =>
+				error
+					? onVariableFetchFailure(variable.name)
+					: onVariableFetchComplete(variable.name),
+		},
+	);
 
 	const options = useMemo(() => {
 		const payload = data?.data;
@@ -71,7 +113,7 @@ function DynamicSelector({
 			options={options}
 			multiSelect={variable.multiSelect}
 			showAllOption={variable.showAllOption}
-			loading={isFetching}
+			loading={isFetching || isVariableWaiting}
 			selection={selection}
 			onChange={onChange}
 			testId={`variable-select-${variable.name}`}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/QuerySelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/QuerySelector.tsx
@@ -8,18 +8,18 @@ import type { GlobalReducer } from 'types/reducer/globalTime';
 
 import { sortValuesByOrder } from '../../DashboardSettings/Variables/variableFormModel';
 import type { VariableFormModel } from '../../DashboardSettings/Variables/variableFormModel';
+import { useDashboardStore } from '../../store/useDashboardStore';
 import type {
 	VariableSelection,
 	VariableSelectionMap,
 } from '../selectionTypes';
-import { isResolved, selectionToPayload } from '../selectionUtils';
+import { selectionToPayload } from '../selectionUtils';
 import { useAutoSelect } from '../useAutoSelect';
+import { useVariableFetchState } from '../useVariableFetchState';
 import ValueSelector from './ValueSelector';
 
 interface QuerySelectorProps {
 	variable: VariableFormModel;
-	/** Names this variable's query references; it waits until they're resolved. */
-	parents: string[];
 	/** All current selections, fed to the query as `{ name: value }`. */
 	selections: VariableSelectionMap;
 	selection: VariableSelection;
@@ -27,14 +27,15 @@ interface QuerySelectorProps {
 }
 
 /**
- * Query-driven options. Dependency orchestration is declarative: the query is
- * `enabled` only once every parent is resolved, and the parent values are in the
- * query key — so it refetches automatically when a parent changes (and a cyclic
- * dependency is simply never enabled).
+ * Query-driven options. WHEN to fetch is owned by the runtime fetch engine
+ * (`variableFetchSlice`): the query is `enabled` while this variable is fetching
+ * (or settled-after-a-first-fetch, so a cycle bump re-runs it), and the engine's
+ * per-variable `cycleId` keys the request — so a parent's value change refetches
+ * only the dependent variables, in dependency order. The current selections feed
+ * the request payload but are deliberately NOT in the key (V1 parity).
  */
 function QuerySelector({
 	variable,
-	parents,
 	selections,
 	selection,
 	onChange,
@@ -43,23 +44,43 @@ function QuerySelector({
 		(state) => state.globalTime,
 	);
 	const payload = useMemo(() => selectionToPayload(selections), [selections]);
-	const enabled = parents.every((parent) => isResolved(selections[parent]));
+
+	const {
+		variableFetchCycleId,
+		isVariableFetching,
+		isVariableSettled,
+		isVariableWaiting,
+		hasVariableFetchedOnce,
+	} = useVariableFetchState(variable.name);
+	const onVariableFetchComplete = useDashboardStore(
+		(s) => s.onVariableFetchComplete,
+	);
+	const onVariableFetchFailure = useDashboardStore(
+		(s) => s.onVariableFetchFailure,
+	);
 
 	const { data, isFetching } = useQuery(
 		[
 			'dashboard-variable',
 			variable.name,
 			variable.queryValue,
-			payload,
 			minTime,
 			maxTime,
+			variableFetchCycleId,
 		],
 		() =>
 			dashboardVariablesQuery({
 				query: variable.queryValue,
 				variables: payload,
 			}),
-		{ enabled, refetchOnWindowFocus: false },
+		{
+			enabled: isVariableFetching || (isVariableSettled && hasVariableFetchedOnce),
+			refetchOnWindowFocus: false,
+			onSettled: (_, error) =>
+				error
+					? onVariableFetchFailure(variable.name)
+					: onVariableFetchComplete(variable.name),
+		},
 	);
 
 	const options = useMemo(() => {
@@ -79,7 +100,7 @@ function QuerySelector({
 			options={options}
 			multiSelect={variable.multiSelect}
 			showAllOption={variable.showAllOption}
-			loading={isFetching}
+			loading={isFetching || isVariableWaiting}
 			selection={selection}
 			onChange={onChange}
 			testId={`variable-select-${variable.name}`}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/QuerySelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/QuerySelector.tsx
@@ -24,6 +24,8 @@ interface QuerySelectorProps {
 	selections: VariableSelectionMap;
 	selection: VariableSelection;
 	onChange: (selection: VariableSelection) => void;
+	/** Batched auto-selection fill applied when options resolve. */
+	onAutoSelect: (selection: VariableSelection) => void;
 }
 
 /**
@@ -39,6 +41,7 @@ function QuerySelector({
 	selections,
 	selection,
 	onChange,
+	onAutoSelect,
 }: QuerySelectorProps): JSX.Element {
 	const { minTime, maxTime } = useSelector<AppState, GlobalReducer>(
 		(state) => state.globalTime,
@@ -93,7 +96,7 @@ function QuerySelector({
 		).map(String);
 	}, [data, variable.sort]);
 
-	useAutoSelect(variable, options, selection, onChange);
+	useAutoSelect(variable, options, selection, onAutoSelect);
 
 	return (
 		<ValueSelector

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useAutoSelect.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useAutoSelect.ts
@@ -12,7 +12,7 @@ export function useAutoSelect(
 	variable: VariableFormModel,
 	options: string[],
 	selection: VariableSelection,
-	onChange: (selection: VariableSelection) => void,
+	onAutoSelect: (selection: VariableSelection) => void,
 ): void {
 	useEffect(() => {
 		if (options.length === 0 || selection.allSelected) {
@@ -32,7 +32,7 @@ export function useAutoSelect(
 		const fallback = Array.isArray(dv) ? dv[0] : dv;
 		const initial =
 			fallback && options.includes(fallback) ? fallback : options[0];
-		onChange({
+		onAutoSelect({
 			value: variable.multiSelect ? [initial] : initial,
 			allSelected: false,
 		});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useAutoSelect.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useAutoSelect.ts
@@ -28,8 +28,8 @@ export function useAutoSelect(
 		if (isValid) {
 			return;
 		}
-		const fallback = (variable.defaultValue as { value?: string } | undefined)
-			?.value;
+		const dv = variable.defaultValue;
+		const fallback = Array.isArray(dv) ? dv[0] : dv;
 		const initial =
 			fallback && options.includes(fallback) ? fallback : options[0];
 		onChange({

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableFetchState.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableFetchState.ts
@@ -1,0 +1,44 @@
+import {
+	selectVariableCycleId,
+	selectVariableFetchedOnce,
+	selectVariableFetchState,
+	type VariableFetchState,
+} from '../store/slices/variableFetchSlice';
+import { useDashboardStore } from '../store/useDashboardStore';
+
+export interface VariableFetchStateResult {
+	variableFetchState: VariableFetchState;
+	/** Include in the selector's react-query key to auto-cancel stale requests. */
+	variableFetchCycleId: number;
+	/** Actively fetching (first load or revalidating). */
+	isVariableFetching: boolean;
+	/** Stable — the fetch completed (or errored). */
+	isVariableSettled: boolean;
+	/** Blocked on parent dependencies (query order) or query variables (dynamics). */
+	isVariableWaiting: boolean;
+	/** Completed at least one fetch — keeps the query subscribed so a cycle bump refetches. */
+	hasVariableFetchedOnce: boolean;
+}
+
+/**
+ * Per-variable view of the runtime fetch engine (`variableFetchSlice`), consumed
+ * by the Query/Dynamic selectors to gate their fetch and key it by cycle id.
+ * V2-native equivalent of V1's `useVariableFetchState`.
+ */
+export function useVariableFetchState(name: string): VariableFetchStateResult {
+	const variableFetchState = useDashboardStore(selectVariableFetchState(name));
+	const variableFetchCycleId = useDashboardStore(selectVariableCycleId(name));
+	const hasVariableFetchedOnce = useDashboardStore(
+		selectVariableFetchedOnce(name),
+	);
+
+	return {
+		variableFetchState,
+		variableFetchCycleId,
+		isVariableFetching:
+			variableFetchState === 'loading' || variableFetchState === 'revalidating',
+		isVariableSettled: variableFetchState === 'idle',
+		isVariableWaiting: variableFetchState === 'waiting',
+		hasVariableFetchedOnce,
+	};
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableFetchState.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableFetchState.ts
@@ -2,7 +2,7 @@ import {
 	selectVariableCycleId,
 	selectVariableFetchedOnce,
 	selectVariableFetchState,
-	type VariableFetchState,
+	VariableFetchState,
 } from '../store/slices/variableFetchSlice';
 import { useDashboardStore } from '../store/useDashboardStore';
 
@@ -36,9 +36,10 @@ export function useVariableFetchState(name: string): VariableFetchStateResult {
 		variableFetchState,
 		variableFetchCycleId,
 		isVariableFetching:
-			variableFetchState === 'loading' || variableFetchState === 'revalidating',
-		isVariableSettled: variableFetchState === 'idle',
-		isVariableWaiting: variableFetchState === 'waiting',
+			variableFetchState === VariableFetchState.Loading ||
+			variableFetchState === VariableFetchState.Revalidating,
+		isVariableSettled: variableFetchState === VariableFetchState.Idle,
+		isVariableWaiting: variableFetchState === VariableFetchState.Waiting,
 		hasVariableFetchedOnce,
 	};
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
@@ -1,6 +1,10 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { parseAsJson, useQueryState } from 'nuqs';
+// eslint-disable-next-line no-restricted-imports -- global time selector still on redux
+import { useSelector } from 'react-redux';
 import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
+import type { AppState } from 'store/reducers';
+import type { GlobalReducer } from 'types/reducer/globalTime';
 
 import { dtoToFormModel } from '../DashboardSettings/Variables/variableAdapters';
 import type { VariableFormModel } from '../DashboardSettings/Variables/variableFormModel';
@@ -12,8 +16,8 @@ import type {
 	VariableSelectionMap,
 } from './selectionTypes';
 import {
-	computeVariableDependencies,
-	type VariableDependencyData,
+	deriveFetchContext,
+	doAllQueryVariablesHaveValues,
 } from './variableDependencies';
 
 /** URL sentinel for an "ALL values selected" state (matches V1). */
@@ -46,7 +50,6 @@ function fromUrlValue(raw: SelectedVariableValue): VariableSelection {
 
 interface UseVariableSelection {
 	variables: VariableFormModel[];
-	dependencyData: VariableDependencyData;
 	selection: VariableSelectionMap;
 	setSelection: (name: string, selection: VariableSelection) => void;
 }
@@ -65,27 +68,34 @@ export function useVariableSelection(
 		() => (dashboard.spec?.variables ?? []).map(dtoToFormModel),
 		[dashboard.spec?.variables],
 	);
-	const dependencyData = useMemo(
-		() => computeVariableDependencies(variables),
-		[variables],
-	);
+	const fetchContext = useMemo(() => deriveFetchContext(variables), [variables]);
 
 	const selection = useDashboardStore(selectVariableValues(dashboardId));
 	const setVariableValue = useDashboardStore((s) => s.setVariableValue);
 	const setVariableValues = useDashboardStore((s) => s.setVariableValues);
+	const initVariableFetch = useDashboardStore((s) => s.initVariableFetch);
+	const enqueueFetchAll = useDashboardStore((s) => s.enqueueFetchAll);
+	const enqueueDescendants = useDashboardStore((s) => s.enqueueDescendants);
+
+	const { minTime, maxTime } = useSelector<AppState, GlobalReducer>(
+		(state) => state.globalTime,
+	);
+
+	// Latest selection, read by the fetch-cycle effect without subscribing to it
+	// (so a value change doesn't re-trigger a full fetch cycle).
+	const selectionRef = useRef(selection);
+	selectionRef.current = selection;
 
 	const [urlValues, setUrlValues] = useQueryState(
 		'variables',
 		variablesUrlParser.withOptions({ history: 'replace' }),
 	);
 
-	// Seed selections for this dashboard: URL wins, then persisted store, then default.
+	// Seed selections: URL wins, then persisted store, then default.
 	useEffect(() => {
 		if (!dashboardId || variables.length === 0) {
 			return;
 		}
-		// `selection` here is the persisted (localStorage) map on mount — the
-		// effect deliberately doesn't depend on it, so seeding runs once per set.
 		const stored = selection;
 		const seeded: VariableSelectionMap = {};
 		variables.forEach((variable) => {
@@ -102,16 +112,37 @@ export function useVariableSelection(
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [dashboardId, variables]);
 
+	// Start a full fetch cycle on load / dependency-order / time change. Runs after
+	// the seeding effect above, so it reads the seeded selection from the store; a
+	// value change instead goes through `enqueueDescendants`, not this effect.
+	const orderKey = `${fetchContext.queryVariableOrder.join(
+		',',
+	)}|${fetchContext.dynamicVariableOrder.join(',')}`;
+	useEffect(() => {
+		if (!dashboardId || variables.length === 0) {
+			return;
+		}
+		const names = variables
+			.map((v) => v.name)
+			.filter((name): name is string => !!name);
+		initVariableFetch(names, fetchContext);
+		enqueueFetchAll(
+			doAllQueryVariablesHaveValues(variables, selectionRef.current),
+		);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [dashboardId, orderKey, minTime, maxTime]);
+
 	const setSelection = useCallback(
 		(name: string, next: VariableSelection): void => {
 			setVariableValue(dashboardId, name, next);
+			enqueueDescendants(name);
 			void setUrlValues((prev) => ({
 				...(prev ?? {}),
 				[name]: next.allSelected ? ALL_SELECTED : next.value,
 			}));
 		},
-		[dashboardId, setVariableValue, setUrlValues],
+		[dashboardId, setVariableValue, enqueueDescendants, setUrlValues],
 	);
 
-	return { variables, dependencyData, selection, setSelection };
+	return { variables, selection, setSelection };
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
@@ -33,11 +33,13 @@ export const variablesUrlParser = parseAsJson<
 );
 
 function defaultSelection(model: VariableFormModel): VariableSelection {
-	const def = (
-		model.defaultValue as { value?: SelectedVariableValue } | undefined
-	)?.value;
-	if (def !== undefined && def !== null && def !== '') {
+	// `defaultValue` is a string | string[] on the wire.
+	const def = model.defaultValue;
+	if (Array.isArray(def) && def.length > 0) {
 		return { value: def, allSelected: false };
+	}
+	if (typeof def === 'string' && def !== '') {
+		return { value: model.multiSelect ? [def] : def, allSelected: false };
 	}
 	return { value: model.multiSelect ? [] : '', allSelected: false };
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
@@ -54,6 +54,12 @@ interface UseVariableSelection {
 	variables: VariableFormModel[];
 	selection: VariableSelectionMap;
 	setSelection: (name: string, selection: VariableSelection) => void;
+	/**
+	 * Auto-selection fill (default/first-option) applied when options arrive. Unlike
+	 * {@link UseVariableSelection.setSelection}, fills from the initial load burst are
+	 * coalesced into one store write + one downstream refresh.
+	 */
+	autoSelect: (name: string, selection: VariableSelection) => void;
 }
 
 /**
@@ -78,6 +84,9 @@ export function useVariableSelection(
 	const initVariableFetch = useDashboardStore((s) => s.initVariableFetch);
 	const enqueueFetchAll = useDashboardStore((s) => s.enqueueFetchAll);
 	const enqueueDescendants = useDashboardStore((s) => s.enqueueDescendants);
+	const enqueueDescendantsBatch = useDashboardStore(
+		(s) => s.enqueueDescendantsBatch,
+	);
 
 	const { minTime, maxTime } = useSelector<AppState, GlobalReducer>(
 		(state) => state.globalTime,
@@ -146,5 +155,51 @@ export function useVariableSelection(
 		[dashboardId, setVariableValue, enqueueDescendants, setUrlValues],
 	);
 
-	return { variables, selection, setSelection };
+	// Coalesce the initial load burst of auto-selections: each selector fills its
+	// value as its options resolve (at different times). Collecting them into one
+	// store write + one `enqueueDescendantsBatch` means dependents re-fetch once
+	// with the settled parent values, instead of once per fill.
+	const pendingAutoFillRef = useRef<VariableSelectionMap>({});
+	const autoFillFrameRef = useRef<number | null>(null);
+
+	const flushAutoFills = useCallback((): void => {
+		autoFillFrameRef.current = null;
+		const fills = pendingAutoFillRef.current;
+		pendingAutoFillRef.current = {};
+		const names = Object.keys(fills);
+		if (names.length === 0 || !dashboardId) {
+			return;
+		}
+		setVariableValues(dashboardId, { ...selectionRef.current, ...fills });
+		void setUrlValues((prev) => {
+			const next = { ...(prev ?? {}) };
+			names.forEach((name) => {
+				const sel = fills[name];
+				next[name] = sel.allSelected ? ALL_SELECTED : sel.value;
+			});
+			return next;
+		});
+		enqueueDescendantsBatch(names);
+	}, [dashboardId, setVariableValues, setUrlValues, enqueueDescendantsBatch]);
+
+	const autoSelect = useCallback(
+		(name: string, next: VariableSelection): void => {
+			pendingAutoFillRef.current[name] = next;
+			if (autoFillFrameRef.current == null) {
+				autoFillFrameRef.current = requestAnimationFrame(flushAutoFills);
+			}
+		},
+		[flushAutoFills],
+	);
+
+	useEffect(
+		() => (): void => {
+			if (autoFillFrameRef.current != null) {
+				cancelAnimationFrame(autoFillFrameRef.current);
+			}
+		},
+		[],
+	);
+
+	return { variables, selection, setSelection, autoSelect };
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/variableDependencies.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/variableDependencies.ts
@@ -1,6 +1,11 @@
 import { textContainsVariableReference } from 'lib/dashboardVariables/variableReference';
 
-import type { VariableFormModel } from '../DashboardSettings/Variables/variableFormModel';
+import type {
+	VariableFormModel,
+	VariableType,
+} from '../DashboardSettings/Variables/variableFormModel';
+import type { VariableSelectionMap } from './selectionTypes';
+import { isResolved } from './selectionUtils';
 
 /**
  * Inter-variable dependency graph for runtime selection. A QUERY variable
@@ -196,4 +201,58 @@ export function computeVariableDependencies(
 	variables: VariableFormModel[],
 ): VariableDependencyData {
 	return buildDependencyData(buildDependencies(variables));
+}
+
+/**
+ * Static context the runtime fetch engine (`variableFetchSlice`) needs to order
+ * fetches: the dependency graph plus the per-name type index and the QUERY /
+ * DYNAMIC fetch orders. Derived from the variable definitions; stable until the
+ * spec's variables change. Mirrors V1's `getVariableDependencyContext`.
+ */
+export interface VariableFetchContext {
+	dependencyData: VariableDependencyData;
+	/** variable name → its type. */
+	variableTypes: Record<string, VariableType>;
+	/** QUERY variables in topological (parent-before-child) order. */
+	queryVariableOrder: string[];
+	/** DYNAMIC variable names (they implicitly depend on all QUERY values). */
+	dynamicVariableOrder: string[];
+}
+
+export function deriveFetchContext(
+	variables: VariableFormModel[],
+): VariableFetchContext {
+	const dependencyData = computeVariableDependencies(variables);
+	const variableTypes: Record<string, VariableType> = {};
+	variables.forEach((v) => {
+		if (v.name) {
+			variableTypes[v.name] = v.type;
+		}
+	});
+	const queryVariableOrder = dependencyData.order.filter(
+		(name) => variableTypes[name] === 'QUERY',
+	);
+	const dynamicVariableOrder = variables
+		.filter((v) => v.type === 'DYNAMIC' && !!v.name)
+		.map((v) => v.name);
+	return {
+		dependencyData,
+		variableTypes,
+		queryVariableOrder,
+		dynamicVariableOrder,
+	};
+}
+
+/**
+ * Whether every QUERY variable already has a usable selection — decides at load
+ * time whether dynamic variables may fetch immediately or must wait for the
+ * query variables to settle first (V1 parity).
+ */
+export function doAllQueryVariablesHaveValues(
+	variables: VariableFormModel[],
+	selection: VariableSelectionMap,
+): boolean {
+	return variables
+		.filter((v) => v.type === 'QUERY')
+		.every((v) => isResolved(selection[v.name]));
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/__tests__/variableFetchSlice.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/__tests__/variableFetchSlice.test.ts
@@ -4,6 +4,7 @@ import {
 } from '../../../DashboardSettings/Variables/variableFormModel';
 import { deriveFetchContext } from '../../../VariablesBar/variableDependencies';
 import { useDashboardStore } from '../../useDashboardStore';
+import { VariableFetchState } from '../variableFetchSlice.utils';
 
 function model(overrides: Partial<VariableFormModel>): VariableFormModel {
 	return { ...emptyVariableFormModel(), ...overrides };
@@ -34,31 +35,43 @@ beforeEach(() => {
 
 describe('variableFetchSlice', () => {
 	it('initializes every variable to idle', () => {
-		expect(states()).toStrictEqual({ q1: 'idle', q2: 'idle', d1: 'idle' });
+		expect(states()).toStrictEqual({
+			q1: VariableFetchState.Idle,
+			q2: VariableFetchState.Idle,
+			d1: VariableFetchState.Idle,
+		});
 	});
 
 	it('enqueueFetchAll loads roots, waits dependents and (ungated) dynamics', () => {
 		store().enqueueFetchAll(false);
 		expect(states()).toStrictEqual({
-			q1: 'loading',
-			q2: 'waiting',
-			d1: 'waiting',
+			q1: VariableFetchState.Loading,
+			q2: VariableFetchState.Waiting,
+			d1: VariableFetchState.Waiting,
 		});
 		expect(store().variableCycleIds).toStrictEqual({ q1: 1, q2: 1, d1: 1 });
 	});
 
 	it('enqueueFetchAll loads dynamics immediately when query values exist', () => {
 		store().enqueueFetchAll(true);
-		expect(states().d1).toBe('loading');
+		expect(states().d1).toBe(VariableFetchState.Loading);
 	});
 
 	it('completing a parent unblocks its query child, then unlocks dynamics', () => {
 		store().enqueueFetchAll(false);
 		store().onVariableFetchComplete('q1');
-		expect(states()).toMatchObject({ q1: 'idle', q2: 'loading', d1: 'waiting' });
+		expect(states()).toMatchObject({
+			q1: VariableFetchState.Idle,
+			q2: VariableFetchState.Loading,
+			d1: VariableFetchState.Waiting,
+		});
 
 		store().onVariableFetchComplete('q2');
-		expect(states()).toMatchObject({ q1: 'idle', q2: 'idle', d1: 'loading' });
+		expect(states()).toMatchObject({
+			q1: VariableFetchState.Idle,
+			q2: VariableFetchState.Idle,
+			d1: VariableFetchState.Loading,
+		});
 	});
 
 	it('enqueueDescendants revalidates only descendants + dynamics', () => {
@@ -69,8 +82,8 @@ describe('variableFetchSlice', () => {
 
 		store().enqueueDescendants('q1');
 		// q2 depends on q1 (settled) → revalidates; d1 waits (q2 no longer settled).
-		expect(states().q2).toBe('revalidating');
-		expect(states().d1).toBe('waiting');
+		expect(states().q2).toBe(VariableFetchState.Revalidating);
+		expect(states().d1).toBe(VariableFetchState.Waiting);
 	});
 
 	it('enqueueDescendantsBatch bumps each descendant + dynamic exactly once', () => {
@@ -91,7 +104,7 @@ describe('variableFetchSlice', () => {
 	it('a failed parent idles its query descendants', () => {
 		store().enqueueFetchAll(false);
 		store().onVariableFetchFailure('q1');
-		expect(states().q1).toBe('error');
-		expect(states().q2).toBe('idle');
+		expect(states().q1).toBe(VariableFetchState.Error);
+		expect(states().q2).toBe(VariableFetchState.Idle);
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/__tests__/variableFetchSlice.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/__tests__/variableFetchSlice.test.ts
@@ -73,6 +73,21 @@ describe('variableFetchSlice', () => {
 		expect(states().d1).toBe('waiting');
 	});
 
+	it('enqueueDescendantsBatch bumps each descendant + dynamic exactly once', () => {
+		store().enqueueFetchAll(false);
+		store().onVariableFetchComplete('q1');
+		store().onVariableFetchComplete('q2');
+		store().onVariableFetchComplete('d1');
+		const before = { ...store().variableCycleIds };
+
+		// q1 and q2 auto-select together: q2 is a descendant of q1 but is also in
+		// the batch — it should still bump only once, as should the dynamic.
+		store().enqueueDescendantsBatch(['q1', 'q2']);
+		const after = store().variableCycleIds;
+		expect(after.q2).toBe(before.q2 + 1);
+		expect(after.d1).toBe(before.d1 + 1);
+	});
+
 	it('a failed parent idles its query descendants', () => {
 		store().enqueueFetchAll(false);
 		store().onVariableFetchFailure('q1');

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/__tests__/variableFetchSlice.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/__tests__/variableFetchSlice.test.ts
@@ -1,0 +1,82 @@
+import {
+	emptyVariableFormModel,
+	type VariableFormModel,
+} from '../../../DashboardSettings/Variables/variableFormModel';
+import { deriveFetchContext } from '../../../VariablesBar/variableDependencies';
+import { useDashboardStore } from '../../useDashboardStore';
+
+function model(overrides: Partial<VariableFormModel>): VariableFormModel {
+	return { ...emptyVariableFormModel(), ...overrides };
+}
+
+// q1 (root query) → q2 (query referencing $q1) ; d1 (dynamic).
+const q1 = model({ name: 'q1', type: 'QUERY', queryValue: 'SELECT 1' });
+const q2 = model({ name: 'q2', type: 'QUERY', queryValue: 'SELECT $q1' });
+const d1 = model({ name: 'd1', type: 'DYNAMIC', dynamicAttribute: 'pod' });
+const context = deriveFetchContext([q1, q2, d1]);
+
+function store(): ReturnType<typeof useDashboardStore.getState> {
+	return useDashboardStore.getState();
+}
+function states(): Record<string, string> {
+	return store().variableFetchStates;
+}
+
+beforeEach(() => {
+	useDashboardStore.setState({
+		variableFetchStates: {},
+		variableLastUpdated: {},
+		variableCycleIds: {},
+		variableFetchContext: null,
+	});
+	store().initVariableFetch(['q1', 'q2', 'd1'], context);
+});
+
+describe('variableFetchSlice', () => {
+	it('initializes every variable to idle', () => {
+		expect(states()).toStrictEqual({ q1: 'idle', q2: 'idle', d1: 'idle' });
+	});
+
+	it('enqueueFetchAll loads roots, waits dependents and (ungated) dynamics', () => {
+		store().enqueueFetchAll(false);
+		expect(states()).toStrictEqual({
+			q1: 'loading',
+			q2: 'waiting',
+			d1: 'waiting',
+		});
+		expect(store().variableCycleIds).toStrictEqual({ q1: 1, q2: 1, d1: 1 });
+	});
+
+	it('enqueueFetchAll loads dynamics immediately when query values exist', () => {
+		store().enqueueFetchAll(true);
+		expect(states().d1).toBe('loading');
+	});
+
+	it('completing a parent unblocks its query child, then unlocks dynamics', () => {
+		store().enqueueFetchAll(false);
+		store().onVariableFetchComplete('q1');
+		expect(states()).toMatchObject({ q1: 'idle', q2: 'loading', d1: 'waiting' });
+
+		store().onVariableFetchComplete('q2');
+		expect(states()).toMatchObject({ q1: 'idle', q2: 'idle', d1: 'loading' });
+	});
+
+	it('enqueueDescendants revalidates only descendants + dynamics', () => {
+		store().enqueueFetchAll(false);
+		store().onVariableFetchComplete('q1');
+		store().onVariableFetchComplete('q2');
+		store().onVariableFetchComplete('d1');
+
+		store().enqueueDescendants('q1');
+		// q2 depends on q1 (settled) → revalidates; d1 waits (q2 no longer settled).
+		expect(states().q2).toBe('revalidating');
+		expect(states().d1).toBe('waiting');
+	});
+
+	it('a failed parent idles its query descendants', () => {
+		store().enqueueFetchAll(false);
+		store().onVariableFetchFailure('q1');
+		expect(states().q1).toBe('error');
+		expect(states().q2).toBe('idle');
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.ts
@@ -1,0 +1,244 @@
+import type { StateCreator } from 'zustand';
+
+import type { VariableFetchContext } from '../../VariablesBar/variableDependencies';
+import type { DashboardStore } from '../useDashboardStore';
+import {
+	areAllQueryVariablesSettled,
+	type FetchMaps,
+	isSettled,
+	resolveFetchState,
+	unlockWaitingDynamicVariables,
+	type VariableFetchState,
+} from './variableFetchSlice.utils';
+
+export type { VariableFetchState } from './variableFetchSlice.utils';
+
+/**
+ * Runtime fetch orchestration for dashboard variables — native port of V1's
+ * `variableFetchStore`. Decides WHEN each variable's options fetch: query
+ * variables in dependency order, dynamics together once query values exist,
+ * text/custom never. `cycleIds` is a per-variable request nonce keyed into each
+ * selector's react-query key (bump = fresh fetch, auto-cancel stale). Transient.
+ * `enqueueFetchAll` = load/time change; `enqueueDescendants` = one value changed.
+ */
+export interface VariableFetchSlice {
+	variableFetchStates: Record<string, VariableFetchState>;
+	variableLastUpdated: Record<string, number>;
+	variableCycleIds: Record<string, number>;
+	/** Static dependency context, set by `initVariableFetch` (null before init). */
+	variableFetchContext: VariableFetchContext | null;
+
+	/** Seed state entries for the current variable set and store the context. */
+	initVariableFetch: (names: string[], context: VariableFetchContext) => void;
+	/** Start a full fetch cycle for every fetchable variable (load / time change). */
+	enqueueFetchAll: (doAllQueryVariablesHaveValuesSelected: boolean) => void;
+	/** Mark a variable's fetch as done; unblock its waiting children / dynamics. */
+	onVariableFetchComplete: (name: string) => void;
+	/** Mark a variable's fetch as failed; idle its query descendants. */
+	onVariableFetchFailure: (name: string) => void;
+	/** Cascade a value change to a variable's query descendants + the dynamics. */
+	enqueueDescendants: (name: string) => void;
+}
+
+/** Snapshot the three fetch maps into mutable clones for a single action. */
+function cloneMaps(state: DashboardStore): FetchMaps {
+	return {
+		states: { ...state.variableFetchStates },
+		lastUpdated: { ...state.variableLastUpdated },
+		cycleIds: { ...state.variableCycleIds },
+	};
+}
+
+export const createVariableFetchSlice: StateCreator<
+	DashboardStore,
+	[['zustand/persist', unknown]],
+	[],
+	VariableFetchSlice
+> = (set, get) => ({
+	variableFetchStates: {},
+	variableLastUpdated: {},
+	variableCycleIds: {},
+	variableFetchContext: null,
+
+	initVariableFetch: (names, context): void => {
+		const maps = cloneMaps(get());
+		// Initialize new variables to idle, preserving existing states.
+		names.forEach((name) => {
+			if (!maps.states[name]) {
+				maps.states[name] = 'idle';
+			}
+		});
+		// Drop entries for variables that no longer exist.
+		const nameSet = new Set(names);
+		Object.keys(maps.states).forEach((name) => {
+			if (!nameSet.has(name)) {
+				delete maps.states[name];
+				delete maps.lastUpdated[name];
+				delete maps.cycleIds[name];
+			}
+		});
+		set({
+			variableFetchStates: maps.states,
+			variableLastUpdated: maps.lastUpdated,
+			variableCycleIds: maps.cycleIds,
+			variableFetchContext: context,
+		});
+	},
+
+	enqueueFetchAll: (doAllQueryVariablesHaveValuesSelected): void => {
+		const { variableFetchContext } = get();
+		if (!variableFetchContext) {
+			return;
+		}
+		const {
+			dependencyData,
+			variableTypes,
+			queryVariableOrder,
+			dynamicVariableOrder,
+		} = variableFetchContext;
+		const maps = cloneMaps(get());
+
+		// Query variables: roots start immediately, dependents wait for parents.
+		queryVariableOrder.forEach((name) => {
+			maps.cycleIds[name] = (maps.cycleIds[name] || 0) + 1;
+			const parents = dependencyData.parentGraph[name] || [];
+			const hasQueryParents = parents.some((p) => variableTypes[p] === 'QUERY');
+			maps.states[name] = hasQueryParents
+				? 'waiting'
+				: resolveFetchState(maps, name);
+		});
+
+		// Dynamic variables: start now if query variables already have values,
+		// otherwise wait until the query variables settle.
+		dynamicVariableOrder.forEach((name) => {
+			maps.cycleIds[name] = (maps.cycleIds[name] || 0) + 1;
+			maps.states[name] = doAllQueryVariablesHaveValuesSelected
+				? resolveFetchState(maps, name)
+				: 'waiting';
+		});
+
+		set({
+			variableFetchStates: maps.states,
+			variableLastUpdated: maps.lastUpdated,
+			variableCycleIds: maps.cycleIds,
+		});
+	},
+
+	onVariableFetchComplete: (name): void => {
+		const { variableFetchContext } = get();
+		const maps = cloneMaps(get());
+		maps.states[name] = 'idle';
+		maps.lastUpdated[name] = Date.now();
+
+		if (variableFetchContext) {
+			const { dependencyData, variableTypes, dynamicVariableOrder } =
+				variableFetchContext;
+			// Unblock waiting query-type children.
+			(dependencyData.graph[name] || []).forEach((child) => {
+				if (variableTypes[child] === 'QUERY' && maps.states[child] === 'waiting') {
+					maps.states[child] = resolveFetchState(maps, child);
+				}
+			});
+			// Once all query variables settle, unlock any waiting dynamics.
+			if (
+				variableTypes[name] === 'QUERY' &&
+				areAllQueryVariablesSettled(maps.states, variableTypes)
+			) {
+				unlockWaitingDynamicVariables(maps, dynamicVariableOrder);
+			}
+		}
+
+		set({
+			variableFetchStates: maps.states,
+			variableLastUpdated: maps.lastUpdated,
+			variableCycleIds: maps.cycleIds,
+		});
+	},
+
+	onVariableFetchFailure: (name): void => {
+		const { variableFetchContext } = get();
+		const maps = cloneMaps(get());
+		maps.states[name] = 'error';
+
+		if (variableFetchContext) {
+			const { dependencyData, variableTypes, dynamicVariableOrder } =
+				variableFetchContext;
+			// Query descendants can't proceed without this parent — idle them.
+			(dependencyData.transitiveDescendants[name] || []).forEach((desc) => {
+				if (variableTypes[desc] === 'QUERY') {
+					maps.states[desc] = 'idle';
+				}
+			});
+			if (
+				variableTypes[name] === 'QUERY' &&
+				areAllQueryVariablesSettled(maps.states, variableTypes)
+			) {
+				unlockWaitingDynamicVariables(maps, dynamicVariableOrder);
+			}
+		}
+
+		set({
+			variableFetchStates: maps.states,
+			variableLastUpdated: maps.lastUpdated,
+			variableCycleIds: maps.cycleIds,
+		});
+	},
+
+	enqueueDescendants: (name): void => {
+		const { variableFetchContext } = get();
+		if (!variableFetchContext) {
+			return;
+		}
+		const { dependencyData, variableTypes, dynamicVariableOrder } =
+			variableFetchContext;
+		const maps = cloneMaps(get());
+
+		// Query descendants: refetch when all their parents are settled, else wait.
+		(dependencyData.transitiveDescendants[name] || [])
+			.filter((desc) => variableTypes[desc] === 'QUERY')
+			.forEach((desc) => {
+				maps.cycleIds[desc] = (maps.cycleIds[desc] || 0) + 1;
+				const parents = dependencyData.parentGraph[desc] || [];
+				const allParentsSettled = parents.every((p) => isSettled(maps.states[p]));
+				maps.states[desc] = allParentsSettled
+					? resolveFetchState(maps, desc)
+					: 'waiting';
+			});
+
+		// Dynamics implicitly depend on all query values: refetch now if the query
+		// variables are settled, otherwise wait for them.
+		dynamicVariableOrder.forEach((dynName) => {
+			maps.cycleIds[dynName] = (maps.cycleIds[dynName] || 0) + 1;
+			maps.states[dynName] = areAllQueryVariablesSettled(
+				maps.states,
+				variableTypes,
+			)
+				? resolveFetchState(maps, dynName)
+				: 'waiting';
+		});
+
+		set({
+			variableFetchStates: maps.states,
+			variableLastUpdated: maps.lastUpdated,
+			variableCycleIds: maps.cycleIds,
+		});
+	},
+});
+
+/** Selector: the fetch state for a single variable (defaults to idle). */
+export const selectVariableFetchState =
+	(name: string) =>
+	(state: DashboardStore): VariableFetchState =>
+		state.variableFetchStates[name] ?? 'idle';
+
+/** Selector: the current fetch cycle id for a single variable (defaults to 0). */
+export const selectVariableCycleId =
+	(name: string) =>
+	(state: DashboardStore): number =>
+		state.variableCycleIds[name] ?? 0;
+
+/** Selector: whether a variable has completed at least one fetch. */
+export const selectVariableFetchedOnce =
+	(name: string) =>
+	(state: DashboardStore): boolean =>
+		(state.variableLastUpdated[name] ?? 0) > 0;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.ts
@@ -8,10 +8,10 @@ import {
 	isSettled,
 	resolveFetchState,
 	unlockWaitingDynamicVariables,
-	type VariableFetchState,
+	VariableFetchState,
 } from './variableFetchSlice.utils';
 
-export type { VariableFetchState } from './variableFetchSlice.utils';
+export { VariableFetchState } from './variableFetchSlice.utils';
 
 /**
  * Runtime fetch orchestration for dashboard variables — native port of V1's
@@ -71,7 +71,7 @@ export const createVariableFetchSlice: StateCreator<
 		// Initialize new variables to idle, preserving existing states.
 		names.forEach((name) => {
 			if (!maps.states[name]) {
-				maps.states[name] = 'idle';
+				maps.states[name] = VariableFetchState.Idle;
 			}
 		});
 		// Drop entries for variables that no longer exist.
@@ -110,7 +110,7 @@ export const createVariableFetchSlice: StateCreator<
 			const parents = dependencyData.parentGraph[name] || [];
 			const hasQueryParents = parents.some((p) => variableTypes[p] === 'QUERY');
 			maps.states[name] = hasQueryParents
-				? 'waiting'
+				? VariableFetchState.Waiting
 				: resolveFetchState(maps, name);
 		});
 
@@ -120,7 +120,7 @@ export const createVariableFetchSlice: StateCreator<
 			maps.cycleIds[name] = (maps.cycleIds[name] || 0) + 1;
 			maps.states[name] = doAllQueryVariablesHaveValuesSelected
 				? resolveFetchState(maps, name)
-				: 'waiting';
+				: VariableFetchState.Waiting;
 		});
 
 		set({
@@ -133,7 +133,7 @@ export const createVariableFetchSlice: StateCreator<
 	onVariableFetchComplete: (name): void => {
 		const { variableFetchContext } = get();
 		const maps = cloneMaps(get());
-		maps.states[name] = 'idle';
+		maps.states[name] = VariableFetchState.Idle;
 		maps.lastUpdated[name] = Date.now();
 
 		if (variableFetchContext) {
@@ -141,7 +141,10 @@ export const createVariableFetchSlice: StateCreator<
 				variableFetchContext;
 			// Unblock waiting query-type children.
 			(dependencyData.graph[name] || []).forEach((child) => {
-				if (variableTypes[child] === 'QUERY' && maps.states[child] === 'waiting') {
+				if (
+					variableTypes[child] === 'QUERY' &&
+					maps.states[child] === VariableFetchState.Waiting
+				) {
 					maps.states[child] = resolveFetchState(maps, child);
 				}
 			});
@@ -164,7 +167,7 @@ export const createVariableFetchSlice: StateCreator<
 	onVariableFetchFailure: (name): void => {
 		const { variableFetchContext } = get();
 		const maps = cloneMaps(get());
-		maps.states[name] = 'error';
+		maps.states[name] = VariableFetchState.Error;
 
 		if (variableFetchContext) {
 			const { dependencyData, variableTypes, dynamicVariableOrder } =
@@ -172,7 +175,7 @@ export const createVariableFetchSlice: StateCreator<
 			// Query descendants can't proceed without this parent — idle them.
 			(dependencyData.transitiveDescendants[name] || []).forEach((desc) => {
 				if (variableTypes[desc] === 'QUERY') {
-					maps.states[desc] = 'idle';
+					maps.states[desc] = VariableFetchState.Idle;
 				}
 			});
 			if (
@@ -219,7 +222,7 @@ export const createVariableFetchSlice: StateCreator<
 			const allParentsSettled = parents.every((p) => isSettled(maps.states[p]));
 			maps.states[desc] = allParentsSettled
 				? resolveFetchState(maps, desc)
-				: 'waiting';
+				: VariableFetchState.Waiting;
 		});
 
 		// Dynamics implicitly depend on all query values: refetch now if the query
@@ -231,7 +234,7 @@ export const createVariableFetchSlice: StateCreator<
 				variableTypes,
 			)
 				? resolveFetchState(maps, dynName)
-				: 'waiting';
+				: VariableFetchState.Waiting;
 		});
 
 		set({
@@ -246,7 +249,7 @@ export const createVariableFetchSlice: StateCreator<
 export const selectVariableFetchState =
 	(name: string) =>
 	(state: DashboardStore): VariableFetchState =>
-		state.variableFetchStates[name] ?? 'idle';
+		state.variableFetchStates[name] ?? VariableFetchState.Idle;
 
 /** Selector: the current fetch cycle id for a single variable (defaults to 0). */
 export const selectVariableCycleId =

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.ts
@@ -38,6 +38,12 @@ export interface VariableFetchSlice {
 	onVariableFetchFailure: (name: string) => void;
 	/** Cascade a value change to a variable's query descendants + the dynamics. */
 	enqueueDescendants: (name: string) => void;
+	/**
+	 * Batched value-change cascade: refresh the union of the given variables'
+	 * query descendants plus the dynamics, each exactly once. Used to collapse the
+	 * initial burst of auto-selections into a single downstream fetch.
+	 */
+	enqueueDescendantsBatch: (names: string[]) => void;
 }
 
 /** Snapshot the three fetch maps into mutable clones for a single action. */
@@ -185,25 +191,36 @@ export const createVariableFetchSlice: StateCreator<
 	},
 
 	enqueueDescendants: (name): void => {
+		get().enqueueDescendantsBatch([name]);
+	},
+
+	enqueueDescendantsBatch: (names): void => {
 		const { variableFetchContext } = get();
-		if (!variableFetchContext) {
+		if (!variableFetchContext || names.length === 0) {
 			return;
 		}
 		const { dependencyData, variableTypes, dynamicVariableOrder } =
 			variableFetchContext;
 		const maps = cloneMaps(get());
 
-		// Query descendants: refetch when all their parents are settled, else wait.
-		(dependencyData.transitiveDescendants[name] || [])
-			.filter((desc) => variableTypes[desc] === 'QUERY')
-			.forEach((desc) => {
-				maps.cycleIds[desc] = (maps.cycleIds[desc] || 0) + 1;
-				const parents = dependencyData.parentGraph[desc] || [];
-				const allParentsSettled = parents.every((p) => isSettled(maps.states[p]));
-				maps.states[desc] = allParentsSettled
-					? resolveFetchState(maps, desc)
-					: 'waiting';
+		// Union of the changed variables' query descendants, refreshed once each:
+		// refetch when all their parents are settled, else wait.
+		const queryDescendants = new Set<string>();
+		names.forEach((name) => {
+			(dependencyData.transitiveDescendants[name] || []).forEach((desc) => {
+				if (variableTypes[desc] === 'QUERY') {
+					queryDescendants.add(desc);
+				}
 			});
+		});
+		queryDescendants.forEach((desc) => {
+			maps.cycleIds[desc] = (maps.cycleIds[desc] || 0) + 1;
+			const parents = dependencyData.parentGraph[desc] || [];
+			const allParentsSettled = parents.every((p) => isSettled(maps.states[p]));
+			maps.states[desc] = allParentsSettled
+				? resolveFetchState(maps, desc)
+				: 'waiting';
+		});
 
 		// Dynamics implicitly depend on all query values: refetch now if the query
 		// variables are settled, otherwise wait for them.

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.utils.ts
@@ -1,12 +1,13 @@
 import type { VariableType } from '../../DashboardSettings/Variables/variableFormModel';
 
 /** Per-variable fetch lifecycle (ported from V1's `variableFetchStore`). */
-export type VariableFetchState =
-	| 'idle'
-	| 'loading'
-	| 'revalidating'
-	| 'waiting'
-	| 'error';
+export enum VariableFetchState {
+	Idle = 'idle',
+	Loading = 'loading',
+	Revalidating = 'revalidating',
+	Waiting = 'waiting',
+	Error = 'error',
+}
 
 /** Mutable clones a fetch action works over before committing back in one `set`. */
 export interface FetchMaps {
@@ -17,7 +18,7 @@ export interface FetchMaps {
 
 /** Settled = can make no further progress (idle or error). */
 export function isSettled(state: VariableFetchState | undefined): boolean {
-	return state === 'idle' || state === 'error';
+	return state === VariableFetchState.Idle || state === VariableFetchState.Error;
 }
 
 /** Fetch-start state: `revalidating` if fetched before, else `loading`. */
@@ -25,7 +26,9 @@ export function resolveFetchState(
 	maps: FetchMaps,
 	name: string,
 ): VariableFetchState {
-	return (maps.lastUpdated[name] || 0) > 0 ? 'revalidating' : 'loading';
+	return (maps.lastUpdated[name] || 0) > 0
+		? VariableFetchState.Revalidating
+		: VariableFetchState.Loading;
 }
 
 /** True once every QUERY variable is settled. */
@@ -44,7 +47,7 @@ export function unlockWaitingDynamicVariables(
 	dynamicVariableOrder: string[],
 ): void {
 	dynamicVariableOrder.forEach((dynName) => {
-		if (maps.states[dynName] === 'waiting') {
+		if (maps.states[dynName] === VariableFetchState.Waiting) {
 			maps.states[dynName] = resolveFetchState(maps, dynName);
 		}
 	});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.utils.ts
@@ -1,0 +1,51 @@
+import type { VariableType } from '../../DashboardSettings/Variables/variableFormModel';
+
+/** Per-variable fetch lifecycle (ported from V1's `variableFetchStore`). */
+export type VariableFetchState =
+	| 'idle'
+	| 'loading'
+	| 'revalidating'
+	| 'waiting'
+	| 'error';
+
+/** Mutable clones a fetch action works over before committing back in one `set`. */
+export interface FetchMaps {
+	states: Record<string, VariableFetchState>;
+	lastUpdated: Record<string, number>;
+	cycleIds: Record<string, number>;
+}
+
+/** Settled = can make no further progress (idle or error). */
+export function isSettled(state: VariableFetchState | undefined): boolean {
+	return state === 'idle' || state === 'error';
+}
+
+/** Fetch-start state: `revalidating` if fetched before, else `loading`. */
+export function resolveFetchState(
+	maps: FetchMaps,
+	name: string,
+): VariableFetchState {
+	return (maps.lastUpdated[name] || 0) > 0 ? 'revalidating' : 'loading';
+}
+
+/** True once every QUERY variable is settled. */
+export function areAllQueryVariablesSettled(
+	states: Record<string, VariableFetchState>,
+	variableTypes: Record<string, VariableType>,
+): boolean {
+	return Object.entries(variableTypes)
+		.filter(([, type]) => type === 'QUERY')
+		.every(([name]) => isSettled(states[name]));
+}
+
+/** Move any `waiting` dynamic variables into loading/revalidating. */
+export function unlockWaitingDynamicVariables(
+	maps: FetchMaps,
+	dynamicVariableOrder: string[],
+): void {
+	dynamicVariableOrder.forEach((dynName) => {
+		if (maps.states[dynName] === 'waiting') {
+			maps.states[dynName] = resolveFetchState(maps, dynName);
+		}
+	});
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/useDashboardStore.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/useDashboardStore.ts
@@ -13,10 +13,15 @@ import {
 	createVariableSelectionSlice,
 	type VariableSelectionSlice,
 } from './slices/variableSelectionSlice';
+import {
+	createVariableFetchSlice,
+	type VariableFetchSlice,
+} from './slices/variableFetchSlice';
 
 export type DashboardStore = EditContextSlice &
 	CollapseSlice &
-	VariableSelectionSlice;
+	VariableSelectionSlice &
+	VariableFetchSlice;
 
 /**
  * V2 dashboard session store. Holds cross-cutting client state only — never the
@@ -31,6 +36,7 @@ export const useDashboardStore = create<DashboardStore>()(
 			...createEditContextSlice(...a),
 			...createCollapseSlice(...a),
 			...createVariableSelectionSlice(...a),
+			...createVariableFetchSlice(...a),
 		}),
 		{
 			name: '@signoz/dashboard-v2',


### PR DESCRIPTION
## Summary
Foundation for runtime dashboard variables in the V2 dashboard (dark-shipped behind `use_dashboard_v2`). Adds a fetch-orchestration engine that decides **when** each variable's options load and wires the selector controls to it.

- **Fetch-state engine** (`variableFetchSlice`): a per-variable state machine (`idle`/`waiting`/`loading`/`revalidating`/`error`) with a per-variable `cycleId` request nonce. Query variables load in dependency order; dynamics load together once query values exist; text/custom never fetch. `enqueueFetchAll` on load/time change; `enqueueDescendants` on a single value change.
- **Selectors driven off the engine**: Query/Dynamic/Custom/Text selectors read their fetch state and cycle id from the store, so a parent value change refetches only the dependent variables, in order.
- **Default value read as a string** (`string | string[]`), matching the wire type — fixes a default that could not be cleared once set.
- **Batched auto-selection**: the initial load burst of auto-fills (each selector picks a value as its options resolve, at different times) is coalesced into one store write + one downstream refresh, so dependents re-fetch once instead of once per fill.
- **Collapsed `+N` hover** shows the hidden variables' current values.

## Test plan
- Unit: `variableFetchSlice` state transitions (load order, descendant revalidation, batched refresh).
- Manual (dev, flag on): open a dashboard with dependent query + dynamic variables → options load in order; change a parent → only dependents refetch; reload → defaults apply and clear correctly.

Stacked PR (base: `main`). Follow-ups build on this: link-variables-to-panels, then the variable editor/UX.
