### PR TITLE
feat(dashboard-v2): View-modal drill-down + editor "Switch to View Mode"

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/Header/Header.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/Header/Header.tsx
@@ -11,14 +11,18 @@ import styles from './Header.module.scss';
 interface HeaderProps {
 	isDirty: boolean;
 	isSaving: boolean;
+	showSwitchToView?: boolean;
 	onSave: () => void;
+	onSwitchToView?: () => void;
 	onClose: () => void;
 }
 
 function Header({
 	isDirty,
 	isSaving,
+	showSwitchToView = false,
 	onSave,
+	onSwitchToView,
 	onClose,
 }: HeaderProps): JSX.Element {
 	const discard = useConfirmableAction(
@@ -49,6 +53,16 @@ function Header({
 				<Typography.Text>Configure panel</Typography.Text>
 			</div>
 			<div className={styles.actions}>
+				{showSwitchToView && (
+					<Button
+						variant="outlined"
+						color="secondary"
+						data-testid="panel-editor-v2-switch-to-view"
+						onClick={onSwitchToView}
+					>
+						Switch to View Mode
+					</Button>
+				)}
 				<Button
 					variant="solid"
 					color="primary"

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/PreviewPane/PreviewPane.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/PreviewPane/PreviewPane.tsx
@@ -5,6 +5,7 @@ import { PanelMode } from 'container/DashboardContainer/visualization/panels/typ
 import DateTimeSelectionV2 from 'container/TopNav/DateTimeSelectionV2';
 import PanelBody from 'pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelBody/PanelBody';
 import PanelHeader from 'pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelHeader/PanelHeader';
+import type { AnyPanelInteractionProps } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/interactions';
 import type { RenderablePanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition';
 import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import type { DashboardPreference } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/rendererProps';
@@ -42,6 +43,10 @@ interface PreviewPaneProps {
 	dashboardPreference?: DashboardPreference;
 	/** Close the standalone View modal — forwarded to the time-series/bar graph manager. */
 	onCloseStandaloneView?: () => void;
+	/** Opens the drill-down context menu; only the View modal wires it (the editor preview omits it). */
+	onClick?: AnyPanelInteractionProps['onClick'];
+	/** Arms the drill-down click on interactive renderers — the View modal enables it, the editor doesn't. */
+	enableDrillDown?: boolean;
 }
 
 /**
@@ -64,6 +69,8 @@ function PreviewPane({
 	hideHeader = false,
 	dashboardPreference,
 	onCloseStandaloneView,
+	onClick,
+	enableDrillDown,
 }: PreviewPaneProps): JSX.Element {
 	const panelType = PANEL_KIND_TO_PANEL_TYPE[panel.spec.plugin.kind];
 	const queryType = getPanelQueryType(panel);
@@ -119,6 +126,8 @@ function PreviewPane({
 						searchTerm={searchable ? searchTerm : undefined}
 						pagination={pagination}
 						onCloseStandaloneView={onCloseStandaloneView}
+						onClick={onClick}
+						enableDrillDown={enableDrillDown}
 					/>
 				</div>
 			</div>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/__tests__/PanelEditorContainer.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/__tests__/PanelEditorContainer.test.tsx
@@ -48,6 +48,10 @@ jest.mock('../hooks/usePanelEditorSave', () => ({
 jest.mock('../hooks/useSwitchColumnsOnSignalChange', () => ({
 	useSwitchColumnsOnSignalChange: jest.fn(),
 }));
+const mockOnSwitchToView = jest.fn();
+jest.mock('../hooks/useSwitchToViewMode', () => ({
+	useSwitchToViewMode: (): (() => void) => mockOnSwitchToView,
+}));
 jest.mock('../hooks/useSeedNewListColumns', () => ({
 	useSeedNewListColumns: jest.fn(),
 }));
@@ -288,8 +292,28 @@ describe('PanelEditorContainer composition', () => {
 		await userEvent.click(screen.getByTestId('editor-save'));
 
 		await waitFor(() => expect(baseProps.onSaved).toHaveBeenCalled());
+
 		expect(mockBuildSaveSpec).toHaveBeenCalledWith(panel.spec);
 		expect(mockSave).toHaveBeenCalledWith(panel.spec);
+	});
+
+	it('offers Switch to View Mode for an existing panel', () => {
+		setup(makePanel('signoz/TimeSeriesPanel'));
+
+		expect(mockHeaderProps).toHaveBeenCalledWith(
+			expect.objectContaining({
+				showSwitchToView: true,
+				onSwitchToView: expect.any(Function),
+			}),
+		);
+	});
+
+	it('hides Switch to View Mode for a new (unsaved) panel', () => {
+		setup(makePanel('signoz/TimeSeriesPanel'), { isNew: true });
+
+		expect(mockHeaderProps).toHaveBeenCalledWith(
+			expect.objectContaining({ showSwitchToView: false }),
+		);
 	});
 
 	it('renders the list-columns editor only for list panels', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/__tests__/PanelEditorContainer.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/__tests__/PanelEditorContainer.test.tsx
@@ -138,13 +138,16 @@ jest.mock('../ListColumnsEditor/ListColumnsEditor', () => ({
 	default: (): JSX.Element => <div data-testid="list-columns" />,
 }));
 
-function makePanel(kind: string): DashboardtypesPanelDTO {
+function makePanel(
+	kind: string,
+	queries: unknown[] = [],
+): DashboardtypesPanelDTO {
 	return {
 		kind: 'Panel',
 		spec: {
 			display: { name: 'CPU' },
 			plugin: { kind, spec: {} },
-			queries: [],
+			queries,
 		},
 	} as unknown as DashboardtypesPanelDTO;
 }
@@ -159,12 +162,13 @@ const baseProps = {
 function setup(
 	panel: DashboardtypesPanelDTO,
 	overrides?: Partial<React.ComponentProps<typeof PanelEditorContainer>>,
+	draftOverrides?: { isSpecDirty?: boolean },
 ): void {
 	mockUseDraft.mockReturnValue({
 		draft: panel,
 		spec: panel.spec,
 		setSpec: mockSetSpec,
-		isSpecDirty: false,
+		isSpecDirty: draftOverrides?.isSpecDirty ?? false,
 	});
 	mockUseQuery.mockReturnValue({
 		data: { response: undefined },
@@ -240,12 +244,38 @@ describe('PanelEditorContainer composition', () => {
 		);
 	});
 
-	it('marks a new panel dirty and always serializes its query', () => {
+	it('keeps a query-less new panel unsaveable but still serializes its seed query', () => {
 		setup(makePanel('signoz/TimeSeriesPanel'), { isNew: true });
 
 		expect(mockUseQuerySync).toHaveBeenCalledWith(
 			expect.objectContaining({ alwaysSerializeQuery: true }),
 		);
+		// No query and no edits yet → nothing to save, so Save stays disabled.
+		expect(mockHeaderProps).toHaveBeenCalledWith(
+			expect.objectContaining({ isDirty: false }),
+		);
+	});
+
+	it('marks a new panel that already has a query saveable (e.g. list auto-runs one)', () => {
+		const seededQuery = {
+			spec: { plugin: { kind: 'signoz/BuilderQuery', spec: { signal: 'logs' } } },
+		};
+		setup(makePanel('signoz/ListPanel', [seededQuery]), { isNew: true });
+
+		expect(mockHeaderProps).toHaveBeenCalledWith(
+			expect.objectContaining({ isDirty: true }),
+		);
+	});
+
+	it('marks a new panel dirty once the user edits its spec', () => {
+		setup(
+			makePanel('signoz/TimeSeriesPanel'),
+			{ isNew: true },
+			{
+				isSpecDirty: true,
+			},
+		);
+
 		expect(mockHeaderProps).toHaveBeenCalledWith(
 			expect.objectContaining({ isDirty: true }),
 		);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/useSwitchToViewMode.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/useSwitchToViewMode.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import type { Query } from 'types/api/queryBuilder/queryBuilderData';
+
+import { useSwitchToViewMode } from '../useSwitchToViewMode';
+
+const mockSafeNavigate = jest.fn();
+jest.mock('hooks/useSafeNavigate', () => ({
+	useSafeNavigate: (): { safeNavigate: jest.Mock } => ({
+		safeNavigate: mockSafeNavigate,
+	}),
+}));
+
+let mockSearch = '';
+jest.mock('hooks/useUrlQuery', () => ({
+	__esModule: true,
+	default: (): URLSearchParams => new URLSearchParams(mockSearch),
+}));
+
+const query = { queryType: 'builder' } as unknown as Query;
+
+describe('useSwitchToViewMode', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockSearch = '';
+	});
+
+	function invoke(): void {
+		const { result } = renderHook(() =>
+			useSwitchToViewMode({
+				dashboardId: 'dash-1',
+				panelId: 'panel-1',
+				panelType: PANEL_TYPES.TIME_SERIES,
+				query,
+			}),
+		);
+		result.current();
+	}
+
+	it('opens the dashboard with the View modal seeded from the live query', () => {
+		invoke();
+
+		expect(mockSafeNavigate).toHaveBeenCalledTimes(1);
+		const target = new URL(mockSafeNavigate.mock.calls[0][0], 'http://x');
+		expect(target.pathname).toBe('/dashboard/dash-1');
+		expect(target.searchParams.get('expandedWidgetId')).toBe('panel-1');
+		expect(target.searchParams.get('graphType')).toBe(PANEL_TYPES.TIME_SERIES);
+		expect(
+			JSON.parse(
+				decodeURIComponent(target.searchParams.get('compositeQuery') || ''),
+			),
+		).toStrictEqual(query);
+	});
+
+	it('carries dashboard variables through and drops other editor URL state', () => {
+		mockSearch = 'variables=%7B%22a%22%3A1%7D&compositeQuery=stale';
+		invoke();
+
+		const target = new URL(mockSafeNavigate.mock.calls[0][0], 'http://x');
+		expect(target.searchParams.get('variables')).toBe('{"a":1}');
+		// The stale editor query is replaced with the live one, not the URL leftover.
+		expect(target.searchParams.get('compositeQuery')).not.toBe('stale');
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/useSwitchToViewMode.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/useSwitchToViewMode.ts
@@ -1,0 +1,46 @@
+import { useCallback } from 'react';
+import { generatePath } from 'react-router-dom';
+import { QueryParams } from 'constants/query';
+import type { PANEL_TYPES } from 'constants/queryBuilder';
+import ROUTES from 'constants/routes';
+import { useSafeNavigate } from 'hooks/useSafeNavigate';
+import useUrlQuery from 'hooks/useUrlQuery';
+import type { Query } from 'types/api/queryBuilder/queryBuilderData';
+
+interface UseSwitchToViewModeArgs {
+	dashboardId: string;
+	panelId: string;
+	panelType: PANEL_TYPES;
+	query: Query;
+}
+
+/**
+ * Callback that leaves the editor for the dashboard with this panel expanded in the
+ * View modal, seeded with the live (un-saved) query — V1's "Switch to View Mode".
+ */
+export function useSwitchToViewMode({
+	dashboardId,
+	panelId,
+	panelType,
+	query,
+}: UseSwitchToViewModeArgs): () => void {
+	const { safeNavigate } = useSafeNavigate();
+	const urlQuery = useUrlQuery();
+
+	return useCallback((): void => {
+		const params = new URLSearchParams();
+		const variables = urlQuery.get(QueryParams.variables);
+		if (variables) {
+			params.set(QueryParams.variables, variables);
+		}
+		params.set(QueryParams.expandedWidgetId, panelId);
+		params.set(QueryParams.graphType, panelType);
+		params.set(
+			QueryParams.compositeQuery,
+			encodeURIComponent(JSON.stringify(query)),
+		);
+		safeNavigate(
+			`${generatePath(ROUTES.DASHBOARD, { dashboardId })}?${params.toString()}`,
+		);
+	}, [safeNavigate, urlQuery, dashboardId, panelId, panelType, query]);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
@@ -13,6 +13,7 @@ import {
 	TelemetrytypesSignalDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
+import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import { getBuilderQueries } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries';
 
 import { getExecStats } from '../queryV5/v5ResponseData';
@@ -28,6 +29,7 @@ import { usePanelEditSession } from './hooks/usePanelEditSession';
 import { usePanelEditorSave } from './hooks/usePanelEditorSave';
 import { useSeedNewListColumns } from './hooks/useSeedNewListColumns';
 import { useSwitchColumnsOnSignalChange } from './hooks/useSwitchColumnsOnSignalChange';
+import { useSwitchToViewMode } from './hooks/useSwitchToViewMode';
 import { useTableColumns } from './hooks/useTableColumns';
 import ListColumnsEditor from './ListColumnsEditor/ListColumnsEditor';
 
@@ -188,6 +190,13 @@ function PanelEditorContainer({
 		return values.length ? Math.min(...values) : undefined;
 	}, [data.response]);
 
+	const onSwitchToView = useSwitchToViewMode({
+		dashboardId,
+		panelId,
+		panelType: PANEL_KIND_TO_PANEL_TYPE[panelKind],
+		query: currentQuery,
+	});
+
 	const onSave = useCallback(async (): Promise<void> => {
 		try {
 			// Bake the live query into the spec so unstaged edits are saved too.
@@ -204,7 +213,9 @@ function PanelEditorContainer({
 			<Header
 				isDirty={isDirty}
 				isSaving={isSaving}
+				showSwitchToView={!isNew}
 				onSave={onSave}
+				onSwitchToView={onSwitchToView}
 				onClose={onClose}
 			/>
 			<ResizablePanelGroup

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
@@ -143,9 +143,13 @@ function PanelEditorContainer({
 		onSelectUnit: seedFormattingUnit,
 	});
 
-	// Spec and query dirtiness are tracked independently so query re-serialization
-	// never false-dirties. A new panel is always savable (you're creating it).
-	const isDirty = isNew || isSpecDirty || isQueryDirty;
+	// A new panel is savable once it has a query to run — List auto-seeds one; other
+	// kinds open query-less, so there's nothing to save until the user builds one.
+	const isDirty = useMemo(
+		() => isSpecDirty || isQueryDirty || (isNew && draft.spec.queries.length > 0),
+		[isSpecDirty, isQueryDirty, isNew, draft.spec.queries.length],
+	);
+
 	const isListPanel = panelKind === 'signoz/ListPanel';
 	// The builder-query `signal` literal matches the TelemetrytypesSignalDTO enum
 	// values; cast at this boundary (as ConfigPane does) so the columns editor's

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/ListPanel/ListPanel.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/ListPanel/ListPanel.module.scss
@@ -21,6 +21,11 @@
 
 // Logs: drop the row separators for a denser log view (V1 logs table parity).
 .logRows {
+	// Every row opens the log detail drawer, so flag it as clickable.
+	:global(.ant-table-tbody) > tr {
+		cursor: pointer;
+	}
+
 	:global(.ant-table-tbody) > tr > td {
 		border-bottom: none;
 	}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/TablePanel.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/TablePanel.module.scss
@@ -18,3 +18,11 @@
 		@include custom-scrollbar;
 	}
 }
+
+.clickableCell {
+	cursor: pointer;
+
+	&:hover {
+		color: var(--primary-background);
+	}
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/tableColumns.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/tableColumns.tsx
@@ -10,6 +10,8 @@ import { formatPanelValue } from '../../utils/formatPanelValue';
 import { getColumnUnit } from '../../utils/getColumnUnit';
 import { toPanelThreshold } from '../../utils/mapComparisonThreshold';
 
+import styles from './TablePanel.module.scss';
+
 /** A prepared scalar-table row flattened for the antd Table, with the antd key. */
 export type TableRowData = Record<string, unknown> & { key: number };
 
@@ -120,7 +122,7 @@ export function buildTableColumns({
 				if (onCellClick) {
 					cellProps.onClick = (event): void =>
 						onCellClick({ columnId: key, record, event });
-					cellProps.style = { ...cellProps.style, cursor: 'pointer' };
+					cellProps.className = styles.clickableCell;
 				}
 
 				return cellProps;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown.ts
@@ -1,5 +1,7 @@
 import type { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import type { PANEL_TYPES } from 'constants/queryBuilder';
 import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
+import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 
 // Drilldown is the click-to-context-menu feature ported from V1. Every renderer turns its native
 // click into one `DrilldownClickPayload`; the kind-agnostic orchestration layer consumes only that.
@@ -34,3 +36,13 @@ export interface DrilldownClickPayload {
 	coordinates: { x: number; y: number };
 	context: DrilldownContext;
 }
+
+/**
+ * Opens the View modal on a refined drilldown query (filter-by-value / breakout). In the grid this
+ * navigates to the modal seeded with the query; inside the modal it refines the view in place.
+ */
+export type OpenDrilldownView = (
+	panelId: string,
+	query: Query,
+	panelType: PANEL_TYPES,
+) => void;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/ViewPanelModalContent.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/ViewPanelModalContent.tsx
@@ -2,11 +2,13 @@ import { useMemo } from 'react';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
 import { PanelMode } from 'container/DashboardContainer/visualization/panels/types';
 import { DashboardCursorSync } from 'lib/uPlotV2/plugins/TooltipPlugin/types';
+import ContextMenu from 'periscope/components/ContextMenu';
 import PanelEditorQueryBuilder from 'pages/DashboardPageV2/DashboardContainer/PanelEditor/PanelEditorQueryBuilder/PanelEditorQueryBuilder';
 import PreviewPane from 'pages/DashboardPageV2/DashboardContainer/PanelEditor/PreviewPane/PreviewPane';
 import type { DashboardPreference } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/rendererProps';
 import { useOpenPanelEditor } from 'pages/DashboardPageV2/DashboardContainer/hooks/useOpenPanelEditor';
 
+import { useDrilldown } from '../hooks/useDrilldown';
 import { usePanelInteractions } from '../hooks/usePanelInteractions';
 import ViewPanelModalHeader from './ViewPanelModalHeader';
 import { useViewPanelMode } from './useViewPanelMode';
@@ -48,8 +50,15 @@ function ViewPanelModalContent({
 		onChangePanelKind,
 		resetQuery,
 		buildSaveSpec,
+		applyDrilldownQuery,
 	} = useViewPanelMode({ panel, panelId, time: timeOverride });
 	const { data, isFetching, error, refetch, cancelQuery, pagination } = query;
+
+	// Grid drill-down, but filter-by-value / breakout refine this view in place. Drills the draft
+	// so it reflects in-modal edits (and the click's time range follows the per-view window).
+	const drilldown = useDrilldown(draft, panelId, {
+		openDrilldownView: applyDrilldownQuery,
+	});
 
 	// Drag-to-zoom stays inside the modal; opt the chart out of the dashboard's
 	// cursor-sync group so a drag here can't replay onto the grid panels.
@@ -115,9 +124,12 @@ function ViewPanelModalContent({
 					panelMode={PanelMode.STANDALONE_VIEW}
 					dashboardPreference={isolatedPreference}
 					onCloseStandaloneView={onClose}
+					onClick={drilldown.onPanelClick}
+					enableDrillDown={drilldown.enableDrillDown}
 					hideHeader
 				/>
 			</div>
+			<ContextMenu {...drilldown.contextMenuProps} />
 		</div>
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/useViewPanelMode.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/useViewPanelMode.ts
@@ -10,6 +10,7 @@ import { useGetCompositeQueryParam } from 'hooks/queryBuilder/useGetCompositeQue
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import useUrlQuery from 'hooks/useUrlQuery';
 import { usePanelEditSession } from 'pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/usePanelEditSession';
+import type { OpenDrilldownView } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
 import type { RenderablePanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelDefinition';
 import {
 	PANEL_KIND_TO_PANEL_TYPE,
@@ -56,6 +57,11 @@ export interface UseViewPanelModeReturn {
 	buildSaveSpec: (
 		spec: DashboardtypesPanelSpecDTO,
 	) => DashboardtypesPanelSpecDTO;
+	/**
+	 * Drill-down handoff for filter-by-value / breakout: refine the view in place (persist to the
+	 * URL so it survives refresh, and re-run the preview), rather than opening a new View modal.
+	 */
+	applyDrilldownQuery: OpenDrilldownView;
 }
 
 /**
@@ -101,6 +107,7 @@ export function useViewPanelMode({
 		onChangePanelKind,
 		buildSaveSpec,
 		reset,
+		setSpec,
 	} = usePanelEditSession({ panel: initialPanel, panelId, time });
 
 	// The query the view opened with, captured once — the Reset target.
@@ -119,6 +126,31 @@ export function useViewPanelMode({
 		redirectWithQueryBuilderData(savedQuery);
 	}, [reset, redirectWithQueryBuilderData, savedQuery]);
 
+	// redirectWithQueryBuilderData (not the grid's openViewWithQuery): the cloned query keeps its id,
+	// so the QB provider's `stagedQuery.id === url id` guard would skip a plain URL write. setSpec
+	// commits into the draft too — filter/breakout aren't a structural change, so it won't auto-commit.
+	const applyDrilldownQuery = useCallback<OpenDrilldownView>(
+		(viewPanelId, drilldownQuery, drilldownPanelType): void => {
+			redirectWithQueryBuilderData(
+				drilldownQuery,
+				{
+					[QueryParams.expandedWidgetId]: viewPanelId,
+					[QueryParams.graphType]: drilldownPanelType,
+				},
+				undefined,
+				true,
+			);
+			setSpec(
+				buildViewPanelSpec({
+					spec: draft.spec,
+					query: drilldownQuery,
+					panelType: drilldownPanelType,
+				}),
+			);
+		},
+		[redirectWithQueryBuilderData, setSpec, draft.spec],
+	);
+
 	// Current builder datasource — resolved the same way as the full editor's
 	// ConfigPane so the two selectors stay in sync, then defaulted to the kind's first
 	// signal (PromQL/ClickHouse carry none) so the query builder always has one.
@@ -135,5 +167,6 @@ export function useViewPanelMode({
 		onChangePanelKind,
 		resetQuery,
 		buildSaveSpec,
+		applyDrilldownQuery,
 	};
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/ViewPanelModal.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/ViewPanelModal.test.tsx
@@ -47,8 +47,26 @@ jest.mock('../ViewPanelModal/useViewPanelMode', () => ({
 			resetQuery: jest.fn(),
 			signal: 'logs',
 			buildSaveSpec: (spec: unknown): unknown => spec,
+			applyDrilldownQuery: jest.fn(),
 		};
 	},
+}));
+
+// Drill-down orchestration (popover, submenus, View-in-X) has its own suite
+// (useDrilldown.test.tsx) and pulls in router/redux/react-query; stub it so this
+// suite only asserts that the modal arms the preview and renders the menu host.
+const mockOnPanelClick = jest.fn();
+jest.mock('../hooks/useDrilldown', () => ({
+	useDrilldown: (): unknown => ({
+		enableDrillDown: true,
+		onPanelClick: mockOnPanelClick,
+		contextMenuProps: {
+			coordinates: null,
+			popoverPosition: null,
+			items: null,
+			onClose: jest.fn(),
+		},
+	}),
 }));
 
 // The View modal reuses the edit page's query builder, which reads the global
@@ -173,5 +191,24 @@ describe('ViewPanelModal', () => {
 			dashboardPreference?: { syncMode?: unknown };
 		};
 		expect(props.dashboardPreference?.syncMode).toBe(DashboardCursorSync.None);
+	});
+
+	// Parity with the grid: the View modal arms the same drill-down click on the preview.
+	it('arms drill-down on the preview', () => {
+		mockPreviewPaneRender.mockClear();
+		renderWithProvider(
+			<ViewPanelModal
+				panel={makePanel('signoz/TimeSeriesPanel')}
+				panelId="p1"
+				open
+				onClose={jest.fn()}
+			/>,
+		);
+		const props = mockPreviewPaneRender.mock.calls.at(-1)?.[0] as {
+			onClick?: unknown;
+			enableDrillDown?: boolean;
+		};
+		expect(props.enableDrillDown).toBe(true);
+		expect(props.onClick).toBe(mockOnPanelClick);
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -10,6 +10,7 @@ import type {
 import type {
 	DrilldownClickPayload,
 	DrilldownContext,
+	OpenDrilldownView,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
 import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import { getPanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/registry';
@@ -54,6 +55,14 @@ export interface UseDrilldownResult {
 	contextMenuProps: DrilldownContextMenuProps;
 }
 
+export interface UseDrilldownOptions {
+	/**
+	 * How filter-by-value / breakout hand off the refined query. Defaults to navigating to the View
+	 * modal (grid); the View modal passes its own handler so those actions refine the view in place.
+	 */
+	openDrilldownView?: OpenDrilldownView;
+}
+
 /**
  * Orchestrates panel drill-down: owns the popover + which submenu is open, and routes the clicked
  * point to the base aggregate menu (View in Logs/Traces), the group filter menu, or the breakout picker.
@@ -61,6 +70,7 @@ export interface UseDrilldownResult {
 export function useDrilldown(
 	panel: DashboardtypesPanelDTO,
 	panelId: string,
+	options?: UseDrilldownOptions,
 ): UseDrilldownResult {
 	const kind = panel.spec.plugin.kind;
 	const panelType = PANEL_KIND_TO_PANEL_TYPE[kind];
@@ -122,7 +132,9 @@ export function useDrilldown(
 		onClose();
 	}, [onClose]);
 
-	const { openViewWithQuery } = useViewPanel();
+	// Default handoff navigates to the View modal (grid); the modal overrides this to refine in place.
+	const { openViewWithQuery: navigateToView } = useViewPanel();
+	const openViewWithQuery = options?.openDrilldownView ?? navigateToView;
 
 	const breakout = useDrilldownBreakout({
 		panelId,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardFetch.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardFetch.ts
@@ -31,9 +31,15 @@ export interface UseDashboardFetchResult {
 export function useDashboardFetch(
 	dashboardId: string,
 ): UseDashboardFetchResult {
-	const { data, isLoading, isError, error, refetch } = useGetDashboardV2({
-		id: dashboardId,
-	});
+	const { data, isLoading, isError, error, refetch } = useGetDashboardV2(
+		{ id: dashboardId },
+		{
+			// The spec is kept fresh in-cache by optimistic patches (useOptimisticPatch),
+			// so never auto-refetch: it would flash the grid back to server state as
+			// observers mount across the panel tree. Explicit refetch() still works.
+			query: { staleTime: Infinity, refetchOnMount: false },
+		},
+	);
 	const dashboard = data?.data;
 
 	return { dashboard, isLoading, isError, error, refetch };


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

Brings the V2 dashboard panel experience closer to V1 parity around the panel **View modal** and **editor**, and fixes two rough edges in the V2 draft/cache flow. Four self-contained changes (one commit each):

1. **`fix`: only mark a new panel savable once it has a query.** A brand-new panel was always treated as dirty, so **Save** was enabled before there was anything to save. Dirtiness is now tracked off spec/query edits and requires a seeded query (List auto-seeds one; other kinds open query-less).
2. **`feat`: drill down from the panel View modal.** The shared drill-down orchestration is wired into the expanded View modal so **filter-by-value** and **breakout** refine the open view *in place* (URL-persisted, re-runs the preview) instead of stacking a nested modal — matching how the grid behaves.
3. **`fix`: keep the dashboard spec cache patch-driven.** The spec cache is kept fresh by optimistic patches, so auto-refetch made the grid flash back to server state as observers mounted across the panel tree. Disabled auto-refetch (`staleTime: Infinity`, `refetchOnMount: false`); explicit `refetch()` still works.
4. **`feat`: add "Switch to View Mode" to the panel editor.** Ports V1's editor button — it leaves the full-page editor for the dashboard with this panel expanded in the View modal, seeded with the live (un-saved) query.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change.

_TODO: attach a short clip of the editor → "Switch to View Mode" → View modal, and a filter-by-value/breakout drill-down inside the modal._

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/pulse-pod/issues/97

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
- **New-panel savable:** `isDirty` was hard-coded to `true` for `isNew`, ignoring whether a query existed.
- **Cache flash:** `useGetDashboardV2` used react-query defaults, so newly-mounting observers triggered background refetches that overwrote the optimistic-patch cache with server state.

#### Fix Strategy
- Derive `isDirty` from `isSpecDirty || isQueryDirty || (isNew && draft.spec.queries.length > 0)`.
- Pass `{ query: { staleTime: Infinity, refetchOnMount: false } }` to `useGetDashboardV2`; explicit `refetch()` is unaffected.

---

### 🧪 Testing Strategy
> How was this change validated?

- **Tests added/updated:**
  - `useSwitchToViewMode.test.ts` (new) — target URL, seeded query, variable pass-through.
  - `PanelEditorContainer.test.tsx` — new-panel savable rules + Switch-to-View wiring (shown for existing, hidden for new).
  - `ViewPanelModal.test.tsx` — modal arms the same drill-down click on the preview.
- **Manual verification:** `pnpm tsgo --noEmit` clean; `pnpm lint:js`/`oxlint` clean; affected Jest suites green (per-commit pre-commit hooks also ran tsgo + lint).
- **Edge cases covered:** new panel (button hidden, Save gated), List auto-seeded query, PromQL/ClickHouse (no signal → falls back to kind default), dashboard variables carried through the switch-to-view navigation.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** V2 dashboard only (`DashboardPageV2`). No V1 files touched. No API/schema changes.
- **Potential regressions:** panel-editor Save enablement; View-modal drill-down navigation; dashboard-grid refetch timing.
- **Rollback plan:** revert this PR — changes are additive and isolated to V2; commits are independent and can be reverted individually.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix |
| Description | V2 dashboards: drill down inside the panel View modal, "Switch to View Mode" from the editor, and correct Save-enablement + cache-refetch behavior. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Reviewable **commit by commit** — each of the four commits is a self-contained change.
- One deliberate deviation from V1: the "Switch to View Mode" button is rendered `outlined`/`secondary` so **Save** stays the sole primary action in the V2 header (V1 rendered it `primary`). Happy to change if you'd prefer exact parity.
- The full production `pnpm build` was not run locally; whole-project `tsgo --noEmit` + lint + affected tests are green (and pre-commit hooks re-ran tsgo/lint on every commit).

---
