### PR TITLE
fix(dashboard-v2): variable selection flow correctness

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariableSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariableSelector.tsx
@@ -1,17 +1,14 @@
-import { useMemo } from 'react';
 import { SolidInfoCircle } from '@signozhq/icons';
 import { Typography } from '@signozhq/ui/typography';
 // eslint-disable-next-line signoz/no-antd-components -- lightweight description tooltip, matches V1
 import { Tooltip } from 'antd';
-import { commaValuesParser } from 'lib/dashboardVariables/customCommaValuesParser';
 
-import { sortValuesByOrder } from '../DashboardSettings/Variables/variableFormModel';
 import type { VariableFormModel } from '../DashboardSettings/Variables/variableFormModel';
 import type { VariableSelection, VariableSelectionMap } from './selectionTypes';
+import CustomSelector from './selectors/CustomSelector';
 import DynamicSelector from './selectors/DynamicSelector';
 import QuerySelector from './selectors/QuerySelector';
 import TextSelector from './selectors/TextSelector';
-import ValueSelector from './selectors/ValueSelector';
 import styles from './VariablesBar.module.scss';
 
 interface VariableSelectorProps {
@@ -22,7 +19,7 @@ interface VariableSelectorProps {
 	selections: VariableSelectionMap;
 	selection: VariableSelection;
 	onChange: (selection: VariableSelection) => void;
-	/** Batched fill applied when options resolve (Query/Dynamic auto-selection). */
+	/** Batched fill applied when options resolve (Query/Dynamic/Custom auto-selection). */
 	onAutoSelect: (selection: VariableSelection) => void;
 }
 
@@ -35,17 +32,6 @@ function VariableSelector({
 	onChange,
 	onAutoSelect,
 }: VariableSelectorProps): JSX.Element {
-	const customOptions = useMemo(
-		() =>
-			variable.type === 'CUSTOM'
-				? sortValuesByOrder(
-						commaValuesParser(variable.customValue),
-						variable.sort,
-					).map(String)
-				: [],
-		[variable],
-	);
-
 	const renderControl = (): JSX.Element => {
 		switch (variable.type) {
 			case 'TEXT':
@@ -81,13 +67,11 @@ function VariableSelector({
 			case 'CUSTOM':
 			default:
 				return (
-					<ValueSelector
-						options={customOptions}
-						multiSelect={variable.multiSelect}
-						showAllOption={variable.showAllOption}
+					<CustomSelector
+						variable={variable}
 						selection={selection}
 						onChange={onChange}
-						testId={`variable-select-${variable.name}`}
+						onAutoSelect={onAutoSelect}
 					/>
 				);
 		}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/useAutoSelect.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/useAutoSelect.test.tsx
@@ -1,0 +1,113 @@
+import { renderHook } from '@testing-library/react';
+
+import {
+	emptyVariableFormModel,
+	type VariableFormModel,
+} from '../../DashboardSettings/Variables/variableFormModel';
+import type { VariableSelection } from '../selectionTypes';
+import { useAutoSelect } from '../useAutoSelect';
+
+function model(overrides: Partial<VariableFormModel>): VariableFormModel {
+	return { ...emptyVariableFormModel(), ...overrides };
+}
+
+function run(
+	variable: VariableFormModel,
+	options: string[],
+	selection: VariableSelection,
+): VariableSelection | undefined {
+	const onAutoSelect = jest.fn();
+	renderHook(() => useAutoSelect(variable, options, selection, onAutoSelect));
+	return onAutoSelect.mock.calls[0]?.[0];
+}
+
+describe('useAutoSelect', () => {
+	it('materializes a query ALL selection to the full option array', () => {
+		const next = run(
+			model({ type: 'QUERY', multiSelect: true, showAllOption: true }),
+			['a', 'b', 'c'],
+			{ value: null, allSelected: true },
+		);
+		expect(next).toStrictEqual({ value: ['a', 'b', 'c'], allSelected: true });
+	});
+
+	it('re-materializes ALL when the options grow', () => {
+		const next = run(
+			model({ type: 'CUSTOM', multiSelect: true, showAllOption: true }),
+			['a', 'b', 'c', 'd'],
+			{ value: ['a', 'b', 'c'], allSelected: true },
+		);
+		expect(next).toStrictEqual({
+			value: ['a', 'b', 'c', 'd'],
+			allSelected: true,
+		});
+	});
+
+	it('leaves a query ALL selection untouched when already the full set', () => {
+		const next = run(
+			model({ type: 'QUERY', multiSelect: true, showAllOption: true }),
+			['a', 'b'],
+			{ value: ['a', 'b'], allSelected: true },
+		);
+		expect(next).toBeUndefined();
+	});
+
+	it('does NOT materialize a dynamic ALL selection (it sends __all__)', () => {
+		const next = run(
+			model({ type: 'DYNAMIC', multiSelect: true, showAllOption: true }),
+			['a', 'b'],
+			{ value: null, allSelected: true },
+		);
+		expect(next).toBeUndefined();
+	});
+
+	it('keeps the still-valid subset of a multi-select when options re-scope', () => {
+		const next = run(
+			model({ type: 'QUERY', multiSelect: true }),
+			['a', 'b', 'd'],
+			{ value: ['a', 'b', 'c'], allSelected: false },
+		);
+		expect(next).toStrictEqual({ value: ['a', 'b'], allSelected: false });
+	});
+
+	it('re-defaults a multi-select when none of the selected values remain', () => {
+		const next = run(model({ type: 'QUERY', multiSelect: true }), ['x', 'y'], {
+			value: ['a', 'b'],
+			allSelected: false,
+		});
+		expect(next).toStrictEqual({ value: ['x'], allSelected: false });
+	});
+
+	it('auto-selects the default (if present) for a single-select', () => {
+		const next = run(
+			model({ type: 'QUERY', defaultValue: 'b' }),
+			['a', 'b', 'c'],
+			{ value: '', allSelected: false },
+		);
+		expect(next).toStrictEqual({ value: 'b', allSelected: false });
+	});
+
+	it('auto-selects the first option when the default is not available', () => {
+		const next = run(model({ type: 'QUERY', defaultValue: 'z' }), ['a', 'b'], {
+			value: '',
+			allSelected: false,
+		});
+		expect(next).toStrictEqual({ value: 'a', allSelected: false });
+	});
+
+	it('leaves a valid single selection untouched', () => {
+		const next = run(model({ type: 'QUERY' }), ['a', 'b'], {
+			value: 'b',
+			allSelected: false,
+		});
+		expect(next).toBeUndefined();
+	});
+
+	it('does nothing while options are empty', () => {
+		const next = run(model({ type: 'QUERY' }), [], {
+			value: '',
+			allSelected: false,
+		});
+		expect(next).toBeUndefined();
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/CustomSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/CustomSelector.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+import { commaValuesParser } from 'lib/dashboardVariables/customCommaValuesParser';
+
+import { sortValuesByOrder } from '../../DashboardSettings/Variables/variableFormModel';
+import type { VariableFormModel } from '../../DashboardSettings/Variables/variableFormModel';
+import type { VariableSelection } from '../selectionTypes';
+import { useAutoSelect } from '../useAutoSelect';
+import ValueSelector from './ValueSelector';
+
+interface CustomSelectorProps {
+	variable: VariableFormModel;
+	selection: VariableSelection;
+	onChange: (selection: VariableSelection) => void;
+	onAutoSelect: (selection: VariableSelection) => void;
+}
+
+/**
+ * Custom-variable options come from the comma-separated `customValue` (no fetch),
+ * but still auto-select a default/first option so the variable is never left blank.
+ */
+function CustomSelector({
+	variable,
+	selection,
+	onChange,
+	onAutoSelect,
+}: CustomSelectorProps): JSX.Element {
+	const options = useMemo(
+		() =>
+			sortValuesByOrder(
+				commaValuesParser(variable.customValue),
+				variable.sort,
+			).map(String),
+		[variable.customValue, variable.sort],
+	);
+
+	useAutoSelect(variable, options, selection, onAutoSelect);
+
+	return (
+		<ValueSelector
+			options={options}
+			multiSelect={variable.multiSelect}
+			showAllOption={variable.showAllOption}
+			selection={selection}
+			onChange={onChange}
+			testId={`variable-select-${variable.name}`}
+		/>
+	);
+}
+
+export default CustomSelector;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
@@ -3,6 +3,7 @@ import { useQuery } from 'react-query';
 // eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { getFieldValues } from 'api/dynamicVariables/getFieldValues';
+import { DASHBOARD_CACHE_TIME } from 'constants/queryCacheTime';
 import type { AppState } from 'store/reducers';
 import type { GlobalReducer } from 'types/reducer/globalTime';
 
@@ -95,6 +96,8 @@ function DynamicSelector({
 				!!variable.dynamicAttribute &&
 				(isVariableFetching || (isVariableSettled && hasVariableFetchedOnce)),
 			refetchOnWindowFocus: false,
+			// Each cycle mints a fresh key; a small cacheTime bounds cache churn.
+			cacheTime: DASHBOARD_CACHE_TIME,
 			onSettled: (_, error) =>
 				error
 					? onVariableFetchFailure(variable.name)

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
@@ -70,7 +70,7 @@ function DynamicSelector({
 		(s) => s.onVariableFetchFailure,
 	);
 
-	const { data, isFetching } = useQuery(
+	const { data, isFetching, error, refetch } = useQuery(
 		[
 			'dashboard-variable-dynamic',
 			variable.name,
@@ -117,6 +117,10 @@ function DynamicSelector({
 			multiSelect={variable.multiSelect}
 			showAllOption={variable.showAllOption}
 			loading={isFetching || isVariableWaiting}
+			errorMessage={error ? (error as Error).message || null : null}
+			onRetry={(): void => {
+				void refetch();
+			}}
 			selection={selection}
 			onChange={onChange}
 			testId={`variable-select-${variable.name}`}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/QuerySelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/QuerySelector.tsx
@@ -3,6 +3,7 @@ import { useQuery } from 'react-query';
 // eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import dashboardVariablesQuery from 'api/dashboard/variables/dashboardVariablesQuery';
+import { DASHBOARD_CACHE_TIME } from 'constants/queryCacheTime';
 import type { AppState } from 'store/reducers';
 import type { GlobalReducer } from 'types/reducer/globalTime';
 
@@ -79,6 +80,8 @@ function QuerySelector({
 		{
 			enabled: isVariableFetching || (isVariableSettled && hasVariableFetchedOnce),
 			refetchOnWindowFocus: false,
+			// Each cycle mints a fresh key; a small cacheTime bounds cache churn.
+			cacheTime: DASHBOARD_CACHE_TIME,
 			onSettled: (_, error) =>
 				error
 					? onVariableFetchFailure(variable.name)

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/QuerySelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/QuerySelector.tsx
@@ -62,7 +62,7 @@ function QuerySelector({
 		(s) => s.onVariableFetchFailure,
 	);
 
-	const { data, isFetching } = useQuery(
+	const { data, isFetching, error, refetch } = useQuery(
 		[
 			'dashboard-variable',
 			variable.name,
@@ -104,6 +104,10 @@ function QuerySelector({
 			multiSelect={variable.multiSelect}
 			showAllOption={variable.showAllOption}
 			loading={isFetching || isVariableWaiting}
+			errorMessage={error ? (error as Error).message || null : null}
+			onRetry={(): void => {
+				void refetch();
+			}}
 			selection={selection}
 			onChange={onChange}
 			testId={`variable-select-${variable.name}`}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/ValueSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/ValueSelector.tsx
@@ -13,6 +13,9 @@ interface ValueSelectorProps {
 	selection: VariableSelection;
 	onChange: (selection: VariableSelection) => void;
 	testId?: string;
+	/** Option-fetch error surfaced in the dropdown, with a retry action. */
+	errorMessage?: string | null;
+	onRetry?: () => void;
 }
 
 /**
@@ -28,6 +31,8 @@ function ValueSelector({
 	selection,
 	onChange,
 	testId,
+	errorMessage,
+	onRetry,
 }: ValueSelectorProps): JSX.Element {
 	const optionData = useMemo<OptionData[]>(
 		() => options.map((option) => ({ label: option, value: option })),
@@ -48,6 +53,8 @@ function ValueSelector({
 				options={optionData}
 				value={value}
 				loading={loading}
+				errorMessage={errorMessage}
+				onRetry={onRetry}
 				showSearch
 				placeholder="Select value"
 				enableAllSelection={showAllOption}
@@ -84,6 +91,8 @@ function ValueSelector({
 					: String(selection.value)
 			}
 			loading={loading}
+			errorMessage={errorMessage}
+			onRetry={onRetry}
 			showSearch
 			placeholder="Select value"
 			onChange={(next): void =>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/ValueSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/ValueSelector.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { CustomMultiSelect, CustomSelect } from 'components/NewSelect';
 import type { OptionData } from 'components/NewSelect/types';
-import { ALL_SELECT_VALUE } from 'container/DashboardContainer/utils';
 
 import type { VariableSelection } from '../selectionTypes';
 import styles from '../VariablesBar.module.scss';
@@ -36,8 +35,11 @@ function ValueSelector({
 	);
 
 	if (multiSelect) {
+		// All-selected → hand CustomMultiSelect the full option set so it engages its
+		// "all" path (overlay when closed, every option checked when open). Passing the
+		// scalar sentinel instead makes it render a literal `__ALL__` row.
 		const value = selection.allSelected
-			? ALL_SELECT_VALUE
+			? options
 			: (Array.isArray(selection.value) ? selection.value : []).map(String);
 		return (
 			<CustomMultiSelect

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useAutoSelect.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useAutoSelect.ts
@@ -1,12 +1,61 @@
 import { useEffect } from 'react';
 
 import type { VariableFormModel } from '../DashboardSettings/Variables/variableFormModel';
-import type { VariableSelection } from './selectionTypes';
+import type {
+	SelectedVariableValue,
+	VariableSelection,
+} from './selectionTypes';
+
+/** The variable's default (or first option) as a fresh selection. */
+function fillDefault(
+	variable: VariableFormModel,
+	options: string[],
+): VariableSelection {
+	const dv = variable.defaultValue;
+	const fallback = Array.isArray(dv) ? dv[0] : dv;
+	const initial = fallback && options.includes(fallback) ? fallback : options[0];
+	return {
+		value: variable.multiSelect ? [initial] : initial,
+		allSelected: false,
+	};
+}
+
+/** For an all-selected variable, the value to materialize (or null if unchanged). */
+function reconcileAllSelected(
+	variable: VariableFormModel,
+	options: string[],
+	current: SelectedVariableValue,
+): VariableSelection | null {
+	// Dynamic ALL travels as the `__all__` wire sentinel and shows ALL from the
+	// flag, so it needs no materialized value. Query/custom ALL must carry the full
+	// option array (the payload builder can't expand it) — keep it in sync.
+	if (!variable.multiSelect || variable.type === 'DYNAMIC') {
+		return null;
+	}
+	const alreadyFull =
+		Array.isArray(current) &&
+		current.length === options.length &&
+		current.every((c) => options.includes(String(c)));
+	return alreadyFull ? null : { value: options, allSelected: true };
+}
+
+function isValidSingle(
+	current: SelectedVariableValue,
+	options: string[],
+): boolean {
+	return (
+		!Array.isArray(current) &&
+		current !== '' &&
+		current !== null &&
+		current !== undefined &&
+		options.includes(String(current))
+	);
+}
 
 /**
- * When fetched options arrive and the current selection isn't one of them,
- * auto-pick the variable's default (if present in the options) or the first
- * option — so dependent children always have a usable parent value.
+ * Reconciles a variable's selection with its freshly-fetched options: materialize
+ * ALL to the full set, keep a still-valid multi-select subset, else auto-pick the
+ * default (or first option) so dependent children always have a usable value.
  */
 export function useAutoSelect(
 	variable: VariableFormModel,
@@ -15,27 +64,36 @@ export function useAutoSelect(
 	onAutoSelect: (selection: VariableSelection) => void,
 ): void {
 	useEffect(() => {
-		if (options.length === 0 || selection.allSelected) {
+		if (options.length === 0) {
 			return;
 		}
 		const current = selection.value;
-		const isValid = Array.isArray(current)
-			? current.length > 0 && current.every((c) => options.includes(String(c)))
-			: current !== '' &&
-				current !== null &&
-				current !== undefined &&
-				options.includes(String(current));
-		if (isValid) {
+
+		if (selection.allSelected) {
+			const next = reconcileAllSelected(variable, options, current);
+			if (next) {
+				onAutoSelect(next);
+			}
 			return;
 		}
-		const dv = variable.defaultValue;
-		const fallback = Array.isArray(dv) ? dv[0] : dv;
-		const initial =
-			fallback && options.includes(fallback) ? fallback : options[0];
-		onAutoSelect({
-			value: variable.multiSelect ? [initial] : initial,
-			allSelected: false,
-		});
+
+		if (variable.multiSelect && Array.isArray(current) && current.length > 0) {
+			const valid = current.map(String).filter((c) => options.includes(c));
+			if (valid.length === current.length) {
+				return;
+			}
+			onAutoSelect(
+				valid.length > 0
+					? { value: valid, allSelected: false }
+					: fillDefault(variable, options),
+			);
+			return;
+		}
+
+		if (!variable.multiSelect && isValidSingle(current, options)) {
+			return;
+		}
+		onAutoSelect(fillDefault(variable, options));
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [options]);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
@@ -33,13 +33,22 @@ export const variablesUrlParser = parseAsJson<
 );
 
 function defaultSelection(model: VariableFormModel): VariableSelection {
-	// `defaultValue` is a string | string[] on the wire.
 	const def = model.defaultValue;
+	// Explicit ALL sentinel, or a multi-select allowing ALL with no default → ALL.
+	if (
+		def === ALL_SELECTED ||
+		(Array.isArray(def) && def.length === 1 && def[0] === ALL_SELECTED)
+	) {
+		return { value: null, allSelected: true };
+	}
 	if (Array.isArray(def) && def.length > 0) {
 		return { value: def, allSelected: false };
 	}
 	if (typeof def === 'string' && def !== '') {
 		return { value: model.multiSelect ? [def] : def, allSelected: false };
+	}
+	if (model.multiSelect && model.showAllOption) {
+		return { value: null, allSelected: true };
 	}
 	return { value: model.multiSelect ? [] : '', allSelected: false };
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/useVariableSelection.ts
@@ -53,10 +53,16 @@ function defaultSelection(model: VariableFormModel): VariableSelection {
 	return { value: model.multiSelect ? [] : '', allSelected: false };
 }
 
-function fromUrlValue(raw: SelectedVariableValue): VariableSelection {
-	return raw === ALL_SELECTED
-		? { value: null, allSelected: true }
-		: { value: raw, allSelected: false };
+function fromUrlValue(
+	raw: SelectedVariableValue,
+	model: VariableFormModel,
+): VariableSelection {
+	// Only read the `__ALL__` sentinel as "ALL" for variables that support it —
+	// otherwise a legitimate value of "__ALL__" (e.g. a text var) is taken literally.
+	if (raw === ALL_SELECTED && model.multiSelect && model.showAllOption) {
+		return { value: null, allSelected: true };
+	}
+	return { value: raw, allSelected: false };
 }
 
 interface UseVariableSelection {
@@ -121,7 +127,7 @@ export function useVariableSelection(
 		variables.forEach((variable) => {
 			const urlValue = urlValues?.[variable.name];
 			if (urlValue !== undefined) {
-				seeded[variable.name] = fromUrlValue(urlValue);
+				seeded[variable.name] = fromUrlValue(urlValue, variable);
 			} else if (stored[variable.name]) {
 				seeded[variable.name] = stored[variable.name];
 			} else {
@@ -129,12 +135,27 @@ export function useVariableSelection(
 			}
 		});
 		setVariableValues(dashboardId, seeded);
+
+		// Drop URL selections for variables that no longer exist (renamed/removed),
+		// so a shared link doesn't carry stale entries a later variable could inherit.
+		if (urlValues) {
+			const validNames = new Set(variables.map((v) => v.name));
+			const orphaned = Object.keys(urlValues).some((n) => !validNames.has(n));
+			if (orphaned) {
+				const pruned: Record<string, SelectedVariableValue> = {};
+				Object.entries(urlValues).forEach(([name, value]) => {
+					if (validNames.has(name)) {
+						pruned[name] = value;
+					}
+				});
+				void setUrlValues(pruned);
+			}
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [dashboardId, variables]);
 
-	// Start a full fetch cycle on load / dependency-order / time change. Runs after
-	// the seeding effect above, so it reads the seeded selection from the store; a
-	// value change instead goes through `enqueueDescendants`, not this effect.
+	// Start a full fetch cycle on load / dependency-order / time change. A value
+	// change instead goes through `enqueueDescendants`, not this effect.
 	const orderKey = `${fetchContext.queryVariableOrder.join(
 		',',
 	)}|${fetchContext.dynamicVariableOrder.join(',')}`;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/__tests__/buildVariablesPayload.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/__tests__/buildVariablesPayload.test.ts
@@ -77,14 +77,21 @@ describe('buildVariablesPayload', () => {
 		});
 	});
 
-	it('falls back to a list variable configured default when unselected', () => {
+	it('falls back to a string configured default when unselected', () => {
 		const definitions = [
-			variable('region', 'QUERY', {
-				defaultValue: { value: 'us-east' },
-			} as unknown as Partial<VariableFormModel>),
+			variable('region', 'QUERY', { defaultValue: 'us-east' }),
 		];
 		expect(buildVariablesPayload(definitions, {})).toStrictEqual({
 			region: { type: 'query', value: 'us-east' },
+		});
+	});
+
+	it('falls back to an array configured default when unselected', () => {
+		const definitions = [
+			variable('region', 'QUERY', { defaultValue: ['us-east', 'us-west'] }),
+		];
+		expect(buildVariablesPayload(definitions, {})).toStrictEqual({
+			region: { type: 'query', value: ['us-east', 'us-west'] },
 		});
 	});
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/buildVariablesPayload.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/queryV5/buildVariablesPayload.ts
@@ -40,9 +40,12 @@ function configuredDefault(
 	if (definition.type === 'TEXT') {
 		return definition.textValue || undefined;
 	}
-	return (
-		definition.defaultValue as { value?: SelectedVariableValue } | undefined
-	)?.value;
+	// `defaultValue` is `string | string[]` on the wire — use it directly.
+	const def = definition.defaultValue;
+	if (Array.isArray(def)) {
+		return def.length > 0 ? def : undefined;
+	}
+	return def || undefined;
 }
 
 /**

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/__tests__/variableFetchSlice.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/__tests__/variableFetchSlice.test.ts
@@ -2,19 +2,15 @@ import {
 	emptyVariableFormModel,
 	type VariableFormModel,
 } from '../../../DashboardSettings/Variables/variableFormModel';
-import { deriveFetchContext } from '../../../VariablesBar/variableDependencies';
+import {
+	deriveFetchContext,
+	type VariableFetchContext,
+} from '../../../VariablesBar/variableDependencies';
 import { useDashboardStore } from '../../useDashboardStore';
-import { VariableFetchState } from '../variableFetchSlice.utils';
 
 function model(overrides: Partial<VariableFormModel>): VariableFormModel {
 	return { ...emptyVariableFormModel(), ...overrides };
 }
-
-// q1 (root query) → q2 (query referencing $q1) ; d1 (dynamic).
-const q1 = model({ name: 'q1', type: 'QUERY', queryValue: 'SELECT 1' });
-const q2 = model({ name: 'q2', type: 'QUERY', queryValue: 'SELECT $q1' });
-const d1 = model({ name: 'd1', type: 'DYNAMIC', dynamicAttribute: 'pod' });
-const context = deriveFetchContext([q1, q2, d1]);
 
 function store(): ReturnType<typeof useDashboardStore.getState> {
 	return useDashboardStore.getState();
@@ -22,89 +18,129 @@ function store(): ReturnType<typeof useDashboardStore.getState> {
 function states(): Record<string, string> {
 	return store().variableFetchStates;
 }
-
-beforeEach(() => {
+function reset(names: string[], context: VariableFetchContext): void {
 	useDashboardStore.setState({
 		variableFetchStates: {},
 		variableLastUpdated: {},
 		variableCycleIds: {},
 		variableFetchContext: null,
 	});
-	store().initVariableFetch(['q1', 'q2', 'd1'], context);
-});
+	store().initVariableFetch(names, context);
+}
 
 describe('variableFetchSlice', () => {
+	// q1 (root query) → q2 (query referencing $q1) ; d1, d2 (dynamics).
+	const q1 = model({ name: 'q1', type: 'QUERY', queryValue: 'SELECT 1' });
+	const q2 = model({ name: 'q2', type: 'QUERY', queryValue: 'SELECT $q1' });
+	const d1 = model({ name: 'd1', type: 'DYNAMIC', dynamicAttribute: 'pod' });
+	const d2 = model({ name: 'd2', type: 'DYNAMIC', dynamicAttribute: 'ns' });
+	const context = deriveFetchContext([q1, q2, d1, d2]);
+
+	beforeEach(() => reset(['q1', 'q2', 'd1', 'd2'], context));
+
 	it('initializes every variable to idle', () => {
 		expect(states()).toStrictEqual({
-			q1: VariableFetchState.Idle,
-			q2: VariableFetchState.Idle,
-			d1: VariableFetchState.Idle,
+			q1: 'idle',
+			q2: 'idle',
+			d1: 'idle',
+			d2: 'idle',
 		});
 	});
 
 	it('enqueueFetchAll loads roots, waits dependents and (ungated) dynamics', () => {
 		store().enqueueFetchAll(false);
-		expect(states()).toStrictEqual({
-			q1: VariableFetchState.Loading,
-			q2: VariableFetchState.Waiting,
-			d1: VariableFetchState.Waiting,
+		expect(states()).toMatchObject({
+			q1: 'loading',
+			q2: 'waiting',
+			d1: 'waiting',
+			d2: 'waiting',
 		});
-		expect(store().variableCycleIds).toStrictEqual({ q1: 1, q2: 1, d1: 1 });
 	});
 
 	it('enqueueFetchAll loads dynamics immediately when query values exist', () => {
 		store().enqueueFetchAll(true);
-		expect(states().d1).toBe(VariableFetchState.Loading);
+		expect(states().d1).toBe('loading');
 	});
 
 	it('completing a parent unblocks its query child, then unlocks dynamics', () => {
 		store().enqueueFetchAll(false);
 		store().onVariableFetchComplete('q1');
-		expect(states()).toMatchObject({
-			q1: VariableFetchState.Idle,
-			q2: VariableFetchState.Loading,
-			d1: VariableFetchState.Waiting,
-		});
+		expect(states()).toMatchObject({ q1: 'idle', q2: 'loading', d1: 'waiting' });
 
 		store().onVariableFetchComplete('q2');
-		expect(states()).toMatchObject({
-			q1: VariableFetchState.Idle,
-			q2: VariableFetchState.Idle,
-			d1: VariableFetchState.Loading,
-		});
+		expect(states()).toMatchObject({ q2: 'idle', d1: 'loading', d2: 'loading' });
 	});
 
-	it('enqueueDescendants revalidates only descendants + dynamics', () => {
-		store().enqueueFetchAll(false);
+	it('ignores a settle for a variable that is not actively fetching', () => {
+		// q1 was never enqueued (still idle) — a stray complete must be a no-op.
 		store().onVariableFetchComplete('q1');
-		store().onVariableFetchComplete('q2');
-		store().onVariableFetchComplete('d1');
-
-		store().enqueueDescendants('q1');
-		// q2 depends on q1 (settled) → revalidates; d1 waits (q2 no longer settled).
-		expect(states().q2).toBe(VariableFetchState.Revalidating);
-		expect(states().d1).toBe(VariableFetchState.Waiting);
+		expect(states().q1).toBe('idle');
+		expect(store().variableLastUpdated.q1 ?? 0).toBe(0);
 	});
 
-	it('enqueueDescendantsBatch bumps each descendant + dynamic exactly once', () => {
-		store().enqueueFetchAll(false);
-		store().onVariableFetchComplete('q1');
-		store().onVariableFetchComplete('q2');
-		store().onVariableFetchComplete('d1');
+	it('changing a query variable revalidates query descendants but NOT dynamics', () => {
+		store().enqueueFetchAll(true);
+		['q1', 'q2', 'd1', 'd2'].forEach((n) => store().onVariableFetchComplete(n));
 		const before = { ...store().variableCycleIds };
 
-		// q1 and q2 auto-select together: q2 is a descendant of q1 but is also in
-		// the batch — it should still bump only once, as should the dynamic.
-		store().enqueueDescendantsBatch(['q1', 'q2']);
-		const after = store().variableCycleIds;
-		expect(after.q2).toBe(before.q2 + 1);
-		expect(after.d1).toBe(before.d1 + 1);
+		store().enqueueDescendants('q1');
+		expect(states().q2).toBe('revalidating');
+		expect(store().variableCycleIds.q2).toBe(before.q2 + 1);
+		expect(store().variableCycleIds.d1).toBe(before.d1);
+		expect(store().variableCycleIds.d2).toBe(before.d2);
+	});
+
+	it('changing a dynamic refreshes the OTHER dynamics, never itself or query vars', () => {
+		store().enqueueFetchAll(true);
+		['q1', 'q2', 'd1', 'd2'].forEach((n) => store().onVariableFetchComplete(n));
+		const before = { ...store().variableCycleIds };
+
+		store().enqueueDescendants('d1');
+		expect(store().variableCycleIds.d1).toBe(before.d1);
+		expect(store().variableCycleIds.d2).toBe(before.d2 + 1);
+		expect(store().variableCycleIds.q1).toBe(before.q1);
 	});
 
 	it('a failed parent idles its query descendants', () => {
 		store().enqueueFetchAll(false);
 		store().onVariableFetchFailure('q1');
-		expect(states().q1).toBe(VariableFetchState.Error);
-		expect(states().q2).toBe(VariableFetchState.Idle);
+		expect(states().q1).toBe('error');
+		expect(states().q2).toBe('idle');
+	});
+});
+
+describe('variableFetchSlice — diamond dependencies', () => {
+	// qA, qB (roots) → qC (references both $qA and $qB).
+	const qA = model({ name: 'qA', type: 'QUERY', queryValue: 'SELECT 1' });
+	const qB = model({ name: 'qB', type: 'QUERY', queryValue: 'SELECT 2' });
+	const qC = model({ name: 'qC', type: 'QUERY', queryValue: 'SELECT $qA $qB' });
+	const context = deriveFetchContext([qA, qB, qC]);
+
+	beforeEach(() => reset(['qA', 'qB', 'qC'], context));
+
+	it('unblocks the child only once BOTH parents are settled', () => {
+		store().enqueueFetchAll(false);
+		expect(states().qC).toBe('waiting');
+
+		store().onVariableFetchComplete('qA');
+		expect(states().qC).toBe('waiting'); // qB still loading
+
+		store().onVariableFetchComplete('qB');
+		expect(states().qC).not.toBe('waiting'); // both settled → fetches
+	});
+});
+
+describe('variableFetchSlice — dependency cycle', () => {
+	// qX ↔ qY reference each other → dropped from the topological order.
+	const qX = model({ name: 'qX', type: 'QUERY', queryValue: 'SELECT $qY' });
+	const qY = model({ name: 'qY', type: 'QUERY', queryValue: 'SELECT $qX' });
+	const context = deriveFetchContext([qX, qY]);
+
+	beforeEach(() => reset(['qX', 'qY'], context));
+
+	it('enqueues cyclic query variables as best-effort roots (not silently idle)', () => {
+		store().enqueueFetchAll(false);
+		expect(states().qX).not.toBe('idle');
+		expect(states().qY).not.toBe('idle');
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.ts
@@ -6,6 +6,7 @@ import {
 	areAllQueryVariablesSettled,
 	type FetchMaps,
 	isSettled,
+	isVariableInActiveFetchState,
 	resolveFetchState,
 	unlockWaitingDynamicVariables,
 	VariableFetchState,
@@ -114,6 +115,17 @@ export const createVariableFetchSlice: StateCreator<
 				: resolveFetchState(maps, name);
 		});
 
+		// Query variables dropped from the dependency order (part of a cycle) would
+		// otherwise never fetch and would stall waiting dynamics — start them as
+		// best-effort roots so they surface data/an error instead of sitting empty.
+		const orderedQuery = new Set(queryVariableOrder);
+		Object.keys(variableTypes).forEach((name) => {
+			if (variableTypes[name] === 'QUERY' && !orderedQuery.has(name)) {
+				maps.cycleIds[name] = (maps.cycleIds[name] || 0) + 1;
+				maps.states[name] = resolveFetchState(maps, name);
+			}
+		});
+
 		// Dynamic variables: start now if query variables already have values,
 		// otherwise wait until the query variables settle.
 		dynamicVariableOrder.forEach((name) => {
@@ -131,6 +143,11 @@ export const createVariableFetchSlice: StateCreator<
 	},
 
 	onVariableFetchComplete: (name): void => {
+		// Ignore a stale/late settle for a variable no longer fetching, so a
+		// superseded cycle can't overwrite fresh state (V1 parity).
+		if (!isVariableInActiveFetchState(get().variableFetchStates[name])) {
+			return;
+		}
 		const { variableFetchContext } = get();
 		const maps = cloneMaps(get());
 		maps.states[name] = VariableFetchState.Idle;
@@ -139,12 +156,17 @@ export const createVariableFetchSlice: StateCreator<
 		if (variableFetchContext) {
 			const { dependencyData, variableTypes, dynamicVariableOrder } =
 				variableFetchContext;
-			// Unblock waiting query-type children.
+			// Unblock a waiting query child only once ALL its parents are settled —
+			// otherwise it would fetch against a not-yet-resolved parent.
 			(dependencyData.graph[name] || []).forEach((child) => {
 				if (
-					variableTypes[child] === 'QUERY' &&
-					maps.states[child] === VariableFetchState.Waiting
+					variableTypes[child] !== 'QUERY' ||
+					maps.states[child] !== VariableFetchState.Waiting
 				) {
+					return;
+				}
+				const parents = dependencyData.parentGraph[child] || [];
+				if (parents.every((p) => isSettled(maps.states[p]))) {
 					maps.states[child] = resolveFetchState(maps, child);
 				}
 			});
@@ -165,6 +187,9 @@ export const createVariableFetchSlice: StateCreator<
 	},
 
 	onVariableFetchFailure: (name): void => {
+		if (!isVariableInActiveFetchState(get().variableFetchStates[name])) {
+			return;
+		}
 		const { variableFetchContext } = get();
 		const maps = cloneMaps(get());
 		maps.states[name] = VariableFetchState.Error;
@@ -205,13 +230,14 @@ export const createVariableFetchSlice: StateCreator<
 		const { dependencyData, variableTypes, dynamicVariableOrder } =
 			variableFetchContext;
 		const maps = cloneMaps(get());
+		const changed = new Set(names);
 
-		// Union of the changed variables' query descendants, refreshed once each:
-		// refetch when all their parents are settled, else wait.
+		// Union of the changed variables' query descendants (never the changed ones
+		// themselves), refreshed once each: refetch when all parents are settled.
 		const queryDescendants = new Set<string>();
 		names.forEach((name) => {
 			(dependencyData.transitiveDescendants[name] || []).forEach((desc) => {
-				if (variableTypes[desc] === 'QUERY') {
+				if (variableTypes[desc] === 'QUERY' && !changed.has(desc)) {
 					queryDescendants.add(desc);
 				}
 			});
@@ -225,17 +251,22 @@ export const createVariableFetchSlice: StateCreator<
 				: VariableFetchState.Waiting;
 		});
 
-		// Dynamics implicitly depend on all query values: refetch now if the query
-		// variables are settled, otherwise wait for them.
-		dynamicVariableOrder.forEach((dynName) => {
-			maps.cycleIds[dynName] = (maps.cycleIds[dynName] || 0) + 1;
-			maps.states[dynName] = areAllQueryVariablesSettled(
-				maps.states,
-				variableTypes,
-			)
-				? resolveFetchState(maps, dynName)
-				: VariableFetchState.Waiting;
-		});
+		// A dynamic's options depend only on its sibling DYNAMIC selections, so only a
+		// dynamic change affects them — refresh the *other* dynamics (never the one
+		// that changed, which would refetch its own identical options).
+		if (names.some((name) => variableTypes[name] === 'DYNAMIC')) {
+			dynamicVariableOrder
+				.filter((dynName) => !changed.has(dynName))
+				.forEach((dynName) => {
+					maps.cycleIds[dynName] = (maps.cycleIds[dynName] || 0) + 1;
+					maps.states[dynName] = areAllQueryVariablesSettled(
+						maps.states,
+						variableTypes,
+					)
+						? resolveFetchState(maps, dynName)
+						: VariableFetchState.Waiting;
+				});
+		}
 
 		set({
 			variableFetchStates: maps.states,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.utils.ts
@@ -21,6 +21,13 @@ export function isSettled(state: VariableFetchState | undefined): boolean {
 	return state === VariableFetchState.Idle || state === VariableFetchState.Error;
 }
 
+/** Active = a fetch is in flight; only then should a settle be applied. */
+export function isVariableInActiveFetchState(
+	state: VariableFetchState | undefined,
+): boolean {
+	return state === 'loading' || state === 'revalidating';
+}
+
 /** Fetch-start state: `revalidating` if fetched before, else `loading`. */
 export function resolveFetchState(
 	maps: FetchMaps,


### PR DESCRIPTION
## Summary
Correctness pass over the V2 dashboard variable **selection** flow (runtime selection, fetch orchestration, and resolution to the query payload), from an in-depth review. Dark-shipped behind `use_dashboard_v2`. Creation/editing of variables is unchanged.

**"ALL" selection**
- A query/custom multi-select "ALL" now materializes to the full option array, so it actually reaches the query payload (it was stored as `null` and silently dropped) and it tracks option growth.
- A multi-select variable that allows ALL defaults to ALL when it has no explicit default (V1 parity).
- The variable-bar dropdown no longer renders a stray literal `__ALL__` row — the control is handed the expanded option set when all-selected.
- The `__ALL__` URL sentinel is read as "ALL" only for variables that support it (a literal `__ALL__` value is no longer misread).

**Selection reconciliation**
- A partly-invalid multi-select keeps its still-valid subset when options re-scope (was collapsing to the first option).
- Custom variables auto-select their default/first option instead of rendering blank.
- Fixed the dead configured-default fallback in the payload builder (it read `.value` off a `string | string[]`).

**Fetch engine**
- Ignore a stale/late fetch settle for a variable that is no longer actively fetching.
- Unblock a waiting query child only once **all** its parents are settled (diamond dependencies no longer fetch against a stale parent).
- A value change no longer refetches the changed variable's own options; only a dynamic change refreshes the other dynamics (query/custom/text changes don't affect dynamic options).
- Cycle-dropped query variables are enqueued as best-effort roots instead of sitting silently empty (and stalling dynamics).

**Misc**
- Surface option-fetch errors with a retry in the bar (a first-fetch failure was silent and stuck).
- Prune orphaned URL selections on rename/remove; bound option-query cache churn with a `cacheTime`.

## Test plan
- Unit: `useAutoSelect`, `buildVariablesPayload`, and the fetch-engine suite (rewritten for the new semantics) — all green.
- Manual (dev, flag on): a query/custom variable defaulting to ALL sends every value and shows "ALL" (no `__ALL__` row); changing a variable doesn't refetch itself; dependent variables re-scope correctly; a failing option fetch shows a retry.

Stacked PR — base: `feat/dashboard-v2-variables-redesign` (#12009). Merge the upstream stack first: #12002 → #12003 → #11942 → #12009 → this.

