### PR TITLE
feat(dashboard-v2): enforce name-length limits on dashboard inputs

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.tsx
@@ -19,6 +19,7 @@ import { openInNewTab } from 'utils/navigation';
 
 import styles from './DashboardInfo.module.scss';
 import { useVisibleTagCount } from './useVisibleTagCount';
+import { DASHBOARD_NAME_MAX_LENGTH } from '../../constants';
 import { useDashboardStore } from '../../store/useDashboardStore';
 
 interface DashboardInfoProps {
@@ -99,7 +100,7 @@ function DashboardInfo({
 						autoFocus
 						value={draft}
 						testId="dashboard-title-input"
-						maxLength={120}
+						maxLength={DASHBOARD_NAME_MAX_LENGTH}
 						className={styles.dashboardTitleInput}
 						onChange={(e): void => onDraftChange(e.target.value)}
 						onKeyDown={onKeyDown}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/DashboardInfoForm/DashboardInfoForm.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/DashboardInfoForm/DashboardInfoForm.tsx
@@ -12,6 +12,7 @@ import { Input as AntdInput } from 'antd';
 import TagKeyValueInput from 'components/TagKeyValueInput/TagKeyValueInput';
 
 import { Base64Icons } from '../utils';
+import { DASHBOARD_NAME_MAX_LENGTH } from '../../../constants';
 import settingsStyles from '../../DashboardSettings.module.scss';
 import styles from './DashboardInfoForm.module.scss';
 
@@ -71,6 +72,7 @@ function DashboardInfoForm({
 							testId="dashboard-name"
 							className={styles.dashboardNameInput}
 							value={title}
+							maxLength={DASHBOARD_NAME_MAX_LENGTH}
 							onChange={(e): void => onTitleChange(e.target.value)}
 						/>
 					</section>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/components/VariableInfoForm/VariableInfoForm.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/components/VariableInfoForm/VariableInfoForm.tsx
@@ -4,6 +4,7 @@ import { Typography } from '@signozhq/ui/typography';
 import { Input as AntdInput } from 'antd';
 
 import styles from './VariableInfoForm.module.scss';
+import { DASHBOARD_NAME_MAX_LENGTH } from '../../../../constants';
 import variableFormStyles from '../../VariableForm/VariableForm.module.scss';
 
 interface VariableInfoFormProps {
@@ -30,6 +31,7 @@ function VariableInfoForm({
 					testId="variable-name"
 					className={styles.variableNameInput}
 					value={title}
+					maxLength={DASHBOARD_NAME_MAX_LENGTH}
 					onChange={(e): void => onTitleChange(e.target.value)}
 					placeholder="Unique name of the variable"
 				/>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.tsx
@@ -14,6 +14,7 @@ import ConfigActions from './ConfigActions/ConfigActions';
 import SectionSlot from './SectionSlot/SectionSlot';
 
 import styles from './ConfigPane.module.scss';
+import { DASHBOARD_NAME_MAX_LENGTH } from '../../constants';
 import { PanelKind } from '../../Panels/types/panelKind';
 
 interface ConfigPaneProps {
@@ -86,6 +87,7 @@ function ConfigPane({
 						data-testid="panel-editor-v2-title"
 						value={spec.display.name}
 						placeholder="Panel title"
+						maxLength={DASHBOARD_NAME_MAX_LENGTH}
 						onChange={(e): void => setDisplayField('name', e.target.value)}
 					/>
 				</div>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionTitleModal.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionTitleModal.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { Modal } from 'antd';
 import { Input } from '@signozhq/ui/input';
 
+import { DASHBOARD_NAME_MAX_LENGTH } from '../../constants';
+
 interface SectionTitleModalProps {
 	open: boolean;
 	/** Modal heading, e.g. "Rename section" / "New section". */
@@ -56,7 +58,7 @@ function SectionTitleModal({
 				testId="section-title-input"
 				autoFocus
 				value={value}
-				maxLength={120}
+				maxLength={DASHBOARD_NAME_MAX_LENGTH}
 				placeholder={placeholder}
 				onChange={(e): void => setValue(e.target.value)}
 				onKeyDown={(e): void => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/constants.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/constants.ts
@@ -1,0 +1,2 @@
+/** Max length for dashboard / section / panel / variable name inputs. */
+export const DASHBOARD_NAME_MAX_LENGTH = 128;

--- a/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/RenameDashboardModal.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/RenameDashboardModal.tsx
@@ -13,6 +13,7 @@ import type { DashboardtypesJSONPatchOperationDTO } from 'api/generated/services
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
+import { DASHBOARD_NAME_MAX_LENGTH } from '../../../DashboardPageV2/DashboardContainer/constants';
 import styles from './ActionsPopover.module.scss';
 
 interface Props {
@@ -102,6 +103,7 @@ function RenameDashboardModal({
 			<Input
 				value={name}
 				autoFocus
+				maxLength={DASHBOARD_NAME_MAX_LENGTH}
 				placeholder="Dashboard name"
 				testId="rename-dashboard-input"
 				onChange={(e): void => setName(e.target.value)}

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
@@ -17,6 +17,7 @@ import TagKeyValueInput from 'components/TagKeyValueInput/TagKeyValueInput';
 
 import { keyValueStringsToTags } from '../../utils/helpers';
 
+import { DASHBOARD_NAME_MAX_LENGTH } from '../../../DashboardPageV2/DashboardContainer/constants';
 import styles from './NewDashboardModal.module.scss';
 
 const DEFAULT_NAME = 'Sample Dashboard';
@@ -79,6 +80,7 @@ function BlankDashboardPanel({ onClose }: Props): JSX.Element {
 					<Input
 						value={name}
 						autoFocus
+						maxLength={DASHBOARD_NAME_MAX_LENGTH}
 						placeholder="e.g. Sample Dashboard"
 						testId="create-dashboard-name"
 						onChange={(e: ChangeEvent<HTMLInputElement>): void =>

--- a/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewNamePopover.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewNamePopover.tsx
@@ -6,7 +6,7 @@ import { Typography } from '@signozhq/ui/typography';
 
 import styles from './ViewsRail.module.scss';
 
-export const VIEW_NAME_MAX_LENGTH = 128;
+export const VIEW_NAME_MAX_LENGTH = 64;
 
 interface Props {
 	open: boolean;


### PR DESCRIPTION
## Summary

Enforces consistent max-length caps across all V2 dashboard name inputs:

- **128 characters** — dashboard name (details toolbar, settings overview, list rename, create-dashboard), section name, panel title, and variable name. Introduces a shared `DASHBOARD_NAME_MAX_LENGTH` constant so every entry point stays in sync.
- **64 characters** — saved-view names (`VIEW_NAME_MAX_LENGTH`), which have a tighter limit than dashboard entities.

Previously several of these inputs had ad-hoc caps (e.g. `maxLength={120}`) or none at all, so the enforced length varied by entry point.

## Test plan

- Type past the limit in each input; the field stops accepting characters at the cap.
- Dashboard/section/panel/variable names cap at 128; saved-view names cap at 64.
- Renaming a dashboard from the list and from the details page both enforce 128.