### PR TITLE
feat(dashboard-v2): gate list-page dashboard & view actions on edit permission

### DIFF
--- a/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.tsx
@@ -39,6 +39,8 @@ interface Props {
 	dashboardName: string;
 	createdBy: string;
 	isLocked: boolean;
+	// Edit permission (edit_dashboard). Read actions show regardless; edit actions are hidden without it.
+	canEdit: boolean;
 	onView: (event: React.MouseEvent<HTMLElement>) => void;
 }
 
@@ -48,6 +50,7 @@ function ActionsPopover({
 	dashboardName,
 	createdBy,
 	isLocked,
+	canEdit,
 	onView,
 }: Props): JSX.Element {
 	const [, setCopy] = useCopyToClipboard();
@@ -135,45 +138,49 @@ function ActionsPopover({
 						>
 							Copy Link
 						</Button>
-						<Tooltip
-							placement="left"
-							title={
-								isLocked ? 'This dashboard is locked, so it cannot be renamed.' : ''
-							}
-						>
-							<span className={styles.menuItemWrap}>
-								<Button
-									color="secondary"
-									className={styles.menuItem}
-									prefix={<PenLine size={14} />}
-									disabled={isLocked}
-									onClick={(e): void => {
-										e.stopPropagation();
-										e.preventDefault();
-										if (!isLocked) {
-											setIsRenameOpen(true);
-										}
-									}}
-									testId="dashboard-action-rename"
-								>
-									Rename
-								</Button>
-							</span>
-						</Tooltip>
-						<Button
-							color="secondary"
-							className={styles.menuItem}
-							prefix={<Copy size={14} />}
-							loading={isCloning}
-							onClick={(e): void => {
-								e.stopPropagation();
-								e.preventDefault();
-								runClone();
-							}}
-							testId="dashboard-action-duplicate"
-						>
-							Duplicate
-						</Button>
+						{canEdit && (
+							<Tooltip
+								placement="left"
+								title={
+									isLocked ? 'This dashboard is locked, so it cannot be renamed.' : ''
+								}
+							>
+								<span className={styles.menuItemWrap}>
+									<Button
+										color="secondary"
+										className={styles.menuItem}
+										prefix={<PenLine size={14} />}
+										disabled={isLocked}
+										onClick={(e): void => {
+											e.stopPropagation();
+											e.preventDefault();
+											if (!isLocked) {
+												setIsRenameOpen(true);
+											}
+										}}
+										testId="dashboard-action-rename"
+									>
+										Rename
+									</Button>
+								</span>
+							</Tooltip>
+						)}
+						{canEdit && (
+							<Button
+								color="secondary"
+								className={styles.menuItem}
+								prefix={<Copy size={14} />}
+								loading={isCloning}
+								onClick={(e): void => {
+									e.stopPropagation();
+									e.preventDefault();
+									runClone();
+								}}
+								testId="dashboard-action-duplicate"
+							>
+								Duplicate
+							</Button>
+						)}
 						{canToggleLock && (
 							<Button
 								color="secondary"
@@ -190,12 +197,14 @@ function ActionsPopover({
 								{isLocked ? 'Unlock Dashboard' : 'Lock Dashboard'}
 							</Button>
 						)}
-						<DeleteActionItem
-							dashboardId={dashboardId}
-							dashboardName={dashboardName}
-							createdBy={createdBy}
-							isLocked={isLocked}
-						/>
+						{canEdit && (
+							<DeleteActionItem
+								dashboardId={dashboardId}
+								dashboardName={dashboardName}
+								createdBy={createdBy}
+								isLocked={isLocked}
+							/>
+						)}
 					</div>
 				}
 				placement="bottomRight"

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.tsx
@@ -24,7 +24,7 @@ import styles from './DashboardRow.module.scss';
 interface Props {
 	dashboard: DashboardListItem;
 	index: number;
-	canAct: boolean;
+	canEdit: boolean;
 	showUpdatedAt: boolean;
 	showUpdatedBy: boolean;
 }
@@ -32,7 +32,7 @@ interface Props {
 function DashboardRow({
 	dashboard,
 	index,
-	canAct,
+	canEdit,
 	showUpdatedAt,
 	showUpdatedBy,
 }: Props): JSX.Element {
@@ -153,16 +153,15 @@ function DashboardRow({
 					</Button>
 				</TooltipSimple>
 
-				{canAct && (
-					<ActionsPopover
-						link={link}
-						dashboardId={id}
-						dashboardName={name}
-						createdBy={createdBy}
-						isLocked={isLocked}
-						onView={onClickHandler}
-					/>
-				)}
+				<ActionsPopover
+					link={link}
+					dashboardId={id}
+					dashboardName={name}
+					createdBy={createdBy}
+					isLocked={isLocked}
+					canEdit={canEdit}
+					onView={onClickHandler}
+				/>
 			</div>
 			<div className={styles.details}>
 				<div className={styles.createdAt}>

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
@@ -44,10 +44,11 @@ function DashboardsList(): JSX.Element {
 	const { isCloudUser } = useGetTenantLicense();
 
 	const { user } = useAppContext();
-	const [action, canCreateNewDashboard] = useComponentPermission(
-		['action', 'create_new_dashboards'],
+	const [editDashboard, canCreateNewDashboard] = useComponentPermission(
+		['edit_dashboard', 'create_new_dashboards'],
 		user.role,
 	);
+	const canEdit = !!editDashboard;
 
 	const {
 		filters,
@@ -285,6 +286,7 @@ function DashboardsList(): JSX.Element {
 				onReset={handleResetView}
 				onDelete={handleRemoveView}
 				onRename={renameView}
+				canEdit={canEdit}
 			/>
 			<div className={styles.main}>
 				<div className={styles.mainScroll}>
@@ -340,7 +342,7 @@ function DashboardsList(): JSX.Element {
 									pageSize={clientView ? CLIENT_VIEW_LIMIT : PAGE_SIZE}
 									total={total}
 									onPageChange={setPage}
-									canAct={!!action}
+									canEdit={canEdit}
 									showUpdatedAt={visibleColumns.updatedAt}
 									showUpdatedBy={visibleColumns.updatedBy}
 									loading={isFetching}

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsListContent.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsListContent.tsx
@@ -11,7 +11,7 @@ interface Props {
 	pageSize: number;
 	total: number;
 	onPageChange: (page: number) => void;
-	canAct: boolean;
+	canEdit: boolean;
 	showUpdatedAt: boolean;
 	showUpdatedBy: boolean;
 	loading: boolean;
@@ -23,7 +23,7 @@ function DashboardsListContent({
 	pageSize,
 	total,
 	onPageChange,
-	canAct,
+	canEdit,
 	showUpdatedAt,
 	showUpdatedBy,
 	loading,
@@ -37,14 +37,14 @@ function DashboardsListContent({
 					<DashboardRow
 						dashboard={dashboard}
 						index={index}
-						canAct={canAct}
+						canEdit={canEdit}
 						showUpdatedAt={showUpdatedAt}
 						showUpdatedBy={showUpdatedBy}
 					/>
 				),
 			},
 		],
-		[canAct, showUpdatedAt, showUpdatedBy],
+		[canEdit, showUpdatedAt, showUpdatedBy],
 	);
 
 	const paginationConfig = total > pageSize && {

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsResults.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsResults.tsx
@@ -30,7 +30,7 @@ interface Props {
 	pageSize: number;
 	total: number;
 	onPageChange: (page: number) => void;
-	canAct: boolean;
+	canEdit: boolean;
 	showUpdatedAt: boolean;
 	showUpdatedBy: boolean;
 	loading: boolean;
@@ -55,7 +55,7 @@ function DashboardsResults({
 	pageSize,
 	total,
 	onPageChange,
-	canAct,
+	canEdit,
 	showUpdatedAt,
 	showUpdatedBy,
 	loading,
@@ -91,7 +91,7 @@ function DashboardsResults({
 				pageSize={pageSize}
 				total={total}
 				onPageChange={onPageChange}
-				canAct={canAct}
+				canEdit={canEdit}
 				showUpdatedAt={showUpdatedAt}
 				showUpdatedBy={showUpdatedBy}
 				loading={loading}

--- a/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewsRail.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewsRail.tsx
@@ -27,6 +27,8 @@ interface Props {
 	isCustomActive: boolean;
 	isModified: boolean;
 	collapsed?: boolean;
+	// Edit permission. Viewers can select views but not add / rename / delete / save.
+	canEdit: boolean;
 	onSelect: (id: string) => void;
 	onSave: (name: string) => void;
 	onSaveChanges: () => void;
@@ -52,6 +54,7 @@ function ViewsRail({
 	isCustomActive,
 	isModified,
 	collapsed = false,
+	canEdit,
 	onSelect,
 	onSave,
 	onSaveChanges,
@@ -129,7 +132,7 @@ function ViewsRail({
 						<div className={styles.dirtyDot} title="Unsaved changes" />
 					)}
 				</Button>
-				{row.deletable && (
+				{canEdit && row.deletable && (
 					<div className={styles.itemActions}>
 						<ViewNamePopover
 							open={renamingId === row.id}
@@ -177,25 +180,27 @@ function ViewsRail({
 		<aside className={cx(styles.rail, { [styles.collapsed]: collapsed })}>
 			<div className={styles.header}>
 				<h4 className={styles.headerTitle}>Views</h4>
-				<ViewNamePopover
-					open={saveOpen}
-					onOpenChange={setSaveOpen}
-					onSubmit={onSave}
-					title="Save as view"
-					confirmLabel="Save view"
-					testIdPrefix="save-view"
-					trigger={
-						<Button
-							variant="ghost"
-							color="secondary"
-							size="icon"
-							title="Save current filters as a view"
-							testId="dashboards-view-save-trigger"
-						>
-							<Plus size={14} />
-						</Button>
-					}
-				/>
+				{canEdit && (
+					<ViewNamePopover
+						open={saveOpen}
+						onOpenChange={setSaveOpen}
+						onSubmit={onSave}
+						title="Save as view"
+						confirmLabel="Save view"
+						testIdPrefix="save-view"
+						trigger={
+							<Button
+								variant="ghost"
+								color="secondary"
+								size="icon"
+								title="Save current filters as a view"
+								testId="dashboards-view-save-trigger"
+							>
+								<Plus size={14} />
+							</Button>
+						}
+					/>
+				)}
 			</div>
 
 			<div className={styles.search}>
@@ -265,23 +270,27 @@ function ViewsRail({
 				<div className={styles.dirtyPanel}>
 					<div className={styles.dirtyTitle}>Unsaved changes</div>
 					<div className={styles.dirtyActions}>
-						<Button
-							variant="solid"
-							color="primary"
-							size="sm"
-							onClick={onSaveChanges}
-							testId="dashboards-view-save-changes"
-						>
-							Save
-						</Button>
-						<Button
-							variant="outlined"
-							color="secondary"
-							size="sm"
-							onClick={(): void => setSaveOpen(true)}
-						>
-							Save as…
-						</Button>
+						{canEdit && (
+							<>
+								<Button
+									variant="solid"
+									color="primary"
+									size="sm"
+									onClick={onSaveChanges}
+									testId="dashboards-view-save-changes"
+								>
+									Save
+								</Button>
+								<Button
+									variant="outlined"
+									color="secondary"
+									size="sm"
+									onClick={(): void => setSaveOpen(true)}
+								>
+									Save as…
+								</Button>
+							</>
+						)}
 						<Button variant="ghost" color="secondary" size="sm" onClick={onReset}>
 							Reset
 						</Button>
@@ -293,16 +302,18 @@ function ViewsRail({
 				<div className={cx(styles.dirtyPanel, styles.dirtyPanelDefault)}>
 					<div className={styles.dirtyTitle}>Filters active</div>
 					<div className={styles.dirtyActions}>
-						<Button
-							variant="solid"
-							color="primary"
-							size="sm"
-							prefix={<Plus size={12} />}
-							onClick={(): void => setSaveOpen(true)}
-							testId="dashboards-view-save-as-new"
-						>
-							Save as new view
-						</Button>
+						{canEdit && (
+							<Button
+								variant="solid"
+								color="primary"
+								size="sm"
+								prefix={<Plus size={12} />}
+								onClick={(): void => setSaveOpen(true)}
+								testId="dashboards-view-save-as-new"
+							>
+								Save as new view
+							</Button>
+						)}
 						<Button variant="ghost" color="secondary" size="sm" onClick={onReset}>
 							Reset
 						</Button>


### PR DESCRIPTION
## Summary

On the V2 dashboards **list page**, edit actions were gated by the `action` permission (ADMIN/EDITOR only), which hid the *entire* per-row menu from viewers — so a view-only user couldn't even open, copy a link, or view a dashboard from the menu. This reworks the gating to the per-row **edit permission** (`edit_dashboard`, which includes AUTHOR) and keeps read actions available to everyone.

## Changes

- **Row actions menu** now always renders. Read actions — **View**, **Open in New Tab**, **Copy Link** — are available to all users. Edit actions — **Rename**, **Duplicate**, **Delete** — are shown only with edit permission (and keep their existing locked-state handling). **Lock/Unlock** is unchanged (author/admin only).
- **Saved Views rail**: selecting/applying a view and filtering stay available to everyone; **Add view (+)**, **Rename**, **Delete**, and the **Save / Save as… / Save as new view** actions are shown only with edit permission. **Reset** (local) stays available.
- **New dashboard** button is unchanged (already gated on `create_new_dashboards`).

Net effect: a view-only user sees a useful read-only menu (view / open / copy) and can browse saved views, but cannot mutate dashboards or views.

## Screenshots

### View Permissions

<img width="1728" height="961" alt="image" src="https://github.com/user-attachments/assets/943aca36-8572-4abc-a9ad-8e9ffde70d5d" />

### Edit Permissions

<img width="1920" height="957" alt="image" src="https://github.com/user-attachments/assets/f62acdb6-ef33-467a-8639-1fa50cc16506" />


## Test plan

- As a viewer: row menu shows only View / Open in New Tab / Copy Link; the views rail has no add/rename/delete and no save buttons (Reset still works); New dashboard hidden.
- As an editor/author/admin: full row menu and views-rail actions; locked dashboards keep Rename/Delete disabled.