### PR TITLE
feat(dashboard-v2): prompt to reload when a dashboard changes elsewhere

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardChangedDialog/DashboardChangedDialog.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardChangedDialog/DashboardChangedDialog.module.scss
@@ -1,0 +1,11 @@
+.body {
+	color: var(--l2-foreground);
+	font-size: 14px;
+	line-height: 20px;
+}
+
+.footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardChangedDialog/DashboardChangedDialog.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardChangedDialog/DashboardChangedDialog.tsx
@@ -1,0 +1,61 @@
+import { RotateCcw } from '@signozhq/icons';
+import { Button } from '@signozhq/ui/button';
+import { DialogWrapper } from '@signozhq/ui/dialog';
+
+import styles from './DashboardChangedDialog.module.scss';
+
+interface DashboardChangedDialogProps {
+	open: boolean;
+	onReload: () => void;
+	onDismiss: () => void;
+}
+
+function DashboardChangedDialog({
+	open,
+	onReload,
+	onDismiss,
+}: DashboardChangedDialogProps): JSX.Element {
+	const footer = (
+		<div className={styles.footer}>
+			<Button
+				variant="solid"
+				color="secondary"
+				onClick={onDismiss}
+				testId="dashboard-changed-dismiss"
+			>
+				Dismiss
+			</Button>
+			<Button
+				variant="solid"
+				color="primary"
+				prefix={<RotateCcw size={12} />}
+				onClick={onReload}
+				testId="dashboard-changed-reload"
+			>
+				Reload
+			</Button>
+		</div>
+	);
+
+	return (
+		<DialogWrapper
+			open={open}
+			onOpenChange={(isOpen): void => {
+				if (!isOpen) {
+					onDismiss();
+				}
+			}}
+			title="Dashboard updated elsewhere"
+			width="narrow"
+			showCloseButton={false}
+			footer={footer}
+		>
+			<div className={styles.body}>
+				This dashboard was changed in another tab or by another user. Reload to see
+				the latest version.
+			</div>
+		</DialogWrapper>
+	);
+}
+
+export default DashboardChangedDialog;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useDashboardStaleCheck.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useDashboardStaleCheck.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useDashboardStaleCheck } from '../useDashboardStaleCheck';
+
+const mockUseQuery = jest.fn();
+const mockUseIsMutating = jest.fn();
+jest.mock('react-query', () => ({
+	useQuery: (...args: unknown[]): unknown => mockUseQuery(...args),
+	useIsMutating: (): number => mockUseIsMutating(),
+	useQueryClient: (): unknown => ({ getQueryData: jest.fn() }),
+}));
+jest.mock('api/generated/services/dashboard', () => ({
+	getDashboardV2: jest.fn(),
+	getGetDashboardV2QueryKey: jest.fn(() => ['/api/v2/dashboards/d1']),
+}));
+
+function setServerUpdatedAt(updatedAt: string | undefined): void {
+	mockUseQuery.mockReturnValue({ data: { data: { updatedAt } } });
+}
+
+describe('useDashboardStaleCheck', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockUseIsMutating.mockReturnValue(0);
+	});
+
+	it('prompts when the server copy is newer than the loaded one', () => {
+		setServerUpdatedAt('2026-07-08T10:00:00Z');
+		const { result } = renderHook(() =>
+			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
+		);
+		expect(result.current.showPrompt).toBe(true);
+	});
+
+	it('does not prompt when the versions match', () => {
+		setServerUpdatedAt('2026-07-08T09:00:00Z');
+		const { result } = renderHook(() =>
+			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
+		);
+		expect(result.current.showPrompt).toBe(false);
+	});
+
+	it('does not prompt while a mutation is in flight (optimistic save)', () => {
+		mockUseIsMutating.mockReturnValue(1);
+		setServerUpdatedAt('2026-07-08T10:00:00Z');
+		const { result } = renderHook(() =>
+			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
+		);
+		expect(result.current.showPrompt).toBe(false);
+	});
+
+	it('stops prompting for a version once dismissed', () => {
+		setServerUpdatedAt('2026-07-08T10:00:00Z');
+		const { result } = renderHook(() =>
+			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
+		);
+		expect(result.current.showPrompt).toBe(true);
+		act(() => result.current.dismiss());
+		expect(result.current.showPrompt).toBe(false);
+	});
+
+	it('reload refetches and clears the dismissed state', () => {
+		setServerUpdatedAt('2026-07-08T10:00:00Z');
+		const refetch = jest.fn();
+		const { result } = renderHook(() =>
+			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', refetch),
+		);
+		act(() => result.current.dismiss());
+		expect(result.current.showPrompt).toBe(false);
+		act(() => result.current.reload());
+		expect(refetch).toHaveBeenCalledTimes(1);
+		expect(result.current.showPrompt).toBe(true);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
@@ -1,0 +1,69 @@
+import { useCallback, useState } from 'react';
+import { useIsMutating, useQuery, useQueryClient } from 'react-query';
+import {
+	getDashboardV2,
+	getGetDashboardV2QueryKey,
+} from 'api/generated/services/dashboard';
+import type { GetDashboardV2200 } from 'api/generated/services/sigNoz.schemas';
+
+interface UseDashboardStaleCheck {
+	// Server copy has a newer updatedAt than the loaded one, and not yet dismissed.
+	showPrompt: boolean;
+	reload: () => void;
+	dismiss: () => void;
+}
+
+/**
+ * Detects when the open dashboard changed on the server (another tab/user) without
+ * touching the render cache: a separate query (own key) refetches on window focus
+ * and its updatedAt is compared to the loaded copy's. Guarded by in-flight
+ * mutations so an optimistic save doesn't false-positive.
+ */
+export function useDashboardStaleCheck(
+	dashboardId: string,
+	loadedUpdatedAt: string | undefined,
+	refetch: () => void,
+): UseDashboardStaleCheck {
+	const isMutating = useIsMutating() > 0;
+	const queryClient = useQueryClient();
+	const [dismissedAt, setDismissedAt] = useState<string | null>(null);
+
+	const { data } = useQuery(
+		['dashboard-freshness', dashboardId],
+		({ signal }) => getDashboardV2({ id: dashboardId }, signal),
+		{
+			enabled: !!dashboardId,
+			refetchOnWindowFocus: true,
+			refetchOnMount: false,
+			retry: false,
+			// Seed from the already-loaded dashboard so mount makes no extra GET; the
+			// query only hits the network on a later window focus.
+			initialData: () =>
+				queryClient.getQueryData<GetDashboardV2200>(
+					getGetDashboardV2QueryKey({ id: dashboardId }),
+				),
+		},
+	);
+
+	const serverUpdatedAt = data?.data?.updatedAt;
+	const changed =
+		!isMutating &&
+		!!serverUpdatedAt &&
+		!!loadedUpdatedAt &&
+		serverUpdatedAt !== loadedUpdatedAt;
+
+	const dismiss = useCallback(
+		(): void => setDismissedAt(serverUpdatedAt ?? null),
+		[serverUpdatedAt],
+	);
+	const reload = useCallback((): void => {
+		refetch();
+		setDismissedAt(null);
+	}, [refetch]);
+
+	return {
+		showPrompt: changed && serverUpdatedAt !== dismissedAt,
+		reload,
+		dismiss,
+	};
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
@@ -12,6 +12,8 @@ import { useDashboardStore } from './store/useDashboardStore';
 import styles from './DashboardContainer.module.scss';
 import DashboardPageHeader from './components/DashboardPageHeader/DashboardPageHeader';
 import LockedIndicator from './components/LockedIndicator/LockedIndicator';
+import DashboardChangedDialog from './components/DashboardChangedDialog/DashboardChangedDialog';
+import { useDashboardStaleCheck } from './hooks/useDashboardStaleCheck';
 import { Base64Icons } from './DashboardSettings/Overview/utils';
 
 interface DashboardContainerProps {
@@ -53,6 +55,12 @@ function DashboardContainer({
 	// suggests them ($variable) in the panel editor and dashboards-page builder.
 	useSyncVariablesForSuggestions(dashboard);
 
+	const staleCheck = useDashboardStaleCheck(
+		dashboard.id,
+		dashboard.updatedAt,
+		refetch,
+	);
+
 	// In full screen show only the sections and panels — the header/toolbar chrome
 	// is hidden for a clean presentation view (exit with Esc).
 	return (
@@ -66,6 +74,11 @@ function DashboardContainer({
 				)}
 				<PanelsAndSectionsLayout layouts={spec.layouts} panels={spec.panels} />
 				{isLocked && <LockedIndicator />}
+				<DashboardChangedDialog
+					open={staleCheck.showPrompt}
+					onReload={staleCheck.reload}
+					onDismiss={staleCheck.dismiss}
+				/>
 			</div>
 		</FullScreen>
 	);


### PR DESCRIPTION
## Summary

The open V2 dashboard never noticed when its dashboard was changed on the server (another tab, or another user) — it kept showing the stale copy with no way to know. This adds a lightweight staleness check that prompts to reload.

The V2 dashboard fetch is intentionally `staleTime: Infinity` + `refetchOnMount: false` (the optimistic cache is authoritative, and auto-refetch flashed the grid back to server state). So this **doesn't** touch that query — a **separate freshness query** (its own key) refetches on window focus and compares its `updatedAt` to the loaded copy's. On a difference it shows a dialog with **Reload** (refetches the main query) / **Dismiss**.

## Details

- `useDashboardStaleCheck(id, loadedUpdatedAt, refetch)` — separate `useQuery(['dashboard-freshness', id], …, { refetchOnWindowFocus: true, refetchOnMount: false })`; never writes the render cache, so no grid flash.
- Guarded by `useIsMutating()` so an in-flight optimistic save doesn't false-positive during its brief pre-reconcile window.
- Dismiss suppresses the prompt for that version; a newer server change re-prompts. Reload refetches the main query and clears the dismissed state.
- Dialog uses the shared `DialogWrapper` (same style as the delete/discard confirms). No backend change; one extra GET per tab-focus.

## Test plan

- Open a dashboard in two tabs; edit + save in tab A; focus tab B → dialog appears → Reload shows the changes.
- Editing in the same tab (optimistic save) does **not** trigger the dialog.
- Unit tests cover the prompt logic: newer version prompts, equal versions don't, in-flight mutation suppresses, dismiss/reload behavior.