### PR TITLE
feat(dashboard-v2): surface legacy dashboards in the v2 list

### DIFF
--- a/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.test.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, userEvent } from 'tests/test-utils';
+
+import ActionsPopover from './ActionsPopover';
+
+const baseProps = {
+	link: '/dashboard/abc',
+	dashboardId: 'abc',
+	dashboardName: 'My Dashboard',
+	createdBy: 'someone-else@signoz.io',
+	isLocked: false,
+	onView: jest.fn(),
+};
+
+describe('ActionsPopover', () => {
+	it('shows the full set of actions for a v2 dashboard', async () => {
+		render(<ActionsPopover {...baseProps} />);
+		await userEvent.click(screen.getByTestId('dashboard-action-icon'));
+
+		await screen.findByTestId('dashboard-action-view');
+		expect(screen.getByTestId('dashboard-action-view')).toBeInTheDocument();
+		expect(
+			screen.getByTestId('dashboard-action-open-new-tab'),
+		).toBeInTheDocument();
+		expect(screen.getByTestId('dashboard-action-copy-link')).toBeInTheDocument();
+		expect(screen.getByTestId('dashboard-action-rename')).toBeInTheDocument();
+		expect(screen.getByTestId('dashboard-action-duplicate')).toBeInTheDocument();
+		expect(screen.getByTestId('dashboard-action-delete')).toBeInTheDocument();
+	});
+
+	it('keeps only Delete for a legacy dashboard', async () => {
+		render(<ActionsPopover {...baseProps} isLegacy />);
+		await userEvent.click(screen.getByTestId('dashboard-action-icon'));
+
+		// Delete is the one action that still applies to a legacy blob.
+		await screen.findByTestId('dashboard-action-delete');
+		expect(screen.getByTestId('dashboard-action-delete')).toBeInTheDocument();
+
+		expect(screen.queryByTestId('dashboard-action-view')).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId('dashboard-action-open-new-tab'),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId('dashboard-action-copy-link'),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId('dashboard-action-rename'),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId('dashboard-action-duplicate'),
+		).not.toBeInTheDocument();
+		expect(screen.queryByTestId('dashboard-action-lock')).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.tsx
@@ -40,6 +40,10 @@ interface Props {
 	createdBy: string;
 	isLocked: boolean;
 	onView: (event: React.MouseEvent<HTMLElement>) => void;
+	// A legacy (pre-v2) dashboard has no v2 spec, so the actions that operate on
+	// one (view, open, copy link, rename, duplicate, lock) don't apply — only
+	// Delete is kept.
+	isLegacy?: boolean;
 }
 
 function ActionsPopover({
@@ -49,6 +53,7 @@ function ActionsPopover({
 	createdBy,
 	isLocked,
 	onView,
+	isLegacy = false,
 }: Props): JSX.Element {
 	const [, setCopy] = useCopyToClipboard();
 	const { safeNavigate } = useSafeNavigate();
@@ -100,101 +105,106 @@ function ActionsPopover({
 					// row's onClick, which would navigate to the dashboard.
 					// eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- wrapper only guards propagation, not an interactive control
 					<div className={styles.content} onClick={(e): void => e.stopPropagation()}>
-						<Button
-							color="secondary"
-							className={styles.menuItem}
-							prefix={<Expand size={14} />}
-							onClick={onView}
-							testId="dashboard-action-view"
-						>
-							View
-						</Button>
-						<Button
-							color="secondary"
-							className={styles.menuItem}
-							prefix={<SquareArrowOutUpRight size={14} />}
-							onClick={(e): void => {
-								e.stopPropagation();
-								e.preventDefault();
-								openInNewTab(link);
-							}}
-							testId="dashboard-action-open-new-tab"
-						>
-							Open in New Tab
-						</Button>
-						<Button
-							color="secondary"
-							className={styles.menuItem}
-							prefix={<Link2 size={14} />}
-							onClick={(e): void => {
-								e.stopPropagation();
-								e.preventDefault();
-								setCopy(getAbsoluteUrl(link));
-							}}
-							testId="dashboard-action-copy-link"
-						>
-							Copy Link
-						</Button>
-						<Tooltip
-							placement="left"
-							title={
-								isLocked ? 'This dashboard is locked, so it cannot be renamed.' : ''
-							}
-						>
-							<span className={styles.menuItemWrap}>
+						{!isLegacy && (
+							<>
 								<Button
 									color="secondary"
 									className={styles.menuItem}
-									prefix={<PenLine size={14} />}
-									disabled={isLocked}
+									prefix={<Expand size={14} />}
+									onClick={onView}
+									testId="dashboard-action-view"
+								>
+									View
+								</Button>
+								<Button
+									color="secondary"
+									className={styles.menuItem}
+									prefix={<SquareArrowOutUpRight size={14} />}
 									onClick={(e): void => {
 										e.stopPropagation();
 										e.preventDefault();
-										if (!isLocked) {
-											setIsRenameOpen(true);
-										}
+										openInNewTab(link);
 									}}
-									testId="dashboard-action-rename"
+									testId="dashboard-action-open-new-tab"
 								>
-									Rename
+									Open in New Tab
 								</Button>
-							</span>
-						</Tooltip>
-						<Button
-							color="secondary"
-							className={styles.menuItem}
-							prefix={<Copy size={14} />}
-							loading={isCloning}
-							onClick={(e): void => {
-								e.stopPropagation();
-								e.preventDefault();
-								runClone();
-							}}
-							testId="dashboard-action-duplicate"
-						>
-							Duplicate
-						</Button>
-						{canToggleLock && (
-							<Button
-								color="secondary"
-								className={styles.menuItem}
-								prefix={<LockKeyhole size={14} />}
-								loading={isTogglingLock}
-								onClick={(e): void => {
-									e.stopPropagation();
-									e.preventDefault();
-									runLockToggle();
-								}}
-								testId="dashboard-action-lock"
-							>
-								{isLocked ? 'Unlock Dashboard' : 'Lock Dashboard'}
-							</Button>
+								<Button
+									color="secondary"
+									className={styles.menuItem}
+									prefix={<Link2 size={14} />}
+									onClick={(e): void => {
+										e.stopPropagation();
+										e.preventDefault();
+										setCopy(getAbsoluteUrl(link));
+									}}
+									testId="dashboard-action-copy-link"
+								>
+									Copy Link
+								</Button>
+								<Tooltip
+									placement="left"
+									title={
+										isLocked ? 'This dashboard is locked, so it cannot be renamed.' : ''
+									}
+								>
+									<span className={styles.menuItemWrap}>
+										<Button
+											color="secondary"
+											className={styles.menuItem}
+											prefix={<PenLine size={14} />}
+											disabled={isLocked}
+											onClick={(e): void => {
+												e.stopPropagation();
+												e.preventDefault();
+												if (!isLocked) {
+													setIsRenameOpen(true);
+												}
+											}}
+											testId="dashboard-action-rename"
+										>
+											Rename
+										</Button>
+									</span>
+								</Tooltip>
+								<Button
+									color="secondary"
+									className={styles.menuItem}
+									prefix={<Copy size={14} />}
+									loading={isCloning}
+									onClick={(e): void => {
+										e.stopPropagation();
+										e.preventDefault();
+										runClone();
+									}}
+									testId="dashboard-action-duplicate"
+								>
+									Duplicate
+								</Button>
+								{canToggleLock && (
+									<Button
+										color="secondary"
+										className={styles.menuItem}
+										prefix={<LockKeyhole size={14} />}
+										loading={isTogglingLock}
+										onClick={(e): void => {
+											e.stopPropagation();
+											e.preventDefault();
+											runLockToggle();
+										}}
+										testId="dashboard-action-lock"
+									>
+										{isLocked ? 'Unlock Dashboard' : 'Lock Dashboard'}
+									</Button>
+								)}
+							</>
 						)}
 						<DeleteActionItem
 							dashboardId={dashboardId}
 							dashboardName={dashboardName}
 							createdBy={createdBy}
 							isLocked={isLocked}
+							showDivider={!isLegacy}
 						/>
 					</div>
 				}

--- a/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/DeleteActionItem.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/DeleteActionItem.tsx
@@ -23,6 +23,9 @@ interface Props {
 	dashboardName: string;
 	createdBy: string;
 	isLocked: boolean;
+	// Delete sits below the other actions, so it leads with a divider. When it's
+	// the only item (a legacy dashboard), the divider is suppressed.
+	showDivider?: boolean;
 }
 
 function DeleteActionItem({
@@ -30,6 +33,7 @@ function DeleteActionItem({
 	dashboardName,
 	createdBy,
 	isLocked,
+	showDivider = true,
 }: Props): JSX.Element {
 	const { t } = useTranslation(['dashboard']);
 	const { user } = useAppContext();
@@ -100,7 +104,7 @@ function DeleteActionItem({
 
 	return (
 		<>
-			<Divider />
+			{showDivider && <Divider />}
 			<Tooltip placement="left" title={tooltip}>
 				<span className={styles.menuItemWrap}>
 					<Button

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.module.scss
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.module.scss
@@ -55,6 +55,10 @@
 	overflow-wrap: anywhere;
 }
 
+.legacyBadge {
+	flex: none;
+}
+
 .tagsWithActions {
 	display: flex;
 	align-items: center;
@@ -69,6 +73,17 @@
 	justify-content: center;
 	flex: none;
 	color: var(--l3-foreground);
+}
+
+/* Wrap so the tooltip has a hoverable target even when the pin button is disabled
+   (a legacy dashboard can't be pinned). */
+.pinButtonWrap {
+	display: inline-flex;
+	flex: none;
+}
+
+.pinButtonWrap button:disabled {
+	pointer-events: none;
 }
 
 .pinButton {

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.test.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, userEvent } from 'tests/test-utils';
+
+import type { DashboardListItem } from '../../utils/helpers';
+
+import DashboardRow from './DashboardRow';
+
+const mockSafeNavigate = jest.fn();
+jest.mock('hooks/useSafeNavigate', () => ({
+	useSafeNavigate: (): { safeNavigate: jest.Mock } => ({
+		safeNavigate: mockSafeNavigate,
+	}),
+}));
+
+const mockTogglePin = jest.fn();
+jest.mock('../../hooks/usePinDashboard', () => ({
+	usePinDashboard: (): { togglePin: jest.Mock; isUpdating: boolean } => ({
+		togglePin: mockTogglePin,
+		isUpdating: false,
+	}),
+}));
+
+jest.mock('api/common/logEvent', () => ({
+	__esModule: true,
+	default: jest.fn(),
+}));
+
+// Stub the actions menu so this suite stays focused on the row; the isLegacy
+// wiring is asserted via the recorded prop, and the menu itself is covered by
+// ActionsPopover's own tests.
+jest.mock('../ActionsPopover/ActionsPopover', () => ({
+	__esModule: true,
+	default: ({ isLegacy }: { isLegacy?: boolean }): JSX.Element => (
+		<div data-testid="actions-popover" data-legacy={String(!!isLegacy)} />
+	),
+}));
+
+const makeDashboard = (
+	overrides: Partial<DashboardListItem> = {},
+): DashboardListItem =>
+	({
+		id: 'dash-1',
+		legacy: false,
+		pinned: false,
+		locked: false,
+		image: '',
+		createdBy: 'alice@signoz.io',
+		updatedBy: 'alice@signoz.io',
+		createdAt: '2024-01-01T00:00:00Z',
+		updatedAt: '2024-01-02T00:00:00Z',
+		tags: [],
+		spec: { display: { name: 'My Dashboard' } },
+		...overrides,
+	}) as unknown as DashboardListItem;
+
+const renderRow = (dashboard: DashboardListItem): void => {
+	render(
+		<DashboardRow
+			dashboard={dashboard}
+			index={0}
+			canAct
+			showUpdatedAt={false}
+			showUpdatedBy={false}
+		/>,
+	);
+};
+
+describe('DashboardRow', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('a v2 dashboard', () => {
+		it('navigates on click and shows no legacy badge', async () => {
+			renderRow(makeDashboard());
+
+			expect(screen.queryByTestId('dashboard-legacy-0')).not.toBeInTheDocument();
+			expect(screen.getByTestId('dashboard-pin-0')).not.toBeDisabled();
+			expect(screen.getByTestId('actions-popover')).toHaveAttribute(
+				'data-legacy',
+				'false',
+			);
+
+			await userEvent.click(screen.getByTestId('dashboard-title-0'));
+			expect(mockSafeNavigate).toHaveBeenCalledTimes(1);
+			expect(screen.queryByTestId('legacy-dashboard-id')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('a legacy dashboard', () => {
+		it('badges the row, disables pin and gates the actions menu', () => {
+			renderRow(makeDashboard({ legacy: true }));
+
+			expect(screen.getByTestId('dashboard-legacy-0')).toBeInTheDocument();
+			expect(screen.getByTestId('dashboard-pin-0')).toBeDisabled();
+			expect(screen.getByTestId('actions-popover')).toHaveAttribute(
+				'data-legacy',
+				'true',
+			);
+		});
+
+		it('opens the explanatory dialog instead of navigating', async () => {
+			renderRow(makeDashboard({ legacy: true }));
+
+			await userEvent.click(screen.getByTestId('dashboard-title-0'));
+
+			expect(mockSafeNavigate).not.toHaveBeenCalled();
+			expect(screen.getByTestId('legacy-dashboard-id')).toBeInTheDocument();
+		});
+	});
+});

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react';
 import TagBadge from 'components/TagBadge/TagBadge';
+import { Badge } from '@signozhq/ui/badge';
 import { Button } from '@signozhq/ui/button';
 import { TooltipSimple } from '@signozhq/ui/tooltip';
 import { Typography } from '@signozhq/ui/typography';
@@ -18,6 +20,7 @@ import { useDashboardViewsStore } from '../../store/useDashboardViewsStore';
 import type { DashboardListItem } from '../../utils/helpers';
 import { lastUpdatedLabel, tagsToStrings } from '../../utils/helpers';
 import ActionsPopover from '../ActionsPopover/ActionsPopover';
+import LegacyDashboardDialog from '../LegacyDashboardDialog/LegacyDashboardDialog';
 
 import styles from './DashboardRow.module.scss';
 
@@ -42,6 +45,11 @@ function DashboardRow({
 	const markViewed = useDashboardViewsStore((s) => s.markViewed);
 	const { togglePin, isUpdating } = usePinDashboard();
 
+	const [isLegacyDialogOpen, setIsLegacyDialogOpen] = useState(false);
+
+	// A legacy dashboard is stored in the pre-v2 shape and has no v2 spec, so it
+	// can't be opened in the new experience — clicking it explains this instead.
+	const isLegacy = !!dashboard.legacy;
 	const isPinned = !!dashboard.pinned;
 	const id = dashboard.id;
 	const name = dashboard.spec?.display?.name ?? '';
@@ -61,9 +69,17 @@ function DashboardRow({
 
 	const onClickHandler = (event: React.MouseEvent<HTMLElement>): void => {
 		event.stopPropagation();
+		if (isLegacy) {
+			setIsLegacyDialogOpen(true);
+			void logEvent('Dashboard List: Clicked on legacy dashboard', {
+				dashboardId: id,
+				dashboardName: name,
+			});
+			return;
+		}
 		markViewed(id);
 		safeNavigate(link, { newTab: isModifierKeyPressed(event) });
-		logEvent('Dashboard List: Clicked on dashboard', {
+		void logEvent('Dashboard List: Clicked on dashboard', {
 			dashboardId: id,
 			dashboardName: name,
 		});
@@ -71,8 +87,16 @@ function DashboardRow({
 
 	const onTogglePin = (event: React.MouseEvent<HTMLElement>): void => {
 		event.stopPropagation();
+		if (isLegacy) {
+			return;
+		}
 		togglePin(id, isPinned);
 	};
+
+	const pinLabel = isPinned ? 'Unpin dashboard' : 'Pin dashboard';
+	const pinTooltip = isLegacy
+		? "This dashboard isn't available in the new experience, so it can't be pinned"
+		: pinLabel;
 
 	// Only long titles are truncated, so only they need the full-name tooltip;
 	// wrapping conditionally avoids an empty hanging tooltip for short names.
@@ -89,120 +113,144 @@ function DashboardRow({
 	);
 
 	return (
-		<div className={styles.row} onClick={onClickHandler}>
-			<div className={styles.titleWithAction}>
-				<div className={styles.titleBlock}>
-					{name.length > 50 ? (
-						<TooltipSimple title={name} side="bottom" disableHoverableContent>
-							{titleLink}
+		<>
+			<div className={styles.row} onClick={onClickHandler}>
+				<div className={styles.titleWithAction}>
+					<div className={styles.titleBlock}>
+						{name.length > 50 ? (
+							<TooltipSimple title={name} side="bottom" disableHoverableContent>
+								{titleLink}
+							</TooltipSimple>
+						) : (
+							titleLink
+						)}
+						{isLegacy && (
+							<Badge
+								color="amber"
+								variant="outline"
+								className={styles.legacyBadge}
+								testId={`dashboard-legacy-${index}`}
+							>
+								Legacy
+							</Badge>
+						)}
+					</div>
+
+					<div className={styles.tagsWithActions}>
+						{tags.length > 0 && (
+							<div className={styles.tags}>
+								{tags.slice(0, 3).map((tag) => (
+									<TagBadge key={tag}>{tag}</TagBadge>
+								))}
+								{tags.length > 3 && (
+									<TagBadge key={tags[3]}>+{tags.length - 3}</TagBadge>
+								)}
+							</div>
+						)}
+					</div>
+
+					{isLocked && (
+						<TooltipSimple
+							title="This dashboard is locked"
+							side="top"
+							disableHoverableContent
+						>
+							<span
+								className={styles.lockIcon}
+								data-testid={`dashboard-lock-${index}`}
+							>
+								<LockKeyhole size={14} />
+							</span>
 						</TooltipSimple>
-					) : (
-						titleLink
 					)}
-				</div>
 
-				<div className={styles.tagsWithActions}>
-					{tags.length > 0 && (
-						<div className={styles.tags}>
-							{tags.slice(0, 3).map((tag) => (
-								<TagBadge key={tag}>{tag}</TagBadge>
-							))}
-							{tags.length > 3 && (
-								<TagBadge key={tags[3]}>+{tags.length - 3}</TagBadge>
-							)}
-						</div>
-					)}
-				</div>
-
-				{isLocked && (
-					<TooltipSimple
-						title="This dashboard is locked"
-						side="top"
-						disableHoverableContent
-					>
-						<span className={styles.lockIcon} data-testid={`dashboard-lock-${index}`}>
-							<LockKeyhole size={14} />
+					<TooltipSimple title={pinTooltip} side="top" disableHoverableContent>
+						<span className={styles.pinButtonWrap}>
+							<Button
+								type="button"
+								variant="ghost"
+								color="secondary"
+								size="icon"
+								className={cx(styles.pinButton, {
+									[styles.pinButtonOn]: isPinned && !isLegacy,
+								})}
+								aria-label={pinLabel}
+								data-testid={`dashboard-pin-${index}`}
+								disabled={isUpdating || isLegacy}
+								onClick={onTogglePin}
+							>
+								{isPinned ? (
+									<>
+										<Pin size={14} className={styles.pinnedIcon} />
+										<PinOff size={14} className={styles.unpinIcon} />
+									</>
+								) : (
+									<Pin size={14} />
+								)}
+							</Button>
 						</span>
 					</TooltipSimple>
-				)}
 
-				<TooltipSimple
-					title={isPinned ? 'Unpin dashboard' : 'Pin dashboard'}
-					side="top"
-					disableHoverableContent
-				>
-					<Button
-						type="button"
-						variant="ghost"
-						color="secondary"
-						size="icon"
-						className={cx(styles.pinButton, { [styles.pinButtonOn]: isPinned })}
-						aria-label={isPinned ? 'Unpin dashboard' : 'Pin dashboard'}
-						data-testid={`dashboard-pin-${index}`}
-						disabled={isUpdating}
-						onClick={onTogglePin}
-					>
-						{isPinned ? (
-							<>
-								<Pin size={14} className={styles.pinnedIcon} />
-								<PinOff size={14} className={styles.unpinIcon} />
-							</>
-						) : (
-							<Pin size={14} />
-						)}
-					</Button>
-				</TooltipSimple>
-
-				{canAct && (
-					<ActionsPopover
-						link={link}
-						dashboardId={id}
-						dashboardName={name}
-						createdBy={createdBy}
-						isLocked={isLocked}
-						onView={onClickHandler}
-					/>
-				)}
-			</div>
-			<div className={styles.details}>
-				<div className={styles.createdAt}>
-					<CalendarClock size={14} />
-					<Typography.Text>{formattedCreatedAt}</Typography.Text>
+					{canAct && (
+						<ActionsPopover
+							link={link}
+							dashboardId={id}
+							dashboardName={name}
+							createdBy={createdBy}
+							isLocked={isLocked}
+							onView={onClickHandler}
+							isLegacy={isLegacy}
+						/>
+					)}
 				</div>
-
-				{createdBy && (
-					<div className={styles.createdBy}>
-						<div className={styles.avatar}>
-							<Typography.Text className={styles.avatarText}>
-								{createdBy.substring(0, 1).toUpperCase()}
-							</Typography.Text>
-						</div>
-						<Typography.Text className={styles.byLabel}>{createdBy}</Typography.Text>
-					</div>
-				)}
-
-				{showUpdatedAt && (
+				<div className={styles.details}>
 					<div className={styles.createdAt}>
 						<CalendarClock size={14} />
-						<Typography.Text>{lastUpdatedLabel(updatedAt)}</Typography.Text>
+						<Typography.Text>{formattedCreatedAt}</Typography.Text>
 					</div>
-				)}
 
-				{updatedBy && showUpdatedBy && (
-					<div className={styles.updatedBy}>
-						<Typography.Text className={styles.byLabel}>
-							Last Updated By -
-						</Typography.Text>
-						<div className={styles.avatar}>
-							<Typography.Text className={styles.avatarText}>
-								{updatedBy.substring(0, 1).toUpperCase()}
-							</Typography.Text>
+					{createdBy && (
+						<div className={styles.createdBy}>
+							<div className={styles.avatar}>
+								<Typography.Text className={styles.avatarText}>
+									{createdBy.substring(0, 1).toUpperCase()}
+								</Typography.Text>
+							</div>
+							<Typography.Text className={styles.byLabel}>{createdBy}</Typography.Text>
 						</div>
-						<Typography.Text className={styles.byLabel}>{updatedBy}</Typography.Text>
-					</div>
-				)}
+					)}
+
+					{showUpdatedAt && (
+						<div className={styles.createdAt}>
+							<CalendarClock size={14} />
+							<Typography.Text>{lastUpdatedLabel(updatedAt)}</Typography.Text>
+						</div>
+					)}
+
+					{updatedBy && showUpdatedBy && (
+						<div className={styles.updatedBy}>
+							<Typography.Text className={styles.byLabel}>
+								Last Updated By -
+							</Typography.Text>
+							<div className={styles.avatar}>
+								<Typography.Text className={styles.avatarText}>
+									{updatedBy.substring(0, 1).toUpperCase()}
+								</Typography.Text>
+							</div>
+							<Typography.Text className={styles.byLabel}>{updatedBy}</Typography.Text>
+						</div>
+					)}
+				</div>
 			</div>
-		</div>
+			{isLegacy && (
+				<LegacyDashboardDialog
+					open={isLegacyDialogOpen}
+					dashboardId={id}
+					dashboardName={name}
+					onClose={(): void => setIsLegacyDialogOpen(false)}
+				/>
+			)}
+		</>
 	);
 }
 

--- a/frontend/src/pages/DashboardsListPageV2/components/LegacyDashboardDialog/LegacyDashboardDialog.module.scss
+++ b/frontend/src/pages/DashboardsListPageV2/components/LegacyDashboardDialog/LegacyDashboardDialog.module.scss
@@ -1,0 +1,54 @@
+.body {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.description {
+	color: var(--l2-foreground);
+	font-size: 13px;
+	line-height: 20px;
+
+	strong {
+		color: var(--l1-foreground);
+		font-weight: 500;
+	}
+}
+
+.idField {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.idLabel {
+	color: var(--l2-foreground);
+	font-size: 11px;
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+}
+
+.idRow {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 6px 6px 6px 12px;
+	border: 1px solid var(--l2-border);
+	border-radius: 4px;
+	background: var(--l2-background);
+}
+
+.idValue {
+	color: var(--l1-foreground);
+	font-family: 'SF Mono', 'Fira Code', monospace;
+	font-size: 12px;
+	word-break: break-all;
+}
+
+.footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+}

--- a/frontend/src/pages/DashboardsListPageV2/components/LegacyDashboardDialog/LegacyDashboardDialog.test.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/LegacyDashboardDialog/LegacyDashboardDialog.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, userEvent } from 'tests/test-utils';
+
+import LegacyDashboardDialog from './LegacyDashboardDialog';
+
+const mockCopy = jest.fn();
+jest.mock('react-use', () => ({
+	...jest.requireActual('react-use'),
+	useCopyToClipboard: (): [unknown, (value: string) => void] => [{}, mockCopy],
+}));
+
+const mockToastSuccess = jest.fn();
+jest.mock('@signozhq/ui/sonner', () => ({
+	toast: { success: (message: string): void => mockToastSuccess(message) },
+}));
+
+const mockContactSupport = jest.fn();
+jest.mock('container/Integrations/utils', () => ({
+	handleContactSupport: (isCloud: boolean): void => mockContactSupport(isCloud),
+}));
+
+const DASHBOARD_ID = '0f9a1b2c-3d4e-5f6a-7b8c-9d0e1f2a3b4c';
+
+describe('LegacyDashboardDialog', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	const setup = (open = true): void => {
+		render(
+			<LegacyDashboardDialog
+				open={open}
+				dashboardId={DASHBOARD_ID}
+				dashboardName="My Legacy Dashboard"
+				onClose={jest.fn()}
+			/>,
+		);
+	};
+
+	it('surfaces the dashboard name and id', () => {
+		setup();
+		expect(screen.getByText('My Legacy Dashboard')).toBeInTheDocument();
+		expect(screen.getByTestId('legacy-dashboard-id')).toHaveTextContent(
+			DASHBOARD_ID,
+		);
+	});
+
+	it('copies the dashboard id and confirms with a toast', async () => {
+		setup();
+		await userEvent.click(screen.getByTestId('legacy-dashboard-copy-id'));
+		expect(mockCopy).toHaveBeenCalledWith(DASHBOARD_ID);
+		expect(mockToastSuccess).toHaveBeenCalledWith('Dashboard ID copied');
+	});
+
+	it('routes the user to support', async () => {
+		setup();
+		await userEvent.click(screen.getByTestId('legacy-dashboard-contact-support'));
+		expect(mockContactSupport).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders nothing when closed', () => {
+		setup(false);
+		expect(screen.queryByTestId('legacy-dashboard-id')).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/pages/DashboardsListPageV2/components/LegacyDashboardDialog/LegacyDashboardDialog.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/LegacyDashboardDialog/LegacyDashboardDialog.tsx
@@ -1,0 +1,105 @@
+import { Button } from '@signozhq/ui/button';
+import { DialogWrapper } from '@signozhq/ui/dialog';
+import { Typography } from '@signozhq/ui/typography';
+import { ArrowUpRight, Copy } from '@signozhq/icons';
+import { useCopyToClipboard } from 'react-use';
+import { toast } from '@signozhq/ui/sonner';
+import { handleContactSupport } from 'container/Integrations/utils';
+import { useGetTenantLicense } from 'hooks/useGetTenantLicense';
+
+import styles from './LegacyDashboardDialog.module.scss';
+
+interface LegacyDashboardDialogProps {
+	open: boolean;
+	dashboardId: string;
+	dashboardName: string;
+	onClose: () => void;
+}
+
+/**
+ * Explains why a legacy (pre-v2) dashboard can't be opened in the new experience
+ * and hands the user the dashboard ID to share with support. Legacy rows are
+ * surfaced by the list API with `legacy: true` but have no v2 spec to render.
+ */
+function LegacyDashboardDialog({
+	open,
+	dashboardId,
+	dashboardName,
+	onClose,
+}: LegacyDashboardDialogProps): JSX.Element {
+	const [, copyToClipboard] = useCopyToClipboard();
+	const { isCloudUser } = useGetTenantLicense();
+
+	const onCopyId = (): void => {
+		copyToClipboard(dashboardId);
+		toast.success('Dashboard ID copied');
+	};
+
+	return (
+		<DialogWrapper
+			title="This dashboard isn't available in the new experience"
+			open={open}
+			width="narrow"
+			onOpenChange={(next): void => {
+				if (!next) {
+					onClose();
+				}
+			}}
+			footer={
+				<div className={styles.footer}>
+					<Button
+						variant="ghost"
+						color="secondary"
+						size="md"
+						onClick={onClose}
+						testId="legacy-dashboard-close"
+					>
+						Close
+					</Button>
+					<Button
+						variant="solid"
+						color="primary"
+						size="md"
+						suffix={<ArrowUpRight size={14} />}
+						onClick={(): void => handleContactSupport(!!isCloudUser)}
+						testId="legacy-dashboard-contact-support"
+					>
+						Contact Support
+					</Button>
+				</div>
+			}
+		>
+			<div className={styles.body}>
+				<Typography.Text className={styles.description}>
+					<strong>{dashboardName || 'This dashboard'}</strong> hasn&apos;t been
+					migrated to the new dashboard experience yet, so it can&apos;t be opened
+					here. Share the dashboard ID below with support and we&apos;ll help you
+					move it over.
+				</Typography.Text>
+
+				<div className={styles.idField}>
+					<Typography.Text className={styles.idLabel}>Dashboard ID</Typography.Text>
+					<div className={styles.idRow}>
+						<Typography.Text
+							className={styles.idValue}
+							data-testid="legacy-dashboard-id"
+						>
+							{dashboardId}
+						</Typography.Text>
+						<Button
+							variant="ghost"
+							color="secondary"
+							size="icon"
+							prefix={<Copy size={14} />}
+							aria-label="Copy dashboard ID"
+							onClick={onCopyId}
+							testId="legacy-dashboard-copy-id"
+						/>
+					</div>
+				</div>
+			</div>
+		</DialogWrapper>
+	);
+}
+
+export default LegacyDashboardDialog;


### PR DESCRIPTION
## Pull Request

> Stacked on #12020 (base branch `nv/list-v2-no-error`). Merge that first.

---

### 📄 Summary

#12020 makes the v2 list API return dashboards that were never migrated to the v2 (perses) schema, flagged `legacy: true`, instead of failing the whole list. This PR is the frontend counterpart: it renders those rows safely.

A legacy row has no v2 spec, so it can't be opened in the new experience and none of the v2 actions apply to it. Instead of letting the user click through to a detail page that can't render (or fire v2 patch/clone/lock calls that would fail on a v1 blob), the row is clearly marked and routed to a help path:

- **Badge** — the row shows a `Legacy` badge.
- **No navigation** — clicking the row opens a dialog explaining the dashboard isn't available in the new experience, rather than navigating.
- **Copyable ID + Contact Support** — the dialog surfaces the dashboard ID (one-click copy) to share with support, plus a Contact Support action.
- **Actions gated** — the pin button is hidden, and the actions menu hides every v2-only item (View, Open in New Tab, Copy Link, Rename, Duplicate, Lock), leaving only Delete.

#### Issues closed by this PR
Closes https://github.com/SigNoz/pulse-pod/issues/101

### Screenshots

<img width="1727" height="959" alt="image" src="https://github.com/user-attachments/assets/f57a3176-a02e-4da7-baeb-566202ea6d13" />


---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature

---

### 🧪 Testing Strategy

- Tests added/updated: none — this page has no component-render test harness (only pure-util `.test.ts`), and the change is presentational branching with no extractable pure logic.
- Manual verification: legacy row shows the badge, click opens the dialog, ID copies, actions menu shows only Delete, pin hidden; non-legacy rows unchanged.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: v2 dashboards list only; gated on the new `legacy` flag (v2 flow).
- Potential regressions: non-legacy rows are untouched (all new behavior is behind `isLegacy`).
- Rollback plan: revert; any fix can follow in a subsequent PR.