### PR TITLE
fix(dashboard-v2): panel drilldown fixes + New Panel modal one-click create

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/BarChartPanel/Renderer.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/BarChartPanel/Renderer.tsx
@@ -146,9 +146,14 @@ function BarPanelRenderer({
 
 	const renderTooltipFooter = useCallback(
 		({ isPinned, dismiss }: IRenderTooltipFooterArgs) => (
-			<TooltipFooter id={panelId} isPinned={isPinned} dismiss={dismiss} />
+			<TooltipFooter
+				id={panelId}
+				isPinned={isPinned}
+				canDrilldown={!!enableDrillDown}
+				dismiss={dismiss}
+			/>
 		),
-		[panelId],
+		[panelId, enableDrillDown],
 	);
 
 	// Keying on sync prefs forces a full chart teardown/re-mount so stale sync

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/__tests__/prepareData.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/__tests__/prepareData.test.ts
@@ -127,4 +127,37 @@ describe('preparePieData', () => {
 	it('returns no slices for empty tables', () => {
 		expect(preparePieData(args([]))).toStrictEqual([]);
 	});
+
+	it('carries the value column query name and group-by labels for drilldown', () => {
+		const table = tableWith(
+			[
+				{
+					name: 'service.name',
+					queryName: 'A',
+					isValueColumn: false,
+					id: 'service.name',
+				},
+				{ name: 'count', queryName: 'A', isValueColumn: true, id: 'A' },
+			],
+			[{ data: { 'service.name': 'adservice', A: 100 } }],
+		);
+
+		const [slice] = preparePieData(args([table]));
+
+		expect(slice.queryName).toBe('A');
+		expect(slice.labels).toStrictEqual({ 'service.name': 'adservice' });
+	});
+
+	it('leaves labels empty for an ungrouped slice', () => {
+		const table = tableWith(
+			[{ name: 'count', queryName: 'A', isValueColumn: true, id: 'A' }],
+			[{ data: { A: 42 } }],
+			{ legend: 'requests' },
+		);
+
+		const [slice] = preparePieData(args([table]));
+
+		expect(slice.queryName).toBe('A');
+		expect(slice.labels).toStrictEqual({});
+	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/prepareData.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/prepareData.ts
@@ -37,6 +37,15 @@ export function preparePieData({
 				.map(String)
 				.join(', ');
 
+			// Group-by key→value, keyed by field name for drilldown filters (`enrichPieClick`).
+			const labels: Record<string, string> = {};
+			labelColumns.forEach((column) => {
+				const value = row.data[column.id || column.name];
+				if (value != null) {
+					labels[column.name] = String(value as string | number);
+				}
+			});
+
 			valueColumns.forEach((column) => {
 				let label: string;
 				if (hasMultipleValueColumns) {
@@ -50,6 +59,8 @@ export function preparePieData({
 					label,
 					value: Number(row.data[column.id || column.name]),
 					color,
+					queryName: column.queryName,
+					labels,
 				});
 			});
 		});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TimeSeriesPanel/Renderer.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TimeSeriesPanel/Renderer.tsx
@@ -147,9 +147,14 @@ function TimeSeriesPanelRenderer({
 
 	const renderTooltipFooter = useCallback(
 		({ isPinned, dismiss }: IRenderTooltipFooterArgs) => (
-			<TooltipFooter id={panelId} isPinned={isPinned} dismiss={dismiss} />
+			<TooltipFooter
+				id={panelId}
+				isPinned={isPinned}
+				canDrilldown={!!enableDrillDown}
+				dismiss={dismiss}
+			/>
 		),
-		[panelId],
+		[panelId, enableDrillDown],
 	);
 
 	// Keying on sync prefs forces a full chart teardown/re-mount so stale sync

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModal.tsx
@@ -27,6 +27,11 @@ function PanelTypeSelectionModal({
 	const sections = useDashboardSections();
 	const options = useMemo(() => buildSectionOptions(sections), [sections]);
 
+	// With more than one section the user must pick a target section, so we keep
+	// the select-then-confirm flow. Otherwise there's nothing to choose: hide the
+	// footer and let a tile click create the panel outright.
+	const hasSectionPicker = options.length > 1;
+
 	const [selectedValue, setSelectedValue] = useState('');
 	const [selectedPanelKind, setSelectedPanelKind] = useState<PanelKind | null>(
 		null,
@@ -40,12 +45,24 @@ function PanelTypeSelectionModal({
 		}
 	}, [open, options, defaultLayoutIndex]);
 
+	const createPanel = (panelKind: PanelKind): void => {
+		const layoutIndex = selectedValue === '' ? undefined : Number(selectedValue);
+		onSelect(panelKind, layoutIndex);
+	};
+
+	const handleTileClick = (panelKind: PanelKind): void => {
+		if (hasSectionPicker) {
+			setSelectedPanelKind(panelKind);
+			return;
+		}
+		createPanel(panelKind);
+	};
+
 	const handleConfirm = (): void => {
 		if (selectedPanelKind === null) {
 			return;
 		}
-		const layoutIndex = selectedValue === '' ? undefined : Number(selectedValue);
-		onSelect(selectedPanelKind, layoutIndex);
+		createPanel(selectedPanelKind);
 	};
 
 	return (
@@ -58,17 +75,21 @@ function PanelTypeSelectionModal({
 			}}
 			title="New Panel"
 			footer={
-				<PanelTypeSelectionModalFooter
-					options={options}
-					selectedValue={selectedValue}
-					onSectionChange={setSelectedValue}
-					isConfirmDisabled={selectedPanelKind === null}
-					onConfirm={handleConfirm}
-				/>
+				hasSectionPicker ? (
+					<PanelTypeSelectionModalFooter
+						options={options}
+						selectedValue={selectedValue}
+						onSectionChange={setSelectedValue}
+						isConfirmDisabled={selectedPanelKind === null}
+						onConfirm={handleConfirm}
+					/>
+				) : undefined
 			}
 		>
 			<div className={styles.panelTypeSection}>
-				<span className={styles.pickerLabel}>Select panel type</span>
+				{hasSectionPicker && (
+					<span className={styles.pickerLabel}>Select panel type</span>
+				)}
 				<div className={styles.grid}>
 					{PANEL_TYPES.map(({ panelKind, label, Icon }) => (
 						<button
@@ -79,7 +100,7 @@ function PanelTypeSelectionModal({
 							})}
 							data-testid={`panel-type-${panelKind}`}
 							aria-pressed={panelKind === selectedPanelKind}
-							onClick={(): void => setSelectedPanelKind(panelKind)}
+							onClick={(): void => handleTileClick(panelKind)}
 						>
 							<Icon size={24} color={Color.BG_ROBIN_400} />
 							{label}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModalFooter.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelTypeSelectionModal/PanelTypeSelectionModalFooter.tsx
@@ -15,8 +15,9 @@ interface PanelTypeSelectionModalFooterProps {
 }
 
 /**
- * Footer for the New Panel modal: an "Add panel to" section picker (shown only
- * when the dashboard has more than one section) and the confirm button.
+ * Footer for the New Panel modal: an "Add panel to" section picker and the
+ * confirm button. Only rendered when the dashboard has more than one section —
+ * otherwise there's nothing to pick and a tile click creates the panel directly.
  */
 function PanelTypeSelectionModalFooter({
 	options,
@@ -25,20 +26,16 @@ function PanelTypeSelectionModalFooter({
 	isConfirmDisabled,
 	onConfirm,
 }: PanelTypeSelectionModalFooterProps): JSX.Element {
-	const hasSectionPicker = options.length > 1;
-
 	return (
 		<div className={styles.footerActions}>
-			{hasSectionPicker && (
-				<div className={styles.footerPicker}>
-					<span className={styles.pickerLabel}>Add panel to</span>
-					<SectionPicker
-						options={options}
-						value={selectedValue}
-						onChange={onSectionChange}
-					/>
-				</div>
-			)}
+			<div className={styles.footerPicker}>
+				<span className={styles.pickerLabel}>Add panel to</span>
+				<SectionPicker
+					options={options}
+					value={selectedValue}
+					onChange={onSectionChange}
+				/>
+			</div>
 			<Button
 				color="primary"
 				size="md"

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldown.test.tsx
@@ -6,12 +6,14 @@ import {
 } from 'api/generated/services/sigNoz.schemas';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
+import { EQueryType } from 'types/common/dashboard';
 
 import { useDrilldown } from '../hooks/useDrilldown';
 
 const mockOpenViewWithQuery = jest.fn();
 const mockNavigate = jest.fn();
 const mockGetBuilderQueries = jest.fn();
+const mockGetPanelQueryType = jest.fn();
 let mockResolved = { resolvedQuery: 'RESOLVED_QUERY', isResolving: false };
 let mockDashboardVariables: {
 	hasFieldVariables: boolean;
@@ -95,6 +97,13 @@ jest.mock(
 			mockGetBuilderQueries(...args),
 	}),
 );
+jest.mock(
+	'pages/DashboardPageV2/DashboardContainer/Panels/utils/getPanelQueryType',
+	() => ({
+		getPanelQueryType: (...args: unknown[]): unknown =>
+			mockGetPanelQueryType(...args),
+	}),
+);
 // Capability lookup mocked (its per-kind values are data in the definitions); avoids
 // importing the whole renderer registry into the test.
 jest.mock('pages/DashboardPageV2/DashboardContainer/Panels/registry', () => ({
@@ -133,6 +142,7 @@ describe('useDrilldown', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockGetBuilderQueries.mockReturnValue([{ name: 'A' }]);
+		mockGetPanelQueryType.mockReturnValue(EQueryType.QUERY_BUILDER);
 		mockResolved = { resolvedQuery: 'RESOLVED_QUERY', isResolving: false };
 		mockDashboardVariables = {
 			hasFieldVariables: true,
@@ -151,6 +161,15 @@ describe('useDrilldown', () => {
 			const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
 			expect(result.current.enableDrillDown).toBe(false);
 		});
+
+		it.each([EQueryType.PROM, EQueryType.CLICKHOUSE, undefined])(
+			'is false when the query type is %s (not the builder)',
+			(queryType) => {
+				mockGetPanelQueryType.mockReturnValue(queryType);
+				const { result } = renderHook(() => useDrilldown(tsPanel, 'p1'));
+				expect(result.current.enableDrillDown).toBe(false);
+			},
+		);
 
 		it('is false for a kind that opts out of drilldown', () => {
 			const { result } = renderHook(() =>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -16,7 +16,9 @@ import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContain
 import { getPanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/registry';
 import { buildAggregateData } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/buildAggregateData';
 import { getBuilderQueries } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries';
+import { getPanelQueryType } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getPanelQueryType';
 import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
+import { EQueryType } from 'types/common/dashboard';
 
 import DrilldownAggregateMenu from '../DrilldownMenu/DrilldownAggregateMenu';
 import DrilldownBreakoutMenu from '../DrilldownMenu/DrilldownBreakoutMenu';
@@ -76,12 +78,14 @@ export function useDrilldown(
 	const panelType = PANEL_KIND_TO_PANEL_TYPE[kind];
 	const queries = panel.spec.queries;
 
-	// Kind must opt in via its capability AND have a builder query to drill into.
+	// Drilldown only for builder-authored panels with a query to drill into (PromQL /
+	// ClickHouse have no builder context to refine).
 	const enableDrillDown = useMemo(
 		() =>
 			getPanelDefinition(kind).actions.drilldown &&
+			getPanelQueryType(panel) === EQueryType.QUERY_BUILDER &&
 			getBuilderQueries(queries).length > 0,
-		[kind, queries],
+		[kind, panel, queries],
 	);
 
 	const v1Query = useMemo(


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

A batch of Dashboard v2 panel bug fixes, each in its own commit:

1. **Drilldown armed on non-builder panels** — drilldown fired for PromQL / ClickHouse panels even though those modes carry no builder context to refine, producing an empty/invalid drilldown. Now gated on the panel being builder-authored.
2. **"Click to drilldown" hint shown when drilldown is off** — the tooltip hint appeared in the panel editor preview and for non-builder queries, i.e. when a click does nothing. Now shown only when a click will actually open the drilldown menu.
3. **Pie panel drilldown never worked** — pie slices were missing the `queryName`/`labels` the drilldown enricher needs, so every slice click was a silent no-op.
4. **Redundant click in the New Panel modal** — single-section dashboards were forced through a select-then-confirm flow with nothing to pick. Now a tile click creates the panel directly.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change.

_To be added — the effects are interactive (tooltip hint visibility, pie slice click opening the drilldown menu, one-click panel create)._

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/engineering-pod/issues/5634

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
- **Non-builder drilldown:** `enableDrillDown` only checked the capability flag + "at least one builder query exists". A mixed `CompositeQuery` (or `deriveQueryType`'s `QUERY_BUILDER` fallback) let PromQL/ClickHouse panels through.
- **Tooltip hint:** `TooltipFooter`'s `canDrilldown` prop defaults to `true`, and the time-series / bar renderers never passed it. Passing it verbatim wasn't enough — `enableDrillDown` is `undefined` in edit mode, and `canDrilldown={undefined}` falls back to the `true` default.
- **Pie drilldown:** `preparePieData` built slices with only `label`/`value`/`color`. With `slice.queryName === undefined`, `enrichPieClick` hit `isValidQueryName('')` and returned `null`, so `onClick` was never called.
- **New Panel modal:** the modal always rendered the footer (section picker + confirm) and used select-then-confirm regardless of section count, so a single-section dashboard had a pointless extra click.

#### Fix Strategy
- Gate `enableDrillDown` on `getPanelQueryType(panel) === EQueryType.QUERY_BUILDER`, alongside the existing capability + builder-query-count checks.
- Pass `canDrilldown={!!enableDrillDown}` (coerced) from the renderers and add `enableDrillDown` to the `useCallback` deps (also fixes a stale closure in the bar renderer).
- Carry the value column's `queryName` and the row's group-by `labels` (keyed by field name) onto each pie slice, mirroring how `enrichTableClick` reads them off the shared `PanelTable` shape.
- Hide the modal footer for the single-section case and create the panel on tile click; keep select-then-confirm when multiple sections exist.

---

### 🧪 Testing Strategy
> How was this change validated?

- **Tests added/updated:**
  - `useDrilldown.test.tsx` — asserts drilldown is disabled for `PROM` / `CLICKHOUSE` / `undefined` query types.
  - `prepareData.test.ts` (pie) — regression tests that slices carry the correct `queryName` and group-by `labels` (grouped and ungrouped).
  - Existing `TooltipFooter.test.tsx` already covers the `canDrilldown={false}` → hint-hidden behavior.
- **Manual verification:** `pnpm tsgo --noEmit`, `pnpm oxlint`, and the affected Jest suites pass. Pre-commit hook (tsgo + oxlint + oxfmt + commitlint) ran clean on every commit.
- **Edge cases covered:** empty queries, PromQL/ClickHouse panels, ungrouped pie slices, single- vs multi-section dashboards, edit-mode preview vs grid vs View modal.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** Dashboard v2 panel rendering only — drilldown gating (time-series/bar/pie/table), the drilldown tooltip hint, and the New Panel modal. No API, schema, or backend changes.
- **Potential regressions:** drilldown intentionally no longer arms for non-builder query panels (by design); the New Panel modal's single-section flow changes from two clicks to one.
- **Rollback plan:** pure frontend, revert the branch. Commits are independent and can be reverted individually.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Dashboard v2: pie panel drilldown now works; drilldown and its "Click to drilldown" hint no longer appear for non-builder query panels or in the panel editor; single-section dashboards create panels in one click. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Four independent fixes, one commit each — reviewable commit-by-commit.
- The non-builder gate (commit 1) and the tooltip hint (commit 2) are deliberately coupled: the hint now tracks the same `enableDrillDown` signal, so it disappears exactly when a click would no-op.
- The `!!enableDrillDown` coercion in commit 2 is load-bearing: `canDrilldown={undefined}` would otherwise fall through to the prop's `true` default.

---
