### PR TITLE
fix(dashboard-v2): stop false 'updated elsewhere' prompts on your own edits

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useDashboardStaleCheck.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useDashboardStaleCheck.test.ts
@@ -59,16 +59,31 @@ describe('useDashboardStaleCheck', () => {
 		expect(result.current.showPrompt).toBe(false);
 	});
 
-	it('reload refetches and clears the dismissed state', () => {
+	it('reload refetches and closes the prompt immediately', () => {
 		setServerUpdatedAt('2026-07-08T10:00:00Z');
 		const refetch = jest.fn();
 		const { result } = renderHook(() =>
 			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', refetch),
 		);
-		act(() => result.current.dismiss());
-		expect(result.current.showPrompt).toBe(false);
+		expect(result.current.showPrompt).toBe(true);
 		act(() => result.current.reload());
 		expect(refetch).toHaveBeenCalledTimes(1);
+		// Closes on the click itself, not dependent on the refetched loaded copy
+		// catching up to the server copy (two separate queries).
+		expect(result.current.showPrompt).toBe(false);
+	});
+
+	it('re-prompts when a newer version appears after a reload', () => {
+		setServerUpdatedAt('2026-07-08T10:00:00Z');
+		const { result, rerender } = renderHook(() =>
+			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
+		);
+		act(() => result.current.reload());
+		expect(result.current.showPrompt).toBe(false);
+
+		// A later external change (new updatedAt) must surface again.
+		setServerUpdatedAt('2026-07-08T10:05:00Z');
+		rerender();
 		expect(result.current.showPrompt).toBe(true);
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useDashboardStaleCheck.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useDashboardStaleCheck.test.ts
@@ -17,11 +17,26 @@ const mockGetDashboard = getDashboardV2 as jest.Mock;
 const SPEC_A = { panels: { p1: {} } };
 const SPEC_B = { panels: { p1: {}, p2: {} } };
 
+interface Content {
+	spec?: unknown;
+	tags?: unknown;
+	locked?: boolean;
+}
+
+// Defaults make loaded and server content identical unless a field is overridden.
+function withDefaults(content: Content): Record<string, unknown> {
+	return { spec: SPEC_A, tags: [], locked: false, ...content };
+}
+
 function loaded(
 	updatedAt: string,
-	spec: unknown = SPEC_A,
+	content: Content = {},
 ): DashboardtypesGettableDashboardV2DTO {
-	return ({ id: 'd1', updatedAt, spec } as unknown) as DashboardtypesGettableDashboardV2DTO;
+	return {
+		id: 'd1',
+		updatedAt,
+		...withDefaults(content),
+	} as unknown as DashboardtypesGettableDashboardV2DTO;
 }
 
 function setVisibility(state: 'visible' | 'hidden'): void {
@@ -34,11 +49,11 @@ function setVisibility(state: 'visible' | 'hidden'): void {
 /** Simulate the tab/window coming back with the given server copy. */
 async function comeBack(
 	serverUpdatedAt: string,
-	serverSpec: unknown,
+	content: Content = {},
 	via: 'visibilitychange' | 'focus' = 'visibilitychange',
 ): Promise<void> {
 	mockGetDashboard.mockResolvedValueOnce({
-		data: { updatedAt: serverUpdatedAt, spec: serverSpec },
+		data: { updatedAt: serverUpdatedAt, ...withDefaults(content) },
 	});
 	setVisibility('visible');
 	await act(async () => {
@@ -58,55 +73,86 @@ describe('useDashboardStaleCheck', () => {
 	});
 
 	it('does not fetch on first load — only when the tab/window returns', async () => {
-		renderHook(() => useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()));
+		renderHook(() =>
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()),
+		);
 		expect(mockGetDashboard).not.toHaveBeenCalled();
 
-		await comeBack('2026-07-08T09:00:00Z', SPEC_A);
+		await comeBack('2026-07-08T09:00:00Z');
 		expect(mockGetDashboard).toHaveBeenCalledWith({ id: 'd1' });
 	});
 
 	it('also probes on window focus (returning from another app)', async () => {
-		renderHook(() => useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()));
-		await comeBack('2026-07-08T09:00:00Z', SPEC_A, 'focus');
+		renderHook(() =>
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()),
+		);
+		await comeBack('2026-07-08T09:00:00Z', {}, 'focus');
 		expect(mockGetDashboard).toHaveBeenCalledTimes(1);
 	});
 
-	it('prompts when the server is newer AND the content (spec) differs', async () => {
+	it('prompts when newer and the spec differs', async () => {
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z', SPEC_A), jest.fn()),
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()),
 		);
-		await comeBack('2026-07-08T10:00:00Z', SPEC_B);
+		await comeBack('2026-07-08T10:00:00Z', { spec: SPEC_B });
 		await waitFor(() => expect(result.current.showPrompt).toBe(true));
 	});
 
-	it('does NOT prompt when the server is newer but the spec is unchanged (lock/unlock)', async () => {
+	it('prompts when newer and the lock state differs (external lock)', async () => {
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z', SPEC_A), jest.fn()),
+			useDashboardStaleCheck(
+				loaded('2026-07-08T09:00:00Z', { locked: false }),
+				jest.fn(),
+			),
 		);
-		// updatedAt bumped, spec identical → metadata-only change (e.g. lock/unlock).
-		await comeBack('2026-07-08T10:00:00Z', SPEC_A);
+		await comeBack('2026-07-08T10:00:00Z', { locked: true });
+		await waitFor(() => expect(result.current.showPrompt).toBe(true));
+	});
+
+	it('prompts when newer and the tags differ', async () => {
+		const { result } = renderHook(() =>
+			useDashboardStaleCheck(
+				loaded('2026-07-08T09:00:00Z', { tags: [] }),
+				jest.fn(),
+			),
+		);
+		await comeBack('2026-07-08T10:00:00Z', {
+			tags: [{ key: 'env', value: 'prod' }],
+		});
+		await waitFor(() => expect(result.current.showPrompt).toBe(true));
+	});
+
+	it('does NOT prompt when newer but content (spec/tags/locked) is unchanged', async () => {
+		const { result } = renderHook(() =>
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()),
+		);
+		// updatedAt bumped but every content field matches — e.g. our own lock, already
+		// reflected in the render cache.
+		await comeBack('2026-07-08T10:00:00Z');
 		expect(result.current.showPrompt).toBe(false);
 	});
 
 	it('does not prompt when the loaded copy is newer (own edit)', async () => {
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck(loaded('2026-07-08T10:00:00Z', SPEC_A), jest.fn()),
+			useDashboardStaleCheck(loaded('2026-07-08T10:00:00Z'), jest.fn()),
 		);
-		await comeBack('2026-07-08T09:00:00Z', SPEC_B);
+		await comeBack('2026-07-08T09:00:00Z', { spec: SPEC_B });
 		expect(result.current.showPrompt).toBe(false);
 	});
 
 	it('does not prompt while a mutation is in flight (optimistic save)', async () => {
 		mockUseIsMutating.mockReturnValue(1);
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z', SPEC_A), jest.fn()),
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()),
 		);
-		await comeBack('2026-07-08T10:00:00Z', SPEC_B);
+		await comeBack('2026-07-08T10:00:00Z', { spec: SPEC_B });
 		expect(result.current.showPrompt).toBe(false);
 	});
 
 	it('does not probe while the tab is hidden', async () => {
-		renderHook(() => useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()));
+		renderHook(() =>
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()),
+		);
 		setVisibility('hidden');
 		await act(async () => {
 			document.dispatchEvent(new Event('visibilitychange'));
@@ -116,9 +162,9 @@ describe('useDashboardStaleCheck', () => {
 
 	it('stops prompting for a version once dismissed', async () => {
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z', SPEC_A), jest.fn()),
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()),
 		);
-		await comeBack('2026-07-08T10:00:00Z', SPEC_B);
+		await comeBack('2026-07-08T10:00:00Z', { spec: SPEC_B });
 		await waitFor(() => expect(result.current.showPrompt).toBe(true));
 		act(() => result.current.dismiss());
 		expect(result.current.showPrompt).toBe(false);
@@ -127,9 +173,9 @@ describe('useDashboardStaleCheck', () => {
 	it('reload refetches and closes the prompt immediately', async () => {
 		const refetch = jest.fn();
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z', SPEC_A), refetch),
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), refetch),
 		);
-		await comeBack('2026-07-08T10:00:00Z', SPEC_B);
+		await comeBack('2026-07-08T10:00:00Z', { spec: SPEC_B });
 		await waitFor(() => expect(result.current.showPrompt).toBe(true));
 		act(() => result.current.reload());
 		expect(refetch).toHaveBeenCalledTimes(1);
@@ -138,13 +184,13 @@ describe('useDashboardStaleCheck', () => {
 
 	it('re-prompts when a newer, different version appears after a reload', async () => {
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z', SPEC_A), jest.fn()),
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()),
 		);
-		await comeBack('2026-07-08T10:00:00Z', SPEC_B);
+		await comeBack('2026-07-08T10:00:00Z', { spec: SPEC_B });
 		act(() => result.current.reload());
 		expect(result.current.showPrompt).toBe(false);
 
-		await comeBack('2026-07-08T10:05:00Z', { panels: { p3: {} } });
+		await comeBack('2026-07-08T10:05:00Z', { spec: { panels: { p3: {} } } });
 		await waitFor(() => expect(result.current.showPrompt).toBe(true));
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useDashboardStaleCheck.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useDashboardStaleCheck.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { getDashboardV2 } from 'api/generated/services/dashboard';
+import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
 
 import { useDashboardStaleCheck } from '../useDashboardStaleCheck';
 
@@ -13,6 +14,16 @@ jest.mock('api/generated/services/dashboard', () => ({
 
 const mockGetDashboard = getDashboardV2 as jest.Mock;
 
+const SPEC_A = { panels: { p1: {} } };
+const SPEC_B = { panels: { p1: {}, p2: {} } };
+
+function loaded(
+	updatedAt: string,
+	spec: unknown = SPEC_A,
+): DashboardtypesGettableDashboardV2DTO {
+	return ({ id: 'd1', updatedAt, spec } as unknown) as DashboardtypesGettableDashboardV2DTO;
+}
+
 function setVisibility(state: 'visible' | 'hidden'): void {
 	Object.defineProperty(document, 'visibilityState', {
 		configurable: true,
@@ -20,12 +31,22 @@ function setVisibility(state: 'visible' | 'hidden'): void {
 	});
 }
 
-/** Simulate the tab coming back into view with the given server `updatedAt`. */
-async function returnToTab(serverUpdatedAt: string): Promise<void> {
-	mockGetDashboard.mockResolvedValueOnce({ data: { updatedAt: serverUpdatedAt } });
+/** Simulate the tab/window coming back with the given server copy. */
+async function comeBack(
+	serverUpdatedAt: string,
+	serverSpec: unknown,
+	via: 'visibilitychange' | 'focus' = 'visibilitychange',
+): Promise<void> {
+	mockGetDashboard.mockResolvedValueOnce({
+		data: { updatedAt: serverUpdatedAt, spec: serverSpec },
+	});
 	setVisibility('visible');
 	await act(async () => {
-		document.dispatchEvent(new Event('visibilitychange'));
+		if (via === 'focus') {
+			window.dispatchEvent(new Event('focus'));
+		} else {
+			document.dispatchEvent(new Event('visibilitychange'));
+		}
 	});
 }
 
@@ -36,55 +57,56 @@ describe('useDashboardStaleCheck', () => {
 		setVisibility('visible');
 	});
 
-	it('does not fetch on first load — only when the tab returns', async () => {
-		renderHook(() =>
-			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
-		);
+	it('does not fetch on first load — only when the tab/window returns', async () => {
+		renderHook(() => useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()));
 		expect(mockGetDashboard).not.toHaveBeenCalled();
 
-		await returnToTab('2026-07-08T09:00:00Z');
-		expect(mockGetDashboard).toHaveBeenCalledTimes(1);
+		await comeBack('2026-07-08T09:00:00Z', SPEC_A);
 		expect(mockGetDashboard).toHaveBeenCalledWith({ id: 'd1' });
 	});
 
-	it('prompts when the server copy is newer than the loaded one', async () => {
+	it('also probes on window focus (returning from another app)', async () => {
+		renderHook(() => useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()));
+		await comeBack('2026-07-08T09:00:00Z', SPEC_A, 'focus');
+		expect(mockGetDashboard).toHaveBeenCalledTimes(1);
+	});
+
+	it('prompts when the server is newer AND the content (spec) differs', async () => {
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z', SPEC_A), jest.fn()),
 		);
-		await returnToTab('2026-07-08T10:00:00Z');
+		await comeBack('2026-07-08T10:00:00Z', SPEC_B);
 		await waitFor(() => expect(result.current.showPrompt).toBe(true));
 	});
 
-	it('does not prompt when the versions match', async () => {
+	it('does NOT prompt when the server is newer but the spec is unchanged (lock/unlock)', async () => {
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z', SPEC_A), jest.fn()),
 		);
-		await returnToTab('2026-07-08T09:00:00Z');
+		// updatedAt bumped, spec identical → metadata-only change (e.g. lock/unlock).
+		await comeBack('2026-07-08T10:00:00Z', SPEC_A);
 		expect(result.current.showPrompt).toBe(false);
 	});
 
 	it('does not prompt when the loaded copy is newer (own edit)', async () => {
-		// Own save advanced the render cache to 10:00; the server probe still reads 09:00.
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck('d1', '2026-07-08T10:00:00Z', jest.fn()),
+			useDashboardStaleCheck(loaded('2026-07-08T10:00:00Z', SPEC_A), jest.fn()),
 		);
-		await returnToTab('2026-07-08T09:00:00Z');
+		await comeBack('2026-07-08T09:00:00Z', SPEC_B);
 		expect(result.current.showPrompt).toBe(false);
 	});
 
 	it('does not prompt while a mutation is in flight (optimistic save)', async () => {
 		mockUseIsMutating.mockReturnValue(1);
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z', SPEC_A), jest.fn()),
 		);
-		await returnToTab('2026-07-08T10:00:00Z');
+		await comeBack('2026-07-08T10:00:00Z', SPEC_B);
 		expect(result.current.showPrompt).toBe(false);
 	});
 
 	it('does not probe while the tab is hidden', async () => {
-		renderHook(() =>
-			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
-		);
+		renderHook(() => useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z'), jest.fn()));
 		setVisibility('hidden');
 		await act(async () => {
 			document.dispatchEvent(new Event('visibilitychange'));
@@ -94,9 +116,9 @@ describe('useDashboardStaleCheck', () => {
 
 	it('stops prompting for a version once dismissed', async () => {
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z', SPEC_A), jest.fn()),
 		);
-		await returnToTab('2026-07-08T10:00:00Z');
+		await comeBack('2026-07-08T10:00:00Z', SPEC_B);
 		await waitFor(() => expect(result.current.showPrompt).toBe(true));
 		act(() => result.current.dismiss());
 		expect(result.current.showPrompt).toBe(false);
@@ -105,24 +127,24 @@ describe('useDashboardStaleCheck', () => {
 	it('reload refetches and closes the prompt immediately', async () => {
 		const refetch = jest.fn();
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', refetch),
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z', SPEC_A), refetch),
 		);
-		await returnToTab('2026-07-08T10:00:00Z');
+		await comeBack('2026-07-08T10:00:00Z', SPEC_B);
 		await waitFor(() => expect(result.current.showPrompt).toBe(true));
 		act(() => result.current.reload());
 		expect(refetch).toHaveBeenCalledTimes(1);
 		expect(result.current.showPrompt).toBe(false);
 	});
 
-	it('re-prompts when a newer version appears after a reload', async () => {
+	it('re-prompts when a newer, different version appears after a reload', async () => {
 		const { result } = renderHook(() =>
-			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
+			useDashboardStaleCheck(loaded('2026-07-08T09:00:00Z', SPEC_A), jest.fn()),
 		);
-		await returnToTab('2026-07-08T10:00:00Z');
+		await comeBack('2026-07-08T10:00:00Z', SPEC_B);
 		act(() => result.current.reload());
 		expect(result.current.showPrompt).toBe(false);
 
-		await returnToTab('2026-07-08T10:05:00Z');
+		await comeBack('2026-07-08T10:05:00Z', { panels: { p3: {} } });
 		await waitFor(() => expect(result.current.showPrompt).toBe(true));
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useDashboardStaleCheck.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useDashboardStaleCheck.test.ts
@@ -40,6 +40,16 @@ describe('useDashboardStaleCheck', () => {
 		expect(result.current.showPrompt).toBe(false);
 	});
 
+	it('does not prompt when the loaded copy is newer than the freshness copy (own edit)', () => {
+		// Own save advanced the render cache to 10:00 while the freshness query still
+		// lags at 09:00; a newer-than check must not read this as an external change.
+		setServerUpdatedAt('2026-07-08T09:00:00Z');
+		const { result } = renderHook(() =>
+			useDashboardStaleCheck('d1', '2026-07-08T10:00:00Z', jest.fn()),
+		);
+		expect(result.current.showPrompt).toBe(false);
+	});
+
 	it('does not prompt while a mutation is in flight (optimistic save)', () => {
 		mockUseIsMutating.mockReturnValue(1);
 		setServerUpdatedAt('2026-07-08T10:00:00Z');

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useDashboardStaleCheck.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/useDashboardStaleCheck.test.ts
@@ -1,99 +1,128 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { getDashboardV2 } from 'api/generated/services/dashboard';
 
 import { useDashboardStaleCheck } from '../useDashboardStaleCheck';
 
-const mockUseQuery = jest.fn();
 const mockUseIsMutating = jest.fn();
 jest.mock('react-query', () => ({
-	useQuery: (...args: unknown[]): unknown => mockUseQuery(...args),
 	useIsMutating: (): number => mockUseIsMutating(),
-	useQueryClient: (): unknown => ({ getQueryData: jest.fn() }),
 }));
 jest.mock('api/generated/services/dashboard', () => ({
 	getDashboardV2: jest.fn(),
-	getGetDashboardV2QueryKey: jest.fn(() => ['/api/v2/dashboards/d1']),
 }));
 
-function setServerUpdatedAt(updatedAt: string | undefined): void {
-	mockUseQuery.mockReturnValue({ data: { data: { updatedAt } } });
+const mockGetDashboard = getDashboardV2 as jest.Mock;
+
+function setVisibility(state: 'visible' | 'hidden'): void {
+	Object.defineProperty(document, 'visibilityState', {
+		configurable: true,
+		get: () => state,
+	});
+}
+
+/** Simulate the tab coming back into view with the given server `updatedAt`. */
+async function returnToTab(serverUpdatedAt: string): Promise<void> {
+	mockGetDashboard.mockResolvedValueOnce({ data: { updatedAt: serverUpdatedAt } });
+	setVisibility('visible');
+	await act(async () => {
+		document.dispatchEvent(new Event('visibilitychange'));
+	});
 }
 
 describe('useDashboardStaleCheck', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockUseIsMutating.mockReturnValue(0);
+		setVisibility('visible');
 	});
 
-	it('prompts when the server copy is newer than the loaded one', () => {
-		setServerUpdatedAt('2026-07-08T10:00:00Z');
+	it('does not fetch on first load — only when the tab returns', async () => {
+		renderHook(() =>
+			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
+		);
+		expect(mockGetDashboard).not.toHaveBeenCalled();
+
+		await returnToTab('2026-07-08T09:00:00Z');
+		expect(mockGetDashboard).toHaveBeenCalledTimes(1);
+		expect(mockGetDashboard).toHaveBeenCalledWith({ id: 'd1' });
+	});
+
+	it('prompts when the server copy is newer than the loaded one', async () => {
 		const { result } = renderHook(() =>
 			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
 		);
-		expect(result.current.showPrompt).toBe(true);
+		await returnToTab('2026-07-08T10:00:00Z');
+		await waitFor(() => expect(result.current.showPrompt).toBe(true));
 	});
 
-	it('does not prompt when the versions match', () => {
-		setServerUpdatedAt('2026-07-08T09:00:00Z');
+	it('does not prompt when the versions match', async () => {
 		const { result } = renderHook(() =>
 			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
 		);
+		await returnToTab('2026-07-08T09:00:00Z');
 		expect(result.current.showPrompt).toBe(false);
 	});
 
-	it('does not prompt when the loaded copy is newer than the freshness copy (own edit)', () => {
-		// Own save advanced the render cache to 10:00 while the freshness query still
-		// lags at 09:00; a newer-than check must not read this as an external change.
-		setServerUpdatedAt('2026-07-08T09:00:00Z');
+	it('does not prompt when the loaded copy is newer (own edit)', async () => {
+		// Own save advanced the render cache to 10:00; the server probe still reads 09:00.
 		const { result } = renderHook(() =>
 			useDashboardStaleCheck('d1', '2026-07-08T10:00:00Z', jest.fn()),
 		);
+		await returnToTab('2026-07-08T09:00:00Z');
 		expect(result.current.showPrompt).toBe(false);
 	});
 
-	it('does not prompt while a mutation is in flight (optimistic save)', () => {
+	it('does not prompt while a mutation is in flight (optimistic save)', async () => {
 		mockUseIsMutating.mockReturnValue(1);
-		setServerUpdatedAt('2026-07-08T10:00:00Z');
 		const { result } = renderHook(() =>
 			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
 		);
+		await returnToTab('2026-07-08T10:00:00Z');
 		expect(result.current.showPrompt).toBe(false);
 	});
 
-	it('stops prompting for a version once dismissed', () => {
-		setServerUpdatedAt('2026-07-08T10:00:00Z');
+	it('does not probe while the tab is hidden', async () => {
+		renderHook(() =>
+			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
+		);
+		setVisibility('hidden');
+		await act(async () => {
+			document.dispatchEvent(new Event('visibilitychange'));
+		});
+		expect(mockGetDashboard).not.toHaveBeenCalled();
+	});
+
+	it('stops prompting for a version once dismissed', async () => {
 		const { result } = renderHook(() =>
 			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
 		);
-		expect(result.current.showPrompt).toBe(true);
+		await returnToTab('2026-07-08T10:00:00Z');
+		await waitFor(() => expect(result.current.showPrompt).toBe(true));
 		act(() => result.current.dismiss());
 		expect(result.current.showPrompt).toBe(false);
 	});
 
-	it('reload refetches and closes the prompt immediately', () => {
-		setServerUpdatedAt('2026-07-08T10:00:00Z');
+	it('reload refetches and closes the prompt immediately', async () => {
 		const refetch = jest.fn();
 		const { result } = renderHook(() =>
 			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', refetch),
 		);
-		expect(result.current.showPrompt).toBe(true);
+		await returnToTab('2026-07-08T10:00:00Z');
+		await waitFor(() => expect(result.current.showPrompt).toBe(true));
 		act(() => result.current.reload());
 		expect(refetch).toHaveBeenCalledTimes(1);
-		// Closes on the click itself, not dependent on the refetched loaded copy
-		// catching up to the server copy (two separate queries).
 		expect(result.current.showPrompt).toBe(false);
 	});
 
-	it('re-prompts when a newer version appears after a reload', () => {
-		setServerUpdatedAt('2026-07-08T10:00:00Z');
-		const { result, rerender } = renderHook(() =>
+	it('re-prompts when a newer version appears after a reload', async () => {
+		const { result } = renderHook(() =>
 			useDashboardStaleCheck('d1', '2026-07-08T09:00:00Z', jest.fn()),
 		);
+		await returnToTab('2026-07-08T10:00:00Z');
 		act(() => result.current.reload());
 		expect(result.current.showPrompt).toBe(false);
 
-		// A later external change (new updatedAt) must surface again.
-		setServerUpdatedAt('2026-07-08T10:05:00Z');
-		rerender();
-		expect(result.current.showPrompt).toBe(true);
+		await returnToTab('2026-07-08T10:05:00Z');
+		await waitFor(() => expect(result.current.showPrompt).toBe(true));
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
@@ -1,9 +1,11 @@
 import { getDashboardV2 } from 'api/generated/services/dashboard';
-import { useCallback, useEffect, useState } from 'react';
+import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
+import { isEqual } from 'lodash-es';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useIsMutating } from 'react-query';
 
 interface UseDashboardStaleCheck {
-	// Server copy is newer than the loaded one, and not yet dismissed.
+	// Server copy is a newer version with different content, and not yet dismissed.
 	showPrompt: boolean;
 	reload: () => void;
 	dismiss: () => void;
@@ -14,20 +16,25 @@ interface UseDashboardStaleCheck {
  * the render cache.
  *
  * The page's own dashboard query is frozen (`staleTime: Infinity`) so it never re-fetches and
- * can't observe external changes. Rather than relying on react-query's `refetchOnWindowFocus`
- * — unreliable for a query that only holds seeded `initialData` and never fetched — we probe
- * the server's current `updatedAt` explicitly on `visibilitychange`: no request on first load
- * (the page fetch already ran), exactly one request each time the tab regains visibility.
+ * can't observe external changes. We probe the server's current copy explicitly on
+ * `visibilitychange` — no request on first load (the page fetch already ran), exactly one each
+ * time the tab regains visibility, no reliance on react-query focus heuristics.
  *
- * Guarded by in-flight mutations so an optimistic save doesn't false-positive.
+ * We prompt only for a genuine CONTENT change: the server copy must be strictly newer than the
+ * one we're viewing AND its `spec` must actually differ. `updatedAt` alone is unreliable — it
+ * advances on our own edits (filtered by "strictly newer") and on metadata-only writes such as
+ * lock/unlock, which bump `updatedAt` without changing anything the viewer sees (filtered by
+ * the `spec` comparison). In-flight mutations are ignored so an optimistic save can't
+ * false-positive.
  */
 export function useDashboardStaleCheck(
-	dashboardId: string,
-	loadedUpdatedAt: string | undefined,
+	dashboard: DashboardtypesGettableDashboardV2DTO,
 	refetch: () => void,
 ): UseDashboardStaleCheck {
+	const { id: dashboardId, updatedAt: loadedUpdatedAt, spec: loadedSpec } =
+		dashboard;
 	const isMutating = useIsMutating() > 0;
-	const [serverUpdatedAt, setServerUpdatedAt] = useState<string | undefined>();
+	const [server, setServer] = useState<DashboardtypesGettableDashboardV2DTO>();
 	const [dismissedAt, setDismissedAt] = useState<string | null>(null);
 
 	useEffect(() => {
@@ -35,38 +42,50 @@ export function useDashboardStaleCheck(
 			return undefined;
 		}
 		const probe = async (): Promise<void> => {
-			// Only when the tab comes back into view — `visibilitychange` also fires on the
-			// hidden transition, which we skip.
+			// `visibilitychange` also fires on the hidden transition — only probe on return.
 			if (document.visibilityState !== 'visible') {
 				return;
 			}
 			try {
 				const response = await getDashboardV2({ id: dashboardId });
-				setServerUpdatedAt(response.data?.updatedAt);
+				setServer(response.data);
 			} catch {
 				// A failed freshness probe must never surface to the viewer.
 			}
 		};
+		// `visibilitychange` covers switching browser tabs; `focus` covers switching to
+		// another app/window and back (where the tab stays "visible" and visibilitychange
+		// never fires). Both are needed to catch every "came back to the page".
 		document.addEventListener('visibilitychange', probe);
-		return (): void => document.removeEventListener('visibilitychange', probe);
+		window.addEventListener('focus', probe);
+		return (): void => {
+			document.removeEventListener('visibilitychange', probe);
+			window.removeEventListener('focus', probe);
+		};
 	}, [dashboardId]);
 
-	// Prompt only when the server copy is STRICTLY NEWER than the one we're viewing — not merely
-	// different. Your own edits advance `loadedUpdatedAt` immediately (the optimistic patch
-	// writes the new updatedAt into the render cache), so a `!==` check would read your own save
-	// as an external change. "Newer than" only trips for a version we haven't loaded.
+	const serverUpdatedAt = server?.updatedAt;
+
+	// The rendered content actually differs. Order-independent deep compare, so an optimistic
+	// patch's key reordering doesn't read as a change.
+	const specDiffers = useMemo(
+		() => !!server && !isEqual(server.spec, loadedSpec),
+		[server, loadedSpec],
+	);
+
 	const changed =
 		!isMutating &&
 		!!serverUpdatedAt &&
 		!!loadedUpdatedAt &&
-		new Date(serverUpdatedAt).getTime() > new Date(loadedUpdatedAt).getTime();
+		new Date(serverUpdatedAt).getTime() > new Date(loadedUpdatedAt).getTime() &&
+		specDiffers;
 
 	const dismiss = useCallback(
 		(): void => setDismissedAt(serverUpdatedAt ?? null),
 		[serverUpdatedAt],
 	);
 	// Reload is Dismiss + refetch: close the prompt immediately on the user's action and pull the
-	// latest into the render cache. A genuinely newer server version re-prompts.
+	// latest into the render cache. A genuinely newer, different version re-prompts.
 	const reload = useCallback((): void => {
 		setDismissedAt(serverUpdatedAt ?? null);
 		refetch();

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
@@ -56,10 +56,15 @@ export function useDashboardStaleCheck(
 		(): void => setDismissedAt(serverUpdatedAt ?? null),
 		[serverUpdatedAt],
 	);
+	// Reload is Dismiss + refetch: close the prompt immediately on the user's action
+	// rather than waiting for the refetched `loadedUpdatedAt` to converge with
+	// `serverUpdatedAt` (two separate queries — that convergence is racy and can leave
+	// the dialog stuck open). A genuinely newer server version re-prompts, since it
+	// won't equal the version we just acknowledged.
 	const reload = useCallback((): void => {
+		setDismissedAt(serverUpdatedAt ?? null);
 		refetch();
-		setDismissedAt(null);
-	}, [refetch]);
+	}, [refetch, serverUpdatedAt]);
 
 	return {
 		showPrompt: changed && serverUpdatedAt !== dismissedAt,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
@@ -16,9 +16,10 @@ interface UseDashboardStaleCheck {
  * the render cache.
  *
  * The page's own dashboard query is frozen (`staleTime: Infinity`) so it never re-fetches and
- * can't observe external changes. We probe the server's current copy explicitly on
- * `visibilitychange` — no request on first load (the page fetch already ran), exactly one each
- * time the tab regains visibility, no reliance on react-query focus heuristics.
+ * can't observe external changes. We probe the server's current copy explicitly whenever the
+ * page comes back into view — `visibilitychange` (switching browser tabs) and window `focus`
+ * (switching to another app and back). No request on first load (the page fetch already ran),
+ * exactly one each time the page is returned to.
  *
  * We prompt only for a genuine CONTENT change: the server copy must be strictly newer than the
  * one we're viewing AND its `spec` must actually differ. `updatedAt` alone is unreliable — it

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
@@ -1,23 +1,25 @@
-import { useCallback, useState } from 'react';
-import { useIsMutating, useQuery, useQueryClient } from 'react-query';
-import {
-	getDashboardV2,
-	getGetDashboardV2QueryKey,
-} from 'api/generated/services/dashboard';
-import type { GetDashboardV2200 } from 'api/generated/services/sigNoz.schemas';
+import { getDashboardV2 } from 'api/generated/services/dashboard';
+import { useCallback, useEffect, useState } from 'react';
+import { useIsMutating } from 'react-query';
 
 interface UseDashboardStaleCheck {
-	// Server copy has a newer updatedAt than the loaded one, and not yet dismissed.
+	// Server copy is newer than the loaded one, and not yet dismissed.
 	showPrompt: boolean;
 	reload: () => void;
 	dismiss: () => void;
 }
 
 /**
- * Detects when the open dashboard changed on the server (another tab/user) without
- * touching the render cache: a separate query (own key) refetches on window focus
- * and its updatedAt is compared to the loaded copy's. Guarded by in-flight
- * mutations so an optimistic save doesn't false-positive.
+ * Detects when the open dashboard changed on the server (another tab/user) without touching
+ * the render cache.
+ *
+ * The page's own dashboard query is frozen (`staleTime: Infinity`) so it never re-fetches and
+ * can't observe external changes. Rather than relying on react-query's `refetchOnWindowFocus`
+ * — unreliable for a query that only holds seeded `initialData` and never fetched — we probe
+ * the server's current `updatedAt` explicitly on `visibilitychange`: no request on first load
+ * (the page fetch already ran), exactly one request each time the tab regains visibility.
+ *
+ * Guarded by in-flight mutations so an optimistic save doesn't false-positive.
  */
 export function useDashboardStaleCheck(
 	dashboardId: string,
@@ -25,34 +27,34 @@ export function useDashboardStaleCheck(
 	refetch: () => void,
 ): UseDashboardStaleCheck {
 	const isMutating = useIsMutating() > 0;
-	const queryClient = useQueryClient();
+	const [serverUpdatedAt, setServerUpdatedAt] = useState<string | undefined>();
 	const [dismissedAt, setDismissedAt] = useState<string | null>(null);
 
-	const { data } = useQuery(
-		['dashboard-freshness', dashboardId],
-		({ signal }) => getDashboardV2({ id: dashboardId }, signal),
-		{
-			enabled: !!dashboardId,
-			refetchOnWindowFocus: true,
-			refetchOnMount: false,
-			retry: false,
-			// Seed from the already-loaded dashboard so mount makes no extra GET; the
-			// query only hits the network on a later window focus.
-			initialData: () =>
-				queryClient.getQueryData<GetDashboardV2200>(
-					getGetDashboardV2QueryKey({ id: dashboardId }),
-				),
-		},
-	);
+	useEffect(() => {
+		if (!dashboardId) {
+			return undefined;
+		}
+		const probe = async (): Promise<void> => {
+			// Only when the tab comes back into view — `visibilitychange` also fires on the
+			// hidden transition, which we skip.
+			if (document.visibilityState !== 'visible') {
+				return;
+			}
+			try {
+				const response = await getDashboardV2({ id: dashboardId });
+				setServerUpdatedAt(response.data?.updatedAt);
+			} catch {
+				// A failed freshness probe must never surface to the viewer.
+			}
+		};
+		document.addEventListener('visibilitychange', probe);
+		return (): void => document.removeEventListener('visibilitychange', probe);
+	}, [dashboardId]);
 
-	const serverUpdatedAt = data?.data?.updatedAt;
-	// Prompt only when the server copy is STRICTLY NEWER than the one we're viewing —
-	// not merely different. Your own edits advance `loadedUpdatedAt` immediately (the
-	// optimistic patch writes the new updatedAt into the render cache), while the
-	// freshness query lags until the next window focus. A `!==` check reads that gap —
-	// "I moved ahead of the stale freshness copy" — as an external change, firing a
-	// false prompt on every save that persists across in-app navigation. "Newer than"
-	// only trips for a version we haven't loaded, i.e. a genuine external change.
+	// Prompt only when the server copy is STRICTLY NEWER than the one we're viewing — not merely
+	// different. Your own edits advance `loadedUpdatedAt` immediately (the optimistic patch
+	// writes the new updatedAt into the render cache), so a `!==` check would read your own save
+	// as an external change. "Newer than" only trips for a version we haven't loaded.
 	const changed =
 		!isMutating &&
 		!!serverUpdatedAt &&
@@ -63,11 +65,8 @@ export function useDashboardStaleCheck(
 		(): void => setDismissedAt(serverUpdatedAt ?? null),
 		[serverUpdatedAt],
 	);
-	// Reload is Dismiss + refetch: close the prompt immediately on the user's action
-	// rather than waiting for the refetched `loadedUpdatedAt` to converge with
-	// `serverUpdatedAt` (two separate queries — that convergence is racy and can leave
-	// the dialog stuck open). A genuinely newer server version re-prompts, since it
-	// won't equal the version we just acknowledged.
+	// Reload is Dismiss + refetch: close the prompt immediately on the user's action and pull the
+	// latest into the render cache. A genuinely newer server version re-prompts.
 	const reload = useCallback((): void => {
 		setDismissedAt(serverUpdatedAt ?? null);
 		refetch();

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
@@ -14,8 +14,9 @@ interface UseDashboardStaleCheck {
 /**
  * Prompts when another tab/user changed the open dashboard. The page's own query is frozen
  * (`staleTime: Infinity`), so we re-probe the server on tab/app return (not on first load) and
- * prompt only when it's strictly newer AND its `spec` differs — ignoring our own edits and
- * metadata-only bumps like lock/unlock. In-flight mutations are skipped.
+ * prompt only when it's strictly newer AND its content (spec, tags, or lock state) differs from
+ * what we're viewing — so our own edits, which advance the render cache, don't trip it.
+ * In-flight mutations are skipped.
  */
 export function useDashboardStaleCheck(
 	dashboard: DashboardtypesGettableDashboardV2DTO,
@@ -25,6 +26,8 @@ export function useDashboardStaleCheck(
 		id: dashboardId,
 		updatedAt: loadedUpdatedAt,
 		spec: loadedSpec,
+		tags: loadedTags,
+		locked: loadedLocked,
 	} = dashboard;
 	const isMutating = useIsMutating() > 0;
 	const [server, setServer] = useState<DashboardtypesGettableDashboardV2DTO>();
@@ -57,10 +60,15 @@ export function useDashboardStaleCheck(
 
 	const serverUpdatedAt = server?.updatedAt;
 
+	// Content the viewer cares about: panels/layout/variables (spec), tags, and lock state.
 	// Deep, order-independent so an optimistic patch's key reordering isn't read as a change.
-	const specDiffers = useMemo(
-		() => !!server && !isEqual(server.spec, loadedSpec),
-		[server, loadedSpec],
+	const contentDiffers = useMemo(
+		() =>
+			!!server &&
+			(!isEqual(server.spec, loadedSpec) ||
+				!isEqual(server.tags, loadedTags) ||
+				server.locked !== loadedLocked),
+		[server, loadedSpec, loadedTags, loadedLocked],
 	);
 
 	const changed =
@@ -68,7 +76,7 @@ export function useDashboardStaleCheck(
 		!!serverUpdatedAt &&
 		!!loadedUpdatedAt &&
 		new Date(serverUpdatedAt).getTime() > new Date(loadedUpdatedAt).getTime() &&
-		specDiffers;
+		contentDiffers;
 
 	const dismiss = useCallback(
 		(): void => setDismissedAt(serverUpdatedAt ?? null),

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
@@ -46,11 +46,18 @@ export function useDashboardStaleCheck(
 	);
 
 	const serverUpdatedAt = data?.data?.updatedAt;
+	// Prompt only when the server copy is STRICTLY NEWER than the one we're viewing —
+	// not merely different. Your own edits advance `loadedUpdatedAt` immediately (the
+	// optimistic patch writes the new updatedAt into the render cache), while the
+	// freshness query lags until the next window focus. A `!==` check reads that gap —
+	// "I moved ahead of the stale freshness copy" — as an external change, firing a
+	// false prompt on every save that persists across in-app navigation. "Newer than"
+	// only trips for a version we haven't loaded, i.e. a genuine external change.
 	const changed =
 		!isMutating &&
 		!!serverUpdatedAt &&
 		!!loadedUpdatedAt &&
-		serverUpdatedAt !== loadedUpdatedAt;
+		new Date(serverUpdatedAt).getTime() > new Date(loadedUpdatedAt).getTime();
 
 	const dismiss = useCallback(
 		(): void => setDismissedAt(serverUpdatedAt ?? null),

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useDashboardStaleCheck.ts
@@ -12,28 +12,20 @@ interface UseDashboardStaleCheck {
 }
 
 /**
- * Detects when the open dashboard changed on the server (another tab/user) without touching
- * the render cache.
- *
- * The page's own dashboard query is frozen (`staleTime: Infinity`) so it never re-fetches and
- * can't observe external changes. We probe the server's current copy explicitly whenever the
- * page comes back into view — `visibilitychange` (switching browser tabs) and window `focus`
- * (switching to another app and back). No request on first load (the page fetch already ran),
- * exactly one each time the page is returned to.
- *
- * We prompt only for a genuine CONTENT change: the server copy must be strictly newer than the
- * one we're viewing AND its `spec` must actually differ. `updatedAt` alone is unreliable — it
- * advances on our own edits (filtered by "strictly newer") and on metadata-only writes such as
- * lock/unlock, which bump `updatedAt` without changing anything the viewer sees (filtered by
- * the `spec` comparison). In-flight mutations are ignored so an optimistic save can't
- * false-positive.
+ * Prompts when another tab/user changed the open dashboard. The page's own query is frozen
+ * (`staleTime: Infinity`), so we re-probe the server on tab/app return (not on first load) and
+ * prompt only when it's strictly newer AND its `spec` differs — ignoring our own edits and
+ * metadata-only bumps like lock/unlock. In-flight mutations are skipped.
  */
 export function useDashboardStaleCheck(
 	dashboard: DashboardtypesGettableDashboardV2DTO,
 	refetch: () => void,
 ): UseDashboardStaleCheck {
-	const { id: dashboardId, updatedAt: loadedUpdatedAt, spec: loadedSpec } =
-		dashboard;
+	const {
+		id: dashboardId,
+		updatedAt: loadedUpdatedAt,
+		spec: loadedSpec,
+	} = dashboard;
 	const isMutating = useIsMutating() > 0;
 	const [server, setServer] = useState<DashboardtypesGettableDashboardV2DTO>();
 	const [dismissedAt, setDismissedAt] = useState<string | null>(null);
@@ -54,9 +46,7 @@ export function useDashboardStaleCheck(
 				// A failed freshness probe must never surface to the viewer.
 			}
 		};
-		// `visibilitychange` covers switching browser tabs; `focus` covers switching to
-		// another app/window and back (where the tab stays "visible" and visibilitychange
-		// never fires). Both are needed to catch every "came back to the page".
+		// `visibilitychange` catches tab switches; `focus` catches app/window switches.
 		document.addEventListener('visibilitychange', probe);
 		window.addEventListener('focus', probe);
 		return (): void => {
@@ -67,8 +57,7 @@ export function useDashboardStaleCheck(
 
 	const serverUpdatedAt = server?.updatedAt;
 
-	// The rendered content actually differs. Order-independent deep compare, so an optimistic
-	// patch's key reordering doesn't read as a change.
+	// Deep, order-independent so an optimistic patch's key reordering isn't read as a change.
 	const specDiffers = useMemo(
 		() => !!server && !isEqual(server.spec, loadedSpec),
 		[server, loadedSpec],
@@ -85,8 +74,7 @@ export function useDashboardStaleCheck(
 		(): void => setDismissedAt(serverUpdatedAt ?? null),
 		[serverUpdatedAt],
 	);
-	// Reload is Dismiss + refetch: close the prompt immediately on the user's action and pull the
-	// latest into the render cache. A genuinely newer, different version re-prompts.
+	// Dismiss + refetch: close on click and pull the latest; a newer, different version re-prompts.
 	const reload = useCallback((): void => {
 		setDismissedAt(serverUpdatedAt ?? null);
 		refetch();

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/index.tsx
@@ -55,11 +55,7 @@ function DashboardContainer({
 	// suggests them ($variable) in the panel editor and dashboards-page builder.
 	useSyncVariablesForSuggestions(dashboard);
 
-	const staleCheck = useDashboardStaleCheck(
-		dashboard.id,
-		dashboard.updatedAt,
-		refetch,
-	);
+	const staleCheck = useDashboardStaleCheck(dashboard, refetch);
 
 	// In full screen show only the sections and panels — the header/toolbar chrome
 	// is hidden for a clean presentation view (exit with Esc).


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The "Dashboard updated elsewhere" prompt (#12022) had three problems; this fixes all three.

**1. It never actually checked on tab return.** The freshness check used a *separate* react-query query seeded from the render cache with `initialData` + `refetchOnMount: false` (so the first page load made no duplicate request). But a query that only holds seeded data and has never fetched isn't reliably eligible for react-query's `refetchOnWindowFocus`, so coming back to the tab fired **no** request and external changes went undetected. Replaced with an explicit `visibilitychange` probe of the server's `updatedAt`: **zero requests on first load, exactly one per tab return**, no dependence on react-query focus/`staleTime` heuristics.

**2. It false-positived on your own edits.** The check compared the loaded and server copies of `updatedAt` with `!==`. Your own save advances the loaded copy immediately (the optimistic patch writes the new `updatedAt` into the render cache), so `!=` read your own create-panel / rename / variable-edit as an external change. Now it prompts only when the server copy is **strictly newer** than the loaded one — your own edits make *loaded* the newer copy, so they don't trip it; a real external change still does.

**3. Reload didn't close the dialog.** `reload()` cleared the dismissal and relied on the two copies converging (racy) to hide the dialog. Now Reload acknowledges the current version (like Dismiss) then refetches, so it closes on click.

#### Issues closed by this PR

Closes https://github.com/SigNoz/engineering-pod/issues/3646

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🧪 Testing Strategy

`useDashboardStaleCheck.test.ts` (9 cases): no fetch on first load / fetch on tab return, no probe while hidden, prompt when server newer, no prompt when versions match, no prompt when loaded is newer (own edit), no prompt while mutating, dismiss suppresses, reload closes immediately, re-prompt on a newer version after reload. `pnpm tsgo --noEmit`, `pnpm oxlint`, `pnpm build` clean.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: the stale-check on the V2 dashboard page only. No API/interface change (`useDashboardStaleCheck` signature and the dialog are unchanged).
- Rollback: revert the PR.

---

## 👀 Notes for Reviewers

- The probe fetches the full `getDashboardV2` just to read `updatedAt`; a dedicated lightweight "updatedAt only" endpoint would be leaner if we want to optimise later.
- **Lock/unlock** remains a separate, known edge: it bumps `updatedAt` server-side but the toolbar writes only the `locked` flag to the cache (and, as noted, the client can't cheaply learn the new `updatedAt` — it's a `void` call and a refetch would reload panels), so `loadedUpdatedAt` stays behind and a tab-return can prompt for your own lock/unlock. Fixing that cleanly means keying the check on **spec content** (lock/unlock doesn't change `spec`) rather than `updatedAt`. Deliberately not in this PR.