### PR TITLE
feat(dashboard-v2): bug bash fixes II (list, dashboard page, create modal)

### DIFF
--- a/frontend/src/components/TagKeyValueInput/TagKeyValueInput.tsx
+++ b/frontend/src/components/TagKeyValueInput/TagKeyValueInput.tsx
@@ -65,7 +65,9 @@ function TagKeyValueInput({
 	};
 
 	const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
-		if (e.key === 'Enter') {
+		// Plain Enter adds the tag; let Cmd/Ctrl+Enter pass through so a host form
+		// (e.g. a modal) can submit on it.
+		if (e.key === 'Enter' && !e.metaKey && !e.ctrlKey) {
 			e.preventDefault();
 			commit();
 		}
@@ -93,11 +95,17 @@ function TagKeyValueInput({
 	};
 
 	const handleEditKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
-		if (e.key === 'Enter') {
+		// Plain Enter commits the edit; let Cmd/Ctrl+Enter pass through so a host
+		// form (e.g. a modal) can submit on it.
+		if (e.key === 'Enter' && !e.metaKey && !e.ctrlKey) {
 			e.preventDefault();
+			e.stopPropagation();
 			commitEdit();
 		} else if (e.key === 'Escape') {
+			// Contain Escape so it cancels the inline edit instead of bubbling up and
+			// closing the host drawer/modal.
 			e.preventDefault();
+			e.stopPropagation();
 			cancelEdit();
 		}
 	};

--- a/frontend/src/container/Home/Dashboards/Dashboards.tsx
+++ b/frontend/src/container/Home/Dashboards/Dashboards.tsx
@@ -1,21 +1,33 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Skeleton } from 'antd';
 import { Badge } from '@signozhq/ui/badge';
 import logEvent from 'api/common/logEvent';
+import { useListDashboardsForUserV2 } from 'api/generated/services/dashboard';
+import {
+	DashboardtypesListOrderDTO,
+	DashboardtypesListSortDTO,
+} from 'api/generated/services/sigNoz.schemas';
 import ROUTES from 'constants/routes';
 import { useGetAllDashboard } from 'hooks/dashboard/useGetAllDashboard';
+import { useIsDashboardV2 } from 'hooks/useIsDashboardV2';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import { ArrowRight, ArrowUpRight, Plus } from '@signozhq/icons';
 import Card from 'periscope/components/Card/Card';
 import { useAppContext } from 'providers/App/App';
-import { Dashboard } from 'types/api/dashboard/getAll';
 import { USER_ROLES } from 'types/roles';
 import { openInNewTab } from 'utils/navigation';
 
 import dialsUrl from '@/assets/Icons/dials.svg';
 
 import { getItemIcon } from '../constants';
+
+// The five most-recent dashboards, normalised across the v1 and v2 list APIs.
+interface RecentDashboard {
+	id: string;
+	title: string;
+	tags: string[];
+}
 
 export default function Dashboards({
 	onUpdateChecklistDoneItem,
@@ -26,33 +38,58 @@ export default function Dashboards({
 }): JSX.Element {
 	const { safeNavigate } = useSafeNavigate();
 	const { user } = useAppContext();
+	const isDashboardV2 = useIsDashboardV2();
 
-	const [sortedDashboards, setSortedDashboards] = useState<Dashboard[]>([]);
-
-	// Fetch Dashboards
+	// Fetch the recent dashboards from whichever API the `use_dashboard_v2` flag
+	// selects; the inactive one stays disabled so it never fires.
 	const {
-		data: dashboardsList,
-		isLoading: isDashboardListLoading,
-		isError: isDashboardListError,
-	} = useGetAllDashboard();
+		data: v1List,
+		isLoading: v1Loading,
+		isError: v1Error,
+	} = useGetAllDashboard({ enabled: !isDashboardV2 });
+
+	const {
+		data: v2List,
+		isLoading: v2Loading,
+		isError: v2Error,
+	} = useListDashboardsForUserV2(
+		{
+			sort: DashboardtypesListSortDTO.updated_at,
+			order: DashboardtypesListOrderDTO.desc,
+			limit: 5,
+			offset: 0,
+		},
+		{ query: { enabled: isDashboardV2 } },
+	);
+
+	const isDashboardListLoading = isDashboardV2 ? v2Loading : v1Loading;
+	const isDashboardListError = isDashboardV2 ? v2Error : v1Error;
+
+	const sortedDashboards = useMemo<RecentDashboard[]>(() => {
+		if (isDashboardV2) {
+			return (v2List?.data?.dashboards ?? []).map((d) => ({
+				id: d.id,
+				title: d.spec?.display?.name ?? d.name,
+				tags: (d.tags ?? []).map((t) => (t.value ? `${t.key}:${t.value}` : t.key)),
+			}));
+		}
+		return [...(v1List?.data ?? [])]
+			.sort(
+				(a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+			)
+			.slice(0, 5)
+			.map((d) => ({
+				id: d.id,
+				title: d.data.title,
+				tags: d.data.tags ?? [],
+			}));
+	}, [isDashboardV2, v1List, v2List]);
 
 	useEffect(() => {
-		if (!dashboardsList) {
-			return;
-		}
-
-		const sortedDashboards = dashboardsList.data.sort((a, b) => {
-			const aUpdateAt = new Date(a.updatedAt).getTime();
-			const bUpdateAt = new Date(b.updatedAt).getTime();
-			return bUpdateAt - aUpdateAt;
-		});
-
 		if (sortedDashboards.length > 0 && !loadingUserPreferences) {
 			onUpdateChecklistDoneItem('SETUP_DASHBOARDS');
 		}
-
-		setSortedDashboards(sortedDashboards.slice(0, 5));
-	}, [dashboardsList, onUpdateChecklistDoneItem, loadingUserPreferences]);
+	}, [sortedDashboards, onUpdateChecklistDoneItem, loadingUserPreferences]);
 
 	const emptyStateCard = (): JSX.Element => (
 		<div className="empty-state-container">
@@ -113,7 +150,7 @@ export default function Dashboards({
 						event.stopPropagation();
 						logEvent('Homepage: Dashboard clicked', {
 							dashboardId: dashboard.id,
-							dashboardName: dashboard.data.title,
+							dashboardName: dashboard.title,
 						});
 						if (event.metaKey || event.ctrlKey) {
 							openInNewTab(getLink());
@@ -143,12 +180,12 @@ export default function Dashboards({
 								/>
 
 								<div className="alert-rule-item-name home-data-item-name">
-									{dashboard.data.title}
+									{dashboard.title}
 								</div>
 							</div>
 
 							<div className="alert-rule-item-description home-data-item-tag">
-								{dashboard.data.tags?.map((tag) => (
+								{dashboard.tags.map((tag) => (
 									<Badge color="sienna" variant="outline" key={tag}>
 										{tag}
 									</Badge>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEvent } from 'react';
+import { type FocusEvent, KeyboardEvent } from 'react';
 import {
 	Check,
 	Globe,
@@ -90,12 +90,20 @@ function DashboardInfo({
 		}
 	};
 
+	// Clicking outside the editor commits, matching the input's Enter behaviour.
+	// Guard against blurs that move focus to the Save/Cancel buttons within it.
+	const onEditorBlur = (event: FocusEvent<HTMLDivElement>): void => {
+		if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+			onCommit();
+		}
+	};
+
 	return (
 		<div className={styles.dashboardInfo}>
 			<img src={image} alt={title} className={styles.dashboardImage} />
 
 			{isEditing ? (
-				<div className={styles.dashboardTitleEditor}>
+				<div className={styles.dashboardTitleEditor} onBlur={onEditorBlur}>
 					<Input
 						autoFocus
 						value={draft}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/DashboardImagePicker/DashboardImagePicker.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/DashboardImagePicker/DashboardImagePicker.module.scss
@@ -1,0 +1,32 @@
+.trigger {
+	display: flex;
+	width: 32px;
+	min-width: 32px;
+	height: 32px;
+	padding: 6px;
+	justify-content: center;
+	align-items: center;
+	background: var(--l3-background);
+
+	// icon-only trigger: drop the dropdown chevron, keep just the selected icon
+	svg {
+		display: none;
+	}
+}
+
+.options {
+	min-width: min-content;
+}
+
+.item {
+	width: min-content;
+
+	span {
+		vertical-align: middle;
+	}
+}
+
+.image {
+	height: 16px;
+	width: 16px;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/DashboardImagePicker/DashboardImagePicker.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/DashboardImagePicker/DashboardImagePicker.tsx
@@ -1,0 +1,43 @@
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+} from '@signozhq/ui/select';
+import cx from 'classnames';
+
+import { Base64Icons } from '../utils';
+
+import styles from './DashboardImagePicker.module.scss';
+
+interface Props {
+	// The selected image — one of the base64 icon data-URIs.
+	image: string;
+	onChange: (value: string) => void;
+	// Consumers set the trigger's border-radius (e.g. rounded-left when joined to
+	// a name input); this component owns size / background / icon-only styling.
+	triggerClassName?: string;
+}
+
+// Icon picker shared by the dashboard-details settings and the create-dashboard
+// modal so both choose from the same `Base64Icons` set.
+function DashboardImagePicker({
+	image,
+	onChange,
+	triggerClassName,
+}: Props): JSX.Element {
+	return (
+		<Select value={image} onChange={(value): void => onChange(value as string)}>
+			<SelectTrigger className={cx(styles.trigger, triggerClassName)} />
+			<SelectContent className={styles.options} withPortal={false}>
+				{Base64Icons.map((icon) => (
+					<SelectItem key={icon} value={icon} className={styles.item}>
+						<img src={icon} alt="dashboard-icon" className={styles.image} />
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+export default DashboardImagePicker;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/DashboardInfoForm/DashboardInfoForm.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/DashboardInfoForm/DashboardInfoForm.module.scss
@@ -25,38 +25,10 @@
 	}
 }
 
+// The image-picker owns its size/background; here we only round the left edge so
+// it joins flush with the name input to its right.
 .dashboardImageInput {
-	display: flex;
-	width: 32px;
-	min-width: 32px;
-	height: 32px;
-	padding: 6px;
-	justify-content: center;
-	align-items: center;
 	border-radius: 2px 0px 0px 2px;
-	background: var(--l3-background);
-
-	// icon-only trigger: drop the dropdown chevron, keep just the selected icon
-	svg {
-		display: none;
-	}
-}
-
-.dashboardImageOptions {
-	min-width: min-content;
-}
-
-.dashboardImageSelectItem {
-	width: min-content;
-
-	span {
-		vertical-align: middle;
-	}
-}
-
-.listItemImage {
-	height: 16px;
-	width: 16px;
 }
 
 .dashboardNameInput {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/DashboardInfoForm/DashboardInfoForm.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/DashboardInfoForm/DashboardInfoForm.tsx
@@ -1,17 +1,11 @@
 import { Dispatch, SetStateAction } from 'react';
 import { Input } from '@signozhq/ui/input';
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-} from '@signozhq/ui/select';
 import { Typography } from '@signozhq/ui/typography';
 // eslint-disable-next-line signoz/no-antd-components -- multiline TextArea has no @signozhq/ui equivalent yet
 import { Input as AntdInput } from 'antd';
 import TagKeyValueInput from 'components/TagKeyValueInput/TagKeyValueInput';
 
-import { Base64Icons } from '../utils';
+import DashboardImagePicker from '../DashboardImagePicker/DashboardImagePicker';
 import { DASHBOARD_NAME_MAX_LENGTH } from '../../../constants';
 import settingsStyles from '../../DashboardSettings.module.scss';
 import styles from './DashboardInfoForm.module.scss';
@@ -43,30 +37,11 @@ function DashboardInfoForm({
 				<div className={styles.infoItemContainer}>
 					<Typography className={styles.infoTitle}>Dashboard Name</Typography>
 					<section className={styles.nameIconInput}>
-						<Select
-							value={image}
-							onChange={(value): void => onImageChange(value as string)}
-						>
-							<SelectTrigger className={styles.dashboardImageInput} />
-							<SelectContent
-								className={styles.dashboardImageOptions}
-								withPortal={false}
-							>
-								{Base64Icons.map((icon) => (
-									<SelectItem
-										key={icon}
-										value={icon}
-										className={styles.dashboardImageSelectItem}
-									>
-										<img
-											src={icon}
-											alt="dashboard-icon"
-											className={styles.listItemImage}
-										/>
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
+						<DashboardImagePicker
+							image={image}
+							onChange={onImageChange}
+							triggerClassName={styles.dashboardImageInput}
+						/>
 
 						<Input
 							testId="dashboard-name"

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/index.tsx
@@ -83,7 +83,18 @@ function Overview({ dashboard }: OverviewProps): JSX.Element {
 			);
 		}
 		if (updatedImage !== image) {
-			ops.push(replace('/image', updatedImage));
+			// `replace` fails when the image doesn't exist yet, so add it when the
+			// dashboard has none (`add` creates or replaces the member). Key off the
+			// raw stored value, not the `Base64Icons[0]`-defaulted local `image`.
+			ops.push(
+				op(
+					dashboard.image
+						? DashboardtypesPatchOpDTO.replace
+						: DashboardtypesPatchOpDTO.add,
+					'/image',
+					updatedImage,
+				),
+			);
 		}
 		if (!isEqual(updatedTags, tagsAsStrings)) {
 			ops.push(replace('/tags', stringsToTags(updatedTags)));
@@ -96,6 +107,7 @@ function Overview({ dashboard }: OverviewProps): JSX.Element {
 		description,
 		updatedImage,
 		image,
+		dashboard.image,
 		updatedTags,
 		tagsAsStrings,
 	]);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { ChevronLeft } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
 import { TooltipSimple } from '@signozhq/ui/tooltip';
@@ -6,6 +5,7 @@ import cx from 'classnames';
 import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
 import { useInlineOverflowCount } from 'hooks/useInlineOverflowCount';
 
+import { selectVariablesExpanded } from '../store/slices/collapseSlice';
 import { useDashboardStore } from '../store/useDashboardStore';
 import AddVariableFull from './AddVariableFull';
 import AddVariableIcon from './AddVariableIcon';
@@ -45,10 +45,13 @@ interface VariablesBarProps {
  * either way so auto-selection and option fetching keep driving the panels.
  */
 function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
+	const dashboardId = dashboard.id ?? '';
 	const { variables, selection, setSelection, autoSelect } =
 		useVariableSelection(dashboard);
 	const isEditable = useDashboardStore((s) => s.isEditable);
-	const [expanded, setExpanded] = useState(false);
+	// Persisted per dashboard so the full/collapsed view survives reloads.
+	const expanded = useDashboardStore(selectVariablesExpanded(dashboardId));
+	const setVariablesExpanded = useDashboardStore((s) => s.setVariablesExpanded);
 	const { containerRef, visibleCount, overflowCount } = useInlineOverflowCount({
 		itemCount: variables.length,
 		gap: 8,
@@ -75,7 +78,7 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 			prefix={expanded ? <ChevronLeft size={14} /> : undefined}
 			aria-expanded={expanded}
 			testId="dashboard-variables-more"
-			onClick={(): void => setExpanded((prev) => !prev)}
+			onClick={(): void => setVariablesExpanded(dashboardId, !expanded)}
 		>
 			{expanded ? 'Less' : `+${overflowCount}`}
 		</Button>
@@ -120,7 +123,7 @@ function VariablesBar({ dashboard }: VariablesBarProps): JSX.Element | null {
 					</div>
 				))}
 
-				{hasOverflow && (
+				{(expanded || hasOverflow) && (
 					<span className={styles.moreButton}>
 						{expanded ? (
 							moreButton

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/ValueSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/ValueSelector.tsx
@@ -57,6 +57,8 @@ function ValueSelector({
 				onRetry={onRetry}
 				showSearch
 				placeholder="Select value"
+				maxTagCount={2}
+				maxTagTextLength={20}
 				enableAllSelection={showAllOption}
 				onChange={(next): void => {
 					const values = Array.isArray(next)

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/collapseSlice.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/collapseSlice.ts
@@ -11,6 +11,10 @@ import type { DashboardStore } from '../useDashboardStore';
 export interface CollapseSlice {
 	collapsed: Record<string, Record<string, boolean>>;
 	toggleSectionCollapse: (dashboardId: string, sectionId: string) => void;
+	// Whether the variables bar shows its full (expanded) list, per dashboard.
+	// Absent → collapsed (the default).
+	variablesExpanded: Record<string, boolean>;
+	setVariablesExpanded: (dashboardId: string, expanded: boolean) => void;
 }
 
 export const createCollapseSlice: StateCreator<
@@ -32,4 +36,17 @@ export const createCollapseSlice: StateCreator<
 			},
 		});
 	},
+	variablesExpanded: {},
+	setVariablesExpanded: (dashboardId, expanded): void => {
+		const { variablesExpanded } = get();
+		set({
+			variablesExpanded: { ...variablesExpanded, [dashboardId]: expanded },
+		});
+	},
 });
+
+/** Selector: is the variables bar expanded for this dashboard? Default collapsed. */
+export const selectVariablesExpanded =
+	(dashboardId: string) =>
+	(state: DashboardStore): boolean =>
+		Boolean(state.variablesExpanded[dashboardId]);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/useDashboardStore.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/useDashboardStore.ts
@@ -49,6 +49,7 @@ export const useDashboardStore = create<DashboardStore>()(
 			// Persist UI-only state (context incl. the refetch fn is transient).
 			partialize: (state) => ({
 				collapsed: state.collapsed,
+				variablesExpanded: state.variablesExpanded,
 				variableValues: state.variableValues,
 			}),
 		},

--- a/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.tsx
@@ -12,6 +12,7 @@ import {
 	LockKeyhole,
 	PenLine,
 	SquareArrowOutUpRight,
+	Tag,
 } from '@signozhq/icons';
 import { useCopyToClipboard } from 'react-use';
 import {
@@ -30,6 +31,7 @@ import { getAbsoluteUrl } from 'utils/basePath';
 import { openInNewTab } from 'utils/navigation';
 
 import DeleteActionItem from './DeleteActionItem';
+import EditTagsModal from './EditTagsModal';
 import RenameDashboardModal from './RenameDashboardModal';
 import styles from './ActionsPopover.module.scss';
 
@@ -39,6 +41,8 @@ interface Props {
 	dashboardName: string;
 	createdBy: string;
 	isLocked: boolean;
+	// Current tags as `key:value` strings, for the inline tag editor.
+	tags: string[];
 	// Edit permission (edit_dashboard). Read actions show regardless; edit actions are hidden without it.
 	canEdit: boolean;
 	onView: (event: React.MouseEvent<HTMLElement>) => void;
@@ -50,6 +54,7 @@ function ActionsPopover({
 	dashboardName,
 	createdBy,
 	isLocked,
+	tags,
 	canEdit,
 	onView,
 }: Props): JSX.Element {
@@ -57,6 +62,7 @@ function ActionsPopover({
 	const { safeNavigate } = useSafeNavigate();
 	const { showErrorModal } = useErrorModal();
 	const [isRenameOpen, setIsRenameOpen] = useState(false);
+	const [isEditTagsOpen, setIsEditTagsOpen] = useState(false);
 
 	// Clone keeps the source's name/panels/tags as a new unlocked dashboard owned
 	// by the caller; open the copy so it can be tweaked right away.
@@ -166,6 +172,35 @@ function ActionsPopover({
 							</Tooltip>
 						)}
 						{canEdit && (
+							<Tooltip
+								placement="left"
+								title={
+									isLocked
+										? 'This dashboard is locked, so its tags cannot be edited.'
+										: ''
+								}
+							>
+								<span className={styles.menuItemWrap}>
+									<Button
+										color="secondary"
+										className={styles.menuItem}
+										prefix={<Tag size={14} />}
+										disabled={isLocked}
+										onClick={(e): void => {
+											e.stopPropagation();
+											e.preventDefault();
+											if (!isLocked) {
+												setIsEditTagsOpen(true);
+											}
+										}}
+										testId="dashboard-action-edit-tags"
+									>
+										{tags.length > 0 ? 'Edit Tags' : 'Add Tags'}
+									</Button>
+								</span>
+							</Tooltip>
+						)}
+						{canEdit && (
 							<Button
 								color="secondary"
 								className={styles.menuItem}
@@ -230,6 +265,12 @@ function ActionsPopover({
 				dashboardId={dashboardId}
 				currentName={dashboardName}
 				onClose={(): void => setIsRenameOpen(false)}
+			/>
+			<EditTagsModal
+				open={isEditTagsOpen}
+				dashboardId={dashboardId}
+				currentTags={tags}
+				onClose={(): void => setIsEditTagsOpen(false)}
 			/>
 		</>
 	);

--- a/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/EditTagsModal.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/EditTagsModal.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+import { Button } from '@signozhq/ui/button';
+import { DialogWrapper } from '@signozhq/ui/dialog';
+import { toast } from '@signozhq/ui/sonner';
+import {
+	invalidateListDashboardsForUserV2,
+	// eslint-disable-next-line no-restricted-imports -- list tag-edit targets another dashboard by id; useOptimisticPatch is bound to the open dashboard's store/cache.
+	patchDashboardV2,
+} from 'api/generated/services/dashboard';
+import type { DashboardtypesJSONPatchOperationDTO } from 'api/generated/services/sigNoz.schemas';
+import TagKeyValueInput from 'components/TagKeyValueInput/TagKeyValueInput';
+import { useErrorModal } from 'providers/ErrorModalProvider';
+import APIError from 'types/api/error';
+
+import { keyValueStringsToTags } from '../../utils/helpers';
+import styles from './ActionsPopover.module.scss';
+
+interface Props {
+	open: boolean;
+	dashboardId: string;
+	// Current tags as `key:value` strings.
+	currentTags: string[];
+	onClose: () => void;
+}
+
+/**
+ * Edits a dashboard's tags from the list via an `add /tags` patch, then refreshes
+ * the list. `add` is used (not `replace`) so it works whether the tags field is
+ * already present or absent on the stored dashboard.
+ */
+function EditTagsModal({
+	open,
+	dashboardId,
+	currentTags,
+	onClose,
+}: Props): JSX.Element {
+	const [tags, setTags] = useState<string[]>(currentTags);
+	const queryClient = useQueryClient();
+	const { showErrorModal } = useErrorModal();
+
+	// Reset to the dashboard's tags when the modal opens. Keyed by content
+	// (`tagsKey`) rather than array identity, since `currentTags` is a fresh array
+	// on each parent render; reconstructing from the key keeps the effect deps
+	// stable and the reset off the per-render path.
+	const tagsKey = currentTags.join('\n');
+	useEffect(() => {
+		if (open) {
+			setTags(tagsKey ? tagsKey.split('\n') : []);
+		}
+	}, [open, tagsKey]);
+
+	const { mutate: runSave, isLoading } = useMutation({
+		mutationFn: () => {
+			const ops: DashboardtypesJSONPatchOperationDTO[] = [
+				{
+					op: 'add' as DashboardtypesJSONPatchOperationDTO['op'],
+					path: '/tags',
+					value: keyValueStringsToTags(tags),
+				},
+			];
+			return patchDashboardV2({ id: dashboardId }, ops);
+		},
+		onSuccess: async () => {
+			toast.success('Tags updated');
+			await invalidateListDashboardsForUserV2(queryClient);
+			onClose();
+		},
+		onError: (error: APIError) => {
+			showErrorModal(error);
+		},
+	});
+
+	// Save on Cmd/Ctrl+Enter from anywhere in the modal (not just the tag input),
+	// while it is open.
+	useEffect(() => {
+		if (!open) {
+			return undefined;
+		}
+		const onKeyDown = (e: KeyboardEvent): void => {
+			if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+				e.preventDefault();
+				runSave();
+			}
+		};
+		window.addEventListener('keydown', onKeyDown);
+		return (): void => window.removeEventListener('keydown', onKeyDown);
+	}, [open, runSave]);
+
+	const title = currentTags.length > 0 ? 'Edit tags' : 'Add tags';
+
+	return (
+		<DialogWrapper
+			title={title}
+			open={open}
+			width="narrow"
+			onOpenChange={(next): void => {
+				if (!next) {
+					onClose();
+				}
+			}}
+			footer={
+				<div className={styles.renameFooter}>
+					<Button
+						variant="ghost"
+						color="secondary"
+						size="md"
+						onClick={onClose}
+						testId="edit-tags-cancel"
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="solid"
+						color="primary"
+						size="md"
+						loading={isLoading}
+						disabled={isLoading}
+						onClick={(): void => runSave()}
+						testId="edit-tags-submit"
+					>
+						Save
+					</Button>
+				</div>
+			}
+		>
+			<TagKeyValueInput
+				tags={tags}
+				onTagsChange={setTags}
+				placeholder="key:value (press Enter)"
+				testId="edit-dashboard-tags"
+			/>
+		</DialogWrapper>
+	);
+}
+
+export default EditTagsModal;

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.tsx
@@ -60,6 +60,12 @@ function DashboardRow({
 	);
 
 	const onClickHandler = (event: React.MouseEvent<HTMLElement>): void => {
+		// Clicks inside portaled overlays (the actions menu, edit modals) bubble here
+		// through React's tree even though they render outside the row in the DOM.
+		// Only navigate when the click actually landed inside the row.
+		if (!event.currentTarget.contains(event.target as Node)) {
+			return;
+		}
 		event.stopPropagation();
 		markViewed(id);
 		safeNavigate(link, { newTab: isModifierKeyPressed(event) });
@@ -159,6 +165,7 @@ function DashboardRow({
 					dashboardName={name}
 					createdBy={createdBy}
 					isLocked={isLocked}
+					tags={tags}
 					canEdit={canEdit}
 					onView={onClickHandler}
 				/>

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
@@ -17,6 +17,8 @@ import TagKeyValueInput from 'components/TagKeyValueInput/TagKeyValueInput';
 
 import { keyValueStringsToTags } from '../../utils/helpers';
 
+import DashboardImagePicker from '../../../DashboardPageV2/DashboardContainer/DashboardSettings/Overview/DashboardImagePicker/DashboardImagePicker';
+import { Base64Icons } from '../../../DashboardPageV2/DashboardContainer/DashboardSettings/Overview/utils';
 import { DASHBOARD_NAME_MAX_LENGTH } from '../../../DashboardPageV2/DashboardContainer/constants';
 import styles from './NewDashboardModal.module.scss';
 
@@ -32,6 +34,7 @@ function BlankDashboardPanel({ onClose }: Props): JSX.Element {
 
 	const [name, setName] = useState(DEFAULT_NAME);
 	const [description, setDescription] = useState('');
+	const [image, setImage] = useState<string>(Base64Icons[0]);
 	const [tags, setTags] = useState<string[]>([]);
 	const [submitting, setSubmitting] = useState(false);
 
@@ -48,6 +51,7 @@ function BlankDashboardPanel({ onClose }: Props): JSX.Element {
 			const created = await createDashboardV2({
 				schemaVersion: 'v6',
 				generateName: true,
+				image,
 				tags: postableTags.length ? postableTags : null,
 				spec: {
 					display: {
@@ -77,21 +81,29 @@ function BlankDashboardPanel({ onClose }: Props): JSX.Element {
 					<Typography.Text className={styles.label}>
 						Title <Typography.Text className={styles.required}>*</Typography.Text>
 					</Typography.Text>
-					<Input
-						value={name}
-						autoFocus
-						maxLength={DASHBOARD_NAME_MAX_LENGTH}
-						placeholder="e.g. Sample Dashboard"
-						testId="create-dashboard-name"
-						onChange={(e: ChangeEvent<HTMLInputElement>): void =>
-							setName(e.target.value)
-						}
-						onKeyDown={(e): void => {
-							if (e.key === 'Enter') {
-								void handleCreate();
+					<div className={styles.titleRow}>
+						<DashboardImagePicker
+							image={image}
+							onChange={setImage}
+							triggerClassName={styles.imageTrigger}
+						/>
+						<Input
+							className={styles.titleInput}
+							value={name}
+							autoFocus
+							maxLength={DASHBOARD_NAME_MAX_LENGTH}
+							placeholder="e.g. Sample Dashboard"
+							testId="create-dashboard-name"
+							onChange={(e: ChangeEvent<HTMLInputElement>): void =>
+								setName(e.target.value)
 							}
-						}}
-					/>
+							onKeyDown={(e): void => {
+								if (e.key === 'Enter') {
+									void handleCreate();
+								}
+							}}
+						/>
+					</div>
 				</div>
 
 				<div className={styles.field}>

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/NewDashboardModal.module.scss
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/NewDashboardModal.module.scss
@@ -35,6 +35,28 @@
 	color: var(--danger-background);
 }
 
+// Title row: icon picker joined flush to the left of the name input.
+.titleRow {
+	display: flex;
+	gap: 4px;
+	align-items: center;
+
+	// The icon picker renders its dropdown inline (no portal); lift it above the
+	// description/tags fields below it.
+	:global([data-radix-popper-content-wrapper]) {
+		z-index: 1100 !important;
+	}
+}
+
+.imageTrigger {
+	border-radius: 2px 0 0 2px;
+}
+
+.titleInput {
+	flex: 1;
+	border-radius: 0 2px 2px 0;
+}
+
 .hint {
 	font-size: var(--font-size-xs);
 	color: var(--l3-foreground);

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/NewDashboardModal.module.scss
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/NewDashboardModal.module.scss
@@ -82,26 +82,62 @@
 	}
 }
 
-.cardName {
-	color: var(--l1-foreground);
+// "From a template" tab: a centered browse-and-request placeholder until the
+// templates BE lands. Fixed height matches .panel so switching tabs won't resize.
+.templatesPanel {
+	height: 460px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 12px;
+	padding: 6px 24px;
+	text-align: center;
+}
+
+.templatesIcon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 44px;
+	height: 44px;
+	margin-bottom: 4px;
+	border-radius: 10px;
+	color: var(--bg-robin-400);
+	background: var(--callout-primary-background);
+	border: 1px solid var(--callout-primary-border);
+}
+
+.templatesDesc {
+	max-width: 360px;
+}
+
+.browseLink {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	margin-top: 4px;
+	color: var(--bg-robin-400);
 	font-size: var(--font-size-sm);
 	font-weight: var(--font-weight-medium);
-}
 
-.cardDesc {
-	color: var(--l2-foreground);
-	font-size: var(--font-size-xs);
-	line-height: 1.45;
-}
-
-.requestRow {
-	border-top: 1px solid var(--l2-border);
-	padding-top: 12px;
-
-	:global(.request-entity-container) {
-		gap: 10px 16px;
-		padding: 14px 16px;
+	&:hover {
+		color: var(--bg-robin-300);
 	}
+}
+
+.requestForm {
+	display: flex;
+	gap: 8px;
+	width: 100%;
+	max-width: 380px;
+	margin-top: 16px;
+	padding-top: 16px;
+	border-top: 1px solid var(--l2-border);
+}
+
+.requestInput {
+	flex: 1;
 }
 
 .importHeader {
@@ -128,73 +164,6 @@
 
 .editorExpanded {
 	margin-top: 8px;
-}
-
-.templatesLayout {
-	display: flex;
-	gap: 12px;
-	flex: 1;
-	min-height: 0;
-}
-
-.templatesList {
-	flex: none;
-	width: 200px;
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-	overflow-y: auto;
-	padding-right: 4px;
-}
-
-.templateItem {
-	display: flex;
-	flex-direction: column;
-	gap: 2px;
-	padding: 8px 10px;
-	border: 1px solid transparent;
-	border-radius: 6px;
-	background: transparent;
-	text-align: left;
-	cursor: pointer;
-	transition:
-		background 0.12s,
-		border-color 0.12s;
-}
-
-.templateItem:hover {
-	background: var(--l2-background);
-}
-
-.templateItemActive {
-	background: var(--l2-background);
-	border-color: var(--primary-background);
-}
-
-.templateName {
-	color: var(--l1-foreground);
-	font-size: var(--font-size-sm);
-	font-weight: var(--font-weight-medium);
-}
-
-.templateCat {
-	color: var(--l3-foreground);
-	font-size: var(--font-size-xs);
-}
-
-.templatesPreview {
-	flex: 1;
-	min-width: 0;
-	display: flex;
-	flex-direction: column;
-	gap: 10px;
-}
-
-.previewHead {
-	display: flex;
-	align-items: flex-start;
-	justify-content: space-between;
-	gap: 12px;
 }
 
 .jsonError {

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/NewDashboardModal.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/NewDashboardModal.tsx
@@ -43,7 +43,7 @@ function NewDashboardModal({ open, onClose }: Props): JSX.Element {
 					{
 						key: 'template',
 						label: 'From a template',
-						children: <TemplatesPanel onClose={onClose} />,
+						children: <TemplatesPanel />,
 					},
 					{
 						key: 'import',

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/TemplatesPanel.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/TemplatesPanel.tsx
@@ -1,67 +1,120 @@
-import { useState } from 'react';
-import { generatePath } from 'react-router-dom';
+import { type ChangeEvent, type KeyboardEvent, useState } from 'react';
+import {
+	Check,
+	LayoutDashboard,
+	LoaderCircle,
+	SquareArrowOutUpRight,
+} from '@signozhq/icons';
+import { Button } from '@signozhq/ui/button';
+import { Input } from '@signozhq/ui/input';
 import { toast } from '@signozhq/ui/sonner';
-import { AxiosError } from 'axios';
+import { Typography } from '@signozhq/ui/typography';
 import logEvent from 'api/common/logEvent';
-import { createDashboardV2 } from 'api/generated/services/dashboard';
-import ROUTES from 'constants/routes';
-import DashboardTemplatesContent from 'container/ListOfDashboard/DashboardTemplates/DashboardTemplatesContent';
-import { useSafeNavigate } from 'hooks/useSafeNavigate';
-import { useErrorModal } from 'providers/ErrorModalProvider';
-import APIError from 'types/api/error';
+import { useGetTenantLicense } from 'hooks/useGetTenantLicense';
 
 import styles from './NewDashboardModal.module.scss';
 
-interface Props {
-	onClose: () => void;
-}
+const TEMPLATES_DOCS_URL =
+	'https://signoz.io/docs/dashboards/dashboard-templates/overview/';
 
-// Until the templates BE API lands, the V2 "From a template" tab embeds the V1
-// template gallery inline (no modal-in-modal). The V1 templates are placeholders,
-// so the action creates a blank dashboard.
-function TemplatesPanel({ onClose }: Props): JSX.Element {
-	const { safeNavigate } = useSafeNavigate();
-	const { showErrorModal } = useErrorModal();
-	const [creating, setCreating] = useState(false);
+// Templates aren't served by the BE yet, so this tab is a browse-and-request
+// placeholder: link out to the published template library, and let cloud users
+// request one we haven't built.
+function TemplatesPanel(): JSX.Element {
+	const { isCloudUser } = useGetTenantLicense();
+	const [name, setName] = useState('');
+	const [submitting, setSubmitting] = useState(false);
 
-	const handleCreate = async (): Promise<void> => {
-		if (creating) {
+	const requestName = name.trim();
+
+	const handleRequest = async (): Promise<void> => {
+		if (!requestName || submitting) {
 			return;
 		}
 		try {
-			setCreating(true);
-			logEvent('Dashboard List: Use template clicked', {});
-			const created = await createDashboardV2({
-				schemaVersion: 'v6',
-				generateName: true,
-				tags: null,
-				spec: {
-					display: { name: 'Sample Dashboard' },
-					layouts: [],
-					panels: {},
-					variables: [],
-				},
+			setSubmitting(true);
+			const response = await logEvent('Dashboard Requested', {
+				screen: 'Dashboard list page',
+				dashboard: requestName,
 			});
-			onClose();
-			safeNavigate(
-				generatePath(ROUTES.DASHBOARD, { dashboardId: created.data.id }),
-			);
-		} catch (e) {
-			showErrorModal(e as APIError);
-			toast.error((e as AxiosError).toString() || 'Failed to create dashboard');
-			setCreating(false);
+			if (response.statusCode === 200) {
+				toast.success('Dashboard request submitted');
+				setName('');
+			} else {
+				toast.error(response.error || 'Something went wrong');
+			}
+		} catch {
+			toast.error('Something went wrong');
+		} finally {
+			setSubmitting(false);
 		}
 	};
 
 	return (
-		<div className={styles.panel}>
-			<div className="new-dashboard-templates-modal">
-				<DashboardTemplatesContent
-					onCreateNewDashboard={(): void => {
-						void handleCreate();
-					}}
-				/>
-			</div>
+		<div className={styles.templatesPanel}>
+			<span className={styles.templatesIcon}>
+				<LayoutDashboard size={20} />
+			</span>
+			<Typography variant="title" size="lg" weight="semibold">
+				Dashboard templates
+			</Typography>
+			<Typography
+				variant="text"
+				size="sm"
+				color="muted"
+				className={styles.templatesDesc}
+			>
+				Browse our library of ready-made dashboards, or request a new one and
+				we&apos;ll build it for you.
+			</Typography>
+
+			<a
+				className={styles.browseLink}
+				href={TEMPLATES_DOCS_URL}
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				Browse dashboard templates
+				<SquareArrowOutUpRight size={14} />
+			</a>
+
+			{isCloudUser && (
+				<div className={styles.requestForm}>
+					<Input
+						className={styles.requestInput}
+						placeholder="Enter dashboard name..."
+						value={name}
+						testId="request-dashboard-name"
+						onChange={(e: ChangeEvent<HTMLInputElement>): void =>
+							setName(e.target.value)
+						}
+						onKeyDown={(e: KeyboardEvent<HTMLInputElement>): void => {
+							if (e.key === 'Enter') {
+								void handleRequest();
+							}
+						}}
+					/>
+					<Button
+						variant="solid"
+						color="primary"
+						size="md"
+						disabled={submitting || requestName.length === 0}
+						testId="request-dashboard-submit"
+						prefix={
+							submitting ? (
+								<LoaderCircle size={14} className={styles.spinner} />
+							) : (
+								<Check size={14} />
+							)
+						}
+						onClick={(): void => {
+							void handleRequest();
+						}}
+					>
+						Submit
+					</Button>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/frontend/src/pages/DashboardsListPageV2/utils/helpers.ts
+++ b/frontend/src/pages/DashboardsListPageV2/utils/helpers.ts
@@ -11,9 +11,9 @@ export type DashboardListItem = DashboardtypesListedDashboardForUserV2DTO;
 export const tagsToStrings = (
 	tags: { key: string; value: string }[] | null | undefined,
 ): string[] =>
-	(tags ?? []).map((tag) =>
-		tag.key === tag.value ? tag.key : `${tag.key}:${tag.value}`,
-	);
+	// Always render both sides (so an env:env tag reads "env:env", not a lone
+	// "env"); fall back to the bare key only when there's no value.
+	(tags ?? []).map((tag) => (tag.value ? `${tag.key}:${tag.value}` : tag.key));
 
 // Convert validated `key:value` tag strings (from TagKeyValueInput) into the
 // postable tag DTO shape. The first colon separates key from value.


### PR DESCRIPTION
## Summary

Second round of bug-bash fixes for the V2 dashboards experience — list page, dashboard page, and the create-dashboard flow. Organized as 9 independently-reviewable, by-concern commits.

**Dashboards list**
- Keep same-key:value tags from collapsing to one word (`env:env`, not `env`).
- Add an "Add Tags"/"Edit Tags" row action (labelled by whether the dashboard has tags) that opens the shared key:value editor and saves in place via an `add /tags` patch; ⌘/Ctrl+Enter saves. Gated on edit permission, disabled while locked.
- Guard row navigation so clicks inside a row's portaled overlay (actions menu / edit / rename modal) no longer open the dashboard (they bubbled through React's tree).

**Home**
- Source the recent-dashboards widget from the v2 list under the `use_dashboard_v2` flag (it was calling v1).

**Dashboard page**
- Commit the inline dashboard-title edit on outside click (previously only the X committed).
- Cap variable multi-select pills so a variable with many values doesn't overflow the bar.
- Persist the variables-bar expand/collapse view per dashboard, and show the "Less" toggle when the bar loads already-expanded.

**Create-dashboard modal**
- Extract a reusable image picker shared by the dashboard settings form and the create modal; patch `/image` with `add` (not `replace`) so it works whether the field is present or absent; lift the inline dropdown above the form fields.
- Replace the placeholder templates gallery (search + category list + preview) with a clean, centered browse-and-request block.
- Contain Escape/Enter in the inline tag editor so it no longer closes the host drawer/modal; let ⌘/Ctrl+Enter pass through for host-form submit.

## Test plan
- V2 dashboards list: verify same-key:value tags render fully; add/edit tags from a row's kebab (⌘/Ctrl+Enter saves; disabled when locked); clicking menu/modal controls doesn't navigate to the dashboard.
- Home: with `use_dashboard_v2` on, recent dashboards come from the v2 list.
- Dashboard page: inline title edit commits on outside click; variables bar doesn't overflow with many selected values; expand/collapse persists across reload and shows "Less" when loaded expanded.
- Create modal: pick an image on create; templates tab shows browse-and-request; editing a tag then pressing Escape cancels the edit without closing the modal.

Closes https://github.com/SigNoz/engineering-pod/issues/5652
