### PR TITLE
fix(infra-monitoring): remove container metrics from `podsTableMetricNamesList` to surface non-empty `k8s.pod.start_time`

### DIFF
--- a/pkg/modules/inframonitoring/implinframonitoring/pods_constants.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/pods_constants.go
@@ -45,8 +45,8 @@ var podsTableMetricNamesList = []string{
 	"k8s.pod.memory_limit_utilization",
 	"k8s.pod.phase",
 	"k8s.pod.status_reason",
-	"k8s.container.status.reason",
-	"k8s.container.restarts",
+	// "k8s.container.status.reason",
+	// "k8s.container.restarts",
 }
 
 var podAttrKeysForMetadata = []string{


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The Pods list resolves per-pod metadata (`k8s.pod.start_time`, workload owner names, node/namespace, etc.) with a single `argMax(tuple(attrs…), unix_milli)` over `podsTableMetricNamesList` — it takes the **whole attribute tuple from the one datapoint with the latest `unix_milli`** across all metrics in that list.

Two entries in that list are **container-scoped** (`k8s.container.status.reason`, `k8s.container.restarts`). Container metrics report frequently, so they very often **win** the `argMax`. But `k8s.pod.start_time` is a **pod-scoped** attribute — the k8s_cluster receiver attaches it only to pod-level metrics, never to `k8s.container.*` datapoints. So whenever a container metric is the latest, the tuple is sourced from a datapoint with no `start_time` → `start_time = ''` → `podAge = -1`.

Fix: drop the two `k8s.container.*` metrics from `podsTableMetricNamesList`. All remaining entries are `k8s.pod.*` and carry the full pod resource attribute set, so the `argMax` tuple can no longer land on a `start_time`-less datapoint.

Scope is Pods only. For nodes / workloads / namespaces I verified against real staging data that the container metrics **do** carry the relevant `k8s.<entity>.name` labels (`k8s.deployment.name` present on `k8s.container.*` series, so those `*TableMetricNamesList` need no change.

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

**Root Cause**
`podsTableMetricNamesList` included container-scoped metrics (`k8s.container.status.reason`, `k8s.container.restarts`). The metadata `argMax(tuple, unix_milli)` picks all attributes from the single latest datapoint; container metrics frequently win but don't carry the pod-scoped `k8s.pod.start_time`, blanking it (and, when they win, any other pod-only attribute).

**Fix Strategy**
Remove the two container-scoped metrics from `podsTableMetricNamesList` so metadata resolution only considers pod-scoped metrics, which always carry `k8s.pod.start_time`. Container metrics are still queried where actually needed (pod status / restart counts use their own metric lists).

---

### 🧪 Testing Strategy

- Manual verification: reproduced `podAge: -1` / empty `k8s.pod.start_time` when a container metric was latest; confirmed fixed after removal.
- Edge cases covered: pod discovery unaffected — every pod emitting container metrics also emits `k8s.pod.phase` (default-on) / kubeletstats pod metrics; verified container metrics carry `k8s.<entity>.name` for the other entity tables, so those lists are intentionally left unchanged.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Pods list only — `podsTableMetricNamesList` is used solely for pod metadata resolution + retention gate; not by the status/restart/main-list queries.
- Potential regressions: none expected; remaining metrics are a strict superset of what's needed to discover pods and richer in labels than the removed ones.
- Rollback plan: revert the one-line list change; no schema/API/state changes.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed Pod Age showing as -1 / blank pod start time in the Kubernetes Pods list. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Only `k8s.container.*` metrics are removed, and only from the **Pods** list — they lack the pod-scoped `k8s.pod.start_time`.
- Nodes / workloads / namespaces lists are intentionally untouched: verified on staging that `k8s.container.*` series carry the relevant `k8s.<entity>.name` labels.