### PR TITLE
chore(sql): enable txlock immediate by default

### DIFF
--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -129,7 +129,7 @@ sqlstore:
     # The timeout for the sqlite database to wait for a lock.
     busy_timeout: 10s
     # The default transaction locking behavior. Supported values: deferred, immediate, exclusive.
-    transaction_mode: deferred
+    transaction_mode: immediate
 
 ##################### APIServer #####################
 apiserver:

--- a/pkg/sqlstore/config.go
+++ b/pkg/sqlstore/config.go
@@ -60,7 +60,7 @@ func newConfig() factory.Config {
 			Path:            "/var/lib/signoz/signoz.db",
 			Mode:            "wal",
 			BusyTimeout:     10000 * time.Millisecond, // increasing the defaults from https://github.com/mattn/go-sqlite3/blob/master/sqlite3.go#L1098 because of transpilation from C to GO
-			TransactionMode: "deferred",
+			TransactionMode: "immediate",
 		},
 	}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,12 +63,6 @@ def pytest_addoption(parser: pytest.Parser):
         help="sqlite mode",
     )
     parser.addoption(
-        "--sqlite-transaction-mode",
-        action="store",
-        default="deferred",
-        help="sqlite transaction mode",
-    )
-    parser.addoption(
         "--postgres-version",
         action="store",
         default="15",

--- a/tests/fixtures/sqlite.py
+++ b/tests/fixtures/sqlite.py
@@ -30,7 +30,6 @@ def sqlite(
             assert result.fetchone()[0] == 1
 
         mode = pytestconfig.getoption("--sqlite-mode")
-        transaction_mode = pytestconfig.getoption("--sqlite-transaction-mode")
         return types.TestContainerSQL(
             container=types.TestContainerDocker(
                 id="",
@@ -42,7 +41,6 @@ def sqlite(
                 "SIGNOZ_SQLSTORE_PROVIDER": "sqlite",
                 "SIGNOZ_SQLSTORE_SQLITE_PATH": str(path),
                 "SIGNOZ_SQLSTORE_SQLITE_MODE": mode,
-                "SIGNOZ_SQLSTORE_SQLITE_TRANSACTION__MODE": transaction_mode,
             },
         )
 


### PR DESCRIPTION


### 📄 Summary
- enable txlock immediate by default

contributes to: https://github.com/SigNoz/platform-pod/issues/2245