### PR TITLE
fix(dashboard-v2): carry unsaved panel edits into view mode

### DIFF
--- a/frontend/src/constants/sessionStorage.ts
+++ b/frontend/src/constants/sessionStorage.ts
@@ -1,3 +1,4 @@
 export enum SESSIONSTORAGE {
 	RETRY_LAZY_REFRESHED = 'retry-lazy-refreshed',
+	VIEW_PANEL_HANDOFF = 'view-panel-handoff',
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/useSwitchToViewMode.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/useSwitchToViewMode.test.ts
@@ -1,5 +1,10 @@
 import { renderHook } from '@testing-library/react';
+import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
 import { PANEL_TYPES } from 'constants/queryBuilder';
+import {
+	clearViewPanelHandoff,
+	readViewPanelHandoff,
+} from 'pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/viewPanelHandoffStore';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 
 import { useSwitchToViewMode } from '../useSwitchToViewMode';
@@ -18,11 +23,16 @@ jest.mock('hooks/useUrlQuery', () => ({
 }));
 
 const query = { queryType: 'builder' } as unknown as Query;
+const spec = {
+	plugin: { kind: 'signoz/TimeSeriesPanel' },
+	display: { name: 'CPU' },
+} as unknown as DashboardtypesPanelSpecDTO;
 
 describe('useSwitchToViewMode', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockSearch = '';
+		clearViewPanelHandoff();
 	});
 
 	function invoke(): void {
@@ -32,6 +42,7 @@ describe('useSwitchToViewMode', () => {
 				panelId: 'panel-1',
 				panelType: PANEL_TYPES.TIME_SERIES,
 				query,
+				spec,
 			}),
 		);
 		result.current();
@@ -50,6 +61,21 @@ describe('useSwitchToViewMode', () => {
 				decodeURIComponent(target.searchParams.get('compositeQuery') || ''),
 			),
 		).toStrictEqual(query);
+	});
+
+	it('stashes the live draft spec in the sessionStorage handoff, not the URL', () => {
+		invoke();
+
+		expect(readViewPanelHandoff('dash-1', 'panel-1')).toStrictEqual(spec);
+		// The spec must not bloat the URL — the config-only display name never leaks into it.
+		expect(mockSafeNavigate.mock.calls[0][0]).not.toContain('CPU');
+	});
+
+	it('scopes the handoff to the exact dashboard + panel', () => {
+		invoke();
+
+		expect(readViewPanelHandoff('dash-1', 'other-panel')).toBeNull();
+		expect(readViewPanelHandoff('other-dash', 'panel-1')).toBeNull();
 	});
 
 	it('carries dashboard variables through and drops other editor URL state', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/useSwitchToViewMode.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/useSwitchToViewMode.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { generatePath } from 'react-router-dom';
+import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
 import { QueryParams } from 'constants/query';
 import type { PANEL_TYPES } from 'constants/queryBuilder';
 import ROUTES from 'constants/routes';
@@ -7,27 +8,35 @@ import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import useUrlQuery from 'hooks/useUrlQuery';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 
+import { writeViewPanelHandoff } from '../../PanelsAndSectionsLayout/Panel/ViewPanelModal/viewPanelHandoffStore';
+
 interface UseSwitchToViewModeArgs {
 	dashboardId: string;
 	panelId: string;
 	panelType: PANEL_TYPES;
 	query: Query;
+	/** Live (un-saved) draft spec — the query rides in the URL, the rest via the handoff. */
+	spec: DashboardtypesPanelSpecDTO;
 }
 
 /**
- * Callback that leaves the editor for the dashboard with this panel expanded in the
- * View modal, seeded with the live (un-saved) query — V1's "Switch to View Mode".
+ * Leaves the editor for the dashboard with this panel expanded in the View modal, seeded with
+ * the live (un-saved) query + config — V1's "Switch to View Mode". The query rides in the URL
+ * (`compositeQuery`); the rest of the spec rides in a tab-scoped sessionStorage handoff.
  */
 export function useSwitchToViewMode({
 	dashboardId,
 	panelId,
 	panelType,
 	query,
+	spec,
 }: UseSwitchToViewModeArgs): () => void {
 	const { safeNavigate } = useSafeNavigate();
 	const urlQuery = useUrlQuery();
 
 	return useCallback((): void => {
+		writeViewPanelHandoff({ dashboardId, panelId, spec });
+
 		const params = new URLSearchParams();
 		const variables = urlQuery.get(QueryParams.variables);
 		if (variables) {
@@ -42,5 +51,5 @@ export function useSwitchToViewMode({
 		safeNavigate(
 			`${generatePath(ROUTES.DASHBOARD, { dashboardId })}?${params.toString()}`,
 		);
-	}, [safeNavigate, urlQuery, dashboardId, panelId, panelType, query]);
+	}, [safeNavigate, urlQuery, dashboardId, panelId, panelType, query, spec]);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
@@ -38,6 +38,8 @@ import { useTableColumns } from './hooks/useTableColumns';
 import ListColumnsEditor from './ListColumnsEditor/ListColumnsEditor';
 
 import styles from './PanelEditor.module.scss';
+import logEvent from '@/api/common/logEvent';
+import { DashboardEvents } from '../../constants/events';
 
 interface PanelEditorContainerProps {
 	dashboardId: string;
@@ -235,6 +237,13 @@ function PanelEditorContainer({
 		onClose();
 	}, [isNew, panelId, setScrollTargetId, onClose]);
 
+	const switchToViewMode = useCallback((): void => {
+		logEvent(DashboardEvents.SWITCH_TO_VIEW_MODE, {
+			panelId: panelId,
+		});
+		onSwitchToView();
+	}, [onSwitchToView]);
+
 	return (
 		<div className={styles.page} data-testid="panel-editor-v2">
 			<Header
@@ -244,7 +253,7 @@ function PanelEditorContainer({
 				readOnly={!isEditable}
 				readOnlyReason={editDisabledReason}
 				onSave={onSave}
-				onSwitchToView={onSwitchToView}
+				onSwitchToView={switchToViewMode}
 				onClose={onCloseEditor}
 			/>
 			<ResizablePanelGroup

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
@@ -204,6 +204,7 @@ function PanelEditorContainer({
 		panelId,
 		panelType: PANEL_KIND_TO_PANEL_TYPE[panelKind],
 		query: currentQuery,
+		spec: draft.spec,
 	});
 
 	const setScrollTargetId = useScrollIntoViewStore((s) => s.setScrollTargetId);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/ViewPanelModalContent.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/ViewPanelModalContent.tsx
@@ -16,6 +16,8 @@ import ViewPanelModalHeader from './ViewPanelModalHeader';
 import { useViewPanelMode } from './useViewPanelMode';
 import { useViewPanelTimeWindow } from './useViewPanelTimeWindow';
 import styles from './ViewPanelModal.module.scss';
+import logEvent from 'api/common/logEvent';
+import { DashboardEvents } from 'pages/DashboardPageV2/constants/events';
 
 interface ViewPanelModalContentProps {
 	panel: DashboardtypesPanelDTO;
@@ -97,6 +99,14 @@ function ViewPanelModalContent({
 		return null;
 	}
 
+	const onSwitchToEdit = (): void => {
+		// Carry the drilldown edits so the editor opens on them, not the saved panel.
+		logEvent(DashboardEvents.SWITCH_TO_EDIT_MODE, {
+			panelId: panelId,
+		});
+		openPanelEditor(panelId, { editSpec: buildSaveSpec(draft.spec) });
+	};
+
 	return (
 		<div className={styles.content} data-testid="view-panel-modal-content">
 			<ViewPanelModalHeader
@@ -114,10 +124,7 @@ function ViewPanelModalContent({
 						refreshWindow();
 					}
 				}}
-				onSwitchToEdit={(): void =>
-					// Carry the drilldown edits so the editor opens on them, not the saved panel.
-					openPanelEditor(panelId, { editSpec: buildSaveSpec(draft.spec) })
-				}
+				onSwitchToEdit={onSwitchToEdit}
 				panelKind={draft.spec.plugin.kind}
 				queryType={queryType}
 				signal={signal}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/ViewPanelModalHeader.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/ViewPanelModalHeader.tsx
@@ -13,6 +13,7 @@ import type { PanelKind } from 'pages/DashboardPageV2/DashboardContainer/Panels/
 import type { EQueryType } from 'types/common/dashboard';
 
 import styles from './ViewPanelModal.module.scss';
+import { useDashboardStore } from 'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore';
 
 interface ViewPanelModalHeaderProps {
 	selectedInterval: Time | CustomTimeType;
@@ -64,6 +65,10 @@ function ViewPanelModalHeader({
 	// Same capabilities-guarded options as the editor's PanelTypeSwitcher, so the two
 	// selectors disable the same kinds (e.g. List under PromQL, metrics-only kinds).
 	const panelTypeItems = usePanelTypeSelectItems({ queryType, signal });
+	const canEditDashboard = useDashboardStore((s) => s.canEditDashboard);
+	const isLocked = useDashboardStore((s) => s.isLocked);
+
+	const canSwitchToEdit = canEditDashboard && !isLocked;
 
 	return (
 		<div className={styles.toolbar}>
@@ -75,15 +80,17 @@ function ViewPanelModalHeader({
 					onChange={onChangePanelKind}
 				/>
 			</div>
-			<Button
-				variant="outlined"
-				color="secondary"
-				prefix={<PenLine />}
-				onClick={onSwitchToEdit}
-				data-testid="view-panel-switch-to-edit"
-			>
-				Switch to Edit Mode
-			</Button>
+			{canSwitchToEdit && (
+				<Button
+					variant="outlined"
+					color="secondary"
+					prefix={<PenLine />}
+					onClick={onSwitchToEdit}
+					data-testid="view-panel-switch-to-edit"
+				>
+					Switch to Edit Mode
+				</Button>
+			)}
 			<Button
 				variant="link"
 				color="primary"

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/useViewPanelMode.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/useViewPanelMode.ts
@@ -23,7 +23,10 @@ import {
 	type PanelQueryTimeOverride,
 	type UsePanelQueryResult,
 } from 'pages/DashboardPageV2/DashboardContainer/hooks/usePanelQuery';
+import { useDashboardStore } from 'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore';
 import type { EQueryType } from 'types/common/dashboard';
+
+import { readViewPanelHandoff } from './viewPanelHandoffStore';
 
 interface UseViewPanelModeArgs {
 	panel: DashboardtypesPanelDTO;
@@ -77,25 +80,33 @@ export function useViewPanelMode({
 }: UseViewPanelModeArgs): UseViewPanelModeReturn {
 	const { currentQuery, redirectWithQueryBuilderData } = useQueryBuilder();
 
-	// Seed the draft from the URL (`compositeQuery` + `graphType`) when present, else the saved
-	// panel — mount-only, so a refresh re-seeds from the URL and in-modal edits survive (V1 parity).
-	const urlQuery = useGetCompositeQueryParam();
+	// Config edits from the editor's "Switch to View Mode" arrive via the handoff; the query
+	// still comes from the URL. Falls back to the saved panel for a plain grid "View".
+	const dashboardId = useDashboardStore((s) => s.dashboardId);
+	const baseSpec = useMemo<DashboardtypesPanelSpecDTO>(
+		() => readViewPanelHandoff(dashboardId, panelId) ?? panel.spec,
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only seed
+		[],
+	);
+
+	// Mount-only so a refresh re-seeds and in-modal edits survive (V1 parity).
+	const compositeQuery = useGetCompositeQueryParam();
 	const urlGraphType = useUrlQuery().get(
 		QueryParams.graphType,
 	) as PANEL_TYPES | null;
 	const initialPanel = useMemo<DashboardtypesPanelDTO>(
 		() =>
-			urlQuery
+			compositeQuery
 				? {
 						...panel,
 						spec: buildViewPanelSpec({
-							spec: panel.spec,
-							query: urlQuery,
+							spec: baseSpec,
+							query: compositeQuery,
 							panelType:
-								urlGraphType ?? PANEL_KIND_TO_PANEL_TYPE[panel.spec.plugin.kind],
+								urlGraphType ?? PANEL_KIND_TO_PANEL_TYPE[baseSpec.plugin.kind],
 						}),
 					}
-				: panel,
+				: { ...panel, spec: baseSpec },
 		// eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only seed from the URL
 		[],
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/viewPanelHandoffStore.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/viewPanelHandoffStore.ts
@@ -1,0 +1,43 @@
+import getSessionStorage from 'api/browser/sessionstorage/get';
+import removeSessionStorage from 'api/browser/sessionstorage/remove';
+import setSessionStorage from 'api/browser/sessionstorage/set';
+import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
+import { SESSIONSTORAGE } from 'constants/sessionStorage';
+
+interface ViewPanelHandoff {
+	/** Correlator: the read returns the spec only for this exact dashboard + panel. */
+	dashboardId: string;
+	panelId: string;
+	spec: DashboardtypesPanelSpecDTO;
+}
+
+/**
+ * Tab-scoped handoff of the editor's un-saved draft spec to the View modal, so "Switch to View
+ * Mode" carries config edits — not just the query, which stays in the URL. sessionStorage keeps
+ * the link small yet survives a refresh, and clears the edits when the tab closes.
+ */
+export function writeViewPanelHandoff(handoff: ViewPanelHandoff): void {
+	setSessionStorage(SESSIONSTORAGE.VIEW_PANEL_HANDOFF, JSON.stringify(handoff));
+}
+
+export function readViewPanelHandoff(
+	dashboardId: string,
+	panelId: string,
+): DashboardtypesPanelSpecDTO | null {
+	const raw = getSessionStorage(SESSIONSTORAGE.VIEW_PANEL_HANDOFF);
+	if (!raw) {
+		return null;
+	}
+	try {
+		const handoff = JSON.parse(raw) as ViewPanelHandoff;
+		return handoff.dashboardId === dashboardId && handoff.panelId === panelId
+			? handoff.spec
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+export function clearViewPanelHandoff(): void {
+	removeSessionStorage(SESSIONSTORAGE.VIEW_PANEL_HANDOFF);
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useViewPanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useViewPanel.ts
@@ -6,6 +6,8 @@ import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import useUrlQuery from 'hooks/useUrlQuery';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 
+import { clearViewPanelHandoff } from '../ViewPanelModal/viewPanelHandoffStore';
+
 export interface UseViewPanelApi {
 	/** Panel id currently expanded in the View modal; null when none is open. */
 	expandedPanelId: string | null;
@@ -41,10 +43,11 @@ export function useViewPanel(): UseViewPanelApi {
 			// Copy before mutating: useUrlQuery returns a memoized instance.
 			const next = new URLSearchParams(urlQuery);
 			next.set(QueryParams.expandedWidgetId, panelId);
-			// Drop any leftover in-modal query/kind so a plain View opens on the saved
-			// panel, not a stale URL query the modal would otherwise hydrate from.
+			// Drop leftover in-modal query/kind + the editor's handoff so a plain View opens
+			// on the saved panel, not stale state the modal would otherwise hydrate from.
 			next.delete(QueryParams.compositeQuery);
 			next.delete(QueryParams.graphType);
+			clearViewPanelHandoff();
 			safeNavigate(`${pathname}?${next.toString()}`);
 		},
 		[pathname, safeNavigate, urlQuery],
@@ -55,6 +58,8 @@ export function useViewPanel(): UseViewPanelApi {
 			const next = new URLSearchParams(urlQuery);
 			next.set(QueryParams.expandedWidgetId, panelId);
 			next.set(QueryParams.graphType, panelType);
+			// A grid drilldown opens on the saved panel, never a stale editor handoff.
+			clearViewPanelHandoff();
 			// Same encoding the query builder uses (see `useGetCompositeQueryParam`): the URL
 			// value is `encodeURIComponent(JSON.stringify(query))`, decoded once on read.
 			next.set(
@@ -73,6 +78,7 @@ export function useViewPanel(): UseViewPanelApi {
 		// (the in-modal query builder writes compositeQuery, V1 parity).
 		next.delete(QueryParams.compositeQuery);
 		next.delete(QueryParams.graphType);
+		clearViewPanelHandoff();
 		const search = next.toString();
 		safeNavigate(search ? `${pathname}?${search}` : pathname);
 	}, [pathname, safeNavigate, urlQuery]);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/DynamicSelector.tsx
@@ -3,7 +3,10 @@ import { useQuery } from 'react-query';
 // eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import { getFieldValues } from 'api/dynamicVariables/getFieldValues';
-import { DASHBOARD_CACHE_TIME } from 'constants/queryCacheTime';
+import {
+	DASHBOARD_CACHE_TIME,
+	DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
+} from 'constants/queryCacheTime';
 import type { AppState } from 'store/reducers';
 import type { GlobalReducer } from 'types/reducer/globalTime';
 
@@ -48,9 +51,10 @@ function DynamicSelector({
 	onChange,
 	onAutoSelect,
 }: DynamicSelectorProps): JSX.Element {
-	const { minTime, maxTime } = useSelector<AppState, GlobalReducer>(
-		(state) => state.globalTime,
-	);
+	const { minTime, maxTime, isAutoRefreshDisabled } = useSelector<
+		AppState,
+		GlobalReducer
+	>((state) => state.globalTime);
 
 	const existingQuery = useMemo(
 		() => buildExistingDynamicVariableQuery(variables, selections, variable.name),
@@ -96,8 +100,10 @@ function DynamicSelector({
 				!!variable.dynamicAttribute &&
 				(isVariableFetching || (isVariableSettled && hasVariableFetchedOnce)),
 			refetchOnWindowFocus: false,
-			// Each cycle mints a fresh key; a small cacheTime bounds cache churn.
-			cacheTime: DASHBOARD_CACHE_TIME,
+			// Each cycle mints a fresh key; 0 under auto-refresh so entries don't pile up (V1 parity).
+			cacheTime: isAutoRefreshDisabled
+				? DASHBOARD_CACHE_TIME
+				: DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
 			onSettled: (_, error) =>
 				error
 					? onVariableFetchFailure(variable.name)

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/QuerySelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectors/QuerySelector.tsx
@@ -3,7 +3,10 @@ import { useQuery } from 'react-query';
 // eslint-disable-next-line no-restricted-imports
 import { useSelector } from 'react-redux';
 import dashboardVariablesQuery from 'api/dashboard/variables/dashboardVariablesQuery';
-import { DASHBOARD_CACHE_TIME } from 'constants/queryCacheTime';
+import {
+	DASHBOARD_CACHE_TIME,
+	DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
+} from 'constants/queryCacheTime';
 import type { AppState } from 'store/reducers';
 import type { GlobalReducer } from 'types/reducer/globalTime';
 
@@ -44,9 +47,10 @@ function QuerySelector({
 	onChange,
 	onAutoSelect,
 }: QuerySelectorProps): JSX.Element {
-	const { minTime, maxTime } = useSelector<AppState, GlobalReducer>(
-		(state) => state.globalTime,
-	);
+	const { minTime, maxTime, isAutoRefreshDisabled } = useSelector<
+		AppState,
+		GlobalReducer
+	>((state) => state.globalTime);
 	const payload = useMemo(() => selectionToPayload(selections), [selections]);
 
 	const {
@@ -80,8 +84,10 @@ function QuerySelector({
 		{
 			enabled: isVariableFetching || (isVariableSettled && hasVariableFetchedOnce),
 			refetchOnWindowFocus: false,
-			// Each cycle mints a fresh key; a small cacheTime bounds cache churn.
-			cacheTime: DASHBOARD_CACHE_TIME,
+			// Each cycle mints a fresh key; 0 under auto-refresh so entries don't pile up (V1 parity).
+			cacheTime: isAutoRefreshDisabled
+				? DASHBOARD_CACHE_TIME
+				: DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
 			onSettled: (_, error) =>
 				error
 					? onVariableFetchFailure(variable.name)

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/usePanelQuery.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/usePanelQuery.test.tsx
@@ -2,6 +2,10 @@
 import { useSelector } from 'react-redux';
 import { act, renderHook } from '@testing-library/react';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import {
+	DASHBOARD_CACHE_TIME,
+	DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
+} from 'constants/queryCacheTime';
 
 import { usePanelQuery } from '../usePanelQuery';
 import { useGetQueryRangeV5 } from '../useGetQueryRangeV5';
@@ -430,6 +434,30 @@ describe('usePanelQuery', () => {
 			act(() => result.current.pagination?.setPageSize(0));
 			expect(result.current.pagination?.pageSize).toBe(25);
 			expect(result.current.pagination?.pageIndex).toBe(0);
+		});
+	});
+
+	describe('cacheTime (auto-refresh OOM guard)', () => {
+		const withAutoRefreshDisabled = (disabled: boolean): void => {
+			mockUseSelector.mockImplementation((selector: unknown) =>
+				(selector as (state: { globalTime: unknown }) => unknown)({
+					globalTime: { ...DEFAULT_GLOBAL_TIME, isAutoRefreshDisabled: disabled },
+				}),
+			);
+		};
+
+		it('caches for DASHBOARD_CACHE_TIME when auto-refresh is disabled', () => {
+			withAutoRefreshDisabled(true);
+			renderHook(() => usePanelQuery({ panel: builderPanel(), panelId: 'p1' }));
+			const [{ cacheTime }] = mockUseGetQueryRangeV5.mock.calls[0];
+			expect(cacheTime).toBe(DASHBOARD_CACHE_TIME);
+		});
+
+		it('drops cacheTime to 0 when auto-refresh is enabled', () => {
+			withAutoRefreshDisabled(false);
+			renderHook(() => usePanelQuery({ panel: builderPanel(), panelId: 'p1' }));
+			const [{ cacheTime }] = mockUseGetQueryRangeV5.mock.calls[0];
+			expect(cacheTime).toBe(DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED);
 		});
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useGetQueryRangeV5.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useGetQueryRangeV5.ts
@@ -13,6 +13,8 @@ export interface UseGetQueryRangeV5Args {
 	enabled: boolean;
 	/** Retain prior data across a key change (list paging) so the table + pager stay mounted. */
 	keepPreviousData?: boolean;
+	/** Unused-entry TTL; callers drop to 0 under auto-refresh to bound cache growth (V1 parity). */
+	cacheTime?: number;
 }
 
 /**
@@ -43,6 +45,7 @@ export function useGetQueryRangeV5({
 	queryKey,
 	enabled,
 	keepPreviousData,
+	cacheTime,
 }: UseGetQueryRangeV5Args): UseQueryResult<QueryRangeV5200, Error> {
 	return useQuery<QueryRangeV5200, Error>({
 		queryKey,
@@ -50,5 +53,6 @@ export function useGetQueryRangeV5({
 		enabled,
 		retry: retryUnlessClientError,
 		keepPreviousData,
+		cacheTime,
 	});
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/usePanelQuery.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/usePanelQuery.ts
@@ -4,6 +4,10 @@ import { useQueryClient } from 'react-query';
 import { useSelector } from 'react-redux';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
 import { PANEL_TYPES } from 'constants/queryBuilder';
+import {
+	DASHBOARD_CACHE_TIME,
+	DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
+} from 'constants/queryCacheTime';
 import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
 import { AppState } from 'store/reducers';
 import { GlobalReducer } from 'types/reducer/globalTime';
@@ -110,6 +114,7 @@ export function usePanelQuery({
 		selectedTime: globalSelectedInterval,
 		maxTime,
 		minTime,
+		isAutoRefreshDisabled,
 	} = useSelector<AppState, GlobalReducer>((state) => state.globalTime);
 
 	// Resolved variable values for this dashboard, published by useResolvedVariables.
@@ -243,6 +248,10 @@ export function usePanelQuery({
 		enabled: enabled && runnable && !isWaitingOnVariable,
 		// Hold the current page while the next loads (offset re-keys) so the pager doesn't flash.
 		keepPreviousData: isPaginated,
+		// 0 under auto-refresh so time-keyed entries don't accumulate and OOM the tab (V1 parity).
+		cacheTime: isAutoRefreshDisabled
+			? DASHBOARD_CACHE_TIME
+			: DASHBOARD_CACHE_TIME_ON_REFRESH_ENABLED,
 	});
 
 	const queryClient = useQueryClient();

--- a/frontend/src/pages/DashboardPageV2/constants/events.ts
+++ b/frontend/src/pages/DashboardPageV2/constants/events.ts
@@ -1,0 +1,4 @@
+export enum DashboardEvents {
+	SWITCH_TO_EDIT_MODE = 'View Panel: Switch to edit mode',
+	SWITCH_TO_VIEW_MODE = 'Edit Panel: Switch to view mode',
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

In the V2 panel editor, clicking **Switch to View Mode** with un-saved changes dropped everything except the query. The View modal re-seeded its draft from the *saved* panel spec and only overlaid the live query, so config edits — thresholds, units, table/list columns, legend, formatting, axes — were silently lost.

This PR hands the live draft spec off to the View modal so those edits carry over. The query already travels in the URL (`compositeQuery`) because the query builder hydrates from it; the rest of the spec now travels in a **tab-scoped `sessionStorage` handoff** keyed by `dashboardId + panelId`.

Why `sessionStorage` and not the URL: an earlier iteration put the whole spec in the URL, but that bloated the link badly. `sessionStorage` keeps the URL small, still **survives a page refresh** (the key requirement), and auto-clears when the tab closes. `expandedWidgetId` in the URL is the correlator, so the handoff is only ever read back for the exact panel it was written for.

#### Screenshots / Screen Recordings (if applicable)
N/A — behavior is state-carry across a mode switch; no visual chrome changes. Verified via unit tests + build (see Testing Strategy).

#### Issues closed by this PR
Closes https://github.com/SigNoz/engineering-pod/issues/5663

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
`useSwitchToViewMode` carried only the live query (via the `compositeQuery` URL param) and the panel type (`graphType`). On the receiving side, `useViewPanelMode` seeded its draft from the **saved** `panel.spec` via `buildViewPanelSpec`, overlaying just the query. There was no channel for the editor's un-saved config edits, so they never reached the View modal.

#### Fix Strategy
- `useSwitchToViewMode` writes the live draft spec to a `sessionStorage` handoff (`writeViewPanelHandoff`) before navigating; the query stays in the URL.
- `useViewPanelMode` uses `readViewPanelHandoff(dashboardId, panelId)` as the base spec for its seed, falling back to the saved panel when there's no handoff / it belongs to another panel / it's malformed.
- The handoff is cleared (`clearViewPanelHandoff`) on plain grid **View**, grid drilldown, and modal **close**, so a stale editor spec can never seed an unrelated view.

---

### 🧪 Testing Strategy
> How was this change validated?

- **Tests added/updated:** `useSwitchToViewMode.test.ts` — asserts the query still goes to the URL, the spec goes to the `sessionStorage` handoff (and *not* the URL), and the handoff is scoped to the exact `dashboardId + panelId`. Ran the full PanelEditor + PanelsAndSectionsLayout suites: **332 passing**.
- **Manual verification:** `pnpm tsgo --noEmit`, `pnpm oxlint`, and `pnpm build` all clean. Not driven in a live browser session.
- **Edge cases covered:** no handoff (plain View → saved panel); handoff for a different panel (ignored); malformed stored value (falls back); refresh (sessionStorage persists, URL re-seeds the query); plain View / drilldown / close clear the handoff.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** V2 dashboard panel View modal + the editor's "Switch to View Mode" only. No API, schema, or shared query-builder changes.
- **Potential regressions:** low. The new base-spec source falls back to the exact prior behavior (`panel.spec`) whenever no handoff is present, so non-editor entry points into the View modal are unchanged.
- **Rollback plan:** revert this commit; no migrations or persisted server state involved. `sessionStorage` entries are tab-scoped and self-expire on tab close.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | V2 dashboards: switching a panel from edit to view mode now keeps your un-saved changes (query and config) instead of reverting to the last saved version. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Because the handoff lives in `sessionStorage` (not the URL), a **copied/shared link won't carry un-saved edits** — it opens on the saved panel. This is intentional (you can't share someone's local unsaved edits) and mirrors the existing reverse view→edit handoff.
- Scope is deliberately editor → view. The reverse direction (view → edit, via router `state`) still has the same refresh limitation and is untouched here — happy to follow up if we want it made refresh-safe too.
- In-modal config edits made *after* switching to view are still not URL/storage-persisted (unchanged, pre-existing).

---
