### PR TITLE
fix(rules): prevent early return in initiate when an org has zero rules

### DIFF
--- a/pkg/query-service/rules/manager.go
+++ b/pkg/query-service/rules/manager.go
@@ -260,7 +260,7 @@ func (m *Manager) initiate(ctx context.Context) error {
 			return err
 		}
 		if len(storedRules) == 0 {
-			return nil
+			continue
 		}
 
 		for _, rec := range storedRules {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

This change fixes a critical bug where the alert rules manager (`initiate()`) aborts its entire startup loop if it encounters an organization with zero rules. Because it was using `return nil`, it silently skipped all organizations that came after the empty one in the database, completely dropping their alert coverage at startup. Changing this to `continue` ensures that an empty organization is simply skipped and the remaining organizations load their rules properly.

#### Screenshots / Screen Recordings (if applicable)
N/A (Backend logic fix)

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes #12059 

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

**Refactor regression:** When the rule manager was refactored from a single-org design to support multiple organizations (in PR #8107), the early-return logic for an empty rule set (`if len(storedRules) == 0 { return nil }`) was left unchanged. In the context of the new `for _, org := range orgs` loop, this mistakenly terminated the entire function instead of just the current iteration.

#### Fix Strategy
> How does this PR address the root cause?

Changed `return nil` to `continue` on line 268 of `pkg/query-service/rules/manager.go` inside the `initiate()` function.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Explicitly not required (1-line logic fix).
- Manual verification: Verified the loop logic in `pkg/query-service/rules/manager.go`. With `continue`, the `initiate()` loop correctly moves to the next organization in the slice without halting execution.
- Edge cases covered: Multi-org deployments where early organizations have no rules configured.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Extremely low. This purely restores intended initialization flow.
- Potential regressions: None expected.
- Rollback plan: Revert this commit if it unexpectedly impacts startup performance (unlikely).

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed a bug where alert rules would silently fail to load for organizations at startup if a preceding organization had no rules configured. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

This is a straightforward 1-line fix addressing a copy-paste oversight from when multi-org support was introduced. Let me know if you need me to write an explicit unit test for this edge case!
