### PR TITLE
fix(ruletypes): tag rule threshold targets as format: double

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -7394,9 +7394,11 @@ components:
         op:
           $ref: '#/components/schemas/RuletypesCompareOperator'
         recoveryTarget:
+          format: double
           nullable: true
           type: number
         target:
+          format: double
           nullable: true
           type: number
         targetUnit:
@@ -7680,6 +7682,7 @@ components:
         selectedQueryName:
           type: string
         target:
+          format: double
           nullable: true
           type: number
         targetUnit:

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -8480,10 +8480,12 @@ export interface RuletypesBasicRuleThresholdDTO {
 	op: RuletypesCompareOperatorDTO;
 	/**
 	 * @type number,null
+	 * @format double
 	 */
 	recoveryTarget?: number | null;
 	/**
 	 * @type number,null
+	 * @format double
 	 */
 	target: number | null;
 	/**
@@ -8677,6 +8679,7 @@ export interface RuletypesRuleConditionDTO {
 	selectedQueryName?: string;
 	/**
 	 * @type number,null
+	 * @format double
 	 */
 	target?: number | null;
 	/**

--- a/pkg/types/ruletypes/alerting.go
+++ b/pkg/types/ruletypes/alerting.go
@@ -112,7 +112,7 @@ type AlertCompositeQuery struct {
 type RuleCondition struct {
 	CompositeQuery    *AlertCompositeQuery `json:"compositeQuery" required:"true"`
 	CompareOperator   CompareOperator      `json:"op,omitzero"`
-	Target            *float64             `json:"target,omitempty"`
+	Target            *float64             `json:"target,omitempty" format:"double"`
 	AlertOnAbsent     bool                 `json:"alertOnAbsent,omitempty"`
 	AbsentFor         uint64               `json:"absentFor,omitempty"`
 	MatchType         MatchType            `json:"matchType,omitzero"`
@@ -187,4 +187,3 @@ func (rc *RuleCondition) String() string {
 	data, _ := json.Marshal(*rc)
 	return string(data)
 }
-

--- a/pkg/types/ruletypes/threshold.go
+++ b/pkg/types/ruletypes/threshold.go
@@ -134,9 +134,9 @@ type RuleThreshold interface {
 
 type BasicRuleThreshold struct {
 	Name            string          `json:"name" required:"true"`
-	TargetValue     *float64        `json:"target" required:"true"`
+	TargetValue     *float64        `json:"target" required:"true" format:"double"`
 	TargetUnit      string          `json:"targetUnit"`
-	RecoveryTarget  *float64        `json:"recoveryTarget"`
+	RecoveryTarget  *float64        `json:"recoveryTarget" format:"double"`
 	MatchType       MatchType       `json:"matchType" required:"true"`
 	CompareOperator CompareOperator `json:"op" required:"true"`
 	Channels        []string        `json:"channels"`


### PR DESCRIPTION
### 📄 Summary

Rule threshold targets — `condition.thresholds.basic.spec[].target` / `recoveryTarget` and the v1 `condition.target` — are `*float64` in Go but were emitted as a bare `type: number` (no `format`) in `docs/api/openapi.yml`. swaggest only stamps `format: double` on **non-pointer** floats, so these nullable fields lost it.

### 🐛 Bug Context

#### Root Cause
A `*float64` field reflects to `{type: number, nullable: true}` with no `format` (swaggest sets `format: double` only for non-pointer floats). Clients generated from that spec use `float32`, losing decimal precision.

#### Fix Strategy
Add a `format:"double"` struct tag to `BasicRuleThreshold.{TargetValue,RecoveryTarget}` (`pkg/types/ruletypes/threshold.go`) and `RuleCondition.Target` (`pkg/types/ruletypes/alerting.go`), so the emitted schema carries `format: double` → generated clients use `float64`.

---

### 🧪 Testing Strategy

- Tests added/updated: none — schema-tag-only change; behavior of SigNoz itself is unchanged (JSON numbers already serialize as float64).