### PR TITLE
feat: scalar/table serializers for client-side export (3)

### DIFF
--- a/frontend/src/lib/exportData/__tests__/exportScalarData.test.ts
+++ b/frontend/src/lib/exportData/__tests__/exportScalarData.test.ts
@@ -1,0 +1,94 @@
+import { SuccessResponse } from 'types/api';
+import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { Query } from 'types/api/queryBuilder/queryBuilderData';
+
+import { exportScalarData } from '../exportScalarData';
+
+const query = {
+	queryType: 'builder',
+	builder: {
+		queryData: [
+			{
+				queryName: 'A',
+				dataSource: 'logs',
+				aggregations: [{ expression: 'count()' }],
+				groupBy: [
+					{ key: 'service.name', dataType: 'string', type: 'tag', id: 'svc' },
+				],
+				legend: '',
+			},
+		],
+		queryFormulas: [],
+	},
+} as unknown as Query;
+
+function makeResponse(
+	tables: {
+		queryName: string;
+		columns: { name: string; id?: string; isValueColumn: boolean }[];
+		rows: Record<string, string | number>[];
+	}[],
+): SuccessResponse<MetricRangePayloadProps> {
+	return {
+		statusCode: 200,
+		error: null,
+		message: '',
+		payload: {
+			data: {
+				resultType: 'scalar',
+				result: tables.map((table) => ({
+					queryName: table.queryName,
+					legend: '',
+					series: null,
+					list: null,
+					table: {
+						columns: table.columns.map((col) => ({
+							...col,
+							queryName: table.queryName,
+						})),
+						rows: table.rows.map((row) => ({ data: row })),
+					},
+				})),
+			},
+		},
+	} as unknown as SuccessResponse<MetricRangePayloadProps>;
+}
+
+describe('exportScalarData', () => {
+	it('serializes the table exactly as QueryTable prepares it', () => {
+		const data = makeResponse([
+			{
+				queryName: 'A',
+				columns: [
+					{ name: 'service.name', id: 'service.name', isValueColumn: false },
+					{ name: 'count()', id: 'A', isValueColumn: true },
+				],
+				rows: [
+					{ 'service.name': 'frontend', A: 120 },
+					{ 'service.name': 'cart', A: 80 },
+				],
+			},
+		]);
+
+		const table = exportScalarData({ data, query });
+
+		// group + aggregation columns, raw values, on-screen order — inherited
+		// 1:1 from createTableColumnsFromQuery (the renderer's own preparer)
+		expect(table).toStrictEqual({
+			headers: ['service.name', 'count()'],
+			rows: [
+				['frontend', 120],
+				['cart', 80],
+			],
+		});
+	});
+
+	it('returns an empty table for an empty response', () => {
+		const table = exportScalarData({
+			data: makeResponse([]),
+			query,
+		});
+
+		expect(table.rows).toStrictEqual([]);
+	});
+});

--- a/frontend/src/lib/exportData/__tests__/exportTableData.test.ts
+++ b/frontend/src/lib/exportData/__tests__/exportTableData.test.ts
@@ -1,0 +1,58 @@
+import { exportTableData } from '../exportTableData';
+
+const columns = [
+	{ name: 'service.name', key: 'service.name' },
+	{ name: 'count()', key: 'A', isValueColumn: true },
+	{ name: 'avg(duration)', key: 'B', isValueColumn: true },
+];
+
+describe('exportTableData', () => {
+	it('serializes raw values in display column order', () => {
+		const table = exportTableData({
+			columns,
+			dataSource: [
+				{ 'service.name': 'frontend', A: 120, B: 45.5 },
+				{ 'service.name': 'cart', A: 80, B: 12 },
+			],
+		});
+
+		expect(table).toStrictEqual({
+			headers: ['service.name', 'count()', 'avg(duration)'],
+			rows: [
+				['frontend', 120, 45.5],
+				['cart', 80, 12],
+			],
+		});
+	});
+
+	it('appends column units to value columns only, skipping display-only ids', () => {
+		const table = exportTableData({
+			columns,
+			dataSource: [{ 'service.name': 'frontend', A: 120, B: 45.5 }],
+			columnUnits: { A: 'short', B: 'ms', 'service.name': 'ms' },
+		});
+
+		// group column never gets a unit; 'short' is display-only and skipped
+		expect(table.headers).toStrictEqual([
+			'service.name',
+			'count()',
+			'avg(duration) (ms)',
+		]);
+	});
+
+	it('marks missing cells as blank gaps', () => {
+		const table = exportTableData({
+			columns,
+			dataSource: [{ 'service.name': 'frontend', A: 120 }],
+		});
+
+		expect(table.rows).toStrictEqual([['frontend', 120, '']]);
+	});
+
+	it('returns a headers-only table for empty data', () => {
+		expect(exportTableData({ columns, dataSource: [] })).toStrictEqual({
+			headers: ['service.name', 'count()', 'avg(duration)'],
+			rows: [],
+		});
+	});
+});

--- a/frontend/src/lib/exportData/exportScalarData.ts
+++ b/frontend/src/lib/exportData/exportScalarData.ts
@@ -1,0 +1,48 @@
+import { createTableColumnsFromQuery } from 'lib/query/createTableColumnsFromQuery';
+import { SuccessResponse } from 'types/api';
+import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { Query } from 'types/api/queryBuilder/queryBuilderData';
+import { QueryDataV3 } from 'types/api/widgets/getQuery';
+
+import { exportTableData } from './exportTableData';
+import { SerializedTable } from './types';
+
+interface ExportScalarDataArgs {
+	// The queryRange response object the table mount already holds (the
+	// formatForWeb payload carrying webTables).
+	data?: SuccessResponse<MetricRangePayloadProps>;
+	query: Query;
+}
+
+/**
+ * Serializes a scalar/table queryRange response into a table — via
+ * createTableColumnsFromQuery, the exact preparer QueryTable renders from, so
+ * the export inherits the on-screen merge, naming and column order 1:1.
+ */
+export function exportScalarData({
+	data,
+	query,
+}: ExportScalarDataArgs): SerializedTable {
+	const queryTableData = (data?.payload?.data?.newResult?.data?.result ||
+		data?.payload?.data?.result ||
+		[]) as QueryDataV3[];
+
+	const { columns, dataSource } = createTableColumnsFromQuery({
+		query,
+		queryTableData,
+	});
+
+	return exportTableData({
+		// antd widens title/dataIndex; createTableColumnsFromQuery always sets strings
+		columns: columns.map((column) => {
+			const rawIndex = 'dataIndex' in column ? column.dataIndex : undefined;
+			const key =
+				typeof rawIndex === 'string' || typeof rawIndex === 'number'
+					? String(rawIndex)
+					: '';
+			const name = typeof column.title === 'string' ? column.title : key;
+			return { name, key: key || name };
+		}),
+		dataSource: dataSource as unknown as Record<string, unknown>[],
+	});
+}

--- a/frontend/src/lib/exportData/exportTableData.ts
+++ b/frontend/src/lib/exportData/exportTableData.ts
@@ -1,0 +1,46 @@
+import { SerializedTable } from './types';
+import { withUnit } from './withUnit';
+
+/** Generic table-model column — any prepared table (QueryTable, dashboard
+ * tables, plain antd tables) adapts to this in a line or two. */
+export interface ExportTableColumn {
+	/** Display name, used as the export header (column order = array order). */
+	name: string;
+	/** Key into each dataSource record. */
+	key: string;
+	isValueColumn?: boolean;
+}
+
+interface ExportTableDataArgs {
+	columns: ExportTableColumn[];
+	dataSource: Record<string, unknown>[];
+	/** Per-column display unit, keyed by column key (dashboards; absent in explorer). */
+	columnUnits?: Record<string, string>;
+}
+
+/**
+ * Serializes a prepared table model into a format-agnostic table — raw values
+ * in display column order (lossless; no cell formatting applied).
+ */
+export function exportTableData({
+	columns,
+	dataSource,
+	columnUnits,
+}: ExportTableDataArgs): SerializedTable {
+	const headers = columns.map((column) =>
+		column.isValueColumn
+			? withUnit(column.name, columnUnits?.[column.key])
+			: column.name,
+	);
+
+	const rows = dataSource.map((record) =>
+		columns.map((column) => {
+			const value = record[column.key];
+			return value === undefined || value === null
+				? ''
+				: (value as string | number);
+		}),
+	);
+
+	return { headers, rows };
+}

--- a/frontend/src/lib/exportData/exportTimeseriesData.ts
+++ b/frontend/src/lib/exportData/exportTimeseriesData.ts
@@ -5,6 +5,7 @@ import { TimeSeries, TimeSeriesData } from 'types/api/v5/queryRange';
 import { QueryData } from 'types/api/widgets/getQuery';
 
 import { SerializedTable } from './types';
+import { withUnit } from './withUnit';
 
 interface ExportTimeseriesDataArgs {
 	data: TimeSeriesData[];
@@ -96,18 +97,6 @@ function flatten(
 		});
 	});
 	return flat;
-}
-
-// Display-format ids, not physical units — meaningful on a chart axis
-// (compact-number formatting) but misleading in an export header.
-const DISPLAY_ONLY_UNITS = new Set(['short', 'none']);
-
-// Appends the y-axis unit to the value header: `value` → `value (ms)`.
-function withUnit(header: string, yAxisUnit?: string): string {
-	if (!yAxisUnit || DISPLAY_ONLY_UNITS.has(yAxisUnit)) {
-		return header;
-	}
-	return `${header} (${yAxisUnit})`;
 }
 
 function toIso(timestamp: number): string {

--- a/frontend/src/lib/exportData/withUnit.ts
+++ b/frontend/src/lib/exportData/withUnit.ts
@@ -1,0 +1,11 @@
+// Display-format ids, not physical units — meaningful on a chart axis
+// (compact-number formatting) but misleading in an export header.
+const DISPLAY_ONLY_UNITS = new Set(['short', 'none']);
+
+/** Appends a unit to a header: `value` → `value (ms)`. Skips display-only ids. */
+export function withUnit(header: string, unit?: string): string {
+	if (!unit || DISPLAY_ONLY_UNITS.has(unit)) {
+		return header;
+	}
+	return `${header} (${unit})`;
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist? What problem does it solve, and why is this the right approach?

Adds the **scalar/table serialization layer** to the client-side export stack — the pure functions the explorer **Table tab** integration (next PR) and, later, dashboard tables plug into. Logic only; no UI wiring in this PR.

- **`exportTableData`** — a generic, surface-agnostic serializer: takes any prepared antd-style table model (`{name, key, isValueColumn}` columns + record rows, optional per-column `columnUnits`) and emits a `SerializedTable` — **raw values in display column order** (lossless; no cell formatting), units on value columns only, blanks for missing cells. Dashboard tables and other antd tables adapt to it in a line or two.
- **`exportScalarData`** — the queryRange-facing wrapper: takes the response object a table view already holds (the formatForWeb webTables payload) + the builder query, and prepares via **`createTableColumnsFromQuery`** — the exact preparer `QueryTable` renders from — so exports inherit the on-screen multi-query merge, column naming and order **1:1**.
- **`withUnit` extracted** to its own module (the timeseries serializer and the new table serializer share the unit-suffix + display-only-id-skip logic).

#### Screenshots / Screen Recordings (if applicable)

N/A — no UI in this PR (serialization layer only; the Table-tab download button lands in the next PR of the stack).

#### Issues closed by this PR

- Implements sub-issue: https://github.com/SigNoz/engineering-pod/issues/5591
- Part of the download-unification epic: https://github.com/SigNoz/engineering-pod/issues/4682

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

N/A — not a bug fix.

---

### 🧪 Testing Strategy
> How was this change validated?

- **Tests added** (in `__tests__/`):
  - `exportTableData` — raw values in display order; units on value columns only (display-only ids like `short` skipped); missing cells as blanks; empty data.
  - `exportScalarData` — end-to-end through the real `createTableColumnsFromQuery` with a webTables fixture; output locked with strict equality (`headers: ['service.name', 'count()']`, raw rows in on-screen order); empty response.
- **Automated gates:** `tsgo --noEmit`, `oxlint` (repo config), `oxfmt --check`, `jest` — all clean; existing export suites unaffected.
- **Manual verification:** N/A here — lands with the Table-tab integration PR, where the output is compared against the rendered table in-browser.
- **Edge cases covered:** multi-query tables (merge inherited from the shared preparer), value-vs-group column units, `'N/A'` placeholder cells (exported as the table shows them — parity).

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** two new pure modules + one refactor (`withUnit` extraction — behavior identical, covered by existing tests). Nothing consumes the new serializers yet.
- **Potential regressions:** none expected — no existing code path changes behavior.
- **Rollback plan:** revert the PR; no migrations, no persisted state, no API changes.

---

### 📝 Changelog
> Use **N/A** for internal or non-user-facing changes

N/A — internal serialization layer; user-facing behavior arrives with the Table-tab integration PR.

---

## 👀 Notes for Reviewers

- **Stacked PR** — builds on the explorer-integration PR (#12055), which builds on the foundation (#12025). Review only this PR's 3 commits:
  1. `refactor` — extract the `withUnit` header helper (shared by both serializers).
  2. `feat` — `exportTableData`, the generic table-model serializer.
  3. `feat` — `exportScalarData`, the queryRange wrapper via `createTableColumnsFromQuery`.
- **Design choice worth knowing:** for tables we deliberately serialize the **prepared table model** (what `QueryTable` renders) rather than walking the raw V5 scalar response — reusing the renderer's own preparer means the export can never diverge from the on-screen table (merge, naming, order), and the generic core stays consumable by dashboard tables that have their own preparers.
- Values are **raw** end-to-end (cell display formatting lives in renderers, not the preparer) — this is the lossless upgrade over the legacy papaparse-the-rendered-cells approach.

---
