### PR TITLE
feat(exceptions): surface docs link on the exceptions page

### DIFF
--- a/frontend/src/pages/AllErrors/index.tsx
+++ b/frontend/src/pages/AllErrors/index.tsx
@@ -10,6 +10,7 @@ import HeaderRightSection from 'components/HeaderRightSection/HeaderRightSection
 import QuickFilters from 'components/QuickFilters/QuickFilters';
 import { QuickFiltersSource, SignalType } from 'components/QuickFilters/types';
 import RouteTab from 'components/RouteTab';
+import TextToolTip from 'components/TextToolTip';
 import TypicalOverlayScrollbar from 'components/TypicalOverlayScrollbar/TypicalOverlayScrollbar';
 import { LOCALSTORAGE } from 'constants/localStorage';
 import RightToolbarActions from 'container/QueryBuilder/components/ToolbarActions/RightToolbarActions';
@@ -92,6 +93,11 @@ function AllErrors(): JSX.Element {
 										onStageRunQuery={handleRunQuery}
 										isLoadingQueries={isLoadingQueries}
 										handleCancelQuery={handleCancelQuery}
+									/>
+									<TextToolTip
+										text="More details on how to use exceptions"
+										url="https://signoz.io/docs/userguide/exceptions/?utm_source=product&utm_medium=all-exceptions"
+										urlText="Learn More"
 									/>
 									<HeaderRightSection
 										enableAnnouncements={false}


### PR DESCRIPTION
Closes #4765.

Surfaces the existing exceptions user guide on the in-app Exceptions (All Errors) page, as requested. Adds a `TextToolTip` "Learn More" docs link (`https://signoz.io/docs/userguide/exceptions/`) in the page's header action cluster — mirroring how other pages (e.g. `ListAlertRules`, `PipelinePage`) surface docs links, with the repo-standard utm params. No new UI element is invented.

## Test plan
`tsgo --noEmit` (the CI typechecker) exits 0; `oxlint` is clean on the changed file. The change adds a header element without altering existing behavior.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted); typecheck + lint verified on the changed file.*