### PR TITLE
fix(query-service): prevent SQL injection in alert history endpoints

### DIFF
--- a/pkg/query-service/app/clickhouseReader/reader.go
+++ b/pkg/query-service/app/clickhouseReader/reader.go
@@ -4086,6 +4086,10 @@ func readRowsForTimeSeriesResult(rows driver.Rows, vars []interface{}, columnNam
 
 // GetTimeSeriesResultV3 runs the query and returns list of time series
 func (r *ClickHouseReader) GetTimeSeriesResultV3(ctx context.Context, query string) ([]*v3.Series, error) {
+	return r.getTimeSeriesResultV3(ctx, query)
+}
+
+func (r *ClickHouseReader) getTimeSeriesResultV3(ctx context.Context, query string, args ...interface{}) ([]*v3.Series, error) {
 	ctx = ctxtypes.NewContextWithCommentVals(ctx, map[string]string{
 		instrumentationtypes.CodeNamespace:    "clickhouse-reader",
 		instrumentationtypes.CodeFunctionName: "GetTimeSeriesResultV3",
@@ -4111,7 +4115,7 @@ func (r *ClickHouseReader) GetTimeSeriesResultV3(ctx context.Context, query stri
 		}
 	}
 
-	rows, err := r.db.Query(ctx, query)
+	rows, err := r.db.Query(ctx, query, args...)
 
 	if err != nil {
 		r.logger.Error("error while reading time series result", errorsV2.Attr(err))
@@ -4631,11 +4635,11 @@ func (r *ClickHouseReader) GetLastSavedRuleStateHistory(ctx context.Context, rul
 		instrumentationtypes.CodeNamespace:    "clickhouse-reader",
 		instrumentationtypes.CodeFunctionName: "GetLastSavedRuleStateHistory",
 	})
-	query := fmt.Sprintf("SELECT * FROM %s.%s WHERE rule_id = '%s' AND state_changed = true ORDER BY unix_milli DESC LIMIT 1 BY fingerprint",
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID)
+	query := fmt.Sprintf("SELECT * FROM %s.%s WHERE rule_id = ? AND state_changed = true ORDER BY unix_milli DESC LIMIT 1 BY fingerprint",
+		signozHistoryDBName, ruleStateHistoryTableName)
 
 	history := []model.RuleStateHistory{}
-	err := r.db.Select(ctx, &history, query)
+	err := r.db.Select(ctx, &history, query, ruleID)
 	if err != nil {
 		return nil, err
 	}
@@ -4650,13 +4654,17 @@ func (r *ClickHouseReader) ReadRuleStateHistoryByRuleID(
 		instrumentationtypes.CodeFunctionName: "ReadRuleStateHistoryByRuleID",
 	})
 	var conditions []string
+	args := make([]interface{}, 0, 4)
 
-	conditions = append(conditions, fmt.Sprintf("rule_id = '%s'", ruleID))
+	conditions = append(conditions, "rule_id = ?")
+	args = append(args, ruleID)
 
-	conditions = append(conditions, fmt.Sprintf("unix_milli >= %d AND unix_milli < %d", params.Start, params.End))
+	conditions = append(conditions, "unix_milli >= ? AND unix_milli < ?")
+	args = append(args, params.Start, params.End)
 
 	if params.State != "" {
-		conditions = append(conditions, fmt.Sprintf("state = '%s'", params.State))
+		conditions = append(conditions, "state = ?")
+		args = append(args, params.State)
 	}
 
 	if params.Filters != nil && len(params.Filters.Items) != 0 {
@@ -4666,42 +4674,45 @@ func (r *ClickHouseReader) ReadRuleStateHistoryByRuleID(
 			if op == v3.FilterOperatorContains || op == v3.FilterOperatorNotContains {
 				toFormat = fmt.Sprintf("%%%s%%", toFormat)
 			}
-			fmtVal := utils.ClickHouseFormattedValue(toFormat)
 			switch op {
 			case v3.FilterOperatorEqual:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') = %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, "JSONExtractString(labels, ?) = ?")
 			case v3.FilterOperatorNotEqual:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') != %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, "JSONExtractString(labels, ?) != ?")
 			case v3.FilterOperatorIn:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') IN %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, "JSONExtractString(labels, ?) IN ?")
 			case v3.FilterOperatorNotIn:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') NOT IN %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, "JSONExtractString(labels, ?) NOT IN ?")
 			case v3.FilterOperatorLike:
-				conditions = append(conditions, fmt.Sprintf("like(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+				conditions = append(conditions, "like(JSONExtractString(labels, ?), ?)")
 			case v3.FilterOperatorNotLike:
-				conditions = append(conditions, fmt.Sprintf("notLike(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+				conditions = append(conditions, "notLike(JSONExtractString(labels, ?), ?)")
 			case v3.FilterOperatorRegex:
-				conditions = append(conditions, fmt.Sprintf("match(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+				conditions = append(conditions, "match(JSONExtractString(labels, ?), ?)")
 			case v3.FilterOperatorNotRegex:
-				conditions = append(conditions, fmt.Sprintf("not match(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+				conditions = append(conditions, "not match(JSONExtractString(labels, ?), ?)")
 			case v3.FilterOperatorGreaterThan:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') > %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, "JSONExtractString(labels, ?) > ?")
 			case v3.FilterOperatorGreaterThanOrEq:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') >= %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, "JSONExtractString(labels, ?) >= ?")
 			case v3.FilterOperatorLessThan:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') < %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, "JSONExtractString(labels, ?) < ?")
 			case v3.FilterOperatorLessThanOrEq:
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, '%s') <= %s", item.Key.Key, fmtVal))
+				conditions = append(conditions, "JSONExtractString(labels, ?) <= ?")
 			case v3.FilterOperatorContains:
-				conditions = append(conditions, fmt.Sprintf("like(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+				conditions = append(conditions, "like(JSONExtractString(labels, ?), ?)")
 			case v3.FilterOperatorNotContains:
-				conditions = append(conditions, fmt.Sprintf("notLike(JSONExtractString(labels, '%s'), %s)", item.Key.Key, fmtVal))
+				conditions = append(conditions, "notLike(JSONExtractString(labels, ?), ?)")
 			case v3.FilterOperatorExists:
-				conditions = append(conditions, fmt.Sprintf("has(JSONExtractKeys(labels), '%s')", item.Key.Key))
+				conditions = append(conditions, "has(JSONExtractKeys(labels), ?)")
 			case v3.FilterOperatorNotExists:
-				conditions = append(conditions, fmt.Sprintf("not has(JSONExtractKeys(labels), '%s')", item.Key.Key))
+				conditions = append(conditions, "not has(JSONExtractKeys(labels), ?)")
 			default:
 				return nil, fmt.Errorf("unsupported filter operator")
+			}
+			args = append(args, item.Key.Key)
+			if op != v3.FilterOperatorExists && op != v3.FilterOperatorNotExists {
+				args = append(args, toFormat)
 			}
 		}
 	}
@@ -4712,7 +4723,7 @@ func (r *ClickHouseReader) ReadRuleStateHistoryByRuleID(
 
 	history := []model.RuleStateHistory{}
 	r.logger.Debug("rule state history query", "query", query)
-	err := r.db.Select(ctx, &history, query)
+	err := r.db.Select(ctx, &history, query, args...)
 	if err != nil {
 		r.logger.Error("Error while reading rule state history", errorsV2.Attr(err))
 		return nil, err
@@ -4722,12 +4733,12 @@ func (r *ClickHouseReader) ReadRuleStateHistoryByRuleID(
 	r.logger.Debug("rule state history total query", "query", fmt.Sprintf("SELECT count(*) FROM %s.%s WHERE %s",
 		signozHistoryDBName, ruleStateHistoryTableName, whereClause))
 	err = r.db.QueryRow(ctx, fmt.Sprintf("SELECT count(*) FROM %s.%s WHERE %s",
-		signozHistoryDBName, ruleStateHistoryTableName, whereClause)).Scan(&total)
+		signozHistoryDBName, ruleStateHistoryTableName, whereClause), args...).Scan(&total)
 	if err != nil {
 		return nil, err
 	}
 
-	labelsQuery := fmt.Sprintf("SELECT DISTINCT labels FROM %s.%s WHERE rule_id = $1",
+	labelsQuery := fmt.Sprintf("SELECT DISTINCT labels FROM %s.%s WHERE rule_id = ?",
 		signozHistoryDBName, ruleStateHistoryTableName)
 	rows, err := r.db.Query(ctx, labelsQuery, ruleID)
 	if err != nil {
@@ -4772,15 +4783,15 @@ func (r *ClickHouseReader) ReadRuleStateHistoryTopContributorsByRuleID(
 		any(labels) as labels,
 		count(*) as count
 	FROM %s.%s
-	WHERE rule_id = '%s' AND (state_changed = true) AND (state = '%s') AND unix_milli >= %d AND unix_milli <= %d
+	WHERE rule_id = ? AND (state_changed = true) AND (state = ?) AND unix_milli >= ? AND unix_milli <= ?
 	GROUP BY fingerprint
 	HAVING labels != '{}'
 	ORDER BY count DESC`,
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, model.StateFiring.String(), params.Start, params.End)
+		signozHistoryDBName, ruleStateHistoryTableName)
 
 	r.logger.Debug("rule state history top contributors query", "query", query)
 	contributors := []model.RuleStateHistoryContributor{}
-	err := r.db.Select(ctx, &contributors, query)
+	err := r.db.Select(ctx, &contributors, query, ruleID, model.StateFiring.String(), params.Start, params.End)
 	if err != nil {
 		r.logger.Error("Error while reading rule state history", errorsV2.Attr(err))
 		return nil, err
@@ -4803,8 +4814,8 @@ func (r *ClickHouseReader) GetOverallStateTransitions(ctx context.Context, ruleI
     FROM %s.%s
     WHERE overall_state = '` + model.StateFiring.String() + `'
       AND overall_state_changed = true
-      AND rule_id IN ('%s')
-	  AND unix_milli >= %d AND unix_milli <= %d
+      AND rule_id = ?
+      AND unix_milli >= ? AND unix_milli <= ?
 ),
 resolution_events AS (
     SELECT
@@ -4814,8 +4825,8 @@ resolution_events AS (
     FROM %s.%s
     WHERE overall_state = '` + model.StateInactive.String() + `'
       AND overall_state_changed = true
-      AND rule_id IN ('%s')
-	  AND unix_milli >= %d AND unix_milli <= %d
+      AND rule_id = ?
+      AND unix_milli >= ? AND unix_milli <= ?
 ),
 matched_events AS (
     SELECT
@@ -4834,13 +4845,13 @@ FROM matched_events
 ORDER BY firing_time ASC;`
 
 	query := fmt.Sprintf(tmpl,
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.Start, params.End,
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.Start, params.End)
+		signozHistoryDBName, ruleStateHistoryTableName,
+		signozHistoryDBName, ruleStateHistoryTableName)
 
 	r.logger.Debug("overall state transitions query", "query", query)
 
 	transitions := []model.RuleStateTransition{}
-	err := r.db.Select(ctx, &transitions, query)
+	err := r.db.Select(ctx, &transitions, query, ruleID, params.Start, params.End, ruleID, params.Start, params.End)
 	if err != nil {
 		return nil, err
 	}
@@ -4869,9 +4880,9 @@ ORDER BY firing_time ASC;`
 
 	// fetch the most recent overall_state from the table
 	var state model.AlertState
-	stateQuery := fmt.Sprintf("SELECT state FROM %s.%s WHERE rule_id = '%s' AND unix_milli <= %d ORDER BY unix_milli DESC LIMIT 1",
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.End)
-	if err := r.db.QueryRow(ctx, stateQuery).Scan(&state); err != nil {
+	stateQuery := fmt.Sprintf("SELECT state FROM %s.%s WHERE rule_id = ? AND unix_milli <= ? ORDER BY unix_milli DESC LIMIT 1",
+		signozHistoryDBName, ruleStateHistoryTableName)
+	if err := r.db.QueryRow(ctx, stateQuery, ruleID, params.End).Scan(&state); err != nil {
 		if err != sql.ErrNoRows {
 			return nil, err
 		}
@@ -4900,9 +4911,9 @@ ORDER BY firing_time ASC;`
 			SELECT
 				unix_milli
 			FROM %s.%s
-			WHERE rule_id = '%s' AND overall_state_changed = true AND overall_state = '%s' AND unix_milli <= %d
-			ORDER BY unix_milli DESC LIMIT 1`, signozHistoryDBName, ruleStateHistoryTableName, ruleID, model.StateFiring.String(), params.End)
-			if err := r.db.QueryRow(ctx, firingQuery).Scan(&firingTime); err != nil {
+				WHERE rule_id = ? AND overall_state_changed = true AND overall_state = ? AND unix_milli <= ?
+				ORDER BY unix_milli DESC LIMIT 1`, signozHistoryDBName, ruleStateHistoryTableName)
+			if err := r.db.QueryRow(ctx, firingQuery, ruleID, model.StateFiring.String(), params.End).Scan(&firingTime); err != nil {
 				return nil, err
 			}
 			stateItems = append(stateItems, model.ReleStateItem{
@@ -4935,8 +4946,8 @@ WITH firing_events AS (
     FROM %s.%s
     WHERE overall_state = '` + model.StateFiring.String() + `'
       AND overall_state_changed = true
-      AND rule_id IN ('%s')
-	  AND unix_milli >= %d AND unix_milli <= %d
+      AND rule_id = ?
+      AND unix_milli >= ? AND unix_milli <= ?
 ),
 resolution_events AS (
     SELECT
@@ -4946,8 +4957,8 @@ resolution_events AS (
     FROM %s.%s
     WHERE overall_state = '` + model.StateInactive.String() + `'
       AND overall_state_changed = true
-      AND rule_id IN ('%s')
-	  AND unix_milli >= %d AND unix_milli <= %d
+      AND rule_id = ?
+      AND unix_milli >= ? AND unix_milli <= ?
 ),
 matched_events AS (
     SELECT
@@ -4966,12 +4977,12 @@ FROM matched_events;
 `
 
 	query := fmt.Sprintf(tmpl,
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.Start, params.End,
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.Start, params.End)
+		signozHistoryDBName, ruleStateHistoryTableName,
+		signozHistoryDBName, ruleStateHistoryTableName)
 
 	r.logger.Debug("avg resolution time query", "query", query)
 	var avgResolutionTime float64
-	err := r.db.QueryRow(ctx, query).Scan(&avgResolutionTime)
+	err := r.db.QueryRow(ctx, query, ruleID, params.Start, params.End, ruleID, params.Start, params.End).Scan(&avgResolutionTime)
 	if err != nil {
 		return 0, err
 	}
@@ -4992,8 +5003,8 @@ WITH firing_events AS (
     FROM %s.%s
     WHERE overall_state = '` + model.StateFiring.String() + `'
       AND overall_state_changed = true
-      AND rule_id IN ('%s')
-	  AND unix_milli >= %d AND unix_milli <= %d
+      AND rule_id = ?
+      AND unix_milli >= ? AND unix_milli <= ?
 ),
 resolution_events AS (
     SELECT
@@ -5003,8 +5014,8 @@ resolution_events AS (
     FROM %s.%s
     WHERE overall_state = '` + model.StateInactive.String() + `'
       AND overall_state_changed = true
-      AND rule_id IN ('%s')
-	  AND unix_milli >= %d AND unix_milli <= %d
+      AND rule_id = ?
+      AND unix_milli >= ? AND unix_milli <= ?
 ),
 matched_events AS (
     SELECT
@@ -5024,11 +5035,11 @@ GROUP BY ts
 ORDER BY ts ASC;`
 
 	query := fmt.Sprintf(tmpl,
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.Start, params.End,
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, params.Start, params.End, step)
+		signozHistoryDBName, ruleStateHistoryTableName,
+		signozHistoryDBName, ruleStateHistoryTableName, step)
 
 	r.logger.Debug("avg resolution time by interval query", "query", query)
-	result, err := r.GetTimeSeriesResultV3(ctx, query)
+	result, err := r.getTimeSeriesResultV3(ctx, query, ruleID, params.Start, params.End, ruleID, params.Start, params.End)
 	if err != nil || len(result) == 0 {
 		return nil, err
 	}
@@ -5041,12 +5052,12 @@ func (r *ClickHouseReader) GetTotalTriggers(ctx context.Context, ruleID string, 
 		instrumentationtypes.CodeNamespace:    "clickhouse-reader",
 		instrumentationtypes.CodeFunctionName: "GetTotalTriggers",
 	})
-	query := fmt.Sprintf("SELECT count(*) FROM %s.%s WHERE rule_id = '%s' AND (state_changed = true) AND (state = '%s') AND unix_milli >= %d AND unix_milli <= %d",
-		signozHistoryDBName, ruleStateHistoryTableName, ruleID, model.StateFiring.String(), params.Start, params.End)
+	query := fmt.Sprintf("SELECT count(*) FROM %s.%s WHERE rule_id = ? AND (state_changed = true) AND (state = ?) AND unix_milli >= ? AND unix_milli <= ?",
+		signozHistoryDBName, ruleStateHistoryTableName)
 
 	var totalTriggers uint64
 
-	err := r.db.QueryRow(ctx, query).Scan(&totalTriggers)
+	err := r.db.QueryRow(ctx, query, ruleID, model.StateFiring.String(), params.Start, params.End).Scan(&totalTriggers)
 	if err != nil {
 		return 0, err
 	}
@@ -5057,10 +5068,10 @@ func (r *ClickHouseReader) GetTotalTriggers(ctx context.Context, ruleID string, 
 func (r *ClickHouseReader) GetTriggersByInterval(ctx context.Context, ruleID string, params *model.QueryRuleStateHistory) (*v3.Series, error) {
 	step := common.MinAllowedStepInterval(params.Start, params.End)
 
-	query := fmt.Sprintf("SELECT count(*), toStartOfInterval(toDateTime(intDiv(unix_milli, 1000)), INTERVAL %d SECOND) as ts FROM %s.%s WHERE rule_id = '%s' AND (state_changed = true) AND (state = '%s') AND unix_milli >= %d AND unix_milli <= %d GROUP BY ts ORDER BY ts ASC",
-		step, signozHistoryDBName, ruleStateHistoryTableName, ruleID, model.StateFiring.String(), params.Start, params.End)
+	query := fmt.Sprintf("SELECT count(*), toStartOfInterval(toDateTime(intDiv(unix_milli, 1000)), INTERVAL %d SECOND) as ts FROM %s.%s WHERE rule_id = ? AND (state_changed = true) AND (state = ?) AND unix_milli >= ? AND unix_milli <= ? GROUP BY ts ORDER BY ts ASC",
+		step, signozHistoryDBName, ruleStateHistoryTableName)
 
-	result, err := r.GetTimeSeriesResultV3(ctx, query)
+	result, err := r.getTimeSeriesResultV3(ctx, query, ruleID, model.StateFiring.String(), params.Start, params.End)
 	if err != nil || len(result) == 0 {
 		return nil, err
 	}

--- a/pkg/query-service/app/clickhouseReader/reader_test.go
+++ b/pkg/query-service/app/clickhouseReader/reader_test.go
@@ -1,10 +1,54 @@
 package clickhouseReader
 
 import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
 	"testing"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/SigNoz/signoz/pkg/query-service/model"
 	"github.com/stretchr/testify/assert"
 )
+
+var errQueryRecorded = errors.New("query recorded")
+
+type recordedQuery struct {
+	query string
+	args  []any
+}
+
+type recordingClickHouseConn struct {
+	driver.Conn
+	queries []recordedQuery
+}
+
+func (c *recordingClickHouseConn) record(query string, args ...any) {
+	c.queries = append(c.queries, recordedQuery{query: query, args: args})
+}
+
+func (c *recordingClickHouseConn) Query(_ context.Context, query string, args ...any) (driver.Rows, error) {
+	c.record(query, args...)
+	return nil, errQueryRecorded
+}
+
+func (c *recordingClickHouseConn) QueryRow(_ context.Context, query string, args ...any) driver.Row {
+	c.record(query, args...)
+	return recordedErrorRow{}
+}
+
+func (c *recordingClickHouseConn) Select(_ context.Context, _ any, query string, args ...any) error {
+	c.record(query, args...)
+	return errQueryRecorded
+}
+
+type recordedErrorRow struct{}
+
+func (recordedErrorRow) Err() error           { return errQueryRecorded }
+func (recordedErrorRow) Scan(...any) error    { return errQueryRecorded }
+func (recordedErrorRow) ScanStruct(any) error { return errQueryRecorded }
 
 type GetStatusFiltersTest struct {
 	query        string
@@ -25,5 +69,121 @@ func TestGetStatusFilters(t *testing.T) {
 	}
 	for _, test := range tests {
 		assert.Equal(getStatusFilters(test.query, test.statusParams, test.excludeMap), test.expected)
+	}
+}
+
+func TestRuleStateHistoryQueriesBindRuleID(t *testing.T) {
+	const maliciousRuleID = "1' OR 1=1 --"
+	params := &model.QueryRuleStateHistory{
+		Start:  1,
+		End:    2,
+		Limit:  10,
+		Order:  "asc",
+		Offset: 0,
+	}
+
+	testCases := []struct {
+		name             string
+		run              func(*ClickHouseReader) error
+		ruleIDArgIndexes []int
+	}{
+		{
+			name: "last saved state",
+			run: func(reader *ClickHouseReader) error {
+				_, err := reader.GetLastSavedRuleStateHistory(context.Background(), maliciousRuleID)
+				return err
+			},
+			ruleIDArgIndexes: []int{0},
+		},
+		{
+			name: "timeline",
+			run: func(reader *ClickHouseReader) error {
+				_, err := reader.ReadRuleStateHistoryByRuleID(context.Background(), maliciousRuleID, params)
+				return err
+			},
+			ruleIDArgIndexes: []int{0},
+		},
+		{
+			name: "top contributors",
+			run: func(reader *ClickHouseReader) error {
+				_, err := reader.ReadRuleStateHistoryTopContributorsByRuleID(context.Background(), maliciousRuleID, params)
+				return err
+			},
+			ruleIDArgIndexes: []int{0},
+		},
+		{
+			name: "overall state transitions",
+			run: func(reader *ClickHouseReader) error {
+				_, err := reader.GetOverallStateTransitions(context.Background(), maliciousRuleID, params)
+				return err
+			},
+			ruleIDArgIndexes: []int{0, 3},
+		},
+		{
+			name: "average resolution time",
+			run: func(reader *ClickHouseReader) error {
+				_, err := reader.GetAvgResolutionTime(context.Background(), maliciousRuleID, params)
+				return err
+			},
+			ruleIDArgIndexes: []int{0, 3},
+		},
+		{
+			name: "average resolution time by interval",
+			run: func(reader *ClickHouseReader) error {
+				_, err := reader.GetAvgResolutionTimeByInterval(context.Background(), maliciousRuleID, params)
+				return err
+			},
+			ruleIDArgIndexes: []int{0, 3},
+		},
+		{
+			name: "total triggers",
+			run: func(reader *ClickHouseReader) error {
+				_, err := reader.GetTotalTriggers(context.Background(), maliciousRuleID, params)
+				return err
+			},
+			ruleIDArgIndexes: []int{0},
+		},
+		{
+			name: "triggers by interval",
+			run: func(reader *ClickHouseReader) error {
+				_, err := reader.GetTriggersByInterval(context.Background(), maliciousRuleID, params)
+				return err
+			},
+			ruleIDArgIndexes: []int{0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &recordingClickHouseConn{}
+			reader := &ClickHouseReader{
+				db:     conn,
+				logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+
+			err := tc.run(reader)
+			if err == nil || !strings.Contains(err.Error(), errQueryRecorded.Error()) {
+				t.Fatalf("expected recorded query error, got %v", err)
+			}
+			if len(conn.queries) != 1 {
+				t.Fatalf("expected one query, got %d", len(conn.queries))
+			}
+
+			query := conn.queries[0]
+			if strings.Contains(query.query, maliciousRuleID) {
+				t.Fatalf("rule ID was interpolated into query: %s", query.query)
+			}
+			if !strings.Contains(query.query, "rule_id = ?") {
+				t.Fatalf("query does not bind rule ID: %s", query.query)
+			}
+			for _, index := range tc.ruleIDArgIndexes {
+				if index >= len(query.args) {
+					t.Fatalf("missing rule ID argument at index %d: %#v", index, query.args)
+				}
+				if query.args[index] != maliciousRuleID {
+					t.Fatalf("expected rule ID argument at index %d, got %#v", index, query.args[index])
+				}
+			}
+		})
 	}
 }

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -797,8 +797,22 @@ func (aH *APIHandler) testRule(w http.ResponseWriter, r *http.Request) {
 	aH.Respond(w, response)
 }
 
+func validateRuleID(ruleID string) error {
+	id, err := strconv.Atoi(ruleID)
+	if err != nil || id <= 0 {
+		return fmt.Errorf("invalid rule id: must be a positive integer")
+	}
+
+	return nil
+}
+
 func (aH *APIHandler) getRuleStats(w http.ResponseWriter, r *http.Request) {
 	ruleID := mux.Vars(r)["id"]
+	if err := validateRuleID(ruleID); err != nil {
+		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)
+		return
+	}
+
 	params := model.QueryRuleStateHistory{}
 	err := json.NewDecoder(r.Body).Decode(&params)
 	if err != nil {
@@ -881,6 +895,11 @@ func (aH *APIHandler) getRuleStats(w http.ResponseWriter, r *http.Request) {
 
 func (aH *APIHandler) getOverallStateTransitions(w http.ResponseWriter, r *http.Request) {
 	ruleID := mux.Vars(r)["id"]
+	if err := validateRuleID(ruleID); err != nil {
+		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)
+		return
+	}
+
 	params := model.QueryRuleStateHistory{}
 	err := json.NewDecoder(r.Body).Decode(&params)
 	if err != nil {
@@ -898,15 +917,14 @@ func (aH *APIHandler) getOverallStateTransitions(w http.ResponseWriter, r *http.
 }
 
 func (aH *APIHandler) getRuleStateHistory(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["id"]
-	id, err := valuer.NewUUID(idStr)
-	if err != nil {
+	ruleID := mux.Vars(r)["id"]
+	if err := validateRuleID(ruleID); err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)
 		return
 	}
 
 	params := model.QueryRuleStateHistory{}
-	err = json.NewDecoder(r.Body).Decode(&params)
+	err := json.NewDecoder(r.Body).Decode(&params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)
 		return
@@ -916,67 +934,69 @@ func (aH *APIHandler) getRuleStateHistory(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	res, err := aH.reader.ReadRuleStateHistoryByRuleID(r.Context(), id.StringValue(), &params)
+	res, err := aH.reader.ReadRuleStateHistoryByRuleID(r.Context(), ruleID, &params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorInternal, Err: err}, nil)
 		return
 	}
 
-	rule, err := aH.ruleManager.GetRule(r.Context(), id)
-	if err == nil {
-		for idx := range res.Items {
-			lbls := make(map[string]string)
-			err := json.Unmarshal([]byte(res.Items[idx].Labels), &lbls)
-			if err != nil {
-				continue
-			}
-			end := time.Unix(res.Items[idx].UnixMilli/1000, 0)
-			// why are we subtracting 3 minutes?
-			// the query range is calculated based on the rule's evalWindow and evalDelay
-			// alerts have 2 minutes delay built in, so we need to subtract that from the start time
-			// to get the correct query range
-			start := end.Add(-rule.EvalWindow.Duration() - 3*time.Minute)
-			if rule.AlertType == ruletypes.AlertTypeLogs {
-				// TODO(srikanthccv): re-visit this and support multiple queries
-				var q qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]
+	if id, err := valuer.NewUUID(ruleID); err == nil {
+		rule, err := aH.ruleManager.GetRule(r.Context(), id)
+		if err == nil {
+			for idx := range res.Items {
+				lbls := make(map[string]string)
+				err := json.Unmarshal([]byte(res.Items[idx].Labels), &lbls)
+				if err != nil {
+					continue
+				}
+				end := time.Unix(res.Items[idx].UnixMilli/1000, 0)
+				// why are we subtracting 3 minutes?
+				// the query range is calculated based on the rule's evalWindow and evalDelay
+				// alerts have 2 minutes delay built in, so we need to subtract that from the start time
+				// to get the correct query range
+				start := end.Add(-rule.EvalWindow.Duration() - 3*time.Minute)
+				if rule.AlertType == ruletypes.AlertTypeLogs {
+					// TODO(srikanthccv): re-visit this and support multiple queries
+					var q qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]
 
-				for _, query := range rule.RuleCondition.CompositeQuery.Queries {
-					if query.Type == qbtypes.QueryTypeBuilder {
-						switch spec := query.Spec.(type) {
-						case qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]:
-							q = spec
+					for _, query := range rule.RuleCondition.CompositeQuery.Queries {
+						if query.Type == qbtypes.QueryTypeBuilder {
+							switch spec := query.Spec.(type) {
+							case qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]:
+								q = spec
+							}
 						}
 					}
-				}
 
-				filterExpr := ""
-				if q.Filter != nil && q.Filter.Expression != "" {
-					filterExpr = q.Filter.Expression
-				}
+					filterExpr := ""
+					if q.Filter != nil && q.Filter.Expression != "" {
+						filterExpr = q.Filter.Expression
+					}
 
-				whereClause := contextlinks.PrepareFilterExpression(lbls, filterExpr, q.GroupBy)
+					whereClause := contextlinks.PrepareFilterExpression(lbls, filterExpr, q.GroupBy)
 
-				res.Items[idx].RelatedLogsLink = contextlinks.PrepareParamsForLogsV5(start, end, whereClause).Encode()
-			} else if rule.AlertType == ruletypes.AlertTypeTraces {
-				// TODO(srikanthccv): re-visit this and support multiple queries
-				var q qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]
+					res.Items[idx].RelatedLogsLink = contextlinks.PrepareParamsForLogsV5(start, end, whereClause).Encode()
+				} else if rule.AlertType == ruletypes.AlertTypeTraces {
+					// TODO(srikanthccv): re-visit this and support multiple queries
+					var q qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]
 
-				for _, query := range rule.RuleCondition.CompositeQuery.Queries {
-					if query.Type == qbtypes.QueryTypeBuilder {
-						switch spec := query.Spec.(type) {
-						case qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]:
-							q = spec
+					for _, query := range rule.RuleCondition.CompositeQuery.Queries {
+						if query.Type == qbtypes.QueryTypeBuilder {
+							switch spec := query.Spec.(type) {
+							case qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]:
+								q = spec
+							}
 						}
 					}
-				}
 
-				filterExpr := ""
-				if q.Filter != nil && q.Filter.Expression != "" {
-					filterExpr = q.Filter.Expression
-				}
+					filterExpr := ""
+					if q.Filter != nil && q.Filter.Expression != "" {
+						filterExpr = q.Filter.Expression
+					}
 
-				whereClause := contextlinks.PrepareFilterExpression(lbls, filterExpr, q.GroupBy)
-				res.Items[idx].RelatedTracesLink = contextlinks.PrepareParamsForTracesV5(start, end, whereClause).Encode()
+					whereClause := contextlinks.PrepareFilterExpression(lbls, filterExpr, q.GroupBy)
+					res.Items[idx].RelatedTracesLink = contextlinks.PrepareParamsForTracesV5(start, end, whereClause).Encode()
+				}
 			}
 		}
 	}
@@ -985,21 +1005,20 @@ func (aH *APIHandler) getRuleStateHistory(w http.ResponseWriter, r *http.Request
 }
 
 func (aH *APIHandler) getRuleStateHistoryTopContributors(w http.ResponseWriter, r *http.Request) {
-	idStr := mux.Vars(r)["id"]
-	id, err := valuer.NewUUID(idStr)
-	if err != nil {
+	ruleID := mux.Vars(r)["id"]
+	if err := validateRuleID(ruleID); err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)
 		return
 	}
 
 	params := model.QueryRuleStateHistory{}
-	err = json.NewDecoder(r.Body).Decode(&params)
+	err := json.NewDecoder(r.Body).Decode(&params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)
 		return
 	}
 
-	res, err := aH.reader.ReadRuleStateHistoryTopContributorsByRuleID(r.Context(), id.StringValue(), &params)
+	res, err := aH.reader.ReadRuleStateHistoryTopContributorsByRuleID(r.Context(), ruleID, &params)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorInternal, Err: err}, nil)
 		return

--- a/pkg/query-service/app/http_handler_test.go
+++ b/pkg/query-service/app/http_handler_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gorilla/mux"
+
 	"github.com/SigNoz/signoz/pkg/query-service/model"
 )
 
@@ -126,6 +128,62 @@ func TestPrepareQuery(t *testing.T) {
 				if query != tc.query {
 					t.Errorf("expected query: %s, but got: %s", tc.query, query)
 				}
+			}
+		})
+	}
+}
+
+func TestValidateRuleID(t *testing.T) {
+	testCases := []struct {
+		name    string
+		ruleID  string
+		wantErr bool
+	}{
+		{name: "valid rule id", ruleID: "123"},
+		{name: "zero rule id", ruleID: "0", wantErr: true},
+		{name: "negative rule id", ruleID: "-1", wantErr: true},
+		{name: "non-numeric rule id", ruleID: "not-a-rule-id", wantErr: true},
+		{name: "sql injection payload", ruleID: "1' OR 1=1 --", wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRuleID(tc.ruleID)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAlertHistoryHandlersRejectInvalidRuleID(t *testing.T) {
+	aH := &APIHandler{}
+	handlers := []struct {
+		name    string
+		handler func(http.ResponseWriter, *http.Request)
+	}{
+		{name: "stats", handler: aH.getRuleStats},
+		{name: "overall status", handler: aH.getOverallStateTransitions},
+		{name: "timeline", handler: aH.getRuleStateHistory},
+		{name: "top contributors", handler: aH.getRuleStateHistoryTopContributors},
+	}
+
+	for _, tc := range handlers {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/rules/bad/history", strings.NewReader(`{"start":1,"end":2}`))
+			req = mux.SetURLVars(req, map[string]string{"id": "bad-id' OR 1=1 --"})
+			resp := httptest.NewRecorder()
+
+			tc.handler(resp, req)
+
+			if resp.Code != http.StatusBadRequest {
+				t.Fatalf("expected status %d, got %d", http.StatusBadRequest, resp.Code)
+			}
+			if !strings.Contains(resp.Body.String(), "invalid rule id") {
+				t.Fatalf("expected invalid rule id error, got %s", resp.Body.String())
 			}
 		})
 	}


### PR DESCRIPTION
### Summary
- validate alert history rule IDs before query execution
- parameterize ClickHouse alert history queries instead of interpolating rule IDs
- add regression tests for malformed and injection-style rule IDs

#### Related Issues / PR's
- Closes #12087

#### Screenshots
NA

#### Affected Areas and Manually Tested Areas
- Affected area: pkg/query-service alert history handlers and ClickHouse reader queries
- Tests: go test ./pkg/query-service/app ./pkg/query-service/app/clickhouseReader
- Manual verification:
  - exercised all alert history endpoints locally with a seeded temporary rule
  - confirmed valid rule requests returned 200 with alert history data
  - confirmed malformed rule IDs returned 400 with invalid rule id errors
