### PR TITLE
style(sidebar): adjust collapsed state layout shift and section name opacity

### DIFF
--- a/frontend/src/container/SideNav/SideNav.styles.scss
+++ b/frontend/src/container/SideNav/SideNav.styles.scss
@@ -268,6 +268,11 @@
 				}
 			}
 
+			.nav-divider {
+				height: 16px;
+				margin-top: 18px;
+			}
+
 			.shortcut-nav-items,
 			.more-nav-items {
 				.nav-title-section {
@@ -279,7 +284,7 @@
 				}
 
 				.nav-section-title {
-					color: var(--l1-foreground);
+					color: var(--l3-foreground);
 					font-family: Inter;
 					font-size: 11px;
 					font-style: normal;
@@ -359,6 +364,11 @@
 			.more-nav-items {
 				.nav-section-title {
 					cursor: pointer;
+					transition: color 0.2s;
+
+					&:hover {
+						color: var(--l1-foreground);
+					}
 				}
 
 				&.collapsed {
@@ -393,14 +403,6 @@
 						transition: all 0.08s ease;
 						height: auto;
 						overflow: visible;
-					}
-				}
-			}
-
-			.shortcut-nav-items {
-				&.sidebar-collapsed {
-					.nav-items-section {
-						margin-top: 0;
 					}
 				}
 			}

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -98,6 +98,7 @@ import {
 import { getActiveMenuKeyFromPath } from './sideNav.utils';
 
 import './SideNav.styles.scss';
+import { Divider } from '@signozhq/ui/divider';
 
 function SortableFilter({ item }: { item: SidebarItem }): JSX.Element {
 	const { attributes, listeners, setNodeRef, transform, transition } =
@@ -1090,6 +1091,8 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 						<div className="primary-nav-items">
 							{renderNavItems(primaryMenuItems)}
 						</div>
+
+						{isCollapsed && <Divider className="nav-divider" />}
 
 						{(pinnedMenuItems.length > 0 || !isCollapsed) && (
 							<div


### PR DESCRIPTION
### 📄 Summary
Noticed layout shift on sidebar collapsed state.. specifically the pinned items (notice in the attached video that I'm trying to open traces page, but it ends up hovering over a different item).

Also, noticed there wasn't any visual differentiation for clickable items vs section headers.


#### Screenshots / Screen Recordings (if applicable)

**Before**

https://github.com/user-attachments/assets/ffbe68a0-ed5d-447f-a5c8-21030a6b1050

**After**

https://github.com/user-attachments/assets/e9ab6237-af45-4fcb-b2d2-9e7a9f06e585


#### Issues closed by this PR
Apologies, I didn't create one since there were minor improvs.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix (maybe?)
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

Toggle "sidebar pinned" state -> ensure hovering over the sidebar doesn't cause layout shift of nav items.

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---
