### PR TITLE
feat(infrastructure-monitoring-v2): add button to open chart at metrics explorer

### DIFF
--- a/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/EntityMetrics/EntityMetrics.module.scss
+++ b/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/EntityMetrics/EntityMetrics.module.scss
@@ -14,9 +14,26 @@
 	box-sizing: border-box;
 }
 
+.entityMetricsTitleContainer {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
 .entityMetricsTitle {
 	font-size: var(--periscope-font-size-base);
 	color: var(--l2-foreground);
+}
+
+.metricsExplorerLink {
+	display: flex;
+	align-items: center;
+	color: var(--l2-foreground);
+	transition: opacity 0.2s;
+
+	&:hover {
+		color: var(--l3-foreground);
+	}
 }
 
 .metricsHeader {

--- a/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/EntityMetrics/EntityMetrics.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/EntityMetrics/EntityMetrics.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { UseQueryResult } from 'react-query';
-import { Skeleton } from 'antd';
+import { Link } from 'react-router-dom';
+import { Compass } from '@signozhq/icons';
+import { Skeleton, Tooltip } from 'antd';
 import cx from 'classnames';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import TimeSeries from 'container/DashboardContainer/visualization/charts/TimeSeries/TimeSeries';
@@ -19,6 +21,7 @@ import { GetQueryResultsProps } from 'lib/dashboard/getQueryResults';
 import { useTimezone } from 'providers/Timezone';
 import { SuccessResponse } from 'types/api';
 import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
+import { getMetricsExplorerUrl } from 'utils/explorerUtils';
 
 import { buildEntityMetricsChartConfig } from './configBuilder';
 
@@ -204,9 +207,31 @@ function EntityMetrics<T>({
 						key={entityWidgetInfo[idx].title}
 						className={styles.entityMetricsCol}
 					>
-						<span className={styles.entityMetricsTitle}>
-							{entityWidgetInfo[idx].title}
-						</span>
+						<div className={styles.entityMetricsTitleContainer}>
+							<span className={styles.entityMetricsTitle}>
+								{entityWidgetInfo[idx].title}
+							</span>
+							{queryPayloads[idx] &&
+								queryPayloads[idx].graphType !== PANEL_TYPES.TABLE && (
+									<Tooltip title="Open in Metrics Explorer">
+										<Link
+											to={getMetricsExplorerUrl({
+												query: queryPayloads[idx].query,
+												...(selectedInterval && selectedInterval !== 'custom'
+													? { relativeTime: selectedInterval }
+													: {
+															startTimeMs: timeRange.startTime * 1000,
+															endTimeMs: timeRange.endTime * 1000,
+														}),
+											})}
+											className={styles.metricsExplorerLink}
+											data-testid={`open-metrics-explorer-${idx}`}
+										>
+											<Compass size={14} />
+										</Link>
+									</Tooltip>
+								)}
+						</div>
 						<div className={styles.entityMetricsCard} ref={graphRef}>
 							{renderCardContent(query, idx)}
 						</div>

--- a/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/EntityMetrics/__tests__/EntityMetrics.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/EntityMetrics/__tests__/EntityMetrics.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { InfraMonitoringEntity } from 'container/InfraMonitoringK8sV2/constants';
 import { Time } from 'container/TopNav/DateTimeSelectionV2/types';
 import * as appContextHooks from 'providers/App/App';
@@ -295,17 +296,19 @@ const renderEntityMetrics = (overrides = {}): any => {
 	};
 
 	return render(
-		<EntityMetrics
-			timeRange={defaultProps.timeRange}
-			isModalTimeSelection={defaultProps.isModalTimeSelection}
-			handleTimeChange={defaultProps.handleTimeChange}
-			selectedInterval={defaultProps.selectedInterval}
-			entity={defaultProps.entity}
-			entityWidgetInfo={defaultProps.entityWidgetInfo}
-			getEntityQueryPayload={defaultProps.getEntityQueryPayload}
-			queryKey={defaultProps.queryKey}
-			category={defaultProps.category}
-		/>,
+		<MemoryRouter>
+			<EntityMetrics
+				timeRange={defaultProps.timeRange}
+				isModalTimeSelection={defaultProps.isModalTimeSelection}
+				handleTimeChange={defaultProps.handleTimeChange}
+				selectedInterval={defaultProps.selectedInterval}
+				entity={defaultProps.entity}
+				entityWidgetInfo={defaultProps.entityWidgetInfo}
+				getEntityQueryPayload={defaultProps.getEntityQueryPayload}
+				queryKey={defaultProps.queryKey}
+				category={defaultProps.category}
+			/>
+		</MemoryRouter>,
 	);
 };
 
@@ -334,8 +337,8 @@ const mockTableData: (import('../utils').MetricsTableData[] | null)[] = [
 ];
 
 const mockQueryPayloads = [
-	{ graphType: 'graph' }, // time_series
-	{ graphType: 'table' }, // table
+	{ graphType: 'graph', query: { queryType: 'builder' } }, // time_series
+	{ graphType: 'table', query: { queryType: 'builder' } }, // table
 ];
 
 describe('EntityMetrics', () => {
@@ -440,6 +443,34 @@ describe('EntityMetrics', () => {
 				visibilities: [true, true],
 			}),
 		);
+	});
+
+	it('renders metrics explorer link only for non-table panels', () => {
+		renderEntityMetrics();
+		expect(screen.getByTestId('open-metrics-explorer-0')).toBeInTheDocument();
+		expect(
+			screen.queryByTestId('open-metrics-explorer-1'),
+		).not.toBeInTheDocument();
+	});
+
+	it('builds metrics explorer link with relativeTime when a relative interval is selected', () => {
+		renderEntityMetrics({ selectedInterval: '5m' as Time });
+		const href = screen
+			.getByTestId('open-metrics-explorer-0')
+			.getAttribute('href');
+		expect(href).toContain('relativeTime=5m');
+		expect(href).not.toContain('startTime=');
+		expect(href).not.toContain('endTime=');
+	});
+
+	it('builds metrics explorer link with absolute time range in milliseconds for custom interval', () => {
+		renderEntityMetrics({ selectedInterval: 'custom' as Time });
+		const href = screen
+			.getByTestId('open-metrics-explorer-0')
+			.getAttribute('href');
+		expect(href).toContain(`startTime=${mockTimeRange.startTime * 1000}`);
+		expect(href).toContain(`endTime=${mockTimeRange.endTime * 1000}`);
+		expect(href).not.toContain('relativeTime=');
 	});
 
 	it('passes correct parameters to useEntityMetrics hook', () => {

--- a/frontend/src/utils/explorerUtils.ts
+++ b/frontend/src/utils/explorerUtils.ts
@@ -1,6 +1,8 @@
 import { QueryParams } from 'constants/query';
 import { PANEL_TYPES } from 'constants/queryBuilder';
+import ROUTES from 'constants/routes';
 import { ExplorerViews } from 'pages/LogsExplorer/utils';
+import { Query } from 'types/api/queryBuilder/queryBuilderData';
 
 // Mapping between panel types and explorer views
 export const panelTypeToExplorerView: Record<PANEL_TYPES, ExplorerViews> = {
@@ -50,3 +52,36 @@ export const getExplorerViewFromUrl = (
 export const getExplorerViewForPanelType = (
 	panelType: PANEL_TYPES,
 ): ExplorerViews => panelTypeToExplorerView[panelType];
+
+export interface MetricsExplorerUrlParams {
+	query: Query;
+	relativeTime?: string;
+	startTimeMs?: number;
+	endTimeMs?: number;
+}
+
+export const getMetricsExplorerUrl = ({
+	query,
+	relativeTime,
+	startTimeMs,
+	endTimeMs,
+}: MetricsExplorerUrlParams): string => {
+	const params = new URLSearchParams();
+	params.set(
+		QueryParams.compositeQuery,
+		encodeURIComponent(JSON.stringify(query)),
+	);
+
+	if (relativeTime) {
+		params.set(QueryParams.relativeTime, relativeTime);
+	} else {
+		if (startTimeMs !== undefined) {
+			params.set(QueryParams.startTime, String(startTimeMs));
+		}
+		if (endTimeMs !== undefined) {
+			params.set(QueryParams.endTime, String(endTimeMs));
+		}
+	}
+
+	return `${ROUTES.METRICS_EXPLORER_EXPLORER}?${params.toString()}`;
+};


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Add a little button at right of the title to allow see that chart at Metrics Explorer.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

https://github.com/user-attachments/assets/ca2a0533-c331-45e9-919e-b080fe3f52f8

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/engineering-pod/issues/5688

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Yes
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Infrastructure Monitoring - Details - Metrics
- Potential regressions: Unknown
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Now you can inspect each chart that are defined at the Infrastructure Monitoring at Metrics Explorer, and add them to any dashboard you want. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
