### PR TITLE
fix(llm o11y): update unpriced models tab test case

### DIFF
--- a/frontend/src/container/LLMObservability/Settings/ModelPricing/UnpricedModelsTab/__tests__/UnpricedModelsTab.test.tsx
+++ b/frontend/src/container/LLMObservability/Settings/ModelPricing/UnpricedModelsTab/__tests__/UnpricedModelsTab.test.tsx
@@ -97,13 +97,6 @@ describe('UnpricedModelsTab (integration)', () => {
 
 		await user.click(await screen.findByTestId('unpriced-map-cancel-btn'));
 
-		// Don't hold a trigger reference across the cancel click: the re-render can
-		// remount the row's cell (seen under CI timing), leaving the captured node
-		// detached. A detached node keeps its old content, so asserting on it checks
-		// a dead element instead of the real trigger — and a negative assertion
-		// passes vacuously. Re-querying inside waitFor always targets the live
-		// element, and asserting the positive end state (placeholder back) avoids
-		// the vacuous pass entirely.
 		await waitFor(() => {
 			const trigger = screen.getByTestId(`map-to-select-${MODEL}`);
 			expect(

--- a/frontend/src/container/LLMObservability/Settings/ModelPricing/UnpricedModelsTab/__tests__/UnpricedModelsTab.test.tsx
+++ b/frontend/src/container/LLMObservability/Settings/ModelPricing/UnpricedModelsTab/__tests__/UnpricedModelsTab.test.tsx
@@ -97,8 +97,9 @@ describe('UnpricedModelsTab (integration)', () => {
 
 		await user.click(await screen.findByTestId('unpriced-map-cancel-btn'));
 
-		// Re-query the trigger inside waitFor — the virtualized table can remount
-		// the row's cells on cancel, detaching any previously captured element.
+		// Re-query the trigger inside waitFor — under CI timing the row's cell can
+		// be remounted on cancel, detaching any previously captured element, and a
+		// negative assertion on a detached node passes vacuously.
 		await waitFor(() => {
 			const trigger = screen.getByTestId(`map-to-select-${MODEL}`);
 			expect(

--- a/frontend/src/container/LLMObservability/Settings/ModelPricing/UnpricedModelsTab/__tests__/UnpricedModelsTab.test.tsx
+++ b/frontend/src/container/LLMObservability/Settings/ModelPricing/UnpricedModelsTab/__tests__/UnpricedModelsTab.test.tsx
@@ -97,9 +97,13 @@ describe('UnpricedModelsTab (integration)', () => {
 
 		await user.click(await screen.findByTestId('unpriced-map-cancel-btn'));
 
-		// Re-query the trigger inside waitFor — under CI timing the row's cell can
-		// be remounted on cancel, detaching any previously captured element, and a
-		// negative assertion on a detached node passes vacuously.
+		// Don't hold a trigger reference across the cancel click: the re-render can
+		// remount the row's cell (seen under CI timing), leaving the captured node
+		// detached. A detached node keeps its old content, so asserting on it checks
+		// a dead element instead of the real trigger — and a negative assertion
+		// passes vacuously. Re-querying inside waitFor always targets the live
+		// element, and asserting the positive end state (placeholder back) avoids
+		// the vacuous pass entirely.
 		await waitFor(() => {
 			const trigger = screen.getByTestId(`map-to-select-${MODEL}`);
 			expect(

--- a/frontend/src/container/LLMObservability/Settings/ModelPricing/UnpricedModelsTab/__tests__/UnpricedModelsTab.test.tsx
+++ b/frontend/src/container/LLMObservability/Settings/ModelPricing/UnpricedModelsTab/__tests__/UnpricedModelsTab.test.tsx
@@ -89,21 +89,22 @@ describe('UnpricedModelsTab (integration)', () => {
 		await screen.findByTestId(`unpriced-model-name-${MODEL}`);
 		await selectRule(user, MODEL, 'rule-openai');
 
-		const trigger = screen.getByTestId(`map-to-select-${MODEL}`);
 		expect(
-			within(trigger).getByText('openai:gpt-4o ($3.00/$9.00)'),
+			within(screen.getByTestId(`map-to-select-${MODEL}`)).getByText(
+				'openai:gpt-4o ($3.00/$9.00)',
+			),
 		).toBeInTheDocument();
 
 		await user.click(await screen.findByTestId('unpriced-map-cancel-btn'));
 
-		await waitFor(() =>
+		// Re-query the trigger inside waitFor — the virtualized table can remount
+		// the row's cells on cancel, detaching any previously captured element.
+		await waitFor(() => {
+			const trigger = screen.getByTestId(`map-to-select-${MODEL}`);
 			expect(
-				within(trigger).queryByText('openai:gpt-4o ($3.00/$9.00)'),
-			).not.toBeInTheDocument(),
-		);
-		expect(
-			within(trigger).getByText('Select / Create a pricing model'),
-		).toBeInTheDocument();
+				within(trigger).getByText('Select / Create a pricing model'),
+			).toBeInTheDocument();
+		});
 	});
 
 	it('commits the mapping in one request when confirmed', async () => {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Fixes a flaky test in `UnpricedModelsTab.test.tsx` that fails intermittently on CI and knocks unrelated PRs out of the merge queue (e.g. the `jsci` failure on the [merge-queue run for #12029](https://github.com/SigNoz/signoz/actions/runs/29313284703/job/87021577131)).

The failing scenario — `UnpricedModelsTab › reverts the row trigger to the placeholder when the mapping is cancelled` — passes locally but fails on CI with a confusing error: the assertion can't find the placeholder text, while the DOM dump shows the old staged label still present, even though the preceding `waitFor` asserting that label was gone had just passed.

#### Issues closed by this PR

N/A — CI flake, no tracked issue.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [x] 🧪 Test-only

---

### 🐛 Bug Context

#### Fix Strategy

- Re-query the trigger by test ID **inside** `waitFor`, so every retry targets the live element regardless of whether the cell was reused or remounted.
- Assert the **positive end state** (placeholder text visible) instead of the absence of the old label, eliminating the vacuous-pass hazard of negative assertions on possibly-detached nodes.
- The pre-cancel assertion no longer holds an element reference across an `await` boundary.
- Added a comment documenting the failure mode so the pattern isn't reintroduced.

---

### 🧪 Testing Strategy

- Tests added/updated: updated the flaky assertion in `UnpricedModelsTab.test.tsx` (test-only change, no product code touched).
- Manual verification: suite run 15× consecutively locally — 15/15 green; `pnpm tsgo --noEmit`, `pnpm lint:js --quiet`, `pnpm oxlint` on the file, and `pnpm build` all clean.
- Edge cases covered: assertion is now correct in both the reused-node and remounted-node cases.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: none at runtime — single test file, no product code changed.
- Potential regressions: none; the test still verifies the same user-facing behavior (cancelling a staged mapping reverts the row trigger to the placeholder).
- Rollback plan: revert this commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | N/A |
| Change Type | Maintenance |
| Description | N/A — internal test fix |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered (test-only)

---



---
