### PR TITLE
fix(sidenav): expose running version in "Help & Support" dropdown (#11602)

### DIFF
--- a/frontend/src/container/SideNav/SideNav.styles.scss
+++ b/frontend/src/container/SideNav/SideNav.styles.scss
@@ -1141,6 +1141,43 @@
 	}
 }
 
+// Informational "SigNoz v0.x.y" entry inside the Help & Support dropdown.
+// Keeps the version visible at the standard "Help" menu like virtually
+// every native GUI application, so users have a one-click path to copy
+// the version when filing bug reports. See issue #11602.
+.help-support-dropdown {
+	.ant-dropdown-menu-item {
+		.help-support-dropdown-version {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 8px;
+			padding: 4px 0;
+
+			.help-support-dropdown-version-label {
+				color: var(--l3-foreground);
+				font-family: Inter;
+				font-size: var(--font-size-xs);
+				font-style: normal;
+				line-height: normal;
+				letter-spacing: 0.14px;
+				text-transform: uppercase;
+			}
+
+			.help-support-dropdown-version-value {
+				color: var(--l1-foreground);
+				font-family: Inter;
+				font-size: var(--font-size-xs);
+				font-style: normal;
+				font-weight: 600;
+				line-height: normal;
+				letter-spacing: 0.14px;
+				font-variant-numeric: tabular-nums;
+			}
+		}
+	}
+}
+
 .secondary-nav-items {
 	.nav-item {
 		position: relative;

--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -84,7 +84,7 @@ import { buildNavUrl, getQueryString } from './helper';
 import {
 	defaultMoreMenuItems,
 	getUserSettingsDropdownMenuItems,
-	helpSupportDropdownMenuItems as DefaultHelpSupportDropdownMenuItems,
+	buildHelpSupportDropdownMenuItems,
 	helpSupportMenuItem,
 	primaryMenuItems,
 	aiAssistantMenuItem,
@@ -161,7 +161,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 
 	const [helpSupportDropdownMenuItems, setHelpSupportDropdownMenuItems] =
 		useState<(SidebarItem | DropdownSeparator)[]>(
-			DefaultHelpSupportDropdownMenuItems,
+			buildHelpSupportDropdownMenuItems(currentVersion),
 		);
 
 	const [tempPinnedMenuItems, setTempPinnedMenuItems] = useState<SidebarItem[]>(
@@ -976,6 +976,28 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 		isCloudUser,
 		isEnterpriseSelfHostedUser,
 	]);
+
+	// Keep the Help & Support dropdown's version label in sync with the
+	// running SigNoz version. Issue #11602 — make the version visible from
+	// the most discoverable menu so users can include it in bug reports.
+	//
+	// Strategy: strip any previous version entry, then re-append the current
+	// one (if available). Preserves everything else (license, changelog, etc.)
+	// added by other effects.
+	useEffect(() => {
+		setHelpSupportDropdownMenuItems((prevState) => {
+			const withoutVersion = prevState.filter(
+				(item) =>
+					!('type' in item) ? item.itemKey !== 'version' : true,
+			);
+			if (!currentVersion) {
+				return withoutVersion;
+			}
+			const rebuilt = buildHelpSupportDropdownMenuItems(currentVersion);
+			const tail = rebuilt.slice(rebuilt.length - 2);
+			return [...withoutVersion, ...tail];
+		});
+	}, [currentVersion]);
 
 	return (
 		<div className={cx('sidenav-container', isPinned && 'pinned')}>

--- a/frontend/src/container/SideNav/__tests__/menuItems.test.tsx
+++ b/frontend/src/container/SideNav/__tests__/menuItems.test.tsx
@@ -1,4 +1,7 @@
-import { getUserSettingsDropdownMenuItems } from 'container/SideNav/menuItems';
+import {
+	buildHelpSupportDropdownMenuItems,
+	getUserSettingsDropdownMenuItems,
+} from 'container/SideNav/menuItems';
 
 const BASE_PARAMS = {
 	userEmail: 'test@signoz.io',
@@ -70,5 +73,73 @@ describe('getUserSettingsDropdownMenuItems', () => {
 		expect(keys[2]).toBe('workspace');
 		expect(keys[3]).toBe('account');
 		expect(keys[keys.length - 1]).toBe('logout');
+	});
+});
+
+describe('buildHelpSupportDropdownMenuItems', () => {
+	it('returns the standard help items without a version entry when no version is provided', () => {
+		const items = buildHelpSupportDropdownMenuItems();
+		const keys = items
+			.filter((item): item is { key: string | number } => !('type' in item))
+			.map((item) => item.key);
+
+		expect(keys).toContain('documentation');
+		expect(keys).toContain('github');
+		expect(keys).toContain('slack');
+		expect(keys).toContain('chat-support');
+		expect(keys).toContain('invite-collaborators');
+		expect(keys).not.toContain('version');
+	});
+
+	it('includes a separator + version entry at the bottom when a version is provided', () => {
+		const items = buildHelpSupportDropdownMenuItems('v0.99.0-rc.1');
+
+		// Last two entries must be divider + version so the version sits
+		// visually at the bottom of the dropdown.
+		const tail = items.slice(items.length - 2) as Array<
+			{ type?: string; key?: string | number; itemKey?: string } | undefined
+		>;
+		expect((tail[0] as { type?: string }).type).toBe('divider');
+
+		const versionEntry = tail[1] as
+			| { key?: string | number; itemKey?: string }
+			| undefined;
+		expect(versionEntry?.key).toBe('version');
+		expect(versionEntry?.itemKey).toBe('version');
+	});
+
+	it('renders the version string into the version label', () => {
+		const items = buildHelpSupportDropdownMenuItems('v0.99.0-rc.1');
+		const versionEntry = items.find(
+			(item) => !('type' in item) && item.itemKey === 'version',
+		) as { label?: unknown } | undefined;
+
+		// The label is a JSX element; assert the rendered text appears in
+		// its serialized form.
+		const serialized = JSON.stringify(versionEntry?.label);
+		expect(serialized).toContain('SigNoz');
+		expect(serialized).toContain('v0.99.0-rc.1');
+	});
+
+	it('omits the version block entirely when currentVersion is empty string', () => {
+		const items = buildHelpSupportDropdownMenuItems('');
+		const versionEntry = items.find(
+			(item) => !('type' in item) && item.itemKey === 'version',
+		);
+		expect(versionEntry).toBeUndefined();
+	});
+
+	it('preserves the original key order when version is provided', () => {
+		const items = buildHelpSupportDropdownMenuItems('v0.99.0');
+		const keys = items
+			.filter((item): item is { key: string | number } => !('type' in item))
+			.map((item) => item.key);
+
+		expect(keys[0]).toBe('documentation');
+		expect(keys[1]).toBe('github');
+		expect(keys[2]).toBe('slack');
+		expect(keys[3]).toBe('chat-support');
+		expect(keys[4]).toBe('invite-collaborators');
+		expect(keys[keys.length - 1]).toBe('version');
 	});
 });

--- a/frontend/src/container/SideNav/menuItems.tsx
+++ b/frontend/src/container/SideNav/menuItems.tsx
@@ -39,6 +39,7 @@ import {
 } from '@signozhq/icons';
 
 import {
+	DropdownSeparator,
 	SecondaryMenuItemKey,
 	SettingsNavSection,
 	SidebarItem,
@@ -426,7 +427,13 @@ export const settingsNavSections: SettingsNavSection[] = [
 	},
 ];
 
-export const helpSupportDropdownMenuItems: SidebarItem[] = [
+// Build the Help & Support dropdown items. The version label is appended
+// at the bottom (informational, non-interactive) so users have a stable,
+// conventional place to read the running SigNoz version when filing a
+// bug report — see https://github.com/SigNoz/signoz/issues/11602.
+export const buildHelpSupportDropdownMenuItems = (
+	currentVersion?: string,
+): (SidebarItem | DropdownSeparator)[] => [
 	{
 		key: 'documentation',
 		label: (
@@ -479,7 +486,37 @@ export const helpSupportDropdownMenuItems: SidebarItem[] = [
 		icon: <Plus size={14} />,
 		itemKey: 'invite-collaborators',
 	},
+	...(currentVersion
+		? [
+				{
+					type: 'divider' as const,
+				},
+				{
+					key: 'version',
+					label: (
+						<div
+							className="help-support-dropdown-version"
+							data-testid="help-support-version"
+						>
+							<span className="help-support-dropdown-version-label">
+								SigNoz
+							</span>
+							<span className="help-support-dropdown-version-value">
+								{currentVersion}
+							</span>
+						</div>
+					),
+					isPinned: false,
+					itemKey: 'version',
+				},
+			]
+		: []),
 ];
+
+// Backwards-compatible default export used in tests and as the seed state
+// when no version has been fetched yet (e.g. before /version resolves).
+export const helpSupportDropdownMenuItems: SidebarItem[] =
+	buildHelpSupportDropdownMenuItems() as SidebarItem[];
 
 export interface UserSettingsMenuItemsParams {
 	userEmail: string;


### PR DESCRIPTION
## Summary

Fixes #11602.

The current SigNoz version is rendered at the top of the sidenav next to the brand tag — but only when it works (see #11596). When users file a bug report, the instinctive place to look for the version is the "Help" menu: that is where nearly every native GUI application puts the "About" item. Today nothing in the Help & Support dropdown surfaces the version.

This change appends an informational "SigNoz <version>" entry to the bottom of the dropdown so users have a single, predictable click path to copy the version into a bug report. The entry is non-interactive (no click handler, no router navigation) and lives below a divider so the existing docs/GitHub/Slack/Chat support items stay in their original order.

## Changes

- `frontend/src/container/SideNav/menuItems.tsx` — refactor `helpSupportDropdownMenuItems` from a constant into a builder `buildHelpSupportDropdownMenuItems(currentVersion?)`. Returns the union `(SidebarItem | DropdownSeparator)[]` that `SideNav` state already accepts, and keep a stable fallback export of the original seed for tests.
- `frontend/src/container/SideNav/SideNav.tsx` — seed the dropdown from the new builder using the `currentVersion` it already pulls from `state.app`. Add a small effect that keeps the version block in sync as `/version` resolves after mount, using a strip-old + re-append strategy that preserves the existing changelog/license entries added by other effects.
- `frontend/src/container/SideNav/SideNav.styles.scss` — add rules for `.help-support-dropdown-version` (uppercase label + tabular-numerals value), matching the existing `.user-settings-dropdown-logged-in-section` visual language.
- `frontend/src/container/SideNav/__tests__/menuItems.test.tsx` — five new unit tests pinning the new contract.

## Tests

```
$ cd frontend && npx jest src/container/SideNav/__tests__/menuItems.test.tsx
PASS src/container/SideNav/__tests__/menuItems.test.tsx
Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
```

All 10 tests pass (5 existing + 5 new). No new lint warnings introduced.

## Risk

Low. Only adds menu entries at the bottom of the dropdown; never removes any existing item. The two small behavior changes (sync read on mount + stale-strip / re-append effect) are encapsulated inside `SideNav` and do not touch the changelog effect that already mutates the same state.

## Out of scope

- No backend, route, or i18n changes — frontend-only display tweak.
- The version-rendering issue tracked in #11596 (where the version at the top of the sidebar sometimes does not appear) is left untouched; that bug belongs to the brand container, not the dropdown.

## UX

The new entry sits at the bottom of the Help & Support dropdown, below a thin divider:

```
  Documentation           ↗
  GitHub                  ↗
  Community Slack         ↗
  Chat with Support
  Invite a Team Member
  ─────────────────────
  SIGNOZ          v0.99.0-rc.1
```

The label is uppercase and secondary, the value is bold and tabular, so the running version reads at a glance but does not compete with the interactive items above it.

Made with [Cursor](https://cursor.com)