### PR TITLE
fix(dashboard-v2): only refetch on-screen panels on time change/auto-refresh

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionGrid/SectionGridItem.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionGrid/SectionGridItem.tsx
@@ -10,8 +10,8 @@ const VIEWPORT_OBSERVER_OPTIONS: IntersectionObserverInit = {
 	rootMargin: '200px',
 };
 
-// Start observing after RGL's mount unfold settles, so transient off-screen
-// panels don't latch as visible.
+// Start observing after RGL's mount unfold settles, so a panel that only
+// transiently overlaps the viewport during layout doesn't fire a throwaway fetch.
 const OBSERVER_START_DELAY_MS = 350;
 
 interface SectionGridItemProps {
@@ -21,9 +21,9 @@ interface SectionGridItemProps {
 }
 
 /**
- * Lazy-loads a single panel: watches its own viewport intersection (latched) and
- * passes it to the presentational Panel as `isVisible`, so a board of many panels
- * only fetches what's on screen.
+ * Lazy-loads a single panel: tracks its live viewport intersection and passes it to
+ * the presentational Panel as `isVisible`, so a board of many panels only fetches
+ * (and refetches on time change / auto-refresh) what's on screen.
  */
 function SectionGridItem({
 	panel,
@@ -34,7 +34,9 @@ function SectionGridItem({
 	const isVisible = useIntersectionObserver(
 		containerRef,
 		VIEWPORT_OBSERVER_OPTIONS,
-		true,
+		// Not once: track the live viewport so a time change / auto-refresh only
+		// refetches on-screen panels (off-screen ones stay query-disabled).
+		false,
 		OBSERVER_START_DELAY_MS,
 	);
 	useScrollIntoView(panelId, containerRef);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useGetQueryRangeV5.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useGetQueryRangeV5.ts
@@ -57,5 +57,8 @@ export function useGetQueryRangeV5({
 		retry: retryUnlessClientError,
 		keepPreviousData,
 		cacheTime,
+		// A resolved window is immutable per key, so a panel scrolled back into view
+		// serves cache instead of refetching; a key change or manual refetch still runs.
+		staleTime: Infinity,
 	});
 }


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

On a V2 dashboard with many panels, once you've scrolled through all of them, changing the time range or an auto-refresh tick refetches **every** panel at once instead of only the ones currently on screen. This burns network + backend on off-screen work the user isn't looking at.

This PR makes lazy-loading track the *live* viewport rather than latching, so a time change / auto-refresh only refetches on-screen panels. Off-screen panels refetch lazily when scrolled back into view — the same contract the initial lazy-load already relies on.

#### Screenshots / Screen Recordings (if applicable)

N/A — behavior is observable in the network tab: before, a time change fires one `query_range` per panel on the board; after, only per on-screen panel.

#### Issues closed by this PR
Closes https://github.com/SigNoz/pulse-pod/issues/111

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

Panel visibility was *latched*. `SectionGridItem` called `useIntersectionObserver(ref, opts, /* isObserverOnce */ true, …)`, which `unobserve`s a panel the moment it first appears — so `isVisible` flips to `true` and stays `true` forever. `Panel` enables its query on `isVisible !== false`, so after the user scrolls through the whole board every panel is permanently query-enabled. A time change / auto-refresh re-keys every panel's query (`minTime`/`maxTime` are part of the query key), so react-query refetches all enabled queries — i.e. all of them. (V1's `GridCard` latches the same way, so this over-fetch exists in V1 too.)

#### Fix Strategy

- **Un-latch visibility** — `isObserverOnce` `true → false` in `SectionGridItem`, so `isVisible` reflects the live viewport. Off-screen panels report `false`, their query stays disabled, and they skip the key-change refetch; scrolling one back into view re-enables it and it fetches the current window lazily.
- **`staleTime: Infinity`** in `useGetQueryRangeV5` — a resolved `[startMs, endMs]` window is immutable per key, so re-entering a panel over an *unchanged* window serves cache instead of thrash-refetching on every scroll (without this, un-latching would introduce that regression via react-query's default `staleTime: 0` + `refetchOnMount`). Real refreshes still run: they change the key (time range / auto-refresh / variables) or go through a manual `refetch()` (retry button, editor Run), both of which bypass `staleTime`.

Panels stay mounted in the RGL DOM even off-screen, so a disabled query keeps its observer and cached data — no flash when scrolling back over an unchanged window.

---

### 🧪 Testing Strategy

- Tests added/updated: No new tests. Existing suites re-run green — `usePanelQuery` and `useScrollIntoView` (35/35). The change is a behavioral toggle on an intersection observer + a react-query option, both exercised by an integration/browser flow rather than a unit test.
- Manual verification: `pnpm tsgo --noEmit`, `oxlint`, and `pnpm build` all clean. In-browser network-tab verification against a large board recommended before merge.
- Edge cases covered: unchanged window scroll-back (cache, no refetch), off-screen panel after a time change (lazy fetch on scroll-in), editor "Run" and error "Retry" (manual refetch bypasses `staleTime`), list pagination (offset re-keys → fetch), auto-refresh under the `cacheTime: 0` OOM guard (unaffected — `staleTime` doesn't change GC).

---

### ⚠️ Risk & Impact Assessment

- Blast radius: V2 dashboard panel fetching. `useGetQueryRangeV5` is shared by the grid, the panel editor preview, and public dashboards V2; `staleTime: Infinity` is safe for all three (window is immutable per key; refresh paths change the key or refetch manually).
- Potential regressions: rapid scrolling could briefly toggle a panel's `enabled` in the 200px prefetch margin — bounded, and strictly cheaper than fetching the whole board. Off-screen panels no longer hold pre-fetched data for a new time range; they fetch on scroll-in (intended lazy semantics).
- Rollback plan: revert the commit — two isolated changes (`isObserverOnce` flag + `staleTime` option), no schema/state/migration involved.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Dashboards now refetch only on-screen panels on a time change or auto-refresh, instead of every panel that had been scrolled into view. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Two-line diff at heart: flip `isObserverOnce` to `false` and add `staleTime: Infinity`. The `staleTime` is load-bearing — without it, un-latching would make every scroll-back refetch. Worth confirming on a real board that a time change fires only visible panels' `query_range` calls, and that scrolling to an off-screen panel afterward fetches on demand.
