### PR TITLE
test(exporttypes): cover ExportRawDataFormatQueryParam defaults and validation

### DIFF
--- a/pkg/types/exporttypes/rawdataexport_test.go
+++ b/pkg/types/exporttypes/rawdataexport_test.go
@@ -1,0 +1,52 @@
+package exporttypes_test
+
+import (
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/http/binding"
+	"github.com/SigNoz/signoz/pkg/types/exporttypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportRawDataFormatQueryParamBinding(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string][]string
+		want  string
+	}{
+		{
+			name:  "missing key defaults to csv",
+			input: map[string][]string{},
+			want:  "csv",
+		},
+		{
+			name:  "format=csv is accepted",
+			input: map[string][]string{"format": {"csv"}},
+			want:  "csv",
+		},
+		{
+			name:  "format=jsonl is accepted",
+			input: map[string][]string{"format": {"jsonl"}},
+			want:  "jsonl",
+		},
+		{
+			name:  "empty value falls back to the default",
+			input: map[string][]string{"format": {""}},
+			want:  "csv",
+		},
+		{
+			name:  "uppercase FORMAT key is ignored, default applies",
+			input: map[string][]string{"FORMAT": {"jsonl"}},
+			want:  "csv",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var params exporttypes.ExportRawDataFormatQueryParam
+			require.NoError(t, binding.Query.BindQuery(tt.input, &params))
+			assert.Equal(t, tt.want, params.Format)
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds the missing unit test file for `ExportRawDataFormatQueryParam` introduced by #12055 (data export feature) and exposed at `POST /api/v1/export_raw_data`.

## Why

`pkg/types/exporttypes/rawdataexport.go` is a brand-new type shipped without any tests. The existing handler-level test in `pkg/modules/rawdataexport/implrawdataexport/handler_test.go` only verifies the empty-query default; it does not lock in:

- that `format=csv` is accepted,
- that `format=jsonl` is accepted,
- that an empty `format=` value falls back to the default, and
- that the `query` tag is case-sensitive (`FORMAT` is ignored).

Without these tests, a future refactor of the `query` / `default` tags would silently break the new `/api/v1/export_raw_data` endpoint's contract.

The new tests live alongside the type under test (Go convention), not in the consumer package, so future changes to the type automatically fail in the same package.

## How

- New file: `pkg/types/exporttypes/rawdataexport_test.go` (~50 lines)
- External test package `exporttypes_test`
- Table-driven, matches the style of the existing `metricreductionruletypes_test`
- Uses `binding.Query.BindQuery` (the same wire path the handler uses), so this exercises the real production bind path

## Test cases

| input                       | expected `Format` |
|-----------------------------|-------------------|
| (no `format` key)           | `csv`             |
| `format=csv`                | `csv`             |
| `format=jsonl`              | `jsonl`           |
| `format=` (empty value)     | `csv` (default)   |
| `FORMAT=jsonl` (uppercase)  | `csv` (default)   |

## Verification

```
gofmt -l pkg/types/exporttypes/rawdataexport_test.go   # empty
go vet ./pkg/types/exporttypes/...                      # clean
go build ./pkg/types/exporttypes/...                    # clean
go test ./pkg/types/exporttypes/...                     # 5/5 pass in <1s
go build ./...                                           # clean (whole tree)
```

## Out of scope

- No production code changes.
- No new dependencies.
- No changes to existing files.
- Enum validation (`csv` / `jsonl`) is enforced at the OpenAPI tier, not by the binder; surfacing `enum`-violation tests for this layer would require a custom unmarshaler, which is a separate piece of work.

## Related

- Feature PR: #12055
- Endeavor: addressing the test-gap pattern from #12096 (also a stale-docs/test-coverage drive-by on a newly-merged feature).
