### PR TITLE
feat: add download option to trace view

### DIFF
--- a/frontend/src/components/DownloadOptionsMenu/DownloadOptionsMenu.tsx
+++ b/frontend/src/components/DownloadOptionsMenu/DownloadOptionsMenu.tsx
@@ -3,6 +3,7 @@ import { Button, Popover, Tooltip } from 'antd';
 import { RadioGroup, RadioGroupItem } from '@signozhq/ui/radio-group';
 import { Typography } from '@signozhq/ui/typography';
 import { TelemetryFieldKey } from 'api/v5/v5';
+import { PANEL_TYPES } from 'constants/queryBuilder';
 import { useExportRawData } from 'hooks/useExportData/useServerExport';
 import { Download, LoaderCircle } from '@signozhq/icons';
 import { DataSource } from 'types/common/queryBuilder';
@@ -18,11 +19,13 @@ import './DownloadOptionsMenu.styles.scss';
 interface DownloadOptionsMenuProps {
 	dataSource: DataSource;
 	selectedColumns?: TelemetryFieldKey[];
+	panelType?: PANEL_TYPES;
 }
 
 export default function DownloadOptionsMenu({
 	dataSource,
 	selectedColumns,
+	panelType,
 }: DownloadOptionsMenuProps): JSX.Element {
 	const [exportFormat, setExportFormat] = useState<string>(DownloadFormats.CSV);
 	const [rowLimit, setRowLimit] = useState<number>(DownloadRowCounts.TEN_K);
@@ -33,6 +36,7 @@ export default function DownloadOptionsMenu({
 
 	const { isDownloading, handleExportRawData } = useExportRawData({
 		dataSource,
+		panelType,
 	});
 
 	const handleExport = useCallback(async (): Promise<void> => {

--- a/frontend/src/container/TracesExplorer/TracesView/index.tsx
+++ b/frontend/src/container/TracesExplorer/TracesView/index.tsx
@@ -11,6 +11,7 @@ import {
 import { useSelector } from 'react-redux';
 import { Typography } from '@signozhq/ui/typography';
 import logEvent from 'api/common/logEvent';
+import DownloadOptionsMenu from 'components/DownloadOptionsMenu/DownloadOptionsMenu';
 import ErrorInPlace from 'components/ErrorInPlace/ErrorInPlace';
 import { ResizeTable } from 'components/ResizeTable';
 import { ENTITY_VERSION_V5 } from 'constants/app';
@@ -152,6 +153,11 @@ function TracesView({
 					</Typography>
 
 					<div className="trace-explorer-controls">
+						<DownloadOptionsMenu
+							dataSource={DataSource.TRACES}
+							panelType={PANEL_TYPES.TRACE}
+						/>
+
 						<TraceExplorerControls
 							isLoading={isLoading}
 							totalCount={responseData?.length || 0}

--- a/frontend/src/hooks/useExportData/useServerExport.ts
+++ b/frontend/src/hooks/useExportData/useServerExport.ts
@@ -19,6 +19,7 @@ interface ExportOptions {
 
 interface UseExportRawDataProps {
 	dataSource: DataSource;
+	panelType?: PANEL_TYPES;
 }
 
 interface UseExportRawDataReturn {
@@ -28,6 +29,7 @@ interface UseExportRawDataReturn {
 
 export function useExportRawData({
 	dataSource,
+	panelType = PANEL_TYPES.LIST,
 }: UseExportRawDataProps): UseExportRawDataReturn {
 	const [isDownloading, setIsDownloading] = useState<boolean>(false);
 
@@ -83,7 +85,7 @@ export function useExportRawData({
 
 				const { queryPayload } = prepareQueryRangePayloadV5({
 					query: exportQuery,
-					graphType: PANEL_TYPES.LIST,
+					graphType: panelType,
 					selectedTime: 'GLOBAL_TIME',
 					globalSelectedInterval,
 				});
@@ -96,7 +98,7 @@ export function useExportRawData({
 				setIsDownloading(false);
 			}
 		},
-		[stagedQuery, globalSelectedInterval, dataSource],
+		[stagedQuery, globalSelectedInterval, dataSource, panelType],
 	);
 
 	return { isDownloading, handleExportRawData };


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Currently, only the List views for Logs and Traces Explorer carry the Download button. The Traces view in the Traces Explorer was lacking this.

As part of this epic: https://github.com/SigNoz/engineering-pod/issues/4682

We are adding this export button to the Traces view as well.

**Implementation**

- The backend already supports export for the traces type. We just need to import the existing DownloadOptionMenu.
- Add support to take in panelType so it does not only revert to the raw type panel.



#### Screenshots / Screen Recordings (if applicable)


<img width="2610" height="1528" alt="image" src="https://github.com/user-attachments/assets/8183fab0-279a-4c19-800f-0a21ba37a55c" />



#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.
https://github.com/SigNoz/engineering-pod/issues/5593

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only


### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | You can now download data from the Traces (root spans) view in Traces Explorer, with the same format/row-limit options as the list view. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
