### PR TITLE
fix(rules): scope alert rule store operations by org

### DIFF
--- a/pkg/query-service/rules/manager.go
+++ b/pkg/query-service/rules/manager.go
@@ -357,10 +357,7 @@ func (m *Manager) EditRule(ctx context.Context, ruleStr string, id valuer.UUID) 
 	if err != nil {
 		return err
 	}
-	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err != nil {
-		return err
-	}
+	orgID := valuer.MustNewUUID(claims.OrgID)
 	parsedRule := ruletypes.PostableRule{}
 	err = json.Unmarshal([]byte(ruleStr), &parsedRule)
 	if err != nil {
@@ -485,10 +482,7 @@ func (m *Manager) DeleteRule(ctx context.Context, idStr string) error {
 		return err
 	}
 
-	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err != nil {
-		return err
-	}
+	orgID := valuer.MustNewUUID(claims.OrgID)
 
 	_, err = m.ruleStore.GetStoredRule(ctx, orgID, id)
 	if err != nil {
@@ -891,10 +885,7 @@ func (m *Manager) GetRule(ctx context.Context, id valuer.UUID) (*ruletypes.Getta
 		return nil, err
 	}
 
-	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err != nil {
-		return nil, err
-	}
+	orgID := valuer.MustNewUUID(claims.OrgID)
 
 	s, err := m.ruleStore.GetStoredRule(ctx, orgID, id)
 	if err != nil {
@@ -961,10 +952,7 @@ func (m *Manager) PatchRule(ctx context.Context, ruleStr string, id valuer.UUID)
 		return nil, err
 	}
 
-	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err != nil {
-		return nil, err
-	}
+	orgID := valuer.MustNewUUID(claims.OrgID)
 
 	taskName := prepareTaskName(id.StringValue())
 

--- a/pkg/query-service/rules/manager.go
+++ b/pkg/query-service/rules/manager.go
@@ -372,7 +372,7 @@ func (m *Manager) EditRule(ctx context.Context, ruleStr string, id valuer.UUID) 
 	if err := m.validateChannels(ctx, claims.OrgID, &parsedRule); err != nil {
 		return err
 	}
-	existingRule, err := m.ruleStore.GetStoredRule(ctx, id)
+	existingRule, err := m.ruleStore.GetStoredRule(ctx, orgID, id)
 	if err != nil {
 		return err
 	}
@@ -485,17 +485,17 @@ func (m *Manager) DeleteRule(ctx context.Context, idStr string) error {
 		return err
 	}
 
-	_, err = m.ruleStore.GetStoredRule(ctx, id)
-	if err != nil {
-		return err
-	}
-
 	orgID, err := valuer.NewUUID(claims.OrgID)
 	if err != nil {
 		return err
 	}
 
-	return m.ruleStore.DeleteRule(ctx, id, func(ctx context.Context) error {
+	_, err = m.ruleStore.GetStoredRule(ctx, orgID, id)
+	if err != nil {
+		return err
+	}
+
+	return m.ruleStore.DeleteRule(ctx, orgID, id, func(ctx context.Context) error {
 		cfg, err := m.alertmanager.GetConfig(ctx, claims.OrgID)
 		if err != nil {
 			return err
@@ -886,7 +886,17 @@ func (m *Manager) ListRuleStates(ctx context.Context) (*ruletypes.GettableRules,
 }
 
 func (m *Manager) GetRule(ctx context.Context, id valuer.UUID) (*ruletypes.GettableRule, error) {
-	s, err := m.ruleStore.GetStoredRule(ctx, id)
+	claims, err := authtypes.ClaimsFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	orgID, err := valuer.NewUUID(claims.OrgID)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := m.ruleStore.GetStoredRule(ctx, orgID, id)
 	if err != nil {
 		return nil, err
 	}
@@ -959,7 +969,7 @@ func (m *Manager) PatchRule(ctx context.Context, ruleStr string, id valuer.UUID)
 	taskName := prepareTaskName(id.StringValue())
 
 	// retrieve rule from DB
-	storedJSON, err := m.ruleStore.GetStoredRule(ctx, id)
+	storedJSON, err := m.ruleStore.GetStoredRule(ctx, orgID, id)
 	if err != nil {
 		m.logger.ErrorContext(ctx, "failed to get stored rule with given id", slog.String("rule.id", id.StringValue()), errors.Attr(err))
 		return nil, err

--- a/pkg/ruler/rulestore/rulestoretest/rule.go
+++ b/pkg/ruler/rulestore/rulestoretest/rule.go
@@ -50,13 +50,13 @@ func (m *MockSQLRuleStore) EditRule(ctx context.Context, rule *ruletypes.Storabl
 }
 
 // DeleteRule implements ruletypes.RuleStore - delegates to underlying ruleStore to trigger SQL.
-func (m *MockSQLRuleStore) DeleteRule(ctx context.Context, id valuer.UUID, fn func(context.Context) error) error {
-	return m.ruleStore.DeleteRule(ctx, id, fn)
+func (m *MockSQLRuleStore) DeleteRule(ctx context.Context, orgID valuer.UUID, id valuer.UUID, fn func(context.Context) error) error {
+	return m.ruleStore.DeleteRule(ctx, orgID, id, fn)
 }
 
 // GetStoredRule implements ruletypes.RuleStore - delegates to underlying ruleStore to trigger SQL.
-func (m *MockSQLRuleStore) GetStoredRule(ctx context.Context, id valuer.UUID) (*ruletypes.StorableRule, error) {
-	return m.ruleStore.GetStoredRule(ctx, id)
+func (m *MockSQLRuleStore) GetStoredRule(ctx context.Context, orgID valuer.UUID, id valuer.UUID) (*ruletypes.StorableRule, error) {
+	return m.ruleStore.GetStoredRule(ctx, orgID, id)
 }
 
 // GetStoredRules implements ruletypes.RuleStore - delegates to underlying ruleStore to trigger SQL.
@@ -82,14 +82,14 @@ func (m *MockSQLRuleStore) ExpectCreateRule(rule *ruletypes.StorableRule) {
 
 // ExpectEditRule sets up SQL expectations for EditRule operation.
 func (m *MockSQLRuleStore) ExpectEditRule(rule *ruletypes.StorableRule) {
-	expectedPattern := `UPDATE "rule".+` + rule.UpdatedBy + `.+` + rule.OrgID + `.+WHERE \(id = '` + rule.ID.StringValue() + `'\)`
+	expectedPattern := `UPDATE "rule".+` + rule.UpdatedBy + `.+` + rule.OrgID + `.+WHERE \(org_id = '` + rule.OrgID + `'\) AND \(id = '` + rule.ID.StringValue() + `'\)`
 	m.mock.ExpectExec(expectedPattern).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 }
 
 // ExpectDeleteRule sets up SQL expectations for DeleteRule operation.
 func (m *MockSQLRuleStore) ExpectDeleteRule(ruleID valuer.UUID) {
-	expectedPattern := `DELETE FROM "rule".+WHERE \(id = '` + ruleID.StringValue() + `'\)`
+	expectedPattern := `DELETE FROM "rule".+WHERE \(org_id = '.+'\) AND \(id = '` + ruleID.StringValue() + `'\)`
 	m.mock.ExpectExec(expectedPattern).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 }
@@ -98,7 +98,7 @@ func (m *MockSQLRuleStore) ExpectDeleteRule(ruleID valuer.UUID) {
 func (m *MockSQLRuleStore) ExpectGetStoredRule(ruleID valuer.UUID, rule *ruletypes.StorableRule) {
 	rows := sqlmock.NewRows([]string{"id", "created_at", "updated_at", "created_by", "updated_by", "deleted", "data", "org_id"}).
 		AddRow(rule.ID, rule.CreatedAt, rule.UpdatedAt, rule.CreatedBy, rule.UpdatedBy, rule.Deleted, rule.Data, rule.OrgID)
-	expectedPattern := `SELECT (.+) FROM "rule".+WHERE \(id = '` + ruleID.StringValue() + `'\)`
+	expectedPattern := `SELECT (.+) FROM "rule".+WHERE \(org_id = '.+'\) AND \(id = '` + ruleID.StringValue() + `'\)`
 	m.mock.ExpectQuery(expectedPattern).
 		WillReturnRows(rows)
 }

--- a/pkg/ruler/rulestore/sqlrulestore/rule.go
+++ b/pkg/ruler/rulestore/sqlrulestore/rule.go
@@ -57,6 +57,7 @@ func (r *rule) EditRule(ctx context.Context, storedRule *ruletypes.StorableRule,
 			BunDBCtx(ctx).
 			NewUpdate().
 			Model(storedRule).
+			Where("org_id = ?", storedRule.OrgID).
 			Where("id = ?", storedRule.ID.StringValue()).
 			Exec(ctx)
 		if err != nil {
@@ -67,12 +68,13 @@ func (r *rule) EditRule(ctx context.Context, storedRule *ruletypes.StorableRule,
 	})
 }
 
-func (r *rule) DeleteRule(ctx context.Context, id valuer.UUID, cb func(context.Context) error) error {
+func (r *rule) DeleteRule(ctx context.Context, orgID valuer.UUID, id valuer.UUID, cb func(context.Context) error) error {
 	if err := r.sqlstore.RunInTxCtx(ctx, nil, func(ctx context.Context) error {
 		_, err := r.sqlstore.
 			BunDBCtx(ctx).
 			NewDelete().
 			Model(new(ruletypes.StorableRule)).
+			Where("org_id = ?", orgID.StringValue()).
 			Where("id = ?", id.StringValue()).
 			Exec(ctx)
 		if err != nil {
@@ -102,12 +104,13 @@ func (r *rule) GetStoredRules(ctx context.Context, orgID string) ([]*ruletypes.S
 	return rules, nil
 }
 
-func (r *rule) GetStoredRule(ctx context.Context, id valuer.UUID) (*ruletypes.StorableRule, error) {
+func (r *rule) GetStoredRule(ctx context.Context, orgID valuer.UUID, id valuer.UUID) (*ruletypes.StorableRule, error) {
 	rule := new(ruletypes.StorableRule)
 	err := r.sqlstore.
 		BunDB().
 		NewSelect().
 		Model(rule).
+		Where("org_id = ?", orgID.StringValue()).
 		Where("id = ?", id.StringValue()).
 		Scan(ctx)
 	if err != nil {

--- a/pkg/types/ruletypes/rule.go
+++ b/pkg/types/ruletypes/rule.go
@@ -56,8 +56,8 @@ type RuleAlert struct {
 type RuleStore interface {
 	CreateRule(context.Context, *StorableRule, func(context.Context, valuer.UUID) error) (valuer.UUID, error)
 	EditRule(context.Context, *StorableRule, func(context.Context) error) error
-	DeleteRule(context.Context, valuer.UUID, func(context.Context) error) error
+	DeleteRule(context.Context, valuer.UUID, valuer.UUID, func(context.Context) error) error
 	GetStoredRules(context.Context, string) ([]*StorableRule, error)
-	GetStoredRule(context.Context, valuer.UUID) (*StorableRule, error)
+	GetStoredRule(context.Context, valuer.UUID, valuer.UUID) (*StorableRule, error)
 	GetStoredRulesByMetricName(context.Context, string, string) ([]RuleAlert, error)
 }


### PR DESCRIPTION
## Summary

Fixes a cross-organization IDOR on alert rules. The rule store predicates (`pkg/ruler/rulestore/sqlrulestore/rule.go`) filtered on the rule `id` only — `GetStoredRule`, `EditRule`, and `DeleteRule` never included `org_id`, even though `StorableRule` has an `OrgID` column. The manager fetched/mutated by the URL UUID alone, and `ViewAccess`/`EditAccess` only check the caller's own-org role, never the resource's org. On multi-org deployments (Cloud / EE / multi-org self-hosted, where orgs share the instance via the noop sharder), an Org A token could read, edit, and delete Org B's alert rules by supplying the target rule UUID.

CVE: https://github.com/advisories/GHSA-h37r-3qfp-73w6
A cross-org id now resolves to `NotFound` instead of leaking or mutating another org's rule.

closes #11830