### PR TITLE
feat(infrastructure-monitoring-v2): add onboarding checks

### DIFF
--- a/frontend/src/container/InfraMonitoringHostsV2/Hosts.tsx
+++ b/frontend/src/container/InfraMonitoringHostsV2/Hosts.tsx
@@ -1,13 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button, Tooltip } from 'antd';
 import { Typography } from '@signozhq/ui/typography';
+import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import { listHosts } from 'api/generated/services/inframonitoring';
 import {
 	InframonitoringtypesHostRecordDTO,
 	InframonitoringtypesHostStatusDTO,
 	InframonitoringtypesResponseTypeDTO,
 	Querybuildertypesv5OrderDirectionDTO,
+	RenderErrorResponseDTO,
 } from 'api/generated/services/sigNoz.schemas';
+import { AxiosError } from 'axios';
+import APIError from 'types/api/error';
 import QuickFilters from 'components/QuickFilters/QuickFilters';
 import { QuickFiltersSource } from 'components/QuickFilters/types';
 import { InfraMonitoringEvents } from 'constants/events';
@@ -122,13 +126,12 @@ function Hosts(): JSX.Element {
 					endTimeBeforeRetention: data.endTimeBeforeRetention,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch hosts';
 				return {
 					type: 'list' as const,
 					records: [] as InframonitoringtypesHostRecordDTO[],
 					total: 0,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},
@@ -141,7 +144,7 @@ function Hosts(): JSX.Element {
 			signal?: AbortSignal,
 		): Promise<{
 			data: InframonitoringtypesHostRecordDTO | null;
-			error?: string | null;
+			error?: APIError | null;
 		}> => {
 			try {
 				const response = await listHosts(
@@ -159,11 +162,10 @@ function Hosts(): JSX.Element {
 					data: response.data.records.length > 0 ? response.data.records[0] : null,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch host';
 				return {
 					data: null,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/K8sBaseDetails.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/K8sBaseDetails.tsx
@@ -12,6 +12,8 @@ import { ToggleGroupSimple } from '@signozhq/ui/toggle-group';
 import { Divider } from '@signozhq/ui/divider';
 import { Typography } from '@signozhq/ui/typography';
 import logEvent from 'api/common/logEvent';
+import ErrorContent from 'components/ErrorModal/components/ErrorContent';
+import APIError from 'types/api/error';
 import { combineInitialAndUserExpression } from 'components/QueryBuilderV2/QueryV2/QuerySearch/utils';
 import { InfraMonitoringEvents } from 'constants/events';
 import { QueryParams } from 'constants/query';
@@ -86,7 +88,7 @@ export interface K8sBaseDetailsProps<T> {
 	fetchEntityData: (
 		filters: K8sDetailsFilters,
 		signal?: AbortSignal,
-	) => Promise<{ data: T | null; error?: string | null }>;
+	) => Promise<{ data: T | null; error?: APIError | null }>;
 	// Entity configuration
 	getEntityName: (entity: T) => string;
 	getInitialLogTracesExpression: (entity: T) => string;
@@ -436,12 +438,18 @@ export default function K8sBaseDetails<T>({
 			{isEntityLoading && <LoadingContainer />}
 			{(isEntityError || hasResponseError) && (
 				<div className="entity-error-container">
-					<Typography.Text color="danger">
-						{entityResponse?.error ||
-							(entityError instanceof Error
-								? entityError.message
-								: 'Failed to load entity details')}
-					</Typography.Text>
+					<ErrorContent
+						error={
+							entityResponse?.error ??
+							(entityError instanceof APIError ? entityError : null) ?? {
+								code: 500,
+								message:
+									entityError instanceof Error
+										? entityError.message
+										: 'Failed to load entity details',
+							}
+						}
+					/>
 				</div>
 			)}
 			{entity && !isEntityLoading && !hasResponseError && (

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/K8sBaseList.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/K8sBaseList.tsx
@@ -14,6 +14,7 @@ import { useGlobalTimeStore } from 'store/globalTime';
 import { NANO_SECOND_MULTIPLIER } from 'store/globalTime/utils';
 import { Querybuildertypesv5QueryWarnDataDTO } from 'api/generated/services/sigNoz.schemas';
 import { openInNewTab } from 'utils/navigation';
+import APIError from 'types/api/error';
 
 import {
 	INFRA_MONITORING_K8S_PARAMS_KEYS,
@@ -40,7 +41,7 @@ import cx from 'classnames';
 
 export type K8sBaseListEmptyStateContext = {
 	isError: boolean;
-	error?: string | null;
+	error?: APIError | null;
 	totalCount: number;
 	hasFilters: boolean;
 	isLoading: boolean;
@@ -67,7 +68,7 @@ export type K8sBaseListProps<
 		records?: T[];
 		data?: T[];
 		total: number;
-		error?: string | null;
+		error?: APIError | null;
 		rawData?: unknown;
 		endTimeBeforeRetention?: boolean;
 		warning?: Querybuildertypesv5QueryWarnDataDTO | null;

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/K8sBaseList.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/K8sBaseList.tsx
@@ -33,6 +33,7 @@ import K8sHeader from './K8sHeader';
 import { K8sPaginationWarning } from './K8sPaginationWarning';
 import { K8sBaseFilters } from './types';
 import { getGroupedByMeta } from './utils';
+import { K8sInstrumentationChecksCallout } from './components/K8sInstrumentationChecksCallout/K8sInstrumentationChecksCallout';
 
 import styles from './K8sBaseList.module.scss';
 import cx from 'classnames';
@@ -377,6 +378,8 @@ export function K8sBaseList<
 				cancelQuery={cancelQuery}
 			/>
 			<div ref={containerRef} className={styles.tableContainer}>
+				<K8sInstrumentationChecksCallout entity={entity} />
+
 				{isError && (
 					<Typography>
 						{data?.error?.toString() || 'Something went wrong'}

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/K8sEmptyState.module.scss
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/K8sEmptyState.module.scss
@@ -44,13 +44,11 @@
 	width: 32px;
 }
 
-.errorIcon {
-	color: var(--danger-background);
-}
-
-.actions {
+.errorContent {
 	display: flex;
+	flex-direction: column;
 	align-items: center;
-	gap: 8px;
-	margin-top: 16px;
+	gap: var(--spacing-3);
+	max-width: 500px;
+	padding: 24px;
 }

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/K8sEmptyState.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/K8sEmptyState.tsx
@@ -1,8 +1,4 @@
-import { useCallback } from 'react';
-import { Button } from '@signozhq/ui/button';
-import { useGetTenantLicense } from 'hooks/useGetTenantLicense';
-import history from 'lib/history';
-import { LifeBuoy, TriangleAlert } from '@signozhq/icons';
+import ErrorContent from 'components/ErrorModal/components/ErrorContent';
 
 import emptyStateUrl from '@/assets/Icons/emptyState.svg';
 import eyesEmojiUrl from '@/assets/Images/eyesEmoji.svg';
@@ -13,26 +9,12 @@ import styles from './K8sEmptyState.module.scss';
 
 type K8sEmptyStateProps = Partial<K8sBaseListEmptyStateContext>;
 
-const handleContactSupport = (isCloudUser: boolean): void => {
-	if (isCloudUser) {
-		history.push('/support');
-	} else {
-		window.open('https://signoz.io/slack', '_blank');
-	}
-};
-
 export function K8sEmptyState({
 	isError,
 	error,
 	isLoading,
 	endTimeBeforeRetention,
 }: K8sEmptyStateProps): JSX.Element | null {
-	const { isCloudUser } = useGetTenantLicense();
-
-	const handleSupport = useCallback(() => {
-		handleContactSupport(isCloudUser);
-	}, [isCloudUser]);
-
 	if (isLoading) {
 		return null;
 	}
@@ -40,25 +22,15 @@ export function K8sEmptyState({
 	if (isError || error) {
 		return (
 			<div className={styles.container}>
-				<div className={styles.content}>
-					<TriangleAlert size={32} className={styles.errorIcon} />
-					<span className={styles.message}>
-						{error || 'An error occurred while fetching data.'}
-					</span>
-					<p>
-						Our team is getting on top to resolve this. Please reach out to support if
-						the issue persists.
-					</p>
-					<div className={styles.actions}>
-						<Button
-							onClick={handleSupport}
-							variant="solid"
-							color="secondary"
-							prefix={<LifeBuoy size={14} />}
-						>
-							Contact Support
-						</Button>
-					</div>
+				<div className={styles.errorContent}>
+					<ErrorContent
+						error={
+							error ?? {
+								code: 500,
+								message: 'An error occurred while fetching data.',
+							}
+						}
+					/>
 				</div>
 			</div>
 		);

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/K8sExpandedRow.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/K8sExpandedRow.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 import { Querybuildertypesv5QueryWarnDataDTO } from 'api/generated/services/sigNoz.schemas';
 import { Button } from '@signozhq/ui/button';
 import { Typography } from '@signozhq/ui/typography';
+import APIError from 'types/api/error';
 import TanStackTable, {
 	SortState,
 	TableColumnDef,
@@ -51,7 +52,7 @@ export type K8sExpandedRowProps<T, TItemKey = string> = {
 		records?: T[];
 		data?: T[];
 		total: number;
-		error?: string | null;
+		error?: APIError | null;
 		rawData?: unknown;
 		warning?: Querybuildertypesv5QueryWarnDataDTO | null;
 	}>;

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/__tests__/K8sBaseList.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/__tests__/K8sBaseList.test.tsx
@@ -17,6 +17,7 @@ import {
 import { AppProvider } from 'providers/App/App';
 import TimezoneProvider from 'providers/Timezone';
 import store from 'store';
+import APIError from 'types/api/error';
 import { openInNewTab } from 'utils/navigation';
 
 import { TableColumnDef } from 'components/TanStackTableView';
@@ -630,7 +631,15 @@ describe('K8sBaseList', () => {
 			fetchListDataMock.mockResolvedValue({
 				data: [],
 				total: 0,
-				error: 'Failed to fetch pods',
+				error: new APIError({
+					httpStatusCode: 500,
+					error: {
+						code: '500',
+						message: 'Failed to fetch pods',
+						url: '',
+						errors: [],
+					},
+				}),
 			});
 
 			renderComponent<TestItem>({

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/__tests__/K8sBaseList.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/__tests__/K8sBaseList.test.tsx
@@ -9,6 +9,8 @@ import { TooltipProvider } from '@signozhq/ui/tooltip';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { InfraMonitoringEvents } from 'constants/events';
+import { server } from 'mocks-server/server';
+import { rest } from 'msw';
 import {
 	NuqsTestingAdapter,
 	OnUrlUpdateFunction,
@@ -1061,6 +1063,306 @@ describe('K8sBaseList', () => {
 			expect(url).toContain(`selectedItem=PodId%3A${itemId}`);
 			expect(url).not.toContain('selectedItemClusterName');
 			expect(url).not.toContain('selectedItemNamespaceName');
+		});
+	});
+
+	describe('instrumentation checks callout', () => {
+		const fetchListDataMock = jest.fn<
+			ReturnType<NonNullable<K8sBaseListProps<TestItem>['fetchListData']>>,
+			Parameters<NonNullable<K8sBaseListProps<TestItem>['fetchListData']>>
+		>();
+
+		beforeEach(() => {
+			fetchListDataMock.mockClear();
+			fetchListDataMock.mockResolvedValue({
+				data: [{ id: 'item-1' }],
+				total: 1,
+				error: null,
+			});
+		});
+
+		it('should not render callout when ready is true', async () => {
+			server.use(
+				rest.get('http://localhost/api/v2/infra_monitoring/checks', (_, res, ctx) =>
+					res(
+						ctx.json({
+							status: 'success',
+							data: {
+								ready: true,
+								type: 'pods',
+								presentDefaultEnabledMetrics: [
+									{
+										associatedComponent: { name: 'otel-collector' },
+										metrics: ['k8s.pod.cpu.usage'],
+									},
+								],
+							},
+						}),
+					),
+				),
+			);
+
+			renderComponent<TestItem>({
+				entity: InfraMonitoringEntity.PODS,
+				eventCategory: InfraMonitoringEvents.Pod,
+				fetchListData: fetchListDataMock,
+				tableColumns: createTestColumns(),
+				getRowKey: (row): string => row.id,
+				getItemKey: (row): string => row.id,
+			});
+
+			await screen.findByText('item-1');
+
+			expect(screen.queryByText('Instrumentation checks')).not.toBeInTheDocument();
+		});
+
+		it('should not render callout when no entries exist', async () => {
+			server.use(
+				rest.get('http://localhost/api/v2/infra_monitoring/checks', (_, res, ctx) =>
+					res(
+						ctx.json({
+							status: 'success',
+							data: {
+								ready: false,
+								type: 'pods',
+								presentDefaultEnabledMetrics: null,
+								presentOptionalMetrics: null,
+								presentRequiredAttributes: null,
+								missingDefaultEnabledMetrics: null,
+								missingOptionalMetrics: null,
+								missingRequiredAttributes: null,
+							},
+						}),
+					),
+				),
+			);
+
+			renderComponent<TestItem>({
+				entity: InfraMonitoringEntity.PODS,
+				eventCategory: InfraMonitoringEvents.Pod,
+				fetchListData: fetchListDataMock,
+				tableColumns: createTestColumns(),
+				getRowKey: (row): string => row.id,
+				getItemKey: (row): string => row.id,
+			});
+
+			await screen.findByText('item-1');
+
+			expect(screen.queryByText('Instrumentation checks')).not.toBeInTheDocument();
+		});
+
+		it('should render callout with present entries', async () => {
+			server.use(
+				rest.get('http://localhost/api/v2/infra_monitoring/checks', (_, res, ctx) =>
+					res(
+						ctx.json({
+							status: 'success',
+							data: {
+								ready: false,
+								type: 'pods',
+								presentDefaultEnabledMetrics: [
+									{
+										associatedComponent: { name: 'otel-collector' },
+										metrics: ['k8s.pod.cpu.usage', 'k8s.pod.memory.usage'],
+									},
+								],
+								presentOptionalMetrics: null,
+								presentRequiredAttributes: null,
+								missingDefaultEnabledMetrics: null,
+								missingOptionalMetrics: null,
+								missingRequiredAttributes: null,
+							},
+						}),
+					),
+				),
+			);
+
+			renderComponent<TestItem>({
+				entity: InfraMonitoringEntity.PODS,
+				eventCategory: InfraMonitoringEvents.Pod,
+				fetchListData: fetchListDataMock,
+				tableColumns: createTestColumns(),
+				getRowKey: (row): string => row.id,
+				getItemKey: (row): string => row.id,
+			});
+
+			await screen.findByText('Instrumentation checks');
+
+			await expect(
+				screen.findByText('Default enabled metrics'),
+			).resolves.toBeInTheDocument();
+			await expect(
+				screen.findByText('k8s.pod.cpu.usage, k8s.pod.memory.usage'),
+			).resolves.toBeInTheDocument();
+			await expect(
+				screen.findByText('otel-collector'),
+			).resolves.toBeInTheDocument();
+		});
+
+		it('should render callout with missing entries', async () => {
+			server.use(
+				rest.get('http://localhost/api/v2/infra_monitoring/checks', (_, res, ctx) =>
+					res(
+						ctx.json({
+							status: 'success',
+							data: {
+								ready: false,
+								type: 'pods',
+								presentDefaultEnabledMetrics: null,
+								presentOptionalMetrics: null,
+								presentRequiredAttributes: null,
+								missingDefaultEnabledMetrics: [
+									{
+										associatedComponent: { name: 'otel-collector' },
+										metrics: ['k8s.pod.cpu.limit'],
+										documentationLink: 'https://example.com/docs',
+									},
+								],
+								missingOptionalMetrics: null,
+								missingRequiredAttributes: null,
+							},
+						}),
+					),
+				),
+			);
+
+			renderComponent<TestItem>({
+				entity: InfraMonitoringEntity.PODS,
+				eventCategory: InfraMonitoringEvents.Pod,
+				fetchListData: fetchListDataMock,
+				tableColumns: createTestColumns(),
+				getRowKey: (row): string => row.id,
+				getItemKey: (row): string => row.id,
+			});
+
+			await screen.findByText('Instrumentation checks');
+
+			await expect(
+				screen.findByText('Missing default metrics'),
+			).resolves.toBeInTheDocument();
+			await expect(
+				screen.findByText('k8s.pod.cpu.limit'),
+			).resolves.toBeInTheDocument();
+			await expect(screen.findByText('Learn here')).resolves.toBeInTheDocument();
+		});
+
+		it('should trigger recheck on button click', async () => {
+			let recheckCallCount = 0;
+			server.use(
+				rest.get(
+					'http://localhost/api/v2/infra_monitoring/checks',
+					(_, res, ctx) => {
+						recheckCallCount++;
+						return res(
+							ctx.json({
+								status: 'success',
+								data: {
+									ready: false,
+									type: 'pods',
+									presentDefaultEnabledMetrics: [
+										{
+											associatedComponent: { name: 'otel-collector' },
+											metrics: ['k8s.pod.cpu.usage'],
+										},
+									],
+								},
+							}),
+						);
+					},
+				),
+			);
+
+			const user = userEvent.setup();
+
+			renderComponent<TestItem>({
+				entity: InfraMonitoringEntity.PODS,
+				eventCategory: InfraMonitoringEvents.Pod,
+				fetchListData: fetchListDataMock,
+				tableColumns: createTestColumns(),
+				getRowKey: (row): string => row.id,
+				getItemKey: (row): string => row.id,
+			});
+
+			await screen.findByText('Instrumentation checks');
+
+			const initialCallCount = recheckCallCount;
+
+			const recheckBtn = screen.getByTestId('instrumentation-checks-recheck-btn');
+			await user.click(recheckBtn);
+
+			await waitFor(() => {
+				expect(recheckCallCount).toBeGreaterThan(initialCallCount);
+			});
+		});
+
+		it('should render both present and missing entries', async () => {
+			server.use(
+				rest.get('http://localhost/api/v2/infra_monitoring/checks', (_, res, ctx) =>
+					res(
+						ctx.json({
+							status: 'success',
+							data: {
+								ready: false,
+								type: 'pods',
+								presentDefaultEnabledMetrics: [
+									{
+										associatedComponent: { name: 'otel-collector' },
+										metrics: ['k8s.pod.cpu.usage'],
+									},
+								],
+								presentOptionalMetrics: null,
+								presentRequiredAttributes: [
+									{
+										associatedComponent: { name: 'otel-collector' },
+										attributes: ['k8s.namespace.name'],
+									},
+								],
+								missingDefaultEnabledMetrics: [
+									{
+										associatedComponent: { name: 'otel-collector' },
+										metrics: ['k8s.pod.memory.limit'],
+									},
+								],
+								missingOptionalMetrics: null,
+								missingRequiredAttributes: null,
+							},
+						}),
+					),
+				),
+			);
+
+			renderComponent<TestItem>({
+				entity: InfraMonitoringEntity.PODS,
+				eventCategory: InfraMonitoringEvents.Pod,
+				fetchListData: fetchListDataMock,
+				tableColumns: createTestColumns(),
+				getRowKey: (row): string => row.id,
+				getItemKey: (row): string => row.id,
+			});
+
+			await screen.findByText('Instrumentation checks');
+
+			// Present entries
+			await expect(
+				screen.findByText('Default enabled metrics'),
+			).resolves.toBeInTheDocument();
+			await expect(
+				screen.findByText('k8s.pod.cpu.usage'),
+			).resolves.toBeInTheDocument();
+			await expect(
+				screen.findByText('Required attributes'),
+			).resolves.toBeInTheDocument();
+			await expect(
+				screen.findByText('k8s.namespace.name'),
+			).resolves.toBeInTheDocument();
+
+			// Missing entries
+			await expect(
+				screen.findByText('Missing default metrics'),
+			).resolves.toBeInTheDocument();
+			await expect(
+				screen.findByText('k8s.pod.memory.limit'),
+			).resolves.toBeInTheDocument();
 		});
 	});
 });

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/K8sInstrumentationChecksCallout.module.scss
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/K8sInstrumentationChecksCallout.module.scss
@@ -1,0 +1,24 @@
+.checkContainer {
+	padding: 0px var(--spacing-4) var(--spacing-4) var(--spacing-4);
+
+	position: relative;
+}
+
+.container {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	width: 100%;
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.entriesList {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/K8sInstrumentationChecksCallout.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/K8sInstrumentationChecksCallout.tsx
@@ -1,0 +1,162 @@
+import { MouseEvent, useCallback, useMemo, useState } from 'react';
+import { useQueryClient } from 'react-query';
+import { Button } from '@signozhq/ui/button';
+import { Callout } from '@signozhq/ui/callout';
+import { RefreshCw } from '@signozhq/icons';
+import setLocalStorage from 'api/browser/localstorage/set';
+import {
+	invalidateGetChecks,
+	useGetChecks,
+} from 'api/generated/services/inframonitoring';
+import { InframonitoringtypesCheckTypeDTO } from 'api/generated/services/sigNoz.schemas';
+import { InfraMonitoringEntity } from '../../../constants';
+
+import styles from './K8sInstrumentationChecksCallout.module.scss';
+import { MissingEntryRow } from './MissingEntryRow';
+import { PresentEntryRow } from './PresentEntryRow';
+import {
+	ENTITY_TO_CHECK_TYPE,
+	getStorageKey,
+	hasAnyEntries,
+	hasMissingEntries,
+	readExpandedState,
+} from './utils';
+
+export interface InstrumentationChecksCalloutProps {
+	entity: InfraMonitoringEntity;
+}
+
+export function K8sInstrumentationChecksCallout({
+	entity,
+}: InstrumentationChecksCalloutProps): JSX.Element | null {
+	const checkType = ENTITY_TO_CHECK_TYPE[entity];
+	const queryClient = useQueryClient();
+
+	const [isExpanded, setIsExpanded] = useState(() => readExpandedState(entity));
+
+	const { data, isLoading, isFetching } = useGetChecks(
+		{ type: checkType as InframonitoringtypesCheckTypeDTO },
+		{ query: { enabled: !!checkType } },
+	);
+
+	const handleRecheck = useCallback(
+		(e: MouseEvent): void => {
+			e.preventDefault();
+			e.stopPropagation();
+
+			if (checkType) {
+				void invalidateGetChecks(queryClient, { type: checkType });
+			}
+		},
+		[queryClient, checkType],
+	);
+
+	const handleExpandToggle = useCallback((): void => {
+		setIsExpanded((prev) => {
+			const next = !prev;
+			setLocalStorage(getStorageKey(entity), String(next));
+			return next;
+		});
+	}, [entity]);
+
+	const checksData = data?.data;
+
+	const hasMissingItems = useMemo(
+		() => (checksData ? hasMissingEntries(checksData) : false),
+		[checksData],
+	);
+
+	if (!checkType || isLoading) {
+		return null;
+	}
+
+	if (!checksData || checksData.ready) {
+		return null;
+	}
+
+	if (!hasAnyEntries(checksData)) {
+		return null;
+	}
+
+	return (
+		<div className={styles.checkContainer}>
+			<Callout
+				type={hasMissingItems ? 'warning' : 'info'}
+				showIcon
+				size="medium"
+				title={
+					<div className={styles.header}>
+						Instrumentation checks
+						<Button
+							variant="outlined"
+							color="warning"
+							size="sm"
+							onClick={handleRecheck}
+							loading={isFetching}
+							prefix={<RefreshCw size={12} />}
+							data-testid="instrumentation-checks-recheck-btn"
+						>
+							Recheck
+						</Button>
+					</div>
+				}
+				action="expandable"
+				defaultExpanded={isExpanded}
+				onClick={handleExpandToggle}
+			>
+				<div className={styles.container} onClick={(e) => e.stopPropagation()}>
+					<div className={styles.entriesList}>
+						{checksData.presentDefaultEnabledMetrics?.map((entry) => (
+							<PresentEntryRow
+								key={`present-default-${entry.associatedComponent.name}`}
+								entry={entry}
+								typeLabel="Default enabled metrics"
+								itemType="metrics"
+							/>
+						))}
+						{checksData.presentOptionalMetrics?.map((entry) => (
+							<PresentEntryRow
+								key={`present-optional-${entry.associatedComponent.name}`}
+								entry={entry}
+								typeLabel="Optional metrics"
+								itemType="metrics"
+							/>
+						))}
+						{checksData.presentRequiredAttributes?.map((entry) => (
+							<PresentEntryRow
+								key={`present-attrs-${entry.associatedComponent.name}`}
+								entry={entry}
+								typeLabel="Required attributes"
+								itemType="attributes"
+							/>
+						))}
+						{checksData.missingDefaultEnabledMetrics?.map((entry) => (
+							<MissingEntryRow
+								key={`missing-default-${entry.associatedComponent.name}`}
+								entry={entry}
+								typeLabel="Missing default metrics"
+								itemType="metrics"
+							/>
+						))}
+						{checksData.missingOptionalMetrics?.map((entry) => (
+							<MissingEntryRow
+								key={`missing-optional-${entry.associatedComponent.name}`}
+								entry={entry}
+								typeLabel="Missing optional metrics"
+								itemType="metrics"
+							/>
+						))}
+						{checksData.missingRequiredAttributes?.map((entry) => (
+							<MissingEntryRow
+								key={`missing-attrs-${entry.associatedComponent.name}`}
+								entry={entry}
+								typeLabel="Missing required attributes"
+								itemType="attributes"
+							/>
+						))}
+					</div>
+				</div>
+			</Callout>
+		</div>
+	);
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/MissingEntryRow.module.scss
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/MissingEntryRow.module.scss
@@ -1,0 +1,27 @@
+.entryRow {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-wrap: wrap;
+	color: var(--l1-foreground);
+}
+
+.missingIcon {
+	color: var(--warning-background);
+	flex-shrink: 0;
+}
+
+.learnMoreLink {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	margin-left: 4px;
+
+	svg {
+		margin-left: 4px;
+	}
+}
+
+.divider {
+	--divider-color: var(--callout-warning-border);
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/MissingEntryRow.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/MissingEntryRow.tsx
@@ -1,0 +1,66 @@
+import styles from './MissingEntryRow.module.scss';
+import { ExternalLink, TriangleAlert } from '@signozhq/icons';
+import { Typography } from '@signozhq/ui/typography';
+import { Divider } from '@signozhq/ui/divider';
+import type {
+	InframonitoringtypesMissingAttributesComponentEntryDTO,
+	InframonitoringtypesMissingMetricsComponentEntryDTO,
+} from 'api/generated/services/sigNoz.schemas';
+
+type MissingEntryRowProps =
+	| {
+			entry: InframonitoringtypesMissingMetricsComponentEntryDTO;
+			typeLabel: string;
+			itemType: 'metrics';
+	  }
+	| {
+			entry: InframonitoringtypesMissingAttributesComponentEntryDTO;
+			typeLabel: string;
+			itemType: 'attributes';
+	  };
+
+export function MissingEntryRow({
+	entry,
+	typeLabel,
+	itemType,
+}: MissingEntryRowProps): JSX.Element {
+	const items = itemType === 'metrics' ? entry.metrics : entry.attributes;
+
+	return (
+		<div className={styles.entryRow}>
+			<TriangleAlert size={14} className={styles.missingIcon} />
+			<Typography.Text size="base" weight="medium">
+				{typeLabel}
+			</Typography.Text>
+			<Typography.Text size="base" color="muted">
+				-
+			</Typography.Text>
+			<Typography.Text
+				size="base"
+				weight="semibold"
+				className={styles.entryRowMetric}
+			>
+				{items?.join(', ')}
+			</Typography.Text>
+			<Typography.Text size="base" color="muted">
+				-
+			</Typography.Text>
+			<Typography.Text size="base" italic color="muted">
+				{entry.associatedComponent.name}
+			</Typography.Text>
+			{entry.documentationLink && (
+				<Typography.Link
+					href={entry.documentationLink}
+					target="_blank"
+					rel="noopener noreferrer"
+					size="base"
+					className={styles.learnMoreLink}
+				>
+					Learn here
+					<ExternalLink size={12} />
+				</Typography.Link>
+			)}
+			<Divider className={styles.divider} />
+		</div>
+	);
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/PresentEntryRow.module.scss
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/PresentEntryRow.module.scss
@@ -1,0 +1,16 @@
+.entryRow {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-wrap: wrap;
+	color: var(--l1-foreground);
+}
+
+.presentIcon {
+	color: var(--success-background);
+	flex-shrink: 0;
+}
+
+.divider {
+	--divider-color: var(--callout-warning-border);
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/PresentEntryRow.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/PresentEntryRow.tsx
@@ -1,0 +1,54 @@
+import styles from './PresentEntryRow.module.scss';
+import { CircleCheck } from '@signozhq/icons';
+import { Typography } from '@signozhq/ui/typography';
+import { Divider } from '@signozhq/ui/divider';
+import type {
+	InframonitoringtypesAttributesComponentEntryDTO,
+	InframonitoringtypesMetricsComponentEntryDTO,
+} from 'api/generated/services/sigNoz.schemas';
+
+type PresentEntryRowProps =
+	| {
+			entry: InframonitoringtypesMetricsComponentEntryDTO;
+			typeLabel: string;
+			itemType: 'metrics';
+	  }
+	| {
+			entry: InframonitoringtypesAttributesComponentEntryDTO;
+			typeLabel: string;
+			itemType: 'attributes';
+	  };
+
+export function PresentEntryRow({
+	entry,
+	typeLabel,
+	itemType,
+}: PresentEntryRowProps): JSX.Element {
+	const items = itemType === 'metrics' ? entry.metrics : entry.attributes;
+
+	return (
+		<div className={styles.entryRow}>
+			<CircleCheck size={14} className={styles.presentIcon} />
+			<Typography.Text size="base" weight="medium">
+				{typeLabel}
+			</Typography.Text>
+			<Typography.Text size="base" color="muted">
+				-
+			</Typography.Text>
+			<Typography.Text
+				size="base"
+				weight="semibold"
+				className={styles.entryRowMetric}
+			>
+				{items?.join(', ')}
+			</Typography.Text>
+			<Typography.Text size="base" color="muted">
+				-
+			</Typography.Text>
+			<Typography.Text size="base" italic color="muted">
+				{entry.associatedComponent.name}
+			</Typography.Text>
+			<Divider className={styles.divider} />
+		</div>
+	);
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/utils.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/components/K8sInstrumentationChecksCallout/utils.tsx
@@ -1,0 +1,60 @@
+import getLocalStorage from 'api/browser/localstorage/get';
+import {
+	InframonitoringtypesChecksDTO,
+	InframonitoringtypesCheckTypeDTO,
+} from 'api/generated/services/sigNoz.schemas';
+import { InfraMonitoringEntity } from '../../../constants';
+
+export const ENTITY_TO_CHECK_TYPE: Record<
+	InfraMonitoringEntity,
+	InframonitoringtypesCheckTypeDTO
+> = {
+	[InfraMonitoringEntity.HOSTS]: InframonitoringtypesCheckTypeDTO.hosts,
+	[InfraMonitoringEntity.PODS]: InframonitoringtypesCheckTypeDTO.pods,
+	[InfraMonitoringEntity.NODES]: InframonitoringtypesCheckTypeDTO.nodes,
+	[InfraMonitoringEntity.NAMESPACES]:
+		InframonitoringtypesCheckTypeDTO.namespaces,
+	[InfraMonitoringEntity.CLUSTERS]: InframonitoringtypesCheckTypeDTO.clusters,
+	[InfraMonitoringEntity.DEPLOYMENTS]:
+		InframonitoringtypesCheckTypeDTO.deployments,
+	[InfraMonitoringEntity.STATEFULSETS]:
+		InframonitoringtypesCheckTypeDTO.statefulsets,
+	[InfraMonitoringEntity.DAEMONSETS]:
+		InframonitoringtypesCheckTypeDTO.daemonsets,
+	[InfraMonitoringEntity.JOBS]: InframonitoringtypesCheckTypeDTO.jobs,
+	[InfraMonitoringEntity.VOLUMES]: InframonitoringtypesCheckTypeDTO.volumes,
+	[InfraMonitoringEntity.CONTAINERS]:
+		InframonitoringtypesCheckTypeDTO.kube_containers,
+};
+
+export function hasMissingEntries(
+	data: InframonitoringtypesChecksDTO,
+): boolean {
+	return (
+		(data.missingDefaultEnabledMetrics?.length ?? 0) > 0 ||
+		(data.missingOptionalMetrics?.length ?? 0) > 0 ||
+		(data.missingRequiredAttributes?.length ?? 0) > 0
+	);
+}
+
+export function hasAnyEntries(data: InframonitoringtypesChecksDTO): boolean {
+	return (
+		(data.presentDefaultEnabledMetrics?.length ?? 0) > 0 ||
+		(data.presentOptionalMetrics?.length ?? 0) > 0 ||
+		(data.presentRequiredAttributes?.length ?? 0) > 0 ||
+		(data.missingDefaultEnabledMetrics?.length ?? 0) > 0 ||
+		(data.missingOptionalMetrics?.length ?? 0) > 0 ||
+		(data.missingRequiredAttributes?.length ?? 0) > 0
+	);
+}
+
+const STORAGE_PREFIX = '@signozhq/k8s-instrumentation-checks-expanded';
+
+export function getStorageKey(entity: InfraMonitoringEntity): string {
+	return `${STORAGE_PREFIX}-${entity}`;
+}
+
+export function readExpandedState(entity: InfraMonitoringEntity): boolean {
+	const stored = getLocalStorage(getStorageKey(entity));
+	return stored === null ? true : stored === 'true';
+}

--- a/frontend/src/container/InfraMonitoringK8sV2/Clusters/K8sClustersList.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Clusters/K8sClustersList.tsx
@@ -1,11 +1,15 @@
 import { useCallback } from 'react';
+import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import { listClusters } from 'api/generated/services/inframonitoring';
+import { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
+import { AxiosError } from 'axios';
 import {
 	InframonitoringtypesClusterRecordDTO,
 	InframonitoringtypesResponseTypeDTO,
 	Querybuildertypesv5OrderDirectionDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { InfraMonitoringEvents } from 'constants/events';
+import APIError from 'types/api/error';
 
 import K8sBaseDetails, { K8sDetailsFilters } from '../Base/K8sBaseDetails';
 import { K8sBaseList } from '../Base/K8sBaseList';
@@ -67,13 +71,12 @@ function K8sClustersList({
 					warning: data.warning,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch clusters';
 				return {
 					type: 'list' as const,
 					records: [] as InframonitoringtypesClusterRecordDTO[],
 					total: 0,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},
@@ -86,7 +89,7 @@ function K8sClustersList({
 			signal?: AbortSignal,
 		): Promise<{
 			data: InframonitoringtypesClusterRecordDTO | null;
-			error?: string | null;
+			error?: APIError | null;
 		}> => {
 			try {
 				const response = await listClusters(
@@ -104,11 +107,10 @@ function K8sClustersList({
 					data: response.data.records.length > 0 ? response.data.records[0] : null,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch cluster';
 				return {
 					data: null,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},

--- a/frontend/src/container/InfraMonitoringK8sV2/DaemonSets/K8sDaemonSetsList.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/DaemonSets/K8sDaemonSetsList.tsx
@@ -1,11 +1,15 @@
 import { useCallback } from 'react';
+import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import { listDaemonSets } from 'api/generated/services/inframonitoring';
+import { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
+import { AxiosError } from 'axios';
 import {
 	InframonitoringtypesDaemonSetRecordDTO,
 	InframonitoringtypesResponseTypeDTO,
 	Querybuildertypesv5OrderDirectionDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { InfraMonitoringEvents } from 'constants/events';
+import APIError from 'types/api/error';
 import K8sBaseDetails, { K8sDetailsFilters } from '../Base/K8sBaseDetails';
 import { K8sBaseList } from '../Base/K8sBaseList';
 import { K8sBaseFilters } from '../Base/types';
@@ -65,13 +69,12 @@ function K8sDaemonSetsList({
 					warning: data.warning,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch daemonsets';
 				return {
 					type: 'list' as const,
 					records: [] as InframonitoringtypesDaemonSetRecordDTO[],
 					total: 0,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},
@@ -83,7 +86,7 @@ function K8sDaemonSetsList({
 			signal?: AbortSignal,
 		): Promise<{
 			data: InframonitoringtypesDaemonSetRecordDTO | null;
-			error?: string | null;
+			error?: APIError | null;
 		}> => {
 			try {
 				const response = await listDaemonSets(
@@ -100,11 +103,10 @@ function K8sDaemonSetsList({
 					data: response.data.records.length > 0 ? response.data.records[0] : null,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch daemonset';
 				return {
 					data: null,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},

--- a/frontend/src/container/InfraMonitoringK8sV2/Deployments/K8sDeploymentsList.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Deployments/K8sDeploymentsList.tsx
@@ -1,11 +1,15 @@
 import { useCallback } from 'react';
+import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import { listDeployments } from 'api/generated/services/inframonitoring';
+import { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
+import { AxiosError } from 'axios';
 import {
 	InframonitoringtypesDeploymentRecordDTO,
 	InframonitoringtypesResponseTypeDTO,
 	Querybuildertypesv5OrderDirectionDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { InfraMonitoringEvents } from 'constants/events';
+import APIError from 'types/api/error';
 
 import K8sBaseDetails, { K8sDetailsFilters } from '../Base/K8sBaseDetails';
 import { K8sBaseList } from '../Base/K8sBaseList';
@@ -68,13 +72,12 @@ function K8sDeploymentsList({
 					warning: data.warning,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch deployments';
 				return {
 					type: 'list' as const,
 					records: [] as InframonitoringtypesDeploymentRecordDTO[],
 					total: 0,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},
@@ -87,7 +90,7 @@ function K8sDeploymentsList({
 			signal?: AbortSignal,
 		): Promise<{
 			data: InframonitoringtypesDeploymentRecordDTO | null;
-			error?: string | null;
+			error?: APIError | null;
 		}> => {
 			try {
 				const response = await listDeployments(
@@ -105,11 +108,10 @@ function K8sDeploymentsList({
 					data: response.data.records.length > 0 ? response.data.records[0] : null,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch deployment';
 				return {
 					data: null,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},

--- a/frontend/src/container/InfraMonitoringK8sV2/Jobs/K8sJobsList.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Jobs/K8sJobsList.tsx
@@ -1,11 +1,15 @@
 import { useCallback } from 'react';
+import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import { listJobs } from 'api/generated/services/inframonitoring';
+import { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
+import { AxiosError } from 'axios';
 import {
 	InframonitoringtypesJobRecordDTO,
 	InframonitoringtypesResponseTypeDTO,
 	Querybuildertypesv5OrderDirectionDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { InfraMonitoringEvents } from 'constants/events';
+import APIError from 'types/api/error';
 
 import K8sBaseDetails, { K8sDetailsFilters } from '../Base/K8sBaseDetails';
 import { K8sBaseList } from '../Base/K8sBaseList';
@@ -68,13 +72,12 @@ function K8sJobsList({
 					warning: data.warning,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch jobs';
 				return {
 					type: 'list' as const,
 					records: [] as InframonitoringtypesJobRecordDTO[],
 					total: 0,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},
@@ -87,7 +90,7 @@ function K8sJobsList({
 			signal?: AbortSignal,
 		): Promise<{
 			data: InframonitoringtypesJobRecordDTO | null;
-			error?: string | null;
+			error?: APIError | null;
 		}> => {
 			try {
 				const response = await listJobs(
@@ -105,11 +108,10 @@ function K8sJobsList({
 					data: response.data.records.length > 0 ? response.data.records[0] : null,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch job';
 				return {
 					data: null,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},

--- a/frontend/src/container/InfraMonitoringK8sV2/Namespaces/K8sNamespacesList.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Namespaces/K8sNamespacesList.tsx
@@ -1,11 +1,15 @@
 import { useCallback } from 'react';
+import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import { listNamespaces } from 'api/generated/services/inframonitoring';
+import { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
+import { AxiosError } from 'axios';
 import {
 	InframonitoringtypesNamespaceRecordDTO,
 	InframonitoringtypesResponseTypeDTO,
 	Querybuildertypesv5OrderDirectionDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { InfraMonitoringEvents } from 'constants/events';
+import APIError from 'types/api/error';
 
 import K8sBaseDetails, { K8sDetailsFilters } from '../Base/K8sBaseDetails';
 import { K8sBaseList } from '../Base/K8sBaseList';
@@ -68,13 +72,12 @@ function K8sNamespacesList({
 					warning: data.warning,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch namespaces';
 				return {
 					type: 'list' as const,
 					records: [] as InframonitoringtypesNamespaceRecordDTO[],
 					total: 0,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},
@@ -87,7 +90,7 @@ function K8sNamespacesList({
 			signal?: AbortSignal,
 		): Promise<{
 			data: InframonitoringtypesNamespaceRecordDTO | null;
-			error?: string | null;
+			error?: APIError | null;
 		}> => {
 			try {
 				const response = await listNamespaces(
@@ -105,11 +108,10 @@ function K8sNamespacesList({
 					data: response.data.records.length > 0 ? response.data.records[0] : null,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch namespace';
 				return {
 					data: null,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},

--- a/frontend/src/container/InfraMonitoringK8sV2/Nodes/K8sNodesList.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Nodes/K8sNodesList.tsx
@@ -1,11 +1,15 @@
 import { useCallback } from 'react';
+import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import { listNodes } from 'api/generated/services/inframonitoring';
+import { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
+import { AxiosError } from 'axios';
 import {
 	InframonitoringtypesNodeRecordDTO,
 	InframonitoringtypesResponseTypeDTO,
 	Querybuildertypesv5OrderDirectionDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { InfraMonitoringEvents } from 'constants/events';
+import APIError from 'types/api/error';
 
 import K8sBaseDetails, { K8sDetailsFilters } from '../Base/K8sBaseDetails';
 import { K8sBaseList } from '../Base/K8sBaseList';
@@ -67,13 +71,12 @@ function K8sNodesList({
 					warning: data.warning,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch nodes';
 				return {
 					type: 'list' as const,
 					records: [] as InframonitoringtypesNodeRecordDTO[],
 					total: 0,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},
@@ -86,7 +89,7 @@ function K8sNodesList({
 			signal?: AbortSignal,
 		): Promise<{
 			data: InframonitoringtypesNodeRecordDTO | null;
-			error?: string | null;
+			error?: APIError | null;
 		}> => {
 			try {
 				const response = await listNodes(
@@ -104,11 +107,10 @@ function K8sNodesList({
 					data: response.data.records.length > 0 ? response.data.records[0] : null,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch node';
 				return {
 					data: null,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},

--- a/frontend/src/container/InfraMonitoringK8sV2/Pods/K8sPodLists.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Pods/K8sPodLists.tsx
@@ -1,11 +1,15 @@
 import { useCallback } from 'react';
+import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import { listPods } from 'api/generated/services/inframonitoring';
+import { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
+import { AxiosError } from 'axios';
 import {
 	InframonitoringtypesPodRecordDTO,
 	InframonitoringtypesResponseTypeDTO,
 	Querybuildertypesv5OrderDirectionDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { InfraMonitoringEvents } from 'constants/events';
+import APIError from 'types/api/error';
 
 import K8sBaseDetails, { K8sDetailsFilters } from '../Base/K8sBaseDetails';
 import { K8sBaseList } from '../Base/K8sBaseList';
@@ -67,13 +71,12 @@ function K8sPodsList({
 					warning: data.warning,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch pods';
 				return {
 					type: 'list' as const,
 					records: [] as InframonitoringtypesPodRecordDTO[],
 					total: 0,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},
@@ -86,7 +89,7 @@ function K8sPodsList({
 			signal?: AbortSignal,
 		): Promise<{
 			data: InframonitoringtypesPodRecordDTO | null;
-			error?: string | null;
+			error?: APIError | null;
 		}> => {
 			try {
 				const response = await listPods(
@@ -104,11 +107,10 @@ function K8sPodsList({
 					data: response.data.records.length > 0 ? response.data.records[0] : null,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch pod';
 				return {
 					data: null,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},

--- a/frontend/src/container/InfraMonitoringK8sV2/StatefulSets/K8sStatefulSetsList.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/StatefulSets/K8sStatefulSetsList.tsx
@@ -1,11 +1,15 @@
 import { useCallback } from 'react';
+import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import { listStatefulSets } from 'api/generated/services/inframonitoring';
+import { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
+import { AxiosError } from 'axios';
 import {
 	InframonitoringtypesResponseTypeDTO,
 	InframonitoringtypesStatefulSetRecordDTO,
 	Querybuildertypesv5OrderDirectionDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { InfraMonitoringEvents } from 'constants/events';
+import APIError from 'types/api/error';
 
 import K8sBaseDetails, { K8sDetailsFilters } from '../Base/K8sBaseDetails';
 import { K8sBaseList } from '../Base/K8sBaseList';
@@ -68,13 +72,12 @@ function K8sStatefulSetsList({
 					warning: data.warning,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch statefulsets';
 				return {
 					type: 'list' as const,
 					records: [] as InframonitoringtypesStatefulSetRecordDTO[],
 					total: 0,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},
@@ -87,7 +90,7 @@ function K8sStatefulSetsList({
 			signal?: AbortSignal,
 		): Promise<{
 			data: InframonitoringtypesStatefulSetRecordDTO | null;
-			error?: string | null;
+			error?: APIError | null;
 		}> => {
 			try {
 				const response = await listStatefulSets(
@@ -105,11 +108,10 @@ function K8sStatefulSetsList({
 					data: response.data.records.length > 0 ? response.data.records[0] : null,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch statefulset';
 				return {
 					data: null,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},

--- a/frontend/src/container/InfraMonitoringK8sV2/Volumes/K8sVolumesList.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Volumes/K8sVolumesList.tsx
@@ -1,11 +1,15 @@
 import { useCallback } from 'react';
+import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import { listVolumes } from 'api/generated/services/inframonitoring';
+import { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
+import { AxiosError } from 'axios';
 import {
 	InframonitoringtypesResponseTypeDTO,
 	InframonitoringtypesVolumeRecordDTO,
 	Querybuildertypesv5OrderDirectionDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { InfraMonitoringEvents } from 'constants/events';
+import APIError from 'types/api/error';
 
 import K8sBaseDetails, { K8sDetailsFilters } from '../Base/K8sBaseDetails';
 import { K8sBaseList } from '../Base/K8sBaseList';
@@ -68,13 +72,12 @@ function K8sVolumesList({
 					warning: data.warning,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch volumes';
 				return {
 					type: 'list' as const,
 					records: [] as InframonitoringtypesVolumeRecordDTO[],
 					total: 0,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},
@@ -87,7 +90,7 @@ function K8sVolumesList({
 			signal?: AbortSignal,
 		): Promise<{
 			data: InframonitoringtypesVolumeRecordDTO | null;
-			error?: string | null;
+			error?: APIError | null;
 		}> => {
 			try {
 				const response = await listVolumes(
@@ -105,11 +108,10 @@ function K8sVolumesList({
 					data: response.data.records.length > 0 ? response.data.records[0] : null,
 				};
 			} catch (error) {
-				const errMsg =
-					error instanceof Error ? error.message : 'Failed to fetch volume';
 				return {
 					data: null,
-					error: errMsg,
+					error:
+						convertToApiError(error as AxiosError<RenderErrorResponseDTO>) ?? null,
 				};
 			}
 		},


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

Add support to render/show onboarding checks, only when `ready: false`.

Also changed the error message to use the standard component "ErrorContent".

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

A little tour of the checks:

https://github.com/user-attachments/assets/bccbdd14-c582-4f54-b38f-c321096af2bb

On normal error on list:

<img width="2052" height="1271" alt="screenshot-2026-07-14_15-45-18" src="https://github.com/user-attachments/assets/15a02d82-b773-4409-82fc-be4c44674d95" />

On blocked network on details:

<img width="2352" height="1269" alt="screenshot-2026-07-14_15-55-00" src="https://github.com/user-attachments/assets/17ab59b0-fe23-4150-a92e-5c5f909fcd18" />

On normal error on details:

<img width="2355" height="1270" alt="screenshot-2026-07-14_15-53-28" src="https://github.com/user-attachments/assets/fb485d6b-d902-4544-a202-970cd5a43ad0" />

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/engineering-pod/issues/5514

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Yes
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Infrastructure Monitoring
- Potential regressions: Bad conversion of apiErrors
- Rollback plan: Find and fix the issue specifically.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | When you don't have K8s Monitoring correctly defined, now you will see an instrumentation checks to help you define all the metrics needed for Infrastructure Monitoring to work correctly. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

