### PR TITLE
feat: add llm observability to side navigation [1/3]

### DIFF
--- a/frontend/src/container/SideNav/SideNav.tsx
+++ b/frontend/src/container/SideNav/SideNav.tsx
@@ -47,6 +47,7 @@ import { useKeyboardHotkeys } from 'hooks/hotkeys/useKeyboardHotkeys';
 import useComponentPermission from 'hooks/useComponentPermission';
 import { useGetTenantLicense } from 'hooks/useGetTenantLicense';
 import { useIsAIAssistantEnabled } from 'hooks/useIsAIAssistantEnabled';
+import { useIsAIObservabilityEnabled } from 'hooks/useIsAIObservabilityEnabled';
 import { useNotifications } from 'hooks/useNotifications';
 import history from 'lib/history';
 import { isArray } from 'lodash-es';
@@ -253,6 +254,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 	const isAdmin = user.role === USER_ROLES.ADMIN;
 	const isEditor = user.role === USER_ROLES.EDITOR;
 	const isAIAssistantEnabled = useIsAIAssistantEnabled();
+	const isAIObservabilityEnabled = useIsAIObservabilityEnabled();
 	const aiAssistantActiveConversationId = useAIAssistantStore(
 		(s) => s.activeConversationId,
 	);
@@ -288,15 +290,22 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 		const shouldShowIntegrationsValue =
 			(isCloudUser || isEnterpriseSelfHostedUser) && (isAdmin || isEditor);
 
+		const isEnabledForItem = (item: SidebarItem): boolean | undefined => {
+			if (item.key === ROUTES.INTEGRATIONS) {
+				return shouldShowIntegrationsValue;
+			}
+			if (item.key === ROUTES.LLM_OBSERVABILITY_OVERVIEW) {
+				return isAIObservabilityEnabled;
+			}
+			return item.isEnabled;
+		};
+
 		return defaultMoreMenuItems.map((item) => ({
 			...item,
 			isPinned: computedPinnedMenuItems.some(
 				(pinned) => pinned.itemKey === item.itemKey,
 			),
-			isEnabled:
-				item.key === ROUTES.INTEGRATIONS
-					? shouldShowIntegrationsValue
-					: item.isEnabled,
+			isEnabled: isEnabledForItem(item),
 		}));
 	}, [
 		computedPinnedMenuItems,
@@ -304,6 +313,7 @@ function SideNav({ isPinned }: { isPinned: boolean }): JSX.Element {
 		isEnterpriseSelfHostedUser,
 		isAdmin,
 		isEditor,
+		isAIObservabilityEnabled,
 	]);
 
 	// Track if we've done the initial sync (to avoid overwriting user actions during session)

--- a/frontend/src/container/SideNav/menuItems.tsx
+++ b/frontend/src/container/SideNav/menuItems.tsx
@@ -564,7 +564,9 @@ export const getUserSettingsDropdownMenuItems = ({
 		},
 	].filter(Boolean);
 
-/** Mapping of some newly added routes and their corresponding active sidebar menu key */
+/** Mapping of some newly added routes and their corresponding active sidebar menu key
+    This is used to highlight the correct menu item when the user navigates to a new route
+**/
 export const NEW_ROUTES_MENU_ITEM_KEY_MAP: Record<string, string> = {
 	[ROUTES.TRACE]: ROUTES.TRACES_EXPLORER,
 	[ROUTES.TRACE_EXPLORER]: ROUTES.TRACES_EXPLORER,
@@ -574,8 +576,6 @@ export const NEW_ROUTES_MENU_ITEM_KEY_MAP: Record<string, string> = {
 		ROUTES.INFRASTRUCTURE_MONITORING_HOSTS,
 	[ROUTES.API_MONITORING_BASE]: ROUTES.API_MONITORING,
 	[ROUTES.MESSAGING_QUEUES_BASE]: ROUTES.MESSAGING_QUEUES_OVERVIEW,
-	// `getActiveMenuKeyFromPath` strips `/llm-observability/overview` down to
-	// `/llm-observability`; point it back to the menu item's concrete key.
 	[ROUTES.LLM_OBSERVABILITY_BASE]: ROUTES.LLM_OBSERVABILITY_OVERVIEW,
 	// `getActiveMenuKeyFromPath` strips the URL down to its first segment;
 	// `/ai-assistant/<id>` reduces to `/ai-assistant`, which we point back

--- a/frontend/src/container/SideNav/menuItems.tsx
+++ b/frontend/src/container/SideNav/menuItems.tsx
@@ -36,6 +36,7 @@ import {
 	UserPlus,
 	Users,
 	Binoculars,
+	Brain,
 } from '@signozhq/icons';
 
 import {
@@ -287,6 +288,16 @@ export const defaultMoreMenuItems: SidebarItem[] = [
 		isNew: true,
 		isEnabled: true,
 		itemKey: 'external-apis',
+	},
+	{
+		key: ROUTES.LLM_OBSERVABILITY_OVERVIEW,
+		label: 'LLM Observability',
+		icon: <Brain size={16} />,
+		isNew: true,
+		// Gated behind the `enable_ai_observability` feature flag in
+		// SideNav's `computedSecondaryMenuItems`; disabled by default.
+		isEnabled: false,
+		itemKey: 'llm-observability',
 	},
 	{
 		key: ROUTES.METER,
@@ -563,6 +574,9 @@ export const NEW_ROUTES_MENU_ITEM_KEY_MAP: Record<string, string> = {
 		ROUTES.INFRASTRUCTURE_MONITORING_HOSTS,
 	[ROUTES.API_MONITORING_BASE]: ROUTES.API_MONITORING,
 	[ROUTES.MESSAGING_QUEUES_BASE]: ROUTES.MESSAGING_QUEUES_OVERVIEW,
+	// `getActiveMenuKeyFromPath` strips `/llm-observability/overview` down to
+	// `/llm-observability`; point it back to the menu item's concrete key.
+	[ROUTES.LLM_OBSERVABILITY_BASE]: ROUTES.LLM_OBSERVABILITY_OVERVIEW,
 	// `getActiveMenuKeyFromPath` strips the URL down to its first segment;
 	// `/ai-assistant/<id>` reduces to `/ai-assistant`, which we point back
 	// to the AI Assistant menu item's concrete key.


### PR DESCRIPTION
> **Stack (1/3):** this PR → #12141 (rename files to AI o11y) → #12145 (CSS fixes). Merge this first.

## Summary

Adds the LLM observability entry to the side navigation:

- New item in `defaultMoreMenuItems` (`menuItems.tsx`), gated behind the `enable_ai_observability` feature flag via `isEnabled` in SideNav's `computedSecondaryMenuItems` (disabled by default)
- SideNav wiring for the new item

Route renames and CSS fixes are split into the follow-up PRs in the stack.

https://github.com/user-attachments/assets/0dc6653f-7846-4215-9570-cebfe29bcc26


