### PR TITLE
fix(agentConf): use DB transaction in insertConfig to prevent pipelines disappearing on 500 error

### DIFF
--- a/frontend/src/api/ErrorResponseHandlerV2.ts
+++ b/frontend/src/api/ErrorResponseHandlerV2.ts
@@ -8,13 +8,14 @@ export function ErrorResponseHandlerV2(error: AxiosError<ErrorV2Resp>): never {
 	// The request was made and the server responded with a status code
 	// that falls out of the range of 2xx
 	if (response) {
+		const errorData = response.data?.error;
 		throw new APIError({
 			httpStatusCode: response.status || 500,
 			error: {
-				code: response.data.error.code,
-				message: response.data.error.message,
-				url: response.data.error.url,
-				errors: response.data.error.errors,
+				code: errorData?.code || String(response.status),
+				message: errorData?.message || response.statusText || 'Something went wrong',
+				url: errorData?.url || '',
+				errors: errorData?.errors || [],
 			},
 		});
 	}

--- a/pkg/query-service/agentConf/db.go
+++ b/pkg/query-service/agentConf/db.go
@@ -147,53 +147,35 @@ func (r *Repo) insertConfig(
 		c.Version = 1
 	}
 
-	// Track whether we've successfully finished the insert operation
-	success := false
-
-	defer func() {
-		if !success {
-			// remove all the damage (invalid rows from db)
-			// Delete elements first, then version (to respect potential foreign key constraints)
-			_, delErr := r.store.BunDB().NewDelete().Model(new(opamptypes.AgentConfigElement)).Where("version_id = ?", c.ID).Exec(ctx)
-			if delErr != nil {
-				slog.ErrorContext(ctx, "failed to delete config elements during cleanup", errors.Attr(delErr), "version_id", c.ID.String())
-			}
-			_, delErr = r.store.BunDB().NewDelete().Model(new(opamptypes.AgentConfigVersion)).Where("id = ?", c.ID).Where("org_id = ?", orgId).Exec(ctx)
-			if delErr != nil {
-				slog.ErrorContext(ctx, "failed to delete config version during cleanup", errors.Attr(delErr), "version_id", c.ID.String())
-			}
-		}
-	}()
-
-	_, dbErr := r.store.
-		BunDB().
-		NewInsert().
-		Model(c).
-		Exec(ctx)
-	if dbErr != nil {
-		slog.ErrorContext(ctx, "error in inserting config version", errors.Attr(dbErr))
-		return errors.WrapInternalf(dbErr, CodeConfigVersionInsertFailed, "failed to insert config version")
-	}
-
-	for _, e := range elements {
-		agentConfigElement := &opamptypes.AgentConfigElement{
-			Identifiable: types.Identifiable{ID: valuer.GenerateUUID()},
-			TimeAuditable: types.TimeAuditable{
-				CreatedAt: time.Now(),
-				UpdatedAt: time.Now(),
-			},
-			VersionID:   c.ID,
-			ElementType: c.ElementType.StringValue(),
-			ElementID:   e,
-		}
-		_, dbErr = r.store.BunDB().NewInsert().Model(agentConfigElement).Exec(ctx)
+	return r.store.RunInTxCtx(ctx, nil, func(ctx context.Context) error {
+		_, dbErr := r.store.BunDBCtx(ctx).
+			NewInsert().
+			Model(c).
+			Exec(ctx)
 		if dbErr != nil {
-			return errors.WrapInternalf(dbErr, CodeConfigElementInsertFailed, "failed to insert config element")
+			slog.ErrorContext(ctx, "error in inserting config version", errors.Attr(dbErr))
+			return errors.WrapInternalf(dbErr, CodeConfigVersionInsertFailed, "failed to insert config version")
 		}
-	}
 
-	success = true
-	return nil
+		for _, e := range elements {
+			agentConfigElement := &opamptypes.AgentConfigElement{
+				Identifiable: types.Identifiable{ID: valuer.GenerateUUID()},
+				TimeAuditable: types.TimeAuditable{
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+				VersionID:   c.ID,
+				ElementType: c.ElementType.StringValue(),
+				ElementID:   e,
+			}
+			_, dbErr = r.store.BunDBCtx(ctx).NewInsert().Model(agentConfigElement).Exec(ctx)
+			if dbErr != nil {
+				return errors.WrapInternalf(dbErr, CodeConfigElementInsertFailed, "failed to insert config element")
+			}
+		}
+
+		return nil
+	})
 }
 
 func (r *Repo) updateDeployStatus(ctx context.Context,

--- a/pkg/query-service/agentConf/db_test.go
+++ b/pkg/query-service/agentConf/db_test.go
@@ -1,0 +1,248 @@
+package agentConf
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/SigNoz/signoz/pkg/factory/factorytest"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/sqlstore/sqlitesqlstore"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/opamptypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+func newTestRepo(t *testing.T) Repo {
+	t.Helper()
+	store, err := sqlitesqlstore.New(context.Background(), factorytest.NewSettings(), sqlstore.Config{
+		Provider: "sqlite",
+		Connection: sqlstore.ConnectionConfig{
+			MaxOpenConns:    1,
+			MaxConnLifetime: 0,
+		},
+		Sqlite: sqlstore.SqliteConfig{
+			Path:            filepath.Join(t.TempDir(), "test.db"),
+			Mode:            "rwc",
+			BusyTimeout:     5 * time.Second,
+			TransactionMode: "deferred",
+		},
+	})
+	require.NoError(t, err)
+
+	// Create the tables used by agentConf
+	_, err = store.BunDB().NewCreateTable().
+		Model((*opamptypes.AgentConfigVersion)(nil)).
+		IfNotExists().
+		Exec(context.Background())
+	require.NoError(t, err)
+
+	_, err = store.BunDB().NewCreateTable().
+		Model((*opamptypes.AgentConfigElement)(nil)).
+		IfNotExists().
+		Exec(context.Background())
+	require.NoError(t, err)
+
+	// Also create org table stub for foreign key references (if any)
+	_, err = store.BunDB().Exec(`
+		CREATE TABLE IF NOT EXISTS organizations (
+			id TEXT PRIMARY KEY,
+			created_at DATETIME,
+			updated_at DATETIME,
+			display_name TEXT
+		)
+	`)
+	require.NoError(t, err)
+
+	_, err = store.BunDB().Exec(`
+		CREATE TABLE IF NOT EXISTS users (
+			id TEXT PRIMARY KEY,
+			created_at DATETIME,
+			updated_at DATETIME,
+			display_name TEXT,
+			email TEXT,
+			org_id TEXT
+		)
+	`)
+	require.NoError(t, err)
+
+	return Repo{store: store}
+}
+
+func seedOrg(t *testing.T, repo Repo) valuer.UUID {
+	t.Helper()
+	orgID := valuer.GenerateUUID()
+	_, err := repo.store.BunDB().Exec(
+		`INSERT INTO organizations (id, created_at, updated_at, display_name) VALUES (?, ?, ?, ?)`,
+		orgID.StringValue(), time.Now(), time.Now(), "test-org",
+	)
+	require.NoError(t, err)
+	return orgID
+}
+
+// TestInsertConfig_HappyPath verifies that a valid insertConfig call persists
+// both the version row and all element rows.
+func TestInsertConfig_HappyPath(t *testing.T) {
+	repo := newTestRepo(t)
+	orgID := seedOrg(t, repo)
+	userID := valuer.GenerateUUID()
+
+	cfg := opamptypes.NewAgentConfigVersion(orgID, userID, opamptypes.ElementTypeLogPipelines)
+	elements := []string{"elem-1", "elem-2", "elem-3"}
+
+	err := repo.insertConfig(context.Background(), orgID, userID, cfg, elements)
+	require.NoError(t, err)
+	require.Equal(t, 1, cfg.Version) // first version
+
+	// Version row must exist
+	var versions []opamptypes.AgentConfigVersion
+	err = repo.store.BunDB().NewSelect().
+		Model(&versions).
+		Where("org_id = ?", orgID).
+		Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+	require.Equal(t, 1, versions[0].Version)
+
+	// All elements must be persisted
+	var elems []opamptypes.AgentConfigElement
+	err = repo.store.BunDB().NewSelect().
+		Model(&elems).
+		Where("version_id = ?", cfg.ID).
+		Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, elems, 3)
+}
+
+// TestInsertConfig_EmptyElementsAllowedForLogPipelines verifies that deleting
+// all pipelines (empty element list) is permitted for LogPipelines type only.
+func TestInsertConfig_EmptyElementsAllowedForLogPipelines(t *testing.T) {
+	repo := newTestRepo(t)
+	orgID := seedOrg(t, repo)
+	userID := valuer.GenerateUUID()
+
+	cfg := opamptypes.NewAgentConfigVersion(orgID, userID, opamptypes.ElementTypeLogPipelines)
+	err := repo.insertConfig(context.Background(), orgID, userID, cfg, []string{})
+	require.NoError(t, err)
+
+	var versions []opamptypes.AgentConfigVersion
+	err = repo.store.BunDB().NewSelect().
+		Model(&versions).
+		Where("org_id = ?", orgID).
+		Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+}
+
+// TestInsertConfig_VersionIncrements verifies that successive inserts get
+// monotonically increasing version numbers.
+func TestInsertConfig_VersionIncrements(t *testing.T) {
+	repo := newTestRepo(t)
+	orgID := seedOrg(t, repo)
+	userID := valuer.GenerateUUID()
+
+	for i := 1; i <= 3; i++ {
+		cfg := opamptypes.NewAgentConfigVersion(orgID, userID, opamptypes.ElementTypeLogPipelines)
+		err := repo.insertConfig(context.Background(), orgID, userID, cfg, []string{"e"})
+		require.NoError(t, err)
+		require.Equal(t, i, cfg.Version)
+	}
+
+	var versions []opamptypes.AgentConfigVersion
+	err := repo.store.BunDB().NewSelect().
+		Model(&versions).
+		Where("org_id = ?", orgID).
+		Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, versions, 3)
+}
+
+// TestInsertConfig_CancelledContextLeavesNoPartialData is the regression test for
+// GitHub issue #12092. Before the fix, a cancelled request context caused the
+// cleanup defer to fail silently, leaving a partial agent_config_version row in
+// the DB. The next list call returned this partial version as "latest", making
+// some pipelines appear to disappear.
+//
+// With the fix (RunInTxCtx), a cancelled context causes the DB transaction to
+// roll back atomically — no partial rows survive.
+func TestInsertConfig_CancelledContextLeavesNoPartialData(t *testing.T) {
+	repo := newTestRepo(t)
+	orgID := seedOrg(t, repo)
+	userID := valuer.GenerateUUID()
+
+	// First, insert a good version with 3 pipelines.
+	cfg1 := opamptypes.NewAgentConfigVersion(orgID, userID, opamptypes.ElementTypeLogPipelines)
+	err := repo.insertConfig(context.Background(), orgID, userID, cfg1, []string{"p1", "p2", "p3"})
+	require.NoError(t, err)
+	require.Equal(t, 1, cfg1.Version)
+
+	// Now simulate a save that fails mid-way due to a cancelled context.
+	// We cancel immediately so the transaction itself will fail.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the call
+
+	cfg2 := opamptypes.NewAgentConfigVersion(orgID, userID, opamptypes.ElementTypeLogPipelines)
+	err = repo.insertConfig(cancelledCtx, orgID, userID, cfg2, []string{"p1", "p2", "p3"})
+	require.Error(t, err, "should fail with cancelled context")
+
+	// CRITICAL: The DB must not contain any partial data from cfg2.
+	// Specifically, the version count must still be 1 (only the original good version).
+	var versions []opamptypes.AgentConfigVersion
+	err = repo.store.BunDB().NewSelect().
+		Model(&versions).
+		Where("org_id = ?", orgID).
+		Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, versions, 1, "no partial version row should survive a cancelled insert")
+	require.Equal(t, 1, versions[0].Version, "only the original version should remain")
+
+	// Also verify no orphan elements from cfg2 exist.
+	var elems []opamptypes.AgentConfigElement
+	err = repo.store.BunDB().NewSelect().
+		Model(&elems).
+		Where("version_id = ?", cfg2.ID).
+		Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, elems, 0, "no orphan elements should survive a cancelled insert")
+}
+
+// TestInsertConfig_RejectsPresetVersion verifies that callers cannot assign a
+// version number — it must be auto-assigned.
+func TestInsertConfig_RejectsPresetVersion(t *testing.T) {
+	repo := newTestRepo(t)
+	orgID := seedOrg(t, repo)
+	userID := valuer.GenerateUUID()
+
+	cfg := opamptypes.NewAgentConfigVersion(orgID, userID, opamptypes.ElementTypeLogPipelines)
+	cfg.Version = 99 // manually set — should be rejected
+
+	err := repo.insertConfig(context.Background(), orgID, userID, cfg, []string{"e"})
+	require.Error(t, err)
+
+	// No rows should be inserted.
+	var versions []opamptypes.AgentConfigVersion
+	_ = repo.store.BunDB().NewSelect().
+		Model(&versions).
+		Where("org_id = ?", orgID).
+		Scan(context.Background())
+	require.Len(t, versions, 0)
+}
+
+// TestInsertConfig_RejectsEmptyElementType validates the element type check.
+func TestInsertConfig_RejectsEmptyElementType(t *testing.T) {
+	repo := newTestRepo(t)
+	orgID := seedOrg(t, repo)
+	userID := valuer.GenerateUUID()
+
+	cfg := &opamptypes.AgentConfigVersion{
+		Identifiable: types.Identifiable{ID: valuer.GenerateUUID()},
+		OrgID:        orgID,
+	}
+	// ElementType is zero-value (empty string)
+
+	err := repo.insertConfig(context.Background(), orgID, userID, cfg, []string{"e"})
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

This PR fixes two separate bugs that together caused pipelines to appear to disappear when a save returned an error.

### Bug 1 - Backend: partial pipeline write on 500 error (root cause of data loss)

- `insertConfig` inserted `agent_config_version` and each `agent_config_element` row separately, with a manual cleanup defer to undo partial writes on failure.
- The cleanup ran with the same request context, which could already be cancelled when a 500 fired - so the DELETE queries silently failed, leaving a partial version row in the DB.
- The next GET returned this partial version as "latest", making pipelines appear to disappear.
- Fix: wrap all inserts in `RunInTxCtx` using `BunDBCtx` so the DB rolls back atomically on any failure.

### Bug 2 - Frontend: JS crash "Cannot read properties of undefined (reading 'code')"

- `ErrorResponseHandlerV2` accessed `response.data.error.code` without checking if `response.data.error` was present.
- When the backend returns a 500 with a non-standard or legacy response body, `response.data.error` is undefined, causing the JS crash shown in the error toast.
- Fix: add optional chaining with sensible fallbacks so the handler always produces a valid APIError.

## Test plan

- [ ] Added `pkg/query-service/agentConf/db_test.go` with 6 unit tests
- [ ] `TestInsertConfig_CancelledContextLeavesNoPartialData` - regression test: confirms a cancelled-context insert leaves zero partial rows
- [ ] `TestInsertConfig_HappyPath` - version + all elements persisted
- [ ] `TestInsertConfig_VersionIncrements` - monotonically increasing versions
- [ ] `TestInsertConfig_EmptyElementsAllowedForLogPipelines` - delete all pipelines still works
- [ ] `TestInsertConfig_RejectsPresetVersion` - manual version numbers rejected
- [ ] `TestInsertConfig_RejectsEmptyElementType` - empty element type rejected
- [ ] All 6 tests pass: `go test ./pkg/query-service/agentConf/...`

Fixes #12092