### PR TITLE
chore: docs update otel demo collector config to span_metrics for Docker Configuration

### DIFF
--- a/docs/otel-demo-docs.md
+++ b/docs/otel-demo-docs.md
@@ -61,7 +61,7 @@ service:
     metrics:
       exporters: [otlp]
     traces:
-      exporters: [spanmetrics, otlp]
+      exporters: [span_metrics, otlp]
     logs: 
       exporters: [otlp]
 ```
@@ -70,7 +70,7 @@ The SigNoz OTel collector [sigNoz's otel-collector service] listens at 4317 port
 
 >
 > Note: When merging extra configuration values with the existing collector config (`src/otel-collector/otelcol-config.yml`), objects are merged and arrays are replaced resulting in previous pipeline configurations getting overridden.
- The spanmetrics exporter must be included in the array of exporters for the traces pipeline if overridden. Not including this exporter will result in an error.
+ The span_metrics exporter must be included in the array of exporters for the traces pipeline if overridden. Not including this exporter will result in an error.
 >
 <br>
 <u>To send data to SigNoz Cloud</u>
@@ -92,7 +92,7 @@ service:
     metrics:
       exporters: [otlp]
     traces:
-      exporters: [spanmetrics, otlp]
+      exporters: [span_metrics, otlp]
     logs: 
       exporters: [otlp]
 ```


### PR DESCRIPTION
### 📄 Summary
The OpenTelemetry Demo renamed the spanmetrics connector to
span_metrics in open-telemetry/opentelemetry-demo#3333 (49a7631b).
The exporter name in this guide no longer matches current versions of
the demo, and the collector rejects the merged config at startup:

  Error: invalid configuration: service::pipelines::traces:
  references exporter "spanmetrics" which is not configured

Because the collector validates its full config before serving, it
crash-loops and no telemetry reaches SigNoz at all — traces, metrics
and logs alike. The failure is silent from the UI, so users following
this guide see an empty SigNoz with no indication why.

Scoped to the Docker sections. The Kubernetes sections use the Helm
chart from opentelemetry-helm-charts, which still ship the old
name;

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.


### ✅ Change Type

- [ ] ✨ Feature
- [ ☑️  ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

#### Fix Strategy
> How does this PR address the root cause?

---

### 🧪 Testing Strategy
- Manual verification:

---

### 📝 Changelog
 edited docs/otel-demo-docs.md — lines 64, 73, 95 only

---
### 📋 Checklist
- [ ] Tests added or explicitly not required
- [ ☑️ ] Manually tested


