### PR TITLE
feat: add dashboard in llm o11y

### DIFF
--- a/frontend/src/container/LLMObservability/Overview/Overview.module.scss
+++ b/frontend/src/container/LLMObservability/Overview/Overview.module.scss
@@ -3,7 +3,7 @@
 	flex-direction: column;
 	gap: var(--spacing-8);
 	padding: var(--spacing-0) var(--spacing-0);
-	//TODO: remove this once we have a proper dashboard page. This is to remove the extra padding added by the dashboard container.
+	//TODO: remove this once we have a proper dashboard page.
 	// The embedded V2 DashboardContainer renders its own page header (dashboard
 	// title + share/feedback chrome) removed it for now
 	:global([class*='dashboardPageHeader']) {

--- a/frontend/src/container/LLMObservability/Overview/Overview.module.scss
+++ b/frontend/src/container/LLMObservability/Overview/Overview.module.scss
@@ -3,7 +3,7 @@
 	flex-direction: column;
 	gap: var(--spacing-8);
 	padding: var(--spacing-0) var(--spacing-0);
-
+	//TODO: remove this once we have a proper dashboard page. This is to remove the extra padding added by the dashboard container.
 	// The embedded V2 DashboardContainer renders its own page header (dashboard
 	// title + share/feedback chrome) removed it for now
 	:global([class*='dashboardPageHeader']) {

--- a/frontend/src/container/LLMObservability/Overview/Overview.module.scss
+++ b/frontend/src/container/LLMObservability/Overview/Overview.module.scss
@@ -2,26 +2,13 @@
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing-8);
-	padding: var(--spacing-12) var(--spacing-16);
-}
+	padding: var(--spacing-0) var(--spacing-0);
 
-.pageHeader {
-	display: flex;
-	align-items: flex-start;
-	justify-content: space-between;
-	gap: var(--spacing-8);
-}
-
-.pageHeaderTitle {
-	.title {
-		margin: 0;
-		font-size: var(--font-size-xl);
-		font-weight: var(--font-weight-semibold);
+	// The embedded V2 DashboardContainer renders its own page header (dashboard
+	// title + share/feedback chrome) removed it for now
+	:global([class*='dashboardPageHeader']) {
+		display: none;
 	}
-
-	.subtitle {
-		margin: var(--spacing-2) 0 0;
-		color: var(--text-vanilla-400);
-		font-size: var(--periscope-font-size-base);
-	}
+	// remove margin added by the hidden header to avoid extra whitespace at the top of the page
+	margin-top: calc(var(--spacing-8) * -1);
 }

--- a/frontend/src/container/LLMObservability/Overview/Overview.tsx
+++ b/frontend/src/container/LLMObservability/Overview/Overview.tsx
@@ -4,6 +4,7 @@ import { useSeededDashboardV2 } from './hooks/useSeededDashboardV2';
 import styles from './Overview.module.scss';
 
 function Overview(): JSX.Element {
+	//TODO: this is a temporary solution to get the seeded dashboard. We should fetch this json from the backend.
 	const { dashboard, refetch } = useSeededDashboardV2();
 
 	return (

--- a/frontend/src/container/LLMObservability/Overview/Overview.tsx
+++ b/frontend/src/container/LLMObservability/Overview/Overview.tsx
@@ -1,18 +1,14 @@
+import DashboardContainer from 'pages/DashboardPageV2/DashboardContainer';
+
+import { useSeededDashboardV2 } from './hooks/useSeededDashboardV2';
 import styles from './Overview.module.scss';
 
-// Overview tab content for LLM Observability. Currently the feature's landing
-// surface; usage/cost/performance widgets land in later PRs.
 function Overview(): JSX.Element {
+	const { dashboard, refetch } = useSeededDashboardV2();
+
 	return (
 		<div className={styles.overview} data-testid="llm-observability-overview">
-			<header className={styles.pageHeader}>
-				<div className={styles.pageHeaderTitle}>
-					<h1 className={styles.title}>LLM Observability</h1>
-					<p className={styles.subtitle}>
-						Monitor and analyze your LLM usage, costs, and performance
-					</p>
-				</div>
-			</header>
+			<DashboardContainer dashboard={dashboard} refetch={refetch} />
 		</div>
 	);
 }

--- a/frontend/src/container/LLMObservability/Overview/hooks/useSeededDashboardV2.ts
+++ b/frontend/src/container/LLMObservability/Overview/hooks/useSeededDashboardV2.ts
@@ -1,0 +1,33 @@
+import { useQueryClient } from 'react-query';
+
+import { getGetDashboardV2QueryKey } from 'api/generated/services/dashboard';
+import type {
+	DashboardtypesGettableDashboardV2DTO,
+	GetDashboardV2200,
+} from 'api/generated/services/sigNoz.schemas';
+
+import dashboardV2Json from '../json/dashboard.json';
+
+const dashboard =
+	dashboardV2Json as unknown as DashboardtypesGettableDashboardV2DTO;
+
+export interface UseSeededDashboardV2Result {
+	dashboard: DashboardtypesGettableDashboardV2DTO;
+	refetch: () => void;
+}
+
+const noop = (): void => {};
+
+export function useSeededDashboardV2(): UseSeededDashboardV2Result {
+	const queryClient = useQueryClient();
+
+	const key = getGetDashboardV2QueryKey({ id: dashboard.id });
+	if (queryClient.getQueryData<GetDashboardV2200>(key) === undefined) {
+		queryClient.setQueryData<GetDashboardV2200>(key, {
+			data: dashboard,
+			status: 'success',
+		});
+	}
+
+	return { dashboard, refetch: noop };
+}

--- a/frontend/src/container/LLMObservability/Overview/json/dashboard.json
+++ b/frontend/src/container/LLMObservability/Overview/json/dashboard.json
@@ -1,0 +1,1149 @@
+{
+  "id": "llm-observability-overview",
+  "orgId": "",
+  "locked": true,
+  "name": "AI Observability Overview",
+  "schemaVersion": "v6",
+  "source": "system",
+  "tags": null,
+  "spec": {
+    "display": {
+      "name": "AI Observability Overview",
+      "description": "AI / LLM observability overview — cost, tokens, latency, errors, RED for tool calls, and time to first token. Scoped by model, environment and service (apply via the variable bar)."
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/11111111-1111-1111-1111-111111111111"
+              }
+            },
+            {
+              "x": 3,
+              "y": 0,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/22222222-2222-2222-2222-222222222222"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 2,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/33333333-3333-3333-3333-333333333333"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 2,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/44444444-4444-4444-4444-444444444444"
+              }
+            },
+            {
+              "x": 10,
+              "y": 0,
+              "width": 2,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/55555555-5555-5555-5555-555555555555"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/66666666-6666-6666-6666-666666666666"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/77777777-7777-7777-7777-777777777777"
+              }
+            },
+            {
+              "x": 0,
+              "y": 7,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/88888888-8888-8888-8888-888888888888"
+              }
+            },
+            {
+              "x": 6,
+              "y": 7,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/99999999-9999-9999-9999-999999999999"
+              }
+            },
+            {
+              "x": 0,
+              "y": 11,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+              }
+            },
+            {
+              "x": 4,
+              "y": 11,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+              }
+            },
+            {
+              "x": 8,
+              "y": 11,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/cccccccc-cccc-cccc-cccc-cccccccccccc"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/dddddddd-dddd-dddd-dddd-dddddddddddd"
+              }
+            },
+            {
+              "x": 4,
+              "y": 15,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+              }
+            },
+            {
+              "x": 8,
+              "y": 15,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/ffffffff-ffff-ffff-ffff-ffffffffffff"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "panels": {
+      "11111111-1111-1111-1111-111111111111": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total cost",
+            "description": "Total LLM cost across all calls. Requires gen_ai.usage.cost attribute."
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": ""
+                          },
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.cost)"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22222222-2222-2222-2222-222222222222": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total tokens",
+            "description": "Sum of input + output tokens."
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": ""
+                          },
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.input_tokens)"
+                            },
+                            {
+                              "expression": "sum(gen_ai.usage.output_tokens)"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "33333333-3333-3333-3333-333333333333": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Avg latency (p95)",
+            "description": "p95 latency of LLM spans."
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": "gen_ai.system != ''"
+                          },
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "p95(duration_nano)"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "44444444-4444-4444-4444-444444444444": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error rate",
+            "description": "Error rate as a percentage of total LLM calls."
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": "gen_ai.system != ''"
+                          },
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "countIf(has_error = true)"
+                            },
+                            {
+                              "expression": "count()"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "55555555-5555-5555-5555-555555555555": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "TTFT (p95)",
+            "description": "p95 time to first token."
+          },
+          "plugin": {
+            "kind": "signoz/NumberPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": ""
+                          },
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "p95(gen_ai.server.ttft)"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "66666666-6666-6666-6666-666666666666": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cost over time",
+            "description": "Cost by model over time."
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "legend": {
+                "position": "bottom"
+              },
+              "chartAppearance": {
+                "lineStyle": "solid",
+                "lineInterpolation": "spline",
+                "fillMode": "none"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": ""
+                          },
+                          "groupBy": [
+                            {
+                              "name": "gen_ai.request.model",
+                              "fieldDataType": "string",
+                              "fieldContext": "tag"
+                            }
+                          ],
+                          "legend": "{{gen_ai.request.model}}",
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.cost)"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "77777777-7777-7777-7777-777777777777": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Token usage over time",
+            "description": "Input vs output tokens over time."
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "legend": {
+                "position": "bottom"
+              },
+              "chartAppearance": {
+                "lineStyle": "solid",
+                "lineInterpolation": "spline",
+                "fillMode": "none"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": ""
+                          },
+                          "legend": "Input",
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.input_tokens)"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "B",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": ""
+                          },
+                          "legend": "Output",
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "sum(gen_ai.usage.output_tokens)"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "88888888-8888-8888-8888-888888888888": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "LLM call latency percentiles",
+            "description": "p50, p90, p95, p99 latency by model."
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": "gen_ai.system != ''"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "gen_ai.request.model",
+                              "fieldDataType": "string",
+                              "fieldContext": "tag"
+                            }
+                          ],
+                          "legend": "{{gen_ai.request.model}}",
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "p50(duration_nano)"
+                            },
+                            {
+                              "expression": "p90(duration_nano)"
+                            },
+                            {
+                              "expression": "p95(duration_nano)"
+                            },
+                            {
+                              "expression": "p99(duration_nano)"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "99999999-9999-9999-9999-999999999999": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "LLM call latency over time",
+            "description": "p95 latency trend by model."
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "legend": {
+                "position": "bottom"
+              },
+              "chartAppearance": {
+                "lineStyle": "solid",
+                "lineInterpolation": "spline",
+                "fillMode": "none"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": "gen_ai.system != ''"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "gen_ai.request.model",
+                              "fieldDataType": "string",
+                              "fieldContext": "tag"
+                            }
+                          ],
+                          "legend": "{{gen_ai.request.model}}",
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "p95(duration_nano)"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Error count",
+            "description": "Errors grouped by error type."
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "legend": {
+                "position": "bottom"
+              },
+              "chartAppearance": {
+                "lineStyle": "solid",
+                "lineInterpolation": "spline",
+                "fillMode": "none"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": "has_error = true AND gen_ai.system != ''"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "gen_ai.error.type",
+                              "fieldDataType": "string",
+                              "fieldContext": "tag"
+                            }
+                          ],
+                          "legend": "{{gen_ai.error.type}}",
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Time to first token",
+            "description": "p95 TTFT by model."
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "legend": {
+                "position": "bottom"
+              },
+              "chartAppearance": {
+                "lineStyle": "solid",
+                "lineInterpolation": "spline",
+                "fillMode": "none"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": ""
+                          },
+                          "groupBy": [
+                            {
+                              "name": "gen_ai.request.model",
+                              "fieldDataType": "string",
+                              "fieldContext": "tag"
+                            }
+                          ],
+                          "legend": "{{gen_ai.request.model}}",
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "p95(gen_ai.server.ttft)"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "cccccccc-cccc-cccc-cccc-cccccccccccc": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Top 10 span names",
+            "description": "Top span names by count across GenAI spans."
+          },
+          "plugin": {
+            "kind": "signoz/TablePanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "scalar",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": "gen_ai.system != ''"
+                          },
+                          "groupBy": [
+                            {
+                              "name": "name",
+                              "fieldDataType": "string",
+                              "fieldContext": "tag"
+                            }
+                          ],
+                          "limit": 10,
+                          "order": [
+                            {
+                              "key": {
+                                "name": "count()"
+                              },
+                              "direction": "desc"
+                            }
+                          ],
+                          "legend": "{{name}}",
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "count()"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "dddddddd-dddd-dddd-dddd-dddddddddddd": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tool call rate",
+            "description": "Tool call rate per second."
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "legend": {
+                "position": "bottom"
+              },
+              "chartAppearance": {
+                "lineStyle": "solid",
+                "lineInterpolation": "spline",
+                "fillMode": "none"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": "name = 'execute_tool'"
+                          },
+                          "legend": "req/s",
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "rate()"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tool error rate",
+            "description": "Percentage of tool calls that errored."
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "legend": {
+                "position": "bottom"
+              },
+              "chartAppearance": {
+                "lineStyle": "solid",
+                "lineInterpolation": "spline",
+                "fillMode": "none"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": "name = 'execute_tool'"
+                          },
+                          "legend": "error %",
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "countIf(has_error = true)"
+                            },
+                            {
+                              "expression": "count()"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "ffffffff-ffff-ffff-ffff-ffffffffffff": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tool duration (p50)",
+            "description": "Median tool call duration."
+          },
+          "plugin": {
+            "kind": "signoz/TimeSeriesPanel",
+            "spec": {
+              "visualization": {
+                "timePreference": "global_time"
+              },
+              "legend": {
+                "position": "bottom"
+              },
+              "chartAppearance": {
+                "lineStyle": "solid",
+                "lineInterpolation": "spline",
+                "fillMode": "none"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "time_series",
+              "spec": {
+                "plugin": {
+                  "kind": "signoz/CompositeQuery",
+                  "spec": {
+                    "queries": [
+                      {
+                        "type": "builder_query",
+                        "spec": {
+                          "name": "A",
+                          "signal": "traces",
+                          "stepInterval": 60,
+                          "disabled": false,
+                          "filter": {
+                            "expression": "name = 'execute_tool'"
+                          },
+                          "legend": "p50",
+                          "having": {
+                            "expression": ""
+                          },
+                          "aggregations": [
+                            {
+                              "expression": "p50(duration_nano)"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "model",
+          "display": {
+            "name": "model",
+            "description": "LLM model"
+          },
+          "allowMultiple": true,
+          "allowAllValue": true,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "signoz/QueryVariable",
+            "spec": {
+              "queryValue": "SELECT DISTINCT attributes_string['gen_ai.request.model'] AS model FROM signoz_traces.distributed_signoz_index_v3 WHERE mapContains(attributes_string, 'gen_ai.request.model') AND timestamp >= now() - INTERVAL 1 DAY"
+            }
+          }
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "environment",
+          "display": {
+            "name": "environment",
+            "description": "Deployment environment"
+          },
+          "allowMultiple": true,
+          "allowAllValue": true,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "signoz/QueryVariable",
+            "spec": {
+              "queryValue": "SELECT DISTINCT resources_string['deployment.environment'] AS environment FROM signoz_traces.distributed_signoz_index_v3 WHERE mapContains(resources_string, 'deployment.environment') AND timestamp >= now() - INTERVAL 1 DAY"
+            }
+          }
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "name": "service_name",
+          "display": {
+            "name": "service_name",
+            "description": "Service name"
+          },
+          "allowMultiple": true,
+          "allowAllValue": true,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "signoz/QueryVariable",
+            "spec": {
+              "queryValue": "SELECT DISTINCT resources_string['service.name'] AS service_name FROM signoz_traces.distributed_signoz_index_v3 WHERE mapContains(resources_string, 'service.name') AND timestamp >= now() - INTERVAL 1 DAY"
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/frontend/src/container/LLMObservability/__tests__/LLMObservability.test.tsx
+++ b/frontend/src/container/LLMObservability/__tests__/LLMObservability.test.tsx
@@ -10,6 +10,14 @@ import { render, screen, userEvent, waitFor } from 'tests/test-utils';
 
 import LLMObservability from '../LLMObservability';
 
+// The Overview tab renders the full V2 DashboardContainer (toolbar + date picker
+// call useNavigationType, which needs a data router this integration test doesn't
+// set up). These cases assert tab routing, not dashboard rendering, so stub it.
+jest.mock('pages/DashboardPageV2/DashboardContainer', () => ({
+	__esModule: true,
+	default: (): JSX.Element => <div data-testid="llm-overview-dashboard" />,
+}));
+
 function setupList(items = mockRules): void {
 	server.use(
 		rest.get(LLM_PRICING_ENDPOINT, (_req, res, ctx) =>
@@ -34,7 +42,7 @@ describe('LLMObservability (integration)', () => {
 
 		expect(screen.getByTestId('llm-observability-tabs')).toBeInTheDocument();
 		expect(screen.getByTestId('llm-observability-overview')).toBeInTheDocument();
-		expect(screen.getByText('LLM Observability')).toBeInTheDocument();
+		expect(screen.getByTestId('llm-overview-dashboard')).toBeInTheDocument();
 		expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();
 		expect(
 			screen.getByRole('tab', { name: 'Model pricing' }),


### PR DESCRIPTION

📄 Summary
---

Currently, the overview tab is an empty tab. We have added this hard-coded JSON as well as the dashboard here in lock mode. Later, we will be removing this JSON and fetching it from the backend. 

Also, one thing to note: we have hidden the dashboard header since it was taking extra space and it was not needed. Also, we have added a few negative margins to reduce space. 

Issues closed by this PR

https://github.com/orgs/SigNoz/projects/39/views/11?filterQuery=assignee%3Atewarig&pane=issue&itemId=196365558&issue=SigNoz%7Cengineering-pod%7C5232



https://github.com/user-attachments/assets/04a45849-c31b-4553-a634-87fff390091b


---
✅ Change Type

Select all that apply

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---
🐛 Bug Context

▎ Required if this PR fixes a bug


---
🧪 Testing Strategy

▎ How was this change validated?

 since this is a hard-coded dashboard with JSON, and anyway we will be using the permission module later, don't think we should add the test right now 
---
⚠️ Risk & Impact Assessment

▎ What could break? How do we recover?

- Blast radius: Scoped to the LLM Observability Overview tab. No changes to shared DashboardContainer or other dashboard surfaces.
- Potential regressions: The CSS hide depends on the header keeping dashboardPageHeader in its class name; if the other team renames that class, the header would reappear (cosmetic only, not a crash).
- Rollback plan: Revert the PR — the tab returns to the placeholder; no data/migrations involved.

---
📝 Changelog

---
📋 Checklist

- [ ] Tests added or explicitly not required
- [x] Manually tested (static checks + build; in-app render pending)
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered (additive; no persisted data)

---