### PR TITLE
fix(ruletypes): round-trip empty notificationSettings fields

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -7571,6 +7571,7 @@ components:
         groupBy:
           items:
             type: string
+          nullable: true
           type: array
         newGroupEvalDelay:
           type: string
@@ -7642,6 +7643,7 @@ components:
         alertStates:
           items:
             $ref: '#/components/schemas/RuletypesAlertState'
+          nullable: true
           type: array
         enabled:
           type: boolean

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -8675,9 +8675,9 @@ export interface RuletypesGettableTestRuleDTO {
 
 export interface RuletypesRenotifyDTO {
 	/**
-	 * @type array
+	 * @type array,null
 	 */
-	alertStates?: RuletypesAlertStateDTO[];
+	alertStates?: RuletypesAlertStateDTO[] | null;
 	/**
 	 * @type boolean
 	 */
@@ -8690,9 +8690,9 @@ export interface RuletypesRenotifyDTO {
 
 export interface RuletypesNotificationSettingsDTO {
 	/**
-	 * @type array
+	 * @type array,null
 	 */
-	groupBy?: string[];
+	groupBy?: string[] | null;
 	/**
 	 * @type string
 	 */

--- a/pkg/types/ruletypes/api_params.go
+++ b/pkg/types/ruletypes/api_params.go
@@ -86,7 +86,7 @@ type NotificationSettings struct {
 type Renotify struct {
 	Enabled          bool                `json:"enabled"`
 	ReNotifyInterval valuer.TextDuration `json:"interval,omitzero"`
-	AlertStates      []AlertState        `json:"alertStates,omitempty"`
+	AlertStates      []AlertState        `json:"alertStates,omitzero"`
 }
 
 func (ns *NotificationSettings) GetAlertManagerNotificationConfig() alertmanagertypes.NotificationConfig {

--- a/pkg/types/ruletypes/api_params.go
+++ b/pkg/types/ruletypes/api_params.go
@@ -76,7 +76,7 @@ type PostableRule struct {
 }
 
 type NotificationSettings struct {
-	GroupBy   []string  `json:"groupBy"`
+	GroupBy   []string  `json:"groupBy,omitzero"`
 	Renotify  *Renotify `json:"renotify,omitempty"`
 	UsePolicy bool      `json:"usePolicy"`
 	// NewGroupEvalDelay is the grace period for new series to be excluded from alerts evaluation

--- a/pkg/types/ruletypes/api_params.go
+++ b/pkg/types/ruletypes/api_params.go
@@ -76,7 +76,7 @@ type PostableRule struct {
 }
 
 type NotificationSettings struct {
-	GroupBy   []string  `json:"groupBy,omitempty"`
+	GroupBy   []string  `json:"groupBy"`
 	Renotify  *Renotify `json:"renotify,omitempty"`
 	UsePolicy bool      `json:"usePolicy"`
 	// NewGroupEvalDelay is the grace period for new series to be excluded from alerts evaluation

--- a/pkg/types/ruletypes/api_params.go
+++ b/pkg/types/ruletypes/api_params.go
@@ -78,7 +78,7 @@ type PostableRule struct {
 type NotificationSettings struct {
 	GroupBy   []string  `json:"groupBy,omitempty"`
 	Renotify  *Renotify `json:"renotify,omitempty"`
-	UsePolicy bool      `json:"usePolicy,omitempty"`
+	UsePolicy bool      `json:"usePolicy"`
 	// NewGroupEvalDelay is the grace period for new series to be excluded from alerts evaluation
 	NewGroupEvalDelay valuer.TextDuration `json:"newGroupEvalDelay,omitzero"`
 }

--- a/pkg/types/ruletypes/roundtrip_test.go
+++ b/pkg/types/ruletypes/roundtrip_test.go
@@ -153,10 +153,9 @@ func TestV2MinimalReadShape(t *testing.T) {
 
 	var ns map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(body["notificationSettings"], &ns))
-	for _, field := range []string{"renotify", "newGroupEvalDelay"} {
+	for _, field := range []string{"renotify", "groupBy", "newGroupEvalDelay"} {
 		assert.NotContains(t, ns, field, "notificationSettings.%s", field)
 	}
-	assert.JSONEq(t, `null`, string(ns["groupBy"]))
 	assert.JSONEq(t, `false`, string(ns["usePolicy"]))
 
 	assert.JSONEq(t, `false`, string(body["disabled"]))
@@ -223,6 +222,59 @@ func TestRenotifyRoundTrip(t *testing.T) {
 				assert.NotContains(t, ns, "renotify")
 			} else {
 				assert.JSONEq(t, tc.wantRenotify, string(ns["renotify"]))
+			}
+		})
+	}
+}
+
+func TestGroupByRoundTrip(t *testing.T) {
+	base := `{
+		"alert": "cpu high",
+		"alertType": "METRIC_BASED_ALERT",
+		"ruleType": "threshold_rule",
+		"schemaVersion": "v2alpha1",
+		"condition": {
+			"compositeQuery": {
+				"queries": [{"type": "promql", "spec": {"name": "A", "query": "up"}}],
+				"panelType": "graph",
+				"queryType": "promql"
+			},
+			"thresholds": {"kind": "basic", "spec": [{"name": "critical", "target": 90, "matchType": "at_least_once", "op": "above"}]}
+		},
+		"evaluation": {"kind": "rolling", "spec": {"evalWindow": "5m", "frequency": "1m"}},
+		"notificationSettings": %s
+	}`
+
+	cases := []struct {
+		name        string
+		settings    string
+		wantGroupBy string
+	}{
+		{
+			name:     "unset group by stays absent",
+			settings: `{"usePolicy": false}`,
+		},
+		{
+			name:        "explicitly empty group by is echoed",
+			settings:    `{"groupBy": []}`,
+			wantGroupBy: `[]`,
+		},
+		{
+			name:        "populated group by is echoed",
+			settings:    `{"groupBy": ["service.name", "deployment.environment"]}`,
+			wantGroupBy: `["service.name", "deployment.environment"]`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := readBody(t, strings.Replace(base, "%s", tc.settings, 1))
+			var ns map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(body["notificationSettings"], &ns))
+			if tc.wantGroupBy == "" {
+				assert.NotContains(t, ns, "groupBy")
+			} else {
+				assert.JSONEq(t, tc.wantGroupBy, string(ns["groupBy"]))
 			}
 		})
 	}

--- a/pkg/types/ruletypes/roundtrip_test.go
+++ b/pkg/types/ruletypes/roundtrip_test.go
@@ -153,9 +153,10 @@ func TestV2MinimalReadShape(t *testing.T) {
 
 	var ns map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(body["notificationSettings"], &ns))
-	for _, field := range []string{"renotify", "groupBy", "newGroupEvalDelay", "usePolicy"} {
+	for _, field := range []string{"renotify", "groupBy", "newGroupEvalDelay"} {
 		assert.NotContains(t, ns, field, "notificationSettings.%s", field)
 	}
+	assert.JSONEq(t, `false`, string(ns["usePolicy"]))
 
 	assert.JSONEq(t, `false`, string(body["disabled"]))
 	assert.JSONEq(t, `"v5"`, string(body["version"]))

--- a/pkg/types/ruletypes/roundtrip_test.go
+++ b/pkg/types/ruletypes/roundtrip_test.go
@@ -153,9 +153,10 @@ func TestV2MinimalReadShape(t *testing.T) {
 
 	var ns map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(body["notificationSettings"], &ns))
-	for _, field := range []string{"renotify", "groupBy", "newGroupEvalDelay"} {
+	for _, field := range []string{"renotify", "newGroupEvalDelay"} {
 		assert.NotContains(t, ns, field, "notificationSettings.%s", field)
 	}
+	assert.JSONEq(t, `null`, string(ns["groupBy"]))
 	assert.JSONEq(t, `false`, string(ns["usePolicy"]))
 
 	assert.JSONEq(t, `false`, string(body["disabled"]))

--- a/pkg/types/ruletypes/roundtrip_test.go
+++ b/pkg/types/ruletypes/roundtrip_test.go
@@ -207,6 +207,11 @@ func TestRenotifyRoundTrip(t *testing.T) {
 			wantRenotify: `{"enabled": false}`,
 		},
 		{
+			name:         "explicitly empty alert states are echoed",
+			settings:     `{"renotify": {"enabled": true, "alertStates": []}}`,
+			wantRenotify: `{"enabled": true, "alertStates": []}`,
+		},
+		{
 			name:         "enabled renotify with states is echoed",
 			settings:     `{"renotify": {"enabled": true, "interval": "30m", "alertStates": ["firing"]}}`,
 			wantRenotify: `{"enabled": true, "interval": "30m", "alertStates": ["firing"]}`,


### PR DESCRIPTION
### Summary

Several `NotificationSettings` fields are tagged `json:"...,omitempty"`, so an explicitly-set empty value is dropped from the rule GET response and read back as absent/null, breaking round-tripping (e.g. the Terraform provider errors with "produced an unexpected new value: usePolicy was false, but now null").

- `usePolicy` (`bool`): drop `omitempty` so `false` always serializes.
- `groupBy` / `renotify.alertStates` (slices): switch to `omitzero` so an explicit `[]` round-trips while an unset (nil) value stays omitted.

Regenerated the OpenAPI spec and frontend client to match.

### Change Type

- [x] 🐛 Bug fix

Addresses point 1 of https://github.com/SigNoz/engineering-pod/issues/5700
