### PR TITLE
fix(query-search): do not override token classes

### DIFF
--- a/frontend/src/components/QueryBuilderV2/QueryV2/QueryAddOns/QueryAddOns.styles.scss
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QueryAddOns/QueryAddOns.styles.scss
@@ -247,11 +247,6 @@
 						var(--l2-background)
 					) !important;
 
-					&,
-					.ͼ1a {
-						color: var(--query-builder-v2-color, var(--l2-foreground));
-					}
-
 					::-moz-selection {
 						background: var(
 							--query-builder-v2-selection-background-color,

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.styles.scss
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QuerySearch/QuerySearch.styles.scss
@@ -293,11 +293,6 @@ $max-recents-shown: 5;
 				var(--l2-background)
 			) !important;
 
-			&,
-			.ͼ1a {
-				color: var(--query-builder-v2-color, var(--l2-foreground));
-			}
-
 			::-moz-selection {
 				background: var(
 					--query-builder-v2-selection-background-color,

--- a/tests/e2e/helpers/query-builder.ts
+++ b/tests/e2e/helpers/query-builder.ts
@@ -1,5 +1,4 @@
 import { Page } from '@playwright/test';
-import { expect, test } from '../../fixtures/auth';
 
 const EDITOR_CONTENT = '.query-where-clause-editor .cm-content';
 const SPANS = '.query-where-clause-editor .cm-line span';

--- a/tests/e2e/tests/query-builder/token-highlight.spec.ts
+++ b/tests/e2e/tests/query-builder/token-highlight.spec.ts
@@ -1,11 +1,6 @@
 import { expect, test } from '../../fixtures/auth';
-import {
-	setupTheme,
-	tokenColor,
-	typeExpression,
-} from '@tests/query-builder/utils';
+import { setupTheme, tokenColor, typeExpression } from '@helpers/query-builder';
 
-const SPANS = '.query-where-clause-editor .cm-line span';
 const LOGS_EXPLORER = '/logs/logs-explorer';
 
 type ThemeConfig = {
@@ -57,25 +52,15 @@ for (const { name, theme, colors } of THEMES) {
 			expect(await tokenColor(page, 'name')).toBe(colors.property);
 		});
 
-		test(`['value', 'value'] — string tokens have native theme color`, async ({
+		test(`['value', 'value2'] — string tokens have native theme color`, async ({
 			authedPage: page,
 		}) => {
 			await setupTheme(page, theme);
 			await page.goto(LOGS_EXPLORER);
-			await typeExpression(page, "['value', 'value']");
+			await typeExpression(page, "['value', 'value2']");
 
-			const allStringColors: string[] = await page.evaluate(
-				({ selector, text }) =>
-					Array.from(document.querySelectorAll<HTMLSpanElement>(selector))
-						.filter((el) => el.textContent === text)
-						.map((el) => window.getComputedStyle(el).color),
-				{ selector: SPANS, text: "'value'" },
-			);
-
-			expect(allStringColors.length).toBe(2);
-			for (const color of allStringColors) {
-				expect(color).toBe(colors.string);
-			}
+			expect(await tokenColor(page, "'value'")).toBe(colors.string);
+			expect(await tokenColor(page, "'value2'")).toBe(colors.string);
 		});
 	});
 }

--- a/tests/e2e/tests/query-builder/token-highlight.spec.ts
+++ b/tests/e2e/tests/query-builder/token-highlight.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '../../fixtures/auth';
+import {
+	setupTheme,
+	tokenColor,
+	typeExpression,
+} from '@tests/query-builder/utils';
+
+const SPANS = '.query-where-clause-editor .cm-line span';
+const LOGS_EXPLORER = '/logs/logs-explorer';
+
+type ThemeConfig = {
+	name: string;
+	theme: 'dark' | 'light';
+	colors: {
+		identifier: string;
+		operator: string;
+		property: string;
+		string: string;
+	};
+};
+
+const THEMES: ThemeConfig[] = [
+	{
+		name: 'dark (copilot)',
+		theme: 'dark',
+		colors: {
+			identifier: 'rgb(147, 157, 165)',
+			operator: 'rgb(186, 142, 247)',
+			property: 'rgb(255, 234, 107)',
+			string: 'rgb(91, 236, 149)',
+		},
+	},
+	{
+		name: 'light (githubLight)',
+		theme: 'light',
+		colors: {
+			identifier: 'rgb(0, 92, 197)',
+			operator: 'rgb(0, 92, 197)',
+			property: 'rgb(111, 66, 193)',
+			string: 'rgb(3, 47, 98)',
+		},
+	},
+];
+
+for (const { name, theme, colors } of THEMES) {
+	test.describe(`QueryBuilder token highlighting — ${name}`, () => {
+		test(`k8s.namespace.name — each segment gets its own color`, async ({
+			authedPage: page,
+		}) => {
+			await setupTheme(page, theme);
+			await page.goto(LOGS_EXPLORER);
+			await typeExpression(page, 'k8s.namespace.name');
+
+			expect(await tokenColor(page, 'k8s')).toBe(colors.identifier);
+			expect(await tokenColor(page, '.')).toBe(colors.operator);
+			expect(await tokenColor(page, 'namespace')).toBe(colors.property);
+			expect(await tokenColor(page, 'name')).toBe(colors.property);
+		});
+
+		test(`['value', 'value'] — string tokens have native theme color`, async ({
+			authedPage: page,
+		}) => {
+			await setupTheme(page, theme);
+			await page.goto(LOGS_EXPLORER);
+			await typeExpression(page, "['value', 'value']");
+
+			const allStringColors: string[] = await page.evaluate(
+				({ selector, text }) =>
+					Array.from(document.querySelectorAll<HTMLSpanElement>(selector))
+						.filter((el) => el.textContent === text)
+						.map((el) => window.getComputedStyle(el).color),
+				{ selector: SPANS, text: "'value'" },
+			);
+
+			expect(allStringColors.length).toBe(2);
+			for (const color of allStringColors) {
+				expect(color).toBe(colors.string);
+			}
+		});
+	});
+}

--- a/tests/e2e/tests/query-builder/utils.ts
+++ b/tests/e2e/tests/query-builder/utils.ts
@@ -1,0 +1,37 @@
+import { Page } from '@playwright/test';
+import { expect, test } from '../../fixtures/auth';
+
+const EDITOR_CONTENT = '.query-where-clause-editor .cm-content';
+const SPANS = '.query-where-clause-editor .cm-line span';
+
+export async function typeExpression(page: Page, expr: string): Promise<void> {
+	const editor = page.locator(EDITOR_CONTENT).first();
+	await editor.waitFor({ state: 'visible', timeout: 15_000 });
+	await editor.click();
+	await page.keyboard.press('ControlOrMeta+a');
+	await page.keyboard.press('Delete');
+	await page.keyboard.type(expr);
+	await page.waitForTimeout(300);
+}
+
+export async function tokenColor(
+	page: Page,
+	text: string,
+): Promise<string | null> {
+	return page.evaluate(
+		({ selector, target }) => {
+			const el = Array.from(
+				document.querySelectorAll<HTMLSpanElement>(selector),
+			).find((s) => s.textContent === target);
+			return el ? window.getComputedStyle(el).color : null;
+		},
+		{ selector: SPANS, target: text },
+	);
+}
+
+export async function setupTheme(
+	page: Page,
+	theme: 'dark' | 'light',
+): Promise<void> {
+	await page.addInitScript((t) => localStorage.setItem('THEME', t), theme);
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

This removes the override for token expression causing the syntax highlight to break, introduced at https://github.com/SigNoz/signoz/pull/11992

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

<img width="2001" height="461" alt="image" src="https://github.com/user-attachments/assets/60bea784-8248-4f41-b16e-af382610cbc2" />

<img width="2007" height="459" alt="image" src="https://github.com/user-attachments/assets/fa995a68-d2a2-4963-bd6f-9e006375e25a" />

After:

<img width="1999" height="447" alt="image" src="https://github.com/user-attachments/assets/bf1c299c-7ba1-42f1-8dc9-59c37145bdd8" />

<img width="2001" height="453" alt="image" src="https://github.com/user-attachments/assets/d083090e-6c9a-4f11-94e1-859a7b21cf13" />

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Related to https://github.com/SigNoz/platform-pod/issues/2739

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

We override a specific token that should not override by mistake.

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

We should not override that specific CSS class, and we didn't notice in dev because it was not taking precedence over the default css.

After some change in the chunk order, it started getting precedence, causing this issue.

#### Fix Strategy
> How does this PR address the root cause?

Just remove the custom css.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Query Builder
- Potential regressions: Another visual bug.
- Rollback plan: Find and fix the issue.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | This PR fixes a little bug introduced in the Query Search causing the values to not be correctly syntax highlighted on dark mode. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
