### PR TITLE
refactor(dashboards-v2): dedupe threshold color palette into an enum & reuse normalizeOperator for alert prefill

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/ThresholdColorSelect.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/ThresholdColorSelect.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown } from '@signozhq/icons';
 import { ColorPicker } from 'antd';
+import { ThresholdColor } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/threshold';
 
 import styles from './ThresholdsSection.module.scss';
 
@@ -11,11 +12,11 @@ interface ThresholdColorSelectProps {
 
 // Named presets from the SigNoz palette (cherry / amber / forest / robin). They surface
 // as quick swatches in the picker; the full picker below covers any custom color.
-const PRESETS: { label: string; value: string }[] = [
-	{ label: 'Red', value: '#F1575F' },
-	{ label: 'Orange', value: '#F5B225' },
-	{ label: 'Green', value: '#2BB673' },
-	{ label: 'Blue', value: '#4E74F8' },
+const PRESETS: { label: string; value: ThresholdColor }[] = [
+	{ label: 'Red', value: ThresholdColor.RED },
+	{ label: 'Orange', value: ThresholdColor.ORANGE },
+	{ label: 'Green', value: ThresholdColor.GREEN },
+	{ label: 'Blue', value: ThresholdColor.BLUE },
 ];
 
 /**

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/ThresholdsSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/ThresholdsSection.tsx
@@ -12,6 +12,7 @@ import {
 	AnyThreshold,
 	ThresholdVariant,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/sections';
+import { ThresholdColor } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/threshold';
 
 import type { TableColumnOption } from '../../../hooks/useTableColumns';
 import type { SectionEditorContext } from '../../sectionContext';
@@ -22,7 +23,7 @@ import TableThresholdRow from './rows/TableThresholdRow';
 import styles from './ThresholdsSection.module.scss';
 
 // New thresholds default to red (the first palette preset); the user recolors per rule.
-const DEFAULT_THRESHOLD_COLOR = '#F1575F';
+const DEFAULT_THRESHOLD_COLOR = ThresholdColor.RED;
 
 // Add-button testId per variant — kept stable so existing E2E/unit selectors hold.
 const ADD_TESTID: Record<ThresholdVariant, string> = {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/threshold.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/threshold.ts
@@ -22,6 +22,22 @@ export interface ComparisonThresholdShape {
 	format?: DashboardtypesThresholdFormatDTO;
 }
 
+/** SigNoz threshold palette; single source of truth for the hex values. */
+export enum ThresholdColor {
+	RED = '#F1575F',
+	ORANGE = '#F5B225',
+	GREEN = '#2BB673',
+	BLUE = '#4E74F8',
+}
+
+/** Palette ordered most-dangerous first (preset order + alert-severity ranking). */
+export const THRESHOLD_COLOR_DANGER_ORDER: ThresholdColor[] = [
+	ThresholdColor.RED,
+	ThresholdColor.ORANGE,
+	ThresholdColor.GREEN,
+	ThresholdColor.BLUE,
+];
+
 /** Comparison operators a threshold can use, as evaluable symbols. */
 export type ThresholdComparisonOperator = '>' | '<' | '>=' | '<=' | '=' | '!=';
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/deriveAlertPrefill.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/deriveAlertPrefill.ts
@@ -5,11 +5,13 @@ import type {
 	DashboardtypesPanelDTO,
 	DashboardtypesPanelPluginDTO,
 } from 'api/generated/services/sigNoz.schemas';
+import { normalizeOperator } from 'container/CreateAlertV2/context/conditionNormalizers';
 import {
 	AlertThresholdMatchType,
 	AlertThresholdOperator,
 	Threshold,
 } from 'container/CreateAlertV2/context/types';
+import { THRESHOLD_COLOR_DANGER_ORDER } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/threshold';
 import type { MetricAggregation } from 'types/api/v5/queryRange';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 import { ReduceOperators } from 'types/common/queryBuilder';
@@ -20,14 +22,6 @@ export interface PanelAlertPrefill {
 	operator?: AlertThresholdOperator;
 	threshold?: Threshold;
 }
-
-// Most-dangerous first, matching the panel editor palette; unknown colors sort last.
-const THRESHOLD_COLOR_DANGER_ORDER = [
-	'#f1575f',
-	'#f5b225',
-	'#2bb673',
-	'#4e74f8',
-];
 
 interface NormalizedPanelThreshold {
 	color: string;
@@ -93,8 +87,12 @@ function readPanelThresholds(
 	}
 }
 
+// Match case-insensitively (picker emits lowercase hex); unknown colors sort last.
 function colorRank(color: string): number {
-	const index = THRESHOLD_COLOR_DANGER_ORDER.indexOf(color.toLowerCase());
+	const target = color.toLowerCase();
+	const index = THRESHOLD_COLOR_DANGER_ORDER.findIndex(
+		(paletteColor) => paletteColor.toLowerCase() === target,
+	);
 	return index === -1 ? THRESHOLD_COLOR_DANGER_ORDER.length : index;
 }
 
@@ -106,22 +104,17 @@ function pickHighestDanger(
 	)[0];
 }
 
+// The alert UI has no inclusive operator; collapse "or equal" onto its strict variant.
 function panelOperatorToAlertOperator(
 	operator: DashboardtypesComparisonOperatorDTO | undefined,
 ): AlertThresholdOperator | undefined {
 	switch (operator) {
-		case 'above':
 		case 'above_or_equal':
-			return AlertThresholdOperator.IS_ABOVE;
-		case 'below':
+			return normalizeOperator('above');
 		case 'below_or_equal':
-			return AlertThresholdOperator.IS_BELOW;
-		case 'equal':
-			return AlertThresholdOperator.IS_EQUAL_TO;
-		case 'not_equal':
-			return AlertThresholdOperator.IS_NOT_EQUAL_TO;
+			return normalizeOperator('below');
 		default:
-			return undefined;
+			return normalizeOperator(operator);
 	}
 }
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

Follow-up to **#12137** (pre-populate alert condition from a V2 dashboard panel) that addresses code-review feedback. It's a pure code-quality pass — no user-facing behavior change — that removes duplicated magic values and hand-rolled mapping introduced by the feature PR:

- **Single source of truth for the threshold palette.** The SigNoz threshold hex values (`#F1575F` / `#F5B225` / `#2BB673` / `#4E74F8`) were hardcoded in three places — the color-picker presets, the default-threshold color, and a lowercased copy inside the alert-prefill danger ranking. They're now a `ThresholdColor` enum in `Panels/types/threshold.ts`, with a `THRESHOLD_COLOR_DANGER_ORDER` const derived from it. The picker presets, the section default, and `deriveAlertPrefill` all consume the enum, so the palette can only drift in one place.
- **Case-insensitive color matching kept.** `colorRank` still lowercases both sides when ranking, since the picker emits lowercase hex while the enum is uppercase — so the shared const doesn't reintroduce the mismatch the old local copy was working around.
- **Reuse `normalizeOperator` instead of a hand-rolled switch.** `panelOperatorToAlertOperator` no longer re-maps every operator by hand; it collapses the two inclusive operators (`above_or_equal` / `below_or_equal`) onto their strict variants — the alert UI has no inclusive operator — and delegates everything else to the existing `normalizeOperator` from `CreateAlertV2/context/conditionNormalizers`.

#### Screenshots / Screen Recordings (if applicable)
> N/A — no visual or behavioral change. The panel editor palette, default threshold color, and alert prefill produce identical results to #12137.

#### Issues closed by this PR
Closes https://github.com/SigNoz/pulse-pod/issues/122

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

N/A — not a bug fix.

---

### 🧪 Testing Strategy
> How was this change validated?

- **Tests added/updated:** None — behavior is unchanged, so the existing `deriveAlertPrefill` / prefill test suites from #12137 (color danger ranking incl. custom colors, `*_or_equal` operator mapping) continue to cover this code and stay green.
- **Manual verification:** Add/recolor thresholds in the V2 panel editor (presets + custom color) and Create Alert from a Value panel with a Red `> 90` threshold → occurrence, operator, and target prefill exactly as before.
- **Edge cases covered:** unknown/custom threshold colors still sort last; lowercase picker hex still ranks against the uppercase enum; inclusive `above_or_equal` / `below_or_equal` collapse to `Is above` / `Is below`.
- `pnpm tsgo --noEmit` and `pnpm lint:js` pass.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** V2 panel-editor threshold color selection and the panel→`/alerts/new` prefill derivation. No other consumers.
- **Potential regressions:** low. The enum values are byte-identical to the previous literals, and `normalizeOperator` maps `above`/`below` to the same operators the old switch produced. The only substantive shift is delegating the `default` case to `normalizeOperator`, which resolves more input forms than the old `undefined` fallthrough.
- **Rollback plan:** revert the PR — the change is self-contained to four frontend files with no schema, API, or persisted-state impact.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior

| Field | Value |
|------|-------|
| Deployment Type | N/A |
| Change Type | Maintenance |
| Description | N/A — internal refactor, no user-facing change. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required (behavior unchanged; covered by #12137 suites)
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- Addresses review comments on **#12137**; best read as a diff against that PR.
- The new `ThresholdColor` enum is uppercase hex; `deriveAlertPrefill.colorRank` intentionally lowercases both sides because the antd `ColorPicker` emits lowercase — dropping the `.toLowerCase()` would reintroduce the mismatch the deleted local array was compensating for.
- `THRESHOLD_COLOR_DANGER_ORDER` lives next to the enum (in `types/threshold.ts`) rather than in the prefill util so both the editor palette and the alert derivation share one ordering.

---
