### PR TITLE
fix: use container width for metrics treemap to account for sidebar

### DIFF
--- a/frontend/src/container/MetricsExplorer/Summary/MetricsTreemap.tsx
+++ b/frontend/src/container/MetricsExplorer/Summary/MetricsTreemap.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useMemo } from 'react';
-import { useWindowSize } from 'react-use';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Group } from '@visx/group';
 import { Treemap } from '@visx/hierarchy';
 import { Empty, Select, Skeleton, Tooltip } from 'antd';
@@ -33,16 +32,15 @@ function MetricsTreemapInternal({
 	data,
 	viewType,
 	openMetricDetails,
+	containerWidth,
 }: MetricsTreemapInternalProps): JSX.Element {
-	const { width: windowWidth } = useWindowSize();
-
 	const treemapWidth = useMemo(
 		() =>
 			Math.max(
-				windowWidth - TREEMAP_MARGINS.LEFT - TREEMAP_MARGINS.RIGHT - 70,
+				containerWidth - TREEMAP_MARGINS.LEFT - TREEMAP_MARGINS.RIGHT,
 				300,
 			),
-		[windowWidth],
+		[containerWidth],
 	);
 
 	const treemapData = useMemo(() => {
@@ -185,8 +183,29 @@ function MetricsTreemap({
 	openMetricDetails,
 	setHeatmapView,
 }: MetricsTreemapProps): JSX.Element {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [containerWidth, setContainerWidth] = useState(0);
+
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+
+		const observer = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				setContainerWidth(entry.contentRect.width);
+			}
+		});
+		observer.observe(container);
+
+		// Set initial width
+		setContainerWidth(container.getBoundingClientRect().width);
+
+		return (): void => observer.disconnect();
+	}, []);
+
 	return (
 		<div
+			ref={containerRef}
 			className="metrics-treemap-container"
 			data-testid="metrics-treemap-container"
 		>
@@ -214,6 +233,7 @@ function MetricsTreemap({
 				data={data}
 				viewType={viewType}
 				openMetricDetails={openMetricDetails}
+				containerWidth={containerWidth}
 			/>
 		</div>
 	);

--- a/frontend/src/container/MetricsExplorer/Summary/__tests__/MetricsTreemap.test.tsx
+++ b/frontend/src/container/MetricsExplorer/Summary/__tests__/MetricsTreemap.test.tsx
@@ -22,9 +22,6 @@ jest.mock('d3-hierarchy', () => ({
 	}),
 	treemapBinary: jest.fn(),
 }));
-jest.mock('react-use', () => ({
-	useWindowSize: jest.fn().mockReturnValue({ width: 1000, height: 1000 }),
-}));
 
 const mockData = [
 	{

--- a/frontend/src/container/MetricsExplorer/Summary/__tests__/Summary.test.tsx
+++ b/frontend/src/container/MetricsExplorer/Summary/__tests__/Summary.test.tsx
@@ -23,9 +23,6 @@ jest.mock('d3-hierarchy', () => ({
 	}),
 	treemapBinary: jest.fn(),
 }));
-jest.mock('react-use', () => ({
-	useWindowSize: jest.fn().mockReturnValue({ width: 1000, height: 1000 }),
-}));
 jest.mock('react-router-dom-v5-compat', () => {
 	const actual = jest.requireActual('react-router-dom-v5-compat');
 	return {

--- a/frontend/src/container/MetricsExplorer/Summary/types.ts
+++ b/frontend/src/container/MetricsExplorer/Summary/types.ts
@@ -62,6 +62,7 @@ export interface MetricsTreemapInternalProps {
 		view: 'list' | 'treemap',
 		event?: React.MouseEvent,
 	) => void;
+	containerWidth: number;
 }
 
 export interface OrderByPayload {


### PR DESCRIPTION
## Summary

Fixes #9120

The Metrics Explorer treemap was using `useWindowSize()` from `react-use` which returns the full viewport width. When the sidebar is open (54px collapsed or 240px pinned), the treemap overflowed because it did not account for the sidebar width.

## Changes

- Replaced `useWindowSize()` with a `ResizeObserver` on the treemap container element to get the actual available content width
- Added `containerWidth` prop to `MetricsTreemapInternal` instead of relying on window dimensions
- Updated the treemap width calculation to use the container width, ensuring it fits correctly regardless of sidebar state
- Removed the unused `react-use` mock from related test files

## Files changed

- `frontend/src/container/MetricsExplorer/Summary/MetricsTreemap.tsx` - Core fix
- `frontend/src/container/MetricsExplorer/Summary/types.ts` - Added `containerWidth` prop
- `frontend/src/container/MetricsExplorer/Summary/__tests__/MetricsTreemap.test.tsx` - Removed unused mock
- `frontend/src/container/MetricsExplorer/Summary/__tests__/Summary.test.tsx` - Removed unused mock