### PR TITLE
fix: css fixes for llm o11y model pricing and overview 

### DIFF
--- a/frontend/src/container/LLMObservability/Overview/Overview.module.scss
+++ b/frontend/src/container/LLMObservability/Overview/Overview.module.scss
@@ -9,6 +9,4 @@
 	:global([class*='dashboardPageHeader']) {
 		display: none;
 	}
-	// remove margin added by the hidden header to avoid extra whitespace at the top of the page
-	margin-top: calc(var(--spacing-8) * -1);
 }

--- a/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/ModelCostDrawer.module.scss
+++ b/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/ModelCostDrawer.module.scss
@@ -18,14 +18,10 @@
 	--dialog-footer-padding: var(--spacing-8) var(--spacing-12);
 
 	display: flex;
-	// Keep the scroll off the content container so the header and footer stay
-	// pinned; only the body scrolls (see [data-slot='drawer-description'] below).
 	overflow: hidden;
 
 	// The drawer body — children render inside [data-slot='drawer-description']
 	// (this is the @signozhq drawer, not antd, so .ant-drawer-body was a no-op).
-	// flex:1 + min-height:0 lets it shrink and scroll within the fixed-height
-	// flex column, leaving the fit-content header/footer sticky.
 	[data-slot='drawer-description'] {
 		display: flex;
 		flex-direction: column;

--- a/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/ModelCostDrawer.module.scss
+++ b/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/ModelCostDrawer.module.scss
@@ -18,15 +18,21 @@
 	--dialog-footer-padding: var(--spacing-8) var(--spacing-12);
 
 	display: flex;
-	overflow-y: auto;
+	// Keep the scroll off the content container so the header and footer stay
+	// pinned; only the body scrolls (see [data-slot='drawer-description'] below).
+	overflow: hidden;
 
 	// The drawer body — children render inside [data-slot='drawer-description']
 	// (this is the @signozhq drawer, not antd, so .ant-drawer-body was a no-op).
+	// flex:1 + min-height:0 lets it shrink and scroll within the fixed-height
+	// flex column, leaving the fit-content header/footer sticky.
 	[data-slot='drawer-description'] {
 		display: flex;
 		flex-direction: column;
 		gap: var(--spacing-12);
 		padding: var(--spacing-10) var(--spacing-12);
+		min-height: 0;
+		overflow-y: auto;
 	}
 
 	[data-slot='select-content'] {

--- a/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/components/ExtraPricingBuckets/ExtraPricingBuckets.module.scss
+++ b/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/components/ExtraPricingBuckets/ExtraPricingBuckets.module.scss
@@ -51,7 +51,6 @@
 	gap: var(--spacing-5);
 	padding: var(--spacing-6);
 	border-radius: 6px;
-	background: var(--l2-background);
 	border: 1px solid var(--l2-border);
 }
 

--- a/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/components/PatternEditor/PatternEditor.module.scss
+++ b/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/components/PatternEditor/PatternEditor.module.scss
@@ -17,7 +17,7 @@
 .patternChips {
 	display: flex;
 	flex-wrap: wrap;
-	gap: var(--spacing-3);
+	gap: var(--spacing-0) var(--spacing-3);
 }
 
 .patternChip {

--- a/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/components/PatternEditor/PatternEditor.module.scss
+++ b/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/components/PatternEditor/PatternEditor.module.scss
@@ -9,7 +9,6 @@
 .patternBox {
 	display: flex;
 	flex-direction: column;
-	gap: var(--spacing-6);
 	padding: var(--spacing-6);
 	border-radius: 6px;
 	border: 1px solid var(--l2-border);
@@ -19,13 +18,13 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: var(--spacing-3);
-	min-height: 28px;
 }
 
 .patternChip {
 	display: inline-flex;
 	align-items: center;
 	gap: var(--spacing-2);
+	margin-bottom: var(--spacing-4);
 }
 
 .patternChipRemove {

--- a/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/components/SourceSelector/SourceSelector.module.scss
+++ b/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/components/SourceSelector/SourceSelector.module.scss
@@ -30,7 +30,6 @@
 		padding: var(--spacing-5) var(--spacing-6);
 		border-radius: var(--radius-2);
 		border: 1px solid transparent;
-		background: var(--l3-background);
 		margin: 0;
 		width: 100%;
 		// Include padding + border in the 100% width so the card fits inside
@@ -67,14 +66,9 @@
 
 		// Radix RadioGroupItem renders <button data-state="checked|unchecked">.
 		// Use :has() to highlight the wrapper card when its inner button is checked.
-		&.sourceRadioAuto:has(button[data-state='checked']) {
+		&:has(button[data-state='checked']) {
 			background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
 			border-color: color-mix(in srgb, var(--accent-primary) 30%, transparent);
-		}
-
-		&.sourceRadioOverride:has(button[data-state='checked']) {
-			background: color-mix(in srgb, var(--accent-amber) 10%, transparent);
-			border-color: color-mix(in srgb, var(--accent-amber) 30%, transparent);
 		}
 
 		&:hover {

--- a/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/components/SourceSelector/SourceSelector.tsx
+++ b/frontend/src/container/LLMObservability/Settings/ModelPricing/ModelCostTabPanel/components/ModelCostDrawer/components/SourceSelector/SourceSelector.tsx
@@ -60,7 +60,7 @@ function SourceSelector({
 			>
 				<RadioGroupItem
 					value="auto"
-					containerClassName={cx(styles.sourceRadio, styles.sourceRadioAuto)}
+					containerClassName={styles.sourceRadio}
 					testId="drawer-source-auto"
 					disabled={disableAuto}
 				>
@@ -73,7 +73,7 @@ function SourceSelector({
 				</RadioGroupItem>
 				<RadioGroupItem
 					value="override"
-					containerClassName={cx(styles.sourceRadio, styles.sourceRadioOverride)}
+					containerClassName={styles.sourceRadio}
 					testId="drawer-source-override"
 				>
 					<div className={styles.sourceRadioTitle}>User override</div>

--- a/frontend/src/container/LLMObservability/Settings/ModelPricing/UnpricedModelsTab/UnpricedModelsTab.module.scss
+++ b/frontend/src/container/LLMObservability/Settings/ModelPricing/UnpricedModelsTab/UnpricedModelsTab.module.scss
@@ -13,6 +13,7 @@
 	border: 1px solid color-mix(in srgb, var(--bg-amber-400) 30%, transparent);
 	background: color-mix(in srgb, var(--bg-amber-400) 8%, transparent);
 	color: var(--bg-amber-300, var(--bg-amber-400));
+	margin-top: var(--spacing-4);
 }
 
 .bannerIcon {


### PR DESCRIPTION

## Summary

CSS-only fixes for AI observability model pricing and overview, split out of #12123 per review feedback:

- **Overview**: remove the negative `margin-top` compensation for the hidden dashboard page header

prev- 
 
<img width="1110" height="333" alt="image" src="https://github.com/user-attachments/assets/c2a33526-0c3f-4a4a-87b2-6d660593daf0" />

Now - 
<img width="1128" height="326" alt="image" src="https://github.com/user-attachments/assets/3f1abcc5-65a8-45e4-84bb-456a0109c048" />



- **SourceSelector (ModelCostDrawer)**: drop the per-variant (`auto`/`override`) checked-state styling in favor of a single accent style, and remove the card background

Prev - 
<img width="584" height="964" alt="image" src="https://github.com/user-attachments/assets/c25204c3-2c5b-4205-ae87-f889f881efc3" />

Now - 
<img width="578" height="797" alt="image" src="https://github.com/user-attachments/assets/a7671eb3-37cb-4962-8955-6ef12ba52352" />

- **ExtraPricingBuckets**: remove the `--l2-background` on the bucket card

Prev -  
<img width="568" height="543" alt="image" src="https://github.com/user-attachments/assets/0cf67055-d40f-429f-b28b-128804ce297a" />

Now - 
<img width="551" height="428" alt="image" src="https://github.com/user-attachments/assets/efbbdce5-0074-418b-85e2-3edb8da188c6" />


- **UnpricedModelsTab**: add `margin-top` spacing to the banner

Prev - 
<img width="1105" height="309" alt="image" src="https://github.com/user-attachments/assets/dd50633f-c112-4734-bf19-89ab5b9bd22c" />


Now  - 

<img width="1082" height="274" alt="image" src="https://github.com/user-attachments/assets/778bd3fd-2cb2-4125-a992-e5a8d222fa7a" />


- **PatternEditor**: tighten spacing between pattern chips — drop the row gap, keep only the column gap (`var(--spacing-0) var(--spacing-3)`), and add `margin-bottom` below the chip row.

- **ModelCostDrawer**: constrain the drawer container to `overflow: hidden` and move scrolling into the inner content (`min-height: 0; overflow-y: auto`) so the  body scrolls on its own instead of the whole drawer.

No functional changes — only styling and the classNames that feed it.


Scroll on drawer body - 

https://github.com/user-attachments/assets/bb28a795-f260-4d6d-9f90-2875f6409efb
