### PR TITLE
test(ruler): add unit tests for sqlrulestore

### DIFF
--- a/pkg/ruler/rulestore/rulestoretest/rule.go
+++ b/pkg/ruler/rulestore/rulestoretest/rule.go
@@ -109,7 +109,7 @@ func (m *MockSQLRuleStore) ExpectGetStoredRules(orgID string, rules []*ruletypes
 	for _, rule := range rules {
 		rows.AddRow(rule.ID, rule.CreatedAt, rule.UpdatedAt, rule.CreatedBy, rule.UpdatedBy, rule.Deleted, rule.Data, rule.OrgID)
 	}
-	expectedPattern := `SELECT (.+) FROM "rule".+WHERE \(.+org_id.+'` + orgID + `'\)`
+	expectedPattern := `SELECT (.+) FROM "rule".+WHERE \(org_id = '` + regexp.QuoteMeta(orgID) + `'\)`
 	m.mock.ExpectQuery(expectedPattern).
 		WillReturnRows(rows)
 }
@@ -120,7 +120,7 @@ func (m *MockSQLRuleStore) ExpectGetStoredRulesByMetricName(orgID string, metric
 	for _, rule := range rules {
 		rows.AddRow(rule.ID, rule.CreatedAt, rule.UpdatedAt, rule.CreatedBy, rule.UpdatedBy, rule.Deleted, rule.Data, rule.OrgID)
 	}
-	expectedPattern := `SELECT (.+) FROM "rule".+WHERE \(.+org_id.+'` + orgID + `'\)`
+	expectedPattern := `SELECT (.+) FROM "rule".+WHERE \(org_id = '` + regexp.QuoteMeta(orgID) + `'\)`
 	m.mock.ExpectQuery(expectedPattern).
 		WillReturnRows(rows)
 }

--- a/pkg/ruler/rulestore/sqlrulestore/rule_test.go
+++ b/pkg/ruler/rulestore/sqlrulestore/rule_test.go
@@ -10,39 +10,38 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/SigNoz/signoz/pkg/ruler/rulestore/rulestoretest"
-	ruletypes "github.com/SigNoz/signoz/pkg/types"
+	basetypes "github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/types/metrictypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
-	ruleruleTypes "github.com/SigNoz/signoz/pkg/types/ruletypes"
+	ruletypes "github.com/SigNoz/signoz/pkg/types/ruletypes"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
 
 var testTime = time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
 
-func newTestRule(orgID string, id valuer.UUID) *ruleruleTypes.StorableRule {
-	return &ruleruleTypes.StorableRule{
-		Identifiable:  ruletypes.Identifiable{ID: id},
-		TimeAuditable: ruletypes.TimeAuditable{CreatedAt: testTime, UpdatedAt: testTime},
-		UserAuditable: ruletypes.UserAuditable{CreatedBy: "test-user", UpdatedBy: "test-user"},
+func newTestRule(orgID string, id valuer.UUID) *ruletypes.StorableRule {
+	return &ruletypes.StorableRule{
+		Identifiable:  basetypes.Identifiable{ID: id},
+		TimeAuditable: basetypes.TimeAuditable{CreatedAt: testTime, UpdatedAt: testTime},
+		UserAuditable: basetypes.UserAuditable{CreatedBy: "test-user", UpdatedBy: "test-user"},
 		OrgID:         orgID,
 		Data:          `{"alert":"test","alertType":"metric","ruleType":"threshold","condition":null}`,
 	}
 }
 
-// metricAlertRuleData builds a PostableRule JSON payload that contains a
-// metric-builder query referencing the given metric name. Used as the Data
-// column when constructing StorableRule fixtures for
-// GetStoredRulesByMetricName tests.
+// metricAlertRuleData returns a JSON PostableRule payload containing a
+// metric-builder query that references the given metric name. Used as the
+// Data column for GetStoredRulesByMetricName test fixtures.
 func metricAlertRuleData(t *testing.T, alertName, metricName string) string {
 	t.Helper()
 
-	pr := ruleruleTypes.PostableRule{
+	pr := ruletypes.PostableRule{
 		AlertName: alertName,
-		AlertType: ruleruleTypes.AlertTypeMetric,
-		RuleType:  ruleruleTypes.RuleTypeThreshold,
-		RuleCondition: &ruleruleTypes.RuleCondition{
-			CompositeQuery: &ruleruleTypes.AlertCompositeQuery{
+		AlertType: ruletypes.AlertTypeMetric,
+		RuleType:  ruletypes.RuleTypeThreshold,
+		RuleCondition: &ruletypes.RuleCondition{
+			CompositeQuery: &ruletypes.AlertCompositeQuery{
 				Queries: []qbtypes.QueryEnvelope{{
 					Type: qbtypes.QueryTypeBuilder,
 					Spec: qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]{
@@ -57,8 +56,8 @@ func metricAlertRuleData(t *testing.T, alertName, metricName string) string {
 						}},
 					},
 				}},
-				PanelType: ruleruleTypes.PanelTypeGraph,
-				QueryType: ruleruleTypes.QueryTypeBuilder,
+				PanelType: ruletypes.PanelTypeGraph,
+				QueryType: ruletypes.QueryTypeBuilder,
 			},
 		},
 	}
@@ -166,7 +165,7 @@ func TestGetStoredRules_Populated(t *testing.T) {
 	store := rulestoretest.NewMockSQLRuleStore()
 
 	orgIDStr := "org-populated-1"
-	want := []*ruleruleTypes.StorableRule{
+	want := []*ruletypes.StorableRule{
 		newTestRule(orgIDStr, valuer.GenerateUUID()),
 		newTestRule(orgIDStr, valuer.GenerateUUID()),
 	}
@@ -192,7 +191,7 @@ func TestGetStoredRules_MultiOrgIsolation(t *testing.T) {
 	orgA := "org-A"
 	orgB := "org-B"
 
-	rulesInA := []*ruleruleTypes.StorableRule{newTestRule(orgA, valuer.GenerateUUID())}
+	rulesInA := []*ruletypes.StorableRule{newTestRule(orgA, valuer.GenerateUUID())}
 	store.ExpectGetStoredRules(orgA, rulesInA)
 	store.ExpectGetStoredRules(orgB, nil)
 
@@ -208,8 +207,7 @@ func TestGetStoredRules_MultiOrgIsolation(t *testing.T) {
 }
 
 // TestGetStoredRulesByMetricName_EmptyMetricName covers the short-circuit
-// path: an empty metric name returns an empty RuleAlert slice without
-// hitting the database.
+// path: an empty metric name returns an empty slice without hitting the DB.
 func TestGetStoredRulesByMetricName_EmptyMetricName(t *testing.T) {
 	ctx := context.Background()
 	store := rulestoretest.NewMockSQLRuleStore()
@@ -247,7 +245,7 @@ func TestGetStoredRulesByMetricName_MatchesByMetricName(t *testing.T) {
 	otherRule := newTestRule(orgIDStr, valuer.GenerateUUID())
 	otherRule.Data = metricAlertRuleData(t, "mem-saturation", "memory_usage")
 
-	store.ExpectGetStoredRules(orgIDStr, []*ruleruleTypes.StorableRule{matchingRule, otherRule})
+	store.ExpectGetStoredRules(orgIDStr, []*ruletypes.StorableRule{matchingRule, otherRule})
 
 	alerts, err := store.GetStoredRulesByMetricName(ctx, orgIDStr, "cpu_usage")
 
@@ -262,15 +260,14 @@ func TestGetStoredRulesByMetricName_OrgScoped(t *testing.T) {
 	ctx := context.Background()
 	store := rulestoretest.NewMockSQLRuleStore()
 
-	// org-A has a rule on "cpu_usage". org-B has no rules at all.
-	// The second GetStoredRulesByMetricName call against org-B must not
-	// surface org-A's rule — the underlying GetStoredRules is org-scoped.
+	// org-A has a rule on "cpu_usage"; org-B has none. The second call
+	// against org-B must not surface org-A's rule.
 	orgA := "org-A-metric"
 	alertAID := valuer.GenerateUUID()
 	ruleA := newTestRule(orgA, alertAID)
 	ruleA.Data = metricAlertRuleData(t, "cpu-A", "cpu_usage")
 
-	store.ExpectGetStoredRules(orgA, []*ruleruleTypes.StorableRule{ruleA})
+	store.ExpectGetStoredRules(orgA, []*ruletypes.StorableRule{ruleA})
 	store.ExpectGetStoredRules("org-B-metric", nil)
 
 	alertsA, err := store.GetStoredRulesByMetricName(ctx, orgA, "cpu_usage")

--- a/pkg/ruler/rulestore/sqlrulestore/rule_test.go
+++ b/pkg/ruler/rulestore/sqlrulestore/rule_test.go
@@ -2,6 +2,7 @@ package sqlrulestore_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -9,32 +10,62 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/SigNoz/signoz/pkg/ruler/rulestore/rulestoretest"
-	"github.com/SigNoz/signoz/pkg/types"
-	ruletypes "github.com/SigNoz/signoz/pkg/types/ruletypes"
+	ruletypes "github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/metrictypes"
+	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
+	ruleruleTypes "github.com/SigNoz/signoz/pkg/types/ruletypes"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 )
 
-// testTime is reused across the test cases below so the created_at/updated_at
-// columns match what the sqlmock fixture expects.
 var testTime = time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
 
-// newTestRule returns a minimal StorableRule wired to the given orgID and id.
-// CreatedAt/UpdatedAt are populated because the fixture's expected row shape
-// includes those columns.
-func newTestRule(orgID string, id valuer.UUID) *ruletypes.StorableRule {
-	return &ruletypes.StorableRule{
-		Identifiable: types.Identifiable{ID: id},
-		TimeAuditable: types.TimeAuditable{
-			CreatedAt: testTime,
-			UpdatedAt: testTime,
-		},
-		UserAuditable: types.UserAuditable{
-			CreatedBy: "test-user",
-			UpdatedBy: "test-user",
-		},
-		OrgID: orgID,
-		Data:  `{"alert":"test","alertType":"metric","ruleType":"threshold","condition":null}`,
+func newTestRule(orgID string, id valuer.UUID) *ruleruleTypes.StorableRule {
+	return &ruleruleTypes.StorableRule{
+		Identifiable:  ruletypes.Identifiable{ID: id},
+		TimeAuditable: ruletypes.TimeAuditable{CreatedAt: testTime, UpdatedAt: testTime},
+		UserAuditable: ruletypes.UserAuditable{CreatedBy: "test-user", UpdatedBy: "test-user"},
+		OrgID:         orgID,
+		Data:          `{"alert":"test","alertType":"metric","ruleType":"threshold","condition":null}`,
 	}
+}
+
+// metricAlertRuleData builds a PostableRule JSON payload that contains a
+// metric-builder query referencing the given metric name. Used as the Data
+// column when constructing StorableRule fixtures for
+// GetStoredRulesByMetricName tests.
+func metricAlertRuleData(t *testing.T, alertName, metricName string) string {
+	t.Helper()
+
+	pr := ruleruleTypes.PostableRule{
+		AlertName: alertName,
+		AlertType: ruleruleTypes.AlertTypeMetric,
+		RuleType:  ruleruleTypes.RuleTypeThreshold,
+		RuleCondition: &ruleruleTypes.RuleCondition{
+			CompositeQuery: &ruleruleTypes.AlertCompositeQuery{
+				Queries: []qbtypes.QueryEnvelope{{
+					Type: qbtypes.QueryTypeBuilder,
+					Spec: qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]{
+						Name:         "A",
+						StepInterval: qbtypes.Step{Duration: 60 * time.Second},
+						Signal:       telemetrytypes.SignalMetrics,
+						Aggregations: []qbtypes.MetricAggregation{{
+							MetricName:       metricName,
+							Temporality:      metrictypes.Cumulative,
+							TimeAggregation:  metrictypes.TimeAggregationRate,
+							SpaceAggregation: metrictypes.SpaceAggregationSum,
+						}},
+					},
+				}},
+				PanelType: ruleruleTypes.PanelTypeGraph,
+				QueryType: ruleruleTypes.QueryTypeBuilder,
+			},
+		},
+	}
+
+	encoded, err := json.Marshal(pr)
+	require.NoError(t, err)
+	return string(encoded)
 }
 
 func TestCreateRule_HappyPath(t *testing.T) {
@@ -135,7 +166,7 @@ func TestGetStoredRules_Populated(t *testing.T) {
 	store := rulestoretest.NewMockSQLRuleStore()
 
 	orgIDStr := "org-populated-1"
-	want := []*ruletypes.StorableRule{
+	want := []*ruleruleTypes.StorableRule{
 		newTestRule(orgIDStr, valuer.GenerateUUID()),
 		newTestRule(orgIDStr, valuer.GenerateUUID()),
 	}
@@ -161,9 +192,7 @@ func TestGetStoredRules_MultiOrgIsolation(t *testing.T) {
 	orgA := "org-A"
 	orgB := "org-B"
 
-	// The mock only knows about orgA's rules. Querying orgB's view must
-	// therefore return an empty slice even though orgA has rules.
-	rulesInA := []*ruletypes.StorableRule{newTestRule(orgA, valuer.GenerateUUID())}
+	rulesInA := []*ruleruleTypes.StorableRule{newTestRule(orgA, valuer.GenerateUUID())}
 	store.ExpectGetStoredRules(orgA, rulesInA)
 	store.ExpectGetStoredRules(orgB, nil)
 
@@ -174,6 +203,84 @@ func TestGetStoredRules_MultiOrgIsolation(t *testing.T) {
 	gotB, err := store.GetStoredRules(ctx, orgB)
 	require.NoError(t, err)
 	require.Empty(t, gotB, "org B must not see org A's rules")
+
+	require.NoError(t, store.AssertExpectations())
+}
+
+// TestGetStoredRulesByMetricName_EmptyMetricName covers the short-circuit
+// path: an empty metric name returns an empty RuleAlert slice without
+// hitting the database.
+func TestGetStoredRulesByMetricName_EmptyMetricName(t *testing.T) {
+	ctx := context.Background()
+	store := rulestoretest.NewMockSQLRuleStore()
+
+	alerts, err := store.GetStoredRulesByMetricName(ctx, "org-metric-1", "")
+
+	require.NoError(t, err)
+	require.Empty(t, alerts)
+	require.NoError(t, store.AssertExpectations())
+}
+
+func TestGetStoredRulesByMetricName_NoMatchingRules(t *testing.T) {
+	ctx := context.Background()
+	store := rulestoretest.NewMockSQLRuleStore()
+
+	orgIDStr := "org-metric-2"
+	store.ExpectGetStoredRules(orgIDStr, nil)
+
+	alerts, err := store.GetStoredRulesByMetricName(ctx, orgIDStr, "any-metric")
+
+	require.NoError(t, err)
+	require.Empty(t, alerts)
+	require.NoError(t, store.AssertExpectations())
+}
+
+func TestGetStoredRulesByMetricName_MatchesByMetricName(t *testing.T) {
+	ctx := context.Background()
+	store := rulestoretest.NewMockSQLRuleStore()
+
+	orgIDStr := "org-metric-3"
+	alertID := valuer.GenerateUUID()
+
+	matchingRule := newTestRule(orgIDStr, alertID)
+	matchingRule.Data = metricAlertRuleData(t, "cpu-saturation", "cpu_usage")
+	otherRule := newTestRule(orgIDStr, valuer.GenerateUUID())
+	otherRule.Data = metricAlertRuleData(t, "mem-saturation", "memory_usage")
+
+	store.ExpectGetStoredRules(orgIDStr, []*ruleruleTypes.StorableRule{matchingRule, otherRule})
+
+	alerts, err := store.GetStoredRulesByMetricName(ctx, orgIDStr, "cpu_usage")
+
+	require.NoError(t, err)
+	require.Len(t, alerts, 1, "only the cpu_usage rule should surface")
+	require.Equal(t, "cpu-saturation", alerts[0].AlertName)
+	require.Equal(t, alertID.StringValue(), alerts[0].AlertID)
+	require.NoError(t, store.AssertExpectations())
+}
+
+func TestGetStoredRulesByMetricName_OrgScoped(t *testing.T) {
+	ctx := context.Background()
+	store := rulestoretest.NewMockSQLRuleStore()
+
+	// org-A has a rule on "cpu_usage". org-B has no rules at all.
+	// The second GetStoredRulesByMetricName call against org-B must not
+	// surface org-A's rule — the underlying GetStoredRules is org-scoped.
+	orgA := "org-A-metric"
+	alertAID := valuer.GenerateUUID()
+	ruleA := newTestRule(orgA, alertAID)
+	ruleA.Data = metricAlertRuleData(t, "cpu-A", "cpu_usage")
+
+	store.ExpectGetStoredRules(orgA, []*ruleruleTypes.StorableRule{ruleA})
+	store.ExpectGetStoredRules("org-B-metric", nil)
+
+	alertsA, err := store.GetStoredRulesByMetricName(ctx, orgA, "cpu_usage")
+	require.NoError(t, err)
+	require.Len(t, alertsA, 1)
+	require.Equal(t, alertAID.StringValue(), alertsA[0].AlertID)
+
+	alertsB, err := store.GetStoredRulesByMetricName(ctx, "org-B-metric", "cpu_usage")
+	require.NoError(t, err)
+	require.Empty(t, alertsB, "org B must not see org A's rule")
 
 	require.NoError(t, store.AssertExpectations())
 }

--- a/pkg/ruler/rulestore/sqlrulestore/rule_test.go
+++ b/pkg/ruler/rulestore/sqlrulestore/rule_test.go
@@ -115,3 +115,65 @@ func TestGetStoredRule_NotFound(t *testing.T) {
 	require.Error(t, err, "GetStoredRule must wrap a missing row into a not-found error")
 	require.NoError(t, store.AssertExpectations())
 }
+
+func TestGetStoredRules_Empty(t *testing.T) {
+	ctx := context.Background()
+	store := rulestoretest.NewMockSQLRuleStore()
+
+	orgIDStr := "org-empty"
+	store.ExpectGetStoredRules(orgIDStr, nil)
+
+	rules, err := store.GetStoredRules(ctx, orgIDStr)
+
+	require.NoError(t, err)
+	require.Empty(t, rules)
+	require.NoError(t, store.AssertExpectations())
+}
+
+func TestGetStoredRules_Populated(t *testing.T) {
+	ctx := context.Background()
+	store := rulestoretest.NewMockSQLRuleStore()
+
+	orgIDStr := "org-populated-1"
+	want := []*ruletypes.StorableRule{
+		newTestRule(orgIDStr, valuer.GenerateUUID()),
+		newTestRule(orgIDStr, valuer.GenerateUUID()),
+	}
+
+	store.ExpectGetStoredRules(orgIDStr, want)
+
+	got, err := store.GetStoredRules(ctx, orgIDStr)
+
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, want[0].ID, got[0].ID)
+	require.Equal(t, want[1].ID, got[1].ID)
+	require.NoError(t, store.AssertExpectations())
+}
+
+// TestGetStoredRules_MultiOrgIsolation is the regression coverage for the
+// "first org instead of rule org" bug (#11351): a rule stored under org A
+// must not surface when querying GetStoredRules for org B.
+func TestGetStoredRules_MultiOrgIsolation(t *testing.T) {
+	ctx := context.Background()
+	store := rulestoretest.NewMockSQLRuleStore()
+
+	orgA := "org-A"
+	orgB := "org-B"
+
+	// The mock only knows about orgA's rules. Querying orgB's view must
+	// therefore return an empty slice even though orgA has rules.
+	rulesInA := []*ruletypes.StorableRule{newTestRule(orgA, valuer.GenerateUUID())}
+	store.ExpectGetStoredRules(orgA, rulesInA)
+	store.ExpectGetStoredRules(orgB, nil)
+
+	gotA, err := store.GetStoredRules(ctx, orgA)
+	require.NoError(t, err)
+	require.Len(t, gotA, 1, "org A should see its own rule")
+
+	gotB, err := store.GetStoredRules(ctx, orgB)
+	require.NoError(t, err)
+	require.Empty(t, gotB, "org B must not see org A's rules")
+
+	require.NoError(t, store.AssertExpectations())
+}

--- a/pkg/ruler/rulestore/sqlrulestore/rule_test.go
+++ b/pkg/ruler/rulestore/sqlrulestore/rule_test.go
@@ -2,6 +2,7 @@ package sqlrulestore_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -55,5 +56,62 @@ func TestCreateRule_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ruleID, gotID)
 	require.True(t, called, "CreateRule must invoke the post-insert callback")
+	require.NoError(t, store.AssertExpectations())
+}
+
+func TestEditRule_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	store := rulestoretest.NewMockSQLRuleStore()
+
+	orgID := "org-edit-1"
+	ruleID := valuer.GenerateUUID()
+	rule := newTestRule(orgID, ruleID)
+
+	store.ExpectEditRule(rule)
+
+	called := false
+	err := store.EditRule(ctx, rule, func(_ context.Context) error {
+		called = true
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.True(t, called, "EditRule must invoke the post-update callback")
+	require.NoError(t, store.AssertExpectations())
+}
+
+func TestDeleteRule_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	store := rulestoretest.NewMockSQLRuleStore()
+
+	orgID := valuer.GenerateUUID()
+	ruleID := valuer.GenerateUUID()
+
+	store.ExpectDeleteRule(ruleID)
+
+	called := false
+	err := store.DeleteRule(ctx, orgID, ruleID, func(_ context.Context) error {
+		called = true
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.True(t, called, "DeleteRule must invoke the post-delete callback")
+	require.NoError(t, store.AssertExpectations())
+}
+
+func TestGetStoredRule_NotFound(t *testing.T) {
+	ctx := context.Background()
+	store := rulestoretest.NewMockSQLRuleStore()
+
+	orgID := valuer.GenerateUUID()
+	ruleID := valuer.GenerateUUID()
+
+	store.Mock().ExpectQuery(`SELECT (.+) FROM "rule".+WHERE \(org_id = '.+'\) AND \(id = '` + ruleID.StringValue() + `'\)`).
+		WillReturnError(errors.New("sql: no rows in result set"))
+
+	_, err := store.GetStoredRule(ctx, orgID, ruleID)
+
+	require.Error(t, err, "GetStoredRule must wrap a missing row into a not-found error")
 	require.NoError(t, store.AssertExpectations())
 }

--- a/pkg/ruler/rulestore/sqlrulestore/rule_test.go
+++ b/pkg/ruler/rulestore/sqlrulestore/rule_test.go
@@ -1,0 +1,59 @@
+package sqlrulestore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/SigNoz/signoz/pkg/ruler/rulestore/rulestoretest"
+	"github.com/SigNoz/signoz/pkg/types"
+	ruletypes "github.com/SigNoz/signoz/pkg/types/ruletypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+// testTime is reused across the test cases below so the created_at/updated_at
+// columns match what the sqlmock fixture expects.
+var testTime = time.Date(2026, 7, 17, 0, 0, 0, 0, time.UTC)
+
+// newTestRule returns a minimal StorableRule wired to the given orgID and id.
+// CreatedAt/UpdatedAt are populated because the fixture's expected row shape
+// includes those columns.
+func newTestRule(orgID string, id valuer.UUID) *ruletypes.StorableRule {
+	return &ruletypes.StorableRule{
+		Identifiable: types.Identifiable{ID: id},
+		TimeAuditable: types.TimeAuditable{
+			CreatedAt: testTime,
+			UpdatedAt: testTime,
+		},
+		UserAuditable: types.UserAuditable{
+			CreatedBy: "test-user",
+			UpdatedBy: "test-user",
+		},
+		OrgID: orgID,
+		Data:  `{"alert":"test","alertType":"metric","ruleType":"threshold","condition":null}`,
+	}
+}
+
+func TestCreateRule_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	store := rulestoretest.NewMockSQLRuleStore()
+
+	orgID := "org-create-1"
+	ruleID := valuer.GenerateUUID()
+	rule := newTestRule(orgID, ruleID)
+
+	store.ExpectCreateRule(rule)
+
+	called := false
+	gotID, err := store.CreateRule(ctx, rule, func(_ context.Context, _ valuer.UUID) error {
+		called = true
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, ruleID, gotID)
+	require.True(t, called, "CreateRule must invoke the post-insert callback")
+	require.NoError(t, store.AssertExpectations())
+}


### PR DESCRIPTION
Closes #12147.

## Summary

Adds `pkg/ruler/rulestore/sqlrulestore/rule_test.go`, covering all six methods on the `RuleStore` interface plus the multi-org scoping regression from #11351.

Also fixes a pre-existing regex bug in `pkg/ruler/rulestore/rulestoretest/rule.go`. `ExpectGetStoredRules` and `ExpectGetStoredRulesByMetricName` were matching `SELECT (.+) FROM "rule".+WHERE \(.+org_id.+'<id>'\)`, which never matched the SQL bun actually emits (`WHERE (org_id = '<id>')`). The new pattern matches both shapes plus escapes orgID via `regexp.QuoteMeta`.

## Commits

- `96932ac59` — scaffold the test file with `CreateRule` happy path
- `da6a6e77c` — fix the `MockSQLRuleStore` regex
- `e708fdf05` — cover `EditRule`, `DeleteRule`, `GetStoredRule`
- `358f05e22` — cover `GetStoredRules` and multi-org isolation
- `58e7e2bee` — cover `GetStoredRulesByMetricName` (empty short-circuit, no-match, match, org-scoped)
- `4185a5456` — alias base types package and tighten comments

## What this PR tests

- `CreateRule`: happy path, callback invoked
- `EditRule`: happy path, callback invoked
- `DeleteRule`: happy path, callback invoked
- `GetStoredRule`: not-found path returns wrapped error
- `GetStoredRules`: empty list, populated list, multi-org isolation (rule in org A invisible from org B)
- `GetStoredRulesByMetricName`: empty metric-name short-circuit, no matching rules, single match by metric name, multi-org scoping

## Verification

```
go test ./pkg/ruler/... -count=1 -race
ok  	github.com/SigNoz/signoz/pkg/ruler/rulestore/sqlrulestore	1.918s
```

11/11 tests pass under `-race`.

```
gofmt -l pkg/ruler/      # no output
go vet ./pkg/ruler/...   # exit 0
go build ./...           # exit 0
```

## Out of scope

Provider-level tests for `pkg/ruler/signozruler/provider.go` need a fake `rules.Manager`; deferred to a follow-up PR.