### PR TITLE
fix(units): scale negative values by magnitude

### DIFF
--- a/pkg/units/formatter_scale.go
+++ b/pkg/units/formatter_scale.go
@@ -122,10 +122,11 @@ func scaledUnits(factor float64, extArray []string, offset int) ValueFormatter {
 			return fmt.Sprintf("%f", value)
 		}
 
+		// The scale index depends only on the magnitude of the value; using
+		// math.Abs above already accounts for the sign. Negating the index for
+		// negative values (and then clamping to a non-negative range) forced the
+		// index to 0, so negative values were printed unscaled without a suffix.
 		siIndex := int(math.Floor(logb(factor, math.Abs(value))))
-		if value < 0 {
-			siIndex = -siIndex
-		}
 		siIndex = lo.Clamp(siIndex+offset, 0, len(extArray)-1)
 
 		suffix := extArray[siIndex]

--- a/pkg/units/formatter_throughput_test.go
+++ b/pkg/units/formatter_throughput_test.go
@@ -17,4 +17,9 @@ func TestThroughput(t *testing.T) {
 	assert.Equal(t, "1M req/s", throughputFormatter.Format(1000000, "{req}/s"))
 	assert.Equal(t, "10 c/m", throughputFormatter.Format(10, "cpm"))
 	assert.Equal(t, "10 c/m", throughputFormatter.Format(10, "{count}/min"))
+
+	// Negative values must be scaled by magnitude just like positive ones.
+	assert.Equal(t, "-10 req/s", throughputFormatter.Format(-10, "reqps"))
+	assert.Equal(t, "-1K req/s", throughputFormatter.Format(-1000, "reqps"))
+	assert.Equal(t, "-1M req/s", throughputFormatter.Format(-1000000, "reqps"))
 }


### PR DESCRIPTION
scaledUnits picks the SI suffix from the magnitude of the value. It already computes the index with logb over math.Abs(value). Right after that it did this:

```go
if value < 0 {
    siIndex = -siIndex
}
```

which negates the index for negative values. The next line clamps siIndex+offset to [0, len-1], so a negated index just gets pinned to 0, and negative values ended up printed with no suffix at all. For example a throughput of -1000000 came out as "-1000000 req/s" instead of "-1M req/s".

The sign has nothing to do with which suffix to use, so I dropped the negation. Negative values now scale the same way as their positive counterparts.

I added a few negative cases to TestThroughput. They fail on master and pass with this change.
