### PR TITLE
fix(querybuildertypesv5): guard float overflow in roundToNonZeroDecimals

### DIFF
--- a/pkg/types/querybuildertypes/querybuildertypesv5/resp.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/resp.go
@@ -328,6 +328,11 @@ func roundToNonZeroDecimals(val float64, n int) float64 {
 		// Round to n decimal places
 		multiplier := math.Pow(10, float64(n))
 		rounded := math.Round(val*multiplier) / multiplier
+		if math.IsInf(rounded, 0) {
+			// val*multiplier overflowed for near-max float64 values; the
+			// finite input must stay finite or the JSON encoder rejects it.
+			return val
+		}
 
 		// If the result is a whole number, return it as such
 		if rounded == math.Trunc(rounded) {


### PR DESCRIPTION
`math.Round(val*multiplier)/multiplier` overflows to `+Inf` for finite values near `math.MaxFloat64`, and the JSON encoder then rejects the series value (HTTP 500). Return the value unrounded when the scaled intermediate overflows.

Found by the upstream promqltest conformance suite (`avg(data{test="big"})`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
