### PR TITLE
fix(clickhouseprometheus): include hour-floored registration rows at the query window end

### DIFF
--- a/pkg/prometheus/clickhouseprometheus/client.go
+++ b/pkg/prometheus/clickhouseprometheus/client.go
@@ -141,7 +141,11 @@ func (client *client) queryToClickhouseQuery(_ context.Context, query *prompb.Qu
 	var args []any
 	conditions = append(conditions, fmt.Sprintf("metric_name = $%d", argCount+1))
 	conditions = append(conditions, "temporality IN ['Cumulative', 'Unspecified']")
-	conditions = append(conditions, fmt.Sprintf("unix_milli >= %d AND unix_milli < %d", start, end))
+	// Inclusive upper bound: registration rows are hour-floored by the
+	// exporter, so a series first registered in the hour starting exactly at
+	// `end` would otherwise be invisible while its samples (<= end) are in
+	// range.
+	conditions = append(conditions, fmt.Sprintf("unix_milli >= %d AND unix_milli <= %d", start, end))
 
 	args = append(args, metricName)
 	for _, m := range query.Matchers {
@@ -202,6 +206,15 @@ func (client *client) getFingerprintsFromClickhouseQuery(ctx context.Context, qu
 
 // buildSamplesQuery renders the samples SQL (and args) that fetches data
 // points for the series selected by subQuery.
+//
+// Time bounds are inclusive on both ends because that is Prometheus's
+// storage contract: Select(mint, maxt) returns [start, end] and the engine
+// itself trims each evaluation window to left-open (T-window, T], so the
+// sample at exactly `end` belongs to the last point. This deliberately
+// differs from the query builder's `unix_milli < end`, which is correct for
+// its own model — toStartOfInterval buckets covering [t, t+step), where a
+// sample at `end` falls in an unrendered bucket and end-exclusive ranges
+// tile exactly across cached time slices.
 func buildSamplesQuery(start int64, end int64, metricName string, subQuery string, args []any) (string, []any) {
 	argCount := len(args)
 


### PR DESCRIPTION
Stacked on #12152.

**Problem**: The series lookup and the samples query used different end bounds. The lookup filtered registration rows with `unix_milli < end` while the samples query used `<= end`. The exporter writes registration rows floored to the hour. So when a series was first registered in the hour starting exactly at `end`, the lookup excluded its registration row even though its samples were fetchable. Queries ending exactly on an hour boundary silently missed newly-registered series.

**Impact:**
- This caused the entire "eval at dataset start" divergence class against the upstream promqltest corpus: 14 cases, including all the subquery undercounts.

**Why inclusive bounds here, when the query builder uses `< end`:** the two follow different evaluation models, and each bound is right for its own.
- Prometheus's storage contract is inclusive on both ends. `Select(mint, maxt)` returns `[start, end]`, and the engine itself trims each evaluation window to `(T − window, T]`. A sample at exactly `end` legitimately contributes to the last point.
- The query builder aggregates `toStartOfInterval` buckets covering `[t, t+step)`. In that model, a sample at exactly `end` belongs to a bucket that is never rendered, and end-exclusive ranges tile cleanly across cached time slices.
- This PR only makes the series lookup agree with the samples query inside the Prometheus model. The query builder is untouched.

**Testing note:**
- The conformance suite (#12156) guards this. This exact regression fails 14 corpus cases there on real ingested data. For data-dependent behavior like this, we rely on that suite instead of a snapshot of generated SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
