### PR TITLE
fix(clickhouseprometheus): resolve __name__ matchers against metric_name and anchor matcher regexes

### DIFF
--- a/ee/query-service/rules/manager_test.go
+++ b/ee/query-service/rules/manager_test.go
@@ -240,16 +240,16 @@ func TestManager_TestNotification_SendUnmatched_PromRule(t *testing.T) {
 					mock := mockStore.Mock()
 
 					// Mock the fingerprint query (for Prometheus label matching)
+					// args: $1=metric_name (the __name__ matcher maps onto the column)
 					mock.ExpectQuery("SELECT fingerprint, any").
-						WithArgs("test_metric", "__name__", "test_metric").
+						WithArgs("test_metric").
 						WillReturnRows(fingerprintRows)
 
 					// Mock the samples query (for Prometheus metric data)
+					// args: metric_name IN (discovered names), subquery metric_name, start, end
 					mock.ExpectQuery("SELECT metric_name, fingerprint, unix_milli").
 						WithArgs(
 							"test_metric",
-							"test_metric",
-							"__name__",
 							"test_metric",
 							queryStart,
 							queryEnd,

--- a/pkg/prometheus/clickhouseprometheus/capture.go
+++ b/pkg/prometheus/clickhouseprometheus/capture.go
@@ -56,19 +56,21 @@ func (c *captureClient) Read(ctx context.Context, query *prompb.Query, _ bool) (
 		}
 	}
 
-	var metricName string
+	// Without executing the series lookup, only an exact-name selector's
+	// metric name is known.
+	var metricNames []string
 	for _, matcher := range query.Matchers {
-		if matcher.Name == "__name__" {
-			metricName = matcher.Value
+		if matcher.Name == "__name__" && matcher.Type == prompb.LabelMatcher_EQ {
+			metricNames = []string{matcher.Value}
 		}
 	}
 
 	// Build the executing path's queries, but only record them.
-	subQuery, args, err := c.queryToClickhouseQuery(ctx, query, metricName, true)
+	sub, err := seriesLookupQuery(query, true)
 	if err != nil {
 		return nil, err
 	}
-	samplesQuery, samplesArgs := buildSamplesQuery(int64(query.StartTimestampMs), int64(query.EndTimestampMs), metricName, subQuery, args)
+	samplesQuery, samplesArgs := buildSamplesQuery(int64(query.StartTimestampMs), int64(query.EndTimestampMs), metricNames, sub)
 	c.recorder.record(samplesQuery, samplesArgs)
 
 	return storage.EmptySeriesSet(), nil

--- a/pkg/prometheus/clickhouseprometheus/client.go
+++ b/pkg/prometheus/clickhouseprometheus/client.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"strconv"
-	"strings"
+	"sort"
 	"sync"
 
 	"github.com/SigNoz/signoz/pkg/errors"
@@ -15,6 +14,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/instrumentationtypes"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/cespare/xxhash/v2"
+	"github.com/huandu/go-sqlbuilder"
 	promValue "github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
@@ -56,19 +56,13 @@ func (client *client) Read(ctx context.Context, query *prompb.Query, sortSeries 
 		}
 	}
 
-	var metricName string
-	for _, matcher := range query.Matchers {
-		if matcher.Name == "__name__" {
-			metricName = matcher.Value
-		}
-	}
-
-	clickhouseQuery, args, err := client.queryToClickhouseQuery(ctx, query, metricName, false)
+	lookup, err := seriesLookupQuery(query, false)
 	if err != nil {
 		return nil, err
 	}
+	lookupSQL, lookupArgs := lookup.BuildWithFlavor(sqlbuilder.ClickHouse)
 
-	fingerprints, err := client.getFingerprintsFromClickhouseQuery(ctx, clickhouseQuery, args)
+	fingerprints, metricNames, err := client.getFingerprintsFromClickhouseQuery(ctx, lookupSQL, lookupArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -76,13 +70,14 @@ func (client *client) Read(ctx context.Context, query *prompb.Query, sortSeries 
 		return remote.FromQueryResult(sortSeries, new(prompb.QueryResult)), nil
 	}
 
-	clickhouseSubQuery, args, err := client.queryToClickhouseQuery(ctx, query, metricName, true)
+	sub, err := seriesLookupQuery(query, true)
 	if err != nil {
 		return nil, err
 	}
+	samplesSQL, samplesArgs := buildSamplesQuery(int64(query.StartTimestampMs), int64(query.EndTimestampMs), metricNames, sub)
 
 	res := new(prompb.QueryResult)
-	timeseries, err := client.querySamples(ctx, int64(query.StartTimestampMs), int64(query.EndTimestampMs), fingerprints, metricName, clickhouseSubQuery, args)
+	timeseries, err := client.querySamples(ctx, samplesSQL, samplesArgs, fingerprints)
 	if err != nil {
 		return nil, err
 	}
@@ -126,86 +121,115 @@ func (c *client) ReadMultiple(ctx context.Context, queries []*prompb.Query, sort
 	return storage.NewMergeSeriesSet(sets, 0, storage.ChainedSeriesMerge), nil
 }
 
-func (client *client) queryToClickhouseQuery(_ context.Context, query *prompb.Query, metricName string, subQuery bool) (string, []any, error) {
-	var clickHouseQuery string
-	var conditions []string
-	var argCount = 0
-	var selectString = "fingerprint, any(labels)"
+// anchorRegex makes a pattern fully anchored, the way Prometheus compiles
+// matcher regexes; ClickHouse's match() would otherwise substring-match.
+func anchorRegex(pattern string) string {
+	return "^(?:" + pattern + ")$"
+}
+
+// seriesLookupQuery builds the time-series lookup. It returns a builder so
+// the samples query can embed it as a subquery with the args merged in
+// render order by the builder instead of hand-numbered placeholders.
+func seriesLookupQuery(query *prompb.Query, subQuery bool) (*sqlbuilder.SelectBuilder, error) {
+	sb := sqlbuilder.NewSelectBuilder()
 	if subQuery {
-		argCount = 1
-		selectString = "fingerprint"
+		sb.Select("fingerprint")
+	} else {
+		sb.Select("fingerprint", "any(labels)")
 	}
 
 	start, end, tableName := getStartAndEndAndTableName(query.StartTimestampMs, query.EndTimestampMs)
+	sb.From(databaseName + "." + tableName)
 
-	var args []any
-	conditions = append(conditions, fmt.Sprintf("metric_name = $%d", argCount+1))
-	conditions = append(conditions, "temporality IN ['Cumulative', 'Unspecified']")
+	sb.Where("temporality IN ['Cumulative', 'Unspecified']")
 	// Inclusive upper bound: registration rows are hour-floored by the
 	// exporter, so a series first registered in the hour starting exactly at
 	// `end` would otherwise be invisible while its samples (<= end) are in
 	// range.
-	conditions = append(conditions, fmt.Sprintf("unix_milli >= %d AND unix_milli <= %d", start, end))
+	sb.Where(fmt.Sprintf("unix_milli >= %d AND unix_milli <= %d", start, end))
 
-	args = append(args, metricName)
 	for _, m := range query.Matchers {
+		if m.Name == "__name__" {
+			// __name__ maps onto the metric_name column per matcher type;
+			// reducing regex/negated/absent name matchers to one equality
+			// made such selectors silently return empty.
+			switch m.Type {
+			case prompb.LabelMatcher_EQ:
+				sb.Where(sb.E("metric_name", m.Value))
+			case prompb.LabelMatcher_NEQ:
+				sb.Where(sb.NE("metric_name", m.Value))
+			case prompb.LabelMatcher_RE:
+				sb.Where(fmt.Sprintf("match(metric_name, %s)", sb.Var(anchorRegex(m.Value))))
+			case prompb.LabelMatcher_NRE:
+				sb.Where(fmt.Sprintf("not match(metric_name, %s)", sb.Var(anchorRegex(m.Value))))
+			default:
+				return nil, errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported or invalid matcher type: %s", m.Type.String())
+			}
+			continue
+		}
 		switch m.Type {
 		case prompb.LabelMatcher_EQ:
-			conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, $%d) = $%d", argCount+2, argCount+3))
+			sb.Where(fmt.Sprintf("JSONExtractString(labels, %s) = %s", sb.Var(m.Name), sb.Var(m.Value)))
 		case prompb.LabelMatcher_NEQ:
-			conditions = append(conditions, fmt.Sprintf("JSONExtractString(labels, $%d) != $%d", argCount+2, argCount+3))
+			sb.Where(fmt.Sprintf("JSONExtractString(labels, %s) != %s", sb.Var(m.Name), sb.Var(m.Value)))
 		case prompb.LabelMatcher_RE:
-			conditions = append(conditions, fmt.Sprintf("match(JSONExtractString(labels, $%d), $%d)", argCount+2, argCount+3))
+			sb.Where(fmt.Sprintf("match(JSONExtractString(labels, %s), %s)", sb.Var(m.Name), sb.Var(anchorRegex(m.Value))))
 		case prompb.LabelMatcher_NRE:
-			conditions = append(conditions, fmt.Sprintf("not match(JSONExtractString(labels, $%d), $%d)", argCount+2, argCount+3))
+			sb.Where(fmt.Sprintf("not match(JSONExtractString(labels, %s), %s)", sb.Var(m.Name), sb.Var(anchorRegex(m.Value))))
 		default:
-			return "", nil, errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported or invalid matcher type: %s", m.Type.String())
+			return nil, errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported or invalid matcher type: %s", m.Type.String())
 		}
-		args = append(args, m.Name, m.Value)
-		argCount += 2
 	}
 
-	whereClause := strings.Join(conditions, " AND ")
-
-	clickHouseQuery = fmt.Sprintf(`SELECT %s FROM %s.%s WHERE %s GROUP BY fingerprint`, selectString, databaseName, tableName, whereClause)
-
-	return clickHouseQuery, args, nil
+	sb.GroupBy("fingerprint")
+	return sb, nil
 }
 
-func (client *client) getFingerprintsFromClickhouseQuery(ctx context.Context, query string, args []any) (map[uint64][]prompb.Label, error) {
+func (client *client) getFingerprintsFromClickhouseQuery(ctx context.Context, query string, args []any) (map[uint64][]prompb.Label, []string, error) {
 	ctx = client.withClickhousePrometheusContext(ctx, "getFingerprintsFromClickhouseQuery")
 	rows, err := client.telemetryStore.ClickhouseDB().Query(ctx, query, args...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer rows.Close()
 
 	fingerprints := make(map[uint64][]prompb.Label)
+	nameSet := make(map[string]struct{})
 
 	var fingerprint uint64
 	var labelString string
 	for rows.Next() {
 		if err = rows.Scan(&fingerprint, &labelString); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
-		labels, _, err := unmarshalLabels(labelString)
+		labels, metricName, err := unmarshalLabels(labelString)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		fingerprints[fingerprint] = labels
+		if metricName != "" {
+			nameSet[metricName] = struct{}{}
+		}
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return fingerprints, nil
+	metricNames := make([]string, 0, len(nameSet))
+	for name := range nameSet {
+		metricNames = append(metricNames, name)
+	}
+	sort.Strings(metricNames)
+
+	return fingerprints, metricNames, nil
 }
 
-// buildSamplesQuery renders the samples SQL (and args) that fetches data
-// points for the series selected by subQuery.
+// buildSamplesQuery renders the samples SQL for the series selected by
+// subQuery. The metric_name condition exists only for primary-key pruning;
+// the fingerprint filter already selects the right rows.
 //
 // Time bounds are inclusive on both ends because that is Prometheus's
 // storage contract: Select(mint, maxt) returns [start, end] and the engine
@@ -215,27 +239,29 @@ func (client *client) getFingerprintsFromClickhouseQuery(ctx context.Context, qu
 // its own model — toStartOfInterval buckets covering [t, t+step), where a
 // sample at `end` falls in an unrendered bucket and end-exclusive ranges
 // tile exactly across cached time slices.
-func buildSamplesQuery(start int64, end int64, metricName string, subQuery string, args []any) (string, []any) {
-	argCount := len(args)
+func buildSamplesQuery(start int64, end int64, metricNames []string, sub *sqlbuilder.SelectBuilder) (string, []any) {
+	sb := sqlbuilder.NewSelectBuilder()
+	sb.Select("metric_name", "fingerprint", "unix_milli", "value", "flags")
+	sb.From(databaseName + "." + distributedSamplesV4)
 
-	query := fmt.Sprintf(`
-		SELECT metric_name, fingerprint, unix_milli, value, flags
-			FROM %s.%s
-			WHERE metric_name = $1 AND fingerprint GLOBAL IN (%s) AND unix_milli >= $%s AND unix_milli <= $%s ORDER BY fingerprint, unix_milli;`,
-		databaseName, distributedSamplesV4, subQuery, strconv.Itoa(argCount+2), strconv.Itoa(argCount+3))
-	query = strings.TrimSpace(query)
+	if len(metricNames) > 0 {
+		names := make([]any, len(metricNames))
+		for i, name := range metricNames {
+			names[i] = name
+		}
+		sb.Where(sb.In("metric_name", names...))
+	}
+	sb.Where(fmt.Sprintf("fingerprint GLOBAL IN (%s)", sb.Var(sub)))
+	sb.Where(sb.GTE("unix_milli", start), sb.LTE("unix_milli", end))
+	sb.OrderBy("fingerprint", "unix_milli")
 
-	allArgs := append([]any{metricName}, args...)
-	allArgs = append(allArgs, start, end)
-	return query, allArgs
+	return sb.BuildWithFlavor(sqlbuilder.ClickHouse)
 }
 
-func (client *client) querySamples(ctx context.Context, start int64, end int64, fingerprints map[uint64][]prompb.Label, metricName string, subQuery string, args []any) ([]*prompb.TimeSeries, error) {
+func (client *client) querySamples(ctx context.Context, query string, args []any, fingerprints map[uint64][]prompb.Label) ([]*prompb.TimeSeries, error) {
 	ctx = client.withClickhousePrometheusContext(ctx, "querySamples")
 
-	query, allArgs := buildSamplesQuery(start, end, metricName, subQuery, args)
-
-	rows, err := client.telemetryStore.ClickhouseDB().Query(ctx, query, allArgs...)
+	rows, err := client.telemetryStore.ClickhouseDB().Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -243,6 +269,7 @@ func (client *client) querySamples(ctx context.Context, start int64, end int64, 
 
 	var res []*prompb.TimeSeries
 	var ts *prompb.TimeSeries
+	var metricName string
 	var fingerprint, prevFingerprint uint64
 	var timestampMs, prevTimestamp int64
 	var value float64

--- a/pkg/prometheus/clickhouseprometheus/client_query_test.go
+++ b/pkg/prometheus/clickhouseprometheus/client_query_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
+	"github.com/huandu/go-sqlbuilder"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 )
@@ -29,7 +30,7 @@ func TestClient_QuerySamples(t *testing.T) {
 		start              int64
 		end                int64
 		fingerprints       map[uint64][]prompb.Label
-		metricName         string
+		metricNames        []string
 		subQuery           string
 		args               []any
 		setupMock          func(mock cmock.ClickConnMockCommon, args ...any)
@@ -52,7 +53,7 @@ func TestClient_QuerySamples(t *testing.T) {
 					{Name: "instance", Value: "localhost:9091"},
 				},
 			},
-			metricName:         "cpu_usage",
+			metricNames:        []string{"cpu_usage"},
 			subQuery:           "SELECT metric_name, fingerprint, unix_milli, value, flags",
 			expectedTimeSeries: 2,
 			expectError:        false,
@@ -97,10 +98,10 @@ func TestClient_QuerySamples(t *testing.T) {
 			telemetryStore := telemetrystoretest.New(telemetrystore.Config{Provider: "clickhouse"}, sqlmock.QueryMatcherRegexp)
 			readClient := client{telemetryStore: telemetryStore}
 			if tt.setupMock != nil {
-				tt.setupMock(telemetryStore.Mock(), tt.metricName, tt.start, tt.end)
+				tt.setupMock(telemetryStore.Mock(), "cpu_usage", tt.start, tt.end)
 
 			}
-			result, err := readClient.querySamples(ctx, tt.start, tt.end, tt.fingerprints, tt.metricName, tt.subQuery, tt.args)
+			result, err := readClient.querySamples(ctx, tt.subQuery, []any{"cpu_usage", tt.start, tt.end}, tt.fingerprints)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -111,101 +112,6 @@ func TestClient_QuerySamples(t *testing.T) {
 				assert.Equal(t, result, tt.result)
 			}
 
-		})
-	}
-}
-
-func TestClient_getFingerprintsFromClickhouseQuery(t *testing.T) {
-	cols := []cmock.ColumnType{
-		{Name: "fingerprint", Type: "UInt64"},
-		{Name: "labels", Type: "String"},
-	}
-
-	sortLabels := func(ls []prompb.Label) {
-		sort.Slice(ls, func(i, j int) bool {
-			if ls[i].Name == ls[j].Name {
-				return ls[i].Value < ls[j].Value
-			}
-			return ls[i].Name < ls[j].Name
-		})
-	}
-
-	tests := []struct {
-		name       string
-		start, end int64
-		metricName string
-		subQuery   string
-		args       []any
-		setupMock  func(m cmock.ClickConnMockCommon, args ...any)
-		want       map[uint64][]prompb.Label
-		wantErr    bool
-	}{
-		{
-			name:       "happy-path - two fingerprints",
-			start:      1000,
-			end:        2000,
-			metricName: "cpu_usage",
-			subQuery:   `SELECT fingerprint,labels`,
-			// args slice is empty here, but test‑case still owns it
-			args: []any{},
-
-			setupMock: func(m cmock.ClickConnMockCommon, args ...any) {
-				rows := [][]any{
-					{uint64(123), `{"t1":"s1","t2":"s2"}`},
-					{uint64(234), `{"t1":"s1","t2":"s2","empty":""}`},
-				}
-				m.ExpectQuery(`SELECT fingerprint,labels`).WithArgs(args...).WillReturnRows(
-					cmock.NewRows(cols, rows),
-				)
-			},
-
-			// No synthetic fingerprint label (#8563), empty-valued labels
-			// dropped: both fingerprints present one labelset for
-			// querySamples to merge.
-			want: map[uint64][]prompb.Label{
-				123: {
-					{Name: "t1", Value: "s1"},
-					{Name: "t2", Value: "s2"},
-				},
-				234: {
-					{Name: "t1", Value: "s1"},
-					{Name: "t2", Value: "s2"},
-				},
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			store := telemetrystoretest.New(
-				telemetrystore.Config{Provider: "clickhouse"},
-				sqlmock.QueryMatcherRegexp,
-			)
-
-			if tc.setupMock != nil {
-				tc.setupMock(store.Mock(), tc.args...)
-			}
-
-			c := client{telemetryStore: store}
-
-			got, err := c.getFingerprintsFromClickhouseQuery(ctx, tc.subQuery, tc.args)
-			if tc.wantErr {
-				require.Error(t, err)
-				require.Nil(t, got)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, len(tc.want), len(got), "fingerprint map length mismatch")
-			for fp, expLabels := range tc.want {
-				gotLabels, ok := got[fp]
-				require.Truef(t, ok, "missing fingerprint %d", fp)
-
-				sortLabels(expLabels)
-				sortLabels(gotLabels)
-
-				assert.Equalf(t, expLabels, gotLabels, "labels mismatch for fingerprint %d", fp)
-			}
 		})
 	}
 }
@@ -251,7 +157,7 @@ func TestClient_QuerySamplesMergesIdenticalLabelSets(t *testing.T) {
 		WillReturnRows(cmock.NewRows(cols, values))
 
 	readClient := client{telemetryStore: telemetryStore}
-	result, err := readClient.querySamples(ctx, 1000, 3000, fingerprints, "requests", "SELECT metric_name, fingerprint, unix_milli, value, flags", nil)
+	result, err := readClient.querySamples(ctx, "SELECT metric_name, fingerprint, unix_milli, value, flags", []any{"requests", int64(1000), int64(3000)}, fingerprints)
 	require.NoError(t, err)
 
 	assert.Equal(t, []*prompb.TimeSeries{
@@ -270,6 +176,188 @@ func TestClient_QuerySamplesMergesIdenticalLabelSets(t *testing.T) {
 			},
 		},
 	}, result)
+}
+
+func TestClient_getFingerprintsFromClickhouseQuery(t *testing.T) {
+	cols := []cmock.ColumnType{
+		{Name: "fingerprint", Type: "UInt64"},
+		{Name: "labels", Type: "String"},
+	}
+
+	sortLabels := func(ls []prompb.Label) {
+		sort.Slice(ls, func(i, j int) bool {
+			if ls[i].Name == ls[j].Name {
+				return ls[i].Value < ls[j].Value
+			}
+			return ls[i].Name < ls[j].Name
+		})
+	}
+
+	tests := []struct {
+		name       string
+		start, end int64
+		metricName string
+		subQuery   string
+		args       []any
+		setupMock  func(m cmock.ClickConnMockCommon, args ...any)
+		want       map[uint64][]prompb.Label
+		wantNames  []string
+		wantErr    bool
+	}{
+		{
+			name:       "happy-path - two fingerprints",
+			start:      1000,
+			end:        2000,
+			metricName: "cpu_usage",
+			subQuery:   `SELECT fingerprint,labels`,
+			// args slice is empty here, but test‑case still owns it
+			args: []any{},
+
+			setupMock: func(m cmock.ClickConnMockCommon, args ...any) {
+				rows := [][]any{
+					{uint64(123), `{"__name__":"cpu_usage","t1":"s1","t2":"s2"}`},
+					{uint64(234), `{"__name__":"cpu_usage","t1":"s1","t2":"s2","empty":""}`},
+				}
+				m.ExpectQuery(`SELECT fingerprint,labels`).WithArgs(args...).WillReturnRows(
+					cmock.NewRows(cols, rows),
+				)
+			},
+
+			// No synthetic fingerprint label (#8563), empty-valued labels
+			// dropped: both fingerprints present one labelset for
+			// querySamples to merge.
+			want: map[uint64][]prompb.Label{
+				123: {
+					{Name: "__name__", Value: "cpu_usage"},
+					{Name: "t1", Value: "s1"},
+					{Name: "t2", Value: "s2"},
+				},
+				234: {
+					{Name: "__name__", Value: "cpu_usage"},
+					{Name: "t1", Value: "s1"},
+					{Name: "t2", Value: "s2"},
+				},
+			},
+			wantNames: []string{"cpu_usage"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := telemetrystoretest.New(
+				telemetrystore.Config{Provider: "clickhouse"},
+				sqlmock.QueryMatcherRegexp,
+			)
+
+			if tc.setupMock != nil {
+				tc.setupMock(store.Mock(), tc.args...)
+			}
+
+			c := client{telemetryStore: store}
+
+			got, gotNames, err := c.getFingerprintsFromClickhouseQuery(ctx, tc.subQuery, tc.args)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantNames, gotNames, "discovered metric names mismatch")
+			require.Equal(t, len(tc.want), len(got), "fingerprint map length mismatch")
+			for fp, expLabels := range tc.want {
+				gotLabels, ok := got[fp]
+				require.Truef(t, ok, "missing fingerprint %d", fp)
+
+				sortLabels(expLabels)
+				sortLabels(gotLabels)
+
+				assert.Equalf(t, expLabels, gotLabels, "labels mismatch for fingerprint %d", fp)
+			}
+		})
+	}
+}
+
+// Regression for nameless/regex-name selectors silently returning empty:
+// the old code reduced every __name__ matcher to `metric_name = <value>`
+// (empty string when absent). Regexes must come out anchored — Prometheus
+// matcher semantics, while ClickHouse match() substring-matches.
+func TestQueryToClickhouseQueryNameMatchers(t *testing.T) {
+	query := func(matchers ...*prompb.LabelMatcher) *prompb.Query {
+		return &prompb.Query{StartTimestampMs: 0, EndTimestampMs: 1000, Matchers: matchers}
+	}
+
+	tests := []struct {
+		name     string
+		query    *prompb.Query
+		contains []string
+		absent   []string
+		args     []any
+	}{
+		{
+			name:     "exact name",
+			query:    query(&prompb.LabelMatcher{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "cpu_usage"}),
+			contains: []string{"metric_name = ?"},
+			args:     []any{"cpu_usage"},
+		},
+		{
+			name:     "regex name is anchored",
+			query:    query(&prompb.LabelMatcher{Type: prompb.LabelMatcher_RE, Name: "__name__", Value: ".+"}),
+			contains: []string{"match(metric_name, ?)"},
+			args:     []any{"^(?:.+)$"},
+		},
+		{
+			name: "nameless selector has no metric_name condition",
+			query: query(
+				&prompb.LabelMatcher{Type: prompb.LabelMatcher_EQ, Name: "job", Value: "api"},
+				&prompb.LabelMatcher{Type: prompb.LabelMatcher_NRE, Name: "group", Value: "can.*"},
+			),
+			contains: []string{
+				"JSONExtractString(labels, ?) = ?",
+				"not match(JSONExtractString(labels, ?), ?)",
+			},
+			absent: []string{"metric_name"},
+			args:   []any{"job", "api", "group", "^(?:can.*)$"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lookup, err := seriesLookupQuery(tt.query, false)
+			require.NoError(t, err)
+			sql, args := lookup.BuildWithFlavor(sqlbuilder.ClickHouse)
+			for _, want := range tt.contains {
+				assert.Contains(t, sql, want)
+			}
+			for _, notWant := range tt.absent {
+				assert.NotContains(t, sql, notWant)
+			}
+			assert.Equal(t, tt.args, args)
+		})
+	}
+}
+
+// The samples query narrows by the metric names the lookup discovered and
+// embeds the series lookup as a subquery, the builder merging its args in
+// render order.
+func TestBuildSamplesQueryMetricNames(t *testing.T) {
+	sub := sqlbuilder.NewSelectBuilder()
+	sub.Select("fingerprint")
+	sub.From("t")
+	sub.Where(sub.E("k", "v"))
+
+	sql, args := buildSamplesQuery(5, 9, []string{"a_total", "b_total"}, sub)
+	assert.Contains(t, sql, "metric_name IN (?, ?)")
+	assert.Contains(t, sql, "fingerprint GLOBAL IN (SELECT fingerprint FROM t WHERE k = ?)")
+	assert.Contains(t, sql, "unix_milli >= ? AND unix_milli <= ?")
+	assert.Equal(t, []any{"a_total", "b_total", "v", int64(5), int64(9)}, args)
+
+	sub2 := sqlbuilder.NewSelectBuilder()
+	sub2.Select("fingerprint")
+	sub2.From("t")
+	sql, args = buildSamplesQuery(5, 9, nil, sub2)
+	assert.NotContains(t, sql, "metric_name IN")
+	assert.Equal(t, []any{int64(5), int64(9)}, args)
 }
 
 // Hash grouping must stay order-insensitive (stored JSON key order is not

--- a/pkg/query-service/rules/manager_test.go
+++ b/pkg/query-service/rules/manager_test.go
@@ -237,15 +237,13 @@ func TestManager_TestNotification_SendUnmatched_PromRule(t *testing.T) {
 
 					// Mock the fingerprint query (for Prometheus label matching)
 					mock.ExpectQuery("SELECT fingerprint, any").
-						WithArgs("test_metric", "__name__", "test_metric").
+						WithArgs("test_metric").
 						WillReturnRows(fingerprintRows)
 
 					// Mock the samples query (for Prometheus metric data)
 					mock.ExpectQuery("SELECT metric_name, fingerprint, unix_milli").
 						WithArgs(
 							"test_metric",
-							"test_metric",
-							"__name__",
 							"test_metric",
 							queryStart,
 							queryEnd,

--- a/pkg/query-service/rules/prom_rule_test.go
+++ b/pkg/query-service/rules/prom_rule_test.go
@@ -925,19 +925,17 @@ func TestPromRuleUnitCombinations(t *testing.T) {
 		}
 		samplesRows := cmock.NewRows(samplesCols, samplesData)
 
-		// args: $1=metric_name, $2=label_name, $3=label_value
+		// args: $1=metric_name (the __name__ matcher maps onto the column)
 		telemetryStore.Mock().
 			ExpectQuery("SELECT fingerprint, any").
-			WithArgs("test_metric", "__name__", "test_metric").
+			WithArgs("test_metric").
 			WillReturnRows(fingerprintRows)
 
-		// args: $1=metric_name (outer), $2=metric_name (subquery), $3=label_name, $4=label_value, $5=start, $6=end
+		// args: $1=metric_name IN (discovered names), $2=metric_name (subquery), $3=start, $4=end
 		telemetryStore.Mock().
 			ExpectQuery("SELECT metric_name, fingerprint, unix_milli").
 			WithArgs(
 				"test_metric",
-				"test_metric",
-				"__name__",
 				"test_metric",
 				queryStart,
 				queryEnd,
@@ -1063,7 +1061,7 @@ func TestPromRuleNoData(t *testing.T) {
 		// no rows == no data
 		telemetryStore.Mock().
 			ExpectQuery("SELECT fingerprint, any").
-			WithArgs("test_metric", "__name__", "test_metric").
+			WithArgs("test_metric").
 			WillReturnRows(fingerprintRows)
 
 		promProvider := prometheustest.New(context.Background(), instrumentationtest.New().ToProviderSettings(), prometheus.Config{Timeout: 2 * time.Minute}, telemetryStore)
@@ -1273,15 +1271,13 @@ func TestMultipleThresholdPromRule(t *testing.T) {
 
 		telemetryStore.Mock().
 			ExpectQuery("SELECT fingerprint, any").
-			WithArgs("test_metric", "__name__", "test_metric").
+			WithArgs("test_metric").
 			WillReturnRows(fingerprintRows)
 
 		telemetryStore.Mock().
 			ExpectQuery("SELECT metric_name, fingerprint, unix_milli").
 			WithArgs(
 				"test_metric",
-				"test_metric",
-				"__name__",
 				"test_metric",
 				queryStart,
 				queryEnd,
@@ -1439,12 +1435,12 @@ func TestPromRule_NoData(t *testing.T) {
 			labelsJSON := `{"__name__":"test_metric"}`
 			telemetryStore.Mock().
 				ExpectQuery("SELECT fingerprint, any").
-				WithArgs("test_metric", "__name__", "test_metric").
+				WithArgs("test_metric").
 				WillReturnRows(cmock.NewRows(fingerprintCols, [][]any{{fingerprint, labelsJSON}}))
 
 			telemetryStore.Mock().
 				ExpectQuery("SELECT metric_name, fingerprint, unix_milli").
-				WithArgs("test_metric", "test_metric", "__name__", "test_metric", queryStart, queryEnd).
+				WithArgs("test_metric", "test_metric", queryStart, queryEnd).
 				WillReturnRows(cmock.NewRows(samplesCols, [][]any{}))
 
 			promProvider := prometheustest.New(
@@ -1575,11 +1571,11 @@ func TestPromRule_NoData_AbsentFor(t *testing.T) {
 			queryStart1, queryEnd1 := calcQueryRange(t1)
 			telemetryStore.Mock().
 				ExpectQuery("SELECT fingerprint, any").
-				WithArgs("test_metric", "__name__", "test_metric").
+				WithArgs("test_metric").
 				WillReturnRows(cmock.NewRows(fingerprintCols, [][]any{{fingerprint, labelsJSON}}))
 			telemetryStore.Mock().
 				ExpectQuery("SELECT metric_name, fingerprint, unix_milli").
-				WithArgs("test_metric", "test_metric", "__name__", "test_metric", queryStart1, queryEnd1).
+				WithArgs("test_metric", "test_metric", queryStart1, queryEnd1).
 				WillReturnRows(cmock.NewRows(samplesCols, [][]any{
 					// Data points in the past relative to t1
 					{"test_metric", fingerprint, baseTime.UnixMilli(), 100.0, uint32(0)},
@@ -1591,11 +1587,11 @@ func TestPromRule_NoData_AbsentFor(t *testing.T) {
 			queryStart2, queryEnd2 := calcQueryRange(t2)
 			telemetryStore.Mock().
 				ExpectQuery("SELECT fingerprint, any").
-				WithArgs("test_metric", "__name__", "test_metric").
+				WithArgs("test_metric").
 				WillReturnRows(cmock.NewRows(fingerprintCols, [][]any{{fingerprint, labelsJSON}}))
 			telemetryStore.Mock().
 				ExpectQuery("SELECT metric_name, fingerprint, unix_milli").
-				WithArgs("test_metric", "test_metric", "__name__", "test_metric", queryStart2, queryEnd2).
+				WithArgs("test_metric", "test_metric", queryStart2, queryEnd2).
 				WillReturnRows(cmock.NewRows(samplesCols, [][]any{})) // empty - no data
 
 			promProvider := prometheustest.New(
@@ -1752,11 +1748,11 @@ func TestPromRuleEval_RequireMinPoints(t *testing.T) {
 			telemetryStore := telemetrystoretest.New(telemetrystore.Config{}, &queryMatcherAny{})
 			telemetryStore.Mock().
 				ExpectQuery("SELECT fingerprint, any").
-				WithArgs("test_metric", "__name__", "test_metric").
+				WithArgs("test_metric").
 				WillReturnRows(cmock.NewRows(fingerprintCols, fingerprintData))
 			telemetryStore.Mock().
 				ExpectQuery("SELECT metric_name, fingerprint, unix_milli").
-				WithArgs("test_metric", "test_metric", "__name__", "test_metric", queryStart, queryEnd).
+				WithArgs("test_metric", "test_metric", queryStart, queryEnd).
 				WillReturnRows(cmock.NewRows(samplesCols, samplesData))
 			promProvider := prometheustest.New(
 				context.Background(),


### PR DESCRIPTION
Stacked on #12153.

The read client reduced every `__name__` matcher to `metric_name = <value>` (empty string when no name matcher exists), so nameless selectors (`{job="api"}`), regex names (`{__name__=~".+"}`), and negations silently returned empty. Map the `__name__` matcher onto the `metric_name` column per matcher type, drop the condition when absent, and narrow the samples query by the metric names the series lookup discovered.

Also anchors matcher regexes (`^(?:...)$`) per Prometheus matcher semantics — ClickHouse `match()` is a substring search, so `{job=~"api"}` also matched `job="api-server"` before. Deliberate behavior change toward engine-exact matching.

The lookup and samples SQL is now built with `huandu/go-sqlbuilder` (ClickHouse flavor), as in telemetrymetrics and the v2 transpiler: the samples query embeds the series lookup as a nested builder with argument order merged in render position, replacing the hand-numbered `$N` placeholder bookkeeping this change would otherwise have grown.

Healed the 15 nameless-selector divergences against the upstream promqltest corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
