### PR TITLE
fix(alerts): reject static labels that conflict with query group by keys

### DIFF
--- a/frontend/public/locales/en-GB/alerts.json
+++ b/frontend/public/locales/en-GB/alerts.json
@@ -13,6 +13,7 @@
 	"button_no": "No",
 	"remove_label_confirm": "This action will remove all the labels. Do you want to proceed?",
 	"remove_label_success": "Labels cleared",
+	"label_group_by_conflict": "Cannot use {{label}} as a label key. It is already a group by attribute in the query.",
 	"alert_form_step1": "Step 1 - Define the metric",
 	"alert_form_step2": "Step {{step}} - Define Alert Conditions",
 	"alert_form_step3": "Step {{step}} - Alert Configuration",

--- a/frontend/public/locales/en/alerts.json
+++ b/frontend/public/locales/en/alerts.json
@@ -13,6 +13,7 @@
 	"button_no": "No",
 	"remove_label_confirm": "This action will remove all the labels. Do you want to proceed?",
 	"remove_label_success": "Labels cleared",
+	"label_group_by_conflict": "Cannot use {{label}} as a label key. It is already a group by attribute in the query.",
 	"alert_form_step1": "Choose a detection method",
 	"alert_form_step2": "Define the metric",
 	"alert_form_step3": "Define Alert Conditions",

--- a/frontend/src/container/FormAlertRules/labels/__tests__/index.test.tsx
+++ b/frontend/src/container/FormAlertRules/labels/__tests__/index.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { message } from 'antd';
+
+import LabelSelect from '../index';
+
+jest.mock('hooks/queryBuilder/useQueryBuilder', () => ({
+	useQueryBuilder: (): unknown => ({
+		currentQuery: {
+			builder: {
+				queryData: [{ groupBy: [{ key: 'service.name' }] }],
+			},
+		},
+	}),
+}));
+
+jest.mock('hooks/useDarkMode', () => ({
+	useIsDarkMode: (): boolean => false,
+}));
+
+jest.mock('react-i18next', () => ({
+	useTranslation: (): { t: (key: string, opts?: unknown) => string } => ({
+		t: (key: string): string => key,
+	}),
+}));
+
+describe('LabelSelect', () => {
+	let onSetLabels: jest.Mock;
+	let messageErrorSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		onSetLabels = jest.fn();
+		messageErrorSpy = jest.spyOn(message, 'error').mockImplementation(jest.fn());
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	function enterLabelKey(key: string): HTMLElement {
+		const input = screen.getByRole('textbox');
+		fireEvent.focus(input);
+		fireEvent.change(input, { target: { value: key } });
+		fireEvent.keyUp(input, { key: 'Enter', code: 'Enter' });
+		return input;
+	}
+
+	it('rejects a label key that matches a query group by attribute', () => {
+		render(<LabelSelect onSetLabels={onSetLabels} initialValues={undefined} />);
+
+		const input = enterLabelKey('service.name');
+
+		expect(messageErrorSpy).toHaveBeenCalledWith('label_group_by_conflict');
+		expect(onSetLabels).not.toHaveBeenCalled();
+		// key is not staged; input still holds the rejected value
+		expect(input).toHaveValue('service.name');
+	});
+
+	it('accepts a label key that does not conflict with group by', () => {
+		render(<LabelSelect onSetLabels={onSetLabels} initialValues={undefined} />);
+
+		const input = enterLabelKey('team');
+
+		expect(messageErrorSpy).not.toHaveBeenCalled();
+		// key staged, input cleared for value entry
+		expect(input).toHaveValue('');
+
+		fireEvent.change(input, { target: { value: 'platform' } });
+		fireEvent.keyUp(input, { key: 'Enter', code: 'Enter' });
+
+		expect(onSetLabels).toHaveBeenCalledWith(
+			expect.objectContaining({ team: 'platform' }),
+		);
+	});
+});

--- a/frontend/src/container/FormAlertRules/labels/index.tsx
+++ b/frontend/src/container/FormAlertRules/labels/index.tsx
@@ -1,7 +1,8 @@
-import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CircleAlert, CircleX } from '@signozhq/icons';
 import { Button, Input, message, Modal } from 'antd';
+import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { map } from 'lodash-es';
 import { Labels } from 'types/api/alerts/def';
@@ -26,6 +27,17 @@ function LabelSelect({
 }: LabelSelectProps): JSX.Element | null {
 	const { t } = useTranslation('alerts');
 	const isDarkMode = useIsDarkMode();
+	const { currentQuery } = useQueryBuilder();
+
+	// Static labels overwrite the group by labels on the alert, collapsing
+	// distinct series into duplicate label sets, so such keys are rejected.
+	const groupByKeys = useMemo(
+		() =>
+			currentQuery.builder.queryData.flatMap((query) =>
+				query.groupBy.map((groupBy) => groupBy.key),
+			),
+		[currentQuery],
+	);
 
 	const [currentVal, setCurrentVal] = useState('');
 	const [staging, setStaging] = useState<string[]>([]);
@@ -39,13 +51,17 @@ function LabelSelect({
 		setQueries(updatedRecs);
 	};
 
-	const onSelectLabelValue = (): void => {
-		if (currentVal !== '') {
-			setStaging((prevState) => [...prevState, currentVal]);
-		} else {
-			return;
+	const onSelectLabelValue = (): boolean => {
+		if (currentVal === '') {
+			return false;
 		}
+		if (groupByKeys.includes(currentVal)) {
+			message.error(t('label_group_by_conflict', { label: currentVal }));
+			return false;
+		}
+		setStaging((prevState) => [...prevState, currentVal]);
 		setCurrentVal('');
+		return true;
 	};
 
 	const onValidateQuery = (): void => {
@@ -63,6 +79,12 @@ function LabelSelect({
 		}
 	};
 
+	const stageLabelKey = (): void => {
+		if (onSelectLabelValue()) {
+			setStep('LabelValue');
+		}
+	};
+
 	const send = (event: LabelEvent): void => {
 		if (event === 'RESET') {
 			setStep('Idle');
@@ -72,8 +94,7 @@ function LabelSelect({
 			if (step === 'Idle') {
 				setStep('LabelKey');
 			} else if (step === 'LabelKey') {
-				onSelectLabelValue();
-				setStep('LabelValue');
+				stageLabelKey();
 			} else if (step === 'LabelValue') {
 				onValidateQuery();
 			}
@@ -81,8 +102,7 @@ function LabelSelect({
 		}
 		if (event === 'onBlur') {
 			if (step === 'LabelKey') {
-				onSelectLabelValue();
-				setStep('LabelValue');
+				stageLabelKey();
 			} else if (step === 'LabelValue') {
 				onValidateQuery();
 			}

--- a/pkg/types/ruletypes/alerting.go
+++ b/pkg/types/ruletypes/alerting.go
@@ -173,6 +173,39 @@ func (rc *RuleCondition) SelectedQueryName() string {
 	return keys[len(keys)-1]
 }
 
+// GroupByKeys returns the group by key names across all enabled builder
+// queries in the composite query.
+func (rc *RuleCondition) GroupByKeys() []string {
+	keys := []string{}
+	if rc.CompositeQuery == nil {
+		return keys
+	}
+
+	for _, query := range rc.CompositeQuery.Queries {
+		switch spec := query.Spec.(type) {
+		case qbtypes.QueryBuilderQuery[qbtypes.TraceAggregation]:
+			if !spec.Disabled {
+				for _, groupBy := range spec.GroupBy {
+					keys = append(keys, groupBy.Name)
+				}
+			}
+		case qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]:
+			if !spec.Disabled {
+				for _, groupBy := range spec.GroupBy {
+					keys = append(keys, groupBy.Name)
+				}
+			}
+		case qbtypes.QueryBuilderQuery[qbtypes.MetricAggregation]:
+			if !spec.Disabled {
+				for _, groupBy := range spec.GroupBy {
+					keys = append(keys, groupBy.Name)
+				}
+			}
+		}
+	}
+	return keys
+}
+
 // ShouldEval checks if the further series should be evaluated at all for alerts.
 func (rc *RuleCondition) ShouldEval(series *qbtypes.TimeSeries) bool {
 	return !rc.RequireMinPoints || len(series.Values) >= rc.RequiredNumPoints

--- a/pkg/types/ruletypes/api_params.go
+++ b/pkg/types/ruletypes/api_params.go
@@ -470,6 +470,17 @@ func (r *PostableRule) Validate() error {
 		}
 	}
 
+	groupByKeys := make(map[string]struct{})
+	for _, key := range r.RuleCondition.GroupByKeys() {
+		groupByKeys[key] = struct{}{}
+	}
+	for k := range r.Labels {
+		if _, ok := groupByKeys[k]; ok {
+			errs = append(errs, errors.NewInvalidInputf(errors.CodeInvalidInput,
+				"label %q conflicts with a group by attribute in the query; remove it from labels or from the group by", k))
+		}
+	}
+
 	for k := range r.Annotations {
 		if !isValidLabelName(k) {
 			errs = append(errs, errors.NewInvalidInputf(errors.CodeInvalidInput, "invalid annotation name: %s", k))

--- a/pkg/types/ruletypes/validate_test.go
+++ b/pkg/types/ruletypes/validate_test.go
@@ -1728,3 +1728,94 @@ func TestValidate_AlertOnAbsent(t *testing.T) {
 		}
 	})
 }
+
+// builderWithGroupBy returns a valid v1 builder rule JSON whose metrics query
+// groups by service.name, with an optional disabled flag on the query.
+func builderWithGroupBy(disabled bool) string {
+	disabledStr := "false"
+	if disabled {
+		disabledStr = "true"
+	}
+	return `{
+		"alert": "TestAlert",
+		"version": "v5",
+		"condition": {
+			"compositeQuery": {
+				"queryType": "builder",
+				"queries": [{
+					"type": "builder_query",
+					"spec": {
+						"name": "A",
+						"signal": "metrics",
+						"disabled": ` + disabledStr + `,
+						"aggregations": [{"metricName": "cpu", "spaceAggregation": "p50"}],
+						"stepInterval": "5m",
+						"groupBy": [{"name": "service.name"}]
+					}
+				}]
+			},
+			"target": 10.0,
+			"matchType": "1",
+			"op": "1"
+		}
+	}`
+}
+
+func TestValidate_LabelGroupByConflict(t *testing.T) {
+	tests := []struct {
+		name      string
+		json      string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:      "label conflicts with group by key",
+			json:      patchJSON(builderWithGroupBy(false), `{"labels": {"service.name": "override"}}`),
+			wantErr:   true,
+			errSubstr: "conflicts with a group by attribute",
+		},
+		{
+			name: "label does not conflict with group by key",
+			json: patchJSON(builderWithGroupBy(false), `{"labels": {"team": "platform"}}`),
+		},
+		{
+			name: "conflicting label on disabled query is allowed",
+			json: patchJSON(builderWithGroupBy(true), `{"labels": {"service.name": "override"}}`),
+		},
+		{
+			name: "labels without group by are allowed",
+			json: patchJSON(validV1Builder(), `{"labels": {"service.name": "checkout"}}`),
+		},
+		{
+			name: "promql rule with labels is allowed",
+			json: patchJSON(validV1Promql(), `{"labels": {"service.name": "checkout"}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unmarshalErr, validateErr := unmarshalAndValidate(tt.json)
+			if unmarshalErr != nil {
+				t.Fatalf("unexpected unmarshal error: %v", unmarshalErr)
+			}
+			if tt.wantErr {
+				if validateErr == nil {
+					t.Fatal("expected validation error, got nil")
+				}
+				if !errorContains(validateErr, tt.errSubstr) {
+					t.Errorf("expected error containing %q, got: %v", tt.errSubstr, validateErr)
+				}
+			} else if validateErr != nil {
+				t.Errorf("unexpected validation error: %v", validateErr)
+			}
+		})
+	}
+
+	t.Run("stored rule with conflict still loads on read path", func(t *testing.T) {
+		j := patchJSON(builderWithGroupBy(false), `{"labels": {"service.name": "override"}}`)
+		var rule PostableRule
+		if err := json.Unmarshal([]byte(j), &rule); err != nil {
+			t.Fatalf("stored rule with label/group by conflict must still unmarshal, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION

### 📄 Summary

A rule that groups by an attribute (e.g. `service.name`) and also has a static
label with the same key saves without complaint, then fails every evaluation
with `vector contains metrics with the same labelset after applying alert
labels`. The static label overwrites the per-series group by label, so distinct
series collapse into duplicate label sets. The rule looks healthy but silently
never fires.

This PR rejects the conflict at save time instead of letting it fail at runtime:

- **Backend (authoritative):** `PostableRule.Validate()` now compares static
  label keys against group by attributes of enabled builder queries and returns
  an invalid-input error on conflict. Adds `RuleCondition.GroupByKeys()`,
  following the existing `SelectedQueryName()` pattern. The check runs only on
  the write path (create/edit/patch/test), not in the `UnmarshalJSON`-time
  `validate()`, so existing stored rules keep loading.
- **Frontend (legacy form):** the v2 create-alert UI already blocks these keys
  at typing time (`CreateAlertHeader.tsx`); this adds the same check to the
  legacy `FormAlertRules` label input (still used for anomaly alerts, the
  classic-experience flag, and old-schema rule edits), with an i18n'd error
  toast.



#### Issues closed by this PR
Closes #6967

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

`BaseRule` stamps static labels onto every result series via `lb.Set(...)`
(`threshold_rule.go`, `prom_rule.go`, `ee/.../anomaly.go`). When a static label
key equals a group by key, the label that distinguished each series is
overwritten with a constant, multiple series hash to the same label set, and
evaluation aborts. Nothing validated this at rule creation.

#### Fix Strategy

Validate at the boundary: reject the conflicting config in
`PostableRule.Validate()` with an actionable message (`label "x" conflicts
with a group by attribute in the query; remove it from labels or from the
group by`), and surface the same feedback instantly in the legacy form UI.

---

### 🧪 Testing Strategy

- Tests added/updated:
  - `pkg/types/ruletypes/validate_test.go`: `TestValidate_LabelGroupByConflict`
    covering conflict rejected, non-conflict allowed, disabled query skipped,
    no group by allowed, promql allowed, and stored conflicting rules still
    loading on the read path.
  - `frontend/src/container/FormAlertRules/labels/__tests__/index.test.tsx`:
    conflicting key rejected with an error toast, clean key flows through to
    `onSetLabels`.
- Manual verification: end-to-end on a local stack (`make devenv-up` +
  `make go-run-community`): `POST /api/v1/rules` and `POST /api/v1/testRule`
  with a conflicting payload return 400; the identical rule without the
  conflicting label returns 201.
- Edge cases covered: disabled queries ignored; PromQL/ClickHouse rules
  unaffected (group by not statically knowable there, same limitation as the
  v2 UI check); existing stored rules with the conflict still load.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: rule create/edit/patch/test API validation plus the legacy
  alert form label input. Read/load path untouched.
- Potential regressions: a user intentionally saving a conflicting label is now
  blocked, which is the point; previously such a rule could never evaluate.
- Rollback plan: revert the commit; no schema or API shape changes.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Alert rules no longer accept static labels that clash with the query's group by attributes; a clear validation error is shown at save time instead of the rule silently failing at evaluation. |

---

### 📋 Checklist

- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The check lives in `Validate()` (write path) and deliberately not in the
  `UnmarshalJSON`-time `validate()`, so pre-existing stored rules with this
  conflict keep loading; they get corrected on next edit.
- Conflict is checked against all enabled builder queries, not just the
  selected one, matching the existing v2 UI behavior in `CreateAlertHeader.tsx`.
- The legacy `/api/v1/rules` error renderer surfaces only the top-level
  "alert rule is not valid" message and drops the detailed additionals (true
  for all validation errors on that endpoint, pre-existing). The specific
  conflict message is still shown by the frontend add-time check.
---