### PR TITLE
fix(dashboards-v2): round-trip all zero-valued spec fields

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -2734,6 +2734,7 @@ components:
         datasources:
           additionalProperties:
             $ref: '#/components/schemas/DashboardtypesDatasourceSpec'
+          nullable: true
           type: object
         display:
           $ref: '#/components/schemas/DashboardtypesDisplay'

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -2596,19 +2596,6 @@ components:
         repeatVariable:
           type: string
       type: object
-    DashboardLink:
-      properties:
-        name:
-          type: string
-        renderVariables:
-          type: boolean
-        targetBlank:
-          type: boolean
-        tooltip:
-          type: string
-        url:
-          type: string
-      type: object
     DashboardtypesAxes:
       properties:
         isLogScale:
@@ -2758,7 +2745,8 @@ components:
           type: array
         links:
           items:
-            $ref: '#/components/schemas/DashboardLink'
+            $ref: '#/components/schemas/DashboardtypesLink'
+          nullable: true
           type: array
         panels:
           additionalProperties:
@@ -3029,6 +3017,19 @@ components:
       - solid
       - dashed
       type: string
+    DashboardtypesLink:
+      properties:
+        name:
+          type: string
+        renderVariables:
+          type: boolean
+        targetBlank:
+          type: boolean
+        tooltip:
+          type: string
+        url:
+          type: string
+      type: object
     DashboardtypesListOrder:
       enum:
       - asc
@@ -3389,7 +3390,8 @@ components:
           $ref: '#/components/schemas/DashboardtypesDisplay'
         links:
           items:
-            $ref: '#/components/schemas/DashboardLink'
+            $ref: '#/components/schemas/DashboardtypesLink'
+          nullable: true
           type: array
         plugin:
           $ref: '#/components/schemas/DashboardtypesPanelPlugin'

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -4011,9 +4011,15 @@ export interface DashboardtypesDatasourceSpecDTO {
 	plugin?: DashboardtypesDatasourcePluginDTO;
 }
 
-export type DashboardtypesDashboardSpecDTODatasources = {
+export type DashboardtypesDashboardSpecDTODatasourcesAnyOf = {
 	[key: string]: DashboardtypesDatasourceSpecDTO;
 };
+
+/**
+ * @nullable
+ */
+export type DashboardtypesDashboardSpecDTODatasources =
+	DashboardtypesDashboardSpecDTODatasourcesAnyOf | null;
 
 export enum DashboardtypesPanelKindDTO {
 	Panel = 'Panel',
@@ -4789,7 +4795,7 @@ export type DashboardtypesVariableDTO =
 
 export interface DashboardtypesDashboardSpecDTO {
 	/**
-	 * @type object
+	 * @type object,null
 	 */
 	datasources?: DashboardtypesDashboardSpecDTODatasources;
 	display: DashboardtypesDisplayDTO;

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -3300,29 +3300,6 @@ export interface DashboardGridLayoutSpecDTO {
 	repeatVariable?: string;
 }
 
-export interface DashboardLinkDTO {
-	/**
-	 * @type string
-	 */
-	name?: string;
-	/**
-	 * @type boolean
-	 */
-	renderVariables?: boolean;
-	/**
-	 * @type boolean
-	 */
-	targetBlank?: boolean;
-	/**
-	 * @type string
-	 */
-	tooltip?: string;
-	/**
-	 * @type string
-	 */
-	url?: string;
-}
-
 export interface DashboardtypesAxesDTO {
 	/**
 	 * @type boolean
@@ -4052,6 +4029,29 @@ export interface DashboardtypesDisplayDTO {
 	name: string;
 }
 
+export interface DashboardtypesLinkDTO {
+	/**
+	 * @type string
+	 */
+	name?: string;
+	/**
+	 * @type boolean
+	 */
+	renderVariables?: boolean;
+	/**
+	 * @type boolean
+	 */
+	targetBlank?: boolean;
+	/**
+	 * @type string
+	 */
+	tooltip?: string;
+	/**
+	 * @type string
+	 */
+	url?: string;
+}
+
 export enum DashboardtypesPanelPluginVariantGithubComSigNozSignozPkgTypesDashboardtypesTimeSeriesPanelSpecDTOKind {
 	'signoz/TimeSeriesPanel' = 'signoz/TimeSeriesPanel',
 }
@@ -4613,9 +4613,9 @@ export interface DashboardtypesQueryDTO {
 export interface DashboardtypesPanelSpecDTO {
 	display: DashboardtypesDisplayDTO;
 	/**
-	 * @type array
+	 * @type array,null
 	 */
-	links?: DashboardLinkDTO[];
+	links?: DashboardtypesLinkDTO[] | null;
 	plugin: DashboardtypesPanelPluginDTO;
 	/**
 	 * @type array
@@ -4802,9 +4802,9 @@ export interface DashboardtypesDashboardSpecDTO {
 	 */
 	layouts: DashboardtypesLayoutDTO[];
 	/**
-	 * @type array
+	 * @type array,null
 	 */
-	links?: DashboardLinkDTO[];
+	links?: DashboardtypesLinkDTO[] | null;
 	/**
 	 * @type object
 	 */

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionRegistry.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionRegistry.tsx
@@ -1,6 +1,6 @@
 import type { ComponentType } from 'react';
 import type {
-	DashboardLinkDTO,
+	DashboardtypesLinkDTO,
 	DashboardtypesAxesDTO,
 	DashboardtypesBarChartVisualizationDTO,
 	DashboardtypesHistogramBucketsDTO,
@@ -120,7 +120,7 @@ export const SECTION_REGISTRY: {
 	[SectionKind.ContextLinks]: {
 		Component: ContextLinksSection,
 		// Panel-level slice (spec.links), not under the plugin spec — no cast needed.
-		get: (spec): DashboardLinkDTO[] | undefined => spec.links,
+		get: (spec): DashboardtypesLinkDTO[] | undefined => spec.links ?? undefined,
 		update: (spec, links): PanelSpec => ({ ...spec, links }),
 	},
 	// One editor for every threshold variant (label / comparison / table); the kind's

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ContextLinksSection/ContextLinkDialog.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ContextLinksSection/ContextLinkDialog.tsx
@@ -5,7 +5,7 @@ import { DialogWrapper } from '@signozhq/ui/dialog';
 import { Switch } from '@signozhq/ui/switch';
 import { Typography } from '@signozhq/ui/typography';
 import { Input } from 'antd';
-import type { DashboardLinkDTO } from 'api/generated/services/sigNoz.schemas';
+import type { DashboardtypesLinkDTO } from 'api/generated/services/sigNoz.schemas';
 
 import type { UrlParam, VariableItem } from './types';
 import {
@@ -21,10 +21,10 @@ import styles from './ContextLinksSection.module.scss';
 interface ContextLinkDialogProps {
 	open: boolean;
 	/** The link being edited, or null when adding a new one. */
-	initialLink: DashboardLinkDTO | null;
+	initialLink: DashboardtypesLinkDTO | null;
 	variables: VariableItem[];
 	onOpenChange: (open: boolean) => void;
-	onSave: (link: DashboardLinkDTO) => void;
+	onSave: (link: DashboardtypesLinkDTO) => void;
 }
 
 const URL_ERROR = 'URL must start with http(s)://, /, or {{variable}}/';

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ContextLinksSection/ContextLinkListItem.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ContextLinksSection/ContextLinkListItem.tsx
@@ -1,12 +1,12 @@
 import { Pencil, Trash2 } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
 import { Typography } from '@signozhq/ui/typography';
-import type { DashboardLinkDTO } from 'api/generated/services/sigNoz.schemas';
+import type { DashboardtypesLinkDTO } from 'api/generated/services/sigNoz.schemas';
 
 import styles from './ContextLinksSection.module.scss';
 
 interface ContextLinkListItemProps {
-	link: DashboardLinkDTO;
+	link: DashboardtypesLinkDTO;
 	index: number;
 	onEdit: () => void;
 	onRemove: () => void;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ContextLinksSection/ContextLinksSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ContextLinksSection/ContextLinksSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Plus } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
-import type { DashboardLinkDTO } from 'api/generated/services/sigNoz.schemas';
+import type { DashboardtypesLinkDTO } from 'api/generated/services/sigNoz.schemas';
 import type {
 	SectionEditorProps,
 	SectionKind,
@@ -34,7 +34,7 @@ function ContextLinksSection({
 	const removeAt = (index: number): void =>
 		onChange(links.filter((_, i) => i !== index));
 
-	const handleSave = (link: DashboardLinkDTO): void => {
+	const handleSave = (link: DashboardtypesLinkDTO): void => {
 		onChange(
 			dialog.index === null
 				? [...links, link]

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ContextLinksSection/__tests__/ContextLinksSection.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ContextLinksSection/__tests__/ContextLinksSection.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import type { DashboardLinkDTO } from 'api/generated/services/sigNoz.schemas';
+import type { DashboardtypesLinkDTO } from 'api/generated/services/sigNoz.schemas';
 
 import ContextLinksSection from '../ContextLinksSection';
 
@@ -12,11 +12,11 @@ jest.mock('../useContextLinkVariables', () => ({
 	],
 }));
 
-const LINKS: DashboardLinkDTO[] = [
+const LINKS: DashboardtypesLinkDTO[] = [
 	{ name: 'Docs', url: 'https://signoz.io', targetBlank: true },
 ];
 
-const lastCall = (fn: jest.Mock): DashboardLinkDTO[] =>
+const lastCall = (fn: jest.Mock): DashboardtypesLinkDTO[] =>
 	fn.mock.calls[fn.mock.calls.length - 1][0];
 
 describe('ContextLinksSection', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/sections.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/sections.ts
@@ -1,5 +1,5 @@
 import type {
-	DashboardLinkDTO,
+	DashboardtypesLinkDTO,
 	DashboardtypesAxesDTO,
 	DashboardtypesBarChartVisualizationDTO,
 	DashboardtypesComparisonThresholdDTO,
@@ -89,7 +89,7 @@ export interface SectionSpecMap {
 	// the `controls` bag gates which fields each kind writes.
 	[SectionKind.Visualization]: DashboardtypesBarChartVisualizationDTO;
 	[SectionKind.Thresholds]: AnyThreshold[]; // spec.plugin.spec.thresholds (variant picks the editor)
-	[SectionKind.ContextLinks]: DashboardLinkDTO[]; // spec.links (PANEL-level)
+	[SectionKind.ContextLinks]: DashboardtypesLinkDTO[]; // spec.links (PANEL-level)
 	[SectionKind.Columns]: TelemetrytypesTelemetryFieldKeyDTO[]; // spec.plugin.spec.selectFields (List)
 }
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks.ts
@@ -1,4 +1,4 @@
-import type { DashboardLinkDTO } from 'api/generated/services/sigNoz.schemas';
+import type { DashboardtypesLinkDTO } from 'api/generated/services/sigNoz.schemas';
 import { resolveTexts } from 'hooks/dashboard/useContextVariables';
 
 import { resolveContextLinkUrl } from './resolveContextLinkUrl';
@@ -15,7 +15,7 @@ export interface ResolvedDrilldownLink {
  * label + URL, drops links without a URL, and skips substitution when `renderVariables === false`.
  */
 export function resolvePanelContextLinks(
-	links: DashboardLinkDTO[] | undefined,
+	links: DashboardtypesLinkDTO[] | undefined,
 	processedVariables: Record<string, string>,
 ): ResolvedDrilldownLink[] {
 	const usable = (links ?? []).filter((link) => !!link.url);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
@@ -7,7 +7,7 @@ import {
 	Loader,
 	ScrollText,
 } from '@signozhq/icons';
-import type { DashboardLinkDTO } from 'api/generated/services/sigNoz.schemas';
+import type { DashboardtypesLinkDTO } from 'api/generated/services/sigNoz.schemas';
 import { getAggregateColumnHeader } from 'container/QueryTable/Drilldown/drilldownUtils';
 import ContextMenu from 'periscope/components/ContextMenu';
 import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
@@ -27,7 +27,7 @@ interface DrilldownAggregateMenuProps {
 	/** While dashboard variables resolve, the actions show a spinner and are disabled. */
 	isResolving?: boolean;
 	/** Panel's context links; resolved against the clicked point + variables here. */
-	links: DashboardLinkDTO[] | undefined;
+	links: DashboardtypesLinkDTO[] | undefined;
 	/** Whether the clicked point exposes group-by fields to bind to dashboard variables. */
 	canSetDashboardVariables: boolean;
 	onViewLogs: () => void;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -218,7 +218,7 @@ export function useDrilldown(
 				context={context}
 				query={v1Query}
 				isResolving={isResolving}
-				links={panel.spec.links}
+				links={panel.spec.links ?? undefined}
 				canSetDashboardVariables={dashboardVariables.hasFieldVariables}
 				onViewLogs={(): void => navigate('view_logs')}
 				onViewTraces={(): void => navigate('view_traces')}

--- a/pkg/types/dashboardtypes/perses_dashboard.go
+++ b/pkg/types/dashboardtypes/perses_dashboard.go
@@ -177,7 +177,7 @@ func nextCloneDisplayName(name string) string {
 
 type DashboardV2MetadataBase struct {
 	SchemaVersion string `json:"schemaVersion" required:"true"`
-	Image         string `json:"image,omitempty"`
+	Image         string `json:"image"`
 }
 
 // ════════════════════════════════════════════════════════════════════════

--- a/pkg/types/dashboardtypes/perses_dashboard_data.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_data.go
@@ -20,12 +20,12 @@ import (
 // per-site discriminated oneOf.
 type DashboardSpec struct {
 	Display         Display                    `json:"display" required:"true"`
-	Datasources     map[string]*DatasourceSpec `json:"datasources,omitempty"`
+	Datasources     map[string]*DatasourceSpec `json:"datasources,omitzero"`
 	Variables       []Variable                 `json:"variables" required:"true" nullable:"false"`
 	Panels          map[string]*Panel          `json:"panels" required:"true" nullable:"false"`
 	Layouts         []Layout                   `json:"layouts" required:"true" nullable:"false"`
-	Duration        common.DurationString      `json:"duration,omitempty"`
-	RefreshInterval common.DurationString      `json:"refreshInterval,omitempty"`
+	Duration        common.DurationString      `json:"duration"`
+	RefreshInterval common.DurationString      `json:"refreshInterval"`
 	Links           []Link                     `json:"links,omitzero"`
 }
 

--- a/pkg/types/dashboardtypes/perses_dashboard_data.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_data.go
@@ -26,7 +26,7 @@ type DashboardSpec struct {
 	Layouts         []Layout                   `json:"layouts" required:"true" nullable:"false"`
 	Duration        common.DurationString      `json:"duration,omitempty"`
 	RefreshInterval common.DurationString      `json:"refreshInterval,omitempty"`
-	Links           []dashboard.Link           `json:"links,omitempty"`
+	Links           []Link                     `json:"links,omitzero"`
 }
 
 // ══════════════════════════════════════════════

--- a/pkg/types/dashboardtypes/perses_replicas.go
+++ b/pkg/types/dashboardtypes/perses_replicas.go
@@ -21,8 +21,10 @@ import (
 const MaxDisplayNameLen = 128
 
 type Display struct {
-	Name        string `json:"name" required:"true"`
-	Description string `json:"description,omitempty"`
+	Name string `json:"name" required:"true"`
+	// Description always serializes ("" included) so a create -> GET round-trip
+	// preserves what a typed client sent; omitempty would drop an explicit "".
+	Description string `json:"description"`
 }
 
 func (d Display) Validate(label, path string) error {
@@ -161,8 +163,8 @@ type ListVariableSpec struct {
 	DefaultValue    *VariableDefaultValue `json:"defaultValue,omitempty"`
 	AllowAllValue   bool                  `json:"allowAllValue"`
 	AllowMultiple   bool                  `json:"allowMultiple"`
-	CustomAllValue  string                `json:"customAllValue,omitempty"`
-	CapturingRegexp string                `json:"capturingRegexp,omitempty"`
+	CustomAllValue  string                `json:"customAllValue"`
+	CapturingRegexp string                `json:"capturingRegexp"`
 	Sort            ListVariableSpecSort  `json:"sort,omitzero"`
 	Plugin          VariablePlugin        `json:"plugin"`
 	Name            string                `json:"name" required:"true" minLength:"1"`
@@ -278,7 +280,7 @@ func (s *ListVariableSpecSort) UnmarshalJSON(data []byte) error {
 type TextVariableSpec struct {
 	Display  Display `json:"display" required:"true"`
 	Value    string  `json:"value" required:"true"`
-	Constant bool    `json:"constant,omitempty"`
+	Constant bool    `json:"constant"`
 	Name     string  `json:"name" required:"true" minLength:"1"`
 }
 

--- a/pkg/types/dashboardtypes/perses_replicas.go
+++ b/pkg/types/dashboardtypes/perses_replicas.go
@@ -75,10 +75,22 @@ func (k *PanelKind) UnmarshalJSON(data []byte) error {
 }
 
 type PanelSpec struct {
-	Display Display          `json:"display" required:"true"`
-	Plugin  PanelPlugin      `json:"plugin" required:"true"`
-	Queries []Query          `json:"queries" required:"true" nullable:"false"`
-	Links   []dashboard.Link `json:"links,omitempty"`
+	Display Display     `json:"display" required:"true"`
+	Plugin  PanelPlugin `json:"plugin" required:"true"`
+	Queries []Query     `json:"queries" required:"true" nullable:"false"`
+	Links   []Link      `json:"links,omitzero"`
+}
+
+// Link replicates dashboard.Link (Perses) so its zero-valued fields survive the
+// create -> GET round-trip. Perses tags name/tooltip/renderVariables/targetBlank
+// omitempty, which drops "" and false; here every field always serializes so a
+// typed client reads back exactly what it sent.
+type Link struct {
+	Name            string `json:"name"`
+	URL             string `json:"url"`
+	Tooltip         string `json:"tooltip"`
+	RenderVariables bool   `json:"renderVariables"`
+	TargetBlank     bool   `json:"targetBlank"`
 }
 
 // ══════════════════════════════════════════════

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -1570,6 +1570,11 @@ def test_dashboard_v2_rejects_comma_separated_aggregation(
 # the required-tag validation used to reject on create), builder slices set to an
 # explicit [] that must echo back as [] (yet stay absent, never null, when unset),
 # and scalars disabled/legend that must always echo false/"".
+#
+# It also covers the spec-wide zero values: a display description "", a text
+# variable's constant false, a list variable's customAllValue/capturingRegexp "",
+# an explicit [] of panel links, and a link whose own zero-valued fields
+# (name/tooltip "", renderVariables/targetBlank false) must echo back.
 
 
 def test_dashboard_v2_roundtrip_preserves_zero_values(
@@ -1585,7 +1590,27 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
         "name": "roundtrip-zero-values",
         "tags": [],
         "spec": {
-            "display": {"name": "Roundtrip Zero Values"},
+            "display": {"name": "Roundtrip Zero Values", "description": ""},
+            "variables": [
+                # TextVariable: constant false must echo back (not be dropped).
+                {"kind": "TextVariable", "spec": {"display": {"name": "tv"}, "value": "x", "constant": False, "name": "tv"}},
+                # ListVariable: customAllValue / capturingRegexp "" must echo back.
+                {
+                    "kind": "ListVariable",
+                    "spec": {
+                        "display": {"name": "lv"},
+                        "allowAllValue": False,
+                        "allowMultiple": False,
+                        "customAllValue": "",
+                        "capturingRegexp": "",
+                        "plugin": {"kind": "signoz/DynamicVariable", "spec": {"name": "service.name", "signal": "metrics"}},
+                        "name": "lv",
+                    },
+                },
+            ],
+            # Dashboard-level link with zero-valued inner fields: the replicated Link
+            # type must echo name/tooltip "" and renderVariables/targetBlank false.
+            "links": [{"url": "https://example.com", "name": "", "tooltip": "", "renderVariables": False, "targetBlank": False}],
             "panels": {
                 # NumberPanel: ComparisonThreshold value 0 + a builder query whose
                 # zero-valued slices/scalars are all set explicitly.
@@ -1593,6 +1618,8 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
                     "kind": "Panel",
                     "spec": {
                         "display": {"name": "number"},
+                        # Explicit empty panel links must round-trip as [].
+                        "links": [],
                         "plugin": {
                             "kind": "signoz/NumberPanel",
                             "spec": {"thresholds": [{"value": 0, "operator": "above_or_equal", "color": "#c2780b", "format": "background"}]},
@@ -1702,7 +1729,10 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
             timeout=5,
         )
         assert response.status_code == HTTPStatus.OK, response.text
-        panels = response.json()["data"]["spec"]["panels"]
+        result_spec = response.json()["data"]["spec"]
+        panels = result_spec["panels"]
+        variables = {v["kind"]: v["spec"] for v in result_spec["variables"]}
+        link = result_spec["links"][0]
 
         def query_spec(panel_id: str) -> dict:
             return panels[panel_id]["spec"]["queries"][0]["spec"]["plugin"]["spec"]
@@ -1731,6 +1761,15 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
             ("promql legend empty", promql["legend"], ""),
             ("clickhouse disabled false", clickhouse["disabled"], False),
             ("clickhouse legend empty", clickhouse["legend"], ""),
+            ("dashboard display description empty", result_spec["display"]["description"], ""),
+            ("text variable constant false", variables["TextVariable"]["constant"], False),
+            ("list variable customAllValue empty", variables["ListVariable"]["customAllValue"], ""),
+            ("list variable capturingRegexp empty", variables["ListVariable"]["capturingRegexp"], ""),
+            ("panel empty links round-trip", panels["number"]["spec"]["links"], []),
+            ("dashboard link name empty", link["name"], ""),
+            ("dashboard link tooltip empty", link["tooltip"], ""),
+            ("dashboard link renderVariables false", link["renderVariables"], False),
+            ("dashboard link targetBlank false", link["targetBlank"], False),
         ]
         for description, actual, expected in roundtrip_cases:
             assert actual == expected, description
@@ -1741,6 +1780,7 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
             ("bare builder omits order", timeseries, "order"),
             ("bare builder omits selectFields", timeseries, "selectFields"),
             ("bare builder omits functions", timeseries, "functions"),
+            ("panel without links omits links", panels["timeseries"]["spec"], "links"),
         ]
         for description, spec, key in absent_cases:
             assert key not in spec, description

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -1780,10 +1780,15 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
             ("bare builder omits order", timeseries, "order"),
             ("bare builder omits selectFields", timeseries, "selectFields"),
             ("bare builder omits functions", timeseries, "functions"),
-            ("panel without links omits links", panels["timeseries"]["spec"], "links"),
         ]
         for description, spec, key in absent_cases:
             assert key not in spec, description
+
+        # A panel with no links comes back with no links value (null or absent);
+        # either is fine for a typed client (an unset optional attribute stays
+        # unset), so this is not a drift. The explicit [] case above is what the
+        # fix guarantees round-trips.
+        assert panels["timeseries"]["spec"].get("links") is None, "unset panel links stays unset"
     finally:
         requests.delete(
             signoz.self.host_configs["8080"].get(f"{BASE_URL}/{dashboard_id}"),

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -1587,10 +1587,16 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
 
     dashboard = {
         "schemaVersion": "v6",
+        # image (dashboard-level) and spec duration/refreshInterval/datasources
+        # each round-trip their zero value ("" / {}) rather than being dropped.
+        "image": "",
         "name": "roundtrip-zero-values",
         "tags": [],
         "spec": {
             "display": {"name": "Roundtrip Zero Values", "description": ""},
+            "duration": "",
+            "refreshInterval": "",
+            "datasources": {},
             "variables": [
                 # TextVariable: constant false must echo back (not be dropped).
                 {"kind": "TextVariable", "spec": {"display": {"name": "tv"}, "value": "x", "constant": False, "name": "tv"}},
@@ -1729,7 +1735,8 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
             timeout=5,
         )
         assert response.status_code == HTTPStatus.OK, response.text
-        result_spec = response.json()["data"]["spec"]
+        result_data = response.json()["data"]
+        result_spec = result_data["spec"]
         panels = result_spec["panels"]
         variables = {v["kind"]: v["spec"] for v in result_spec["variables"]}
         link = result_spec["links"][0]
@@ -1770,6 +1777,10 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
             ("dashboard link tooltip empty", link["tooltip"], ""),
             ("dashboard link renderVariables false", link["renderVariables"], False),
             ("dashboard link targetBlank false", link["targetBlank"], False),
+            ("dashboard image empty", result_data["image"], ""),
+            ("spec duration empty", result_spec["duration"], ""),
+            ("spec refreshInterval empty", result_spec["refreshInterval"], ""),
+            ("spec empty datasources round-trip", result_spec["datasources"], {}),
         ]
         for description, actual, expected in roundtrip_cases:
             assert actual == expected, description


### PR DESCRIPTION
Completes the dashboards-v2 create → GET round-trip: every zero value a typed client (Terraform / SDK / PUT-after-GET) can set now echoes back verbatim instead of being dropped.

## Fixed
- `Display.Description`, `TextVariableSpec.Constant`, `ListVariableSpec.CustomAllValue` / `CapturingRegexp` — drop `omitempty` so `""` / `false` round-trip.
- `DashboardV2.Image`, `DashboardSpec.Duration` / `RefreshInterval` — drop `omitempty` so `""` round-trips (server already accepts `""`: `DurationString` allows empty, image has no validation).
- `PanelSpec.Links` / `DashboardSpec.Links` — `omitzero` so an explicit `[]` round-trips, **and** replace the imported perses `dashboard.Link` with a SigNoz-owned `Link` replica whose `name` / `tooltip` / `renderVariables` / `targetBlank` always serialize (perses tagged them `omitempty`, dropping their zero values).
- `DashboardSpec.Datasources` — `omitzero` so an explicit `{}` round-trips.
- Extended the v2 dashboards integration round-trip test to cover all of the above.
- Regenerated `docs/api/openapi.yml` + frontend client (`links` and `datasources` are now `nullable`).

## Not changed (intentional)
- `Thresholds`, `Legend.CustomColors`, `TableFormatting.ColumnUnits`, grid `GridItem` positions — no `omitempty`, so explicit `[]` / `{}` / `0` already round-trip; unset → `null` is consistent for a typed client (not a drift) and already `nullable` in the schema.
- `ListVariableSpec.Sort` — `omitzero`; "no sort" is the value `"none"`, so only the invalid `""` is omitted.
- `QuerySpec.Name` — the query-envelope name isn't a meaningful zero value (it's an identifier; the real name lives in `plugin.spec`).
- Enum defaulting (`decimalPrecision`, legend `position` / `mode`, `lineInterpolation`, …) — these emit their default when unset by design; explicit values round-trip.

## Deferred
- **Deferred** (need replicating a perses type, low-impact): `DatasourceSpec.Display` (perses `common.Display` drops inner `""`) and `GridLayoutSpec.RepeatVariable`.