### PR TITLE
fix(querybuildertypesv5): allow empty source, temporality and timeAggregation in the metric query spec

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -6334,6 +6334,7 @@ components:
       - delta
       - cumulative
       - unspecified
+      - ""
       type: string
     MetrictypesTimeAggregation:
       enum:
@@ -6346,6 +6347,7 @@ components:
       - count_distinct
       - rate
       - increase
+      - ""
       type: string
     MetrictypesType:
       enum:
@@ -8596,6 +8598,7 @@ components:
     TelemetrytypesSource:
       enum:
       - meter
+      - ""
       type: string
     TelemetrytypesTelemetryFieldKey:
       properties:

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -3631,6 +3631,7 @@ export enum Querybuildertypesv5QueryBuilderQueryGithubComSigNozSignozPkgTypesQue
 }
 export enum TelemetrytypesSourceDTO {
 	meter = 'meter',
+	'' = '',
 }
 export interface Querybuildertypesv5QueryBuilderQueryGithubComSigNozSignozPkgTypesQuerybuildertypesQuerybuildertypesv5LogAggregationDTO {
 	/**
@@ -3730,6 +3731,7 @@ export enum MetrictypesTemporalityDTO {
 	delta = 'delta',
 	cumulative = 'cumulative',
 	unspecified = 'unspecified',
+	'' = '',
 }
 export enum MetrictypesTimeAggregationDTO {
 	latest = 'latest',
@@ -3741,6 +3743,7 @@ export enum MetrictypesTimeAggregationDTO {
 	count_distinct = 'count_distinct',
 	rate = 'rate',
 	increase = 'increase',
+	'' = '',
 }
 export interface Querybuildertypesv5MetricAggregationDTO {
 	comparisonSpaceAggregationParam?: MetrictypesComparisonSpaceAggregationParamDTO;

--- a/pkg/types/metrictypes/metrictypes.go
+++ b/pkg/types/metrictypes/metrictypes.go
@@ -69,9 +69,6 @@ func (t *Temporality) Scan(src any) error {
 	return nil
 }
 
-// Enum returns the acceptable values for Temporality. The unknown (empty) value
-// is accepted and echoed back by the server when a query omits temporality, so
-// it is a valid enum member a typed client can round-trip.
 func (Temporality) Enum() []any {
 	return []any{
 		Delta,
@@ -180,9 +177,6 @@ var (
 	TimeAggregationIncrease      = TimeAggregation{valuer.NewString("increase")}
 )
 
-// Enum returns the acceptable values for TimeAggregation. The unspecified
-// (empty) value is accepted and echoed back by the server when a query omits
-// time aggregation, so it is a valid enum member a typed client can round-trip.
 func (TimeAggregation) Enum() []any {
 	return []any{
 		TimeAggregationLatest,

--- a/pkg/types/metrictypes/metrictypes.go
+++ b/pkg/types/metrictypes/metrictypes.go
@@ -69,11 +69,15 @@ func (t *Temporality) Scan(src any) error {
 	return nil
 }
 
+// Enum returns the acceptable values for Temporality. The unknown (empty) value
+// is accepted and echoed back by the server when a query omits temporality, so
+// it is a valid enum member a typed client can round-trip.
 func (Temporality) Enum() []any {
 	return []any{
 		Delta,
 		Cumulative,
 		Unspecified,
+		Unknown,
 	}
 }
 
@@ -176,6 +180,9 @@ var (
 	TimeAggregationIncrease      = TimeAggregation{valuer.NewString("increase")}
 )
 
+// Enum returns the acceptable values for TimeAggregation. The unspecified
+// (empty) value is accepted and echoed back by the server when a query omits
+// time aggregation, so it is a valid enum member a typed client can round-trip.
 func (TimeAggregation) Enum() []any {
 	return []any{
 		TimeAggregationLatest,
@@ -187,6 +194,7 @@ func (TimeAggregation) Enum() []any {
 		TimeAggregationCountDistinct,
 		TimeAggregationRate,
 		TimeAggregationIncrease,
+		TimeAggregationUnspecified,
 	}
 }
 

--- a/pkg/types/querybuildertypes/querybuildertypesv5/builder_elements.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/builder_elements.go
@@ -514,11 +514,11 @@ type MetricAggregation struct {
 	// type of the metric
 	Type metrictypes.Type `json:"-"`
 	// temporality to apply to the query
-	Temporality metrictypes.Temporality `json:"temporality,omitzero"`
+	Temporality metrictypes.Temporality `json:"temporality"`
 	// time aggregation to apply to the query
-	TimeAggregation metrictypes.TimeAggregation `json:"timeAggregation,omitzero"`
+	TimeAggregation metrictypes.TimeAggregation `json:"timeAggregation"`
 	// space aggregation to apply to the query
-	SpaceAggregation metrictypes.SpaceAggregation `json:"spaceAggregation,omitzero"`
+	SpaceAggregation metrictypes.SpaceAggregation `json:"spaceAggregation"`
 	// param for space aggregation if needed
 	ComparisonSpaceAggregationParam *metrictypes.ComparisonSpaceAggregationParam `json:"comparisonSpaceAggregationParam,omitempty"`
 	// table hints to use for the query

--- a/pkg/types/querybuildertypes/querybuildertypesv5/builder_elements.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/builder_elements.go
@@ -514,11 +514,11 @@ type MetricAggregation struct {
 	// type of the metric
 	Type metrictypes.Type `json:"-"`
 	// temporality to apply to the query
-	Temporality metrictypes.Temporality `json:"temporality"`
+	Temporality metrictypes.Temporality `json:"temporality,omitzero"`
 	// time aggregation to apply to the query
-	TimeAggregation metrictypes.TimeAggregation `json:"timeAggregation"`
+	TimeAggregation metrictypes.TimeAggregation `json:"timeAggregation,omitzero"`
 	// space aggregation to apply to the query
-	SpaceAggregation metrictypes.SpaceAggregation `json:"spaceAggregation"`
+	SpaceAggregation metrictypes.SpaceAggregation `json:"spaceAggregation,omitzero"`
 	// param for space aggregation if needed
 	ComparisonSpaceAggregationParam *metrictypes.ComparisonSpaceAggregationParam `json:"comparisonSpaceAggregationParam,omitempty"`
 	// table hints to use for the query

--- a/pkg/types/querybuildertypes/querybuildertypesv5/builder_query.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/builder_query.go
@@ -22,7 +22,7 @@ type QueryBuilderQuery[T any] struct {
 	Signal telemetrytypes.Signal `json:"signal,omitempty"`
 
 	// source for query
-	Source telemetrytypes.Source `json:"source,omitempty"`
+	Source telemetrytypes.Source `json:"source,omitzero"`
 
 	// we want to support multiple aggregations
 	// currently supported: []Aggregation, []MetricAggregation

--- a/pkg/types/querybuildertypes/querybuildertypesv5/builder_query.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/builder_query.go
@@ -22,7 +22,7 @@ type QueryBuilderQuery[T any] struct {
 	Signal telemetrytypes.Signal `json:"signal,omitempty"`
 
 	// source for query
-	Source telemetrytypes.Source `json:"source,omitzero"`
+	Source telemetrytypes.Source `json:"source"`
 
 	// we want to support multiple aggregations
 	// currently supported: []Aggregation, []MetricAggregation

--- a/pkg/types/querybuildertypes/querybuildertypesv5/builder_query_test.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/builder_query_test.go
@@ -651,3 +651,62 @@ func TestQueryBuilderQuery_UnmarshalJSON(t *testing.T) {
 		assert.Equal(t, telemetrytypes.FieldContextSpan, query.Order[0].Key.FieldContext)
 	})
 }
+
+func TestQueryBuilderQuery_MarshalJSONEnumRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name    string
+		query   QueryBuilderQuery[MetricAggregation]
+		absent  []string
+		present []string
+	}{
+		{
+			// An unset enum serializes as "", which fails the schema enum on read
+			// back (the terraform provider rejects "" for source/temporality/etc).
+			// ,omitzero drops the invalid unset state instead of emitting "".
+			name: "UnsetEnumsAreOmitted",
+			query: QueryBuilderQuery[MetricAggregation]{
+				Name:         "A",
+				Signal:       telemetrytypes.SignalMetrics,
+				Aggregations: []MetricAggregation{{MetricName: "system.cpu.usage"}},
+			},
+			absent: []string{`"source"`, `"temporality"`, `"timeAggregation"`, `"spaceAggregation"`},
+		},
+		{
+			name: "SetEnumsAreSerialized",
+			query: QueryBuilderQuery[MetricAggregation]{
+				Name:   "A",
+				Signal: telemetrytypes.SignalMetrics,
+				Source: telemetrytypes.SourceMeter,
+				Aggregations: []MetricAggregation{{
+					MetricName:       "system.cpu.usage",
+					Temporality:      metrictypes.Cumulative,
+					TimeAggregation:  metrictypes.TimeAggregationRate,
+					SpaceAggregation: metrictypes.SpaceAggregationSum,
+				}},
+			},
+			present: []string{`"source":"meter"`, `"temporality":"cumulative"`, `"timeAggregation":"rate"`, `"spaceAggregation":"sum"`},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			expected, err := json.Marshal(testCase.query)
+			require.NoError(t, err)
+
+			for _, fragment := range testCase.absent {
+				assert.NotContains(t, string(expected), fragment)
+			}
+			for _, fragment := range testCase.present {
+				assert.Contains(t, string(expected), fragment)
+			}
+
+			// Marshal -> unmarshal -> marshal must be stable so a create -> GET
+			// round-trip never reintroduces an invalid empty enum value.
+			var decoded QueryBuilderQuery[MetricAggregation]
+			require.NoError(t, json.Unmarshal(expected, &decoded))
+			actual, err := json.Marshal(decoded)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(expected), string(actual))
+		})
+	}
+}

--- a/pkg/types/querybuildertypes/querybuildertypesv5/builder_query_test.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/builder_query_test.go
@@ -659,12 +659,6 @@ func TestQueryBuilderQuery_MetricAggregation_MarshalJSONEnumRoundTrip(t *testing
 		present []string
 	}{
 		{
-			// The server accepts an unset source/temporality/timeAggregation, so it
-			// echoes "" back rather than dropping it (spaceAggregation is required, so
-			// its "" is 400'd at creation and never reaches a stored query). "" is a
-			// member of each of those enums, so a typed client round-trips faithfully.
-			// The marshal -> unmarshal -> marshal check below also covers the reverse
-			// path: a client that sends "" reads back exactly what it sent.
 			name: "AcceptedEmptyEnumsAreEchoed",
 			query: QueryBuilderQuery[MetricAggregation]{
 				Name:   "A",

--- a/pkg/types/querybuildertypes/querybuildertypesv5/builder_query_test.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/builder_query_test.go
@@ -710,3 +710,36 @@ func TestQueryBuilderQuery_MarshalJSONEnumRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestQueryBuilderQuery_UnmarshalEmptyEnumsAreDropped(t *testing.T) {
+	// A client may send explicit empty enum values (e.g. terraform emits
+	// source:"" for a non-meter metric, temporality:"" when unset). Unmarshaling
+	// must accept them and normalize to the zero value, and re-marshaling must
+	// drop them so a create -> GET round-trip never echoes an invalid "" back.
+	input := `{
+		"name": "A",
+		"signal": "metrics",
+		"source": "",
+		"aggregations": [{
+			"metricName": "system.cpu.usage",
+			"temporality": "",
+			"timeAggregation": "",
+			"spaceAggregation": ""
+		}]
+	}`
+
+	var query QueryBuilderQuery[MetricAggregation]
+	require.NoError(t, json.Unmarshal([]byte(input), &query))
+
+	assert.True(t, query.Source.IsZero())
+	assert.True(t, query.Aggregations[0].Temporality.IsZero())
+	assert.True(t, query.Aggregations[0].TimeAggregation.IsZero())
+	assert.True(t, query.Aggregations[0].SpaceAggregation.IsZero())
+
+	actual, err := json.Marshal(query)
+	require.NoError(t, err)
+
+	for _, fragment := range []string{`"source"`, `"temporality"`, `"timeAggregation"`, `"spaceAggregation"`} {
+		assert.NotContains(t, string(actual), fragment)
+	}
+}

--- a/pkg/types/querybuildertypes/querybuildertypesv5/builder_query_test.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/builder_query_test.go
@@ -652,7 +652,7 @@ func TestQueryBuilderQuery_UnmarshalJSON(t *testing.T) {
 	})
 }
 
-func TestQueryBuilderQuery_MarshalJSONEnumRoundTrip(t *testing.T) {
+func TestQueryBuilderQuery_MetricAggregation_MarshalJSONEnumRoundTrip(t *testing.T) {
 	testCases := []struct {
 		name    string
 		query   QueryBuilderQuery[MetricAggregation]
@@ -663,6 +663,8 @@ func TestQueryBuilderQuery_MarshalJSONEnumRoundTrip(t *testing.T) {
 			// echoes "" back rather than dropping it (spaceAggregation is required, so
 			// its "" is 400'd at creation and never reaches a stored query). "" is a
 			// member of each of those enums, so a typed client round-trips faithfully.
+			// The marshal -> unmarshal -> marshal check below also covers the reverse
+			// path: a client that sends "" reads back exactly what it sent.
 			name: "AcceptedEmptyEnumsAreEchoed",
 			query: QueryBuilderQuery[MetricAggregation]{
 				Name:   "A",
@@ -711,37 +713,5 @@ func TestQueryBuilderQuery_MarshalJSONEnumRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 			assert.JSONEq(t, string(expected), string(actual))
 		})
-	}
-}
-
-func TestQueryBuilderQuery_UnmarshalEmptyEnumsAreEchoed(t *testing.T) {
-	// A client may send explicit empty enum values (e.g. terraform emits source:""
-	// for a non-meter metric, temporality:"" when unset). Unmarshaling accepts them
-	// and re-marshaling echoes them back, so a create -> GET round-trip returns
-	// exactly what was sent instead of silently dropping the value.
-	input := `{
-		"name": "A",
-		"signal": "metrics",
-		"source": "",
-		"aggregations": [{
-			"metricName": "system.cpu.usage",
-			"temporality": "",
-			"timeAggregation": "",
-			"spaceAggregation": "sum"
-		}]
-	}`
-
-	var query QueryBuilderQuery[MetricAggregation]
-	require.NoError(t, json.Unmarshal([]byte(input), &query))
-
-	assert.True(t, query.Source.IsZero())
-	assert.True(t, query.Aggregations[0].Temporality.IsZero())
-	assert.True(t, query.Aggregations[0].TimeAggregation.IsZero())
-
-	actual, err := json.Marshal(query)
-	require.NoError(t, err)
-
-	for _, fragment := range []string{`"source":""`, `"temporality":""`, `"timeAggregation":""`, `"spaceAggregation":"sum"`} {
-		assert.Contains(t, string(actual), fragment)
 	}
 }

--- a/pkg/types/querybuildertypes/querybuildertypesv5/builder_query_test.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/builder_query_test.go
@@ -656,20 +656,26 @@ func TestQueryBuilderQuery_MarshalJSONEnumRoundTrip(t *testing.T) {
 	testCases := []struct {
 		name    string
 		query   QueryBuilderQuery[MetricAggregation]
-		absent  []string
 		present []string
 	}{
 		{
-			// An unset enum serializes as "", which fails the schema enum on read
-			// back (the terraform provider rejects "" for source/temporality/etc).
-			// ,omitzero drops the invalid unset state instead of emitting "".
-			name: "UnsetEnumsAreOmitted",
+			// The server accepts an unset source/temporality/timeAggregation, so it
+			// echoes "" back rather than dropping it (spaceAggregation is required, so
+			// its "" is 400'd at creation and never reaches a stored query). "" is a
+			// member of each of those enums, so a typed client round-trips faithfully.
+			name: "AcceptedEmptyEnumsAreEchoed",
 			query: QueryBuilderQuery[MetricAggregation]{
-				Name:         "A",
-				Signal:       telemetrytypes.SignalMetrics,
-				Aggregations: []MetricAggregation{{MetricName: "system.cpu.usage"}},
+				Name:   "A",
+				Signal: telemetrytypes.SignalMetrics,
+				Source: telemetrytypes.SourceUnspecified,
+				Aggregations: []MetricAggregation{{
+					MetricName:       "system.cpu.usage",
+					Temporality:      metrictypes.Unknown,
+					TimeAggregation:  metrictypes.TimeAggregationUnspecified,
+					SpaceAggregation: metrictypes.SpaceAggregationSum,
+				}},
 			},
-			absent: []string{`"source"`, `"temporality"`, `"timeAggregation"`, `"spaceAggregation"`},
+			present: []string{`"source":""`, `"temporality":""`, `"timeAggregation":""`, `"spaceAggregation":"sum"`},
 		},
 		{
 			name: "SetEnumsAreSerialized",
@@ -693,15 +699,12 @@ func TestQueryBuilderQuery_MarshalJSONEnumRoundTrip(t *testing.T) {
 			expected, err := json.Marshal(testCase.query)
 			require.NoError(t, err)
 
-			for _, fragment := range testCase.absent {
-				assert.NotContains(t, string(expected), fragment)
-			}
 			for _, fragment := range testCase.present {
 				assert.Contains(t, string(expected), fragment)
 			}
 
 			// Marshal -> unmarshal -> marshal must be stable so a create -> GET
-			// round-trip never reintroduces an invalid empty enum value.
+			// round-trip preserves exactly what the client sent.
 			var decoded QueryBuilderQuery[MetricAggregation]
 			require.NoError(t, json.Unmarshal(expected, &decoded))
 			actual, err := json.Marshal(decoded)
@@ -711,11 +714,11 @@ func TestQueryBuilderQuery_MarshalJSONEnumRoundTrip(t *testing.T) {
 	}
 }
 
-func TestQueryBuilderQuery_UnmarshalEmptyEnumsAreDropped(t *testing.T) {
-	// A client may send explicit empty enum values (e.g. terraform emits
-	// source:"" for a non-meter metric, temporality:"" when unset). Unmarshaling
-	// must accept them and normalize to the zero value, and re-marshaling must
-	// drop them so a create -> GET round-trip never echoes an invalid "" back.
+func TestQueryBuilderQuery_UnmarshalEmptyEnumsAreEchoed(t *testing.T) {
+	// A client may send explicit empty enum values (e.g. terraform emits source:""
+	// for a non-meter metric, temporality:"" when unset). Unmarshaling accepts them
+	// and re-marshaling echoes them back, so a create -> GET round-trip returns
+	// exactly what was sent instead of silently dropping the value.
 	input := `{
 		"name": "A",
 		"signal": "metrics",
@@ -724,7 +727,7 @@ func TestQueryBuilderQuery_UnmarshalEmptyEnumsAreDropped(t *testing.T) {
 			"metricName": "system.cpu.usage",
 			"temporality": "",
 			"timeAggregation": "",
-			"spaceAggregation": ""
+			"spaceAggregation": "sum"
 		}]
 	}`
 
@@ -734,12 +737,11 @@ func TestQueryBuilderQuery_UnmarshalEmptyEnumsAreDropped(t *testing.T) {
 	assert.True(t, query.Source.IsZero())
 	assert.True(t, query.Aggregations[0].Temporality.IsZero())
 	assert.True(t, query.Aggregations[0].TimeAggregation.IsZero())
-	assert.True(t, query.Aggregations[0].SpaceAggregation.IsZero())
 
 	actual, err := json.Marshal(query)
 	require.NoError(t, err)
 
-	for _, fragment := range []string{`"source"`, `"temporality"`, `"timeAggregation"`, `"spaceAggregation"`} {
-		assert.NotContains(t, string(actual), fragment)
+	for _, fragment := range []string{`"source":""`, `"temporality":""`, `"timeAggregation":""`, `"spaceAggregation":"sum"`} {
+		assert.Contains(t, string(actual), fragment)
 	}
 }

--- a/pkg/types/telemetrytypes/source.go
+++ b/pkg/types/telemetrytypes/source.go
@@ -13,8 +13,6 @@ var (
 )
 
 // Enum returns the acceptable values for Source.
-// The unspecified (empty) value is accepted and echoed back by the server for a
-// non-meter query, so it is a valid enum member a typed client can round-trip.
 // TODO: Add SourceAudit once the frontend is ready for consumption.
 func (Source) Enum() []any {
 	return []any{

--- a/pkg/types/telemetrytypes/source.go
+++ b/pkg/types/telemetrytypes/source.go
@@ -13,9 +13,12 @@ var (
 )
 
 // Enum returns the acceptable values for Source.
+// The unspecified (empty) value is accepted and echoed back by the server for a
+// non-meter query, so it is a valid enum member a typed client can round-trip.
 // TODO: Add SourceAudit once the frontend is ready for consumption.
 func (Source) Enum() []any {
 	return []any{
 		SourceMeter,
+		SourceUnspecified,
 	}
 }


### PR DESCRIPTION
The Terraform provider's `generate-config` rejects an imported `signoz_rule` because a metric query returns empty strings for `source`, `temporality`, and `timeAggregation`, but the OpenAPI enums for those fields didn't allow `""`.

The server accepts these empty values when a rule is created and echoes them back on `GET`, so `""` is a real, valid value — the spec just didn't say so. This adds `""` to the `Source`, `Temporality`, and `TimeAggregation` enums so the spec matches what the API actually accepts and returns.

`spaceAggregation` is deliberately left alone: an empty value there is rejected with a 400 at creation, so it's never stored or returned, and `""` correctly stays out of its enum.

Regenerated the OpenAPI spec and the frontend client, and added round-trip tests.

Fixes SigNoz/terraform-provider-signoz#132