### PR TITLE
fix(querybuildertypesv5): round-trip unset stepInterval and empty field-key values

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -8599,6 +8599,7 @@ components:
       - traces
       - logs
       - metrics
+      - ""
       type: string
     TelemetrytypesSource:
       enum:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -8558,6 +8558,7 @@ components:
       - resource
       - attribute
       - body
+      - ""
       type: string
     TelemetrytypesFieldDataType:
       enum:
@@ -8566,6 +8567,7 @@ components:
       - float64
       - int64
       - number
+      - ""
       type: string
     TelemetrytypesGettableFieldKeys:
       properties:

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -3493,6 +3493,7 @@ export enum TelemetrytypesSignalDTO {
 	traces = 'traces',
 	logs = 'logs',
 	metrics = 'metrics',
+	'' = '',
 }
 export interface Querybuildertypesv5GroupByKeyDTO {
 	/**

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -3479,6 +3479,7 @@ export enum TelemetrytypesFieldContextDTO {
 	resource = 'resource',
 	attribute = 'attribute',
 	body = 'body',
+	'' = '',
 }
 export enum TelemetrytypesFieldDataTypeDTO {
 	string = 'string',
@@ -3486,6 +3487,7 @@ export enum TelemetrytypesFieldDataTypeDTO {
 	float64 = 'float64',
 	int64 = 'int64',
 	number = 'number',
+	'' = '',
 }
 export enum TelemetrytypesSignalDTO {
 	traces = 'traces',

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel.ts
@@ -16,7 +16,13 @@ import { sortBy } from 'lodash-es';
 export type VariableType = 'QUERY' | 'CUSTOM' | 'TEXT' | 'DYNAMIC';
 
 /** Telemetry signal — the generated enum (traces / logs / metrics). */
-export type TelemetrySignal = TelemetrytypesSignalDTO;
+// A query/variable signal is only logs/traces/metrics. TelemetrytypesSignalDTO
+// also carries the empty "any" value used on field keys, which is not a valid
+// query/variable signal, so exclude it here.
+export type TelemetrySignal =
+	| TelemetrytypesSignalDTO.logs
+	| TelemetrytypesSignalDTO.traces
+	| TelemetrytypesSignalDTO.metrics;
 
 /**
  * Signal selected in the dynamic-variable editor. `'all'` is UI-only (the

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/PanelTypeSwitcher/utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/PanelTypeSwitcher/utils.ts
@@ -17,6 +17,9 @@ const SIGNAL_LABEL: Record<TelemetrytypesSignalDTO, string> = {
 	[TelemetrytypesSignalDTO.logs]: 'logs',
 	[TelemetrytypesSignalDTO.traces]: 'traces',
 	[TelemetrytypesSignalDTO.metrics]: 'metrics',
+	// The empty "any" signal only appears on field keys, never on a panel query;
+	// mapped for exhaustiveness.
+	[TelemetrytypesSignalDTO['']]: '',
 };
 
 /**

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
@@ -105,7 +105,8 @@ export function useDrilldownDashboardVariables({
 				type: 'DYNAMIC',
 				multiSelect: true,
 				dynamicAttribute: fieldName,
-				dynamicSignal: signal ?? DYNAMIC_SIGNAL_ALL,
+				// `||` (not `??`): an empty "any" signal maps to All, same as unset.
+				dynamicSignal: signal || DYNAMIC_SIGNAL_ALL,
 			};
 			try {
 				await patchAsync(

--- a/pkg/types/querybuildertypes/querybuildertypesv5/builder_elements.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/builder_elements.go
@@ -613,7 +613,7 @@ func (o OrderBy) Copy() OrderBy {
 type SecondaryAggregation struct {
 	// stepInterval of the query
 	// if not set, it will use the step interval of the primary aggregation
-	StepInterval Step `json:"stepInterval,omitempty"`
+	StepInterval Step `json:"stepInterval,omitzero"`
 	// expression to aggregate. example: count(), sum(item_price), countIf(day > 10)
 	Expression string `json:"expression"`
 	// if any, it will be used as the alias of the aggregation in the result

--- a/pkg/types/querybuildertypes/querybuildertypesv5/builder_query.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/builder_query.go
@@ -16,7 +16,7 @@ type QueryBuilderQuery[T any] struct {
 	Name string `json:"name"`
 
 	// stepInterval of the query
-	StepInterval Step `json:"stepInterval,omitempty"`
+	StepInterval Step `json:"stepInterval,omitzero"`
 
 	// signal to query
 	Signal telemetrytypes.Signal `json:"signal,omitempty"`

--- a/pkg/types/querybuildertypes/querybuildertypesv5/builder_query_test.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/builder_query_test.go
@@ -709,3 +709,40 @@ func TestQueryBuilderQuery_MetricAggregation_MarshalJSONEnumRoundTrip(t *testing
 		})
 	}
 }
+
+// stepInterval is a struct-backed Step, so omitempty had no effect and an unset
+// value serialized as 0; ,omitzero omits it when unset while still echoing a set
+// value (as seconds), keeping the create -> GET round-trip stable.
+func TestQueryBuilderQuery_StepInterval_MarshalRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name    string
+		query   QueryBuilderQuery[LogAggregation]
+		present []string
+		absent  []string
+	}{
+		{
+			name:   "UnsetStepIntervalIsOmitted",
+			query:  QueryBuilderQuery[LogAggregation]{Name: "A", Signal: telemetrytypes.SignalLogs},
+			absent: []string{`"stepInterval"`},
+		},
+		{
+			name:    "SetStepIntervalIsSerializedAsSeconds",
+			query:   QueryBuilderQuery[LogAggregation]{Name: "A", Signal: telemetrytypes.SignalLogs, StepInterval: Step{60 * time.Second}},
+			present: []string{`"stepInterval":60`},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			expected, err := json.Marshal(testCase.query)
+			require.NoError(t, err)
+
+			for _, fragment := range testCase.present {
+				assert.Contains(t, string(expected), fragment)
+			}
+			for _, fragment := range testCase.absent {
+				assert.NotContains(t, string(expected), fragment)
+			}
+		})
+	}
+}

--- a/pkg/types/querybuildertypes/querybuildertypesv5/resp_test.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/resp_test.go
@@ -130,7 +130,7 @@ func TestScalarData_MarshalJSON(t *testing.T) {
 					{4.0, 5.0, 6.0},
 				},
 			},
-			expected: `{"queryName":"test_query","columns":[{"name":"value","fieldContext":"","fieldDataType":"","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[[1,2,3],[4,5,6]]}`,
+			expected: `{"queryName":"test_query","columns":[{"name":"value","signal":"","fieldContext":"","fieldDataType":"","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[[1,2,3],[4,5,6]]}`,
 		},
 		{
 			name: "scalar data with NaN",
@@ -149,7 +149,7 @@ func TestScalarData_MarshalJSON(t *testing.T) {
 					{math.Inf(1), 5.0, math.Inf(-1)},
 				},
 			},
-			expected: `{"queryName":"test_query","columns":[{"name":"value","fieldContext":"","fieldDataType":"","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[[1,"NaN",3],["Inf",5,"-Inf"]]}`,
+			expected: `{"queryName":"test_query","columns":[{"name":"value","signal":"","fieldContext":"","fieldDataType":"","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[[1,"NaN",3],["Inf",5,"-Inf"]]}`,
 		},
 		{
 			name: "scalar data with mixed types",
@@ -168,7 +168,7 @@ func TestScalarData_MarshalJSON(t *testing.T) {
 					{nil, math.Inf(1), 3.14, false},
 				},
 			},
-			expected: `{"queryName":"test_query","columns":[{"name":"mixed","fieldContext":"","fieldDataType":"","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[["string",42,"NaN",true],[null,"Inf",3.14,false]]}`,
+			expected: `{"queryName":"test_query","columns":[{"name":"mixed","signal":"","fieldContext":"","fieldDataType":"","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[["string",42,"NaN",true],[null,"Inf",3.14,false]]}`,
 		},
 		{
 			name: "scalar data with nested structures",
@@ -189,7 +189,7 @@ func TestScalarData_MarshalJSON(t *testing.T) {
 					},
 				},
 			},
-			expected: `{"queryName":"test_query","columns":[{"name":"nested","fieldContext":"","fieldDataType":"","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[[{"count":10,"value":"NaN"},[1,"Inf",3]]]}`,
+			expected: `{"queryName":"test_query","columns":[{"name":"nested","signal":"","fieldContext":"","fieldDataType":"","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[[{"count":10,"value":"NaN"},[1,"Inf",3]]]}`,
 		},
 		{
 			name: "empty scalar data",

--- a/pkg/types/querybuildertypes/querybuildertypesv5/resp_test.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/resp_test.go
@@ -130,7 +130,7 @@ func TestScalarData_MarshalJSON(t *testing.T) {
 					{4.0, 5.0, 6.0},
 				},
 			},
-			expected: `{"queryName":"test_query","columns":[{"name":"value","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[[1,2,3],[4,5,6]]}`,
+			expected: `{"queryName":"test_query","columns":[{"name":"value","fieldContext":"","fieldDataType":"","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[[1,2,3],[4,5,6]]}`,
 		},
 		{
 			name: "scalar data with NaN",
@@ -149,7 +149,7 @@ func TestScalarData_MarshalJSON(t *testing.T) {
 					{math.Inf(1), 5.0, math.Inf(-1)},
 				},
 			},
-			expected: `{"queryName":"test_query","columns":[{"name":"value","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[[1,"NaN",3],["Inf",5,"-Inf"]]}`,
+			expected: `{"queryName":"test_query","columns":[{"name":"value","fieldContext":"","fieldDataType":"","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[[1,"NaN",3],["Inf",5,"-Inf"]]}`,
 		},
 		{
 			name: "scalar data with mixed types",
@@ -168,7 +168,7 @@ func TestScalarData_MarshalJSON(t *testing.T) {
 					{nil, math.Inf(1), 3.14, false},
 				},
 			},
-			expected: `{"queryName":"test_query","columns":[{"name":"mixed","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[["string",42,"NaN",true],[null,"Inf",3.14,false]]}`,
+			expected: `{"queryName":"test_query","columns":[{"name":"mixed","fieldContext":"","fieldDataType":"","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[["string",42,"NaN",true],[null,"Inf",3.14,false]]}`,
 		},
 		{
 			name: "scalar data with nested structures",
@@ -189,7 +189,7 @@ func TestScalarData_MarshalJSON(t *testing.T) {
 					},
 				},
 			},
-			expected: `{"queryName":"test_query","columns":[{"name":"nested","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[[{"count":10,"value":"NaN"},[1,"Inf",3]]]}`,
+			expected: `{"queryName":"test_query","columns":[{"name":"nested","fieldContext":"","fieldDataType":"","queryName":"test_query","aggregationIndex":0,"meta":{},"columnType":"aggregation"}],"data":[[{"count":10,"value":"NaN"},[1,"Inf",3]]]}`,
 		},
 		{
 			name: "empty scalar data",

--- a/pkg/types/querybuildertypes/querybuildertypesv5/trace_operator.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/trace_operator.go
@@ -51,7 +51,7 @@ type QueryBuilderTraceOperator struct {
 	Order []OrderBy `json:"order,omitzero"`
 
 	Aggregations []TraceAggregation `json:"aggregations,omitzero"`
-	StepInterval Step               `json:"stepInterval,omitempty"`
+	StepInterval Step               `json:"stepInterval,omitzero"`
 	GroupBy      []GroupByKey       `json:"groupBy,omitzero"`
 
 	// having clause to apply to the aggregated query results

--- a/pkg/types/telemetrytypes/field.go
+++ b/pkg/types/telemetrytypes/field.go
@@ -33,12 +33,11 @@ type TelemetryFieldKey struct {
 	Name        string `json:"name" validate:"required" required:"true"`
 	Description string `json:"description,omitempty"`
 	Unit        string `json:"unit,omitempty"`
-	Signal      Signal `json:"signal,omitzero"`
-	// fieldContext/fieldDataType always serialize (empty included): the empty value
-	// is a first-class "unspecified / any" selection a client can set, so it must
-	// round-trip verbatim rather than be dropped. Their Enum()s include the empty
-	// member so the "" is a valid schema value. signal stays omitzero — its empty
-	// value is invalid for the query/variable signal contexts that share the enum.
+	// signal/fieldContext/fieldDataType always serialize (empty included): the empty
+	// value is a first-class "unspecified / any" selection a client can set, so it
+	// must round-trip verbatim rather than be dropped. Their Enum()s include the
+	// empty member so the "" is a valid schema value.
+	Signal        Signal        `json:"signal"`
 	FieldContext  FieldContext  `json:"fieldContext"`
 	FieldDataType FieldDataType `json:"fieldDataType"`
 

--- a/pkg/types/telemetrytypes/field.go
+++ b/pkg/types/telemetrytypes/field.go
@@ -30,12 +30,17 @@ const (
 )
 
 type TelemetryFieldKey struct {
-	Name          string        `json:"name" validate:"required" required:"true"`
-	Description   string        `json:"description,omitempty"`
-	Unit          string        `json:"unit,omitempty"`
-	Signal        Signal        `json:"signal,omitzero"`
-	FieldContext  FieldContext  `json:"fieldContext,omitzero"`
-	FieldDataType FieldDataType `json:"fieldDataType,omitzero"`
+	Name        string `json:"name" validate:"required" required:"true"`
+	Description string `json:"description,omitempty"`
+	Unit        string `json:"unit,omitempty"`
+	Signal      Signal `json:"signal,omitzero"`
+	// fieldContext/fieldDataType always serialize (empty included): the empty value
+	// is a first-class "unspecified / any" selection a client can set, so it must
+	// round-trip verbatim rather than be dropped. Their Enum()s include the empty
+	// member so the "" is a valid schema value. signal stays omitzero — its empty
+	// value is invalid for the query/variable signal contexts that share the enum.
+	FieldContext  FieldContext  `json:"fieldContext"`
+	FieldDataType FieldDataType `json:"fieldDataType"`
 
 	JSONPlan     JSONAccessPlan               `json:"-"`
 	Indexes      []TelemetryFieldKeySkipIndex `json:"-"`

--- a/pkg/types/telemetrytypes/field_context.go
+++ b/pkg/types/telemetrytypes/field_context.go
@@ -185,5 +185,6 @@ func (FieldContext) Enum() []any {
 		FieldContextAttribute,
 		// FieldContextEvent,
 		FieldContextBody,
+		FieldContextUnspecified,
 	}
 }

--- a/pkg/types/telemetrytypes/field_datatype.go
+++ b/pkg/types/telemetrytypes/field_datatype.go
@@ -190,6 +190,7 @@ func (FieldDataType) Enum() []any {
 		FieldDataTypeFloat64,
 		FieldDataTypeInt64,
 		FieldDataTypeNumber,
+		FieldDataTypeUnspecified,
 		// FieldDataTypeArrayString,
 		// FieldDataTypeArrayFloat64,
 		// FieldDataTypeArrayBool,

--- a/pkg/types/telemetrytypes/signal.go
+++ b/pkg/types/telemetrytypes/signal.go
@@ -19,5 +19,6 @@ func (Signal) Enum() []any {
 		SignalTraces,
 		SignalLogs,
 		SignalMetrics,
+		SignalUnspecified,
 	}
 }

--- a/tests/integration/tests/querierlogs/02_aggregation.py
+++ b/tests/integration/tests/querierlogs/02_aggregation.py
@@ -390,6 +390,9 @@ def test_logs_time_series_count(
         {
             "key": {
                 "name": "host.name",
+                "signal": "",
+                "fieldContext": "",
+                "fieldDataType": "",
             },
             "value": "linux-001",
         }
@@ -411,6 +414,9 @@ def test_logs_time_series_count(
         {
             "key": {
                 "name": "host.name",
+                "signal": "",
+                "fieldContext": "",
+                "fieldDataType": "",
             },
             "value": "linux-000",
         }


### PR DESCRIPTION
Some query fields didn't survive a create → GET round-trip. If you left them empty/unset, the API either echoed back a value you never sent or dropped your empty value — so a typed client (Terraform / SDK) that read the query back saw something different from what it sent. Came out of the #12158 review.

### What changed
- **`stepInterval`** now disappears when you don't set it. It's a struct, so the old `omitempty` did nothing and an unset step was coming back as `0`. Switched to `omitzero`.
- **A field key's `signal` / `fieldContext` / `fieldDataType`** can be deliberately left empty to mean "any", and that empty value now round-trips instead of being dropped. To make an empty value legal on the wire, it's now a member of each enum — the same fix #12164 used for `source`.
- **Frontend:** the `signal` enum is shared with the variable/panel signal pickers, where empty isn't a real choice, so those were narrowed back to `logs`/`traces`/`metrics` (keeping them exhaustive) and an empty drilldown signal is treated as "All".
- Regenerated the OpenAPI spec + frontend client, and updated a marshal test plus the querierlogs aggregation test whose labels now carry the empty fields.

### Next Fields to Review
 `reduceTo`, function-arg names, aggregation aliases, `offset`, `cursor`