### PR TITLE
fix(dashboard-v2): variable, panel-layout, and dashboards-list bug-bash fixes

### DIFF
--- a/frontend/src/components/TagBadge/TagBadge.module.scss
+++ b/frontend/src/components/TagBadge/TagBadge.module.scss
@@ -1,0 +1,11 @@
+.static {
+	// Tag chips are not interactive, but the @signozhq Badge darkens outline
+	// variants on hover — which reads as clickable. Pin the hover background to the
+	// resting background so hovering a plain tag produces no change.
+	--badge-outline-hover-background-color: var(
+		--badge-outline-background-color,
+		color-mix(in oklab, var(--badge-background) 10%, transparent)
+	);
+
+	cursor: default;
+}

--- a/frontend/src/components/TagBadge/TagBadge.tsx
+++ b/frontend/src/components/TagBadge/TagBadge.tsx
@@ -1,5 +1,8 @@
 import { type MouseEvent, type ReactNode } from 'react';
 import { Badge } from '@signozhq/ui/badge';
+import cx from 'classnames';
+
+import styles from './TagBadge.module.scss';
 
 interface TagBadgeProps {
 	children: ReactNode;
@@ -22,7 +25,7 @@ function TagBadge({
 		<Badge
 			color="sienna"
 			variant="outline"
-			className={className}
+			className={cx(styles.static, className)}
 			closable={closable}
 			onClose={onClose}
 		>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
@@ -101,8 +101,10 @@ function DashboardActions({
 
 	const handleCreateSection = useCallback(
 		async (title: string): Promise<void> => {
-			await addSection(title);
-			setIsNewSectionOpen(false);
+			const ok = await addSection(title);
+			if (ok) {
+				setIsNewSectionOpen(false);
+			}
 		},
 		[addSection],
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/JsonEditorDrawer.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/JsonEditorDrawer.tsx
@@ -78,6 +78,12 @@ function JsonEditorDrawer({
 	const onKeyDown = useCallback(
 		(event: KeyboardEvent<HTMLDivElement>): void => {
 			event.stopPropagation();
+
+			if (event.key === 'Escape') {
+				onClose();
+				return;
+			}
+
 			if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
 				event.preventDefault();
 				if (!readOnly) {
@@ -85,7 +91,7 @@ function JsonEditorDrawer({
 				}
 			}
 		},
-		[apply, readOnly],
+		[apply, readOnly, onClose],
 	);
 
 	const applyDisabled = readOnly || !isDirty || !validity.valid || isSaving;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/__tests__/useJsonEditor.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/__tests__/useJsonEditor.test.tsx
@@ -44,8 +44,12 @@ const dashboard = {
 	},
 } as unknown as DashboardtypesGettableDashboardV2DTO;
 
-// The editor only exposes `tags` and `spec`; every other key is redacted.
-const redacted = { tags: dashboard.tags, spec: dashboard.spec };
+// The editor exposes `spec`, `tags`, `image` (in that order); every other key is redacted.
+const redacted = {
+	spec: dashboard.spec,
+	tags: dashboard.tags,
+	image: dashboard.image,
+};
 const serialized = JSON.stringify(redacted, null, 2);
 
 describe('useJsonEditor', () => {
@@ -65,17 +69,18 @@ describe('useJsonEditor', () => {
 		expect(result.current.validity.lineCount).toBe(serialized.split('\n').length);
 	});
 
-	it('redacts server-owned keys from the editable draft', () => {
+	it('exposes spec/tags/image (in order) and redacts server-owned keys', () => {
 		const { result } = renderHook(() =>
 			useJsonEditor({ dashboard, isOpen: true, onApplied: jest.fn() }),
 		);
 
 		const parsed = JSON.parse(result.current.draft);
-		expect(Object.keys(parsed).sort()).toStrictEqual(['spec', 'tags']);
+		// Key order is intentional: spec, then tags, then image.
+		expect(Object.keys(parsed)).toStrictEqual(['spec', 'tags', 'image']);
+		expect(parsed.image).toBe('icon.png');
 		expect(parsed.id).toBeUndefined();
 		expect(parsed.name).toBeUndefined();
 		expect(parsed.schemaVersion).toBeUndefined();
-		expect(parsed.image).toBeUndefined();
 	});
 
 	it('flags invalid JSON with a line number and marks the draft dirty', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/useJsonEditor.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/useJsonEditor.ts
@@ -12,6 +12,7 @@ import { toAPIError } from 'utils/errorUtils';
 
 import { dashboardToUpdatable } from './dashboardToUpdatable';
 import { findPanelLayoutIssues } from './danglingPanels';
+import { compactSpecLayouts } from '../../layoutCompaction';
 import { useDashboardStore } from '../../store/useDashboardStore';
 
 export interface JsonValidity {
@@ -46,15 +47,16 @@ interface Result {
 }
 
 /**
- * The editable, user-facing view: only `tags` and `spec`. Everything else
- * (id, orgId, name, timestamps, locked, schemaVersion, image, …) is redacted so it
- * can't be seen, copied, exported or edited; those keys are preserved on save (see `apply`).
+ * The editable, user-facing view: `spec`, `tags` and `image`, in that key order.
+ * Everything else (id, orgId, name, timestamps, locked, schemaVersion, …) is redacted
+ * so it can't be seen, copied, exported or edited; those keys are preserved on save.
  */
 const redact = (
 	dashboard: DashboardtypesGettableDashboardV2DTO,
-): Pick<DashboardtypesGettableDashboardV2DTO, 'tags' | 'spec'> => ({
-	tags: dashboard.tags,
+): Pick<DashboardtypesGettableDashboardV2DTO, 'spec' | 'tags' | 'image'> => ({
 	spec: dashboard.spec,
+	tags: dashboard.tags,
+	image: dashboard.image,
 });
 
 const serialize = (dashboard: DashboardtypesGettableDashboardV2DTO): string =>
@@ -167,7 +169,18 @@ export function useJsonEditor({
 			setIsSaving(true);
 			// The draft only carries name/tags/spec; overlay it on the current dashboard
 			// so the redacted fields (schemaVersion, image, …) are preserved on save.
-			const edited = JSON.parse(draft) as Record<string, unknown>;
+			const edited = JSON.parse(draft) as Pick<
+				DashboardtypesGettableDashboardV2DTO,
+				'spec' | 'tags' | 'image'
+			>;
+			// Snap hand-edited panel geometry to a non-overlapping layout so a JSON edit
+			// can't be rejected by the backend's no-overlap check (matches drag/resize).
+			if (edited.spec?.layouts) {
+				edited.spec = {
+					...edited.spec,
+					layouts: compactSpecLayouts(edited.spec.layouts),
+				};
+			}
 			await updateDashboardV2(
 				{ id: dashboardId },
 				dashboardToUpdatable({ ...dashboard, ...edited }),

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/DashboardImagePicker/DashboardImagePicker.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/DashboardImagePicker/DashboardImagePicker.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from 'react';
 import {
 	Select,
 	SelectContent,
@@ -26,11 +27,28 @@ function DashboardImagePicker({
 	onChange,
 	triggerClassName,
 }: Props): JSX.Element {
+	// A custom image (pasted URL / base64 data-URI, not in the preset set) is kept as
+	// a selectable option for the picker's lifetime — without a matching option the
+	// trigger renders the raw value string and the image can't be re-selected.
+	const [customImages, setCustomImages] = useState<string[]>(() =>
+		image && !Base64Icons.includes(image) ? [image] : [],
+	);
+	useEffect(() => {
+		if (image && !Base64Icons.includes(image)) {
+			setCustomImages((prev) => (prev.includes(image) ? prev : [...prev, image]));
+		}
+	}, [image]);
+
+	const options = useMemo(
+		() => [...customImages, ...Base64Icons],
+		[customImages],
+	);
+
 	return (
 		<Select value={image} onChange={(value): void => onChange(value as string)}>
 			<SelectTrigger className={cx(styles.trigger, triggerClassName)} />
 			<SelectContent className={styles.options} withPortal={false}>
-				{Base64Icons.map((icon) => (
+				{options.map((icon) => (
 					<SelectItem key={icon} value={icon} className={styles.item}>
 						<img src={icon} alt="dashboard-icon" className={styles.image} />
 					</SelectItem>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/QueryVariableFields.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/QueryVariableFields.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@signozhq/ui/button';
 import { Typography } from '@signozhq/ui/typography';
 import logEvent from 'api/common/logEvent';
@@ -27,6 +27,7 @@ function QueryVariableFields({
 	onError,
 }: QueryVariableFieldsProps): JSX.Element {
 	const [isRunning, setIsRunning] = useState(false);
+	const hasAutoRun = useRef(false);
 
 	const runTest = async (): Promise<void> => {
 		setIsRunning(true);
@@ -58,6 +59,16 @@ function QueryVariableFields({
 			});
 		}
 	};
+
+	// Fetch options on load so the Default Value dropdown is populated without a
+	// manual Test Run — once, and only when there's a query to run.
+	useEffect(() => {
+		if (!hasAutoRun.current && queryValue) {
+			hasAutoRun.current = true;
+			void runTest();
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [queryValue]);
 
 	return (
 		<div className={styles.queryContainer}>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableForm.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableForm.module.scss
@@ -166,7 +166,7 @@
 	margin-left: 4px;
 	vertical-align: middle;
 
-	@media (max-width: 1024px) {
+	@media (max-width: 1280px) {
 		display: none;
 	}
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableForm.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableForm.module.scss
@@ -160,6 +160,26 @@
 	vertical-align: middle;
 }
 
+/* The full "Not Recommended" pill — hidden once the tab row gets tight so it
+   never forces horizontal scroll; the amber info icon takes over below. */
+.notRecommendedBadge {
+	margin-left: 4px;
+	vertical-align: middle;
+
+	@media (max-width: 1024px) {
+		display: none;
+	}
+}
+
+/* Amber info icon: always present, but the sole "not recommended" cue on small
+   screens (its tooltip carries the message + learn-more link). */
+.notRecommendedInfo {
+	display: inline-flex;
+	align-items: center;
+	margin-left: 4px;
+	vertical-align: middle;
+}
+
 /* Query */
 .queryContainer {
 	display: flex;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableForm.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableForm.tsx
@@ -130,6 +130,9 @@ function VariableForm({
 									value={selectedPanelIds}
 									onChange={(value): void => setSelectedPanelIds(value as string[])}
 									data-testid="variable-apply-panels"
+									// Resolve the closed-state tags to panel names (else they show the id).
+									showLabels
+									placement="topRight"
 								/>
 							</div>
 						</div>
@@ -215,7 +218,7 @@ function VariableForm({
 						variant="solid"
 						color="primary"
 						prefix={<Check size={14} />}
-						disabled={!!nameError || !!attributeError}
+						disabled={!!nameError || !!attributeError || isSaving}
 						loading={isSaving}
 						onClick={handleSave}
 						testId="variable-save"

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableTypeTabs.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/VariableTypeTabs.tsx
@@ -1,3 +1,4 @@
+import { Color } from '@signozhq/design-tokens';
 import {
 	ClipboardType,
 	DatabaseZap,
@@ -67,20 +68,23 @@ function VariableTypeTabs(): JSX.Element {
 					>
 						<DatabaseZap size={14} />
 						Query
-						<Badge color="amber" className={styles.betaTag}>
+						{/* Wide screens: the full "Not Recommended" pill. */}
+						<Badge color="amber" className={styles.notRecommendedBadge}>
 							Not Recommended
 						</Badge>
+						{/* Small screens: an amber info icon stands in for the pill (keeps the
+						    tab row from overflowing), its tooltip carries the same message + link. */}
 						<span
-							className={styles.betaTag}
+							className={styles.notRecommendedInfo}
 							onClick={(e): void => e.stopPropagation()}
 							role="presentation"
 						>
 							<TextToolTip
-								text="Learn why we don't recommend"
+								text="Query variables can be slow and brittle, so they aren't recommended. Learn why"
 								url="https://signoz.io/docs/userguide/manage-variables/#why-avoid-clickhouse-query-variables"
 								urlText="here"
 								useFilledIcon={false}
-								outlinedIcon={<Info size={14} />}
+								outlinedIcon={<Info size={14} color={Color.BG_AMBER_600} />}
 							/>
 						</span>
 					</TabsTrigger>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/hooks/useVariableListActions.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/hooks/useVariableListActions.ts
@@ -129,22 +129,30 @@ export function useVariableListActions({
 				}
 			}
 
-			setIsEditing(null);
-			setVariables(next);
 			void (async (): Promise<void> => {
 				const saved = await save(next);
-				if (!saved || formModel.type !== 'DYNAMIC') {
+				if (!saved) {
 					return;
 				}
+
+				setIsEditing(null);
+				setVariables(next);
+
+				if (formModel.type !== 'DYNAMIC') {
+					return;
+				}
+
 				const ops = buildSyncVariableToPanelsPatch(
 					dashboard.spec.panels,
 					formModel.dynamicAttribute,
 					formModel.name,
 					selectedPanelIds,
 				);
+
 				if (ops.length === 0) {
 					return;
 				}
+
 				try {
 					await patchAsync(ops);
 				} catch {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionTitleModal.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionTitleModal.module.scss
@@ -1,0 +1,5 @@
+.footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionTitleModal.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/SectionTitleModal.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
-import { Modal } from 'antd';
+import { Button } from '@signozhq/ui/button';
+import { DialogWrapper } from '@signozhq/ui/dialog';
 import { Input } from '@signozhq/ui/input';
 
 import { DASHBOARD_NAME_MAX_LENGTH } from '../../constants';
+import styles from './SectionTitleModal.module.scss';
 
 interface SectionTitleModalProps {
 	open: boolean;
@@ -17,7 +19,7 @@ interface SectionTitleModalProps {
 	onSubmit: (title: string) => void;
 }
 
-/** Title-entry modal shared by section create and rename. */
+/** Title-entry modal shared by section create and rename (mirrors RenameDashboardModal). */
 function SectionTitleModal({
 	open,
 	heading,
@@ -37,22 +39,51 @@ function SectionTitleModal({
 		}
 	}, [open, initialValue]);
 
+	// `!isSaving` also guards a second submit (e.g. a double Enter) while a request
+	// is in flight — otherwise two sections would be created.
+	const canSave = value.trim().length > 0 && !isSaving;
+
 	const submit = (): void => {
-		const trimmed = value.trim();
-		if (trimmed) {
-			onSubmit(trimmed);
+		if (!canSave) {
+			return;
 		}
+		onSubmit(value.trim());
 	};
 
 	return (
-		<Modal
-			open={open}
+		<DialogWrapper
 			title={heading}
-			onCancel={onClose}
-			onOk={submit}
-			okText={okText}
-			okButtonProps={{ disabled: isSaving || !value.trim() }}
-			destroyOnClose
+			open={open}
+			width="narrow"
+			onOpenChange={(next): void => {
+				if (!next) {
+					onClose();
+				}
+			}}
+			footer={
+				<div className={styles.footer}>
+					<Button
+						variant="ghost"
+						color="secondary"
+						size="md"
+						onClick={onClose}
+						testId="section-title-cancel"
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="solid"
+						color="primary"
+						size="md"
+						disabled={!canSave}
+						loading={isSaving}
+						onClick={submit}
+						testId="section-title-submit"
+					>
+						{okText}
+					</Button>
+				</div>
+			}
 		>
 			<Input
 				testId="section-title-input"
@@ -62,13 +93,13 @@ function SectionTitleModal({
 				placeholder={placeholder}
 				onChange={(e): void => setValue(e.target.value)}
 				onKeyDown={(e): void => {
-					if (e.key === 'Enter') {
+					if (e.key === 'Enter' && canSave) {
 						e.preventDefault();
 						submit();
 					}
 				}}
 			/>
-		</Modal>
+		</DialogWrapper>
 	);
 }
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useAddSection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useAddSection.ts
@@ -21,7 +21,7 @@ interface Params {
 }
 
 interface Result {
-	addSection: (title: string) => Promise<void>;
+	addSection: (title: string) => Promise<boolean>;
 	isSaving: boolean;
 }
 
@@ -38,10 +38,10 @@ export function useAddSection({ layouts }: Params): Result {
 	const setScrollTargetId = useScrollIntoViewStore((s) => s.setScrollTargetId);
 
 	const addSection = useCallback(
-		async (title: string): Promise<void> => {
+		async (title: string): Promise<boolean> => {
 			const trimmed = title.trim();
 			if (!dashboardId || !trimmed) {
-				return;
+				return false;
 			}
 			const isFirstSection = !layouts || layouts.length === 0;
 			const op = isFirstSection
@@ -58,8 +58,10 @@ export function useAddSection({ layouts }: Params): Result {
 				// key it the way `getSectionStableId` does so it reveals itself on render.
 				const newIndex = isFirstSection ? 0 : layouts.length;
 				setScrollTargetId(getSectionStableId([], newIndex));
+				return true;
 			} catch (error) {
 				showErrorModal(error as APIError);
+				return false;
 			} finally {
 				setIsSaving(false);
 			}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/usePersistLayout.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/usePersistLayout.ts
@@ -7,6 +7,7 @@ import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
 import { useOptimisticPatch } from '../../../hooks/useOptimisticPatch';
+import { compactGridItems } from '../../../layoutCompaction';
 import { replaceSectionItemsOp } from '../../../patchOps';
 import { useDashboardStore } from '../../../store/useDashboardStore';
 import type { GridItem } from '../../../utils';
@@ -76,7 +77,9 @@ export function usePersistLayout({ layoutIndex, items }: Params): Result {
 			if (!dashboardId) {
 				return;
 			}
-			const nextItems = mergeRglLayout(rglLayout, items);
+			// Compact to the snapped, non-overlapping layout RGL shows on-screen, so
+			// the persisted geometry can never trip the backend's no-overlap check.
+			const nextItems = compactGridItems(mergeRglLayout(rglLayout, items));
 			if (!hasGeometryChanged(nextItems, items)) {
 				return;
 			}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/VariablesBar.module.scss
@@ -86,6 +86,15 @@
 	:global(.ant-select-selection-overflow) {
 		flex-wrap: nowrap;
 	}
+
+	// The shared NewSelect selector scrolls (max-height: 200px; overflow: auto),
+	// which surfaces horizontal + vertical scrollbars inside the fixed-width
+	// variable pill. Clip instead — the value is a single line (maxTagCount + "+N"),
+	// so there is nothing to scroll to.
+	:global(.ant-select-selector) {
+		max-height: none !important;
+		overflow: hidden !important;
+	}
 }
 
 .overflowTooltip {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/resolveVariableSelection.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/resolveVariableSelection.test.ts
@@ -107,6 +107,18 @@ describe('reconcileWithOptions', () => {
 		).toStrictEqual({ value: ['a', 'b'], allSelected: false });
 	});
 
+	it('preserves a user-entered single value not in the options (freeform)', () => {
+		// A typed value that isn't among the fetched options must survive a refetch
+		// (e.g. a time-range change) rather than being reset to the default.
+		expect(
+			reconcileWithOptions(
+				model({ type: 'QUERY' }),
+				{ value: 'typed-value', allSelected: false },
+				['a', 'b'],
+			),
+		).toBeNull();
+	});
+
 	it('falls back to the configured default (else first) when invalid', () => {
 		expect(
 			reconcileWithOptions(

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/AddVariable/AddVariable.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/AddVariable/AddVariable.module.scss
@@ -1,4 +1,12 @@
-.addVariable {
+.addVariableNameWithIcon {
+	flex: none;
+	border-style: dashed !important;
+	border-color: var(--l3-border) !important;
+	margin-top: 12px;
+	margin-bottom: 2px;
+}
+
+.addVariableIcon {
 	flex: none;
 	border-style: dashed !important;
 	border-color: var(--l3-border) !important;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/AddVariable/AddVariableFull.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/AddVariable/AddVariableFull.tsx
@@ -16,7 +16,7 @@ function AddVariableFull(): JSX.Element {
 			variant="outlined"
 			color="secondary"
 			size="md"
-			className={styles.addVariable}
+			className={styles.addVariableNameWithIcon}
 			prefix={<Plus size={14} />}
 			testId="dashboard-variables-add"
 			onClick={(): void =>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/AddVariable/AddVariableIcon.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/AddVariable/AddVariableIcon.tsx
@@ -19,7 +19,7 @@ function AddVariableIcon(): JSX.Element {
 				variant="outlined"
 				color="secondary"
 				size="icon"
-				className={styles.addVariable}
+				className={styles.addVariableIcon}
 				aria-label="Add variable"
 				testId="dashboard-variables-add"
 				onClick={(): void =>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/utils/resolveVariableSelection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/utils/resolveVariableSelection.ts
@@ -53,19 +53,6 @@ function isAllDefault(
 	);
 }
 
-function isValidSingle(
-	value: SelectedVariableValue,
-	options: string[],
-): boolean {
-	return (
-		!Array.isArray(value) &&
-		value !== '' &&
-		value !== null &&
-		value !== undefined &&
-		options.includes(String(value))
-	);
-}
-
 /** The configured default (or first option) as a fresh selection. */
 function fillDefault(
 	model: VariableFormModel,
@@ -167,8 +154,17 @@ export function reconcileWithOptions(
 			: fillDefault(model, options);
 	}
 
-	if (!model.multiSelect && isValidSingle(current.value, options)) {
-		return null;
+	if (!model.multiSelect) {
+		// Preserve any non-empty single value across a refetch — including a user-typed
+		// value that isn't in the fetched options (freeform). Only fall back to the
+		// default/first option when there is no value yet, so e.g. a time-range change
+		// (which refetches options) never wipes a value the user didn't change.
+		const hasValue =
+			!Array.isArray(current.value) &&
+			current.value !== '' &&
+			current.value !== null &&
+			current.value !== undefined;
+		return hasValue ? null : fillDefault(model, options);
 	}
 	return fillDefault(model, options);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/__tests__/layoutCompaction.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/__tests__/layoutCompaction.test.ts
@@ -1,0 +1,73 @@
+import type { DashboardtypesLayoutDTO } from 'api/generated/services/sigNoz.schemas';
+
+import { compactGridItems, compactSpecLayouts } from '../layoutCompaction';
+import type { GridItem } from '../utils';
+
+const item = (
+	id: string,
+	x: number,
+	y: number,
+	width = 6,
+	height = 2,
+): GridItem => ({ id, x, y, width, height, panel: undefined });
+
+describe('compactGridItems', () => {
+	it('pulls a floating item up to the top', () => {
+		const [a] = compactGridItems([item('a', 0, 5)]);
+		expect(a.y).toBe(0);
+	});
+
+	it('resolves an overlap by pushing the colliding item down', () => {
+		// Order is preserved, so [0] is 'a' and [1] is 'b'.
+		const result = compactGridItems([item('a', 0, 0), item('b', 0, 1)]);
+		// a occupies rows 0-1 (height 2), so b must sit at row 2 — no overlap.
+		expect(result[0].y).toBe(0);
+		expect(result[1].y).toBe(2);
+	});
+
+	it('preserves item order and the panel reference', () => {
+		const panel = { kind: 'panel' } as unknown as GridItem['panel'];
+		const result = compactGridItems([
+			{ ...item('a', 0, 0), panel },
+			item('b', 6, 0),
+		]);
+		expect(result.map((i) => i.id)).toStrictEqual(['a', 'b']);
+		expect(result[0].panel).toBe(panel);
+	});
+});
+
+describe('compactSpecLayouts', () => {
+	const grid = (
+		items: { x: number; y: number; width: number; height: number; ref: string }[],
+	): DashboardtypesLayoutDTO =>
+		({
+			kind: 'Grid',
+			spec: {
+				items: items.map((i) => ({
+					x: i.x,
+					y: i.y,
+					width: i.width,
+					height: i.height,
+					content: { $ref: i.ref },
+				})),
+			},
+		}) as unknown as DashboardtypesLayoutDTO;
+
+	it('compacts overlapping items and keeps their panel refs', () => {
+		const [layout] = compactSpecLayouts([
+			grid([
+				{ x: 0, y: 0, width: 6, height: 2, ref: '#/spec/panels/a' },
+				{ x: 0, y: 1, width: 6, height: 2, ref: '#/spec/panels/b' },
+			]),
+		]);
+		const items = layout.spec?.items ?? [];
+		expect(items[0]?.y).toBe(0);
+		expect(items[1]?.y).toBe(2);
+		expect(items[1]?.content?.$ref).toBe('#/spec/panels/b');
+	});
+
+	it('passes a non-Grid layout through untouched', () => {
+		const other = { kind: 'Other' } as unknown as DashboardtypesLayoutDTO;
+		expect(compactSpecLayouts([other])[0]).toBe(other);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/layoutCompaction.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/layoutCompaction.ts
@@ -1,0 +1,84 @@
+import * as ReactGridLayout from 'react-grid-layout';
+import type { Layout } from 'react-grid-layout';
+import type { DashboardtypesLayoutDTO } from 'api/generated/services/sigNoz.schemas';
+
+import { GRID_COLS } from './patchOps';
+import type { GridItem } from './utils';
+
+// `utils.compact` is exported by react-grid-layout at runtime — it is the exact
+// vertical compaction the grid applies on-screen while dragging — but it is absent
+// from the package's TypeScript types, so it is reached through a typed cast.
+const { compact } = (
+	ReactGridLayout as unknown as {
+		utils: {
+			compact: (
+				layout: Layout[],
+				compactType: 'vertical' | 'horizontal',
+				cols: number,
+			) => Layout[];
+		};
+	}
+).utils;
+
+/** Vertically compact geometry so no two items overlap (mirrors on-screen RGL). */
+function compactVertically(layout: Layout[]): Layout[] {
+	return compact(layout, 'vertical', GRID_COLS);
+}
+
+/**
+ * Snap a section's grid items to a non-overlapping, vertically-compacted layout —
+ * the same normalization RGL applies mid-drag — so a persisted layout can never be
+ * rejected by the backend's no-overlap validation. Panel refs and every other item
+ * field are preserved; item order is unchanged (only geometry updates).
+ */
+export function compactGridItems(items: GridItem[]): GridItem[] {
+	const compacted = compactVertically(
+		items.map((item) => ({
+			i: item.id,
+			x: item.x,
+			y: item.y,
+			w: item.width,
+			h: item.height,
+		})),
+	);
+	const byId = new Map(compacted.map((entry) => [entry.i, entry]));
+	return items.map((item) => {
+		const entry = byId.get(item.id);
+		return entry
+			? { ...item, x: entry.x, y: entry.y, width: entry.w, height: entry.h }
+			: item;
+	});
+}
+
+/**
+ * Compact every Grid section in a `spec.layouts` array — used on JSON-editor save,
+ * where hand-edited items can overlap. Items are keyed by index (spec items carry
+ * no id of their own); non-Grid or empty layouts pass through untouched.
+ */
+export function compactSpecLayouts(
+	layouts: DashboardtypesLayoutDTO[],
+): DashboardtypesLayoutDTO[] {
+	return layouts.map((layout) => {
+		const items = layout?.kind === 'Grid' ? (layout.spec?.items ?? []) : [];
+		if (items.length === 0) {
+			return layout;
+		}
+		const compacted = compactVertically(
+			items.map((item, index) => ({
+				i: String(index),
+				x: item.x ?? 0,
+				y: item.y ?? 0,
+				w: item.width ?? 6,
+				h: item.height ?? 6,
+			})),
+		);
+		const byIndex = new Map(compacted.map((entry) => [entry.i, entry]));
+		const nextItems = items.map((item, index) => {
+			const entry = byIndex.get(String(index));
+			return entry
+				? { ...item, x: entry.x, y: entry.y, width: entry.w, height: entry.h }
+				: item;
+		});
+		return { ...layout, spec: { ...layout.spec, items: nextItems } };
+	});
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/patchOps.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/patchOps.ts
@@ -167,7 +167,7 @@ interface CreatePanelOpsArgs {
 const NEW_PANEL_SIZE = { width: 6, height: 6 };
 
 /** Columns in the section grid — mirrors `cols` on SectionGrid's GridLayout. */
-const GRID_COLS = 12;
+export const GRID_COLS = 12;
 
 /** Minimal placement fields shared by grid-item DTOs and flattened `GridItem`s. */
 type PlacedItem = Pick<DashboardGridItemDTO, 'x' | 'y' | 'width' | 'height'>;

--- a/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.tsx
@@ -18,10 +18,12 @@ import { useCopyToClipboard } from 'react-use';
 import logEvent from 'api/common/logEvent';
 import {
 	cloneDashboardV2,
+	getGetDashboardV2QueryKey,
 	invalidateListDashboardsForUserV2,
 	lockDashboardV2,
 	unlockDashboardV2,
 } from 'api/generated/services/dashboard';
+import type { GetDashboardV2200 } from 'api/generated/services/sigNoz.schemas';
 import ROUTES from 'constants/routes';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
@@ -109,6 +111,17 @@ function ActionsPopover({
 				action: isLocked ? 'unlock' : 'lock',
 				dashboardId,
 			});
+			// Patch the detail-page cache too: it uses staleTime:Infinity +
+			// refetchOnMount:false, so without this, returning to the dashboard would
+			// still show the stale (pre-toggle) lock state.
+			const key = getGetDashboardV2QueryKey({ id: dashboardId });
+			const cached = queryClient.getQueryData<GetDashboardV2200>(key);
+			if (cached) {
+				queryClient.setQueryData<GetDashboardV2200>(key, {
+					...cached,
+					data: { ...cached.data, locked: !isLocked },
+				});
+			}
 			await invalidateListDashboardsForUserV2(queryClient);
 		},
 		onError: (error: APIError) => {

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.module.scss
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.module.scss
@@ -59,14 +59,6 @@
 	flex: none;
 }
 
-.tagsWithActions {
-	display: flex;
-	align-items: center;
-	flex: 0 1 auto;
-	min-width: 0;
-	justify-content: flex-end;
-}
-
 .lockIcon {
 	display: inline-flex;
 	align-items: center;
@@ -138,11 +130,10 @@
 	display: inline-flex;
 }
 
-.tags {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 8px;
-	justify-content: flex-end;
+// Cap the name tooltip so a long name wraps instead of spanning the page.
+.nameTooltip {
+	max-width: 480px;
+	overflow-wrap: break-word;
 }
 
 .details {

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import TagBadge from 'components/TagBadge/TagBadge';
 import { Badge } from '@signozhq/ui/badge';
 import { Button } from '@signozhq/ui/button';
 import { TooltipSimple } from '@signozhq/ui/tooltip';
@@ -21,6 +20,7 @@ import { useDashboardViewsStore } from '../../store/useDashboardViewsStore';
 import type { DashboardListItem } from '../../utils/helpers';
 import { lastUpdatedLabel, tagsToStrings } from '../../utils/helpers';
 import ActionsPopover from '../ActionsPopover/ActionsPopover';
+import DashboardRowTags from './DashboardRowTags/DashboardRowTags';
 import LegacyDashboardDialog from '../LegacyDashboardDialog/LegacyDashboardDialog';
 
 import styles from './DashboardRow.module.scss';
@@ -129,7 +129,12 @@ function DashboardRow({
 				<div className={styles.titleWithAction}>
 					<div className={styles.titleBlock}>
 						{name.length > 50 ? (
-							<TooltipSimple title={name} side="bottom" disableHoverableContent>
+							<TooltipSimple
+								title={name}
+								side="bottom"
+								disableHoverableContent
+								tooltipContentProps={{ className: styles.nameTooltip }}
+							>
 								{titleLink}
 							</TooltipSimple>
 						) : (
@@ -147,18 +152,7 @@ function DashboardRow({
 						)}
 					</div>
 
-					<div className={styles.tagsWithActions}>
-						{tags.length > 0 && (
-							<div className={styles.tags}>
-								{tags.slice(0, 3).map((tag) => (
-									<TagBadge key={tag}>{tag}</TagBadge>
-								))}
-								{tags.length > 3 && (
-									<TagBadge key={tags[3]}>+{tags.length - 3}</TagBadge>
-								)}
-							</div>
-						)}
-					</div>
+					<DashboardRowTags tags={tags} />
 
 					{isLocked && (
 						<TooltipSimple

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRowTags/DashboardRowTags.module.scss
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRowTags/DashboardRowTags.module.scss
@@ -1,0 +1,23 @@
+.tags {
+	display: flex;
+	flex: 0 1 auto;
+	min-width: 0;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 8px;
+}
+
+.extraTags {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	max-width: 320px;
+}
+
+/* Recolor via the tooltip's own CSS variables so the arrow (whose fill reads
+   --tooltip-background) turns black along with the content. */
+.extraTagsTooltip {
+	--tooltip-background: var(--bg-ink-500, #0b0c0e);
+	--tooltip-border-color: var(--bg-ink-500, #0b0c0e);
+}

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRowTags/DashboardRowTags.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRowTags/DashboardRowTags.tsx
@@ -1,0 +1,51 @@
+import { TooltipSimple } from '@signozhq/ui/tooltip';
+import TagBadge from 'components/TagBadge/TagBadge';
+
+import styles from './DashboardRowTags.module.scss';
+
+const MAX_VISIBLE_TAGS = 3;
+
+interface DashboardRowTagsProps {
+	tags: string[];
+}
+
+/**
+ * The dashboards-list row tag chips: the first few inline, the rest revealed on
+ * hover of a "+N" chip.
+ */
+function DashboardRowTags({ tags }: DashboardRowTagsProps): JSX.Element | null {
+	if (tags.length === 0) {
+		return null;
+	}
+
+	const extra = tags.slice(MAX_VISIBLE_TAGS);
+
+	return (
+		<div className={styles.tags}>
+			{tags.slice(0, MAX_VISIBLE_TAGS).map((tag) => (
+				<TagBadge key={tag}>{tag}</TagBadge>
+			))}
+			{extra.length > 0 && (
+				<TooltipSimple
+					side="bottom"
+					arrow
+					tooltipContentProps={{ className: styles.extraTagsTooltip }}
+					title={
+						<div className={styles.extraTags}>
+							{extra.map((tag) => (
+								<TagBadge key={tag}>{tag}</TagBadge>
+							))}
+						</div>
+					}
+				>
+					{/* Stop the click so hovering/clicking the chip doesn't navigate the row. */}
+					<span role="presentation" onClick={(e): void => e.stopPropagation()}>
+						<TagBadge>+{extra.length}</TagBadge>
+					</span>
+				</TooltipSimple>
+			)}
+		</div>
+	);
+}
+
+export default DashboardRowTags;


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

A batch of V2 dashboard fixes across variables, panel layout, and the dashboards list, from the latest bug-bash. Each concern is its own commit so they can be reviewed (or reverted) independently.

Variables & form
- **Default reset** now fires only on a real option-set change (Test Run for query, attribute/signal change for dynamic, options edit for custom) — never on sort-only changes or on edit-open.
- **Multiselect** buffers edits while open and commits once on close (no per-toggle cascade); closing with nothing selected falls back to the default, so a variable is never left empty (which stranded dependents on a spinner). Tags now truncate with a bare "+N" overflow and the control is 180px wide.
- **Single-select** keeps a user-typed value across a refetch (e.g. a time-range change no longer wipes it).
- **Save** waits for the backend before closing the form; on failure the form stays open (button disabled) and the exact backend error is surfaced, instead of silently "saving".
- Apply-to-panels tags show panel **names** (not ids) when closed, and the dropdown anchors to the body so it no longer shifts when opened near the bottom of the form.

Panel layout
- Panel geometry is **compacted to a non-overlapping layout** before persisting — on drag/resize and on JSON-editor save — so the backend's no-overlap validation can't reject a valid-looking edit.
- Section creation guards against a double submit (double Enter no longer creates two sections).

Dashboards list
- Locking a dashboard from the list page now updates the detail-page cache, so returning to it reflects the locked state.
- The "+N" tags indicator opens a popover of the remaining tags instead of navigating to the dashboard; the name tooltip is width-capped (480px); non-interactive tag badges no longer show a clickable hover state.

#### Issues closed by this PR
Closes https://github.com/SigNoz/pulse-pod/issues/117

---

### ✅ Change Type

- [x] 🐛 Bug fix
- [x] 🧪 Test-only (unit tests added for the pure logic)

---

### 🐛 Bug Context

#### Root Cause
Several independent issues: default-reset keyed on the wrong signal; the multiselect cascaded per toggle and could commit an empty selection; single-select values were dropped by post-fetch reconciliation; the variable form closed before the save resolved; `onDragStop`/JSON-save persisted a not-yet-compacted (overlapping) layout; the list-page lock never invalidated the detail-query cache; and the tags "+N" fell through to the row's navigation handler.

#### Fix Strategy
Each is addressed at its source and committed separately — see the per-commit messages and the Summary above.

---

### 🧪 Testing Strategy

- Tests added/updated: `resolveVariableSelection` (typed-value persistence), `layoutCompaction` (compaction + panel-ref preservation), `useVariableForm` (default-reset semantics), plus a hoist-order regression check.
- Manual verification: pending in-app validation of the interactive flows (multiselect commit-on-close, drag/resize, share-agnostic surfaces).
- Edge cases covered: ALL selection, empty-close → default, re-run with identical values, non-Grid layouts.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: V2 dashboard variables bar/form, panel grid persistence, and the dashboards list row. `TagBadge` is shared (hover-only change).
- Potential regressions: multiselect selection timing; layout compaction on drag/JSON save.
- Rollback plan: revert the specific concern's commit.
