### PR TITLE
fix(overlayscrollbars): leaking memory due to img.load event listener

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -89,7 +89,7 @@
     "lodash-es": "^4.17.21",
     "motion": "12.4.13",
     "nuqs": "2.8.8",
-    "overlayscrollbars": "^2.8.1",
+    "overlayscrollbars": "^2.16.0",
     "overlayscrollbars-react": "^0.5.6",
     "papaparse": "5.4.1",
     "posthog-js": "1.298.0",
@@ -221,5 +221,18 @@
     "*.(scss|css)": [
       "stylelint"
     ]
+  },
+  "overrides": {
+    "@babel/core@<=7.29.0": ">=7.29.6 <8",
+    "@istanbuljs/load-nyc-config>js-yaml": ">=4.2.0 <5",
+    "cookie@<0.7.0": ">=0.7.1 <1",
+    "dompurify@<=3.4.10": ">=3.4.11 <4",
+    "esbuild@>=0.27.3 <0.28.1": ">=0.28.1 <0.29.0",
+    "js-cookie@<=3.0.5": ">=3.0.7 <4",
+    "js-yaml@>=4.0.0 <=4.1.1": ">=4.2.0 <5",
+    "prismjs@<1.30.0": ">=1.30.0 <2",
+    "react-router@>=6.7.0 <6.30.4": ">=6.30.4 <7",
+    "tmp@<0.2.6": ">=0.2.6 <0.3.0",
+    "yaml@>=1.0.0 <1.10.3": ">=1.10.3 <2"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -187,11 +187,11 @@ importers:
         specifier: 2.8.8
         version: 2.8.8(react-router-dom@5.3.4(react@18.2.0))(react-router@6.30.4(react@18.2.0))(react@18.2.0)
       overlayscrollbars:
-        specifier: ^2.8.1
-        version: 2.9.2
+        specifier: ^2.16.0
+        version: 2.16.0
       overlayscrollbars-react:
         specifier: ^0.5.6
-        version: 0.5.6(overlayscrollbars@2.9.2)(react@18.2.0)
+        version: 0.5.6(overlayscrollbars@2.16.0)(react@18.2.0)
       papaparse:
         specifier: 5.4.1
         version: 5.4.1
@@ -6941,8 +6941,8 @@ packages:
       overlayscrollbars: ^2.0.0
       react: '>=16.8.0'
 
-  overlayscrollbars@2.9.2:
-    resolution: {integrity: sha512-iDT84r39i7oWP72diZN2mbJUsn/taCq568aQaIrc84S87PunBT7qtsVltAF2esk7ORTRjQDnfjVYoqqTzgs8QA==}
+  overlayscrollbars@2.16.0:
+    resolution: {integrity: sha512-N03oje/q7j93D0aLZtoCdsDSYLmhheSsv8H7oSLE7HhdV9P/bmCURtLV/KbPye7P/bpfyt/obSfDpGUYoJ0OWg==}
 
   oxfmt@0.54.0:
     resolution: {integrity: sha512-DjnMwn7smSLF+Mc2+pRItnuPftm/dkUFpY/d4+33y9TfKrsHZo8GLhmUg9BrOIUEy94Rlom1Q11N6vuhE+e0oQ==}
@@ -16456,12 +16456,12 @@ snapshots:
 
   outvariant@1.4.0: {}
 
-  overlayscrollbars-react@0.5.6(overlayscrollbars@2.9.2)(react@18.2.0):
+  overlayscrollbars-react@0.5.6(overlayscrollbars@2.16.0)(react@18.2.0):
     dependencies:
-      overlayscrollbars: 2.9.2
+      overlayscrollbars: 2.16.0
       react: 18.2.0
 
-  overlayscrollbars@2.9.2: {}
+  overlayscrollbars@2.16.0: {}
 
   oxfmt@0.54.0:
     dependencies:

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -7,6 +7,7 @@ import AppRoutes from 'AppRoutes';
 import { AxiosError } from 'axios';
 import { GlobalTimeStoreAdapter } from 'components/GlobalTimeStoreAdapter/GlobalTimeStoreAdapter';
 import { ThemeProvider } from 'hooks/useDarkMode';
+import { configureOverlayScrollbars } from 'lib/configureOverlayScrollbars';
 import { NuqsAdapter } from 'nuqs/adapters/react';
 import { AppProvider } from 'providers/App/App';
 import TimezoneProvider from 'providers/Timezone';
@@ -16,6 +17,8 @@ import APIError from 'types/api/error';
 import './ReactI18';
 
 import 'styles.scss';
+
+configureOverlayScrollbars();
 
 const queryClient = new QueryClient({
 	defaultOptions: {

--- a/frontend/src/lib/configureOverlayScrollbars.ts
+++ b/frontend/src/lib/configureOverlayScrollbars.ts
@@ -1,0 +1,22 @@
+import { OverlayScrollbars } from 'overlayscrollbars';
+
+/**
+ * Disables the content `elementEvents` option (default: `[['img', 'load']]`)
+ * for every OverlayScrollbars instance.
+ *
+ * The per-element event cleanups OverlayScrollbars stores in its internal
+ * WeakMap close over the MutationObserver callback scope, which holds arrays
+ * with every node added/removed in that mutation batch. A single long-lived
+ * reference to one of those elements (e.g. CodeMirror's EditContext or its
+ * module-level scratch Range pinning a detached editor) then retains entire
+ * unmounted subtrees as detached DOM — ~1.3k nodes per InfraMonitoring
+ * category switch.
+ *
+ * Content size changes from loading images are still handled by the
+ * scrollbars' size observer, so scrollbar geometry stays correct.
+ */
+export function configureOverlayScrollbars(): void {
+	OverlayScrollbars.env().setDefaultOptions({
+		update: { elementEvents: null },
+	});
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

This fixes a memory leak caused by OverlayScrollbar, similar to https://github.com/KingSora/OverlayScrollbars/issues/377.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

In the end of the following videos, you can see the amount of nodes count before/after this change.

Before:

https://github.com/user-attachments/assets/3040dc54-1d7f-4c93-89c8-0a312b459796

After:

https://github.com/user-attachments/assets/05bd423e-0c71-467d-bf2c-de3458d6e3d0

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/engineering-pod/issues/5754

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

I was investigating performance regressions in the infrastructure monitoring when I notice the memory issue, the initial investigation pointed to an issue similar to https://github.com/KingSora/OverlayScrollbars/issues/377

But that issue itself is closed, not sure the reason why for us still leaking.

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

The issue is caused by a img inside the QueryBuilder:
<img width="820" height="921" alt="screenshot-2026-07-20_13-41-06" src="https://github.com/user-attachments/assets/15cba920-20f3-4e15-9c4d-d4b166b72898" />

For some reason causes the entire table to be kept in memory:

<img width="1084" height="1266" alt="screenshot-2026-07-20_13-42-59" src="https://github.com/user-attachments/assets/801625e6-bc3f-417e-9f47-c562b898b0a5" />

#### Fix Strategy
> How does this PR address the root cause?

A temporary fix is to `OverlayScrollbars.env().setDefaultOptions({ update: { elementEvents: null } });`, but I will upstream this bug to the author of the lib since this is likely a bug in the lib.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: OverlayScrollbar
- Potential regressions: -
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | A small memory leak was fixed in the UI due to a lib that we use to create smooth scrollbars. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

This likely affected any place that uses QuerySearch, and caused the memory to leak across the entire app.