### PR TITLE
test(e2e): fix flaky dashboards-detail specs (sidenav overlay + slow hydration)

### DIFF
--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -30,6 +30,7 @@ async function storageFor(browser: Browser, user: User): Promise<StorageState> {
 		const ctx = await browser.newContext();
 		const page = await ctx.newPage();
 		await login(page, user);
+		await pinSidenav(page);
 		const state = await ctx.storageState();
 		await ctx.close();
 		return state;
@@ -56,6 +57,24 @@ async function login(page: Page, user: User): Promise<void> {
 	// welcome). Wait for URL to move off /login — whichever page follows
 	// is fine, each spec navigates to the feature under test anyway.
 	await page.waitForURL((url) => !url.pathname.startsWith('/login'));
+}
+
+// Pin the nav suite-wide: unpinned it flies out on hover and overlays content.
+// Server-side pref, so set once per user at login.
+async function pinSidenav(page: Page): Promise<void> {
+	const token = await page.evaluate(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		() => (globalThis as any).localStorage.getItem('AUTH_TOKEN') || '',
+	);
+	const res = await page.request.put('/api/v1/user/preferences/sidenav_pinned', {
+		data: { value: true },
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!res.ok()) {
+		throw new Error(
+			`PUT /api/v1/user/preferences/sidenav_pinned ${res.status()}: ${await res.text()}`,
+		);
+	}
 }
 
 export const test = base.extend<{

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -31,6 +31,10 @@ export default defineConfig({
 	// Workers
 	workers: process.env.CI ? 2 : undefined,
 
+	// The SPA hydrates slowly on CI, so the 5s expect default fires mid-load.
+	expect: { timeout: 15_000 },
+	timeout: process.env.CI ? 60_000 : 30_000,
+
 	// Reporter
 	reporter: [
 		['html', { outputFolder: 'artifacts/html', open: 'never' }],

--- a/tests/e2e/tests/dashboards/details/12-sections.spec.ts
+++ b/tests/e2e/tests/dashboards/details/12-sections.spec.ts
@@ -137,6 +137,26 @@ async function toggleSection(row: ReturnType<Page['locator']>): Promise<void> {
 	});
 }
 
+// Poll a section to the target collapsed/expanded state, re-clicking if a
+// toggle is dropped under CI load. `name` has no regex metacharacters.
+async function setSectionCollapsed(
+	page: Page,
+	name: string,
+	collapsed: boolean,
+): Promise<void> {
+	const collapsedTitle = new RegExp(`^${name} \\(\\d+ widgets?\\)$`);
+	await expect(async () => {
+		const alreadyCollapsed = (await page.getByText(collapsedTitle).count()) > 0;
+		if (alreadyCollapsed === collapsed) {
+			return;
+		}
+		await toggleSection(
+			sectionRow(page, alreadyCollapsed ? collapsedTitle : name),
+		);
+		expect((await page.getByText(collapsedTitle).count()) > 0).toBe(collapsed);
+	}).toPass({ timeout: 30_000 });
+}
+
 /**
  * Click the settings (⋮) icon on a section header, bypassing the sidenav's
  * pointer-event interception via `dispatchEvent('click')` (same root cause
@@ -475,19 +495,19 @@ test.describe('Dashboard Detail — Sections', () => {
 	}) => {
 		await gotoApmDashboard(page);
 
-		await toggleSection(sectionRow(page, 'DB Metrics'));
+		await setSectionCollapsed(page, 'DB Metrics', true);
 		await expect(
 			page.getByText(/^DB Metrics \(\d+ widgets?\)$/).first(),
 		).toBeVisible();
 
-		await toggleSection(sectionRow(page, 'External calls'));
+		await setSectionCollapsed(page, 'External calls', true);
 		await expect(
 			page.getByText(/^External calls \(\d+ widgets?\)$/).first(),
 		).toBeVisible();
 
 		// Restore both so the test leaves no state behind.
-		await toggleSection(sectionRow(page, /^DB Metrics \(\d+ widgets?\)$/));
-		await toggleSection(sectionRow(page, /^External calls \(\d+ widgets?\)$/));
+		await setSectionCollapsed(page, 'DB Metrics', false);
+		await setSectionCollapsed(page, 'External calls', false);
 		await expect(page.getByText(/^DB Metrics \(\d+ widgets?\)$/)).toHaveCount(0);
 		await expect(page.getByText(/^External calls \(\d+ widgets?\)$/)).toHaveCount(
 			0,


### PR DESCRIPTION
## What & why

The dashboards-detail E2E specs have been flaking in CI — dashboard title/section assertions timing out (`element(s) not found`) and section-collapse toggles not firing. Two distinct root causes, addressed in two commits.

### 1. Sidenav flyout overlaying content
Those specs run against an *unpinned* sidenav, which is a 54px rail that expands to a **240px absolute overlay on `:hover`**. Playwright's pointer defaults to `(0,0)` — inside that rail — so on a freshly loaded page the flyout expands and covers the content's left strip: the dashboard title sits behind it and left-edge section-collapse toggles get their clicks intercepted. Failure screenshots confirmed the nav flown out over the dashboard.

**Fix:** pin the sidenav once per user at login in the shared auth fixture (server-side `sidenav_pinned` preference). Pinned, the nav reserves layout space and occludes nothing, so every spec inherits a docked nav. The trace-details suite already did this for the same reason; the dashboards suite never did. No spec asserts the unpinned state.

### 2. Slow hydration under the CI runner
Even with the nav pinned, the SPA sits on a blank loading spinner for several seconds on the 2-vCPU runner before dashboard content paints, so Playwright's 5s `expect` default fires mid-load. Traces show **no failed requests** — it's slow, not broken.

**Fix:**
- Raise the global `expect` timeout to 15s and the per-test timeout to 60s on CI, so assertions wait for hydration instead of firing during the spinner.
- Add `setSectionCollapsed`, which polls a section to a target collapsed/expanded state and re-clicks if a toggle is dropped by `GridCardLayout`'s `isDashboardFetching` gate. Used in TC-09 (the most persistent failure), whose blind restore-toggle left a section collapsed under load.

## Verification

Ran against a local stack (dockerized backend + seeder) reproducing the runner's CPU throttle:

- Overlay fix confirmed applied: `sidenav-container pinned`, server pref `value: true`.
- Full CI harness (2 workers, 2 retries, 4× CPU throttle) on the affected specs: **all green**, previously-failing TC-03 / TC-09 now pass.

## Notes

- The now-redundant `dispatchEvent` sidenav-overlap workarounds in several detail specs can be cleaned up in a follow-up.
- TC-08 ("add a section") remains occasionally flaky and recovers on retry; not addressed here.
