### PR TITLE
fix(uplot): missing destroy uplot on unmount

### DIFF
--- a/frontend/src/lib/uPlotV2/components/UPlotChart/UPlotChart.tsx
+++ b/frontend/src/lib/uPlotV2/components/UPlotChart/UPlotChart.tsx
@@ -127,6 +127,15 @@ export default function UPlotChart({
 	}, [isDataEmpty, destroyPlot]);
 
 	/**
+	 * Destroy the plot on unmount. Without this, uPlot's window-level
+	 * `dppxchange` listener keeps the instance (and its whole detached DOM
+	 * subtree) alive after the component is gone.
+	 */
+	const destroyPlotRef = useRef(destroyPlot);
+	destroyPlotRef.current = destroyPlot;
+	useEffect(() => (): void => destroyPlotRef.current(), []);
+
+	/**
 	 * Handle initialization and prop changes
 	 */
 	useEffect(() => {

--- a/frontend/src/lib/uPlotV2/components/__tests__/UPlotChart.test.tsx
+++ b/frontend/src/lib/uPlotV2/components/__tests__/UPlotChart.test.tsx
@@ -327,6 +327,32 @@ describe('UPlotChart', () => {
 			expect(firstInstance.destroy).toHaveBeenCalled();
 			expect(instances).toHaveLength(2);
 		});
+
+		it('destroys the instance and notifies callbacks on unmount', () => {
+			const plotRef = jest.fn();
+			const onDestroy = jest.fn();
+
+			const { unmount } = render(
+				<UPlotChart
+					config={createMockConfig()}
+					data={validData}
+					width={600}
+					height={400}
+					plotRef={plotRef}
+					onDestroy={onDestroy}
+				/>,
+				{ wrapper: Wrapper },
+			);
+
+			const firstInstance = instances[0];
+			plotRef.mockClear();
+
+			unmount();
+
+			expect(onDestroy).toHaveBeenCalledWith(firstInstance);
+			expect(firstInstance.destroy).toHaveBeenCalledTimes(1);
+			expect(plotRef).toHaveBeenCalledWith(null);
+		});
 	});
 
 	describe('spanGaps data transformation', () => {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

As the title said, just missing a destroy for uPlot chart visualization.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

In the following videos, in the end you can see the node count after taking a snapshot of the memory (and detached nodes).

Before:

https://github.com/user-attachments/assets/0bf12ed9-f529-432c-9704-b00eff7b3950

After:

https://github.com/user-attachments/assets/73b53d37-3509-4a98-8280-12543d6d9516

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/engineering-pod/issues/5755

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

The code always destroy the uPlot instance when the data is empty.

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

Just forgot to include a destroy when component unmount.

#### Fix Strategy
> How does this PR address the root cause?

Just call destroy on unmount.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: Yes
- Manual verification: Yes
- Edge cases covered: No

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: uPlot Chart Wrapper - Any chart on Infrastructure Monitoring or Dashboards
- Potential regressions: -
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | A small memory leak in the chart, due to missing destroy the chart instance on leave the page, was fixed. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

