### PR TITLE
fix(opamp): isolate config subscribers by agent

### DIFF
--- a/pkg/query-service/app/opamp/model/coordinator.go
+++ b/pkg/query-service/app/opamp/model/coordinator.go
@@ -8,68 +8,80 @@ import (
 )
 
 // communicates with calling apis when config is applied or fails
-var coordinator *Coordinator
-
-func init() {
-	subscribers := make(map[string][]OnChangeCallback, 0)
-	coordinator = &Coordinator{
-		subscribers: subscribers,
-	}
-}
+var coordinator = newCoordinator()
 
 type OnChangeCallback func(orgId valuer.UUID, agentId string, hash string, err error)
+
+type subscriberKey struct {
+	orgID   string
+	agentID string
+	hash    string
+}
 
 // responsible for managing subscribers on config change
 type Coordinator struct {
 	mutex sync.Mutex
 
-	// hash wise list of subscribers
-	subscribers map[string][]OnChangeCallback
+	// subscribers are isolated by organization, agent, and config hash so one
+	// agent's terminal status cannot consume another agent's callbacks.
+	subscribers map[subscriberKey][]OnChangeCallback
 }
 
-func getSubscriberKey(orgId valuer.UUID, hash string) string {
-	return orgId.String() + hash
+func newCoordinator() *Coordinator {
+	return &Coordinator{
+		subscribers: make(map[subscriberKey][]OnChangeCallback),
+	}
+}
+
+func getSubscriberKey(orgId valuer.UUID, agentId string, hash string) subscriberKey {
+	return subscriberKey{
+		orgID:   orgId.String(),
+		agentID: agentId,
+		hash:    hash,
+	}
 }
 
 func onConfigSuccess(orgId valuer.UUID, agentId string, hash string) {
-	key := getSubscriberKey(orgId, hash)
-	notifySubscribers(orgId, agentId, key, nil)
+	coordinator.notifySubscribers(orgId, agentId, hash, nil)
 }
 
 func onConfigFailure(orgId valuer.UUID, agentId string, hash string, errorMessage string) {
-	key := getSubscriberKey(orgId, hash)
-	notifySubscribers(orgId, agentId, key, errors.New(errorMessage))
+	coordinator.notifySubscribers(orgId, agentId, hash, errors.New(errorMessage))
 }
 
-// OnSuccess listens to config changes and notifies subscribers
-func notifySubscribers(orgId valuer.UUID, agentId string, key string, err error) {
-	// this method currently does not handle multi-agent scenario.
-	// as soon as a message is delivered, we release all the subscribers
-	// for a given key
+// notifySubscribers removes and notifies callbacks for one agent's config
+// deployment. Callbacks run outside the lock so they can safely subscribe to
+// another update and cannot block other coordinator operations.
+func (coordinator *Coordinator) notifySubscribers(orgId valuer.UUID, agentId string, hash string, err error) {
+	key := getSubscriberKey(orgId, agentId, hash)
+
+	coordinator.mutex.Lock()
 	subs, ok := coordinator.subscribers[key]
 	if !ok {
+		coordinator.mutex.Unlock()
 		return
 	}
+	delete(coordinator.subscribers, key)
+	coordinator.mutex.Unlock()
 
 	for _, s := range subs {
-		s(orgId, agentId, key, err)
+		s(orgId, agentId, orgId.String()+hash, err)
 	}
-
-	// delete all subscribers for this key, assume future
-	// notifies will be disabled. the first response is processed
-	delete(coordinator.subscribers, key)
 }
 
 // callers subscribe to this function to listen on config change requests
 func ListenToConfigUpdate(orgId valuer.UUID, agentId string, hash string, ss OnChangeCallback) {
+	coordinator.listenToConfigUpdate(orgId, agentId, hash, ss)
+}
+
+func (coordinator *Coordinator) listenToConfigUpdate(orgId valuer.UUID, agentId string, hash string, ss OnChangeCallback) {
 	coordinator.mutex.Lock()
 	defer coordinator.mutex.Unlock()
 
-	key := getSubscriberKey(orgId, hash)
+	key := getSubscriberKey(orgId, agentId, hash)
 
 	if subs, ok := coordinator.subscribers[key]; ok {
-		subs = append(subs, ss)
-		coordinator.subscribers[key] = subs
+		coordinator.subscribers[key] = append(subs, ss)
 	} else {
 		coordinator.subscribers[key] = []OnChangeCallback{ss}
 	}

--- a/pkg/query-service/app/opamp/model/coordinator_test.go
+++ b/pkg/query-service/app/opamp/model/coordinator_test.go
@@ -1,0 +1,125 @@
+package model
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+func TestCoordinatorNotifiesAgentsIndependently(t *testing.T) {
+	coordinator := newCoordinator()
+	orgID := valuer.GenerateUUID()
+	const (
+		agentA = "agent-a"
+		agentB = "agent-b"
+		hash   = "config-hash"
+	)
+
+	type notification struct {
+		agentID  string
+		configID string
+		err      error
+	}
+	notifications := make(chan notification, 2)
+	callback := func(_ valuer.UUID, agentID string, configID string, err error) {
+		notifications <- notification{agentID: agentID, configID: configID, err: err}
+	}
+
+	coordinator.listenToConfigUpdate(orgID, agentA, hash, callback)
+	coordinator.listenToConfigUpdate(orgID, agentB, hash, callback)
+
+	coordinator.notifySubscribers(orgID, agentA, hash, nil)
+
+	first := <-notifications
+	assert.Equal(t, agentA, first.agentID)
+	assert.Equal(t, orgID.String()+hash, first.configID)
+	assert.NoError(t, first.err)
+	assert.Len(t, notifications, 0)
+
+	failure := errors.New("deployment failed")
+	coordinator.notifySubscribers(orgID, agentB, hash, failure)
+
+	second := <-notifications
+	assert.Equal(t, agentB, second.agentID)
+	assert.Equal(t, orgID.String()+hash, second.configID)
+	assert.ErrorIs(t, second.err, failure)
+	assert.Len(t, notifications, 0)
+}
+
+func TestCoordinatorNotifiesAllSubscribersForAgentOnce(t *testing.T) {
+	coordinator := newCoordinator()
+	orgID := valuer.GenerateUUID()
+	const (
+		agentID = "agent-a"
+		hash    = "config-hash"
+	)
+
+	var calls atomic.Int32
+	callback := func(_ valuer.UUID, _ string, _ string, _ error) {
+		calls.Add(1)
+	}
+
+	coordinator.listenToConfigUpdate(orgID, agentID, hash, callback)
+	coordinator.listenToConfigUpdate(orgID, agentID, hash, callback)
+
+	coordinator.notifySubscribers(orgID, agentID, hash, nil)
+	coordinator.notifySubscribers(orgID, agentID, hash, nil)
+
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestCoordinatorInvokesCallbacksOutsideLock(t *testing.T) {
+	coordinator := newCoordinator()
+	orgID := valuer.GenerateUUID()
+	const (
+		agentID = "agent-a"
+		hash    = "config-hash"
+	)
+
+	callbackCompleted := make(chan struct{})
+	coordinator.listenToConfigUpdate(orgID, agentID, hash, func(_ valuer.UUID, _ string, _ string, _ error) {
+		coordinator.listenToConfigUpdate(orgID, agentID, "next-hash", func(_ valuer.UUID, _ string, _ string, _ error) {})
+		close(callbackCompleted)
+	})
+
+	coordinator.notifySubscribers(orgID, agentID, hash, nil)
+
+	select {
+	case <-callbackCompleted:
+	default:
+		require.Fail(t, "callback could not subscribe to another update")
+	}
+}
+
+func TestCoordinatorConcurrentSubscribeAndNotify(t *testing.T) {
+	coordinator := newCoordinator()
+	orgID := valuer.GenerateUUID()
+	const iterations = 1_000
+
+	var wg sync.WaitGroup
+	for idx := range iterations {
+		agentID := valuer.GenerateUUID().String()
+		hash := valuer.GenerateUUID().String()
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			coordinator.listenToConfigUpdate(orgID, agentID, hash, func(_ valuer.UUID, _ string, _ string, _ error) {})
+		}()
+		go func() {
+			defer wg.Done()
+			coordinator.notifySubscribers(orgID, agentID, hash, nil)
+		}()
+
+		if idx%10 == 0 {
+			wg.Wait()
+		}
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
### 📄 Summary

  The OpAMP configuration deployment coordinator previously grouped subscribers only by organization ID and configuration hash.
  It did not include the agent ID in the subscription identity.

  Consequently, when multiple agents received the same configuration, the first agent to report `APPLIED` or `FAILED` consumed
  every callback registered for that organization and configuration. Later deployment results from the remaining agents were
  silently ignored.

  The coordinator also accessed its subscriber map inconsistently:

  - `ListenToConfigUpdate` modified the map while holding the coordinator mutex.
  - `notifySubscribers` read from and deleted from the same map without holding the mutex.

  Because subscriptions and agent status updates may be processed concurrently, this created a data race and possible
  concurrent-map runtime failure.

  This PR makes subscriptions agent-aware and ensures that all access to coordinator state is protected by the mutex. Matching
  callbacks are removed while holding the lock and invoked after releasing it.

  #### Screenshots / Screen Recordings (if applicable)

  N/A — this is an internal OpAMP coordination fix with no direct UI changes.

  #### Issues closed by this PR

  Closes #12184

  ---

  ### ✅ Change Type

  - [ ] ✨ Feature
  - [x] 🐛 Bug fix
  - [ ] ♻️ Refactor
  - [ ] 🛠️ Infra / Tooling
  - [ ] 🧪 Test-only

  ---

  ### 🐛 Bug Context

  #### Root Cause

  The coordinator stored callbacks in a map keyed by a concatenation of:

  - Organization ID
  - Configuration hash

  Although `ListenToConfigUpdate` accepted an agent ID, it was not used when constructing the subscriber key.

  This faulty assumption treated a configuration deployment as organization-wide rather than agent-specific. All agents
  receiving the same configuration shared one callback collection.

  When any one agent reported a terminal status, `notifySubscribers`:

  1. Loaded every callback registered for the organization and hash.
  2. Invoked all callbacks using the responding agent's ID and result.
  3. Deleted the entire subscriber entry.

  This caused the first response to consume subscriptions belonging to other agents.

  Additionally, `notifySubscribers` accessed and deleted entries from the shared subscriber map without acquiring
  `coordinator.mutex`. This could race with concurrent calls to `ListenToConfigUpdate`.

  #### Fix Strategy

  The coordinator now uses a structured subscription key containing:

  - Organization ID
  - Agent ID
  - Configuration hash

  This ensures that each agent's deployment callbacks are stored and consumed independently.

  The notification flow now:

  1. Constructs the agent-specific subscriber key.
  2. Acquires the coordinator mutex.
  3. Finds and removes only the matching agent's callbacks.
  4. Releases the mutex.
  5. Invokes the copied callbacks outside the critical section.

  Executing callbacks outside the lock prevents slow or reentrant callbacks from blocking other coordinator operations or
  causing a deadlock.

  The existing callback contract is preserved: callbacks continue receiving the organization-prefixed configuration ID.

  The global coordinator is now constructed through `newCoordinator`, allowing tests to use isolated coordinator instances
  without mutating package-global state.

  ---

  ### 🧪 Testing Strategy

  #### Tests added/updated

  Added focused tests in:

  `pkg/query-service/app/opamp/model/coordinator_test.go`

  The tests cover:

  - Two agents in the same organization using the same configuration hash.
  - Independent success and failure notifications for each agent.
  - Preservation of the existing organization-prefixed callback config ID.
  - Multiple callbacks registered for the same agent.
  - Duplicate terminal notifications invoking callbacks only once.
  - Callback reentrancy, proving callbacks execute outside the mutex.
  - Concurrent subscription and notification operations.

  #### Commands executed

  ```bash
  go test -race ./pkg/query-service/app/opamp/model

  go test -race -count=10 ./pkg/query-service/app/opamp/model

  go test -race ./pkg/query-service/app/opamp/...

  go test -race ./pkg/query-service/agentConf

  go vet ./pkg/query-service/app/opamp/model

  git diff --check

  All commands passed.

  #### Manual verification

  No live multi-agent OpAMP environment was used. The behavior is covered through isolated unit tests and repeated race-detector
  runs.

  #### Edge cases covered

  - Same organization and hash, different agents.
  - Success for one agent followed by failure for another.
  - Multiple callbacks for one agent and configuration.
  - Repeated terminal status for the same deployment.
  - Callback registering another subscription.
  - Concurrent subscribe and notify operations.

  ———

  ### ⚠️ Risk & Impact Assessment

  - Blast radius: Limited to the in-memory OpAMP configuration deployment coordinator.
  - Potential regressions: Consumers that unintentionally depended on the first agent response consuming all callbacks will now
    receive independent callbacks for each agent.

  - Backward compatibility: The public callback signature and organization-prefixed configuration ID are unchanged.
  - Concurrency impact: Map reads, writes, and deletions are now serialized through the existing mutex.
  - Deadlock risk: Reduced by invoking callbacks after releasing the mutex.
  - Rollback plan: Revert this commit to restore the previous coordinator behavior.

  ———

  ### 📝 Changelog

   Field              Value
  ━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   Deployment Type    Cloud / OSS / Enterprise
  ─────────────────  ───────────────────────────────────────────────────────────────────────────────────────────────────────────
   Change Type        Bug Fix
  ─────────────────  ───────────────────────────────────────────────────────────────────────────────────────────────────────────
   Description        Track OpAMP configuration deployment results independently for each agent and prevent concurrent
                      subscriber-map access.

  ———

  ### 📋 Checklist

  - [x] Tests added or explicitly not required
  - [ ] Manually tested
  - [x] Breaking changes documented
  - [x] Backward compatibility considered

  ———

  ## 👀 Notes for Reviewers

  The internal subscriber key now includes the agent ID, but the callback's configId argument intentionally remains orgID +
  hash.

  That preserves the existing contract used by AgentConfigProvider.ReportConfigDeploymentStatus while preventing the internal
  map key from leaking into callback behavior.

  Callbacks are deliberately invoked after deleting their subscription and releasing the mutex. This provides at-most-once
  notification for a terminal status and permits callbacks to register a subsequent configuration update safely.
