### PR TITLE
fix(querier): stop live stream goroutine leaks

### DIFF
--- a/pkg/querier/api.go
+++ b/pkg/querier/api.go
@@ -208,21 +208,27 @@ func (handler *handler) QueryRawStream(rw http.ResponseWriter, req *http.Request
 
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case log := <-client.Logs:
 			var buf bytes.Buffer
 			enc := json.NewEncoder(&buf)
 			err := enc.Encode(log)
 			if err != nil {
-				fmt.Fprintf(rw, "event: error\ndata: %v\n\n", err.Error())
+				_, _ = fmt.Fprintf(rw, "event: error\ndata: %v\n\n", err.Error())
 				flusher.Flush()
 				return
 			}
-			fmt.Fprintf(rw, "data: %v\n\n", buf.String())
+			if _, err := fmt.Fprintf(rw, "data: %v\n\n", buf.String()); err != nil {
+				return
+			}
 			flusher.Flush()
 		case <-client.Done:
 			return
 		case err := <-client.Error:
-			fmt.Fprintf(rw, "event: error\ndata: %v\n\n", err.Error())
+			if _, writeErr := fmt.Fprintf(rw, "event: error\ndata: %v\n\n", err.Error()); writeErr != nil {
+				return
+			}
 			flusher.Flush()
 			return
 		}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -464,6 +464,7 @@ func (q *querier) resolveMetricMetadata(ctx context.Context, orgID valuer.UUID, 
 }
 
 func (q *querier) QueryRawStream(ctx context.Context, orgID valuer.UUID, req *qbtypes.QueryRangeRequest, client *qbtypes.RawStream) {
+	defer close(client.Done)
 
 	// Coerce the window to epoch milliseconds up front (End may be 0 for the
 	// open-ended stream, which ToMilliSecs leaves untouched).
@@ -484,12 +485,12 @@ func (q *querier) QueryRawStream(ctx context.Context, orgID valuer.UUID, req *qb
 				event.FilterApplied = spec.Filter != nil && spec.Filter.Expression != ""
 			default:
 				// return if it's not log aggregation
-				client.Error <- errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported builder spec type %T", query.Spec)
+				sendRawStreamError(ctx, client.Error, errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported builder spec type %T", query.Spec))
 				return
 			}
 		} else {
 			// return if it's not of type query builder
-			client.Error <- errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported query type %s", query.Type)
+			sendRawStreamError(ctx, client.Error, errors.NewInvalidInputf(errors.CodeInvalidInput, "unsupported query type %s", query.Type))
 			return
 		}
 	}
@@ -515,54 +516,71 @@ func (q *querier) QueryRawStream(ctx context.Context, orgID valuer.UUID, req *qb
 	ticker := time.NewTicker(q.liveDataRefresh)
 	defer ticker.Stop()
 
-	// we are creating a custom ticker wrapper to trigger it instantly
-	tick := make(chan time.Time, 1)
-	tick <- time.Now() // initial tick
-	go func() {
-		for t := range ticker.C {
-			tick <- t
-		}
-	}()
-
+	firstQuery := true
 	for {
-		select {
-		case <-ctx.Done():
-			done := true
-			client.Done <- &done
-			return
-		case <-tick:
-			// timestamp end is not specified here
-			timeRange := adjustTimeRangeForShift(spec, qbtypes.TimeRange{From: tsStart}, req.RequestType)
-			liveTailStmtBuilder := q.logStmtBuilder
-			if spec.Source == telemetrytypes.SourceAudit {
-				liveTailStmtBuilder = q.auditStmtBuilder
-			}
-			bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, liveTailStmtBuilder, spec, timeRange, req.RequestType, map[string]qbtypes.VariableItem{
-				"id": {
-					Value: updatedLogID,
-				},
-			}, q.builderConfig)
-			queries[spec.Name] = bq
-
-			qbResp, qbErr := q.run(ctx, orgID, queries, req, nil, event, nil)
-			if qbErr != nil {
-				client.Error <- qbErr
+		if firstQuery {
+			firstQuery = false
+			if ctx.Err() != nil {
 				return
 			}
-
-			if qbResp == nil || len(qbResp.Data.Results) == 0 || qbResp.Data.Results[0] == nil {
-				continue
+		} else {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
 			}
-			data := qbResp.Data.Results[0].(*qbtypes.RawData)
-			for i := len(data.Rows) - 1; i >= 0; i-- {
-				client.Logs <- data.Rows[i]
-				if i == 0 {
-					tsStart = uint64(data.Rows[i].Timestamp.UnixNano())
-					updatedLogID = data.Rows[i].Data["id"].(string)
-				}
-			}
-
 		}
+
+		// timestamp end is not specified here
+		timeRange := adjustTimeRangeForShift(spec, qbtypes.TimeRange{From: tsStart}, req.RequestType)
+		liveTailStmtBuilder := q.logStmtBuilder
+		if spec.Source == telemetrytypes.SourceAudit {
+			liveTailStmtBuilder = q.auditStmtBuilder
+		}
+		bq := newBuilderQuery(q.logger, q.telemetryStore, orgID, liveTailStmtBuilder, spec, timeRange, req.RequestType, map[string]qbtypes.VariableItem{
+			"id": {
+				Value: updatedLogID,
+			},
+		}, q.builderConfig)
+		queries[spec.Name] = bq
+
+		qbResp, qbErr := q.run(ctx, orgID, queries, req, nil, event, nil)
+		if qbErr != nil {
+			sendRawStreamError(ctx, client.Error, qbErr)
+			return
+		}
+
+		if qbResp == nil || len(qbResp.Data.Results) == 0 || qbResp.Data.Results[0] == nil {
+			continue
+		}
+		data := qbResp.Data.Results[0].(*qbtypes.RawData)
+		for i := len(data.Rows) - 1; i >= 0; i-- {
+			if !sendRawStreamLog(ctx, client.Logs, data.Rows[i]) {
+				return
+			}
+			if i == 0 {
+				tsStart = uint64(data.Rows[i].Timestamp.UnixNano())
+				updatedLogID = data.Rows[i].Data["id"].(string)
+			}
+		}
+	}
+}
+
+func sendRawStreamLog(ctx context.Context, logs chan<- *qbtypes.RawRow, log *qbtypes.RawRow) bool {
+	select {
+	case logs <- log:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func sendRawStreamError(ctx context.Context, errors chan<- error, err error) bool {
+	select {
+	case errors <- err:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }
 

--- a/pkg/querier/raw_stream_test.go
+++ b/pkg/querier/raw_stream_test.go
@@ -1,0 +1,112 @@
+package querier
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendRawStreamLogReturnsWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	logs := make(chan *qbtypes.RawRow, 1)
+	logs <- &qbtypes.RawRow{}
+
+	require.False(t, sendRawStreamLog(ctx, logs, &qbtypes.RawRow{}))
+}
+
+func TestSendRawStreamErrorReturnsWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.False(t, sendRawStreamError(ctx, make(chan error), context.Canceled))
+}
+
+func TestQueryRawStreamClosesDoneWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	q := &querier{liveDataRefresh: time.Hour}
+	req := &qbtypes.QueryRangeRequest{
+		RequestType: qbtypes.RequestTypeRawStream,
+		CompositeQuery: qbtypes.CompositeQuery{
+			Queries: []qbtypes.QueryEnvelope{
+				{
+					Type: qbtypes.QueryTypeBuilder,
+					Spec: qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]{
+						Signal: telemetrytypes.SignalLogs,
+						Name:   "raw_stream",
+					},
+				},
+			},
+		},
+	}
+	client := &qbtypes.RawStream{
+		Logs:  make(chan *qbtypes.RawRow),
+		Done:  make(chan *bool),
+		Error: make(chan error),
+	}
+
+	q.QueryRawStream(ctx, valuer.GenerateUUID(), req, client)
+
+	_, open := <-client.Done
+	require.False(t, open)
+}
+
+type contextBlockingQuerier struct {
+	started chan struct{}
+}
+
+func (q *contextBlockingQuerier) QueryRange(context.Context, valuer.UUID, *qbtypes.QueryRangeRequest) (*qbtypes.QueryRangeResponse, error) {
+	return nil, nil
+}
+
+func (q *contextBlockingQuerier) QueryRawStream(ctx context.Context, _ valuer.UUID, _ *qbtypes.QueryRangeRequest, _ *qbtypes.RawStream) {
+	close(q.started)
+	<-ctx.Done()
+}
+
+func (q *contextBlockingQuerier) Collect(context.Context, valuer.UUID) (map[string]any, error) {
+	return nil, nil
+}
+
+func (q *contextBlockingQuerier) QueryRangePreview(context.Context, valuer.UUID, *qbtypes.QueryRangeRequest, qbtypes.QueryRangePreviewOptions) (*qbtypes.QueryRangePreviewResponse, error) {
+	return nil, nil
+}
+
+func TestQueryRawStreamHandlerReturnsWhenRequestIsCanceled(t *testing.T) {
+	q := &contextBlockingQuerier{started: make(chan struct{})}
+	handler := &handler{querier: q}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = authtypes.NewContextWithClaims(ctx, authtypes.Claims{OrgID: valuer.GenerateUUID().StringValue()})
+	req := httptest.NewRequest("GET", "/api/v3/logs/livetail", nil).WithContext(ctx)
+	rw := httptest.NewRecorder()
+	returned := make(chan struct{})
+
+	go func() {
+		handler.QueryRawStream(rw, req)
+		close(returned)
+	}()
+
+	select {
+	case <-q.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for raw stream query to start")
+	}
+	cancel()
+
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("raw stream handler did not return after request cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

  Fixes goroutine and query-state leaks in live-log streaming when an SSE client disconnects.

  The live-tail implementation previously had several shutdown paths that could block indefinitely:

  - A forwarding goroutine ranged over `ticker.C`, but `ticker.Stop()` does not close that channel.
  - Cancellation attempted to send on the unbuffered `client.Done` channel.
  - Log and error delivery could block after the SSE handler stopped receiving.
  - The SSE handler did not directly observe request cancellation.
  - Failed response writes did not terminate the handler immediately.

  This change makes the entire live-stream lifecycle cancellation-aware and ensures both the producer and HTTP handler can
  terminate after a client disconnects.

  ## Related Issue

  Closes #12186

  ## Root Cause

  `QueryRawStream` wrapped its ticker with an additional channel and forwarding goroutine:

  ```go
  go func() {
      for t := range ticker.C {
          tick <- t
      }
  }()

  Stopping a time.Ticker prevents future ticks but does not close ticker.C. As a result, this goroutine remained blocked on the
  channel after the stream ended.

  The producer also used blocking channel sends:

  client.Done <- &done
  client.Logs <- row
  client.Error <- err

  If the SSE handler had already returned, the unbuffered Done and Error sends could block permanently. Log delivery could
  similarly block once the 1,000-element buffer filled.

  Finally, the HTTP handler only waited on the stream channels and did not select on req.Context().Done().

  ## Changes

  ### Remove the ticker-forwarding goroutine

  The first query is now executed immediately, after which QueryRawStream waits directly on either:

  - ticker.C
  - ctx.Done()

  This preserves immediate first-query behavior without creating another goroutine.

  ### Make producer completion non-blocking

  QueryRawStream now owns the Done channel lifecycle and closes it when the producer returns:

  defer close(client.Done)

  Closing the channel wakes any active receiver without requiring a matching receive operation.

  ### Make all stream delivery cancellation-aware

  Log and error sends now select between channel delivery and context cancellation.

  This prevents the producer from remaining blocked when:

  - The log buffer is full.
  - The handler has stopped receiving errors.
  - The client has disconnected.

  ### Stop the SSE handler on request cancellation

  The HTTP handler now selects directly on ctx.Done(), allowing it to exit even if the producer does not send a completion
  event.

  Response-write errors are also checked so disconnected clients terminate the handler immediately.

  ## Testing

  Added focused tests covering:

  - Log delivery returning when the context is canceled and the log buffer is full.
  - Error delivery returning when no receiver exists.
  - QueryRawStream closing its completion channel after cancellation.
  - The SSE handler returning on request cancellation even when its producer never signals completion.

  Commands run:

  GOTOOLCHAIN=go1.25.7 go test ./pkg/querier -count=1
  GOTOOLCHAIN=go1.25.7 go test -race ./pkg/querier -count=1
  GOTOOLCHAIN=go1.25.7 go vet ./pkg/querier
  git diff --check

  All checks pass.

  > Note: The repository declares Go 1.25.7. The machine's default Go 1.26.5 is incompatible with the currently pinned
  > github.com/bytedance/sonic version, so validation was run with the repository-declared toolchain.

  ## Risk Assessment

  Risk is low to moderate.

  The live-tail polling and row-ordering behavior remain unchanged. The main behavioral difference is that stream producers and
  HTTP handlers now terminate promptly when their request context is canceled or response delivery fails.

  ## Change Type

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [x] Tests
  - [ ] Documentation update

  ## Checklist

  - [x] The change is scoped to live-log streaming.
  - [x] Immediate initial polling behavior is preserved.
  - [x] All producer channel sends are cancellation-aware.
  - [x] The SSE handler observes request cancellation.
  - [x] Response-write errors terminate the handler.
  - [x] Focused regression tests were added.
  - [x] Package tests pass.
  - [x] Race detector passes.
  - [x] go vet passes.