### PR TITLE
docs: explain Azure config narrowing on resource_groups

### DIFF
--- a/frontend/src/container/Integrations/CloudIntegration/AzureCloudServices/EditAccount/AccountSettingsModal.tsx
+++ b/frontend/src/container/Integrations/CloudIntegration/AzureCloudServices/EditAccount/AccountSettingsModal.tsx
@@ -36,6 +36,10 @@ function AccountSettingsModal({
 
 	const queryClient = useQueryClient();
 
+	// `account.config` is the shared per-provider union (Azure | AWS | GCP).
+	// Narrow to Azure by `resource_groups` (Azure-only) rather than
+	// `deployment_region`, which GCP also has — so it no longer identifies
+	// Azure uniquely.
 	const azureConfig = useMemo(
 		() => ('resource_groups' in account.config ? account.config : null),
 		[account.config],

--- a/frontend/src/hooks/integration/azure/useAccountSettingsModal.ts
+++ b/frontend/src/hooks/integration/azure/useAccountSettingsModal.ts
@@ -39,6 +39,10 @@ export function useAccountSettingsModal({
 }: UseAccountSettingsModalProps): UseAccountSettingsModal {
 	const [form] = Form.useForm();
 	const { mutate: updateAccount, isLoading } = useUpdateAccount();
+	// `account.config` is the shared per-provider union (Azure | AWS | GCP).
+	// Narrow to Azure by `resource_groups` (Azure-only) rather than
+	// `deployment_region`, which GCP also has — so it no longer identifies
+	// Azure uniquely.
 	const accountConfig = useMemo(
 		() => ('resource_groups' in account.config ? account.config : null),
 		[account.config],


### PR DESCRIPTION
## Why

Reviewers on the GCP branch asked why the Azure `AccountSettingsModal` / `useAccountSettingsModal` were touched. This adds a code comment so the change is self-explanatory.

## Context

`CloudAccount.config` is a shared per-provider union (`Azure | AWS | GCP`). The Azure code narrows the union with an `in` check. It used `deployment_region`, but GCP's new config **also** has `deployment_region`, so that field no longer uniquely identifies Azure — narrowing widened to `Azure | GCP` and `.resource_groups` access failed to compile (5× TS2339). The fix (already on the GCP branch) switched the discriminator to the Azure-only `resource_groups`; this PR just documents that at both call sites.

Comment-only change. No behavior change. `tsgo --noEmit` clean.