### PR TITLE
fix(querycache): preserve fresh data on cache errors

### DIFF
--- a/pkg/query-service/app/querier/helper.go
+++ b/pkg/query-service/app/querier/helper.go
@@ -107,7 +107,7 @@ func (q *querier) runBuilderQuery(
 			return
 		}
 
-		misses := q.queryCache.FindMissingTimeRanges(orgID, start, end, builderQuery.StepInterval, cacheKeys[queryName])
+		misses := q.queryCache.FindMissingTimeRanges(ctx, orgID, start, end, builderQuery.StepInterval, cacheKeys[queryName])
 		q.logger.InfoContext(ctx, "cache misses for logs query", "misses", misses)
 		missedSeries := make([]querycache.CachedSeriesData, 0)
 		filteredMissedSeries := make([]querycache.CachedSeriesData, 0)
@@ -147,10 +147,10 @@ func (q *querier) runBuilderQuery(
 			})
 		}
 
-		filteredMergedSeries := q.queryCache.MergeWithCachedSeriesDataV2(orgID, cacheKeys[queryName], filteredMissedSeries)
-		q.queryCache.StoreSeriesInCache(orgID, cacheKeys[queryName], filteredMergedSeries)
+		filteredMergedSeries := q.queryCache.MergeWithCachedSeriesDataV2(ctx, orgID, cacheKeys[queryName], filteredMissedSeries)
+		q.queryCache.StoreSeriesInCache(ctx, orgID, cacheKeys[queryName], filteredMergedSeries)
 
-		mergedSeries := q.queryCache.MergeWithCachedSeriesDataV2(orgID, cacheKeys[queryName], missedSeries)
+		mergedSeries := q.queryCache.MergeWithCachedSeriesDataV2(ctx, orgID, cacheKeys[queryName], missedSeries)
 
 		resultSeries := common.GetSeriesFromCachedDataV2(mergedSeries, start, end, builderQuery.StepInterval)
 
@@ -228,7 +228,7 @@ func (q *querier) runBuilderQuery(
 	}
 
 	cacheKey := cacheKeys[queryName]
-	misses := q.queryCache.FindMissingTimeRanges(orgID, start, end, builderQuery.StepInterval, cacheKey)
+	misses := q.queryCache.FindMissingTimeRanges(ctx, orgID, start, end, builderQuery.StepInterval, cacheKey)
 	q.logger.InfoContext(ctx, "cache misses for metrics query", "misses", misses)
 	missedSeries := make([]querycache.CachedSeriesData, 0)
 	for _, miss := range misses {
@@ -265,7 +265,7 @@ func (q *querier) runBuilderQuery(
 			Data:  series,
 		})
 	}
-	mergedSeries := q.queryCache.MergeWithCachedSeriesData(orgID, cacheKey, missedSeries)
+	mergedSeries := q.queryCache.MergeWithCachedSeriesData(ctx, orgID, cacheKey, missedSeries)
 
 	resultSeries := common.GetSeriesFromCachedData(mergedSeries, start, end)
 
@@ -305,7 +305,7 @@ func (q *querier) runBuilderExpression(
 
 	cacheKey := cacheKeys[queryName]
 	step := postprocess.StepIntervalForFunction(params, queryName)
-	misses := q.queryCache.FindMissingTimeRanges(orgID, params.Start, params.End, step, cacheKey)
+	misses := q.queryCache.FindMissingTimeRanges(ctx, orgID, params.Start, params.End, step, cacheKey)
 	q.logger.InfoContext(ctx, "cache misses for expression query", "misses", misses)
 	missedSeries := make([]querycache.CachedSeriesData, 0)
 	for _, miss := range misses {
@@ -329,7 +329,7 @@ func (q *querier) runBuilderExpression(
 			Data:  series,
 		})
 	}
-	mergedSeries := q.queryCache.MergeWithCachedSeriesData(orgID, cacheKey, missedSeries)
+	mergedSeries := q.queryCache.MergeWithCachedSeriesData(ctx, orgID, cacheKey, missedSeries)
 
 	resultSeries := common.GetSeriesFromCachedData(mergedSeries, params.Start, params.End)
 

--- a/pkg/query-service/app/querier/querier.go
+++ b/pkg/query-service/app/querier/querier.go
@@ -217,7 +217,7 @@ func (q *querier) runPromQueries(ctx context.Context, orgID valuer.UUID, params 
 				channelResults <- channelResult{Err: err, Name: queryName, Query: query.Query, Series: series}
 				return
 			}
-			misses := q.queryCache.FindMissingTimeRanges(orgID, params.Start, params.End, params.Step, cacheKey)
+			misses := q.queryCache.FindMissingTimeRanges(ctx, orgID, params.Start, params.End, params.Step, cacheKey)
 			q.logger.InfoContext(ctx, "cache misses for metrics prom query", "misses", misses)
 			missedSeries := make([]querycache.CachedSeriesData, 0)
 			for _, miss := range misses {
@@ -233,7 +233,7 @@ func (q *querier) runPromQueries(ctx context.Context, orgID valuer.UUID, params 
 					End:   miss.End,
 				})
 			}
-			mergedSeries := q.queryCache.MergeWithCachedSeriesData(orgID, cacheKey, missedSeries)
+			mergedSeries := q.queryCache.MergeWithCachedSeriesData(ctx, orgID, cacheKey, missedSeries)
 			resultSeries := common.GetSeriesFromCachedData(mergedSeries, params.Start, params.End)
 			channelResults <- channelResult{Err: nil, Name: queryName, Query: promQuery.Query, Series: resultSeries}
 

--- a/pkg/query-service/app/querier/querier_test.go
+++ b/pkg/query-service/app/querier/querier_test.go
@@ -260,7 +260,7 @@ func TestFindMissingTimeRangesZeroFreshNess(t *testing.T) {
 			err = c.Set(context.Background(), orgID, cacheKey, &cacheableData, 0)
 			assert.NoError(t, err)
 
-			misses := qc.FindMissingTimeRanges(orgID, tc.requestedStart, tc.requestedEnd, tc.requestedStep, cacheKey)
+			misses := qc.FindMissingTimeRanges(context.Background(), orgID, tc.requestedStart, tc.requestedEnd, tc.requestedStep, cacheKey)
 			if len(misses) != len(tc.expectedMiss) {
 				t.Errorf("expected %d misses, got %d", len(tc.expectedMiss), len(misses))
 			}
@@ -480,7 +480,7 @@ func TestFindMissingTimeRangesWithFluxInterval(t *testing.T) {
 			err = c.Set(context.Background(), orgID, cacheKey, &cacheableData, 0)
 			assert.NoError(t, err)
 
-			misses := qc.FindMissingTimeRanges(orgID, tc.requestedStart, tc.requestedEnd, tc.requestedStep, cacheKey)
+			misses := qc.FindMissingTimeRanges(context.Background(), orgID, tc.requestedStart, tc.requestedEnd, tc.requestedStep, cacheKey)
 			if len(misses) != len(tc.expectedMiss) {
 				t.Errorf("expected %d misses, got %d", len(tc.expectedMiss), len(misses))
 			}

--- a/pkg/query-service/app/querier/v2/helper.go
+++ b/pkg/query-service/app/querier/v2/helper.go
@@ -110,7 +110,7 @@ func (q *querier) runBuilderQuery(
 			ch <- channelResult{Err: err, Name: queryName, Query: query, Series: series}
 			return
 		}
-		misses := q.queryCache.FindMissingTimeRangesV2(orgID, start, end, builderQuery.StepInterval, cacheKeys[queryName])
+		misses := q.queryCache.FindMissingTimeRangesV2(ctx, orgID, start, end, builderQuery.StepInterval, cacheKeys[queryName])
 		q.logger.InfoContext(ctx, "cache misses for logs query", "misses", misses)
 		missedSeries := make([]querycache.CachedSeriesData, 0)
 		filteredMissedSeries := make([]querycache.CachedSeriesData, 0)
@@ -151,10 +151,10 @@ func (q *querier) runBuilderQuery(
 			})
 		}
 
-		filteredMergedSeries := q.queryCache.MergeWithCachedSeriesDataV2(orgID, cacheKeys[queryName], filteredMissedSeries)
-		q.queryCache.StoreSeriesInCache(orgID, cacheKeys[queryName], filteredMergedSeries)
+		filteredMergedSeries := q.queryCache.MergeWithCachedSeriesDataV2(ctx, orgID, cacheKeys[queryName], filteredMissedSeries)
+		q.queryCache.StoreSeriesInCache(ctx, orgID, cacheKeys[queryName], filteredMergedSeries)
 
-		mergedSeries := q.queryCache.MergeWithCachedSeriesDataV2(orgID, cacheKeys[queryName], missedSeries)
+		mergedSeries := q.queryCache.MergeWithCachedSeriesDataV2(ctx, orgID, cacheKeys[queryName], missedSeries)
 
 		resultSeries := common.GetSeriesFromCachedDataV2(mergedSeries, start, end, builderQuery.StepInterval)
 
@@ -231,7 +231,7 @@ func (q *querier) runBuilderQuery(
 		return
 	}
 
-	misses := q.queryCache.FindMissingTimeRanges(orgID, start, end, builderQuery.StepInterval, cacheKeys[queryName])
+	misses := q.queryCache.FindMissingTimeRanges(ctx, orgID, start, end, builderQuery.StepInterval, cacheKeys[queryName])
 	q.logger.InfoContext(ctx, "cache misses for metrics query", "misses", misses)
 	missedSeries := make([]querycache.CachedSeriesData, 0)
 	for _, miss := range misses {
@@ -268,7 +268,7 @@ func (q *querier) runBuilderQuery(
 			End:   miss.End,
 		})
 	}
-	mergedSeries := q.queryCache.MergeWithCachedSeriesData(orgID, cacheKeys[queryName], missedSeries)
+	mergedSeries := q.queryCache.MergeWithCachedSeriesData(ctx, orgID, cacheKeys[queryName], missedSeries)
 
 	resultSeries := common.GetSeriesFromCachedData(mergedSeries, start, end)
 

--- a/pkg/query-service/app/querier/v2/querier.go
+++ b/pkg/query-service/app/querier/v2/querier.go
@@ -223,7 +223,7 @@ func (q *querier) runPromQueries(ctx context.Context, orgID valuer.UUID, params 
 				channelResults <- channelResult{Err: err, Name: queryName, Query: query.Query, Series: series}
 				return
 			}
-			misses := q.queryCache.FindMissingTimeRanges(orgID, params.Start, params.End, params.Step, cacheKey)
+			misses := q.queryCache.FindMissingTimeRanges(ctx, orgID, params.Start, params.End, params.Step, cacheKey)
 			q.logger.InfoContext(ctx, "cache misses for metrics prom query", "misses", misses)
 			missedSeries := make([]querycache.CachedSeriesData, 0)
 			for _, miss := range misses {
@@ -239,7 +239,7 @@ func (q *querier) runPromQueries(ctx context.Context, orgID valuer.UUID, params 
 					End:   miss.End,
 				})
 			}
-			mergedSeries := q.queryCache.MergeWithCachedSeriesData(orgID, cacheKey, missedSeries)
+			mergedSeries := q.queryCache.MergeWithCachedSeriesData(ctx, orgID, cacheKey, missedSeries)
 			resultSeries := common.GetSeriesFromCachedData(mergedSeries, params.Start, params.End)
 			channelResults <- channelResult{Err: nil, Name: queryName, Query: promQuery.Query, Series: resultSeries}
 		}(queryName, promQuery)

--- a/pkg/query-service/app/querier/v2/querier_test.go
+++ b/pkg/query-service/app/querier/v2/querier_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/SigNoz/signoz/pkg/cache"
 	"github.com/SigNoz/signoz/pkg/cache/cachetest"
 	"github.com/SigNoz/signoz/pkg/flagger/flaggertest"
@@ -27,7 +28,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
 	"github.com/SigNoz/signoz/pkg/valuer"
-	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -260,7 +260,7 @@ func TestV2FindMissingTimeRangesZeroFreshNess(t *testing.T) {
 			err = c.Set(context.Background(), orgID, cacheKey, &cacheableData, 0)
 			assert.NoError(t, err)
 
-			misses := qc.FindMissingTimeRanges(orgID, tc.requestedStart, tc.requestedEnd, tc.requestedStep, cacheKey)
+			misses := qc.FindMissingTimeRanges(context.Background(), orgID, tc.requestedStart, tc.requestedEnd, tc.requestedStep, cacheKey)
 			if len(misses) != len(tc.expectedMiss) {
 				t.Errorf("expected %d misses, got %d", len(tc.expectedMiss), len(misses))
 			}
@@ -480,7 +480,7 @@ func TestV2FindMissingTimeRangesWithFluxInterval(t *testing.T) {
 			err = c.Set(context.Background(), orgID, cacheKey, &cacheableData, 0)
 			assert.NoError(t, err)
 
-			misses := qc.FindMissingTimeRanges(orgID, tc.requestedStart, tc.requestedEnd, tc.requestedStep, cacheKey)
+			misses := qc.FindMissingTimeRanges(context.Background(), orgID, tc.requestedStart, tc.requestedEnd, tc.requestedStep, cacheKey)
 			if len(misses) != len(tc.expectedMiss) {
 				t.Errorf("expected %d misses, got %d", len(tc.expectedMiss), len(misses))
 			}

--- a/pkg/query-service/interfaces/interface.go
+++ b/pkg/query-service/interfaces/interface.go
@@ -120,9 +120,9 @@ type Querier interface {
 }
 
 type QueryCache interface {
-	FindMissingTimeRanges(orgID valuer.UUID, start, end int64, step int64, cacheKey string) []querycache.MissInterval
-	FindMissingTimeRangesV2(orgID valuer.UUID, start, end int64, step int64, cacheKey string) []querycache.MissInterval
-	MergeWithCachedSeriesData(orgID valuer.UUID, cacheKey string, newData []querycache.CachedSeriesData) []querycache.CachedSeriesData
-	StoreSeriesInCache(orgID valuer.UUID, cacheKey string, series []querycache.CachedSeriesData)
-	MergeWithCachedSeriesDataV2(orgID valuer.UUID, cacheKey string, series []querycache.CachedSeriesData) []querycache.CachedSeriesData
+	FindMissingTimeRanges(ctx context.Context, orgID valuer.UUID, start, end int64, step int64, cacheKey string) []querycache.MissInterval
+	FindMissingTimeRangesV2(ctx context.Context, orgID valuer.UUID, start, end int64, step int64, cacheKey string) []querycache.MissInterval
+	MergeWithCachedSeriesData(ctx context.Context, orgID valuer.UUID, cacheKey string, newData []querycache.CachedSeriesData) []querycache.CachedSeriesData
+	StoreSeriesInCache(ctx context.Context, orgID valuer.UUID, cacheKey string, series []querycache.CachedSeriesData)
+	MergeWithCachedSeriesDataV2(ctx context.Context, orgID valuer.UUID, cacheKey string, series []querycache.CachedSeriesData) []querycache.CachedSeriesData
 }

--- a/pkg/query-service/querycache/query_range_cache.go
+++ b/pkg/query-service/querycache/query_range_cache.go
@@ -70,7 +70,7 @@ func WithFluxInterval(fluxInterval time.Duration) QueryCacheOption {
 
 // FindMissingTimeRangesV2 is a new correct implementation of FindMissingTimeRanges
 // It takes care of any timestamps that were not queried due to rounding in the first version.
-func (q *queryCache) FindMissingTimeRangesV2(orgID valuer.UUID, start, end int64, step int64, cacheKey string) []MissInterval {
+func (q *queryCache) FindMissingTimeRangesV2(ctx context.Context, orgID valuer.UUID, start, end int64, step int64, cacheKey string) []MissInterval {
 	if q.cache == nil || cacheKey == "" {
 		return []MissInterval{{Start: start, End: end}}
 	}
@@ -82,7 +82,7 @@ func (q *queryCache) FindMissingTimeRangesV2(orgID valuer.UUID, start, end int64
 		return []MissInterval{{Start: start, End: end}}
 	}
 
-	cachedSeriesDataList := q.getCachedSeriesData(orgID, cacheKey)
+	cachedSeriesDataList := q.getCachedSeriesData(ctx, orgID, cacheKey)
 
 	// Sort the cached data by start time
 	sort.Slice(cachedSeriesDataList, func(i, j int) bool {
@@ -170,12 +170,12 @@ func (q *queryCache) FindMissingTimeRangesV2(orgID valuer.UUID, start, end int64
 	return merged
 }
 
-func (q *queryCache) FindMissingTimeRanges(orgID valuer.UUID, start, end, step int64, cacheKey string) []MissInterval {
+func (q *queryCache) FindMissingTimeRanges(ctx context.Context, orgID valuer.UUID, start, end, step int64, cacheKey string) []MissInterval {
 	if q.cache == nil || cacheKey == "" {
 		return []MissInterval{{Start: start, End: end}}
 	}
 
-	cachedSeriesDataList := q.getCachedSeriesData(orgID, cacheKey)
+	cachedSeriesDataList := q.getCachedSeriesData(ctx, orgID, cacheKey)
 
 	// Sort the cached data by start time
 	sort.Slice(cachedSeriesDataList, func(i, j int) bool {
@@ -236,10 +236,11 @@ func (q *queryCache) FindMissingTimeRanges(orgID valuer.UUID, start, end, step i
 	return missingRanges
 }
 
-func (q *queryCache) getCachedSeriesData(orgID valuer.UUID, cacheKey string) []*CachedSeriesData {
+func (q *queryCache) getCachedSeriesData(ctx context.Context, orgID valuer.UUID, cacheKey string) []*CachedSeriesData {
 	cacheableSeriesData := new(CacheableSeriesData)
-	err := q.cache.Get(context.TODO(), orgID, cacheKey, cacheableSeriesData)
+	err := q.cache.Get(ctx, orgID, cacheKey, cacheableSeriesData)
 	if err != nil && !errors.Ast(err, errors.TypeNotFound) {
+		slog.ErrorContext(ctx, "error reading cached series data", "cache_key", cacheKey, errors.Attr(err))
 		return nil
 	}
 	cachedSeriesData := make([]*CachedSeriesData, 0)
@@ -286,26 +287,27 @@ func (q *queryCache) mergeSeries(cachedSeries, missedSeries []*v3.Series) []*v3.
 	return mergedSeries
 }
 
-func (q *queryCache) storeMergedData(orgID valuer.UUID, cacheKey string, mergedData []CachedSeriesData) {
+func (q *queryCache) storeMergedData(ctx context.Context, orgID valuer.UUID, cacheKey string, mergedData []CachedSeriesData) {
 	if q.cache == nil {
 		return
 	}
 	cacheableSeriesData := CacheableSeriesData{Series: mergedData}
-	err := q.cache.Set(context.TODO(), orgID, cacheKey, &cacheableSeriesData, 0)
+	err := q.cache.Set(ctx, orgID, cacheKey, &cacheableSeriesData, 0)
 	if err != nil {
-		slog.Error("error storing merged data", errors.Attr(err))
+		slog.ErrorContext(ctx, "error storing merged data", "cache_key", cacheKey, errors.Attr(err))
 	}
 }
 
-func (q *queryCache) MergeWithCachedSeriesDataV2(orgID valuer.UUID, cacheKey string, newData []CachedSeriesData) []CachedSeriesData {
+func (q *queryCache) MergeWithCachedSeriesDataV2(ctx context.Context, orgID valuer.UUID, cacheKey string, newData []CachedSeriesData) []CachedSeriesData {
 	if q.cache == nil {
 		return newData
 	}
 
 	cacheableSeriesData := new(CacheableSeriesData)
-	err := q.cache.Get(context.TODO(), orgID, cacheKey, cacheableSeriesData)
+	err := q.cache.Get(ctx, orgID, cacheKey, cacheableSeriesData)
 	if err != nil && !errors.Ast(err, errors.TypeNotFound) {
-		return nil
+		slog.ErrorContext(ctx, "error reading cached series data; using fresh query data", "cache_key", cacheKey, errors.Attr(err))
+		return newData
 	}
 	allData := append(cacheableSeriesData.Series, newData...)
 
@@ -351,13 +353,13 @@ func (q *queryCache) MergeWithCachedSeriesDataV2(orgID valuer.UUID, cacheKey str
 	return mergedData
 }
 
-func (q *queryCache) MergeWithCachedSeriesData(orgID valuer.UUID, cacheKey string, newData []CachedSeriesData) []CachedSeriesData {
+func (q *queryCache) MergeWithCachedSeriesData(ctx context.Context, orgID valuer.UUID, cacheKey string, newData []CachedSeriesData) []CachedSeriesData {
 
-	mergedData := q.MergeWithCachedSeriesDataV2(orgID, cacheKey, newData)
-	q.storeMergedData(orgID, cacheKey, mergedData)
+	mergedData := q.MergeWithCachedSeriesDataV2(ctx, orgID, cacheKey, newData)
+	q.storeMergedData(ctx, orgID, cacheKey, mergedData)
 	return mergedData
 }
 
-func (q *queryCache) StoreSeriesInCache(orgID valuer.UUID, cacheKey string, series []CachedSeriesData) {
-	q.storeMergedData(orgID, cacheKey, series)
+func (q *queryCache) StoreSeriesInCache(ctx context.Context, orgID valuer.UUID, cacheKey string, series []CachedSeriesData) {
+	q.storeMergedData(ctx, orgID, cacheKey, series)
 }

--- a/pkg/query-service/querycache/query_range_cache_test.go
+++ b/pkg/query-service/querycache/query_range_cache_test.go
@@ -2,12 +2,15 @@ package querycache_test
 
 import (
 	"context"
+	stderrors "errors"
 	"testing"
+	"time"
 
 	"github.com/SigNoz/signoz/pkg/cache"
 	"github.com/SigNoz/signoz/pkg/cache/cachetest"
 	v3 "github.com/SigNoz/signoz/pkg/query-service/model/v3"
 	"github.com/SigNoz/signoz/pkg/query-service/querycache"
+	"github.com/SigNoz/signoz/pkg/types/cachetypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -231,7 +234,7 @@ func TestFindMissingTimeRanges(t *testing.T) {
 			}
 
 			// Call FindMissingTimeRanges
-			missingRanges := q.FindMissingTimeRanges(orgID, tc.requestedStart, tc.requestedEnd, tc.step, tc.cacheKey)
+			missingRanges := q.FindMissingTimeRanges(context.Background(), orgID, tc.requestedStart, tc.requestedEnd, tc.step, tc.cacheKey)
 
 			// Verify the missing ranges
 			assert.Equal(t, tc.expectedMiss, missingRanges)
@@ -578,7 +581,7 @@ func TestFindMissingTimeRangesV2(t *testing.T) {
 			}
 
 			// Call FindMissingTimeRanges
-			missingRanges := q.FindMissingTimeRangesV2(orgID, tc.requestedStart, tc.requestedEnd, tc.step, tc.cacheKey)
+			missingRanges := q.FindMissingTimeRangesV2(context.Background(), orgID, tc.requestedStart, tc.requestedEnd, tc.step, tc.cacheKey)
 
 			// Verify the missing ranges
 			assert.Equal(t, tc.expectedMiss, missingRanges)
@@ -673,7 +676,7 @@ func TestMergeWithCachedSeriesData(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Call MergeWithCachedSeriesData
-	mergedData := q.MergeWithCachedSeriesData(orgID, cacheKey, newData)
+	mergedData := q.MergeWithCachedSeriesData(context.Background(), orgID, cacheKey, newData)
 
 	// Verify the merged data
 	assert.Equal(t, len(expectedMergedData), len(mergedData))
@@ -693,4 +696,55 @@ func TestMergeWithCachedSeriesData(t *testing.T) {
 			}
 		}
 	}
+}
+
+type recordingErrorCache struct {
+	cache.Cache
+	getCtx context.Context
+	setCtx context.Context
+}
+
+func (c *recordingErrorCache) Get(ctx context.Context, _ valuer.UUID, _ string, _ cachetypes.Cacheable) error {
+	c.getCtx = ctx
+	return stderrors.New("cache unavailable")
+}
+
+func (c *recordingErrorCache) Set(ctx context.Context, _ valuer.UUID, _ string, _ cachetypes.Cacheable, _ time.Duration) error {
+	c.setCtx = ctx
+	return nil
+}
+
+type cacheContextKey struct{}
+
+func TestMergeWithCachedSeriesDataV2ReturnsFreshDataOnCacheFailure(t *testing.T) {
+	c := &recordingErrorCache{}
+	q := querycache.NewQueryCache(querycache.WithCache(c))
+	ctx := context.WithValue(context.Background(), cacheContextKey{}, "request-context")
+	newData := []querycache.CachedSeriesData{
+		{
+			Start: 1000,
+			End:   2000,
+			Data: []*v3.Series{
+				{
+					Labels: map[string]string{"metric": "cpu"},
+					Points: []v3.Point{{Timestamp: 1500, Value: 0.5}},
+				},
+			},
+		},
+	}
+
+	mergedData := q.MergeWithCachedSeriesDataV2(ctx, valuer.GenerateUUID(), "cache-key", newData)
+
+	require.Equal(t, newData, mergedData)
+	require.Equal(t, "request-context", c.getCtx.Value(cacheContextKey{}))
+}
+
+func TestStoreSeriesInCachePropagatesContext(t *testing.T) {
+	c := &recordingErrorCache{}
+	q := querycache.NewQueryCache(querycache.WithCache(c))
+	ctx := context.WithValue(context.Background(), cacheContextKey{}, "request-context")
+
+	q.StoreSeriesInCache(ctx, valuer.GenerateUUID(), "cache-key", nil)
+
+	require.Equal(t, "request-context", c.setCtx.Value(cacheContextKey{}))
 }


### PR DESCRIPTION
## Summary

  This PR prevents operational cache failures from erasing successfully queried telemetry data.

  When `MergeWithCachedSeriesDataV2` encountered a cache read error other than a cache miss, it returned `nil`. By that point,
  the querier had already fetched fresh data successfully from ClickHouse, but the `nil` result replaced that data before the
  response was constructed.

  As a result, transient Redis or cache-provider incidents could cause successful telemetry queries to appear as empty charts.

  This PR changes the cache to behave as an optional optimization rather than a correctness dependency.

  ## Root Cause

  `MergeWithCachedSeriesDataV2` previously handled operational cache errors as follows:

  ```go
  if err != nil && !errors.Ast(err, errors.TypeNotFound) {
      return nil
  }

  The caller had already populated newData with fresh ClickHouse results. Returning nil discarded those results and caused the
  final response to contain no telemetry.

  Additionally, query-cache reads and writes used context.TODO():

  q.cache.Get(context.TODO(), ...)
  q.cache.Set(context.TODO(), ...)

  This detached cache operations from the original query lifecycle, preventing:

  - Request cancellation from reaching the cache provider.
  - Request deadlines from being respected.
  - Trace and request-scoped values from propagating.
  - Context-aware logging and instrumentation.

  ## Changes

  ### Preserve fresh telemetry on cache read failures

  MergeWithCachedSeriesDataV2 now returns newData when the cache provider returns an operational error:

  if err != nil && !errors.Ast(err, errors.TypeNotFound) {
      slog.ErrorContext(
          ctx,
          "error reading cached series data; using fresh query data",
          "cache_key",
          cacheKey,
          errors.Attr(err),
      )
      return newData
  }

  A cache failure can therefore reduce cache effectiveness, but it no longer changes a successful query into an empty response.

  Cache misses continue to follow the existing behavior and are not logged as operational failures.

  ### Log operational cache failures

  Cache read and write failures are now logged with:

  - The caller context.
  - The affected cache key.
  - The underlying error.

  This makes cache incidents observable while allowing telemetry queries to continue using fresh data.

  ### Propagate the caller context

  The query-cache interface now accepts context.Context for:

  - FindMissingTimeRanges
  - FindMissingTimeRangesV2
  - MergeWithCachedSeriesData
  - MergeWithCachedSeriesDataV2
  - StoreSeriesInCache

  The original query context is passed through both the legacy and v2 querier implementations.

  All related context.TODO() cache operations were replaced with the caller-provided context.

  ## Behavior Before

  1. The querier fetched telemetry successfully from ClickHouse.
  2. The querier attempted to read previously cached series.
  3. Redis or another cache provider returned an operational error.
  4. MergeWithCachedSeriesDataV2 returned nil.
  5. The fresh ClickHouse data was discarded.
  6. The user received an empty chart despite the successful database query.

  ## Behavior After

  1. The querier fetches telemetry successfully from ClickHouse.
  2. The cache provider returns an operational error.
  3. The error is logged with the request context and cache key.
  4. MergeWithCachedSeriesDataV2 returns the fresh ClickHouse data.
  5. The user receives the successfully queried telemetry.

  ## Tests Added

  Added regression coverage to verify that:

  - An operational cache read failure returns fresh query data.
  - The original request context reaches cache reads.
  - The original request context reaches cache writes.

  Existing query-cache tests were updated for the context-aware API.

  ## Validation

  The following checks pass using the repository-declared Go 1.25.7 toolchain:

  GOTOOLCHAIN=go1.25.7 go test ./pkg/query-service/querycache -count=1
  GOTOOLCHAIN=go1.25.7 go test ./pkg/query-service/app/querier/... -count=1
  GOTOOLCHAIN=go1.25.7 go test -race ./pkg/query-service/querycache \
      -run 'Test(MergeWithCachedSeriesDataV2ReturnsFreshDataOnCacheFailure|StoreSeriesInCachePropagatesContext)' \
      -count=1
  GOTOOLCHAIN=go1.25.7 go vet \
      ./pkg/query-service/querycache \
      ./pkg/query-service/app/querier/...
  git diff --check

  ## Risk Assessment

  Risk is low.

  The successful-cache and cache-miss merge behavior remains unchanged. The behavioral difference is limited to operational
  cache failures, where fresh query data is now retained instead of being replaced with nil.

  The query-cache interface changed to accept a context, and all in-repository callers in both querier implementations were
  updated.

  ## Change Type

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [x] Tests
  - [ ] Documentation update

  ## Checklist

  - [x] Fresh ClickHouse data is preserved when cache reads fail.
  - [x] Cache misses retain their existing behavior.
  - [x] Operational cache errors are logged.
  - [x] Cache keys are included in error logs.
  - [x] Request context propagates through cache reads.
  - [x] Request context propagates through cache writes.
  - [x] Legacy querier call sites were updated.
  - [x] V2 querier call sites were updated.
  - [x] Regression tests were added.
  - [x] Existing query-cache tests pass.
  - [x] Querier tests pass.
  - [x] Race detector passes.
  - [x] go vet passes.
