### PR TITLE
feat(gcp): tooltips on cloud account setup drawer field labels

### DIFF
--- a/frontend/src/container/Integrations/CloudIntegration/GoogleCloudPlatform/AddNewAccount/CloudAccountSetupDrawer.module.scss
+++ b/frontend/src/container/Integrations/CloudIntegration/GoogleCloudPlatform/AddNewAccount/CloudAccountSetupDrawer.module.scss
@@ -69,10 +69,6 @@
 	composes: drawerSection from './shared.module.scss';
 }
 
-.required {
-	composes: required from './shared.module.scss';
-}
-
 .mono {
 	composes: mono from './shared.module.scss';
 }

--- a/frontend/src/container/Integrations/CloudIntegration/GoogleCloudPlatform/AddNewAccount/CloudAccountSetupDrawer.tsx
+++ b/frontend/src/container/Integrations/CloudIntegration/GoogleCloudPlatform/AddNewAccount/CloudAccountSetupDrawer.tsx
@@ -13,6 +13,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { popupContainer } from 'utils/selectPopupContainer';
 
 import ConnectionSecretsFields from './ConnectionSecretsFields';
+import FieldLabel from './FieldLabel';
 import FlowSelector from './FlowSelector';
 import { GcpSetupFormValues, SetupFlow } from './types';
 
@@ -126,12 +127,12 @@ function CloudAccountSetupDrawer({
 					}
 				/> */}
 			<div className={styles.drawerSection}>
-				<label htmlFor="gcp-account-name-input">
-					Account Name{' '}
-					<span className={styles.required} aria-hidden="true">
-						*
-					</span>
-				</label>
+				<FieldLabel
+					htmlFor="gcp-account-name-input"
+					label="Account Name"
+					tooltip="A label to identify this group of GCP projects (org ID, billing email, or any descriptive name)"
+					required
+				/>
 				<Controller
 					name="accountName"
 					control={control}
@@ -161,12 +162,12 @@ function CloudAccountSetupDrawer({
 				/>
 			</div>
 			<div className={styles.drawerSection}>
-				<label htmlFor="gcp-deployment-project-id-input">
-					Deployment Project ID{' '}
-					<span className={styles.required} aria-hidden="true">
-						*
-					</span>
-				</label>
+				<FieldLabel
+					htmlFor="gcp-deployment-project-id-input"
+					label="Deployment Project ID"
+					tooltip="The GCP project that hosts your OTel Collector deployment — often separate from the projects you actually monitor"
+					required
+				/>
 				<Controller
 					name="deploymentProjectId"
 					control={control}
@@ -196,12 +197,12 @@ function CloudAccountSetupDrawer({
 				/>
 			</div>
 			<div className={styles.drawerSection}>
-				<label htmlFor="gcp-deployment-region-select">
-					Deployment Region{' '}
-					<span className={styles.required} aria-hidden="true">
-						*
-					</span>
-				</label>
+				<FieldLabel
+					htmlFor="gcp-deployment-region-select"
+					label="Deployment Region"
+					tooltip="The GCP region where your OTel Collector will be deployed"
+					required
+				/>
 				<Controller
 					name="deploymentRegion"
 					control={control}
@@ -234,12 +235,12 @@ function CloudAccountSetupDrawer({
 				/>
 			</div>
 			<div className={styles.drawerSection}>
-				<label htmlFor="gcp-project-ids-select">
-					Projects to Monitor{' '}
-					<span className={styles.required} aria-hidden="true">
-						*
-					</span>
-				</label>
+				<FieldLabel
+					htmlFor="gcp-project-ids-select"
+					label="Projects to Monitor"
+					tooltip="Enter each GCP project ID then press Enter"
+					required
+				/>
 				<Controller
 					name="projectIds"
 					control={control}

--- a/frontend/src/container/Integrations/CloudIntegration/GoogleCloudPlatform/AddNewAccount/ConnectionSecretsFields.tsx
+++ b/frontend/src/container/Integrations/CloudIntegration/GoogleCloudPlatform/AddNewAccount/ConnectionSecretsFields.tsx
@@ -10,6 +10,7 @@ import cx from 'classnames';
 import { Control, Controller } from 'react-hook-form';
 import { useCopyToClipboard } from 'react-use';
 
+import FieldLabel from './FieldLabel';
 import { GcpSetupFormValues } from './types';
 import { SecretFieldType, validateSecretValue } from './validators';
 import styles from './ConnectionSecretsFields.module.scss';
@@ -19,6 +20,7 @@ type CredentialField = keyof CloudintegrationtypesCredentialsDTO;
 interface FieldConfig {
 	name: CredentialField;
 	label: string;
+	tooltip: string;
 	placeholder: string;
 	testId: string;
 	type: SecretFieldType;
@@ -28,6 +30,7 @@ const FIELDS: FieldConfig[] = [
 	{
 		name: 'sigNozApiUrl',
 		label: 'SigNoz API URL',
+		tooltip: 'Base URL of your SigNoz instance the collector reports to',
 		placeholder: 'https://<tenant>.signoz.cloud',
 		testId: 'gcp-signoz-api-url-input',
 		type: 'url',
@@ -35,6 +38,7 @@ const FIELDS: FieldConfig[] = [
 	{
 		name: 'sigNozApiKey',
 		label: 'SigNoz API Key',
+		tooltip: 'API key used to authenticate with your SigNoz instance',
 		placeholder: 'Enter SigNoz API key',
 		testId: 'gcp-signoz-api-key-input',
 		type: 'text',
@@ -42,6 +46,7 @@ const FIELDS: FieldConfig[] = [
 	{
 		name: 'ingestionUrl',
 		label: 'Ingestion URL',
+		tooltip: 'OTLP ingestion endpoint your OTel Collector sends telemetry to',
 		placeholder: 'https://ingest.<region>.signoz.cloud',
 		testId: 'gcp-ingestion-url-input',
 		type: 'url',
@@ -49,6 +54,7 @@ const FIELDS: FieldConfig[] = [
 	{
 		name: 'ingestionKey',
 		label: 'Ingestion Key',
+		tooltip: 'Ingestion key that authorizes telemetry sent to SigNoz',
 		placeholder: 'Enter ingestion key',
 		testId: 'gcp-ingestion-key-input',
 		type: 'text',
@@ -112,7 +118,11 @@ function ConnectionSecretsFields({
 						if (providedValue) {
 							return (
 								<div key={field.name} className={styles.drawerSection}>
-									<label htmlFor={field.testId}>{field.label}</label>
+									<FieldLabel
+										htmlFor={field.testId}
+										label={field.label}
+										tooltip={field.tooltip}
+									/>
 									<div className={styles.readonlyField}>
 										<Typography.Text
 											as="span"
@@ -142,7 +152,11 @@ function ConnectionSecretsFields({
 
 						return (
 							<div key={field.name} className={styles.drawerSection}>
-								<label htmlFor={field.testId}>{field.label}</label>
+								<FieldLabel
+									htmlFor={field.testId}
+									label={field.label}
+									tooltip={field.tooltip}
+								/>
 								<Controller
 									name={field.name}
 									control={control}

--- a/frontend/src/container/Integrations/CloudIntegration/GoogleCloudPlatform/AddNewAccount/FieldLabel.module.scss
+++ b/frontend/src/container/Integrations/CloudIntegration/GoogleCloudPlatform/AddNewAccount/FieldLabel.module.scss
@@ -1,0 +1,16 @@
+.fieldLabel {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--spacing-2);
+}
+
+.required {
+	composes: required from './shared.module.scss';
+}
+
+.infoTrigger {
+	display: inline-flex;
+	align-items: center;
+	color: var(--l3-foreground);
+	cursor: help;
+}

--- a/frontend/src/container/Integrations/CloudIntegration/GoogleCloudPlatform/AddNewAccount/FieldLabel.tsx
+++ b/frontend/src/container/Integrations/CloudIntegration/GoogleCloudPlatform/AddNewAccount/FieldLabel.tsx
@@ -1,0 +1,44 @@
+import { Info } from '@signozhq/icons';
+import { TooltipSimple } from '@signozhq/ui/tooltip';
+
+import styles from './FieldLabel.module.scss';
+
+interface FieldLabelProps {
+	htmlFor: string;
+	label: string;
+	tooltip: string;
+	required?: boolean;
+}
+
+function FieldLabel({
+	htmlFor,
+	label,
+	tooltip,
+	required,
+}: FieldLabelProps): JSX.Element {
+	return (
+		<label className={styles.fieldLabel} htmlFor={htmlFor}>
+			{label}
+			{required && (
+				<span className={styles.required} aria-hidden="true">
+					*
+				</span>
+			)}
+			<TooltipSimple title={tooltip} side="top">
+				<span
+					className={styles.infoTrigger}
+					aria-label={`${label} help`}
+					data-testid={`${htmlFor}-tooltip`}
+				>
+					<Info size={12} />
+				</span>
+			</TooltipSimple>
+		</label>
+	);
+}
+
+FieldLabel.defaultProps = {
+	required: false,
+};
+
+export default FieldLabel;


### PR DESCRIPTION
## What

Adds an info-icon tooltip next to each field label in the GCP **Connect account** setup drawer.

Introduces a small reusable `FieldLabel` component (label + optional required marker + `TooltipSimple` info icon) and applies it to all 8 fields across `CloudAccountSetupDrawer` and `ConnectionSecretsFields`.

## Tooltips

| Field | Tooltip |
|---|---|
| Account Name | A label to identify this group of GCP projects (org ID, billing email, or any descriptive name) |
| Deployment Project ID | The GCP project that hosts your OTel Collector deployment — often separate from the projects you actually monitor |
| Deployment Region | The GCP region where your OTel Collector will be deployed |
| Projects to Monitor | Enter each GCP project ID then press Enter |
| SigNoz API URL | Base URL of your SigNoz instance the collector reports to |
| SigNoz API Key | API key used to authenticate with your SigNoz instance |
| Ingestion URL | OTLP ingestion endpoint your OTel Collector sends telemetry to |
| Ingestion Key | Ingestion key that authorizes telemetry sent to SigNoz |

_(Deployment Project ID copy written by me per request — please tweak if you'd prefer different wording.)_

## Notes
- Also removed the now-dead `.required` class from `CloudAccountSetupDrawer.module.scss` (moved into `FieldLabel`).
- Verified: `tsgo --noEmit` clean, `oxlint`/`stylelint` clean (pre-commit). No existing tests cover these files.