### PR TITLE
fix(opamp): reject invalid agent instance IDs

### DIFF
--- a/pkg/query-service/app/opamp/model/agents.go
+++ b/pkg/query-service/app/opamp/model/agents.go
@@ -74,8 +74,9 @@ func (agents *Agents) FindAgent(agentID string) *Agent {
 // If the Agent instance does not exist, it is created and added to the list of
 // Agent instances.
 func (agents *Agents) FindOrCreateAgent(agentID string, conn types.Connection, orgID valuer.UUID) (*Agent, bool, error) {
-	if agentID == "" {
-		return nil, false, errors.New("cannot create agent without agentID")
+	parsedAgentID, err := valuer.NewUUID(agentID)
+	if err != nil || parsedAgentID.IsZero() {
+		return nil, false, errors.New("cannot create agent with invalid agentID")
 	}
 
 	agents.mux.Lock()
@@ -91,7 +92,7 @@ func (agents *Agents) FindOrCreateAgent(agentID string, conn types.Connection, o
 	}
 
 	agent = New(agents.store, agents.logger, orgID, agentID, conn)
-	err := agent.Upsert()
+	err = agent.Upsert()
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/query-service/app/opamp/model/agents_test.go
+++ b/pkg/query-service/app/opamp/model/agents_test.go
@@ -1,0 +1,39 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindOrCreateAgentRejectsInvalidAgentID(t *testing.T) {
+	tests := []struct {
+		name    string
+		agentID string
+	}{
+		{
+			name: "missing agent ID",
+		},
+		{
+			name:    "malformed agent ID",
+			agentID: "not-a-uuid",
+		},
+		{
+			name:    "zero agent ID",
+			agentID: "00000000-0000-0000-0000-000000000000",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			agents := &Agents{}
+
+			agent, created, err := agents.FindOrCreateAgent(test.agentID, nil, valuer.UUID{})
+
+			require.ErrorContains(t, err, "invalid agentID")
+			require.Nil(t, agent)
+			require.False(t, created)
+		})
+	}
+}

--- a/pkg/query-service/app/opamp/opamp_server.go
+++ b/pkg/query-service/app/opamp/opamp_server.go
@@ -101,7 +101,25 @@ func (srv *Server) onDisconnect(conn types.Connection) {
 // orgID from the context
 // note :- there can only be 50 agents in the db for a given orgID, we don't have a check in-memory but we delete from the db after insert.
 func (srv *Server) OnMessage(ctx context.Context, conn types.Connection, msg *protobufs.AgentToServer) *protobufs.ServerToAgent {
-	agentID, _ := valuer.NewUUIDFromBytes(msg.GetInstanceUid())
+	instanceUID := msg.GetInstanceUid()
+	agentID, err := valuer.NewUUIDFromBytes(instanceUID)
+	if err != nil || agentID.IsZero() {
+		logArgs := []any{
+			"instance_uid_length", len(instanceUID),
+		}
+		if err != nil {
+			logArgs = append(logArgs, errors.Attr(err))
+		}
+		srv.logger.WarnContext(ctx, "rejected OpAMP message with invalid agent instance UID", logArgs...)
+
+		return &protobufs.ServerToAgent{
+			InstanceUid: instanceUID,
+			ErrorResponse: &protobufs.ServerErrorResponse{
+				Type:         protobufs.ServerErrorResponseType_ServerErrorResponseType_BadRequest,
+				ErrorMessage: "instance UID must be a non-zero 16-byte value",
+			},
+		}
+	}
 
 	// find the orgID, if nothing is found keep it empty.
 	// the find or create agent will return an error if orgID is empty

--- a/pkg/query-service/app/opamp/opamp_server_test.go
+++ b/pkg/query-service/app/opamp/opamp_server_test.go
@@ -1,0 +1,54 @@
+package opamp
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnMessageRejectsInvalidInstanceUID(t *testing.T) {
+	tests := []struct {
+		name        string
+		instanceUID []byte
+	}{
+		{
+			name: "missing instance UID",
+		},
+		{
+			name:        "short instance UID",
+			instanceUID: []byte("too-short"),
+		},
+		{
+			name:        "long instance UID",
+			instanceUID: []byte("longer-than-16-bytes"),
+		},
+		{
+			name:        "zero instance UID",
+			instanceUID: make([]byte, 16),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := &Server{
+				logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+			msg := &protobufs.AgentToServer{InstanceUid: test.instanceUID}
+
+			response := srv.OnMessage(context.Background(), nil, msg)
+
+			require.Equal(t, test.instanceUID, response.GetInstanceUid())
+			require.NotNil(t, response.GetErrorResponse())
+			require.Equal(
+				t,
+				protobufs.ServerErrorResponseType_ServerErrorResponseType_BadRequest,
+				response.GetErrorResponse().GetType(),
+			)
+			require.Equal(t, "instance UID must be a non-zero 16-byte value", response.GetErrorResponse().GetErrorMessage())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

  This PR prevents malformed OpAMP agent instance IDs from being silently converted into the zero UUID.

  Previously, the error returned by `valuer.NewUUIDFromBytes` was discarded. If an agent supplied a missing or incorrectly sized
  `InstanceUid`, UUID parsing failed and returned the zero-value UUID:

  ```text
  00000000-0000-0000-0000-000000000000

  Because the zero UUID has a non-empty string representation, it passed the existing empty-string validation in
  FindOrCreateAgent.

  Multiple malformed agents could therefore be registered under the same identifier and share connection, status, and
  configuration state.

  ## Root Cause

  The OpAMP message handler ignored UUID parsing errors:

  agentID, _ := valuer.NewUUIDFromBytes(msg.GetInstanceUid())

  The resulting zero UUID was converted to a non-empty string and passed to the registry:

  srv.agents.FindOrCreateAgent(agentID.String(), conn, orgID)

  FindOrCreateAgent only rejected an empty string:

  if agentID == "" {
      return nil, false, errors.New("cannot create agent without agentID")
  }

  It did not reject:

  - Malformed UUID strings.
  - Missing UUIDs converted into the zero UUID.
  - Explicit zero UUIDs.

  ## Changes

  ### Validate InstanceUid before registry access

  The OpAMP server now checks the error returned by valuer.NewUUIDFromBytes.

  It also explicitly rejects the zero UUID:

  agentID, err := valuer.NewUUIDFromBytes(instanceUID)
  if err != nil || agentID.IsZero() {
      // Return BadRequest without accessing the registry.
  }

  Invalid messages are rejected before:

  - Looking up the organization.
  - Looking up or creating an agent.
  - Updating connection state.
  - Processing agent status.
  - Recommending configuration.

  ### Return an OpAMP BadRequest response

  Malformed IDs represent an invalid agent request rather than a temporary server failure.

  The server now returns:

  &protobufs.ServerErrorResponse{
      Type: protobufs.ServerErrorResponseType_ServerErrorResponseType_BadRequest,
      ErrorMessage: "instance UID must be a non-zero 16-byte value",
  }

  The original InstanceUid remains attached to the response as required for request correlation.

  The response does not include retry information because retrying the same malformed identifier would not resolve the problem.

  ### Add defensive registry validation

  FindOrCreateAgent now independently validates the supplied agent ID as a UUID and rejects the zero UUID:

  parsedAgentID, err := valuer.NewUUID(agentID)
  if err != nil || parsedAgentID.IsZero() {
      return nil, false, errors.New(
          "cannot create agent with invalid agentID",
      )
  }

  This protects the registry if it is called from another code path in the future without passing through the OpAMP server
  validation.

  ### Add contextual logging

  Rejected OpAMP messages are logged with:

  - The request context.
  - The supplied InstanceUid length.
  - The parsing error, when available.

  The raw identifier is not written to the log.

  ## Behavior Before

  1. An agent sent a missing or malformed InstanceUid.
  2. UUID parsing failed.
  3. The parsing error was discarded.
  4. The zero UUID was converted into a non-empty string.
  5. The agent registry accepted the value.
  6. Multiple malformed agents could share the same registry entry.
  7. Connection, status, and configuration state could be overwritten or delivered to the wrong agent.

  ## Behavior After

  1. An agent sends a missing, malformed, or zero InstanceUid.
  2. The server detects the invalid value immediately.
  3. The message is rejected before registry or organization access.
  4. The agent receives an OpAMP BadRequest response.
  5. No agent, connection, status, or configuration state is created or modified.

  ## Tests Added

  ### OpAMP server tests

  Added table-driven coverage for:

  - Missing InstanceUid.
  - An InstanceUid shorter than 16 bytes.
  - An InstanceUid longer than 16 bytes.
  - A 16-byte all-zero InstanceUid.

  Each case verifies that:

  - The handler returns an error response.
  - The response type is BadRequest.
  - The error message explains the required identifier format.
  - The malformed identifier is returned for request correlation.
  - Validation occurs before registry access.

  ### Agent registry tests

  Added table-driven coverage confirming that FindOrCreateAgent rejects:

  - An empty agent ID.
  - A malformed UUID string.
  - The canonical zero UUID string.

  Each case verifies that no agent is returned or created.

  ## Validation

  The following checks pass using the repository-declared Go 1.25.7 toolchain:

  GOTOOLCHAIN=go1.25.7 go test \
      ./pkg/query-service/app/opamp \
      ./pkg/query-service/app/opamp/model \
      -count=1

  GOTOOLCHAIN=go1.25.7 go test -race \
      ./pkg/query-service/app/opamp \
      ./pkg/query-service/app/opamp/model \
      -count=1

  GOTOOLCHAIN=go1.25.7 go vet \
      ./pkg/query-service/app/opamp \
      ./pkg/query-service/app/opamp/model

  git diff --check

  All checks pass.

  > The race build emits a non-failing macOS linker warning about LC_DYSYMTAB. Both test packages still complete successfully.

  ## Risk Assessment

  Risk is low.

  The change only affects messages containing:

  - A missing instance ID.
  - An incorrectly sized instance ID.
  - An all-zero instance ID.

  Valid 16-byte, non-zero OpAMP instance IDs continue through the existing registration and message-processing flow unchanged.

  The registry validation is stricter, but all normal server calls already provide canonical UUID strings.


