### PR TITLE
fix(pagination): preserve totals for out-of-range pages

### DIFF
--- a/pkg/modules/dashboard/impldashboard/store.go
+++ b/pkg/modules/dashboard/impldashboard/store.go
@@ -122,10 +122,16 @@ func (store *store) ListForUser(
 	}
 
 	// COUNT(*) OVER () is computed pre-LIMIT, so any returned row carries the
-	// full filter total. Empty result page => zero matches.
+	// full filter total. An empty page with a non-zero offset needs a separate
+	// count because the window function has no row on which to return its value.
 	var total int64
 	if len(rows) > 0 {
 		total = rows[0].Total
+	} else if params.Offset > 0 {
+		total, err = store.countListV2(ctx, orgID, compiled)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 
 	out := make([]*dashboardtypes.StorableDashboardWithPinInfo, len(rows))
@@ -184,10 +190,16 @@ func (store *store) ListV2(
 	}
 
 	// COUNT(*) OVER () is computed pre-LIMIT, so any returned row carries the
-	// full filter total. Empty result page => zero matches.
+	// full filter total. An empty page with a non-zero offset needs a separate
+	// count because the window function has no row on which to return its value.
 	var total int64
 	if len(rows) > 0 {
 		total = rows[0].Total
+	} else if params.Offset > 0 {
+		total, err = store.countListV2(ctx, orgID, compiled)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 
 	out := make([]*dashboardtypes.StorableDashboard, len(rows))
@@ -195,6 +207,25 @@ func (store *store) ListV2(
 		out[i] = r.StorableDashboard
 	}
 	return out, total, nil
+}
+
+func (store *store) countListV2(ctx context.Context, orgID valuer.UUID, compiled *Compiled) (int64, error) {
+	q := store.sqlstore.
+		BunDB().
+		NewSelect().
+		Model((*dashboardtypes.StorableDashboard)(nil)).
+		Where("dashboard.org_id = ?", orgID).
+		Where("dashboard.source != ?", dashboardtypes.SourceSystem)
+
+	if !compiled.IsEmpty() {
+		q = q.Where(compiled.SQL, compiled.Args...)
+	}
+
+	total, err := q.Count(ctx)
+	if err != nil {
+		return 0, errors.WrapInternalf(err, errors.CodeInternal, "couldn't count dashboards")
+	}
+	return int64(total), nil
 }
 
 // sortExprForListV2 maps a sort enum to the SQL expression to plug into

--- a/pkg/modules/dashboard/impldashboard/store_test.go
+++ b/pkg/modules/dashboard/impldashboard/store_test.go
@@ -1,9 +1,18 @@
 package impldashboard
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/SigNoz/signoz/pkg/factory/factorytest"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/sqlstore/sqlitesqlstore"
+	"github.com/SigNoz/signoz/pkg/types/dashboardtypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildContainsAnyClauseForDataColumn(t *testing.T) {
@@ -40,4 +49,70 @@ func TestBuildContainsAnyClauseForDataColumn(t *testing.T) {
 			assert.Equal(t, c.expectedArgs, args)
 		})
 	}
+}
+
+func newDashboardTestStore(t *testing.T) sqlstore.SQLStore {
+	t.Helper()
+	store, err := sqlitesqlstore.New(context.Background(), factorytest.NewSettings(), sqlstore.Config{
+		Provider: "sqlite",
+		Connection: sqlstore.ConnectionConfig{
+			MaxOpenConns:    1,
+			MaxConnLifetime: 0,
+		},
+		Sqlite: sqlstore.SqliteConfig{
+			Path:            filepath.Join(t.TempDir(), "dashboard.db"),
+			Mode:            "wal",
+			BusyTimeout:     5 * time.Second,
+			TransactionMode: "deferred",
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = store.BunDB().NewCreateTable().Model((*dashboardtypes.StorableDashboard)(nil)).Exec(context.Background())
+	require.NoError(t, err)
+	_, err = store.BunDB().NewCreateTable().Model((*dashboardtypes.UserDashboardPreference)(nil)).Exec(context.Background())
+	require.NoError(t, err)
+	return store
+}
+
+func createDashboardForListTest(t *testing.T, store *store, orgID valuer.UUID, name string) {
+	t.Helper()
+	dashboard, err := dashboardtypes.NewDashboard(
+		orgID,
+		"test-user",
+		dashboardtypes.SourceUser,
+		dashboardtypes.StorableDashboardData{"name": name},
+	)
+	require.NoError(t, err)
+	storable, err := dashboardtypes.NewStorableDashboardFromDashboard(dashboard)
+	require.NoError(t, err)
+	storable.Name = name
+	require.NoError(t, store.Create(context.Background(), storable))
+}
+
+func TestListV2OutOfRangePagePreservesTotal(t *testing.T) {
+	ctx := context.Background()
+	store := &store{sqlstore: newDashboardTestStore(t)}
+	orgID := valuer.GenerateUUID()
+	createDashboardForListTest(t, store, orgID, "one")
+	createDashboardForListTest(t, store, orgID, "two")
+
+	params := &dashboardtypes.ListDashboardsV2Params{
+		ListFilter: dashboardtypes.ListFilter{
+			Sort:  dashboardtypes.ListSortUpdatedAt,
+			Order: dashboardtypes.ListOrderDesc,
+		},
+		Limit:  1,
+		Offset: 10,
+	}
+
+	dashboards, total, err := store.ListV2(ctx, orgID, params)
+	require.NoError(t, err)
+	require.Empty(t, dashboards)
+	require.Equal(t, int64(2), total)
+
+	dashboardsForUser, totalForUser, err := store.ListForUser(ctx, orgID, valuer.GenerateUUID(), params)
+	require.NoError(t, err)
+	require.Empty(t, dashboardsForUser)
+	require.Equal(t, int64(2), totalForUser)
 }

--- a/pkg/modules/metricsexplorer/implmetricsexplorer/module.go
+++ b/pkg/modules/metricsexplorer/implmetricsexplorer/module.go
@@ -257,7 +257,7 @@ func (m *module) GetStats(ctx context.Context, orgID valuer.UUID, req *metricsex
 	if len(metricStats) == 0 {
 		return &metricsexplorertypes.StatsResponse{
 			Metrics: []metricsexplorertypes.Stat{},
-			Total:   0,
+			Total:   total,
 		}, nil
 	}
 
@@ -1080,6 +1080,7 @@ func (m *module) fetchMetricsStatsWithSamples(
 	}
 
 	var finalSB *sqlbuilder.SelectBuilder
+	var countSB *sqlbuilder.SelectBuilder
 	if reductionEnabled {
 		reducedTsSB := sqlbuilder.NewSelectBuilder()
 		reducedTsSB.Select(
@@ -1148,6 +1149,13 @@ func (m *module) fetchMetricsStatsWithSamples(
 		finalSB.JoinWithOption(sqlbuilder.FullOuterJoin, "__sample_counts s", "COALESCE(ts.metric_name, rts.metric_name) = s.metric_name")
 		finalSB.JoinWithOption(sqlbuilder.FullOuterJoin, "__reduced_sample_counts rs", "COALESCE(ts.metric_name, rts.metric_name, s.metric_name) = rs.metric_name")
 		finalSB.Where("(COALESCE(ts.timeseries, 0) + COALESCE(rts.timeseries, 0) > 0 OR COALESCE(s.samples, 0) + COALESCE(rs.samples, 0) > 0)")
+
+		countSB = sqlbuilder.With(ctes...).Select("COUNT(*) AS total")
+		countSB.From("__time_series_counts ts")
+		countSB.JoinWithOption(sqlbuilder.FullOuterJoin, "__reduced_time_series_counts rts", "ts.metric_name = rts.metric_name")
+		countSB.JoinWithOption(sqlbuilder.FullOuterJoin, "__sample_counts s", "COALESCE(ts.metric_name, rts.metric_name) = s.metric_name")
+		countSB.JoinWithOption(sqlbuilder.FullOuterJoin, "__reduced_sample_counts rs", "COALESCE(ts.metric_name, rts.metric_name, s.metric_name) = rs.metric_name")
+		countSB.Where("(COALESCE(ts.timeseries, 0) + COALESCE(rts.timeseries, 0) > 0 OR COALESCE(s.samples, 0) + COALESCE(rs.samples, 0) > 0)")
 	} else {
 		cteBuilder := sqlbuilder.With(ctes...)
 
@@ -1160,6 +1168,11 @@ func (m *module) fetchMetricsStatsWithSamples(
 		finalSB.From("__time_series_counts ts")
 		finalSB.JoinWithOption(sqlbuilder.FullOuterJoin, "__sample_counts s", "ts.metric_name = s.metric_name")
 		finalSB.Where("(COALESCE(ts.timeseries, 0) > 0 OR COALESCE(s.samples, 0) > 0)")
+
+		countSB = sqlbuilder.With(ctes...).Select("COUNT(*) AS total")
+		countSB.From("__time_series_counts ts")
+		countSB.JoinWithOption(sqlbuilder.FullOuterJoin, "__sample_counts s", "ts.metric_name = s.metric_name")
+		countSB.Where("(COALESCE(ts.timeseries, 0) > 0 OR COALESCE(s.samples, 0) > 0)")
 	}
 
 	finalSB.OrderBy(
@@ -1200,6 +1213,17 @@ func (m *module) fetchMetricsStatsWithSamples(
 
 	if err := rows.Err(); err != nil {
 		return nil, 0, errors.WrapInternalf(err, errors.CodeInternal, "error iterating metrics stats rows")
+	}
+	rows.Close()
+
+	if len(metricStats) == 0 && req.Offset > 0 {
+		countQuery, countArgs := countSB.BuildWithFlavor(sqlbuilder.ClickHouse)
+		if reductionEnabled {
+			countQuery += " SETTINGS join_use_nulls = 1"
+		}
+		if err := db.QueryRow(valueCtx, countQuery, countArgs...).Scan(&total); err != nil {
+			return nil, 0, errors.WrapInternalf(err, errors.CodeInternal, "failed to count metrics stats")
+		}
 	}
 
 	return metricStats, total, nil

--- a/pkg/modules/metricsexplorer/implmetricsexplorer/module_test.go
+++ b/pkg/modules/metricsexplorer/implmetricsexplorer/module_test.go
@@ -117,6 +117,12 @@ func withStatsLimit(limit int) statsOpt {
 	}
 }
 
+func withStatsOffset(offset int) statsOpt {
+	return func(req *metricsexplorertypes.StatsRequest) {
+		req.Offset = offset
+	}
+}
+
 func withStatsOrderBy(name string, dir qbtypes.OrderDirection) statsOpt {
 	return func(req *metricsexplorertypes.StatsRequest) {
 		req.OrderBy = &qbtypes.OrderBy{
@@ -229,6 +235,25 @@ func TestGetStats(t *testing.T) {
 			assert.NoError(t, mock.ExpectationsWereMet())
 		})
 	}
+}
+
+func TestGetStatsOutOfRangePagePreservesTotal(t *testing.T) {
+	mod, mock, _ := newTestModule(t, sqlmock.QueryMatcherRegexp, true)
+	mock.ExpectQuery(regexp.QuoteMeta(statsNoFilterSQL)).
+		WithArgs(anyArgs(14)...).
+		WillReturnRows(cmock.NewRows(nil, nil))
+	mock.ExpectQueryRow(`(?s)^WITH .*SELECT COUNT\(\*\) AS total FROM __time_series_counts ts.*$`).
+		WillReturnRow(cmock.NewRow(
+			[]cmock.ColumnType{{Name: "total", Type: "UInt64"}},
+			[]any{uint64(3)},
+		))
+
+	response, err := mod.GetStats(context.Background(), testOrgID, statsRequest(withStatsOffset(10)))
+
+	assert.NoError(t, err)
+	assert.Empty(t, response.Metrics)
+	assert.Equal(t, uint64(3), response.Total)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestGetTreemap(t *testing.T) {


### PR DESCRIPTION
## Summary

  This PR fixes incorrect pagination totals when a valid offset points beyond the final matching record.

  Several paginated APIs derived the total count from:

  ```sql
  COUNT(*) OVER()

  This works when the requested page contains at least one row because each returned row carries the full pre-pagination count.

  However, when the offset is beyond the last matching row, the query returns no rows. There is therefore no row from which to
  read the window count, and the APIs incorrectly reported:

  {
    "total": 0
  }

  This affected:

  - Dashboard ListV2
  - Dashboard ListForUser
  - Metrics Explorer statistics

  The APIs now execute a count fallback only when a positive offset returns an empty page.

  ## Root Cause

  The dashboard list implementations assumed that an empty page meant there were no matching records:

  // Empty result page => zero matches.
  var total int64
  if len(rows) > 0 {
      total = rows[0].Total
  }

  That assumption is only correct when the offset is zero.

  For example, if five dashboards match and a client requests:

  limit=10&offset=100

  the result page is correctly empty, but the total should still be 5.

  Metrics Explorer had the same window-count limitation. It also explicitly replaced the returned total with zero whenever the
  page contained no metrics:

  if len(metricStats) == 0 {
      return &metricsexplorertypes.StatsResponse{
          Metrics: []metricsexplorertypes.Stat{},
          Total:   0,
      }, nil
  }

  This discarded any total recovered through another query path.

  ## Changes

  ### Add a conditional dashboard count fallback

  Both dashboard-list variants retain the existing COUNT(*) OVER() query for normal pages.

  When the page contains no rows and offset > 0, the store now executes a separate count query using the same:

  - Organization constraint.
  - System-dashboard exclusion.
  - Compiled dashboard filter.

  if len(rows) > 0 {
      total = rows[0].Total
  } else if params.Offset > 0 {
      total, err = store.countListV2(ctx, orgID, compiled)
  }

  The count helper is shared by:

  - ListV2
  - ListForUser

  The user-specific preference join is not required for the count because pagination totals represent matching dashboards, not
  preference rows.

  ### Add a conditional Metrics Explorer count fallback

  Metrics Explorer continues to use its existing window count for pages containing results.

  When a positive offset returns no rows, it executes a separate count query over the same aggregated metric dataset.

  The fallback preserves:

  - Raw and reduced metrics behavior.
  - Existing time-series and sample joins.
  - Filter expressions.
  - Reduction feature-flag behavior.
  - join_use_nulls settings for reduced metrics.

  if len(metricStats) == 0 && req.Offset > 0 {
      countQuery, countArgs := countSB.BuildWithFlavor(sqlbuilder.ClickHouse)
      // Execute count query and retain the actual total.
  }

  ### Preserve totals in empty Metrics Explorer responses

  GetStats now returns the total produced by the query layer even when the requested page contains no metrics:

  if len(metricStats) == 0 {
      return &metricsexplorertypes.StatsResponse{
          Metrics: []metricsexplorertypes.Stat{},
          Total:   total,
      }, nil
  }

  ### Avoid additional work for normal requests

  The separate count query is only executed when both conditions are true:

  The returned page is empty
  AND
  offset > 0

  This means:

  - Normal non-empty pages still use one query.
  - A first page with no matches still returns zero without another query.
  - Only potentially out-of-range pages require the fallback count.

  ## Behavior Before

  Given five matching records and this request:

  limit=10
  offset=100

  the API returned:

  {
    "items": [],
    "total": 0
  }

  Clients could incorrectly conclude that:

  - No records matched the filter.
  - Pagination controls should be reset or hidden.
  - Returning to an earlier page was unnecessary.

  ## Behavior After

  The same request returns:

  {
    "items": [],
    "total": 5
  }

  The page remains correctly empty, while the response accurately describes the complete filtered dataset.

  ## Tests Added

  ### Dashboard regression test

  Added an SQLite-backed store test that:

  1. Creates two user dashboards.
  2. Requests limit=1 with offset=10.
  3. Verifies that the result page is empty.
  4. Verifies that total remains 2.

  The test covers both:

  - ListV2
  - ListForUser

  ### Metrics Explorer regression test

  Added ClickHouse mock coverage that:

  1. Returns no rows for the requested page.
  2. Uses a positive out-of-range offset.
  3. Expects the count fallback query.
  4. Returns a total of 3.
  5. Verifies that the API response contains an empty metrics list with total: 3.

  ## Validation

  The following checks pass using the repository-declared Go 1.25.7 toolchain:

  GOTOOLCHAIN=go1.25.7 go test \
      ./pkg/modules/dashboard/impldashboard \
      ./pkg/modules/metricsexplorer/implmetricsexplorer \
      -count=1

  GOTOOLCHAIN=go1.25.7 go test -race \
      ./pkg/modules/dashboard/impldashboard \
      ./pkg/modules/metricsexplorer/implmetricsexplorer \
      -run 'Test(ListV2OutOfRangePagePreservesTotal|GetStatsOutOfRangePagePreservesTotal)' \
      -count=1

  GOTOOLCHAIN=go1.25.7 go vet \
      ./pkg/modules/dashboard/impldashboard \
      ./pkg/modules/metricsexplorer/implmetricsexplorer

  git diff --check

  All checks pass.

  > The race build emits a non-failing macOS linker warning about LC_DYSYMTAB. Both test packages still complete successfully.

  ## Performance Impact

  Normal pagination requests are unaffected and retain the existing single-query path.

  An additional count query is performed only when:

  - The requested page contains no rows.
  - The offset is greater than zero.

  This limits the extra database work to requests that may have moved beyond the final page.

  ## Risk Assessment

  Risk is low.

  The existing page queries, sorting, filtering, and normal window-count behavior remain unchanged.

  The fallback count queries reuse the same filtering and aggregation conditions as their corresponding page queries. The change
  only affects how totals are recovered for empty pages with positive offsets.

  ## Change Type

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [x] Tests
  - [ ] Documentation update

  ## Checklist

  - [x] Dashboard ListV2 preserves totals for out-of-range pages.
  - [x] Dashboard ListForUser preserves totals for out-of-range pages.
  - [x] Metrics Explorer preserves totals for out-of-range pages.
  - [x] Empty Metrics Explorer responses retain the computed total.
  - [x] Dashboard count queries reuse the active filter.
  - [x] Metrics count queries reuse the aggregation conditions.
  - [x] Reduction-enabled metrics queries remain supported.
  - [x] Normal pages retain the existing single-query path.
  - [x] First-page empty results still return zero without an extra query.
  - [x] Regression tests were added.
  - [x] Unit tests pass.
  - [x] Race detector passes.
  - [x] go vet passes.