### PR TITLE
fix(pipelines): validate strptime guard regexes

### DIFF
--- a/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
+++ b/pkg/query-service/app/logparsingpipeline/pipelineBuilder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	signozstanzahelper "github.com/SigNoz/signoz-otel-collector/processor/signozlogspipelineprocessor/stanza/operator/helper"
@@ -179,7 +180,7 @@ func getOperators(ops []pipelinetypes.PipelineOperator) ([]pipelinetypes.Pipelin
 					}
 
 					operator.If = fmt.Sprintf(
-						`%s && %s matches "%s"`, operator.If, operator.ParseFrom, regex,
+						`%s && %s matches %s`, operator.If, operator.ParseFrom, strconv.Quote(regex),
 					)
 				} else if operator.LayoutType == "epoch" {
 					valueRegex := `^\\s*[0-9]+\\s*$`

--- a/pkg/types/pipelinetypes/time_parser.go
+++ b/pkg/types/pipelinetypes/time_parser.go
@@ -12,77 +12,76 @@ import (
 // spam collector logs when encountering values that can't be parsed.
 //
 // Based on ctimeSubstitutes defined in https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt.go#L22
-//
-// TODO(Raj): Maybe make the expressions tighter.
 var ctimeRegex = map[string]string{
 	//	%Y - Year, zero-padded (0001, 0002, ..., 2019, 2020, ..., 9999)
 	"%Y": "[0-9]{4}",
 	//	%y - Year, last two digits, zero-padded (01, ..., 99)
 	"%y": "[0-9]{2}",
 	//	%m - Month as a decimal number (01, 02, ..., 12)
-	"%m": "[0-9]{2}",
-	//	%o - Month as a space-padded number ( 1, 2, ..., 12)
-	"%o": "_[0-9]",
+	"%m": "(0[1-9]|1[0-2])",
+	//	%o - Month prefixed by an underscore (_1, _2, ..., _12),
+	//	matching the collector's _1 Go layout
+	"%o": "_([1-9]|1[0-2])",
 	//	%q - Month as a unpadded number (1,2,...,12)
-	"%q": "[0-9]",
+	"%q": "([1-9]|1[0-2])",
 	//	%b, %h - Abbreviated month name (Jan, Feb, ...)
-	"%b": "[a-zA-Z]*?",
-	"%h": "[a-zA-Z]*?",
+	"%b": "(?i:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)",
+	"%h": "(?i:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)",
 	//	%B - Full month name (January, February, ...)
-	"%B": "[a-zA-Z]*?",
+	"%B": "(?i:January|February|March|April|May|June|July|August|September|October|November|December)",
 	//	%d - Day of the month, zero-padded (01, 02, ..., 31)
-	"%d": "[0-9]{2}",
+	"%d": "(0[1-9]|[12][0-9]|3[01])",
 	//	%e - Day of the month, space-padded ( 1, 2, ..., 31)
-	"%e": "_[0-9]",
+	"%e": "( [1-9]|[12][0-9]|3[01])",
 	//	%g - Day of the month, unpadded (1,2,...,31)
-	"%g": "[0-9]",
+	"%g": "([1-9]|[12][0-9]|3[01])",
 	//	%a - Abbreviated weekday name (Sun, Mon, ...)
-	"%a": "[a-zA-Z]*?",
+	"%a": "(?i:Sun|Mon|Tue|Wed|Thu|Fri|Sat)",
 	//	%A - Full weekday name (Sunday, Monday, ...)
-	"%A": "[a-zA-Z]*?",
-	//	%H - Hour (24-hour clock) as a zero-padded decimal number (00, ..., 24)
-	"%H": "[0-9]{2}",
+	"%A": "(?i:Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday)",
+	//	%H - Hour (24-hour clock) as a zero-padded decimal number (00, ..., 23)
+	"%H": "([01][0-9]|2[0-3])",
 	//	%l - Hour (12-hour clock: 0, ..., 12)
-	"%l": "[0-9]{1-2}",
+	"%l": "([0-9]|1[0-2])",
 	//	%I - Hour (12-hour clock) as a zero-padded decimal number (00, ..., 12)
-	"%I": "[0-9]{2}",
+	"%I": "(0[0-9]|1[0-2])",
 	//	%p - Locale’s equivalent of either AM or PM
 	"%p": "(AM|PM)",
 	//	%P - Locale’s equivalent of either am or pm
 	"%P": "(am|pm)",
 	//	%M - Minute, zero-padded (00, 01, ..., 59)
-	"%M": "[0-9]{2}",
+	"%M": "[0-5][0-9]",
 	//	%S - Second as a zero-padded decimal number (00, 01, ..., 59)
-	"%S": "[0-9]{2}",
+	"%S": "[0-5][0-9]",
 	//	%L - Millisecond as a decimal number, zero-padded on the left (000, 001, ..., 999)
-	"%L": "[0-9]*?",
+	"%L": "[0-9]{3}",
 	//	%f - Microsecond as a decimal number, zero-padded on the left (000000, ..., 999999)
-	"%f": "[0-9]*?",
-	//	%s - Nanosecond as a decimal number, zero-padded on the left (000000, ..., 999999)
-	"%s": "[0-9]*?",
-	//	%Z - Timezone name or abbreviation or empty (UTC, EST, CST)
-	"%Z": "[a-zA-Z]*?",
-	//	%z - UTC offset in the form ±HHMM[SS[.ffffff]] or empty(+0000, -0400)
-	"%z": "[-+][0-9]*?",
-	// Weekday as a decimal number, where 0 is Sunday and 6 is Saturday.
-	"%w": "[-+][0-9]*?",
-	"%i": "[-+][0-9]*?",
-	"%j": "[-+][0-9]{2}:[0-9]{2}",
-	"%k": "[-+][0-9]{2}:[0-9]{2}:[0-9]{2}",
-	//	%D, %x - Short MM/DD/YY date, equivalent to %m/%d/%y
-	"%D": "[0-9]{2}/[0-9]{2}/[0-9]{4}",
-	//	%D, %x - Short MM/DD/YY date, equivalent to %m/%d/%y
-	"%x": "[0-9]{2}/[0-9]{2}/[0-9]{4}",
+	"%f": "[0-9]{6}",
+	//	%s - Fractional second as eight decimal digits (00000000, ..., 99999999)
+	"%s": "[0-9]{8}",
+	//	%Z - Timezone name or abbreviation (UTC, EST, CST)
+	"%Z": "(GMT([+-]([1-9]|1[0-9]|2[0-3]))?|ChST|MeST|WITA|[A-Z]{3}|[A-Z]{3}T|[A-Z]{4}T)",
+	//	%z - UTC offset in the form Z or ±HHMM (Z, +0000, -0400)
+	"%z": "(Z|[+-]([01][0-9]|2[0-4])([0-5][0-9]|60))",
+	// Numeric UTC offsets matching the collector's -070000, -07, -07:00, and -07:00:00 Go layouts.
+	"%w": "[+-]([01][0-9]|2[0-4])([0-5][0-9]|60)([0-5][0-9]|60)",
+	"%i": "[+-]([01][0-9]|2[0-4])",
+	"%j": "[+-]([01][0-9]|2[0-4]):([0-5][0-9]|60)",
+	"%k": "[+-]([01][0-9]|2[0-4]):([0-5][0-9]|60):([0-5][0-9]|60)",
+	//	%D, %x - Short MM/DD/YYYY date
+	"%D": "(0[1-9]|1[0-2])/(0[1-9]|[12][0-9]|3[01])/[0-9]{4}",
+	//	%D, %x - Short MM/DD/YYYY date
+	"%x": "(0[1-9]|1[0-2])/(0[1-9]|[12][0-9]|3[01])/[0-9]{4}",
 	//	%F - Short YYYY-MM-DD date, equivalent to %Y-%m-%d
-	"%F": "[0-9]{4}-[0-9]{2}-[0-9]{2}",
+	"%F": "[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])",
 	//	%T, %X - ISO 8601 time format (HH:MM:SS), equivalent to %H:%M:%S
-	"%T": "[0-9]{2}:[0-9]{2}:[0-9]{2}",
+	"%T": "([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]",
 	//	%T, %X - ISO 8601 time format (HH:MM:SS), equivalent to %H:%M:%S
-	"%X": "[0-9]{2}:[0-9]{2}:[0-9]{2}",
+	"%X": "([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]",
 	//	%r - 12-hour clock time (02:55:02 pm)
-	"%r": "[0-9]{2}:[0-9]{2}:[0-9]{2} (am|pm)",
+	"%r": "(0[0-9]|1[0-2]):[0-5][0-9]:[0-5][0-9] (am|pm)",
 	//	%R - 24-hour HH:MM time, equivalent to %H:%M
-	"%R": "[0-9]{2}:[0-9]{2}",
+	"%R": "([01][0-9]|2[0-3]):[0-5][0-9]",
 	//	%n - New-line character ('\n')
 	"%n": "\n",
 	//	%t - Horizontal-tab character ('\t')
@@ -90,31 +89,45 @@ var ctimeRegex = map[string]string{
 	//	%% - A % sign
 	"%%": "%",
 	//	%c - Date and time representation (Mon Jan 02 15:04:05 2006)
-	"%c": "[a-zA-Z]{3} [a-zA-Z]{3} [0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [0-9]{4}",
+	"%c": "(?i:Sun|Mon|Tue|Wed|Thu|Fri|Sat) (?i:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9] [0-9]{4}",
 }
 
 func RegexForStrptimeLayout(layout string) (string, error) {
-	layoutRegex := layout
-	for _, regexSpecialChar := range []string{
-		".", "+", "*", "?", "^", "$", "(", ")", "[", "]", "{", "}", "|", `\`,
-	} {
-		layoutRegex = strings.ReplaceAll(layoutRegex, regexSpecialChar, `\`+regexSpecialChar)
-	}
-
 	var errs []error
-	replaceStrptimeDirectiveWithRegex := func(directive string) string {
-		if regex, ok := ctimeRegex[directive]; ok {
-			return regex
-		}
-		errs = append(errs, errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "unsupported ctimefmt directive: "+directive))
-		return ""
-	}
+	var layoutRegex strings.Builder
+	layoutRegex.WriteString("^")
 
-	strptimeDirectiveRegexp := regexp.MustCompile(`%.`)
-	layoutRegex = strptimeDirectiveRegexp.ReplaceAllStringFunc(layoutRegex, replaceStrptimeDirectiveWithRegex)
+	for len(layout) > 0 {
+		directiveIndex := strings.IndexByte(layout, '%')
+		if directiveIndex == -1 {
+			layoutRegex.WriteString(regexp.QuoteMeta(layout))
+			break
+		}
+
+		layoutRegex.WriteString(regexp.QuoteMeta(layout[:directiveIndex]))
+		if directiveIndex+1 >= len(layout) {
+			errs = append(errs, errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "incomplete ctimefmt directive: %"))
+			break
+		}
+
+		directive := layout[directiveIndex : directiveIndex+2]
+		directiveRegex, ok := ctimeRegex[directive]
+		if !ok {
+			errs = append(errs, errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "unsupported ctimefmt directive: "+directive))
+		} else {
+			layoutRegex.WriteString(directiveRegex)
+		}
+		layout = layout[directiveIndex+2:]
+	}
 	if len(errs) != 0 {
 		return "", errors.NewInvalidInputf(errors.CodeInvalidInput, "couldn't generate regex for ctime format: %v", errs)
 	}
 
-	return layoutRegex, nil
+	layoutRegex.WriteString("$")
+	generatedRegex := layoutRegex.String()
+	if _, err := regexp.Compile(generatedRegex); err != nil {
+		return "", errors.WrapInvalidInputf(err, errors.CodeInvalidInput, "couldn't compile regex for ctime format")
+	}
+
+	return generatedRegex, nil
 }

--- a/pkg/types/pipelinetypes/time_parser_test.go
+++ b/pkg/types/pipelinetypes/time_parser_test.go
@@ -1,55 +1,150 @@
 package pipelinetypes
 
 import (
-	"fmt"
+	"regexp"
 	"testing"
 
-	"github.com/antonmedv/expr"
+	"github.com/SigNoz/signoz-otel-collector/processor/signozlogspipelineprocessor/stanza/operator/helper/ctimefmt"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegexForStrptimeLayout(t *testing.T) {
-	require := require.New(t)
-
-	var testCases = []struct {
-		strptimeLayout string
-		str            string
-		shouldMatch    bool
+func TestRegexForStrptimeLayoutMatchesCompleteValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		layout  string
+		value   string
+		matches bool
 	}{
 		{
-			strptimeLayout: "%Y-%m-%dT%H:%M:%S.%f%z",
-			str:            "2023-11-26T12:03:28.239907+0530",
-			shouldMatch:    true,
-		}, {
-			strptimeLayout: "%d-%m-%Y",
-			str:            "26-11-2023",
-			shouldMatch:    true,
-		}, {
-			strptimeLayout: "%d/%m/%y",
-			str:            "11/03/02",
-			shouldMatch:    true,
-		}, {
-			strptimeLayout: "%A, %d. %B %Y %I:%M%p",
-			str:            "Tuesday, 21. November 2006 04:30PM11/03/02",
-			shouldMatch:    true,
-		}, {
-			strptimeLayout: "%A, %d. %B %Y %I:%M%p",
-			str:            "some random text",
-			shouldMatch:    false,
+			name:    "full timestamp",
+			layout:  "%Y-%m-%dT%H:%M:%S.%f%z",
+			value:   "2023-11-26T12:03:28.239907+0530",
+			matches: true,
+		},
+		{
+			name:    "unpadded two-digit month",
+			layout:  "%Y-%q-%d",
+			value:   "2023-12-26",
+			matches: true,
+		},
+		{
+			name:    "trailing garbage",
+			layout:  "%A, %d. %B %Y %I:%M%p",
+			value:   "Tuesday, 21. November 2006 04:30PM11/03/02",
+			matches: false,
+		},
+		{
+			name:    "leading garbage",
+			layout:  "%Y-%m-%d",
+			value:   "date=2023-11-26",
+			matches: false,
+		},
+		{
+			name:    "literal regexp characters",
+			layout:  "[%Y].%m+%d",
+			value:   "[2023].11+26",
+			matches: true,
 		},
 	}
 
-	for _, test := range testCases {
-		regex, err := RegexForStrptimeLayout(test.strptimeLayout)
-		require.Nil(err, test.strptimeLayout)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			generated, err := RegexForStrptimeLayout(test.layout)
+			require.NoError(t, err)
+			require.Equal(t, test.matches, regexp.MustCompile(generated).MatchString(test.value))
+		})
+	}
+}
 
-		code := fmt.Sprintf(`"%s" matches "%s"`, test.str, regex)
-		program, err := expr.Compile(code)
-		require.Nil(err, test.strptimeLayout)
+func TestRegexForStrptimeLayoutSupportsEveryCollectorDirective(t *testing.T) {
+	tests := []struct {
+		directive string
+		layout    string
+		value     string
+	}{
+		{directive: "%Y", layout: "%Y", value: "2023"},
+		{directive: "%y", layout: "%y", value: "23"},
+		{directive: "%m", layout: "%m", value: "12"},
+		{directive: "%o", layout: "%o", value: "_1"},
+		{directive: "%q", layout: "%q", value: "12"},
+		{directive: "%b", layout: "%b", value: "Nov"},
+		{directive: "%h", layout: "%h", value: "Nov"},
+		{directive: "%B", layout: "%B", value: "November"},
+		{directive: "%d", layout: "%d", value: "26"},
+		{directive: "%e", layout: "%e", value: " 6"},
+		{directive: "%g", layout: "%g", value: "26"},
+		{directive: "%a", layout: "%a", value: "Sun"},
+		{directive: "%A", layout: "%A", value: "Sunday"},
+		{directive: "%H", layout: "%H", value: "23"},
+		{directive: "%l", layout: "%l", value: "12"},
+		{directive: "%I", layout: "%I", value: "12"},
+		{directive: "%p", layout: "%I %p", value: "03 PM"},
+		{directive: "%P", layout: "%I %P", value: "03 pm"},
+		{directive: "%M", layout: "%H:%M", value: "12:59"},
+		{directive: "%S", layout: "%H:%M:%S", value: "12:03:59"},
+		{directive: "%L", layout: "%H:%M:%S.%L", value: "12:03:28.239"},
+		{directive: "%f", layout: "%H:%M:%S.%f", value: "12:03:28.239907"},
+		{directive: "%s", layout: "%H:%M:%S.%s", value: "12:03:28.23990712"},
+		{directive: "%Z", layout: "%Z", value: "UTC"},
+		{directive: "%z", layout: "%z", value: "+0530"},
+		{directive: "%w", layout: "%w", value: "+053000"},
+		{directive: "%i", layout: "%i", value: "+05"},
+		{directive: "%j", layout: "%j", value: "+05:30"},
+		{directive: "%k", layout: "%k", value: "+05:30:00"},
+		{directive: "%D", layout: "%D", value: "11/26/2023"},
+		{directive: "%x", layout: "%x", value: "11/26/2023"},
+		{directive: "%F", layout: "%F", value: "2023-11-26"},
+		{directive: "%T", layout: "%T", value: "12:03:28"},
+		{directive: "%X", layout: "%X", value: "12:03:28"},
+		{directive: "%r", layout: "%r", value: "03:04:05 pm"},
+		{directive: "%R", layout: "%R", value: "23:59"},
+		{directive: "%n", layout: "%Y%n%m", value: "2023\n11"},
+		{directive: "%t", layout: "%Y%t%m", value: "2023\t11"},
+		{directive: "%%", layout: "%Y%%", value: "2023%"},
+		{directive: "%c", layout: "%c", value: "Sun Nov 26 12:03:28 2023"},
+	}
 
-		output, err := expr.Run(program, map[string]string{})
-		require.Nil(err, test.strptimeLayout)
-		require.Equal(test.shouldMatch, output, test.strptimeLayout)
+	require.Len(t, tests, len(ctimeRegex), "every supported directive must have a test case")
+	for _, test := range tests {
+		t.Run(test.directive, func(t *testing.T) {
+			generated, err := RegexForStrptimeLayout(test.layout)
+			require.NoError(t, err)
+			require.True(t, regexp.MustCompile(generated).MatchString(test.value), "generated regex rejected a valid value")
+			_, err = ctimefmt.Parse(test.layout, test.value)
+			require.NoError(t, err, "collector parser rejected the test value")
+		})
+	}
+}
 
+func TestRegexForStrptimeLayoutRejectsInvalidLayouts(t *testing.T) {
+	for _, layout := range []string{"%", "%Q", "%Y-%"} {
+		t.Run(layout, func(t *testing.T) {
+			generated, err := RegexForStrptimeLayout(layout)
+			require.Error(t, err)
+			require.Empty(t, generated)
+		})
+	}
+}
+
+func TestRegexForStrptimeLayoutRejectsValuesCollectorCannotParse(t *testing.T) {
+	tests := []struct {
+		layout string
+		value  string
+	}{
+		{layout: "%q", value: "13"},
+		{layout: "%H", value: "24"},
+		{layout: "%M", value: "60"},
+		{layout: "%Z", value: "abc"},
+		{layout: "%z", value: "+2561"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.layout+"_"+test.value, func(t *testing.T) {
+			generated, err := RegexForStrptimeLayout(test.layout)
+			require.NoError(t, err)
+			require.False(t, regexp.MustCompile(generated).MatchString(test.value))
+			_, err = ctimefmt.Parse(test.layout, test.value)
+			require.Error(t, err)
+		})
 	}
 }


### PR DESCRIPTION

  ## Summary

  This PR fixes invalid and overly permissive regular expressions generated for `strptime` time-parser guards.

  These guards prevent timestamp values that cannot be parsed from reaching the collector time parser and repeatedly producing
  warning or error logs.

  The previous implementation contained several correctness problems:

  - `%l` generated invalid Go regexp syntax.
  - `%q` rejected valid unpadded months 10–12.
  - Generated expressions were not anchored.
  - Generated regexes were returned without being compiled.
  - Several directives accepted values outside the collector parser’s supported ranges.
  - Literal regexp characters were escaped manually and incompletely.
  - Generated regexes were interpolated into collector expressions without safe string quoting.

  This PR aligns the guards more closely with the collector’s `ctimefmt` parser and validates every supported directive.

  ## Root Cause

  ### Invalid `%l` repetition syntax

  The `%l` directive used:

  ```go
  "%l": "[0-9]{1-2}",

  Go regexp repetition ranges use a comma:

  {1,2}

  The generated expression was therefore syntactically invalid.

  Because RegexForStrptimeLayout did not compile its result, pipeline validation could accept the invalid expression and fail
  later while constructing the collector pipeline.

  ### %q rejected valid months

  The %q directive represents an unpadded month:

  1, 2, ..., 12

  It previously used:

  "%q": "[0-9]",

  This rejected October, November, and December because they contain two digits.

  ### Partial values passed the guard

  Generated expressions were not anchored.

  A layout such as:

  %Y-%m-%d

  could therefore match a valid timestamp substring inside an otherwise invalid value:

  prefix-2023-11-26-trailing-garbage

  The value passed the guard but was subsequently rejected by the collector parser, defeating the purpose of the guard.

  ### Generated expressions were not compiled during validation

  RegexForStrptimeLayout only assembled and returned a string.

  A syntactically invalid expression could pass pipeline validation and fail later when the collector attempted to compile it.

  ### Unsafe collector-expression interpolation

  The generated regexp was inserted directly into a quoted collector expression:

  fmt.Sprintf(
      `%s && %s matches "%s"`,
      operator.If,
      operator.ParseFrom,
      regex,
  )

  Regexp escapes such as \. were interpreted as invalid escapes in the expression’s string literal.

  Control characters and other escaped literals could produce similar problems.

  ## Changes

  ### Correct directive patterns

  The invalid %l expression was replaced with a valid one-or-two-digit pattern constrained to the collector-supported range:

  "%l": "([0-9]|1[0-2])",

  The %q expression now accepts unpadded months 1–12:

  "%q": "([1-9]|1[0-2])",

  ### Tighten supported directive patterns

  Patterns were tightened to better match the collector parser’s accepted values, including:

  - Month ranges.
  - Day ranges.
  - 12-hour and 24-hour clock ranges.
  - Minute and second ranges.
  - Fractional-second widths.
  - Abbreviated and full month names.
  - Abbreviated and full weekday names.
  - Numeric timezone formats.
  - Timezone abbreviations.
  - Composite date and time formats.

  For example:

  "%m": "(0[1-9]|1[0-2])"
  "%H": "([01][0-9]|2[0-3])"
  "%M": "[0-5][0-9]"
  "%S": "[0-5][0-9]"

  ### Require full-value matches

  Generated expressions are now anchored:

  ^...$

  The guard therefore checks the complete timestamp value instead of accepting a matching substring.

  Values with leading or trailing garbage no longer pass.

  ### Escape literal layout segments safely

  The implementation now parses the layout into literal segments and directives.

  Literal segments are escaped using:

  regexp.QuoteMeta

  This correctly handles regexp characters such as:

  . + * ? ^ $ ( ) [ ] { } | \

  It also avoids applying escaping transformations to the generated directive patterns.

  ### Reject incomplete directives

  Layouts ending with an incomplete directive are now rejected explicitly.

  Examples include:

  %
  %Y-%

  Unsupported directives such as %Q remain invalid.

  ### Compile generated regexes during validation

  Before returning, RegexForStrptimeLayout now calls:

  regexp.Compile(generatedRegex)

  Compilation failures are returned as invalid-input errors.

  Because pipeline validation already calls RegexForStrptimeLayout, invalid generated expressions are now rejected before
  collector configuration is built.

  ### Safely quote collector expression strings

  Generated regexes are now embedded into collector expressions using:

  strconv.Quote(regex)

  This preserves regexp escapes and control characters when the expression parser reads the generated condition.

  The collector receives the intended regexp rather than an invalid expression string.

  ## Behavior Before

  For %l, pipeline validation could generate:

  [0-9]{1-2}

  and accept the pipeline, only for collector configuration to fail later.

  For %q, the valid value:

  12

  did not match the guard.

  For %Y-%m-%d, this invalid complete value could pass:

  date=2023-11-26-trailing

  because the unanchored expression found the valid substring.

  ## Behavior After

  - Every generated regexp is syntactically compiled during validation.
  - %l produces valid regexp syntax.
  - %q accepts months 10–12.
  - Complete values must match the requested layout.
  - Unsupported and incomplete directives are rejected early.
  - Generated regexes remain valid when embedded in collector expressions.
  - Directive patterns are checked against the collector parser.

  ## Tests Added

  ### Full-value matching

  Added coverage verifying:

  - A complete timestamp matches.
  - %q accepts a two-digit unpadded month.
  - Leading garbage is rejected.
  - Trailing garbage is rejected.
  - Literal regexp characters in layouts are handled correctly.

  ### Every supported directive

  Added table-driven coverage for every entry in the supported directive table:

  %Y %y %m %o %q %b %h %B
  %d %e %g %a %A %H %l %I
  %p %P %M %S %L %f %s %Z
  %z %w %i %j %k %D %x %F
  %T %X %r %R %n %t %% %c

  Each case verifies that:

  1. A regexp is generated successfully.
  2. The regexp accepts the valid example.
  3. The pinned collector’s ctimefmt.Parse accepts the same example.

  The test also asserts that the number of cases equals the number of supported directives, preventing newly added directives
  from silently missing coverage.

  ### Invalid layouts

  Added coverage for:

  - A trailing %.
  - An unsupported %Q directive.
  - A layout ending in an incomplete directive.

  ### Parser-rejected values

  Added coverage confirming that the guard rejects representative values the collector also rejects, including:

  - Month 13.
  - Hour 24.
  - Minute 60.
  - Lowercase invalid timezone abbreviations.
  - Out-of-range numeric timezone offsets.

  ### Collector integration

  The existing collector-simulation suites verify that:

  - Valid timestamps are still parsed.
  - Mismatched timestamp values are skipped without collector warnings.
  - Generated expressions compile successfully in the real pipeline configuration.

  ## Validation

  The following checks pass using the repository-declared Go 1.25.7 toolchain:

  GOTOOLCHAIN=go1.25.7 go test \
      ./pkg/types/pipelinetypes \
      ./pkg/query-service/app/logparsingpipeline \
      -count=1

  GOTOOLCHAIN=go1.25.7 go test -race \
      ./pkg/types/pipelinetypes \
      ./pkg/query-service/app/logparsingpipeline \
      -run 'Test(RegexForStrptimeLayout|TimestampParsingProcessor|NoCollectorErrorsFromProcessorsForMismatchedLogs)' \
      -count=1

  GOTOOLCHAIN=go1.25.7 go vet \
      ./pkg/types/pipelinetypes \
      ./pkg/query-service/app/logparsingpipeline

  git diff --check

  All checks pass.

  > The race build emits a non-failing macOS linker warning about LC_DYSYMTAB. Both packages still complete successfully.

  ## Risk Assessment

  Risk is low to moderate.

  The generated guards are intentionally stricter and now require complete timestamp values to match the configured layout.

  This matches the collector parser’s full-value behavior and prevents invalid values from reaching it.

  Valid layouts and timestamps covered by all supported collector directives continue to compile and parse successfully.