### PR TITLE
feat(dashboard-v2): share a dashboard link with the current variable selection

### DIFF
--- a/frontend/src/components/HeaderRightSection/HeaderRightSection.tsx
+++ b/frontend/src/components/HeaderRightSection/HeaderRightSection.tsx
@@ -20,7 +20,7 @@ import { Globe, Inbox, SquarePen } from '@signozhq/icons';
 
 import AnnouncementsModal from './AnnouncementsModal';
 import FeedbackModal from './FeedbackModal';
-import ShareURLModal from './ShareURLModal';
+import ShareURLModal, { type ShareURLExtraOption } from './ShareURLModal';
 
 import './HeaderRightSection.styles.scss';
 import { Typography } from '@signozhq/ui/typography';
@@ -29,12 +29,15 @@ interface HeaderRightSectionProps {
 	enableAnnouncements: boolean;
 	enableShare: boolean;
 	enableFeedback: boolean;
+	/** Optional page-specific toggle for the share dialog (e.g. "Include variables"). */
+	shareModalExtraOption?: ShareURLExtraOption;
 }
 
 function HeaderRightSection({
 	enableAnnouncements,
 	enableShare,
 	enableFeedback,
+	shareModalExtraOption,
 }: HeaderRightSectionProps): JSX.Element | null {
 	const location = useLocation();
 
@@ -185,7 +188,7 @@ function HeaderRightSection({
 					rootClassName="header-section-popover-root"
 					className="shareable-link-popover"
 					placement="bottomRight"
-					content={<ShareURLModal />}
+					content={<ShareURLModal extraOption={shareModalExtraOption} />}
 					open={openShareURLModal}
 					destroyTooltipOnHide
 					arrow={false}

--- a/frontend/src/components/HeaderRightSection/ShareURLModal.tsx
+++ b/frontend/src/components/HeaderRightSection/ShareURLModal.tsx
@@ -24,7 +24,22 @@ const routesToBeSharedWithTime = [
 	ROUTES.METER_EXPLORER,
 ];
 
-function ShareURLModal(): JSX.Element {
+/**
+ * An optional, page-specific toggle in the share dialog (e.g. a dashboard's
+ * "Include variables"). When enabled, `apply` mutates the URL params that go into
+ * the shared link. Keeps this shared modal generic — the page owns what it adds.
+ */
+export interface ShareURLExtraOption {
+	label: string;
+	defaultEnabled?: boolean;
+	apply: (params: URLSearchParams) => void;
+}
+
+interface ShareURLModalProps {
+	extraOption?: ShareURLExtraOption;
+}
+
+function ShareURLModal({ extraOption }: ShareURLModalProps): JSX.Element {
 	const urlQuery = useUrlQuery();
 	const location = useLocation();
 	const { selectedTime } = useSelector<AppState, GlobalReducer>(
@@ -33,6 +48,9 @@ function ShareURLModal(): JSX.Element {
 
 	const [enableAbsoluteTime, setEnableAbsoluteTime] = useState(
 		selectedTime !== 'custom',
+	);
+	const [enableExtraOption, setEnableExtraOption] = useState(
+		extraOption?.defaultEnabled ?? false,
 	);
 
 	const startTime = urlQuery.get(QueryParams.startTime);
@@ -93,6 +111,11 @@ function ShareURLModal(): JSX.Element {
 			}
 		}
 
+		if (extraOption && enableExtraOption) {
+			extraOption.apply(urlQuery);
+			currentUrl = getAbsoluteUrl(`${location.pathname}?${urlQuery.toString()}`);
+		}
+
 		return currentUrl;
 	};
 
@@ -141,6 +164,20 @@ function ShareURLModal(): JSX.Element {
 						</div>
 					)}
 				</>
+			)}
+
+			{extraOption && (
+				<div className="absolute-relative-time-toggler-container">
+					<Typography.Text className="absolute-relative-time-toggler-label">
+						{extraOption.label}
+					</Typography.Text>
+					<div className="absolute-relative-time-toggler">
+						<Switch
+							value={enableExtraOption}
+							onChange={(): void => setEnableExtraOption((prev) => !prev)}
+						/>
+					</div>
+				</div>
 			)}
 
 			<div className="share-link">

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardPageHeader/DashboardPageHeader.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardPageHeader/DashboardPageHeader.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import HeaderRightSection from 'components/HeaderRightSection/HeaderRightSection';
 
 import DashboardPageBreadcrumbs from './DashboardPageBreadcrumbs';
+import { useShareVariablesOption } from './useShareVariablesOption';
 
 import styles from './DashboardPageHeader.module.scss';
 
@@ -14,10 +15,16 @@ function DashboardPageHeader({
 	title,
 	image,
 }: DashboardPageHeaderProps): JSX.Element {
+	const shareVariablesOption = useShareVariablesOption();
 	return (
 		<div className={styles.dashboardPageHeader}>
 			<DashboardPageBreadcrumbs title={title} image={image} />
-			<HeaderRightSection enableAnnouncements={false} enableShare enableFeedback />
+			<HeaderRightSection
+				enableAnnouncements={false}
+				enableShare
+				enableFeedback
+				shareModalExtraOption={shareVariablesOption}
+			/>
 		</div>
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardPageHeader/useShareVariablesOption.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardPageHeader/useShareVariablesOption.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import type { ShareURLExtraOption } from 'components/HeaderRightSection/ShareURLModal';
+
+import type { SelectedVariableValue } from '../../VariablesBar/selectionTypes';
+import {
+	ALL_SELECTED,
+	variablesUrlParser,
+} from '../../VariablesBar/utils/variablesUrlState';
+import { selectVariableValues } from '../../store/slices/variableSelectionSlice';
+import { useDashboardStore } from '../../store/useDashboardStore';
+
+/**
+ * The share-dialog "Include variables" option: serializes the current variable
+ * selection into the `?variables=` param (ALL encoded as the sentinel) so a shared
+ * link reproduces it for the recipient — who hydrates it into local storage on load,
+ * after which the param is cleared (see useSeedVariableSelection). Returns undefined
+ * when there is nothing selected to share.
+ */
+export function useShareVariablesOption(): ShareURLExtraOption | undefined {
+	const dashboardId = useDashboardStore((s) => s.dashboardId);
+	const selections = useDashboardStore(selectVariableValues(dashboardId ?? ''));
+
+	return useMemo(() => {
+		const names = Object.keys(selections);
+		if (names.length === 0) {
+			return undefined;
+		}
+		const urlShape: Record<string, SelectedVariableValue> = {};
+		names.forEach((name) => {
+			const selection = selections[name];
+			urlShape[name] = selection.allSelected ? ALL_SELECTED : selection.value;
+		});
+		const serialized = variablesUrlParser.serialize(urlShape);
+		return {
+			label: 'Include variables',
+			apply: (params): void => {
+				params.set('variables', serialized);
+			},
+		};
+	}, [selections]);
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Adds an **"Include variables"** toggle to the dashboard's share dialog so a shared link reproduces the sender's current variable selection for the recipient.

- The shared `ShareURLModal` gains an optional, generic `extraOption` (label + `apply(params)` callback). Absent for every other page, so nothing else changes; the modal stays dashboard-agnostic.
- On a V2 dashboard, `DashboardPageHeader` supplies an "Include variables" option that serializes the current store selection into the `?variables=` param (ALL encoded as the `__ALL__` sentinel), reusing the existing `variablesUrlParser`.
- The recipient side already works: `useSeedVariableSelection` reads `?variables=` (URL → store → default precedence), writes it to local storage, then clears the param — so refreshes keep the shared values. This PR only adds the *link generation*.
- Toggle is **off by default** (opt-in).

### Recording

https://github.com/user-attachments/assets/b7800b7f-a118-450a-a75c-21c0cb65adb1


#### Issues closed by this PR
Closes https://github.com/SigNoz/pulse-pod/issues/119

---

### ✅ Change Type

- [x] ✨ Feature

---

### 🧪 Testing Strategy

- Existing `ShareURLModal.test.tsx` still passes (10/10) — the new prop is optional and backward-compatible.
- Manual verification: pending — toggle on, copy link, open in another session, confirm the selection is applied then the URL is cleaned.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: `ShareURLModal` / `HeaderRightSection` are shared, but the change is a purely additive optional prop (undefined for all existing callers). Dashboard-specific logic lives in the V2 header hook.
- Potential regressions: none expected for non-dashboard pages; serialization uses the same parser the recipient parses with.
- Rollback plan: revert the two commits (shared foundation, then dashboard wiring).
