### PR TITLE
feat(dashboard-v2): product analytics instrumentation for list + detail pages

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
@@ -143,6 +143,29 @@ function DashboardActions({
 		});
 	}, [deleteDashboardMutation, dashboard.id, dashboard.spec.panels]);
 
+	const handleOpenSettings = useCallback((): void => {
+		void logEvent(DashboardDetailEvents.SettingsOpened, {
+			dashboardId: dashboard.id,
+		});
+		setIsSettingsDrawerOpen(true);
+	}, [dashboard.id]);
+
+	const handleOpenJsonEditor = useCallback((): void => {
+		void logEvent(DashboardDetailEvents.JsonEditorOpened, {
+			dashboardId: dashboard.id,
+			readOnly: !isEditable,
+		});
+		setIsJsonEditorOpen(true);
+	}, [dashboard.id, isEditable]);
+
+	const handleEnterFullScreen = useCallback((): void => {
+		void logEvent(DashboardDetailEvents.FullScreenToggled, {
+			dashboardId: dashboard.id,
+			enabled: true,
+		});
+		void handle.enter();
+	}, [dashboard.id, handle]);
+
 	// Shown only to edit-permitted users, so the only disabled reason is the lock.
 	const editLabel = useCallback(
 		(text: string): ReactNode =>
@@ -188,13 +211,7 @@ function DashboardActions({
 			key: 'fullscreen',
 			label: 'Full screen',
 			icon: <Fullscreen size={14} />,
-			onClick: (): void => {
-				void logEvent(DashboardDetailEvents.FullScreenToggled, {
-					dashboardId: dashboard.id,
-					enabled: true,
-				});
-				void handle.enter();
-			},
+			onClick: handleEnterFullScreen,
 		});
 
 		const items: MenuItem[] = [
@@ -243,11 +260,10 @@ function DashboardActions({
 		user.role,
 		isDashboardLocked,
 		dashboard.createdBy,
-		dashboard.id,
 		onOpenRename,
 		handleClone,
 		onLockToggle,
-		handle,
+		handleEnterFullScreen,
 	]);
 
 	return (
@@ -277,12 +293,7 @@ function DashboardActions({
 							prefix={<Configure size="md" />}
 							testId="show-drawer"
 							disabled={isLocked}
-							onClick={(): void => {
-								void logEvent(DashboardDetailEvents.SettingsOpened, {
-									dashboardId: dashboard.id,
-								});
-								setIsSettingsDrawerOpen(true);
-							}}
+							onClick={handleOpenSettings}
 							size="md"
 						>
 							Configure
@@ -307,13 +318,7 @@ function DashboardActions({
 				className={styles.toolbarButton}
 				prefix={<Braces size="md" />}
 				testId="edit-json"
-				onClick={(): void => {
-					void logEvent(DashboardDetailEvents.JsonEditorOpened, {
-						dashboardId: dashboard.id,
-						readOnly: !isEditable,
-					});
-					setIsJsonEditorOpen(true);
-				}}
+				onClick={handleOpenJsonEditor}
 				size="md"
 			>
 				JSON

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardActions/DashboardActions.tsx
@@ -23,12 +23,14 @@ import { Button } from '@signozhq/ui/button';
 import { DropdownMenuSimple } from '@signozhq/ui/dropdown-menu';
 import type { MenuItem } from '@signozhq/ui/dropdown-menu';
 import { toast } from '@signozhq/ui/sonner';
+import logEvent from 'api/common/logEvent';
 import { cloneDashboardV2 } from 'api/generated/services/dashboard';
 import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
 import ROUTES from 'constants/routes';
 import { useDeleteDashboard } from 'hooks/dashboard/useDeleteDashboard';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import history from 'lib/history';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { useAppContext } from 'providers/App/App';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
@@ -69,6 +71,7 @@ function DashboardActions({
 }: DashboardActionsProps): JSX.Element {
 	const canEditDashboard = useDashboardStore((s) => s.canEditDashboard);
 	const isLocked = useDashboardStore((s) => s.isLocked);
+	const isEditable = useDashboardStore((s) => s.isEditable);
 	const settingsRequest = useDashboardStore((s) => s.settingsRequest);
 	const clearSettingsRequest = useDashboardStore((s) => s.clearSettingsRequest);
 	const { user } = useAppContext();
@@ -112,6 +115,11 @@ function DashboardActions({
 			setIsCloning(true);
 			const response = await cloneDashboardV2({ id: dashboard.id });
 			toast.success('Dashboard cloned');
+			void logEvent(DashboardDetailEvents.Cloned, {
+				dashboardId: dashboard.id,
+				dashboardName: title,
+				source: 'detail',
+			});
 			safeNavigate(
 				generatePath(ROUTES.DASHBOARD, { dashboardId: response.data.id }),
 			);
@@ -120,16 +128,20 @@ function DashboardActions({
 		} finally {
 			setIsCloning(false);
 		}
-	}, [dashboard.id, safeNavigate, showErrorModal]);
+	}, [dashboard.id, title, safeNavigate, showErrorModal]);
 
 	const handleConfirmDelete = useCallback((): void => {
 		deleteDashboardMutation.mutate(undefined, {
 			onSuccess: () => {
+				void logEvent(DashboardDetailEvents.Deleted, {
+					dashboardId: dashboard.id,
+					panelCount: Object.keys(dashboard.spec.panels).length,
+				});
 				setIsDeleteOpen(false);
 				history.replace(ROUTES.ALL_DASHBOARD);
 			},
 		});
-	}, [deleteDashboardMutation]);
+	}, [deleteDashboardMutation, dashboard.id, dashboard.spec.panels]);
 
 	// Shown only to edit-permitted users, so the only disabled reason is the lock.
 	const editLabel = useCallback(
@@ -176,7 +188,13 @@ function DashboardActions({
 			key: 'fullscreen',
 			label: 'Full screen',
 			icon: <Fullscreen size={14} />,
-			onClick: handle.enter,
+			onClick: (): void => {
+				void logEvent(DashboardDetailEvents.FullScreenToggled, {
+					dashboardId: dashboard.id,
+					enabled: true,
+				});
+				void handle.enter();
+			},
 		});
 
 		const items: MenuItem[] = [
@@ -225,10 +243,11 @@ function DashboardActions({
 		user.role,
 		isDashboardLocked,
 		dashboard.createdBy,
+		dashboard.id,
 		onOpenRename,
 		handleClone,
 		onLockToggle,
-		handle.enter,
+		handle,
 	]);
 
 	return (
@@ -258,7 +277,12 @@ function DashboardActions({
 							prefix={<Configure size="md" />}
 							testId="show-drawer"
 							disabled={isLocked}
-							onClick={(): void => setIsSettingsDrawerOpen(true)}
+							onClick={(): void => {
+								void logEvent(DashboardDetailEvents.SettingsOpened, {
+									dashboardId: dashboard.id,
+								});
+								setIsSettingsDrawerOpen(true);
+							}}
 							size="md"
 						>
 							Configure
@@ -283,7 +307,13 @@ function DashboardActions({
 				className={styles.toolbarButton}
 				prefix={<Braces size="md" />}
 				testId="edit-json"
-				onClick={(): void => setIsJsonEditorOpen(true)}
+				onClick={(): void => {
+					void logEvent(DashboardDetailEvents.JsonEditorOpened, {
+						dashboardId: dashboard.id,
+						readOnly: !isEditable,
+					});
+					setIsJsonEditorOpen(true);
+				}}
 				size="md"
 			>
 				JSON

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.tsx
@@ -101,6 +101,14 @@ function DashboardInfo({
 		}
 	};
 
+	const handleOpenPublicUrl = (): void => {
+		void logEvent(DashboardDetailEvents.PublicUrlOpened, {
+			dashboardId,
+			dashboardName: title,
+		});
+		openInNewTab(publicUrl);
+	};
+
 	return (
 		<div className={styles.dashboardInfo}>
 			<img src={image} alt={title} className={styles.dashboardImage} />
@@ -185,13 +193,7 @@ function DashboardInfo({
 						className={styles.publicLink}
 						aria-label="Open public dashboard"
 						testId="dashboard-public-link"
-						onClick={(): void => {
-							void logEvent(DashboardDetailEvents.PublicUrlOpened, {
-								dashboardId,
-								dashboardName: title,
-							});
-							openInNewTab(publicUrl);
-						}}
+						onClick={handleOpenPublicUrl}
 					>
 						<Globe size={14} />
 					</Button>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/DashboardInfo/DashboardInfo.tsx
@@ -12,8 +12,10 @@ import { Button } from '@signozhq/ui/button';
 import { Input } from '@signozhq/ui/input';
 import { TooltipSimple } from '@signozhq/ui/tooltip';
 import { Typography } from '@signozhq/ui/typography';
+import logEvent from 'api/common/logEvent';
 import cx from 'classnames';
 import { isEmpty } from 'lodash-es';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { linkifyText } from 'utils/linkifyText';
 import { openInNewTab } from 'utils/navigation';
 
@@ -61,6 +63,7 @@ function DashboardInfo({
 	onCancel,
 }: DashboardInfoProps): JSX.Element {
 	const canEdit = useDashboardStore((s) => s.isEditable);
+	const dashboardId = useDashboardStore((s) => s.dashboardId);
 
 	const hasTags = tags.length > 0;
 	const hasDescription = !isEmpty(description);
@@ -182,7 +185,13 @@ function DashboardInfo({
 						className={styles.publicLink}
 						aria-label="Open public dashboard"
 						testId="dashboard-public-link"
-						onClick={(): void => openInNewTab(publicUrl)}
+						onClick={(): void => {
+							void logEvent(DashboardDetailEvents.PublicUrlOpened, {
+								dashboardId,
+								dashboardName: title,
+							});
+							openInNewTab(publicUrl);
+						}}
 					>
 						<Globe size={14} />
 					</Button>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/JsonEditorDrawer.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/JsonEditorDrawer.tsx
@@ -6,7 +6,9 @@ import { TooltipSimple } from '@signozhq/ui/tooltip';
 import { Typography } from '@signozhq/ui/typography';
 import cx from 'classnames';
 import { Drawer } from 'antd';
+import logEvent from 'api/common/logEvent';
 import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { useCopyToClipboard } from 'react-use';
 import { toast } from '@signozhq/ui/sonner';
 
@@ -51,9 +53,17 @@ function JsonEditorDrawer({
 	const onCopy = useCallback((): void => {
 		copyToClipboard(draft);
 		toast.success('JSON copied to clipboard');
-	}, [copyToClipboard, draft]);
+		void logEvent(DashboardDetailEvents.JsonEditorAction, {
+			action: 'copy',
+			dashboardId: dashboard.id,
+		});
+	}, [copyToClipboard, draft, dashboard.id]);
 
 	const onDownload = useCallback((): void => {
+		void logEvent(DashboardDetailEvents.JsonEditorAction, {
+			action: 'download',
+			dashboardId: dashboard.id,
+		});
 		const blob = new Blob([draft], { type: 'application/json' });
 		const url = URL.createObjectURL(blob);
 		const link = document.createElement('a');
@@ -63,7 +73,7 @@ function JsonEditorDrawer({
 		link.click();
 		document.body.removeChild(link);
 		URL.revokeObjectURL(url);
-	}, [draft, dashboard.name]);
+	}, [draft, dashboard.name, dashboard.id]);
 
 	const onKeyDown = useCallback(
 		(event: KeyboardEvent<HTMLDivElement>): void => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/useJsonEditor.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/JsonEditorDrawer/useJsonEditor.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from '@signozhq/ui/sonner';
+import logEvent from 'api/common/logEvent';
 import { updateDashboardV2 } from 'api/generated/services/dashboard';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import type {
 	DashboardtypesDashboardSpecDTO,
 	DashboardtypesGettableDashboardV2DTO,
@@ -140,14 +142,22 @@ export function useJsonEditor({
 	const format = useCallback((): void => {
 		try {
 			setDraft(JSON.stringify(JSON.parse(draft), null, 2));
+			void logEvent(DashboardDetailEvents.JsonEditorAction, {
+				action: 'format',
+				dashboardId,
+			});
 		} catch {
 			// Leave the draft untouched when it can't be parsed.
 		}
-	}, [draft]);
+	}, [draft, dashboardId]);
 
 	const reset = useCallback((): void => {
 		setDraft(appliedText);
-	}, [appliedText]);
+		void logEvent(DashboardDetailEvents.JsonEditorAction, {
+			action: 'reset',
+			dashboardId,
+		});
+	}, [appliedText, dashboardId]);
 
 	const apply = useCallback(async (): Promise<void> => {
 		if (readOnly || !validity.valid || !isDirty) {
@@ -163,6 +173,10 @@ export function useJsonEditor({
 				dashboardToUpdatable({ ...dashboard, ...edited }),
 			);
 			toast.success('Dashboard updated');
+			void logEvent(DashboardDetailEvents.JsonEditorAction, {
+				action: 'apply',
+				dashboardId,
+			});
 			refetch();
 			onApplied();
 		} catch (error) {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardPageToolbar/index.tsx
@@ -15,6 +15,7 @@ import type {
 } from 'api/generated/services/sigNoz.schemas';
 import { Base64Icons } from 'container/DashboardContainer/DashboardSettings/General/utils';
 import DateTimeSelectionV2 from 'container/TopNav/DateTimeSelectionV2';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { useAppContext } from 'providers/App/App';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
@@ -87,38 +88,47 @@ function DashboardPageToolbar(props: DashboardPageToolbarProps): JSX.Element {
 	const { isPublic, publicMeta } = usePublicDashboardMeta(id);
 	const publicUrl = getAbsoluteUrl(publicMeta?.publicPath ?? '');
 
-	const handleLockDashboardToggle = useCallback(async (): Promise<void> => {
-		if (!id) {
-			return;
-		}
-		const next = !isDashboardLocked;
-		setIsDashboardLocked(next);
-		if (next) {
-			setShowLockToggle(true);
-		}
-		try {
+	const handleLockDashboardToggle = useCallback(
+		async (source: 'menu' | 'header'): Promise<void> => {
+			if (!id) {
+				return;
+			}
+			const next = !isDashboardLocked;
+			setIsDashboardLocked(next);
 			if (next) {
-				await lockDashboardV2({ id });
-				toast.success('Dashboard locked');
-			} else {
-				await unlockDashboardV2({ id });
-				toast.success('Dashboard unlocked');
+				setShowLockToggle(true);
 			}
-			// Patch just the `locked` flag in the cache — a full refetch would reload
-			// every panel's chart data for a metadata-only change.
-			const key = getGetDashboardV2QueryKey({ id });
-			const cached = queryClient.getQueryData<GetDashboardV2200>(key);
-			if (cached) {
-				queryClient.setQueryData<GetDashboardV2200>(key, {
-					...cached,
-					data: { ...cached.data, locked: next },
+			try {
+				if (next) {
+					await lockDashboardV2({ id });
+					toast.success('Dashboard locked');
+				} else {
+					await unlockDashboardV2({ id });
+					toast.success('Dashboard unlocked');
+				}
+				// Patch just the `locked` flag in the cache — a full refetch would reload
+				// every panel's chart data for a metadata-only change.
+				const key = getGetDashboardV2QueryKey({ id });
+				const cached = queryClient.getQueryData<GetDashboardV2200>(key);
+				if (cached) {
+					queryClient.setQueryData<GetDashboardV2200>(key, {
+						...cached,
+						data: { ...cached.data, locked: next },
+					});
+				}
+				void logEvent(DashboardDetailEvents.LockToggled, {
+					dashboardId: id,
+					dashboardName: title,
+					locked: next,
+					source,
 				});
+			} catch (error) {
+				setIsDashboardLocked(!next);
+				showErrorModal(error as APIError);
 			}
-		} catch (error) {
-			setIsDashboardLocked(!next);
-			showErrorModal(error as APIError);
-		}
-	}, [id, isDashboardLocked, queryClient, showErrorModal]);
+		},
+		[id, title, isDashboardLocked, queryClient, showErrorModal],
+	);
 
 	const onNameSave = useCallback(
 		async (next: string): Promise<void> => {
@@ -135,6 +145,11 @@ function DashboardPageToolbar(props: DashboardPageToolbarProps): JSX.Element {
 				];
 				await patchAsync(patch);
 				toast.success('Dashboard renamed successfully');
+				void logEvent(DashboardDetailEvents.Renamed, {
+					dashboardId: id,
+					dashboardName: next,
+					source: 'inline',
+				});
 			} catch (error) {
 				showErrorModal(error as APIError);
 			}
@@ -167,7 +182,11 @@ function DashboardPageToolbar(props: DashboardPageToolbarProps): JSX.Element {
 					publicUrl={publicUrl}
 					isDashboardLocked={isDashboardLocked}
 					showLockToggle={showLockToggle}
-					onToggleLock={canToggleLock ? handleLockDashboardToggle : undefined}
+					onToggleLock={
+						canToggleLock
+							? (): void => void handleLockDashboardToggle('header')
+							: undefined
+					}
 					isEditing={isEditing}
 					draft={draft}
 					onDraftChange={setDraft}
@@ -182,7 +201,7 @@ function DashboardPageToolbar(props: DashboardPageToolbarProps): JSX.Element {
 					isDashboardLocked={isDashboardLocked}
 					isAuthor={isAuthor}
 					onAddPanel={onAddPanel}
-					onLockToggle={handleLockDashboardToggle}
+					onLockToggle={(): void => void handleLockDashboardToggle('menu')}
 					onOpenRename={startEdit}
 				/>
 			</div>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/CrossPanelSync/CrossPanelSync.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/CrossPanelSync/CrossPanelSync.tsx
@@ -3,6 +3,7 @@ import { TooltipSimple } from '@signozhq/ui/tooltip';
 import { Typography } from '@signozhq/ui/typography';
 import logEvent from 'api/common/logEvent';
 import { Events } from 'constants/events';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { useDashboardCursorSyncMode } from 'hooks/dashboard/useDashboardCursorSyncMode';
 import { useSyncTooltipFilterMode } from 'hooks/dashboard/useSyncTooltipFilterMode';
 import {
@@ -72,7 +73,13 @@ function CrossPanelSync({ dashboardId }: CrossPanelSyncProps): JSX.Element {
 				<SegmentedControl
 					testId="cursor-sync-mode"
 					value={cursorSyncMode}
-					onChange={setCursorSyncMode}
+					onChange={(value): void => {
+						void logEvent(DashboardDetailEvents.CursorSyncChanged, {
+							mode: value,
+							dashboardId,
+						});
+						setCursorSyncMode(value);
+					}}
 					options={[
 						{ label: 'No Sync', value: DashboardCursorSync.None },
 						{ label: 'Crosshair', value: DashboardCursorSync.Crosshair },

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/CrossPanelSync/CrossPanelSync.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/CrossPanelSync/CrossPanelSync.tsx
@@ -27,6 +27,22 @@ function CrossPanelSync({ dashboardId }: CrossPanelSyncProps): JSX.Element {
 	const [syncTooltipFilterMode, setSyncTooltipFilterMode] =
 		useSyncTooltipFilterMode(dashboardId);
 
+	const handleCursorSyncChange = (value: DashboardCursorSync): void => {
+		void logEvent(DashboardDetailEvents.CursorSyncChanged, {
+			mode: value,
+			dashboardId,
+		});
+		setCursorSyncMode(value);
+	};
+
+	const handleTooltipFilterModeChange = (value: SyncTooltipFilterMode): void => {
+		void logEvent(Events.TOOLTIP_SYNC_MODE_CHANGED, {
+			path: getAbsoluteUrl(window.location.pathname),
+			mode: value,
+		});
+		setSyncTooltipFilterMode(value);
+	};
+
 	return (
 		<div className={cx(settingsStyles.settingsCard, styles.crossPanelSyncGroup)}>
 			<div className={styles.crossPanelSyncSectionHeader}>
@@ -73,13 +89,7 @@ function CrossPanelSync({ dashboardId }: CrossPanelSyncProps): JSX.Element {
 				<SegmentedControl
 					testId="cursor-sync-mode"
 					value={cursorSyncMode}
-					onChange={(value): void => {
-						void logEvent(DashboardDetailEvents.CursorSyncChanged, {
-							mode: value,
-							dashboardId,
-						});
-						setCursorSyncMode(value);
-					}}
+					onChange={handleCursorSyncChange}
 					options={[
 						{ label: 'No Sync', value: DashboardCursorSync.None },
 						{ label: 'Crosshair', value: DashboardCursorSync.Crosshair },
@@ -103,13 +113,7 @@ function CrossPanelSync({ dashboardId }: CrossPanelSyncProps): JSX.Element {
 					<SegmentedControl
 						testId="sync-tooltip-filter-mode"
 						value={syncTooltipFilterMode}
-						onChange={(value): void => {
-							void logEvent(Events.TOOLTIP_SYNC_MODE_CHANGED, {
-								path: getAbsoluteUrl(window.location.pathname),
-								mode: value,
-							});
-							setSyncTooltipFilterMode(value);
-						}}
+						onChange={handleTooltipFilterModeChange}
 						options={[
 							{ label: 'All', value: SyncTooltipFilterMode.All },
 							{ label: 'Filtered', value: SyncTooltipFilterMode.Filtered },

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Overview/index.tsx
@@ -5,7 +5,9 @@ import type {
 	DashboardtypesJSONPatchOperationDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { toast } from '@signozhq/ui/sonner';
+import logEvent from 'api/common/logEvent';
 import { isEqual } from 'lodash-es';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
@@ -122,12 +124,13 @@ function Overview({ dashboard }: OverviewProps): JSX.Element {
 			setIsSaving(true);
 			await patchAsync(ops);
 			toast.success('Dashboard updated');
+			void logEvent(DashboardDetailEvents.OverviewSaved, { dashboardId: id });
 		} catch (error) {
 			showErrorModal(error as APIError);
 		} finally {
 			setIsSaving(false);
 		}
-	}, [buildPatch, patchAsync, showErrorModal]);
+	}, [buildPatch, patchAsync, showErrorModal, id]);
 
 	useEffect(() => {
 		let numberOfUnsavedChanges = 0;
@@ -160,7 +163,8 @@ function Overview({ dashboard }: OverviewProps): JSX.Element {
 		setUpdatedImage(image);
 		setUpdatedTags(tagsAsStrings);
 		setUpdatedDescription(description);
-	}, [title, image, tagsAsStrings, description]);
+		void logEvent(DashboardDetailEvents.OverviewDiscarded, { dashboardId: id });
+	}, [title, image, tagsAsStrings, description, id]);
 
 	return (
 		<div className={styles.overviewContent}>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/PublicDashboard/usePublicDashboard.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/PublicDashboard/usePublicDashboard.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from 'react-query';
 import { useCopyToClipboard } from 'react-use';
 import { toast } from '@signozhq/ui/sonner';
+import logEvent from 'api/common/logEvent';
 import {
 	invalidateGetPublicDashboard,
 	useCreatePublicDashboard,
@@ -9,6 +10,7 @@ import {
 	useUpdatePublicDashboard,
 } from 'api/generated/services/dashboard';
 import { DEFAULT_TIME_RANGE } from 'container/TopNav/DateTimeSelectionV2/constants';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { useAppContext } from 'providers/App/App';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
@@ -131,6 +133,11 @@ export function usePublicDashboard(
 		if (!dashboardId) {
 			return;
 		}
+		void logEvent(DashboardDetailEvents.PublicDashboardAction, {
+			action: 'publish',
+			timeRangeEnabled,
+			dashboardId,
+		});
 		createPublicDashboard({
 			pathParams: { id: dashboardId },
 			data: { timeRangeEnabled, defaultTimeRange },
@@ -141,6 +148,10 @@ export function usePublicDashboard(
 		if (!dashboardId) {
 			return;
 		}
+		void logEvent(DashboardDetailEvents.PublicDashboardAction, {
+			action: 'update',
+			dashboardId,
+		});
 		updatePublicDashboard({
 			pathParams: { id: dashboardId },
 			data: { timeRangeEnabled, defaultTimeRange },
@@ -151,6 +162,10 @@ export function usePublicDashboard(
 		if (!dashboardId) {
 			return;
 		}
+		void logEvent(DashboardDetailEvents.PublicDashboardAction, {
+			action: 'unpublish',
+			dashboardId,
+		});
 		deletePublicDashboard({ pathParams: { id: dashboardId } });
 	}, [deletePublicDashboard, dashboardId]);
 
@@ -160,13 +175,21 @@ export function usePublicDashboard(
 		}
 		copyToClipboard(publicUrl);
 		toast.success('Copied public dashboard URL successfully');
-	}, [copyToClipboard, publicUrl]);
+		void logEvent(DashboardDetailEvents.PublicDashboardAction, {
+			action: 'copyUrl',
+			dashboardId,
+		});
+	}, [copyToClipboard, publicUrl, dashboardId]);
 
 	const onOpenUrl = useCallback((): void => {
 		if (publicUrl) {
 			openInNewTab(publicUrl);
+			void logEvent(DashboardDetailEvents.PublicDashboardAction, {
+				action: 'openUrl',
+				dashboardId,
+			});
 		}
-	}, [publicUrl]);
+	}, [publicUrl, dashboardId]);
 
 	const isLoading =
 		isLoadingMeta || isFetching || isPublishing || isUpdating || isUnpublishing;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/QueryVariableFields.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/QueryVariableFields.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { Button } from '@signozhq/ui/button';
 import { Typography } from '@signozhq/ui/typography';
+import logEvent from 'api/common/logEvent';
 import dashboardVariablesQuery from 'api/dashboard/variables/dashboardVariablesQuery';
 import Editor from 'components/Editor';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import type { PayloadVariables } from 'types/api/dashboard/variables/query';
 
 import styles from './VariableForm.module.scss';
@@ -29,10 +31,12 @@ function QueryVariableFields({
 	const runTest = async (): Promise<void> => {
 		setIsRunning(true);
 		onError(null);
+		let success = false;
 		try {
 			const res = await dashboardVariablesQuery({ query: queryValue, variables });
 			if (res.statusCode === 200 && res.payload) {
 				onPreview(res.payload.variableValues ?? []);
+				success = true;
 			} else {
 				onError(res.error || 'Failed to run query');
 				onPreview([]);
@@ -48,6 +52,10 @@ function QueryVariableFields({
 			onPreview([]);
 		} finally {
 			setIsRunning(false);
+			void logEvent(DashboardDetailEvents.VariableQueryTested, {
+				variableType: 'query',
+				success,
+			});
 		}
 	};
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/useVariableForm.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/useVariableForm.ts
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
+import logEvent from 'api/common/logEvent';
 import { commaValuesParser } from 'lib/dashboardVariables/customCommaValuesParser';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import type { PayloadVariables } from 'types/api/dashboard/variables/query';
 
 import type { VariableSelectionMap } from '../../../VariablesBar/selectionTypes';
@@ -7,6 +9,7 @@ import { useDashboardStore } from '../../../store/useDashboardStore';
 import { detectVariableCycle } from '../utils/variableCycleDetection';
 import {
 	sortValuesByOrder,
+	VARIABLE_TYPE_EVENT_LABEL,
 	type VariableFormModel,
 	type VariableType,
 } from '../variableFormModel';
@@ -167,6 +170,13 @@ export function useVariableForm({
 			return;
 		}
 		setCycleError(null);
+		void logEvent(DashboardDetailEvents.VariableSaved, {
+			variableType: VARIABLE_TYPE_EVENT_LABEL[next.type],
+			multiSelect: next.multiSelect,
+			hasAllOption: next.showAllOption,
+			isNew,
+			dashboardId,
+		});
 		onSave(next);
 	};
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/hooks/useVariableListActions.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/hooks/useVariableListActions.ts
@@ -4,14 +4,20 @@ import {
 	useCallback,
 	useState,
 } from 'react';
+import logEvent from 'api/common/logEvent';
 import { toast } from '@signozhq/ui/sonner';
 import type {
 	DashboardtypesGettableDashboardV2DTO,
 	DashboardtypesJSONPatchOperationDTO,
 } from 'api/generated/services/sigNoz.schemas';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
+import { useDashboardStore } from '../../../store/useDashboardStore';
 import { buildSyncVariableToPanelsPatch } from '../utils/applyVariableToPanelsPatch';
-import type { VariableFormModel } from '../variableFormModel';
+import {
+	VARIABLE_TYPE_EVENT_LABEL,
+	type VariableFormModel,
+} from '../variableFormModel';
 import {
 	applyVariableQueryEdits,
 	buildVariableImpactPatch,
@@ -75,6 +81,7 @@ export function useVariableListActions({
 	save,
 	patchAsync,
 }: UseVariableListActionsParams): UseVariableListActions {
+	const dashboardId = useDashboardStore((s) => s.dashboardId);
 	const [confirmDeleteIndex, setConfirmDeleteIndex] = useState<number | null>(
 		null,
 	);
@@ -165,16 +172,27 @@ export function useVariableListActions({
 			const [moved] = next.splice(from, 1);
 			next.splice(to, 0, moved);
 			persist(next);
+			void logEvent(DashboardDetailEvents.VariableReordered, {
+				variableType: VARIABLE_TYPE_EVENT_LABEL[moved.type],
+				fromIndex: from,
+				toIndex: to,
+				dashboardId,
+			});
 		},
-		[persist, variables],
+		[dashboardId, persist, variables],
 	);
 
 	const handleConfirmDelete = useCallback(
 		(index: number): void => {
+			void logEvent(DashboardDetailEvents.VariableDeleted, {
+				variableType: VARIABLE_TYPE_EVENT_LABEL[variables[index].type],
+				hadReferences: false,
+				dashboardId,
+			});
 			persist(variables.filter((_, i) => i !== index));
 			setConfirmDeleteIndex(null);
 		},
-		[persist, variables],
+		[dashboardId, persist, variables],
 	);
 
 	// Delete requested from the list: if the variable is referenced anywhere, block
@@ -224,6 +242,16 @@ export function useVariableListActions({
 						? `Renamed to $${impact.newName}`
 						: `Deleted $${impact.variableName}`,
 				);
+				if (impact.mode === 'delete') {
+					const deleted = variables.find((v) => v.name === impact.variableName);
+					void logEvent(DashboardDetailEvents.VariableDeleted, {
+						variableType: deleted
+							? VARIABLE_TYPE_EVENT_LABEL[deleted.type]
+							: undefined,
+						hadReferences: true,
+						dashboardId,
+					});
+				}
 			} catch {
 				toast.error(
 					impact.mode === 'rename'
@@ -233,7 +261,7 @@ export function useVariableListActions({
 			}
 			setImpact(null);
 		},
-		[dashboard, impact, patchAsync, setVariables],
+		[dashboard, dashboardId, impact, patchAsync, setVariables, variables],
 	);
 
 	return {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/index.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from '@signozhq/ui/sonner';
+import logEvent from 'api/common/logEvent';
 import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
 import cx from 'classnames';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import settingsStyles from '../DashboardSettings.module.scss';
 import { useOptimisticPatch } from '../../hooks/useOptimisticPatch';
@@ -32,6 +34,7 @@ interface VariablesSettingsProps {
 
 function VariablesSettings({ dashboard }: VariablesSettingsProps): JSX.Element {
 	const isEditable = useDashboardStore((s) => s.isEditable);
+	const dashboardId = useDashboardStore((s) => s.dashboardId);
 	// The drawer destroys on close, so reading this once on mount is enough to
 	// open the add-form when deep-linked (e.g. the bar's "Add variable" button).
 	const openAddOnMount = useDashboardStore(
@@ -133,6 +136,10 @@ function VariablesSettings({ dashboard }: VariablesSettingsProps): JSX.Element {
 		try {
 			await patchAsync(ops);
 			toast.success(`Applied $${applyToAllVariable.name} to all panels`);
+			void logEvent(DashboardDetailEvents.ApplyToAllConfirmed, {
+				variableType: 'dynamic',
+				dashboardId,
+			});
 		} catch {
 			toast.error('Could not apply the variable to panels');
 		}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel.ts
@@ -15,6 +15,14 @@ import { sortBy } from 'lodash-es';
  */
 export type VariableType = 'QUERY' | 'CUSTOM' | 'TEXT' | 'DYNAMIC';
 
+/** Analytics label for each variable type (TEXT is surfaced as "textbox"). */
+export const VARIABLE_TYPE_EVENT_LABEL: Record<VariableType, string> = {
+	QUERY: 'query',
+	CUSTOM: 'custom',
+	TEXT: 'textbox',
+	DYNAMIC: 'dynamic',
+};
+
 /** Telemetry signal — the generated enum (traces / logs / metrics). */
 // A query/variable signal is only logs/traces/metrics. TelemetrytypesSignalDTO
 // also carries the empty "any" value used on field keys, which is not a valid

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/Header/Header.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/Header/Header.tsx
@@ -4,7 +4,9 @@ import { Button } from '@signozhq/ui/button';
 import { DialogWrapper } from '@signozhq/ui/dialog';
 import { Divider } from '@signozhq/ui/divider';
 import { Typography } from '@signozhq/ui/typography';
+import logEvent from 'api/common/logEvent';
 import { useConfirmableAction } from 'hooks/useConfirmableAction';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import DisabledControlTooltip from '../../components/DisabledControlTooltip/DisabledControlTooltip';
 import styles from './Header.module.scss';
@@ -32,7 +34,13 @@ function Header({
 	onClose,
 }: HeaderProps): JSX.Element {
 	const discard = useConfirmableAction(
-		useCallback(async (): Promise<void> => onClose(), [onClose]),
+		useCallback(async (): Promise<void> => {
+			// Only reachable after confirming a discard, which is gated on unsaved edits.
+			void logEvent(DashboardDetailEvents.PanelEditorDiscarded, {
+				wasDirty: true,
+			});
+			onClose();
+		}, [onClose]),
 	);
 
 	// Confirm before closing with unsaved edits; a pristine panel closes straight away.

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/usePanelEditorSave.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/usePanelEditorSave.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useQueryClient } from 'react-query';
 import { v4 as uuid } from 'uuid';
+import logEvent from 'api/common/logEvent';
 import { getGetDashboardV2QueryKey } from 'api/generated/services/dashboard';
 import {
 	type DashboardtypesJSONPatchOperationDTO,
@@ -9,6 +10,7 @@ import {
 	DashboardtypesPatchOpDTO,
 	type GetDashboardV2200,
 } from 'api/generated/services/sigNoz.schemas';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import { useOptimisticPatch } from '../../hooks/useOptimisticPatch';
 import { createPanelOps } from '../../patchOps';
@@ -73,6 +75,12 @@ export function usePanelEditorSave({
 
 			// Optimistic cache write + settle refetch (replaces the manual invalidate).
 			await patchAsync(ops);
+			void logEvent(DashboardDetailEvents.PanelEditorSaved, {
+				panelType: spec.plugin.kind,
+				isNew,
+				dashboardId,
+				panelId: savedPanelId,
+			});
 			return savedPanelId;
 		},
 		[dashboardId, panelId, isNew, layoutIndex, patchAsync, queryClient],

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/usePanelTypeSwitch.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/usePanelTypeSwitch.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from 'react';
+import logEvent from 'api/common/logEvent';
 import type {
 	DashboardtypesPanelPluginDTO,
 	DashboardtypesPanelSpecDTO,
@@ -11,6 +12,7 @@ import {
 	type PartialPanelTypes,
 } from 'container/NewWidget/utils';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import type {
 	OrderByPayload,
 	Query,
@@ -96,6 +98,10 @@ export function usePanelTypeSwitch({
 			if (newKind === oldKind) {
 				return;
 			}
+			void logEvent(DashboardDetailEvents.PanelTypeChanged, {
+				from: oldKind,
+				to: newKind,
+			});
 			const query = queryRef.current;
 
 			cacheRef.current.set(oldKind, {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/components/NoData/NoData.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/components/NoData/NoData.tsx
@@ -1,11 +1,14 @@
 import { CalendarRange, Clock, RotateCw } from '@signozhq/icons';
+import logEvent from 'api/common/logEvent';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import { panelHasFixedTimePreference } from '../../../hooks/resolvePanelTimeWindow';
 import {
 	selectViewPanelExtendWindow,
 	useViewPanelStore,
 } from '../../../store/useViewPanelStore';
+import { PANEL_KIND_TO_PANEL_TYPE } from '../../types/panelKind';
 import PanelLoader from '../PanelLoader/PanelLoader';
 import PanelMessage, { PanelMessageAction } from '../PanelMessage/PanelMessage';
 import { useExtendTimeWindow } from './useExtendTimeWindow';
@@ -50,17 +53,37 @@ function NoData({
 		return <PanelLoader />;
 	}
 
+	const panelType = panel
+		? PANEL_KIND_TO_PANEL_TYPE[panel.spec.plugin.kind]
+		: undefined;
+
 	const extendAction: PanelMessageAction | undefined =
 		activeExtend?.canExtend && activeExtend.actionLabel
 			? {
 					label: activeExtend.actionLabel,
-					onClick: activeExtend.extend,
+					onClick: (): void => {
+						void logEvent(DashboardDetailEvents.NoDataAction, {
+							action: 'extendTime',
+							panelType,
+						});
+						activeExtend.extend();
+					},
 					icon: <CalendarRange size={14} />,
 				}
 			: undefined;
 
 	const retryAction: PanelMessageAction | undefined = onRetry
-		? { label: 'Retry', onClick: onRetry, icon: <RotateCw size={14} /> }
+		? {
+				label: 'Retry',
+				onClick: (): void => {
+					void logEvent(DashboardDetailEvents.NoDataAction, {
+						action: 'retry',
+						panelType,
+					});
+					onRetry();
+				},
+				icon: <RotateCw size={14} />,
+			}
 		: undefined;
 
 	return (

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
@@ -74,6 +74,20 @@ function DrilldownAggregateMenu({
 		[context.filters],
 	);
 
+	const handleViewLogs = (): void => {
+		void logEvent(DashboardDetailEvents.DrilldownAction, {
+			action: 'viewLogs',
+		});
+		onViewLogs();
+	};
+
+	const handleViewTraces = (): void => {
+		void logEvent(DashboardDetailEvents.DrilldownAction, {
+			action: 'viewTraces',
+		});
+		onViewTraces();
+	};
+
 	return (
 		<>
 			<ContextMenu.Header>
@@ -106,12 +120,7 @@ function DrilldownAggregateMenu({
 						</span>
 					)
 				}
-				onClick={(): void => {
-					void logEvent(DashboardDetailEvents.DrilldownAction, {
-						action: 'viewLogs',
-					});
-					onViewLogs();
-				}}
+				onClick={handleViewLogs}
 				disabled={isResolving}
 			>
 				<span data-testid="drilldown-view-logs">View in Logs</span>
@@ -126,12 +135,7 @@ function DrilldownAggregateMenu({
 						</span>
 					)
 				}
-				onClick={(): void => {
-					void logEvent(DashboardDetailEvents.DrilldownAction, {
-						action: 'viewTraces',
-					});
-					onViewTraces();
-				}}
+				onClick={handleViewTraces}
 				disabled={isResolving}
 			>
 				<span data-testid="drilldown-view-traces">View in Traces</span>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
@@ -7,12 +7,14 @@ import {
 	Loader,
 	ScrollText,
 } from '@signozhq/icons';
+import logEvent from 'api/common/logEvent';
 import type { DashboardtypesLinkDTO } from 'api/generated/services/sigNoz.schemas';
 import { getAggregateColumnHeader } from 'container/QueryTable/Drilldown/drilldownUtils';
 import ContextMenu from 'periscope/components/ContextMenu';
 import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
 import { getDataLinks } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/getDataLinks';
 import { resolvePanelContextLinks } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 import { openInNewTab } from 'utils/navigation';
 
@@ -104,7 +106,12 @@ function DrilldownAggregateMenu({
 						</span>
 					)
 				}
-				onClick={onViewLogs}
+				onClick={(): void => {
+					void logEvent(DashboardDetailEvents.DrilldownAction, {
+						action: 'viewLogs',
+					});
+					onViewLogs();
+				}}
 				disabled={isResolving}
 			>
 				<span data-testid="drilldown-view-logs">View in Logs</span>
@@ -119,7 +126,12 @@ function DrilldownAggregateMenu({
 						</span>
 					)
 				}
-				onClick={onViewTraces}
+				onClick={(): void => {
+					void logEvent(DashboardDetailEvents.DrilldownAction, {
+						action: 'viewTraces',
+					});
+					onViewTraces();
+				}}
 				disabled={isResolving}
 			>
 				<span data-testid="drilldown-view-traces">View in Traces</span>
@@ -139,6 +151,9 @@ function DrilldownAggregateMenu({
 					key={link.id}
 					icon={<Link size={16} color={context.seriesColor} />}
 					onClick={(): void => {
+						void logEvent(DashboardDetailEvents.DrilldownAction, {
+							action: 'contextLink',
+						});
 						openInNewTab(link.url);
 						onClose();
 					}}
@@ -151,6 +166,9 @@ function DrilldownAggregateMenu({
 					key={link.id}
 					icon={<Link size={16} color={context.seriesColor} />}
 					onClick={(): void => {
+						void logEvent(DashboardDetailEvents.DrilldownAction, {
+							action: 'contextLink',
+						});
 						openInNewTab(link.url);
 						onClose();
 					}}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelHeader/PanelHeaderSearch.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelHeader/PanelHeaderSearch.tsx
@@ -36,6 +36,11 @@ function PanelHeaderSearch({
 		setExpanded(false);
 	};
 
+	const handleSearchChange = (e: ChangeEvent<HTMLInputElement>): void => {
+		onChange(e.target.value);
+		void logEvent(DashboardDetailEvents.PanelSearched, {}, 'track', true);
+	};
+
 	if (!expanded) {
 		return (
 			<TooltipSimple title="Search" arrow>
@@ -78,10 +83,7 @@ function PanelHeaderSearch({
 					<X size={14} />
 				</Button>
 			}
-			onChange={(e: ChangeEvent<HTMLInputElement>): void => {
-				onChange(e.target.value);
-				void logEvent(DashboardDetailEvents.PanelSearched, {}, 'track', true);
-			}}
+			onChange={handleSearchChange}
 			onBlur={collapseIfEmpty}
 			onKeyDown={(e: KeyboardEvent<HTMLInputElement>): void => {
 				if (e.key === 'Escape') {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelHeader/PanelHeaderSearch.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelHeader/PanelHeaderSearch.tsx
@@ -2,6 +2,8 @@ import { useState, type ChangeEvent, type KeyboardEvent } from 'react';
 import { Input } from '@signozhq/ui/input';
 import { Search, X } from '@signozhq/icons';
 import { TooltipSimple } from '@signozhq/ui/tooltip';
+import logEvent from 'api/common/logEvent';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import styles from './PanelHeaderSearch.module.scss';
 import { Button } from '@signozhq/ui/button';
@@ -76,9 +78,10 @@ function PanelHeaderSearch({
 					<X size={14} />
 				</Button>
 			}
-			onChange={(e: ChangeEvent<HTMLInputElement>): void =>
-				onChange(e.target.value)
-			}
+			onChange={(e: ChangeEvent<HTMLInputElement>): void => {
+				onChange(e.target.value);
+				void logEvent(DashboardDetailEvents.PanelSearched, {}, 'track', true);
+			}}
 			onBlur={collapseIfEmpty}
 			onKeyDown={(e: KeyboardEvent<HTMLInputElement>): void => {
 				if (e.key === 'Escape') {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/ViewPanelModalContent.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/ViewPanelModal/ViewPanelModalContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
 import { PanelMode } from 'container/DashboardContainer/visualization/panels/types';
 import { DashboardCursorSync } from 'lib/uPlotV2/plugins/TooltipPlugin/types';
@@ -17,7 +17,10 @@ import { useViewPanelMode } from './useViewPanelMode';
 import { useViewPanelTimeWindow } from './useViewPanelTimeWindow';
 import styles from './ViewPanelModal.module.scss';
 import logEvent from 'api/common/logEvent';
-import { DashboardEvents } from 'pages/DashboardPageV2/constants/events';
+import {
+	DashboardDetailEvents,
+	DashboardEvents,
+} from 'pages/DashboardPageV2/constants/events';
 
 interface ViewPanelModalContentProps {
 	panel: DashboardtypesPanelDTO;
@@ -84,6 +87,21 @@ function ViewPanelModalContent({
 		[dashboardPreference],
 	);
 	const openPanelEditor = useOpenPanelEditor();
+
+	// Modal drag-to-zoom is its own path (local window, not the grid's) — tag it distinctly.
+	const handleDragSelect = useCallback(
+		(start: number, end: number): void => {
+			if (Math.floor(start) !== Math.floor(end)) {
+				void logEvent(DashboardDetailEvents.PanelZoomed, {
+					context: 'viewModal',
+					panelType: draft.spec.plugin.kind,
+					panelId,
+				});
+			}
+			onDragSelect(start, end);
+		},
+		[onDragSelect, draft.spec.plugin.kind, panelId],
+	);
 
 	// Publish the modal's local extender for the nested no-data state; cleared on close.
 	const setViewPanelExtendWindow = useViewPanelStore(
@@ -160,7 +178,7 @@ function ViewPanelModalContent({
 					isPreviousData={isPreviousData}
 					error={error}
 					refetch={refetch}
-					onDragSelect={onDragSelect}
+					onDragSelect={handleDragSelect}
 					pagination={pagination}
 					panelMode={PanelMode.STANDALONE_VIEW}
 					dashboardPreference={isolatedPreference}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useClonePanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useClonePanel.ts
@@ -1,6 +1,9 @@
 import { useCallback } from 'react';
 import { toast } from '@signozhq/ui/sonner';
+import logEvent from 'api/common/logEvent';
 import { cloneDeep } from 'lodash-es';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
+import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import { v4 as uuid } from 'uuid';
 
 import { useOptimisticPatch } from '../../../hooks/useOptimisticPatch';
@@ -75,6 +78,12 @@ export function useClonePanel({
 			// rejection (the optimistic cache write + settle refetch handle state).
 			try {
 				await clone;
+				void logEvent(DashboardDetailEvents.PanelAction, {
+					action: 'clone',
+					panelType: PANEL_KIND_TO_PANEL_TYPE[source.panel.spec.plugin.kind],
+					panelId,
+					dashboardId,
+				});
 			} catch {
 				// no-op
 			}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDeletePanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDeletePanel.ts
@@ -1,4 +1,7 @@
 import { useCallback } from 'react';
+import logEvent from 'api/common/logEvent';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
+import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
@@ -38,12 +41,21 @@ export function useDeletePanel({
 				return;
 			}
 
+			const removed = section.items.find((i) => i.id === panelId);
 			const nextItems = section.items.filter((i) => i.id !== panelId);
 			try {
 				await patchAsync([
 					replaceSectionItemsOp(layoutIndex, nextItems),
 					removePanelOp(panelId),
 				]);
+				void logEvent(DashboardDetailEvents.PanelAction, {
+					action: 'delete',
+					panelType: removed?.panel
+						? PANEL_KIND_TO_PANEL_TYPE[removed.panel.spec.plugin.kind]
+						: undefined,
+					panelId,
+					dashboardId,
+				});
 			} catch (error) {
 				showErrorModal(error as APIError);
 			}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelCsv.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelCsv.ts
@@ -1,6 +1,9 @@
 import { useCallback } from 'react';
+import logEvent from 'api/common/logEvent';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { getTableCsvRows } from 'pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/tableCsv';
+import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 import type { PanelOfKind } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/rendererProps';
 import { downloadCsv } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/downloadCsv';
 import type { PanelQueryData } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
@@ -37,5 +40,9 @@ export function useDownloadPanelCsv({
 			return;
 		}
 		downloadCsv(rows, fileName);
+		void logEvent(DashboardDetailEvents.PanelExported, {
+			format: 'csv',
+			panelType: PANEL_KIND_TO_PANEL_TYPE[panel.spec.plugin.kind],
+		});
 	}, [canDownloadCsv, fileName, panel, data]);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelImage.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDownloadPanelImage.ts
@@ -1,5 +1,7 @@
 import { useCallback } from 'react';
 import { toast } from '@signozhq/ui/sonner';
+import logEvent from 'api/common/logEvent';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import {
 	downloadElementAsImage,
@@ -37,6 +39,10 @@ export function useDownloadPanelImage(): UseDownloadPanelImage {
 			}
 			try {
 				await downloadElementAsImage(node, panelName, format);
+				void logEvent(DashboardDetailEvents.PanelExported, {
+					format,
+					panelId,
+				});
 			} catch {
 				toast.error('Could not download panel.', {
 					action: {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
+import logEvent from 'api/common/logEvent';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
 import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
 import useBaseDrilldownNavigate from 'container/QueryTable/Drilldown/useBaseDrilldownNavigate';
@@ -18,6 +19,7 @@ import { buildAggregateData } from 'pages/DashboardPageV2/DashboardContainer/Pan
 import { getBuilderQueries } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries';
 import { getPanelQueryType } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getPanelQueryType';
 import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { EQueryType } from 'types/common/dashboard';
 
 import DrilldownAggregateMenu from '../DrilldownMenu/DrilldownAggregateMenu';
@@ -125,10 +127,11 @@ export function useDrilldown(
 
 	const onPanelClick = useCallback(
 		(payload: DrilldownClickPayload): void => {
+			void logEvent(DashboardDetailEvents.DrilldownOpened, { panelType });
 			setSubMenu(DrilldownSubMenu.Base);
 			onClick(payload.coordinates, payload.context);
 		},
-		[onClick],
+		[onClick, panelType],
 	);
 
 	const handleClose = useCallback((): void => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownBreakout.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownBreakout.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import logEvent from 'api/common/logEvent';
 import type { PANEL_TYPES } from 'constants/queryBuilder';
 import { getQueryData } from 'container/QueryTable/Drilldown/drilldownUtils';
 import {
@@ -7,6 +8,7 @@ import {
 } from 'container/QueryTable/Drilldown/tableDrilldownUtils';
 import type { BreakoutAttributeType } from 'container/QueryTable/Drilldown/types';
 import type { AggregateData } from 'container/QueryTable/Drilldown/useAggregateDrilldown';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import type {
 	IBuilderQuery,
 	Query,
@@ -54,6 +56,10 @@ export function useDrilldownBreakout({
 			if (!aggregateData) {
 				return;
 			}
+			void logEvent(DashboardDetailEvents.DrilldownAction, {
+				action: 'breakout',
+				panelType,
+			});
 			const breakoutQuery = getBreakoutQuery(
 				v1Query,
 				aggregateData,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { toast } from '@signozhq/ui/sonner';
+import logEvent from 'api/common/logEvent';
 import type { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
 import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
 import {
@@ -17,6 +18,7 @@ import { useOptimisticPatch } from 'pages/DashboardPageV2/DashboardContainer/hoo
 import { selectVariableValues } from 'pages/DashboardPageV2/DashboardContainer/store/slices/variableSelectionSlice';
 import { useDashboardStore } from 'pages/DashboardPageV2/DashboardContainer/store/useDashboardStore';
 import type { VariableSelection } from 'pages/DashboardPageV2/DashboardContainer/VariablesBar/selectionTypes';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 interface UseDrilldownDashboardVariablesArgs {
 	/** Group-by field filters from the clicked point (empty when the click has no group-by). */
@@ -98,6 +100,10 @@ export function useDrilldownDashboardVariables({
 				toast.error(`Variable "${fieldName}" already exists`);
 				return;
 			}
+			void logEvent(DashboardDetailEvents.DrilldownAction, {
+				action: 'createVariable',
+				dashboardId,
+			});
 			const model: VariableFormModel = {
 				...emptyVariableFormModel(),
 				name: fieldName,
@@ -120,7 +126,15 @@ export function useDrilldownDashboardVariables({
 			}
 			onClose();
 		},
-		[existingNames, signal, variables, patchAsync, setSelection, onClose],
+		[
+			existingNames,
+			signal,
+			variables,
+			patchAsync,
+			setSelection,
+			onClose,
+			dashboardId,
+		],
 	);
 
 	const actions = useMemo<DrilldownVariableAction[]>(
@@ -156,6 +170,10 @@ export function useDrilldownDashboardVariables({
 						? DrilldownVariableActionKind.Unset
 						: DrilldownVariableActionKind.Set,
 					onClick: (): void => {
+						void logEvent(DashboardDetailEvents.DrilldownAction, {
+							action: 'setVariable',
+							dashboardId,
+						});
 						setSelection(existing.name, {
 							value: isSame ? cleared : assigned,
 							allSelected: false,
@@ -171,6 +189,7 @@ export function useDrilldownDashboardVariables({
 			setSelection,
 			handleCreate,
 			onClose,
+			dashboardId,
 		],
 	);
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownFilter.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownFilter.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import logEvent from 'api/common/logEvent';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import {
 	addFilterToQuery,
@@ -6,6 +7,7 @@ import {
 	isNumberDataType,
 } from 'container/QueryTable/Drilldown/drilldownUtils';
 import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 
 interface UseDrilldownFilterArgs {
@@ -59,6 +61,10 @@ export function useDrilldownFilter({
 			const refinedQuery = addFilterToQuery(v1Query, [
 				{ filterKey: context.clickedKey, filterValue, operator },
 			]);
+			void logEvent(DashboardDetailEvents.DrilldownAction, {
+				action: 'filterByValue',
+				panelType,
+			});
 			openViewWithQuery(panelId, refinedQuery, panelType);
 			onClose();
 		},

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useMovePanelToSection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useMovePanelToSection.ts
@@ -1,4 +1,7 @@
 import { useCallback } from 'react';
+import logEvent from 'api/common/logEvent';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
+import { PANEL_KIND_TO_PANEL_TYPE } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/panelKind';
 
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
@@ -66,6 +69,14 @@ export function useMovePanelToSection({
 						targetItems,
 					}),
 				);
+				void logEvent(DashboardDetailEvents.PanelAction, {
+					action: 'move',
+					panelType: moved.panel
+						? PANEL_KIND_TO_PANEL_TYPE[moved.panel.spec.plugin.kind]
+						: undefined,
+					panelId,
+					dashboardId,
+				});
 			} catch (error) {
 				showErrorModal(error as APIError);
 			}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/usePanelInteractions.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/usePanelInteractions.ts
@@ -9,6 +9,8 @@ import { useDashboardCursorSyncMode } from 'hooks/dashboard/useDashboardCursorSy
 import { useSyncTooltipFilterMode } from 'hooks/dashboard/useSyncTooltipFilterMode';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import useUrlQuery from 'hooks/useUrlQuery';
+import logEvent from 'api/common/logEvent';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { UpdateTimeInterval } from 'store/actions';
 
 export interface PanelInteractions {
@@ -51,6 +53,7 @@ export function usePanelInteractions(): PanelInteractions {
 
 			if (startTimestamp !== endTimestamp) {
 				dispatch(UpdateTimeInterval('custom', [startTimestamp, endTimestamp]));
+				void logEvent(DashboardDetailEvents.PanelZoomed, { context: 'panel' });
 			}
 		},
 		[dispatch, pathname, safeNavigate, urlQuery],

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useViewPanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useViewPanel.ts
@@ -1,9 +1,11 @@
 import { useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
+import logEvent from 'api/common/logEvent';
 import { QueryParams } from 'constants/query';
 import type { PANEL_TYPES } from 'constants/queryBuilder';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import useUrlQuery from 'hooks/useUrlQuery';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 
 import { clearViewPanelHandoff } from '../ViewPanelModal/viewPanelHandoffStore';
@@ -48,6 +50,7 @@ export function useViewPanel(): UseViewPanelApi {
 			next.delete(QueryParams.compositeQuery);
 			next.delete(QueryParams.graphType);
 			clearViewPanelHandoff();
+			void logEvent(DashboardDetailEvents.PanelViewed, { panelId });
 			safeNavigate(`${pathname}?${next.toString()}`);
 		},
 		[pathname, safeNavigate, urlQuery],

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useAddSection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useAddSection.ts
@@ -1,6 +1,8 @@
 import { useCallback, useState } from 'react';
 
+import logEvent from 'api/common/logEvent';
 import type { DashboardtypesLayoutDTO } from 'api/generated/services/sigNoz.schemas';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
@@ -48,6 +50,10 @@ export function useAddSection({ layouts }: Params): Result {
 			try {
 				setIsSaving(true);
 				await patchAsync([op]);
+				void logEvent(DashboardDetailEvents.SectionAction, {
+					action: 'add',
+					dashboardId,
+				});
 				// The new empty section is appended, so its layout index is the prior count;
 				// key it the way `getSectionStableId` does so it reveals itself on render.
 				const newIndex = isFirstSection ? 0 : layouts.length;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useCloneSection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useCloneSection.ts
@@ -3,6 +3,9 @@ import { toast } from '@signozhq/ui/sonner';
 import { cloneDeep } from 'lodash-es';
 import { v4 as uuid } from 'uuid';
 
+import logEvent from 'api/common/logEvent';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
+
 import { useOptimisticPatch } from '../../../hooks/useOptimisticPatch';
 import { cloneSectionOps } from '../../../patchOps';
 import type { DashboardSection } from '../../../utils';
@@ -46,6 +49,10 @@ export function useCloneSection(): (
 
 			try {
 				await clone;
+				void logEvent(DashboardDetailEvents.SectionAction, {
+					action: 'clone',
+					panelCount: panels.length,
+				});
 			} catch {
 				// toast.promise owns the error UX; the optimistic write + settle handle state.
 			}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useDeleteSection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useDeleteSection.ts
@@ -1,6 +1,8 @@
 import { useCallback, useState } from 'react';
 
+import logEvent from 'api/common/logEvent';
 import type { DashboardtypesJSONPatchOperationDTO } from 'api/generated/services/sigNoz.schemas';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
@@ -39,6 +41,11 @@ export function useDeleteSection({ section }: Params): Result {
 		try {
 			setIsSaving(true);
 			await patchAsync(ops);
+			void logEvent(DashboardDetailEvents.SectionAction, {
+				action: 'delete',
+				panelCount: section.items.length,
+				dashboardId,
+			});
 		} catch (error) {
 			showErrorModal(error as APIError);
 		} finally {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useFirstSectionMigration.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useFirstSectionMigration.ts
@@ -1,6 +1,8 @@
 import { useCallback, useState } from 'react';
 
+import logEvent from 'api/common/logEvent';
 import type { DashboardtypesJSONPatchOperationDTO } from 'api/generated/services/sigNoz.schemas';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
@@ -50,6 +52,9 @@ export function useFirstSectionMigration({ sections }: Params): Result {
 			try {
 				setIsSaving(true);
 				await patchAsync(ops);
+				void logEvent(DashboardDetailEvents.FirstSectionMigrationConfirmed, {
+					dashboardId,
+				});
 			} catch (error) {
 				showErrorModal(error as APIError);
 			} finally {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/usePersistLayout.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/usePersistLayout.ts
@@ -1,6 +1,8 @@
 import { useCallback, useState } from 'react';
 import type { Layout } from 'react-grid-layout';
 
+import logEvent from 'api/common/logEvent';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
@@ -78,6 +80,9 @@ export function usePersistLayout({ layoutIndex, items }: Params): Result {
 			if (!hasGeometryChanged(nextItems, items)) {
 				return;
 			}
+			// High-frequency (drag/resize stop) — rate-limited. Single handler can't tell
+			// drag from resize, so changeType is omitted.
+			void logEvent(DashboardDetailEvents.LayoutChanged, {}, 'track', true);
 			try {
 				setIsSaving(true);
 				await patchAsync([replaceSectionItemsOp(layoutIndex, nextItems)]);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useRenameSection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useRenameSection.ts
@@ -1,5 +1,7 @@
 import { useCallback, useState } from 'react';
 
+import logEvent from 'api/common/logEvent';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
@@ -32,6 +34,10 @@ export function useRenameSection({ layoutIndex }: Params): Result {
 			try {
 				setIsSaving(true);
 				await patchAsync([renameSectionOp(layoutIndex, trimmed)]);
+				void logEvent(DashboardDetailEvents.SectionAction, {
+					action: 'rename',
+					dashboardId,
+				});
 				return true;
 			} catch (error) {
 				showErrorModal(error as APIError);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useSectionDragReorder.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useSectionDragReorder.ts
@@ -9,7 +9,9 @@ import {
 } from '@dnd-kit/core';
 import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 
+import logEvent from 'api/common/logEvent';
 import type { DashboardtypesLayoutDTO } from 'api/generated/services/sigNoz.schemas';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
@@ -100,6 +102,10 @@ export function useSectionDragReorder({ sections, layouts }: Params): Result {
 
 			try {
 				await patchAsync([reorderLayoutsOp(newLayouts)]);
+				void logEvent(DashboardDetailEvents.SectionsReordered, {
+					sectionCount: newOrdered.length,
+					dashboardId,
+				});
 			} catch (error) {
 				setLocalOrderIds(null); // revert optimistic order on failure
 				showErrorModal(error as APIError);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useToggleSectionCollapse.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Section/hooks/useToggleSectionCollapse.ts
@@ -1,5 +1,8 @@
 import { useCallback } from 'react';
 
+import logEvent from 'api/common/logEvent';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
+
 import {
 	selectIsSectionOpen,
 	useDashboardStore,
@@ -29,8 +32,13 @@ export function useToggleSectionCollapse({ sectionId }: Params): Result {
 	const toggle = useCallback((): void => {
 		if (dashboardId) {
 			toggleSectionCollapse(dashboardId, sectionId);
+			// `open` flips on toggle, so the resulting collapsed state is the current `open`.
+			void logEvent(DashboardDetailEvents.SectionCollapsed, {
+				collapsed: open,
+				dashboardId,
+			});
 		}
-	}, [dashboardId, sectionId, toggleSectionCollapse]);
+	}, [dashboardId, sectionId, toggleSectionCollapse, open]);
 
 	return { open, toggle };
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/selectors/TextSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/selectors/TextSelector.tsx
@@ -2,6 +2,8 @@ import { useCallback, useRef, useState } from 'react';
 import type { InputRef } from 'antd';
 // eslint-disable-next-line signoz/no-antd-components -- match V1 textbox behaviour (commit on blur/Enter, borderless)
 import { Input } from 'antd';
+import logEvent from 'api/common/logEvent';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import type { VariableSelection } from '../../selectionTypes';
 import styles from '../../VariablesBar.module.scss';
@@ -30,7 +32,19 @@ function TextSelector({
 	);
 
 	const commit = useCallback(
-		(next: string): void => onChange({ value: next, allSelected: false }),
+		(next: string): void => {
+			void logEvent(
+				DashboardDetailEvents.VariableValueSelected,
+				{
+					variableType: 'textbox',
+					multiSelect: false,
+					selectionCount: next ? 1 : 0,
+				},
+				'track',
+				true,
+			);
+			onChange({ value: next, allSelected: false });
+		},
 		[onChange],
 	);
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/selectors/ValueSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/selectors/ValueSelector.tsx
@@ -1,12 +1,16 @@
 import { useMemo } from 'react';
+import logEvent from 'api/common/logEvent';
 import { CustomMultiSelect, CustomSelect } from 'components/NewSelect';
 import type { OptionData } from 'components/NewSelect/types';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import type { VariableSelection } from '../../selectionTypes';
 import styles from '../../VariablesBar.module.scss';
 
 interface ValueSelectorProps {
 	options: string[];
+	/** Analytics label for the variable type (query / custom / dynamic). */
+	variableType: string;
 	multiSelect: boolean;
 	showAllOption: boolean;
 	loading?: boolean;
@@ -25,6 +29,7 @@ interface ValueSelectorProps {
  */
 function ValueSelector({
 	options,
+	variableType,
 	multiSelect,
 	showAllOption,
 	loading,
@@ -67,6 +72,12 @@ function ValueSelector({
 						: next
 							? [String(next)]
 							: [];
+					void logEvent(
+						DashboardDetailEvents.VariableValueSelected,
+						{ variableType, multiSelect: true, selectionCount: values.length },
+						'track',
+						true,
+					);
 					if (values.length === 0) {
 						onChange({ value: [], allSelected: false });
 						return;
@@ -78,7 +89,12 @@ function ValueSelector({
 						options.every((option) => values.includes(option));
 					onChange({ value: values, allSelected: isAll });
 				}}
-				onClear={(): void => onChange({ value: [], allSelected: false })}
+				onClear={(): void => {
+					void logEvent(DashboardDetailEvents.VariableMultiSelectCleared, {
+						variableType,
+					});
+					onChange({ value: [], allSelected: false });
+				}}
 			/>
 		);
 	}
@@ -98,9 +114,15 @@ function ValueSelector({
 			onRetry={onRetry}
 			showSearch
 			placeholder="Select value"
-			onChange={(next): void =>
-				onChange({ value: next == null ? '' : String(next), allSelected: false })
-			}
+			onChange={(next): void => {
+				void logEvent(
+					DashboardDetailEvents.VariableValueSelected,
+					{ variableType, multiSelect: false, selectionCount: next == null ? 0 : 1 },
+					'track',
+					true,
+				);
+				onChange({ value: next == null ? '' : String(next), allSelected: false });
+			}}
 		/>
 	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/selectors/VariableValueControl.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/selectors/VariableValueControl.tsx
@@ -1,4 +1,7 @@
-import type { VariableFormModel } from '../../../DashboardSettings/Variables/variableFormModel';
+import {
+	VARIABLE_TYPE_EVENT_LABEL,
+	type VariableFormModel,
+} from '../../../DashboardSettings/Variables/variableFormModel';
 import type {
 	VariableSelection,
 	VariableSelectionMap,
@@ -44,6 +47,7 @@ function VariableValueControl({
 	return (
 		<ValueSelector
 			options={options}
+			variableType={VARIABLE_TYPE_EVENT_LABEL[variable.type]}
 			multiSelect={variable.multiSelect}
 			showAllOption={variable.showAllOption}
 			loading={loading}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/hooks/useVariableOptions.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/hooks/useVariableOptions.ts
@@ -1,7 +1,12 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
+import logEvent from 'api/common/logEvent';
 import { commaValuesParser } from 'lib/dashboardVariables/customCommaValuesParser';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
-import { sortValuesByOrder } from '../../DashboardSettings/Variables/variableFormModel';
+import {
+	sortValuesByOrder,
+	VARIABLE_TYPE_EVENT_LABEL,
+} from '../../DashboardSettings/Variables/variableFormModel';
 import type { VariableFormModel } from '../../DashboardSettings/Variables/variableFormModel';
 import type { VariableSelectionMap } from '../selectionTypes';
 import {
@@ -35,6 +40,15 @@ export function useVariableOptions(
 				: ([] as string[]),
 		[variable.type, variable.customValue, variable.sort],
 	);
+
+	// One-shot per distinct fetch error (effect only re-runs when it changes).
+	useEffect(() => {
+		if (fetched.errorMessage) {
+			void logEvent(DashboardDetailEvents.VariableOptionsFetchFailed, {
+				variableType: VARIABLE_TYPE_EVENT_LABEL[variable.type],
+			});
+		}
+	}, [fetched.errorMessage, variable.type]);
 
 	if (variable.type === 'CUSTOM') {
 		return { options: customOptions, loading: false, errorMessage: null };

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardChangedDialog/DashboardChangedDialog.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/components/DashboardChangedDialog/DashboardChangedDialog.tsx
@@ -1,7 +1,10 @@
 import { RotateCcw } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
 import { DialogWrapper } from '@signozhq/ui/dialog';
+import logEvent from 'api/common/logEvent';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
+import { useDashboardStore } from '../../store/useDashboardStore';
 import styles from './DashboardChangedDialog.module.scss';
 
 interface DashboardChangedDialogProps {
@@ -15,12 +18,30 @@ function DashboardChangedDialog({
 	onReload,
 	onDismiss,
 }: DashboardChangedDialogProps): JSX.Element {
+	const dashboardId = useDashboardStore((s) => s.dashboardId);
+
+	const handleReload = (): void => {
+		void logEvent(DashboardDetailEvents.StaleReloadPrompted, {
+			dashboardId,
+			action: 'reload',
+		});
+		onReload();
+	};
+
+	const handleDismiss = (): void => {
+		void logEvent(DashboardDetailEvents.StaleReloadPrompted, {
+			dashboardId,
+			action: 'dismiss',
+		});
+		onDismiss();
+	};
+
 	const footer = (
 		<div className={styles.footer}>
 			<Button
 				variant="solid"
 				color="secondary"
-				onClick={onDismiss}
+				onClick={handleDismiss}
 				testId="dashboard-changed-dismiss"
 			>
 				Dismiss
@@ -29,7 +50,7 @@ function DashboardChangedDialog({
 				variant="solid"
 				color="primary"
 				prefix={<RotateCcw size={12} />}
-				onClick={onReload}
+				onClick={handleReload}
 				testId="dashboard-changed-reload"
 			>
 				Reload

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useCreatePanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useCreatePanel.ts
@@ -1,10 +1,15 @@
 import { useCallback, useState } from 'react';
 import { generatePath } from 'react-router-dom';
+import logEvent from 'api/common/logEvent';
 import ROUTES from 'constants/routes';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import { newPanelSearch, NEW_PANEL_ID } from '../PanelEditor/newPanelRoute';
-import type { PanelKind } from '../Panels/types/panelKind';
+import {
+	PANEL_KIND_TO_PANEL_TYPE,
+	type PanelKind,
+} from '../Panels/types/panelKind';
 import { useDashboardStore } from '../store/useDashboardStore';
 
 interface UseCreatePanelResult {
@@ -43,6 +48,10 @@ export function useCreatePanel(): UseCreatePanelResult {
 	const createPanel = useCallback(
 		(panelKind: PanelKind, targetIndex?: number): void => {
 			setIsPickerOpen(false);
+			void logEvent(DashboardDetailEvents.PanelAdded, {
+				panelType: PANEL_KIND_TO_PANEL_TYPE[panelKind],
+				dashboardId,
+			});
 			const path = generatePath(ROUTES.DASHBOARD_PANEL_EDITOR, {
 				dashboardId,
 				panelId: NEW_PANEL_ID,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useCreatePanel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useCreatePanel.ts
@@ -1,16 +1,8 @@
 import { useCallback, useState } from 'react';
-import { generatePath } from 'react-router-dom';
-import logEvent from 'api/common/logEvent';
-import ROUTES from 'constants/routes';
-import { useSafeNavigate } from 'hooks/useSafeNavigate';
-import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import { newPanelSearch, NEW_PANEL_ID } from '../PanelEditor/newPanelRoute';
-import {
-	PANEL_KIND_TO_PANEL_TYPE,
-	type PanelKind,
-} from '../Panels/types/panelKind';
-import { useDashboardStore } from '../store/useDashboardStore';
+import type { PanelKind } from '../Panels/types/panelKind';
+import { useOpenPanelEditor } from './useOpenPanelEditor';
 
 interface UseCreatePanelResult {
 	isPickerOpen: boolean;
@@ -47,14 +39,6 @@ export function useCreatePanel(): UseCreatePanelResult {
 	const createPanel = useCallback(
 		(panelKind: PanelKind, targetIndex?: number): void => {
 			setIsPickerOpen(false);
-			void logEvent(DashboardDetailEvents.PanelAdded, {
-				panelType: PANEL_KIND_TO_PANEL_TYPE[panelKind],
-				dashboardId,
-			});
-			const path = generatePath(ROUTES.DASHBOARD_PANEL_EDITOR, {
-				dashboardId,
-				panelId: NEW_PANEL_ID,
-			});
 			const target = targetIndex ?? layoutIndex;
 			openPanelEditor(NEW_PANEL_ID, {
 				search: newPanelSearch(panelKind, target),

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useOpenPanelEditor.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useOpenPanelEditor.ts
@@ -1,13 +1,13 @@
 import { useCallback } from 'react';
 import { generatePath } from 'react-router-dom';
-import logEvent from 'api/common/logEvent';
 import ROUTES from 'constants/routes';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
-import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import type { PanelEditorHandoffState } from '../PanelEditor/panelEditorHandoff';
 import { useDashboardStore } from '../store/useDashboardStore';
 import { useTimeSearchParams } from './useTimeSearchParams';
+import logEvent from '@/api/common/logEvent';
+import { DashboardDetailEvents } from '../../constants/events';
 
 interface OpenPanelEditorOptions {
 	handoffState?: PanelEditorHandoffState;
@@ -25,12 +25,21 @@ export function useOpenPanelEditor(): (
 	const dashboardId = useDashboardStore((s) => s.dashboardId);
 
 	return useCallback(
-		(panelId: string, handoffState?: PanelEditorHandoffState): void => {
+		(panelId: string, options?: OpenPanelEditorOptions): void => {
 			void logEvent(DashboardDetailEvents.PanelAction, {
 				action: 'edit',
 				panelId,
 				dashboardId,
 			});
+			const path = generatePath(ROUTES.DASHBOARD_PANEL_EDITOR, {
+				dashboardId,
+				panelId,
+			});
+			const params = new URLSearchParams(options?.search);
+			new URLSearchParams(timeSearch).forEach((value, key) => {
+				params.set(key, value);
+			});
+			const search = params.toString();
 			safeNavigate(
 				search ? `${path}?${search}` : path,
 				options?.handoffState ? { state: options.handoffState } : undefined,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useOpenPanelEditor.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useOpenPanelEditor.ts
@@ -1,7 +1,9 @@
 import { useCallback } from 'react';
 import { generatePath } from 'react-router-dom';
+import logEvent from 'api/common/logEvent';
 import ROUTES from 'constants/routes';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import type { PanelEditorHandoffState } from '../PanelEditor/panelEditorHandoff';
 import { useDashboardStore } from '../store/useDashboardStore';
@@ -24,6 +26,11 @@ export function useOpenPanelEditor(): (
 
 	return useCallback(
 		(panelId: string, handoffState?: PanelEditorHandoffState): void => {
+			void logEvent(DashboardDetailEvents.PanelAction, {
+				action: 'edit',
+				panelId,
+				dashboardId,
+			});
 			safeNavigate(
 				generatePath(ROUTES.DASHBOARD_PANEL_EDITOR, { dashboardId, panelId }),
 				handoffState ? { state: handoffState } : undefined,

--- a/frontend/src/pages/DashboardPageV2/DashboardPageV2.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardPageV2.tsx
@@ -1,7 +1,10 @@
+import { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { Typography } from '@signozhq/ui/typography';
+import logEvent from 'api/common/logEvent';
 import Spinner from 'components/Spinner';
+import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import DashboardContainer from './DashboardContainer';
 import { useDashboardFetch } from './DashboardContainer/hooks/useDashboardFetch';
@@ -12,6 +15,23 @@ function DashboardPageV2(): JSX.Element {
 
 	const { dashboard, isLoading, isError, error, refetch } =
 		useDashboardFetch(dashboardId);
+
+	// Fire once per dashboard load (re-fires on navigating to a different id).
+	const openedRef = useRef<string | null>(null);
+	useEffect(() => {
+		if (!dashboard || openedRef.current === dashboard.id) {
+			return;
+		}
+		openedRef.current = dashboard.id;
+		const { spec } = dashboard;
+		void logEvent(DashboardDetailEvents.Opened, {
+			dashboardId: dashboard.id,
+			dashboardName: spec.display.name,
+			panelCount: Object.keys(spec.panels).length,
+			variableCount: spec.variables.length,
+			sectionCount: spec.layouts.length,
+		});
+	}, [dashboard]);
 
 	if (isLoading) {
 		return <Spinner tip="Loading dashboard..." />;

--- a/frontend/src/pages/DashboardPageV2/constants/events.ts
+++ b/frontend/src/pages/DashboardPageV2/constants/events.ts
@@ -2,3 +2,69 @@ export enum DashboardEvents {
 	SWITCH_TO_EDIT_MODE = 'View Panel: Switch to edit mode',
 	SWITCH_TO_VIEW_MODE = 'Edit Panel: Switch to view mode',
 }
+
+/**
+ * Analytics events for the V2 dashboard detail page.
+ * Fire via `logEvent(DashboardDetailEvents.<X>, { ...camelCaseProps })`.
+ */
+export enum DashboardDetailEvents {
+	// Lifecycle
+	Opened = 'Dashboard Detail V2: Opened',
+	PanelDataFetched = 'Dashboard Detail V2: Panel data fetched',
+	Renamed = 'Dashboard Detail V2: Dashboard renamed',
+	Cloned = 'Dashboard Detail V2: Dashboard cloned',
+	Deleted = 'Dashboard Detail V2: Dashboard deleted',
+	LockToggled = 'Dashboard Detail V2: Lock toggled',
+	FullScreenToggled = 'Dashboard Detail V2: Full screen toggled',
+	StaleReloadPrompted = 'Dashboard Detail V2: Stale reload prompted',
+	PublicUrlOpened = 'Dashboard Detail V2: Public URL opened',
+
+	// Sections
+	SectionAction = 'Dashboard Detail V2: Section action',
+	SectionCollapsed = 'Dashboard Detail V2: Section collapsed',
+	SectionsReordered = 'Dashboard Detail V2: Sections reordered',
+	FirstSectionMigrationConfirmed = 'Dashboard Detail V2: First section migration confirmed',
+
+	// Panels
+	PanelAdded = 'Dashboard Detail V2: Panel added',
+	// Reuses the existing V1 string so panel actions stay comparable across versions.
+	PanelAction = 'Dashboard Detail: Panel action',
+	PanelExported = 'Dashboard Detail V2: Panel exported',
+	PanelViewed = 'Dashboard Detail V2: Panel viewed',
+	PanelEditorSaved = 'Dashboard Detail V2: Panel editor saved',
+	PanelEditorDiscarded = 'Dashboard Detail V2: Panel editor discarded',
+	PanelTypeChanged = 'Dashboard Detail V2: Panel type changed',
+	PanelSearched = 'Dashboard Detail V2: Panel searched',
+	NoDataAction = 'Dashboard Detail V2: No data action',
+
+	// Layout (high-frequency — fire rate-limited)
+	LayoutChanged = 'Dashboard Detail V2: Layout changed',
+
+	// Variables — setup
+	VariableSaved = 'Dashboard Detail V2: Variable saved',
+	VariableDeleted = 'Dashboard Detail V2: Variable deleted',
+	VariableReordered = 'Dashboard Detail V2: Variable reordered',
+	VariableQueryTested = 'Dashboard Detail V2: Variable query tested',
+	ApplyToAllConfirmed = 'Dashboard Detail V2: Apply to all confirmed',
+
+	// Variables — runtime selection
+	VariableValueSelected = 'Dashboard Detail V2: Variable value selected',
+	VariableMultiSelectCleared = 'Dashboard Detail V2: Variable multiselect cleared',
+	VariableOptionsFetchFailed = 'Dashboard Detail V2: Variable options fetch failed',
+
+	// Drill-down
+	DrilldownOpened = 'Dashboard Detail V2: Drilldown opened',
+	DrilldownAction = 'Dashboard Detail V2: Drilldown action',
+	PanelZoomed = 'Dashboard Detail V2: Panel zoomed',
+
+	// JSON editor
+	JsonEditorOpened = 'Dashboard Detail V2: JSON editor opened',
+	JsonEditorAction = 'Dashboard Detail V2: JSON editor action',
+
+	// Settings & sharing
+	SettingsOpened = 'Dashboard Detail V2: Settings opened',
+	OverviewSaved = 'Dashboard Detail V2: Overview saved',
+	OverviewDiscarded = 'Dashboard Detail V2: Overview discarded',
+	CursorSyncChanged = 'Dashboard Detail V2: Cursor sync changed',
+	PublicDashboardAction = 'Dashboard Detail V2: Public dashboard action',
+}

--- a/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.tsx
@@ -116,6 +116,26 @@ function ActionsPopover({
 		},
 	});
 
+	const handleOpenInNewTab = (e: React.MouseEvent<HTMLElement>): void => {
+		e.stopPropagation();
+		e.preventDefault();
+		openInNewTab(link);
+		void logEvent(DashboardListEvents.RowAction, {
+			action: 'openNewTab',
+			dashboardId,
+		});
+	};
+
+	const handleCopyLink = (e: React.MouseEvent<HTMLElement>): void => {
+		e.stopPropagation();
+		e.preventDefault();
+		setCopy(getAbsoluteUrl(link));
+		void logEvent(DashboardListEvents.RowAction, {
+			action: 'copyLink',
+			dashboardId,
+		});
+	};
+
 	return (
 		<>
 			<Popover
@@ -139,15 +159,7 @@ function ActionsPopover({
 									color="secondary"
 									className={styles.menuItem}
 									prefix={<SquareArrowOutUpRight size={14} />}
-									onClick={(e): void => {
-										e.stopPropagation();
-										e.preventDefault();
-										openInNewTab(link);
-										void logEvent(DashboardListEvents.RowAction, {
-											action: 'openNewTab',
-											dashboardId,
-										});
-									}}
+									onClick={handleOpenInNewTab}
 									testId="dashboard-action-open-new-tab"
 								>
 									Open in New Tab
@@ -156,15 +168,7 @@ function ActionsPopover({
 									color="secondary"
 									className={styles.menuItem}
 									prefix={<Link2 size={14} />}
-									onClick={(e): void => {
-										e.stopPropagation();
-										e.preventDefault();
-										setCopy(getAbsoluteUrl(link));
-										void logEvent(DashboardListEvents.RowAction, {
-											action: 'copyLink',
-											dashboardId,
-										});
-									}}
+									onClick={handleCopyLink}
 									testId="dashboard-action-copy-link"
 								>
 									Copy Link

--- a/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/ActionsPopover.tsx
@@ -15,6 +15,7 @@ import {
 	Tag,
 } from '@signozhq/icons';
 import { useCopyToClipboard } from 'react-use';
+import logEvent from 'api/common/logEvent';
 import {
 	cloneDashboardV2,
 	invalidateListDashboardsForUserV2,
@@ -23,6 +24,7 @@ import {
 } from 'api/generated/services/dashboard';
 import ROUTES from 'constants/routes';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 import { useAppContext } from 'providers/App/App';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
@@ -75,6 +77,10 @@ function ActionsPopover({
 		mutationFn: () => cloneDashboardV2({ id: dashboardId }),
 		onSuccess: (response) => {
 			toast.success(`Duplicated "${dashboardName}"`);
+			void logEvent(DashboardListEvents.RowAction, {
+				action: 'duplicate',
+				dashboardId,
+			});
 			safeNavigate(
 				generatePath(ROUTES.DASHBOARD, { dashboardId: response.data.id }),
 			);
@@ -99,6 +105,10 @@ function ActionsPopover({
 				: lockDashboardV2({ id: dashboardId }),
 		onSuccess: async () => {
 			toast.success(isLocked ? 'Dashboard unlocked' : 'Dashboard locked');
+			void logEvent(DashboardListEvents.RowAction, {
+				action: isLocked ? 'unlock' : 'lock',
+				dashboardId,
+			});
 			await invalidateListDashboardsForUserV2(queryClient);
 		},
 		onError: (error: APIError) => {
@@ -133,6 +143,10 @@ function ActionsPopover({
 										e.stopPropagation();
 										e.preventDefault();
 										openInNewTab(link);
+										void logEvent(DashboardListEvents.RowAction, {
+											action: 'openNewTab',
+											dashboardId,
+										});
 									}}
 									testId="dashboard-action-open-new-tab"
 								>
@@ -146,6 +160,10 @@ function ActionsPopover({
 										e.stopPropagation();
 										e.preventDefault();
 										setCopy(getAbsoluteUrl(link));
+										void logEvent(DashboardListEvents.RowAction, {
+											action: 'copyLink',
+											dashboardId,
+										});
 									}}
 									testId="dashboard-action-copy-link"
 								>

--- a/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/DeleteActionItem.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/DeleteActionItem.tsx
@@ -7,10 +7,12 @@ import { CircleAlert, Trash2 } from '@signozhq/icons';
 import { toast } from '@signozhq/ui/sonner';
 import { Divider } from '@signozhq/ui/divider';
 import { Typography } from '@signozhq/ui/typography';
+import logEvent from 'api/common/logEvent';
 import {
 	deleteDashboardV2,
 	invalidateListDashboardsForUserV2,
 } from 'api/generated/services/dashboard';
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 import { useAppContext } from 'providers/App/App';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
@@ -50,6 +52,10 @@ function DeleteActionItem({
 			toast.success(
 				t('dashboard:delete_dashboard_success', { name: dashboardName }),
 			);
+			void logEvent(DashboardListEvents.RowAction, {
+				action: 'delete',
+				dashboardId,
+			});
 			await invalidateListDashboardsForUserV2(queryClient);
 		},
 		onError: (error: APIError) => {

--- a/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/EditTagsModal.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/EditTagsModal.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from 'react-query';
 import { Button } from '@signozhq/ui/button';
 import { DialogWrapper } from '@signozhq/ui/dialog';
 import { toast } from '@signozhq/ui/sonner';
+import logEvent from 'api/common/logEvent';
 import {
 	invalidateListDashboardsForUserV2,
 	// eslint-disable-next-line no-restricted-imports -- list tag-edit targets another dashboard by id; useOptimisticPatch is bound to the open dashboard's store/cache.
@@ -10,6 +11,7 @@ import {
 } from 'api/generated/services/dashboard';
 import type { DashboardtypesJSONPatchOperationDTO } from 'api/generated/services/sigNoz.schemas';
 import TagKeyValueInput from 'components/TagKeyValueInput/TagKeyValueInput';
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
@@ -63,6 +65,10 @@ function EditTagsModal({
 		},
 		onSuccess: async () => {
 			toast.success('Tags updated');
+			void logEvent(DashboardListEvents.RowAction, {
+				action: 'editTags',
+				dashboardId,
+			});
 			await invalidateListDashboardsForUserV2(queryClient);
 			onClose();
 		},

--- a/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/RenameDashboardModal.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ActionsPopover/RenameDashboardModal.tsx
@@ -4,12 +4,14 @@ import { Button } from '@signozhq/ui/button';
 import { DialogWrapper } from '@signozhq/ui/dialog';
 import { Input } from '@signozhq/ui/input';
 import { toast } from '@signozhq/ui/sonner';
+import logEvent from 'api/common/logEvent';
 import {
 	invalidateListDashboardsForUserV2,
 	// eslint-disable-next-line no-restricted-imports -- list rename targets another dashboard by id; useOptimisticPatch is bound to the open dashboard's store/cache.
 	patchDashboardV2,
 } from 'api/generated/services/dashboard';
 import type { DashboardtypesJSONPatchOperationDTO } from 'api/generated/services/sigNoz.schemas';
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 import { useErrorModal } from 'providers/ErrorModalProvider';
 import APIError from 'types/api/error';
 
@@ -54,6 +56,10 @@ function RenameDashboardModal({
 		},
 		onSuccess: async () => {
 			toast.success('Dashboard renamed');
+			void logEvent(DashboardListEvents.RowAction, {
+				action: 'rename',
+				dashboardId,
+			});
 			await invalidateListDashboardsForUserV2(queryClient);
 			onClose();
 		},

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardRow/DashboardRow.tsx
@@ -12,6 +12,7 @@ import { Base64Icons } from 'container/DashboardContainer/DashboardSettings/Gene
 import { DATE_TIME_FORMATS } from 'constants/dateTimeFormats';
 import ROUTES from 'constants/routes';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 import { useTimezone } from 'providers/Timezone';
 import { isModifierKeyPressed } from 'utils/app';
 
@@ -97,6 +98,10 @@ function DashboardRow({
 			return;
 		}
 		togglePin(id, isPinned);
+		void logEvent(DashboardListEvents.DashboardPinned, {
+			pinned: !isPinned,
+			dashboardId: id,
+		});
 	};
 
 	const pinLabel = isPinned ? 'Unpin dashboard' : 'Pin dashboard';

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsList.tsx
@@ -7,6 +7,7 @@ import {
 } from 'api/generated/services/sigNoz.schemas';
 import useComponentPermission from 'hooks/useComponentPermission';
 import { useGetTenantLicense } from 'hooks/useGetTenantLicense';
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 import { useAppContext } from 'providers/App/App';
 import { toAPIError } from 'utils/errorUtils';
 
@@ -99,12 +100,17 @@ function DashboardsList(): JSX.Element {
 	// View actions that change the result set reset pagination too.
 	const handleSelectView = useCallback(
 		(id: string): void => {
+			void logEvent(DashboardListEvents.ViewSelected, {
+				viewId: id,
+				viewType: builtinViews.some((v) => v.id === id) ? 'builtin' : 'custom',
+			});
 			selectView(id);
 			void setPage(1);
 		},
-		[selectView, setPage],
+		[selectView, setPage, builtinViews],
 	);
 	const handleResetView = useCallback((): void => {
+		void logEvent(DashboardListEvents.ViewReset, {});
 		resetView();
 		void setPage(1);
 	}, [resetView, setPage]);
@@ -116,6 +122,7 @@ function DashboardsList(): JSX.Element {
 		[removeView, setPage],
 	);
 	const toggleRail = useCallback((): void => {
+		void logEvent(DashboardListEvents.RailToggled, { collapsed: !railCollapsed });
 		setRailCollapsed(!railCollapsed);
 	}, [setRailCollapsed, railCollapsed]);
 
@@ -228,18 +235,23 @@ function DashboardsList(): JSX.Element {
 
 	const onSortChange = useCallback(
 		(column: DashboardtypesListSortDTO): void => {
+			void logEvent(DashboardListEvents.SortChanged, { column, order: sortOrder });
 			void setSortColumn(column);
 			void setPage(1);
 		},
-		[setSortColumn, setPage],
+		[setSortColumn, setPage, sortOrder],
 	);
 
 	const onOrderChange = useCallback(
 		(order: DashboardtypesListOrderDTO): void => {
+			void logEvent(DashboardListEvents.SortChanged, {
+				column: sortColumn,
+				order,
+			});
 			void setSortOrder(order);
 			void setPage(1);
 		},
-		[setSortOrder, setPage],
+		[setSortOrder, setPage, sortColumn],
 	);
 
 	const visitLoggedRef = useRef(false);

--- a/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsListContent.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/DashboardsList/DashboardsListContent.tsx
@@ -1,6 +1,9 @@
 import { useMemo } from 'react';
 import { Table } from 'antd';
 import type { TableProps } from 'antd/lib';
+import logEvent from 'api/common/logEvent';
+
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 
 import type { DashboardListItem } from '../../utils/helpers';
 import DashboardRow from '../DashboardRow/DashboardRow';
@@ -50,7 +53,10 @@ function DashboardsListContent({
 	const paginationConfig = total > pageSize && {
 		pageSize,
 		showSizeChanger: false,
-		onChange: onPageChange,
+		onChange: (pageNumber: number): void => {
+			void logEvent(DashboardListEvents.Paginated, { pageNumber });
+			onPageChange(pageNumber);
+		},
 		current: page,
 		total,
 		hideOnSinglePage: true,

--- a/frontend/src/pages/DashboardsListPageV2/components/FilterZone/FilterZone.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/FilterZone/FilterZone.tsx
@@ -5,9 +5,12 @@ import {
 	useMemo,
 	useState,
 } from 'react';
+import logEvent from 'api/common/logEvent';
 import { Button } from '@signozhq/ui/button';
 import { Typography } from '@signozhq/ui/typography';
 import { X } from '@signozhq/icons';
+
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 
 import type { SuggestionSource } from '../../utils/dslSuggestions';
 import {
@@ -65,6 +68,10 @@ function FilterZone({
 	// Created-by (multi-select) only STAGES its clause into the draft; the query runs
 	// when the dropdown closes (FilterChips fires onApply), not on each pick.
 	const handleCreatedByChange = useCallback((emails: string[]): void => {
+		void logEvent(DashboardListEvents.FilterApplied, {
+			filterType: 'createdBy',
+			valueCount: emails.length,
+		});
 		setDraft((d) => spliceClause(d, 'created_by', createdByClause(emails)));
 	}, []);
 
@@ -72,6 +79,9 @@ function FilterZone({
 	// immediately (with the fresh value, avoiding the async draft-state lag).
 	const handleUpdatedChange = useCallback(
 		(window: UpdatedWindow): void => {
+			void logEvent(DashboardListEvents.FilterApplied, {
+				filterType: 'updatedWindow',
+			});
 			const next = spliceClause(draft, 'updated_at', updatedClause(window));
 			setDraft(next);
 			const trimmed = next.trim();
@@ -94,6 +104,7 @@ function FilterZone({
 
 	// Clear resets the draft and runs immediately (empty query).
 	const handleClear = useCallback((): void => {
+		void logEvent(DashboardListEvents.FiltersCleared, {});
 		setDraft('');
 		if (query !== '') {
 			onQueryChange('');

--- a/frontend/src/pages/DashboardsListPageV2/components/LegacyDashboardDialog/LegacyDashboardDialog.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/LegacyDashboardDialog/LegacyDashboardDialog.tsx
@@ -41,6 +41,14 @@ function LegacyDashboardDialog({
 		});
 	};
 
+	const onContactSupport = (): void => {
+		handleContactSupport(!!isCloudUser);
+		void logEvent(DashboardListEvents.LegacyDialogAction, {
+			action: 'contactSupport',
+			dashboardId,
+		});
+	};
+
 	return (
 		<DialogWrapper
 			title="This dashboard isn't available in the new experience"
@@ -67,13 +75,7 @@ function LegacyDashboardDialog({
 						color="primary"
 						size="md"
 						suffix={<ArrowUpRight size={14} />}
-						onClick={(): void => {
-							handleContactSupport(!!isCloudUser);
-							void logEvent(DashboardListEvents.LegacyDialogAction, {
-								action: 'contactSupport',
-								dashboardId,
-							});
-						}}
+						onClick={onContactSupport}
 						testId="legacy-dashboard-contact-support"
 					>
 						Contact Support

--- a/frontend/src/pages/DashboardsListPageV2/components/LegacyDashboardDialog/LegacyDashboardDialog.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/LegacyDashboardDialog/LegacyDashboardDialog.tsx
@@ -4,8 +4,10 @@ import { Typography } from '@signozhq/ui/typography';
 import { ArrowUpRight, Copy } from '@signozhq/icons';
 import { useCopyToClipboard } from 'react-use';
 import { toast } from '@signozhq/ui/sonner';
+import logEvent from 'api/common/logEvent';
 import { handleContactSupport } from 'container/Integrations/utils';
 import { useGetTenantLicense } from 'hooks/useGetTenantLicense';
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 
 import styles from './LegacyDashboardDialog.module.scss';
 
@@ -33,6 +35,10 @@ function LegacyDashboardDialog({
 	const onCopyId = (): void => {
 		copyToClipboard(dashboardId);
 		toast.success('Dashboard ID copied');
+		void logEvent(DashboardListEvents.LegacyDialogAction, {
+			action: 'copyId',
+			dashboardId,
+		});
 	};
 
 	return (
@@ -61,7 +67,13 @@ function LegacyDashboardDialog({
 						color="primary"
 						size="md"
 						suffix={<ArrowUpRight size={14} />}
-						onClick={(): void => handleContactSupport(!!isCloudUser)}
+						onClick={(): void => {
+							handleContactSupport(!!isCloudUser);
+							void logEvent(DashboardListEvents.LegacyDialogAction, {
+								action: 'contactSupport',
+								dashboardId,
+							});
+						}}
 						testId="legacy-dashboard-contact-support"
 					>
 						Contact Support

--- a/frontend/src/pages/DashboardsListPageV2/components/ListHeader/ListHeader.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ListHeader/ListHeader.tsx
@@ -5,10 +5,12 @@ import { Switch } from '@signozhq/ui/switch';
 import { Typography } from '@signozhq/ui/typography';
 import { ArrowDown, ArrowUp, Check, Columns3 } from '@signozhq/icons';
 
+import logEvent from 'api/common/logEvent';
 import {
 	DashboardtypesListOrderDTO,
 	DashboardtypesListSortDTO,
 } from 'api/generated/services/sigNoz.schemas';
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 
 import {
 	type DashboardDynamicColumns,
@@ -61,9 +63,13 @@ function ListHeader({
 					<Switch
 						value={visibleColumns[col.key]}
 						testId={`metadata-toggle-${col.key}`}
-						onChange={(checked): void =>
-							setVisibleColumns({ ...visibleColumns, [col.key]: checked })
-						}
+						onChange={(checked): void => {
+							void logEvent(DashboardListEvents.ColumnsToggled, {
+								column: col.key,
+								visible: checked,
+							});
+							setVisibleColumns({ ...visibleColumns, [col.key]: checked });
+						}}
 					/>
 				</div>
 			))}

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
@@ -12,6 +12,7 @@ import { createDashboardV2 } from 'api/generated/services/dashboard';
 import ROUTES from 'constants/routes';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import { useErrorModal } from 'providers/ErrorModalProvider';
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 import APIError from 'types/api/error';
 import TagKeyValueInput from 'components/TagKeyValueInput/TagKeyValueInput';
 
@@ -62,6 +63,12 @@ function BlankDashboardPanel({ onClose }: Props): JSX.Element {
 					panels: {},
 					variables: [],
 				},
+			});
+			void logEvent(DashboardListEvents.DashboardCreated, {
+				method: 'blank',
+				hasDescription: Boolean(description.trim()),
+				tagCount: postableTags.length,
+				hasImage: Boolean(image),
 			});
 			onClose();
 			safeNavigate(

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/ImportJsonPanel.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/ImportJsonPanel.tsx
@@ -13,6 +13,7 @@ import { createDashboardV2 } from 'api/generated/services/dashboard';
 import ROUTES from 'constants/routes';
 import { useSafeNavigate } from 'hooks/useSafeNavigate';
 import { useErrorModal } from 'providers/ErrorModalProvider';
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 import APIError from 'types/api/error';
 
 import { normalizeToPostable } from './importUtils';
@@ -51,6 +52,7 @@ function ImportJsonPanel({ onClose }: Props): JSX.Element {
 				setIsUploadError(false);
 			} catch {
 				setIsUploadError(true);
+				void logEvent(DashboardListEvents.ImportFailed, { reason: 'parse' });
 			}
 		};
 		reader.readAsText(lastFile.originFileObj);
@@ -63,6 +65,7 @@ function ImportJsonPanel({ onClose }: Props): JSX.Element {
 			const parsed = JSON.parse(editorValue) as Record<string, unknown>;
 			const payload = normalizeToPostable(parsed);
 			const response = await createDashboardV2(payload);
+			void logEvent(DashboardListEvents.DashboardCreated, { method: 'import' });
 			onClose();
 			safeNavigate(
 				generatePath(ROUTES.DASHBOARD, { dashboardId: response.data.id }),
@@ -70,6 +73,7 @@ function ImportJsonPanel({ onClose }: Props): JSX.Element {
 		} catch (error) {
 			showErrorModal(error as APIError);
 			setIsCreateError(true);
+			void logEvent(DashboardListEvents.ImportFailed, { reason: 'schema' });
 			toast.error(
 				error instanceof Error ? error.message : t('error_loading_json'),
 			);

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/NewDashboardModal.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/NewDashboardModal.tsx
@@ -22,6 +22,11 @@ function NewDashboardModal({ open, onClose }: Props): JSX.Element {
 		}
 	}, [open]);
 
+	const handleTabChange = (key: string): void => {
+		setTab(key);
+		void logEvent(DashboardListEvents.CreateModalTabChanged, { tab: key });
+	};
+
 	return (
 		<DialogWrapper
 			title="New dashboard"
@@ -35,10 +40,7 @@ function NewDashboardModal({ open, onClose }: Props): JSX.Element {
 		>
 			<Tabs
 				value={tab}
-				onChange={(key): void => {
-					setTab(key);
-					void logEvent(DashboardListEvents.CreateModalTabChanged, { tab: key });
-				}}
+				onChange={handleTabChange}
 				items={[
 					{
 						key: 'blank',

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/NewDashboardModal.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/NewDashboardModal.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { DialogWrapper } from '@signozhq/ui/dialog';
 import { Tabs } from '@signozhq/ui/tabs';
+import logEvent from 'api/common/logEvent';
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 
 import BlankDashboardPanel from './BlankDashboardPanel';
 import ImportJsonPanel from './ImportJsonPanel';
@@ -33,7 +35,10 @@ function NewDashboardModal({ open, onClose }: Props): JSX.Element {
 		>
 			<Tabs
 				value={tab}
-				onChange={(key): void => setTab(key)}
+				onChange={(key): void => {
+					setTab(key);
+					void logEvent(DashboardListEvents.CreateModalTabChanged, { tab: key });
+				}}
 				items={[
 					{
 						key: 'blank',

--- a/frontend/src/pages/DashboardsListPageV2/components/SearchBar/SearchBar.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/SearchBar/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent, useMemo, useRef } from 'react';
+import { type MouseEvent, useCallback, useMemo, useRef } from 'react';
 import {
 	autocompletion,
 	closeCompletion,
@@ -14,6 +14,8 @@ import CodeMirror, {
 	Prec,
 	type ReactCodeMirrorRef,
 } from '@uiw/react-codemirror';
+import logEvent from 'api/common/logEvent';
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 import { getUserOperatingSystem, UserOperatingSystem } from 'utils/getUserOS';
 
 import type { SuggestionSource } from '../../utils/dslSuggestions';
@@ -83,8 +85,14 @@ function SearchBar({
 	// Refs so the (memoised, stable) extensions always see the latest values.
 	const sourceRef = useRef(source);
 	sourceRef.current = source;
-	const onSubmitRef = useRef(onSubmit);
-	onSubmitRef.current = onSubmit;
+	const handleSubmit = useCallback((): void => {
+		void logEvent(DashboardListEvents.SearchExecuted, {
+			hasQuery: !!value.trim(),
+		});
+		onSubmit();
+	}, [onSubmit, value]);
+	const onSubmitRef = useRef(handleSubmit);
+	onSubmitRef.current = handleSubmit;
 
 	const extensions = useMemo(
 		() => [
@@ -162,7 +170,7 @@ function SearchBar({
 					onMouseDown={(e: MouseEvent<HTMLButtonElement>): void => {
 						e.preventDefault();
 					}}
-					onClick={onSubmit}
+					onClick={handleSubmit}
 				>
 					{dirty && (
 						<span

--- a/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewsRail.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewsRail.tsx
@@ -1,5 +1,6 @@
 import { type ChangeEvent, useCallback, useState } from 'react';
 import { Modal } from 'antd';
+import logEvent from 'api/common/logEvent';
 import { Button } from '@signozhq/ui/button';
 import { Input } from '@signozhq/ui/input';
 import { Typography } from '@signozhq/ui/typography';
@@ -12,6 +13,8 @@ import {
 	Trash2,
 } from '@signozhq/icons';
 import cx from 'classnames';
+
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 
 import type { SavedView } from '../../types';
 import { type BuiltinView } from '../../utils/views';
@@ -104,6 +107,7 @@ function ViewsRail({
 					onClick: (e): void => {
 						e.preventDefault();
 						e.stopPropagation();
+						void logEvent(DashboardListEvents.ViewDeleted, {});
 						onDelete(id);
 						destroy();
 					},
@@ -137,7 +141,10 @@ function ViewsRail({
 						<ViewNamePopover
 							open={renamingId === row.id}
 							onOpenChange={(open): void => setRenamingId(open ? row.id : null)}
-							onSubmit={(name): void => onRename(row.id, name)}
+							onSubmit={(name): void => {
+								void logEvent(DashboardListEvents.ViewRenamed, {});
+								onRename(row.id, name);
+							}}
 							title="Rename view"
 							confirmLabel="Rename"
 							initialName={row.label}
@@ -184,7 +191,10 @@ function ViewsRail({
 					<ViewNamePopover
 						open={saveOpen}
 						onOpenChange={setSaveOpen}
-						onSubmit={onSave}
+						onSubmit={(name): void => {
+							void logEvent(DashboardListEvents.ViewSaved, { mode: 'new' });
+							onSave(name);
+						}}
 						title="Save as view"
 						confirmLabel="Save view"
 						testIdPrefix="save-view"
@@ -276,7 +286,10 @@ function ViewsRail({
 									variant="solid"
 									color="primary"
 									size="sm"
-									onClick={onSaveChanges}
+									onClick={(): void => {
+										void logEvent(DashboardListEvents.ViewSaved, { mode: 'update' });
+										onSaveChanges();
+									}}
 									testId="dashboards-view-save-changes"
 								>
 									Save

--- a/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewsRail.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/ViewsRail/ViewsRail.tsx
@@ -118,6 +118,16 @@ function ViewsRail({
 		[modal, onDelete],
 	);
 
+	const handleSaveAsView = (name: string): void => {
+		void logEvent(DashboardListEvents.ViewSaved, { mode: 'new' });
+		onSave(name);
+	};
+
+	const handleSaveViewChanges = (): void => {
+		void logEvent(DashboardListEvents.ViewSaved, { mode: 'update' });
+		onSaveChanges();
+	};
+
 	const renderItem = (row: ViewRow): JSX.Element => {
 		const Icon = row.icon;
 		const active = row.id === activeViewId;
@@ -191,10 +201,7 @@ function ViewsRail({
 					<ViewNamePopover
 						open={saveOpen}
 						onOpenChange={setSaveOpen}
-						onSubmit={(name): void => {
-							void logEvent(DashboardListEvents.ViewSaved, { mode: 'new' });
-							onSave(name);
-						}}
+						onSubmit={handleSaveAsView}
 						title="Save as view"
 						confirmLabel="Save view"
 						testIdPrefix="save-view"
@@ -286,10 +293,7 @@ function ViewsRail({
 									variant="solid"
 									color="primary"
 									size="sm"
-									onClick={(): void => {
-										void logEvent(DashboardListEvents.ViewSaved, { mode: 'update' });
-										onSaveChanges();
-									}}
+									onClick={handleSaveViewChanges}
 									testId="dashboards-view-save-changes"
 								>
 									Save

--- a/frontend/src/pages/DashboardsListPageV2/components/states/ErrorState/ErrorState.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/states/ErrorState/ErrorState.tsx
@@ -34,6 +34,20 @@ function ErrorState({
 
 	const cleanedDetail = formatQueryErrorMessage(errorMessage);
 
+	const handleRetry = (): void => {
+		void logEvent(DashboardListEvents.ErrorStateAction, {
+			action: 'retry',
+		});
+		onRetry();
+	};
+
+	const handleContactSupportClick = (): void => {
+		void logEvent(DashboardListEvents.ErrorStateAction, {
+			action: 'contactSupport',
+		});
+		handleContactSupport(isCloudUser);
+	};
+
 	return (
 		<div className={styles.wrapper}>
 			<img src={awwSnapUrl} alt="something went wrong" className={styles.img} />
@@ -59,12 +73,7 @@ function ErrorState({
 						variant="outlined"
 						color="secondary"
 						prefix={<RotateCw size={16} />}
-						onClick={(): void => {
-							void logEvent(DashboardListEvents.ErrorStateAction, {
-								action: 'retry',
-							});
-							onRetry();
-						}}
+						onClick={handleRetry}
 						testId="dashboards-list-retry"
 					>
 						Retry
@@ -74,12 +83,7 @@ function ErrorState({
 					variant="link"
 					color="primary"
 					className={styles.learnMore}
-					onClick={(): void => {
-						void logEvent(DashboardListEvents.ErrorStateAction, {
-							action: 'contactSupport',
-						});
-						handleContactSupport(isCloudUser);
-					}}
+					onClick={handleContactSupportClick}
 					testId="dashboards-list-contact-support"
 				>
 					Contact Support

--- a/frontend/src/pages/DashboardsListPageV2/components/states/ErrorState/ErrorState.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/states/ErrorState/ErrorState.tsx
@@ -1,7 +1,9 @@
 import { Button } from '@signozhq/ui/button';
 import { Typography } from '@signozhq/ui/typography';
 import { ArrowUpRight, RotateCw } from '@signozhq/icons';
+import logEvent from 'api/common/logEvent';
 import { handleContactSupport } from 'container/Integrations/utils';
+import { DashboardListEvents } from 'pages/DashboardsListPageV2/constants/events';
 
 import awwSnapUrl from '@/assets/Icons/awwSnap.svg';
 
@@ -57,7 +59,12 @@ function ErrorState({
 						variant="outlined"
 						color="secondary"
 						prefix={<RotateCw size={16} />}
-						onClick={onRetry}
+						onClick={(): void => {
+							void logEvent(DashboardListEvents.ErrorStateAction, {
+								action: 'retry',
+							});
+							onRetry();
+						}}
 						testId="dashboards-list-retry"
 					>
 						Retry
@@ -67,7 +74,12 @@ function ErrorState({
 					variant="link"
 					color="primary"
 					className={styles.learnMore}
-					onClick={(): void => handleContactSupport(isCloudUser)}
+					onClick={(): void => {
+						void logEvent(DashboardListEvents.ErrorStateAction, {
+							action: 'contactSupport',
+						});
+						handleContactSupport(isCloudUser);
+					}}
 					testId="dashboards-list-contact-support"
 				>
 					Contact Support

--- a/frontend/src/pages/DashboardsListPageV2/constants/events.ts
+++ b/frontend/src/pages/DashboardsListPageV2/constants/events.ts
@@ -1,0 +1,36 @@
+/**
+ * Analytics events for the V2 dashboards list page.
+ * Fire via `logEvent(DashboardListEvents.<X>, { ...camelCaseProps })`.
+ */
+export enum DashboardListEvents {
+	// Creating / importing
+	CreateModalTabChanged = 'Dashboard List V2: Create modal tab changed',
+	DashboardCreated = 'Dashboard List V2: Dashboard created',
+	ImportFailed = 'Dashboard List V2: Import failed',
+
+	// Finding dashboards (search / filter / sort / columns / pin / pagination)
+	SearchExecuted = 'Dashboard List V2: Search executed',
+	FilterApplied = 'Dashboard List V2: Filter applied',
+	FiltersCleared = 'Dashboard List V2: Filters cleared',
+	SortChanged = 'Dashboard List V2: Sort changed',
+	ColumnsToggled = 'Dashboard List V2: Columns toggled',
+	DashboardPinned = 'Dashboard List V2: Dashboard pinned',
+	Paginated = 'Dashboard List V2: Paginated',
+
+	// Views rail
+	ViewSelected = 'Dashboard List V2: View selected',
+	ViewSaved = 'Dashboard List V2: View saved',
+	ViewRenamed = 'Dashboard List V2: View renamed',
+	ViewDeleted = 'Dashboard List V2: View deleted',
+	ViewReset = 'Dashboard List V2: View reset',
+	RailToggled = 'Dashboard List V2: Rail toggled',
+
+	// Row actions (grouped: view / openNewTab / copyLink / rename / editTags / duplicate / lock / unlock / delete)
+	RowAction = 'Dashboard List V2: Row action',
+
+	// Legacy (V1) dashboard explainer dialog
+	LegacyDialogAction = 'Dashboard List V2: Legacy dialog action',
+
+	// Error / empty states
+	ErrorStateAction = 'Dashboard List V2: Error state action',
+}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The V2 dashboard revamp (`DashboardPageV2` + `DashboardsListPageV2`) shipped with almost no product analytics — only a handful of `logEvent` calls survived from V1, leaving the new surfaces (Views rail, filters, sections, drill-down, runtime variables, public dashboards) completely dark. Without instrumentation we can't answer basic product questions about the revamp: is V2 winning over V1, do people use the new navigation, is drill-down a hit, are dashboards actually interactive?

This PR adds a complete, convention-following analytics layer:

- **Event catalog** — two enums (`DashboardListEvents`, `DashboardDetailEvents`) as the single source of truth for event-name strings, extending the existing `constants/events.ts` pattern. All new names use the `<Area> V2: <verb phrase>` convention; property keys are camelCase; `deployment_url`/`user_email` remain auto-injected by `logEvent`.
- **Grouped action events** — multi-variant surfaces use one event with an `action` discriminator (`RowAction`, `SectionAction`, `PanelAction`, `DrilldownAction`, `JsonEditorAction`, `PublicDashboardAction`), mirroring the existing `'Dashboard Detail: Panel action'`. `PanelAction` deliberately reuses the V1 string so panel actions stay comparable across versions.
- **Additive only** — existing inline `logEvent` calls and their historical strings are untouched.
- High-frequency events (layout drag/resize, runtime variable selection, panel search) fire **rate-limited**.

Coverage: list page (create/import funnel incl. failure arm, search/filter/sort/columns/pin/pagination, Views rail, row actions, legacy dialog, error states) and detail page (lifecycle, sections, panels, layout, variables setup + runtime, drill-down, JSON editor, settings/overview/cursor-sync, public dashboard).

> Intentionally **not** included: `PanelDataFetched` — V2 fetches panels individually with no clean single aggregation point (unlike V1's grid); can be added later if we want the data-availability signal.

#### Issues closed by this PR
Closes https://github.com/SigNoz/pulse-pod/issues/99
Closes https://github.com/SigNoz/pulse-pod/issues/116

---

### ✅ Change Type

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy

- Tests added/updated: none (instrumentation only — no behavior change)
- Manual verification: pending (recommend spot-checking a few events fire with expected payloads via the network tab)
- Static checks: `tsgo --noEmit` clean on all touched files; `oxlint` introduces **zero** new warnings vs `origin/main` (verified by baseline diff); `oxfmt --check` clean.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: low — additive `void logEvent(...)` calls inside existing handlers; no control-flow or behavior changes.
