### PR TITLE
fix(dashboards-v2): dedicated "all" dynamic-variable signal + required non-nullable links

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -2858,6 +2858,7 @@ components:
           $ref: '#/components/schemas/DashboardtypesDynamicVariableSignal'
       required:
       - name
+      - signal
       type: object
     DashboardtypesFillMode:
       enum:

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -2843,12 +2843,19 @@ components:
       required:
       - name
       type: object
+    DashboardtypesDynamicVariableSignal:
+      enum:
+      - traces
+      - logs
+      - metrics
+      - all
+      type: string
     DashboardtypesDynamicVariableSpec:
       properties:
         name:
           type: string
         signal:
-          $ref: '#/components/schemas/TelemetrytypesSignal'
+          $ref: '#/components/schemas/DashboardtypesDynamicVariableSignal'
       required:
       - name
       type: object

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -2748,7 +2748,6 @@ components:
         links:
           items:
             $ref: '#/components/schemas/DashboardtypesLink'
-          nullable: true
           type: array
         panels:
           additionalProperties:
@@ -2765,6 +2764,7 @@ components:
       - variables
       - panels
       - layouts
+      - links
       type: object
     DashboardtypesDashboardView:
       properties:
@@ -3393,7 +3393,6 @@ components:
         links:
           items:
             $ref: '#/components/schemas/DashboardtypesLink'
-          nullable: true
           type: array
         plugin:
           $ref: '#/components/schemas/DashboardtypesPanelPlugin'
@@ -3405,6 +3404,7 @@ components:
       - display
       - plugin
       - queries
+      - links
       type: object
     DashboardtypesPatchOp:
       enum:

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -4626,9 +4626,9 @@ export interface DashboardtypesQueryDTO {
 export interface DashboardtypesPanelSpecDTO {
 	display: DashboardtypesDisplayDTO;
 	/**
-	 * @type array,null
+	 * @type array
 	 */
-	links?: DashboardtypesLinkDTO[] | null;
+	links: DashboardtypesLinkDTO[];
 	plugin: DashboardtypesPanelPluginDTO;
 	/**
 	 * @type array
@@ -4815,9 +4815,9 @@ export interface DashboardtypesDashboardSpecDTO {
 	 */
 	layouts: DashboardtypesLayoutDTO[];
 	/**
-	 * @type array,null
+	 * @type array
 	 */
-	links?: DashboardtypesLinkDTO[] | null;
+	links: DashboardtypesLinkDTO[];
 	/**
 	 * @type object
 	 */

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -4668,12 +4668,18 @@ export type DashboardtypesVariableDefaultValueDTO = string | string[];
 export enum DashboardtypesVariablePluginVariantGithubComSigNozSignozPkgTypesDashboardtypesDynamicVariableSpecDTOKind {
 	'signoz/DynamicVariable' = 'signoz/DynamicVariable',
 }
+export enum DashboardtypesDynamicVariableSignalDTO {
+	traces = 'traces',
+	logs = 'logs',
+	metrics = 'metrics',
+	all = 'all',
+}
 export interface DashboardtypesDynamicVariableSpecDTO {
 	/**
 	 * @type string
 	 */
 	name: string;
-	signal?: TelemetrytypesSignalDTO;
+	signal: DashboardtypesDynamicVariableSignalDTO;
 }
 
 export interface DashboardtypesVariablePluginVariantGithubComSigNozSignozPkgTypesDashboardtypesDynamicVariableSpecDTO {

--- a/frontend/src/hooks/dashboard/useCreateExportDashboard.ts
+++ b/frontend/src/hooks/dashboard/useCreateExportDashboard.ts
@@ -55,6 +55,7 @@ export function useCreateExportDashboard({
 					layouts: [],
 					panels: {},
 					variables: [],
+					links: [],
 				},
 			}),
 		{

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/DynamicVariableFields.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/VariableForm/DynamicVariableFields.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Info } from '@signozhq/icons';
 import { Typography } from '@signozhq/ui/typography';
+import { DashboardtypesDynamicVariableSignalDTO } from 'api/generated/services/sigNoz.schemas';
 import cx from 'classnames';
 // eslint-disable-next-line signoz/no-antd-components -- fixed-option signal picker
 import { Select } from 'antd';
@@ -14,17 +15,16 @@ import { isRetryableError } from 'utils/errorUtils';
 import {
 	DYNAMIC_SIGNAL_LABEL,
 	DYNAMIC_SIGNALS,
-	type DynamicSignalOption,
 	signalForApi,
 } from '../variableFormModel';
 import styles from './VariableForm.module.scss';
 
 interface DynamicVariableFieldsProps {
 	attribute: string;
-	signal: DynamicSignalOption;
+	signal: DashboardtypesDynamicVariableSignalDTO;
 	onChange: (patch: {
 		dynamicAttribute?: string;
-		dynamicSignal?: DynamicSignalOption;
+		dynamicSignal?: DashboardtypesDynamicVariableSignalDTO;
 	}) => void;
 	onPreview: (values: (string | number)[]) => void;
 	/** Inline error shown under the attribute field (e.g. duplicate attribute). */
@@ -117,7 +117,9 @@ function DynamicVariableFields({
 						value: s,
 					}))}
 					onChange={(value): void =>
-						onChange({ dynamicSignal: value as DynamicSignalOption })
+						onChange({
+							dynamicSignal: value as DashboardtypesDynamicVariableSignalDTO,
+						})
 					}
 					data-testid="variable-signal-select"
 				/>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters.ts
@@ -13,11 +13,7 @@ import type {
 } from 'api/generated/services/sigNoz.schemas';
 
 import {
-	DYNAMIC_SIGNAL_ALL,
-	DYNAMIC_SIGNALS,
-	type DynamicSignalOption,
 	emptyVariableFormModel,
-	signalForApi,
 	VARIABLE_SORT_DISABLED,
 	type VariableFormModel,
 } from './variableFormModel';
@@ -69,12 +65,8 @@ export function dtoToFormModel(
 			...listCommon,
 			type: 'DYNAMIC',
 			dynamicAttribute: plugin.spec.name ?? '',
-			// Unrecognized/empty signal → "all telemetry", so the source always shows.
-			dynamicSignal: DYNAMIC_SIGNALS.includes(
-				plugin.spec.signal as DynamicSignalOption,
-			)
-				? (plugin.spec.signal as DynamicSignalOption)
-				: DYNAMIC_SIGNAL_ALL,
+			// signal is a required wire field (`all` = every telemetry signal), used as-is.
+			dynamicSignal: plugin.spec.signal,
 		};
 	}
 	// Default to Query (also covers a query plugin or a missing/unknown plugin).
@@ -102,7 +94,7 @@ function buildPlugin(
 				kind: DynamicPluginKind['signoz/DynamicVariable'],
 				spec: {
 					name: model.dynamicAttribute,
-					signal: signalForApi(model.dynamicSignal),
+					signal: model.dynamicSignal,
 				},
 			};
 		case 'QUERY':

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel.ts
@@ -1,6 +1,6 @@
 import {
+	DashboardtypesDynamicVariableSignalDTO,
 	DashboardtypesListVariableSpecSortDTO,
-	TelemetrytypesSignalDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import type { DashboardtypesVariableDefaultValueDTO } from 'api/generated/services/sigNoz.schemas';
 import { sortBy } from 'lodash-es';
@@ -22,23 +22,6 @@ export const VARIABLE_TYPE_EVENT_LABEL: Record<VariableType, string> = {
 	TEXT: 'textbox',
 	DYNAMIC: 'dynamic',
 };
-
-/** Telemetry signal — the generated enum (traces / logs / metrics). */
-// A query/variable signal is only logs/traces/metrics. TelemetrytypesSignalDTO
-// also carries the empty "any" value used on field keys, which is not a valid
-// query/variable signal, so exclude it here.
-export type TelemetrySignal =
-	| TelemetrytypesSignalDTO.logs
-	| TelemetrytypesSignalDTO.traces
-	| TelemetrytypesSignalDTO.metrics;
-
-/**
- * Signal selected in the dynamic-variable editor. `'all'` is UI-only (the
- * generated `TelemetrytypesSignalDTO` has no "all") — it searches across every
- * signal and maps to an omitted `signal` on the wire (see {@link signalForApi}).
- */
-export const DYNAMIC_SIGNAL_ALL = 'all' as const;
-export type DynamicSignalOption = TelemetrySignal | typeof DYNAMIC_SIGNAL_ALL;
 
 /**
  * Sort order for list-variable values, keyed by the generated wire enum so the
@@ -81,25 +64,38 @@ export const VARIABLE_SORT_LABEL: Record<VariableSort, string> = {
 	[VARIABLE_SORT.CI_DESC]: 'Alphabetical, case-insensitive (descending)',
 };
 
-export const DYNAMIC_SIGNALS: DynamicSignalOption[] = [
-	DYNAMIC_SIGNAL_ALL,
-	TelemetrytypesSignalDTO.traces,
-	TelemetrytypesSignalDTO.logs,
-	TelemetrytypesSignalDTO.metrics,
+export const DYNAMIC_SIGNALS: DashboardtypesDynamicVariableSignalDTO[] = [
+	DashboardtypesDynamicVariableSignalDTO.all,
+	DashboardtypesDynamicVariableSignalDTO.traces,
+	DashboardtypesDynamicVariableSignalDTO.logs,
+	DashboardtypesDynamicVariableSignalDTO.metrics,
 ];
 
-export const DYNAMIC_SIGNAL_LABEL: Record<DynamicSignalOption, string> = {
-	[DYNAMIC_SIGNAL_ALL]: 'All telemetry',
-	[TelemetrytypesSignalDTO.traces]: 'Traces',
-	[TelemetrytypesSignalDTO.logs]: 'Logs',
-	[TelemetrytypesSignalDTO.metrics]: 'Metrics',
+export const DYNAMIC_SIGNAL_LABEL: Record<
+	DashboardtypesDynamicVariableSignalDTO,
+	string
+> = {
+	[DashboardtypesDynamicVariableSignalDTO.all]: 'All telemetry',
+	[DashboardtypesDynamicVariableSignalDTO.traces]: 'Traces',
+	[DashboardtypesDynamicVariableSignalDTO.logs]: 'Logs',
+	[DashboardtypesDynamicVariableSignalDTO.metrics]: 'Metrics',
 };
 
-/** Maps the editor's signal selection to the wire value (`'all'` → omitted). */
+/**
+ * Field-keys/values API param. The `all` signal is omitted (that endpoint only
+ * accepts a concrete signal), everything else passes through.
+ */
 export function signalForApi(
-	signal: DynamicSignalOption,
-): TelemetrySignal | undefined {
-	return signal === DYNAMIC_SIGNAL_ALL ? undefined : signal;
+	signal: DashboardtypesDynamicVariableSignalDTO,
+):
+	| Exclude<
+			DashboardtypesDynamicVariableSignalDTO,
+			DashboardtypesDynamicVariableSignalDTO.all
+	  >
+	| undefined {
+	return signal === DashboardtypesDynamicVariableSignalDTO.all
+		? undefined
+		: signal;
 }
 
 type SortableValues = (string | number | boolean)[];
@@ -144,7 +140,7 @@ export interface VariableFormModel {
 	textValue: string; // TEXT
 	textConstant: boolean; // TEXT
 	dynamicAttribute: string; // DYNAMIC — the telemetry field name
-	dynamicSignal: DynamicSignalOption; // DYNAMIC — the telemetry signal
+	dynamicSignal: DashboardtypesDynamicVariableSignalDTO; // DYNAMIC — the telemetry signal (`all` = every signal)
 
 	/**
 	 * Runtime-selected default, not editable in the management tab yet; carried
@@ -166,6 +162,6 @@ export function emptyVariableFormModel(): VariableFormModel {
 		textValue: '',
 		textConstant: false,
 		dynamicAttribute: '',
-		dynamicSignal: DYNAMIC_SIGNAL_ALL,
+		dynamicSignal: DashboardtypesDynamicVariableSignalDTO.all,
 	};
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/PanelTypeSwitcher/utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/PanelTypeSwitcher/utils.ts
@@ -17,8 +17,6 @@ const SIGNAL_LABEL: Record<TelemetrytypesSignalDTO, string> = {
 	[TelemetrytypesSignalDTO.logs]: 'logs',
 	[TelemetrytypesSignalDTO.traces]: 'traces',
 	[TelemetrytypesSignalDTO.metrics]: 'metrics',
-	// The empty "any" signal only appears on field keys, never on a panel query;
-	// mapped for exhaustiveness.
 	[TelemetrytypesSignalDTO['']]: '',
 };
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionRegistry.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionRegistry.tsx
@@ -120,7 +120,7 @@ export const SECTION_REGISTRY: {
 	[SectionKind.ContextLinks]: {
 		Component: ContextLinksSection,
 		// Panel-level slice (spec.links), not under the plugin spec — no cast needed.
-		get: (spec): DashboardtypesLinkDTO[] | undefined => spec.links ?? undefined,
+		get: (spec): DashboardtypesLinkDTO[] => spec.links,
 		update: (spec, links): PanelSpec => ({ ...spec, links }),
 	},
 	// One editor for every threshold variant (label / comparison / table); the kind's

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/signal.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/signal.ts
@@ -1,4 +1,7 @@
-import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import {
+	DashboardtypesDynamicVariableSignalDTO,
+	TelemetrytypesSignalDTO,
+} from 'api/generated/services/sigNoz.schemas';
 import type { BuilderQuery } from 'types/api/v5/queryRange';
 
 /**
@@ -15,5 +18,25 @@ export function resolveDrilldownSignal(
 			return TelemetrytypesSignalDTO.traces;
 		default:
 			return TelemetrytypesSignalDTO.metrics;
+	}
+}
+
+/**
+ * Maps a clicked query's telemetry signal to a dynamic-variable signal (used
+ * when a drilldown seeds a new variable). Concrete signals map 1:1; an unset
+ * signal (no active drilldown) falls back to `all`.
+ */
+export function dynamicSignalFromQuerySignal(
+	signal?: TelemetrytypesSignalDTO,
+): DashboardtypesDynamicVariableSignalDTO {
+	switch (signal) {
+		case TelemetrytypesSignalDTO.traces:
+			return DashboardtypesDynamicVariableSignalDTO.traces;
+		case TelemetrytypesSignalDTO.logs:
+			return DashboardtypesDynamicVariableSignalDTO.logs;
+		case TelemetrytypesSignalDTO.metrics:
+			return DashboardtypesDynamicVariableSignalDTO.metrics;
+		default:
+			return DashboardtypesDynamicVariableSignalDTO.all;
 	}
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldownDashboardVariables.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/useDrilldownDashboardVariables.test.tsx
@@ -1,6 +1,6 @@
 import { render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { DashboardtypesDynamicVariableSignalDTO } from 'api/generated/services/sigNoz.schemas';
 import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
 
 import DrilldownDashboardVariablesMenu from '../DrilldownMenu/DrilldownDashboardVariablesMenu';
@@ -63,7 +63,6 @@ jest.mock(
 	'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel',
 	() => ({
 		emptyVariableFormModel: (): unknown => ({}),
-		DYNAMIC_SIGNAL_ALL: 'all',
 	}),
 );
 jest.mock('components/OverlayScrollbar/OverlayScrollbar', () => ({
@@ -84,7 +83,7 @@ function renderItems(): void {
 	const { result } = renderHook(() =>
 		useDrilldownDashboardVariables({
 			filters,
-			signal: TelemetrytypesSignalDTO.metrics,
+			signal: DashboardtypesDynamicVariableSignalDTO.metrics,
 			onClose: jest.fn(),
 		}),
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -221,7 +221,7 @@ export function useDrilldown(
 				context={context}
 				query={v1Query}
 				isResolving={isResolving}
-				links={panel.spec.links ?? undefined}
+				links={panel.spec.links}
 				canSetDashboardVariables={dashboardVariables.hasFieldVariables}
 				onViewLogs={(): void => navigate('view_logs')}
 				onViewTraces={(): void => navigate('view_traces')}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldown.tsx
@@ -19,6 +19,7 @@ import { buildAggregateData } from 'pages/DashboardPageV2/DashboardContainer/Pan
 import { getBuilderQueries } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getBuilderQueries';
 import { getPanelQueryType } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/getPanelQueryType';
 import { fromPerses } from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
+import { dynamicSignalFromQuerySignal } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/signal';
 import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 import { EQueryType } from 'types/common/dashboard';
 
@@ -163,7 +164,7 @@ export function useDrilldown(
 
 	const dashboardVariables = useDrilldownDashboardVariables({
 		filters: context?.filters ?? EMPTY_FILTERS,
-		signal: context?.signal,
+		signal: dynamicSignalFromQuerySignal(context?.signal),
 		onClose: handleClose,
 	});
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useDrilldownDashboardVariables.tsx
@@ -1,14 +1,13 @@
 import { useCallback, useMemo } from 'react';
 import { toast } from '@signozhq/ui/sonner';
 import logEvent from 'api/common/logEvent';
-import type { TelemetrytypesSignalDTO } from 'api/generated/services/sigNoz.schemas';
+import { DashboardtypesDynamicVariableSignalDTO } from 'api/generated/services/sigNoz.schemas';
 import type { FilterData } from 'container/QueryTable/Drilldown/drilldownUtils';
 import {
 	dtoToFormModel,
 	formModelToDto,
 } from 'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableAdapters';
 import {
-	DYNAMIC_SIGNAL_ALL,
 	emptyVariableFormModel,
 	type VariableFormModel,
 } from 'pages/DashboardPageV2/DashboardContainer/DashboardSettings/Variables/variableFormModel';
@@ -23,8 +22,8 @@ import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 interface UseDrilldownDashboardVariablesArgs {
 	/** Group-by field filters from the clicked point (empty when the click has no group-by). */
 	filters: FilterData[];
-	/** Clicked query's telemetry signal — seeds a created variable's `dynamicSignal`. */
-	signal?: TelemetrytypesSignalDTO;
+	/** Dynamic-variable signal derived from the clicked query — seeds a created variable's `dynamicSignal`. */
+	signal?: DashboardtypesDynamicVariableSignalDTO;
 	onClose: () => void;
 }
 
@@ -111,8 +110,7 @@ export function useDrilldownDashboardVariables({
 				type: 'DYNAMIC',
 				multiSelect: true,
 				dynamicAttribute: fieldName,
-				// `||` (not `??`): an empty "any" signal maps to All, same as unset.
-				dynamicSignal: signal || DYNAMIC_SIGNAL_ALL,
+				dynamicSignal: signal ?? DashboardtypesDynamicVariableSignalDTO.all,
 			};
 			try {
 				await patchAsync(

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useSyncVariablesForSuggestions.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/useSyncVariablesForSuggestions.ts
@@ -1,5 +1,8 @@
 import { useEffect, useMemo } from 'react';
-import type { DashboardtypesGettableDashboardV2DTO } from 'api/generated/services/sigNoz.schemas';
+import {
+	DashboardtypesDynamicVariableSignalDTO,
+	type DashboardtypesGettableDashboardV2DTO,
+} from 'api/generated/services/sigNoz.schemas';
 import { setDashboardVariablesStore } from 'providers/Dashboard/store/dashboardVariables/dashboardVariablesStore';
 import type {
 	IDashboardVariable,
@@ -8,7 +11,6 @@ import type {
 
 import { dtoToFormModel } from '../DashboardSettings/Variables/variableAdapters';
 import {
-	DYNAMIC_SIGNAL_ALL,
 	type VariableFormModel,
 	type VariableType,
 } from '../DashboardSettings/Variables/variableFormModel';
@@ -35,7 +37,7 @@ function toV1Variable(model: VariableFormModel): IDashboardVariable {
 		showALLOption: model.showAllOption,
 		dynamicVariablesAttribute: model.dynamicAttribute,
 		dynamicVariablesSource:
-			model.dynamicSignal === DYNAMIC_SIGNAL_ALL
+			model.dynamicSignal === DashboardtypesDynamicVariableSignalDTO.all
 				? 'all sources'
 				: model.dynamicSignal,
 	};

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/patchOps.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/patchOps.ts
@@ -49,6 +49,7 @@ export function createDefaultPanel(
 				spec: pluginSpec,
 			} as DashboardtypesPanelPluginDTO,
 			queries,
+			links: [],
 		},
 	};
 }

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
@@ -62,6 +62,7 @@ function BlankDashboardPanel({ onClose }: Props): JSX.Element {
 					layouts: [],
 					panels: {},
 					variables: [],
+					links: [],
 				},
 			});
 			void logEvent(DashboardListEvents.DashboardCreated, {

--- a/pkg/types/dashboardtypes/perses_dashboard.go
+++ b/pkg/types/dashboardtypes/perses_dashboard.go
@@ -239,6 +239,9 @@ func (p *PostableDashboardV2) Validate() error {
 	if err := validateDashboardTags(p.Tags); err != nil {
 		return err
 	}
+	if err := p.Spec.validateLinksPresent(); err != nil {
+		return err
+	}
 	return p.Spec.Validate()
 }
 
@@ -407,6 +410,9 @@ func (u *UpdatableDashboardV2) Validate() error {
 		return err
 	}
 	if err := validateDashboardTags(u.Tags); err != nil {
+		return err
+	}
+	if err := u.Spec.validateLinksPresent(); err != nil {
 		return err
 	}
 	return u.Spec.Validate()

--- a/pkg/types/dashboardtypes/perses_dashboard.go
+++ b/pkg/types/dashboardtypes/perses_dashboard.go
@@ -239,9 +239,6 @@ func (p *PostableDashboardV2) Validate() error {
 	if err := validateDashboardTags(p.Tags); err != nil {
 		return err
 	}
-	if err := p.Spec.validateLinksPresent(); err != nil {
-		return err
-	}
 	return p.Spec.Validate()
 }
 
@@ -410,9 +407,6 @@ func (u *UpdatableDashboardV2) Validate() error {
 		return err
 	}
 	if err := validateDashboardTags(u.Tags); err != nil {
-		return err
-	}
-	if err := u.Spec.validateLinksPresent(); err != nil {
 		return err
 	}
 	return u.Spec.Validate()

--- a/pkg/types/dashboardtypes/perses_dashboard_convertors_test.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_convertors_test.go
@@ -54,10 +54,12 @@ func newTestDashboardV2(t *testing.T, orgID valuer.UUID, source Source) *Dashboa
 							},
 						},
 					},
+					Links: []Link{},
 				},
 			},
 		},
 		Layouts: []Layout{},
+		Links:   []Link{},
 	}
 
 	return &DashboardV2{

--- a/pkg/types/dashboardtypes/perses_dashboard_data.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_data.go
@@ -26,7 +26,7 @@ type DashboardSpec struct {
 	Layouts         []Layout                   `json:"layouts" required:"true" nullable:"false"`
 	Duration        common.DurationString      `json:"duration"`
 	RefreshInterval common.DurationString      `json:"refreshInterval"`
-	Links           []Link                     `json:"links,omitzero"`
+	Links           []Link                     `json:"links" required:"true" nullable:"false"`
 }
 
 // ══════════════════════════════════════════════
@@ -43,6 +43,24 @@ func (d *DashboardSpec) UnmarshalJSON(data []byte) error {
 	}
 	*d = DashboardSpec(tmp)
 	return d.Validate()
+}
+
+// validateLinksPresent enforces the required, non-nullable links field on the
+// create/update request paths: a missing/null links value (spec- or panel-level)
+// is rejected rather than silently defaulted, so a typed client's value round-trips
+// faithfully. Deliberately not part of Validate() — reads, clones and patches of
+// already-stored specs must not re-reject, and Validate() covers only cross-field
+// semantic checks (never required-field presence, matching its sibling slices).
+func (d *DashboardSpec) validateLinksPresent() error {
+	if d.Links == nil {
+		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "spec.links is required; send [] when there are no links")
+	}
+	for key, panel := range d.Panels {
+		if panel != nil && panel.Spec.Links == nil {
+			return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "spec.panels.%s.spec.links is required; send [] when there are no links", key)
+		}
+	}
+	return nil
 }
 
 // ══════════════════════════════════════════════

--- a/pkg/types/dashboardtypes/perses_dashboard_data.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_data.go
@@ -45,20 +45,12 @@ func (d *DashboardSpec) UnmarshalJSON(data []byte) error {
 	return d.Validate()
 }
 
-// validateLinksPresent enforces the required, non-nullable links field on the
-// create/update request paths: a missing/null links value (spec- or panel-level)
-// is rejected rather than silently defaulted, so a typed client's value round-trips
-// faithfully. Deliberately not part of Validate() — reads, clones and patches of
-// already-stored specs must not re-reject, and Validate() covers only cross-field
-// semantic checks (never required-field presence, matching its sibling slices).
-func (d *DashboardSpec) validateLinksPresent() error {
+// validateLinks rejects a missing/null spec.links value: a typed client must
+// send [] rather than omitting links, so its value round-trips faithfully.
+// Panel links are the panel spec's concern, validated in validatePanels.
+func (d *DashboardSpec) validateLinks() error {
 	if d.Links == nil {
 		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "spec.links is required; send [] when there are no links")
-	}
-	for key, panel := range d.Panels {
-		if panel != nil && panel.Spec.Links == nil {
-			return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "spec.panels.%s.spec.links is required; send [] when there are no links", key)
-		}
 	}
 	return nil
 }
@@ -69,6 +61,9 @@ func (d *DashboardSpec) validateLinksPresent() error {
 
 func (d *DashboardSpec) Validate() error {
 	if err := d.Display.Validate("dashboard", "spec.display.name"); err != nil {
+		return err
+	}
+	if err := d.validateLinks(); err != nil {
 		return err
 	}
 	if err := d.validateVariables(); err != nil {
@@ -120,6 +115,9 @@ func (d *DashboardSpec) validatePanels() error {
 		}
 		path := fmt.Sprintf("spec.panels.%s", key)
 		if err := panel.Spec.Display.Validate("panel", path+".spec.display.name"); err != nil {
+			return err
+		}
+		if err := panel.Spec.validateLinks(path); err != nil {
 			return err
 		}
 		panelKind := panel.Spec.Plugin.Kind

--- a/pkg/types/dashboardtypes/perses_dashboard_patch_test.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_patch_test.go
@@ -502,7 +502,7 @@ func TestPatchableDashboardV2_Apply(t *testing.T) {
 			"path": "/spec/panels/p1",
 			"value": {
 				"kind": "Panel",
-				"spec": {"plugin": {"kind": "signoz/NotAPanel", "spec": {}}}
+				"spec": {"links": [], "plugin": {"kind": "signoz/NotAPanel", "spec": {}}}
 			}
 		}]`).Apply(base)
 		require.Error(t, err)
@@ -518,6 +518,7 @@ func TestPatchableDashboardV2_Apply(t *testing.T) {
 			"value": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {"kind": "signoz/ListPanel", "spec": {}},
 					"queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/PromQLQuery", "spec": {"name": "A", "query": "up"}}}}]
 				}
@@ -543,6 +544,7 @@ func TestPatchableDashboardV2_Apply(t *testing.T) {
 			"value": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
 					"queries": [
 						{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {

--- a/pkg/types/dashboardtypes/perses_dashboard_patch_test.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_patch_test.go
@@ -23,6 +23,7 @@ const basePostableJSON = `{
 	"tags": [{"key": "team", "value": "alpha"}, {"key": "env", "value": "prod"}],
 	"spec": {
 		"display": {"name": "Service overview"},
+		"links": [],
 		"variables": [
 			{
 				"kind": "ListVariable",
@@ -41,6 +42,7 @@ const basePostableJSON = `{
 			"p1": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
 					"queries": [
 						{
@@ -64,6 +66,7 @@ const basePostableJSON = `{
 			"p2": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {"kind": "signoz/NumberPanel", "spec": {}},
 					"queries": [
 						{
@@ -182,6 +185,7 @@ func TestPatchableDashboardV2_Apply(t *testing.T) {
 			"value": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {"kind": "signoz/TablePanel", "spec": {}},
 					"queries": [{
 						"kind": "time_series",
@@ -216,6 +220,7 @@ func TestPatchableDashboardV2_Apply(t *testing.T) {
 			"value": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {"kind": "signoz/BarChartPanel", "spec": {}},
 					"queries": [{
 						"kind": "time_series",
@@ -327,7 +332,7 @@ func TestPatchableDashboardV2_Apply(t *testing.T) {
 		// Appending needs a not-yet-placed panel, so add one in the same patch;
 		// re-placing p1 or p2 would be a duplicate reference.
 		out, err := decode(t, `[
-			{"op": "add", "path": "/spec/panels/p3", "value": {"kind": "Panel", "spec": {"plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {"name": "A", "signal": "logs", "aggregations": [{"expression": "count()"}]}}}}]}}},
+			{"op": "add", "path": "/spec/panels/p3", "value": {"kind": "Panel", "spec": {"links": [], "plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {"name": "A", "signal": "logs", "aggregations": [{"expression": "count()"}]}}}}]}}},
 			{"op": "add", "path": "/spec/layouts/0/spec/items/-", "value": {"x": 0, "y": 6, "width": 12, "height": 6, "content": {"$ref": "#/spec/panels/p3"}}}
 		]`).Apply(base)
 		require.NoError(t, err)
@@ -346,6 +351,7 @@ func TestPatchableDashboardV2_Apply(t *testing.T) {
 				"value": {
 					"kind": "Panel",
 					"spec": {
+						"links": [],
 						"plugin": {"kind": "signoz/TablePanel", "spec": {}},
 						"queries": [{
 							"kind": "time_series",

--- a/pkg/types/dashboardtypes/perses_dashboard_test.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_test.go
@@ -51,10 +51,12 @@ func TestUnmarshalErrorPreservesNestedMessage(t *testing.T) {
 			"p1": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {"kind": "NonExistentPanel", "spec": {}}
 				}
 			}
 		},
+		"links": [],
 		"layouts": []
 	}`)
 
@@ -76,7 +78,7 @@ func TestUnmarshalErrorPreservesNestedMessage(t *testing.T) {
 
 func TestValidateEmptySpec(t *testing.T) {
 	// no variables no panels
-	data := []byte(`{}`)
+	data := []byte(`{"links": []}`)
 	_, err := unmarshalDashboard(data)
 	assert.NoError(t, err, "expected valid")
 }
@@ -107,6 +109,7 @@ func TestValidateOnlyVariables(t *testing.T) {
 				}
 			}
 		],
+		"links": [],
 		"layouts": []
 	}`)
 	_, err := unmarshalDashboard(data)
@@ -133,6 +136,7 @@ func TestInvalidateDuplicateVariableNames(t *testing.T) {
 				}
 			}
 		],
+		"links": [],
 		"layouts": []
 	}`)
 	_, err := unmarshalDashboard(data)
@@ -157,6 +161,7 @@ func TestInvalidateVariableNameWithInvalidChars(t *testing.T) {
 					}
 				}
 			],
+			"links": [],
 			"layouts": []
 		}`)
 	}
@@ -186,6 +191,7 @@ func TestInvalidatePanelKey(t *testing.T) {
 			"bad key!": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {"kind": "signoz/TablePanel", "spec": {}},
 					"queries": [{
 						"kind": "time_series",
@@ -196,6 +202,7 @@ func TestInvalidatePanelKey(t *testing.T) {
 				}
 			}
 		},
+		"links": [],
 		"layouts": []
 	}`)
 	_, err := unmarshalDashboard(data)
@@ -219,6 +226,7 @@ func TestInvalidateListVariableCrossFields(t *testing.T) {
 					}
 				}
 			],
+			"links": [],
 			"layouts": []
 		}`)
 	}
@@ -282,6 +290,7 @@ func TestInvalidateEmptyVariableName(t *testing.T) {
 	cases := map[string][]byte{
 		"text variable": []byte(`{
 			"variables": [{"kind": "TextVariable", "spec": {"name": "", "value": "x"}}],
+			"links": [],
 			"layouts": []
 		}`),
 		"list variable": []byte(`{
@@ -294,6 +303,7 @@ func TestInvalidateEmptyVariableName(t *testing.T) {
 					"plugin": {"kind": "signoz/DynamicVariable", "spec": {"name": "service.name", "signal": "metrics"}}
 				}
 			}],
+			"links": [],
 			"layouts": []
 		}`),
 	}
@@ -319,10 +329,12 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {"kind": "NonExistentPanel", "spec": {}}
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "NonExistentPanel",
@@ -338,6 +350,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "unknown panel kind",
@@ -349,6 +362,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
 							"queries": [{
 								"kind": "time_series",
@@ -359,6 +373,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "FakeQueryPlugin",
@@ -370,6 +385,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
 							"queries": [{
 								"kind": "TimeSeriesQuery",
@@ -380,6 +396,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "unknown request type",
@@ -391,6 +408,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
 							"queries": [{
 								"kind": "",
@@ -401,6 +419,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "unknown request type",
@@ -417,6 +436,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 						"plugin": {"kind": "FakeVariable", "spec": {}}
 					}
 				}],
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "FakeVariable",
@@ -430,6 +450,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 						"plugin": {"kind": "FakeDatasource", "spec": {}}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "FakeDatasource",
@@ -450,13 +471,14 @@ func TestInvalidateOneInvalidPanel(t *testing.T) {
 		"panels": {
 			"good": {
 				"kind": "Panel",
-				"spec": {"plugin": {"kind": "signoz/NumberPanel", "spec": {}}}
+				"spec": {"links": [],"plugin": {"kind": "signoz/NumberPanel", "spec": {}}}
 			},
 			"bad": {
 				"kind": "Panel",
-				"spec": {"plugin": {"kind": "FakePanel", "spec": {}}}
+				"spec": {"links": [],"plugin": {"kind": "FakePanel", "spec": {}}}
 			}
 		},
+		"links": [],
 		"layouts": []
 	}`)
 	_, err := unmarshalDashboard(data)
@@ -469,6 +491,7 @@ func TestInvalidateLayoutPanelReferences(t *testing.T) {
 		"p1": {
 			"kind": "Panel",
 			"spec": {
+				"links": [],
 				"plugin": {"kind": "signoz/TablePanel", "spec": {}},
 				"queries": [{
 					"kind": "time_series",
@@ -480,7 +503,7 @@ func TestInvalidateLayoutPanelReferences(t *testing.T) {
 		}
 	}`
 	layout := func(items string) []byte {
-		return []byte(`{` + validPanels + `, "layouts": [{"kind": "Grid", "spec": {"items": [` + items + `]}}]}`)
+		return []byte(`{` + validPanels + `, "links": [], "layouts": [{"kind": "Grid", "spec": {"items": [` + items + `]}}]}`)
 	}
 
 	tests := []struct {
@@ -536,6 +559,7 @@ func TestRejectUnknownFieldsInPluginSpec(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {
 								"kind": "signoz/TimeSeriesPanel",
 								"spec": {"bogusField": true}
@@ -543,6 +567,7 @@ func TestRejectUnknownFieldsInPluginSpec(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "bogusField",
@@ -554,6 +579,7 @@ func TestRejectUnknownFieldsInPluginSpec(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
 							"queries": [{
 								"kind": "time_series",
@@ -567,6 +593,7 @@ func TestRejectUnknownFieldsInPluginSpec(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "unknownThing",
@@ -586,6 +613,7 @@ func TestRejectUnknownFieldsInPluginSpec(t *testing.T) {
 						}
 					}
 				}],
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "extraField",
@@ -614,6 +642,7 @@ func TestInvalidateWrongFieldTypeInPluginSpec(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {
 								"kind": "signoz/TimeSeriesPanel",
 								"spec": {"visualization": {"fillSpans": "notabool"}}
@@ -621,6 +650,7 @@ func TestInvalidateWrongFieldTypeInPluginSpec(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "fillSpans",
@@ -632,6 +662,7 @@ func TestInvalidateWrongFieldTypeInPluginSpec(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
 							"queries": [{
 								"kind": "time_series",
@@ -645,6 +676,7 @@ func TestInvalidateWrongFieldTypeInPluginSpec(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "",
@@ -664,6 +696,7 @@ func TestInvalidateWrongFieldTypeInPluginSpec(t *testing.T) {
 						}
 					}
 				}],
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "",
@@ -694,6 +727,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {
 								"kind": "signoz/TimeSeriesPanel",
 								"spec": {}
@@ -710,6 +744,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "signal",
@@ -721,6 +756,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {
 								"kind": "signoz/TimeSeriesPanel",
 								"spec": {"chartAppearance": {"lineInterpolation": "cubic"}}
@@ -728,6 +764,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "line interpolation",
@@ -739,6 +776,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {
 								"kind": "signoz/TimeSeriesPanel",
 								"spec": {"chartAppearance": {"lineStyle": "dotted"}}
@@ -746,6 +784,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "line style",
@@ -757,6 +796,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {
 								"kind": "signoz/TimeSeriesPanel",
 								"spec": {"chartAppearance": {"fillMode": "striped"}}
@@ -764,6 +804,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "fill mode",
@@ -775,6 +816,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {
 								"kind": "signoz/TimeSeriesPanel",
 								"spec": {"chartAppearance": {"spanGaps": {"fillOnlyBelow": true, "fillLessThan": "notaduration"}}}
@@ -782,6 +824,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "duration",
@@ -793,6 +836,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {
 								"kind": "signoz/TimeSeriesPanel",
 								"spec": {"visualization": {"timePreference": "last2Hr"}}
@@ -800,6 +844,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "timePreference",
@@ -811,6 +856,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {
 								"kind": "signoz/BarChartPanel",
 								"spec": {"legend": {"position": "top"}}
@@ -818,6 +864,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "legend position",
@@ -829,6 +876,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {
 								"kind": "signoz/BarChartPanel",
 								"spec": {"legend": {"mode": "grid"}}
@@ -836,6 +884,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "legend mode",
@@ -847,6 +896,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {
 								"kind": "signoz/NumberPanel",
 								"spec": {"thresholds": [{"value": 100, "operator": "above", "color": "Red", "format": "Color"}]}
@@ -854,6 +904,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "threshold format",
@@ -865,6 +916,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {
 								"kind": "signoz/NumberPanel",
 								"spec": {"thresholds": [{"value": 100, "operator": "!=", "color": "Red", "format": "text"}]}
@@ -872,6 +924,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "comparison operator",
@@ -883,6 +936,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {
 								"kind": "signoz/TimeSeriesPanel",
 								"spec": {"formatting": {"decimalPrecision": "9"}}
@@ -890,6 +944,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`,
 			wantContain: "precision",
@@ -921,11 +976,13 @@ func TestThresholdLabelOptional(t *testing.T) {
 					"p1": {
 						"kind": "Panel",
 						"spec": {
+							"links": [],
 							"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {"thresholds": [` + tt.threshold + `]}},
 							"queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/PromQLQuery", "spec": {"name": "A", "query": "up"}}}}]
 						}
 					}
 				},
+				"links": [],
 				"layouts": []
 			}`)
 			d, err := unmarshalDashboard(data)
@@ -943,9 +1000,10 @@ func TestInvalidatePanelWithoutQueries(t *testing.T) {
 		"panels": {
 			"p1": {
 				"kind": "Panel",
-				"spec": {"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}}}
+				"spec": {"links": [],"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}}}
 			}
 		},
+		"links": [],
 		"layouts": []
 	}`)
 	_, err := unmarshalDashboard(data)
@@ -959,11 +1017,13 @@ func TestInvalidatePanelWithEmptyQueriesArray(t *testing.T) {
 			"p1": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
 					"queries": []
 				}
 			}
 		},
+		"links": [],
 		"layouts": []
 	}`)
 	_, err := unmarshalDashboard(data)
@@ -979,6 +1039,7 @@ func TestInvalidatePanelWithMultipleDirectQueries(t *testing.T) {
 			"p1": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
 					"queries": [
 						{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {"name": "A", "signal": "metrics"}}}},
@@ -987,6 +1048,7 @@ func TestInvalidatePanelWithMultipleDirectQueries(t *testing.T) {
 				}
 			}
 		},
+		"links": [],
 		"layouts": []
 	}`)
 	_, err := unmarshalDashboard(data)
@@ -1006,6 +1068,7 @@ func TestValidateRequiredFields(t *testing.T) {
 					"plugin": {"kind": "` + pluginKind + `", "spec": ` + pluginSpec + `}
 				}
 			}],
+			"links": [],
 			"layouts": []
 		}`
 	}
@@ -1015,10 +1078,12 @@ func TestValidateRequiredFields(t *testing.T) {
 				"p1": {
 					"kind": "Panel",
 					"spec": {
+						"links": [],
 						"plugin": {"kind": "` + panelKind + `", "spec": ` + panelSpec + `}
 					}
 				}
 			},
+			"links": [],
 			"layouts": []
 		}`
 	}
@@ -1083,6 +1148,7 @@ func TestTimeSeriesPanelDefaults(t *testing.T) {
 			"p1": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {
 						"kind": "signoz/TimeSeriesPanel",
 						"spec": {}
@@ -1091,6 +1157,7 @@ func TestTimeSeriesPanelDefaults(t *testing.T) {
 				}
 			}
 		},
+		"links": [],
 		"layouts": []
 	}`)
 	d, err := unmarshalDashboard(data)
@@ -1133,6 +1200,7 @@ func TestNumberPanelDefaults(t *testing.T) {
 			"p1": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {
 						"kind": "signoz/NumberPanel",
 						"spec": {"thresholds": [{"value": 100, "color": "Red"}]}
@@ -1141,6 +1209,7 @@ func TestNumberPanelDefaults(t *testing.T) {
 				}
 			}
 		},
+		"links": [],
 		"layouts": []
 	}`)
 	d, err := unmarshalDashboard(data)
@@ -1194,6 +1263,7 @@ func TestStorageRoundTrip(t *testing.T) {
 			"p1": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {
 						"kind": "signoz/TimeSeriesPanel",
 						"spec": {}
@@ -1204,6 +1274,7 @@ func TestStorageRoundTrip(t *testing.T) {
 			"p2": {
 				"kind": "Panel",
 				"spec": {
+					"links": [],
 					"plugin": {
 						"kind": "signoz/NumberPanel",
 						"spec": {"thresholds": [{"value": 100, "color": "Red"}]}
@@ -1212,6 +1283,7 @@ func TestStorageRoundTrip(t *testing.T) {
 				}
 			}
 		},
+		"links": [],
 		"layouts": []
 	}`)
 
@@ -1290,7 +1362,7 @@ func TestPostableDashboardV2GenerateNameFlag(t *testing.T) {
 		},
 		{
 			scenario:     "flag true with non-empty name is rejected",
-			body:         `{"schemaVersion":"` + SchemaVersion + `","name":"already-set","generateName":true,"spec":{"display":{"name":"My Dashboard"},"panels":{},"layouts":[]}}`,
+			body:         `{"schemaVersion":"` + SchemaVersion + `","name":"already-set","generateName":true,"spec":{"display":{"name":"My Dashboard"},"panels":{},"layouts":[],"links":[]}}`,
 			wantErr:      true,
 			wantErrMatch: "name must be empty when generateName is true",
 		},
@@ -1450,20 +1522,24 @@ func TestPanelTypeQueryTypeCompatibility(t *testing.T) {
 	mkQuery := func(panelKind, queryKind, querySpec string) []byte {
 		return []byte(`{
 			"panels": {"p1": {"kind": "Panel", "spec": {
+				"links": [],
 				"plugin": {"kind": "` + panelKind + `", "spec": {}},
 				"queries": [{"kind": "` + requestKind(panelKind) + `", "spec": {"plugin": {"kind": "` + queryKind + `", "spec": ` + querySpec + `}}}]
 			}}},
+			"links": [],
 			"layouts": []
 		}`)
 	}
 	mkComposite := func(panelKind, subType, subSpec string) []byte {
 		return []byte(`{
 			"panels": {"p1": {"kind": "Panel", "spec": {
+				"links": [],
 				"plugin": {"kind": "` + panelKind + `", "spec": {}},
 				"queries": [{"kind": "` + requestKind(panelKind) + `", "spec": {"plugin": {"kind": "signoz/CompositeQuery", "spec": {
 					"queries": [{"type": "` + subType + `", "spec": ` + subSpec + `}]
 				}}}}]
 			}}},
+			"links": [],
 			"layouts": []
 		}`)
 	}
@@ -1507,11 +1583,13 @@ func TestCommaSeparatedAggregationRejectedOnWrite(t *testing.T) {
 	buildDashboardWithLogsAggregation := func(aggregationsJSON string) []byte {
 		return []byte(`{
 		"panels": {"p1": {"kind": "Panel", "spec": {
+			"links": [],
 			"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
 			"queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {
 				"name": "A", "signal": "logs", "aggregations": ` + aggregationsJSON + `
 			}}}}]
 		}}},
+		"links": [],
 		"layouts": []
 	}`)
 	}
@@ -1625,9 +1703,10 @@ func TestValidateGridItemLimit(t *testing.T) {
 func TestInvalidateLayoutOverlapViaUnmarshal(t *testing.T) {
 	data := []byte(`{
 		"panels": {
-			"p1": {"kind": "Panel", "spec": {"plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {"name": "A", "signal": "logs", "aggregations": [{"expression": "count()"}]}}}}]}},
-			"p2": {"kind": "Panel", "spec": {"plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {"name": "A", "signal": "logs", "aggregations": [{"expression": "count()"}]}}}}]}}
+			"p1": {"kind": "Panel", "spec": {"links": [],"plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {"name": "A", "signal": "logs", "aggregations": [{"expression": "count()"}]}}}}]}},
+			"p2": {"kind": "Panel", "spec": {"links": [],"plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {"name": "A", "signal": "logs", "aggregations": [{"expression": "count()"}]}}}}]}}
 		},
+		"links": [],
 		"layouts": [{"kind": "Grid", "spec": {"items": [
 			{"x": 0, "y": 0, "width": 6, "height": 6, "content": {"$ref": "#/spec/panels/p1"}},
 			{"x": 3, "y": 3, "width": 6, "height": 6, "content": {"$ref": "#/spec/panels/p2"}}
@@ -1644,8 +1723,9 @@ func TestInvalidateLayoutOverlapViaUnmarshal(t *testing.T) {
 func TestInvalidateDuplicatePanelReference(t *testing.T) {
 	data := []byte(`{
 		"panels": {
-			"p1": {"kind": "Panel", "spec": {"plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {"name": "A", "signal": "logs", "aggregations": [{"expression": "count()"}]}}}}]}}
+			"p1": {"kind": "Panel", "spec": {"links": [],"plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {"name": "A", "signal": "logs", "aggregations": [{"expression": "count()"}]}}}}]}}
 		},
+		"links": [],
 		"layouts": [{"kind": "Grid", "spec": {"items": [
 			{"x": 0, "y": 0, "width": 6, "height": 6, "content": {"$ref": "#/spec/panels/p1"}},
 			{"x": 6, "y": 0, "width": 6, "height": 6, "content": {"$ref": "#/spec/panels/p1"}}
@@ -1675,31 +1755,31 @@ func TestInvalidateDisplayNameTooLong(t *testing.T) {
 	}{
 		{
 			scenario:      "dashboard display name",
-			dashboardJSON: `{"display": {"name": "` + tooLong + `"}, "layouts": []}`,
+			dashboardJSON: `{"display": {"name": "` + tooLong + `"}, "links": [], "layouts": []}`,
 			expectedLabel: "dashboard",
 			expectedPath:  "spec.display.name",
 		},
 		{
 			scenario:      "panel display name",
-			dashboardJSON: `{"panels": {"p1": {"kind": "Panel", "spec": {"display": {"name": "` + tooLong + `"}, "plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": []}}}, "layouts": []}`,
+			dashboardJSON: `{"panels": {"p1": {"kind": "Panel", "spec": {"links": [],"display": {"name": "` + tooLong + `"}, "plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": []}}}, "links": [], "layouts": []}`,
 			expectedLabel: "panel",
 			expectedPath:  "spec.panels.p1.spec.display.name",
 		},
 		{
 			scenario:      "list variable display name",
-			dashboardJSON: `{"variables": [{"kind": "ListVariable", "spec": {"name": "svc", "display": {"name": "` + tooLong + `"}, "plugin": {"kind": "signoz/DynamicVariable", "spec": {"name": "service.name", "signal": "metrics"}}}}], "layouts": []}`,
+			dashboardJSON: `{"variables": [{"kind": "ListVariable", "spec": {"name": "svc", "display": {"name": "` + tooLong + `"}, "plugin": {"kind": "signoz/DynamicVariable", "spec": {"name": "service.name", "signal": "metrics"}}}}], "links": [], "layouts": []}`,
 			expectedLabel: "variable",
 			expectedPath:  "spec.variables[0].spec.display.name",
 		},
 		{
 			scenario:      "text variable display name",
-			dashboardJSON: `{"variables": [{"kind": "TextVariable", "spec": {"name": "mytext", "value": "v", "display": {"name": "` + tooLong + `"}}}], "layouts": []}`,
+			dashboardJSON: `{"variables": [{"kind": "TextVariable", "spec": {"name": "mytext", "value": "v", "display": {"name": "` + tooLong + `"}}}], "links": [], "layouts": []}`,
 			expectedLabel: "variable",
 			expectedPath:  "spec.variables[0].spec.display.name",
 		},
 		{
 			scenario:      "layout title",
-			dashboardJSON: `{"layouts": [{"kind": "Grid", "spec": {"display": {"title": "` + tooLong + `"}, "items": []}}]}`,
+			dashboardJSON: `{"links": [], "layouts": [{"kind": "Grid", "spec": {"display": {"title": "` + tooLong + `"}, "items": []}}]}`,
 			expectedLabel: "layout",
 			expectedPath:  "spec.layouts[0].spec.display.title",
 		},
@@ -1719,7 +1799,7 @@ func TestInvalidateDisplayNameTooLong(t *testing.T) {
 // A display name at exactly the limit is accepted.
 func TestValidateDisplayNameAtMaxLength(t *testing.T) {
 	atLimit := strings.Repeat("x", MaxDisplayNameLen)
-	_, err := unmarshalDashboard([]byte(`{"display": {"name": "` + atLimit + `"}, "layouts": []}`))
+	_, err := unmarshalDashboard([]byte(`{"display": {"name": "` + atLimit + `"}, "links": [], "layouts": []}`))
 	assert.NoError(t, err)
 }
 

--- a/pkg/types/dashboardtypes/perses_dashboard_test.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_test.go
@@ -1272,7 +1272,7 @@ func TestStorageRoundTrip(t *testing.T) {
 }
 
 func TestPostableDashboardV2GenerateNameFlag(t *testing.T) {
-	const validSpec = `"spec": {"panels": {}, "layouts": []}`
+	const validSpec = `"spec": {"panels": {}, "layouts": [], "links": []}`
 
 	tests := []struct {
 		scenario     string
@@ -1284,7 +1284,7 @@ func TestPostableDashboardV2GenerateNameFlag(t *testing.T) {
 	}{
 		{
 			scenario:    "flag true with display.name derives name on conversion",
-			body:        `{"schemaVersion":"` + SchemaVersion + `","generateName":true,"spec":{"display":{"name":"My Dashboard!"},"panels":{},"layouts":[]}}`,
+			body:        `{"schemaVersion":"` + SchemaVersion + `","generateName":true,"spec":{"display":{"name":"My Dashboard!"},"panels":{},"layouts":[],"links":[]}}`,
 			wantName:    "",
 			wantDisplay: "My Dashboard!",
 		},

--- a/pkg/types/dashboardtypes/perses_public_dashboard_redaction_test.go
+++ b/pkg/types/dashboardtypes/perses_public_dashboard_redaction_test.go
@@ -228,7 +228,7 @@ func TestRedactVariableQueries(t *testing.T) {
 
 	t.Run("leaves non-query variables untouched", func(t *testing.T) {
 		spec := DashboardSpec{Variables: []Variable{
-			{Kind: variable.KindList, Spec: &ListVariableSpec{Name: "signal", Plugin: VariablePlugin{Kind: VariableKindDynamic, Spec: &DynamicVariableSpec{Name: "service.name", Signal: telemetrytypes.SignalTraces}}}},
+			{Kind: variable.KindList, Spec: &ListVariableSpec{Name: "signal", Plugin: VariablePlugin{Kind: VariableKindDynamic, Spec: &DynamicVariableSpec{Name: "service.name", Signal: DynamicVariableSignalTraces}}}},
 			{Kind: variable.KindList, Spec: &ListVariableSpec{Name: "env", Plugin: VariablePlugin{Kind: VariableKindCustom, Spec: &CustomVariableSpec{CustomValue: "prod,staging"}}}},
 		}}
 

--- a/pkg/types/dashboardtypes/perses_replicas.go
+++ b/pkg/types/dashboardtypes/perses_replicas.go
@@ -78,7 +78,7 @@ type PanelSpec struct {
 	Display Display     `json:"display" required:"true"`
 	Plugin  PanelPlugin `json:"plugin" required:"true"`
 	Queries []Query     `json:"queries" required:"true" nullable:"false"`
-	Links   []Link      `json:"links,omitzero"`
+	Links   []Link      `json:"links" required:"true" nullable:"false"`
 }
 
 // Link replicates dashboard.Link (Perses) so its zero-valued fields survive the

--- a/pkg/types/dashboardtypes/perses_replicas.go
+++ b/pkg/types/dashboardtypes/perses_replicas.go
@@ -81,6 +81,16 @@ type PanelSpec struct {
 	Links   []Link      `json:"links" required:"true" nullable:"false"`
 }
 
+// validateLinks rejects a missing/null links field, where path is the panel's
+// location (e.g. "spec.panels.<key>"). A typed client must send [] rather than
+// omitting links, so its value round-trips faithfully.
+func (s *PanelSpec) validateLinks(path string) error {
+	if s.Links == nil {
+		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "%s.spec.links is required; send [] when there are no links", path)
+	}
+	return nil
+}
+
 // Link replicates dashboard.Link (Perses) so its zero-valued fields survive the
 // create -> GET round-trip. Perses tags name/tooltip/renderVariables/targetBlank
 // omitempty, which drops "" and false; here every field always serializes so a

--- a/pkg/types/dashboardtypes/perses_signoz_plugins.go
+++ b/pkg/types/dashboardtypes/perses_signoz_plugins.go
@@ -67,10 +67,6 @@ func (s *DynamicVariableSignal) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &v); err != nil {
 		return errors.WrapInvalidInputf(err, ErrCodeDashboardInvalidInput, "invalid signal: must be a string, one of `traces`, `logs`, `metrics`, or `all`")
 	}
-	if v == "" {
-		*s = DynamicVariableSignalAll
-		return nil
-	}
 	sig := DynamicVariableSignal{valuer.NewString(v)}
 	switch sig {
 	case DynamicVariableSignalTraces, DynamicVariableSignalLogs, DynamicVariableSignalMetrics, DynamicVariableSignalAll:

--- a/pkg/types/dashboardtypes/perses_signoz_plugins.go
+++ b/pkg/types/dashboardtypes/perses_signoz_plugins.go
@@ -32,7 +32,53 @@ type DynamicVariableSpec struct {
 	// Name is the name of the attribute being fetched dynamically from the
 	// signal. This could be extended to a richer selector in the future.
 	Name   string                `json:"name" validate:"required" required:"true"`
-	Signal telemetrytypes.Signal `json:"signal"`
+	Signal DynamicVariableSignal `json:"signal" required:"true" nullable:"false"`
+}
+
+// DynamicVariableSignal is the telemetry signal a dynamic variable draws its
+// values from. Separate from telemetrytypes.Signal because it carries "all"
+// (values span every signal) rather than "" for an unpinned query signal.
+type DynamicVariableSignal struct{ valuer.String }
+
+var (
+	DynamicVariableSignalTraces  = DynamicVariableSignal{valuer.NewString("traces")}
+	DynamicVariableSignalLogs    = DynamicVariableSignal{valuer.NewString("logs")}
+	DynamicVariableSignalMetrics = DynamicVariableSignal{valuer.NewString("metrics")}
+	DynamicVariableSignalAll     = DynamicVariableSignal{valuer.NewString("all")} // default
+)
+
+func (DynamicVariableSignal) Enum() []any {
+	return []any{DynamicVariableSignalTraces, DynamicVariableSignalLogs, DynamicVariableSignalMetrics, DynamicVariableSignalAll}
+}
+
+func (s DynamicVariableSignal) ValueOrDefault() string {
+	if s.IsZero() {
+		return DynamicVariableSignalAll.StringValue()
+	}
+	return s.StringValue()
+}
+
+func (s DynamicVariableSignal) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.ValueOrDefault())
+}
+
+func (s *DynamicVariableSignal) UnmarshalJSON(data []byte) error {
+	var v string
+	if err := json.Unmarshal(data, &v); err != nil {
+		return errors.WrapInvalidInputf(err, ErrCodeDashboardInvalidInput, "invalid signal: must be a string, one of `traces`, `logs`, `metrics`, or `all`")
+	}
+	if v == "" {
+		*s = DynamicVariableSignalAll
+		return nil
+	}
+	sig := DynamicVariableSignal{valuer.NewString(v)}
+	switch sig {
+	case DynamicVariableSignalTraces, DynamicVariableSignalLogs, DynamicVariableSignalMetrics, DynamicVariableSignalAll:
+		*s = sig
+		return nil
+	default:
+		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "invalid signal %q: must be `traces`, `logs`, `metrics`, or `all`", v)
+	}
 }
 
 type QueryVariableSpec struct {

--- a/pkg/types/dashboardtypes/testdata/perses.json
+++ b/pkg/types/dashboardtypes/testdata/perses.json
@@ -80,6 +80,7 @@
             }
         }
     ],
+    "links": [],
     "panels": {
         "24e2697b": {
             "kind": "Panel",
@@ -167,6 +168,7 @@
         "ff2f72f1": {
             "kind": "Panel",
             "spec": {
+                "links": [],
                 "display": {
                     "name": "fraction of calls",
                     "description": ""
@@ -253,6 +255,7 @@
         "011605e7": {
             "kind": "Panel",
             "spec": {
+                "links": [],
                 "display": {
                     "name": "total resp size"
                 },
@@ -304,6 +307,7 @@
         "e23516fc": {
             "kind": "Panel",
             "spec": {
+                "links": [],
                 "display": {
                     "name": "num traces for service"
                 },
@@ -359,6 +363,7 @@
         "130c8d6b": {
             "kind": "Panel",
             "spec": {
+                "links": [],
                 "display": {
                     "name": "num logs for service"
                 },
@@ -398,6 +403,7 @@
         "246f7c6d": {
             "kind": "Panel",
             "spec": {
+                "links": [],
                 "display": {
                     "name": "num traces for service per resp code"
                 },
@@ -451,6 +457,7 @@
         "21f7d4d0": {
             "kind": "Panel",
             "spec": {
+                "links": [],
                 "display": {
                     "name": "average latency per service"
                 },
@@ -493,6 +500,7 @@
         "ad5fd556": {
             "kind": "Panel",
             "spec": {
+                "links": [],
                 "display": {
                     "name": "logs from service"
                 },
@@ -557,6 +565,7 @@
         "f07b59ee": {
             "kind": "Panel",
             "spec": {
+                "links": [],
                 "display": {
                     "name": "response size buckets"
                 },
@@ -596,6 +605,7 @@
         "e1a41831": {
             "kind": "Panel",
             "spec": {
+                "links": [],
                 "display": {
                     "name": "trace operator",
                     "description": ""
@@ -672,6 +682,7 @@
         "f0d70491": {
             "kind": "Panel",
             "spec": {
+                "links": [],
                 "display": {
                     "name": "no results in this promql",
                     "description": ""
@@ -713,6 +724,7 @@
         "0e6eb4ca": {
             "kind": "Panel",
             "spec": {
+                "links": [],
                 "display": {
                     "name": "no results in this promql",
                     "description": ""

--- a/pkg/types/dashboardtypes/testdata/perses_with_sections.json
+++ b/pkg/types/dashboardtypes/testdata/perses_with_sections.json
@@ -12,10 +12,12 @@
             }
         }
     },
+    "links": [],
     "panels": {
         "b424e23b": {
             "kind": "Panel",
             "spec": {
+                "links": [],
                 "display": {
                     "name": ""
                 },
@@ -58,6 +60,7 @@
         "251df4d5": {
             "kind": "Panel",
             "spec": {
+                "links": [],
                 "display": {
                     "name": ""
                 },

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -209,6 +209,7 @@ def test_create_rejects_invalid_grid_layout(
             "kind": "Panel",
             "spec": {
                 "display": {"name": name},
+                "links": [],
                 "plugin": {"kind": "signoz/TablePanel", "spec": {}},
                 "queries": [
                     {
@@ -410,7 +411,7 @@ def test_update_missing_dashboard_returns_not_found(
         json={
             "schemaVersion": "v6",
             "name": "missing-dashboard",
-            "spec": {"display": {"name": "Missing Dashboard"}},
+            "spec": {"display": {"name": "Missing Dashboard"}, "links": []},
             "tags": [],
         },
         headers={"Authorization": f"Bearer {token}"},
@@ -535,7 +536,7 @@ def test_dashboard_v2_lifecycle(  # pylint: disable=too-many-locals,too-many-sta
             json={
                 "schemaVersion": "v6",
                 "name": name,
-                "spec": {"display": {"name": display}},
+                "spec": {"display": {"name": display}, "links": []},
                 "tags": tags,
             },
             headers={"Authorization": f"Bearer {token}"},
@@ -897,7 +898,7 @@ def test_dashboard_v2_lifecycle(  # pylint: disable=too-many-locals,too-many-sta
     update_body = {
         "schemaVersion": "v6",
         "name": "lc-alpha",
-        "spec": {"display": {"name": "Alpha Overview"}},
+        "spec": {"display": {"name": "Alpha Overview"}, "links": []},
         "tags": [
             {"key": "team", "value": "pulse"},
             {"key": "env", "value": "prod"},
@@ -941,7 +942,7 @@ def test_dashboard_v2_lifecycle(  # pylint: disable=too-many-locals,too-many-sta
     beta_body = {
         "schemaVersion": "v6",
         "name": "lc-beta",
-        "spec": {"display": {"name": "Beta Overview"}},
+        "spec": {"display": {"name": "Beta Overview"}, "links": []},
         "tags": [{"key": "team", "value": "pulse"}, {"key": "env", "value": "dev"}],
     }
     response = requests.put(
@@ -1137,7 +1138,7 @@ def test_dashboard_v2_pin_limit(
             json={
                 "schemaVersion": "v6",
                 "name": f"pl-{i}",
-                "spec": {"display": {"name": f"Pin Limit {i}"}},
+                "spec": {"display": {"name": f"Pin Limit {i}"}, "links": []},
                 "tags": [],
             },
             headers={"Authorization": f"Bearer {token}"},
@@ -1235,7 +1236,7 @@ def test_dashboard_v2_like_escaping(
             json={
                 "schemaVersion": "v6",
                 "name": name,
-                "spec": {"display": {"name": display}},
+                "spec": {"display": {"name": display}, "links": []},
                 "tags": [],
             },
             headers={"Authorization": f"Bearer {token}"},
@@ -1326,11 +1327,13 @@ def test_dashboard_v2_get_by_metric_name(
             "name": "by-metric-builder",
             "spec": {
                 "display": {"name": "by-metric-builder"},
+                "links": [],
                 "panels": {
                     "p-builder": {
                         "kind": "Panel",
                         "spec": {
                             "display": {"name": "D1 builder target"},
+                            "links": [],
                             "plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
                             "queries": [
                                 {
@@ -1375,11 +1378,13 @@ def test_dashboard_v2_get_by_metric_name(
             "name": "by-metric-ch-promql",
             "spec": {
                 "display": {"name": "by-metric-ch-promql"},
+                "links": [],
                 "panels": {
                     "p-ch": {
                         "kind": "Panel",
                         "spec": {
                             "display": {"name": "D2 clickhouse target"},
+                            "links": [],
                             "plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
                             "queries": [
                                 {
@@ -1401,6 +1406,7 @@ def test_dashboard_v2_get_by_metric_name(
                         "kind": "Panel",
                         "spec": {
                             "display": {"name": "D2 promql target"},
+                            "links": [],
                             "plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
                             "queries": [
                                 {
@@ -1437,11 +1443,13 @@ def test_dashboard_v2_get_by_metric_name(
             "name": "by-metric-promql",
             "spec": {
                 "display": {"name": "by-metric-promql"},
+                "links": [],
                 "panels": {
                     "p-promql": {
                         "kind": "Panel",
                         "spec": {
                             "display": {"name": "D3 promql target"},
+                            "links": [],
                             "plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
                             "queries": [
                                 {
@@ -1480,11 +1488,13 @@ def test_dashboard_v2_get_by_metric_name(
             "name": "by-metric-false-positive",
             "spec": {
                 "display": {"name": "by-metric-false-positive"},
+                "links": [],
                 "panels": {
                     "p-builder": {
                         "kind": "Panel",
                         "spec": {
                             "display": {"name": f"{target_metric} builder"},
+                            "links": [],
                             "plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
                             "queries": [
                                 {
@@ -1513,6 +1523,7 @@ def test_dashboard_v2_get_by_metric_name(
                         "kind": "Panel",
                         "spec": {
                             "display": {"name": f"{target_metric} clickhouse"},
+                            "links": [],
                             "plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
                             "queries": [
                                 {
@@ -1534,6 +1545,7 @@ def test_dashboard_v2_get_by_metric_name(
                         "kind": "Panel",
                         "spec": {
                             "display": {"name": f"{target_metric} promql"},
+                            "links": [],
                             "plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
                             "queries": [
                                 {
@@ -1607,11 +1619,13 @@ def test_dashboard_v2_rejects_comma_separated_aggregation(
             "tags": [],
             "spec": {
                 "display": {"name": "Aggregation"},
+                "links": [],
                 "panels": {
                     "p-agg": {
                         "kind": "Panel",
                         "spec": {
                             "display": {"name": "agg"},
+                            "links": [],
                             "plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
                             "queries": [
                                 {
@@ -1763,6 +1777,7 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
                     "kind": "Panel",
                     "spec": {
                         "display": {"name": "timeseries"},
+                        "links": [],
                         "plugin": {
                             "kind": "signoz/TimeSeriesPanel",
                             "spec": {"thresholds": [{"value": 0, "color": "#c2780b"}]},
@@ -1785,6 +1800,7 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
                     "kind": "Panel",
                     "spec": {
                         "display": {"name": "promql"},
+                        "links": [],
                         "plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
                         "queries": [
                             {
@@ -1804,6 +1820,7 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
                     "kind": "Panel",
                     "spec": {
                         "display": {"name": "clickhouse"},
+                        "links": [],
                         "plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
                         "queries": [
                             {
@@ -1899,11 +1916,9 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
         for description, spec, key in absent_cases:
             assert key not in spec, description
 
-        # A panel with no links comes back with no links value (null or absent);
-        # either is fine for a typed client (an unset optional attribute stays
-        # unset), so this is not a drift. The explicit [] case above is what the
-        # fix guarantees round-trips.
-        assert panels["timeseries"]["spec"].get("links") is None, "unset panel links stays unset"
+        # links is a required, non-nullable field: an explicit [] round-trips as [],
+        # so a typed client always reads a concrete array (never null or absent).
+        assert panels["timeseries"]["spec"]["links"] == [], "panel links round-trip as []"
     finally:
         requests.delete(
             signoz.self.host_configs["8080"].get(f"{BASE_URL}/{dashboard_id}"),

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -113,7 +113,7 @@ def test_create_rejects_unknown_field(
         json={
             "schemaVersion": "v6",
             "name": "rejects-unknown",
-            "spec": {"display": {"name": "Rejects Unknown"}},
+            "spec": {"display": {"name": "Rejects Unknown"}, "links": []},
             "tags": [],
             "unknownfield": "boom",
         },
@@ -250,6 +250,7 @@ def test_create_rejects_invalid_grid_layout(
                         },
                     }
                 ],
+                "links": [],
             },
             "tags": [],
         },
@@ -281,6 +282,7 @@ def test_create_rejects_invalid_grid_layout(
                         },
                     }
                 ],
+                "links": [],
             },
             "tags": [],
         },
@@ -306,6 +308,7 @@ def test_create_rejects_invalid_grid_layout(
                         "spec": {"items": [{"x": 0, "y": 0, "width": 1, "height": 1} for _ in range(101)]},
                     }
                 ],
+                "links": [],
             },
             "tags": [],
         },
@@ -1046,7 +1049,7 @@ def test_dashboard_v2_tag_order_round_trips(
     ]
     response = requests.post(
         signoz.self.host_configs["8080"].get(BASE_URL),
-        json={"schemaVersion": "v6", "name": "tag-order", "spec": {"display": {"name": "Tag Order"}}, "tags": created_order},
+        json={"schemaVersion": "v6", "name": "tag-order", "spec": {"display": {"name": "Tag Order"}, "links": []}, "tags": created_order},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -1072,7 +1075,7 @@ def test_dashboard_v2_tag_order_round_trips(
     ]
     response = requests.put(
         signoz.self.host_configs["8080"].get(f"{BASE_URL}/{dashboard_id}"),
-        json={"schemaVersion": "v6", "name": "tag-order", "spec": {"display": {"name": "Tag Order"}}, "tags": reordered},
+        json={"schemaVersion": "v6", "name": "tag-order", "spec": {"display": {"name": "Tag Order"}, "links": []}, "tags": reordered},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -1101,7 +1104,7 @@ def test_dashboard_v2_tag_order_round_trips(
     ]
     response = requests.put(
         signoz.self.host_configs["8080"].get(f"{BASE_URL}/{dashboard_id}"),
-        json={"schemaVersion": "v6", "name": "tag-order", "spec": {"display": {"name": "Tag Order"}}, "tags": new_order},
+        json={"schemaVersion": "v6", "name": "tag-order", "spec": {"display": {"name": "Tag Order"}, "links": []}, "tags": new_order},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -1970,6 +1973,7 @@ def test_dashboard_v2_omitted_enums_apply_defaults(
                                 },
                             }
                         ],
+                        "links": [],
                     },
                 },
                 "num": {
@@ -1991,9 +1995,11 @@ def test_dashboard_v2_omitted_enums_apply_defaults(
                                 },
                             }
                         ],
+                        "links": [],
                     },
                 },
             },
+            "links": [],
         },
     }
 

--- a/tests/integration/tests/dashboard/05_v2_public_dashboard.py
+++ b/tests/integration/tests/dashboard/05_v2_public_dashboard.py
@@ -59,6 +59,7 @@ def test_public_dashboard_v2(
             "spec": {
                 "display": {"name": "Sample Dashboard", "description": "Used for integration tests"},
                 "duration": "1h",
+                "links": [],
                 "variables": [
                     {
                         "kind": "ListVariable",
@@ -77,6 +78,7 @@ def test_public_dashboard_v2(
                         "kind": "Panel",
                         "spec": {
                             "display": {"name": "total"},
+                            "links": [],
                             "plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {"visualization": {"fillSpans": True}}},
                             "queries": [
                                 {


### PR DESCRIPTION
Two dashboards-v2 spec-fidelity fixes so query fields survive a create → GET round-trip for typed clients (Terraform / SDK).

## 1. Dynamic-variable signal: a dedicated `all` value

A dynamic variable's signal is now its own enum — `traces | logs | metrics | all` — with `all` (search across every signal) as the default. This is intentionally separate from a panel query's signal (which uses an empty value to mean "unpinned"): a variable's "search everywhere" is a real, named `all` value that round-trips verbatim instead of relying on an empty string.

- **Backend:** the dynamic-variable `signal` is a required, non-nullable field (`traces`/`logs`/`metrics`/`all`). An empty or otherwise-invalid value is rejected; an omitted field defaults to `all`.
- **Frontend:** the editor, save, read and drilldown paths all use the `all` value directly — no empty-string sentinel. The field-keys/values fetch (which only accepts a concrete signal) maps `all` → omitted.

## 2. Panel/dashboard `links`: required and non-nullable

`links` was nullable, so an unset value round-tripped as `null`. Since v2 dashboards haven't shipped, the contract is tightened rather than left nullable:

- `PanelSpec.Links` and `DashboardSpec.Links` are now **required and non-nullable**; a missing value is rejected (validated on both write and read) instead of being silently defaulted.
- The generated client makes `links` a non-optional `Link[]`, so every spec builder sends `links: []` and the null guards were removed.

## Testing

- Go unit tests (`pkg/types/dashboardtypes/...`, `pkg/modules/dashboard/...`) updated and passing.
- Frontend `tsgo` / `oxlint` clean; dashboard-v2 Variables + drilldown Jest suites passing.
- v2 dashboard integration tests updated to send the required fields; these need the Docker stack, so CI is the check.

#### Tickets closed by this PR

Closes https://github.com/SigNoz/pulse-pod/issues/135
Closes https://github.com/SigNoz/pulse-pod/issues/136
