### PR TITLE
fix(onboarding): surface Temporal Cloud Metrics as a metrics integration

### DIFF
--- a/frontend/src/container/OnboardingV2Container/onboarding-configs/onboarding-config-with-links.ts
+++ b/frontend/src/container/OnboardingV2Container/onboarding-configs/onboarding-config-with-links.ts
@@ -5263,6 +5263,24 @@ const onboardingConfigWithLinks = [
 		},
 	},
 	{
+		dataSource: 'temporal-cloud-metrics',
+		label: 'Temporal Cloud Metrics',
+		imgUrl: temporalUrl,
+		tags: ['metrics'],
+		module: 'metrics',
+		relatedSearchKeywords: [
+			'metrics',
+			'integrations',
+			'temporal',
+			'temporal cloud',
+			'temporal cloud metrics',
+			'temporal metrics',
+			'openmetrics',
+			'prometheus',
+		],
+		link: '/docs/integrations/temporal-cloud-metrics/',
+	},
+	{
 		dataSource: 'temporal',
 		label: 'Temporal',
 		imgUrl: temporalUrl,
@@ -5273,9 +5291,6 @@ const onboardingConfigWithLinks = [
 			'application performance monitoring',
 			'integrations',
 			'temporal',
-			'temporal cloud',
-			'temporal logs',
-			'temporal metrics',
 			'temporal traces',
 			'traces',
 			'tracing',
@@ -5284,12 +5299,6 @@ const onboardingConfigWithLinks = [
 			desc: 'What are you using ?',
 			type: 'select',
 			options: [
-				{
-					key: 'temporal-cloud',
-					label: 'Cloud Metrics',
-					imgUrl: temporalUrl,
-					link: '/docs/integrations/temporal-cloud-metrics/',
-				},
 				{
 					key: 'temporal-golang',
 					label: 'Go',


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
Temporal Cloud Metrics only appeared under **APM/Traces**, inside the Temporal card's SDK picker next to Go and TypeScript. It scrapes Temporal Cloud's OpenMetrics endpoint, so it belongs in the Metrics category on its own.

- New **Temporal Cloud Metrics** card under **Metrics** (`tags: ['metrics']`, `module: 'metrics'`), linking to the setup doc.
- Temporal APM card now offers only **Go** and **TypeScript**.

One file: `frontend/src/container/OnboardingV2Container/onboarding-configs/onboarding-config-with-links.ts`.

#### Screenshots / Screen Recordings (if applicable)
<img width="1280" height="577" alt="image" src="https://github.com/user-attachments/assets/ec01269c-2084-4f7d-b80b-a7313c75c00d" />

#### Issues closed by this PR
Closes SigNoz/growth-pod#1122

---

### ✅ Change Type
- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause
The `temporal` entry used `tags: ['apm/traces']` and listed Cloud Metrics as an SDK sub-option. Grouping keys off `tags`, so the metrics setup never showed under Metrics.

#### Fix Strategy
Added a separate `temporal-cloud-metrics` entry tagged `metrics`, and removed the Cloud Metrics option from the Temporal APM card.

---

### 🧪 Testing Strategy
- Tests added/updated: none, static config with no test coverage
- Manual verification: ran the frontend on a local backend, opened `/get-started-with-signoz-cloud`, confirmed the new card under Metrics and the APM picker showing only Go and TypeScript
- Edge cases covered: split `relatedSearchKeywords` so both cards stay searchable

---

### ⚠️ Risk & Impact Assessment
- Blast radius: onboarding "Add Data Source" grid only
- Potential regressions: none expected; existing `temporal` key unchanged
- Rollback plan: revert the commit

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Temporal Cloud Metrics now appears under the Metrics category, separate from the Temporal SDK tracing options |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers
Single-file config change. The Temporal APM card stays under APM/Traces on purpose; Go and TypeScript are real tracing SDKs. Only Cloud Metrics moved out.