### PR TITLE
test(e2e): fix teardown crashes (network endpoint race + eager keeper lookup)

### DIFF
--- a/tests/fixtures/clickhouse.py
+++ b/tests/fixtures/clickhouse.py
@@ -203,9 +203,9 @@ def create_clickhouse(  # pylint: disable=too-many-arguments,too-many-positional
     pytestconfig: pytest.Config,
     cache_key: str = "clickhouse",
 ) -> types.TestContainerClickhouse:
-    coordinator = next(iter(keeper.container_configs.values()))
-
     def create() -> types.TestContainerClickhouse:
+        # Lazy: the keeper fixture is empty under --teardown (never created).
+        coordinator = next(iter(keeper.container_configs.values()))
         clickhouse_version = request.config.getoption("--clickhouse-version")
 
         container = ClickHouseContainer(
@@ -381,9 +381,10 @@ def create_clickhouse_cluster(  # pylint: disable=too-many-arguments,too-many-po
     migration goes through. Per-node containers are exposed via `nodes` so
     tests can assert shard-local state.
     """
-    coordinator = next(iter(keeper.container_configs.values()))
 
     def create() -> types.TestContainerClickhouse:
+        # Lazy: the keeper fixture is empty under --teardown (never created).
+        coordinator = next(iter(keeper.container_configs.values()))
         clickhouse_version = request.config.getoption("--clickhouse-version")
 
         # Unique aliases per creation: docker allows duplicate network aliases

--- a/tests/fixtures/network.py
+++ b/tests/fixtures/network.py
@@ -1,3 +1,5 @@
+import time
+
 import docker
 import docker.errors
 import pytest
@@ -23,12 +25,37 @@ def network(request: pytest.FixtureRequest, pytestconfig: pytest.Config) -> type
     def delete(nw: types.Network):
         client = docker.from_env()
         try:
-            client.networks.get(network_id=nw.id).remove()
+            network = client.networks.get(network_id=nw.id)
         except docker.errors.NotFound:
             logger.info(
                 "Skipping removal of Network, Network(%s) not found. Maybe it was manually removed?",
                 {"name": nw.name, "id": nw.id},
             )
+            return
+
+        # Docker detaches endpoints asynchronously, so the network can briefly
+        # report "has active endpoints" after its containers are gone. Retry,
+        # force-disconnecting any stragglers.
+        last_err: docker.errors.APIError | None = None
+        for _ in range(10):
+            try:
+                network.remove()
+                return
+            except docker.errors.NotFound:
+                return
+            except docker.errors.APIError as err:
+                if "has active endpoints" not in str(err):
+                    raise
+                last_err = err
+                network.reload()
+                for container_id in network.attrs.get("Containers") or {}:
+                    try:
+                        network.disconnect(container_id, force=True)
+                    except docker.errors.APIError:
+                        pass
+                time.sleep(1)
+
+        raise last_err
 
     def restore(existing: dict) -> types.Network:
         client = docker.from_env()


### PR DESCRIPTION
## What & why

The e2e `teardown-stack` step (`pytest --teardown`) fails even when all tests pass, reddening the job. Two harness bugs in the teardown path:

1. **`network.remove()` → `403 … has active endpoints`** — Docker detaches container endpoints asynchronously, so the network briefly looks in-use after its containers are gone. Fixed in `fixtures/network.py`: retry with a force-disconnect of stragglers.
2. **`StopIteration`** — Surfaced once above was fixed. `create_clickhouse` / `create_clickhouse_cluster` resolved the keeper coordinator eagerly, before `create()`; under `--teardown` the keeper is empty. Fixed in `fixtures/clickhouse.py`: resolve it lazily inside `create()`.

## Verification

Local bring-up + `--teardown` on the same commit: teardown removes every container and the network, exits `0` — no `StopIteration`, no `403`.

Harness-only; no test or product code changes.
