### PR TITLE
fix: fetch latest monotonicty for metrics instead of any random

### DIFF
--- a/pkg/modules/metricsexplorer/implmetricsexplorer/module.go
+++ b/pkg/modules/metricsexplorer/implmetricsexplorer/module.go
@@ -87,7 +87,7 @@ func (m *module) listMeterMetrics(ctx context.Context, params *metricsexplorerty
 		"any(type) AS metric_type",
 		"any(unit) AS metric_unit",
 		"argMax(temporality, unix_milli) AS temporality",
-		"any(is_monotonic) AS is_monotonic",
+		"argMax(is_monotonic, unix_milli) AS is_monotonic",
 	)
 	sb.From(fmt.Sprintf("%s.%s", telemetrymeter.DBName, telemetrymeter.SamplesTableName))
 
@@ -775,7 +775,7 @@ func (m *module) fetchTimeseriesMetadata(ctx context.Context, orgID valuer.UUID,
 		"anyLast(type) AS metric_type",
 		"argMax(unit, unix_milli) AS metric_unit",
 		"anyLast(temporality) AS temporality",
-		"anyLast(is_monotonic) AS is_monotonic",
+		"argMax(is_monotonic, unix_milli) AS is_monotonic",
 	)
 	sb.From(fmt.Sprintf("%s.%s", telemetrymetrics.DBName, telemetrymetrics.TimeseriesV4TableName))
 	sb.Where(sb.In("metric_name", args...))

--- a/pkg/telemetrymetadata/metadata.go
+++ b/pkg/telemetrymetadata/metadata.go
@@ -2323,7 +2323,7 @@ func (t *telemetryMetaStore) fetchTemporalityTypeForTable(ctx context.Context, t
 	types := make(map[string]metrictypes.Type)
 
 	sb := sqlbuilder.NewSelectBuilder()
-	sb.Select("metric_name", "temporality", "any(type) AS type", "any(is_monotonic) as is_monotonic")
+	sb.Select("metric_name", "temporality", "any(type) AS type", "argMax(is_monotonic, unix_milli) as is_monotonic")
 	sb.From(t.metricsDBName + "." + tableName)
 	conds := []string{
 		sb.In("metric_name", metricNames),
@@ -2379,7 +2379,7 @@ func (t *telemetryMetaStore) fetchMeterSourceMetricsTemporalityAndType(ctx conte
 		"metric_name",
 		"argMax(temporality, unix_milli) as temporality",
 		"any(type) AS type",
-		"any(is_monotonic) as is_monotonic",
+		"argMax(is_monotonic, unix_milli) as is_monotonic",
 	).From(t.meterDBName + "." + t.meterFieldsTblName)
 
 	// Filter by metric names (in the temporality column due to data mix-up)

--- a/tests/integration/tests/queriermetrics/11_metric_metadata.py
+++ b/tests/integration/tests/queriermetrics/11_metric_metadata.py
@@ -1,0 +1,99 @@
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+import requests
+
+from fixtures import types
+from fixtures.auth import USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD
+from fixtures.metrics import Metrics
+
+
+def test_metric_metadata_returns_latest_monotonic_true(
+    signoz: types.SigNoz,
+    create_user_admin: None,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+    insert_metrics: Callable[[list[Metrics]], None],
+) -> None:
+    now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
+    metric_name = "test.metric.metadata.latest_true"
+
+    metrics: list[Metrics] = [
+        Metrics(
+            metric_name=metric_name,
+            labels={"series": "older"},
+            timestamp=now - timedelta(minutes=20),
+            value=1.0,
+            temporality="Cumulative",
+            type_="Sum",
+            is_monotonic=False,
+        ),
+        Metrics(
+            metric_name=metric_name,
+            labels={"series": "newer"},
+            timestamp=now - timedelta(minutes=2),
+            value=2.0,
+            temporality="Cumulative",
+            type_="Sum",
+            is_monotonic=True,
+        ),
+    ]
+    insert_metrics(metrics)
+
+    token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+
+    response = requests.get(
+        signoz.self.host_configs["8080"].get("/api/v2/metrics/metadata"),
+        params={"metricName": metric_name},
+        headers={"authorization": f"Bearer {token}"},
+        timeout=30,
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()["status"] == "success"
+    assert response.json()["data"]["isMonotonic"] is True
+
+
+def test_metric_metadata_returns_latest_monotonic_false(
+    signoz: types.SigNoz,
+    create_user_admin: None,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+    insert_metrics: Callable[[list[Metrics]], None],
+) -> None:
+    now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
+    metric_name = "test.metric.metadata.latest_false"
+
+    metrics: list[Metrics] = [
+        Metrics(
+            metric_name=metric_name,
+            labels={"series": "older"},
+            timestamp=now - timedelta(minutes=20),
+            value=1.0,
+            temporality="Cumulative",
+            type_="Sum",
+            is_monotonic=True,
+        ),
+        Metrics(
+            metric_name=metric_name,
+            labels={"series": "newer"},
+            timestamp=now - timedelta(minutes=2),
+            value=2.0,
+            temporality="Cumulative",
+            type_="Sum",
+            is_monotonic=False,
+        ),
+    ]
+    insert_metrics(metrics)
+
+    token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+
+    response = requests.get(
+        signoz.self.host_configs["8080"].get("/api/v2/metrics/metadata"),
+        params={"metricName": metric_name},
+        headers={"authorization": f"Bearer {token}"},
+        timeout=30,
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()["status"] == "success"
+    assert response.json()["data"]["isMonotonic"] is False


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Latest monotonicity of any metric is a better look at this field that picking any random one. Changes to this field are rare, and if a change is there, we should pick up the latest value to make such changes visible.

Currently, GCP metrics are not setting this field as true where they should, and we'll be putting up an issue upstream to fix same. SigNoz needs to be ready to accept the changed value of the flag once the fix is there upstream.

#### Issues closed by this PR

Closes https://github.com/SigNoz/pulse-pod/issues/115

---
