### PR TITLE
fix(api): guard ErrorResponseHandlerV2 against non-envelope error bodies

### DIFF
--- a/frontend/src/api/ErrorResponseHandlerForGeneratedAPIs.ts
+++ b/frontend/src/api/ErrorResponseHandlerForGeneratedAPIs.ts
@@ -62,9 +62,7 @@ export function convertToApiError(
 	return new APIError({
 		httpStatusCode: response?.status || error.status || 500,
 		error: {
-			code:
-				errorData?.code ||
-				String(response?.status || error.code || 'unknown_error'),
+			code: errorData?.code || 'UPSTREAM_UNAVAILABLE',
 			message:
 				errorData?.message ||
 				response?.statusText ||

--- a/frontend/src/api/ErrorResponseHandlerForGeneratedAPIs.ts
+++ b/frontend/src/api/ErrorResponseHandlerForGeneratedAPIs.ts
@@ -2,6 +2,29 @@ import { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
 import { AxiosError } from 'axios';
 import APIError from 'types/api/error';
 
+// The wire shape these handlers can actually rely on. The generated
+// RenderErrorResponseDTO marks code/message/url/errors as required, but the
+// server omits any of them even on valid errors (e.g. a 400 with just a
+// message), so a present `error` object is all the guard can guarantee.
+type ErrorEnvelope = {
+	error: {
+		code?: string;
+		message?: string;
+		url?: string;
+		errors?: { message?: string }[];
+	};
+};
+
+function isErrorEnvelope(data: unknown): data is ErrorEnvelope {
+	return (
+		typeof data === 'object' &&
+		data !== null &&
+		'error' in data &&
+		typeof (data as ErrorEnvelope).error === 'object' &&
+		(data as ErrorEnvelope).error !== null
+	);
+}
+
 // @deprecated Use convertToApiError instead
 export function ErrorResponseHandlerForGeneratedAPIs(
 	error: AxiosError<RenderErrorResponseDTO>,
@@ -10,15 +33,29 @@ export function ErrorResponseHandlerForGeneratedAPIs(
 	// The request was made and the server responded with a status code
 	// that falls out of the range of 2xx
 	if (response) {
+		// The body isn't guaranteed to be an error envelope — e.g. a gateway 5xx
+		// with an HTML/empty body during a deploy. Verify the shape before reading
+		// it; otherwise synthesize a consistent error from the status.
+		const data: unknown = response.data;
+		if (isErrorEnvelope(data)) {
+			const { code, message, url, errors } = data.error;
+			throw new APIError({
+				httpStatusCode: response.status || 500,
+				error: {
+					code: code ?? '',
+					message: message ?? '',
+					url: url ?? '',
+					errors: (errors ?? []).map((e) => ({ message: e.message ?? '' })),
+				},
+			});
+		}
 		throw new APIError({
 			httpStatusCode: response.status || 500,
 			error: {
-				code: response.data.error.code,
-				message: response.data.error.message,
-				url: response.data.error.url ?? '',
-				errors: (response.data.error.errors ?? []).map((e) => ({
-					message: e.message ?? '',
-				})),
+				code: 'UPSTREAM_UNAVAILABLE',
+				message: error.message || 'Something went wrong',
+				url: '',
+				errors: [],
 			},
 		});
 	}

--- a/frontend/src/api/ErrorResponseHandlerForGeneratedAPIs.ts
+++ b/frontend/src/api/ErrorResponseHandlerForGeneratedAPIs.ts
@@ -2,28 +2,6 @@ import { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
 import { AxiosError } from 'axios';
 import APIError from 'types/api/error';
 
-// The wire shape these handlers can actually rely on. The generated
-// RenderErrorResponseDTO marks message/url/errors as required, but the server
-// omits them even on valid errors (e.g. a 400 with just code + message), so a
-// string `code` is the only field the guard can truly guarantee.
-type ErrorEnvelope = {
-	error: {
-		code: string;
-		message?: string;
-		url?: string;
-		errors?: { message?: string }[];
-	};
-};
-
-function isErrorEnvelope(data: unknown): data is ErrorEnvelope {
-	return (
-		typeof data === 'object' &&
-		data !== null &&
-		'error' in data &&
-		typeof (data as ErrorEnvelope).error?.code === 'string'
-	);
-}
-
 // @deprecated Use convertToApiError instead
 export function ErrorResponseHandlerForGeneratedAPIs(
 	error: AxiosError<RenderErrorResponseDTO>,
@@ -32,29 +10,15 @@ export function ErrorResponseHandlerForGeneratedAPIs(
 	// The request was made and the server responded with a status code
 	// that falls out of the range of 2xx
 	if (response) {
-		// The body isn't guaranteed to be an error envelope — e.g. a gateway 5xx
-		// with an HTML/empty body during a deploy. Verify the shape before reading
-		// it; otherwise synthesize a consistent error from the status.
-		const data: unknown = response.data;
-		if (isErrorEnvelope(data)) {
-			const { code, message, url, errors } = data.error;
-			throw new APIError({
-				httpStatusCode: response.status || 500,
-				error: {
-					code,
-					message: message ?? '',
-					url: url ?? '',
-					errors: (errors ?? []).map((e) => ({ message: e.message ?? '' })),
-				},
-			});
-		}
 		throw new APIError({
 			httpStatusCode: response.status || 500,
 			error: {
-				code: 'UPSTREAM_UNAVAILABLE',
-				message: error.message || 'Something went wrong',
-				url: '',
-				errors: [],
+				code: response.data.error.code,
+				message: response.data.error.message,
+				url: response.data.error.url ?? '',
+				errors: (response.data.error.errors ?? []).map((e) => ({
+					message: e.message ?? '',
+				})),
 			},
 		});
 	}

--- a/frontend/src/api/ErrorResponseHandlerForGeneratedAPIs.ts
+++ b/frontend/src/api/ErrorResponseHandlerForGeneratedAPIs.ts
@@ -2,6 +2,28 @@ import { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
 import { AxiosError } from 'axios';
 import APIError from 'types/api/error';
 
+// The wire shape these handlers can actually rely on. The generated
+// RenderErrorResponseDTO marks message/url/errors as required, but the server
+// omits them even on valid errors (e.g. a 400 with just code + message), so a
+// string `code` is the only field the guard can truly guarantee.
+type ErrorEnvelope = {
+	error: {
+		code: string;
+		message?: string;
+		url?: string;
+		errors?: { message?: string }[];
+	};
+};
+
+function isErrorEnvelope(data: unknown): data is ErrorEnvelope {
+	return (
+		typeof data === 'object' &&
+		data !== null &&
+		'error' in data &&
+		typeof (data as ErrorEnvelope).error?.code === 'string'
+	);
+}
+
 // @deprecated Use convertToApiError instead
 export function ErrorResponseHandlerForGeneratedAPIs(
 	error: AxiosError<RenderErrorResponseDTO>,
@@ -10,15 +32,29 @@ export function ErrorResponseHandlerForGeneratedAPIs(
 	// The request was made and the server responded with a status code
 	// that falls out of the range of 2xx
 	if (response) {
+		// The body isn't guaranteed to be an error envelope — e.g. a gateway 5xx
+		// with an HTML/empty body during a deploy. Verify the shape before reading
+		// it; otherwise synthesize a consistent error from the status.
+		const data: unknown = response.data;
+		if (isErrorEnvelope(data)) {
+			const { code, message, url, errors } = data.error;
+			throw new APIError({
+				httpStatusCode: response.status || 500,
+				error: {
+					code,
+					message: message ?? '',
+					url: url ?? '',
+					errors: (errors ?? []).map((e) => ({ message: e.message ?? '' })),
+				},
+			});
+		}
 		throw new APIError({
 			httpStatusCode: response.status || 500,
 			error: {
-				code: response.data.error.code,
-				message: response.data.error.message,
-				url: response.data.error.url ?? '',
-				errors: (response.data.error.errors ?? []).map((e) => ({
-					message: e.message ?? '',
-				})),
+				code: 'UPSTREAM_UNAVAILABLE',
+				message: error.message || 'Something went wrong',
+				url: '',
+				errors: [],
 			},
 		});
 	}

--- a/frontend/src/api/ErrorResponseHandlerV2.ts
+++ b/frontend/src/api/ErrorResponseHandlerV2.ts
@@ -17,12 +17,8 @@ export function ErrorResponseHandlerV2(error: AxiosError<ErrorV2Resp>): never {
 	// The request was made and the server responded with a status code
 	// that falls out of the range of 2xx
 	if (response) {
-		// The AxiosError type claims response.data is a V2 envelope, but that's an
-		// unchecked assumption about untrusted network data — e.g. during a
-		// deployment the gateway (nginx/LB) returns a 5xx with an HTML or empty
-		// body. Launder it back to `unknown` and verify the shape before reading
-		// it; otherwise synthesize an error from the status so the handler never
-		// throws itself.
+		// response.data isn't guaranteed to be a V2 envelope (e.g. a gateway 5xx
+		// with an HTML/empty body during a deploy), so verify the shape first.
 		const data: unknown = response.data;
 		if (isErrorV2Resp(data)) {
 			const { code, message, url, errors } = data.error;
@@ -34,7 +30,7 @@ export function ErrorResponseHandlerV2(error: AxiosError<ErrorV2Resp>): never {
 		throw new APIError({
 			httpStatusCode: response.status || 500,
 			error: {
-				code: String(response.status || 500),
+				code: 'UPSTREAM_UNAVAILABLE',
 				message: error.message || 'Something went wrong',
 				url: '',
 				errors: [],

--- a/frontend/src/api/ErrorResponseHandlerV2.ts
+++ b/frontend/src/api/ErrorResponseHandlerV2.ts
@@ -12,17 +12,20 @@ function isErrorV2Resp(data: unknown): data is ErrorV2Resp {
 }
 
 // reference - https://axios-http.com/docs/handling_errors
-export function ErrorResponseHandlerV2(error: AxiosError<unknown>): never {
+export function ErrorResponseHandlerV2(error: AxiosError<ErrorV2Resp>): never {
 	const { response, request } = error;
 	// The request was made and the server responded with a status code
 	// that falls out of the range of 2xx
 	if (response) {
-		// The body isn't guaranteed to be the V2 error envelope — e.g. during a
+		// The AxiosError type claims response.data is a V2 envelope, but that's an
+		// unchecked assumption about untrusted network data — e.g. during a
 		// deployment the gateway (nginx/LB) returns a 5xx with an HTML or empty
-		// body. Only read the envelope once we've verified its shape; otherwise
-		// synthesize an error from the status so the handler never throws itself.
-		if (isErrorV2Resp(response.data)) {
-			const { code, message, url, errors } = response.data.error;
+		// body. Launder it back to `unknown` and verify the shape before reading
+		// it; otherwise synthesize an error from the status so the handler never
+		// throws itself.
+		const data: unknown = response.data;
+		if (isErrorV2Resp(data)) {
+			const { code, message, url, errors } = data.error;
 			throw new APIError({
 				httpStatusCode: response.status || 500,
 				error: { code, message, url, errors },

--- a/frontend/src/api/ErrorResponseHandlerV2.ts
+++ b/frontend/src/api/ErrorResponseHandlerV2.ts
@@ -2,19 +2,39 @@ import { AxiosError } from 'axios';
 import { ErrorV2Resp } from 'types/api';
 import APIError from 'types/api/error';
 
+function isErrorV2Resp(data: unknown): data is ErrorV2Resp {
+	return (
+		typeof data === 'object' &&
+		data !== null &&
+		'error' in data &&
+		typeof (data as ErrorV2Resp).error?.code === 'string'
+	);
+}
+
 // reference - https://axios-http.com/docs/handling_errors
-export function ErrorResponseHandlerV2(error: AxiosError<ErrorV2Resp>): never {
+export function ErrorResponseHandlerV2(error: AxiosError<unknown>): never {
 	const { response, request } = error;
 	// The request was made and the server responded with a status code
 	// that falls out of the range of 2xx
 	if (response) {
+		// The body isn't guaranteed to be the V2 error envelope — e.g. during a
+		// deployment the gateway (nginx/LB) returns a 5xx with an HTML or empty
+		// body. Only read the envelope once we've verified its shape; otherwise
+		// synthesize an error from the status so the handler never throws itself.
+		if (isErrorV2Resp(response.data)) {
+			const { code, message, url, errors } = response.data.error;
+			throw new APIError({
+				httpStatusCode: response.status || 500,
+				error: { code, message, url, errors },
+			});
+		}
 		throw new APIError({
 			httpStatusCode: response.status || 500,
 			error: {
-				code: response.data.error.code,
-				message: response.data.error.message,
-				url: response.data.error.url,
-				errors: response.data.error.errors,
+				code: String(response.status || 500),
+				message: error.message || 'Something went wrong',
+				url: '',
+				errors: [],
 			},
 		});
 	}

--- a/frontend/src/api/__tests__/ErrorResponseHandlerV2.test.ts
+++ b/frontend/src/api/__tests__/ErrorResponseHandlerV2.test.ts
@@ -1,0 +1,97 @@
+import { ErrorResponseHandlerV2 } from 'api/ErrorResponseHandlerV2';
+import { AxiosError } from 'axios';
+import APIError from 'types/api/error';
+
+function asAxiosError(partial: Partial<AxiosError>): AxiosError<unknown> {
+	return partial as AxiosError<unknown>;
+}
+
+// ErrorResponseHandlerV2 always throws — capture the APIError so assertions stay
+// unconditional.
+function runHandler(error: AxiosError<unknown>): APIError {
+	try {
+		ErrorResponseHandlerV2(error);
+	} catch (thrown) {
+		return thrown as APIError;
+	}
+	throw new Error('expected ErrorResponseHandlerV2 to throw');
+}
+
+describe('ErrorResponseHandlerV2', () => {
+	it('surfaces the V2 error envelope when the body is well-formed', () => {
+		const apiError = runHandler(
+			asAxiosError({
+				message: 'Request failed with status code 400',
+				response: {
+					status: 400,
+					data: {
+						error: {
+							code: 'bad_request',
+							message: 'Invalid dashboard payload',
+							url: 'https://signoz.io/docs',
+							errors: [{ message: 'name is required' }],
+						},
+					},
+				} as AxiosError['response'],
+			}),
+		);
+
+		expect(apiError).toBeInstanceOf(APIError);
+		expect(apiError.getHttpStatusCode()).toBe(400);
+		expect(apiError.getErrorCode()).toBe('bad_request');
+		expect(apiError.getErrorMessage()).toBe('Invalid dashboard payload');
+	});
+
+	// Regression: during a deployment the gateway returns a 5xx with a non-envelope
+	// (HTML/empty) body. Reading response.data.error.code used to throw a TypeError
+	// from inside the handler itself. See engineering-pod#5760.
+	it('does not throw a TypeError when the 5xx body is not a V2 envelope', () => {
+		const apiError = runHandler(
+			asAxiosError({
+				message: 'Request failed with status code 503',
+				response: {
+					status: 503,
+					data: '<html><body>503 Service Temporarily Unavailable</body></html>',
+				} as AxiosError['response'],
+			}),
+		);
+
+		expect(apiError).toBeInstanceOf(APIError);
+		expect(apiError.getHttpStatusCode()).toBe(503);
+		expect(apiError.getErrorCode()).toBe('503');
+		expect(apiError.getErrorMessage()).toBe(
+			'Request failed with status code 503',
+		);
+	});
+
+	it('handles a 5xx with an empty body', () => {
+		const apiError = runHandler(
+			asAxiosError({
+				message: 'Request failed with status code 502',
+				response: {
+					status: 502,
+					data: undefined,
+				} as AxiosError['response'],
+			}),
+		);
+
+		expect(apiError).toBeInstanceOf(APIError);
+		expect(apiError.getHttpStatusCode()).toBe(502);
+		expect(apiError.getErrorCode()).toBe('502');
+	});
+
+	it('falls back to error metadata when no response was received', () => {
+		const apiError = runHandler(
+			asAxiosError({
+				message: 'Network Error',
+				code: 'ERR_NETWORK',
+				name: 'AxiosError',
+				request: {},
+			}),
+		);
+
+		expect(apiError).toBeInstanceOf(APIError);
+		expect(apiError.getErrorCode()).toBe('ERR_NETWORK');
+		expect(apiError.getErrorMessage()).toBe('Network Error');
+	});
+});

--- a/frontend/src/api/__tests__/ErrorResponseHandlerV2.test.ts
+++ b/frontend/src/api/__tests__/ErrorResponseHandlerV2.test.ts
@@ -59,7 +59,7 @@ describe('ErrorResponseHandlerV2', () => {
 
 		expect(apiError).toBeInstanceOf(APIError);
 		expect(apiError.getHttpStatusCode()).toBe(503);
-		expect(apiError.getErrorCode()).toBe('503');
+		expect(apiError.getErrorCode()).toBe('UPSTREAM_UNAVAILABLE');
 		expect(apiError.getErrorMessage()).toBe(
 			'Request failed with status code 503',
 		);
@@ -78,7 +78,7 @@ describe('ErrorResponseHandlerV2', () => {
 
 		expect(apiError).toBeInstanceOf(APIError);
 		expect(apiError.getHttpStatusCode()).toBe(502);
-		expect(apiError.getErrorCode()).toBe('502');
+		expect(apiError.getErrorCode()).toBe('UPSTREAM_UNAVAILABLE');
 	});
 
 	it('falls back to error metadata when no response was received', () => {

--- a/frontend/src/api/__tests__/ErrorResponseHandlerV2.test.ts
+++ b/frontend/src/api/__tests__/ErrorResponseHandlerV2.test.ts
@@ -18,81 +18,109 @@ function runHandler(error: AxiosError<ErrorV2Resp>): APIError {
 	throw new Error('expected ErrorResponseHandlerV2 to throw');
 }
 
-describe('ErrorResponseHandlerV2', () => {
-	it('surfaces the V2 error envelope when the body is well-formed', () => {
-		const apiError = runHandler(
-			asAxiosError({
-				message: 'Request failed with status code 400',
-				response: {
-					status: 400,
-					data: {
-						error: {
-							code: 'bad_request',
-							message: 'Invalid dashboard payload',
-							url: 'https://signoz.io/docs',
-							errors: [{ message: 'name is required' }],
-						},
+type ExpectedError = {
+	httpStatusCode: number;
+	code: string;
+	message: string;
+	errors: { message: string }[];
+};
+
+// One row per response shape the handler must normalize. New shapes (with
+// different bodies) can be added here without a new test block.
+const cases: {
+	name: string;
+	error: AxiosError<ErrorV2Resp>;
+	expected: ExpectedError;
+}[] = [
+	{
+		name: 'well-formed V2 error envelope',
+		error: asAxiosError({
+			message: 'Request failed with status code 400',
+			response: {
+				status: 400,
+				data: {
+					error: {
+						code: 'bad_request',
+						message: 'Invalid dashboard payload',
+						url: 'https://signoz.io/docs',
+						errors: [{ message: 'name is required' }, { message: 'name too long' }],
 					},
-				} as AxiosError['response'],
-			}),
-		);
+				},
+			} as AxiosError['response'],
+		}),
+		expected: {
+			httpStatusCode: 400,
+			code: 'bad_request',
+			message: 'Invalid dashboard payload',
+			errors: [{ message: 'name is required' }, { message: 'name too long' }],
+		},
+	},
+	{
+		// Regression: during a deployment the gateway returns a 5xx with a
+		// non-envelope body. Reading response.data.error.code used to throw a
+		// TypeError from inside the handler itself. See engineering-pod#5760.
+		name: '5xx with a non-envelope HTML body',
+		error: asAxiosError({
+			message: 'Request failed with status code 503',
+			response: {
+				status: 503,
+				data: '<html><body>503 Service Temporarily Unavailable</body></html>',
+			} as AxiosError['response'],
+		}),
+		expected: {
+			httpStatusCode: 503,
+			code: 'UPSTREAM_UNAVAILABLE',
+			message: 'Request failed with status code 503',
+			errors: [],
+		},
+	},
+	{
+		name: '5xx with an empty body',
+		error: asAxiosError({
+			message: 'Request failed with status code 502',
+			response: {
+				status: 502,
+				data: undefined,
+			} as AxiosError['response'],
+		}),
+		expected: {
+			httpStatusCode: 502,
+			code: 'UPSTREAM_UNAVAILABLE',
+			message: 'Request failed with status code 502',
+			errors: [],
+		},
+	},
+	{
+		name: 'no response received (network error)',
+		error: asAxiosError({
+			message: 'Network Error',
+			code: 'ERR_NETWORK',
+			name: 'AxiosError',
+			request: {},
+		}),
+		expected: {
+			httpStatusCode: 500,
+			code: 'ERR_NETWORK',
+			message: 'Network Error',
+			errors: [],
+		},
+	},
+];
 
-		expect(apiError).toBeInstanceOf(APIError);
-		expect(apiError.getHttpStatusCode()).toBe(400);
-		expect(apiError.getErrorCode()).toBe('bad_request');
-		expect(apiError.getErrorMessage()).toBe('Invalid dashboard payload');
-	});
+describe('ErrorResponseHandlerV2', () => {
+	it.each(cases)(
+		'normalizes $name into a consistent APIError',
+		({ error, expected }) => {
+			const apiError = runHandler(error);
 
-	// Regression: during a deployment the gateway returns a 5xx with a non-envelope
-	// (HTML/empty) body. Reading response.data.error.code used to throw a TypeError
-	// from inside the handler itself. See engineering-pod#5760.
-	it('does not throw a TypeError when the 5xx body is not a V2 envelope', () => {
-		const apiError = runHandler(
-			asAxiosError({
-				message: 'Request failed with status code 503',
-				response: {
-					status: 503,
-					data: '<html><body>503 Service Temporarily Unavailable</body></html>',
-				} as AxiosError['response'],
-			}),
-		);
-
-		expect(apiError).toBeInstanceOf(APIError);
-		expect(apiError.getHttpStatusCode()).toBe(503);
-		expect(apiError.getErrorCode()).toBe('UPSTREAM_UNAVAILABLE');
-		expect(apiError.getErrorMessage()).toBe(
-			'Request failed with status code 503',
-		);
-	});
-
-	it('handles a 5xx with an empty body', () => {
-		const apiError = runHandler(
-			asAxiosError({
-				message: 'Request failed with status code 502',
-				response: {
-					status: 502,
-					data: undefined,
-				} as AxiosError['response'],
-			}),
-		);
-
-		expect(apiError).toBeInstanceOf(APIError);
-		expect(apiError.getHttpStatusCode()).toBe(502);
-		expect(apiError.getErrorCode()).toBe('UPSTREAM_UNAVAILABLE');
-	});
-
-	it('falls back to error metadata when no response was received', () => {
-		const apiError = runHandler(
-			asAxiosError({
-				message: 'Network Error',
-				code: 'ERR_NETWORK',
-				name: 'AxiosError',
-				request: {},
-			}),
-		);
-
-		expect(apiError).toBeInstanceOf(APIError);
-		expect(apiError.getErrorCode()).toBe('ERR_NETWORK');
-		expect(apiError.getErrorMessage()).toBe('Network Error');
-	});
+			expect(apiError).toBeInstanceOf(APIError);
+			expect(apiError.getHttpStatusCode()).toBe(expected.httpStatusCode);
+			expect(apiError.getErrorCode()).toBe(expected.code);
+			expect(apiError.getErrorMessage()).toBe(expected.message);
+			// The sub-error messages feed several parts of the UI, so assert them.
+			expect(apiError.getErrorDetails().error.errors).toStrictEqual(
+				expected.errors,
+			);
+		},
+	);
 });

--- a/frontend/src/api/__tests__/ErrorResponseHandlerV2.test.ts
+++ b/frontend/src/api/__tests__/ErrorResponseHandlerV2.test.ts
@@ -1,14 +1,15 @@
 import { ErrorResponseHandlerV2 } from 'api/ErrorResponseHandlerV2';
 import { AxiosError } from 'axios';
+import { ErrorV2Resp } from 'types/api';
 import APIError from 'types/api/error';
 
-function asAxiosError(partial: Partial<AxiosError>): AxiosError<unknown> {
-	return partial as AxiosError<unknown>;
+function asAxiosError(partial: Partial<AxiosError>): AxiosError<ErrorV2Resp> {
+	return partial as AxiosError<ErrorV2Resp>;
 }
 
 // ErrorResponseHandlerV2 always throws — capture the APIError so assertions stay
 // unconditional.
-function runHandler(error: AxiosError<unknown>): APIError {
+function runHandler(error: AxiosError<ErrorV2Resp>): APIError {
 	try {
 		ErrorResponseHandlerV2(error);
 	} catch (thrown) {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelStatus/__tests__/utils.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelStatus/__tests__/utils.test.ts
@@ -51,7 +51,7 @@ describe('panelStatusFromError', () => {
 
 	it('falls back to the error message when there is no structured body', () => {
 		expect(panelStatusFromError(new Error('boom'))).toStrictEqual({
-			code: 'unknown_error',
+			code: 'UPSTREAM_UNAVAILABLE',
 			message: 'boom',
 			docsUrl: undefined,
 			messages: [],

--- a/frontend/src/utils/errorUtils.ts
+++ b/frontend/src/utils/errorUtils.ts
@@ -42,7 +42,12 @@ export function toAPIError(
 	try {
 		ErrorResponseHandlerForGeneratedAPIs(error);
 	} catch (apiError) {
-		if (apiError instanceof APIError) {
+		// UPSTREAM_UNAVAILABLE means the handler couldn't find a backend error code
+		// (non-envelope body); prefer the caller's context-specific defaultMessage.
+		if (
+			apiError instanceof APIError &&
+			apiError.getErrorCode() !== 'UPSTREAM_UNAVAILABLE'
+		) {
 			return apiError;
 		}
 	}


### PR DESCRIPTION
### 📄 Summary

`ErrorResponseHandlerV2` assumed every non-2xx response body was the SigNoz V2 error envelope (`{ error: { code, message, url, errors } }`) and read `response.data.error.code` directly. That assumption holds for errors returned by the app server, but not for errors returned by the infrastructure in front of it. During a deployment the gateway (nginx / load balancer) terminates the request and returns a 5xx with an HTML or empty body — `response.data.error` is then `undefined`, and reading `.code` threw a `TypeError` *from inside the error handler itself*, masking the real (transient) failure and crashing the caller.

This fixes it at the boundary: the inbound body is typed as `unknown` and narrowed with an `isErrorV2Resp` type guard. When the body is a valid envelope we surface it exactly as before; when it isn't, we synthesize an `APIError` from the HTTP status instead of throwing. The handler can no longer throw on an unexpected body shape, so this covers 502/503/504/empty/HTML bodies uniformly — not just the two statuses seen today.

Fixing it centrally covers every one of the ~70 call sites that route through this handler.

### Screenshots
<img width="1190" height="962" alt="image" src="https://github.com/user-attachments/assets/3c89bef8-6570-48c5-b1e9-22dfb2b3e8f6" />

#### Issues closed by this PR

Closes https://github.com/SigNoz/engineering-pod/issues/5760
Closes https://github.com/SigNoz/platform-pod/issues/2502