### PR TITLE
refactor(infrastructure-monitoring-v2): remove map between dot and underscore attributes

### DIFF
--- a/frontend/src/container/InfraMonitoringHostsV2/Hosts.tsx
+++ b/frontend/src/container/InfraMonitoringHostsV2/Hosts.tsx
@@ -15,7 +15,6 @@ import APIError from 'types/api/error';
 import QuickFilters from 'components/QuickFilters/QuickFilters';
 import { QuickFiltersSource } from 'components/QuickFilters/types';
 import { InfraMonitoringEvents } from 'constants/events';
-import { FeatureKeys } from 'constants/features';
 import { initialQueriesMap } from 'constants/queryBuilder';
 import K8sBaseDetails, {
 	K8sDetailsFilters,
@@ -29,7 +28,6 @@ import {
 } from 'container/InfraMonitoringK8sV2/constants';
 import { useGetCompositeQueryParam } from 'hooks/queryBuilder/useGetCompositeQueryParam';
 import { useQueryBuilder } from 'hooks/queryBuilder/useQueryBuilder';
-import { useAppContext } from 'providers/App/App';
 import { DataSource } from 'types/common/queryBuilder';
 
 import {
@@ -92,11 +90,6 @@ function Hosts(): JSX.Element {
 			});
 		}
 	}, [compositeQuery, redirectWithQueryBuilderData]);
-
-	const { featureFlags } = useAppContext();
-	const dotMetricsEnabled =
-		featureFlags?.find((flag) => flag.name === FeatureKeys.DOT_METRICS_ENABLED)
-			?.active || false;
 
 	const handleFilterVisibilityChange = (): void => {
 		setShowFilters(!showFilters);
@@ -190,8 +183,8 @@ function Hosts(): JSX.Element {
 
 	const getInitialLogTracesExpression = useCallback(
 		(host: InframonitoringtypesHostRecordDTO) =>
-			hostInitialLogTracesExpression(host, dotMetricsEnabled),
-		[dotMetricsEnabled],
+			hostInitialLogTracesExpression(host),
+		[],
 	);
 	const controlListPrefix = !showFilters ? (
 		<div className={styles.quickFiltersToggleContainer}>
@@ -226,7 +219,7 @@ function Hosts(): JSX.Element {
 									</div>
 									<QuickFilters
 										source={QuickFiltersSource.INFRA_MONITORING}
-										config={getHostsQuickFiltersConfig(dotMetricsEnabled)}
+										config={getHostsQuickFiltersConfig()}
 										handleFilterVisibilityChange={handleFilterVisibilityChange}
 										useFieldApis={{
 											metricNamespace:

--- a/frontend/src/container/InfraMonitoringHostsV2/constants.tsx
+++ b/frontend/src/container/InfraMonitoringHostsV2/constants.tsx
@@ -8,8 +8,8 @@ import {
 	InframonitoringtypesHostStatusDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { K8sDetailsMetadataConfig } from 'container/InfraMonitoringK8sV2/Base/K8sBaseDetails';
-import { formatValueForExpression } from 'components/QueryBuilderV2/utils';
 import { INFRA_MONITORING_ATTR_KEYS } from 'container/InfraMonitoringK8sV2/constants';
+import { formatValueForExpression } from 'components/QueryBuilderV2/utils';
 import { SelectedItemParams } from 'container/InfraMonitoringK8sV2/hooks';
 import {
 	getHostQueryPayload,
@@ -63,7 +63,7 @@ export const hostDetailsMetadataConfig: HostDetailMetadataConfigType[] = [
 	},
 	{
 		label: 'OPERATING SYSTEM',
-		getValue: (h): string => h.meta?.['os.type'] || '-',
+		getValue: (h): string => h.meta?.[INFRA_MONITORING_ATTR_KEYS.OS_TYPE] || '-',
 		render: (value): React.ReactNode =>
 			value !== '-' ? (
 				<Badge variant="outline" className={infraHostsStyles.infraMonitoringTags}>
@@ -101,9 +101,8 @@ export function getHostMetricsQueryPayload(
 	host: InframonitoringtypesHostRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ): ReturnType<typeof getHostQueryPayload> {
-	return getHostQueryPayload(host.hostName, start, end, dotMetricsEnabled);
+	return getHostQueryPayload(host.hostName, start, end, true);
 }
 
 export { hostWidgetInfo };
@@ -111,17 +110,13 @@ export { hostWidgetInfo };
 export const hostGetSelectedItemExpression = (
 	params: SelectedItemParams,
 ): string =>
-	`host.name = ${formatValueForExpression(params.selectedItem ?? '')}`;
+	`${INFRA_MONITORING_ATTR_KEYS.HOST_NAME} = ${formatValueForExpression(params.selectedItem ?? '')}`;
 
 export function hostInitialLogTracesExpression(
 	host: InframonitoringtypesHostRecordDTO,
-	dotMetricsEnabled: boolean,
 ): string {
-	const hostKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.HOST_NAME
-		: 'host_name';
 	const hostName = formatValueForExpression(host.hostName || '');
-	return `${hostKey} = ${hostName}`;
+	return `${INFRA_MONITORING_ATTR_KEYS.HOST_NAME} = ${hostName}`;
 }
 
 export function hostInitialEventsExpression(

--- a/frontend/src/container/InfraMonitoringHostsV2/utils.tsx
+++ b/frontend/src/container/InfraMonitoringHostsV2/utils.tsx
@@ -7,8 +7,8 @@ import {
 	IQuickFiltersConfig,
 } from 'components/QuickFilters/types';
 import { TriangleAlert } from '@signozhq/icons';
-import { INFRA_MONITORING_ATTR_KEYS } from 'container/InfraMonitoringK8sV2/constants';
 import { CellValueTooltip } from 'container/InfraMonitoringK8sV2/components';
+import { INFRA_MONITORING_ATTR_KEYS } from 'container/InfraMonitoringK8sV2/constants';
 import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { DataSource } from 'types/common/queryBuilder';
 const HOSTNAME_DOCS_URL =
@@ -62,32 +62,18 @@ export function HostnameCell({
 	);
 }
 
-export function getHostsQuickFiltersConfig(
-	dotMetricsEnabled: boolean,
-): IQuickFiltersConfig[] {
-	const hostNameKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.HOST_NAME
-		: 'host_name';
-	const osTypeKey = dotMetricsEnabled ? 'os.type' : 'os_type';
-	const metricName = dotMetricsEnabled
-		? 'system.cpu.load_average.15m'
-		: 'system_cpu_load_average_15m';
-
-	const environmentKey = dotMetricsEnabled
-		? 'deployment.environment'
-		: 'deployment_environment';
-
+export function getHostsQuickFiltersConfig(): IQuickFiltersConfig[] {
 	return [
 		{
 			type: FiltersType.CHECKBOX,
 			title: 'Host Name',
 			attributeKey: {
-				key: hostNameKey,
+				key: INFRA_MONITORING_ATTR_KEYS.HOST_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metricName,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.SYSTEM_CPU_LOAD_AVERAGE_15M,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -95,12 +81,12 @@ export function getHostsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'OS Type',
 			attributeKey: {
-				key: osTypeKey,
+				key: INFRA_MONITORING_ATTR_KEYS.OS_TYPE,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metricName,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.SYSTEM_CPU_LOAD_AVERAGE_15M,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -108,7 +94,7 @@ export function getHostsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Environment',
 			attributeKey: {
-				key: environmentKey,
+				key: INFRA_MONITORING_ATTR_KEYS.DEPLOYMENT_ENVIRONMENT,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/types.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/types.ts
@@ -70,7 +70,6 @@ export type GetEntityQueryPayload<T> = (
 	entity: T,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ) => GetQueryResultsProps[];
 
 export interface K8sDetailsTabsConfig {

--- a/frontend/src/container/InfraMonitoringK8sV2/Base/utils.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/Base/utils.tsx
@@ -9,33 +9,14 @@ import {
 import { SelectedItemParams } from 'container/InfraMonitoringK8sV2/hooks';
 import { INFRA_MONITORING_ATTR_KEYS } from 'container/InfraMonitoringK8sV2/constants';
 
-const dotToUnder: Record<string, string> = {
-	'os.type': 'os_type',
-	'host.name': 'host_name',
-	'deployment.environment': 'deployment_environment',
-	'k8s.node.name': 'k8s_node_name',
-	'k8s.cluster.name': 'k8s_cluster_name',
-	'k8s.node.uid': 'k8s_node_uid',
-	'k8s.cronjob.name': 'k8s_cronjob_name',
-	'k8s.daemonset.name': 'k8s_daemonset_name',
-	'k8s.deployment.name': 'k8s_deployment_name',
-	'k8s.job.name': 'k8s_job_name',
-	'k8s.namespace.name': 'k8s_namespace_name',
-	'k8s.pod.name': 'k8s_pod_name',
-	'k8s.pod.uid': 'k8s_pod_uid',
-	'k8s.statefulset.name': 'k8s_statefulset_name',
-	'k8s.persistentvolumeclaim.name': 'k8s_persistentvolumeclaim_name',
-};
-
 export function getGroupedByMeta<
 	T extends { meta?: Record<string, string> | null },
 >(itemData: T, groupBy: string[]): Record<string, string> {
 	const result: Record<string, string> = {};
 	const meta = itemData.meta ?? {};
 
-	groupBy.forEach((rawKey) => {
-		const metaKey = (dotToUnder[rawKey] ?? rawKey) as keyof typeof meta;
-		result[rawKey] = (meta[metaKey] || meta[rawKey]) ?? '';
+	groupBy.forEach((key) => {
+		result[key] = meta[key] ?? '';
 	});
 
 	return result;
@@ -47,9 +28,8 @@ export function getGroupByEl<
 	const groupByValues: string[] = [];
 	const meta = itemData.meta ?? {};
 
-	groupBy.forEach((rawKey) => {
-		const metaKey = (dotToUnder[rawKey] ?? rawKey) as keyof typeof meta;
-		const value = meta[metaKey] || meta[rawKey] || '<no-value>';
+	groupBy.forEach((key) => {
+		const value = meta[key] || '<no-value>';
 
 		groupByValues.push(value);
 	});

--- a/frontend/src/container/InfraMonitoringK8sV2/Clusters/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Clusters/constants.ts
@@ -24,7 +24,7 @@ import {
 export const k8sClusterGetSelectedItemExpression = (
 	params: SelectedItemParams,
 ): string =>
-	`k8s.cluster.name = ${formatValueForExpression(params.selectedItem ?? '')}`;
+	`${INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME} = ${formatValueForExpression(params.selectedItem ?? '')}`;
 
 export const k8sClusterDetailsMetadataConfig: K8sDetailsMetadataConfig<InframonitoringtypesClusterRecordDTO>[] =
 	[{ label: 'Cluster Name', getValue: (p): string => p.clusterName || '' }];
@@ -86,7 +86,7 @@ export const k8sClusterGetEntityName = (
 export const k8sClusterGetCountsFilterExpression = (
 	item: InframonitoringtypesClusterRecordDTO,
 ): string =>
-	`k8s.cluster.name = ${formatValueForExpression(item.clusterName ?? '')}`;
+	`${INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME} = ${formatValueForExpression(item.clusterName ?? '')}`;
 
 export const clusterWidgetInfo = [
 	{
@@ -138,96 +138,7 @@ export const getClusterMetricsQueryPayload = (
 	cluster: InframonitoringtypesClusterRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ): GetQueryResultsProps[] => {
-	const getKey = (dotKey: string, underscoreKey: string): string =>
-		dotMetricsEnabled ? dotKey : underscoreKey;
-	const k8sPodCpuUtilizationKey = getKey(
-		'k8s.pod.cpu.usage',
-		'k8s_pod_cpu_usage',
-	);
-	const k8sNodeAllocatableCpuKey = getKey(
-		'k8s.node.allocatable_cpu',
-		'k8s_node_allocatable_cpu',
-	);
-	const k8sPodMemoryUsageKey = getKey(
-		'k8s.pod.memory.usage',
-		'k8s_pod_memory_usage',
-	);
-	const k8sNodeAllocatableMemoryKey = getKey(
-		'k8s.node.allocatable_memory',
-		'k8s_node_allocatable_memory',
-	);
-	const k8sNodeConditionReadyKey = getKey(
-		'k8s.node.condition_ready',
-		'k8s_node_condition_ready',
-	);
-	const k8sDeploymentAvailableKey = getKey(
-		'k8s.deployment.available',
-		'k8s_deployment_available',
-	);
-	const k8sDeploymentDesiredKey = getKey(
-		'k8s.deployment.desired',
-		'k8s_deployment_desired',
-	);
-	const k8sStatefulsetCurrentPodsKey = getKey(
-		'k8s.statefulset.current_pods',
-		'k8s_statefulset_current_pods',
-	);
-	const k8sStatefulsetDesiredPodsKey = getKey(
-		'k8s.statefulset.desired_pods',
-		'k8s_statefulset_desired_pods',
-	);
-	const k8sStatefulsetReadyPodsKey = getKey(
-		'k8s.statefulset.ready_pods',
-		'k8s_statefulset_ready_pods',
-	);
-	const k8sStatefulsetUpdatedPodsKey = getKey(
-		'k8s.statefulset.updated_pods',
-		'k8s_statefulset_updated_pods',
-	);
-	const k8sDaemonsetCurrentScheduledNodesKey = getKey(
-		'k8s.daemonset.current_scheduled_nodes',
-		'k8s_daemonset_current_scheduled_nodes',
-	);
-	const k8sDaemonsetDesiredScheduledNodesKey = getKey(
-		'k8s.daemonset.desired_scheduled_nodes',
-		'k8s_daemonset_desired_scheduled_nodes',
-	);
-	const k8sDaemonsetReadyNodesKey = getKey(
-		'k8s.daemonset.ready_nodes',
-		'k8s_daemonset_ready_nodes',
-	);
-	const k8sJobActivePodsKey = getKey(
-		'k8s.job.active_pods',
-		'k8s_job_active_pods',
-	);
-	const k8sJobSuccessfulPodsKey = getKey(
-		'k8s.job.successful_pods',
-		'k8s_job_successful_pods',
-	);
-	const k8sJobFailedPodsKey = getKey(
-		'k8s.job.failed_pods',
-		'k8s_job_failed_pods',
-	);
-	const k8sJobDesiredSuccessfulPodsKey = getKey(
-		'k8s.job.desired_successful_pods',
-		'k8s_job_desired_successful_pods',
-	);
-	const k8sClusterNameKey = getKey('k8s.cluster.name', 'k8s_cluster_name');
-	const k8sNodeNameKey = getKey('k8s.node.name', 'k8s_node_name');
-	const k8sDeploymentNameKey = getKey(
-		'k8s.deployment.name',
-		'k8s_deployment_name',
-	);
-	const k8sNamespaceNameKey = getKey('k8s.namespace.name', 'k8s_namespace_name');
-	const k8sStatefulsetNameKey = getKey(
-		'k8s.statefulset.name',
-		'k8s_statefulset_name',
-	);
-	const k8sDaemonsetNameKey = getKey('k8s.daemonset.name', 'k8s_daemonset_name');
-	const k8sJobNameKey = getKey('k8s.job.name', 'k8s_job_name');
-
 	return [
 		{
 			selectedTime: 'GLOBAL_TIME',
@@ -239,7 +150,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_usage--float64--Gauge--true',
-								key: k8sPodCpuUtilizationKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -253,7 +164,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -278,7 +189,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_usage--float64--Gauge--true',
-								key: k8sPodCpuUtilizationKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'min',
@@ -292,7 +203,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -317,7 +228,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_usage--float64--Gauge--true',
-								key: k8sPodCpuUtilizationKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -331,7 +242,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -356,7 +267,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_allocatable_cpu--float64--Gauge--true',
-								key: k8sNodeAllocatableCpuKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_ALLOCATABLE_CPU,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -370,7 +281,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -429,7 +340,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_usage--float64--Gauge--true',
-								key: k8sPodMemoryUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -443,7 +354,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -468,7 +379,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_usage--float64--Gauge--true',
-								key: k8sPodMemoryUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'min',
@@ -482,7 +393,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -507,7 +418,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_usage--float64--Gauge--true',
-								key: k8sPodMemoryUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -521,7 +432,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -546,7 +457,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_allocatable_memory--float64--Gauge--true',
-								key: k8sNodeAllocatableMemoryKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_ALLOCATABLE_MEMORY,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -560,7 +471,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -619,7 +530,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_condition_ready--float64--Gauge--true',
-								key: k8sNodeConditionReadyKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CONDITION_READY,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -633,7 +544,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -647,18 +558,18 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_node_name--string--tag--false',
-									key: k8sNodeNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 									type: 'tag',
 								},
 							],
 							having: [
 								{
-									columnName: `MAX(${k8sNodeConditionReadyKey})`,
+									columnName: `MAX(${INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CONDITION_READY})`,
 									op: '=',
 									value: 1,
 								},
 							],
-							legend: `{{${k8sNodeNameKey}}}`,
+							legend: `{{${INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME}}}`,
 							limit: null,
 							orderBy: [],
 							queryName: 'A',
@@ -705,7 +616,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_condition_ready--float64--Gauge--true',
-								key: k8sNodeConditionReadyKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CONDITION_READY,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -719,7 +630,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -733,18 +644,18 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_node_name--string--tag--false',
-									key: k8sNodeNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 									type: 'tag',
 								},
 							],
 							having: [
 								{
-									columnName: `MAX(${k8sNodeConditionReadyKey})`,
+									columnName: `MAX(${INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CONDITION_READY})`,
 									op: '=',
 									value: 0,
 								},
 							],
-							legend: `{{${k8sNodeNameKey}}}`,
+							legend: `{{${INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME}}}`,
 							limit: null,
 							orderBy: [],
 							queryName: 'A',
@@ -791,7 +702,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_deployment_available--float64--Gauge--true',
-								key: k8sDeploymentAvailableKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_AVAILABLE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -805,7 +716,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -819,13 +730,13 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_deployment_name--string--tag--false',
-									key: k8sDeploymentNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME,
 									type: 'tag',
 								},
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_namespace_name--string--tag--false',
-									key: k8sNamespaceNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 									type: 'tag',
 								},
 							],
@@ -843,7 +754,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_deployment_desired--float64--Gauge--true',
-								key: k8sDeploymentDesiredKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_DESIRED,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -857,7 +768,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -871,13 +782,13 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_deployment_name--string--tag--false',
-									key: k8sDeploymentNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME,
 									type: 'tag',
 								},
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_namespace_name--string--tag--false',
-									key: k8sNamespaceNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 									type: 'tag',
 								},
 							],
@@ -941,7 +852,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_statefulset_current_pods--float64--Gauge--true',
-								key: k8sStatefulsetCurrentPodsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_CURRENT_PODS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -955,7 +866,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -969,13 +880,13 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_statefulset_name--string--tag--false',
-									key: k8sStatefulsetNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 									type: 'tag',
 								},
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_namespace_name--string--tag--false',
-									key: k8sNamespaceNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 									type: 'tag',
 								},
 							],
@@ -993,7 +904,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_statefulset_desired_pods--float64--Gauge--true',
-								key: k8sStatefulsetDesiredPodsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_DESIRED_PODS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -1007,7 +918,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1021,13 +932,13 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_statefulset_name--string--tag--false',
-									key: k8sStatefulsetNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 									type: 'tag',
 								},
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_namespace_name--string--tag--false',
-									key: k8sNamespaceNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 									type: 'tag',
 								},
 							],
@@ -1045,7 +956,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_statefulset_ready_pods--float64--Gauge--true',
-								key: k8sStatefulsetReadyPodsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_READY_PODS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -1059,7 +970,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1073,13 +984,13 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_statefulset_name--string--tag--false',
-									key: k8sStatefulsetNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 									type: 'tag',
 								},
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_namespace_name--string--tag--false',
-									key: k8sNamespaceNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 									type: 'tag',
 								},
 							],
@@ -1097,7 +1008,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_statefulset_updated_pods--float64--Gauge--true',
-								key: k8sStatefulsetUpdatedPodsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_UPDATED_PODS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -1111,7 +1022,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1125,13 +1036,13 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_statefulset_name--string--tag--false',
-									key: k8sStatefulsetNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 									type: 'tag',
 								},
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_namespace_name--string--tag--false',
-									key: k8sNamespaceNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 									type: 'tag',
 								},
 							],
@@ -1219,7 +1130,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_daemonset_current_scheduled_nodes--float64--Gauge--true',
-								key: k8sDaemonsetCurrentScheduledNodesKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_CURRENT_SCHEDULED_NODES,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1233,7 +1144,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1247,7 +1158,7 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_daemonset_name--string--tag--false',
-									key: k8sDaemonsetNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 									type: 'tag',
 								},
 							],
@@ -1265,7 +1176,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_daemonset_desired_scheduled_nodes--float64--Gauge--true',
-								key: k8sDaemonsetDesiredScheduledNodesKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_DESIRED_SCHEDULED_NODES,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1279,7 +1190,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1293,7 +1204,7 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_daemonset_name--string--tag--false',
-									key: k8sDaemonsetNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 									type: 'tag',
 								},
 							],
@@ -1311,7 +1222,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_daemonset_ready_nodes--float64--Gauge--true',
-								key: k8sDaemonsetReadyNodesKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_READY_NODES,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1325,7 +1236,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1339,7 +1250,7 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_daemonset_name--string--tag--false',
-									key: k8sDaemonsetNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 									type: 'tag',
 								},
 							],
@@ -1415,7 +1326,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_job_active_pods--float64--Gauge--true',
-								key: k8sJobActivePodsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_JOB_ACTIVE_PODS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -1429,7 +1340,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1443,13 +1354,13 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_job_name--string--tag--false',
-									key: k8sJobNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_JOB_NAME,
 									type: 'tag',
 								},
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_namespace_name--string--tag--false',
-									key: k8sNamespaceNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 									type: 'tag',
 								},
 							],
@@ -1467,7 +1378,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_job_successful_pods--float64--Gauge--true',
-								key: k8sJobSuccessfulPodsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_JOB_SUCCESSFUL_PODS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -1481,7 +1392,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1495,13 +1406,13 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_job_name--string--tag--false',
-									key: k8sJobNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_JOB_NAME,
 									type: 'tag',
 								},
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_namespace_name--string--tag--false',
-									key: k8sNamespaceNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 									type: 'tag',
 								},
 							],
@@ -1519,7 +1430,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_job_failed_pods--float64--Gauge--true',
-								key: k8sJobFailedPodsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_JOB_FAILED_PODS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -1533,7 +1444,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1547,13 +1458,13 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_job_name--string--tag--false',
-									key: k8sJobNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_JOB_NAME,
 									type: 'tag',
 								},
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_namespace_name--string--tag--false',
-									key: k8sNamespaceNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 									type: 'tag',
 								},
 							],
@@ -1571,7 +1482,7 @@ export const getClusterMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_job_desired_successful_pods--float64--Gauge--true',
-								key: k8sJobDesiredSuccessfulPodsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_JOB_DESIRED_SUCCESSFUL_PODS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -1585,7 +1496,7 @@ export const getClusterMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1599,13 +1510,13 @@ export const getClusterMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_job_name--string--tag--false',
-									key: k8sJobNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_JOB_NAME,
 									type: 'tag',
 								},
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_namespace_name--string--tag--false',
-									key: k8sNamespaceNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 									type: 'tag',
 								},
 							],

--- a/frontend/src/container/InfraMonitoringK8sV2/DaemonSets/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/DaemonSets/constants.ts
@@ -100,54 +100,7 @@ export const getDaemonSetMetricsQueryPayload = (
 	daemonSet: InframonitoringtypesDaemonSetRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ): GetQueryResultsProps[] => {
-	const k8sPodCpuUtilizationKey = dotMetricsEnabled
-		? 'k8s.pod.cpu.usage'
-		: 'k8s_pod_cpu_usage';
-
-	const k8sContainerCpuRequestKey = dotMetricsEnabled
-		? 'k8s.container.cpu_request'
-		: 'k8s_container_cpu_request';
-
-	const k8sContainerCpuLimitKey = dotMetricsEnabled
-		? 'k8s.container.cpu_limit'
-		: 'k8s_container_cpu_limit';
-
-	const k8sPodMemoryUsageKey = dotMetricsEnabled
-		? 'k8s.pod.memory.usage'
-		: 'k8s_pod_memory_usage';
-
-	const k8sContainerMemoryRequestKey = dotMetricsEnabled
-		? 'k8s.container.memory_request'
-		: 'k8s_container_memory_request';
-
-	const k8sContainerMemoryLimitKey = dotMetricsEnabled
-		? 'k8s.container.memory_limit'
-		: 'k8s_container_memory_limit';
-
-	const k8sPodNetworkIoKey = dotMetricsEnabled
-		? 'k8s.pod.network.io'
-		: 'k8s_pod_network_io';
-
-	const k8sPodNetworkErrorsKey = dotMetricsEnabled
-		? 'k8s.pod.network.errors'
-		: 'k8s_pod_network_errors';
-
-	const k8sDaemonSetNameKey = dotMetricsEnabled
-		? 'k8s.daemonset.name'
-		: 'k8s_daemonset_name';
-
-	const k8sPodNameKey = dotMetricsEnabled ? 'k8s.pod.name' : 'k8s_pod_name';
-
-	const k8sNamespaceNameKey = dotMetricsEnabled
-		? 'k8s.namespace.name'
-		: 'k8s_namespace_name';
-
-	const k8sClusterNameKey = dotMetricsEnabled
-		? 'k8s.cluster.name'
-		: 'k8s_cluster_name';
-
 	const clusterName =
 		daemonSet.meta?.[INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME] ?? '';
 	const namespaceName =
@@ -159,7 +112,7 @@ export const getDaemonSetMetricsQueryPayload = (
 			key: {
 				dataType: DataTypes.String,
 				id: 'k8s_cluster_name--string--tag--false',
-				key: k8sClusterNameKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				type: 'tag',
 			},
 			op: '=',
@@ -170,7 +123,7 @@ export const getDaemonSetMetricsQueryPayload = (
 			key: {
 				dataType: DataTypes.String,
 				id: 'k8s_namespace_name--string--tag--false',
-				key: k8sNamespaceNameKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 				type: 'tag',
 			},
 			op: '=',
@@ -189,7 +142,7 @@ export const getDaemonSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_usage--float64--Gauge--true',
-								key: k8sPodCpuUtilizationKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -203,7 +156,7 @@ export const getDaemonSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_daemonset_name--string--tag--false',
-											key: k8sDaemonSetNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -231,7 +184,7 @@ export const getDaemonSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_cpu_request--float64--Gauge--true',
-								key: k8sContainerCpuRequestKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_CPU_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -245,7 +198,7 @@ export const getDaemonSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: 'contains',
@@ -273,7 +226,7 @@ export const getDaemonSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_cpu_limit--float64--Gauge--true',
-								key: k8sContainerCpuLimitKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_CPU_LIMIT,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -287,7 +240,7 @@ export const getDaemonSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: 'contains',
@@ -349,7 +302,7 @@ export const getDaemonSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_usage--float64--Gauge--true',
-								key: k8sPodMemoryUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -363,7 +316,7 @@ export const getDaemonSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_daemonset_name--string--tag--false',
-											key: k8sDaemonSetNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -391,7 +344,7 @@ export const getDaemonSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_memory_request--float64--Gauge--true',
-								key: k8sContainerMemoryRequestKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_MEMORY_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -405,7 +358,7 @@ export const getDaemonSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: 'contains',
@@ -433,7 +386,7 @@ export const getDaemonSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_memory_limit--float64--Gauge--true',
-								key: k8sContainerMemoryLimitKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_MEMORY_LIMIT,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -447,7 +400,7 @@ export const getDaemonSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: 'contains',
@@ -509,7 +462,7 @@ export const getDaemonSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_network_io--float64--Sum--true',
-								key: k8sPodNetworkIoKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_IO,
 								type: 'Sum',
 							},
 							aggregateOperator: 'rate',
@@ -523,7 +476,7 @@ export const getDaemonSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_daemonset_name--string--tag--false',
-											key: k8sDaemonSetNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -598,7 +551,7 @@ export const getDaemonSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_network_errors--float64--Sum--true',
-								key: k8sPodNetworkErrorsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_ERRORS,
 								type: 'Sum',
 							},
 							aggregateOperator: 'increase',
@@ -612,7 +565,7 @@ export const getDaemonSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_daemonset_name--string--tag--false',
-											key: k8sDaemonSetNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -684,15 +637,10 @@ export const getDaemonSetPodMetricsQueryPayload = (
 	daemonSet: InframonitoringtypesDaemonSetRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ): GetQueryResultsProps[] => {
-	const k8sDaemonSetNameKey = dotMetricsEnabled
-		? 'k8s.daemonset.name'
-		: 'k8s_daemonset_name';
-
 	return getPodUtilizationByPodQueryPayloads(
 		{
-			workloadNameKey: k8sDaemonSetNameKey,
+			workloadNameKey: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 			workloadNameValue:
 				daemonSet.meta?.[INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME] ?? '',
 			clusterName:
@@ -702,6 +650,5 @@ export const getDaemonSetPodMetricsQueryPayload = (
 		},
 		start,
 		end,
-		dotMetricsEnabled,
 	);
 };

--- a/frontend/src/container/InfraMonitoringK8sV2/Deployments/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Deployments/constants.ts
@@ -100,52 +100,7 @@ export const getDeploymentMetricsQueryPayload = (
 	deployment: InframonitoringtypesDeploymentRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ): GetQueryResultsProps[] => {
-	const k8sPodCpuUtilizationKey = dotMetricsEnabled
-		? 'k8s.pod.cpu.usage'
-		: 'k8s_pod_cpu_usage';
-
-	const k8sContainerCpuRequestKey = dotMetricsEnabled
-		? 'k8s.container.cpu_request'
-		: 'k8s_container_cpu_request';
-
-	const k8sContainerCpuLimitKey = dotMetricsEnabled
-		? 'k8s.container.cpu_limit'
-		: 'k8s_container_cpu_limit';
-
-	const k8sPodMemoryUsageKey = dotMetricsEnabled
-		? 'k8s.pod.memory.usage'
-		: 'k8s_pod_memory_usage';
-
-	const k8sContainerMemoryRequestKey = dotMetricsEnabled
-		? 'k8s.container.memory_request'
-		: 'k8s_container_memory_request';
-
-	const k8sContainerMemoryLimitKey = dotMetricsEnabled
-		? 'k8s.container.memory_limit'
-		: 'k8s_container_memory_limit';
-
-	const k8sPodNetworkIoKey = dotMetricsEnabled
-		? 'k8s.pod.network.io'
-		: 'k8s_pod_network_io';
-
-	const k8sPodNetworkErrorsKey = dotMetricsEnabled
-		? 'k8s.pod.network.errors'
-		: 'k8s_pod_network_errors';
-
-	const k8sDeploymentNameKey = dotMetricsEnabled
-		? 'k8s.deployment.name'
-		: 'k8s_deployment_name';
-
-	const k8sPodNameKey = dotMetricsEnabled ? 'k8s.pod.name' : 'k8s_pod_name';
-	const k8sClusterNameKey = dotMetricsEnabled
-		? 'k8s.cluster.name'
-		: 'k8s_cluster_name';
-	const k8sNamespaceNameKey = dotMetricsEnabled
-		? 'k8s.namespace.name'
-		: 'k8s_namespace_name';
-
 	const clusterName =
 		deployment.meta?.[INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME] ?? '';
 
@@ -158,7 +113,7 @@ export const getDeploymentMetricsQueryPayload = (
 			key: {
 				dataType: DataTypes.String,
 				id: 'k8s_cluster_name--string--tag--false',
-				key: k8sClusterNameKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				type: 'tag',
 			},
 			op: '=',
@@ -169,7 +124,7 @@ export const getDeploymentMetricsQueryPayload = (
 			key: {
 				dataType: DataTypes.String,
 				id: 'k8s_namespace_name--string--tag--false',
-				key: k8sNamespaceNameKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 				type: 'tag',
 			},
 			op: '=',
@@ -188,7 +143,7 @@ export const getDeploymentMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_usage--float64--Gauge--true',
-								key: k8sPodCpuUtilizationKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -202,7 +157,7 @@ export const getDeploymentMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_deployment_name--string--tag--false',
-											key: k8sDeploymentNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -230,7 +185,7 @@ export const getDeploymentMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_cpu_request--float64--Gauge--true',
-								key: k8sContainerCpuRequestKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_CPU_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -244,7 +199,7 @@ export const getDeploymentMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: 'contains',
@@ -272,7 +227,7 @@ export const getDeploymentMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_cpu_limit--float64--Gauge--true',
-								key: k8sContainerCpuLimitKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_CPU_LIMIT,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -286,7 +241,7 @@ export const getDeploymentMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: 'contains',
@@ -348,7 +303,7 @@ export const getDeploymentMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_usage--float64--Gauge--true',
-								key: k8sPodMemoryUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -362,7 +317,7 @@ export const getDeploymentMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_deployment_name--string--tag--false',
-											key: k8sDeploymentNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -390,7 +345,7 @@ export const getDeploymentMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_memory_request--float64--Gauge--true',
-								key: k8sContainerMemoryRequestKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_MEMORY_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -404,7 +359,7 @@ export const getDeploymentMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: 'contains',
@@ -432,7 +387,7 @@ export const getDeploymentMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_memory_limit--float64--Gauge--true',
-								key: k8sContainerMemoryLimitKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_MEMORY_LIMIT,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -446,7 +401,7 @@ export const getDeploymentMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: 'contains',
@@ -508,7 +463,7 @@ export const getDeploymentMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_network_io--float64--Sum--true',
-								key: k8sPodNetworkIoKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_IO,
 								type: 'Sum',
 							},
 							aggregateOperator: 'rate',
@@ -522,7 +477,7 @@ export const getDeploymentMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_deployment_name--string--tag--false',
-											key: k8sDeploymentNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -597,7 +552,7 @@ export const getDeploymentMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_network_errors--float64--Sum--true',
-								key: k8sPodNetworkErrorsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_ERRORS,
 								type: 'Sum',
 							},
 							aggregateOperator: 'increase',
@@ -611,7 +566,7 @@ export const getDeploymentMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_deployment_name--string--tag--false',
-											key: k8sDeploymentNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -683,15 +638,10 @@ export const getDeploymentPodMetricsQueryPayload = (
 	deployment: InframonitoringtypesDeploymentRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
-): GetQueryResultsProps[] => {
-	const k8sDeploymentNameKey = dotMetricsEnabled
-		? 'k8s.deployment.name'
-		: 'k8s_deployment_name';
-
-	return getPodUtilizationByPodQueryPayloads(
+): GetQueryResultsProps[] =>
+	getPodUtilizationByPodQueryPayloads(
 		{
-			workloadNameKey: k8sDeploymentNameKey,
+			workloadNameKey: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME,
 			workloadNameValue:
 				deployment.meta?.[INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME] ?? '',
 			clusterName:
@@ -701,6 +651,4 @@ export const getDeploymentPodMetricsQueryPayload = (
 		},
 		start,
 		end,
-		dotMetricsEnabled,
 	);
-};

--- a/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/EntityMetrics/EntityMetrics.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/EntityMetrics/EntityMetrics.tsx
@@ -40,7 +40,6 @@ interface EntityMetricsProps<T> {
 		node: T,
 		start: number,
 		end: number,
-		dotMetricsEnabled: boolean,
 	) => GetQueryResultsProps[];
 	queryKey: string;
 	category: InfraMonitoringEntity;

--- a/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/EntityMetrics/__tests__/EntityMetrics.timeRange.test.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/EntityMetrics/__tests__/EntityMetrics.timeRange.test.tsx
@@ -85,7 +85,6 @@ describe('EntityMetrics time range wiring', () => {
 			entity,
 			START_SECONDS,
 			END_SECONDS,
-			false,
 		);
 		expect(mockBuildChartConfig).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/EntityMetrics/hooks.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/EntityMetrics/hooks.ts
@@ -13,8 +13,6 @@ import { SuccessResponse } from 'types/api';
 import { MetricRangePayloadProps } from 'types/api/metrics/getQueryRange';
 import uPlot from 'uplot';
 
-import { FeatureKeys } from 'constants/features';
-import { useAppContext } from 'providers/App/App';
 import { getMetricsTableData, MetricsTableData } from './utils';
 
 export interface UseEntityMetricsParams<T> {
@@ -25,7 +23,6 @@ export interface UseEntityMetricsParams<T> {
 		entity: T,
 		start: number,
 		end: number,
-		dotMetricsEnabled: boolean,
 	) => GetQueryResultsProps[];
 	visibilities: boolean[];
 	category: InfraMonitoringEntity;
@@ -46,26 +43,9 @@ export function useEntityMetrics<T>({
 	visibilities,
 	category,
 }: UseEntityMetricsParams<T>): UseEntityMetricsResult {
-	const { featureFlags } = useAppContext();
-	const dotMetricsEnabled =
-		featureFlags?.find((flag) => flag.name === FeatureKeys.DOT_METRICS_ENABLED)
-			?.active || false;
-
 	const queryPayloads = useMemo(
-		() =>
-			getEntityQueryPayload(
-				entity,
-				timeRange.startTime,
-				timeRange.endTime,
-				dotMetricsEnabled,
-			),
-		[
-			getEntityQueryPayload,
-			entity,
-			timeRange.startTime,
-			timeRange.endTime,
-			dotMetricsEnabled,
-		],
+		() => getEntityQueryPayload(entity, timeRange.startTime, timeRange.endTime),
+		[getEntityQueryPayload, entity, timeRange.startTime, timeRange.endTime],
 	);
 
 	const queries = useQueries(

--- a/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/createPodMetricsTab.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/EntityDetailsUtils/createPodMetricsTab.tsx
@@ -30,7 +30,6 @@ interface CreatePodMetricsTabParams<T> {
 		entity: T,
 		start: number,
 		end: number,
-		dotMetricsEnabled: boolean,
 	) => GetQueryResultsProps[];
 	queryKey: string;
 	category: InfraMonitoringEntity;

--- a/frontend/src/container/InfraMonitoringK8sV2/InfraMonitoringK8s.tsx
+++ b/frontend/src/container/InfraMonitoringK8sV2/InfraMonitoringK8s.tsx
@@ -26,8 +26,6 @@ import {
 import ErrorBoundaryFallback from 'pages/ErrorBoundaryFallback/ErrorBoundaryFallback';
 import { DataSource } from 'types/common/queryBuilder';
 
-import { FeatureKeys } from '../../constants/features';
-import { useAppContext } from '../../providers/App/App';
 import { K8sDynamicList } from './Base/K8sDynamicList';
 import {
 	GetClustersQuickFiltersConfig,
@@ -128,69 +126,64 @@ export default function InfraMonitoringK8s(): JSX.Element {
 		setShowFilters((show) => !show);
 	}, []);
 
-	const { featureFlags } = useAppContext();
-	const dotMetricsEnabled =
-		featureFlags?.find((flag) => flag.name === FeatureKeys.DOT_METRICS_ENABLED)
-			?.active || false;
-
 	const categories = useMemo(
 		() => [
 			{
 				key: K8sCategories.PODS,
 				label: 'Pods',
 				icon: <Container size={14} />,
-				config: GetPodsQuickFiltersConfig(dotMetricsEnabled),
+				config: GetPodsQuickFiltersConfig(),
 			},
 			{
 				key: K8sCategories.NODES,
 				label: 'Nodes',
 				icon: <Workflow size={14} />,
-				config: GetNodesQuickFiltersConfig(dotMetricsEnabled),
+				config: GetNodesQuickFiltersConfig(),
 			},
 			{
 				key: K8sCategories.NAMESPACES,
 				label: 'Namespaces',
 				icon: <FilePenLine size={14} />,
-				config: GetNamespaceQuickFiltersConfig(dotMetricsEnabled),
+				config: GetNamespaceQuickFiltersConfig(),
 			},
 			{
 				key: K8sCategories.CLUSTERS,
 				label: 'Clusters',
 				icon: <Boxes size={14} />,
-				config: GetClustersQuickFiltersConfig(dotMetricsEnabled),
+				config: GetClustersQuickFiltersConfig(),
 			},
 			{
 				key: K8sCategories.DEPLOYMENTS,
 				label: 'Deployments',
 				icon: <Computer size={14} />,
-				config: GetDeploymentsQuickFiltersConfig(dotMetricsEnabled),
+				config: GetDeploymentsQuickFiltersConfig(),
 			},
 			{
 				key: K8sCategories.JOBS,
 				label: 'Jobs',
 				icon: <Bolt size={14} />,
-				config: GetJobsQuickFiltersConfig(dotMetricsEnabled),
+				config: GetJobsQuickFiltersConfig(),
 			},
 			{
 				key: K8sCategories.DAEMONSETS,
 				label: 'DaemonSets',
 				icon: <Group size={14} />,
-				config: GetDaemonsetsQuickFiltersConfig(dotMetricsEnabled),
+				config: GetDaemonsetsQuickFiltersConfig(),
 			},
 			{
 				key: K8sCategories.STATEFULSETS,
 				label: 'StatefulSets',
 				icon: <ArrowUpDown size={14} />,
-				config: GetStatefulsetsQuickFiltersConfig(dotMetricsEnabled),
+				config: GetStatefulsetsQuickFiltersConfig(),
 			},
 			{
 				key: K8sCategories.VOLUMES,
 				label: 'Volumes',
 				icon: <HardDrive size={14} />,
-				config: GetVolumesQuickFiltersConfig(dotMetricsEnabled),
+				config: GetVolumesQuickFiltersConfig(),
 			},
 		],
-		[dotMetricsEnabled],
+		[],
 	);
 
 	const selectedCategoryConfig = useMemo(

--- a/frontend/src/container/InfraMonitoringK8sV2/Jobs/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Jobs/constants.ts
@@ -96,28 +96,7 @@ export const getJobMetricsQueryPayload = (
 	job: InframonitoringtypesJobRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ): GetQueryResultsProps[] => {
-	const k8sPodCpuUtilizationKey = dotMetricsEnabled
-		? 'k8s.pod.cpu.usage'
-		: 'k8s_pod_cpu_usage';
-	const k8sPodMemoryUsageKey = dotMetricsEnabled
-		? 'k8s.pod.memory.usage'
-		: 'k8s_pod_memory_usage';
-	const k8sPodNetworkIoKey = dotMetricsEnabled
-		? 'k8s.pod.network.io'
-		: 'k8s_pod_network_io';
-	const k8sPodNetworkErrorsKey = dotMetricsEnabled
-		? 'k8s.pod.network.errors'
-		: 'k8s_pod_network_errors';
-	const k8sJobNameKey = dotMetricsEnabled ? 'k8s.job.name' : 'k8s_job_name';
-	const k8sClusterNameKey = dotMetricsEnabled
-		? 'k8s.cluster.name'
-		: 'k8s_cluster_name';
-	const k8sNamespaceNameKey = dotMetricsEnabled
-		? 'k8s.namespace.name'
-		: 'k8s_namespace_name';
-
 	const clusterName =
 		job.meta?.[INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME] ?? '';
 	const namespaceName =
@@ -129,7 +108,7 @@ export const getJobMetricsQueryPayload = (
 			key: {
 				dataType: DataTypes.String,
 				id: 'k8s_job_name--string--tag--false',
-				key: k8sJobNameKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_JOB_NAME,
 				type: 'tag',
 			},
 			op: '=',
@@ -140,7 +119,7 @@ export const getJobMetricsQueryPayload = (
 			key: {
 				dataType: DataTypes.String,
 				id: 'k8s_cluster_name--string--tag--false',
-				key: k8sClusterNameKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				type: 'tag',
 			},
 			op: '=',
@@ -151,7 +130,7 @@ export const getJobMetricsQueryPayload = (
 			key: {
 				dataType: DataTypes.String,
 				id: 'k8s_namespace_name--string--tag--false',
-				key: k8sNamespaceNameKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 				type: 'tag',
 			},
 			op: '=',
@@ -170,7 +149,7 @@ export const getJobMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_usage--float64--Gauge--true',
-								key: k8sPodCpuUtilizationKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -231,7 +210,7 @@ export const getJobMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_usage--float64--Gauge--true',
-								key: k8sPodMemoryUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -292,7 +271,7 @@ export const getJobMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_network_io--float64--Sum--true',
-								key: k8sPodNetworkIoKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_IO,
 								type: 'Sum',
 							},
 							aggregateOperator: 'rate',
@@ -366,7 +345,7 @@ export const getJobMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_network_errors--float64--Sum--true',
-								key: k8sPodNetworkErrorsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_ERRORS,
 								type: 'Sum',
 							},
 							aggregateOperator: 'increase',
@@ -437,13 +416,10 @@ export const getJobPodMetricsQueryPayload = (
 	job: InframonitoringtypesJobRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
-): GetQueryResultsProps[] => {
-	const k8sJobNameKey = dotMetricsEnabled ? 'k8s.job.name' : 'k8s_job_name';
-
-	return getPodUtilizationByPodQueryPayloads(
+): GetQueryResultsProps[] =>
+	getPodUtilizationByPodQueryPayloads(
 		{
-			workloadNameKey: k8sJobNameKey,
+			workloadNameKey: INFRA_MONITORING_ATTR_KEYS.K8S_JOB_NAME,
 			workloadNameValue: job.jobName ?? '',
 			clusterName: job.meta?.[INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME] ?? '',
 			namespaceName:
@@ -451,6 +427,4 @@ export const getJobPodMetricsQueryPayload = (
 		},
 		start,
 		end,
-		dotMetricsEnabled,
 	);
-};

--- a/frontend/src/container/InfraMonitoringK8sV2/Namespaces/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Namespaces/constants.ts
@@ -166,97 +166,7 @@ export const getNamespaceMetricsQueryPayload = (
 	namespace: InframonitoringtypesNamespaceRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ): GetQueryResultsProps[] => {
-	const getKey = (dotKey: string, underscoreKey: string): string =>
-		dotMetricsEnabled ? dotKey : underscoreKey;
-	const k8sPodCpuUtilizationKey = getKey(
-		'k8s.pod.cpu.usage',
-		'k8s_pod_cpu_usage',
-	);
-	const k8sContainerCpuRequestKey = getKey(
-		'k8s.container.cpu_request',
-		'k8s_container_cpu_request',
-	);
-	const k8sPodMemoryUsageKey = getKey(
-		'k8s.pod.memory.usage',
-		'k8s_pod_memory_usage',
-	);
-	const k8sContainerMemoryRequestKey = getKey(
-		'k8s.container.memory_request',
-		'k8s_container_memory_request',
-	);
-	const k8sPodMemoryWorkingSetKey = getKey(
-		'k8s.pod.memory.working_set',
-		'k8s_pod_memory_working_set',
-	);
-	const k8sPodMemoryRssKey = getKey('k8s.pod.memory.rss', 'k8s_pod_memory_rss');
-	const k8sPodNetworkIoKey = getKey('k8s.pod.network.io', 'k8s_pod_network_io');
-	const k8sPodNetworkErrorsKey = getKey(
-		'k8s.pod.network.errors',
-		'k8s_pod_network_errors',
-	);
-	const k8sStatefulsetCurrentPodsKey = getKey(
-		'k8s.statefulset.current_pods',
-		'k8s_statefulset_current_pods',
-	);
-	const k8sStatefulsetDesiredPodsKey = getKey(
-		'k8s.statefulset.desired_pods',
-		'k8s_statefulset_desired_pods',
-	);
-	const k8sStatefulsetUpdatedPodsKey = getKey(
-		'k8s.statefulset.updated_pods',
-		'k8s_statefulset_updated_pods',
-	);
-	const k8sReplicasetDesiredKey = getKey(
-		'k8s.replicaset.desired',
-		'k8s_replicaset_desired',
-	);
-	const k8sReplicasetAvailableKey = getKey(
-		'k8s.replicaset.available',
-		'k8s_replicaset_available',
-	);
-	const k8sDaemonsetDesiredScheduledNodesKey = getKey(
-		'k8s.daemonset.desired_scheduled_nodes',
-		'k8s_daemonset_desired_scheduled_nodes',
-	);
-	const k8sDaemonsetCurrentScheduledNodesKey = getKey(
-		'k8s.daemonset.current_scheduled_nodes',
-		'k8s_daemonset_current_scheduled_nodes',
-	);
-	const k8sDaemonsetReadyNodesKey = getKey(
-		'k8s.daemonset.ready_nodes',
-		'k8s_daemonset_ready_nodes',
-	);
-	const k8sDaemonsetMisscheduledNodesKey = getKey(
-		'k8s.daemonset.misscheduled_nodes',
-		'k8s_daemonset_misscheduled_nodes',
-	);
-	const k8sDeploymentDesiredKey = getKey(
-		'k8s.deployment.desired',
-		'k8s_deployment_desired',
-	);
-	const k8sDeploymentAvailableKey = getKey(
-		'k8s.deployment.available',
-		'k8s_deployment_available',
-	);
-	const k8sNamespaceNameKey = getKey('k8s.namespace.name', 'k8s_namespace_name');
-	const k8sPodNameKey = getKey('k8s.pod.name', 'k8s_pod_name');
-	const k8sStatefulsetNameKey = getKey(
-		'k8s.statefulset.name',
-		'k8s_statefulset_name',
-	);
-	const k8sReplicasetNameKey = getKey(
-		'k8s.replicaset.name',
-		'k8s_replicaset_name',
-	);
-	const k8sDaemonsetNameKey = getKey('k8s.daemonset.name', 'k8s_daemonset_name');
-	const k8sDeploymentNameKey = getKey(
-		'k8s.deployment.name',
-		'k8s_deployment_name',
-	);
-	const k8sClusterNameKey = getKey('k8s.cluster.name', 'k8s_cluster_name');
-
 	const clusterName =
 		namespace.meta?.[INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME] ?? '';
 
@@ -266,7 +176,7 @@ export const getNamespaceMetricsQueryPayload = (
 			key: {
 				dataType: DataTypes.String,
 				id: 'k8s_cluster_name--string--tag--false',
-				key: k8sClusterNameKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				type: 'tag',
 			},
 			op: '=',
@@ -284,8 +194,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sPodCpuUtilizationKey,
-								key: k8sPodCpuUtilizationKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -298,8 +208,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '47b3adae',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -324,8 +234,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sContainerCpuRequestKey,
-								key: k8sContainerCpuRequestKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_CPU_REQUEST,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_CPU_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -338,8 +248,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '93d2be5e',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -364,8 +274,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sPodCpuUtilizationKey,
-								key: k8sPodCpuUtilizationKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'min',
@@ -378,8 +288,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '795eb679',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -404,8 +314,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sPodCpuUtilizationKey,
-								key: k8sPodCpuUtilizationKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -418,8 +328,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '6792adbe',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -478,8 +388,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sPodMemoryUsageKey,
-								key: k8sPodMemoryUsageKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -492,8 +402,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '10011298',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -518,8 +428,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sContainerMemoryRequestKey,
-								key: k8sContainerMemoryRequestKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_MEMORY_REQUEST,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_MEMORY_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -532,8 +442,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: 'ea53b656',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -558,8 +468,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sPodMemoryWorkingSetKey,
-								key: k8sPodMemoryWorkingSetKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_WORKING_SET,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_WORKING_SET,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -572,8 +482,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '674ace83',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -598,8 +508,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sPodMemoryRssKey,
-								key: k8sPodMemoryRssKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_RSS,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_RSS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -612,8 +522,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '187dbdb3',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -638,8 +548,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sPodMemoryUsageKey,
-								key: k8sPodMemoryUsageKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'min',
@@ -652,8 +562,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: 'a3dbf468',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -678,8 +588,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sPodMemoryUsageKey,
-								key: k8sPodMemoryUsageKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -692,8 +602,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '4b2406c2',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -752,8 +662,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sPodCpuUtilizationKey,
-								key: k8sPodCpuUtilizationKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -766,8 +676,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: 'c3a73f0a',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -781,13 +691,13 @@ export const getNamespaceMetricsQueryPayload = (
 							groupBy: [
 								{
 									dataType: DataTypes.String,
-									id: k8sPodNameKey,
-									key: k8sPodNameKey,
+									id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 									type: 'tag',
 								},
 							],
 							having: [],
-							legend: `{{${k8sPodNameKey}}}`,
+							legend: `{{${INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME}}}`,
 							limit: 10,
 							orderBy: [],
 							queryName: 'A',
@@ -833,8 +743,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sPodMemoryUsageKey,
-								key: k8sPodMemoryUsageKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -847,8 +757,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '5cad3379',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -862,13 +772,13 @@ export const getNamespaceMetricsQueryPayload = (
 							groupBy: [
 								{
 									dataType: DataTypes.String,
-									id: k8sPodNameKey,
-									key: k8sPodNameKey,
+									id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 									type: 'tag',
 								},
 							],
 							having: [],
-							legend: `{{${k8sPodNameKey}}}`,
+							legend: `{{${INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME}}}`,
 							limit: 10,
 							orderBy: [],
 							queryName: 'A',
@@ -914,8 +824,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sPodNetworkIoKey,
-								key: k8sPodNetworkIoKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_IO,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_IO,
 								type: 'Sum',
 							},
 							aggregateOperator: 'rate',
@@ -928,8 +838,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '00f5c5e1',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1001,8 +911,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.String,
-								id: k8sPodNetworkErrorsKey,
-								key: k8sPodNetworkErrorsKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_ERRORS,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_ERRORS,
 								type: 'Sum',
 							},
 							aggregateOperator: 'increase',
@@ -1015,8 +925,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '3aa8e064',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1088,8 +998,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sStatefulsetCurrentPodsKey,
-								key: k8sStatefulsetCurrentPodsKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_CURRENT_PODS,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_CURRENT_PODS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -1102,8 +1012,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '5f2a55c5',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1117,8 +1027,8 @@ export const getNamespaceMetricsQueryPayload = (
 							groupBy: [
 								{
 									dataType: DataTypes.String,
-									id: k8sStatefulsetNameKey,
-									key: k8sStatefulsetNameKey,
+									id: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 									type: 'tag',
 								},
 							],
@@ -1135,8 +1045,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sStatefulsetDesiredPodsKey,
-								key: k8sStatefulsetDesiredPodsKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_DESIRED_PODS,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_DESIRED_PODS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -1149,8 +1059,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '13bd7a1d',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1164,8 +1074,8 @@ export const getNamespaceMetricsQueryPayload = (
 							groupBy: [
 								{
 									dataType: DataTypes.String,
-									id: k8sStatefulsetNameKey,
-									key: k8sStatefulsetNameKey,
+									id: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 									type: 'tag',
 								},
 							],
@@ -1182,8 +1092,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sStatefulsetUpdatedPodsKey,
-								key: k8sStatefulsetUpdatedPodsKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_UPDATED_PODS,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_UPDATED_PODS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -1196,8 +1106,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '9d287c73',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1211,8 +1121,8 @@ export const getNamespaceMetricsQueryPayload = (
 							groupBy: [
 								{
 									dataType: DataTypes.String,
-									id: k8sStatefulsetNameKey,
-									key: k8sStatefulsetNameKey,
+									id: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 									type: 'tag',
 								},
 							],
@@ -1263,8 +1173,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sReplicasetDesiredKey,
-								key: k8sReplicasetDesiredKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_DESIRED,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_DESIRED,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -1277,8 +1187,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '0c1e655c',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1292,14 +1202,14 @@ export const getNamespaceMetricsQueryPayload = (
 							groupBy: [
 								{
 									dataType: DataTypes.String,
-									id: k8sReplicasetNameKey,
-									key: k8sReplicasetNameKey,
+									id: INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_NAME,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_NAME,
 									type: 'tag',
 								},
 							],
 							having: [
 								{
-									columnName: `MAX(${k8sReplicasetDesiredKey})`,
+									columnName: `MAX(${INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_DESIRED})`,
 									op: '>',
 									value: 0,
 								},
@@ -1316,8 +1226,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sReplicasetAvailableKey,
-								key: k8sReplicasetAvailableKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_AVAILABLE,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_AVAILABLE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -1330,8 +1240,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: 'b2296bdb',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1345,14 +1255,14 @@ export const getNamespaceMetricsQueryPayload = (
 							groupBy: [
 								{
 									dataType: DataTypes.String,
-									id: k8sReplicasetNameKey,
-									key: k8sReplicasetNameKey,
+									id: INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_NAME,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_NAME,
 									type: 'tag',
 								},
 							],
 							having: [
 								{
-									columnName: `MAX(${k8sReplicasetDesiredKey})`,
+									columnName: `MAX(${INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_DESIRED})`,
 									op: '>',
 									value: 0,
 								},
@@ -1403,8 +1313,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sDaemonsetDesiredScheduledNodesKey,
-								key: k8sDaemonsetDesiredScheduledNodesKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_DESIRED_SCHEDULED_NODES,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_DESIRED_SCHEDULED_NODES,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -1417,8 +1327,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '2964eb92',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1432,8 +1342,8 @@ export const getNamespaceMetricsQueryPayload = (
 							groupBy: [
 								{
 									dataType: DataTypes.String,
-									id: k8sDaemonsetNameKey,
-									key: k8sDaemonsetNameKey,
+									id: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 									type: 'tag',
 								},
 							],
@@ -1450,8 +1360,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sDaemonsetCurrentScheduledNodesKey,
-								key: k8sDaemonsetCurrentScheduledNodesKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_CURRENT_SCHEDULED_NODES,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_CURRENT_SCHEDULED_NODES,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -1464,8 +1374,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: 'cd324eff',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1479,8 +1389,8 @@ export const getNamespaceMetricsQueryPayload = (
 							groupBy: [
 								{
 									dataType: DataTypes.String,
-									id: k8sDaemonsetNameKey,
-									key: k8sDaemonsetNameKey,
+									id: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 									type: 'tag',
 								},
 							],
@@ -1497,8 +1407,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sDaemonsetReadyNodesKey,
-								key: k8sDaemonsetReadyNodesKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_READY_NODES,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_READY_NODES,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -1511,8 +1421,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '0416fa6f',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1526,8 +1436,8 @@ export const getNamespaceMetricsQueryPayload = (
 							groupBy: [
 								{
 									dataType: DataTypes.String,
-									id: k8sDaemonsetNameKey,
-									key: k8sDaemonsetNameKey,
+									id: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 									type: 'tag',
 								},
 							],
@@ -1544,8 +1454,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sDaemonsetMisscheduledNodesKey,
-								key: k8sDaemonsetMisscheduledNodesKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_MISSCHEDULED_NODES,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_MISSCHEDULED_NODES,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -1558,8 +1468,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: 'c0a126d3',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1573,8 +1483,8 @@ export const getNamespaceMetricsQueryPayload = (
 							groupBy: [
 								{
 									dataType: DataTypes.String,
-									id: k8sDaemonsetNameKey,
-									key: k8sDaemonsetNameKey,
+									id: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 									type: 'tag',
 								},
 							],
@@ -1625,8 +1535,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sDeploymentDesiredKey,
-								key: k8sDeploymentDesiredKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_DESIRED,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_DESIRED,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -1639,8 +1549,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: '9bc659c1',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1654,8 +1564,8 @@ export const getNamespaceMetricsQueryPayload = (
 							groupBy: [
 								{
 									dataType: DataTypes.String,
-									id: k8sDeploymentNameKey,
-									key: k8sDeploymentNameKey,
+									id: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME,
 									type: 'tag',
 								},
 							],
@@ -1672,8 +1582,8 @@ export const getNamespaceMetricsQueryPayload = (
 						{
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
-								id: k8sDeploymentAvailableKey,
-								key: k8sDeploymentAvailableKey,
+								id: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_AVAILABLE,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_AVAILABLE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1686,8 +1596,8 @@ export const getNamespaceMetricsQueryPayload = (
 										id: 'e1696631',
 										key: {
 											dataType: DataTypes.String,
-											id: k8sNamespaceNameKey,
-											key: k8sNamespaceNameKey,
+											id: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1701,8 +1611,8 @@ export const getNamespaceMetricsQueryPayload = (
 							groupBy: [
 								{
 									dataType: DataTypes.String,
-									id: k8sDeploymentNameKey,
-									key: k8sDeploymentNameKey,
+									id: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME,
 									type: 'tag',
 								},
 							],
@@ -1758,21 +1668,14 @@ export const getNamespacePodMetricsQueryPayload = (
 	namespace: InframonitoringtypesNamespaceRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
-): GetQueryResultsProps[] => {
-	const k8sNamespaceNameKey = dotMetricsEnabled
-		? 'k8s.namespace.name'
-		: 'k8s_namespace_name';
-
-	return getPodUtilizationByPodQueryPayloads(
+): GetQueryResultsProps[] =>
+	getPodUtilizationByPodQueryPayloads(
 		{
-			workloadNameKey: k8sNamespaceNameKey,
+			workloadNameKey: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 			workloadNameValue: namespace.namespaceName ?? '',
 			clusterName:
 				namespace.meta?.[INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME] ?? '',
 		},
 		start,
 		end,
-		dotMetricsEnabled,
 	);
-};

--- a/frontend/src/container/InfraMonitoringK8sV2/Nodes/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Nodes/constants.ts
@@ -19,7 +19,7 @@ import { SelectedItemParams } from '../hooks';
 export const k8sNodeGetSelectedItemExpression = (
 	params: SelectedItemParams,
 ): string =>
-	`k8s.node.name = ${formatValueForExpression(params.selectedItem ?? '')}`;
+	`${INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME} = ${formatValueForExpression(params.selectedItem ?? '')}`;
 
 export const k8sNodeDetailsMetadataConfig: K8sDetailsMetadataConfig<InframonitoringtypesNodeRecordDTO>[] =
 	[
@@ -111,89 +111,7 @@ export const getNodeMetricsQueryPayload = (
 	node: InframonitoringtypesNodeRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ): GetQueryResultsProps[] => {
-	const getKey = (dotKey: string, underscoreKey: string): string =>
-		dotMetricsEnabled ? dotKey : underscoreKey;
-	const k8sNodeCpuUtilizationKey = getKey(
-		'k8s.node.cpu.usage',
-		'k8s_node_cpu_usage',
-	);
-
-	const k8sNodeAllocatableCpuKey = getKey(
-		'k8s.node.allocatable_cpu',
-		'k8s_node_allocatable_cpu',
-	);
-
-	const k8sContainerCpuRequestKey = getKey(
-		'k8s.container.cpu_request',
-		'k8s_container_cpu_request',
-	);
-
-	const k8sNodeMemoryUsageKey = getKey(
-		'k8s.node.memory.usage',
-		'k8s_node_memory_usage',
-	);
-
-	const k8sNodeAllocatableMemoryKey = getKey(
-		'k8s.node.allocatable_memory',
-		'k8s_node_allocatable_memory',
-	);
-
-	const k8sContainerMemoryRequestKey = getKey(
-		'k8s.container.memory_request',
-		'k8s_container_memory_request',
-	);
-
-	const k8sNodeMemoryWorkingSetKey = getKey(
-		'k8s.node.memory.working_set',
-		'k8s_node_memory_working_set',
-	);
-
-	const k8sNodeMemoryRssKey = getKey(
-		'k8s.node.memory.rss',
-		'k8s_node_memory_rss',
-	);
-
-	const k8sPodCpuUtilizationKey = getKey(
-		'k8s.pod.cpu.usage',
-		'k8s_pod_cpu_usage',
-	);
-
-	const k8sPodMemoryUsageKey = getKey(
-		'k8s.pod.memory.usage',
-		'k8s_pod_memory_usage',
-	);
-
-	const k8sNodeNetworkErrorsKey = getKey(
-		'k8s.node.network.errors',
-		'k8s_node_network_errors',
-	);
-
-	const k8sNodeNetworkIoKey = getKey(
-		'k8s.node.network.io',
-		'k8s_node_network_io',
-	);
-
-	const k8sNodeFilesystemUsageKey = getKey(
-		'k8s.node.filesystem.usage',
-		'k8s_node_filesystem_usage',
-	);
-
-	const k8sNodeFilesystemCapacityKey = getKey(
-		'k8s.node.filesystem.capacity',
-		'k8s_node_filesystem_capacity',
-	);
-
-	const k8sNodeFilesystemAvailableKey = getKey(
-		'k8s.node.filesystem.available',
-		'k8s_node_filesystem_available',
-	);
-
-	const k8sNodeNameKey = getKey('k8s.node.name', 'k8s_node_name');
-
-	const k8sPodNameKey = getKey('k8s.pod.name', 'k8s_pod_name');
-
 	return [
 		{
 			selectedTime: 'GLOBAL_TIME',
@@ -205,7 +123,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_cpu_usage--float64--Gauge--true',
-								key: k8sNodeCpuUtilizationKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -219,7 +137,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -244,7 +162,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_allocatable_cpu--float64--Gauge--true',
-								key: k8sNodeAllocatableCpuKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_ALLOCATABLE_CPU,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -258,7 +176,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -283,7 +201,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_cpu_request--float64--Gauge--true',
-								key: k8sContainerCpuRequestKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_CPU_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -297,7 +215,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -322,7 +240,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_cpu_usage--float64--Gauge--true',
-								key: k8sNodeCpuUtilizationKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -336,7 +254,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -361,7 +279,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_cpu_usage--float64--Gauge--true',
-								key: k8sNodeCpuUtilizationKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'min',
@@ -375,7 +293,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -434,7 +352,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_memory_usage--float64--Gauge--true',
-								key: k8sNodeMemoryUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -448,7 +366,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -473,7 +391,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_allocatable_memory--float64--Gauge--true',
-								key: k8sNodeAllocatableMemoryKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_ALLOCATABLE_MEMORY,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -487,7 +405,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -512,7 +430,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_memory_request--float64--Gauge--true',
-								key: k8sContainerMemoryRequestKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_MEMORY_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -526,7 +444,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -551,7 +469,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_memory_usage--float64--Gauge--true',
-								key: k8sNodeMemoryUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -565,7 +483,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -590,7 +508,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_memory_usage--float64--Gauge--true',
-								key: k8sNodeMemoryUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'min',
@@ -604,7 +522,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -629,7 +547,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_memory_working_set--float64--Gauge--true',
-								key: k8sNodeMemoryWorkingSetKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_MEMORY_WORKING_SET,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -643,7 +561,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -668,7 +586,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_memory_rss--float64--Gauge--true',
-								key: k8sNodeMemoryRssKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_MEMORY_RSS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -682,7 +600,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -741,7 +659,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_cpu_usage--float64--Gauge--true',
-								key: k8sNodeCpuUtilizationKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -755,7 +673,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -780,7 +698,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_allocatable_cpu--float64--Gauge--true',
-								key: k8sNodeAllocatableCpuKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_ALLOCATABLE_CPU,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -794,7 +712,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -819,7 +737,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_cpu_request--float64--Gauge--true',
-								key: k8sContainerCpuRequestKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_CPU_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -833,7 +751,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -905,7 +823,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_memory_usage--float64--Gauge--true',
-								key: k8sNodeMemoryUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -919,7 +837,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -944,7 +862,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_allocatable_memory--float64--Gauge--true',
-								key: k8sNodeAllocatableMemoryKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_ALLOCATABLE_MEMORY,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -958,7 +876,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -983,7 +901,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_memory_request--float64--Gauge--true',
-								key: k8sContainerMemoryRequestKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_MEMORY_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -997,7 +915,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1069,7 +987,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_usage--float64--Gauge--true',
-								key: k8sPodCpuUtilizationKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1083,7 +1001,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1097,12 +1015,12 @@ export const getNodeMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_pod_name--string--tag--false',
-									key: k8sPodNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 									type: 'tag',
 								},
 							],
 							having: [],
-							legend: `{{${k8sPodNameKey}}}`,
+							legend: `{{${INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME}}}`,
 							limit: 10,
 							orderBy: [],
 							queryName: 'A',
@@ -1149,7 +1067,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_usage--float64--Gauge--true',
-								key: k8sPodMemoryUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1163,7 +1081,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1177,12 +1095,12 @@ export const getNodeMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_pod_name--string--tag--false',
-									key: k8sPodNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 									type: 'tag',
 								},
 							],
 							having: [],
-							legend: `{{${k8sPodNameKey}}}`,
+							legend: `{{${INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME}}}`,
 							limit: 10,
 							orderBy: [],
 							queryName: 'A',
@@ -1229,7 +1147,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_network_errors--float64--Sum--true',
-								key: k8sNodeNetworkErrorsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NETWORK_ERRORS,
 								type: 'Sum',
 							},
 							aggregateOperator: 'increase',
@@ -1243,7 +1161,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1315,7 +1233,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_network_io--float64--Sum--true',
-								key: k8sNodeNetworkIoKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NETWORK_IO,
 								type: 'Sum',
 							},
 							aggregateOperator: 'rate',
@@ -1329,7 +1247,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1401,7 +1319,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_filesystem_usage--float64--Gauge--true',
-								key: k8sNodeFilesystemUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_FILESYSTEM_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1415,7 +1333,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1440,7 +1358,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_filesystem_capacity--float64--Gauge--true',
-								key: k8sNodeFilesystemCapacityKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_FILESYSTEM_CAPACITY,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1454,7 +1372,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1479,7 +1397,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_filesystem_available--float64--Gauge--true',
-								key: k8sNodeFilesystemAvailableKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_FILESYSTEM_AVAILABLE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1493,7 +1411,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1552,7 +1470,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_filesystem_usage--float64--Gauge--true',
-								key: k8sNodeFilesystemUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_FILESYSTEM_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1566,7 +1484,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1591,7 +1509,7 @@ export const getNodeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_node_filesystem_capacity--float64--Gauge--true',
-								key: k8sNodeFilesystemCapacityKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_FILESYSTEM_CAPACITY,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1605,7 +1523,7 @@ export const getNodeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_node_name--string--tag--false',
-											key: k8sNodeNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 											type: 'tag',
 										},
 										op: '=',

--- a/frontend/src/container/InfraMonitoringK8sV2/Pods/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Pods/constants.ts
@@ -18,7 +18,7 @@ import { SelectedItemParams } from '../hooks';
 export const k8sPodGetSelectedItemExpression = (
 	params: SelectedItemParams,
 ): string =>
-	`k8s.pod.uid = ${formatValueForExpression(params.selectedItem ?? '')}`;
+	`${INFRA_MONITORING_ATTR_KEYS.K8S_POD_UID} = ${formatValueForExpression(params.selectedItem ?? '')}`;
 
 export const k8sPodDetailsMetadataConfig: K8sDetailsMetadataConfig<InframonitoringtypesPodRecordDTO>[] =
 	[
@@ -142,122 +142,7 @@ export const getPodMetricsQueryPayload = (
 	pod: InframonitoringtypesPodRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ): GetQueryResultsProps[] => {
-	const getKey = (dotKey: string, underscoreKey: string): string =>
-		dotMetricsEnabled ? dotKey : underscoreKey;
-	const k8sContainerNameKey = getKey('k8s.container.name', 'k8s_container_name');
-
-	const k8sPodCpuUtilKey = getKey('k8s.pod.cpu.usage', 'k8s_pod_cpu_usage');
-
-	const k8sPodCpuReqUtilKey = getKey(
-		'k8s.pod.cpu_request_utilization',
-		'k8s_pod_cpu_request_utilization',
-	);
-
-	const k8sPodCpuLimitUtilKey = getKey(
-		'k8s.pod.cpu_limit_utilization',
-		'k8s_pod_cpu_limit_utilization',
-	);
-
-	const k8sPodMemUsageKey = getKey(
-		'k8s.pod.memory.usage',
-		'k8s_pod_memory_usage',
-	);
-
-	const k8sPodMemReqUtilKey = getKey(
-		'k8s.pod.memory_request_utilization',
-		'k8s_pod_memory_request_utilization',
-	);
-
-	const k8sPodMemLimitUtilKey = getKey(
-		'k8s.pod.memory_limit_utilization',
-		'k8s_pod_memory_limit_utilization',
-	);
-
-	const k8sPodMemRssKey = getKey('k8s.pod.memory.rss', 'k8s_pod_memory_rss');
-
-	const k8sPodMemWorkingSetKey = getKey(
-		'k8s.pod.memory.working_set',
-		'k8s_pod_memory_working_set',
-	);
-
-	const k8sPodMemMajorPFKey = getKey(
-		'k8s.pod.memory.major_page_faults',
-		'k8s_pod_memory_major_page_faults',
-	);
-
-	const containerCpuUtilKey = getKey(
-		'container.cpu.usage',
-		'container_cpu_usage',
-	);
-
-	const k8sContainerCpuRequestKey = getKey(
-		'k8s.container.cpu_request',
-		'k8s_container_cpu_request',
-	);
-
-	const k8sContainerCpuLimitKey = getKey(
-		'k8s.container.cpu_limit',
-		'k8s_container_cpu_limit',
-	);
-
-	const k8sContainerMemoryLimitKey = getKey(
-		'k8s.container.memory_limit',
-		'k8s_container_memory_limit',
-	);
-
-	const k8sContainerMemoryRequestKey = getKey(
-		'k8s.container.memory_request',
-		'k8s_container_memory_request',
-	);
-
-	const containerMemUsageKey = getKey(
-		'container.memory.usage',
-		'container_memory_usage',
-	);
-
-	const containerMemWorkingSetKey = getKey(
-		'container.memory.working_set',
-		'container_memory_working_set',
-	);
-
-	const containerMemRssKey = getKey(
-		'container.memory.rss',
-		'container_memory_rss',
-	);
-
-	const k8sPodNetworkIoKey = getKey('k8s.pod.network.io', 'k8s_pod_network_io');
-
-	const k8sPodNetworkErrorsKey = getKey(
-		'k8s.pod.network.errors',
-		'k8s_pod_network_errors',
-	);
-
-	const k8sPodFilesystemCapacityKey = getKey(
-		'k8s.pod.filesystem.capacity',
-		'k8s_pod_filesystem_capacity',
-	);
-
-	const k8sPodFilesystemAvailableKey = getKey(
-		'k8s.pod.filesystem.available',
-		'k8s_pod_filesystem_available',
-	);
-
-	const k8sPodFilesystemUsageKey = getKey(
-		'k8s.pod.filesystem.usage',
-		'k8s_pod_filesystem_usage',
-	);
-
-	const k8sPodNameKey = getKey(
-		INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
-		'k8s_pod_name',
-	);
-
-	const k8sNamespaceNameKey = getKey(
-		INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
-		'k8s_namespace_name',
-	);
 	return [
 		{
 			selectedTime: 'GLOBAL_TIME',
@@ -269,7 +154,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_usage--float64--Gauge--true',
-								key: k8sPodCpuUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -283,7 +168,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -294,7 +179,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -320,7 +205,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_usage--float64--Gauge--true',
-								key: k8sPodCpuUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -334,7 +219,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -345,7 +230,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -371,7 +256,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_usage--float64--Gauge--true',
-								key: k8sPodCpuUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'min',
@@ -385,7 +270,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -396,7 +281,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -456,7 +341,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_request_utilization--float64--Gauge--true',
-								key: k8sPodCpuReqUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_REQUEST_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -470,7 +355,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -482,7 +367,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -507,7 +392,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_limit_utilization--float64--Gauge--true',
-								key: k8sPodCpuLimitUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_LIMIT_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -521,7 +406,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -533,7 +418,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -558,7 +443,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_request_utilization--float64--Gauge--true',
-								key: k8sPodCpuReqUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_REQUEST_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -572,7 +457,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -584,7 +469,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -609,7 +494,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_request_utilization--float64--Gauge--true',
-								key: k8sPodCpuReqUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_REQUEST_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'min',
@@ -623,7 +508,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -635,7 +520,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -660,7 +545,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_limit_utilization--float64--Gauge--true',
-								key: k8sPodCpuLimitUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_LIMIT_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -674,7 +559,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -686,7 +571,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -711,7 +596,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_cpu_limit_utilization--float64--Gauge--true',
-								key: k8sPodCpuLimitUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_LIMIT_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'min',
@@ -725,7 +610,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -737,7 +622,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -796,7 +681,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_usage--float64--Gauge--true',
-								key: k8sPodMemUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -810,7 +695,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -822,7 +707,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -847,7 +732,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_usage--float64--Gauge--true',
-								key: k8sPodMemUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -861,7 +746,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -873,7 +758,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -898,7 +783,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_usage--float64--Gauge--true',
-								key: k8sPodMemUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'min',
@@ -912,7 +797,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -924,7 +809,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -983,7 +868,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_request_utilization--float64--Gauge--true',
-								key: k8sPodMemReqUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_REQUEST_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -997,7 +882,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1009,7 +894,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1034,7 +919,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_limit_utilization--float64--Gauge--true',
-								key: k8sPodMemLimitUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_LIMIT_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1048,7 +933,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1060,7 +945,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1085,7 +970,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_request_utilization--float64--Gauge--true',
-								key: k8sPodMemReqUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_REQUEST_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -1099,7 +984,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1111,7 +996,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1136,7 +1021,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_limit_utilization--float64--Gauge--true',
-								key: k8sPodMemLimitUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_LIMIT_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'max',
@@ -1150,7 +1035,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1162,7 +1047,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1187,7 +1072,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_request_utilization--float64--Gauge--true',
-								key: k8sPodMemReqUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_REQUEST_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'min',
@@ -1201,7 +1086,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1213,7 +1098,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1238,7 +1123,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_limit_utilization--float64--Gauge--true',
-								key: k8sPodMemLimitUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_LIMIT_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'min',
@@ -1252,7 +1137,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1264,7 +1149,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1323,7 +1208,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_rss--float64--Gauge--true',
-								key: k8sPodMemRssKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_RSS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1337,7 +1222,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1349,7 +1234,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1374,7 +1259,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_working_set--float64--Gauge--true',
-								key: k8sPodMemWorkingSetKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_WORKING_SET,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1388,7 +1273,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1400,7 +1285,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1466,7 +1351,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_memory_major_page_faults--float64--Gauge--true',
-								key: k8sPodMemMajorPFKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_MAJOR_PAGE_FAULTS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1480,7 +1365,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1492,7 +1377,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1551,7 +1436,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'container_cpu_usage--float64--Gauge--true',
-								key: containerCpuUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.CONTAINER_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1565,7 +1450,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1577,7 +1462,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1591,12 +1476,12 @@ export const getPodMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_container_name--string--tag--false',
-									key: k8sContainerNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME,
 									type: 'tag',
 								},
 							],
 							having: [],
-							legend: `{{${k8sContainerNameKey}}}`,
+							legend: `{{${INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME}}}`,
 							limit: null,
 							orderBy: [],
 							queryName: 'A',
@@ -1643,7 +1528,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'container_cpu_usage--float64--Gauge--true',
-								key: containerCpuUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.CONTAINER_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1657,7 +1542,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1669,7 +1554,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1683,7 +1568,7 @@ export const getPodMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_container_name--string--tag--false',
-									key: k8sContainerNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME,
 									type: 'tag',
 								},
 							],
@@ -1701,7 +1586,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_cpu_request--float64--Gauge--true',
-								key: k8sContainerCpuRequestKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_CPU_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -1715,7 +1600,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1727,7 +1612,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1741,7 +1626,7 @@ export const getPodMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_container_name--string--tag--false',
-									key: k8sContainerNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME,
 									type: 'tag',
 								},
 							],
@@ -1759,7 +1644,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_cpu_limit--float64--Gauge--true',
-								key: k8sContainerCpuLimitKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_CPU_LIMIT,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -1773,7 +1658,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1785,7 +1670,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1799,7 +1684,7 @@ export const getPodMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_container_name--string--tag--false',
-									key: k8sContainerNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME,
 									type: 'tag',
 								},
 							],
@@ -1818,13 +1703,13 @@ export const getPodMetricsQueryPayload = (
 						{
 							disabled: false,
 							expression: 'A/B',
-							legend: `Req % : {{${k8sContainerNameKey}}} `,
+							legend: `Req % : {{${INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME}}} `,
 							queryName: 'F1',
 						},
 						{
 							disabled: false,
 							expression: 'A/C',
-							legend: `Limit % : {{${k8sContainerNameKey}}}`,
+							legend: `Limit % : {{${INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME}}}`,
 							queryName: 'F2',
 						},
 					],
@@ -1864,7 +1749,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'container_memory_usage--float64--Gauge--true',
-								key: containerMemUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.CONTAINER_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1878,7 +1763,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1890,7 +1775,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1904,12 +1789,12 @@ export const getPodMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_container_name--string--tag--false',
-									key: k8sContainerNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME,
 									type: 'tag',
 								},
 							],
 							having: [],
-							legend: `usage :: {{${k8sContainerNameKey}}}`,
+							legend: `usage :: {{${INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME}}}`,
 							limit: null,
 							orderBy: [],
 							queryName: 'A',
@@ -1922,7 +1807,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'container_memory_working_set--float64--Gauge--true',
-								key: containerMemWorkingSetKey,
+								key: INFRA_MONITORING_ATTR_KEYS.CONTAINER_MEMORY_WORKING_SET,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1936,7 +1821,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1948,7 +1833,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -1962,12 +1847,12 @@ export const getPodMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_container_name--string--tag--false',
-									key: k8sContainerNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME,
 									type: 'tag',
 								},
 							],
 							having: [],
-							legend: `working set :: {{${k8sContainerNameKey}}}`,
+							legend: `working set :: {{${INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME}}}`,
 							limit: null,
 							orderBy: [],
 							queryName: 'B',
@@ -1980,7 +1865,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'container_memory_rss--float64--Gauge--true',
-								key: containerMemRssKey,
+								key: INFRA_MONITORING_ATTR_KEYS.CONTAINER_MEMORY_RSS,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -1994,7 +1879,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2006,7 +1891,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2020,12 +1905,12 @@ export const getPodMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_container_name--string--tag--false',
-									key: k8sContainerNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME,
 									type: 'tag',
 								},
 							],
 							having: [],
-							legend: `rss :: {{${k8sContainerNameKey}}}`,
+							legend: `rss :: {{${INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME}}}`,
 							limit: null,
 							orderBy: [],
 							queryName: 'C',
@@ -2072,7 +1957,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'container_memory_usage--float64--Gauge--true',
-								key: containerMemUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.CONTAINER_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -2086,7 +1971,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2098,7 +1983,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2112,7 +1997,7 @@ export const getPodMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_container_name--string--tag--false',
-									key: k8sContainerNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME,
 									type: 'tag',
 								},
 							],
@@ -2130,7 +2015,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_memory_request--float64--Gauge--true',
-								key: k8sContainerMemoryRequestKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_MEMORY_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -2144,7 +2029,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2156,7 +2041,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2170,7 +2055,7 @@ export const getPodMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_container_name--string--tag--false',
-									key: k8sContainerNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME,
 									type: 'tag',
 								},
 							],
@@ -2188,7 +2073,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_container_memory_limit--float64--Gauge--true',
-								key: k8sContainerMemoryLimitKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_MEMORY_LIMIT,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -2202,7 +2087,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2214,7 +2099,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2228,7 +2113,7 @@ export const getPodMetricsQueryPayload = (
 								{
 									dataType: DataTypes.String,
 									id: 'k8s_container_name--string--tag--false',
-									key: k8sContainerNameKey,
+									key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME,
 									type: 'tag',
 								},
 							],
@@ -2247,13 +2132,13 @@ export const getPodMetricsQueryPayload = (
 						{
 							disabled: false,
 							expression: 'A/B',
-							legend: `Req % : {{${k8sContainerNameKey}}} `,
+							legend: `Req % : {{${INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME}}} `,
 							queryName: 'F1',
 						},
 						{
 							disabled: false,
 							expression: 'A/C',
-							legend: `Limit % : {{${k8sContainerNameKey}}} `,
+							legend: `Limit % : {{${INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_NAME}}} `,
 							queryName: 'F2',
 						},
 					],
@@ -2293,7 +2178,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_network_io--float64--Sum--true',
-								key: k8sPodNetworkIoKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_IO,
 								type: 'Sum',
 							},
 							aggregateOperator: 'rate',
@@ -2307,7 +2192,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2319,7 +2204,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2391,7 +2276,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_network_errors--float64--Sum--true',
-								key: k8sPodNetworkErrorsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_ERRORS,
 								type: 'Sum',
 							},
 							aggregateOperator: 'increase',
@@ -2405,7 +2290,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2417,7 +2302,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2489,7 +2374,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_filesystem_capacity--float64--Gauge--true',
-								key: k8sPodFilesystemCapacityKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_FILESYSTEM_CAPACITY,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -2503,7 +2388,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2515,7 +2400,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2540,7 +2425,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_filesystem_available--float64--Gauge--true',
-								key: k8sPodFilesystemAvailableKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_FILESYSTEM_AVAILABLE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -2554,7 +2439,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2566,7 +2451,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2591,7 +2476,7 @@ export const getPodMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_pod_filesystem_usage--float64--Gauge--true',
-								key: k8sPodFilesystemUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_FILESYSTEM_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -2605,7 +2490,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -2617,7 +2502,7 @@ export const getPodMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_pod_name--string--tag--false',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: '=',

--- a/frontend/src/container/InfraMonitoringK8sV2/StatefulSets/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/StatefulSets/constants.ts
@@ -113,21 +113,7 @@ export const getStatefulSetMetricsQueryPayload = (
 	statefulSet: InframonitoringtypesStatefulSetRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ): GetQueryResultsProps[] => {
-	const k8sStatefulSetNameKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME
-		: 'k8s_statefulset_name';
-	const k8sNamespaceNameKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME
-		: 'k8s_namespace_name';
-	const k8sPodNameKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME
-		: 'k8s_pod_name';
-	const k8sClusterNameKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME
-		: 'k8s_cluster_name';
-
 	const clusterName =
 		statefulSet.meta?.[INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME] ?? '';
 	const namespaceName =
@@ -139,7 +125,7 @@ export const getStatefulSetMetricsQueryPayload = (
 			key: {
 				dataType: DataTypes.String,
 				id: 'k8s_namespace_name--string--tag--false',
-				key: k8sNamespaceNameKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 				type: 'tag',
 			},
 			op: '=',
@@ -150,52 +136,13 @@ export const getStatefulSetMetricsQueryPayload = (
 			key: {
 				dataType: DataTypes.String,
 				id: 'k8s_cluster_name--string--tag--false',
-				key: k8sClusterNameKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				type: 'tag',
 			},
 			op: '=',
 			value: clusterName,
 		},
 	];
-
-	const k8sPodCpuUtilKey = dotMetricsEnabled
-		? 'k8s.pod.cpu.usage'
-		: 'k8s_pod_cpu_usage';
-	const k8sContainerCpuRequestKey = dotMetricsEnabled
-		? 'k8s.container.cpu_request'
-		: 'k8s_container_cpu_request';
-	const k8sContainerCpuLimitKey = dotMetricsEnabled
-		? 'k8s.container.cpu_limit'
-		: 'k8s_container_cpu_limit';
-	const k8sPodCpuReqUtilKey = dotMetricsEnabled
-		? 'k8s.pod.cpu_request_utilization'
-		: 'k8s_pod_cpu_request_utilization';
-	const k8sPodCpuLimitUtilKey = dotMetricsEnabled
-		? 'k8s.pod.cpu_limit_utilization'
-		: 'k8s_pod_cpu_limit_utilization';
-
-	const k8sPodMemUsageKey = dotMetricsEnabled
-		? 'k8s.pod.memory.usage'
-		: 'k8s_pod_memory_usage';
-	const k8sContainerMemRequestKey = dotMetricsEnabled
-		? 'k8s.container.memory_request'
-		: 'k8s_container_memory_request';
-	const k8sContainerMemLimitKey = dotMetricsEnabled
-		? 'k8s.container.memory_limit'
-		: 'k8s_container_memory_limit';
-	const k8sPodMemReqUtilKey = dotMetricsEnabled
-		? 'k8s.pod.memory_request_utilization'
-		: 'k8s_pod_memory_request_utilization';
-	const k8sPodMemLimitUtilKey = dotMetricsEnabled
-		? 'k8s.pod.memory_limit_utilization'
-		: 'k8s_pod_memory_limit_utilization';
-
-	const k8sPodNetworkIoKey = dotMetricsEnabled
-		? 'k8s.pod.network.io'
-		: 'k8s_pod_network_io';
-	const k8sPodNetworkErrorsKey = dotMetricsEnabled
-		? 'k8s.pod.network.errors'
-		: 'k8s_pod_network_errors';
 
 	return [
 		{
@@ -208,7 +155,7 @@ export const getStatefulSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'cpu_usage',
-								key: k8sPodCpuUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -222,7 +169,7 @@ export const getStatefulSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'ss_name',
-											key: k8sStatefulSetNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -251,7 +198,7 @@ export const getStatefulSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'cpu_request',
-								key: k8sContainerCpuRequestKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_CPU_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -265,7 +212,7 @@ export const getStatefulSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'pod_name',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: 'contains',
@@ -294,7 +241,7 @@ export const getStatefulSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'cpu_limit',
-								key: k8sContainerCpuLimitKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_CPU_LIMIT,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -308,7 +255,7 @@ export const getStatefulSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'pod_name',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: 'contains',
@@ -357,7 +304,7 @@ export const getStatefulSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'cpu_req_util',
-								key: k8sPodCpuReqUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_REQUEST_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -371,7 +318,7 @@ export const getStatefulSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'ss_name',
-											key: k8sStatefulSetNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -400,7 +347,7 @@ export const getStatefulSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'cpu_limit_util',
-								key: k8sPodCpuLimitUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_LIMIT_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -414,7 +361,7 @@ export const getStatefulSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'ss_name',
-											key: k8sStatefulSetNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -463,7 +410,7 @@ export const getStatefulSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'mem_usage',
-								key: k8sPodMemUsageKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_USAGE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -477,7 +424,7 @@ export const getStatefulSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'ss_name',
-											key: k8sStatefulSetNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -506,7 +453,7 @@ export const getStatefulSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'mem_request',
-								key: k8sContainerMemRequestKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_MEMORY_REQUEST,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -520,7 +467,7 @@ export const getStatefulSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'pod_name',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: 'contains',
@@ -549,7 +496,7 @@ export const getStatefulSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'mem_limit',
-								key: k8sContainerMemLimitKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_CONTAINER_MEMORY_LIMIT,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'latest',
@@ -563,7 +510,7 @@ export const getStatefulSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'pod_name',
-											key: k8sPodNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 											type: 'tag',
 										},
 										op: 'contains',
@@ -612,7 +559,7 @@ export const getStatefulSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'mem_req_util',
-								key: k8sPodMemReqUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_REQUEST_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -626,7 +573,7 @@ export const getStatefulSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'ss_name',
-											key: k8sStatefulSetNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -655,7 +602,7 @@ export const getStatefulSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'mem_limit_util',
-								key: k8sPodMemLimitUtilKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_LIMIT_UTILIZATION,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -669,7 +616,7 @@ export const getStatefulSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'ss_name',
-											key: k8sStatefulSetNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -718,7 +665,7 @@ export const getStatefulSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'net_io',
-								key: k8sPodNetworkIoKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_IO,
 								type: 'Sum',
 							},
 							aggregateOperator: 'rate',
@@ -732,7 +679,7 @@ export const getStatefulSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'ss_name',
-											key: k8sStatefulSetNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -794,7 +741,7 @@ export const getStatefulSetMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'net_err',
-								key: k8sPodNetworkErrorsKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NETWORK_ERRORS,
 								type: 'Sum',
 							},
 							aggregateOperator: 'increase',
@@ -808,7 +755,7 @@ export const getStatefulSetMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'ss_name',
-											key: k8sStatefulSetNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -867,15 +814,10 @@ export const getStatefulSetPodMetricsQueryPayload = (
 	statefulSet: InframonitoringtypesStatefulSetRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ): GetQueryResultsProps[] => {
-	const k8sStatefulSetNameKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME
-		: 'k8s_statefulset_name';
-
 	return getPodUtilizationByPodQueryPayloads(
 		{
-			workloadNameKey: k8sStatefulSetNameKey,
+			workloadNameKey: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 			workloadNameValue:
 				statefulSet.meta?.[INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME] ?? '',
 			clusterName:
@@ -885,6 +827,5 @@ export const getStatefulSetPodMetricsQueryPayload = (
 		},
 		start,
 		end,
-		dotMetricsEnabled,
 	);
 };

--- a/frontend/src/container/InfraMonitoringK8sV2/Volumes/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Volumes/constants.ts
@@ -97,36 +97,7 @@ export const getVolumeMetricsQueryPayload = (
 	volume: InframonitoringtypesVolumeRecordDTO,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ): GetQueryResultsProps[] => {
-	const k8sClusterNameKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME
-		: 'k8s_cluster_name';
-	const k8sNamespaceNameKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME
-		: 'k8s_namespace_name';
-	const k8sVolumeAvailableKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_AVAILABLE
-		: 'k8s_volume_available';
-	const k8sVolumeCapacityKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_CAPACITY
-		: 'k8s_volume_capacity';
-	const k8sVolumeInodesUsedKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_INODES_USED
-		: 'k8s_volume_inodes_used';
-	const k8sVolumeInodesKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_INODES
-		: 'k8s_volume_inodes';
-	const k8sVolumeInodesFreeKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_INODES_FREE
-		: 'k8s_volume_inodes_free';
-	const k8sVolumeTypeKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_TYPE
-		: 'k8s_volume_type';
-	const k8sPVCNameKey = dotMetricsEnabled
-		? INFRA_MONITORING_ATTR_KEYS.K8S_PERSISTENT_VOLUME_CLAIM_NAME
-		: 'k8s_persistentvolumeclaim_name';
-
 	return [
 		{
 			selectedTime: 'GLOBAL_TIME',
@@ -138,7 +109,7 @@ export const getVolumeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_volume_available--float64--Gauge--true',
-								key: k8sVolumeAvailableKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_AVAILABLE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -152,7 +123,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -164,7 +135,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: 'in',
@@ -177,7 +148,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_volume_type--string--tag--false',
-											key: k8sVolumeTypeKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_TYPE,
 											type: 'tag',
 										},
 										op: 'in',
@@ -188,7 +159,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_persistentvolumeclaim_name--string--tag--false',
-											key: k8sPVCNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_PERSISTENT_VOLUME_CLAIM_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -233,7 +204,7 @@ export const getVolumeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_volume_capacity--float64--Gauge--true',
-								key: k8sVolumeCapacityKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_CAPACITY,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -247,7 +218,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -259,7 +230,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: 'in',
@@ -272,7 +243,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_volume_type--string--tag--false',
-											key: k8sVolumeTypeKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_TYPE,
 											type: 'tag',
 										},
 										op: 'in',
@@ -283,7 +254,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_persistentvolumeclaim_name--string--tag--false',
-											key: k8sPVCNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_PERSISTENT_VOLUME_CLAIM_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -328,7 +299,7 @@ export const getVolumeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_volume_inodes_used--float64--Gauge--true',
-								key: k8sVolumeInodesUsedKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_INODES_USED,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -342,7 +313,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -354,7 +325,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: 'in',
@@ -367,7 +338,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_volume_type--string--tag--false',
-											key: k8sVolumeTypeKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_TYPE,
 											type: 'tag',
 										},
 										op: 'in',
@@ -378,7 +349,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_persistentvolumeclaim_name--string--tag--false',
-											key: k8sPVCNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_PERSISTENT_VOLUME_CLAIM_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -423,7 +394,7 @@ export const getVolumeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_volume_inodes--float64--Gauge--true',
-								key: k8sVolumeInodesKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_INODES,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -437,7 +408,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -449,7 +420,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: 'in',
@@ -462,7 +433,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_volume_type--string--tag--false',
-											key: k8sVolumeTypeKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_TYPE,
 											type: 'tag',
 										},
 										op: 'in',
@@ -473,7 +444,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_persistentvolumeclaim_name--string--tag--false',
-											key: k8sPVCNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_PERSISTENT_VOLUME_CLAIM_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -518,7 +489,7 @@ export const getVolumeMetricsQueryPayload = (
 							aggregateAttribute: {
 								dataType: DataTypes.Float64,
 								id: 'k8s_volume_inodes_free--float64--Gauge--true',
-								key: k8sVolumeInodesFreeKey,
+								key: INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_INODES_FREE,
 								type: 'Gauge',
 							},
 							aggregateOperator: 'avg',
@@ -532,7 +503,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_cluster_name--string--tag--false',
-											key: k8sClusterNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 											type: 'tag',
 										},
 										op: '=',
@@ -544,7 +515,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_namespace_name--string--tag--false',
-											key: k8sNamespaceNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 											type: 'tag',
 										},
 										op: 'in',
@@ -557,7 +528,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_volume_type--string--tag--false',
-											key: k8sVolumeTypeKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_TYPE,
 											type: 'tag',
 										},
 										op: 'in',
@@ -568,7 +539,7 @@ export const getVolumeMetricsQueryPayload = (
 										key: {
 											dataType: DataTypes.String,
 											id: 'k8s_persistentvolumeclaim_name--string--tag--false',
-											key: k8sPVCNameKey,
+											key: INFRA_MONITORING_ATTR_KEYS.K8S_PERSISTENT_VOLUME_CLAIM_NAME,
 											type: 'tag',
 										},
 										op: '=',

--- a/frontend/src/container/InfraMonitoringK8sV2/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/constants.ts
@@ -61,6 +61,10 @@ export const INFRA_MONITORING_ATTR_KEYS = {
 	K8S_CONTAINER_CPU_LIMIT: 'k8s.container.cpu_limit',
 	K8S_CONTAINER_MEMORY_REQUEST: 'k8s.container.memory_request',
 	K8S_CONTAINER_MEMORY_LIMIT: 'k8s.container.memory_limit',
+	CONTAINER_CPU_USAGE: 'container.cpu.usage',
+	CONTAINER_MEMORY_USAGE: 'container.memory.usage',
+	CONTAINER_MEMORY_WORKING_SET: 'container.memory.working_set',
+	CONTAINER_MEMORY_RSS: 'container.memory.rss',
 
 	// Deployment
 	K8S_DEPLOYMENT_NAME: 'k8s.deployment.name',
@@ -109,6 +113,10 @@ export const INFRA_MONITORING_ATTR_KEYS = {
 
 	// Environment
 	DEPLOYMENT_ENVIRONMENT: 'deployment.environment',
+
+	// Host System
+	OS_TYPE: 'os.type',
+	SYSTEM_CPU_LOAD_AVERAGE_15M: 'system.cpu.load_average.15m',
 } as const;
 
 export const DEFAULT_PAGE_SIZE = 10;
@@ -159,81 +167,48 @@ export const K8sCategories = {
 	VOLUMES: 'volumes',
 };
 
-const underscoreMap = {
-	[InfraMonitoringEntity.HOSTS]: 'system_cpu_load_average_15m',
-	[InfraMonitoringEntity.PODS]: 'k8s_pod_cpu_usage',
-	[InfraMonitoringEntity.NODES]: 'k8s_node_cpu_usage',
-	[InfraMonitoringEntity.NAMESPACES]: 'k8s_pod_cpu_usage',
-	[InfraMonitoringEntity.CLUSTERS]: 'k8s_node_cpu_usage',
-	[InfraMonitoringEntity.DEPLOYMENTS]: 'k8s_pod_cpu_usage',
-	[InfraMonitoringEntity.STATEFULSETS]: 'k8s_pod_cpu_usage',
-	[InfraMonitoringEntity.DAEMONSETS]: 'k8s_pod_cpu_usage',
-	[InfraMonitoringEntity.CONTAINERS]: 'k8s_pod_cpu_usage',
-	[InfraMonitoringEntity.JOBS]: 'k8s_job_desired_successful_pods',
-	[InfraMonitoringEntity.VOLUMES]: 'k8s_volume_capacity',
-};
-
 const dotMap = {
-	[InfraMonitoringEntity.HOSTS]: 'system.cpu.load_average.15m',
-	[InfraMonitoringEntity.PODS]: 'k8s.pod.cpu.usage',
-	[InfraMonitoringEntity.NODES]: 'k8s.node.cpu.usage',
-	[InfraMonitoringEntity.NAMESPACES]: 'k8s.pod.cpu.usage',
-	[InfraMonitoringEntity.CLUSTERS]: 'k8s.node.cpu.usage',
-	[InfraMonitoringEntity.DEPLOYMENTS]: 'k8s.pod.cpu.usage',
-	[InfraMonitoringEntity.STATEFULSETS]: 'k8s.pod.cpu.usage',
-	[InfraMonitoringEntity.DAEMONSETS]: 'k8s.pod.cpu.usage',
-	[InfraMonitoringEntity.CONTAINERS]: 'k8s.pod.cpu.usage',
-	[InfraMonitoringEntity.JOBS]: 'k8s.job.desired_successful_pods',
-	[InfraMonitoringEntity.VOLUMES]: 'k8s.volume.capacity',
+	[InfraMonitoringEntity.HOSTS]:
+		INFRA_MONITORING_ATTR_KEYS.SYSTEM_CPU_LOAD_AVERAGE_15M,
+	[InfraMonitoringEntity.PODS]: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
+	[InfraMonitoringEntity.NODES]: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CPU_USAGE,
+	[InfraMonitoringEntity.NAMESPACES]:
+		INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
+	[InfraMonitoringEntity.CLUSTERS]:
+		INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CPU_USAGE,
+	[InfraMonitoringEntity.DEPLOYMENTS]:
+		INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
+	[InfraMonitoringEntity.STATEFULSETS]:
+		INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
+	[InfraMonitoringEntity.DAEMONSETS]:
+		INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
+	[InfraMonitoringEntity.CONTAINERS]:
+		INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
+	[InfraMonitoringEntity.JOBS]:
+		INFRA_MONITORING_ATTR_KEYS.K8S_JOB_DESIRED_SUCCESSFUL_PODS,
+	[InfraMonitoringEntity.VOLUMES]:
+		INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_CAPACITY,
 };
 
 export function GetK8sEntityToAggregateAttribute(
 	category: InfraMonitoringEntity,
-	dotMetricsEnabled: boolean,
 ): string {
-	return dotMetricsEnabled ? dotMap[category] : underscoreMap[category];
+	return dotMap[category];
 }
 
-export function GetPodsQuickFiltersConfig(
-	dotMetricsEnabled: boolean,
-): IQuickFiltersConfig[] {
-	const podKey = dotMetricsEnabled ? 'k8s.pod.name' : 'k8s_pod_name';
-	const namespaceKey = dotMetricsEnabled
-		? 'k8s.namespace.name'
-		: 'k8s_namespace_name';
-	const nodeKey = dotMetricsEnabled ? 'k8s.node.name' : 'k8s_node_name';
-	const clusterKey = dotMetricsEnabled ? 'k8s.cluster.name' : 'k8s_cluster_name';
-	const deploymentKey = dotMetricsEnabled
-		? 'k8s.deployment.name'
-		: 'k8s_deployment_name';
-	const statefulsetKey = dotMetricsEnabled
-		? 'k8s.statefulset.name'
-		: 'k8s_statefulset_name';
-	const daemonsetKey = dotMetricsEnabled
-		? 'k8s.daemonset.name'
-		: 'k8s_daemonset_name';
-	const jobKey = dotMetricsEnabled ? 'k8s.job.name' : 'k8s_job_name';
-	const environmentKey = dotMetricsEnabled
-		? 'deployment.environment'
-		: 'deployment_environment';
-
-	// Define aggregate attribute (metric) name
-	const cpuUtilizationMetric = dotMetricsEnabled
-		? 'k8s.pod.cpu.usage'
-		: 'k8s_pod_cpu_usage';
-
+export function GetPodsQuickFiltersConfig(): IQuickFiltersConfig[] {
 	return [
 		{
 			type: FiltersType.CHECKBOX,
 			title: 'Pod',
 			attributeKey: {
-				key: podKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 				dataType: DataTypes.String,
 				type: 'tag',
-				id: `${podKey}--string--tag--true`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME}--string--tag--true`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: cpuUtilizationMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -241,13 +216,13 @@ export function GetPodsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Namespace',
 			attributeKey: {
-				key: namespaceKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${namespaceKey}--string--resource--false`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME}--string--resource--false`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: cpuUtilizationMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: false,
 		},
@@ -255,13 +230,13 @@ export function GetPodsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Node',
 			attributeKey: {
-				key: nodeKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${nodeKey}--string--resource--false`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME}--string--resource--false`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: cpuUtilizationMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: false,
 		},
@@ -269,13 +244,13 @@ export function GetPodsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Cluster',
 			attributeKey: {
-				key: clusterKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${clusterKey}--string--resource--false`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME}--string--resource--false`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: cpuUtilizationMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: false,
 		},
@@ -283,13 +258,13 @@ export function GetPodsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Deployment',
 			attributeKey: {
-				key: deploymentKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${deploymentKey}--string--resource--false`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME}--string--resource--false`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: cpuUtilizationMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: false,
 		},
@@ -297,13 +272,13 @@ export function GetPodsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Statefulset',
 			attributeKey: {
-				key: statefulsetKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${statefulsetKey}--string--resource--false`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME}--string--resource--false`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: cpuUtilizationMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: false,
 		},
@@ -311,13 +286,13 @@ export function GetPodsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'DaemonSet',
 			attributeKey: {
-				key: daemonsetKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${daemonsetKey}--string--resource--false`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME}--string--resource--false`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: cpuUtilizationMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: false,
 		},
@@ -325,13 +300,13 @@ export function GetPodsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Job',
 			attributeKey: {
-				key: jobKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_JOB_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${jobKey}--string--resource--false`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_JOB_NAME}--string--resource--false`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: cpuUtilizationMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: false,
 		},
@@ -339,7 +314,7 @@ export function GetPodsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Environment',
 			attributeKey: {
-				key: environmentKey,
+				key: INFRA_MONITORING_ATTR_KEYS.DEPLOYMENT_ENVIRONMENT,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
@@ -348,33 +323,19 @@ export function GetPodsQuickFiltersConfig(
 	];
 }
 
-export function GetNodesQuickFiltersConfig(
-	dotMetricsEnabled: boolean,
-): IQuickFiltersConfig[] {
-	// Define attribute keys
-	const nodeKey = dotMetricsEnabled ? 'k8s.node.name' : 'k8s_node_name';
-	const clusterKey = dotMetricsEnabled ? 'k8s.cluster.name' : 'k8s_cluster_name';
-
-	// Define aggregate metric name for node CPU utilization
-	const cpuUtilMetric = dotMetricsEnabled
-		? 'k8s.node.cpu.usage'
-		: 'k8s_node_cpu_usage';
-	const environmentKey = dotMetricsEnabled
-		? 'deployment.environment'
-		: 'deployment_environment';
-
+export function GetNodesQuickFiltersConfig(): IQuickFiltersConfig[] {
 	return [
 		{
 			type: FiltersType.CHECKBOX,
 			title: 'Node Name',
 			attributeKey: {
-				key: nodeKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${nodeKey}--string--resource--true`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME}--string--resource--true`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: cpuUtilMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -382,13 +343,13 @@ export function GetNodesQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Cluster Name',
 			attributeKey: {
-				key: clusterKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${clusterKey}--string--resource--true`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME}--string--resource--true`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: cpuUtilMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -396,7 +357,7 @@ export function GetNodesQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Environment',
 			attributeKey: {
-				key: environmentKey,
+				key: INFRA_MONITORING_ATTR_KEYS.DEPLOYMENT_ENVIRONMENT,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
@@ -405,32 +366,19 @@ export function GetNodesQuickFiltersConfig(
 	];
 }
 
-export function GetNamespaceQuickFiltersConfig(
-	dotMetricsEnabled: boolean,
-): IQuickFiltersConfig[] {
-	const namespaceKey = dotMetricsEnabled
-		? 'k8s.namespace.name'
-		: 'k8s_namespace_name';
-	const clusterKey = dotMetricsEnabled ? 'k8s.cluster.name' : 'k8s_cluster_name';
-	const cpuUtilMetric = dotMetricsEnabled
-		? 'k8s.pod.cpu.usage'
-		: 'k8s_pod_cpu_usage';
-	const environmentKey = dotMetricsEnabled
-		? 'deployment.environment'
-		: 'deployment_environment';
-
+export function GetNamespaceQuickFiltersConfig(): IQuickFiltersConfig[] {
 	return [
 		{
 			type: FiltersType.CHECKBOX,
 			title: 'Namespace Name',
 			attributeKey: {
-				key: namespaceKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${namespaceKey}--string--resource`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME}--string--resource`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: cpuUtilMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -438,13 +386,13 @@ export function GetNamespaceQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Cluster Name',
 			attributeKey: {
-				key: clusterKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${clusterKey}--string--resource`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME}--string--resource`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: cpuUtilMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -452,7 +400,7 @@ export function GetNamespaceQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Environment',
 			attributeKey: {
-				key: environmentKey,
+				key: INFRA_MONITORING_ATTR_KEYS.DEPLOYMENT_ENVIRONMENT,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
@@ -461,29 +409,19 @@ export function GetNamespaceQuickFiltersConfig(
 	];
 }
 
-export function GetClustersQuickFiltersConfig(
-	dotMetricsEnabled: boolean,
-): IQuickFiltersConfig[] {
-	const clusterKey = dotMetricsEnabled ? 'k8s.cluster.name' : 'k8s_cluster_name';
-	const cpuUtilMetric = dotMetricsEnabled
-		? 'k8s.node.cpu.usage'
-		: 'k8s_node_cpu_usage';
-	const environmentKey = dotMetricsEnabled
-		? 'deployment.environment'
-		: 'deployment_environment';
-
+export function GetClustersQuickFiltersConfig(): IQuickFiltersConfig[] {
 	return [
 		{
 			type: FiltersType.CHECKBOX,
 			title: 'Cluster Name',
 			attributeKey: {
-				key: clusterKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${clusterKey}--string--resource`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME}--string--resource`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: cpuUtilMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -491,7 +429,7 @@ export function GetClustersQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Environment',
 			attributeKey: {
-				key: environmentKey,
+				key: INFRA_MONITORING_ATTR_KEYS.DEPLOYMENT_ENVIRONMENT,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
@@ -500,35 +438,19 @@ export function GetClustersQuickFiltersConfig(
 	];
 }
 
-export function GetVolumesQuickFiltersConfig(
-	dotMetricsEnabled: boolean,
-): IQuickFiltersConfig[] {
-	const pvcKey = dotMetricsEnabled
-		? 'k8s.persistentvolumeclaim.name'
-		: 'k8s_persistentvolumeclaim_name';
-	const namespaceKey = dotMetricsEnabled
-		? 'k8s.namespace.name'
-		: 'k8s_namespace_name';
-	const clusterKey = dotMetricsEnabled ? 'k8s.cluster.name' : 'k8s_cluster_name';
-	const volumeMetric = dotMetricsEnabled
-		? 'k8s.volume.capacity'
-		: 'k8s_volume_capacity';
-	const environmentKey = dotMetricsEnabled
-		? 'deployment.environment'
-		: 'deployment_environment';
-
+export function GetVolumesQuickFiltersConfig(): IQuickFiltersConfig[] {
 	return [
 		{
 			type: FiltersType.CHECKBOX,
 			title: 'PVC Volume Claim Name',
 			attributeKey: {
-				key: pvcKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_PERSISTENT_VOLUME_CLAIM_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${pvcKey}--string--resource`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_PERSISTENT_VOLUME_CLAIM_NAME}--string--resource`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: volumeMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_CAPACITY,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -536,13 +458,13 @@ export function GetVolumesQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Namespace Name',
 			attributeKey: {
-				key: namespaceKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${namespaceKey}--string--resource`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME}--string--resource`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: volumeMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_CAPACITY,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -550,13 +472,13 @@ export function GetVolumesQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Cluster Name',
 			attributeKey: {
-				key: clusterKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${clusterKey}--string--resource`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME}--string--resource`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: volumeMetric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_VOLUME_CAPACITY,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -564,7 +486,7 @@ export function GetVolumesQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Environment',
 			attributeKey: {
-				key: environmentKey,
+				key: INFRA_MONITORING_ATTR_KEYS.DEPLOYMENT_ENVIRONMENT,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
@@ -573,33 +495,19 @@ export function GetVolumesQuickFiltersConfig(
 	];
 }
 
-export function GetDeploymentsQuickFiltersConfig(
-	dotMetricsEnabled: boolean,
-): IQuickFiltersConfig[] {
-	const deployKey = dotMetricsEnabled
-		? 'k8s.deployment.name'
-		: 'k8s_deployment_name';
-	const namespaceKey = dotMetricsEnabled
-		? 'k8s.namespace.name'
-		: 'k8s_namespace_name';
-	const clusterKey = dotMetricsEnabled ? 'k8s.cluster.name' : 'k8s_cluster_name';
-	const metric = dotMetricsEnabled ? 'k8s.pod.cpu.usage' : 'k8s_pod_cpu_usage';
-	const environmentKey = dotMetricsEnabled
-		? 'deployment.environment'
-		: 'deployment_environment';
-
+export function GetDeploymentsQuickFiltersConfig(): IQuickFiltersConfig[] {
 	return [
 		{
 			type: FiltersType.CHECKBOX,
 			title: 'Deployment Name',
 			attributeKey: {
-				key: deployKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${deployKey}--string--resource`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_DEPLOYMENT_NAME}--string--resource`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -607,13 +515,13 @@ export function GetDeploymentsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Namespace Name',
 			attributeKey: {
-				key: namespaceKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${namespaceKey}--string--resource`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME}--string--resource`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -621,13 +529,13 @@ export function GetDeploymentsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Cluster Name',
 			attributeKey: {
-				key: clusterKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${clusterKey}--string--resource`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME}--string--resource`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -635,7 +543,7 @@ export function GetDeploymentsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Environment',
 			attributeKey: {
-				key: environmentKey,
+				key: INFRA_MONITORING_ATTR_KEYS.DEPLOYMENT_ENVIRONMENT,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
@@ -644,33 +552,19 @@ export function GetDeploymentsQuickFiltersConfig(
 	];
 }
 
-export function GetStatefulsetsQuickFiltersConfig(
-	dotMetricsEnabled: boolean,
-): IQuickFiltersConfig[] {
-	const ssKey = dotMetricsEnabled
-		? 'k8s.statefulset.name'
-		: 'k8s_statefulset_name';
-	const namespaceKey = dotMetricsEnabled
-		? 'k8s.namespace.name'
-		: 'k8s_namespace_name';
-	const clusterKey = dotMetricsEnabled ? 'k8s.cluster.name' : 'k8s_cluster_name';
-	const metric = dotMetricsEnabled ? 'k8s.pod.cpu.usage' : 'k8s_pod_cpu_usage';
-	const environmentKey = dotMetricsEnabled
-		? 'deployment.environment'
-		: 'deployment_environment';
-
+export function GetStatefulsetsQuickFiltersConfig(): IQuickFiltersConfig[] {
 	return [
 		{
 			type: FiltersType.CHECKBOX,
 			title: 'Statefulset Name',
 			attributeKey: {
-				key: ssKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${ssKey}--string--resource`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_STATEFULSET_NAME}--string--resource`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -678,13 +572,13 @@ export function GetStatefulsetsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Namespace Name',
 			attributeKey: {
-				key: namespaceKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${namespaceKey}--string--resource`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME}--string--resource`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -692,13 +586,13 @@ export function GetStatefulsetsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Cluster Name',
 			attributeKey: {
-				key: clusterKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${clusterKey}--string--resource`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME}--string--resource`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metric,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -706,7 +600,7 @@ export function GetStatefulsetsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Environment',
 			attributeKey: {
-				key: environmentKey,
+				key: INFRA_MONITORING_ATTR_KEYS.DEPLOYMENT_ENVIRONMENT,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
@@ -715,35 +609,19 @@ export function GetStatefulsetsQuickFiltersConfig(
 	];
 }
 
-export function GetDaemonsetsQuickFiltersConfig(
-	dotMetricsEnabled: boolean,
-): IQuickFiltersConfig[] {
-	const nameKey = dotMetricsEnabled
-		? 'k8s.daemonset.name'
-		: 'k8s_daemonset_name';
-	const namespaceKey = dotMetricsEnabled
-		? 'k8s.namespace.name'
-		: 'k8s_namespace_name';
-	const clusterKey = dotMetricsEnabled ? 'k8s.cluster.name' : 'k8s_cluster_name';
-	const metricName = dotMetricsEnabled
-		? 'k8s.pod.cpu.usage'
-		: 'k8s_pod_cpu_usage';
-	const environmentKey = dotMetricsEnabled
-		? 'deployment.environment'
-		: 'deployment_environment';
-
+export function GetDaemonsetsQuickFiltersConfig(): IQuickFiltersConfig[] {
 	return [
 		{
 			type: FiltersType.CHECKBOX,
 			title: 'DaemonSet Name',
 			attributeKey: {
-				key: nameKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${nameKey}--string--resource--true`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_DAEMONSET_NAME}--string--resource--true`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metricName,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -751,12 +629,12 @@ export function GetDaemonsetsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Namespace Name',
 			attributeKey: {
-				key: namespaceKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metricName,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -764,12 +642,12 @@ export function GetDaemonsetsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Cluster Name',
 			attributeKey: {
-				key: clusterKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metricName,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -777,7 +655,7 @@ export function GetDaemonsetsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Environment',
 			attributeKey: {
-				key: environmentKey,
+				key: INFRA_MONITORING_ATTR_KEYS.DEPLOYMENT_ENVIRONMENT,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
@@ -786,33 +664,19 @@ export function GetDaemonsetsQuickFiltersConfig(
 	];
 }
 
-export function GetJobsQuickFiltersConfig(
-	dotMetricsEnabled: boolean,
-): IQuickFiltersConfig[] {
-	const nameKey = dotMetricsEnabled ? 'k8s.job.name' : 'k8s_job_name';
-	const namespaceKey = dotMetricsEnabled
-		? 'k8s.namespace.name'
-		: 'k8s_namespace_name';
-	const clusterKey = dotMetricsEnabled ? 'k8s.cluster.name' : 'k8s_cluster_name';
-	const metricName = dotMetricsEnabled
-		? 'k8s.pod.cpu.usage'
-		: 'k8s_pod_cpu_usage';
-	const environmentKey = dotMetricsEnabled
-		? 'deployment.environment'
-		: 'deployment_environment';
-
+export function GetJobsQuickFiltersConfig(): IQuickFiltersConfig[] {
 	return [
 		{
 			type: FiltersType.CHECKBOX,
 			title: 'Job Name',
 			attributeKey: {
-				key: nameKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_JOB_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
-				id: `${nameKey}--string--resource--true`,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_JOB_NAME}--string--resource--true`,
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metricName,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -820,12 +684,12 @@ export function GetJobsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Namespace Name',
 			attributeKey: {
-				key: namespaceKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metricName,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -833,12 +697,12 @@ export function GetJobsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Cluster Name',
 			attributeKey: {
-				key: clusterKey,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
 			aggregateOperator: 'noop',
-			aggregateAttribute: metricName,
+			aggregateAttribute: INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_USAGE,
 			dataSource: DataSource.METRICS,
 			defaultOpen: true,
 		},
@@ -846,7 +710,7 @@ export function GetJobsQuickFiltersConfig(
 			type: FiltersType.CHECKBOX,
 			title: 'Environment',
 			attributeKey: {
-				key: environmentKey,
+				key: INFRA_MONITORING_ATTR_KEYS.DEPLOYMENT_ENVIRONMENT,
 				dataType: DataTypes.String,
 				type: 'resource',
 			},
@@ -965,39 +829,7 @@ export function getPodUtilizationByPodQueryPayloads(
 	context: WorkloadFilterContext,
 	start: number,
 	end: number,
-	dotMetricsEnabled: boolean,
 ): GetQueryResultsProps[] {
-	const getKey = (dotKey: string, underscoreKey: string): string =>
-		dotMetricsEnabled ? dotKey : underscoreKey;
-
-	const k8sPodCpuLimitUtilKey = getKey(
-		'k8s.pod.cpu_limit_utilization',
-		'k8s_pod_cpu_limit_utilization',
-	);
-	const k8sPodCpuRequestUtilKey = getKey(
-		'k8s.pod.cpu_request_utilization',
-		'k8s_pod_cpu_request_utilization',
-	);
-	const k8sPodMemLimitUtilKey = getKey(
-		'k8s.pod.memory_limit_utilization',
-		'k8s_pod_memory_limit_utilization',
-	);
-	const k8sPodMemRequestUtilKey = getKey(
-		'k8s.pod.memory_request_utilization',
-		'k8s_pod_memory_request_utilization',
-	);
-	const k8sPodFsUsageKey = getKey(
-		'k8s.pod.filesystem.usage',
-		'k8s_pod_filesystem_usage',
-	);
-	const k8sPodFsCapacityKey = getKey(
-		'k8s.pod.filesystem.capacity',
-		'k8s_pod_filesystem_capacity',
-	);
-	const k8sPodNameKey = getKey('k8s.pod.name', 'k8s_pod_name');
-	const k8sClusterNameKey = getKey('k8s.cluster.name', 'k8s_cluster_name');
-	const k8sNamespaceNameKey = getKey('k8s.namespace.name', 'k8s_namespace_name');
-
 	const baseFilters = [
 		{
 			id: 'workload',
@@ -1014,8 +846,8 @@ export function getPodUtilizationByPodQueryPayloads(
 			id: 'cluster',
 			key: {
 				dataType: DataTypes.String,
-				id: `${k8sClusterNameKey}--string--tag--false`,
-				key: k8sClusterNameKey,
+				id: `${INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME}--string--tag--false`,
+				key: INFRA_MONITORING_ATTR_KEYS.K8S_CLUSTER_NAME,
 				type: 'tag',
 			},
 			op: '=',
@@ -1027,8 +859,8 @@ export function getPodUtilizationByPodQueryPayloads(
 						id: 'namespace',
 						key: {
 							dataType: DataTypes.String,
-							id: `${k8sNamespaceNameKey}--string--tag--false`,
-							key: k8sNamespaceNameKey,
+							id: `${INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME}--string--tag--false`,
+							key: INFRA_MONITORING_ATTR_KEYS.K8S_NAMESPACE_NAME,
 							type: 'tag',
 						},
 						op: '=',
@@ -1041,8 +873,8 @@ export function getPodUtilizationByPodQueryPayloads(
 	const podNameGroupBy = [
 		{
 			dataType: DataTypes.String,
-			id: `${k8sPodNameKey}--string--tag--false`,
-			key: k8sPodNameKey,
+			id: `${INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME}--string--tag--false`,
+			key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME,
 			type: 'tag',
 		},
 	];
@@ -1074,7 +906,7 @@ export function getPodUtilizationByPodQueryPayloads(
 						functions: [],
 						groupBy: podNameGroupBy,
 						having: [],
-						legend: `{{${k8sPodNameKey}}}`,
+						legend: `{{${INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME}}}`,
 						limit: null,
 						orderBy: [],
 						queryName: 'A',
@@ -1108,7 +940,7 @@ export function getPodUtilizationByPodQueryPayloads(
 						aggregateAttribute: {
 							dataType: DataTypes.Float64,
 							id: 'fs_usage',
-							key: k8sPodFsUsageKey,
+							key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_FILESYSTEM_USAGE,
 							type: 'Gauge',
 						},
 						aggregateOperator: 'avg',
@@ -1122,7 +954,7 @@ export function getPodUtilizationByPodQueryPayloads(
 						functions: [],
 						groupBy: podNameGroupBy,
 						having: [],
-						legend: `{{${k8sPodNameKey}}}`,
+						legend: `{{${INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME}}}`,
 						limit: null,
 						orderBy: [],
 						queryName: 'A',
@@ -1135,7 +967,7 @@ export function getPodUtilizationByPodQueryPayloads(
 						aggregateAttribute: {
 							dataType: DataTypes.Float64,
 							id: 'fs_capacity',
-							key: k8sPodFsCapacityKey,
+							key: INFRA_MONITORING_ATTR_KEYS.K8S_POD_FILESYSTEM_CAPACITY,
 							type: 'Gauge',
 						},
 						aggregateOperator: 'avg',
@@ -1149,7 +981,7 @@ export function getPodUtilizationByPodQueryPayloads(
 						functions: [],
 						groupBy: podNameGroupBy,
 						having: [],
-						legend: `{{${k8sPodNameKey}}}`,
+						legend: `{{${INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME}}}`,
 						limit: null,
 						orderBy: [],
 						queryName: 'B',
@@ -1163,7 +995,7 @@ export function getPodUtilizationByPodQueryPayloads(
 					{
 						disabled: false,
 						expression: 'A/B',
-						legend: `{{${k8sPodNameKey}}}`,
+						legend: `{{${INFRA_MONITORING_ATTR_KEYS.K8S_POD_NAME}}}`,
 						queryName: 'F1',
 					},
 				],
@@ -1181,10 +1013,22 @@ export function getPodUtilizationByPodQueryPayloads(
 	};
 
 	return [
-		buildSingleMetricQuery(k8sPodCpuLimitUtilKey, 'cpu_limit_util'),
-		buildSingleMetricQuery(k8sPodCpuRequestUtilKey, 'cpu_request_util'),
-		buildSingleMetricQuery(k8sPodMemLimitUtilKey, 'mem_limit_util'),
-		buildSingleMetricQuery(k8sPodMemRequestUtilKey, 'mem_request_util'),
+		buildSingleMetricQuery(
+			INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_LIMIT_UTILIZATION,
+			'cpu_limit_util',
+		),
+		buildSingleMetricQuery(
+			INFRA_MONITORING_ATTR_KEYS.K8S_POD_CPU_REQUEST_UTILIZATION,
+			'cpu_request_util',
+		),
+		buildSingleMetricQuery(
+			INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_LIMIT_UTILIZATION,
+			'mem_limit_util',
+		),
+		buildSingleMetricQuery(
+			INFRA_MONITORING_ATTR_KEYS.K8S_POD_MEMORY_REQUEST_UTILIZATION,
+			'mem_request_util',
+		),
 		filesystemUsagePercentQuery,
 	];
 }


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

This removes the support for underscore metrics in favor to be only dot metrics always.

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/engineering-pod/issues/5762

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Infrastructure Monitoring V2
- Potential regressions: Wrong metric being mapped
- Rollback plan: Find and fix the issue specifically

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance |
| Description | We are cleaning the usages of underscore metrics and attributes used in the Infrastructure Monitoring since it was supported due to legacy reasons. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

By default, all the instances had this flag enabled, so we should not have any issue by removing this.