### PR TITLE
fix: show the backend error message in the error modal instead of a generic axios error

### DIFF
--- a/frontend/src/providers/ErrorModalProvider.test.tsx
+++ b/frontend/src/providers/ErrorModalProvider.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { useEffect } from 'react';
+import APIError from 'types/api/error';
+
+import { ErrorModalProvider, useErrorModal } from './ErrorModalProvider';
+
+// Mock the heavy modal so the test only asserts which error it receives.
+jest.mock('components/ErrorModal/ErrorModal', () => ({
+	__esModule: true,
+	default: ({ error }: { error: APIError }): JSX.Element => (
+		<div data-testid="error-message">{error.getErrorMessage()}</div>
+	),
+}));
+
+function Trigger({ error }: { error: unknown }): null {
+	const { showErrorModal } = useErrorModal();
+	useEffect(() => {
+		showErrorModal(error);
+	}, [error, showErrorModal]);
+	return null;
+}
+
+describe('ErrorModalProvider — showErrorModal', () => {
+	it('surfaces the backend error message from a raw AxiosError', () => {
+		const axiosError = {
+			isAxiosError: true,
+			response: {
+				status: 400,
+				data: {
+					error: {
+						code: 'tag_invalid_key',
+						message: 'tag key contains disallowed characters',
+						errors: [],
+					},
+				},
+			},
+		};
+		render(
+			<ErrorModalProvider>
+				<Trigger error={axiosError} />
+			</ErrorModalProvider>,
+		);
+		expect(screen.getByTestId('error-message')).toHaveTextContent(
+			'tag key contains disallowed characters',
+		);
+	});
+
+	it('passes an already-constructed APIError through unchanged', () => {
+		const apiError = new APIError({
+			httpStatusCode: 409,
+			error: { code: 'conflict', message: 'already exists', url: '', errors: [] },
+		});
+		render(
+			<ErrorModalProvider>
+				<Trigger error={apiError} />
+			</ErrorModalProvider>,
+		);
+		expect(screen.getByTestId('error-message')).toHaveTextContent(
+			'already exists',
+		);
+	});
+});

--- a/frontend/src/providers/ErrorModalProvider.tsx
+++ b/frontend/src/providers/ErrorModalProvider.tsx
@@ -8,11 +8,17 @@ import {
 	useMemo,
 	useState,
 } from 'react';
+import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
 import ErrorModal from 'components/ErrorModal/ErrorModal';
 import APIError from 'types/api/error';
 
 interface ErrorModalContextType {
-	showErrorModal: (error: APIError) => void;
+	/**
+	 * Accepts any thrown value. Generated-client calls reject with a raw
+	 * `AxiosError`, so we normalize to `APIError` here — otherwise the modal would
+	 * show a generic "status 400" instead of the backend's `error.message`.
+	 */
+	showErrorModal: (error: unknown) => void;
 	hideErrorModal: () => void;
 	isErrorModalVisible: boolean;
 }
@@ -29,8 +35,15 @@ export function ErrorModalProvider({
 	const [error, setError] = useState<APIError | null>(null);
 	const [isVisible, setIsVisible] = useState(false);
 
-	const showErrorModal = useCallback((error: APIError): void => {
-		setError(error);
+	const showErrorModal = useCallback((rawError: unknown): void => {
+		const apiError =
+			rawError instanceof APIError
+				? rawError
+				: convertToApiError(rawError as Parameters<typeof convertToApiError>[0]);
+		if (!apiError) {
+			return;
+		}
+		setError(apiError);
 		setIsVisible(true);
 	}, []);
 


### PR DESCRIPTION
## Summary

The error modal showed a generic `status 400` / network error instead of the backend's actual `error.message` (e.g. `tag key "…" contains disallowed characters`), across the V2 dashboards and anywhere else the modal is used.

**Root cause:** the generated API client's reject interceptor rejects with a raw `AxiosError` — it never converts to `APIError`. But nearly every caller does `showErrorModal(error as APIError)` (a false cast), so `ErrorModal` couldn't read the structured `error.message` and fell back to the generic message.

**Fix:** normalize once, centrally, in `ErrorModalProvider.showErrorModal` — accept `unknown`, pass an `APIError` through untouched, and run anything else through the existing `convertToApiError` (which extracts `response.data.error.{code,message,errors}`). Every `showErrorModal(error as APIError)` call site is corrected with no call-site changes; the casts are now merely redundant.

Intentionally central, so it fixes every `showErrorModal` caller app-wide, not just the dashboards where it was reported.

## Test plan
- `ErrorModalProvider.test.tsx`: a raw AxiosError surfaces `response.data.error.message`; an already-built `APIError` passes through unchanged.

> Split out of #12062 (which now carries only the tag-editor validation).
> Follow-up (converting generated errors to APIError at the interceptor) tracked in pulse-pod.
