### PR TITLE
feat(rules): make PromQL rule evaluation interval configurable

### DIFF
--- a/ee/query-service/rules/manager.go
+++ b/ee/query-service/rules/manager.go
@@ -61,6 +61,7 @@ func PrepareTaskFunc(opts baserules.PrepareTaskOptions) (baserules.Task, error) 
 			opts.Logger,
 			opts.ManagerOpts.Prometheus,
 			opts.ManagerOpts.Alertmanager.Config().ExternalURL,
+			baserules.WithEvalInterval(opts.ManagerOpts.EvalInterval),
 			baserules.WithSQLStore(opts.SQLStore),
 			baserules.WithQueryParser(opts.ManagerOpts.QueryParser),
 			baserules.WithMetadataStore(opts.ManagerOpts.MetadataStore),

--- a/pkg/query-service/rules/base_rule.go
+++ b/pkg/query-service/rules/base_rule.go
@@ -44,6 +44,9 @@ type BaseRule struct {
 	// this is useful in cases where the data is not available immediately
 	evalDelay valuer.TextDuration
 
+	// evalInterval is the step used for PromQL range queries
+	evalInterval valuer.TextDuration
+
 	// holds the static set of labels and annotations for the rule
 	// these are the same for all alerts created for this rule
 	labels      ruletypes.Labels
@@ -106,6 +109,12 @@ func WithSendUnmatched() RuleOption {
 func WithEvalDelay(dur valuer.TextDuration) RuleOption {
 	return func(r *BaseRule) {
 		r.evalDelay = dur
+	}
+}
+
+func WithEvalInterval(dur valuer.TextDuration) RuleOption {
+	return func(r *BaseRule) {
+		r.evalInterval = dur
 	}
 }
 
@@ -229,6 +238,10 @@ func (r *BaseRule) ActiveAlertsLabelFP() map[uint64]struct{} {
 
 func (r *BaseRule) EvalDelay() valuer.TextDuration {
 	return r.evalDelay
+}
+
+func (r *BaseRule) EvalInterval() valuer.TextDuration {
+	return r.evalInterval
 }
 
 func (r *BaseRule) EvalWindow() valuer.TextDuration {

--- a/pkg/query-service/rules/manager.go
+++ b/pkg/query-service/rules/manager.go
@@ -80,6 +80,10 @@ type ManagerOptions struct {
 
 	EvalDelay valuer.TextDuration
 
+	// EvalInterval is the step used for PromQL range queries inside
+	// PromRule. Defaults to 60s when zero so existing behavior is preserved.
+	EvalInterval valuer.TextDuration
+
 	RuleStateHistoryModule rulestatehistory.Module
 
 	PrepareTaskFunc     func(opts PrepareTaskOptions) (Task, error)
@@ -119,6 +123,9 @@ func defaultOptions(o *ManagerOptions) *ManagerOptions {
 	if o.ResendDelay == time.Duration(0) {
 		o.ResendDelay = 1 * time.Minute
 	}
+	if !o.EvalInterval.IsPositive() {
+		o.EvalInterval = valuer.MustParseTextDuration("60s")
+	}
 	if o.Logger == nil {
 		o.Logger = slog.Default()
 	}
@@ -152,6 +159,7 @@ func defaultPrepareTaskFunc(opts PrepareTaskOptions) (Task, error) {
 			opts.Logger,
 			opts.ManagerOpts.Alertmanager.Config().ExternalURL,
 			WithEvalDelay(opts.ManagerOpts.EvalDelay),
+			WithEvalInterval(opts.ManagerOpts.EvalInterval),
 			WithSQLStore(opts.SQLStore),
 			WithQueryParser(opts.ManagerOpts.QueryParser),
 			WithMetadataStore(opts.ManagerOpts.MetadataStore),

--- a/pkg/query-service/rules/prom_rule.go
+++ b/pkg/query-service/rules/prom_rule.go
@@ -92,7 +92,10 @@ func (r *PromRule) matrixToCommonSeries(res promql.Matrix) []*qbtypes.TimeSeries
 
 func (r *PromRule) buildAndRunQuery(ctx context.Context, ts time.Time) (ruletypes.Vector, error) {
 	start, end := r.Timestamps(ts)
-	interval := 60 * time.Second // TODO(srikanthccv): this should be configurable
+	interval := r.evalInterval.Duration()
+	if interval == 0 {
+		interval = 60 * time.Second
+	}
 
 	q, err := r.getPqlQuery(ctx)
 	if err != nil {

--- a/pkg/query-service/rules/prom_rule_test.go
+++ b/pkg/query-service/rules/prom_rule_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	pql "github.com/prometheus/prometheus/promql"
 	cmock "github.com/SigNoz/clickhouse-go-mock"
+	pql "github.com/prometheus/prometheus/promql"
 
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/prometheus"
@@ -1619,6 +1619,61 @@ func TestPromRule_NoData_AbsentFor(t *testing.T) {
 			assert.Equal(t, c.expectAlertOnEval2, alertsFound2)
 		})
 	}
+}
+
+func TestPromRuleEvalIntervalHonored(t *testing.T) {
+	newRule := func(name string, extraOpts ...RuleOption) *PromRule {
+		target := 1.0
+		rule := &ruletypes.PostableRule{
+			AlertName: name,
+			AlertType: ruletypes.AlertTypeMetric,
+			RuleType:  ruletypes.RuleTypeProm,
+			Evaluation: &ruletypes.EvaluationEnvelope{Kind: ruletypes.RollingEvaluation, Spec: ruletypes.RollingWindow{
+				EvalWindow: valuer.MustParseTextDuration("5m"),
+				Frequency:  valuer.MustParseTextDuration("1m"),
+			}},
+			RuleCondition: &ruletypes.RuleCondition{
+				CompositeQuery: &ruletypes.AlertCompositeQuery{
+					QueryType: ruletypes.QueryTypePromQL,
+					Queries: []qbtypes.QueryEnvelope{{
+						Type: qbtypes.QueryTypePromQL,
+						Spec: qbtypes.PromQuery{Query: "noop"},
+					}},
+				},
+				Thresholds: &ruletypes.RuleThresholdData{
+					Kind: ruletypes.BasicThresholdKind,
+					Spec: ruletypes.BasicRuleThresholds{{
+						Name:            name,
+						TargetValue:     &target,
+						MatchType:       ruletypes.AtleastOnce,
+						CompareOperator: ruletypes.ValueIsAbove,
+					}},
+				},
+			},
+		}
+
+		opts := append([]RuleOption(nil), extraOpts...)
+		pr, err := NewPromRule(
+			name,
+			valuer.GenerateUUID(),
+			rule,
+			instrumentationtest.New().Logger(),
+			nil,
+			mustParseURL(t, "http://localhost:8080"),
+			opts...,
+		)
+		require.NoError(t, err)
+		return pr
+	}
+
+	// Default: no option applied, field is zero so the buildAndRunQuery fallback
+	// of 60s applies.
+	defaultRule := newRule("default")
+	assert.Equal(t, valuer.TextDuration{}, defaultRule.EvalInterval(), "no option applied leaves the field zero so the engine fallback applies")
+
+	// With WithEvalInterval applied, the field is observable via the accessor.
+	customRule := newRule("custom", WithEvalInterval(valuer.MustParseTextDuration("5s")))
+	assert.Equal(t, 5*time.Second, customRule.EvalInterval().Duration(), "WithEvalInterval should set the field on the rule")
 }
 
 func TestPromRuleEval_RequireMinPoints(t *testing.T) {

--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -7,7 +7,8 @@ import (
 )
 
 type Config struct {
-	EvalDelay time.Duration `mapstructure:"eval_delay"`
+	EvalDelay    time.Duration `mapstructure:"eval_delay"`
+	EvalInterval time.Duration `mapstructure:"eval_interval"`
 }
 
 func NewConfigFactory() factory.ConfigFactory {
@@ -16,7 +17,8 @@ func NewConfigFactory() factory.ConfigFactory {
 
 func newConfig() factory.Config {
 	return Config{
-		EvalDelay: 2 * time.Minute,
+		EvalDelay:    2 * time.Minute,
+		EvalInterval: 60 * time.Second,
 	}
 }
 

--- a/pkg/ruler/signozruler/provider.go
+++ b/pkg/ruler/signozruler/provider.go
@@ -57,6 +57,7 @@ func NewFactory(
 			Logger:                 providerSettings.Logger,
 			Cache:                  cache,
 			EvalDelay:              valuer.MustParseTextDuration(config.EvalDelay.String()),
+			EvalInterval:           valuer.MustParseTextDuration(config.EvalInterval.String()),
 			PrepareTaskFunc:        prepareTaskFunc,
 			PrepareTestRuleFunc:    prepareTestRuleFunc,
 			Alertmanager:           alertmanager,


### PR DESCRIPTION
## Make PromQL rule evaluation interval configurable

Fixes #12217

### Summary

The PromQL range-query step used inside `PromRule.buildAndRunQuery` was a hard-coded `60 * time.Second` with a maintainer-tagged TODO asking for it to become configurable. This PR plumbs that value through the existing config surface so operators can tune it via `SIGNOZ_RULER_EVAL__INTERVAL`.

The default stays `60s`, so existing deployments behave identically.

### Changes

- `pkg/ruler/config.go`: add `EvalInterval time.Duration` with `mapstructure:"eval_interval"`, default `60s`.
- `pkg/ruler/signozruler/provider.go`: forward `config.EvalInterval` into `ManagerOptions.EvalInterval`.
- `pkg/query-service/rules/base_rule.go`: add `evalInterval` field, `WithEvalInterval` option, and `EvalInterval()` accessor on `BaseRule`.
- `pkg/query-service/rules/manager.go`: add `EvalInterval` to `ManagerOptions`, default to `60s` in `defaultOptions`, and pass it via `WithEvalInterval` when building `PromRule`.
- `pkg/query-service/rules/prom_rule.go`: read `r.evalInterval.Duration()` in `buildAndRunQuery`, with a `60s` fallback when zero.
- `ee/query-service/rules/manager.go`: pass `WithEvalInterval` in the EE `PrepareTaskFunc` for PromQL rules.
- `pkg/query-service/rules/prom_rule_test.go`: focused unit test covering the new option via the `EvalInterval()` accessor.

### Why this matters

The hard-coded step meant operators had no knob for the resolution-vs-compute trade-off. Short eval windows lose precision at the edges (range query collapses to a single step). Long eval windows can sample an awkward phase of low-frequency metrics. The TODO has been parked for a while; this finishes it using the same plumbing already in place for `eval_delay`.

### Verification

- `gofmt -l` on all touched files: clean.
- `go vet ./pkg/ruler/... ./pkg/query-service/rules/... ./ee/query-service/rules/...`: clean.
- `go build ./...`: clean.
- `go test ./pkg/query-service/rules/ -count=1 -race`: pass (incl. new `TestPromRuleEvalIntervalHonored`).
- `go test ./ee/query-service/rules/... -count=1 -race`: pass.
- `go test ./pkg/config/... -count=1 -race`: pass.

### Backward compatibility

None. The default value matches the previous hard-coded `60s`. Existing rule definitions do not change.

### Risks

Low. One constant moved from inline to config. Operators setting a very small value (e.g. `1s`) will see proportionally more PromQL query compute; that is a deliberate trade-off, not a regression.
