### PR TITLE
fix(tracefunnel): honour the requested latency percentile in step overview

### DIFF
--- a/pkg/modules/tracefunnel/clickhouse_queries.go
+++ b/pkg/modules/tracefunnel/clickhouse_queries.go
@@ -2,6 +2,7 @@ package tracefunnel
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -313,6 +314,36 @@ FROM (
 	)
 }
 
+// defaultLatencyQuantile is the quantile used when a step does not specify a
+// latency type, or specifies one that is not a valid percentile.
+const defaultLatencyQuantile = "0.99"
+
+// parseLatencyQuantile converts a percentile label such as "p50", "p90" or "p99"
+// into the 0-1 quantile literal expected by ClickHouse's quantileIf. It reports
+// false when latencyType is empty or is not a percentile in the (0, 100) range,
+// in which case callers should fall back to defaultLatencyQuantile.
+func parseLatencyQuantile(latencyType string) (string, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(latencyType))
+	if !strings.HasPrefix(normalized, "p") {
+		return "", false
+	}
+
+	digits := strings.TrimPrefix(normalized, "p")
+	percentile, err := strconv.ParseFloat(digits, 64)
+	if err != nil || !(percentile > 0 && percentile < 100) {
+		return "", false
+	}
+
+	// Two decimals keep p90/p95/p99 identical to the previously hardcoded values,
+	// while fractional percentiles such as "p99.9" get the precision they need.
+	precision := 2
+	if dot := strings.IndexByte(digits, '.'); dot >= 0 {
+		precision += len(digits) - dot - 1
+	}
+
+	return strconv.FormatFloat(percentile/100, 'f', precision, 64), true
+}
+
 // BuildFunnelStepOverviewQuery builds a step overview query for transitions between any specified steps.
 func BuildFunnelStepOverviewQuery(
 	steps []struct {
@@ -381,17 +412,9 @@ func BuildFunnelStepOverviewQuery(
 	}
 
 	// Determine latency quantile for the end step
-	latencyQuantile := "0.99"
-	if steps[endIdx].LatencyType != "" {
-		latency := strings.ToLower(steps[endIdx].LatencyType)
-		switch latency {
-		case "p90":
-			latencyQuantile = "0.90"
-		case "p95":
-			latencyQuantile = "0.95"
-		default:
-			latencyQuantile = "0.99"
-		}
+	latencyQuantile := defaultLatencyQuantile
+	if quantile, ok := parseLatencyQuantile(steps[endIdx].LatencyType); ok {
+		latencyQuantile = quantile
 	}
 
 	// Build conversion condition - all steps from start to end must be in order

--- a/pkg/modules/tracefunnel/clickhouse_queries_latency_test.go
+++ b/pkg/modules/tracefunnel/clickhouse_queries_latency_test.go
@@ -152,6 +152,48 @@ func TestBuildFunnelStepOverviewQuery_WithLatencyPointer(t *testing.T) {
 	}
 }
 
+func TestBuildFunnelStepOverviewQuery_WithLatencyType(t *testing.T) {
+	tests := []struct {
+		name         string
+		latencyType  string
+		wantContains string
+	}{
+		{name: "p50 maps to the median quantile", latencyType: "p50", wantContains: "quantileIf(0.50)"},
+		{name: "p75 maps to the 75th percentile", latencyType: "p75", wantContains: "quantileIf(0.75)"},
+		{name: "p90 maps to the 90th percentile", latencyType: "p90", wantContains: "quantileIf(0.90)"},
+		{name: "p95 maps to the 95th percentile", latencyType: "p95", wantContains: "quantileIf(0.95)"},
+		{name: "p99 maps to the 99th percentile", latencyType: "p99", wantContains: "quantileIf(0.99)"},
+		{name: "fractional percentile keeps its precision", latencyType: "p99.9", wantContains: "quantileIf(0.999)"},
+		{name: "uppercase percentile is accepted", latencyType: "P50", wantContains: "quantileIf(0.50)"},
+		{name: "empty latency type falls back to p99", latencyType: "", wantContains: "quantileIf(0.99)"},
+		{name: "unsupported latency type falls back to p99", latencyType: "median", wantContains: "quantileIf(0.99)"},
+		{name: "out of range percentile falls back to p99", latencyType: "p100", wantContains: "quantileIf(0.99)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			steps := []struct {
+				ServiceName    string
+				SpanName       string
+				ContainsError  int
+				LatencyPointer string
+				LatencyType    string
+				Clause         string
+			}{
+				{ServiceName: "service1", SpanName: "span1", ContainsError: 0, LatencyPointer: "start", LatencyType: "", Clause: ""},
+				{ServiceName: "service2", SpanName: "span2", ContainsError: 0, LatencyPointer: "start", LatencyType: tt.latencyType, Clause: ""},
+			}
+
+			query := BuildFunnelStepOverviewQuery(steps, 1000000000, 2000000000, 1, 2)
+
+			if !strings.Contains(query, tt.wantContains) {
+				t.Errorf("Query for latency_type %q missing expected content: %s", tt.latencyType, tt.wantContains)
+				t.Logf("Got query:\n%s", query)
+			}
+		})
+	}
+}
+
 func TestBuildFunnelTopSlowTracesQuery_WithLatencyPointer(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

`BuildFunnelStepOverviewQuery` picks the ClickHouse quantile for the funnel step-overview `latency` field from the end step's `latency_type`, but only `p90` and `p95` were implemented. Every other value — notably `p50` — fell through to `default` and was served the **p99** quantile under the requested label. That is silently wrong data rather than an error: a client asking for a median gets a tail number with no way to detect the substitution.

This PR replaces the two-case switch with a generic `pNN` parse, so any percentile a client sends maps to the quantile it names. Empty or unparseable `latency_type` keeps the existing `0.99` default, and `p90`/`p95`/`p99` produce byte-identical SQL to before (`0.90`/`0.95`/`0.99`), so no existing query output changes.

Parsing was chosen over a longer switch because `latency_type` is a free-form string on the public API (`pkg/types/tracefunneltypes/tracefunnel.go`), so any hardcoded list will keep silently mismapping whatever is not in it.

#### Screenshots / Screen Recordings (if applicable)

N/A — backend query construction; covered by unit tests on the generated SQL.

#### Issues closed by this PR

Closes #12220

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

Incomplete enumeration. The quantile selection in `BuildFunnelStepOverviewQuery` handled only two of the percentiles the API accepts:

```go
latencyQuantile := "0.99"
if steps[endIdx].LatencyType != "" {
	latency := strings.ToLower(steps[endIdx].LatencyType)
	switch latency {
	case "p90":
		latencyQuantile = "0.90"
	case "p95":
		latencyQuantile = "0.95"
	default:
		latencyQuantile = "0.99"
	}
}
```

`latency_type` is a plain `string` on `tracefunneltypes.FunnelStep` and is passed through `query.go` unvalidated, so the `default` branch is reachable with any client-supplied value. The result is `quantileIf(0.99)` in the emitted SQL while the caller believes it asked for something else.

#### Fix Strategy

Extract a `parseLatencyQuantile` helper that lowercases/trims the value, requires a `p` prefix, parses the numeric suffix, and rejects anything outside `(0, 100)`. It returns the quantile as a fixed-point literal with at least two decimals — which reproduces the previous `0.90`/`0.95`/`0.99` strings exactly, and gives fractional percentiles such as `p99.9` the precision they need. The call site falls back to a named `defaultLatencyQuantile` constant when the helper reports failure, preserving today's behavior for unset `latency_type`.

---

### 🧪 Testing Strategy

- **Tests added/updated:** new table-driven `TestBuildFunnelStepOverviewQuery_WithLatencyType` in `pkg/modules/tracefunnel/clickhouse_queries_latency_test.go`, asserting the emitted SQL for `p50` → `quantileIf(0.50)`, plus `p75`, `p90`, `p95`, `p99`, fractional `p99.9`, uppercase `P50`, and the three fallback paths (empty, non-percentile `median`, out-of-range `p100`) → `quantileIf(0.99)`.
- **Manual verification:** confirmed at the query-builder level — `BuildFunnelStepOverviewQuery` emits `quantileIf(0.99)` for a step with `LatencyType: "p50"` on `main`, and `quantileIf(0.50)` after this change. Also reproduced end-to-end on a self-hosted v0.132.2 deployment: varying only the end step's `latency_type` on a single funnel (60 traces) returned `p50` = `p99` = unset = 18.673343 ms, while `p90` = 17.963510 and `p95` = 18.011850 — i.e. the reported "median" came back *larger* than the p90 and p95 of the same distribution. Full table in the linked issue.
- **Edge cases covered:** empty string, non-percentile strings, out-of-range percentiles, `NaN`/`Inf`-style inputs (`pnan` is rejected by the `(0, 100)` range test rather than reaching the SQL), case-insensitivity, and fractional percentiles.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** one field (`latency`) of one endpoint, `/api/v1/trace-funnels/{id}/analytics/steps/overview`. No schema, API-surface, or frontend change.
- **Potential regressions:** minimal — the generated SQL is unchanged for every value the UI can currently produce (`p90`, `p95`, `p99`) and for unset `latency_type`. Behavior changes only for values that were previously mismapped.
- **Rollback plan:** revert the commit; no data or migration impact.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Trace Funnels step overview now returns the latency percentile that was requested. Previously any `latency_type` other than `p90`/`p95` — including `p50` — silently returned the p99 value. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The two-decimal formatting is deliberate: it keeps `p90`/`p95`/`p99` producing the exact strings the previous code hardcoded, so existing test expectations and query plans are untouched.
- **Out of scope, but worth a decision:** `BuildFunnelOverviewQuery` (the `/analytics/overview` sibling) hardcodes `quantileIf(0.99)` and has no `latency_type` knob at all, so the whole-funnel overview is always p99. I left it alone to keep this PR to the reported bug — happy to follow up if you'd like that endpoint to honour `latency_type` as well.
- The frontend `LatencyOptions` enum currently offers only `P99`/`P95`/`P90`, so this is not reachable from the UI today; it is reachable from the API, and it also unblocks adding `P50` to that enum without a backend change.

---