### PR TITLE
fix(alerts-v2): preserve loaded thresholds on edit-page refresh

### DIFF
--- a/frontend/src/container/CreateAlertV2/context/__tests__/CreateAlertProvider.prefill.test.tsx
+++ b/frontend/src/container/CreateAlertV2/context/__tests__/CreateAlertProvider.prefill.test.tsx
@@ -1,9 +1,11 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { MemoryRouter } from 'react-router-dom';
-import { render, screen } from '@testing-library/react';
+import { MemoryRouter, useHistory } from 'react-router-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { AlertTypes } from 'types/api/alerts/alertTypes';
 
+import { INITIAL_CREATE_ALERT_STATE } from '../constants';
 import { CreateAlertProvider, useCreateAlertState } from '../index';
+import { AlertThresholdMatchType } from '../types';
 
 // The provider only needs a query with a unit + empty builder for these assertions.
 jest.mock('hooks/queryBuilder/useQueryBuilder', () => ({
@@ -106,5 +108,69 @@ describe('CreateAlertProvider — URL-declared prefill (issue #5291)', () => {
 		expect(screen.getByTestId('match-type')).toHaveTextContent('in_total');
 		expect(screen.getByTestId('threshold-value')).toHaveTextContent('500');
 		expect(screen.getByTestId('window-type')).toHaveTextContent('cumulative');
+	});
+});
+
+// Reproduces the #12137 regression: on the alert overview page the query builder
+// rewrites location.search after the alert loads, which used to re-run the prefill
+// effect and RESET the loaded threshold back to 0.
+function SearchMutator(): JSX.Element {
+	const routerHistory = useHistory();
+	return (
+		<button
+			type="button"
+			data-testid="mutate-search"
+			onClick={(): void =>
+				routerHistory.replace(
+					'/alerts/overview?compositeQuery=normalized&ruleId=r1',
+				)
+			}
+		>
+			change search
+		</button>
+	);
+}
+
+describe('CreateAlertProvider — edit mode ignores URL prefill', () => {
+	it('keeps loaded thresholds when the query builder rewrites location.search', () => {
+		const initialAlertState = {
+			...INITIAL_CREATE_ALERT_STATE,
+			threshold: {
+				...INITIAL_CREATE_ALERT_STATE.threshold,
+				matchType: AlertThresholdMatchType.AT_LEAST_ONCE,
+				thresholds: [
+					{
+						...INITIAL_CREATE_ALERT_STATE.threshold.thresholds[0],
+						thresholdValue: 245,
+					},
+				],
+			},
+		};
+
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		render(
+			<MemoryRouter initialEntries={['/alerts/overview?ruleId=r1']}>
+				<QueryClientProvider client={queryClient}>
+					<CreateAlertProvider
+						initialAlertType={AlertTypes.METRICS_BASED_ALERT}
+						isEditMode
+						ruleId="r1"
+						initialAlertState={initialAlertState}
+					>
+						<Probe />
+						<SearchMutator />
+					</CreateAlertProvider>
+				</QueryClientProvider>
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByTestId('threshold-value')).toHaveTextContent('245');
+
+		// Simulate the query builder normalizing the query into the URL post-load.
+		fireEvent.click(screen.getByTestId('mutate-search'));
+
+		expect(screen.getByTestId('threshold-value')).toHaveTextContent('245');
 	});
 });

--- a/frontend/src/container/CreateAlertV2/context/index.tsx
+++ b/frontend/src/container/CreateAlertV2/context/index.tsx
@@ -168,6 +168,14 @@ export function CreateAlertProvider(
 	const yAxisUnitAppliedRef = useRef(false);
 
 	useEffect(() => {
+		// URL-declared prefill is a create-flow concern. In edit mode the alert
+		// state is owned by SET_INITIAL_STATE; running the RESET below would wipe
+		// the loaded thresholds each time the query builder rewrites location.search
+		// (which yields a fresh urlPrefill object and re-triggers this effect).
+		if (isEditMode) {
+			return;
+		}
+
 		setCreateAlertState({
 			slice: CreateAlertSlice.THRESHOLD,
 			action: {
@@ -235,7 +243,7 @@ export function CreateAlertProvider(
 				},
 			});
 		}
-	}, [alertType, urlPrefill, ruleNameFromURL, yAxisUnitFromURL]);
+	}, [alertType, urlPrefill, ruleNameFromURL, yAxisUnitFromURL, isEditMode]);
 
 	useEffect(() => {
 		if (isEditMode && initialAlertState) {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

On the alert **overview/edit** page, refreshing a saved threshold alert showed the threshold value as **0** instead of the persisted value (e.g. `245`). The alert was correct in the API response — only the UI reset it on load.

This is a regression from #12137. That PR reworked the URL-prefill effect in `CreateAlertV2/context/index.tsx` to drive off a memoized `urlPrefill` **object** (`useMemo(..., [location.search])`) instead of the previous primitive `thresholdsFromURL` string. The effect starts with an unconditional threshold `RESET` (→ `thresholdValue: 0`). Because the query builder normalizes the loaded query back into the URL after the page mounts, `location.search` changes, `urlPrefill` gets a fresh object reference, and the effect re-runs — its `RESET` wipes the value that `SET_INITIAL_STATE` had just loaded. Before #12137 the dependency was a primitive that stayed `null` across that URL change, so the effect never re-ran.

URL-declared prefill is a **create-flow** concern. In edit mode the alert state is owned entirely by `SET_INITIAL_STATE` (its reducer branch fully replaces the threshold slice). The fix skips the prefill/RESET effect when `isEditMode` is true.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change.

_To add:_ open a saved threshold alert (target `245`) and refresh — before: threshold shows `0`; after: threshold shows `245`.

#### Issues closed by this PR
Closes https://github.com/SigNoz/pulse-pod/issues/134


---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
Regression from #12137. The prefill `useEffect` dependency moved from the primitive `thresholdsFromURL` (stable `null` on the edit page) to the memoized `urlPrefill` object, which is re-created on every `location.search` change. The query builder rewrites `location.search` after the alert loads (normalizing the query — visible as extra `reduceTo`/`signal`/`name` fields in the URL's `compositeQuery`), so the effect re-runs and its unconditional threshold `RESET` overwrites the value applied by `SET_INITIAL_STATE`.

#### Fix Strategy
Bail out of the prefill effect when `isEditMode` is true, and add `isEditMode` to its dependency array. URL prefill is only meaningful for the create flow (`/alerts/new`); in edit mode `SET_INITIAL_STATE` is the single source of truth and fully replaces the threshold slice, so skipping the RESET is safe.

---

### 🧪 Testing Strategy
> How was this change validated?

- **Tests added/updated:** New case in `CreateAlertProvider.prefill.test.tsx` — renders the provider in edit mode with a loaded threshold of `245`, then simulates the query builder rewriting `location.search`, asserting the threshold stays `245`. Verified it fails (`245 → 0`) without the guard and passes with it.
- **Manual verification:** Traced the mount/re-run ordering against the reported alert payload (`thresholds.spec[0].target = 245`, `schemaVersion: v2alpha1`).
- **Edge cases covered:** Create-flow prefill paths unchanged — existing prefill tests (dashboard-style, occurrence-only, meter preset) still pass. All 62 tests in `CreateAlertV2/context/__tests__/` green; `tsgo --noEmit` and `oxlint` clean.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** The CreateAlertV2 provider's URL-prefill effect, edit mode only. Create-flow behavior is untouched (guard is a no-op when `isEditMode` is false).
- **Potential regressions:** None expected — in edit mode the effect previously ran a RESET then relied on `SET_INITIAL_STATE`; now `SET_INITIAL_STATE` (which fully replaces the threshold slice) is the only writer.
- **Rollback plan:** Revert this PR — it is a self-contained early-return guard plus one test.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Editing a saved threshold alert no longer resets the threshold value to 0 on page refresh. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The same object-dependency root cause also affects the **create** flow: after landing on `/alerts/new?...thresholds=...`, editing the query re-runs the effect and re-applies the URL prefill, overwriting a manually-edited threshold. That is out of scope here (not the reported bug). A cleaner long-term fix would apply URL prefill once via a ref — like `ruleName`/`yAxisUnit` already do — rather than on every `location.search` change. Happy to follow up.
- `SET_INITIAL_STATE` for the threshold slice is a full replace (`return action.payload`), so dropping the pre-RESET in edit mode does not leave stale state.
