### PR TITLE
test(e2e): cover alert edit-page threshold persistence

### DIFF
--- a/tests/e2e/helpers/alerts.ts
+++ b/tests/e2e/helpers/alerts.ts
@@ -1,0 +1,188 @@
+import { expect, type Page } from '@playwright/test';
+
+import { authToken } from './common';
+
+// ─── Constants ───────────────────────────────────────────────────────────
+
+export const ALERTS_LIST_PATH = '/alerts';
+export const ALERT_OVERVIEW_PATH = '/alerts/overview';
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export interface ThresholdAlertSeed {
+	/** Alert rule name. Keep unique per test to avoid collisions. */
+	name: string;
+	/** The critical-threshold target value to persist and later assert. */
+	target: number;
+	/**
+	 * Notification channel names for the critical threshold. At least one is
+	 * required by the API — seed one with {@link createEmailChannelViaApi}.
+	 */
+	channels: string[];
+}
+
+// ─── Payload ─────────────────────────────────────────────────────────────
+
+// A minimal but valid v2 (schemaVersion v2alpha1 / version v5) threshold rule
+// on the always-present `signoz_calls_total` metric. Mirrors the shape the
+// CreateAlertV2 UI posts to POST /api/v2/rules.
+function buildThresholdRulePayload({
+	name,
+	target,
+	channels,
+}: ThresholdAlertSeed): Record<string, unknown> {
+	return {
+		alert: name,
+		alertType: 'METRIC_BASED_ALERT',
+		ruleType: 'threshold_rule',
+		schemaVersion: 'v2alpha1',
+		version: 'v5',
+		disabled: false,
+		source: '',
+		annotations: {
+			description:
+				'This alert is fired when the defined metric (current value: {{$value}}) crosses the threshold ({{$threshold}})',
+			summary:
+				'This alert is fired when the defined metric (current value: {{$value}}) crosses the threshold ({{$threshold}})',
+		},
+		evaluation: {
+			kind: 'rolling',
+			spec: { evalWindow: '5m0s', frequency: '1m' },
+		},
+		notificationSettings: {
+			groupBy: [],
+			renotify: { enabled: false, interval: '30m', alertStates: [] },
+			usePolicy: false,
+		},
+		condition: {
+			selectedQueryName: 'A',
+			compositeQuery: {
+				panelType: 'graph',
+				queryType: 'builder',
+				queries: [
+					{
+						type: 'builder_query',
+						spec: {
+							name: 'A',
+							signal: 'metrics',
+							source: '',
+							aggregations: [
+								{
+									metricName: 'signoz_calls_total',
+									temporality: '',
+									timeAggregation: 'rate',
+									spaceAggregation: 'sum',
+								},
+							],
+							disabled: false,
+							filter: { expression: '' },
+							having: { expression: '' },
+							legend: '',
+						},
+					},
+				],
+			},
+			thresholds: {
+				kind: 'basic',
+				spec: [
+					{
+						name: 'critical',
+						target,
+						targetUnit: '',
+						recoveryTarget: null,
+						matchType: 'at_least_once',
+						op: 'above',
+						channels,
+					},
+				],
+			},
+		},
+	};
+}
+
+// ─── API helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Seed an email notification channel via API. Returns its `{ id, name }`;
+ * thresholds reference channels by name, cleanup deletes by id. `to` is never
+ * delivered — the channel only needs to exist to satisfy rule validation.
+ */
+export async function createEmailChannelViaApi(
+	page: Page,
+	name: string,
+): Promise<{ id: string; name: string }> {
+	const token = await authToken(page);
+	const res = await page.request.post('/api/v1/channels', {
+		data: {
+			name,
+			email_configs: [
+				{ send_resolved: true, to: 'e2e@signoz.test', html: '', headers: {} },
+			],
+		},
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!res.ok()) {
+		throw new Error(`POST /api/v1/channels ${res.status()}: ${await res.text()}`);
+	}
+	const json = (await res.json()) as { data: { id: string } };
+	return { id: String(json.data.id), name };
+}
+
+/** Delete a notification channel by ID (best-effort cleanup). */
+export async function deleteChannelViaApi(
+	page: Page,
+	id: string,
+): Promise<void> {
+	const token = await authToken(page);
+	await page.request.delete(`/api/v1/channels/${id}`, {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+}
+
+/**
+ * Seed a v2 threshold alert via API. Returns the new rule ID. Pair with
+ * {@link deleteAlertViaApi} in an `afterAll`/`afterEach` for cleanup.
+ */
+export async function createThresholdAlertViaApi(
+	page: Page,
+	seed: ThresholdAlertSeed,
+): Promise<string> {
+	const token = await authToken(page);
+	const res = await page.request.post('/api/v2/rules', {
+		data: buildThresholdRulePayload(seed),
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!res.ok()) {
+		throw new Error(`POST /api/v2/rules ${res.status()}: ${await res.text()}`);
+	}
+	const json = (await res.json()) as { data: { id: string } };
+	return json.data.id;
+}
+
+/** Delete a rule by ID. Tolerates an already-deleted rule (best-effort cleanup). */
+export async function deleteAlertViaApi(page: Page, id: string): Promise<void> {
+	const token = await authToken(page);
+	await page.request.delete(`/api/v2/rules/${id}`, {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+}
+
+// ─── Navigation ────────────────────────────────────────────────────────────
+
+/**
+ * Open the alert overview (edit) page for `ruleId` and wait until it has fully
+ * settled: the condition editor is visible and the query builder has finished
+ * serializing the loaded query into the URL.
+ */
+export async function gotoAlertOverview(
+	page: Page,
+	ruleId: string,
+): Promise<void> {
+	await page.goto(`${ALERT_OVERVIEW_PATH}?ruleId=${ruleId}`);
+	await expect(page.getByTestId('threshold-value-input')).toBeVisible();
+	// The builder rewrites location.search shortly after load (adds compositeQuery).
+	await page.waitForURL(/compositeQuery=/, { timeout: 15_000 });
+	// Let post-load state updates flush so callers read the settled value.
+	// eslint-disable-next-line playwright/no-wait-for-timeout -- no DOM signal for the async settle
+	await page.waitForTimeout(500);
+}

--- a/tests/e2e/tests/alerts/alerts.spec.ts
+++ b/tests/e2e/tests/alerts/alerts.spec.ts
@@ -40,9 +40,6 @@ test.describe('alerts — threshold persists on edit-page load', () => {
 	});
 
 	test.afterAll(async ({ browser }) => {
-		if (!ruleId && !channelId) {
-			return;
-		}
 		const ctx = await newAdminContext(browser);
 		const page = await ctx.newPage();
 		try {

--- a/tests/e2e/tests/alerts/alerts.spec.ts
+++ b/tests/e2e/tests/alerts/alerts.spec.ts
@@ -1,7 +1,70 @@
-import { test, expect } from '../../fixtures/auth';
+import { expect, test } from '../../fixtures/auth';
+import {
+	createEmailChannelViaApi,
+	createThresholdAlertViaApi,
+	deleteAlertViaApi,
+	deleteChannelViaApi,
+	gotoAlertOverview,
+} from '../../helpers/alerts';
+import { newAdminContext } from '../../helpers/auth';
 
 test('TC-01 alerts page — tabs render', async ({ authedPage: page }) => {
 	await page.goto('/alerts');
 	await expect(page.getByRole('tab', { name: /alert rules/i })).toBeVisible();
 	await expect(page.getByRole('tab', { name: /configuration/i })).toBeVisible();
+});
+
+test.describe('alerts — threshold persists on edit-page load', () => {
+	const TARGET = 245;
+	let ruleId: string;
+	let channelId: string;
+
+	test.beforeAll(async ({ browser }) => {
+		const ctx = await newAdminContext(browser);
+		const page = await ctx.newPage();
+		try {
+			const stamp = Date.now();
+			const channel = await createEmailChannelViaApi(
+				page,
+				`e2e-threshold-persistence-ch-${stamp}`,
+			);
+			channelId = channel.id;
+			ruleId = await createThresholdAlertViaApi(page, {
+				name: `e2e-threshold-persistence-${stamp}`,
+				target: TARGET,
+				channels: [channel.name],
+			});
+		} finally {
+			await ctx.close();
+		}
+	});
+
+	test.afterAll(async ({ browser }) => {
+		if (!ruleId && !channelId) {
+			return;
+		}
+		const ctx = await newAdminContext(browser);
+		const page = await ctx.newPage();
+		try {
+			if (ruleId) {
+				await deleteAlertViaApi(page, ruleId);
+			}
+			if (channelId) {
+				await deleteChannelViaApi(page, channelId);
+			}
+		} finally {
+			await ctx.close();
+		}
+	});
+
+	test('TC-02 edit page shows the saved threshold value', async ({
+		authedPage: page,
+	}) => {
+		await gotoAlertOverview(page, ruleId);
+
+		// The condition editor should show the persisted target once loaded.
+		await expect(page.getByTestId('threshold-value-input')).toHaveValue(
+			String(TARGET),
+		);
+	});
 });


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

Adds E2E coverage for the alert **overview/edit** page: opening a saved threshold alert must show the persisted threshold value in the condition editor. This exercises the load path where the query builder serializes the loaded query back into the URL after mount — a spot that has been fragile — so a future change that drops the loaded threshold on the edit page is caught automatically.

The test follows the repo's existing pattern: seed real data via API, then drive the real UI.

- **`tests/e2e/helpers/alerts.ts`** (new) — seeding/navigation helpers mirroring `helpers/dashboards.ts`: create an email notification channel, create a v2 threshold alert (`POST /api/v2/rules`) on `signoz_calls_total`, delete both for cleanup, and `gotoAlertOverview` (open the edit page and wait for it to settle).
- **`tests/e2e/tests/alerts/alerts.spec.ts`** — adds `TC-02 edit page shows the saved threshold value` alongside the existing tabs test. It seeds an alert with target `245`, opens the overview page, and asserts `threshold-value-input` holds `245`.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change.

N/A — test-only.

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

N/A.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [x] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

N/A — not a bug fix.

---

### 🧪 Testing Strategy
> How was this change validated?

- **Tests added:** `TC-02 edit page shows the saved threshold value` in `tests/e2e/tests/alerts/alerts.spec.ts`, plus seeding helpers in `tests/e2e/helpers/alerts.ts`.
- **Manual verification:** Ran against a local `--with-web` stack (pytest bootstrap). The full `alerts.spec.ts` (TC-01 + TC-02) passes. Cross-checked the assertion is meaningful by serving a build where the edit page resets the value — TC-02 then fails with `Expected: "245", Received: "0"`.
- **Static checks:** `oxfmt --check`, `tsc --noEmit`, and `oxlint` all clean for the two files.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** E2E suite only — no product code touched.
- **Potential regressions:** None to the app. The new test depends on `signoz_calls_total` being present (seeded by the golden-dataset bootstrap) and on the `POST /api/v1/channels` + `POST /api/v2/rules` APIs.
- **Rollback plan:** Revert the PR — it only adds a test and a helper.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior

N/A — internal test-only change.

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

- The seed leaves `channels: []` invalid per the API (rule creation requires at least one channel), so the helper seeds an email channel first and references it by name; both are cleaned up in `afterAll`.
- `gotoAlertOverview` waits for the query builder to serialize the query into the URL (`compositeQuery=…`) and then briefly settles so the assertion reads the final value; that single `waitForTimeout` carries an inline lint-suppression with a rationale.
- Behavior verified is exactly what #12226 fixed on the edit page; this PR just locks it in at the E2E level.
