### PR TITLE
fix(api): guard deprecated generated-API handler against non-envelope bodies

### DIFF
--- a/frontend/src/api/ErrorResponseHandlerForGeneratedAPIs.ts
+++ b/frontend/src/api/ErrorResponseHandlerForGeneratedAPIs.ts
@@ -2,6 +2,29 @@ import { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
 import { AxiosError } from 'axios';
 import APIError from 'types/api/error';
 
+// The wire shape these handlers can actually rely on. The generated
+// RenderErrorResponseDTO marks code/message/url/errors as required, but the
+// server omits any of them even on valid errors (e.g. a 400 with just a
+// message), so a present `error` object is all the guard can guarantee.
+type ErrorEnvelope = {
+	error: {
+		code?: string;
+		message?: string;
+		url?: string;
+		errors?: { message?: string }[];
+	};
+};
+
+function isErrorEnvelope(data: unknown): data is ErrorEnvelope {
+	return (
+		typeof data === 'object' &&
+		data !== null &&
+		'error' in data &&
+		typeof (data as ErrorEnvelope).error === 'object' &&
+		(data as ErrorEnvelope).error !== null
+	);
+}
+
 // @deprecated Use convertToApiError instead
 export function ErrorResponseHandlerForGeneratedAPIs(
 	error: AxiosError<RenderErrorResponseDTO>,
@@ -10,15 +33,29 @@ export function ErrorResponseHandlerForGeneratedAPIs(
 	// The request was made and the server responded with a status code
 	// that falls out of the range of 2xx
 	if (response) {
+		// The body isn't guaranteed to be an error envelope — e.g. a gateway 5xx
+		// with an HTML/empty body during a deploy. Verify the shape before reading
+		// it; otherwise synthesize a consistent error from the status.
+		const data: unknown = response.data;
+		if (isErrorEnvelope(data)) {
+			const { code, message, url, errors } = data.error;
+			throw new APIError({
+				httpStatusCode: response.status || 500,
+				error: {
+					code: code ?? '',
+					message: message ?? '',
+					url: url ?? '',
+					errors: (errors ?? []).map((e) => ({ message: e.message ?? '' })),
+				},
+			});
+		}
 		throw new APIError({
 			httpStatusCode: response.status || 500,
 			error: {
-				code: response.data.error.code,
-				message: response.data.error.message,
-				url: response.data.error.url ?? '',
-				errors: (response.data.error.errors ?? []).map((e) => ({
-					message: e.message ?? '',
-				})),
+				code: 'UPSTREAM_UNAVAILABLE',
+				message: error.message || 'Something went wrong',
+				url: '',
+				errors: [],
 			},
 		});
 	}

--- a/frontend/src/utils/errorUtils.ts
+++ b/frontend/src/utils/errorUtils.ts
@@ -42,7 +42,12 @@ export function toAPIError(
 	try {
 		ErrorResponseHandlerForGeneratedAPIs(error);
 	} catch (apiError) {
-		if (apiError instanceof APIError) {
+		// UPSTREAM_UNAVAILABLE means the handler couldn't find a backend error code
+		// (non-envelope body); prefer the caller's context-specific defaultMessage.
+		if (
+			apiError instanceof APIError &&
+			apiError.getErrorCode() !== 'UPSTREAM_UNAVAILABLE'
+		) {
 			return apiError;
 		}
 	}


### PR DESCRIPTION
## Pull Request

> **Stacked on #12209** (base branch `fix/error-handler-v2-non-envelope-body`). Review/merge that PR first — this one only shows its own diff once #12209 lands. Holding ~2 weeks before merge.

---

### 📄 Summary

Applies the shape-guard from `ErrorResponseHandlerV2` to the deprecated `ErrorResponseHandlerForGeneratedAPIs`, so the generated-API error path no longer throws its own `TypeError` on a non-envelope response body (a gateway 5xx with an HTML/empty body during a deploy).

This was carved out of #12209 because guarding the handler has blast radius: the handler *crashing* was the (fragile) signal `toAPIError(error, defaultMessage)` used to fall back to a caller-provided, context-specific message. Once the handler stops crashing, that fallback needed to be made explicit — so `toAPIError` now treats the synthetic `UPSTREAM_UNAVAILABLE` code (no backend code found) as "could not parse" and returns the `defaultMessage`, preserving the ServiceAccount / Roles error-screen UX with **no changes to those feature tests**.

Guard detail: the discriminator is "**is `error` a present object**", not "is `error.code` a string" — a valid backend error can carry a `message` without a `code` (e.g. `{ error: { message: 'Role name already exists' } }`), and that message must still surface.

#### Issues

Part of https://github.com/SigNoz/engineering-pod/issues/5761 (H4ad's suggestion is tracked there). Fixes the generated-API handler crash noted in https://github.com/SigNoz/platform-pod/issues/2502.

---

### ✅ Change Type

- [x] 🐛 Bug fix

---

### 🐛 Bug Context

#### Root Cause
`ErrorResponseHandlerForGeneratedAPIs` read `response.data.error.code` directly; on a body with no `error` object it threw a `TypeError` instead of producing an `APIError`.

#### Fix Strategy
Launder `response.data` through `unknown`, verify `error` is a present object with `isErrorEnvelope`, then read it defensively (all fields optional on the wire). Non-envelope bodies synthesize an `UPSTREAM_UNAVAILABLE` `APIError`. `toAPIError` falls back to `defaultMessage` when it sees `UPSTREAM_UNAVAILABLE`.

---

### 🧪 Testing Strategy
- Existing ServiceAccountDrawer / CreateRolePage / ServiceAccountsSettings error tests pass **unchanged** (defaultMessage + real-message paths both preserved).
- tsgo / oxlint / oxfmt clean.

---

### ⚠️ Risk & Impact Assessment
- Blast radius: all `toAPIError` / deprecated-handler callers. Behavior preserved for well-formed envelopes and for the defaultMessage fallback; the only change is a non-envelope body now produces a catchable `APIError` instead of a crash.
- Rollback: revert this commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Generated-API calls no longer crash the UI when the server returns a non-standard error body; the failure surfaces as a normal, retryable error. |
