### PR TITLE
fix(tracefunnel): support p50/p75/p99 in step overview latency query

### DIFF
--- a/pkg/modules/tracefunnel/clickhouse_queries.go
+++ b/pkg/modules/tracefunnel/clickhouse_queries.go
@@ -380,15 +380,21 @@ func BuildFunnelStepOverviewQuery(
 		whereConditions = append(whereConditions, fmt.Sprintf("(%s)", strings.Join(orConditions, " OR ")))
 	}
 
-	// Determine latency quantile for the end step
+	// Determine latency quantile for the end step.
+	// All standard percentiles are supported; unknown values fall back to p99.
 	latencyQuantile := "0.99"
 	if steps[endIdx].LatencyType != "" {
-		latency := strings.ToLower(steps[endIdx].LatencyType)
-		switch latency {
+		switch strings.ToLower(steps[endIdx].LatencyType) {
+		case "p50":
+			latencyQuantile = "0.50"
+		case "p75":
+			latencyQuantile = "0.75"
 		case "p90":
 			latencyQuantile = "0.90"
 		case "p95":
 			latencyQuantile = "0.95"
+		case "p99":
+			latencyQuantile = "0.99"
 		default:
 			latencyQuantile = "0.99"
 		}

--- a/pkg/modules/tracefunnel/clickhouse_queries_latency_test.go
+++ b/pkg/modules/tracefunnel/clickhouse_queries_latency_test.go
@@ -137,6 +137,57 @@ func TestBuildFunnelStepOverviewQuery_WithLatencyPointer(t *testing.T) {
 				"minIf(timestamp, resource_string_service$$name = step2.1 AND name = step2.2) + toIntervalNanosecond(minIf(duration_nano, resource_string_service$$name = step2.1 AND name = step2.2)) AS t2_time",
 			},
 		},
+		{
+			name: "p50 latency type uses 0.50 quantile",
+			steps: []struct {
+				ServiceName    string
+				SpanName       string
+				ContainsError  int
+				LatencyPointer string
+				LatencyType    string
+				Clause         string
+			}{
+				{ServiceName: "svc", SpanName: "op1", LatencyPointer: "start", LatencyType: "p50", Clause: ""},
+				{ServiceName: "svc", SpanName: "op2", LatencyPointer: "start", LatencyType: "p50", Clause: ""},
+			},
+			stepStart:    1,
+			stepEnd:      2,
+			wantContains: []string{"quantileIf(0.50)"},
+		},
+		{
+			name: "p75 latency type uses 0.75 quantile",
+			steps: []struct {
+				ServiceName    string
+				SpanName       string
+				ContainsError  int
+				LatencyPointer string
+				LatencyType    string
+				Clause         string
+			}{
+				{ServiceName: "svc", SpanName: "op1", LatencyPointer: "start", LatencyType: "p75", Clause: ""},
+				{ServiceName: "svc", SpanName: "op2", LatencyPointer: "start", LatencyType: "p75", Clause: ""},
+			},
+			stepStart:    1,
+			stepEnd:      2,
+			wantContains: []string{"quantileIf(0.75)"},
+		},
+		{
+			name: "unknown latency type falls back to p99",
+			steps: []struct {
+				ServiceName    string
+				SpanName       string
+				ContainsError  int
+				LatencyPointer string
+				LatencyType    string
+				Clause         string
+			}{
+				{ServiceName: "svc", SpanName: "op1", LatencyPointer: "start", LatencyType: "p42", Clause: ""},
+				{ServiceName: "svc", SpanName: "op2", LatencyPointer: "start", LatencyType: "p42", Clause: ""},
+			},
+			stepStart:    1,
+			stepEnd:      2,
+			wantContains: []string{"quantileIf(0.99)"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

`BuildFunnelStepOverviewQuery` only handled `p90` and `p95` in its `latency_type` switch — every other value including `p50` fell through to `default` and silently produced a p99 quantile, returning a wrong number with HTTP 200. A user reading a "p50 median" was actually seeing a tail value.

Closes #12220

## Change

Add `p50`, `p75`, and an explicit `p99` case to the switch in `pkg/modules/tracefunnel/clickhouse_queries.go`. Unknown values still fall back to p99.

## Tests

Added cases to `clickhouse_queries_latency_test.go` covering p50 (→ `0.50`), p75 (→ `0.75`), and an unknown value (→ `0.99` fallback). All existing tests pass.