### PR TITLE
fix(opamp): make config deployment coordinator concurrency-safe and agent-aware

### DIFF
--- a/pkg/query-service/app/opamp/model/coordinator.go
+++ b/pkg/query-service/app/opamp/model/coordinator.go
@@ -27,50 +27,53 @@ type Coordinator struct {
 	subscribers map[string][]OnChangeCallback
 }
 
-func getSubscriberKey(orgId valuer.UUID, hash string) string {
-	return orgId.String() + hash
+// getSubscriberKey returns a key that uniquely identifies a (org, agent, config-hash)
+// triple. Including the agent ID ensures that concurrent deployments to different
+// agents under the same org and hash do not share subscribers and therefore cannot
+// deliver a result from the wrong agent to a waiting caller.
+func getSubscriberKey(orgId valuer.UUID, agentId string, hash string) string {
+	return orgId.String() + agentId + hash
 }
 
 func onConfigSuccess(orgId valuer.UUID, agentId string, hash string) {
-	key := getSubscriberKey(orgId, hash)
+	key := getSubscriberKey(orgId, agentId, hash)
 	notifySubscribers(orgId, agentId, key, nil)
 }
 
 func onConfigFailure(orgId valuer.UUID, agentId string, hash string, errorMessage string) {
-	key := getSubscriberKey(orgId, hash)
+	key := getSubscriberKey(orgId, agentId, hash)
 	notifySubscribers(orgId, agentId, key, errors.New(errorMessage))
 }
 
-// OnSuccess listens to config changes and notifies subscribers
+// notifySubscribers delivers a config-change result to all callbacks registered
+// for key, then removes them. It holds coordinator.mutex for the entire operation
+// so concurrent ListenToConfigUpdate calls cannot observe a partially-torn map.
 func notifySubscribers(orgId valuer.UUID, agentId string, key string, err error) {
-	// this method currently does not handle multi-agent scenario.
-	// as soon as a message is delivered, we release all the subscribers
-	// for a given key
+	coordinator.mutex.Lock()
 	subs, ok := coordinator.subscribers[key]
 	if !ok {
+		coordinator.mutex.Unlock()
 		return
 	}
+	// Drain the entry before invoking callbacks so the map is consistent if a
+	// callback re-registers for the same key.
+	delete(coordinator.subscribers, key)
+	coordinator.mutex.Unlock()
 
 	for _, s := range subs {
 		s(orgId, agentId, key, err)
 	}
-
-	// delete all subscribers for this key, assume future
-	// notifies will be disabled. the first response is processed
-	delete(coordinator.subscribers, key)
 }
 
-// callers subscribe to this function to listen on config change requests
+// ListenToConfigUpdate registers ss to be called when the config identified by
+// (orgId, agentId, hash) is applied or fails. The agent ID is part of the
+// subscription key so that results from one agent are not delivered to callers
+// waiting on a different agent.
 func ListenToConfigUpdate(orgId valuer.UUID, agentId string, hash string, ss OnChangeCallback) {
 	coordinator.mutex.Lock()
 	defer coordinator.mutex.Unlock()
 
-	key := getSubscriberKey(orgId, hash)
+	key := getSubscriberKey(orgId, agentId, hash)
 
-	if subs, ok := coordinator.subscribers[key]; ok {
-		subs = append(subs, ss)
-		coordinator.subscribers[key] = subs
-	} else {
-		coordinator.subscribers[key] = []OnChangeCallback{ss}
-	}
+	coordinator.subscribers[key] = append(coordinator.subscribers[key], ss)
 }

--- a/pkg/query-service/app/opamp/model/coordinator_test.go
+++ b/pkg/query-service/app/opamp/model/coordinator_test.go
@@ -1,0 +1,60 @@
+package model
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCoordinator_NoRaceOnConcurrentListenAndNotify runs ListenToConfigUpdate
+// and onConfigSuccess concurrently. The -race detector catches any unsynchronised
+// access to the subscribers map that existed before this fix.
+func TestCoordinator_NoRaceOnConcurrentListenAndNotify(t *testing.T) {
+	const goroutines = 20
+	orgID := valuer.GenerateUUID()
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(2)
+		agentID := valuer.GenerateUUID().String()
+		hash := valuer.GenerateUUID().String()
+
+		go func() {
+			defer wg.Done()
+			ListenToConfigUpdate(orgID, agentID, hash, func(valuer.UUID, string, string, error) {})
+		}()
+		go func() {
+			defer wg.Done()
+			onConfigSuccess(orgID, agentID, hash)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestCoordinator_AgentIsolation verifies that a notification for agent A does
+// not invoke the subscriber registered for agent B on the same org and hash.
+func TestCoordinator_AgentIsolation(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	hash := valuer.GenerateUUID().String()
+	agentA := valuer.GenerateUUID().String()
+	agentB := valuer.GenerateUUID().String()
+
+	calledFor := []string{}
+	var mu sync.Mutex
+
+	ListenToConfigUpdate(orgID, agentA, hash, func(_ valuer.UUID, agentId string, _ string, _ error) {
+		mu.Lock(); calledFor = append(calledFor, agentId); mu.Unlock()
+	})
+	ListenToConfigUpdate(orgID, agentB, hash, func(_ valuer.UUID, agentId string, _ string, _ error) {
+		mu.Lock(); calledFor = append(calledFor, agentId); mu.Unlock()
+	})
+
+	// Notify only agentA
+	onConfigSuccess(orgID, agentA, hash)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{agentA}, calledFor, "only agentA's subscriber should fire")
+}


### PR DESCRIPTION
## Problem

Two related bugs in `pkg/query-service/app/opamp/model/coordinator.go` (issue #12184):

1. **Data race**: `ListenToConfigUpdate` held `coordinator.mutex` while writing to `coordinator.subscribers`, but `notifySubscribers` read and deleted from the same map **without acquiring the mutex**. Concurrent agent status messages and new subscriptions could produce `fatal error: concurrent map read and map write`.

2. **Wrong agent isolation**: `getSubscriberKey` keyed on `orgId+hash` only — subscriptions for different agents sharing the same org and config hash were merged, so a result from agent A could fire callbacks registered for agent B.

Closes #12184

## Fix

- `notifySubscribers` now acquires `coordinator.mutex`, drains the entry before invoking callbacks (safe for re-registration inside a callback), then releases before calling out.
- `getSubscriberKey` includes `agentId` in the key. All existing callers already pass `agentId` — no signature change needed.

## Tests

- `TestCoordinator_NoRaceOnConcurrentListenAndNotify`: 20 concurrent listen/notify pairs — passes `-race`.
- `TestCoordinator_AgentIsolation`: fires success for agent A, asserts agent B's subscriber is not called.