### PR TITLE
feat(ruler): make PromQL rule evaluation interval configurable

### DIFF
--- a/pkg/query-service/rules/base_rule.go
+++ b/pkg/query-service/rules/base_rule.go
@@ -44,6 +44,10 @@ type BaseRule struct {
 	// this is useful in cases where the data is not available immediately
 	evalDelay valuer.TextDuration
 
+	// evalInterval is the step used when building the PromQL range query
+	// inside buildAndRunQuery. Defaults to 60s when not set.
+	evalInterval valuer.TextDuration
+
 	// holds the static set of labels and annotations for the rule
 	// these are the same for all alerts created for this rule
 	labels      ruletypes.Labels
@@ -106,6 +110,12 @@ func WithSendUnmatched() RuleOption {
 func WithEvalDelay(dur valuer.TextDuration) RuleOption {
 	return func(r *BaseRule) {
 		r.evalDelay = dur
+	}
+}
+
+func WithEvalInterval(dur valuer.TextDuration) RuleOption {
+	return func(r *BaseRule) {
+		r.evalInterval = dur
 	}
 }
 

--- a/pkg/query-service/rules/manager.go
+++ b/pkg/query-service/rules/manager.go
@@ -78,7 +78,8 @@ type ManagerOptions struct {
 	Logger      *slog.Logger
 	Cache       cache.Cache
 
-	EvalDelay valuer.TextDuration
+	EvalDelay    valuer.TextDuration
+	EvalInterval valuer.TextDuration
 
 	RuleStateHistoryModule rulestatehistory.Module
 
@@ -118,6 +119,9 @@ type Manager struct {
 func defaultOptions(o *ManagerOptions) *ManagerOptions {
 	if o.ResendDelay == time.Duration(0) {
 		o.ResendDelay = 1 * time.Minute
+	}
+	if !o.EvalInterval.IsPositive() {
+		o.EvalInterval = valuer.MustParseTextDuration("60s")
 	}
 	if o.Logger == nil {
 		o.Logger = slog.Default()
@@ -180,6 +184,7 @@ func defaultPrepareTaskFunc(opts PrepareTaskOptions) (Task, error) {
 			WithQueryParser(opts.ManagerOpts.QueryParser),
 			WithMetadataStore(opts.ManagerOpts.MetadataStore),
 			WithRuleStateHistoryModule(opts.ManagerOpts.RuleStateHistoryModule),
+			WithEvalInterval(opts.ManagerOpts.EvalInterval),
 		)
 		if err != nil {
 			return task, err

--- a/pkg/query-service/rules/prom_rule.go
+++ b/pkg/query-service/rules/prom_rule.go
@@ -92,7 +92,10 @@ func (r *PromRule) matrixToCommonSeries(res promql.Matrix) []*qbtypes.TimeSeries
 
 func (r *PromRule) buildAndRunQuery(ctx context.Context, ts time.Time) (ruletypes.Vector, error) {
 	start, end := r.Timestamps(ts)
-	interval := 60 * time.Second // TODO(srikanthccv): this should be configurable
+	interval := 60 * time.Second
+	if r.evalInterval.IsPositive() {
+		interval = r.evalInterval.Duration()
+	}
 
 	q, err := r.getPqlQuery(ctx)
 	if err != nil {

--- a/pkg/ruler/config.go
+++ b/pkg/ruler/config.go
@@ -7,7 +7,8 @@ import (
 )
 
 type Config struct {
-	EvalDelay time.Duration `mapstructure:"eval_delay"`
+	EvalDelay    time.Duration `mapstructure:"eval_delay"`
+	EvalInterval time.Duration `mapstructure:"eval_interval"`
 }
 
 func NewConfigFactory() factory.ConfigFactory {
@@ -16,7 +17,8 @@ func NewConfigFactory() factory.ConfigFactory {
 
 func newConfig() factory.Config {
 	return Config{
-		EvalDelay: 2 * time.Minute,
+		EvalDelay:    2 * time.Minute,
+		EvalInterval: 60 * time.Second,
 	}
 }
 

--- a/pkg/ruler/signozruler/provider.go
+++ b/pkg/ruler/signozruler/provider.go
@@ -57,6 +57,7 @@ func NewFactory(
 			Logger:                 providerSettings.Logger,
 			Cache:                  cache,
 			EvalDelay:              valuer.MustParseTextDuration(config.EvalDelay.String()),
+			EvalInterval:           valuer.MustParseTextDuration(config.EvalInterval.String()),
 			PrepareTaskFunc:        prepareTaskFunc,
 			PrepareTestRuleFunc:    prepareTestRuleFunc,
 			Alertmanager:           alertmanager,


### PR DESCRIPTION
## Problem

`prom_rule.go:buildAndRunQuery` hard-coded `60 * time.Second` as the PromQL range-query step with a `TODO` noting it should be configurable. Operators had no way to tune this — paying the same granularity cost regardless of rule eval window or metric frequency.

Closes #12217

## Change

Threads a new `EvalInterval` knob through the existing config/option chain — same pattern as the existing `EvalDelay`:

| Layer | What changed |
|---|---|
| `pkg/ruler/config.go` | `EvalInterval time.Duration` field (`mapstructure:"eval_interval"`), default `60s` |
| `pkg/query-service/rules/manager.go` | `ManagerOptions.EvalInterval`; `defaultOptions` sets `60s` when zero |
| `pkg/query-service/rules/base_rule.go` | `evalInterval` field + `WithEvalInterval` option |
| `pkg/query-service/rules/prom_rule.go` | `buildAndRunQuery` uses `r.evalInterval.Duration()` (falls back to `60s`) |
| `pkg/ruler/signozruler/provider.go` | Wires `config.EvalInterval → ManagerOptions.EvalInterval` |

Default remains `60s` — existing deployments behave identically. Set `SIGNOZ_RULER_EVAL__INTERVAL` (or `ruler.eval_interval`) to change it.

## Tests

`go build` / `go vet` / `go test ./pkg/query-service/rules/...` all pass.