### PR TITLE
fix(query-service): fix double JSON write and missing return for PromQL cancel/timeout errors

### DIFF
--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1196,16 +1196,14 @@ func (aH *APIHandler) queryRangeMetrics(w http.ResponseWriter, r *http.Request) 
 
 	if res.Err != nil {
 		aH.logger.ErrorContext(r.Context(), "error in query range metrics", errors.Attr(res.Err))
-	}
-
-	if res.Err != nil {
 		switch res.Err.(type) {
 		case promql.ErrQueryCanceled:
 			RespondError(w, &model.ApiError{Typ: model.ErrorCanceled, Err: res.Err}, nil)
 		case promql.ErrQueryTimeout:
 			RespondError(w, &model.ApiError{Typ: model.ErrorTimeout, Err: res.Err}, nil)
+		default:
+			RespondError(w, &model.ApiError{Typ: model.ErrorExec, Err: res.Err}, nil)
 		}
-		RespondError(w, &model.ApiError{Typ: model.ErrorExec, Err: res.Err}, nil)
 		return
 	}
 
@@ -1251,16 +1249,15 @@ func (aH *APIHandler) queryMetrics(w http.ResponseWriter, r *http.Request) {
 
 	if res.Err != nil {
 		aH.logger.ErrorContext(r.Context(), "error in query range metrics", errors.Attr(res.Err))
-	}
-
-	if res.Err != nil {
 		switch res.Err.(type) {
 		case promql.ErrQueryCanceled:
 			RespondError(w, &model.ApiError{Typ: model.ErrorCanceled, Err: res.Err}, nil)
 		case promql.ErrQueryTimeout:
 			RespondError(w, &model.ApiError{Typ: model.ErrorTimeout, Err: res.Err}, nil)
+		default:
+			RespondError(w, &model.ApiError{Typ: model.ErrorExec, Err: res.Err}, nil)
 		}
-		RespondError(w, &model.ApiError{Typ: model.ErrorExec, Err: res.Err}, nil)
+		return
 	}
 
 	responseData := &model.QueryData{


### PR DESCRIPTION
## Problem

Two bugs in `queryRangeMetrics` and `queryMetrics` in `pkg/query-service/app/http_handler.go` (issue #11899):

**Bug 1 — Double response write (both handlers)**

The error switch called `RespondError` for `ErrQueryCanceled`/`ErrQueryTimeout`, then fell through to an unconditional `RespondError` after the switch — writing two JSON bodies to the same `ResponseWriter`. The client received a concatenated response of two error objects.

**Bug 2 — Missing `return` + potential nil panic (`queryMetrics` only)**

After the error block, execution continued unconditionally to:
```go
responseData := &model.QueryData{
    ResultType: res.Value.Type(),  // panics: res.Value is nil when res.Err is set
```

Closes #11899

## Fix

Collapse the duplicate `RespondError` call into a `default` case in the switch so only one response is written, and add `return` after the switch in both handlers. Merge the log line into the same error block.

## Tests

`go build` + `go vet` clean on `pkg/query-service/app/`.