### PR TITLE
fix(frontend): dashboard tags crash Home/Dashboards when backend returns {key,value} objects

### DIFF
--- a/frontend/src/container/Home/Dashboards/Dashboards.tsx
+++ b/frontend/src/container/Home/Dashboards/Dashboards.tsx
@@ -81,7 +81,16 @@ export default function Dashboards({
 			.map((d) => ({
 				id: d.id,
 				title: d.data.title,
-				tags: d.data.tags ?? [],
+				// `data.tags` is typed as `string[]`, but some backend versions report
+				// `{key, value}` objects instead — rendering one directly as a Badge
+				// child crashes the page (React error #31), so normalize defensively.
+				tags: (d.data.tags ?? []).map((t) =>
+					typeof t === 'string'
+						? t
+						: [(t as { key: string }).key, (t as { value?: string }).value]
+								.filter(Boolean)
+								.join(':'),
+				),
 			}));
 	}, [isDashboardV2, v1List, v2List]);
 

--- a/frontend/src/container/ListOfDashboard/utils.ts
+++ b/frontend/src/container/ListOfDashboard/utils.ts
@@ -1,5 +1,21 @@
 import { Dashboard, DashboardTemplate } from 'types/api/dashboard/getAll';
 
+// `Dashboard['data']['tags']` is typed as `string[]`, but some backend versions
+// report tags as `{key, value}` objects instead (the shape the newer key/value
+// tag model uses) — that mismatch isn't caught by the type system since API
+// responses are cast, not runtime-validated. Normalize defensively so a
+// non-string tag degrades to a label instead of throwing at `.toLowerCase()`.
+const tagToString = (tag: unknown): string => {
+	if (typeof tag === 'string') {
+		return tag;
+	}
+	if (tag && typeof tag === 'object' && 'key' in tag) {
+		const { key, value } = tag as { key: string; value?: string };
+		return value ? `${key}:${value}` : key;
+	}
+	return String(tag);
+};
+
 export const filterDashboards = (
 	searchValue: string,
 	dashboardList: Dashboard[],
@@ -12,7 +28,7 @@ export const filterDashboards = (
 		const itemValuesNew = [title, description];
 
 		if (tags && tags.length > 0) {
-			itemValuesNew.push(...tags);
+			itemValuesNew.push(...tags.map(tagToString));
 		}
 
 		// Check if any property value contains the searchValue

--- a/frontend/src/periscope/components/KeyValueLabel/KeyValueLabel.tsx
+++ b/frontend/src/periscope/components/KeyValueLabel/KeyValueLabel.tsx
@@ -1,3 +1,4 @@
+import { isValidElement } from 'react';
 import { Tooltip } from 'antd';
 
 import TrimmedText from '../TrimmedText/TrimmedText';
@@ -13,6 +14,32 @@ type KeyValueLabelProps = {
 	onClick?: () => void;
 };
 
+/**
+ * badgeKey/badgeValue are typed as `string | ReactNode`, but callers have accidentally
+ * passed plain objects (e.g. an untyped API error/value) that satisfy that type yet
+ * aren't renderable, crashing the whole app with "Objects are not valid as a React
+ * child" (React error #31). Coerce anything that isn't a primitive or a valid element
+ * to a string instead of handing it to React as a child.
+ */
+function toRenderable(value: unknown): React.ReactNode {
+	if (
+		value === null ||
+		value === undefined ||
+		typeof value === 'string' ||
+		typeof value === 'number' ||
+		typeof value === 'boolean' ||
+		isValidElement(value)
+	) {
+		return value as React.ReactNode;
+	}
+
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}
+
 export default function KeyValueLabel({
 	badgeKey,
 	badgeValue,
@@ -24,13 +51,16 @@ export default function KeyValueLabel({
 		return null;
 	}
 
+	const safeBadgeKey = toRenderable(badgeKey);
+	const safeBadgeValue = toRenderable(badgeValue);
+
 	const renderValue = (): JSX.Element => {
-		if (typeof badgeValue !== 'string') {
-			return <div className="key-value-label__value">{badgeValue}</div>;
+		if (typeof safeBadgeValue !== 'string') {
+			return <div className="key-value-label__value">{safeBadgeValue}</div>;
 		}
 
 		return (
-			<Tooltip title={badgeValue}>
+			<Tooltip title={safeBadgeValue}>
 				<div
 					className={`key-value-label__value ${
 						onClick ? 'key-value-label__value--clickable' : ''
@@ -48,7 +78,7 @@ export default function KeyValueLabel({
 							: undefined
 					}
 				>
-					<TrimmedText text={badgeValue} maxCharacters={maxCharacters} />
+					<TrimmedText text={safeBadgeValue} maxCharacters={maxCharacters} />
 				</div>
 			</Tooltip>
 		);
@@ -57,10 +87,10 @@ export default function KeyValueLabel({
 	return (
 		<div className={`key-value-label key-value-label--${direction}`}>
 			<div className="key-value-label__key">
-				{typeof badgeKey === 'string' ? (
-					<TrimmedText text={badgeKey} maxCharacters={maxCharacters} />
+				{typeof safeBadgeKey === 'string' ? (
+					<TrimmedText text={safeBadgeKey} maxCharacters={maxCharacters} />
 				) : (
-					badgeKey
+					safeBadgeKey
 				)}
 			</div>
 			{renderValue()}


### PR DESCRIPTION
## Summary

On a fresh self-hosted community install, both the Home page and the Dashboards list crash to the generic error boundary ("Something went wrong :/") shortly after load, while Traces/Metrics/Logs/Alerts pages work fine. Confirmed via a de-minified stack trace (source maps are served alongside the production bundle) against a live instance — this is two related, now-confirmed bugs, not the speculative one I originally opened this PR with (see below for that history).

## Root cause (confirmed)

```
TypeError: e.toLowerCase is not a function
    at utils.ts:21   (value.toLowerCase())
    at utils.ts:19   (itemValuesNew.some(...))
    at utils.ts:10   (dashboardList.filter(...))
    at DashboardsList.tsx:180  (filterDashboards(...))
```

`Dashboard['data']['tags']` is typed as `string[]` (`types/api/dashboard/getAll.ts:92`), but the backend response actually contains `{key, value}` objects instead of plain strings — a mismatch the type system can't catch since API responses are cast, not runtime-validated.

Two consumers assume the old plain-string shape and crash on the object shape:

1. **`container/ListOfDashboard/utils.ts`** (`filterDashboards`) — spreads `tags` directly into a list of values it calls `.toLowerCase()` on, throwing the `TypeError` above the moment the dashboards list (or its search box) renders/filters. This is the exact crash confirmed via the stack trace.
2. **`container/Home/Dashboards/Dashboards.tsx`** — the legacy (non-v2) branch passes `data.tags` straight through to a `<Badge>{tag}</Badge>` child with zero conversion, crashing via React error #31 ("Objects are not valid as a React child (found: object with keys {key, value})") instead. Same root data shape, different failure mode, and matches the Home-page crash I originally saw before getting a de-minified trace.

Both are fixed to normalize each tag to a display string (`key:value`, or just `key` when there's no value) before use, regardless of which shape the backend actually returns — the same normalization the newer `pages/DashboardsListPageV2` code already does correctly for the v2 API (see `pages/DashboardsListPageV2/utils/helpers.ts:tagsToStrings`), just applied to these two legacy call sites that predate that pattern.

## Earlier commit in this PR

The first commit (`fix(frontend): harden KeyValueLabel against non-renderable badge props`) was my initial, more speculative theory before I had a de-minified stack trace to work from — `KeyValueLabel` is a shared component whose prop shape conceptually matched the crash signature, so I hardened it defensively. It's still a valid, low-risk improvement (any future caller passing a non-primitive to `badgeKey`/`badgeValue` would otherwise crash the whole app), so I've left it in rather than dropping it, but the two commits are independent — happy to split them into separate PRs if that's preferred for review.

## Test plan
- [ ] Dashboards list with a dashboard whose tags are `{key, value}` objects: search/filter no longer throws, tag renders as `key:value`
- [ ] Home page "Dashboards" widget with the same data: renders the tag badge instead of crashing
- [ ] Existing string-tag dashboards render unchanged