### PR TITLE
fix(dashboard): filter-quote escaping, panel export encoding, right-legend width, number-panel query warning

### DIFF
--- a/frontend/src/components/QueryBuilderV2/__tests__/utils.test.ts
+++ b/frontend/src/components/QueryBuilderV2/__tests__/utils.test.ts
@@ -9,6 +9,7 @@ import { extractQueryPairs } from 'utils/queryContextUtils';
 
 import {
 	convertAggregationToExpression,
+	convertExpressionToFilters,
 	convertFiltersToExpression,
 	convertFiltersToExpressionWithExistingQuery,
 	formatValueForExpression,
@@ -1596,6 +1597,38 @@ describe('formatValueForExpression', () => {
 		it('should handle array with single element', () => {
 			expect(formatValueForExpression(['single'])).toBe("['single']");
 			expect(formatValueForExpression([123] as any)).toBe('[123]');
+		});
+	});
+
+	// Regression: an escaped single quote must not gain a backslash on each
+	// expression <-> filters round-trip (broke Create Alert from a panel).
+	describe('escaped quote round-trip', () => {
+		const EXPR = "name = 'it\\'s a ribbon'"; // name = 'it\'s a ribbon' (single backslash)
+
+		it('stores the unescaped value in the filter item', () => {
+			const items = convertExpressionToFilters(EXPR);
+			expect(items).toHaveLength(1);
+			expect(items[0].value).toBe("it's a ribbon");
+		});
+
+		it('is lossless: expression -> filters -> expression', () => {
+			const items = convertExpressionToFilters(EXPR);
+			expect(convertFiltersToExpression({ items, op: 'AND' }).expression).toBe(
+				EXPR,
+			);
+		});
+
+		it('is idempotent across repeated existing-query conversions', () => {
+			const pass1 = convertFiltersToExpressionWithExistingQuery(
+				{ items: [], op: 'AND' },
+				EXPR,
+			);
+			expect(pass1.filter.expression).toBe(EXPR);
+			const pass2 = convertFiltersToExpressionWithExistingQuery(
+				pass1.filters,
+				pass1.filter.expression,
+			);
+			expect(pass2.filter.expression).toBe(EXPR);
 		});
 	});
 });

--- a/frontend/src/components/QueryBuilderV2/utils.ts
+++ b/frontend/src/components/QueryBuilderV2/utils.ts
@@ -176,7 +176,9 @@ function formatSingleValueForFilter(
 		}
 
 		if (isQuoted(value)) {
-			return unquote(value);
+			// Unescape `\'` → `'` (inverse of formatSingleValue) so the round-trip doesn't
+			// double the backslash each pass.
+			return unquote(value).replace(/\\'/g, "'");
 		}
 	}
 

--- a/frontend/src/container/DashboardContainer/visualization/charts/Pie/Pie.module.scss
+++ b/frontend/src/container/DashboardContainer/visualization/charts/Pie/Pie.module.scss
@@ -65,4 +65,5 @@
 	min-width: 0;
 	padding-left: 12px;
 	padding-bottom: 12px;
+	padding-top: 8px;
 }

--- a/frontend/src/container/DashboardContainer/visualization/charts/__tests__/utils.test.ts
+++ b/frontend/src/container/DashboardContainer/visualization/charts/__tests__/utils.test.ts
@@ -25,18 +25,50 @@ describe('calculateChartDimensions', () => {
 		});
 	});
 
-	it('RIGHT: reserves a side column capped at 30% of the width and keeps full height', () => {
+	it('RIGHT: reserves a side column capped at 320px / 40% of the width and keeps full height', () => {
 		const dims = calculateChartDimensions({
 			containerWidth: 1000,
 			containerHeight: 400,
 			legendConfig: { position: LegendPosition.RIGHT },
 			seriesLabels: labels(10, 40),
 		});
-		// 40-char labels approximate to 336px, capped at min(240, 30% of 1000).
-		expect(dims.legendWidth).toBe(240);
-		expect(dims.width).toBe(760);
+		expect(dims.legendWidth).toBe(320);
+		expect(dims.width).toBe(680);
 		expect(dims.height).toBe(400);
 		expect(dims.legendHeight).toBe(400);
+	});
+
+	it('RIGHT: sizes the column to the longest label when it fits under the cap', () => {
+		const dims = calculateChartDimensions({
+			containerWidth: 1000,
+			containerHeight: 400,
+			legendConfig: { position: LegendPosition.RIGHT },
+			seriesLabels: labels(5, 20),
+		});
+		expect(dims.legendWidth).toBe(216);
+		expect(dims.width).toBe(784);
+	});
+
+	it('RIGHT: never shrinks the column below the 150px floor', () => {
+		const dims = calculateChartDimensions({
+			containerWidth: 1000,
+			containerHeight: 400,
+			legendConfig: { position: LegendPosition.RIGHT },
+			seriesLabels: labels(3, 3),
+		});
+		expect(dims.legendWidth).toBe(150);
+		expect(dims.width).toBe(850);
+	});
+
+	it('RIGHT: on a narrow container the legend never takes more than 40% of the width', () => {
+		const dims = calculateChartDimensions({
+			containerWidth: 300,
+			containerHeight: 400,
+			legendConfig: { position: LegendPosition.RIGHT },
+			seriesLabels: labels(10, 40),
+		});
+		expect(dims.legendWidth).toBe(120);
+		expect(dims.width).toBe(180);
 	});
 
 	it('BOTTOM: a single row of items reserves one legend row', () => {

--- a/frontend/src/container/DashboardContainer/visualization/charts/utils.ts
+++ b/frontend/src/container/DashboardContainer/visualization/charts/utils.ts
@@ -15,6 +15,12 @@ const BASE_LEGEND_WIDTH = 16;
 const LEGEND_PADDING = 12;
 const LEGEND_LINE_HEIGHT = 28;
 
+// RIGHT legend is a vertical column with its own width budget (cap protects the donut).
+const MAX_RIGHT_LEGEND_WIDTH = 320;
+const RIGHT_LEGEND_WIDTH_RATIO = 0.4;
+// Column padding + copy button, not covered by the text-length estimate.
+const RIGHT_LEGEND_RESERVED_WIDTH = 40;
+
 /**
  * Calculates the average width of the legend items based on the labels of the series.
  * @param legends - The labels of the series.
@@ -42,7 +48,7 @@ export function calculateAverageLegendWidth(legends: string[]): number {
  * Implementation details (high level):
  * - Approximates legend item width from label text length, using a fixed average char width.
  * - RIGHT legend:
- *   - `legendWidth` is clamped between 150px and min(MAX_LEGEND_WIDTH, 30% of container width).
+ *   - `legendWidth` fits the longest label, clamped to [150px, min(MAX_RIGHT_LEGEND_WIDTH, 40% width)].
  *   - Chart width is `containerWidth - legendWidth`.
  * - BOTTOM legend:
  *   - Computes how many items fit per row, then uses at most 2 rows.
@@ -80,9 +86,22 @@ export function calculateChartDimensions({
 	const legendItemCount = seriesLabels.length;
 
 	if (legendConfig.position === LegendPosition.RIGHT) {
-		const maxRightLegendWidth = Math.min(MAX_LEGEND_WIDTH, containerWidth * 0.3);
+		// Size the column to the longest name (up to the cap) so it doesn't ellipsize.
+		const longestLabelLength = seriesLabels.reduce(
+			(max, label) => Math.max(max, label.length),
+			0,
+		);
+		const desiredLegendWidth =
+			BASE_LEGEND_WIDTH +
+			longestLabelLength * AVG_CHAR_WIDTH +
+			RIGHT_LEGEND_RESERVED_WIDTH;
+
+		const maxRightLegendWidth = Math.min(
+			MAX_RIGHT_LEGEND_WIDTH,
+			containerWidth * RIGHT_LEGEND_WIDTH_RATIO,
+		);
 		const rightLegendWidth = Math.min(
-			Math.max(150, approxLegendItemWidth),
+			Math.max(150, desiredLegendWidth),
 			maxRightLegendWidth,
 		);
 

--- a/frontend/src/container/DashboardContainer/visualization/layout/ChartLayout/ChartLayout.styles.scss
+++ b/frontend/src/container/DashboardContainer/visualization/layout/ChartLayout/ChartLayout.styles.scss
@@ -15,6 +15,10 @@
 
 	&--legend-right {
 		flex-direction: row;
+
+		.chart-layout__legend-wrapper {
+			padding-top: 8px;
+		}
 	}
 
 	&__legend-wrapper {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/__tests__/newPanelRoute.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/__tests__/newPanelRoute.test.ts
@@ -49,6 +49,14 @@ describe('newPanelRoute', () => {
 			return { path, params: new URLSearchParams(search) };
 		};
 
+		// Mirrors useGetCompositeQueryParam: it decodes the param twice.
+		const readCompositeQuery = (params: URLSearchParams): unknown =>
+			JSON.parse(
+				decodeURIComponent(
+					(params.get('compositeQuery') as string).replace(/\+/g, ' '),
+				),
+			);
+
 		it.each([
 			[PANEL_TYPES.TIME_SERIES, 'signoz/TimeSeriesPanel'],
 			[PANEL_TYPES.TABLE, 'signoz/TablePanel'],
@@ -67,16 +75,34 @@ describe('newPanelRoute', () => {
 			);
 		});
 
-		it('carries the query as a decodable compositeQuery param', () => {
+		it('carries the query as a compositeQuery param the reader can decode', () => {
 			const link = buildExportPanelLink({
 				dashboardId: 'dash-1',
 				panelType: PANEL_TYPES.TIME_SERIES,
 				query,
 			});
 			const { params } = parseLink(link);
-			expect(JSON.parse(params.get('compositeQuery') as string)).toStrictEqual(
-				query,
-			);
+			expect(readCompositeQuery(params)).toStrictEqual(query);
+		});
+
+		// Regression: a bare `%`/`+` must survive the reader's double-decode.
+		it('round-trips a filter expression containing % and + literals', () => {
+			const queryWithLiterals = {
+				id: 'q1',
+				queryType: 'builder',
+				builder: {
+					queryData: [
+						{ filter: { expression: "severity_text ILIKE 'Inf%' AND path = 'a+b'" } },
+					],
+				},
+			} as unknown as Query;
+			const link = buildExportPanelLink({
+				dashboardId: 'dash-1',
+				panelType: PANEL_TYPES.LIST,
+				query: queryWithLiterals,
+			});
+			const { params } = parseLink(link);
+			expect(readCompositeQuery(params)).toStrictEqual(queryWithLiterals);
 		});
 
 		it('returns null for a panel type with no V2 kind', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/newPanelRoute.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/newPanelRoute.ts
@@ -45,9 +45,11 @@ export function parseNewPanelKind(
 
 /**
  * New-panel editor link that exports an explorer query into a V2 dashboard. Carries the
- * raw `Query` as `compositeQuery` encoded as the V1 link so `useGetCompositeQueryParam`
- * reads it identically (conversion happens in the editor). `null` when the panel type has
- * no V2 kind, so the caller skips the export instead of landing on an unrelated kind.
+ * raw `Query` as `compositeQuery` (conversion happens in the editor). `null` when the panel
+ * type has no V2 kind, so the caller skips the export instead of landing on an unrelated kind.
+ *
+ * Double-encoded on purpose: `useGetCompositeQueryParam` decodes twice, so a single encode
+ * would let a bare `%`/`+` (e.g. `ILIKE 'Inf%'`) break its second decode and drop the query.
  */
 export function buildExportPanelLink({
 	dashboardId,
@@ -68,7 +70,7 @@ export function buildExportPanelLink({
 	});
 	return `${path}${newPanelSearch(kind)}&${
 		QueryParams.compositeQuery
-	}=${encodeURIComponent(JSON.stringify(query))}`;
+	}=${encodeURIComponent(encodeURIComponent(JSON.stringify(query)))}`;
 }
 
 /** Target section index for a new panel, or undefined when unset/invalid. */

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/countEnabledQueries.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/countEnabledQueries.test.ts
@@ -1,0 +1,80 @@
+import type { DashboardtypesQueryDTO } from 'api/generated/services/sigNoz.schemas';
+
+import { countEnabledQueries } from '../countEnabledQueries';
+
+function compositeQuery(
+	envelopes: { type: string; disabled?: boolean }[],
+): DashboardtypesQueryDTO {
+	return {
+		spec: {
+			plugin: {
+				kind: 'signoz/CompositeQuery',
+				spec: {
+					queries: envelopes.map(({ type, disabled }) => ({
+						type,
+						spec: { disabled },
+					})),
+				},
+			},
+		},
+	} as unknown as DashboardtypesQueryDTO;
+}
+
+function bareBuilderQuery(disabled?: boolean): DashboardtypesQueryDTO {
+	return {
+		spec: {
+			plugin: { kind: 'signoz/BuilderQuery', spec: { signal: 'logs', disabled } },
+		},
+	} as unknown as DashboardtypesQueryDTO;
+}
+
+describe('countEnabledQueries', () => {
+	it('returns 0 when there are no queries', () => {
+		expect(countEnabledQueries([])).toBe(0);
+	});
+
+	it('counts every enabled envelope inside the composite wrapper', () => {
+		expect(
+			countEnabledQueries([
+				compositeQuery([{ type: 'builder_query' }, { type: 'builder_query' }]),
+			]),
+		).toBe(2);
+	});
+
+	it('does not count disabled envelopes', () => {
+		expect(
+			countEnabledQueries([
+				compositeQuery([
+					{ type: 'builder_query' },
+					{ type: 'builder_query', disabled: true },
+				]),
+			]),
+		).toBe(1);
+	});
+
+	it('counts formula envelopes alongside builder queries', () => {
+		expect(
+			countEnabledQueries([
+				compositeQuery([
+					{ type: 'builder_query' },
+					{ type: 'builder_query' },
+					{ type: 'builder_formula' },
+				]),
+			]),
+		).toBe(3);
+	});
+
+	it('treats an absent disabled flag as enabled', () => {
+		expect(
+			countEnabledQueries([compositeQuery([{ type: 'builder_query' }])]),
+		).toBe(1);
+	});
+
+	it('unwraps a bare builder query (List panel shape)', () => {
+		expect(countEnabledQueries([bareBuilderQuery()])).toBe(1);
+	});
+
+	it('does not count a disabled bare builder query', () => {
+		expect(countEnabledQueries([bareBuilderQuery(true)])).toBe(0);
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/countEnabledQueries.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/countEnabledQueries.ts
@@ -1,0 +1,8 @@
+import type { DashboardtypesQueryDTO } from 'api/generated/services/sigNoz.schemas';
+import { toQueryEnvelopes } from 'pages/DashboardPageV2/DashboardContainer/queryV5/buildQueryRangeRequest';
+
+/** Counts enabled queries, unwrapping the single `signoz/CompositeQuery` wrapper. */
+export function countEnabledQueries(queries: DashboardtypesQueryDTO[]): number {
+	return toQueryEnvelopes(queries).filter((envelope) => !envelope.spec?.disabled)
+		.length;
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelHeader/PanelHeader.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelHeader/PanelHeader.tsx
@@ -15,6 +15,7 @@ import PanelHeaderSearch from './PanelHeaderSearch';
 import PanelStatusPopover from '../PanelStatus/PanelStatusPopover';
 import {
 	panelStatusFromError,
+	panelStatusFromMultipleEnabledQueries,
 	panelStatusFromWarning,
 } from '../PanelStatus/utils';
 import styles from './PanelHeader.module.scss';
@@ -74,11 +75,24 @@ function PanelHeader({
 		[warning],
 	);
 
+	// Client-derived: warn a Number panel that has more than one enabled query (#9512).
+	const multiQueryWarningDetail = useMemo(
+		() => panelStatusFromMultipleEnabledQueries(panel),
+		[panel],
+	);
+
 	/**
 	 * Hide the entire header when there's no title, description, or status to show,
 	 * and the actions menu is suppressed (editor preview).
 	 */
-	if (!name && !description && !errorDetail && !warningDetail && hideActions) {
+	if (
+		!name &&
+		!description &&
+		!errorDetail &&
+		!warningDetail &&
+		!multiQueryWarningDetail &&
+		hideActions
+	) {
 		return <Fragment />;
 	}
 
@@ -123,6 +137,13 @@ function PanelHeader({
 				{errorDetail && <PanelStatusPopover variant="error" detail={errorDetail} />}
 				{warningDetail && (
 					<PanelStatusPopover variant="warning" detail={warningDetail} />
+				)}
+				{multiQueryWarningDetail && (
+					<PanelStatusPopover
+						variant="warning"
+						detail={multiQueryWarningDetail}
+						testId="panel-status-config-warning"
+					/>
 				)}
 				{/* Renders nothing when no action survives its gates (kind/role/context). */}
 				{!hideActions && (

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelStatus/PanelStatusPopover.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelStatus/PanelStatusPopover.tsx
@@ -17,6 +17,8 @@ const VARIANT_CONFIG: Record<
 interface PanelStatusPopoverProps {
 	variant: PanelStatusVariant;
 	detail: PanelStatusDetail;
+	/** Overrides the trigger's test id; defaults to `panel-status-<variant>`. */
+	testId?: string;
 }
 
 /**
@@ -26,6 +28,7 @@ interface PanelStatusPopoverProps {
 function PanelStatusPopover({
 	variant,
 	detail,
+	testId,
 }: PanelStatusPopoverProps): JSX.Element {
 	const { color, ariaLabel } = VARIANT_CONFIG[variant];
 	const Icon = variant === 'error' ? CircleX : TriangleAlert;
@@ -41,7 +44,7 @@ function PanelStatusPopover({
 			<span
 				className={styles.trigger}
 				aria-label={ariaLabel}
-				data-testid={`panel-status-${variant}`}
+				data-testid={testId ?? `panel-status-${variant}`}
 			>
 				<Icon size={16} color={color} />
 			</span>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelStatus/__tests__/utils.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelStatus/__tests__/utils.test.ts
@@ -1,9 +1,16 @@
-import type { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
+import type {
+	DashboardtypesPanelDTO,
+	Querybuildertypesv5QueryWarnDataDTO as WarningDTO,
+	RenderErrorResponseDTO,
+} from 'api/generated/services/sigNoz.schemas';
 import type { AxiosError } from 'axios';
-import type { Querybuildertypesv5QueryWarnDataDTO as WarningDTO } from 'api/generated/services/sigNoz.schemas';
 import { StatusCodes } from 'http-status-codes';
 
-import { panelStatusFromError, panelStatusFromWarning } from '../utils';
+import {
+	panelStatusFromError,
+	panelStatusFromMultipleEnabledQueries,
+	panelStatusFromWarning,
+} from '../utils';
 
 // The query layer rejects with the raw AxiosError from the generated client
 // (it is not pre-converted to APIError), so the tests mirror that wire shape.
@@ -85,5 +92,64 @@ describe('panelStatusFromWarning', () => {
 			docsUrl: 'https://docs/warn',
 			messages: ['series A truncated'],
 		});
+	});
+});
+
+function panel(
+	kind: string,
+	envelopes: { disabled?: boolean }[],
+): DashboardtypesPanelDTO {
+	return {
+		spec: {
+			plugin: { kind, spec: {} },
+			queries: [
+				{
+					spec: {
+						plugin: {
+							kind: 'signoz/CompositeQuery',
+							spec: {
+								queries: envelopes.map(({ disabled }) => ({
+									type: 'builder_query',
+									spec: { disabled },
+								})),
+							},
+						},
+					},
+				},
+			],
+		},
+	} as unknown as DashboardtypesPanelDTO;
+}
+
+describe('panelStatusFromMultipleEnabledQueries', () => {
+	it('warns when a Number panel has more than one enabled query', () => {
+		const detail = panelStatusFromMultipleEnabledQueries(
+			panel('signoz/NumberPanel', [{}, {}]),
+		);
+		expect(detail).not.toBeNull();
+		expect(detail?.message).toMatch(/single value/i);
+		expect(detail?.messages).toHaveLength(1);
+	});
+
+	it('counts only enabled queries (a disabled second query is fine)', () => {
+		expect(
+			panelStatusFromMultipleEnabledQueries(
+				panel('signoz/NumberPanel', [{}, { disabled: true }]),
+			),
+		).toBeNull();
+	});
+
+	it('does not warn when a Number panel has a single enabled query', () => {
+		expect(
+			panelStatusFromMultipleEnabledQueries(panel('signoz/NumberPanel', [{}])),
+		).toBeNull();
+	});
+
+	it('does not warn for other panel kinds even with multiple enabled queries', () => {
+		expect(
+			panelStatusFromMultipleEnabledQueries(
+				panel('signoz/TimeSeriesPanel', [{}, {}]),
+			),
+		).toBeNull();
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelStatus/utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/PanelStatus/utils.ts
@@ -1,7 +1,11 @@
 import { convertToApiError } from 'api/ErrorResponseHandlerForGeneratedAPIs';
-import type { RenderErrorResponseDTO } from 'api/generated/services/sigNoz.schemas';
+import type {
+	DashboardtypesPanelDTO,
+	Querybuildertypesv5QueryWarnDataDTO as WarningDTO,
+	RenderErrorResponseDTO,
+} from 'api/generated/services/sigNoz.schemas';
 import type { AxiosError } from 'axios';
-import type { Querybuildertypesv5QueryWarnDataDTO as WarningDTO } from 'api/generated/services/sigNoz.schemas';
+import { countEnabledQueries } from 'pages/DashboardPageV2/DashboardContainer/Panels/utils/countEnabledQueries';
 
 import type { PanelStatusDetail } from './types';
 
@@ -50,5 +54,27 @@ export function panelStatusFromWarning(
 		messages: (warning.warnings ?? [])
 			.map((w) => w.message)
 			.filter((message): message is string => Boolean(message)),
+	};
+}
+
+/**
+ * A Number panel renders only the first query's value, so more than one enabled
+ * query silently hides the rest. Warns for that case; null otherwise.
+ */
+export function panelStatusFromMultipleEnabledQueries(
+	panel: DashboardtypesPanelDTO,
+): PanelStatusDetail | null {
+	if (panel.spec.plugin.kind !== 'signoz/NumberPanel') {
+		return null;
+	}
+	if (countEnabledQueries(panel.spec.queries) <= 1) {
+		return null;
+	}
+	return {
+		message:
+			'This panel shows a single value, but more than one query is enabled.',
+		messages: [
+			"Disable the queries you don't want to display, keeping only the one whose value you want to show.",
+		],
 	};
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/PanelHeader.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/__tests__/PanelHeader.test.tsx
@@ -41,6 +41,40 @@ function makePanel(overrides?: {
 	} as unknown as DashboardtypesPanelDTO;
 }
 
+// Blank name so the editor-preview guard test relies on the warning alone.
+function makePanelWithQueries(
+	kind: string,
+	enabled: number,
+	disabled = 0,
+): DashboardtypesPanelDTO {
+	const envelope = (isDisabled: boolean): unknown => ({
+		type: 'builder_query',
+		spec: { disabled: isDisabled },
+	});
+	return {
+		kind: 'Panel',
+		spec: {
+			display: { name: '' },
+			plugin: { kind, spec: {} },
+			queries: [
+				{
+					spec: {
+						plugin: {
+							kind: 'signoz/CompositeQuery',
+							spec: {
+								queries: [
+									...Array.from({ length: enabled }, () => envelope(false)),
+									...Array.from({ length: disabled }, () => envelope(true)),
+								],
+							},
+						},
+					},
+				},
+			],
+		},
+	} as unknown as DashboardtypesPanelDTO;
+}
+
 const baseProps = {
 	panel: makePanel(),
 	panelId: 'panel-1',
@@ -98,6 +132,53 @@ describe('PanelHeader status indicators', () => {
 		renderWithProvider(<PanelHeader {...baseProps} />);
 		expect(screen.queryByTestId('panel-status-error')).not.toBeInTheDocument();
 		expect(screen.queryByTestId('panel-status-warning')).not.toBeInTheDocument();
+	});
+});
+
+describe('PanelHeader multi-query config warning (issue #9512)', () => {
+	it('warns when a Number panel has more than one enabled query', () => {
+		renderWithProvider(
+			<PanelHeader
+				{...baseProps}
+				panel={makePanelWithQueries('signoz/NumberPanel', 2)}
+			/>,
+		);
+		expect(screen.getByTestId('panel-status-config-warning')).toBeInTheDocument();
+	});
+
+	it('does not warn when only one query is enabled (others disabled)', () => {
+		renderWithProvider(
+			<PanelHeader
+				{...baseProps}
+				panel={makePanelWithQueries('signoz/NumberPanel', 1, 2)}
+			/>,
+		);
+		expect(
+			screen.queryByTestId('panel-status-config-warning'),
+		).not.toBeInTheDocument();
+	});
+
+	it('does not warn for non-Number panels with multiple enabled queries', () => {
+		renderWithProvider(
+			<PanelHeader
+				{...baseProps}
+				panel={makePanelWithQueries('signoz/TimeSeriesPanel', 3)}
+			/>,
+		);
+		expect(
+			screen.queryByTestId('panel-status-config-warning'),
+		).not.toBeInTheDocument();
+	});
+
+	it('shows the warning in the editor preview (hideActions, no title)', () => {
+		renderWithProvider(
+			<PanelHeader
+				{...baseProps}
+				panel={makePanelWithQueries('signoz/NumberPanel', 2)}
+				hideActions
+			/>,
+		);
+		expect(screen.getByTestId('panel-status-config-warning')).toBeInTheDocument();
 	});
 });
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Four small, independent changes in the V2 dashboard / query-builder area, one per commit:

1. **`fix(qb)`** — Filter values with an escaped single quote gained an extra backslash on every `expression ⇄ filters` round-trip, breaking **Create alert from panel**.
2. **`fix(dashboard)`** — The explorer→V2-dashboard panel export link single-encoded `compositeQuery`, so a `%`/`+` literal in a filter dropped the whole query on read.
3. **`fix(dashboard)`** — A right-positioned pie/donut legend was capped too narrowly and ellipsized long series names.
4. **`feat(dashboard)`** — A Number panel with more than one enabled query silently shows only the first query's value; now it surfaces a warning (in the editor and on the rendered panel) prompting the user to disable the extras.

Each is committed separately so they can be reviewed in isolation.

#### Screenshots / Screen Recordings (if applicable)

Fix 1 (before): `name = 'it\'s a ribbon'` in a panel became `name = 'it\\'s a ribbon'` on the alert page and failed with `token recognition error at: '''`.

#### Issues closed by this PR

Closes https://github.com/SigNoz/pulse-pod/issues/137
Closes https://github.com/SigNoz/signoz/issues/9512

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

**1. Escaped-quote doubling.** `formatSingleValue` escapes `'` → `\'` when it serializes a filter value into an expression, but its inverse (`unquote`, used by `formatSingleValueForFilter`) only stripped the surrounding quotes and never unescaped. So each `expression → filters → expression` pass added one backslash. Creating an alert from a panel re-reads the query through the URL twice (`useGetCompositeQueryParam` populates `filters.items` with the lossy value on the first read; a subsequent `redirectWithQueryBuilderData` writes it back and the second read re-escapes), turning `name = 'it\'s a ribbon'` into `name = 'it\\'s a ribbon'`.

**2. Single-encoded compositeQuery.** `useGetCompositeQueryParam` decodes the `compositeQuery` param twice (once via `URLSearchParams.get()`, once via `decodeURIComponent`). `buildExportPanelLink` encoded only once, so a bare `%`/`+` from a filter expression (e.g. `ILIKE 'Inf%'`) made the reader's second decode throw and drop the query.

**3. Right-legend width.** The right legend reused the bottom-legend width cap (`min(MAX_LEGEND_WIDTH, 30% width)`), which is tuned for row-packing and left a vertical column too narrow for long labels.

**4. Number panel shows only the first query.** A Number/Value panel renders a single scalar — internally it takes the first query's result (`prepareNumberData`). When a user builds a formula but leaves its input queries enabled (or otherwise leaves more than one query on), the panel silently shows query `A` instead of the intended value, with no feedback. This is a common trap and the subject of #9512.

#### Fix Strategy

1. Make `formatSingleValueForFilter` a true inverse of `formatSingleValue` — unescape `\'` → `'` after unquoting, so the round-trip is lossless and idempotent.
2. Double-encode `compositeQuery` in `buildExportPanelLink` so it survives the reader's double decode.
3. Give the right legend its own budget: size it to the longest label, clamped to `[150px, min(320, 40% width)]`.
4. Surface a non-blocking warning (the existing amber status popover) when a Number panel has more than one enabled query. A new `countEnabledQueries` util unwraps the single `signoz/CompositeQuery` wrapper and counts envelopes whose spec is not `disabled`; a `panelStatusFromMultipleEnabledQueries` adapter turns that into a warning for the `signoz/NumberPanel` kind. It's wired into the shared `PanelHeader`, so it shows in both the editor preview and the rendered grid panel and updates live as queries are toggled. We warn rather than auto-disable because the app can't infer which query the user meant to show, and formulas need their input queries enabled — auto-disabling would either guess wrong or break the formula, and would mutate the shared dashboard spec.

---

### 🧪 Testing Strategy

- **Tests added/updated:**
  - `QueryBuilderV2/__tests__/utils.test.ts` — new `escaped quote round-trip` suite: unescaped filter-item value, lossless `expression → filters → expression`, and idempotency across repeated existing-query conversions.
  - `PanelEditor/__tests__/newPanelRoute.test.ts` — round-trips a filter expression containing `%` and `+` literals through the reader's double-decode.
  - `charts/__tests__/utils.test.ts` — right-legend sizing (caps at max, sizes to longest label, respects the 150px floor).
  - `Panels/utils/__tests__/countEnabledQueries.test.ts` — enabled-query counting across the composite wrapper, disabled envelopes, formulas, and the bare-builder (List) shape.
  - `Panel/PanelStatus/__tests__/utils.test.ts` — `panelStatusFromMultipleEnabledQueries` warns only for a Number panel with >1 enabled query.
  - `Panel/__tests__/PanelHeader.test.tsx` — the warning renders on a multi-query Number panel (grid + editor preview) and is absent for single-query and non-Number panels.
- **Manual verification:** Reproduced the original `token recognition error` from a panel filter with an escaped quote, then confirmed the alert page now receives the expression verbatim.
- **Edge cases covered:** values with `%`/`+` literals; multi-pass URL round-trips; long series names in the right legend; disabled queries and formula envelopes in the enabled-query count.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** `formatSingleValueForFilter` is shared by the query builder's `convertExpressionToFilters` / `convertFiltersToExpressionWithExistingQuery`, so it also affects explorer/metrics/trace filter parsing — the change only makes stored values more correct (unescaped), and re-serialization re-escapes them. The number-panel warning is additive and V2-only: it derives from `panel.spec.queries`, adds no query-behavior change, and reuses the existing status-popover machinery.
- **Potential regressions:** Any consumer that expected the previously-escaped `filters.items` value; none found — display and re-serialization paths both handle the unescaped form.
- **Rollback plan:** Revert the offending commit(s); each fix is isolated in its own commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix + Feature |
| Description | Creating an alert from a dashboard panel no longer corrupts filter expressions that contain quotes; exporting an explorer query to a V2 dashboard no longer drops filters containing `%`/`+`; right-side pie/donut legends fit long series names; a Number panel now warns when more than one query is enabled (only the first is displayed). |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The four commits are independent — review each on its own. Fix 1 is the shared query-builder utility change (widest blast radius); fixes 2 and 3 are localized to the V2 panel export link and the pie/donut chart legend respectively; change 4 (the Number-panel multi-query warning, #9512) is additive and confined to the V2 panel header + two small utils.

---
