### PR TITLE
fix(quick-filters): smooth only/toggle hover reveal

### DIFF
--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.styles.scss
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/Checkbox.styles.scss
@@ -92,52 +92,76 @@
 						color: var(--l3-foreground);
 					}
 
-					.only-btn {
-						cursor: not-allowed;
-						color: var(--l3-foreground);
-					}
-
+					.only-btn,
 					.toggle-btn {
 						cursor: not-allowed;
 						color: var(--l3-foreground);
 					}
 				}
 
-				.only-btn {
-					display: none;
+				// Stack "Only"/"All" and "Toggle" in a single cell so revealing
+				// one swaps in place instead of shifting the row layout.
+				.value-actions {
+					display: grid;
+					align-items: center;
+					justify-items: end;
+
+					> * {
+						grid-area: 1 / 1;
+					}
 				}
+
+				.only-btn,
 				.toggle-btn {
 					display: none;
-				}
-
-				.toggle-btn:hover {
-					background-color: unset;
-				}
-
-				.only-btn:hover {
-					background-color: unset;
-				}
-			}
-
-			.checkbox-value-section:hover {
-				.toggle-btn {
-					display: none;
-				}
-				.only-btn {
-					display: flex;
 					align-items: center;
 					justify-content: center;
 					height: 21px;
+					opacity: 0;
+					transform: translateX(4px);
+					// `display` is animated as a discrete property so the button
+					// stays mounted through its fade-out on exit.
+					transition:
+						opacity 0.16s ease,
+						transform 0.16s ease,
+						display 0.16s allow-discrete;
+
+					&:hover {
+						background-color: unset;
+					}
+				}
+			}
+
+			// Hovering the label/value area reveals the "Only"/"All" action.
+			.checkbox-value-section:hover .only-btn {
+				display: flex;
+				opacity: 1;
+				transform: translateX(0);
+
+				// Entry animation start state (fires on the display switch).
+				@starting-style {
+					opacity: 0;
+					transform: translateX(4px);
+				}
+			}
+
+			// Hovering the checkbox reveals the "Toggle" action.
+			.check-box:hover ~ .checkbox-value-section .toggle-btn {
+				display: flex;
+				opacity: 1;
+				transform: translateX(0);
+
+				@starting-style {
+					opacity: 0;
+					transform: translateX(4px);
 				}
 			}
 		}
 
-		.value:hover {
+		@media (prefers-reduced-motion: reduce) {
+			.only-btn,
 			.toggle-btn {
-				display: flex;
-				align-items: center;
-				justify-content: center;
-				height: 21px;
+				transition: none;
 			}
 		}
 	}

--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/CheckboxValueRow.tsx
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/CheckboxValueRow.tsx
@@ -53,12 +53,14 @@ function CheckboxValueRow({
 						</Typography.Text>
 					</TooltipSimple>
 				)}
-				<Button type="text" className="only-btn">
-					{onlyButtonLabel}
-				</Button>
-				<Button type="text" className="toggle-btn">
-					Toggle
-				</Button>
+				<div className="value-actions">
+					<Button type="text" className="only-btn">
+						{onlyButtonLabel}
+					</Button>
+					<Button type="text" className="toggle-btn">
+						Toggle
+					</Button>
+				</div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The `Only` / `All` and `Toggle` action buttons in the quick-filters checkbox row (`FilterRenderers/Checkbox`) revealed on hover with a visible "jerk": hovering a row first showed `Toggle`, then `Only` appeared **beside** it, shifting the row's layout. The swap was also an instant `display` flip with no animation.

This PR makes the hover reveal clean and smooth without changing any filtering behavior — it's purely presentational (CSS + one wrapper element).

#### Screenshots / Screen Recordings (if applicable)

Before - 


https://github.com/user-attachments/assets/1d6bb600-d833-46c5-8eb8-736b935119a4

After - 



https://github.com/user-attachments/assets/b78bf96f-8375-488d-9c2b-1e82f2509562





#### Issues closed by this PR

https://github.com/orgs/SigNoz/projects/39/views/11?filterQuery=assignee%3Atewarig&pane=issue&itemId=212848255&issue=SigNoz%7Cengineering-pod%7C5696 

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context


---

### 🧪 Testing Strategy

- **Tests added/updated:** none required — change is CSS + a presentational wrapper; no logic/props changed. Existing `Checkbox.test.tsx` (7 tests) still passes.


---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** the v1 quick-filters checkbox renderer only (used across Logs/Infra/Metrics/API explorers). v2 renderer untouched.
- **Potential regressions:** low — no change to filter query logic or click handlers; only hover visuals and DOM nesting of the two action buttons.
- **Rollback plan:** revert this PR; purely presentational, no data/state migration.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Quick-filter value rows no longer flicker/shift when hovering; the Only/Toggle actions now fade in smoothly. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers
