### PR TITLE
fix(tracedetail): correct EndTimestampMillis in flamegraph API response

### DIFF
--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -182,7 +182,6 @@ func (m *module) getFullFlamegraph(ctx context.Context, traceID string, summary 
 		return nil, spantypes.ErrTraceNotFound
 	}
 	flamegraphTrace := spantypes.NewFlamegraphTraceFromStorable(fullSpans, selectFields)
-	// Use span-derived bounds: summary.End = max(span_start), which misses span durations.
 	start, end := flamegraphTrace.TimeRange()
 	return spantypes.NewGettableFlamegraphTrace(flamegraphTrace.GetAllLevels(), start, end, false), nil
 }
@@ -200,8 +199,6 @@ func (m *module) getWindowedFlamegraph(ctx context.Context, traceID, selectedSpa
 	flamegraphTrace := spantypes.NewFlamegraphTraceFromMinimal(minimalSpans)
 	minimalSpans = nil //nolint:ineffassign,wastedassign // release backing array before further db calls
 
-	// Capture span-derived bounds before GetSelectedLevels (which nils span children).
-	// summary.End = max(span_start) from the MV, which misses span durations.
 	start, end := flamegraphTrace.TimeRange()
 
 	cfg := m.config.Flamegraph

--- a/pkg/modules/tracedetail/impltracedetail/module.go
+++ b/pkg/modules/tracedetail/impltracedetail/module.go
@@ -182,7 +182,9 @@ func (m *module) getFullFlamegraph(ctx context.Context, traceID string, summary 
 		return nil, spantypes.ErrTraceNotFound
 	}
 	flamegraphTrace := spantypes.NewFlamegraphTraceFromStorable(fullSpans, selectFields)
-	return spantypes.NewGettableFlamegraphTrace(flamegraphTrace.GetAllLevels(), summary.Start, summary.End, false), nil
+	// Use span-derived bounds: summary.End = max(span_start), which misses span durations.
+	start, end := flamegraphTrace.TimeRange()
+	return spantypes.NewGettableFlamegraphTrace(flamegraphTrace.GetAllLevels(), start, end, false), nil
 }
 
 // getWindowedFlamegraph returns a window of a max levels and max sampled spans per level around the selected span.
@@ -198,6 +200,10 @@ func (m *module) getWindowedFlamegraph(ctx context.Context, traceID, selectedSpa
 	flamegraphTrace := spantypes.NewFlamegraphTraceFromMinimal(minimalSpans)
 	minimalSpans = nil //nolint:ineffassign,wastedassign // release backing array before further db calls
 
+	// Capture span-derived bounds before GetSelectedLevels (which nils span children).
+	// summary.End = max(span_start) from the MV, which misses span durations.
+	start, end := flamegraphTrace.TimeRange()
+
 	cfg := m.config.Flamegraph
 	selectedSpans := flamegraphTrace.GetSelectedLevels(selectedSpanID, cfg.MaxSelectedLevels, cfg.MaxSpansPerLevel, cfg.SamplingTopLatencySpansCount, cfg.SamplingBucketCount)
 	if len(selectedSpans) == 0 {
@@ -210,5 +216,5 @@ func (m *module) getWindowedFlamegraph(ctx context.Context, traceID, selectedSpa
 	}
 
 	enrichedSpans := flamegraphTrace.EnrichSelectedSpans(selectedSpans, fullSpans, selectFields)
-	return spantypes.NewGettableFlamegraphTrace(enrichedSpans, summary.Start, summary.End, true), nil
+	return spantypes.NewGettableFlamegraphTrace(enrichedSpans, start, end, true), nil
 }

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -2,6 +2,7 @@ package spantypes
 
 import (
 	"sort"
+	"time"
 
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 )
@@ -119,6 +120,12 @@ func (t *FlamegraphTrace) updateTimeRange(timestamp, durationNano uint64) {
 	if end := timestamp + durationNano; end > t.endTime {
 		t.endTime = end
 	}
+}
+
+// TimeRange returns the actual trace start and end computed from span timestamps
+// and durations (end = max(span_start + span_duration)), NOT from the summary table.
+func (t *FlamegraphTrace) TimeRange() (start, end time.Time) {
+	return time.Unix(0, int64(t.startTime)), time.Unix(0, int64(t.endTime))
 }
 
 func (t *FlamegraphTrace) buildSpanTree() {

--- a/pkg/types/spantypes/flamegraph_trace.go
+++ b/pkg/types/spantypes/flamegraph_trace.go
@@ -122,8 +122,7 @@ func (t *FlamegraphTrace) updateTimeRange(timestamp, durationNano uint64) {
 	}
 }
 
-// TimeRange returns the actual trace start and end computed from span timestamps
-// and durations (end = max(span_start + span_duration)), NOT from the summary table.
+// TimeRange returns the actual trace start and end computed from span timestamps.
 func (t *FlamegraphTrace) TimeRange() (start, end time.Time) {
 	return time.Unix(0, int64(t.startTime)), time.Unix(0, int64(t.endTime))
 }

--- a/pkg/types/spantypes/flamegraph_trace_test.go
+++ b/pkg/types/spantypes/flamegraph_trace_test.go
@@ -127,6 +127,55 @@ func TestGetAllLevels(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// TimeRange
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestTimeRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		spans     []MinimalSpan
+		wantStart uint64 // nanoseconds since epoch
+		wantEnd   uint64 // nanoseconds since epoch (max of span_start + span_duration)
+	}{
+		{
+			// Single span: end must include duration, not just start.
+			name:      "single_span_end_includes_duration",
+			spans:     []MinimalSpan{mkMinimal("a", "", 1_000_000_000, 500_000_000)},
+			wantStart: 1_000_000_000,
+			wantEnd:   1_500_000_000,
+		},
+		{
+			// Two spans: end is the max of (start+duration) across all spans, not max(start).
+			name: "end_from_longest_span_not_latest_start",
+			spans: []MinimalSpan{
+				mkMinimal("a", "", 1_000_000_000, 1_000_000_000), // ends at 2_000_000_000
+				mkMinimal("b", "", 1_800_000_000, 100_000_000),   // ends at 1_900_000_000; starts later but ends sooner
+			},
+			wantStart: 1_000_000_000,
+			wantEnd:   2_000_000_000, // must NOT be 1_900_000_000 (max start + its duration)
+		},
+		{
+			// Missing parent: synthetic span must not influence TimeRange beyond its children.
+			name: "missing_parent_does_not_skew_range",
+			spans: []MinimalSpan{
+				mkMinimal("child", "ghost", 1_000_000_000, 200_000_000),
+			},
+			wantStart: 1_000_000_000,
+			wantEnd:   1_200_000_000,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			trace := NewFlamegraphTraceFromMinimal(tc.spans)
+			start, end := trace.TimeRange()
+			assert.Equal(t, tc.wantStart, uint64(start.UnixNano()), "start mismatch")
+			assert.Equal(t, tc.wantEnd, uint64(end.UnixNano()), "end mismatch")
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // GetSelectedLevels
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `EndTimestampMillis` in the flamegraph API response was returning the max span **start** time instead of the actual trace end time (max of span_start + span_duration)
- Root cause: `trace_summary_mv` stores `max(timestamp) AS end` — `timestamp` is the span start, so duration is never included
- Fix: expose `TimeRange()` on `FlamegraphTrace` (which already computed the correct end via `updateTimeRange`) and use it in both `getFullFlamegraph` and `getWindowedFlamegraph` instead of `summary.End`
- The waterfall was unaffected — `NewWaterfallTraceFromSpans` already computed `endTime = max(span.TimeUnix + span.DurationNano)`

Closes https://github.com/SigNoz/engineering-pod/issues/5767

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxTqz7CqqmoFEPHFqhJUCa