### PR TITLE
feat(NewSelect): make multi-select Only/All + Toggle real clickable pills

### DIFF
--- a/frontend/src/components/NewSelect/CustomMultiSelect.tsx
+++ b/frontend/src/components/NewSelect/CustomMultiSelect.tsx
@@ -768,11 +768,34 @@ const CustomMultiSelect: React.FC<CustomMultiSelectProps> = ({
 								<div className="option-badge">{capitalize(option.type)}</div>
 							)}
 							{option.value && ensureValidOption(option.value) && (
-								<Button type="text" className="only-btn">
+								<Button
+									type="text"
+									className="only-btn"
+									onClick={(e): void => {
+										// Own handler + preventDefault so the visible "Only/All"
+										// button actually selects only this value, instead of the
+										// wrapping checkbox toggling it.
+										e.stopPropagation();
+										e.preventDefault();
+										handleItemSelection('option');
+										setActiveChipIndex(-1);
+										setActiveIndex(-1);
+									}}
+								>
 									{currentToggleTagValue({ option: option.value })}
 								</Button>
 							)}
-							<Button type="text" className="toggle-btn">
+							<Button
+								type="text"
+								className="toggle-btn"
+								onClick={(e): void => {
+									e.stopPropagation();
+									e.preventDefault();
+									handleItemSelection('checkbox');
+									setActiveChipIndex(-1);
+									setActiveIndex(-1);
+								}}
+							>
 								Toggle
 							</Button>
 						</div>

--- a/frontend/src/components/NewSelect/__test__/CustomMultiSelect.comprehensive.test.tsx
+++ b/frontend/src/components/NewSelect/__test__/CustomMultiSelect.comprehensive.test.tsx
@@ -1,5 +1,5 @@
 import { VirtuosoMockContext } from 'react-virtuoso';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import CustomMultiSelect from '../CustomMultiSelect';
@@ -654,6 +654,29 @@ describe('CustomMultiSelect - Comprehensive Tests', () => {
 				const onlyButtons = screen.getAllByText(/Only|All/);
 				expect(onlyButtons.length).toBeGreaterThan(0);
 			});
+		});
+
+		it('UI-03b: clicking "Only" selects just that value', async () => {
+			renderWithVirtuoso(
+				<CustomMultiSelect
+					options={mockOptions}
+					onChange={mockOnChange}
+					value={['frontend']}
+				/>,
+			);
+
+			const combobox = screen.getByRole('combobox');
+			await user.click(combobox);
+
+			// "Only" renders for the non-selected rows; it's revealed on hover via CSS
+			// (not applied in jsdom) so it sits at display:none — click it directly
+			// rather than through userEvent's visibility gate.
+			const onlyButtons = await screen.findAllByText('Only');
+			mockOnChange.mockClear();
+			fireEvent.click(onlyButtons[0]);
+
+			expect(mockOnChange).toHaveBeenCalledTimes(1);
+			expect(mockOnChange.mock.calls[0][0]).toEqual(['backend']);
 		});
 
 		it('UI-04: Should display values with loading info at bottom', async () => {

--- a/frontend/src/components/NewSelect/styles.scss
+++ b/frontend/src/components/NewSelect/styles.scss
@@ -535,9 +535,8 @@ $custom-border-color: #2c3044;
 				}
 			}
 
-			// Size the buttons to the row's resting content height (20px) and fully
-			// override antd's default 32px Button box, so revealing them on hover
-			// never changes the row height.
+			// Bordered pills sized to the row's resting height so they read as
+			// clickable and revealing them on hover never shifts the row height.
 			.only-btn,
 			.toggle-btn {
 				display: none;
@@ -548,32 +547,30 @@ $custom-border-color: #2c3044;
 				padding: 0 6px;
 				font-size: 12px;
 				line-height: 1;
-				border: none;
+				border: 1px solid var(--l2-border);
+				border-radius: 2px;
+				background-color: var(--l1-background);
 				box-shadow: none;
 
 				&:hover {
-					background-color: unset;
-				}
-			}
-
-			.option-content:hover {
-				.only-btn {
-					display: flex;
-				}
-				.toggle-btn {
-					display: none;
-				}
-
-				.option-badge {
-					display: none;
+					border-color: var(--primary-background);
+					background-color: color-mix(
+						in srgb,
+						var(--primary-background) 15%,
+						transparent
+					);
 				}
 			}
 		}
 
-		.option-checkbox:hover {
+		// Reveal both actions on row hover, wherever the cursor is: "Only/All"
+		// selects only this value, "Toggle" flips it. Both are real buttons now.
+		&:hover {
+			.only-btn,
 			.toggle-btn {
 				display: flex;
 			}
+
 			.option-badge {
 				display: none;
 			}


### PR DESCRIPTION
### Problem
In the `CustomMultiSelect` dropdown, each option row wraps its whole content (label + the "Only/All" and "Toggle" labels) inside the `Checkbox`, and those labels have **no click handlers of their own**. So:
- Clicking the visible "Only/All" button actually **toggles** the checkbox (the wrapping checkbox captures the click) instead of selecting only that value.
- The row's real "Only" action (`onClick` on the outer `.option-item`) only fires in the thin padding outside the checkbox.
- The hover reveal conflicts (`.option-content:hover` vs `.option-checkbox:hover`), so which affordance shows depends on where in the row the cursor is.

Net: the affordance lies about what a click does, and the hit-targets feel random.

### Change
- **Only/All** and **Toggle** are now real buttons with their own handlers (`stopPropagation` + `preventDefault`), mirroring the QuickFilters `CheckboxValueRow` pattern — clicking "Only/All" selects just that value (or selects-all when it's the sole selection), "Toggle" flips it.
- **Consistent hover**: both actions reveal on row hover regardless of cursor position (replaces the conflicting content/checkbox hover rules).
- **Livelier look**: the actions render as bordered pills (semantic tokens) that tint on hover, so they read as clickable.

### Scope / testing
`CustomMultiSelect` is shared — 4 consumers today, all dashboard variable selectors (V1 + V2). Unit tests pass (45/45 in the comprehensive suite, including the existing UI-03 labels test) and a new **UI-03b** verifies clicking "Only" emits just that value. Still worth a manual pass across those selectors for the visual/interaction change.