### PR TITLE
fix(dashboard): defer legacy grid visibility observation

### DIFF
--- a/frontend/src/container/GridCardLayout/GridCard/index.test.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/index.test.tsx
@@ -1,0 +1,57 @@
+import { render } from 'tests/test-utils';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { Widgets } from 'types/api/dashboard/getAll';
+
+import GridCardGraph from './index';
+
+const useIntersectionObserverMock = jest.fn(() => true);
+
+jest.mock('hooks/useIntersectionObserver', () => ({
+	useIntersectionObserver: (...args: unknown[]): boolean =>
+		useIntersectionObserverMock(...args),
+}));
+
+jest.mock(
+	'container/DashboardContainer/visualization/hooks/useScrollWidgetIntoView',
+	() => ({ useScrollWidgetIntoView: jest.fn() }),
+);
+
+jest.mock('hooks/dashboard/useVariableFetchState', () => ({
+	useIsPanelWaitingOnVariable: (): boolean => false,
+}));
+
+jest.mock('hooks/queryBuilder/useGetQueryRange', () => ({
+	useGetQueryRange: (): Record<string, boolean> => ({
+		isFetching: false,
+	}),
+}));
+
+jest.mock('./WidgetGraphComponent', () => ({
+	__esModule: true,
+	default: (): null => null,
+}));
+
+const widget = {
+	id: 'fold-panel',
+	panelTypes: PANEL_TYPES.TIME_SERIES,
+	query: {
+		builder: {
+			queryData: [],
+		},
+	},
+} as unknown as Widgets;
+
+describe('GridCardGraph', () => {
+	it('waits for the grid mount layout before latching panel visibility', () => {
+		render(
+			<GridCardGraph widget={widget} isQueryEnabled onDragSelect={jest.fn()} />,
+		);
+
+		expect(useIntersectionObserverMock).toHaveBeenCalledWith(
+			expect.anything(),
+			undefined,
+			true,
+			350,
+		);
+	});
+});

--- a/frontend/src/container/GridCardLayout/GridCard/index.tsx
+++ b/frontend/src/container/GridCardLayout/GridCard/index.tsx
@@ -36,6 +36,10 @@ import { GridCardGraphProps } from './types';
 import { errorDetails, isDataAvailableByPanelType } from './utils';
 import WidgetGraphComponent from './WidgetGraphComponent';
 
+// React Grid Layout settles item geometry after mount. Delay the one-shot
+// observation so panels near the fold are measured at their final position.
+const GRID_LAYOUT_OBSERVER_START_DELAY_MS = 350;
+
 // eslint-disable-next-line sonarjs/cognitive-complexity
 function GridCardGraph({
 	widget,
@@ -104,7 +108,12 @@ function GridCardGraph({
 
 	const widgetContainerRef = useRef<HTMLDivElement>(null);
 
-	const isVisible = useIntersectionObserver(widgetContainerRef, undefined, true);
+	const isVisible = useIntersectionObserver(
+		widgetContainerRef,
+		undefined,
+		true,
+		GRID_LAYOUT_OBSERVER_START_DELAY_MS,
+	);
 
 	useScrollWidgetIntoView(widget?.id || '', widgetContainerRef);
 


### PR DESCRIPTION
## Problem

Closes #12253.

Legacy dashboard GridCard panels near the initial fold can latch a one-shot visibility check before React Grid Layout has settled their final geometry, leaving `query_range` disabled.

## Changes

- defer the legacy grid’s one-shot visibility observation by 350 ms
- add a focused regression that locks the mount-settle delay at the GridCard boundary

## Validation

- `pnpm exec jest src/container/GridCardLayout/GridCard/index.test.tsx --runInBand`
- `oxfmt --check` on both changed files
- `git diff --check`

No Cloud environment was touched.