### PR TITLE
fix: remove requirement for links to be always present

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -2748,6 +2748,7 @@ components:
         links:
           items:
             $ref: '#/components/schemas/DashboardtypesLink'
+          nullable: true
           type: array
         panels:
           additionalProperties:
@@ -2764,7 +2765,6 @@ components:
       - variables
       - panels
       - layouts
-      - links
       type: object
     DashboardtypesDashboardView:
       properties:
@@ -3401,6 +3401,7 @@ components:
         links:
           items:
             $ref: '#/components/schemas/DashboardtypesLink'
+          nullable: true
           type: array
         plugin:
           $ref: '#/components/schemas/DashboardtypesPanelPlugin'
@@ -3412,7 +3413,6 @@ components:
       - display
       - plugin
       - queries
-      - links
       type: object
     DashboardtypesPatchOp:
       enum:

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -4626,9 +4626,9 @@ export interface DashboardtypesQueryDTO {
 export interface DashboardtypesPanelSpecDTO {
 	display: DashboardtypesDisplayDTO;
 	/**
-	 * @type array
+	 * @type array,null
 	 */
-	links: DashboardtypesLinkDTO[];
+	links?: DashboardtypesLinkDTO[] | null;
 	plugin: DashboardtypesPanelPluginDTO;
 	/**
 	 * @type array
@@ -4821,9 +4821,9 @@ export interface DashboardtypesDashboardSpecDTO {
 	 */
 	layouts: DashboardtypesLayoutDTO[];
 	/**
-	 * @type array
+	 * @type array,null
 	 */
-	links: DashboardtypesLinkDTO[];
+	links?: DashboardtypesLinkDTO[] | null;
 	/**
 	 * @type object
 	 */

--- a/frontend/src/hooks/dashboard/useCreateExportDashboard.ts
+++ b/frontend/src/hooks/dashboard/useCreateExportDashboard.ts
@@ -55,7 +55,6 @@ export function useCreateExportDashboard({
 					layouts: [],
 					panels: {},
 					variables: [],
-					links: [],
 				},
 			}),
 		{

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionRegistry.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionRegistry.tsx
@@ -120,7 +120,7 @@ export const SECTION_REGISTRY: {
 	[SectionKind.ContextLinks]: {
 		Component: ContextLinksSection,
 		// Panel-level slice (spec.links), not under the plugin spec — no cast needed.
-		get: (spec): DashboardtypesLinkDTO[] => spec.links,
+		get: (spec): DashboardtypesLinkDTO[] => spec.links || [],
 		update: (spec, links): PanelSpec => ({ ...spec, links }),
 	},
 	// One editor for every threshold variant (label / comparison / table); the kind's

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/drilldown/resolvePanelContextLinks.ts
@@ -1,4 +1,4 @@
-import type { DashboardtypesLinkDTO } from 'api/generated/services/sigNoz.schemas';
+import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
 import { resolveTexts } from 'hooks/dashboard/useContextVariables';
 
 import { resolveContextLinkUrl } from './resolveContextLinkUrl';
@@ -15,7 +15,7 @@ export interface ResolvedDrilldownLink {
  * label + URL, drops links without a URL, and skips substitution when `renderVariables === false`.
  */
 export function resolvePanelContextLinks(
-	links: DashboardtypesLinkDTO[] | undefined,
+	links: DashboardtypesPanelSpecDTO['links'],
 	processedVariables: Record<string, string>,
 ): ResolvedDrilldownLink[] {
 	const usable = (links ?? []).filter((link) => !!link.url);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/DrilldownMenu/DrilldownAggregateMenu.tsx
@@ -8,7 +8,7 @@ import {
 	ScrollText,
 } from '@signozhq/icons';
 import logEvent from 'api/common/logEvent';
-import type { DashboardtypesLinkDTO } from 'api/generated/services/sigNoz.schemas';
+import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
 import { getAggregateColumnHeader } from 'container/QueryTable/Drilldown/drilldownUtils';
 import ContextMenu from 'periscope/components/ContextMenu';
 import type { DrilldownContext } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/drilldown';
@@ -29,7 +29,7 @@ interface DrilldownAggregateMenuProps {
 	/** While dashboard variables resolve, the actions show a spinner and are disabled. */
 	isResolving?: boolean;
 	/** Panel's context links; resolved against the clicked point + variables here. */
-	links: DashboardtypesLinkDTO[] | undefined;
+	links: DashboardtypesPanelSpecDTO['links'];
 	/** Whether the clicked point exposes group-by fields to bind to dashboard variables. */
 	canSetDashboardVariables: boolean;
 	onViewLogs: () => void;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/patchOps.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/patchOps.ts
@@ -49,7 +49,6 @@ export function createDefaultPanel(
 				spec: pluginSpec,
 			} as DashboardtypesPanelPluginDTO,
 			queries,
-			links: [],
 		},
 	};
 }

--- a/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
+++ b/frontend/src/pages/DashboardsListPageV2/components/NewDashboardModal/BlankDashboardPanel.tsx
@@ -62,7 +62,6 @@ function BlankDashboardPanel({ onClose }: Props): JSX.Element {
 					layouts: [],
 					panels: {},
 					variables: [],
-					links: [],
 				},
 			});
 			void logEvent(DashboardListEvents.DashboardCreated, {

--- a/pkg/types/dashboardtypes/perses_dashboard_data.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_data.go
@@ -26,7 +26,7 @@ type DashboardSpec struct {
 	Layouts         []Layout                   `json:"layouts" required:"true" nullable:"false"`
 	Duration        common.DurationString      `json:"duration"`
 	RefreshInterval common.DurationString      `json:"refreshInterval"`
-	Links           []Link                     `json:"links" required:"true" nullable:"false"`
+	Links           []Link                     `json:"links,omitzero"`
 }
 
 // ══════════════════════════════════════════════
@@ -45,25 +45,12 @@ func (d *DashboardSpec) UnmarshalJSON(data []byte) error {
 	return d.Validate()
 }
 
-// validateLinks rejects a missing/null spec.links value: a typed client must
-// send [] rather than omitting links, so its value round-trips faithfully.
-// Panel links are the panel spec's concern, validated in validatePanels.
-func (d *DashboardSpec) validateLinks() error {
-	if d.Links == nil {
-		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "spec.links is required; send [] when there are no links")
-	}
-	return nil
-}
-
 // ══════════════════════════════════════════════
 // Cross-field validation
 // ══════════════════════════════════════════════
 
 func (d *DashboardSpec) Validate() error {
 	if err := d.Display.Validate("dashboard", "spec.display.name"); err != nil {
-		return err
-	}
-	if err := d.validateLinks(); err != nil {
 		return err
 	}
 	if err := d.validateVariables(); err != nil {
@@ -115,9 +102,6 @@ func (d *DashboardSpec) validatePanels() error {
 		}
 		path := fmt.Sprintf("spec.panels.%s", key)
 		if err := panel.Spec.Display.Validate("panel", path+".spec.display.name"); err != nil {
-			return err
-		}
-		if err := panel.Spec.validateLinks(path); err != nil {
 			return err
 		}
 		panelKind := panel.Spec.Plugin.Kind

--- a/pkg/types/dashboardtypes/perses_dashboard_test.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_test.go
@@ -77,8 +77,8 @@ func TestUnmarshalErrorPreservesNestedMessage(t *testing.T) {
 }
 
 func TestValidateEmptySpec(t *testing.T) {
-	// no variables no panels
-	data := []byte(`{"links": []}`)
+	// no variables no panels no links
+	data := []byte(`{}`)
 	_, err := unmarshalDashboard(data)
 	assert.NoError(t, err, "expected valid")
 }

--- a/pkg/types/dashboardtypes/perses_replicas.go
+++ b/pkg/types/dashboardtypes/perses_replicas.go
@@ -78,17 +78,7 @@ type PanelSpec struct {
 	Display Display     `json:"display" required:"true"`
 	Plugin  PanelPlugin `json:"plugin" required:"true"`
 	Queries []Query     `json:"queries" required:"true" nullable:"false"`
-	Links   []Link      `json:"links" required:"true" nullable:"false"`
-}
-
-// validateLinks rejects a missing/null links field, where path is the panel's
-// location (e.g. "spec.panels.<key>"). A typed client must send [] rather than
-// omitting links, so its value round-trips faithfully.
-func (s *PanelSpec) validateLinks(path string) error {
-	if s.Links == nil {
-		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "%s.spec.links is required; send [] when there are no links", path)
-	}
-	return nil
+	Links   []Link      `json:"links,omitzero"`
 }
 
 // Link replicates dashboard.Link (Perses) so its zero-valued fields survive the

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -1803,7 +1803,6 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
                     "kind": "Panel",
                     "spec": {
                         "display": {"name": "promql"},
-                        "links": [],
                         "plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
                         "queries": [
                             {
@@ -1919,9 +1918,10 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
         for description, spec, key in absent_cases:
             assert key not in spec, description
 
-        # links is a required, non-nullable field: an explicit [] round-trips as [],
-        # so a typed client always reads a concrete array (never null or absent).
-        assert panels["timeseries"]["spec"]["links"] == [], "panel links round-trip as []"
+        # links is optional: an explicit [] round-trips as [], while an omitted
+        # links is absent (never null) on read-back.
+        assert panels["timeseries"]["spec"]["links"] == [], "explicit panel links round-trip as []"
+        assert "links" not in panels["promql"]["spec"], "omitted panel links absent on read-back"
     finally:
         requests.delete(
             signoz.self.host_configs["8080"].get(f"{BASE_URL}/{dashboard_id}"),

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -1919,9 +1919,9 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
             assert key not in spec, description
 
         # links is optional: an explicit [] round-trips as [], while an omitted
-        # links is absent (never null) on read-back.
+        # links reads back as null.
         assert panels["timeseries"]["spec"]["links"] == [], "explicit panel links round-trip as []"
-        assert "links" not in panels["promql"]["spec"], "omitted panel links absent on read-back"
+        assert panels["promql"]["spec"]["links"] is None, "omitted panel links read back as null"
     finally:
         requests.delete(
             signoz.self.host_configs["8080"].get(f"{BASE_URL}/{dashboard_id}"),


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Adding the required tag on links in v2 dashboards was too much of an overcorrection to ensure that roundtrips of dashboard json don't have drift. Omitzero flag is enough.