### PR TITLE
fix(dashboard-v2): config-pane restyle, section quick-add, pie labels & list pagination

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigActions/ConfigActions.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigActions/ConfigActions.module.scss
@@ -2,7 +2,7 @@
    from the collapsible config sections above by the same hairline divider. */
 .divider {
 	height: 1px;
-	background: var(--l2-border);
+	background: var(--l1-border);
 	margin: 18px 0;
 }
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigActions/ConfigActions.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigActions/ConfigActions.tsx
@@ -1,4 +1,4 @@
-import { Bell } from '@signozhq/icons';
+import { Flame } from '@signozhq/icons';
 import type { DashboardtypesPanelDTO } from 'api/generated/services/sigNoz.schemas';
 import { getPanelDefinition } from 'pages/DashboardPageV2/DashboardContainer/Panels/registry';
 import { useCreateAlertFromPanel } from 'pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useCreateAlertFromPanel';
@@ -38,7 +38,7 @@ function ConfigActions({
 				<div className={styles.list}>
 					<ConfigActionRow
 						testId="panel-editor-v2-create-alert"
-						icon={<Bell size={14} />}
+						icon={<Flame size={14} />}
 						label="Create alert"
 						onClick={(): void => createAlert(panel, panelId)}
 					/>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.module.scss
@@ -1,3 +1,5 @@
+@use '../../../../../styles/scrollbar' as *;
+
 .config {
 	display: flex;
 	flex-direction: column;
@@ -6,33 +8,24 @@
 	background-color: var(--l1-background);
 	overflow-y: auto;
 	overflow-x: hidden;
+	padding-bottom: 44px;
 
-	//TODO: replace this with custom-scrollbar mixin
-	// Thin, unobtrusive scrollbar (replaces the chunky native bar).
-	$thumb: color-mix(in srgb, var(--bg-vanilla-100) 16%, transparent);
-
-	scrollbar-width: thin;
-	scrollbar-color: $thumb transparent;
-
-	&::-webkit-scrollbar {
-		width: 8px;
-	}
-
-	&::-webkit-scrollbar-track {
-		background: transparent;
-	}
-
-	&::-webkit-scrollbar-thumb {
-		background: $thumb;
-		border-radius: 999px;
-		border: 2px solid transparent;
-		background-clip: padding-box;
-	}
+	@include custom-scrollbar;
 }
 
 .heading {
-	margin-bottom: 18px;
-	padding: 16px 16px 0 16px;
+	padding: 16px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.marker {
+	display: inline-block;
+	width: 8px;
+	height: 4px;
+	border-radius: 20px;
+	background-color: var(--primary);
 }
 
 .title {
@@ -49,11 +42,10 @@
 
 .eyebrow {
 	display: block;
-	margin: 0 2px 10px;
 	font-size: 11px;
 	font-weight: 600;
+	padding: 16px;
 	letter-spacing: 0.06em;
-	text-transform: uppercase;
 	color: var(--l1-foreground);
 }
 
@@ -61,7 +53,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
-	padding: 0 16px;
+	padding: 16px;
 }
 
 .field {
@@ -71,20 +63,19 @@
 }
 
 .divider {
+	// flex-shrink:0 keeps the 1px line from collapsing to 0 once the pane
+	// content overflows and the flex column starts shrinking its children.
+	flex-shrink: 0;
 	height: 1px;
-	background: var(--l2-border);
-	margin: 18px 0;
-}
-
-.sectionsContainer {
-	padding: 0 16px;
+	background: var(--l1-border);
 }
 
 .sections {
 	display: flex;
 	flex-direction: column;
 
-	& > * + * {
-		border-top: 1px solid var(--l2-border);
+	& > * {
+		padding: 0 16px;
+		border-top: 1px solid var(--l1-border);
 	}
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/ConfigPane.tsx
@@ -77,8 +77,10 @@ function ConfigPane({
 	return (
 		<div className={styles.config}>
 			<header className={styles.heading}>
-				<Typography.Text>Panel settings</Typography.Text>
+				<span className={styles.marker} />
+				<Typography.Text>Panel Details</Typography.Text>
 			</header>
+			<div className={styles.divider} />
 
 			<div className={styles.group}>
 				<div className={styles.field}>
@@ -108,7 +110,7 @@ function ConfigPane({
 				<>
 					<div className={styles.divider} />
 					<div className={styles.sectionsContainer}>
-						<span className={styles.eyebrow}>Display</span>
+						<span className={styles.eyebrow}>DISPLAY OPTIONS</span>
 						<div className={styles.sections}>
 							{sections.map((config) => (
 								<SectionSlot

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionHeaderQuickAdd.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionHeaderQuickAdd.tsx
@@ -1,0 +1,39 @@
+import { Plus } from '@signozhq/icons';
+import { Button } from '@signozhq/ui/button';
+import { TooltipSimple } from '@signozhq/ui/tooltip';
+
+interface SectionHeaderQuickAddConfig {
+	label: string;
+	testId: string;
+}
+
+interface SectionHeaderQuickAddProps {
+	action: SectionHeaderQuickAddConfig;
+	/** Expands the section and runs the editor's registered add handler. */
+	onClick: () => void;
+}
+
+/** Quick-add control rendered in a configuration section's header, beside the chevron. */
+function SectionHeaderQuickAdd({
+	action,
+	onClick,
+}: SectionHeaderQuickAddProps): JSX.Element {
+	return (
+		<TooltipSimple title="Quick Add" side="top" arrow>
+			<Button
+				type="button"
+				variant="ghost"
+				color="secondary"
+				size="icon"
+				aria-label={action.label}
+				// Not `testId`: TooltipTrigger's Slot merge overwrites it with undefined.
+				data-testid={action.testId}
+				onClick={onClick}
+			>
+				<Plus size={15} />
+			</Button>
+		</TooltipSimple>
+	);
+}
+
+export default SectionHeaderQuickAdd;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
@@ -1,3 +1,6 @@
+import { type ReactNode, useCallback, useRef, useState } from 'react';
+import { Plus } from '@signozhq/icons';
+import { Button } from '@signozhq/ui/button';
 import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
 import {
 	type PanelFormattingSlice,
@@ -10,12 +13,45 @@ import type { SectionEditorContext } from '../sectionContext';
 import { resolveSectionEditor } from '../sectionRegistry';
 import SettingsSection from '../SettingsSection/SettingsSection';
 
-// `yAxisUnit` is derived from the spec below, not forwarded, so it's omitted.
+// `yAxisUnit` is derived from the spec below; `registerHeaderAction` is wired here.
 type SectionSlotProps = {
 	config: SectionConfig;
 	spec: DashboardtypesPanelSpecDTO;
 	onChangeSpec: (next: DashboardtypesPanelSpecDTO) => void;
-} & Omit<SectionEditorContext, 'yAxisUnit'>;
+} & Omit<SectionEditorContext, 'yAxisUnit' | 'registerHeaderAction'>;
+
+// Per-section header control (beside the chevron). A render fn, so a section shows
+// whatever it wants; `trigger` expands the section and runs the editor's handler.
+const SECTION_HEADER_ACTION: Partial<
+	Record<SectionKind, (trigger: () => void) => ReactNode>
+> = {
+	[SectionKind.Thresholds]: (trigger): ReactNode => (
+		<Button
+			type="button"
+			variant="ghost"
+			color="secondary"
+			size="icon"
+			aria-label="Add threshold"
+			testId="panel-editor-v2-add-threshold-header"
+			onClick={trigger}
+		>
+			<Plus size={15} />
+		</Button>
+	),
+	[SectionKind.ContextLinks]: (trigger): ReactNode => (
+		<Button
+			type="button"
+			variant="ghost"
+			color="secondary"
+			size="icon"
+			aria-label="Add Context Link"
+			testId="panel-editor-v2-add-link-header"
+			onClick={trigger}
+		>
+			<Plus size={15} />
+		</Button>
+	),
+};
 
 /**
  * Renders one configuration section: its collapsible wrapper plus the registered editor
@@ -36,13 +72,46 @@ function SectionSlot({
 	stepInterval,
 	metricUnit,
 }: SectionSlotProps): JSX.Element | null {
+	const editor = resolveSectionEditor(config.kind);
+	// Controlled so the header quick-add can expand on click. Visualization opens by
+	// default; list sections (Thresholds/Context Links) open when already populated.
+	const [open, setOpen] = useState(() => {
+		if (config.kind === SectionKind.Visualization) {
+			return true;
+		}
+		const value = editor?.get(spec);
+		return Array.isArray(value) && value.length > 0;
+	});
+	// The editor mounts only while open; `pendingAction` runs the add after a collapsed-click expand.
+	const actionHandlerRef = useRef<(() => void) | null>(null);
+	const pendingActionRef = useRef(false);
+
+	const registerHeaderAction = useCallback(
+		(handler: (() => void) | null): void => {
+			actionHandlerRef.current = handler;
+			if (handler && pendingActionRef.current) {
+				pendingActionRef.current = false;
+				handler();
+			}
+		},
+		[],
+	);
+
+	const triggerHeaderAction = useCallback((): void => {
+		setOpen(true);
+		if (actionHandlerRef.current) {
+			actionHandlerRef.current();
+		} else {
+			pendingActionRef.current = true;
+		}
+	}, []);
+
 	// A kind can hide a section based on current spec state (e.g. Histogram legend once
 	// queries are merged) — skip it before resolving the editor.
 	if (config.isHidden?.(spec)) {
 		return null;
 	}
 
-	const editor = resolveSectionEditor(config.kind);
 	if (!editor) {
 		return null;
 	}
@@ -56,12 +125,15 @@ function SectionSlot({
 	const yAxisUnit = (spec.plugin.spec as { formatting?: PanelFormattingSlice })
 		.formatting?.unit;
 
+	const headerAction = SECTION_HEADER_ACTION[config.kind]?.(triggerHeaderAction);
+
 	return (
 		<SettingsSection
 			title={title}
 			icon={<Icon size={15} />}
-			// Open Visualization by default so the type switcher is visible.
-			defaultOpen={config.kind === SectionKind.Visualization}
+			open={open}
+			onOpenChange={setOpen}
+			headerAction={headerAction}
 		>
 			<Component
 				value={get(spec)}
@@ -76,6 +148,7 @@ function SectionSlot({
 				queryType={queryType}
 				stepInterval={stepInterval}
 				metricUnit={metricUnit}
+				registerHeaderAction={registerHeaderAction}
 			/>
 		</SettingsSection>
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/SectionSlot.tsx
@@ -1,6 +1,4 @@
 import { type ReactNode, useCallback, useRef, useState } from 'react';
-import { Plus } from '@signozhq/icons';
-import { Button } from '@signozhq/ui/button';
 import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
 import {
 	type PanelFormattingSlice,
@@ -12,52 +10,41 @@ import {
 import type { SectionEditorContext } from '../sectionContext';
 import { resolveSectionEditor } from '../sectionRegistry';
 import SettingsSection from '../SettingsSection/SettingsSection';
+import SectionHeaderQuickAdd from './SectionHeaderQuickAdd';
 
-// `yAxisUnit` is derived from the spec below; `registerHeaderAction` is wired here.
 type SectionSlotProps = {
 	config: SectionConfig;
 	spec: DashboardtypesPanelSpecDTO;
 	onChangeSpec: (next: DashboardtypesPanelSpecDTO) => void;
 } & Omit<SectionEditorContext, 'yAxisUnit' | 'registerHeaderAction'>;
 
-// Per-section header control (beside the chevron). A render fn, so a section shows
-// whatever it wants; `trigger` expands the section and runs the editor's handler.
-const SECTION_HEADER_ACTION: Partial<
+// Per-section header content; `trigger` expands the section and runs the editor's handler.
+const SECTION_HEADER_SLOT: Partial<
 	Record<SectionKind, (trigger: () => void) => ReactNode>
 > = {
 	[SectionKind.Thresholds]: (trigger): ReactNode => (
-		<Button
-			type="button"
-			variant="ghost"
-			color="secondary"
-			size="icon"
-			aria-label="Add threshold"
-			testId="panel-editor-v2-add-threshold-header"
+		<SectionHeaderQuickAdd
+			action={{
+				label: 'Add Threshold',
+				testId: 'panel-editor-v2-add-threshold-header',
+			}}
 			onClick={trigger}
-		>
-			<Plus size={15} />
-		</Button>
+		/>
 	),
 	[SectionKind.ContextLinks]: (trigger): ReactNode => (
-		<Button
-			type="button"
-			variant="ghost"
-			color="secondary"
-			size="icon"
-			aria-label="Add Context Link"
-			testId="panel-editor-v2-add-link-header"
+		<SectionHeaderQuickAdd
+			action={{
+				label: 'Add Context Link',
+				testId: 'panel-editor-v2-add-link-header',
+			}}
 			onClick={trigger}
-		>
-			<Plus size={15} />
-		</Button>
+		/>
 	),
 };
 
 /**
  * Renders one configuration section: its collapsible wrapper plus the registered editor
- * for `config.kind`, wired through the registry's spec lens. Renders nothing when the
- * kind has no editor yet (sections roll out incrementally), so a kind can declare a
- * section before its editor exists.
+ * for `config.kind`. Renders nothing when the kind has no editor yet.
  */
 function SectionSlot({
 	config,
@@ -73,8 +60,7 @@ function SectionSlot({
 	metricUnit,
 }: SectionSlotProps): JSX.Element | null {
 	const editor = resolveSectionEditor(config.kind);
-	// Controlled so the header quick-add can expand on click. Visualization opens by
-	// default; list sections (Thresholds/Context Links) open when already populated.
+	// Controlled so the header slot can expand on click; list sections open when populated.
 	const [open, setOpen] = useState(() => {
 		if (config.kind === SectionKind.Visualization) {
 			return true;
@@ -82,7 +68,7 @@ function SectionSlot({
 		const value = editor?.get(spec);
 		return Array.isArray(value) && value.length > 0;
 	});
-	// The editor mounts only while open; `pendingAction` runs the add after a collapsed-click expand.
+	// The editor mounts only while open, so a collapsed-click defers the handler until it registers.
 	const actionHandlerRef = useRef<(() => void) | null>(null);
 	const pendingActionRef = useRef(false);
 
@@ -106,8 +92,6 @@ function SectionSlot({
 		}
 	}, []);
 
-	// A kind can hide a section based on current spec state (e.g. Histogram legend once
-	// queries are merged) — skip it before resolving the editor.
 	if (config.isHidden?.(spec)) {
 		return null;
 	}
@@ -120,12 +104,11 @@ function SectionSlot({
 	const { Component, get, update } = editor;
 	// Atomic sections carry no `controls`; controlled ones do.
 	const controls = 'controls' in config ? config.controls : undefined;
-	// The panel's formatting unit, forwarded to editors that scope to it (thresholds
-	// restrict their unit picker to this unit's category, as in V1).
+	// Forwarded to editors that scope to the panel's unit (e.g. the thresholds unit picker).
 	const yAxisUnit = (spec.plugin.spec as { formatting?: PanelFormattingSlice })
 		.formatting?.unit;
 
-	const headerAction = SECTION_HEADER_ACTION[config.kind]?.(triggerHeaderAction);
+	const headerSlot = SECTION_HEADER_SLOT[config.kind]?.(triggerHeaderAction);
 
 	return (
 		<SettingsSection
@@ -133,7 +116,7 @@ function SectionSlot({
 			icon={<Icon size={15} />}
 			open={open}
 			onOpenChange={setOpen}
-			headerAction={headerAction}
+			headerSlot={headerSlot}
 		>
 			<Component
 				value={get(spec)}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/__tests__/SectionSlot.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/__tests__/SectionSlot.test.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
+import {
+	type SectionConfig,
+	SectionKind,
+	ThresholdVariant,
+} from 'pages/DashboardPageV2/DashboardContainer/Panels/types/sections';
+
+import SectionSlot from '../SectionSlot';
+
+const THRESHOLDS_CONFIG: SectionConfig = {
+	kind: SectionKind.Thresholds,
+	controls: { variant: ThresholdVariant.LABEL },
+};
+
+function makeSpec(thresholds: unknown[] = []): DashboardtypesPanelSpecDTO {
+	return {
+		display: { name: 'CPU' },
+		plugin: { kind: 'signoz/TimeSeriesPanel', spec: { thresholds } },
+		queries: [],
+	} as unknown as DashboardtypesPanelSpecDTO;
+}
+
+// Stateful harness so onChange feeds back into the spec (as ConfigPane owns it).
+function Harness({ initial = [] }: { initial?: unknown[] } = {}): JSX.Element {
+	const [spec, setSpec] = useState<DashboardtypesPanelSpecDTO>(
+		makeSpec(initial),
+	);
+	return (
+		<SectionSlot config={THRESHOLDS_CONFIG} spec={spec} onChangeSpec={setSpec} />
+	);
+}
+
+describe('SectionSlot header action', () => {
+	it('shows the header "+" while the section is collapsed', () => {
+		render(<Harness />);
+
+		// Collapsed: body (inline add) hidden, but the header quick-add is available.
+		expect(
+			screen.queryByTestId('panel-editor-v2-add-threshold'),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByTestId('panel-editor-v2-add-threshold-header'),
+		).toBeInTheDocument();
+	});
+
+	it('starts expanded when the section already has items', () => {
+		render(
+			<Harness initial={[{ value: 80, color: '#F5B225', label: 'High' }]} />,
+		);
+
+		// Body is shown on mount (no header click needed) because content exists.
+		expect(
+			screen.getByTestId('panel-editor-v2-add-threshold'),
+		).toBeInTheDocument();
+		expect(screen.getByText('High')).toBeInTheDocument();
+	});
+
+	it('expands the section and adds a threshold when the header "+" is clicked', () => {
+		render(<Harness />);
+
+		fireEvent.click(screen.getByTestId('panel-editor-v2-add-threshold-header'));
+
+		// Expanded, with a fresh row opened in edit mode.
+		expect(
+			screen.getByTestId('panel-editor-v2-add-threshold'),
+		).toBeInTheDocument();
+		expect(screen.getByTestId('threshold-value-0')).toBeInTheDocument();
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/__tests__/SectionSlot.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SectionSlot/__tests__/SectionSlot.test.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
 import type { DashboardtypesPanelSpecDTO } from 'api/generated/services/sigNoz.schemas';
 import {
 	type SectionConfig,
 	SectionKind,
 	ThresholdVariant,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/sections';
+import { render, screen, userEvent } from 'tests/test-utils';
 
 import SectionSlot from '../SectionSlot';
 
@@ -57,10 +57,11 @@ describe('SectionSlot header action', () => {
 		expect(screen.getByText('High')).toBeInTheDocument();
 	});
 
-	it('expands the section and adds a threshold when the header "+" is clicked', () => {
+	it('expands the section and adds a threshold when the header "+" is clicked', async () => {
+		const user = userEvent.setup();
 		render(<Harness />);
 
-		fireEvent.click(screen.getByTestId('panel-editor-v2-add-threshold-header'));
+		await user.click(screen.getByTestId('panel-editor-v2-add-threshold-header'));
 
 		// Expanded, with a fresh row opened in edit mode.
 		expect(

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SettingsSection/SettingsSection.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SettingsSection/SettingsSection.module.scss
@@ -1,10 +1,19 @@
 .header {
 	display: flex;
 	align-items: center;
-	gap: 11px;
+	gap: 6px;
 	width: 100%;
 	height: 44px;
-	padding: 0 4px;
+}
+
+// Disclosure control (icon tile + title); fills the row so the action slot and chevron sit right.
+.toggle {
+	display: flex;
+	flex: 1;
+	align-items: center;
+	gap: 11px;
+	min-width: 0;
+	padding: 0 !important;
 	border: none;
 	background: transparent;
 	cursor: pointer;
@@ -37,8 +46,6 @@
 }
 
 .chevron {
-	flex: none;
-	color: var(--l2-border);
 	transition: transform 0.15s ease;
 
 	&.open {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SettingsSection/SettingsSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SettingsSection/SettingsSection.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useState } from 'react';
 import { ChevronDown } from '@signozhq/icons';
+import { Button } from '@signozhq/ui/button';
 import { Typography } from '@signozhq/ui/typography';
 import cx from 'classnames';
 
@@ -9,45 +10,77 @@ interface SettingsSectionProps {
 	title: string;
 	icon?: ReactNode;
 	defaultOpen?: boolean;
+	/** Controlled open state; when set, the section defers to `onOpenChange`. */
+	open?: boolean;
+	onOpenChange?: (open: boolean) => void;
+	/** Generic slot rendered between the title and the chevron (e.g. a quick-add "+"). */
+	headerAction?: ReactNode;
 	children: ReactNode;
 }
 
 /**
  * Collapsible container for one configuration section in the V2 panel editor's
- * ConfigPane. Header shows an icon tile (accented when expanded), the title, and a
- * rotating chevron; sections are separated by hairline dividers (no surrounding boxes),
- * matching the Configure-panel design.
+ * ConfigPane. Header shows an icon tile (accented when expanded), the title, an optional
+ * caller-provided action, and a rotating chevron; sections are separated by hairline
+ * dividers (no surrounding boxes), matching the Configure-panel design.
  */
 function SettingsSection({
 	title,
 	icon,
 	defaultOpen = false,
+	open,
+	onOpenChange,
+	headerAction,
 	children,
 }: SettingsSectionProps): JSX.Element {
-	const [isOpen, setIsOpen] = useState(defaultOpen);
+	const [internalOpen, setInternalOpen] = useState(defaultOpen);
+	const isControlled = open !== undefined;
+	const isOpen = isControlled ? open : internalOpen;
+
+	const toggle = (): void => {
+		const next = !isOpen;
+		if (!isControlled) {
+			setInternalOpen(next);
+		}
+		onOpenChange?.(next);
+	};
 
 	const serializedTitle = title.toLowerCase().replace(/\s+/g, '-');
 
 	return (
 		<section className={styles.section}>
-			<button
-				type="button"
-				className={styles.header}
-				aria-expanded={isOpen}
-				data-testid={`config-section-${serializedTitle}`}
-				onClick={(): void => setIsOpen((prev) => !prev)}
-			>
-				{icon && (
-					<span className={cx(styles.iconTile, { [styles.iconTileOpen]: isOpen })}>
-						{icon}
-					</span>
-				)}
-				<Typography.Text className={styles.title}>{title}</Typography.Text>
-				<ChevronDown
-					size={15}
-					className={cx(styles.chevron, { [styles.open]: isOpen })}
+			<div className={styles.header}>
+				<button
+					type="button"
+					className={styles.toggle}
+					aria-expanded={isOpen}
+					data-testid={`config-section-${serializedTitle}`}
+					onClick={toggle}
+				>
+					{icon && (
+						<span className={cx(styles.iconTile, { [styles.iconTileOpen]: isOpen })}>
+							{icon}
+						</span>
+					)}
+					<Typography.Text className={styles.title}>{title}</Typography.Text>
+				</button>
+				{headerAction}
+				<Button
+					type="button"
+					variant="ghost"
+					color="secondary"
+					size="icon"
+					prefix={
+						<ChevronDown
+							size={15}
+							className={cx(styles.chevron, { [styles.open]: isOpen })}
+						/>
+					}
+					aria-label={isOpen ? `Collapse ${title}` : `Expand ${title}`}
+					tabIndex={-1}
+					onClick={toggle}
 				/>
-			</button>
+			</div>
 			{isOpen && <div className={styles.body}>{children}</div>}
 		</section>
 	);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SettingsSection/SettingsSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SettingsSection/SettingsSection.tsx
@@ -13,16 +13,13 @@ interface SettingsSectionProps {
 	/** Controlled open state; when set, the section defers to `onOpenChange`. */
 	open?: boolean;
 	onOpenChange?: (open: boolean) => void;
-	/** Generic slot rendered between the title and the chevron (e.g. a quick-add "+"). */
-	headerAction?: ReactNode;
+	/** Rendered between the title and the chevron. */
+	headerSlot?: ReactNode;
 	children: ReactNode;
 }
 
 /**
- * Collapsible container for one configuration section in the V2 panel editor's
- * ConfigPane. Header shows an icon tile (accented when expanded), the title, an optional
- * caller-provided action, and a rotating chevron; sections are separated by hairline
- * dividers (no surrounding boxes), matching the Configure-panel design.
+ * Collapsible container for one configuration section in the V2 panel editor's ConfigPane.
  */
 function SettingsSection({
 	title,
@@ -30,7 +27,7 @@ function SettingsSection({
 	defaultOpen = false,
 	open,
 	onOpenChange,
-	headerAction,
+	headerSlot,
 	children,
 }: SettingsSectionProps): JSX.Element {
 	const [internalOpen, setInternalOpen] = useState(defaultOpen);
@@ -64,7 +61,7 @@ function SettingsSection({
 					)}
 					<Typography.Text className={styles.title}>{title}</Typography.Text>
 				</button>
-				{headerAction}
+				{headerSlot}
 				<Button
 					type="button"
 					variant="ghost"

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SettingsSection/__tests__/SettingsSection.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SettingsSection/__tests__/SettingsSection.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import SettingsSection from '../SettingsSection';
+
+describe('SettingsSection', () => {
+	it('renders an arbitrary headerAction node beside the header', () => {
+		render(
+			<SettingsSection
+				title="Thresholds"
+				headerAction={
+					<button type="button" aria-label="custom action" data-testid="my-action" />
+				}
+			>
+				<div>body</div>
+			</SettingsSection>,
+		);
+
+		expect(screen.getByTestId('my-action')).toBeInTheDocument();
+	});
+
+	it('is collapsed by default: hides the body until the header is clicked', () => {
+		render(
+			<SettingsSection title="Thresholds">
+				<div data-testid="body">body</div>
+			</SettingsSection>,
+		);
+
+		expect(screen.queryByTestId('body')).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByTestId('config-section-thresholds'));
+		expect(screen.getByTestId('body')).toBeInTheDocument();
+	});
+
+	it('defers to onOpenChange when open is controlled', () => {
+		const onOpenChange = jest.fn();
+		const { rerender } = render(
+			<SettingsSection title="Thresholds" open={false} onOpenChange={onOpenChange}>
+				<div data-testid="body">body</div>
+			</SettingsSection>,
+		);
+
+		expect(screen.queryByTestId('body')).not.toBeInTheDocument();
+		fireEvent.click(screen.getByTestId('config-section-thresholds'));
+		expect(onOpenChange).toHaveBeenCalledWith(true);
+
+		rerender(
+			<SettingsSection title="Thresholds" open onOpenChange={onOpenChange}>
+				<div data-testid="body">body</div>
+			</SettingsSection>,
+		);
+		expect(screen.getByTestId('body')).toBeInTheDocument();
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SettingsSection/__tests__/SettingsSection.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/SettingsSection/__tests__/SettingsSection.test.tsx
@@ -1,13 +1,14 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import SettingsSection from '../SettingsSection';
 
 describe('SettingsSection', () => {
-	it('renders an arbitrary headerAction node beside the header', () => {
+	it('renders an arbitrary headerSlot node beside the header', () => {
 		render(
 			<SettingsSection
 				title="Thresholds"
-				headerAction={
+				headerSlot={
 					<button type="button" aria-label="custom action" data-testid="my-action" />
 				}
 			>
@@ -18,7 +19,8 @@ describe('SettingsSection', () => {
 		expect(screen.getByTestId('my-action')).toBeInTheDocument();
 	});
 
-	it('is collapsed by default: hides the body until the header is clicked', () => {
+	it('is collapsed by default: hides the body until the header is clicked', async () => {
+		const user = userEvent.setup();
 		render(
 			<SettingsSection title="Thresholds">
 				<div data-testid="body">body</div>
@@ -27,11 +29,12 @@ describe('SettingsSection', () => {
 
 		expect(screen.queryByTestId('body')).not.toBeInTheDocument();
 
-		fireEvent.click(screen.getByTestId('config-section-thresholds'));
+		await user.click(screen.getByTestId('config-section-thresholds'));
 		expect(screen.getByTestId('body')).toBeInTheDocument();
 	});
 
-	it('defers to onOpenChange when open is controlled', () => {
+	it('defers to onOpenChange when open is controlled', async () => {
+		const user = userEvent.setup();
 		const onOpenChange = jest.fn();
 		const { rerender } = render(
 			<SettingsSection title="Thresholds" open={false} onOpenChange={onOpenChange}>
@@ -40,7 +43,7 @@ describe('SettingsSection', () => {
 		);
 
 		expect(screen.queryByTestId('body')).not.toBeInTheDocument();
-		fireEvent.click(screen.getByTestId('config-section-thresholds'));
+		await user.click(screen.getByTestId('config-section-thresholds'));
 		expect(onOpenChange).toHaveBeenCalledWith(true);
 
 		rerender(

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/__tests__/ConfigPane.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/__tests__/ConfigPane.test.tsx
@@ -1,19 +1,12 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
 import type {
 	DashboardtypesPanelDTO,
 	DashboardtypesPanelSpecDTO,
 } from 'api/generated/services/sigNoz.schemas';
+import { render, screen, userEvent } from 'tests/test-utils';
 import { EQueryType } from 'types/common/dashboard';
 
 import ConfigPane from '../ConfigPane';
-
-// The Actions group's hook navigates/logs; stub it so ConfigPane renders without a router.
-jest.mock(
-	'pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/hooks/useCreateAlertFromPanel',
-	() => ({
-		useCreateAlertFromPanel: (): jest.Mock => jest.fn(),
-	}),
-);
 
 function spec(unit?: string): DashboardtypesPanelSpecDTO {
 	return {
@@ -40,7 +33,23 @@ function renderConfigPane(
 		panelId: 'panel-1',
 		...overrides,
 	};
-	render(<ConfigPane {...props} />);
+
+	// Stateful so typed edits feed back into the spec, as the panel editor owns it.
+	function Harness(): JSX.Element {
+		const [currentSpec, setCurrentSpec] = useState(props.spec);
+		return (
+			<ConfigPane
+				{...props}
+				spec={currentSpec}
+				onChangeSpec={(next): void => {
+					props.onChangeSpec(next);
+					setCurrentSpec(next);
+				}}
+			/>
+		);
+	}
+
+	render(<Harness />);
 	return props;
 }
 
@@ -54,14 +63,15 @@ describe('ConfigPane', () => {
 		);
 	});
 
-	it('reports title edits through onChangeSpec (into spec.display)', () => {
+	it('reports title edits through onChangeSpec (into spec.display)', async () => {
+		const user = userEvent.setup();
 		const { onChangeSpec } = renderConfigPane();
 
-		fireEvent.change(screen.getByTestId('panel-editor-v2-title'), {
-			target: { value: 'Memory' },
-		});
+		const title = screen.getByTestId('panel-editor-v2-title');
+		await user.clear(title);
+		await user.type(title, 'Memory');
 
-		expect(onChangeSpec).toHaveBeenCalledWith(
+		expect(onChangeSpec).toHaveBeenLastCalledWith(
 			expect.objectContaining({
 				display: { name: 'Memory', description: 'usage' },
 			}),

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/controls/ConfigSelect/ConfigSelect.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/controls/ConfigSelect/ConfigSelect.module.scss
@@ -1,6 +1,10 @@
 // Fill the section field so the select lines up with the other full-width controls.
 .select {
 	width: 100%;
+
+	:global(.ant-select-selector) {
+		border-color: var(--l2-border) !important;
+	}
 }
 
 .item {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/controls/ConfigSwitch/ConfigSwitch.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/controls/ConfigSwitch/ConfigSwitch.module.scss
@@ -5,7 +5,7 @@
 	gap: 12px;
 	padding: 12px 14px;
 	border: 1px solid var(--l2-border);
-	border-radius: 6px;
+	border-radius: 2px;
 	background: var(--l2-background-60);
 }
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/controls/LegendColors/LegendColors.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/controls/LegendColors/LegendColors.module.scss
@@ -1,3 +1,5 @@
+@use '../../../../../../../styles/scrollbar' as *;
+
 .container {
 	display: flex;
 	flex-direction: column;
@@ -5,6 +7,7 @@
 }
 
 .list {
+	@include custom-scrollbar;
 	width: 100%;
 }
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionContext.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sectionContext.ts
@@ -21,4 +21,6 @@ export interface SectionEditorContext {
 	stepInterval?: number;
 	/** Unit the selected metric was sent with; drives the unit selector's mismatch warning. */
 	metricUnit?: string;
+	/** An editor registers the handler its header action (e.g. a quick-add "+") triggers; `null` to clear. */
+	registerHeaderAction?: (handler: (() => void) | null) => void;
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ContextLinksSection/ContextLinksSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ContextLinksSection/ContextLinksSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Plus } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
 import type { DashboardtypesLinkDTO } from 'api/generated/services/sigNoz.schemas';
@@ -7,6 +7,7 @@ import type {
 	SectionKind,
 } from 'pages/DashboardPageV2/DashboardContainer/Panels/types/sections';
 
+import type { SectionEditorContext } from '../../sectionContext';
 import ContextLinkDialog from './ContextLinkDialog';
 import ContextLinkListItem from './ContextLinkListItem';
 import { useContextLinkVariables } from './useContextLinkVariables';
@@ -21,7 +22,9 @@ import styles from './ContextLinksSection.module.scss';
 function ContextLinksSection({
 	value,
 	onChange,
-}: SectionEditorProps<SectionKind.ContextLinks>): JSX.Element {
+	registerHeaderAction,
+}: SectionEditorProps<SectionKind.ContextLinks> &
+	Pick<SectionEditorContext, 'registerHeaderAction'>): JSX.Element {
 	const links = value ?? [];
 	const variables = useContextLinkVariables();
 
@@ -30,6 +33,16 @@ function ContextLinksSection({
 		open: false,
 		index: null,
 	});
+
+	const openAddDialog = useCallback(
+		(): void => setDialog({ open: true, index: null }),
+		[],
+	);
+
+	useEffect(() => {
+		registerHeaderAction?.(openAddDialog);
+		return (): void => registerHeaderAction?.(null);
+	}, [registerHeaderAction, openAddDialog]);
 
 	const removeAt = (index: number): void =>
 		onChange(links.filter((_, i) => i !== index));
@@ -66,7 +79,7 @@ function ContextLinksSection({
 				color="secondary"
 				prefix={<Plus size={14} />}
 				data-testid="panel-editor-v2-add-link"
-				onClick={(): void => setDialog({ open: true, index: null })}
+				onClick={openAddDialog}
 			>
 				Add Context Link
 			</Button>

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/FormattingSection/FormattingSection.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/FormattingSection/FormattingSection.module.scss
@@ -8,6 +8,9 @@
 	:global(.ant-select) {
 		width: 100%;
 	}
+	:global(.ant-select-selector) {
+		border-color: var(--l2-border) !important;
+	}
 }
 
 // Stacked per-column unit pickers; each column keeps the standard field layout.

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/ThresholdsSection.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/ThresholdsSection.module.scss
@@ -96,6 +96,9 @@
 	:global(.ant-select) {
 		width: 100%;
 	}
+	:global(.ant-select-selector) {
+		border-color: var(--l2-border) !important;
+	}
 }
 
 .invalidUnit {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/ThresholdsSection.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/ConfigPane/sections/ThresholdsSection/ThresholdsSection.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Plus } from '@signozhq/icons';
 import { Button } from '@signozhq/ui/button';
 import {
@@ -63,7 +63,10 @@ type ThresholdsSectionProps = {
 	/** `variant` picks the row editor + element shape; defaults to `label`. */
 	controls?: { variant?: ThresholdVariant };
 	onChange: (next: AnyThreshold[]) => void;
-} & Pick<SectionEditorContext, 'yAxisUnit' | 'tableColumns'>;
+} & Pick<
+	SectionEditorContext,
+	'yAxisUnit' | 'tableColumns' | 'registerHeaderAction'
+>;
 
 /**
  * Edits the `thresholds` slice for every panel kind. All variants share the same
@@ -77,6 +80,7 @@ function ThresholdsSection({
 	onChange,
 	yAxisUnit,
 	tableColumns = [],
+	registerHeaderAction,
 }: ThresholdsSectionProps): JSX.Element {
 	const variant = controls?.variant ?? ThresholdVariant.LABEL;
 	const thresholds = value ?? [];
@@ -93,12 +97,17 @@ function ThresholdsSection({
 			onChange(thresholds.map((t, i) => (i === index ? next : t)));
 		};
 
-	const addThreshold = (): void => {
-		const nextIndex = thresholds.length;
-		onChange([...thresholds, defaultThreshold(variant, tableColumns)]);
-		setEditingIndex(nextIndex);
-		setUnsavedIndex(nextIndex);
-	};
+	const addThreshold = useCallback((): void => {
+		const current = value ?? [];
+		onChange([...current, defaultThreshold(variant, tableColumns)]);
+		setEditingIndex(current.length);
+		setUnsavedIndex(current.length);
+	}, [value, onChange, variant, tableColumns]);
+
+	useEffect(() => {
+		registerHeaderAction?.(addThreshold);
+		return (): void => registerHeaderAction?.(null);
+	}, [registerHeaderAction, addThreshold]);
 
 	const beginEdit = (index: number): void => {
 		editSnapshot.current = thresholds[index] ?? null;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/__tests__/prepareData.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/__tests__/prepareData.test.ts
@@ -83,6 +83,32 @@ describe('preparePieData', () => {
 		]);
 	});
 
+	it('substitutes a legend format template with the group-by values', () => {
+		const table = tableWith(
+			[
+				{
+					name: 'service.name',
+					queryName: 'A',
+					isValueColumn: false,
+					id: 'service.name',
+				},
+				{ name: 'count', queryName: 'A', isValueColumn: true, id: 'A' },
+			],
+			[
+				{ data: { 'service.name': 'adservice', A: 100 } },
+				{ data: { 'service.name': 'cartservice', A: 200 } },
+			],
+			{ legend: 'service.name = {{service.name}}' },
+		);
+
+		const slices = preparePieData(args([table]));
+
+		expect(slices.map((s) => s.label)).toStrictEqual([
+			'service.name = adservice',
+			'service.name = cartservice',
+		]);
+	});
+
 	it('prefixes the group when multiple value columns are grouped', () => {
 		const table = tableWith(
 			[

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/sections.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/types/sections.ts
@@ -14,15 +14,16 @@ import type {
 	TelemetrytypesTelemetryFieldKeyDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import {
+	Antenna,
 	BarChart,
 	Columns3,
 	Hash,
-	Layers,
-	LayoutDashboard,
-	Link,
+	Link2,
 	Palette,
-	Ruler,
-	SlidersHorizontal,
+	PencilRuler,
+	Scale3D,
+	Signpost,
+	Wallpaper,
 } from '@signozhq/icons';
 
 // Derived from an actual icon component so the type stays exact (size is a
@@ -157,14 +158,14 @@ export type SectionConfig =
 // Per-section title + sidebar icon. Pure data; the editor component + spec lens
 // live in the ConfigPane section registry.
 export const SECTION_METADATA = {
-	[SectionKind.Formatting]: { title: 'Formatting & Units', icon: Hash },
-	[SectionKind.Axes]: { title: 'Axes', icon: Ruler },
-	[SectionKind.Legend]: { title: 'Legend', icon: Layers },
+	[SectionKind.Formatting]: { title: 'Formatting & Units', icon: PencilRuler },
+	[SectionKind.Axes]: { title: 'Axes', icon: Scale3D },
+	[SectionKind.Legend]: { title: 'Legend', icon: Signpost },
 	[SectionKind.ChartAppearance]: { title: 'Chart appearance', icon: Palette },
-	[SectionKind.Visualization]: { title: 'Visualization', icon: LayoutDashboard },
+	[SectionKind.Visualization]: { title: 'Visualization', icon: Wallpaper },
 	[SectionKind.Buckets]: { title: 'Histogram / Buckets', icon: BarChart },
-	[SectionKind.Thresholds]: { title: 'Thresholds', icon: SlidersHorizontal },
-	[SectionKind.ContextLinks]: { title: 'Context Links', icon: Link },
+	[SectionKind.Thresholds]: { title: 'Thresholds', icon: Antenna },
+	[SectionKind.ContextLinks]: { title: 'Context Links', icon: Link2 },
 	[SectionKind.Columns]: { title: 'Columns', icon: Columns3 },
 } as const satisfies Record<SectionKind, SectionMetadata>;
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/usePanelQuery.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/__tests__/usePanelQuery.test.tsx
@@ -387,15 +387,23 @@ describe('usePanelQuery', () => {
 			expect(result.current.pagination?.canNext).toBe(false);
 		});
 
-		it('drives canNext from the response cursor, not the row count', () => {
-			// Full page but no cursor → backend says these are the last rows.
+		it('drives canNext from the cursor OR a full page (offset fallback for non-timestamp sorts)', () => {
+			// Full page, no cursor → the backend's offset path (a non-timestamp sort skips the
+			// window/cursor path), so a full page is the has-more signal.
 			withResponse(rawResponse(25));
-			const noCursor = renderHook(() =>
+			const fullPage = renderHook(() =>
 				usePanelQuery({ panel: listPanel({}), panelId: 'p1' }),
 			);
-			expect(noCursor.result.current.pagination?.canNext).toBe(false);
+			expect(fullPage.result.current.pagination?.canNext).toBe(true);
 
-			// Cursor present (even on a partial page) → more rows.
+			// Partial page, no cursor → the last page.
+			withResponse(rawResponse(3));
+			const partialPage = renderHook(() =>
+				usePanelQuery({ panel: listPanel({}), panelId: 'p1' }),
+			);
+			expect(partialPage.result.current.pagination?.canNext).toBe(false);
+
+			// Cursor present (even on a partial page) → more rows (timestamp window path).
 			withResponse(rawResponse(3, 'cursor-1'));
 			const withCursor = renderHook(() =>
 				usePanelQuery({ panel: listPanel({}), panelId: 'p1' }),

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/usePanelQuery.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/hooks/usePanelQuery.ts
@@ -283,8 +283,10 @@ export function usePanelQuery({
 		[pageSize],
 	);
 
-	// Paging handles for raw/list panels. The backend sets `nextCursor` iff the page filled,
-	// so it's the authoritative has-more signal (there's no total count on the wire).
+	// Paging handles for raw/list panels. The backend only emits `nextCursor` on the
+	// timestamp-ordered window path (isWindowList); a non-timestamp sort falls back to plain
+	// offset paging with no cursor. So treat a full page as a has-more signal too — matching the
+	// offset heuristic the logs/traces explorers use (there's no total count on the wire).
 	const pagination = useMemo<PanelPagination | undefined>(() => {
 		if (!isPaginated) {
 			return undefined;
@@ -300,7 +302,7 @@ export function usePanelQuery({
 		return {
 			pageIndex: Math.floor(safeOffset / safePageSize),
 			canPrev: safeOffset > 0,
-			canNext: !!result?.nextCursor,
+			canNext: !!result?.nextCursor || (result?.rows?.length ?? 0) >= safePageSize,
 			goPrev,
 			goNext,
 			pageSize: safePageSize,


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

A batch of polish and bug fixes for the V2 dashboard panel editor's **ConfigPane**, plus two panel-behavior fixes surfaced during the same pass:

- **Config-pane restyle** — the pane now matches the Configure-panel design: a "Panel Details" header with an accent marker, a "DISPLAY OPTIONS" eyebrow, hairline `--l1-border` dividers/section separators (kept from collapsing on overflow), and the shared `custom-scrollbar` mixin in place of the ad-hoc scrollbar.
- **Control border alignment** — `ConfigSelect`, `FormattingSection` and the threshold select use the standard `--l2-border`, and `ConfigSwitch` radius drops to 2px so all full-width controls read as one system.
- **Section header quick-add** — collapsible sections gain a generic `headerAction` slot; Thresholds and Context Links expose a header "+" that expands the section (if collapsed) and immediately starts a new entry.
- **Pie slice labels** — legend format templates now resolve `{{key}}` placeholders against group-by values instead of rendering the raw template.
- **List/raw pagination** — non-timestamp sorts (which page by offset with no cursor) can now page past the first page via a full-page heuristic, matching the logs/traces explorers.

#### Screenshots / Screen Recordings (if applicable)
> Config-pane restyle and the header quick-add are visual — before/after screenshots to be attached.

#### Issues closed by this PR
Closes https://github.com/SigNoz/pulse-pod/issues/140

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [x] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
- **Pie labels:** a single value column with a legend format was rendered as the raw template string because the label was never run through `getLabelName`, so `{{key}}` placeholders were left unresolved.
- **Pagination:** the backend only emits `nextCursor` on the timestamp-ordered window path; a non-timestamp sort falls back to plain offset paging with no cursor, so `canNext` was always false and list/raw panels were stuck on page one.
- **Styling:** dividers/borders used mismatched `--l2-border` tokens and an ad-hoc scrollbar, drifting from the Configure-panel design.

#### Fix Strategy
- Run single-value pie labels through `getLabelName` so placeholders resolve to group-by values.
- Fall back to a full-page heuristic for `canNext` when no cursor is present, matching the explorers.
- Normalize dividers to `--l1-border`, controls to `--l2-border`, and adopt the shared `custom-scrollbar` mixin.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
  - `SettingsSection.test.tsx` — headerAction slot + controlled `open`/`onOpenChange`.
  - `SectionSlot.test.tsx` — header "+" shows while collapsed, opens-when-populated, and expand-then-add.
  - `PieChartPanel/prepareData.test.ts` — legend format template resolution for slice labels.
  - `usePanelQuery.test.tsx` — `canNext` full-page heuristic under non-timestamp sorts.
- Manual verification: config pane restyle, header quick-add for Thresholds & Context Links, pie labels, and list pagination in the panel editor.
- Edge cases covered: collapsed vs populated sections, single value column with format template, non-timestamp sort paging past page one.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: V2 dashboard panel editor (ConfigPane) and pie/list panel rendering only; V1 untouched.
- Potential regressions: section open/collapse behavior, control styling drift, pie label formatting.
- Rollback plan: revert the PR; commits are scoped per-fix for granular revert if needed.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix / Feature |
| Description | V2 dashboard config-pane restyle and section header quick-add, plus pie slice label formatting and list-panel pagination fixes. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Commits are split per-fix, so each change can be reviewed (or reverted) independently. All changes are confined to V2 dashboard land — no V1 files are modified.

---
