### PR TITLE
chore: fix schema and validations based on migration errors

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -1592,13 +1592,6 @@ components:
       required:
       - config
       type: object
-    CommonDisplay:
-      properties:
-        description:
-          type: string
-        name:
-          type: string
-      type: object
     CommonJSONRef:
       properties:
         $ref:
@@ -2732,11 +2725,6 @@ components:
       type: object
     DashboardtypesDashboardSpec:
       properties:
-        datasources:
-          additionalProperties:
-            $ref: '#/components/schemas/DashboardtypesDatasourceSpec'
-          nullable: true
-          type: object
         display:
           $ref: '#/components/schemas/DashboardtypesDisplay'
         duration:
@@ -2800,39 +2788,6 @@ components:
           type: string
       required:
       - version
-      type: object
-    DashboardtypesDatasourcePlugin:
-      discriminator:
-        mapping:
-          signoz/Datasource: '#/components/schemas/DashboardtypesDatasourcePluginVariantGithubComSigNozSignozPkgTypesDashboardtypesSigNozDatasourceSpec'
-        propertyName: kind
-      oneOf:
-      - $ref: '#/components/schemas/DashboardtypesDatasourcePluginVariantGithubComSigNozSignozPkgTypesDashboardtypesSigNozDatasourceSpec'
-      type: object
-    DashboardtypesDatasourcePluginKind:
-      enum:
-      - signoz/Datasource
-      type: string
-    DashboardtypesDatasourcePluginVariantGithubComSigNozSignozPkgTypesDashboardtypesSigNozDatasourceSpec:
-      properties:
-        kind:
-          enum:
-          - signoz/Datasource
-          type: string
-        spec:
-          $ref: '#/components/schemas/DashboardtypesSigNozDatasourceSpec'
-      required:
-      - kind
-      - spec
-      type: object
-    DashboardtypesDatasourceSpec:
-      properties:
-        default:
-          type: boolean
-        display:
-          $ref: '#/components/schemas/CommonDisplay'
-        plugin:
-          $ref: '#/components/schemas/DashboardtypesDatasourcePlugin'
       type: object
     DashboardtypesDisplay:
       properties:
@@ -3609,8 +3564,6 @@ components:
           type: string
       required:
       - queryValue
-      type: object
-    DashboardtypesSigNozDatasourceSpec:
       type: object
     DashboardtypesSource:
       enum:

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -3236,17 +3236,6 @@ export interface CloudintegrationtypesUpdatableServiceDTO {
 	config: CloudintegrationtypesServiceConfigDTO;
 }
 
-export interface CommonDisplayDTO {
-	/**
-	 * @type string
-	 */
-	description?: string;
-	/**
-	 * @type string
-	 */
-	name?: string;
-}
-
 export interface CommonJSONRefDTO {
 	/**
 	 * @type string
@@ -3989,44 +3978,6 @@ export interface DashboardtypesDashboardPanelRefDTO {
 	 */
 	panelName: string;
 }
-
-export enum DashboardtypesDatasourcePluginVariantGithubComSigNozSignozPkgTypesDashboardtypesSigNozDatasourceSpecDTOKind {
-	'signoz/Datasource' = 'signoz/Datasource',
-}
-export interface DashboardtypesSigNozDatasourceSpecDTO {
-	[key: string]: unknown;
-}
-
-export interface DashboardtypesDatasourcePluginVariantGithubComSigNozSignozPkgTypesDashboardtypesSigNozDatasourceSpecDTO {
-	/**
-	 * @enum signoz/Datasource
-	 * @type string
-	 */
-	kind: DashboardtypesDatasourcePluginVariantGithubComSigNozSignozPkgTypesDashboardtypesSigNozDatasourceSpecDTOKind;
-	spec: DashboardtypesSigNozDatasourceSpecDTO;
-}
-
-export type DashboardtypesDatasourcePluginDTO =
-	DashboardtypesDatasourcePluginVariantGithubComSigNozSignozPkgTypesDashboardtypesSigNozDatasourceSpecDTO;
-
-export interface DashboardtypesDatasourceSpecDTO {
-	/**
-	 * @type boolean
-	 */
-	default?: boolean;
-	display?: CommonDisplayDTO;
-	plugin?: DashboardtypesDatasourcePluginDTO;
-}
-
-export type DashboardtypesDashboardSpecDTODatasourcesAnyOf = {
-	[key: string]: DashboardtypesDatasourceSpecDTO;
-};
-
-/**
- * @nullable
- */
-export type DashboardtypesDashboardSpecDTODatasources =
-	DashboardtypesDashboardSpecDTODatasourcesAnyOf | null;
 
 export enum DashboardtypesPanelKindDTO {
 	Panel = 'Panel',
@@ -4807,10 +4758,6 @@ export type DashboardtypesVariableDTO =
 	| DashboardtypesVariableEnvelopeGithubComSigNozSignozPkgTypesDashboardtypesTextVariableSpecDTO;
 
 export interface DashboardtypesDashboardSpecDTO {
-	/**
-	 * @type object,null
-	 */
-	datasources?: DashboardtypesDashboardSpecDTODatasources;
 	display: DashboardtypesDisplayDTO;
 	/**
 	 * @type string
@@ -4886,9 +4833,6 @@ export interface DashboardtypesDashboardViewDTO {
 	updatedAt?: string;
 }
 
-export enum DashboardtypesDatasourcePluginKindDTO {
-	'signoz/Datasource' = 'signoz/Datasource',
-}
 export interface TagtypesGettableTagDTO {
 	/**
 	 * @type string

--- a/pkg/types/dashboardtypes/perses_dashboard_data.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_data.go
@@ -106,7 +106,7 @@ func (d *DashboardSpec) validatePanels() error {
 		}
 		panelKind := panel.Spec.Plugin.Kind
 		if len(panel.Spec.Queries) != 1 {
-			return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "%s.spec.queries: panel must have one query", path)
+			return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "%s.spec.queries: panel must have one query, found %d", path, len(panel.Spec.Queries))
 		}
 		allowed := allowedQueryKinds[panelKind]
 		for qi, q := range panel.Spec.Queries {
@@ -269,8 +269,8 @@ func (d *DashboardSpec) validateLayouts() error {
 			return errors.NewInternalf(errors.CodeInternal, "spec.layouts[%d].spec: unexpected layout spec type %T", li, layout.Spec)
 		}
 		if grid.Display != nil {
-			if n := utf8.RuneCountInString(grid.Display.Title); n > MaxDisplayNameLen {
-				return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "spec.layouts[%d].spec.display.title: layout name must be at most %d characters, got %d", li, MaxDisplayNameLen, n)
+			if n := utf8.RuneCountInString(grid.Display.Title); n > MaxLayoutTitleLen {
+				return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "spec.layouts[%d].spec.display.title: layout name must be at most %d characters, got %d", li, MaxLayoutTitleLen, n)
 			}
 		}
 		if err := validateGridLayoutGeometry(grid, li); err != nil {

--- a/pkg/types/dashboardtypes/perses_dashboard_data.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_data.go
@@ -17,16 +17,17 @@ import (
 // DashboardSpec is the SigNoz dashboard v2 spec shape. It mirrors
 // dashboard.Spec (Perses) field-for-field, except every common.Plugin
 // occurrence is replaced with a typed SigNoz plugin whose OpenAPI schema is a
-// per-site discriminated oneOf.
+// per-site discriminated oneOf. Perses's datasources field is deliberately
+// dropped: SigNoz never reads it (queries carry their own signal/source), so
+// the drift test allowlists it as an intentional omission.
 type DashboardSpec struct {
-	Display         Display                    `json:"display" required:"true"`
-	Datasources     map[string]*DatasourceSpec `json:"datasources,omitzero"`
-	Variables       []Variable                 `json:"variables" required:"true" nullable:"false"`
-	Panels          map[string]*Panel          `json:"panels" required:"true" nullable:"false"`
-	Layouts         []Layout                   `json:"layouts" required:"true" nullable:"false"`
-	Duration        common.DurationString      `json:"duration"`
-	RefreshInterval common.DurationString      `json:"refreshInterval"`
-	Links           []Link                     `json:"links,omitzero"`
+	Display         Display               `json:"display" required:"true"`
+	Variables       []Variable            `json:"variables" required:"true" nullable:"false"`
+	Panels          map[string]*Panel     `json:"panels" required:"true" nullable:"false"`
+	Layouts         []Layout              `json:"layouts" required:"true" nullable:"false"`
+	Duration        common.DurationString `json:"duration"`
+	RefreshInterval common.DurationString `json:"refreshInterval"`
+	Links           []Link                `json:"links,omitzero"`
 }
 
 // ══════════════════════════════════════════════

--- a/pkg/types/dashboardtypes/perses_dashboard_patch_test.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_patch_test.go
@@ -30,7 +30,7 @@ const basePostableJSON = `{
 				"spec": {
 					"name": "service",
 					"allowAllValue": true,
-					"allowMultiple": false,
+					"allowMultiple": true,
 					"plugin": {
 						"kind": "signoz/DynamicVariable",
 						"spec": {"name": "service.name", "signal": "metrics"}

--- a/pkg/types/dashboardtypes/perses_dashboard_test.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_test.go
@@ -44,7 +44,7 @@ func TestInvalidateNotAJSON(t *testing.T) {
 // TestUnmarshalErrorPreservesNestedMessage guards the wrap on dec.Decode in
 // DashboardSpec.UnmarshalJSON. The wrap stamps a consistent type/code on
 // decode failures, but must not smother the rich messages produced by nested
-// UnmarshalJSON methods (panel/query/variable/datasource plugin envelopes).
+// UnmarshalJSON methods (panel/query/variable plugin envelopes).
 func TestUnmarshalErrorPreservesNestedMessage(t *testing.T) {
 	data := []byte(`{
 		"panels": {
@@ -446,20 +446,6 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 				"layouts": []
 			}`,
 			wantContain: "FakeVariable",
-		},
-		{
-			name: "unknown datasource plugin",
-			data: `{
-				"datasources": {
-					"ds1": {
-						"default": true,
-						"plugin": {"kind": "FakeDatasource", "spec": {}}
-					}
-				},
-				"links": [],
-				"layouts": []
-			}`,
-			wantContain: "FakeDatasource",
 		},
 	}
 

--- a/pkg/types/dashboardtypes/perses_dashboard_test.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_test.go
@@ -91,7 +91,7 @@ func TestValidateOnlyVariables(t *testing.T) {
 				"spec": {
 					"name": "service",
 					"allowAllValue": true,
-					"allowMultiple": false,
+					"allowMultiple": true,
 					"plugin": {
 						"kind": "signoz/DynamicVariable",
 						"spec": {
@@ -235,6 +235,12 @@ func TestInvalidateListVariableCrossFields(t *testing.T) {
 		_, err := unmarshalDashboard(listVar(`"allowAllValue": false, "allowMultiple": false, "customAllValue": "*",`))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "customAllValue cannot be set")
+	})
+
+	t.Run("allowAllValue without allowMultiple", func(t *testing.T) {
+		_, err := unmarshalDashboard(listVar(`"allowAllValue": true, "allowMultiple": false,`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "allowAllValue cannot be set")
 	})
 
 	t.Run("list defaultValue without allowMultiple", func(t *testing.T) {
@@ -1739,55 +1745,61 @@ func TestInvalidateDuplicatePanelReference(t *testing.T) {
 	assert.Contains(t, err.Error(), "spec.layouts[0].spec.items[1].content")
 }
 
-// Every display name — dashboard, panel, variable — and the grid layout title is
-// bounded at MaxDisplayNameLen. The name is one over the limit in each case, and
-// the message reads "<json path>: <field> name must be at most ...", pairing the
-// locatable path (like the other spec errors) with a human field label.
+// Every display name — dashboard, panel, variable — is bounded at MaxDisplayNameLen,
+// while the grid layout title has its own, larger bound (MaxLayoutTitleLen). The name
+// is one over the relevant limit in each case, and the message reads "<json path>:
+// <field> name must be at most ...", pairing the locatable path (like the other spec
+// errors) with a human field label.
 func TestInvalidateDisplayNameTooLong(t *testing.T) {
-	tooLong := strings.Repeat("x", MaxDisplayNameLen+1)
-	lengthMsg := fmt.Sprintf("must be at most %d characters, got %d", MaxDisplayNameLen, MaxDisplayNameLen+1)
-
 	testCases := []struct {
-		scenario      string
-		dashboardJSON string
-		expectedPath  string
-		expectedLabel string
+		scenario         string
+		limit            int
+		dashboardJSONFmt string
+		expectedPath     string
+		expectedLabel    string
 	}{
 		{
-			scenario:      "dashboard display name",
-			dashboardJSON: `{"display": {"name": "` + tooLong + `"}, "links": [], "layouts": []}`,
-			expectedLabel: "dashboard",
-			expectedPath:  "spec.display.name",
+			scenario:         "dashboard display name",
+			limit:            MaxDisplayNameLen,
+			dashboardJSONFmt: `{"display": {"name": "%s"}, "links": [], "layouts": []}`,
+			expectedLabel:    "dashboard",
+			expectedPath:     "spec.display.name",
 		},
 		{
-			scenario:      "panel display name",
-			dashboardJSON: `{"panels": {"p1": {"kind": "Panel", "spec": {"links": [],"display": {"name": "` + tooLong + `"}, "plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": []}}}, "links": [], "layouts": []}`,
-			expectedLabel: "panel",
-			expectedPath:  "spec.panels.p1.spec.display.name",
+			scenario:         "panel display name",
+			limit:            MaxDisplayNameLen,
+			dashboardJSONFmt: `{"panels": {"p1": {"kind": "Panel", "spec": {"links": [], "display": {"name": "%s"}, "plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": []}}}, "links": [], "layouts": []}`,
+			expectedLabel:    "panel",
+			expectedPath:     "spec.panels.p1.spec.display.name",
 		},
 		{
-			scenario:      "list variable display name",
-			dashboardJSON: `{"variables": [{"kind": "ListVariable", "spec": {"name": "svc", "display": {"name": "` + tooLong + `"}, "plugin": {"kind": "signoz/DynamicVariable", "spec": {"name": "service.name", "signal": "metrics"}}}}], "links": [], "layouts": []}`,
-			expectedLabel: "variable",
-			expectedPath:  "spec.variables[0].spec.display.name",
+			scenario:         "list variable display name",
+			limit:            MaxDisplayNameLen,
+			dashboardJSONFmt: `{"variables": [{"kind": "ListVariable", "spec": {"name": "svc", "display": {"name": "%s"}, "plugin": {"kind": "signoz/DynamicVariable", "spec": {"name": "service.name", "signal": "metrics"}}}}], "links": [], "layouts": []}`,
+			expectedLabel:    "variable",
+			expectedPath:     "spec.variables[0].spec.display.name",
 		},
 		{
-			scenario:      "text variable display name",
-			dashboardJSON: `{"variables": [{"kind": "TextVariable", "spec": {"name": "mytext", "value": "v", "display": {"name": "` + tooLong + `"}}}], "links": [], "layouts": []}`,
-			expectedLabel: "variable",
-			expectedPath:  "spec.variables[0].spec.display.name",
+			scenario:         "text variable display name",
+			limit:            MaxDisplayNameLen,
+			dashboardJSONFmt: `{"variables": [{"kind": "TextVariable", "spec": {"name": "mytext", "value": "v", "display": {"name": "%s"}}}], "links": [], "layouts": []}`,
+			expectedLabel:    "variable",
+			expectedPath:     "spec.variables[0].spec.display.name",
 		},
 		{
-			scenario:      "layout title",
-			dashboardJSON: `{"links": [], "layouts": [{"kind": "Grid", "spec": {"display": {"title": "` + tooLong + `"}, "items": []}}]}`,
-			expectedLabel: "layout",
-			expectedPath:  "spec.layouts[0].spec.display.title",
+			scenario:         "layout title",
+			limit:            MaxLayoutTitleLen,
+			dashboardJSONFmt: `{"links": [], "layouts": [{"kind": "Grid", "spec": {"display": {"title": "%s"}, "items": []}}]}`,
+			expectedLabel:    "layout",
+			expectedPath:     "spec.layouts[0].spec.display.title",
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.scenario, func(t *testing.T) {
-			_, err := unmarshalDashboard([]byte(testCase.dashboardJSON))
+			tooLong := strings.Repeat("x", testCase.limit+1)
+			lengthMsg := fmt.Sprintf("must be at most %d characters, got %d", testCase.limit, testCase.limit+1)
+			_, err := unmarshalDashboard(fmt.Appendf(nil, testCase.dashboardJSONFmt, tooLong))
 			require.Error(t, err)
 			// Message is "<path>: <label> name must be at most N characters, got M".
 			want := testCase.expectedPath + ": " + testCase.expectedLabel + " name " + lengthMsg

--- a/pkg/types/dashboardtypes/perses_drift_test.go
+++ b/pkg/types/dashboardtypes/perses_drift_test.go
@@ -6,12 +6,12 @@ package dashboardtypes
 
 import (
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
 
 	"github.com/perses/spec/go/dashboard"
-	"github.com/perses/spec/go/datasource"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -21,22 +21,27 @@ func TestDashboardSpecMatchesPerses(t *testing.T) {
 		name   string
 		ours   reflect.Type
 		perses reflect.Type
+		// omit lists json fields intentionally dropped from our type that Perses
+		// still has, so their absence is not reported as drift.
+		omit []string
 	}{
-		{"DashboardSpec", typeOf[DashboardSpec](), typeOf[dashboard.Spec]()},
-		{"Panel", typeOf[Panel](), typeOf[dashboard.Panel]()},
-		{"PanelSpec", typeOf[PanelSpec](), typeOf[dashboard.PanelSpec]()},
-		{"Query", typeOf[Query](), typeOf[dashboard.Query]()},
-		{"QuerySpec", typeOf[QuerySpec](), typeOf[dashboard.QuerySpec]()},
-		{"DatasourceSpec", typeOf[DatasourceSpec](), typeOf[datasource.Spec]()},
-		{"Variable", typeOf[Variable](), typeOf[dashboard.Variable]()},
-		{"ListVariableSpec", typeOf[ListVariableSpec](), typeOf[dashboard.ListVariableSpec]()},
-		{"TextVariableSpec", typeOf[TextVariableSpec](), typeOf[dashboard.TextVariableSpec]()},
-		{"Layout", typeOf[Layout](), typeOf[dashboard.Layout]()},
+		{name: "DashboardSpec", ours: typeOf[DashboardSpec](), perses: typeOf[dashboard.Spec](), omit: []string{"datasources"}},
+		{name: "Panel", ours: typeOf[Panel](), perses: typeOf[dashboard.Panel]()},
+		{name: "PanelSpec", ours: typeOf[PanelSpec](), perses: typeOf[dashboard.PanelSpec]()},
+		{name: "Query", ours: typeOf[Query](), perses: typeOf[dashboard.Query]()},
+		{name: "QuerySpec", ours: typeOf[QuerySpec](), perses: typeOf[dashboard.QuerySpec]()},
+		{name: "Variable", ours: typeOf[Variable](), perses: typeOf[dashboard.Variable]()},
+		{name: "ListVariableSpec", ours: typeOf[ListVariableSpec](), perses: typeOf[dashboard.ListVariableSpec]()},
+		{name: "TextVariableSpec", ours: typeOf[TextVariableSpec](), perses: typeOf[dashboard.TextVariableSpec]()},
+		{name: "Layout", ours: typeOf[Layout](), perses: typeOf[dashboard.Layout]()},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			missing, extra := drift(c.ours, c.perses)
+			for _, f := range c.omit {
+				missing = slices.DeleteFunc(missing, func(m string) bool { return m == f })
+			}
 
 			assert.Empty(t, missing,
 				"DashboardSpec (%s) is missing json fields present on Perses %s — upstream likely added or renamed a field",

--- a/pkg/types/dashboardtypes/perses_plugin_wrappers.go
+++ b/pkg/types/dashboardtypes/perses_plugin_wrappers.go
@@ -216,54 +216,6 @@ func (v VariablePluginVariant[S]) PrepareJSONSchema(s *jsonschema.Schema) error 
 }
 
 // ══════════════════════════════════════════════
-// Datasource plugin
-// ══════════════════════════════════════════════
-
-type DatasourcePlugin struct {
-	Kind DatasourcePluginKind `json:"kind" required:"true"`
-	Spec any                  `json:"spec" required:"true"`
-}
-
-func (DatasourcePlugin) PrepareJSONSchema(s *jsonschema.Schema) error {
-	return markDiscriminator(s, "kind", map[string]string{
-		string(DatasourceKindSigNoz): schemaRef("DashboardtypesDatasourcePluginVariantGithubComSigNozSignozPkgTypesDashboardtypesSigNozDatasourceSpec"),
-	})
-}
-
-func (p *DatasourcePlugin) UnmarshalJSON(data []byte) error {
-	kind, specJSON, err := extractKindAndSpec(data)
-	if err != nil {
-		return err
-	}
-	factory, ok := datasourcePluginSpecs[DatasourcePluginKind(kind)]
-	if !ok {
-		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "unknown datasource plugin kind %q; allowed values: %s", kind, allowedValuesForKind(slices.Sorted(maps.Keys(datasourcePluginSpecs))))
-	}
-	spec, err := decodeSpec(specJSON, factory(), kind)
-	if err != nil {
-		return err
-	}
-	p.Kind = DatasourcePluginKind(kind)
-	p.Spec = *spec
-	return nil
-}
-
-func (DatasourcePlugin) JSONSchemaOneOf() []any {
-	return []any{
-		DatasourcePluginVariant[SigNozDatasourceSpec]{Kind: string(DatasourceKindSigNoz)},
-	}
-}
-
-type DatasourcePluginVariant[S any] struct {
-	Kind string `json:"kind" required:"true"`
-	Spec S      `json:"spec" required:"true"`
-}
-
-func (v DatasourcePluginVariant[S]) PrepareJSONSchema(s *jsonschema.Schema) error {
-	return restrictKindToOneValue(s, v.Kind)
-}
-
-// ══════════════════════════════════════════════
 // Helpers
 // ══════════════════════════════════════════════
 
@@ -290,10 +242,6 @@ var (
 		VariableKindQuery:   func() any { return new(QueryVariableSpec) },
 		VariableKindCustom:  func() any { return new(CustomVariableSpec) },
 	}
-	datasourcePluginSpecs = map[DatasourcePluginKind]func() any{
-		DatasourceKindSigNoz: func() any { return new(SigNozDatasourceSpec) },
-	}
-
 	allowedQueryKinds = map[PanelPluginKind][]QueryPluginKind{
 		PanelKindTimeSeries: {QueryKindBuilder, QueryKindComposite, QueryKindFormula, QueryKindTraceOperator, QueryKindPromQL, QueryKindClickHouseSQL},
 		PanelKindBarChart:   {QueryKindBuilder, QueryKindComposite, QueryKindFormula, QueryKindTraceOperator, QueryKindPromQL, QueryKindClickHouseSQL},

--- a/pkg/types/dashboardtypes/perses_replicas.go
+++ b/pkg/types/dashboardtypes/perses_replicas.go
@@ -16,9 +16,13 @@ import (
 	"github.com/swaggest/jsonschema-go"
 )
 
-// MaxDisplayNameLen bounds every human-readable display name — dashboard, panel,
-// and variable display names, plus the grid layout title.
+// MaxDisplayNameLen bounds the human-readable display names — dashboard, panel,
+// and variable. The grid layout title has its own, larger bound (MaxLayoutTitleLen).
 const MaxDisplayNameLen = 128
+
+// MaxLayoutTitleLen bounds a grid layout title. It is larger than MaxDisplayNameLen
+// because v1 section (row) titles ran longer.
+const MaxLayoutTitleLen = 256
 
 type Display struct {
 	Name string `json:"name" required:"true"`
@@ -230,6 +234,9 @@ func (s *ListVariableSpec) validate(path string) error {
 	}
 	if s.CustomAllValue != "" && !s.AllowAllValue {
 		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "%s: customAllValue cannot be set if allowAllValue is not set to true", path)
+	}
+	if s.AllowAllValue && !s.AllowMultiple {
+		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "%s: allowAllValue cannot be set if allowMultiple is not set to true", path)
 	}
 	if s.DefaultValue != nil && len(s.DefaultValue.SliceValues) > 0 && !s.AllowMultiple {
 		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "%s: defaultValue cannot be a list if allowMultiple is not set to true", path)

--- a/pkg/types/dashboardtypes/perses_replicas.go
+++ b/pkg/types/dashboardtypes/perses_replicas.go
@@ -39,16 +39,6 @@ func (d Display) Validate(label, path string) error {
 }
 
 // ══════════════════════════════════════════════
-// Datasource
-// ══════════════════════════════════════════════
-
-type DatasourceSpec struct {
-	Display *common.Display  `json:"display,omitempty"`
-	Default bool             `json:"default"`
-	Plugin  DatasourcePlugin `json:"plugin"`
-}
-
-// ══════════════════════════════════════════════
 // Panel
 // ══════════════════════════════════════════════
 

--- a/pkg/types/dashboardtypes/perses_signoz_plugins.go
+++ b/pkg/types/dashboardtypes/perses_signoz_plugins.go
@@ -179,21 +179,6 @@ func (PanelPluginKind) Enum() []any {
 	return []any{PanelKindTimeSeries, PanelKindBarChart, PanelKindNumber, PanelKindPieChart, PanelKindTable, PanelKindHistogram, PanelKindList}
 }
 
-type DatasourcePluginKind string
-
-const (
-	DatasourceKindSigNoz DatasourcePluginKind = "signoz/Datasource"
-)
-
-func (DatasourcePluginKind) Enum() []any {
-	return []any{DatasourceKindSigNoz}
-}
-
-// SigNozDatasourceSpec is the (empty) signoz/Datasource plugin spec. Naming the
-// type gives the variant a concrete, non-nullable spec schema instead of an
-// inline free-form one.
-type SigNozDatasourceSpec struct{}
-
 type TimeSeriesPanelSpec struct {
 	Visualization   TimeSeriesVisualization   `json:"visualization"`
 	Formatting      PanelFormatting           `json:"formatting"`

--- a/pkg/types/dashboardtypes/testdata/perses.json
+++ b/pkg/types/dashboardtypes/testdata/perses.json
@@ -22,7 +22,7 @@
                     "name": "serviceName"
                 },
                 "allowAllValue": true,
-                "allowMultiple": false,
+                "allowMultiple": true,
                 "sort": "none",
                 "plugin": {
                     "kind": "signoz/DynamicVariable",

--- a/pkg/types/dashboardtypes/testdata/perses.json
+++ b/pkg/types/dashboardtypes/testdata/perses.json
@@ -4,15 +4,6 @@
         "description": "Trying to cover as many concepts here as possible"
     },
     "duration": "1h",
-    "datasources": {
-        "SigNozDatasource": {
-            "default": true,
-            "plugin": {
-                "kind": "signoz/Datasource",
-                "spec": {}
-            }
-        }
-    },
     "variables": [
         {
             "kind": "ListVariable",

--- a/pkg/types/dashboardtypes/testdata/perses_with_sections.json
+++ b/pkg/types/dashboardtypes/testdata/perses_with_sections.json
@@ -3,15 +3,6 @@
         "name": "NV dashboard with sections",
         "description": ""
     },
-    "datasources": {
-        "SigNozDatasource": {
-            "default": true,
-            "plugin": {
-                "kind": "signoz/Datasource",
-                "spec": {}
-            }
-        }
-    },
     "links": [],
     "panels": {
         "b424e23b": {

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -196,6 +196,70 @@ def test_create_rejects_long_display_name(
     assert response.json()["error"]["code"] == "dashboard_invalid_input"
     assert "spec.display.name: dashboard name must be at most 128 characters" in response.json()["error"]["message"]
 
+    # A grid layout title has its own, larger bound of 256 characters; one over
+    # must be rejected.
+    response = requests.post(
+        signoz.self.host_configs["8080"].get(BASE_URL),
+        json={
+            "schemaVersion": "v6",
+            "name": "long-layout-title",
+            "spec": {
+                "display": {"name": "Long Layout Title"},
+                "links": [],
+                "layouts": [{"kind": "Grid", "spec": {"display": {"title": "x" * 257}, "items": []}}],
+            },
+        },
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=5,
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json()["error"]["code"] == "dashboard_invalid_input"
+    assert "spec.layouts[0].spec.display.title: layout name must be at most 256 characters" in response.json()["error"]["message"]
+
+
+def test_create_rejects_all_value_without_multiselect(
+    signoz: SigNoz,
+    create_user_admin: Operation,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+):
+    token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+
+    # A list variable cannot offer an "all" value unless it also allows selecting
+    # multiple values — allowAllValue without allowMultiple must be rejected.
+    response = requests.post(
+        signoz.self.host_configs["8080"].get(BASE_URL),
+        json={
+            "schemaVersion": "v6",
+            "name": "all-without-multi",
+            "spec": {
+                "display": {"name": "All Without Multi"},
+                "links": [],
+                "variables": [
+                    {
+                        "kind": "ListVariable",
+                        "spec": {
+                            "name": "svc",
+                            "allowAllValue": True,
+                            "allowMultiple": False,
+                            "plugin": {
+                                "kind": "signoz/DynamicVariable",
+                                "spec": {"name": "service.name", "signal": "metrics"},
+                            },
+                        },
+                    }
+                ],
+            },
+            "tags": [],
+        },
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=5,
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json()["error"]["code"] == "dashboard_invalid_input"
+    assert "allowAllValue cannot be set" in response.json()["error"]["message"]
+
 
 def test_create_rejects_invalid_grid_layout(
     signoz: SigNoz,

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -1772,8 +1772,8 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
 
     dashboard = {
         "schemaVersion": "v6",
-        # image (dashboard-level) and spec duration/refreshInterval/datasources
-        # each round-trip their zero value ("" / {}) rather than being dropped.
+        # image (dashboard-level) and spec duration/refreshInterval each
+        # round-trip their zero value ("") rather than being dropped.
         "image": "",
         "name": "roundtrip-zero-values",
         "tags": [],
@@ -1781,7 +1781,6 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
             "display": {"name": "Roundtrip Zero Values", "description": ""},
             "duration": "",
             "refreshInterval": "",
-            "datasources": {},
             "variables": [
                 # TextVariable: constant false must echo back (not be dropped).
                 {"kind": "TextVariable", "spec": {"display": {"name": "tv"}, "value": "x", "constant": False, "name": "tv"}},
@@ -1967,7 +1966,6 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
             ("dashboard image empty", result_data["image"], ""),
             ("spec duration empty", result_spec["duration"], ""),
             ("spec refreshInterval empty", result_spec["refreshInterval"], ""),
-            ("spec empty datasources round-trip", result_spec["datasources"], {}),
         ]
         for description, actual, expected in roundtrip_cases:
             assert actual == expected, description


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Migration may take some more time to review, but at least the validations added to the dashboards code through migration testing should be merged quickly so that the MCP server docs can be updated properly

List of fixes:
1. don't show the ALL variables options if multiple values are not allowed
2. longer layout title than other titles
3. better error messages 

And a big one: Remove `datasource` field altogether. This is because this field is optional in perses schema, and signoz does not use this field at all.

[Even the Perses user guide](https://perses.dev/perses-operator/docs/user-guide/#creating-datasources-and-dashboards) defines datasource as a separate entity, with the dashboard omitting this field.

SigNoz dashboards remain valid perses dashboards even if this optional field is not there.