### PR TITLE
fix(signoz): consolidate the duplicate telemetryMetadataStore construction

### DIFF
--- a/pkg/querier/signozquerier/provider.go
+++ b/pkg/querier/signozquerier/provider.go
@@ -11,16 +11,17 @@ import (
 	"github.com/SigNoz/signoz/pkg/querybuilder"
 	"github.com/SigNoz/signoz/pkg/telemetryaudit"
 	"github.com/SigNoz/signoz/pkg/telemetrylogs"
-	"github.com/SigNoz/signoz/pkg/telemetrymetadata"
 	"github.com/SigNoz/signoz/pkg/telemetrymeter"
 	"github.com/SigNoz/signoz/pkg/telemetrymetrics"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrytraces"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 )
 
 // NewFactory creates a new factory for the signoz querier provider.
 func NewFactory(
 	telemetryStore telemetrystore.TelemetryStore,
+	telemetryMetadataStore telemetrytypes.MetadataStore,
 	prometheus prometheus.Prometheus,
 	cache cache.Cache,
 	flagger flagger.Flagger,
@@ -32,7 +33,7 @@ func NewFactory(
 			settings factory.ProviderSettings,
 			cfg querier.Config,
 		) (querier.Querier, error) {
-			return newProvider(ctx, settings, cfg, telemetryStore, prometheus, cache, flagger)
+			return newProvider(ctx, settings, cfg, telemetryStore, telemetryMetadataStore, prometheus, cache, flagger)
 		},
 	)
 }
@@ -42,38 +43,11 @@ func newProvider(
 	settings factory.ProviderSettings,
 	cfg querier.Config,
 	telemetryStore telemetrystore.TelemetryStore,
+	telemetryMetadataStore telemetrytypes.MetadataStore,
 	prometheus prometheus.Prometheus,
 	cache cache.Cache,
 	flagger flagger.Flagger,
 ) (querier.Querier, error) {
-
-	// Create telemetry metadata store
-	telemetryMetadataStore := telemetrymetadata.NewTelemetryMetaStore(
-		settings,
-		telemetryStore,
-		telemetrytraces.DBName,
-		telemetrytraces.TagAttributesV2TableName,
-		telemetrytraces.SpanAttributesKeysTblName,
-		telemetrytraces.SpanIndexV3TableName,
-		telemetrymetrics.DBName,
-		telemetrymetrics.AttributesMetadataTableName,
-		telemetrymeter.DBName,
-		telemetrymeter.SamplesAgg1dTableName,
-		telemetrylogs.DBName,
-		telemetrylogs.LogsV2TableName,
-		telemetrylogs.TagAttributesV2TableName,
-		telemetrylogs.LogAttributeKeysTblName,
-		telemetrylogs.LogResourceKeysTblName,
-		telemetryaudit.DBName,
-		telemetryaudit.AuditLogsTableName,
-		telemetryaudit.TagAttributesTableName,
-		telemetryaudit.LogAttributeKeysTblName,
-		telemetryaudit.LogResourceKeysTblName,
-		telemetrymetadata.DBName,
-		telemetrymetadata.AttributesMetadataLocalTableName,
-		telemetrymetadata.ColumnEvolutionMetadataTableName,
-		flagger,
-	)
 
 	// Create trace statement builder
 	traceFieldMapper := telemetrytraces.NewFieldMapper()

--- a/pkg/query-service/rules/managertestfactory.go
+++ b/pkg/query-service/rules/managertestfactory.go
@@ -18,8 +18,14 @@ import (
 	"github.com/SigNoz/signoz/pkg/querier/signozquerier"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
 	"github.com/SigNoz/signoz/pkg/sqlstore/sqlstoretest"
+	"github.com/SigNoz/signoz/pkg/telemetryaudit"
+	"github.com/SigNoz/signoz/pkg/telemetrylogs"
+	"github.com/SigNoz/signoz/pkg/telemetrymetadata"
+	"github.com/SigNoz/signoz/pkg/telemetrymeter"
+	"github.com/SigNoz/signoz/pkg/telemetrymetrics"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
+	"github.com/SigNoz/signoz/pkg/telemetrytraces"
 	"github.com/stretchr/testify/require"
 )
 
@@ -104,8 +110,36 @@ func NewTestManager(t *testing.T, testOpts *TestManagerOptions) *Manager {
 		t.Fatalf("failed to create flagger: %v", err)
 	}
 
-	// Create querier with test values
-	providerFactory := signozquerier.NewFactory(telemetryStore, prometheus, cache, flagger)
+	// Create querier with test values. A real telemetry metadata store is
+	// required so the querier can resolve metric metadata against the mock
+	// telemetry store during rule evaluation.
+	metadataStore := telemetrymetadata.NewTelemetryMetaStore(
+		providerSettings,
+		telemetryStore,
+		telemetrytraces.DBName,
+		telemetrytraces.TagAttributesV2TableName,
+		telemetrytraces.SpanAttributesKeysTblName,
+		telemetrytraces.SpanIndexV3TableName,
+		telemetrymetrics.DBName,
+		telemetrymetrics.AttributesMetadataTableName,
+		telemetrymeter.DBName,
+		telemetrymeter.SamplesAgg1dTableName,
+		telemetrylogs.DBName,
+		telemetrylogs.LogsV2TableName,
+		telemetrylogs.TagAttributesV2TableName,
+		telemetrylogs.LogAttributeKeysTblName,
+		telemetrylogs.LogResourceKeysTblName,
+		telemetryaudit.DBName,
+		telemetryaudit.AuditLogsTableName,
+		telemetryaudit.TagAttributesTableName,
+		telemetryaudit.LogAttributeKeysTblName,
+		telemetryaudit.LogResourceKeysTblName,
+		telemetrymetadata.DBName,
+		telemetrymetadata.AttributesMetadataLocalTableName,
+		telemetrymetadata.ColumnEvolutionMetadataTableName,
+		flagger,
+	)
+	providerFactory := signozquerier.NewFactory(telemetryStore, metadataStore, prometheus, cache, flagger)
 	mockQuerier, err := providerFactory.New(context.Background(), providerSettings, querier.Config{})
 	require.NoError(t, err)
 

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -61,6 +61,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/clickhousetelemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystorehook"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/tokenizer"
 	"github.com/SigNoz/signoz/pkg/tokenizer/jwttokenizer"
 	"github.com/SigNoz/signoz/pkg/tokenizer/opaquetokenizer"
@@ -280,9 +281,9 @@ func NewStatsReporterProviderFactories(aggregator statsreporter.Aggregator, orgG
 	)
 }
 
-func NewQuerierProviderFactories(telemetryStore telemetrystore.TelemetryStore, prometheus prometheus.Prometheus, cache cache.Cache, flagger flagger.Flagger) factory.NamedMap[factory.ProviderFactory[querier.Querier, querier.Config]] {
+func NewQuerierProviderFactories(telemetryStore telemetrystore.TelemetryStore, telemetryMetadataStore telemetrytypes.MetadataStore, prometheus prometheus.Prometheus, cache cache.Cache, flagger flagger.Flagger) factory.NamedMap[factory.ProviderFactory[querier.Querier, querier.Config]] {
 	return factory.MustNewNamedMap(
-		signozquerier.NewFactory(telemetryStore, prometheus, cache, flagger),
+		signozquerier.NewFactory(telemetryStore, telemetryMetadataStore, prometheus, cache, flagger),
 	)
 }
 

--- a/pkg/signoz/signoz.go
+++ b/pkg/signoz/signoz.go
@@ -253,12 +253,40 @@ func New(
 		return nil, err
 	}
 
+	// Initialize telemetry metadata store
+	telemetryMetadataStore := telemetrymetadata.NewTelemetryMetaStore(
+		providerSettings,
+		telemetrystore,
+		telemetrytraces.DBName,
+		telemetrytraces.TagAttributesV2TableName,
+		telemetrytraces.SpanAttributesKeysTblName,
+		telemetrytraces.SpanIndexV3TableName,
+		telemetrymetrics.DBName,
+		telemetrymetrics.AttributesMetadataTableName,
+		telemetrymeter.DBName,
+		telemetrymeter.SamplesAgg1dTableName,
+		telemetrylogs.DBName,
+		telemetrylogs.LogsV2TableName,
+		telemetrylogs.TagAttributesV2TableName,
+		telemetrylogs.LogAttributeKeysTblName,
+		telemetrylogs.LogResourceKeysTblName,
+		telemetryaudit.DBName,
+		telemetryaudit.AuditLogsTableName,
+		telemetryaudit.TagAttributesTableName,
+		telemetryaudit.LogAttributeKeysTblName,
+		telemetryaudit.LogResourceKeysTblName,
+		telemetrymetadata.DBName,
+		telemetrymetadata.AttributesMetadataLocalTableName,
+		telemetrymetadata.ColumnEvolutionMetadataTableName,
+		flagger,
+	)
+
 	// Initialize querier from the available querier provider factories
 	querier, err := factory.NewProviderFromNamedMap(
 		ctx,
 		providerSettings,
 		config.Querier,
-		NewQuerierProviderFactories(telemetrystore, prometheus, cache, flagger),
+		NewQuerierProviderFactories(telemetrystore, telemetryMetadataStore, prometheus, cache, flagger),
 		config.Querier.Provider(),
 	)
 	if err != nil {
@@ -422,35 +450,6 @@ func New(
 	if err != nil {
 		return nil, err
 	}
-
-	// Initialize telemetry metadata store
-	// TODO: consolidate other telemetrymetadata.NewTelemetryMetaStore initializations to reuse this instance instead.
-	telemetryMetadataStore := telemetrymetadata.NewTelemetryMetaStore(
-		providerSettings,
-		telemetrystore,
-		telemetrytraces.DBName,
-		telemetrytraces.TagAttributesV2TableName,
-		telemetrytraces.SpanAttributesKeysTblName,
-		telemetrytraces.SpanIndexV3TableName,
-		telemetrymetrics.DBName,
-		telemetrymetrics.AttributesMetadataTableName,
-		telemetrymeter.DBName,
-		telemetrymeter.SamplesAgg1dTableName,
-		telemetrylogs.DBName,
-		telemetrylogs.LogsV2TableName,
-		telemetrylogs.TagAttributesV2TableName,
-		telemetrylogs.LogAttributeKeysTblName,
-		telemetrylogs.LogResourceKeysTblName,
-		telemetryaudit.DBName,
-		telemetryaudit.AuditLogsTableName,
-		telemetryaudit.TagAttributesTableName,
-		telemetryaudit.LogAttributeKeysTblName,
-		telemetryaudit.LogResourceKeysTblName,
-		telemetrymetadata.DBName,
-		telemetrymetadata.AttributesMetadataLocalTableName,
-		telemetrymetadata.ColumnEvolutionMetadataTableName,
-		flagger,
-	)
 
 	global, err := factory.NewProviderFromNamedMap(
 		ctx,


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The querier built a second `telemetryMetadataStore` with the same 23 arguments the rest of the system already used to build the canonical one. The querier held a private copy the rest of the system could not see, and the two caches doubled the metadata footprint and the read load on `signoz_metadata.attributes_metadata_local`. A maintainer-tagged TODO at `pkg/signoz/signoz.go:427` already asked for this consolidation.

The fix moves the canonical construction in `pkg/signoz/signoz.go` to before the querier init, threads the resulting instance through `NewQuerierProviderFactories` and `signozquerier.NewFactory` / `newProvider`, and removes the duplicate call. The querier, modules, handlers, ruler, rule-state-history store, infra monitoring, metrics explorer, promote and the new Fields handler all end up reading from one instance.

Only one `NewTelemetryMetaStore` call site remains in production code (`pkg/signoz/signoz.go:257`).

#### Screenshots / Screen Recordings (if applicable)
N/A

#### Issues closed by this PR

Closes #12266

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

`pkg/querier/signozquerier/provider.go:51` and `pkg/signoz/signoz.go:428` both called `telemetrymetadata.NewTelemetryMetaStore` with the same arguments. The two instances never shared state. The constructor was duplicated and the maintainer-tagged TODO asked for it to be fixed.

#### Fix Strategy
> How does this PR address the root cause?

- Reorder: build the canonical `telemetryMetadataStore` before the querier init in `pkg/signoz/signoz.go` so it can be passed in.
- Plumb the existing instance through `NewQuerierProviderFactories` and `signozquerier.NewFactory` / `newProvider`. The factory signature gains one parameter; the duplicate construction in `newProvider` is removed.
- Remove the TODO at the original site.
- Update `pkg/query-service/rules/managertestfactory.go` to build its own metadata store for the test path, since the old code was relying on the implicit one `newProvider` used to construct.

---

### 🧪 Testing Strategy
> How was this change validated?

- `go build ./...` clean.
- `go vet ./...` clean for the affected packages (`go vet ./...` has two pre-existing warnings on `upstream/main` in `pkg/parser/havingexpression/grammar/...` and `ee/query-service/app/api/...` that are unrelated to this PR; verified by re-running `go vet` against `upstream/main` and observing the same warnings).
- `go test -count=1` green for the directly affected packages and downstream consumers:
  - `pkg/signoz`
  - `pkg/querier`
  - `pkg/query-service/rules`
  - `pkg/telemetrymetadata`
  - `pkg/alertmanager/...`
  - `pkg/ruler/...`
  - `pkg/modules/rulestatehistory/...`
  - `pkg/modules/inframonitoring/...`
  - `pkg/modules/metricsexplorer/...`
  - `pkg/modules/promote/...`
  - `pkg/modules/fields/...`
- Both `cmd/community` and `cmd/enterprise` build cleanly and produce binaries.
- `rg "telemetrymetadata.NewTelemetryMetaStore" pkg/ ee/` returns exactly one production call site, the one in `pkg/signoz/signoz.go:257`. The remaining call is in `pkg/query-service/rules/managertestfactory.go`, which is the test factory.

- Tests added/updated: none. The refactor is covered by the existing test suite for the affected packages; behaviour is unchanged.
- Manual verification: none beyond the tests above.
- Edge cases covered: the rules manager test path (`TestManager_TestNotification_SendUnmatched_ThresholdRule`) was the regression-risk area; it passes with the updated test factory.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: internal wiring. The querier, all modules, handlers, ruler, rule-state-history store, infra monitoring, metrics explorer, promote and the Fields handler all read from the same `MetadataStore` interface; behaviour is unchanged because the only difference is the identity of the instance.
- Potential regressions: a future change that introduces mutable derived state on the metadata store would have been desynchronised before this PR; it is now safe by construction. No other regressions expected.
- Rollback plan: revert the commit. The change is a pure refactor and reverts cleanly.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | OSS / Enterprise (internal) |
| Change Type | Maintenance |
| Description | N/A — internal refactor; no user-facing change. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required (existing tests cover the refactor)
- [x] Manually tested (build + tests for both variants)
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered (no public API change)

---

## 👀 Notes for Reviewers

The most surprising line in the diff is the 24-line metadata store constructor in `pkg/query-service/rules/managertestfactory.go`. The old test factory relied on the implicit construction that used to happen inside `signozquerier.newProvider`. With the consolidation, `newProvider` no longer builds a metadata store, so the test factory has to. The constructor mirrors the one in `pkg/signoz/signoz.go` exactly and uses the canonical table-name constants.

The reorder in `pkg/signoz/signoz.go` is safe: the metadata store depends only on `providerSettings`, `telemetrystore` and `flagger`, all of which exist before the querier init.
