### PR TITLE
Wire the LLM-pricing and span-mapper processors into the traces pipeline

### DIFF
--- a/pkg/types/llmpricingruletypes/processorconfig.go
+++ b/pkg/types/llmpricingruletypes/processorconfig.go
@@ -2,6 +2,7 @@ package llmpricingruletypes
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"gopkg.in/yaml.v3"
@@ -133,9 +134,63 @@ func GenerateCollectorConfigWithLLMPricingProcessor(
 	processors[ProcessorName] = buildProcessorConfig(rules)
 	collectorConf["processors"] = processors
 
+	// Defining the processor under `processors` is not enough: the collector only
+	// runs a processor that also appears in a pipeline's processor list. Wire it
+	// into service.pipelines.traces.processors (ahead of `batch`), mirroring the
+	// logs pipeline builder in logparsingpipeline/collector_config.go:187.
+	insertProcessorIntoTracesPipeline(collectorConf, ProcessorName)
+
 	out, err := yaml.Marshal(collectorConf)
 	if err != nil {
 		return nil, errors.Wrapf(err, errors.TypeInternal, ErrCodeBuildPricingProcessorConf, "failed to marshal llm pricing processor config")
 	}
 	return out, nil
+}
+
+// insertProcessorIntoTracesPipeline adds processorName to
+// service.pipelines.traces.processors so the collector actually executes it.
+// The processor is placed immediately before the first `batch` processor
+// (so it runs before spans are batched and exported), and the call is
+// idempotent: if the processor is already listed the pipeline is unchanged.
+// If there is no traces pipeline, the config is left untouched.
+func insertProcessorIntoTracesPipeline(collectorConf map[string]any, processorName string) {
+	service, ok := collectorConf["service"].(map[string]any)
+	if !ok {
+		return
+	}
+	pipelines, ok := service["pipelines"].(map[string]any)
+	if !ok {
+		return
+	}
+	traces, ok := pipelines["traces"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	existing, ok := traces["processors"].([]any)
+	if !ok && traces["processors"] != nil {
+		// `processors` is present but not a sequence; leave it rather than clobber.
+		return
+	}
+
+	for _, p := range existing {
+		if name, ok := p.(string); ok && name == processorName {
+			return // already wired
+		}
+	}
+
+	updated := make([]any, 0, len(existing)+1)
+	placed := false
+	for _, p := range existing {
+		if name, ok := p.(string); ok && !placed &&
+			(name == "batch" || strings.HasPrefix(name, "batch/")) {
+			updated = append(updated, processorName)
+			placed = true
+		}
+		updated = append(updated, p)
+	}
+	if !placed {
+		updated = append(updated, processorName)
+	}
+	traces["processors"] = updated
 }

--- a/pkg/types/spantypes/spanmapperprocessor.go
+++ b/pkg/types/spantypes/spanmapperprocessor.go
@@ -2,6 +2,7 @@ package spantypes
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/query-service/agentConf"
@@ -75,11 +76,65 @@ func GenerateCollectorConfigWithSpanMapperProcessor(currentConfYaml []byte, grou
 	processors[ProcessorName] = procConfig
 	collectorConf["processors"] = processors
 
+	// Defining the processor under `processors` is not enough: the collector only
+	// runs a processor that also appears in a pipeline's processor list. Wire it
+	// into service.pipelines.traces.processors (ahead of `batch`), mirroring the
+	// logs pipeline builder in logparsingpipeline/collector_config.go:187.
+	insertProcessorIntoTracesPipeline(collectorConf, ProcessorName)
+
 	out, err := yaml.Marshal(collectorConf)
 	if err != nil {
 		return nil, errors.Wrapf(err, errors.TypeInternal, ErrCodeBuildMappingProcessorConfig, "failed to marshal collector config")
 	}
 	return out, nil
+}
+
+// insertProcessorIntoTracesPipeline adds processorName to
+// service.pipelines.traces.processors so the collector actually executes it.
+// The processor is placed immediately before the first `batch` processor
+// (so it runs before spans are batched and exported), and the call is
+// idempotent: if the processor is already listed the pipeline is unchanged.
+// If there is no traces pipeline, the config is left untouched.
+func insertProcessorIntoTracesPipeline(collectorConf map[string]any, processorName string) {
+	service, ok := collectorConf["service"].(map[string]any)
+	if !ok {
+		return
+	}
+	pipelines, ok := service["pipelines"].(map[string]any)
+	if !ok {
+		return
+	}
+	traces, ok := pipelines["traces"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	existing, ok := traces["processors"].([]any)
+	if !ok && traces["processors"] != nil {
+		// `processors` is present but not a sequence; leave it rather than clobber.
+		return
+	}
+
+	for _, p := range existing {
+		if name, ok := p.(string); ok && name == processorName {
+			return // already wired
+		}
+	}
+
+	updated := make([]any, 0, len(existing)+1)
+	placed := false
+	for _, p := range existing {
+		if name, ok := p.(string); ok && !placed &&
+			(name == "batch" || strings.HasPrefix(name, "batch/")) {
+			updated = append(updated, processorName)
+			placed = true
+		}
+		updated = append(updated, p)
+	}
+	if !placed {
+		updated = append(updated, processorName)
+	}
+	traces["processors"] = updated
 }
 
 func buildProcessorConfig(groups []*SpanMapperGroupWithMappers) *spanMapperProcessorConfig {


### PR DESCRIPTION
# Wire the LLM-pricing and span-mapper processors into the traces pipeline

## Summary

`GenerateCollectorConfigWithLLMPricingProcessor` and
`GenerateCollectorConfigWithSpanMapperProcessor` both define their OTel processor
under the collector's top-level `processors:` map, but neither adds the processor
to `service.pipelines.traces.processors`. The OpenTelemetry Collector only runs a
processor that appears in a pipeline's processor list, so today both processors
are deployed as **dead config**: the `signozllmpricing` and `signozspanmapper`
blocks show up in the effective config, but no span ever flows through them.

The net effect for AI observability: with `enable_ai_observability` on and pricing
rules configured, the collector's effective traces pipeline stays
`[signozspanmetrics/delta, batch]`, and the cost attributes the processor is
supposed to emit (`_signoz.gen_ai.total_cost`, `_signoz.gen_ai.cost_input`,
`_signoz.gen_ai.cost_output`, ...) never land on spans. Cost tracking silently
produces nothing.

**Why this reached release:** the existing unit tests pass because their fixtures
already pre-wire the processor into `service.pipelines.traces.processors` — the one
step the production path never does. The tests assert on a config that the code
under test doesn't actually produce. The fix therefore includes a fixture matching
the real baseline so this can't regress (see *Test note*).

## Prior art

The logs feature already solves exactly this problem the right way. In
`pkg/query-service/app/logparsingpipeline/collector_config.go:187`,
`GenerateCollectorConfigWithPipelines` reads the service pipelines, rebuilds the
processor list in the required order (memory_limiter → signoz processors → custom
→ `batch`), and writes it back:

```go
// collector_config.go:187
collectorConf["service"].(map[string]interface{})["pipelines"].(map[string]interface{})["logs"] = p.Pipelines.Logs
```

The two trace generators stop one step short of that — they update
`collectorConf["processors"]` and marshal, never touching `service.pipelines`.

## The fix

Add a small `insertProcessorIntoTracesPipeline` helper to each generator and call
it right after the `processors` map is updated. Mirroring the logs builder, it:

- inserts the processor into `service.pipelines.traces.processors` **immediately
  before the first `batch` processor** (so it runs before spans are batched and
  exported), matching the ordering guarantee the logs path relies on;
- is **idempotent** — if the processor is already in the list, the pipeline is
  left unchanged (important because `RecommendAgentConfig` is re-run on every
  config update via OpAMP);
- is **defensive** — if there is no `service` / `pipelines` / `traces` block, or
  `processors` is present but not a sequence, it leaves the config untouched
  rather than fabricating a pipeline or clobbering existing content.

The helper works directly on the `map[string]any` shape the generators already
unmarshal into (yaml.v3), so no new marshal/unmarshal round trip is introduced.

Given `traces.processors: [signozspanmetrics/delta, batch]`, the result becomes:

- LLM pricing: `[signozspanmetrics/delta, signozllmpricing, batch]`
- Span mapper: `[signozspanmetrics/delta, signozspanmapper, batch]`

## Reproduction (2 minutes)

1. Start SigNoz and set the org feature flag `enable_ai_observability` to on.
2. Add a pricing rule for `gpt-4o` (e.g. pattern `gpt-4o*`, input `5`, output `15`).
   This triggers `RecommendAgentConfig`, which calls
   `GenerateCollectorConfigWithLLMPricingProcessor` and pushes the config to the
   collector via OpAMP.
3. Inspect the collector's **effective** config
   (`service.pipelines.traces.processors`).

   - **Before this change:** the pipeline is still
     `[signozspanmetrics/delta, batch]`. The `signozllmpricing` processor exists
     under `processors:` but is not in the pipeline. Send a gen_ai span with
     token-usage attributes and query the stored spans — `_signoz.gen_ai.total_cost`
     and the other `_signoz.gen_ai.cost_*` attributes never appear.
   - **After this change:** the pipeline is
     `[signozspanmetrics/delta, signozllmpricing, batch]`, and the same span comes
     back with the cost attributes populated.

The `signozspanmapper` path (add a span-attribute mapping group under the same
feature flag) reproduces identically.

## Test note

The existing unit tests in `pkg/types/llmpricingruletypes/processorconfig_test.go`
and `pkg/types/spantypes/spanmapperprocessor_test.go` do **not** catch this bug:
their `testdata/collector_baseline.yaml` fixtures already list the processor in
`service.pipelines.traces.processors`, and the assertions only compare structural
YAML equality of the whole doc, so the pipeline is copied through verbatim and the
missing-wiring case is never exercised. This PR is a good place to add a fixture
whose baseline pipeline is `[signozspanmetrics/delta, batch]` (matching the real
`.devenv/docker/signoz-otel-collector/otel-collector-config.yaml`) and assert the
processor is inserted before `batch`, plus an idempotency case.

## Verification

Built and tested against Go 1.25.7 (the version in `go.mod`):

- `go build ./...` — **passes** (full monorepo compiles clean with the patch).
- `go test ./pkg/types/llmpricingruletypes/... ./pkg/types/spantypes/... ./pkg/query-service/app/logparsingpipeline/...`:

  ```
  ok   github.com/SigNoz/signoz/pkg/types/llmpricingruletypes      0.078s
  ok   github.com/SigNoz/signoz/pkg/types/spantypes                0.053s
  ok   github.com/SigNoz/signoz/pkg/query-service/app/logparsingpipeline  0.313s
  ```

  The existing package tests pass — i.e. the change is non-breaking. Note that,
  as described above, those existing tests do not *exercise* the wiring bug
  (their fixtures pre-wire the processor); the added `[signozspanmetrics/delta,
  batch]` fixture is what actually guards the fix against regression.

## Follow-up worth flagging (out of scope here)

`signozspanmapper` normalizes raw attributes into the canonical `gen_ai.*` names
that `signozllmpricing` reads. These two processors are wired by two independent
modules, each running against the config the other produced, so the relative order
of `signozspanmapper` vs `signozllmpricing` in the final pipeline depends on module
execution order rather than being pinned. This PR guarantees each lands before
`batch` (fixing the dead-config bug); guaranteeing span-mapper runs *before*
llm-pricing is a separate ordering concern that likely belongs in a single
trace-pipeline assembler rather than two independent inserts.
