### PR TITLE
feat(logs): highlight the URL-linked (activeLogId) row in table format

### DIFF
--- a/frontend/src/container/LiveLogs/LiveLogsList/LiveLogsList.styles.scss
+++ b/frontend/src/container/LiveLogs/LiveLogsList/LiveLogsList.styles.scss
@@ -60,3 +60,10 @@
 		}
 	}
 }
+
+// Highlight for a URL-linked (activeLogId) row in table/Column format.
+// See LogsExplorerList.style.scss for rationale; duplicated so the rule is
+// present when the Live Logs page loads independently.
+.logs-linked-row td {
+	background-color: var(--row-active-bg) !important;
+}

--- a/frontend/src/container/LiveLogs/LiveLogsList/index.tsx
+++ b/frontend/src/container/LiveLogs/LiveLogsList/index.tsx
@@ -204,6 +204,9 @@ function LiveLogsList({
 							data={formattedLogs}
 							isLoading={false}
 							isRowActive={(log): boolean => log.id === activeLog?.id}
+							getRowClassName={(log): string =>
+								log.id === activeLogId ? 'logs-linked-row' : ''
+							}
 							getRowStyle={(log): CSSProperties =>
 								({
 									'--row-active-bg': getRowBackgroundColor(

--- a/frontend/src/container/LogsExplorerList/LogsExplorerList.style.scss
+++ b/frontend/src/container/LogsExplorerList/LogsExplorerList.style.scss
@@ -323,3 +323,11 @@
 		}
 	}
 }
+
+// Highlight for a URL-linked (activeLogId) row in table/Column format.
+// Global + lowest specificity so the table's own :hover/.tableRowActive
+// !important cell rules win when a linked row is also hovered or open.
+// --row-active-bg is set per-row on the <tr> via getRowStyle and inherits to cells.
+.logs-linked-row td {
+	background-color: var(--row-active-bg) !important;
+}

--- a/frontend/src/container/LogsExplorerList/index.tsx
+++ b/frontend/src/container/LogsExplorerList/index.tsx
@@ -212,6 +212,9 @@ function LogsExplorerList({
 					isLoading={isLoading || isFetching}
 					onEndReached={onEndReached}
 					isRowActive={(log): boolean => log.id === activeLog?.id}
+					getRowClassName={(log): string =>
+						log.id === activeLogId ? 'logs-linked-row' : ''
+					}
 					getRowStyle={(log): CSSProperties =>
 						({
 							'--row-active-bg': getRowBackgroundColor(
@@ -283,6 +286,7 @@ function LogsExplorerList({
 		options.maxLines,
 		options.fontSize,
 		activeLogIndex,
+		activeLogId,
 		logs,
 		onEndReached,
 		getItemContent,


### PR DESCRIPTION
## Pull Request

> **Stacked on #12269** (base = that branch). Review/merge PR-1 first.

---

### 📄 Summary
Restores the linked-row highlight for **Column (table)** format that the TanStack migration (#10946) dropped: the row referenced by `?activeLogId=...` is visually highlighted (and, thanks to #12269, still opens on first click). Applied to **Logs Explorer** and **Live Logs**. Done via the table's existing styling-only `getRowClassName` hook — no new shared-table prop, and nothing that can affect click routing.

#### Screenshots / Screen Recordings (if applicable)
_N/A — visual highlight; open a log link in Column format and the referenced row is highlighted._

#### Issues closed by this PR
Follow-up to SigNoz/engineering-pod#5768 (highlight portion). _Does not close it — #12269 does._

---

### ✅ Change Type
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
_N/A — not a bug fix._

---

### 🧪 Testing Strategy
- **Tests added/updated:** none required — reuses the existing, already-tested `getRowClassName` hook; no logic change.
- **Manual verification:** open a log link in Column format (Logs Explorer + Live Logs) → referenced row is highlighted and opens on click; highlight persists; hover/active override it correctly.
- **Edge cases covered:** linked row that is also active/hovered (active/hover win by specificity); non-linked rows unaffected.

---

### ⚠️ Risk & Impact Assessment
- **Blast radius:** two Logs consumers + their SCSS only. No shared-component change.
- **Potential regressions:** none — `getRowClassName` is styling-only; the rule is global + lowest-specificity so the table's own `:hover`/`.tableRowActive` `!important` cell rules win on overlap. `tsgo` clean, 475 tests pass, build ok.
- **Rollback plan:** revert this PR; PR-1 (the actual fix) is unaffected.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | The log row referenced by a shared link is now highlighted in Column (table) format. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers
Implementation:
```tsx
isRowActive={(log) => log.id === activeLog?.id}                               // open state (PR-1)
getRowClassName={(log) => (log.id === activeLogId ? 'logs-linked-row' : '')}  // highlight only
```
```scss
.logs-linked-row td { background-color: var(--row-active-bg) !important; }
```
Open follow-ups (non-blocking): color reuses `--row-active-bg` (a distinct "linked" token is a design call); highlight is persistent (old behavior faded via `useCopyLogLink` if a fade is preferred).