### PR TITLE
chore: deprecate v1 dashboard APIs with proper reference to v2 APIs

### DIFF
--- a/pkg/modules/dashboard/impldashboard/handler.go
+++ b/pkg/modules/dashboard/impldashboard/handler.go
@@ -30,13 +30,11 @@ func NewHandler(module dashboard.Module, providerSettings factory.ProviderSettin
 }
 
 func (handler *handler) Create(rw http.ResponseWriter, r *http.Request) {
-	render.Error(rw, dashboardtypes.NewV1DeprecatedError(
-		"create a dashboard with POST /api/v2/dashboards (schema: "+dashboardtypes.V2CreateDashboardSchemaLink+")"))
+	render.Error(rw, dashboardtypes.NewV1DeprecatedError("create a dashboard with POST /api/v2/dashboards"))
 }
 
 func (handler *handler) Update(rw http.ResponseWriter, r *http.Request) {
-	render.Error(rw, dashboardtypes.NewV1DeprecatedError(
-		"update a dashboard with PUT /api/v2/dashboards/{id} (schema: "+dashboardtypes.V2UpdateDashboardSchemaLink+"), or patch it with PATCH /api/v2/dashboards/{id} (schema: "+dashboardtypes.V2PatchDashboardSchemaLink+")"))
+	render.Error(rw, dashboardtypes.NewV1DeprecatedError("update a dashboard with PUT /api/v2/dashboards/{id}, or patch it with PATCH /api/v2/dashboards/{id}"))
 }
 
 func (handler *handler) LockUnlock(rw http.ResponseWriter, r *http.Request) {

--- a/pkg/modules/dashboard/impldashboard/handler.go
+++ b/pkg/modules/dashboard/impldashboard/handler.go
@@ -2,7 +2,6 @@ package impldashboard
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"strconv"
 	"time"
@@ -13,10 +12,8 @@ import (
 	"github.com/SigNoz/signoz/pkg/http/binding"
 	"github.com/SigNoz/signoz/pkg/http/render"
 	"github.com/SigNoz/signoz/pkg/modules/dashboard"
-	"github.com/SigNoz/signoz/pkg/transition"
 	"github.com/SigNoz/signoz/pkg/types"
 	"github.com/SigNoz/signoz/pkg/types/authtypes"
-	"github.com/SigNoz/signoz/pkg/types/coretypes"
 	"github.com/SigNoz/signoz/pkg/types/dashboardtypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/gorilla/mux"
@@ -33,190 +30,21 @@ func NewHandler(module dashboard.Module, providerSettings factory.ProviderSettin
 }
 
 func (handler *handler) Create(rw http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	claims, err := authtypes.ClaimsFromContext(ctx)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	req := dashboardtypes.PostableDashboard{}
-	err = json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	dashboardMigrator := transition.NewDashboardMigrateV5(handler.providerSettings.Logger, nil, nil)
-	if req["version"] != "v5" {
-		dashboardMigrator.Migrate(ctx, req)
-	}
-
-	dashboard, err := handler.module.Create(ctx, orgID, claims.Email, valuer.MustNewUUID(claims.IdentityID()), dashboardtypes.SourceUser, req)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	gettableDashboard, err := dashboardtypes.NewGettableDashboardFromDashboard(dashboard)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	render.Success(rw, http.StatusCreated, gettableDashboard)
+	render.Error(rw, dashboardtypes.NewV1DeprecatedError(
+		"create a dashboard with POST /api/v2/dashboards (schema: "+dashboardtypes.V2CreateDashboardSchemaLink+")"))
 }
 
 func (handler *handler) Update(rw http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	claims, err := authtypes.ClaimsFromContext(ctx)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	id := mux.Vars(r)["id"]
-	if id == "" {
-		render.Error(rw, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "id is missing in the path"))
-		return
-	}
-	dashboardID, err := valuer.NewUUID(id)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	req := dashboardtypes.UpdatableDashboard{}
-	err = json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	diff := 0
-	// Allow multiple deletions for API key requests; enforce for others
-	if claims.IdentNProvider == authtypes.IdentNProviderTokenizer {
-		diff = 1
-	}
-
-	dashboard, err := handler.module.Update(ctx, orgID, dashboardID, claims.Email, req, diff)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	render.Success(rw, http.StatusOK, dashboard)
+	render.Error(rw, dashboardtypes.NewV1DeprecatedError(
+		"update a dashboard with PUT /api/v2/dashboards/{id} (schema: "+dashboardtypes.V2UpdateDashboardSchemaLink+"), or patch it with PATCH /api/v2/dashboards/{id} (schema: "+dashboardtypes.V2PatchDashboardSchemaLink+")"))
 }
 
 func (handler *handler) LockUnlock(rw http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	claims, err := authtypes.ClaimsFromContext(ctx)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	id := mux.Vars(r)["id"]
-	if id == "" {
-		render.Error(rw, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "id is missing in the path"))
-		return
-	}
-	dashboardID, err := valuer.NewUUID(id)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	req := new(dashboardtypes.LockUnlockDashboard)
-	err = json.NewDecoder(r.Body).Decode(req)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	isAdmin := false
-	selectors := []coretypes.Selector{
-		coretypes.TypeRole.MustSelector(authtypes.SigNozAdminRoleName),
-	}
-	err = handler.authz.CheckWithTupleCreation(
-		ctx,
-		claims,
-		valuer.MustNewUUID(claims.OrgID),
-		authtypes.Relation{Verb: coretypes.VerbAssignee},
-		coretypes.NewResourceRole(),
-		selectors,
-		selectors,
-	)
-	if err == nil {
-		isAdmin = true
-	}
-
-	err = handler.module.LockUnlock(ctx, orgID, dashboardID, claims.Email, isAdmin, *req.Locked)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	render.Success(rw, http.StatusOK, nil)
-
+	render.Error(rw, dashboardtypes.NewV1DeprecatedError("lock a dashboard with PUT /api/v2/dashboards/{id}/lock, or unlock it with DELETE /api/v2/dashboards/{id}/lock"))
 }
 
 func (handler *handler) Delete(rw http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	claims, err := authtypes.ClaimsFromContext(ctx)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	id := mux.Vars(r)["id"]
-	if id == "" {
-		render.Error(rw, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "id is missing in the path"))
-		return
-	}
-	dashboardID, err := valuer.NewUUID(id)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-	err = handler.module.Delete(ctx, orgID, dashboardID)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	render.Success(rw, http.StatusNoContent, nil)
+	render.Error(rw, dashboardtypes.NewV1DeprecatedError("delete a dashboard with DELETE /api/v2/dashboards/{id}"))
 }
 
 func (handler *handler) CreatePublic(rw http.ResponseWriter, r *http.Request) {

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1078,75 +1078,11 @@ func prepareQuery(r *http.Request) (string, error) {
 }
 
 func (aH *APIHandler) Get(rw http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	claims, err := authtypes.ClaimsFromContext(ctx)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	id := mux.Vars(r)["id"]
-	if id == "" {
-		render.Error(rw, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "id is missing in the path"))
-		return
-	}
-
-	dashboardID, err := valuer.NewUUID(id)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-	dashboard, err := aH.Signoz.Modules.Dashboard.Get(ctx, orgID, dashboardID)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	gettableDashboard, err := dashboardtypes.NewGettableDashboardFromDashboard(dashboard)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	render.Success(rw, http.StatusOK, gettableDashboard)
+	render.Error(rw, dashboardtypes.NewV1DeprecatedError("get a dashboard with GET /api/v2/dashboards/{id}"))
 }
 
 func (aH *APIHandler) List(rw http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	claims, err := authtypes.ClaimsFromContext(ctx)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	orgID, err := valuer.NewUUID(claims.OrgID)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-
-	dashboards, err := aH.Signoz.Modules.Dashboard.List(ctx, orgID)
-	if err != nil && !errors.Ast(err, errors.TypeNotFound) {
-		render.Error(rw, err)
-		return
-	}
-
-	gettableDashboards, err := dashboardtypes.NewGettableDashboardsFromDashboards(dashboards)
-	if err != nil {
-		render.Error(rw, err)
-		return
-	}
-	render.Success(rw, http.StatusOK, gettableDashboards)
+	render.Error(rw, dashboardtypes.NewV1DeprecatedError("list dashboards with GET /api/v2/dashboards"))
 }
 
 func (aH *APIHandler) queryDashboardVarsV2(w http.ResponseWriter, r *http.Request) {

--- a/pkg/types/dashboardtypes/dashboard.go
+++ b/pkg/types/dashboardtypes/dashboard.go
@@ -22,6 +22,7 @@ var (
 	ErrCodeDashboardImmutable          = errors.MustNewCode("dashboard_immutable")
 	ErrCodeDashboardInvalidPatch       = errors.MustNewCode("dashboard_invalid_patch")
 	ErrCodeDashboardMigrationFailed    = errors.MustNewCode("dashboard_migration_failed")
+	ErrCodeDashboardV1Deprecated       = errors.MustNewCode("dashboard_deprecated")
 )
 
 type StorableDashboard struct {

--- a/pkg/types/dashboardtypes/v1_deprecation.go
+++ b/pkg/types/dashboardtypes/v1_deprecation.go
@@ -1,0 +1,21 @@
+package dashboardtypes
+
+import "github.com/SigNoz/signoz/pkg/errors"
+
+// The v1 dashboard API is superseded by the v2 dashboard API; every v1 endpoint
+// now returns a deprecation error pointing at its v2 replacement. The body-carrying
+// endpoints (create, update) point to the v2 request-schema docs below; the
+// body-less endpoints just name the v2 endpoint to call.
+const (
+	V2CreateDashboardSchemaLink = "https://signoz.io/dashboards/schema/dashboard_create.json"
+	V2UpdateDashboardSchemaLink = "https://signoz.io/dashboards/schema/dashboard_update.json"
+	V2PatchDashboardSchemaLink  = "https://signoz.io/dashboards/schema/dashboard_patch.json"
+)
+
+// NewV1DeprecatedError builds the error a deprecated v1 dashboard endpoint returns.
+// useInstead names the v2 replacement — a schema link for the create/update
+// endpoints, or the v2 endpoint to call for the body-less ones.
+func NewV1DeprecatedError(useInstead string) error {
+	return errors.Newf(errors.TypeUnsupported, ErrCodeDashboardV1Deprecated,
+		"the v1 dashboard API is deprecated; instead, %s", useInstead)
+}

--- a/pkg/types/dashboardtypes/v1_deprecation.go
+++ b/pkg/types/dashboardtypes/v1_deprecation.go
@@ -2,20 +2,12 @@ package dashboardtypes
 
 import "github.com/SigNoz/signoz/pkg/errors"
 
-// The v1 dashboard API is superseded by the v2 dashboard API; every v1 endpoint
-// now returns a deprecation error pointing at its v2 replacement. The body-carrying
-// endpoints (create, update) point to the v2 request-schema docs below; the
-// body-less endpoints just name the v2 endpoint to call.
-const (
-	V2CreateDashboardSchemaLink = "https://signoz.io/dashboards/schema/dashboard_create.json"
-	V2UpdateDashboardSchemaLink = "https://signoz.io/dashboards/schema/dashboard_update.json"
-	V2PatchDashboardSchemaLink  = "https://signoz.io/dashboards/schema/dashboard_patch.json"
-)
+// V2DashboardAPIDocsLink documents the v2 dashboard API — its endpoints and request bodies.
+const V2DashboardAPIDocsLink = "https://signoz.io/docs/dashboards/dashboards-v2-api/"
 
 // NewV1DeprecatedError builds the error a deprecated v1 dashboard endpoint returns.
-// useInstead names the v2 replacement — a schema link for the create/update
-// endpoints, or the v2 endpoint to call for the body-less ones.
+// useInstead names the v2 endpoint to call; the docs link is appended for the details.
 func NewV1DeprecatedError(useInstead string) error {
 	return errors.Newf(errors.TypeUnsupported, ErrCodeDashboardV1Deprecated,
-		"the v1 dashboard API is deprecated; instead, %s", useInstead)
+		"the v1 dashboard API is deprecated; instead, %s. See %s", useInstead, V2DashboardAPIDocsLink)
 }

--- a/tests/integration/tests/cloudintegrations/05_services.py
+++ b/tests/integration/tests/cloudintegrations/05_services.py
@@ -567,11 +567,11 @@ def test_disable_metrics_deprovisions_dashboards(
 
     # Assertion 2: Dashboards listing API no longer contains the provisioned dashboard IDs
     list_response = requests.get(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards?limit=200"),
         headers={"Authorization": f"Bearer {admin_token}"},
         timeout=10,
     )
     assert list_response.status_code == HTTPStatus.OK, f"Expected 200 from dashboards list, got {list_response.status_code}: {list_response.text}"
 
-    listed_ids = {d["id"] for d in list_response.json()["data"]}
+    listed_ids = {d["id"] for d in list_response.json()["data"]["dashboards"]}
     assert not provisioned_ids & listed_ids, f"Provisioned dashboard IDs {provisioned_ids & listed_ids} still appear in dashboards list after disabling metrics"

--- a/tests/integration/tests/dashboard/01_dashboard.py
+++ b/tests/integration/tests/dashboard/01_dashboard.py
@@ -1,39 +1,15 @@
+import uuid
 from collections.abc import Callable
 from http import HTTPStatus
 
+import pytest
 import requests
 from wiremock.resources.mappings import Mapping
 
 from fixtures.auth import USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD, add_license
 from fixtures.types import Operation, SigNoz, TestContainerDocker
 
-
-def test_create_and_delete_dashboard_without_license(
-    signoz: SigNoz,
-    create_user_admin: Operation,  # pylint: disable=unused-argument
-    get_token: Callable[[str, str], str],
-):
-    admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
-
-    response = requests.post(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
-        json={"title": "Sample Title", "uploadedGrafana": False, "version": "v5"},
-        headers={"Authorization": f"Bearer {admin_token}"},
-        timeout=2,
-    )
-
-    assert response.status_code == HTTPStatus.CREATED
-    assert response.json()["status"] == "success"
-    data = response.json()["data"]
-    dashboard_id = data["id"]
-
-    response = requests.delete(
-        signoz.self.host_configs["8080"].get(f"/api/v1/dashboards/{dashboard_id}"),
-        headers={"Authorization": f"Bearer {admin_token}"},
-        timeout=2,
-    )
-
-    assert response.status_code == HTTPStatus.NO_CONTENT
+DOCS_LINK = "https://signoz.io/docs/dashboards/dashboards-v2-api/"
 
 
 def test_apply_license(
@@ -48,29 +24,40 @@ def test_apply_license(
     add_license(signoz, make_http_mocks, get_token)
 
 
-def test_create_and_delete_dashboard_with_license(
+@pytest.mark.parametrize(
+    "deprecated_request",
+    [
+        ("POST", "/api/v1/dashboards", {"title": "Sample Title", "uploadedGrafana": False, "version": "v5"}),
+        ("GET", "/api/v1/dashboards", None),
+        ("GET", f"/api/v1/dashboards/{uuid.uuid4()}", None),
+        ("PUT", f"/api/v1/dashboards/{uuid.uuid4()}", {"title": "Sample Title"}),
+        ("DELETE", f"/api/v1/dashboards/{uuid.uuid4()}", None),
+        ("PUT", f"/api/v1/dashboards/{uuid.uuid4()}/lock", {"lock": True}),
+    ],
+)
+def test_v1_dashboard_endpoints_are_deprecated(
     signoz: SigNoz,
     create_user_admin: Operation,  # pylint: disable=unused-argument
     get_token: Callable[[str, str], str],
+    deprecated_request: tuple[str, str, dict | None],
 ):
+    """Every v1 dashboard endpoint is superseded by v2 and answers with a
+    deprecation error naming its replacement — the id in the path is never
+    resolved, so a random one still gets the deprecation error rather than a 404."""
+    method, path, body = deprecated_request
     admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
 
-    response = requests.post(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
-        json={"title": "Sample Title", "uploadedGrafana": False, "version": "v5"},
+    response = requests.request(
+        method,
+        signoz.self.host_configs["8080"].get(path),
+        json=body,
         headers={"Authorization": f"Bearer {admin_token}"},
         timeout=2,
     )
 
-    assert response.status_code == HTTPStatus.CREATED
-    assert response.json()["status"] == "success"
-    data = response.json()["data"]
-    dashboard_id = data["id"]
-
-    response = requests.delete(
-        signoz.self.host_configs["8080"].get(f"/api/v1/dashboards/{dashboard_id}"),
-        headers={"Authorization": f"Bearer {admin_token}"},
-        timeout=2,
-    )
-
-    assert response.status_code == HTTPStatus.NO_CONTENT
+    assert response.status_code == HTTPStatus.NOT_IMPLEMENTED, response.text
+    error = response.json()["error"]
+    assert error["code"] == "dashboard_deprecated"
+    assert "the v1 dashboard API is deprecated" in error["message"]
+    assert "/api/v2/dashboards" in error["message"]
+    assert DOCS_LINK in error["message"]

--- a/tests/integration/tests/dashboard/02_public_dashboard.py
+++ b/tests/integration/tests/dashboard/02_public_dashboard.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 
 import pytest
@@ -8,7 +7,6 @@ from sqlalchemy import sql
 from wiremock.resources.mappings import Mapping
 
 from fixtures.auth import USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD, add_license
-from fixtures.metrics import Metrics
 from fixtures.types import Operation, SigNoz, TestContainerDocker
 
 
@@ -32,8 +30,13 @@ def test_create_and_get_public_dashboard(
     admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
 
     response = requests.post(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
-        json={"title": "Sample Title", "uploadedGrafana": False, "version": "v5"},
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
+        json={
+            "schemaVersion": "v6",
+            "name": "sample-title",
+            "spec": {"display": {"name": "Sample Title"}, "links": []},
+            "tags": [],
+        },
         headers={"Authorization": f"Bearer {admin_token}"},
         timeout=2,
     )
@@ -66,143 +69,6 @@ def test_create_and_get_public_dashboard(
     assert response.json()["status"] == "success"
     assert response.json()["data"]["timeRangeEnabled"] is True
     assert response.json()["data"]["defaultTimeRange"] == "10s"
-
-
-def test_public_dashboard_widget_query_range(
-    signoz: SigNoz,
-    create_user_admin: Operation,  # pylint: disable=unused-argument
-    get_token: Callable[[str, str], str],
-    insert_metrics: Callable[[list[Metrics]], None],
-):
-    admin_token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
-
-    # Insert metric data so the widget query returns results instead of 404
-    now = datetime.now(tz=UTC).replace(second=0, microsecond=0)
-    metrics: list[Metrics] = [
-        Metrics(
-            metric_name="container.cpu.time",
-            labels={"service": "test-service"},
-            timestamp=now - timedelta(minutes=5),
-            value=100.0,
-            temporality="Cumulative",
-        ),
-        Metrics(
-            metric_name="container.cpu.time",
-            labels={"service": "test-service"},
-            timestamp=now - timedelta(minutes=3),
-            value=200.0,
-            temporality="Cumulative",
-        ),
-        Metrics(
-            metric_name="container.cpu.time",
-            labels={"service": "test-service"},
-            timestamp=now - timedelta(minutes=1),
-            value=300.0,
-            temporality="Cumulative",
-        ),
-    ]
-    insert_metrics(metrics)
-
-    dashboard_req = {
-        "title": "Test Widget Query Range Dashboard",
-        "description": "For testing widget query range",
-        "version": "v5",
-        "widgets": [
-            {
-                "id": "6990c9d8-57ad-492f-8c63-039081e30d02",
-                "panelTypes": "graph",
-                "query": {
-                    "builder": {
-                        "queryData": [
-                            {
-                                "aggregations": [
-                                    {
-                                        "metricName": "container.cpu.time",
-                                        "reduceTo": "avg",
-                                        "spaceAggregation": "sum",
-                                        "temporality": "",
-                                        "timeAggregation": "rate",
-                                    }
-                                ],
-                                "dataSource": "metrics",
-                                "disabled": False,
-                                "expression": "A",
-                                "filter": {"expression": ""},
-                                "functions": [],
-                                "groupBy": [],
-                                "having": {"expression": ""},
-                                "legend": "",
-                                "limit": 10,
-                                "orderBy": [],
-                                "queryName": "A",
-                                "source": "",
-                                "stepInterval": 10,
-                            }
-                        ],
-                        "queryFormulas": [],
-                        "queryTraceOperator": [],
-                    },
-                    "clickhouse_sql": [{"disabled": False, "legend": "", "name": "A", "query": ""}],
-                    "id": "80f12506-ef72-4013-8282-2713c8114c9e",
-                    "promql": [{"disabled": False, "legend": "", "name": "A", "query": ""}],
-                    "queryType": "builder",
-                },
-            }
-        ],
-    }
-    create_response = requests.post(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
-        json=dashboard_req,
-        headers={"Authorization": f"Bearer {admin_token}"},
-        timeout=2,
-    )
-    assert create_response.status_code == HTTPStatus.CREATED
-    data = create_response.json()["data"]
-    dashboard_id = data["id"]
-
-    # create public dashboard
-    response = requests.post(
-        signoz.self.host_configs["8080"].get(f"/api/v1/dashboards/{dashboard_id}/public"),
-        json={
-            "timeRangeEnabled": False,
-            "defaultTimeRange": "10m",
-        },
-        headers={"Authorization": f"Bearer {admin_token}"},
-        timeout=2,
-    )
-
-    assert response.status_code == HTTPStatus.CREATED
-    assert "id" in response.json()["data"]
-
-    response = requests.get(
-        signoz.self.host_configs["8080"].get(f"/api/v1/dashboards/{dashboard_id}/public"),
-        headers={"Authorization": f"Bearer {admin_token}"},
-        timeout=2,
-    )
-
-    assert response.status_code == HTTPStatus.OK
-    assert response.json()["status"] == "success"
-    public_path = response.json()["data"]["publicPath"]
-    public_dashboard_id = public_path.split("/public/dashboard/")[-1]
-
-    resp = requests.get(
-        signoz.self.host_configs["8080"].get(f"/api/v1/public/dashboards/{public_dashboard_id}/widgets/0/query_range"),
-        timeout=2,
-    )
-    assert resp.status_code == HTTPStatus.OK
-    assert resp.json().get("status") == "success"
-
-    resp = requests.get(
-        signoz.self.host_configs["8080"].get(f"/api/v1/public/dashboards/{public_dashboard_id}/widgets/-1/query_range"),
-        timeout=2,
-    )
-    assert resp.status_code == HTTPStatus.BAD_REQUEST
-
-    resp = requests.get(
-        signoz.self.host_configs["8080"].get(f"/api/v1/public/dashboards/{public_dashboard_id}/widgets/1/query_range"),
-        timeout=2,
-    )
-    assert resp.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_anonymous_role_has_public_dashboard_permission(

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -10,28 +10,29 @@ from fixtures.metrics import Metrics
 from fixtures.types import Operation, SigNoz
 
 BASE_URL = "/api/v2/dashboards"
-# v1 list returns every dashboard regardless of schema. v2 list converts each row
-# to the perses schema and 501s if any stored dashboard isn't perses-schema, so
-# listing for cleanup against a shared DB must go through v1.
-V1_BASE_URL = "/api/v1/dashboards"
+# MaxListLimit caps a single list page, so wiping a shared DB has to drain pages
+# until the list comes back empty.
+MAX_LIST_LIMIT = 200
 
 
 def _wipe_all_dashboards(signoz: SigNoz, token: str) -> None:
-    response = requests.get(
-        signoz.self.host_configs["8080"].get(V1_BASE_URL),
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=5,
-    )
-    assert response.status_code == HTTPStatus.OK, response.text
-    for dashboard in response.json()["data"]:
-        metadata = (dashboard.get("data") or {}).get("metadata") or {}
-        base = BASE_URL if metadata.get("schemaVersion") == "v6" else V1_BASE_URL
-        del_res = requests.delete(
-            signoz.self.host_configs["8080"].get(f"{base}/{dashboard['id']}"),
+    while True:
+        response = requests.get(
+            signoz.self.host_configs["8080"].get(f"{BASE_URL}?limit={MAX_LIST_LIMIT}"),
             headers={"Authorization": f"Bearer {token}"},
             timeout=5,
         )
-        assert del_res.status_code == HTTPStatus.NO_CONTENT, del_res.text
+        assert response.status_code == HTTPStatus.OK, response.text
+        dashboards = response.json()["data"]["dashboards"]
+        if not dashboards:
+            return
+        for dashboard in dashboards:
+            del_res = requests.delete(
+                signoz.self.host_configs["8080"].get(f"{BASE_URL}/{dashboard['id']}"),
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=5,
+            )
+            assert del_res.status_code == HTTPStatus.NO_CONTENT, del_res.text
 
 
 # ─── failure cases (create no dashboards) ────────────────────────────────────

--- a/tests/integration/tests/serviceaccount/02_keys.py
+++ b/tests/integration/tests/serviceaccount/02_keys.py
@@ -155,7 +155,7 @@ def test_create_api_key_with_expiry(
 
     # key should work since it hasn't expired
     dash_resp = requests.get(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
     )
@@ -211,7 +211,7 @@ def test_create_api_key_no_expiry(
     api_key = response.json()["data"]["key"]
 
     dash_resp = requests.get(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
     )
@@ -259,7 +259,7 @@ def test_update_api_key_expiry(
 
     # key should still work since the update was rejected
     dash_resp = requests.get(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
     )

--- a/tests/integration/tests/serviceaccount/03_auth.py
+++ b/tests/integration/tests/serviceaccount/03_auth.py
@@ -25,7 +25,7 @@ def test_service_account_key_auth_on_dashboards(
     _, api_key = create_service_account_with_key(signoz, token, "sa-dashboard-test")
 
     response = requests.get(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
     )
@@ -90,11 +90,12 @@ def test_service_account_role_access_admin(
 
     # EditAccess: create a dashboard
     resp = requests.post(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         json={
-            "title": "admin-sa-dash",
-            "uploadedGrafana": False,
-            "version": "v4",
+            "schemaVersion": "v6",
+            "name": "admin-sa-dash",
+            "spec": {"display": {"name": "admin-sa-dash"}, "links": []},
+            "tags": [],
         },
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
@@ -103,7 +104,7 @@ def test_service_account_role_access_admin(
 
     # ViewAccess: list dashboards
     resp = requests.get(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
     )
@@ -129,11 +130,12 @@ def test_service_account_role_access_editor(
 
     # EditAccess: create a dashboard
     resp = requests.post(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         json={
-            "title": "editor-sa-dash",
-            "uploadedGrafana": False,
-            "version": "v4",
+            "schemaVersion": "v6",
+            "name": "editor-sa-dash",
+            "spec": {"display": {"name": "editor-sa-dash"}, "links": []},
+            "tags": [],
         },
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
@@ -142,7 +144,7 @@ def test_service_account_role_access_editor(
 
     # ViewAccess: list dashboards
     resp = requests.get(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
     )
@@ -168,11 +170,12 @@ def test_service_account_role_access_viewer(
 
     # EditAccess: should be forbidden
     resp = requests.post(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         json={
-            "title": "viewer-sa-dash",
-            "uploadedGrafana": False,
-            "version": "v4",
+            "schemaVersion": "v6",
+            "name": "viewer-sa-dash",
+            "spec": {"display": {"name": "viewer-sa-dash"}, "links": []},
+            "tags": [],
         },
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
@@ -181,7 +184,7 @@ def test_service_account_role_access_viewer(
 
     # ViewAccess: list dashboards
     resp = requests.get(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
     )
@@ -199,7 +202,7 @@ def test_service_account_key_deleted_account_rejected(
 
     # verify the key works before deleting
     response = requests.get(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
     )
@@ -210,7 +213,7 @@ def test_service_account_key_deleted_account_rejected(
 
     # now the key should be rejected
     response = requests.get(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
     )
@@ -229,7 +232,7 @@ def test_service_account_key_revoked_key_rejected(
 
     # verify the key works first
     response = requests.get(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
     )
@@ -253,7 +256,7 @@ def test_service_account_key_revoked_key_rejected(
 
     # now the key should be rejected
     response = requests.get(
-        signoz.self.host_configs["8080"].get("/api/v1/dashboards"),
+        signoz.self.host_configs["8080"].get("/api/v2/dashboards"),
         headers={"SIGNOZ-API-KEY": api_key},
         timeout=5,
     )


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

For a while, MCP servers may be on an older version that still expects v1 APIs to work. When they call those APIs they should be given a proper error message to move to V2 APIs, and adding a link for the schema of V2 can even help any agents to build the dashboards on the fly.

Closes https://github.com/SigNoz/engineering-pod/issues/5683