### PR TITLE
fix: reencode svg images to base64 when migrating dashboards

### DIFF
--- a/pkg/types/dashboardtypes/perses_v1_to_v2_icons.go
+++ b/pkg/types/dashboardtypes/perses_v1_to_v2_icons.go
@@ -1,5 +1,11 @@
 package dashboardtypes
 
+import (
+	"encoding/base64"
+	"net/url"
+	"strings"
+)
+
 // v1 dashboards stored their `image` as one of a fixed set of base64 icon data
 // URIs. v2 references the same icons by a stable asset path (dashboardIconPathPrefix
 // + name). This maps each preset v1 base64 blob to its v2 icon path so a migrated
@@ -45,8 +51,37 @@ func resolveV1Image(image string) string {
 	if path, ok := v1Base64IconToAssetPath[image]; ok {
 		return path
 	}
+	if reencoded, ok := reencodeInlineSVGImage(image); ok {
+		image = reencoded
+	}
 	if (DashboardV2MetadataBase{Image: image}).validateImage() == nil {
 		return image
 	}
 	return defaultDashboardIconPath
+}
+
+// reencodeInlineSVGImage rewrites a percent-encoded inline SVG data URI into the
+// base64 form the v2 schema accepts, preserving an icon that would otherwise fail
+// validation. Returns (image, false) unchanged for anything else.
+func reencodeInlineSVGImage(image string) (string, bool) {
+	const mediaType = "data:image/svg+xml"
+	if !strings.HasPrefix(image, mediaType) {
+		return image, false
+	}
+	rest := image[len(mediaType):]
+	// The media type must be followed by its params/data separator, not more type
+	// text (guards against a longer type that merely shares this prefix).
+	if len(rest) == 0 || (rest[0] != ',' && rest[0] != ';') {
+		return image, false
+	}
+	params, encoded, found := strings.Cut(rest, ",")
+	// A base64 URI carries ";base64" before the comma and is already valid — leave it.
+	if !found || strings.Contains(params, "base64") {
+		return image, false
+	}
+	svg, err := url.PathUnescape(encoded)
+	if err != nil {
+		return image, false // malformed escaping — leave it; conversion falls back to the default icon
+	}
+	return "data:image/svg+xml;base64," + base64.StdEncoding.EncodeToString([]byte(svg)), true
 }

--- a/pkg/types/dashboardtypes/perses_v1_to_v2_test.go
+++ b/pkg/types/dashboardtypes/perses_v1_to_v2_test.go
@@ -429,6 +429,11 @@ func TestResolveV1Image(t *testing.T) {
 		assert.Equal(t, passthrough, resolveV1Image(passthrough))
 	}
 
+	// A percent-encoded inline SVG icon is preserved by re-encoding it to base64
+	// (the form v2 accepts) rather than being dropped to the default.
+	svgResolved := resolveV1Image("data:image/svg+xml,%3Csvg%2F%3E")
+	assert.Equal(t, "data:image/svg+xml;base64,PHN2Zy8+", svgResolved)
+
 	// A value that v2 would reject (a URL, a corrupt data URI) falls back to the
 	// default eight-ball icon rather than failing the dashboard migration.
 	for _, invalid := range []string{
@@ -437,6 +442,66 @@ func TestResolveV1Image(t *testing.T) {
 		"just-some-string",
 	} {
 		assert.Equal(t, "/assets/Icons/eight-ball", resolveV1Image(invalid))
+	}
+}
+
+func TestReencodeInlineSVGImage(t *testing.T) {
+	testCases := []struct {
+		scenario      string
+		image         string
+		wantRewritten bool
+		want          string
+	}{
+		{
+			scenario:      "percent-encoded inline svg",
+			image:         "data:image/svg+xml,%3Csvg%2F%3E",
+			wantRewritten: true,
+			want:          "data:image/svg+xml;base64,PHN2Zy8+",
+		},
+		{
+			scenario:      "percent-encoded inline svg with charset param",
+			image:         "data:image/svg+xml;charset=utf-8,%3Csvg%2F%3E",
+			wantRewritten: true,
+			want:          "data:image/svg+xml;base64,PHN2Zy8+",
+		},
+		{
+			scenario:      "already base64 svg is left unchanged",
+			image:         "data:image/svg+xml;base64,PHN2Zy8+",
+			wantRewritten: false,
+			want:          "data:image/svg+xml;base64,PHN2Zy8+",
+		},
+		{
+			scenario:      "non-svg data uri is left unchanged",
+			image:         "data:image/png,%89PNG",
+			wantRewritten: false,
+			want:          "data:image/png,%89PNG",
+		},
+		{
+			scenario:      "an icon path is left unchanged",
+			image:         "/assets/Icons/eight-ball",
+			wantRewritten: false,
+			want:          "/assets/Icons/eight-ball",
+		},
+		{
+			scenario:      "a longer media type merely sharing the svg prefix is left unchanged",
+			image:         "data:image/svg+xmlish,%3Csvg%2F%3E",
+			wantRewritten: false,
+			want:          "data:image/svg+xmlish,%3Csvg%2F%3E",
+		},
+		{
+			scenario:      "empty is left unchanged",
+			image:         "",
+			wantRewritten: false,
+			want:          "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.scenario, func(t *testing.T) {
+			got, rewritten := reencodeInlineSVGImage(testCase.image)
+			assert.Equal(t, testCase.wantRewritten, rewritten)
+			assert.Equal(t, testCase.want, got)
+		})
 	}
 }
 


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Integration dashboards have SVG images, which are not supported in the UI anymore. Migration was earlier defaulting to the 8-ball image, but we can re-encode these SVGs to base64, so that needs to be done