### PR TITLE
fix: handle malformed reduceTo + pick correct columns for traces in list panel

### DIFF
--- a/pkg/types/dashboardtypes/perses_v1_to_v2_panels.go
+++ b/pkg/types/dashboardtypes/perses_v1_to_v2_panels.go
@@ -266,11 +266,27 @@ func (d *v1Decoder) legendFromWidget(w map[string]any) Legend {
 	}
 }
 
+// widgetBuilderSignal returns the signal of the widget's first builder query. Empty
+// for non-builder (promql/clickhouse) widgets, which have no per-signal selected fields.
+func (d *v1Decoder) widgetBuilderSignal(w map[string]any) telemetrytypes.Signal {
+	builder := d.readObject(d.readObject(w, "query"), "builder")
+	for _, q := range d.readObjects(builder, "queryData") {
+		return signalFromDataSource(q["dataSource"])
+	}
+	return telemetrytypes.Signal{}
+}
+
 func (d *v1Decoder) mapV1SelectFields(w map[string]any) []telemetrytypes.TelemetryFieldKey {
-	field := "selectedLogFields"
+	// Read the array matching the query's signal: traces and logs each keep their own
+	// selected columns, and a widget can carry a stale array for the other signal.
+	primary, fallback := "selectedLogFields", "selectedTracesFields"
+	if d.widgetBuilderSignal(w) == telemetrytypes.SignalTraces {
+		primary, fallback = "selectedTracesFields", "selectedLogFields"
+	}
+	field := primary
 	raw := d.readArray(w, field)
 	if len(raw) == 0 {
-		field = "selectedTracesFields"
+		field = fallback
 		raw = d.readArray(w, field)
 	}
 	if len(raw) == 0 {

--- a/pkg/types/dashboardtypes/perses_v1_to_v2_queries_malformed.go
+++ b/pkg/types/dashboardtypes/perses_v1_to_v2_queries_malformed.go
@@ -33,6 +33,7 @@ var preV5Migrator = transition.NewDashboardMigrateV5(slog.New(slog.DiscardHandle
 func normalizePreV5QueryData(query map[string]any, widgetType string) {
 	dropLegacyFilter(query)
 	normalizeFilterItemOps(query)
+	foldReduceToIntoMetricAggregations(query)
 	preV5Migrator.MigrateQueryDataShapeSafe(context.Background(), query, widgetType)
 	normalizePreV5LogTraceAggregations(query)
 	normalizeMetricAggregations(query)
@@ -226,7 +227,7 @@ func dropLegacyFilter(query map[string]any) {
 
 // normalizeFilterItemOps lowercases exists/nexists filter ops (frontend stores them
 // uppercase) to the spelling transition's buildCondition (pkg/transition/migrate_common.go)
-// matches; otherwise it appends a spurious empty value ("svc EXISTS ''"). Value
+// matches; otherwise it appends a spurious empty value ("svc EXISTS ”"). Value
 // operators already round-trip via that switch's default case.
 func normalizeFilterItemOps(query map[string]any) {
 	filters, ok := query["filters"].(map[string]any)
@@ -299,6 +300,32 @@ func normalizeMetricAggregations(query map[string]any) {
 		sa, _ := agg["spaceAggregation"].(string)
 		if !(metrictypes.SpaceAggregation{String: valuer.NewString(sa)}).IsValid() {
 			agg["spaceAggregation"] = metrictypes.SpaceAggregationSum.StringValue()
+		}
+	}
+}
+
+// foldReduceToIntoMetricAggregations moves a metric query's top-level reduceTo onto
+// its existing aggregations[] (where v5 wants it), which the shared migrator only does
+// when building an aggregation from flat fields. Runs before it so the value survives.
+func foldReduceToIntoMetricAggregations(query map[string]any) {
+	if signalFromDataSource(query["dataSource"]) != telemetrytypes.SignalMetrics {
+		return
+	}
+	reduceTo, ok := query["reduceTo"].(string)
+	if !ok || reduceTo == "" {
+		return
+	}
+	aggs, ok := query["aggregations"].([]any)
+	if !ok || len(aggs) == 0 {
+		return
+	}
+	for _, a := range aggs {
+		agg, ok := a.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, exists := agg["reduceTo"]; !exists {
+			agg["reduceTo"] = reduceTo
 		}
 	}
 }

--- a/pkg/types/dashboardtypes/perses_v1_to_v2_test.go
+++ b/pkg/types/dashboardtypes/perses_v1_to_v2_test.go
@@ -524,6 +524,48 @@ func TestConvertV1ToV2ReplacesInvalidImage(t *testing.T) {
 	assert.Equal(t, "/assets/Icons/eight-ball", dashboard.Image)
 }
 
+func TestFoldReduceToIntoMetricAggregations(t *testing.T) {
+	// A metric query's top-level reduceTo lands on its aggregation (where v5 wants it).
+	query := map[string]any{
+		"dataSource":   "metrics",
+		"reduceTo":     "sum",
+		"aggregations": []any{map[string]any{"metricName": "m", "spaceAggregation": "sum"}},
+	}
+	foldReduceToIntoMetricAggregations(query)
+	assert.Equal(t, "sum", query["aggregations"].([]any)[0].(map[string]any)["reduceTo"])
+
+	// An aggregation that already carries a reduceTo is not overwritten.
+	query = map[string]any{
+		"dataSource":   "metrics",
+		"reduceTo":     "sum",
+		"aggregations": []any{map[string]any{"metricName": "m", "reduceTo": "avg"}},
+	}
+	foldReduceToIntoMetricAggregations(query)
+	assert.Equal(t, "avg", query["aggregations"].([]any)[0].(map[string]any)["reduceTo"])
+}
+
+func TestMapV1SelectFieldsPicksBySignal(t *testing.T) {
+	d := &v1Decoder{}
+	// A list widget carrying both arrays; the query's signal must decide which wins.
+	widget := func(dataSource string) map[string]any {
+		return map[string]any{
+			"query": map[string]any{
+				"builder": map[string]any{"queryData": []any{map[string]any{"dataSource": dataSource}}},
+			},
+			"selectedLogFields":    []any{map[string]any{"name": "log_field"}},
+			"selectedTracesFields": []any{map[string]any{"name": "trace_field"}},
+		}
+	}
+
+	logs := d.mapV1SelectFields(widget("logs"))
+	require.Len(t, logs, 1)
+	assert.Equal(t, "log_field", logs[0].Name)
+
+	traces := d.mapV1SelectFields(widget("traces"))
+	require.Len(t, traces, 1)
+	assert.Equal(t, "trace_field", traces[0].Name)
+}
+
 func TestConvertV1ToV2RejectsAlreadyV2(t *testing.T) {
 	storable := &StorableDashboard{
 		Identifiable: types.Identifiable{ID: valuer.GenerateUUID()},


### PR DESCRIPTION


## Pull Request

---

### 📄 Summary

1. In some malformed dashboards the reduce to is not defined in the metric aggregation but at the root level of the query
2. Migration script was picking select log fields even when data source is traces in a list panel