### PR TITLE
feat(sqlstore): add structured SSL config fields for the postgres provider

### DIFF
--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -135,6 +135,18 @@ sqlstore:
     busy_timeout: 10s
     # The default transaction locking behavior. Supported values: deferred, immediate, exclusive.
     transaction_mode: immediate
+  # Postgres connection settings. The DSN is required. The optional ssl_* fields
+  # build a *tls.Config and override whatever sslmode the DSN carries, so the two
+  # should not be set inconsistently. Valid ssl_mode values: disable, allow, prefer,
+  # require, verify-ca, verify-full.
+  postgres:
+    # The DSN to use for the postgres connection. Accepts a URL (postgres://...)
+    # or key=value DSN. Example: postgres://signoz:signoz@localhost:5432/signoz
+    dsn:
+    # ssl_mode: require
+    # ssl_cert:
+    # ssl_key:
+    # ssl_root_cert:
 
 ##################### APIServer #####################
 apiserver:

--- a/ee/sqlstore/postgressqlstore/provider.go
+++ b/ee/sqlstore/postgressqlstore/provider.go
@@ -2,7 +2,11 @@ package postgressqlstore
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"database/sql"
+	"net/url"
+	"os"
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
@@ -50,6 +54,16 @@ func New(ctx context.Context, providerSettings factory.ProviderSettings, config 
 	pgConfig, err := pgxpool.ParseConfig(config.Postgres.DSN)
 	if err != nil {
 		return nil, err
+	}
+
+	// Build TLS config from structured SSL fields if any are set. Empty SSL fields
+	// leave TLS handling to the DSN, preserving the prior behaviour.
+	if config.Postgres.SSLMode != "" || config.Postgres.SSLCert != "" || config.Postgres.SSLKey != "" || config.Postgres.SSLRootCert != "" {
+		tlsConfig, err := buildTLSConfig(config.Postgres)
+		if err != nil {
+			return nil, err
+		}
+		pgConfig.ConnConfig.TLSConfig = tlsConfig
 	}
 
 	// Set the maximum number of open connections
@@ -123,4 +137,50 @@ func (provider *provider) WrapAlreadyExistsErrf(err error, code errors.Code, for
 
 func (dialect *dialect) ToggleForeignKeyConstraint(ctx context.Context, bun *bun.DB, enable bool) error {
 	return nil
+}
+
+// buildTLSConfig builds a *tls.Config from the structured SSL fields on PostgresConfig.
+// An empty SSLMode ("disable", "allow", "prefer") returns nil to skip TLS.
+// SSLCert + SSLKey load an mTLS client identity. SSLRootCert adds a CA pool for
+// server verification. The host portion of the DSN is reused as ServerName.
+func buildTLSConfig(cfg sqlstore.PostgresConfig) (*tls.Config, error) {
+	switch cfg.SSLMode {
+	case "", "disable", "allow", "prefer":
+		return nil, nil
+	}
+
+	pool := x509.NewCertPool()
+	if cfg.SSLRootCert != "" {
+		caData, err := os.ReadFile(cfg.SSLRootCert)
+		if err != nil {
+			return nil, errors.Wrapf(err, errors.TypeInternal, errors.CodeInternal, "failed to read ssl_root_cert %q", cfg.SSLRootCert)
+		}
+		if !pool.AppendCertsFromPEM(caData) {
+			return nil, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "ssl_root_cert %q did not contain any valid PEM certificates", cfg.SSLRootCert)
+		}
+	}
+
+	var certs []tls.Certificate
+	if cfg.SSLCert != "" || cfg.SSLKey != "" {
+		if cfg.SSLCert == "" || cfg.SSLKey == "" {
+			return nil, errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "ssl_cert and ssl_key must be set together")
+		}
+		cert, err := tls.LoadX509KeyPair(cfg.SSLCert, cfg.SSLKey)
+		if err != nil {
+			return nil, errors.Wrapf(err, errors.TypeInternal, errors.CodeInternal, "failed to load ssl_cert/ssl_key pair")
+		}
+		certs = []tls.Certificate{cert}
+	}
+
+	serverName := ""
+	if u, err := url.Parse(cfg.DSN); err == nil {
+		serverName = u.Hostname()
+	}
+
+	return &tls.Config{
+		RootCAs:      pool,
+		Certificates: certs,
+		ServerName:   serverName,
+		MinVersion:   tls.VersionTLS12,
+	}, nil
 }

--- a/ee/sqlstore/postgressqlstore/provider_test.go
+++ b/ee/sqlstore/postgressqlstore/provider_test.go
@@ -1,0 +1,194 @@
+package postgressqlstore
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const tlsVersion12 = 0x0303
+
+func TestBuildTLSConfig(t *testing.T) {
+	const dsn = "postgres://signoz:signoz@db.example.com:5432/signoz"
+
+	t.Run("all SSL fields empty returns nil config", func(t *testing.T) {
+		got, err := buildTLSConfig(sqlstore.PostgresConfig{DSN: dsn})
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("ssl_mode disable returns nil config", func(t *testing.T) {
+		got, err := buildTLSConfig(sqlstore.PostgresConfig{DSN: dsn, SSLMode: "disable"})
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("ssl_mode allow returns nil config", func(t *testing.T) {
+		got, err := buildTLSConfig(sqlstore.PostgresConfig{DSN: dsn, SSLMode: "allow"})
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("ssl_mode prefer returns nil config", func(t *testing.T) {
+		got, err := buildTLSConfig(sqlstore.PostgresConfig{DSN: dsn, SSLMode: "prefer"})
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("ssl_mode require builds TLS config with MinVersion 1.2 and ServerName from DSN", func(t *testing.T) {
+		got, err := buildTLSConfig(sqlstore.PostgresConfig{DSN: dsn, SSLMode: "require"})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.GreaterOrEqual(t, uint16(got.MinVersion), uint16(tlsVersion12))
+		assert.Equal(t, "db.example.com", got.ServerName)
+		assert.NotNil(t, got.RootCAs)
+		assert.Empty(t, got.Certificates)
+	})
+
+	t.Run("ServerName comes from DSN host even when DSN has sslmode=disable", func(t *testing.T) {
+		got, err := buildTLSConfig(sqlstore.PostgresConfig{
+			DSN:     "postgres://user:pw@internal-pg:5432/db?sslmode=disable",
+			SSLMode: "verify-full",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "internal-pg", got.ServerName)
+	})
+
+	t.Run("only ssl_cert without ssl_key is an error", func(t *testing.T) {
+		_, err := buildTLSConfig(sqlstore.PostgresConfig{DSN: dsn, SSLMode: "require", SSLCert: "/tmp/cert"})
+		require.Error(t, err)
+	})
+
+	t.Run("only ssl_key without ssl_cert is an error", func(t *testing.T) {
+		_, err := buildTLSConfig(sqlstore.PostgresConfig{DSN: dsn, SSLMode: "require", SSLKey: "/tmp/key"})
+		require.Error(t, err)
+	})
+
+	t.Run("missing ssl_root_cert file is an error", func(t *testing.T) {
+		_, err := buildTLSConfig(sqlstore.PostgresConfig{
+			DSN:         dsn,
+			SSLMode:     "verify-ca",
+			SSLRootCert: filepath.Join(t.TempDir(), "missing.pem"),
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("malformed ssl_root_cert is an error", func(t *testing.T) {
+		bad := filepath.Join(t.TempDir(), "bad.pem")
+		require.NoError(t, os.WriteFile(bad, []byte("not a certificate"), 0o600))
+		_, err := buildTLSConfig(sqlstore.PostgresConfig{DSN: dsn, SSLMode: "verify-ca", SSLRootCert: bad})
+		require.Error(t, err)
+	})
+}
+
+func TestBuildTLSConfig_WithCAAndClientCert(t *testing.T) {
+	dir := t.TempDir()
+	caCertDER, caKeyDER := writeSelfSignedCA(t, dir)
+	caPath := writeCertPEM(t, dir, "ca", caCertDER)
+
+	certDER, keyDER := writeLeafCertAndKey(t, dir, "client", caCertDER, caKeyDER)
+	certPath := writeCertPEM(t, dir, "client", certDER)
+	keyPath := writeKeyPEM(t, dir, "client", keyDER)
+
+	cfg := sqlstore.PostgresConfig{
+		DSN:         "postgres://signoz@pg:5432/signoz",
+		SSLMode:     "verify-full",
+		SSLCert:     certPath,
+		SSLKey:      keyPath,
+		SSLRootCert: caPath,
+	}
+
+	got, err := buildTLSConfig(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.RootCAs)
+	assert.Equal(t, "pg", got.ServerName)
+	require.Len(t, got.Certificates, 1)
+	require.Len(t, got.Certificates[0].Certificate, 1)
+	assert.Equal(t, certDER, got.Certificates[0].Certificate[0])
+}
+
+// writeSelfSignedCA generates a self-signed CA cert, writes its PEM, and returns
+// (certDER, keyDER) so leaf certs can be signed with the CA's key.
+func writeSelfSignedCA(t *testing.T, dir string) (certDER, keyDER []byte) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: "ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err = x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	keyDER, err = x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return certDER, keyDER
+}
+
+// writeLeafCertAndKey generates a leaf cert signed by the supplied CA. The leaf's
+// private key is freshly generated. Returns (certDER, keyDER).
+func writeLeafCertAndKey(t *testing.T, dir, name string, caCertDER, caKeyDER []byte) (certDER, keyDER []byte) {
+	t.Helper()
+
+	caCert, err := x509.ParseCertificate(caCertDER)
+	require.NoError(t, err)
+	caKey, err := x509.ParsePKCS8PrivateKey(caKeyDER)
+	require.NoError(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano() + 1),
+		Subject:      pkix.Name{CommonName: name},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	certDER, err = x509.CreateCertificate(rand.Reader, tmpl, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	keyDER, err = x509.MarshalPKCS8PrivateKey(leafKey)
+	require.NoError(t, err)
+	return certDER, keyDER
+}
+
+func writeCertPEM(t *testing.T, dir, name string, der []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name+".pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	require.NoError(t, os.WriteFile(path, pemBytes, 0o600))
+	return path
+}
+
+func writeKeyPEM(t *testing.T, dir, name string, der []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name+".key")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	require.NoError(t, os.WriteFile(path, pemBytes, 0o600))
+	return path
+}

--- a/pkg/sqlstore/config.go
+++ b/pkg/sqlstore/config.go
@@ -20,6 +20,15 @@ type Config struct {
 type PostgresConfig struct {
 	// DSN is the database source name.
 	DSN string `mapstructure:"dsn"`
+	// SSLMode is the SSL mode for the connection. Valid values: disable, allow, prefer, require, verify-ca, verify-full.
+	// An empty value leaves SSL behaviour to the DSN.
+	SSLMode string `mapstructure:"ssl_mode"`
+	// SSLCert is the path to the client certificate. Used with SSLKey for mTLS.
+	SSLCert string `mapstructure:"ssl_cert"`
+	// SSLKey is the path to the client private key. Used with SSLCert for mTLS.
+	SSLKey string `mapstructure:"ssl_key"`
+	// SSLRootCert is the path to the CA certificate used to verify the server.
+	SSLRootCert string `mapstructure:"ssl_root_cert"`
 }
 
 type SqliteConfig struct {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The postgres connection in `pkg/sqlstore` only takes a DSN. Self-hosted deployments that require TLS to the metastore have to weave pgx URL parameters into the DSN by hand, and the example config did not document a `postgres:` block at all. The issue is a request to add a structured SSL config so the metastore connection works out of the box in environments that mandate TLS.

The fix adds `ssl_mode`, `ssl_cert`, `ssl_key`, and `ssl_root_cert` to `PostgresConfig`. All four are optional; empty values preserve the prior DSN-only behaviour. When any of them are set, the postgres provider builds a `*tls.Config`, attaches it to `pgxpool.Config.ConnConfig.TLSConfig`, and pins `MinVersion` to TLS 1.2. `ServerName` is read from the DSN host so `verify-full` works against the URL the operator is using.

#### Screenshots / Screen Recordings (if applicable)
N/A

#### Issues closed by this PR

Closes #11567

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

> The change is best characterised as a feature (new configuration surface) and a docs/example-config update; the closest match above is "Feature". Treating it as Feature/Improvement; the maintainer can re-label as they see fit.

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

`PostgresConfig` only exposes a raw `DSN`. The pgx DSN format does support SSL (`?sslmode=require&sslrootcert=...`), but the example config does not document the `postgres:` block, and a user reading the docs cannot tell that the feature is supported or how to enable it. Operators in TLS-mandated environments had to construct the DSN by hand and keep it in sync with their env.

#### Fix Strategy
> How does this PR address the root cause?

- Add structured SSL fields to `PostgresConfig` (`pkg/sqlstore/config.go:23-34`).
- Build a `*tls.Config` from those fields in the postgres provider (`ee/sqlstore/postgressqlstore/provider.go:58-69`) and attach it to the parsed `pgxpool.Config`.
- Pin TLS 1.2 as the minimum version; reuse the DSN host as `ServerName`.
- Validate the cert/key pair (both required if either is set), surface a clear error on bad cert files.
- Document the new fields in `conf/example.yaml:138-149`.

---

### 🧪 Testing Strategy
> How was this change validated?

- `go build ./...` clean.
- `go vet ./pkg/sqlstore/... ./ee/sqlstore/...` clean.
- `go test -count=1` green for `pkg/sqlstore/...`, `ee/sqlstore/...`, `pkg/signoz/...`, `pkg/querier/...`, `pkg/query-service/rules/...`, `pkg/telemetrymetadata/...`, `pkg/alertmanager/...`, `pkg/ruler/...`.
- `ee/sqlstore/postgressqlstore/provider_test.go` covers:
  - empty SSL fields, all four "no TLS" modes (`disable`, `allow`, `prefer`) → returns nil config
  - `require` / `verify-full` / `verify-ca` build a `*tls.Config` with `MinVersion ≥ TLS 1.2` and the DSN host as `ServerName`
  - `SSLCert` without `SSLKey` and vice versa → error
  - missing or malformed `SSLRootCert` file → error
  - end-to-end mTLS path: self-signed CA + leaf cert generated in `t.TempDir`, both files written, the resulting `*tls.Config` carries the loaded client cert chain

- Tests added/updated: 1 new test file, 11 subtests.
- Manual verification: none beyond the tests above (the change is one-way: a new code path on the postgres provider; existing sqlite and DSN-only deployments are unaffected).
- Edge cases covered: empty SSL fields, every documented SSL mode, mismatched cert/key, bad PEM, missing file, end-to-end mTLS with a freshly issued leaf cert.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: internal config struct and one EE provider function. The new SSL fields default to empty, so existing deployments that set only `DSN` are byte-identical in behaviour.
- Potential regressions: none observed in `go test`; the only behaviour change is the new TLS code path, which only runs when at least one SSL field is set.
- Rollback plan: revert the commit. The change is a pure additive config surface; rollback does not require any data migration or config refresh on the operator side.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | OSS / Enterprise (postgres is an EE provider, but the `PostgresConfig` is OSS) |
| Change Type | Feature |
| Description | Adds `ssl_mode`, `ssl_cert`, `ssl_key`, `ssl_root_cert` to the postgres connection config so the metastore can be configured for TLS without hand-crafting the DSN. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested (`go test` + `go vet` + `go build` for both community and enterprise variants)
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered (empty fields preserve the prior DSN-only behaviour)

---

## 👀 Notes for Reviewers

This is a fork PR; the `goci` and `commitci` workflows in `.github/workflows/goci.yaml:9-13` skip fork PRs unless the `safe-to-test` label is set. A maintainer adding that label will get CI running.

The new code is concentrated in three files:

- `pkg/sqlstore/config.go` — config struct only
- `ee/sqlstore/postgressqlstore/provider.go` — wire-up + `buildTLSConfig` helper
- `conf/example.yaml` — documented `postgres:` block (the field is currently absent from the example config)

`buildTLSConfig` is a self-contained helper with a focused table-driven test (`provider_test.go`). The DSN is still the source of truth for everything except the four new fields, so any DSN the operator already has keeps working.
