### PR TITLE
fix(dashboard): V2 pie legend format/height + table empty-cell parity with V1

### DIFF
--- a/frontend/src/container/DashboardContainer/visualization/charts/Pie/Pie.module.scss
+++ b/frontend/src/container/DashboardContainer/visualization/charts/Pie/Pie.module.scss
@@ -56,14 +56,19 @@
 	margin-top: 4px;
 }
 
-// Wraps the shared chart Legend. Its width/height are set inline from the
-// computed chart dimensions, so the VirtuosoGrid inside gets the same bounded
-// box (right column / bottom rows) the uPlot charts use.
+// width/height are set inline from the computed chart dimensions; border-box
+// keeps the padding inside that height and overflow:hidden clips the
+// virtualized grid to the rectangle.
 .pieChartLegend {
 	flex: 0 0 auto;
+	box-sizing: border-box;
 	min-height: 0;
 	min-width: 0;
+	overflow: hidden;
 	padding-left: 12px;
 	padding-bottom: 12px;
+}
+
+.pieChartLegendRight {
 	padding-top: 8px;
 }

--- a/frontend/src/container/DashboardContainer/visualization/charts/Pie/Pie.tsx
+++ b/frontend/src/container/DashboardContainer/visualization/charts/Pie/Pie.tsx
@@ -3,6 +3,7 @@ import { Color } from '@signozhq/design-tokens';
 import { Group } from '@visx/group';
 import { Pie as VisxPie } from '@visx/shape';
 import { defaultStyles, useTooltip, useTooltipInPortal } from '@visx/tooltip';
+import cx from 'classnames';
 import { getYAxisFormattedValue } from 'components/Graph/yAxisConfig';
 import { useResizeObserver } from 'hooks/useDimensions';
 import Legend from 'lib/uPlotV2/components/Legend/Legend';
@@ -210,7 +211,9 @@ export default function Pie({
 				)}
 			</div>
 			<div
-				className={styles.pieChartLegend}
+				className={cx(styles.pieChartLegend, {
+					[styles.pieChartLegendRight]: isRightLegend,
+				})}
 				style={{
 					width: legendWidth,
 					height: legendHeight,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/__tests__/prepareData.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/__tests__/prepareData.test.ts
@@ -33,7 +33,7 @@ describe('preparePieData', () => {
 		]);
 	});
 
-	it('keeps one slice per group row for a single value column', () => {
+	it('serialises a single group-by column as {key="value"} (V1 parity)', () => {
 		const table = tableWith(
 			[
 				{
@@ -53,8 +53,33 @@ describe('preparePieData', () => {
 		const slices = preparePieData(args([table]));
 
 		expect(slices.map((s) => [s.label, s.value])).toStrictEqual([
-			['adservice', 100],
-			['cartservice', 200],
+			['{service.name="adservice"}', 100],
+			['{service.name="cartservice"}', 200],
+		]);
+	});
+
+	it('serialises a grouped metrics query as {direction="write"} (V1 parity)', () => {
+		const table = tableWith(
+			[
+				{
+					name: 'direction',
+					queryName: 'A',
+					isValueColumn: false,
+					id: 'direction',
+				},
+				{ name: 'A', queryName: 'A', isValueColumn: true, id: 'A' },
+			],
+			[
+				{ data: { direction: 'write', A: 3170000000 } },
+				{ data: { direction: 'read', A: 10000000 } },
+			],
+		);
+
+		const slices = preparePieData(args([table]));
+
+		expect(slices.map((s) => s.label)).toStrictEqual([
+			'{direction="write"}',
+			'{direction="read"}',
 		]);
 	});
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/prepareData.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/PieChartPanel/prepareData.ts
@@ -1,5 +1,6 @@
 import { themeColors } from 'constants/theme';
 import type { PieSlice } from 'container/DashboardContainer/visualization/charts/types';
+import getLabelName from 'lib/getLabelName';
 import { generateColor } from 'lib/uPlotLib/utils/generateColor';
 import type { PanelTable } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
 
@@ -51,7 +52,8 @@ export function preparePieData({
 				if (hasMultipleValueColumns) {
 					label = groupLabel ? `${groupLabel} · ${column.name}` : column.name;
 				} else {
-					label = groupLabel || table.legend || table.queryName || '';
+					// V1 parity: serialise group-by labels as `{key="value"}`.
+					label = getLabelName(labels, table.queryName || '', table.legend || '');
 				}
 
 				const color = customColors?.[label] ?? generateColor(label, colorMap);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/__tests__/tableColumns.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/__tests__/tableColumns.test.ts
@@ -1,0 +1,60 @@
+import type { PanelTableColumn } from 'pages/DashboardPageV2/DashboardContainer/queryV5/types';
+
+import { formatTableCellText } from '../tableColumns';
+
+jest.mock('../../../utils/formatPanelValue', () => ({
+	formatPanelValue: (value: number, unit?: string): string =>
+		`${value}${unit ?? ''}`,
+}));
+
+const valueColumn: PanelTableColumn = {
+	name: 'p99',
+	queryName: 'A',
+	isValueColumn: true,
+	id: 'A',
+};
+
+const groupColumn: PanelTableColumn = {
+	name: 'service',
+	queryName: 'A',
+	isValueColumn: false,
+	id: 'service',
+};
+
+describe('formatTableCellText', () => {
+	it.each([null, undefined, ''])(
+		'renders empty value-column cells (%p) as n/a instead of 0',
+		(raw) => {
+			expect(formatTableCellText(valueColumn, raw, 'ms', undefined)).toBe('n/a');
+		},
+	);
+
+	it('keeps a real zero as a formatted 0, not n/a', () => {
+		expect(formatTableCellText(valueColumn, 0, 'ms', undefined)).toBe('0ms');
+	});
+
+	it('formats a numeric value column through unit + precision', () => {
+		expect(formatTableCellText(valueColumn, 1234, 'ms', undefined)).toBe(
+			'1234ms',
+		);
+	});
+
+	it('renders a non-numeric value cell as raw text', () => {
+		expect(formatTableCellText(valueColumn, 'n/a', 'ms', undefined)).toBe('n/a');
+	});
+
+	it.each([null, undefined, ''])(
+		'renders empty group-column cells (%p) as n/a',
+		(raw) => {
+			expect(formatTableCellText(groupColumn, raw, undefined, undefined)).toBe(
+				'n/a',
+			);
+		},
+	);
+
+	it('renders group-column labels as raw text', () => {
+		expect(
+			formatTableCellText(groupColumn, 'frontend', undefined, undefined),
+		).toBe('frontend');
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/__tests__/tableCsv.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/__tests__/tableCsv.test.ts
@@ -64,6 +64,19 @@ describe('buildTableCsvRows', () => {
 
 		expect(rows).toStrictEqual([{ service: 'api', p99: 'n/a' }]);
 	});
+
+	it('exports empty value cells as n/a rather than 0', () => {
+		const rows = buildTableCsvRows({
+			table: {
+				...table,
+				rows: [{ data: { service: 'api', A: null } }],
+			},
+			columnUnits: { A: 'ms' },
+			decimalPrecision: undefined,
+		});
+
+		expect(rows).toStrictEqual([{ service: 'api', p99: 'n/a' }]);
+	});
 });
 
 describe('getTableCsvRows', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/tableColumns.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/tableColumns.tsx
@@ -18,6 +18,17 @@ import styles from './TablePanel.module.scss';
 /** A prepared scalar-table row flattened for the antd Table, with the antd key. */
 export type TableRowData = Record<string, unknown> & { key: number };
 
+const NA_TEXT = 'n/a';
+
+// Empty cells (null/undefined/'') aren't numbers: `Number(null)` is 0, which
+// would render/colour/sort an empty cell as a real zero.
+function toCellNumber(raw: unknown): number {
+	if (raw == null || raw === '') {
+		return NaN;
+	}
+	return Number(raw);
+}
+
 /**
  * Groups table thresholds by the column they target, mapping each onto the
  * V2-native `PanelThreshold` consumed by `resolveActiveThreshold`. A column with
@@ -43,6 +54,9 @@ export function formatTableCellText(
 	unit: string | undefined,
 	decimalPrecision?: PrecisionOption,
 ): string {
+	if (raw == null || raw === '') {
+		return NA_TEXT;
+	}
 	if (!col.isValueColumn) {
 		return coerceToString(raw);
 	}
@@ -56,15 +70,17 @@ export function formatTableCellText(
 // Sort comparator: numeric when both cells parse as numbers (value columns and
 // numeric group keys), otherwise a locale string compare. Nullish sorts last.
 function compareCells(a: unknown, b: unknown): number {
-	const aNum = Number(a);
-	const bNum = Number(b);
+	const aNum = toCellNumber(a);
+	const bNum = toCellNumber(b);
 	if (Number.isFinite(aNum) && Number.isFinite(bNum)) {
 		return aNum - bNum;
 	}
-	if (a == null) {
-		return b == null ? 0 : 1;
+	const aEmpty = a == null || a === '';
+	const bEmpty = b == null || b === '';
+	if (aEmpty) {
+		return bEmpty ? 0 : 1;
 	}
-	if (b == null) {
+	if (bEmpty) {
 		return -1;
 	}
 	return coerceToString(a).localeCompare(coerceToString(b));
@@ -113,7 +129,7 @@ export function buildTableColumns({
 				compareCells(a[key], b[key]),
 			render: (raw: unknown): React.ReactNode => {
 				const text = formatTableCellText(col, raw, unit, decimalPrecision);
-				const num = Number(raw);
+				const num = toCellNumber(raw);
 				if (
 					!col.isValueColumn ||
 					colThresholds.length === 0 ||
@@ -131,7 +147,7 @@ export function buildTableColumns({
 				const cellProps: React.HTMLAttributes<HTMLElement> = {};
 
 				if (col.isValueColumn && colThresholds.length > 0) {
-					const num = Number(record[key]);
+					const num = toCellNumber(record[key]);
 					if (Number.isFinite(num)) {
 						const { threshold } = resolveActiveThreshold(colThresholds, num, unit);
 						if (threshold?.format === 'background') {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

A batch of three bug fixes for the V2 dashboard panels (pure-V5 renderers) where behavior had diverged from V1:

1. **Pie legend format** — V2 showed group-by legends as bare values (`write`) instead of V1's `{direction="write"}`. This also broke `customColors` overrides copied from V1 JSON, since they are keyed by the label string.
2. **Pie legend height** — the pie legend wrapper exceeded its computed height and clipped the donut.
3. **Table empty cells** — empty scalar cells rendered as `0`, picked up value-column threshold colors, and sorted as real zeros.

Each fix aligns the V2 renderer with the established V1 behavior.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change.

**Pie legend format (before → after):**

- Before (V2): legend renders as `write` / `read`
- After (V2, matches V1): legend renders as `{direction="write"}` / `{direction="read"}`

_(Reviewer: please add captured screenshots from staging.)_

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/pulse-pod/issues/142

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause

- **Pie legend format:** The V2 pie renderer is fed by the scalar-table path (`prepareScalarTables`), which stores only the raw value per cell. `preparePieData` joined those values directly, dropping the `{key="value"}` wrapping. V2's other renderers (time-series, bar, histogram) already route through `getLabelName`; the pie was the only scalar-table-fed renderer, so it was the only one that regressed. Because `customColors` overrides are keyed by the label string, the mismatched label also broke color overrides copied from V1 JSON.
- **Pie legend height:** The pie legend wrapper was missing `box-sizing: border-box` and `overflow: hidden` and applied top padding unconditionally, so its height exceeded the value from `calculateChartDimensions` and clipped the donut.
- **Table empty cells:** Empty scalar cells (`null` / `undefined` / `''`) were coerced via `Number()` to `0`, so they rendered as `0`, picked up value-column color thresholds, and sorted as real zeros.

#### Fix Strategy

- **Pie legend format:** Route the single-value-column label through `getLabelName` (matching V1's `slicesFromSeries`), reusing the `labels` map already built for drilldown. Multi-value-column labels (e.g. ClickHouse `count() AS c1, sum() AS c2`) are unchanged, matching V1's `slicesFromTables`.
- **Pie legend height:** Mirror the shared chart legend wrapper — add `box-sizing`/`overflow` and gate the top padding to the right-legend position.
- **Table empty cells:** Route cells through `toCellNumber` (`NaN` for empty) so empties show `n/a`, skip threshold coloring, and sort last.

---

### 🧪 Testing Strategy
> How was this change validated?

- **Tests added/updated:**
  - `PieChartPanel/__tests__/prepareData.test.ts` — updated the single-group assertion to expect `{key="value"}` and added a case locking in `{direction="write"}` / `{direction="read"}`.
  - `TablePanel/__tests__/tableColumns.test.ts` and `tableCsv.test.ts` — empty-cell → `n/a` coverage.
- **Manual verification:** Verified on staging with a metrics pie panel grouped by `direction`.
- **Edge cases covered:** No group-by (falls back to legend format / query name), custom legend format, multi-value-column ClickHouse queries, non-positive / non-numeric values dropped, empty table cells.
- Local `jest`, `tsgo --noEmit`, and `oxlint` all pass on the changed files.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** V2 dashboard pie and table panels only. No V1 files touched; no shared query-builder code touched.
- **Potential regressions:** Pie legend strings and pie/table color-override keys change for V2 panels; because they now match V1, previously-saved V1 JSON overrides resolve correctly again.
- **Rollback plan:** Revert the commits on this branch — changes are self-contained to the V2 pie/table renderer utils.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | V2 dashboard: pie legends now match V1's `{key="value"}` format, pie legend no longer clips the donut, and empty table cells render as `n/a` instead of `0`. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Three separate commits, one per bug — reviewable independently. The pie legend-format fix also repairs `customColors` overrides copied from V1 JSON, since those are keyed by the label string.

---
