### PR TITLE
test(dashboards-v2): make explorer export tests flag-aware (V1 + V2)

### DIFF
--- a/frontend/src/container/ExplorerOptions/__tests__/ExplorerOptionWrapper.test.tsx
+++ b/frontend/src/container/ExplorerOptions/__tests__/ExplorerOptionWrapper.test.tsx
@@ -1,10 +1,17 @@
 import { useHistory } from 'react-router-dom';
+import { FeatureKeys } from 'constants/features';
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import { MOCK_QUERY } from 'container/QueryTable/Drilldown/__tests__/mockTableData';
 import { ExportDashboard } from 'hooks/dashboard/useExportDashboards';
 import { useUpdateDashboard } from 'hooks/dashboard/useUpdateDashboard';
 import { rest, server } from 'mocks-server/server';
-import { render, screen, userEvent, waitFor } from 'tests/test-utils';
+import {
+	defaultFeatureFlags,
+	render,
+	screen,
+	userEvent,
+	waitFor,
+} from 'tests/test-utils';
 import { Dashboard } from 'types/api/dashboard/getAll';
 import { Query } from 'types/api/queryBuilder/queryBuilderData';
 import { DataSource } from 'types/common/queryBuilder';
@@ -46,7 +53,28 @@ const TEST_DASHBOARD_DESCRIPTION = 'Test Description';
 const TEST_TIMESTAMP = '2023-01-01T00:00:00Z';
 const TEST_DASHBOARD_TITLE_2 = 'Test Dashboard for Export';
 const NEW_DASHBOARD_ID = 'new-dashboard-id';
-const DASHBOARDS_API_ENDPOINT = '*/api/v1/dashboards';
+
+// The export dialog is flag-aware (`use_dashboard_v2`): V1 talks to the legacy
+// dashboards API, V2 to the generated Perses-spec endpoints. The tests below run
+// against both contracts, so each path gets its own endpoints + response shapes.
+const V1_DASHBOARDS_ENDPOINT = '*/api/v1/dashboards';
+const V2_LIST_ENDPOINT = '*/api/v2/users/me/dashboards';
+const V2_CREATE_ENDPOINT = '*/api/v2/dashboards';
+
+// V2 "create new dashboard" names the dashboard from the `new_dashboard_title`
+// i18n key; the test-utils react-i18next mock returns the key verbatim.
+const NEW_V2_DASHBOARD_TITLE = 'new_dashboard_title';
+
+const featureFlagsWithDashboardV2 = [
+	...defaultFeatureFlags,
+	{
+		name: FeatureKeys.USE_DASHBOARD_V2,
+		active: true,
+		usage: 0,
+		usage_limit: -1,
+		route: '',
+	},
+];
 
 // Use the existing mock query from the codebase
 const mockQuery: Query = {
@@ -71,9 +99,97 @@ const createMockDashboard = (id: string = TEST_DASHBOARD_ID): Dashboard => ({
 
 const ADD_TO_DASHBOARD_BUTTON_NAME = /add to dashboard/i;
 
+interface PickerDashboard {
+	id: string;
+	title: string;
+}
+
+/**
+ * Describes one dashboard-API contract (V1 or V2) the export dialog can run
+ * against: the feature flags that select it, plus helpers that register the
+ * matching MSW handlers so the same test body exercises either path.
+ */
+interface ExportVariant {
+	name: string;
+	featureFlags: typeof defaultFeatureFlags;
+	/** Register the "list dashboards" endpoint the picker reads. */
+	mockDashboardList: (dashboards: PickerDashboard[]) => void;
+	/**
+	 * Register the "create dashboard" endpoint the "New dashboard" button hits.
+	 * Returns the title `onExport` should receive for the created dashboard.
+	 */
+	mockCreateDashboard: (id: string) => { expectedTitle: string };
+}
+
+const v1Variant: ExportVariant = {
+	name: 'V1',
+	featureFlags: defaultFeatureFlags,
+	mockDashboardList: (dashboards): void => {
+		server.use(
+			rest.get(V1_DASHBOARDS_ENDPOINT, (_req, res, ctx) =>
+				res(
+					ctx.status(200),
+					ctx.json({
+						data: dashboards.map(({ id, title }) => {
+							const dashboard = createMockDashboard(id);
+							dashboard.data.title = title;
+							return dashboard;
+						}),
+					}),
+				),
+			),
+		);
+	},
+	mockCreateDashboard: (id): { expectedTitle: string } => {
+		const dashboard = createMockDashboard(id);
+		server.use(
+			rest.post(V1_DASHBOARDS_ENDPOINT, (_req, res, ctx) =>
+				res(ctx.status(200), ctx.json({ data: dashboard })),
+			),
+		);
+		return { expectedTitle: dashboard.data.title ?? '' };
+	},
+};
+
+const v2Variant: ExportVariant = {
+	name: 'V2',
+	featureFlags: featureFlagsWithDashboardV2,
+	mockDashboardList: (dashboards): void => {
+		server.use(
+			rest.get(V2_LIST_ENDPOINT, (_req, res, ctx) =>
+				res(
+					ctx.status(200),
+					ctx.json({
+						status: 'success',
+						data: {
+							dashboards: dashboards.map(({ id, title }) => ({
+								id,
+								name: title,
+								spec: { display: { name: title } },
+							})),
+							reservedKeywords: [],
+						},
+					}),
+				),
+			),
+		);
+	},
+	mockCreateDashboard: (id): { expectedTitle: string } => {
+		server.use(
+			rest.post(V2_CREATE_ENDPOINT, (_req, res, ctx) =>
+				res(ctx.status(201), ctx.json({ status: 'success', data: { id } })),
+			),
+		);
+		return { expectedTitle: NEW_V2_DASHBOARD_TITLE };
+	},
+};
+
+const exportVariants: ExportVariant[] = [v1Variant, v2Variant];
+
 // Helper function to render component with props
 const renderExplorerOptionWrapper = (
 	overrides = {},
+	featureFlags: typeof defaultFeatureFlags = defaultFeatureFlags,
 ): ReturnType<typeof render> => {
 	const props = {
 		disabled: false,
@@ -104,6 +220,8 @@ const renderExplorerOptionWrapper = (
 			splitedQueries={props.splitedQueries}
 			signalSource={props.signalSource}
 		/>,
+		undefined,
+		{ appContextOverrides: { featureFlags } },
 	);
 };
 
@@ -146,249 +264,238 @@ describe('ExplorerOptionWrapper', () => {
 		expect(params.has('compositeQuery')).toBe(true);
 	});
 
-	describe('onExport functionality', () => {
-		it('should call onExport when New Dashboard button is clicked in export modal', async () => {
-			const user = userEvent.setup({ pointerEventsCheck: 0 });
-			const testOnExport = jest.fn() as jest.MockedFunction<
-				(
-					dashboard: ExportDashboard | null,
-					isNewDashboard?: boolean,
-					queryToExport?: Query,
-				) => void
-			>;
+	describe.each(exportVariants)(
+		'onExport functionality [$name dashboards]',
+		({ featureFlags, mockDashboardList, mockCreateDashboard }) => {
+			it('should call onExport when New Dashboard button is clicked in export modal', async () => {
+				const user = userEvent.setup({ pointerEventsCheck: 0 });
+				const testOnExport = jest.fn() as jest.MockedFunction<
+					(
+						dashboard: ExportDashboard | null,
+						isNewDashboard?: boolean,
+						queryToExport?: Query,
+					) => void
+				>;
 
-			// Mock the dashboard creation API
-			const mockNewDashboard = createMockDashboard(NEW_DASHBOARD_ID);
-			server.use(
-				rest.post(DASHBOARDS_API_ENDPOINT, (_req, res, ctx) =>
-					res(ctx.status(200), ctx.json({ data: mockNewDashboard })),
-				),
-			);
+				// Mock the dashboard creation API for the active contract.
+				const { expectedTitle } = mockCreateDashboard(NEW_DASHBOARD_ID);
 
-			renderExplorerOptionWrapper({
-				onExport: testOnExport,
-			});
+				renderExplorerOptionWrapper({ onExport: testOnExport }, featureFlags);
 
-			// Find and click the "Add to Dashboard" button
-			const addToDashboardButton = screen.getByRole('button', {
-				name: ADD_TO_DASHBOARD_BUTTON_NAME,
-			});
-			await user.click(addToDashboardButton);
+				// Find and click the "Add to Dashboard" button
+				const addToDashboardButton = screen.getByRole('button', {
+					name: ADD_TO_DASHBOARD_BUTTON_NAME,
+				});
+				await user.click(addToDashboardButton);
 
-			// Wait for the export modal to appear
-			await waitFor(() => {
-				expect(screen.getByRole('dialog')).toBeInTheDocument();
-			});
-
-			// Click the "New dashboard" button
-			const newDashboardButton = screen.getByTestId('export-panel-new-dashboard');
-			await user.click(newDashboardButton);
-
-			// Wait for the API call to complete and onExport to be called
-			await waitFor(() => {
-				expect(testOnExport).toHaveBeenCalledWith(
-					{ id: NEW_DASHBOARD_ID, title: TEST_DASHBOARD_TITLE },
-					true,
-				);
-			});
-		});
-
-		it('should call onExport when selecting existing dashboard and clicking Export button', async () => {
-			const user = userEvent.setup({ pointerEventsCheck: 0 });
-			const testOnExport = jest.fn() as jest.MockedFunction<
-				(
-					dashboard: ExportDashboard | null,
-					isNewDashboard?: boolean,
-					queryToExport?: Query,
-				) => void
-			>;
-
-			// Mock existing dashboards with unique titles
-			const mockDashboard1 = createMockDashboard('dashboard-1');
-			mockDashboard1.data.title = 'Dashboard 1';
-			const mockDashboard2 = createMockDashboard('dashboard-2');
-			mockDashboard2.data.title = 'Dashboard 2';
-			const mockDashboards = [mockDashboard1, mockDashboard2];
-
-			server.use(
-				rest.get(DASHBOARDS_API_ENDPOINT, (_req, res, ctx) =>
-					res(ctx.status(200), ctx.json({ data: mockDashboards })),
-				),
-			);
-
-			renderExplorerOptionWrapper({
-				onExport: testOnExport,
-			});
-
-			// Find and click the "Add to Dashboard" button
-			const addToDashboardButton = screen.getByRole('button', {
-				name: ADD_TO_DASHBOARD_BUTTON_NAME,
-			});
-			await user.click(addToDashboardButton);
-
-			// Wait for the export modal to appear
-			await waitFor(() => {
-				expect(screen.getByRole('dialog')).toBeInTheDocument();
-			});
-
-			// Wait for the dashboard select dropdown to render inside the dialog
-			const modal = screen.getByRole('dialog');
-			await waitFor(() => {
-				expect(modal.querySelector('[role="combobox"]')).toBeTruthy();
-			});
-
-			const dashboardSelect = modal.querySelector(
-				'[role="combobox"]',
-			) as HTMLElement;
-			expect(dashboardSelect).toBeInTheDocument();
-			await user.click(dashboardSelect);
-
-			// Wait for the dropdown options to appear and select the first dashboard
-			await waitFor(() => {
-				expect(screen.getByText(mockDashboard1.data.title)).toBeInTheDocument();
-			});
-
-			// Click on the first dashboard option
-			const dashboardOption = screen.getByText(mockDashboard1.data.title);
-			await user.click(dashboardOption);
-
-			// Wait for the selection to be made and the export button to be enabled
-			await waitFor(() => {
-				expect(screen.getByTestId('export-panel-export')).not.toBeDisabled();
-			});
-
-			// Click the export button
-			const exportButton = screen.getByTestId('export-panel-export');
-			await user.click(exportButton);
-
-			// Wait for onExport to be called with the selected dashboard
-			await waitFor(() => {
-				expect(testOnExport).toHaveBeenCalledWith(
-					{ id: 'dashboard-1', title: 'Dashboard 1' },
-					false,
-				);
-			});
-		});
-
-		it('should test actual handleExport function with generateExportToDashboardLink and verify useUpdateDashboard is NOT called', async () => {
-			const user = userEvent.setup({ pointerEventsCheck: 0 });
-
-			// Mock the safeNavigate function
-			const mockSafeNavigate = jest.fn();
-
-			// Get the mock mutate function to track calls
-			const mockMutate = mockUseUpdateDashboard().mutate as jest.MockedFunction<
-				(...args: unknown[]) => void
-			>;
-
-			const panelTypeParam = PANEL_TYPES.TIME_SERIES;
-			const widgetId = v4();
-			const query = mockQuery;
-
-			// Create a real handleExport function similar to LogsExplorerViews
-			// This should NOT call useUpdateDashboard (as per PR #8029)
-			const handleExport = (dashboard: ExportDashboard | null): void => {
-				if (!dashboard) {
-					return;
-				}
-
-				// Call the actual generateExportToDashboardLink function (not mocked)
-				const dashboardEditView = generateExportToDashboardLink({
-					query,
-					panelType: panelTypeParam,
-					dashboardId: dashboard.id,
-					widgetId,
+				// Wait for the export modal to appear
+				await waitFor(() => {
+					expect(screen.getByRole('dialog')).toBeInTheDocument();
 				});
 
-				// Simulate navigation
-				mockSafeNavigate(dashboardEditView);
-			};
+				// Click the "New dashboard" button
+				const newDashboardButton = screen.getByTestId('export-panel-new-dashboard');
+				await user.click(newDashboardButton);
 
-			// Mock existing dashboards
-			const mockDashboard = createMockDashboard('test-dashboard-id');
-			mockDashboard.data.title = TEST_DASHBOARD_TITLE_2;
-
-			server.use(
-				rest.get(DASHBOARDS_API_ENDPOINT, (_req, res, ctx) =>
-					res(ctx.status(200), ctx.json({ data: [mockDashboard] })),
-				),
-			);
-
-			renderExplorerOptionWrapper({
-				onExport: handleExport,
+				// Wait for the API call to complete and onExport to be called
+				await waitFor(() => {
+					expect(testOnExport).toHaveBeenCalledWith(
+						{ id: NEW_DASHBOARD_ID, title: expectedTitle },
+						true,
+					);
+				});
 			});
 
-			// Find and click the "Add to Dashboard" button
-			const addToDashboardButton = screen.getByRole('button', {
-				name: ADD_TO_DASHBOARD_BUTTON_NAME,
+			it('should call onExport when selecting existing dashboard and clicking Export button', async () => {
+				const user = userEvent.setup({ pointerEventsCheck: 0 });
+				const testOnExport = jest.fn() as jest.MockedFunction<
+					(
+						dashboard: ExportDashboard | null,
+						isNewDashboard?: boolean,
+						queryToExport?: Query,
+					) => void
+				>;
+
+				// Mock existing dashboards with unique titles
+				const dashboards: PickerDashboard[] = [
+					{ id: 'dashboard-1', title: 'Dashboard 1' },
+					{ id: 'dashboard-2', title: 'Dashboard 2' },
+				];
+				mockDashboardList(dashboards);
+
+				renderExplorerOptionWrapper({ onExport: testOnExport }, featureFlags);
+
+				// Find and click the "Add to Dashboard" button
+				const addToDashboardButton = screen.getByRole('button', {
+					name: ADD_TO_DASHBOARD_BUTTON_NAME,
+				});
+				await user.click(addToDashboardButton);
+
+				// Wait for the export modal to appear
+				await waitFor(() => {
+					expect(screen.getByRole('dialog')).toBeInTheDocument();
+				});
+
+				// Wait for the dashboard select to render AND finish loading. antd
+				// disables the Select while the list request is in flight, and a click
+				// on a disabled combobox is a no-op — so sync on the ready (enabled)
+				// state before clicking.
+				const modal = screen.getByRole('dialog');
+				await waitFor(() => {
+					const combobox = modal.querySelector('[role="combobox"]');
+					expect(combobox).toBeTruthy();
+					expect(combobox).not.toBeDisabled();
+				});
+
+				const dashboardSelect = modal.querySelector(
+					'[role="combobox"]',
+				) as HTMLElement;
+				expect(dashboardSelect).toBeInTheDocument();
+				await user.click(dashboardSelect);
+
+				// Wait for the dropdown options to appear and select the first dashboard
+				await waitFor(() => {
+					expect(screen.getByText(dashboards[0].title)).toBeInTheDocument();
+				});
+
+				// Click on the first dashboard option
+				const dashboardOption = screen.getByText(dashboards[0].title);
+				await user.click(dashboardOption);
+
+				// Wait for the selection to be made and the export button to be enabled
+				await waitFor(() => {
+					expect(screen.getByTestId('export-panel-export')).not.toBeDisabled();
+				});
+
+				// Click the export button
+				const exportButton = screen.getByTestId('export-panel-export');
+				await user.click(exportButton);
+
+				// Wait for onExport to be called with the selected dashboard
+				await waitFor(() => {
+					expect(testOnExport).toHaveBeenCalledWith(
+						{ id: dashboards[0].id, title: dashboards[0].title },
+						false,
+					);
+				});
 			});
-			await user.click(addToDashboardButton);
 
-			// Wait for the export modal to appear
-			await waitFor(() => {
-				expect(screen.getByRole('dialog')).toBeInTheDocument();
+			it('should test actual handleExport function with generateExportToDashboardLink and verify useUpdateDashboard is NOT called', async () => {
+				const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+				// Mock the safeNavigate function
+				const mockSafeNavigate = jest.fn();
+
+				// Get the mock mutate function to track calls
+				const mockMutate = mockUseUpdateDashboard().mutate as jest.MockedFunction<
+					(...args: unknown[]) => void
+				>;
+
+				const panelTypeParam = PANEL_TYPES.TIME_SERIES;
+				const widgetId = v4();
+				const query = mockQuery;
+
+				// Create a real handleExport function similar to LogsExplorerViews
+				// This should NOT call useUpdateDashboard (as per PR #8029)
+				const handleExport = (dashboard: ExportDashboard | null): void => {
+					if (!dashboard) {
+						return;
+					}
+
+					// Call the actual generateExportToDashboardLink function (not mocked)
+					const dashboardEditView = generateExportToDashboardLink({
+						query,
+						panelType: panelTypeParam,
+						dashboardId: dashboard.id,
+						widgetId,
+					});
+
+					// Simulate navigation
+					mockSafeNavigate(dashboardEditView);
+				};
+
+				// Mock existing dashboards
+				const dashboards: PickerDashboard[] = [
+					{ id: TEST_DASHBOARD_ID, title: TEST_DASHBOARD_TITLE_2 },
+				];
+				mockDashboardList(dashboards);
+
+				renderExplorerOptionWrapper({ onExport: handleExport }, featureFlags);
+
+				// Find and click the "Add to Dashboard" button
+				const addToDashboardButton = screen.getByRole('button', {
+					name: ADD_TO_DASHBOARD_BUTTON_NAME,
+				});
+				await user.click(addToDashboardButton);
+
+				// Wait for the export modal to appear
+				await waitFor(() => {
+					expect(screen.getByRole('dialog')).toBeInTheDocument();
+				});
+
+				// Wait for the dashboard select to render AND finish loading (see note above).
+				const modal = screen.getByRole('dialog');
+				await waitFor(() => {
+					const combobox = modal.querySelector('[role="combobox"]');
+					expect(combobox).toBeTruthy();
+					expect(combobox).not.toBeDisabled();
+				});
+
+				const dashboardSelect = modal.querySelector(
+					'[role="combobox"]',
+				) as HTMLElement;
+				expect(dashboardSelect).toBeInTheDocument();
+				await user.click(dashboardSelect);
+
+				// Wait for the dropdown options to appear and select the dashboard
+				await waitFor(() => {
+					expect(screen.getByText(dashboards[0].title)).toBeInTheDocument();
+				});
+
+				// Click on the dashboard option
+				const dashboardOption = screen.getByText(dashboards[0].title);
+				await user.click(dashboardOption);
+
+				// Wait for the selection to be made and the export button to be enabled
+				await waitFor(() => {
+					expect(screen.getByTestId('export-panel-export')).not.toBeDisabled();
+				});
+
+				// Click the export button
+				const exportButton = screen.getByTestId('export-panel-export');
+				await user.click(exportButton);
+
+				// Wait for the handleExport function to be called and navigation to occur
+				await waitFor(() => {
+					expect(mockSafeNavigate).toHaveBeenCalledTimes(1);
+					expect(mockSafeNavigate).toHaveBeenCalledWith(
+						`/dashboard/${TEST_DASHBOARD_ID}/new?graphType=${panelTypeParam}&widgetId=${widgetId}&compositeQuery=${encodeURIComponent(
+							JSON.stringify(query),
+						)}`,
+					);
+				});
+
+				// Assert that useUpdateDashboard was NOT called (as per PR #8029)
+				expect(mockMutate).not.toHaveBeenCalled();
 			});
+		},
+	);
 
-			// Wait for the dashboard select dropdown to render inside the dialog
-			const modal = screen.getByRole('dialog');
-			await waitFor(() => {
-				expect(modal.querySelector('[role="combobox"]')).toBeTruthy();
-			});
+	it('should not show export buttons when component is disabled', () => {
+		const testOnExport = jest.fn() as jest.MockedFunction<
+			(
+				dashboard: ExportDashboard | null,
+				isNewDashboard?: boolean,
+				queryToExport?: Query,
+			) => void
+		>;
 
-			const dashboardSelect = modal.querySelector(
-				'[role="combobox"]',
-			) as HTMLElement;
-			expect(dashboardSelect).toBeInTheDocument();
-			await user.click(dashboardSelect);
+		renderExplorerOptionWrapper({ disabled: true, onExport: testOnExport });
 
-			// Wait for the dropdown options to appear and select the dashboard
-			await waitFor(() => {
-				expect(screen.getByText(mockDashboard.data.title)).toBeInTheDocument();
-			});
-
-			// Click on the dashboard option
-			const dashboardOption = screen.getByText(mockDashboard.data.title);
-			await user.click(dashboardOption);
-
-			// Wait for the selection to be made and the export button to be enabled
-			await waitFor(() => {
-				expect(screen.getByTestId('export-panel-export')).not.toBeDisabled();
-			});
-
-			// Click the export button
-			const exportButton = screen.getByTestId('export-panel-export');
-			await user.click(exportButton);
-
-			// Wait for the handleExport function to be called and navigation to occur
-			await waitFor(() => {
-				expect(mockSafeNavigate).toHaveBeenCalledTimes(1);
-				expect(mockSafeNavigate).toHaveBeenCalledWith(
-					`/dashboard/test-dashboard-id/new?graphType=${panelTypeParam}&widgetId=${widgetId}&compositeQuery=${encodeURIComponent(
-						JSON.stringify(query),
-					)}`,
-				);
-			});
-
-			// Assert that useUpdateDashboard was NOT called (as per PR #8029)
-			expect(mockMutate).not.toHaveBeenCalled();
+		// The "Add to Dashboard" button should be disabled
+		const addToDashboardButton = screen.getByRole('button', {
+			name: ADD_TO_DASHBOARD_BUTTON_NAME,
 		});
-
-		it('should not show export buttons when component is disabled', () => {
-			const testOnExport = jest.fn() as jest.MockedFunction<
-				(
-					dashboard: ExportDashboard | null,
-					isNewDashboard?: boolean,
-					queryToExport?: Query,
-				) => void
-			>;
-
-			renderExplorerOptionWrapper({ disabled: true, onExport: testOnExport });
-
-			// The "Add to Dashboard" button should be disabled
-			const addToDashboardButton = screen.getByRole('button', {
-				name: ADD_TO_DASHBOARD_BUTTON_NAME,
-			});
-			expect(addToDashboardButton).toBeDisabled();
-		});
+		expect(addToDashboardButton).toBeDisabled();
 	});
 });


### PR DESCRIPTION
## Summary

`ExplorerOptionWrapper`'s "Add to dashboard" export tests were failing in CI. The export dialog is **flag-aware** (`use_dashboard_v2`): the V1 path calls `/api/v1/dashboards`, while V2 calls the generated Perses-spec endpoints `GET /api/v2/users/me/dashboards` (list) and `POST /api/v2/dashboards` (create), and their response shapes differ (`spec.display.name`, nested `data.dashboards`, create `data.id`).

The tests only mocked the **V1** endpoints and only ever ran the V1 path (the flag is off in the default test context), so the V2 contract was never exercised — and when the component takes the V2 path the V1 mocks are never hit, leaving the picker empty / `onExport` uncalled.

## What changed

- **Parametrized the `onExport` tests over the `use_dashboard_v2` flag** (`describe.each`): each runs once with the flag off (V1 endpoints/shapes) and once with it on (V2 endpoints/shapes), mocking and asserting per contract. The flag is injected via `appContextOverrides.featureFlags`.
- Per-path MSW handlers via small `ExportVariant` helpers, so the same test body covers either contract and the suite can't silently drift if the default flips.
- Sync on the picker's **enabled (loaded)** state before clicking the combobox — antd disables the Select while the list request is in flight, and a click on a disabled combobox is a no-op (the root cause of the flaky/empty-dropdown failures). This is a ready-state sync, not a timeout bump.

Closes https://github.com/SigNoz/pulse-pod/issues/149

## Test plan

- `jest src/container/ExplorerOptions/__tests__/ExplorerOptionWrapper.test.tsx` → **8/8 pass** (V1 + V2 variants), stable across repeated runs.
- Confirmed the V2 variant genuinely hits `/api/v2/...` (assertions derive from V2 response shapes).
- oxlint clean; tsgo introduces no new errors for this file.