### PR TITLE
fix(alertmanager): update notification title link from /alerts/edit to /alerts/overview

### DIFF
--- a/pkg/types/alertmanagertypes/template.go
+++ b/pkg/types/alertmanagertypes/template.go
@@ -42,7 +42,7 @@ func FromGlobs(paths []string) (*alertmanagertemplate.Template, error) {
 	}
 
 	if err := t.Parse(bytes.NewReader([]byte(`
-	{{ define "__ruleIdPath" }}{{- $isTestAlert := "" -}}{{- range .CommonLabels.SortedPairs -}}{{- if eq .Name "testalert" -}}{{- if eq .Value "true" -}}{{- $isTestAlert = "true" -}}{{- end -}}{{- end -}}{{- end -}}{{- range .CommonLabels.SortedPairs -}}{{- if eq .Name "ruleId" -}}{{- if ne .Value "" -}}/edit?ruleId={{ .Value | urlescape }}{{- if $isTestAlert -}}&isTestAlert=true{{- end -}}{{- end -}}{{- end -}}{{- end -}}{{- end }}
+	{{ define "__ruleIdPath" }}{{- $isTestAlert := "" -}}{{- range .CommonLabels.SortedPairs -}}{{- if eq .Name "testalert" -}}{{- if eq .Value "true" -}}{{- $isTestAlert = "true" -}}{{- end -}}{{- end -}}{{- end -}}{{- range .CommonLabels.SortedPairs -}}{{- if eq .Name "ruleId" -}}{{- if ne .Value "" -}}/overview?ruleId={{ .Value | urlescape }}{{- if $isTestAlert -}}&isTestAlert=true{{- end -}}{{- end -}}{{- end -}}{{- end -}}{{- end }}
 	{{ define "__alertmanagerURL" }}{{ .ExternalURL }}/alerts{{ template "__ruleIdPath" . }}{{ end }}
 	{{ define "msteamsv2.default.titleLink" }}{{ template "__alertmanagerURL" . }}{{ end }}
 	`))); err != nil {

--- a/pkg/types/alertmanagertypes/template_test.go
+++ b/pkg/types/alertmanagertypes/template_test.go
@@ -34,7 +34,7 @@ func TestFromGlobs(t *testing.T) {
 					Timeout:   false,
 				},
 			},
-			expected: "http://localhost:8080/alerts/edit?ruleId=01961575-461c-7668-875f-05d374062bfc",
+			expected: "http://localhost:8080/alerts/overview?ruleId=01961575-461c-7668-875f-05d374062bfc",
 		},
 		{
 			name: "SingleAlertWithValidRuleUUIDv4",
@@ -49,7 +49,7 @@ func TestFromGlobs(t *testing.T) {
 					Timeout:   false,
 				},
 			},
-			expected: "http://localhost:8080/alerts/edit?ruleId=2d8edca5-4f24-4266-afd1-28cefadcfa88",
+			expected: "http://localhost:8080/alerts/overview?ruleId=2d8edca5-4f24-4266-afd1-28cefadcfa88",
 		},
 		{
 			name: "MultipleAlertsWithMismatchingRuleId",
@@ -97,7 +97,7 @@ func TestFromGlobs(t *testing.T) {
 					Timeout:   false,
 				},
 			},
-			expected: "http://localhost:8080/alerts/edit?ruleId=01961575-461c-7668-875f-05d374062bfc",
+			expected: "http://localhost:8080/alerts/overview?ruleId=01961575-461c-7668-875f-05d374062bfc",
 		},
 		{
 			name: "MultipleAlertsWithNoRuleId",
@@ -152,7 +152,7 @@ func TestFromGlobs(t *testing.T) {
 					Timeout:   false,
 				},
 			},
-			expected: "http://localhost:8080/alerts/edit?ruleId=01961575-461c-7668-875f-05d374062bfc&isTestAlert=true",
+			expected: "http://localhost:8080/alerts/overview?ruleId=01961575-461c-7668-875f-05d374062bfc&isTestAlert=true",
 		},
 		{
 			name: "TestAlertWithRuleIdWithSpacesAndSymbol",
@@ -168,7 +168,7 @@ func TestFromGlobs(t *testing.T) {
 					Timeout:   false,
 				},
 			},
-			expected: "http://localhost:8080/alerts/edit?ruleId=Prom+%2B+Alert+%26+Rule&isTestAlert=true",
+			expected: "http://localhost:8080/alerts/overview?ruleId=Prom+%2B+Alert+%26+Rule&isTestAlert=true",
 		},
 		{
 			name: "AlertWithBlankRuleId",


### PR DESCRIPTION
## Pull Request

---

### Summary

Notification title links (Slack, MS Teams, and any receiver using the default title-link template) were pointing to <ExternalURL>/alerts/edit?ruleId=<id>. The rule-detail page was moved to /alerts/overview in PR #11413, but the notification title-link template was never updated, causing 404 errors when users click notification links.

#### Issues closed by this PR
Closes #12247

---

### Change Type

- [x] Bug fix

---

### Bug Context

#### Root Cause
The __ruleIdPath template in pkg/types/alertmanagertypes/template.go hardcoded /edit?ruleId= in the generated notification title links. When PR #11413 moved the rule-detail page from /alerts/edit to /alerts/overview and updated ase_rule.go to use the new path, the alertmanager notification template was overlooked.

#### Fix Strategy
Changed /edit?ruleId= to /overview?ruleId= in the __ruleIdPath Go template definition. This aligns the notification title links with:
- ase_rule.go:253 which uses .ExternalURL(alerts/overview, params)
- Frontend route ALERT_OVERVIEW = '/alerts/overview' in constants/routes.ts

---

### Testing Strategy

- Tests updated: All 5 test cases in TestFromGlobs that assert uleId-bearing URLs were updated from /alerts/edit to /alerts/overview
- The MultipleAlertsWithMismatchingRuleId, MultipleAlertsWithNoRuleId, TestAlertWithNoRuleId, and AlertWithBlankRuleId cases (no ruleId path) remain unaffected
- Edge cases covered: UUIDs, URL-encoded characters, test alerts with &isTestAlert=true parameter

---

### Risk & Impact Assessment

- Blast radius: Only affects notification title links (Slack, MS Teams, email templates) — not API behavior or UI rendering
- Potential regressions: None — this is a one-word change that aligns with the existing frontend route and ase_rule.go source URL
- Rollback plan: Revert the single commit

---

### Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fix notification title links to use /alerts/overview instead of the stale /alerts/edit path |

---

### Checklist
- [x] Tests updated
- [x] Backward compatibility considered