### PR TITLE
fix(infra-hosts): show table spinner during sort and pagination refetch

### DIFF
--- a/frontend/src/container/InfraMonitoringHosts/HostsListTable.tsx
+++ b/frontend/src/container/InfraMonitoringHosts/HostsListTable.tsx
@@ -227,7 +227,7 @@ export default function HostsListTable({
 			}}
 			scroll={{ x: true }}
 			loading={{
-				spinning: showTableLoadingState,
+				spinning: isFetching || isLoading,
 				indicator: <Spin indicator={<LoadingOutlined size={14} spin />} />,
 			}}
 			tableLayout="fixed"


### PR DESCRIPTION
The `Table`'s `loading.spinning` was gated on `showTableLoadingState`, which required `formattedHostMetricsData.length === 0`. This meant the spinner only fired on initial load — during sort or pagination refetches where existing data is cached, `isFetching` is `true` but `length > 0`, so `showTableLoadingState` stayed `false`. The table updated silently with no visual feedback.

The `EmptyOrLoadingView` Skeleton already handles the initial-load path and short-circuits before the `Table` renders, so the existing data-clear at `dataSource` is unaffected. Changing `spinning` to use `isFetching || isLoading` directly ensures the native Ant Design spinner fires on every active fetch, not just the first one.

Fixes #6980