### PR TITLE
fix(query-builder): drop empty having from V5 query payload (V2 panel dirty-on-load)

### DIFF
--- a/frontend/src/api/v5/queryRange/prepareQueryRangePayloadV5.test.ts
+++ b/frontend/src/api/v5/queryRange/prepareQueryRangePayloadV5.test.ts
@@ -18,7 +18,10 @@ import {
 import { EQueryType } from 'types/common/dashboard';
 import { DataSource, ReduceOperators } from 'types/common/queryBuilder';
 
-import { prepareQueryRangePayloadV5 } from './prepareQueryRangePayloadV5';
+import {
+	convertBuilderQueriesToV5,
+	prepareQueryRangePayloadV5,
+} from './prepareQueryRangePayloadV5';
 
 jest.mock('lib/getStartEndRangeTime', () => ({
 	__esModule: true,
@@ -897,5 +900,38 @@ describe('prepareQueryRangePayloadV5', () => {
 		) as QueryEnvelope;
 		const logSpec = builderQuery.spec as LogBuilderQuery;
 		expect(logSpec.filter).toStrictEqual({ expression: '' });
+	});
+});
+
+describe('convertBuilderQueriesToV5 having normalization', () => {
+	const buildSpec = (having: unknown): MetricBuilderQuery => {
+		const [envelope] = convertBuilderQueriesToV5(
+			{
+				A: {
+					dataSource: DataSource.METRICS,
+					queryName: 'A',
+					aggregations: [{ metricName: 'm', spaceAggregation: 'p99' }],
+					having,
+				} as unknown as IBuilderQuery,
+			},
+			'time_series',
+			PANEL_TYPES.TIME_SERIES,
+		);
+		return envelope.spec as MetricBuilderQuery;
+	};
+
+	it.each([
+		['a legacy V4 array', []],
+		['a blank empty-object having', { expression: '' }],
+		['a whitespace-only having', { expression: '   ' }],
+		['a nullish having', undefined],
+	])('drops %s (serializes to undefined)', (_label, having) => {
+		expect(buildSpec(having).having).toBeUndefined();
+	});
+
+	it('preserves a real having expression', () => {
+		expect(buildSpec({ expression: 'count() > 5' }).having).toStrictEqual({
+			expression: 'count() > 5',
+		});
 	});
 });

--- a/frontend/src/api/v5/queryRange/prepareQueryRangePayloadV5.ts
+++ b/frontend/src/api/v5/queryRange/prepareQueryRangePayloadV5.ts
@@ -134,6 +134,21 @@ function getFilter(queryData: IBuilderQuery): Filter {
 	};
 }
 
+/**
+ * Normalizes a builder query's `having` to the V5 shape, treating "no having filter" as absent.
+ * V4 stored it as an array; V5 expects `{ expression }`. An array (legacy), a nullish value, or a
+ * blank expression — the query builder seeds `{ expression: '' }` for an empty having — all mean
+ * "no having" and must serialize to `undefined`. Emitting an empty `{ expression: '' }` sends a
+ * no-op filter and, because a saved panel never carries one, reads an untouched panel as dirty.
+ */
+function normalizeHaving(having: unknown): Having | undefined {
+	if (having == null || Array.isArray(having)) {
+		return undefined;
+	}
+	const { expression } = having as Having;
+	return expression?.trim() ? (having as Having) : undefined;
+}
+
 function createBaseSpec(
 	queryData: IBuilderQuery,
 	requestType: RequestType,
@@ -181,12 +196,7 @@ function createBaseSpec(
 					)
 				: undefined,
 		legend: isEmpty(queryData.legend) ? undefined : queryData.legend,
-		// V4 uses having as array, V5 uses having as object with expression field
-		// If having is an array (V4 format), treat it as undefined for V5
-		having:
-			isEmpty(queryData.having) || Array.isArray(queryData.having)
-				? undefined
-				: (queryData?.having as Having),
+		having: normalizeHaving(queryData.having),
 		functions: isEmpty(queryData.functions)
 			? undefined
 			: queryData.functions.map((func: QueryFunction): QueryFunction => {
@@ -414,10 +424,7 @@ function createTraceOperatorBaseSpec(
 					)
 				: undefined,
 		legend: isEmpty(legend) ? undefined : legend,
-		// V4 uses having as array, V5 uses having as object with expression field
-		// If having is an array (V4 format), treat it as undefined for V5
-		having:
-			isEmpty(having) || Array.isArray(having) ? undefined : (having as Having),
+		having: normalizeHaving(having),
 		selectFields: isEmpty(nonEmptySelectColumns)
 			? undefined
 			: nonEmptySelectColumns?.map(

--- a/frontend/src/components/DownloadOptionsMenu/DownloadOptionsMenu.test.tsx
+++ b/frontend/src/components/DownloadOptionsMenu/DownloadOptionsMenu.test.tsx
@@ -213,7 +213,9 @@ describe.each([
 			const callArgs = mockDownloadExportData.mock.calls[0][0];
 			const query = callArgs.body.compositeQuery.queries[0];
 			expect(query.spec.groupBy).toBeUndefined();
-			expect(query.spec.having).toStrictEqual({ expression: '' });
+			// An empty having ({ expression: '' }) is a no-op filter and serializes to
+			// undefined — same as the cleared groupBy above.
+			expect(query.spec.having).toBeUndefined();
 		});
 	});
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/usePanelEditorQuerySync.integration.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/usePanelEditorQuerySync.integration.test.tsx
@@ -9,7 +9,7 @@ import type { Query } from 'types/api/queryBuilder/queryBuilderData';
 import { DataSource } from 'types/common/queryBuilder';
 import { AllTheProviders } from 'tests/test-utils';
 
-import { toPerses } from '../../../queryV5/persesQueryAdapters';
+import { fromPerses, toPerses } from '../../../queryV5/persesQueryAdapters';
 import { usePanelEditorQuerySync } from '../usePanelEditorQuerySync';
 
 // Exercises the REAL query builder provider (not mocks) so the dirty check is
@@ -43,6 +43,28 @@ function makePanel(queries: DashboardtypesQueryDTO[]): DashboardtypesPanelDTO {
 			queries,
 		},
 	} as unknown as DashboardtypesPanelDTO;
+}
+
+/** Providers whose URL already carries `query` as the compositeQuery param (a mid-edit refresh). */
+function makeUrlWrapper(
+	query: Query,
+): ({ children }: { children: React.ReactNode }) => JSX.Element {
+	const params = new URLSearchParams();
+	params.set(
+		QueryParams.compositeQuery,
+		encodeURIComponent(JSON.stringify(query)),
+	);
+	return function UrlWrapper({
+		children,
+	}: {
+		children: React.ReactNode;
+	}): JSX.Element {
+		return (
+			<AllTheProviders initialRoute={`/?${params.toString()}`}>
+				{children}
+			</AllTheProviders>
+		);
+	};
 }
 
 describe('usePanelEditorQuerySync (real query builder)', () => {
@@ -112,6 +134,80 @@ describe('usePanelEditorQuerySync (real query builder)', () => {
 		expect(result.current.isQueryDirty).toBe(false);
 	});
 
+	it('a saved panel with no `having` is NOT dirty on mount (builder seeds an empty having)', async () => {
+		// Reproduces the reported bug: a panel saved as a bare signoz/BuilderQuery that never
+		// carried a `having`. On editor open the builder hydrates from the URL and
+		// prepareQueryBuilderData seeds an empty `{ expression: '' }`, so a verbatim envelope
+		// compare flags the untouched panel as dirty. Seed via the URL (not resetQuery) so the
+		// hydration path that synthesizes the having actually runs.
+		const savedNoHaving: DashboardtypesQueryDTO[] = [
+			{
+				kind: 'time_series',
+				spec: {
+					name: 'A',
+					plugin: {
+						kind: 'signoz/BuilderQuery',
+						spec: {
+							name: 'A',
+							signal: 'metrics',
+							source: '',
+							aggregations: [
+								{
+									metricName: 'signoz_latency.bucket',
+									temporality: 'delta',
+									timeAggregation: '',
+									spaceAggregation: 'p99',
+								},
+							],
+							disabled: false,
+							filter: { expression: 'service.name IN $service_name' },
+							groupBy: [
+								{
+									name: 'service.name',
+									signal: '',
+									fieldContext: 'resource',
+									fieldDataType: '',
+								},
+							],
+							order: [
+								{
+									key: {
+										name: '__result',
+										signal: '',
+										fieldContext: '',
+										fieldDataType: '',
+									},
+									direction: 'desc',
+								},
+							],
+							limit: 100,
+							legend: '',
+						},
+					},
+				},
+			},
+		] as unknown as DashboardtypesQueryDTO[];
+
+		// The editor puts the (having-less) seed query into the URL; the provider then hydrates
+		// from it, which is where the empty having is added.
+		const seededInUrl = fromPerses(savedNoHaving, panelType);
+
+		const { result } = renderHook(
+			() =>
+				usePanelEditorQuerySync({
+					draft: makePanel(savedNoHaving),
+					panelType,
+					setSpec: jest.fn(),
+					refetch: jest.fn(),
+					savedQueries: savedNoHaving,
+				}),
+			{ wrapper: makeUrlWrapper(seededInUrl) },
+		);
+
+		await waitFor(() => expect(result.current.isQueryDirty).toBe(false));
+		expect(result.current.isQueryDirty).toBe(false);
+	});
+
 	it('retains an in-editor query edit carried in the URL across a refresh (and reads dirty)', async () => {
 		// Simulate a refresh mid-edit: the saved panel is unchanged, but the URL still
 		// carries the last-run (edited) query. The builder must hydrate from the URL —
@@ -130,22 +226,7 @@ describe('usePanelEditorQuerySync (real query builder)', () => {
 				],
 			},
 		};
-		const params = new URLSearchParams();
-		params.set(
-			QueryParams.compositeQuery,
-			encodeURIComponent(JSON.stringify(editedInUrl)),
-		);
 		const setSpec = jest.fn();
-
-		const wrapper = ({
-			children,
-		}: {
-			children: React.ReactNode;
-		}): JSX.Element => (
-			<AllTheProviders initialRoute={`/?${params.toString()}`}>
-				{children}
-			</AllTheProviders>
-		);
 
 		const { result } = renderHook(
 			() =>
@@ -157,7 +238,7 @@ describe('usePanelEditorQuerySync (real query builder)', () => {
 					refetch: jest.fn(),
 					savedQueries: saved,
 				}),
-			{ wrapper },
+			{ wrapper: makeUrlWrapper(editedInUrl) },
 		);
 
 		// The URL edit is retained → dirty, and it's synced into the draft so the

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/components/PanelMessage/PanelMessage.module.scss
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/components/PanelMessage/PanelMessage.module.scss
@@ -1,16 +1,24 @@
+@use '../../../../../../styles/scrollbar' as *;
+
 // Centred, vertically-stacked panel state (no query / no data / error). Fills
-// the panel body below the header and centres its content both axes.
+// the panel body below the header and centres its content both axes. When the
+// panel is too small to fit icon + text + actions, it scrolls instead of
+// clipping the buttons at the edge (`safe center` keeps the top reachable).
 .message {
 	flex: 1;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	justify-content: center;
+	justify-content: safe center;
 	gap: 6px;
 	padding: 16px;
 	text-align: center;
 	min-height: 0;
 	min-width: 0;
+	overflow: auto;
+
+	// Match the shared panel scrollbar (chart legend, table/list panels).
+	@include custom-scrollbar;
 }
 
 // Muted glyph in a soft tinted disc so the icon reads as decorative chrome
@@ -51,4 +59,5 @@
 	justify-content: center;
 	gap: 8px;
 	margin-top: 8px;
+	max-width: 100%;
 }


### PR DESCRIPTION
This PR contains two independent fixes (see the two commits).

---

## 1. Empty `having` leaks into V5 payload → V2 panel dirty on load

### Problem
Opening a V2 dashboard panel in **edit mode** (or the **view modal**) marked an untouched panel as **dirty immediately on load** — "Save changes" lit up with no user edit. View mode was fine because it never runs the live-vs-saved comparison.

### Root cause
The dirty check compares the live query's V5 envelopes against the saved panel's. An **empty `having`** leaked into the live side but not the saved side:
1. `prepareQueryBuilderData` seeds every builder query with `having: []`.
2. On the URL round-trip, `useGetCompositeQueryParam` runs `convertHavingToExpression([])` → **`{ expression: "" }`**.
3. The V5 serializer (`createBaseSpec`) dropped an empty **array** having but let the empty **object** `{ expression: "" }` pass through.

A saved panel never carries a `having`, so `undefined` (saved) vs `{ expression: "" }` (live) never matched → dirty on load. Migrated panels (no `having`) hit this every time.

### Fix
A single `normalizeHaving` helper at the serializer treats a **blank / array / nullish** having as absent, at both emission sites (`createBaseSpec` + `createTraceOperatorBaseSpec`) — closing the gap in the ternary that already intended to drop empty having. No consumer-side wrapper, so the bad shape never leaves the serializer.

An empty `having` is a no-op filter, so query results, alert evaluation, and export contents are unchanged. The export payload now omits it consistently with the already-cleared `groupBy`.

### Blast radius (verified)
Shared by dashboards (V1/V2), alerts, exports, and explorers. The only change is dropping an *empty* having from the **outgoing** payload:
- No non-test code reads the payload's `having` (all `.having` reads are of input query-builder state / URL), so nothing derefs `undefined`.
- `having` is optional in the V5 schema; absent ≡ empty for the backend.
- ~1400 tests across every caller (dashboards V2, alerts V1 `FormAlertRules` + V2 `CreateAlertV2`, exports, explorers, grid, mappers) pass.

### Tests
- **Serializer unit coverage:** array / blank / whitespace / nullish having → `undefined`; a real having expression is preserved.
- **Panel-editor query-sync integration test:** an untouched no-having panel is **not** dirty on mount — confirmed to fail without the fix.
- **DownloadOptionsMenu:** assertion updated to the corrected (dropped) shape, matching the adjacent cleared-`groupBy` assertion.

> The separate "panel renders empty in edit/view mode" issue (empty inner query `name`) is being fixed on the backend and is not part of this PR.

---

## 2. Panel empty-state scrolls instead of clipping actions

When a panel is too small to fit the empty-state icon + text + action buttons (no query / no data / error), the centred column clipped the buttons at the panel edge and they became unreachable. The message column now scrolls (`overflow: auto`) with the shared panel scrollbar, uses `justify-content: safe center` so the top stays reachable on overflow, and caps the actions row at `max-width: 100%`.

#### Issues Closed
Closes https://github.com/SigNoz/pulse-pod/issues/148