### PR TITLE
fix(query-builder): fix query table sort

### DIFF
--- a/frontend/src/lib/query/__tests__/createTableColumnsFromQuery.test.ts
+++ b/frontend/src/lib/query/__tests__/createTableColumnsFromQuery.test.ts
@@ -1,0 +1,94 @@
+import {
+	compareTableColumnValues,
+	RowData,
+} from '../createTableColumnsFromQuery';
+
+// Builds a minimal RowData row. Values are intentionally loosely typed because
+// real query responses can put objects/arrays into cells despite RowData's
+// declared `string | number` index signature (that mismatch is the bug under test).
+const row = (value: unknown, dataIndex = 'col'): RowData =>
+	({
+		timestamp: 0,
+		key: 'k',
+		[dataIndex]: value,
+	}) as unknown as RowData;
+
+describe('compareTableColumnValues', () => {
+	it('sorts numerically when both cells are numbers', () => {
+		expect(compareTableColumnValues(row(1), row(2), 'col')).toBeLessThan(0);
+		expect(compareTableColumnValues(row(2), row(1), 'col')).toBeGreaterThan(0);
+		expect(compareTableColumnValues(row(5), row(5), 'col')).toBe(0);
+	});
+
+	it('sorts numeric-looking strings numerically, not lexically', () => {
+		// "10" vs "9": numeric branch => 10 - 9 > 0. A string compare would be < 0.
+		expect(compareTableColumnValues(row('10'), row('9'), 'col')).toBeGreaterThan(
+			0,
+		);
+	});
+
+	it('prefers the `<dataIndex>_without_unit` value for numeric comparison', () => {
+		const a = row('2 ms');
+		const b = row('10 ms');
+		a.col_without_unit = 2;
+		b.col_without_unit = 10;
+		expect(compareTableColumnValues(a, b, 'col')).toBeLessThan(0);
+	});
+
+	it('falls back to locale string compare for non-numeric strings', () => {
+		expect(compareTableColumnValues(row('abc'), row('abd'), 'col')).toBe(
+			'abc'.localeCompare('abd'),
+		);
+	});
+
+	it('treats null/undefined cells as empty string (no "null"/"undefined")', () => {
+		// Empty string sorts before a real word, and two empties are equal.
+		expect(compareTableColumnValues(row(null), row('a'), 'col')).toBeLessThan(0);
+		expect(compareTableColumnValues(row(undefined), row(undefined), 'col')).toBe(
+			0,
+		);
+		// If null coerced to the literal "null", this would sort after "a".
+		expect(
+			compareTableColumnValues(row(null), row('a'), 'col'),
+		).not.toBeGreaterThan(0);
+	});
+
+	it('does not throw when a cell value is an object', () => {
+		const a = row({ foo: 'bar' });
+		const b = row({ foo: 'baz' });
+		expect(() => compareTableColumnValues(a, b, 'col')).not.toThrow();
+		expect(typeof compareTableColumnValues(a, b, 'col')).toBe('number');
+	});
+
+	it('does not throw when a cell value is an array', () => {
+		const a = row([1, 2]);
+		const b = row([3, 4]);
+		expect(() => compareTableColumnValues(a, b, 'col')).not.toThrow();
+		// String([1,2]) === "1,2" < String([3,4]) === "3,4"
+		expect(compareTableColumnValues(a, b, 'col')).toBeLessThan(0);
+	});
+
+	it('does not throw when one cell is numeric and the other is an object', () => {
+		const a = row(42);
+		const b = row({ foo: 'bar' });
+		expect(() => compareTableColumnValues(a, b, 'col')).not.toThrow();
+		expect(typeof compareTableColumnValues(a, b, 'col')).toBe('number');
+	});
+
+	it('does not throw for a number cell compared against an "N/A" cell', () => {
+		// http.status_code column: [null, "200", ...] -> ["N/A", 200, ...]
+		const numberCell = row(200); // numeric string "200" becomes the number 200
+		const naCell = row('N/A'); // null becomes the string "N/A"
+
+		// Both orderings — antd's sorter compares pairs in both directions.
+		expect(() =>
+			compareTableColumnValues(numberCell, naCell, 'col'),
+		).not.toThrow();
+		expect(() =>
+			compareTableColumnValues(naCell, numberCell, 'col'),
+		).not.toThrow();
+		expect(typeof compareTableColumnValues(numberCell, naCell, 'col')).toBe(
+			'number',
+		);
+	});
+});

--- a/frontend/src/lib/query/createTableColumnsFromQuery.ts
+++ b/frontend/src/lib/query/createTableColumnsFromQuery.ts
@@ -637,6 +637,21 @@ const generateData = (
 	return data;
 };
 
+export const compareTableColumnValues = (
+	a: RowData,
+	b: RowData,
+	dataIndex: string,
+): number => {
+	const valueA = Number(a[`${dataIndex}_without_unit`] ?? a[dataIndex]);
+	const valueB = Number(b[`${dataIndex}_without_unit`] ?? b[dataIndex]);
+
+	if (!isNaN(valueA) && !isNaN(valueB)) {
+		return valueA - valueB;
+	}
+
+	return String(a[dataIndex] ?? '').localeCompare(String(b[dataIndex] ?? ''));
+};
+
 const generateTableColumns = (
 	dynamicColumns: DynamicColumns,
 	renderColumnCell?: QueryTableProps['renderColumnCell'],
@@ -650,18 +665,8 @@ const generateTableColumns = (
 			title: item.title,
 			width: QUERY_TABLE_CONFIG.width,
 			render: renderColumnCell && renderColumnCell[dataIndex],
-			sorter: (a: RowData, b: RowData): number => {
-				const valueA = Number(a[`${dataIndex}_without_unit`] ?? a[dataIndex]);
-				const valueB = Number(b[`${dataIndex}_without_unit`] ?? b[dataIndex]);
-
-				if (!isNaN(valueA) && !isNaN(valueB)) {
-					return valueA - valueB;
-				}
-
-				return ((a[dataIndex] as string) || '').localeCompare(
-					(b[dataIndex] as string) || '',
-				);
-			},
+			sorter: (a: RowData, b: RowData): number =>
+				compareTableColumnValues(a, b, dataIndex),
 		};
 
 		return [...acc, column];


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

This is a fix PR for breaking sort behaviour in Query Table.
The QueryTable sorter assumed the remaining values were strings and called localeCompare(). However, processTableRowValue converts numeric strings to numbers, while null values become "N/A", so a column can contain both numbers and strings. When comparing 200 with "N/A", the numeric comparison is skipped and localeCompare() is called on a number, causing localeCompare is not a function and crashing the table sort.

More details here: https://github.com/SigNoz/engineering-pod/issues/5777#issuecomment-5089994668

This PR is a fix for SIGNOZ-UI-5GC 



#### Screenshots / Screen Recordings (if applicable)

Before

https://github.com/user-attachments/assets/00008daa-e30c-4bfb-9dc9-a2ca970b2945


After


https://github.com/user-attachments/assets/6cb4e1eb-0d74-4d4b-8a82-cc286e086bb5



#### Issues closed by this PR

https://github.com/SigNoz/engineering-pod/issues/5777
---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
> What caused the issue?  
> Regression, faulty assumption, edge case, refactor, etc.

#### Fix Strategy
> How does this PR address the root cause?

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
- Manual verification:
- Edge cases covered:

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius:
- Potential regressions:
- Rollback plan:

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature / Bug Fix / Maintenance |
| Description | User-facing summary |

---

### 📋 Checklist
- [ ] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered

---

## 👀 Notes for Reviewers

<!-- Anything reviewers should keep in mind while reviewing -->

---
