### PR TITLE
fix(ai-assistant): page context for the V2 panel editor (edit + create) and the v2 dashboards list in the picker

### DIFF
--- a/frontend/src/container/AIAssistant/__tests__/getAutoContexts.test.ts
+++ b/frontend/src/container/AIAssistant/__tests__/getAutoContexts.test.ts
@@ -190,7 +190,7 @@ describe('getAutoContexts', () => {
 		]);
 	});
 
-	it('falls back to dashboard detail on the unsaved new-panel editor', () => {
+	it('returns new panel context on the unsaved new-panel editor', () => {
 		const dashboardId = 'dash-123';
 		const pathname = ROUTES.DASHBOARD_PANEL_EDITOR.replace(
 			':dashboardId',
@@ -210,7 +210,7 @@ describe('getAutoContexts', () => {
 				type: 'dashboard',
 				resourceId: dashboardId,
 				metadata: {
-					page: 'dashboard_detail',
+					page: 'panel_create',
 					timeRange: { start: Number(startTime), end: Number(endTime) },
 				},
 			},

--- a/frontend/src/container/AIAssistant/__tests__/getAutoContexts.test.ts
+++ b/frontend/src/container/AIAssistant/__tests__/getAutoContexts.test.ts
@@ -167,6 +167,56 @@ describe('getAutoContexts', () => {
 		]);
 	});
 
+	it('returns panel edit context on the V2 panel editor', () => {
+		const dashboardId = 'dash-123';
+		const panelId = 'panel-abc';
+		const pathname = ROUTES.DASHBOARD_PANEL_EDITOR.replace(
+			':dashboardId',
+			dashboardId,
+		).replace(':panelId', panelId);
+
+		const contexts = getAutoContexts(pathname, '');
+
+		expect(contexts).toStrictEqual([
+			{
+				source: 'auto',
+				type: 'dashboard',
+				resourceId: dashboardId,
+				metadata: {
+					page: 'panel_edit',
+					widgetId: panelId,
+				},
+			},
+		]);
+	});
+
+	it('falls back to dashboard detail on the unsaved new-panel editor', () => {
+		const dashboardId = 'dash-123';
+		const pathname = ROUTES.DASHBOARD_PANEL_EDITOR.replace(
+			':dashboardId',
+			dashboardId,
+		).replace(':panelId', 'new');
+		const startTime = '1700000000000';
+		const endTime = '1700003600000';
+
+		const contexts = getAutoContexts(
+			pathname,
+			`?panelKind=TimeSeries&${QueryParams.startTime}=${startTime}&${QueryParams.endTime}=${endTime}`,
+		);
+
+		expect(contexts).toStrictEqual([
+			{
+				source: 'auto',
+				type: 'dashboard',
+				resourceId: dashboardId,
+				metadata: {
+					page: 'dashboard_detail',
+					timeRange: { start: Number(startTime), end: Number(endTime) },
+				},
+			},
+		]);
+	});
+
 	it('returns empty array on alert overview without ruleId', () => {
 		const contexts = getAutoContexts(ROUTES.ALERT_OVERVIEW, '');
 

--- a/frontend/src/container/AIAssistant/__tests__/resolvePageType.test.ts
+++ b/frontend/src/container/AIAssistant/__tests__/resolvePageType.test.ts
@@ -17,6 +17,26 @@ describe('resolvePageType', () => {
 		expect(resolvePageType(pathname, '')).toBe(PageTypeDTO.dashboard_detail);
 	});
 
+	it('returns panel_edit on the V2 panel editor', () => {
+		const pathname = ROUTES.DASHBOARD_PANEL_EDITOR.replace(
+			':dashboardId',
+			'dash-123',
+		).replace(':panelId', 'panel-abc');
+
+		expect(resolvePageType(pathname, '')).toBe(PageTypeDTO.panel_edit);
+	});
+
+	it('returns dashboard_detail on the unsaved new-panel editor', () => {
+		const pathname = ROUTES.DASHBOARD_PANEL_EDITOR.replace(
+			':dashboardId',
+			'dash-123',
+		).replace(':panelId', 'new');
+
+		expect(resolvePageType(pathname, '?panelKind=TimeSeries')).toBe(
+			PageTypeDTO.dashboard_detail,
+		);
+	});
+
 	it('returns alerts_triggered on alert history without ruleId', () => {
 		expect(resolvePageType(ROUTES.ALERT_HISTORY, '')).toBe(
 			PageTypeDTO.alerts_triggered,

--- a/frontend/src/container/AIAssistant/__tests__/resolvePageType.test.ts
+++ b/frontend/src/container/AIAssistant/__tests__/resolvePageType.test.ts
@@ -26,14 +26,16 @@ describe('resolvePageType', () => {
 		expect(resolvePageType(pathname, '')).toBe(PageTypeDTO.panel_edit);
 	});
 
-	it('returns dashboard_detail on the unsaved new-panel editor', () => {
+	// `panel_create` has no PageTypeDTO counterpart yet, so it reports
+	// `panel_edit` rather than degrading to `other`.
+	it('returns panel_edit on the unsaved new-panel editor', () => {
 		const pathname = ROUTES.DASHBOARD_PANEL_EDITOR.replace(
 			':dashboardId',
 			'dash-123',
 		).replace(':panelId', 'new');
 
 		expect(resolvePageType(pathname, '?panelKind=TimeSeries')).toBe(
-			PageTypeDTO.dashboard_detail,
+			PageTypeDTO.panel_edit,
 		);
 	});
 

--- a/frontend/src/container/AIAssistant/components/ChatInput/ChatInput.tsx
+++ b/frontend/src/container/AIAssistant/components/ChatInput/ChatInput.tsx
@@ -17,16 +17,21 @@ import type { UploadFile } from 'antd';
 import getSessionStorage from 'api/browser/sessionstorage/get';
 import setSessionStorage from 'api/browser/sessionstorage/set';
 import {
+	getListDashboardsForUserV2QueryKey,
+	useListDashboardsForUserV2,
+} from 'api/generated/services/dashboard';
+import {
 	getListRulesQueryKey,
 	useListRules,
 } from 'api/generated/services/rules';
-import type { ListRules200 } from 'api/generated/services/sigNoz.schemas';
+import type {
+	DashboardtypesListedDashboardForUserV2DTO,
+	ListDashboardsForUserV2200,
+	ListDashboardsForUserV2Params,
+	ListRules200,
+} from 'api/generated/services/sigNoz.schemas';
 import logEvent from 'api/common/logEvent';
-import { REACT_QUERY_KEY } from 'constants/reactQueryKeys';
-import { useGetAllDashboard } from 'hooks/dashboard/useGetAllDashboard';
 import { useQueryService } from 'hooks/useQueryService';
-import type { SuccessResponseV2 } from 'types/api';
-import type { Dashboard } from 'types/api/dashboard/getAll';
 // eslint-disable-next-line
 import { useSelector } from 'react-redux';
 import { AppState } from 'store/reducers';
@@ -164,6 +169,18 @@ const TEXTAREA_MAX_HEIGHT_PX = 200;
 const HOME_SERVICES_INTERVAL = 30 * 60 * 1000;
 /** sessionStorage key for the "voice input failed this tab" flag. */
 const VOICE_UNAVAILABLE_KEY = 'ai-assistant-voice-unavailable';
+/**
+ * The picker filters client-side, so it pulls one large page instead of
+ * paginating. Shared with `getQueryData` below — the params are part of the
+ * generated query key, so both sides must use the same object.
+ */
+const DASHBOARD_LIST_PARAMS: ListDashboardsForUserV2Params = { limit: 1000 };
+
+function dashboardTitle(
+	dashboard: DashboardtypesListedDashboardForUserV2DTO,
+): string {
+	return dashboard.spec.display?.name || dashboard.name || 'Untitled';
+}
 
 interface SelectedContextItem {
 	category: ContextCategory;
@@ -716,9 +733,11 @@ export default function ChatInput({
 		data: dashboardsResponse,
 		isLoading: isDashboardsLoading,
 		isError: isDashboardsError,
-	} = useGetAllDashboard({
-		enabled: isContextPickerOpen && activeContextCategory === 'Dashboards',
-		staleTime: Infinity,
+	} = useListDashboardsForUserV2(DASHBOARD_LIST_PARAMS, {
+		query: {
+			enabled: isContextPickerOpen && activeContextCategory === 'Dashboards',
+			staleTime: Infinity,
+		},
 	});
 
 	const {
@@ -765,12 +784,12 @@ export default function ChatInput({
 				return ctx.resourceId;
 			}
 			if (ctx.type === 'dashboard' && ctx.resourceId) {
-				const cached = queryClient.getQueryData<SuccessResponseV2<Dashboard[]>>(
-					REACT_QUERY_KEY.GET_ALL_DASHBOARDS,
+				const cached = queryClient.getQueryData<ListDashboardsForUserV2200>(
+					getListDashboardsForUserV2QueryKey(DASHBOARD_LIST_PARAMS),
 				);
-				const dash = cached?.data?.find((d) => d.id === ctx.resourceId);
-				if (dash?.data.title) {
-					return dash.data.title;
+				const dash = cached?.data?.dashboards?.find((d) => d.id === ctx.resourceId);
+				if (dash) {
+					return dashboardTitle(dash);
 				}
 			}
 			if (ctx.type === 'alert' && ctx.resourceId) {
@@ -800,9 +819,9 @@ export default function ChatInput({
 	const contextEntitiesByCategory: Record<ContextCategory, ContextEntityItem[]> =
 		{
 			Dashboards:
-				dashboardsResponse?.data?.map((dashboard) => ({
+				dashboardsResponse?.data?.dashboards?.map((dashboard) => ({
 					id: dashboard.id,
-					value: dashboard.data.title ?? 'Untitled',
+					value: dashboardTitle(dashboard),
 				})) ?? [],
 			Alerts:
 				alertsResponse?.data

--- a/frontend/src/container/AIAssistant/components/ChatInput/ChatInput.tsx
+++ b/frontend/src/container/AIAssistant/components/ChatInput/ChatInput.tsx
@@ -105,6 +105,8 @@ function autoContextLabel(ctx: MessageContext): string {
 			return 'Current dashboard';
 		case 'panel_edit':
 			return 'Editing panel';
+		case 'panel_create':
+			return 'New panel';
 		case 'panel_fullscreen':
 			return 'Panel (fullscreen)';
 		case 'dashboard_list':

--- a/frontend/src/container/AIAssistant/components/ChatInput/__tests__/ChatInput.prefill.test.tsx
+++ b/frontend/src/container/AIAssistant/components/ChatInput/__tests__/ChatInput.prefill.test.tsx
@@ -2,12 +2,13 @@ import { render, screen, userEvent, waitFor } from 'tests/test-utils';
 
 // The prefill flow only depends on the context-picker data hooks resolving to
 // empty lists (so the empty state renders) — mock them to skip real fetches.
-jest.mock('hooks/dashboard/useGetAllDashboard', () => ({
-	useGetAllDashboard: (): unknown => ({
-		data: [],
+jest.mock('api/generated/services/dashboard', () => ({
+	useListDashboardsForUserV2: (): unknown => ({
+		data: undefined,
 		isLoading: false,
 		isError: false,
 	}),
+	getListDashboardsForUserV2QueryKey: (): string[] => ['dashboards'],
 }));
 
 jest.mock('api/generated/services/rules', () => ({

--- a/frontend/src/container/AIAssistant/getAutoContexts.ts
+++ b/frontend/src/container/AIAssistant/getAutoContexts.ts
@@ -2,6 +2,7 @@ import type { MessageContext } from 'api/ai-assistant/chat';
 import { QueryParams } from 'constants/query';
 import ROUTES from 'constants/routes';
 import { AlertListTabs } from 'pages/AlertList/types';
+import { NEW_PANEL_ID } from 'pages/DashboardPageV2/DashboardContainer/PanelEditor/newPanelRoute';
 import { matchPath } from 'react-router-dom';
 
 /**
@@ -29,6 +30,29 @@ export function getAutoContexts(
 	const sharedMetadata = collectSharedMetadata(params);
 
 	// ── Dashboards ────────────────────────────────────────────────────────────
+
+	// Panel editor (V2) — `/dashboard/:dashboardId/panel/:panelId`. An unsaved
+	// panel (`panel/new`) has no id to attach yet and the schema requires a
+	// non-empty `panel_edit.widgetId`, so it degrades to the dashboard context —
+	// the in-progress query still rides along in `sharedMetadata`.
+	const panelEditorMatch = matchPath<{ dashboardId: string; panelId: string }>(
+		pathname,
+		{ path: ROUTES.DASHBOARD_PANEL_EDITOR, exact: true },
+	);
+	if (panelEditorMatch) {
+		const { dashboardId, panelId } = panelEditorMatch.params;
+		const isNewPanel = panelId === NEW_PANEL_ID;
+		return [
+			{
+				source: 'auto',
+				type: 'dashboard',
+				resourceId: dashboardId,
+				metadata: isNewPanel
+					? { page: 'dashboard_detail', ...sharedMetadata }
+					: { page: 'panel_edit', widgetId: panelId, ...sharedMetadata },
+			},
+		];
+	}
 
 	// Widget edit (panel_edit) — `/dashboard/:dashboardId/:widgetId`.
 	const widgetMatch = matchPath<{ dashboardId: string; widgetId: string }>(

--- a/frontend/src/container/AIAssistant/getAutoContexts.ts
+++ b/frontend/src/container/AIAssistant/getAutoContexts.ts
@@ -31,10 +31,8 @@ export function getAutoContexts(
 
 	// ── Dashboards ────────────────────────────────────────────────────────────
 
-	// Panel editor (V2) — `/dashboard/:dashboardId/panel/:panelId`. An unsaved
-	// panel (`panel/new`) has no id to attach yet and the schema requires a
-	// non-empty `panel_edit.widgetId`, so it degrades to the dashboard context —
-	// the in-progress query still rides along in `sharedMetadata`.
+	// Panel editor (V2). `panel/new` has no widget id yet and the schema requires
+	// a non-empty `panel_edit.widgetId`, so it reports `panel_create` instead.
 	const panelEditorMatch = matchPath<{ dashboardId: string; panelId: string }>(
 		pathname,
 		{ path: ROUTES.DASHBOARD_PANEL_EDITOR, exact: true },
@@ -48,28 +46,8 @@ export function getAutoContexts(
 				type: 'dashboard',
 				resourceId: dashboardId,
 				metadata: isNewPanel
-					? { page: 'dashboard_detail', ...sharedMetadata }
+					? { page: 'panel_create', ...sharedMetadata }
 					: { page: 'panel_edit', widgetId: panelId, ...sharedMetadata },
-			},
-		];
-	}
-
-	// Widget edit (panel_edit) — `/dashboard/:dashboardId/:widgetId`.
-	const widgetMatch = matchPath<{ dashboardId: string; widgetId: string }>(
-		pathname,
-		{ path: ROUTES.DASHBOARD_WIDGET, exact: true },
-	);
-	if (widgetMatch) {
-		return [
-			{
-				source: 'auto',
-				type: 'dashboard',
-				resourceId: widgetMatch.params.dashboardId,
-				metadata: {
-					page: 'panel_edit',
-					widgetId: widgetMatch.params.widgetId,
-					...sharedMetadata,
-				},
 			},
 		];
 	}

--- a/frontend/src/container/AIAssistant/resolvePageType.ts
+++ b/frontend/src/container/AIAssistant/resolvePageType.ts
@@ -9,6 +9,8 @@ const PAGE_METADATA_TO_DTO: Record<string, PageTypeDTO> = {
 	dashboard_detail: PageTypeDTO.dashboard_detail,
 	dashboard_list: PageTypeDTO.dashboard_list,
 	panel_edit: PageTypeDTO.panel_edit,
+	// There is no panel_create, so sending panel_edit temporarily
+	panel_create: PageTypeDTO.panel_edit,
 	panel_fullscreen: PageTypeDTO.panel_fullscreen,
 	logs_explorer: PageTypeDTO.logs_explorer,
 	trace_detail: PageTypeDTO.trace_detail,


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Two AI-assistant bugs on the V2 dashboard surface.

**The V2 panel editor had no page context.** Every page feeds the assistant drawer a `source: 'auto'` context chip derived from the URL, but the V2 panel editor got none — it opened bare, with no idea which dashboard or panel the user was editing. It lives on its own route, `/dashboard/:dashboardId/panel/:panelId`, which `getAutoContexts` never matched: the three existing dashboard matchers are all `exact`, so a 4-segment URL fell through every branch and returned `[]`. `resolvePageType` derives from `metadata.page`, so the contextual empty-state chips degraded to `other` as well.

**The context picker called the deprecated v1 dashboards list.** `GET /api/v1/dashboards` is now a stub returning a V1-deprecated error (`APIHandler.List`), and `useGetAllDashboard` routes errors through `useErrorModal` — so opening the picker on the Dashboards tab both rendered "Failed to load dashboards" and popped a global error modal. The same stale query key broke `resolveAutoContextName`, so auto-context chips fell back to generic labels instead of the real dashboard title.

Switching to `useListDashboardsForUserV2` is the right fix rather than reviving v1: it's the same source the V2 list page and the export picker already read, so the picker shares their cache instead of maintaining a parallel one.

#### Screenshots / Screen Recordings (if applicable)

N/A — no visual change. The difference is a context chip that now appears in the drawer on the panel editor, and a picker tab that loads instead of erroring.

#### Issues closed by this PR

Closes https://github.com/SigNoz/pulse-pod/issues/144

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

Both are fallout from the V1 → V2 dashboard migration, in code that wasn't migrated alongside it.

1. The V2 panel editor introduced a new route shape (`/panel/:panelId`) that no `getAutoContexts` matcher covers. Only V1's `/dashboard/:dashboardId/:widgetId` was matched — the new one was never added.
2. `ChatInput` was written against `useGetAllDashboard` before the v1 list handler was replaced by a deprecation stub. Nothing failed at build time because the endpoint still exists; it just returns an error now.

#### Fix Strategy

1. Add a `DASHBOARD_PANEL_EDITOR` matcher. A saved panel maps to `panel_edit` carrying `widgetId`. The unsaved `panel/new` route has no id yet and the schema requires a non-empty `panel_edit.widgetId`, so it reports `panel_create` rather than emitting a bogus `widgetId: 'new'` — the dashboard and the in-progress query/time range still attach.

   | Route | `metadata.page` | `page_type` | Chip |
   |---|---|---|---|
   | `/panel/new` | `panel_create` | `panel_edit` | New panel |
   | `/panel/:id` | `panel_edit` | `panel_edit` | Editing panel |

   **`PageTypeDTO` has no `panel_create` member**, so `resolvePageType` maps it to `panel_edit` — an unmapped key falls through to `other` and loses the empty-state chips. `alert_new` is the precedent the enum is missing; once the backend adds `panel_create` this becomes a one-line change. The server also won't recognise `panel_create` in `metadata.page`; it'll see an unfamiliar value and still have the dashboard id.

   This commit also **drops the `DASHBOARD_WIDGET` matcher**. That V1 route is unreachable — nothing generates a link to it since V2 always builds panel-editor paths — and it read the `:widgetId` path segment, which V1's own page ignored in favour of `?widgetId=`. Its `widgetId` was never correct.
2. Point the picker at `useListDashboardsForUserV2`, reading titles from `spec.display.name` with a `name` fallback, and read the same v2 query key in `resolveAutoContextName` so cached lookups resolve.

---

### 🧪 Testing Strategy

- Tests added/updated: 4 new cases — panel editor and unsaved-new-panel in both `getAutoContexts.test.ts` and `resolvePageType.test.ts`. Updated the stale `useGetAllDashboard` mock in `ChatInput.prefill.test.tsx` to mock the v2 hook. `pnpm jest src/container/AIAssistant` → 8 suites, 73 tests passing.
- Manual verification: not run in a live app — validated via the test suite plus `pnpm tsgo --noEmit`, `pnpm lint:js --quiet`, `pnpm oxfmt --check` and `pnpm build`, all clean. Worth a reviewer pass in the running app on both the saved-panel and new-panel editor.
- Edge cases covered: unsaved `panel/new` (no widget id), panel editor with an explicit time range in the URL, and the existing `panel_fullscreen` path on the V2 detail page (unchanged — V2 still uses `expandedWidgetId`). The export-to-dashboard flow lands on `panel/new` carrying `compositeQuery`, so the assistant gets the full in-progress query — verified it parses through `collectSharedMetadata`.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: the AI assistant drawer only. `getAutoContexts` gains one branch on a route that previously returned `[]`, so no existing page's context can change. The picker's Dashboards tab swaps its data source.
- Potential regressions: the picker now depends on `GET /api/v2/users/me/dashboards`. It pulls a single `limit: 1000` page and filters client-side, matching the existing behaviour of the v1 list — an org past 1000 dashboards would see a truncated picker, same as before.
- Rollback plan: revert; the three commits are independent and any can be reverted on its own.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | The AI assistant now picks up dashboard and panel context when opened from the panel editor (including a "New panel" context while creating one), and its context picker lists dashboards again instead of erroring. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

While tracing the v1 list I checked what else still calls it. `container/ListOfDashboard/DashboardsList.tsx` is the only other caller and it is **unreachable** — its sole entry point is `pages/DashboardsListPage/DashboardsListPage.tsx`, while the routed `pages/DashboardsListPage/index.tsx` renders `DashboardsListPageV2`. Same for `pages/DashboardPage/DashboardPage.tsx` and the v1 `container/DashboardContainer` shell. So the assistant was the last live consumer.

**Backend dependency, not blocking:** `PageTypeDTO` needs a `panel_create` member so the unsaved panel editor stops borrowing `panel_edit`. Filed as part of pulse-pod#144.

One thing deliberately left out of scope: the `DASHBOARD_WIDGET` route (`/dashboard/:dashboardId/:widgetId`) is still registered and its page calls `api/v1/dashboards/id/get`, deprecated the same way. Nothing navigates there anymore since V2 always generates panel-editor links, but an old bookmark or shared link still resolves to it and lands on a broken page. That plus the dead v1 containers looks like a follow-up cleanup PR.
