### PR TITLE
fix(sqlmigration): write integer operation in migration 101 PG branch

### DIFF
--- a/pkg/sqlmigration/101_add_telemetry_tuples.go
+++ b/pkg/sqlmigration/101_add_telemetry_tuples.go
@@ -103,7 +103,7 @@ func (migration *addTelemetryTuples) Up(ctx context.Context, db *bun.DB) error {
 					INSERT INTO changelog (store, object_type, object_id, relation, _user, operation, ulid, inserted_at)
 					VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 					ON CONFLICT (store, ulid, object_type) DO NOTHING`,
-					storeID, tuple.objectType, objectID, tuple.relation, user, "TUPLE_OPERATION_WRITE", tupleID, now,
+					storeID, tuple.objectType, objectID, tuple.relation, user, 0, tupleID, now,
 				)
 				if err != nil {
 					return err


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Migration `101_add_telemetry_tuples` (new in v0.134.0) inserts the Go string literal `"TUPLE_OPERATION_WRITE"` into `changelog.operation` in its PostgreSQL branch. That column is `INTEGER NOT NULL`, so PostgreSQL rejects the statement:

```
ERROR: invalid input syntax for type integer: "TUPLE_OPERATION_WRITE" (SQLSTATE 22P02)
```

The column type is deliberate — migration `090_fix_changelog_operation_type` recreated it as `INTEGER` on purpose, with the comment *"changelog.operation is TEXT, should be INTEGER (OpenFGA v1.14.0 passes int32)"*.

Because the migration runs inside a transaction, it rolls back and re-fails identically on every restart, so SigNoz never starts:

```json
{"level":"ERROR","msg":"starting sqlstore migrations","dialect":"pg"}
{"level":"ERROR","msg":"failed to create signoz","exception.type":"internal","exception.message":"ERROR: invalid input syntax for type integer: \"TUPLE_OPERATION_WRITE\" (SQLSTATE 22P02)"}
```

On Kubernetes the pod lands in permanent `CrashLoopBackOff`, the Deployment never becomes Ready, and any `helm upgrade --wait` or `kubectl rollout status` gated on it fails with `Progress deadline exceeded`. The only workarounds are pinning back to v0.133.0 or hand-editing the database.

The fix passes the integer `TupleOperation` value `0`, exactly as the non-PG branch of the same function already does 26 lines below.

#### Issues closed by this PR

Closes #12293

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

A hardcoded string literal where an integer enum value was required, introduced with migration 101 in #12095 and unchanged on `main`.

`changelog.operation` holds OpenFGA's `TupleOperation` enum, which the driver passes as `int32`. The two branches of migration 101's insert loop disagreed about how to express it:

```go
// PG branch — line 106, string literal:
storeID, tuple.objectType, objectID, tuple.relation, user, "TUPLE_OPERATION_WRITE", tupleID, now,

// non-PG branch — line 132, correct integer:
storeID, tuple.objectType, objectID, tuple.relation, "role", roleSubject, "assignee", 0, tupleID, now,
```

Why this wasn't caught earlier:

- **SQLite is unaffected.** Its branch already passes `0`, and SQLite's dynamic typing would accept the string in an `INTEGER` column anyway.
- **Fresh databases are unaffected.** `organizations` is empty when migrations run, so the loop body never executes.
- **Only existing installations trip it** — those with at least one organization *and* at least one of the 13 telemetry tuples missing, since the `changelog` insert is only reached when the preceding `tuple` insert returns `rowsAffected == 1`.
- Migration 101 is the first migration ordered *after* 090 that writes `changelog.operation`, so it is the first to meet the `INTEGER` column.

#### Fix Strategy

Pass `0` instead of the string, matching the non-PG branch of the same function and every sibling migration's non-PG branch. One line, no behavior change beyond the corrected value — `0` is `TUPLE_OPERATION_WRITE`, so the row written is what the migration always intended.

Happy to switch to an explicit `int32(openfgav1.TupleOperation_TUPLE_OPERATION_WRITE)` if reviewers prefer self-documenting over consistency with the surrounding code; it would add an import to this file for a single literal.

---

### 🧪 Testing Strategy

- **Tests added/updated:** none. Migration 101 has no existing test coverage, and the repo has no PostgreSQL-backed sqlmigration test harness to hook into — the defect is a wrong literal in a SQL parameter list, invisible to Go-level unit tests and only observable against a real PG instance. Guidance welcome if maintainers want a harness added here.
- **Manual verification:** `go build` and `go vet` pass on `./pkg/sqlmigration/`. Migration 101's PG insert was run verbatim against affected PostgreSQL 16.14 and 18.4 instances and reproduces `22P02`; the identical statement with `0` in the `operation` position returns `INSERT 0 1`. A full v0.133.0 → patched-v0.134.0 upgrade against a real affected database is being validated now, and I'll report back here.
- **Edge cases covered:** re-running the migration is still a no-op — the `ON CONFLICT (store, ulid, object_type) DO NOTHING` clause and the `rowsAffected == 0 → continue` guard are untouched.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** one line in one migration, on the PostgreSQL path only. The migration currently cannot succeed on PostgreSQL, so there is no working behavior to regress. SQLite is untouched.
- **Potential regressions:** none identified. Installations that already applied 101 successfully are by definition SQLite or had nothing to insert; neither is affected by this change.
- **Rollback plan:** revert the commit. Note that anyone who already hit this bug has no committed rows from 101 (the transaction rolled back), so the fixed migration applies cleanly with no manual cleanup.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | OSS / Enterprise (self-hosted, PostgreSQL metadata store) |
| Change Type | Bug Fix |
| Description | Fixed a migration that prevented v0.134.0 from starting on PostgreSQL, crash-looping upgrades from v0.133.0 and earlier. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

**Seven sibling migrations carry the same string literal, and I deliberately left them alone** — 061, 062, 063, 075, 078, 081, 083. They are currently inert, because all of them are ordered *before* 090, and 090 drops and recreates `changelog` outright rather than casting the column, so any string rows they wrote are discarded rather than failing a type conversion. Migration 101 is the only one that runs after 090 and therefore the only one that actually breaks.

They are still a latent footgun: the next migration written by copy-pasting one of them will reintroduce this bug. Worth a follow-up sweep, or a shared constant for the operation value — happy to fold either into this PR if you'd rather fix it all at once.

For context on the related-but-distinct upstream issue: openfga/openfga#3011 and openfga/openfga#3012 fixed the same enum-as-string problem in OpenFGA's own changelog insert path by casting to `int32`. That fix ships in openfga v1.14.1, which v0.134.0 already pins, so the *runtime* write path is correct. This is purely SigNoz's own hardcoded literal in a migration and is not covered by those fixes.
