### PR TITLE
fix: clamp over-wide widgets, drop zero-width widgets, and properly h…

### DIFF
--- a/pkg/types/dashboardtypes/perses_v1_to_v2_layouts.go
+++ b/pkg/types/dashboardtypes/perses_v1_to_v2_layouts.go
@@ -180,6 +180,11 @@ func placedWidgetIDs(data StorableDashboardData) map[string]bool {
 		for _, e := range layout {
 			if m, ok := e.(map[string]any); ok {
 				if i, ok := m["i"].(string); ok && i != "" {
+					// A zero-width placement doesn't render in the v1 UI; treat it as
+					// unplaced so the widget is dropped rather than migrated invisibly.
+					if w, ok := m["w"].(float64); ok && w <= 0 {
+						continue
+					}
 					ids[i] = true
 				}
 			}
@@ -319,6 +324,9 @@ func compactGridItemsVertically(items []dashboard.GridItem) {
 		}
 		if l.X < 0 {
 			l.X = 0
+		}
+		if l.X+l.Width > gridColumnCount { // still overflows (wider than the grid) → clamp width so x+width = cols
+			l.Width = gridColumnCount - l.X
 		}
 		if l.Y < 0 {
 			l.Y = 0

--- a/pkg/types/dashboardtypes/perses_v1_to_v2_queries_malformed.go
+++ b/pkg/types/dashboardtypes/perses_v1_to_v2_queries_malformed.go
@@ -3,6 +3,7 @@ package dashboardtypes
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -108,26 +109,12 @@ func normalizeFunctionArgs(query map[string]any) {
 	}
 }
 
-// malformedOrderByValueKeys are v4 order-by columnNames meaning "order by the aggregation value"
-// that the v5 aggregation validator rejects (validateOrderByForAggregation). All resolve
-// to the same aggregation key. Add more as they surface. The frontend passes these
-// through (the query-service resolves them), but the v2 dashboard validator only accepts
-// a real aggregation key.
-var malformedOrderByValueKeys = map[string]bool{
-	"#SIGNOZ_VALUE":                  true,
-	"A":                              true,
-	"A.count()":                      true,
-	"__result":                       true,
-	"value":                          true,
-	"A.p99(duration_nano)":           true,
-	"aws_Kafka_MessagesInPerSec_max": true,
-	"byte_in_count":                  true,
-	"(http_server_request_duration_ms.bucket)": true,
-}
-
-// normalizeOrderByKeys rewrites any orderBy columnName in orderByValueKeys to the
-// v5-valid aggregation key. Left untouched if the key can't resolve (no aggregation to
-// name).
+// normalizeOrderByKeys rewrites any orderBy columnName the v5 aggregation validator
+// would reject (validateOrderByForAggregation) to the canonical aggregation value key.
+// v1 tolerated free-form "order by the value" aliases (#SIGNOZ_VALUE, the query name,
+// the raw metric/expression) that the query-service resolved at query time; v2 accepts
+// only a real order key. Anything already valid (a group-by key, an aggregation
+// expression/alias/index) is left alone. No-op if no aggregation key can be named.
 func normalizeOrderByKeys(query map[string]any) {
 	orders, ok := query["orderBy"].([]any)
 	if !ok {
@@ -137,15 +124,86 @@ func normalizeOrderByKeys(query map[string]any) {
 	if !ok {
 		return
 	}
+	valid := validAggregationOrderKeys(query)
 	for _, o := range orders {
 		order, ok := o.(map[string]any)
 		if !ok {
 			continue
 		}
-		if cn, _ := order["columnName"].(string); malformedOrderByValueKeys[cn] {
+		if cn, _ := order["columnName"].(string); cn != "" && !valid[cn] {
 			order["columnName"] = key
 		}
 	}
+}
+
+// validAggregationOrderKeys is a line-for-line mirror of validateOrderByForAggregation
+// (querybuildertypesv5/validation.go) over the untyped query map instead of a typed
+// QueryBuilderQuery. Keep the two in lockstep — every insertion here must match one
+// there — so a side-by-side read makes any drift obvious. The only adaptations: fields
+// are read out of maps, the type switch on the aggregation becomes a switch on the
+// query signal (metrics vs logs/traces), and a not-yet-upgraded group-by still carries
+// the v4 "key" instead of the v5 "name".
+func validAggregationOrderKeys(query map[string]any) map[string]bool {
+	validOrderKeys := make(map[string]bool)
+
+	for _, gb := range asObjects(query["groupBy"]) {
+		name, _ := gb["name"].(string)
+		if name == "" {
+			name, _ = gb["key"].(string)
+		}
+		validOrderKeys[name] = true
+	}
+
+	signal := signalFromDataSource(query["dataSource"])
+	for i, agg := range asObjects(query["aggregations"]) {
+		validOrderKeys[fmt.Sprintf("%d", i)] = true
+
+		switch signal {
+		// TraceAggregation / LogAggregation (identical bodies in the validator).
+		case telemetrytypes.SignalTraces, telemetrytypes.SignalLogs:
+			if alias, _ := agg["alias"].(string); alias != "" {
+				validOrderKeys[alias] = true
+			}
+			expression, _ := agg["expression"].(string)
+			validOrderKeys[expression] = true
+
+		// MetricAggregation.
+		case telemetrytypes.SignalMetrics:
+			// Also allow the generic __result pattern
+			validOrderKeys["__result"] = true
+
+			metricName, _ := agg["metricName"].(string)
+			spaceRaw, _ := agg["spaceAggregation"].(string)
+			timeRaw, _ := agg["timeAggregation"].(string)
+			spaceAggregation := metrictypes.SpaceAggregation{String: valuer.NewString(spaceRaw)}
+			timeAggregation := metrictypes.TimeAggregation{String: valuer.NewString(timeRaw)}
+
+			validOrderKeys[fmt.Sprintf("%s(%s)", spaceAggregation.StringValue(), metricName)] = true
+			if timeAggregation != metrictypes.TimeAggregationUnspecified {
+				validOrderKeys[fmt.Sprintf("%s(%s)", timeAggregation.StringValue(), metricName)] = true
+			}
+			if timeAggregation != metrictypes.TimeAggregationUnspecified && spaceAggregation != metrictypes.SpaceAggregationUnspecified {
+				validOrderKeys[fmt.Sprintf("%s(%s(%s))", spaceAggregation.StringValue(), timeAggregation.StringValue(), metricName)] = true
+			}
+		}
+	}
+
+	return validOrderKeys
+}
+
+// asObjects returns the map elements of a []any, skipping non-object entries.
+func asObjects(raw any) []map[string]any {
+	items, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(items))
+	for _, it := range items {
+		if m, ok := it.(map[string]any); ok {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // aggregationOrderKey names the first aggregation the way validateOrderByForAggregation

--- a/pkg/types/dashboardtypes/perses_v1_to_v2_test.go
+++ b/pkg/types/dashboardtypes/perses_v1_to_v2_test.go
@@ -1738,6 +1738,47 @@ func TestConvertV1WidgetQueryRewritesValueOrderKeyAfterDefaultAggregation(t *tes
 	assert.Equal(t, "count()", spec.Order[0].Key.Name, "#SIGNOZ_VALUE resolves to the injected default aggregation")
 }
 
+// A metric query ordering by a value alias the v5 validator rejects (here the raw
+// metric name, never enumerated anywhere) is rewritten to the canonical aggregation
+// key, while a genuine group-by order key is left alone. Guards the allowlist
+// approach: validity is derived from the query, not a hardcoded set of bad keys.
+func TestConvertV1WidgetQueryRewritesUnknownMetricValueOrderKey(t *testing.T) {
+	widget := map[string]any{
+		"id":         "m-1",
+		"panelTypes": "graph",
+		"query": map[string]any{
+			"queryType": "builder",
+			"builder": map[string]any{
+				"queryData": []any{
+					map[string]any{
+						"queryName":    "A",
+						"expression":   "A",
+						"dataSource":   "metrics",
+						"aggregations": []any{map[string]any{"metricName": "http_requests_total", "spaceAggregation": "sum"}},
+						"groupBy":      []any{map[string]any{"key": "service.name", "dataType": "string", "type": "resource"}},
+						"orderBy": []any{
+							map[string]any{"columnName": "http_requests_total", "order": "desc"},
+							map[string]any{"columnName": "service.name", "order": "asc"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	queries := (&v1Decoder{}).convertV1WidgetQuery(widget, PanelKindTimeSeries)
+	require.Len(t, queries, 1)
+
+	wrapper, ok := queries[0].Spec.Plugin.Spec.(*BuilderQuerySpec)
+	require.True(t, ok)
+	spec, ok := wrapper.Spec.(qb.QueryBuilderQuery[qb.MetricAggregation])
+	require.True(t, ok, "metrics query should dispatch to MetricAggregation, got %T", wrapper.Spec)
+
+	require.Len(t, spec.Order, 2)
+	assert.Equal(t, "sum(http_requests_total)", spec.Order[0].Key.Name, "unknown value alias rewritten to the aggregation key")
+	assert.Equal(t, "service.name", spec.Order[1].Key.Name, "valid group-by order key left alone")
+}
+
 func TestConvertV1WidgetQueryInjectsCountForNoopOnAggregationPanel(t *testing.T) {
 	// A logs query with the list-style "noop" operator placed on an aggregation
 	// panel (graph). createAggregationsShapeSafe drops noop, leaving no aggregation;
@@ -2084,6 +2125,26 @@ func TestConvertV1LayoutsClampsXBounds(t *testing.T) {
 	assert.Equal(t, 6, grid.Items[1].X) // x+w=16>12 shifted left to 12-6
 }
 
+func TestConvertV1LayoutsClampsOverwideWidth(t *testing.T) {
+	// A widget wider than the 12-col grid (e.g. carried over from a 24-col v1 grid)
+	// can't be shifted to fit, so its width is clamped so x+width = grid width —
+	// otherwise it overflows and v2 validation rejects it.
+	data := StorableDashboardData{
+		"widgets": []any{map[string]any{"id": "wide", "panelTypes": "graph", "query": singleLogsBuilderQuery()}},
+		"layout":  []any{map[string]any{"i": "wide", "x": float64(0), "y": float64(0), "w": float64(24), "h": float64(6)}},
+	}
+
+	d := &v1Decoder{}
+	layouts := d.convertV1Layouts(data, d.convertV1Panels(data["widgets"]))
+	require.NoError(t, d.errIfHasMalformedFields())
+	require.Len(t, layouts, 1)
+	grid, ok := layouts[0].Spec.(*dashboard.GridLayoutSpec)
+	require.True(t, ok)
+	require.Len(t, grid.Items, 1)
+	assert.Equal(t, 0, grid.Items[0].X)
+	assert.Equal(t, 12, grid.Items[0].Width) // w=24 clamped to 12 so x+width = 12
+}
+
 // TestConvertV1LayoutsToleratesNonObjectPanelMap covers templates that store
 // panelMap as {rowID: []widgetID} instead of the canonical {rowID: {widgets,
 // collapsed}}. The frontend reads such an entry as "not collapsed" (it accesses
@@ -2149,6 +2210,33 @@ func TestConvertV1LayoutsDropsEntryForUnrenderableWidget(t *testing.T) {
 	spec, ok := layouts[0].Spec.(*dashboard.GridLayoutSpec)
 	require.True(t, ok)
 	require.Len(t, spec.Items, 1, "e-1 has no panel → its layout entry is dropped, not emitted as a dangling ref")
+	assert.Equal(t, "#/spec/panels/p-1", spec.Items[0].Content.Ref)
+}
+
+func TestRetainPlacedWidgetsDropsZeroWidth(t *testing.T) {
+	// z-1 is placed with zero width, which the v1 UI doesn't render. It must be
+	// dropped entirely: no panel, and no dangling layout entry.
+	data := StorableDashboardData{
+		"widgets": []any{
+			map[string]any{"id": "p-1", "panelTypes": "graph", "query": singleLogsBuilderQuery()},
+			map[string]any{"id": "z-1", "panelTypes": "graph", "query": singleLogsBuilderQuery()},
+		},
+		"layout": []any{
+			map[string]any{"i": "p-1", "x": float64(0), "y": float64(0), "w": float64(6), "h": float64(6)},
+			map[string]any{"i": "z-1", "x": float64(6), "y": float64(0), "w": float64(0), "h": float64(6)},
+		},
+	}
+
+	d := &v1Decoder{}
+	panels := d.convertV1Panels(retainPlacedWidgets(data))
+	require.Contains(t, panels, "p-1")
+	require.NotContains(t, panels, "z-1", "a zero-width widget is not retained → no panel")
+
+	layouts := d.convertV1Layouts(data, panels)
+	require.Len(t, layouts, 1)
+	spec, ok := layouts[0].Spec.(*dashboard.GridLayoutSpec)
+	require.True(t, ok)
+	require.Len(t, spec.Items, 1, "the zero-width widget's layout entry is dropped too")
 	assert.Equal(t, "#/spec/panels/p-1", spec.Items[0].Content.Ref)
 }
 


### PR DESCRIPTION
…andle invalid order by

## Pull Request

---

### 📄 Summary

Some more testing on backups found more migration issues. Fixes needed for them: 
1. over-wide widgets get shifted/clamped to fit the 12-col grid
2. zero-width widgets (which don't render anyway) get dropped
3. invalid order-by keys are now fixed by checking against what the v5 validator actually accepts instead of a hardcoded blocklist we had to keep growing.