### PR TITLE
fix(dashboards-v2): new panel reads clean on open, not dirty

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/__tests__/PanelEditorContainer.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/__tests__/PanelEditorContainer.test.tsx
@@ -174,11 +174,13 @@ const baseProps = {
 function setup(
 	panel: DashboardtypesPanelDTO,
 	overrides?: Partial<React.ComponentProps<typeof PanelEditorContainer>>,
-	draftOverrides?: { isSpecDirty?: boolean },
+	draftOverrides?: { isSpecDirty?: boolean; draft?: DashboardtypesPanelDTO },
 ): void {
+	// The live draft can diverge from the seed `panel`; default to the seed.
+	const draftPanel = draftOverrides?.draft ?? panel;
 	mockUseDraft.mockReturnValue({
-		draft: panel,
-		spec: panel.spec,
+		draft: draftPanel,
+		spec: draftPanel.spec,
 		setSpec: mockSetSpec,
 		isSpecDirty: draftOverrides?.isSpecDirty ?? false,
 	});
@@ -266,6 +268,23 @@ describe('PanelEditorContainer composition', () => {
 			expect.objectContaining({ alwaysSerializeQuery: true }),
 		);
 		// No query and no edits yet → nothing to save, so Save stays disabled.
+		expect(mockHeaderProps).toHaveBeenCalledWith(
+			expect.objectContaining({ isDirty: false }),
+		);
+	});
+
+	it('keeps a query-less new panel clean after the staged-query sync seeds its draft (regression)', () => {
+		// Staged-query sync populated the draft with the seed; dirty must read the seed
+		// `panel` (query-less), not the draft, else an untouched new panel reads dirty.
+		const committedDraft = makePanel('signoz/TimeSeriesPanel', [
+			{ spec: { plugin: { kind: 'signoz/CompositeQuery', spec: {} } } },
+		]);
+		setup(
+			makePanel('signoz/TimeSeriesPanel'),
+			{ isNew: true },
+			{ draft: committedDraft },
+		);
+
 		expect(mockHeaderProps).toHaveBeenCalledWith(
 			expect.objectContaining({ isDirty: false }),
 		);

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/usePanelEditorQuerySync.integration.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/hooks/__tests__/usePanelEditorQuerySync.integration.test.tsx
@@ -2,6 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import type {
 	DashboardtypesPanelDTO,
 	DashboardtypesQueryDTO,
+	TelemetrytypesSignalDTO,
 } from 'api/generated/services/sigNoz.schemas';
 import { QueryParams } from 'constants/query';
 import { initialQueriesMap, PANEL_TYPES } from 'constants/queryBuilder';
@@ -88,6 +89,33 @@ describe('usePanelEditorQuerySync (real query builder)', () => {
 		// And stays clean (no late re-stage flips it dirty).
 		expect(result.current.isQueryDirty).toBe(false);
 	});
+
+	it.each([
+		[DataSource.METRICS, PANEL_TYPES.TIME_SERIES],
+		[DataSource.LOGS, PANEL_TYPES.TIME_SERIES],
+		[DataSource.TRACES, PANEL_TYPES.TIME_SERIES],
+		[DataSource.LOGS, PANEL_TYPES.LIST],
+	])(
+		'a NEW %s panel (%s, no savedQueries) is NOT query-dirty on mount',
+		async (ds, pt) => {
+			const { result } = renderHook(
+				() =>
+					usePanelEditorQuerySync({
+						draft: makePanel([]),
+						panelType: pt,
+						setSpec: jest.fn(),
+						refetch: jest.fn(),
+						alwaysSerializeQuery: true,
+						signal: ds as unknown as TelemetrytypesSignalDTO,
+						// savedQueries omitted — new panel.
+					}),
+				{ wrapper: AllTheProviders },
+			);
+
+			await waitFor(() => expect(result.current.isQueryDirty).toBe(false));
+			expect(result.current.isQueryDirty).toBe(false);
+		},
+	);
 
 	it('an untouched panel with a minimal/older stored query is NOT dirty (drift fix)', async () => {
 		// An older saved query carries only a few fields; the builder re-emits many more

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelEditor/index.tsx
@@ -159,11 +159,12 @@ function PanelEditorContainer({
 		return section?.controls;
 	}, [panelDefinition]);
 
-	// A new panel is savable once it has a query to run — List auto-seeds one; other
-	// kinds open query-less, so there's nothing to save until the user builds one.
+	// New panels are savable once seeded with a query (List auto-seeds one). Read the
+	// seed `panel`, not the live `draft` — the staged-query sync commits the seed into
+	// the draft on open, which would falsely dirty an untouched query-less new panel.
 	const isDirty = useMemo(
-		() => isSpecDirty || isQueryDirty || (isNew && draft.spec.queries.length > 0),
-		[isSpecDirty, isQueryDirty, isNew, draft.spec.queries.length],
+		() => isSpecDirty || isQueryDirty || (isNew && panel.spec.queries.length > 0),
+		[isSpecDirty, isQueryDirty, isNew, panel.spec.queries.length],
 	);
 
 	const isListPanel = panelKind === 'signoz/ListPanel';


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

Creating a new panel in the V2 dashboard editor made the panel read **dirty the instant it opened** — Save was enabled and closing prompted a "Discard changes?" dialog, even though the user had made no edits.

The editor's `isDirty` third clause `(isNew && draft.spec.queries.length > 0)` gates a new panel as savable once it carries a query. It read the live `draft`, but the staged-query sync (added in `f514af469e`) commits the builder-seeded query into `draft.spec.queries` on open for **every** kind — so the clause tripped even for a query-less panel.

The fix reads the **immutable seed** (`panel.spec.queries`) instead of the live draft: `[]` for non-List (clean on open), a real query for List / explorer-exports (savable on open). Genuine edits still surface via `isSpecDirty` / `isQueryDirty`. This restores the intended distinction the clause was written for, at its source.

#### Screenshots / Screen Recordings (if applicable)
> N/A — behavior verified via unit/integration tests (see Testing Strategy).

#### Issues closed by this PR
Closes https://github.com/SigNoz/pulse-pod/issues/147

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context
> Required if this PR fixes a bug

#### Root Cause
Regression from `f514af469e` (panel editor Save/dirty rework). That change added a staged-query sync effect that commits the builder-seeded query into `draft.spec.queries` on open for all panel kinds. The `isDirty` clause `(isNew && draft.spec.queries.length > 0)` had assumed `draft.spec.queries` stayed empty for query-less new panels (only List auto-seeds a query), so the newly-committed seed tripped it and every new panel read dirty on open. `isQueryDirty` itself was already correct — this is purely the third clause reading a mutable value it shouldn't.

#### Fix Strategy
Point the clause at the immutable seed `panel.spec.queries` (from `buildDefaultQueries` — `[]` for non-List, a real query for List/exports) instead of the live `draft.spec.queries` that the staged-query sync mutates. One-line change plus the dependency array.

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated:
  - `PanelEditorContainer.test.tsx`: regression test where the staged sync populated the draft but the seed is query-less → asserts `isDirty: false`. Fails before the fix, passes after. (The container mock previously returned `draft === panel`, which is why this class of bug slipped past coverage — `setup()` now accepts a distinct draft.)
  - `usePanelEditorQuerySync.integration.test.tsx`: a new panel is not query-dirty on mount, parametrized across metrics/logs/traces signals and the List kind, against the real query-builder provider.
- Manual verification: reproduced the dirty-on-open at both hook and container level before fixing; confirmed clean after.
- Edge cases covered: new List panel (still savable on open), new explorer-export panel (still savable on open), existing-panel edit (unaffected), spec/query edits still mark dirty.

Full PanelEditor suite: **249/249 passing**. `tsgo --noEmit` and oxlint clean on changed files.

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: V2 dashboard panel editor `isDirty` only (Save-button enablement + discard-on-close prompt). No query, save, or render path changes.
- Potential regressions: if a new panel kind ever needed to be savable on open without a seed query, it would now read clean — but no such kind exists (List/exports seed a query; others intentionally open query-less).
- Rollback plan: revert this commit; single-file logic change, trivially reversible.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | New dashboard panels no longer open as "unsaved" — the editor stays clean until you actually make a change. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Separate, pre-existing behavior worth a product call (not addressed here): the same staged-query sync also makes a new non-List panel's **preview auto-run its default query** on open (pre-`f514af469e` it opened blank). That's independent of this dirty-flag fix — happy to follow up if we want to revert that too.

---
