### PR TITLE
fix(dashboard-v2): stop the table drilldown crashing on a numeric group-by column

### DIFF
--- a/frontend/src/container/QueryTable/Drilldown/__tests__/contextConfig.test.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/__tests__/contextConfig.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import { ClickedData } from 'periscope/components/ContextMenu';
+import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
+import { Query } from 'types/api/queryBuilder/queryBuilderData';
+
+import { getGroupContextMenuConfig } from '../contextConfig';
+
+const GROUP_KEY = 'http.status_code';
+
+const makeQuery = (dataType: string): Query =>
+	({
+		builder: {
+			queryData: [
+				{
+					queryName: 'A',
+					groupBy: [{ key: GROUP_KEY, dataType, type: 'attribute' }],
+				},
+			],
+			queryFormulas: [],
+			queryTraceOperator: [],
+		},
+		promql: [],
+		clickhouse_sql: [],
+	}) as unknown as Query;
+
+const clickedData: ClickedData = {
+	column: { dataIndex: GROUP_KEY },
+	record: { key: GROUP_KEY, timestamp: 0 },
+};
+
+const renderGroupMenu = (query: Query): void => {
+	const { items } = getGroupContextMenuConfig({
+		query,
+		clickedData,
+		panelType: PANEL_TYPES.TABLE,
+		onColumnClick: jest.fn(),
+	});
+	render(<div>{items}</div>);
+};
+
+describe('getGroupContextMenuConfig', () => {
+	// A `number` group-by used to throw: it isn't a key of QUERY_BUILDER_OPERATORS_BY_TYPES.
+	it('renders comparison operators for a `number` group-by column', () => {
+		renderGroupMenu(makeQuery('number'));
+
+		expect(screen.getByText(`Filter by ${GROUP_KEY}`)).toBeInTheDocument();
+		expect(screen.getByText('Is this')).toBeInTheDocument();
+		expect(screen.getByText('Is greater than or equal to')).toBeInTheDocument();
+		expect(screen.getByText('Is less than')).toBeInTheDocument();
+	});
+
+	it('renders only equality operators for a string group-by column', () => {
+		renderGroupMenu(makeQuery(DataTypes.String));
+
+		expect(screen.getByText('Is this')).toBeInTheDocument();
+		expect(screen.getByText('Is not this')).toBeInTheDocument();
+		expect(
+			screen.queryByText('Is greater than or equal to'),
+		).not.toBeInTheDocument();
+	});
+
+	it('falls back to equality operators when the column has no known data type', () => {
+		renderGroupMenu(makeQuery(''));
+
+		expect(screen.getByText('Is this')).toBeInTheDocument();
+		expect(
+			screen.queryByText('Is greater than or equal to'),
+		).not.toBeInTheDocument();
+	});
+
+	it('returns no items for a non-table panel', () => {
+		const config = getGroupContextMenuConfig({
+			query: makeQuery('number'),
+			clickedData,
+			panelType: PANEL_TYPES.TIME_SERIES,
+			onColumnClick: jest.fn(),
+		});
+
+		expect(config.items).toBeUndefined();
+	});
+});

--- a/frontend/src/container/QueryTable/Drilldown/__tests__/drilldownUtils.test.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/__tests__/drilldownUtils.test.tsx
@@ -1,8 +1,11 @@
+import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { Query } from 'types/api/queryBuilder/queryBuilderData';
 
 import {
+	getOperatorsByDataType,
 	getQueryData,
 	getViewQuery,
+	isNumberDataType,
 	isValidQueryName,
 } from '../drilldownUtils';
 import { METRIC_TO_LOGS_TRACES_MAPPINGS } from '../metricsCorrelationUtils';
@@ -686,5 +689,42 @@ describe('drilldownUtils', () => {
 			expect(expr).toContain('serviceName');
 			expect(expr).toContain(`name = 'GET /api'`);
 		});
+	});
+
+	describe('getOperatorsByDataType', () => {
+		it('gives numeric operators for the V5 `number` data type', () => {
+			const operators = getOperatorsByDataType('number');
+			expect(operators).toContain('>=');
+			expect(operators).toContain('<');
+			expect(operators).not.toContain('LIKE');
+		});
+
+		it('gives numeric operators for the V3 int64 / float64 data types', () => {
+			expect(getOperatorsByDataType(DataTypes.Int64)).toContain('>=');
+			expect(getOperatorsByDataType(DataTypes.Float64)).toContain('>=');
+		});
+
+		it('falls back to the string operators for unmapped, empty and missing types', () => {
+			const stringOperators = getOperatorsByDataType(DataTypes.String);
+			expect(getOperatorsByDataType('[]string')).toStrictEqual(stringOperators);
+			expect(getOperatorsByDataType('')).toStrictEqual(stringOperators);
+			expect(getOperatorsByDataType(undefined)).toStrictEqual(stringOperators);
+		});
+	});
+
+	describe('isNumberDataType', () => {
+		it.each([DataTypes.Int64, DataTypes.Float64, 'number' as DataTypes])(
+			'treats %s as numeric',
+			(dataType) => {
+				expect(isNumberDataType(dataType)).toBe(true);
+			},
+		);
+
+		it.each([DataTypes.String, DataTypes.bool, DataTypes.EMPTY, undefined])(
+			'does not treat %s as numeric',
+			(dataType) => {
+				expect(isNumberDataType(dataType)).toBe(false);
+			},
+		);
 	});
 });

--- a/frontend/src/container/QueryTable/Drilldown/__tests__/numericGroupByDrilldown.test.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/__tests__/numericGroupByDrilldown.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react';
+import {
+	DashboardtypesQueryDTO,
+	Querybuildertypesv5BuilderQuerySpecDTO,
+	Querybuildertypesv5CompositeQueryDTO,
+} from 'api/generated/services/sigNoz.schemas';
+import { PANEL_TYPES } from 'constants/queryBuilder';
+import {
+	fromPerses,
+	toPerses,
+} from 'pages/DashboardPageV2/DashboardContainer/queryV5/persesQueryAdapters';
+import { ClickedData } from 'periscope/components/ContextMenu';
+
+import { getGroupContextMenuConfig } from '../contextConfig';
+import {
+	addFilterToQuery,
+	getBaseMeta,
+	isNumberDataType,
+} from '../drilldownUtils';
+
+const GROUP_KEY = 'panja.pinger.status_code';
+
+/**
+ * A saved V2 table panel grouped by a numeric attribute. The backend rewrites `float64` to
+ * `number` when it stores the panel, so `number` is what a reload actually carries.
+ */
+const savedPanelQueries = [
+	{
+		kind: 'signoz/scalar',
+		spec: {
+			plugin: {
+				kind: 'signoz/CompositeQuery',
+				spec: {
+					queries: [
+						{
+							type: 'builder_query',
+							spec: {
+								name: 'A',
+								signal: 'metrics',
+								aggregations: [{ metricName: 'probe_checks', spaceAggregation: 'sum' }],
+								groupBy: [
+									{
+										name: GROUP_KEY,
+										fieldDataType: 'number',
+										fieldContext: 'attribute',
+									},
+								],
+								filter: { expression: '' },
+								disabled: false,
+							},
+						},
+					],
+				},
+			},
+		},
+	},
+] as unknown as DashboardtypesQueryDTO[];
+
+describe('drilldown on a numeric group-by column (V2 table panel)', () => {
+	const v1Query = fromPerses(savedPanelQueries, PANEL_TYPES.TABLE);
+	const groupByDataType = getBaseMeta(v1Query, GROUP_KEY)?.dataType;
+
+	it('sees the `number` type the panel was stored with', () => {
+		expect(groupByDataType).toBe('number');
+	});
+
+	it('offers the numeric operators instead of throwing', () => {
+		const clickedData: ClickedData = {
+			column: { dataIndex: GROUP_KEY },
+			record: { key: GROUP_KEY, timestamp: 0 },
+		};
+		const { items } = getGroupContextMenuConfig({
+			query: v1Query,
+			clickedData,
+			panelType: PANEL_TYPES.TABLE,
+			onColumnClick: jest.fn(),
+		});
+		render(<div>{items}</div>);
+
+		expect(screen.getByText(`Filter by ${GROUP_KEY}`)).toBeInTheDocument();
+		expect(screen.getByText('Is this')).toBeInTheDocument();
+		expect(screen.getByText('Is greater than or equal to')).toBeInTheDocument();
+	});
+
+	it('filters on an unquoted number', () => {
+		// What the filter hooks branch on before coercing the clicked value.
+		expect(isNumberDataType(groupByDataType)).toBe(true);
+
+		const refined = addFilterToQuery(v1Query, [
+			{ filterKey: GROUP_KEY, filterValue: 200, operator: '=' },
+		]);
+		expect(refined.builder.queryData[0].filter?.expression).toBe(
+			`${GROUP_KEY} = 200`,
+		);
+	});
+
+	it('leaves the stored query shape untouched on the way back out', () => {
+		const [envelope] = toPerses(v1Query, PANEL_TYPES.TABLE);
+		const composite = envelope.spec.plugin
+			.spec as Querybuildertypesv5CompositeQueryDTO;
+		const [query] = composite.queries ?? [];
+		// The generated envelope union doesn't discriminate `spec` by `type`.
+		const spec = query?.spec as Querybuildertypesv5BuilderQuerySpecDTO;
+
+		expect(spec.groupBy?.[0]).toMatchObject({
+			name: GROUP_KEY,
+			fieldDataType: 'number',
+			fieldContext: 'attribute',
+		});
+	});
+});

--- a/frontend/src/container/QueryTable/Drilldown/contextConfig.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/contextConfig.tsx
@@ -1,12 +1,9 @@
 import { ReactNode } from 'react';
-import {
-	PANEL_TYPES,
-	QUERY_BUILDER_OPERATORS_BY_TYPES,
-} from 'constants/queryBuilder';
+import { PANEL_TYPES } from 'constants/queryBuilder';
 import ContextMenu, { ClickedData } from 'periscope/components/ContextMenu';
 import { IBuilderQuery, Query } from 'types/api/queryBuilder/queryBuilderData';
 
-import { getBaseMeta } from './drilldownUtils';
+import { getBaseMeta, getOperatorsByDataType } from './drilldownUtils';
 import { SUPPORTED_OPERATORS } from './menuOptions';
 import { BreakoutAttributeType } from './types';
 
@@ -49,15 +46,9 @@ export function getGroupContextMenuConfig({
 }: Omit<ContextMenuConfigParams, 'configType'>): GroupContextMenuConfig {
 	const filterKey = clickedData?.column?.dataIndex;
 
-	const filterDataType =
-		getBaseMeta(query, filterKey as string)?.dataType || 'string';
+	const filterDataType = getBaseMeta(query, filterKey as string)?.dataType;
 
-	const operators =
-		QUERY_BUILDER_OPERATORS_BY_TYPES[
-			filterDataType as keyof typeof QUERY_BUILDER_OPERATORS_BY_TYPES
-		];
-
-	const filterOperators = operators.filter(
+	const filterOperators = getOperatorsByDataType(filterDataType).filter(
 		(operator) => SUPPORTED_OPERATORS[operator],
 	);
 

--- a/frontend/src/container/QueryTable/Drilldown/drilldownUtils.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/drilldownUtils.tsx
@@ -3,6 +3,7 @@ import { convertFiltersToExpressionWithExistingQuery } from 'components/QueryBui
 import {
 	initialQueryBuilderFormValuesMap,
 	OPERATORS,
+	QUERY_BUILDER_OPERATORS_BY_TYPES,
 } from 'constants/queryBuilder';
 import ROUTES from 'constants/routes';
 import { isApmMetric } from 'container/PanelWrapper/utils';
@@ -54,12 +55,43 @@ export const getRoute = (key: string): string => {
 	}
 };
 
+/**
+ * A group-by's `dataType` comes from the field metadata, which reports a numeric as `number`
+ * (V5, what a saved V2 panel carries) or as `int64` / `float64` (V3) — all three are numeric.
+ */
+const NUMERIC_DATA_TYPES: string[] = [
+	DataTypes.Int64,
+	DataTypes.Float64,
+	'number',
+];
+
 export const isNumberDataType = (dataType: DataTypes | undefined): boolean => {
 	if (!dataType) {
 		return false;
 	}
-	return dataType === DataTypes.Int64 || dataType === DataTypes.Float64;
+	return NUMERIC_DATA_TYPES.includes(dataType);
 };
+
+/**
+ * `QUERY_BUILDER_OPERATORS_BY_TYPES` is keyed by the V3 data types, so the `number` a saved V2
+ * panel carries misses it — and a raw lookup returns `undefined`, which throws on the caller's
+ * `.filter`. Resolve through this table and fall back to the string set.
+ */
+const OPERATOR_DATA_TYPES: Record<
+	string,
+	keyof typeof QUERY_BUILDER_OPERATORS_BY_TYPES
+> = {
+	[DataTypes.String]: 'string',
+	[DataTypes.Int64]: 'int64',
+	[DataTypes.Float64]: 'float64',
+	[DataTypes.bool]: 'bool',
+	number: 'float64',
+};
+
+export const getOperatorsByDataType = (dataType?: string): string[] =>
+	QUERY_BUILDER_OPERATORS_BY_TYPES[
+		OPERATOR_DATA_TYPES[dataType ?? ''] ?? 'string'
+	];
 
 export interface FilterData {
 	filterKey: string;


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Clicking a numeric group-by column to drill down in a **V2 dashboard table panel** replaced the whole dashboard with `Something went wrong :/`.

The operator menu indexed `QUERY_BUILDER_OPERATORS_BY_TYPES` with the group-by's `dataType` and called `.filter` on the result. That map is keyed by the **V3** data types (`string | int64 | float64 | bool`), but a V2 panel's group-by carries the **V5** `fieldDataType` — and the backend stores every `float64` as `number` ([`FieldDataType.UnmarshalJSON`](https://github.com/SigNoz/signoz/blob/main/pkg/types/telemetrytypes/field_datatype.go)). `number` was never a key, so the lookup returned `undefined`, `.filter` threw during render, and the page-level error boundary took the dashboard down.

Scope is deliberately just this bug. The underlying problem is broader — the frontend carries two vocabularies for field types and several lookups are keyed on only one of them — but that cleanup touches shared conversion code used by the explorers, alerts and both dashboard versions, so it's written up separately in SigNoz/pulse-pod#145 rather than bundled here.

#### Screenshots / Screen Recordings (if applicable)

Before: `Uncaught TypeError: Cannot read properties of undefined (reading 'filter')` at `contextConfig.tsx:60`, whole page replaced by the error boundary.

After: the menu opens with the numeric operators — `Is this`, `Is not this`, `Is greater than or equal to`, `Is less than or equal to`, `Is less than` — and applying one filters on an unquoted number.

---

#### Issues Closed
Closes https://github.com/SigNoz/pulse-pod/issues/146


### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

A faulty assumption at a type boundary. The operator map is keyed by the V3 data types, and V1 dashboards only ever fed it V3 values — their data is stored untyped (`map[string]interface{}`), so a group-by's `dataType` round-trips exactly as the picker wrote it, and the picker sources from `/api/v3/autocomplete/attribute_keys`. V2 panels deserialize into typed Go structs where `float64` is rewritten to `number`, and that value reaches the same map.

Secondary symptom, same gap: `isNumberDataType` only matched `int64`/`float64`, so a numeric column's filter value went out as a quoted string (`= '200'`).

#### Fix Strategy

- resolve the operator list through a table that knows `number`, falling back to the string set — so an unmapped type can never white-screen a panel again
- treat `number` as numeric in `isNumberDataType`, so the filter value is a number

No query payload changes: this only affects how the menu is built and how the clicked value is typed locally.

---

### 🧪 Testing Strategy

- **Tests added/updated:**
  - `numericGroupByDrilldown.test.tsx` — starts from a saved panel spec carrying `fieldDataType: 'number'` and walks the real path unmocked: the menu renders the numeric operators, `isNumberDataType` reports numeric, applying `=` yields `key = 200` unquoted, and `toPerses` round-trips the stored shape unchanged (guarding that no payload moved).
  - `contextConfig.test.tsx` — the menu for `number`, `string`, empty and non-table cases. Reverting the fix reproduces the exact production `TypeError`.
  - `drilldownUtils.test.tsx` — `getOperatorsByDataType` and `isNumberDataType` across the V3 types, `number`, list types, empty and `undefined`.
- **Manual verification:** not done in a browser — my dev server proxies to a remote tenant I can't authenticate against. The unmocked test above stands in for it; a reviewer with an affected dashboard should confirm the click.
- **Edge cases covered:** `number` / `int64` / `float64` / `bool` / `string`, list types (`[]string`, `array(string)`), empty string, `undefined`, non-table panel types.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** two functions in `drilldownUtils` plus their one caller in `contextConfig`. Both are used by the V1 table drilldown as well, which gains the same protection.
- **Potential regressions:** the only behaviour change for existing (V3-typed) columns is that a numeric column now offers comparison operators where it previously threw or offered none; string columns are unchanged (`=`, `!=`). No request payloads change.
- **Rollback plan:** revert the single commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed a crash when drilling down on a numeric column in a dashboard table panel, and numeric filters built by drilldown are now typed as numbers rather than strings. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested — see Testing Strategy; needs a reviewer with access to an affected dashboard
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

One commit, five files, two of them production code.

The `number` spelling is handled locally here rather than normalized at the conversion boundary on purpose — see SigNoz/pulse-pod#145 for why that boundary work is a separate change, and for the other places the same two-vocabulary problem shows up.
