### PR TITLE
fix(warning-popover): background color to l2 & message alignment

### DIFF
--- a/frontend/src/components/WarningPopover/WarningPopover.styles.scss
+++ b/frontend/src/components/WarningPopover/WarningPopover.styles.scss
@@ -12,7 +12,6 @@
 	&__summary {
 		display: flex;
 		justify-content: space-between;
-		gap: var(--spacing-8);
 		padding: 16px;
 	}
 
@@ -154,7 +153,7 @@
 		width: 2px;
 		height: 4px;
 		border-radius: 50px;
-		background: var(--l3-foreground);
+		background: var(--l1-border);
 	}
 
 	&__scroll-hint {

--- a/frontend/src/components/WarningPopover/WarningPopover.styles.scss
+++ b/frontend/src/components/WarningPopover/WarningPopover.styles.scss
@@ -1,3 +1,7 @@
+.warning-popover-overlay {
+	--antd-arrow-background-color: var(--l2-background);
+}
+
 .warning-content {
 	display: flex;
 	flex-direction: column;
@@ -11,14 +15,23 @@
 
 	&__summary {
 		display: flex;
+		align-items: flex-start;
 		justify-content: space-between;
+		gap: 16px;
 		padding: 16px;
 	}
 
 	&__summary-left {
 		display: flex;
-		align-items: flex-end;
+		align-items: flex-start;
 		gap: 8px;
+	}
+
+	&__icon-wrapper {
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
+		height: 24px;
 	}
 
 	&__summary-text {

--- a/frontend/src/components/WarningPopover/WarningPopover.styles.scss
+++ b/frontend/src/components/WarningPopover/WarningPopover.styles.scss
@@ -1,6 +1,7 @@
 .warning-content {
 	display: flex;
 	flex-direction: column;
+	background-color: var(--l2-background);
 
 	// === SECTION: Summary (Top)
 	&__summary-section {
@@ -11,12 +12,13 @@
 	&__summary {
 		display: flex;
 		justify-content: space-between;
+		gap: var(--spacing-8);
 		padding: 16px;
 	}
 
 	&__summary-left {
 		display: flex;
-		align-items: baseline;
+		align-items: center;
 		gap: 8px;
 	}
 
@@ -24,6 +26,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 6px;
+		min-width: 0;
 	}
 
 	&__warning-code {
@@ -124,35 +127,35 @@
 	}
 
 	&__message-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--spacing-2);
 		margin: 0;
-		padding: 0;
+		padding: 0 var(--spacing-8) var(--spacing-8);
 		list-style: none;
 		max-height: 275px;
 	}
 
 	&__message-item {
 		position: relative;
-		margin-bottom: 4px;
 		color: var(--l2-foreground);
 		font-family: Geist Mono;
 		font-size: 12px;
 		font-weight: 400;
 		line-height: 18px;
-		padding: 3px 12px;
-		padding-left: 26px;
+		padding-left: var(--spacing-6);
 	}
 
 	&__message-item::before {
 		font-family: unset;
 		content: '';
 		position: absolute;
-		left: 12px;
-		top: 50%;
-		transform: translateY(-50%);
-		width: 2px;
-		height: 4px;
-		border-radius: 50px;
-		background: var(--l1-border);
+		left: 0;
+		top: 7px;
+		width: var(--spacing-2);
+		height: var(--spacing-2);
+		border-radius: 50%;
+		background: var(--l3-foreground);
 	}
 
 	&__scroll-hint {

--- a/frontend/src/components/WarningPopover/WarningPopover.styles.scss
+++ b/frontend/src/components/WarningPopover/WarningPopover.styles.scss
@@ -18,7 +18,7 @@
 
 	&__summary-left {
 		display: flex;
-		align-items: center;
+		align-items: flex-end;
 		gap: 8px;
 	}
 
@@ -26,7 +26,6 @@
 		display: flex;
 		flex-direction: column;
 		gap: 6px;
-		min-width: 0;
 	}
 
 	&__warning-code {
@@ -127,34 +126,34 @@
 	}
 
 	&__message-list {
-		display: flex;
-		flex-direction: column;
-		gap: var(--spacing-2);
 		margin: 0;
-		padding: 0 var(--spacing-8) var(--spacing-8);
+		padding: 0;
 		list-style: none;
 		max-height: 275px;
 	}
 
 	&__message-item {
 		position: relative;
+		margin-bottom: 4px;
 		color: var(--l2-foreground);
 		font-family: Geist Mono;
 		font-size: 12px;
 		font-weight: 400;
 		line-height: 18px;
-		padding-left: var(--spacing-6);
+		padding: 3px 12px;
+		padding-left: 26px;
 	}
 
 	&__message-item::before {
 		font-family: unset;
 		content: '';
 		position: absolute;
-		left: 0;
-		top: 7px;
-		width: var(--spacing-2);
-		height: var(--spacing-2);
-		border-radius: 50%;
+		left: 12px;
+		top: 50%;
+		transform: translateY(-50%);
+		width: 2px;
+		height: 4px;
+		border-radius: 50px;
 		background: var(--l3-foreground);
 	}
 

--- a/frontend/src/components/WarningPopover/WarningPopover.styles.scss
+++ b/frontend/src/components/WarningPopover/WarningPopover.styles.scss
@@ -17,7 +17,7 @@
 		display: flex;
 		align-items: flex-start;
 		justify-content: space-between;
-		gap: 16px;
+		gap: var(--spacing-8);
 		padding: 16px;
 	}
 
@@ -31,7 +31,7 @@
 		display: flex;
 		align-items: center;
 		flex-shrink: 0;
-		height: 24px;
+		height: var(--spacing-12);
 	}
 
 	&__summary-text {

--- a/frontend/src/components/WarningPopover/WarningPopover.tsx
+++ b/frontend/src/components/WarningPopover/WarningPopover.tsx
@@ -36,12 +36,8 @@ export function WarningContent({ warning }: WarningContentProps): JSX.Element {
 						</div>
 
 						<div className="warning-content__summary-text">
-							{warningCode && (
-								<h2 className="warning-content__warning-code">{warningCode}</h2>
-							)}
-							{warningMessage && (
-								<p className="warning-content__warning-message">{warningMessage}</p>
-							)}
+							<h2 className="warning-content__warning-code">{warningCode}</h2>
+							<p className="warning-content__warning-message">{warningMessage}</p>
 						</div>
 					</div>
 

--- a/frontend/src/components/WarningPopover/WarningPopover.tsx
+++ b/frontend/src/components/WarningPopover/WarningPopover.tsx
@@ -36,8 +36,12 @@ export function WarningContent({ warning }: WarningContentProps): JSX.Element {
 						</div>
 
 						<div className="warning-content__summary-text">
-							<h2 className="warning-content__warning-code">{warningCode}</h2>
-							<p className="warning-content__warning-message">{warningMessage}</p>
+							{warningCode && (
+								<h2 className="warning-content__warning-code">{warningCode}</h2>
+							)}
+							{warningMessage && (
+								<p className="warning-content__warning-message">{warningMessage}</p>
+							)}
 						</div>
 					</div>
 

--- a/frontend/src/components/WarningPopover/WarningPopover.tsx
+++ b/frontend/src/components/WarningPopover/WarningPopover.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useMemo } from 'react';
 import { Color } from '@signozhq/design-tokens';
 import { Button, Popover, PopoverProps } from 'antd';
 import ErrorIcon from 'assets/Error';
+import cx from 'classnames';
 import OverlayScrollbar from 'components/OverlayScrollbar/OverlayScrollbar';
 import { BookOpenText, ChevronsDown, TriangleAlert } from '@signozhq/icons';
 import KeyValueLabel from 'periscope/components/KeyValueLabel';
@@ -30,16 +31,18 @@ export function WarningContent({ warning }: WarningContentProps): JSX.Element {
 			{/* Summary Header */}
 			<section className="warning-content__summary-section">
 				<header className="warning-content__summary">
-					<div className="warning-content__summary-left">
-						<div className="warning-content__icon-wrapper">
-							<ErrorIcon />
-						</div>
+					{(warningCode || warningMessage) && (
+						<div className="warning-content__summary-left">
+							<div className="warning-content__icon-wrapper">
+								<ErrorIcon />
+							</div>
 
-						<div className="warning-content__summary-text">
-							<h2 className="warning-content__warning-code">{warningCode}</h2>
-							<p className="warning-content__warning-message">{warningMessage}</p>
+							<div className="warning-content__summary-text">
+								<h2 className="warning-content__warning-code">{warningCode}</h2>
+								<p className="warning-content__warning-message">{warningMessage}</p>
+							</div>
 						</div>
-					</div>
+					)}
 
 					{warningUrl && (
 						<div className="warning-content__summary-right">
@@ -154,6 +157,10 @@ function WarningPopover({
 			overlayInnerStyle={{ padding: 0 }}
 			autoAdjustOverflow
 			{...popoverProps}
+			overlayClassName={cx(
+				'warning-popover-overlay',
+				popoverProps.overlayClassName,
+			)}
 		>
 			{children || (
 				<TriangleAlert


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Things fixes - 
1. Error icon drifted with the message text
2. change of Popover and popover arrow  color 
3. Header spacing 


#### Screenshots / Screen Recordings (if applicable)

Before -
<img width="698" height="305" alt="image" src="https://github.com/user-attachments/assets/c40599bd-9a09-4369-a47a-ef5c1016f39b" />

After -
<img width="784" height="267" alt="image" src="https://github.com/user-attachments/assets/8768d04e-4146-41ef-ac43-0c7ba2fb1f75" />

This popover is shared, so checked it on all the places it shows up.

1. /traces-explorer
<img width="647" height="247" alt="image" src="https://github.com/user-attachments/assets/f34a8ab5-9769-4867-9893-a7c69b22fea5" />

2. /logs/logs-explorer
<img width="902" height="316" alt="image" src="https://github.com/user-attachments/assets/02a2c354-b148-4f1d-be65-43e82e3e2f51" />

3. /alerts/new
<img width="640" height="362" alt="image" src="https://github.com/user-attachments/assets/0f44aa3b-6dc0-4ce6-9f7f-55f4cd279df6" />

4. /dashboard/:dashboardId
<img width="634" height="244" alt="image" src="https://github.com/user-attachments/assets/220096ce-cb1b-4e50-bd93-965f084e46c6" />

5. /infrastructure-monitoring/hosts
<img width="691" height="373" alt="image" src="https://github.com/user-attachments/assets/b71f3922-1337-435c-b8da-bea7b2a37588" />

6. /trace/:id
<img width="805" height="312" alt="image" src="https://github.com/user-attachments/assets/bcf8fff6-2dda-40f9-8ae7-bca80e8cd743" />

#### Issues closed by this PR

https://github.com/orgs/SigNoz/projects/39/views/11?filterQuery=assignee%3Atewarig&pane=issue&itemId=212938441&issue=SigNoz%7Cengineering-pod%7C5703
 
 
Tracked on the engineering-pod board, link above.

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

The header used baseline alignment with no gap and an unstyled icon wrapper, so the icon drifted
with wrapped text and long messages crowded the Open Docs button. Separately, the arrow fills from
`--antd-arrow-background-color`, which nothing set, so it never matched the popover body.

#### Fix Strategy
1. Arrow color: new `.warning-popover-overlay` class sets the variable, passed via `overlayClassName` and merged with `cx` so callers keep theirs.
2. Header: top-aligned, `gap: 16px`, icon in a fixed 24px non-shrinking box.
3. Summary row renders only when `code` or `message` is present — this is the one behavior change.

---

### 🧪 Testing Strategy

- Tests added/updated: none, it's CSS plus one conditional wrapper.
- Manual verification: all the places this popover renders, in dark and light mode.
- Edge cases covered: single line variant, warning with only a url, more than 10 messages, and `bottomLeft` placement.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: only this component, nothing else uses the new class.
- Potential regressions: low. Warnings with only `warnings[]` and no code/message won't show the top row anymore.
- Rollback plan: revert the commit.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed the warning popover arrow color and header alignment. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

-
---
