### PR TITLE
fix(drilldown): carry the field type through a breakout

### DIFF
--- a/frontend/src/components/FieldsSelector/OtherFields.tsx
+++ b/frontend/src/components/FieldsSelector/OtherFields.tsx
@@ -8,7 +8,6 @@ import { buildCompositeKey } from 'container/OptionsMenu/utils';
 import { useGetQueryKeySuggestions } from 'hooks/querySuggestions/useGetQueryKeySuggestions';
 import {
 	FieldContext,
-	FieldDataType,
 	SignalType,
 	TelemetryFieldKey,
 } from 'types/api/v5/queryRange';
@@ -55,7 +54,7 @@ function OtherFields({
 				key: buildCompositeKey(attr.name, attr.fieldContext as string),
 				signal: attr.signal as SignalType,
 				fieldContext: attr.fieldContext as FieldContext,
-				fieldDataType: attr.fieldDataType as FieldDataType,
+				fieldDataType: attr.fieldDataType,
 			}),
 		);
 		const addedIds = new Set(

--- a/frontend/src/components/QueryBuilderV2/QueryV2/QueryAggregation/QueryAggregationSelect.tsx
+++ b/frontend/src/components/QueryBuilderV2/QueryV2/QueryAggregation/QueryAggregationSelect.tsx
@@ -25,12 +25,12 @@ import CodeMirror, {
 } from '@uiw/react-codemirror';
 import { Button, Popover, Tooltip } from 'antd';
 import { getKeySuggestions } from 'api/querySuggestions/getKeySuggestions';
-import { QUERY_BUILDER_KEY_TYPES } from 'constants/antlrQueryConstants';
 import { QueryBuilderKeys } from 'constants/queryBuilder';
 import { tracesAggregateOperatorOptions } from 'constants/queryBuilderOperators';
 import { useIsDarkMode } from 'hooks/useDarkMode';
 import { Info, TriangleAlert } from '@signozhq/icons';
 import { IBuilderQuery } from 'types/api/queryBuilder/queryBuilderData';
+import { FieldDataType } from 'types/api/v5/queryRange';
 import { TracesAggregatorOperator } from 'types/common/queryBuilder';
 
 import { useQueryBuilderV2Context } from '../../QueryBuilderV2Context';
@@ -323,16 +323,16 @@ function QueryAggregationSelect({
 				TracesAggregatorOperator.RATE,
 			];
 
-			const fieldDataType =
+			const fieldDataType: FieldDataType | undefined =
 				functionContextForFetch &&
 				operatorsWithoutDataType.includes(functionContextForFetch)
 					? undefined
-					: QUERY_BUILDER_KEY_TYPES.NUMBER;
+					: 'number';
 
 			return getKeySuggestions({
 				signal: queryData.dataSource,
 				searchText: '',
-				fieldDataType: fieldDataType as QUERY_BUILDER_KEY_TYPES,
+				fieldDataType,
 			});
 		},
 		{

--- a/frontend/src/container/OptionsMenu/useOptionsMenu.ts
+++ b/frontend/src/container/OptionsMenu/useOptionsMenu.ts
@@ -113,7 +113,7 @@ const useOptionsMenu = ({
 					(suggestion) => ({
 						name: suggestion.name,
 						signal: suggestion.signal as SignalType,
-						fieldDataType: suggestion.fieldDataType as FieldDataType,
+						fieldDataType: suggestion.fieldDataType,
 						fieldContext: suggestion.fieldContext as FieldContext,
 					}),
 				);
@@ -192,7 +192,7 @@ const useOptionsMenu = ({
 				name: e.name,
 				signal: e.signal as SignalType,
 				fieldContext: e.fieldContext as FieldContext,
-				fieldDataType: e.fieldDataType as FieldDataType,
+				fieldDataType: e.fieldDataType,
 			}));
 		}
 		if (dataSource === DataSource.TRACES) {

--- a/frontend/src/container/QueryTable/Drilldown/BreakoutOptions.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/BreakoutOptions.tsx
@@ -4,11 +4,11 @@ import { Input } from '@signozhq/ui/input';
 import { Skeleton } from 'antd';
 import { getKeySuggestions } from 'api/querySuggestions/getKeySuggestions';
 import OverlayScrollbar from 'components/OverlayScrollbar/OverlayScrollbar';
-import { QUERY_BUILDER_KEY_TYPES } from 'constants/antlrQueryConstants';
 import useDebounce from 'hooks/useDebounce';
 import { ContextMenu } from 'periscope/components/ContextMenu';
 import { BaseAutocompleteData } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { MetricAggregation } from 'types/api/v5/queryRange';
+import { fieldDataTypeToDataType } from 'utils/fieldDataType';
 
 import { BreakoutOptionsProps } from './contextConfig';
 import { BreakoutAttributeType } from './types';
@@ -80,7 +80,7 @@ function BreakoutOptions({
 			keyArray.forEach((keyData) => {
 				transformedOptions.push({
 					key: keyData.name,
-					dataType: keyData.fieldDataType as QUERY_BUILDER_KEY_TYPES,
+					dataType: fieldDataTypeToDataType(keyData.fieldDataType),
 					type: '',
 				});
 			});

--- a/frontend/src/container/QueryTable/Drilldown/__tests__/Breakout.test.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/__tests__/Breakout.test.tsx
@@ -238,6 +238,10 @@ describe('TableDrilldown Breakout Functionality', () => {
 		expect(aggregateQueryData.groupBy).toHaveLength(1);
 		expect(aggregateQueryData.groupBy[0].key).toBe('deployment.environment');
 
+		// The picked field's type travels with it — dropping it leaves the breakout query
+		// untyped, so a drilldown on its result can't tell a number from a string.
+		expect(aggregateQueryData.groupBy[0].dataType).toBe('string');
+
 		// Verify that orderBy has been cleared (as per getBreakoutQuery logic)
 		expect(aggregateQueryData.orderBy).toStrictEqual([]);
 

--- a/frontend/src/container/QueryTable/Drilldown/tableDrilldownUtils.tsx
+++ b/frontend/src/container/QueryTable/Drilldown/tableDrilldownUtils.tsx
@@ -1,6 +1,5 @@
 import { OPERATORS, PANEL_TYPES } from 'constants/queryBuilder';
 import cloneDeep from 'lodash-es/cloneDeep';
-import { BaseAutocompleteData } from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { IBuilderQuery, Query } from 'types/api/queryBuilder/queryBuilderData';
 
 import { addFilterToSelectedQuery, FilterData } from './drilldownUtils';
@@ -89,7 +88,11 @@ export const getBreakoutQuery = (
 		.filter((item: IBuilderQuery) => item.queryName === aggregateData.queryName)
 		.map((item: IBuilderQuery) => ({
 			...item,
-			groupBy: [{ key: groupBy.key, type: groupBy.type } as BaseAutocompleteData],
+			// The picked field's type travels with it: dropped, the breakout query goes out
+			// untyped and a drilldown on its result can't tell a number from a string.
+			groupBy: [
+				{ key: groupBy.key, dataType: groupBy.dataType, type: groupBy.type },
+			],
 			orderBy: [],
 			legend: item.legend && groupBy.key ? `{{${groupBy.key}}}` : '',
 		}));

--- a/frontend/src/container/QueryTable/Drilldown/types.ts
+++ b/frontend/src/container/QueryTable/Drilldown/types.ts
@@ -1,6 +1,8 @@
 import { ReactNode } from 'react';
-import { QUERY_BUILDER_KEY_TYPES } from 'constants/antlrQueryConstants';
-import { BaseAutocompleteData } from 'types/api/queryBuilder/queryAutocompleteResponse';
+import {
+	BaseAutocompleteData,
+	DataTypes,
+} from 'types/api/queryBuilder/queryAutocompleteResponse';
 import { IBuilderQuery } from 'types/api/queryBuilder/queryBuilderData';
 
 export type ContextMenuItem = ReactNode;
@@ -31,7 +33,8 @@ export interface AggregateContextMenuConfig {
 
 export interface BreakoutAttributeType {
 	key: string;
-	dataType: QUERY_BUILDER_KEY_TYPES;
+	/** The picked field's type, in the vocabulary the group-by it becomes is read with. */
+	dataType: DataTypes;
 	type: string;
 }
 

--- a/frontend/src/types/api/querySuggestions/types.ts
+++ b/frontend/src/types/api/querySuggestions/types.ts
@@ -1,4 +1,4 @@
-import { QUERY_BUILDER_KEY_TYPES } from 'constants/antlrQueryConstants';
+import { FieldDataType } from 'types/api/v5/queryRange';
 
 export interface QueryKeyDataSuggestionsProps {
 	label: string;
@@ -7,7 +7,12 @@ export interface QueryKeyDataSuggestionsProps {
 	apply?: string;
 	detail?: string;
 	fieldContext?: 'resource' | 'scope' | 'attribute' | 'span';
-	fieldDataType?: QUERY_BUILDER_KEY_TYPES;
+	/**
+	 * The field's type as the API reports it. Was declared as the antlr key-type enum
+	 * (`string | number | boolean`), which the endpoint never returns — every consumer cast it
+	 * back to `FieldDataType`.
+	 */
+	fieldDataType?: FieldDataType;
 	name: string;
 	signal: 'traces' | 'logs' | 'metrics';
 }
@@ -26,7 +31,7 @@ export interface QueryKeyRequestProps {
 	signal: 'traces' | 'logs' | 'metrics';
 	searchText: string;
 	fieldContext?: 'resource' | 'scope' | 'attribute' | 'span';
-	fieldDataType?: QUERY_BUILDER_KEY_TYPES;
+	fieldDataType?: FieldDataType;
 	metricName?: string;
 	metricNamespace?: string;
 	signalSource?: 'meter' | '';

--- a/frontend/src/utils/__tests__/fieldDataType.test.ts
+++ b/frontend/src/utils/__tests__/fieldDataType.test.ts
@@ -1,0 +1,34 @@
+import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
+import type { FieldDataType } from 'types/api/v5/queryRange';
+
+import { fieldDataTypeToDataType } from '../fieldDataType';
+
+describe('fieldDataTypeToDataType', () => {
+	it('maps the reported numeric spellings onto the query-builder numerics', () => {
+		expect(fieldDataTypeToDataType('number')).toBe(DataTypes.Float64);
+		expect(fieldDataTypeToDataType('int64')).toBe(DataTypes.Int64);
+		expect(fieldDataTypeToDataType('float64')).toBe(DataTypes.Float64);
+	});
+
+	it('maps the list spellings onto the array types', () => {
+		expect(fieldDataTypeToDataType('[]string')).toBe(DataTypes.ArrayString);
+		expect(fieldDataTypeToDataType('[]bool')).toBe(DataTypes.ArrayBool);
+		expect(fieldDataTypeToDataType('[]int64')).toBe(DataTypes.ArrayInt64);
+		expect(fieldDataTypeToDataType('[]float64')).toBe(DataTypes.ArrayFloat64);
+		expect(fieldDataTypeToDataType('[]number')).toBe(DataTypes.ArrayFloat64);
+	});
+
+	it('passes through the spellings the two vocabularies share', () => {
+		expect(fieldDataTypeToDataType('string')).toBe(DataTypes.String);
+		expect(fieldDataTypeToDataType('bool')).toBe(DataTypes.bool);
+	});
+
+	it('returns EMPTY for empty, missing and not-yet-known types', () => {
+		expect(fieldDataTypeToDataType('')).toBe(DataTypes.EMPTY);
+		expect(fieldDataTypeToDataType(undefined)).toBe(DataTypes.EMPTY);
+		// The backend can store `[]json` / `[]dynamic`, which the API union doesn't list.
+		expect(fieldDataTypeToDataType('[]json' as FieldDataType)).toBe(
+			DataTypes.EMPTY,
+		);
+	});
+});

--- a/frontend/src/utils/fieldDataType.ts
+++ b/frontend/src/utils/fieldDataType.ts
@@ -1,0 +1,31 @@
+import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
+import type { FieldDataType } from 'types/api/v5/queryRange';
+
+/**
+ * The field metadata APIs and the query builder spell field types differently: the metadata
+ * collapses the numerics to `number` and writes lists as `[]string`, while `DataTypes` — which
+ * keys the operator and attribute-value lookups — uses `float64` and `array(string)`. Convert
+ * where a reported type becomes a query-builder one, so those lookups can't miss.
+ */
+const TO_DATA_TYPE: Record<FieldDataType, DataTypes> = {
+	'': DataTypes.EMPTY,
+	string: DataTypes.String,
+	bool: DataTypes.bool,
+	int64: DataTypes.Int64,
+	float64: DataTypes.Float64,
+	number: DataTypes.Float64,
+	'[]string': DataTypes.ArrayString,
+	'[]bool': DataTypes.ArrayBool,
+	'[]int64': DataTypes.ArrayInt64,
+	'[]float64': DataTypes.ArrayFloat64,
+	'[]number': DataTypes.ArrayFloat64,
+};
+
+/**
+ * Exhaustive over `FieldDataType`, so a type added to the API union fails to compile here
+ * rather than going missing at runtime. The fallback is for a spelling the union doesn't know
+ * yet — the backend can store `[]json` and `[]dynamic` — not for any of the cases above.
+ */
+export const fieldDataTypeToDataType = (
+	fieldDataType?: FieldDataType,
+): DataTypes => TO_DATA_TYPE[fieldDataType ?? ''] ?? DataTypes.EMPTY;


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

A breakout threw away the field type. `getBreakoutQuery` rebuilt the group-by as `{ key, type }`, so the breakout query goes out with no field type for the backend to work from — and a drilldown on the breakout's *own* result has nothing to branch on, which means a numeric column's filter value gets quoted like a string.

Carrying the type through turned out to need a type fix first, which is most of this diff. `QueryKeyDataSuggestionsProps.fieldDataType` was declared as the antlr key-type enum (`string | number | boolean`) — a vocabulary that endpoint never returns. Five call sites already cast it back to `FieldDataType` to get anything done, and passing it into a group-by needed a second cast on top. Fixing the declaration removes all of them instead of adding one more.

Builds on #12298, which is already merged — a numeric breakout now carries a real type, and before that fix the operator menu threw on any spelling its map didn't have. This branch is rebased on top of it.

#### Screenshots / Screen Recordings (if applicable)

No visual change. The behavioural difference is in the query a breakout produces: its group-by now carries `dataType`, so a subsequent drilldown on that result filters on `status_code = 200` rather than `status_code = '200'`.

---

### Issues Closed
 Closes https://github.com/SigNoz/pulse-pod/issues/158

### ✅ Change Type

- [x] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

Two things, one behind the other:

1. `getBreakoutQuery` dropped `dataType` when it rebuilt the group-by — a plain omission, masked by the fact that an absent type degrades quietly (the backend infers, and the drilldown treats "no type" as "not numeric").
2. It couldn't have been carried through as the code stood: the suggestions response declared its field type in a third vocabulary, so the value's declared type didn't fit anywhere it needed to go. The existing `as FieldDataType` casts scattered around are the fingerprints of that.

#### Fix Strategy

- declare the suggestions response's `fieldDataType` as `FieldDataType` — what the endpoint actually returns — and delete the casts that existed only to undo the wrong declaration (`useOptionsMenu`, `OtherFields`, `QueryAggregationSelect`)
- convert where a *reported* type becomes a *query-builder* type, so that crossing is a function call rather than a cast (`utils/fieldDataType.ts`). The table is keyed `Record<FieldDataType, DataTypes>`, so a type added to the API union fails to compile here instead of going missing at runtime — verified by temporarily adding `'[]json'` to the union and watching it error, then restoring
- carry `dataType` through `getBreakoutQuery`; with a real `DataTypes` the object satisfies `BaseAutocompleteData` on its own, so that cast goes too

Net: one small converter added, four casts removed, one type declaration corrected.

---

### 🧪 Testing Strategy

- **Tests added/updated:**
  - `Breakout.test.tsx` — asserts the picked field's type survives into the breakout query's group-by. Stashing only the runtime change makes it fail with `Received: undefined`, so it's a real regression test.
  - `fieldDataType.test.ts` — the converter across the numeric spellings, the list spellings, values already in the query-builder vocabulary, and unknown/missing input.
- **Manual verification:** not done in a browser — my dev server proxies to a remote tenant I can't authenticate against.
- **Edge cases covered:** `number` / `int64` / `float64` / `bool` / `string`, `[]string` and friends, unrecognized and absent types (both become `EMPTY`, which every consumer already treats as unknown).

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** the type declaration is read by the options menu, the fields selector, the aggregation-select suggestion fetch and the drilldown breakout. All four are compile-time only — `tsgo --noEmit` is clean and no runtime value changes in them (`QUERY_BUILDER_KEY_TYPES.NUMBER` and the `'number'` literal it was replaced with are the same string).
- **Behavioural change:** exactly one — a breakout's group-by now carries a field type, so the V5 payload sends `fieldDataType` instead of omitting it, and a drilldown on a breakout result types numeric filter values as numbers.

#### What the backend does with that type

Since that payload change is the whole risk surface, I traced it per signal rather than assuming:

- **Metrics — ignored outright.** The metrics field mapper takes the required data type as `_` and discards it (`pkg/telemetrymetrics/field_mapper.go:105`), and the statement builder hardcodes `FieldDataTypeString` for every group-by regardless of the key's own type (`pkg/telemetrymetrics/statement_builder.go:318`). The panel in the original report is metrics, so that flow is provably unaffected.
- **Logs / traces — effectively no change.** The column switch *does* branch on the type (`attributes_string` / `attributes_number` / `attributes_bool`, `pkg/telemetrylogs/field_mapper.go:87-95`), and an attribute with `Unspecified` falls through it to `ErrColumnNotFound` — which is what made me check. But the group-by path doesn't get there with our key: `CandidateKeys` (`field_mapper.go:351-357`) resolves `keys[field.Name]` from DB metadata and returns every variant, ignoring the `fieldDataType` we send. It's only used to *synthesize* a key when metadata has no match — and there `''` previously meant `ErrColumnNotFound`, so carrying a real type is strictly better.

So for keys that exist in metadata the value is advisory, and for body-JSON fields it's an improvement. Corrections welcome if I've misread the resolution order.
- **Test status:** 98 tests pass across the drilldown, options-menu, fields-selector and converter suites. `QuerySearch.test.tsx` fails, and it fails identically with my changes stashed — pre-existing state leaking between tests in that file, unrelated to this diff.
- **Rollback plan:** revert the single commit; nothing here touches stored data or migrations.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Breaking out a panel by an attribute now keeps that field's type, so filters built by drilling into the result are typed correctly. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested — see Testing Strategy
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The interesting question is the declaration change, not the one-line carry-through. If `QueryKeyDataSuggestionsProps.fieldDataType` should stay as the antlr enum for a reason I haven't found, say so and I'll do this with a local conversion instead — but then the five existing `as FieldDataType` casts deserve an explanation too.

Broader context for why these vocabularies keep colliding: SigNoz/pulse-pod#145.
