### PR TITLE
fix(metrics-explorer): fetch related dashboards from the v3 API

### DIFF
--- a/frontend/src/container/MetricsExplorer/MetricDetails/DashboardsAndAlertsPopover.tsx
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/DashboardsAndAlertsPopover.tsx
@@ -6,7 +6,7 @@ import { Skeleton } from 'antd';
 import { Typography } from '@signozhq/ui/typography';
 import {
 	useGetMetricAlerts,
-	useGetMetricDashboards,
+	useGetMetricDashboardsV2,
 } from 'api/generated/services/metrics';
 import { QueryParams } from 'constants/query';
 import ROUTES from 'constants/routes';
@@ -38,7 +38,7 @@ function DashboardsAndAlertsPopover({
 		data: dashboardsData,
 		isLoading: isLoadingDashboards,
 		isError: isErrorDashboards,
-	} = useGetMetricDashboards(
+	} = useGetMetricDashboardsV2(
 		{
 			metricName,
 		},
@@ -55,7 +55,8 @@ function DashboardsAndAlertsPopover({
 
 	const dashboards = useMemo(() => {
 		const currentDashboards = dashboardsData?.data.dashboards ?? [];
-		// Remove duplicate dashboards
+		// The API returns one entry per referencing panel, so a dashboard repeats
+		// once per panel that uses the metric.
 		return currentDashboards.filter(
 			(dashboard, index, self) =>
 				index === self.findIndex((t) => t.dashboardId === dashboard.dashboardId),

--- a/frontend/src/container/MetricsExplorer/MetricDetails/__tests__/DashboardsAndAlertsPopover.test.tsx
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/__tests__/DashboardsAndAlertsPopover.test.tsx
@@ -23,7 +23,7 @@ const useGetMetricAlertsMock = jest.spyOn(
 );
 const useGetMetricDashboardsMock = jest.spyOn(
 	metricsExplorerHooks,
-	'useGetMetricDashboards',
+	'useGetMetricDashboardsV2',
 );
 
 describe('DashboardsAndAlertsPopover', () => {
@@ -153,11 +153,15 @@ describe('DashboardsAndAlertsPopover', () => {
 		);
 	});
 
-	it('renders unique dashboards even when there are duplicates', async () => {
+	it('collapses multiple panels of the same dashboard into one entry', async () => {
 		useGetMetricDashboardsMock.mockReturnValue(
 			getMockDashboardsData({
 				data: {
-					dashboards: [MOCK_DASHBOARD_1, MOCK_DASHBOARD_2, MOCK_DASHBOARD_1],
+					dashboards: [
+						MOCK_DASHBOARD_1,
+						MOCK_DASHBOARD_2,
+						{ ...MOCK_DASHBOARD_1, panelId: '3', panelName: 'Panel 3' },
+					],
 				},
 			}),
 		);

--- a/frontend/src/container/MetricsExplorer/MetricDetails/__tests__/testUtlls.ts
+++ b/frontend/src/container/MetricsExplorer/MetricDetails/__tests__/testUtlls.ts
@@ -2,7 +2,7 @@ import * as metricsExplorerHooks from 'api/generated/services/metrics';
 import {
 	GetMetricAlerts200,
 	GetMetricAttributes200,
-	GetMetricDashboards200,
+	GetMetricDashboardsV2200,
 	GetMetricHighlights200,
 	GetMetricMetadata200,
 	MetrictypesTemporalityDTO,
@@ -40,14 +40,14 @@ export function getMockMetricHighlightsData(
 export const MOCK_DASHBOARD_1 = {
 	dashboardName: 'Dashboard 1',
 	dashboardId: '1',
-	widgetId: '1',
-	widgetName: 'Widget 1',
+	panelId: '1',
+	panelName: 'Panel 1',
 };
 export const MOCK_DASHBOARD_2 = {
 	dashboardName: 'Dashboard 2',
 	dashboardId: '2',
-	widgetId: '2',
-	widgetName: 'Widget 2',
+	panelId: '2',
+	panelName: 'Panel 2',
 };
 export const MOCK_ALERT_1 = {
 	alertName: 'Alert 1',
@@ -59,7 +59,7 @@ export const MOCK_ALERT_2 = {
 };
 
 export function getMockDashboardsData(
-	overrides?: Partial<GetMetricDashboards200>,
+	overrides?: Partial<GetMetricDashboardsV2200>,
 	{
 		isLoading = false,
 		isError = false,
@@ -67,7 +67,7 @@ export function getMockDashboardsData(
 		isLoading?: boolean;
 		isError?: boolean;
 	} = {},
-): ReturnType<typeof metricsExplorerHooks.useGetMetricDashboards> {
+): ReturnType<typeof metricsExplorerHooks.useGetMetricDashboardsV2> {
 	return {
 		data: {
 			data: {
@@ -79,7 +79,7 @@ export function getMockDashboardsData(
 
 		isLoading,
 		isError,
-	} as ReturnType<typeof metricsExplorerHooks.useGetMetricDashboards>;
+	} as ReturnType<typeof metricsExplorerHooks.useGetMetricDashboardsV2>;
 }
 
 export function getMockAlertsData(


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

The metric details drawer in Metrics Explorer shows a "N dashboards" pill listing the dashboards that reference the metric. It resolved that through `GET /api/v2/metrics/dashboards`, whose backend only understands v1-schema dashboards — so since the Perses migration it matches nothing and the pill silently shows no dashboards.

Switches the popover to `useGetMetricDashboardsV2` (`GET /api/v3/metrics/dashboards`), which parses the Perses spec.

#### Issues closed by this PR

Closes https://github.com/SigNoz/pulse-pod/issues/151

---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

The two endpoints read different schemas, and the app moved to the other side of that line.

`GET /api/v2/metrics/dashboards` → [`GetByMetricNames`](https://github.com/SigNoz/signoz/blob/main/pkg/modules/dashboard/impldashboard/module.go#L172) walks the raw stored blob:

```go
widgets, ok := dashData["widgets"].([]interface{})
if !ok {
    continue
}
```

A Perses dashboard has `spec.panels`, not `widgets`, so every dashboard is skipped.

`GET /api/v3/metrics/dashboards` → [`GetByMetricNamesV2`](https://github.com/SigNoz/signoz/blob/main/pkg/modules/dashboard/impldashboard/v2_dashboards_by_metric_name.go#L14) (added in #11784) parses the spec, and is the mirror image: `ToDashboardV2` [rejects anything that isn't `schemaVersion == "v6"`](https://github.com/SigNoz/signoz/blob/main/pkg/types/dashboardtypes/perses_dashboard.go#L484).

#12249 landed both halves of the migration — `pkg/sqlmigration/103_migrate_dashboards_v1_to_v2.go` converts stored dashboards to Perses, and `pages/DashboardPage/index.tsx` now renders `DashboardPageV2` unconditionally. Post-migration every dashboard is v6: the v2 endpoint matches zero, the v3 endpoint matches all. The popover was still on v2.

It fails silently rather than loudly — [the component](https://github.com/SigNoz/signoz/blob/main/frontend/src/container/MetricsExplorer/MetricDetails/DashboardsAndAlertsPopover.tsx#L120-L125) treats an empty list as "this metric isn't on any dashboard" and renders an empty container. A metric charted on a dozen dashboards looked identical to one charted on none.

#### Fix Strategy

Swap the hook. The response item changes from `MetricDashboard` to `DashboardPanelRef`:

| v2 | v3 |
|---|---|
| `dashboardId` | `dashboardId` |
| `dashboardName` | `dashboardName` |
| `widgetId` | `panelId` |
| `widgetName` | `panelName` |
| — | `groupBy`, `filterBy` (optional) |

The popover only reads `dashboardId`/`dashboardName`, so the render path and the `/dashboard/:dashboardId` link are unchanged. The existing dedup still applies — v3 returns one entry per referencing *panel*, so a dashboard with three panels on the metric arrives three times — and the comment now says why rather than just restating the code.

**Alerts are deliberately untouched.** There is no v3 counterpart, and [`GetMetricAlerts`](https://github.com/SigNoz/signoz/blob/main/pkg/modules/metricsexplorer/implmetricsexplorer/module.go#L375) reads the rule store rather than dashboard schema, so the migration never affected it.

---

### 🧪 Testing Strategy

- **Tests added/updated:** fixtures in `testUtlls.ts` moved to the v3 shape (`widgetId`/`widgetName` → `panelId`/`panelName`, `GetMetricDashboards200` → `GetMetricDashboardsV2200`), and the spy retargeted to `useGetMetricDashboardsV2`. The dedup test was renamed to *"collapses multiple panels of the same dashboard into one entry"* and its fixture reworked from a literally-repeated object to two distinct panels of the same dashboard — which is what the v3 API actually returns, and what the dedup exists for. 8/8 pass.
- **Manual verification:** not run. Needs a stack with migrated (v6) dashboards charting a metric that also has ingested data; I couldn't stand that up here. **This is the gap worth covering before merge** — the change is small, but its whole point is a runtime behaviour I haven't observed.
- **Static checks:** `pnpm tsgo --noEmit` clean, `oxfmt --check` clean, `oxlint` reports no new warnings on the touched files (8 pre-existing `no-floating-promises` warnings elsewhere in the folder).
- **Edge cases covered:** empty dashboards list, single dashboard, missing `dashboardName` (falls back to id), multiple panels per dashboard, dashboards error while alerts succeed.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** one component, one read-only GET. No writes, no schema change, no API contract change. The alerts half of the popover is untouched.
- **Potential regressions:** any deployment whose dashboards have *not* been through migration 103 would go from "v2 endpoint finds them" to "v3 endpoint doesn't" — i.e. the same empty pill, just for the opposite reason. Given #12249 ships the migration alongside the unconditional V2 page render, that state shouldn't persist, but it's the one scenario where this makes things no better.
- **Rollback plan:** revert the commit; it's a hook name and two field renames in fixtures.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | The metric details drawer in Metrics Explorer again lists the dashboards that use a metric; the count had silently dropped to zero after dashboards moved to the new schema. |

---

## 👀 Notes for Reviewers

**Panel-level data is available now but discarded.** v3 hands back `panelId`/`panelName`, and there's a ready-made pattern for it in this same feature area — [`RelatedAssetsWarning.tsx`](https://github.com/SigNoz/signoz/blob/main/frontend/src/container/MetricsExplorer/VolumeControl/components/VolumeControlConfigDrawer/RelatedAssetsWarning/RelatedAssetsWarning.tsx#L20-L25) deep-links `?expandedWidgetId=<panelId>` and labels entries `Dashboard · Panel`. I left it out because adopting it means the pill count ("N dashboards") stops matching the menu item count, which is a product call rather than a mechanical one. Noted on the issue as a separate decision — say the word and I'll fold it in.

`groupBy`/`filterBy` also come back on each ref and are likewise unused here.
