### PR TITLE
fix: add meter source where needed during dashboard migration

### DIFF
--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -227,6 +227,7 @@ func NewSQLMigrationProviderFactories(
 		sqlmigration.NewAddTelemetryTuplesFactory(sqlstore),
 		sqlmigration.NewAddTagRelationRankFactory(sqlstore, sqlschema),
 		sqlmigration.NewMigrateDashboardsV1ToV2Factory(sqlstore, sqlschema, dashboardStore, tagModule),
+		sqlmigration.NewFillDashboardMeterSourceFactory(sqlstore, dashboardStore),
 	)
 }
 

--- a/pkg/sqlmigration/104_fill_dashboard_meter_source.go
+++ b/pkg/sqlmigration/104_fill_dashboard_meter_source.go
@@ -1,0 +1,166 @@
+package sqlmigration
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/dashboardtypes"
+	qb "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/migrate"
+)
+
+// meterMetricNames are the SigNoz meter metrics: a metrics query aggregating one of
+// these is a meter query. Spans what the frontend authors (log/span count and size,
+// metric datapoint count) plus the backend platform.active meter.
+var meterMetricNames = map[string]bool{
+	"signoz.meter.log.count":              true,
+	"signoz.meter.log.size":               true,
+	"signoz.meter.span.count":             true,
+	"signoz.meter.span.size":              true,
+	"signoz.meter.metric.datapoint.count": true,
+	"signoz.meter.platform.active":        true,
+}
+
+type fillDashboardMeterSource struct {
+	sqlstore       sqlstore.SQLStore
+	dashboardStore dashboardtypes.Store
+	settings       factory.ProviderSettings
+}
+
+func NewFillDashboardMeterSourceFactory(sqlstore sqlstore.SQLStore, dashboardStore dashboardtypes.Store) factory.ProviderFactory[SQLMigration, Config] {
+	return factory.NewProviderFactory(
+		factory.MustNewName("fill_dashboard_meter_source"),
+		func(ctx context.Context, ps factory.ProviderSettings, c Config) (SQLMigration, error) {
+			return &fillDashboardMeterSource{sqlstore: sqlstore, dashboardStore: dashboardStore, settings: ps}, nil
+		},
+	)
+}
+
+func (migration *fillDashboardMeterSource) Register(migrations *migrate.Migrations) error {
+	return migrations.Register(migration.Up, migration.Down)
+}
+
+// Up restores the meter source on v2 dashboards mis-migrated by 103. That migration
+// mapped a v1 meter query (dataSource metrics + source "meter") to a plain metrics
+// query and dropped the source, so on clusters where 103 already ran those panels read
+// non-meter data. Every metrics builder query aggregating a meter metric has its source
+// set back to "meter". v1 dashboards are left alone — 103 now carries the source through
+// when it runs. Runs in a single transaction so a mid-run failure leaves every dashboard
+// untouched; a dashboard whose data can't be parsed as v2 is skipped.
+func (migration *fillDashboardMeterSource) Up(ctx context.Context, _ *bun.DB) error {
+	return migration.sqlstore.RunInTxCtx(ctx, nil, func(ctx context.Context) error {
+		var orgIDs []string
+		if err := migration.sqlstore.BunDBCtx(ctx).NewSelect().Model((*types.Organization)(nil)).Column("id").Scan(ctx, &orgIDs); err != nil {
+			return err
+		}
+
+		for _, id := range orgIDs {
+			orgID, err := valuer.NewUUID(id)
+			if err != nil {
+				return err
+			}
+			if err := migration.fillOrg(ctx, orgID); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// fillOrg fills the meter source on every v2 dashboard in the org that needs it. Runs
+// inside the caller's transaction.
+func (migration *fillDashboardMeterSource) fillOrg(ctx context.Context, orgID valuer.UUID) error {
+	// List, not ListV2: ListV2 paginates and excludes system dashboards; a migration needs every row.
+	storables, err := migration.dashboardStore.List(ctx, orgID)
+	if err != nil {
+		return err
+	}
+
+	logger := migration.settings.Logger
+	var stillInV1, skippedNoMeter, wouldMigrateButErrored, migrated int
+	for _, storable := range storables {
+		// ToDashboardV2 rejects non-v2 data, so v1 dashboards fall through untouched.
+		dashboard, err := storable.ToDashboardV2(nil)
+		if err != nil {
+			stillInV1++
+			continue
+		}
+		if !fillMeterSource(&dashboard.Spec) {
+			skippedNoMeter++
+			continue
+		}
+		restorable, err := dashboard.ToStorableDashboard()
+		if err != nil {
+			wouldMigrateButErrored++
+			logger.WarnContext(ctx, "failed to re-serialize dashboard after filling meter source", slog.String("org_id", orgID.String()), slog.String("dashboard_id", storable.ID.String()), slog.Any("error", err))
+			continue
+		}
+		if err := migration.dashboardStore.Update(ctx, orgID, restorable); err != nil {
+			return err
+		}
+		migrated++
+	}
+
+	logger.InfoContext(ctx, "filled meter source on v2 dashboards",
+		slog.String("org_id", orgID.String()),
+		slog.Int("total", len(storables)),
+		slog.Int("still_in_v1", stillInV1),
+		slog.Int("skipped_no_meter", skippedNoMeter),
+		slog.Int("would_migrate_but_errored", wouldMigrateButErrored),
+		slog.Int("migrated", migrated),
+	)
+	return nil
+}
+
+// fillMeterSource sets Source=meter on every metrics builder query in the spec whose
+// aggregation targets a meter metric, reporting whether anything changed.
+func fillMeterSource(spec *dashboardtypes.DashboardSpec) bool {
+	changed := false
+	for _, panel := range spec.Panels {
+		if panel == nil {
+			continue
+		}
+		for _, query := range panel.Spec.Queries {
+			switch plugin := query.Spec.Plugin.Spec.(type) {
+			case *qb.CompositeQuery:
+				for i := range plugin.Queries {
+					changed = setMeterSource(&plugin.Queries[i].Spec) || changed
+				}
+			case *dashboardtypes.BuilderQuerySpec:
+				changed = setMeterSource(&plugin.Spec) || changed
+			}
+		}
+	}
+	return changed
+}
+
+// setMeterSource sets the meter source when spec holds a metrics builder query
+// aggregating a meter metric. The assertion to QueryBuilderQuery[MetricAggregation] is
+// itself the metrics-signal check — only metrics queries decode to that type — and the
+// already-meter guard keeps repeated runs idempotent. The mutated value is written back
+// through the pointer, since a value inside an interface isn't addressable.
+func setMeterSource(spec *any) bool {
+	query, ok := (*spec).(qb.QueryBuilderQuery[qb.MetricAggregation])
+	if !ok || query.Source == telemetrytypes.SourceMeter {
+		return false
+	}
+	for _, aggregation := range query.Aggregations {
+		if meterMetricNames[aggregation.MetricName] {
+			query.Source = telemetrytypes.SourceMeter
+			*spec = query
+			return true
+		}
+	}
+	return false
+}
+
+func (migration *fillDashboardMeterSource) Down(context.Context, *bun.DB) error {
+	return nil
+}

--- a/pkg/sqlmigration/104_fill_dashboard_meter_source.go
+++ b/pkg/sqlmigration/104_fill_dashboard_meter_source.go
@@ -15,9 +15,8 @@ import (
 	"github.com/uptrace/bun/migrate"
 )
 
-// meterMetricNames are the SigNoz meter metrics: a metrics query aggregating one of
-// these is a meter query. Spans what the frontend authors (log/span count and size,
-// metric datapoint count) plus the backend platform.active meter.
+// meterMetricNames are the SigNoz meter metrics; a metrics query aggregating one is a
+// meter query.
 var meterMetricNames = map[string]bool{
 	"signoz.meter.log.count":              true,
 	"signoz.meter.log.size":               true,
@@ -46,13 +45,9 @@ func (migration *fillDashboardMeterSource) Register(migrations *migrate.Migratio
 	return migrations.Register(migration.Up, migration.Down)
 }
 
-// Up restores the meter source on v2 dashboards mis-migrated by 103. That migration
-// mapped a v1 meter query (dataSource metrics + source "meter") to a plain metrics
-// query and dropped the source, so on clusters where 103 already ran those panels read
-// non-meter data. Every metrics builder query aggregating a meter metric has its source
-// set back to "meter". v1 dashboards are left alone — 103 now carries the source through
-// when it runs. Runs in a single transaction so a mid-run failure leaves every dashboard
-// untouched; a dashboard whose data can't be parsed as v2 is skipped.
+// Up resets the meter source that 103 dropped when converting v1 meter queries to v2:
+// every metrics query aggregating a meter metric is set back to source "meter". One
+// transaction; v1 (unparseable-as-v2) dashboards are skipped.
 func (migration *fillDashboardMeterSource) Up(ctx context.Context, _ *bun.DB) error {
 	return migration.sqlstore.RunInTxCtx(ctx, nil, func(ctx context.Context) error {
 		var orgIDs []string
@@ -141,11 +136,9 @@ func fillMeterSource(spec *dashboardtypes.DashboardSpec) bool {
 	return changed
 }
 
-// setMeterSource sets the meter source when spec holds a metrics builder query
-// aggregating a meter metric. The assertion to QueryBuilderQuery[MetricAggregation] is
-// itself the metrics-signal check — only metrics queries decode to that type — and the
-// already-meter guard keeps repeated runs idempotent. The mutated value is written back
-// through the pointer, since a value inside an interface isn't addressable.
+// setMeterSource sets source "meter" on a metrics query aggregating a meter metric. The
+// type assertion doubles as the metrics-signal check; the already-meter guard keeps it
+// idempotent. Written back through the pointer, as an interface value isn't addressable.
 func setMeterSource(spec *any) bool {
 	query, ok := (*spec).(qb.QueryBuilderQuery[qb.MetricAggregation])
 	if !ok || query.Source == telemetrytypes.SourceMeter {

--- a/pkg/types/dashboardtypes/perses_v1_to_v2_queries.go
+++ b/pkg/types/dashboardtypes/perses_v1_to_v2_queries.go
@@ -189,9 +189,7 @@ func (d *v1Decoder) collectV1QueryEnvelopes(widget map[string]any, panelKind Pan
 		queries = dropUnrenderableQueries(queries)
 		for _, q := range queries {
 			name := d.readString(q, "queryName")
-			env := qb.WrapInV5Envelope(name, q, string(qb.QueryTypeBuilder.StringValue()))
-			carryQuerySource(env, q)
-			out = append(out, env)
+			out = append(out, qb.WrapInV5Envelope(name, q, string(qb.QueryTypeBuilder.StringValue())))
 			if signal.IsZero() {
 				signal = signalFromDataSource(q["dataSource"])
 			}
@@ -447,17 +445,4 @@ func signalFromDataSource(raw any) telemetrytypes.Signal {
 		return telemetrytypes.SignalMetrics
 	}
 	return telemetrytypes.Signal{}
-}
-
-// carryQuerySource copies a v1 builder query's meter source onto the v5 spec.
-// WrapInV5Envelope maps dataSource→signal but ignores the separate `source` field, so a
-// meter query (dataSource metrics + source "meter") would otherwise migrate as plain
-// metrics and read the wrong data. Only "meter" is carried through — the sole non-empty
-// source the v1 UI produces and v5 accepts; anything else stays unspecified.
-func carryQuerySource(env, query map[string]any) {
-	if source, _ := query["source"].(string); source == telemetrytypes.SourceMeter.StringValue() {
-		if spec, ok := env["spec"].(map[string]any); ok {
-			spec["source"] = source
-		}
-	}
 }

--- a/pkg/types/dashboardtypes/perses_v1_to_v2_queries.go
+++ b/pkg/types/dashboardtypes/perses_v1_to_v2_queries.go
@@ -189,7 +189,9 @@ func (d *v1Decoder) collectV1QueryEnvelopes(widget map[string]any, panelKind Pan
 		queries = dropUnrenderableQueries(queries)
 		for _, q := range queries {
 			name := d.readString(q, "queryName")
-			out = append(out, qb.WrapInV5Envelope(name, q, string(qb.QueryTypeBuilder.StringValue())))
+			env := qb.WrapInV5Envelope(name, q, string(qb.QueryTypeBuilder.StringValue()))
+			carryQuerySource(env, q)
+			out = append(out, env)
 			if signal.IsZero() {
 				signal = signalFromDataSource(q["dataSource"])
 			}
@@ -445,4 +447,17 @@ func signalFromDataSource(raw any) telemetrytypes.Signal {
 		return telemetrytypes.SignalMetrics
 	}
 	return telemetrytypes.Signal{}
+}
+
+// carryQuerySource copies a v1 builder query's meter source onto the v5 spec.
+// WrapInV5Envelope maps dataSource→signal but ignores the separate `source` field, so a
+// meter query (dataSource metrics + source "meter") would otherwise migrate as plain
+// metrics and read the wrong data. Only "meter" is carried through — the sole non-empty
+// source the v1 UI produces and v5 accepts; anything else stays unspecified.
+func carryQuerySource(env, query map[string]any) {
+	if source, _ := query["source"].(string); source == telemetrytypes.SourceMeter.StringValue() {
+		if spec, ok := env["spec"].(map[string]any); ok {
+			spec["source"] = source
+		}
+	}
 }

--- a/pkg/types/dashboardtypes/perses_v1_to_v2_test.go
+++ b/pkg/types/dashboardtypes/perses_v1_to_v2_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/coretypes"
 	qb "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/tagtypes"
+	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/perses/spec/go/dashboard"
 	"github.com/perses/spec/go/dashboard/variable"
@@ -1777,6 +1778,41 @@ func TestConvertV1WidgetQueryRewritesUnknownMetricValueOrderKey(t *testing.T) {
 	require.Len(t, spec.Order, 2)
 	assert.Equal(t, "sum(http_requests_total)", spec.Order[0].Key.Name, "unknown value alias rewritten to the aggregation key")
 	assert.Equal(t, "service.name", spec.Order[1].Key.Name, "valid group-by order key left alone")
+}
+
+// A v1 meter query is dataSource "metrics" with a separate source "meter". The signal
+// maps to metrics, and the meter source must survive onto the v5 spec — otherwise the
+// panel migrates as a plain metrics query and reads the wrong data.
+func TestConvertV1WidgetQueryCarriesMeterSource(t *testing.T) {
+	widget := map[string]any{
+		"id":         "meter-1",
+		"panelTypes": "graph",
+		"query": map[string]any{
+			"queryType": "builder",
+			"builder": map[string]any{
+				"queryData": []any{
+					map[string]any{
+						"queryName":    "A",
+						"expression":   "A",
+						"dataSource":   "metrics",
+						"source":       "meter",
+						"aggregations": []any{map[string]any{"metricName": "signoz.meter.log.size", "spaceAggregation": "sum"}},
+					},
+				},
+			},
+		},
+	}
+
+	queries := (&v1Decoder{}).convertV1WidgetQuery(widget, PanelKindTimeSeries)
+	require.Len(t, queries, 1)
+
+	wrapper, ok := queries[0].Spec.Plugin.Spec.(*BuilderQuerySpec)
+	require.True(t, ok)
+	spec, ok := wrapper.Spec.(qb.QueryBuilderQuery[qb.MetricAggregation])
+	require.True(t, ok, "meter query should dispatch to MetricAggregation, got %T", wrapper.Spec)
+
+	assert.Equal(t, telemetrytypes.SignalMetrics, spec.Signal, "signal maps from dataSource")
+	assert.Equal(t, telemetrytypes.SourceMeter, spec.Source, "meter source carried onto the v5 spec")
 }
 
 func TestConvertV1WidgetQueryInjectsCountForNoopOnAggregationPanel(t *testing.T) {

--- a/pkg/types/querybuildertypes/querybuildertypesv5/migrate_envelope.go
+++ b/pkg/types/querybuildertypes/querybuildertypesv5/migrate_envelope.go
@@ -44,6 +44,13 @@ func WrapInV5Envelope(name string, queryMap map[string]any, queryType string) ma
 		}
 	}
 
+	// Carry the query source (e.g. "meter"): a metrics-shaped query against a non-default
+	// data source, stored separately from dataSource. Only set when present so a query
+	// without one stays source-unspecified.
+	if source, ok := queryMap["source"].(string); ok && source != "" {
+		v5Query["source"] = source
+	}
+
 	if stepInterval, ok := queryMap["stepInterval"]; ok {
 		v5Query["stepInterval"] = stepInterval
 	}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

`qb.WrapInV5Envelope` did not handle the source field, which is causing query range API in meter panels to break. Need to add handling for this field in migration code.

#### Testing
Ran the dashbaord repo migration with this fix, and the `meter.json` works fine after this fix.