### PR TITLE
feat(dashboard-v2): format panel values with thousand separators

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/NumberPanel/__tests__/Renderer.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/NumberPanel/__tests__/Renderer.test.tsx
@@ -125,6 +125,37 @@ describe('NumberPanelRenderer', () => {
 		expect(queryByText('3.14159')).not.toBeInTheDocument();
 	});
 
+	// #7669: large scalars are unreadable as an undelimited digit run.
+	it('groups large values into thousands', () => {
+		const { getByText, queryByText } = renderPanel({
+			panel: panelWith({}),
+			data: dataWith('1234567'),
+		});
+
+		expect(getByText('1,234,567')).toBeInTheDocument();
+		expect(queryByText('1234567')).not.toBeInTheDocument();
+	});
+
+	it('groups the value while keeping its unit separate', () => {
+		const { getByText } = renderPanel({
+			panel: panelWith({ formatting: { unit: 'percent' } }),
+			data: dataWith('1234567'),
+		});
+
+		expect(getByText('1,234,567')).toBeInTheDocument();
+		expect(getByText('%')).toBeInTheDocument();
+	});
+
+	it('leaves a unit-scaled value ungrouped', () => {
+		const { getByText } = renderPanel({
+			panel: panelWith({ formatting: { unit: 'bytes' } }),
+			data: dataWith('1234567'),
+		});
+
+		expect(getByText('1.18')).toBeInTheDocument();
+		expect(getByText('MiB')).toBeInTheDocument();
+	});
+
 	it('renders No Data when the response has no scalar results', () => {
 		const { getByTestId } = renderPanel({ data: emptyData });
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/__tests__/Renderer.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/kinds/TablePanel/__tests__/Renderer.test.tsx
@@ -93,6 +93,15 @@ describe('TablePanelRenderer', () => {
 		expect(getByText('cartservice')).toBeInTheDocument();
 	});
 
+	// Value cells share `formatPanelValue`, so they group like the Number panel.
+	it('groups large value cells into thousands', () => {
+		const { getByText } = renderPanel({
+			data: dataWith([['frontend', 1234567]]),
+		});
+
+		expect(getByText('1,234,567')).toBeInTheDocument();
+	});
+
 	it('renders No Data when the response has no scalar results', () => {
 		const { getByTestId } = renderPanel({ data: emptyData });
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/formatPanelValue.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/formatPanelValue.test.ts
@@ -30,4 +30,14 @@ describe('formatPanelValue', () => {
 	it('renders whole numbers without a trailing decimal', () => {
 		expect(formatPanelValue(5, undefined, 2)).toBe('5');
 	});
+
+	it('groups the integer part into thousands', () => {
+		expect(formatPanelValue(1234567, undefined, 2)).toBe('1,234,567');
+		expect(formatPanelValue(1234567, 'percent', 2)).toBe('1,234,567%');
+		expect(formatPanelValue(1234567.891, undefined, 2)).toBe('1,234,567.89');
+	});
+
+	it('leaves unit-scaled values ungrouped', () => {
+		expect(formatPanelValue(1234567, 'bytes', 2)).toBe('1.18 MiB');
+	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/groupThousands.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/groupThousands.test.ts
@@ -1,0 +1,55 @@
+import { groupThousands } from '../groupThousands';
+
+describe('groupThousands', () => {
+	it('groups the integer digits of a plain number', () => {
+		expect(groupThousands('1234567')).toBe('1,234,567');
+		expect(groupThousands('1000')).toBe('1,000');
+		expect(groupThousands('1000000000000000000000')).toBe(
+			'1,000,000,000,000,000,000,000',
+		);
+	});
+
+	it('leaves values below a thousand alone', () => {
+		expect(groupThousands('0')).toBe('0');
+		expect(groupThousands('999')).toBe('999');
+		expect(groupThousands('295.43')).toBe('295.43');
+	});
+
+	it('groups only the integer part', () => {
+		expect(groupThousands('1234567.891')).toBe('1,234,567.891');
+		expect(groupThousands('1234.0001234')).toBe('1,234.0001234');
+	});
+
+	it('keeps the sign outside the first group', () => {
+		expect(groupThousands('-1234567')).toBe('-1,234,567');
+		expect(groupThousands('-1234567.891')).toBe('-1,234,567.891');
+	});
+
+	it('preserves suffix and prefix unit decoration', () => {
+		expect(groupThousands('1234567 ms')).toBe('1,234,567 ms');
+		expect(groupThousands('1234567%')).toBe('1,234,567%');
+		expect(groupThousands('$ 1234567')).toBe('$ 1,234,567');
+	});
+
+	it('leaves formatter-scaled values untouched', () => {
+		expect(groupThousands('1.18 MiB')).toBe('1.18 MiB');
+		expect(groupThousands('1.23 Mil')).toBe('1.23 Mil');
+		expect(groupThousands('20.58 mins')).toBe('20.58 mins');
+	});
+
+	it('leaves exponent notation untouched', () => {
+		expect(groupThousands('1.234567e+21')).toBe('1.234567e+21');
+		expect(groupThousands('1234567e-8')).toBe('1234567e-8');
+	});
+
+	it('returns non-numeric output unchanged', () => {
+		expect(groupThousands('∞')).toBe('∞');
+		expect(groupThousands('-∞')).toBe('-∞');
+		expect(groupThousands('NaN')).toBe('NaN');
+		expect(groupThousands('')).toBe('');
+	});
+
+	it('is idempotent on already-grouped input', () => {
+		expect(groupThousands(groupThousands('1234567'))).toBe('1,234,567');
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/parseFormattedValue.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/__tests__/parseFormattedValue.test.ts
@@ -1,0 +1,60 @@
+import { parseFormattedValue } from '../parseFormattedValue';
+
+describe('parseFormattedValue', () => {
+	it('splits a trailing unit label off the numeric core', () => {
+		expect(parseFormattedValue('295.43 ms')).toStrictEqual({
+			numericValue: '295.43',
+			prefixUnit: '',
+			suffixUnit: 'ms',
+		});
+	});
+
+	it('splits a leading currency symbol off the numeric core', () => {
+		expect(parseFormattedValue('$ 1.2K')).toStrictEqual({
+			numericValue: '1.2K',
+			prefixUnit: '$',
+			suffixUnit: '',
+		});
+	});
+
+	// Regression: the numeric core used to reject `,`, so a grouped value fell
+	// through to the whole-string fallback and lost its unit split.
+	it('keeps the unit split for grouped values', () => {
+		expect(parseFormattedValue('1,234,567 ms')).toStrictEqual({
+			numericValue: '1,234,567',
+			prefixUnit: '',
+			suffixUnit: 'ms',
+		});
+		expect(parseFormattedValue('1,234,567%')).toStrictEqual({
+			numericValue: '1,234,567',
+			prefixUnit: '',
+			suffixUnit: '%',
+		});
+		expect(parseFormattedValue('$ 1,234,567.89')).toStrictEqual({
+			numericValue: '1,234,567.89',
+			prefixUnit: '$',
+			suffixUnit: '',
+		});
+	});
+
+	it('treats a unitless value as the numeric core', () => {
+		expect(parseFormattedValue('1,234,567')).toStrictEqual({
+			numericValue: '1,234,567',
+			prefixUnit: '',
+			suffixUnit: '',
+		});
+	});
+
+	it('falls back to the whole string when nothing matches', () => {
+		expect(parseFormattedValue('∞')).toStrictEqual({
+			numericValue: '∞',
+			prefixUnit: '',
+			suffixUnit: '',
+		});
+		expect(parseFormattedValue('NaN')).toStrictEqual({
+			numericValue: 'NaN',
+			prefixUnit: '',
+			suffixUnit: '',
+		});
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/formatPanelValue.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/formatPanelValue.ts
@@ -1,16 +1,21 @@
 import type { PrecisionOption } from 'components/Graph/types';
 import { getYAxisFormattedValue } from 'components/Graph/yAxisConfig';
 
+import { groupThousands } from './groupThousands';
+
 /**
- * Formats a scalar for display in a V2 panel, honoring decimal precision. The
- * single seam through which panels touch `getYAxisFormattedValue`. Unitless
- * values format through the `'none'` unit, which still respects precision — so
- * precision isn't silently dropped when no unit is set.
+ * Formats a scalar for display in a V2 panel, honoring decimal precision and
+ * grouping the integer part into thousands. The single seam through which panels
+ * touch `getYAxisFormattedValue`. Unitless values format through the `'none'`
+ * unit, which still respects precision — so precision isn't silently dropped
+ * when no unit is set.
  */
 export function formatPanelValue(
 	value: number,
 	unit?: string,
 	precision?: PrecisionOption,
 ): string {
-	return getYAxisFormattedValue(String(value), unit || 'none', precision);
+	return groupThousands(
+		getYAxisFormattedValue(String(value), unit || 'none', precision),
+	);
 }

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/groupThousands.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/groupThousands.ts
@@ -1,0 +1,22 @@
+const THOUSANDS_BOUNDARY = /(\d)(?=(?:\d{3})+$)/g;
+
+/** Leading number of a formatted value; unit decoration falls outside the match. */
+const NUMERIC_TOKEN = /-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/;
+
+/**
+ * Inserts thousand separators into the integer part of an already-formatted value,
+ * so large scalars read as `1,234,567`. Fractions, unit labels and formatter-scaled
+ * values (`1.18 MiB`) are left as-is, as is exponent notation.
+ */
+export function groupThousands(formatted: string): string {
+	return formatted.replace(NUMERIC_TOKEN, (token) => {
+		if (token.includes('e') || token.includes('E')) {
+			return token;
+		}
+
+		const [integerPart, fraction] = token.split('.');
+		const grouped = integerPart.replace(THOUSANDS_BOUNDARY, '$1,');
+
+		return fraction === undefined ? grouped : `${grouped}.${fraction}`;
+	});
+}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/parseFormattedValue.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/utils/parseFormattedValue.ts
@@ -1,5 +1,5 @@
 export interface ParsedFormattedValue {
-	/** The numeric portion (e.g. "295.43", "1.2K"). */
+	/** The numeric portion (e.g. "295.43", "1,234,567", "1.2K"). */
 	numericValue: string;
 	/** A leading unit symbol such as a currency prefix, if any. */
 	prefixUnit: string;
@@ -8,13 +8,14 @@ export interface ParsedFormattedValue {
 }
 
 /**
- * Splits a formatted value (e.g. "$ 1.2K", "295.43 ms") into its numeric core
- * and prefix/suffix unit for independent styling. Non-matching input falls back
- * to the whole string as the numeric value.
+ * Splits a formatted value (e.g. "$ 1.2K", "295.43 ms", "1,234,567") into its
+ * numeric core and prefix/suffix unit for independent styling. The core accepts
+ * thousand separators, so a grouped value keeps its unit split. Non-matching
+ * input falls back to the whole string as the numeric value.
  */
 export function parseFormattedValue(value: string): ParsedFormattedValue {
 	const matches = value.match(
-		/^([^\d.]*)?([\d.]+(?:[eE][+-]?[\d]+)?[KMB]?)([^\d.]*)?$/,
+		/^([^\d.]*)?([\d.,]+(?:[eE][+-]?[\d]+)?[KMB]?)([^\d.]*)?$/,
 	);
 
 	return {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Large numbers in dashboard panels rendered as an undelimited digit run — `1234567` instead of `1,234,567` — which is hard to read at a glance and hard to compare between panels.

Unitless values were the visible gap. They format through the `'none'` unit, which routes to `formatDecimalWithLeadingZeros`, whose `Intl.NumberFormat` is constructed with `useGrouping: false`. Units that scale their own value (`bytes` → `1.18 MiB`, `short` → `1.23 Mil`) never reach four integer digits, so they never showed the problem.

The grouping is applied inside `formatPanelValue` — the single seam through which V2 panels reach `getYAxisFormattedValue` — rather than at one call site. That is deliberate: readability of a large scalar is not specific to one panel kind, so the Number panel, Table value cells and the threshold-row previews all pick it up from one place instead of each opting in.

`groupThousands` itself is conservative. It touches only the first numeric token's integer digits, so fractions, unit labels and formatter-scaled values pass through untouched, and exponent notation is skipped (grouping a mantissa reads as noise).

#### Screenshots / Screen Recordings (if applicable)

No capture attached. The visible delta is purely the separators:

| Panel | Unit | Before | After |
|---|---|---|---|
| Number | — | `1234567` | `1,234,567` |
| Number | `percent` | `1234567%` | `1,234,567%` |
| Number | `bytes` | `1.18 MiB` | `1.18 MiB` (unchanged) |
| Table cell | — | `1234567` | `1,234,567` |

#### Issues closed by this PR

Closes #7669

---

### ✅ Change Type
_Select all that apply_

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

**N/A** — this is an enhancement, not a regression. Grouping was never implemented; `useGrouping: false` in `formatDecimalWithLeadingZeros` is longstanding and intentional for the axis-tick path it was written for.

---

### 🧪 Testing Strategy

- **Tests added/updated:**
  - `groupThousands.test.ts` (new) — the transform in isolation.
  - `parseFormattedValue.test.ts` (new) — this util had no suite; covers the unit split, including grouped input.
  - `formatPanelValue.test.ts` — asserts grouping at the seam, and that unit-scaled values stay ungrouped.
  - `NumberPanel/__tests__/Renderer.test.tsx` — grouped value, grouped value + separate unit, and unit-scaled value left alone.
  - `TablePanel/__tests__/Renderer.test.tsx` — pins the grouping that Table cells inherit. Worth noting for reviewers: `tableColumns.test.ts` and `tableCsv.test.ts` both stub `formatPanelValue`, so they are blind to this change by construction — the renderer test is what actually covers the Table path.

- **Manual verification:** not a click-through of a live dashboard. Instead: the full frontend jest suite (7,312 passing; the 3 failures are in unrelated suites — `QuerySearch`, `AuthDomain` — and were confirmed flaky/pre-existing by re-running them alone and against a stashed pristine tree), plus `tsgo --noEmit`, `oxlint`, `oxfmt --check` and `vite build` all clean. The real `getYAxisFormattedValue` output was probed directly for 11 value/unit combinations before writing the transform, and `papaparse.unparse` was run directly to confirm exactly how a grouped cell serializes.

- **Edge cases covered:** negative values (sign stays outside the first group), fractions (never grouped), exponent notation (skipped), `∞` / `-∞` / `NaN` (untouched), prefix and suffix unit decoration (`$ 1,234,567`, `1,234,567%`, `1,234,567 ms`), formatter-scaled units, values below 1000, zero, and idempotency on already-grouped input.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** every `formatPanelValue` consumer — the Number panel, Table panel value cells, the three threshold-row previews in the config pane, and the Table CSV export. Display-only in all cases; no spec/DTO or API change, nothing persisted.

- **Potential regressions:**
  - **The CSV export is the one behavior change worth a reviewer's attention.** `formatTableCellText` is shared by the Table renderer and the export, so a unitless numeric column now serializes as `"1,234,567"` (papaparse quotes any field containing the delimiter) instead of `1234567` — spreadsheet `SUM`/`AVG` and downstream `parseFloat` would read it as text. Columns with a unit were *already* display-text in the export (`295.43 ms`, `1.18 MiB`) by design ("reusing the on-screen cell formatting", V1 parity), so only unitless numeric columns change in kind. Called out explicitly because it is an accepted trade-off, not an oversight — if we would rather keep the export numeric, the contained fix is a flag threaded through `formatTableCellText` from `tableCsv.ts` only, leaving the render path grouped.
  - Table **sorting and threshold evaluation are unaffected** — both read `toCellNumber(raw)`, never the formatted string.
  - `parseFormattedValue` had to learn to accept `,`, otherwise a grouped value would fall through to the whole-string fallback and lose its unit split. Covered by its new suite.

- **Rollback plan:** revert the PR. Display-only with no migration or persisted state, so a revert is immediate and total.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | Large numbers in dashboard panels are now formatted with thousand separators (`1,234,567`), in the Number panel, Table panel value cells and threshold labels. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Two things I would want a second pair of eyes on:

1. **"Manually tested" is deliberately unchecked.** This was validated through tests and direct probes of the real formatter, not by clicking through a running dashboard. A quick look at a Number panel and a Table panel — plus a screenshot for this PR — is worth doing before merge.
2. **The CSV trade-off** under Risk & Impact. Grouping at the seam is what makes the change one line instead of four call sites, but the export rides the same path. The narrower alternative is described there if you would rather not accept it.

The three commits are independently reviewable: the transform, the parser tolerance it requires, then the seam that turns it on.
