### PR TITLE
fix(dashboard): substitute per-row groupBy values in context-link URLs

### DIFF
--- a/frontend/src/container/NewWidget/RightContainer/ContextLinks/__test__/utils.test.ts
+++ b/frontend/src/container/NewWidget/RightContainer/ContextLinks/__test__/utils.test.ts
@@ -1,0 +1,40 @@
+import { processContextLinks } from '../utils';
+
+describe('processContextLinks', () => {
+	// Regression for #11325.
+	it('substitutes per-row groupBy values in the path and query params', () => {
+		const [link] = processContextLinks(
+			[
+				{
+					id: '1',
+					label: 'Open trace {{trace_id}}',
+					url: '/trace/{{trace_id}}?spanId={{span_id}}&levelUp=0&levelDown=0',
+				},
+			],
+			{ _trace_id: 'abc123', _span_id: 'def456' },
+		);
+
+		expect(link.url).toBe('/trace/abc123?spanId=def456&levelUp=0&levelDown=0');
+		expect(link.label).toBe('Open trace abc123');
+	});
+
+	it('resolves dashboard and global variables alongside row fields', () => {
+		const [link] = processContextLinks(
+			[
+				{ id: '1', label: 'Logs', url: '/logs/{{service}}?ts={{timestamp_start}}' },
+			],
+			{ service: 'frontend', timestamp_start: '1720512000000', _service: 'redis' },
+		);
+
+		expect(link.url).toBe('/logs/frontend?ts=1720512000000');
+	});
+
+	it('leaves an unresolvable token in place', () => {
+		const [link] = processContextLinks(
+			[{ id: '1', label: 'Open', url: '/trace/{{trace_id}}' }],
+			{},
+		);
+
+		expect(link.url).toBe('/trace/{{trace_id}}');
+	});
+});

--- a/frontend/src/hooks/dashboard/__test__/useContextVariables.test.ts
+++ b/frontend/src/hooks/dashboard/__test__/useContextVariables.test.ts
@@ -1,0 +1,61 @@
+import { resolveTexts } from '../useContextVariables';
+
+const ROW_VARIABLES = { _trace_id: 'abc123', _span_id: 'def456' };
+
+const resolveOne = (
+	text: string,
+	processedVariables: Record<string, string>,
+): string => resolveTexts({ texts: [text], processedVariables }).fullTexts[0];
+
+describe('resolveTexts', () => {
+	it('resolves bare {{field}} placeholders from per-row field variables', () => {
+		expect(
+			resolveOne('/trace/{{trace_id}}?spanId={{span_id}}', ROW_VARIABLES),
+		).toBe('/trace/abc123?spanId=def456');
+	});
+
+	it('still resolves the explicitly prefixed {{_field}} form', () => {
+		expect(resolveOne('/trace/{{_trace_id}}', ROW_VARIABLES)).toBe(
+			'/trace/abc123',
+		);
+	});
+
+	it.each([
+		['{{.trace_id}}', '/trace/{{.trace_id}}'],
+		['[[trace_id]]', '/trace/[[trace_id]]'],
+		['$trace_id', '/trace/$trace_id'],
+	])('resolves the %s placeholder syntax', (_syntax, text) => {
+		expect(resolveOne(text, ROW_VARIABLES)).toBe('/trace/abc123');
+	});
+
+	it('resolves a field name containing dots', () => {
+		expect(
+			resolveOne('/svc/{{service.name}}', { '_service.name': 'redis' }),
+		).toBe('/svc/redis');
+	});
+
+	it('gives a dashboard variable precedence over a same-named row field', () => {
+		expect(
+			resolveOne('/svc/{{service}}', {
+				service: 'from-dashboard',
+				_service: 'from-row',
+			}),
+		).toBe('/svc/from-dashboard');
+	});
+
+	it('leaves an unknown placeholder untouched', () => {
+		expect(resolveOne('/trace/{{unknown}}', ROW_VARIABLES)).toBe(
+			'/trace/{{unknown}}',
+		);
+	});
+
+	it('picks the truncated side of a multi-value field for truncatedTexts', () => {
+		const { fullTexts, truncatedTexts } = resolveTexts({
+			texts: ['services: {{service}}'],
+			processedVariables: { _service: 'a, b +1-|-a, b, c' },
+		});
+
+		expect(fullTexts[0]).toBe('services: a, b, c');
+		expect(truncatedTexts[0]).toBe('services: a, b +1');
+	});
+});

--- a/frontend/src/hooks/dashboard/useContextVariables.tsx
+++ b/frontend/src/hooks/dashboard/useContextVariables.tsx
@@ -223,6 +223,14 @@ const extractVarName = (
 	return match;
 };
 
+// Per-row fields are registered `_`-prefixed, but templates use the bare name (`{{trace_id}}`).
+// Exact match first so dashboard/global variables keep precedence over a same-named row field.
+const lookupVariableValue = (
+	varName: string,
+	processedVariables: Record<string, string>,
+): string | undefined =>
+	processedVariables[varName] ?? processedVariables[`_${varName}`];
+
 // Utility function to resolve text with processed variables
 const resolveText = (
 	text: string,
@@ -233,7 +241,7 @@ const resolveText = (
 
 	return text.replace(combinedPattern, (match) => {
 		const varName = extractVarName(match, matcher, processedVariables);
-		const value = processedVariables[varName];
+		const value = lookupVariableValue(varName, processedVariables);
 
 		if (value != null) {
 			const parts = value.split('-|-');
@@ -254,7 +262,7 @@ const resolveTextWithTruncation = (
 
 	const result = text.replace(combinedPattern, (match) => {
 		const varName = extractVarName(match, matcher, processedVariables);
-		const value = processedVariables[varName];
+		const value = lookupVariableValue(varName, processedVariables);
 
 		if (value != null) {
 			const parts = value.split('-|-');


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Dashboard context links advertise `{{var}}` templating, but a link authored as
`/trace/{{trace_id}}?spanId={{span_id}}` navigated to
`/trace/%7B%7Btrace_id%7D%7D?spanId=%7B%7Bspan_id%7D%7D` — the placeholders were percent-encoded
instead of substituted with the clicked row's values. That reduced table-panel context links to
static URLs, which defeats the point (jump-to-trace from an audit table, jump-to-pod from a K8s
table, etc.).

The clicked row's values already reach the resolver; only the name they're registered under didn't
line up with the name templates use. This PR aligns the two in the one shared lookup, rather than
renaming variables at either producer (which would break links already saved with the prefixed
form) or dropping the `_` prefix (which would reintroduce the name collision it exists to prevent).

#### Screenshots / Screen Recordings (if applicable)

N/A — the change is a string-resolution fix; the observable difference is the destination URL, which
the added tests assert directly:

| | URL opened for a row with `trace_id=abc123`, `span_id=def456` |
|---|---|
| Before | `/trace/%7B%7Btrace_id%7D%7D?spanId=%7B%7Bspan_id%7D%7D&levelUp=0&levelDown=0` |
| After | `/trace/abc123?spanId=def456&levelUp=0&levelDown=0` |

#### Issues closed by this PR

Closes #11325

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

Faulty assumption in the shared resolver, not a missing wiring.

`useContextVariables` registers per-row field variables with a `_` prefix so a clicked row's field
can't shadow a dashboard variable of the same name:

```ts
name: `_${name}`, // Add '_' prefix to avoid conflicts
```

`resolveText` / `resolveTextWithTruncation`, however, looked up only the bare name extracted from
the placeholder (`{{trace_id}}` → `processedVariables['trace_id']`). Only `_trace_id` is ever
registered, so the lookup returned `undefined`, the placeholder was left as literal text, and
`processContextLinks` then ran it through `encodeURIComponent` — producing the reported
`%7B%7Btrace_id%7D%7D`.

Consequence of the mismatch: `{{_trace_id}}` (what the variable picker inserts) worked, while
`{{trace_id}}` (what anyone hand-writing or copy-pasting a URL types, and what the issue reports)
silently didn't. Worth noting the issue's own diagnosis is partly stale — it says the row values are
never threaded in, but `useAggregateDrilldown` does build `fieldVariables` from the clicked row's
groupBy filter values today. The empty-string map it points at lives only in the *editor's* variable
picker, where names are all that's needed.

#### Fix Strategy

One lookup helper, used by both resolvers: exact name first, then the `_`-prefixed fallback.

```ts
processedVariables[varName] ?? processedVariables[`_${varName}`]
```

Exact-first is what preserves the prefix's original purpose — a dashboard variable named `service`
still wins over a row field named `service` — and it keeps links already saved with `{{_field}}`
working unchanged. Because the fallback sits at the lookup step rather than in any one syntax
branch, it fixes `{{var}}`, `{{.var}}`, `[[var]]` and `$var` at once, and covers both V1 and V2
dashboards, which share this resolver and the same `_` convention (`useDrilldownContextVariables`).

---

### 🧪 Testing Strategy

- **Tests added/updated:**
  - `frontend/src/hooks/dashboard/__test__/useContextVariables.test.ts` (new) — unit coverage for
    `resolveTexts`: bare `{{field}}`, explicitly prefixed `{{_field}}`, all four placeholder
    syntaxes, dotted field names (`{{service.name}}`), dashboard-variable precedence over a
    same-named row field, unknown token left untouched, and the truncated-vs-full side of a
    multi-value (`-|-`) value.
  - `frontend/src/container/NewWidget/RightContainer/ContextLinks/__test__/utils.test.ts` (new) —
    end-to-end regression through `processContextLinks` on the exact URL from the issue, asserting
    both path and query-param substitution plus label resolution.
  - Confirmed the new tests are non-vacuous: reverting the hook change makes 7 of the 12 fail.
- **Manual verification:** not performed — no running SigNoz stack in the environment this was
  written in. The behavior is asserted at the URL level by the tests above; a reviewer with a live
  dashboard should sanity-check one click-through before merge.
- **Edge cases covered:**
  - Dashboard/global variable and row field sharing a name → dashboard wins (precedence unchanged).
  - Field keys containing dots (`service.name`) → resolve via `_service.name`.
  - Unresolvable token → left literal, i.e. pre-existing behavior, deliberately not changed here.
  - Existing links using `{{_field}}` → still resolve (exact match short-circuits the fallback).
- **Regression suites run:** 29 suites / 274 tests across `hooks/dashboard`, `ContextLinks`,
  `QueryTable/Drilldown`, and the V2 drilldown + `ContextLinksSection` suites — all pass.
  `tsgo --noEmit`, `oxlint ./src --quiet` and `pnpm build` are clean.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** small but shared. `resolveTexts` is used by V1 context links
  (`processContextLinks`), V2 context links (`resolveContextLinkUrl` / `resolvePanelContextLinks`),
  and the V2 drilldown menu. The sibling resolver `useGetResolvedText` (widget titles) is untouched.
- **Potential regressions:** the only behavior change is that a previously-unresolved bare
  placeholder now resolves. A template that *intended* to keep a literal `{{trace_id}}` in a URL
  while a row field of that name is in scope would now be substituted — no such usage is plausible,
  since the literal form produces a broken link. Names that already resolved keep resolving to the
  same value, because the exact match is tried first.
- **Rollback plan:** revert this commit; it's a single self-contained helper plus two new test files,
  with no schema, API, or saved-dashboard-payload changes. Nothing needs migrating either way.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Dashboard context links now substitute the clicked row's groupBy values into URL templates, so `{{trace_id}}`-style placeholders deep-link to the actual row instead of opening a URL with the encoded placeholder. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested — not done, see Testing Strategy
- [x] Breaking changes documented — none; links using `{{_field}}` keep working
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Two things I deliberately left alone, both arguably worth a follow-up:

1. **The variable pickers still insert `_`-prefixed names** (`{{_trace_id}}`) in both the V1
   `VariablesPopover` and V2 `useContextLinkVariables`. That reads oddly to users, but switching
   them to bare names would make picker output ambiguous whenever a dashboard variable shares a
   field's name — exactly what the prefix guards against. Worth a UX decision separately.
2. **An unresolvable token still renders literally** (and gets percent-encoded in query params)
   rather than resolving to empty or the link being hidden. That's pre-existing in V1 and V2, and
   changing it is a product call, not part of this fix.
