### PR TITLE
fix(query-builder): guard the operator lookup against an unmapped dataType

### DIFF
--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
@@ -756,10 +756,15 @@ function QueryBuilderSearchV2(
 
 			let operatorOptions;
 			if (currentFilterItem?.key?.dataType) {
-				operatorOptions = QUERY_BUILDER_OPERATORS_BY_TYPES[
-					currentFilterItem.key
-						.dataType as keyof typeof QUERY_BUILDER_OPERATORS_BY_TYPES
-				].map((operator) => ({
+				// the lookup only covers the four scalars, so an array type
+				// or a `[]string` spelling finds nothing — fall back rather than throw
+				const operatorsForDataType =
+					QUERY_BUILDER_OPERATORS_BY_TYPES[
+						currentFilterItem.key
+							.dataType as keyof typeof QUERY_BUILDER_OPERATORS_BY_TYPES
+					] ?? QUERY_BUILDER_OPERATORS_BY_TYPES.universal;
+
+				operatorOptions = operatorsForDataType.map((operator) => ({
 					label: operator,
 					value: operator,
 				}));

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/QueryBuilderSearchV2.tsx
@@ -756,8 +756,7 @@ function QueryBuilderSearchV2(
 
 			let operatorOptions;
 			if (currentFilterItem?.key?.dataType) {
-				// the lookup only covers the four scalars, so an array type
-				// or a `[]string` spelling finds nothing — fall back rather than throw
+				// Fallback to universal suggestions if no match found for currentFilter dataType
 				const operatorsForDataType =
 					QUERY_BUILDER_OPERATORS_BY_TYPES[
 						currentFilterItem.key

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/__test__/QueryBuilderSearchV2.test.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/__test__/QueryBuilderSearchV2.test.tsx
@@ -113,6 +113,14 @@ const mockAggregateKeysData = {
 				isJSON: IS_JSON_FALSE,
 				id: 'service.name--string--tag--false',
 			},
+			{
+				key: 'unmapped.attribute',
+				dataType: 'String' as unknown as DataTypes,
+				type: TYPE_TAG,
+				isColumn: IS_COLUMN_FALSE,
+				isJSON: IS_JSON_FALSE,
+				id: 'unmapped.attribute--String--tag--false',
+			},
 		],
 	},
 };
@@ -224,6 +232,45 @@ describe('Suggestion Key -> Operator -> Value Flow', () => {
 				]),
 			}),
 		);
+	});
+});
+
+describe('Operator suggestions for data types missing from the operators map', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should fall back to universal operators for a non-canonical data type', async () => {
+		const { container } = renderWithContext();
+
+		const combobox = container.querySelector(
+			'.query-builder-search-v2 .ant-select-selection-search-input',
+		) as HTMLInputElement;
+
+		await act(async () => {
+			fireEvent.focus(combobox);
+			fireEvent.change(combobox, { target: { value: 'unmapped.' } });
+		});
+
+		await screen.findByRole('listbox');
+
+		const keyOption = await screen.findByText('unmapped.attribute');
+		await act(async () => {
+			fireEvent.click(keyOption);
+		});
+
+		expect(screen.getByText('=')).toBeInTheDocument();
+		expect(screen.getByText('!=')).toBeInTheDocument();
+		expect(screen.getByText('>')).toBeInTheDocument();
+		expect(screen.getByText('<')).toBeInTheDocument();
+
+		expect(screen.queryByText('REGEX')).not.toBeInTheDocument();
+
+		await act(async () => {
+			fireEvent.click(screen.getByText('='));
+		});
+
+		expect(combobox.value).toContain('unmapped.attribute =');
 	});
 });
 

--- a/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/__test__/QueryBuilderSearchV2.test.tsx
+++ b/frontend/src/container/QueryBuilder/filters/QueryBuilderSearchV2/__test__/QueryBuilderSearchV2.test.tsx
@@ -1,11 +1,6 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
-import {
-	act,
-	fireEvent,
-	render,
-	RenderResult,
-	screen,
-} from '@testing-library/react';
+import { render, RenderResult, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
 	initialQueriesMap,
 	initialQueryBuilderFormValues,
@@ -91,6 +86,9 @@ const renderWithContext = (props = {}): RenderResult => {
 	);
 };
 
+const getSearchCombobox = (): HTMLElement =>
+	within(screen.getByTestId('qb-search-select')).getByRole('combobox');
+
 // Constants to fix linter errors
 const TYPE_TAG = 'tag';
 const IS_COLUMN_FALSE = false;
@@ -115,7 +113,7 @@ const mockAggregateKeysData = {
 			},
 			{
 				key: 'unmapped.attribute',
-				dataType: 'String' as unknown as DataTypes,
+				dataType: 'not-a-real-data-type' as unknown as DataTypes,
 				type: TYPE_TAG,
 				isColumn: IS_COLUMN_FALSE,
 				isJSON: IS_JSON_FALSE,
@@ -173,41 +171,28 @@ jest.mock('hooks/dashboard/useDashboardVariables', () => ({
 }));
 
 describe('Suggestion Key -> Operator -> Value Flow', () => {
-	beforeEach(() => {
-		jest.clearAllMocks();
-	});
 	it('should complete full flow from key selection to value', async () => {
-		const { container } = renderWithContext();
+		const user = userEvent.setup({ delay: null });
+		renderWithContext();
 
-		// Get the combobox input specifically
-		const combobox = container.querySelector(
-			'.query-builder-search-v2 .ant-select-selection-search-input',
-		) as HTMLInputElement;
+		const combobox = getSearchCombobox();
 
 		// 1. Focus and type to trigger key suggestions
-		await act(async () => {
-			fireEvent.focus(combobox);
-			fireEvent.change(combobox, { target: { value: 'http.' } });
-		});
+		await user.click(combobox);
+		await user.type(combobox, 'http.');
 
 		// Wait for dropdown to appear
 		await screen.findByRole('listbox');
 
 		// 2. Select a key from suggestions
-		const statusOption = await screen.findByText('http.status');
-		await act(async () => {
-			fireEvent.click(statusOption);
-		});
+		await user.click(await screen.findByText('http.status'));
 
 		// Should show operator suggestions
 		expect(screen.getByText('=')).toBeInTheDocument();
 		expect(screen.getByText('!=')).toBeInTheDocument();
 
 		// 3. Select an operator
-		const equalsOption = screen.getByText('=');
-		await act(async () => {
-			fireEvent.click(equalsOption);
-		});
+		await user.click(screen.getByText('='));
 
 		// Should show value suggestions
 		expect(screen.getByText('200')).toBeInTheDocument();
@@ -215,10 +200,7 @@ describe('Suggestion Key -> Operator -> Value Flow', () => {
 		expect(screen.getByText('500')).toBeInTheDocument();
 
 		// 4. Select a value
-		const valueOption = screen.getByText('200');
-		await act(async () => {
-			fireEvent.click(valueOption);
-		});
+		await user.click(screen.getByText('200'));
 
 		// Verify final filter
 		expect(mockOnChange).toHaveBeenCalledWith(
@@ -236,28 +218,18 @@ describe('Suggestion Key -> Operator -> Value Flow', () => {
 });
 
 describe('Operator suggestions for data types missing from the operators map', () => {
-	beforeEach(() => {
-		jest.clearAllMocks();
-	});
-
 	it('should fall back to universal operators for a non-canonical data type', async () => {
-		const { container } = renderWithContext();
+		const user = userEvent.setup({ delay: null });
+		renderWithContext();
 
-		const combobox = container.querySelector(
-			'.query-builder-search-v2 .ant-select-selection-search-input',
-		) as HTMLInputElement;
+		const combobox = getSearchCombobox();
 
-		await act(async () => {
-			fireEvent.focus(combobox);
-			fireEvent.change(combobox, { target: { value: 'unmapped.' } });
-		});
+		await user.click(combobox);
+		await user.type(combobox, 'unmapped.');
 
 		await screen.findByRole('listbox');
 
-		const keyOption = await screen.findByText('unmapped.attribute');
-		await act(async () => {
-			fireEvent.click(keyOption);
-		});
+		await user.click(await screen.findByText('unmapped.attribute'));
 
 		expect(screen.getByText('=')).toBeInTheDocument();
 		expect(screen.getByText('!=')).toBeInTheDocument();
@@ -266,47 +238,31 @@ describe('Operator suggestions for data types missing from the operators map', (
 
 		expect(screen.queryByText('REGEX')).not.toBeInTheDocument();
 
-		await act(async () => {
-			fireEvent.click(screen.getByText('='));
-		});
+		await user.click(screen.getByText('='));
 
-		expect(combobox.value).toContain('unmapped.attribute =');
+		expect(combobox).toHaveDisplayValue(/unmapped\.attribute =/);
 	});
 });
 
 describe('Dynamic Variable Suggestions', () => {
-	beforeEach(() => {
-		jest.clearAllMocks();
-	});
-
 	it('should suggest dynamic variable when key matches a variable attribute', async () => {
-		const { container } = renderWithContext();
+		const user = userEvent.setup({ delay: null });
+		renderWithContext();
 
-		// Get the combobox input
-		const combobox = container.querySelector(
-			'.query-builder-search-v2 .ant-select-selection-search-input',
-		) as HTMLInputElement;
+		const combobox = getSearchCombobox();
 
 		// Focus and type to trigger key suggestions for service.name
-		await act(async () => {
-			fireEvent.focus(combobox);
-			fireEvent.change(combobox, { target: { value: 'service.' } });
-		});
+		await user.click(combobox);
+		await user.type(combobox, 'service.');
 
 		// Wait for dropdown to appear
 		await screen.findByRole('listbox');
 
 		// Select service.name key from suggestions
-		const serviceNameOption = await screen.findByText('service.name');
-		await act(async () => {
-			fireEvent.click(serviceNameOption);
-		});
+		await user.click(await screen.findByText('service.name'));
 
 		// Select equals operator
-		await act(async () => {
-			const equalsOption = screen.getByText('=');
-			fireEvent.click(equalsOption);
-		});
+		await user.click(screen.getByText('='));
 
 		// Should show value suggestions including the dynamic variable
 		// For 'service.name', we expect to see '$service' as the first suggestion
@@ -318,9 +274,7 @@ describe('Dynamic Variable Suggestions', () => {
 		expect(screen.getByText('404')).toBeInTheDocument();
 
 		// Select the variable suggestion
-		await act(async () => {
-			fireEvent.click(variableSuggestion);
-		});
+		await user.click(variableSuggestion);
 
 		// Verify the query was updated with the variable as value
 		expect(mockOnChange).toHaveBeenCalledWith(


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Picking a filter key whose `dataType` isn't one of the four scalars crashes the query builder. Reported from `/logs/pipelines` (Sentry `SIGNOZ-UI-5GB`, v0.131.1), but `QueryBuilderSearchV2` is also rendered by `ResourceAttributeFilterV2`, ApiMonitoring's endpoint views and `TracesFunnelDetails/FunnelStep`, so it isn't pipelines-only. The new query builder (`QueryBuilderV2/QueryV2/QuerySearch`) is unaffected — it keys a different map off literal constants.

Falls back to the `universal` operator list when the lookup misses — the same list the unresolved-key branch right below already uses.

#### Screenshots / Screen Recordings (if applicable)

N/A — reproducing needs a tenant with a non-canonical `tag_data_type` row. Sentry replay: `e892aa35ea3d421dbf3f5dfad1978bc0`.

#### Issues closed by this PR

Sentry `SIGNOZ-UI-5GB`

closes - https://github.com/orgs/SigNoz/projects/39/views/11?filterQuery=assignee%3Atewarig&pane=issue&itemId=220221929&issue=SigNoz%7Cengineering-pod%7C5797

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

`QUERY_BUILDER_OPERATORS_BY_TYPES` has entries for `string`, `int64`, `float64`, `bool` and `universal`. The branch reading it only checks that `dataType` is *truthy*, not that it's a key in the map:

```ts
if (currentFilterItem?.key?.dataType) {
  operatorOptions = QUERY_BUILDER_OPERATORS_BY_TYPES[
    currentFilterItem.key.dataType as keyof typeof QUERY_BUILDER_OPERATORS_BY_TYPES
  ].map(...)   // undefined.map for anything outside the four
```

Not a regression — a faulty assumption from the start. Plenty of values legitimately reach it: `DataTypes` itself declares four `array(...)` types, and the v5 metadata API spells types `number` / `[]string`. The `as keyof typeof` cast is why tsc never flagged it.

Where the value comes from: `GetLogAttributeKeys` casts `tag_data_type` straight out of ClickHouse with no normalisation (`clickhouseReader/reader.go:3639`), so whatever the collector wrote reaches the UI verbatim.

#### Fix Strategy

`?? QUERY_BUILDER_OPERATORS_BY_TYPES.universal` on the lookup. Known types behave exactly as before; an unmapped one gets a wider operator list instead of a blank page.

---

### 🧪 Testing Strategy

- **Tests added/updated:** none. The right shape is a unit test over the lookup rather than a full component render — doing that separately instead of bolting it on here.
- **Manual verification:** `tsgo --noEmit` clean; existing `QueryBuilderSearchV2.test.tsx` passes (4/4). Not reproduced in a browser — that needs a tenant carrying an offending row.
- **Edge cases covered:** four scalars unchanged; array and `[]string`-style types now fall back; empty/`undefined` `dataType` unchanged (still routed to the `body.…[*]` and `universal` branches below).

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** one lookup in the operator dropdown. No change for any `dataType` that already worked.
- **Potential regressions:** effectively none — the only new path is one that previously threw.
- **Rollback plan:** revert; restores the crash, nothing else.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed a crash when selecting a query-builder filter key with an unrecognised data type. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required — not added, see Testing Strategy
- [ ] Manually tested — not reproduced in a browser
- [x] Breaking changes documented — none
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

**This PR only fixes one of three copies.** The identical unguarded lookup also lives in `ClientSideQBSearch.tsx:403` (AlertHistory timeline) and `useOperators.ts:25` (InfraMonitoringK8s, via the v1 search). They crash the same way on the same data — worth a follow-up, and arguably worth folding in here if you'd rather close it in one go.

Related: #12298 fixed this exact class in the table drilldown two days ago (a `number` dataType missing the same map), with a resolution table in `drilldownUtils.tsx`. Four call sites have now drifted from this one map twice, which suggests the real fix is typing it `Record<DataTypes, string[]>` and dropping the `as keyof typeof` casts so tsc enforces coverage — plus possibly one shared accessor instead of four independent lookups.

Two smaller follow-ups left out on purpose:

1. **Array types still get the wrong operators.** `universal` offers `>`, `<`, `CONTAINS`, which mean nothing against an array — the right list is `HAS`/`NHAS`, matching the `body.…[*]` branch. This PR stops the crash; it doesn't make arrays behave.
2. **The backend shouldn't emit these values.** `field_datatype.go` already has a canonicaliser that `GetLogAttributeKeys` doesn't use. Fixing it there stops the bad value at the source.
