### PR TITLE
fix(frontend): alias lodash to lodash-es to survive a page-level AMD loader

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -143,6 +143,12 @@ export default defineConfig(({ mode }): UserConfig => {
 		plugins,
 		resolve: {
 			alias: {
+				// @grafana/data imports bare CJS `lodash`, whose UMD footer checks for an
+				// AMD loader before assigning module.exports. Any third-party script that
+				// defines window.define.amd first leaves the bundled namespace empty, so
+				// every lodash method reached through it is undefined at runtime. lodash-es
+				// is the same version, real ESM, and tree-shakes.
+				lodash: 'lodash-es',
 				'@': resolve(__dirname, './src'),
 				utils: resolve(__dirname, './src/utils'),
 				types: resolve(__dirname, './src/types'),


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Y-axis / panel values were intermittently rendering unformatted (raw numbers instead of `117 MiB`, `1.2 s`, etc.) for a subset of users, with Sentry reporting `Error applying formatter: (0 , Uu.clamp) is not a function`.

The cause is a CJS-interop hazard in `lodash`, not anything in our formatter code. Aliasing bare `lodash` to `lodash-es` — already a direct dependency at the **same version (4.18.1)** — removes the hazard entirely.

#### Issues closed by this PR

Closes https://github.com/SigNoz/pulse-pod/issues/153

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

1. `frontend/src/components/Graph/yAxisConfig.ts` calls `getValueFormat(format)` from `@grafana/data`. For byte/bit/SI units that resolves to grafana's `scaledUnits`, which lives in `@grafana/data/dist/esm/valueFormats/valueFormats.mjs` and begins with `import { clamp } from 'lodash'` — bare **CJS** `lodash`, not `lodash-es`.

2. `lodash` is the UMD monolith. Its methods are attached dynamically (`lodash.clamp = clamp`), which rolldown cannot statically detect, so the import compiles down to a **runtime namespace read**:

   ```js
   var import_lodash = require_lodash();
   ...extArray[(0, import_lodash.clamp)(offset + siIndex, 0, extArray.length - 1)]
   ```

   Minified, `import_lodash` becomes `Uu` — that is the `(0 , Uu.clamp)` in the Sentry message.

3. lodash's UMD footer checks **AMD first**, and that branch never assigns `module.exports`:

   ```js
   if (typeof define == 'function' && typeof define.amd == 'object' && define.amd) {
     root._ = _; define(function() { return _; });   // ← module.exports NEVER assigned
   } else if (freeModule) {
     (freeModule.exports = _)._ = _;
   }
   ```

   The branch survives bundling intact.

4. So if anything on the page has installed an AMD loader (`window.define.amd`) before that chunk executes, `require_lodash()` returns `{}` and **every** lodash method reached through the namespace is `undefined`.

This is why it only affects some sessions. Third-party tags in `index.html` (Pylon, Appcues) are injected *before* the deferred `<script type="module">` entry, so any AMD loader they pull in wins the race — as can a browser extension.

`clamp` is not the only casualty: **~28 modules** across `@grafana/data` import bare `lodash` (`isEqual`, `cloneDeep`, `merge`, `memoize`, `set`, …). All are dead in an affected session. This one is visible in Sentry only because `yAxisConfig.ts` happens to catch, report, and fall back to unformatted output — the other sites fail silently or louder elsewhere.

#### Fix Strategy

Alias bare `lodash` → `lodash-es` in `vite.config.ts`. `lodash-es` is real ESM with no UMD footer, so there is no AMD branch to take and all named imports bind statically at build time.

---

### 🧪 Testing Strategy

- **Tests added/updated:** none — Jest does not read `vite.config.ts`, so no unit test can exercise or regress a resolver alias. Verification is on the emitted bundle (below).

- **Reproduced first, with an exact message match.** Built a minimal entry (`getValueFormat('bytes')`) with the repo's own toolchain and ran it twice against the same bundle, differing only by a page-level AMD loader:

  ```
  node -e "await import('./out.js')"                        → RESULT: 117.74 MiB
  node -e "define=()=>{}; define.amd={}; await import(...)"  → THREW: (0 , import_lodash.clamp) is not a function
  ```

  The second line is the Sentry message with the identifier unminified, including the `(0 , ` spacing. The same entry built with the alias returns `117.74 MiB` correctly **with `define.amd` present**.

- **Manual verification on the real build:**
  - `tsgo --noEmit` — clean
  - full `vite build` — succeeds, no missing-export errors
  - **lodash's UMD/AMD footer is gone from every chunk in `build/assets`** — there is no longer an AMD branch to trip over anywhere in the bundle. This is the decisive check.
  - `oxlint` + `oxfmt --check` — clean

- **Edge cases covered:**
  - The alias matches `lodash` and `lodash/*`. Confirmed `@grafana/data` only ever imports bare `'lodash'` — no deep subpaths, no `lodash/fp` (which would fail loudly at build time rather than silently).
  - The only other browser-graph package with a nested `lodash` is `@visx/shape`, whose ESM build does not reference it.
  - One `(0,_.clamp)` remains in the output, in `react-grid-layout` — that is its own `calculateUtils` module (`exports.clamp = clamp`, no UMD footer); lodash is only a devDependency there. Unrelated and unaffected.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** build-time module resolution for the whole frontend bundle. Every bare `lodash` import now resolves to `lodash-es`.
- **Potential regressions:** low. Same version (4.18.1), same API surface, and any resolution miss (e.g. a subpath `lodash-es` lacks) is a hard build failure rather than a runtime surprise. The full production build passes.
- **Side benefit:** the app previously shipped both lodash and lodash-es. Deduping them, plus lodash-es being tree-shakeable where the CJS monolith is not, cut the minimal repro bundle from 117 kB → 81 kB gzipped.
- **Rollback plan:** revert this commit — single-line resolver change, no runtime code touched.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Fixed panel and Y-axis values intermittently rendering unformatted (raw numbers instead of units like `117 MiB` or `1.2 s`) for users whose browser session had a third-party AMD loader present. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The one-line change is easy to review; the value is in the diagnosis, so the root-cause section above is the part worth reading.

Two things to weigh:

1. **Scope.** This fixes the whole class of failure, not just `clamp` — all ~28 `@grafana/data` lodash call sites are affected by the same mechanism, and any future dependency importing bare `lodash` is covered too.

2. **`yAxisConfig.ts`'s catch block stays as-is.** Its fallback is what kept this a cosmetic bug instead of a white screen, and it's still the right safety net for genuinely malformed formats. Worth noting though that its `Sentry.captureEvent` uses a templated message string, so each distinct error text becomes its own Sentry issue — that's how this surfaced as an `(alert)`-labelled issue rather than grouping with anything else. Not changing it here, but flagging it as a possible follow-up if the noise is unwelcome.

---
