### PR TITLE
test(querier): assert rendered SQL in skip_resource_fingerprint tests

### DIFF
--- a/tests/fixtures/querier.py
+++ b/tests/fixtures/querier.py
@@ -192,6 +192,59 @@ def make_query_request(
     )
 
 
+def make_preview_query_request(
+    signoz: types.SigNoz,
+    token: str,
+    start_ms: int,
+    end_ms: int,
+    queries: list[dict],
+    *,
+    request_type: str = RequestType.TIME_SERIES,
+    format_options: dict | None = None,
+    variables: dict | None = None,
+    verbose: bool = True,
+    timeout: int = QUERY_TIMEOUT,
+) -> requests.Response:
+    """Dry-run the same payload as make_query_request against /query_range/preview.
+    Verbose (the default) renders the underlying ClickHouse statement per query."""
+    if format_options is None:
+        format_options = {"formatTableResultForUI": False, "fillGaps": False}
+
+    payload = {
+        "schemaVersion": "v1",
+        "start": start_ms,
+        "end": end_ms,
+        "requestType": request_type,
+        "compositeQuery": {"queries": queries},
+        "formatOptions": format_options,
+    }
+    if variables:
+        payload["variables"] = variables
+
+    return requests.post(
+        signoz.self.host_configs["8080"].get("/api/v5/query_range/preview"),
+        params={"verbose": str(verbose).lower()},
+        timeout=timeout,
+        headers={"authorization": f"Bearer {token}"},
+        json=payload,
+    )
+
+
+def get_preview_statements(response: requests.Response, name: str) -> list[dict[str, Any]]:
+    """The rendered statements for the named query in a preview response."""
+    assert response.status_code == HTTPStatus.OK, response.text
+    preview = response.json()["data"]["compositeQuery"][name]
+    assert preview["valid"], f"preview for query {name} is invalid: {preview['error']}"
+    return preview["statements"]
+
+
+def get_preview_sql(response: requests.Response, name: str) -> str:
+    """The single rendered ClickHouse statement for the named query in a preview response."""
+    statements = get_preview_statements(response, name)
+    assert len(statements) == 1, f"expected 1 statement for query {name}, got {len(statements)}"
+    return statements[0]["db.statement.query"]
+
+
 def aligned_epoch(ago: timedelta, step_seconds: int = DEFAULT_STEP_INTERVAL) -> int:
     """Epoch seconds for `now - ago`, floored to a step boundary so seeded
     points land exactly on the query's toStartOfInterval buckets."""

--- a/tests/integration/tests/querier_skip_resource_fingerprint/01_skip_resource_fingerprint.py
+++ b/tests/integration/tests/querier_skip_resource_fingerprint/01_skip_resource_fingerprint.py
@@ -5,7 +5,8 @@ At or above the configured fingerprint threshold the optimization pushes resourc
 conditions onto the main spans/logs table instead of the fingerprint CTE. That
 rewrite must change ClickHouse performance, never the rows: each test runs the same
 query against the primary instance (optimization on, threshold=2) and
-`signoz_fingerprint` (optimization off) and asserts the responses are identical.
+`signoz_fingerprint` (optimization off) and asserts the responses are identical, then
+diffs the rendered SQL to prove the two really did take different paths.
 """
 
 from collections.abc import Callable
@@ -17,12 +18,19 @@ from fixtures.logs import Logs
 from fixtures.querier import (
     BuilderQuery,
     OrderBy,
+    RequestType,
     TelemetryFieldKey,
     assert_identical_query_response,
+    get_preview_sql,
     get_rows,
+    make_preview_query_request,
     make_query_request,
 )
 from fixtures.traces import Traces
+
+# The clause the baseline joins the fingerprint CTE with; the fallback path renders the
+# resource conditions on the main table and drops it.
+FINGERPRINT_CTE_FILTER = "resource_fingerprint GLOBAL IN (SELECT fingerprint FROM __resource_filter)"
 
 
 def test_skip_resource_fingerprint_traces_fallback_matches_fingerprint(
@@ -58,11 +66,20 @@ def test_skip_resource_fingerprint_traces_fallback_matches_fingerprint(
 
     start_ms = int((datetime.now(tz=UTC) - timedelta(minutes=5)).timestamp() * 1000)
     end_ms = int(datetime.now(tz=UTC).timestamp() * 1000)
-    optimized = make_query_request(signoz, token, start_ms=start_ms, end_ms=end_ms, request_type="raw", queries=[query])
-    fingerprint = make_query_request(signoz_fingerprint, token, start_ms=start_ms, end_ms=end_ms, request_type="raw", queries=[query])
+    optimized = make_query_request(signoz, token, start_ms=start_ms, end_ms=end_ms, request_type=RequestType.RAW, queries=[query])
+    fingerprint = make_query_request(signoz_fingerprint, token, start_ms=start_ms, end_ms=end_ms, request_type=RequestType.RAW, queries=[query])
 
     assert len(get_rows(optimized)) == 3
     assert_identical_query_response(optimized, fingerprint)
+
+    # Identical rows alone can't tell the two instances apart; the rendered SQL can.
+    # The baseline resolves the env filter through the fingerprint CTE, the optimized
+    # instance pushes it onto the spans table.
+    optimized_sql = get_preview_sql(make_preview_query_request(signoz, token, start_ms=start_ms, end_ms=end_ms, request_type=RequestType.RAW, queries=[query]), "A")
+    fingerprint_sql = get_preview_sql(make_preview_query_request(signoz_fingerprint, token, start_ms=start_ms, end_ms=end_ms, request_type=RequestType.RAW, queries=[query]), "A")
+
+    assert FINGERPRINT_CTE_FILTER in fingerprint_sql, fingerprint_sql
+    assert FINGERPRINT_CTE_FILTER not in optimized_sql, optimized_sql
 
 
 def test_skip_resource_fingerprint_logs_fallback_matches_fingerprint(
@@ -98,8 +115,15 @@ def test_skip_resource_fingerprint_logs_fallback_matches_fingerprint(
 
     start_ms = int((datetime.now(tz=UTC) - timedelta(minutes=5)).timestamp() * 1000)
     end_ms = int(datetime.now(tz=UTC).timestamp() * 1000)
-    optimized = make_query_request(signoz, token, start_ms=start_ms, end_ms=end_ms, request_type="raw", queries=[query])
-    fingerprint = make_query_request(signoz_fingerprint, token, start_ms=start_ms, end_ms=end_ms, request_type="raw", queries=[query])
+    optimized = make_query_request(signoz, token, start_ms=start_ms, end_ms=end_ms, request_type=RequestType.RAW, queries=[query])
+    fingerprint = make_query_request(signoz_fingerprint, token, start_ms=start_ms, end_ms=end_ms, request_type=RequestType.RAW, queries=[query])
 
     assert len(get_rows(optimized)) == 3
     assert_identical_query_response(optimized, fingerprint)
+
+    # Same transparency check as above, on the logs table.
+    optimized_sql = get_preview_sql(make_preview_query_request(signoz, token, start_ms=start_ms, end_ms=end_ms, request_type=RequestType.RAW, queries=[query]), "A")
+    fingerprint_sql = get_preview_sql(make_preview_query_request(signoz_fingerprint, token, start_ms=start_ms, end_ms=end_ms, request_type=RequestType.RAW, queries=[query]), "A")
+
+    assert FINGERPRINT_CTE_FILTER in fingerprint_sql, fingerprint_sql
+    assert FINGERPRINT_CTE_FILTER not in optimized_sql, optimized_sql

--- a/tests/integration/tests/querier_skip_resource_fingerprint/conftest.py
+++ b/tests/integration/tests/querier_skip_resource_fingerprint/conftest.py
@@ -31,8 +31,8 @@ def signoz_skip_resource_fingerprint(
         pytestconfig=pytestconfig,
         cache_key="signoz-skip-resource-fingerprint",
         env_overrides={
-            "SIGNOZ_QUERIER_SKIP__RESOURCE__FINGERPRINT_ENABLED": True,
-            "SIGNOZ_QUERIER_SKIP__RESOURCE__FINGERPRINT_THRESHOLD": 2,
+            "SIGNOZ_STATEMENTBUILDER_SKIP__RESOURCE__FINGERPRINT_ENABLED": True,
+            "SIGNOZ_STATEMENTBUILDER_SKIP__RESOURCE__FINGERPRINT_THRESHOLD": 2,
         },
     )
 
@@ -66,6 +66,6 @@ def signoz_fingerprint(
         pytestconfig=pytestconfig,
         cache_key="signoz-skip-resource-fingerprint-baseline",
         env_overrides={
-            "SIGNOZ_QUERIER_SKIP__RESOURCE__FINGERPRINT_ENABLED": False,
+            "SIGNOZ_STATEMENTBUILDER_SKIP__RESOURCE__FINGERPRINT_ENABLED": False,
         },
     )


### PR DESCRIPTION
The `skip_resource_fingerprint` integration tests compared rows between the optimized and baseline instances, which passes even when neither instance has the optimization on. They now also compare the rendered ClickHouse SQL.

### What
- Adds `make_preview_query_request` / `get_preview_statements` / `get_preview_sql` to `tests/fixtures/querier.py` — dry-run the same payload as `make_query_request` against `/api/v5/query_range/preview?verbose=true` and pull out the rendered statement for a named query.
- Traces and logs tests now assert the baseline SQL contains the `__resource_filter` CTE and the optimized SQL does not, on top of the existing row-equality check.

### Guardrails
- Fixes the fixture env prefix: `skip_resource_fingerprint` lives in its own config namespace, so `SIGNOZ_QUERIER_SKIP__RESOURCE__FINGERPRINT_*` was silently ignored and both instances ran with the optimization disabled (defaults). Now `SIGNOZ_STATEMENTBUILDER_SKIP__RESOURCE__FINGERPRINT_*`.
- The new SQL assertions are what makes that misconfiguration fail loudly instead of passing vacuously.

### Notes
- Switches the two tests' `request_type="raw"` string literals to the existing `RequestType.RAW` constant.

### Testing
- `make py-fmt` and `make py-lint` clean.

Fixes https://github.com/SigNoz/engineering-pod/issues/5810
