### PR TITLE
chore(statementbuilder): log key adjustment actions at debug level

### DIFF
--- a/pkg/statementbuilder/auditstatementbuilder/statement_builder.go
+++ b/pkg/statementbuilder/auditstatementbuilder/statement_builder.go
@@ -205,7 +205,7 @@ func (b *auditQueryStatementBuilder) adjustKeys(ctx context.Context, keys map[st
 	}
 
 	for _, action := range actions {
-		b.logger.InfoContext(ctx, "key adjustment action", slog.String("action", action))
+		b.logger.DebugContext(ctx, "key adjustment action", slog.String("action", action))
 	}
 
 	return query

--- a/pkg/statementbuilder/logsstatementbuilder/statement_builder.go
+++ b/pkg/statementbuilder/logsstatementbuilder/statement_builder.go
@@ -274,8 +274,7 @@ func (b *logQueryStatementBuilder) adjustKeys(ctx context.Context, keys map[stri
 	}
 
 	for _, action := range actions {
-		// TODO: change to debug level once we are confident about the behavior
-		b.logger.InfoContext(ctx, "key adjustment action", slog.String("action", action))
+		b.logger.DebugContext(ctx, "key adjustment action", slog.String("action", action))
 	}
 
 	return query

--- a/pkg/statementbuilder/tracesstatementbuilder/statement_builder.go
+++ b/pkg/statementbuilder/tracesstatementbuilder/statement_builder.go
@@ -127,8 +127,7 @@ func (b *traceQueryStatementBuilder) Build(
 	}
 
 	for _, action := range adjustTraceKeys(keys, &query, requestType) {
-		// TODO: change to debug level once we are confident about the behavior
-		b.logger.InfoContext(ctx, "key adjustment action", slog.String("action", action))
+		b.logger.DebugContext(ctx, "key adjustment action", slog.String("action", action))
 	}
 	// Create SQL builder
 	q := sqlbuilder.NewSelectBuilder()

--- a/pkg/statementbuilder/tracesstatementbuilder/trace_operator_cte_builder.go
+++ b/pkg/statementbuilder/tracesstatementbuilder/trace_operator_cte_builder.go
@@ -223,8 +223,7 @@ func (b *traceOperatorCTEBuilder) buildQueryCTE(ctx context.Context, queryName s
 	// The CTE only selects spans matching the filter. Aggregations, group by
 	// and order by run later in buildFinalQuery, so RequestTypeRaw is fine here.
 	for _, action := range adjustTraceKeys(keys, query, qbtypes.RequestTypeRaw) {
-		// TODO: change to debug level once we are confident about the behavior
-		b.stmtBuilder.logger.InfoContext(ctx, "key adjustment action", slog.String("action", action))
+		b.stmtBuilder.logger.DebugContext(ctx, "key adjustment action", slog.String("action", action))
 	}
 
 	// Build resource filter CTE for this specific query
@@ -576,7 +575,7 @@ func (b *traceOperatorCTEBuilder) adjustOperatorKeys(ctx context.Context, keys m
 	b.operator.Order = tmp.Order
 
 	for _, action := range actions {
-		b.stmtBuilder.logger.InfoContext(ctx, "key adjustment action", slog.String("action", action))
+		b.stmtBuilder.logger.DebugContext(ctx, "key adjustment action", slog.String("action", action))
 	}
 }
 


### PR DESCRIPTION
The `key adjustment action` logs fire at info on every query build — one line per adjusted key, per query — which is a lot of noise for something that has been stable for a while now.

### What

Dropped them to `DebugContext` across the audit, logs and traces statement builders and the trace operator CTE builder, and removed the three `// TODO: change to debug level once we are confident about the behavior` comments that asked for exactly this.

### Notes

No behavior change beyond log level — the same actions are still recorded, just at debug.

### Testing

`go build ./pkg/statementbuilder/...` and `golangci-lint run ./pkg/statementbuilder/...` are clean.


Fixes https://github.com/SigNoz/engineering-pod/issues/5812
