### PR TITLE
fix(alertmanager): reject file references in channels sent over the API

### DIFF
--- a/pkg/alertmanager/signozalertmanager/handler.go
+++ b/pkg/alertmanager/signozalertmanager/handler.go
@@ -72,6 +72,11 @@ func (handler *handler) TestReceiver(rw http.ResponseWriter, req *http.Request) 
 		return
 	}
 
+	if err := receiver.ValidateFileReferences(); err != nil {
+		render.Error(rw, err)
+		return
+	}
+
 	err = handler.alertmanager.TestReceiver(ctx, claims.OrgID, receiver)
 	if err != nil {
 		render.Error(rw, err)
@@ -196,6 +201,11 @@ func (handler *handler) UpdateChannelByID(rw http.ResponseWriter, req *http.Requ
 		return
 	}
 
+	if err := receiver.ValidateFileReferences(); err != nil {
+		render.Error(rw, err)
+		return
+	}
+
 	err = handler.alertmanager.UpdateChannelByReceiverAndID(ctx, claims.OrgID, receiver, id)
 	if err != nil {
 		render.Error(rw, err)
@@ -262,6 +272,11 @@ func (handler *handler) CreateChannel(rw http.ResponseWriter, req *http.Request)
 
 	receiver, err := alertmanagertypes.NewReceiver(string(body))
 	if err != nil {
+		render.Error(rw, err)
+		return
+	}
+
+	if err := receiver.ValidateFileReferences(); err != nil {
 		render.Error(rw, err)
 		return
 	}

--- a/pkg/types/alertmanagertypes/receiver_file_reference.go
+++ b/pkg/types/alertmanagertypes/receiver_file_reference.go
@@ -1,0 +1,125 @@
+package alertmanagertypes
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+)
+
+var ErrCodeAlertmanagerReceiverFileReference = errors.MustNewCode("alertmanager_receiver_file_reference")
+
+// ValidateFileReferences rejects a receiver that points at a file on the host
+// running SigNoz.
+//
+// Notifier configs can carry a secret indirectly instead of inline, e.g.
+// basic_auth.password_file, authorization.credentials_file, tls_config.ca_file,
+// opsgenie api_key_file or the files list of an http header. Alertmanager reads
+// those paths from the local filesystem when the notification is sent, which is
+// what you want for a config file an operator owns.
+//
+// Receivers that arrive over the API are user input, so they must not be able to
+// name a path. Everything a receiver needs is accepted inline.
+func (receiver *Receiver) ValidateFileReferences() error {
+	if receiver == nil {
+		return nil
+	}
+
+	return walkFileReferences(reflect.ValueOf(receiver), "")
+}
+
+func walkFileReferences(value reflect.Value, path string) error {
+	switch value.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if value.IsNil() {
+			return nil
+		}
+
+		return walkFileReferences(value.Elem(), path)
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < value.Len(); i++ {
+			if err := walkFileReferences(value.Index(i), path); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		iterator := value.MapRange()
+		for iterator.Next() {
+			if err := walkFileReferences(iterator.Value(), path); err != nil {
+				return err
+			}
+		}
+	case reflect.Struct:
+		structType := value.Type()
+		for i := 0; i < structType.NumField(); i++ {
+			field := structType.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+
+			name := serializedFieldName(field)
+			fieldPath := name
+			if path != "" && name != "" {
+				fieldPath = path + "." + name
+			}
+
+			if isFileReference(name) && isSet(value.Field(i)) {
+				return errors.Newf(
+					errors.TypeInvalidInput,
+					ErrCodeAlertmanagerReceiverFileReference,
+					"%q is not supported in a channel, it would read a file from the SigNoz host, provide the value itself instead",
+					fieldPath,
+				)
+			}
+
+			if err := walkFileReferences(value.Field(i), fieldPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// serializedFieldName returns the name the field is (un)marshalled under,
+// preferring the yaml tag over the json tag. Fields that are not serialized at
+// all cannot be set by a caller and return an empty name.
+func serializedFieldName(field reflect.StructField) string {
+	for _, key := range []string{"yaml", "json"} {
+		tag, ok := field.Tag.Lookup(key)
+		if !ok {
+			continue
+		}
+
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "-" {
+			return ""
+		}
+
+		if name != "" {
+			return name
+		}
+	}
+
+	if field.Anonymous {
+		return ""
+	}
+
+	return field.Name
+}
+
+// isFileReference reports whether a field name denotes a path that alertmanager
+// reads at notify time. Upstream names those fields consistently, either with a
+// _file suffix or, for http header values, files.
+func isFileReference(name string) bool {
+	return strings.HasSuffix(name, "_file") || name == "files"
+}
+
+func isSet(value reflect.Value) bool {
+	switch value.Kind() {
+	case reflect.String, reflect.Slice, reflect.Array, reflect.Map:
+		return value.Len() > 0
+	default:
+		return !value.IsZero()
+	}
+}

--- a/pkg/types/alertmanagertypes/receiver_file_reference_test.go
+++ b/pkg/types/alertmanagertypes/receiver_file_reference_test.go
@@ -1,0 +1,62 @@
+package alertmanagertypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReceiverValidateFileReferences(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+		pass  bool
+	}{
+		{
+			name:  "WebhookWithInlinePassword",
+			input: `{"name":"webhook","webhook_configs":[{"url":"https://example.com/hook","http_config":{"basic_auth":{"username":"u","password":"p"}}}]}`,
+			pass:  true,
+		},
+		{
+			name:  "SlackWithInlineAPIURL",
+			input: `{"name":"slack","slack_configs":[{"api_url":"https://hooks.slack.com/services/T/B/X","channel":"#alerts"}]}`,
+			pass:  true,
+		},
+		{
+			name:  "WebhookWithPasswordFile",
+			input: `{"name":"webhook","webhook_configs":[{"url":"https://example.com/hook","http_config":{"basic_auth":{"username":"u","password_file":"/proc/self/environ"}}}]}`,
+			pass:  false,
+		},
+		{
+			name:  "WebhookWithCredentialsFile",
+			input: `{"name":"webhook","webhook_configs":[{"url":"https://example.com/hook","http_config":{"authorization":{"type":"Bearer","credentials_file":"/etc/passwd"}}}]}`,
+			pass:  false,
+		},
+		{
+			name:  "WebhookWithTLSCAFile",
+			input: `{"name":"webhook","webhook_configs":[{"url":"https://example.com/hook","http_config":{"tls_config":{"ca_file":"/etc/passwd"}}}]}`,
+			pass:  false,
+		},
+		{
+			name:  "OpsgenieWithAPIKeyFile",
+			input: `{"name":"opsgenie","opsgenie_configs":[{"api_key_file":"/etc/passwd"}]}`,
+			pass:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			receiver, err := NewReceiver(tc.input)
+			require.NoError(t, err)
+
+			err = receiver.ValidateFileReferences()
+			if tc.pass {
+				assert.NoError(t, err)
+				return
+			}
+
+			assert.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
### What

Notifier configs can carry a secret indirectly instead of inline, by naming a file: `basic_auth.password_file`, `authorization.credentials_file`, `oauth2.client_secret_file`, `tls_config.ca_file` / `cert_file` / `key_file`, the opsgenie `api_key_file`, the `files` list of an http header, and the equivalents on the other notifier types. Alertmanager reads those paths from the local filesystem when the notification is sent. For a config file that an operator owns and edits on disk, that is exactly the intended behaviour.

Channels, however, are submitted as JSON over the API and decoded straight into `config.Receiver`:

```go
receiver, err := alertmanagertypes.NewReceiver(string(body))   // handler.go, test/create/update channel
```

`NewReceiver` only applies per-notifier defaults, it does not restrict which fields a caller may set. So a channel can name any path that the SigNoz process can read, and the content is then sent to the webhook target named in the same channel. SigNoz runs as root in the published image, and `/api/v1/channels/test` (plus the deprecated `/api/v1/testChannel`) only requires the editor role, so this does not even need an admin.

### How

`Receiver.ValidateFileReferences` walks the decoded receiver with reflection and rejects any populated field whose serialized name ends in `_file`, plus the `files` list of an http header. Reflection rather than an explicit list because upstream names these fields consistently across notifier types, and a new notifier (or a new upstream field) is then covered without anyone having to remember this check.

It is called from the three handlers that build a receiver from a request body: test channel, create channel, update channel.

Deliberately **not** put inside `NewReceiver`: the same constructor also parses receivers that are already stored (`channel.go`, `config.go`). Validating there would make an existing stored channel unloadable rather than just rejecting new input, so the check sits at the API boundary.

Everything a channel needs can still be provided inline, that path is untouched.

### Testing

- new table test in `receiver_file_reference_test.go`: inline password and inline slack api_url pass, `password_file`, `credentials_file`, `tls_config.ca_file` and opsgenie `api_key_file` are rejected
- `go vet` and `gofmt` clean, `go test ./pkg/types/alertmanagertypes/... ./pkg/alertmanager/...` passes except `TestEmailRejected` in `alertmanagernotify/email`, which fails the same way on unmodified `main` here ("smtp: server already closed"), so it is unrelated to this change
- built the enterprise binary from this branch, ran it in the `signoz/signoz:v0.135.0` image next to an unpatched v0.135.0 container, both pointed at a webhook receiver:
  - `POST /api/v1/channels/test` with `basic_auth.password_file` set: unpatched returns 204 and the receiving endpoint gets the file content as the basic-auth password; patched returns 400 with `"webhook_configs.http_config.basic_auth.password_file" is not supported in a channel ...` and sends nothing
  - same call with an ordinary inline `password`: 204 on the patched build and the webhook target receives the notification as before

Happy to adjust the wording of the error or to turn the reflection walk into an explicit field list if you would rather have that.