### PR TITLE
fix: choose first panel during migration

### DIFF
--- a/pkg/types/dashboardtypes/perses_v1_to_v2_panels.go
+++ b/pkg/types/dashboardtypes/perses_v1_to_v2_panels.go
@@ -41,6 +41,9 @@ func (d *v1Decoder) convertV1Panels(raw any) map[string]*Panel {
 		if !ok || id == "" {
 			continue
 		}
+		if _, present := panels[id]; present {
+			continue
+		}
 		var panel *Panel
 		panelType := d.readString(widget, "panelTypes")
 		switch panelType {

--- a/pkg/types/dashboardtypes/perses_v1_to_v2_test.go
+++ b/pkg/types/dashboardtypes/perses_v1_to_v2_test.go
@@ -238,6 +238,24 @@ func TestConvertV1PanelsSkipsUnknownType(t *testing.T) {
 	require.NoError(t, d.errIfHasMalformedFields())
 }
 
+// TestConvertV1PanelsKeepsFirstOfDuplicateIDs verifies that when two widgets share
+// an id, the first is kept and later ones dropped — matching v1's widgets.find()
+// lookup, which returns the first match.
+func TestConvertV1PanelsKeepsFirstOfDuplicateIDs(t *testing.T) {
+	widgets := []any{
+		map[string]any{"id": "dup", "panelTypes": "graph", "title": "First", "query": singleLogsBuilderQuery()},
+		map[string]any{"id": "dup", "panelTypes": "graph", "title": "Second", "query": singleLogsBuilderQuery()},
+	}
+
+	d := &v1Decoder{}
+	panels := d.convertV1Panels(widgets)
+	require.NoError(t, d.errIfHasMalformedFields())
+
+	require.Len(t, panels, 1)
+	require.Contains(t, panels, "dup")
+	assert.Equal(t, "First", panels["dup"].Spec.Display.Name)
+}
+
 func TestConvertGraphWidgetToTimeSeriesPanel(t *testing.T) {
 	widget := map[string]any{
 		"id":                 "widget-1",


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

If an ID is repeated in a v1 json, migration should choose the first one in the array. This is exactly what V1 UI did.