### PR TITLE
fix(ruletypes): expose above_or_equal and below_or_equal in CompareOperator enum

### DIFF
--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -7430,6 +7430,8 @@ components:
       - below
       - equal
       - not_equal
+      - above_or_equal
+      - below_or_equal
       - outside_bounds
       type: string
     RuletypesCumulativeSchedule:

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -8479,6 +8479,8 @@ export enum RuletypesCompareOperatorDTO {
 	below = 'below',
 	equal = 'equal',
 	not_equal = 'not_equal',
+	above_or_equal = 'above_or_equal',
+	below_or_equal = 'below_or_equal',
 	outside_bounds = 'outside_bounds',
 }
 export interface RuletypesBasicRuleThresholdDTO {

--- a/frontend/src/container/CreateAlertV2/AlertCondition/ThresholdItem.tsx
+++ b/frontend/src/container/CreateAlertV2/AlertCondition/ThresholdItem.tsx
@@ -66,6 +66,10 @@ function ThresholdItem({
 				return '=';
 			case AlertThresholdOperator.IS_NOT_EQUAL_TO:
 				return '!=';
+			case AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO:
+				return '>=';
+			case AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO:
+				return '<=';
 			default:
 				return '';
 		}

--- a/frontend/src/container/CreateAlertV2/AlertCondition/utils.tsx
+++ b/frontend/src/container/CreateAlertV2/AlertCondition/utils.tsx
@@ -83,6 +83,10 @@ const getOperatorWord = (op: AlertThresholdOperator): string => {
 			return 'equal';
 		case AlertThresholdOperator.IS_NOT_EQUAL_TO:
 			return 'not equal';
+		case AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO:
+			return 'equal or exceed';
+		case AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO:
+			return 'equal or fall below';
 		default:
 			return 'exceed';
 	}
@@ -98,6 +102,10 @@ const getThresholdValue = (op: AlertThresholdOperator): number => {
 			return 100;
 		case AlertThresholdOperator.IS_NOT_EQUAL_TO:
 			return 0;
+		case AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO:
+			return 80;
+		case AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO:
+			return 50;
 		default:
 			return 80;
 	}
@@ -116,6 +124,8 @@ const getDataPoints = (
 			[AlertThresholdOperator.IS_EQUAL_TO]: [95, 100, 105, 90, 100],
 			[AlertThresholdOperator.IS_NOT_EQUAL_TO]: [5, 0, 10, 15, 0],
 			[AlertThresholdOperator.IS_ABOVE]: [75, 85, 90, 78, 95],
+			[AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO]: [75, 80, 90, 78, 95],
+			[AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO]: [60, 50, 40, 55, 35],
 			[AlertThresholdOperator.ABOVE_BELOW]: [75, 85, 90, 78, 95],
 		},
 		[AlertThresholdMatchType.ALL_THE_TIME]: {
@@ -123,6 +133,8 @@ const getDataPoints = (
 			[AlertThresholdOperator.IS_EQUAL_TO]: [100, 100, 100, 100, 100],
 			[AlertThresholdOperator.IS_NOT_EQUAL_TO]: [5, 10, 15, 8, 12],
 			[AlertThresholdOperator.IS_ABOVE]: [85, 87, 90, 88, 95],
+			[AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO]: [80, 87, 90, 88, 95],
+			[AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO]: [50, 40, 35, 42, 38],
 			[AlertThresholdOperator.ABOVE_BELOW]: [85, 87, 90, 88, 95],
 		},
 		[AlertThresholdMatchType.ON_AVERAGE]: {
@@ -130,6 +142,8 @@ const getDataPoints = (
 			[AlertThresholdOperator.IS_EQUAL_TO]: [95, 105, 100, 95, 105],
 			[AlertThresholdOperator.IS_NOT_EQUAL_TO]: [5, 10, 15, 8, 12],
 			[AlertThresholdOperator.IS_ABOVE]: [75, 85, 90, 78, 95],
+			[AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO]: [70, 85, 90, 75, 80],
+			[AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO]: [60, 40, 55, 45, 50],
 			[AlertThresholdOperator.ABOVE_BELOW]: [75, 85, 90, 78, 95],
 		},
 		[AlertThresholdMatchType.IN_TOTAL]: {
@@ -137,6 +151,8 @@ const getDataPoints = (
 			[AlertThresholdOperator.IS_EQUAL_TO]: [20, 20, 20, 20, 20],
 			[AlertThresholdOperator.IS_NOT_EQUAL_TO]: [10, 15, 25, 5, 30],
 			[AlertThresholdOperator.IS_ABOVE]: [10, 15, 25, 5, 30],
+			[AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO]: [10, 15, 25, 5, 25],
+			[AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO]: [8, 5, 10, 12, 15],
 			[AlertThresholdOperator.ABOVE_BELOW]: [10, 15, 25, 5, 30],
 		},
 		[AlertThresholdMatchType.LAST]: {
@@ -144,6 +160,8 @@ const getDataPoints = (
 			[AlertThresholdOperator.IS_EQUAL_TO]: [75, 85, 90, 78, 100],
 			[AlertThresholdOperator.IS_NOT_EQUAL_TO]: [75, 85, 90, 78, 25],
 			[AlertThresholdOperator.IS_ABOVE]: [75, 85, 90, 78, 95],
+			[AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO]: [75, 85, 90, 78, 80],
+			[AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO]: [75, 85, 90, 78, 50],
 			[AlertThresholdOperator.ABOVE_BELOW]: [75, 85, 90, 78, 95],
 		},
 	};
@@ -157,6 +175,8 @@ const getTooltipOperatorSymbol = (op: AlertThresholdOperator): string => {
 		[AlertThresholdOperator.IS_BELOW]: '<',
 		[AlertThresholdOperator.IS_EQUAL_TO]: '=',
 		[AlertThresholdOperator.IS_NOT_EQUAL_TO]: '!=',
+		[AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO]: '>=',
+		[AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO]: '<=',
 		[AlertThresholdOperator.ABOVE_BELOW]: '>',
 	};
 	return symbolMap[op] || '>';
@@ -252,6 +272,10 @@ export const getMatchTypeTooltip = (
 					return p === thresholdValue;
 				case AlertThresholdOperator.IS_NOT_EQUAL_TO:
 					return p !== thresholdValue;
+				case AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO:
+					return p >= thresholdValue;
+				case AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO:
+					return p <= thresholdValue;
 				default:
 					return p > thresholdValue;
 			}
@@ -294,7 +318,8 @@ export const getMatchTypeTooltip = (
 						matchType={matchType}
 					>
 						Alert triggers (all points {operatorWord} {thresholdValue})<br />
-						If any point was {thresholdValue}, no alert would fire
+						If any point didn&apos;t {operatorWord} {thresholdValue}, no alert would
+						fire
 					</TooltipExample>
 					<TooltipLink />
 				</TooltipContent>

--- a/frontend/src/container/CreateAlertV2/Footer/__tests__/utils.test.ts
+++ b/frontend/src/container/CreateAlertV2/Footer/__tests__/utils.test.ts
@@ -532,7 +532,7 @@ describe('Footer utils', () => {
 			['symbol', '>', 'at_least_once'],
 			['literal', 'above', 'at_least_once'],
 			['short', 'eq', 'avg'],
-			['UI-unexposed', 'above_or_equal', 'at_least_once'],
+			['inclusive', 'above_or_equal', 'at_least_once'],
 		])(
 			'round-trips %s op/matchType unchanged through the submit payload (%s / %s)',
 			(_desc, op, matchType) => {

--- a/frontend/src/container/CreateAlertV2/__tests__/utils.test.tsx
+++ b/frontend/src/container/CreateAlertV2/__tests__/utils.test.tsx
@@ -332,23 +332,18 @@ describe('CreateAlertV2 utils', () => {
 			['not_equal', AlertThresholdOperator.IS_NOT_EQUAL_TO],
 			['not_eq', AlertThresholdOperator.IS_NOT_EQUAL_TO],
 			['!=', AlertThresholdOperator.IS_NOT_EQUAL_TO],
+			['5', AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO],
+			['above_or_equal', AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO],
+			['above_or_eq', AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO],
+			['>=', AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO],
+			['6', AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO],
+			['below_or_equal', AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO],
+			['below_or_eq', AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO],
+			['<=', AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO],
 			['7', AlertThresholdOperator.ABOVE_BELOW],
 			['outside_bounds', AlertThresholdOperator.ABOVE_BELOW],
 		])('maps backend alias %s to canonical enum', (alias, expected) => {
 			expect(normalizeOperator(alias)).toBe(expected);
-		});
-
-		it.each([
-			['5', 'above_or_equal'],
-			['above_or_equal', 'above_or_equal'],
-			['above_or_eq', 'above_or_equal'],
-			['>=', 'above_or_equal'],
-			['6', 'below_or_equal'],
-			['below_or_equal', 'below_or_equal'],
-			['below_or_eq', 'below_or_equal'],
-			['<=', 'below_or_equal'],
-		])('returns undefined for UI-unexposed alias %s (%s family)', (alias) => {
-			expect(normalizeOperator(alias)).toBeUndefined();
 		});
 
 		it('returns undefined for unknown values', () => {
@@ -413,8 +408,8 @@ describe('CreateAlertV2 utils', () => {
 			['symbol', '>', 'at_least_once'],
 			['short form', 'eq', 'avg'],
 			['mixed numeric and literal', '7', 'last'],
-			['UI-unexposed operator', 'above_or_equal', 'at_least_once'],
-			['UI-unexposed numeric operator', '5', 'at_least_once'],
+			['inclusive literal operator', 'above_or_equal', 'at_least_once'],
+			['inclusive numeric operator', '5', 'at_least_once'],
 		])('preserves %s op/matchType verbatim (%s / %s)', (_desc, op, matchType) => {
 			const state = getThresholdStateFromAlertDef(buildDef(op, matchType));
 			expect(state.operator).toBe(op);

--- a/frontend/src/container/CreateAlertV2/context/conditionNormalizers.ts
+++ b/frontend/src/container/CreateAlertV2/context/conditionNormalizers.ts
@@ -2,9 +2,8 @@ import { AlertThresholdMatchType, AlertThresholdOperator } from './types';
 
 // Mirrors the backend's CompareOperator.Normalize() in
 // pkg/types/ruletypes/compare.go. Maps any accepted alias to the enum value
-// the dropdown understands. Returns undefined for aliases the UI does not
-// expose (e.g. above_or_equal, below_or_equal) so callers can keep the raw
-// value on screen instead of silently rewriting it.
+// the dropdown understands. Returns undefined for unknown values so callers
+// can keep the raw value on screen instead of silently rewriting it.
 export function normalizeOperator(
 	raw: string | undefined,
 ): AlertThresholdOperator | undefined {
@@ -27,6 +26,16 @@ export function normalizeOperator(
 		case 'not_eq':
 		case '!=':
 			return AlertThresholdOperator.IS_NOT_EQUAL_TO;
+		case '5':
+		case 'above_or_equal':
+		case 'above_or_eq':
+		case '>=':
+			return AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO;
+		case '6':
+		case 'below_or_equal':
+		case 'below_or_eq':
+		case '<=':
+			return AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO;
 		case '7':
 		case 'outside_bounds':
 			return AlertThresholdOperator.ABOVE_BELOW;

--- a/frontend/src/container/CreateAlertV2/context/constants.ts
+++ b/frontend/src/container/CreateAlertV2/context/constants.ts
@@ -125,6 +125,14 @@ export const THRESHOLD_OPERATOR_OPTIONS = [
 	{ value: AlertThresholdOperator.IS_BELOW, label: 'BELOW' },
 	{ value: AlertThresholdOperator.IS_EQUAL_TO, label: 'EQUAL TO' },
 	{ value: AlertThresholdOperator.IS_NOT_EQUAL_TO, label: 'NOT EQUAL TO' },
+	{
+		value: AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO,
+		label: 'ABOVE OR EQUAL TO',
+	},
+	{
+		value: AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO,
+		label: 'BELOW OR EQUAL TO',
+	},
 ];
 
 export const ANOMALY_THRESHOLD_OPERATOR_OPTIONS = [

--- a/frontend/src/container/CreateAlertV2/context/types.ts
+++ b/frontend/src/container/CreateAlertV2/context/types.ts
@@ -99,6 +99,8 @@ export enum AlertThresholdOperator {
 	IS_BELOW = 'below',
 	IS_EQUAL_TO = 'equal',
 	IS_NOT_EQUAL_TO = 'not_equal',
+	IS_ABOVE_OR_EQUAL_TO = 'above_or_equal',
+	IS_BELOW_OR_EQUAL_TO = 'below_or_equal',
 	ABOVE_BELOW = 'outside_bounds',
 }
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/__tests__/deriveAlertPrefill.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/__tests__/deriveAlertPrefill.test.ts
@@ -167,9 +167,9 @@ describe('deriveAlertPrefill', () => {
 
 		it.each([
 			['above', AlertThresholdOperator.IS_ABOVE],
-			['above_or_equal', AlertThresholdOperator.IS_ABOVE],
+			['above_or_equal', AlertThresholdOperator.IS_ABOVE_OR_EQUAL_TO],
 			['below', AlertThresholdOperator.IS_BELOW],
-			['below_or_equal', AlertThresholdOperator.IS_BELOW],
+			['below_or_equal', AlertThresholdOperator.IS_BELOW_OR_EQUAL_TO],
 			['equal', AlertThresholdOperator.IS_EQUAL_TO],
 			['not_equal', AlertThresholdOperator.IS_NOT_EQUAL_TO],
 		])('maps panel operator %s → %s', (op, expected) => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/deriveAlertPrefill.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/PanelsAndSectionsLayout/Panel/utils/deriveAlertPrefill.ts
@@ -104,20 +104,6 @@ function pickHighestDanger(
 	)[0];
 }
 
-// The alert UI has no inclusive operator; collapse "or equal" onto its strict variant.
-function panelOperatorToAlertOperator(
-	operator: DashboardtypesComparisonOperatorDTO | undefined,
-): AlertThresholdOperator | undefined {
-	switch (operator) {
-		case 'above_or_equal':
-			return normalizeOperator('above');
-		case 'below_or_equal':
-			return normalizeOperator('below');
-		default:
-			return normalizeOperator(operator);
-	}
-}
-
 export function deriveAlertPrefill(
 	panel: DashboardtypesPanelDTO,
 	query: Query,
@@ -135,7 +121,7 @@ export function deriveAlertPrefill(
 
 	const top = pickHighestDanger(readPanelThresholds(panel.spec.plugin));
 	if (top) {
-		prefill.operator = panelOperatorToAlertOperator(top.operator);
+		prefill.operator = normalizeOperator(top.operator);
 		prefill.threshold = {
 			id: uuid(),
 			label: 'critical',

--- a/pkg/types/ruletypes/compare.go
+++ b/pkg/types/ruletypes/compare.go
@@ -48,8 +48,8 @@ func (CompareOperator) Enum() []any {
 		ValueIsBelowLiteral,
 		ValueIsEqLiteral,
 		ValueIsNotEqLiteral,
-		// ValueAboveOrEqLiteral,
-		// ValueBelowOrEqLiteral,
+		ValueAboveOrEqLiteral,
+		ValueBelowOrEqLiteral,
 		ValueOutsideBoundsLiteral,
 	}
 }


### PR DESCRIPTION
The `above_or_equal` and `below_or_equal` operators are accepted by `Validate()`, normalized, evaluated, and returned by the rules API, but were commented out of `CompareOperator.Enum()`. Since `Enum()` feeds the generated OpenAPI spec, clients generated from it (e.g. terraform-provider-signoz) reject rules the server itself creates and returns — including on the read/import path.

### Changes

- **Backend**: uncomments the two values in `CompareOperator.Enum()` and regenerates `docs/api/openapi.yml` and the frontend client.
- **Frontend (CreateAlertV2 only)**: the two operators are now selectable in the threshold operator dropdown, normalized from all backend aliases (`5`/`6`, `above_or_eq`/`below_or_eq`, `>=`/`<=`), rendered with their symbols in threshold rows and match-type tooltips, and prefilled losslessly from dashboard panel thresholds (previously collapsed onto the strict variants). Without this, a rule created with these operators over the API would render with raw enum strings and lose its operator on dashboard-to-alert prefill. The v1 form is left untouched.

closes #12350