### PR TITLE
feat(infra-monitoring): goroutines for metadata and order-by-column queries

### DIFF
--- a/pkg/modules/inframonitoring/implinframonitoring/clusters.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/clusters.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/inframonitoringtypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/valuer"
+	"golang.org/x/sync/errgroup"
 )
 
 // buildClusterRecords assembles the page records. Node condition counts and
@@ -83,16 +84,36 @@ func buildClusterRecords(
 	return records
 }
 
-func (m *module) getTopClusterGroups(
+func (m *module) getTopClusterGroupsAndMetadata(
 	ctx context.Context,
 	orgID valuer.UUID,
 	req *inframonitoringtypes.PostableClusters,
-	metadataMap map[string]map[string]string,
-) ([]map[string]string, error) {
-	orderByKey := req.OrderBy.Key.Name
+) ([]map[string]string, map[string]map[string]string, error) {
+
+	var (
+		orderByKey      string
+		metadataMap     map[string]map[string]string
+		allMetricGroups []rankedGroup
+	)
+
+	orderByKey = req.OrderBy.Key.Name
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		metadataMap, err = m.getClustersTableMetadata(gCtx, orgID, req)
+		return err
+	})
+
 	if orderByKey == inframonitoringtypes.ClusterNameAttrKey {
-		return inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.ClusterNameAttrKey), nil
+		if err := g.Wait(); err != nil {
+			return nil, nil, err
+		}
+		pageGroups := inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.ClusterNameAttrKey)
+		return pageGroups, metadataMap, nil
 	}
+
 	queryNamesForOrderBy := orderByToClustersQueryNames[orderByKey]
 	rankingQueryName := queryNamesForOrderBy[len(queryNamesForOrderBy)-1]
 
@@ -126,13 +147,20 @@ func (m *module) getTopClusterGroups(
 		topReq.CompositeQuery.Queries = append(topReq.CompositeQuery.Queries, copied)
 	}
 
-	resp, err := m.querier.QueryRange(ctx, orgID, topReq)
-	if err != nil {
-		return nil, err
+	g.Go(func() error {
+		resp, err := m.querier.QueryRange(gCtx, orgID, topReq)
+		if err != nil {
+			return err
+		}
+		allMetricGroups = parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
 	}
 
-	allMetricGroups := parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
-	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), nil
+	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), metadataMap, nil
 }
 
 func (m *module) getClustersTableMetadata(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableClusters) (map[string]map[string]string, error) {

--- a/pkg/modules/inframonitoring/implinframonitoring/containers.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/containers.go
@@ -12,6 +12,7 @@ import (
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/huandu/go-sqlbuilder"
+	"golang.org/x/sync/errgroup"
 )
 
 // buildContainerRecords assembles the page records, merging kubeletstats
@@ -138,16 +139,36 @@ func buildContainerRecords(
 	return records
 }
 
-func (m *module) getTopContainerGroups(
+func (m *module) getTopContainerGroupsAndMetadata(
 	ctx context.Context,
 	orgID valuer.UUID,
 	req *inframonitoringtypes.PostableContainers,
-	metadataMap map[string]map[string]string,
-) ([]map[string]string, error) {
-	orderByKey := req.OrderBy.Key.Name
+) ([]map[string]string, map[string]map[string]string, error) {
+
+	var (
+		orderByKey      string
+		metadataMap     map[string]map[string]string
+		allMetricGroups []rankedGroup
+	)
+
+	orderByKey = req.OrderBy.Key.Name
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		metadataMap, err = m.getContainersTableMetadata(gCtx, orgID, req)
+		return err
+	})
+
 	if orderByKey == inframonitoringtypes.ContainerNameAttrKey {
-		return inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.ContainerNameAttrKey), nil
+		if err := g.Wait(); err != nil {
+			return nil, nil, err
+		}
+		pageGroups := inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.ContainerNameAttrKey)
+		return pageGroups, metadataMap, nil
 	}
+
 	queryNamesForOrderBy := orderByToContainersQueryNames[orderByKey]
 	rankingQueryName := queryNamesForOrderBy[len(queryNamesForOrderBy)-1]
 
@@ -181,13 +202,20 @@ func (m *module) getTopContainerGroups(
 		topReq.CompositeQuery.Queries = append(topReq.CompositeQuery.Queries, copied)
 	}
 
-	resp, err := m.querier.QueryRange(ctx, orgID, topReq)
-	if err != nil {
-		return nil, err
+	g.Go(func() error {
+		resp, err := m.querier.QueryRange(gCtx, orgID, topReq)
+		if err != nil {
+			return err
+		}
+		allMetricGroups = parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
 	}
 
-	allMetricGroups := parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
-	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), nil
+	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), metadataMap, nil
 }
 
 func (m *module) getContainersTableMetadata(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableContainers) (map[string]map[string]string, error) {

--- a/pkg/modules/inframonitoring/implinframonitoring/daemonsets.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/daemonsets.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/inframonitoringtypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/valuer"
+	"golang.org/x/sync/errgroup"
 )
 
 // buildDaemonSetRecords assembles the page records. Pod status counts come from
@@ -89,16 +90,36 @@ func buildDaemonSetRecords(
 	return records
 }
 
-func (m *module) getTopDaemonSetGroups(
+func (m *module) getTopDaemonSetGroupsAndMetadata(
 	ctx context.Context,
 	orgID valuer.UUID,
 	req *inframonitoringtypes.PostableDaemonSets,
-	metadataMap map[string]map[string]string,
-) ([]map[string]string, error) {
-	orderByKey := req.OrderBy.Key.Name
+) ([]map[string]string, map[string]map[string]string, error) {
+
+	var (
+		orderByKey      string
+		metadataMap     map[string]map[string]string
+		allMetricGroups []rankedGroup
+	)
+
+	orderByKey = req.OrderBy.Key.Name
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		metadataMap, err = m.getDaemonSetsTableMetadata(gCtx, orgID, req)
+		return err
+	})
+
 	if orderByKey == inframonitoringtypes.DaemonSetNameAttrKey {
-		return inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.DaemonSetNameAttrKey), nil
+		if err := g.Wait(); err != nil {
+			return nil, nil, err
+		}
+		pageGroups := inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.DaemonSetNameAttrKey)
+		return pageGroups, metadataMap, nil
 	}
+
 	queryNamesForOrderBy := orderByToDaemonSetsQueryNames[orderByKey]
 	rankingQueryName := queryNamesForOrderBy[len(queryNamesForOrderBy)-1]
 
@@ -132,13 +153,20 @@ func (m *module) getTopDaemonSetGroups(
 		topReq.CompositeQuery.Queries = append(topReq.CompositeQuery.Queries, copied)
 	}
 
-	resp, err := m.querier.QueryRange(ctx, orgID, topReq)
-	if err != nil {
-		return nil, err
+	g.Go(func() error {
+		resp, err := m.querier.QueryRange(gCtx, orgID, topReq)
+		if err != nil {
+			return err
+		}
+		allMetricGroups = parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
 	}
 
-	allMetricGroups := parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
-	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), nil
+	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), metadataMap, nil
 }
 
 func (m *module) getDaemonSetsTableMetadata(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableDaemonSets) (map[string]map[string]string, error) {

--- a/pkg/modules/inframonitoring/implinframonitoring/deployments.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/deployments.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/inframonitoringtypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/valuer"
+	"golang.org/x/sync/errgroup"
 )
 
 // buildDeploymentRecords assembles the page records. Pod status counts come from
@@ -81,16 +82,36 @@ func buildDeploymentRecords(
 	return records
 }
 
-func (m *module) getTopDeploymentGroups(
+func (m *module) getTopDeploymentGroupsAndMetadata(
 	ctx context.Context,
 	orgID valuer.UUID,
 	req *inframonitoringtypes.PostableDeployments,
-	metadataMap map[string]map[string]string,
-) ([]map[string]string, error) {
-	orderByKey := req.OrderBy.Key.Name
+) ([]map[string]string, map[string]map[string]string, error) {
+
+	var (
+		orderByKey      string
+		metadataMap     map[string]map[string]string
+		allMetricGroups []rankedGroup
+	)
+
+	orderByKey = req.OrderBy.Key.Name
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		metadataMap, err = m.getDeploymentsTableMetadata(gCtx, orgID, req)
+		return err
+	})
+
 	if orderByKey == inframonitoringtypes.DeploymentNameAttrKey {
-		return inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.DeploymentNameAttrKey), nil
+		if err := g.Wait(); err != nil {
+			return nil, nil, err
+		}
+		pageGroups := inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.DeploymentNameAttrKey)
+		return pageGroups, metadataMap, nil
 	}
+
 	queryNamesForOrderBy := orderByToDeploymentsQueryNames[orderByKey]
 	rankingQueryName := queryNamesForOrderBy[len(queryNamesForOrderBy)-1]
 
@@ -124,13 +145,20 @@ func (m *module) getTopDeploymentGroups(
 		topReq.CompositeQuery.Queries = append(topReq.CompositeQuery.Queries, copied)
 	}
 
-	resp, err := m.querier.QueryRange(ctx, orgID, topReq)
-	if err != nil {
-		return nil, err
+	g.Go(func() error {
+		resp, err := m.querier.QueryRange(gCtx, orgID, topReq)
+		if err != nil {
+			return err
+		}
+		allMetricGroups = parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
 	}
 
-	allMetricGroups := parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
-	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), nil
+	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), metadataMap, nil
 }
 
 func (m *module) getDeploymentsTableMetadata(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableDeployments) (map[string]map[string]string, error) {

--- a/pkg/modules/inframonitoring/implinframonitoring/hosts.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/hosts.go
@@ -13,6 +13,7 @@ import (
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/huandu/go-sqlbuilder"
+	"golang.org/x/sync/errgroup"
 )
 
 // getPerGroupHostStatusCounts computes the number of active and inactive hosts per group
@@ -248,19 +249,41 @@ func buildHostRecords(
 	return records
 }
 
-// getTopHostGroups runs a ranking query for the ordering metric, sorts the
-// results, paginates, and backfills from metadataMap when the page extends
-// past the metric-ranked groups.
-func (m *module) getTopHostGroups(
+// getTopHostGroupsAndMetadata fetches the group metadata and the ordering-metric
+// ranking concurrently, then sorts the ranked results, paginates, and backfills
+// from metadataMap when the page extends past the metric-ranked groups. Returns
+// the page of groups and the metadata map (the caller needs it for Total and
+// records). Callers must apply any req.Filter mutation before calling.
+func (m *module) getTopHostGroupsAndMetadata(
 	ctx context.Context,
 	orgID valuer.UUID,
 	req *inframonitoringtypes.PostableHosts,
-	metadataMap map[string]map[string]string,
-) ([]map[string]string, error) {
-	orderByKey := req.OrderBy.Key.Name
+) ([]map[string]string, map[string]map[string]string, error) {
+
+	var (
+		orderByKey      string
+		metadataMap     map[string]map[string]string
+		allMetricGroups []rankedGroup
+	)
+
+	orderByKey = req.OrderBy.Key.Name
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		metadataMap, err = m.getHostsTableMetadata(gCtx, orgID, req)
+		return err
+	})
+
 	if orderByKey == inframonitoringtypes.HostNameAttrKey {
-		return inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.HostNameAttrKey), nil
+		if err := g.Wait(); err != nil {
+			return nil, nil, err
+		}
+		pageGroups := inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.HostNameAttrKey)
+		return pageGroups, metadataMap, nil
 	}
+
 	queryNamesForOrderBy := orderByToHostsQueryNames[orderByKey]
 	// The last entry is the formula/query whose value we sort by.
 	rankingQueryName := queryNamesForOrderBy[len(queryNamesForOrderBy)-1]
@@ -295,13 +318,20 @@ func (m *module) getTopHostGroups(
 		topReq.CompositeQuery.Queries = append(topReq.CompositeQuery.Queries, copied)
 	}
 
-	resp, err := m.querier.QueryRange(ctx, orgID, topReq)
-	if err != nil {
-		return nil, err
+	g.Go(func() error {
+		resp, err := m.querier.QueryRange(gCtx, orgID, topReq)
+		if err != nil {
+			return err
+		}
+		allMetricGroups = parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
 	}
 
-	allMetricGroups := parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
-	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), nil
+	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), metadataMap, nil
 }
 
 // applyHostsActiveStatusFilter MODIFIES req.Filter.Expression to include an IN/NOT IN

--- a/pkg/modules/inframonitoring/implinframonitoring/jobs.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/jobs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/inframonitoringtypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/valuer"
+	"golang.org/x/sync/errgroup"
 )
 
 // buildJobRecords assembles the page records. Pod status counts come from
@@ -89,16 +90,36 @@ func buildJobRecords(
 	return records
 }
 
-func (m *module) getTopJobGroups(
+func (m *module) getTopJobGroupsAndMetadata(
 	ctx context.Context,
 	orgID valuer.UUID,
 	req *inframonitoringtypes.PostableJobs,
-	metadataMap map[string]map[string]string,
-) ([]map[string]string, error) {
-	orderByKey := req.OrderBy.Key.Name
+) ([]map[string]string, map[string]map[string]string, error) {
+
+	var (
+		orderByKey      string
+		metadataMap     map[string]map[string]string
+		allMetricGroups []rankedGroup
+	)
+
+	orderByKey = req.OrderBy.Key.Name
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		metadataMap, err = m.getJobsTableMetadata(gCtx, orgID, req)
+		return err
+	})
+
 	if orderByKey == inframonitoringtypes.JobNameAttrKey {
-		return inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.JobNameAttrKey), nil
+		if err := g.Wait(); err != nil {
+			return nil, nil, err
+		}
+		pageGroups := inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.JobNameAttrKey)
+		return pageGroups, metadataMap, nil
 	}
+
 	queryNamesForOrderBy := orderByToJobsQueryNames[orderByKey]
 	rankingQueryName := queryNamesForOrderBy[len(queryNamesForOrderBy)-1]
 
@@ -132,13 +153,20 @@ func (m *module) getTopJobGroups(
 		topReq.CompositeQuery.Queries = append(topReq.CompositeQuery.Queries, copied)
 	}
 
-	resp, err := m.querier.QueryRange(ctx, orgID, topReq)
-	if err != nil {
-		return nil, err
+	g.Go(func() error {
+		resp, err := m.querier.QueryRange(gCtx, orgID, topReq)
+		if err != nil {
+			return err
+		}
+		allMetricGroups = parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
 	}
 
-	allMetricGroups := parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
-	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), nil
+	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), metadataMap, nil
 }
 
 func (m *module) getJobsTableMetadata(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableJobs) (map[string]map[string]string, error) {

--- a/pkg/modules/inframonitoring/implinframonitoring/module.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/module.go
@@ -191,17 +191,12 @@ func (m *module) ListHosts(ctx context.Context, orgID valuer.UUID, req *inframon
 		return resp, nil
 	}
 
-	metadataMap, err := m.getHostsTableMetadata(ctx, orgID, req)
+	pageGroups, metadataMap, err := m.getTopHostGroupsAndMetadata(ctx, orgID, req)
 	if err != nil {
 		return nil, err
 	}
 
 	resp.Total = len(metadataMap)
-
-	pageGroups, err := m.getTopHostGroups(ctx, orgID, req, metadataMap)
-	if err != nil {
-		return nil, err
-	}
 
 	if len(pageGroups) == 0 {
 		resp.Records = []inframonitoringtypes.HostRecord{}
@@ -291,17 +286,12 @@ func (m *module) ListPods(ctx context.Context, orgID valuer.UUID, req *inframoni
 		return resp, nil
 	}
 
-	metadataMap, err := m.getPodsTableMetadata(ctx, orgID, req)
+	pageGroups, metadataMap, err := m.getTopPodGroupsAndMetadata(ctx, orgID, req)
 	if err != nil {
 		return nil, err
 	}
 
 	resp.Total = len(metadataMap)
-
-	pageGroups, err := m.getTopPodGroups(ctx, orgID, req, metadataMap)
-	if err != nil {
-		return nil, err
-	}
 
 	if len(pageGroups) == 0 {
 		resp.Records = []inframonitoringtypes.PodRecord{}
@@ -389,17 +379,12 @@ func (m *module) ListContainers(ctx context.Context, orgID valuer.UUID, req *inf
 		return resp, nil
 	}
 
-	metadataMap, err := m.getContainersTableMetadata(ctx, orgID, req)
+	pageGroups, metadataMap, err := m.getTopContainerGroupsAndMetadata(ctx, orgID, req)
 	if err != nil {
 		return nil, err
 	}
 
 	resp.Total = len(metadataMap)
-
-	pageGroups, err := m.getTopContainerGroups(ctx, orgID, req, metadataMap)
-	if err != nil {
-		return nil, err
-	}
 
 	if len(pageGroups) == 0 {
 		resp.Records = []inframonitoringtypes.ContainerRecord{}
@@ -493,17 +478,12 @@ func (m *module) ListNodes(ctx context.Context, orgID valuer.UUID, req *inframon
 		return resp, nil
 	}
 
-	metadataMap, err := m.getNodesTableMetadata(ctx, orgID, req)
+	pageGroups, metadataMap, err := m.getTopNodeGroupsAndMetadata(ctx, orgID, req)
 	if err != nil {
 		return nil, err
 	}
 
 	resp.Total = len(metadataMap)
-
-	pageGroups, err := m.getTopNodeGroups(ctx, orgID, req, metadataMap)
-	if err != nil {
-		return nil, err
-	}
 
 	if len(pageGroups) == 0 {
 		resp.Records = []inframonitoringtypes.NodeRecord{}
@@ -591,17 +571,12 @@ func (m *module) ListNamespaces(ctx context.Context, orgID valuer.UUID, req *inf
 		return resp, nil
 	}
 
-	metadataMap, err := m.getNamespacesTableMetadata(ctx, orgID, req)
+	pageGroups, metadataMap, err := m.getTopNamespaceGroupsAndMetadata(ctx, orgID, req)
 	if err != nil {
 		return nil, err
 	}
 
 	resp.Total = len(metadataMap)
-
-	pageGroups, err := m.getTopNamespaceGroups(ctx, orgID, req, metadataMap)
-	if err != nil {
-		return nil, err
-	}
 
 	if len(pageGroups) == 0 {
 		resp.Records = []inframonitoringtypes.NamespaceRecord{}
@@ -688,17 +663,12 @@ func (m *module) ListClusters(ctx context.Context, orgID valuer.UUID, req *infra
 		return resp, nil
 	}
 
-	metadataMap, err := m.getClustersTableMetadata(ctx, orgID, req)
+	pageGroups, metadataMap, err := m.getTopClusterGroupsAndMetadata(ctx, orgID, req)
 	if err != nil {
 		return nil, err
 	}
 
 	resp.Total = len(metadataMap)
-
-	pageGroups, err := m.getTopClusterGroups(ctx, orgID, req, metadataMap)
-	if err != nil {
-		return nil, err
-	}
 
 	if len(pageGroups) == 0 {
 		resp.Records = []inframonitoringtypes.ClusterRecord{}
@@ -799,17 +769,12 @@ func (m *module) ListVolumes(ctx context.Context, orgID valuer.UUID, req *infram
 		return resp, nil
 	}
 
-	metadataMap, err := m.getVolumesTableMetadata(ctx, orgID, req)
+	pageGroups, metadataMap, err := m.getTopVolumeGroupsAndMetadata(ctx, orgID, req)
 	if err != nil {
 		return nil, err
 	}
 
 	resp.Total = len(metadataMap)
-
-	pageGroups, err := m.getTopVolumeGroups(ctx, orgID, req, metadataMap)
-	if err != nil {
-		return nil, err
-	}
 
 	if len(pageGroups) == 0 {
 		resp.Records = []inframonitoringtypes.VolumeRecord{}
@@ -877,17 +842,12 @@ func (m *module) ListDeployments(ctx context.Context, orgID valuer.UUID, req *in
 		return resp, nil
 	}
 
-	metadataMap, err := m.getDeploymentsTableMetadata(ctx, orgID, req)
+	pageGroups, metadataMap, err := m.getTopDeploymentGroupsAndMetadata(ctx, orgID, req)
 	if err != nil {
 		return nil, err
 	}
 
 	resp.Total = len(metadataMap)
-
-	pageGroups, err := m.getTopDeploymentGroups(ctx, orgID, req, metadataMap)
-	if err != nil {
-		return nil, err
-	}
 
 	if len(pageGroups) == 0 {
 		resp.Records = []inframonitoringtypes.DeploymentRecord{}
@@ -974,17 +934,12 @@ func (m *module) ListStatefulSets(ctx context.Context, orgID valuer.UUID, req *i
 		return resp, nil
 	}
 
-	metadataMap, err := m.getStatefulSetsTableMetadata(ctx, orgID, req)
+	pageGroups, metadataMap, err := m.getTopStatefulSetGroupsAndMetadata(ctx, orgID, req)
 	if err != nil {
 		return nil, err
 	}
 
 	resp.Total = len(metadataMap)
-
-	pageGroups, err := m.getTopStatefulSetGroups(ctx, orgID, req, metadataMap)
-	if err != nil {
-		return nil, err
-	}
 
 	if len(pageGroups) == 0 {
 		resp.Records = []inframonitoringtypes.StatefulSetRecord{}
@@ -1073,17 +1028,12 @@ func (m *module) ListJobs(ctx context.Context, orgID valuer.UUID, req *inframoni
 		return resp, nil
 	}
 
-	metadataMap, err := m.getJobsTableMetadata(ctx, orgID, req)
+	pageGroups, metadataMap, err := m.getTopJobGroupsAndMetadata(ctx, orgID, req)
 	if err != nil {
 		return nil, err
 	}
 
 	resp.Total = len(metadataMap)
-
-	pageGroups, err := m.getTopJobGroups(ctx, orgID, req, metadataMap)
-	if err != nil {
-		return nil, err
-	}
 
 	if len(pageGroups) == 0 {
 		resp.Records = []inframonitoringtypes.JobRecord{}
@@ -1172,17 +1122,12 @@ func (m *module) ListDaemonSets(ctx context.Context, orgID valuer.UUID, req *inf
 		return resp, nil
 	}
 
-	metadataMap, err := m.getDaemonSetsTableMetadata(ctx, orgID, req)
+	pageGroups, metadataMap, err := m.getTopDaemonSetGroupsAndMetadata(ctx, orgID, req)
 	if err != nil {
 		return nil, err
 	}
 
 	resp.Total = len(metadataMap)
-
-	pageGroups, err := m.getTopDaemonSetGroups(ctx, orgID, req, metadataMap)
-	if err != nil {
-		return nil, err
-	}
 
 	if len(pageGroups) == 0 {
 		resp.Records = []inframonitoringtypes.DaemonSetRecord{}

--- a/pkg/modules/inframonitoring/implinframonitoring/namespaces.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/namespaces.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/inframonitoringtypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/valuer"
+	"golang.org/x/sync/errgroup"
 )
 
 // buildNamespaceRecords assembles the page records. Pod status counts come from
@@ -64,16 +65,36 @@ func buildNamespaceRecords(
 	return records
 }
 
-func (m *module) getTopNamespaceGroups(
+func (m *module) getTopNamespaceGroupsAndMetadata(
 	ctx context.Context,
 	orgID valuer.UUID,
 	req *inframonitoringtypes.PostableNamespaces,
-	metadataMap map[string]map[string]string,
-) ([]map[string]string, error) {
-	orderByKey := req.OrderBy.Key.Name
+) ([]map[string]string, map[string]map[string]string, error) {
+
+	var (
+		orderByKey      string
+		metadataMap     map[string]map[string]string
+		allMetricGroups []rankedGroup
+	)
+
+	orderByKey = req.OrderBy.Key.Name
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		metadataMap, err = m.getNamespacesTableMetadata(gCtx, orgID, req)
+		return err
+	})
+
 	if orderByKey == inframonitoringtypes.NamespaceNameAttrKey {
-		return inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.NamespaceNameAttrKey), nil
+		if err := g.Wait(); err != nil {
+			return nil, nil, err
+		}
+		pageGroups := inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.NamespaceNameAttrKey)
+		return pageGroups, metadataMap, nil
 	}
+
 	queryNamesForOrderBy := orderByToNamespacesQueryNames[orderByKey]
 	rankingQueryName := queryNamesForOrderBy[len(queryNamesForOrderBy)-1]
 
@@ -107,13 +128,20 @@ func (m *module) getTopNamespaceGroups(
 		topReq.CompositeQuery.Queries = append(topReq.CompositeQuery.Queries, copied)
 	}
 
-	resp, err := m.querier.QueryRange(ctx, orgID, topReq)
-	if err != nil {
-		return nil, err
+	g.Go(func() error {
+		resp, err := m.querier.QueryRange(gCtx, orgID, topReq)
+		if err != nil {
+			return err
+		}
+		allMetricGroups = parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
 	}
 
-	allMetricGroups := parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
-	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), nil
+	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), metadataMap, nil
 }
 
 func (m *module) getNamespacesTableMetadata(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableNamespaces) (map[string]map[string]string, error) {

--- a/pkg/modules/inframonitoring/implinframonitoring/nodes.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/nodes.go
@@ -12,6 +12,7 @@ import (
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/huandu/go-sqlbuilder"
+	"golang.org/x/sync/errgroup"
 )
 
 // buildNodeRecords assembles the page records. Condition counts come from
@@ -91,16 +92,36 @@ func buildNodeRecords(
 	return records
 }
 
-func (m *module) getTopNodeGroups(
+func (m *module) getTopNodeGroupsAndMetadata(
 	ctx context.Context,
 	orgID valuer.UUID,
 	req *inframonitoringtypes.PostableNodes,
-	metadataMap map[string]map[string]string,
-) ([]map[string]string, error) {
-	orderByKey := req.OrderBy.Key.Name
+) ([]map[string]string, map[string]map[string]string, error) {
+
+	var (
+		orderByKey      string
+		metadataMap     map[string]map[string]string
+		allMetricGroups []rankedGroup
+	)
+
+	orderByKey = req.OrderBy.Key.Name
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		metadataMap, err = m.getNodesTableMetadata(gCtx, orgID, req)
+		return err
+	})
+
 	if orderByKey == inframonitoringtypes.NodeNameAttrKey {
-		return inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.NodeNameAttrKey), nil
+		if err := g.Wait(); err != nil {
+			return nil, nil, err
+		}
+		pageGroups := inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.NodeNameAttrKey)
+		return pageGroups, metadataMap, nil
 	}
+
 	queryNamesForOrderBy := orderByToNodesQueryNames[orderByKey]
 	rankingQueryName := queryNamesForOrderBy[len(queryNamesForOrderBy)-1]
 
@@ -134,13 +155,20 @@ func (m *module) getTopNodeGroups(
 		topReq.CompositeQuery.Queries = append(topReq.CompositeQuery.Queries, copied)
 	}
 
-	resp, err := m.querier.QueryRange(ctx, orgID, topReq)
-	if err != nil {
-		return nil, err
+	g.Go(func() error {
+		resp, err := m.querier.QueryRange(gCtx, orgID, topReq)
+		if err != nil {
+			return err
+		}
+		allMetricGroups = parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
 	}
 
-	allMetricGroups := parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
-	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), nil
+	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), metadataMap, nil
 }
 
 func (m *module) getNodesTableMetadata(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableNodes) (map[string]map[string]string, error) {

--- a/pkg/modules/inframonitoring/implinframonitoring/pods.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/pods.go
@@ -13,6 +13,7 @@ import (
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/valuer"
 	"github.com/huandu/go-sqlbuilder"
+	"golang.org/x/sync/errgroup"
 )
 
 // buildPodRecords assembles the page records. Status counts come from
@@ -145,16 +146,40 @@ func buildPodRecords(
 	return records
 }
 
-func (m *module) getTopPodGroups(
+// getTopPodGroupsAndMetadata fetches the group metadata and the ordering-metric
+// ranking concurrently, then pages the ranked groups, backfilling from metadata
+// when the page extends past the metric-ranked groups. Returns the page of
+// groups and the metadata map (needed by the caller for Total and records).
+func (m *module) getTopPodGroupsAndMetadata(
 	ctx context.Context,
 	orgID valuer.UUID,
 	req *inframonitoringtypes.PostablePods,
-	metadataMap map[string]map[string]string,
-) ([]map[string]string, error) {
-	orderByKey := req.OrderBy.Key.Name
+) ([]map[string]string, map[string]map[string]string, error) {
+
+	var (
+		orderByKey      string
+		metadataMap     map[string]map[string]string
+		allMetricGroups []rankedGroup
+	)
+
+	orderByKey = req.OrderBy.Key.Name
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		metadataMap, err = m.getPodsTableMetadata(gCtx, orgID, req)
+		return err
+	})
+
 	if orderByKey == inframonitoringtypes.PodNameAttrKey {
-		return inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.PodNameAttrKey), nil
+		if err := g.Wait(); err != nil {
+			return nil, nil, err
+		}
+		pageGroups := inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.PodNameAttrKey)
+		return pageGroups, metadataMap, nil
 	}
+
 	queryNamesForOrderBy := orderByToPodsQueryNames[orderByKey]
 	rankingQueryName := queryNamesForOrderBy[len(queryNamesForOrderBy)-1]
 
@@ -188,13 +213,20 @@ func (m *module) getTopPodGroups(
 		topReq.CompositeQuery.Queries = append(topReq.CompositeQuery.Queries, copied)
 	}
 
-	resp, err := m.querier.QueryRange(ctx, orgID, topReq)
-	if err != nil {
-		return nil, err
+	g.Go(func() error {
+		resp, err := m.querier.QueryRange(gCtx, orgID, topReq)
+		if err != nil {
+			return err
+		}
+		allMetricGroups = parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
 	}
 
-	allMetricGroups := parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
-	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), nil
+	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), metadataMap, nil
 }
 
 func (m *module) getPodsTableMetadata(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostablePods) (map[string]map[string]string, error) {

--- a/pkg/modules/inframonitoring/implinframonitoring/statefulsets.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/statefulsets.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/inframonitoringtypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/valuer"
+	"golang.org/x/sync/errgroup"
 )
 
 // buildStatefulSetRecords assembles the page records. Pod status counts come from
@@ -81,16 +82,36 @@ func buildStatefulSetRecords(
 	return records
 }
 
-func (m *module) getTopStatefulSetGroups(
+func (m *module) getTopStatefulSetGroupsAndMetadata(
 	ctx context.Context,
 	orgID valuer.UUID,
 	req *inframonitoringtypes.PostableStatefulSets,
-	metadataMap map[string]map[string]string,
-) ([]map[string]string, error) {
-	orderByKey := req.OrderBy.Key.Name
+) ([]map[string]string, map[string]map[string]string, error) {
+
+	var (
+		orderByKey      string
+		metadataMap     map[string]map[string]string
+		allMetricGroups []rankedGroup
+	)
+
+	orderByKey = req.OrderBy.Key.Name
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		metadataMap, err = m.getStatefulSetsTableMetadata(gCtx, orgID, req)
+		return err
+	})
+
 	if orderByKey == inframonitoringtypes.StatefulSetNameAttrKey {
-		return inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.StatefulSetNameAttrKey), nil
+		if err := g.Wait(); err != nil {
+			return nil, nil, err
+		}
+		pageGroups := inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.StatefulSetNameAttrKey)
+		return pageGroups, metadataMap, nil
 	}
+
 	queryNamesForOrderBy := orderByToStatefulSetsQueryNames[orderByKey]
 	rankingQueryName := queryNamesForOrderBy[len(queryNamesForOrderBy)-1]
 
@@ -124,13 +145,20 @@ func (m *module) getTopStatefulSetGroups(
 		topReq.CompositeQuery.Queries = append(topReq.CompositeQuery.Queries, copied)
 	}
 
-	resp, err := m.querier.QueryRange(ctx, orgID, topReq)
-	if err != nil {
-		return nil, err
+	g.Go(func() error {
+		resp, err := m.querier.QueryRange(gCtx, orgID, topReq)
+		if err != nil {
+			return err
+		}
+		allMetricGroups = parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
 	}
 
-	allMetricGroups := parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
-	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), nil
+	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), metadataMap, nil
 }
 
 func (m *module) getStatefulSetsTableMetadata(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableStatefulSets) (map[string]map[string]string, error) {

--- a/pkg/modules/inframonitoring/implinframonitoring/volumes.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/volumes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/types/inframonitoringtypes"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/valuer"
+	"golang.org/x/sync/errgroup"
 )
 
 // buildVolumeRecords assembles the page records. VolumeUsage is taken from the
@@ -68,16 +69,36 @@ func buildVolumeRecords(
 	return records
 }
 
-func (m *module) getTopVolumeGroups(
+func (m *module) getTopVolumeGroupsAndMetadata(
 	ctx context.Context,
 	orgID valuer.UUID,
 	req *inframonitoringtypes.PostableVolumes,
-	metadataMap map[string]map[string]string,
-) ([]map[string]string, error) {
-	orderByKey := req.OrderBy.Key.Name
+) ([]map[string]string, map[string]map[string]string, error) {
+
+	var (
+		orderByKey      string
+		metadataMap     map[string]map[string]string
+		allMetricGroups []rankedGroup
+	)
+
+	orderByKey = req.OrderBy.Key.Name
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		var err error
+		metadataMap, err = m.getVolumesTableMetadata(gCtx, orgID, req)
+		return err
+	})
+
 	if orderByKey == inframonitoringtypes.PersistentVolumeClaimNameAttrKey {
-		return inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.PersistentVolumeClaimNameAttrKey), nil
+		if err := g.Wait(); err != nil {
+			return nil, nil, err
+		}
+		pageGroups := inframonitoringtypes.PaginateMetadataByName(metadataMap, req.GroupBy, req.OrderBy.Direction, req.Offset, req.Limit, inframonitoringtypes.PersistentVolumeClaimNameAttrKey)
+		return pageGroups, metadataMap, nil
 	}
+
 	queryNamesForOrderBy := orderByToVolumesQueryNames[orderByKey]
 	rankingQueryName := queryNamesForOrderBy[len(queryNamesForOrderBy)-1]
 
@@ -111,13 +132,20 @@ func (m *module) getTopVolumeGroups(
 		topReq.CompositeQuery.Queries = append(topReq.CompositeQuery.Queries, copied)
 	}
 
-	resp, err := m.querier.QueryRange(ctx, orgID, topReq)
-	if err != nil {
-		return nil, err
+	g.Go(func() error {
+		resp, err := m.querier.QueryRange(gCtx, orgID, topReq)
+		if err != nil {
+			return err
+		}
+		allMetricGroups = parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
 	}
 
-	allMetricGroups := parseAndSortGroups(resp, rankingQueryName, req.GroupBy, req.OrderBy.Direction)
-	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), nil
+	return paginateWithBackfill(allMetricGroups, metadataMap, req.GroupBy, req.Offset, req.Limit), metadataMap, nil
 }
 
 func (m *module) getVolumesTableMetadata(ctx context.Context, orgID valuer.UUID, req *inframonitoringtypes.PostableVolumes) (map[string]map[string]string, error) {


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

In v2 infra-monitoring, two of the ClickHouse round trips- the group-metadata query and the order-by-column ranking query are fully independent of each other, and only the final pagination needs both.

- Both now run concurrently in an `errgroup`. 
- `getTopXGroups` is renamed to `getTopXGroupsAndMetadata`: it owns both fetches plus the orchestration and returns `(pageGroups, metadataMap)`, so each `ListX` drops to a single call.
- Applied uniformly across all 11 endpoints: hosts, pods, containers, nodes, namespaces, clusters, volumes, deployments, statefulsets, jobs, daemonsets.

No new queries are issued and no SQL changed — this is purely a reordering of existing work.

#### Issues closed by this PR

N/A

---

### ✅ Change Type

- [x] ♻️ Refactor

---

### 🧪 Testing Strategy

- Manual verification: exercise each tab on staging
- Edge cases covered: ordering by name still issues zero ranking queries (early return before the ranking build); `Total` is still derived from the metadata map even when the page is empty.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: all 11 infra-monitoring v2 list APIs. Response payloads are unchanged; only execution order differs.
- Rollback plan: revert the PR; the change is self-contained to `pkg/modules/inframonitoring/implinframonitoring` with no schema, API, or config changes.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance |
| Description | Infrastructure monitoring list views load faster. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

N/A