### PR TITLE
chore: remove doc.go files

### DIFF
--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -1,4 +1,0 @@
-// Package config provides the configuration management for the Signoz application.
-// It includes functionality to define, load, and validate the application's configuration
-// using various providers and formats.
-package config

--- a/pkg/errors/doc.go
+++ b/pkg/errors/doc.go
@@ -1,3 +1,0 @@
-// package error contains error related utilities. Use this package when
-// a well-defined error has to be shown.
-package errors

--- a/pkg/http/doc.go
+++ b/pkg/http/doc.go
@@ -1,3 +1,0 @@
-// package http contains all http related functions such
-// as servers, middlewares, routers and renders.
-package http

--- a/pkg/http/server/doc.go
+++ b/pkg/http/server/doc.go
@@ -1,2 +1,0 @@
-// package server contains an implementation of the http server.
-package server

--- a/pkg/instrumentation/doc.go
+++ b/pkg/instrumentation/doc.go
@@ -1,5 +1,0 @@
-// Package instrumentation provides utilities for initializing and managing
-// OpenTelemetry resources, logging, tracing, and metering within the application. It
-// leverages the OpenTelemetry SDK to facilitate the collection and
-// export of telemetry data, to an OTLP (OpenTelemetry Protocol) endpoint.
-package instrumentation

--- a/pkg/templating/markdownrenderer/blockkit/doc.go
+++ b/pkg/templating/markdownrenderer/blockkit/doc.go
@@ -1,9 +1,0 @@
-// Package blockkit provides a goldmark extension that renders markdown as
-// Slack Block Kit JSON (an array of blocks suitable for the Slack API's
-// `blocks` payload field).
-//
-// The current Slack notifier uses the sibling mrkdwn package instead, because
-// Block Kit's hard limits (one table per message, 50 blocks per message,
-// 12k-character total text) would silently truncate or reject notifications
-// with rich bodies. This package is kept in tree for future use.
-package blockkit

--- a/pkg/templating/markdownrenderer/doc.go
+++ b/pkg/templating/markdownrenderer/doc.go
@@ -1,3 +1,0 @@
-// Package markdownrenderer renders markdown to the formats that alert
-// notifications are delivered in: HTML, Slack Block Kit JSON, and Slack mrkdwn.
-package markdownrenderer

--- a/pkg/templating/markdownrenderer/mrkdwn/doc.go
+++ b/pkg/templating/markdownrenderer/mrkdwn/doc.go
@@ -1,4 +1,0 @@
-// Package mrkdwn provides a goldmark extension that renders markdown as
-// Slack's "mrkdwn" text format (the legacy text field used in attachments
-// and message payloads).
-package mrkdwn


### PR DESCRIPTION
### What

Deletes the eight doc.go files under pkg/. Each contained only the package clause and a package comment, no code. Subsystem context belongs in docs/contributing/, not in per-package doc.go files.

- pkg/config/doc.go
- pkg/errors/doc.go
- pkg/http/doc.go
- pkg/http/server/doc.go
- pkg/instrumentation/doc.go
- pkg/templating/markdownrenderer/doc.go
- pkg/templating/markdownrenderer/blockkit/doc.go
- pkg/templating/markdownrenderer/mrkdwn/doc.go