### PR TITLE
feat(tests): fixed network alias for zeus wiremock container

### DIFF
--- a/docs/contributing/tests/integration.md
+++ b/docs/contributing/tests/integration.md
@@ -258,7 +258,7 @@ Tests can be configured using pytest options:
 - `--clickhouse-version` — ClickHouse version, also used for ClickHouse Keeper (default: `25.12.5`)
 - `--schema-migrator-version` — SigNoz schema migrator version (default: `v0.144.6`)
 - `--with-web` — Build the frontend into the SigNoz image (required for e2e)
-- `--network-aliases` — Give the WireMock containers fixed network aliases (`zeus`, `gateway`) so the SigNoz image build args are deterministic; used by CI to share one image across jobs. Don't flip it between runs of a `--reuse` environment (cached container configs would go stale).
+- `--zeus-network-aliases` — Give the zeus WireMock container a fixed network alias (`zeus`) so the SigNoz image build args are deterministic; used by CI to share one image across jobs. Don't flip it between runs of a `--reuse` environment (cached container configs would go stale).
 
 Example:
 

--- a/docs/contributing/tests/integration.md
+++ b/docs/contributing/tests/integration.md
@@ -258,6 +258,7 @@ Tests can be configured using pytest options:
 - `--clickhouse-version` — ClickHouse version, also used for ClickHouse Keeper (default: `25.12.5`)
 - `--schema-migrator-version` — SigNoz schema migrator version (default: `v0.144.6`)
 - `--with-web` — Build the frontend into the SigNoz image (required for e2e)
+- `--network-aliases` — Give the WireMock containers fixed network aliases (`zeus`, `gateway`) so the SigNoz image build args are deterministic; used by CI to share one image across jobs. Don't flip it between runs of a `--reuse` environment (cached container configs would go stale).
 
 Example:
 

--- a/docs/contributing/tests/integration.md
+++ b/docs/contributing/tests/integration.md
@@ -258,7 +258,7 @@ Tests can be configured using pytest options:
 - `--clickhouse-version` — ClickHouse version, also used for ClickHouse Keeper (default: `25.12.5`)
 - `--schema-migrator-version` — SigNoz schema migrator version (default: `v0.144.6`)
 - `--with-web` — Build the frontend into the SigNoz image (required for e2e)
-- `--zeus-network-aliases` — Give the zeus WireMock container a fixed network alias (`zeus`) so the SigNoz image build args are deterministic; used by CI to share one image across jobs. Don't flip it between runs of a `--reuse` environment (cached container configs would go stale).
+- `--zeus-network-alias` — Give the zeus WireMock container a fixed network alias (e.g. `--zeus-network-alias zeus`) so the SigNoz image build args are deterministic; used by CI to share one image across jobs. Don't flip it between runs of a `--reuse` environment (cached container configs would go stale).
 
 Example:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,10 +82,10 @@ def pytest_addoption(parser: pytest.Parser):
         help="Build and run with web. Run pytest --basetemp=./tmp/ -vv --with-web src/bootstrap/setup::test_setup to setup your local dev environment with web.",
     )
     parser.addoption(
-        "--network-aliases",
+        "--zeus-network-aliases",
         action="store_true",
         default=False,
-        help="Give the WireMock containers fixed network aliases (zeus, gateway) so the signoz image build args are deterministic; used by CI to share one image across jobs. Do not flip this option between runs of a --reuse environment: cached container configs would go stale.",
+        help="Give the zeus WireMock container a fixed network alias (zeus) so the signoz image build args are deterministic; used by CI to share one image across jobs. Do not flip this option between runs of a --reuse environment: cached container configs would go stale.",
     )
     parser.addoption(
         "--sqlstore-provider",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,12 @@ def pytest_addoption(parser: pytest.Parser):
         help="Build and run with web. Run pytest --basetemp=./tmp/ -vv --with-web src/bootstrap/setup::test_setup to setup your local dev environment with web.",
     )
     parser.addoption(
+        "--network-aliases",
+        action="store_true",
+        default=False,
+        help="Give the WireMock containers fixed network aliases (zeus, gateway) so the signoz image build args are deterministic; used by CI to share one image across jobs. Do not flip this option between runs of a --reuse environment: cached container configs would go stale.",
+    )
+    parser.addoption(
         "--sqlstore-provider",
         action="store",
         default="postgres",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,10 +82,10 @@ def pytest_addoption(parser: pytest.Parser):
         help="Build and run with web. Run pytest --basetemp=./tmp/ -vv --with-web src/bootstrap/setup::test_setup to setup your local dev environment with web.",
     )
     parser.addoption(
-        "--zeus-network-aliases",
-        action="store_true",
-        default=False,
-        help="Give the zeus WireMock container a fixed network alias (zeus) so the signoz image build args are deterministic; used by CI to share one image across jobs. Do not flip this option between runs of a --reuse environment: cached container configs would go stale.",
+        "--zeus-network-alias",
+        action="store",
+        default="",
+        help="Give the zeus WireMock container a fixed network alias (e.g. --zeus-network-alias zeus) so the signoz image build args are deterministic; used by CI to share one image across jobs. Do not flip this option between runs of a --reuse environment: cached container configs would go stale.",
     )
     parser.addoption(
         "--sqlstore-provider",

--- a/tests/fixtures/http.py
+++ b/tests/fixtures/http.py
@@ -31,12 +31,13 @@ def zeus(
     def create() -> types.TestContainerDocker:
         container = WireMockContainer(image="wiremock/wiremock:2.35.1-1", secure=False)
         container.with_network(network)
-        if pytestconfig.getoption("--zeus-network-aliases"):
-            container.with_network_aliases("zeus")
+        network_alias = pytestconfig.getoption("--zeus-network-alias")
+        if network_alias:
+            container.with_network_aliases(network_alias)
         container.start()
 
-        if pytestconfig.getoption("--zeus-network-aliases"):
-            container_address = "zeus"
+        if network_alias:
+            container_address = network_alias
         else:
             container_address = container.get_wrapped_container().name
 

--- a/tests/fixtures/http.py
+++ b/tests/fixtures/http.py
@@ -31,7 +31,14 @@ def zeus(
     def create() -> types.TestContainerDocker:
         container = WireMockContainer(image="wiremock/wiremock:2.35.1-1", secure=False)
         container.with_network(network)
+        if pytestconfig.getoption("--network-aliases"):
+            container.with_network_aliases("zeus")
         container.start()
+
+        if pytestconfig.getoption("--network-aliases"):
+            container_address = "zeus"
+        else:
+            container_address = container.get_wrapped_container().name
 
         return types.TestContainerDocker(
             id=container.get_wrapped_container().id,
@@ -42,7 +49,7 @@ def zeus(
                     container.get_exposed_port(8080),
                 )
             },
-            container_configs={"8080": types.TestContainerUrlConfig("http", container.get_wrapped_container().name, 8080)},
+            container_configs={"8080": types.TestContainerUrlConfig("http", container_address, 8080)},
         )
 
     def delete(container: types.TestContainerDocker):
@@ -84,7 +91,14 @@ def gateway(
         container = WireMockContainer(image="wiremock/wiremock:2.35.1-1", secure=False)
         container.with_exposed_ports(8080)
         container.with_network(network)
+        if pytestconfig.getoption("--network-aliases"):
+            container.with_network_aliases("gateway")
         container.start()
+
+        if pytestconfig.getoption("--network-aliases"):
+            container_address = "gateway"
+        else:
+            container_address = container.get_wrapped_container().name
 
         return types.TestContainerDocker(
             id=container.get_wrapped_container().id,
@@ -95,7 +109,7 @@ def gateway(
                     container.get_exposed_port(8080),
                 )
             },
-            container_configs={"8080": types.TestContainerUrlConfig("http", container.get_wrapped_container().name, 8080)},
+            container_configs={"8080": types.TestContainerUrlConfig("http", container_address, 8080)},
         )
 
     def delete(container: types.TestContainerDocker):

--- a/tests/fixtures/http.py
+++ b/tests/fixtures/http.py
@@ -31,11 +31,11 @@ def zeus(
     def create() -> types.TestContainerDocker:
         container = WireMockContainer(image="wiremock/wiremock:2.35.1-1", secure=False)
         container.with_network(network)
-        if pytestconfig.getoption("--network-aliases"):
+        if pytestconfig.getoption("--zeus-network-aliases"):
             container.with_network_aliases("zeus")
         container.start()
 
-        if pytestconfig.getoption("--network-aliases"):
+        if pytestconfig.getoption("--zeus-network-aliases"):
             container_address = "zeus"
         else:
             container_address = container.get_wrapped_container().name
@@ -91,14 +91,7 @@ def gateway(
         container = WireMockContainer(image="wiremock/wiremock:2.35.1-1", secure=False)
         container.with_exposed_ports(8080)
         container.with_network(network)
-        if pytestconfig.getoption("--network-aliases"):
-            container.with_network_aliases("gateway")
         container.start()
-
-        if pytestconfig.getoption("--network-aliases"):
-            container_address = "gateway"
-        else:
-            container_address = container.get_wrapped_container().name
 
         return types.TestContainerDocker(
             id=container.get_wrapped_container().id,
@@ -109,7 +102,7 @@ def gateway(
                     container.get_exposed_port(8080),
                 )
             },
-            container_configs={"8080": types.TestContainerUrlConfig("http", container_address, 8080)},
+            container_configs={"8080": types.TestContainerUrlConfig("http", container.get_wrapped_container().name, 8080)},
         )
 
     def delete(container: types.TestContainerDocker):


### PR DESCRIPTION
## Summary

- Adds an opt-in `--zeus-network-alias <alias>` pytest option; default behavior is unchanged when unset.
- When set, the zeus WireMock container gets the given docker network alias and its `container_configs` address uses that alias instead of the random container name, making the `signoz:integration` build-arg `ZEUSURL` deterministic (e.g. `http://zeus:8080`).
- This is a prerequisite for CI to prebuild the integration image once and share it across jobs. The gateway needs no alias: `SIGNOZ_GATEWAY_URL` is runtime container env, not a build-arg.

Usage: `uv run pytest --basetemp=./tmp/ -vv --zeus-network-alias zeus integration/bootstrap/setup.py::test_setup`