### PR TITLE
ci: add cacheci workflow to maintain shared go and pnpm caches

### DIFF
--- a/.github/workflows/cacheci.yml
+++ b/.github/workflows/cacheci.yml
@@ -1,0 +1,86 @@
+name: cacheci
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: cacheci
+  cancel-in-progress: false
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: restore
+        id: restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/cacheci
+          key: tests-primary
+          restore-keys: |
+            tests-secondary
+      - name: inject
+        if: steps.restore.outputs.cache-matched-key != ''
+        run: |
+          cat > "$RUNNER_TEMP/inject.Dockerfile" <<'EOF'
+          FROM busybox:1.37
+          RUN --mount=type=cache,target=/root/.cache/go-build \
+              --mount=type=cache,target=/go/pkg/mod \
+              --mount=type=cache,target=/pnpm/store \
+              --mount=type=bind,target=/restored \
+              cp -a /restored/go-build/. /root/.cache/go-build/ && \
+              cp -a /restored/go-mod/. /go/pkg/mod/ && \
+              cp -a /restored/pnpm-store/. /pnpm/store/
+          EOF
+          docker build -f "$RUNNER_TEMP/inject.Dockerfile" "$RUNNER_TEMP/cacheci"
+      - name: build
+        run: |
+          docker build -f cmd/enterprise/Dockerfile.integration --build-arg TARGETARCH=amd64 --build-arg ZEUSURL=http://zeus:8080 .
+          docker build -f cmd/enterprise/Dockerfile.with-web.integration --build-arg TARGETARCH=amd64 --build-arg ZEUSURL=http://zeus:8080 .
+      - name: extract
+        run: |
+          rm -rf "$RUNNER_TEMP/cacheci"
+          mkdir -p "$RUNNER_TEMP/extract-context"
+          cat > "$RUNNER_TEMP/extract.Dockerfile" <<'EOF'
+          FROM busybox:1.37 AS mounts
+          RUN --mount=type=cache,target=/root/.cache/go-build \
+              --mount=type=cache,target=/go/pkg/mod \
+              --mount=type=cache,target=/pnpm/store \
+              mkdir -p /out/go-build /out/go-mod /out/pnpm-store && \
+              cp -a /root/.cache/go-build/. /out/go-build/ && \
+              cp -a /go/pkg/mod/. /out/go-mod/ && \
+              cp -a /pnpm/store/. /out/pnpm-store/
+          FROM scratch
+          COPY --from=mounts /out/ /
+          EOF
+          docker build -f "$RUNNER_TEMP/extract.Dockerfile" --output "type=local,dest=$RUNNER_TEMP/cacheci" "$RUNNER_TEMP/extract-context"
+      # Fixed cache keys are immutable, so each key must be deleted before it
+      # can be saved again. Rotating primary and secondary one after the other
+      # keeps at least one key restorable for concurrent test runs.
+      - name: delete-primary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh cache delete tests-primary --repo "$GITHUB_REPOSITORY" || true
+      - name: save-primary
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/cacheci
+          key: tests-primary
+      - name: delete-secondary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh cache delete tests-secondary --repo "$GITHUB_REPOSITORY" || true
+      - name: save-secondary
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/cacheci
+          key: tests-secondary


### PR DESCRIPTION
### What

- Adds `.github/workflows/cacheci.yml`, which maintains two GitHub Actions caches — `tests-primary` and `tests-secondary` — holding the go build cache, go module cache, and pnpm store used by the integration image builds (`cmd/enterprise/Dockerfile.integration` and `cmd/enterprise/Dockerfile.with-web.integration`).
- Restores an existing cache (primary, falling back to secondary), injects it into the BuildKit cache mounts, builds both integration images to warm the caches, then extracts the mount contents back out. Inject/extract are minimal one-`RUN` Dockerfiles that copy between a bind-mounted directory and the cache mounts.

### When it runs

- On every push to `main`, and via `workflow_dispatch` for a manual recreate.
- A `concurrency` group (no cancel-in-progress) serializes runs.

### Two-key rotation

- Fixed cache keys are immutable, so each key is deleted then re-saved; rotating primary and secondary sequentially guarantees concurrent test runs can always restore at least one of them.