### PR TITLE
ci(cacheci): extract cache mounts via docker cp instead of the local exporter

### DIFF
--- a/.github/workflows/cacheci.yml
+++ b/.github/workflows/cacheci.yml
@@ -58,13 +58,15 @@ jobs:
           mkdir -p "$RUNNER_TEMP/cacheci" "$RUNNER_TEMP/extract-context"
           cat > "$RUNNER_TEMP/extract.Dockerfile" <<'EOF'
           FROM busybox:1.37
+          # chmod: go's read-only modcache dirs break docker cp's unprivileged untar and later rm -rf on the host
           RUN --mount=type=cache,target=/root/.cache/go-build \
               --mount=type=cache,target=/go/pkg/mod \
               --mount=type=cache,target=/pnpm/store \
               mkdir -p /out/go-build /out/go-mod /out/pnpm-store && \
               cp -a /root/.cache/go-build/. /out/go-build/ && \
               cp -a /go/pkg/mod/. /out/go-mod/ && \
-              cp -a /pnpm/store/. /out/pnpm-store/
+              cp -a /pnpm/store/. /out/pnpm-store/ && \
+              chmod -R u+w /out
           EOF
           docker build -f "$RUNNER_TEMP/extract.Dockerfile" -t cacheci-extract "$RUNNER_TEMP/extract-context"
           id=$(docker create cacheci-extract)

--- a/.github/workflows/cacheci.yml
+++ b/.github/workflows/cacheci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  # temporary: remove before merge
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -46,12 +50,14 @@ jobs:
         run: |
           docker build -f cmd/enterprise/Dockerfile.integration --build-arg TARGETARCH=amd64 --build-arg ZEUSURL=http://zeus:8080 .
           docker build -f cmd/enterprise/Dockerfile.with-web.integration --build-arg TARGETARCH=amd64 --build-arg ZEUSURL=http://zeus:8080 .
+      # docker cp instead of --output type=local: the local exporter stalls
+      # streaming multi-GB, high-file-count outputs back to the client.
       - name: extract
         run: |
           rm -rf "$RUNNER_TEMP/cacheci"
-          mkdir -p "$RUNNER_TEMP/extract-context"
+          mkdir -p "$RUNNER_TEMP/cacheci" "$RUNNER_TEMP/extract-context"
           cat > "$RUNNER_TEMP/extract.Dockerfile" <<'EOF'
-          FROM busybox:1.37 AS mounts
+          FROM busybox:1.37
           RUN --mount=type=cache,target=/root/.cache/go-build \
               --mount=type=cache,target=/go/pkg/mod \
               --mount=type=cache,target=/pnpm/store \
@@ -59,27 +65,36 @@ jobs:
               cp -a /root/.cache/go-build/. /out/go-build/ && \
               cp -a /go/pkg/mod/. /out/go-mod/ && \
               cp -a /pnpm/store/. /out/pnpm-store/
-          FROM scratch
-          COPY --from=mounts /out/ /
           EOF
-          docker build -f "$RUNNER_TEMP/extract.Dockerfile" --output "type=local,dest=$RUNNER_TEMP/cacheci" "$RUNNER_TEMP/extract-context"
+          docker build -f "$RUNNER_TEMP/extract.Dockerfile" -t cacheci-extract "$RUNNER_TEMP/extract-context"
+          id=$(docker create cacheci-extract)
+          docker cp "$id":/out/. "$RUNNER_TEMP/cacheci/"
+          docker rm "$id"
       # Fixed cache keys are immutable, so each key must be deleted before it
       # can be saved again. Rotating primary and secondary one after the other
       # keeps at least one key restorable for concurrent test runs.
       - name: delete-primary
+        # temporary: remove before merge
+        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh cache delete tests-primary --repo "$GITHUB_REPOSITORY" || true
       - name: save-primary
+        # temporary: remove before merge
+        if: github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/cacheci
           key: tests-primary
       - name: delete-secondary
+        # temporary: remove before merge
+        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh cache delete tests-secondary --repo "$GITHUB_REPOSITORY" || true
       - name: save-secondary
+        # temporary: remove before merge
+        if: github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/cacheci

--- a/.github/workflows/cacheci.yml
+++ b/.github/workflows/cacheci.yml
@@ -41,32 +41,31 @@ jobs:
               --mount=type=cache,target=/go/pkg/mod \
               --mount=type=cache,target=/pnpm/store \
               --mount=type=bind,target=/restored \
-              cp -a /restored/go-build/. /root/.cache/go-build/ && \
-              cp -a /restored/go-mod/. /go/pkg/mod/ && \
-              cp -a /restored/pnpm-store/. /pnpm/store/
+              tar -xf /restored/go-build.tar -C /root/.cache/go-build && \
+              tar -xf /restored/go-mod.tar -C /go/pkg/mod && \
+              tar -xf /restored/pnpm-store.tar -C /pnpm/store
           EOF
           docker build -f "$RUNNER_TEMP/inject.Dockerfile" "$RUNNER_TEMP/cacheci"
       - name: build
         run: |
           docker build -f cmd/enterprise/Dockerfile.integration --build-arg TARGETARCH=amd64 --build-arg ZEUSURL=http://zeus:8080 .
           docker build -f cmd/enterprise/Dockerfile.with-web.integration --build-arg TARGETARCH=amd64 --build-arg ZEUSURL=http://zeus:8080 .
-      # docker cp instead of --output type=local: the local exporter stalls
-      # streaming multi-GB, high-file-count outputs back to the client.
+      # docker cp instead of --output type=local (the local exporter stalls on
+      # multi-GB outputs); tarballs instead of raw trees so the host never hits
+      # the permission and symlink semantics that broke docker cp.
       - name: extract
         run: |
           rm -rf "$RUNNER_TEMP/cacheci"
           mkdir -p "$RUNNER_TEMP/cacheci" "$RUNNER_TEMP/extract-context"
           cat > "$RUNNER_TEMP/extract.Dockerfile" <<'EOF'
           FROM busybox:1.37
-          # chmod: go's read-only modcache dirs break docker cp's unprivileged untar and later rm -rf on the host
           RUN --mount=type=cache,target=/root/.cache/go-build \
               --mount=type=cache,target=/go/pkg/mod \
               --mount=type=cache,target=/pnpm/store \
-              mkdir -p /out/go-build /out/go-mod /out/pnpm-store && \
-              cp -a /root/.cache/go-build/. /out/go-build/ && \
-              cp -a /go/pkg/mod/. /out/go-mod/ && \
-              cp -a /pnpm/store/. /out/pnpm-store/ && \
-              chmod -R u+w /out
+              mkdir -p /out && \
+              tar -cf /out/go-build.tar -C /root/.cache/go-build . && \
+              tar -cf /out/go-mod.tar -C /go/pkg/mod . && \
+              tar -cf /out/pnpm-store.tar -C /pnpm/store .
           EOF
           docker build -f "$RUNNER_TEMP/extract.Dockerfile" -t cacheci-extract "$RUNNER_TEMP/extract-context"
           id=$(docker create cacheci-extract)

--- a/.github/workflows/cacheci.yml
+++ b/.github/workflows/cacheci.yml
@@ -4,19 +4,17 @@ on:
   push:
     branches:
       - main
-  # temporary: remove before merge
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:
   contents: read
   actions: write
 
+# Cancelling mid-rotation is safe: the sequential delete-then-save order
+# leaves at most one key missing at any moment.
 concurrency:
   group: cacheci
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   tests:
@@ -75,27 +73,19 @@ jobs:
       # can be saved again. Rotating primary and secondary one after the other
       # keeps at least one key restorable for concurrent test runs.
       - name: delete-primary
-        # temporary: remove before merge
-        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh cache delete tests-primary --repo "$GITHUB_REPOSITORY" || true
       - name: save-primary
-        # temporary: remove before merge
-        if: github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/cacheci
           key: tests-primary
       - name: delete-secondary
-        # temporary: remove before merge
-        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh cache delete tests-secondary --repo "$GITHUB_REPOSITORY" || true
       - name: save-secondary
-        # temporary: remove before merge
-        if: github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/cacheci


### PR DESCRIPTION
### Symptom

- The first cacheci run on main stalled in the extract step: build stages completed, then `exporting to client directory` froze at ~39MB — BuildKit's local exporter (`--output type=local` on the docker driver) stalls streaming the multi-GB, high-file-count output back to the client.

### Fix

- Drop the scratch stage and the local exporter; build the extract image with a tag, then `docker create` + `docker cp "$id":/out/. …` + `docker rm`. docker cp streams a single tar internally, which is reliable at any file count.
- Move the cache contents as three opaque tarballs (`go-build.tar`, `go-mod.tar`, `pnpm-store.tar`) instead of raw trees, so the host never hits go's read-only modcache permissions or pnpm's root-escaping store symlinks; inject untars as root inside the container.
- Concurrency is now `cancel-in-progress: true`: a newer main run always supersedes, and cancellation mid-rotation is safe because the sequential delete-then-save order leaves at most one key missing at any moment.