### PR TITLE
feat(identn): add trusted-header auth with verified proxy provenance

### DIFF
--- a/.github/workflows/integrationci.yaml
+++ b/.github/workflows/integrationci.yaml
@@ -62,6 +62,7 @@ jobs:
           - spanmapper
           - querier_json_body
           - querier_skip_resource_fingerprint
+          - trustedheaderauthn
           - ttl
           - clickhousecluster
           - metricreduction

--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -407,6 +407,40 @@ identn:
   impersonation:
     # toggle impersonation identN, when enabled, all requests will impersonate the root user
     enabled: false
+  trusted_header:
+    # toggle trusted-header identN. When enabled, identity comes from a fronting
+    # identity-aware proxy. Cannot be enabled together with impersonation.
+    enabled: false
+    trust:
+      # how proxy provenance is established. Required when enabled.
+      # "jwt": verify a signed assertion against a JWKS endpoint. Recommended:
+      #   it is the only mode an attacker with network access cannot forge.
+      # "secret": require a secret header, compared in constant time. Weaker,
+      #   because anything that can read the pod spec can read the secret.
+      mode: ""
+      jwt:
+        assertion_header: Teleport-Jwt-Assertion
+        jwks_url: ""
+        issuer: ""
+        audience: ""
+        identity_claim: sub
+      secret:
+        header: ""
+        value: ""
+    # headers carrying the authenticated user's email. Ignored in jwt mode.
+    email_headers:
+      - X-Forwarded-Email
+    # optional headers setting a display name when provisioning
+    name_headers: []
+    # create a Viewer for an unknown email. Note that Viewer can run raw
+    # ClickHouse SQL, so this is not a small grant.
+    auto_provision: false
+    # optional peer CIDR allowlist. Defence in depth only: in Kubernetes every
+    # pod shares the pod CIDR, so this cannot distinguish the proxy from any
+    # other pod. Never rely on it as the only control.
+    trusted_proxies: []
+    # where the UI sends a user on logout, so the proxy session ends too
+    logout_redirect_url: ""
 
 ##################### Service Account #####################
 serviceaccount:

--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -410,6 +410,9 @@ identn:
   trusted_header:
     # toggle trusted-header identN. When enabled, identity comes from a fronting
     # identity-aware proxy. Cannot be enabled together with impersonation.
+    # The API port must not be reachable except through that proxy: the
+    # provider trusts the header on any request that passes the trust check
+    # below, direct access bypasses the proxy's authentication entirely.
     enabled: false
     trust:
       # how proxy provenance is established. Required when enabled.
@@ -419,12 +422,20 @@ identn:
       #   because anything that can read the pod spec can read the secret.
       mode: ""
       jwt:
+        # the proxy must be configured to overwrite this header, not merely
+        # add to it. Teleport in particular passes through any header not
+        # named in that application's rewrite.headers, so an unlisted
+        # assertion header lets a client set its own.
         assertion_header: Teleport-Jwt-Assertion
         jwks_url: ""
         issuer: ""
         audience: ""
         identity_claim: sub
       secret:
+        # a wrong secret here produces no log line on the SigNoz side: the
+        # check runs in the trust checker's Test, before identity resolution,
+        # so the request never reaches anything that logs. Diagnose a
+        # mismatch from the proxy's own logs, not this service's.
         header: ""
         value: ""
     # headers carrying the authenticated user's email. Ignored in jwt mode.

--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -413,6 +413,8 @@ identn:
     # The API port must not be reachable except through that proxy: the
     # provider trusts the header on any request that passes the trust check
     # below, direct access bypasses the proxy's authentication entirely.
+    # An organization must already exist. Identity is resolved within the
+    # existing organizations, so finish first-time setup before enabling this.
     enabled: false
     trust:
       # how proxy provenance is established. Required when enabled.
@@ -439,12 +441,20 @@ identn:
         header: ""
         value: ""
     # headers carrying the authenticated user's email. Ignored in jwt mode.
+    # The proxy must overwrite or strip every header named here on inbound
+    # requests. Teleport passes through any header not named in that
+    # application's rewrite.headers, and in secret mode a passed-through
+    # header lets anyone already authenticated at the proxy assert someone
+    # else's email. The provider refuses a header sent more than once, which
+    # catches a proxy that appends but not one that passes through.
     email_headers:
       - X-Forwarded-Email
     # optional headers setting a display name when provisioning
     name_headers: []
     # create a Viewer for an unknown email. Note that Viewer can run raw
-    # ClickHouse SQL, so this is not a small grant.
+    # ClickHouse SQL, so this is not a small grant. In secret mode nothing
+    # vouches for the email beyond the secret itself, so anyone holding the
+    # secret can mint Viewers without limit.
     auto_provision: false
     # optional peer CIDR allowlist. Defence in depth only: in Kubernetes every
     # pod shares the pod CIDR, so this cannot distinguish the proxy from any

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -4112,6 +4112,8 @@ components:
           $ref: '#/components/schemas/GlobaltypesImpersonationConfig'
         tokenizer:
           $ref: '#/components/schemas/GlobaltypesTokenizerConfig'
+        trustedHeader:
+          $ref: '#/components/schemas/GlobaltypesTrustedHeaderConfig'
       type: object
     GlobaltypesImpersonationConfig:
       properties:
@@ -4122,6 +4124,13 @@ components:
       properties:
         enabled:
           type: boolean
+      type: object
+    GlobaltypesTrustedHeaderConfig:
+      properties:
+        enabled:
+          type: boolean
+        logoutRedirectUrl:
+          type: string
       type: object
     InframonitoringtypesAssociatedComponent:
       properties:

--- a/frontend/src/api/__tests__/Logout.test.ts
+++ b/frontend/src/api/__tests__/Logout.test.ts
@@ -1,0 +1,113 @@
+import { LOCALSTORAGE } from 'constants/localStorage';
+import ROUTES from 'constants/routes';
+
+import { Logout } from '../utils';
+
+jest.mock('api/v2/sessions/delete', () => ({
+	__esModule: true,
+	default: jest.fn().mockResolvedValue({ httpStatusCode: 200, data: null }),
+}));
+
+jest.mock('api/browser/localstorage/remove', () => ({
+	__esModule: true,
+	default: jest.fn(),
+}));
+
+jest.mock('lib/history', () => ({
+	__esModule: true,
+	default: { push: jest.fn() },
+}));
+
+jest.mock('utils/proxyAuthMode', () => ({
+	getIsProxyAuthMode: jest.fn(),
+	getProxyLogoutUrl: jest.fn(),
+}));
+
+// oxlint-disable-next-line typescript/no-require-imports typescript/no-var-requires
+const localStorageRemove = require('api/browser/localstorage/remove');
+const deleteLocalStorageKey = localStorageRemove.default;
+// oxlint-disable-next-line typescript/no-require-imports typescript/no-var-requires
+const history = require('lib/history').default;
+// oxlint-disable-next-line typescript/no-require-imports typescript/no-var-requires
+const proxyAuthMode = require('utils/proxyAuthMode');
+const { getIsProxyAuthMode, getProxyLogoutUrl } = proxyAuthMode;
+
+describe('Logout', () => {
+	const dispatchEventSpy = jest.spyOn(window, 'dispatchEvent');
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		Object.defineProperty(window, 'location', {
+			value: { assign: jest.fn() },
+			writable: true,
+		});
+	});
+
+	it('redirects to the proxy sign-out URL when proxy auth is on and a URL is configured', async () => {
+		(getIsProxyAuthMode as jest.Mock).mockReturnValue(true);
+		(getProxyLogoutUrl as jest.Mock).mockReturnValue(
+			'https://proxy.example.com/logout',
+		);
+
+		await Logout();
+
+		expect(window.location.assign).toHaveBeenCalledWith(
+			'https://proxy.example.com/logout',
+		);
+		expect(history.push).not.toHaveBeenCalled();
+	});
+
+	it('falls back to /login when proxy auth is on but no URL is configured', async () => {
+		(getIsProxyAuthMode as jest.Mock).mockReturnValue(true);
+		(getProxyLogoutUrl as jest.Mock).mockReturnValue('');
+
+		await Logout();
+
+		expect(window.location.assign).not.toHaveBeenCalled();
+		expect(history.push).toHaveBeenCalledWith(ROUTES.LOGIN);
+	});
+
+	it('goes to /login when proxy auth is off even if a URL is somehow set', async () => {
+		(getIsProxyAuthMode as jest.Mock).mockReturnValue(false);
+		(getProxyLogoutUrl as jest.Mock).mockReturnValue(
+			'https://proxy.example.com/logout',
+		);
+
+		await Logout();
+
+		expect(window.location.assign).not.toHaveBeenCalled();
+		expect(history.push).toHaveBeenCalledWith(ROUTES.LOGIN);
+	});
+
+	it('still clears local storage and dispatches LOGOUT on the proxy redirect path', async () => {
+		(getIsProxyAuthMode as jest.Mock).mockReturnValue(true);
+		(getProxyLogoutUrl as jest.Mock).mockReturnValue(
+			'https://proxy.example.com/logout',
+		);
+
+		await Logout();
+
+		expect(deleteLocalStorageKey).toHaveBeenCalledWith(LOCALSTORAGE.AUTH_TOKEN);
+		expect(deleteLocalStorageKey).toHaveBeenCalledWith(LOCALSTORAGE.IS_LOGGED_IN);
+		expect(deleteLocalStorageKey).toHaveBeenCalledWith(
+			LOCALSTORAGE.IS_IDENTIFIED_USER,
+		);
+		expect(deleteLocalStorageKey).toHaveBeenCalledWith(
+			LOCALSTORAGE.REFRESH_AUTH_TOKEN,
+		);
+		expect(deleteLocalStorageKey).toHaveBeenCalledWith(
+			LOCALSTORAGE.LOGGED_IN_USER_EMAIL,
+		);
+		expect(deleteLocalStorageKey).toHaveBeenCalledWith(
+			LOCALSTORAGE.LOGGED_IN_USER_NAME,
+		);
+		expect(deleteLocalStorageKey).toHaveBeenCalledWith(LOCALSTORAGE.CHAT_SUPPORT);
+		expect(deleteLocalStorageKey).toHaveBeenCalledWith(LOCALSTORAGE.USER_ID);
+		expect(deleteLocalStorageKey).toHaveBeenCalledWith(
+			LOCALSTORAGE.QUICK_FILTERS_SETTINGS_ANNOUNCEMENT,
+		);
+		expect(dispatchEventSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ type: 'LOGOUT' }),
+		);
+	});
+});

--- a/frontend/src/api/__tests__/interceptorRejected.no-auth.test.ts
+++ b/frontend/src/api/__tests__/interceptorRejected.no-auth.test.ts
@@ -1,10 +1,15 @@
 import axios from 'axios';
 import { getIsNoAuthMode } from 'utils/noAuthMode';
+import { getIsProxyAuthMode } from 'utils/proxyAuthMode';
 
 import { interceptorRejected } from '../index';
 
 jest.mock('utils/noAuthMode', () => ({
 	getIsNoAuthMode: jest.fn(),
+}));
+
+jest.mock('utils/proxyAuthMode', () => ({
+	getIsProxyAuthMode: jest.fn(),
 }));
 
 jest.mock('api/v2/sessions/rotate/post', () => ({
@@ -26,46 +31,49 @@ const post = require('api/v2/sessions/rotate/post').default;
 // oxlint-disable-next-line typescript/no-require-imports typescript/no-var-requires
 const { Logout } = require('../utils');
 
-describe('interceptorRejected — no-auth mode', () => {
+const unauthorized = (): unknown => ({
+	isAxiosError: true,
+	response: {
+		status: 401,
+		config: { url: '/dashboards', method: 'get' },
+	},
+	config: { url: '/dashboards', headers: {} },
+});
+
+describe('interceptorRejected: sessionless auth modes', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		jest.spyOn(axios, 'isAxiosError').mockReturnValue(true);
+		(getIsNoAuthMode as jest.Mock).mockReturnValue(false);
+		(getIsProxyAuthMode as jest.Mock).mockReturnValue(false);
 	});
 
 	it('does NOT call rotate or Logout when no-auth mode is enabled on 401', async () => {
 		(getIsNoAuthMode as jest.Mock).mockReturnValue(true);
 
-		const error = {
-			isAxiosError: true,
-			response: {
-				status: 401,
-				config: { url: '/dashboards', method: 'get' },
-			},
-			config: { url: '/dashboards', headers: {} },
-		};
-
-		await interceptorRejected(error as any).catch(() => {});
+		await interceptorRejected(unauthorized() as any).catch(() => {});
 
 		expect(post).not.toHaveBeenCalled();
 		expect(Logout).not.toHaveBeenCalled();
 	});
 
-	it('DOES attempt rotate when no-auth mode is disabled on 401', async () => {
-		(getIsNoAuthMode as jest.Mock).mockReturnValue(false);
+	// There is no session to rotate under proxy auth, and Logout would send the
+	// user to the proxy's sign-out page and straight back in.
+	it('does NOT call rotate or Logout when proxy auth mode is enabled on 401', async () => {
+		(getIsProxyAuthMode as jest.Mock).mockReturnValue(true);
+
+		await interceptorRejected(unauthorized() as any).catch(() => {});
+
+		expect(post).not.toHaveBeenCalled();
+		expect(Logout).not.toHaveBeenCalled();
+	});
+
+	it('DOES attempt rotate when neither mode is enabled on 401', async () => {
 		(post as jest.Mock).mockResolvedValue({
 			data: { accessToken: 'a', refreshToken: 'b' },
 		});
 
-		const error = {
-			isAxiosError: true,
-			response: {
-				status: 401,
-				config: { url: '/dashboards', method: 'get' },
-			},
-			config: { url: '/dashboards', headers: {} },
-		};
-
-		await interceptorRejected(error as any).catch(() => {});
+		await interceptorRejected(unauthorized() as any).catch(() => {});
 
 		expect(post).toHaveBeenCalled();
 	});

--- a/frontend/src/api/__tests__/interceptorRejected.preflight.test.ts
+++ b/frontend/src/api/__tests__/interceptorRejected.preflight.test.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { getIsNoAuthMode } from 'utils/noAuthMode';
+import { markPreflightComplete } from 'utils/preflight';
 import { getIsProxyAuthMode } from 'utils/proxyAuthMode';
 
 import { interceptorRejected } from '../index';
@@ -10,15 +11,6 @@ jest.mock('utils/noAuthMode', () => ({
 
 jest.mock('utils/proxyAuthMode', () => ({
 	getIsProxyAuthMode: jest.fn(),
-}));
-
-// These cases are about which mode the interceptor reads, not about when it is
-// allowed to read it. The wait itself is covered in
-// interceptorRejected.preflight.test.ts, which needs the real module: the
-// promise behind it resolves once and never resets, so a test that must observe
-// it still pending cannot share a module registry with tests that resolve it.
-jest.mock('utils/preflight', () => ({
-	waitForPreflight: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('api/v2/sessions/rotate/post', () => ({
@@ -49,41 +41,42 @@ const unauthorized = (): unknown => ({
 	config: { url: '/dashboards', headers: {} },
 });
 
-describe('interceptorRejected: sessionless auth modes', () => {
+// utils/preflight is deliberately NOT mocked here: the point is the real
+// promise, which starts out pending and resolves exactly once. Because it never
+// resets, this file holds a single test.
+describe('interceptorRejected: preflight gate', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		jest.spyOn(axios, 'isAxiosError').mockReturnValue(true);
 		(getIsNoAuthMode as jest.Mock).mockReturnValue(false);
+		// What a full page load looks like before the global config lands: the
+		// singleton still reads its false default even though this deployment is
+		// header-authenticated.
 		(getIsProxyAuthMode as jest.Mock).mockReturnValue(false);
 	});
 
-	it('does NOT call rotate or Logout when no-auth mode is enabled on 401', async () => {
-		(getIsNoAuthMode as jest.Mock).mockReturnValue(true);
-
-		await interceptorRejected(unauthorized() as any).catch(() => {});
-
-		expect(post).not.toHaveBeenCalled();
-		expect(Logout).not.toHaveBeenCalled();
-	});
-
-	// There is no session to rotate under proxy auth, and Logout would send the
-	// user to the proxy's sign-out page and straight back in.
-	it('does NOT call rotate or Logout when proxy auth mode is enabled on 401', async () => {
-		(getIsProxyAuthMode as jest.Mock).mockReturnValue(true);
-
-		await interceptorRejected(unauthorized() as any).catch(() => {});
-
-		expect(post).not.toHaveBeenCalled();
-		expect(Logout).not.toHaveBeenCalled();
-	});
-
-	it('DOES attempt rotate when neither mode is enabled on 401', async () => {
+	// Deciding without waiting reads proxy auth mode as false and rotates. That
+	// rotate fails, the failure path logs out, and with logout_redirect_url set
+	// the user is sent to the proxy's sign-out page and straight back in, which
+	// loops wherever the proxy can re-authenticate silently.
+	it('does not rotate when a 401 arrives before preflight has finished', async () => {
 		(post as jest.Mock).mockResolvedValue({
 			data: { accessToken: 'a', refreshToken: 'b' },
 		});
 
-		await interceptorRejected(unauthorized() as any).catch(() => {});
+		const settled = interceptorRejected(unauthorized() as any).catch(() => {});
 
-		expect(post).toHaveBeenCalled();
+		// Nothing may have happened yet: the interceptor is still waiting.
+		expect(post).not.toHaveBeenCalled();
+
+		// Stand in for the preflight effect in providers/App/App.tsx, which sets
+		// the flags and then releases the gate.
+		(getIsProxyAuthMode as jest.Mock).mockReturnValue(true);
+		markPreflightComplete();
+
+		await settled;
+
+		expect(post).not.toHaveBeenCalled();
+		expect(Logout).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/api/generated/services/sigNoz.schemas.ts
+++ b/frontend/src/api/generated/services/sigNoz.schemas.ts
@@ -5493,10 +5493,22 @@ export interface GlobaltypesTokenizerConfigDTO {
 	enabled?: boolean;
 }
 
+export interface GlobaltypesTrustedHeaderConfigDTO {
+	/**
+	 * @type boolean
+	 */
+	enabled?: boolean;
+	/**
+	 * @type string
+	 */
+	logoutRedirectUrl?: string;
+}
+
 export interface GlobaltypesIdentNConfigDTO {
 	apikey?: GlobaltypesAPIKeyConfigDTO;
 	impersonation?: GlobaltypesImpersonationConfigDTO;
 	tokenizer?: GlobaltypesTokenizerConfigDTO;
+	trustedHeader?: GlobaltypesTrustedHeaderConfigDTO;
 }
 
 export interface GlobaltypesConfigDTO {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -14,6 +14,7 @@ import { LOCALSTORAGE } from 'constants/localStorage';
 import { getBasePath } from 'utils/basePath';
 import { eventEmitter } from 'utils/getEventEmitter';
 import { getIsNoAuthMode } from 'utils/noAuthMode';
+import { getIsProxyAuthMode } from 'utils/proxyAuthMode';
 
 import apiV1, { apiAlertManager, apiV2, apiV3, apiV4, apiV5 } from './apiV1';
 import { Logout } from './utils';
@@ -109,10 +110,14 @@ export const interceptorRejected = async (
 		if (axios.isAxiosError(value) && value.response) {
 			const { response } = value;
 
-			const isNoAuthMode = getIsNoAuthMode();
+			// Under proxy auth there is no session to rotate: identity is asserted by
+			// a header on every request. Rotating cannot help, and its failure path
+			// logs out, which under a configured logout_redirect_url sends the user
+			// to the proxy's sign-out page and back again. A 401 is final here.
+			const hasSession = !getIsNoAuthMode() && !getIsProxyAuthMode();
 
 			if (
-				!isNoAuthMode &&
+				hasSession &&
 				response.status === 401 &&
 				// if the session rotate call or the create session errors out with 401 or the delete sessions call returns 401 then we do not retry!
 				response.config.url !== '/sessions/rotate' &&
@@ -154,7 +159,7 @@ export const interceptorRejected = async (
 			}
 
 			if (
-				!isNoAuthMode &&
+				hasSession &&
 				response.status === 401 &&
 				response.config.url === '/sessions/rotate'
 			) {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -14,6 +14,7 @@ import { LOCALSTORAGE } from 'constants/localStorage';
 import { getBasePath } from 'utils/basePath';
 import { eventEmitter } from 'utils/getEventEmitter';
 import { getIsNoAuthMode } from 'utils/noAuthMode';
+import { waitForPreflight } from 'utils/preflight';
 import { getIsProxyAuthMode } from 'utils/proxyAuthMode';
 
 import apiV1, { apiAlertManager, apiV2, apiV3, apiV4, apiV5 } from './apiV1';
@@ -109,6 +110,14 @@ export const interceptorRejected = async (
 	try {
 		if (axios.isAxiosError(value) && value.response) {
 			const { response } = value;
+
+			// Only 401s wait, so nothing else changes timing. The flags below are
+			// module singletons the preflight effect populates once the global
+			// config lands, and the queries that can 401 fire before that; reading
+			// them too early reports a session that does not exist.
+			if (response.status === 401) {
+				await waitForPreflight();
+			}
 
 			// Under proxy auth there is no session to rotate: identity is asserted by
 			// a header on every request. Rotating cannot help, and its failure path

--- a/frontend/src/api/interceptors.test.ts
+++ b/frontend/src/api/interceptors.test.ts
@@ -21,6 +21,15 @@ jest.mock('AppRoutes/utils', () => ({
 	default: jest.fn(),
 }));
 
+// The 401 path waits for the preflight effect in providers/App/App.tsx to
+// record which auth mode this deployment uses. No App renders here, so the real
+// gate would stay shut until its timeout. These cases are about the retried
+// request's payload, not about the gate; interceptorRejected.preflight.test.ts
+// covers the gate itself.
+jest.mock('utils/preflight', () => ({
+	waitForPreflight: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock('axios', () => {
 	const actualAxios = jest.requireActual('axios');
 	const mockAxios = jest.fn().mockResolvedValue({ data: 'success' });

--- a/frontend/src/api/utils.ts
+++ b/frontend/src/api/utils.ts
@@ -2,6 +2,7 @@ import deleteLocalStorageKey from 'api/browser/localstorage/remove';
 import { LOCALSTORAGE } from 'constants/localStorage';
 import ROUTES from 'constants/routes';
 import history from 'lib/history';
+import { getIsProxyAuthMode, getProxyLogoutUrl } from 'utils/proxyAuthMode';
 
 import deleteSession from './v2/sessions/delete';
 
@@ -22,6 +23,17 @@ export const Logout = async (): Promise<void> => {
 	deleteLocalStorageKey(LOCALSTORAGE.USER_ID);
 	deleteLocalStorageKey(LOCALSTORAGE.QUICK_FILTERS_SETTINGS_ANNOUNCEMENT);
 	window.dispatchEvent(new CustomEvent('LOGOUT'));
+
+	// Clearing local state is not enough under proxy auth: the next request
+	// carries the same proxy assertion and re-authenticates immediately, so only
+	// the proxy can end the session. Hand off to its sign-out endpoint when one
+	// is configured, and otherwise behave exactly as before.
+	const proxyLogoutUrl = getProxyLogoutUrl();
+	if (getIsProxyAuthMode() && proxyLogoutUrl) {
+		window.location.assign(proxyLogoutUrl);
+		return;
+	}
+
 	history.push(ROUTES.LOGIN);
 };
 

--- a/frontend/src/providers/App/App.tsx
+++ b/frontend/src/providers/App/App.tsx
@@ -18,6 +18,7 @@ import { useGetMyUser } from 'api/generated/services/users';
 import listOrgPreferences from 'api/v1/org/preferences/list';
 import { clearAuthStorage } from 'utils/clearAuthStorage';
 import { getIsNoAuthMode, setNoAuthMode } from 'utils/noAuthMode';
+import { markPreflightComplete } from 'utils/preflight';
 import { setProxyAuthMode, setProxyLogoutUrl } from 'utils/proxyAuthMode';
 import listUserPreferences from 'api/v1/user/preferences/list';
 import getUserVersion from 'api/v1/version/get';
@@ -127,6 +128,10 @@ export function AppProvider({ children }: PropsWithChildren): JSX.Element {
 			setProxyAuthMode(false);
 			setProxyLogoutUrl('');
 		}
+
+		// Releases the response interceptor's 401 path, which cannot decide whether
+		// there is a session to rotate until the flags above are set.
+		markPreflightComplete();
 
 		setIsPreflightLoading(false);
 	}, [globalConfigData, isFetchingGlobalConfig]);

--- a/frontend/src/providers/App/App.tsx
+++ b/frontend/src/providers/App/App.tsx
@@ -18,6 +18,7 @@ import { useGetMyUser } from 'api/generated/services/users';
 import listOrgPreferences from 'api/v1/org/preferences/list';
 import { clearAuthStorage } from 'utils/clearAuthStorage';
 import { getIsNoAuthMode, setNoAuthMode } from 'utils/noAuthMode';
+import { setProxyAuthMode } from 'utils/proxyAuthMode';
 import listUserPreferences from 'api/v1/user/preferences/list';
 import getUserVersion from 'api/v1/version/get';
 import { LOCALSTORAGE } from 'constants/localStorage';
@@ -101,6 +102,8 @@ export function AppProvider({ children }: PropsWithChildren): JSX.Element {
 
 		const impersonationEnabled =
 			globalConfigData?.data?.identN?.impersonation?.enabled === true;
+		const trustedHeaderEnabled =
+			globalConfigData?.data?.identN?.trustedHeader?.enabled === true;
 
 		if (impersonationEnabled) {
 			clearAuthStorage();
@@ -108,8 +111,17 @@ export function AppProvider({ children }: PropsWithChildren): JSX.Element {
 			setLocalStorageApi(LOCALSTORAGE.IS_LOGGED_IN, 'true');
 			setNoAuthMode(true);
 			setIsLoggedIn(true);
+		} else if (trustedHeaderEnabled) {
+			// The proxy authenticates every request, so there is no login form to
+			// show. Tokens are left alone: a password session may still be active
+			// and must keep rotating.
+			setProxyAuthMode(true);
+			setNoAuthMode(false);
+			setLocalStorageApi(LOCALSTORAGE.IS_LOGGED_IN, 'true');
+			setIsLoggedIn(true);
 		} else {
 			setNoAuthMode(false);
+			setProxyAuthMode(false);
 		}
 
 		setIsPreflightLoading(false);

--- a/frontend/src/providers/App/App.tsx
+++ b/frontend/src/providers/App/App.tsx
@@ -18,7 +18,7 @@ import { useGetMyUser } from 'api/generated/services/users';
 import listOrgPreferences from 'api/v1/org/preferences/list';
 import { clearAuthStorage } from 'utils/clearAuthStorage';
 import { getIsNoAuthMode, setNoAuthMode } from 'utils/noAuthMode';
-import { setProxyAuthMode } from 'utils/proxyAuthMode';
+import { setProxyAuthMode, setProxyLogoutUrl } from 'utils/proxyAuthMode';
 import listUserPreferences from 'api/v1/user/preferences/list';
 import getUserVersion from 'api/v1/version/get';
 import { LOCALSTORAGE } from 'constants/localStorage';
@@ -116,12 +116,16 @@ export function AppProvider({ children }: PropsWithChildren): JSX.Element {
 			// show. Tokens are left alone: a password session may still be active
 			// and must keep rotating.
 			setProxyAuthMode(true);
+			setProxyLogoutUrl(
+				globalConfigData?.data?.identN?.trustedHeader?.logoutRedirectUrl ?? '',
+			);
 			setNoAuthMode(false);
 			setLocalStorageApi(LOCALSTORAGE.IS_LOGGED_IN, 'true');
 			setIsLoggedIn(true);
 		} else {
 			setNoAuthMode(false);
 			setProxyAuthMode(false);
+			setProxyLogoutUrl('');
 		}
 
 		setIsPreflightLoading(false);

--- a/frontend/src/providers/App/__tests__/App.test.tsx
+++ b/frontend/src/providers/App/__tests__/App.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import setLocalStorageApi from 'api/browser/localstorage/set';
 import { getIsNoAuthMode, setNoAuthMode } from 'utils/noAuthMode';
+import { getIsProxyAuthMode, setProxyAuthMode } from 'utils/proxyAuthMode';
 import { LOCALSTORAGE } from 'constants/localStorage';
 import { SINGLE_FLIGHT_WAIT_TIME_MS } from 'lib/authz/hooks/useAuthZ/constants';
 import { server } from 'mocks-server/server';
@@ -372,6 +373,7 @@ describe('AppProvider no-auth preflight', () => {
 
 	afterEach(() => {
 		setNoAuthMode(false);
+		setProxyAuthMode(false);
 	});
 
 	it('sets noAuthMode singleton when impersonation is enabled', async () => {
@@ -485,5 +487,34 @@ describe('AppProvider no-auth preflight', () => {
 			},
 			{ timeout: 3000 },
 		);
+	});
+
+	it('sets logged in without clearing tokens when trusted header mode is enabled', async () => {
+		server.use(
+			rest.get(GLOBAL_CONFIG_URL, (_, res, ctx) =>
+				res(
+					ctx.status(200),
+					ctx.json({
+						data: { identN: { trustedHeader: { enabled: true } } },
+					}),
+				),
+			),
+		);
+
+		const wrapper = createWrapper();
+		const { result } = renderHook(() => useAppContext(), { wrapper });
+
+		await waitFor(
+			() => {
+				expect(result.current.isPreflightLoading).toBe(false);
+			},
+			{ timeout: 3000 },
+		);
+
+		expect(getIsProxyAuthMode()).toBe(true);
+
+		// Password sessions coexist with proxy auth, so the global no-auth flag must
+		// stay off or token rotation and logout break for those users.
+		expect(getIsNoAuthMode()).toBe(false);
 	});
 });

--- a/frontend/src/utils/preflight.ts
+++ b/frontend/src/utils/preflight.ts
@@ -1,0 +1,36 @@
+// Whether this deployment has a session to rotate is only known once the global
+// config has landed and the preflight effect in providers/App/App.tsx has
+// recorded it. Protected queries fire earlier than that: they are gated on
+// isLoggedIn, read synchronously from localStorage, so a 401 can reach the
+// response interceptor while getIsNoAuthMode and getIsProxyAuthMode still
+// return their false defaults.
+//
+// Reading those defaults sends a header-authenticated deployment down the
+// rotate-then-logout path, and with logout_redirect_url set that bounces the
+// user through the proxy's sign-out page and straight back in. Awaiting this
+// before deciding closes the window for both header-driven modes while leaving
+// password sessions rotating as before, since the wait is one already-in-flight
+// config round trip.
+let markComplete!: () => void;
+
+const complete = new Promise<void>((resolve) => {
+	markComplete = resolve;
+});
+
+export const markPreflightComplete = (): void => {
+	markComplete();
+};
+
+// A deadlock guard rather than a policy. The preflight effect runs whenever the
+// global config query settles, success or failure, but if that query never
+// settles at all then every 401 would wait here forever instead of being
+// handled.
+export const PREFLIGHT_WAIT_TIMEOUT_MS = 5000;
+
+export const waitForPreflight = (): Promise<void> =>
+	Promise.race([
+		complete,
+		new Promise<void>((resolve) => {
+			setTimeout(resolve, PREFLIGHT_WAIT_TIMEOUT_MS);
+		}),
+	]);

--- a/frontend/src/utils/proxyAuthMode.ts
+++ b/frontend/src/utils/proxyAuthMode.ts
@@ -3,6 +3,16 @@
 // noAuthMode: impersonation forbids the tokenizer, so noAuthMode can disable
 // token rotation wholesale, whereas proxy auth coexists with password sessions
 // that still need rotation and logout to work.
+//
+// This is set by the preflight effect in providers/App/App.tsx, which waits on
+// the global config, while the protected queries are gated only on isLoggedIn,
+// read synchronously from localStorage. A 401 arriving before the effect runs
+// therefore still sees false and takes the rotate-then-logout path. The bounce
+// that path can cause needs _proxyLogoutUrl below, which the same effect sets,
+// so in that window Logout falls through to the login route instead, and the
+// login page skips its form once the config lands. noAuthMode has the same
+// window; closing it means sequencing those queries behind preflight, which is
+// a change to shared behaviour rather than to this feature.
 let _isProxyAuthMode = false;
 
 export const setProxyAuthMode = (value: boolean): void => {

--- a/frontend/src/utils/proxyAuthMode.ts
+++ b/frontend/src/utils/proxyAuthMode.ts
@@ -10,3 +10,15 @@ export const setProxyAuthMode = (value: boolean): void => {
 };
 
 export const getIsProxyAuthMode = (): boolean => _isProxyAuthMode;
+
+// The proxy's sign-out endpoint, when configured. Logout is a plain module
+// function outside React, so it cannot read react-query state directly; the
+// preflight effect populates this singleton the same way it populates
+// _isProxyAuthMode above.
+let _proxyLogoutUrl = '';
+
+export const setProxyLogoutUrl = (value: string): void => {
+	_proxyLogoutUrl = value;
+};
+
+export const getProxyLogoutUrl = (): string => _proxyLogoutUrl;

--- a/frontend/src/utils/proxyAuthMode.ts
+++ b/frontend/src/utils/proxyAuthMode.ts
@@ -6,13 +6,13 @@
 //
 // This is set by the preflight effect in providers/App/App.tsx, which waits on
 // the global config, while the protected queries are gated only on isLoggedIn,
-// read synchronously from localStorage. A 401 arriving before the effect runs
-// therefore still sees false and takes the rotate-then-logout path. The bounce
-// that path can cause needs _proxyLogoutUrl below, which the same effect sets,
-// so in that window Logout falls through to the login route instead, and the
-// login page skips its form once the config lands. noAuthMode has the same
-// window; closing it means sequencing those queries behind preflight, which is
-// a change to shared behaviour rather than to this feature.
+// read synchronously from localStorage. A 401 can therefore reach the response
+// interceptor before the effect has run, when this still reads its false
+// default. The interceptor closes that window by awaiting utils/preflight
+// before it reads either mode flag; see the comment there. Without that wait a
+// 401 during startup rotates, fails, logs out, and with _proxyLogoutUrl set
+// bounces through the proxy's sign-out page and back in, which is a loop
+// wherever the proxy can re-authenticate silently.
 let _isProxyAuthMode = false;
 
 export const setProxyAuthMode = (value: boolean): void => {

--- a/frontend/src/utils/proxyAuthMode.ts
+++ b/frontend/src/utils/proxyAuthMode.ts
@@ -1,0 +1,12 @@
+// Proxy auth mode means identity comes from a fronting identity-aware proxy, so
+// there is no login form to render. It is deliberately separate from
+// noAuthMode: impersonation forbids the tokenizer, so noAuthMode can disable
+// token rotation wholesale, whereas proxy auth coexists with password sessions
+// that still need rotation and logout to work.
+let _isProxyAuthMode = false;
+
+export const setProxyAuthMode = (value: boolean): void => {
+	_isProxyAuthMode = value;
+};
+
+export const getIsProxyAuthMode = (): boolean => _isProxyAuthMode;

--- a/pkg/global/signozglobal/provider.go
+++ b/pkg/global/signozglobal/provider.go
@@ -54,6 +54,10 @@ func (provider *provider) GetConfig(context.Context) *globaltypes.Config {
 			globaltypes.TokenizerConfig{Enabled: provider.identNConfig.Tokenizer.Enabled},
 			globaltypes.APIKeyConfig{Enabled: provider.identNConfig.APIKeyConfig.Enabled},
 			globaltypes.ImpersonationConfig{Enabled: provider.identNConfig.Impersonation.Enabled},
+			globaltypes.TrustedHeaderConfig{
+				Enabled:           provider.identNConfig.TrustedHeader.Enabled,
+				LogoutRedirectURL: provider.identNConfig.TrustedHeader.LogoutRedirectURL,
+			},
 		),
 	)
 }

--- a/pkg/global/signozglobal/provider_test.go
+++ b/pkg/global/signozglobal/provider_test.go
@@ -1,0 +1,53 @@
+package signozglobal
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/SigNoz/signoz/pkg/factory/factorytest"
+	"github.com/SigNoz/signoz/pkg/global"
+	"github.com/SigNoz/signoz/pkg/identn"
+)
+
+// providerForTest mirrors how newProvider constructs the provider in
+// provider.go. GetConfig dereferences both ExternalURL and IngestionURL
+// unconditionally (unlike MCPURL and AIAssistantURL, which are nil-checked),
+// so both must be non-nil or GetConfig panics.
+func providerForTest(t *testing.T, identNConfig identn.Config) global.Global {
+	t.Helper()
+
+	externalURL, err := url.Parse("https://signoz.example.com")
+	require.NoError(t, err)
+
+	provider, err := newProvider(context.Background(), factorytest.NewSettings(), global.Config{
+		ExternalURL:  externalURL,
+		IngestionURL: externalURL,
+	}, identNConfig)
+	require.NoError(t, err)
+
+	return provider
+}
+
+// The browser has no other way to learn that identity comes from a proxy, so the
+// public config must carry the flag. It must never carry the mode or the secret.
+func TestGetConfigExposesTrustedHeaderEnabled(t *testing.T) {
+	provider := providerForTest(t, identn.Config{
+		TrustedHeader: identn.TrustedHeaderConfig{
+			Enabled:           true,
+			LogoutRedirectURL: "https://proxy.example/logout",
+			Trust: identn.TrustConfig{
+				Mode:   identn.TrustModeSecret,
+				Secret: identn.SecretTrustConfig{Header: "X-Proxy-Auth", Value: "s3cret"},
+			},
+		},
+	})
+
+	config := provider.GetConfig(context.Background())
+
+	assert.True(t, config.IdentN.TrustedHeader.Enabled)
+	assert.Equal(t, "https://proxy.example/logout", config.IdentN.TrustedHeader.LogoutRedirectURL)
+}

--- a/pkg/http/middleware/identn.go
+++ b/pkg/http/middleware/identn.go
@@ -54,14 +54,6 @@ func (m *IdentN) Wrap(next http.Handler) http.Handler {
 			// appends it as %!(EXTRA string=...). The code is a static constant
 			// and is what an operator actually needs to tell a rejected
 			// assertion from a missing credential.
-			// Only the code is logged, never the message. Provider errors are
-			// built in store layers that interpolate the credential into the
-			// message: the api key store formats the raw key into
-			// "api key with key: %s doesn't exist.", and the tokenizer store
-			// passes the access token to a format string with no verb, so fmt
-			// appends it as %!(EXTRA string=...). The code is a static constant
-			// and is what an operator actually needs to tell a rejected
-			// assertion from a missing credential.
 			_, code, _, _, _, _ := errors.Unwrapb(err)
 			m.logger.WarnContext(r.Context(), "failed to resolve identity",
 				slog.String("identn_provider", idn.Name().StringValue()),

--- a/pkg/http/middleware/identn.go
+++ b/pkg/http/middleware/identn.go
@@ -46,6 +46,27 @@ func (m *IdentN) Wrap(next http.Handler) http.Handler {
 
 		identity, err := idn.GetIdentity(r)
 		if err != nil {
+			// Only the code is logged, never the message. Provider errors are
+			// built in store layers that interpolate the credential into the
+			// message: the api key store formats the raw key into
+			// "api key with key: %s doesn't exist.", and the tokenizer store
+			// passes the access token to a format string with no verb, so fmt
+			// appends it as %!(EXTRA string=...). The code is a static constant
+			// and is what an operator actually needs to tell a rejected
+			// assertion from a missing credential.
+			// Only the code is logged, never the message. Provider errors are
+			// built in store layers that interpolate the credential into the
+			// message: the api key store formats the raw key into
+			// "api key with key: %s doesn't exist.", and the tokenizer store
+			// passes the access token to a format string with no verb, so fmt
+			// appends it as %!(EXTRA string=...). The code is a static constant
+			// and is what an operator actually needs to tell a rejected
+			// assertion from a missing credential.
+			_, code, _, _, _, _ := errors.Unwrapb(err)
+			m.logger.WarnContext(r.Context(), "failed to resolve identity",
+				slog.String("identn_provider", idn.Name().StringValue()),
+				slog.String("identn_error_code", code.String()),
+			)
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/pkg/http/middleware/identn_test.go
+++ b/pkg/http/middleware/identn_test.go
@@ -1,0 +1,176 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/identn"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockIdentN is a test implementation of identn.IdentN.
+type mockIdentN struct {
+	provider authtypes.IdentNProvider
+	err      error
+}
+
+func (m *mockIdentN) Test(r *http.Request) bool {
+	return true
+}
+
+func (m *mockIdentN) GetIdentity(r *http.Request) (*authtypes.Identity, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "mock: GetIdentity not configured with an error")
+}
+
+func (m *mockIdentN) Name() authtypes.IdentNProvider {
+	return m.provider
+}
+
+// mockIdentNResolver returns a fixed IdentN.
+type mockIdentNResolver struct {
+	idn identn.IdentN
+}
+
+func (m *mockIdentNResolver) GetIdentN(r *http.Request) identn.IdentN {
+	return m.idn
+}
+
+// mockSharder is a no-op sharder.
+type mockSharder struct{}
+
+func (m *mockSharder) GetMyOwnedKeyRange(ctx context.Context) (uint32, uint32, error) {
+	return 0, 0, nil
+}
+
+func (m *mockSharder) IsMyOwnedKey(ctx context.Context, key uint32) error {
+	return nil
+}
+
+func TestIdentN_LogsFailedResolutionWithoutCredential(t *testing.T) {
+	t.Parallel()
+
+	// Create a test error shaped like the API key store error that leaks the credential
+	credential := "super-secret-api-key-12345"
+	testErr := errors.Newf(
+		errors.TypeUnauthenticated,
+		errors.MustNewCode("api_key_not_found"),
+		"api key with key: %s doesn't exist.",
+		credential,
+	)
+
+	mockIDN := &mockIdentN{
+		provider: authtypes.IdentNProviderAPIKey,
+		err:      testErr,
+	}
+
+	// Capture logs in JSON format
+	var logBuf bytes.Buffer
+	jsonHandler := slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	logger := slog.New(jsonHandler)
+
+	middleware := &IdentN{
+		resolver: &mockIdentNResolver{idn: mockIDN},
+		sharder:  &mockSharder{},
+		logger:   logger,
+	}
+
+	// Create a test request and handler
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+
+	nextCalled := false
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := middleware.Wrap(nextHandler)
+	wrapped.ServeHTTP(w, req)
+
+	// Verify the next handler was called (failed auth should not block)
+	assert.True(t, nextCalled, "next handler should be called on failed identity resolution")
+
+	// Parse the log output
+	logOutput := logBuf.String()
+	assert.NotEmpty(t, logOutput, "log should not be empty")
+
+	var logRecord map[string]interface{}
+	err := json.Unmarshal([]byte(logOutput), &logRecord)
+	require.NoError(t, err, "log output should be valid JSON")
+
+	// Verify the log contains the expected fields
+	assert.Equal(t, "failed to resolve identity", logRecord["msg"])
+	assert.Equal(t, "api_key", logRecord["identn_provider"], "should log provider name")
+	assert.Equal(t, "api_key_not_found", logRecord["identn_error_code"], "should log error code")
+
+	// Verify the log does NOT contain the credential
+	logStr := logBuf.String()
+	assert.NotContains(t, logStr, credential, "log must not contain the API key credential")
+	assert.NotContains(t, logStr, "api key with key:", "log must not contain the formatted error message")
+}
+
+func TestIdentN_TokenError_NoCredentialLeakage(t *testing.T) {
+	t.Parallel()
+
+	// Create a test error shaped like the tokenizer store error
+	// The tokenizer store passes a token to a format string with no verb,
+	// so fmt appends it as %!(EXTRA string=...)
+	credential := "opaque-access-token-xyz789"
+	testErr := errors.Newf(
+		errors.TypeUnauthenticated,
+		errors.MustNewCode("token_not_found"),
+		"token does not exist %s",
+		credential, // The message contains the token
+	)
+
+	mockIDN := &mockIdentN{
+		provider: authtypes.IdentNProviderTokenizer,
+		err:      testErr,
+	}
+
+	// Capture logs in JSON format
+	var logBuf bytes.Buffer
+	jsonHandler := slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	logger := slog.New(jsonHandler)
+
+	middleware := &IdentN{
+		resolver: &mockIdentNResolver{idn: mockIDN},
+		sharder:  &mockSharder{},
+		logger:   logger,
+	}
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrapped := middleware.Wrap(nextHandler)
+	wrapped.ServeHTTP(w, req)
+
+	// Verify the log does NOT contain the credential
+	logStr := logBuf.String()
+	assert.NotContains(t, logStr, credential, "log must not contain the token credential")
+	assert.NotContains(t, logStr, "%!(EXTRA", "log must not contain fmt's extra argument notation")
+
+	// Verify the log contains the expected fields
+	var logRecord map[string]interface{}
+	err := json.Unmarshal([]byte(logStr), &logRecord)
+	require.NoError(t, err)
+
+	assert.Equal(t, "failed to resolve identity", logRecord["msg"])
+	assert.Equal(t, "tokenizer", logRecord["identn_provider"])
+	assert.Equal(t, "token_not_found", logRecord["identn_error_code"])
+}

--- a/pkg/identn/config.go
+++ b/pkg/identn/config.go
@@ -14,6 +14,9 @@ type Config struct {
 
 	// Config for impersonation identN resolver
 	Impersonation ImpersonationConfig `mapstructure:"impersonation"`
+
+	// Config for trusted-header identN resolver
+	TrustedHeader TrustedHeaderConfig `mapstructure:"trusted_header"`
 }
 
 type ImpersonationConfig struct {
@@ -37,6 +40,28 @@ type APIKeyConfig struct {
 	Headers []string `mapstructure:"headers"`
 }
 
+type TrustedHeaderConfig struct {
+	// Toggles the identN resolver. Defaults to false. Only enable when SigNoz is
+	// deployed behind a reverse proxy that strips client-supplied headers and injects
+	// its own (e.g., Authentik forward-auth, oauth2-proxy). Otherwise any client can
+	// forge identity by setting the header.
+	Enabled bool `mapstructure:"enabled"`
+
+	// EmailHeader is the request header that carries the authenticated user's email.
+	// Defaults to "X-Forwarded-Email" (the de-facto convention for oauth2-proxy and
+	// similar). Authentik users typically set this to "X-Authentik-Email".
+	EmailHeader string `mapstructure:"email_header"`
+
+	// NameHeader is optional; used during auto-provisioning to populate the user's
+	// display name. Falls back to the email local-part when not set or empty.
+	NameHeader string `mapstructure:"name_header"`
+
+	// AutoProvision controls whether unknown emails get a user record auto-created
+	// with role Viewer in the request's organization. When false, requests with
+	// unknown emails return 401. Default false (operators opt in explicitly).
+	AutoProvision bool `mapstructure:"auto_provision"`
+}
+
 func NewConfigFactory() factory.ConfigFactory {
 	return factory.NewConfigFactory(factory.MustNewName("identn"), newConfig)
 }
@@ -54,6 +79,10 @@ func newConfig() factory.Config {
 		Impersonation: ImpersonationConfig{
 			Enabled: false,
 		},
+		TrustedHeader: TrustedHeaderConfig{
+			Enabled:     false,
+			EmailHeader: "X-Forwarded-Email",
+		},
 	}
 }
 
@@ -66,6 +95,10 @@ func (c Config) Validate() error {
 		if c.APIKeyConfig.Enabled {
 			return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::impersonation cannot be enabled if identn::apikey is enabled")
 		}
+	}
+
+	if c.TrustedHeader.Enabled && c.TrustedHeader.EmailHeader == "" {
+		return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::email_header is required when identn::trusted_header is enabled")
 	}
 
 	return nil

--- a/pkg/identn/config.go
+++ b/pkg/identn/config.go
@@ -184,8 +184,11 @@ func (c Config) Validate() error {
 				return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::email_headers is required in secret mode")
 			}
 		case TrustModeJWT:
-			if c.TrustedHeader.Trust.JWT.JWKSURL == "" || c.TrustedHeader.Trust.JWT.Issuer == "" || c.TrustedHeader.Trust.JWT.Audience == "" {
-				return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::trust::jwt requires jwks_url, issuer and audience")
+			// An empty assertion_header is not merely incomplete config: the
+			// trust check reads the header by name, and Header.Values("") never
+			// matches, so every request would be refused with nothing to say why.
+			if c.TrustedHeader.Trust.JWT.AssertionHeader == "" || c.TrustedHeader.Trust.JWT.JWKSURL == "" || c.TrustedHeader.Trust.JWT.Issuer == "" || c.TrustedHeader.Trust.JWT.Audience == "" {
+				return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::trust::jwt requires assertion_header, jwks_url, issuer and audience")
 			}
 
 			parsedJWKSURL, err := url.Parse(c.TrustedHeader.Trust.JWT.JWKSURL)

--- a/pkg/identn/config.go
+++ b/pkg/identn/config.go
@@ -1,8 +1,13 @@
 package identn
 
 import (
+	"net"
+	"net/url"
+	"strings"
+
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/valuer"
 )
 
 type Config struct {
@@ -40,6 +45,54 @@ type APIKeyConfig struct {
 	Headers []string `mapstructure:"headers"`
 }
 
+var (
+	TrustModeJWT    = TrustMode{valuer.NewString("jwt")}
+	TrustModeSecret = TrustMode{valuer.NewString("secret")}
+)
+
+// TrustMode selects how the provider establishes that a request genuinely came
+// from the trusted proxy. There is deliberately no mode that trusts network
+// placement alone.
+type TrustMode struct{ valuer.String }
+
+func (TrustMode) Enum() []any {
+	return []any{TrustModeJWT, TrustModeSecret}
+}
+
+type TrustConfig struct {
+	// Mode is required when the trusted-header resolver is enabled.
+	Mode TrustMode `mapstructure:"mode"`
+
+	JWT    JWTTrustConfig    `mapstructure:"jwt"`
+	Secret SecretTrustConfig `mapstructure:"secret"`
+}
+
+type JWTTrustConfig struct {
+	// AssertionHeader carries the signed assertion. Defaults to the header
+	// Teleport injects and always overwrites.
+	AssertionHeader string `mapstructure:"assertion_header"`
+
+	// JWKSURL is the endpoint publishing the signing keys.
+	JWKSURL string `mapstructure:"jwks_url"`
+
+	Issuer   string `mapstructure:"issuer"`
+	Audience string `mapstructure:"audience"`
+
+	// IdentityClaim names the claim carrying the user's email.
+	IdentityClaim string `mapstructure:"identity_claim"`
+}
+
+type SecretTrustConfig struct {
+	// Header carries a secret only the proxy knows.
+	Header string `mapstructure:"header"`
+
+	// Value is compared in constant time. It appears in the debug-level config
+	// dump at pkg/signoz/signoz.go:187, in common with the SMTP and Redis
+	// passwords, so treat it as readable by anyone who can read those logs.
+	// jwt mode needs no shared secret at all.
+	Value string `mapstructure:"value"`
+}
+
 type TrustedHeaderConfig struct {
 	// Toggles the identN resolver. Defaults to false. Only enable when SigNoz is
 	// deployed behind a reverse proxy that strips client-supplied headers and injects
@@ -47,9 +100,13 @@ type TrustedHeaderConfig struct {
 	// forge identity by setting the header.
 	Enabled bool `mapstructure:"enabled"`
 
-	// EmailHeaders is the request header that carries the authenticated user's email.
-	// Defaults to "X-Forwarded-Email" (the de-facto convention for oauth2-proxy and
-	// similar). Authentik users typically set this to "X-Authentik-Email".
+	// Trust selects and configures how proxy provenance is established.
+	Trust TrustConfig `mapstructure:"trust"`
+
+	// EmailHeaders carry the authenticated user's email. Ignored in jwt mode,
+	// where the email comes from a verified claim. Defaults to
+	// "X-Forwarded-Email" (the de-facto convention for oauth2-proxy and similar).
+	// Authentik users typically set this to "X-Authentik-Email".
 	EmailHeaders []string `mapstructure:"email_headers"`
 
 	// NameHeaders is optional; used during auto-provisioning to populate the user's
@@ -60,6 +117,15 @@ type TrustedHeaderConfig struct {
 	// with role Viewer in the request's organization. When false, requests with
 	// unknown emails return 401. Default false (operators opt in explicitly).
 	AutoProvision bool `mapstructure:"auto_provision"`
+
+	// TrustedProxies optionally restricts the peer address. Defence in depth
+	// only: in Kubernetes every pod shares the pod CIDR, so this cannot
+	// distinguish the proxy from any other pod. It is never the only control.
+	TrustedProxies []string `mapstructure:"trusted_proxies"`
+
+	// LogoutRedirectURL, when set, is where the UI sends a user on logout so the
+	// proxy session ends too.
+	LogoutRedirectURL string `mapstructure:"logout_redirect_url"`
 }
 
 func NewConfigFactory() factory.ConfigFactory {
@@ -82,6 +148,12 @@ func newConfig() factory.Config {
 		TrustedHeader: TrustedHeaderConfig{
 			Enabled:      false,
 			EmailHeaders: []string{"X-Forwarded-Email"},
+			Trust: TrustConfig{
+				JWT: JWTTrustConfig{
+					AssertionHeader: "Teleport-Jwt-Assertion",
+					IdentityClaim:   "sub",
+				},
+			},
 		},
 	}
 }
@@ -97,8 +169,68 @@ func (c Config) Validate() error {
 		}
 	}
 
-	if c.TrustedHeader.Enabled && len(c.TrustedHeader.EmailHeaders) == 0 {
-		return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::email_headers is required when identn::trusted_header is enabled")
+	if c.TrustedHeader.Enabled {
+		if c.Impersonation.Enabled {
+			return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header cannot be enabled if identn::impersonation is enabled")
+		}
+
+		switch c.TrustedHeader.Trust.Mode {
+		case TrustModeSecret:
+			if c.TrustedHeader.Trust.Secret.Header == "" || c.TrustedHeader.Trust.Secret.Value == "" {
+				return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::trust::secret requires both header and value")
+			}
+
+			if len(c.TrustedHeader.EmailHeaders) == 0 {
+				return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::email_headers is required in secret mode")
+			}
+		case TrustModeJWT:
+			if c.TrustedHeader.Trust.JWT.JWKSURL == "" || c.TrustedHeader.Trust.JWT.Issuer == "" || c.TrustedHeader.Trust.JWT.Audience == "" {
+				return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::trust::jwt requires jwks_url, issuer and audience")
+			}
+
+			parsedJWKSURL, err := url.Parse(c.TrustedHeader.Trust.JWT.JWKSURL)
+			if err != nil || !parsedJWKSURL.IsAbs() || parsedJWKSURL.Host == "" {
+				return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::trust::jwt::jwks_url is not a valid URL")
+			}
+
+			if c.TrustedHeader.Trust.JWT.IdentityClaim == "" {
+				return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::trust::jwt::identity_claim is required")
+			}
+		default:
+			return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::trust::mode must be one of jwt, secret")
+		}
+
+		headers := append(append([]string{}, c.TrustedHeader.EmailHeaders...), c.TrustedHeader.NameHeaders...)
+		switch c.TrustedHeader.Trust.Mode {
+		case TrustModeSecret:
+			headers = append(headers, c.TrustedHeader.Trust.Secret.Header)
+		case TrustModeJWT:
+			headers = append(headers, c.TrustedHeader.Trust.JWT.AssertionHeader)
+		}
+
+		for _, header := range headers {
+			if strings.Contains(header, "_") {
+				return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "header name %q must not contain an underscore: common reverse proxies (e.g. nginx) silently drop such headers, so SigNoz refuses to boot rather than trust a header that may never arrive; choose a name using hyphens instead", header)
+			}
+		}
+
+		for _, cidr := range c.TrustedHeader.TrustedProxies {
+			addr, network, err := net.ParseCIDR(cidr)
+			if err != nil {
+				return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::trusted_proxies entry %q is not a valid CIDR", cidr)
+			}
+
+			if !addr.Equal(network.IP) {
+				return errors.Newf(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::trusted_proxies entry %q sets host bits, which would silently widen the range to %s; write the network address instead", cidr, network.String())
+			}
+		}
+
+		if c.TrustedHeader.LogoutRedirectURL != "" {
+			parsed, err := url.Parse(c.TrustedHeader.LogoutRedirectURL)
+			if err != nil || !parsed.IsAbs() {
+				return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::logout_redirect_url must be an absolute URL")
+			}
+		}
 	}
 
 	return nil

--- a/pkg/identn/config.go
+++ b/pkg/identn/config.go
@@ -47,14 +47,14 @@ type TrustedHeaderConfig struct {
 	// forge identity by setting the header.
 	Enabled bool `mapstructure:"enabled"`
 
-	// EmailHeader is the request header that carries the authenticated user's email.
+	// EmailHeaders is the request header that carries the authenticated user's email.
 	// Defaults to "X-Forwarded-Email" (the de-facto convention for oauth2-proxy and
 	// similar). Authentik users typically set this to "X-Authentik-Email".
-	EmailHeader string `mapstructure:"email_header"`
+	EmailHeaders []string `mapstructure:"email_headers"`
 
-	// NameHeader is optional; used during auto-provisioning to populate the user's
+	// NameHeaders is optional; used during auto-provisioning to populate the user's
 	// display name. Falls back to the email local-part when not set or empty.
-	NameHeader string `mapstructure:"name_header"`
+	NameHeaders []string `mapstructure:"name_headers"`
 
 	// AutoProvision controls whether unknown emails get a user record auto-created
 	// with role Viewer in the request's organization. When false, requests with
@@ -80,8 +80,8 @@ func newConfig() factory.Config {
 			Enabled: false,
 		},
 		TrustedHeader: TrustedHeaderConfig{
-			Enabled:     false,
-			EmailHeader: "X-Forwarded-Email",
+			Enabled:      false,
+			EmailHeaders: []string{"X-Forwarded-Email"},
 		},
 	}
 }
@@ -97,8 +97,8 @@ func (c Config) Validate() error {
 		}
 	}
 
-	if c.TrustedHeader.Enabled && c.TrustedHeader.EmailHeader == "" {
-		return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::email_header is required when identn::trusted_header is enabled")
+	if c.TrustedHeader.Enabled && len(c.TrustedHeader.EmailHeaders) == 0 {
+		return errors.New(errors.TypeInvalidInput, errors.CodeInvalidInput, "identn::trusted_header::email_headers is required when identn::trusted_header is enabled")
 	}
 
 	return nil

--- a/pkg/identn/config_test.go
+++ b/pkg/identn/config_test.go
@@ -106,6 +106,21 @@ func TestValidateRejectsJWTAssertionHeaderWithUnderscore(t *testing.T) {
 	require.Error(t, c.Validate())
 }
 
+// An empty assertion header used to pass validation and then refuse every
+// request at the trust check, since Header.Values("") matches nothing, with no
+// error anywhere that named the cause.
+func TestValidateRejectsEmptyJWTAssertionHeader(t *testing.T) {
+	c := newTestConfig()
+	c.TrustedHeader.Enabled = true
+	c.TrustedHeader.Trust.Mode = TrustModeJWT
+	c.TrustedHeader.Trust.JWT.JWKSURL = "https://idp.internal/keys"
+	c.TrustedHeader.Trust.JWT.Issuer = "issuer"
+	c.TrustedHeader.Trust.JWT.Audience = "audience"
+	c.TrustedHeader.Trust.JWT.AssertionHeader = ""
+
+	require.Error(t, c.Validate())
+}
+
 // url.Parse accepts almost anything, including a bare host-and-path string
 // with no scheme, so the check must additionally require an absolute URL
 // with a host rather than trusting url.Parse to fail on its own.

--- a/pkg/identn/config_test.go
+++ b/pkg/identn/config_test.go
@@ -1,0 +1,125 @@
+package identn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateRequiresTrustModeWhenEnabled(t *testing.T) {
+	c := newTestConfig()
+	c.TrustedHeader.Enabled = true
+
+	require.Error(t, c.Validate())
+}
+
+func TestValidateRejectsSecretModeWithoutSecret(t *testing.T) {
+	c := newTestConfig()
+	c.TrustedHeader.Enabled = true
+	c.TrustedHeader.Trust.Mode = TrustModeSecret
+
+	require.Error(t, c.Validate())
+
+	c.TrustedHeader.Trust.Secret.Header = "X-Proxy-Auth"
+	require.Error(t, c.Validate())
+
+	c.TrustedHeader.Trust.Secret.Value = "s3cret"
+	require.NoError(t, c.Validate())
+}
+
+func TestValidateRejectsImpersonationAlongsideTrustedHeader(t *testing.T) {
+	c := newTestConfig()
+	c.Impersonation.Enabled = true
+	c.Tokenizer.Enabled = false
+	c.APIKeyConfig.Enabled = false
+	c.TrustedHeader.Enabled = true
+	c.TrustedHeader.Trust.Mode = TrustModeSecret
+	c.TrustedHeader.Trust.Secret.Header = "X-Proxy-Auth"
+	c.TrustedHeader.Trust.Secret.Value = "s3cret"
+
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "impersonation")
+}
+
+func TestValidateRejectsUnderscoreHeaderNames(t *testing.T) {
+	c := newTestConfig()
+	c.TrustedHeader.Enabled = true
+	c.TrustedHeader.Trust.Mode = TrustModeSecret
+	c.TrustedHeader.Trust.Secret.Header = "X-Proxy-Auth"
+	c.TrustedHeader.Trust.Secret.Value = "s3cret"
+	c.TrustedHeader.EmailHeaders = []string{"X_Forwarded_Email"}
+
+	require.Error(t, c.Validate())
+}
+
+func TestValidateRejectsBadTrustedProxyCIDR(t *testing.T) {
+	c := newTestConfig()
+	c.TrustedHeader.Enabled = true
+	c.TrustedHeader.Trust.Mode = TrustModeSecret
+	c.TrustedHeader.Trust.Secret.Header = "X-Proxy-Auth"
+	c.TrustedHeader.Trust.Secret.Value = "s3cret"
+	c.TrustedHeader.TrustedProxies = []string{"not-a-cidr"}
+
+	require.Error(t, c.Validate())
+}
+
+// net.ParseCIDR("10.0.0.5/24") silently discards the host bits and returns
+// the network 10.0.0.0/24, so an operator intending to pin one address would
+// otherwise get a 256-address allowlist without any error.
+func TestValidateRejectsTrustedProxyCIDRWithHostBits(t *testing.T) {
+	c := newTestConfig()
+	c.TrustedHeader.Enabled = true
+	c.TrustedHeader.Trust.Mode = TrustModeSecret
+	c.TrustedHeader.Trust.Secret.Header = "X-Proxy-Auth"
+	c.TrustedHeader.Trust.Secret.Value = "s3cret"
+	c.TrustedHeader.TrustedProxies = []string{"10.0.0.5/24"}
+
+	require.Error(t, c.Validate())
+}
+
+// A /32 sets no host bits, so pinning a single proxy address this way must
+// keep working.
+func TestValidateAcceptsSingleAddressTrustedProxyCIDR(t *testing.T) {
+	c := newTestConfig()
+	c.TrustedHeader.Enabled = true
+	c.TrustedHeader.Trust.Mode = TrustModeSecret
+	c.TrustedHeader.Trust.Secret.Header = "X-Proxy-Auth"
+	c.TrustedHeader.Trust.Secret.Value = "s3cret"
+	c.TrustedHeader.TrustedProxies = []string{"10.0.0.5/32"}
+
+	require.NoError(t, c.Validate())
+}
+
+// The assertion header is the jwt-mode equivalent of the secret header: it
+// must be checked for underscores too, not just the email and name headers.
+func TestValidateRejectsJWTAssertionHeaderWithUnderscore(t *testing.T) {
+	c := newTestConfig()
+	c.TrustedHeader.Enabled = true
+	c.TrustedHeader.Trust.Mode = TrustModeJWT
+	c.TrustedHeader.Trust.JWT.JWKSURL = "https://idp.internal/keys"
+	c.TrustedHeader.Trust.JWT.Issuer = "issuer"
+	c.TrustedHeader.Trust.JWT.Audience = "audience"
+	c.TrustedHeader.Trust.JWT.AssertionHeader = "Teleport_Jwt_Assertion"
+
+	require.Error(t, c.Validate())
+}
+
+// url.Parse accepts almost anything, including a bare host-and-path string
+// with no scheme, so the check must additionally require an absolute URL
+// with a host rather than trusting url.Parse to fail on its own.
+func TestValidateRejectsRelativeJWKSURL(t *testing.T) {
+	c := newTestConfig()
+	c.TrustedHeader.Enabled = true
+	c.TrustedHeader.Trust.Mode = TrustModeJWT
+	c.TrustedHeader.Trust.JWT.JWKSURL = "jwks.internal/keys"
+	c.TrustedHeader.Trust.JWT.Issuer = "issuer"
+	c.TrustedHeader.Trust.JWT.Audience = "audience"
+
+	require.Error(t, c.Validate())
+}
+
+func newTestConfig() Config {
+	return *newConfig().(*Config)
+}

--- a/pkg/identn/resolver.go
+++ b/pkg/identn/resolver.go
@@ -59,6 +59,20 @@ func NewIdentNResolver(ctx context.Context, providerSettings factory.ProviderSet
 		identNs = append(identNs, identN)
 	}
 
+	if identNConfig.TrustedHeader.Enabled {
+		identNFactory, err := identNFactories.Get(authtypes.IdentNProviderTrustedHeader.StringValue())
+		if err != nil {
+			return nil, err
+		}
+
+		identN, err := identNFactory.New(ctx, providerSettings, identNConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		identNs = append(identNs, identN)
+	}
+
 	return &identNResolver{
 		identNs:  identNs,
 		settings: factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/identn"),

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -102,18 +102,25 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 		return nil, err
 	}
 
-	// Drop deleted users; only active or pending-invite users are eligible.
-	users = slices.DeleteFunc(users, func(u *types.User) bool { return u.ErrIfDeleted() != nil })
+	// Drop ineligible users — deleted ones (soft-deleted accounts) and root users.
+	// Root users are filtered (not hard-failed on first encounter) because
+	// ListUsersByEmailAndOrgIDs has no guaranteed ordering: in a multi-org
+	// installation where the same email exists in multiple orgs, hard-failing
+	// on `users[0]` being root would non-deterministically block a valid
+	// non-root user that happens to come later in the slice.
+	//
+	// Root users are deliberately not authenticatable via trusted headers
+	// (matches the SAML/OIDC posture) — treating them as "not a match" here
+	// keeps the resolver consistent.
+	users = slices.DeleteFunc(users, func(u *types.User) bool {
+		return u.ErrIfDeleted() != nil || u.ErrIfRoot() != nil
+	})
 
 	if len(users) > 0 {
-		// Pick the first matching user. Multi-org installations should pin the
-		// user to a specific org via the proxy or a separate header in a
+		// Pick the first remaining match. Multi-org installations should pin
+		// the user to a specific org via the proxy or a separate header in a
 		// future enhancement.
 		matched := users[0]
-
-		if err := matched.ErrIfRoot(); err != nil {
-			return nil, errors.WithAdditionalf(err, "root user cannot authenticate via trusted headers")
-		}
 
 		return authtypes.NewPrincipalUserIdentity(
 			matched.ID,

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -1,0 +1,179 @@
+package trustedheaderidentn
+
+import (
+	"context"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/identn"
+	"github.com/SigNoz/signoz/pkg/modules/organization"
+	"github.com/SigNoz/signoz/pkg/modules/user"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+var (
+	ErrCodeTrustedHeaderEmailMissing = errors.MustNewCode("trusted_header_email_missing")
+	ErrCodeTrustedHeaderUserNotFound = errors.MustNewCode("trusted_header_user_not_found")
+	ErrCodeTrustedHeaderNoOrg        = errors.MustNewCode("trusted_header_no_org")
+)
+
+type provider struct {
+	config     identn.Config
+	settings   factory.ScopedProviderSettings
+	orgGetter  organization.Getter
+	userGetter user.Getter
+	userSetter user.Setter
+}
+
+func NewFactory(orgGetter organization.Getter, userGetter user.Getter, userSetter user.Setter) factory.ProviderFactory[identn.IdentN, identn.Config] {
+	return factory.NewProviderFactory(
+		factory.MustNewName(authtypes.IdentNProviderTrustedHeader.StringValue()),
+		func(ctx context.Context, providerSettings factory.ProviderSettings, config identn.Config) (identn.IdentN, error) {
+			return New(ctx, providerSettings, config, orgGetter, userGetter, userSetter)
+		},
+	)
+}
+
+func New(ctx context.Context, providerSettings factory.ProviderSettings, config identn.Config, orgGetter organization.Getter, userGetter user.Getter, userSetter user.Setter) (identn.IdentN, error) {
+	settings := factory.NewScopedProviderSettings(providerSettings, "github.com/SigNoz/signoz/pkg/identn/trustedheaderidentn")
+
+	settings.Logger().WarnContext(ctx,
+		"trusted-header identity provider is enabled; SigNoz must be deployed behind a reverse proxy that strips client-supplied identity headers, otherwise any client can forge identity",
+	)
+
+	return &provider{
+		config:     config,
+		settings:   settings,
+		orgGetter:  orgGetter,
+		userGetter: userGetter,
+		userSetter: userSetter,
+	}, nil
+}
+
+func (provider *provider) Name() authtypes.IdentNProvider {
+	return authtypes.IdentNProviderTrustedHeader
+}
+
+// Test returns true when the configured email header is present on the request.
+// Test is intentionally cheap (header presence) — full email validation and the
+// user lookup happen in GetIdentity.
+func (provider *provider) Test(req *http.Request) bool {
+	return provider.extractEmail(req) != ""
+}
+
+// GetIdentity resolves the request to an authenticated identity using only
+// trusted headers injected by the upstream reverse proxy. The request is
+// expected to have already been authenticated by the proxy; SigNoz simply
+// trusts the headers.
+func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, error) {
+	ctx := req.Context()
+
+	rawEmail := provider.extractEmail(req)
+	if rawEmail == "" {
+		return nil, errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderEmailMissing, "trusted-header IdentN expected an email header but none was present")
+	}
+
+	email, err := valuer.NewEmail(rawEmail)
+	if err != nil {
+		return nil, err
+	}
+
+	orgs, err := provider.orgGetter.ListByOwnedKeyRange(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(orgs) == 0 {
+		return nil, errors.New(errors.TypeNotFound, ErrCodeTrustedHeaderNoOrg, "trusted-header IdentN cannot resolve identity because no organization exists")
+	}
+
+	orgIDs := make([]valuer.UUID, 0, len(orgs))
+	for _, org := range orgs {
+		orgIDs = append(orgIDs, org.ID)
+	}
+
+	users, err := provider.userGetter.ListUsersByEmailAndOrgIDs(ctx, email, orgIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Drop deleted users; only active or pending-invite users are eligible.
+	users = slices.DeleteFunc(users, func(u *types.User) bool { return u.ErrIfDeleted() != nil })
+
+	if len(users) > 0 {
+		// Pick the first matching user. Multi-org installations should pin the
+		// user to a specific org via the proxy or a separate header in a
+		// future enhancement.
+		matched := users[0]
+
+		if err := matched.ErrIfRoot(); err != nil {
+			return nil, errors.WithAdditionalf(err, "root user cannot authenticate via trusted headers")
+		}
+
+		return authtypes.NewPrincipalUserIdentity(
+			matched.ID,
+			matched.OrgID,
+			matched.Email,
+			authtypes.IdentNProviderTrustedHeader,
+		), nil
+	}
+
+	if !provider.config.TrustedHeader.AutoProvision {
+		return nil, errors.Newf(errors.TypeUnauthenticated, ErrCodeTrustedHeaderUserNotFound, "no user found for email %q and auto-provisioning is disabled", email.StringValue())
+	}
+
+	// Auto-provision: create the user with Viewer role in the (only) org.
+	// We refuse to guess when multiple orgs exist — operators must disable
+	// AutoProvision or pin a single org.
+	if len(orgs) > 1 {
+		return nil, errors.Newf(errors.TypeInvalidInput, ErrCodeTrustedHeaderNoOrg, "trusted-header auto-provisioning is not supported with multiple organizations (found %d)", len(orgs))
+	}
+
+	orgID := orgs[0].ID
+	displayName := provider.extractDisplayName(req, email)
+
+	newUser, err := types.NewUser(displayName, email, orgID, types.UserStatusActive)
+	if err != nil {
+		return nil, err
+	}
+
+	createdUser, err := provider.userSetter.GetOrCreateUser(ctx, newUser, user.WithRoleNames([]string{authtypes.SigNozViewerRoleName}))
+	if err != nil {
+		return nil, err
+	}
+
+	return authtypes.NewPrincipalUserIdentity(
+		createdUser.ID,
+		createdUser.OrgID,
+		createdUser.Email,
+		authtypes.IdentNProviderTrustedHeader,
+	), nil
+}
+
+// extractEmail reads the configured email header and trims whitespace.
+func (provider *provider) extractEmail(req *http.Request) string {
+	return strings.TrimSpace(req.Header.Get(provider.config.TrustedHeader.EmailHeader))
+}
+
+// extractDisplayName falls back through:
+//
+//  1. The configured NameHeader (when set and non-empty)
+//  2. The local-part of the email address
+func (provider *provider) extractDisplayName(req *http.Request, email valuer.Email) string {
+	if provider.config.TrustedHeader.NameHeader != "" {
+		if name := strings.TrimSpace(req.Header.Get(provider.config.TrustedHeader.NameHeader)); name != "" {
+			return name
+		}
+	}
+
+	if at := strings.IndexByte(email.StringValue(), '@'); at > 0 {
+		return email.StringValue()[:at]
+	}
+
+	return email.StringValue()
+}

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -66,7 +66,7 @@ func New(ctx context.Context, providerSettings factory.ProviderSettings, config 
 	case identn.TrustModeSecret:
 		checker = newSecretTrust(config.TrustedHeader.Trust.Secret)
 	case identn.TrustModeJWT:
-		checker = newJWTTrust(ctx, config.TrustedHeader.Trust.JWT)
+		checker = newJWTTrust(ctx, settings.Logger(), config.TrustedHeader.Trust.JWT)
 	default:
 		return nil, errors.Newf(errors.TypeInvalidInput, ErrCodeTrustedHeaderUnsupportedMode, "identn::trusted_header::trust::mode %q is not supported", config.TrustedHeader.Trust.Mode.StringValue())
 	}

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -17,9 +17,11 @@ import (
 )
 
 var (
-	ErrCodeTrustedHeaderEmailMissing = errors.MustNewCode("trusted_header_email_missing")
-	ErrCodeTrustedHeaderUserNotFound = errors.MustNewCode("trusted_header_user_not_found")
-	ErrCodeTrustedHeaderNoOrg        = errors.MustNewCode("trusted_header_no_org")
+	ErrCodeTrustedHeaderEmailMissing  = errors.MustNewCode("trusted_header_email_missing")
+	ErrCodeTrustedHeaderUserNotFound  = errors.MustNewCode("trusted_header_user_not_found")
+	ErrCodeTrustedHeaderNoOrg         = errors.MustNewCode("trusted_header_no_org")
+	ErrCodeTrustedHeaderMultipleOrgs  = errors.MustNewCode("trusted_header_multiple_orgs")
+	ErrCodeTrustedHeaderAmbiguousUser = errors.MustNewCode("trusted_header_ambiguous_user")
 )
 
 type provider struct {
@@ -102,24 +104,20 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 		return nil, err
 	}
 
-	// Drop ineligible users — deleted ones (soft-deleted accounts) and root users.
-	// Root users are filtered (not hard-failed on first encounter) because
-	// ListUsersByEmailAndOrgIDs has no guaranteed ordering: in a multi-org
-	// installation where the same email exists in multiple orgs, hard-failing
-	// on `users[0]` being root would non-deterministically block a valid
-	// non-root user that happens to come later in the slice.
-	//
-	// Root users are deliberately not authenticatable via trusted headers
-	// (matches the SAML/OIDC posture) — treating them as "not a match" here
-	// keeps the resolver consistent.
+	// Deleted, root and pending-invite users are not authenticatable through a
+	// trusted header. Root can only authenticate by password. A pending invite
+	// has not proved control of the mailbox, and GetOrCreateUser would activate
+	// it as a side effect while resetting the role an admin chose.
 	users = slices.DeleteFunc(users, func(u *types.User) bool {
-		return u.ErrIfDeleted() != nil || u.ErrIfRoot() != nil
+		return u.ErrIfDeleted() != nil || u.ErrIfRoot() != nil || u.ErrIfPending() != nil
 	})
 
-	if len(users) > 0 {
-		// Pick the first remaining match. Multi-org installations should pin
-		// the user to a specific org via the proxy or a separate header in a
-		// future enhancement.
+	if len(users) > 1 {
+		return nil, errors.Newf(errors.TypeInvalidInput, ErrCodeTrustedHeaderAmbiguousUser, "email resolves to %d eligible users across owned organizations", len(users)).
+			WithAdditional("the unique index on users is (email, org_id), so an email can exist in more than one organization; pin the organization instead of relying on lookup order")
+	}
+
+	if len(users) == 1 {
 		matched := users[0]
 
 		return authtypes.NewPrincipalUserIdentity(
@@ -138,7 +136,7 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 	// We refuse to guess when multiple orgs exist — operators must disable
 	// AutoProvision or pin a single org.
 	if len(orgs) > 1 {
-		return nil, errors.Newf(errors.TypeInvalidInput, ErrCodeTrustedHeaderNoOrg, "trusted-header auto-provisioning is not supported with multiple organizations (found %d)", len(orgs))
+		return nil, errors.Newf(errors.TypeInvalidInput, ErrCodeTrustedHeaderMultipleOrgs, "auto-provisioning is not supported with multiple organizations (found %d)", len(orgs))
 	}
 
 	orgID := orgs[0].ID

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -109,9 +109,9 @@ func (provider *provider) Name() authtypes.IdentNProvider {
 // header lists stay populated in config even when the resolver is off.
 //
 // Provenance is established first: the peer address must be allowed, and then
-// the configured trust check (a proxy secret today; a verified JWT assertion
-// in a later change) must pass. Only once the request is trusted does this
-// look at identity at all.
+// the configured trust check (a proxy secret or a verified JWT assertion,
+// depending on trust.mode) must pass. Only once the request is trusted does
+// this look at identity at all.
 func (provider *provider) Test(req *http.Request) bool {
 	if !provider.peerAllowed(req) {
 		return false
@@ -169,8 +169,10 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 	// Check, but that is a property of how the resolver is wired today, not a
 	// contract Test or GetIdentity enforce on each other. Test is a
 	// provider-selection predicate on an exported interface, not an
-	// authorization boundary, so provenance is verified again here rather than
-	// relying on caller discipline.
+	// authorization boundary, so the trust check specifically is re-run here
+	// rather than relying on caller discipline. peerAllowed is not re-checked:
+	// it depends only on req.RemoteAddr, which cannot change between Test and
+	// GetIdentity within a single request.
 	if err := provider.trust.Check(req); err != nil {
 		return nil, err
 	}
@@ -224,9 +226,9 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 	// pkg/sqlmigration/067_add_status_user.go) is a partial unique index on
 	// (email, org_id) WHERE status != 'deleted', so a soft-deleted row sits
 	// outside that constraint entirely and a freshly created active row for
-	// the same email and org never collides with it. GetOrCreateUser's own
-	// lookup (GetNonDeletedUserByEmailAndOrgID) also excludes deleted rows, so
-	// it cannot adopt one either; a plain CreateUser follows and succeeds.
+	// the same email and org never collides with it. CreateUser performs no
+	// lookup of its own before inserting, so a deleted row is never even a
+	// candidate to adopt; the insert below simply succeeds against the index.
 	// Filtering deleted users here is purely to keep them out of the
 	// ambiguous/matched counting below; it does not, by itself, need to block
 	// provisioning.
@@ -237,14 +239,15 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 	// Root and pending-invite users are not authenticatable through a trusted
 	// header: root can only authenticate by password, and a pending invite
 	// has not proved control of the mailbox. Unlike a deleted user, they still
-	// occupy the live (org_id, email, deleted_at=zero) slot, so if control
-	// reached the auto-provisioning branch below, GetOrCreateUser would find
-	// and silently adopt one of these records instead of creating a new one:
-	// for a pending invite that means activatePendingUser flips it active and
-	// re-grants only Viewer, discarding whatever role an admin chose; for
-	// root it would go on to mint an admin-privileged identity. ineligible
-	// counts how many such records were filtered, so that case can be told
-	// apart from "no user found at all" below.
+	// occupy the live (org_id, email, deleted_at=zero) slot, so without this
+	// filter they would come back from ListUsersByEmailAndOrgIDs and be handed
+	// straight out as the matched identity in the len(users) == 1 branch
+	// below: for a pending invite that means treating an unconfirmed invite as
+	// an authenticated session without ever activating it or granting it a
+	// role, and for root it means minting an admin-privileged identity that
+	// bypasses the password check entirely. ineligible counts how many such
+	// records were filtered, so that case can be told apart from "no user
+	// found at all" below.
 	ineligible := 0
 	users = slices.DeleteFunc(users, func(u *types.User) bool {
 		if u.ErrIfRoot() != nil || u.ErrIfPending() != nil {
@@ -272,13 +275,16 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 
 	// The address is already known but not eligible (root or pending). Refuse
 	// outright rather than falling through to auto-provisioning, which would
-	// otherwise read as "nobody here, safe to create" and let GetOrCreateUser
-	// adopt the existing record. This applies regardless of AutoProvision:
-	// with it off, "no user found" would also have been misleading, since a
-	// user does exist for this email.
+	// otherwise read as "nobody here, safe to create" and attempt to insert a
+	// second row for this email and org: CreateUser does no lookup of its
+	// own, so that insert would fail only after the fact, on the partial
+	// unique index, as an opaque constraint violation instead of this
+	// explicit refusal. This applies regardless of AutoProvision: with it
+	// off, "no user found" would also have been misleading, since a user does
+	// exist for this email.
 	if ineligible > 0 {
 		return nil, errors.Newf(errors.TypeUnauthenticated, ErrCodeTrustedHeaderUserNotEligible, "email %q matches an existing user that cannot authenticate through a trusted header", email.StringValue()).
-			WithAdditional("the user is root or has a pending invite; auto-provisioning is refused because GetOrCreateUser would otherwise adopt that record instead of creating a new one")
+			WithAdditional("the user is root or has a pending invite; auto-provisioning is refused up front rather than attempting an insert that would only fail later on the unique (email, org_id) constraint")
 	}
 
 	if !provider.config.TrustedHeader.AutoProvision {

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -152,6 +152,14 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 		return nil, err
 	}
 
+	// GetOrCreateUser returns any pre-existing non-deleted record for this email
+	// and org, including root, in which case the Viewer role option above is
+	// never applied. implsession does the same check after provisioning an SSO
+	// user.
+	if err := createdUser.ErrIfRoot(); err != nil {
+		return nil, errors.WithAdditionalf(err, "root user can only authenticate via password")
+	}
+
 	return authtypes.NewPrincipalUserIdentity(
 		createdUser.ID,
 		createdUser.OrgID,

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -17,11 +17,13 @@ import (
 )
 
 var (
-	ErrCodeTrustedHeaderEmailMissing  = errors.MustNewCode("trusted_header_email_missing")
-	ErrCodeTrustedHeaderUserNotFound  = errors.MustNewCode("trusted_header_user_not_found")
-	ErrCodeTrustedHeaderNoOrg         = errors.MustNewCode("trusted_header_no_org")
-	ErrCodeTrustedHeaderMultipleOrgs  = errors.MustNewCode("trusted_header_multiple_orgs")
-	ErrCodeTrustedHeaderAmbiguousUser = errors.MustNewCode("trusted_header_ambiguous_user")
+	ErrCodeTrustedHeaderEmailMissing    = errors.MustNewCode("trusted_header_email_missing")
+	ErrCodeTrustedHeaderUserNotFound    = errors.MustNewCode("trusted_header_user_not_found")
+	ErrCodeTrustedHeaderNoOrg           = errors.MustNewCode("trusted_header_no_org")
+	ErrCodeTrustedHeaderMultipleOrgs    = errors.MustNewCode("trusted_header_multiple_orgs")
+	ErrCodeTrustedHeaderAmbiguousUser   = errors.MustNewCode("trusted_header_ambiguous_user")
+	ErrCodeTrustedHeaderAmbiguousHeader = errors.MustNewCode("trusted_header_ambiguous_header")
+	ErrCodeTrustedHeaderBlankHeader     = errors.MustNewCode("trusted_header_blank_header")
 )
 
 type provider struct {
@@ -72,7 +74,8 @@ func (provider *provider) Name() authtypes.IdentNProvider {
 // those resolvers are enabled, and harmful when they are not, because the
 // header lists stay populated in config even when the resolver is off.
 func (provider *provider) Test(req *http.Request) bool {
-	return provider.extractEmail(req) != ""
+	email, err := provider.extractEmail(req)
+	return err == nil && email != ""
 }
 
 // GetIdentity resolves the request to an authenticated identity using only
@@ -82,9 +85,13 @@ func (provider *provider) Test(req *http.Request) bool {
 func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, error) {
 	ctx := req.Context()
 
-	rawEmail := provider.extractEmail(req)
+	rawEmail, err := provider.extractEmail(req)
+	if err != nil {
+		return nil, err
+	}
+
 	if rawEmail == "" {
-		return nil, errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderEmailMissing, "trusted-header IdentN expected an email header but none was present")
+		return nil, errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderEmailMissing, "expected an email header but none was present")
 	}
 
 	email, err := valuer.NewEmail(rawEmail)
@@ -175,18 +182,49 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 	), nil
 }
 
-// extractEmail reads the configured email header and trims whitespace.
-func (provider *provider) extractEmail(req *http.Request) string {
-	return strings.TrimSpace(req.Header.Get(provider.config.TrustedHeader.EmailHeader))
+// extractEmail reads the first configured email header that is present on the
+// request. A header carrying more than one value is refused: Header.Get would
+// return only the first, so a proxy that appends rather than replaces would
+// let a client-supplied value win. A header that is present but blank is also
+// refused rather than skipped: a blank identity header means the proxy failed
+// to authenticate the caller, and falling through to a later, less
+// authoritative header would let an attacker supply that one instead. Only a
+// header that is entirely absent falls through to the next configured header.
+func (provider *provider) extractEmail(req *http.Request) (string, error) {
+	for _, header := range provider.config.TrustedHeader.EmailHeaders {
+		values := req.Header.Values(header)
+		if len(values) == 0 {
+			continue
+		}
+
+		if len(values) > 1 {
+			return "", errors.Newf(errors.TypeUnauthenticated, ErrCodeTrustedHeaderAmbiguousHeader, "header carries %d values, expected exactly one", len(values)).
+				WithAdditional(header)
+		}
+
+		value := strings.TrimSpace(values[0])
+		if value == "" {
+			return "", errors.Newf(errors.TypeUnauthenticated, ErrCodeTrustedHeaderBlankHeader, "header is present but carries no value").
+				WithAdditional(header)
+		}
+
+		return value, nil
+	}
+
+	return "", nil
 }
 
-// extractDisplayName falls back through:
-//
-//  1. The configured NameHeader (when set and non-empty)
-//  2. The local-part of the email address
+// extractDisplayName falls back through the configured name headers and then the
+// local part of the email. A name header with several values is ignored rather
+// than fatal: it decides only a display string.
 func (provider *provider) extractDisplayName(req *http.Request, email valuer.Email) string {
-	if provider.config.TrustedHeader.NameHeader != "" {
-		if name := strings.TrimSpace(req.Header.Get(provider.config.TrustedHeader.NameHeader)); name != "" {
+	for _, header := range provider.config.TrustedHeader.NameHeaders {
+		values := req.Header.Values(header)
+		if len(values) != 1 {
+			continue
+		}
+
+		if name := strings.TrimSpace(values[0]); name != "" {
 			return name
 		}
 	}

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -300,23 +300,26 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 		return nil, err
 	}
 
-	createdUser, err := provider.userSetter.GetOrCreateUser(ctx, newUser, user.WithRoleNames([]string{authtypes.SigNozViewerRoleName}))
-	if err != nil {
+	// CreateUser is used here, not GetOrCreateUser. The ineligible check above
+	// and this insert are not atomic: a pending invite (or any other
+	// non-deleted row for this email and org) can appear in the window between
+	// them, invisible to that check. GetOrCreateUser would silently adopt such
+	// a row through GetNonDeletedUserByEmailAndOrgID, reopening the very
+	// pending-invite escalation the ineligible guard exists to close. CreateUser
+	// has no adoption path at all, so a concurrent row instead collides with
+	// the partial unique index on (email, org_id) WHERE status != 'deleted'
+	// (pkg/sqlmigration/076_drop_user_deleted_at.go) and the insert fails: the
+	// race fails closed rather than escalating. This also makes it impossible
+	// for provisioning to ever hand back a pre-existing root record, so there
+	// is no post-create root check to perform here.
+	if err := provider.userSetter.CreateUser(ctx, newUser, user.WithRoleNames([]string{authtypes.SigNozViewerRoleName})); err != nil {
 		return nil, err
 	}
 
-	// GetOrCreateUser returns any pre-existing non-deleted record for this email
-	// and org, including root, in which case the Viewer role option above is
-	// never applied. implsession does the same check after provisioning an SSO
-	// user.
-	if err := createdUser.ErrIfRoot(); err != nil {
-		return nil, errors.WithAdditionalf(err, "root user can only authenticate via password")
-	}
-
 	return authtypes.NewPrincipalUserIdentity(
-		createdUser.ID,
-		createdUser.OrgID,
-		createdUser.Email,
+		newUser.ID,
+		newUser.OrgID,
+		newUser.Email,
 		authtypes.IdentNProviderTrustedHeader,
 	), nil
 }

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -26,6 +26,7 @@ var (
 	ErrCodeTrustedHeaderAmbiguousHeader = errors.MustNewCode("trusted_header_ambiguous_header")
 	ErrCodeTrustedHeaderBlankHeader     = errors.MustNewCode("trusted_header_blank_header")
 	ErrCodeTrustedHeaderUnsupportedMode = errors.MustNewCode("trusted_header_unsupported_trust_mode")
+	ErrCodeTrustedHeaderUserNotEligible = errors.MustNewCode("trusted_header_user_not_eligible")
 )
 
 type provider struct {
@@ -216,12 +217,41 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 		return nil, err
 	}
 
-	// Deleted, root and pending-invite users are not authenticatable through a
-	// trusted header. Root can only authenticate by password. A pending invite
-	// has not proved control of the mailbox, and GetOrCreateUser would activate
-	// it as a side effect while resetting the role an admin chose.
+	// Deleted users are gone: the email is free to re-provision as a brand
+	// new user. The live constraint on users (see
+	// pkg/sqlmigration/076_drop_user_deleted_at.go, which superseded an
+	// earlier (org_id, email, deleted_at) index from
+	// pkg/sqlmigration/067_add_status_user.go) is a partial unique index on
+	// (email, org_id) WHERE status != 'deleted', so a soft-deleted row sits
+	// outside that constraint entirely and a freshly created active row for
+	// the same email and org never collides with it. GetOrCreateUser's own
+	// lookup (GetNonDeletedUserByEmailAndOrgID) also excludes deleted rows, so
+	// it cannot adopt one either; a plain CreateUser follows and succeeds.
+	// Filtering deleted users here is purely to keep them out of the
+	// ambiguous/matched counting below; it does not, by itself, need to block
+	// provisioning.
 	users = slices.DeleteFunc(users, func(u *types.User) bool {
-		return u.ErrIfDeleted() != nil || u.ErrIfRoot() != nil || u.ErrIfPending() != nil
+		return u.ErrIfDeleted() != nil
+	})
+
+	// Root and pending-invite users are not authenticatable through a trusted
+	// header: root can only authenticate by password, and a pending invite
+	// has not proved control of the mailbox. Unlike a deleted user, they still
+	// occupy the live (org_id, email, deleted_at=zero) slot, so if control
+	// reached the auto-provisioning branch below, GetOrCreateUser would find
+	// and silently adopt one of these records instead of creating a new one:
+	// for a pending invite that means activatePendingUser flips it active and
+	// re-grants only Viewer, discarding whatever role an admin chose; for
+	// root it would go on to mint an admin-privileged identity. ineligible
+	// counts how many such records were filtered, so that case can be told
+	// apart from "no user found at all" below.
+	ineligible := 0
+	users = slices.DeleteFunc(users, func(u *types.User) bool {
+		if u.ErrIfRoot() != nil || u.ErrIfPending() != nil {
+			ineligible++
+			return true
+		}
+		return false
 	})
 
 	if len(users) > 1 {
@@ -238,6 +268,17 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 			matched.Email,
 			authtypes.IdentNProviderTrustedHeader,
 		), nil
+	}
+
+	// The address is already known but not eligible (root or pending). Refuse
+	// outright rather than falling through to auto-provisioning, which would
+	// otherwise read as "nobody here, safe to create" and let GetOrCreateUser
+	// adopt the existing record. This applies regardless of AutoProvision:
+	// with it off, "no user found" would also have been misleading, since a
+	// user does exist for this email.
+	if ineligible > 0 {
+		return nil, errors.Newf(errors.TypeUnauthenticated, ErrCodeTrustedHeaderUserNotEligible, "email %q matches an existing user that cannot authenticate through a trusted header", email.StringValue()).
+			WithAdditional("the user is root or has a pending invite; auto-provisioning is refused because GetOrCreateUser would otherwise adopt that record instead of creating a new one")
 	}
 
 	if !provider.config.TrustedHeader.AutoProvision {

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -54,12 +54,18 @@ func New(ctx context.Context, providerSettings factory.ProviderSettings, config 
 		"trusted-header identity provider is enabled; SigNoz must be deployed behind a reverse proxy that strips client-supplied identity headers, otherwise any client can forge identity",
 	)
 
+	if config.TrustedHeader.Trust.Mode == identn.TrustModeSecret {
+		settings.Logger().WarnContext(ctx,
+			"trusted-header identity provider is enabled in secret mode; the proxy secret is only as private as the pod that holds it, and any peer that learns it can assert any identity",
+		)
+	}
+
 	var checker trust
 	switch config.TrustedHeader.Trust.Mode {
 	case identn.TrustModeSecret:
 		checker = newSecretTrust(config.TrustedHeader.Trust.Secret)
 	case identn.TrustModeJWT:
-		return nil, errors.New(errors.TypeInvalidInput, ErrCodeTrustedHeaderUnsupportedMode, "identn::trusted_header::trust::mode jwt is not yet supported")
+		checker = newJWTTrust(ctx, config.TrustedHeader.Trust.JWT)
 	default:
 		return nil, errors.Newf(errors.TypeInvalidInput, ErrCodeTrustedHeaderUnsupportedMode, "identn::trusted_header::trust::mode %q is not supported", config.TrustedHeader.Trust.Mode.StringValue())
 	}

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -2,6 +2,7 @@ package trustedheaderidentn
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"slices"
 	"strings"
@@ -24,14 +25,17 @@ var (
 	ErrCodeTrustedHeaderAmbiguousUser   = errors.MustNewCode("trusted_header_ambiguous_user")
 	ErrCodeTrustedHeaderAmbiguousHeader = errors.MustNewCode("trusted_header_ambiguous_header")
 	ErrCodeTrustedHeaderBlankHeader     = errors.MustNewCode("trusted_header_blank_header")
+	ErrCodeTrustedHeaderUnsupportedMode = errors.MustNewCode("trusted_header_unsupported_trust_mode")
 )
 
 type provider struct {
-	config     identn.Config
-	settings   factory.ScopedProviderSettings
-	orgGetter  organization.Getter
-	userGetter user.Getter
-	userSetter user.Setter
+	config         identn.Config
+	settings       factory.ScopedProviderSettings
+	orgGetter      organization.Getter
+	userGetter     user.Getter
+	userSetter     user.Setter
+	trust          trust
+	trustedProxies []*net.IPNet
 }
 
 func NewFactory(orgGetter organization.Getter, userGetter user.Getter, userSetter user.Setter) factory.ProviderFactory[identn.IdentN, identn.Config] {
@@ -50,12 +54,35 @@ func New(ctx context.Context, providerSettings factory.ProviderSettings, config 
 		"trusted-header identity provider is enabled; SigNoz must be deployed behind a reverse proxy that strips client-supplied identity headers, otherwise any client can forge identity",
 	)
 
+	var checker trust
+	switch config.TrustedHeader.Trust.Mode {
+	case identn.TrustModeSecret:
+		checker = newSecretTrust(config.TrustedHeader.Trust.Secret)
+	case identn.TrustModeJWT:
+		return nil, errors.New(errors.TypeInvalidInput, ErrCodeTrustedHeaderUnsupportedMode, "identn::trusted_header::trust::mode jwt is not yet supported")
+	default:
+		return nil, errors.Newf(errors.TypeInvalidInput, ErrCodeTrustedHeaderUnsupportedMode, "identn::trusted_header::trust::mode %q is not supported", config.TrustedHeader.Trust.Mode.StringValue())
+	}
+
+	// Parsed once here, rather than per request, since config validation
+	// already guarantees every entry parses as a CIDR.
+	trustedProxies := make([]*net.IPNet, 0, len(config.TrustedHeader.TrustedProxies))
+	for _, cidr := range config.TrustedHeader.TrustedProxies {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, err
+		}
+		trustedProxies = append(trustedProxies, network)
+	}
+
 	return &provider{
-		config:     config,
-		settings:   settings,
-		orgGetter:  orgGetter,
-		userGetter: userGetter,
-		userSetter: userSetter,
+		config:         config,
+		settings:       settings,
+		orgGetter:      orgGetter,
+		userGetter:     userGetter,
+		userSetter:     userSetter,
+		trust:          checker,
+		trustedProxies: trustedProxies,
 	}, nil
 }
 
@@ -73,9 +100,55 @@ func (provider *provider) Name() authtypes.IdentNProvider {
 // reaches this provider. Duplicating the check here would be unreachable when
 // those resolvers are enabled, and harmful when they are not, because the
 // header lists stay populated in config even when the resolver is off.
+//
+// Provenance is established first: the peer address must be allowed, and then
+// the configured trust check (a proxy secret today; a verified JWT assertion
+// in a later change) must pass. Only once the request is trusted does this
+// look at identity at all.
 func (provider *provider) Test(req *http.Request) bool {
+	if !provider.peerAllowed(req) {
+		return false
+	}
+
+	if err := provider.trust.Check(req); err != nil {
+		return false
+	}
+
+	// When the proof carries the identity, Check having passed is enough to claim
+	// the request. Verifying the assertion itself would mean network I/O, which
+	// this method must not do; that happens in GetIdentity.
+	if provider.trust.CarriesIdentity() {
+		return true
+	}
+
 	email, err := provider.extractEmail(req)
 	return err == nil && email != ""
+}
+
+// peerAllowed matches the immediate TCP peer against the configured CIDRs. It
+// deliberately ignores X-Forwarded-For, which a client controls.
+func (provider *provider) peerAllowed(req *http.Request) bool {
+	if len(provider.trustedProxies) == 0 {
+		return true
+	}
+
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		host = req.RemoteAddr
+	}
+
+	addr := net.ParseIP(host)
+	if addr == nil {
+		return false
+	}
+
+	for _, network := range provider.trustedProxies {
+		if network.Contains(addr) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // GetIdentity resolves the request to an authenticated identity using only
@@ -85,9 +158,28 @@ func (provider *provider) Test(req *http.Request) bool {
 func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, error) {
 	ctx := req.Context()
 
-	rawEmail, err := provider.extractEmail(req)
-	if err != nil {
+	// GetIdentity is reached only after the resolver's Test has already called
+	// Check, but that is a property of how the resolver is wired today, not a
+	// contract Test or GetIdentity enforce on each other. Test is a
+	// provider-selection predicate on an exported interface, not an
+	// authorization boundary, so provenance is verified again here rather than
+	// relying on caller discipline.
+	if err := provider.trust.Check(req); err != nil {
 		return nil, err
+	}
+
+	var rawEmail string
+	var err error
+	if provider.trust.CarriesIdentity() {
+		rawEmail, err = provider.trust.Email(req)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		rawEmail, err = provider.extractEmail(req)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if rawEmail == "" {

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -61,9 +61,16 @@ func (provider *provider) Name() authtypes.IdentNProvider {
 	return authtypes.IdentNProviderTrustedHeader
 }
 
-// Test returns true when the configured email header is present on the request.
-// Test is intentionally cheap (header presence) — full email validation and the
-// user lookup happen in GetIdentity.
+// Test reports whether this provider should handle the request. It performs no
+// I/O and does not mutate the request.
+//
+// There is deliberately no check for bearer-token or API-key headers here. The
+// resolver registers this provider after the tokenizer and apikey resolvers and
+// returns the first whose Test passes, and their Test bodies read the same
+// configured header lists, so a request carrying either credential never
+// reaches this provider. Duplicating the check here would be unreachable when
+// those resolvers are enabled, and harmful when they are not, because the
+// header lists stay populated in config even when the resolver is off.
 func (provider *provider) Test(req *http.Request) bool {
 	return provider.extractEmail(req) != ""
 }

--- a/pkg/identn/trustedheaderidentn/provider.go
+++ b/pkg/identn/trustedheaderidentn/provider.go
@@ -286,7 +286,7 @@ func (provider *provider) GetIdentity(req *http.Request) (*authtypes.Identity, e
 	}
 
 	// Auto-provision: create the user with Viewer role in the (only) org.
-	// We refuse to guess when multiple orgs exist — operators must disable
+	// We refuse to guess when multiple orgs exist, operators must disable
 	// AutoProvision or pin a single org.
 	if len(orgs) > 1 {
 		return nil, errors.Newf(errors.TypeInvalidInput, ErrCodeTrustedHeaderMultipleOrgs, "auto-provisioning is not supported with multiple organizations (found %d)", len(orgs))

--- a/pkg/identn/trustedheaderidentn/provider_test.go
+++ b/pkg/identn/trustedheaderidentn/provider_test.go
@@ -264,12 +264,19 @@ func (f *fakeUserSetter) Collect(context.Context, valuer.UUID) (map[string]any, 
 
 var _ user.Setter = (*fakeUserSetter)(nil)
 
+const testSecretHeader = "X-Proxy-Auth"
+const testSecretValue = "test-proxy-secret"
+
 func newConfig(emailHeader, nameHeader string, autoProvision bool) identn.Config {
 	cfg := identn.Config{
 		TrustedHeader: identn.TrustedHeaderConfig{
 			Enabled:       true,
 			EmailHeaders:  []string{emailHeader},
 			AutoProvision: autoProvision,
+			Trust: identn.TrustConfig{
+				Mode:   identn.TrustModeSecret,
+				Secret: identn.SecretTrustConfig{Header: testSecretHeader, Value: testSecretValue},
+			},
 		},
 	}
 
@@ -290,8 +297,27 @@ func newConfigWithHeaders(emailHeaders []string, nameHeaders []string, autoProvi
 			EmailHeaders:  emailHeaders,
 			NameHeaders:   nameHeaders,
 			AutoProvision: autoProvision,
+			Trust: identn.TrustConfig{
+				Mode:   identn.TrustModeSecret,
+				Secret: identn.SecretTrustConfig{Header: testSecretHeader, Value: testSecretValue},
+			},
 		},
 	}
+}
+
+// newTrustedRequest builds a request that already satisfies the trust check,
+// so tests can focus on identity resolution. header names which request
+// header the email is set under; it must match the provider's configured
+// email header, since a mismatch here would silently exercise the "header
+// absent" path instead of the one the test intends. Tests exercising
+// multi-value or multi-header setups build the request directly instead.
+func newTrustedRequest(header, email string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(testSecretHeader, testSecretValue)
+	if email != "" {
+		req.Header.Set(header, email)
+	}
+	return req
 }
 
 func newProvider(t *testing.T, cfg identn.Config, orgGetter organization.Getter, userGetter user.Getter, userSetter user.Setter) identn.IdentN {
@@ -309,11 +335,98 @@ func TestProviderName(t *testing.T) {
 	assert.Equal(t, authtypes.IdentNProviderTrustedHeader, p.Name())
 }
 
-func TestTestReturnsTrueWhenHeaderPresent(t *testing.T) {
+func TestNewRefusesJWTMode(t *testing.T) {
+	cfg := identn.Config{
+		TrustedHeader: identn.TrustedHeaderConfig{
+			Enabled: true,
+			Trust:   identn.TrustConfig{Mode: identn.TrustModeJWT},
+		},
+	}
+
+	_, err := New(context.Background(), instrumentationtest.New().ToProviderSettings(), cfg, &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+	require.Error(t, err)
+}
+
+func TestNewRefusesUnsetTrustMode(t *testing.T) {
+	cfg := identn.Config{
+		TrustedHeader: identn.TrustedHeaderConfig{
+			Enabled: true,
+		},
+	}
+
+	_, err := New(context.Background(), instrumentationtest.New().ToProviderSettings(), cfg, &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+	require.Error(t, err)
+}
+
+// The following six tests pin down that Test actually consults the trust
+// checker and the peer allowlist rather than only the email header. Deleting
+// the provider.trust.Check call from Test, or the peerAllowed call, must make
+// at least one of these fail; that experiment is recorded in the task report.
+func TestTestReturnsFalseWhenSecretHeaderAbsent(t *testing.T) {
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+
+	assert.False(t, p.Test(req))
+}
+
+func TestTestReturnsFalseWhenSecretWrong(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+	req.Header.Set(testSecretHeader, "wrong-value")
+
+	assert.False(t, p.Test(req))
+}
+
+func TestTestReturnsFalseWhenSecretHeaderDuplicated(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+	req.Header.Add(testSecretHeader, testSecretValue)
+	req.Header.Add(testSecretHeader, testSecretValue)
+
+	assert.False(t, p.Test(req))
+}
+
+func TestTestReturnsFalseWhenPeerOutsideTrustedProxies(t *testing.T) {
+	cfg := newConfig("X-Forwarded-Email", "", false)
+	cfg.TrustedHeader.TrustedProxies = []string{"10.0.0.0/24"}
+	p := newProvider(t, cfg, &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := newTrustedRequest("X-Forwarded-Email", "alice@example.com")
+	req.RemoteAddr = "192.168.1.5:12345"
+
+	assert.False(t, p.Test(req))
+}
+
+func TestTestReturnsTrueWhenPeerInsideTrustedProxies(t *testing.T) {
+	cfg := newConfig("X-Forwarded-Email", "", false)
+	cfg.TrustedHeader.TrustedProxies = []string{"10.0.0.0/24"}
+	p := newProvider(t, cfg, &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := newTrustedRequest("X-Forwarded-Email", "alice@example.com")
+	req.RemoteAddr = "10.0.0.5:12345"
+
+	assert.True(t, p.Test(req))
+}
+
+func TestTestReturnsTrueWhenTrustedProxiesEmptyRegardlessOfPeer(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := newTrustedRequest("X-Forwarded-Email", "alice@example.com")
+	req.RemoteAddr = "203.0.113.7:54321"
+
+	assert.True(t, p.Test(req))
+}
+
+func TestTestReturnsTrueWhenHeaderPresent(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := newTrustedRequest("X-Forwarded-Email", "alice@example.com")
 
 	assert.True(t, p.Test(req))
 }
@@ -321,7 +434,7 @@ func TestTestReturnsTrueWhenHeaderPresent(t *testing.T) {
 func TestTestReturnsFalseWhenHeaderMissing(t *testing.T) {
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := newTrustedRequest("X-Forwarded-Email", "")
 
 	assert.False(t, p.Test(req))
 }
@@ -329,7 +442,7 @@ func TestTestReturnsFalseWhenHeaderMissing(t *testing.T) {
 func TestTestReturnsFalseWhenHeaderBlank(t *testing.T) {
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := newTrustedRequest("X-Forwarded-Email", "")
 	req.Header.Set("X-Forwarded-Email", "   ")
 
 	assert.False(t, p.Test(req))
@@ -349,8 +462,7 @@ func TestGetIdentityReturnsExistingUser(t *testing.T) {
 
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, userSetter)
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+	req := newTrustedRequest("X-Forwarded-Email", "alice@example.com")
 
 	identity, err := p.GetIdentity(req)
 	require.NoError(t, err)
@@ -364,10 +476,35 @@ func TestGetIdentityReturnsExistingUser(t *testing.T) {
 	assert.Empty(t, userSetter.createdUsers, "expected no auto-provisioned users")
 }
 
+// GetIdentity must not rely on Test having already run: even a fully valid,
+// known email must be refused if the request never proved it came from the
+// trusted proxy.
+func TestGetIdentityRefusesRequestWithoutSecret(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+
+	existing, err := types.NewUser("Alice", email, orgID, types.UserStatusActive)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{existing}}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+	assert.True(t, errors.Asc(err, ErrCodeTrustedHeaderUntrusted))
+}
+
 func TestGetIdentityErrorsWhenHeaderMissing(t *testing.T) {
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := newTrustedRequest("X-Forwarded-Email", "")
 
 	identity, err := p.GetIdentity(req)
 	require.Error(t, err)
@@ -378,8 +515,7 @@ func TestGetIdentityErrorsWhenHeaderMissing(t *testing.T) {
 func TestGetIdentityErrorsWhenEmailInvalid(t *testing.T) {
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("X-Forwarded-Email", "not-an-email")
+	req := newTrustedRequest("X-Forwarded-Email", "not-an-email")
 
 	identity, err := p.GetIdentity(req)
 	require.Error(t, err)
@@ -392,8 +528,7 @@ func TestGetIdentityErrorsWhenUserUnknownAndAutoProvisionDisabled(t *testing.T) 
 
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, &fakeUserGetter{}, &fakeUserSetter{})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("X-Forwarded-Email", "ghost@example.com")
+	req := newTrustedRequest("X-Forwarded-Email", "ghost@example.com")
 
 	identity, err := p.GetIdentity(req)
 	require.Error(t, err)
@@ -408,8 +543,7 @@ func TestGetIdentityAutoProvisionsWhenEnabled(t *testing.T) {
 
 	p := newProvider(t, newConfig("X-Forwarded-Email", "X-Forwarded-User", true), orgGetter, &fakeUserGetter{}, userSetter)
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("X-Forwarded-Email", "newcomer@example.com")
+	req := newTrustedRequest("X-Forwarded-Email", "newcomer@example.com")
 	req.Header.Set("X-Forwarded-User", "Newcomer Bob")
 
 	identity, err := p.GetIdentity(req)
@@ -431,8 +565,7 @@ func TestGetIdentityAutoProvisionUsesEmailLocalPartWhenNoNameHeader(t *testing.T
 
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), orgGetter, &fakeUserGetter{}, userSetter)
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("X-Forwarded-Email", "carol@example.com")
+	req := newTrustedRequest("X-Forwarded-Email", "carol@example.com")
 
 	_, err := p.GetIdentity(req)
 	require.NoError(t, err)
@@ -451,8 +584,7 @@ func TestGetIdentityRefusesAutoProvisionWithMultipleOrgs(t *testing.T) {
 
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), orgGetter, &fakeUserGetter{}, &fakeUserSetter{})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("X-Forwarded-Email", "newcomer@example.com")
+	req := newTrustedRequest("X-Forwarded-Email", "newcomer@example.com")
 
 	identity, err := p.GetIdentity(req)
 	require.Error(t, err)
@@ -462,8 +594,7 @@ func TestGetIdentityRefusesAutoProvisionWithMultipleOrgs(t *testing.T) {
 func TestGetIdentityErrorsWhenNoOrganization(t *testing.T) {
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+	req := newTrustedRequest("X-Forwarded-Email", "alice@example.com")
 
 	identity, err := p.GetIdentity(req)
 	require.Error(t, err)
@@ -483,8 +614,7 @@ func TestGetIdentityRejectsRootUser(t *testing.T) {
 
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("X-Forwarded-Email", "root@example.com")
+	req := newTrustedRequest("X-Forwarded-Email", "root@example.com")
 
 	identity, err := p.GetIdentity(req)
 	require.Error(t, err)
@@ -509,8 +639,7 @@ func TestGetIdentityDoesNotProvisionIntoRootUser(t *testing.T) {
 
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), orgGetter, userGetter, userSetter)
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("X-Forwarded-Email", "root@example.com")
+	req := newTrustedRequest("X-Forwarded-Email", "root@example.com")
 
 	identity, err := p.GetIdentity(req)
 	require.Error(t, err)
@@ -546,8 +675,7 @@ func TestGetIdentityPicksNonRootWhenRootAndRegularShareEmail(t *testing.T) {
 		userGetter := &fakeUserGetter{users: ordering}
 		p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
 
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		req.Header.Set("X-Forwarded-Email", "shared@example.com")
+		req := newTrustedRequest("X-Forwarded-Email", "shared@example.com")
 
 		identity, err := p.GetIdentity(req)
 		require.NoError(t, err)
@@ -570,8 +698,7 @@ func TestGetIdentityRejectsPendingInviteUser(t *testing.T) {
 
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+	req := newTrustedRequest("X-Forwarded-Email", "alice@example.com")
 
 	identity, err := p.GetIdentity(req)
 	require.Error(t, err)
@@ -602,6 +729,7 @@ func TestGetIdentityRejectsDuplicateEmailHeaderValues(t *testing.T) {
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(testSecretHeader, testSecretValue)
 	req.Header.Add("X-Forwarded-Email", "attacker@evil.example")
 	req.Header.Add("X-Forwarded-Email", "alice@example.com")
 
@@ -628,6 +756,7 @@ func TestGetIdentityFallsThroughToSecondEmailHeaderWhenFirstAbsent(t *testing.T)
 	p := newProvider(t, cfg, orgGetter, userGetter, &fakeUserSetter{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(testSecretHeader, testSecretValue)
 	req.Header.Set("X-Authentik-Email", "alice@example.com")
 
 	identity, err := p.GetIdentity(req)
@@ -656,6 +785,7 @@ func TestGetIdentityRejectsBlankFirstEmailHeaderInsteadOfFallingThrough(t *testi
 	p := newProvider(t, cfg, orgGetter, userGetter, &fakeUserSetter{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(testSecretHeader, testSecretValue)
 	req.Header.Set("X-Forwarded-Email", "   ")
 	req.Header.Set("X-Authentik-Email", "alice@example.com")
 
@@ -682,6 +812,7 @@ func TestGetIdentityRejectsDuplicateFirstEmailHeaderWithoutConsultingSecond(t *t
 	p := newProvider(t, cfg, orgGetter, userGetter, &fakeUserSetter{})
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(testSecretHeader, testSecretValue)
 	req.Header.Add("X-Forwarded-Email", "attacker@evil.example")
 	req.Header.Add("X-Forwarded-Email", "alice@example.com")
 	req.Header.Set("X-Authentik-Email", "alice@example.com")
@@ -703,6 +834,7 @@ func TestGetIdentityAutoProvisionUsesEmailLocalPartWhenNameHeaderHasMultipleValu
 	p := newProvider(t, cfg, orgGetter, &fakeUserGetter{}, userSetter)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(testSecretHeader, testSecretValue)
 	req.Header.Set("X-Forwarded-Email", "newcomer@example.com")
 	req.Header.Add("X-Forwarded-User", "Newcomer Bob")
 	req.Header.Add("X-Forwarded-User", "Someone Else")
@@ -733,8 +865,7 @@ func TestGetIdentityErrorsWhenEmailMatchesUsersInTwoOrgs(t *testing.T) {
 
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+	req := newTrustedRequest("X-Forwarded-Email", "alice@example.com")
 
 	identity, err := p.GetIdentity(req)
 	require.Error(t, err)

--- a/pkg/identn/trustedheaderidentn/provider_test.go
+++ b/pkg/identn/trustedheaderidentn/provider_test.go
@@ -2,6 +2,7 @@ package trustedheaderidentn
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -157,19 +158,26 @@ func (f *fakeUserGetter) VerifyResetPasswordToken(context.Context, string) error
 
 var _ user.Getter = (*fakeUserGetter)(nil)
 
-// fakeUserSetter records the last user passed to GetOrCreateUser.
+// fakeUserSetter records the users passed to CreateUser.
 //
 // Most methods are stubs returning nil/zero — they exist purely to satisfy the
-// user.Setter interface. Only GetOrCreateUser is exercised by these tests.
+// user.Setter interface. Only CreateUser is exercised by these tests;
+// GetIdentity no longer calls GetOrCreateUser (see provider.go), so that
+// method is kept only to satisfy the interface and is not used to model any
+// behaviour here.
 type fakeUserSetter struct {
 	createdUsers []*types.User
 	autoFail     bool
 	existing     []*types.User
 }
 
-// existing returns a pre-existing user for a matching email and org, mirroring
-// impluser.GetOrCreateUser, which short-circuits on
-// GetNonDeletedUserByEmailAndOrgID before creating anything.
+// withExisting primes the fake with a non-deleted row that already occupies
+// the (email, org_id) slot a later CreateUser call will try to insert into.
+// It models the partial unique index on (email, org_id) WHERE status !=
+// 'deleted' (pkg/sqlmigration/076_drop_user_deleted_at.go): a real INSERT
+// colliding with that index fails, so CreateUser below returns an error
+// instead of creating anything, rather than adopting the existing row the way
+// GetOrCreateUser once did.
 func (f *fakeUserSetter) withExisting(users ...*types.User) *fakeUserSetter {
 	f.existing = append(f.existing, users...)
 	return f
@@ -183,21 +191,17 @@ func (f *fakeUserSetter) CreateUser(_ context.Context, u *types.User, _ ...user.
 	if f.autoFail {
 		return errors.New(errors.TypeInternal, errors.CodeInternal, "create user failed")
 	}
+	for _, e := range f.existing {
+		if e.Email == u.Email && e.OrgID == u.OrgID && e.ErrIfDeleted() == nil {
+			return errors.New(errors.TypeAlreadyExists, errors.CodeAlreadyExists, "a non-deleted user already exists for this email and org")
+		}
+	}
 	f.createdUsers = append(f.createdUsers, u)
 	return nil
 }
 
-func (f *fakeUserSetter) GetOrCreateUser(_ context.Context, u *types.User, _ ...user.CreateUserOption) (*types.User, error) {
-	if f.autoFail {
-		return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "get or create user failed")
-	}
-	for _, e := range f.existing {
-		if e.Email == u.Email && e.OrgID == u.OrgID {
-			return e, nil
-		}
-	}
-	f.createdUsers = append(f.createdUsers, u)
-	return u, nil
+func (f *fakeUserSetter) GetOrCreateUser(context.Context, *types.User, ...user.CreateUserOption) (*types.User, error) {
+	return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "GetOrCreateUser is not used by the trusted-header provider and is not modelled by this fake")
 }
 
 func (f *fakeUserSetter) GetOrCreateResetPasswordToken(context.Context, valuer.UUID) (*types.ResetPasswordToken, error) {
@@ -640,10 +644,14 @@ func TestGetIdentityRejectsRootUser(t *testing.T) {
 	assert.Nil(t, identity)
 }
 
-// The root user is filtered out of the lookup, so control reaches the
-// provisioning branch, where GetOrCreateUser finds the existing root record and
-// returns it. Without a post-create guard the provider mints an identity for
-// root, which always holds the admin role.
+// The root user is filtered out by the ineligible guard before the
+// auto-provisioning branch is ever reached, even with AutoProvision enabled,
+// so this test no longer exercises CreateUser at all: it pins the same
+// refusal as TestGetIdentityRejectsRootUser, but confirms it holds regardless
+// of AutoProvision. This used to describe GetOrCreateUser adopting the
+// existing root record after a post-create check; that check was removed
+// because CreateUser (unlike GetOrCreateUser) has no adoption path and so can
+// never hand back a pre-existing record for the provider to inspect.
 func TestGetIdentityDoesNotProvisionIntoRootUser(t *testing.T) {
 	orgID := valuer.GenerateUUID()
 	email, err := valuer.NewEmail("root@example.com")
@@ -654,7 +662,7 @@ func TestGetIdentityDoesNotProvisionIntoRootUser(t *testing.T) {
 
 	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
 	userGetter := &fakeUserGetter{users: []*types.User{rootUser}}
-	userSetter := (&fakeUserSetter{}).withExisting(rootUser)
+	userSetter := &fakeUserSetter{}
 
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), orgGetter, userGetter, userSetter)
 
@@ -663,6 +671,8 @@ func TestGetIdentityDoesNotProvisionIntoRootUser(t *testing.T) {
 	identity, err := p.GetIdentity(req)
 	require.Error(t, err)
 	assert.Nil(t, identity)
+	assert.True(t, errors.Asc(err, ErrCodeTrustedHeaderUserNotEligible))
+	assert.Empty(t, userSetter.createdUsers, "auto-provisioning must not run for a known ineligible user")
 }
 
 // Multi-org case: when ListUsersByEmailAndOrgIDs returns both a root user
@@ -728,12 +738,13 @@ func TestGetIdentityRejectsPendingInviteUser(t *testing.T) {
 // escalation TestGetIdentityRejectsPendingInviteUser could not reach: that
 // test runs with autoProvision=false, so it never exercises the provisioning
 // branch. With autoProvision=true, a pending user is still filtered out of
-// the matched set, so control used to fall through to auto-provisioning
-// believing no user existed. GetOrCreateUser (primed here via withExisting to
-// mirror GetNonDeletedUserByEmailAndOrgID finding the pending row) would then
-// adopt that record, activating it and re-granting only Viewer, discarding
-// whatever role an admin actually chose. The fix refuses this outright instead
-// of reaching GetOrCreateUser at all.
+// the matched set, so without the ineligible guard control would fall
+// through to auto-provisioning believing no user existed. Here the pending
+// row is visible to ListUsersByEmailAndOrgIDs, so the ineligible guard itself
+// is what refuses the request before CreateUser is ever called; the
+// narrower case where the pending row is invisible to that lookup but
+// present by the time CreateUser runs is pinned separately by
+// TestGetIdentityFailsClosedWhenPendingInviteAppearsBetweenLookupAndCreate.
 func TestGetIdentityRejectsPendingInviteUserEvenWithAutoProvision(t *testing.T) {
 	orgID := valuer.GenerateUUID()
 	email, err := valuer.NewEmail("alice@example.com")
@@ -744,7 +755,7 @@ func TestGetIdentityRejectsPendingInviteUserEvenWithAutoProvision(t *testing.T) 
 
 	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
 	userGetter := &fakeUserGetter{users: []*types.User{pending}}
-	userSetter := (&fakeUserSetter{}).withExisting(pending)
+	userSetter := &fakeUserSetter{}
 
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), orgGetter, userGetter, userSetter)
 
@@ -755,6 +766,44 @@ func TestGetIdentityRejectsPendingInviteUserEvenWithAutoProvision(t *testing.T) 
 	assert.Nil(t, identity)
 	assert.True(t, errors.Asc(err, ErrCodeTrustedHeaderUserNotEligible))
 	assert.Empty(t, userSetter.createdUsers, "auto-provisioning must not run for a known ineligible user")
+}
+
+// TestGetIdentityFailsClosedWhenPendingInviteAppearsBetweenLookupAndCreate is
+// the regression test for the TOCTOU race: the ineligible guard reads the
+// world once, through ListUsersByEmailAndOrgIDs, and CreateUser acts on it
+// much later. An invite created inside that window is invisible to the
+// guard, so unlike the test above, userGetter here returns no users at all
+// (the read sees nothing), yet a pending row for the same email and org
+// already exists by the time CreateUser runs, modelled with withExisting.
+// GetOrCreateUser would have silently adopted that row and activated it;
+// CreateUser has no adoption path, so the fake's conflict simulation (a
+// stand-in for the partial unique index on (email, org_id) WHERE status !=
+// 'deleted') must surface as an error instead, and no identity may be
+// returned.
+func TestGetIdentityFailsClosedWhenPendingInviteAppearsBetweenLookupAndCreate(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+
+	pending, err := types.NewUser("Alice", email, orgID, types.UserStatusPendingInvite)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	// The invite is absent here: the lookup this request performs runs before
+	// the concurrent invite is created, so it sees nothing for this email.
+	userGetter := &fakeUserGetter{}
+	// But by the time CreateUser runs, the row already exists, exactly as it
+	// would in the real store after the concurrent invite committed.
+	userSetter := (&fakeUserSetter{}).withExisting(pending)
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), orgGetter, userGetter, userSetter)
+
+	req := newTrustedRequest("X-Forwarded-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+	assert.Empty(t, userSetter.createdUsers, "the race must fail closed instead of adopting the concurrently created invite")
 }
 
 // TestGetIdentityRejectsDeletedUser pins that a deleted user's email cannot
@@ -785,11 +834,13 @@ func TestGetIdentityRejectsDeletedUser(t *testing.T) {
 
 // TestGetIdentityAutoProvisionsFreshUserWhenOnlyMatchIsDeleted is the mirror
 // of TestGetIdentityRejectsPendingInviteUserEvenWithAutoProvision: a deleted
-// user is not "known but ineligible" the way root and pending are.
-// GetOrCreateUser looks up through GetNonDeletedUserByEmailAndOrgID, which
-// filters on status != deleted (pkg/modules/user/impluser/store.go), so it
-// cannot adopt a deleted row; auto-provisioning must still go on to create a
-// brand new user for this email rather than being refused.
+// user is not "known but ineligible" the way root and pending are, so it is
+// filtered out of the matched set without being counted, and provisioning
+// must proceed. A deleted row sits outside the partial unique index on
+// (email, org_id) WHERE status != 'deleted' (see
+// pkg/sqlmigration/076_drop_user_deleted_at.go), so CreateUser's insert for
+// this email and org never collides with it; a brand new user is created
+// rather than the request being refused or the deleted row adopted.
 func TestGetIdentityAutoProvisionsFreshUserWhenOnlyMatchIsDeleted(t *testing.T) {
 	orgID := valuer.GenerateUUID()
 	email, err := valuer.NewEmail("alice@example.com")
@@ -811,6 +862,44 @@ func TestGetIdentityAutoProvisionsFreshUserWhenOnlyMatchIsDeleted(t *testing.T) 
 	require.NotNil(t, identity)
 	assert.NotEqual(t, deleted.ID, identity.UserID)
 	assert.Len(t, userSetter.createdUsers, 1, "a fresh user should be created rather than the deleted record being adopted")
+}
+
+// TestGetIdentityRejectsMixedDeletedAndPendingUsersForSameEmailAndOrg pins a
+// combination the partial unique index on (email, org_id) WHERE status !=
+// 'deleted' explicitly permits: a deleted row and a pending row can coexist
+// for the same email and org, since only the pending row occupies the live
+// slot the index protects. ListUsersByEmailAndOrgIDs returns both;
+// ErrIfDeleted drops the deleted one uncounted, and the pending one is
+// dropped by the root/pending pass and counted as ineligible, so the request
+// must still be refused with user_not_eligible and nothing created,
+// regardless of AutoProvision.
+func TestGetIdentityRejectsMixedDeletedAndPendingUsersForSameEmailAndOrg(t *testing.T) {
+	for _, autoProvision := range []bool{false, true} {
+		t.Run(fmt.Sprintf("autoProvision=%v", autoProvision), func(t *testing.T) {
+			orgID := valuer.GenerateUUID()
+			email, err := valuer.NewEmail("alice@example.com")
+			require.NoError(t, err)
+
+			deleted, err := types.NewUser("Alice", email, orgID, types.UserStatusDeleted)
+			require.NoError(t, err)
+			pending, err := types.NewUser("Alice", email, orgID, types.UserStatusPendingInvite)
+			require.NoError(t, err)
+
+			orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+			userGetter := &fakeUserGetter{users: []*types.User{deleted, pending}}
+			userSetter := &fakeUserSetter{}
+
+			p := newProvider(t, newConfig("X-Forwarded-Email", "", autoProvision), orgGetter, userGetter, userSetter)
+
+			req := newTrustedRequest("X-Forwarded-Email", "alice@example.com")
+
+			identity, err := p.GetIdentity(req)
+			require.Error(t, err)
+			assert.Nil(t, identity)
+			assert.True(t, errors.Asc(err, ErrCodeTrustedHeaderUserNotEligible))
+			assert.Empty(t, userSetter.createdUsers, "no user should be created for a mixed deleted/pending pair")
+		})
+	}
 }
 
 // Header.Get returns only the first value. A proxy that appends rather than

--- a/pkg/identn/trustedheaderidentn/provider_test.go
+++ b/pkg/identn/trustedheaderidentn/provider_test.go
@@ -265,11 +265,30 @@ func (f *fakeUserSetter) Collect(context.Context, valuer.UUID) (map[string]any, 
 var _ user.Setter = (*fakeUserSetter)(nil)
 
 func newConfig(emailHeader, nameHeader string, autoProvision bool) identn.Config {
+	cfg := identn.Config{
+		TrustedHeader: identn.TrustedHeaderConfig{
+			Enabled:       true,
+			EmailHeaders:  []string{emailHeader},
+			AutoProvision: autoProvision,
+		},
+	}
+
+	if nameHeader != "" {
+		cfg.TrustedHeader.NameHeaders = []string{nameHeader}
+	}
+
+	return cfg
+}
+
+// newConfigWithHeaders is like newConfig but accepts full header lists, so
+// tests can exercise multi-header fallback and precedence behaviour that a
+// single-header config cannot express.
+func newConfigWithHeaders(emailHeaders []string, nameHeaders []string, autoProvision bool) identn.Config {
 	return identn.Config{
 		TrustedHeader: identn.TrustedHeaderConfig{
 			Enabled:       true,
-			EmailHeader:   emailHeader,
-			NameHeader:    nameHeader,
+			EmailHeaders:  emailHeaders,
+			NameHeaders:   nameHeaders,
 			AutoProvision: autoProvision,
 		},
 	}
@@ -557,6 +576,143 @@ func TestGetIdentityRejectsPendingInviteUser(t *testing.T) {
 	identity, err := p.GetIdentity(req)
 	require.Error(t, err)
 	assert.Nil(t, identity)
+}
+
+// Header.Get returns only the first value. A proxy that appends rather than
+// replaces leaves the client's value ahead of the injected one, so the client
+// would choose the identity. Both emails below belong to real active users in
+// the same organization, so without the exactly-one rule this request resolves
+// successfully as the attacker.
+func TestGetIdentityRejectsDuplicateEmailHeaderValues(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+
+	aliceEmail, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+	alice, err := types.NewUser("Alice", aliceEmail, orgID, types.UserStatusActive)
+	require.NoError(t, err)
+
+	attackerEmail, err := valuer.NewEmail("attacker@evil.example")
+	require.NoError(t, err)
+	attacker, err := types.NewUser("Attacker", attackerEmail, orgID, types.UserStatusActive)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{alice, attacker}}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Add("X-Forwarded-Email", "attacker@evil.example")
+	req.Header.Add("X-Forwarded-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+	assert.True(t, errors.Asc(err, ErrCodeTrustedHeaderAmbiguousHeader))
+}
+
+// When the first configured email header is entirely absent from the
+// request, the resolver falls through to the next configured header.
+func TestGetIdentityFallsThroughToSecondEmailHeaderWhenFirstAbsent(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+
+	alice, err := types.NewUser("Alice", email, orgID, types.UserStatusActive)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{alice}}
+
+	cfg := newConfigWithHeaders([]string{"X-Forwarded-Email", "X-Authentik-Email"}, nil, false)
+	p := newProvider(t, cfg, orgGetter, userGetter, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Authentik-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.NoError(t, err)
+	require.NotNil(t, identity)
+	assert.Equal(t, alice.ID, identity.UserID)
+}
+
+// A configured email header that is present but blank is a proxy that failed
+// to authenticate the caller, not a signal to try a less authoritative
+// header. This must be refused rather than falling through to
+// X-Authentik-Email, even though that header carries a real, active user's
+// email in this test.
+func TestGetIdentityRejectsBlankFirstEmailHeaderInsteadOfFallingThrough(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+
+	alice, err := types.NewUser("Alice", email, orgID, types.UserStatusActive)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{alice}}
+
+	cfg := newConfigWithHeaders([]string{"X-Forwarded-Email", "X-Authentik-Email"}, nil, false)
+	p := newProvider(t, cfg, orgGetter, userGetter, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "   ")
+	req.Header.Set("X-Authentik-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+	assert.True(t, errors.Asc(err, ErrCodeTrustedHeaderBlankHeader))
+}
+
+// When the first configured email header carries two values, the request is
+// refused before the second configured header is ever consulted.
+func TestGetIdentityRejectsDuplicateFirstEmailHeaderWithoutConsultingSecond(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+
+	alice, err := types.NewUser("Alice", email, orgID, types.UserStatusActive)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{alice}}
+
+	cfg := newConfigWithHeaders([]string{"X-Forwarded-Email", "X-Authentik-Email"}, nil, false)
+	p := newProvider(t, cfg, orgGetter, userGetter, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Add("X-Forwarded-Email", "attacker@evil.example")
+	req.Header.Add("X-Forwarded-Email", "alice@example.com")
+	req.Header.Set("X-Authentik-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+	assert.True(t, errors.Asc(err, ErrCodeTrustedHeaderAmbiguousHeader))
+}
+
+// A name header carrying more than one value is ignored rather than fatal,
+// so provisioning falls back to the email local part for the display name.
+func TestGetIdentityAutoProvisionUsesEmailLocalPartWhenNameHeaderHasMultipleValues(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userSetter := &fakeUserSetter{}
+
+	cfg := newConfigWithHeaders([]string{"X-Forwarded-Email"}, []string{"X-Forwarded-User"}, true)
+	p := newProvider(t, cfg, orgGetter, &fakeUserGetter{}, userSetter)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "newcomer@example.com")
+	req.Header.Add("X-Forwarded-User", "Newcomer Bob")
+	req.Header.Add("X-Forwarded-User", "Someone Else")
+
+	identity, err := p.GetIdentity(req)
+	require.NoError(t, err)
+	require.NotNil(t, identity)
+
+	require.Len(t, userSetter.createdUsers, 1)
+	assert.Equal(t, "newcomer", userSetter.createdUsers[0].DisplayName)
 }
 
 func TestGetIdentityErrorsWhenEmailMatchesUsersInTwoOrgs(t *testing.T) {

--- a/pkg/identn/trustedheaderidentn/provider_test.go
+++ b/pkg/identn/trustedheaderidentn/provider_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -335,16 +337,33 @@ func TestProviderName(t *testing.T) {
 	assert.Equal(t, authtypes.IdentNProviderTrustedHeader, p.Name())
 }
 
-func TestNewRefusesJWTMode(t *testing.T) {
+// TestNewAcceptsJWTMode pins that jwt mode is a fully supported trust mode,
+// not a placeholder: New must construct a working provider from a valid jwt
+// config rather than refusing it. This replaces a now-obsolete assertion:
+// jwt mode used to be rejected outright at construction time before this
+// checker existed.
+func TestNewAcceptsJWTMode(t *testing.T) {
+	_, jwksURL, _ := newJWKSFixture(t)
+
 	cfg := identn.Config{
 		TrustedHeader: identn.TrustedHeaderConfig{
 			Enabled: true,
-			Trust:   identn.TrustConfig{Mode: identn.TrustModeJWT},
+			Trust: identn.TrustConfig{
+				Mode: identn.TrustModeJWT,
+				JWT: identn.JWTTrustConfig{
+					AssertionHeader: "Teleport-Jwt-Assertion",
+					JWKSURL:         jwksURL,
+					Issuer:          "https://teleport.example",
+					Audience:        "signoz",
+					IdentityClaim:   "sub",
+				},
+			},
 		},
 	}
 
-	_, err := New(context.Background(), instrumentationtest.New().ToProviderSettings(), cfg, &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
-	require.Error(t, err)
+	p, err := New(context.Background(), instrumentationtest.New().ToProviderSettings(), cfg, &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+	require.NoError(t, err)
+	assert.NotNil(t, p)
 }
 
 func TestNewRefusesUnsetTrustMode(t *testing.T) {
@@ -871,4 +890,107 @@ func TestGetIdentityErrorsWhenEmailMatchesUsersInTwoOrgs(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, identity)
 	assert.True(t, errors.Ast(err, errors.TypeInvalidInput))
+}
+
+// TestJWTModeTestTrueButGetIdentityFailsOnGarbageAssertion pins a deliberate
+// asymmetry that is specific to jwt mode: Check (and therefore Test) only
+// counts assertion headers, since Test must stay free of I/O, so a request
+// carrying a garbage assertion still makes Test report true. The real
+// verification happens in Email, called only from GetIdentity, which must
+// then fail. That sequence is correct and must not be "fixed" by moving
+// signature verification into Check or Test.
+func TestJWTModeTestTrueButGetIdentityFailsOnGarbageAssertion(t *testing.T) {
+	_, jwksURL, _ := newJWKSFixture(t)
+
+	cfg := identn.Config{
+		TrustedHeader: identn.TrustedHeaderConfig{
+			Enabled: true,
+			Trust: identn.TrustConfig{
+				Mode: identn.TrustModeJWT,
+				JWT: identn.JWTTrustConfig{
+					AssertionHeader: "Teleport-Jwt-Assertion",
+					JWKSURL:         jwksURL,
+					Issuer:          "https://teleport.example",
+					Audience:        "signoz",
+					IdentityClaim:   "sub",
+				},
+			},
+		},
+	}
+
+	p := newProvider(t, cfg, &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Teleport-Jwt-Assertion", "garbage")
+
+	assert.True(t, p.Test(req))
+
+	identity, err := p.GetIdentity(req)
+	assert.Error(t, err)
+	assert.Nil(t, identity)
+}
+
+// TestJWTModeIgnoresEmailHeadersEvenWhenRootMatches pins the defining
+// property of jwt mode: GetIdentity takes the identity only from the
+// verified assertion (trust.Email), and never consults EmailHeaders, even
+// when a client-supplied header on the very same request would resolve to a
+// different, more privileged user. Both alice (matching the assertion) and
+// root (matching the header) exist in the store, so if GetIdentity ever
+// preferred the header, this test would not silently pass as root (root is
+// filtered out of eligible users), but it would still fail, since
+// auto-provisioning is disabled and no non-root user would remain: the FIX 3
+// experiment in the task report demonstrates exactly that failure mode.
+func TestJWTModeIgnoresEmailHeadersEvenWhenRootMatches(t *testing.T) {
+	key, jwksURL, kid := newJWKSFixture(t)
+
+	orgID := valuer.GenerateUUID()
+
+	aliceEmail, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+	alice, err := types.NewUser("Alice", aliceEmail, orgID, types.UserStatusActive)
+	require.NoError(t, err)
+
+	rootEmail, err := valuer.NewEmail("root@example.com")
+	require.NoError(t, err)
+	rootUser, err := types.NewRootUser("Root", rootEmail, orgID)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{alice, rootUser}}
+
+	cfg := identn.Config{
+		TrustedHeader: identn.TrustedHeaderConfig{
+			Enabled:      true,
+			EmailHeaders: []string{"X-Forwarded-Email"},
+			Trust: identn.TrustConfig{
+				Mode: identn.TrustModeJWT,
+				JWT: identn.JWTTrustConfig{
+					AssertionHeader: "Teleport-Jwt-Assertion",
+					JWKSURL:         jwksURL,
+					Issuer:          "https://teleport.example",
+					Audience:        "signoz",
+					IdentityClaim:   "sub",
+				},
+			},
+		},
+	}
+
+	p := newProvider(t, cfg, orgGetter, userGetter, &fakeUserSetter{})
+
+	assertion := signAssertion(t, key, kid, jwt.MapClaims{
+		"iss": "https://teleport.example",
+		"aud": "signoz",
+		"sub": "alice@example.com",
+		"exp": time.Now().Add(time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Teleport-Jwt-Assertion", assertion)
+	req.Header.Set("X-Forwarded-Email", "root@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.NoError(t, err)
+	require.NotNil(t, identity)
+	assert.Equal(t, alice.ID, identity.UserID)
+	assert.NotEqual(t, rootUser.ID, identity.UserID)
 }

--- a/pkg/identn/trustedheaderidentn/provider_test.go
+++ b/pkg/identn/trustedheaderidentn/provider_test.go
@@ -162,6 +162,15 @@ var _ user.Getter = (*fakeUserGetter)(nil)
 type fakeUserSetter struct {
 	createdUsers []*types.User
 	autoFail     bool
+	existing     []*types.User
+}
+
+// existing returns a pre-existing user for a matching email and org, mirroring
+// impluser.GetOrCreateUser, which short-circuits on
+// GetNonDeletedUserByEmailAndOrgID before creating anything.
+func (f *fakeUserSetter) withExisting(users ...*types.User) *fakeUserSetter {
+	f.existing = append(f.existing, users...)
+	return f
 }
 
 func (f *fakeUserSetter) CreateFirstUser(context.Context, *types.Organization, string, valuer.Email, string) (*types.User, error) {
@@ -179,6 +188,11 @@ func (f *fakeUserSetter) CreateUser(_ context.Context, u *types.User, _ ...user.
 func (f *fakeUserSetter) GetOrCreateUser(_ context.Context, u *types.User, _ ...user.CreateUserOption) (*types.User, error) {
 	if f.autoFail {
 		return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "get or create user failed")
+	}
+	for _, e := range f.existing {
+		if e.Email == u.Email && e.OrgID == u.OrgID {
+			return e, nil
+		}
 	}
 	f.createdUsers = append(f.createdUsers, u)
 	return u, nil
@@ -449,6 +463,32 @@ func TestGetIdentityRejectsRootUser(t *testing.T) {
 	userGetter := &fakeUserGetter{users: []*types.User{rootUser}}
 
 	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "root@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+}
+
+// The root user is filtered out of the lookup, so control reaches the
+// provisioning branch, where GetOrCreateUser finds the existing root record and
+// returns it. Without a post-create guard the provider mints an identity for
+// root, which always holds the admin role.
+func TestGetIdentityDoesNotProvisionIntoRootUser(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("root@example.com")
+	require.NoError(t, err)
+
+	rootUser, err := types.NewRootUser("Root", email, orgID)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{rootUser}}
+	userSetter := (&fakeUserSetter{}).withExisting(rootUser)
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), orgGetter, userGetter, userSetter)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("X-Forwarded-Email", "root@example.com")

--- a/pkg/identn/trustedheaderidentn/provider_test.go
+++ b/pkg/identn/trustedheaderidentn/provider_test.go
@@ -1,0 +1,459 @@
+package trustedheaderidentn
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/identn"
+	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
+	"github.com/SigNoz/signoz/pkg/modules/organization"
+	"github.com/SigNoz/signoz/pkg/modules/user"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/authtypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+)
+
+// fakeOrgGetter is a minimal organization.Getter test double.
+type fakeOrgGetter struct {
+	orgs []*types.Organization
+}
+
+func (f *fakeOrgGetter) Get(ctx context.Context, id valuer.UUID) (*types.Organization, error) {
+	for _, org := range f.orgs {
+		if org.ID == id {
+			return org, nil
+		}
+	}
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "organization not found")
+}
+
+func (f *fakeOrgGetter) GetByIDOrName(ctx context.Context, id valuer.UUID, name string) (*types.Organization, bool, error) {
+	for _, org := range f.orgs {
+		if org.ID == id {
+			return org, false, nil
+		}
+	}
+	for _, org := range f.orgs {
+		if org.Name == name {
+			return org, true, nil
+		}
+	}
+	return nil, false, errors.New(errors.TypeNotFound, errors.CodeNotFound, "organization not found")
+}
+
+func (f *fakeOrgGetter) ListByOwnedKeyRange(ctx context.Context) ([]*types.Organization, error) {
+	return f.orgs, nil
+}
+
+func (f *fakeOrgGetter) GetByName(ctx context.Context, name string) (*types.Organization, error) {
+	for _, org := range f.orgs {
+		if org.Name == name {
+			return org, nil
+		}
+	}
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "organization not found")
+}
+
+var _ organization.Getter = (*fakeOrgGetter)(nil)
+
+// fakeUserGetter is a minimal user.Getter test double; only methods used by
+// the trusted-header IdentN need real behaviour.
+type fakeUserGetter struct {
+	users []*types.User
+}
+
+func (f *fakeUserGetter) GetRootUserByOrgID(context.Context, valuer.UUID) (*types.User, []*authtypes.UserRole, error) {
+	return nil, nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "not implemented")
+}
+
+func (f *fakeUserGetter) ListDeprecatedUsersByOrgID(context.Context, valuer.UUID) ([]*types.DeprecatedUser, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) ListUsersByOrgID(context.Context, valuer.UUID) ([]*types.User, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) GetDeprecatedUserByOrgIDAndID(context.Context, valuer.UUID, valuer.UUID) (*types.DeprecatedUser, error) {
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "not implemented")
+}
+
+func (f *fakeUserGetter) GetUserByOrgIDAndID(context.Context, valuer.UUID, valuer.UUID) (*types.User, error) {
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "not implemented")
+}
+
+func (f *fakeUserGetter) Get(context.Context, valuer.UUID) (*types.DeprecatedUser, error) {
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "not implemented")
+}
+
+func (f *fakeUserGetter) ListUsersByEmailAndOrgIDs(_ context.Context, email valuer.Email, orgIDs []valuer.UUID) ([]*types.User, error) {
+	matches := make([]*types.User, 0)
+	for _, u := range f.users {
+		if u.Email != email {
+			continue
+		}
+		for _, orgID := range orgIDs {
+			if u.OrgID == orgID {
+				matches = append(matches, u)
+				break
+			}
+		}
+	}
+	return matches, nil
+}
+
+func (f *fakeUserGetter) CountByOrgID(context.Context, valuer.UUID) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeUserGetter) CountByOrgIDAndStatuses(context.Context, valuer.UUID, []string) (map[valuer.String]int64, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) GetFactorPasswordByUserID(context.Context, valuer.UUID) (*types.FactorPassword, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) GetResetPasswordTokenByOrgIDAndUserID(context.Context, valuer.UUID, valuer.UUID) (*types.ResetPasswordToken, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) GetNonDeletedUserByEmailAndOrgID(_ context.Context, email valuer.Email, orgID valuer.UUID) (*types.User, error) {
+	for _, u := range f.users {
+		if u.Email == email && u.OrgID == orgID && u.ErrIfDeleted() == nil {
+			return u, nil
+		}
+	}
+	return nil, errors.New(errors.TypeNotFound, types.ErrCodeUserNotFound, "user not found")
+}
+
+func (f *fakeUserGetter) GetRolesByUserID(context.Context, valuer.UUID) ([]*authtypes.UserRole, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) GetUsersByOrgIDAndRoleID(context.Context, valuer.UUID, valuer.UUID) ([]*types.User, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) OnBeforeRoleDelete(context.Context, valuer.UUID, valuer.UUID, string) error {
+	return nil
+}
+
+func (f *fakeUserGetter) GetUserRoleByOrgIDAndID(context.Context, valuer.UUID, valuer.UUID) (*authtypes.UserRole, error) {
+	return nil, nil
+}
+
+func (f *fakeUserGetter) VerifyResetPasswordToken(context.Context, string) error {
+	return nil
+}
+
+var _ user.Getter = (*fakeUserGetter)(nil)
+
+// fakeUserSetter records the last user passed to GetOrCreateUser.
+//
+// Most methods are stubs returning nil/zero — they exist purely to satisfy the
+// user.Setter interface. Only GetOrCreateUser is exercised by these tests.
+type fakeUserSetter struct {
+	createdUsers []*types.User
+	autoFail     bool
+}
+
+func (f *fakeUserSetter) CreateFirstUser(context.Context, *types.Organization, string, valuer.Email, string) (*types.User, error) {
+	return nil, nil
+}
+
+func (f *fakeUserSetter) CreateUser(_ context.Context, u *types.User, _ ...user.CreateUserOption) error {
+	if f.autoFail {
+		return errors.New(errors.TypeInternal, errors.CodeInternal, "create user failed")
+	}
+	f.createdUsers = append(f.createdUsers, u)
+	return nil
+}
+
+func (f *fakeUserSetter) GetOrCreateUser(_ context.Context, u *types.User, _ ...user.CreateUserOption) (*types.User, error) {
+	if f.autoFail {
+		return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "get or create user failed")
+	}
+	f.createdUsers = append(f.createdUsers, u)
+	return u, nil
+}
+
+func (f *fakeUserSetter) GetOrCreateResetPasswordToken(context.Context, valuer.UUID) (*types.ResetPasswordToken, error) {
+	return nil, nil
+}
+
+func (f *fakeUserSetter) UpdatePasswordByResetPasswordToken(context.Context, string, string) error {
+	return nil
+}
+
+func (f *fakeUserSetter) UpdatePassword(context.Context, valuer.UUID, string, string) error {
+	return nil
+}
+
+func (f *fakeUserSetter) ForgotPassword(context.Context, valuer.UUID, valuer.Email, string) error {
+	return nil
+}
+
+func (f *fakeUserSetter) UpdateUserDeprecated(context.Context, valuer.UUID, string, *types.DeprecatedUser) (*types.DeprecatedUser, error) {
+	return nil, nil
+}
+
+func (f *fakeUserSetter) UpdateUser(context.Context, valuer.UUID, valuer.UUID, *types.UpdatableUser) (*types.User, error) {
+	return nil, nil
+}
+
+func (f *fakeUserSetter) UpdateAnyUserDeprecated(context.Context, valuer.UUID, *types.DeprecatedUser) error {
+	return nil
+}
+
+func (f *fakeUserSetter) UpdateAnyUser(context.Context, valuer.UUID, *types.User) error {
+	return nil
+}
+
+func (f *fakeUserSetter) DeleteUser(context.Context, valuer.UUID, string, string) error {
+	return nil
+}
+
+func (f *fakeUserSetter) CreateBulkInvite(context.Context, valuer.UUID, valuer.UUID, valuer.Email, *types.PostableBulkInviteRequest) ([]*types.Invite, error) {
+	return nil, nil
+}
+
+func (f *fakeUserSetter) UpdateUserRoles(context.Context, valuer.UUID, valuer.UUID, []string) error {
+	return nil
+}
+
+func (f *fakeUserSetter) CreatePendingInviteUser(context.Context, valuer.UUID, valuer.Email, string, *types.User, ...user.CreateUserOption) (*types.User, error) {
+	return nil, nil
+}
+
+func (f *fakeUserSetter) AddUserRole(context.Context, valuer.UUID, valuer.UUID, string) (*authtypes.UserRole, error) {
+	return nil, nil
+}
+
+func (f *fakeUserSetter) AddUserRoleByRoleID(context.Context, valuer.UUID, valuer.UUID, valuer.UUID) (*authtypes.UserRole, error) {
+	return nil, nil
+}
+
+func (f *fakeUserSetter) RemoveUserRole(context.Context, valuer.UUID, valuer.UUID, valuer.UUID) error {
+	return nil
+}
+
+func (f *fakeUserSetter) Collect(context.Context, valuer.UUID) (map[string]any, error) {
+	return nil, nil
+}
+
+var _ user.Setter = (*fakeUserSetter)(nil)
+
+func newConfig(emailHeader, nameHeader string, autoProvision bool) identn.Config {
+	return identn.Config{
+		TrustedHeader: identn.TrustedHeaderConfig{
+			Enabled:       true,
+			EmailHeader:   emailHeader,
+			NameHeader:    nameHeader,
+			AutoProvision: autoProvision,
+		},
+	}
+}
+
+func newProvider(t *testing.T, cfg identn.Config, orgGetter organization.Getter, userGetter user.Getter, userSetter user.Setter) identn.IdentN {
+	t.Helper()
+
+	p, err := New(context.Background(), instrumentationtest.New().ToProviderSettings(), cfg, orgGetter, userGetter, userSetter)
+	require.NoError(t, err)
+
+	return p
+}
+
+func TestProviderName(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	assert.Equal(t, authtypes.IdentNProviderTrustedHeader, p.Name())
+}
+
+func TestTestReturnsTrueWhenHeaderPresent(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+
+	assert.True(t, p.Test(req))
+}
+
+func TestTestReturnsFalseWhenHeaderMissing(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	assert.False(t, p.Test(req))
+}
+
+func TestTestReturnsFalseWhenHeaderBlank(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "   ")
+
+	assert.False(t, p.Test(req))
+}
+
+func TestGetIdentityReturnsExistingUser(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+
+	existing, err := types.NewUser("Alice", email, orgID, types.UserStatusActive)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{existing}}
+	userSetter := &fakeUserSetter{}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, userSetter)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.NoError(t, err)
+	require.NotNil(t, identity)
+
+	assert.Equal(t, existing.ID, identity.UserID)
+	assert.Equal(t, orgID, identity.OrgID)
+	assert.Equal(t, email, identity.Email)
+	assert.Equal(t, authtypes.PrincipalUser, identity.Principal)
+	assert.Equal(t, authtypes.IdentNProviderTrustedHeader, identity.IdenNProvider)
+	assert.Empty(t, userSetter.createdUsers, "expected no auto-provisioned users")
+}
+
+func TestGetIdentityErrorsWhenHeaderMissing(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+	assert.True(t, errors.Ast(err, errors.TypeUnauthenticated), "expected unauthenticated error type")
+}
+
+func TestGetIdentityErrorsWhenEmailInvalid(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "not-an-email")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+}
+
+func TestGetIdentityErrorsWhenUserUnknownAndAutoProvisionDisabled(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "ghost@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+	assert.True(t, errors.Ast(err, errors.TypeUnauthenticated), "expected unauthenticated error type")
+}
+
+func TestGetIdentityAutoProvisionsWhenEnabled(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userSetter := &fakeUserSetter{}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "X-Forwarded-User", true), orgGetter, &fakeUserGetter{}, userSetter)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "newcomer@example.com")
+	req.Header.Set("X-Forwarded-User", "Newcomer Bob")
+
+	identity, err := p.GetIdentity(req)
+	require.NoError(t, err)
+	require.NotNil(t, identity)
+	assert.Equal(t, orgID, identity.OrgID)
+	assert.Equal(t, "newcomer@example.com", identity.Email.StringValue())
+	assert.Equal(t, authtypes.IdentNProviderTrustedHeader, identity.IdenNProvider)
+
+	require.Len(t, userSetter.createdUsers, 1)
+	assert.Equal(t, "Newcomer Bob", userSetter.createdUsers[0].DisplayName)
+	assert.Equal(t, orgID, userSetter.createdUsers[0].OrgID)
+}
+
+func TestGetIdentityAutoProvisionUsesEmailLocalPartWhenNoNameHeader(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userSetter := &fakeUserSetter{}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), orgGetter, &fakeUserGetter{}, userSetter)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "carol@example.com")
+
+	_, err := p.GetIdentity(req)
+	require.NoError(t, err)
+
+	require.Len(t, userSetter.createdUsers, 1)
+	assert.Equal(t, "carol", userSetter.createdUsers[0].DisplayName)
+}
+
+func TestGetIdentityRefusesAutoProvisionWithMultipleOrgs(t *testing.T) {
+	orgGetter := &fakeOrgGetter{
+		orgs: []*types.Organization{
+			{Identifiable: types.Identifiable{ID: valuer.GenerateUUID()}, Name: "one"},
+			{Identifiable: types.Identifiable{ID: valuer.GenerateUUID()}, Name: "two"},
+		},
+	}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), orgGetter, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "newcomer@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+}
+
+func TestGetIdentityErrorsWhenNoOrganization(t *testing.T) {
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+}
+
+func TestGetIdentityRejectsRootUser(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("root@example.com")
+	require.NoError(t, err)
+
+	rootUser, err := types.NewRootUser("Root", email, orgID)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{rootUser}}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "root@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+}

--- a/pkg/identn/trustedheaderidentn/provider_test.go
+++ b/pkg/identn/trustedheaderidentn/provider_test.go
@@ -457,3 +457,43 @@ func TestGetIdentityRejectsRootUser(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, identity)
 }
+
+// Multi-org case: when ListUsersByEmailAndOrgIDs returns both a root user
+// and a regular user for the same email, the resolver must skip the root
+// and pick the non-root regardless of slice order — DB query order is not
+// guaranteed.
+func TestGetIdentityPicksNonRootWhenRootAndRegularShareEmail(t *testing.T) {
+	rootOrgID := valuer.GenerateUUID()
+	regularOrgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("shared@example.com")
+	require.NoError(t, err)
+
+	rootUser, err := types.NewRootUser("Root", email, rootOrgID)
+	require.NoError(t, err)
+	regularUser, err := types.NewUser("Regular", email, regularOrgID, types.UserStatusActive)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{
+		{Identifiable: types.Identifiable{ID: rootOrgID}, Name: "root-org"},
+		{Identifiable: types.Identifiable{ID: regularOrgID}, Name: "regular-org"},
+	}}
+
+	// Iterate both possible slice orderings so the test fails the same way
+	// regardless of whether the DB returns the root or the regular user first.
+	for _, ordering := range [][]*types.User{
+		{rootUser, regularUser},
+		{regularUser, rootUser},
+	} {
+		userGetter := &fakeUserGetter{users: ordering}
+		p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("X-Forwarded-Email", "shared@example.com")
+
+		identity, err := p.GetIdentity(req)
+		require.NoError(t, err)
+		require.NotNil(t, identity)
+		assert.Equal(t, regularUser.ID, identity.UserID)
+		assert.Equal(t, regularOrgID, identity.OrgID)
+	}
+}

--- a/pkg/identn/trustedheaderidentn/provider_test.go
+++ b/pkg/identn/trustedheaderidentn/provider_test.go
@@ -497,3 +497,51 @@ func TestGetIdentityPicksNonRootWhenRootAndRegularShareEmail(t *testing.T) {
 		assert.Equal(t, regularOrgID, identity.OrgID)
 	}
 }
+
+func TestGetIdentityRejectsPendingInviteUser(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+
+	pending, err := types.NewUser("Alice", email, orgID, types.UserStatusPendingInvite)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{pending}}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+}
+
+func TestGetIdentityErrorsWhenEmailMatchesUsersInTwoOrgs(t *testing.T) {
+	orgA, orgB := valuer.GenerateUUID(), valuer.GenerateUUID()
+	email, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+
+	userA, err := types.NewUser("Alice", email, orgA, types.UserStatusActive)
+	require.NoError(t, err)
+	userB, err := types.NewUser("Alice", email, orgB, types.UserStatusActive)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{
+		{Identifiable: types.Identifiable{ID: orgA}, Name: "a"},
+		{Identifiable: types.Identifiable{ID: orgB}, Name: "b"},
+	}}
+	userGetter := &fakeUserGetter{users: []*types.User{userA, userB}}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+	assert.True(t, errors.Ast(err, errors.TypeInvalidInput))
+}

--- a/pkg/identn/trustedheaderidentn/provider_test.go
+++ b/pkg/identn/trustedheaderidentn/provider_test.go
@@ -116,15 +116,15 @@ func (f *fakeUserGetter) CountByOrgID(context.Context, valuer.UUID) (int64, erro
 }
 
 func (f *fakeUserGetter) CountByOrgIDAndStatuses(context.Context, valuer.UUID, []string) (map[valuer.String]int64, error) {
-	return nil, nil
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "not implemented")
 }
 
 func (f *fakeUserGetter) GetFactorPasswordByUserID(context.Context, valuer.UUID) (*types.FactorPassword, error) {
-	return nil, nil
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "not implemented")
 }
 
 func (f *fakeUserGetter) GetResetPasswordTokenByOrgIDAndUserID(context.Context, valuer.UUID, valuer.UUID) (*types.ResetPasswordToken, error) {
-	return nil, nil
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "not implemented")
 }
 
 func (f *fakeUserGetter) GetNonDeletedUserByEmailAndOrgID(_ context.Context, email valuer.Email, orgID valuer.UUID) (*types.User, error) {
@@ -149,7 +149,7 @@ func (f *fakeUserGetter) OnBeforeRoleDelete(context.Context, valuer.UUID, valuer
 }
 
 func (f *fakeUserGetter) GetUserRoleByOrgIDAndID(context.Context, valuer.UUID, valuer.UUID) (*authtypes.UserRole, error) {
-	return nil, nil
+	return nil, errors.New(errors.TypeNotFound, errors.CodeNotFound, "not implemented")
 }
 
 func (f *fakeUserGetter) VerifyResetPasswordToken(context.Context, string) error {
@@ -160,7 +160,7 @@ var _ user.Getter = (*fakeUserGetter)(nil)
 
 // fakeUserSetter records the users passed to CreateUser.
 //
-// Most methods are stubs returning nil/zero — they exist purely to satisfy the
+// Most methods are stubs returning nil/zero: they exist purely to satisfy the
 // user.Setter interface. Only CreateUser is exercised by these tests;
 // GetIdentity no longer calls GetOrCreateUser (see provider.go), so that
 // method is kept only to satisfy the interface and is not used to model any
@@ -184,7 +184,7 @@ func (f *fakeUserSetter) withExisting(users ...*types.User) *fakeUserSetter {
 }
 
 func (f *fakeUserSetter) CreateFirstUser(context.Context, *types.Organization, string, valuer.Email, string) (*types.User, error) {
-	return nil, nil
+	return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "not implemented")
 }
 
 func (f *fakeUserSetter) CreateUser(_ context.Context, u *types.User, _ ...user.CreateUserOption) error {
@@ -205,7 +205,7 @@ func (f *fakeUserSetter) GetOrCreateUser(context.Context, *types.User, ...user.C
 }
 
 func (f *fakeUserSetter) GetOrCreateResetPasswordToken(context.Context, valuer.UUID) (*types.ResetPasswordToken, error) {
-	return nil, nil
+	return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "not implemented")
 }
 
 func (f *fakeUserSetter) UpdatePasswordByResetPasswordToken(context.Context, string, string) error {
@@ -221,11 +221,11 @@ func (f *fakeUserSetter) ForgotPassword(context.Context, valuer.UUID, valuer.Ema
 }
 
 func (f *fakeUserSetter) UpdateUserDeprecated(context.Context, valuer.UUID, string, *types.DeprecatedUser) (*types.DeprecatedUser, error) {
-	return nil, nil
+	return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "not implemented")
 }
 
 func (f *fakeUserSetter) UpdateUser(context.Context, valuer.UUID, valuer.UUID, *types.UpdatableUser) (*types.User, error) {
-	return nil, nil
+	return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "not implemented")
 }
 
 func (f *fakeUserSetter) UpdateAnyUserDeprecated(context.Context, valuer.UUID, *types.DeprecatedUser) error {
@@ -249,15 +249,15 @@ func (f *fakeUserSetter) UpdateUserRoles(context.Context, valuer.UUID, valuer.UU
 }
 
 func (f *fakeUserSetter) CreatePendingInviteUser(context.Context, valuer.UUID, valuer.Email, string, *types.User, ...user.CreateUserOption) (*types.User, error) {
-	return nil, nil
+	return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "not implemented")
 }
 
 func (f *fakeUserSetter) AddUserRole(context.Context, valuer.UUID, valuer.UUID, string) (*authtypes.UserRole, error) {
-	return nil, nil
+	return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "not implemented")
 }
 
 func (f *fakeUserSetter) AddUserRoleByRoleID(context.Context, valuer.UUID, valuer.UUID, valuer.UUID) (*authtypes.UserRole, error) {
-	return nil, nil
+	return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "not implemented")
 }
 
 func (f *fakeUserSetter) RemoveUserRole(context.Context, valuer.UUID, valuer.UUID, valuer.UUID) error {
@@ -265,7 +265,7 @@ func (f *fakeUserSetter) RemoveUserRole(context.Context, valuer.UUID, valuer.UUI
 }
 
 func (f *fakeUserSetter) Collect(context.Context, valuer.UUID) (map[string]any, error) {
-	return nil, nil
+	return nil, errors.New(errors.TypeInternal, errors.CodeInternal, "not implemented")
 }
 
 var _ user.Setter = (*fakeUserSetter)(nil)
@@ -316,7 +316,13 @@ func newConfigWithHeaders(emailHeaders []string, nameHeaders []string, autoProvi
 // header the email is set under; it must match the provider's configured
 // email header, since a mismatch here would silently exercise the "header
 // absent" path instead of the one the test intends. Tests exercising
-// multi-value or multi-header setups build the request directly instead.
+// multi-value or multi-header setups build the request directly instead, so
+// every current caller happens to pass "X-Forwarded-Email". header stays a
+// parameter anyway: hardcoding it here would silently break the first test
+// that configures a different single email header, exactly the mismatch this
+// function exists to prevent (see above).
+//
+//nolint:unparam // kept to prevent a silent header mismatch; see comment above
 func newTrustedRequest(header, email string) *http.Request {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set(testSecretHeader, testSecretValue)
@@ -335,8 +341,11 @@ func newProvider(t *testing.T, cfg identn.Config, orgGetter organization.Getter,
 	return p
 }
 
+// The email header below is deliberately not X-Forwarded-Email: Name() never
+// looks at the request, so this pins that newConfig's emailHeader is honored
+// verbatim regardless of which header an operator configures.
 func TestProviderName(t *testing.T) {
-	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
+	p := newProvider(t, newConfig("X-Custom-Auth-Email", "", false), &fakeOrgGetter{}, &fakeUserGetter{}, &fakeUserSetter{})
 
 	assert.Equal(t, authtypes.IdentNProviderTrustedHeader, p.Name())
 }
@@ -677,7 +686,7 @@ func TestGetIdentityDoesNotProvisionIntoRootUser(t *testing.T) {
 
 // Multi-org case: when ListUsersByEmailAndOrgIDs returns both a root user
 // and a regular user for the same email, the resolver must skip the root
-// and pick the non-root regardless of slice order — DB query order is not
+// and pick the non-root regardless of slice order - DB query order is not
 // guaranteed.
 func TestGetIdentityPicksNonRootWhenRootAndRegularShareEmail(t *testing.T) {
 	rootOrgID := valuer.GenerateUUID()

--- a/pkg/identn/trustedheaderidentn/provider_test.go
+++ b/pkg/identn/trustedheaderidentn/provider_test.go
@@ -724,6 +724,95 @@ func TestGetIdentityRejectsPendingInviteUser(t *testing.T) {
 	assert.Nil(t, identity)
 }
 
+// TestGetIdentityRejectsPendingInviteUserEvenWithAutoProvision pins the
+// escalation TestGetIdentityRejectsPendingInviteUser could not reach: that
+// test runs with autoProvision=false, so it never exercises the provisioning
+// branch. With autoProvision=true, a pending user is still filtered out of
+// the matched set, so control used to fall through to auto-provisioning
+// believing no user existed. GetOrCreateUser (primed here via withExisting to
+// mirror GetNonDeletedUserByEmailAndOrgID finding the pending row) would then
+// adopt that record, activating it and re-granting only Viewer, discarding
+// whatever role an admin actually chose. The fix refuses this outright instead
+// of reaching GetOrCreateUser at all.
+func TestGetIdentityRejectsPendingInviteUserEvenWithAutoProvision(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+
+	pending, err := types.NewUser("Alice", email, orgID, types.UserStatusPendingInvite)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{pending}}
+	userSetter := (&fakeUserSetter{}).withExisting(pending)
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), orgGetter, userGetter, userSetter)
+
+	req := newTrustedRequest("X-Forwarded-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+	assert.True(t, errors.Asc(err, ErrCodeTrustedHeaderUserNotEligible))
+	assert.Empty(t, userSetter.createdUsers, "auto-provisioning must not run for a known ineligible user")
+}
+
+// TestGetIdentityRejectsDeletedUser pins that a deleted user's email cannot
+// authenticate. ListUsersByEmailAndOrgIDs (pkg/modules/user/impluser/store.go)
+// applies no status filter at all, so the only thing keeping a deleted record
+// out of the matched set is the in-provider ErrIfDeleted check; this test
+// exists because nothing previously asserted that check directly, which is
+// exactly why a prior edit could drop it unnoticed.
+func TestGetIdentityRejectsDeletedUser(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+
+	deleted, err := types.NewUser("Alice", email, orgID, types.UserStatusDeleted)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{deleted}}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", false), orgGetter, userGetter, &fakeUserSetter{})
+
+	req := newTrustedRequest("X-Forwarded-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.Error(t, err)
+	assert.Nil(t, identity)
+}
+
+// TestGetIdentityAutoProvisionsFreshUserWhenOnlyMatchIsDeleted is the mirror
+// of TestGetIdentityRejectsPendingInviteUserEvenWithAutoProvision: a deleted
+// user is not "known but ineligible" the way root and pending are.
+// GetOrCreateUser looks up through GetNonDeletedUserByEmailAndOrgID, which
+// filters on status != deleted (pkg/modules/user/impluser/store.go), so it
+// cannot adopt a deleted row; auto-provisioning must still go on to create a
+// brand new user for this email rather than being refused.
+func TestGetIdentityAutoProvisionsFreshUserWhenOnlyMatchIsDeleted(t *testing.T) {
+	orgID := valuer.GenerateUUID()
+	email, err := valuer.NewEmail("alice@example.com")
+	require.NoError(t, err)
+
+	deleted, err := types.NewUser("Alice", email, orgID, types.UserStatusDeleted)
+	require.NoError(t, err)
+
+	orgGetter := &fakeOrgGetter{orgs: []*types.Organization{{Identifiable: types.Identifiable{ID: orgID}, Name: "default"}}}
+	userGetter := &fakeUserGetter{users: []*types.User{deleted}}
+	userSetter := &fakeUserSetter{}
+
+	p := newProvider(t, newConfig("X-Forwarded-Email", "", true), orgGetter, userGetter, userSetter)
+
+	req := newTrustedRequest("X-Forwarded-Email", "alice@example.com")
+
+	identity, err := p.GetIdentity(req)
+	require.NoError(t, err)
+	require.NotNil(t, identity)
+	assert.NotEqual(t, deleted.ID, identity.UserID)
+	assert.Len(t, userSetter.createdUsers, 1, "a fresh user should be created rather than the deleted record being adopted")
+}
+
 // Header.Get returns only the first value. A proxy that appends rather than
 // replaces leaves the client's value ahead of the injected one, so the client
 // would choose the identity. Both emails below belong to real active users in

--- a/pkg/identn/trustedheaderidentn/trust.go
+++ b/pkg/identn/trustedheaderidentn/trust.go
@@ -26,7 +26,9 @@ var (
 // trust establishes that a request genuinely came from the trusted proxy.
 type trust interface {
 	// Check returns nil when the request carries acceptable proof of provenance.
-	// It must be free of I/O, because it is called from Test.
+	// It must be free of I/O, because it is called from Test, and GetIdentity
+	// also calls it directly, on the request's own goroutine, before doing any
+	// of its own I/O.
 	Check(req *http.Request) error
 
 	// CarriesIdentity reports whether the proof itself carries the user's

--- a/pkg/identn/trustedheaderidentn/trust.go
+++ b/pkg/identn/trustedheaderidentn/trust.go
@@ -1,9 +1,17 @@
 package trustedheaderidentn
 
 import (
+	"context"
 	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/json"
+	"math"
 	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/identn"
@@ -11,6 +19,7 @@ import (
 
 var (
 	ErrCodeTrustedHeaderUntrusted        = errors.MustNewCode("trusted_header_untrusted_request")
+	ErrCodeTrustedHeaderInvalidAssertion = errors.MustNewCode("trusted_header_invalid_assertion")
 	ErrCodeTrustedHeaderSecretNoIdentity = errors.MustNewCode("trusted_header_secret_no_identity")
 )
 
@@ -74,3 +83,194 @@ func (t *secretTrust) Email(_ *http.Request) (string, error) {
 }
 
 var _ trust = (*secretTrust)(nil)
+
+// jwksFetchTimeout bounds a single JWKS fetch. go-oidc's RemoteKeySet fetches
+// with http.DefaultClient when no client is attached to its context, and
+// http.DefaultClient has no timeout; RemoteKeySet also stores
+// context.WithoutCancel(ctx) internally, so the fetch cannot be cancelled
+// from outside either. The request context reaching Email carries no
+// deadline of its own: middleware.NewIdentN is registered before
+// middleware.NewTimeout in pkg/query-service/app/server.go, and gorilla/mux
+// wraps middleware in reverse registration order, which makes IdentN the
+// outer handler, running before the timeout middleware ever attaches a
+// deadline. Without an explicit client timeout, a JWKS endpoint that accepts
+// a connection and then stops responding would pin a goroutine and a
+// connection per request, with no self-healing.
+const jwksFetchTimeout = 10 * time.Second
+
+// jwtTrust verifies a signed assertion against a remote key set. Unlike
+// secret mode, nothing an attacker can read from inside the cluster lets
+// them forge one.
+type jwtTrust struct {
+	config identn.JWTTrustConfig
+	keySet *oidc.RemoteKeySet
+}
+
+// newJWTTrust takes ctx from the provider factory, which is process-lifetime
+// rather than startup-scoped. That matters here only as a source of values,
+// not for cancellation: go-oidc v3.17.0 stores context.WithoutCancel(ctx)
+// internally (oidc/jwks.go), so a cancellable or deadlined ctx passed in
+// would neither cancel background refreshes early nor leak them anyway.
+// What ctx does carry, through oidc.ClientContext, is the HTTP client used
+// for every fetch; that client has jwksFetchTimeout set precisely because
+// the context mechanism cannot bound the fetch itself.
+func newJWTTrust(ctx context.Context, config identn.JWTTrustConfig) *jwtTrust {
+	client := &http.Client{Timeout: jwksFetchTimeout}
+
+	return &jwtTrust{
+		config: config,
+		// JWKS refetch amplification: a kid miss or a signature that fails to
+		// verify against the cached keys makes RemoteKeySet refetch the whole
+		// set with no negative caching. In practice this is bounded to about
+		// one fetch per round trip by RemoteKeySet's own inflight
+		// singleflight, is inherent to every consumer of go-oidc's
+		// RemoteKeySet (not specific to this provider), and the endpoint is
+		// the operator's own proxy rather than attacker-controlled
+		// infrastructure, so a negative cache is not worth building here.
+		keySet: oidc.NewRemoteKeySet(oidc.ClientContext(ctx, client), config.JWKSURL),
+	}
+}
+
+// Check verifies presence only, so it stays free of I/O as the IdentN
+// contract requires. Signature verification happens in Email, which runs
+// inside GetIdentity where I/O is allowed. A garbage assertion therefore
+// still satisfies Check, and Test along with it; Email is where it is
+// actually rejected.
+func (t *jwtTrust) Check(req *http.Request) error {
+	if len(req.Header.Values(t.config.AssertionHeader)) != 1 {
+		return errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderUntrusted, "request did not carry exactly one assertion header")
+	}
+
+	return nil
+}
+
+// CarriesIdentity reports that jwt mode carries its own verified identity
+// claim; the configured email headers are not consulted. NameHeaders is a
+// separate list from EmailHeaders, and extractDisplayName still reads it
+// during auto-provisioning, so an authenticated caller can still choose
+// their own display name. That is cosmetic, since they are authenticated as
+// themselves either way, but it is not the same claim as "the configured
+// headers are not consulted".
+func (t *jwtTrust) CarriesIdentity() bool {
+	return true
+}
+
+// Email verifies the assertion signature against the remote key set, checks
+// issuer, audience, expiry and not-before, and returns the configured
+// identity claim.
+func (t *jwtTrust) Email(req *http.Request) (string, error) {
+	values := req.Header.Values(t.config.AssertionHeader)
+	if len(values) != 1 {
+		return "", errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderUntrusted, "request did not carry exactly one assertion header")
+	}
+
+	// VerifySignature parses with jose.ParseSigned(jwt, allAlgs), and allAlgs in
+	// go-oidc v3.17.0 lists only asymmetric algorithms (RS/ES/PS/EdDSA); there is
+	// no HMAC family and no "none". An HS256 token forged using the RSA public
+	// key as an HMAC secret is rejected here, before any key is ever tried.
+	payload, err := t.keySet.VerifySignature(req.Context(), values[0])
+	if err != nil {
+		// err.Error() is deliberately not attached. It can echo the attacker's
+		// own unbounded "alg" header value verbatim, and, on a JWKS fetch
+		// failure, go-oidc formats the endpoint's raw response body into the
+		// error with %s (oidc/jwks.go), which could carry an internal error
+		// page or stack trace from the JWKS endpoint into what would
+		// otherwise be a client-facing authentication error. If the fetch
+		// itself needs to be diagnosable, that belongs in a separate log line
+		// that says the fetch failed without echoing the body, not smuggled
+		// into this error.
+		return "", errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderUntrusted, "assertion signature is not valid")
+	}
+
+	var claims struct {
+		Issuer    string      `json:"iss"`
+		Audience  jwtAudience `json:"aud"`
+		Expiry    *float64    `json:"exp"`
+		NotBefore *float64    `json:"nbf"`
+	}
+
+	// iss, aud and exp/nbf above are matched by encoding/json's own
+	// case-insensitive fallback (a claim named "ISS" would still populate
+	// Issuer), while the identity claim below is matched case-sensitively
+	// through a map lookup. This is not exploitable: an exact-case match
+	// always wins over a case-insensitive one when both are present in the
+	// same JSON object, so a claim named exactly "iss" is never shadowed by
+	// one named "Iss". It is still an asymmetry worth knowing about.
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderInvalidAssertion, "assertion claims are not valid JSON")
+	}
+
+	if claims.Issuer != t.config.Issuer {
+		return "", errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderInvalidAssertion, "assertion issuer does not match")
+	}
+
+	if !claims.Audience.contains(t.config.Audience) {
+		return "", errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderInvalidAssertion, "assertion audience does not match")
+	}
+
+	// exp is decoded as *float64, not int64: RFC 7519 permits a NumericDate
+	// with a fractional part, and a pointer distinguishes "claim absent" from
+	// "claim present and zero", which a bare int64 cannot. exp stays
+	// mandatory; nbf below does not, since RFC 7519 makes nbf optional.
+	if claims.Expiry == nil || time.Now().After(numericDateToTime(*claims.Expiry)) {
+		return "", errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderInvalidAssertion, "assertion has expired or carries no expiry")
+	}
+
+	if claims.NotBefore != nil && time.Now().Before(numericDateToTime(*claims.NotBefore)) {
+		return "", errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderInvalidAssertion, "assertion is not yet valid")
+	}
+
+	// A second pass reads the identity claim from an untyped map. The standard
+	// claims above need typed extraction anyway (jwtAudience's custom
+	// UnmarshalJSON handles the string-or-array form from RFC 7519, and exp/nbf
+	// need to be numbers), so decoding the identity claim from a map avoids
+	// hard-coding every possible identity_claim name into the struct. Both
+	// unmarshals run against the same in-memory payload already returned by
+	// VerifySignature, so this is not a second round of I/O, only a second,
+	// cheap decode of a small byte slice.
+	var raw map[string]any
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return "", errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderInvalidAssertion, "assertion claims are not valid JSON")
+	}
+
+	value, ok := raw[t.config.IdentityClaim].(string)
+	if !ok || strings.TrimSpace(value) == "" {
+		return "", errors.Newf(errors.TypeUnauthenticated, ErrCodeTrustedHeaderInvalidAssertion, "assertion does not carry a usable %q claim", t.config.IdentityClaim)
+	}
+
+	return strings.TrimSpace(value), nil
+}
+
+var _ trust = (*jwtTrust)(nil)
+
+// numericDateToTime converts a JSON Numeric Date (RFC 7519 section 2), which
+// may carry a fractional part, to a time.Time without losing that fraction.
+func numericDateToTime(seconds float64) time.Time {
+	whole := math.Trunc(seconds)
+	frac := seconds - whole
+	return time.Unix(int64(whole), int64(frac*float64(time.Second)))
+}
+
+// jwtAudience decodes the aud claim, which is either a string or an array of
+// strings per RFC 7519.
+type jwtAudience []string
+
+func (a *jwtAudience) UnmarshalJSON(data []byte) error {
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*a = jwtAudience{single}
+		return nil
+	}
+
+	var many []string
+	if err := json.Unmarshal(data, &many); err != nil {
+		return err
+	}
+
+	*a = jwtAudience(many)
+	return nil
+}
+
+func (a jwtAudience) contains(want string) bool {
+	return slices.Contains(a, want)
+}

--- a/pkg/identn/trustedheaderidentn/trust.go
+++ b/pkg/identn/trustedheaderidentn/trust.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
+	"log/slog"
 	"math"
 	"net/http"
 	"slices"
@@ -105,6 +106,7 @@ const jwksFetchTimeout = 10 * time.Second
 // them forge one.
 type jwtTrust struct {
 	config identn.JWTTrustConfig
+	logger *slog.Logger
 	keySet *oidc.RemoteKeySet
 }
 
@@ -116,11 +118,12 @@ type jwtTrust struct {
 // What ctx does carry, through oidc.ClientContext, is the HTTP client used
 // for every fetch; that client has jwksFetchTimeout set precisely because
 // the context mechanism cannot bound the fetch itself.
-func newJWTTrust(ctx context.Context, config identn.JWTTrustConfig) *jwtTrust {
+func newJWTTrust(ctx context.Context, logger *slog.Logger, config identn.JWTTrustConfig) *jwtTrust {
 	client := &http.Client{Timeout: jwksFetchTimeout}
 
 	return &jwtTrust{
 		config: config,
+		logger: logger,
 		// JWKS refetch amplification: a kid miss or a signature that fails to
 		// verify against the cached keys makes RemoteKeySet refetch the whole
 		// set with no negative caching. In practice this is bounded to about
@@ -172,15 +175,19 @@ func (t *jwtTrust) Email(req *http.Request) (string, error) {
 	// key as an HMAC secret is rejected here, before any key is ever tried.
 	payload, err := t.keySet.VerifySignature(req.Context(), values[0])
 	if err != nil {
-		// err.Error() is deliberately not attached. It can echo the attacker's
-		// own unbounded "alg" header value verbatim, and, on a JWKS fetch
-		// failure, go-oidc formats the endpoint's raw response body into the
-		// error with %s (oidc/jwks.go), which could carry an internal error
-		// page or stack trace from the JWKS endpoint into what would
-		// otherwise be a client-facing authentication error. If the fetch
-		// itself needs to be diagnosable, that belongs in a separate log line
-		// that says the fetch failed without echoing the body, not smuggled
-		// into this error.
+		// err.Error() is logged rather than attached to the returned error. It
+		// can echo the caller's own "alg" header value, and on a JWKS fetch
+		// failure go-oidc formats the endpoint's raw response body into it with
+		// %s (oidc/jwks.go), which could carry an internal error page or a
+		// stack trace. None of that belongs in a client-facing authentication
+		// error. It does belong in the operator's log: a typo'd jwks_url, a
+		// firewalled endpoint, a rotated key and a forged assertion all reach
+		// the caller as this one error code, and this line is the only thing
+		// that tells them apart.
+		t.logger.WarnContext(req.Context(), "trusted-header assertion did not verify",
+			slog.String("error", err.Error()),
+		)
+
 		return "", errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderUntrusted, "assertion signature is not valid")
 	}
 

--- a/pkg/identn/trustedheaderidentn/trust.go
+++ b/pkg/identn/trustedheaderidentn/trust.go
@@ -1,0 +1,76 @@
+package trustedheaderidentn
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"net/http"
+
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/identn"
+)
+
+var (
+	ErrCodeTrustedHeaderUntrusted        = errors.MustNewCode("trusted_header_untrusted_request")
+	ErrCodeTrustedHeaderSecretNoIdentity = errors.MustNewCode("trusted_header_secret_no_identity")
+)
+
+// trust establishes that a request genuinely came from the trusted proxy.
+type trust interface {
+	// Check returns nil when the request carries acceptable proof of provenance.
+	// It must be free of I/O, because it is called from Test.
+	Check(req *http.Request) error
+
+	// CarriesIdentity reports whether the proof itself carries the user's
+	// identity, in which case the configured email headers are not consulted. It
+	// is a property of the mode, so it needs no request and performs no I/O.
+	CarriesIdentity() bool
+
+	// Email returns the identity the proof carries. It is only called when
+	// CarriesIdentity reports true, and only from GetIdentity, so it may perform
+	// I/O such as fetching a key set.
+	Email(req *http.Request) (string, error)
+}
+
+type secretTrust struct {
+	config identn.SecretTrustConfig
+}
+
+func newSecretTrust(config identn.SecretTrustConfig) *secretTrust {
+	return &secretTrust{config: config}
+}
+
+// Check compares the secret in constant time so a failure reveals nothing about
+// how much of the secret matched. Comparing fixed-width SHA-256 digests rather
+// than the raw values keeps the comparison constant time in the secret's
+// length as well as its contents: ConstantTimeCompare itself short-circuits
+// on unequal-length inputs, so comparing the raw values directly would leak
+// the secret's length through timing.
+func (t *secretTrust) Check(req *http.Request) error {
+	values := req.Header.Values(t.config.Header)
+	if len(values) != 1 {
+		return errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderUntrusted, "request did not carry exactly one proxy secret header")
+	}
+
+	got := sha256.Sum256([]byte(values[0]))
+	want := sha256.Sum256([]byte(t.config.Value))
+
+	if subtle.ConstantTimeCompare(got[:], want[:]) != 1 {
+		return errors.New(errors.TypeUnauthenticated, ErrCodeTrustedHeaderUntrusted, "proxy secret did not match")
+	}
+
+	return nil
+}
+
+// CarriesIdentity reports that secret mode carries no identity of its own; the
+// configured email headers remain authoritative.
+func (t *secretTrust) CarriesIdentity() bool {
+	return false
+}
+
+// Email is never called for secret mode: CarriesIdentity reports false, and
+// GetIdentity only calls Email when CarriesIdentity is true.
+func (t *secretTrust) Email(_ *http.Request) (string, error) {
+	return "", errors.New(errors.TypeInternal, ErrCodeTrustedHeaderSecretNoIdentity, "secret mode carries no identity of its own")
+}
+
+var _ trust = (*secretTrust)(nil)

--- a/pkg/identn/trustedheaderidentn/trust_test.go
+++ b/pkg/identn/trustedheaderidentn/trust_test.go
@@ -1,0 +1,72 @@
+package trustedheaderidentn
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/SigNoz/signoz/pkg/identn"
+)
+
+func TestSecretTrustAcceptsMatchingSecret(t *testing.T) {
+	checker := newSecretTrust(identn.SecretTrustConfig{Header: "X-Proxy-Auth", Value: "s3cret"})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Proxy-Auth", "s3cret")
+
+	require.NoError(t, checker.Check(req))
+}
+
+func TestSecretTrustRejectsWrongAbsentAndShortSecret(t *testing.T) {
+	checker := newSecretTrust(identn.SecretTrustConfig{Header: "X-Proxy-Auth", Value: "s3cret"})
+
+	for name, value := range map[string]string{
+		"wrong":   "wrong",
+		"absent":  "",
+		"shorter": "s3cre",
+		"longer":  "s3cret-extra",
+	} {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if value != "" {
+				req.Header.Set("X-Proxy-Auth", value)
+			}
+
+			assert.Error(t, checker.Check(req))
+		})
+	}
+}
+
+func TestSecretTrustRejectsDuplicateSecretHeaderValues(t *testing.T) {
+	checker := newSecretTrust(identn.SecretTrustConfig{Header: "X-Proxy-Auth", Value: "s3cret"})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Add("X-Proxy-Auth", "s3cret")
+	req.Header.Add("X-Proxy-Auth", "s3cret")
+
+	assert.Error(t, checker.Check(req))
+}
+
+// secret mode never carries the identity itself: the configured email
+// headers stay authoritative, and GetIdentity must keep consulting them.
+func TestSecretTrustCarriesIdentityIsFalse(t *testing.T) {
+	checker := newSecretTrust(identn.SecretTrustConfig{Header: "X-Proxy-Auth", Value: "s3cret"})
+
+	assert.False(t, checker.CarriesIdentity())
+}
+
+// Email is never expected to be called in secret mode, since CarriesIdentity
+// reports false, but it must still fail safe rather than silently return an
+// identity if it ever is.
+func TestSecretTrustEmailReturnsError(t *testing.T) {
+	checker := newSecretTrust(identn.SecretTrustConfig{Header: "X-Proxy-Auth", Value: "s3cret"})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	email, err := checker.Email(req)
+
+	assert.Error(t, err)
+	assert.Empty(t, email)
+}

--- a/pkg/identn/trustedheaderidentn/trust_test.go
+++ b/pkg/identn/trustedheaderidentn/trust_test.go
@@ -1,6 +1,7 @@
 package trustedheaderidentn
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -8,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -125,13 +127,45 @@ func signAssertion(t *testing.T, key *rsa.PrivateKey, kid string, claims jwt.Map
 func newTestJWTTrust(t *testing.T, jwksURL string) *jwtTrust {
 	t.Helper()
 
-	return newJWTTrust(context.Background(), identn.JWTTrustConfig{
+	checker, _ := newTestJWTTrustWithLogs(t, jwksURL)
+
+	return checker
+}
+
+// newTestJWTTrustWithLogs also returns the checker's log output, so a test can
+// assert on what an operator would actually see.
+func newTestJWTTrustWithLogs(t *testing.T, jwksURL string) (*jwtTrust, *bytes.Buffer) {
+	t.Helper()
+
+	logs := &bytes.Buffer{}
+
+	checker := newJWTTrust(context.Background(), slog.New(slog.NewTextHandler(logs, nil)), identn.JWTTrustConfig{
 		AssertionHeader: "Teleport-Jwt-Assertion",
 		JWKSURL:         jwksURL,
 		Issuer:          "https://teleport.example",
 		Audience:        "signoz",
 		IdentityClaim:   "sub",
 	})
+
+	return checker, logs
+}
+
+// Every verification failure reaches the caller as the same opaque code, so
+// this log line is the only thing that separates a forged assertion from a
+// JWKS endpoint the operator cannot reach. It has to carry the reason, not
+// just the fact.
+func TestJWTTrustLogsWhyVerificationFailed(t *testing.T) {
+	checker, logs := newTestJWTTrustWithLogs(t, "http://127.0.0.1:1/jwks.json")
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Teleport-Jwt-Assertion", "not.a.jwt")
+
+	_, err := checker.Email(req)
+	require.Error(t, err)
+	assert.True(t, errors.Asc(err, ErrCodeTrustedHeaderUntrusted))
+
+	assert.Contains(t, logs.String(), "trusted-header assertion did not verify")
+	assert.Contains(t, logs.String(), "error=")
 }
 
 func TestJWTTrustAcceptsValidAssertion(t *testing.T) {

--- a/pkg/identn/trustedheaderidentn/trust_test.go
+++ b/pkg/identn/trustedheaderidentn/trust_test.go
@@ -1,13 +1,24 @@
 package trustedheaderidentn
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/identn"
 )
 
@@ -69,4 +80,255 @@ func TestSecretTrustEmailReturnsError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Empty(t, email)
+}
+
+// newJWKSFixture generates an RSA key, serves its public half from an
+// httptest server in JWKS form, and returns the private key plus that
+// server's URL and key ID so tests can both sign assertions and configure a
+// jwtTrust to verify them.
+func newJWKSFixture(t *testing.T) (*rsa.PrivateKey, string, string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	jwk := map[string]any{
+		"kty": "RSA",
+		"kid": "test-key",
+		"alg": "RS256",
+		"use": "sig",
+		"n":   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"keys": []any{jwk}}))
+	}))
+	t.Cleanup(server.Close)
+
+	return key, server.URL, "test-key"
+}
+
+func signAssertion(t *testing.T, key *rsa.PrivateKey, kid string, claims jwt.MapClaims) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+
+	signed, err := token.SignedString(key)
+	require.NoError(t, err)
+
+	return signed
+}
+
+func newTestJWTTrust(t *testing.T, jwksURL string) *jwtTrust {
+	t.Helper()
+
+	return newJWTTrust(context.Background(), identn.JWTTrustConfig{
+		AssertionHeader: "Teleport-Jwt-Assertion",
+		JWKSURL:         jwksURL,
+		Issuer:          "https://teleport.example",
+		Audience:        "signoz",
+		IdentityClaim:   "sub",
+	})
+}
+
+func TestJWTTrustAcceptsValidAssertion(t *testing.T) {
+	key, jwksURL, kid := newJWKSFixture(t)
+	checker := newTestJWTTrust(t, jwksURL)
+
+	assertion := signAssertion(t, key, kid, jwt.MapClaims{
+		"iss": "https://teleport.example",
+		"aud": "signoz",
+		"sub": "alice@example.com",
+		"exp": time.Now().Add(time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Teleport-Jwt-Assertion", assertion)
+
+	require.NoError(t, checker.Check(req))
+
+	email, err := checker.Email(req)
+	require.NoError(t, err)
+	assert.Equal(t, "alice@example.com", email)
+}
+
+// TestJWTTrustAcceptsAudienceArrayClaim pins RFC 7519's allowance of aud as
+// either a single string or an array of strings: a proxy that lists more than
+// one intended audience must not be refused just because signoz is not the
+// first entry.
+func TestJWTTrustAcceptsAudienceArrayClaim(t *testing.T) {
+	key, jwksURL, kid := newJWKSFixture(t)
+	checker := newTestJWTTrust(t, jwksURL)
+
+	assertion := signAssertion(t, key, kid, jwt.MapClaims{
+		"iss": "https://teleport.example",
+		"aud": []string{"other", "signoz"},
+		"sub": "alice@example.com",
+		"exp": time.Now().Add(time.Minute).Unix(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Teleport-Jwt-Assertion", assertion)
+
+	require.NoError(t, checker.Check(req))
+
+	email, err := checker.Email(req)
+	require.NoError(t, err)
+	assert.Equal(t, "alice@example.com", email)
+}
+
+// TestJWTTrustRejectsBadAssertions asserts, per case, the specific error code
+// the failing validation step is expected to produce: ErrCodeTrustedHeaderUntrusted
+// for a proof-of-provenance failure (bad or unverifiable signature), and
+// ErrCodeTrustedHeaderInvalidAssertion for a claim-level failure once the
+// signature itself checked out (issuer, audience, expiry, not-before, or the
+// identity claim). Asserting a single shared code for every case would let a
+// bug that swapped, say, the issuer and audience branches pass unnoticed.
+func TestJWTTrustRejectsBadAssertions(t *testing.T) {
+	key, jwksURL, kid := newJWKSFixture(t)
+	otherKey, _, _ := newJWKSFixture(t)
+	checker := newTestJWTTrust(t, jwksURL)
+
+	valid := jwt.MapClaims{
+		"iss": "https://teleport.example",
+		"aud": "signoz",
+		"sub": "alice@example.com",
+		"exp": time.Now().Add(time.Minute).Unix(),
+	}
+
+	cases := []struct {
+		name      string
+		assertion string
+		wantCode  errors.Code
+	}{
+		{"wrong issuer", signAssertion(t, key, kid, jwt.MapClaims{"iss": "https://evil.example", "aud": "signoz", "sub": "alice@example.com", "exp": time.Now().Add(time.Minute).Unix()}), ErrCodeTrustedHeaderInvalidAssertion},
+		{"wrong audience", signAssertion(t, key, kid, jwt.MapClaims{"iss": "https://teleport.example", "aud": "other", "sub": "alice@example.com", "exp": time.Now().Add(time.Minute).Unix()}), ErrCodeTrustedHeaderInvalidAssertion},
+		{"expired", signAssertion(t, key, kid, jwt.MapClaims{"iss": "https://teleport.example", "aud": "signoz", "sub": "alice@example.com", "exp": time.Now().Add(-time.Minute).Unix()}), ErrCodeTrustedHeaderInvalidAssertion},
+		{"missing exp", signAssertion(t, key, kid, jwt.MapClaims{"iss": "https://teleport.example", "aud": "signoz", "sub": "alice@example.com"}), ErrCodeTrustedHeaderInvalidAssertion},
+		{"future nbf", signAssertion(t, key, kid, jwt.MapClaims{"iss": "https://teleport.example", "aud": "signoz", "sub": "alice@example.com", "nbf": time.Now().Add(time.Minute).Unix(), "exp": time.Now().Add(time.Hour).Unix()}), ErrCodeTrustedHeaderInvalidAssertion},
+		{"missing claim", signAssertion(t, key, kid, jwt.MapClaims{"iss": "https://teleport.example", "aud": "signoz", "exp": time.Now().Add(time.Minute).Unix()}), ErrCodeTrustedHeaderInvalidAssertion},
+		{"non-string claim", signAssertion(t, key, kid, jwt.MapClaims{"iss": "https://teleport.example", "aud": "signoz", "sub": 12345, "exp": time.Now().Add(time.Minute).Unix()}), ErrCodeTrustedHeaderInvalidAssertion},
+		{"empty string claim", signAssertion(t, key, kid, jwt.MapClaims{"iss": "https://teleport.example", "aud": "signoz", "sub": "", "exp": time.Now().Add(time.Minute).Unix()}), ErrCodeTrustedHeaderInvalidAssertion},
+		{"object claim", signAssertion(t, key, kid, jwt.MapClaims{"iss": "https://teleport.example", "aud": "signoz", "sub": map[string]any{"id": "alice"}, "exp": time.Now().Add(time.Minute).Unix()}), ErrCodeTrustedHeaderInvalidAssertion},
+		{"unknown key", signAssertion(t, otherKey, kid, valid), ErrCodeTrustedHeaderUntrusted},
+		{"not a jwt", "garbage", ErrCodeTrustedHeaderUntrusted},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Teleport-Jwt-Assertion", tc.assertion)
+
+			// Check only counts assertion headers, so it must pass for every
+			// case here: if it ever started rejecting one of these inputs,
+			// the subtest below would pass having exercised nothing. Assert
+			// this loudly rather than silently skipping past it.
+			require.NoError(t, checker.Check(req))
+
+			_, err := checker.Email(req)
+			require.Error(t, err)
+			assert.True(t, errors.Asc(err, tc.wantCode), "expected code %v, got %v", tc.wantCode, err)
+		})
+	}
+}
+
+// TestJWTTrustAcceptsFractionalExpiry pins RFC 7519's NumericDate, which
+// permits a fractional number of seconds. exp is decoded as *float64 rather
+// than int64 precisely so a proxy that emits "1700000000.5" is not rejected
+// with a confusing "claims are not valid JSON" error.
+func TestJWTTrustAcceptsFractionalExpiry(t *testing.T) {
+	key, jwksURL, kid := newJWKSFixture(t)
+	checker := newTestJWTTrust(t, jwksURL)
+
+	expiry := float64(time.Now().Add(time.Minute).Unix()) + 0.5
+
+	assertion := signAssertion(t, key, kid, jwt.MapClaims{
+		"iss": "https://teleport.example",
+		"aud": "signoz",
+		"sub": "alice@example.com",
+		"exp": expiry,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Teleport-Jwt-Assertion", assertion)
+
+	require.NoError(t, checker.Check(req))
+
+	email, err := checker.Email(req)
+	require.NoError(t, err)
+	assert.Equal(t, "alice@example.com", email)
+}
+
+// TestJWTTrustRejectsHS256AlgorithmConfusion constructs the classic
+// algorithm-confusion attack: a token signed HS256 using the RSA public key's
+// PEM encoding as the HMAC secret, which is exactly what an attacker inside
+// the cluster could compute since the public key is, by definition, public.
+// coreos/go-oidc's RemoteKeySet.VerifySignature parses with go-jose's
+// jose.ParseSigned(jwt, allAlgs), and allAlgs in go-oidc v3.17.0 lists only
+// asymmetric algorithms, so this must be rejected before any key is ever
+// tried. If this test does not fail to verify, the whole premise of jwt mode
+// (that header forgery becomes irrelevant, not merely blocked) is unsound.
+func TestJWTTrustRejectsHS256AlgorithmConfusion(t *testing.T) {
+	key, jwksURL, kid := newJWKSFixture(t)
+	checker := newTestJWTTrust(t, jwksURL)
+
+	pubDER, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	require.NoError(t, err)
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss": "https://teleport.example",
+		"aud": "signoz",
+		"sub": "alice@example.com",
+		"exp": time.Now().Add(time.Minute).Unix(),
+	})
+	token.Header["kid"] = kid
+
+	forged, err := token.SignedString(pubPEM)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Teleport-Jwt-Assertion", forged)
+
+	require.NoError(t, checker.Check(req))
+
+	_, err = checker.Email(req)
+	require.Error(t, err)
+	assert.True(t, errors.Asc(err, ErrCodeTrustedHeaderUntrusted))
+}
+
+func TestJWTTrustRejectsAbsentAssertion(t *testing.T) {
+	_, jwksURL, _ := newJWKSFixture(t)
+	checker := newTestJWTTrust(t, jwksURL)
+
+	assert.Error(t, checker.Check(httptest.NewRequest(http.MethodGet, "/", nil)))
+}
+
+// TestJWTTrustEmailFailsOnGarbageEvenWhenCheckPasses pins the deliberate
+// asymmetry between Check and Email: Check only counts assertion headers, so
+// a garbage assertion still satisfies it, and Email is where the assertion is
+// actually verified. That is correct behaviour, not a bug: Check must stay
+// free of I/O because it is called from Test, so it cannot verify a
+// signature. Nobody should "fix" this by moving verification into Check.
+func TestJWTTrustEmailFailsOnGarbageEvenWhenCheckPasses(t *testing.T) {
+	_, jwksURL, _ := newJWKSFixture(t)
+	checker := newTestJWTTrust(t, jwksURL)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Teleport-Jwt-Assertion", "garbage")
+
+	require.NoError(t, checker.Check(req))
+
+	_, err := checker.Email(req)
+	assert.Error(t, err)
+}
+
+func TestJWTTrustCarriesIdentityIsTrue(t *testing.T) {
+	_, jwksURL, _ := newJWKSFixture(t)
+	checker := newTestJWTTrust(t, jwksURL)
+
+	assert.True(t, checker.CarriesIdentity())
 }

--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -28,6 +28,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/identn/apikeyidentn"
 	"github.com/SigNoz/signoz/pkg/identn/impersonationidentn"
 	"github.com/SigNoz/signoz/pkg/identn/tokenizeridentn"
+	"github.com/SigNoz/signoz/pkg/identn/trustedheaderidentn"
 	"github.com/SigNoz/signoz/pkg/meterreporter"
 	"github.com/SigNoz/signoz/pkg/meterreporter/noopmeterreporter"
 	"github.com/SigNoz/signoz/pkg/modules/authdomain/implauthdomain"
@@ -342,11 +343,12 @@ func NewTokenizerProviderFactories(cache cache.Cache, sqlstore sqlstore.SQLStore
 	)
 }
 
-func NewIdentNProviderFactories(tokenizer tokenizer.Tokenizer, serviceAccount serviceaccount.Module, orgGetter organization.Getter, userGetter user.Getter, userConfig user.Config) factory.NamedMap[factory.ProviderFactory[identn.IdentN, identn.Config]] {
+func NewIdentNProviderFactories(tokenizer tokenizer.Tokenizer, serviceAccount serviceaccount.Module, orgGetter organization.Getter, userGetter user.Getter, userSetter user.Setter, userConfig user.Config) factory.NamedMap[factory.ProviderFactory[identn.IdentN, identn.Config]] {
 	return factory.MustNewNamedMap(
 		impersonationidentn.NewFactory(orgGetter, userGetter, userConfig),
 		tokenizeridentn.NewFactory(tokenizer),
 		apikeyidentn.NewFactory(serviceAccount),
+		trustedheaderidentn.NewFactory(orgGetter, userGetter, userSetter),
 	)
 }
 

--- a/pkg/signoz/signoz.go
+++ b/pkg/signoz/signoz.go
@@ -521,7 +521,7 @@ func New(
 	}
 
 	// Initialize identN resolver
-	identNFactories := NewIdentNProviderFactories(tokenizer, serviceAccount, orgGetter, userGetter, config.User)
+	identNFactories := NewIdentNProviderFactories(tokenizer, serviceAccount, orgGetter, userGetter, modules.UserSetter, config.User)
 	identNResolver, err := identn.NewIdentNResolver(ctx, providerSettings, config.IdentN, identNFactories)
 	if err != nil {
 		return nil, err

--- a/pkg/types/authtypes/authn.go
+++ b/pkg/types/authtypes/authn.go
@@ -20,6 +20,7 @@ var (
 	AuthNProviderSAML          = AuthNProvider{valuer.NewString("saml")}
 	AuthNProviderEmailPassword = AuthNProvider{valuer.NewString("email_password")}
 	AuthNProviderOIDC          = AuthNProvider{valuer.NewString("oidc")}
+	AuthNProviderTrustedHeader = AuthNProvider{valuer.NewString("trusted_header")}
 )
 
 var (
@@ -162,6 +163,7 @@ func (AuthNProvider) Enum() []any {
 		AuthNProviderSAML,
 		AuthNProviderEmailPassword,
 		AuthNProviderOIDC,
+		AuthNProviderTrustedHeader,
 	}
 }
 

--- a/pkg/types/authtypes/authn.go
+++ b/pkg/types/authtypes/authn.go
@@ -20,7 +20,6 @@ var (
 	AuthNProviderSAML          = AuthNProvider{valuer.NewString("saml")}
 	AuthNProviderEmailPassword = AuthNProvider{valuer.NewString("email_password")}
 	AuthNProviderOIDC          = AuthNProvider{valuer.NewString("oidc")}
-	AuthNProviderTrustedHeader = AuthNProvider{valuer.NewString("trusted_header")}
 )
 
 var (
@@ -163,7 +162,6 @@ func (AuthNProvider) Enum() []any {
 		AuthNProviderSAML,
 		AuthNProviderEmailPassword,
 		AuthNProviderOIDC,
-		AuthNProviderTrustedHeader,
 	}
 }
 

--- a/pkg/types/authtypes/identn.go
+++ b/pkg/types/authtypes/identn.go
@@ -8,6 +8,7 @@ var (
 	IdentNProviderAnonymous     = IdentNProvider{valuer.NewString("anonymous")}
 	IdentNProviderInternal      = IdentNProvider{valuer.NewString("internal")}
 	IdentNProviderImpersonation = IdentNProvider{valuer.NewString("impersonation")}
+	IdentNProviderTrustedHeader = IdentNProvider{valuer.NewString("trusted_header")}
 )
 
 type IdentNProvider struct{ valuer.String }

--- a/pkg/types/globaltypes/identn.go
+++ b/pkg/types/globaltypes/identn.go
@@ -4,6 +4,7 @@ type IdentNConfig struct {
 	Tokenizer     TokenizerConfig     `json:"tokenizer"`
 	APIKey        APIKeyConfig        `json:"apikey"`
 	Impersonation ImpersonationConfig `json:"impersonation"`
+	TrustedHeader TrustedHeaderConfig `json:"trustedHeader"`
 }
 
 type TokenizerConfig struct {
@@ -18,10 +19,19 @@ type ImpersonationConfig struct {
 	Enabled bool `json:"enabled"`
 }
 
-func NewIdentNConfig(tokenizer TokenizerConfig, apiKey APIKeyConfig, impersonation ImpersonationConfig) IdentNConfig {
+// TrustedHeaderConfig tells the browser that identity comes from a fronting
+// proxy, so it should not render a login form. It deliberately carries neither
+// the trust mode nor any secret.
+type TrustedHeaderConfig struct {
+	Enabled           bool   `json:"enabled"`
+	LogoutRedirectURL string `json:"logoutRedirectUrl"`
+}
+
+func NewIdentNConfig(tokenizer TokenizerConfig, apiKey APIKeyConfig, impersonation ImpersonationConfig, trustedHeader TrustedHeaderConfig) IdentNConfig {
 	return IdentNConfig{
 		Tokenizer:     tokenizer,
 		APIKey:        apiKey,
 		Impersonation: impersonation,
+		TrustedHeader: trustedHeader,
 	}
 }

--- a/tests/integration/tests/trustedheaderauthn/01_secret_mode.py
+++ b/tests/integration/tests/trustedheaderauthn/01_secret_mode.py
@@ -1,0 +1,149 @@
+import http.client
+from collections.abc import Callable
+from http import HTTPStatus
+from urllib.parse import urlparse
+
+import pytest
+import requests
+
+from fixtures import types
+from fixtures.auth import create_active_user
+from fixtures.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+# Must match conftest.py's _trusted_header_env(), which is what the `signoz`
+# fixture in this package actually boots the server with.
+SECRET_HEADER = "X-Signoz-Trusted-Secret"
+SECRET_VALUE = "trusted-header-test-secret-do-not-reuse"
+EMAIL_HEADER = "X-Forwarded-Email"
+ROOT_USER_EMAIL = "trustedheader-root@integration.test"
+ROOT_USER_PASSWORD = "password123Z$"
+
+KNOWN_USER_EMAIL = "trustedheader-known@integration.test"
+KNOWN_USER_PASSWORD = "password123Z$"
+
+ME_PATH = "/api/v2/users/me"
+
+
+@pytest.fixture(name="known_user_id", scope="module")
+def known_user_id(
+    signoz: types.SigNoz,
+    signoz_ready: None,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+) -> str:
+    """A pre-created, active user the secret-mode header can resolve to.
+    Root doubles as the admin here: register_admin cannot be used once
+    SIGNOZ_USER_ROOT_ENABLED is set (see conftest.py)."""
+    root_token = get_token(ROOT_USER_EMAIL, ROOT_USER_PASSWORD)
+    return create_active_user(signoz, root_token, KNOWN_USER_EMAIL, "VIEWER", KNOWN_USER_PASSWORD)
+
+
+def _get(signoz: types.SigNoz, headers: dict) -> requests.Response:
+    return requests.get(signoz.self.host_configs["8080"].get(ME_PATH), headers=headers, timeout=5)
+
+
+def _get_with_repeated_header(signoz: types.SigNoz, header_name: str, values: list[str], extra_headers: dict | None = None) -> int:
+    """
+    Send a GET with the same header name repeated across several lines.
+
+    `requests` cannot express this: its `headers` argument is a plain dict, so
+    a second entry for the same key just overwrites the first. Only
+    http.client's putheader lets a single request carry two literal header
+    lines with the same name, which is what a misbehaving reverse proxy would
+    produce if it appended a header instead of replacing it. Returns the
+    status code.
+
+    putrequest() already emits a Host header on its own unless skip_host is
+    passed, so this must not add a second one: Go's net/http rejects a
+    request carrying two Host header lines with 400 before it ever reaches
+    application routing, which would look like this test succeeding for the
+    wrong reason (a generic bad-request response, not the trusted-header
+    provider's own rejection of duplicate values).
+    """
+    url = urlparse(signoz.self.host_configs["8080"].get(ME_PATH))
+    conn = http.client.HTTPConnection(url.hostname, url.port, timeout=5)
+    try:
+        conn.putrequest("GET", url.path or "/")
+        for value in values:
+            conn.putheader(header_name, value)
+        for key, value in (extra_headers or {}).items():
+            conn.putheader(key, value)
+        conn.endheaders()
+        return conn.getresponse().status
+    finally:
+        conn.close()
+
+
+def test_correct_secret_and_known_email_resolves_to_user(signoz: types.SigNoz, known_user_id: str) -> None:  # pylint: disable=unused-argument
+    """A request carrying the correct secret and a known active user's email
+    resolves to that user, confirmed via the current-user endpoint."""
+    response = _get(signoz, {SECRET_HEADER: SECRET_VALUE, EMAIL_HEADER: KNOWN_USER_EMAIL})
+
+    assert response.status_code == HTTPStatus.OK, response.text
+    assert response.json()["data"]["email"] == KNOWN_USER_EMAIL
+
+
+def test_missing_secret_header_is_rejected(signoz: types.SigNoz, known_user_id: str) -> None:  # pylint: disable=unused-argument
+    """The same request without the secret header is rejected."""
+    response = _get(signoz, {EMAIL_HEADER: KNOWN_USER_EMAIL})
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_wrong_secret_is_rejected(signoz: types.SigNoz, known_user_id: str) -> None:  # pylint: disable=unused-argument
+    """The same request with a wrong secret is rejected."""
+    response = _get(signoz, {SECRET_HEADER: "wrong-secret-value", EMAIL_HEADER: KNOWN_USER_EMAIL})
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_duplicate_email_header_values_rejected(signoz: types.SigNoz, known_user_id: str) -> None:  # pylint: disable=unused-argument
+    """A request carrying two values for the email header is rejected rather
+    than resolving to whichever value Header.Get happens to prefer."""
+    status = _get_with_repeated_header(
+        signoz,
+        EMAIL_HEADER,
+        [KNOWN_USER_EMAIL, "attacker@evil.example"],
+        extra_headers={SECRET_HEADER: SECRET_VALUE},
+    )
+
+    assert status == HTTPStatus.UNAUTHORIZED
+
+
+def test_authorization_header_defers_to_tokenizer(signoz: types.SigNoz, known_user_id: str) -> None:  # pylint: disable=unused-argument
+    """A request carrying an Authorization header is not resolved by this
+    provider. The tokenizer resolver is registered ahead of the trusted-header
+    resolver and its Test() matches on header presence alone, so a request
+    with a bearer token is claimed by the tokenizer even when it also carries
+    a fully valid secret and a known email. An invalid token then makes the
+    tokenizer itself fail, which must surface as rejection rather than a
+    successful header resolution.
+    """
+    # Control: without Authorization, this exact secret+email combination
+    # succeeds (already covered above, repeated here so the contrast is local
+    # to this test).
+    control = _get(signoz, {SECRET_HEADER: SECRET_VALUE, EMAIL_HEADER: KNOWN_USER_EMAIL})
+    assert control.status_code == HTTPStatus.OK
+
+    response = _get(
+        signoz,
+        {
+            SECRET_HEADER: SECRET_VALUE,
+            EMAIL_HEADER: KNOWN_USER_EMAIL,
+            "Authorization": "Bearer not-a-real-token",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_root_user_email_is_rejected(signoz: types.SigNoz, signoz_ready: None) -> None:  # pylint: disable=unused-argument
+    """A request asserting the root user's email is rejected: root can only
+    authenticate by password. Depends on `signoz_ready` so the root user is
+    actually reconciled by the time this runs; otherwise the request would be
+    rejected merely because the email matches no user yet, which would prove
+    nothing about the root-specific filter this test is named for."""
+    response = _get(signoz, {SECRET_HEADER: SECRET_VALUE, EMAIL_HEADER: ROOT_USER_EMAIL})
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED

--- a/tests/integration/tests/trustedheaderauthn/02_provisioning.py
+++ b/tests/integration/tests/trustedheaderauthn/02_provisioning.py
@@ -1,0 +1,148 @@
+from collections.abc import Callable
+from http import HTTPStatus
+
+import requests
+
+from fixtures import types
+from fixtures.auth import assert_user_has_role, find_user_with_roles_by_email
+from fixtures.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+# Must match conftest.py's _trusted_header_env(), which is what the `signoz`
+# and `signoz_auto_provision` fixtures in this package actually boot the
+# server with.
+SECRET_HEADER = "X-Signoz-Trusted-Secret"
+SECRET_VALUE = "trusted-header-test-secret-do-not-reuse"
+EMAIL_HEADER = "X-Forwarded-Email"
+ROOT_USER_EMAIL = "trustedheader-root@integration.test"
+ROOT_USER_PASSWORD = "password123Z$"
+
+ME_PATH = "/api/v2/users/me"
+USERS_PATH = "/api/v2/users"
+
+
+def _get_me(signoz: types.SigNoz) -> requests.Response:
+    return requests.get(
+        signoz.self.host_configs["8080"].get(ME_PATH),
+        headers={SECRET_HEADER: SECRET_VALUE, EMAIL_HEADER: ROOT_USER_EMAIL},
+        timeout=5,
+    )
+
+
+def _get_me_for(signoz: types.SigNoz, email: str) -> requests.Response:
+    return requests.get(
+        signoz.self.host_configs["8080"].get(ME_PATH),
+        headers={SECRET_HEADER: SECRET_VALUE, EMAIL_HEADER: email},
+        timeout=5,
+    )
+
+
+def _user_exists(signoz: types.SigNoz, admin_token: str, email: str) -> bool:
+    response = requests.get(
+        signoz.self.host_configs["8080"].get(USERS_PATH),
+        headers={"Authorization": f"Bearer {admin_token}"},
+        timeout=5,
+    )
+    assert response.status_code == HTTPStatus.OK, response.text
+    return any(u["email"] == email for u in response.json()["data"])
+
+
+def test_auto_provision_false_unknown_email_rejected_and_no_user_created(
+    signoz: types.SigNoz,
+    signoz_ready: None,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+) -> None:
+    """With auto_provision:false, an unknown email is rejected and no user
+    record is created for it."""
+    unknown_email = "trustedheader-unknown-noprovision@integration.test"
+
+    response = _get_me_for(signoz, unknown_email)
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+    admin_token = get_token(ROOT_USER_EMAIL, ROOT_USER_PASSWORD)
+    assert not _user_exists(signoz, admin_token, unknown_email)
+
+
+def test_auto_provision_true_unknown_email_creates_viewer(
+    signoz_auto_provision: types.SigNoz,
+    signoz_auto_provision_ready: None,  # pylint: disable=unused-argument
+    get_token_auto_provision: Callable[[str, str], str],
+) -> None:
+    """With auto_provision:true, an unknown email creates exactly one user,
+    and that user's role is Viewer."""
+    unknown_email = "trustedheader-unknown-autoprovision@integration.test"
+
+    response = _get_me_for(signoz_auto_provision, unknown_email)
+    assert response.status_code == HTTPStatus.OK, response.text
+    assert response.json()["data"]["email"] == unknown_email
+
+    admin_token = get_token_auto_provision(ROOT_USER_EMAIL, ROOT_USER_PASSWORD)
+
+    users_response = requests.get(
+        signoz_auto_provision.self.host_configs["8080"].get(USERS_PATH),
+        headers={"Authorization": f"Bearer {admin_token}"},
+        timeout=5,
+    )
+    assert users_response.status_code == HTTPStatus.OK
+    matches = [u for u in users_response.json()["data"] if u["email"] == unknown_email]
+    assert len(matches) == 1, f"expected exactly one user for {unknown_email}, found {len(matches)}"
+
+    created = find_user_with_roles_by_email(signoz_auto_provision, admin_token, unknown_email)
+    assert_user_has_role(created, "signoz-viewer")
+
+
+def test_auto_provision_true_root_email_still_rejected_and_creates_nothing(
+    signoz_auto_provision: types.SigNoz,
+    signoz_auto_provision_ready: None,  # pylint: disable=unused-argument
+    get_token_auto_provision: Callable[[str, str], str],
+) -> None:
+    """With auto_provision:true, asserting the root user's email is still
+    rejected: GetOrCreateUser would otherwise find and return the existing
+    root record, so the provider must refuse it explicitly rather than
+    minting an admin-privileged identity. No new user is created for it.
+    Depends on `signoz_auto_provision_ready` so root is actually reconciled
+    by the time this runs, which is what makes the rejection prove the
+    root-specific filter rather than a mere "email matches nobody yet"."""
+    response = _get_me(signoz_auto_provision)
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+    admin_token = get_token_auto_provision(ROOT_USER_EMAIL, ROOT_USER_PASSWORD)
+
+    users_response = requests.get(
+        signoz_auto_provision.self.host_configs["8080"].get(USERS_PATH),
+        headers={"Authorization": f"Bearer {admin_token}"},
+        timeout=5,
+    )
+    assert users_response.status_code == HTTPStatus.OK
+    matches = [u for u in users_response.json()["data"] if u["email"] == ROOT_USER_EMAIL]
+    assert len(matches) == 1, "root user itself should still be the only record for this email"
+    assert matches[0]["isRoot"] is True
+
+
+def test_pending_invite_email_rejected_and_invite_remains_pending(
+    signoz_auto_provision: types.SigNoz,
+    signoz_auto_provision_ready: None,  # pylint: disable=unused-argument
+    get_token_auto_provision: Callable[[str, str], str],
+) -> None:
+    """A pending-invite user's email is rejected, and the invite is left
+    untouched: it does not get silently activated (with its role reset to
+    Viewer) as a side effect of GetOrCreateUser, even though auto_provision
+    is on and GetOrCreateUser would otherwise happily reactivate it."""
+    admin_token = get_token_auto_provision(ROOT_USER_EMAIL, ROOT_USER_PASSWORD)
+
+    pending_email = "trustedheader-pending-invite@integration.test"
+    invite_response = requests.post(
+        signoz_auto_provision.self.host_configs["8080"].get("/api/v1/invite"),
+        json={"email": pending_email, "role": "EDITOR", "name": "pending invite"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+        timeout=5,
+    )
+    assert invite_response.status_code == HTTPStatus.CREATED, invite_response.text
+
+    response = _get_me_for(signoz_auto_provision, pending_email)
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+    invited = find_user_with_roles_by_email(signoz_auto_provision, admin_token, pending_email)
+    assert invited["status"] == "pending_invite"
+    assert_user_has_role(invited, "signoz-editor")

--- a/tests/integration/tests/trustedheaderauthn/02_provisioning.py
+++ b/tests/integration/tests/trustedheaderauthn/02_provisioning.py
@@ -98,9 +98,9 @@ def test_auto_provision_true_root_email_still_rejected_and_creates_nothing(
     get_token_auto_provision: Callable[[str, str], str],
 ) -> None:
     """With auto_provision:true, asserting the root user's email is still
-    rejected: GetOrCreateUser would otherwise find and return the existing
-    root record, so the provider must refuse it explicitly rather than
-    minting an admin-privileged identity. No new user is created for it.
+    rejected: the root record is filtered from the matched set and counted as
+    ineligible, so the provider refuses up front rather than minting an
+    admin-privileged identity. No new user is created for it.
     Depends on `signoz_auto_provision_ready` so root is actually reconciled
     by the time this runs, which is what makes the rejection prove the
     root-specific filter rather than a mere "email matches nobody yet"."""
@@ -126,9 +126,10 @@ def test_pending_invite_email_rejected_and_invite_remains_pending(
     get_token_auto_provision: Callable[[str, str], str],
 ) -> None:
     """A pending-invite user's email is rejected, and the invite is left
-    untouched: it does not get silently activated (with its role reset to
-    Viewer) as a side effect of GetOrCreateUser, even though auto_provision
-    is on and GetOrCreateUser would otherwise happily reactivate it."""
+    untouched, even though auto_provision is on. This is the escalation this
+    suite found: the invite used to be adopted by the provisioning branch,
+    which activated it and reset its role to Viewer, authenticating someone
+    who had never proved control of the mailbox."""
     admin_token = get_token_auto_provision(ROOT_USER_EMAIL, ROOT_USER_PASSWORD)
 
     pending_email = "trustedheader-pending-invite@integration.test"

--- a/tests/integration/tests/trustedheaderauthn/conftest.py
+++ b/tests/integration/tests/trustedheaderauthn/conftest.py
@@ -1,0 +1,200 @@
+import time
+from collections.abc import Callable
+from http import HTTPStatus
+
+import pytest
+import requests
+from testcontainers.core.container import Network
+
+from fixtures import types
+from fixtures.auth import token_getter
+from fixtures.logger import setup_logger
+from fixtures.signoz import create_signoz
+
+logger = setup_logger(__name__)
+
+# Secret-mode trust config shared by every test in this suite. The header
+# names use hyphens rather than underscores: identn.Config.Validate refuses
+# to boot with an underscore in a configured header name, since nginx and
+# similar proxies silently drop such headers. The secret value is an
+# obviously-fake string chosen only to exercise the constant-time comparison
+# in trust.go; it is never a real credential.
+SECRET_HEADER = "X-Signoz-Trusted-Secret"
+SECRET_VALUE = "trusted-header-test-secret-do-not-reuse"
+EMAIL_HEADER = "X-Forwarded-Email"
+
+# Root is disabled by default (pkg/modules/user/config.go); it must be turned
+# on explicitly so the "root email is rejected" tests in both suites have a
+# root user to assert against. Root doubles as the admin account this suite
+# uses to create/invite/list users: SigNoz refuses a second POST
+# /api/v1/register once root reconciliation has run (it is the same
+# first-user bootstrap endpoint root itself would use), so `register_admin`
+# cannot be combined with SIGNOZ_USER_ROOT_ENABLED. Root already holds the
+# signoz-admin role (see tests/integration/tests/rootuser/02_impersonation.py),
+# so authenticating as root serves the same purpose.
+ROOT_USER_EMAIL = "trustedheader-root@integration.test"
+ROOT_USER_PASSWORD = "password123Z$"
+
+_SETUP_COMPLETED_MAX_ATTEMPTS = 15
+_ROOT_LOGIN_MAX_ATTEMPTS = 30
+_POLL_INTERVAL_SECONDS = 2
+
+
+def _trusted_header_env(auto_provision: bool) -> dict:
+    return {
+        "SIGNOZ_IDENTN_TRUSTED__HEADER_ENABLED": True,
+        "SIGNOZ_IDENTN_TRUSTED__HEADER_TRUST_MODE": "secret",
+        "SIGNOZ_IDENTN_TRUSTED__HEADER_TRUST_SECRET_HEADER": SECRET_HEADER,
+        "SIGNOZ_IDENTN_TRUSTED__HEADER_TRUST_SECRET_VALUE": SECRET_VALUE,
+        "SIGNOZ_IDENTN_TRUSTED__HEADER_AUTO__PROVISION": auto_provision,
+        "SIGNOZ_USER_ROOT_ENABLED": True,
+        "SIGNOZ_USER_ROOT_EMAIL": ROOT_USER_EMAIL,
+        "SIGNOZ_USER_ROOT_PASSWORD": ROOT_USER_PASSWORD,
+    }
+
+
+def _wait_for_setup_completed(signoz: types.SigNoz) -> None:
+    """
+    Poll /api/v1/version until setupCompleted is true. Modeled on
+    tests/integration/tests/rootuser/01_rootuser.py's phase 1.
+    """
+    last_error: Exception | None = None
+    for attempt in range(_SETUP_COMPLETED_MAX_ATTEMPTS):
+        try:
+            response = requests.get(
+                signoz.self.host_configs["8080"].get("/api/v1/version"),
+                timeout=2,
+            )
+            assert response.status_code == HTTPStatus.OK
+            if response.json().get("setupCompleted") is True:
+                return
+        except (AssertionError, requests.RequestException) as exc:
+            last_error = exc
+        logger.info("Attempt %s: setupCompleted is not yet true, retrying ...", attempt + 1)
+        time.sleep(_POLL_INTERVAL_SECONDS)
+    raise AssertionError("setupCompleted did not become true within the expected time") from last_error
+
+
+def _wait_for_root_login(signoz: types.SigNoz, email: str, password: str) -> None:
+    """
+    pkg/query-service/app/http_handler.go flips setupCompleted to true as soon
+    as it reads config.User.Root.Enabled, before the org and the root user row
+    it describes necessarily exist. The row itself is created by
+    pkg/modules/user/impluser/service.go's Start(), a background loop that
+    retries reconciliation every 10s on failure and keeps running after the
+    server is already answering requests. rootuser/01_rootuser.py hits this
+    same gap and closes it with a second poll (listing users through
+    impersonation, which only succeeds once root exists). This suite does not
+    enable impersonation, so it retries the real password login instead: that
+    only succeeds once the reconciled root user and its password both exist,
+    which is exactly the fact every test here depends on.
+    """
+    fetch_token = token_getter(signoz)
+    last_error: Exception | None = None
+    for attempt in range(_ROOT_LOGIN_MAX_ATTEMPTS):
+        try:
+            fetch_token(email, password)
+            return
+        except (AssertionError, KeyError, IndexError, requests.RequestException) as exc:
+            last_error = exc
+            logger.info("Attempt %s: root user cannot log in yet (%s), retrying ...", attempt + 1, exc)
+            time.sleep(_POLL_INTERVAL_SECONDS)
+    raise AssertionError(f"root user ({email}) did not become able to log in within the expected time") from last_error
+
+
+@pytest.fixture(name="signoz", scope="package")
+def signoz_trusted_header(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    network: Network,
+    zeus: types.TestContainerDocker,
+    gateway: types.TestContainerDocker,
+    sqlstore: types.TestContainerSQL,
+    clickhouse: types.TestContainerClickhouse,
+    request: pytest.FixtureRequest,
+    pytestconfig: pytest.Config,
+) -> types.SigNoz:
+    """
+    Package-scoped SigNoz with trusted-header secret-mode auth enabled and
+    auto_provision off. Used by the secret-mode suite and by the
+    auto_provision:false half of the provisioning suite.
+    """
+    return create_signoz(
+        network=network,
+        zeus=zeus,
+        gateway=gateway,
+        sqlstore=sqlstore,
+        clickhouse=clickhouse,
+        request=request,
+        pytestconfig=pytestconfig,
+        cache_key="signoz_trusted_header",
+        env_overrides=_trusted_header_env(auto_provision=False),
+    )
+
+
+@pytest.fixture(name="signoz_auto_provision", scope="package")
+def signoz_trusted_header_auto_provision(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    network: Network,
+    zeus: types.TestContainerDocker,
+    gateway: types.TestContainerDocker,
+    sqlstore: types.TestContainerSQL,
+    clickhouse: types.TestContainerClickhouse,
+    request: pytest.FixtureRequest,
+    pytestconfig: pytest.Config,
+) -> types.SigNoz:
+    """
+    A second, independent SigNoz instance, identical to `signoz` except
+    auto_provision is on. A package-scoped fixture carries exactly one
+    configuration, and this suite needs both values of auto_provision, so the
+    provisioning tests that require auto_provision:true depend on this
+    fixture instead of on `signoz`.
+    """
+    return create_signoz(
+        network=network,
+        zeus=zeus,
+        gateway=gateway,
+        sqlstore=sqlstore,
+        clickhouse=clickhouse,
+        request=request,
+        pytestconfig=pytestconfig,
+        cache_key="signoz_trusted_header_auto_provision",
+        env_overrides=_trusted_header_env(auto_provision=True),
+    )
+
+
+@pytest.fixture(name="signoz_ready", scope="package")
+def signoz_ready(signoz: types.SigNoz) -> None:
+    """
+    Blocks every test that depends on it until `signoz` has finished booting
+    and its root user can actually authenticate, so the login/invite/list
+    calls those tests make never race the asynchronous root reconciliation.
+    """
+    _wait_for_setup_completed(signoz)
+    _wait_for_root_login(signoz, ROOT_USER_EMAIL, ROOT_USER_PASSWORD)
+
+
+@pytest.fixture(name="signoz_auto_provision_ready", scope="package")
+def signoz_auto_provision_ready(signoz_auto_provision: types.SigNoz) -> None:
+    """Same as `signoz_ready`, for the auto_provision:true instance."""
+    _wait_for_setup_completed(signoz_auto_provision)
+    _wait_for_root_login(signoz_auto_provision, ROOT_USER_EMAIL, ROOT_USER_PASSWORD)
+
+
+@pytest.fixture(name="get_token", scope="package")
+def get_token(signoz: types.SigNoz) -> Callable[[str, str], str]:
+    """
+    Package-scoped rather than function-scoped (the model in fixtures/auth.py
+    is function-scoped): `known_user_id` in 01_secret_mode.py is
+    module-scoped and depends on this fixture to log in as root while
+    creating its known user, and pytest refuses a higher-scoped fixture
+    depending on a lower-scoped one. Widening here (rather than narrowing
+    `known_user_id` to function scope, which would recreate that user for
+    every test) is safe: the returned callable is stateless, it just performs
+    a login on each call, so sharing it across the whole package changes
+    nothing about what each call does.
+    """
+    return token_getter(signoz)
+
+
+@pytest.fixture(name="get_token_auto_provision", scope="package")
+def get_token_auto_provision(signoz_auto_provision: types.SigNoz) -> Callable[[str, str], str]:
+    """Same reasoning as `get_token`, for the auto_provision:true instance."""
+    return token_getter(signoz_auto_provision)


### PR DESCRIPTION
## Summary

We run SigNoz behind Teleport, which fronts internal apps and mints a signed JWT assertion per request. Reaching it meant a second set of SigNoz passwords, with no supported way to hand the already-authenticated user through.

Builds on #11245, which trusted the identity headers on sight. Any client that could reach the pod could set `X-Forwarded-Email` and become that user. In Kubernetes every pod shares the pod CIDR, so a peer address cannot tell the proxy from an attacker.

This PR adds the proof that a request came from the proxy. `trust.mode` is required when the resolver is enabled, and no mode trusts network placement alone.

Closes #6197. Supersedes #11245.

## Trust modes

- `jwt`: a signed assertion verified against a JWKS endpoint, then issuer, audience, expiry and not-before. Identity comes from a verified claim, so the email headers are never read and there is no shared secret to leak. Recommended, and the only mode an attacker with network access cannot forge.
- `secret`: a shared secret header, compared in constant time over SHA-256 digests, so neither the secret's contents nor its length leaks through timing. Identity comes from the email headers. Weaker, because anything that can read the pod spec can read the secret.

## Config example

Teleport application access mints the assertion and publishes the keys at `/.well-known/jwks.json`. `issuer` is the cluster name, `audience` is the application's URI:

```yaml
identn:
  trusted_header:
    enabled: true
    trust:
      mode: jwt
      jwt:
        assertion_header: Teleport-Jwt-Assertion
        jwks_url: https://teleport.example.com/.well-known/jwks.json
        issuer: teleport.example.com
        audience: https://signoz.example.com
        identity_claim: sub
    auto_provision: true
```

oauth2-proxy and Authentik forward-auth inject an email header instead of an assertion, so the secret is what proves provenance:

```yaml
identn:
  trusted_header:
    enabled: true
    trust:
      mode: secret
      secret:
        header: X-Signoz-Trusted-Secret
        value: ${SIGNOZ_TRUSTED_HEADER_SECRET}
    email_headers:
      - X-Forwarded-Email
    name_headers:
      - X-Forwarded-User
    auto_provision: false
    logout_redirect_url: https://proxy.example.com/oauth2/sign_out
```

The proxy must overwrite or strip every header named here on inbound requests. Teleport passes through any header not listed in that application's `rewrite.headers`, so an unlisted assertion or email header lets a client set its own. `conf/example.yaml` carries the full annotated block.

## Behaviour

- Disabled by default. Refuses to boot without a `trust.mode`, on a header name containing an underscore (nginx and similar drop those silently), on an empty `assertion_header`, and on a `trusted_proxies` entry with host bits set.
- 401 for a pending invite, an ambiguous match, an email resolving to a user who cannot authenticate this way, a header sent more than once (a proxy that appends instead of replacing), and any attempt to resolve to a root user.
- Auto-provisioning creates a Viewer, refuses to guess when several orgs exist, and uses `CreateUser` rather than `GetOrCreateUser`, since adoption would silently claim a pending-invite row.
- `trusted_proxies` is an optional peer CIDR allowlist. It is an extra layer on top of the trust mode, never a control to rely on by itself.
- The public config gains `identN.trustedHeader.{enabled,logoutRedirectUrl}`, carrying neither the trust mode nor any secret. The UI uses it to skip the login form and to send logout to the proxy.

## Test plan

- [x] `go test -race ./pkg/identn/... ./pkg/http/middleware/... ./pkg/global/...`
- [x] `golangci-lint run` clean on the changed packages
- [x] `pnpm jest src/api src/providers/App src/utils`, 206 pass; `pnpm tsgo --noEmit`; `pnpm build`
- [x] `pytest tests/integration/tests/trustedheaderauthn/`
- [x] Manual, both modes, behind oauth2-proxy with Keycloak as the IdP

The manual pass is the box #11245 left unchecked. In `secret` mode, login through Keycloak lands in the UI with no login form, an unknown email provisions as `signoz-viewer`, and logout reaches the proxy's sign-out endpoint. Eight forgery variants all 401, including a correct secret naming the root user, and duplicated headers.

In `jwt` mode I tested against real Keycloak `id_token`s. A valid assertion for one user plus `X-Forwarded-Email` naming root resolves to the user in the assertion, which confirms the email headers are ignored once the proof carries identity. Rejected: tampered payload, tampered signature, `alg=none` forging a root claim, malformed input, absent and duplicated assertion headers, wrong audience, and an unreachable `jwks_url`. The last two are distinguishable in the log (`get keys failed: 404` against `failed to verify id token signature`) while the caller gets the same opaque code.

That pass found one real bug, fixed in the last commit. The decision on whether a 401 had a session worth rotating read `getIsProxyAuthMode()`. That is a module singleton, and the preflight effect only sets it once the global config lands, while the protected queries fire earlier off `isLoggedIn` in localStorage. With a deliberately wrong secret this produced two rotate attempts and three hits on the proxy's sign-out endpoint, two of them inside the same second. That is the logout loop the preceding commit was meant to prevent. The interceptor now awaits preflight before reading either mode flag, and only for 401s, so password sessions keep rotating.
