### PR TITLE
fix: enforce the required tag on dashboard spec fields

### DIFF
--- a/pkg/signoz/provider.go
+++ b/pkg/signoz/provider.go
@@ -231,6 +231,7 @@ func NewSQLMigrationProviderFactories(
 		sqlmigration.NewMigrateDashboardsV1ToV2Factory(sqlstore, sqlschema, dashboardStore, tagModule),
 		sqlmigration.NewFillDashboardMeterSourceFactory(sqlstore, dashboardStore),
 		sqlmigration.NewUpdateRoleTransactionGroupsFactory(),
+		sqlmigration.NewFillDashboardSpecCollectionsFactory(sqlstore, dashboardStore),
 	)
 }
 

--- a/pkg/sqlmigration/106_fill_dashboard_spec_collections.go
+++ b/pkg/sqlmigration/106_fill_dashboard_spec_collections.go
@@ -1,0 +1,124 @@
+package sqlmigration
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/types"
+	"github.com/SigNoz/signoz/pkg/types/dashboardtypes"
+	"github.com/SigNoz/signoz/pkg/valuer"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/migrate"
+)
+
+// Required, non-nullable v2 spec fields, mapped to their empty value.
+var nullableSpecCollections = map[string]any{
+	"variables": []any{},
+	"panels":    map[string]any{},
+	"layouts":   []any{},
+}
+
+type fillDashboardSpecCollections struct {
+	sqlstore       sqlstore.SQLStore
+	dashboardStore dashboardtypes.Store
+	settings       factory.ProviderSettings
+}
+
+func NewFillDashboardSpecCollectionsFactory(sqlstore sqlstore.SQLStore, dashboardStore dashboardtypes.Store) factory.ProviderFactory[SQLMigration, Config] {
+	return factory.NewProviderFactory(
+		factory.MustNewName("fill_dashboard_spec_collections"),
+		func(ctx context.Context, ps factory.ProviderSettings, c Config) (SQLMigration, error) {
+			return &fillDashboardSpecCollections{sqlstore: sqlstore, dashboardStore: dashboardStore, settings: ps}, nil
+		},
+	)
+}
+
+func (migration *fillDashboardSpecCollections) Register(migrations *migrate.Migrations) error {
+	return migrations.Register(migration.Up, migration.Down)
+}
+
+// Up replaces a missing or null spec.variables / spec.panels / spec.layouts with the
+// empty collection. One transaction; v1 dashboards are skipped.
+func (migration *fillDashboardSpecCollections) Up(ctx context.Context, _ *bun.DB) error {
+	return migration.sqlstore.RunInTxCtx(ctx, nil, func(ctx context.Context) error {
+		var orgIDs []string
+		if err := migration.sqlstore.BunDBCtx(ctx).NewSelect().Model((*types.Organization)(nil)).Column("id").Scan(ctx, &orgIDs); err != nil {
+			return err
+		}
+
+		for _, id := range orgIDs {
+			orgID, err := valuer.NewUUID(id)
+			if err != nil {
+				return err
+			}
+			if err := migration.fillOrg(ctx, orgID); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// fillOrg fills every v2 dashboard in the org that needs it, inside the caller's transaction.
+func (migration *fillDashboardSpecCollections) fillOrg(ctx context.Context, orgID valuer.UUID) error {
+	// List, not ListV2: ListV2 paginates and excludes system dashboards; a migration needs every row.
+	storables, err := migration.dashboardStore.List(ctx, orgID)
+	if err != nil {
+		return err
+	}
+
+	logger := migration.settings.Logger
+	var stillInV1, malformedSpec, skippedNoNulls, migrated int
+	for _, storable := range storables {
+		if !storable.IsV2() {
+			stillInV1++
+			continue
+		}
+		// Raw data, not ToDashboardV2: decoding validates, and these are the rows it rejects.
+		spec, ok := storable.Data["spec"].(map[string]any)
+		if !ok {
+			malformedSpec++
+			logger.WarnContext(ctx, "v2 dashboard has no spec object; leaving it untouched", slog.String("org_id", orgID.String()), slog.String("dashboard_id", storable.ID.String()))
+			continue
+		}
+		if !fillSpecCollections(spec) {
+			skippedNoNulls++
+			continue
+		}
+		if err := migration.dashboardStore.Update(ctx, orgID, storable); err != nil {
+			return err
+		}
+		migrated++
+	}
+
+	logger.InfoContext(ctx, "filled required collections on v2 dashboards",
+		slog.String("org_id", orgID.String()),
+		slog.Int("total", len(storables)),
+		slog.Int("still_in_v1", stillInV1),
+		slog.Int("malformed_spec", malformedSpec),
+		slog.Int("skipped_no_nulls", skippedNoNulls),
+		slog.Int("migrated", migrated),
+	)
+	return nil
+}
+
+// fillSpecCollections empties each absent or null required collection, reporting whether
+// anything changed. A present value is left alone whatever its shape, so a malformed one
+// still surfaces as a validation error.
+func fillSpecCollections(spec map[string]any) bool {
+	changed := false
+	for field, empty := range nullableSpecCollections {
+		if value, present := spec[field]; !present || value == nil {
+			spec[field] = empty
+			changed = true
+		}
+	}
+	return changed
+}
+
+func (migration *fillDashboardSpecCollections) Down(context.Context, *bun.DB) error {
+	return nil
+}

--- a/pkg/types/dashboardtypes/perses_dashboard_convertors_test.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_convertors_test.go
@@ -22,7 +22,8 @@ func newTestDashboardV2(t *testing.T, orgID valuer.UUID, source Source) *Dashboa
 	updatedAt := time.Date(2026, time.January, 2, 12, 0, 0, 0, time.UTC)
 
 	spec := DashboardSpec{
-		Display: Display{Name: "Test Dashboard"},
+		Display:   Display{Name: "Test Dashboard"},
+		Variables: []Variable{},
 		Panels: map[string]*Panel{
 			"p1": {
 				Kind: "Panel",

--- a/pkg/types/dashboardtypes/perses_dashboard_data.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_data.go
@@ -63,8 +63,13 @@ func (d *DashboardSpec) Validate() error {
 	return d.validateLayouts()
 }
 
-// validateVariables rejects two variables sharing the same name.
+// validateVariables rejects an absent or null list, and duplicate variable names.
 func (d *DashboardSpec) validateVariables() error {
+	// Nil is an absent or explicitly null field; `[]` decodes non-nil. The schema
+	// declares it required and non-nullable, so both are rejected.
+	if d.Variables == nil {
+		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "spec.variables: is required and must not be null; use [] for a dashboard with no variables")
+	}
 	seen := make(map[string]struct{}, len(d.Variables))
 	for i, v := range d.Variables {
 		var name string
@@ -94,6 +99,9 @@ func (d *DashboardSpec) validateVariables() error {
 }
 
 func (d *DashboardSpec) validatePanels() error {
+	if d.Panels == nil {
+		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "spec.panels: is required and must not be null; use {} for a dashboard with no panels")
+	}
 	for key, panel := range d.Panels {
 		if err := common.ValidateID(key); err != nil {
 			return errors.WrapInvalidInputf(err, ErrCodeDashboardInvalidInput, "spec.panels: %s", err.Error())
@@ -252,6 +260,9 @@ const maxLayoutsPerDashboard = 500
 // Geometry (validateGridLayoutGeometry) needs only each layout's own data but
 // runs here so its errors can name the layout by index.
 func (d *DashboardSpec) validateLayouts() error {
+	if d.Layouts == nil {
+		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "spec.layouts: is required and must not be null; use [] for a dashboard with no layouts")
+	}
 	if len(d.Layouts) > maxLayoutsPerDashboard {
 		return errors.NewInvalidInputf(ErrCodeDashboardInvalidInput, "spec.layouts: dashboard has %d layouts; maximum is %d", len(d.Layouts), maxLayoutsPerDashboard)
 	}

--- a/pkg/types/dashboardtypes/perses_dashboard_test.go
+++ b/pkg/types/dashboardtypes/perses_dashboard_test.go
@@ -47,6 +47,7 @@ func TestInvalidateNotAJSON(t *testing.T) {
 // UnmarshalJSON methods (panel/query/variable plugin envelopes).
 func TestUnmarshalErrorPreservesNestedMessage(t *testing.T) {
 	data := []byte(`{
+		"variables": [],
 		"panels": {
 			"p1": {
 				"kind": "Panel",
@@ -77,14 +78,15 @@ func TestUnmarshalErrorPreservesNestedMessage(t *testing.T) {
 }
 
 func TestValidateEmptySpec(t *testing.T) {
-	// no variables no panels no links
-	data := []byte(`{}`)
+	// The three required collections must be present, but may be empty.
+	data := []byte(`{"variables": [], "panels": {}, "layouts": []}`)
 	_, err := unmarshalDashboard(data)
 	assert.NoError(t, err, "expected valid")
 }
 
 func TestValidateOnlyVariables(t *testing.T) {
 	data := []byte(`{
+		"panels": {},
 		"variables": [
 			{
 				"kind": "ListVariable",
@@ -116,8 +118,60 @@ func TestValidateOnlyVariables(t *testing.T) {
 	assert.NoError(t, err, "expected valid")
 }
 
+// TestInvalidateAbsentOrNullRequiredCollections pins the strict reading of the
+// schema on the three required, non-nullable collections: an absent key breaks
+// `required`, an explicit null breaks the array/object type, and both are
+// rejected. Only the empty collection is accepted.
+func TestInvalidateAbsentOrNullRequiredCollections(t *testing.T) {
+	cases := []struct {
+		description  string
+		specJSON     string
+		expectedPath string
+	}{
+		{
+			description:  "variables absent",
+			specJSON:     `{"panels": {}, "layouts": []}`,
+			expectedPath: "spec.variables",
+		},
+		{
+			description:  "variables null",
+			specJSON:     `{"variables": null, "panels": {}, "layouts": []}`,
+			expectedPath: "spec.variables",
+		},
+		{
+			description:  "panels absent",
+			specJSON:     `{"variables": [], "layouts": []}`,
+			expectedPath: "spec.panels",
+		},
+		{
+			description:  "panels null",
+			specJSON:     `{"variables": [], "panels": null, "layouts": []}`,
+			expectedPath: "spec.panels",
+		},
+		{
+			description:  "layouts absent",
+			specJSON:     `{"variables": [], "panels": {}}`,
+			expectedPath: "spec.layouts",
+		},
+		{
+			description:  "layouts null",
+			specJSON:     `{"variables": [], "panels": {}, "layouts": null}`,
+			expectedPath: "spec.layouts",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			_, err := unmarshalDashboard([]byte(c.specJSON))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), c.expectedPath+": is required and must not be null")
+		})
+	}
+}
+
 func TestInvalidateDuplicateVariableNames(t *testing.T) {
 	data := []byte(`{
+		"panels": {},
 		"variables": [
 			{
 				"kind": "TextVariable",
@@ -147,6 +201,7 @@ func TestInvalidateDuplicateVariableNames(t *testing.T) {
 func TestInvalidateVariableNameWithInvalidChars(t *testing.T) {
 	listVarWithName := func(name string) []byte {
 		return []byte(`{
+			"panels": {},
 			"variables": [
 				{
 					"kind": "ListVariable",
@@ -187,6 +242,7 @@ func TestInvalidateVariableNameWithInvalidChars(t *testing.T) {
 
 func TestInvalidatePanelKey(t *testing.T) {
 	data := []byte(`{
+		"variables": [],
 		"panels": {
 			"bad key!": {
 				"kind": "Panel",
@@ -213,6 +269,7 @@ func TestInvalidatePanelKey(t *testing.T) {
 func TestInvalidateListVariableCrossFields(t *testing.T) {
 	listVar := func(specFields string) []byte {
 		return []byte(`{
+			"panels": {},
 			"variables": [
 				{
 					"kind": "ListVariable",
@@ -295,11 +352,13 @@ func TestInvalidateListVariableCrossFields(t *testing.T) {
 func TestInvalidateEmptyVariableName(t *testing.T) {
 	cases := map[string][]byte{
 		"text variable": []byte(`{
+			"panels": {},
 			"variables": [{"kind": "TextVariable", "spec": {"name": "", "value": "x"}}],
 			"links": [],
 			"layouts": []
 		}`),
 		"list variable": []byte(`{
+			"panels": {},
 			"variables": [{
 				"kind": "ListVariable",
 				"spec": {
@@ -331,6 +390,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 		{
 			name: "unknown panel plugin",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -348,6 +408,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 		{
 			name: "unknown panel envelope kind",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Row",
@@ -364,6 +425,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 		{
 			name: "unknown query plugin",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -387,6 +449,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 		{
 			name: "unknown query envelope kind",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -410,6 +473,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 		{
 			name: "empty query envelope kind",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -433,6 +497,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 		{
 			name: "unknown variable plugin",
 			data: `{
+				"panels": {},
 				"variables": [{
 					"kind": "ListVariable",
 					"spec": {
@@ -460,6 +525,7 @@ func TestInvalidateUnknownPluginKind(t *testing.T) {
 
 func TestInvalidateOneInvalidPanel(t *testing.T) {
 	data := []byte(`{
+		"variables": [],
 		"panels": {
 			"good": {
 				"kind": "Panel",
@@ -495,7 +561,7 @@ func TestInvalidateLayoutPanelReferences(t *testing.T) {
 		}
 	}`
 	layout := func(items string) []byte {
-		return []byte(`{` + validPanels + `, "links": [], "layouts": [{"kind": "Grid", "spec": {"items": [` + items + `]}}]}`)
+		return []byte(`{"variables": [], ` + validPanels + `, "links": [], "layouts": [{"kind": "Grid", "spec": {"items": [` + items + `]}}]}`)
 	}
 
 	tests := []struct {
@@ -547,6 +613,7 @@ func TestRejectUnknownFieldsInPluginSpec(t *testing.T) {
 		{
 			name: "unknown field in panel spec",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -567,6 +634,7 @@ func TestRejectUnknownFieldsInPluginSpec(t *testing.T) {
 		{
 			name: "unknown field in query spec",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -593,6 +661,7 @@ func TestRejectUnknownFieldsInPluginSpec(t *testing.T) {
 		{
 			name: "unknown field in variable spec",
 			data: `{
+				"panels": {},
 				"variables": [{
 					"kind": "ListVariable",
 					"spec": {
@@ -630,6 +699,7 @@ func TestInvalidateWrongFieldTypeInPluginSpec(t *testing.T) {
 		{
 			name: "wrong type on panel plugin field",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -650,6 +720,7 @@ func TestInvalidateWrongFieldTypeInPluginSpec(t *testing.T) {
 		{
 			name: "wrong type on query plugin field",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -676,6 +747,7 @@ func TestInvalidateWrongFieldTypeInPluginSpec(t *testing.T) {
 		{
 			name: "wrong type on variable plugin field",
 			data: `{
+				"panels": {},
 				"variables": [{
 					"kind": "ListVariable",
 					"spec": {
@@ -715,6 +787,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 		{
 			name: "bad signal in builder query",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -744,6 +817,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 		{
 			name: "bad line interpolation",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -764,6 +838,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 		{
 			name: "bad line style",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -784,6 +859,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 		{
 			name: "bad fill mode",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -804,6 +880,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 		{
 			name: "bad spanGaps fillLessThan",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -824,6 +901,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 		{
 			name: "bad time preference",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -844,6 +922,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 		{
 			name: "bad legend position",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -864,6 +943,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 		{
 			name: "bad legend mode",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -884,6 +964,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 		{
 			name: "bad threshold format",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -904,6 +985,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 		{
 			name: "bad comparison operator",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -924,6 +1006,7 @@ func TestInvalidateBadPanelSpecValues(t *testing.T) {
 		{
 			name: "bad precision",
 			data: `{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -964,6 +1047,7 @@ func TestThresholdLabelOptional(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			data := []byte(`{
+				"variables": [],
 				"panels": {
 					"p1": {
 						"kind": "Panel",
@@ -989,6 +1073,7 @@ func TestThresholdLabelOptional(t *testing.T) {
 
 func TestInvalidatePanelWithoutQueries(t *testing.T) {
 	data := []byte(`{
+		"variables": [],
 		"panels": {
 			"p1": {
 				"kind": "Panel",
@@ -1005,6 +1090,7 @@ func TestInvalidatePanelWithoutQueries(t *testing.T) {
 
 func TestInvalidatePanelWithEmptyQueriesArray(t *testing.T) {
 	data := []byte(`{
+		"variables": [],
 		"panels": {
 			"p1": {
 				"kind": "Panel",
@@ -1027,6 +1113,7 @@ func TestInvalidatePanelWithEmptyQueriesArray(t *testing.T) {
 // signoz/CompositeQuery, not by listing multiple top-level queries.
 func TestInvalidatePanelWithMultipleDirectQueries(t *testing.T) {
 	data := []byte(`{
+		"variables": [],
 		"panels": {
 			"p1": {
 				"kind": "Panel",
@@ -1136,6 +1223,7 @@ func TestValidateRequiredFields(t *testing.T) {
 
 func TestTimeSeriesPanelDefaults(t *testing.T) {
 	data := []byte(`{
+		"variables": [],
 		"panels": {
 			"p1": {
 				"kind": "Panel",
@@ -1188,6 +1276,7 @@ func TestTimeSeriesPanelDefaults(t *testing.T) {
 
 func TestNumberPanelDefaults(t *testing.T) {
 	data := []byte(`{
+		"variables": [],
 		"panels": {
 			"p1": {
 				"kind": "Panel",
@@ -1251,6 +1340,7 @@ func TestPersesFixtureStorageRoundTrip(t *testing.T) {
 // then unmarshal it back (what would be read from DB), and verify defaults survive.
 func TestStorageRoundTrip(t *testing.T) {
 	input := []byte(`{
+		"variables": [],
 		"panels": {
 			"p1": {
 				"kind": "Panel",
@@ -1336,7 +1426,7 @@ func TestStorageRoundTrip(t *testing.T) {
 }
 
 func TestPostableDashboardV2GenerateNameFlag(t *testing.T) {
-	const validSpec = `"spec": {"panels": {}, "layouts": [], "links": []}`
+	const validSpec = `"spec": {"variables": [], "panels": {}, "layouts": [], "links": []}`
 
 	tests := []struct {
 		scenario     string
@@ -1348,13 +1438,13 @@ func TestPostableDashboardV2GenerateNameFlag(t *testing.T) {
 	}{
 		{
 			scenario:    "flag true with display.name derives name on conversion",
-			body:        `{"schemaVersion":"` + SchemaVersion + `","generateName":true,"spec":{"display":{"name":"My Dashboard!"},"panels":{},"layouts":[],"links":[]}}`,
+			body:        `{"schemaVersion":"` + SchemaVersion + `","generateName":true,"spec":{"display":{"name":"My Dashboard!"},"variables":[],"panels":{},"layouts":[],"links":[]}}`,
 			wantName:    "",
 			wantDisplay: "My Dashboard!",
 		},
 		{
 			scenario:     "flag true with non-empty name is rejected",
-			body:         `{"schemaVersion":"` + SchemaVersion + `","name":"already-set","generateName":true,"spec":{"display":{"name":"My Dashboard"},"panels":{},"layouts":[],"links":[]}}`,
+			body:         `{"schemaVersion":"` + SchemaVersion + `","name":"already-set","generateName":true,"spec":{"display":{"name":"My Dashboard"},"variables":[],"panels":{},"layouts":[],"links":[]}}`,
 			wantErr:      true,
 			wantErrMatch: "name must be empty when generateName is true",
 		},
@@ -1513,6 +1603,7 @@ func TestPanelTypeQueryTypeCompatibility(t *testing.T) {
 	}
 	mkQuery := func(panelKind, queryKind, querySpec string) []byte {
 		return []byte(`{
+			"variables": [],
 			"panels": {"p1": {"kind": "Panel", "spec": {
 				"links": [],
 				"plugin": {"kind": "` + panelKind + `", "spec": {}},
@@ -1524,6 +1615,7 @@ func TestPanelTypeQueryTypeCompatibility(t *testing.T) {
 	}
 	mkComposite := func(panelKind, subType, subSpec string) []byte {
 		return []byte(`{
+			"variables": [],
 			"panels": {"p1": {"kind": "Panel", "spec": {
 				"links": [],
 				"plugin": {"kind": "` + panelKind + `", "spec": {}},
@@ -1574,6 +1666,7 @@ func TestPanelTypeQueryTypeCompatibility(t *testing.T) {
 func TestCommaSeparatedAggregationRejectedOnWrite(t *testing.T) {
 	buildDashboardWithLogsAggregation := func(aggregationsJSON string) []byte {
 		return []byte(`{
+		"variables": [],
 		"panels": {"p1": {"kind": "Panel", "spec": {
 			"links": [],
 			"plugin": {"kind": "signoz/TimeSeriesPanel", "spec": {}},
@@ -1694,6 +1787,7 @@ func TestValidateGridItemLimit(t *testing.T) {
 // the unmarshal path — it does, via DashboardSpec.Validate -> validateLayouts.
 func TestInvalidateLayoutOverlapViaUnmarshal(t *testing.T) {
 	data := []byte(`{
+		"variables": [],
 		"panels": {
 			"p1": {"kind": "Panel", "spec": {"links": [],"plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {"name": "A", "signal": "logs", "aggregations": [{"expression": "count()"}]}}}}]}},
 			"p2": {"kind": "Panel", "spec": {"links": [],"plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {"name": "A", "signal": "logs", "aggregations": [{"expression": "count()"}]}}}}]}}
@@ -1714,6 +1808,7 @@ func TestInvalidateLayoutOverlapViaUnmarshal(t *testing.T) {
 // two items are side by side so they clear the overlap check first.
 func TestInvalidateDuplicatePanelReference(t *testing.T) {
 	data := []byte(`{
+		"variables": [],
 		"panels": {
 			"p1": {"kind": "Panel", "spec": {"links": [],"plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": [{"kind": "time_series", "spec": {"plugin": {"kind": "signoz/BuilderQuery", "spec": {"name": "A", "signal": "logs", "aggregations": [{"expression": "count()"}]}}}}]}}
 		},
@@ -1745,39 +1840,43 @@ func TestInvalidateDisplayNameTooLong(t *testing.T) {
 		expectedLabel    string
 	}{
 		{
-			scenario:         "dashboard display name",
-			limit:            MaxDisplayNameLen,
-			dashboardJSONFmt: `{"display": {"name": "%s"}, "links": [], "layouts": []}`,
-			expectedLabel:    "dashboard",
-			expectedPath:     "spec.display.name",
+			scenario: "dashboard display name",
+			limit:    MaxDisplayNameLen,
+			dashboardJSONFmt: `{
+		"variables": [],
+		"panels": {},"display": {"name": "%s"}, "links": [], "layouts": []}`,
+			expectedLabel: "dashboard",
+			expectedPath:  "spec.display.name",
 		},
 		{
 			scenario:         "panel display name",
 			limit:            MaxDisplayNameLen,
-			dashboardJSONFmt: `{"panels": {"p1": {"kind": "Panel", "spec": {"links": [], "display": {"name": "%s"}, "plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": []}}}, "links": [], "layouts": []}`,
+			dashboardJSONFmt: `{"variables": [], "panels": {"p1": {"kind": "Panel", "spec": {"links": [], "display": {"name": "%s"}, "plugin": {"kind": "signoz/TablePanel", "spec": {}}, "queries": []}}}, "links": [], "layouts": []}`,
 			expectedLabel:    "panel",
 			expectedPath:     "spec.panels.p1.spec.display.name",
 		},
 		{
 			scenario:         "list variable display name",
 			limit:            MaxDisplayNameLen,
-			dashboardJSONFmt: `{"variables": [{"kind": "ListVariable", "spec": {"name": "svc", "display": {"name": "%s"}, "plugin": {"kind": "signoz/DynamicVariable", "spec": {"name": "service.name", "signal": "metrics"}}}}], "links": [], "layouts": []}`,
+			dashboardJSONFmt: `{"panels": {}, "variables": [{"kind": "ListVariable", "spec": {"name": "svc", "display": {"name": "%s"}, "plugin": {"kind": "signoz/DynamicVariable", "spec": {"name": "service.name", "signal": "metrics"}}}}], "links": [], "layouts": []}`,
 			expectedLabel:    "variable",
 			expectedPath:     "spec.variables[0].spec.display.name",
 		},
 		{
 			scenario:         "text variable display name",
 			limit:            MaxDisplayNameLen,
-			dashboardJSONFmt: `{"variables": [{"kind": "TextVariable", "spec": {"name": "mytext", "value": "v", "display": {"name": "%s"}}}], "links": [], "layouts": []}`,
+			dashboardJSONFmt: `{"panels": {}, "variables": [{"kind": "TextVariable", "spec": {"name": "mytext", "value": "v", "display": {"name": "%s"}}}], "links": [], "layouts": []}`,
 			expectedLabel:    "variable",
 			expectedPath:     "spec.variables[0].spec.display.name",
 		},
 		{
-			scenario:         "layout title",
-			limit:            MaxLayoutTitleLen,
-			dashboardJSONFmt: `{"links": [], "layouts": [{"kind": "Grid", "spec": {"display": {"title": "%s"}, "items": []}}]}`,
-			expectedLabel:    "layout",
-			expectedPath:     "spec.layouts[0].spec.display.title",
+			scenario: "layout title",
+			limit:    MaxLayoutTitleLen,
+			dashboardJSONFmt: `{
+		"variables": [],
+		"panels": {},"links": [], "layouts": [{"kind": "Grid", "spec": {"display": {"title": "%s"}, "items": []}}]}`,
+			expectedLabel: "layout",
+			expectedPath:  "spec.layouts[0].spec.display.title",
 		},
 	}
 
@@ -1797,7 +1896,9 @@ func TestInvalidateDisplayNameTooLong(t *testing.T) {
 // A display name at exactly the limit is accepted.
 func TestValidateDisplayNameAtMaxLength(t *testing.T) {
 	atLimit := strings.Repeat("x", MaxDisplayNameLen)
-	_, err := unmarshalDashboard([]byte(`{"display": {"name": "` + atLimit + `"}, "links": [], "layouts": []}`))
+	_, err := unmarshalDashboard([]byte(`{
+		"variables": [],
+		"panels": {},"display": {"name": "` + atLimit + `"}, "links": [], "layouts": []}`))
 	assert.NoError(t, err)
 }
 

--- a/pkg/types/dashboardtypes/testdata/perses_with_sections.json
+++ b/pkg/types/dashboardtypes/testdata/perses_with_sections.json
@@ -1,4 +1,5 @@
 {
+    "variables": [],
     "display": {
         "name": "NV dashboard with sections",
         "description": ""

--- a/tests/integration/tests/dashboard/02_public_dashboard.py
+++ b/tests/integration/tests/dashboard/02_public_dashboard.py
@@ -34,7 +34,7 @@ def test_create_and_get_public_dashboard(
         json={
             "schemaVersion": "v6",
             "name": "sample-title",
-            "spec": {"display": {"name": "Sample Title"}, "links": []},
+            "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "Sample Title"}, "links": []},
             "tags": [],
         },
         headers={"Authorization": f"Bearer {admin_token}"},

--- a/tests/integration/tests/dashboard/03_v2_dashboard.py
+++ b/tests/integration/tests/dashboard/03_v2_dashboard.py
@@ -91,7 +91,7 @@ def test_create_rejects_non_dns_name(
         json={
             "schemaVersion": "v6",
             "name": "Not A Label",
-            "spec": {"display": {"name": "Not A Label"}},
+            "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "Not A Label"}},
             "tags": [],
         },
         headers={"Authorization": f"Bearer {token}"},
@@ -114,7 +114,7 @@ def test_create_rejects_unknown_field(
         json={
             "schemaVersion": "v6",
             "name": "rejects-unknown",
-            "spec": {"display": {"name": "Rejects Unknown"}, "links": []},
+            "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "Rejects Unknown"}, "links": []},
             "tags": [],
             "unknownfield": "boom",
         },
@@ -139,7 +139,7 @@ def test_create_rejects_reserved_tag_key(
         json={
             "schemaVersion": "v6",
             "name": "rejects-reserved",
-            "spec": {"display": {"name": "Rejects Reserved"}},
+            "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "Rejects Reserved"}},
             "tags": [{"key": "source", "value": "x"}],
         },
         headers={"Authorization": f"Bearer {token}"},
@@ -163,7 +163,7 @@ def test_create_rejects_too_many_tags(
         json={
             "schemaVersion": "v6",
             "name": "too-many-tags",
-            "spec": {"display": {"name": "Too Many"}},
+            "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "Too Many"}},
             "tags": tags,
         },
         headers={"Authorization": f"Bearer {token}"},
@@ -187,7 +187,7 @@ def test_create_rejects_long_display_name(
         json={
             "schemaVersion": "v6",
             "name": "long-display-name",
-            "spec": {"display": {"name": "x" * 129}},
+            "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "x" * 129}},
         },
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
@@ -205,6 +205,8 @@ def test_create_rejects_long_display_name(
             "schemaVersion": "v6",
             "name": "long-layout-title",
             "spec": {
+                "variables": [],
+                "panels": {},
                 "display": {"name": "Long Layout Title"},
                 "links": [],
                 "layouts": [{"kind": "Grid", "spec": {"display": {"title": "x" * 257}, "items": []}}],
@@ -234,6 +236,8 @@ def test_create_rejects_all_value_without_multiselect(
             "schemaVersion": "v6",
             "name": "all-without-multi",
             "spec": {
+                "panels": {},
+                "layouts": [],
                 "display": {"name": "All Without Multi"},
                 "links": [],
                 "variables": [
@@ -302,6 +306,7 @@ def test_create_rejects_invalid_grid_layout(
             "schemaVersion": "v6",
             "name": "rejects-overlap",
             "spec": {
+                "variables": [],
                 "display": {"name": "Rejects Overlap"},
                 "panels": {"p1": panel("P1"), "p2": panel("P2")},
                 "layouts": [
@@ -334,6 +339,7 @@ def test_create_rejects_invalid_grid_layout(
             "schemaVersion": "v6",
             "name": "rejects-multiref",
             "spec": {
+                "variables": [],
                 "display": {"name": "Rejects Multiref"},
                 "panels": {"p1": panel("P1")},
                 "layouts": [
@@ -366,6 +372,8 @@ def test_create_rejects_invalid_grid_layout(
             "schemaVersion": "v6",
             "name": "rejects-too-many-items",
             "spec": {
+                "variables": [],
+                "panels": {},
                 "display": {"name": "Rejects Too Many"},
                 "layouts": [
                     {
@@ -457,7 +465,7 @@ def test_update_rejects_malformed_id(
         json={
             "schemaVersion": "v6",
             "name": "malformed-id",
-            "spec": {"display": {"name": "Malformed Id"}},
+            "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "Malformed Id"}},
             "tags": [],
         },
         headers={"Authorization": f"Bearer {token}"},
@@ -479,7 +487,7 @@ def test_update_missing_dashboard_returns_not_found(
         json={
             "schemaVersion": "v6",
             "name": "missing-dashboard",
-            "spec": {"display": {"name": "Missing Dashboard"}, "links": []},
+            "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "Missing Dashboard"}, "links": []},
             "tags": [],
         },
         headers={"Authorization": f"Bearer {token}"},
@@ -675,7 +683,7 @@ def test_dashboard_v2_lifecycle(  # pylint: disable=too-many-locals,too-many-sta
             json={
                 "schemaVersion": "v6",
                 "name": name,
-                "spec": {"display": {"name": display}, "links": []},
+                "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": display}, "links": []},
                 "tags": tags,
             },
             headers={"Authorization": f"Bearer {token}"},
@@ -1037,7 +1045,7 @@ def test_dashboard_v2_lifecycle(  # pylint: disable=too-many-locals,too-many-sta
     update_body = {
         "schemaVersion": "v6",
         "name": "lc-alpha",
-        "spec": {"display": {"name": "Alpha Overview"}, "links": []},
+        "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "Alpha Overview"}, "links": []},
         "tags": [
             {"key": "team", "value": "pulse"},
             {"key": "env", "value": "prod"},
@@ -1081,7 +1089,7 @@ def test_dashboard_v2_lifecycle(  # pylint: disable=too-many-locals,too-many-sta
     beta_body = {
         "schemaVersion": "v6",
         "name": "lc-beta",
-        "spec": {"display": {"name": "Beta Overview"}, "links": []},
+        "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "Beta Overview"}, "links": []},
         "tags": [{"key": "team", "value": "pulse"}, {"key": "env", "value": "dev"}],
     }
     response = requests.put(
@@ -1185,7 +1193,7 @@ def test_dashboard_v2_tag_order_round_trips(
     ]
     response = requests.post(
         signoz.self.host_configs["8080"].get(BASE_URL),
-        json={"schemaVersion": "v6", "name": "tag-order", "spec": {"display": {"name": "Tag Order"}, "links": []}, "tags": created_order},
+        json={"schemaVersion": "v6", "name": "tag-order", "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "Tag Order"}, "links": []}, "tags": created_order},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -1211,7 +1219,7 @@ def test_dashboard_v2_tag_order_round_trips(
     ]
     response = requests.put(
         signoz.self.host_configs["8080"].get(f"{BASE_URL}/{dashboard_id}"),
-        json={"schemaVersion": "v6", "name": "tag-order", "spec": {"display": {"name": "Tag Order"}, "links": []}, "tags": reordered},
+        json={"schemaVersion": "v6", "name": "tag-order", "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "Tag Order"}, "links": []}, "tags": reordered},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -1240,7 +1248,7 @@ def test_dashboard_v2_tag_order_round_trips(
     ]
     response = requests.put(
         signoz.self.host_configs["8080"].get(f"{BASE_URL}/{dashboard_id}"),
-        json={"schemaVersion": "v6", "name": "tag-order", "spec": {"display": {"name": "Tag Order"}, "links": []}, "tags": new_order},
+        json={"schemaVersion": "v6", "name": "tag-order", "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "Tag Order"}, "links": []}, "tags": new_order},
         headers={"Authorization": f"Bearer {token}"},
         timeout=5,
     )
@@ -1277,7 +1285,7 @@ def test_dashboard_v2_pin_limit(
             json={
                 "schemaVersion": "v6",
                 "name": f"pl-{i}",
-                "spec": {"display": {"name": f"Pin Limit {i}"}, "links": []},
+                "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": f"Pin Limit {i}"}, "links": []},
                 "tags": [],
             },
             headers={"Authorization": f"Bearer {token}"},
@@ -1375,7 +1383,7 @@ def test_dashboard_v2_like_escaping(
             json={
                 "schemaVersion": "v6",
                 "name": name,
-                "spec": {"display": {"name": display}, "links": []},
+                "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": display}, "links": []},
                 "tags": [],
             },
             headers={"Authorization": f"Bearer {token}"},
@@ -1465,6 +1473,8 @@ def test_dashboard_v2_get_by_metric_name(
             "schemaVersion": "v6",
             "name": "by-metric-builder",
             "spec": {
+                "variables": [],
+                "layouts": [],
                 "display": {"name": "by-metric-builder"},
                 "links": [],
                 "panels": {
@@ -1516,6 +1526,8 @@ def test_dashboard_v2_get_by_metric_name(
             "schemaVersion": "v6",
             "name": "by-metric-ch-promql",
             "spec": {
+                "variables": [],
+                "layouts": [],
                 "display": {"name": "by-metric-ch-promql"},
                 "links": [],
                 "panels": {
@@ -1581,6 +1593,8 @@ def test_dashboard_v2_get_by_metric_name(
             "schemaVersion": "v6",
             "name": "by-metric-promql",
             "spec": {
+                "variables": [],
+                "layouts": [],
                 "display": {"name": "by-metric-promql"},
                 "links": [],
                 "panels": {
@@ -1626,6 +1640,8 @@ def test_dashboard_v2_get_by_metric_name(
             "schemaVersion": "v6",
             "name": "by-metric-false-positive",
             "spec": {
+                "variables": [],
+                "layouts": [],
                 "display": {"name": "by-metric-false-positive"},
                 "links": [],
                 "panels": {
@@ -1757,6 +1773,8 @@ def test_dashboard_v2_rejects_comma_separated_aggregation(
             "name": f"agg-{uuid.uuid4().hex[:8]}",
             "tags": [],
             "spec": {
+                "variables": [],
+                "layouts": [],
                 "display": {"name": "Aggregation"},
                 "links": [],
                 "panels": {
@@ -1850,6 +1868,7 @@ def test_dashboard_v2_roundtrip_preserves_zero_values(
         "name": "roundtrip-zero-values",
         "tags": [],
         "spec": {
+            "layouts": [],
             "display": {"name": "Roundtrip Zero Values", "description": ""},
             "duration": "",
             "refreshInterval": "",
@@ -2089,6 +2108,8 @@ def test_dashboard_v2_omitted_enums_apply_defaults(
         "name": f"enum-{uuid.uuid4().hex[:8]}",
         "tags": [],
         "spec": {
+            "variables": [],
+            "layouts": [],
             "display": {"name": "Enum"},
             "panels": {
                 "ts": {
@@ -2196,6 +2217,8 @@ def test_dashboard_v2_rejects_explicit_empty_enum(
             "name": f"enum-{uuid.uuid4().hex[:8]}",
             "tags": [],
             "spec": {
+                "variables": [],
+                "layouts": [],
                 "display": {"name": "Enum"},
                 "panels": {
                     "p": {
@@ -2225,6 +2248,8 @@ def test_dashboard_v2_rejects_explicit_empty_enum(
             "name": f"enum-{uuid.uuid4().hex[:8]}",
             "tags": [],
             "spec": {
+                "panels": {},
+                "layouts": [],
                 "display": {"name": "Enum"},
                 "variables": [
                     {

--- a/tests/integration/tests/serviceaccount/03_auth.py
+++ b/tests/integration/tests/serviceaccount/03_auth.py
@@ -94,7 +94,7 @@ def test_service_account_role_access_admin(
         json={
             "schemaVersion": "v6",
             "name": "admin-sa-dash",
-            "spec": {"display": {"name": "admin-sa-dash"}, "links": []},
+            "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "admin-sa-dash"}, "links": []},
             "tags": [],
         },
         headers={"SIGNOZ-API-KEY": api_key},
@@ -134,7 +134,7 @@ def test_service_account_role_access_editor(
         json={
             "schemaVersion": "v6",
             "name": "editor-sa-dash",
-            "spec": {"display": {"name": "editor-sa-dash"}, "links": []},
+            "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "editor-sa-dash"}, "links": []},
             "tags": [],
         },
         headers={"SIGNOZ-API-KEY": api_key},
@@ -174,7 +174,7 @@ def test_service_account_role_access_viewer(
         json={
             "schemaVersion": "v6",
             "name": "viewer-sa-dash",
-            "spec": {"display": {"name": "viewer-sa-dash"}, "links": []},
+            "spec": {"variables": [], "panels": {}, "layouts": [], "display": {"name": "viewer-sa-dash"}, "links": []},
             "tags": [],
         },
         headers={"SIGNOZ-API-KEY": api_key},


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  

The current dashboard create/update/patch APIs accept null values for variables/layouts/panels even though the spec explicitly says that they are required.

> What problem does it solve, and why is this the right approach?

This PR adds enforcement for these fields such that if any API call sends these as null or omits them, then the API call should fail.

> Why not just convert nil to empty list/object?

This goes against the semantics of the required tag.

> Why is the migration required?

The v1->v2 migration ensured that no such field is stored as empty. But because the API would still accept omitted/null values, we need to add these empty list/object values for these fields into the database for the dashboards that were erroneously created earlier. Otherwise converting the stored data into get response will fail on validation for such dashboards.

#### Issues closed by this PR

https://github.com/SigNoz/pulse-pod/issues/161