### PR TITLE
fix(dashboards-list): never replace past the caret in DSL autocomplete

### DIFF
--- a/frontend/src/pages/DashboardsListPageV2/utils/dslTokenizer.test.ts
+++ b/frontend/src/pages/DashboardsListPageV2/utils/dslTokenizer.test.ts
@@ -114,6 +114,23 @@ describe('getCaretContext — stage detection', () => {
 		expect(ctx.partial).toBe('');
 	});
 
+	it('never replaces past the caret when it sits before the operator', () => {
+		const ctx = getCaretContext("env  = 'prod'", 4);
+		expect(ctx.stage).toBe('operator');
+		expect(ctx.partial).toBe('');
+		expect(ctx.replaceStart).toBe(4);
+		expect(ctx.replaceEnd).toBe(4);
+	});
+
+	it('never replaces past the caret when it sits before the value', () => {
+		const ctx = getCaretContext("env =  'prod'", 6);
+		expect(ctx.stage).toBe('value');
+		expect(ctx.operator).toBe('=');
+		expect(ctx.partial).toBe('');
+		expect(ctx.replaceStart).toBe(6);
+		expect(ctx.replaceEnd).toBe(6);
+	});
+
 	it('detects the stage of the term under a mid-string caret', () => {
 		const q = "env =  AND team = 'core'";
 		// caret right after the first `env ` (index 4) is the operator stage
@@ -140,6 +157,13 @@ describe('spliceAtCaret', () => {
 		const ctx = getCaretContext(q, q.length);
 		const { next } = spliceAtCaret(q, ctx, "'prod'");
 		expect(next).toBe("env = 'prod'");
+	});
+
+	it('inserts (without duplicating text) at a caret parked before a token', () => {
+		const q = "env  = 'prod'";
+		const ctx = getCaretContext(q, 4);
+		const { next } = spliceAtCaret(q, ctx, '!= ');
+		expect(next).toBe("env !=  = 'prod'");
 	});
 
 	it('preserves text after the caret', () => {

--- a/frontend/src/pages/DashboardsListPageV2/utils/dslTokenizer.ts
+++ b/frontend/src/pages/DashboardsListPageV2/utils/dslTokenizer.ts
@@ -328,7 +328,7 @@ export const getCaretContext = (query: string, caret: number): CaretContext => {
 		fieldKey: scan.key ? scan.key.text : '',
 		operator: slot.operator,
 		partial: slot.partial,
-		replaceStart: term.start + slot.replaceStartRel,
+		replaceStart: Math.min(term.start + slot.replaceStartRel, pos),
 		replaceEnd: pos,
 	};
 };


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

Accepting a suggestion in the dashboards-list V2 search bar did nothing when the caret sat in the whitespace *before* an existing operator or value token — i.e. whenever you edit a query mid-string instead of typing it left-to-right. The dispatch throws before the transaction applies, so the suggestion is dropped and the exception escapes the completion handler to Sentry. The page itself keeps working.

```
RangeError: Invalid change range 16 to 15 (in doc of length 36)
  @codemirror/state@6.5.2/dist/index.js:971:31
  DashboardsListPageV2/components/SearchBar/dslCompletions.ts:38:11  <object>.apply
  @codemirror/autocomplete@6.18.6/dist/index.js:1031:9
```

#### Issues closed by this PR

Closes https://github.com/SigNoz/pulse-pod/issues/181

#### Screen Recordings

Now

https://github.com/user-attachments/assets/ba065c7f-09e7-45b2-92aa-7822e0db539a

Before

https://github.com/user-attachments/assets/85bc13c4-b5e5-4a8f-b517-c905cc0d91b3

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

`getCaretContext` resolves the active slot to the **token's** start index but keeps `replaceEnd` at the caret:

```ts
replaceStart: term.start + slot.replaceStartRel,
replaceEnd: pos,
```

When the caret has not reached that token yet, `replaceStartRel` points past it and the range comes out inverted (`replaceStart > replaceEnd`). Both call sites are affected:

- `dslCompletionSource` passes it to CodeMirror as `CompletionResult.from`/`to`, so `view.dispatch` throws on accept and the change never applies. Suggestions still render — the inverted `String.slice` yields an empty `partial` — so the popup looks normal, and picking an option simply does nothing.
- `spliceAtCaret` silently duplicates the skipped character instead of inserting.

Reachable via both the operator slot (`name  = test`, caret 5 → `from 6 to 5`) and the value slot (`env =  'prod'`, caret 6 → `from 7 to 6`). Sentry's `16 to 15` is the same off-by-one on a longer query.

#### Fix Strategy

`replaceStart..replaceEnd` is defined as the range *ending at the caret*, so `replaceStart` can never sit past it. Clamped at the single place absolute coordinates are produced, which collapses the slot to a plain insertion point at the caret:

```ts
replaceStart: Math.min(term.start + slot.replaceStartRel, pos),
```

No change needed in `dslCompletions.ts` — CodeMirror's own range mapping preserves `from <= to`; the inversion came in through our `CompletionResult`.
