### PR TITLE
refactor(querier): squash statement-builder config under querier

### DIFF
--- a/pkg/querier/config.go
+++ b/pkg/querier/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/SigNoz/signoz/pkg/errors"
 	"github.com/SigNoz/signoz/pkg/factory"
+	"github.com/SigNoz/signoz/pkg/statementbuilder"
 )
 
 const DefaultMaxConcurrentQueries = 8
@@ -19,6 +20,9 @@ type Config struct {
 	MaxConcurrentQueries int `yaml:"max_concurrent_queries" mapstructure:"max_concurrent_queries"`
 	// LogTraceIDWindowPadding is the padding added to narrowed down timerange from trace summary to logs with trace_id filter.
 	LogTraceIDWindowPadding time.Duration `yaml:"log_trace_id_window_padding" mapstructure:"log_trace_id_window_padding"`
+
+	// Keys sit under querier.skip_resource_fingerprint.
+	statementbuilder.Config `mapstructure:",squash" yaml:",squash"`
 }
 
 // NewConfigFactory creates a new config factory for querier.
@@ -29,10 +33,11 @@ func NewConfigFactory() factory.ConfigFactory {
 func newConfig() factory.Config {
 	return Config{
 		// Default values
-		CacheTTL:             168 * time.Hour,
-		FluxInterval:         5 * time.Minute,
+		CacheTTL:                168 * time.Hour,
+		FluxInterval:            5 * time.Minute,
 		MaxConcurrentQueries:    DefaultMaxConcurrentQueries,
 		LogTraceIDWindowPadding: 5 * time.Minute,
+		Config:                  statementbuilder.NewConfig(),
 	}
 }
 
@@ -49,6 +54,10 @@ func (c Config) Validate() error {
 	}
 	if c.LogTraceIDWindowPadding < 0 {
 		return errors.NewInvalidInputf(errors.CodeInvalidInput, "log_trace_id_window_padding must not be negative, got %v", c.LogTraceIDWindowPadding)
+	}
+	// Embedded Validate is shadowed by this one; call it explicitly.
+	if err := c.Config.Validate(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/signoz/config.go
+++ b/pkg/signoz/config.go
@@ -39,7 +39,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/sqlmigrator"
 	"github.com/SigNoz/signoz/pkg/sqlschema"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
-	"github.com/SigNoz/signoz/pkg/statementbuilder"
 	"github.com/SigNoz/signoz/pkg/statsreporter"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/tokenizer"
@@ -97,9 +96,6 @@ type Config struct {
 
 	// Querier config
 	Querier querier.Config `mapstructure:"querier"`
-
-	// StatementBuilder config
-	StatementBuilder statementbuilder.Config `mapstructure:"statementbuilder"`
 
 	// Ruler config
 	Ruler ruler.Config `mapstructure:"ruler"`
@@ -170,7 +166,6 @@ func NewConfig(ctx context.Context, logger *slog.Logger, resolverConfig config.R
 		prometheus.NewConfigFactory(),
 		alertmanager.NewConfigFactory(),
 		querier.NewConfigFactory(),
-		statementbuilder.NewConfigFactory(),
 		ruler.NewConfigFactory(),
 		emailing.NewConfigFactory(),
 		sharder.NewConfigFactory(),

--- a/pkg/signoz/signoz.go
+++ b/pkg/signoz/signoz.go
@@ -122,7 +122,7 @@ func newQueryStack(
 ) {
 	metadataStore := telemetrymetadata.NewTelemetryMetaStore(settings, telemetryStore, fl)
 
-	cfg := config.StatementBuilder
+	cfg := config.Querier.Config
 	traceStmtBuilder, err := tracesstatementbuilder.NewFactory(telemetryStore, metadataStore, fl).New(ctx, settings, cfg)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, nil, err

--- a/pkg/statementbuilder/config.go
+++ b/pkg/statementbuilder/config.go
@@ -2,7 +2,6 @@ package statementbuilder
 
 import (
 	"github.com/SigNoz/signoz/pkg/errors"
-	"github.com/SigNoz/signoz/pkg/factory"
 )
 
 // SkipResourceFingerprint configures when the resource fingerprint subquery is skipped in favor of main-table filtering.
@@ -18,12 +17,7 @@ type Config struct {
 	SkipResourceFingerprint SkipResourceFingerprint `yaml:"skip_resource_fingerprint" mapstructure:"skip_resource_fingerprint"`
 }
 
-// NewConfigFactory creates a new config factory for the statement builders.
-func NewConfigFactory() factory.ConfigFactory {
-	return factory.NewConfigFactory(factory.MustNewName("statementbuilder"), newConfig)
-}
-
-func newConfig() factory.Config {
+func NewConfig() Config {
 	return Config{
 		SkipResourceFingerprint: SkipResourceFingerprint{
 			Enabled:   false,

--- a/pkg/statementbuilder/logsstatementbuilder/groupby_unknown_key_test.go
+++ b/pkg/statementbuilder/logsstatementbuilder/groupby_unknown_key_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/flagger/flaggertest"
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/querybuilder"
+	"github.com/SigNoz/signoz/pkg/statementbuilder"
 	"github.com/SigNoz/signoz/pkg/telemetryschema/logstelemetryschema"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
@@ -51,7 +52,8 @@ func TestStatementBuilderGroupByUnknownKey(t *testing.T) {
 			statementBuilder := NewLogQueryStatementBuilder(
 				instrumentationtest.New().ToProviderSettings(),
 				mockMetadataStore, fm, cb, aggExprRewriter,
-				logstelemetryschema.DefaultFullTextColumn, fl, nil, false, 100000,
+				logstelemetryschema.DefaultFullTextColumn, fl, nil,
+				statementbuilder.Config{SkipResourceFingerprint: statementbuilder.SkipResourceFingerprint{Enabled: false, Threshold: 100000}},
 			)
 
 			query := qbtypes.QueryBuilderQuery[qbtypes.LogAggregation]{

--- a/pkg/statementbuilder/logsstatementbuilder/json_stmt_builder_test.go
+++ b/pkg/statementbuilder/logsstatementbuilder/json_stmt_builder_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/flagger/flaggertest"
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/querybuilder"
+	"github.com/SigNoz/signoz/pkg/statementbuilder"
 	"github.com/SigNoz/signoz/pkg/telemetryschema/logstelemetryschema"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
@@ -1346,8 +1347,7 @@ func buildJSONTestStatementBuilder(t *testing.T, addIndexes bool) (*logQueryStat
 		logstelemetryschema.DefaultFullTextColumn,
 		fl,
 		nil,
-		false,
-		100000,
+		statementbuilder.Config{SkipResourceFingerprint: statementbuilder.SkipResourceFingerprint{Enabled: false, Threshold: 100000}},
 	)
 
 	return statementBuilder, mockMetadataStore

--- a/pkg/statementbuilder/logsstatementbuilder/statement_builder.go
+++ b/pkg/statementbuilder/logsstatementbuilder/statement_builder.go
@@ -62,7 +62,7 @@ func NewFactory(
 			aggExprRewriter := querybuilder.NewAggExprRewriter(settings, logstelemetryschema.DefaultFullTextColumn, fm, cb, fl)
 			return NewLogQueryStatementBuilder(
 				settings, metadataStore, fm, cb, aggExprRewriter, logstelemetryschema.DefaultFullTextColumn,
-				fl, telemetryStore, cfg.SkipResourceFingerprint.Enabled, cfg.SkipResourceFingerprint.Threshold,
+				fl, telemetryStore, cfg,
 			), nil
 		},
 	)
@@ -77,8 +77,7 @@ func NewLogQueryStatementBuilder(
 	fullTextColumn *telemetrytypes.TelemetryFieldKey,
 	fl flagger.Flagger,
 	telemetryStore telemetrystore.TelemetryStore,
-	skipResourceFingerprintEnable bool,
-	skipResourceFingerprintThreshold uint64,
+	cfg statementbuilder.Config,
 ) *logQueryStatementBuilder {
 	logsSettings := factory.NewScopedProviderSettings(settings, "github.com/SigNoz/signoz/pkg/telemetryschema/logstelemetryschema")
 
@@ -92,7 +91,7 @@ func NewLogQueryStatementBuilder(
 		fullTextColumn,
 		fl,
 		telemetryStore,
-		skipResourceFingerprintThreshold,
+		cfg.SkipResourceFingerprint.Threshold,
 	)
 
 	return &logQueryStatementBuilder{
@@ -103,7 +102,7 @@ func NewLogQueryStatementBuilder(
 		resourceFilterResolver:         resourceFilterResolver,
 		aggExprRewriter:                aggExprRewriter,
 		fl:                             fl,
-		skipResourceFingerprintEnabled: skipResourceFingerprintEnable,
+		skipResourceFingerprintEnabled: cfg.SkipResourceFingerprint.Enabled,
 		fullTextColumn:                 fullTextColumn,
 	}
 }

--- a/pkg/statementbuilder/logsstatementbuilder/stmt_builder_test.go
+++ b/pkg/statementbuilder/logsstatementbuilder/stmt_builder_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/flagger/flaggertest"
 	"github.com/SigNoz/signoz/pkg/instrumentation/instrumentationtest"
 	"github.com/SigNoz/signoz/pkg/querybuilder"
+	"github.com/SigNoz/signoz/pkg/statementbuilder"
 	"github.com/SigNoz/signoz/pkg/telemetryschema/logstelemetryschema"
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
@@ -231,8 +232,7 @@ func TestStatementBuilderTimeSeries(t *testing.T) {
 		logstelemetryschema.DefaultFullTextColumn,
 		fl,
 		nil,
-		false,
-		100000,
+		statementbuilder.Config{SkipResourceFingerprint: statementbuilder.SkipResourceFingerprint{Enabled: false, Threshold: 100000}},
 	)
 
 	for _, c := range cases {
@@ -374,8 +374,7 @@ func TestStatementBuilderListQuery(t *testing.T) {
 		logstelemetryschema.DefaultFullTextColumn,
 		fl,
 		nil,
-		false,
-		100000,
+		statementbuilder.Config{SkipResourceFingerprint: statementbuilder.SkipResourceFingerprint{Enabled: false, Threshold: 100000}},
 	)
 
 	for _, c := range cases {
@@ -525,8 +524,7 @@ func TestStatementBuilderListQueryResourceTests(t *testing.T) {
 		logstelemetryschema.DefaultFullTextColumn,
 		fl,
 		nil,
-		false,
-		100000,
+		statementbuilder.Config{SkipResourceFingerprint: statementbuilder.SkipResourceFingerprint{Enabled: false, Threshold: 100000}},
 	)
 
 	for _, c := range cases {
@@ -603,8 +601,7 @@ func TestStatementBuilderTimeSeriesBodyGroupBy(t *testing.T) {
 		logstelemetryschema.DefaultFullTextColumn,
 		fl,
 		nil,
-		false,
-		100000,
+		statementbuilder.Config{SkipResourceFingerprint: statementbuilder.SkipResourceFingerprint{Enabled: false, Threshold: 100000}},
 	)
 
 	for _, c := range cases {
@@ -700,8 +697,7 @@ func TestStatementBuilderListQueryServiceCollision(t *testing.T) {
 		logstelemetryschema.DefaultFullTextColumn,
 		fl,
 		nil,
-		false,
-		100000,
+		statementbuilder.Config{SkipResourceFingerprint: statementbuilder.SkipResourceFingerprint{Enabled: false, Threshold: 100000}},
 	)
 
 	for _, c := range cases {
@@ -926,8 +922,7 @@ func TestAdjustKey(t *testing.T) {
 		logstelemetryschema.DefaultFullTextColumn,
 		fl,
 		nil,
-		false,
-		100000,
+		statementbuilder.Config{SkipResourceFingerprint: statementbuilder.SkipResourceFingerprint{Enabled: false, Threshold: 100000}},
 	)
 
 	for _, c := range cases {
@@ -1073,8 +1068,7 @@ func TestStmtBuilderBodyField(t *testing.T) {
 				logstelemetryschema.DefaultFullTextColumn,
 				fl,
 				nil,
-				false,
-				100000,
+				statementbuilder.Config{SkipResourceFingerprint: statementbuilder.SkipResourceFingerprint{Enabled: false, Threshold: 100000}},
 			)
 
 			q, err := statementBuilder.Build(context.Background(), valuer.UUID{}, 1747947419000, 1747983448000, c.requestType, c.query, nil)
@@ -1174,8 +1168,7 @@ func TestStmtBuilderBodyFullTextSearch(t *testing.T) {
 				logstelemetryschema.DefaultFullTextColumn,
 				fl,
 				nil,
-				false,
-				100000,
+				statementbuilder.Config{SkipResourceFingerprint: statementbuilder.SkipResourceFingerprint{Enabled: false, Threshold: 100000}},
 			)
 
 			q, err := statementBuilder.Build(context.Background(), valuer.UUID{}, 1747947419000, 1747983448000, c.requestType, c.query, nil)
@@ -1296,7 +1289,6 @@ func newSkipResourceFingerprintLogsBuilder(
 		logstelemetryschema.DefaultFullTextColumn,
 		fl,
 		telemetryStore,
-		skipEnable,
-		threshold,
+		statementbuilder.Config{SkipResourceFingerprint: statementbuilder.SkipResourceFingerprint{Enabled: skipEnable, Threshold: threshold}},
 	)
 }

--- a/tests/integration/tests/querier_skip_resource_fingerprint/conftest.py
+++ b/tests/integration/tests/querier_skip_resource_fingerprint/conftest.py
@@ -31,8 +31,8 @@ def signoz_skip_resource_fingerprint(
         pytestconfig=pytestconfig,
         cache_key="signoz-skip-resource-fingerprint",
         env_overrides={
-            "SIGNOZ_STATEMENTBUILDER_SKIP__RESOURCE__FINGERPRINT_ENABLED": True,
-            "SIGNOZ_STATEMENTBUILDER_SKIP__RESOURCE__FINGERPRINT_THRESHOLD": 2,
+            "SIGNOZ_QUERIER_SKIP__RESOURCE__FINGERPRINT_ENABLED": True,
+            "SIGNOZ_QUERIER_SKIP__RESOURCE__FINGERPRINT_THRESHOLD": 2,
         },
     )
 
@@ -66,6 +66,6 @@ def signoz_fingerprint(
         pytestconfig=pytestconfig,
         cache_key="signoz-skip-resource-fingerprint-baseline",
         env_overrides={
-            "SIGNOZ_STATEMENTBUILDER_SKIP__RESOURCE__FINGERPRINT_ENABLED": False,
+            "SIGNOZ_QUERIER_SKIP__RESOURCE__FINGERPRINT_ENABLED": False,
         },
     )


### PR DESCRIPTION
`statementbuilder.Config` was registered as its own top-level config section in #12304, but everything it configures is reached through the querier — so it becomes an embedded, squashed part of `querier.Config` instead of a sibling section.

### What
- `querier.Config` embeds `statementbuilder.Config` with `mapstructure:",squash"`, so its keys live directly under the querier namespace: `querier.skip_resource_fingerprint.*`.
- Drops the standalone `statementbuilder` section and its `NewConfigFactory`; `statementbuilder.NewConfig()` now just returns the defaults, seeded from querier's `newConfig`.
- `signoz.go` reads `config.Querier.Config` when constructing the per-signal statement builders.
- `NewLogQueryStatementBuilder` takes `statementbuilder.Config` wholesale instead of destructuring `SkipResourceFingerprint` into two positional args.

### Notes
- Env keys move: `SIGNOZ_STATEMENTBUILDER_SKIP__RESOURCE__FINGERPRINT_*` → `SIGNOZ_QUERIER_SKIP__RESOURCE__FINGERPRINT_*`. The section only landed in #12304 and nothing in this repo sets it outside the one integration conftest updated here, so this renames the keys before anything depends on them — worth a check against SaaS/helm values.
- The embedded `Validate` is shadowed by `querier.Config.Validate`, so it is called explicitly.

### Testing
- `go build ./...`, `go vet`, and the querier / signoz / statementbuilder unit tests pass; golangci-lint v2.6.0 reports 0 issues on the touched packages.
- `querier_skip_resource_fingerprint` integration tests exercise the renamed env keys.

Fixes https://github.com/SigNoz/engineering-pod/issues/5829
