### PR TITLE
refactor: adjust aggregation values for GCP metrics

### DIFF
--- a/pkg/modules/cloudintegration/implcloudintegration/definitionstore_test.go
+++ b/pkg/modules/cloudintegration/implcloudintegration/definitionstore_test.go
@@ -1,0 +1,40 @@
+package implcloudintegration
+
+import (
+	"context"
+	"testing"
+
+	citypes "github.com/SigNoz/signoz/pkg/types/cloudintegrationtypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceDefinitionsAreValid(t *testing.T) {
+	store := NewServiceDefinitionStore()
+
+	for _, provider := range []citypes.CloudProviderType{
+		citypes.CloudProviderTypeAWS,
+		citypes.CloudProviderTypeAzure,
+		citypes.CloudProviderTypeGCP,
+	} {
+		t.Run(provider.StringValue(), func(t *testing.T) {
+			defs, err := store.List(context.Background(), provider)
+			require.NoError(t, err, "all embedded definitions must load and validate")
+			require.NotEmpty(t, defs, "provider should ship at least one service definition")
+
+			for _, def := range defs {
+				assert.NotEmpty(t, def.ID, "service definition must have an id")
+				assert.NotEmpty(t, def.Title, "service %q must have a title", def.ID)
+
+				// Get() must agree with List() for every service it advertises.
+				serviceID, err := citypes.NewServiceID(provider, def.ID)
+				if !assert.NoError(t, err, "service id %q must be registered in serviceid.go", def.ID) {
+					continue
+				}
+				got, err := store.Get(context.Background(), provider, serviceID)
+				require.NoError(t, err, "service %q listed but not gettable", def.ID)
+				assert.Equal(t, def.ID, got.ID)
+			}
+		})
+	}
+}

--- a/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/cloudsql_postgres/assets/dashboards/overview.json
+++ b/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/cloudsql_postgres/assets/dashboards/overview.json
@@ -621,7 +621,7 @@
                       {
                         "metricName": "cloudsql.googleapis.com/database/postgresql/deadlock_count",
                         "temporality": "",
-                        "timeAggregation": "max",
+                        "timeAggregation": "rate",
                         "spaceAggregation": "sum",
                         "reduceTo": "avg"
                       }
@@ -882,7 +882,7 @@
                       {
                         "metricName": "cloudsql.googleapis.com/database/postgresql/transaction_count",
                         "temporality": "",
-                        "timeAggregation": "max",
+                        "timeAggregation": "rate",
                         "spaceAggregation": "sum",
                         "reduceTo": "avg"
                       }

--- a/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/cloudsql_postgres/integration.json
+++ b/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/cloudsql_postgres/integration.json
@@ -54,13 +54,13 @@
       {
         "name": "cloudsql.googleapis.com/database/postgresql/transaction_count",
         "unit": "Count",
-        "type": "Gauge",
+        "type": "Sum",
         "description": ""
       },
       {
         "name": "cloudsql.googleapis.com/database/postgresql/deadlock_count",
         "unit": "Count",
-        "type": "Gauge",
+        "type": "Sum",
         "description": ""
       },
       {

--- a/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/computeengine/assets/dashboards/overview.json
+++ b/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/computeengine/assets/dashboards/overview.json
@@ -925,7 +925,7 @@
                         "metricName": "compute.googleapis.com/instance/disk/average_io_latency",
                         "temporality": "",
                         "timeAggregation": "avg",
-                        "spaceAggregation": "sum",
+                        "spaceAggregation": "max",
                         "reduceTo": "avg"
                       }
                     ],

--- a/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/gke/assets/dashboards/overview.json
+++ b/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/gke/assets/dashboards/overview.json
@@ -1207,8 +1207,8 @@
                       {
                         "metricName": "kubernetes.io/container/restart_count",
                         "temporality": "",
-                        "timeAggregation": "max",
-                        "spaceAggregation": "max",
+                        "timeAggregation": "increase",
+                        "spaceAggregation": "sum",
                         "reduceTo": "avg"
                       }
                     ],

--- a/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/memorystore_redis/assets/dashboards/overview.json
+++ b/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/memorystore_redis/assets/dashboards/overview.json
@@ -601,8 +601,8 @@
                       {
                         "metricName": "redis.googleapis.com/stats/cache_hit_ratio",
                         "temporality": "",
-                        "timeAggregation": "max",
-                        "spaceAggregation": "sum",
+                        "timeAggregation": "min",
+                        "spaceAggregation": "min",
                         "reduceTo": "avg"
                       }
                     ],
@@ -788,7 +788,7 @@
                         "metricName": "redis.googleapis.com/commands/usec_per_call",
                         "temporality": "",
                         "timeAggregation": "max",
-                        "spaceAggregation": "sum",
+                        "spaceAggregation": "max",
                         "reduceTo": "avg"
                       }
                     ],
@@ -945,7 +945,7 @@
                       {
                         "metricName": "redis.googleapis.com/commands/calls",
                         "temporality": "",
-                        "timeAggregation": "max",
+                        "timeAggregation": "rate",
                         "spaceAggregation": "sum",
                         "reduceTo": "avg"
                       }
@@ -1044,8 +1044,8 @@
                       {
                         "metricName": "redis.googleapis.com/stats/reject_connections_count",
                         "temporality": "",
-                        "timeAggregation": "avg",
-                        "spaceAggregation": "avg",
+                        "timeAggregation": "rate",
+                        "spaceAggregation": "sum",
                         "reduceTo": "avg"
                       }
                     ],


### PR DESCRIPTION
## Pull Request

1. GCP integration dashboards - adjusted aggregation to more sensible values.
2. With delta sums metrics change which is not taking monotonicity in account, made changes to them as well to use rate function now. 