### PR TITLE
POC: AI Observability Quick Filters

### DIFF
--- a/frontend/src/api/querySuggestions/getKeySuggestions.ts
+++ b/frontend/src/api/querySuggestions/getKeySuggestions.ts
@@ -23,6 +23,7 @@ export const getKeySuggestions = (
 		fieldDataType = '',
 		signalSource = '',
 		metricNamespace = '',
+		type = '',
 	} = props;
 
 	const encodedSignal = encodeURIComponent(signal);
@@ -32,8 +33,11 @@ export const getKeySuggestions = (
 	const encodedFieldDataType = encodeURIComponent(fieldDataType);
 	const encodedSource = encodeURIComponent(signalSource);
 	const encodedMetricNamespace = encodeURIComponent(metricNamespace);
+	const encodedType = encodeURIComponent(type);
+
+	const typeParam = type ? `&type=${encodedType}` : '';
 
 	return axios.get(
-		`/fields/keys?signal=${encodedSignal}&searchText=${encodedSearchText}&metricName=${encodedMetricName}&fieldContext=${encodedFieldContext}&fieldDataType=${encodedFieldDataType}&source=${encodedSource}&metricNamespace=${encodedMetricNamespace}`,
+		`/fields/keys?signal=${encodedSignal}&searchText=${encodedSearchText}&metricName=${encodedMetricName}&fieldContext=${encodedFieldContext}&fieldDataType=${encodedFieldDataType}&source=${encodedSource}&metricNamespace=${encodedMetricNamespace}${typeParam}`,
 	);
 };

--- a/frontend/src/api/querySuggestions/getValueSuggestion.ts
+++ b/frontend/src/api/querySuggestions/getValueSuggestion.ts
@@ -15,15 +15,16 @@ import {
 export const getValueSuggestions = (
 	props: QueryKeyValueRequestProps,
 ): Promise<AxiosResponse<QueryKeyValueSuggestionsResponseProps>> => {
-	const { signal, key, searchText, signalSource, metricName } = props;
+	const { signal, key, searchText, signalSource, metricName, type } = props;
 
 	const encodedSignal = encodeURIComponent(signal);
 	const encodedKey = encodeURIComponent(key);
 	const encodedMetricName = encodeURIComponent(metricName || '');
 	const encodedSearchText = encodeURIComponent(searchText);
 	const encodedSource = encodeURIComponent(signalSource || '');
+	const typeParam = type ? `&type=${encodeURIComponent(type)}` : '';
 
 	return axios.get(
-		`/fields/values?signal=${encodedSignal}&name=${encodedKey}&searchText=${encodedSearchText}&metricName=${encodedMetricName}&source=${encodedSource}`,
+		`/fields/values?signal=${encodedSignal}&name=${encodedKey}&searchText=${encodedSearchText}&metricName=${encodedMetricName}&source=${encodedSource}${typeParam}`,
 	);
 };

--- a/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/useCheckboxFilterValues.tsx
+++ b/frontend/src/components/QuickFilters/FilterRenderers/Checkbox/useCheckboxFilterValues.tsx
@@ -27,6 +27,10 @@ function useCheckboxFilterValues({
 	searchText,
 	isOpen,
 }: UseCheckboxFilterValuesProps): UseCheckboxFilterValuesReturn {
+	const usesFieldsValuesApi =
+		source === QuickFiltersSource.METER_EXPLORER ||
+		source === QuickFiltersSource.AI_OBSERVABILITY;
+
 	const { data, isLoading } = useGetAggregateValues(
 		{
 			aggregateOperator: filter.aggregateOperator || 'noop',
@@ -38,7 +42,7 @@ function useCheckboxFilterValues({
 			searchText: searchText ?? '',
 		},
 		{
-			enabled: isOpen && source !== QuickFiltersSource.METER_EXPLORER,
+			enabled: isOpen && !usesFieldsValuesApi,
 			keepPreviousData: true,
 		},
 	);
@@ -47,9 +51,14 @@ function useCheckboxFilterValues({
 		useGetQueryKeyValueSuggestions({
 			key: filter.attributeKey.key,
 			signal: filter.dataSource || DataSource.LOGS,
-			signalSource: 'meter',
+			signalSource: source === QuickFiltersSource.METER_EXPLORER ? 'meter' : '',
+			// POC: AI value suggestions — type=builder_ai_query (no suggestions for aggregates)
+			type:
+				source === QuickFiltersSource.AI_OBSERVABILITY
+					? 'builder_ai_query'
+					: undefined,
 			options: {
-				enabled: isOpen && source === QuickFiltersSource.METER_EXPLORER,
+				enabled: isOpen && usesFieldsValuesApi,
 				keepPreviousData: true,
 			},
 		});
@@ -57,7 +66,7 @@ function useCheckboxFilterValues({
 	const attributeValues: string[] = useMemo(() => {
 		const dataType = filter.attributeKey.dataType || DataTypes.String;
 
-		if (source === QuickFiltersSource.METER_EXPLORER && keyValueSuggestions) {
+		if (usesFieldsValuesApi && keyValueSuggestions) {
 			// Process the response data
 			const responseData = keyValueSuggestions?.data as any;
 			const values = responseData.data?.values || {};
@@ -88,7 +97,12 @@ function useCheckboxFilterValues({
 		return (data?.payload?.[key] || []).filter(
 			(val) => val !== undefined && val !== null,
 		);
-	}, [data?.payload, filter.attributeKey.dataType, keyValueSuggestions, source]);
+	}, [
+		data?.payload,
+		filter.attributeKey.dataType,
+		keyValueSuggestions,
+		usesFieldsValuesApi,
+	]);
 
 	return {
 		attributeValues,

--- a/frontend/src/components/QuickFilters/QuickFiltersSettings/OtherFilters.tsx
+++ b/frontend/src/components/QuickFilters/QuickFiltersSettings/OtherFilters.tsx
@@ -48,6 +48,11 @@ function OtherFilters({
 		() => signal && signal === SignalType.METER_EXPLORER,
 		[signal],
 	);
+	// POC: AI O11y quick-filter settings fetch keys with type=builder_ai_query
+	const isAiObservability = useMemo(
+		() => signal === SignalType.AI_OBSERVABILITY,
+		[signal],
+	);
 
 	const { data: suggestionsData, isFetching: isFetchingSuggestions } =
 		useGetAttributeSuggestions(
@@ -73,7 +78,8 @@ function OtherFilters({
 			},
 			{
 				queryKey: [REACT_QUERY_KEY.GET_OTHER_FILTERS, inputValue],
-				enabled: !!signal && !isLogDataSource && !isMeterDataSource,
+				enabled:
+					!!signal && !isLogDataSource && !isMeterDataSource && !isAiObservability,
 			},
 		);
 
@@ -82,11 +88,17 @@ function OtherFilters({
 			{
 				searchText: inputValue,
 				signal: SIGNAL_DATA_SOURCE_MAP[signal as SignalType],
-				signalSource: 'meter',
+				signalSource: isMeterDataSource ? 'meter' : '',
+				// POC: AI keys API — type=builder_ai_query&signal=traces
+				type: isAiObservability ? 'builder_ai_query' : undefined,
 			},
 			{
-				queryKey: [REACT_QUERY_KEY.GET_OTHER_FILTERS, inputValue],
-				enabled: !!signal && isMeterDataSource,
+				queryKey: [
+					REACT_QUERY_KEY.GET_OTHER_FILTERS,
+					inputValue,
+					isAiObservability ? 'builder_ai_query' : undefined,
+				],
+				enabled: !!signal && (isMeterDataSource || isAiObservability),
 			},
 		);
 
@@ -94,7 +106,7 @@ function OtherFilters({
 		let filterAttributes;
 		if (isLogDataSource) {
 			filterAttributes = suggestionsData?.payload?.attributes || [];
-		} else if (isMeterDataSource) {
+		} else if (isMeterDataSource || isAiObservability) {
 			const fieldKeys: QueryKeyDataSuggestionsProps[] = Object.values(
 				fieldKeysData?.data?.data?.keys || {},
 			)?.flat();
@@ -120,6 +132,7 @@ function OtherFilters({
 		isLogDataSource,
 		fieldKeysData,
 		isMeterDataSource,
+		isAiObservability,
 	]);
 
 	const handleAddFilter = (filter: FilterType): void => {

--- a/frontend/src/components/QuickFilters/QuickFiltersSettings/constants.ts
+++ b/frontend/src/components/QuickFilters/QuickFiltersSettings/constants.ts
@@ -7,4 +7,6 @@ export const SIGNAL_DATA_SOURCE_MAP = {
 	[SignalType.EXCEPTIONS]: DataSource.TRACES,
 	[SignalType.API_MONITORING]: DataSource.TRACES,
 	[SignalType.METER_EXPLORER]: DataSource.METRICS,
+	// POC: AI quick filters still resolve attribute keys against traces
+	[SignalType.AI_OBSERVABILITY]: DataSource.TRACES,
 };

--- a/frontend/src/components/QuickFilters/types.ts
+++ b/frontend/src/components/QuickFilters/types.ts
@@ -24,6 +24,8 @@ export enum SignalType {
 	API_MONITORING = 'api_monitoring',
 	EXCEPTIONS = 'exceptions',
 	METER_EXPLORER = 'meter',
+	// POC: AI Observability explorer — maps to GET /orgs/me/filters/ai_observability
+	AI_OBSERVABILITY = 'ai_observability',
 }
 
 /**
@@ -68,6 +70,8 @@ export enum QuickFiltersSource {
 	API_MONITORING = 'api-monitoring',
 	EXCEPTIONS = 'exceptions',
 	METER_EXPLORER = 'meter',
+	// POC: AI Observability explorer surface
+	AI_OBSERVABILITY = 'ai-observability',
 }
 
 /**

--- a/frontend/src/hooks/querySuggestions/useGetQueryKeySuggestions.ts
+++ b/frontend/src/hooks/querySuggestions/useGetQueryKeySuggestions.ts
@@ -26,6 +26,7 @@ export const useGetQueryKeySuggestions: UseGetQueryKeySuggestions = (
 		fieldDataType,
 		metricName,
 		signalSource,
+		type,
 	}: QueryKeyRequestProps,
 	options?: UseQueryOptions<
 		AxiosResponse<QueryKeySuggestionsResponseProps>,
@@ -44,6 +45,7 @@ export const useGetQueryKeySuggestions: UseGetQueryKeySuggestions = (
 			fieldContext,
 			fieldDataType,
 			signalSource,
+			type,
 		];
 	}, [
 		options?.queryKey,
@@ -53,6 +55,7 @@ export const useGetQueryKeySuggestions: UseGetQueryKeySuggestions = (
 		fieldContext,
 		fieldDataType,
 		signalSource,
+		type,
 	]);
 	return useQuery<AxiosResponse<QueryKeySuggestionsResponseProps>, AxiosError>({
 		queryFn: () =>
@@ -63,6 +66,7 @@ export const useGetQueryKeySuggestions: UseGetQueryKeySuggestions = (
 				fieldContext,
 				fieldDataType,
 				signalSource,
+				type,
 			}),
 		...options,
 		queryKey,

--- a/frontend/src/hooks/querySuggestions/useGetQueryKeyValueSuggestions.ts
+++ b/frontend/src/hooks/querySuggestions/useGetQueryKeyValueSuggestions.ts
@@ -9,6 +9,7 @@ export const useGetQueryKeyValueSuggestions = ({
 	searchText,
 	signalSource,
 	metricName,
+	type,
 	options,
 }: {
 	key: string;
@@ -20,6 +21,8 @@ export const useGetQueryKeyValueSuggestions = ({
 		AxiosError
 	>;
 	metricName?: string;
+	/** POC / AI O11y: forwarded as `type` on /fields/values */
+	type?: string;
 }): UseQueryResult<
 	AxiosResponse<QueryKeyValueSuggestionsResponseProps>,
 	AxiosError
@@ -32,6 +35,7 @@ export const useGetQueryKeyValueSuggestions = ({
 			searchText,
 			signalSource,
 			metricName,
+			type,
 		],
 		queryFn: () =>
 			getValueSuggestions({
@@ -40,6 +44,7 @@ export const useGetQueryKeyValueSuggestions = ({
 				searchText: searchText || '',
 				signalSource: signalSource as 'meter' | '',
 				metricName: metricName || '',
+				type,
 			}),
 		...options,
 	});

--- a/frontend/src/pages/TracesExplorer/index.tsx
+++ b/frontend/src/pages/TracesExplorer/index.tsx
@@ -260,10 +260,13 @@ function TracesExplorer(): JSX.Element {
 		<Sentry.ErrorBoundary fallback={<ErrorBoundaryFallback />}>
 			<div className="trace-explorer-page">
 				<Card className="filter" hidden={!isOpen}>
+					{/* POC: AI Observability quick filters — signal hits /filters/ai_observability
+					    and key/value suggestions send type=builder_ai_query */}
 					<QuickFilters
 						className="qf-traces-explorer"
-						source={QuickFiltersSource.TRACES_EXPLORER}
-						signal={SignalType.TRACES}
+						source={QuickFiltersSource.AI_OBSERVABILITY}
+						signal={SignalType.AI_OBSERVABILITY}
+						showQueryName={false}
 						handleFilterVisibilityChange={(): void => {
 							setOpen(!isOpen);
 						}}

--- a/frontend/src/types/api/querySuggestions/types.ts
+++ b/frontend/src/types/api/querySuggestions/types.ts
@@ -30,11 +30,13 @@ export interface QueryKeySuggestionsResponseProps {
 export interface QueryKeyRequestProps {
 	signal: 'traces' | 'logs' | 'metrics';
 	searchText: string;
-	fieldContext?: 'resource' | 'scope' | 'attribute' | 'span';
+	fieldContext?: 'resource' | 'scope' | 'attribute' | 'span' | 'trace';
 	fieldDataType?: FieldDataType;
 	metricName?: string;
 	metricNamespace?: string;
 	signalSource?: 'meter' | '';
+	/** POC / AI O11y: e.g. 'builder_ai_query' — forwarded as `type` on /fields/keys */
+	type?: string;
 }
 
 export interface QueryKeyValueSuggestionsProps {
@@ -53,6 +55,8 @@ export interface QueryKeyValueRequestProps {
 	searchText: string;
 	signalSource?: 'meter' | '';
 	metricName?: string;
+	/** POC / AI O11y: e.g. 'builder_ai_query' — forwarded as `type` on /fields/values */
+	type?: string;
 }
 
 export type SignalType = 'traces' | 'logs' | 'metrics';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Note, this PR is just a reference. There can be some edge cases which aren't covered here since I was doing POC with cursor, so that's why, consider the props which we have added here . 

POC for AI Observability Explorer quick filters (TDD §6.2B D3 / D8).

Minimal wiring only — no tests, no new page shell.

### What changed

- Added `SignalType.AI_OBSERVABILITY` (`ai_observability`) and `QuickFiltersSource.AI_OBSERVABILITY`
- Mapped the signal → `DataSource.TRACES` in `SIGNAL_DATA_SOURCE_MAP` (filters API: `GET /orgs/me/filters/ai_observability`)
- Forward optional `type=builder_ai_query` on `/fields/keys` and `/fields/values`
- OtherFilters + checkbox value fetchers branch for the AI source
- **POC demo:** Traces Explorer mounts QuickFilters with the AI signal/source so the path is exercisable

### Out of scope

- Dedicated AI Explorer page
- Tests
- Dashboard / alerts
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f9bc660-e1c7-4863-b317-f4a2d8b6453c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f9bc660-e1c7-4863-b317-f4a2d8b6453c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

