### PR TITLE
fix(tests): deflake SSO login tests — wait until the browser has left the idp after keycloak login

### DIFF
--- a/tests/fixtures/idp.py
+++ b/tests/fixtures/idp.py
@@ -371,20 +371,20 @@ def idp_login(driver: webdriver.Chrome) -> Callable[[str, str], None]:
         password_field.send_keys(password)
 
         # Click the login button
-        login_url = driver.current_url
+        idp_host = urlparse(driver.current_url).netloc
         login_button = wait.until(EC.element_to_be_clickable((By.ID, "kc-login")))
         login_button.click()
 
-        # Wait till the browser has navigated off the login page, which means that a redirection is taking place.
-        # The button is looked up afresh on every poll instead of reusing the clicked element: mid-navigation the
-        # old node detaches and chrome reports that as a bare WebDriverException, not a stale element reference.
-        def _left_login_page(drv: webdriver.Chrome) -> bool:
+        # Wait till the browser has left the idp host — not just the login page: keycloak's SAML flow inserts an
+        # auto-submitting interstitial on the idp whose POST is what creates the user in signoz. The button is
+        # re-queried per poll; a mid-navigation WebDriverException (detached node) just retries the poll.
+        def _left_idp(drv: webdriver.Chrome) -> bool:
             try:
-                return drv.current_url != login_url and not drv.find_elements(By.ID, "kc-login")
+                return urlparse(drv.current_url).netloc != idp_host and not drv.find_elements(By.ID, "kc-login")
             except WebDriverException:
                 return False
 
-        wait.until(_left_login_page)
+        wait.until(_left_idp)
 
     return _idp_login
 

--- a/tests/fixtures/idp.py
+++ b/tests/fixtures/idp.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 from keycloak import KeycloakAdmin
 from selenium import webdriver
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
@@ -370,11 +371,20 @@ def idp_login(driver: webdriver.Chrome) -> Callable[[str, str], None]:
         password_field.send_keys(password)
 
         # Click the login button
+        login_url = driver.current_url
         login_button = wait.until(EC.element_to_be_clickable((By.ID, "kc-login")))
         login_button.click()
 
-        # Wait till kc-login element has vanished from the page, which means that a redirection is taking place.
-        wait.until(EC.invisibility_of_element((By.ID, "kc-login")))
+        # Wait till the browser has navigated off the login page, which means that a redirection is taking place.
+        # The button is looked up afresh on every poll instead of reusing the clicked element: mid-navigation the
+        # old node detaches and chrome reports that as a bare WebDriverException, not a stale element reference.
+        def _left_login_page(drv: webdriver.Chrome) -> bool:
+            try:
+                return drv.current_url != login_url and not drv.find_elements(By.ID, "kc-login")
+            except WebDriverException:
+                return False
+
+        wait.until(_left_login_page)
 
     return _idp_login
 


### PR DESCRIPTION
Deflakes the SSO login tests (`callbackauthn` and `basepath`). They all share the `idp_login` fixture, and after it clicked Keycloak's login button it could hand control back to the test too early — in two different ways ([example CI failure](https://github.com/SigNoz/signoz/actions/runs/30898802502/job/91957986941)).

### What

The fixture used to wait for the login button to disappear and treat that as "login is done". Two things go wrong with that:

1. **The page can vanish while we're looking at it.** Asking "is the button still visible?" takes two round-trips to the browser: find `kc-login`, then ask whether it's displayed. If Keycloak's redirect lands between the two, the second call is asking about a node that no longer exists. Selenium normally recognises that as a stale element and quietly retries — but Keycloak → SigNoz is a *same-site* hop (`localhost` → `localhost`), where the renderer survives the swap and that detection can miss. The raw chromedriver error (`Node with given id does not belong to the document`) then escapes and fails the test. That's the CI failure above.

2. **The button disappearing doesn't mean login finished.** It only means we left the login *page*. In the SAML flow Keycloak next serves a small auto-submitting page — still on the IdP — and *that* POST is what actually creates the user in SigNoz. So a test could go looking for the user before SigNoz had ever seen the callback, and fail with `User ... not found`. Reproduces locally on `test_idp_initiated_saml_authn`.

The wait now checks what the tests actually need: **the browser has left the IdP host** (the hostname in the URL changed) *and* the login button is gone.

### Guardrails

- Nothing is held across the navigation — the button is looked up fresh on every poll with `find_elements`, so "gone" is simply an empty list, never a question asked of a dying node.
- Any browser error during a poll is read as "still navigating, try again" instead of failing the wait.
- The wait sits through everything that's still on Keycloak (the `login-actions` hops, the SAML interstitial) and passes only once SigNoz has handled the callback and redirected — so the user exists by the time the test asserts on it.
- Wrong credentials still fail loudly: Keycloak re-renders the login form on its own host, so the wait times out exactly as before.

One change, in the shared fixture — the OIDC and SAML flows in both `callbackauthn` and `basepath` all go through it.

### Notes

- Failure 1 needs the redirect to land inside a ~2–5 ms window of a poll that only runs every 500 ms, so it's effectively a loaded-CI-runner lottery — which is why it's rare and CI-only. Failure 2 shows up locally.
- Unrelated to the PR it fired on (#12382, query-builder only); the identical SAML test passed in the same run.

### Testing

- Reproduced failure 1 outside pytest, with a probe driving real headless **Chrome for Testing 151.0.7922.71** (the exact build from the CI log) through a click → POST → same-site redirect that mimics the Keycloak login flow, with server think-time near the 500 ms poll boundary. Both waits ran verbatim, at their real polling rate:

  | Post-click wait | Logins | Failures |
  |---|---|---|
  | old (`EC.invisibility_of_element`) | 400 | **3 × the exact CI inspector error** |
  | new (left-the-IdP check) | 400 | **0** |

- Cross-checked the mechanism against the selenium 4.40 source with a stubbed driver: the detached-node error does escape the old wait (it only catches stale/not-found), while the new one absorbs it and passes on the next poll. A bad-credentials control times out on both old and new, so failure detection isn't weakened.
- Ran the full suites locally on the final fixture, with a fresh sqlite + wal store per suite (matching the failing CI leg): `basepath` 6/6, and all 36 SSO/domain tests in `callbackauthn` — including `test_idp_initiated_saml_authn`, which flaked with `User not found` on the old wait in the same setup. (The one local non-pass, `test_apply_license`, is unrelated: it asserts on wiremock's request journal and the reused license-mock container is never reset between runs — CI gets a fresh mock.)
- `make py-fmt` / `make py-lint` clean.

Fixes https://github.com/SigNoz/engineering-pod/issues/5850
