### PR TITLE
chore(flagger): remove use_fine_grained_authz feature flag

### DIFF
--- a/ee/query-service/app/api/featureFlags.go
+++ b/ee/query-service/app/api/featureFlags.go
@@ -80,15 +80,6 @@ func (ah *APIHandler) getFeatureFlags(w http.ResponseWriter, r *http.Request) {
 		Route:      "",
 	})
 
-	fineGrainedAuthz := ah.Signoz.Flagger.BooleanOrEmpty(ctx, flagger.FeatureUseFineGrainedAuthz, evalCtx)
-	featureSet = append(featureSet, &licensetypes.Feature{
-		Name:       valuer.NewString(flagger.FeatureUseFineGrainedAuthz.String()),
-		Active:     fineGrainedAuthz,
-		Usage:      0,
-		UsageLimit: -1,
-		Route:      "",
-	})
-
 	aiObservability := ah.Signoz.Flagger.BooleanOrEmpty(ctx, flagger.FeatureEnableAIObservability, evalCtx)
 	featureSet = append(featureSet, &licensetypes.Feature{
 		Name:       valuer.NewString(flagger.FeatureEnableAIObservability.String()),

--- a/frontend/src/constants/features.ts
+++ b/frontend/src/constants/features.ts
@@ -9,7 +9,6 @@ export enum FeatureKeys {
 	ANOMALY_DETECTION = 'anomaly_detection',
 	DOT_METRICS_ENABLED = 'dot_metrics_enabled',
 	USE_JSON_BODY = 'use_json_body',
-	USE_FINE_GRAINED_AUTHZ = 'use_fine_grained_authz',
 	ENABLE_AI_OBSERVABILITY = 'enable_ai_observability',
 	ENABLE_METRICS_REDUCTION = 'enable_metrics_reduction',
 }

--- a/frontend/src/container/RolesSettings/CreateEditRolePage/__tests__/CreateEditRolePage.featureGate.test.tsx
+++ b/frontend/src/container/RolesSettings/CreateEditRolePage/__tests__/CreateEditRolePage.featureGate.test.tsx
@@ -1,8 +1,7 @@
 import { Route, Switch } from 'react-router-dom';
 import ROUTES from 'constants/routes';
-import { FeatureKeys } from 'constants/features';
 import { server } from 'mocks-server/server';
-import { defaultFeatureFlags, render, screen } from 'tests/test-utils';
+import { render, screen } from 'tests/test-utils';
 import {
 	invalidLicense,
 	setupAuthzAdmin,
@@ -59,23 +58,6 @@ function renderEditPage(
 
 describe('CreateEditRolePage - Feature Gate', () => {
 	describe('create mode - feature disabled', () => {
-		it('shows error when fine-grained authz flag is inactive', async () => {
-			renderCreatePage({
-				featureFlags: defaultFeatureFlags.map((f) =>
-					f.name === FeatureKeys.USE_FINE_GRAINED_AUTHZ
-						? { ...f, active: false }
-						: f,
-				),
-			});
-
-			await expect(
-				screen.findByTestId('feature-gate-error-banner'),
-			).resolves.toBeInTheDocument();
-			await expect(
-				screen.findByText(/Custom roles feature is not available/i),
-			).resolves.toBeInTheDocument();
-		});
-
 		it('shows error when license is invalid', async () => {
 			renderCreatePage({ activeLicense: invalidLicense });
 
@@ -112,23 +94,6 @@ describe('CreateEditRolePage - Feature Gate', () => {
 	describe('edit mode - feature disabled', () => {
 		const ROLE_ID = '019c24aa-3333-0001-aaaa-111111111111';
 		const ROLE_NAME = 'test-role';
-
-		it('shows error when fine-grained authz flag is inactive', async () => {
-			renderEditPage(ROLE_ID, ROLE_NAME, {
-				featureFlags: defaultFeatureFlags.map((f) =>
-					f.name === FeatureKeys.USE_FINE_GRAINED_AUTHZ
-						? { ...f, active: false }
-						: f,
-				),
-			});
-
-			await expect(
-				screen.findByTestId('feature-gate-error-banner'),
-			).resolves.toBeInTheDocument();
-			await expect(
-				screen.findByText(/Custom roles feature is not available/i),
-			).resolves.toBeInTheDocument();
-		});
 
 		it('shows error when license is invalid', async () => {
 			renderEditPage(ROLE_ID, ROLE_NAME, { activeLicense: invalidLicense });

--- a/frontend/src/container/RolesSettings/ViewRolePage/__tests__/ViewRolePage.featureGate.test.tsx
+++ b/frontend/src/container/RolesSettings/ViewRolePage/__tests__/ViewRolePage.featureGate.test.tsx
@@ -1,7 +1,6 @@
 import * as roleApi from 'api/generated/services/role';
-import { FeatureKeys } from 'constants/features';
 import { server } from 'mocks-server/server';
-import { defaultFeatureFlags, render, screen, waitFor } from 'tests/test-utils';
+import { render, screen, waitFor } from 'tests/test-utils';
 import {
 	invalidLicense,
 	setupAuthzAdmin,
@@ -33,26 +32,6 @@ describe('ViewRolePage - Feature Gate', () => {
 	});
 
 	describe('feature disabled', () => {
-		it('shows error when fine-grained authz flag is inactive', async () => {
-			render(<ViewRolePage />, undefined, {
-				initialRoute: buildViewRoleRoute(CUSTOM_ROLE_ID, CUSTOM_ROLE_NAME),
-				appContextOverrides: {
-					featureFlags: defaultFeatureFlags.map((f) =>
-						f.name === FeatureKeys.USE_FINE_GRAINED_AUTHZ
-							? { ...f, active: false }
-							: f,
-					),
-				},
-			});
-
-			await expect(
-				screen.findByTestId('feature-gate-error-banner'),
-			).resolves.toBeInTheDocument();
-			await expect(
-				screen.findByText(/Custom roles feature is not available/i),
-			).resolves.toBeInTheDocument();
-		});
-
 		it('shows error when license is invalid', async () => {
 			render(<ViewRolePage />, undefined, {
 				initialRoute: buildViewRoleRoute(CUSTOM_ROLE_ID, CUSTOM_ROLE_NAME),

--- a/frontend/src/container/RolesSettings/__tests__/RolesSettings.authz.test.tsx
+++ b/frontend/src/container/RolesSettings/__tests__/RolesSettings.authz.test.tsx
@@ -4,13 +4,7 @@ import {
 } from 'mocks-server/__mockdata__/roles';
 import { server } from 'mocks-server/server';
 import { rest } from 'msw';
-import {
-	defaultFeatureFlags,
-	render,
-	screen,
-	userEvent,
-} from 'tests/test-utils';
-import { FeatureKeys } from 'constants/features';
+import { render, screen, userEvent } from 'tests/test-utils';
 import {
 	invalidLicense,
 	setupAuthzAdmin,
@@ -189,30 +183,6 @@ describe('RolesSettings', () => {
 				).resolves.toBeInTheDocument();
 			}
 		}
-	});
-
-	it('hides the create button and disables row clicks when fine-grained authz flag is inactive', async () => {
-		render(<RolesSettings />, undefined, {
-			appContextOverrides: {
-				featureFlags: defaultFeatureFlags.map((f) =>
-					f.name === FeatureKeys.USE_FINE_GRAINED_AUTHZ
-						? { ...f, active: false }
-						: f,
-				),
-			},
-		});
-
-		await expect(screen.findByText('signoz-admin')).resolves.toBeInTheDocument();
-
-		expect(
-			screen.queryByRole('button', { name: /custom role/i }),
-		).not.toBeInTheDocument();
-
-		const rows = document.querySelectorAll('.roles-table-row');
-		rows.forEach((row) => {
-			expect(row).not.toHaveClass('roles-table-row--clickable');
-			expect(row.getAttribute('role')).not.toBe('button');
-		});
 	});
 
 	it('hides the create button and disables row clicks when license is not valid', async () => {

--- a/frontend/src/hooks/useRolesFeatureGate.ts
+++ b/frontend/src/hooks/useRolesFeatureGate.ts
@@ -1,4 +1,3 @@
-import { FeatureKeys } from 'constants/features';
 import { useAppContext } from 'providers/App/App';
 import { LicenseStatus } from 'types/api/licensesV3/getActive';
 
@@ -6,22 +5,12 @@ export const useRolesFeatureGate = (): {
 	isRolesEnabled: boolean;
 	isLoading: boolean;
 } => {
-	const {
-		activeLicense,
-		featureFlags,
-		isFetchingActiveLicense,
-		isFetchingFeatureFlags,
-	} = useAppContext();
+	const { activeLicense, isFetchingActiveLicense } = useAppContext();
 
 	const isValidLicense = activeLicense?.status === LicenseStatus.VALID;
-	const isFineGrainedAuthzEnabled =
-		featureFlags?.find((f) => f.name === FeatureKeys.USE_FINE_GRAINED_AUTHZ)
-			?.active ?? false;
 
 	return {
-		isRolesEnabled: isValidLicense && isFineGrainedAuthzEnabled,
-		isLoading:
-			(isFetchingActiveLicense && !activeLicense) ||
-			(isFetchingFeatureFlags && !featureFlags),
+		isRolesEnabled: isValidLicense,
+		isLoading: isFetchingActiveLicense && !activeLicense,
 	};
 };

--- a/frontend/src/tests/test-utils.tsx
+++ b/frontend/src/tests/test-utils.tsx
@@ -150,13 +150,6 @@ export const defaultFeatureFlags = [
 		usage_limit: -1,
 		route: '',
 	},
-	{
-		name: FeatureKeys.USE_FINE_GRAINED_AUTHZ,
-		active: true,
-		usage: 0,
-		usage_limit: -1,
-		route: '',
-	},
 ];
 
 export function getAppContextMock(

--- a/pkg/flagger/registry.go
+++ b/pkg/flagger/registry.go
@@ -10,7 +10,6 @@ var (
 	FeaturePutMetersInZeus        = featuretypes.MustNewName("put_meters_in_zeus")
 	FeatureUseMeterReporter       = featuretypes.MustNewName("use_meter_reporter")
 	FeatureUseJSONBody            = featuretypes.MustNewName("use_json_body")
-	FeatureUseFineGrainedAuthz    = featuretypes.MustNewName("use_fine_grained_authz")
 	FeatureEnableAIObservability  = featuretypes.MustNewName("enable_ai_observability")
 	FeatureEnableMetricsReduction = featuretypes.MustNewName("enable_metrics_reduction")
 	FeatureUsePrometheusClickhouseV2 = featuretypes.MustNewName("use_prometheus_clickhouse_v2")
@@ -71,14 +70,6 @@ func MustNewRegistry() featuretypes.Registry {
 			Kind:           featuretypes.KindBoolean,
 			Stage:          featuretypes.StageExperimental,
 			Description:    "Controls whether body JSON querying is enabled",
-			DefaultVariant: featuretypes.MustNewName("disabled"),
-			Variants:       featuretypes.NewBooleanVariants(),
-		},
-		&featuretypes.Feature{
-			Name:           FeatureUseFineGrainedAuthz,
-			Kind:           featuretypes.KindBoolean,
-			Stage:          featuretypes.StageExperimental,
-			Description:    "Controls whether fine-grained authorization is enabled",
 			DefaultVariant: featuretypes.MustNewName("disabled"),
 			Variants:       featuretypes.NewBooleanVariants(),
 		},

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1599,15 +1599,6 @@ func (aH *APIHandler) getFeatureFlags(w http.ResponseWriter, r *http.Request) {
 		Route:      "",
 	})
 
-	fineGrainedAuthz := aH.Signoz.Flagger.BooleanOrEmpty(r.Context(), flagger.FeatureUseFineGrainedAuthz, evalCtx)
-	featureSet = append(featureSet, &licensetypes.Feature{
-		Name:       valuer.NewString(flagger.FeatureUseFineGrainedAuthz.String()),
-		Active:     fineGrainedAuthz,
-		Usage:      0,
-		UsageLimit: -1,
-		Route:      "",
-	})
-
 	aiObservability := aH.Signoz.Flagger.BooleanOrEmpty(r.Context(), flagger.FeatureEnableAIObservability, evalCtx)
 	featureSet = append(featureSet, &licensetypes.Feature{
 		Name:       valuer.NewString(flagger.FeatureEnableAIObservability.String()),


### PR DESCRIPTION
## Summary

Removes the `use_fine_grained_authz` feature flag (added in #11341). The custom roles feature is permanent now, so the flag is no longer needed.

The flag had no backend gating — it was only published via `GET /api/v1/featureFlags`. The sole consumer was the frontend `useRolesFeatureGate` hook, which gated the custom-roles UI on `validLicense && flagActive`. The roles UI is now gated by license validity alone.

## Changes

**Backend**
- Remove the flag constant and registration from `pkg/flagger/registry.go`
- Remove the publish blocks from the community (`pkg/query-service/app/http_handler.go`) and EE (`ee/query-service/app/api/featureFlags.go`) featureFlags handlers

**Frontend**
- `useRolesFeatureGate` now returns `isRolesEnabled` based only on license validity
- Remove `USE_FINE_GRAINED_AUTHZ` from `FeatureKeys` and from `defaultFeatureFlags` in test-utils
- Delete the flag-inactive tests; the parallel license-invalid tests keep the disabled-state UI paths covered (those branches remain reachable via an invalid license)

## Testing

- `go build` on affected packages passes
- `tsc --noEmit` clean on touched files
- `npx jest src/container/RolesSettings`: 21 suites, 241 tests pass
- `rg -i 'fine_grained_authz|FineGrainedAuthz'` returns no matches