### PR TITLE
fix: add history replace in trace detail 

### DIFF
--- a/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
+++ b/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/Success.tsx
@@ -690,7 +690,7 @@ function Success(props: ISuccessProps): JSX.Element {
 				urlQuery.set('spanId', span?.span_id);
 			}
 
-			safeNavigate({ search: urlQuery.toString() });
+			safeNavigate({ search: urlQuery.toString() }, { replace: true });
 		},
 		[setSelectedSpan, urlQuery, safeNavigate],
 	);

--- a/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/__tests__/UnifiedSpanClick.test.tsx
+++ b/frontend/src/pages/TraceDetailsV3/TraceWaterfall/TraceWaterfallStates/Success/__tests__/UnifiedSpanClick.test.tsx
@@ -260,11 +260,13 @@ describe('Span Click User Flows', () => {
 		) as HTMLElement;
 		await user.click(spanElement);
 
-		// Verify URL was updated with spanId
 		expect(mockUrlQuery.get('spanId')).toBe('span-1');
-		expect(mockSafeNavigate).toHaveBeenCalledWith({
-			search: expect.stringContaining('spanId=span-1'),
-		});
+		expect(mockSafeNavigate).toHaveBeenCalledWith(
+			{
+				search: expect.stringContaining('spanId=span-1'),
+			},
+			{ replace: true },
+		);
 	});
 
 	it('clicking span duration visually selects the span', async () => {
@@ -430,10 +432,13 @@ describe('Span Click User Flows', () => {
 		expect(mockUrlQuery.get('anotherParam')).toBe('anotherValue');
 		expect(mockUrlQuery.get('spanId')).toBe('span-1');
 
-		expect(mockSafeNavigate).toHaveBeenCalledWith({
-			search: expect.stringMatching(
-				/existingParam=existingValue.*anotherParam=anotherValue.*spanId=span-1/,
-			),
-		});
+		expect(mockSafeNavigate).toHaveBeenCalledWith(
+			{
+				search: expect.stringMatching(
+					/existingParam=existingValue.*anotherParam=anotherValue.*spanId=span-1/,
+				),
+			},
+			{ replace: true },
+		);
 	});
 });

--- a/frontend/src/pages/TraceDetailsV3/index.tsx
+++ b/frontend/src/pages/TraceDetailsV3/index.tsx
@@ -80,7 +80,7 @@ function TraceDetailsV3(): JSX.Element {
 
 	const handleSpanDetailsClose = useCallback((): void => {
 		urlQuery.delete('spanId');
-		safeNavigate({ search: urlQuery.toString() });
+		safeNavigate({ search: urlQuery.toString() }, { replace: true });
 	}, [urlQuery, safeNavigate]);
 
 	const handleFilteredSpansChange = useCallback(


### PR DESCRIPTION
## Pull Request

We have issues in TraceDetailsV3:
- When you open TraceDetailsV3 and click on spans, if you keep clicking on these spans, it will change the URL. When you click on Go Back, it will just navigate you through the history of URLs you have clicked, which is not the right experience.
- The same thing happens if you have opened span details, The drawerless modal on the right-hand side: if you close it and click on the Back button, it will just open that drawer once again.

### 📄 Summary


#### Screenshots / Screen Recordings (if applicable)


https://github.com/user-attachments/assets/a60f544c-83ea-4f06-9233-8fc722428a04


#### Issues closed by this PR

Closes - 

Before - 
https://github.com/orgs/SigNoz/projects/39/views/11?filterQuery=assignee%3Atewarig&pane=issue&itemId=223289782&issue=SigNoz%7Cengineering-pod%7C5851


Now - 

https://github.com/user-attachments/assets/ec28925b-c61a-43f1-b01e-510fab7c5a62



---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

We are pushing span click as well as when the span detail modal closes and opens to the history. Ideally, we should just replace it.


#### Fix Strategy

Pass `{ replace: true }` to `safeNavigate` at both call sites. Every route that mutates `spanId` in trace details now replaces rather than pushes:

| Site | Trigger | Before | After |
|---|---|---|---|
| `Success.tsx:693` | waterfall span click | push | **replace** |
| `index.tsx:83` | close span details panel | push | **replace** |


`useCopySpanLink` also builds a `spanId` URL but only writes it to the clipboard — it never navigates, so it is correctly untouched.

---

### 🧪 Testing Strategy

- **Tests added/updated:** `UnifiedSpanClick.test.tsx` 
I have tested manually.

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** Small and contained. Two one-line changes, both inside `pages/TraceDetailsV3`. No API, schema, or shared-utility changes. Nothing outside trace details reads or writes the `spanId` param.
- **Rollback plan:** Revert the commit. There is no state, migration, or persisted data involved, so a revert fully restores the prior behaviour with no cleanup.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | The browser Back button on the trace detail page now returns you to the page you came from, instead of stepping back through each span you had clicked within the trace. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers


Two smaller notes:

