### PR TITLE
test(dashboard-v2): e2e for panel actions, controls, drilldown and the View modal

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/components/ResizableTable/ResizableHeader.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/components/ResizableTable/ResizableHeader.tsx
@@ -16,6 +16,8 @@ export interface ResizableHeaderProps extends Omit<
 > {
 	width?: number;
 	onResize?: (e: SyntheticEvent<Element>, data: ResizeCallbackData) => void;
+	/** Column key, used only to give the drag grip a stable test handle. */
+	columnKey?: string;
 }
 
 /**
@@ -27,6 +29,7 @@ export interface ResizableHeaderProps extends Omit<
 function ResizableHeader({
 	width,
 	onResize,
+	columnKey,
 	...restProps
 }: ResizableHeaderProps): JSX.Element {
 	const handle = useMemo(
@@ -34,13 +37,14 @@ function ResizableHeader({
 			<span
 				className={styles.handle}
 				role="presentation"
+				data-testid={columnKey ? `column-resize-${columnKey}` : undefined}
 				// Stop the grip's click from reaching the column sorter underneath.
 				// The grip is a pointer-only resize affordance, not keyboard-actionable.
 				// oxlint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
 				onClick={(e): void => e.stopPropagation()}
 			/>
 		),
-		[],
+		[columnKey],
 	);
 
 	if (!width || !onResize) {
@@ -64,6 +68,7 @@ function ResizableHeader({
 ResizableHeader.defaultProps = {
 	width: undefined,
 	onResize: undefined,
+	columnKey: undefined,
 };
 
 export default ResizableHeader;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/hooks/useResizableColumns.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/Panels/hooks/useResizableColumns.ts
@@ -132,6 +132,7 @@ export function useResizableColumns<T>({
 					onHeaderCell: (): ResizableHeaderProps => ({
 						width,
 						onResize: key && width ? handleResize(key) : undefined,
+						columnKey: key,
 					}),
 				} as Column<T>;
 			}),

--- a/tests/e2e/helpers/panel-editor-v2.ts
+++ b/tests/e2e/helpers/panel-editor-v2.ts
@@ -1,0 +1,288 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+// Locators and interactions for the V2 panel editor.
+//
+// Two gotchas: antd popups portal to `document.body` (a testid finds the
+// TRIGGER, options live in a detached `.ant-select-dropdown`), and config
+// sections only mount their editors while open.
+
+// ─── Labels ──────────────────────────────────────────────────────────────
+
+export const EditorText = {
+	title: 'Configure panel',
+	unsavedBadge: 'Unsaved Changes',
+	save: 'Save changes',
+	switchToView: 'Switch to View Mode',
+	discardTitle: 'Discard changes?',
+	discardBody: 'Your unsaved edits to this panel will be lost.',
+	savedToast: 'Panel saved',
+	lockedReason: 'This dashboard is locked',
+	runQuery: 'Run Query',
+} as const;
+
+export const QueryTab = {
+	builder: 'Query Builder',
+	clickhouse: 'ClickHouse Query',
+	promql: 'PromQL',
+} as const;
+
+/** SettingsSection titles, as rendered — `sectionTestId` slugifies them. */
+export const Section = {
+	visualization: 'Visualization',
+	formatting: 'Formatting & Units',
+	axes: 'Axes',
+	legend: 'Legend',
+	chartAppearance: 'Chart Appearance',
+	buckets: 'Histogram / Buckets',
+	thresholds: 'Thresholds',
+	contextLinks: 'Context Links',
+} as const;
+
+/** Slugified as `title.toLowerCase().replace(/\s+/g,'-')` — `&` and `/` survive. */
+export function sectionTestId(title: string): string {
+	return `config-section-${title.toLowerCase().replace(/\s+/g, '-')}`;
+}
+
+// ─── Shell locators ──────────────────────────────────────────────────────
+
+/**
+ * `panel-editor-v2` is NOT unique — the ResizablePanelGroup derives the same
+ * testid from its `id` (also the localStorage layout key, so unrenameable).
+ * `:not([data-group])` picks the page root.
+ */
+const EDITOR_ROOT = '[data-testid="panel-editor-v2"]:not([data-group])';
+
+export const editor = {
+	root: (page: Page): Locator => page.locator(EDITOR_ROOT),
+	title: (page: Page): Locator => page.getByTestId('panel-editor-v2-title'),
+	description: (page: Page): Locator =>
+		page.getByTestId('panel-editor-v2-description'),
+	save: (page: Page): Locator => page.getByTestId('panel-editor-v2-save'),
+	close: (page: Page): Locator => page.getByTestId('panel-editor-v2-close'),
+	unsavedBadge: (page: Page): Locator =>
+		page.getByTestId('panel-editor-v2-unsaved-badge'),
+	switchToView: (page: Page): Locator =>
+		page.getByTestId('panel-editor-v2-switch-to-view'),
+	typeSwitcher: (page: Page): Locator =>
+		page.getByTestId('panel-editor-v2-type-switcher'),
+	queryBuilder: (page: Page): Locator =>
+		page.getByTestId('panel-editor-v2-query-builder'),
+};
+
+// ─── Sections ────────────────────────────────────────────────────────────
+
+export function sectionToggle(page: Page, title: string): Locator {
+	return page.getByTestId(sectionTestId(title));
+}
+
+/** Idempotent: a blind click on an open section would collapse it. */
+export async function expandSection(page: Page, title: string): Promise<void> {
+	const toggle = sectionToggle(page, title);
+	await expect(toggle).toBeVisible();
+	if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+		await toggle.click();
+	}
+	await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+}
+
+export async function collapseSection(
+	page: Page,
+	title: string,
+): Promise<void> {
+	const toggle = sectionToggle(page, title);
+	if ((await toggle.getAttribute('aria-expanded')) === 'true') {
+		await toggle.click();
+	}
+	await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+}
+
+// ─── antd Select helpers ─────────────────────────────────────────────────
+
+/**
+ * Open a Select and resolve ITS dropdown via `aria-controls`. A closing
+ * dropdown still matches `:not(.ant-select-dropdown-hidden)`, so opening two
+ * Selects in a row otherwise trips strict mode.
+ */
+async function openDropdown(
+	page: Page,
+	triggerTestId: string,
+): Promise<Locator> {
+	const trigger = page.getByTestId(triggerTestId);
+	await trigger.click();
+	const listId = await trigger.locator('input').getAttribute('aria-controls');
+	const dropdown = listId
+		? page
+				.locator(`#${listId}`)
+				.locator('xpath=ancestor::div[contains(@class,"ant-select-dropdown")][1]')
+		: page
+				.locator('.ant-select-dropdown:not(.ant-select-dropdown-hidden)')
+				.last();
+	await expect(dropdown).toBeVisible();
+	return dropdown;
+}
+
+/** Pick an option from an antd Select identified by the trigger's testid. */
+export async function selectOption(
+	page: Page,
+	triggerTestId: string,
+	optionLabel: string,
+): Promise<void> {
+	const dropdown = await openDropdown(page, triggerTestId);
+	await dropdown
+		.locator('.ant-select-item-option')
+		.filter({ hasText: optionLabel })
+		.first()
+		.click();
+}
+
+/** Searches first — long option lists are virtualised (needed for unit pickers). */
+export async function searchAndSelectOption(
+	page: Page,
+	triggerTestId: string,
+	searchTerm: string,
+	optionLabel: string,
+): Promise<void> {
+	const dropdown = await openDropdown(page, triggerTestId);
+	await page.getByTestId(triggerTestId).locator('input').fill(searchTerm);
+	await dropdown
+		.locator('.ant-select-item-option')
+		.filter({ hasText: optionLabel })
+		.first()
+		.click();
+}
+
+/** Read the option labels a Select currently offers, plus their disabled state. */
+export async function selectOptions(
+	page: Page,
+	triggerTestId: string,
+): Promise<{ label: string; disabled: boolean }[]> {
+	const dropdown = await openDropdown(page, triggerTestId);
+	return dropdown.locator('.ant-select-item-option').evaluateAll((nodes) =>
+		nodes.map((node) => ({
+			label: node.textContent?.trim() ?? '',
+			disabled: node.classList.contains('ant-select-item-option-disabled'),
+		})),
+	);
+}
+
+// ─── Segmented / switch controls ─────────────────────────────────────────
+
+/** Segments carry `aria-label`; the testid is on the group. */
+export async function setSegment(
+	page: Page,
+	groupTestId: string,
+	label: string,
+): Promise<void> {
+	await page.getByTestId(groupTestId).locator(`[aria-label="${label}"]`).click();
+}
+
+export function segment(
+	page: Page,
+	groupTestId: string,
+	label: string,
+): Locator {
+	return page.getByTestId(groupTestId).locator(`[aria-label="${label}"]`);
+}
+
+// ─── Query builder ───────────────────────────────────────────────────────
+
+/** The Run button has no testid at this call site, so match by role. */
+export async function runQuery(page: Page): Promise<void> {
+	const response = page.waitForResponse((r) => r.url().includes('/query_range'));
+	await page.getByRole('button', { name: EditorText.runQuery }).click();
+	await response;
+}
+
+export function queryTab(page: Page, label: string): Locator {
+	return editor.queryBuilder(page).getByRole('tab', { name: label });
+}
+
+/**
+ * Pick a metric. An antd AutoComplete: testid is on a wrapper, options are
+ * fetched as you type. Required before a new metrics panel can be saved — the
+ * backend rejects an empty aggregation with "metric name is required".
+ */
+export async function selectMetric(
+	page: Page,
+	metricName: string,
+	index = 0,
+): Promise<void> {
+	const field = page.getByTestId(`metric-name-selector-${index}`);
+	await field.click();
+	await field.locator('input').fill(metricName);
+	const dropdown = page.locator(
+		'.ant-select-dropdown:not(.ant-select-dropdown-hidden)',
+	);
+	await expect(dropdown).toBeVisible();
+	await dropdown
+		.locator('.ant-select-item-option')
+		.filter({ hasText: metricName })
+		.first()
+		.click();
+}
+
+// ─── Save / discard ──────────────────────────────────────────────────────
+
+/** Save is NOT gated on dirty state — a pristine panel still saves. */
+export async function savePanel(page: Page): Promise<void> {
+	const patch = page.waitForResponse(
+		(r) =>
+			r.request().method() === 'PATCH' && /\/api\/v2\/dashboards\//.test(r.url()),
+	);
+	await editor.save(page).click();
+	const response = await patch;
+	// A rejected patch leaves the editor open, which would surface as an
+	// unrelated timeout several lines later.
+	expect(
+		response.ok(),
+		`PATCH ${response.url()} failed: ${response.status()} ${await response.text()}`,
+	).toBe(true);
+}
+
+/** A dirty panel raises the discard dialog; a pristine one closes immediately. */
+export async function closeEditor(
+	page: Page,
+	options?: { expectDirty?: boolean; keepEditing?: boolean },
+): Promise<void> {
+	await editor.close(page).click();
+	if (!options?.expectDirty) {
+		return;
+	}
+	await expect(page.getByTestId('panel-editor-v2-discard-modal')).toBeVisible();
+	await page
+		.getByTestId(
+			options.keepEditing
+				? 'panel-editor-v2-discard-cancel'
+				: 'panel-editor-v2-discard-confirm',
+		)
+		.click();
+}
+
+// ─── Patch capture ───────────────────────────────────────────────────────
+
+export interface PatchOperation {
+	op: string;
+	path: string;
+	value?: unknown;
+}
+
+/**
+ * Record the RFC-6902 ops sent on save. Stricter than re-reading the dashboard:
+ * catches a whole-spec replace that would clobber concurrent edits.
+ */
+export function capturePatchOps(page: Page): PatchOperation[][] {
+	const batches: PatchOperation[][] = [];
+	page.on('request', (request) => {
+		if (
+			request.method() !== 'PATCH' ||
+			!/\/api\/v2\/dashboards\//.test(request.url())
+		) {
+			return;
+		}
+		const body = request.postDataJSON() as PatchOperation[] | null;
+		if (body) {
+			batches.push(body);
+		}
+	});
+	return batches;
+}

--- a/tests/e2e/tests/dashboards/v2/panels/12-actions-menu.spec.ts
+++ b/tests/e2e/tests/dashboards/v2/panels/12-actions-menu.spec.ts
@@ -1,0 +1,231 @@
+import { expect, test } from '../../../../fixtures/dashboards';
+import {
+	getDashboardV2ViaApi,
+	gotoDashboardV2,
+	setDashboardLockedViaApi,
+} from '../../../../helpers/dashboards-v2';
+import {
+	PanelAction,
+	closePanelActions,
+	downloadPanelAs,
+	openPanelActions,
+	panelRoot,
+	runPanelAction,
+} from '../../../../helpers/panels-v2';
+import {
+	COMPACT_PANELS,
+	compactDashboard,
+} from '../../../../testdata/v2/panels-dashboard';
+
+// Scope: the panel ⋮ menu — which items exist per kind, how capability and the
+// dashboard lock gate them, and that the mutating ones reach the spec.
+//
+// Items carry no testid, so everything matches role + visible label.
+
+test.describe('Dashboards V2 — panel actions menu', () => {
+	test('TC-01 an editable panel offers the full action set', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await dashboards.seedAndOpen(compactDashboard());
+		await openPanelActions(page, COMPACT_PANELS.timeseries);
+
+		for (const label of [
+			PanelAction.view,
+			PanelAction.edit,
+			PanelAction.clone,
+			PanelAction.download,
+			PanelAction.createAlert,
+			PanelAction.move,
+			PanelAction.delete,
+		]) {
+			await expect(
+				page.getByRole('menuitem', { name: label, exact: true }),
+			).toBeVisible();
+		}
+	});
+
+	test('TC-02 Download offers CSV only on Table', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await dashboards.seedAndOpen(compactDashboard());
+
+		// Table declares `csv: true`; others expose PNG/SVG only.
+		await openPanelActions(page, COMPACT_PANELS.table);
+		await page
+			.getByRole('menuitem', { name: PanelAction.download, exact: true })
+			.hover();
+		await expect(
+			page.getByRole('menuitem', { name: PanelAction.downloadCsv, exact: true }),
+		).toBeVisible();
+		await closePanelActions(page);
+
+		await openPanelActions(page, COMPACT_PANELS.timeseries);
+		await page
+			.getByRole('menuitem', { name: PanelAction.download, exact: true })
+			.hover();
+		await expect(
+			page.getByRole('menuitem', { name: PanelAction.downloadPng, exact: true }),
+		).toBeVisible();
+		await expect(
+			page.getByRole('menuitem', { name: PanelAction.downloadCsv, exact: true }),
+		).toHaveCount(0);
+	});
+
+	test('TC-03 Create Alerts is hidden for kinds that do not declare it', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await dashboards.seedAndOpen(compactDashboard());
+
+		await openPanelActions(page, COMPACT_PANELS.timeseries);
+		await expect(
+			page.getByRole('menuitem', { name: PanelAction.createAlert, exact: true }),
+		).toBeVisible();
+		await closePanelActions(page);
+
+		for (const panelId of [COMPACT_PANELS.table, COMPACT_PANELS.list]) {
+			await openPanelActions(page, panelId);
+			await expect(
+				page.getByRole('menuitem', {
+					name: PanelAction.createAlert,
+					exact: true,
+				}),
+			).toHaveCount(0);
+			await closePanelActions(page);
+		}
+	});
+
+	test('TC-04 Create Alerts opens the alert builder in a new tab', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await dashboards.seedAndOpen(compactDashboard());
+
+		const popup = page.context().waitForEvent('page');
+		await runPanelAction(
+			page,
+			COMPACT_PANELS.timeseries,
+			PanelAction.createAlert,
+		);
+		const alertTab = await popup;
+		await expect(alertTab).toHaveURL(/\/alerts\/new/);
+		await alertTab.close();
+	});
+
+	// Chromium-only: headless Firefox/WebKit don't surface the canvas blob as a
+	// Playwright download event. CSV and SVG are unaffected.
+	test('TC-05 Download as PNG produces a file', async ({
+		authedPage: page,
+		dashboards,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			'headless Firefox/WebKit do not emit a download event for the canvas blob',
+		);
+		await dashboards.seedAndOpen(compactDashboard());
+		await panelRoot(page, COMPACT_PANELS.timeseries).scrollIntoViewIfNeeded();
+
+		const download = page.waitForEvent('download');
+		await downloadPanelAs(page, COMPACT_PANELS.timeseries, 'PNG');
+		const file = await download;
+		expect(file.suggestedFilename()).toMatch(/\.png$/);
+	});
+
+	test('TC-06 Clone adds a second panel and persists it', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seedAndOpen(compactDashboard());
+
+		const before = await getDashboardV2ViaApi(page, id);
+		const beforeCount = Object.keys(before.spec.panels).length;
+
+		await runPanelAction(page, COMPACT_PANELS.timeseries, PanelAction.clone);
+
+		await expect
+			.poll(async () => {
+				const after = await getDashboardV2ViaApi(page, id);
+				return Object.keys(after.spec.panels).length;
+			})
+			.toBe(beforeCount + 1);
+	});
+
+	test('TC-07 Delete panel removes the panel and its layout item', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seedAndOpen(compactDashboard());
+
+		await runPanelAction(page, COMPACT_PANELS.list, PanelAction.delete);
+		await expect(page.getByText('Delete panel?')).toBeVisible();
+		await page.getByTestId('confirm-delete').click();
+
+		await expect(panelRoot(page, COMPACT_PANELS.list)).toHaveCount(0);
+
+		// Optimistic: the panel leaves the DOM before the PATCH lands.
+		await expect
+			.poll(async () => {
+				const after = await getDashboardV2ViaApi(page, id);
+				return after.spec.panels[COMPACT_PANELS.list];
+			})
+			.toBeUndefined();
+
+		// The grid item must go too, or a dangling $ref renders an empty tile.
+		const after = await getDashboardV2ViaApi(page, id);
+		const refs = after.spec.layouts.flatMap((layout) =>
+			layout.spec.items.map((item) => item.content.$ref),
+		);
+		expect(refs).not.toContain(`#/spec/panels/${COMPACT_PANELS.list}`);
+	});
+
+	test('TC-08 Move to section relocates the panel between sections', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seedAndOpen(compactDashboard());
+
+		await openPanelActions(page, COMPACT_PANELS.timeseries);
+		await page
+			.getByRole('menuitem', { name: PanelAction.move, exact: true })
+			.hover();
+		await page.getByRole('menuitem', { name: 'Tabular', exact: true }).click();
+
+		await expect
+			.poll(async () => {
+				const after = await getDashboardV2ViaApi(page, id);
+				const target = after.spec.layouts.find(
+					(layout) => layout.spec.display.title === 'Tabular',
+				);
+				return target?.spec.items.some(
+					(item) =>
+						item.content.$ref === `#/spec/panels/${COMPACT_PANELS.timeseries}`,
+				);
+			})
+			.toBe(true);
+	});
+
+	test('TC-09 a locked dashboard disables the mutating actions', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seed(compactDashboard());
+		await setDashboardLockedViaApi(page, id, true);
+		await gotoDashboardV2(page, id);
+
+		await openPanelActions(page, COMPACT_PANELS.timeseries);
+
+		// View and Download don't mutate, so they stay available.
+		await expect(
+			page.getByRole('menuitem', { name: PanelAction.view, exact: true }),
+		).toBeEnabled();
+
+		for (const label of [PanelAction.edit, PanelAction.clone]) {
+			await expect(
+				page.getByRole('menuitem', { name: label, exact: true }),
+			).toBeDisabled();
+		}
+	});
+});

--- a/tests/e2e/tests/dashboards/v2/panels/48-table-list.spec.ts
+++ b/tests/e2e/tests/dashboards/v2/panels/48-table-list.spec.ts
@@ -1,0 +1,218 @@
+import { expect, test } from '../../../../fixtures/dashboards';
+import { PanelKind } from '../../../../helpers/dashboard-v2-spec';
+import {
+	boundingBoxOf,
+	listPager,
+	panelRoot,
+	searchInPanel,
+} from '../../../../helpers/panels-v2';
+import {
+	QueryRange,
+	mockQueryRange,
+	mockQueryRangeSequence,
+} from '../../../../helpers/query-range-mock';
+import {
+	COMPACT_PANELS,
+	SINGLE_PANEL_ID,
+	singlePanelDashboard,
+	compactDashboard,
+} from '../../../../testdata/v2/panels-dashboard';
+
+// Scope: the tabular-only controls — header search, column resize, and List's
+// server-side pager. Paging is mocked (it needs a stable row set).
+
+// Next only enables when a response FILLS the page, so page one must be full.
+const PAGE_SIZE = 25;
+
+const LOG_ROWS = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+	timestamp: new Date(Date.UTC(2026, 0, 1, 0, i)).toISOString(),
+	body: `page-one line ${i}`,
+	'service.name': 'adservice',
+}));
+
+const LOG_ROWS_PAGE_TWO = Array.from({ length: 6 }, (_, i) => ({
+	timestamp: new Date(Date.UTC(2026, 0, 1, 1, i)).toISOString(),
+	body: `page-two line ${i}`,
+	'service.name': 'cartservice',
+}));
+
+test.describe('Dashboards V2 — table and list controls', () => {
+	test('TC-01 header search filters the table and can be cleared', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await mockQueryRange(
+			page,
+			QueryRange.scalar({
+				groupColumns: ['service.name'],
+				aggregationColumns: ['A'],
+				rows: [
+					['adservice', 10],
+					['cartservice', 20],
+					['frontend', 30],
+				],
+			}),
+		);
+		await dashboards.seedAndOpen(compactDashboard());
+
+		const root = panelRoot(page, COMPACT_PANELS.table);
+		await root.scrollIntoViewIfNeeded();
+		await expect(root.getByTestId('table-panel-renderer')).toBeVisible();
+
+		const rows = root.locator('tbody tr.ant-table-row');
+		await expect(rows).toHaveCount(3);
+
+		await searchInPanel(page, COMPACT_PANELS.table, 'cart');
+		await expect(rows).toHaveCount(1);
+
+		await root.getByTestId('panel-header-search-clear').click();
+		await expect(rows).toHaveCount(3);
+	});
+
+	test('TC-02 Escape closes the search box', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await dashboards.seedAndOpen(compactDashboard());
+
+		const root = panelRoot(page, COMPACT_PANELS.table);
+		await root.scrollIntoViewIfNeeded();
+		await searchInPanel(page, COMPACT_PANELS.table, 'cart');
+
+		await page.keyboard.press('Escape');
+		await expect(root.getByTestId('panel-header-search-input')).toHaveCount(0);
+	});
+
+	test('TC-03 search is not offered on kinds that do not declare it', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await dashboards.seedAndOpen(compactDashboard());
+
+		const chart = panelRoot(page, COMPACT_PANELS.timeseries);
+		await chart.hover();
+		await expect(chart.getByTestId('panel-header-search-trigger')).toHaveCount(0);
+	});
+
+	test('TC-04 a resized column persists across a reload', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await mockQueryRange(
+			page,
+			QueryRange.scalar({
+				groupColumns: ['service.name'],
+				aggregationColumns: ['A'],
+				rows: [['adservice', 10]],
+			}),
+		);
+		await dashboards.seedAndOpen(singlePanelDashboard({ kind: PanelKind.Table }));
+
+		const root = panelRoot(page, SINGLE_PANEL_ID);
+		await expect(root.getByTestId('table-panel-renderer')).toBeVisible();
+
+		const header = root.locator('th').filter({ hasText: 'service.name' });
+		const before = (await header.boundingBox())?.width ?? 0;
+		expect(before).toBeGreaterThan(0);
+
+		const gripBox = await boundingBoxOf(
+			root.getByTestId('column-resize-service.name'),
+			'the resize grip',
+		);
+		await page.mouse.move(
+			gripBox.x + gripBox.width / 2,
+			gripBox.y + gripBox.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(gripBox.x + 120, gripBox.y + gripBox.height / 2, {
+			steps: 10,
+		});
+		await page.mouse.up();
+
+		await expect
+			.poll(async () => (await header.boundingBox())?.width ?? 0)
+			.toBeGreaterThan(before);
+
+		// Widths persist behind a 400ms debounce; reloading before it flushes drops
+		// the write and looks exactly like a persistence bug.
+		await expect
+			.poll(async () =>
+				page.evaluate((panelId) => {
+					const raw = localStorage.getItem('DASHBOARD_V2_PANEL_COLUMN_WIDTHS');
+					const widths = raw ? JSON.parse(raw) : {};
+					return widths?.[panelId]?.['service.name'] ?? 0;
+				}, SINGLE_PANEL_ID),
+			)
+			.toBeGreaterThan(before);
+
+		const widened = (await header.boundingBox())?.width ?? 0;
+		await page.reload();
+		await expect(root.getByTestId('table-panel-renderer')).toBeVisible();
+		await expect
+			.poll(async () => (await header.boundingBox())?.width ?? 0)
+			.toBeCloseTo(widened, -1);
+	});
+
+	test('TC-05 the List pager advances and re-queries', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await mockQueryRangeSequence(page, [
+			QueryRange.raw(LOG_ROWS),
+			QueryRange.raw(LOG_ROWS_PAGE_TWO),
+		]);
+		await dashboards.seedAndOpen(singlePanelDashboard({ kind: PanelKind.List }));
+
+		const root = panelRoot(page, SINGLE_PANEL_ID);
+		await root.scrollIntoViewIfNeeded();
+		await expect(root.getByTestId('list-panel-renderer')).toBeVisible();
+		await expect(listPager.page(page, SINGLE_PANEL_ID)).toHaveText('Page 1');
+		await expect(root.getByText('page-one line 0')).toBeVisible();
+
+		// Server-side: Next must issue a new query.
+		const nextQuery = page.waitForRequest((r) =>
+			r.url().includes('/query_range'),
+		);
+		await listPager.next(page, SINGLE_PANEL_ID).click();
+		await nextQuery;
+
+		await expect(listPager.page(page, SINGLE_PANEL_ID)).toHaveText('Page 2');
+		await expect(root.getByText('page-two line 0')).toBeVisible();
+	});
+
+	test('TC-06 Previous is disabled on the first page', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await mockQueryRange(page, QueryRange.raw(LOG_ROWS));
+		await dashboards.seedAndOpen(singlePanelDashboard({ kind: PanelKind.List }));
+
+		const root = panelRoot(page, SINGLE_PANEL_ID);
+		await root.scrollIntoViewIfNeeded();
+		await expect(root.getByTestId('list-panel-renderer')).toBeVisible();
+		await expect(listPager.prev(page, SINGLE_PANEL_ID)).toBeDisabled();
+	});
+
+	test('TC-07 changing the page size re-queries', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await mockQueryRange(page, QueryRange.raw(LOG_ROWS));
+		await dashboards.seedAndOpen(singlePanelDashboard({ kind: PanelKind.List }));
+
+		const root = panelRoot(page, SINGLE_PANEL_ID);
+		await root.scrollIntoViewIfNeeded();
+		await expect(root.getByTestId('list-panel-renderer')).toBeVisible();
+
+		const resize = page.waitForRequest((r) => r.url().includes('/query_range'));
+		await listPager.pageSize(page, SINGLE_PANEL_ID).click();
+		await page
+			.locator('.ant-select-dropdown:not(.ant-select-dropdown-hidden)')
+			.getByText('50 / page')
+			.click();
+		await resize;
+
+		// Page size resets to page 1.
+		await expect(listPager.page(page, SINGLE_PANEL_ID)).toHaveText('Page 1');
+	});
+});

--- a/tests/e2e/tests/dashboards/v2/panels/57-drilldown.spec.ts
+++ b/tests/e2e/tests/dashboards/v2/panels/57-drilldown.spec.ts
@@ -1,0 +1,259 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test, type SeedApi } from '../../../../fixtures/dashboards';
+import { PanelKind, metricsQuery } from '../../../../helpers/dashboard-v2-spec';
+import { getDashboardV2ViaApi } from '../../../../helpers/dashboards-v2';
+import {
+	boundingBoxOf,
+	contextMenu,
+	drilldownItem,
+	panelChart,
+	panelRoot,
+} from '../../../../helpers/panels-v2';
+import {
+	QueryRange,
+	mockQueryRange,
+	ramp,
+} from '../../../../helpers/query-range-mock';
+import {
+	QUERY_TYPE_PANELS,
+	SINGLE_PANEL_ID,
+	VARIABLE_NAMES,
+	VARIABLE_PANEL_ID,
+	queryTypesDashboard,
+	singlePanelDashboard,
+	variablesDashboard,
+} from '../../../../testdata/v2/panels-dashboard';
+
+// Scope: the drilldown ContextMenu — items, navigation, and the kinds/query
+// types deliberately excluded. Mocked so a click lands on a known series.
+
+async function openChartDrilldown(page: Page, panelId: string): Promise<void> {
+	const box = await boundingBoxOf(panelChart(page, panelId), 'the chart');
+	await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+	await expect(contextMenu(page)).toBeVisible();
+}
+
+async function seedChartPanel(
+	page: Page,
+	dashboards: SeedApi,
+): Promise<string> {
+	await mockQueryRange(
+		page,
+		QueryRange.timeSeries([
+			{ labels: { 'service.name': 'adservice' }, points: ramp(12, 2, 8) },
+		]),
+	);
+	const id = await dashboards.seedAndOpen(singlePanelDashboard());
+	await expect(
+		panelRoot(page, SINGLE_PANEL_ID).getByTestId('time-series-renderer'),
+	).toBeVisible();
+	return id;
+}
+
+test.describe('Dashboards V2 — panel drilldown', () => {
+	test('TC-01 clicking a series opens the aggregate menu', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await seedChartPanel(page, dashboards);
+		await openChartDrilldown(page, SINGLE_PANEL_ID);
+
+		await expect(drilldownItem(page, 'drilldown-view-logs')).toBeVisible();
+		await expect(drilldownItem(page, 'drilldown-view-traces')).toBeVisible();
+		await expect(drilldownItem(page, 'drilldown-breakout')).toBeVisible();
+	});
+
+	test('TC-02 clicking the backdrop closes the menu', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await seedChartPanel(page, dashboards);
+		await openChartDrilldown(page, SINGLE_PANEL_ID);
+
+		// Backdrop click. Escape only works when the backdrop holds focus.
+		await page.locator('.context-menu-backdrop').click();
+		await expect(contextMenu(page)).toHaveCount(0);
+	});
+
+	test('TC-03 View in Logs navigates to the logs explorer', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await seedChartPanel(page, dashboards);
+		await openChartDrilldown(page, SINGLE_PANEL_ID);
+
+		// Disabled while the drilldown query resolves.
+		const viewLogs = drilldownItem(page, 'drilldown-view-logs');
+		await expect(viewLogs).toBeEnabled();
+
+		// safeNavigate uses `{ newTab: true }`, so the dashboard stays put.
+		const popup = page.context().waitForEvent('page');
+		await viewLogs.click();
+		const logsTab = await popup;
+
+		await logsTab.waitForURL(/\/logs\/logs-explorer/);
+		// The clicked series carries across as a composite query.
+		expect(
+			new URL(logsTab.url()).searchParams.get('compositeQuery'),
+		).toBeTruthy();
+		await logsTab.close();
+
+		await expect(page).toHaveURL(/\/dashboard\//);
+	});
+
+	test('TC-04 Breakout opens a submenu and the back arrow returns', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await seedChartPanel(page, dashboards);
+		await openChartDrilldown(page, SINGLE_PANEL_ID);
+
+		await drilldownItem(page, 'drilldown-breakout').click();
+		const back = page.getByTestId('drilldown-breakout-back');
+		await expect(back).toBeVisible();
+		await expect(
+			page.getByPlaceholder('Search breakout options...'),
+		).toBeVisible();
+
+		// Back returns to the aggregate menu.
+		await back.click();
+		await expect(drilldownItem(page, 'drilldown-view-logs')).toBeVisible();
+	});
+
+	test('TC-05 the Dashboard Variables submenu offers set and create', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await mockQueryRange(
+			page,
+			QueryRange.timeSeries([
+				{ labels: { 'service.name': 'adservice' }, points: ramp(12, 2, 8) },
+			]),
+		);
+		await dashboards.seedAndOpen(variablesDashboard());
+		await expect(
+			panelRoot(page, VARIABLE_PANEL_ID).getByTestId('time-series-renderer'),
+		).toBeVisible();
+
+		await openChartDrilldown(page, VARIABLE_PANEL_ID);
+		await drilldownItem(page, 'drilldown-dashboard-variables').click();
+
+		// `service.name` is grouped-by and already has a variable, so Set is offered.
+		await expect(drilldownItem(page, 'drilldown-var-set')).toBeVisible();
+		await expect(page.getByTestId('drilldown-var-back')).toBeVisible();
+	});
+
+	test('TC-06 setting a variable from the menu updates the variables bar', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await mockQueryRange(
+			page,
+			QueryRange.timeSeries([
+				{ labels: { 'service.name': 'adservice' }, points: ramp(12, 2, 8) },
+			]),
+		);
+		await dashboards.seedAndOpen(variablesDashboard());
+		await expect(
+			panelRoot(page, VARIABLE_PANEL_ID).getByTestId('time-series-renderer'),
+		).toBeVisible();
+
+		await openChartDrilldown(page, VARIABLE_PANEL_ID);
+		await drilldownItem(page, 'drilldown-dashboard-variables').click();
+		await drilldownItem(page, 'drilldown-var-set').click();
+
+		await expect(
+			page.getByTestId(`variable-${VARIABLE_NAMES.custom}`),
+		).toContainText('adservice');
+	});
+
+	test('TC-07 creating a variable from the menu patches the dashboard spec', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await mockQueryRange(
+			page,
+			QueryRange.timeSeries([
+				{
+					labels: { 'k8s.namespace.name': 'signoz-adservice' },
+					points: ramp(12, 2, 8),
+				},
+			]),
+		);
+		// No matching variable for this field, so the menu offers Create.
+		const id = await dashboards.seedAndOpen(
+			variablesDashboard(
+				undefined,
+				metricsQuery({ groupBy: ['k8s.namespace.name'] }),
+			),
+		);
+		await expect(
+			panelRoot(page, VARIABLE_PANEL_ID).getByTestId('time-series-renderer'),
+		).toBeVisible();
+
+		await openChartDrilldown(page, VARIABLE_PANEL_ID);
+		await drilldownItem(page, 'drilldown-dashboard-variables').click();
+		await drilldownItem(page, 'drilldown-var-create').click();
+
+		// Create persists a DYNAMIC variable into spec.variables.
+		await expect
+			.poll(async () => {
+				const after = await getDashboardV2ViaApi(page, id);
+				return after.spec.variables.some(
+					(variable) => variable.spec.name === 'k8s.namespace.name',
+				);
+			})
+			.toBe(true);
+	});
+
+	test('TC-08 kinds that do not declare drilldown open no menu', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await mockQueryRange(
+			page,
+			QueryRange.timeSeries([
+				{ labels: { 'service.name': 'adservice' }, points: ramp(12, 2, 8) },
+			]),
+		);
+		await dashboards.seedAndOpen(
+			singlePanelDashboard({ kind: PanelKind.Histogram }),
+		);
+
+		const root = panelRoot(page, SINGLE_PANEL_ID);
+		await expect(root.getByTestId('histogram-panel-renderer')).toBeVisible();
+
+		// Histogram sets `drilldown: false`.
+		const box = await boundingBoxOf(
+			root.getByTestId('uplot-main-div'),
+			'the histogram chart',
+		);
+		await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+		await expect(contextMenu(page)).toHaveCount(0);
+	});
+
+	test('TC-09 a non-builder query opens no menu', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await mockQueryRange(
+			page,
+			QueryRange.timeSeries([
+				{ labels: { 'service.name': 'adservice' }, points: ramp(12, 2, 8) },
+			]),
+		);
+		await dashboards.seedAndOpen(queryTypesDashboard());
+
+		const root = panelRoot(page, QUERY_TYPE_PANELS.promql);
+		await expect(root.getByTestId('time-series-renderer')).toBeVisible();
+
+		// Gated to QUERY_BUILDER queries.
+		const box = await boundingBoxOf(
+			root.getByTestId('uplot-main-div'),
+			'the promql chart',
+		);
+		await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+		await expect(contextMenu(page)).toHaveCount(0);
+	});
+});

--- a/tests/e2e/tests/dashboards/v2/panels/66-view-modal.spec.ts
+++ b/tests/e2e/tests/dashboards/v2/panels/66-view-modal.spec.ts
@@ -1,0 +1,184 @@
+import { expect, test } from '../../../../fixtures/dashboards';
+import {
+	getDashboardV2ViaApi,
+	gotoDashboardV2,
+	setDashboardLockedViaApi,
+} from '../../../../helpers/dashboards-v2';
+import { editor } from '../../../../helpers/panel-editor-v2';
+import {
+	PanelAction,
+	openViewModal,
+	runPanelAction,
+} from '../../../../helpers/panels-v2';
+import {
+	SINGLE_PANEL_ID,
+	singlePanelDashboard,
+} from '../../../../testdata/v2/panels-dashboard';
+
+// Scope: the View modal, and its two-way handoff with the panel editor.
+//
+// Both directions carry LIVE, unsaved state — modal → editor via router state
+// (`editSpec`), editor → modal via sessionStorage + `compositeQuery`. Losing
+// either silently discards in-progress work, so TC-09/TC-10 assert the carried
+// state AND that nothing was persisted.
+
+test.describe('Dashboards V2 — View modal', () => {
+	test('TC-01 View opens the modal and reflects it in the URL', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await dashboards.seedAndOpen(singlePanelDashboard());
+		const modal = await openViewModal(page, SINGLE_PANEL_ID);
+
+		await expect(modal).toBeVisible();
+		await expect(page.getByTestId('view-panel-refresh')).toBeVisible();
+		expect(new URL(page.url()).searchParams.get('expandedWidgetId')).toBe(
+			SINGLE_PANEL_ID,
+		);
+	});
+
+	test('TC-02 the modal opens directly from a deep link', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seedAndOpen(singlePanelDashboard());
+
+		await page.goto(
+			`/dashboard/${id}?expandedWidgetId=${SINGLE_PANEL_ID}&graphType=graph`,
+		);
+		await expect(page.getByTestId('view-panel-modal-content')).toBeVisible();
+	});
+
+	test('TC-04 Refresh re-issues the query', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		await dashboards.seedAndOpen(singlePanelDashboard());
+		await openViewModal(page, SINGLE_PANEL_ID);
+
+		const refetch = page.waitForRequest((r) => r.url().includes('/query_range'));
+		await page.getByTestId('view-panel-refresh').click();
+		const request = await refetch;
+		expect(request.method()).toBe('POST');
+	});
+
+	test('TC-05 switching the panel type in the modal does not persist', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seedAndOpen(singlePanelDashboard());
+		await openViewModal(page, SINGLE_PANEL_ID);
+
+		await page.getByTestId('view-panel-type-selector').click();
+		await page
+			.locator('.ant-select-dropdown:not(.ant-select-dropdown-hidden)')
+			.getByText('Table', { exact: true })
+			.click();
+		await expect(page.getByTestId('table-panel-renderer')).toBeVisible();
+
+		await page.goBack();
+		const after = await getDashboardV2ViaApi(page, id);
+		expect(after.spec.panels[SINGLE_PANEL_ID].spec.plugin.kind).toBe(
+			'signoz/TimeSeriesPanel',
+		);
+	});
+
+	test('TC-06 Switch to Edit Mode hands off to the panel editor', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seedAndOpen(singlePanelDashboard());
+		await openViewModal(page, SINGLE_PANEL_ID);
+
+		await page.getByTestId('view-panel-switch-to-edit').click();
+
+		await page.waitForURL(new RegExp(`/dashboard/${id}/panel/`));
+		await expect(editor.root(page)).toBeVisible();
+	});
+
+	test('TC-07 a locked panel opens in View but offers no Switch to Edit', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		// `canSwitchToEdit = canEditDashboard && !isLocked`, but View itself is not
+		// role-gated — so the modal opens and only the handoff button disappears.
+		const id = await dashboards.seed(singlePanelDashboard());
+		await setDashboardLockedViaApi(page, id, true);
+		await gotoDashboardV2(page, id);
+
+		await runPanelAction(page, SINGLE_PANEL_ID, PanelAction.view);
+		await expect(page.getByTestId('view-panel-modal-content')).toBeVisible();
+		await expect(page.getByTestId('view-panel-switch-to-edit')).toHaveCount(0);
+		await expect(page.getByTestId('view-panel-refresh')).toBeVisible();
+	});
+
+	test('TC-08 View → Edit → View round-trips with no changes', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seedAndOpen(
+			singlePanelDashboard({ panelName: 'Round trip' }),
+		);
+		await openViewModal(page, SINGLE_PANEL_ID);
+
+		await page.getByTestId('view-panel-switch-to-edit').click();
+		await page.waitForURL(new RegExp(`/dashboard/${id}/panel/`));
+		await expect(editor.title(page)).toHaveValue('Round trip');
+		await expect(editor.unsavedBadge(page)).toHaveCount(0);
+
+		await editor.switchToView(page).click();
+		await expect(page.getByTestId('view-panel-modal-content')).toBeVisible();
+
+		const after = await getDashboardV2ViaApi(page, id);
+		expect(after.spec.panels[SINGLE_PANEL_ID].spec.display.name).toBe(
+			'Round trip',
+		);
+	});
+
+	test('TC-09 an unsaved change in the modal carries into the editor', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seedAndOpen(singlePanelDashboard());
+		await openViewModal(page, SINGLE_PANEL_ID);
+
+		await page.getByTestId('view-panel-type-selector').click();
+		await page
+			.locator('.ant-select-dropdown:not(.ant-select-dropdown-hidden)')
+			.getByText('Table', { exact: true })
+			.click();
+		await expect(page.getByTestId('table-panel-renderer')).toBeVisible();
+
+		await page.getByTestId('view-panel-switch-to-edit').click();
+		await page.waitForURL(new RegExp(`/dashboard/${id}/panel/`));
+
+		// Editor opens on the MODIFIED panel, and still nothing is committed.
+		await expect(page.getByTestId('table-panel-renderer')).toBeVisible();
+		const after = await getDashboardV2ViaApi(page, id);
+		expect(after.spec.panels[SINGLE_PANEL_ID].spec.plugin.kind).toBe(
+			'signoz/TimeSeriesPanel',
+		);
+	});
+
+	test('TC-10 an unsaved change in the editor carries back into the modal', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seedAndEdit(
+			singlePanelDashboard(),
+			SINGLE_PANEL_ID,
+		);
+
+		await editor.title(page).fill('Edited but not saved');
+		await expect(editor.unsavedBadge(page)).toBeVisible();
+
+		await editor.switchToView(page).click();
+		await expect(page.getByTestId('view-panel-modal-content')).toBeVisible();
+		await expect(page.getByRole('dialog')).toContainText('Edited but not saved');
+
+		const after = await getDashboardV2ViaApi(page, id);
+		expect(after.spec.panels[SINGLE_PANEL_ID].spec.display.name).toBe(
+			'Solo panel',
+		);
+	});
+});

--- a/tests/e2e/tests/dashboards/v2/panels/75-layout.spec.ts
+++ b/tests/e2e/tests/dashboards/v2/panels/75-layout.spec.ts
@@ -1,0 +1,167 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../../../../fixtures/dashboards';
+import { getDashboardV2ViaApi } from '../../../../helpers/dashboards-v2';
+import {
+	boundingBoxOf,
+	panelResizeHandle,
+	panelRoot,
+} from '../../../../helpers/panels-v2';
+import {
+	COMPACT_PANELS,
+	compactDashboard,
+} from '../../../../testdata/v2/panels-dashboard';
+
+// Scope: grid layout mutations — drag, resize, and the guarantee that the
+// header's action cluster never starts a drag.
+//
+// react-grid-layout exposes no testids; `.panel-drag-handle` and
+// `.react-resizable-handle` are the documented class contract it is configured
+// with (draggableHandle / draggableCancel in SectionGrid), so they're used
+// directly here.
+
+/** Grid geometry for one panel, read from the persisted spec. */
+async function gridItemOf(
+	page: Page,
+	dashboardId: string,
+	panelId: string,
+): Promise<{ x: number; y: number; width: number; height: number }> {
+	const dashboard = await getDashboardV2ViaApi(page, dashboardId);
+	for (const layout of dashboard.spec.layouts) {
+		const item = layout.spec.items.find(
+			(candidate) => candidate.content.$ref === `#/spec/panels/${panelId}`,
+		);
+		if (item) {
+			return {
+				x: item.x,
+				y: item.y,
+				width: item.width,
+				height: item.height,
+			};
+		}
+	}
+	throw new Error(`no grid item for panel ${panelId}`);
+}
+
+test.describe('Dashboards V2 — grid layout', () => {
+	test('TC-01 resizing a panel persists its new size', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seedAndOpen(compactDashboard());
+
+		const root = panelRoot(page, COMPACT_PANELS.timeseries);
+		await expect(root.getByTestId('time-series-renderer')).toBeVisible();
+		const before = await gridItemOf(page, id, COMPACT_PANELS.timeseries);
+
+		const handle = await boundingBoxOf(
+			panelResizeHandle(page, COMPACT_PANELS.timeseries),
+			'the resize handle',
+		);
+		await page.mouse.move(
+			handle.x + handle.width / 2,
+			handle.y + handle.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(handle.x + 60, handle.y + 90, { steps: 12 });
+		await page.mouse.up();
+
+		// The grid persists on resize-stop, so the spec is the source of truth
+		// rather than the rendered pixel size.
+		await expect
+			.poll(async () => {
+				const after = await gridItemOf(page, id, COMPACT_PANELS.timeseries);
+				return after.height > before.height || after.width > before.width;
+			})
+			.toBe(true);
+	});
+
+	test('TC-02 a resized layout survives a reload', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seedAndOpen(compactDashboard());
+
+		const root = panelRoot(page, COMPACT_PANELS.timeseries);
+		await expect(root.getByTestId('time-series-renderer')).toBeVisible();
+
+		const handle = await boundingBoxOf(
+			panelResizeHandle(page, COMPACT_PANELS.timeseries),
+			'the resize handle',
+		);
+		await page.mouse.move(
+			handle.x + handle.width / 2,
+			handle.y + handle.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(handle.x, handle.y + 90, { steps: 12 });
+		await page.mouse.up();
+
+		await expect
+			.poll(async () => {
+				const item = await gridItemOf(page, id, COMPACT_PANELS.timeseries);
+				return item.height;
+			})
+			.toBeGreaterThan(6);
+
+		const persisted = await gridItemOf(page, id, COMPACT_PANELS.timeseries);
+		await page.reload();
+		await expect(root.getByTestId('time-series-renderer')).toBeVisible();
+		expect(await gridItemOf(page, id, COMPACT_PANELS.timeseries)).toEqual(
+			persisted,
+		);
+	});
+
+	test('TC-03 opening the actions menu does not start a drag', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seedAndOpen(compactDashboard());
+
+		const root = panelRoot(page, COMPACT_PANELS.timeseries);
+		await expect(root.getByTestId('time-series-renderer')).toBeVisible();
+		const before = await gridItemOf(page, id, COMPACT_PANELS.timeseries);
+
+		// The ⋮ button sits inside the drag handle but is marked `panel-no-drag`
+		// and stops pointerdown, so opening the menu must leave the grid alone.
+		await root.hover();
+		await page.getByTestId(`panel-actions-${COMPACT_PANELS.timeseries}`).click();
+		await expect(page.getByRole('menu')).toBeVisible();
+		await page.keyboard.press('Escape');
+
+		expect(await gridItemOf(page, id, COMPACT_PANELS.timeseries)).toEqual(before);
+	});
+
+	test('TC-04 dragging by the header moves the panel within its section', async ({
+		authedPage: page,
+		dashboards,
+	}) => {
+		const id = await dashboards.seedAndOpen(compactDashboard());
+
+		const root = panelRoot(page, COMPACT_PANELS.timeseries);
+		await expect(root.getByTestId('time-series-renderer')).toBeVisible();
+		const before = await gridItemOf(page, id, COMPACT_PANELS.timeseries);
+
+		const handle = await boundingBoxOf(
+			root.locator('.panel-drag-handle').first(),
+			'the drag handle',
+		);
+		await page.mouse.move(
+			handle.x + handle.width / 4,
+			handle.y + handle.height / 2,
+		);
+		await page.mouse.down();
+		// Drag a full tile-width right so the swap is unambiguous.
+		await page.mouse.move(handle.x + handle.width, handle.y + handle.height / 2, {
+			steps: 15,
+		});
+		await page.mouse.up();
+
+		await expect
+			.poll(async () => {
+				const after = await gridItemOf(page, id, COMPACT_PANELS.timeseries);
+				return after.x !== before.x || after.y !== before.y;
+			})
+			.toBe(true);
+	});
+});


### PR DESCRIPTION
## Pull Request

---

### 🧱 Stack

**2 of 4.** Part of the stack that adds the Dashboards V2 E2E suite. Based on #12409 — review that one first; the diff here is specs plus one test id.

| # | PR | Base | Tests |
|---|---|---|---:|
| 1 | #12409 — harness + panel rendering specs | `main` | +25 |
| **2** | **#12410 — panel actions, controls, drilldown and the View modal — 👈 you are here** | #12409 | +38 |
| 3 | #12411 — panel editor shell, creation and query pane | #12410 | +46 |
| 4 | #12412 — editor sections, thresholds and list columns | #12411 | +51 |

---

### 📄 Summary
> Why does this change exist?
> What problem does it solve, and why is this the right approach?

Covers everything a reader does to a panel **on the dashboard**, without opening the editor: the actions menu, the Table/List controls, the drilldown context menu, the View modal, and grid drag/resize.

Two areas carry most of the value:

- **Drilldown** reaches past navigation into the dashboard spec. The specs assert the aggregate menu's targets (View in Logs, Breakout and its back arrow) and its variable paths — setting a variable updates the variables bar, creating one patches the dashboard spec — plus the two negative cases that are easy to regress into: kinds that do not declare drilldown must open no menu, and neither must a non-builder query.
- **The View modal ↔ editor handoff** carries *live, unsaved* state in both directions — modal → editor through router state, editor → modal through `sessionStorage`. Losing either silently discards in-progress work, so TC-09/TC-10 assert both that the state arrives and that nothing was persisted on the way. TC-08 pins the round-trip as a no-op.

The rest is contract coverage: which actions each panel kind offers (Download CSV only on Table, Create Alerts only where declared), that clone/delete/move-to-section persist, that a locked dashboard disables the mutating actions, and that header search and column resize behave per kind.

**Supporting change outside the suite**

`ResizableHeader` accepts the column key and puts it on the drag grip as `column-resize-<key>`, threaded through from `useResizableColumns`. Without it the grips are indistinguishable, so "this column was resized and the width persisted" is not assertable. Adds a prop and a `data-testid`; no behaviour change.

| Scope | Before (`main`) | After (this branch) | Delta |
|---|---:|---:|---:|
| Dashboards V2 E2E tests | 0 | 63 | **+63** |
| ↳ added by this PR | 25 | 63 | **+38** |
| Whole E2E suite | 20 | 83 | +63 |

Counts are per browser project; the suite runs chromium, firefox and webkit.

#### Panel actions menu (9)

| File | Test | Status |
|---|---|---|
| `panels/12-actions-menu.spec.ts` | TC-01 an editable panel offers the full action set | |
| `panels/12-actions-menu.spec.ts` | TC-02 Download offers CSV only on Table | |
| `panels/12-actions-menu.spec.ts` | TC-03 Create Alerts is hidden for kinds that do not declare it | |
| `panels/12-actions-menu.spec.ts` | TC-04 Create Alerts opens the alert builder in a new tab | |
| `panels/12-actions-menu.spec.ts` | TC-05 Download as PNG produces a file | conditional |
| `panels/12-actions-menu.spec.ts` | TC-06 Clone adds a second panel and persists it | |
| `panels/12-actions-menu.spec.ts` | TC-07 Delete panel removes the panel and its layout item | |
| `panels/12-actions-menu.spec.ts` | TC-08 Move to section relocates the panel between sections | |
| `panels/12-actions-menu.spec.ts` | TC-09 a locked dashboard disables the mutating actions | |

#### Table and list controls (7)

| File | Test | Status |
|---|---|---|
| `panels/48-table-list.spec.ts` | TC-01 header search filters the table and can be cleared | |
| `panels/48-table-list.spec.ts` | TC-02 Escape closes the search box | |
| `panels/48-table-list.spec.ts` | TC-03 search is not offered on kinds that do not declare it | |
| `panels/48-table-list.spec.ts` | TC-04 a resized column persists across a reload | |
| `panels/48-table-list.spec.ts` | TC-05 the List pager advances and re-queries | |
| `panels/48-table-list.spec.ts` | TC-06 Previous is disabled on the first page | |
| `panels/48-table-list.spec.ts` | TC-07 changing the page size re-queries | |

#### Drilldown (9)

| File | Test | Status |
|---|---|---|
| `panels/57-drilldown.spec.ts` | TC-01 clicking a series opens the aggregate menu | |
| `panels/57-drilldown.spec.ts` | TC-02 clicking the backdrop closes the menu | |
| `panels/57-drilldown.spec.ts` | TC-03 View in Logs navigates to the logs explorer | |
| `panels/57-drilldown.spec.ts` | TC-04 Breakout opens a submenu and the back arrow returns | |
| `panels/57-drilldown.spec.ts` | TC-05 the Dashboard Variables submenu offers set and create | |
| `panels/57-drilldown.spec.ts` | TC-06 setting a variable from the menu updates the variables bar | |
| `panels/57-drilldown.spec.ts` | TC-07 creating a variable from the menu patches the dashboard spec | |
| `panels/57-drilldown.spec.ts` | TC-08 kinds that do not declare drilldown open no menu | |
| `panels/57-drilldown.spec.ts` | TC-09 a non-builder query opens no menu | |

#### View modal (9)

| File | Test | Status |
|---|---|---|
| `panels/66-view-modal.spec.ts` | TC-01 View opens the modal and reflects it in the URL | |
| `panels/66-view-modal.spec.ts` | TC-02 the modal opens directly from a deep link | |
| `panels/66-view-modal.spec.ts` | TC-04 Refresh re-issues the query | |
| `panels/66-view-modal.spec.ts` | TC-05 switching the panel type in the modal does not persist | |
| `panels/66-view-modal.spec.ts` | TC-06 Switch to Edit Mode hands off to the panel editor | |
| `panels/66-view-modal.spec.ts` | TC-07 a locked panel opens in View but offers no Switch to Edit | |
| `panels/66-view-modal.spec.ts` | TC-08 View → Edit → View round-trips with no changes | |
| `panels/66-view-modal.spec.ts` | TC-09 an unsaved change in the modal carries into the editor | |
| `panels/66-view-modal.spec.ts` | TC-10 an unsaved change in the editor carries back into the modal | |

#### Grid layout (4)

| File | Test | Status |
|---|---|---|
| `panels/75-layout.spec.ts` | TC-01 resizing a panel persists its new size | |
| `panels/75-layout.spec.ts` | TC-02 a resized layout survives a reload | |
| `panels/75-layout.spec.ts` | TC-03 opening the actions menu does not start a drag | |
| `panels/75-layout.spec.ts` | TC-04 dragging by the header moves the panel within its section | |

#### Known gap

The View modal table jumps from TC-02 to TC-04. TC-03 was "browser Back closes the modal", and it is not covered: while the modal is open the URL is rewritten on every render with a freshly generated `compositeQuery` id, so each write is a new history entry — Back pops one and the next render immediately pushes another. Diagnosed while writing this suite (three consecutive Backs left the modal open, with only the `compositeQuery` id changing). It also grows history without bound. That wants a fix at the source — an idempotent URL write, i.e. a stable id or `history: 'replace'` — not a test that encodes the broken behaviour, so the case is left uncovered until then.

#### Skipped tests

No test is skipped unconditionally. The only skip is browser-scoped:

| Test | File | Kind | Reason |
|---|---|---|---|
| TC-05 Download as PNG produces a file | `panels/12-actions-menu.spec.ts` | conditional | Chromium only: headless Firefox and WebKit do not emit a download event for the canvas blob, so there is nothing to wait on. |

#### Note on `helpers/panel-editor-v2.ts`

The editor locators land in this PR rather than the next one because the View modal handoff is their first consumer. The editor specs in #12411 and #12412 reuse them unchanged.

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Nothing closes here — the closing references live on #12412.

Part of SigNoz/engineering-pod#4304 — *e2e test for Dashboard Panels*.

| Sub-issue | What this PR contributes |
|---|---|
| SigNoz/engineering-pod#4515 — Timeseries | actions menu (clone, delete, move to section, Download PNG, Create Alerts, locked-dashboard gating); drilldown aggregate menu, its navigation targets and its variable set/create paths; the View modal and its two-way editor handoff; grid drag and resize |
| SigNoz/engineering-pod#4518 — Table | Download as CSV offered only here; header search and its Escape/clear behaviour; a resized column persisting across a reload |
| SigNoz/engineering-pod#4521 — List | pager advance and re-query, Previous disabled on the first page, page-size change |
| SigNoz/engineering-pod#4517 — Histogram | the negative drilldown case: a kind that does not declare drilldown opens no menu |
| SigNoz/engineering-pod#4516 — Bar, SigNoz/engineering-pod#4519 — Number, SigNoz/engineering-pod#4520 — Pie | not exercised here. The actions menu, View modal and layout specs run on `compactDashboard` (TimeSeries + Table + List); these kinds get their coverage in #12411 and #12412 |
| SigNoz/engineering-pod#4524 — create from scratch + cleanup | — |

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [x] 🧪 Test-only

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- **Blast radius:** the E2E suite, plus a `columnKey` prop and `data-testid` on the Table/List resize grip.
- **Potential regressions:** none expected — the grip's `useMemo` now depends on `columnKey`, which is stable per column.
- **Rollback plan:** revert; nothing outside the suite depends on it.

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Maintenance |
| Description | N/A — test coverage only. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [ ] Manually tested
- [ ] Breaking changes documented — N/A
- [ ] Backward compatibility considered — N/A
