### PR TITLE
fix(infra-monitoring): use local sample tables in custom queries in `metric-reduction-feature` path

### DIFF
--- a/pkg/modules/inframonitoring/implinframonitoring/helpers.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/helpers.go
@@ -372,9 +372,7 @@ func (m *module) buildSamplesTblFingerprintSubQuery(metricNames []string, sample
 }
 
 // buildReducedSamplesTblFingerprintSubQuery is like buildSamplesTblFingerprintSubQuery
-// but for the reduced tables. Uses local tables: a distributed subquery inside the
-// distributed outer query is rejected by ClickHouse (distributed_product_mode = 'deny'),
-// and reduced series/samples share the same sharding key so per-shard lookup is exact.
+// but for the reduced tables.
 func (m *module) buildReducedSamplesTblFingerprintSubQuery(metricNames []string, flooredStart, flooredEnd uint64) *sqlbuilder.SelectBuilder {
 	lastSB := sqlbuilder.NewSelectBuilder()
 	lastSB.Select("reduced_fingerprint")

--- a/pkg/modules/inframonitoring/implinframonitoring/helpers.go
+++ b/pkg/modules/inframonitoring/implinframonitoring/helpers.go
@@ -372,11 +372,13 @@ func (m *module) buildSamplesTblFingerprintSubQuery(metricNames []string, sample
 }
 
 // buildReducedSamplesTblFingerprintSubQuery is like buildSamplesTblFingerprintSubQuery
-// but for the reduced tables.
+// but for the reduced tables. Uses local tables: a distributed subquery inside the
+// distributed outer query is rejected by ClickHouse (distributed_product_mode = 'deny'),
+// and reduced series/samples share the same sharding key so per-shard lookup is exact.
 func (m *module) buildReducedSamplesTblFingerprintSubQuery(metricNames []string, flooredStart, flooredEnd uint64) *sqlbuilder.SelectBuilder {
 	lastSB := sqlbuilder.NewSelectBuilder()
 	lastSB.Select("reduced_fingerprint")
-	lastSB.From(fmt.Sprintf("%s.%s", metricstelemetryschema.DBName, metricstelemetryschema.SamplesV4ReducedLastTableName))
+	lastSB.From(fmt.Sprintf("%s.%s", metricstelemetryschema.DBName, metricstelemetryschema.SamplesV4ReducedLastLocalTableName))
 	lastSB.Where(
 		lastSB.In("metric_name", sqlbuilder.List(metricNames)),
 		lastSB.GE("unix_milli", flooredStart),
@@ -385,7 +387,7 @@ func (m *module) buildReducedSamplesTblFingerprintSubQuery(metricNames []string,
 
 	sumSB := sqlbuilder.NewSelectBuilder()
 	sumSB.Select("reduced_fingerprint")
-	sumSB.From(fmt.Sprintf("%s.%s", metricstelemetryschema.DBName, metricstelemetryschema.SamplesV4ReducedSumTableName))
+	sumSB.From(fmt.Sprintf("%s.%s", metricstelemetryschema.DBName, metricstelemetryschema.SamplesV4ReducedSumLocalTableName))
 	sumSB.Where(
 		sumSB.In("metric_name", sqlbuilder.List(metricNames)),
 		sumSB.GE("unix_milli", flooredStart),

--- a/pkg/telemetryschema/metricstelemetryschema/const.go
+++ b/pkg/telemetryschema/metricstelemetryschema/const.go
@@ -34,14 +34,16 @@ const (
 
 	// The buffer holds raw points for ~24h; the reduced tables hold 60s
 	// aggregates of dropped-label series.
-	SamplesV4BufferTableName          = "distributed_samples_v4_buffer"
-	SamplesV4BufferLocalTableName     = "samples_v4_buffer"
-	TimeseriesV4BufferTableName       = "distributed_time_series_v4_buffer"
-	TimeseriesV4BufferLocalTableName  = "time_series_v4_buffer"
-	SamplesV4ReducedLastTableName     = "distributed_samples_v4_reduced_last_60s"
-	SamplesV4ReducedSumTableName      = "distributed_samples_v4_reduced_sum_60s"
-	TimeseriesV4ReducedTableName      = "distributed_time_series_v4_reduced"
-	TimeseriesV4ReducedLocalTableName = "time_series_v4_reduced"
+	SamplesV4BufferTableName           = "distributed_samples_v4_buffer"
+	SamplesV4BufferLocalTableName      = "samples_v4_buffer"
+	TimeseriesV4BufferTableName        = "distributed_time_series_v4_buffer"
+	TimeseriesV4BufferLocalTableName   = "time_series_v4_buffer"
+	SamplesV4ReducedLastTableName      = "distributed_samples_v4_reduced_last_60s"
+	SamplesV4ReducedLastLocalTableName = "samples_v4_reduced_last_60s"
+	SamplesV4ReducedSumTableName       = "distributed_samples_v4_reduced_sum_60s"
+	SamplesV4ReducedSumLocalTableName  = "samples_v4_reduced_sum_60s"
+	TimeseriesV4ReducedTableName       = "distributed_time_series_v4_reduced"
+	TimeseriesV4ReducedLocalTableName  = "time_series_v4_reduced"
 
 	ReductionRulesTableName = "distributed_metric_reduction_rules"
 )

--- a/tests/integration/tests/metricreduction/05_inframonitoring.py
+++ b/tests/integration/tests/metricreduction/05_inframonitoring.py
@@ -40,51 +40,52 @@ POD_EXTRA_LABELS = {
     "k8s.pod.start_time": "2025-01-01T00:00:00Z",
 }
 
-ENTITY_CASES = [
-    pytest.param(
-        "/api/v2/infra_monitoring/hosts",
-        "host",
-        ["system.cpu.load_average.15m"],
-        lambda name: {"host.name": name, "os.type": "linux"},
-        lambda record: record["hostName"],
-        id="hosts",
-    ),
-    pytest.param(
-        "/api/v2/infra_monitoring/nodes",
-        "node",
-        ["k8s.node.cpu.usage", "k8s.node.memory.working_set"],
-        lambda name: {"k8s.node.name": name, "k8s.node.uid": f"{name}-uid", "k8s.cluster.name": "cluster-mr"},
-        lambda record: record["nodeName"],
-        id="nodes",
-    ),
-    pytest.param(
-        "/api/v2/infra_monitoring/pods",
-        "pod",
-        ["k8s.pod.cpu.usage", "k8s.pod.memory.working_set"],
-        lambda name: {"k8s.pod.uid": f"{name}-uid", "k8s.pod.name": name, "k8s.deployment.name": "dep-mr", **POD_EXTRA_LABELS},
-        lambda record: record["meta"]["k8s.pod.name"],
-        id="pods",
-    ),
-    pytest.param(
-        "/api/v2/infra_monitoring/clusters",
-        "cluster",
-        ["k8s.node.cpu.usage", "k8s.node.memory.working_set"],
-        lambda name: {"k8s.node.name": f"{name}-n1", "k8s.node.uid": f"{name}-n1-uid", "k8s.cluster.name": name},
-        lambda record: record["clusterName"],
-        id="clusters",
-    ),
-    pytest.param(
-        "/api/v2/infra_monitoring/deployments",
-        "deployment",
-        ["k8s.pod.cpu.usage", "k8s.pod.memory.working_set"],
-        lambda name: {"k8s.pod.uid": f"{name}-p1-uid", "k8s.pod.name": f"{name}-p1", "k8s.deployment.name": name, **POD_EXTRA_LABELS},
-        lambda record: record["deploymentName"],
-        id="deployments",
-    ),
-]
 
-
-@pytest.mark.parametrize("endpoint, prefix, metric_names, labels_of, name_of", ENTITY_CASES)
+@pytest.mark.parametrize(
+    "endpoint, prefix, metric_names, labels_of, name_of",
+    [
+        pytest.param(
+            "/api/v2/infra_monitoring/hosts",
+            "host",
+            ["system.cpu.load_average.15m"],
+            lambda name: {"host.name": name, "os.type": "linux"},
+            lambda record: record["hostName"],
+            id="hosts",
+        ),
+        pytest.param(
+            "/api/v2/infra_monitoring/nodes",
+            "node",
+            ["k8s.node.cpu.usage", "k8s.node.memory.working_set"],
+            lambda name: {"k8s.node.name": name, "k8s.node.uid": f"{name}-uid", "k8s.cluster.name": "cluster-mr"},
+            lambda record: record["nodeName"],
+            id="nodes",
+        ),
+        pytest.param(
+            "/api/v2/infra_monitoring/pods",
+            "pod",
+            ["k8s.pod.cpu.usage", "k8s.pod.memory.working_set"],
+            lambda name: {"k8s.pod.uid": f"{name}-uid", "k8s.pod.name": name, "k8s.deployment.name": "dep-mr", **POD_EXTRA_LABELS},
+            lambda record: record["meta"]["k8s.pod.name"],
+            id="pods",
+        ),
+        pytest.param(
+            "/api/v2/infra_monitoring/clusters",
+            "cluster",
+            ["k8s.node.cpu.usage", "k8s.node.memory.working_set"],
+            lambda name: {"k8s.node.name": f"{name}-n1", "k8s.node.uid": f"{name}-n1-uid", "k8s.cluster.name": name},
+            lambda record: record["clusterName"],
+            id="clusters",
+        ),
+        pytest.param(
+            "/api/v2/infra_monitoring/deployments",
+            "deployment",
+            ["k8s.pod.cpu.usage", "k8s.pod.memory.working_set"],
+            lambda name: {"k8s.pod.uid": f"{name}-p1-uid", "k8s.pod.name": f"{name}-p1", "k8s.deployment.name": name, **POD_EXTRA_LABELS},
+            lambda record: record["deploymentName"],
+            id="deployments",
+        ),
+    ],
+)
 def test_list_merges_raw_and_reduced_entities(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
     signoz: types.SigNoz,
     create_user_admin: None,  # pylint: disable=unused-argument

--- a/tests/integration/tests/metricreduction/05_inframonitoring.py
+++ b/tests/integration/tests/metricreduction/05_inframonitoring.py
@@ -1,0 +1,258 @@
+"""Infra-monitoring v2 list endpoints on the metrics-reduction path.
+
+With reduction enabled, every list endpoint unions raw and reduced series and
+restricts each side with a fingerprint IN (samples) subquery. Those subqueries
+must read local tables: a distributed subquery inside the distributed outer
+query is rejected by ClickHouse with error 288 (distributed_product_mode =
+'deny'), which only ever fires on a multi-shard cluster — exactly what this
+package's fixtures provide. Seed raw-only and reduced-only entities and assert
+each endpoint returns the union of both."""
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from http import HTTPStatus
+
+import clickhouse_connect.driver.client
+import pytest
+import requests
+
+from fixtures import types
+from fixtures.auth import USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD
+from fixtures.metricreduction import assert_spans_shards
+from fixtures.metrics import (
+    Metrics,
+    MetricsReducedSampleLast60s,
+    MetricsReducedTimeSeries,
+)
+from fixtures.querier import aligned_epoch
+
+MINUTES = 5
+COUNT_PER_SOURCE = 8
+
+POD_EXTRA_LABELS = {
+    "k8s.namespace.name": "ns-mr",
+    "k8s.node.name": "node-mr",
+    "k8s.cluster.name": "cluster-mr",
+    "k8s.statefulset.name": "",
+    "k8s.daemonset.name": "",
+    "k8s.job.name": "",
+    "k8s.cronjob.name": "",
+    "k8s.pod.start_time": "2025-01-01T00:00:00Z",
+}
+
+ENTITY_CASES = [
+    pytest.param(
+        "/api/v2/infra_monitoring/hosts",
+        "host",
+        ["system.cpu.load_average.15m"],
+        lambda name: {"host.name": name, "os.type": "linux"},
+        lambda record: record["hostName"],
+        id="hosts",
+    ),
+    pytest.param(
+        "/api/v2/infra_monitoring/nodes",
+        "node",
+        ["k8s.node.cpu.usage", "k8s.node.memory.working_set"],
+        lambda name: {"k8s.node.name": name, "k8s.node.uid": f"{name}-uid", "k8s.cluster.name": "cluster-mr"},
+        lambda record: record["nodeName"],
+        id="nodes",
+    ),
+    pytest.param(
+        "/api/v2/infra_monitoring/pods",
+        "pod",
+        ["k8s.pod.cpu.usage", "k8s.pod.memory.working_set"],
+        lambda name: {"k8s.pod.uid": f"{name}-uid", "k8s.pod.name": name, "k8s.deployment.name": "dep-mr", **POD_EXTRA_LABELS},
+        lambda record: record["meta"]["k8s.pod.name"],
+        id="pods",
+    ),
+    pytest.param(
+        "/api/v2/infra_monitoring/clusters",
+        "cluster",
+        ["k8s.node.cpu.usage", "k8s.node.memory.working_set"],
+        lambda name: {"k8s.node.name": f"{name}-n1", "k8s.node.uid": f"{name}-n1-uid", "k8s.cluster.name": name},
+        lambda record: record["clusterName"],
+        id="clusters",
+    ),
+    pytest.param(
+        "/api/v2/infra_monitoring/deployments",
+        "deployment",
+        ["k8s.pod.cpu.usage", "k8s.pod.memory.working_set"],
+        lambda name: {"k8s.pod.uid": f"{name}-p1-uid", "k8s.pod.name": f"{name}-p1", "k8s.deployment.name": name, **POD_EXTRA_LABELS},
+        lambda record: record["deploymentName"],
+        id="deployments",
+    ),
+]
+
+
+@pytest.mark.parametrize("endpoint, prefix, metric_names, labels_of, name_of", ENTITY_CASES)
+def test_list_merges_raw_and_reduced_entities(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+    signoz: types.SigNoz,
+    create_user_admin: None,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+    insert_metrics: Callable[[list[Metrics]], None],
+    insert_reduced_metrics: Callable[..., None],
+    clickhouse_node_conns: list[clickhouse_connect.driver.client.Client],
+    endpoint: str,
+    prefix: str,
+    metric_names: list[str],
+    labels_of: Callable[[str], dict],
+    name_of: Callable[[dict], str],
+) -> None:
+    """One set of entities exists only in the raw tables, another only in the
+    reduced tables. The list response must contain both sets: pre-fix, the
+    reduced branch's fingerprint subquery on distributed tables made every one
+    of these endpoints fail with ClickHouse error 288."""
+    base_epoch = aligned_epoch(timedelta(hours=30), step_seconds=300)
+    raw_names = [f"{prefix}-raw-{i}" for i in range(COUNT_PER_SOURCE)]
+    reduced_names = [f"{prefix}-red-{i}" for i in range(COUNT_PER_SOURCE)]
+
+    insert_metrics(
+        [
+            Metrics(
+                metric_name=metric,
+                labels=labels_of(name),
+                timestamp=datetime.fromtimestamp(base_epoch + minute * 60, tz=UTC),
+                value=0.5,
+                type_="Gauge",
+                is_monotonic=False,
+            )
+            for name in raw_names
+            for metric in metric_names
+            for minute in range(MINUTES)
+        ]
+    )
+
+    time_series = [
+        MetricsReducedTimeSeries(
+            metric_name=metric,
+            kept_labels=labels_of(name),
+            timestamp=datetime.fromtimestamp(base_epoch, tz=UTC),
+        )
+        for name in reduced_names
+        for metric in metric_names
+    ]
+    insert_reduced_metrics(
+        time_series,
+        [
+            MetricsReducedSampleLast60s(
+                metric_name=ts.metric_name,
+                reduced_fingerprint=ts.fingerprint,
+                timestamp=datetime.fromtimestamp(base_epoch + minute * 60, tz=UTC),
+                sum_last=0.5,
+                min_value=0.5,
+                max_value=0.5,
+                sum_values=0.5,
+                count_series=1,
+                count_samples=1,
+            )
+            for ts in time_series
+            for minute in range(MINUTES)
+        ],
+    )
+
+    assert_spans_shards(clickhouse_node_conns, "time_series_v4", metric_names[0], total=COUNT_PER_SOURCE)
+    assert_spans_shards(clickhouse_node_conns, "time_series_v4_reduced", metric_names[0], total=COUNT_PER_SOURCE)
+
+    token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+    response = requests.post(
+        signoz.self.host_configs["8080"].get(endpoint),
+        headers={"authorization": f"Bearer {token}"},
+        json={
+            "start": base_epoch * 1000,
+            "end": (base_epoch + 30 * 60) * 1000,
+            "limit": 50,
+        },
+        timeout=30,
+    )
+    assert response.status_code == HTTPStatus.OK, response.text
+    records = response.json()["data"]["records"]
+    assert {name_of(r) for r in records} == set(raw_names) | set(reduced_names)
+
+
+def test_hosts_groupby_counts_span_raw_and_reduced(
+    signoz: types.SigNoz,
+    create_user_admin: None,  # pylint: disable=unused-argument
+    get_token: Callable[[str, str], str],
+    insert_metrics: Callable[[list[Metrics]], None],
+    insert_reduced_metrics: Callable[..., None],
+    clickhouse_node_conns: list[clickhouse_connect.driver.client.Client],
+) -> None:
+    """Grouped hosts responses build per-group status counts over the same
+    raw + reduced union (a hosts-only query, separate from the list path).
+    Raw hosts are seeded as linux and reduced hosts as windows, so each group's
+    host count proves its side of the union was read."""
+    metric_name = "system.cpu.load_average.15m"
+    base_epoch = aligned_epoch(timedelta(hours=30), step_seconds=300)
+    raw_names = [f"grp-raw-{i}" for i in range(COUNT_PER_SOURCE)]
+    reduced_names = [f"grp-red-{i}" for i in range(COUNT_PER_SOURCE)]
+
+    insert_metrics(
+        [
+            Metrics(
+                metric_name=metric_name,
+                labels={"host.name": name, "os.type": "linux"},
+                timestamp=datetime.fromtimestamp(base_epoch + minute * 60, tz=UTC),
+                value=1.5,
+                type_="Gauge",
+                is_monotonic=False,
+            )
+            for name in raw_names
+            for minute in range(MINUTES)
+        ]
+    )
+
+    time_series = [
+        MetricsReducedTimeSeries(
+            metric_name=metric_name,
+            kept_labels={"host.name": name, "os.type": "windows"},
+            timestamp=datetime.fromtimestamp(base_epoch, tz=UTC),
+        )
+        for name in reduced_names
+    ]
+    insert_reduced_metrics(
+        time_series,
+        [
+            MetricsReducedSampleLast60s(
+                metric_name=metric_name,
+                reduced_fingerprint=ts.fingerprint,
+                timestamp=datetime.fromtimestamp(base_epoch + minute * 60, tz=UTC),
+                sum_last=1.5,
+                min_value=1.5,
+                max_value=1.5,
+                sum_values=1.5,
+                count_series=1,
+                count_samples=1,
+            )
+            for ts in time_series
+            for minute in range(MINUTES)
+        ],
+    )
+
+    assert_spans_shards(clickhouse_node_conns, "time_series_v4", metric_name, total=COUNT_PER_SOURCE)
+    assert_spans_shards(clickhouse_node_conns, "time_series_v4_reduced", metric_name, total=COUNT_PER_SOURCE)
+
+    token = get_token(USER_ADMIN_EMAIL, USER_ADMIN_PASSWORD)
+    response = requests.post(
+        signoz.self.host_configs["8080"].get("/api/v2/infra_monitoring/hosts"),
+        headers={"authorization": f"Bearer {token}"},
+        json={
+            "start": base_epoch * 1000,
+            "end": (base_epoch + 30 * 60) * 1000,
+            "limit": 50,
+            "groupBy": [
+                {
+                    "name": "os.type",
+                    "fieldDataType": "string",
+                    "fieldContext": "resource",
+                },
+            ],
+        },
+        timeout=30,
+    )
+    assert response.status_code == HTTPStatus.OK, response.text
+    records = response.json()["data"]["records"]
+    by_group = {r["meta"]["os.type"]: r for r in records}
+    assert set(by_group.keys()) == {"linux", "windows"}
+    for group in ("linux", "windows"):
+        rec = by_group[group]
+        assert rec["activeHostCount"] + rec["inactiveHostCount"] == COUNT_PER_SOURCE, f"{group}: got {rec['activeHostCount']} active + {rec['inactiveHostCount']} inactive"


### PR DESCRIPTION
### 📄 Summary

Infra-monitoring v2 APIs fail with ClickHouse error 288 (`Double-distributed IN/JOIN subqueries is denied`) for tenants with metrics reduction enabled. The reduced path's `fingerprint IN (...)` subquery read the distributed reduced-samples tables inside a query that is itself on a distributed table. This PR switches the subquery to the local tables, mirroring what the raw path already does with `samples_v4`.

Closes https://github.com/SigNoz/pulse-pod/issues/205

### ✅ Change Type

- [x] 🐛 Bug fix

### 🐛 Bug Context

**Root Cause**: `buildReducedSamplesTblFingerprintSubQuery` built its subquery on `distributed_samples_v4_reduced_{last,sum}_60s` while the outer query reads `distributed_time_series_v4_reduced` — rejected under ClickHouse's default `distributed_product_mode = 'deny'`. All three callers (`getMetadata`, `getPerGroupDistinctCounts`, `getPerGroupHostStatusCounts`) share this helper, so every entity page broke for reduction-enabled tenants.

**Fix Strategy**: The subquery now reads the local tables, so each shard resolves fingerprints against its own data. This is exact because the reduced time-series and reduced-samples tables share the same sharding key (`cityHash64(env, temporality, metric_name, <reduced_>fingerprint)`), keeping a series row and its samples on the same shard — verified on the affected tenant's cluster. Local tables were preferred over `GLOBAL IN` to avoid broadcasting the subquery result and to stay consistent with the raw path and the QB v5 statement builder.

### 🧪 Testing Strategy

- Added `tests/integration/tests/metricreduction/05_inframonitoring.py`: hosts, nodes, pods, clusters, and deployments list endpoints are tested on a 2-shard cluster with reduction enabled, seeding raw-only and reduced-only entities and asserting the response returns the union. These tests fail with error 288 without the fix. A hosts groupBy test covers the per-group status counts path. Full metricreduction suite passes (18/18).
- Manually reproduced against the affected tenant's ClickHouse: infra pages failed with error 288 before the fix, and the corrected query returns results.
- Non-reduced tenants are unaffected; the helper only runs on the reduction-enabled path.

### ⚠️ Risk & Impact Assessment

- Blast radius is limited to infra-monitoring v2 queries for tenants with `enable_metrics_reduction` on.
- Rollback: revert the commit, or disable the flag per tenant to bypass the reduced path.

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud |
| Change Type | Bug Fix |
| Description | Fixed infra-monitoring pages failing with a ClickHouse error for tenants with metrics reduction enabled. |

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered
