### PR TITLE
fix(dashboard-v2): stop a time-range change resetting a dynamic variable's selection to ALL

### DIFF
--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/ValueSelector.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/ValueSelector.test.tsx
@@ -182,4 +182,56 @@ describe('ValueSelector', () => {
 			});
 		});
 	});
+
+	describe('opening and closing without touching the list', () => {
+		function renderWith(
+			selection: VariableSelection,
+			options: string[],
+		): jest.Mock {
+			const onChange = jest.fn();
+			render(
+				<TooltipProvider>
+					<ValueSelector
+						options={options}
+						variableType="dynamic"
+						multiSelect
+						showAllOption
+						selection={selection}
+						onChange={onChange}
+						emptyFallback={{ value: [], allSelected: false }}
+						testId="variable-select-env"
+					/>
+				</TooltipProvider>,
+			);
+			return onChange;
+		}
+
+		async function openThenClose(): Promise<void> {
+			const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+			const control = screen.getByTestId('variable-select-env');
+			await user.click(control.querySelector('input') as HTMLInputElement);
+			await user.keyboard('{Escape}');
+		}
+
+		it('does not promote a pick that covers every available option to ALL', async () => {
+			// A narrow time range can leave only the selected value in the list. That is
+			// still an explicit pick, not "everything, always".
+			const onChange = renderWith(
+				{ value: ['checkout-service-prod'], allSelected: false },
+				['checkout-service-prod'],
+			);
+
+			await openThenClose();
+
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it('does not rewrite a dynamic ALL into concrete values', async () => {
+			const onChange = renderWith({ value: null, allSelected: true }, OPTIONS);
+
+			await openThenClose();
+
+			expect(onChange).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/resolveVariableSelection.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/resolveVariableSelection.test.ts
@@ -145,6 +145,53 @@ describe('reconcileWithOptions', () => {
 			),
 		).toBeNull();
 	});
+
+	describe('preserveSelection (options moved on their own — time range, reload)', () => {
+		const multi = model({
+			type: 'DYNAMIC',
+			multiSelect: true,
+			showAllOption: true,
+			dynamicAttribute: 'service.name',
+		});
+
+		it('keeps a multi-select pick the new option list no longer offers', () => {
+			expect(
+				reconcileWithOptions(multi, { value: ['frontend'], allSelected: false }, [
+					'backend',
+					'cart',
+				]),
+			).toStrictEqual({ value: null, allSelected: true });
+
+			expect(
+				reconcileWithOptions(
+					multi,
+					{ value: ['frontend'], allSelected: false },
+					['backend', 'cart'],
+					{ preserveSelection: true },
+				),
+			).toBeNull();
+		});
+
+		it('still materializes ALL, which must track the option list', () => {
+			expect(
+				reconcileWithOptions(
+					model({ type: 'QUERY', multiSelect: true, showAllOption: true }),
+					{ value: ['a'], allSelected: true },
+					['a', 'b'],
+					{ preserveSelection: true },
+				),
+			).toStrictEqual({ value: ['a', 'b'], allSelected: true });
+		});
+
+		it('still fills the default when nothing is selected yet', () => {
+			expect(
+				reconcileWithOptions(multi, { value: [], allSelected: false }, ['a', 'b'], {
+					preserveSelection: true,
+				}),
+			).toStrictEqual({ value: null, allSelected: true });
+		});
+	});
+
 });
 
 describe('configuredDefaultValue', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/resolveVariableSelection.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/resolveVariableSelection.test.ts
@@ -192,6 +192,86 @@ describe('reconcileWithOptions', () => {
 		});
 	});
 
+	// A typed value is in no option list, so no refetch can invalidate it.
+	describe('customValues (typed in, never offered by the data)', () => {
+		const multi = model({
+			type: 'DYNAMIC',
+			multiSelect: true,
+			showAllOption: true,
+			dynamicAttribute: 'service.name',
+		});
+
+		it('keeps them through a re-scope that drops a fetched value', () => {
+			expect(
+				reconcileWithOptions(
+					multi,
+					{
+						value: ['frontend', 'typed-in'],
+						allSelected: false,
+						customValues: ['typed-in'],
+					},
+					['backend', 'cart'],
+				),
+			).toStrictEqual({
+				value: ['typed-in'],
+				allSelected: false,
+				customValues: ['typed-in'],
+			});
+		});
+
+		it('never re-defaults a selection made only of them', () => {
+			expect(
+				reconcileWithOptions(
+					multi,
+					{ value: ['typed-in'], allSelected: false, customValues: ['typed-in'] },
+					['backend', 'cart'],
+				),
+			).toBeNull();
+		});
+
+		// An inert marker is not worth a store write + dependent refetch to prune.
+		it('leaves a stale marker alone when it drops nothing', () => {
+			expect(
+				reconcileWithOptions(
+					multi,
+					{
+						value: ['frontend', 'typed-in'],
+						allSelected: false,
+						customValues: ['typed-in', 'removed-earlier'],
+					},
+					['frontend'],
+				),
+			).toBeNull();
+		});
+
+		it('prunes markers for values it does drop', () => {
+			expect(
+				reconcileWithOptions(
+					multi,
+					{
+						value: ['stale', 'typed-in'],
+						allSelected: false,
+						customValues: ['typed-in'],
+					},
+					['frontend'],
+				),
+			).toStrictEqual({
+				value: ['typed-in'],
+				allSelected: false,
+				customValues: ['typed-in'],
+			});
+		});
+
+		it('still drops an unmarked value the list no longer offers', () => {
+			expect(
+				reconcileWithOptions(
+					multi,
+					{ value: ['frontend', 'stale'], allSelected: false },
+					['frontend'],
+				),
+			).toStrictEqual({ value: ['frontend'], allSelected: false });
+		});
+	});
 });
 
 describe('configuredDefaultValue', () => {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/selectionUtils.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/selectionUtils.test.ts
@@ -1,0 +1,91 @@
+import type { VariableSelection } from '../selectionTypes';
+import { selectionFromCommittedValues } from '../utils/selectionUtils';
+
+const OPTIONS = ['checkout', 'payments', 'cart'];
+const FALLBACK: VariableSelection = { value: null, allSelected: true };
+
+function commit(
+	values: string[],
+	overrides: Partial<Parameters<typeof selectionFromCommittedValues>[0]> = {},
+): VariableSelection {
+	return selectionFromCommittedValues({
+		values,
+		options: OPTIONS,
+		showAllOption: true,
+		emptyFallback: FALLBACK,
+		...overrides,
+	});
+}
+
+// What a multi-select commit resolves to. The option list is known only here, so this
+// is the one place a typed value can be recognised.
+describe('selectionFromCommittedValues', () => {
+	it('marks values the option list did not offer as typed in', () => {
+		expect(commit(['checkout', 'typed-in'])).toStrictEqual({
+			value: ['checkout', 'typed-in'],
+			allSelected: false,
+			customValues: ['typed-in'],
+		});
+	});
+
+	it('marks a selection made only of typed-in values', () => {
+		expect(commit(['a', 'b'])).toStrictEqual({
+			value: ['a', 'b'],
+			allSelected: false,
+			customValues: ['a', 'b'],
+		});
+	});
+
+	it('records no marker when every pick came from the list', () => {
+		expect(commit(['checkout', 'cart'])).toStrictEqual({
+			value: ['checkout', 'cart'],
+			allSelected: false,
+		});
+	});
+
+	it('reads a set covering every option as ALL', () => {
+		expect(commit(OPTIONS)).toStrictEqual({
+			value: OPTIONS,
+			allSelected: true,
+		});
+	});
+
+	// ALL re-materializes to the option set, so recording this as ALL would drop the
+	// typed value on the next refetch.
+	it('does not read every option PLUS a typed value as ALL', () => {
+		expect(commit([...OPTIONS, 'typed-in'])).toStrictEqual({
+			value: [...OPTIONS, 'typed-in'],
+			allSelected: false,
+			customValues: ['typed-in'],
+		});
+	});
+
+	// Derived from the values + options at commit time, never from the old selection.
+	it('recomputes the marker: a typed value the data now offers is a normal pick', () => {
+		expect(
+			commit(['checkout', 'was-typed'], {
+				options: [...OPTIONS, 'was-typed'],
+			}),
+		).toStrictEqual({ value: ['checkout', 'was-typed'], allSelected: false });
+	});
+
+	it('does not read it as ALL when the variable offers no ALL', () => {
+		expect(commit(OPTIONS, { showAllOption: false })).toStrictEqual({
+			value: OPTIONS,
+			allSelected: false,
+		});
+	});
+
+	it('resolves an empty commit to the variable fallback', () => {
+		expect(commit([])).toBe(FALLBACK);
+	});
+
+	it('marks everything while the options have not arrived', () => {
+		// Nothing to judge against yet; erring this way keeps a value rather than dropping it.
+		expect(commit(['typed-in'], { options: [] })).toStrictEqual({
+			value: ['typed-in'],
+			allSelected: false,
+			customValues: ['typed-in'],
+		});
+	});
+});

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/useAutoSelect.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/useAutoSelect.test.tsx
@@ -4,6 +4,8 @@ import {
 	emptyVariableFormModel,
 	type VariableFormModel,
 } from '../../DashboardSettings/Variables/variableFormModel';
+import { VariableCycleReason } from '../../store/slices/variableFetchSlice';
+import { useDashboardStore } from '../../store/useDashboardStore';
 import type { VariableSelection } from '../selectionTypes';
 import { useAutoSelect } from '../hooks/useAutoSelect';
 
@@ -15,7 +17,11 @@ function run(
 	variable: VariableFormModel,
 	options: string[],
 	selection: VariableSelection,
+	cycleReason?: VariableCycleReason,
 ): VariableSelection | undefined {
+	useDashboardStore.setState({
+		variableCycleReasons: cycleReason ? { [variable.name]: cycleReason } : {},
+	});
 	const onAutoSelect = jest.fn();
 	renderHook(() => useAutoSelect(variable, options, selection, onAutoSelect));
 	return onAutoSelect.mock.calls[0]?.[0];
@@ -70,11 +76,13 @@ describe('useAutoSelect', () => {
 		expect(next).toStrictEqual({ value: ['a', 'b'], allSelected: true });
 	});
 
-	it('falls back to ALL, not the first option, when every selected value is gone', () => {
+	// Re-scoped options only — a time-range refetch must NOT re-default; see below.
+	it('re-scoped: falls back to ALL, not the first option, when every selected value is gone', () => {
 		const next = run(
 			model({ type: 'QUERY', multiSelect: true, showAllOption: true }),
 			['x', 'y'],
 			{ value: ['a', 'b'], allSelected: false },
+			VariableCycleReason.ValueCascade,
 		);
 		expect(next).toStrictEqual({ value: ['x', 'y'], allSelected: true });
 	});
@@ -102,20 +110,23 @@ describe('useAutoSelect', () => {
 		expect(next).toStrictEqual({ value: ['b'], allSelected: false });
 	});
 
-	it('keeps the still-valid subset of a multi-select when options re-scope', () => {
+	it('re-scoped: keeps the still-valid subset of a multi-select', () => {
 		const next = run(
 			model({ type: 'QUERY', multiSelect: true }),
 			['a', 'b', 'd'],
 			{ value: ['a', 'b', 'c'], allSelected: false },
+			VariableCycleReason.ValueCascade,
 		);
 		expect(next).toStrictEqual({ value: ['a', 'b'], allSelected: false });
 	});
 
-	it('re-defaults a multi-select when none of the selected values remain', () => {
-		const next = run(model({ type: 'QUERY', multiSelect: true }), ['x', 'y'], {
-			value: ['a', 'b'],
-			allSelected: false,
-		});
+	it('re-scoped: re-defaults a multi-select when none of the selected values remain', () => {
+		const next = run(
+			model({ type: 'QUERY', multiSelect: true }),
+			['x', 'y'],
+			{ value: ['a', 'b'], allSelected: false },
+			VariableCycleReason.ValueCascade,
+		);
 		expect(next).toStrictEqual({ value: ['x'], allSelected: false });
 	});
 
@@ -150,5 +161,46 @@ describe('useAutoSelect', () => {
 			allSelected: false,
 		});
 		expect(next).toBeUndefined();
+	});
+
+	describe('by cycle reason', () => {
+		const service = model({
+			name: 'service',
+			type: 'DYNAMIC',
+			multiSelect: true,
+			showAllOption: true,
+			dynamicAttribute: 'service.name',
+		});
+		const gone: VariableSelection = { value: ['frontend'], allSelected: false };
+
+		it('keeps the selection when a full cycle refetched the options', () => {
+			// The new window has no data for the selected service — no reason to widen to ALL.
+			const next = run(
+				service,
+				['backend', 'cart'],
+				gone,
+				VariableCycleReason.FullCycle,
+			);
+			expect(next).toBeUndefined();
+		});
+
+		it('re-scopes the selection when a value cascade refetched the options', () => {
+			const next = run(
+				service,
+				['backend', 'cart'],
+				gone,
+				VariableCycleReason.ValueCascade,
+			);
+			expect(next).toStrictEqual({ value: null, allSelected: true });
+		});
+
+		it('reconciles a variable with no cycle of its own (custom definition change)', () => {
+			const next = run(
+				model({ name: 'env', type: 'CUSTOM', multiSelect: true }),
+				['staging', 'prod'],
+				{ value: ['dev'], allSelected: false },
+			);
+			expect(next).toStrictEqual({ value: ['staging'], allSelected: false });
+		});
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/useVariableSelection.test.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/__tests__/useVariableSelection.test.tsx
@@ -13,11 +13,11 @@ jest.mock('nuqs', () => ({
 	useQueryState: (): unknown => [null, jest.fn()],
 }));
 
+const mockGlobalTime = { minTime: 1, maxTime: 2, selectedTime: '5m' };
+
 jest.mock('react-redux', () => ({
 	useSelector: (selector: (state: unknown) => unknown): unknown =>
-		selector({
-			globalTime: { minTime: 1, maxTime: 2, selectedTime: '5m' },
-		}),
+		selector({ globalTime: mockGlobalTime }),
 }));
 
 jest.mock('../../DashboardSettings/Variables/variableAdapters', () => ({
@@ -148,5 +148,59 @@ describe('useVariableSelection — setSelection', () => {
 			allSelected: false,
 		});
 		expect(svcCycleId()).toBe(before + 1);
+	});
+});
+
+describe('useVariableSelection — what a time-range change enqueues', () => {
+	// Longer than FETCH_CYCLE_DEBOUNCE_MS, which the hook keeps private.
+	const PAST_DEBOUNCE = 400;
+
+	function reasons(): Record<string, string> {
+		return useDashboardStore.getState().variableCycleReasons;
+	}
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		mockGlobalTime.selectedTime = '5m';
+		useDashboardStore.setState({
+			variableValues: {},
+			variableFetchStates: {},
+			variableLastUpdated: {},
+			variableCycleIds: {},
+			variableCycleReasons: {},
+			variableResolvedEmpty: {},
+			variableFetchContext: null,
+			lastFetchAllKey: null,
+		});
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	// The tag is what stops the reconcile re-defaulting a user's selection.
+	it('tags every variable as a full cycle, overriding an earlier cascade tag', () => {
+		const { result, rerender } = renderHook(() =>
+			useVariableSelection(dashboard),
+		);
+
+		act(() => {
+			jest.advanceTimersByTime(PAST_DEBOUNCE);
+		});
+		expect(reasons()).toStrictEqual({ env: 'full-cycle', svc: 'full-cycle' });
+
+		// A value change re-scopes the dependent's options: it may drop what no longer applies.
+		act(() => {
+			result.current.setSelection('env', { value: ['prod'], allSelected: false });
+		});
+		expect(reasons().svc).toBe('value-cascade');
+
+		mockGlobalTime.selectedTime = '30m';
+		rerender();
+		act(() => {
+			jest.advanceTimersByTime(PAST_DEBOUNCE);
+		});
+
+		expect(reasons()).toStrictEqual({ env: 'full-cycle', svc: 'full-cycle' });
 	});
 });

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/selectors/ValueSelector.tsx
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/components/selectors/ValueSelector.tsx
@@ -6,6 +6,7 @@ import { DashboardDetailEvents } from 'pages/DashboardPageV2/constants/events';
 
 import type { VariableSelection } from '../../selectionTypes';
 import { areSelectionsEqual } from '../../utils/resolveVariableSelection';
+import { selectionFromCommittedValues } from '../../utils/selectionUtils';
 import OverflowValuesTooltip from './OverflowValuesTooltip';
 import styles from '../../VariablesBar.module.scss';
 
@@ -75,13 +76,23 @@ function ValueSelector({
 		options.every((option) => draft.includes(option));
 
 	const commit = (values: string[]): void => {
-		// CustomMultiSelect emits the full value set when ALL is picked.
-		const isAll =
-			showAllOption &&
-			options.length > 0 &&
-			options.every((option) => values.includes(option));
-		const next: VariableSelection =
-			values.length === 0 ? emptyFallback : { value: values, allSelected: isAll };
+		// A close that left the list as it opened commits nothing — else a pick covering
+		// every option this window offers would be promoted to a standing ALL.
+		if (
+			areSelectionsEqual(
+				{ value: values, allSelected: false },
+				{ value: committedValues, allSelected: false },
+			)
+		) {
+			return;
+		}
+
+		const next = selectionFromCommittedValues({
+			values,
+			options,
+			showAllOption,
+			emptyFallback,
+		});
 
 		// Closing without actually changing the selection must not re-fire onChange —
 		// that would needlessly re-cascade to dependent variables/panels.

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/hooks/useAutoSelect.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/hooks/useAutoSelect.ts
@@ -1,6 +1,11 @@
 import { useEffect } from 'react';
 
 import type { VariableFormModel } from '../../DashboardSettings/Variables/variableFormModel';
+import {
+	selectVariableCycleReason,
+	VariableCycleReason,
+} from '../../store/slices/variableFetchSlice';
+import { useDashboardStore } from '../../store/useDashboardStore';
 import { reconcileWithOptions } from '../utils/resolveVariableSelection';
 import type { VariableSelection } from '../selectionTypes';
 
@@ -9,6 +14,9 @@ import type { VariableSelection } from '../selectionTypes';
  * `onAutoSelect` only when the value must change. The reconcile rule lives in
  * {@link reconcileWithOptions} (shared with seed + payload defaulting) so the bar
  * and the panel query can never disagree about a variable's default.
+ *
+ * Only a value cascade may re-default the selection; a full cycle (time range,
+ * reload) leaves the user's pick alone. Types with no cycle of their own reconcile.
  */
 export function useAutoSelect(
 	variable: VariableFormModel,
@@ -16,8 +24,14 @@ export function useAutoSelect(
 	selection: VariableSelection,
 	onAutoSelect: (selection: VariableSelection) => void,
 ): void {
+	const cycleReason = useDashboardStore(
+		selectVariableCycleReason(variable.name),
+	);
+
 	useEffect(() => {
-		const next = reconcileWithOptions(variable, selection, options);
+		const next = reconcileWithOptions(variable, selection, options, {
+			preserveSelection: cycleReason === VariableCycleReason.FullCycle,
+		});
 		if (next) {
 			onAutoSelect(next);
 		}

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectionTypes.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/selectionTypes.ts
@@ -10,6 +10,11 @@ export interface VariableSelection {
 	value: SelectedVariableValue;
 	/** True when every option is selected ("ALL"); for dynamic vars value may be null. */
 	allSelected: boolean;
+	/**
+	 * Entries of `value` the user typed rather than picked. Never in any option list,
+	 * so the reconcile keeps them instead of reading them as invalid.
+	 */
+	customValues?: string[];
 }
 
 /** Selected values for a dashboard's variables, keyed by variable name. */

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/utils/resolveVariableSelection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/utils/resolveVariableSelection.ts
@@ -134,11 +134,21 @@ export function resolveDefaultSelection(
 	return { value: model.multiSelect ? [] : '', allSelected: false };
 }
 
+interface ReconcileOptions {
+	/**
+	 * Set when no other variable caused this refetch (time-range change, reload): the
+	 * selection then outranks the options and is kept as-is. Leave false for a
+	 * dependency cascade, where a selection that no longer applies must give way.
+	 */
+	preserveSelection?: boolean;
+}
+
 /**
  * Reconciles a variable's current selection against its freshly-fetched options.
  * Returns the next selection, or null when nothing should change (a valid pick is
  * left untouched — local-first). Behaviour, in order:
  * - materialize ALL to the full option set (query/custom);
+ * - keep a multi-select selection outright when `preserveSelection` is set;
  * - keep a still-valid multi-select subset, dropping only invalid entries;
  * - otherwise auto-pick the default (or first option) so dependent variables and
  *   panels always resolve against a usable value.
@@ -147,6 +157,7 @@ export function reconcileWithOptions(
 	model: VariableFormModel,
 	current: VariableSelection,
 	options: string[],
+	{ preserveSelection = false }: ReconcileOptions = {},
 ): VariableSelection | null {
 	if (options.length === 0) {
 		return null;
@@ -161,6 +172,12 @@ export function reconcileWithOptions(
 		Array.isArray(current.value) &&
 		current.value.length > 0
 	) {
+		// A pick this window has no data for is still the user's filter; re-defaulting it
+		// here is what widened a single pick to ALL on every time-range change.
+		if (preserveSelection) {
+			return null;
+		}
+
 		const valid = current.value.map(String).filter((c) => options.includes(c));
 		if (valid.length === current.value.length) {
 			return null;

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/utils/resolveVariableSelection.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/utils/resolveVariableSelection.ts
@@ -149,7 +149,8 @@ interface ReconcileOptions {
  * left untouched — local-first). Behaviour, in order:
  * - materialize ALL to the full option set (query/custom);
  * - keep a multi-select selection outright when `preserveSelection` is set;
- * - keep a still-valid multi-select subset, dropping only invalid entries;
+ * - keep a still-valid multi-select subset, dropping only entries the list no longer
+ *   offers and the user did not type in (`customValues`);
  * - otherwise auto-pick the default (or first option) so dependent variables and
  *   panels always resolve against a usable value.
  */
@@ -178,13 +179,25 @@ export function reconcileWithOptions(
 			return null;
 		}
 
-		const valid = current.value.map(String).filter((c) => options.includes(c));
+		// A typed value is in no option list, so it is never "no longer offered".
+		const custom = new Set(current.customValues ?? []);
+		const valid = current.value
+			.map(String)
+			.filter((c) => options.includes(c) || custom.has(c));
+
 		if (valid.length === current.value.length) {
 			return null;
 		}
-		return valid.length > 0
-			? { value: valid, allSelected: false }
-			: fillDefault(model, options);
+		if (valid.length === 0) {
+			return fillDefault(model, options);
+		}
+
+		const customValues = valid.filter((v) => custom.has(v));
+		return {
+			value: valid,
+			allSelected: false,
+			...(customValues.length > 0 && { customValues }),
+		};
 	}
 
 	if (!model.multiSelect) {

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/utils/selectionUtils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/VariablesBar/utils/selectionUtils.ts
@@ -47,6 +47,43 @@ export function hasUsableValue(
 	return value !== '' && value !== null && value !== undefined;
 }
 
+interface CommittedValues {
+	values: string[];
+	options: string[];
+	showAllOption: boolean;
+	emptyFallback: VariableSelection;
+}
+
+/**
+ * The selection a multi-select commit resolves to. Options are known only here, so
+ * this is where a value the list never offered is recorded as typed in.
+ */
+export function selectionFromCommittedValues({
+	values,
+	options,
+	showAllOption,
+	emptyFallback,
+}: CommittedValues): VariableSelection {
+	if (values.length === 0) {
+		return emptyFallback;
+	}
+
+	const customValues = values.filter((value) => !options.includes(value));
+	// ALL re-materializes to the option set, so a set carrying a typed value is not ALL
+	// — the next refetch would expand it back and drop what the user typed.
+	const allSelected =
+		showAllOption &&
+		options.length > 0 &&
+		customValues.length === 0 &&
+		options.every((option) => values.includes(option));
+
+	return {
+		value: values,
+		allSelected,
+		...(customValues.length > 0 && { customValues }),
+	};
+}
+
 /** Flatten the selection map into the `{ name: value }` payload a query expects. */
 export function selectionToPayload(
 	selection: VariableSelectionMap,

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/__tests__/variableFetchSlice.test.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/__tests__/variableFetchSlice.test.ts
@@ -34,6 +34,7 @@ function reset(names: string[], context: VariableFetchContext): void {
 		variableFetchStates: {},
 		variableLastUpdated: {},
 		variableCycleIds: {},
+		variableCycleReasons: {},
 		variableFetchContext: null,
 	});
 	store().initVariableFetch(names, context);
@@ -132,6 +133,33 @@ describe('variableFetchSlice', () => {
 		store().onVariableFetchFailure('q1');
 		expect(states().q1).toBe('error');
 		expect(states().q2).toBe('idle');
+	});
+
+	// The reason is what tells the post-fetch reconcile whether it may re-default a
+	// selection: a full cycle must not, a value cascade must.
+	it('tags a full cycle, then re-tags only the cascaded variables', () => {
+		store().enqueueFetchAll();
+		expect(store().variableCycleReasons).toStrictEqual({
+			q1: 'full-cycle',
+			q2: 'full-cycle',
+			d1: 'full-cycle',
+			d2: 'full-cycle',
+		});
+
+		resolve('q1');
+		store().enqueueDescendants('q1');
+		expect(store().variableCycleReasons).toStrictEqual({
+			q1: 'full-cycle',
+			q2: 'value-cascade',
+			d1: 'full-cycle',
+			d2: 'full-cycle',
+		});
+	});
+
+	it('drops the reason for a variable that no longer exists', () => {
+		store().enqueueFetchAll();
+		store().initVariableFetch(['q1'], context);
+		expect(store().variableCycleReasons).toStrictEqual({ q1: 'full-cycle' });
 	});
 });
 

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.ts
@@ -9,6 +9,7 @@ import {
 	type FetchMaps,
 	isVariableInActiveFetchState,
 	resolveFetchState,
+	VariableCycleReason,
 	VariableFetchState,
 } from './variableFetchSlice.utils';
 
@@ -30,7 +31,10 @@ function queryParentsHaveValues(
 	);
 }
 
-export { VariableFetchState } from './variableFetchSlice.utils';
+export {
+	VariableCycleReason,
+	VariableFetchState,
+} from './variableFetchSlice.utils';
 
 /**
  * Runtime fetch orchestration for dashboard variables — native port of V1's
@@ -45,6 +49,8 @@ export interface VariableFetchSlice {
 	variableFetchStates: Record<string, VariableFetchState>;
 	variableLastUpdated: Record<string, number>;
 	variableCycleIds: Record<string, number>;
+	/** Why each variable's current cycle was enqueued, read by the post-fetch reconcile. */
+	variableCycleReasons: Record<string, VariableCycleReason>;
 	/**
 	 * Whether a QUERY/DYNAMIC variable settled its fetch with zero options (so it
 	 * will never get a value). Lets a dependent panel fall through to "no data"
@@ -106,6 +112,7 @@ export const createVariableFetchSlice: StateCreator<
 	variableFetchStates: {},
 	variableLastUpdated: {},
 	variableCycleIds: {},
+	variableCycleReasons: {},
 	variableResolvedEmpty: {},
 	variableFetchContext: null,
 	lastFetchAllKey: null,
@@ -115,6 +122,7 @@ export const createVariableFetchSlice: StateCreator<
 			variableFetchStates: {},
 			variableLastUpdated: {},
 			variableCycleIds: {},
+			variableCycleReasons: {},
 			variableResolvedEmpty: {},
 			variableFetchContext: null,
 			lastFetchAllKey: null,
@@ -132,6 +140,7 @@ export const createVariableFetchSlice: StateCreator<
 	initVariableFetch: (names, context): void => {
 		const maps = cloneMaps(get());
 		const resolvedEmpty = { ...get().variableResolvedEmpty };
+		const reasons = { ...get().variableCycleReasons };
 		names.forEach((name) => {
 			if (!maps.states[name]) {
 				maps.states[name] = VariableFetchState.Idle;
@@ -144,12 +153,14 @@ export const createVariableFetchSlice: StateCreator<
 				delete maps.lastUpdated[name];
 				delete maps.cycleIds[name];
 				delete resolvedEmpty[name];
+				delete reasons[name];
 			}
 		});
 		set({
 			variableFetchStates: maps.states,
 			variableLastUpdated: maps.lastUpdated,
 			variableCycleIds: maps.cycleIds,
+			variableCycleReasons: reasons,
 			variableResolvedEmpty: resolvedEmpty,
 			variableFetchContext: context,
 		});
@@ -171,6 +182,11 @@ export const createVariableFetchSlice: StateCreator<
 			dynamicVariableOrder,
 		} = variableFetchContext;
 		const maps = cloneMaps(get());
+		const reasons = { ...get().variableCycleReasons };
+		const bump = (name: string): void => {
+			maps.cycleIds[name] = (maps.cycleIds[name] || 0) + 1;
+			reasons[name] = VariableCycleReason.FullCycle;
+		};
 
 		// Query variables wait only for their QUERY parents. A DYNAMIC parent does not
 		// gate: its option fetch feeds only its own dropdown, while its selected value
@@ -178,7 +194,7 @@ export const createVariableFetchSlice: StateCreator<
 		// dependent query substitutes it immediately and refetches via the cascade if
 		// it later changes. Text/custom parents resolve synchronously, so nothing waits.
 		queryVariableOrder.forEach((name) => {
-			maps.cycleIds[name] = (maps.cycleIds[name] || 0) + 1;
+			bump(name);
 			const parents = dependencyData.parentGraph[name] || [];
 			const hasQueryParents = parents.some((p) => variableTypes[p] === 'QUERY');
 			maps.states[name] = hasQueryParents
@@ -192,7 +208,7 @@ export const createVariableFetchSlice: StateCreator<
 		const orderedQuery = new Set(queryVariableOrder);
 		Object.keys(variableTypes).forEach((name) => {
 			if (variableTypes[name] === 'QUERY' && !orderedQuery.has(name)) {
-				maps.cycleIds[name] = (maps.cycleIds[name] || 0) + 1;
+				bump(name);
 				maps.states[name] = resolveFetchState(maps, name);
 			}
 		});
@@ -203,7 +219,7 @@ export const createVariableFetchSlice: StateCreator<
 		// populate fast even when query variables are slow; a sibling selection change
 		// later refetches them via `enqueueDescendantsBatch`.
 		dynamicVariableOrder.forEach((name) => {
-			maps.cycleIds[name] = (maps.cycleIds[name] || 0) + 1;
+			bump(name);
 			maps.states[name] = resolveFetchState(maps, name);
 		});
 
@@ -211,6 +227,7 @@ export const createVariableFetchSlice: StateCreator<
 			variableFetchStates: maps.states,
 			variableLastUpdated: maps.lastUpdated,
 			variableCycleIds: maps.cycleIds,
+			variableCycleReasons: reasons,
 			lastFetchAllKey: key ?? get().lastFetchAllKey,
 		});
 	},
@@ -290,6 +307,11 @@ export const createVariableFetchSlice: StateCreator<
 		const { dependencyData, variableTypes, dynamicVariableOrder } =
 			variableFetchContext;
 		const maps = cloneMaps(get());
+		const reasons = { ...get().variableCycleReasons };
+		const bump = (name: string): void => {
+			maps.cycleIds[name] = (maps.cycleIds[name] || 0) + 1;
+			reasons[name] = VariableCycleReason.ValueCascade;
+		};
 		const changed = new Set(names);
 		// Callers commit values before this runs, so the gate sees the new parent values.
 		const selection = selectVariableValues(get().dashboardId)(get());
@@ -305,7 +327,7 @@ export const createVariableFetchSlice: StateCreator<
 			});
 		});
 		queryDescendants.forEach((desc) => {
-			maps.cycleIds[desc] = (maps.cycleIds[desc] || 0) + 1;
+			bump(desc);
 			maps.states[desc] = queryParentsHaveValues(
 				desc,
 				variableFetchContext,
@@ -322,7 +344,7 @@ export const createVariableFetchSlice: StateCreator<
 			dynamicVariableOrder
 				.filter((dynName) => !changed.has(dynName))
 				.forEach((dynName) => {
-					maps.cycleIds[dynName] = (maps.cycleIds[dynName] || 0) + 1;
+					bump(dynName);
 					maps.states[dynName] = resolveFetchState(maps, dynName);
 				});
 		}
@@ -331,6 +353,7 @@ export const createVariableFetchSlice: StateCreator<
 			variableFetchStates: maps.states,
 			variableLastUpdated: maps.lastUpdated,
 			variableCycleIds: maps.cycleIds,
+			variableCycleReasons: reasons,
 		});
 	},
 });
@@ -346,6 +369,12 @@ export const selectVariableCycleId =
 	(name: string) =>
 	(state: DashboardStore): number =>
 		state.variableCycleIds[name] ?? 0;
+
+/** Selector: why a variable's cycle was enqueued. Undefined for types that never fetch. */
+export const selectVariableCycleReason =
+	(name: string) =>
+	(state: DashboardStore): VariableCycleReason | undefined =>
+		state.variableCycleReasons[name];
 
 /** Selector: whether a variable has completed at least one fetch. */
 export const selectVariableFetchedOnce =

--- a/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.utils.ts
+++ b/frontend/src/pages/DashboardPageV2/DashboardContainer/store/slices/variableFetchSlice.utils.ts
@@ -7,6 +7,14 @@ export enum VariableFetchState {
 	Error = 'error',
 }
 
+/** Why a cycle was started — only a cascade may re-default a user's selection. */
+export enum VariableCycleReason {
+	/** `enqueueFetchAll`: load, time-range or variable-order change. */
+	FullCycle = 'full-cycle',
+	/** `enqueueDescendantsBatch`: a parent or sibling variable's value changed. */
+	ValueCascade = 'value-cascade',
+}
+
 /** Mutable clones a fetch action works over before committing back in one `set`. */
 export interface FetchMaps {
 	states: Record<string, VariableFetchState>;


### PR DESCRIPTION
## Summary

On a V2 dashboard, picking values in a multi-select variable and then changing the time range could silently switch the variable to **ALL** — widening every panel to all values without the user touching the variable. A value *typed into* a variable was dropped on any refetch for the same underlying reason.

The post-fetch reconcile compares a selection against freshly-fetched options and could not tell *why* those options changed: "the user has nothing selected yet" and "the user's selection was just invalidated by a refetch" arrived as the same input, and both resolved to the variable's default — ALL for an ALL-enabled multi-select. A time-range change refetches every variable, so any window without data for the selected value hit that path.

Two guarantees now, each with its own mechanism:

| Guarantee | Mechanism |
| --- | --- |
| A refetch nothing else caused (time range, reload) never re-defaults a selection | The fetch engine tags each cycle with why it was enqueued; only a value cascade may re-default |
| A typed-in value survives every refetch, whatever caused it | The selection records which entries were typed, judged at pick time against the options then offered |

A parent variable's value changing still re-scopes its children — that behaviour is unchanged and intended. Single-select variables have preserved a non-empty value since #12178; this brings multi-select in line, which is the half that was left untouched then.

Also fixed, same family: opening and closing the dropdown without touching it promoted an explicit pick into a standing ALL whenever the current window offered only the selected values, and rewrote a dynamic ALL's `__all__` into concrete values.

Closes https://github.com/SigNoz/pulse-pod/issues/207

## Commits

1. `refactor` — record why each variable fetch cycle was enqueued (full cycle vs value cascade)
2. `fix` — keep a variable's selection across a time-range refetch
3. `fix` — keep typed-in variable values through every refetch; ALL now means exactly the option set
4. `fix` — a no-op close of the variable list commits nothing; commit rule extracted out of the component

Each commit typechecks on its own.

## Test plan

- [x] `jest src/pages/DashboardPageV2` — 136 suites / 1073 tests pass, including 20 added: the reconcile split by cycle reason, the cycle tagging in the store, a time-range change tagging every variable as a full cycle, the typed-value rules, and the commit resolver
- [x] `tsgo --noEmit` clean, at every commit
- [x] `oxlint` and `oxfmt --check` clean on the changed files
- [x] Manual: multi-select variable, pick one value, switch to a window with no data for it → selection holds, panels show no data rather than everything
- [x] Manual: type a custom value into a variable, change the time range and switch a sibling variable → the typed value stays selected
- [x] Manual: namespace → pod pair, change namespace → pod values still re-scope

## Notes for reviewers

- `customValues` is new on the runtime selection and is persisted with it. It never reaches the wire or a shared link: `buildVariablesPayload` and the share-URL builder both project `value` / the `__all__` sentinel explicitly.
- A selection seeded from a `?variables=` share link carries no typed-value marker — that URL format stores `name → value` only, so a typed value from a link is indistinguishable from a fetched one and a cascade can still drop it.
- The pill can still *read* ALL when the current option list happens to be a subset of the selection: `CustomMultiSelect` infers that from `options ⊆ value`, and V1 depends on the inference. It is display-only now and self-corrects as the window widens; making it exact needs an explicit prop on the shared control.
