### PR TITLE
fix(querier): enforce read-only ClickHouse SQL

### DIFF
--- a/pkg/querier/clickhouse_query.go
+++ b/pkg/querier/clickhouse_query.go
@@ -20,7 +20,6 @@ import (
 )
 
 type chSQLQuery struct {
-	logger         *slog.Logger
 	telemetryStore telemetrystore.TelemetryStore
 
 	query  qbtypes.ClickHouseQuery
@@ -35,7 +34,7 @@ var _ qbtypes.Query = (*chSQLQuery)(nil)
 var _ qbtypes.StatementProvider = (*chSQLQuery)(nil)
 
 func newchSQLQuery(
-	logger *slog.Logger,
+	_ *slog.Logger,
 	telemetryStore telemetrystore.TelemetryStore,
 	query qbtypes.ClickHouseQuery,
 	args []any,
@@ -44,7 +43,6 @@ func newchSQLQuery(
 	variables map[string]qbtypes.VariableItem,
 ) *chSQLQuery {
 	return &chSQLQuery{
-		logger:         logger,
 		telemetryStore: telemetryStore,
 		query:          query,
 		args:           args,
@@ -100,20 +98,22 @@ func (q *chSQLQuery) renderVars(query string, vars map[string]qbtypes.VariableIt
 	return newQuery.String(), nil
 }
 
-func (q *chSQLQuery) render(ctx context.Context) (string, error) {
+func (q *chSQLQuery) render() (string, error) {
 	rendered, err := q.renderVars(q.query.Query, q.vars, q.fromMS, q.toMS)
 	if err != nil {
 		return "", err
 	}
 
-	querybuilder.LogIfStatementIsNotValid(ctx, q.logger, rendered)
+	if err := querybuilder.ErrIfStatementIsNotValid(rendered); err != nil {
+		return "", err
+	}
 
 	return rendered, nil
 }
 
 // Statement renders the SQL without executing it, for the preview path.
-func (q *chSQLQuery) Statement(ctx context.Context) (*qbtypes.Statement, error) {
-	rendered, err := q.render(ctx)
+func (q *chSQLQuery) Statement(_ context.Context) (*qbtypes.Statement, error) {
+	rendered, err := q.render()
 	if err != nil {
 		return nil, err
 	}
@@ -135,10 +135,11 @@ func (q *chSQLQuery) Execute(ctx context.Context) (*qbtypes.Result, error) {
 		elapsed += p.Elapsed
 	}))
 
-	query, err := q.render(ctx)
+	query, err := q.render()
 	if err != nil {
 		return nil, err
 	}
+	ctx = ctxtypes.SetClickhouseReadOnly(ctx)
 
 	rows, err := q.telemetryStore.ClickhouseDB().Query(ctx, query, q.args...)
 	if err != nil {

--- a/pkg/querier/clickhouse_query_test.go
+++ b/pkg/querier/clickhouse_query_test.go
@@ -1,0 +1,61 @@
+package querier
+
+import (
+	"testing"
+
+	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClickHouseSQLRenderValidatesRenderedQuery(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		vars    map[string]qbtypes.VariableItem
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "valid select",
+			query: "SELECT count() FROM signoz_logs.distributed_logs_v2",
+			want:  "SELECT count() FROM signoz_logs.distributed_logs_v2",
+		},
+		{
+			name:  "variable control characters remain quoted",
+			query: "SELECT $value",
+			vars: map[string]qbtypes.VariableItem{
+				"value": {Value: "1; DROP TABLE events"},
+			},
+			want: "SELECT '1; DROP TABLE events'",
+		},
+		{
+			name:    "multiple statements",
+			query:   "SELECT 1; DROP TABLE events",
+			wantErr: true,
+		},
+		{
+			name:    "internal database",
+			query:   "SELECT * FROM system.users",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := &chSQLQuery{
+				query: qbtypes.ClickHouseQuery{Query: tt.query},
+				vars:  tt.vars,
+			}
+
+			rendered, err := query.render()
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, rendered)
+		})
+	}
+}

--- a/pkg/query-service/app/http_handler.go
+++ b/pkg/query-service/app/http_handler.go
@@ -1093,9 +1093,13 @@ func (aH *APIHandler) queryDashboardVarsV2(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	querybuilder.LogIfStatementIsNotValid(r.Context(), aH.logger, query)
+	if err := querybuilder.ErrIfStatementIsNotValid(query); err != nil {
+		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)
+		return
+	}
 
-	dashboardVars, err := aH.reader.QueryDashboardVars(r.Context(), query)
+	ctx := ctxtypes.SetClickhouseReadOnly(r.Context())
+	dashboardVars, err := aH.reader.QueryDashboardVars(ctx, query)
 	if err != nil {
 		RespondError(w, &model.ApiError{Typ: model.ErrorBadData, Err: err}, nil)
 		return

--- a/pkg/query-service/app/querier/querier.go
+++ b/pkg/query-service/app/querier/querier.go
@@ -16,6 +16,8 @@ import (
 	chErrors "github.com/SigNoz/signoz/pkg/query-service/errors"
 	"github.com/SigNoz/signoz/pkg/query-service/querycache"
 	"github.com/SigNoz/signoz/pkg/query-service/utils"
+	qbvalidation "github.com/SigNoz/signoz/pkg/querybuilder"
+	"github.com/SigNoz/signoz/pkg/types/ctxtypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 
 	"log/slog"
@@ -121,6 +123,14 @@ func (q *querier) execClickHouseQuery(ctx context.Context, query string) ([]*v3.
 		q.logger.ErrorContext(ctx, "found points with negative timestamps for query", "query", query)
 	}
 	return result, err
+}
+
+func (q *querier) execUserClickHouseQuery(ctx context.Context, query string) ([]*v3.Series, error) {
+	if err := qbvalidation.ErrIfStatementIsNotValid(query); err != nil {
+		return nil, err
+	}
+
+	return q.execClickHouseQuery(ctxtypes.SetClickhouseReadOnly(ctx), query)
 }
 
 func (q *querier) execPromQuery(ctx context.Context, params *model.QueryRangeParams) ([]*v3.Series, error) {
@@ -276,7 +286,7 @@ func (q *querier) runClickHouseQueries(ctx context.Context, params *v3.QueryRang
 		wg.Add(1)
 		go func(queryName string, clickHouseQuery *v3.ClickHouseQuery) {
 			defer wg.Done()
-			series, err := q.execClickHouseQuery(ctx, clickHouseQuery.Query)
+			series, err := q.execUserClickHouseQuery(ctx, clickHouseQuery.Query)
 			channelResults <- channelResult{Err: err, Name: queryName, Query: clickHouseQuery.Query, Series: series}
 		}(queryName, clickHouseQuery)
 	}

--- a/pkg/query-service/app/querier/querier_test.go
+++ b/pkg/query-service/app/querier/querier_test.go
@@ -56,6 +56,16 @@ func maxTimestamp(series []*v3.Series) int64 {
 	return max
 }
 
+func TestExecUserClickHouseQueryValidatesUserSQL(t *testing.T) {
+	querier := &querier{testingMode: true}
+
+	_, err := querier.execUserClickHouseQuery(context.Background(), "SELECT 1")
+	assert.NoError(t, err)
+
+	_, err = querier.execUserClickHouseQuery(context.Background(), "DROP TABLE signoz_logs.logs_v2")
+	assert.Error(t, err)
+}
+
 func TestFindMissingTimeRangesZeroFreshNess(t *testing.T) {
 	// There are five scenarios:
 	// 1. Cached time range is a subset of the requested time range

--- a/pkg/query-service/app/querier/v2/querier.go
+++ b/pkg/query-service/app/querier/v2/querier.go
@@ -18,6 +18,8 @@ import (
 	chErrors "github.com/SigNoz/signoz/pkg/query-service/errors"
 	"github.com/SigNoz/signoz/pkg/query-service/querycache"
 	"github.com/SigNoz/signoz/pkg/query-service/utils"
+	qbvalidation "github.com/SigNoz/signoz/pkg/querybuilder"
+	"github.com/SigNoz/signoz/pkg/types/ctxtypes"
 	"github.com/SigNoz/signoz/pkg/valuer"
 
 	"log/slog"
@@ -127,6 +129,14 @@ func (q *querier) execClickHouseQuery(ctx context.Context, query string) ([]*v3.
 		q.logger.ErrorContext(ctx, "found points with negative timestamps for query", "query", query)
 	}
 	return result, err
+}
+
+func (q *querier) execUserClickHouseQuery(ctx context.Context, query string) ([]*v3.Series, error) {
+	if err := qbvalidation.ErrIfStatementIsNotValid(query); err != nil {
+		return nil, err
+	}
+
+	return q.execClickHouseQuery(ctxtypes.SetClickhouseReadOnly(ctx), query)
 }
 
 // execPromQuery executes the prom query and returns the series list
@@ -281,7 +291,7 @@ func (q *querier) runClickHouseQueries(ctx context.Context, params *v3.QueryRang
 		wg.Add(1)
 		go func(queryName string, clickHouseQuery *v3.ClickHouseQuery) {
 			defer wg.Done()
-			series, err := q.execClickHouseQuery(ctx, clickHouseQuery.Query)
+			series, err := q.execUserClickHouseQuery(ctx, clickHouseQuery.Query)
 			channelResults <- channelResult{Err: err, Name: queryName, Query: clickHouseQuery.Query, Series: series}
 		}(queryName, clickHouseQuery)
 	}

--- a/pkg/query-service/app/querier/v2/querier_test.go
+++ b/pkg/query-service/app/querier/v2/querier_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/SigNoz/signoz/pkg/cache"
 	"github.com/SigNoz/signoz/pkg/cache/cachetest"
 	"github.com/SigNoz/signoz/pkg/flagger/flaggertest"
@@ -27,7 +28,6 @@ import (
 	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	"github.com/SigNoz/signoz/pkg/telemetrystore/telemetrystoretest"
 	"github.com/SigNoz/signoz/pkg/valuer"
-	cmock "github.com/SigNoz/clickhouse-go-mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,6 +54,16 @@ func maxTimestamp(series []*v3.Series) int64 {
 		}
 	}
 	return max
+}
+
+func TestExecUserClickHouseQueryValidatesUserSQL(t *testing.T) {
+	querier := &querier{testingMode: true}
+
+	_, err := querier.execUserClickHouseQuery(context.Background(), "SELECT 1")
+	assert.NoError(t, err)
+
+	_, err = querier.execUserClickHouseQuery(context.Background(), "DROP TABLE signoz_logs.logs_v2")
+	assert.Error(t, err)
 }
 
 func TestV2FindMissingTimeRangesZeroFreshNess(t *testing.T) {

--- a/pkg/querybuilder/clickhouse_sql.go
+++ b/pkg/querybuilder/clickhouse_sql.go
@@ -1,8 +1,6 @@
 package querybuilder
 
 import (
-	"context"
-	"log/slog"
 	"maps"
 	"slices"
 	"strings"
@@ -103,11 +101,4 @@ func ErrIfStatementIsNotValid(query string) (err error) {
 	}}
 
 	return selectQuery.Accept(visitor)
-}
-
-// TODO(@therealpandey): remove this and move to ErrIfStatementIsNotValid.
-func LogIfStatementIsNotValid(ctx context.Context, logger *slog.Logger, query string) {
-	if err := ErrIfStatementIsNotValid(query); err != nil {
-		logger.WarnContext(ctx, "clickhouse sql is not valid", errors.Attr(err), slog.String("query", query))
-	}
 }

--- a/pkg/telemetrystore/telemetrystorehook/settings.go
+++ b/pkg/telemetrystore/telemetrystorehook/settings.go
@@ -26,6 +26,11 @@ func NewSettings(ctx context.Context, providerSettings factory.ProviderSettings,
 }
 
 func (h *provider) BeforeQuery(ctx context.Context, _ *telemetrystore.QueryEvent) context.Context {
+	settings := h.settingsForContext(ctx)
+	return clickhouse.Context(ctx, clickhouse.WithSettings(settings))
+}
+
+func (h *provider) settingsForContext(ctx context.Context) clickhouse.Settings {
 	settings := clickhouse.Settings{}
 
 	settings["log_comment"] = ctxtypes.CommentFromContext(ctx).String()
@@ -72,12 +77,16 @@ func (h *provider) BeforeQuery(ctx context.Context, _ *telemetrystore.QueryEvent
 		settings["result_overflow_mode"] = ctx.Value("result_overflow_mode")
 	}
 
+	if ctxtypes.IsClickhouseReadOnly(ctx) {
+		// Mode 2 blocks writes while still allowing SELECT-level settings.
+		settings["readonly"] = 2
+	}
+
 	// TODO(srikanthccv): enable it when the "Cannot read all data" issue is fixed
 	// https://github.com/ClickHouse/ClickHouse/issues/82283
 	settings["secondary_indices_enable_bulk_filtering"] = false
 
-	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(settings))
-	return ctx
+	return settings
 }
 
 func (h *provider) AfterQuery(ctx context.Context, event *telemetrystore.QueryEvent) {}

--- a/pkg/telemetrystore/telemetrystorehook/settings_test.go
+++ b/pkg/telemetrystore/telemetrystorehook/settings_test.go
@@ -1,0 +1,21 @@
+package telemetrystorehook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SigNoz/signoz/pkg/telemetrystore"
+	"github.com/SigNoz/signoz/pkg/types/ctxtypes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSettingsForContextReadOnly(t *testing.T) {
+	hook := &provider{settings: telemetrystore.QuerySettings{}}
+
+	normalSettings := hook.settingsForContext(context.Background())
+	_, ok := normalSettings["readonly"]
+	assert.False(t, ok)
+
+	readOnlySettings := hook.settingsForContext(ctxtypes.SetClickhouseReadOnly(context.Background()))
+	assert.Equal(t, 2, readOnlySettings["readonly"])
+}

--- a/pkg/types/ctxtypes/clickhouse.go
+++ b/pkg/types/ctxtypes/clickhouse.go
@@ -6,9 +6,21 @@ type ctxKey string
 
 const (
 	ClickhouseContextMaxThreadsKey ctxKey = "clickhouse_max_threads"
+	clickhouseContextReadOnlyKey   ctxKey = "clickhouse_read_only"
 )
 
 // SetClickhouseMaxThreads stores the max threads value in context.
 func SetClickhouseMaxThreads(ctx context.Context, maxThreads int) context.Context {
 	return context.WithValue(ctx, ClickhouseContextMaxThreadsKey, maxThreads)
+}
+
+// SetClickhouseReadOnly marks queries that must be executed in ClickHouse read-only mode.
+func SetClickhouseReadOnly(ctx context.Context) context.Context {
+	return context.WithValue(ctx, clickhouseContextReadOnlyKey, true)
+}
+
+// IsClickhouseReadOnly reports whether the query must be executed in ClickHouse read-only mode.
+func IsClickhouseReadOnly(ctx context.Context) bool {
+	readOnly, ok := ctx.Value(clickhouseContextReadOnlyKey).(bool)
+	return ok && readOnly
 }

--- a/pkg/types/ctxtypes/clickhouse_test.go
+++ b/pkg/types/ctxtypes/clickhouse_test.go
@@ -1,0 +1,16 @@
+package ctxtypes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClickhouseReadOnlyContext(t *testing.T) {
+	ctx := context.Background()
+	assert.False(t, IsClickhouseReadOnly(ctx))
+
+	ctx = SetClickhouseReadOnly(ctx)
+	assert.True(t, IsClickhouseReadOnly(ctx))
+}


### PR DESCRIPTION
## Summary

- reject user-authored ClickHouse SQL that fails the existing rendered-query validator
- enforce the same policy for v5 `clickhouse_sql`, dashboard variables, and legacy v3/v4 `chQueries`
- mark accepted user SQL contexts and apply ClickHouse `readonly=2` as a database-level backstop
- remove the transitional log-only helper, which logged failures but continued execution

## Context

#12301 added the parser and initially kept it in observation-only mode because valid production queries exposed parser grammar gaps. Those gaps have since been covered by parser updates and regression tests, while #12376 added an allowlist for safe row-generator table functions. The current validator test corpus now accepts those known query shapes, so callers can enforce it without applying validation to internally generated builder SQL.

The ClickHouse setting is applied only to user-authored SQL. Mode 2 blocks writes while preserving normal SELECT-level settings. Query-level `readonly` overrides remain rejected by the AST validator because ClickHouse otherwise lets that clause take precedence.

## Verification

- `GOTOOLCHAIN=go1.25.7 go test ./pkg/querybuilder ./pkg/querier ./pkg/telemetrystore/... ./pkg/types/ctxtypes ./pkg/query-service/app/querier ./pkg/query-service/app/querier/v2 ./pkg/query-service/app`
- `GOTOOLCHAIN=go1.25.7 go test -race ./pkg/querybuilder ./pkg/querier ./pkg/telemetrystore/telemetrystorehook ./pkg/types/ctxtypes ./pkg/query-service/app/querier ./pkg/query-service/app/querier/v2`
- `GOTOOLCHAIN=go1.25.7 go vet ./pkg/querybuilder ./pkg/querier ./pkg/telemetrystore/telemetrystorehook ./pkg/types/ctxtypes ./pkg/query-service/app/querier ./pkg/query-service/app/querier/v2 ./pkg/query-service/app`
- ClickHouse `24.1.2-alpine`: SELECT and normal SELECT settings succeeded with `readonly=2`; INSERT, CREATE, ALTER, DROP, and SYSTEM returned `Code 164 READONLY`; post-check confirmed no attempted mutation took effect

Closes #12417.