### PR TITLE
fix(services): check rows.Err() after iterating top level operations

### DIFF
--- a/pkg/modules/services/implservices/module.go
+++ b/pkg/modules/services/implservices/module.go
@@ -54,9 +54,6 @@ func (m *module) FetchTopLevelOperations(ctx context.Context, start time.Time, s
 	defer rows.Close()
 
 	ops := make(map[string][]string)
-	if err := rows.Err(); err != nil {
-		return nil, errors.WrapInternalf(err, errors.CodeInternal, "failed to fetch top level operations")
-	}
 	for rows.Next() {
 		var name, serviceName string
 		var ts time.Time
@@ -67,6 +64,9 @@ func (m *module) FetchTopLevelOperations(ctx context.Context, start time.Time, s
 			ops[serviceName] = []string{"overflow_operation"}
 		}
 		ops[serviceName] = append(ops[serviceName], name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.WrapInternalf(err, errors.CodeInternal, "error iterating top level operations")
 	}
 	return ops, nil
 }

--- a/pkg/modules/services/implservices/module_test.go
+++ b/pkg/modules/services/implservices/module_test.go
@@ -1,8 +1,15 @@
 package implservices
 
 import (
+	"context"
+	stderrors "errors"
 	"testing"
+	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
+	chdriver "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/SigNoz/signoz/pkg/errors"
+	"github.com/SigNoz/signoz/pkg/telemetrystore"
 	qbtypes "github.com/SigNoz/signoz/pkg/types/querybuildertypes/querybuildertypesv5"
 	"github.com/SigNoz/signoz/pkg/types/servicetypes/servicetypesv1"
 	"github.com/SigNoz/signoz/pkg/types/telemetrytypes"
@@ -767,6 +774,105 @@ func TestMapEntryPointOpsQueryRangeResp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := m.mapEntryPointOpsQueryRangeResp(tt.resp)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+type fakeTelemetryStore struct {
+	telemetrystore.TelemetryStore
+	conn clickhouse.Conn
+}
+
+func (f *fakeTelemetryStore) ClickhouseDB() clickhouse.Conn { return f.conn }
+
+type fakeConn struct {
+	clickhouse.Conn
+	rows chdriver.Rows
+}
+
+func (f *fakeConn) Query(context.Context, string, ...any) (chdriver.Rows, error) {
+	return f.rows, nil
+}
+
+type topLevelOpRow struct {
+	name        string
+	serviceName string
+}
+
+// fakeTopLevelOpsRows mimics the driver's behaviour when a stream is cut off
+// mid-iteration: Next returns false once the delivered rows are exhausted, and
+// only then does Err report the stream error.
+type fakeTopLevelOpsRows struct {
+	chdriver.Rows
+	rows    []topLevelOpRow
+	pos     int
+	iterErr error
+}
+
+func (r *fakeTopLevelOpsRows) Next() bool { return r.pos < len(r.rows) }
+
+func (r *fakeTopLevelOpsRows) Scan(dest ...any) error {
+	*(dest[0].(*string)) = r.rows[r.pos].name
+	*(dest[1].(*string)) = r.rows[r.pos].serviceName
+	*(dest[2].(*time.Time)) = time.Time{}
+	r.pos++
+	return nil
+}
+
+func (r *fakeTopLevelOpsRows) Err() error {
+	if r.pos >= len(r.rows) {
+		return r.iterErr
+	}
+	return nil
+}
+
+func (r *fakeTopLevelOpsRows) Close() error { return nil }
+
+func TestFetchTopLevelOperations(t *testing.T) {
+	tests := []struct {
+		name    string
+		rows    []topLevelOpRow
+		iterErr error
+		want    map[string][]string
+		wantErr string
+	}{
+		{
+			name: "groups operations by service",
+			rows: []topLevelOpRow{
+				{name: "GET /orders", serviceName: "frontend"},
+				{name: "POST /orders", serviceName: "frontend"},
+				{name: "GET /health", serviceName: "backend"},
+			},
+			want: map[string][]string{
+				"frontend": {"overflow_operation", "GET /orders", "POST /orders"},
+				"backend":  {"overflow_operation", "GET /health"},
+			},
+		},
+		{
+			name: "surfaces error when stream is cut off mid-iteration",
+			rows: []topLevelOpRow{
+				{name: "GET /orders", serviceName: "frontend"},
+			},
+			iterErr: stderrors.New("code: 159, message: Cannot read all data"),
+			wantErr: "Cannot read all data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &module{TelemetryStore: &fakeTelemetryStore{conn: &fakeConn{
+				rows: &fakeTopLevelOpsRows{rows: tt.rows, iterErr: tt.iterErr},
+			}}}
+
+			got, err := m.FetchTopLevelOperations(context.Background(), time.Unix(0, 0), nil)
+			if tt.wantErr != "" {
+				assert.Nil(t, got)
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.True(t, errors.Ast(err, errors.TypeInternal))
+				return
+			}
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary

`FetchTopLevelOperations` in `pkg/modules/services/implservices/module.go` checked `rows.Err()` **before** the `rows.Next()` loop — at that point no rows have been consumed, so the check is always nil and effectively dead code. There was no check after the loop.

Consequence: if the ClickHouse stream fails mid-iteration (e.g. network interruption, `code: 159 Cannot read all data`), `rows.Next()` returns false, the loop exits cleanly, and a **silently truncated** top-level-operations map is returned as success. The APM services list (`POST /api/v2/services`) then renders with missing operations and no error surfaced to the user — missing data presented as healthy data.

This PR moves the `rows.Err()` check to after the loop, matching the convention already used across the codebase (e.g. `implmetricsexplorer/module.go`, `implinframonitoring`).

#### Screenshots / Screen Recordings (if applicable)

N/A — backend-only error-handling fix. Manual verification output included below.

#### Issues closed by this PR

None filed — small self-contained bug fix.

---

### ✅ Change Type

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause

Misplaced error check. Per the ClickHouse driver contract (same as `database/sql`), `rows.Err()` only reports an error encountered **during** iteration, after `rows.Next()` has returned false. Checking it immediately after `Query()` succeeds — before any `rows.Next()` call — always yields nil, and the absence of a post-loop check means mid-stream errors are swallowed.

#### Fix Strategy

Move the `rows.Err()` check from before the iteration loop to after it, so a stream cut off mid-iteration returns an internal error instead of partial data. Happy-path behavior is unchanged.

---

### 🧪 Testing Strategy

- **Tests added/updated:** `TestFetchTopLevelOperations` in `module_test.go` with two cases: (1) happy path grouping operations per service, (2) a fake `driver.Rows` that mimics a stream cut off mid-iteration (`Next()` returns false after N rows, then `Err()` reports the stream error). Case (2) fails on the previous code (returned partial data + nil error) and passes with this fix. A hand-rolled fake is used because the shared `clickhouse-go-mock` hardcodes `Rows.Err()` to nil and cannot simulate this failure mode.
- **Manual verification:** ran the full local stack (devenv ClickHouse + signoz-otel-collector + community backend from this branch), ingested OTLP spans for two test services, and confirmed `POST /api/v2/services` returns both services with correct `topLevelOps` — no happy-path regression.
- **Edge cases covered:** empty result set (loop body never runs, `rows.Err()` nil → empty map), scan errors (pre-existing handling unchanged).

---

### ⚠️ Risk & Impact Assessment

- **Blast radius:** one function, called only by `attachTopLevelOps` for the APM services list.
- **Potential regressions:** requests that previously returned partial data on a mid-stream failure will now return an error — this is the intended behavior change and is strictly in the direction of correctness.
- **Rollback plan:** revert the commit; no schema, config, or API contract changes.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | N/A |
| Change Type | N/A |
| Description | N/A (internal error-handling correctness; no user-facing behavior change on healthy systems) |

---

### 📋 Checklist

- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented (none)
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

The error message on the post-loop check was changed to `"error iterating top level operations"` to distinguish it from the query-execution failure message above it, following the wording used in `implmetricsexplorer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
