### PR TITLE
refactor(infrastructure-monitoring): always represent IO as binBps instead of bytes for hosts

### DIFF
--- a/frontend/src/container/LogDetailedView/InfraMetrics/constants.ts
+++ b/frontend/src/container/LogDetailedView/InfraMetrics/constants.ts
@@ -2894,8 +2894,8 @@ export const hostWidgetInfo = [
 		docPath: '/infrastructure-monitoring/host-monitoring/#system-load-average',
 	},
 	{
-		title: 'Network usage (bytes)',
-		yAxisUnit: 'bytes',
+		title: 'Network usage',
+		yAxisUnit: 'binBps',
 		docPath: '/infrastructure-monitoring/host-monitoring/#network-usage-bytes',
 	},
 	{
@@ -2919,8 +2919,8 @@ export const hostWidgetInfo = [
 		docPath: '/infrastructure-monitoring/host-monitoring/#network-connections',
 	},
 	{
-		title: 'System disk io (bytes transferred)',
-		yAxisUnit: 'bytes',
+		title: 'System disk IO',
+		yAxisUnit: 'binBps',
 		docPath: '/infrastructure-monitoring/host-monitoring/#system-disk-io-bytes',
 	},
 	{


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

The other charts related to network uses binBps instead of `bytes`, and similar to System Disk IO, we can use binBps since we are representing throghutput 

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

> The changes are on `Network Usage` and `System Disk Chart`, pay attention to the Y unit.

Before:

<img width="1726" height="1090" alt="image" src="https://github.com/user-attachments/assets/6a71f9fd-ae19-4ed8-bba1-3851ecf815f4" />

After:

<img width="1726" height="1091" alt="image" src="https://github.com/user-attachments/assets/b3fc41dc-af20-4784-afe2-c3c1936ceba8" />

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/pulse-pod/issues/211

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Infrastructure Monitoring - Hosts
- Potential regressions: None
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Feature |
| Description | We updated the charts of Network IO and System disk IO to use unit of bytes per second instead of bytes. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
