### PR TITLE
fix(infrastructure-monitoring-namespaces): wrong division for available/desired and use lastest instead of avg

### DIFF
--- a/frontend/src/container/InfraMonitoringK8sV2/Namespaces/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Namespaces/constants.ts
@@ -1625,13 +1625,13 @@ export const getNamespaceMetricsQueryPayload = (
 							reduceTo: ReduceOperators.LAST,
 							spaceAggregation: 'max',
 							stepInterval: 60,
-							timeAggregation: 'avg',
+							timeAggregation: 'latest',
 						},
 					],
 					queryFormulas: [
 						{
 							disabled: false,
-							expression: 'A/B',
+							expression: '(B/A) * 100',
 							legend: 'util %',
 							queryName: 'F1',
 						},


### PR DESCRIPTION
## Pull Request

---

### 📄 Summary
> Why does this change exist?  
> What problem does it solve, and why is this the right approach?

This follows the same pattern as https://github.com/SigNoz/signoz/pull/11681 to use `latest` instead of `avg`, and also fixes the calculation of `util %` that was suppose to be `desired/available * 100` instead of current value `available/desired`.

#### Screenshots / Screen Recordings (if applicable)
> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.

Before:

<img width="857" height="364" alt="image" src="https://github.com/user-attachments/assets/949db1a8-c27d-41da-8573-398a4d53af24" />

After:

<img width="851" height="336" alt="image" src="https://github.com/user-attachments/assets/5181849a-28e4-45f8-b7a5-0d611b5ae02e" />

#### Issues closed by this PR
> Reference issues using `Closes #issue-number` to enable automatic closure on merge.

Closes https://github.com/SigNoz/pulse-pod/issues/210

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🧪 Testing Strategy
> How was this change validated?

- Tests added/updated: No
- Manual verification: Yes
- Edge cases covered: -

---

### ⚠️ Risk & Impact Assessment
> What could break? How do we recover?

- Blast radius: Infrastructure Monitoring - Namespaces
- Potential regressions: None
- Rollback plan: Revert this commit

---

### 📝 Changelog
> Fill only if this affects users, APIs, UI, or documented behavior  
> Use **N/A** for internal or non-user-facing changes

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | We updated the table for Desired (pods) inside the Namespace Details on Infrastructure Monitoring to correctly show the `util %`. |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [ ] Breaking changes documented
- [ ] Backward compatibility considered
