### PR TITLE
fix(alertmanager): point notification title links to /alerts/overview

### DIFF
--- a/pkg/types/alertmanagertypes/template.go
+++ b/pkg/types/alertmanagertypes/template.go
@@ -42,7 +42,7 @@ func FromGlobs(paths []string) (*alertmanagertemplate.Template, error) {
 	}
 
 	if err := t.Parse(bytes.NewReader([]byte(`
-	{{ define "__ruleIdPath" }}{{- $isTestAlert := "" -}}{{- range .CommonLabels.SortedPairs -}}{{- if eq .Name "testalert" -}}{{- if eq .Value "true" -}}{{- $isTestAlert = "true" -}}{{- end -}}{{- end -}}{{- end -}}{{- range .CommonLabels.SortedPairs -}}{{- if eq .Name "ruleId" -}}{{- if ne .Value "" -}}/edit?ruleId={{ .Value | urlescape }}{{- if $isTestAlert -}}&isTestAlert=true{{- end -}}{{- end -}}{{- end -}}{{- end -}}{{- end }}
+	{{ define "__ruleIdPath" }}{{- $isTestAlert := "" -}}{{- range .CommonLabels.SortedPairs -}}{{- if eq .Name "testalert" -}}{{- if eq .Value "true" -}}{{- $isTestAlert = "true" -}}{{- end -}}{{- end -}}{{- end -}}{{- range .CommonLabels.SortedPairs -}}{{- if eq .Name "ruleId" -}}{{- if ne .Value "" -}}/overview?ruleId={{ .Value | urlescape }}{{- if $isTestAlert -}}&isTestAlert=true{{- end -}}{{- end -}}{{- end -}}{{- end -}}{{- end }}
 	{{ define "__alertmanagerURL" }}{{ .ExternalURL }}/alerts{{ template "__ruleIdPath" . }}{{ end }}
 	{{ define "msteamsv2.default.titleLink" }}{{ template "__alertmanagerURL" . }}{{ end }}
 	`))); err != nil {

--- a/pkg/types/alertmanagertypes/template_test.go
+++ b/pkg/types/alertmanagertypes/template_test.go
@@ -34,7 +34,7 @@ func TestFromGlobs(t *testing.T) {
 					Timeout:   false,
 				},
 			},
-			expected: "http://localhost:8080/alerts/edit?ruleId=01961575-461c-7668-875f-05d374062bfc",
+			expected: "http://localhost:8080/alerts/overview?ruleId=01961575-461c-7668-875f-05d374062bfc",
 		},
 		{
 			name: "SingleAlertWithValidRuleUUIDv4",
@@ -49,7 +49,7 @@ func TestFromGlobs(t *testing.T) {
 					Timeout:   false,
 				},
 			},
-			expected: "http://localhost:8080/alerts/edit?ruleId=2d8edca5-4f24-4266-afd1-28cefadcfa88",
+			expected: "http://localhost:8080/alerts/overview?ruleId=2d8edca5-4f24-4266-afd1-28cefadcfa88",
 		},
 		{
 			name: "MultipleAlertsWithMismatchingRuleId",
@@ -97,7 +97,7 @@ func TestFromGlobs(t *testing.T) {
 					Timeout:   false,
 				},
 			},
-			expected: "http://localhost:8080/alerts/edit?ruleId=01961575-461c-7668-875f-05d374062bfc",
+			expected: "http://localhost:8080/alerts/overview?ruleId=01961575-461c-7668-875f-05d374062bfc",
 		},
 		{
 			name: "MultipleAlertsWithNoRuleId",
@@ -152,7 +152,7 @@ func TestFromGlobs(t *testing.T) {
 					Timeout:   false,
 				},
 			},
-			expected: "http://localhost:8080/alerts/edit?ruleId=01961575-461c-7668-875f-05d374062bfc&isTestAlert=true",
+			expected: "http://localhost:8080/alerts/overview?ruleId=01961575-461c-7668-875f-05d374062bfc&isTestAlert=true",
 		},
 		{
 			name: "TestAlertWithRuleIdWithSpacesAndSymbol",
@@ -168,7 +168,7 @@ func TestFromGlobs(t *testing.T) {
 					Timeout:   false,
 				},
 			},
-			expected: "http://localhost:8080/alerts/edit?ruleId=Prom+%2B+Alert+%26+Rule&isTestAlert=true",
+			expected: "http://localhost:8080/alerts/overview?ruleId=Prom+%2B+Alert+%26+Rule&isTestAlert=true",
 		},
 		{
 			name: "AlertWithBlankRuleId",


### PR DESCRIPTION
## Summary
> Notification title links (Slack, MS Teams, and other receivers using the default title-link template) still pointed at `/alerts/edit?ruleId=…` after the rule-detail page moved to `/alerts/overview`. That path 404s in deployments without a reliable SPA fallback. This updates `__ruleIdPath` so title links match the live route and the generator URL already emitted by `BaseRule.GeneratorURL()`.

#### Issues closed by this PR
> Closes #12247

---

### ✅ Change Type
_Select all that apply_

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🛠️ Infra / Tooling
- [ ] 🧪 Test-only

---

### 🐛 Bug Context

#### Root Cause
> Regression after the in-tree alertmanager / rule-detail route move: `pkg/query-service/rules/base_rule.go` was updated to emit `/alerts/overview` (#11413), but `FromGlobs` in `pkg/types/alertmanagertypes/template.go` kept hardcoding `/edit` in `__ruleIdPath`. Slack/MS Teams title links resolve through `__alertmanagerURL`, so every default notification inherited the stale path.

#### Fix Strategy
> Change `__ruleIdPath` to emit `/overview?ruleId=…` and update the existing `TestFromGlobs` expectations so the suite guards against re-drift. No new abstraction; one-word path change plus test expectation updates.

---

### 🧪 Testing Strategy

- Tests added/updated: Updated `TestFromGlobs` cases that assert title-link URLs (`/alerts/edit` → `/alerts/overview`), including `isTestAlert=true` and URL-escaped rule IDs. Cases without a `ruleId` remain `/alerts`.
- Manual verification: `go test -race -count=1 ./pkg/types/alertmanagertypes/`
- Edge cases covered: matching/mismatching multi-alert rule IDs, blank rule ID, test-alert query param, rule IDs with spaces/symbols.

---

### ⚠️ Risk & Impact Assessment

- Blast radius: Notification title links only (Slack / MS Teams default templates via `__alertmanagerURL`). Generator/source URLs were already correct.
- Potential regressions: Custom receivers that override `title_link` are unaffected. Legacy `/alerts/edit` SPA redirect remains for old bookmarks/links.
- Rollback plan: Revert this commit; title links return to `/alerts/edit`.

---

### 📝 Changelog

| Field | Value |
|------|-------|
| Deployment Type | Cloud / OSS / Enterprise |
| Change Type | Bug Fix |
| Description | Alert notification title links now open `/alerts/overview` instead of the retired `/alerts/edit` path |

---

### 📋 Checklist
- [x] Tests added or explicitly not required
- [x] Manually tested
- [x] Breaking changes documented
- [x] Backward compatibility considered

---

## 👀 Notes for Reviewers

Legacy `/alerts/edit` → `/alerts/overview` SPA redirect is intentionally left in place for older links. This PR only updates the server-side notification template so new notifications point at the canonical route.