### PR TITLE
chore(sentry): drop the posthog session replay link from error events

### DIFF
--- a/frontend/src/AppRoutes/index.tsx
+++ b/frontend/src/AppRoutes/index.tsx
@@ -372,16 +372,6 @@ function App(): JSX.Element {
 							return null;
 						}
 
-						const sessionReplayUrl = posthog.get_session_replay_url?.({
-							withTimestamp: true,
-						});
-						if (sessionReplayUrl) {
-							// eslint-disable-next-line no-param-reassign
-							event.contexts = {
-								...event.contexts,
-								posthog: { session_replay_url: sessionReplayUrl },
-							};
-						}
 						return event;
 					},
 				});


### PR DESCRIPTION
`beforeSend` attached a PostHog session-replay URL to every Sentry error as an `event.contexts.posthog` block. We're using Sentry's own Replay (`replayIntegration`, `replaysOnErrorSampleRate: 1.0`), so the cross-link is redundant.

### What changed

- Removed the `posthog.get_session_replay_url()` call and the `event.contexts` mutation from `Sentry.init`'s `beforeSend`.
- The `warning` / `info` level drop is unrelated and stays, so `beforeSend` is kept.

### What did not change

- PostHog itself. `posthog.init`, `identify`, `group` and `reset` are product analytics, untouched — `posthog-js` is still a dependency.
- Sentry Replay config.

`get_session_replay_url` was the only session-replay reference in the frontend, so there is nothing else to unwind.
