### PR TITLE
chore: simplify PR template and add agent rules

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,0 +1,11 @@
+# Comments
+
+Applies to everything in the repo — code, config, workflows.
+
+- **No unnecessary comments.** Do not comment where the code is self-explanatory; never restate what the code already says.
+- **Document only** non-obvious behavior, constraints, formats, and edge cases.
+- **Rationale goes in prose, not source.** Why a version is pinned, why a job exists, how a subsystem fits together — that belongs in the README or the PR.
+- **Never remove pre-existing comments** when editing code. The bar above applies to comments you write, not comments already there.
+- **Never talk to the reviewer.** No comments about where a change came from, what was changed, or why the change is correct — that belongs in the PR description and is noise the moment it merges.
+
+Language rules build on this one: [`go-comments`](go-comments.md), [`py-comments`](py-comments.md).

--- a/.claude/rules/go-comments.md
+++ b/.claude/rules/go-comments.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "**/*.go"
+---
+
+# Go comments
+
+The bar is the [`comments`](comments.md) rule: nothing where the code is self-explanatory.
+
+- **Names carry the meaning.** Make function, type, and variable names self-explanatory so the comment is unnecessary in the first place. If a comment is needed to explain what a function does, fix the name, not the comment.
+- **Godoc**: Skip comments that merely restate the identifier. Document only non-obvious behavior, constraints, formats, and edge cases.
+- **Generated code**: If the comment is emitted by an external codegen tool, leave it as-is — do not add or trim comments in generated files.

--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -1,0 +1,7 @@
+# Pull requests
+
+- **Follow the template** (`.github/pull_request_template.md`): fill in its headings (Description / Issues closed by this PR / Screenshots / Additional Information). Don't add sections the template doesn't have.
+- **Keep only the headings that apply.** Delete every heading that has nothing under it, along with its `<!--...-->` placeholder comment. The body must never contain an empty heading — if only Description applies, the body has exactly that one heading.
+- **Keep the description concise and human-readable.** A few plain bullets saying what changed and why, for a reviewer skimming it — not a wall of text, not a restatement of the diff, not generated boilerplate.
+- **Reference issues with `Closes #issue-number`** under "Issues closed by this PR" so they auto-close on merge. This goes in the PR description only — never in commit messages.
+- **AI assistance in commits may optionally be disclosed with an `Assisted-by:` trailer** naming the model (e.g. `Assisted-by: Claude Opus 4.5`) — do NOT use a `Co-authored-by:` trailer for this.

--- a/.claude/rules/py-comments.md
+++ b/.claude/rules/py-comments.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - "**/*.py"
+---
+
+# Python comments
+
+The bar is the [`comments`](comments.md) rule: nothing where the code is self-explanatory.
+
+- **Names carry the meaning.** Make function and variable names self-explanatory so the comment or docstring is unnecessary in the first place. If a docstring is needed to explain what a function does, fix the name, not the docstring.
+- **No file-level docstring.** The filename says what the module is for — `tool_bin.py` gets the tool binary. A module docstring restating that is noise, and a paragraph of design prose at the top of a file goes stale where nobody is looking. A constraint belongs next to the code it constrains, not in a preamble.
+- **Docstrings**: only when they say something the name and signature don't — drop them otherwise. Keep them short. A contract that genuinely needs a few lines (interacting flags, retry semantics, an edge case) is fine; a narrative is not.
+- **No song and dance.** Comment the constraint or the edge case. Not the narrative, not the rationale, not what the next line does.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,85 +1,13 @@
-## Pull Request
+<!--A few plain bullets saying what changed and why, for a reviewer skimming it - not a wall of text, not a restatement of the diff, not generated boilerplate.-->
+#### Description
 
----
-
-### 📄 Summary
-> Why does this change exist?  
-> What problem does it solve, and why is this the right approach?
-
-
-
-#### Screenshots / Screen Recordings (if applicable)
-> Include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. This helps reviewers quickly understand the impact and verify the update.
-
-
+<!--Reference issues using `Closes #issue-number` to enable automatic closure on merge. -->
 #### Issues closed by this PR
-> Reference issues using `Closes #issue-number` to enable automatic closure on merge.
 
----
+<!--If applicable, include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. -->
+#### Screenshots / Screen Recordings
 
-### ✅ Change Type
-_Select all that apply_
+<!--Anything reviewers should keep in mind while reviewing -->
+#### Additional Information
 
-- [ ] ✨ Feature
-- [ ] 🐛 Bug fix
-- [ ] ♻️ Refactor
-- [ ] 🛠️ Infra / Tooling
-- [ ] 🧪 Test-only
-
----
-
-### 🐛 Bug Context
-> Required if this PR fixes a bug
-
-#### Root Cause
-> What caused the issue?  
-> Regression, faulty assumption, edge case, refactor, etc.
-
-#### Fix Strategy
-> How does this PR address the root cause?
-
----
-
-### 🧪 Testing Strategy
-> How was this change validated?
-
-- Tests added/updated:
-- Manual verification:
-- Edge cases covered:
-
----
-
-### ⚠️ Risk & Impact Assessment
-> What could break? How do we recover?
-
-- Blast radius:
-- Potential regressions:
-- Rollback plan:
-
----
-
-### 📝 Changelog
-> Fill only if this affects users, APIs, UI, or documented behavior  
-> Use **N/A** for internal or non-user-facing changes
-
-| Field | Value |
-|------|-------|
-| Deployment Type | Cloud / OSS / Enterprise |
-| Change Type | Feature / Bug Fix / Maintenance |
-| Description | User-facing summary |
-
----
-
-### 📋 Checklist
-- [ ] Tests added or explicitly not required
-- [ ] Manually tested
-- [ ] Breaking changes documented
-- [ ] Backward compatibility considered
-
----
-
-## 👀 Notes for Reviewers
-
-<!-- Anything reviewers should keep in mind while reviewing -->
-
----
+<!--Please delete paragraphs that you did not use before submitting.-->

--- a/.gitignore
+++ b/.gitignore
@@ -90,8 +90,6 @@ queries.active
 .devenv/**/tmp/**
 .qodo
 
-.dev
-
 ### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -231,4 +229,6 @@ cython_debug/
 # LSP config files
 pyrightconfig.json
 
-
+# dev
+.dev/
+.claude/worktrees/


### PR DESCRIPTION
#### Description

- Replace the multi-section PR template (change type, risk assessment, changelog, checklist) with four concise headings: Description, Issues closed, Screenshots, Additional Information.
- Add `.claude/rules/` with agent rules for comments (repo-wide, Go, Python) and pull requests.
- Ignore `.dev/` and `.claude/worktrees/` in `.gitignore`.