### PR TITLE
fix(infrastructure-monitoring): migrate having clause to new format

### DIFF
--- a/frontend/src/container/InfraMonitoringHostsV2/constants.tsx
+++ b/frontend/src/container/InfraMonitoringHostsV2/constants.tsx
@@ -82,7 +82,7 @@ export function getHostMetricsQueryPayload(
 	start: number,
 	end: number,
 ): ReturnType<typeof getHostQueryPayload> {
-	return getHostQueryPayload(host.hostName, start, end);
+	return getHostQueryPayload(host.hostName, start, end, true);
 }
 
 export { hostWidgetInfo };

--- a/frontend/src/container/InfraMonitoringK8sV2/Clusters/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Clusters/constants.ts
@@ -562,13 +562,9 @@ export const getClusterMetricsQueryPayload = (
 									type: 'tag',
 								},
 							],
-							having: [
-								{
-									columnName: `MAX(${INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CONDITION_READY})`,
-									op: '=',
-									value: 1,
-								},
-							],
+							having: {
+								expression: `max(${INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CONDITION_READY}) = 1`,
+							},
 							legend: `{{${INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME}}}`,
 							limit: null,
 							orderBy: [],
@@ -648,13 +644,9 @@ export const getClusterMetricsQueryPayload = (
 									type: 'tag',
 								},
 							],
-							having: [
-								{
-									columnName: `MAX(${INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CONDITION_READY})`,
-									op: '=',
-									value: 0,
-								},
-							],
+							having: {
+								expression: `max(${INFRA_MONITORING_ATTR_KEYS.K8S_NODE_CONDITION_READY}) = 0`,
+							},
 							legend: `{{${INFRA_MONITORING_ATTR_KEYS.K8S_NODE_NAME}}}`,
 							limit: null,
 							orderBy: [],

--- a/frontend/src/container/InfraMonitoringK8sV2/Namespaces/constants.ts
+++ b/frontend/src/container/InfraMonitoringK8sV2/Namespaces/constants.ts
@@ -1208,13 +1208,9 @@ export const getNamespaceMetricsQueryPayload = (
 									type: 'tag',
 								},
 							],
-							having: [
-								{
-									columnName: `MAX(${INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_DESIRED})`,
-									op: '>',
-									value: 0,
-								},
-							],
+							having: {
+								expression: `max(${INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_DESIRED}) > 0`,
+							},
 							legend: 'desired',
 							limit: null,
 							orderBy: [],
@@ -1261,13 +1257,9 @@ export const getNamespaceMetricsQueryPayload = (
 									type: 'tag',
 								},
 							],
-							having: [
-								{
-									columnName: `MAX(${INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_DESIRED})`,
-									op: '>',
-									value: 0,
-								},
-							],
+							having: {
+								expression: `max(${INFRA_MONITORING_ATTR_KEYS.K8S_REPLICASET_AVAILABLE}) > 0`,
+							},
 							legend: 'available',
 							limit: null,
 							orderBy: [],

--- a/frontend/src/container/LogDetailedView/InfraMetrics/constants.ts
+++ b/frontend/src/container/LogDetailedView/InfraMetrics/constants.ts
@@ -1,8 +1,18 @@
 import { PANEL_TYPES } from 'constants/queryBuilder';
 import { GetQueryResultsProps } from 'lib/dashboard/getQueryResults';
+import type { Having } from 'types/api/queryBuilder/queryBuilderData';
 import { DataTypes } from 'types/api/queryBuilder/queryAutocompleteResponse';
+import type { Having as HavingV5 } from 'types/api/v5/queryRange';
 import { EQueryType } from 'types/common/dashboard';
 import { DataSource, ReduceOperators } from 'types/common/queryBuilder';
+
+const buildSumGreaterThanZeroHaving = (
+	metricKey: string,
+	useV5HavingFormat: boolean,
+): Having[] | HavingV5 =>
+	useV5HavingFormat
+		? { expression: `sum(${metricKey}) > 0` }
+		: [{ columnName: `SUM(${metricKey})`, op: '>', value: 0 }];
 
 export const getPodQueryPayload = (
 	clusterName: string,
@@ -1540,6 +1550,7 @@ export const getHostQueryPayload = (
 	hostName: string,
 	start: number,
 	end: number,
+	useV5HavingFormat = false,
 ): GetQueryResultsProps[] => {
 	const hostNameKey = 'host.name';
 	const cpuTimeKey = 'system.cpu.time';
@@ -1802,13 +1813,7 @@ export const getHostQueryPayload = (
 									type: 'tag',
 								},
 							],
-							having: [
-								{
-									columnName: `SUM(${fsUsageKey})`,
-									op: '>',
-									value: 0,
-								},
-							],
+							having: buildSumGreaterThanZeroHaving(fsUsageKey, useV5HavingFormat),
 							legend: '{{mountpoint}}',
 							limit: null,
 							orderBy: [],
@@ -1857,13 +1862,7 @@ export const getHostQueryPayload = (
 									type: 'tag',
 								},
 							],
-							having: [
-								{
-									columnName: `SUM(${fsUsageKey})`,
-									op: '>',
-									value: 0,
-								},
-							],
+							having: buildSumGreaterThanZeroHaving(fsUsageKey, useV5HavingFormat),
 							legend: '{{mountpoint}}',
 							limit: null,
 							orderBy: [],
@@ -2089,13 +2088,7 @@ export const getHostQueryPayload = (
 									type: 'tag',
 								},
 							],
-							having: [
-								{
-									columnName: `SUM(${netIoKey})`,
-									op: '>',
-									value: 0,
-								},
-							],
+							having: buildSumGreaterThanZeroHaving(netIoKey, useV5HavingFormat),
 							legend: '{{device}}::{{direction}}',
 							limit: 30,
 							orderBy: [],
@@ -2551,13 +2544,7 @@ export const getHostQueryPayload = (
 									type: 'tag',
 								},
 							],
-							having: [
-								{
-									columnName: `SUM(${diskOpsKey})`,
-									op: '>',
-									value: 0,
-								},
-							],
+							having: buildSumGreaterThanZeroHaving(diskOpsKey, useV5HavingFormat),
 							legend: '{{device}}::{{direction}}',
 							limit: null,
 							orderBy: [],
@@ -2626,13 +2613,7 @@ export const getHostQueryPayload = (
 									type: 'tag',
 								},
 							],
-							having: [
-								{
-									columnName: `SUM(${diskPendingKey})`,
-									op: '>',
-									value: 0,
-								},
-							],
+							having: buildSumGreaterThanZeroHaving(diskPendingKey, useV5HavingFormat),
 							legend: '{{device}}',
 							limit: null,
 							orderBy: [],
@@ -2708,13 +2689,7 @@ export const getHostQueryPayload = (
 									type: 'tag',
 								},
 							],
-							having: [
-								{
-									columnName: `SUM(${diskOpTimeKey})`,
-									op: '>',
-									value: 0,
-								},
-							],
+							having: buildSumGreaterThanZeroHaving(diskOpTimeKey, useV5HavingFormat),
 							legend: '{{device}}::{{direction}}',
 							limit: null,
 							orderBy: [],


### PR DESCRIPTION
<!--A few plain bullets saying what changed and why, for a reviewer skimming it - not a wall of text, not a restatement of the diff, not generated boilerplate.-->
#### Description

This fixes the bad migration I did at https://github.com/SigNoz/signoz/pull/11060, and correctly fixes the expressions for `having` clause inside the charts.

<!--Reference issues using `Closes #issue-number` to enable automatic closure on merge. -->
#### Issues closed by this PR

Closes https://github.com/SigNoz/platform-pod/issues/2905

Closes https://github.com/SigNoz/pulse-pod/issues/212

<!--If applicable, include screenshots or screen recordings that clearly show the behavior before the change and the result after the change. -->
#### Screenshots / Screen Recordings

| Before | After |
|--------|--------|
| <img width="2156" height="1081" alt="screenshot-2026-08-07_17-15-41" src="https://github.com/user-attachments/assets/b5617e88-2d63-4a21-915f-d21ed78f9f8b" /> | <img width="2148" height="1075" alt="screenshot-2026-08-07_17-12-06" src="https://github.com/user-attachments/assets/4de3ffd0-533f-4b3b-81ac-df1515b4a076" /> |
| <img width="2145" height="357" alt="screenshot-2026-08-07_17-16-08" src="https://github.com/user-attachments/assets/0bfb92f3-e0c4-4cf6-9e4e-62068501da96" /> | <img width="2146" height="360" alt="screenshot-2026-08-07_17-11-54" src="https://github.com/user-attachments/assets/bba8ee82-68cd-4205-951f-711adaad07e0" /> |
| <img width="1074" height="356" alt="screenshot-2026-08-07_17-15-55" src="https://github.com/user-attachments/assets/574430b4-8547-4a1e-b53a-982ef33344ae" /> | <img width="1074" height="363" alt="screenshot-2026-08-07_17-11-44" src="https://github.com/user-attachments/assets/bf5698af-f7fb-45b6-886a-bc8ed4aba808" /> |
