### PR TITLE
fix(metrics-explorer): use container width for treemap instead of window width

### DIFF
--- a/frontend/src/container/MetricsExplorer/Summary/MetricsTreemap.tsx
+++ b/frontend/src/container/MetricsExplorer/Summary/MetricsTreemap.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useMemo } from 'react';
-import { useWindowSize } from 'react-use';
+import { useCallback, useMemo, useRef } from 'react';
 import { Group } from '@visx/group';
 import { Treemap } from '@visx/hierarchy';
+import { useResizeObserver } from 'hooks/useDimensions';
 import { Empty, Select, Skeleton, Tooltip } from 'antd';
 import { Typography } from '@signozhq/ui/typography';
 import { MetricsexplorertypesTreemapModeDTO } from 'api/generated/services/sigNoz.schemas';
@@ -33,16 +33,15 @@ function MetricsTreemapInternal({
 	data,
 	viewType,
 	openMetricDetails,
+	containerWidth,
 }: MetricsTreemapInternalProps): JSX.Element {
-	const { width: windowWidth } = useWindowSize();
-
 	const treemapWidth = useMemo(
 		() =>
 			Math.max(
-				windowWidth - TREEMAP_MARGINS.LEFT - TREEMAP_MARGINS.RIGHT - 70,
+				containerWidth - TREEMAP_MARGINS.LEFT - TREEMAP_MARGINS.RIGHT,
 				300,
 			),
-		[windowWidth],
+		[containerWidth],
 	);
 
 	const treemapData = useMemo(() => {
@@ -185,8 +184,12 @@ function MetricsTreemap({
 	openMetricDetails,
 	setHeatmapView,
 }: MetricsTreemapProps): JSX.Element {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const { width: containerWidth } = useResizeObserver(containerRef);
+
 	return (
 		<div
+			ref={containerRef}
 			className="metrics-treemap-container"
 			data-testid="metrics-treemap-container"
 		>
@@ -214,6 +217,7 @@ function MetricsTreemap({
 				data={data}
 				viewType={viewType}
 				openMetricDetails={openMetricDetails}
+				containerWidth={containerWidth}
 			/>
 		</div>
 	);

--- a/frontend/src/container/MetricsExplorer/Summary/types.ts
+++ b/frontend/src/container/MetricsExplorer/Summary/types.ts
@@ -62,6 +62,8 @@ export interface MetricsTreemapInternalProps {
 		view: 'list' | 'treemap',
 		event?: React.MouseEvent,
 	) => void;
+	/** Measured width of the treemap container in pixels. */
+	containerWidth: number;
 }
 
 export interface OrderByPayload {


### PR DESCRIPTION
## What does this PR do?

Fixes the treemap layout breaking when the sidebar is open in Metrics Explorer → Summary page.

**Root cause:** `MetricsTreemapInternal` was computing its render width using `useWindowSize()` with a hardcoded `-70px` offset. When the sidebar opens, the window width stays the same — only the available content area shrinks — so the SVG overflowed the container.

**Fix:** Attach a `ref` to the outer `metrics-treemap-container` div in `MetricsTreemap` and measure its actual width using the existing `useResizeObserver` hook from `hooks/useDimensions.ts`. Pass that measured width down to `MetricsTreemapInternal` as `containerWidth`. The SVG now always fits inside its real parent regardless of sidebar state.

## Changes

- `MetricsTreemap.tsx`: replaced `useWindowSize` with `useResizeObserver` on the container ref; removed hardcoded `-70` offset; passes `containerWidth` to inner component
- `types.ts`: added `containerWidth: number` to `MetricsTreemapInternalProps`

## Related issue

Fixes #9120