### PR TITLE
fix(sqlmigration): skip saved views with dangling org_id in migration 109

### DIFF
--- a/pkg/sqlmigration/109_restructure_saved_view_spec.go
+++ b/pkg/sqlmigration/109_restructure_saved_view_spec.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SigNoz/signoz/pkg/factory"
 	"github.com/SigNoz/signoz/pkg/sqlschema"
 	"github.com/SigNoz/signoz/pkg/sqlstore"
+	"github.com/SigNoz/signoz/pkg/types"
 )
 
 type restructureSavedViewSpec struct {
@@ -164,6 +165,15 @@ func (migration *restructureSavedViewSpec) Up(ctx context.Context, db *bun.DB) e
 		return err
 	}
 
+	var orgIDs []string
+	if err := tx.NewSelect().Model((*types.Organization)(nil)).Column("id").Scan(ctx, &orgIDs); err != nil {
+		return err
+	}
+	validOrgIDs := make(map[string]struct{}, len(orgIDs))
+	for _, id := range orgIDs {
+		validOrgIDs[id] = struct{}{}
+	}
+
 	// drop table `saved_views`
 	for _, sql := range migration.sqlschema.Operator().DropTable(savedViewsTable) {
 		if _, err := tx.ExecContext(ctx, string(sql)); err != nil {
@@ -208,6 +218,13 @@ func (migration *restructureSavedViewSpec) Up(ctx context.Context, db *bun.DB) e
 		if old.OrgID == "" {
 			skipped++
 			continue // orphaned row from a pre-existing org_id backfill gap; nothing sane to attach it to
+		}
+
+		// to avoid foreign key constraint issues
+		if _, ok := validOrgIDs[old.OrgID]; !ok {
+			skipped++
+			migration.settings.Logger.WarnContext(ctx, "saved view references an org that no longer exists, skipping", slog.String("org_id", old.OrgID), slog.String("saved_view_id", old.ID))
+			continue
 		}
 
 		var compositeQuery legacySavedViewCompositeQuery


### PR DESCRIPTION
## Summary
- `restructureSavedViewSpec` (migration 109) bulk-inserts legacy `saved_views` rows into the new `saved_view` table, which has an enforced `org_id -> organizations(id)` FK (sqlite runs with `foreign_keys=ON`).
- Some tenants hit `constraint failed: FOREIGN KEY constraint failed (787)` on startup because a row's `org_id` didn't match any live organization -- e.g. an org deleted before the old table had a cascading FK, or an install where `org_id` was never backfilled (`015_update_dashboards_savedviews` only backfills it when there's exactly one org).
- Fix: fetch live organization IDs up front inside the same transaction, and skip (with a `WarnContext` log, counted in `skipped`) any row whose non-empty `org_id` isn't among them -- same treatment as the existing empty-`org_id` skip.

Followup to https://github.com/SigNoz/signoz/pull/12342