### PR TITLE
refactor: removing logs support for gcp integration services

### DIFF
--- a/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/cloudsql_postgres/integration.json
+++ b/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/cloudsql_postgres/integration.json
@@ -5,7 +5,7 @@
   "overview": "file://overview.md",
   "supportedSignals": {
     "metrics": true,
-    "logs": true
+    "logs": false
   },
   "dataCollected": {
     "metrics": [

--- a/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/cloudstorage/integration.json
+++ b/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/cloudstorage/integration.json
@@ -5,7 +5,7 @@
   "overview": "file://overview.md",
   "supportedSignals": {
     "metrics": true,
-    "logs": true
+    "logs": false
   },
   "dataCollected": {
     "metrics": [

--- a/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/computeengine/integration.json
+++ b/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/computeengine/integration.json
@@ -5,7 +5,7 @@
   "overview": "file://overview.md",
   "supportedSignals": {
     "metrics": true,
-    "logs": true
+    "logs": false
   },
   "dataCollected": {
     "metrics": [

--- a/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/gke/integration.json
+++ b/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/gke/integration.json
@@ -5,7 +5,7 @@
   "overview": "file://overview.md",
   "supportedSignals": {
     "metrics": true,
-    "logs": true
+    "logs": false
   },
   "dataCollected": {
     "metrics": [

--- a/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/memorystore_redis/integration.json
+++ b/pkg/modules/cloudintegration/implcloudintegration/fs/definitions/gcp/memorystore_redis/integration.json
@@ -5,7 +5,7 @@
   "overview": "file://overview.md",
   "supportedSignals": {
     "metrics": true,
-    "logs": true
+    "logs": false
   },
   "dataCollected": {
     "metrics": [


### PR DESCRIPTION
<!--A few plain bullets saying what changed and why, for a reviewer skimming it - not a wall of text, not a restatement of the diff, not generated boilerplate.-->
#### Description
Disabling logs support for all GCP integration services.

Reasons:
1. googlecloudpubsubpush receiver needs to reach Alpha stability, thus not included in contrib build -> can't suggest for logs
2. signoz otel collector includes this receiver in the build but it needs upgrade to v0.158.0 for a metrics related [fix](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49826) -> needs more testing hence can't suggest either

Decision was taken to go ahead without logs for now - follow [ticket here](https://github.com/SigNoz/platform-pod/issues/2901) for details.


<!--Reference issues using `Closes #issue-number` to enable automatic closure on merge. -->
#### Contributes to 
https://github.com/SigNoz/platform-pod/issues/2901

<!--Anything reviewers should keep in mind while reviewing -->
#### Additional Information
The explanation above should be enough

<!--Please delete paragraphs that you did not use before submitting.-->
