### PR TITLE
fix(tests): call Metrics.load_from_file directly in the pods filter test

### DIFF
--- a/tests/integration/tests/inframonitoring/02_pods.py
+++ b/tests/integration/tests/inframonitoring/02_pods.py
@@ -468,8 +468,8 @@ def test_pods_filter_pagination_and_ordering(
     crashloopbackoff matches 4 pods in pods_phases.jsonl: clbo-a, clbo-b, run-p, unk-p."""
     now = datetime.now(tz=UTC).replace(microsecond=0)
     insert_metrics(
-        _load_pods_metrics(
-            "inframonitoring/pods_phases.jsonl",
+        Metrics.load_from_file(
+            get_testdata_file_path("inframonitoring/pods_phases.jsonl"),
             base_time=now - timedelta(minutes=4),
         )
     )


### PR DESCRIPTION
#### Description

- `make py-lint` is failing on `main` with `F821 Undefined name _load_pods_metrics` at `inframonitoring/02_pods.py:471`, which blocks every open PR.
- `test_pods_filter_pagination_and_ordering` calls a helper that no longer exists. Replaced with `Metrics.load_from_file(get_testdata_file_path(...))`, matching the two other tests that seed `pods_phases.jsonl`.

#### Additional Information

- How it broke: #12460 replaced the module-level `_load_pods_metrics` with a `load_pods_metrics` fixture, then #12462 dropped that fixture in favour of calling `Metrics.load_from_file` directly. #12278 branched before either landed and merged after, re-introducing one call to the long-gone helper. Git merged cleanly because the branches touched different lines, so nothing flagged it.
- No behaviour change: the broken call passed no `start_time`, so no placeholder substitution happened; `load_from_file` with `label_substitutions=None` does the same earliest-to-`base_time` rebase. The replacement is byte-identical to the two sibling call sites for the same dataset.