### PR TITLE
feat(invite): accept multiple roles per invited member

### DIFF
--- a/frontend/src/components/InviteMembers/InviteMembers.tsx
+++ b/frontend/src/components/InviteMembers/InviteMembers.tsx
@@ -80,7 +80,7 @@ function InviteMembers({
 							weight="semibold"
 							className={styles.headerCellRole}
 						>
-							Role
+							Roles
 						</Typography.Text>
 						<div className={styles.headerCellAction} />
 					</div>
@@ -108,11 +108,10 @@ function InviteMembers({
 
 							<div className={styles.cellRole}>
 								<RolesSelect
-									mode="single"
-									value={row.roleId || undefined}
-									onChange={(roleId): void => updateRole(row.id, roleId)}
-									placeholder="Select role"
-									allowClear={false}
+									mode="multiple"
+									value={row.roleIds}
+									onChange={(roleIds): void => updateRole(row.id, roleIds)}
+									placeholder="Select roles"
 									id={`invite-role-${row.id}`}
 								/>
 							</div>

--- a/frontend/src/components/InviteMembers/__tests__/InviteMembers.edgeCases.test.tsx
+++ b/frontend/src/components/InviteMembers/__tests__/InviteMembers.edgeCases.test.tsx
@@ -68,8 +68,8 @@ describe('InviteMembers - Edge Cases', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], VALID_EMAIL);
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.click(screen.getByTestId('submit-btn'));
 			await expect(
@@ -100,8 +100,8 @@ describe('InviteMembers - Edge Cases', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], VALID_EMAIL);
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.click(screen.getByTestId('submit-btn'));
 			await expect(
@@ -132,17 +132,17 @@ describe('InviteMembers - Edge Cases', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], VALID_EMAIL);
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.click(screen.getByTestId('submit-btn'));
 			await expect(
 				screen.findByTestId('invite-api-error'),
 			).resolves.toBeInTheDocument();
 
-			const viewerElements = screen.getAllByText('Viewer');
+			const viewerElements = screen.getAllByTitle('Viewer');
 			await user.click(viewerElements[0]);
-			const editorOptions = await screen.findAllByText('Editor');
+			const editorOptions = await screen.findAllByTitle('Editor');
 			await user.click(editorOptions[editorOptions.length - 1]);
 
 			await waitFor(() => {
@@ -189,8 +189,8 @@ describe('InviteMembers - Edge Cases', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], VALID_EMAIL);
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			const submitBtn = screen.getByTestId('submit-btn');
 			await user.click(submitBtn);
@@ -226,8 +226,8 @@ describe('InviteMembers - Edge Cases', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], '  alice@signoz.io  ');
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.click(screen.getByTestId('submit-btn'));
 

--- a/frontend/src/components/InviteMembers/__tests__/InviteMembers.rendering.test.tsx
+++ b/frontend/src/components/InviteMembers/__tests__/InviteMembers.rendering.test.tsx
@@ -32,14 +32,14 @@ describe('InviteMembers - Rendering', () => {
 		render(<InviteMembers />);
 
 		expect(screen.getByText('Email address')).toBeInTheDocument();
-		expect(screen.getByText('Role')).toBeInTheDocument();
+		expect(screen.getByText('Roles')).toBeInTheDocument();
 	});
 
 	it('hides header when showHeader is false', () => {
 		render(<InviteMembers showHeader={false} />);
 
 		expect(screen.queryByText('Email address')).not.toBeInTheDocument();
-		expect(screen.queryByText('Role')).not.toBeInTheDocument();
+		expect(screen.queryByText('Roles')).not.toBeInTheDocument();
 	});
 
 	it('renders add button by default', () => {
@@ -89,7 +89,7 @@ describe('InviteMembers - Rendering', () => {
 	it('renders role select for each row', () => {
 		render(<InviteMembers initialRowCount={2} />);
 
-		const roleSelects = screen.getAllByText('Select role');
+		const roleSelects = screen.getAllByText('Select roles');
 		expect(roleSelects).toHaveLength(2);
 	});
 });

--- a/frontend/src/components/InviteMembers/__tests__/InviteMembers.submission.test.tsx
+++ b/frontend/src/components/InviteMembers/__tests__/InviteMembers.submission.test.tsx
@@ -40,8 +40,8 @@ describe('InviteMembers - Submission', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], 'alice@signoz.io');
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.click(screen.getByTestId('submit-btn'));
 
@@ -73,17 +73,17 @@ describe('InviteMembers - Submission', () => {
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 
 			await user.type(emailInputs[0], 'alice@signoz.io');
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.type(emailInputs[1], 'bob@signoz.io');
-			await user.click(screen.getAllByText('Select role')[0]);
-			const editorOptions = await screen.findAllByText('Editor');
+			await user.click(screen.getAllByText('Select roles')[0]);
+			const editorOptions = await screen.findAllByTitle('Editor');
 			await user.click(editorOptions[editorOptions.length - 1]);
 
 			await user.type(emailInputs[2], 'charlie@signoz.io');
-			await user.click(screen.getAllByText('Select role')[0]);
-			const adminOptions = await screen.findAllByText('Admin');
+			await user.click(screen.getAllByText('Select roles')[0]);
+			const adminOptions = await screen.findAllByTitle('Admin');
 			await user.click(adminOptions[adminOptions.length - 1]);
 
 			await user.click(screen.getByTestId('submit-btn'));
@@ -125,8 +125,8 @@ describe('InviteMembers - Submission', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], VALID_EMAIL);
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.click(screen.getByTestId('submit-btn'));
 
@@ -154,8 +154,8 @@ describe('InviteMembers - Submission', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], VALID_EMAIL);
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.click(screen.getByTestId('submit-btn'));
 
@@ -218,12 +218,12 @@ describe('InviteMembers - Submission', () => {
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 
 			await user.type(emailInputs[0], 'alice@signoz.io');
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.type(emailInputs[1], 'bob@signoz.io');
-			await user.click(screen.getAllByText('Select role')[0]);
-			const editorOptions = await screen.findAllByText('Editor');
+			await user.click(screen.getAllByText('Select roles')[0]);
+			const editorOptions = await screen.findAllByTitle('Editor');
 			await user.click(editorOptions[editorOptions.length - 1]);
 
 			await user.click(screen.getByTestId('submit-btn'));
@@ -276,8 +276,8 @@ describe('InviteMembers - Submission', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], VALID_EMAIL);
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.click(screen.getByTestId('submit-btn'));
 
@@ -303,8 +303,8 @@ describe('InviteMembers - Submission', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], VALID_EMAIL);
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.click(screen.getByTestId('submit-btn'));
 

--- a/frontend/src/components/InviteMembers/__tests__/InviteMembers.validation.test.tsx
+++ b/frontend/src/components/InviteMembers/__tests__/InviteMembers.validation.test.tsx
@@ -35,8 +35,8 @@ describe('InviteMembers - Validation', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], INVALID_EMAIL);
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.click(screen.getByTestId('submit-btn'));
 
@@ -60,8 +60,8 @@ describe('InviteMembers - Validation', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], INVALID_EMAIL);
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.click(screen.getByTestId('submit-btn'));
 
@@ -85,8 +85,8 @@ describe('InviteMembers - Validation', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], INVALID_EMAIL);
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 			await user.click(screen.getByTestId('submit-btn'));
 
 			await expect(
@@ -149,8 +149,8 @@ describe('InviteMembers - Validation', () => {
 				screen.findByText('Please select roles for team members'),
 			).resolves.toBeInTheDocument();
 
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await waitFor(() => {
 				expect(
@@ -204,8 +204,8 @@ describe('InviteMembers - Validation', () => {
 
 			const emailInputs = screen.getAllByPlaceholderText('e.g. john@signoz.io');
 			await user.type(emailInputs[0], VALID_EMAIL);
-			await user.click(screen.getAllByText('Select role')[0]);
-			await user.click(await screen.findByText('Viewer'));
+			await user.click(screen.getAllByText('Select roles')[0]);
+			await user.click(await screen.findByTitle('Viewer'));
 
 			await user.click(screen.getByTestId('submit-btn'));
 

--- a/frontend/src/components/InviteMembers/types.ts
+++ b/frontend/src/components/InviteMembers/types.ts
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 export interface InviteMemberRow {
 	id: string;
 	email: string;
-	roleId: string;
+	roleIds: string[];
 }
 
 export interface InviteResult {
@@ -38,7 +38,7 @@ export interface UseInviteMembersReturn {
 	addRow: () => void;
 	removeRow: (id: string) => void;
 	updateEmail: (id: string, email: string) => void;
-	updateRole: (id: string, roleId: string | undefined) => void;
+	updateRole: (id: string, roleIds: string[]) => void;
 	reset: () => void;
 	submit: () => Promise<InviteResult[]>;
 

--- a/frontend/src/components/InviteMembers/useInviteMembers.ts
+++ b/frontend/src/components/InviteMembers/useInviteMembers.ts
@@ -18,11 +18,11 @@ import {
 const createEmptyRow = (): InviteMemberRow => ({
 	id: uuid(),
 	email: '',
-	roleId: '',
+	roleIds: [],
 });
 
 const isRowTouched = (row: InviteMemberRow): boolean =>
-	row.email.trim() !== '' || row.roleId !== '';
+	row.email.trim() !== '' || row.roleIds.length > 0;
 
 export function useInviteMembers(
 	options: UseInviteMembersOptions = {},
@@ -78,7 +78,7 @@ export function useInviteMembers(
 
 		touched.forEach((row) => {
 			const emailValid = EMAIL_REGEX.test(row.email);
-			const roleValid = row.roleId !== '';
+			const roleValid = row.roleIds.length > 0;
 
 			if (!emailValid || !row.email) {
 				isValid = false;
@@ -139,12 +139,12 @@ export function useInviteMembers(
 	);
 
 	const updateRole = useCallback(
-		(id: string, roleId: string | undefined): void => {
+		(id: string, roleIds: string[]): void => {
 			setRows((prev) => {
 				const updated = cloneDeep(prev);
 				const row = updated.find((r) => r.id === id);
 				if (row) {
-					row.roleId = roleId ?? '';
+					row.roleIds = roleIds;
 				}
 				return updated;
 			});
@@ -187,7 +187,7 @@ export function useInviteMembers(
 				await createUser({
 					email: row.email.trim(),
 					frontendBaseUrl: getBaseUrl(),
-					userRoles: [{ id: row.roleId }],
+					userRoles: row.roleIds.map((id) => ({ id })),
 				});
 				results.push({ email: row.email, success: true });
 			} catch (err) {

--- a/frontend/src/container/OnboardingQuestionaire/InviteTeamMembers/InviteTeamMembers.tsx
+++ b/frontend/src/container/OnboardingQuestionaire/InviteTeamMembers/InviteTeamMembers.tsx
@@ -14,7 +14,7 @@ import './InviteTeamMembers.styles.scss';
 
 interface TeamMember {
 	email: string;
-	role: string;
+	roles: string[];
 	name: string;
 	frontendBaseUrl: string;
 	id: string;
@@ -45,7 +45,7 @@ function InviteTeamMembers({
 	const toTeamMembers = (rows: InviteMemberRow[]): TeamMember[] =>
 		rows.map((row) => ({
 			email: row.email,
-			role: roleIdToName[row.roleId] ?? row.roleId,
+			roles: row.roleIds.map((roleId) => roleIdToName[roleId] ?? roleId),
 			name: '',
 			frontendBaseUrl: getBaseUrl(),
 			id: row.id,

--- a/frontend/src/container/OnboardingQuestionaire/InviteTeamMembers/__tests__/InviteTeamMembers.test.tsx
+++ b/frontend/src/container/OnboardingQuestionaire/InviteTeamMembers/__tests__/InviteTeamMembers.test.tsx
@@ -166,8 +166,8 @@ describe('InviteTeamMembers', () => {
 				{ email: 'user2@test.com', success: true },
 			];
 			const mockRows: InviteMemberRow[] = [
-				{ id: 'row-1', email: 'user1@test.com', roleId: 'role-viewer-id' },
-				{ id: 'row-2', email: 'user2@test.com', roleId: 'role-editor-id' },
+				{ id: 'row-1', email: 'user1@test.com', roleIds: ['role-viewer-id'] },
+				{ id: 'row-2', email: 'user2@test.com', roleIds: ['role-editor-id'] },
 			];
 			mockInviteMembersProps?.onSuccess?.(mockResults, mockRows);
 
@@ -177,14 +177,14 @@ describe('InviteTeamMembers', () => {
 					teamMembers: [
 						{
 							email: 'user1@test.com',
-							role: 'VIEWER',
+							roles: ['VIEWER'],
 							name: '',
 							frontendBaseUrl: 'http://localhost:3301',
 							id: 'row-1',
 						},
 						{
 							email: 'user2@test.com',
-							role: 'EDITOR',
+							roles: ['EDITOR'],
 							name: '',
 							frontendBaseUrl: 'http://localhost:3301',
 							id: 'row-2',
@@ -211,8 +211,8 @@ describe('InviteTeamMembers', () => {
 				{ email: 'user2@test.com', success: false, error: 'Already exists' },
 			];
 			const mockRows: InviteMemberRow[] = [
-				{ id: 'row-1', email: 'user1@test.com', roleId: 'role-viewer-id' },
-				{ id: 'row-2', email: 'user2@test.com', roleId: 'role-admin-id' },
+				{ id: 'row-1', email: 'user1@test.com', roleIds: ['role-viewer-id'] },
+				{ id: 'row-2', email: 'user2@test.com', roleIds: ['role-admin-id'] },
 			];
 			mockInviteMembersProps?.onPartialSuccess?.(mockResults, mockRows);
 
@@ -222,14 +222,14 @@ describe('InviteTeamMembers', () => {
 					teamMembers: [
 						{
 							email: 'user1@test.com',
-							role: 'VIEWER',
+							roles: ['VIEWER'],
 							name: '',
 							frontendBaseUrl: 'http://localhost:3301',
 							id: 'row-1',
 						},
 						{
 							email: 'user2@test.com',
-							role: 'ADMIN',
+							roles: ['ADMIN'],
 							name: '',
 							frontendBaseUrl: 'http://localhost:3301',
 							id: 'row-2',
@@ -252,8 +252,8 @@ describe('InviteTeamMembers', () => {
 				{ email: 'user2@test.com', success: false, error: 'Error 2' },
 			];
 			const mockRows: InviteMemberRow[] = [
-				{ id: 'row-1', email: 'user1@test.com', roleId: 'role-editor-id' },
-				{ id: 'row-2', email: 'user2@test.com', roleId: 'role-viewer-id' },
+				{ id: 'row-1', email: 'user1@test.com', roleIds: ['role-editor-id'] },
+				{ id: 'row-2', email: 'user2@test.com', roleIds: ['role-viewer-id'] },
 			];
 			mockInviteMembersProps?.onAllFailed?.(mockResults, mockRows);
 
@@ -263,14 +263,14 @@ describe('InviteTeamMembers', () => {
 					teamMembers: [
 						{
 							email: 'user1@test.com',
-							role: 'EDITOR',
+							roles: ['EDITOR'],
 							name: '',
 							frontendBaseUrl: 'http://localhost:3301',
 							id: 'row-1',
 						},
 						{
 							email: 'user2@test.com',
-							role: 'VIEWER',
+							roles: ['VIEWER'],
 							name: '',
 							frontendBaseUrl: 'http://localhost:3301',
 							id: 'row-2',


### PR DESCRIPTION
#### Description

- Invited members can now be given more than one role. The picker was single-select even though `POST /api/v2/users` has accepted a list of roles since custom roles landed.
- Frontend only — nothing changed on the backend, the grant chain was already multi-role.
- Onboarding analytics now emits `teamMembers[].roles` as a list, replacing the singular `role` key.

#### Issues closed by this PR

Closes SigNoz/platform-pod#2920


#### Screenshots / Screen Recordings

#### Members Page
https://github.com/user-attachments/assets/8b556549-789c-4ddf-b4af-5994eccc75f3


#### Onboarding Flow
https://github.com/user-attachments/assets/a6dde5d3-e9b4-48c1-965f-352bb0a6a89f



#### Additional Information

- A row still requires at least one role to be considered valid.
- Existing invite tests moved to `findByTitle` for role options, matching how `EditMemberDrawer` already drives the multi-select.