### PR TITLE
fix(querier): do not re-shift already-shifted sub-ranges on partial cache hit

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -940,28 +940,29 @@ func (q *querier) createRangedQuery(_ valuer.UUID, originalQuery qbtypes.Query, 
 	case *builderQuery[qbtypes.TraceAggregation]:
 		specCopy := qt.spec.Copy()
 		specCopy.ShiftBy = extractShiftFromBuilderQuery(specCopy)
-		adjustedTimeRange := adjustTimeRangeForShift(specCopy, timeRange, qt.kind)
+		// timeRange is already a sub-range of the shifted query window (q.Window()), so it
+		// must be executed as-is; shifting it again would query the wrong window (#12380).
 		// reuse the original query's statement builder so an AI query keeps its AI builder
-		return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, qt.stmtBuilder, specCopy, adjustedTimeRange, qt.kind, qt.variables, builderConfig{})
+		return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, qt.stmtBuilder, specCopy, timeRange, qt.kind, qt.variables, builderConfig{})
 
 	case *builderQuery[qbtypes.LogAggregation]:
 		specCopy := qt.spec.Copy()
 		specCopy.ShiftBy = extractShiftFromBuilderQuery(specCopy)
-		adjustedTimeRange := adjustTimeRangeForShift(specCopy, timeRange, qt.kind)
+		// timeRange is already a sub-range of the shifted query window; do not shift again (#12380).
 		shiftStmtBuilder := q.logStmtBuilder
 		if qt.spec.Source == telemetrytypes.SourceAudit {
 			shiftStmtBuilder = q.auditStmtBuilder
 		}
-		return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, shiftStmtBuilder, specCopy, adjustedTimeRange, qt.kind, qt.variables, q.builderConfig)
+		return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, shiftStmtBuilder, specCopy, timeRange, qt.kind, qt.variables, q.builderConfig)
 
 	case *builderQuery[qbtypes.MetricAggregation]:
 		specCopy := qt.spec.Copy()
 		specCopy.ShiftBy = extractShiftFromBuilderQuery(specCopy)
-		adjustedTimeRange := adjustTimeRangeForShift(specCopy, timeRange, qt.kind)
+		// timeRange is already a sub-range of the shifted query window; do not shift again (#12380).
 		if qt.spec.Source == telemetrytypes.SourceMeter {
-			return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, q.meterStmtBuilder, specCopy, adjustedTimeRange, qt.kind, qt.variables, builderConfig{})
+			return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, q.meterStmtBuilder, specCopy, timeRange, qt.kind, qt.variables, builderConfig{})
 		}
-		return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, q.metricStmtBuilder, specCopy, adjustedTimeRange, qt.kind, qt.variables, builderConfig{})
+		return newBuilderQuery(q.logger, q.telemetryStore, qt.orgID, q.metricStmtBuilder, specCopy, timeRange, qt.kind, qt.variables, builderConfig{})
 	case *traceOperatorQuery:
 		specCopy := qt.spec.Copy()
 		return &traceOperatorQuery{


### PR DESCRIPTION
Fixes #12380.

## Problem

For a time-shifted (`timeShift`) query-builder query, a partial bucket-cache hit silently returns and caches data from the wrong time window.

`buildQueries` calls `adjustTimeRangeForShift` once on the raw request range and builds the query with that shifted window, so from then on `query.Window()` returns already-shifted bounds. On a partial cache hit, `executeWithCache` computes the missing sub-ranges from that already-shifted window and hands each one to `createRangedQuery`. But `createRangedQuery`'s `builderQuery` branches (`TraceAggregation`, `LogAggregation`, `MetricAggregation`) call `adjustTimeRangeForShift` a **second** time on that sub-range, so the executed query covers a doubly-shifted window. The wrong-hour data is returned to the caller and durably written into the cache under the correct range's key. No error is raised.

## Fix

In `createRangedQuery`, pass the incoming `timeRange` straight through to `newBuilderQuery` for the three `builderQuery` branches instead of shifting it again. The sub-range is already a slice of the shifted window, so it must be executed as-is.

`specCopy.ShiftBy` is still set, exactly as `buildQueries` does, so the query fingerprint stays consistent (it feeds the cache key, not a second window shift — see `builder_query.go`). `adjustTimeRangeForShift` remains in `buildQueries` and the live-tail path, which do operate on raw ranges.

## Notes

All three aggregation branches had the same double-shift, so all three are corrected. The end-to-end trace and a standalone illustration of the doubled shift are in the issue.
